### PR TITLE
DataLayer boundary refactor and architectural cleanup

### DIFF
--- a/notes/datalayer-refactor.md
+++ b/notes/datalayer-refactor.md
@@ -1,0 +1,159 @@
+# DataLayer Boundary Refactor (TECHDEBT-32)
+
+## Purpose
+
+This note documents the findings of the TECHDEBT-32 audit of the
+`core`/`DataLayer` boundary. It captures layer violations, proposes the
+minimal refactoring needed to fix them, and records decisions about
+`Record`/`StorableRecord` and the vocabulary registry.
+
+---
+
+## Layer Rules (Recap)
+
+| Layer | Module path | Allowed imports |
+|---|---|---|
+| Core | `vultron/core/` | Core only + shared neutral modules |
+| Wire | `vultron/wire/` | Core + wire internals |
+| Adapters | `vultron/adapters/` | All layers |
+
+---
+
+## 1. `object_to_record()` / `record_to_object()` Call Sites
+
+### Calls from adapter layer (acceptable)
+
+All of the following are in `vultron/adapters/driven/datalayer_tinydb.py`
+and `vultron/adapters/driven/db_record.py` — adapter code calling adapter
+utilities. No architectural issue.
+
+### Calls from core layer (**violation** — CS-05-001)
+
+Two core modules import `object_to_record` from the adapter:
+
+| File | Line | Call |
+|---|---|---|
+| `vultron/core/use_cases/triggers/embargo.py` | 26, 137, 217, 293 | `object_to_record(case)` passed to `dl.update()` |
+| `vultron/core/use_cases/triggers/_helpers.py` | 26, 118, 157 | `object_to_record(...)` passed to `dl.update()` |
+
+Both files use the pattern:
+
+```python
+from vultron.adapters.driven.db_record import object_to_record
+...
+dl.update(obj.as_id, object_to_record(obj))
+```
+
+**Fix**: The `DataLayer` Protocol already exposes `save(obj: BaseModel) -> None`,
+which performs the same operation internally (inside the adapter where
+`object_to_record` belongs). Replace all occurrences with:
+
+```python
+dl.save(obj)
+```
+
+This eliminates all adapter imports from core.
+
+---
+
+## 2. `find_in_vocabulary()` Call Sites
+
+| File | Layer | Status |
+|---|---|---|
+| `vultron/wire/as2/vocab/base/registry.py` | Wire | Definition — OK |
+| `vultron/adapters/driven/db_record.py` | Adapter | Adapter imports wire — OK |
+| `vultron/wire/as2/rehydration.py` | Wire | Wire-to-wire — OK |
+| `vultron/adapters/driving/fastapi/routers/actors.py` | Adapter | Adapter imports wire — OK |
+| `vultron/adapters/driving/fastapi/helpers.py` | Adapter | Adapter imports wire — OK |
+
+**No core violations** for `find_in_vocabulary`.
+
+---
+
+## 3. Core Branching on DataLayer Return Types
+
+No evidence of core code doing `isinstance(result, Record)` or
+`isinstance(result, Document)`. The one `isinstance` check involving
+`StorableRecord` is in `TinyDbDataLayer.create()` — adapter code, acceptable.
+
+---
+
+## 4. `Record` / `StorableRecord` Architecture
+
+| Class | Location | Status |
+|---|---|---|
+| `StorableRecord` | `vultron/core/ports/datalayer.py` | Core port — correct |
+| `Record` | `vultron/adapters/driven/db_record.py` | Adapter subclass — correct |
+
+`StorableRecord` defines the minimal 3-field contract (`id_`, `type_`,
+`data_`). `Record` extends it with `from_obj()` / `to_obj()` adapter
+helpers. The hierarchy is sound; no changes needed to these classes.
+
+**Canonical save pattern for core code**:
+
+| Pattern | Where used | Status |
+|---|---|---|
+| `dl.update(id, object_to_record(obj))` | `triggers/embargo.py`, `triggers/_helpers.py` | **Violation** — imports adapter |
+| `save_to_datalayer(dl, obj)` | BT `case/nodes.py`, `report/nodes.py` | Works, but redundant helper |
+| `dl.save(obj)` | `use_cases/embargo.py`, `use_cases/case.py`, etc. | **Correct** — use this |
+
+**Recommendation**: Standardise on `dl.save(obj)` across all core code.
+Remove `save_to_datalayer()` from `vultron/core/behaviors/helpers.py` once
+all callers are migrated.
+
+---
+
+## 5. Vocabulary Registry Entanglement
+
+`find_in_vocabulary` (wire) is used by the driven adapter (`db_record.py`)
+to reconstitute domain objects from stored records. This is an intentional
+design: the adapter needs the wire vocabulary to deserialise stored records.
+
+`vultron/wire/as2/rehydration.py` uses `find_in_vocabulary` for wire-to-wire
+type promotion — acceptable.
+
+The one concern is `rehydration.py` also importing `get_datalayer` from the
+TinyDB adapter as a fallback:
+
+```python
+from vultron.adapters.driven.datalayer_tinydb import get_datalayer
+```
+
+This is a **wire-imports-adapter violation** (CS-05-001). It exists only
+for backward compatibility on code paths where no `DataLayer` is in scope.
+
+**Fix proposal (TECHDEBT-32c — separate task)**: Remove the fallback; make
+`dl` a required parameter in `rehydrate()`, or inject a factory via a
+neutral port. All current callers in the production path already pass `dl`
+explicitly; the fallback serves only old test paths.
+
+---
+
+## 6. Implementation Tasks
+
+### TECHDEBT-32b — Fix core adapter imports (implemented in same commit)
+
+- Remove `from vultron.adapters.driven.db_record import object_to_record`
+  from `triggers/embargo.py` and `triggers/_helpers.py`.
+- Replace all `dl.update(obj.as_id, object_to_record(obj))` calls with
+  `dl.save(obj)`.
+- Replace `save_to_datalayer(self.datalayer, obj)` calls in BT nodes with
+  `self.datalayer.save(obj)`.
+- Delete `save_to_datalayer()` from `vultron/core/behaviors/helpers.py`.
+
+### TECHDEBT-32c — Fix wire/rehydration.py adapter import (future task)
+
+Remove `from vultron.adapters.driven.datalayer_tinydb import get_datalayer`
+from `vultron/wire/as2/rehydration.py`. Make `dl` a required parameter or
+provide a core-level factory port.
+
+---
+
+## References
+
+- `specs/code-style.md` CS-05-001 (no core imports from adapter)
+- `docs/adr/0009-hexagonal-architecture.md`
+- `docs/adr/0012-per-actor-datalayer-isolation.md`
+- `vultron/core/ports/datalayer.py` — `DataLayer` Protocol and
+  `StorableRecord`
+- `plan/IMPLEMENTATION_PLAN.md` — TECHDEBT-32, TECHDEBT-32b, TECHDEBT-32c

--- a/plan/IMPLEMENTATION_HISTORY.md
+++ b/plan/IMPLEMENTATION_HISTORY.md
@@ -2820,3 +2820,38 @@ is now the canonical single pattern for persisting domain objects from core code
 ### Test results
 
 985 passed, 5581 subtests passed.
+
+---
+
+## TECHDEBT-32c — Remove get_datalayer fallback from wire/as2/rehydration.py
+
+**Completed**: 2026-03-24
+
+### What was done
+
+Removed the adapter-layer import (`from vultron.adapters.driven.datalayer_tinydb
+import get_datalayer`) from `vultron/wire/as2/rehydration.py`. The wire layer
+must not import from a concrete adapter implementation.
+
+- Made `dl: DataLayer` a required positional parameter in `rehydrate()`;
+  removed the `None` default and the fallback `get_datalayer()` call.
+- Updated three adapter-layer callers to pass `dl` explicitly:
+  `vultron/adapters/driving/cli.py`,
+  `vultron/adapters/driving/fastapi/routers/datalayer.py`,
+  `vultron/adapters/driving/fastapi/inbox_handler.py`.
+- Removed 25 legacy `monkeypatch.setattr(rehydration.get_datalayer, ...)` stubs
+  from 6 test files under `test/core/use_cases/` — these were defensive patches
+  for a fallback that no longer exists.
+- Updated test mock in `test/api/v2/backend/test_inbox_handler.py` to accept
+  `dl` keyword argument.
+
+### Lessons learned
+
+The "all production callers already pass `dl` explicitly" note in the plan was
+incorrect — three adapter-layer callers were not passing `dl`. The fix required
+updating callers in addition to removing the fallback. Always verify caller
+state before relying on plan notes about external-facing APIs.
+
+### Test results
+
+985 passed, 5581 subtests passed.

--- a/plan/IMPLEMENTATION_HISTORY.md
+++ b/plan/IMPLEMENTATION_HISTORY.md
@@ -2775,3 +2775,48 @@ and checked off. No code changes needed.
 ### Test results
 
 985 passed, 5581 subtests passed.
+
+---
+
+## TECHDEBT-32 / TECHDEBT-32b — DataLayer boundary audit and core adapter import removal (COMPLETE 2026-03-24)
+
+### What was done
+
+**TECHDEBT-32 (research)**: Audited the `core`/`DataLayer` boundary for layer
+violations. Findings written to `notes/datalayer-refactor.md`.
+
+Key findings:
+
+1. **Core violations** (CS-05-001): `vultron/core/use_cases/triggers/embargo.py`
+   and `vultron/core/use_cases/triggers/_helpers.py` both imported
+   `object_to_record` from `vultron.adapters.driven.db_record`. 5 call sites
+   used `dl.update(obj.as_id, object_to_record(obj))`.
+2. **Redundant core helper**: `save_to_datalayer()` in
+   `vultron/core/behaviors/helpers.py` duplicated `dl.save()` using
+   `StorableRecord`; used in BT nodes (`case/nodes.py`, `report/nodes.py`).
+3. **Wire violation** (separate task TECHDEBT-32c): `rehydration.py` imports
+   `get_datalayer` from the TinyDB adapter as a fallback.
+4. `Record`/`StorableRecord` hierarchy is architecturally sound — no changes
+   needed. `find_in_vocabulary` usages are all in adapter or wire layers.
+
+**TECHDEBT-32b (code fix)**: Standardised on `dl.save(obj)` across all core code:
+
+- Removed `object_to_record` import from `triggers/embargo.py` and
+  `triggers/_helpers.py`. Replaced 5 `dl.update(..., object_to_record(...))` calls
+  with `dl.save(obj)`.
+- Replaced 4 `save_to_datalayer(self.datalayer, obj)` calls in BT nodes
+  (`case/nodes.py`, `report/nodes.py`) with `self.datalayer.save(obj)`.
+- Deleted `save_to_datalayer()` function from `helpers.py`.
+- Removed now-unused `BaseModel` import from `helpers.py`.
+- Added TECHDEBT-32c to plan for remaining wire-imports-adapter violation in
+  `rehydration.py`.
+
+### Lessons learned
+
+The three `dl.save()` patterns (`object_to_record` + `dl.update`, `save_to_datalayer`,
+and direct `dl.save`) all existed simultaneously, causing confusion. `dl.save()`
+is now the canonical single pattern for persisting domain objects from core code.
+
+### Test results
+
+985 passed, 5581 subtests passed.

--- a/plan/IMPLEMENTATION_NOTES.md
+++ b/plan/IMPLEMENTATION_NOTES.md
@@ -47,3 +47,29 @@ OPP-05 (consolidate duplicate participant RM helpers) is explicitly NOT done
 This is captured as TECHDEBT-39 in `plan/IMPLEMENTATION_PLAN.md`.
 
 ---
+
+---
+
+## `dl.save()` is the canonical persistence pattern for core code
+
+After TECHDEBT-32b, `dl.save(obj)` is the **sole** approved pattern for
+persisting domain objects from core code:
+
+```python
+# Correct
+dl.save(case)
+dl.save(participant)
+dl.save(actor_obj)
+
+# Now removed from codebase (do not reintroduce):
+dl.update(obj.as_id, object_to_record(obj))   # core importing adapter
+save_to_datalayer(dl, obj)                      # redundant core helper
+```
+
+The `save_to_datalayer()` helper has been deleted. The `object_to_record`
+import from adapter is banned in core. Future core/BT code must use
+`dl.save(obj)` exclusively.
+
+TECHDEBT-32c remains open: `vultron/wire/as2/rehydration.py` imports
+`get_datalayer` from the TinyDB adapter as a fallback — this is a
+wire-imports-adapter violation to be fixed separately.

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -1,6 +1,6 @@
 # Vultron API v2 Implementation Plan
 
-**Last Updated**: 2026-03-24 (refresh #46: TECHDEBT-36 and TECHDEBT-38 complete)
+**Last Updated**: 2026-03-24 (refresh #47: TECHDEBT-32, TECHDEBT-32b complete)
 
 ## Overview
 
@@ -13,8 +13,7 @@ it does not override `plan/PRIORITIES.md` when the two differ.
 
 ### Current Status Summary
 
-**Test suite**: 984 passed, 5581 subtests (branch: `transitions-part-2`,
-2026-03-23).
+**Test suite**: 985 passed, 5581 subtests (2026-03-24).
 
 **All 38 handlers implemented** (including `unknown`) — see `IMPLEMENTATION_HISTORY.md`.
 **Trigger endpoints**: all 9 complete (P30-1–P30-6). **Demo scripts**: 12 scripts,
@@ -36,13 +35,16 @@ validity guards applied; OPP-06 spec captured in `specs/`.
 
 **Active phases**: **PRIORITY-80** (technical debt cleanup) and
 **PRIORITY-100** (actor independence — pre-requisites PREPX-1/2/3 and P90
-all complete). TECHDEBT-16 through TECHDEBT-33 complete (TECHDEBT-32 and
-34–37 still open); VCR-A batch (8/8 tasks) complete. VCR-B batch complete.
+all complete). TECHDEBT-16 through TECHDEBT-33 complete; TECHDEBT-32b complete
+(34–37 still open); VCR-A batch (8/8 tasks) complete. VCR-B batch complete.
 VCR-019a/b/c/e complete — state enums in `vultron/core/states/`;
 `vultron/case_states/` removed; errors merged into `vultron/errors.py`.
 OX-1.4 complete. BUG-001 (outbox_handler missing return) documented in
 `plan/BUGS.md`; TECHDEBT-38 added to fix it. TECHDEBT-39 added for OPP-05
-participant RM helper consolidation.
+participant RM helper consolidation. TECHDEBT-32/32b complete: all
+`object_to_record` / `save_to_datalayer` usages in core removed; `dl.save()`
+is now the sole save pattern in core. TECHDEBT-32c added (wire/rehydration
+adapter import).
 
 ---
 
@@ -628,7 +630,7 @@ should go away" (2026-03-20); `notes/codebase-structure.md`
 core to datalayer port and adapter boundaries" (2026-03-20);
 `notes/domain-model-separation.md`
 
-- [ ] **TECHDEBT-32**: Audit the core/DataLayer boundary to understand the
+- [x] **TECHDEBT-32**: Audit the core/DataLayer boundary to understand the
   current coupling. Produce a written analysis (add to
   `notes/domain-model-separation.md` or a new `notes/datalayer-refactor.md`)
   that:
@@ -645,6 +647,40 @@ core to datalayer port and adapter boundaries" (2026-03-20);
   Done when the analysis document is committed and a follow-up implementation
   task (TECHDEBT-32b) is added to this plan based on the findings.
   **No code changes in this task — research and planning only.**
+
+  **COMPLETE**: Analysis written to `notes/datalayer-refactor.md`. Found 2
+  core-imports-adapter violations (`triggers/embargo.py`,
+  `triggers/_helpers.py` importing `object_to_record` from adapter) and 1
+  wire-imports-adapter violation (`rehydration.py` importing `get_datalayer`
+  from TinyDB adapter). `Record`/`StorableRecord` hierarchy is sound.
+  TECHDEBT-32b (code fix) implemented in same commit; TECHDEBT-32c (wire fix)
+  added as follow-up. 985 tests pass.
+
+- [x] **TECHDEBT-32b**: Remove `object_to_record` adapter imports from core
+  trigger modules and replace all three save patterns with `dl.save(obj)`:
+  1. Remove `from vultron.adapters.driven.db_record import object_to_record`
+     from `triggers/embargo.py` and `triggers/_helpers.py`. Replace 5
+     `dl.update(obj.as_id, object_to_record(obj))` calls with `dl.save(obj)`.
+  2. Replace 4 `save_to_datalayer(self.datalayer, obj)` calls in BT nodes
+     (`case/nodes.py`, `report/nodes.py`) with `self.datalayer.save(obj)`.
+  3. Delete `save_to_datalayer()` helper from
+     `vultron/core/behaviors/helpers.py` (no callers remain).
+
+  Done when no core module imports from `vultron.adapters.driven.db_record`,
+  all `object_to_record` and `save_to_datalayer` usages in core are gone,
+  and 985 tests pass.
+
+  **COMPLETE**: All 5 `object_to_record` sites and 4 `save_to_datalayer`
+  sites replaced with `dl.save()`. `save_to_datalayer` function deleted.
+  985 tests pass.
+
+- [ ] **TECHDEBT-32c**: Remove `from vultron.adapters.driven.datalayer_tinydb
+  import get_datalayer` from `vultron/wire/as2/rehydration.py`. The wire
+  layer must not import directly from the TinyDB adapter. Make `dl` a
+  required parameter in `rehydrate()`, or inject a core-level factory port.
+  All production callers already pass `dl` explicitly; the fallback exists
+  only for legacy test paths. Done when no wire module imports from
+  `vultron.adapters.driven.*` and 985 tests pass.
 
 ---
 

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -945,9 +945,8 @@ They are larger structural changes; plan as a single coordinated PR.
   `roles.py` (CVDRoles, add_role). Updated `__init__.py` and all 59 callers.
   Deleted original `states.py` files. No shims. 982 tests pass.
 
-- [ ] **VCR-019d** (future): Consider using the `transitions` module to model
-  RM/EM/CS state machines once enum consolidation is complete. Defer until after
-  VCR-019a/b/c are done.
+- [x] **VCR-019d**: Consider using the `transitions` module to model
+  RM/EM/CS state machines once enum consolidation is complete.
 
 - [x] **VCR-019e**: Convert older non-StrEnum Enums to `StrEnum` where semantically
   appropriate (i.e., where string representation is the primary use). Apply

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -1,6 +1,6 @@
 # Vultron API v2 Implementation Plan
 
-**Last Updated**: 2026-03-24 (refresh #47: TECHDEBT-32, TECHDEBT-32b complete)
+**Last Updated**: 2026-03-24 (refresh #48: TECHDEBT-32c complete)
 
 ## Overview
 
@@ -43,8 +43,8 @@ OX-1.4 complete. BUG-001 (outbox_handler missing return) documented in
 `plan/BUGS.md`; TECHDEBT-38 added to fix it. TECHDEBT-39 added for OPP-05
 participant RM helper consolidation. TECHDEBT-32/32b complete: all
 `object_to_record` / `save_to_datalayer` usages in core removed; `dl.save()`
-is now the sole save pattern in core. TECHDEBT-32c added (wire/rehydration
-adapter import).
+is now the sole save pattern in core. TECHDEBT-32c complete: `get_datalayer`
+fallback removed from `wire/as2/rehydration.py`; `dl` is now required.
 
 ---
 
@@ -674,13 +674,19 @@ core to datalayer port and adapter boundaries" (2026-03-20);
   sites replaced with `dl.save()`. `save_to_datalayer` function deleted.
   985 tests pass.
 
-- [ ] **TECHDEBT-32c**: Remove `from vultron.adapters.driven.datalayer_tinydb
+- [x] **TECHDEBT-32c**: Remove `from vultron.adapters.driven.datalayer_tinydb
   import get_datalayer` from `vultron/wire/as2/rehydration.py`. The wire
   layer must not import directly from the TinyDB adapter. Make `dl` a
   required parameter in `rehydrate()`, or inject a core-level factory port.
   All production callers already pass `dl` explicitly; the fallback exists
   only for legacy test paths. Done when no wire module imports from
   `vultron.adapters.driven.*` and 985 tests pass.
+
+  **COMPLETE**: Removed `get_datalayer` import; made `dl: DataLayer` a
+  required positional parameter. Updated three callers (`cli.py`,
+  `fastapi/routers/datalayer.py`, `fastapi/inbox_handler.py`) to pass `dl`
+  explicitly. Removed 25 legacy `monkeypatch.setattr(rehydration.get_datalayer)`
+  stubs from 6 test files. 985 tests pass.
 
 ---
 

--- a/test/api/v2/backend/test_inbox_handler.py
+++ b/test/api/v2/backend/test_inbox_handler.py
@@ -68,7 +68,7 @@ def test_inbox_handler_retries_and_aborts_after_too_many_errors(monkeypatch):
     monkeypatch.setattr(
         ih, "get_actor_io", lambda actor_id, raise_on_missing=True: actor_io
     )
-    monkeypatch.setattr(ih, "rehydrate", lambda x: x)
+    monkeypatch.setattr(ih, "rehydrate", lambda x, dl=None: x)
 
     def always_raise(actor_id, obj, dl):
         raise RuntimeError("boom")

--- a/test/core/use_cases/test_actor_use_cases.py
+++ b/test/core/use_cases/test_actor_use_cases.py
@@ -125,11 +125,6 @@ class TestInviteActorUseCases:
         )
 
         dl = TinyDbDataLayer(db_path=None)
-        monkeypatch.setattr(
-            "vultron.wire.as2.rehydration.get_datalayer",
-            lambda **_: dl,
-        )
-
         invitee_id = "https://example.org/users/coordinator"
         invitee = as_Actor(id=invitee_id)
         case = VulnerabilityCase(
@@ -173,11 +168,6 @@ class TestInviteActorUseCases:
         )
 
         dl = TinyDbDataLayer(db_path=None)
-        monkeypatch.setattr(
-            "vultron.wire.as2.rehydration.get_datalayer",
-            lambda **_: dl,
-        )
-
         invitee_id = "https://example.org/users/coordinator"
         invitee = as_Actor(id=invitee_id)
         embargo = EmbargoEvent(
@@ -230,11 +220,6 @@ class TestInviteActorUseCases:
         )
 
         dl = TinyDbDataLayer(db_path=None)
-        monkeypatch.setattr(
-            "vultron.wire.as2.rehydration.get_datalayer",
-            lambda **_: dl,
-        )
-
         invitee_id = "https://example.org/users/coordinator"
         invitee = as_Actor(id=invitee_id)
         case = VulnerabilityCase(
@@ -440,11 +425,6 @@ class TestOwnershipTransferUseCases:
         )
 
         dl = TinyDbDataLayer(db_path=None)
-        monkeypatch.setattr(
-            "vultron.wire.as2.rehydration.get_datalayer",
-            lambda **_: dl,
-        )
-
         case = VulnerabilityCase(
             id="https://example.org/cases/case_ot2",
             name="OT Case 2",

--- a/test/core/use_cases/test_case_participant_use_cases.py
+++ b/test/core/use_cases/test_case_participant_use_cases.py
@@ -37,11 +37,6 @@ class TestCaseParticipantUseCases:
         )
 
         dl = TinyDbDataLayer(db_path=None)
-        monkeypatch.setattr(
-            "vultron.wire.as2.rehydration.get_datalayer",
-            lambda **_: dl,
-        )
-
         case = VulnerabilityCase(
             id="https://example.org/cases/case2",
             name="TEST-REMOVE",
@@ -130,10 +125,6 @@ class TestCaseParticipantUseCases:
         )
 
         dl = TinyDbDataLayer(db_path=None)
-        monkeypatch.setattr(
-            "vultron.wire.as2.rehydration.get_datalayer",
-            lambda **_: dl,
-        )
         actor_id = "https://example.org/users/coordinator"
         case = VulnerabilityCase(
             id="https://example.org/cases/caseAP1",
@@ -177,10 +168,6 @@ class TestCaseParticipantUseCases:
         )
 
         dl = TinyDbDataLayer(db_path=None)
-        monkeypatch.setattr(
-            "vultron.wire.as2.rehydration.get_datalayer",
-            lambda **_: dl,
-        )
         actor_id = "https://example.org/users/coordinator"
         case = VulnerabilityCase(
             id="https://example.org/cases/caseRM1",

--- a/test/core/use_cases/test_case_use_cases.py
+++ b/test/core/use_cases/test_case_use_cases.py
@@ -31,11 +31,6 @@ class TestCaseUseCases:
     ):
         """update_case applies name/summary/content updates from a full object."""
         dl = TinyDbDataLayer(db_path=None)
-        monkeypatch.setattr(
-            "vultron.wire.as2.rehydration.get_datalayer",
-            lambda **_: dl,
-        )
-
         owner_id = "https://example.org/users/owner"
         case = VulnerabilityCase(
             id="https://example.org/cases/uc1",
@@ -79,11 +74,6 @@ class TestCaseUseCases:
     ):
         """update_case logs a warning and skips if actor is not the case owner."""
         dl = TinyDbDataLayer(db_path=None)
-        monkeypatch.setattr(
-            "vultron.wire.as2.rehydration.get_datalayer",
-            lambda **_: dl,
-        )
-
         owner_id = "https://example.org/users/owner"
         non_owner_id = "https://example.org/users/other"
         case = VulnerabilityCase(
@@ -115,11 +105,6 @@ class TestCaseUseCases:
     def test_update_case_idempotent(self, monkeypatch, make_payload):
         """update_case with same data produces the same result (last-write-wins)."""
         dl = TinyDbDataLayer(db_path=None)
-        monkeypatch.setattr(
-            "vultron.wire.as2.rehydration.get_datalayer",
-            lambda **_: dl,
-        )
-
         owner_id = "https://example.org/users/owner"
         case = VulnerabilityCase(
             id="https://example.org/cases/uc3",
@@ -161,11 +146,6 @@ class TestCaseUseCases:
     ):
         """update_case logs WARNING per CM-10-004 when a participant has not accepted the active embargo."""
         dl = TinyDbDataLayer(db_path=None)
-        monkeypatch.setattr(
-            "vultron.wire.as2.rehydration.get_datalayer",
-            lambda **_: dl,
-        )
-
         owner_id = "https://example.org/users/owner"
         actor_id = "https://example.org/users/alice"
         embargo = EmbargoEvent(id="https://example.org/embargoes/em1")
@@ -209,11 +189,6 @@ class TestCaseUseCases:
     ):
         """update_case does NOT warn when all participants have accepted the active embargo (CM-10-004)."""
         dl = TinyDbDataLayer(db_path=None)
-        monkeypatch.setattr(
-            "vultron.wire.as2.rehydration.get_datalayer",
-            lambda **_: dl,
-        )
-
         owner_id = "https://example.org/users/owner"
         actor_id = "https://example.org/users/bob"
         embargo = EmbargoEvent(id="https://example.org/embargoes/em2")
@@ -254,11 +229,6 @@ class TestCaseUseCases:
     ):
         """update_case does NOT warn when there is no active embargo (CM-10-004)."""
         dl = TinyDbDataLayer(db_path=None)
-        monkeypatch.setattr(
-            "vultron.wire.as2.rehydration.get_datalayer",
-            lambda **_: dl,
-        )
-
         owner_id = "https://example.org/users/owner"
         actor_id = "https://example.org/users/carol"
 

--- a/test/core/use_cases/test_embargo_use_cases.py
+++ b/test/core/use_cases/test_embargo_use_cases.py
@@ -116,11 +116,6 @@ class TestEmbargoUseCases:
         from vultron.core.states.em import EM
 
         dl = TinyDbDataLayer(db_path=None)
-        monkeypatch.setattr(
-            "vultron.wire.as2.rehydration.get_datalayer",
-            lambda **_: dl,
-        )
-
         case = VulnerabilityCase(
             id="https://example.org/cases/case_em1",
             name="EM Test Case",
@@ -191,11 +186,6 @@ class TestEmbargoUseCases:
         from vultron.core.states.em import EM
 
         dl = TinyDbDataLayer(db_path=None)
-        monkeypatch.setattr(
-            "vultron.wire.as2.rehydration.get_datalayer",
-            lambda **_: dl,
-        )
-
         case = VulnerabilityCase(
             id="https://example.org/cases/case_em3",
             name="EM Accept Test",
@@ -246,11 +236,6 @@ class TestEmbargoUseCases:
         )
 
         dl = TinyDbDataLayer(db_path=None)
-        monkeypatch.setattr(
-            "vultron.wire.as2.rehydration.get_datalayer",
-            lambda **_: dl,
-        )
-
         coordinator_id = "https://example.org/users/coordinator"
         case = VulnerabilityCase(
             id="https://example.org/cases/case_em5",
@@ -305,11 +290,6 @@ class TestEmbargoUseCases:
         )
 
         dl = TinyDbDataLayer(db_path=None)
-        monkeypatch.setattr(
-            "vultron.wire.as2.rehydration.get_datalayer",
-            lambda **_: dl,
-        )
-
         case = VulnerabilityCase(
             id="https://example.org/cases/case_em6",
             name="EM Accept Event Test",

--- a/test/core/use_cases/test_note_use_cases.py
+++ b/test/core/use_cases/test_note_use_cases.py
@@ -73,11 +73,6 @@ class TestNoteUseCases:
     def test_add_note_to_case_appends_note(self, monkeypatch, make_payload):
         """add_note_to_case appends note ID to case.notes and persists."""
         dl = TinyDbDataLayer(db_path=None)
-        monkeypatch.setattr(
-            "vultron.wire.as2.rehydration.get_datalayer",
-            lambda **_: dl,
-        )
-
         case = VulnerabilityCase(
             id="https://example.org/cases/case_n1",
             name="Note Case",
@@ -104,11 +99,6 @@ class TestNoteUseCases:
     def test_add_note_to_case_idempotent(self, monkeypatch, make_payload):
         """add_note_to_case skips adding a note already in the case."""
         dl = TinyDbDataLayer(db_path=None)
-        monkeypatch.setattr(
-            "vultron.wire.as2.rehydration.get_datalayer",
-            lambda **_: dl,
-        )
-
         note = as_Note(
             id="https://example.org/notes/note4",
             content="A note",
@@ -137,11 +127,6 @@ class TestNoteUseCases:
     ):
         """remove_note_from_case removes note ID from case.notes and persists."""
         dl = TinyDbDataLayer(db_path=None)
-        monkeypatch.setattr(
-            "vultron.wire.as2.rehydration.get_datalayer",
-            lambda **_: dl,
-        )
-
         note = as_Note(
             id="https://example.org/notes/note5",
             content="A note",
@@ -169,11 +154,6 @@ class TestNoteUseCases:
     def test_remove_note_from_case_idempotent(self, monkeypatch, make_payload):
         """remove_note_from_case is idempotent when note not in case."""
         dl = TinyDbDataLayer(db_path=None)
-        monkeypatch.setattr(
-            "vultron.wire.as2.rehydration.get_datalayer",
-            lambda **_: dl,
-        )
-
         note = as_Note(
             id="https://example.org/notes/note6",
             content="A note",

--- a/test/core/use_cases/test_status_use_cases.py
+++ b/test/core/use_cases/test_status_use_cases.py
@@ -96,11 +96,6 @@ class TestStatusUseCases:
     ):
         """add_case_status_to_case appends status ID to case.case_statuses."""
         dl = TinyDbDataLayer(db_path=None)
-        monkeypatch.setattr(
-            "vultron.wire.as2.rehydration.get_datalayer",
-            lambda **_: dl,
-        )
-
         case = VulnerabilityCase(
             id="https://example.org/cases/case_cs3",
             name="Add Status Case",
@@ -132,11 +127,6 @@ class TestStatusUseCases:
     ):
         """Invalid EM transition is blocked; status is not appended."""
         dl = TinyDbDataLayer(db_path=None)
-        monkeypatch.setattr(
-            "vultron.wire.as2.rehydration.get_datalayer",
-            lambda **_: dl,
-        )
-
         case = VulnerabilityCase(
             id="https://example.org/cases/case_em_guard",
             name="EM Guard Test Case",
@@ -182,11 +172,6 @@ class TestStatusUseCases:
     ):
         """Valid EM transition is permitted; status is appended."""
         dl = TinyDbDataLayer(db_path=None)
-        monkeypatch.setattr(
-            "vultron.wire.as2.rehydration.get_datalayer",
-            lambda **_: dl,
-        )
-
         case = VulnerabilityCase(
             id="https://example.org/cases/case_em_valid",
             name="EM Valid Transition Case",
@@ -255,11 +240,6 @@ class TestStatusUseCases:
     ):
         """add_participant_status_to_participant appends status to participant."""
         dl = TinyDbDataLayer(db_path=None)
-        monkeypatch.setattr(
-            "vultron.wire.as2.rehydration.get_datalayer",
-            lambda **_: dl,
-        )
-
         participant = CaseParticipant(
             id="https://example.org/cases/case_ps2/participants/p2",
             context="https://example.org/cases/case_ps2",

--- a/vultron/adapters/driving/cli.py
+++ b/vultron/adapters/driving/cli.py
@@ -54,7 +54,7 @@ def deliver(actor_id: str, activity_json) -> None:
         click.echo(f"Parse error: {e}", err=True)
         sys.exit(1)
 
-    activity = rehydrate(activity)
+    activity = rehydrate(activity, dl=dl)
     handle_inbox_item(actor_id=actor_id, obj=activity, dl=dl)
     click.echo("Activity delivered.")
 

--- a/vultron/adapters/driving/fastapi/inbox_handler.py
+++ b/vultron/adapters/driving/fastapi/inbox_handler.py
@@ -126,7 +126,7 @@ async def inbox_handler(actor_id: str, dl: DataLayer) -> None:
     while actor_io.inbox.items:
         item = actor_io.inbox.items.pop(0)
 
-        item = rehydrate(item)
+        item = rehydrate(item, dl=dl)
 
         logger.debug("Rehydrated item from inbox: %s", item.as_type)
         if hasattr(item, "as_object"):

--- a/vultron/adapters/driving/fastapi/routers/datalayer.py
+++ b/vultron/adapters/driving/fastapi/routers/datalayer.py
@@ -197,7 +197,7 @@ def get_actor_outbox(
     # make a copy
     outbox = deepcopy(actor.outbox)
 
-    outbox.items = [rehydrate(item) for item in outbox.items]
+    outbox.items = [rehydrate(item, dl=datalayer) for item in outbox.items]
 
     return outbox
 

--- a/vultron/core/behaviors/case/nodes.py
+++ b/vultron/core/behaviors/case/nodes.py
@@ -42,7 +42,6 @@ from vultron.core.states.roles import CVDRoles
 from vultron.core.behaviors.helpers import (
     DataLayerAction,
     DataLayerCondition,
-    save_to_datalayer,
 )
 
 logger = logging.getLogger(__name__)
@@ -378,7 +377,7 @@ class CreateInitialVendorParticipant(DataLayerAction):
             }
             if participant.as_id not in existing_ids:
                 stored_case.case_participants.append(participant.as_id)
-                save_to_datalayer(self.datalayer, stored_case)
+                self.datalayer.save(stored_case)
                 self.logger.info(
                     f"{self.name}: Added VendorParticipant"
                     f" {participant.as_id} to case {stored_case.as_id}"
@@ -466,7 +465,7 @@ class RecordCaseCreationEvents(DataLayerAction):
                 f"{self.name}: Recorded case_created event on case {case_id}"
             )
 
-            save_to_datalayer(self.datalayer, case)
+            self.datalayer.save(case)
             return Status.SUCCESS
 
         except Exception as e:
@@ -521,7 +520,7 @@ class UpdateActorOutbox(DataLayerAction):
                 return Status.FAILURE
 
             actor_obj.outbox.items.append(activity_id)
-            save_to_datalayer(self.datalayer, actor_obj)
+            self.datalayer.save(actor_obj)
             self.logger.info(
                 f"{self.name}: Added activity {activity_id} to"
                 f" actor {self.actor_id} outbox"

--- a/vultron/core/behaviors/helpers.py
+++ b/vultron/core/behaviors/helpers.py
@@ -30,31 +30,10 @@ from typing import Any
 
 import py_trees
 from py_trees.common import Status
-from pydantic import BaseModel
 
 from vultron.core.ports.datalayer import DataLayer, StorableRecord
 
 logger = logging.getLogger(__name__)
-
-
-def save_to_datalayer(dl: DataLayer, obj: BaseModel) -> None:
-    """Persist an AS2-like Pydantic model to the DataLayer.
-
-    Constructs a ``StorableRecord`` from the object's ``as_id``,
-    ``as_type``, and serialised data, then calls ``dl.update()``.
-    This helper lets core BT nodes persist objects without importing
-    the adapter-layer ``Record`` / ``object_to_record`` utilities.
-
-    Args:
-        dl: The DataLayer instance to persist to.
-        obj: A Pydantic model with ``as_id`` and ``as_type`` attributes.
-    """
-    record = StorableRecord(
-        id_=getattr(obj, "as_id"),
-        type_=str(getattr(obj, "as_type", type(obj).__name__)),
-        data_=obj.model_dump(mode="json"),
-    )
-    dl.update(record.id_, record)
 
 
 class DataLayerCondition(py_trees.behaviour.Behaviour):

--- a/vultron/core/behaviors/report/nodes.py
+++ b/vultron/core/behaviors/report/nodes.py
@@ -37,7 +37,6 @@ from vultron.core.models.vultron_types import (
 from vultron.core.behaviors.helpers import (
     DataLayerAction,
     DataLayerCondition,
-    save_to_datalayer,
 )
 from vultron.core.states.rm import RM
 from vultron.core.use_cases._helpers import (
@@ -547,7 +546,7 @@ class UpdateActorOutbox(DataLayerAction):
             )
 
             # Persist updated actor
-            save_to_datalayer(self.datalayer, actor_obj)
+            self.datalayer.save(actor_obj)
             self.logger.info(
                 f"{self.name}: Updated actor {self.actor_id} in DataLayer"
             )

--- a/vultron/core/models/case_actor.py
+++ b/vultron/core/models/case_actor.py
@@ -34,7 +34,7 @@ class VultronCaseActor(VultronObject):
     Mirrors the Vultron-specific fields of ``CaseActor`` (which inherits
     ``as_Service``).  The ``outbox`` field carries the actor's outgoing
     activity IDs and is required so that ``UpdateActorOutbox`` can append
-    to it via ``save_to_datalayer``.
+    to it via ``datalayer.save``.
     ``as_type`` is ``"Service"`` to match ``CaseActor``'s wire value.
     """
 

--- a/vultron/core/use_cases/triggers/_helpers.py
+++ b/vultron/core/use_cases/triggers/_helpers.py
@@ -23,7 +23,6 @@ framework imports allowed here.
 
 import logging
 
-from vultron.adapters.driven.db_record import object_to_record
 from vultron.core.states.rm import RM
 from vultron.core.ports.datalayer import DataLayer
 from vultron.core.models.protocols import CaseModel
@@ -115,7 +114,7 @@ def update_participant_rm_state(
                     case_id,
                 )
                 return False
-            dl.update(participant.as_id, object_to_record(participant))
+            dl.save(participant)
             logger.info(
                 "Set participant '%s' RM state to %s in case '%s'",
                 actor_id,
@@ -154,7 +153,7 @@ def add_activity_to_outbox(
         )
         return
     actor_obj.outbox.items.append(activity_id)
-    dl.update(actor_obj.as_id, object_to_record(actor_obj))
+    dl.save(actor_obj)
     logger.debug(
         "Added activity '%s' to actor '%s' outbox", activity_id, actor_id
     )

--- a/vultron/core/use_cases/triggers/embargo.py
+++ b/vultron/core/use_cases/triggers/embargo.py
@@ -23,7 +23,6 @@ import logging
 
 from transitions import MachineError
 
-from vultron.adapters.driven.db_record import object_to_record
 from vultron.core.states.em import EM, EMAdapter, create_em_machine
 from vultron.core.ports.datalayer import DataLayer
 from vultron.core.use_cases.triggers._helpers import (
@@ -134,7 +133,7 @@ class SvcProposeEmbargoUseCase:
             )
 
         case.proposed_embargoes.append(embargo.as_id)
-        dl.update(case.as_id, object_to_record(case))
+        dl.save(case)
 
         add_activity_to_outbox(actor_id, proposal.as_id, dl)
 
@@ -214,7 +213,7 @@ class SvcEvaluateEmbargoUseCase:
 
         case.set_embargo(embargo_id)
         case.current_status.em_state = EM.ACTIVE
-        dl.update(case.as_id, object_to_record(case))
+        dl.save(case)
 
         add_activity_to_outbox(actor_id, accept.as_id, dl)
 
@@ -290,7 +289,7 @@ class SvcTerminateEmbargoUseCase:
 
         case.current_status.em_state = EM(adapter.state)
         case.active_embargo = None
-        dl.update(case.as_id, object_to_record(case))
+        dl.save(case)
 
         add_activity_to_outbox(actor_id, announce.as_id, dl)
 

--- a/vultron/wire/as2/rehydration.py
+++ b/vultron/wire/as2/rehydration.py
@@ -17,10 +17,9 @@
 Wire-layer object rehydration utilities.
 
 ``rehydrate`` converts a loosely-typed ``as_Object`` (or a string ID reference)
-into the correct wire-vocabulary subclass.  Callers that already hold a
-``DataLayer`` instance SHOULD pass it via the *dl* parameter; when *dl* is
-omitted the function falls back to ``get_datalayer()`` for backward
-compatibility with code paths that do not have a DataLayer in scope.
+into the correct wire-vocabulary subclass.  Callers MUST pass the active
+``DataLayer`` instance via the *dl* parameter so that string ID references can
+be resolved without importing a concrete adapter.
 """
 
 from __future__ import annotations
@@ -30,7 +29,6 @@ from typing import TYPE_CHECKING
 
 from pydantic import ValidationError
 
-from vultron.adapters.driven.datalayer_tinydb import get_datalayer
 from vultron.wire.as2.vocab.base.objects.base import as_Object
 from vultron.wire.as2.vocab.base.registry import find_in_vocabulary
 
@@ -43,7 +41,7 @@ MAX_REHYDRATION_DEPTH = 5
 
 
 def rehydrate(
-    obj: as_Object | str, dl: DataLayer | None = None, depth: int = 0
+    obj: as_Object | str, dl: DataLayer, depth: int = 0
 ) -> as_Object | str:
     """Recursively rehydrate an object if needed.
 
@@ -51,8 +49,7 @@ def rehydrate(
 
     Args:
         obj: The object (or string ID) to rehydrate.
-        dl: Optional DataLayer used to resolve string ID references.  When
-            *None* the function falls back to ``get_datalayer()``.
+        dl: DataLayer used to resolve string ID references.
         depth: Current recursion depth (callers should not set this).
 
     Returns:
@@ -70,16 +67,8 @@ def rehydrate(
         )
 
     if isinstance(obj, str):
-        if dl is not None:
-            logger.debug(
-                "Rehydrating string ID '%s' via provided DataLayer.", obj
-            )
-            resolved = dl.read(obj)
-        else:
-            logger.debug(
-                "Rehydrating string ID '%s' via fallback get_datalayer().", obj
-            )
-            resolved = get_datalayer().get(id_=obj)
+        logger.debug("Rehydrating string ID '%s' via provided DataLayer.", obj)
+        resolved = dl.read(obj)
 
         if resolved is None:
             raise ValueError(f"Object '{obj}' not found in data layer")


### PR DESCRIPTION
This pull request completes the TECHDEBT-32/32b/32c tasks to audit and refactor the DataLayer boundary, eliminating architectural violations and standardizing persistence patterns in the codebase. The most important changes are the removal of core-to-adapter and wire-to-adapter imports, the adoption of `dl.save(obj)` as the sole persistence method in core code, and related code and test cleanups. All changes are documented in plan and note files, and all tests pass.

**DataLayer boundary refactor and architectural cleanup:**

* Audited the DataLayer boundary, identified and removed all core imports of adapter utilities (`object_to_record`), and replaced all such usages with the canonical `dl.save(obj)` pattern in core modules [[1]](diffhunk://#diff-7028d0f9219f498d54fbfd9a9c95be957de6ee7a536ccd43d6ce29dd5a3094f4R1-R159) [[2]](diffhunk://#diff-61688cbed3169f2f61d7aaa61f51d19ba13bcd4a3f6709e30966d3669e7e9ea2R2778-R2857) [[3]](diffhunk://#diff-43674ea8e26ce0ee1fa32ec136d97a358b22a8ea96e802b739fd70bdfbb2e2aaR651-R690).
* Deleted the redundant `save_to_datalayer()` helper from core and updated all BT node usages to use `self.datalayer.save(obj)` instead [[1]](diffhunk://#diff-7028d0f9219f498d54fbfd9a9c95be957de6ee7a536ccd43d6ce29dd5a3094f4R1-R159) [[2]](diffhunk://#diff-61688cbed3169f2f61d7aaa61f51d19ba13bcd4a3f6709e30966d3669e7e9ea2R2778-R2857) [[3]](diffhunk://#diff-43674ea8e26ce0ee1fa32ec136d97a358b22a8ea96e802b739fd70bdfbb2e2aaR651-R690).
* Removed the wire-layer import of `get_datalayer` from the TinyDB adapter in `rehydration.py`, making `dl` a required parameter and updating all callers accordingly; eliminated legacy monkeypatches in tests [[1]](diffhunk://#diff-61688cbed3169f2f61d7aaa61f51d19ba13bcd4a3f6709e30966d3669e7e9ea2R2778-R2857) [[2]](diffhunk://#diff-0a20476275b2788eef9e7ae09e6e82f8662af6f16b9a645256f7e620d6772b5aL71-R71) [[3]](diffhunk://#diff-35e1e9b42a3e7bf925f2328f1ab562c0dfec1d8570063db0ab1467a125ee96f3L128-L132) [[4]](diffhunk://#diff-35e1e9b42a3e7bf925f2328f1ab562c0dfec1d8570063db0ab1467a125ee96f3L176-L180) [[5]](diffhunk://#diff-35e1e9b42a3e7bf925f2328f1ab562c0dfec1d8570063db0ab1467a125ee96f3L233-L237) [[6]](diffhunk://#diff-35e1e9b42a3e7bf925f2328f1ab562c0dfec1d8570063db0ab1467a125ee96f3L443-L447) [[7]](diffhunk://#diff-7e13f0176a2bc3e3826c017eb108e102f0b8921b7169ec7c29ddd0eeac4fc41cL40-L44) [[8]](diffhunk://#diff-7e13f0176a2bc3e3826c017eb108e102f0b8921b7169ec7c29ddd0eeac4fc41cL133-L136) [[9]](diffhunk://#diff-7e13f0176a2bc3e3826c017eb108e102f0b8921b7169ec7c29ddd0eeac4fc41cL180-L183) [[10]](diffhunk://#diff-e0573fbe2c43a9728d732ee8cfe26918e33564fe8331919dfcb3a308ad5dd1d6L34-L38) [[11]](diffhunk://#diff-e0573fbe2c43a9728d732ee8cfe26918e33564fe8331919dfcb3a308ad5dd1d6L82-L86).

**Documentation and implementation plan updates:**

* Added a detailed audit note (`notes/datalayer-refactor.md`) summarizing findings, violations, and refactor decisions for the DataLayer boundary.
* Updated implementation plan and history files to reflect completion of TECHDEBT-32, 32b, and 32c, including marking tasks as complete, summarizing lessons learned, and updating test counts [[1]](diffhunk://#diff-43674ea8e26ce0ee1fa32ec136d97a358b22a8ea96e802b739fd70bdfbb2e2aaL3-R3) [[2]](diffhunk://#diff-43674ea8e26ce0ee1fa32ec136d97a358b22a8ea96e802b739fd70bdfbb2e2aaL16-R16) [[3]](diffhunk://#diff-43674ea8e26ce0ee1fa32ec136d97a358b22a8ea96e802b739fd70bdfbb2e2aaL39-R47) [[4]](diffhunk://#diff-43674ea8e26ce0ee1fa32ec136d97a358b22a8ea96e802b739fd70bdfbb2e2aaL631-R633) [[5]](diffhunk://#diff-43674ea8e26ce0ee1fa32ec136d97a358b22a8ea96e802b739fd70bdfbb2e2aaR651-R690) [[6]](diffhunk://#diff-43674ea8e26ce0ee1fa32ec136d97a358b22a8ea96e802b739fd70bdfbb2e2aaL906-R949) [[7]](diffhunk://#diff-61688cbed3169f2f61d7aaa61f51d19ba13bcd4a3f6709e30966d3669e7e9ea2R2778-R2857).

**Best practices and future guidance:**

* Documented in implementation notes that `dl.save(obj)` is now the only approved persistence method for core code; importing adapter utilities or using legacy helpers is explicitly banned.

All 985 tests pass, confirming the correctness of these refactors.