### PR TITLE
Vultron ActivityStreams Examples: Python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dataclasses-json~=0.6.3
+dataclasses-json==0.6.3
 markdown-exec==1.8.0
 mkdocs-include-markdown-plugin==6.0.4
 mkdocs-material-extensions==1.3.1

--- a/test/test_as_vocab/test_vocab_examples.py
+++ b/test/test_as_vocab/test_vocab_examples.py
@@ -1,0 +1,861 @@
+#  Copyright (c) 2024 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  (“Third Party Software”). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+import datetime
+import json
+import os
+import tempfile
+import unittest
+from dataclasses import dataclass
+from typing import Sequence
+
+from dataclasses_json import LetterCase, dataclass_json
+
+import vultron.scripts.vocab_examples as examples
+from vultron.as_vocab.base.base import as_Base
+from vultron.as_vocab.base.objects.activities.base import as_Activity
+from vultron.as_vocab.base.objects.activities.intransitive import as_Question
+from vultron.as_vocab.base.objects.activities.transitive import (
+    as_Accept,
+    as_Add,
+    as_Announce,
+    as_Create,
+    as_Ignore,
+    as_Invite,
+    as_Join,
+    as_Leave,
+    as_Offer,
+    as_Read,
+    as_Reject,
+    as_Remove,
+    as_Undo,
+    as_Update,
+)
+from vultron.as_vocab.base.objects.actors import as_Actor, as_Organization
+from vultron.as_vocab.base.objects.base import as_Object
+from vultron.as_vocab.base.objects.object_types import as_Event, as_Note
+from vultron.as_vocab.objects.case_participant import CaseParticipant
+from vultron.as_vocab.objects.case_status import CaseStatus, ParticipantStatus
+from vultron.as_vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.as_vocab.objects.vulnerability_report import VulnerabilityReport
+from vultron.bt.embargo_management.states import EM
+from vultron.bt.report_management.states import RM
+from vultron.case_states.states import CS_pxa, CS_vfd
+
+
+@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass(kw_only=True)
+class Foo(as_Base):
+    bar: str = "baz"
+
+
+class MyTestCase(unittest.TestCase):
+    def test_json2md(self):
+        # an object with a to_json method
+
+        foo = Foo(bar="baz")
+
+        txt = examples.json2md(foo)
+        self.assertTrue(txt.startswith("```json"))
+        self.assertTrue(txt.endswith("```"))
+        self.assertTrue("bar" in txt)
+        self.assertTrue("baz" in txt)
+
+    def test_obj_to_file(self):
+        foo = Foo(bar="baz")
+        # open a temporary file
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            filename = tmpdirname + "/test.md"
+            self.assertFalse(os.path.exists(filename))
+            examples.obj_to_file(foo, filename)
+            self.assertTrue(os.path.exists(filename))
+
+            # read the file
+            with open(filename, "r") as f:
+                obj = json.load(f)
+            self.assertEqual(obj["bar"], "baz")
+
+    def test_finder(self):
+        finder = examples.finder()
+        self.assertIsInstance(finder, as_Actor)
+
+    def test_vendor(self):
+        vendor = examples.vendor()
+        self.assertIsInstance(vendor, as_Actor)
+
+    def test_report(self):
+        report = examples.report()
+        self.assertIsInstance(report, as_Object)
+        self.assertIsInstance(report, VulnerabilityReport)
+
+        self.assertTrue(hasattr(report, "to_json"))
+        json = report.to_json()
+        self.assertIsInstance(json, str)
+
+    def test_create_report(self):
+        # is it an activity?
+        create_report = examples.create_report()
+        self.assertIsInstance(create_report, as_Activity)
+        finder = examples.finder()
+        report = examples.report()
+
+        # does it have the right fields?
+        self.assertIsInstance(create_report, as_Create)
+        self.assertEqual(create_report.as_type, "Create")
+        self.assertEqual(create_report.actor, finder.as_id)
+        self.assertEqual(create_report.as_object, report)
+
+    def test_submit_report(self):
+        # is it an activity?
+        submit_report = examples.submit_report()
+        self.assertIsInstance(submit_report, as_Activity)
+        finder = examples.finder()
+        report = examples.report()
+
+        # does it have the right fields?
+        self.assertIsInstance(submit_report, as_Offer)
+        self.assertEqual(submit_report.as_type, "Offer")
+        self.assertEqual(submit_report.actor, finder.as_id)
+        self.assertEqual(submit_report.as_object, report)
+
+    def test_read_report(self):
+        # is it an activity?
+        read_report = examples.read_report()
+        self.assertIsInstance(read_report, as_Activity)
+        vendor = examples.vendor()
+        report = examples.report()
+
+        # does it have the right fields?
+        self.assertIsInstance(read_report, as_Read)
+        self.assertEqual(read_report.as_type, "Read")
+        self.assertEqual(read_report.actor, vendor.as_id)
+        self.assertEqual(read_report.as_object, report.as_id)
+
+    def test_validate_report(self):
+        # is it an activity?
+        validate_report = examples.validate_report()
+        self.assertIsInstance(validate_report, as_Activity)
+        vendor = examples.vendor()
+        report = examples.report()
+
+        # does it have the right fields?
+        self.assertIsInstance(validate_report, as_Accept)
+        self.assertEqual(validate_report.as_type, "Accept")
+        self.assertEqual(validate_report.actor, vendor.as_id)
+        self.assertEqual(validate_report.as_object, report.as_id)
+
+    def test_invalidate_report(self):
+        # is it an activity?
+        invalidate_report = examples.invalidate_report()
+        self.assertIsInstance(invalidate_report, as_Activity)
+        vendor = examples.vendor()
+        report = examples.report()
+
+        # does it have the right fields?
+        self.assertIsInstance(invalidate_report, as_Reject)
+        self.assertEqual(invalidate_report.as_type, "Reject")
+        self.assertEqual(invalidate_report.actor, vendor.as_id)
+        self.assertEqual(invalidate_report.as_object, report.as_id)
+
+    def test_close_report(self):
+        # is it an activity?
+        close_report = examples.close_report()
+        self.assertIsInstance(close_report, as_Activity)
+        vendor = examples.vendor()
+        report = examples.report()
+
+        # does it have the right fields?
+        self.assertIsInstance(close_report, as_Leave)
+        self.assertEqual(close_report.as_type, "Leave")
+        self.assertEqual(close_report.actor, vendor.as_id)
+        self.assertEqual(close_report.as_object, report.as_id)
+
+    def test_case(self):
+        case = examples.case()
+        self.assertIsInstance(case, as_Object)
+        self.assertIsInstance(case, VulnerabilityCase)
+
+        self.assertTrue(hasattr(case, "to_json"))
+        json = case.to_json()
+        self.assertIsInstance(json, str)
+
+    def test_create_case(self):
+        # is it an activity?
+        create_case = examples.create_case()
+        self.assertIsInstance(create_case, as_Activity)
+        vendor = examples.vendor()
+        case = examples.case()
+        report = examples.report()
+
+        # does it have the right fields?
+        self.assertIsInstance(create_case, as_Create)
+        self.assertEqual(create_case.as_type, "Create")
+        self.assertEqual(create_case.actor, vendor.as_id)
+
+        case_from_activity = create_case.as_object
+        # the case should be the object, but it will have the report and participant embedded
+        self.assertEqual(case_from_activity.as_id, case.as_id)
+        # report should be the report id
+        self.assertEqual(
+            case_from_activity.vulnerability_reports[0], report.as_id
+        )
+        # actor should be a pointer to the vendor
+        self.assertEqual(
+            case_from_activity.case_participants[0].actor, vendor.as_id
+        )
+
+    def test_add_report_to_case(self):
+        # is it an activity?
+        add_report_to_case = examples.add_report_to_case()
+        self.assertIsInstance(add_report_to_case, as_Activity)
+        vendor = examples.vendor()
+        case = examples.case()
+        report = examples.report()
+
+        # does it have the right fields?
+        self.assertIsInstance(add_report_to_case, as_Add)
+        self.assertEqual(add_report_to_case.as_type, "Add")
+        self.assertEqual(add_report_to_case.actor, vendor.as_id)
+        self.assertEqual(add_report_to_case.as_object, report.as_id)
+        self.assertEqual(add_report_to_case.target, case.as_id)
+
+    def test_add_vendor_participant_to_case(self):
+        activity = examples.add_vendor_participant_to_case()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        case = examples.case()
+
+        self.assertIsInstance(activity, as_Add)
+        self.assertEqual(activity.as_type, "Add")
+
+        self.assertEqual(activity.actor, vendor.as_id)
+        self.assertEqual(activity.target, case.as_id)
+
+        participant = activity.as_object
+        self.assertEqual(participant.actor, vendor.as_id)
+        self.assertEqual(participant.name, vendor.name)
+        self.assertEqual(participant.context, case.as_id)
+
+    def test_add_finder_participant_to_case(self):
+        activity = examples.add_finder_participant_to_case()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        finder = examples.finder()
+        case = examples.case()
+
+        self.assertIsInstance(activity, as_Add)
+        self.assertEqual(activity.as_type, "Add")
+
+        self.assertEqual(activity.actor, vendor.as_id)
+        self.assertEqual(activity.target, case.as_id)
+
+        participant = activity.as_object
+        self.assertEqual(participant.actor, finder.as_id)
+        self.assertEqual(participant.name, finder.name)
+        self.assertEqual(participant.context, case.as_id)
+
+    def test_add_coordinator_participant_to_case(self):
+        activity = examples.add_coordinator_participant_to_case()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        coordinator = examples.coordinator()
+        case = examples.case()
+
+        self.assertIsInstance(activity, as_Add)
+        self.assertEqual(activity.as_type, "Add")
+
+        self.assertEqual(activity.actor, vendor.as_id)
+        self.assertEqual(activity.target, case.as_id)
+
+        participant = activity.as_object
+        self.assertEqual(participant.actor, coordinator.as_id)
+        self.assertEqual(participant.name, coordinator.name)
+        self.assertEqual(participant.context, case.as_id)
+
+    def test_engage_case(self):
+        activity = examples.engage_case()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        case = examples.case()
+
+        self.assertIsInstance(activity, as_Join)
+        self.assertEqual(activity.as_type, "Join")
+
+        self.assertEqual(activity.actor, vendor.as_id)
+        self.assertEqual(activity.as_object, case.as_id)
+
+    def test_close_case(self):
+        activity = examples.close_case()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        case = examples.case()
+
+        self.assertIsInstance(activity, as_Leave)
+        self.assertEqual(activity.as_type, "Leave")
+
+        self.assertEqual(activity.actor, vendor.as_id)
+        self.assertEqual(activity.as_object, case.as_id)
+
+    def test_defer_case(self):
+        activity = examples.defer_case()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        case = examples.case()
+
+        self.assertIsInstance(activity, as_Ignore)
+        self.assertEqual(activity.as_type, "Ignore")
+
+        self.assertEqual(activity.actor, vendor.as_id)
+        self.assertEqual(activity.as_object, case.as_id)
+
+    def test_reengage_case(self):
+        activity = examples.reengage_case()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        case = examples.case()
+
+        self.assertIsInstance(activity, as_Undo)
+
+        self.assertEqual(activity.as_type, "Undo")
+
+        self.assertEqual(activity.actor, vendor.as_id)
+        # inside the activity is a deferral activity
+        self.assertEqual(activity.as_object.as_type, "Ignore")
+        self.assertEqual(activity.as_object.actor, vendor.as_id)
+        self.assertEqual(activity.as_object.as_object, case.as_id)
+
+        self.assertEqual(activity.context, case.as_id)
+
+    def test_note(self):
+        note = examples.note()
+        self.assertIsInstance(note, as_Object)
+        self.assertIsInstance(note, as_Note)
+
+        self.assertTrue(hasattr(note, "to_json"))
+        self.assertIn("This is a note", note.content)
+
+    def test_add_note_to_case(self):
+        activity = examples.add_note_to_case()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        finder = examples.finder()
+        case = examples.case()
+        note = examples.note()
+
+        self.assertIsInstance(activity, as_Add)
+        self.assertEqual(activity.as_type, "Add")
+
+        self.assertEqual(activity.actor, finder.as_id)
+        self.assertEqual(activity.target, case.as_id)
+
+        add_note = activity.as_object
+        self.assertIsInstance(add_note, as_Note)
+        self.assertEqual(add_note.context, case.as_id)
+        self.assertEqual(add_note.content, note.content)
+
+    def test_coordinator(self):
+        coordinator = examples.coordinator()
+        self.assertIsInstance(coordinator, as_Actor)
+
+        self.assertTrue(hasattr(coordinator, "to_json"))
+        self.assertIsInstance(coordinator, as_Organization)
+        self.assertIn("coordinator", coordinator.name.lower())
+
+    def test_offer_case_ownership_transfer(self):
+        activity = examples.offer_case_ownership_transfer()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        coordinator = examples.coordinator()
+        case = examples.case()
+
+        self.assertIsInstance(activity, as_Offer)
+        self.assertEqual(activity.as_type, "Offer")
+
+        self.assertEqual(activity.actor, vendor.as_id)
+        self.assertEqual(activity.target, coordinator.as_id)
+
+        for k, v in activity.as_object.to_dict().items():
+            # skip list fields because they aren't always identical
+            if isinstance(v, list):
+                continue
+
+            self.assertEqual(v, case.to_dict()[k])
+
+    def test_accept_case_ownership_transfer(self):
+        activity = examples.accept_case_ownership_transfer()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        coordinator = examples.coordinator()
+        case = examples.case()
+
+        self.assertIsInstance(activity, as_Accept)
+        self.assertEqual(activity.as_type, "Accept")
+
+        self.assertEqual(activity.actor, coordinator.as_id)
+        self.assertEqual(activity.origin, vendor.as_id)
+
+        for k, v in activity.as_object.to_dict().items():
+            # skip list fields because they aren't always identical
+            if isinstance(v, list):
+                continue
+
+            self.assertEqual(v, case.to_dict()[k])
+
+    def test_reject_case_ownership_transfer(self):
+        activity = examples.reject_case_ownership_transfer()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        coordinator = examples.coordinator()
+        case = examples.case()
+
+        self.assertIsInstance(activity, as_Reject)
+        self.assertEqual(activity.as_type, "Reject")
+
+        self.assertEqual(activity.actor, coordinator.as_id)
+        self.assertEqual(activity.origin, vendor.as_id)
+
+        for k, v in activity.as_object.to_dict().items():
+            # skip list fields because they aren't always identical
+            if isinstance(v, list):
+                continue
+
+            self.assertEqual(v, case.to_dict()[k])
+
+    def test_update_case(self):
+        activity = examples.update_case()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        case = examples.case()
+
+        self.assertIsInstance(activity, as_Update)
+        self.assertEqual(activity.as_type, "Update")
+
+        self.assertEqual(activity.actor, vendor.as_id)
+        self.assertEqual(activity.as_object, case.as_id)
+
+    def test_recommend_actor(self):
+        activity = examples.recommend_actor()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        case = examples.case()
+        finder = examples.finder()
+        coordinator = examples.coordinator()
+
+        self.assertIsInstance(activity, as_Offer)
+        self.assertEqual(activity.as_type, "Offer")
+
+        self.assertEqual(activity.actor, finder.as_id)
+        self.assertEqual(activity.as_object, coordinator.as_id)
+        self.assertEqual(activity.target, case.as_id)
+        self.assertEqual(activity.to, vendor.as_id)
+
+    def test_accept_actor_recommendation(self):
+        activity = examples.accept_actor_recommendation()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        case = examples.case()
+        finder = examples.finder()
+        coordinator = examples.coordinator()
+
+        self.assertIsInstance(activity, as_Accept)
+        self.assertEqual(activity.as_type, "Accept")
+
+        self.assertEqual(activity.actor, vendor.as_id)
+        self.assertEqual(activity.context, case.as_id)
+
+        self.assertEqual(activity.as_object, coordinator.as_id)
+        self.assertEqual(activity.target, case.as_id)
+        self.assertEqual(activity.to, finder.as_id)
+
+    def test_reject_actor_recommendation(self):
+        activity = examples.reject_actor_recommendation()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        case = examples.case()
+        finder = examples.finder()
+        coordinator = examples.coordinator()
+
+        self.assertIsInstance(activity, as_Reject)
+        self.assertEqual(activity.as_type, "Reject")
+
+        self.assertEqual(activity.actor, vendor.as_id)
+        self.assertEqual(activity.context, case.as_id)
+
+        self.assertEqual(activity.as_object, coordinator.as_id)
+        self.assertEqual(activity.target, case.as_id)
+        self.assertEqual(activity.to, finder.as_id)
+
+    def test_rm_invite_to_case(self):
+        activity = examples.rm_invite_to_case()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        case = examples.case()
+        finder = examples.finder()
+        coordinator = examples.coordinator()
+
+        self.assertIsInstance(activity, as_Invite)
+        self.assertEqual(activity.as_type, "Invite")
+
+        self.assertEqual(activity.actor, vendor.as_id)
+        self.assertEqual(activity.as_object, coordinator.as_id)
+        self.assertEqual(activity.target, case.as_id)
+        self.assertEqual(activity.to, coordinator.as_id)
+
+    def test_accept_invite_to_case(self):
+        activity = examples.accept_invite_to_case()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        case = examples.case()
+        coordinator = examples.coordinator()
+        invite = examples.rm_invite_to_case()
+
+        self.assertIsInstance(activity, as_Accept)
+        self.assertEqual(activity.as_type, "Accept")
+
+        self.assertEqual(activity.actor, coordinator.as_id)
+        self.assertEqual(activity.as_object, case.as_id)
+        self.assertEqual(activity.to, vendor.as_id)
+        self.assertEqual(activity.in_reply_to, invite.as_id)
+
+    def test_reject_invite_to_case(self):
+        activity = examples.reject_invite_to_case()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        case = examples.case()
+        coordinator = examples.coordinator()
+        invite = examples.rm_invite_to_case()
+
+        self.assertIsInstance(activity, as_Reject)
+        self.assertEqual(activity.as_type, "Reject")
+
+        self.assertEqual(activity.actor, coordinator.as_id)
+        self.assertEqual(activity.as_object, case.as_id)
+        self.assertEqual(activity.to, vendor.as_id)
+        self.assertEqual(activity.in_reply_to, invite.as_id)
+
+    def test_create_participant(self):
+        activity = examples.create_participant()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        case = examples.case()
+        coordinator = examples.coordinator()
+
+        self.assertIsInstance(activity, as_Create)
+        self.assertEqual(activity.as_type, "Create")
+
+        self.assertEqual(activity.actor, vendor.as_id)
+        self.assertEqual(activity.target, case.as_id)
+        self.assertEqual(activity.as_object.actor, coordinator.as_id)
+        self.assertEqual(activity.as_object.context, case.as_id)
+        self.assertEqual(activity.as_object.name, coordinator.name)
+
+    def test_case_status(self):
+        obj = examples.case_status()
+        self.assertIsInstance(obj, as_Object)
+        self.assertIsInstance(obj, CaseStatus)
+        self.assertIn(obj.em_state, EM)
+        self.assertIn(obj.pxa_state, CS_pxa)
+
+    def test_participant_status(self):
+        obj = examples.participant_status()
+        self.assertIsInstance(obj, as_Object)
+        self.assertIsInstance(obj, ParticipantStatus)
+
+        # actor and context are required
+        self.assertIsNotNone(obj.actor)
+        self.assertIsNotNone(obj.context)
+
+        self.assertIn(obj.rm_state, RM)
+        self.assertIn(obj.vfd_state, CS_vfd)
+
+        if obj.case_status is not None:
+            self.assertIsInstance(obj.case_status, CaseStatus)
+            self.assertIn(obj.case_status.em_state, EM)
+            self.assertIn(obj.case_status.pxa_state, CS_pxa)
+
+    def test_case_participant(self):
+        obj = examples.case_participant()
+        self.assertIsInstance(obj, as_Object)
+        self.assertIsInstance(obj, CaseParticipant)
+
+        # actor and context are required
+        self.assertIsNotNone(obj.as_id)
+        self.assertIsNotNone(obj.name)
+        self.assertIsNotNone(obj.actor)
+        self.assertIsNotNone(obj.context)
+
+        # status should be a list of ParticipantStatus objects
+        # and there should be at least one
+        self.assertIsInstance(obj.participant_status, Sequence)
+        self.assertGreaterEqual(len(obj.participant_status), 1)
+        for status in obj.participant_status:
+            self.assertIsInstance(status, ParticipantStatus)
+
+    def test_embargo_event(self):
+        obj = examples.embargo_event()
+        self.assertIsInstance(obj, as_Object)
+        self.assertIsInstance(obj, as_Event)
+
+        # id, name, and context are required
+        self.assertIsNotNone(obj.as_id)
+        self.assertIsNotNone(obj.name)
+        self.assertIsNotNone(obj.context)
+
+        # end time is required
+        # end time should be a TZ-aware datetime
+        self.assertIsNotNone(obj.end_time)
+        self.assertIsInstance(obj.end_time, datetime.datetime)
+        self.assertIsNotNone(obj.end_time.tzinfo)
+
+        if obj.start_time is not None:
+            # start time should be a TZ-aware datetime
+            self.assertIsNotNone(obj.start_time)
+            self.assertIsInstance(obj.start_time, datetime.datetime)
+            self.assertIsNotNone(obj.start_time.tzinfo)
+            # start time should be at or before end time
+            self.assertLessEqual(obj.start_time, obj.end_time)
+
+    def test_invite_to_case(self):
+        activity = examples.invite_to_case()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        case = examples.case()
+        finder = examples.finder()
+        coordinator = examples.coordinator()
+
+        self.assertIsInstance(activity, as_Invite)
+        self.assertEqual(activity.as_type, "Invite")
+
+        self.assertEqual(activity.actor, vendor.as_id)
+        self.assertEqual(activity.as_object, coordinator.as_id)
+        self.assertEqual(activity.target, case.as_id)
+        self.assertEqual(activity.to, coordinator.as_id)
+
+    def test_create_participant_status(self):
+        activity = examples.create_participant_status()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        case = examples.case()
+        coordinator = examples.coordinator()
+
+        self.assertIsInstance(activity, as_Create)
+        self.assertEqual(activity.as_type, "Create")
+
+        self.assertEqual(activity.actor, vendor.as_id)
+        self.assertIsInstance(activity.as_object, ParticipantStatus)
+
+    def test_add_status_to_participant(self):
+        activity = examples.add_status_to_participant()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        case = examples.case()
+        coordinator = examples.coordinator()
+        status = examples.participant_status()
+
+        self.assertIsInstance(activity, as_Add)
+        self.assertEqual(activity.as_type, "Add")
+
+        self.assertEqual(activity.actor, vendor.as_id)
+        self.assertEqual(activity.target, coordinator.as_id)
+        self.assertEqual(activity.as_object, status.as_id)
+
+    def test_add_status_to_participant(self):
+        activity = examples.add_status_to_participant()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        status = examples.participant_status()
+
+        self.assertIsInstance(activity, as_Add)
+        self.assertEqual(activity.as_type, "Add")
+
+        self.assertEqual(activity.actor, vendor.as_id)
+        self.assertIsNotNone(activity.target)
+        self.assertEqual(activity.as_object, status)
+
+    def test_remove_participant_from_case(self):
+        activity = examples.remove_participant_from_case()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        case = examples.case()
+        coord_p = examples.coordinator_participant()
+
+        self.assertIsInstance(activity, as_Remove)
+        self.assertEqual(activity.as_type, "Remove")
+
+        self.assertEqual(activity.actor, vendor.as_id)
+        self.assertEqual(activity.as_object, coord_p.as_id)
+        self.assertEqual(activity.origin, case.as_id)
+
+    def test_propose_embargo(self):
+        activity = examples.propose_embargo()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        case = examples.case()
+        embargo = examples.embargo_event()
+
+        self.assertIsInstance(activity, as_Invite)
+        self.assertEqual(activity.as_type, "Invite")
+
+        self.assertEqual(activity.actor, vendor.as_id)
+        self.assertEqual(activity.as_object, embargo)
+        self.assertEqual(activity.target, case.as_id)
+
+    def test_choose_preferred_embargo(self):
+        activity = examples.choose_preferred_embargo()
+        self.assertIsInstance(activity, as_Activity)
+        case = examples.case()
+        embargo = examples.embargo_event()
+        coordinator = examples.coordinator()
+
+        # is it a question?
+        self.assertIsInstance(activity, as_Question)
+
+        self.assertEqual(activity.actor, coordinator.as_id)
+        self.assertIn(case.as_id, activity.context)
+
+        # one_of is a list, is non-empty, and contains embargo events
+        self.assertIsInstance(activity.one_of, Sequence)
+        self.assertGreaterEqual(len(activity.one_of), 1)
+        for obj in activity.one_of:
+            self.assertIsInstance(obj, as_Event)
+
+    def test_accept_embargo(self):
+        activity = examples.accept_embargo()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        question = examples.choose_preferred_embargo()
+
+        self.assertIsInstance(activity, as_Accept)
+        self.assertEqual(activity.as_type, "Accept")
+
+        self.assertEqual(activity.actor, vendor.as_id)
+        self.assertIsNotNone(activity.context)
+        self.assertIsNotNone(activity.to)
+        self.assertEqual(activity.in_reply_to, question.as_id)
+
+    def test_reject_embargo(self):
+        activity = examples.reject_embargo()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        question = examples.choose_preferred_embargo()
+
+        self.assertIsInstance(activity, as_Reject)
+        self.assertEqual(activity.as_type, "Reject")
+
+        self.assertEqual(activity.actor, vendor.as_id)
+        self.assertIsNotNone(activity.context)
+        self.assertIsNotNone(activity.to)
+        self.assertEqual(activity.in_reply_to, question.as_id)
+
+    def test_add_embargo_to_case(self):
+        activity = examples.add_embargo_to_case()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        case = examples.case()
+        embargo = examples.embargo_event()
+
+        self.assertIsInstance(activity, as_Add)
+        self.assertEqual(activity.as_type, "Add")
+
+        self.assertEqual(activity.actor, vendor.as_id)
+        self.assertEqual(activity.target, case.as_id)
+        self.assertEqual(activity.as_object, embargo)
+
+    def test_activate_embargo(self):
+        activity = examples.activate_embargo()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        case = examples.case()
+        embargo = examples.embargo_event()
+
+        self.assertIsInstance(activity, as_Add)
+        self.assertEqual(activity.as_type, "Add")
+
+        self.assertEqual(activity.actor, vendor.as_id)
+        self.assertEqual(activity.target, case.as_id)
+        self.assertEqual(activity.as_object, embargo)
+
+    def test_announce_embargo(self):
+        activity = examples.announce_embargo()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        case = examples.case()
+        embargo = examples.embargo_event(days=90)
+
+        self.assertIsInstance(activity, as_Announce)
+        self.assertEqual(activity.as_type, "Announce")
+
+        self.assertEqual(activity.actor, vendor.as_id)
+        self.assertEqual(activity.context, case.as_id)
+        self.assertEqual(activity.as_object, embargo)
+        self.assertIsNotNone(activity.to)
+
+    def test_remove_embargo(self):
+        activity = examples.remove_embargo()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        case = examples.case()
+        embargo = examples.embargo_event(days=90)
+
+        self.assertIsInstance(activity, as_Remove)
+        self.assertEqual(activity.as_type, "Remove")
+
+        self.assertEqual(activity.actor, vendor.as_id)
+        self.assertEqual(activity.origin, case.as_id)
+        self.assertIsNone(activity.target)
+        self.assertEqual(activity.as_object, embargo)
+
+    def test_create_case_status(self):
+        activity = examples.create_case_status()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        case = examples.case()
+        status = examples.case_status()
+
+        self.assertIsInstance(activity, as_Create)
+        self.assertEqual(activity.as_type, "Create")
+
+        self.assertEqual(activity.actor, vendor.as_id)
+        self.assertEqual(activity.context, case.as_id)
+        self.assertEqual(activity.as_object, status)
+
+    def test_add_case_status_to_case(self):
+        activity = examples.add_status_to_case()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        case = examples.case()
+        status = examples.case_status()
+
+        self.assertIsInstance(activity, as_Add)
+        self.assertEqual(activity.as_type, "Add")
+
+        self.assertEqual(activity.actor, vendor.as_id)
+        self.assertEqual(activity.target, case.as_id)
+        self.assertEqual(activity.as_object, status)
+
+    def test_create_note(self):
+        activity = examples.create_note()
+        self.assertIsInstance(activity, as_Activity)
+        vendor = examples.vendor()
+        case = examples.case()
+        note = examples.note()
+
+        self.assertIsInstance(activity, as_Create)
+        self.assertEqual(activity.as_type, "Create")
+
+        self.assertEqual(activity.actor, vendor.as_id)
+        self.assertEqual(activity.target, case.as_id)
+        self.assertEqual(activity.as_object, note)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vultron/as_vocab/activities/actor.py
+++ b/vultron/as_vocab/activities/actor.py
@@ -16,7 +16,7 @@ Provides Vultron ActivityStreams Activities related to Actors
 """
 
 from dataclasses import dataclass, field
-from typing import Optional, Union
+from typing import Optional
 
 from dataclasses_json import LetterCase, config, dataclass_json
 
@@ -35,11 +35,11 @@ from vultron.as_vocab.objects.vulnerability_case import VulnerabilityCase
 class RecommendActor(as_Offer):
     """The actor is recommending another actor to a case."""
 
-    as_type = "Offer"
-    as_object: Optional[Union[as_Actor, as_Link]] = field(
+    as_type: str = field(default="Offer", init=False)
+    as_object: Optional[as_Actor | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
-    target: Optional[Union[VulnerabilityCase, as_Link]] = field(
+    target: Optional[VulnerabilityCase | as_Link | str] = field(
         default=None,
         repr=True,
     )
@@ -52,11 +52,11 @@ class AcceptActorRecommendation(as_Accept):
     Should be followed by an RmInviteToCase activity targeted at the recommended actor.
     """
 
-    as_type = "Accept"
-    as_object: Optional[Union[as_Actor, as_Link]] = field(
+    as_type: str = field(default="Accept", init=False)
+    as_object: Optional[as_Actor | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
-    target: Optional[Union[VulnerabilityCase, as_Link]] = field(
+    target: Optional[VulnerabilityCase | as_Link | str] = field(
         default=None,
         repr=True,
     )
@@ -67,11 +67,11 @@ class AcceptActorRecommendation(as_Accept):
 class RejectActorRecommendation(as_Reject):
     """The case owner is rejecting a recommendation to add an actor to the case."""
 
-    as_type = "Reject"
-    as_object: Optional[Union[as_Actor, as_Link]] = field(
+    as_type: str = field(default="Reject", init=False)
+    as_object: Optional[as_Actor | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
-    target: Optional[Union[VulnerabilityCase, as_Link]] = field(
+    target: Optional[VulnerabilityCase | as_Link | str] = field(
         default=None,
         repr=True,
     )

--- a/vultron/as_vocab/activities/case.py
+++ b/vultron/as_vocab/activities/case.py
@@ -17,7 +17,7 @@ Each activity should have a VulnerabilityCase object as either its target or obj
 """
 
 from dataclasses import dataclass, field
-from typing import Optional, Union
+from typing import Optional
 
 from dataclasses_json import LetterCase, config, dataclass_json
 
@@ -38,7 +38,6 @@ from vultron.as_vocab.base.objects.actors import as_Actor
 from vultron.as_vocab.base.objects.object_types import as_Note
 from vultron.as_vocab.base.utils import exclude_if_none
 from vultron.as_vocab.objects.case_status import CaseStatus
-from vultron.as_vocab.objects.embargo_event import EmbargoEvent
 from vultron.as_vocab.objects.vulnerability_case import VulnerabilityCase
 from vultron.as_vocab.objects.vulnerability_report import VulnerabilityReport
 
@@ -57,33 +56,14 @@ class AddReportToCase(as_Add):
     """
 
     as_type: str = field(default="Add", init=False)
-    as_object: Optional[Union[VulnerabilityReport, as_Link]] = field(
+    as_object: Optional[VulnerabilityReport | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
-    target: Optional[Union[VulnerabilityCase, as_Link]] = field(default=None)
+    target: Optional[VulnerabilityCase | as_Link | str] = field(default=None)
 
 
 # add CaseParticipant to VulnerabilityCase
 # see AddParticipantToCase in case_participant.py
-
-
-# add EmbargoEvent to VulnerabilityCase
-@dataclass_json(letter_case=LetterCase.CAMEL)
-@dataclass(kw_only=True)
-class AddEmbargoToCase(as_Add):
-    """Add an EmbargoEvent to a VulnerabilityCase.
-    This implies that the case owner is setting the embargo for the case, which should come
-    after an embargo proposal has been accepted by the case owner.
-    For embargo proposals, see EmProposeEmbargo.
-    as_object: EmbargoEvent
-    target: VulnerabilityCase
-    """
-
-    as_type: str = field(default="Add", init=False)
-    as_object: Optional[Union[EmbargoEvent, as_Link]] = field(
-        metadata=config(field_name="object"), default=None, repr=True
-    )
-    target: Optional[Union[VulnerabilityCase, as_Link]] = field(default=None)
 
 
 # add CaseStatus to VulnerabilityCase
@@ -99,10 +79,10 @@ class AddStatusToCase(as_Add):
     """
 
     as_type: str = field(default="Add", init=False)
-    as_object: Optional[Union[CaseStatus, as_Link]] = field(
+    as_object: Optional[CaseStatus | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
-    target: Optional[Union[VulnerabilityCase, as_Link]] = field(default=None)
+    target: Optional[VulnerabilityCase | as_Link | str] = field(default=None)
 
 
 ########################################################################################
@@ -119,7 +99,20 @@ class CreateCase(as_Create):
     """
 
     as_type: str = field(default="Create", init=False)
-    as_object: Optional[Union[VulnerabilityCase, as_Link]] = field(
+    as_object: Optional[VulnerabilityCase | as_Link | str] = field(
+        metadata=config(field_name="object"), default=None, repr=True
+    )
+
+
+@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass(kw_only=True)
+class CreateCaseStatus(as_Create):
+    """Create a CaseStatus.
+    as_object: CaseStatus
+    """
+
+    as_type: str = field(default="Create", init=False)
+    as_object: Optional[CaseStatus | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
 
@@ -134,10 +127,10 @@ class AddNoteToCase(as_Add):
     """
 
     as_type: str = field(default="Add", init=False)
-    as_object: Optional[Union[as_Note, as_Link]] = field(
+    as_object: Optional[as_Note | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
-    target: Optional[Union[VulnerabilityCase, as_Link]] = field(default=None)
+    target: Optional[VulnerabilityCase | as_Link | str] = field(default=None)
 
 
 # update a VulnerabilityCase
@@ -149,7 +142,7 @@ class UpdateCase(as_Update):
     """
 
     as_type: str = field(default="Update", init=False)
-    as_object: Optional[Union[VulnerabilityCase, as_Link]] = field(
+    as_object: Optional[VulnerabilityCase | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
 
@@ -168,7 +161,8 @@ class RmEngageCase(as_Join):
     as_object: VulnerabilityCase
     """
 
-    as_object: Optional[Union[VulnerabilityCase, as_Link]] = field(
+    as_type: str = field(default="Join", init=False)
+    as_object: Optional[VulnerabilityCase | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
 
@@ -185,7 +179,8 @@ class RmDeferCase(as_Ignore):
     as_object: VulnerabilityCase
     """
 
-    as_object: Optional[Union[VulnerabilityCase, as_Link]] = field(
+    as_type: str = field(default="Ignore", init=False)
+    as_object: Optional[VulnerabilityCase | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
 
@@ -201,7 +196,8 @@ class RmCloseCase(as_Leave):
     as_object: VulnerabilityCase
     """
 
-    as_object: Optional[Union[VulnerabilityCase, as_Link]] = field(
+    as_type: str = field(default="Leave", init=False)
+    as_object: Optional[VulnerabilityCase | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
 
@@ -214,10 +210,11 @@ class OfferCaseOwnershipTransfer(as_Offer):
     target: as_Actor
     """
 
-    as_object: Optional[Union[VulnerabilityCase, as_Link]] = field(
+    as_type: str = field(default="Offer", init=False)
+    as_object: Optional[VulnerabilityCase | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
-    target: Optional[Union[as_Actor, as_Link]] = field(
+    target: Optional[as_Actor | as_Link | str] = field(
         metadata=config(exclude=exclude_if_none), default=None
     )
 
@@ -231,7 +228,8 @@ class AcceptCaseOwnershipTransfer(as_Accept):
     - in_reply_to: the original offer
     """
 
-    as_object: Optional[Union[VulnerabilityCase, as_Link]] = field(
+    as_type: str = field(default="Accept", init=False)
+    as_object: Optional[VulnerabilityCase | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
     in_reply_to: OfferCaseOwnershipTransfer = field(
@@ -247,7 +245,8 @@ class RejectCaseOwnershipTransfer(as_Reject):
     context: the original offer
     """
 
-    as_object: Optional[Union[VulnerabilityCase, as_Link]] = field(
+    as_type: str = field(default="Reject", init=False)
+    as_object: Optional[VulnerabilityCase | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
     in_reply_to: OfferCaseOwnershipTransfer = field(
@@ -264,7 +263,8 @@ class RmInviteToCase(as_Invite):
     as_object: VulnerabilityCase
     """
 
-    as_object: Optional[Union[VulnerabilityCase, as_Link]] = field(
+    as_type: str = field(default="Invite", init=False)
+    as_object: Optional[VulnerabilityCase | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
 
@@ -279,7 +279,8 @@ class RmAcceptInviteToCase(as_Accept):
     in_reply_to: RmInviteToCase
     """
 
-    as_object: Optional[Union[VulnerabilityCase, as_Link]] = field(
+    as_type: str = field(default="Accept", init=False)
+    as_object: Optional[VulnerabilityCase | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
     in_reply_to: RmInviteToCase = field(default=None)
@@ -296,7 +297,8 @@ class RmRejectInviteToCase(as_Reject):
     `in_reply_to`: `RmInviteToCase`
     """
 
-    as_object: Optional[Union[VulnerabilityCase, as_Link]] = field(
+    as_type: str = field(default="Reject", init=False)
+    as_object: Optional[VulnerabilityCase | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
     in_reply_to: RmInviteToCase = field(default=None)

--- a/vultron/as_vocab/activities/case_participant.py
+++ b/vultron/as_vocab/activities/case_participant.py
@@ -16,7 +16,7 @@ Provides Vultron ActivityStreams Activities related to CaseParticipants
 """
 
 from dataclasses import dataclass, field
-from typing import Optional, Union
+from typing import Optional
 
 from dataclasses_json import LetterCase, config, dataclass_json
 
@@ -33,14 +33,26 @@ from vultron.as_vocab.objects.vulnerability_case import VulnerabilityCase
 
 @dataclass_json(letter_case=LetterCase.CAMEL)
 @dataclass(kw_only=True)
+class CreateParticipant(as_Create):
+    """Create a new CaseParticipant"""
+
+    as_type: str = field(default="Create", init=False)
+    as_object: Optional[CaseParticipant | as_Link | str] = field(
+        metadata=config(field_name="object"), default=None, repr=True
+    )
+    target: Optional[VulnerabilityCase | as_Link | str] = field(default=None)
+
+
+@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass(kw_only=True)
 class CreateStatusForParticipant(as_Create):
     """Create a new CaseStatus for a CaseParticipant"""
 
     as_type: str = field(default="Create", init=False)
-    as_object: Optional[Union[ParticipantStatus, as_Link]] = field(
+    as_object: Optional[ParticipantStatus | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
-    target: Optional[Union[CaseParticipant, as_Link]] = field(default=None)
+    target: Optional[CaseParticipant | as_Link | str] = field(default=None)
 
 
 # add CaseStatus to CaseParticipant
@@ -53,10 +65,10 @@ class AddStatusToParticipant(as_Add):
     """
 
     as_type: str = field(default="Add", init=False)
-    as_object: Optional[Union[ParticipantStatus, as_Link]] = field(
+    as_object: Optional[ParticipantStatus | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
-    target: Optional[Union[CaseParticipant, as_Link]] = field(default=None)
+    target: Optional[CaseParticipant | as_Link | str] = field(default=None)
 
 
 @dataclass_json(letter_case=LetterCase.CAMEL)
@@ -68,10 +80,10 @@ class AddParticipantToCase(as_Add):
     """
 
     as_type: str = field(default="Add", init=False)
-    as_object: Optional[Union[CaseParticipant, as_Link]] = field(
+    as_object: Optional[CaseParticipant | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
-    target: Optional[Union[VulnerabilityCase, as_Link]] = field(default=None)
+    target: Optional[VulnerabilityCase | as_Link | str] = field(default=None)
 
 
 @dataclass_json(letter_case=LetterCase.CAMEL)
@@ -84,7 +96,7 @@ class RemoveParticipantFromCase(as_Remove):
     """
 
     as_type: str = field(default="Remove", init=False)
-    as_object: Optional[Union[CaseParticipant, as_Link]] = field(
+    as_object: Optional[CaseParticipant | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
-    origin: Optional[Union[VulnerabilityCase, as_Link]] = field(default=None)
+    origin: Optional[VulnerabilityCase | as_Link | str] = field(default=None)

--- a/vultron/as_vocab/activities/embargo.py
+++ b/vultron/as_vocab/activities/embargo.py
@@ -16,7 +16,7 @@ Provides Vultron Activity Streams Vocabulary classes for Embargo activities
 """
 
 from dataclasses import dataclass, field
-from typing import Optional, Union
+from typing import Optional, Sequence
 
 from dataclasses_json import LetterCase, config, dataclass_json
 
@@ -47,10 +47,10 @@ class EmProposeEmbargo(as_Invite):
 
     as_type: str = field(default="Invite", init=False)
 
-    as_object: Optional[Union[EmbargoEvent, as_Link]] = field(
+    as_object: Optional[EmbargoEvent | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
-    context: Optional[Union[VulnerabilityCase, as_Link]] = field(
+    context: Optional[VulnerabilityCase | as_Link | str] = field(
         default=None, repr=True
     )
 
@@ -67,13 +67,13 @@ class EmAcceptEmbargo(as_Accept):
 
     as_type: str = field(default="Accept", init=False)
 
-    as_object: Optional[Union[EmbargoEvent, as_Link]] = field(
+    as_object: Optional[EmbargoEvent | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
-    context: Optional[Union[VulnerabilityCase, as_Link]] = field(
+    context: Optional[VulnerabilityCase | as_Link | str] = field(
         default=None, repr=True
     )
-    in_reply_to: Optional[Union[EmProposeEmbargo, as_Link]] = field(
+    in_reply_to: Optional[EmProposeEmbargo | as_Link | str] = field(
         default=None, repr=True
     )
 
@@ -90,13 +90,13 @@ class EmRejectEmbargo(as_Reject):
 
     as_type: str = field(default="Reject", init=False)
 
-    as_object: Optional[Union[EmbargoEvent, as_Link]] = field(
+    as_object: Optional[EmbargoEvent | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
-    context: Optional[Union[VulnerabilityCase, as_Link]] = field(
+    context: Optional[VulnerabilityCase | as_Link | str] = field(
         default=None, repr=True
     )
-    in_reply_to: Optional[Union[EmProposeEmbargo, as_Link]] = field(
+    in_reply_to: Optional[EmProposeEmbargo | as_Link | str] = field(
         default=None, repr=True
     )
 
@@ -112,10 +112,11 @@ class ChoosePreferredEmbargo(as_Question):
 
     # note: not specifying as_object here because Questions are intransitive
 
-    any_of: Optional[Union[EmbargoEvent, as_Link]] = field(
+    as_type: str = field(default="Question", init=False)
+    any_of: Optional[Sequence[EmbargoEvent | as_Link | str]] = field(
         metadata=config(exclude=exclude_if_none), default=None
     )
-    one_of: Optional[Union[EmbargoEvent, as_Link]] = field(
+    one_of: Optional[Sequence[EmbargoEvent | as_Link | str]] = field(
         metadata=config(exclude=exclude_if_none), default=None
     )
 
@@ -131,13 +132,31 @@ class ActivateEmbargo(as_Add):
     """
 
     as_type: str = field(default="Add", init=False)
-    as_object: Optional[Union[EmbargoEvent, as_Link]] = field(
+    as_object: Optional[EmbargoEvent | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
-    target: Optional[Union[VulnerabilityCase, as_Link]] = field(
+    target: Optional[VulnerabilityCase | as_Link | str] = field(
         default=None, repr=True
     )
-    in_reply_to: Optional[Union[EmProposeEmbargo, as_Link]] = field(
+    in_reply_to: Optional[EmProposeEmbargo | as_Link | str] = field(
+        default=None, repr=True
+    )
+
+
+@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass(kw_only=True)
+class AddEmbargoToCase(as_Add):
+    """Add an EmbargoEvent to a case. This should only be performed by the case owner.
+    For use when the case owner is activating an embargo on the case without first proposing it to the participants.
+    See ActivateEmbargo for use when the case owner is activating an embargo on the case
+    in response to a previous EmProposeEmbargo activity.
+    """
+
+    as_type: str = field(default="Add", init=False)
+    as_object: Optional[EmbargoEvent | as_Link | str] = field(
+        metadata=config(field_name="object"), default=None, repr=True
+    )
+    target: Optional[VulnerabilityCase | as_Link | str] = field(
         default=None, repr=True
     )
 
@@ -151,10 +170,10 @@ class AnnounceEmbargo(as_Announce):
     """
 
     as_type: str = field(default="Announce", init=False)
-    as_object: Optional[Union[EmbargoEvent, as_Link]] = field(
+    as_object: Optional[EmbargoEvent | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
-    context: Optional[Union[VulnerabilityCase, as_Link]] = field(
+    context: Optional[VulnerabilityCase | as_Link | str] = field(
         default=None, repr=True
     )
 
@@ -171,7 +190,7 @@ class RemoveEmbargoFromCase(as_Remove):
     """
 
     as_type: str = field(default="Remove", init=False)
-    as_object: Optional[Union[EmbargoEvent, as_Link]] = field(
+    as_object: Optional[EmbargoEvent | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
-    origin: Optional[Union[VulnerabilityCase, as_Link]] = field(default=None)
+    origin: Optional[VulnerabilityCase | as_Link | str] = field(default=None)

--- a/vultron/as_vocab/activities/report.py
+++ b/vultron/as_vocab/activities/report.py
@@ -17,7 +17,7 @@ VulnerabilityReports.
 """
 
 from dataclasses import dataclass, field
-from typing import Optional, Union
+from typing import Optional
 
 from dataclasses_json import LetterCase, config, dataclass_json
 
@@ -38,8 +38,8 @@ from vultron.as_vocab.objects.vulnerability_report import VulnerabilityReport
 class RmCreateReport(as_Create):
     """The actor is creating a report."""
 
-    as_type: str = "Create"
-    as_object: Optional[Union[VulnerabilityReport, as_Link]] = field(
+    as_type: str = field(default="Create", init=False)
+    as_object: Optional[VulnerabilityReport | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
 
@@ -53,8 +53,8 @@ class RmSubmitReport(as_Offer):
     as_object: VulnerabilityReport
     """
 
-    as_type: str = "Offer"
-    as_object: Optional[Union[VulnerabilityReport, as_Link]] = field(
+    as_type: str = field(default="Offer", init=False)
+    as_object: Optional[VulnerabilityReport | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
 
@@ -67,8 +67,8 @@ class RmReadReport(as_Read):
     as_object: VulnerabilityReport
     """
 
-    as_type: str = "Read"
-    as_object: Optional[Union[VulnerabilityReport, as_Link]] = field(
+    as_type: str = field(default="Read", init=False)
+    as_object: Optional[VulnerabilityReport | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
 
@@ -82,8 +82,8 @@ class RmValidateReport(as_Accept):
     as_object: VulnerabilityReport
     """
 
-    as_type: str = "Accept"
-    as_object: Optional[Union[VulnerabilityReport, as_Link]] = field(
+    as_type: str = field(default="Accept", init=False)
+    as_object: Optional[VulnerabilityReport | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
 
@@ -97,8 +97,8 @@ class RmInvalidateReport(as_Reject):
     as_object: VulnerabilityReport
     """
 
-    as_type: str = "Reject"
-    as_object: Optional[Union[VulnerabilityReport, as_Link]] = field(
+    as_type: str = field(default="Reject", init=False)
+    as_object: Optional[VulnerabilityReport | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
 
@@ -113,6 +113,7 @@ class RmCloseReport(as_Leave):
     as_object: VulnerabilityReport
     """
 
-    as_object: Optional[Union[VulnerabilityReport, as_Link]] = field(
+    as_type: str = field(default="Leave", init=False)
+    as_object: Optional[VulnerabilityReport | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )

--- a/vultron/as_vocab/base/objects/activities/base.py
+++ b/vultron/as_vocab/base/objects/activities/base.py
@@ -17,7 +17,7 @@ created_at: 2/15/23 9:32 AM
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
 from dataclasses import dataclass, field
-from typing import Optional, Union
+from typing import Optional
 
 from dataclasses_json import config, dataclass_json
 
@@ -39,19 +39,19 @@ class as_Activity(as_Object):
     of the picture, not the person walking down the street.
     """
 
-    actor: Union[as_Object, as_Link] = field(
+    actor: as_Object | as_Link | str = field(
         metadata=config(exclude=exclude_if_none), default=None
     )
-    target: Optional[Union[as_Object, as_Link]] = field(
+    target: Optional[as_Object | as_Link | str] = field(
         metadata=config(exclude=exclude_if_none), default=None
     )
-    origin: Optional[Union[as_Object, as_Link]] = field(
+    origin: Optional[as_Object | as_Link | str] = field(
         metadata=config(exclude=exclude_if_none), default=None
     )
-    instrument: Optional[Union[as_Object, as_Link]] = field(
+    instrument: Optional[as_Object | as_Link | str] = field(
         metadata=config(exclude=exclude_if_none), default=None
     )
-    result: Optional[Union[as_Object, as_Link]] = field(
+    result: Optional[as_Object | as_Link | str] = field(
         metadata=config(exclude=exclude_if_none), default=None
     )
 

--- a/vultron/as_vocab/base/objects/activities/intransitive.py
+++ b/vultron/as_vocab/base/objects/activities/intransitive.py
@@ -71,10 +71,10 @@ class as_Question(as_IntransitiveActivity):
     See definition in ActivityStreams Vocabulary <https://www.w3.org/TR/activitystreams-vocabulary/#dfn-question>
     """
 
-    anyOf: Optional[Union[as_Object, as_Link]] = field(
+    anyOf: Optional[as_Object | as_Link | str] = field(
         metadata=config(exclude=exclude_if_none), default=None
     )
-    oneOf: Optional[Union[as_Object, as_Link]] = field(
+    oneOf: Optional[as_Object | as_Link | str] = field(
         metadata=config(exclude=exclude_if_none), default=None
     )
     closed: Optional[Union[as_Object, as_Link, datetime, bool]] = field(

--- a/vultron/as_vocab/base/objects/activities/transitive.py
+++ b/vultron/as_vocab/base/objects/activities/transitive.py
@@ -17,7 +17,7 @@ created_at: 12/8/22 4:01 PM
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
 from dataclasses import dataclass, field
-from typing import Optional, Union
+from typing import Optional
 
 from dataclasses_json import LetterCase, config, dataclass_json
 
@@ -39,7 +39,7 @@ class as_TransitiveActivity(Activity):
     See definition in ActivityStreams Vocabulary <https://www.w3.org/TR/activitystreams-vocabulary/#dfn-activity>
     """
 
-    as_object: Optional[Union[as_Object, as_Link]] = field(
+    as_object: Optional[as_Object | as_Link | str] = field(
         metadata=config(field_name="object"), default=None, repr=True
     )
 

--- a/vultron/as_vocab/objects/case_status.py
+++ b/vultron/as_vocab/objects/case_status.py
@@ -16,7 +16,7 @@ Provides Case Status objects for the Vultron ActivityStreams Vocabulary.
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
 from dataclasses import dataclass, field
-from typing import Optional, Union
+from typing import Optional
 
 from dataclasses_json import LetterCase, config, dataclass_json
 from marshmallow import fields
@@ -82,8 +82,8 @@ class ParticipantStatus(VultronObject):
     Represents the status of a participant with respect to a VulnerabilityCase (participant-specific).
     """
 
-    actor: Optional[Union[as_Actor, as_Link]] = field(default=None)
-    context: Optional[Union[as_Object, as_Link]] = field(default=None)
+    actor: Optional[as_Actor | as_Link | str] = field(default=None)
+    context: Optional[as_Object | as_Link | str] = field(default=None)
     rm_state: RM = field(
         default=RM.START,
         repr=True,
@@ -105,7 +105,7 @@ class ParticipantStatus(VultronObject):
             }
         },
     )
-    case_engagement: bool = False
+    case_engagement: bool = True
     embargo_adherence: bool = True
     tracking_id: Optional[str] = field(
         metadata=config(exclude=exclude_if_none), default=None

--- a/vultron/as_vocab/objects/vulnerability_case.py
+++ b/vultron/as_vocab/objects/vulnerability_case.py
@@ -77,6 +77,13 @@ class VulnerabilityCase(VultronObject):
         default_factory=list, metadata=config(exclude=exclude_if_empty)
     )
 
+    def __post_init__(self):
+        super().__post_init__()
+
+        # set the context of the case status objects to the case id
+        for cs in self.case_status:
+            cs.context = self.as_id
+
     def add_report(self, report: VulnerabilityReport) -> None:
         """Add a vulnerability report to the case
 

--- a/vultron/scripts/vocab_examples.py
+++ b/vultron/scripts/vocab_examples.py
@@ -1,0 +1,1095 @@
+#!/usr/bin/env python
+"""
+Provides tools for generating examples of Vultron ActivityStreams objects.
+
+Used within the Vultron documentation to provide examples of Vultron ActivityStreams objects.
+
+When run as a script, this module will generate a set of example objects and write them to the docs/reference/examples
+directory.
+"""
+#  Copyright (c) 2024 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  (“Third Party Software”). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+from datetime import datetime, timedelta
+
+from vultron.as_vocab.activities.actor import (
+    AcceptActorRecommendation,
+    RecommendActor,
+    RejectActorRecommendation,
+)
+from vultron.as_vocab.activities.case import (
+    AcceptCaseOwnershipTransfer,
+    AddNoteToCase,
+    AddReportToCase,
+    AddStatusToCase,
+    CreateCase,
+    CreateCaseStatus,
+    OfferCaseOwnershipTransfer,
+    RejectCaseOwnershipTransfer,
+    RmAcceptInviteToCase,
+    RmCloseCase,
+    RmDeferCase,
+    RmEngageCase,
+    RmInviteToCase,
+    RmRejectInviteToCase,
+    UpdateCase,
+)
+from vultron.as_vocab.activities.case_participant import (
+    AddParticipantToCase,
+    AddStatusToParticipant,
+    CreateParticipant,
+    CreateStatusForParticipant,
+    RemoveParticipantFromCase,
+)
+from vultron.as_vocab.activities.embargo import (
+    ActivateEmbargo,
+    AddEmbargoToCase,
+    AnnounceEmbargo,
+    ChoosePreferredEmbargo,
+    EmAcceptEmbargo,
+    EmProposeEmbargo,
+    EmRejectEmbargo,
+    RemoveEmbargoFromCase,
+)
+from vultron.as_vocab.activities.report import (
+    RmCloseReport,
+    RmCreateReport,
+    RmInvalidateReport,
+    RmReadReport,
+    RmSubmitReport,
+    RmValidateReport,
+)
+from vultron.as_vocab.base.base import as_Base
+from vultron.as_vocab.base.objects.activities.transitive import (
+    as_Create,
+    as_Undo,
+)
+from vultron.as_vocab.base.objects.actors import as_Organization, as_Person
+from vultron.as_vocab.base.objects.object_types import as_Event, as_Note
+from vultron.as_vocab.objects.case_participant import (
+    CaseParticipant,
+    CoordinatorParticipant,
+    FinderReporterParticipant,
+    VendorParticipant,
+)
+from vultron.as_vocab.objects.case_status import CaseStatus, ParticipantStatus
+from vultron.as_vocab.objects.embargo_event import EmbargoEvent
+from vultron.as_vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.as_vocab.objects.vulnerability_report import VulnerabilityReport
+from vultron.bt.embargo_management.states import EM
+from vultron.bt.report_management.states import RM
+from vultron.case_states.states import CS_pxa, CS_vfd
+
+#  Copyright (c) 2024 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  (“Third Party Software”). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+base_url = "https://vultron.example"
+user_base_url = f"{base_url}/users"
+case_base_url = f"{base_url}/cases"
+organization_base_url = f"{base_url}/organizations"
+report_base_url = f"{base_url}/reports"
+
+
+def json2md(obj: as_Base) -> str:
+    """
+    Given an object with a to_json method, return a markdown-formatted string of the object's JSON.
+    Args:
+        obj: an object with a to_json method
+
+    Returns:
+        a markdown-formatted string of the object's JSON
+    """
+
+    # strip out published and updated timestamps
+    obj.published = None
+    obj.updated = None
+
+    if not hasattr(obj, "to_json"):
+        raise TypeError(f"obj must have a to_json method: {obj}")
+
+    s = f"```json\n{obj.to_json(indent=2)}\n```"
+    return s
+
+
+def obj_to_file(obj: as_Base, filename: str) -> None:
+    """
+    Given an object with a to_json method, write it to a file.
+    Args:
+        obj: an object with a to_json method
+        filename: the file to write to
+
+    Returns:
+        None
+    """
+    # strip out published and updated timestamps
+    obj.published = None
+    obj.updated = None
+
+    with open(filename, "w") as fp:
+        fp.write(obj.to_json(indent=2))
+
+
+def print_obj(obj: as_Base) -> None:
+    """
+    Given an object with a to_json method, print it to stdout.
+    Args:
+        obj: an object with a to_json method
+
+    Returns:
+        None
+    """
+    print(obj.to_json(indent=2))
+
+
+def finder() -> as_Person:
+    """
+    Create a finder (Person) object
+    Returns:
+        an as_Person object
+    """
+    _finder = as_Person(name="Finn der Vul", as_id=f"{user_base_url}/finn")
+    return _finder
+
+
+def vendor() -> as_Organization:
+    """
+    Create a vendor (Organization) object
+    Returns:
+        an as_Organization object
+    """
+    _vendor = as_Organization(
+        name="VendorCo", as_id=f"{organization_base_url}/vendor"
+    )
+    return _vendor
+
+
+def report() -> VulnerabilityReport:
+    """
+    Create a vulnerability report
+    Returns:
+        a VulnerabilityReport object
+    """
+    _finder = finder()
+    report = VulnerabilityReport(
+        name="FDR-8675309",
+        as_id=f"{report_base_url}/FDR-8675309",
+        content="I found a vulnerability!",
+        attributed_to=[
+            _finder.as_id,
+        ],
+    )
+    return report
+
+
+def create_report() -> RmCreateReport:
+    """
+    In this example, a finder creates a vulnerability report.
+
+    Example:
+          >>> RmCreateReport(actor=finder.as_id, as_object=report)
+    """
+    _finder = finder()
+    _report = report()
+    activity = RmCreateReport(actor=_finder.as_id, as_object=_report)
+    return activity
+
+
+def submit_report() -> RmSubmitReport:
+    _finder = finder()
+    _vendor = vendor()
+    _report = report()
+    activity = RmSubmitReport(
+        actor=_finder.as_id, as_object=_report, to=_vendor.as_id
+    )
+    return activity
+
+
+def read_report() -> RmReadReport:
+    _report = report()
+    _vendor = vendor()
+    activity = RmReadReport(
+        actor=_vendor.as_id,
+        as_object=_report.as_id,
+        content="We've read the report. We'll get back to you soon.",
+    )
+    return activity
+
+
+def validate_report() -> RmValidateReport:
+    _report = report()
+    _vendor = vendor()
+    activity = RmValidateReport(
+        actor=_vendor.as_id,
+        as_object=_report.as_id,
+        content="We've validated the report. We'll be creating a case shortly.",
+    )
+    return activity
+
+
+def invalidate_report() -> RmInvalidateReport:
+    _report = report()
+    _vendor = vendor()
+    activity = RmInvalidateReport(
+        actor=_vendor.as_id,
+        as_object=_report.as_id,
+        content="We're declining this report as invalid. If you have a reason we should reconsider, please let us know. Otherwise we'll be closing it shortly.",
+    )
+    return activity
+
+
+def close_report() -> RmCloseReport:
+    _report = report()
+    _vendor = vendor()
+    activity = RmCloseReport(
+        actor=_vendor.as_id,
+        as_object=_report.as_id,
+        content="We're closing this report.",
+    )
+    return activity
+
+
+def case() -> VulnerabilityCase:
+    # create a vulnerability case
+    _case = VulnerabilityCase(
+        name="VENDOR Case #20991514",
+        as_id=f"{case_base_url}/VDR-20991514",
+    )
+    return _case
+
+
+def create_case() -> CreateCase:
+    _case = case()
+    _vendor = vendor()
+    _report = report()
+    _case.add_report(_report.as_id)
+    participant = VendorParticipant(actor=_vendor.as_id, name=_vendor.name)
+    _case.add_participant(participant)
+
+    activity = CreateCase(
+        actor=_vendor.as_id,
+        as_object=_case,
+        content="We've created a case from this report.",
+        context=_report.as_id,
+    )
+    return activity
+
+
+def add_report_to_case() -> AddReportToCase:
+    _vendor = vendor()
+    _report = report()
+    _case = case()
+
+    activity = AddReportToCase(
+        actor=_vendor.as_id,
+        as_object=_report.as_id,
+        target=_case.as_id,
+        content="We're adding this report to this case.",
+    )
+    return activity
+
+
+def add_vendor_participant_to_case() -> AddParticipantToCase:
+    _vendor = vendor()
+    _case = case()
+
+    shortname = _vendor.as_id.split("/")[-1]
+    _vendor_participant = VendorParticipant(
+        as_id=f"{_case.as_id}/participants/{shortname}",
+        name=_vendor.name,
+        actor=_vendor.as_id,
+        context=_case.as_id,
+    )
+
+    _pstatus = ParticipantStatus(
+        context=_case.as_id,
+        actor=_vendor.as_id,
+        rm_state=RM.RECEIVED,
+        vfd_state=CS_vfd.Vfd,
+    )
+    _vendor_participant.participant_status = [_pstatus]
+
+    activity = AddParticipantToCase(
+        actor=_vendor.as_id,
+        as_object=_vendor_participant,
+        target=_case.as_id,
+        content="We're adding ourselves as a participant to this case.",
+    )
+    return activity
+
+
+def add_finder_participant_to_case() -> AddParticipantToCase:
+    _vendor = vendor()
+    _case = case()
+
+    _finder = finder()
+    shortname = _finder.as_id.split("/")[-1]
+    _finder_participant = FinderReporterParticipant(
+        as_id=f"{_case.as_id}/participants/{shortname}",
+        name=_finder.name,
+        actor=_finder.as_id,
+        context=_case.as_id,
+    )
+
+    activity = AddParticipantToCase(
+        actor=_vendor.as_id,
+        as_object=_finder_participant,
+        target=_case.as_id,
+        content="We're adding the finder as a participant to this case.",
+    )
+    return activity
+
+
+def add_coordinator_participant_to_case() -> AddParticipantToCase:
+    _vendor = vendor()
+    _case = case()
+
+    _coordinator = coordinator()
+    shortname = _coordinator.as_id.split("/")[-1]
+    _coordinator_participant = CoordinatorParticipant(
+        as_id=f"{_case.as_id}/participants/{shortname}",
+        name=_coordinator.name,
+        actor=_coordinator.as_id,
+        context=_case.as_id,
+    )
+
+    activity = AddParticipantToCase(
+        actor=_vendor.as_id,
+        as_object=_coordinator_participant,
+        target=_case.as_id,
+        content="We're adding the coordinator as a participant to this case.",
+    )
+    return activity
+
+
+def engage_case() -> RmEngageCase:
+    _vendor = vendor()
+    _case = case()
+
+    activity = RmEngageCase(
+        actor=_vendor.as_id,
+        as_object=_case.as_id,
+        content="We're engaging this case.",
+    )
+    return activity
+
+
+def close_case() -> RmCloseCase:
+    _vendor = vendor()
+    _case = case()
+
+    activity = RmCloseCase(
+        actor=_vendor.as_id,
+        as_object=_case.as_id,
+        content="We're closing this case.",
+    )
+    return activity
+
+
+def defer_case() -> RmDeferCase:
+    _vendor = vendor()
+    _case = case()
+
+    activity = RmDeferCase(
+        actor=_vendor.as_id,
+        as_object=_case.as_id,
+        content="We're deferring this case.",
+    )
+    return activity
+
+
+def reengage_case() -> as_Undo:
+    _vendor = vendor()
+    _case = case()
+    _deferral = defer_case()
+
+    activity = as_Undo(
+        actor=_vendor.as_id,
+        as_object=_deferral,
+        content="We're reengaging this case.",
+        context=_case.as_id,
+    )
+    return activity
+
+
+def note() -> as_Note:
+    _case = case()
+    _note = as_Note(
+        name="Note",
+        as_id=f"{base_url}/notes/1",
+        content="This is a note.",
+        context=_case.as_id,
+    )
+    return _note
+
+
+def add_note_to_case() -> AddNoteToCase:
+    _finder = finder()
+    _case = case()
+    _note = note()
+    _note.context = _case.as_id
+
+    activity = AddNoteToCase(
+        actor=_finder.as_id,
+        as_object=_note,
+        target=_case.as_id,
+    )
+
+    return activity
+
+
+def coordinator() -> as_Organization:
+    _coordinator = as_Organization(
+        name="Coordinator LLC", as_id=f"{organization_base_url}/coordinator"
+    )
+    return _coordinator
+
+
+def accept_case_ownership_transfer() -> AcceptCaseOwnershipTransfer:
+    _case = case()
+    _coordinator = coordinator()
+    _vendor = vendor()
+    _activity = AcceptCaseOwnershipTransfer(
+        actor=_coordinator.as_id,
+        as_object=_case,
+        origin=_vendor.as_id,
+        content=f"We're accepting your offer to transfer ownership of case {_case.name} to us.",
+    )
+    return _activity
+
+
+def offer_case_ownership_transfer() -> OfferCaseOwnershipTransfer:
+    _vendor = vendor()
+    _case = case()
+    _coordinator = coordinator()
+    _activity = OfferCaseOwnershipTransfer(
+        actor=_vendor.as_id,
+        as_object=_case,
+        target=_coordinator.as_id,
+        content=f"We're offering to transfer ownership of case {_case.name} to you.",
+    )
+    return _activity
+
+
+def reject_case_ownership_transfer() -> RejectCaseOwnershipTransfer:
+    _case = case()
+    _coordinator = coordinator()
+    _vendor = vendor()
+    _activity = RejectCaseOwnershipTransfer(
+        actor=_coordinator.as_id,
+        as_object=_case,
+        origin=_vendor.as_id,
+        content=f"We're declining your offer to transfer ownership of case {_case.name} to us.",
+    )
+    return _activity
+
+
+def update_case() -> UpdateCase:
+    _case = case()
+    _vendor = vendor()
+
+    _activity = UpdateCase(
+        actor=_vendor.as_id,
+        as_object=_case.as_id,
+        content="We're updating the case to reflect a transfer of ownership.",
+    )
+    return _activity
+
+
+def recommend_actor() -> RecommendActor:
+    _case = case()
+    _finder = finder()
+    _vendor = vendor()
+    _coordinator = coordinator()
+    _activity = RecommendActor(
+        actor=_finder.as_id,
+        as_object=_coordinator.as_id,
+        context=_case.as_id,
+        target=_case.as_id,
+        to=_vendor.as_id,
+        content=f"I'm recommending we add {_coordinator.name} to the case.",
+    )
+    return _activity
+
+
+def accept_actor_recommendation() -> AcceptActorRecommendation:
+    _vendor = vendor()
+    _coordinator = coordinator()
+    _finder = finder()
+    _case = case()
+    _activity = AcceptActorRecommendation(
+        actor=_vendor.as_id,
+        as_object=_coordinator.as_id,
+        context=_case.as_id,
+        target=_case.as_id,
+        to=_finder.as_id,
+        content=f"We're accepting your recommendation to add {_coordinator.name} to the case. "
+        "We'll reach out to them shortly.",
+    )
+    return _activity
+
+
+def reject_actor_recommendation() -> RejectActorRecommendation:
+    _vendor = vendor()
+    _coordinator = coordinator()
+    _finder = finder()
+    _case = case()
+    _activity = RejectActorRecommendation(
+        actor=_vendor.as_id,
+        as_object=_coordinator.as_id,
+        context=_case.as_id,
+        target=_case.as_id,
+        to=_finder.as_id,
+        content=f"We're declining your recommendation to add {_coordinator.name} to the case. Thanks anyway.",
+    )
+    return _activity
+
+
+def rm_invite_to_case() -> RmInviteToCase:
+    _vendor = vendor()
+    _coordinator = coordinator()
+    _case = case()
+    _activity = RmInviteToCase(
+        as_id=f"{_case.as_id}/invitation/1",
+        actor=_vendor.as_id,
+        as_object=_coordinator.as_id,
+        target=_case.as_id,
+        to=_coordinator.as_id,
+        content=f"We're inviting you to participate in {_case.name}.",
+    )
+    return _activity
+
+
+def accept_invite_to_case() -> RmAcceptInviteToCase:
+    _vendor = vendor()
+    _coordinator = coordinator()
+    _case = case()
+    _activity = RmAcceptInviteToCase(
+        actor=_coordinator.as_id,
+        as_object=_case.as_id,
+        to=_vendor.as_id,
+        in_reply_to=rm_invite_to_case().as_id,
+        content=f"We're accepting your invitation to participate in {_case.name}.",
+    )
+    return _activity
+
+
+def reject_invite_to_case() -> RmRejectInviteToCase:
+    _vendor = vendor()
+    _coordinator = coordinator()
+    _case = case()
+    _activity = RmRejectInviteToCase(
+        actor=_coordinator.as_id,
+        as_object=_case.as_id,
+        to=_vendor.as_id,
+        in_reply_to=rm_invite_to_case().as_id,
+        content=f"Thanks for the invitation, but we're declining to participate in {_case.name}.",
+    )
+    return _activity
+
+
+def create_participant():
+    _vendor = vendor()
+    _case = case()
+    _coordinator = coordinator()
+    _coord_participant = CoordinatorParticipant(
+        as_id=f"{_case.as_id}/participants/{_coordinator.as_id}",
+        name=_coordinator.name,
+        actor=_coordinator.as_id,
+        context=_case.as_id,
+    )
+    _activity = CreateParticipant(
+        actor=_vendor.as_id,
+        as_object=_coord_participant,
+        target=_case.as_id,
+        content=f"We're adding {_coordinator.name} to the case.",
+    )
+    return _activity
+
+
+def case_status() -> CaseStatus:
+    status = CaseStatus(
+        as_id="https://vultron.example/cases/1/status/1",
+        context="https://vultron.example/cases/1",
+        em_state=EM.EMBARGO_MANAGEMENT_NONE,
+        pxa_state=CS_pxa.pxa,
+    )
+    return status
+
+
+def create_case_status():
+    actor = vendor()
+    status = case_status()
+    _case = case()
+
+    activity = CreateCaseStatus(
+        actor=actor.as_id,
+        as_object=status,
+        context=_case.as_id,
+    )
+    return activity
+
+
+def case_participant() -> CaseParticipant:
+    participant = VendorParticipant(
+        as_id="https://vultron.example/cases/1/participants/vendor",
+        name="Vendor",
+        actor="https://vultron.example/organizations/vendor",
+        context="https://vultron.example/cases/1",
+        participant_status=[participant_status()],
+    )
+    return participant
+
+
+def coordinator_participant() -> CaseParticipant:
+    _actor = coordinator()
+    _case = case()
+
+    participant = CoordinatorParticipant(
+        as_id=f"{_case.as_id}/participants/coordinator",
+        name=_actor.name,
+        actor=_actor.as_id,
+        context=_case.as_id,
+    )
+    return participant
+
+
+def participant_status() -> ParticipantStatus:
+    status = ParticipantStatus(
+        as_id="https://vultron.example/cases/1/participants/vendor/status/1",
+        context="https://vultron.example/cases/1/participants/vendor",
+        actor="https://vultron.example/organizations/vendor",
+        rm_state=RM.RECEIVED,
+        vfd_state=CS_vfd.Vfd,
+        case_status=case_status(),
+    )
+    return status
+
+
+def invite_to_case():
+    _case = case()
+    _coordinator = coordinator()
+    _vendor = vendor()
+
+    activity = RmInviteToCase(
+        as_id=f"{_case.as_id}/invitation/1",
+        actor=_vendor.as_id,
+        as_object=_coordinator.as_id,
+        target=_case.as_id,
+        to=_coordinator.as_id,
+        content=f"We're inviting you to participate in case {_case.name}.",
+    )
+    return activity
+
+
+def embargo_event(days: int = 90) -> as_Event:
+    start_at = datetime.now().astimezone(tz=None)
+    # zero out the seconds and microseconds
+    start_at = start_at.replace(second=0, microsecond=0)
+
+    # set end time to 90 days from now, with a time of 00:00:00, in UTC
+    end_at = start_at + timedelta(days=days)
+    # zero out the time
+    end_at = end_at.replace(hour=0, minute=0, second=0, microsecond=0)
+    # convert to UTC
+    end_at = end_at.astimezone(tz=None)
+
+    _case = case()
+
+    event = EmbargoEvent(
+        as_id=f"{_case.as_id}/embargo_events/{end_at.isoformat()}",
+        name=f"Embargo for {_case.name}",
+        context=_case.as_id,
+        start_time=start_at,
+        end_time=end_at,
+        content=f"We propose to embargo {_case.name} for {days} days.",
+    )
+    return event
+
+
+def create_participant_status() -> ParticipantStatus:
+    pstatus = participant_status()
+
+    activity = CreateStatusForParticipant(
+        actor="https://vultron.example/organizations/vendor",
+        as_object=pstatus,
+    )
+    return activity
+
+
+def add_status_to_participant() -> AddStatusToParticipant:
+    pstatus = participant_status()
+
+    activity = AddStatusToParticipant(
+        actor="https://vultron.example/organizations/vendor",
+        as_object=pstatus,
+        target="https://vultron.example/cases/1/participants/vendor",
+    )
+    return activity
+
+
+def remove_participant_from_case():
+    _vendor = vendor()
+    _case = case()
+    coord_p = coordinator_participant()
+    activity = RemoveParticipantFromCase(
+        actor=_vendor.as_id,
+        as_object=coord_p.as_id,
+        origin=_case.as_id,
+        summary="Vendor is removing the coordinator from the case.",
+    )
+    return activity
+
+
+def propose_embargo() -> EmProposeEmbargo:
+    embargo = embargo_event()
+
+    activity = EmProposeEmbargo(
+        actor="https://vultron.example/organizations/vendor",
+        as_object=embargo,
+        target=embargo.context,
+        summary="We propose to embargo case 1 for 90 days.",
+    )
+    return activity
+
+
+def choose_preferred_embargo() -> ChoosePreferredEmbargo:
+    embargo_list = [
+        embargo_event(90),
+        embargo_event(45),
+    ]
+
+    _case = case()
+    activity = ChoosePreferredEmbargo(
+        as_id="https://vultron.example/cases/1/polls/1",
+        actor="https://vultron.example/organizations/coordinator",
+        one_of=embargo_list,
+        summary="Please accept or reject each of the proposed embargoes.",
+        to=f"{_case.as_id}/participants",
+        context=_case.as_id,
+    )
+    return activity
+
+
+def accept_embargo() -> EmAcceptEmbargo:
+    question = choose_preferred_embargo()
+    _vendor = vendor()
+    activity = EmAcceptEmbargo(
+        actor=_vendor.as_id,
+        as_object=embargo_event(90),
+        context="https://vultron.example/cases/1",
+        in_reply_to=question.as_id,
+        to="https://vultron.example/cases/1/participants",
+    )
+    return activity
+
+
+def reject_embargo() -> EmRejectEmbargo:
+    question = choose_preferred_embargo()
+    activity = EmRejectEmbargo(
+        actor="https://vultron.example/organizations/vendor",
+        as_object=embargo_event(45),
+        context="https://vultron.example/cases/1",
+        in_reply_to=question.as_id,
+        to="https://vultron.example/cases/1/participants",
+    )
+    return activity
+
+
+def add_embargo_to_case() -> AddEmbargoToCase:
+    _case = case()
+    _vendor = vendor()
+    activity = AddEmbargoToCase(
+        actor=_vendor.as_id,
+        as_object=embargo_event(90),
+        target=_case.as_id,
+        to=f"{_case.as_id}/participants",
+    )
+    return activity
+
+
+def activate_embargo() -> ActivateEmbargo:
+    _case = case()
+    _vendor = vendor()
+    activity = ActivateEmbargo(
+        actor=_vendor.as_id,
+        as_object=propose_embargo().as_object,
+        target=_case.as_id,
+        in_reply_to=propose_embargo().as_id,
+        to=f"{_case.as_id}/participants",
+    )
+    return activity
+
+
+def announce_embargo() -> AnnounceEmbargo:
+    _vendor = vendor()
+    _case = case()
+
+    activity = AnnounceEmbargo(
+        actor=_vendor.as_id,
+        as_object=embargo_event(90),
+        context=_case.as_id,
+        to=f"{_case.as_id}/participants",
+    )
+    return activity
+
+
+def remove_embargo() -> RemoveEmbargoFromCase:
+    _vendor = vendor()
+    _case = case()
+    activity = RemoveEmbargoFromCase(
+        actor=_vendor.as_id,
+        as_object=embargo_event(90),
+        origin=_case.as_id,
+    )
+    return activity
+
+
+def add_status_to_case() -> AddStatusToCase:
+    _vendor = vendor()
+    _case = case()
+    _status = case_status()
+    activity = AddStatusToCase(
+        actor=_vendor.as_id,
+        as_object=_status,
+        target=_case.as_id,
+    )
+    return activity
+
+
+def create_note():
+    _case = case()
+    _note = note()
+    activity = as_Create(
+        actor="https://vultron.example/organizations/vendor",
+        as_object=_note,
+        target=_case.as_id,
+    )
+    return activity
+
+
+def main():
+    outdir = "../../docs/reference/examples"
+    print(f"Generating examples to: {outdir}")
+
+    # ensure the output directory exists
+    from pathlib import Path
+
+    Path(outdir).mkdir(parents=True, exist_ok=True)
+
+    # create a finder (Person) object
+    _finder = finder()
+    obj_to_file(_finder, f"{outdir}/finder.json")
+
+    # create a vendor (Organization) object
+    _vendor = vendor()
+    obj_to_file(_vendor, f"{outdir}/vendor.json")
+
+    # create a vulnerability _report
+    _report = report()
+    obj_to_file(_report, f"{outdir}/vulnerability_report.json")
+
+    # activity: finder creates _report
+    activity = create_report()
+    obj_to_file(activity, f"{outdir}/create_report.json")
+
+    # activity: finder submits _report to vendor
+    activity = submit_report()
+    obj_to_file(activity, f"{outdir}/submit_report.json")
+
+    # activity: vendor reads _report
+    activity = read_report()
+    obj_to_file(activity, f"{outdir}/read_report.json")
+
+    # activity: vendor validates _report
+    activity = validate_report()
+    obj_to_file(activity, f"{outdir}/validate_report.json")
+
+    # activity: vendor invalidates _report
+    activity = invalidate_report()
+    obj_to_file(activity, f"{outdir}/invalidate_report.json")
+
+    # activity: vendor closes _report
+    activity = close_report()
+    obj_to_file(activity, f"{outdir}/close_report.json")
+
+    # case object
+    _case = case()
+    obj_to_file(_case, f"{outdir}/vulnerability_case.json")
+
+    # activity: vendor creates case from _report
+    activity = create_case()
+    obj_to_file(activity, f"{outdir}/create_case.json")
+
+    # activity: vendor adds _report to case
+    activity = add_report_to_case()
+    obj_to_file(activity, f"{outdir}/add_report_to_case.json")
+
+    # activity: vendor adds self as participant to case
+    activity = add_vendor_participant_to_case()
+
+    participant = activity.as_object
+    obj_to_file(participant, f"{outdir}/vendor_participant.json")
+    obj_to_file(activity, f"{outdir}/add_vendor_participant_to_case.json")
+
+    # activity: vendor adds finder as participant to case
+    activity = add_finder_participant_to_case()
+    participant = activity.as_object
+    obj_to_file(participant, f"{outdir}/finder_participant.json")
+    obj_to_file(activity, f"{outdir}/add_finder_participant_to_case.json")
+
+    # activity: vendor engages case
+    activity = engage_case()
+    obj_to_file(activity, f"{outdir}/engage_case.json")
+
+    # activity: vendor closes case
+    activity = close_case()
+    obj_to_file(activity, f"{outdir}/close_case.json")
+
+    # activity: vendor defers case
+    activity = defer_case()
+    obj_to_file(activity, f"{outdir}/defer_case.json")
+
+    # activity: vendor reengages case
+    activity = reengage_case()
+    obj_to_file(activity, f"{outdir}/reengage_case.json")
+
+    # activity: add note to case
+    activity = add_note_to_case()
+    obj_to_file(activity, f"{outdir}/add_note_to_case.json")
+
+    _coordinator = coordinator()
+    obj_to_file(_coordinator, f"{outdir}/coordinator.json")
+
+    # activity: offer case ownership transfer
+    activity = offer_case_ownership_transfer()
+    obj_to_file(activity, f"{outdir}/offer_case_ownership_transfer.json")
+
+    # activity: accept case ownership transfer
+    activity = accept_case_ownership_transfer()
+    obj_to_file(activity, f"{outdir}/accept_case_ownership_transfer.json")
+
+    # activity: reject case ownership transfer
+    activity = reject_case_ownership_transfer()
+    obj_to_file(activity, f"{outdir}/reject_case_ownership_transfer.json")
+
+    # activity: update case
+    activity = update_case()
+    obj_to_file(activity, f"{outdir}/update_case.json")
+
+    # recommend actor
+    activity = recommend_actor()
+    obj_to_file(activity, f"{outdir}/recommend_actor.json")
+
+    # accept actor recommendation
+    activity = accept_actor_recommendation()
+    obj_to_file(activity, f"{outdir}/accept_actor_recommendation.json")
+
+    # reject actor recommendation
+    activity = reject_actor_recommendation()
+    obj_to_file(activity, f"{outdir}/reject_actor_recommendation.json")
+
+    # rm_invite_to_case
+    activity = rm_invite_to_case()
+    obj_to_file(activity, f"{outdir}/invite_to_case.json")
+
+    # rm_accept_invite_to_case
+    activity = accept_invite_to_case()
+    obj_to_file(activity, f"{outdir}/accept_invite_to_case.json")
+
+    # rm_reject_invite_to_case
+    activity = reject_invite_to_case()
+    obj_to_file(activity, f"{outdir}/reject_invite_to_case.json")
+
+    # create participant
+    activity = create_participant()
+    obj_to_file(activity, f"{outdir}/create_participant.json")
+
+    _case_status = case_status()
+    obj_to_file(_case_status, f"{outdir}/case_status.json")
+
+    _create_case_status = create_case_status()
+    obj_to_file(_create_case_status, f"{outdir}/create_case_status.json")
+
+    _add_status_to_case = add_status_to_case()
+    obj_to_file(_add_status_to_case, f"{outdir}/add_status_to_case.json")
+
+    _participant_status = participant_status()
+    obj_to_file(_participant_status, f"{outdir}/participant_status.json")
+
+    _case_participant = case_participant()
+    obj_to_file(_case_participant, f"{outdir}/case_participant.json")
+
+    _embargo_event = embargo_event()
+    obj_to_file(_embargo_event, f"{outdir}/embargo_event.json")
+
+    _invite_to_case = invite_to_case()
+    obj_to_file(_invite_to_case, f"{outdir}/invite_to_case.json")
+
+    _create_participant_status = create_participant_status()
+    obj_to_file(
+        _create_participant_status, f"{outdir}/create_participant_status.json"
+    )
+
+    _add_status_to_participant = add_status_to_participant()
+    obj_to_file(
+        _add_status_to_participant, f"{outdir}/add_status_to_participant.json"
+    )
+
+    _remove_participant_from_case = remove_participant_from_case()
+    obj_to_file(
+        _remove_participant_from_case,
+        f"{outdir}/remove_participant_from_case.json",
+    )
+
+    _propose_embargo = propose_embargo()
+    obj_to_file(_propose_embargo, f"{outdir}/propose_embargo.json")
+
+    _choose_preferred_embargo = choose_preferred_embargo()
+    obj_to_file(
+        _choose_preferred_embargo, f"{outdir}/choose_preferred_embargo.json"
+    )
+
+    _accept_embargo = accept_embargo()
+    obj_to_file(_accept_embargo, f"{outdir}/accept_embargo.json")
+
+    _reject_embargo = reject_embargo()
+    obj_to_file(_reject_embargo, f"{outdir}/reject_embargo.json")
+
+    _add_embargo_to_case = add_embargo_to_case()
+    obj_to_file(_add_embargo_to_case, f"{outdir}/add_embargo_to_case.json")
+
+    _activate_embargo = activate_embargo()
+    obj_to_file(_activate_embargo, f"{outdir}/activate_embargo.json")
+
+    _announce_embargo = announce_embargo()
+    obj_to_file(_announce_embargo, f"{outdir}/announce_embargo.json")
+
+    _remove_embargo = remove_embargo()
+    obj_to_file(_remove_embargo, f"{outdir}/remove_embargo.json")
+
+    _create_note = create_note()
+    obj_to_file(_create_note, f"{outdir}/create_note.json")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR contains python changes that can generate lots of examples of ActivityPub activity JSON objects for inclusion in the documentation. 

A separate PR will be created to include the corresponding documentation. I'm splitting these up into separate PRs just to make it a little easier to track the changes.