### PR TITLE
Refactor make_payload() in tests

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,7 +17,8 @@ Case State (CS) — modeled as Behavior Trees.
 uv sync --dev
 
 # Format (run before every commit)
-uv run black vultron/ test/
+# Format and lint Python sources before committing
+uv run black vultron/ test/ && uv run flake8 vultron/ test/
 
 # Full test suite — run exactly once, read the last 5 lines
 uv run pytest --tb=short 2>&1 | tail -5
@@ -34,8 +35,9 @@ uv run mypy
 uv run mkdocs serve
 ```
 
-Always format with Black before staging Python changes. Do not run Black on
-markdown files — use `markdownlint-cli2` for those.
+Always format Python sources with Black and run `flake8` before staging
+changes for commit. Do not run Black on markdown files — use
+`markdownlint-cli2` for those.
 
 ## Architecture
 

--- a/.github/prompts/BUGFIX.md
+++ b/.github/prompts/BUGFIX.md
@@ -31,8 +31,9 @@ Objective: Fix the highest-priority open bug using test-first development.
 
 7. Finalize
    - Mark the bug fixed in plan/BUGS.md.
-   - Update plan/IMPLEMENTATION_NOTES.md with relevant details.
+   - Update plan/IMPLEMENTATION_HISTORY.md with relevant details.
      - include a summary of the issue, root cause, and how it was resolved.
+   - Add lessons learned (if any) to plan/IMPLEMENTATION_NOTES.md.
      - include notes about other bugs encountered if applicable.
      - include notes of architectural or design implications if applicable
    - git add and commit changes with a clear, specific message.

--- a/.github/skills/format-code/SKILL.md
+++ b/.github/skills/format-code/SKILL.md
@@ -8,7 +8,7 @@ tags:
   - dev-workflow
 shell: "zsh"
 commands:
-  - "uv run black vultron/ test/"
+  - "uv run black vultron/ test/ && uv run flake8 vultron/ test/"
 inputs:
   - name: repo_root
     description: "Repository root"
@@ -36,11 +36,11 @@ consistent code style and avoids pre-commit failures.
 
 ## Procedure
 
-1. From the repository root, run Black on the `vultron/` and `test/`
-   directories:
+1. From the repository root, run Black and flake8 on the `vultron/` and
+   `test/` directories:
 
 ```bash
-uv run black vultron/ test/
+uv run black vultron/ test/ && uv run flake8 vultron/ test/
 ```
 
 2. Inspect the output and stage changes if any files were reformatted.
@@ -55,7 +55,7 @@ uv run black vultron/ test/
 
 ```bash
 cd "$REPO_ROOT"
-uv run black vultron/ test/
+uv run black vultron/ test/ && uv run flake8 vultron/ test/
 ```
 
 ## Rationale

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -719,21 +719,24 @@ to relevant tests and design notes.
 ### Commit Workflow
 
 **BEFORE committing**, agents MUST follow the procedure documented in
-`.github/skills/format-code/SKILL.md` (format first), then `.github/skills/run-tests/SKILL.md` (run
-the test-suite exactly once), then commit. The skill files contain the exact
-commands and the required invocation order.
+`.github/skills/format-code/SKILL.md` (format and lint first), then
+`.github/skills/run-tests/SKILL.md` (run the test-suite exactly once), then
+commit. The skill files contain the exact commands and the required
+invocation order.
 
 **Why this order matters**:
 
-1. Black formatting is enforced by pre-commit hooks — format first to avoid a
-   failed commit → re-stage → re-commit cycle.
+1. Black formatting is enforced by pre-commit hooks — format (and run
+   flake8) first to avoid a failed commit → re-stage → re-commit cycle.
 2. The test suite must pass before committing — read the single-run test
    output as documented in the skill file (the skill explains how to capture
    the summary line and why you must not re-run pytest to grep for counts).
 
-**When to run Black**:
+**When to run formatting and linters**:
 
 - After editing any Python files, before staging for commit
+- Run `flake8` on `vultron/` and `test/` to catch linting issues before
+  committing
 - Do NOT run `black` on markdown files (use `markdownlint-cli2` for those)
 
 **Alternative**: If you forget and the pre-commit hook reformats files, simply:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,5 +36,6 @@ There are a number of ways you can contribute to the development of Vultron.
 [ContributionInstructions.md](https://github.com/CERTCC/Vultron/blob/main/ContributionInstructions.md)
 before submitting a PR.
 - Before making any significant changes that you expect to result in a pull request, we encourage you to discuss your plans with
-the maintainers first, whether that be in the form of an [Issue](https://github.com/CERTCC/Vultron/issues) or a [Discussion](https://github.com/CERTCC/Vultron/discussions).
-- Python code should be formatted with [Black](https://black.readthedocs.io/en/stable/)
+  the maintainers first, whether that be in the form of an [Issue](https://github.com/CERTCC/Vultron/issues) or a [Discussion](https://github.com/CERTCC/Vultron/discussions).
+- Python code should be formatted with [Black](https://black.readthedocs.io/en/stable/) and linted with `flake8`.
+  Run `uv run flake8 vultron/ test/` to check for lint issues before committing.

--- a/plan/IMPLEMENTATION_HISTORY.md
+++ b/plan/IMPLEMENTATION_HISTORY.md
@@ -2737,3 +2737,41 @@ to access domain properties instead of generic names.
 ### Test results
 
 984 passed, 5581 subtests passed.
+
+---
+
+## TECHDEBT-36 — Centralize `_make_payload()` test helper (COMPLETE 2026-03-24)
+
+**Goal**: Remove 5 duplicate local `_make_payload(activity, **extra_fields)` functions from
+test files in `test/core/use_cases/` and replace with the shared `make_payload` pytest
+fixture already defined in `test/core/use_cases/conftest.py`.
+
+**Approach**: Removed the local function definition from each of the 5 affected test files.
+Removed the now-unused `from vultron.wire.as2.extractor import extract_intent` module-level
+import from 3 files (`test_status_use_cases.py`, `test_note_use_cases.py`,
+`test_case_use_cases.py`). Added `make_payload` as a fixture parameter to all 37 test
+methods that previously called the local function.
+
+**Source files changed**:
+
+- `test/core/use_cases/test_status_use_cases.py` — removed local def, updated 7 test methods
+- `test/core/use_cases/test_actor_use_cases.py` — removed local def, updated 13 test methods
+- `test/core/use_cases/test_note_use_cases.py` — removed local def, updated 6 test methods
+- `test/core/use_cases/test_case_use_cases.py` — removed local def, updated 6 test methods
+- `test/core/use_cases/test_embargo_use_cases.py` — removed local def, updated 11 test methods
+
+### Test results
+
+985 passed, 5581 subtests passed.
+
+---
+
+## TECHDEBT-38 — Fix `outbox_handler` crash on missing actor / BUG-001 (COMPLETE 2026-03-24)
+
+**Note**: The code fix (early `return` in `outbox_handler.py` when actor is `None`) was
+already applied during OX-1.4 work. This entry records that the plan item was verified
+and checked off. No code changes needed.
+
+### Test results
+
+985 passed, 5581 subtests passed.

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -1,7 +1,6 @@
 # Vultron API v2 Implementation Plan
 
-**Last Updated**: 2026-03-23 (refresh #45: P90 all complete; TECHDEBT-34 updated;
-BUG-001 fix and TECHDEBT-38/39 added; gap analysis updated)
+**Last Updated**: 2026-03-24 (refresh #46: TECHDEBT-36 and TECHDEBT-38 complete)
 
 ## Overview
 
@@ -731,13 +730,18 @@ direct enum assignments in `vultron/core/` that bypass machine validation.
 
 **Source**: `plan/IMPLEMENTATION_NOTES.md` "`_make_payload()` duplicated across tests"
 
-- [ ] **TECHDEBT-36**: Multiple test files under `test/` contain a local
+- [x] **TECHDEBT-36**: Multiple test files under `test/` contain a local
   `_make_payload(activity, **extra_fields)` helper function that was duplicated
   during a large test-file split. Identify all copies, extract the shared
   implementation into a centralized test fixture (e.g., a helper in
   `test/conftest.py` or a `test/helpers.py` utility module), and replace all
   local copies with imports of the shared version. Done when no duplicate
   `_make_payload` definitions remain and all affected tests pass.
+  **COMPLETE**: Removed local `_make_payload` from 5 test files
+  (`test_status_use_cases.py`, `test_actor_use_cases.py`, `test_note_use_cases.py`,
+  `test_case_use_cases.py`, `test_embargo_use_cases.py`). All 37 affected test
+  methods now use the `make_payload` fixture from `test/core/use_cases/conftest.py`.
+  985 tests pass.
 
 ---
 
@@ -765,7 +769,7 @@ direct enum assignments in `vultron/core/` that bypass machine validation.
 **Source**: `plan/BUGS.md` BUG-001 (discovered during OX-1.4 test writing,
 2026-03-23)
 
-- [ ] **TECHDEBT-38**: In
+- [x] **TECHDEBT-38**: In
   `vultron/adapters/driving/fastapi/outbox_handler.py`, add a `return` (or
   `return None`) immediately after the `logger.warning(...)` line that fires
   when `actor is None`. Without this early return, the next line
@@ -773,6 +777,8 @@ direct enum assignments in `vultron/core/` that bypass machine validation.
   no attribute 'outbox'` for any unknown `actor_id`. Done when the early return
   is present, the existing `test_outbox.py` test that covers the missing-actor
   path passes, and the full test suite passes.
+  **COMPLETE**: The early return was already present in the code (applied as
+  part of OX-1.4 work); plan entry was not yet checked off. Verified 985 tests pass.
 
 ---
 

--- a/test/core/use_cases/test_actor_use_cases.py
+++ b/test/core/use_cases/test_actor_use_cases.py
@@ -30,20 +30,13 @@ from vultron.core.use_cases.actor import (
 )
 
 
-def _make_payload(activity, **extra_fields):
-    from vultron.wire.as2.extractor import extract_intent
-
-    event = extract_intent(activity)
-    if extra_fields:
-        return event.model_copy(update=extra_fields)
-    return event
-
-
 class TestInviteActorUseCases:
     """Tests for invite_actor_to_case, accept_invite_actor_to_case,
     and reject_invite_actor_to_case."""
 
-    def test_invite_actor_to_case_stores_invite(self, monkeypatch):
+    def test_invite_actor_to_case_stores_invite(
+        self, monkeypatch, make_payload
+    ):
         """InviteActorToCaseReceivedUseCase persists the Invite activity to the DataLayer."""
         from vultron.adapters.driven.datalayer_tinydb import TinyDbDataLayer
         from vultron.wire.as2.vocab.activities.case import (
@@ -59,14 +52,14 @@ class TestInviteActorUseCases:
             target="https://example.org/cases/case1",
         )
 
-        event = _make_payload(invite)
+        event = make_payload(invite)
 
         InviteActorToCaseReceivedUseCase(dl, event).execute()
 
         stored = dl.get(invite.as_type.value, invite.as_id)
         assert stored is not None
 
-    def test_invite_actor_to_case_idempotent(self, monkeypatch):
+    def test_invite_actor_to_case_idempotent(self, monkeypatch, make_payload):
         """InviteActorToCaseReceivedUseCase skips storing a duplicate Invite."""
         from vultron.adapters.driven.datalayer_tinydb import TinyDbDataLayer
         from vultron.wire.as2.vocab.activities.case import (
@@ -82,7 +75,7 @@ class TestInviteActorUseCases:
             target="https://example.org/cases/case1",
         )
 
-        event = _make_payload(invite)
+        event = make_payload(invite)
 
         InviteActorToCaseReceivedUseCase(dl, event).execute()
         InviteActorToCaseReceivedUseCase(
@@ -92,7 +85,7 @@ class TestInviteActorUseCases:
         stored = dl.get(invite.as_type.value, invite.as_id)
         assert stored is not None
 
-    def test_reject_invite_actor_to_case_logs_rejection(self):
+    def test_reject_invite_actor_to_case_logs_rejection(self, make_payload):
         """RejectInviteActorToCaseReceivedUseCase logs without raising."""
         from vultron.wire.as2.vocab.activities.case import (
             RmInviteToCaseActivity,
@@ -110,14 +103,16 @@ class TestInviteActorUseCases:
             object=invite,
         )
 
-        event = _make_payload(reject)
+        event = make_payload(reject)
 
         result = RejectInviteActorToCaseReceivedUseCase(
             MagicMock(), event
         ).execute()
         assert result is None
 
-    def test_accept_invite_actor_to_case_adds_participant(self, monkeypatch):
+    def test_accept_invite_actor_to_case_adds_participant(
+        self, monkeypatch, make_payload
+    ):
         """AcceptInviteActorToCaseReceivedUseCase creates a CaseParticipant and adds them to the case."""
         from vultron.adapters.driven.datalayer_tinydb import TinyDbDataLayer
         from vultron.wire.as2.vocab.activities.case import (
@@ -155,7 +150,7 @@ class TestInviteActorUseCases:
             object=invite,
         )
 
-        event = _make_payload(accept)
+        event = make_payload(accept)
 
         AcceptInviteActorToCaseReceivedUseCase(dl, event).execute()
 
@@ -163,7 +158,7 @@ class TestInviteActorUseCases:
         assert invitee_id in case.actor_participant_index
 
     def test_accept_invite_actor_to_case_records_active_embargo(
-        self, monkeypatch
+        self, monkeypatch, make_payload
     ):
         """AcceptInviteActorToCaseReceivedUseCase records the active embargo ID on the new participant (CM-10-001, CM-10-003)."""
         from vultron.adapters.driven.datalayer_tinydb import TinyDbDataLayer
@@ -209,7 +204,7 @@ class TestInviteActorUseCases:
             object=invite,
         )
 
-        event = _make_payload(accept)
+        event = make_payload(accept)
 
         AcceptInviteActorToCaseReceivedUseCase(dl, event).execute()
 
@@ -220,7 +215,9 @@ class TestInviteActorUseCases:
         assert participant_obj is not None
         assert embargo.as_id in participant_obj.accepted_embargo_ids
 
-    def test_accept_invite_actor_to_case_records_case_event(self, monkeypatch):
+    def test_accept_invite_actor_to_case_records_case_event(
+        self, monkeypatch, make_payload
+    ):
         """AcceptInviteActorToCaseReceivedUseCase appends a trusted-timestamp event to case.events (CM-02-009)."""
         from vultron.adapters.driven.datalayer_tinydb import TinyDbDataLayer
         from vultron.wire.as2.vocab.activities.case import (
@@ -258,7 +255,7 @@ class TestInviteActorUseCases:
             object=invite,
         )
 
-        event = _make_payload(accept)
+        event = make_payload(accept)
 
         assert len(case.events) == 0
 
@@ -273,7 +270,9 @@ class TestInviteActorUseCases:
 class TestSuggestActorUseCases:
     """Tests for suggest_actor_to_case, accept/reject suggest_actor use cases."""
 
-    def test_suggest_actor_to_case_persists_recommendation(self, monkeypatch):
+    def test_suggest_actor_to_case_persists_recommendation(
+        self, monkeypatch, make_payload
+    ):
         """SuggestActorToCaseReceivedUseCase persists the RecommendActor offer."""
         from vultron.adapters.driven.datalayer_tinydb import TinyDbDataLayer
         from vultron.wire.as2.vocab.base.objects.actors import as_Actor
@@ -295,14 +294,14 @@ class TestSuggestActorUseCases:
             to="https://example.org/users/vendor",
         )
 
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         SuggestActorToCaseReceivedUseCase(dl, event).execute()
 
         stored = dl.get(activity.as_type.value, activity.as_id)
         assert stored is not None
 
-    def test_suggest_actor_to_case_idempotent(self, monkeypatch):
+    def test_suggest_actor_to_case_idempotent(self, monkeypatch, make_payload):
         """SuggestActorToCaseReceivedUseCase is idempotent — second call is a no-op."""
         from vultron.adapters.driven.datalayer_tinydb import TinyDbDataLayer
         from vultron.wire.as2.vocab.activities.actor import (
@@ -322,7 +321,7 @@ class TestSuggestActorUseCases:
             object=coordinator,
             target=case,
         )
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         SuggestActorToCaseReceivedUseCase(dl, event).execute()
         SuggestActorToCaseReceivedUseCase(dl, event).execute()
@@ -331,7 +330,7 @@ class TestSuggestActorUseCases:
         assert stored is not None
 
     def test_accept_suggest_actor_to_case_persists_acceptance(
-        self, monkeypatch
+        self, monkeypatch, make_payload
     ):
         """AcceptSuggestActorToCaseReceivedUseCase persists the AcceptActorRecommendation."""
         from vultron.adapters.driven.datalayer_tinydb import TinyDbDataLayer
@@ -358,7 +357,7 @@ class TestSuggestActorUseCases:
             object=recommendation,
             target=case,
         )
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         AcceptSuggestActorToCaseReceivedUseCase(dl, event).execute()
 
@@ -366,7 +365,7 @@ class TestSuggestActorUseCases:
         assert stored is not None
 
     def test_reject_suggest_actor_to_case_logs_rejection(
-        self, monkeypatch, caplog
+        self, monkeypatch, caplog, make_payload
     ):
         """RejectSuggestActorToCaseReceivedUseCase logs rejection without state change."""
         from vultron.wire.as2.vocab.activities.actor import (
@@ -390,7 +389,7 @@ class TestSuggestActorUseCases:
             object=recommendation,
             target=case,
         )
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         with caplog.at_level(logging.INFO):
             RejectSuggestActorToCaseReceivedUseCase(
@@ -403,7 +402,9 @@ class TestSuggestActorUseCases:
 class TestOwnershipTransferUseCases:
     """Tests for offer/accept/reject ownership transfer use cases."""
 
-    def test_offer_case_ownership_transfer_persists_offer(self, monkeypatch):
+    def test_offer_case_ownership_transfer_persists_offer(
+        self, monkeypatch, make_payload
+    ):
         """OfferCaseOwnershipTransferReceivedUseCase persists the offer."""
         from vultron.adapters.driven.datalayer_tinydb import TinyDbDataLayer
         from vultron.wire.as2.vocab.activities.case import (
@@ -421,7 +422,7 @@ class TestOwnershipTransferUseCases:
             object=case,
             target="https://example.org/users/coordinator",
         )
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         OfferCaseOwnershipTransferReceivedUseCase(dl, event).execute()
 
@@ -429,7 +430,7 @@ class TestOwnershipTransferUseCases:
         assert stored is not None
 
     def test_accept_case_ownership_transfer_updates_attributed_to(
-        self, monkeypatch
+        self, monkeypatch, make_payload
     ):
         """AcceptCaseOwnershipTransferReceivedUseCase updates case.attributed_to to new owner."""
         from vultron.adapters.driven.datalayer_tinydb import TinyDbDataLayer
@@ -463,7 +464,7 @@ class TestOwnershipTransferUseCases:
             actor="https://example.org/users/coordinator",
             object=offer,
         )
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         AcceptCaseOwnershipTransferReceivedUseCase(dl, event).execute()
 
@@ -476,7 +477,7 @@ class TestOwnershipTransferUseCases:
         )
 
     def test_reject_case_ownership_transfer_logs_rejection(
-        self, monkeypatch, caplog
+        self, monkeypatch, caplog, make_payload
     ):
         """RejectCaseOwnershipTransferReceivedUseCase logs rejection; ownership unchanged."""
         from vultron.wire.as2.vocab.activities.case import (
@@ -498,7 +499,7 @@ class TestOwnershipTransferUseCases:
             actor="https://example.org/users/coordinator",
             object=offer,
         )
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         with caplog.at_level(logging.INFO):
             RejectCaseOwnershipTransferReceivedUseCase(

--- a/test/core/use_cases/test_case_use_cases.py
+++ b/test/core/use_cases/test_case_use_cases.py
@@ -16,7 +16,6 @@ import logging
 
 from vultron.adapters.driven.datalayer_tinydb import TinyDbDataLayer
 from vultron.core.use_cases.case import UpdateCaseReceivedUseCase
-from vultron.wire.as2.extractor import extract_intent
 from vultron.wire.as2.rehydration import rehydrate as real_rehydrate
 from vultron.wire.as2.vocab.activities.case import UpdateCaseActivity
 from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
@@ -24,17 +23,12 @@ from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
 
 
-def _make_payload(activity, **extra_fields):
-    event = extract_intent(activity)
-    if extra_fields:
-        return event.model_copy(update=extra_fields)
-    return event
-
-
 class TestCaseUseCases:
     """Tests for update_case handler."""
 
-    def test_update_case_applies_scalar_updates(self, monkeypatch, caplog):
+    def test_update_case_applies_scalar_updates(
+        self, monkeypatch, caplog, make_payload
+    ):
         """update_case applies name/summary/content updates from a full object."""
         dl = TinyDbDataLayer(db_path=None)
         monkeypatch.setattr(
@@ -60,7 +54,7 @@ class TestCaseUseCases:
             actor=owner_id,
             object=updated_case,
         )
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         def _mock_rehydrate_applies(obj, **kwargs):
             if obj == case.as_id:
@@ -80,7 +74,9 @@ class TestCaseUseCases:
         assert stored.name == "Updated Name"
         assert stored.content == "New content"
 
-    def test_update_case_rejects_non_owner(self, monkeypatch, caplog):
+    def test_update_case_rejects_non_owner(
+        self, monkeypatch, caplog, make_payload
+    ):
         """update_case logs a warning and skips if actor is not the case owner."""
         dl = TinyDbDataLayer(db_path=None)
         monkeypatch.setattr(
@@ -106,7 +102,7 @@ class TestCaseUseCases:
             actor=non_owner_id,
             object=updated_case,
         )
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         with caplog.at_level(logging.WARNING):
             UpdateCaseReceivedUseCase(dl, event).execute()
@@ -116,7 +112,7 @@ class TestCaseUseCases:
         assert stored.name == "Original Name"
         assert any("not the owner" in r.message for r in caplog.records)
 
-    def test_update_case_idempotent(self, monkeypatch):
+    def test_update_case_idempotent(self, monkeypatch, make_payload):
         """update_case with same data produces the same result (last-write-wins)."""
         dl = TinyDbDataLayer(db_path=None)
         monkeypatch.setattr(
@@ -141,7 +137,7 @@ class TestCaseUseCases:
             actor=owner_id,
             object=updated_case,
         )
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         def _mock_rehydrate_idempotent(obj, **kwargs):
             if obj == case.as_id:
@@ -161,7 +157,7 @@ class TestCaseUseCases:
         assert stored.name == "Updated"
 
     def test_update_case_warns_when_participant_has_not_accepted_embargo(
-        self, monkeypatch, caplog
+        self, monkeypatch, caplog, make_payload
     ):
         """update_case logs WARNING per CM-10-004 when a participant has not accepted the active embargo."""
         dl = TinyDbDataLayer(db_path=None)
@@ -198,7 +194,7 @@ class TestCaseUseCases:
             attributed_to=owner_id,
         )
         activity = UpdateCaseActivity(actor=owner_id, object=updated_case)
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         with caplog.at_level(logging.WARNING):
             UpdateCaseReceivedUseCase(dl, event).execute()
@@ -209,7 +205,7 @@ class TestCaseUseCases:
         )
 
     def test_update_case_no_warning_when_all_participants_accepted_embargo(
-        self, monkeypatch, caplog
+        self, monkeypatch, caplog, make_payload
     ):
         """update_case does NOT warn when all participants have accepted the active embargo (CM-10-004)."""
         dl = TinyDbDataLayer(db_path=None)
@@ -246,7 +242,7 @@ class TestCaseUseCases:
             attributed_to=owner_id,
         )
         activity = UpdateCaseActivity(actor=owner_id, object=updated_case)
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         with caplog.at_level(logging.WARNING):
             UpdateCaseReceivedUseCase(dl, event).execute()
@@ -254,7 +250,7 @@ class TestCaseUseCases:
         assert not any("has not accepted" in r.message for r in caplog.records)
 
     def test_update_case_no_warning_when_no_active_embargo(
-        self, monkeypatch, caplog
+        self, monkeypatch, caplog, make_payload
     ):
         """update_case does NOT warn when there is no active embargo (CM-10-004)."""
         dl = TinyDbDataLayer(db_path=None)
@@ -289,7 +285,7 @@ class TestCaseUseCases:
             attributed_to=owner_id,
         )
         activity = UpdateCaseActivity(actor=owner_id, object=updated_case)
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         with caplog.at_level(logging.WARNING):
             UpdateCaseReceivedUseCase(dl, event).execute()

--- a/test/core/use_cases/test_embargo_use_cases.py
+++ b/test/core/use_cases/test_embargo_use_cases.py
@@ -26,19 +26,12 @@ from vultron.core.use_cases.embargo import (
 )
 
 
-def _make_payload(activity, **extra_fields):
-    from vultron.wire.as2.extractor import extract_intent
-
-    event = extract_intent(activity)
-    if extra_fields:
-        return event.model_copy(update=extra_fields)
-    return event
-
-
 class TestEmbargoUseCases:
     """Tests for embargo management handlers."""
 
-    def test_create_embargo_event_stores_event(self, monkeypatch):
+    def test_create_embargo_event_stores_event(
+        self, monkeypatch, make_payload
+    ):
         """create_embargo_event persists the EmbargoEvent to the DataLayer."""
         from vultron.adapters.driven.datalayer_tinydb import TinyDbDataLayer
         from vultron.wire.as2.vocab.base.objects.activities.transitive import (
@@ -65,14 +58,14 @@ class TestEmbargoUseCases:
             context=case,
         )
 
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         CreateEmbargoEventReceivedUseCase(dl, event).execute()
 
         stored = dl.get(embargo.as_type.value, embargo.as_id)
         assert stored is not None
 
-    def test_create_embargo_event_idempotent(self, monkeypatch):
+    def test_create_embargo_event_idempotent(self, monkeypatch, make_payload):
         """create_embargo_event skips storing a duplicate EmbargoEvent."""
         from vultron.adapters.driven.datalayer_tinydb import TinyDbDataLayer
         from vultron.wire.as2.vocab.base.objects.activities.transitive import (
@@ -98,7 +91,7 @@ class TestEmbargoUseCases:
             object=embargo,
             context=case,
         )
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         CreateEmbargoEventReceivedUseCase(dl, event).execute()
         CreateEmbargoEventReceivedUseCase(
@@ -108,7 +101,9 @@ class TestEmbargoUseCases:
         stored = dl.get(embargo.as_type.value, embargo.as_id)
         assert stored is not None
 
-    def test_add_embargo_event_to_case_activates_embargo(self, monkeypatch):
+    def test_add_embargo_event_to_case_activates_embargo(
+        self, monkeypatch, make_payload
+    ):
         """add_embargo_event_to_case sets the active embargo on the case."""
         from vultron.adapters.driven.datalayer_tinydb import TinyDbDataLayer
         from vultron.wire.as2.vocab.activities.embargo import (
@@ -142,7 +137,7 @@ class TestEmbargoUseCases:
             object=embargo,
             target=case,
         )
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         AddEmbargoEventToCaseReceivedUseCase(dl, event).execute()
 
@@ -150,7 +145,9 @@ class TestEmbargoUseCases:
         assert case.active_embargo is not None
         assert case.current_status.em_state == EM.ACTIVE
 
-    def test_invite_to_embargo_on_case_stores_proposal(self, monkeypatch):
+    def test_invite_to_embargo_on_case_stores_proposal(
+        self, monkeypatch, make_payload
+    ):
         """invite_to_embargo_on_case persists the EmProposeEmbargoActivity activity."""
         from vultron.adapters.driven.datalayer_tinydb import TinyDbDataLayer
         from vultron.wire.as2.vocab.activities.embargo import (
@@ -171,7 +168,7 @@ class TestEmbargoUseCases:
             context="https://example.org/cases/case_em2",
         )
 
-        event = _make_payload(proposal)
+        event = make_payload(proposal)
 
         InviteToEmbargoOnCaseReceivedUseCase(dl, event).execute()
 
@@ -179,7 +176,7 @@ class TestEmbargoUseCases:
         assert stored is not None
 
     def test_accept_invite_to_embargo_on_case_activates_embargo(
-        self, monkeypatch
+        self, monkeypatch, make_payload
     ):
         """accept_invite_to_embargo_on_case activates the embargo on the case."""
         from vultron.adapters.driven.datalayer_tinydb import TinyDbDataLayer
@@ -223,7 +220,7 @@ class TestEmbargoUseCases:
             object=proposal,
             context=case,
         )
-        event = _make_payload(accept)
+        event = make_payload(accept)
 
         AcceptInviteToEmbargoOnCaseReceivedUseCase(dl, event).execute()
 
@@ -232,7 +229,7 @@ class TestEmbargoUseCases:
         assert case.current_status.em_state == EM.ACTIVE
 
     def test_accept_invite_to_embargo_records_embargo_on_participant(
-        self, monkeypatch
+        self, monkeypatch, make_payload
     ):
         """accept_invite_to_embargo_on_case records embargo ID in participant.accepted_embargo_ids (CM-10-002, CM-10-003)."""
         from vultron.adapters.driven.datalayer_tinydb import TinyDbDataLayer
@@ -285,7 +282,7 @@ class TestEmbargoUseCases:
             object=proposal,
             context=case,
         )
-        event = _make_payload(accept)
+        event = make_payload(accept)
 
         AcceptInviteToEmbargoOnCaseReceivedUseCase(dl, event).execute()
 
@@ -293,7 +290,9 @@ class TestEmbargoUseCases:
         assert updated_participant is not None
         assert embargo.as_id in updated_participant.accepted_embargo_ids
 
-    def test_accept_invite_to_embargo_records_case_event(self, monkeypatch):
+    def test_accept_invite_to_embargo_records_case_event(
+        self, monkeypatch, make_payload
+    ):
         """accept_invite_to_embargo_on_case appends a trusted-timestamp event to case.events (CM-02-009)."""
         from vultron.adapters.driven.datalayer_tinydb import TinyDbDataLayer
         from vultron.wire.as2.vocab.activities.embargo import (
@@ -334,7 +333,7 @@ class TestEmbargoUseCases:
             object=proposal,
             context=case,
         )
-        event = _make_payload(accept)
+        event = make_payload(accept)
 
         assert len(case.events) == 0
 
@@ -345,7 +344,9 @@ class TestEmbargoUseCases:
         event_types = [e.event_type for e in case.events]
         assert "embargo_accepted" in event_types
 
-    def test_reject_invite_to_embargo_on_case_logs_rejection(self):
+    def test_reject_invite_to_embargo_on_case_logs_rejection(
+        self, make_payload
+    ):
         """reject_invite_to_embargo_on_case logs without raising."""
         from vultron.wire.as2.vocab.activities.embargo import (
             EmProposeEmbargoActivity,
@@ -369,14 +370,16 @@ class TestEmbargoUseCases:
             context="https://example.org/cases/case_em4",
         )
 
-        event = _make_payload(reject)
+        event = make_payload(reject)
 
         result = RejectInviteToEmbargoOnCaseReceivedUseCase(
             MagicMock(), event
         ).execute()
         assert result is None
 
-    def test_remove_embargo_from_proposed_clears_proposed_list(self):
+    def test_remove_embargo_from_proposed_clears_proposed_list(
+        self, make_payload
+    ):
         """remove_embargo_event removes embargo from proposed_embargoes."""
         from vultron.adapters.driven.datalayer_tinydb import TinyDbDataLayer
         from vultron.wire.as2.vocab.activities.embargo import (
@@ -405,7 +408,7 @@ class TestEmbargoUseCases:
             object=embargo,
             origin=case,
         )
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         RemoveEmbargoEventFromCaseReceivedUseCase(dl, event).execute()
 
@@ -415,7 +418,9 @@ class TestEmbargoUseCases:
             for e in updated.proposed_embargoes
         ]
 
-    def test_remove_active_embargo_proposed_state_transitions_to_none(self):
+    def test_remove_active_embargo_proposed_state_transitions_to_none(
+        self, make_payload
+    ):
         """remove_embargo_event uses REJECT machine trigger when EM is PROPOSED."""
         from vultron.adapters.driven.datalayer_tinydb import TinyDbDataLayer
         from vultron.wire.as2.vocab.activities.embargo import (
@@ -444,7 +449,7 @@ class TestEmbargoUseCases:
             object=embargo,
             origin=case,
         )
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         RemoveEmbargoEventFromCaseReceivedUseCase(dl, event).execute()
 
@@ -452,7 +457,9 @@ class TestEmbargoUseCases:
         assert updated.active_embargo is None
         assert updated.current_status.em_state == EM.NONE
 
-    def test_remove_active_embargo_active_state_admin_override(self, caplog):
+    def test_remove_active_embargo_active_state_admin_override(
+        self, caplog, make_payload
+    ):
         """remove_embargo_event logs WARNING when EM state is ACTIVE (admin override)."""
         from vultron.adapters.driven.datalayer_tinydb import TinyDbDataLayer
         from vultron.wire.as2.vocab.activities.embargo import (
@@ -481,7 +488,7 @@ class TestEmbargoUseCases:
             object=embargo,
             origin=case,
         )
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         with caplog.at_level(logging.WARNING):
             RemoveEmbargoEventFromCaseReceivedUseCase(dl, event).execute()

--- a/test/core/use_cases/test_note_use_cases.py
+++ b/test/core/use_cases/test_note_use_cases.py
@@ -18,7 +18,6 @@ from vultron.core.use_cases.note import (
     CreateNoteReceivedUseCase,
     RemoveNoteFromCaseReceivedUseCase,
 )
-from vultron.wire.as2.extractor import extract_intent
 from vultron.wire.as2.vocab.activities.case import AddNoteToCaseActivity
 from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Create,
@@ -28,17 +27,10 @@ from vultron.wire.as2.vocab.base.objects.object_types import as_Note
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
 
 
-def _make_payload(activity, **extra_fields):
-    event = extract_intent(activity)
-    if extra_fields:
-        return event.model_copy(update=extra_fields)
-    return event
-
-
 class TestNoteUseCases:
     """Tests for note management handlers."""
 
-    def test_create_note_stores_note(self, monkeypatch):
+    def test_create_note_stores_note(self, monkeypatch, make_payload):
         """create_note persists the Note to the DataLayer."""
         dl = TinyDbDataLayer(db_path=None)
 
@@ -51,14 +43,14 @@ class TestNoteUseCases:
             object=note,
         )
 
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         CreateNoteReceivedUseCase(dl, event).execute()
 
         stored = dl.get(note.as_type.value, note.as_id)
         assert stored is not None
 
-    def test_create_note_idempotent(self, monkeypatch):
+    def test_create_note_idempotent(self, monkeypatch, make_payload):
         """create_note skips storing a duplicate Note."""
         dl = TinyDbDataLayer(db_path=None)
 
@@ -70,7 +62,7 @@ class TestNoteUseCases:
             actor="https://example.org/users/finder",
             object=note,
         )
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         dl.create(note)
         CreateNoteReceivedUseCase(dl, event).execute()
@@ -78,7 +70,7 @@ class TestNoteUseCases:
         stored = dl.get(note.as_type.value, note.as_id)
         assert stored is not None
 
-    def test_add_note_to_case_appends_note(self, monkeypatch):
+    def test_add_note_to_case_appends_note(self, monkeypatch, make_payload):
         """add_note_to_case appends note ID to case.notes and persists."""
         dl = TinyDbDataLayer(db_path=None)
         monkeypatch.setattr(
@@ -102,14 +94,14 @@ class TestNoteUseCases:
             object=note,
             target=case,
         )
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         AddNoteToCaseReceivedUseCase(dl, event).execute()
 
         case = dl.read(case.as_id)
         assert note.as_id in case.notes
 
-    def test_add_note_to_case_idempotent(self, monkeypatch):
+    def test_add_note_to_case_idempotent(self, monkeypatch, make_payload):
         """add_note_to_case skips adding a note already in the case."""
         dl = TinyDbDataLayer(db_path=None)
         monkeypatch.setattr(
@@ -134,13 +126,15 @@ class TestNoteUseCases:
             object=note,
             target=case,
         )
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         AddNoteToCaseReceivedUseCase(dl, event).execute()
 
         assert case.notes.count(note.as_id) == 1
 
-    def test_remove_note_from_case_removes_note(self, monkeypatch):
+    def test_remove_note_from_case_removes_note(
+        self, monkeypatch, make_payload
+    ):
         """remove_note_from_case removes note ID from case.notes and persists."""
         dl = TinyDbDataLayer(db_path=None)
         monkeypatch.setattr(
@@ -165,14 +159,14 @@ class TestNoteUseCases:
             object=note,
             target=case,
         )
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         RemoveNoteFromCaseReceivedUseCase(dl, event).execute()
 
         case = dl.read(case.as_id)
         assert note.as_id not in case.notes
 
-    def test_remove_note_from_case_idempotent(self, monkeypatch):
+    def test_remove_note_from_case_idempotent(self, monkeypatch, make_payload):
         """remove_note_from_case is idempotent when note not in case."""
         dl = TinyDbDataLayer(db_path=None)
         monkeypatch.setattr(
@@ -196,7 +190,7 @@ class TestNoteUseCases:
             object=note,
             target=case,
         )
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         result = RemoveNoteFromCaseReceivedUseCase(dl, event).execute()
         assert result is None

--- a/test/core/use_cases/test_status_use_cases.py
+++ b/test/core/use_cases/test_status_use_cases.py
@@ -20,7 +20,6 @@ from vultron.core.use_cases.status import (
     CreateCaseStatusReceivedUseCase,
     CreateParticipantStatusReceivedUseCase,
 )
-from vultron.wire.as2.extractor import extract_intent
 from vultron.wire.as2.vocab.activities.case import (
     AddStatusToCaseActivity,
     CreateCaseStatusActivity,
@@ -37,17 +36,10 @@ from vultron.wire.as2.vocab.objects.case_status import (
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
 
 
-def _make_payload(activity, **extra_fields):
-    event = extract_intent(activity)
-    if extra_fields:
-        return event.model_copy(update=extra_fields)
-    return event
-
-
 class TestStatusUseCases:
     """Tests for case status and participant status handlers."""
 
-    def test_create_case_status_stores_status(self, monkeypatch):
+    def test_create_case_status_stores_status(self, monkeypatch, make_payload):
         """create_case_status persists the CaseStatus to the DataLayer."""
 
         dl = TinyDbDataLayer(db_path=None)
@@ -66,14 +58,14 @@ class TestStatusUseCases:
             context=case.as_id,
         )
 
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         CreateCaseStatusReceivedUseCase(dl, event).execute()
 
         stored = dl.get(status.as_type.value, status.as_id)
         assert stored is not None
 
-    def test_create_case_status_idempotent(self, monkeypatch):
+    def test_create_case_status_idempotent(self, monkeypatch, make_payload):
         """create_case_status skips storing a duplicate CaseStatus."""
         dl = TinyDbDataLayer(db_path=None)
 
@@ -92,14 +84,16 @@ class TestStatusUseCases:
             object=status,
             context=case.as_id,
         )
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         CreateCaseStatusReceivedUseCase(dl, event).execute()
 
         stored = dl.get(status.as_type.value, status.as_id)
         assert stored is not None
 
-    def test_add_case_status_to_case_appends_status(self, monkeypatch):
+    def test_add_case_status_to_case_appends_status(
+        self, monkeypatch, make_payload
+    ):
         """add_case_status_to_case appends status ID to case.case_statuses."""
         dl = TinyDbDataLayer(db_path=None)
         monkeypatch.setattr(
@@ -123,7 +117,7 @@ class TestStatusUseCases:
             object=status,
             target=case,
         )
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         AddCaseStatusToCaseReceivedUseCase(dl, event).execute()
 
@@ -133,7 +127,9 @@ class TestStatusUseCases:
         ]
         assert status.as_id in status_ids
 
-    def test_add_case_status_blocks_invalid_em_transition(self, monkeypatch):
+    def test_add_case_status_blocks_invalid_em_transition(
+        self, monkeypatch, make_payload
+    ):
         """Invalid EM transition is blocked; status is not appended."""
         dl = TinyDbDataLayer(db_path=None)
         monkeypatch.setattr(
@@ -168,7 +164,7 @@ class TestStatusUseCases:
             object=bad_status,
             target=case,
         )
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         AddCaseStatusToCaseReceivedUseCase(dl, event).execute()
 
@@ -181,7 +177,9 @@ class TestStatusUseCases:
             bad_status.as_id not in status_ids
         ), "Bad status should not have been appended"
 
-    def test_add_case_status_allows_valid_em_transition(self, monkeypatch):
+    def test_add_case_status_allows_valid_em_transition(
+        self, monkeypatch, make_payload
+    ):
         """Valid EM transition is permitted; status is appended."""
         dl = TinyDbDataLayer(db_path=None)
         monkeypatch.setattr(
@@ -214,7 +212,7 @@ class TestStatusUseCases:
             object=good_status,
             target=case,
         )
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         AddCaseStatusToCaseReceivedUseCase(dl, event).execute()
 
@@ -225,7 +223,9 @@ class TestStatusUseCases:
         ]
         assert good_status.as_id in status_ids
 
-    def test_create_participant_status_stores_status(self, monkeypatch):
+    def test_create_participant_status_stores_status(
+        self, monkeypatch, make_payload
+    ):
         """create_participant_status persists the ParticipantStatus."""
         dl = TinyDbDataLayer(db_path=None)
 
@@ -243,7 +243,7 @@ class TestStatusUseCases:
             context=case_ps1,
         )
 
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         CreateParticipantStatusReceivedUseCase(dl, event).execute()
 
@@ -251,7 +251,7 @@ class TestStatusUseCases:
         assert stored is not None
 
     def test_add_participant_status_to_participant_appends_status(
-        self, monkeypatch
+        self, monkeypatch, make_payload
     ):
         """add_participant_status_to_participant appends status to participant."""
         dl = TinyDbDataLayer(db_path=None)
@@ -282,7 +282,7 @@ class TestStatusUseCases:
             target=participant,
             context=case_ps2,
         )
-        event = _make_payload(activity)
+        event = make_payload(activity)
 
         AddParticipantStatusToParticipantReceivedUseCase(dl, event).execute()
 


### PR DESCRIPTION
This pull request updates the development workflow and centralizes test helpers to improve code quality and maintainability. The most important changes are the addition of flake8 linting to the commit workflow, the removal of duplicated test helper functions, and the documentation of these improvements in project planning and history files.

**Development workflow improvements:**

* Added flake8 linting to the required pre-commit steps alongside Black formatting for Python code. All relevant documentation (`.github/copilot-instructions.md`, `.github/skills/format-code/SKILL.md`, `AGENTS.md`, `CONTRIBUTING.md`) now instructs contributors to run both Black and flake8 before committing, and the rationale for this order is explained. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L20-R21) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L37-R40) [[3]](diffhunk://#diff-c8a3e0d5da5ff7b33e5b5d054a297b9462cd3b27a5022f8f43c5a5c2d9e4950aL11-R11) [[4]](diffhunk://#diff-c8a3e0d5da5ff7b33e5b5d054a297b9462cd3b27a5022f8f43c5a5c2d9e4950aL39-R43) [[5]](diffhunk://#diff-c8a3e0d5da5ff7b33e5b5d054a297b9462cd3b27a5022f8f43c5a5c2d9e4950aL58-R58) [[6]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L722-R739) [[7]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L40-R41)

**Test code maintenance:**

* Centralized the `_make_payload()` test helper by removing duplicated local definitions from five test files in `test/core/use_cases/` and updating all affected test methods to use the shared `make_payload` fixture from `test/core/use_cases/conftest.py`. [[1]](diffhunk://#diff-35e1e9b42a3e7bf925f2328f1ab562c0dfec1d8570063db0ab1467a125ee96f3L33-R39) [[2]](diffhunk://#diff-35e1e9b42a3e7bf925f2328f1ab562c0dfec1d8570063db0ab1467a125ee96f3L62-R62) [[3]](diffhunk://#diff-35e1e9b42a3e7bf925f2328f1ab562c0dfec1d8570063db0ab1467a125ee96f3L85-R78) [[4]](diffhunk://#diff-35e1e9b42a3e7bf925f2328f1ab562c0dfec1d8570063db0ab1467a125ee96f3L95-R88) [[5]](diffhunk://#diff-35e1e9b42a3e7bf925f2328f1ab562c0dfec1d8570063db0ab1467a125ee96f3L113-R115) [[6]](diffhunk://#diff-35e1e9b42a3e7bf925f2328f1ab562c0dfec1d8570063db0ab1467a125ee96f3L158-R161) [[7]](diffhunk://#diff-35e1e9b42a3e7bf925f2328f1ab562c0dfec1d8570063db0ab1467a125ee96f3L212-R207) [[8]](diffhunk://#diff-35e1e9b42a3e7bf925f2328f1ab562c0dfec1d8570063db0ab1467a125ee96f3L223-R220) [[9]](diffhunk://#diff-35e1e9b42a3e7bf925f2328f1ab562c0dfec1d8570063db0ab1467a125ee96f3L276-R275) [[10]](diffhunk://#diff-35e1e9b42a3e7bf925f2328f1ab562c0dfec1d8570063db0ab1467a125ee96f3L298-R304) [[11]](diffhunk://#diff-35e1e9b42a3e7bf925f2328f1ab562c0dfec1d8570063db0ab1467a125ee96f3L325-R324) [[12]](diffhunk://#diff-35e1e9b42a3e7bf925f2328f1ab562c0dfec1d8570063db0ab1467a125ee96f3L334-R333) [[13]](diffhunk://#diff-35e1e9b42a3e7bf925f2328f1ab562c0dfec1d8570063db0ab1467a125ee96f3L361-R368)

**Project planning and documentation:**

* Updated `plan/IMPLEMENTATION_PLAN.md` and `plan/IMPLEMENTATION_HISTORY.md` to mark TECHDEBT-36 (centralizing `_make_payload`) and TECHDEBT-38 (outbox_handler early return for missing actor) as complete, with details on the changes and test results. [[1]](diffhunk://#diff-43674ea8e26ce0ee1fa32ec136d97a358b22a8ea96e802b739fd70bdfbb2e2aaL3-R3) [[2]](diffhunk://#diff-43674ea8e26ce0ee1fa32ec136d97a358b22a8ea96e802b739fd70bdfbb2e2aaL734-R744) [[3]](diffhunk://#diff-43674ea8e26ce0ee1fa32ec136d97a358b22a8ea96e802b739fd70bdfbb2e2aaL768-R781) [[4]](diffhunk://#diff-61688cbed3169f2f61d7aaa61f51d19ba13bcd4a3f6709e30966d3669e7e9ea2R2740-R2777)

**Bugfix documentation:**

* Clarified the process for updating implementation notes and history after bugfixes, specifying which files to update and what information to include.

These changes together enforce stricter code quality standards, reduce code duplication in tests, and improve project documentation and contributor guidance.