### PR TITLE
docs(plan): restore SPEC-AUDIT-1/2 history and completion markers

### DIFF
--- a/plan/IMPLEMENTATION_HISTORY.md
+++ b/plan/IMPLEMENTATION_HISTORY.md
@@ -3727,7 +3727,7 @@ on its first line, and remove keyword suffixes from section headers.
 
 **Verification**:
 
-- `grep -rn "^\- \`[A-Z]" specs/*.md | grep -v "MUST\|SHOULD\|..." → 0 hits`
+- ``grep -rn "^\- `[A-Z]" specs/*.md | grep -v "MUST\|SHOULD\|..." → 0 hits``
 - `grep -rh "^## \|^### " specs/*.md | grep "(MUST)\|(SHOULD)\|(MAY)"` → 0 hits
 - `markdownlint-cli2`: 0 errors
 

--- a/plan/IMPLEMENTATION_HISTORY.md
+++ b/plan/IMPLEMENTATION_HISTORY.md
@@ -3701,3 +3701,134 @@ convention throughout the codebase (both wire layer and core layer).
   all pitfall code snippets to use `id_`, `type_`, `object_`.
 
 **Tests**: 1080 passed, 5581 subtests passed.
+
+---
+
+## SPEC-AUDIT-2 — RFC 2119 strength keyword migration (2026-03-30)
+
+**Task**: Ensure every requirement line in `specs/` has an RFC 2119 keyword
+on its first line, and remove keyword suffixes from section headers.
+
+**Changes**:
+
+- **176 keyword additions**: Requirement lines missing a keyword on the first
+  line (keyword was on a wrapped continuation line, absent, or only in the
+  section header) now have the keyword inserted immediately after the ID.
+  Prefix-style keywords are parenthesised: `` `ID` (MUST) text ``.
+  Naturally-embedded keywords (e.g. `All handlers MUST ...`) are left as-is.
+- **293 header cleanups**: `## Section (MUST)` / `(SHOULD)` / `(MAY)` etc.
+  suffixes removed from all `##` and `###` headers across 37 spec files.
+  Removing headers that had identical base names (e.g. two `## Embargo Rules`
+  sections previously separated by `(MUST)`/`(SHOULD)`) also resulted in
+  31 duplicate-header merges in `vultron-protocol-spec.md` and `code-style.md`.
+- **171 format fixes**: A second pass converted bare prefix keywords
+  (`MUST text`) to the parenthesised form (`(MUST) text`) for visual
+  clarity and to distinguish them from sentence-embedded keywords.
+
+**Verification**:
+
+- `grep -rn "^\- \`[A-Z]" specs/*.md | grep -v "MUST\|SHOULD\|..." → 0 hits`
+- `grep -rh "^## \|^### " specs/*.md | grep "(MUST)\|(SHOULD)\|(MAY)"` → 0 hits
+- `markdownlint-cli2`: 0 errors
+
+**Tests**: 1080 passed, 5581 subtests (no code changes; docs only).
+
+---
+
+## SPEC-AUDIT-1 — Consolidation audit: eliminate redundant requirements (2026-03-30)
+
+**Task**: Audit all `specs/` files to identify overlapping or duplicated
+requirements; merge or cross-reference to eliminate maintenance-burden
+redundancy.
+
+**Changes**: Added 21 bidirectional cross-reference sub-bullets across 6
+spec files, following the `ID-1 relationship ID-2` convention from
+`specs/meta-specifications.md`.
+
+### dispatch-routing.md ↔ handler-protocol.md
+
+- `HP-02-001 depends-on DR-01-003` / `DR-01-003 is-dependency-of HP-02-001`:
+  Handler semantic-type verification is fulfilled by the dispatcher lookup.
+- `HP-02-002 refines DR-01-003` / `DR-01-003 is-refined-by HP-02-002`:
+  Handler perspective on how the verification mechanism must behave.
+- `HP-03-001 derives-from DR-02-001` / `DR-02-001 is-derived-by HP-03-001`:
+  Handler discoverability requirement derives from the USE_CASE_MAP lookup.
+- `HP-03-002 refines DR-02-002` / `DR-02-002 is-refined-by HP-03-002`:
+  Registry key–type matching refines the completeness requirement.
+
+### semantic-extraction.md → dispatch-routing.md
+
+- `SE-05-002 derives-from DR-02-002` / `DR-02-002 is-derived-by SE-05-002`:
+  Pattern→use-case coverage check derives from the USE_CASE_MAP completeness
+  requirement.
+
+### code-style.md ↔ tech-stack.md
+
+- `CS-01-001 refines IMPL-TS-07-001` / reverse: code style requirement
+  refines the authoritative Black tooling requirement.
+- `CS-01-002 derives-from IMPL-TS-07-005` / reverse: CI formatting-check
+  requirement derives from the parallel-jobs CI requirement.
+- `CS-01-003 duplicates IMPL-TS-07-001/004/005` (and reverses): developer
+  enforcement summary in code-style duplicates canonical tool requirements
+  in tech-stack.
+- `CS-01-006 duplicates IMPL-TS-07-002/003` (and reverses): static type
+  enforcement in code-style duplicates canonical per-tool requirements in
+  tech-stack.
+
+### architecture.md ↔ code-style.md
+
+- `CS-05-001 derives-from ARCH-01-001` / `ARCH-01-001 is-derived-by CS-05-001`:
+  Code-style layer-separation import rule derives from the architecture
+  layer-separation requirement.
+
+**Verification**:
+
+- `markdownlint-cli2`: 0 errors (453 files linted)
+- No code changes; cross-references are docs-only additions.
+
+**Tests**: 1080 passed, 5581 subtests (no code changes; docs only).
+
+---
+
+## SPEC-AUDIT-1 — Consolidation audit: eliminate redundant requirements (COMPLETE 2026-03-30)
+
+*(Note: a partial cross-reference-only pass was made earlier in this session;
+this entry records the completed elimination pass.)*
+
+**Task**: Audit all `specs/` files to identify overlapping or duplicated
+requirements; eliminate redundant requirements and cross-reference between
+canonical and superseded items.
+
+### Pairs audited
+
+**`tech-stack.md` vs `code-style.md`** (canonical: `tech-stack.md` for
+enforcement; `code-style.md` for style conventions):
+
+- `CS-01-002` deprecated and superseded by `IMPL-TS-07-005`
+- `CS-01-003` deprecated and superseded by `IMPL-TS-07-001`, `IMPL-TS-07-004`,
+  `IMPL-TS-07-005`
+- `CS-01-006` deprecated and superseded by `IMPL-TS-07-002`, `IMPL-TS-07-003`
+- Added consolidation note to `code-style.md` header
+- `IMPL-TS-07-001–005` updated with `supersedes` relationships (replacing
+  `is-duplicated-by`)
+
+**`dispatch-routing.md` vs `handler-protocol.md`** (canonical: dispatch-routing
+for mechanism; handler-protocol for contract):
+
+- Removed duplicate `**Implementation**:` notes from `HP-02-001` and
+  `HP-03-001` (implementation details live in `dispatch-routing.md`)
+- Replaced duplicate test assertions in `HP-02-001/002` and `HP-03-001/002`
+  verification sections with pointers to `dispatch-routing.md` verification
+  criteria
+- All bidirectional `depends-on`/`is-dependency-of`, `refines`/`is-refined-by`,
+  and `derives-from`/`is-derived-by` cross-references retained
+
+**`semantic-extraction.md` → `dispatch-routing.md`**: `SE-05-002` cross-
+referenced to `DR-02-002`
+
+**`architecture.md` ↔ `code-style.md`**: `ARCH-01-001 is-derived-by CS-05-001`
+/ `CS-05-001 derives-from ARCH-01-001`
+
+**Verification**: `markdownlint-cli2` → 0 errors (453 files)
+
+**Tests**: No code changes; docs only. Test count unchanged (1080 passed).

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -279,7 +279,7 @@ are needed before resuming feature development.
   assertions from handler-protocol.md (covered by dispatch-routing.md).
   Added bidirectional cross-references across 6 spec files (dispatch-routing,
   handler-protocol, semantic-extraction, code-style, tech-stack, architecture).
-  All 453 markdown files lint clean.
+  All 453 Markdown files pass markdownlint.
 
 ### SPEC-AUDIT-2 — Strength keyword migration ✅
 

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -17,12 +17,18 @@ NOT override `plan/PRIORITIES.md` when the two differ.
 
 All 38 message handlers implemented (including `unknown`). All 9 trigger
 endpoints complete. 12 demo scripts, all dockerized in `docker-compose.yml`.
-All PRIORITY-30 through PRIORITY-200 phases complete. Active open work:
-**PRIORITY-250** (pre-300 cleanup — all tasks done: NAMING-1, QUALITY-1,
-SM-GUARD-1, VSR-ERR-1, BUG-FLAKY-1, REORG-1, SECOPS-1, DOCMAINT-1,
-SPEC-AUDIT-3) and
+All PRIORITY-30 through PRIORITY-200 phases complete.
+
+#### Active open work
+
+**PRIORITY-250** Pre-300 cleanup
+
+- done: NAMING-1, QUALITY-1, SM-GUARD-1, VSR-ERR-1,
+  BUG-FLAKY-1, REORG-1, SECOPS-1, DOCMAINT-1, SPEC-AUDIT-1, SPEC-AUDIT-2,
+  SPEC-AUDIT-3
+
 **PRIORITY-300** (multi-actor demos; D5-1 unblocked, D5-2 and later blocked
-by PRIORITY-250 — now complete).
+by PRIORITY-250).
 
 ---
 
@@ -264,23 +270,24 @@ Participant Actors via log synchronization.
 These tasks were identified during the March 27, 2026 spec review session and
 are needed before resuming feature development.
 
-### SPEC-AUDIT-1 — Consolidation audit: eliminate redundant requirements
+### SPEC-AUDIT-1 — Consolidation audit: eliminate redundant requirements ✅
 
-- [ ] **SPEC-AUDIT-1**: Audit all `specs/` files to identify overlapping or
-  duplicated requirements across files. Known high-priority candidates include
-  `dispatch-routing.md` vs `handler-protocol.md` and `tech-stack.md` vs
-  `code-style.md`. Merge or cross-reference requirements to eliminate
-  maintenance-burden redundancy and reduce risk of specification divergence.
+- [x] **SPEC-AUDIT-1**: Audited all `specs/` files; identified and eliminated
+  redundant requirements across four overlapping pairs. Deprecated CS-01-002,
+  CS-01-003, CS-01-006 (superseded by canonical IMPL-TS-07-* in tech-stack.md).
+  Removed duplicate implementation notes and duplicate verification test
+  assertions from handler-protocol.md (covered by dispatch-routing.md).
+  Added bidirectional cross-references across 6 spec files (dispatch-routing,
+  handler-protocol, semantic-extraction, code-style, tech-stack, architecture).
+  All 453 markdown files lint clean.
 
-### SPEC-AUDIT-2 — Strength keyword migration
+### SPEC-AUDIT-2 — Strength keyword migration ✅
 
-- [ ] **SPEC-AUDIT-2**: Audit all `.md` files in `specs/` to ensure every
-  individual requirement line includes an inline RFC 2119 strength keyword
-  (MUST, SHOULD, or MAY). Per the updated `specs/meta-specifications.md`,
-  keywords MUST appear in the requirement text itself, not only in section
-  headers. Insert the keyword between the requirement ID and the requirement
-  text on each line that is missing it (e.g., `XX-01-001 (MUST) Use SHA-256
-  hashes...`). A full-spectrum audit across all spec files is required.
+- [x] **SPEC-AUDIT-2**: Every requirement line in all 37 spec files now has an
+  RFC 2119 keyword on its first line (greppable). Prefix-style keywords are
+  parenthesised: `` `ID` (MUST) text ``; naturally-embedded keywords left as-is.
+  All section-header keyword suffixes (e.g. `(MUST)`) removed. 176 keyword
+  additions, 293 header cleanups, 171 format fixes. Completed 2026-03-30.
 
 ### SPEC-AUDIT-3 — Relocate transient implementation notes from specs ✅
 


### PR DESCRIPTION
## Summary

The REORG-1 merge (PR #350) inadvertently dropped 296 lines from
`plan/IMPLEMENTATION_HISTORY.md` when merging a branch that predated the
SPEC-AUDIT-1/2 work. The plan-docs PR (#357) similarly overwrote the
completion markers that PRs #355 and #356 had set.

## Root cause

PR #350 (REORG-1) was branched from `p251` before SPEC-AUDIT-1/2 were
complete, but was merged **after** PRs #355 and #356. The three-way merge
conflict was resolved by keeping the REORG-1 branch's older version of
`IMPLEMENTATION_HISTORY.md`, silently dropping the 131 lines that had
been added by the SPEC-AUDIT PRs. PR #357 (plan-docs) had the same issue
with completion markers in `IMPLEMENTATION_PLAN.md`.

## Changes

- **`plan/IMPLEMENTATION_HISTORY.md`**: restored three missing entries:
  - SPEC-AUDIT-2 completion (176 keyword additions, 293 header cleanups,
    171 format fixes across 37 spec files)
  - SPEC-AUDIT-1 partial cross-reference pass
  - SPEC-AUDIT-1 completed elimination pass
- **`plan/IMPLEMENTATION_PLAN.md`**:
  - SPEC-AUDIT-1 and SPEC-AUDIT-2 marked `[x]` / ✅
  - PRIORITY-250 summary updated to list both in the 'done' set
  - 'Active open work' section reformatted for clarity

No spec or source code changes; docs/plan only.