### PR TITLE
limit python build runs to push/pr against python code

### DIFF
--- a/.github/workflows/lint_md_changes.yml
+++ b/.github/workflows/lint_md_changes.yml
@@ -1,5 +1,11 @@
 name: "Lint Markdown (Changes)"
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - '**/*.md'
+  pull_request:
+    paths:
+      - '**/*.md'
 
 jobs:
   lint:

--- a/.github/workflows/lint_md_changes.yml
+++ b/.github/workflows/lint_md_changes.yml
@@ -3,9 +3,11 @@ on:
   push:
     paths:
       - '**/*.md'
+      - .github/workflows/lint_md_changes.yml
   pull_request:
     paths:
       - '**/*.md'
+      - .github/workflows/lint_md_changes.yml
 
 jobs:
   lint:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -8,12 +8,14 @@ on:
     branches: [ "main" ]
     paths:
       - vultron/**
+      - test/**
       - pyproject.toml
       - .github/workflows/python-app.yml
   pull_request:
     branches: [ "main" ]
     paths:
       - vultron/**
+      - test/**
       - pyproject.toml
       - .github/workflows/python-app.yml
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -6,8 +6,16 @@ name: Python application
 on:
   push:
     branches: [ "main" ]
+    paths:
+      - vultron/**
+      - pyproject.toml
+      - .github/workflows/python-app.yml
   pull_request:
     branches: [ "main" ]
+    paths:
+      - vultron/**
+      - pyproject.toml
+      - .github/workflows/python-app.yml
 
 permissions:
   contents: read


### PR DESCRIPTION
We don't need to run a python build test unless the python code changes. 
Similarly, we only need to run a markdown linter if a markdown file has changed.