### PR TITLE
feat: add YAML frontmatter to notes/*.md (IDEA-26042403)

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -27,6 +27,11 @@ config:
   # Allow duplicate headings as long as they don't share the same parent section
   "MD024":
     siblings_only: true
+  # 025 Single title / single H1
+  # Disable front_matter_title so that YAML frontmatter 'title:' does not
+  # count as an H1, allowing both frontmatter title and a body # heading.
+  "MD025":
+    front_matter_title: ""
   # 051 Link fragments should be valid
   # Disabled because conversion from TeX to markdown produces invalid links
   # We might eventually be able to re-enable this one.

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -11,5 +11,8 @@ exclude = (?x)(
 [mypy-vultron.*]
 # Specific configurations for vultron package
 
+[mypy-frontmatter]
+ignore_missing_imports = True
+
 [mypy-test.*]
 # Specific configurations for test modules

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,10 @@ repos:
         args: ["--fix", "--config", ".markdownlint-cli2.yaml", "**/*.md"]
         files: \.(md|markdown)$
 
+      - id: validate-notes-frontmatter
+        name: Validate notes frontmatter
+        entry: uv run python -c "from vultron.metadata.notes.loader import load_notes_registry; load_notes_registry()"
+        language: system
+        files: ^notes/.*\.md$
+        exclude: ^notes/README\.md$
+        pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1467,6 +1467,24 @@ Use `markdownlint-cli2` for linting markdown. The default config
 All other directories (`specs/`, `notes/`, `docs/`, `plan/`) are linted
 by the default config.
 
+### Notes frontmatter maintenance (NF-06-001, NF-06-002)
+
+Every `notes/*.md` file (except `notes/README.md`) MUST contain a YAML
+frontmatter block at the top of the file with at least `title` and `status`
+fields. Valid `status` values are `active`, `draft`, `superseded`, and
+`archived`. When `status` is `superseded`, a `superseded_by` field is also
+required.
+
+When modifying any `notes/*.md` file, review and update its frontmatter —
+in particular `status`, `related_specs`, and `related_notes` — to reflect
+any changes in scope or relationships.
+
+A pre-commit hook (`validate-notes-frontmatter`) and a pytest test
+(`test/metadata/test_notes_frontmatter.py`) enforce that every notes file
+has valid frontmatter. The schema is defined in
+`vultron/metadata/notes/schema.py` and the loader in
+`vultron/metadata/notes/loader.py`.
+
 ### Docs links must be relative
 
 Markdown links in `docs/` MUST be relative to the current file and MUST NOT

--- a/notes/activity-factories.md
+++ b/notes/activity-factories.md
@@ -8,6 +8,8 @@ related_specs:
   - specs/activity-factories.md
 relevant_packages:
   - pydantic
+  - vultron/wire/as2
+  - vultron/core/use_cases
 ---
 
 # Activity Factory Functions — Implementation Notes

--- a/notes/activity-factories.md
+++ b/notes/activity-factories.md
@@ -1,3 +1,15 @@
+---
+title: Activity Factory Functions — Implementation Notes
+status: active
+description: >
+  Factory functions as the public construction API for outbound Vultron
+  activity messages; replaces direct subclass instantiation.
+related_specs:
+  - specs/activity-factories.md
+relevant_packages:
+  - pydantic
+---
+
 # Activity Factory Functions — Implementation Notes
 
 ## Summary

--- a/notes/activitystreams-semantics.md
+++ b/notes/activitystreams-semantics.md
@@ -1,3 +1,19 @@
+---
+title: ActivityStreams Semantics in Vultron
+status: active
+description: >
+  Activities as state-change statements, not commands; inbound/outbound
+  semantics, Accept/Reject object rules, and rehydration.
+related_specs:
+  - specs/semantic-extraction.md
+  - specs/response-format.md
+  - specs/case-management.md
+related_notes:
+  - notes/bt-integration.md
+relevant_packages:
+  - pydantic
+---
+
 # ActivityStreams Semantics in Vultron
 
 ## Activities Are State-Change Notifications, Not Commands

--- a/notes/activitystreams-semantics.md
+++ b/notes/activitystreams-semantics.md
@@ -12,6 +12,8 @@ related_notes:
   - notes/bt-integration.md
 relevant_packages:
   - pydantic
+  - vultron/wire/as2
+  - vultron/core/models/events
 ---
 
 # ActivityStreams Semantics in Vultron

--- a/notes/actor-knowledge-model.md
+++ b/notes/actor-knowledge-model.md
@@ -9,6 +9,9 @@ related_specs:
   - specs/testability.md
 relevant_packages:
   - fastapi
+  - vultron/core/behaviors
+  - vultron/core/use_cases
+  - vultron/adapters/driving/fastapi
 ---
 
 # Actor Knowledge Model — Implementation Notes

--- a/notes/actor-knowledge-model.md
+++ b/notes/actor-knowledge-model.md
@@ -1,3 +1,16 @@
+---
+title: Actor Knowledge Model — Implementation Notes
+status: active
+description: >
+  Design decisions and implementation guidance for the Actor Knowledge Model
+  (IDEA-26041601/02).
+related_specs:
+  - specs/actor-knowledge-model.md
+  - specs/testability.md
+relevant_packages:
+  - fastapi
+---
+
 # Actor Knowledge Model — Implementation Notes
 
 ## Overview

--- a/notes/append-only-file-handling.md
+++ b/notes/append-only-file-handling.md
@@ -1,3 +1,13 @@
+---
+title: Append-Only History File Handling
+status: active
+description: >
+  Implementation guidance for agents writing to plan/*HISTORY.md append-only
+  files; canonical append procedure and prohibited patterns.
+related_specs:
+  - specs/project-documentation.md
+---
+
 # Append-Only History File Handling
 
 Implementation guidance for agents writing to `plan/*HISTORY.md` files.

--- a/notes/architecture-ports-and-adapters.md
+++ b/notes/architecture-ports-and-adapters.md
@@ -1,3 +1,17 @@
+---
+title: Architecture Spec
+status: active
+description: >
+  Hexagonal Architecture (Ports and Adapters): core domain isolation, layer
+  rules, adapter patterns, and violation inventory.
+related_notes:
+  - notes/federation_ideas.md
+relevant_packages:
+  - fastapi
+  - pydantic
+  - rdflib
+---
+
 # Architecture Spec
 
 ## Overview

--- a/notes/architecture-ports-and-adapters.md
+++ b/notes/architecture-ports-and-adapters.md
@@ -1,15 +1,16 @@
 ---
 title: Architecture Spec
 status: active
-description: >
-  Hexagonal Architecture (Ports and Adapters): core domain isolation, layer
-  rules, adapter patterns, and violation inventory.
+description: "Hexagonal Architecture (Ports and Adapters): core domain isolation, layer rules, adapter patterns, and violation inventory."
 related_notes:
   - notes/federation_ideas.md
 relevant_packages:
   - fastapi
   - pydantic
   - rdflib
+  - vultron/core
+  - vultron/adapters
+  - vultron/wire/as2
 ---
 
 # Architecture Spec

--- a/notes/bt-composability.md
+++ b/notes/bt-composability.md
@@ -11,6 +11,8 @@ related_notes:
   - notes/bt-reusability.md
 relevant_packages:
   - py_trees
+  - vultron/bt
+  - vultron/core/behaviors
 ---
 
 # Behavior Tree Composability Design Notes

--- a/notes/bt-composability.md
+++ b/notes/bt-composability.md
@@ -1,3 +1,18 @@
+---
+title: Behavior Tree Composability Design Notes
+status: active
+description: >
+  Vultron's fractal composability principle for behavior trees; concrete
+  patterns for composing behavioral subtrees.
+related_specs:
+  - specs/bt-composability.md
+related_notes:
+  - notes/bt-integration.md
+  - notes/bt-reusability.md
+relevant_packages:
+  - py_trees
+---
+
 # Behavior Tree Composability Design Notes
 
 ## Overview

--- a/notes/bt-design-patterns.md
+++ b/notes/bt-design-patterns.md
@@ -13,6 +13,8 @@ related_notes:
   - notes/bt-reusability.md
 relevant_packages:
   - py_trees
+  - vultron/bt
+  - vultron/core/behaviors
 ---
 
 # Behavior Tree Design Patterns

--- a/notes/bt-design-patterns.md
+++ b/notes/bt-design-patterns.md
@@ -1,3 +1,20 @@
+---
+title: Behavior Tree Design Patterns
+status: active
+description: >
+  Idiomatic BT construction patterns from Colledanchise & Ögren; applies to
+  simulation and prototype BT implementations.
+related_specs:
+  - specs/behavior-tree-integration.md
+  - specs/behavior-tree-node-design.md
+related_notes:
+  - notes/bt-composability.md
+  - notes/bt-integration.md
+  - notes/bt-reusability.md
+relevant_packages:
+  - py_trees
+---
+
 # Behavior Tree Design Patterns
 
 ## Overview

--- a/notes/bt-fuzzer-nodes.md
+++ b/notes/bt-fuzzer-nodes.md
@@ -1,3 +1,15 @@
+---
+title: "Vultron BT Fuzzer Nodes: External Dependency Touchpoints"
+status: active
+description: >
+  Catalog of all fuzzer (stub) BT nodes in the Vultron simulation; external
+  dependency touchpoints for prototype implementation.
+related_specs:
+  - specs/behavior-tree-integration.md
+related_notes:
+  - notes/bt-integration.md
+---
+
 # Vultron BT Fuzzer Nodes: External Dependency Touchpoints
 
 ## Background and Purpose

--- a/notes/bt-fuzzer-nodes.md
+++ b/notes/bt-fuzzer-nodes.md
@@ -8,6 +8,10 @@ related_specs:
   - specs/behavior-tree-integration.md
 related_notes:
   - notes/bt-integration.md
+relevant_packages:
+  - vultron/bt/report_management
+  - vultron/bt/embargo_management
+  - vultron/bt/messaging
 ---
 
 # Vultron BT Fuzzer Nodes: External Dependency Touchpoints

--- a/notes/bt-integration.md
+++ b/notes/bt-integration.md
@@ -1,3 +1,19 @@
+---
+title: Behavior Tree Integration Design Notes
+status: active
+description: >
+  BT design decisions, py_trees patterns, simulation-to-prototype translation
+  strategy, subtree map, and anti-patterns to avoid.
+related_specs:
+  - specs/behavior-tree-integration.md
+related_notes:
+  - notes/bt-fuzzer-nodes.md
+  - notes/protocol-event-cascades.md
+  - notes/use-case-behavior-trees.md
+relevant_packages:
+  - py_trees
+---
+
 # Behavior Tree Integration Design Notes
 
 ## Architecture Overview

--- a/notes/bt-integration.md
+++ b/notes/bt-integration.md
@@ -12,6 +12,9 @@ related_notes:
   - notes/use-case-behavior-trees.md
 relevant_packages:
   - py_trees
+  - vultron/bt
+  - vultron/core/behaviors
+  - vultron/core/use_cases
 ---
 
 # Behavior Tree Integration Design Notes

--- a/notes/bt-reusability.md
+++ b/notes/bt-reusability.md
@@ -1,3 +1,21 @@
+---
+title: Behavior Tree Reusability and Composability Patterns
+status: active
+description: >
+  Design patterns for composable, reusable BT nodes and subtrees; vocabulary
+  for reusability and concrete anti-patterns.
+related_specs:
+  - specs/behavior-tree-integration.md
+  - specs/behavior-tree-node-design.md
+  - specs/bt-composability.md
+related_notes:
+  - notes/bt-composability.md
+  - notes/bt-integration.md
+  - notes/use-case-behavior-trees.md
+relevant_packages:
+  - py_trees
+---
+
 # Behavior Tree Reusability and Composability Patterns
 
 ## Overview

--- a/notes/bt-reusability.md
+++ b/notes/bt-reusability.md
@@ -14,6 +14,8 @@ related_notes:
   - notes/use-case-behavior-trees.md
 relevant_packages:
   - py_trees
+  - vultron/bt
+  - vultron/core/behaviors
 ---
 
 # Behavior Tree Reusability and Composability Patterns

--- a/notes/bugfix-workflow.md
+++ b/notes/bugfix-workflow.md
@@ -1,3 +1,11 @@
+---
+title: Bugfix Workflow — Implementation Notes
+status: active
+description: Design decisions and implementation patterns for the test-first bugfix workflow.
+related_specs:
+  - specs/bugfix-workflow.md
+---
+
 # Bugfix Workflow — Implementation Notes
 
 Design decisions, implementation patterns, and examples for the bugfix skill

--- a/notes/bugfix-workflow.md
+++ b/notes/bugfix-workflow.md
@@ -1,7 +1,9 @@
 ---
 title: Bugfix Workflow — Implementation Notes
 status: active
-description: Design decisions and implementation patterns for the test-first bugfix workflow.
+description: >
+  Design decisions and implementation patterns for the test-first bugfix
+  workflow.
 related_specs:
   - specs/bugfix-workflow.md
 ---

--- a/notes/case-log-authority.md
+++ b/notes/case-log-authority.md
@@ -1,3 +1,19 @@
+---
+title: Case Log Authority and Assertion Recording
+status: active
+description: >
+  Authority model for the case activity log: trusted timestamps, assertion
+  recording, and authority chain.
+related_specs:
+  - specs/case-log-processing.md
+  - specs/case-management.md
+  - specs/sync-log-replication.md
+related_notes:
+  - notes/activitystreams-semantics.md
+  - notes/case-state-model.md
+  - notes/sync-log-replication.md
+---
+
 # Case Log Authority and Assertion Recording
 
 **Relates to**: `specs/case-log-processing.md`,

--- a/notes/case-log-authority.md
+++ b/notes/case-log-authority.md
@@ -1,9 +1,7 @@
 ---
 title: Case Log Authority and Assertion Recording
 status: active
-description: >
-  Authority model for the case activity log: trusted timestamps, assertion
-  recording, and authority chain.
+description: "Authority model for the case activity log: trusted timestamps, assertion recording, and authority chain."
 related_specs:
   - specs/case-log-processing.md
   - specs/case-management.md
@@ -12,6 +10,9 @@ related_notes:
   - notes/activitystreams-semantics.md
   - notes/case-state-model.md
   - notes/sync-log-replication.md
+relevant_packages:
+  - vultron/wire/as2
+  - vultron/core/models
 ---
 
 # Case Log Authority and Assertion Recording

--- a/notes/case-state-model.md
+++ b/notes/case-state-model.md
@@ -1,3 +1,18 @@
+---
+title: Case State Model Notes
+status: active
+description: >
+  CVD case state model: six binary dimensions (RM/EM/CS), CaseStatus append-
+  only history, and CaseEvent trusted timestamps.
+related_specs:
+  - specs/case-management.md
+related_notes:
+  - notes/activitystreams-semantics.md
+  - notes/protocol-event-cascades.md
+relevant_packages:
+  - transitions
+---
+
 # Case State Model Notes
 
 ## The Six-Dimensional Case State Model

--- a/notes/case-state-model.md
+++ b/notes/case-state-model.md
@@ -1,9 +1,7 @@
 ---
 title: Case State Model Notes
 status: active
-description: >
-  CVD case state model: six binary dimensions (RM/EM/CS), CaseStatus append-
-  only history, and CaseEvent trusted timestamps.
+description: "CVD case state model: six binary dimensions (RM/EM/CS), CaseStatus append- only history, and CaseEvent trusted timestamps."
 related_specs:
   - specs/case-management.md
 related_notes:
@@ -11,6 +9,9 @@ related_notes:
   - notes/protocol-event-cascades.md
 relevant_packages:
   - transitions
+  - vultron/bt/embargo_management
+  - vultron/bt/report_management
+  - vultron/core/case_states
 ---
 
 # Case State Model Notes

--- a/notes/codebase-structure.md
+++ b/notes/codebase-structure.md
@@ -12,6 +12,11 @@ related_notes:
 relevant_packages:
   - fastapi
   - py_trees
+  - vultron/core
+  - vultron/bt
+  - vultron/adapters
+  - vultron/wire/as2
+  - vultron/demo
 ---
 
 # Codebase Structure Notes

--- a/notes/codebase-structure.md
+++ b/notes/codebase-structure.md
@@ -1,3 +1,19 @@
+---
+title: Codebase Structure Notes
+status: active
+description: >
+  Overview of the Vultron codebase structure, module organization, and
+  hexagonal architecture layout.
+related_specs:
+  - specs/prototype-shortcuts.md
+related_notes:
+  - notes/bt-integration.md
+  - notes/domain-model-separation.md
+relevant_packages:
+  - fastapi
+  - py_trees
+---
+
 # Codebase Structure Notes
 
 ## Top-Level Module Reorganization Status

--- a/notes/configuration.md
+++ b/notes/configuration.md
@@ -8,6 +8,9 @@ relevant_packages:
   - fastapi
   - pydantic
   - yaml
+  - vultron/config
+  - vultron/adapters
+  - vultron/core
 ---
 
 # Configuration Management — Implementation Notes

--- a/notes/configuration.md
+++ b/notes/configuration.md
@@ -1,3 +1,15 @@
+---
+title: Configuration Management — Implementation Notes
+status: active
+description: Design decisions for YAML-backed Pydantic configuration loading in Vultron.
+related_specs:
+  - specs/configuration.md
+relevant_packages:
+  - fastapi
+  - pydantic
+  - yaml
+---
+
 # Configuration Management — Implementation Notes
 
 ## Background

--- a/notes/datalayer-design.md
+++ b/notes/datalayer-design.md
@@ -8,6 +8,9 @@ related_specs:
   - specs/datalayer.md
 related_notes:
   - notes/domain-model-separation.md
+relevant_packages:
+  - vultron/adapters/driven
+  - vultron/core/ports
 ---
 
 # DataLayer Design Notes

--- a/notes/datalayer-design.md
+++ b/notes/datalayer-design.md
@@ -1,3 +1,15 @@
+---
+title: DataLayer Design Notes
+status: active
+description: >
+  Design guidance for the DataLayer port and its adapters; auto-rehydration
+  contract, storage record evaluation.
+related_specs:
+  - specs/datalayer.md
+related_notes:
+  - notes/domain-model-separation.md
+---
+
 # DataLayer Design Notes
 
 Design guidance for the `DataLayer` port and its adapters. Covers the

--- a/notes/demo-future-ideas.md
+++ b/notes/demo-future-ideas.md
@@ -4,6 +4,8 @@ status: draft
 description: >
   Speculative future demo scenarios and multi-actor workflow ideas for the
   Vultron prototype.
+relevant_packages:
+  - vultron/demo
 ---
 
 # Future Demo Ideas

--- a/notes/demo-future-ideas.md
+++ b/notes/demo-future-ideas.md
@@ -1,3 +1,11 @@
+---
+title: Future Demo Ideas
+status: draft
+description: >
+  Speculative future demo scenarios and multi-actor workflow ideas for the
+  Vultron prototype.
+---
+
 # Future Demo Ideas
 
 ## Two-Actor Demo: Finder, Vendor coordinate in separate containers

--- a/notes/demo-review-26042001.md
+++ b/notes/demo-review-26042001.md
@@ -1,3 +1,15 @@
+---
+title: Demo Review — 2026-04-20
+status: archived
+description: >
+  Point-in-time demo review from 2026-04-20; log analysis and findings from
+  the demonstration run.
+related_specs:
+  - specs/architecture.md
+relevant_packages:
+  - transitions
+---
+
 # Demo Review — 2026-04-20
 
 Log files analysed:

--- a/notes/demo-review-26042001.md
+++ b/notes/demo-review-26042001.md
@@ -8,6 +8,7 @@ related_specs:
   - specs/architecture.md
 relevant_packages:
   - transitions
+  - vultron/demo
 ---
 
 # Demo Review — 2026-04-20

--- a/notes/diataxis-framework.md
+++ b/notes/diataxis-framework.md
@@ -1,3 +1,11 @@
+---
+title: "Implementation Standards for Technical Documentation: The Diátaxis Framework"
+status: active
+description: >
+  Implementation standards for Vultron technical documentation using the
+  Diátaxis framework.
+---
+
 # Implementation Standards for Technical Documentation: The Diátaxis Framework
 
 ## 1. Executive philosophy — Documentation as a function of user need

--- a/notes/do-work-behaviors.md
+++ b/notes/do-work-behaviors.md
@@ -1,3 +1,17 @@
+---
+title: "Do-Work Behaviors: Scope and Implementation Notes"
+status: active
+description: >
+  Scope boundaries for 'do work' behaviors in the Vultron prototype;
+  identifies which behaviors are unimplemented stubs.
+related_specs:
+  - specs/behavior-tree-integration.md
+  - specs/case-management.md
+  - specs/triggerable-behaviors.md
+relevant_packages:
+  - transitions
+---
+
 # Do-Work Behaviors: Scope and Implementation Notes
 
 This note documents the scope boundaries for "do work" behaviors in the

--- a/notes/do-work-behaviors.md
+++ b/notes/do-work-behaviors.md
@@ -10,6 +10,8 @@ related_specs:
   - specs/triggerable-behaviors.md
 relevant_packages:
   - transitions
+  - vultron/bt
+  - vultron/wire/as2
 ---
 
 # Do-Work Behaviors: Scope and Implementation Notes

--- a/notes/docker-build.md
+++ b/notes/docker-build.md
@@ -1,3 +1,11 @@
+---
+title: Docker Build Notes
+status: active
+description: >
+  Observations and guidance for Vultron Docker image optimization and docker-
+  compose configuration.
+---
+
 # Docker Build Notes
 
 ## Project-Specific Build Context Observations

--- a/notes/documentation-strategy.md
+++ b/notes/documentation-strategy.md
@@ -1,3 +1,14 @@
+---
+title: Documentation Strategy Notes
+status: active
+description: >
+  Documentation chronology and strategy for interpreting conflicting
+  documentation generations in Vultron.
+related_notes:
+  - notes/bt-integration.md
+  - notes/case-state-model.md
+---
+
 # Documentation Strategy Notes
 
 ## Documentation Chronology and Trust Levels

--- a/notes/documentation-strategy.md
+++ b/notes/documentation-strategy.md
@@ -7,6 +7,11 @@ description: >
 related_notes:
   - notes/bt-integration.md
   - notes/case-state-model.md
+relevant_packages:
+  - vultron/bt
+  - vultron/core
+  - vultron/demo
+  - vultron/wire/as2
 ---
 
 # Documentation Strategy Notes

--- a/notes/domain-model-separation.md
+++ b/notes/domain-model-separation.md
@@ -14,6 +14,9 @@ related_notes:
   - notes/datalayer-design.md
 relevant_packages:
   - pydantic
+  - vultron/wire/as2
+  - vultron/core/models
+  - vultron/adapters
 ---
 
 # Domain Model Separation: Wire, Domain, and Persistence

--- a/notes/domain-model-separation.md
+++ b/notes/domain-model-separation.md
@@ -1,3 +1,21 @@
+---
+title: "Domain Model Separation: Wire, Domain, and Persistence"
+status: active
+description: >
+  Analysis of wire/domain/persistence model coupling in VulnerabilityCase and
+  recommended separation path.
+related_specs:
+  - specs/architecture.md
+  - specs/case-management.md
+  - specs/datalayer.md
+related_notes:
+  - notes/activitystreams-semantics.md
+  - notes/case-state-model.md
+  - notes/datalayer-design.md
+relevant_packages:
+  - pydantic
+---
+
 # Domain Model Separation: Wire, Domain, and Persistence
 
 ## The Problem

--- a/notes/embargo-default-semantics.md
+++ b/notes/embargo-default-semantics.md
@@ -1,3 +1,16 @@
+---
+title: Embargo Default Semantics — Implementation Notes
+status: active
+description: >
+  Design decisions for embargo policy EP-04 requirements; default embargo
+  duration and expiry semantics.
+related_specs:
+  - specs/case-management.md
+  - specs/embargo-policy.md
+relevant_packages:
+  - transitions
+---
+
 # Embargo Default Semantics — Implementation Notes
 
 Design decisions, implementation patterns, and known gaps for

--- a/notes/embargo-default-semantics.md
+++ b/notes/embargo-default-semantics.md
@@ -9,6 +9,8 @@ related_specs:
   - specs/embargo-policy.md
 relevant_packages:
   - transitions
+  - vultron/bt/embargo_management
+  - vultron/core/use_cases/triggers
 ---
 
 # Embargo Default Semantics — Implementation Notes

--- a/notes/encryption.md
+++ b/notes/encryption.md
@@ -1,3 +1,11 @@
+---
+title: Encryption implementation notes
+status: draft
+description: >
+  Exploratory notes on encryption options for Vultron using ActivityPub
+  public-key infrastructure.
+---
+
 # Encryption implementation notes
 
 ## Overview

--- a/notes/event-driven-control-flow.md
+++ b/notes/event-driven-control-flow.md
@@ -1,3 +1,17 @@
+---
+title: Event-Driven Control Flow Design Notes
+status: active
+description: >
+  Conceptual model for event-driven control flow in Vultron; actor reaction
+  patterns and design rationale.
+related_specs:
+  - specs/event-driven-control-flow.md
+related_notes:
+  - notes/bt-integration.md
+  - notes/bt-reusability.md
+  - notes/protocol-event-cascades.md
+---
+
 # Event-Driven Control Flow Design Notes
 
 ## Overview

--- a/notes/event-driven-control-flow.md
+++ b/notes/event-driven-control-flow.md
@@ -10,6 +10,9 @@ related_notes:
   - notes/bt-integration.md
   - notes/bt-reusability.md
   - notes/protocol-event-cascades.md
+relevant_packages:
+  - vultron/bt
+  - vultron/core
 ---
 
 # Event-Driven Control Flow Design Notes

--- a/notes/federation_ideas.md
+++ b/notes/federation_ideas.md
@@ -7,6 +7,8 @@ description: >
 relevant_packages:
   - pydantic
   - rdflib
+  - vultron/wire/as2
+  - vultron/adapters
 ---
 
 # Federation Design Ideas

--- a/notes/federation_ideas.md
+++ b/notes/federation_ideas.md
@@ -1,3 +1,14 @@
+---
+title: Federation Design Ideas
+status: draft
+description: >
+  Exploratory federation architecture ideas for Vultron captured from design
+  discussion; input for future ADRs.
+relevant_packages:
+  - pydantic
+  - rdflib
+---
+
 # Federation Design Ideas
 
 > Captured from architecture discussion. Intended as input to design specs and

--- a/notes/mermaid-sequence-diagrams.md
+++ b/notes/mermaid-sequence-diagrams.md
@@ -1,3 +1,11 @@
+---
+title: Mermaid Sequence Diagram Reference
+status: active
+description: >
+  Mermaid sequence diagram syntax reference for documenting Vultron protocol
+  interactions.
+---
+
 # Mermaid Sequence Diagram Reference
 
 A sequence diagram is an interaction diagram that shows how processes

--- a/notes/notes-frontmatter.md
+++ b/notes/notes-frontmatter.md
@@ -9,6 +9,7 @@ related_specs:
 relevant_packages:
   - pydantic
   - python-frontmatter
+  - vultron/metadata/notes
 ---
 
 # Notes Frontmatter Design
@@ -120,6 +121,8 @@ related_notes:
   - notes/bt-composability.md
 relevant_packages:
   - py_trees
+  - vultron/core/behaviors
+  - vultron/bt
 ---
 ```
 

--- a/notes/notes-frontmatter.md
+++ b/notes/notes-frontmatter.md
@@ -1,0 +1,281 @@
+# Notes Frontmatter Design
+
+## Decision Table
+
+| Question | Decision | Rationale |
+|---|---|---|
+| Required vs optional fields | `title` + `status` required; all others optional | Lowers migration barrier; minimal required set enables validation |
+| Status vocabulary | `active \| draft \| superseded \| archived` | Mirrors ADR lifecycle; four states cover all practical cases |
+| `superseded_by` | Optional string, required when `status: superseded` | Makes replacement explicit; avoids orphaned superseded notes |
+| Relationship fields | Three separate lists: `related_specs`, `related_notes`, `relevant_packages` | Explicit, queryable; absent is ok; present-and-populated only |
+| Empty-list rule | Present-and-populated or absent; present-and-empty is invalid | Mirrors `OptionalNonEmptyString` pattern already in codebase |
+| `description` field | Optional non-empty string | Seeds future README auto-generation from the registry |
+| Module location | `vultron/metadata/notes/` subpackage | Parallel to planned `vultron/metadata/specs/`; shared `base.py` |
+| Loader isolation | `vultron/metadata/` MUST NOT import application code | Keeps tooling layer standalone; no circular imports |
+| Validation enforcement | pytest (all files) + pre-commit (changed files) | Belt-and-suspenders: CI catches everything; pre-commit is fast |
+| Migration scope | All existing `notes/*.md` at once | Enables hard enforcement from day one |
+| `notes/README.md` | Excluded from frontmatter requirements | Index file, not a design note; loader skips it |
+| `title` field | Explicit in frontmatter | Self-contained for tooling; no need to parse markdown body |
+| Query/dump tool | Deferred (future task) | Requires both notes and specs loaders; out of scope here |
+| Maintenance guidance | Update AGENTS.md + spec; pre-commit for structural checks | Agents need an explicit rule; structure is machine-checked |
+
+---
+
+## Schema Design
+
+### `NoteStatus` StrEnum
+
+```python
+from enum import StrEnum
+
+class NoteStatus(StrEnum):
+    ACTIVE     = "active"
+    DRAFT      = "draft"
+    SUPERSEDED = "superseded"
+    ARCHIVED   = "archived"
+```
+
+### `NotesFrontmatter` Pydantic Model
+
+```python
+from __future__ import annotations
+
+from pydantic import BaseModel, model_validator
+from vultron.metadata.base import NonEmptyStr, NonEmptyStrList
+
+class NotesFrontmatter(BaseModel):
+    title: NonEmptyStr
+    status: NoteStatus
+    superseded_by: NonEmptyStr | None = None
+    description: NonEmptyStr | None = None
+    related_specs: NonEmptyStrList | None = None
+    related_notes: NonEmptyStrList | None = None
+    relevant_packages: NonEmptyStrList | None = None
+
+    @model_validator(mode="after")
+    def superseded_by_required_when_superseded(self) -> NotesFrontmatter:
+        if self.status == NoteStatus.SUPERSEDED and not self.superseded_by:
+            raise ValueError(
+                "'superseded_by' is required when status is 'superseded'"
+            )
+        return self
+```
+
+### Shared type aliases in `vultron/metadata/base.py`
+
+```python
+from typing import Annotated
+from pydantic import StringConstraints
+
+NonEmptyStr = Annotated[str, StringConstraints(min_length=1)]
+NonEmptyStrList = Annotated[list[NonEmptyStr], ...]  # non-empty list
+```
+
+For the "non-empty list when present" rule, use a field validator or
+`Annotated` with `minlength=1` at the list level:
+
+```python
+from pydantic import field_validator
+
+@field_validator("related_specs", "related_notes", "relevant_packages",
+                  mode="before")
+@classmethod
+def non_empty_list_if_present(cls, v):
+    if v is not None and len(v) == 0:
+        raise ValueError("list field must be non-empty if present")
+    return v
+```
+
+---
+
+## Sample Frontmatter Block
+
+A well-formed frontmatter block at the top of a notes file looks like:
+
+```yaml
+---
+title: Behavior Tree Integration Design Notes
+status: active
+description: >
+  BT design decisions, py_trees patterns, simulation-to-prototype
+  translation strategy, and anti-patterns to avoid.
+related_specs:
+  - specs/behavior-tree-integration.md
+  - specs/behavior-tree-node-design.md
+related_notes:
+  - notes/bt-reusability.md
+  - notes/bt-composability.md
+relevant_packages:
+  - py_trees
+---
+```
+
+A minimal valid block:
+
+```yaml
+---
+title: Docker Build Notes
+status: active
+---
+```
+
+A superseded file:
+
+```yaml
+---
+title: Old Architecture Notes
+status: superseded
+superseded_by: notes/architecture-ports-and-adapters.md
+---
+```
+
+---
+
+## Loader Design
+
+### Module: `vultron/metadata/notes/loader.py`
+
+```python
+from pathlib import Path
+import yaml
+from vultron.metadata.notes.schema import NotesFrontmatter
+
+SKIP_FILES = {"README.md"}
+
+def _find_repo_root(start: Path = Path.cwd()) -> Path:
+    for parent in [start, *start.parents]:
+        if (parent / "pyproject.toml").exists():
+            return parent
+    raise FileNotFoundError("Could not locate repository root (pyproject.toml)")
+
+def _extract_frontmatter(text: str) -> dict | None:
+    """Return parsed YAML from a --- ... --- block, or None if absent."""
+    if not text.startswith("---"):
+        return None
+    end = text.index("\n---", 3)
+    return yaml.safe_load(text[3:end])
+
+def load_notes_registry(
+    repo_root: Path | None = None,
+) -> dict[str, NotesFrontmatter]:
+    root = repo_root or _find_repo_root()
+    notes_dir = root / "notes"
+    registry: dict[str, NotesFrontmatter] = {}
+    for path in sorted(notes_dir.glob("*.md")):
+        if path.name in SKIP_FILES:
+            continue
+        raw = _extract_frontmatter(path.read_text())
+        if raw is None:
+            raise ValueError(f"{path}: missing YAML frontmatter")
+        key = str(path.relative_to(root))
+        registry[key] = NotesFrontmatter.model_validate(raw)
+    return registry
+```
+
+### Package layout
+
+```text
+vultron/metadata/
+    __init__.py
+    base.py              # shared NonEmptyStr, NonEmptyStrList
+    notes/
+        __init__.py
+        schema.py        # NoteStatus, NotesFrontmatter
+        loader.py        # load_notes_registry()
+    specs/               # future — IDEA-26042402
+        __init__.py
+        schema.py
+        loader.py
+```
+
+---
+
+## Pytest Validation Test
+
+```python
+# test/metadata/test_notes_frontmatter.py
+import pytest
+from vultron.metadata.notes.loader import load_notes_registry
+
+def test_all_notes_files_have_valid_frontmatter():
+    """Every notes/*.md (except README.md) must parse cleanly."""
+    registry = load_notes_registry()
+    assert len(registry) > 0, "Notes registry must not be empty"
+    # If load_notes_registry() raises, the test fails with the validation error.
+```
+
+Mirror source layout: `test/metadata/` parallels `vultron/metadata/`.
+
+---
+
+## Pre-Commit Hook
+
+Add to `.pre-commit-config.yaml`:
+
+```yaml
+- repo: local
+  hooks:
+    - id: validate-notes-frontmatter
+      name: Validate notes frontmatter
+      entry: python -c "
+        from vultron.metadata.notes.loader import load_notes_registry;
+        load_notes_registry()
+      "
+      language: python
+      files: ^notes/.*\.md$
+      exclude: ^notes/README\.md$
+      pass_filenames: false
+```
+
+This re-validates the full registry on any notes change, ensuring no file
+is accidentally broken by a related edit.
+
+---
+
+## Migration Checklist for Existing Files
+
+For each `notes/*.md` file (except `README.md`), add a frontmatter block with:
+
+1. `title`: copy from the `# H1` heading
+2. `status`: choose from `active | draft | superseded | archived` based on
+   the file's current relevance
+3. `description`: paste or paraphrase the first paragraph or "Load when" line
+4. `related_specs`: list any `specs/*.md` files explicitly cross-referenced
+5. `related_notes`: list any other `notes/*.md` files cross-referenced
+6. `relevant_packages`: list any Python packages central to the topic
+
+Most files warrant `status: active`. Files that have been explicitly replaced
+should use `status: superseded` with `superseded_by` pointing to the replacement.
+
+---
+
+## Layer and Import Rules
+
+- `vultron/metadata/` is a **standalone tooling layer**.
+- It MUST NOT import from `vultron/core/`, `vultron/wire/`, or
+  `vultron/adapters/`.
+- It MAY be imported by test files and CLI tools.
+- It uses only `pydantic`, `pyyaml` (already in `pyproject.toml`), and
+  the standard library.
+
+---
+
+## Future: Registry and Query Tool (Deferred)
+
+When IDEA-26042402 (YAML specs) is also implemented, a unified
+`vultron/metadata/registry.py` can combine both loaders and expose:
+
+```python
+def relevant_context(topic: str) -> dict:
+    """Return notes and specs whose frontmatter relates to `topic`."""
+    ...
+```
+
+Matching strategy options (to be decided in that task):
+
+- Keyword substring match on `title` + `description`
+- File-path inclusion in `related_notes` / `related_specs` cross-references
+- Tag/keyword list field added to frontmatter at that time
+
+The `notes/README.md` can also be generated from the registry at that point,
+replacing manual summaries with content derived from the `description` fields.

--- a/notes/notes-frontmatter.md
+++ b/notes/notes-frontmatter.md
@@ -1,3 +1,16 @@
+---
+title: Notes Frontmatter Design
+status: active
+description: >
+  Design decisions for YAML frontmatter schema in notes/*.md files; schema,
+  loader, migration checklist, and pre-commit hook.
+related_specs:
+  - specs/notes-frontmatter.md
+relevant_packages:
+  - pydantic
+  - python-frontmatter
+---
+
 # Notes Frontmatter Design
 
 ## Decision Table

--- a/notes/outbox.md
+++ b/notes/outbox.md
@@ -1,3 +1,13 @@
+---
+title: Outbox Notes
+status: active
+description: Implementation guidance for outbox addressing requirements.
+related_specs:
+  - specs/outbox.md
+relevant_packages:
+  - fastapi
+---
+
 # Outbox Notes
 
 Implementation guidance for outbox addressing requirements.

--- a/notes/outbox.md
+++ b/notes/outbox.md
@@ -6,6 +6,7 @@ related_specs:
   - specs/outbox.md
 relevant_packages:
   - fastapi
+  - vultron/adapters/driving/fastapi
 ---
 
 # Outbox Notes

--- a/notes/participant-case-replica.md
+++ b/notes/participant-case-replica.md
@@ -1,3 +1,15 @@
+---
+title: Participant Case Replica — Implementation Notes
+status: active
+description: >
+  Design notes for participant case replicas: per-actor case copies and
+  synchronization model.
+related_specs:
+  - specs/participant-case-replica.md
+  - specs/case-management.md
+  - specs/sync-log-replication.md
+---
+
 # Participant Case Replica — Implementation Notes
 
 **Relates to**: `specs/participant-case-replica.md`

--- a/notes/participant-case-replica.md
+++ b/notes/participant-case-replica.md
@@ -1,13 +1,15 @@
 ---
 title: Participant Case Replica — Implementation Notes
 status: active
-description: >
-  Design notes for participant case replicas: per-actor case copies and
-  synchronization model.
+description: "Design notes for participant case replicas: per-actor case copies and synchronization model."
 related_specs:
   - specs/participant-case-replica.md
   - specs/case-management.md
   - specs/sync-log-replication.md
+relevant_packages:
+  - vultron/core/behaviors/case
+  - vultron/core/models
+  - vultron/core/use_cases
 ---
 
 # Participant Case Replica — Implementation Notes

--- a/notes/participant-embargo-consent.md
+++ b/notes/participant-embargo-consent.md
@@ -1,3 +1,17 @@
+---
+title: Participant Embargo Consent State Machine
+status: active
+description: >
+  Design decisions for tracking per-participant embargo acceptance; consent
+  state machine and implementation patterns.
+related_specs:
+  - specs/case-management.md
+related_notes:
+  - notes/stub-objects.md
+relevant_packages:
+  - transitions
+---
+
 # Participant Embargo Consent State Machine
 
 **Status**: Design decision — not yet implemented

--- a/notes/participant-embargo-consent.md
+++ b/notes/participant-embargo-consent.md
@@ -10,6 +10,8 @@ related_notes:
   - notes/stub-objects.md
 relevant_packages:
   - transitions
+  - vultron/bt/embargo_management
+  - vultron/core/use_cases
 ---
 
 # Participant Embargo Consent State Machine

--- a/notes/plan-history-management.md
+++ b/notes/plan-history-management.md
@@ -1,3 +1,13 @@
+---
+title: Plan / History Management Contract
+status: active
+description: >
+  Authoritative rules for managing IMPLEMENTATION_PLAN.md (forward roadmap)
+  and IMPLEMENTATION_HISTORY.md (append-only log).
+related_specs:
+  - specs/project-documentation.md
+---
+
 # Plan / History Management Contract
 
 This document defines the authoritative rules for managing

--- a/notes/plan-organization.md
+++ b/notes/plan-organization.md
@@ -1,3 +1,13 @@
+---
+title: "Plan Organization: Topic-Based Sections with Decoupled Priorities"
+status: active
+description: >
+  Topic-based plan organization with decoupled priorities;
+  IMPLEMENTATION_PLAN.md vs PRIORITIES.md separation rationale.
+related_specs:
+  - specs/project-documentation.md
+---
+
 # Plan Organization: Topic-Based Sections with Decoupled Priorities
 
 ## Overview

--- a/notes/protocol-event-cascades.md
+++ b/notes/protocol-event-cascades.md
@@ -11,6 +11,9 @@ related_specs:
 related_notes:
   - notes/activitystreams-semantics.md
   - notes/bt-integration.md
+relevant_packages:
+  - vultron/core/use_cases
+  - vultron/core/behaviors
 ---
 
 # Protocol Event Cascades

--- a/notes/protocol-event-cascades.md
+++ b/notes/protocol-event-cascades.md
@@ -1,3 +1,18 @@
+---
+title: Protocol Event Cascades
+status: active
+description: >
+  Event-driven causal model for protocol cascades; primary events, their
+  automated downstream consequences, and gap inventory.
+related_specs:
+  - specs/behavior-tree-integration.md
+  - specs/case-management.md
+  - specs/triggerable-behaviors.md
+related_notes:
+  - notes/activitystreams-semantics.md
+  - notes/bt-integration.md
+---
+
 # Protocol Event Cascades
 
 ## Overview

--- a/notes/stub-objects.md
+++ b/notes/stub-objects.md
@@ -1,3 +1,16 @@
+---
+title: Stub Objects and Selective Disclosure
+status: active
+description: >
+  Design notes for lightweight stub object representations in Vultron wire
+  messages; not yet implemented.
+related_specs:
+  - specs/stub-objects.md
+  - specs/message-validation.md
+related_notes:
+  - notes/datalayer-design.md
+---
+
 # Stub Objects and Selective Disclosure
 
 Design notes for lightweight object representations in Vultron wire messages.

--- a/notes/stub-objects.md
+++ b/notes/stub-objects.md
@@ -9,6 +9,8 @@ related_specs:
   - specs/message-validation.md
 related_notes:
   - notes/datalayer-design.md
+relevant_packages:
+  - vultron/wire/as2
 ---
 
 # Stub Objects and Selective Disclosure

--- a/notes/sync-log-replication.md
+++ b/notes/sync-log-replication.md
@@ -1,15 +1,16 @@
 ---
 title: Sync Log Replication — Design Notes
 status: active
-description: >
-  Design notes for sync log replication: append-only case activity log
-  synchronization between actors.
+description: "Design notes for sync log replication: append-only case activity log synchronization between actors."
 related_specs:
   - specs/sync-log-replication.md
   - specs/case-log-processing.md
 related_notes:
   - notes/case-log-authority.md
   - notes/case-state-model.md
+relevant_packages:
+  - vultron/core/behaviors
+  - vultron/wire/as2
 ---
 
 # Sync Log Replication — Design Notes

--- a/notes/sync-log-replication.md
+++ b/notes/sync-log-replication.md
@@ -1,3 +1,17 @@
+---
+title: Sync Log Replication — Design Notes
+status: active
+description: >
+  Design notes for sync log replication: append-only case activity log
+  synchronization between actors.
+related_specs:
+  - specs/sync-log-replication.md
+  - specs/case-log-processing.md
+related_notes:
+  - notes/case-log-authority.md
+  - notes/case-state-model.md
+---
+
 # Sync Log Replication — Design Notes
 
 **Relates to**: `specs/sync-log-replication.md`, `plan/IMPLEMENTATION_PLAN.md`

--- a/notes/trigger-classification.md
+++ b/notes/trigger-classification.md
@@ -1,3 +1,19 @@
+---
+title: "Trigger Classification: Demo vs General-Purpose"
+status: active
+description: >
+  Classification of demo vs general-purpose triggers; trigger routing, naming
+  conventions, and configuration guidance.
+related_specs:
+  - specs/triggerable-behaviors.md
+  - specs/configuration.md
+related_notes:
+  - notes/protocol-event-cascades.md
+  - notes/triggerable-behaviors.md
+relevant_packages:
+  - fastapi
+---
+
 # Trigger Classification: Demo vs General-Purpose
 
 **Cross-references**: `specs/triggerable-behaviors.md` (TRIG-08, TRIG-09,

--- a/notes/trigger-classification.md
+++ b/notes/trigger-classification.md
@@ -12,6 +12,9 @@ related_notes:
   - notes/triggerable-behaviors.md
 relevant_packages:
   - fastapi
+  - vultron/adapters/driving/fastapi
+  - vultron/config
+  - vultron/core/use_cases/triggers
 ---
 
 # Trigger Classification: Demo vs General-Purpose

--- a/notes/triggerable-behaviors.md
+++ b/notes/triggerable-behaviors.md
@@ -1,3 +1,22 @@
+---
+title: "Triggerable Behaviors: Design Notes"
+status: active
+description: >
+  Design notes for triggerable behaviors: API endpoints, CLI commands, BT
+  integration, and behavior routing patterns.
+related_specs:
+  - specs/triggerable-behaviors.md
+  - specs/behavior-tree-integration.md
+  - specs/code-style.md
+related_notes:
+  - notes/bt-fuzzer-nodes.md
+  - notes/bt-integration.md
+  - notes/do-work-behaviors.md
+  - notes/domain-model-separation.md
+relevant_packages:
+  - transitions
+---
+
 # Triggerable Behaviors: Design Notes
 
 **Cross-references**: `plan/PRIORITIES.md` PRIORITY 30,

--- a/notes/triggerable-behaviors.md
+++ b/notes/triggerable-behaviors.md
@@ -1,9 +1,7 @@
 ---
 title: "Triggerable Behaviors: Design Notes"
 status: active
-description: >
-  Design notes for triggerable behaviors: API endpoints, CLI commands, BT
-  integration, and behavior routing patterns.
+description: "Design notes for triggerable behaviors: API endpoints, CLI commands, BT integration, and behavior routing patterns."
 related_specs:
   - specs/triggerable-behaviors.md
   - specs/behavior-tree-integration.md
@@ -15,6 +13,9 @@ related_notes:
   - notes/domain-model-separation.md
 relevant_packages:
   - transitions
+  - vultron/adapters/driving/fastapi
+  - vultron/core/use_cases/triggers
+  - vultron/bt
 ---
 
 # Triggerable Behaviors: Design Notes

--- a/notes/use-case-behavior-trees.md
+++ b/notes/use-case-behavior-trees.md
@@ -1,3 +1,18 @@
+---
+title: Use Cases, Domain Logic, and Behavior Trees
+status: active
+description: >
+  Clarifies the relationship between use cases, domain logic, and behavior
+  trees; documents where each concern belongs.
+related_specs:
+  - specs/code-style.md
+related_notes:
+  - notes/bt-integration.md
+  - notes/domain-model-separation.md
+relevant_packages:
+  - transitions
+---
+
 # Use Cases, Domain Logic, and Behavior Trees
 
 This note clarifies the relationship between **use cases**, **domain logic**,

--- a/notes/use-case-behavior-trees.md
+++ b/notes/use-case-behavior-trees.md
@@ -11,6 +11,8 @@ related_notes:
   - notes/domain-model-separation.md
 relevant_packages:
   - transitions
+  - vultron/core/use_cases
+  - vultron/core/behaviors
 ---
 
 # Use Cases, Domain Logic, and Behavior Trees

--- a/notes/user-stories-trace.md
+++ b/notes/user-stories-trace.md
@@ -1,3 +1,13 @@
+---
+title: User Story Traceability Matrix
+status: active
+description: >
+  Traceability matrix mapping user stories from docs/topics/user_stories/ to
+  formal requirements in specs/.
+relevant_packages:
+  - transitions
+---
+
 # User Story Traceability Matrix
 
 This document maps user stories from `docs/topics/user_stories/` to formal

--- a/notes/vocabulary-registry.md
+++ b/notes/vocabulary-registry.md
@@ -1,3 +1,15 @@
+---
+title: Vocabulary Registry Design
+status: active
+description: >
+  Design notes for the Vultron wire vocabulary registry: AS2 type-to-class
+  mapping and dynamic deserialization.
+related_specs:
+  - specs/vocabulary-model.md
+related_notes:
+  - notes/activitystreams-semantics.md
+---
+
 # Vocabulary Registry Design
 
 ## Overview

--- a/notes/vocabulary-registry.md
+++ b/notes/vocabulary-registry.md
@@ -1,13 +1,13 @@
 ---
 title: Vocabulary Registry Design
 status: active
-description: >
-  Design notes for the Vultron wire vocabulary registry: AS2 type-to-class
-  mapping and dynamic deserialization.
+description: "Design notes for the Vultron wire vocabulary registry: AS2 type-to-class mapping and dynamic deserialization."
 related_specs:
   - specs/vocabulary-model.md
 related_notes:
   - notes/activitystreams-semantics.md
+relevant_packages:
+  - vultron/wire/as2
 ---
 
 # Vocabulary Registry Design

--- a/plan/IDEA-HISTORY.md
+++ b/plan/IDEA-HISTORY.md
@@ -469,3 +469,27 @@ instead of just modifying the PRIORITIES.md file to reflect the new priority ord
 `specs/project-documentation.md` (PD-06-001 through PD-06-006) and
 `notes/plan-organization.md`. Existing `plan/IMPLEMENTATION_PLAN.md` sections
 migrated to `TASK-FOO` headings and dot-notation task IDs in the same commit.
+
+## IDEA-26042403 Add YAML frontmatter to notes/*.md files
+
+Similar to IDEA-26042402, we should add YAML frontmatter to the `notes/*.md`
+files to capture file-level metadata such as related spec files, related
+notes files, relevant packages, etc. We could also note things like whether
+a note is a long-term design idea that will be persistent or a short-term
+implementation note that is ephemeral until the tasks that need it are
+completed, etc. This will improve our ability to harvest obsoleted notes
+into the archive and keep context relevant for active development. We will
+need to consider maintenance of the frontmatter and ensure it gets updated
+whenever the files are modified, so it may require changes to some
+documentation related specs, skills, AGENTS.md, and prompts to ensure that
+the frontmatter is maintained consistently with changes to the notes files.
+
+As with specs, yaml frontmatter means we can make a pydantic based loader
+that can validate them and make the frontmatter testable as well as build a
+graph of the notes and their relationships to each other and to specs. This
+could be part of the same tool that loads the specs, so that we have a way
+to easily dump "all the notes and specs relevant to topic X" for an agent to
+use when reasoning about a topic or task.
+
+**Processed**: 2026-04-24 — design decisions captured in
+`specs/notes-frontmatter.md` (NF-01 through NF-07) and `notes/notes-frontmatter.md`.

--- a/plan/IDEAS.md
+++ b/plan/IDEAS.md
@@ -26,24 +26,3 @@ reasoning about requirements would be useful to have as well.
 
 Requirements checks could be made into pre-commit hooks and part of the
 pytest suite so we get errors when structure is invalid.
-
-## IDEA-26042403 Add YAML frontmatter to notes/*.md files
-
-Similar to IDEA-26042402, we should add YAML frontmatter to the `notes/*.md`
-files to capture file-level metadata such as related spec files, related
-notes files, relevant packages, etc. We could also note things like whether
-a note is a long-term design idea that will be persistent or a short-term
-implementation note that is ephemeral until the tasks that need it are
-completed, etc. This will improve our ability to harvest obsoleted notes
-into the archive and keep context relevant for active development. We will
-need to consider maintenance of the frontmatter and ensure it gets updated
-whenever the files are modified, so it may require changes to some
-documentation related specs, skills, AGENTS.md, and prompts to ensure that
-the frontmatter is maintained consistently with changes to the notes files.
-
-As with specs, yaml frontmatter means we can make a pydantic based loader
-that can validate them and make the frontmatter testable as well as build a
-graph of the notes and their relationships to each other and to specs. This
-could be part of the same tool that loads the specs, so that we have a way
-to easily dump "all the notes and specs relevant to topic X" for an agent to
-use when reasoning about a topic or task.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dependencies = [
     "transitions>=0.9.3",
     "sqlmodel>=0.0.38",
     "pyyaml>=6.0",
+    "python-frontmatter>=1.1.0",
 ]
 dynamic = ["version",]
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -60,6 +60,7 @@ Load additional files only when the task touches the relevant area. See the
 | Agentic API | `agentic-readiness.md` |
 | Documentation work | `diataxis-requirements.md`, `project-documentation.md`, `traceability.md` |
 | Plan organization / priorities | `project-documentation.md`, `notes/plan-organization.md` |
+| Notes frontmatter / metadata tooling | `notes-frontmatter.md` |
 | Bugfix skill / bug lifecycle | `bugfix-workflow.md` |
 
 ---
@@ -265,6 +266,11 @@ Specifications are organized by topic with minimal overlap. Cross-references lin
   (Phase 2b), user engagement, issue escalation to `plan/BUGS.md`, and bug
   lifecycle archiving to `plan/IMPLEMENTATION_HISTORY.md`
   (BFW-01 through BFW-04)
+- **`notes-frontmatter.md`** - YAML frontmatter schema for `notes/*.md` files:
+  required fields (`title`, `status`), optional relationship fields, Pydantic
+  loader in `vultron/metadata/notes/`, validation enforcement (pytest +
+  pre-commit), migration requirements, and future registry/query tool notes
+  (NF-01 through NF-07)
 
 ---
 
@@ -332,6 +338,7 @@ is reserved for `testability.md`).
 | `IE` | `inbox-endpoint.md` |
 | `IMPL-TS` | `tech-stack.md` |
 | `MV` | `message-validation.md` |
+| `NF` | `notes-frontmatter.md` |
 | `OB` | `observability.md` |
 | `OID` | `object-ids.md` |
 | `OX` | `outbox.md` |

--- a/specs/notes-frontmatter.md
+++ b/specs/notes-frontmatter.md
@@ -37,8 +37,12 @@ parallel but separate concern; this spec covers the notes side only. A shared
 - `NF-01-007` The optional `related_notes` field, when present, MUST be a
   non-empty list of non-empty strings naming related notes files.
 - `NF-01-008` The optional `relevant_packages` field, when present, MUST be a
-  non-empty list of non-empty strings naming relevant Python packages
-  (e.g., `["py_trees", "pydantic"]`).
+  non-empty list of non-empty strings naming packages relevant to the note's
+  topic. Each entry is either:
+  - An external PyPI package name (e.g., `py_trees`, `pydantic`), or
+  - An internal Vultron subpackage path using forward slashes
+    (e.g., `vultron/core/behaviors`, `vultron/wire/as2`).
+  Both forms MAY appear in the same list.
 
 ## Pydantic Schema Module (MUST)
 

--- a/specs/notes-frontmatter.md
+++ b/specs/notes-frontmatter.md
@@ -1,0 +1,105 @@
+# Notes Frontmatter Specification
+
+## Overview
+
+This specification defines requirements for YAML frontmatter in `notes/*.md`
+files: the required schema, a Pydantic-based loader in `vultron/metadata/`,
+validation enforcement, and migration requirements.
+
+**Source**: IDEA-26042403  
+**Note**: The `vultron/metadata/specs/` subpackage (for IDEA-26042402) is a
+parallel but separate concern; this spec covers the notes side only. A shared
+`vultron/metadata/base.py` holds common vocabulary.
+
+---
+
+## Frontmatter Schema (MUST)
+
+- `NF-01-001` Every `notes/*.md` file (except `notes/README.md`) MUST contain
+  a YAML frontmatter block delimited by `---` at the top of the file.
+- `NF-01-002` The frontmatter MUST include a `title` field whose value is a
+  non-empty string matching the file's `# H1` heading.
+- `NF-01-003` The frontmatter MUST include a `status` field whose value is one
+  of: `active`, `draft`, `superseded`, `archived`.
+  - `active`: the note is current and relevant to ongoing work.
+  - `draft`: the note is in progress and not yet authoritative.
+  - `superseded`: the note has been replaced by another file.
+  - `archived`: the note is complete or obsolete; candidate for
+    `archived_notes/`.
+- `NF-01-004` When `status` is `superseded`, a `superseded_by` field MUST be
+  present and MUST contain a non-empty string identifying the replacement
+  file path (e.g., `notes/new-topic.md` or `specs/new-spec.md`).
+- `NF-01-005` The optional `description` field, when present, MUST be a
+  non-empty string summarising the file's purpose for tooling and agents.
+- `NF-01-006` The optional `related_specs` field, when present, MUST be a
+  non-empty list of non-empty strings naming related specification files
+  (e.g., `["specs/behavior-tree-integration.md"]`).
+- `NF-01-007` The optional `related_notes` field, when present, MUST be a
+  non-empty list of non-empty strings naming related notes files.
+- `NF-01-008` The optional `relevant_packages` field, when present, MUST be a
+  non-empty list of non-empty strings naming relevant Python packages
+  (e.g., `["py_trees", "pydantic"]`).
+
+## Pydantic Schema Module (MUST)
+
+- `NF-02-001` The `vultron/metadata/notes/` subpackage MUST define a Pydantic
+  model (`NotesFrontmatter`) that validates the frontmatter schema described
+  in NF-01.
+- `NF-02-002` `NotesFrontmatter` MUST use a `StrEnum` for the `status` field
+  vocabulary (`NoteStatus`).
+- `NF-02-003` Shared base vocabulary (e.g., common `StrEnum` base classes or
+  type aliases) MUST live in `vultron/metadata/base.py` and be importable by
+  both `metadata/notes/` and the future `metadata/specs/` subpackage.
+- `NF-02-004` The `vultron/metadata/` package MUST NOT import from
+  `vultron/core/`, `vultron/wire/`, or `vultron/adapters/`; it is a
+  standalone tooling layer with no dependency on application code.
+
+## Loader (MUST)
+
+- `NF-03-001` The `vultron/metadata/notes/` subpackage MUST provide a loader
+  that discovers and parses all `notes/*.md` files relative to the repository
+  root.
+- `NF-03-002` The loader MUST skip `notes/README.md`.
+- `NF-03-003` The loader MUST parse each file's YAML frontmatter block and
+  validate it against `NotesFrontmatter`, raising a `ValueError` (or
+  equivalent) on schema violations.
+- `NF-03-004` The loader MUST return a registry mapping file path to validated
+  `NotesFrontmatter` instance.
+- `NF-03-005` The loader SHOULD resolve the repository root by searching
+  upward from the current working directory for a `pyproject.toml` file, so
+  it works correctly regardless of where it is called from.
+
+## Validation Enforcement (MUST)
+
+- `NF-04-001` A pytest test MUST load all `notes/*.md` files via the loader
+  and assert that every file parses without validation errors.
+- `NF-04-002` A pre-commit hook MUST validate the frontmatter of any changed
+  `notes/*.md` file before the commit is accepted.
+  - The hook SHOULD run the same loader logic used in the pytest test.
+
+## Migration (MUST)
+
+- `NF-05-001` All existing `notes/*.md` files (except `notes/README.md`) MUST
+  have compliant YAML frontmatter added as part of the initial implementation
+  of this spec.
+- `NF-05-002` The `status` field added during migration MUST accurately
+  reflect the current state of each file's content.
+
+## Maintenance (SHOULD)
+
+- `NF-06-001` When modifying any `notes/*.md` file, the author SHOULD review
+  and update its frontmatter — in particular `status`, `related_specs`, and
+  `related_notes` — to reflect any changes in scope or relationships.
+- `NF-06-002` `AGENTS.md` MUST document the frontmatter maintenance rule so
+  that AI coding agents apply it consistently.
+
+## Future: Registry and Query Tool (MAY)
+
+- `NF-07-001` A query/dump tool MAY be built (in a later task) that accepts a
+  topic keyword and returns all notes (and eventually specs) whose frontmatter
+  indicates relevance to that topic.
+  - This tool depends on both `vultron/metadata/notes/` and the planned
+    `vultron/metadata/specs/` loader (IDEA-26042402).
+- `NF-07-002` The `notes/README.md` index MAY be generated from the notes
+  registry in a later task, replacing the manually-maintained summaries with
+  content derived from `description` frontmatter fields.

--- a/test/metadata/test_notes_frontmatter.py
+++ b/test/metadata/test_notes_frontmatter.py
@@ -1,0 +1,93 @@
+"""Tests for vultron.metadata.notes schema and loader.
+
+Validation test requirement: specs/notes-frontmatter.md NF-04-001.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from vultron.metadata.notes.loader import load_notes_registry
+from vultron.metadata.notes.schema import NotesFrontmatter, NoteStatus
+
+
+class TestNotesFrontmatterSchema:
+    def test_minimal_valid(self):
+        nf = NotesFrontmatter.model_validate(
+            {"title": "My Note", "status": "active"}
+        )
+        assert nf.title == "My Note"
+        assert nf.status == NoteStatus.ACTIVE
+
+    def test_all_fields_valid(self):
+        nf = NotesFrontmatter.model_validate(
+            {
+                "title": "Full Note",
+                "status": "active",
+                "description": "A description.",
+                "related_specs": ["specs/some-spec.md"],
+                "related_notes": ["notes/other.md"],
+                "relevant_packages": ["pydantic"],
+            }
+        )
+        assert nf.description == "A description."
+        assert nf.related_specs == ["specs/some-spec.md"]
+
+    def test_superseded_status_requires_superseded_by(self):
+        with pytest.raises(ValidationError, match="superseded_by"):
+            NotesFrontmatter.model_validate(
+                {"title": "Old Note", "status": "superseded"}
+            )
+
+    def test_superseded_status_with_superseded_by_valid(self):
+        nf = NotesFrontmatter.model_validate(
+            {
+                "title": "Old Note",
+                "status": "superseded",
+                "superseded_by": "notes/new-note.md",
+            }
+        )
+        assert nf.superseded_by == "notes/new-note.md"
+
+    def test_invalid_status_rejected(self):
+        with pytest.raises(ValidationError):
+            NotesFrontmatter.model_validate(
+                {"title": "A Note", "status": "unknown"}
+            )
+
+    def test_empty_title_rejected(self):
+        with pytest.raises(ValidationError):
+            NotesFrontmatter.model_validate({"title": "", "status": "active"})
+
+    def test_empty_list_fields_rejected(self):
+        for field in ("related_specs", "related_notes", "relevant_packages"):
+            with pytest.raises(ValidationError, match="non-empty"):
+                NotesFrontmatter.model_validate(
+                    {"title": "A Note", "status": "active", field: []}
+                )
+
+    def test_absent_optional_list_fields_ok(self):
+        nf = NotesFrontmatter.model_validate(
+            {"title": "A Note", "status": "draft"}
+        )
+        assert nf.related_specs is None
+        assert nf.related_notes is None
+        assert nf.relevant_packages is None
+
+    def test_all_status_values_accepted(self):
+        for status in ("active", "draft", "superseded", "archived"):
+            kwargs: dict = {"title": "A Note", "status": status}
+            if status == "superseded":
+                kwargs["superseded_by"] = "notes/replacement.md"
+            nf = NotesFrontmatter.model_validate(kwargs)
+            assert nf.status.value == status
+
+
+def test_all_notes_files_have_valid_frontmatter():
+    """Every notes/*.md (except README.md) must have valid frontmatter.
+
+    Satisfies NF-04-001.
+    """
+    registry = load_notes_registry()
+    assert len(registry) > 0, "Notes registry must not be empty"
+    # If load_notes_registry() raises a ValueError or ValidationError,
+    # the test will fail with that error as the diagnostic message.

--- a/uv.lock
+++ b/uv.lock
@@ -1256,6 +1256,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-frontmatter"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/de/910fa208120314a12f9a88ea63e03707261692af782c99283f1a2c8a5e6f/python-frontmatter-1.1.0.tar.gz", hash = "sha256:7118d2bd56af9149625745c58c9b51fb67e8d1294a0c76796dafdc72c36e5f6d", size = 16256, upload-time = "2024-01-16T18:50:04.052Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/87/3c8da047b3ec5f99511d1b4d7a5bc72d4b98751c7e78492d14dc736319c5/python_frontmatter-1.1.0-py3-none-any.whl", hash = "sha256:335465556358d9d0e6c98bbeb69b1c969f2a4a21360587b9873bfc3b213407c1", size = 9834, upload-time = "2024-01-16T18:50:00.911Z" },
+]
+
+[[package]]
 name = "pytokens"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1675,6 +1687,7 @@ dependencies = [
     { name = "pandas" },
     { name = "py-trees" },
     { name = "pydantic" },
+    { name = "python-frontmatter" },
     { name = "pyyaml" },
     { name = "rdflib" },
     { name = "scipy" },
@@ -1720,6 +1733,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=3.0.2" },
     { name = "py-trees", specifier = ">=2.2.0" },
     { name = "pydantic", specifier = "==2.13.3" },
+    { name = "python-frontmatter", specifier = ">=1.1.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rdflib", specifier = ">=7.2.1" },
     { name = "scipy", specifier = ">=1.16.2" },

--- a/vultron/metadata/__init__.py
+++ b/vultron/metadata/__init__.py
@@ -1,0 +1,5 @@
+"""Metadata tooling for the Vultron repository.
+
+This package is a standalone tooling layer. It MUST NOT import from
+``vultron.core``, ``vultron.wire``, or ``vultron.adapters``.
+"""

--- a/vultron/metadata/base.py
+++ b/vultron/metadata/base.py
@@ -1,0 +1,8 @@
+"""Shared type aliases for the vultron.metadata tooling layer."""
+
+from typing import Annotated
+
+from pydantic import StringConstraints
+
+NonEmptyStr = Annotated[str, StringConstraints(min_length=1)]
+NonEmptyStrList = list[NonEmptyStr]

--- a/vultron/metadata/notes/__init__.py
+++ b/vultron/metadata/notes/__init__.py
@@ -1,0 +1,1 @@
+"""Notes frontmatter schema and loader."""

--- a/vultron/metadata/notes/loader.py
+++ b/vultron/metadata/notes/loader.py
@@ -1,0 +1,64 @@
+"""Loader for the notes/*.md frontmatter registry.
+
+Loader requirements: specs/notes-frontmatter.md NF-03.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import frontmatter
+
+from vultron.metadata.notes.schema import NotesFrontmatter
+
+SKIP_FILES = {"README.md"}
+
+
+def _find_repo_root(start: Path | None = None) -> Path:
+    """Return the repository root by searching upward for ``pyproject.toml``.
+
+    Satisfies NF-03-005: works regardless of the caller's working directory.
+    """
+    origin = start or Path.cwd()
+    for parent in [origin, *origin.parents]:
+        if (parent / "pyproject.toml").exists():
+            return parent
+    raise FileNotFoundError(
+        f"Could not locate repository root (pyproject.toml) starting from {origin}"
+    )
+
+
+def load_notes_registry(
+    repo_root: Path | None = None,
+) -> dict[str, NotesFrontmatter]:
+    """Discover and validate frontmatter for all ``notes/*.md`` files.
+
+    Args:
+        repo_root: Repository root path.  When ``None`` the root is resolved
+            automatically by searching upward for ``pyproject.toml``.
+
+    Returns:
+        Mapping from relative file path (e.g. ``"notes/bt-integration.md"``)
+        to validated :class:`NotesFrontmatter` instance.
+
+    Raises:
+        ValueError: If a notes file is missing frontmatter or its frontmatter
+            fails schema validation.
+        FileNotFoundError: If the repository root cannot be resolved.
+    """
+    root = repo_root or _find_repo_root()
+    notes_dir = root / "notes"
+    registry: dict[str, NotesFrontmatter] = {}
+
+    for path in sorted(notes_dir.glob("*.md")):
+        if path.name in SKIP_FILES:
+            continue
+
+        post = frontmatter.load(str(path))
+        if not post.metadata:
+            raise ValueError(f"{path}: missing YAML frontmatter")
+
+        key = str(path.relative_to(root))
+        registry[key] = NotesFrontmatter.model_validate(post.metadata)
+
+    return registry

--- a/vultron/metadata/notes/schema.py
+++ b/vultron/metadata/notes/schema.py
@@ -1,0 +1,56 @@
+"""Pydantic schema for notes/*.md YAML frontmatter.
+
+Schema requirements: specs/notes-frontmatter.md NF-01, NF-02.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, field_validator, model_validator
+
+from vultron.metadata.base import NonEmptyStr, NonEmptyStrList
+
+
+class NoteStatus(StrEnum):
+    """Valid values for the ``status`` frontmatter field."""
+
+    ACTIVE = "active"
+    DRAFT = "draft"
+    SUPERSEDED = "superseded"
+    ARCHIVED = "archived"
+
+
+class NotesFrontmatter(BaseModel):
+    """Validated representation of a ``notes/*.md`` YAML frontmatter block.
+
+    Required fields: ``title``, ``status``.
+    All other fields are optional but must be non-empty when present.
+    """
+
+    title: NonEmptyStr
+    status: NoteStatus
+    superseded_by: NonEmptyStr | None = None
+    description: NonEmptyStr | None = None
+    related_specs: NonEmptyStrList | None = None
+    related_notes: NonEmptyStrList | None = None
+    relevant_packages: NonEmptyStrList | None = None
+
+    @field_validator(
+        "related_specs", "related_notes", "relevant_packages", mode="before"
+    )
+    @classmethod
+    def non_empty_list_if_present(cls, v: object) -> object:
+        """Reject present-and-empty list fields (NF-01-006 through NF-01-008)."""
+        if v is not None and isinstance(v, list) and len(v) == 0:
+            raise ValueError("list field must be non-empty if present")
+        return v
+
+    @model_validator(mode="after")
+    def superseded_by_required_when_superseded(self) -> NotesFrontmatter:
+        """Require ``superseded_by`` when ``status`` is ``superseded`` (NF-01-004)."""
+        if self.status == NoteStatus.SUPERSEDED and not self.superseded_by:
+            raise ValueError(
+                "'superseded_by' is required when status is 'superseded'"
+            )
+        return self


### PR DESCRIPTION
## Summary

Implements [specs/notes-frontmatter.md](specs/notes-frontmatter.md) requirements NF-01 through NF-06.

Adds YAML frontmatter validation infrastructure and migrates all 42 `notes/*.md` files.

## Changes

### New dependency
- `python-frontmatter>=1.1.0` added to `pyproject.toml`

### New package: `vultron/metadata/` (standalone tooling layer)
- `base.py` — `NonEmptyStr`, `NonEmptyStrList` shared type aliases
- `notes/schema.py` — `NoteStatus` StrEnum + `NotesFrontmatter` Pydantic model with cross-field validator (`superseded_by` required when `status == superseded`)
- `notes/loader.py` — `load_notes_registry()` using `python-frontmatter`; auto-locates repo root via `pyproject.toml`

### New tests: `test/metadata/`
- 9 schema unit tests (valid/invalid inputs, empty-list rejection, cross-field validation)
- `test_all_notes_files_have_valid_frontmatter()` integration test (NF-04-001)

### Migration: 42 notes files
All `notes/*.md` files (except `README.md`) now have YAML frontmatter with `title`, `status`, and optional `description`/`related_specs`/`related_notes`/`relevant_packages`. Status assignments: `active` (most), `draft` (speculative/exploratory), `archived` (historical review).

### Config changes
- `.pre-commit-config.yaml` — `validate-notes-frontmatter` hook using `uv run` (NF-04-002)
- `.mypy.ini` — `[mypy-frontmatter]` ignore for missing stubs
- `.markdownlint-cli2.yaml` — `MD025: front_matter_title: ""` to allow frontmatter `title:` + body `# H1` to coexist
- `AGENTS.md` — frontmatter maintenance rule (NF-06-002)

## Spec coverage

| Requirement | Description | Status |
|---|---|---|
| NF-01-001 through NF-01-008 | Frontmatter schema (title, status, optional fields) | ✅ |
| NF-02-001 through NF-02-004 | Pydantic schema module in `vultron/metadata/notes/` | ✅ |
| NF-03-001 through NF-03-005 | Loader with repo-root discovery, skip README, validate | ✅ |
| NF-04-001 | pytest test for all notes files | ✅ |
| NF-04-002 | pre-commit hook | ✅ |
| NF-05-001 through NF-05-002 | All 42 existing files migrated with accurate status | ✅ |
| NF-06-002 | AGENTS.md maintenance rule | ✅ |

## Test results

```
1822 passed, 12 skipped in 22s
```