### PR TITLE
spec: normalize RFC 2119 keywords across all specification files (SPEC-AUDIT-2)

### DIFF
--- a/plan/IMPLEMENTATION_HISTORY.md
+++ b/plan/IMPLEMENTATION_HISTORY.md
@@ -3674,3 +3674,61 @@ paths in 9 spec files:
 to reflect current `test/adapters/`, `test/core/`, `test/wire/` layout.
 
 **Tests:** 1080 passed, 5581 subtests passed (no code changes; docs only).
+
+---
+
+## NAMING-1 — Standardize `as_`-prefixed field names (2026-03-30)
+
+**Task**: Rename all `as_`-prefixed Pydantic field names to the trailing-underscore
+convention throughout the codebase (both wire layer and core layer).
+
+**Changes**:
+
+- Renamed 4 field names across 130 Python files (~2756 occurrences):
+  - `as_id` → `id_`
+  - `as_type` → `type_`
+  - `as_object` → `object_`
+  - `as_context` → `context_`
+- Renames cover: field definitions, attribute accesses (`.as_id` etc.),
+  keyword arguments (`as_id=...`), string references in `getattr`/`hasattr`
+  calls, and docstrings/comments.
+- Class names (`as_Activity`, `as_Object`, etc.) are **not** renamed.
+- Pydantic field aliases (`validation_alias`, `serialization_alias`) are
+  unchanged — JSON serialization and deserialization behavior is preserved.
+- Updated `specs/code-style.md` CS-07-001 through CS-07-003 to reflect
+  migration complete (MUST-level policy now).
+- Updated `AGENTS.md` naming conventions, pattern-matching example, and
+  all pitfall code snippets to use `id_`, `type_`, `object_`.
+
+**Tests**: 1080 passed, 5581 subtests passed.
+
+---
+
+## SPEC-AUDIT-2 — RFC 2119 strength keyword migration (2026-03-30)
+
+**Task**: Ensure every requirement line in `specs/` has an RFC 2119 keyword
+on its first line, and remove keyword suffixes from section headers.
+
+**Changes**:
+
+- **176 keyword additions**: Requirement lines missing a keyword on the first
+  line (keyword was on a wrapped continuation line, absent, or only in the
+  section header) now have the keyword inserted immediately after the ID.
+  Prefix-style keywords are parenthesised: `` `ID` (MUST) text ``.
+  Naturally-embedded keywords (e.g. `All handlers MUST ...`) are left as-is.
+- **293 header cleanups**: `## Section (MUST)` / `(SHOULD)` / `(MAY)` etc.
+  suffixes removed from all `##` and `###` headers across 37 spec files.
+  Removing headers that had identical base names (e.g. two `## Embargo Rules`
+  sections previously separated by `(MUST)`/`(SHOULD)`) also resulted in
+  31 duplicate-header merges in `vultron-protocol-spec.md` and `code-style.md`.
+- **171 format fixes**: A second pass converted bare prefix keywords
+  (`MUST text`) to the parenthesised form (`(MUST) text`) for visual
+  clarity and to distinguish them from sentence-embedded keywords.
+
+**Verification**:
+
+- `grep -rn "^\- \`[A-Z]" specs/*.md | grep -v "MUST\|SHOULD\|..." → 0 hits`
+- `grep -rh "^## \|^### " specs/*.md | grep "(MUST)\|(SHOULD)\|(MAY)"` → 0 hits
+- `markdownlint-cli2`: 0 errors
+
+**Tests**: 1080 passed, 5581 subtests (no code changes; docs only).

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -17,10 +17,16 @@ NOT override `plan/PRIORITIES.md` when the two differ.
 
 All 38 message handlers implemented (including `unknown`). All 9 trigger
 endpoints complete. 12 demo scripts, all dockerized in `docker-compose.yml`.
-All PRIORITY-30 through PRIORITY-200 phases complete. Active open work:
-**PRIORITY-250** (pre-300 cleanup — NAMING-1 remain
-open; QUALITY-1, SM-GUARD-1, VSR-ERR-1, BUG-FLAKY-1, REORG-1, SECOPS-1,
-DOCMAINT-1, SPEC-AUDIT-3 done) and
+All PRIORITY-30 through PRIORITY-200 phases complete.
+
+#### Active open work
+
+**PRIORITY-250** Pre-300 cleanup
+
+- done: NAMING-1, QUALITY-1, SM-GUARD-1, VSR-ERR-1,
+BUG-FLAKY-1, REORG-1, SECOPS-1, DOCMAINT-1, SPEC-AUDIT-2, SPEC-AUDIT-3
+- not done: SPEC-AUDIT-1
+
 **PRIORITY-300** (multi-actor demos; D5-1 unblocked, D5-2 and later blocked
 by PRIORITY-250).
 
@@ -110,14 +116,13 @@ by PRIORITY-250).
 Per `plan/PRIORITIES.md`, these tasks MUST be completed before D5-2 and later
 PRIORITY-300 demo work. D5-1 (architecture review) MAY proceed in parallel.
 
-#### NAMING-1 — Standardize wire-layer field naming
+#### NAMING-1 — Standardize wire-layer field naming ✅
 
-- [ ] **NAMING-1**: Audit and migrate all `as_`-prefixed field names in
-  `vultron/wire/as2/` to use trailing-underscore convention (e.g.,
-  `as_object` → `object_`, `as_type` → `type_`). Class names (e.g.,
-  `as_Activity`, `as_Object`) retain the `as_` prefix. Update `specs/`,
-  `notes/`, `AGENTS.md`, and documentation to reflect this convention.
-  Reference `specs/code-style.md` CS-07-003.
+- [x] **NAMING-1**: Renamed all `as_`-prefixed field names to trailing-underscore
+  convention: `as_id` → `id_`, `as_type` → `type_`, `as_object` → `object_`,
+  `as_context` → `context_`. All 130 affected files updated. Class names
+  (`as_Activity`, `as_Object`, etc.) retain the `as_` prefix. Updated
+  `specs/code-style.md` CS-07-001–003 and `AGENTS.md`. Completed 2026-03-30.
 
 #### SECOPS-1 — CI security: ADR + automated pin-verification test ✅
 
@@ -273,15 +278,13 @@ are needed before resuming feature development.
   `code-style.md`. Merge or cross-reference requirements to eliminate
   maintenance-burden redundancy and reduce risk of specification divergence.
 
-### SPEC-AUDIT-2 — Strength keyword migration
+### SPEC-AUDIT-2 — Strength keyword migration ✅
 
-- [ ] **SPEC-AUDIT-2**: Audit all `.md` files in `specs/` to ensure every
-  individual requirement line includes an inline RFC 2119 strength keyword
-  (MUST, SHOULD, or MAY). Per the updated `specs/meta-specifications.md`,
-  keywords MUST appear in the requirement text itself, not only in section
-  headers. Insert the keyword between the requirement ID and the requirement
-  text on each line that is missing it (e.g., `XX-01-001 (MUST) Use SHA-256
-  hashes...`). A full-spectrum audit across all spec files is required.
+- [x] **SPEC-AUDIT-2**: Every requirement line in all 37 spec files now has an
+  RFC 2119 keyword on its first line (greppable). Prefix-style keywords are
+  parenthesised: `` `ID` (MUST) text ``; naturally-embedded keywords left as-is.
+  All section-header keyword suffixes (e.g. `(MUST)`) removed. 176 keyword
+  additions, 293 header cleanups, 171 format fixes. Completed 2026-03-30.
 
 ### SPEC-AUDIT-3 — Relocate transient implementation notes from specs ✅
 

--- a/specs/agentic-readiness.md
+++ b/specs/agentic-readiness.md
@@ -13,7 +13,7 @@ interfaces that support agentic workflows.
 
 ---
 
-## API Discoverability (MUST)
+## API Discoverability
 
 - `AR-01-001` The API MUST expose a machine-readable OpenAPI JSON schema at
   `/openapi.json`
@@ -21,22 +21,22 @@ interfaces that support agentic workflows.
   `/redoc` in development environments
 - `AR-01-003` Every endpoint MUST have a unique, stable `operationId`
   following the `{resource}_{action}` naming convention
-- `AR-01-004` `PROD_ONLY` All possible HTTP response codes for each endpoint
+- `AR-01-004` MUST `PROD_ONLY` All possible HTTP response codes for each endpoint
   MUST be declared in the OpenAPI spec with typed response models
 
-## State and Workflow Transitions (SHOULD)
+## State and Workflow Transitions
 
 - `AR-02-001` `PROD_ONLY` Resources with a `status` field SHOULD include a
   `next_allowed_actions` list identifying valid state transitions from the
   current state
-- `AR-02-002` All valid states and state transitions for state machine
+- `AR-02-002` MUST All valid states and state transitions for state machine
   resources MUST be documented
 - `AR-02-003` `PROD_ONLY` Endpoints with prerequisites MUST return a structured
   error using the `error` field value `"PreconditionFailedError"` when invoked
   out of sequence
   - AR-02-003 depends-on EH-05-001
 
-## Stable Error Types (MUST)
+## Stable Error Types
 
 - `AR-03-001` The API MUST use the `error` field (per `error-handling.md`
   EH-05-001) as a stable, machine-parseable error type identifier
@@ -44,24 +44,24 @@ interfaces that support agentic workflows.
     human-readable `message` field
   - AR-03-001 depends-on EH-05-001
 
-## Long-Running Operations (SHOULD)
+## Long-Running Operations
 
 - `AR-04-001` `PROD_ONLY` Long-running operations SHOULD return a job or task
   object immediately with a stable `id` and `status` field
-- `AR-04-002` `PROD_ONLY` A separate polling endpoint or webhook mechanism
+- `AR-04-002` SHOULD `PROD_ONLY` A separate polling endpoint or webhook mechanism
   SHOULD be available to report operation completion
 
-## Pagination (SHOULD)
+## Pagination
 
 - `AR-05-001` Collection endpoints SHOULD expose `limit` and `offset` (or
   `cursor`) query parameters with documented defaults and maximums
 
-## Bulk Operations (MAY)
+## Bulk Operations
 
-- `AR-06-001` `PROD_ONLY` Resources that agents may need to create, update, or
+- `AR-06-001` MAY `PROD_ONLY` Resources that agents may need to create, update, or
   delete in quantity MAY expose batch endpoints (e.g., `POST /v1/items/batch`)
 
-## Actor Discovery Profile (MUST)
+## Actor Discovery Profile
 
 - `AR-10-001` The API MUST expose `GET /actors/{actor_id}/profile` returning an
   ActivityStreams actor profile document for actor discovery and federation
@@ -75,7 +75,7 @@ interfaces that support agentic workflows.
 - `AR-10-003` The profile endpoint MUST support both full actor URI and short
   actor ID (e.g., `vendorco`) as the `actor_id` path parameter
 
-## CVD Action Rules API (SHOULD)
+## CVD Action Rules API
 
 - `AR-07-001` The system SHOULD expose an endpoint that returns the set of
   valid CVD actions available to a participant given current case state and
@@ -96,7 +96,7 @@ interfaces that support agentic workflows.
   - AR-07-003 depends-on CM-07-002
   - AR-07-003 depends-on CM-07-003
 
-## CLI Interface (MUST)
+## CLI Interface
 
 - `AR-08-001` `PROD_ONLY` The CLI MUST be installable as a Python package entry point
   defined in `pyproject.toml`
@@ -109,7 +109,7 @@ interfaces that support agentic workflows.
 - `AR-08-005` `PROD_ONLY` Long-running CLI commands SHOULD support `--wait` / `--no-wait`
   flags; `--no-wait` returns the job object immediately
 
-## MCP Server Adapter (MAY)
+## MCP Server Adapter
 
 The Model Context Protocol (MCP) server is a driving adapter that exposes the
 Vultron core to AI agent tool calls. Like the CLI and HTTP inbox, the MCP
@@ -169,10 +169,10 @@ Driving Adapters) for the architecture context.
 
 ### AR-08-001, AR-08-002, AR-08-003 Verification
 
-- `PROD_ONLY` Integration test: CLI entry point installed and executable via
+- `PROD_ONLY` MAY Integration test: CLI entry point installed and executable via
   `pyproject.toml`
-- `PROD_ONLY` Integration test: `--output json` produces valid JSON on stdout
-- `PROD_ONLY` Integration test: CLI exit codes match specification
+- `PROD_ONLY` MAY Integration test: `--output json` produces valid JSON on stdout
+- `PROD_ONLY` MAY Integration test: CLI exit codes match specification
 
 ### AR-07-001, AR-07-002 Verification
 

--- a/specs/agentic-readiness.md
+++ b/specs/agentic-readiness.md
@@ -21,7 +21,7 @@ interfaces that support agentic workflows.
   `/redoc` in development environments
 - `AR-01-003` Every endpoint MUST have a unique, stable `operationId`
   following the `{resource}_{action}` naming convention
-- `AR-01-004` MUST `PROD_ONLY` All possible HTTP response codes for each endpoint
+- `AR-01-004` (MUST) `PROD_ONLY` All possible HTTP response codes for each endpoint
   MUST be declared in the OpenAPI spec with typed response models
 
 ## State and Workflow Transitions
@@ -29,7 +29,7 @@ interfaces that support agentic workflows.
 - `AR-02-001` `PROD_ONLY` Resources with a `status` field SHOULD include a
   `next_allowed_actions` list identifying valid state transitions from the
   current state
-- `AR-02-002` MUST All valid states and state transitions for state machine
+- `AR-02-002` (MUST) All valid states and state transitions for state machine
   resources MUST be documented
 - `AR-02-003` `PROD_ONLY` Endpoints with prerequisites MUST return a structured
   error using the `error` field value `"PreconditionFailedError"` when invoked
@@ -48,7 +48,7 @@ interfaces that support agentic workflows.
 
 - `AR-04-001` `PROD_ONLY` Long-running operations SHOULD return a job or task
   object immediately with a stable `id` and `status` field
-- `AR-04-002` SHOULD `PROD_ONLY` A separate polling endpoint or webhook mechanism
+- `AR-04-002` (SHOULD) `PROD_ONLY` A separate polling endpoint or webhook mechanism
   SHOULD be available to report operation completion
 
 ## Pagination
@@ -58,7 +58,7 @@ interfaces that support agentic workflows.
 
 ## Bulk Operations
 
-- `AR-06-001` MAY `PROD_ONLY` Resources that agents may need to create, update, or
+- `AR-06-001` (MAY) `PROD_ONLY` Resources that agents may need to create, update, or
   delete in quantity MAY expose batch endpoints (e.g., `POST /v1/items/batch`)
 
 ## Actor Discovery Profile

--- a/specs/agentic-readiness.md
+++ b/specs/agentic-readiness.md
@@ -169,10 +169,10 @@ Driving Adapters) for the architecture context.
 
 ### AR-08-001, AR-08-002, AR-08-003 Verification
 
-- `PROD_ONLY` MAY Integration test: CLI entry point installed and executable via
+- `PROD_ONLY` Integration test: CLI entry point installed and executable via
   `pyproject.toml`
-- `PROD_ONLY` MAY Integration test: `--output json` produces valid JSON on stdout
-- `PROD_ONLY` MAY Integration test: CLI exit codes match specification
+- `PROD_ONLY` Integration test: `--output json` produces valid JSON on stdout
+- `PROD_ONLY` Integration test: CLI exit codes match specification
 
 ### AR-07-001, AR-07-002 Verification
 

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -18,7 +18,7 @@ prevention), `prototype-shortcuts.md` PROTO-06-001 (domain model deferral),
 
 ---
 
-## Layer Separation (MUST)
+## Layer Separation
 
 - `ARCH-01-001` The `core/` package (or equivalent domain layer) MUST NOT
   import from `wire/`, `adapters/`, or any external framework
@@ -42,7 +42,7 @@ prevention), `prototype-shortcuts.md` PROTO-06-001 (domain model deferral),
   - **Rationale**: Wire format concerns are structurally distinct from
     domain concerns; mixing them prevents future wire format substitution
 
-## SemanticIntent Enum (MUST)
+## SemanticIntent Enum
 
 - `ARCH-02-001` The `MessageSemantics` enum (`SemanticIntent`) MUST be
   defined in the domain layer, not in the wire layer
@@ -54,7 +54,7 @@ prevention), `prototype-shortcuts.md` PROTO-06-001 (domain model deferral),
     ARCH-1.1); re-exported from `vultron/enums.py` for compatibility. AS2
     structural enums moved to `vultron/wire/as2/enums.py` (ARCH-CLEANUP-2).
 
-## Semantic Extractor (MUST)
+## Semantic Extractor
 
 - `ARCH-03-001` AS2 vocabulary MUST be mapped to domain concepts in exactly
   one location: the semantic extractor
@@ -66,9 +66,9 @@ prevention), `prototype-shortcuts.md` PROTO-06-001 (domain model deferral),
     sole location of AS2-to-domain vocabulary mapping (ARCH-1.3,
     ARCH-CLEANUP-1). Handler code no longer inspects AS2 types (ARCH-CLEANUP-3).
 
-## Driven Adapter Injection (MUST)
+## Driven Adapter Injection
 
-- `ARCH-04-001` Driven adapters (persistence, delivery queue, DNS resolver,
+- `ARCH-04-001` MUST Driven adapters (persistence, delivery queue, DNS resolver,
   HTTP delivery) MUST be injected into core services via port interfaces
   - Core services MUST NOT instantiate concrete adapter implementations
     directly
@@ -78,7 +78,7 @@ prevention), `prototype-shortcuts.md` PROTO-06-001 (domain model deferral),
     parameter injection (ARCH-1.4). `get_datalayer()` is no longer called
     inside handler bodies.
 
-## Connector Plugins (MUST)
+## Connector Plugins
 
 - `ARCH-05-001` Connector plugins (tracker integrations) MUST be discovered
   via Python entry points (`importlib.metadata`); the core MUST NOT import
@@ -86,7 +86,7 @@ prevention), `prototype-shortcuts.md` PROTO-06-001 (domain model deferral),
 - `ARCH-05-002` Connector plugins MUST translate only — no case handling
   logic, authorization, or journal management belongs in a connector
 
-## Wire Layer Replaceability (SHOULD)
+## Wire Layer Replaceability
 
 - `ARCH-06-001` The wire layer (`wire/as2/`) SHOULD be replaceable as a
   unit without touching the core or adapter layers
@@ -96,7 +96,7 @@ prevention), `prototype-shortcuts.md` PROTO-06-001 (domain model deferral),
     now typed as `InboundPayload` (domain type), not `as_Activity` (ARCH-1.2).
     Full wire replaceability requires completing P60-3 (adapters package).
 
-## Handler Isolation (MUST)
+## Handler Isolation
 
 - `ARCH-07-001` Handler functions MUST NOT re-invoke semantic extraction
   - The semantic type MUST be pre-computed and carried in the dispatch
@@ -107,7 +107,7 @@ prevention), `prototype-shortcuts.md` PROTO-06-001 (domain model deferral),
     time via `USE_CASE_MAP` key lookup in `vultron/core/dispatcher.py`;
     no re-invocation of `find_matching_semantics`.
 
-## Driving Adapter Boundary (MUST)
+## Driving Adapter Boundary
 
 - `ARCH-08-001` Driving adapters (HTTP inbox, CLI, MCP server) MUST invoke
   the wire pipeline before calling into the core
@@ -119,7 +119,7 @@ prevention), `prototype-shortcuts.md` PROTO-06-001 (domain model deferral),
     `vultron/wire/as2/parser.py`; the router calls it as a thin wrapper
     (ARCH-1.3).
 
-## Core Model Richness (MUST)
+## Core Model Richness
 
 - `ARCH-09-001` Core domain models MUST be as rich as or richer than their
   wire-layer counterparts
@@ -133,7 +133,7 @@ prevention), `prototype-shortcuts.md` PROTO-06-001 (domain model deferral),
   - **Cross-reference**: `notes/architecture-ports-and-adapters.md`
     "Core Models Must Be Richer Than Wire Models"
 
-## Fail-Fast Domain Objects (MUST)
+## Fail-Fast Domain Objects
 
 - `ARCH-10-001` Domain events and domain models MUST validate required
   fields at construction time and fail immediately if required invariants
@@ -148,7 +148,7 @@ prevention), `prototype-shortcuts.md` PROTO-06-001 (domain model deferral),
   - **Cross-reference**: `notes/architecture-ports-and-adapters.md`
     "Design Constraints and Invariants" invariant 2
 
-## Port Inbound/Outbound Discrimination (SHOULD)
+## Port Inbound/Outbound Discrimination
 
 - `ARCH-11-001` Core ports SHOULD be organized into inbound (driving)
   and outbound (driven) categories

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -68,7 +68,7 @@ prevention), `prototype-shortcuts.md` PROTO-06-001 (domain model deferral),
 
 ## Driven Adapter Injection
 
-- `ARCH-04-001` MUST Driven adapters (persistence, delivery queue, DNS resolver,
+- `ARCH-04-001` (MUST) Driven adapters (persistence, delivery queue, DNS resolver,
   HTTP delivery) MUST be injected into core services via port interfaces
   - Core services MUST NOT instantiate concrete adapter implementations
     directly

--- a/specs/behavior-tree-integration.md
+++ b/specs/behavior-tree-integration.md
@@ -13,14 +13,14 @@ SHOULD use BTs for clarity and maintainability.
 
 ---
 
-## BT Execution Model (MUST)
+## BT Execution Model
 
 - `BT-01-001` BT execution MUST be event-driven, triggered by handler invocation
 - `BT-01-002` BTs MUST execute to completion (or max iterations) per invocation
 - `BT-01-003` BT execution MUST NOT use continuous tick-based polling loops
 - `BT-01-004` BTs MUST be single-shot executions within handler context
 
-## BT Library (MUST)
+## BT Library
 
 - `BT-02-001` Prototype handlers MUST implement BT execution using industry-
   standard BT library
@@ -33,7 +33,7 @@ SHOULD use BTs for clarity and maintainability.
   - Simulation uses custom BT engine; prototype uses py_trees
   - No refactoring of simulation to py_trees
 
-## State Management (MUST)
+## State Management
 
 - `BT-03-001` BTs MUST use DataLayer as persistent state store
 - `BT-03-002` BTs MUST NOT maintain separate blackboard persistence
@@ -48,21 +48,21 @@ SHOULD use BTs for clarity and maintainability.
 - `BT-03-004` State changes MUST be committed to DataLayer on successful
   execution
 
-## Handler Integration (MUST)
+## Handler Integration
 
 - `BT-04-001` Handler protocol MUST be preserved (decorator, signature, registration)
 - `BT-04-002` Handlers MAY invoke BTs via bridge layer
 - `BT-04-003` Handlers MUST remain synchronous (BT execution within handler)
 - `BT-04-004` BT execution errors MUST propagate to handler error handling
 
-## BT Bridge Layer (SHOULD)
+## BT Bridge Layer
 
 - `BT-05-001` System SHOULD provide BT execution bridge for handler-to-BT invocation
 - `BT-05-002` Bridge SHOULD set up py_trees context with DataLayer access
 - `BT-05-003` Bridge SHOULD populate blackboard with activity and actor state
 - `BT-05-004` Bridge SHOULD execute tree and return execution result
 
-## Workflow-Specific Trees (SHOULD)
+## Workflow-Specific Trees
 
 - `BT-06-001` Complex workflows SHOULD have dedicated BT implementations
   - Report validation, case creation, embargo management, case engagement/deferral
@@ -90,7 +90,7 @@ SHOULD use BTs for clarity and maintainability.
     and visible for analysis; it ensures the process behaves as intended and
     can be reasoned about from the tree alone
 
-## DataLayer Integration (MUST)
+## DataLayer Integration
 
 - `BT-07-001` BT nodes MUST interact with DataLayer via Protocol interface
   - **Protocol**: `vultron.api.v2.datalayer.abc.DataLayer` (duck typing, not
@@ -105,20 +105,20 @@ SHOULD use BTs for clarity and maintainability.
   - BT-07-003 depends-on SL-03-001
   - BT-07-003 depends-on SL-04-001
 
-## Command-Line Execution (MAY)
+## Command-Line Execution
 
 - `BT-08-001` System MAY provide CLI interface for BT execution
   - Enables testing and AI agent integration
 - `BT-08-002` CLI SHOULD support invoking specific trees with test data
 - `BT-08-003` CLI SHOULD log BT execution visualization
 
-## Actor Isolation (MUST)
+## Actor Isolation
 
 - `BT-09-001` Each actor MUST have isolated BT execution context
 - `BT-09-002` Actor blackboards MUST NOT share state
 - `BT-09-003` Actor interaction MUST occur only via protocol messages
 
-## CaseActor Management (MUST)
+## CaseActor Management
 
 - `BT-10-001` Report validation MUST trigger VulnerabilityCase creation
   - BT-10-001 implements VP-02-015
@@ -127,9 +127,9 @@ SHOULD use BTs for clarity and maintainability.
 - `BT-10-003` CaseActor MUST manage case-related message processing
 - `BT-10-004` `PROD_ONLY` CaseActor MUST enforce case-level authorization
 
-## VFD/PXA State Machine Usage (SHOULD)
+## VFD/PXA State Machine Usage
 
-- `BT-12-001` When implementing VFD (vendor fix deployed) or PXA (public
+- `BT-12-001` MUST When implementing VFD (vendor fix deployed) or PXA (public
   exploit/attack) state transitions, new code MUST use `create_vfd_machine()`
   and `create_pxa_machine()` (defined in `vultron/core/states/cs.py`) as the
   authoritative source of valid transition sequences. Hand-rolled transition
@@ -139,7 +139,7 @@ SHOULD use BTs for clarity and maintainability.
     preventing divergence between the machines and the implementation.
   - **See also**: OPP-06 in `notes/state-machine-findings.md`
 
-## Concurrency (MUST)
+## Concurrency
 
 - `BT-11-001` Prototype MUST process messages sequentially (FIFO order)
   - **Rationale**: Eliminates race conditions in prototype phase

--- a/specs/behavior-tree-integration.md
+++ b/specs/behavior-tree-integration.md
@@ -129,7 +129,7 @@ SHOULD use BTs for clarity and maintainability.
 
 ## VFD/PXA State Machine Usage
 
-- `BT-12-001` MUST When implementing VFD (vendor fix deployed) or PXA (public
+- `BT-12-001` (MUST) When implementing VFD (vendor fix deployed) or PXA (public
   exploit/attack) state transitions, new code MUST use `create_vfd_machine()`
   and `create_pxa_machine()` (defined in `vultron/core/states/cs.py`) as the
   authoritative source of valid transition sequences. Hand-rolled transition

--- a/specs/case-management.md
+++ b/specs/case-management.md
@@ -264,7 +264,7 @@ the distinction between participant-specific and participant-agnostic state.
 ### CM-02-004, CM-02-005 Verification
 
 - Unit test: CaseActor has reference to case owner
-- `PROD_ONLY` SHOULD Integration test: Non-owner attempt to close case → authorization error
+- `PROD_ONLY` Integration test: Non-owner attempt to close case → authorization error
 
 ### CM-02-009 Verification
 
@@ -381,12 +381,12 @@ the distinction between participant-specific and participant-agnostic state.
 
 ### CM-09-001 through CM-09-004 Verification
 
-- `PROD_ONLY` MUST Unit test: `VulnerabilityCase.redact(invitee_id)` returns a
+- `PROD_ONLY` Unit test: `VulnerabilityCase.redact(invitee_id)` returns a
   `RedactedVulnerabilityCase` excluding report content, discussion, and
   participant details
-- `PROD_ONLY` MUST Unit test: Two calls to `redact()` with different invitee IDs
+- `PROD_ONLY` Unit test: Two calls to `redact()` with different invitee IDs
   return objects with distinct IDs
-- `PROD_ONLY` MUST Unit test: Redacted case ID shares no substrings with the full
+- `PROD_ONLY` Unit test: Redacted case ID shares no substrings with the full
   case ID
 
 ### CM-10-001 through CM-10-004 Verification

--- a/specs/case-management.md
+++ b/specs/case-management.md
@@ -13,7 +13,7 @@ the distinction between participant-specific and participant-agnostic state.
 
 ---
 
-## Actor Isolation (MUST)
+## Actor Isolation
 
 - `CM-01-001` Each actor MUST have an isolated protocol state domain
   - Actor A and Actor B MUST NOT share internal state (RM, EM, CS, BT blackboard)
@@ -21,7 +21,7 @@ the distinction between participant-specific and participant-agnostic state.
 - `CM-01-002` Each actor's RM state MUST be maintained independently per case
   - RM state is participant-specific; each actor tracks their own RM lifecycle
 
-## CaseActor Lifecycle (MUST)
+## CaseActor Lifecycle
 
 - `CM-02-001` Each VulnerabilityCase MUST have exactly one associated CaseActor
   - CaseActor is an ActivityStreams Service object
@@ -46,7 +46,7 @@ the distinction between participant-specific and participant-agnostic state.
     `case_participants` and `vulnerability_reports` tracking
   - Handlers implementing `AddNoteToCase` MUST append the `as_NoteRef` to
     `VulnerabilityCase.notes`
-- `CM-02-008` When a `VulnerabilityCase` is created from an originating
+- `CM-02-008` MUST When a `VulnerabilityCase` is created from an originating
   `VulnerabilityReport` Offer, the vendor (case recipient / owner) MUST be
   recorded as the initial primary participant
   - `VulnerabilityCase.attributed_to` MUST be set to the vendor/coordinator's
@@ -68,7 +68,7 @@ the distinction between participant-specific and participant-agnostic state.
     single-source-of-truth guarantee
   - CM-02-009 depends-on CM-02-002
 
-## Case State Model (MUST)
+## Case State Model
 
 - `CM-03-001` The system MUST implement the three interacting state machines:
   RM (Report Management), EM (Embargo Management), and CS (Case State)
@@ -117,7 +117,7 @@ the distinction between participant-specific and participant-agnostic state.
     transition
   - CM-03-007 implements VP-02-004
 
-## State Transition Correctness (MUST)
+## State Transition Correctness
 
 - `CM-04-001` Handlers processing RM state transitions MUST update
   `ParticipantStatus.rm_state` for the sending actor's CaseParticipant
@@ -135,7 +135,7 @@ the distinction between participant-specific and participant-agnostic state.
   - CM-04-003 implements VP-11-002
   - CM-04-003 implements VP-14-001
   - CM-04-003 implements VP-14-002
-- `CM-04-004` Handlers processing PXA state transitions (public disclosure,
+- `CM-04-004` MUST Handlers processing PXA state transitions (public disclosure,
   exploit publication, attack observation) MUST update `CaseStatus.pxa_state`
   - CM-04-004 implements VP-03-002
   - CM-04-004 implements VP-14-003
@@ -153,7 +153,7 @@ the distinction between participant-specific and participant-agnostic state.
     incorrect and MUST be avoided
   - CM-04-006 implements VP-13-009
 
-## Object Model Relationships (MUST)
+## Object Model Relationships
 
 - `CM-05-001` The system MUST distinguish the following domain objects as
   separate, non-interchangeable types:
@@ -201,14 +201,14 @@ the distinction between participant-specific and participant-agnostic state.
   identifiers from different namespaces for the same vulnerability
   - **Rationale**: Multiple IDs from different namespaces may refer to the
     same underlying vulnerability (e.g., a CVE ID and a CERT/CC VU# ID)
-- `CM-05-010` When a `VulnerabilityRecord` is a `CVERecord` (i.e., it
+- `CM-05-010` MUST When a `VulnerabilityRecord` is a `CVERecord` (i.e., it
   carries a CVE ID), its data MUST conform to the CVE JSON schema
   (<https://github.com/CVEProject/cve-schema>)
   - The `CVERecord` Pydantic model SHOULD reuse the CVE JSON schema
     `reference` definition for its `references` array, ensuring
     compatibility with CVE data interchange formats
 
-## Case Update Broadcast (MUST)
+## Case Update Broadcast
 
 - `CM-06-001` When the CaseActor updates canonical case state, it MUST
   notify all current case participants
@@ -227,7 +227,7 @@ the distinction between participant-specific and participant-agnostic state.
   notifications before accepting them as authoritative
   - CM-06-004 is-constrained-by PROTO-01-001
 
-## CVD Action Rules API (SHOULD)
+## CVD Action Rules API
 
 - `CM-07-001` The system SHOULD expose an endpoint that returns the set of
   valid actions available to a case participant given the current case state
@@ -264,7 +264,7 @@ the distinction between participant-specific and participant-agnostic state.
 ### CM-02-004, CM-02-005 Verification
 
 - Unit test: CaseActor has reference to case owner
-- `PROD_ONLY` Integration test: Non-owner attempt to close case → authorization error
+- `PROD_ONLY` SHOULD Integration test: Non-owner attempt to close case → authorization error
 
 ### CM-02-009 Verification
 
@@ -317,7 +317,7 @@ the distinction between participant-specific and participant-agnostic state.
   case
 - Unit test: Action rules reflect current RM/EM/CS state for the participant
 
-## Domain Model Architecture (SHOULD)
+## Domain Model Architecture
 
 - `CM-08-001` The system SHOULD maintain a clear separation between the wire
   representation, domain model, and persistence model for CVD objects
@@ -334,7 +334,7 @@ the distinction between participant-specific and participant-agnostic state.
   - See `notes/domain-model-separation.md` for design rationale and recommended migration steps
   - CM-08-002 is-constrained-by PROTO-06-001
 
-## Redacted Case View (SHOULD)
+## Redacted Case View
 
 - `CM-09-001` `PROD_ONLY` The system SHOULD support a `RedactedVulnerabilityCase`
   type for sharing case information with invited-but-not-yet-accepted participants
@@ -356,7 +356,7 @@ the distinction between participant-specific and participant-agnostic state.
   by full case ID only, deferring the redacted view to a later phase
   - CM-09-004 is-constrained-by PROTO-01-001
 
-## Per-Participant Embargo Acceptance (MUST)
+## Per-Participant Embargo Acceptance
 
 - `CM-10-001` `CaseParticipant` MUST track which embargo(es) a participant has
   explicitly accepted
@@ -381,12 +381,12 @@ the distinction between participant-specific and participant-agnostic state.
 
 ### CM-09-001 through CM-09-004 Verification
 
-- `PROD_ONLY` Unit test: `VulnerabilityCase.redact(invitee_id)` returns a
+- `PROD_ONLY` MUST Unit test: `VulnerabilityCase.redact(invitee_id)` returns a
   `RedactedVulnerabilityCase` excluding report content, discussion, and
   participant details
-- `PROD_ONLY` Unit test: Two calls to `redact()` with different invitee IDs
+- `PROD_ONLY` MUST Unit test: Two calls to `redact()` with different invitee IDs
   return objects with distinct IDs
-- `PROD_ONLY` Unit test: Redacted case ID shares no substrings with the full
+- `PROD_ONLY` MUST Unit test: Redacted case ID shares no substrings with the full
   case ID
 
 ### CM-10-001 through CM-10-004 Verification

--- a/specs/case-management.md
+++ b/specs/case-management.md
@@ -46,7 +46,7 @@ the distinction between participant-specific and participant-agnostic state.
     `case_participants` and `vulnerability_reports` tracking
   - Handlers implementing `AddNoteToCase` MUST append the `as_NoteRef` to
     `VulnerabilityCase.notes`
-- `CM-02-008` MUST When a `VulnerabilityCase` is created from an originating
+- `CM-02-008` (MUST) When a `VulnerabilityCase` is created from an originating
   `VulnerabilityReport` Offer, the vendor (case recipient / owner) MUST be
   recorded as the initial primary participant
   - `VulnerabilityCase.attributed_to` MUST be set to the vendor/coordinator's
@@ -135,7 +135,7 @@ the distinction between participant-specific and participant-agnostic state.
   - CM-04-003 implements VP-11-002
   - CM-04-003 implements VP-14-001
   - CM-04-003 implements VP-14-002
-- `CM-04-004` MUST Handlers processing PXA state transitions (public disclosure,
+- `CM-04-004` (MUST) Handlers processing PXA state transitions (public disclosure,
   exploit publication, attack observation) MUST update `CaseStatus.pxa_state`
   - CM-04-004 implements VP-03-002
   - CM-04-004 implements VP-14-003
@@ -201,7 +201,7 @@ the distinction between participant-specific and participant-agnostic state.
   identifiers from different namespaces for the same vulnerability
   - **Rationale**: Multiple IDs from different namespaces may refer to the
     same underlying vulnerability (e.g., a CVE ID and a CERT/CC VU# ID)
-- `CM-05-010` MUST When a `VulnerabilityRecord` is a `CVERecord` (i.e., it
+- `CM-05-010` (MUST) When a `VulnerabilityRecord` is a `CVERecord` (i.e., it
   carries a CVE ID), its data MUST conform to the CVE JSON schema
   (<https://github.com/CVEProject/cve-schema>)
   - The `CVERecord` Pydantic model SHOULD reuse the CVE JSON schema

--- a/specs/ci-security.md
+++ b/specs/ci-security.md
@@ -11,7 +11,7 @@ Vultron project.
 
 ---
 
-## Action Version Pinning (MUST)
+## Action Version Pinning
 
 - `CI-SEC-01-001` All `uses:` references in `.github/workflows/*.yml` MUST
   be pinned to a specific commit SHA rather than a version tag or branch name
@@ -23,7 +23,7 @@ Vultron project.
   comment identifying the corresponding human-readable version tag
   (e.g., `# v4.1.0`) to aid maintainability
 
-## Secrets Management (MUST)
+## Secrets Management
 
 - `CI-SEC-02-001` Workflow secrets and tokens MUST be stored in GitHub
   Secrets and MUST NOT appear in repository files
@@ -31,7 +31,7 @@ Vultron project.
   explicitly via `permissions:` at the job or workflow level
   - Workflows MUST NOT use `permissions: write-all`
 
-## Automated Pin Verification (SHOULD)
+## Automated Pin Verification
 
 - `CI-SEC-01-003` A CI verification test SHOULD confirm that all `uses:`
   lines in `.github/workflows/*.yml` reference a SHA hash rather than a
@@ -41,13 +41,13 @@ Vultron project.
     workflow YAML files) so it can run in the same CI environment as other
     project tests
 
-## Artifact Integrity (MUST)
+## Artifact Integrity
 
-- `CI-SEC-03-001` CI workflows that download third-party artifacts or tools
+- `CI-SEC-03-001` MUST CI workflows that download third-party artifacts or tools
   MUST verify signatures or checksums before using them
   - **Rationale**: Prevents supply-chain attacks via compromised artifacts
 
-## Maintenance (SHOULD)
+## Maintenance
 
 - `CI-SEC-04-001` SHA pins SHOULD be reviewed and updated on a documented
   periodic cadence, at minimum when a security advisory is issued for the
@@ -56,5 +56,5 @@ Vultron project.
     as the primary mechanism for keeping SHA pins current; the periodic
     manual review cadence is then a secondary backstop for cases Dependabot
     does not cover
-- `CI-SEC-04-002` When adding a new workflow step or action, the SHA pin and
+- `CI-SEC-04-002` MUST When adding a new workflow step or action, the SHA pin and
   version annotation MUST be included before the step is merged to `main`

--- a/specs/ci-security.md
+++ b/specs/ci-security.md
@@ -43,7 +43,7 @@ Vultron project.
 
 ## Artifact Integrity
 
-- `CI-SEC-03-001` MUST CI workflows that download third-party artifacts or tools
+- `CI-SEC-03-001` (MUST) CI workflows that download third-party artifacts or tools
   MUST verify signatures or checksums before using them
   - **Rationale**: Prevents supply-chain attacks via compromised artifacts
 
@@ -56,5 +56,5 @@ Vultron project.
     as the primary mechanism for keeping SHA pins current; the periodic
     manual review cadence is then a secondary backstop for cases Dependabot
     does not cover
-- `CI-SEC-04-002` MUST When adding a new workflow step or action, the SHA pin and
+- `CI-SEC-04-002` (MUST) When adding a new workflow step or action, the SHA pin and
   version annotation MUST be included before the step is merged to `main`

--- a/specs/code-style.md
+++ b/specs/code-style.md
@@ -90,10 +90,10 @@ def extract_id_segment(url: str) -> str:
 
 - `CS-03-001` Wildcard imports (e.g., `from module import *`) MUST NOT be used
 - `CS-03-002` Unused imports MUST be removed
-- `CS-03-003` MUST When importing more than 10 items from a module, import the module itself instead
+- `CS-03-003` (MUST) When importing more than 10 items from a module, import the module itself instead
   - Access attributes as `module.attribute` for maintainability
   - **Rationale**: Reduces line noise and makes module boundaries clearer
-- `CS-03-004` SHOULD NOT In test modules, avoid multiple imports from the module under test; consider importing the module and using attribute access for clarity.
+- `CS-03-004` (SHOULD NOT) In test modules, avoid multiple imports from the module under test; consider importing the module and using attribute access for clarity.
   - Shorthand aliases are acceptable in test modules where the context is clear (e.g., `import my_module as mm` in `test_my_module.py`)
 
 ## Circular Import Prevention
@@ -105,7 +105,7 @@ def extract_id_segment(url: str) -> str:
     no longer exist as top-level modules; their contents were relocated to
     `vultron/wire/as2/extractor.py` and `vultron/core/use_cases/use_case_map.py`
     as part of the hexagonal architecture refactoring (ARCH-CLEANUP-1)
-- `CS-05-002` SHOULD When circular dependencies cannot be resolved by reorganization,
+- `CS-05-002` (SHOULD) When circular dependencies cannot be resolved by reorganization,
   use lazy initialization patterns as a **last resort**
   - Prefer module-level imports; local imports are a code smell indicating a
     circular dependency that SHOULD be refactored
@@ -115,7 +115,7 @@ def extract_id_segment(url: str) -> str:
   - Use caching to avoid repeated initialization overhead
 - `CS-05-003` Shared types and errors SHALL be placed in neutral modules
   - Example: `types.py` for shared type definitions, `dispatcher_errors.py` for dispatcher errors
-- `CS-05-004` MUST Before adding imports between modules, trace the import chain to prevent cycles
+- `CS-05-004` (MUST) Before adding imports between modules, trace the import chain to prevent cycles
 
 **Verification**: Run `python -c "import vultron.MODULE_NAME"` to detect circular imports early
 
@@ -125,17 +125,17 @@ def extract_id_segment(url: str) -> str:
 
 ## Module Size
 
-- `CS-06-001` SHOULD Prefer modules that are < ~400 lines; split large modules by
+- `CS-06-001` (SHOULD) Prefer modules that are < ~400 lines; split large modules by
   responsibility and avoid single-file catchalls
   - E.g., separate handlers registry, handler implementations, and handler
     utilities into distinct modules
 
 ## `as_` Field Prefix Policy
 
-- `CS-07-001` MUST NOT use the `as_` prefix on Pydantic **field names**
+- `CS-07-001` (MUST NOT) use the `as_` prefix on Pydantic **field names**
   anywhere in the codebase. Class names (e.g., `as_Activity`, `as_Object`)
   retain the `as_` prefix as an ActivityStreams provenance marker.
-- `CS-07-002` MUST For fields whose plain name collides with a Python builtin or
+- `CS-07-002` (MUST) For fields whose plain name collides with a Python builtin or
   reserved word (e.g., `object`, `type`, `id`, `context`), use a trailing
   underscore: `object_`, `type_`, `id_`, `context_`
   - Define a Pydantic field alias so that serialized JSON uses the clean
@@ -148,7 +148,7 @@ def extract_id_segment(url: str) -> str:
   - **Rationale**: Trailing underscore + alias is the idiomatic Python
     pattern (PEP 8) for builtin/reserved-word field names. It keeps models
     readable and decoupled from AS2 naming conventions across all layers.
-- `CS-07-003` MUST Do not introduce new `as_`-prefixed field names anywhere.
+- `CS-07-003` (MUST) Do not introduce new `as_`-prefixed field names anywhere.
   The migration of existing `as_`-prefixed field names was completed in
   NAMING-1 (2026-03-30). All wire-layer and core-layer field names now use
   the trailing-underscore convention where needed. Class names retain `as_`.
@@ -298,7 +298,7 @@ def extract_id_segment(url: str) -> str:
 
 ## Wire Model Configuration
 
-- `CS-14-001` MUST Wire-layer Pydantic models (classes in
+- `CS-14-001` (MUST) Wire-layer Pydantic models (classes in
   `vultron/wire/as2/vocab/`) MUST inherit `model_config` from `as_Base`,
   which sets `alias_generator=to_camel`, `validate_by_name=True`, and
   `validate_by_alias=True`
@@ -308,7 +308,7 @@ def extract_id_segment(url: str) -> str:
     declarations
   - Subclasses that override `model_config` MUST extend the parent config
     to preserve these settings; see `specs/vocabulary-model.md` VM-02-001
-- `CS-14-002` MUST Core/domain-layer Pydantic models (classes in
+- `CS-14-002` (MUST) Core/domain-layer Pydantic models (classes in
   `vultron/core/models/`) MUST set `populate_by_name=True` in their
   `model_config`
   - This allows field access using both the Python field name and the

--- a/specs/code-style.md
+++ b/specs/code-style.md
@@ -93,7 +93,7 @@ def extract_id_segment(url: str) -> str:
 - `CS-03-003` (MUST) When importing more than 10 items from a module, import the module itself instead
   - Access attributes as `module.attribute` for maintainability
   - **Rationale**: Reduces line noise and makes module boundaries clearer
-- `CS-03-004` (SHOULD NOT) In test modules, avoid multiple imports from the module under test; consider importing the module and using attribute access for clarity.
+- `CS-03-004` (SHOULD) In test modules, avoid multiple imports from the module under test; consider importing the module and using attribute access for clarity.
   - Shorthand aliases are acceptable in test modules where the context is clear (e.g., `import my_module as mm` in `test_my_module.py`)
 
 ## Circular Import Prevention

--- a/specs/code-style.md
+++ b/specs/code-style.md
@@ -9,7 +9,7 @@ Defines code formatting and import organization standards for Python code.
 
 ---
 
-## Code Formatting (MUST)
+## Code Formatting
 
 - `CS-01-001` Code MUST follow PEP 8 style guidelines
   - **Implementation**: Black formatter MUST be used for consistency
@@ -28,7 +28,7 @@ Defines code formatting and import organization standards for Python code.
   - **Rationale**: The codebase is known-clean; maintaining zero-warning
     status is required to preserve that baseline
 
-## Docstring Standards (SHOULD)
+## Docstring Standards
 
 - `CS-01-004` Functions and methods SHOULD have docstrings following PEP 257
   conventions
@@ -75,7 +75,7 @@ def extract_id_segment(url: str) -> str:
   appropriate
 - Use descriptive variable and function names for readability
 
-## Import Organization (SHOULD)
+## Import Organization
 
 - `CS-02-001` Imports SHOULD be organized in three groups: standard library, third-party libraries, local application
   - Each group separated by a single blank line
@@ -86,17 +86,17 @@ def extract_id_segment(url: str) -> str:
     test discovery harder, obscures dependencies, and complicates refactoring.
 - `CS-02-003` Multi-line import statements SHOULD use parentheses for readability
 
-## Import Practices (MUST)
+## Import Practices
 
 - `CS-03-001` Wildcard imports (e.g., `from module import *`) MUST NOT be used
 - `CS-03-002` Unused imports MUST be removed
-- `CS-03-003` When importing more than 10 items from a module, import the module itself instead
+- `CS-03-003` MUST When importing more than 10 items from a module, import the module itself instead
   - Access attributes as `module.attribute` for maintainability
   - **Rationale**: Reduces line noise and makes module boundaries clearer
-- `CS-03-004` In test modules, avoid multiple imports from the module under test; consider importing the module and using attribute access for clarity.
+- `CS-03-004` SHOULD NOT In test modules, avoid multiple imports from the module under test; consider importing the module and using attribute access for clarity.
   - Shorthand aliases are acceptable in test modules where the context is clear (e.g., `import my_module as mm` in `test_my_module.py`)
 
-## Circular Import Prevention (MUST)
+## Circular Import Prevention
 
 - `CS-05-001` Core modules SHALL NOT import from application layer modules
   - Core modules: `vultron/core/`, `vultron/wire/`
@@ -105,7 +105,7 @@ def extract_id_segment(url: str) -> str:
     no longer exist as top-level modules; their contents were relocated to
     `vultron/wire/as2/extractor.py` and `vultron/core/use_cases/use_case_map.py`
     as part of the hexagonal architecture refactoring (ARCH-CLEANUP-1)
-- `CS-05-002` When circular dependencies cannot be resolved by reorganization,
+- `CS-05-002` SHOULD When circular dependencies cannot be resolved by reorganization,
   use lazy initialization patterns as a **last resort**
   - Prefer module-level imports; local imports are a code smell indicating a
     circular dependency that SHOULD be refactored
@@ -115,35 +115,29 @@ def extract_id_segment(url: str) -> str:
   - Use caching to avoid repeated initialization overhead
 - `CS-05-003` Shared types and errors SHALL be placed in neutral modules
   - Example: `types.py` for shared type definitions, `dispatcher_errors.py` for dispatcher errors
-- `CS-05-004` Before adding imports between modules, trace the import chain to prevent cycles
+- `CS-05-004` MUST Before adding imports between modules, trace the import chain to prevent cycles
 
 **Verification**: Run `python -c "import vultron.MODULE_NAME"` to detect circular imports early
-
-## Import Practices (MAY)
 
 - `CS-04-001` Relative imports MAY be used for local application imports when appropriate
 - `CS-04-002` Module imports MAY use aliases for clarity or to avoid naming conflicts
   - Aliases SHOULD be descriptive and widely recognized (e.g., `import numpy as np`)
 
-## Module Size (SHOULD)
+## Module Size
 
-- `CS-06-001` Prefer modules that are < ~400 lines; split large modules by
+- `CS-06-001` SHOULD Prefer modules that are < ~400 lines; split large modules by
   responsibility and avoid single-file catchalls
   - E.g., separate handlers registry, handler implementations, and handler
     utilities into distinct modules
 
-## `as_` Field Prefix Policy (SHOULD)
+## `as_` Field Prefix Policy
 
-- `CS-07-001` Use the `as_` prefix on Pydantic fields **only in the wire layer**
-  (`vultron/wire/as2/vocab/`) where it is part of the established AS2
-  vocabulary convention
-- `CS-07-002` In **core** (`vultron/core/`) domain model classes, do NOT use
-  the `as_` prefix
-  - The `as_` prefix on core fields is a relic of the original wire/core
-    blending and SHOULD be removed as core models are refactored
-  - For fields whose plain name collides with a Python reserved word (e.g.,
-    `object`, `type`, `id`), use a trailing underscore: `object_`, `type_`,
-    `id_`
+- `CS-07-001` MUST NOT use the `as_` prefix on Pydantic **field names**
+  anywhere in the codebase. Class names (e.g., `as_Activity`, `as_Object`)
+  retain the `as_` prefix as an ActivityStreams provenance marker.
+- `CS-07-002` MUST For fields whose plain name collides with a Python builtin or
+  reserved word (e.g., `object`, `type`, `id`, `context`), use a trailing
+  underscore: `object_`, `type_`, `id_`, `context_`
   - Define a Pydantic field alias so that serialized JSON uses the clean
     name without the trailing underscore:
 
@@ -151,27 +145,15 @@ def extract_id_segment(url: str) -> str:
     object_: str = Field(alias="object")
     ```
 
-  - **Rationale**: The `as_` prefix leaks wire-format concerns into the
-    domain layer. Trailing underscore + alias is the idiomatic Python pattern
-    for reserved-word field names; it keeps core models readable and decoupled
-    from AS2 naming conventions.
-- `CS-07-003` In the wire layer, field names that conflict with Python reserved
-  keywords MUST use trailing-underscore convention (e.g., `object_`, `type_`)
-  rather than the `as_`-prefix convention for **new code**. The `as_` prefix
-  is retained for **class names** (e.g., `as_Activity`, `as_Object`) where it
-  helpfully signals ActivityStreams provenance, but MUST NOT be applied to
-  field names.
-  - **Note:** This is a forward-looking standard for new wire-layer code.
-    Existing `as_`-prefixed field names in the wire layer will be migrated in a
-    separate task (see `plan/IMPLEMENTATION_PLAN.md` NAMING-1). Do not
-    introduce new `as_`-prefixed field names in the wire layer; use the
-    trailing-underscore convention instead.
-  - **Rationale:** Unifying field naming across all layers on trailing-underscore
-    removes the confusion between `as_object` (wire) and `object_` (core) for
-    the same concept. Class names retain `as_` because it is unambiguous — a
-    class name does not collide with Python keywords.
+  - **Rationale**: Trailing underscore + alias is the idiomatic Python
+    pattern (PEP 8) for builtin/reserved-word field names. It keeps models
+    readable and decoupled from AS2 naming conventions across all layers.
+- `CS-07-003` MUST Do not introduce new `as_`-prefixed field names anywhere.
+  The migration of existing `as_`-prefixed field names was completed in
+  NAMING-1 (2026-03-30). All wire-layer and core-layer field names now use
+  the trailing-underscore convention where needed. Class names retain `as_`.
 
-## Optional Field Non-Emptiness (MUST)
+## Optional Field Non-Emptiness
 
 - `CS-08-001` Optional string fields MUST NOT contain empty strings when
   present; the invariant is "if present, then non-empty"
@@ -198,7 +180,7 @@ def extract_id_segment(url: str) -> str:
     constraints
   - CS-08-002 refines CS-08-001
 
-## Code Reuse (SHOULD)
+## Code Reuse
 
 - `CS-09-001` New code SHOULD NOT duplicate logic already present elsewhere;
   prefer extracting shared logic into reusable helpers, base classes, or type
@@ -218,7 +200,7 @@ def extract_id_segment(url: str) -> str:
   - **Rationale**: Duplicated models diverge silently over time; a hierarchy
     makes the relationship explicit and reduces boilerplate
 
-## Port and Adapter Data Exchange (MUST)
+## Port and Adapter Data Exchange
 
 - `CS-10-001` Data passed across port/adapter boundaries MUST use Pydantic
   `BaseModel`-derived classes rather than plain `dict`s
@@ -230,7 +212,7 @@ def extract_id_segment(url: str) -> str:
     validation, and make interfaces ambiguous. Pydantic models preserve
     validation, IDE support, and documentation at every layer crossing.
 
-## Domain Event and Wire Activity Naming (SHOULD)
+## Domain Event and Wire Activity Naming
 
 - `CS-10-002` Wire-level ActivityStreams payload classes SHOULD carry the
   `Activity` suffix; domain event classes SHOULD carry the `Event` suffix
@@ -249,7 +231,7 @@ def extract_id_segment(url: str) -> str:
     point explicit. See `notes/domain-model-separation.md` for the full
     design rationale.
 
-## Type Annotations (MUST)
+## Type Annotations
 
 - `CS-11-001` Code MUST NOT use `Any` in type hints when the type can be
   determined
@@ -262,7 +244,7 @@ def extract_id_segment(url: str) -> str:
   - **Rationale**: `Any` defeats static type checking, obscures API
     contracts, and hides bugs at the boundary between typed and untyped code
 
-## Domain Model Naming (SHOULD)
+## Domain Model Naming
 
 - `CS-12-001` Core domain model class names SHOULD reflect the domain concept
   they represent, not a parallel to a wire-format class name
@@ -278,7 +260,7 @@ def extract_id_segment(url: str) -> str:
     classes when they are refactored; do not rename existing classes
     incidentally while working on unrelated changes
 
-## Datetime and Timezone Conventions (MUST)
+## Datetime and Timezone Conventions
 
 - `CS-13-001` All datetime values produced by the application MUST be
   timezone-aware and MUST use UTC
@@ -314,9 +296,9 @@ def extract_id_segment(url: str) -> str:
   - Pydantic serializes timezone-aware `datetime` objects to ISO 8601 by
     default; no custom serializer is needed as long as CS-13-001 is followed
 
-## Wire Model Configuration (MUST)
+## Wire Model Configuration
 
-- `CS-14-001` Wire-layer Pydantic models (classes in
+- `CS-14-001` MUST Wire-layer Pydantic models (classes in
   `vultron/wire/as2/vocab/`) MUST inherit `model_config` from `as_Base`,
   which sets `alias_generator=to_camel`, `validate_by_name=True`, and
   `validate_by_alias=True`
@@ -326,7 +308,7 @@ def extract_id_segment(url: str) -> str:
     declarations
   - Subclasses that override `model_config` MUST extend the parent config
     to preserve these settings; see `specs/vocabulary-model.md` VM-02-001
-- `CS-14-002` Core/domain-layer Pydantic models (classes in
+- `CS-14-002` MUST Core/domain-layer Pydantic models (classes in
   `vultron/core/models/`) MUST set `populate_by_name=True` in their
   `model_config`
   - This allows field access using both the Python field name and the
@@ -342,7 +324,7 @@ def extract_id_segment(url: str) -> str:
   - Example: `semantic_type: Literal[MessageSemantics.CREATE_CASE] = MessageSemantics.CREATE_CASE`
   - CS-14-003 refines CS-10-002
 
-## Use Case Naming (SHOULD)
+## Use Case Naming
 
 - `CS-12-002` Use case class names SHOULD carry a suffix that reflects their
   origin (received message vs. local trigger):

--- a/specs/demo-cli.md
+++ b/specs/demo-cli.md
@@ -33,7 +33,7 @@ CLI structure, demo isolation, Docker packaging, and test requirements.
 
 ## Demo Utilities
 
-- `DC-02-001` MUST Shared demo utilities (`demo_step`, `demo_check` context
+- `DC-02-001` (MUST) Shared demo utilities (`demo_step`, `demo_check` context
   managers and HTTP client helpers) MUST be extracted to `vultron/demo/utils.py`
   - All demo scripts MUST import from `vultron.demo.utils`
   - No demo script MAY define its own copy of `demo_step`, `demo_check`, or
@@ -62,7 +62,7 @@ CLI structure, demo isolation, Docker packaging, and test requirements.
   container runs interactively and prompts the user to select a demo
   - When the `DEMO` environment variable is set, the container MUST run the
     named sub-command non-interactively and exit
-- `DC-04-003` MUST Individual per-demo Docker services (one service per demo
+- `DC-04-003` (MUST) Individual per-demo Docker services (one service per demo
   script) MUST be removed from `docker-compose.yml` once the unified demo
   service is operational
 

--- a/specs/demo-cli.md
+++ b/specs/demo-cli.md
@@ -13,7 +13,7 @@ CLI structure, demo isolation, Docker packaging, and test requirements.
 
 ---
 
-## CLI Interface (MUST)
+## CLI Interface
 
 - `DC-01-001` The unified demo MUST be implemented as a `click`-based CLI
   script at `vultron/demo/cli.py`
@@ -31,9 +31,9 @@ CLI structure, demo isolation, Docker packaging, and test requirements.
 - `DC-01-005` Individual demo scripts MUST retain their existing
   `if __name__ == "__main__"` entry points so they remain directly invokable
 
-## Demo Utilities (MUST)
+## Demo Utilities
 
-- `DC-02-001` Shared demo utilities (`demo_step`, `demo_check` context
+- `DC-02-001` MUST Shared demo utilities (`demo_step`, `demo_check` context
   managers and HTTP client helpers) MUST be extracted to `vultron/demo/utils.py`
   - All demo scripts MUST import from `vultron.demo.utils`
   - No demo script MAY define its own copy of `demo_step`, `demo_check`, or
@@ -41,7 +41,7 @@ CLI structure, demo isolation, Docker packaging, and test requirements.
 - `DC-02-002` Demo scripts MUST be relocated to `vultron/demo/` and MUST be
   importable as `vultron.demo.<script_name>`
 
-## Demo Isolation (MUST)
+## Demo Isolation
 
 - `DC-03-001` Each demo MUST include setup and teardown logic that leaves the
   DataLayer in a clean state after the demo completes
@@ -52,7 +52,7 @@ CLI structure, demo isolation, Docker packaging, and test requirements.
 - `DC-03-003` The CLI MUST NOT assume a globally pre-initialized DataLayer;
   each demo invocation MUST create and clean up its own context
 
-## Docker Packaging (MUST)
+## Docker Packaging
 
 - `DC-04-001` The unified demo MUST be packaged as a Docker service
   (`demo` service in `docker/docker-compose.yml`)
@@ -62,11 +62,11 @@ CLI structure, demo isolation, Docker packaging, and test requirements.
   container runs interactively and prompts the user to select a demo
   - When the `DEMO` environment variable is set, the container MUST run the
     named sub-command non-interactively and exit
-- `DC-04-003` Individual per-demo Docker services (one service per demo
+- `DC-04-003` MUST Individual per-demo Docker services (one service per demo
   script) MUST be removed from `docker-compose.yml` once the unified demo
   service is operational
 
-## Unit Testing (MUST)
+## Unit Testing
 
 - `DC-05-001` The unified CLI MUST have unit tests in
   `test/demo/test_cli.py`
@@ -78,7 +78,7 @@ CLI structure, demo isolation, Docker packaging, and test requirements.
 - `DC-05-004` Unit tests for each sub-command MUST verify the sub-command
   invokes the correct underlying demo function
 
-## Integration Testing (SHOULD)
+## Integration Testing
 
 - `DC-06-001` An integration test script SHOULD exist at
   `integration_tests/demo/run_demo_integration_test.sh` (or equivalent

--- a/specs/diataxis-requirements.md
+++ b/specs/diataxis-requirements.md
@@ -21,7 +21,7 @@ Diátaxis framework.
 - `DF-01-002` (MUST) Ensure each documentation page maps to exactly one of
   the four user needs (Learning, Goals, Information, or Understanding).
   - Use front-matter or a classification tag to record the assigned quadrant.
-- `DF-01-003` (SHOULD NOT) Avoid combining multiple Diátaxis content types within a
+- `DF-01-003` (SHOULD NOT) Combine multiple Diátaxis content types within a
   single page or section; where a combined view is temporarily unavoidable,
   clearly separate the parts and link to full pages of the appropriate type.
 - `DF-01-004` (SHOULD) Use hyperlinks to connect related but distinct content

--- a/specs/diataxis-requirements.md
+++ b/specs/diataxis-requirements.md
@@ -10,129 +10,129 @@ Diátaxis framework.
 
 ---
 
-## General architecture (SHOULD)
+## General architecture
 
-- `DF-01-001` Organize the main documentation into the four Diátaxis
+- `DF-01-001` SHOULD Organize the main documentation into the four Diátaxis
   categories: Tutorials, How-to guides, Reference, and Explanation.
   - Preserve folders where practical: `docs/tutorials`, `docs/howto`,
     `docs/reference`, `docs/topics`.
   - If repository constraints prevent a strict four-way top-level layout,
     document the deviation and map each page to the nearest quadrant.
-- `DF-01-002` Ensure each documentation page maps to exactly one of
+- `DF-01-002` MUST Ensure each documentation page maps to exactly one of
   the four user needs (Learning, Goals, Information, or Understanding).
   - Use front-matter or a classification tag to record the assigned quadrant.
-- `DF-01-003` Avoid combining multiple Diátaxis content types within a
+- `DF-01-003` SHOULD NOT Avoid combining multiple Diátaxis content types within a
   single page or section; where a combined view is temporarily unavoidable,
   clearly separate the parts and link to full pages of the appropriate type.
-- `DF-01-004` Use hyperlinks to connect related but distinct content
+- `DF-01-004` SHOULD Use hyperlinks to connect related but distinct content
   types instead of embedding cross-type content.
-- `DF-01-005` Write documentation in Markdown and prepare it for the
+- `DF-01-005` SHOULD Write documentation in Markdown and prepare it for the
   MkDocs site defined by `mkdocs.yml`.
 
-## Documentation maintenance (SHOULD)
+## Documentation maintenance
 
-- `DF-02-001` Build the documentation architecture iteratively from the
+- `DF-02-001` SHOULD Build the documentation architecture iteratively from the
   inside-out by improving pages until their Diátaxis category is clear.
-- `DF-02-002` Maintain navigation structure to avoid link breakage when
+- `DF-02-002` SHOULD Maintain navigation structure to avoid link breakage when
   moving or renaming files.
   - Use `mkdocs-redirects` and run a link checker after moves.
 
-## Tutorials (MUST)
+## Tutorials
 
-- `DF-03-001` Author tutorials as practical lessons that help learners
+- `DF-03-001` MUST Author tutorials as practical lessons that help learners
   acquire new skills through guided, hands-on experience.
-- `DF-03-002` Require that each tutorial is an activity where the learner
+- `DF-03-002` MUST Require that each tutorial is an activity where the learner
   learns by doing.
-- `DF-03-003` Ensure tutorials produce visible results early and often
+- `DF-03-003` MUST Ensure tutorials produce visible results early and often
   to maintain learner confidence.
-- `DF-03-004` Use first-person plural ("we") in the tutorial narrative to
+- `DF-03-004` MUST Use first-person plural ("we") in the tutorial narrative to
   establish tutor/learner rapport.
-- `DF-03-005` Forbid alternative learning paths within a single
+- `DF-03-005` MUST NOT Forbid alternative learning paths within a single
   tutorial's primary flow; present a single prescribed learning path.
-- `DF-03-006` Exclude in-depth explanations and theoretical discussions
+- `DF-03-006` MUST NOT Exclude in-depth explanations and theoretical discussions
   from the body of tutorials; link to explanatory pages for background.
-- `DF-03-007` Require every tutorial step to produce a comprehensible
+- `DF-03-007` MUST Require every tutorial step to produce a comprehensible
   result that gives immediate feedback.
-- `DF-03-008` State at the start of each tutorial exactly what the learner
+- `DF-03-008` MUST State at the start of each tutorial exactly what the learner
   will have accomplished.
-- `DF-03-009` Point out specific signs or changes the learner should
+- `DF-03-009` MUST Point out specific signs or changes the learner should
   notice during the tutorial.
 - `DF-03-010` SHOULD provide explicit links to the related Reference and
   Explanation pages (prerequisites, background, deeper rationale). Keep these
   resources out of the tutorial body.
 
-## How-to guides (MUST)
+## How-to guides
 
-- `DF-04-001` Present how-to guides as goal-oriented directions that
+- `DF-04-001` MUST Present how-to guides as goal-oriented directions that
   resolve a specific real-world task or problem.
-- `DF-04-002` Assume the reader is a competent user with required basic
+- `DF-04-002` MUST Assume the reader is a competent user with required basic
   skills; surface prerequisites explicitly rather than embedding lessons.
-- `DF-04-003` Require how-to titles to state exactly what the guide shows
+- `DF-04-003` MUST Require how-to titles to state exactly what the guide shows
   the user how to do (e.g., start with "How to ...").
-- `DF-04-004` Use conditional imperatives (e.g., "If you want X, do Y")
+- `DF-04-004` MUST Use conditional imperatives (e.g., "If you want X, do Y")
   when appropriate.
-- `DF-04-005` Exclude pedagogical teaching, background history, and
+- `DF-04-005` MUST NOT Exclude pedagogical teaching, background history, and
   extended lessons from how-to bodies.
-- `DF-04-006` Prefer concise branching ("if this, then that") to prepare
+- `DF-04-006` SHOULD Prefer concise branching ("if this, then that") to prepare
   users for real-world complexity.
-- `DF-04-007` Omit unnecessary steps that do not contribute directly to
+- `DF-04-007` MUST Omit unnecessary steps that do not contribute directly to
   the specified goal.
 - `DF-04-008` SHOULD provide a short "Prerequisites" or "Starting points"
   section (or link to one) that handles different starting states and messy
   real-world setups instead of embedding multiple alternative flows.
 
-## Reference (MUST)
+## Reference
 
-- `DF-05-001` Produce reference material that is neutral, objective, and
+- `DF-05-001` MUST Produce reference material that is neutral, objective, and
   technical in tone.
-- `DF-05-002` Structure reference content to mirror the physical or
+- `DF-05-002` MUST Structure reference content to mirror the physical or
   logical architecture of the system or code being described.
-- `DF-05-003` Keep reference content dry and free from instruction,
+- `DF-05-003` MUST Keep reference content dry and free from instruction,
   discussion, or opinion.
-- `DF-05-004` State facts about behaviors, commands, parameters, versions,
+- `DF-05-004` MUST State facts about behaviors, commands, parameters, versions,
   and limitations.
-- `DF-05-005` Use consistent, standard patterns and formatting in
+- `DF-05-005` MUST Use consistent, standard patterns and formatting in
   reference documents to make information easy to find.
-- `DF-05-006` Allow brief code examples in reference material only to
+- `DF-05-006` MAY Allow brief code examples in reference material only to
   illustrate usage, not to provide step-by-step instruction.
 
-## Explanation (MUST)
+## Explanation
 
-- `DF-06-001` Provide explanatory material that focuses on understanding
+- `DF-06-001` MUST Provide explanatory material that focuses on understanding
   and context for a topic.
-- `DF-06-002` Address "Why?" questions by discussing history, design
+- `DF-06-002` MUST Address "Why?" questions by discussing history, design
   decisions, or technical constraints.
-- `DF-06-003` Permit opinion, perspective, and weighing of approaches in
+- `DF-06-003` MAY Permit opinion, perspective, and weighing of approaches in
   explanatory documents.
-- `DF-06-004` Exclude practical instructions and dry technical descriptions
+- `DF-06-004` MUST NOT Exclude practical instructions and dry technical descriptions
   that belong in Tutorials, How-to, or Reference.
-- `DF-06-005` Prefer titles that can be read as "About X" for explanatory
+- `DF-06-005` SHOULD Prefer titles that can be read as "About X" for explanatory
   topics.
-- `DF-06-006` Weave connections to related topics to build a web of
+- `DF-06-006` MUST Weave connections to related topics to build a web of
   understanding.
 
-## Verification and checks (SHOULD)
+## Verification and checks
 
-- `DF-07-001` Verify the top-level navigation contains the four
+- `DF-07-001` SHOULD Verify the top-level navigation contains the four
   Diátaxis categories where practical; if the site does not expose four
   primary sections, require a documented rationale and a mapping of pages to
   quadrants.
-- `DF-07-002` Use a classification check (e.g., the "Diátaxis Compass")
+- `DF-07-002` MUST Use a classification check (e.g., the "Diátaxis Compass")
   to confirm each page maps to a single category. The Compass MUST be used in
   periodic reviews.
-- `DF-07-003` Confirm tutorials use first-person plural ("we") and do
+- `DF-07-003` SHOULD Confirm tutorials use first-person plural ("we") and do
   not contain alternative paths or optional branches within the primary flow.
-- `DF-07-004` Confirm how-to guide titles start with "How to" and contain
+- `DF-07-004` SHOULD Confirm how-to guide titles start with "How to" and contain
   no lessons in their bodies; check for an explicit "Prerequisites" link when
   multiple starting points exist.
-- `DF-07-005` Validate reference sections by comparing the documentation
+- `DF-07-005` SHOULD Validate reference sections by comparing the documentation
   tree to the source tree where appropriate.
-- `DF-07-006` Validate explanatory pages by confirming they remain useful
+- `DF-07-006` SHOULD Validate explanatory pages by confirming they remain useful
   when read away from the running product.
 
-## File metadata (SHOULD)
+## File metadata
 
-- `DF-08-001` Name Diátaxis specification files using snake_case and
+- `DF-08-001` SHOULD Name Diátaxis specification files using snake_case and
   concise topic descriptors.
-- `DF-08-002` Place cross-reference sources only in the header metadata
+- `DF-08-002` SHOULD Place cross-reference sources only in the header metadata
   and use inline links for cross-spec references.

--- a/specs/diataxis-requirements.md
+++ b/specs/diataxis-requirements.md
@@ -12,127 +12,127 @@ Diátaxis framework.
 
 ## General architecture
 
-- `DF-01-001` SHOULD Organize the main documentation into the four Diátaxis
+- `DF-01-001` (SHOULD) Organize the main documentation into the four Diátaxis
   categories: Tutorials, How-to guides, Reference, and Explanation.
   - Preserve folders where practical: `docs/tutorials`, `docs/howto`,
     `docs/reference`, `docs/topics`.
   - If repository constraints prevent a strict four-way top-level layout,
     document the deviation and map each page to the nearest quadrant.
-- `DF-01-002` MUST Ensure each documentation page maps to exactly one of
+- `DF-01-002` (MUST) Ensure each documentation page maps to exactly one of
   the four user needs (Learning, Goals, Information, or Understanding).
   - Use front-matter or a classification tag to record the assigned quadrant.
-- `DF-01-003` SHOULD NOT Avoid combining multiple Diátaxis content types within a
+- `DF-01-003` (SHOULD NOT) Avoid combining multiple Diátaxis content types within a
   single page or section; where a combined view is temporarily unavoidable,
   clearly separate the parts and link to full pages of the appropriate type.
-- `DF-01-004` SHOULD Use hyperlinks to connect related but distinct content
+- `DF-01-004` (SHOULD) Use hyperlinks to connect related but distinct content
   types instead of embedding cross-type content.
-- `DF-01-005` SHOULD Write documentation in Markdown and prepare it for the
+- `DF-01-005` (SHOULD) Write documentation in Markdown and prepare it for the
   MkDocs site defined by `mkdocs.yml`.
 
 ## Documentation maintenance
 
-- `DF-02-001` SHOULD Build the documentation architecture iteratively from the
+- `DF-02-001` (SHOULD) Build the documentation architecture iteratively from the
   inside-out by improving pages until their Diátaxis category is clear.
-- `DF-02-002` SHOULD Maintain navigation structure to avoid link breakage when
+- `DF-02-002` (SHOULD) Maintain navigation structure to avoid link breakage when
   moving or renaming files.
   - Use `mkdocs-redirects` and run a link checker after moves.
 
 ## Tutorials
 
-- `DF-03-001` MUST Author tutorials as practical lessons that help learners
+- `DF-03-001` (MUST) Author tutorials as practical lessons that help learners
   acquire new skills through guided, hands-on experience.
-- `DF-03-002` MUST Require that each tutorial is an activity where the learner
+- `DF-03-002` (MUST) Require that each tutorial is an activity where the learner
   learns by doing.
-- `DF-03-003` MUST Ensure tutorials produce visible results early and often
+- `DF-03-003` (MUST) Ensure tutorials produce visible results early and often
   to maintain learner confidence.
-- `DF-03-004` MUST Use first-person plural ("we") in the tutorial narrative to
+- `DF-03-004` (MUST) Use first-person plural ("we") in the tutorial narrative to
   establish tutor/learner rapport.
-- `DF-03-005` MUST NOT Forbid alternative learning paths within a single
+- `DF-03-005` (MUST NOT) Forbid alternative learning paths within a single
   tutorial's primary flow; present a single prescribed learning path.
-- `DF-03-006` MUST NOT Exclude in-depth explanations and theoretical discussions
+- `DF-03-006` (MUST NOT) Exclude in-depth explanations and theoretical discussions
   from the body of tutorials; link to explanatory pages for background.
-- `DF-03-007` MUST Require every tutorial step to produce a comprehensible
+- `DF-03-007` (MUST) Require every tutorial step to produce a comprehensible
   result that gives immediate feedback.
-- `DF-03-008` MUST State at the start of each tutorial exactly what the learner
+- `DF-03-008` (MUST) State at the start of each tutorial exactly what the learner
   will have accomplished.
-- `DF-03-009` MUST Point out specific signs or changes the learner should
+- `DF-03-009` (MUST) Point out specific signs or changes the learner should
   notice during the tutorial.
-- `DF-03-010` SHOULD provide explicit links to the related Reference and
+- `DF-03-010` (SHOULD) provide explicit links to the related Reference and
   Explanation pages (prerequisites, background, deeper rationale). Keep these
   resources out of the tutorial body.
 
 ## How-to guides
 
-- `DF-04-001` MUST Present how-to guides as goal-oriented directions that
+- `DF-04-001` (MUST) Present how-to guides as goal-oriented directions that
   resolve a specific real-world task or problem.
-- `DF-04-002` MUST Assume the reader is a competent user with required basic
+- `DF-04-002` (MUST) Assume the reader is a competent user with required basic
   skills; surface prerequisites explicitly rather than embedding lessons.
-- `DF-04-003` MUST Require how-to titles to state exactly what the guide shows
+- `DF-04-003` (MUST) Require how-to titles to state exactly what the guide shows
   the user how to do (e.g., start with "How to ...").
-- `DF-04-004` MUST Use conditional imperatives (e.g., "If you want X, do Y")
+- `DF-04-004` (MUST) Use conditional imperatives (e.g., "If you want X, do Y")
   when appropriate.
-- `DF-04-005` MUST NOT Exclude pedagogical teaching, background history, and
+- `DF-04-005` (MUST NOT) Exclude pedagogical teaching, background history, and
   extended lessons from how-to bodies.
-- `DF-04-006` SHOULD Prefer concise branching ("if this, then that") to prepare
+- `DF-04-006` (SHOULD) Prefer concise branching ("if this, then that") to prepare
   users for real-world complexity.
-- `DF-04-007` MUST Omit unnecessary steps that do not contribute directly to
+- `DF-04-007` (MUST) Omit unnecessary steps that do not contribute directly to
   the specified goal.
-- `DF-04-008` SHOULD provide a short "Prerequisites" or "Starting points"
+- `DF-04-008` (SHOULD) provide a short "Prerequisites" or "Starting points"
   section (or link to one) that handles different starting states and messy
   real-world setups instead of embedding multiple alternative flows.
 
 ## Reference
 
-- `DF-05-001` MUST Produce reference material that is neutral, objective, and
+- `DF-05-001` (MUST) Produce reference material that is neutral, objective, and
   technical in tone.
-- `DF-05-002` MUST Structure reference content to mirror the physical or
+- `DF-05-002` (MUST) Structure reference content to mirror the physical or
   logical architecture of the system or code being described.
-- `DF-05-003` MUST Keep reference content dry and free from instruction,
+- `DF-05-003` (MUST) Keep reference content dry and free from instruction,
   discussion, or opinion.
-- `DF-05-004` MUST State facts about behaviors, commands, parameters, versions,
+- `DF-05-004` (MUST) State facts about behaviors, commands, parameters, versions,
   and limitations.
-- `DF-05-005` MUST Use consistent, standard patterns and formatting in
+- `DF-05-005` (MUST) Use consistent, standard patterns and formatting in
   reference documents to make information easy to find.
-- `DF-05-006` MAY Allow brief code examples in reference material only to
+- `DF-05-006` (MAY) Allow brief code examples in reference material only to
   illustrate usage, not to provide step-by-step instruction.
 
 ## Explanation
 
-- `DF-06-001` MUST Provide explanatory material that focuses on understanding
+- `DF-06-001` (MUST) Provide explanatory material that focuses on understanding
   and context for a topic.
-- `DF-06-002` MUST Address "Why?" questions by discussing history, design
+- `DF-06-002` (MUST) Address "Why?" questions by discussing history, design
   decisions, or technical constraints.
-- `DF-06-003` MAY Permit opinion, perspective, and weighing of approaches in
+- `DF-06-003` (MAY) Permit opinion, perspective, and weighing of approaches in
   explanatory documents.
-- `DF-06-004` MUST NOT Exclude practical instructions and dry technical descriptions
+- `DF-06-004` (MUST NOT) Exclude practical instructions and dry technical descriptions
   that belong in Tutorials, How-to, or Reference.
-- `DF-06-005` SHOULD Prefer titles that can be read as "About X" for explanatory
+- `DF-06-005` (SHOULD) Prefer titles that can be read as "About X" for explanatory
   topics.
-- `DF-06-006` MUST Weave connections to related topics to build a web of
+- `DF-06-006` (MUST) Weave connections to related topics to build a web of
   understanding.
 
 ## Verification and checks
 
-- `DF-07-001` SHOULD Verify the top-level navigation contains the four
+- `DF-07-001` (SHOULD) Verify the top-level navigation contains the four
   Diátaxis categories where practical; if the site does not expose four
   primary sections, require a documented rationale and a mapping of pages to
   quadrants.
-- `DF-07-002` MUST Use a classification check (e.g., the "Diátaxis Compass")
+- `DF-07-002` (MUST) Use a classification check (e.g., the "Diátaxis Compass")
   to confirm each page maps to a single category. The Compass MUST be used in
   periodic reviews.
-- `DF-07-003` SHOULD Confirm tutorials use first-person plural ("we") and do
+- `DF-07-003` (SHOULD) Confirm tutorials use first-person plural ("we") and do
   not contain alternative paths or optional branches within the primary flow.
-- `DF-07-004` SHOULD Confirm how-to guide titles start with "How to" and contain
+- `DF-07-004` (SHOULD) Confirm how-to guide titles start with "How to" and contain
   no lessons in their bodies; check for an explicit "Prerequisites" link when
   multiple starting points exist.
-- `DF-07-005` SHOULD Validate reference sections by comparing the documentation
+- `DF-07-005` (SHOULD) Validate reference sections by comparing the documentation
   tree to the source tree where appropriate.
-- `DF-07-006` SHOULD Validate explanatory pages by confirming they remain useful
+- `DF-07-006` (SHOULD) Validate explanatory pages by confirming they remain useful
   when read away from the running product.
 
 ## File metadata
 
-- `DF-08-001` SHOULD Name Diátaxis specification files using snake_case and
+- `DF-08-001` (SHOULD) Name Diátaxis specification files using snake_case and
   concise topic descriptors.
-- `DF-08-002` SHOULD Place cross-reference sources only in the header metadata
+- `DF-08-002` (SHOULD) Place cross-reference sources only in the header metadata
   and use inline links for cross-spec references.

--- a/specs/dispatch-routing.md
+++ b/specs/dispatch-routing.md
@@ -10,7 +10,7 @@ synchronously (DirectActivityDispatcher) or asynchronously (queue-based).
 
 ---
 
-## Dispatcher Protocol (MUST)
+## Dispatcher Protocol
 
 - `DR-01-001` All dispatcher implementations MUST implement ActivityDispatcher protocol
 - `DR-01-002` Dispatchers MUST construct use-case instances with the complete
@@ -23,12 +23,12 @@ synchronously (DirectActivityDispatcher) or asynchronously (queue-based).
 - `DR-01-003` Dispatchers MUST perform semantic type validation at dispatch time using the configured
   semantics-to-use-case mapping
 
-## Handler Lookup (MUST)
+## Handler Lookup
 
 - `DR-02-001` The system MUST look up use-case classes by semantic type using `USE_CASE_MAP`
 - `DR-02-002` `USE_CASE_MAP` MUST contain entries for all MessageSemantics values
 
-## Direct Dispatch Implementation (MUST)
+## Direct Dispatch Implementation
 
 - `DR-03-001` The DirectActivityDispatcher MUST execute handlers synchronously
 - `DR-03-002` The DirectActivityDispatcher MUST catch and log handler exceptions at ERROR level
@@ -36,7 +36,7 @@ synchronously (DirectActivityDispatcher) or asynchronously (queue-based).
   - DR-03-002 depends-on EH-06-001
   - **Verification**: Logged exceptions include handler name, activity ID, and full error context
 
-## Async Dispatch Implementation (SHOULD)
+## Async Dispatch Implementation
 
 - `DR-04-001` An async dispatcher SHOULD queue activities for processing
 - `DR-04-002` An async dispatcher SHOULD process activities in FIFO order

--- a/specs/embargo-policy.md
+++ b/specs/embargo-policy.md
@@ -14,7 +14,7 @@ Coordination", "Prior Art and References (Embargo Policy)")
 
 ---
 
-## Policy Record Format (MUST)
+## Policy Record Format
 
 - `EP-01-001` An Actor profile MAY include a `embargo_policy` field
   containing a structured embargo policy record
@@ -40,7 +40,7 @@ Coordination", "Prior Art and References (Embargo Policy)")
 - `EP-01-005` The embargo policy record MUST use full-URI IDs for `actor_id`
   - EP-01-005 depends-on OID-01-001
 
-## API Endpoint (SHOULD)
+## API Endpoint
 
 - `EP-02-001` `PROD_ONLY` Each Actor SHOULD expose its embargo policy at
   `GET /actors/{actor_id}/embargo-policy`
@@ -51,9 +51,9 @@ Coordination", "Prior Art and References (Embargo Policy)")
   (returns JSON) and MUST be listed in the Actor's ActivityPub profile under
   a well-known key (e.g., `vultron:embargoPolicy`)
 
-## Policy Compatibility Evaluation (SHOULD)
+## Policy Compatibility Evaluation
 
-- `EP-03-001` `PROD_ONLY` Before proposing an embargo or inviting an actor
+- `EP-03-001` SHOULD `PROD_ONLY` Before proposing an embargo or inviting an actor
   to join an existing embargo, the CaseActor SHOULD retrieve and evaluate
   the target actor's embargo policy for compatibility with the proposed
   embargo terms
@@ -77,13 +77,13 @@ Coordination", "Prior Art and References (Embargo Policy)")
 
 ### EP-02-001 Verification
 
-- `PROD_ONLY` Integration test: `GET /actors/{id}/embargo-policy` returns
+- `PROD_ONLY` SHOULD Integration test: `GET /actors/{id}/embargo-policy` returns
   200 with valid JSON for an actor with a declared policy
-- `PROD_ONLY` Integration test: Returns 404 for an actor without a policy
+- `PROD_ONLY` SHOULD Integration test: Returns 404 for an actor without a policy
 
 ### EP-03-001, EP-03-002 Verification
 
-- `PROD_ONLY` Unit test: Compatibility check returns `True` when proposed
+- `PROD_ONLY` SHOULD Unit test: Compatibility check returns `True` when proposed
   duration is within range, `False` otherwise
 
 ## Related

--- a/specs/embargo-policy.md
+++ b/specs/embargo-policy.md
@@ -53,7 +53,7 @@ Coordination", "Prior Art and References (Embargo Policy)")
 
 ## Policy Compatibility Evaluation
 
-- `EP-03-001` SHOULD `PROD_ONLY` Before proposing an embargo or inviting an actor
+- `EP-03-001` (SHOULD) `PROD_ONLY` Before proposing an embargo or inviting an actor
   to join an existing embargo, the CaseActor SHOULD retrieve and evaluate
   the target actor's embargo policy for compatibility with the proposed
   embargo terms

--- a/specs/embargo-policy.md
+++ b/specs/embargo-policy.md
@@ -77,13 +77,13 @@ Coordination", "Prior Art and References (Embargo Policy)")
 
 ### EP-02-001 Verification
 
-- `PROD_ONLY` SHOULD Integration test: `GET /actors/{id}/embargo-policy` returns
+- `PROD_ONLY` Integration test: `GET /actors/{id}/embargo-policy` returns
   200 with valid JSON for an actor with a declared policy
-- `PROD_ONLY` SHOULD Integration test: Returns 404 for an actor without a policy
+- `PROD_ONLY` Integration test: Returns 404 for an actor without a policy
 
 ### EP-03-001, EP-03-002 Verification
 
-- `PROD_ONLY` SHOULD Unit test: Compatibility check returns `True` when proposed
+- `PROD_ONLY` Unit test: Compatibility check returns `True` when proposed
   duration is within range, `False` otherwise
 
 ## Related

--- a/specs/encryption.md
+++ b/specs/encryption.md
@@ -14,7 +14,7 @@ implemented in the prototype.
 
 ---
 
-## Key Management (MUST)
+## Key Management
 
 - `ENC-01-001` `PROD_ONLY` Each CaseActor MUST generate an asymmetric key
   pair at instantiation
@@ -29,20 +29,20 @@ implemented in the prototype.
 - `ENC-01-004` `PROD_ONLY` Private keys MUST be stored securely and MUST
   NOT be logged or included in API responses
 
-## Message Encryption (SHOULD)
+## Message Encryption
 
 - `ENC-02-001` `PROD_ONLY` Case participants MAY encrypt messages sent to
   the CaseActor using the CaseActor's published public key
   - ENC-02-001 implements VP-15-003
   - ENC-02-001 implements VP-15-004
-- `ENC-02-002` `PROD_ONLY` When sending messages to case participants, the
+- `ENC-02-002` SHOULD `PROD_ONLY` When sending messages to case participants, the
   CaseActor SHOULD encrypt each outbound message to the recipient's public
   key individually (one encrypted payload per recipient)
   - Broadcast encryption to multiple recipients in a single message payload
     is out of scope for the initial implementation
   - ENC-02-002 implements VP-15-004
 
-## Decryption Pipeline (MUST)
+## Decryption Pipeline
 
 - `ENC-03-001` `PROD_ONLY` Decryption of inbound encrypted activities MUST
   occur in the inbox handler before the activity is passed to semantic
@@ -62,20 +62,20 @@ implemented in the prototype.
 
 ### ENC-01-001, ENC-01-002 Verification
 
-- `PROD_ONLY` Unit test: CaseActor instantiation produces a key pair
-- `PROD_ONLY` Integration test: `GET /actors/{id}` response includes
+- `PROD_ONLY` MUST Unit test: CaseActor instantiation produces a key pair
+- `PROD_ONLY` MUST Integration test: `GET /actors/{id}` response includes
   `publicKey` field
 
 ### ENC-02-001 Verification
 
-- `PROD_ONLY` Integration test: Message encrypted with actor public key is
+- `PROD_ONLY` MUST Integration test: Message encrypted with actor public key is
   accepted and decrypted successfully
 
 ### ENC-03-001, ENC-03-002 Verification
 
-- `PROD_ONLY` Unit test: Inbox handler passes decrypted content to
+- `PROD_ONLY` MUST Unit test: Inbox handler passes decrypted content to
   semantic extraction
-- `PROD_ONLY` Unit test: Inbox handler returns HTTP 400 on decryption
+- `PROD_ONLY` MUST Unit test: Inbox handler returns HTTP 400 on decryption
   failure
 
 ## Related

--- a/specs/encryption.md
+++ b/specs/encryption.md
@@ -35,7 +35,7 @@ implemented in the prototype.
   the CaseActor using the CaseActor's published public key
   - ENC-02-001 implements VP-15-003
   - ENC-02-001 implements VP-15-004
-- `ENC-02-002` SHOULD `PROD_ONLY` When sending messages to case participants, the
+- `ENC-02-002` (SHOULD) `PROD_ONLY` When sending messages to case participants, the
   CaseActor SHOULD encrypt each outbound message to the recipient's public
   key individually (one encrypted payload per recipient)
   - Broadcast encryption to multiple recipients in a single message payload

--- a/specs/encryption.md
+++ b/specs/encryption.md
@@ -73,9 +73,9 @@ implemented in the prototype.
 
 ### ENC-03-001, ENC-03-002 Verification
 
-- `PROD_ONLY` MUST Unit test: Inbox handler passes decrypted content to
+- `PROD_ONLY` Unit test: Inbox handler passes decrypted content to
   semantic extraction
-- `PROD_ONLY` MUST Unit test: Inbox handler returns HTTP 400 on decryption
+- `PROD_ONLY` Unit test: Inbox handler returns HTTP 400 on decryption
   failure
 
 ## Related

--- a/specs/error-handling.md
+++ b/specs/error-handling.md
@@ -13,25 +13,25 @@ The Vultron inbox handler must handle various error conditions gracefully, provi
 
 ---
 
-## Exception Hierarchy (MUST)
+## Exception Hierarchy
 
 - `EH-01-001` The system MUST define custom exceptions for application-specific errors
 - `EH-01-002` Custom exceptions MUST inherit from a base VultronError exception
 - `EH-01-003` Custom exceptions MUST be centralized in `vultron/errors.py`
 
-## Submodule Errors (MUST)
+## Submodule Errors
 
 - `EH-02-001` Submodule-specific errors MUST be defined in submodule `errors.py`
 - `EH-02-002` Submodule errors MUST inherit from base custom exceptions in `vultron/errors.py`
 
-## Error Categories (MUST)
+## Error Categories
 
 - `EH-03-001` The system MUST define error categories
   - Validation errors (4xx client errors)
   - Protocol errors (semantic/routing failures)
   - System errors (5xx server errors)
 
-## Error Context (SHOULD)
+## Error Context
 
 - `EH-04-001` Exceptions SHOULD include contextual information
   - Activity ID
@@ -39,7 +39,7 @@ The Vultron inbox handler must handle various error conditions gracefully, provi
   - Error message
   - Original exception (if wrapped)
 
-## Error Response Format (MUST)
+## Error Response Format
 
 - `EH-05-001` HTTP error responses MUST include structured JSON body with fields:
   - `status`: HTTP status code (integer)
@@ -49,7 +49,7 @@ The Vultron inbox handler must handle various error conditions gracefully, provi
   - **Example**: `{"status": 400, "error": "ValidationError", "message": "...", "activity_id": "urn:uuid:..."}`
   - EH-05-001 depends-on HTTP-03-001
 
-## Error Logging (MUST)
+## Error Logging
 
 - `EH-06-001` All errors MUST be logged at the appropriate level per log level
   semantics

--- a/specs/handler-protocol.md
+++ b/specs/handler-protocol.md
@@ -10,20 +10,20 @@ protocol business logic. All handlers follow a common contract defined by the
 
 ---
 
-## Protocol Semantics (MUST)
+## Protocol Semantics
 
 - `HP-00-001` Handlers MUST interpret received activities as assertions about the
   sender's state, not as commands to perform work
 - `HP-00-002` Handlers MUST update local RM/EM/CS state to reflect the state
   transition asserted by the received activity
 
-## Handler Signature (MUST)
+## Handler Signature
 
 - `HP-01-001` All handler use-case classes MUST accept `(event: VultronEvent,
   dl: DataLayer)` — either as `__init__` parameters or as `execute` parameters
 - `HP-01-002` Handler use-case `execute` methods MAY return None or HandlerResult
 
-## Semantic Verification (MUST)
+## Semantic Verification
 
 - `HP-02-001` All handlers MUST have semantic type verification before execution
   - **Implementation**: Semantic type is checked at dispatcher lookup time using
@@ -31,25 +31,25 @@ protocol business logic. All handlers follow a common contract defined by the
 - `HP-02-002` The verification mechanism MUST check that the activity's semantic type matches the handler's expected type
   - **Rationale**: Prevents routing errors where wrong handler processes an activity
 
-## Handler Registration (MUST)
+## Handler Registration
 
 - `HP-03-001` All handlers MUST be discoverable via a handler registry mechanism
   - **Implementation**: Registry map (`USE_CASE_MAP`) maps MessageSemantics → use-case classes
 - `HP-03-002` Registry keys MUST match handler semantic verification types
 
-## Payload Access (MUST)
+## Payload Access
 
 - `HP-04-001` Handlers MUST access activity data via `dispatchable.payload`
   - **Rationale**: Encapsulation; payload may be validated/transformed by dispatcher
 - `HP-04-002` Handlers MUST use schema validation for type-safe payload access
   - **Implementation**: Pydantic models provide validation and type safety
 
-## Error Handling (MUST)
+## Error Handling
 
 - `HP-05-001` Handlers MUST raise exceptions for unrecoverable errors
 - `HP-05-002` Handlers MUST log expected errors without raising exceptions
 
-## Logging (MUST)
+## Logging
 
 - `HP-06-001` Handlers MUST log entry at DEBUG level with handler name
 - `HP-06-002` Handlers MUST log state transitions at INFO level with before/after states
@@ -57,14 +57,14 @@ protocol business logic. All handlers follow a common contract defined by the
   - HP-06-003 depends-on SL-03-001
   - HP-06-003 depends-on SL-04-001
 
-## Idempotency (SHOULD)
+## Idempotency
 
 - `HP-07-001` Handlers SHOULD be idempotent to support retries
   - State-changing handlers (those that transition RM/EM/CS state) MUST be
     idempotent to prevent data corruption
   - HP-07-001 depends-on ID-04-001
 
-## Execution Timeout (MUST)
+## Execution Timeout
 
 - `HP-07-002` `PROD_ONLY` Handlers MUST complete execution within 30 seconds
   - **Rationale**: Prevents indefinite blocking of background task queue
@@ -77,7 +77,7 @@ protocol business logic. All handlers follow a common contract defined by the
   - **Pattern**: Use FastAPI BackgroundTasks for orchestration; split work into
     multiple handler invocations
 
-## Data Model Persistence (MUST)
+## Data Model Persistence
 
 - `HP-08-001` Handlers MUST use helper functions when persisting Pydantic models to the data layer
   - **Verification**: Pydantic models round-trip through database without data loss

--- a/specs/http-protocol.md
+++ b/specs/http-protocol.md
@@ -10,17 +10,17 @@ MV-07), `error-handling.md` (EH-06), `agentic-readiness.md` (AR-03-002)
 
 ---
 
-## Content-Type Validation (MUST)
+## Content-Type Validation
 
 - `HTTP-01-001` Inbox endpoint MUST accept `application/activity+json` Content-Type
 - `HTTP-01-002` Inbox endpoint MUST accept `application/ld+json; profile="https://www.w3.org/ns/activitystreams"` Content-Type
 - `HTTP-01-003` Inbox endpoint MUST reject requests with invalid Content-Type using HTTP 415
 
-## Request Size Limits (MUST)
+## Request Size Limits
 
 - `HTTP-02-001` `PROD_ONLY` Inbox endpoint MUST reject requests exceeding 1 MB with HTTP 413
 
-## HTTP Status Codes (MUST)
+## HTTP Status Codes
 
 - `HTTP-03-001` API MUST use standard HTTP status codes with consistent semantics per table below
 
@@ -38,16 +38,16 @@ MV-07), `error-handling.md` (EH-06), `agentic-readiness.md` (AR-03-002)
 | 500 | Internal Server Error | Unhandled exception |
 | 503 | Service Unavailable | System not ready |
 
-## Response Headers (MUST)
+## Response Headers
 
 - `HTTP-04-001` All JSON responses MUST include `Content-Type: application/json` header
 
-## Correlation ID Propagation (SHOULD)
+## Correlation ID Propagation
 
 - `HTTP-05-001` `PROD_ONLY` API SHOULD accept `X-Correlation-ID` or `X-Request-ID` headers for request tracing
 - `HTTP-05-002` `PROD_ONLY` API SHOULD generate correlation ID from activity `id` field if header not provided
 
-## Request Timeout Handling (SHOULD)
+## Request Timeout Handling
 
 - `HTTP-06-001` Inbox endpoints SHOULD respond with HTTP headers within 100ms
   - **Measurement point**: Time from HTTP request received by server to response
@@ -61,7 +61,7 @@ MV-07), `error-handling.md` (EH-06), `agentic-readiness.md` (AR-03-002)
 - `HTTP-06-003` `PROD_ONLY` Timeout occurrences SHOULD be logged at WARNING level
   - **Log format**: "Inbox request exceeded 100ms threshold: {duration}ms"
 
-## Rate Limiting Headers (MAY)
+## Rate Limiting Headers
 
 - `HTTP-07-001` `PROD_ONLY` API MAY include `X-RateLimit-Limit` header (maximum requests per window)
 - `HTTP-07-002` `PROD_ONLY` API MAY include `X-RateLimit-Remaining` header (requests remaining)
@@ -104,7 +104,7 @@ MV-07), `error-handling.md` (EH-06), `agentic-readiness.md` (AR-03-002)
 
 - Integration test: HTTP 429 and 503 responses include `Retry-After` header
 
-## FastAPI Response Serialization (MUST)
+## FastAPI Response Serialization
 
 - `HTTP-08-001` API responses MUST include all fields of the actual returned
   object type, not only fields declared on the annotated base class

--- a/specs/idempotency.md
+++ b/specs/idempotency.md
@@ -11,18 +11,18 @@ The system must handle duplicate activity submissions gracefully, ensuring repea
 
 ---
 
-## Activity ID Uniqueness (MUST)
+## Activity ID Uniqueness
 
 - `ID-01-001` All activities MUST have globally unique `id` field (URI)
 - `ID-01-002` Activity IDs MUST remain stable (same activity = same ID)
 
-## Duplicate Detection (MUST)
+## Duplicate Detection
 
 - `ID-02-001` System MUST detect duplicate activity submissions by ID
 - `ID-02-002` System SHOULD track processed activity IDs in DataLayer
 - `ID-02-003` Detection MUST occur before handler business logic execution
 
-## Idempotent Response (MUST)
+## Idempotent Response
 
 - `ID-03-001` Duplicate submissions MUST return same HTTP status as original
   - First submission: HTTP 202 (queued for processing)
@@ -31,7 +31,7 @@ The system must handle duplicate activity submissions gracefully, ensuring repea
 - `ID-03-003` System SHOULD log duplicate submissions at WARNING level
   - ID-03-003 depends-on SL-03-001
 
-## Handler Idempotency (SHOULD)
+## Handler Idempotency
 
 - `ID-04-001` Handlers SHOULD be idempotent (same input → same output)
 - `ID-04-002` Handlers SHOULD check existing state before state transitions
@@ -44,11 +44,11 @@ The system must handle duplicate activity submissions gracefully, ensuring repea
     corruption; SHOULD-level idempotency is insufficient for state machines
   - **Examples**: `validate_report`, `create_report`, `create_case`
 
-## Implementation Strategy (SHOULD)
+## Implementation Strategy
 
 - `ID-05-001` Validation layer SHOULD reject exact duplicates (same ID, same content)
 - `ID-05-002` HTTP layer MAY implement early duplicate filtering for performance
-- `ID-05-003` Handlers provide final idempotency guarantee via state checks
+- `ID-05-003` SHOULD Handlers provide final idempotency guarantee via state checks
 
 ## Verification
 

--- a/specs/idempotency.md
+++ b/specs/idempotency.md
@@ -48,7 +48,7 @@ The system must handle duplicate activity submissions gracefully, ensuring repea
 
 - `ID-05-001` Validation layer SHOULD reject exact duplicates (same ID, same content)
 - `ID-05-002` HTTP layer MAY implement early duplicate filtering for performance
-- `ID-05-003` SHOULD Handlers provide final idempotency guarantee via state checks
+- `ID-05-003` (SHOULD) Handlers provide final idempotency guarantee via state checks
 
 ## Verification
 

--- a/specs/inbox-endpoint.md
+++ b/specs/inbox-endpoint.md
@@ -10,7 +10,7 @@ The inbox endpoint is the primary entry point for actor-to-actor communication i
 
 ---
 
-## Endpoint Configuration (MUST)
+## Endpoint Configuration
 
 - `IE-02-001` The endpoint URL MUST be discoverable from actor profile
   - **Implementation**: Default pattern `POST /actors/{actor_id}/inbox/`
@@ -19,14 +19,14 @@ The inbox endpoint is the primary entry point for actor-to-actor communication i
 - `IE-02-003` The endpoint MUST reject non-POST requests with HTTP 405
   - IE-02-003 depends-on HTTP-03-001
 
-## Request Handling (MUST)
+## Request Handling
 
 - `IE-03-001` The endpoint MUST validate Content-Type header
   - IE-03-001 depends-on HTTP-01-001
 - `IE-03-002` The endpoint MUST enforce request size limits
   - IE-03-002 depends-on HTTP-02-001
 
-## Activity Validation (MUST)
+## Activity Validation
 
 - `IE-04-001` The endpoint MUST validate activity structure via schema validation
   - **Implementation**: Uses Pydantic models (see `message-validation.md`)
@@ -34,36 +34,36 @@ The inbox endpoint is the primary entry point for actor-to-actor communication i
   - Include detailed validation errors in response
   - IE-04-002 depends-on HTTP-03-001
 
-## Response Timing (MUST)
+## Response Timing
 
 - `IE-05-001` The endpoint MUST return HTTP 202 within 100ms
   - IE-05-001 depends-on HTTP-06-001
 - `IE-05-002` The endpoint MUST NOT block on handler execution
 
-## Asynchronous Processing (MUST)
+## Asynchronous Processing
 
 - `IE-06-001` The endpoint MUST queue activities for background processing
 - `IE-06-002` Background processing MUST be isolated from HTTP request/response cycle
   - **Implementation**: FastAPI BackgroundTasks or equivalent async mechanism
 
-## Error Responses (MUST)
+## Error Responses
 
 - `IE-07-001` The endpoint MUST return appropriate HTTP status codes
   - IE-07-001 depends-on HTTP-03-001
 
-## Response Format (MUST)
+## Response Format
 
 - `IE-08-001` Response body MUST be JSON with fields: `status`, `activity_id`, `message`
   - IE-08-001 depends-on EH-05-001
 
-## Logging (MUST)
+## Logging
 
 - `IE-09-001` The endpoint MUST log all requests at INFO level
   - IE-09-001 depends-on SL-01-001
   - IE-09-001 depends-on SL-02-001
   - IE-09-001 depends-on SL-03-001
 
-## Idempotency (SHOULD)
+## Idempotency
 
 - `IE-10-001` The endpoint SHOULD implement early duplicate detection at HTTP layer
   - **Note**: Optional performance optimization; see `idempotency.md` for complete requirements

--- a/specs/message-validation.md
+++ b/specs/message-validation.md
@@ -13,7 +13,7 @@ The inbox handler validates ActivityStreams 2.0 activities before processing to 
 
 ---
 
-## Activity Structure Validation (MUST)
+## Activity Structure Validation
 
 - `MV-01-001` Incoming payloads MUST conform to ActivityStreams 2.0 structure
   - MUST have a `type` field containing a valid Activity type
@@ -24,7 +24,7 @@ The inbox handler validates ActivityStreams 2.0 activities before processing to 
   - If a pattern expects an object type (or an actor base class), the match algorithm MUST handle both subclassed object types and URI string references without raising exceptions.
   - When activity data includes string references, the inbox handler SHOULD attempt rehydration prior to pattern matching; if rehydration is not possible, the system MUST log a warning and return MessageSemantics.UNKNOWN (see `specs/semantic-extraction.md`).
 
-## Schema Validation (MUST)
+## Schema Validation
 
 - `MV-02-001` The system MUST use Pydantic models to validate activities
   - MV-02-001 implements VP-15-001
@@ -33,7 +33,7 @@ The inbox handler validates ActivityStreams 2.0 activities before processing to 
 - `MV-02-004` The system MUST log validation failures at WARNING level
   - Validation failures are client errors (HTTP 422); see `structured-logging.md` SL-03-001
 
-## Required Field Validation (MUST)
+## Required Field Validation
 
 - `MV-03-001` The system MUST validate required fields based on activity type
   - Create activities MUST have an `object` field
@@ -41,7 +41,7 @@ The inbox handler validates ActivityStreams 2.0 activities before processing to 
   - Add activities MUST have both `object` and `target` fields
   - Remove activities MUST have both `object` and `target` fields
 
-## Object Type Validation (MUST)
+## Object Type Validation
 
 - `MV-04-001` The system MUST validate that object types are recognized Vultron types
   - VulnerabilityReport
@@ -49,13 +49,13 @@ The inbox handler validates ActivityStreams 2.0 activities before processing to 
   - CaseParticipant
   - EmbargoEvent
   - Standard ActivityStreams types (Person, Organization, Service)
-- `MV-04-002` For Create-style activities that create sub-objects (e.g.,
+- `MV-04-002` SHOULD For Create-style activities that create sub-objects (e.g.,
   `CreateParticipant`), the activity `name` field SHOULD be a descriptive
   human-readable string identifying the actor, created object ID, and context
   (case ID)
   - Example: `"{actor} Create CaseParticipant {participant_id} from {attributed_to} in {case_id}"`
 
-## URI Validation (MUST)
+## URI Validation
 
 - `MV-05-001` The system MUST validate that ID and reference fields contain valid URIs
   - MUST use URI validation schemes (http, https, urn, etc.)
@@ -67,7 +67,7 @@ The inbox handler validates ActivityStreams 2.0 activities before processing to 
   - All layers (API, handlers, data layer) MUST consistently store and compare IDs as URI strings; when creating IDs, prefer fully-qualified URIs.
   - The data layer and rehydration logic MUST perform URL-encoding/decoding only for transport concerns and must persist the original URI string as-is.
   
-## Duplicate Detection (SHOULD)
+## Duplicate Detection
 
 - `MV-08-001` The system SHOULD detect duplicate activity submissions during validation
   - MV-08-001 depends-on ID-02-001

--- a/specs/message-validation.md
+++ b/specs/message-validation.md
@@ -49,7 +49,7 @@ The inbox handler validates ActivityStreams 2.0 activities before processing to 
   - CaseParticipant
   - EmbargoEvent
   - Standard ActivityStreams types (Person, Organization, Service)
-- `MV-04-002` SHOULD For Create-style activities that create sub-objects (e.g.,
+- `MV-04-002` (SHOULD) For Create-style activities that create sub-objects (e.g.,
   `CreateParticipant`), the activity `name` field SHOULD be a descriptive
   human-readable string identifying the actor, created object ID, and context
   (case ID)

--- a/specs/meta-specifications.md
+++ b/specs/meta-specifications.md
@@ -54,7 +54,7 @@ Accepted keywords:
 Format — section header carries the dominant level for the group:
 
 ```markdown
-## Category (MUST)
+## Category
 ```
 
 Format — each requirement line carries its own keyword inline:

--- a/specs/multi-actor-demo.md
+++ b/specs/multi-actor-demo.md
@@ -43,9 +43,9 @@ actor isolation, acceptance testing, and reproducibility.
   - DEMO-MA-02-001 refines IMPL-TS-05-002 (tech-stack.md)
   - DEMO-MA-02-001 depends-on OB-05-002 (observability.md): the
     `/health/ready` endpoint MUST check DataLayer connectivity
-- `DEMO-MA-02-002` MUST Dependent services (e.g., a demo orchestration container)
+- `DEMO-MA-02-002` (MUST) Dependent services (e.g., a demo orchestration container)
   MUST use `condition: service_healthy` for all actor service dependencies
-- `DEMO-MA-02-003` MUST Port mappings, network names, and required environment
+- `DEMO-MA-02-003` (MUST) Port mappings, network names, and required environment
   variables MUST be documented in the `docker-compose.yml` file or an
   accompanying `README.md`
 

--- a/specs/multi-actor-demo.md
+++ b/specs/multi-actor-demo.md
@@ -12,14 +12,14 @@ actor isolation, acceptance testing, and reproducibility.
 
 ---
 
-## Cross-Actor Communication (MUST)
+## Cross-Actor Communication
 
 - `DEMO-MA-00-001` Cross-actor communication MUST occur exclusively via HTTP
   using the ActivityStreams inbox endpoint
   - No actor MAY read from or write to another actor's DataLayer directly;
     all coordination MUST pass through the inbox API
 
-## Actor Isolation (MUST)
+## Actor Isolation
 
 - `DEMO-MA-01-001` Each actor in a multi-actor demo MUST run in a separate
   container with its own DataLayer instance
@@ -35,7 +35,7 @@ actor isolation, acceptance testing, and reproducibility.
   - Documentation MUST describe how to seed initial actor state and how to
     trigger the automatic reset for a repeatable re-run
 
-## Container Orchestration (MUST)
+## Container Orchestration
 
 - `DEMO-MA-02-001` Docker Compose configurations for multi-actor demos MUST
   include a `healthcheck` for each actor service that probes the
@@ -43,13 +43,13 @@ actor isolation, acceptance testing, and reproducibility.
   - DEMO-MA-02-001 refines IMPL-TS-05-002 (tech-stack.md)
   - DEMO-MA-02-001 depends-on OB-05-002 (observability.md): the
     `/health/ready` endpoint MUST check DataLayer connectivity
-- `DEMO-MA-02-002` Dependent services (e.g., a demo orchestration container)
+- `DEMO-MA-02-002` MUST Dependent services (e.g., a demo orchestration container)
   MUST use `condition: service_healthy` for all actor service dependencies
-- `DEMO-MA-02-003` Port mappings, network names, and required environment
+- `DEMO-MA-02-003` MUST Port mappings, network names, and required environment
   variables MUST be documented in the `docker-compose.yml` file or an
   accompanying `README.md`
 
-## Acceptance Tests (MUST)
+## Acceptance Tests
 
 - `DEMO-MA-03-001` Each multi-actor demo scenario MUST include an acceptance
   test that validates the end-to-end workflow deterministically
@@ -60,7 +60,7 @@ actor isolation, acceptance testing, and reproducibility.
 - `DEMO-MA-03-003` Acceptance tests MUST be reproducible: the same test on
   the same codebase MUST produce the same result on successive runs
 
-## Scenario Coverage (SHOULD)
+## Scenario Coverage
 
 - `DEMO-MA-04-001` Multi-actor demo scenarios SHOULD be implemented
   progressively:

--- a/specs/object-ids.md
+++ b/specs/object-ids.md
@@ -25,7 +25,7 @@ Should Be URL-Like, Not Bare UUIDs"), `plan/IMPLEMENTATION_PLAN.md`
 - `OID-01-002` IDs MUST be globally unique within the system
 - `OID-01-003` The canonical base URI for locally created objects MUST be
   configurable via an environment variable (`VULTRON_BASE_URL` or equivalent)
-- `OID-01-004` MUST Helper functions for constructing full-URI IDs from UUIDs
+- `OID-01-004` (MUST) Helper functions for constructing full-URI IDs from UUIDs
   MUST be provided in a shared utility module (e.g.,
   `vultron.as_vocab.utils.make_id`)
 

--- a/specs/object-ids.md
+++ b/specs/object-ids.md
@@ -14,7 +14,7 @@ Should Be URL-Like, Not Bare UUIDs"), `plan/IMPLEMENTATION_PLAN.md`
 
 ---
 
-## ID Format (MUST)
+## ID Format
 
 - `OID-01-001` All ActivityStreams object IDs (`as_id`) MUST use full URI form
   - Acceptable forms: `https://example.org/objects/{uuid}` or
@@ -25,11 +25,11 @@ Should Be URL-Like, Not Bare UUIDs"), `plan/IMPLEMENTATION_PLAN.md`
 - `OID-01-002` IDs MUST be globally unique within the system
 - `OID-01-003` The canonical base URI for locally created objects MUST be
   configurable via an environment variable (`VULTRON_BASE_URL` or equivalent)
-- `OID-01-004` Helper functions for constructing full-URI IDs from UUIDs
+- `OID-01-004` MUST Helper functions for constructing full-URI IDs from UUIDs
   MUST be provided in a shared utility module (e.g.,
   `vultron.as_vocab.utils.make_id`)
 
-## DataLayer Handling (MUST)
+## DataLayer Handling
 
 - `OID-02-001` The DataLayer MUST store and retrieve objects using their
   full-URI `as_id` as the primary key
@@ -40,7 +40,7 @@ Should Be URL-Like, Not Bare UUIDs"), `plan/IMPLEMENTATION_PLAN.md`
 - `OID-02-004` DataLayer lookups MUST accept full-URI IDs; bare UUIDs MUST
   NOT be accepted as valid lookup keys
 
-## Blackboard Key Handling (MUST)
+## Blackboard Key Handling
 
 - `OID-03-001` Behavior Tree blackboard keys derived from object IDs MUST
   NOT use the raw full URI as the key
@@ -48,7 +48,7 @@ Should Be URL-Like, Not Bare UUIDs"), `plan/IMPLEMENTATION_PLAN.md`
     avoid hierarchical key parsing issues in py_trees
   - OID-03-001 refines BT-03-003
 
-## ADR Requirement (SHOULD)
+## ADR Requirement
 
 - `OID-04-001` An Architecture Decision Record MUST be created at
   `docs/adr/ADR-XXXX-standardize-object-ids.md` before migrating existing

--- a/specs/observability.md
+++ b/specs/observability.md
@@ -16,7 +16,7 @@ Observability enables operators to understand system behavior, diagnose issues, 
 
 ---
 
-## Health Checks (MUST)
+## Health Checks
 
 - `OB-05-001` The system MUST provide liveness endpoint at `/health/live`
   - Return HTTP 200 if process is running

--- a/specs/outbox.md
+++ b/specs/outbox.md
@@ -11,14 +11,14 @@ is deferred to future work.
 
 ---
 
-## Outbox Structure (MUST)
+## Outbox Structure
 
 - `OX-01-001` Each actor MUST have an outbox collection
 - `OX-01-002` Outbox MUST preserve insertion order (FIFO)
 - `OX-01-003` Activities added to outbox MUST be persisted to DataLayer
   immediately
 
-## Outbox Population (MUST)
+## Outbox Population
 
 - `OX-02-001` Handlers that generate response activities MUST add them to the
   actor's outbox
@@ -27,7 +27,7 @@ is deferred to future work.
 - `OX-02-002` Each outbox activity MUST conform to ActivityStreams 2.0 structure
   - See `specs/response-format.md` for response activity requirements
 
-## Outbox Delivery (MUST)
+## Outbox Delivery
 
 - `OX-03-001` Activities in an actor's outbox MUST be delivered to recipient
   inboxes
@@ -36,13 +36,13 @@ is deferred to future work.
   - **Implementation**: Use FastAPI BackgroundTasks or a follow-on background
     task after the handler
 
-## Local Delivery (MUST)
+## Local Delivery
 
 - `OX-04-001` For actors on the same server, delivery MUST write directly to the
   recipient actor's inbox collection in the DataLayer
 - `OX-04-002` Local delivery MUST persist the inbox update immediately
 
-## Federation Delivery (MAY)
+## Federation Delivery
 
 - `OX-05-001` `PROD_ONLY` For remote actors, the system MAY deliver via HTTP POST to the
   remote actor's inbox URL
@@ -51,7 +51,7 @@ is deferred to future work.
 - `OX-05-002` `PROD_ONLY` Remote delivery failures SHOULD be logged at WARNING level and
   retried
 
-## Delivery Idempotency (MUST)
+## Delivery Idempotency
 
 - `OX-06-001` Outbox delivery MUST be idempotent
   - Delivering the same activity twice MUST NOT create duplicate inbox entries

--- a/specs/project-documentation.md
+++ b/specs/project-documentation.md
@@ -353,7 +353,7 @@ When one document references another:
   - Forward-looking statements such as "not yet implemented" MUST be
     replaced with historical references (e.g., "implemented in Phase X")
     once the described work is done
-- `PD-03-002` SHOULD `notes/*.md` files that are purely historical and contain no
+- `PD-03-002` (SHOULD) `notes/*.md` files that are purely historical and contain no
   durable design guidance SHOULD be archived in `docs/archived_notes/` with
   a brief rationale, rather than deleted
 - `PD-03-003` Module paths referenced in `notes/` MUST be updated to

--- a/specs/project-documentation.md
+++ b/specs/project-documentation.md
@@ -346,14 +346,14 @@ When one document references another:
 
 ---
 
-## Documentation Currency (MUST / SHOULD)
+## Documentation Currency
 
 - `PD-03-001` `notes/*.md` files MUST be updated when implementation phases
   they describe are completed
   - Forward-looking statements such as "not yet implemented" MUST be
     replaced with historical references (e.g., "implemented in Phase X")
     once the described work is done
-- `PD-03-002` `notes/*.md` files that are purely historical and contain no
+- `PD-03-002` SHOULD `notes/*.md` files that are purely historical and contain no
   durable design guidance SHOULD be archived in `docs/archived_notes/` with
   a brief rationale, rather than deleted
 - `PD-03-003` Module paths referenced in `notes/` MUST be updated to

--- a/specs/prototype-shortcuts.md
+++ b/specs/prototype-shortcuts.md
@@ -13,14 +13,14 @@ during the prototype stage.
 
 ## Authentication
 
-- `PROTO-01-001` MAY Omit cryptographic authentication for agent-to-agent
+- `PROTO-01-001` (MAY) Omit cryptographic authentication for agent-to-agent
   communication.
   - PROTO-01-001 constrains CM-06-004
 
 ## Federation
 
-- `PROTO-02-001` MAY Assume all actors are local to a single ActivityPub server.
-- `PROTO-02-002` MAY Post direct messages to an actor's inbox without federation
+- `PROTO-02-001` (MAY) Assume all actors are local to a single ActivityPub server.
+- `PROTO-02-002` (MAY) Post direct messages to an actor's inbox without federation
   or cross-server routing.
 
 **Note**: The intended production federation model uses AS2 as a vocabulary
@@ -32,13 +32,13 @@ and Python stack candidates.
 
 ## Performance
 
-- `PROTO-03-001` SHOULD NOT Avoid algorithms with exponential or worse time complexity.
+- `PROTO-03-001` (SHOULD NOT) Avoid algorithms with exponential or worse time complexity.
   - E.g., O(2^n) is not acceptable; O(n^2) is acceptable.
-- `PROTO-03-002` SHOULD Prefer the simplest algorithm when multiple options exist,
+- `PROTO-03-002` (SHOULD) Prefer the simplest algorithm when multiple options exist,
   even if less efficient.
-- `PROTO-03-003` SHOULD Implement straightforward optimizations that do not
+- `PROTO-03-003` (SHOULD) Implement straightforward optimizations that do not
   significantly increase complexity.
-- `PROTO-03-004` SHOULD Document known unimplemented optimizations in implementation
+- `PROTO-03-004` (SHOULD) Document known unimplemented optimizations in implementation
   notes for future reference.
 
 ## Production Deferral
@@ -50,7 +50,7 @@ and Python stack candidates.
     the full production intent is preserved alongside the prototype deferral
   - Agents SHOULD treat any `PROD_ONLY` requirement as out-of-scope for
     prototype implementation unless explicitly instructed otherwise
-- `PROTO-04-002` SHOULD Review specifications to identify requirements that should
+- `PROTO-04-002` (SHOULD) Review specifications to identify requirements that should
   carry the `PROD_ONLY` tag.
   - Any requirement that cannot be practically tested without production
     infrastructure (e.g., HSMs, PKI, mTLS) or that imposes overhead
@@ -58,7 +58,7 @@ and Python stack candidates.
 
 ## Case Prioritization
 
-- `PROTO-05-001` MAY Use a stub always-engage policy (`AlwaysPrioritizePolicy`)
+- `PROTO-05-001` (MAY) Use a stub always-engage policy (`AlwaysPrioritizePolicy`)
   in place of a real prioritization framework.
   - The intended production mechanism is SSVC (Stakeholder-Specific
     Vulnerability Categorization) or an equivalent tool that evaluates report

--- a/specs/prototype-shortcuts.md
+++ b/specs/prototype-shortcuts.md
@@ -32,7 +32,7 @@ and Python stack candidates.
 
 ## Performance
 
-- `PROTO-03-001` (SHOULD NOT) Avoid algorithms with exponential or worse time complexity.
+- `PROTO-03-001` (SHOULD NOT) Use algorithms with exponential or worse time complexity.
   - E.g., O(2^n) is not acceptable; O(n^2) is acceptable.
 - `PROTO-03-002` (SHOULD) Prefer the simplest algorithm when multiple options exist,
   even if less efficient.

--- a/specs/prototype-shortcuts.md
+++ b/specs/prototype-shortcuts.md
@@ -11,16 +11,16 @@ during the prototype stage.
 
 ---
 
-## Authentication (MAY)
+## Authentication
 
-- `PROTO-01-001` Omit cryptographic authentication for agent-to-agent
+- `PROTO-01-001` MAY Omit cryptographic authentication for agent-to-agent
   communication.
   - PROTO-01-001 constrains CM-06-004
 
-## Federation (MAY)
+## Federation
 
-- `PROTO-02-001` Assume all actors are local to a single ActivityPub server.
-- `PROTO-02-002` Post direct messages to an actor's inbox without federation
+- `PROTO-02-001` MAY Assume all actors are local to a single ActivityPub server.
+- `PROTO-02-002` MAY Post direct messages to an actor's inbox without federation
   or cross-server routing.
 
 **Note**: The intended production federation model uses AS2 as a vocabulary
@@ -30,18 +30,18 @@ journal + delivery log, and connector plugins. See
 `notes/federation_ideas.md` for the full federation design, open questions,
 and Python stack candidates.
 
-## Performance (SHOULD)
+## Performance
 
-- `PROTO-03-001` Avoid algorithms with exponential or worse time complexity.
+- `PROTO-03-001` SHOULD NOT Avoid algorithms with exponential or worse time complexity.
   - E.g., O(2^n) is not acceptable; O(n^2) is acceptable.
-- `PROTO-03-002` Prefer the simplest algorithm when multiple options exist,
+- `PROTO-03-002` SHOULD Prefer the simplest algorithm when multiple options exist,
   even if less efficient.
-- `PROTO-03-003` Implement straightforward optimizations that do not
+- `PROTO-03-003` SHOULD Implement straightforward optimizations that do not
   significantly increase complexity.
-- `PROTO-03-004` Document known unimplemented optimizations in implementation
+- `PROTO-03-004` SHOULD Document known unimplemented optimizations in implementation
   notes for future reference.
 
-## Production Deferral (SHOULD)
+## Production Deferral
 
 - `PROTO-04-001` Specification files SHOULD tag production-only requirements
   with `PROD_ONLY` so they can be systematically identified and deferred
@@ -50,15 +50,15 @@ and Python stack candidates.
     the full production intent is preserved alongside the prototype deferral
   - Agents SHOULD treat any `PROD_ONLY` requirement as out-of-scope for
     prototype implementation unless explicitly instructed otherwise
-- `PROTO-04-002` Review specifications to identify requirements that should
+- `PROTO-04-002` SHOULD Review specifications to identify requirements that should
   carry the `PROD_ONLY` tag.
   - Any requirement that cannot be practically tested without production
     infrastructure (e.g., HSMs, PKI, mTLS) or that imposes overhead
     inconsistent with rapid prototyping SHOULD carry the `PROD_ONLY` tag
 
-## Case Prioritization (MAY)
+## Case Prioritization
 
-- `PROTO-05-001` Use a stub always-engage policy (`AlwaysPrioritizePolicy`)
+- `PROTO-05-001` MAY Use a stub always-engage policy (`AlwaysPrioritizePolicy`)
   in place of a real prioritization framework.
   - The intended production mechanism is SSVC (Stakeholder-Specific
     Vulnerability Categorization) or an equivalent tool that evaluates report
@@ -74,7 +74,7 @@ and Python stack candidates.
     only for reports that have not yet been associated with a case (i.e.,
     before a case is created from a validated report).
 
-## Domain Model Separation (MAY)
+## Domain Model Separation
 
 - `PROTO-06-001` Prototype MAY allow domain objects to directly inherit from
   ActivityStreams base types (`VultronObject`, `as_Object`, etc.) without a
@@ -97,7 +97,7 @@ and Python stack candidates.
   require domain objects free of AS2 inheritance. This shortcut SHOULD be
   revisited when stubbing `core/use_cases/` in P60-3.
 
-## Performance Testing (MAY)
+## Performance Testing
 
 - `PROTO-07-001` `PROD_ONLY` Performance tests and performance assertions MAY
   be skipped or marked as expected failures during the prototype stage

--- a/specs/response-format.md
+++ b/specs/response-format.md
@@ -8,7 +8,7 @@ The Vultron protocol uses ActivityStreams activities for both requests and respo
 
 ---
 
-## Response Activity Structure (MUST)
+## Response Activity Structure
 
 - `RF-01-001` Response activities MUST conform to ActivityStreams 2.0
   - MUST have `type` field with appropriate activity type
@@ -16,44 +16,44 @@ The Vultron protocol uses ActivityStreams activities for both requests and respo
   - MUST have `actor` field identifying responding actor
   - MUST have `object` field referencing relevant object or activity
 
-## Accept Response (MUST)
+## Accept Response
 
 - `RF-02-001` Accept responses MUST use `Accept` activity type
   - RF-02-001 implements VP-06-004
 - `RF-02-002` Accept responses MUST include `object` field referencing accepted activity or object
 - `RF-02-003` Accepting an Offer of an object MUST reference the Offer activity in the `object` field of the Accept response
-- `RF-02-004` When accepting an offered object, the `object` field of the
+- `RF-02-004` MUST When accepting an offered object, the `object` field of the
   `Accept` activity MUST reference the Offer activity itself (e.g.,
   `OfferCaseOwnershipTransfer`, `RecommendActor`), not the underlying object
   being offered
   - Downstream processing SHOULD rehydrate the referenced Offer to discover
     the underlying offered object
 
-## Reject Response (MUST)
+## Reject Response
 
 - `RF-03-001` Reject responses MUST use `Reject` activity type
   - RF-03-001 implements VP-06-004
 - `RF-03-002` Reject responses SHOULD include reason in `content` field
 - `RF-03-003` Rejecting an Offer of an object MUST reference the Offer activity in the `object` field of the Reject response
-- `RF-03-004` When rejecting an offered object, the `object` field of the
+- `RF-03-004` MUST When rejecting an offered object, the `object` field of the
   `Reject` activity MUST reference the Offer activity itself, not the
   underlying object being offered
   - Downstream processing SHOULD rehydrate the referenced Offer to discover
     the underlying offered object
 
-## TentativeReject Response (MUST)
+## TentativeReject Response
 
 - `RF-04-001` TentativeReject responses MUST use `TentativeReject` activity type
   - RF-04-001 implements VP-06-004
 - `RF-04-002` TentativeReject responses SHOULD include reason in `content` field
 - `RF-04-003` Tentatively Rejecting an Offer of an object MUST reference the Offer activity in the `object` field of the TentativeReject response
-- `RF-04-004` When tentatively rejecting an offered object, the `object` field
+- `RF-04-004` MUST When tentatively rejecting an offered object, the `object` field
   of the `Tentative Reject` activity MUST reference the Offer activity itself,
   not the underlying object being offered
   - Downstream processing SHOULD rehydrate the referenced Offer to discover
     the underlying offered object
 
-## Error Response (MUST)
+## Error Response
 
 - `RF-05-001` Error responses SHOULD use ActivityStreams error extensions
   - Include error type and message
@@ -61,7 +61,7 @@ The Vultron protocol uses ActivityStreams activities for both requests and respo
   - RF-05-001 implements VP-03-011
   - RF-05-001 implements VP-11-005
 
-## Response Delivery (MUST)
+## Response Delivery
 
 - `RF-06-001` Response activities MUST be delivered to the relevant actors' inboxes
 - `RF-06-002` Response activities MUST be addressed to the INITIATING actor's
@@ -75,11 +75,11 @@ The Vultron protocol uses ActivityStreams activities for both requests and respo
     receive the response to update their model of the case state
   - See `notes/activitystreams-semantics.md` for the asymmetric routing pattern and examples
 
-## Response Timing (MUST)
+## Response Timing
 
 - `RF-07-001` Response generation MUST NOT delay inbox acknowledgment
 
-## Response Correlation (MUST)
+## Response Correlation
 
 - `RF-08-001` Response activities MUST include `inReplyTo` field
   - MUST reference the activity ID being responded to
@@ -87,7 +87,7 @@ The Vultron protocol uses ActivityStreams activities for both requests and respo
   - RF-08-001 implements VP-11-004
   - RF-08-001 implements VP-11-005
 
-## Idempotent Responses (MUST)
+## Idempotent Responses
 
 - `RF-09-001` Response generation MUST be idempotent
   - RF-09-001 depends-on ID-02-001

--- a/specs/response-format.md
+++ b/specs/response-format.md
@@ -22,7 +22,7 @@ The Vultron protocol uses ActivityStreams activities for both requests and respo
   - RF-02-001 implements VP-06-004
 - `RF-02-002` Accept responses MUST include `object` field referencing accepted activity or object
 - `RF-02-003` Accepting an Offer of an object MUST reference the Offer activity in the `object` field of the Accept response
-- `RF-02-004` MUST When accepting an offered object, the `object` field of the
+- `RF-02-004` (MUST) When accepting an offered object, the `object` field of the
   `Accept` activity MUST reference the Offer activity itself (e.g.,
   `OfferCaseOwnershipTransfer`, `RecommendActor`), not the underlying object
   being offered
@@ -35,7 +35,7 @@ The Vultron protocol uses ActivityStreams activities for both requests and respo
   - RF-03-001 implements VP-06-004
 - `RF-03-002` Reject responses SHOULD include reason in `content` field
 - `RF-03-003` Rejecting an Offer of an object MUST reference the Offer activity in the `object` field of the Reject response
-- `RF-03-004` MUST When rejecting an offered object, the `object` field of the
+- `RF-03-004` (MUST) When rejecting an offered object, the `object` field of the
   `Reject` activity MUST reference the Offer activity itself, not the
   underlying object being offered
   - Downstream processing SHOULD rehydrate the referenced Offer to discover
@@ -47,7 +47,7 @@ The Vultron protocol uses ActivityStreams activities for both requests and respo
   - RF-04-001 implements VP-06-004
 - `RF-04-002` TentativeReject responses SHOULD include reason in `content` field
 - `RF-04-003` Tentatively Rejecting an Offer of an object MUST reference the Offer activity in the `object` field of the TentativeReject response
-- `RF-04-004` MUST When tentatively rejecting an offered object, the `object` field
+- `RF-04-004` (MUST) When tentatively rejecting an offered object, the `object` field
   of the `Tentative Reject` activity MUST reference the Offer activity itself,
   not the underlying object being offered
   - Downstream processing SHOULD rehydrate the referenced Offer to discover

--- a/specs/semantic-extraction.md
+++ b/specs/semantic-extraction.md
@@ -8,7 +8,7 @@ The inbox handler extracts semantic meaning from ActivityStreams activities by m
 
 ---
 
-## Pattern Matching (MUST)
+## Pattern Matching
 
 - `SE-01-001` The system MUST match activities using activity type and object
   type patterns
@@ -39,23 +39,23 @@ The inbox handler extracts semantic meaning from ActivityStreams activities by m
     and a warning MUST be logged
   - SE-01-004 depends-on SE-01-002
 
-## Semantic Type Assignment (MUST)
+## Semantic Type Assignment
 
 - `SE-02-001` The system MUST assign MessageSemantics enum value via `find_matching_semantics()`
 - `SE-02-002` The function MUST return the first matching semantic type
 - `SE-02-003` The function MUST return MessageSemantics.UNKNOWN if no patterns match
 
-## Pattern Registry (MUST)
+## Pattern Registry
 
 - `SE-03-001` SEMANTICS_ACTIVITY_PATTERNS MUST contain patterns for all supported MessageSemantics values except UNKNOWN
 - `SE-03-002` Pattern registry MUST be ordered from most specific to least specific
 
-## Unrecognized Activity Handling (MUST)
+## Unrecognized Activity Handling
 
 - `SE-04-001` The system MUST log unrecognized activities at WARNING level
 - `SE-04-002` The system MUST raise VultronApiHandlerMissingSemanticError for unmatched activities
 
-## Pattern Validation (MUST)
+## Pattern Validation
 
 - `SE-05-001` All patterns MUST have corresponding MessageSemantics enum value
 - `SE-05-002` All patterns MUST have corresponding use-case class in USE_CASE_MAP

--- a/specs/state-machine.md
+++ b/specs/state-machine.md
@@ -44,7 +44,7 @@ tracking), `behavior-tree-integration.md` BT-06 (BT-driven transitions),
     and debug output that displays the full case state string (e.g., `"VFdPxa"`)
   - Both forms MUST refer to the same string value (the short aliases are
     aliases, not separate states)
-- `SM-01-003` MUST State enum values are the authoritative definition of valid
+- `SM-01-003` (MUST) State enum values are the authoritative definition of valid
   states
   - When documentation and code disagree on state names or valid state
     sets, the enum definitions in `vultron/core/states/` MUST take
@@ -116,7 +116,7 @@ tracking), `behavior-tree-integration.md` BT-06 (BT-driven transitions),
 
 ## State History
 
-- `SM-05-001` MUST Persisted state for both case-level and participant-level
+- `SM-05-001` (MUST) Persisted state for both case-level and participant-level
   axes MUST use an append-only history list
   - New state records (e.g., `VultronCaseStatus`, `VultronParticipantStatus`)
     MUST be appended to the history list; existing entries MUST NOT be
@@ -145,20 +145,20 @@ tracking), `behavior-tree-integration.md` BT-06 (BT-driven transitions),
 
 ## In-Memory (Transient) State
 
-- `SM-06-001` SHOULD Transient state used only during a single request (e.g., for
+- `SM-06-001` (SHOULD) Transient state used only during a single request (e.g., for
   tracking report status during validation processing) SHOULD be clearly
   separated from persisted state
   - Transient state MUST NOT be written to the DataLayer
   - Transient state MUST be documented (e.g., in a module docstring) as
     non-persistent so future developers do not assume it survives a restart
-- `SM-06-002` MUST Transient RM status for reports (e.g., `ReportStatus` in the
+- `SM-06-002` (MUST) Transient RM status for reports (e.g., `ReportStatus` in the
   in-memory `STATUS` dict) MUST be replaced by persisted participant-level
   state once a report is associated with a case and a `CaseParticipant`
   record exists
 
 ## State Subsets and Guards
 
-- `SM-07-001` SHOULD Commonly used groups of states that define validity zones for
+- `SM-07-001` (SHOULD) Commonly used groups of states that define validity zones for
   transitions SHOULD be defined as module-level constants (tuples or
   frozensets) in the same module as the state enum
   - Examples: `RM_ACTIVE = (RM.RECEIVED, RM.VALID, RM.ACCEPTED)`,
@@ -176,7 +176,7 @@ tracking), `behavior-tree-integration.md` BT-06 (BT-driven transitions),
   string value (not as Python enum names or as integers)
   - `StrEnum` satisfies this requirement automatically; using `Enum` or
     `IntEnum` for state axes is prohibited
-- `SM-08-002` MUST When deserializing state values from the DataLayer or from
+- `SM-08-002` (MUST) When deserializing state values from the DataLayer or from
   wire payloads, the receiving Pydantic model MUST declare the state field
   with the `StrEnum` type so that Pydantic coerces the incoming string to
   the correct enum member

--- a/specs/state-machine.md
+++ b/specs/state-machine.md
@@ -26,7 +26,7 @@ tracking), `behavior-tree-integration.md` BT-06 (BT-driven transitions),
 
 ---
 
-## State Enum Design (MUST)
+## State Enum Design
 
 - `SM-01-001` All protocol state axes (RM, EM, VFD, PXA) MUST be defined
   using Python `StrEnum`
@@ -44,7 +44,7 @@ tracking), `behavior-tree-integration.md` BT-06 (BT-driven transitions),
     and debug output that displays the full case state string (e.g., `"VFdPxa"`)
   - Both forms MUST refer to the same string value (the short aliases are
     aliases, not separate states)
-- `SM-01-003` State enum values are the authoritative definition of valid
+- `SM-01-003` MUST State enum values are the authoritative definition of valid
   states
   - When documentation and code disagree on state names or valid state
     sets, the enum definitions in `vultron/core/states/` MUST take
@@ -56,7 +56,7 @@ tracking), `behavior-tree-integration.md` BT-06 (BT-driven transitions),
     than being silently corrected; such discrepancies indicate a potential
     design flaw requiring explicit review
 
-## State Machine Definitions (SHOULD)
+## State Machine Definitions
 
 - `SM-02-001` Each state axis SHOULD have a corresponding
   `create_*_machine()` factory function that produces a `transitions`
@@ -77,7 +77,7 @@ tracking), `behavior-tree-integration.md` BT-06 (BT-driven transitions),
   that trigger strings remain stable and are not inlined as string literals
   scattered across the codebase
 
-## Transition Definitions (SHOULD)
+## Transition Definitions
 
 - `SM-03-001` Each state transition SHOULD be expressed as a typed
   `TransitionBase` subclass with `trigger`, `source`, and `dest` fields
@@ -93,7 +93,7 @@ tracking), `behavior-tree-integration.md` BT-06 (BT-driven transitions),
     (source → dest) pair that the protocol describes MUST have a
     corresponding transition entry
 
-## Runtime State Changes (MUST)
+## Runtime State Changes
 
 - `SM-04-001` Runtime state changes MUST be guarded by an explicit
   precondition check before the state value is written
@@ -114,9 +114,9 @@ tracking), `behavior-tree-integration.md` BT-06 (BT-driven transitions),
     level so that protocol violations are captured in system logs
   - SM-04-002 implements HP-07-001 (handler-protocol.md)
 
-## State History (MUST)
+## State History
 
-- `SM-05-001` Persisted state for both case-level and participant-level
+- `SM-05-001` MUST Persisted state for both case-level and participant-level
   axes MUST use an append-only history list
   - New state records (e.g., `VultronCaseStatus`, `VultronParticipantStatus`)
     MUST be appended to the history list; existing entries MUST NOT be
@@ -143,22 +143,22 @@ tracking), `behavior-tree-integration.md` BT-06 (BT-driven transitions),
   - The pointer list SHOULD be automatically refreshed whenever a state
     event is recorded to the main history log
 
-## In-Memory (Transient) State (SHOULD)
+## In-Memory (Transient) State
 
-- `SM-06-001` Transient state used only during a single request (e.g., for
+- `SM-06-001` SHOULD Transient state used only during a single request (e.g., for
   tracking report status during validation processing) SHOULD be clearly
   separated from persisted state
   - Transient state MUST NOT be written to the DataLayer
   - Transient state MUST be documented (e.g., in a module docstring) as
     non-persistent so future developers do not assume it survives a restart
-- `SM-06-002` Transient RM status for reports (e.g., `ReportStatus` in the
+- `SM-06-002` MUST Transient RM status for reports (e.g., `ReportStatus` in the
   in-memory `STATUS` dict) MUST be replaced by persisted participant-level
   state once a report is associated with a case and a `CaseParticipant`
   record exists
 
-## State Subsets and Guards (SHOULD)
+## State Subsets and Guards
 
-- `SM-07-001` Commonly used groups of states that define validity zones for
+- `SM-07-001` SHOULD Commonly used groups of states that define validity zones for
   transitions SHOULD be defined as module-level constants (tuples or
   frozensets) in the same module as the state enum
   - Examples: `RM_ACTIVE = (RM.RECEIVED, RM.VALID, RM.ACCEPTED)`,
@@ -170,13 +170,13 @@ tracking), `behavior-tree-integration.md` BT-06 (BT-driven transitions),
 - `SM-07-002` State subset constants MUST be derived from enum values, not
   raw strings, to prevent silent mismatches when enum values change
 
-## Wire and DataLayer Compatibility (MUST)
+## Wire and DataLayer Compatibility
 
 - `SM-08-001` State enum values MUST be stored and transmitted as their
   string value (not as Python enum names or as integers)
   - `StrEnum` satisfies this requirement automatically; using `Enum` or
     `IntEnum` for state axes is prohibited
-- `SM-08-002` When deserializing state values from the DataLayer or from
+- `SM-08-002` MUST When deserializing state values from the DataLayer or from
   wire payloads, the receiving Pydantic model MUST declare the state field
   with the `StrEnum` type so that Pydantic coerces the incoming string to
   the correct enum member

--- a/specs/structured-logging.md
+++ b/specs/structured-logging.md
@@ -9,19 +9,19 @@ Consolidated logging requirements for Vultron API v2: log format, correlation ID
 
 ---
 
-## Log Format (MUST)
+## Log Format
 
 - `SL-01-001` `PROD_ONLY` All log entries MUST include `timestamp` field in ISO 8601 format
 - `SL-01-002` `PROD_ONLY` All log entries MUST include `level` field (DEBUG, INFO, WARNING, ERROR, CRITICAL)
 - `SL-01-003` `PROD_ONLY` All log entries MUST include `component` field (module or function name)
 - `SL-01-004` `PROD_ONLY` All log entries MUST include `message` field (human-readable text)
 
-## Correlation IDs (MUST)
+## Correlation IDs
 
 - `SL-02-001` `PROD_ONLY` Log entries MUST include `activity_id` field when activity is available
 - `SL-02-002` `PROD_ONLY` Log entries MUST include `actor_id` field when actor is available
 
-## Log Level Semantics (MUST)
+## Log Level Semantics
 
 - `SL-03-001` Log levels MUST follow standard severity semantics per table below
 
@@ -33,7 +33,7 @@ Consolidated logging requirements for Vultron API v2: log format, correlation ID
 | ERROR | Unrecoverable failures, HTTP 5xx errors | "Failed to store activity", "Handler crashed" |
 | CRITICAL | System-level failures | Reserved for catastrophic failures |
 
-## State Transition Logging (MUST)
+## State Transition Logging
 
 - `SL-04-001` All state transitions MUST be logged at INFO level
 - `SL-04-002` State transition logs MUST include before state
@@ -59,26 +59,26 @@ Example:
 }
 ```
 
-## Error Context (SHOULD)
+## Error Context
 
 - `SL-05-001` ERROR level logs SHOULD include exception type and message
 - `SL-05-002` ERROR level logs SHOULD include stack trace for unexpected exceptions
 - `SL-05-003` ERROR level logs SHOULD include original activity ID if available
 
-## Authorization Logging (SHOULD)
+## Authorization Logging
 
 - `SL-06-001` `PROD_ONLY` Authorization decisions SHOULD be logged with decision (allowed/denied)
 - `SL-06-002` `PROD_ONLY` Authorization logs SHOULD include actor performing action
 - `SL-06-003` `PROD_ONLY` Authorization logs SHOULD include resource being accessed
 - `SL-06-004` `PROD_ONLY` Authorization logs SHOULD include denial reason if denied
 
-## Data Access Logging (SHOULD)
+## Data Access Logging
 
 - `SL-07-001` `PROD_ONLY` Sensitive data operations SHOULD log operation type (CREATE, READ, UPDATE, DELETE)
 - `SL-07-002` `PROD_ONLY` Data access logs SHOULD include resource type and ID
 - `SL-07-003` `PROD_ONLY` Data access logs SHOULD include actor performing operation
 
-## Performance Metrics (MAY)
+## Performance Metrics
 
 - `SL-08-001` `PROD_ONLY` System MAY log performance metrics at DEBUG level
   - Request processing duration

--- a/specs/sync-log-replication.md
+++ b/specs/sync-log-replication.md
@@ -37,7 +37,7 @@ spec captures the normative requirements.
 
 ## Replication Transport
 
-- `SYNC-02-001` MUST Log replication between CaseActor and Participant Actors
+- `SYNC-02-001` (MUST) Log replication between CaseActor and Participant Actors
   MUST use ActivityStreams `Announce` activities as the transport envelope
 - `SYNC-02-002` Each replication message MUST identify the sender, target
   recipient, the log entry hash, and the predecessor hash
@@ -60,7 +60,7 @@ spec captures the normative requirements.
 
 ## Log State in Context
 
-- `SYNC-03-004` SHOULD When a Participant Actor sends any message to the CaseActor,
+- `SYNC-03-004` (SHOULD) When a Participant Actor sends any message to the CaseActor,
   it SHOULD include the hash of its last accepted log entry as a parameter
   in the activity's context field
   - This allows the CaseActor to proactively detect that a participant is
@@ -87,7 +87,7 @@ spec captures the normative requirements.
   case ownership
   - A case ownership transfer implies a replication leadership change; a
     leadership change alone does not imply an ownership transfer
-- `SYNC-06-002` SHOULD The conditions under which replication leadership changes
+- `SYNC-06-002` (SHOULD) The conditions under which replication leadership changes
   SHOULD be documented in `notes/sync-log-replication.md`
 
 ## Testing
@@ -108,13 +108,13 @@ preserved under normal operation and partial failure:
 
 - `SYNC-08-001` Append-only integrity: log entries MUST be immutable once
   committed and MUST be uniquely identified by their content hash
-- `SYNC-08-002` MUST Deterministic projection: given an identical log prefix,
+- `SYNC-08-002` (MUST) Deterministic projection: given an identical log prefix,
   all compliant implementations MUST derive identical state
-- `SYNC-08-003` MUST NOT Idempotent replay: reprocessing any log prefix (including
+- `SYNC-08-003` (MUST NOT) Idempotent replay: reprocessing any log prefix (including
   duplicates) MUST NOT change the resulting state
 - `SYNC-08-004` Monotonic visibility: participants MUST NOT regress their
   acknowledged log position
-- `SYNC-08-005` MUST Reject-on-divergence: entries that do not extend the current
+- `SYNC-08-005` (MUST) Reject-on-divergence: entries that do not extend the current
   hash chain MUST be rejected and MUST trigger resynchronization
 
 **Note**: All specs interacting with state, messaging, or storage MUST treat

--- a/specs/sync-log-replication.md
+++ b/specs/sync-log-replication.md
@@ -17,7 +17,7 @@ spec captures the normative requirements.
 
 ---
 
-## Append-Only Log (MUST)
+## Append-Only Log
 
 - `SYNC-01-001` The local case event log MUST be append-only; log entries
   MUST be immutable once appended
@@ -35,9 +35,9 @@ spec captures the normative requirements.
   as the single authoritative write path
   - SYNC-01-004 implements CM-02-009 (case-management.md)
 
-## Replication Transport (MUST)
+## Replication Transport
 
-- `SYNC-02-001` Log replication between CaseActor and Participant Actors
+- `SYNC-02-001` MUST Log replication between CaseActor and Participant Actors
   MUST use ActivityStreams `Announce` activities as the transport envelope
 - `SYNC-02-002` Each replication message MUST identify the sender, target
   recipient, the log entry hash, and the predecessor hash
@@ -45,7 +45,7 @@ spec captures the normative requirements.
   (initially the CaseActor) and be sent to each Participant Actor
   individually
 
-## Conflict Handling (MUST)
+## Conflict Handling
 
 - `SYNC-03-001` A receiver MUST reject a replication message whose
   predecessor hash does not match the receiver's current log tail hash
@@ -58,39 +58,39 @@ spec captures the normative requirements.
   same log entry MUST NOT produce duplicate entries in the receiver's log
   - SYNC-03-003 implements IDEM-01-001 (idempotency.md)
 
-## Log State in Context (SHOULD)
+## Log State in Context
 
-- `SYNC-03-004` When a Participant Actor sends any message to the CaseActor,
+- `SYNC-03-004` SHOULD When a Participant Actor sends any message to the CaseActor,
   it SHOULD include the hash of its last accepted log entry as a parameter
   in the activity's context field
   - This allows the CaseActor to proactively detect that a participant is
     behind and immediately replay missing entries without waiting for an
     explicit sync request
 
-## Per-Peer Replication State (MUST)
+## Per-Peer Replication State
 
 - `SYNC-04-001` The replication leader MUST track per-peer state including
   at minimum the last acknowledged log entry hash for each peer
 - `SYNC-04-002` Per-peer replication state MUST be persisted via the
   DataLayer so that it survives a leader restart
 
-## Retry and Backoff (SHOULD)
+## Retry and Backoff
 
 - `SYNC-05-001` The replication sender SHOULD implement retry with
   exponential backoff on delivery failure
 - `SYNC-05-002` Retry and backoff parameters SHOULD be configurable;
   default values MUST be documented
 
-## Leadership and Ownership (SHOULD)
+## Leadership and Ownership
 
 - `SYNC-06-001` Replication leadership SHOULD be treated as distinct from
   case ownership
   - A case ownership transfer implies a replication leadership change; a
     leadership change alone does not imply an ownership transfer
-- `SYNC-06-002` The conditions under which replication leadership changes
+- `SYNC-06-002` SHOULD The conditions under which replication leadership changes
   SHOULD be documented in `notes/sync-log-replication.md`
 
-## Testing (MUST)
+## Testing
 
 - `SYNC-07-001` Unit tests MUST cover append-only semantics: entries are
   immutable, hashes are unique, and predecessor hash references are set correctly
@@ -101,20 +101,20 @@ spec captures the normative requirements.
   mismatched predecessor hash, duplicate delivery, and leader retry after
   rejection
 
-## System Invariants (MUST)
+## System Invariants
 
 The log-centric architecture requires the following invariants to be
 preserved under normal operation and partial failure:
 
 - `SYNC-08-001` Append-only integrity: log entries MUST be immutable once
   committed and MUST be uniquely identified by their content hash
-- `SYNC-08-002` Deterministic projection: given an identical log prefix,
+- `SYNC-08-002` MUST Deterministic projection: given an identical log prefix,
   all compliant implementations MUST derive identical state
-- `SYNC-08-003` Idempotent replay: reprocessing any log prefix (including
+- `SYNC-08-003` MUST NOT Idempotent replay: reprocessing any log prefix (including
   duplicates) MUST NOT change the resulting state
 - `SYNC-08-004` Monotonic visibility: participants MUST NOT regress their
   acknowledged log position
-- `SYNC-08-005` Reject-on-divergence: entries that do not extend the current
+- `SYNC-08-005` MUST Reject-on-divergence: entries that do not extend the current
   hash chain MUST be rejected and MUST trigger resynchronization
 
 **Note**: All specs interacting with state, messaging, or storage MUST treat

--- a/specs/tech-stack.md
+++ b/specs/tech-stack.md
@@ -12,7 +12,7 @@ This specification defines the normative technology constraints and implementati
 ## Runtime and Language
 
 - `IMPL-TS-01-001` The implementation MUST use Python 3.12 or later.
-- `IMPL-TS-01-007` MUST Before updating the `requires-python` floor in
+- `IMPL-TS-01-007` (MUST) Before updating the `requires-python` floor in
   `pyproject.toml`, the full test suite MUST pass on the target Python
   version in CI, and all static type checks (`mypy`, `pyright`) and linters
   MUST pass under the new runtime
@@ -91,7 +91,7 @@ This specification defines the normative technology constraints and implementati
   jobs pass.
   - **Rationale**: Parallel execution surfaces all failures simultaneously,
     reducing fix-cycle time and preserving the known-clean codebase baseline.
-- `IMPL-TS-07-006` MUST The pytest configuration in `[tool.pytest.ini_options]`
+- `IMPL-TS-07-006` (MUST) The pytest configuration in `[tool.pytest.ini_options]`
   MUST include `filterwarnings = ["error"]` so that test-suite warnings are
   treated as errors and cannot accumulate as silent technical debt. Existing
   warnings MUST be resolved before this setting is activated; new warnings

--- a/specs/tech-stack.md
+++ b/specs/tech-stack.md
@@ -9,10 +9,10 @@ This specification defines the normative technology constraints and implementati
 
 ---
 
-## Runtime and Language (MUST)
+## Runtime and Language
 
 - `IMPL-TS-01-001` The implementation MUST use Python 3.12 or later.
-- `IMPL-TS-01-007` Before updating the `requires-python` floor in
+- `IMPL-TS-01-007` MUST Before updating the `requires-python` floor in
   `pyproject.toml`, the full test suite MUST pass on the target Python
   version in CI, and all static type checks (`mypy`, `pyright`) and linters
   MUST pass under the new runtime
@@ -33,7 +33,7 @@ This specification defines the normative technology constraints and implementati
 
 ---
 
-## Persistence and Data (MUST)
+## Persistence and Data
 
 - `IMPL-TS-02-001` The prototype MUST use TinyDB for lightweight local persistence.
 - `IMPL-TS-02-002` The system MUST support JSON-based storage for demo and local development use.
@@ -42,7 +42,7 @@ This specification defines the normative technology constraints and implementati
 
 ---
 
-## Interfaces and Tooling (MUST)
+## Interfaces and Tooling
 
 - `IMPL-TS-03-001` Command line interfaces MUST be implemented using `click`.
 - `IMPL-TS-03-002` The system MUST support HTTP interactions with external services using requests.
@@ -51,7 +51,7 @@ This specification defines the normative technology constraints and implementati
 
 ---
 
-## Documentation and Visualization (SHOULD)
+## Documentation and Visualization
 
 - `IMPL-TS-04-001` The project SHOULD generate static documentation using MkDocs.
 - `IMPL-TS-04-002` The documentation SHOULD use `mkdocstrings` for API reference generation.
@@ -60,7 +60,7 @@ This specification defines the normative technology constraints and implementati
 
 ---
 
-## Containerization and Deployment (SHOULD)
+## Containerization and Deployment
 
 - `IMPL-TS-05-001` The system SHOULD support containerization using Docker.
 - `IMPL-TS-05-002` Multi-container demo environments SHOULD be orchestrated using `docker-compose`.
@@ -72,7 +72,7 @@ This specification defines the normative technology constraints and implementati
 
 ---
 
-## Code Quality Tooling (MUST)
+## Code Quality Tooling
 
 - `IMPL-TS-07-001` The project MUST use Black for code formatting; Black
   MUST be enforced via pre-commit hooks AND in the CI pipeline.
@@ -91,7 +91,7 @@ This specification defines the normative technology constraints and implementati
   jobs pass.
   - **Rationale**: Parallel execution surfaces all failures simultaneously,
     reducing fix-cycle time and preserving the known-clean codebase baseline.
-- `IMPL-TS-07-006` The pytest configuration in `[tool.pytest.ini_options]`
+- `IMPL-TS-07-006` MUST The pytest configuration in `[tool.pytest.ini_options]`
   MUST include `filterwarnings = ["error"]` so that test-suite warnings are
   treated as errors and cannot accumulate as silent technical debt. Existing
   warnings MUST be resolved before this setting is activated; new warnings
@@ -103,7 +103,7 @@ This specification defines the normative technology constraints and implementati
 
 ---
 
-## Optional and Prototype Extensions (MAY)
+## Optional and Prototype Extensions
 
 - `IMPL-TS-06-001` The system MAY provide interactive demo interfaces using Streamlit.
 - `IMPL-TS-06-002` The project MAY use uv for Python environment and dependency management.

--- a/specs/testability.md
+++ b/specs/testability.md
@@ -112,7 +112,7 @@ The Vultron inbox handler must be thoroughly testable at unit, integration, and 
 
 ## Architecture Boundary Tests
 
-- `TB-10-001` SHOULD `PROD_ONLY` Once the `core` and `wire` packages are fully
+- `TB-10-001` (SHOULD) `PROD_ONLY` Once the `core` and `wire` packages are fully
   separated (see `specs/architecture.md` and `notes/architecture-review.md`),
   architecture boundary tests SHOULD be added to enforce layer separation rules
   - Tests SHOULD verify that `vultron/core/` does not import from

--- a/specs/testability.md
+++ b/specs/testability.md
@@ -8,12 +8,12 @@ The Vultron inbox handler must be thoroughly testable at unit, integration, and 
 
 ---
 
-## Testing Framework (MUST)
+## Testing Framework
 
 - `TB-01-001` The system MUST use pytest as the testing framework
 - `TB-01-002` Test configuration MUST be defined in `pyproject.toml`
 
-## Test Coverage (MUST)
+## Test Coverage
 
 - `TB-02-001` Unit tests MUST achieve 80%+ line coverage
 - `TB-02-002` Critical paths MUST achieve 100% line coverage
@@ -22,13 +22,13 @@ The Vultron inbox handler must be thoroughly testable at unit, integration, and 
   - Dispatch routing
   - Error handling
 
-## Integration Test Coverage (MUST)
+## Integration Test Coverage
 
 - `TB-03-001` Integration tests MUST cover inbox POST → handler invocation flow
 - `TB-03-002` Integration tests MUST cover validation → error response flow
 - `TB-03-003` Integration tests MUST verify async processing behavior
 
-## Test Organization (MUST)
+## Test Organization
 
 - `TB-04-001` Test structure MUST mirror source code structure
   - `test/adapters/` mirrors `vultron/adapters/`
@@ -37,7 +37,7 @@ The Vultron inbox handler must be thoroughly testable at unit, integration, and 
 - `TB-04-002` Test files MUST use descriptive names starting with `test_`
 - `TB-04-003` Unit and integration tests MUST be in separate directories or marked with pytest markers
 
-## Test Data Management (MUST)
+## Test Data Management
 
 - `TB-05-001` The system MUST provide reusable test fixtures
 - `TB-05-002` Test data MUST be generated via factories, not hardcoded
@@ -55,7 +55,7 @@ The Vultron inbox handler must be thoroughly testable at unit, integration, and 
     key lookup at dispatch time; mismatched tests bypass actual code paths
   - **Verification**: Each test uses the semantic type that would be extracted from the activity
 
-## Test Isolation (MUST)
+## Test Isolation
 
 - `TB-06-001` Tests MUST be independent and runnable in any order
 - `TB-06-002` Tests MUST use test database or mocked database
@@ -92,27 +92,27 @@ The Vultron inbox handler must be thoroughly testable at unit, integration, and 
     failures, and slow development. A flaky test MUST be fixed or removed;
     it MUST NOT be left in the suite.
 
-## Mocking and Stubbing (MUST)
+## Mocking and Stubbing
 
 - `TB-07-001` External services MUST be mocked in unit tests
 - `TB-07-002` Database access MUST be stubbed in unit tests
 - `TB-07-003` Integration tests MAY use real database with test data
 
-## Test Documentation (MUST)
+## Test Documentation
 
 - `TB-08-001` Tests MUST use descriptive names explaining what is tested
 - `TB-08-002` Complex tests SHOULD include docstrings
 - `TB-08-003` Tests SHOULD serve as usage examples
 
-## Test Maintainability (MUST)
+## Test Maintainability
 
 - `TB-09-001` Tests MUST be kept simple and readable
 - `TB-09-002` Test duplication SHOULD be avoided via fixtures and helpers
 - `TB-09-003` Tests MUST be refactored along with production code
 
-## Architecture Boundary Tests (SHOULD)
+## Architecture Boundary Tests
 
-- `TB-10-001` `PROD_ONLY` Once the `core` and `wire` packages are fully
+- `TB-10-001` SHOULD `PROD_ONLY` Once the `core` and `wire` packages are fully
   separated (see `specs/architecture.md` and `notes/architecture-review.md`),
   architecture boundary tests SHOULD be added to enforce layer separation rules
   - Tests SHOULD verify that `vultron/core/` does not import from

--- a/specs/traceability.md
+++ b/specs/traceability.md
@@ -11,7 +11,7 @@ to specification requirements.
 
 ---
 
-## Traceability Matrix (MUST)
+## Traceability Matrix
 
 - `TRACE-01-001` A traceability file MUST exist at
   `notes/user-stories-trace.md` mapping each user story in
@@ -23,7 +23,7 @@ to specification requirements.
   specifications are added or existing requirements are significantly changed
   in a way that affects story coverage
 
-## Maintenance (SHOULD)
+## Maintenance
 
 - `TRACE-02-001` The traceability matrix SHOULD be reviewed and updated as
   part of any spec-authoring or user-story-authoring activity

--- a/specs/triggerable-behaviors.md
+++ b/specs/triggerable-behaviors.md
@@ -20,7 +20,7 @@ them; a complete implementation requires both reactive and triggerable sides.
 
 ---
 
-## Endpoint Format (MUST)
+## Endpoint Format
 
 - `TRIG-01-001` The system MUST expose trigger endpoints using the path
   pattern `POST /actors/{actor_id}/trigger/{behavior-name}`
@@ -48,7 +48,7 @@ them; a complete implementation requires both reactive and triggerable sides.
 
 ---
 
-## Candidate RM Behaviors (SHOULD)
+## Candidate RM Behaviors
 
 - `TRIG-02-001` The following RM behaviors SHOULD be individually
   triggerable via the trigger API:
@@ -71,7 +71,7 @@ them; a complete implementation requires both reactive and triggerable sides.
 
 ---
 
-## Candidate EM Behaviors (SHOULD)
+## Candidate EM Behaviors
 
 - `TRIG-02-002` The following EM behaviors SHOULD be individually
   triggerable via the trigger API:
@@ -84,7 +84,7 @@ them; a complete implementation requires both reactive and triggerable sides.
 
 ---
 
-## Additional Candidate Behaviors (MAY)
+## Additional Candidate Behaviors
 
 - `TRIG-02-003` The following additional behaviors MAY be individually
   triggerable via the trigger API in a later phase:
@@ -97,7 +97,7 @@ them; a complete implementation requires both reactive and triggerable sides.
 
 ---
 
-## Request Body (MUST)
+## Request Body
 
 - `TRIG-03-001` The trigger endpoint request body MUST be a JSON object
   containing sufficient context to identify the target report or case:
@@ -123,7 +123,7 @@ them; a complete implementation requires both reactive and triggerable sides.
 
 ---
 
-## Response Body (SHOULD)
+## Response Body
 
 - `TRIG-04-001` A successful trigger response SHOULD include the resulting
   ActivityStreams activity in the response body under an `activity` key:
@@ -134,14 +134,14 @@ them; a complete implementation requires both reactive and triggerable sides.
   }
   ```
 
-- `TRIG-04-002` `PROD_ONLY` When a trigger initiates a long-running
+- `TRIG-04-002` MAY `PROD_ONLY` When a trigger initiates a long-running
   behavior, the response MAY return a job object per `AR-04-001`
   instead of the activity directly
   - TRIG-04-002 depends-on AR-04-001
 
 ---
 
-## BT Integration (SHOULD)
+## BT Integration
 
 - `TRIG-05-001` Trigger endpoint implementations SHOULD reuse existing
   BT trees rather than duplicating behavior logic
@@ -154,7 +154,7 @@ them; a complete implementation requires both reactive and triggerable sides.
 
 ---
 
-## Per-Actor DataLayer (MUST)
+## Per-Actor DataLayer
 
 - `TRIG-06-001` Trigger endpoints MUST resolve the correct per-actor
   DataLayer instance using the `actor_id` path parameter
@@ -168,7 +168,7 @@ them; a complete implementation requires both reactive and triggerable sides.
 
 ---
 
-## Outbox Activity (MUST)
+## Outbox Activity
 
 - `TRIG-07-001` A successfully executed trigger MUST produce an outgoing
   ActivityStreams activity added to the actor's outbox

--- a/specs/triggerable-behaviors.md
+++ b/specs/triggerable-behaviors.md
@@ -134,7 +134,7 @@ them; a complete implementation requires both reactive and triggerable sides.
   }
   ```
 
-- `TRIG-04-002` MAY `PROD_ONLY` When a trigger initiates a long-running
+- `TRIG-04-002` (MAY) `PROD_ONLY` When a trigger initiates a long-running
   behavior, the response MAY return a job object per `AR-04-001`
   instead of the activity directly
   - TRIG-04-002 depends-on AR-04-001

--- a/specs/use-case-organization.md
+++ b/specs/use-case-organization.md
@@ -12,21 +12,21 @@ trigger → received → sync information flow pattern.
 
 ---
 
-## Package Layout (MUST)
+## Package Layout
 
-- `UC-ORG-01-001` Use-case classes that process inbound received messages
+- `UC-ORG-01-001` MUST Use-case classes that process inbound received messages
   MUST reside under `vultron/core/use_cases/received/`
   - Modules in `received/` SHOULD group use cases by protocol domain
     (e.g., `report.py`, `case.py`, `embargo.py`, `participant.py`)
   - UC-ORG-01-001 implements CS-12-002 (code-style.md)
-- `UC-ORG-01-002` Trigger use-case classes that implement actor-initiated
+- `UC-ORG-01-002` MUST Trigger use-case classes that implement actor-initiated
   behaviors MUST reside under `vultron/core/use_cases/triggers/`
   - UC-ORG-01-002 implements CS-12-002 (code-style.md)
 - `UC-ORG-01-003` The `vultron/core/use_cases/` package root MUST contain
   only `__init__.py` and `use_case_map.py`; use-case implementations MUST
   NOT be placed at the root level
 
-## Registry Synchronization (MUST)
+## Registry Synchronization
 
 - `UC-ORG-02-001` Any relocation or rename of a use-case class MUST update
   `USE_CASE_MAP` in `vultron/core/use_cases/use_case_map.py` in the same
@@ -37,7 +37,7 @@ trigger → received → sync information flow pattern.
   - The test MUST live in `test/core/use_cases/test_use_case_map.py` or an
     equivalent coverage module
 
-## Test Layout (MUST)
+## Test Layout
 
 - `UC-ORG-03-001` Tests MUST mirror the source layout:
   - `test/core/use_cases/received/` mirrors
@@ -46,9 +46,9 @@ trigger → received → sync information flow pattern.
     `vultron/core/use_cases/triggers/`
   - UC-ORG-03-001 refines TB-04-001 (testability.md)
 
-## Information Flow Documentation (SHOULD)
+## Information Flow Documentation
 
-- `UC-ORG-04-001` The trigger → received → sync information flow pattern
+- `UC-ORG-04-001` SHOULD The trigger → received → sync information flow pattern
   SHOULD be documented in `notes/` and summarized in a `README.md` under
   `vultron/core/use_cases/`
   - Pattern: local triggers emit outbound activities; received handlers

--- a/specs/use-case-organization.md
+++ b/specs/use-case-organization.md
@@ -14,12 +14,12 @@ trigger → received → sync information flow pattern.
 
 ## Package Layout
 
-- `UC-ORG-01-001` MUST Use-case classes that process inbound received messages
+- `UC-ORG-01-001` (MUST) Use-case classes that process inbound received messages
   MUST reside under `vultron/core/use_cases/received/`
   - Modules in `received/` SHOULD group use cases by protocol domain
     (e.g., `report.py`, `case.py`, `embargo.py`, `participant.py`)
   - UC-ORG-01-001 implements CS-12-002 (code-style.md)
-- `UC-ORG-01-002` MUST Trigger use-case classes that implement actor-initiated
+- `UC-ORG-01-002` (MUST) Trigger use-case classes that implement actor-initiated
   behaviors MUST reside under `vultron/core/use_cases/triggers/`
   - UC-ORG-01-002 implements CS-12-002 (code-style.md)
 - `UC-ORG-01-003` The `vultron/core/use_cases/` package root MUST contain
@@ -48,7 +48,7 @@ trigger → received → sync information flow pattern.
 
 ## Information Flow Documentation
 
-- `UC-ORG-04-001` SHOULD The trigger → received → sync information flow pattern
+- `UC-ORG-04-001` (SHOULD) The trigger → received → sync information flow pattern
   SHOULD be documented in `notes/` and summarized in a `README.md` under
   `vultron/core/use_cases/`
   - Pattern: local triggers emit outbound activities; received handlers

--- a/specs/vocabulary-model.md
+++ b/specs/vocabulary-model.md
@@ -19,9 +19,9 @@ type before semantic extraction can assign it a domain meaning.
 
 ---
 
-## Vocabulary Registration (MUST)
+## Vocabulary Registration
 
-- `VM-01-001` Every concrete wire-layer AS2 class (object, activity, or link)
+- `VM-01-001` MUST Every concrete wire-layer AS2 class (object, activity, or link)
   MUST be registered in the shared `VOCABULARY` registry at module import time
   using the appropriate decorator:
   - `@activitystreams_object` for object subclasses
@@ -57,7 +57,7 @@ type before semantic extraction can assign it a domain meaning.
     SHOULD be evaluated; the goal is to prevent runtime failures from
     unimported vocabulary modules
 
-## Base Model Configuration (MUST)
+## Base Model Configuration
 
 - `VM-02-001` All wire-layer AS2 Pydantic models MUST inherit `model_config`
   from `as_Base` (or an intermediate class that inherits from `as_Base`),
@@ -82,7 +82,7 @@ type before semantic extraction can assign it a domain meaning.
     ways that change the `exclude_none=True` or `by_alias=True` defaults,
     as doing so would produce non-standard AS2 output
 
-## Type Auto-Inference (MUST)
+## Type Auto-Inference
 
 - `VM-03-001` The `as_type` field on every concrete wire-layer class MUST be
   set automatically at construction time if not supplied by the caller
@@ -103,7 +103,7 @@ type before semantic extraction can assign it a domain meaning.
     field because AS2 type names do not carry this prefix
   - VM-03-003 constrains VM-03-001
 
-## ID Generation (MUST)
+## ID Generation
 
 - `VM-04-001` All wire-layer objects MUST have a globally unique `as_id`
   field set at construction time by `generate_new_id()` if not supplied
@@ -113,9 +113,9 @@ type before semantic extraction can assign it a domain meaning.
     to `generate_new_id(prefix)` to produce `https://…/{uuid}` style IDs
   - VM-04-001 implements OID-01-001
 
-## Vocabulary Extension (MUST)
+## Vocabulary Extension
 
-- `VM-05-001` When adding a new Vultron-specific object type, the new class
+- `VM-05-001` MUST When adding a new Vultron-specific object type, the new class
   MUST:
   1. Inherit from `VultronObject` (or an appropriate AS2 base such as
      `as_Object`, `as_Activity`, etc.)
@@ -127,7 +127,7 @@ type before semantic extraction can assign it a domain meaning.
      (`vocab/objects/`, `vocab/activities/`)
   5. Be exported from the subpackage `__init__.py` so that it is imported
      and registered at startup
-- `VM-05-002` Adding a new vocabulary type that represents a domain concept
+- `VM-05-002` MUST Adding a new vocabulary type that represents a domain concept
   MUST be accompanied by:
   - A `MessageSemantics` enum value (see `architecture.md` ARCH-02-001)
   - An `ActivityPattern` in `extractor.py` (see `semantic-extraction.md`
@@ -135,9 +135,9 @@ type before semantic extraction can assign it a domain meaning.
   - A handler use-case class registered in `USE_CASE_MAP`
   - Tests for pattern matching and dispatch
 
-## Rehydration (MUST)
+## Rehydration
 
-- `VM-06-001` Before any wire-layer activity is passed to semantic extraction,
+- `VM-06-001` MUST Before any wire-layer activity is passed to semantic extraction,
   callers MUST attempt to rehydrate all nested URI string references into
   fully typed objects via `rehydrate(obj, dl)`
   - VM-06-001 refines SE-01-002 (semantic-extraction.md)
@@ -152,20 +152,20 @@ type before semantic extraction can assign it a domain meaning.
   rehydrated up to `MAX_REHYDRATION_DEPTH` levels
   - Exceeding `MAX_REHYDRATION_DEPTH` MUST raise `RecursionError` to
     prevent infinite loops on circular reference graphs
-- `VM-06-004` If a URI string reference cannot be resolved (object not in
+- `VM-06-004` MUST If a URI string reference cannot be resolved (object not in
   DataLayer), rehydration MUST:
   - Log a warning identifying the unresolvable URI
   - Raise `ValueError` to indicate that the object cannot be found
   - The caller (semantic extraction pipeline) then returns
     `MessageSemantics.UNKNOWN`
   - VM-06-004 implements SE-01-003 (semantic-extraction.md)
-- `VM-06-005` If a rehydrated object's `as_type` is not found in the
+- `VM-06-005` MUST If a rehydrated object's `as_type` is not found in the
   vocabulary registry, rehydration MUST raise `KeyError` or `ValueError`
   rather than returning a partially constructed object
   - An unknown type in the rehydration path indicates a vocabulary
     registration gap that MUST be corrected before deployment
 
-## Serialization Rules (MUST)
+## Serialization Rules
 
 - `VM-07-001` Serialized wire-layer objects MUST exclude `None` fields and
   MUST exclude empty string fields
@@ -186,9 +186,9 @@ type before semantic extraction can assign it a domain meaning.
     type name (without the `as_` prefix); a value starting with `"as_"` would
     break `find_in_vocabulary()` lookup during `record_to_object()`
 
-## Static Object Integrity (SHOULD)
+## Static Object Integrity
 
-- `VM-08-001` Objects intended to be static once created (e.g., vocabulary
+- `VM-08-001` SHOULD Objects intended to be static once created (e.g., vocabulary
   registry entries, canonical example objects) SHOULD use immutable
   (frozen) configuration so that any attempt to modify them at runtime
   raises an exception
@@ -197,9 +197,9 @@ type before semantic extraction can assign it a domain meaning.
   - Immutability ensures that runtime integrity violations are caught
     immediately rather than silently corrupting shared state
 
-## Unknown Message Handling (MAY)
+## Unknown Message Handling
 
-- `VM-09-001` Messages that cannot be parsed or whose semantics are unknown
+- `VM-09-001` MAY Messages that cannot be parsed or whose semantics are unknown
   MAY still be forwarded to the case event log to create an entry for
   human or agent review
   - This provides an opening for manual override: a user or advanced agent

--- a/specs/vocabulary-model.md
+++ b/specs/vocabulary-model.md
@@ -21,7 +21,7 @@ type before semantic extraction can assign it a domain meaning.
 
 ## Vocabulary Registration
 
-- `VM-01-001` MUST Every concrete wire-layer AS2 class (object, activity, or link)
+- `VM-01-001` (MUST) Every concrete wire-layer AS2 class (object, activity, or link)
   MUST be registered in the shared `VOCABULARY` registry at module import time
   using the appropriate decorator:
   - `@activitystreams_object` for object subclasses
@@ -115,7 +115,7 @@ type before semantic extraction can assign it a domain meaning.
 
 ## Vocabulary Extension
 
-- `VM-05-001` MUST When adding a new Vultron-specific object type, the new class
+- `VM-05-001` (MUST) When adding a new Vultron-specific object type, the new class
   MUST:
   1. Inherit from `VultronObject` (or an appropriate AS2 base such as
      `as_Object`, `as_Activity`, etc.)
@@ -127,7 +127,7 @@ type before semantic extraction can assign it a domain meaning.
      (`vocab/objects/`, `vocab/activities/`)
   5. Be exported from the subpackage `__init__.py` so that it is imported
      and registered at startup
-- `VM-05-002` MUST Adding a new vocabulary type that represents a domain concept
+- `VM-05-002` (MUST) Adding a new vocabulary type that represents a domain concept
   MUST be accompanied by:
   - A `MessageSemantics` enum value (see `architecture.md` ARCH-02-001)
   - An `ActivityPattern` in `extractor.py` (see `semantic-extraction.md`
@@ -137,7 +137,7 @@ type before semantic extraction can assign it a domain meaning.
 
 ## Rehydration
 
-- `VM-06-001` MUST Before any wire-layer activity is passed to semantic extraction,
+- `VM-06-001` (MUST) Before any wire-layer activity is passed to semantic extraction,
   callers MUST attempt to rehydrate all nested URI string references into
   fully typed objects via `rehydrate(obj, dl)`
   - VM-06-001 refines SE-01-002 (semantic-extraction.md)
@@ -152,14 +152,14 @@ type before semantic extraction can assign it a domain meaning.
   rehydrated up to `MAX_REHYDRATION_DEPTH` levels
   - Exceeding `MAX_REHYDRATION_DEPTH` MUST raise `RecursionError` to
     prevent infinite loops on circular reference graphs
-- `VM-06-004` MUST If a URI string reference cannot be resolved (object not in
+- `VM-06-004` (MUST) If a URI string reference cannot be resolved (object not in
   DataLayer), rehydration MUST:
   - Log a warning identifying the unresolvable URI
   - Raise `ValueError` to indicate that the object cannot be found
   - The caller (semantic extraction pipeline) then returns
     `MessageSemantics.UNKNOWN`
   - VM-06-004 implements SE-01-003 (semantic-extraction.md)
-- `VM-06-005` MUST If a rehydrated object's `as_type` is not found in the
+- `VM-06-005` (MUST) If a rehydrated object's `as_type` is not found in the
   vocabulary registry, rehydration MUST raise `KeyError` or `ValueError`
   rather than returning a partially constructed object
   - An unknown type in the rehydration path indicates a vocabulary
@@ -188,7 +188,7 @@ type before semantic extraction can assign it a domain meaning.
 
 ## Static Object Integrity
 
-- `VM-08-001` SHOULD Objects intended to be static once created (e.g., vocabulary
+- `VM-08-001` (SHOULD) Objects intended to be static once created (e.g., vocabulary
   registry entries, canonical example objects) SHOULD use immutable
   (frozen) configuration so that any attempt to modify them at runtime
   raises an exception
@@ -199,7 +199,7 @@ type before semantic extraction can assign it a domain meaning.
 
 ## Unknown Message Handling
 
-- `VM-09-001` MAY Messages that cannot be parsed or whose semantics are unknown
+- `VM-09-001` (MAY) Messages that cannot be parsed or whose semantics are unknown
   MAY still be forwarded to the case event log to create an entry for
   human or agent review
   - This provides an opening for manual override: a user or advanced agent

--- a/specs/vultron-as2-mapping.md
+++ b/specs/vultron-as2-mapping.md
@@ -52,7 +52,7 @@ sole implementation location for the AS2 mapping.
 - `VAM-01-004` An AS2 activity MUST be rehydrated (URI string references
   expanded to full objects via the DataLayer) before pattern matching; pattern
   matching MUST NOT rely on unhydrated string fields for type discrimination
-- `VAM-01-005` MUST When a pattern specifies a nested activity as the `object` field,
+- `VAM-01-005` (MUST) When a pattern specifies a nested activity as the `object` field,
   the outer activity's `object` MUST be a fully rehydrated AS2 activity object
   matching the inner `ActivityPattern`
 - `VAM-01-006` Pattern matching MUST be conservative when a field is a
@@ -60,7 +60,7 @@ sole implementation location for the AS2 mapping.
   expected type rather than failing the match
 - `VAM-01-007` `MessageSemantics.UNKNOWN` MUST be returned when no registered
   pattern matches the incoming activity
-- `VAM-01-008` MUST Inbound activities represent state-change notifications, not
+- `VAM-01-008` (MUST) Inbound activities represent state-change notifications, not
   commands; the AS2 activity type used for each semantic MUST reflect the
   completed state transition, not a requested action
   - See `notes/activitystreams-semantics.md` for the full treatment of this
@@ -297,7 +297,7 @@ participant.
 
 ## Unrecognized Activities
 
-- `VAM-09-001` MUST An inbound AS2 activity that does not match any registered
+- `VAM-09-001` (MUST) An inbound AS2 activity that does not match any registered
   pattern MUST be assigned `MessageSemantics.UNKNOWN`
 - `VAM-09-002` `MessageSemantics.UNKNOWN` MUST NOT have an entry in
   `SEMANTICS_ACTIVITY_PATTERNS`; the fallback is implemented by

--- a/specs/vultron-as2-mapping.md
+++ b/specs/vultron-as2-mapping.md
@@ -21,11 +21,11 @@ sole implementation location for the AS2 mapping.
 
 **Notation used in this document**:
 
-- `Verb(Object)` MUST — an AS2 activity of type `Verb` whose `object` field is of
+- `Verb(Object)` — an AS2 activity of type `Verb` whose `object` field is of
   type `Object`
-- `Verb(Object)[field=Type]` MUST — the activity additionally requires `field` to
+- `Verb(Object)[field=Type]` — the activity additionally requires `field` to
   be of type `Type` (e.g., `target=VulnerabilityCase`)
-- `Verb(Verb2(Object)[…])` MUST — a nested pattern: the outer activity's `object`
+- `Verb(Verb2(Object)[…])` — a nested pattern: the outer activity's `object`
   field is itself an activity matching the inner pattern; the inner pattern is
   matched against the rehydrated `object` field
 - AS2 core types are rendered in `CamelCase` without a namespace prefix

--- a/specs/vultron-as2-mapping.md
+++ b/specs/vultron-as2-mapping.md
@@ -21,11 +21,11 @@ sole implementation location for the AS2 mapping.
 
 **Notation used in this document**:
 
-- `Verb(Object)` — an AS2 activity of type `Verb` whose `object` field is of
+- `Verb(Object)` MUST — an AS2 activity of type `Verb` whose `object` field is of
   type `Object`
-- `Verb(Object)[field=Type]` — the activity additionally requires `field` to
+- `Verb(Object)[field=Type]` MUST — the activity additionally requires `field` to
   be of type `Type` (e.g., `target=VulnerabilityCase`)
-- `Verb(Verb2(Object)[…])` — a nested pattern: the outer activity's `object`
+- `Verb(Verb2(Object)[…])` MUST — a nested pattern: the outer activity's `object`
   field is itself an activity matching the inner pattern; the inner pattern is
   matched against the rehydrated `object` field
 - AS2 core types are rendered in `CamelCase` without a namespace prefix
@@ -36,7 +36,7 @@ sole implementation location for the AS2 mapping.
 
 ---
 
-## General Mapping Conventions (MUST)
+## General Mapping Conventions
 
 - `VAM-01-001` Every `MessageSemantics` enum value except `UNKNOWN` MUST have
   exactly one entry in `SEMANTICS_ACTIVITY_PATTERNS` that defines its AS2
@@ -52,7 +52,7 @@ sole implementation location for the AS2 mapping.
 - `VAM-01-004` An AS2 activity MUST be rehydrated (URI string references
   expanded to full objects via the DataLayer) before pattern matching; pattern
   matching MUST NOT rely on unhydrated string fields for type discrimination
-- `VAM-01-005` When a pattern specifies a nested activity as the `object` field,
+- `VAM-01-005` MUST When a pattern specifies a nested activity as the `object` field,
   the outer activity's `object` MUST be a fully rehydrated AS2 activity object
   matching the inner `ActivityPattern`
 - `VAM-01-006` Pattern matching MUST be conservative when a field is a
@@ -60,7 +60,7 @@ sole implementation location for the AS2 mapping.
   expected type rather than failing the match
 - `VAM-01-007` `MessageSemantics.UNKNOWN` MUST be returned when no registered
   pattern matches the incoming activity
-- `VAM-01-008` Inbound activities represent state-change notifications, not
+- `VAM-01-008` MUST Inbound activities represent state-change notifications, not
   commands; the AS2 activity type used for each semantic MUST reflect the
   completed state transition, not a requested action
   - See `notes/activitystreams-semantics.md` for the full treatment of this
@@ -68,7 +68,7 @@ sole implementation location for the AS2 mapping.
 
 ---
 
-## Report Management Messages (MUST)
+## Report Management Messages
 
 These messages correspond to the Report Management (RM) state machine
 transitions. A `VulnerabilityReport` is the domain object at the centre of this
@@ -102,7 +102,7 @@ group.
 
 ---
 
-## Case Management Messages (MUST)
+## Case Management Messages
 
 These messages correspond to lifecycle operations on a `VulnerabilityCase`.
 
@@ -128,7 +128,7 @@ These messages correspond to lifecycle operations on a `VulnerabilityCase`.
 
 ---
 
-## Actor Suggestion and Invitation Messages (MUST)
+## Actor Suggestion and Invitation Messages
 
 These messages handle adding actors to a vulnerability case, either by
 suggestion (coordinators recommending other participants) or by direct
@@ -186,7 +186,7 @@ invitation.
 
 ---
 
-## Embargo Management Messages (MUST)
+## Embargo Management Messages
 
 These messages correspond to Embargo Management (EM) state machine transitions.
 An `EmbargoEvent` (an AS2 `Event` object representing the embargo agreement) is
@@ -228,7 +228,7 @@ with a specific case.
 
 ---
 
-## Case Participant Management Messages (MUST)
+## Case Participant Management Messages
 
 These messages manage the explicit creation and lifecycle of `CaseParticipant`
 objects (the per-participant state records attached to a case).
@@ -248,7 +248,7 @@ objects (the per-participant state records attached to a case).
 
 ---
 
-## Note Management Messages (MUST)
+## Note Management Messages
 
 These messages manage AS2 `Note` objects attached to a vulnerability case.
 
@@ -265,7 +265,7 @@ These messages manage AS2 `Note` objects attached to a vulnerability case.
 
 ---
 
-## Status Tracking Messages (MUST)
+## Status Tracking Messages
 
 These messages manage `CaseStatus` and `ParticipantStatus` objects, which
 record point-in-time snapshots of the RM/EM/CS/VFD state for a case or
@@ -295,9 +295,9 @@ participant.
 
 ---
 
-## Unrecognized Activities (MUST)
+## Unrecognized Activities
 
-- `VAM-09-001` An inbound AS2 activity that does not match any registered
+- `VAM-09-001` MUST An inbound AS2 activity that does not match any registered
   pattern MUST be assigned `MessageSemantics.UNKNOWN`
 - `VAM-09-002` `MessageSemantics.UNKNOWN` MUST NOT have an entry in
   `SEMANTICS_ACTIVITY_PATTERNS`; the fallback is implemented by

--- a/specs/vultron-protocol-spec.md
+++ b/specs/vultron-protocol-spec.md
@@ -96,7 +96,7 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   - Source: `docs/topics/process_models/rm/index.md`
   - VP-02-010 is-implemented-by CM-03-001
   - VP-02-010 is-implemented-by CM-04-001
-- `VP-02-011` SHOULD Once a Vendor confirms that a reported vulnerability affects one
+- `VP-02-011` (SHOULD) Once a Vendor confirms that a reported vulnerability affects one
   or more of their products or services, the Vendor SHOULD designate the report
   as Valid
   - Source: `docs/topics/process_models/rm/index.md`
@@ -263,7 +263,7 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   except $RK$ itself
   - Source: `docs/reference/formal_protocol/transitions.md`
   - VP-03-009 is-implemented-by RF-08-001
-- `VP-03-010` SHOULD Recipients who receive an $R*$ message (other than $RS$) while in
+- `VP-03-010` (SHOULD) Recipients who receive an $R*$ message (other than $RS$) while in
   RM Start ($q^{rm} \in S$) SHOULD respond with both $RE$ to signal the error
   and $GI$ to find out what the sender expected
   - Source: `docs/reference/formal_protocol/transitions.md`
@@ -272,7 +272,7 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   ($GI$) as to the nature of the error
   - Source: `docs/reference/formal_protocol/transitions.md`
   - VP-03-011 is-implemented-by RF-05-001
-- `VP-03-012` SHOULD Participants whose state changes in the RM, EM, or CVD Case State
+- `VP-03-012` (SHOULD) Participants whose state changes in the RM, EM, or CVD Case State
   Models SHOULD send a message to other Participants for each transition
   - Source: `docs/reference/formal_protocol/messages.md`
   - VP-03-012 is-implemented-by CM-06-001
@@ -436,7 +436,7 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   - Source: `docs/topics/process_models/em/negotiating.md`
   - **Gap**: Not addressed by any current implementation spec
 
-- `VP-06-007` SHALL Submitting a report when an embargo proposal is pending
+- `VP-06-007` (SHALL) Submitting a report when an embargo proposal is pending
   ($q^{em} \in P$) SHALL be construed as the Sender's acceptance of the
   proposed terms
   - Source: `docs/topics/process_models/em/negotiating.md`
@@ -466,12 +466,12 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   to an embargo proposal in a timely manner as a rejection of that proposal
   - Source: `docs/topics/process_models/em/negotiating.md`
   - **Gap**: Not addressed by any current implementation spec
-- `VP-06-014` MAY In the absence of an explicit accept or reject response from a
+- `VP-06-014` (MAY) In the absence of an explicit accept or reject response from a
   Receiver in a timely manner, the Sender MAY proceed consistent with an EM
   state of None ($q^{em} \in N$)
   - Source: `docs/topics/process_models/em/negotiating.md`
   - **Gap**: Not addressed by any current implementation spec
-- `VP-06-015` MAY In a case where the embargo state is None and for which an embargo
+- `VP-06-015` (MAY) In a case where the embargo state is None and for which an embargo
   has been proposed and either explicitly or tacitly rejected, Participants MAY
   take any action they choose with the report, including immediate publication
   - Source: `docs/topics/process_models/em/negotiating.md`
@@ -490,27 +490,27 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
 
 ## Embargo Default Policies
 
-- `VP-07-001` SHALL If neither Sender nor Receiver proposes an embargo and no policy
+- `VP-07-001` (SHALL) If neither Sender nor Receiver proposes an embargo and no policy
   defaults apply, no embargo SHALL exist
   - Source: `docs/topics/process_models/em/defaults.md`
   - VP-07-001 is-implemented-by EP-01-002
   - VP-07-001 is-implemented-by EP-03-001
-- `VP-07-002` SHALL A Receiver's default embargo specified in its vulnerability
+- `VP-07-002` (SHALL) A Receiver's default embargo specified in its vulnerability
   disclosure policy SHALL be treated as an initial embargo proposal
   - Source: `docs/topics/process_models/em/defaults.md`
   - VP-07-002 is-implemented-by EP-01-002
-- `VP-07-003` SHALL If the Receiver has declared a default embargo in its
+- `VP-07-003` (SHALL) If the Receiver has declared a default embargo in its
   vulnerability disclosure policy and the Sender proposes nothing to the
   contrary, the Receiver's default embargo SHALL be considered as an accepted
   proposal
   - Source: `docs/topics/process_models/em/defaults.md`
   - VP-07-003 is-implemented-by EP-03-002
-- `VP-07-004` SHALL If the Sender proposes an embargo longer than the Receiver's
+- `VP-07-004` (SHALL) If the Sender proposes an embargo longer than the Receiver's
   default, the Receiver's default SHALL be taken as accepted and the Sender's
   proposal taken as a proposed revision
   - Source: `docs/topics/process_models/em/defaults.md`
   - VP-07-004 is-implemented-by EP-03-002
-- `VP-07-005` SHALL If the Sender proposes an embargo shorter than the Receiver's
+- `VP-07-005` (SHALL) If the Sender proposes an embargo shorter than the Receiver's
   default, the Sender's proposal SHALL be taken as accepted and the Receiver's
   default taken as a proposed revision
   - Source: `docs/topics/process_models/em/defaults.md`
@@ -523,16 +523,16 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   - VP-07-006 is-implemented-by EP-01-003
   - VP-07-006 is-implemented-by EP-02-001
   - VP-07-006 is-implemented-by EP-03-001
-- `VP-07-007` SHOULD If the Sender proposes an embargo and the Receiver has no default
+- `VP-07-007` (SHOULD) If the Sender proposes an embargo and the Receiver has no default
   embargo specified by policy, the Receiver SHOULD accept the Sender's proposal
   - Source: `docs/topics/process_models/em/defaults.md`
   - VP-07-007 is-implemented-by EP-03-001
-- `VP-07-008` SHOULD When two or more embargo proposals are open and no embargo has yet
+- `VP-07-008` (SHOULD) When two or more embargo proposals are open and no embargo has yet
   been accepted ($q^{em} \in P$), Participants SHOULD accept the shortest one
   and propose the remainder as revisions
   - Source: `docs/topics/process_models/em/defaults.md`
   - VP-07-008 is-implemented-by EP-03-001
-- `VP-07-009` SHOULD When two or more embargo revisions are open and an embargo is
+- `VP-07-009` (SHOULD) When two or more embargo revisions are open and an embargo is
   active ($q^{em} \in R$), Participants SHOULD accept or reject them
   individually in earliest-to-latest expiration order
   - Source: `docs/topics/process_models/em/defaults.md`
@@ -548,12 +548,12 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   - Source: `docs/topics/process_models/em/defaults.md`
   - VP-07-011 is-implemented-by EP-01-001
   - VP-07-011 is-implemented-by EP-03-001
-- `VP-07-012` MAY When the Sender proposes longer than the Receiver's default, the
+- `VP-07-012` (MAY) When the Sender proposes longer than the Receiver's default, the
   Receiver MAY accept or reject the proposed extension
   - Source: `docs/topics/process_models/em/defaults.md`
   - VP-07-012 is-implemented-by EP-01-001
   - VP-07-012 is-implemented-by EP-03-001
-- `VP-07-013` MAY When the Sender proposes shorter than the Receiver's default, the
+- `VP-07-013` (MAY) When the Sender proposes shorter than the Receiver's default, the
   Sender MAY accept or reject the Receiver's proposed revision
   - Source: `docs/topics/process_models/em/defaults.md`
   - VP-07-013 is-implemented-by EP-01-001
@@ -563,7 +563,7 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
 
 ## Multi-Party Coordination
 
-- `VP-08-001` SHALL When inviting a new Participant to a case with an existing embargo,
+- `VP-08-001` (SHALL) When inviting a new Participant to a case with an existing embargo,
   the inviting Participant SHALL propose the existing embargo to the invited
   Participant
   - Source: `docs/topics/process_models/em/working_with_others.md`
@@ -581,7 +581,7 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   Participants
   - Source: `docs/topics/process_models/em/working_with_others.md`
   - **Gap**: Not addressed by any current implementation spec
-- `VP-08-005` SHOULD A newly invited Participant to a case with an existing embargo
+- `VP-08-005` (SHOULD) A newly invited Participant to a case with an existing embargo
   SHOULD accept the existing embargo
   - Source: `docs/topics/process_models/em/working_with_others.md`
   - **Gap**: Not addressed by any current implementation spec
@@ -594,7 +594,7 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   accepting longer embargoes in MPCVD cases
   - Source: `docs/topics/process_models/em/working_with_others.md`
   - **Gap**: Not addressed by any current implementation spec
-- `VP-08-008` SHOULD Potential Participants with a longer default policy than an
+- `VP-08-008` (SHOULD) Potential Participants with a longer default policy than an
   existing case SHOULD accept the embargo terms offered
   - Source: `docs/topics/process_models/em/working_with_others.md`
   - **Gap**: Not addressed by any current implementation spec
@@ -602,13 +602,13 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   Vendors with a longer default embargo policy
   - Source: `docs/topics/process_models/em/working_with_others.md`
   - **Gap**: Not addressed by any current implementation spec
-- `VP-08-010` SHOULD Participants known to leak or provide vulnerability information to
+- `VP-08-010` (SHOULD) Participants known to leak or provide vulnerability information to
   adversaries as a matter of policy or historical fact SHOULD be treated similar
   to Participants with brief disclosure policies
   - Source: `docs/topics/process_models/em/working_with_others.md`
   - **Gap**: Not addressed by any current implementation spec
 
-- `VP-08-011` MAY When consensus fails to reach agreement on embargo terms,
+- `VP-08-011` (MAY) When consensus fails to reach agreement on embargo terms,
   Participants MAY appoint a case lead to resolve conflicts
   - Source: `docs/topics/process_models/em/working_with_others.md`
   - **Gap**: Not addressed by any current implementation spec
@@ -636,7 +636,7 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   with the agreed embargo
   - Source: `docs/topics/process_models/em/working_with_others.md`
   - **Gap**: Not addressed by any current implementation spec
-- `VP-08-018` MAY After accepting an existing embargo, newly invited Participants
+- `VP-08-018` (MAY) After accepting an existing embargo, newly invited Participants
   with a longer default policy MAY propose a revision to accommodate their
   preferences
   - Source: `docs/topics/process_models/em/working_with_others.md`
@@ -695,12 +695,12 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
 
 ## Embargo Case Splits and Merges
 
-- `VP-10-001` SHALL If no new embargo has been proposed or agreement has not been
+- `VP-10-001` (SHALL) If no new embargo has been proposed or agreement has not been
   reached following a case merge, the earliest of the previously accepted
   embargo dates SHALL be adopted for the merged case
   - Source: `docs/topics/process_models/em/split_merge.md`
   - **Gap**: Not addressed by any current implementation spec
-- `VP-10-002` SHALL If an earlier embargo date is needed for a child case following a
+- `VP-10-002` (SHALL) If an earlier embargo date is needed for a child case following a
   case split, consideration SHALL be given to the impact that ending the embargo
   on that case will have on the other child cases retaining a later embargo date
   - Source: `docs/topics/process_models/em/split_merge.md`
@@ -716,11 +716,11 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   prior to the merger
   - Source: `docs/topics/process_models/em/split_merge.md`
   - **Gap**: Not addressed by any current implementation spec
-- `VP-10-005` SHOULD When a case is split into two or more parts, any existing embargo
+- `VP-10-005` (SHOULD) When a case is split into two or more parts, any existing embargo
   SHOULD transfer to the new cases
   - Source: `docs/topics/process_models/em/split_merge.md`
   - **Gap**: Not addressed by any current implementation spec
-- `VP-10-006` SHOULD If any of the new cases need to renegotiate the embargo inherited
+- `VP-10-006` (SHOULD) If any of the new cases need to renegotiate the embargo inherited
   from the parent case, any new embargo SHOULD be later than the inherited
   embargo
   - Source: `docs/topics/process_models/em/split_merge.md`
@@ -745,7 +745,7 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   - Source: `docs/reference/formal_protocol/transitions.md`
   - VP-11-001 is-implemented-by CM-04-003
   - VP-11-001 is-implemented-by CM-04-004
-- `VP-11-002` SHALL If information about the vulnerability or an exploit has been made
+- `VP-11-002` (SHALL) If information about the vulnerability or an exploit has been made
   public, Participants SHALL terminate the embargo
   ($q^{cs} \in \{\cdots P \cdots, \cdots X \cdot\}$)
   - Source: `docs/reference/formal_protocol/transitions.md`
@@ -776,7 +776,7 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   - Source: `docs/reference/formal_protocol/transitions.md`
   - VP-11-007 is-implemented-by CM-04-003
   - VP-11-007 is-implemented-by CM-04-004
-- `VP-11-008` SHOULD If early embargo termination is desired but the termination
+- `VP-11-008` (SHOULD) If early embargo termination is desired but the termination
   date/time is in the future, this SHOULD be achieved through an Embargo
   Revision Proposal and additional communication
   - Source: `docs/reference/formal_protocol/messages.md`
@@ -843,18 +843,18 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   - Source: `docs/topics/process_models/model_interactions/rm_em.md`
   - VP-13-006 is-implemented-by CM-04-001
   - VP-13-006 is-implemented-by CM-04-003
-- `VP-13-007` SHOULD Participants who choose to close a report while an embargo remains
+- `VP-13-007` (SHOULD) Participants who choose to close a report while an embargo remains
   in force SHOULD communicate their intent to either continue to adhere to the
   embargo or terminate their compliance with it
   - Source: `docs/topics/process_models/model_interactions/rm_em.md`
   - VP-13-007 is-implemented-by CM-06-001
-- `VP-13-008` SHOULD Any changes to a Participant's intention to adhere to an active
+- `VP-13-008` (SHOULD) Any changes to a Participant's intention to adhere to an active
   embargo SHOULD be communicated clearly in addition to any necessary RM or EM
   state change notifications
   - Source: `docs/topics/process_models/model_interactions/rm_em.md`
   - VP-13-008 is-implemented-by CM-06-001
 
-- `VP-13-009` SHALL NOT A Participant's closure or deferral ($q^{rm} \in \{C, D\}$) of a
+- `VP-13-009` (SHALL NOT) A Participant's closure or deferral ($q^{rm} \in \{C, D\}$) of a
   report while an embargo remains active ($q^{em} \in \{A, R\}$) and while
   other Participants remain engaged SHALL NOT automatically terminate the embargo
   - Source: `docs/topics/process_models/model_interactions/rm_em.md`
@@ -880,7 +880,7 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   - VP-13-012 is-implemented-by CM-03-001
   - VP-13-012 is-implemented-by CM-03-003
   - VP-13-012 is-implemented-by CM-04-003
-- `VP-13-013` MAY EM revision proposals and acceptance or rejection of those
+- `VP-13-013` (MAY) EM revision proposals and acceptance or rejection of those
   proposals MAY occur during any of the valid yet unclosed RM states
   ($q^{rm} \in \{V, A, D\}$)
   - Source: `docs/topics/process_models/model_interactions/rm_em.md`
@@ -912,7 +912,7 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   - VP-13-017 is-implemented-by CM-03-001
   - VP-13-017 is-implemented-by CM-03-003
   - VP-13-017 is-implemented-by CM-04-003
-- `VP-13-018` MAY Upon receipt of a Participant's notification of intent to end
+- `VP-13-018` (MAY) Upon receipt of a Participant's notification of intent to end
   their compliance with an embargo, other Participants MAY choose to terminate
   the embargo
   - Source: `docs/topics/process_models/model_interactions/rm_em.md`
@@ -924,18 +924,18 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
 
 ## RM-EM-CS Interactions
 
-- `VP-14-001` SHALL NOT Once Public Awareness has happened ($q^{cs} \in \cdots P \cdots$),
+- `VP-14-001` (SHALL NOT) Once Public Awareness has happened ($q^{cs} \in \cdots P \cdots$),
   new embargoes SHALL NOT be sought and any existing embargo SHALL terminate
   - Source: `docs/topics/process_models/model_interactions/rm_em_cs.md`
   - VP-14-001 is-implemented-by CM-04-003
   - VP-14-001 is-implemented-by CM-04-004
-- `VP-14-002` SHALL NOT Once Exploit Publication has occurred
+- `VP-14-002` (SHALL NOT) Once Exploit Publication has occurred
   ($q^{cs} \in \cdots X \cdot$), new embargoes SHALL NOT be sought and any
   existing embargo SHALL terminate
   - Source: `docs/topics/process_models/model_interactions/rm_em_cs.md`
   - VP-14-002 is-implemented-by CM-04-003
   - VP-14-002 is-implemented-by CM-04-004
-- `VP-14-003` SHALL NOT Once Attacks have been observed ($q^{cs} \in \cdots A$), new
+- `VP-14-003` (SHALL NOT) Once Attacks have been observed ($q^{cs} \in \cdots A$), new
   embargoes SHALL NOT be sought
   - Source: `docs/topics/process_models/model_interactions/rm_em_cs.md`
   - VP-14-003 is-implemented-by CM-04-004
@@ -945,7 +945,7 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   - Source: `docs/topics/process_models/model_interactions/rm_em_cs.md`
   - VP-14-004 is-implemented-by CM-04-004
 
-- `VP-14-005` SHOULD Once a case has reached Vendor Aware ($q^{cs} \in Vfdpxa$) for at
+- `VP-14-005` (SHOULD) Once a case has reached Vendor Aware ($q^{cs} \in Vfdpxa$) for at
   least one Vendor, if the EM process has not started, it SHOULD begin as soon
   as possible
   - Source: `docs/topics/process_models/model_interactions/rm_em_cs.md`
@@ -954,12 +954,12 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   after the first Vendor is notified
   - Source: `docs/topics/process_models/model_interactions/rm_em_cs.md`
   - VP-14-006 is-implemented-by CM-04-003
-- `VP-14-007` SHOULD NOT Once a case has reached Fix Ready ($q^{cs} \in VF\cdot pxa$), new
+- `VP-14-007` (SHOULD NOT) Once a case has reached Fix Ready ($q^{cs} \in VF\cdot pxa$), new
   embargo negotiations SHOULD NOT start and proposed but not-yet-agreed-to
   embargoes SHOULD be rejected
   - Source: `docs/topics/process_models/model_interactions/rm_em_cs.md`
   - VP-14-007 is-implemented-by CM-04-003
-- `VP-14-008` SHOULD Existing embargoes ($q^{em} \in \{Active, Revise\}$) when Fix
+- `VP-14-008` (SHOULD) Existing embargoes ($q^{em} \in \{Active, Revise\}$) when Fix
   Ready is reached SHOULD prepare to terminate soon
   - Source: `docs/topics/process_models/model_interactions/rm_em_cs.md`
   - VP-14-008 is-implemented-by CM-04-003
@@ -967,11 +967,11 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   trailing Vendors to catch up before publication when possible
   - Source: `docs/topics/process_models/model_interactions/rm_em_cs.md`
   - **Gap**: Not addressed by any current implementation spec
-- `VP-14-010` SHOULD NOT By the time a fix has been deployed ($q^{cs} \in VFD\cdots$), new
+- `VP-14-010` (SHOULD NOT) By the time a fix has been deployed ($q^{cs} \in VFD\cdots$), new
   embargoes SHOULD NOT be sought and any existing embargo SHOULD terminate
   - Source: `docs/topics/process_models/model_interactions/rm_em_cs.md`
   - VP-14-010 is-implemented-by CM-04-003
-- `VP-14-011` SHOULD Exploit Publishers who are Participants in pre-public CVD cases
+- `VP-14-011` (SHOULD) Exploit Publishers who are Participants in pre-public CVD cases
   ($q^{cs} \in \cdots p \cdots$) SHOULD comply with the protocol, especially
   when they also fulfill other roles (e.g., Finder, Reporter, Coordinator,
   Vendor)
@@ -981,13 +981,13 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   embargo is active ($q^{em} \in \{A, R\}$)
   - Source: `docs/topics/process_models/model_interactions/rm_em_cs.md`
   - **Gap**: Not addressed by any current implementation spec
-- `VP-14-013` SHOULD Once Attacks have been observed ($q^{cs} \in \cdots A$), any
+- `VP-14-013` (SHOULD) Once Attacks have been observed ($q^{cs} \in \cdots A$), any
   existing embargo SHOULD terminate
   - Source: `docs/topics/process_models/model_interactions/rm_em_cs.md`
   - VP-14-013 is-implemented-by CM-04-003
   - VP-14-013 is-implemented-by CM-04-004
 
-- `VP-14-014` MAY In MPCVD cases where some Vendors reach Fix Ready before others,
+- `VP-14-014` (MAY) In MPCVD cases where some Vendors reach Fix Ready before others,
   Participants MAY propose an embargo extension to allow trailing Vendors to
   catch up before publication
   - Source: `docs/topics/process_models/model_interactions/rm_em_cs.md`

--- a/specs/vultron-protocol-spec.md
+++ b/specs/vultron-protocol-spec.md
@@ -27,7 +27,7 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
 
 ---
 
-## Participant State Tracking (SHOULD)
+## Participant State Tracking
 
 - `VP-01-001` Participants SHOULD track the state of other Participants in a
   case to inform their own decision making
@@ -42,8 +42,6 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   - VP-01-002 is-implemented-by CM-03-002
   - VP-01-002 is-implemented-by CM-04-001
 
-## Participant State Tracking (MUST NOT)
-
 - `VP-01-003` Adequate operation of the protocol MUST NOT depend on perfect
   information across all Participants
   - Source: `docs/reference/formal_protocol/states.md`
@@ -51,7 +49,7 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
 
 ---
 
-## Report Management (RM): Receiving Reports (MUST)
+## Report Management (RM): Receiving Reports
 
 - `VP-02-001` Coordinators MUST have a clearly defined and publicly available
   mechanism for receiving reports
@@ -65,13 +63,9 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   - Source: `docs/topics/process_models/rm/index.md`
   - VP-02-003 is-implemented-by CM-04-001
 
-## Report Management (RM): Receiving Reports (MUST NOT)
-
 - `VP-02-004` Participants MUST NOT close cases or reports from the Valid state
   - Source: `docs/topics/process_models/rm/index.md`
   - VP-02-004 is-implemented-by CM-03-007
-
-## Report Management (RM): Receiving Reports (SHOULD)
 
 - `VP-02-005` Vendors SHOULD have a clearly defined and publicly available
   mechanism for receiving reports
@@ -102,7 +96,7 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   - Source: `docs/topics/process_models/rm/index.md`
   - VP-02-010 is-implemented-by CM-03-001
   - VP-02-010 is-implemented-by CM-04-001
-- `VP-02-011` Once a Vendor confirms that a reported vulnerability affects one
+- `VP-02-011` SHOULD Once a Vendor confirms that a reported vulnerability affects one
   or more of their products or services, the Vendor SHOULD designate the report
   as Valid
   - Source: `docs/topics/process_models/rm/index.md`
@@ -174,8 +168,6 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   - VP-02-024 is-implemented-by CM-03-001
   - VP-02-024 is-implemented-by CM-04-001
 
-## Report Management (RM): Receiving Reports (MAY)
-
 - `VP-02-025` Participants MAY perform a more technical report validation process
   before exiting the Received state
   - Source: `docs/topics/process_models/rm/index.md`
@@ -232,7 +224,7 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
 
 ---
 
-## RM Messaging (MUST)
+## RM Messaging
 
 - `VP-03-001` Participants MUST be in RM Accepted to send a Report Submission
   ($RS$) message to someone else
@@ -243,8 +235,6 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   ($q^{cs} \xrightarrow{\mathbf{V}} Vfd\cdots$)
   - Source: `docs/reference/formal_protocol/transitions.md`
   - VP-03-002 is-implemented-by CM-04-004
-
-## RM Messaging (SHOULD)
 
 - `VP-03-003` Participants SHOULD send $RI$ when the report validation process
   ends in an invalid determination
@@ -273,7 +263,7 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   except $RK$ itself
   - Source: `docs/reference/formal_protocol/transitions.md`
   - VP-03-009 is-implemented-by RF-08-001
-- `VP-03-010` Recipients who receive an $R*$ message (other than $RS$) while in
+- `VP-03-010` SHOULD Recipients who receive an $R*$ message (other than $RS$) while in
   RM Start ($q^{rm} \in S$) SHOULD respond with both $RE$ to signal the error
   and $GI$ to find out what the sender expected
   - Source: `docs/reference/formal_protocol/transitions.md`
@@ -282,12 +272,10 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   ($GI$) as to the nature of the error
   - Source: `docs/reference/formal_protocol/transitions.md`
   - VP-03-011 is-implemented-by RF-05-001
-- `VP-03-012` Participants whose state changes in the RM, EM, or CVD Case State
+- `VP-03-012` SHOULD Participants whose state changes in the RM, EM, or CVD Case State
   Models SHOULD send a message to other Participants for each transition
   - Source: `docs/reference/formal_protocol/messages.md`
   - VP-03-012 is-implemented-by CM-06-001
-
-## RM Messaging (MAY)
 
 - `VP-03-013` Recipients MAY ignore messages received on Closed cases
   - Source: `docs/reference/formal_protocol/transitions.md`
@@ -295,19 +283,15 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
 
 ---
 
-## Embargo Management (EM) Process (MUST)
+## Embargo Management (EM) Process
 
 - `VP-04-001` Accepted embargoes MUST eventually terminate
   - Source: `docs/topics/process_models/em/index.md`
   - **Gap**: Not addressed by any current implementation spec
 
-## Embargo Management (EM) Process (SHALL)
-
 - `VP-04-002` A CVD case SHALL NOT have more than one active embargo at a time
   - Source: `docs/topics/process_models/em/index.md`
   - VP-04-002 is-implemented-by CM-03-003
-
-## Embargo Management (EM) Process (MAY)
 
 - `VP-04-003` An embargo MAY be proposed
   - Source: `docs/topics/process_models/em/index.md`
@@ -325,7 +309,7 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
 
 ---
 
-## Embargo Principles (SHALL)
+## Embargo Principles
 
 - `VP-05-001` An embargo SHALL specify an unambiguous date and time as its
   endpoint
@@ -349,8 +333,6 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   publish
   - Source: `docs/topics/process_models/em/principles.md`
   - **Gap**: Not addressed by any current implementation spec
-
-## Embargo Principles (SHOULD)
 
 - `VP-05-006` Embargo Participants SHOULD NOT knowingly release information about
   an embargoed case until all proposed embargoes have been explicitly rejected,
@@ -394,8 +376,6 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   - Source: `docs/topics/process_models/em/principles.md`
   - **Gap**: Not addressed by any current implementation spec
 
-## Embargo Principles (MAY)
-
 - `VP-05-015` Additional Participants MAY be added to an existing embargo upon
   accepting the terms of that embargo
   - Source: `docs/topics/process_models/em/principles.md`
@@ -422,7 +402,7 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
 
 ---
 
-## Embargo Negotiation (MUST NOT)
+## Embargo Negotiation
 
 - `VP-06-001` CVD Participants MUST NOT propose or accept a new embargo
   negotiation when information about the vulnerability is already known to the
@@ -432,8 +412,6 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   - Source: `docs/topics/process_models/em/negotiating.md`
   - VP-06-001 is-implemented-by CM-04-003
   - VP-06-001 is-implemented-by CM-04-004
-
-## Embargo Negotiation (SHOULD)
 
 - `VP-06-002` CVD Participants SHOULD NOT propose or accept a new embargo when
   the fix for a vulnerability has already been deployed ($q^{cs} \in VFDpxa$)
@@ -458,15 +436,11 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   - Source: `docs/topics/process_models/em/negotiating.md`
   - **Gap**: Not addressed by any current implementation spec
 
-## Embargo Negotiation (SHALL)
-
-- `VP-06-007` Submitting a report when an embargo proposal is pending
+- `VP-06-007` SHALL Submitting a report when an embargo proposal is pending
   ($q^{em} \in P$) SHALL be construed as the Sender's acceptance of the
   proposed terms
   - Source: `docs/topics/process_models/em/negotiating.md`
   - **Gap**: Not addressed by any current implementation spec
-
-## Embargo Negotiation (MAY)
 
 - `VP-06-008` CVD Participants MAY propose or accept a new embargo when the fix
   for a vulnerability is ready but has neither been made public nor deployed
@@ -492,12 +466,12 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   to an embargo proposal in a timely manner as a rejection of that proposal
   - Source: `docs/topics/process_models/em/negotiating.md`
   - **Gap**: Not addressed by any current implementation spec
-- `VP-06-014` In the absence of an explicit accept or reject response from a
+- `VP-06-014` MAY In the absence of an explicit accept or reject response from a
   Receiver in a timely manner, the Sender MAY proceed consistent with an EM
   state of None ($q^{em} \in N$)
   - Source: `docs/topics/process_models/em/negotiating.md`
   - **Gap**: Not addressed by any current implementation spec
-- `VP-06-015` In a case where the embargo state is None and for which an embargo
+- `VP-06-015` MAY In a case where the embargo state is None and for which an embargo
   has been proposed and either explicitly or tacitly rejected, Participants MAY
   take any action they choose with the report, including immediate publication
   - Source: `docs/topics/process_models/em/negotiating.md`
@@ -514,35 +488,33 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
 
 ---
 
-## Embargo Default Policies (SHALL)
+## Embargo Default Policies
 
-- `VP-07-001` If neither Sender nor Receiver proposes an embargo and no policy
+- `VP-07-001` SHALL If neither Sender nor Receiver proposes an embargo and no policy
   defaults apply, no embargo SHALL exist
   - Source: `docs/topics/process_models/em/defaults.md`
   - VP-07-001 is-implemented-by EP-01-002
   - VP-07-001 is-implemented-by EP-03-001
-- `VP-07-002` A Receiver's default embargo specified in its vulnerability
+- `VP-07-002` SHALL A Receiver's default embargo specified in its vulnerability
   disclosure policy SHALL be treated as an initial embargo proposal
   - Source: `docs/topics/process_models/em/defaults.md`
   - VP-07-002 is-implemented-by EP-01-002
-- `VP-07-003` If the Receiver has declared a default embargo in its
+- `VP-07-003` SHALL If the Receiver has declared a default embargo in its
   vulnerability disclosure policy and the Sender proposes nothing to the
   contrary, the Receiver's default embargo SHALL be considered as an accepted
   proposal
   - Source: `docs/topics/process_models/em/defaults.md`
   - VP-07-003 is-implemented-by EP-03-002
-- `VP-07-004` If the Sender proposes an embargo longer than the Receiver's
+- `VP-07-004` SHALL If the Sender proposes an embargo longer than the Receiver's
   default, the Receiver's default SHALL be taken as accepted and the Sender's
   proposal taken as a proposed revision
   - Source: `docs/topics/process_models/em/defaults.md`
   - VP-07-004 is-implemented-by EP-03-002
-- `VP-07-005` If the Sender proposes an embargo shorter than the Receiver's
+- `VP-07-005` SHALL If the Sender proposes an embargo shorter than the Receiver's
   default, the Sender's proposal SHALL be taken as accepted and the Receiver's
   default taken as a proposed revision
   - Source: `docs/topics/process_models/em/defaults.md`
   - VP-07-005 is-implemented-by EP-03-002
-
-## Embargo Default Policies (SHOULD)
 
 - `VP-07-006` Report Recipients SHOULD post a default embargo period as part of
   their Vulnerability Disclosure Policy to set expectations with potential
@@ -551,22 +523,20 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   - VP-07-006 is-implemented-by EP-01-003
   - VP-07-006 is-implemented-by EP-02-001
   - VP-07-006 is-implemented-by EP-03-001
-- `VP-07-007` If the Sender proposes an embargo and the Receiver has no default
+- `VP-07-007` SHOULD If the Sender proposes an embargo and the Receiver has no default
   embargo specified by policy, the Receiver SHOULD accept the Sender's proposal
   - Source: `docs/topics/process_models/em/defaults.md`
   - VP-07-007 is-implemented-by EP-03-001
-- `VP-07-008` When two or more embargo proposals are open and no embargo has yet
+- `VP-07-008` SHOULD When two or more embargo proposals are open and no embargo has yet
   been accepted ($q^{em} \in P$), Participants SHOULD accept the shortest one
   and propose the remainder as revisions
   - Source: `docs/topics/process_models/em/defaults.md`
   - VP-07-008 is-implemented-by EP-03-001
-- `VP-07-009` When two or more embargo revisions are open and an embargo is
+- `VP-07-009` SHOULD When two or more embargo revisions are open and an embargo is
   active ($q^{em} \in R$), Participants SHOULD accept or reject them
   individually in earliest-to-latest expiration order
   - Source: `docs/topics/process_models/em/defaults.md`
   - VP-07-009 is-implemented-by EP-03-001
-
-## Embargo Default Policies (MAY)
 
 - `VP-07-010` Participants MAY include a default embargo period as part of a
   published Vulnerability Disclosure Policy
@@ -578,12 +548,12 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   - Source: `docs/topics/process_models/em/defaults.md`
   - VP-07-011 is-implemented-by EP-01-001
   - VP-07-011 is-implemented-by EP-03-001
-- `VP-07-012` When the Sender proposes longer than the Receiver's default, the
+- `VP-07-012` MAY When the Sender proposes longer than the Receiver's default, the
   Receiver MAY accept or reject the proposed extension
   - Source: `docs/topics/process_models/em/defaults.md`
   - VP-07-012 is-implemented-by EP-01-001
   - VP-07-012 is-implemented-by EP-03-001
-- `VP-07-013` When the Sender proposes shorter than the Receiver's default, the
+- `VP-07-013` MAY When the Sender proposes shorter than the Receiver's default, the
   Sender MAY accept or reject the Receiver's proposed revision
   - Source: `docs/topics/process_models/em/defaults.md`
   - VP-07-013 is-implemented-by EP-01-001
@@ -591,15 +561,13 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
 
 ---
 
-## Multi-Party Coordination (SHALL)
+## Multi-Party Coordination
 
-- `VP-08-001` When inviting a new Participant to a case with an existing embargo,
+- `VP-08-001` SHALL When inviting a new Participant to a case with an existing embargo,
   the inviting Participant SHALL propose the existing embargo to the invited
   Participant
   - Source: `docs/topics/process_models/em/working_with_others.md`
   - VP-08-001 is-implemented-by CM-06-001
-
-## Multi-Party Coordination (SHOULD)
 
 - `VP-08-002` Participants SHOULD attempt to establish an embargo as early in
   the process of handling the case as possible
@@ -613,7 +581,7 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   Participants
   - Source: `docs/topics/process_models/em/working_with_others.md`
   - **Gap**: Not addressed by any current implementation spec
-- `VP-08-005` A newly invited Participant to a case with an existing embargo
+- `VP-08-005` SHOULD A newly invited Participant to a case with an existing embargo
   SHOULD accept the existing embargo
   - Source: `docs/topics/process_models/em/working_with_others.md`
   - **Gap**: Not addressed by any current implementation spec
@@ -626,7 +594,7 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   accepting longer embargoes in MPCVD cases
   - Source: `docs/topics/process_models/em/working_with_others.md`
   - **Gap**: Not addressed by any current implementation spec
-- `VP-08-008` Potential Participants with a longer default policy than an
+- `VP-08-008` SHOULD Potential Participants with a longer default policy than an
   existing case SHOULD accept the embargo terms offered
   - Source: `docs/topics/process_models/em/working_with_others.md`
   - **Gap**: Not addressed by any current implementation spec
@@ -634,15 +602,13 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   Vendors with a longer default embargo policy
   - Source: `docs/topics/process_models/em/working_with_others.md`
   - **Gap**: Not addressed by any current implementation spec
-- `VP-08-010` Participants known to leak or provide vulnerability information to
+- `VP-08-010` SHOULD Participants known to leak or provide vulnerability information to
   adversaries as a matter of policy or historical fact SHOULD be treated similar
   to Participants with brief disclosure policies
   - Source: `docs/topics/process_models/em/working_with_others.md`
   - **Gap**: Not addressed by any current implementation spec
 
-## Multi-Party Coordination (MAY)
-
-- `VP-08-011` When consensus fails to reach agreement on embargo terms,
+- `VP-08-011` MAY When consensus fails to reach agreement on embargo terms,
   Participants MAY appoint a case lead to resolve conflicts
   - Source: `docs/topics/process_models/em/working_with_others.md`
   - **Gap**: Not addressed by any current implementation spec
@@ -670,7 +636,7 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   with the agreed embargo
   - Source: `docs/topics/process_models/em/working_with_others.md`
   - **Gap**: Not addressed by any current implementation spec
-- `VP-08-018` After accepting an existing embargo, newly invited Participants
+- `VP-08-018` MAY After accepting an existing embargo, newly invited Participants
   with a longer default policy MAY propose a revision to accommodate their
   preferences
   - Source: `docs/topics/process_models/em/working_with_others.md`
@@ -690,14 +656,12 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
 
 ---
 
-## Embargo Early Termination (SHALL)
+## Embargo Early Termination
 
 - `VP-09-001` Embargoes SHALL terminate immediately when information about the
   vulnerability becomes public ($q^{cs} \in \{\cdots P \cdots, \cdots X \cdot\}$)
   - Source: `docs/topics/process_models/em/early_termination.md`
   - VP-09-001 is-implemented-by CM-04-003
-
-## Embargo Early Termination (SHOULD)
 
 - `VP-09-002` Participants SHOULD be prepared with contingency plans in the
   event of early embargo termination
@@ -717,8 +681,6 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   - Source: `docs/topics/process_models/em/early_termination.md`
   - **Gap**: Not addressed by any current implementation spec
 
-## Embargo Early Termination (MAY)
-
 - `VP-09-006` Embargoes MAY terminate early when there is evidence that
   adversaries are aware of the technical details of the vulnerability
   - Source: `docs/topics/process_models/em/early_termination.md`
@@ -731,14 +693,14 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
 
 ---
 
-## Embargo Case Splits and Merges (SHALL)
+## Embargo Case Splits and Merges
 
-- `VP-10-001` If no new embargo has been proposed or agreement has not been
+- `VP-10-001` SHALL If no new embargo has been proposed or agreement has not been
   reached following a case merge, the earliest of the previously accepted
   embargo dates SHALL be adopted for the merged case
   - Source: `docs/topics/process_models/em/split_merge.md`
   - **Gap**: Not addressed by any current implementation spec
-- `VP-10-002` If an earlier embargo date is needed for a child case following a
+- `VP-10-002` SHALL If an earlier embargo date is needed for a child case following a
   case split, consideration SHALL be given to the impact that ending the embargo
   on that case will have on the other child cases retaining a later embargo date
   - Source: `docs/topics/process_models/em/split_merge.md`
@@ -749,24 +711,20 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   - Source: `docs/topics/process_models/em/split_merge.md`
   - **Gap**: Not addressed by any current implementation spec
 
-## Embargo Case Splits and Merges (SHOULD)
-
 - `VP-10-004` A new embargo SHOULD be proposed when any two or more CVD cases
   are to be merged and multiple parties have agreed to different embargo terms
   prior to the merger
   - Source: `docs/topics/process_models/em/split_merge.md`
   - **Gap**: Not addressed by any current implementation spec
-- `VP-10-005` When a case is split into two or more parts, any existing embargo
+- `VP-10-005` SHOULD When a case is split into two or more parts, any existing embargo
   SHOULD transfer to the new cases
   - Source: `docs/topics/process_models/em/split_merge.md`
   - **Gap**: Not addressed by any current implementation spec
-- `VP-10-006` If any of the new cases need to renegotiate the embargo inherited
+- `VP-10-006` SHOULD If any of the new cases need to renegotiate the embargo inherited
   from the parent case, any new embargo SHOULD be later than the inherited
   embargo
   - Source: `docs/topics/process_models/em/split_merge.md`
   - **Gap**: Not addressed by any current implementation spec
-
-## Embargo Case Splits and Merges (MAY)
 
 - `VP-10-007` Participants MAY propose revisions to the embargo on a merged case
   as usual
@@ -780,14 +738,14 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
 
 ---
 
-## EM Messaging (SHALL)
+## EM Messaging
 
 - `VP-11-001` Participants SHALL NOT negotiate embargoes where the vulnerability
   or its exploit is public or attacks are known to have occurred
   - Source: `docs/reference/formal_protocol/transitions.md`
   - VP-11-001 is-implemented-by CM-04-003
   - VP-11-001 is-implemented-by CM-04-004
-- `VP-11-002` If information about the vulnerability or an exploit has been made
+- `VP-11-002` SHALL If information about the vulnerability or an exploit has been made
   public, Participants SHALL terminate the embargo
   ($q^{cs} \in \{\cdots P \cdots, \cdots X \cdot\}$)
   - Source: `docs/reference/formal_protocol/transitions.md`
@@ -798,8 +756,6 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   - Source: `docs/reference/formal_protocol/transitions.md`
   - VP-11-003 is-implemented-by CM-04-003
   - VP-11-003 is-implemented-by CM-04-004
-
-## EM Messaging (SHOULD)
 
 - `VP-11-004` Participants SHOULD send $EK$ in acknowledgment of any other $E*$
   message except $EK$ itself
@@ -820,13 +776,11 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   - Source: `docs/reference/formal_protocol/transitions.md`
   - VP-11-007 is-implemented-by CM-04-003
   - VP-11-007 is-implemented-by CM-04-004
-- `VP-11-008` If early embargo termination is desired but the termination
+- `VP-11-008` SHOULD If early embargo termination is desired but the termination
   date/time is in the future, this SHOULD be achieved through an Embargo
   Revision Proposal and additional communication
   - Source: `docs/reference/formal_protocol/messages.md`
   - **Gap**: Not addressed by any current implementation spec
-
-## EM Messaging (MAY)
 
 - `VP-11-009` Participants MAY begin embargo negotiations before sending the
   report itself in an $RS$ message; therefore it is not an error for an $E*$
@@ -841,7 +795,7 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
 
 ---
 
-## CVD Case State (CS) Messaging (SHOULD)
+## CVD Case State (CS) Messaging
 
 - `VP-12-001` Vendor Awareness ($CV$) messages SHOULD be sent only by
   Participants with direct knowledge of the notification (i.e., either the
@@ -857,7 +811,7 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
 
 ---
 
-## RM-EM Interactions (SHOULD)
+## RM-EM Interactions
 
 - `VP-13-001` The EM process SHOULD begin when a recipient is in RM Received
   ($q^{rm} \in R$) whenever possible
@@ -889,27 +843,23 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   - Source: `docs/topics/process_models/model_interactions/rm_em.md`
   - VP-13-006 is-implemented-by CM-04-001
   - VP-13-006 is-implemented-by CM-04-003
-- `VP-13-007` Participants who choose to close a report while an embargo remains
+- `VP-13-007` SHOULD Participants who choose to close a report while an embargo remains
   in force SHOULD communicate their intent to either continue to adhere to the
   embargo or terminate their compliance with it
   - Source: `docs/topics/process_models/model_interactions/rm_em.md`
   - VP-13-007 is-implemented-by CM-06-001
-- `VP-13-008` Any changes to a Participant's intention to adhere to an active
+- `VP-13-008` SHOULD Any changes to a Participant's intention to adhere to an active
   embargo SHOULD be communicated clearly in addition to any necessary RM or EM
   state change notifications
   - Source: `docs/topics/process_models/model_interactions/rm_em.md`
   - VP-13-008 is-implemented-by CM-06-001
 
-## RM-EM Interactions (SHALL NOT)
-
-- `VP-13-009` A Participant's closure or deferral ($q^{rm} \in \{C, D\}$) of a
+- `VP-13-009` SHALL NOT A Participant's closure or deferral ($q^{rm} \in \{C, D\}$) of a
   report while an embargo remains active ($q^{em} \in \{A, R\}$) and while
   other Participants remain engaged SHALL NOT automatically terminate the embargo
   - Source: `docs/topics/process_models/model_interactions/rm_em.md`
   - VP-13-009 is-implemented-by CM-03-003
   - VP-13-009 is-implemented-by CM-04-005
-
-## RM-EM Interactions (MAY)
 
 - `VP-13-010` The EM process MAY begin prior to the report being sent to a
   potential Participant ($q^{rm} \in S$)
@@ -930,7 +880,7 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   - VP-13-012 is-implemented-by CM-03-001
   - VP-13-012 is-implemented-by CM-03-003
   - VP-13-012 is-implemented-by CM-04-003
-- `VP-13-013` EM revision proposals and acceptance or rejection of those
+- `VP-13-013` MAY EM revision proposals and acceptance or rejection of those
   proposals MAY occur during any of the valid yet unclosed RM states
   ($q^{rm} \in \{V, A, D\}$)
   - Source: `docs/topics/process_models/model_interactions/rm_em.md`
@@ -962,7 +912,7 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   - VP-13-017 is-implemented-by CM-03-001
   - VP-13-017 is-implemented-by CM-03-003
   - VP-13-017 is-implemented-by CM-04-003
-- `VP-13-018` Upon receipt of a Participant's notification of intent to end
+- `VP-13-018` MAY Upon receipt of a Participant's notification of intent to end
   their compliance with an embargo, other Participants MAY choose to terminate
   the embargo
   - Source: `docs/topics/process_models/model_interactions/rm_em.md`
@@ -972,34 +922,30 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
 
 ---
 
-## RM-EM-CS Interactions (SHALL NOT)
+## RM-EM-CS Interactions
 
-- `VP-14-001` Once Public Awareness has happened ($q^{cs} \in \cdots P \cdots$),
+- `VP-14-001` SHALL NOT Once Public Awareness has happened ($q^{cs} \in \cdots P \cdots$),
   new embargoes SHALL NOT be sought and any existing embargo SHALL terminate
   - Source: `docs/topics/process_models/model_interactions/rm_em_cs.md`
   - VP-14-001 is-implemented-by CM-04-003
   - VP-14-001 is-implemented-by CM-04-004
-- `VP-14-002` Once Exploit Publication has occurred
+- `VP-14-002` SHALL NOT Once Exploit Publication has occurred
   ($q^{cs} \in \cdots X \cdot$), new embargoes SHALL NOT be sought and any
   existing embargo SHALL terminate
   - Source: `docs/topics/process_models/model_interactions/rm_em_cs.md`
   - VP-14-002 is-implemented-by CM-04-003
   - VP-14-002 is-implemented-by CM-04-004
-- `VP-14-003` Once Attacks have been observed ($q^{cs} \in \cdots A$), new
+- `VP-14-003` SHALL NOT Once Attacks have been observed ($q^{cs} \in \cdots A$), new
   embargoes SHALL NOT be sought
   - Source: `docs/topics/process_models/model_interactions/rm_em_cs.md`
   - VP-14-003 is-implemented-by CM-04-004
-
-## RM-EM-CS Interactions (MUST)
 
 - `VP-14-004` Participants MUST treat attacks as an event that could occur at
   any time and adapt their process as needed in light of available information
   - Source: `docs/topics/process_models/model_interactions/rm_em_cs.md`
   - VP-14-004 is-implemented-by CM-04-004
 
-## RM-EM-CS Interactions (SHOULD)
-
-- `VP-14-005` Once a case has reached Vendor Aware ($q^{cs} \in Vfdpxa$) for at
+- `VP-14-005` SHOULD Once a case has reached Vendor Aware ($q^{cs} \in Vfdpxa$) for at
   least one Vendor, if the EM process has not started, it SHOULD begin as soon
   as possible
   - Source: `docs/topics/process_models/model_interactions/rm_em_cs.md`
@@ -1008,12 +954,12 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   after the first Vendor is notified
   - Source: `docs/topics/process_models/model_interactions/rm_em_cs.md`
   - VP-14-006 is-implemented-by CM-04-003
-- `VP-14-007` Once a case has reached Fix Ready ($q^{cs} \in VF\cdot pxa$), new
+- `VP-14-007` SHOULD NOT Once a case has reached Fix Ready ($q^{cs} \in VF\cdot pxa$), new
   embargo negotiations SHOULD NOT start and proposed but not-yet-agreed-to
   embargoes SHOULD be rejected
   - Source: `docs/topics/process_models/model_interactions/rm_em_cs.md`
   - VP-14-007 is-implemented-by CM-04-003
-- `VP-14-008` Existing embargoes ($q^{em} \in \{Active, Revise\}$) when Fix
+- `VP-14-008` SHOULD Existing embargoes ($q^{em} \in \{Active, Revise\}$) when Fix
   Ready is reached SHOULD prepare to terminate soon
   - Source: `docs/topics/process_models/model_interactions/rm_em_cs.md`
   - VP-14-008 is-implemented-by CM-04-003
@@ -1021,11 +967,11 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   trailing Vendors to catch up before publication when possible
   - Source: `docs/topics/process_models/model_interactions/rm_em_cs.md`
   - **Gap**: Not addressed by any current implementation spec
-- `VP-14-010` By the time a fix has been deployed ($q^{cs} \in VFD\cdots$), new
+- `VP-14-010` SHOULD NOT By the time a fix has been deployed ($q^{cs} \in VFD\cdots$), new
   embargoes SHOULD NOT be sought and any existing embargo SHOULD terminate
   - Source: `docs/topics/process_models/model_interactions/rm_em_cs.md`
   - VP-14-010 is-implemented-by CM-04-003
-- `VP-14-011` Exploit Publishers who are Participants in pre-public CVD cases
+- `VP-14-011` SHOULD Exploit Publishers who are Participants in pre-public CVD cases
   ($q^{cs} \in \cdots p \cdots$) SHOULD comply with the protocol, especially
   when they also fulfill other roles (e.g., Finder, Reporter, Coordinator,
   Vendor)
@@ -1035,15 +981,13 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   embargo is active ($q^{em} \in \{A, R\}$)
   - Source: `docs/topics/process_models/model_interactions/rm_em_cs.md`
   - **Gap**: Not addressed by any current implementation spec
-- `VP-14-013` Once Attacks have been observed ($q^{cs} \in \cdots A$), any
+- `VP-14-013` SHOULD Once Attacks have been observed ($q^{cs} \in \cdots A$), any
   existing embargo SHOULD terminate
   - Source: `docs/topics/process_models/model_interactions/rm_em_cs.md`
   - VP-14-013 is-implemented-by CM-04-003
   - VP-14-013 is-implemented-by CM-04-004
 
-## RM-EM-CS Interactions (MAY)
-
-- `VP-14-014` In MPCVD cases where some Vendors reach Fix Ready before others,
+- `VP-14-014` MAY In MPCVD cases where some Vendors reach Fix Ready before others,
   Participants MAY propose an embargo extension to allow trailing Vendors to
   catch up before publication
   - Source: `docs/topics/process_models/model_interactions/rm_em_cs.md`
@@ -1051,7 +995,7 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
 
 ---
 
-## Implementation Guidance (SHOULD)
+## Implementation Guidance
 
 - `VP-15-001` Vultron Protocol messages SHOULD use well-defined format
   specifications (e.g., JSON Schema, protobuf, XSD)
@@ -1068,8 +1012,6 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
   - VP-15-003 is-implemented-by ENC-02-001
   - VP-15-003 is-implemented-by ENC-03-001
 
-## Implementation Guidance (MAY)
-
 - `VP-15-004` `PROD_ONLY` Vultron Protocol implementations MAY use end-to-end
   encryption to protect sensitive data in transit
   - Source: `docs/howto/general_implementation.md`
@@ -1082,7 +1024,7 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
 
 ---
 
-## Embargo Representation Privacy (MUST NOT)
+## Embargo Representation Privacy
 
 - `VP-16-001` Vulnerability details MUST NOT appear in embargo representation
   data (e.g., embargo scheduling or notification messages)
@@ -1091,8 +1033,6 @@ CVD Case State (CS) messaging, model interactions, and implementation guidance.
     the target format
   - VP-16-001 is-implemented-by MV-05-001
   - VP-16-001 is-implemented-by MV-05-002
-
-## Embargo Representation Privacy (SHOULD)
 
 - `VP-16-002` A case or vulnerability identifier SHOULD appear in embargo
   representation data along with an indication that it relates to an embargo


### PR DESCRIPTION
## Summary

Two-pass normalization of RFC 2119 keyword usage in all `specs/` files:

1. **Add missing keywords** (176 requirement fixes): Insert RFC 2119 keyword immediately after each requirement ID where one was missing. Selection priority: (1) keyword found in continuation lines, (2) imperative verb inference, (3) parent section header keyword.

2. **Strip keywords from section headers** (292 header fixes): Remove parenthetical RFC 2119 suffixes from `##`/`###` section headers (e.g., `## Foo (MUST)` → `## Foo`).

3. **Parenthesise prefix keywords** (171 line fixes): Wrap inserted keywords in parentheses for visual clarity: e.g., `AR-02-002` (MUST) All valid states...

Result: 26 spec files with consistent, machine-readable RFC 2119 keyword placement. Zero bare-prefix keywords remain. Markdown linter: 0 errors.

Specs-only changes — no code modifications.