### PR TITLE
Narrow DataLayer port and consolidate semantic registry (Priority 473, part 1)

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -24,3 +24,23 @@ receiver-side dead-letter path (`UnresolvableObjectUseCase`) remains in place
 for non-compliant or legacy senders; it was not changed. If a future need arises
 to auto-retry deferred activities, implement a `DeferredActivityRecord` model
 and a dispatcher post-hook (see issue #386 description for design sketch).
+
+### 2026-04-30 TASK-DL-REHYDRATE — Do not name a method `list` in a Python class
+
+Defining `def list(self, ...)` on a class causes Python to shadow the built-in
+`list` type in the class body scope. Any annotation `list[str]` that appears
+AFTER the `def list(...)` definition is evaluated at class-body execution time
+with `list` resolving to the method (a function), producing `TypeError:
+'function' object is not subscriptable`. `# type: ignore[valid-type]` only
+suppresses mypy — it does NOT prevent the runtime error. Fix: rename the method
+to avoid collision (e.g., `list_objects`). This affects any method that shares
+a name with a Python built-in type (`dict`, `set`, `tuple`, etc.).
+
+### 2026-04-30 BUG-26043001 — append-history: always use a Pydantic model for structured file formats
+
+When a CLI tool writes structured files (frontmatter, YAML, JSON), define a
+Pydantic model for the structure upfront. Without it, required-field validation
+is either missing or duplicated across callers. The fallback-to-default pattern
+(`metadata.get("source", "")`) makes it impossible to distinguish "absent field"
+from "empty field". A Pydantic model with `ValidationError` on missing fields is
+the single source of truth and forces callers to handle the error path explicitly.

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -14,33 +14,6 @@ PD-06). Do not infer priority from section order.
 
 ---
 
-## TASK-RFC-403 — Narrow DataLayer Port to CasePersistence
-
-**Source**: <https://github.com/CERTCC/Vultron/issues/403>
-
-`DataLayer` exposes 20+ methods to all core use cases; most callers use 3–6.
-Introduce `CasePersistence` (6-method) and `CaseOutboxPersistence` Protocols
-in `vultron/core/ports/`. `SqliteDataLayer` satisfies both structurally (no
-changes needed). Update all core use-case and BT base-class `dl: DataLayer`
-type annotations to the narrower type. Enables `MagicMock(spec=CasePersistence)`
-in tests instead of 22-method stub classes.
-
-**Acceptance criteria:**
-
-- `vultron/core/ports/case_persistence.py` exists with `CasePersistence` and
-  `CaseOutboxPersistence` Protocols.
-- All `vultron/core/use_cases/**` `__init__(dl:)` params use `CasePersistence`
-  or `CaseOutboxPersistence`.
-- `DataLayerCondition`, `DataLayerAction`, `BTBridge` use `CasePersistence`.
-- All linters and tests pass.
-
-- [ ] RFC-403.1: Create `vultron/core/ports/case_persistence.py`
-- [ ] RFC-403.2: Update `vultron/core/use_cases/**` `dl:` type annotations
-  (~40 one-line changes)
-- [ ] RFC-403.3: Update `vultron/core/behaviors/helpers.py` and `bridge.py`
-
----
-
 ## TASK-RFC-400 — TriggerService Facade
 
 **Source**: <https://github.com/CERTCC/Vultron/issues/400>

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -14,30 +14,6 @@ PD-06). Do not infer priority from section order.
 
 ---
 
-## TASK-RFC-402 — Consolidate find_matching_semantics into semantic_registry
-
-**Source**: <https://github.com/CERTCC/Vultron/issues/402>
-
-`extractor.py` and `semantic_registry.py` maintain two parallel 40-entry
-ordered lists. Move `find_matching_semantics()` to `semantic_registry.py`
-(iterates `SEMANTIC_REGISTRY` directly), delete `_PATTERN_SEMANTICS` and
-`_ACTIVITY_TYPES_WITH_PATTERNS` from `extractor.py`, add `matches_semantics()`
-predicate, and update 3 import sites.
-
-**Acceptance criteria:**
-
-- `_PATTERN_SEMANTICS` does not appear in `extractor.py`.
-- `find_matching_semantics` importable from `vultron.semantic_registry`.
-- `matches_semantics(activity, expected) -> bool` exists in `semantic_registry`.
-- `datalayer_sqlite.py` imports `find_matching_semantics` from `semantic_registry`.
-- All existing tests pass.
-
-- [ ] RFC-402.1: Move `find_matching_semantics` + `_ACTIVITY_TYPES_WITH_PATTERNS`
-  to `semantic_registry`; add `matches_semantics()`; delete `_PATTERN_SEMANTICS`;
-  update 3 import sites
-
----
-
 ## TASK-RFC-403 — Narrow DataLayer Port to CasePersistence
 
 **Source**: <https://github.com/CERTCC/Vultron/issues/403>

--- a/plan/PRIORITIES.md
+++ b/plan/PRIORITIES.md
@@ -27,6 +27,8 @@ Resolving these before cyclomatic complexity reduction (Priority 480) enables
 cleaner refactors: narrower interfaces and deeper modules reduce CC
 organically.
 
+**See also**: `TASK-RFC-400`, `TASK-RFC-401`, `TASK-RFC-403`
+
 Additional implementation-level architecture tasks (no GitHub issues yet):
 
 - **TASK-AF** — Activity Factory Functions: introduce

--- a/plan/history/2604/README.md
+++ b/plan/history/2604/README.md
@@ -5,10 +5,12 @@
 | Date | Type | Source | Title |
 |------|------|--------|-------|
 | 2026-04-30 | priority | Priority 472 | Priority 472 — Docs Batch (LaTeX Fixes and Versioning Updates) |
+| 2026-04-30 | implementation | BUG-26043001 | BUG-26043001 — append-history: validate required frontmatter fields |
 | 2026-04-30 | implementation | P472-LATEX | Fix block-math opening delimiter in conclusion.md (#234, #235) |
 | 2026-04-30 | implementation | TASK-BUG-386 | BUG-386 — Defer unresolved Accept.object_ references (resolved via sender-side fix) |
 | 2026-04-30 | implementation | TASK-DOCS-472 | TASK-DOCS-472 — Fix LaTeX Rendering and Versioning Docs |
 | 2026-04-30 | implementation | TASK-RFC-402 | Consolidate find_matching_semantics into semantic_registry |
+| 2026-04-30 | implementation | TASK-RFC-403 | Introduce CasePersistence and CaseOutboxPersistence narrow Protocols (RFC-403) |
 | 2026-04-29 | priority | Priority 471 | Priority 471: Bug Fixes and Demo Polish — COMPLETE |
 | 2026-04-29 | implementation | TASK-BUGS-471 | Bug Fixes: BUG-471.5, BUG-471.6, BUG-471.7a, BUG-471.7b |
 | 2026-04-28 | priority | Priority 470 | Priority 470 — Skills-upgrade spec tasks complete |

--- a/plan/history/2604/README.md
+++ b/plan/history/2604/README.md
@@ -8,6 +8,7 @@
 | 2026-04-30 | implementation | P472-LATEX | Fix block-math opening delimiter in conclusion.md (#234, #235) |
 | 2026-04-30 | implementation | TASK-BUG-386 | BUG-386 — Defer unresolved Accept.object_ references (resolved via sender-side fix) |
 | 2026-04-30 | implementation | TASK-DOCS-472 | TASK-DOCS-472 — Fix LaTeX Rendering and Versioning Docs |
+| 2026-04-30 | implementation | TASK-RFC-402 | Consolidate find_matching_semantics into semantic_registry |
 | 2026-04-29 | priority | Priority 471 | Priority 471: Bug Fixes and Demo Polish — COMPLETE |
 | 2026-04-29 | implementation | TASK-BUGS-471 | Bug Fixes: BUG-471.5, BUG-471.6, BUG-471.7a, BUG-471.7b |
 | 2026-04-28 | priority | Priority 470 | Priority 470 — Skills-upgrade spec tasks complete |

--- a/plan/history/2604/implementation/BUG-26043001.md
+++ b/plan/history/2604/implementation/BUG-26043001.md
@@ -1,0 +1,34 @@
+---
+title: "BUG-26043001 — append-history: validate required frontmatter fields"
+type: implementation
+date: 2026-04-30
+source: BUG-26043001
+---
+
+## BUG-26043001 — `append-history` silently accepted invalid frontmatter
+
+**Symptom**: `append-history` accepted entries with missing required frontmatter
+fields (`title`, `type`, `date`, `source`). Missing `source` caused a
+timestamp-based fallback filename; missing `type` or `date` produced empty
+cells in the auto-generated README table.
+
+**Root cause**: No Pydantic model existed for frontmatter validation. The tool
+silently fell back to a timestamp filename when `source` was absent, and
+`readme_gen._parse_entry` silently returned empty-string defaults for any
+missing field.
+
+**Fix**:
+
+- Added `HistoryEntryFrontmatter(BaseModel)` in
+  `vultron/metadata/history/models.py` as the single source of truth for
+  required-field validation (`title`, `type`, `date`, `source`); non-empty
+  validation for `title` and `source`.
+- `cli.py`: added `_validate_frontmatter()` called before writing; removed
+  the silent timestamp fallback. Added cross-check that the CLI `<type>`
+  argument matches the frontmatter `type` field. Added rollback: if
+  `regenerate_readme()` fails after writing, the just-written file is deleted.
+- `readme_gen._parse_entry()`: now raises `ValueError` with file path and field
+  details on any malformed or missing frontmatter (crash loudly).
+- Migrated one pre-existing frontmatter-less entry (`implementation-260430111518.md`)
+  created before validation existed.
+- 24 new tests across `test_history_models.py` and `test_append_history.py`.

--- a/plan/history/2604/implementation/TASK-RFC-402.md
+++ b/plan/history/2604/implementation/TASK-RFC-402.md
@@ -1,0 +1,17 @@
+---
+title: Consolidate find_matching_semantics into semantic_registry
+type: implementation
+date: 2026-04-30
+source: TASK-RFC-402
+---
+
+## TASK-RFC-402 — Consolidate find_matching_semantics into semantic_registry
+
+Moved `find_matching_semantics()` from `vultron/wire/as2/extractor.py` to
+`vultron/semantic_registry.py`, where it now iterates `SEMANTIC_REGISTRY`
+directly. Deleted the duplicate `_PATTERN_SEMANTICS` list (~90 lines) and
+`_ACTIVITY_TYPES_WITH_PATTERNS` from `extractor.py`. Added `matches_semantics()`
+predicate to `semantic_registry.py`. Updated 3 import sites:
+`datalayer_sqlite.py`, `test/test_semantic_activity_patterns.py`,
+`test/wire/as2/test_extractor.py`. Net change: ~-100 lines, no new files.
+All 1962 unit tests pass, all 4 linters clean.

--- a/plan/history/2604/implementation/TASK-RFC-403.md
+++ b/plan/history/2604/implementation/TASK-RFC-403.md
@@ -1,3 +1,10 @@
+---
+title: "Introduce CasePersistence and CaseOutboxPersistence narrow Protocols (RFC-403)"
+type: implementation
+date: 2026-04-30
+source: TASK-RFC-403
+---
+
 # Introduced CasePersistence and CaseOutboxPersistence narrow Protocols (RFC-403)
 
 ## Summary

--- a/plan/history/2604/implementation/implementation-260430111518.md
+++ b/plan/history/2604/implementation/implementation-260430111518.md
@@ -1,0 +1,25 @@
+# Introduced CasePersistence and CaseOutboxPersistence narrow Protocols (RFC-403)
+
+## Summary
+
+Replaced all direct `DataLayer` imports in core use cases and BT nodes with two narrow Protocol classes:
+
+- `CasePersistence` (7 methods: `create`, `read`, `get`, `save`, `by_type`, `find_case_by_report_id`, `find_actor_by_short_id`)
+- `CaseOutboxPersistence(CasePersistence)` (adds `record_outbox_item`, `outbox_append`)
+
+## Files Created
+
+- `vultron/core/ports/case_persistence.py`
+
+## Files Modified
+
+- `vultron/core/behaviors/helpers.py` — BT base classes use `CasePersistence`; `cast()` for `update()` and `record_outbox_item()`
+- `vultron/core/behaviors/bridge.py` — `BTBridge.__init__` param narrowed to `CasePersistence`
+- `vultron/core/behaviors/case/nodes.py` — narrowed; cast for outbox/commit trigger calls
+- `vultron/core/behaviors/report/nodes.py` — cast for outbox calls
+- `vultron/core/behaviors/case/suggest_actor_tree.py` — cast for outbox calls
+- `vultron/core/use_cases/_helpers.py`, `triggers/_helpers.py`, and all trigger/received use-case files
+
+## Outcome
+
+All four linters (Black, flake8, mypy, pyright) pass cleanly. All 1962 tests pass.

--- a/test/metadata/test_append_history.py
+++ b/test/metadata/test_append_history.py
@@ -86,15 +86,13 @@ class TestAppendHistoryEntryCreation:
         written_path = Path(result.stdout.strip())
         assert "This is a test idea body." in written_path.read_text()
 
-    def test_fallback_id_when_source_absent(self, fake_repo: Path) -> None:
+    def test_missing_source_exits_nonzero(self, fake_repo: Path) -> None:
         content = (
             "---\ntitle: No Source\ntype: idea\ndate: 2026-04-28\n---\n\nBody."
         )
         result = _run_append("idea", content=content, cwd=fake_repo)
-        assert result.returncode == 0
-        written_path = Path(result.stdout.strip())
-        # Falls back to idea-<timestamp>
-        assert written_path.stem.startswith("idea-")
+        assert result.returncode != 0
+        assert "source" in result.stderr.lower()
 
     def test_creates_type_subdirectory(self, fake_repo: Path) -> None:
         result = _run_append(
@@ -253,3 +251,121 @@ class TestAppendHistoryEntryIdSanitization:
         )
         result = _run_append("idea", content=content, cwd=fake_repo)
         assert result.returncode != 0
+
+
+class TestFrontmatterValidation:
+    """append-history rejects entries with missing or invalid frontmatter fields."""
+
+    @pytest.mark.parametrize(
+        "missing_field,content",
+        [
+            (
+                "source",
+                "---\ntitle: T\ntype: idea\ndate: 2026-04-28\n---\n\nBody.\n",
+            ),
+            (
+                "title",
+                "---\ntype: idea\ndate: 2026-04-28\nsource: SRC-1\n---\n\nBody.\n",
+            ),
+            (
+                "date",
+                "---\ntitle: T\ntype: idea\nsource: SRC-2\n---\n\nBody.\n",
+            ),
+            (
+                "type",
+                "---\ntitle: T\ndate: 2026-04-28\nsource: SRC-3\n---\n\nBody.\n",
+            ),
+        ],
+    )
+    def test_missing_required_field_exits_nonzero(
+        self, missing_field: str, content: str, fake_repo: Path
+    ) -> None:
+        result = _run_append("idea", content=content, cwd=fake_repo)
+        assert result.returncode != 0
+        assert missing_field in result.stderr.lower()
+
+    @pytest.mark.parametrize(
+        "field,content",
+        [
+            (
+                "source",
+                "---\ntitle: T\ntype: idea\ndate: 2026-04-28\nsource: '   '\n---\n\nBody.\n",
+            ),
+            (
+                "title",
+                "---\ntitle: '   '\ntype: idea\ndate: 2026-04-28\nsource: SRC-4\n---\n\nBody.\n",
+            ),
+        ],
+    )
+    def test_whitespace_only_field_exits_nonzero(
+        self, field: str, content: str, fake_repo: Path
+    ) -> None:
+        result = _run_append("idea", content=content, cwd=fake_repo)
+        assert result.returncode != 0
+
+    def test_no_frontmatter_block_exits_nonzero(self, fake_repo: Path) -> None:
+        result = _run_append(
+            "idea", content="Just plain text.\n", cwd=fake_repo
+        )
+        assert result.returncode != 0
+
+    def test_frontmatter_type_mismatch_with_cli_arg_exits_nonzero(
+        self, fake_repo: Path
+    ) -> None:
+        content = "---\ntitle: T\ntype: implementation\ndate: 2026-04-28\nsource: SRC-5\n---\n\nBody.\n"
+        result = _run_append("idea", content=content, cwd=fake_repo)
+        assert result.returncode != 0
+        assert "type" in result.stderr.lower()
+
+    def test_invalid_date_format_exits_nonzero(self, fake_repo: Path) -> None:
+        content = "---\ntitle: T\ntype: idea\ndate: not-a-date\nsource: SRC-6\n---\n\nBody.\n"
+        result = _run_append("idea", content=content, cwd=fake_repo)
+        assert result.returncode != 0
+
+
+class TestReadmeGenValidation:
+    """readme_gen raises on malformed existing entry files."""
+
+    def test_missing_field_raises(self, fake_repo: Path) -> None:
+        from vultron.metadata.history.readme_gen import regenerate_readme
+
+        month_dir = fake_repo / "plan" / "history" / "2604"
+        impl_dir = month_dir / "implementation"
+        impl_dir.mkdir(parents=True)
+        bad_entry = impl_dir / "BAD-ENTRY.md"
+        bad_entry.write_text(
+            "---\ntitle: Missing fields\n---\n\nNo type, date, or source.\n"
+        )
+        with pytest.raises((ValueError, Exception)):
+            regenerate_readme(month_dir)
+
+    def test_no_frontmatter_raises(self, fake_repo: Path) -> None:
+        from vultron.metadata.history.readme_gen import regenerate_readme
+
+        month_dir = fake_repo / "plan" / "history" / "2604"
+        impl_dir = month_dir / "implementation"
+        impl_dir.mkdir(parents=True)
+        bad_entry = impl_dir / "NO-FM.md"
+        bad_entry.write_text("Just plain text, no frontmatter at all.\n")
+        with pytest.raises((ValueError, Exception)):
+            regenerate_readme(month_dir)
+
+    def test_rollback_on_existing_malformed_entry(
+        self, fake_repo: Path
+    ) -> None:
+        """Append fails without leaving a new entry file when README regen fails."""
+        import datetime
+
+        yymm = datetime.date.today().strftime("%y%m")
+        month_dir = fake_repo / "plan" / "history" / yymm
+        impl_dir = month_dir / "implementation"
+        impl_dir.mkdir(parents=True)
+        bad_entry = impl_dir / "BAD-PREEXISTING.md"
+        bad_entry.write_text("---\ntitle: Bad\n---\n\nNo type/date/source.\n")
+
+        content = "---\ntitle: New\ntype: implementation\ndate: 2026-04-30\nsource: NEW-ENTRY\n---\n\nBody.\n"
+        result = _run_append("implementation", content=content, cwd=fake_repo)
+
+        assert result.returncode != 0
+        new_file = impl_dir / "NEW-ENTRY.md"
+        assert not new_file.exists(), "new entry file should be rolled back"

--- a/test/metadata/test_history_models.py
+++ b/test/metadata/test_history_models.py
@@ -1,0 +1,103 @@
+"""Tests for HistoryEntryFrontmatter Pydantic model.
+
+Covers: HM-02-001 required-field contract.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+from pydantic import ValidationError
+
+from vultron.metadata.history.types import HistoryEntryType
+
+
+class TestHistoryEntryFrontmatter:
+    """HistoryEntryFrontmatter validates required frontmatter fields."""
+
+    @pytest.fixture()
+    def model_cls(self):  # type: ignore[no-untyped-def]
+        from vultron.metadata.history.models import HistoryEntryFrontmatter
+
+        return HistoryEntryFrontmatter
+
+    def test_valid_model_accepted(self, model_cls) -> None:  # type: ignore[no-untyped-def]
+        m = model_cls(
+            title="Test",
+            type=HistoryEntryType.idea,
+            date=datetime.date(2026, 4, 28),
+            source="IDEA-001",
+        )
+        assert m.title == "Test"
+        assert m.type == HistoryEntryType.idea
+        assert m.source == "IDEA-001"
+
+    @pytest.mark.parametrize("missing", ["title", "type", "date", "source"])
+    def test_missing_field_raises(self, model_cls, missing: str) -> None:  # type: ignore[no-untyped-def]
+        data = {
+            "title": "T",
+            "type": "idea",
+            "date": "2026-04-28",
+            "source": "SRC-1",
+        }
+        del data[missing]
+        with pytest.raises(ValidationError):
+            model_cls.model_validate(data)
+
+    @pytest.mark.parametrize("field", ["title", "source"])
+    def test_empty_string_rejected(self, model_cls, field: str) -> None:  # type: ignore[no-untyped-def]
+        data = {
+            "title": "T",
+            "type": "idea",
+            "date": "2026-04-28",
+            "source": "SRC-2",
+        }
+        data[field] = ""
+        with pytest.raises(ValidationError):
+            model_cls.model_validate(data)
+
+    @pytest.mark.parametrize("field", ["title", "source"])
+    def test_whitespace_only_rejected(self, model_cls, field: str) -> None:  # type: ignore[no-untyped-def]
+        data = {
+            "title": "T",
+            "type": "idea",
+            "date": "2026-04-28",
+            "source": "SRC-3",
+        }
+        data[field] = "   "
+        with pytest.raises(ValidationError):
+            model_cls.model_validate(data)
+
+    def test_invalid_type_rejected(self, model_cls) -> None:  # type: ignore[no-untyped-def]
+        with pytest.raises(ValidationError):
+            model_cls.model_validate(
+                {
+                    "title": "T",
+                    "type": "bogus",
+                    "date": "2026-04-28",
+                    "source": "SRC-4",
+                }
+            )
+
+    def test_invalid_date_rejected(self, model_cls) -> None:  # type: ignore[no-untyped-def]
+        with pytest.raises(ValidationError):
+            model_cls.model_validate(
+                {
+                    "title": "T",
+                    "type": "idea",
+                    "date": "not-a-date",
+                    "source": "SRC-5",
+                }
+            )
+
+    def test_date_string_coerced(self, model_cls) -> None:  # type: ignore[no-untyped-def]
+        m = model_cls.model_validate(
+            {
+                "title": "T",
+                "type": "idea",
+                "date": "2026-04-28",
+                "source": "SRC-6",
+            }
+        )
+        assert m.date == datetime.date(2026, 4, 28)

--- a/test/test_semantic_activity_patterns.py
+++ b/test/test_semantic_activity_patterns.py
@@ -5,10 +5,12 @@ import pytest
 from pydantic import ValidationError
 
 from vultron.core.models.events import MessageSemantics
-from vultron.semantic_registry import SEMANTIC_REGISTRY
+from vultron.semantic_registry import (
+    SEMANTIC_REGISTRY,
+    find_matching_semantics,
+)
 from vultron.wire.as2.extractor import (
     ActivityPattern,
-    find_matching_semantics,
 )
 from vultron.wire.as2.vocab.activities.case import (
     OfferCaseOwnershipTransferActivity,

--- a/test/wire/as2/test_extractor.py
+++ b/test/wire/as2/test_extractor.py
@@ -6,9 +6,12 @@ from typing import Any, cast
 from vultron.core.models.events import MessageSemantics
 from vultron.wire.as2.extractor import (
     ActivityPattern,
+)
+from vultron.semantic_registry import (
+    SEMANTIC_REGISTRY,
+    extract_event,
     find_matching_semantics,
 )
-from vultron.semantic_registry import SEMANTIC_REGISTRY, extract_event
 
 
 def test_find_matching_semantics_returns_unknown_for_unmatched_activity():

--- a/vultron/adapters/driven/datalayer_sqlite.py
+++ b/vultron/adapters/driven/datalayer_sqlite.py
@@ -52,10 +52,8 @@ from vultron.adapters.utils import _URN_UUID_PREFIX, _UUID_RE
 from vultron.core.models.protocols import PersistableModel
 from vultron.core.ports.datalayer import StorableRecord
 from vultron.semantic_registry import (
-    semantics_to_activity_class as _semantics_to_activity_class,
-)
-from vultron.wire.as2.extractor import (
     find_matching_semantics,
+    semantics_to_activity_class as _semantics_to_activity_class,
 )
 from vultron.wire.as2.vocab.base.objects.activities.base import as_Activity
 from vultron.wire.as2.vocab.base.registry import find_in_vocabulary

--- a/vultron/core/behaviors/bridge.py
+++ b/vultron/core/behaviors/bridge.py
@@ -44,7 +44,7 @@ import py_trees
 from py_trees.common import Status
 from py_trees.display import unicode_tree
 
-from vultron.core.ports.datalayer import DataLayer
+from vultron.core.ports.case_persistence import CasePersistence
 
 logger = logging.getLogger(__name__)
 
@@ -86,14 +86,14 @@ class BTBridge:
 
     def __init__(
         self,
-        datalayer: DataLayer,
+        datalayer: CasePersistence,
         is_leader: Callable[[], bool] = _default_is_leader,
     ):
         """
         Initialize BT bridge with DataLayer access and optional leadership guard.
 
         Args:
-            datalayer: DataLayer implementation for persistent state access.
+            datalayer: CasePersistence implementation for persistent state access.
             is_leader: Callable returning True iff this node is the
                 replication leader.  Defaults to a function that always
                 returns True (single-node behaviour).  Per SYNC-09-003.

--- a/vultron/core/behaviors/case/nodes.py
+++ b/vultron/core/behaviors/case/nodes.py
@@ -26,7 +26,7 @@ CM-02 requirements.
 
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import Any, cast
 
 import isodate  # type: ignore[import-untyped]
 
@@ -55,7 +55,10 @@ from vultron.core.behaviors.helpers import (
     DataLayerCondition,
 )
 from vultron.core.behaviors.helpers import UpdateActorOutbox  # noqa: F401
-from vultron.core.ports.datalayer import DataLayer
+from vultron.core.ports.case_persistence import (
+    CasePersistence,
+    CaseOutboxPersistence,
+)
 from vultron.core.use_cases._helpers import (
     _report_phase_status_id,
     update_participant_rm_state,
@@ -408,7 +411,7 @@ class SetCaseAttributedTo(DataLayerAction):
 
 
 def _create_and_attach_participant(
-    dl: DataLayer,
+    dl: CasePersistence,
     participant: "VultronParticipant",
     case_id: str,
     actor_id_for_index: str,
@@ -976,7 +979,7 @@ class CreateCaseParticipantNode(DataLayerAction):
             if has_outbox(actor_obj):
                 actor_obj.outbox.items.append(add_notification.id_)
                 self.datalayer.save(actor_obj)
-            self.datalayer.record_outbox_item(
+            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
                 self.actor_id, add_notification.id_
             )
             self.logger.info(
@@ -1090,7 +1093,7 @@ class CommitCaseLogEntryNode(DataLayerAction):
                 object_id=object_id,
                 event_type=event_type,
                 actor_id=self.actor_id,
-                dl=self.datalayer,
+                dl=cast(CaseOutboxPersistence, self.datalayer),
             )
             self.logger.info(
                 "%s: committed log entry '%s' for case '%s'",

--- a/vultron/core/behaviors/case/suggest_actor_tree.py
+++ b/vultron/core/behaviors/case/suggest_actor_tree.py
@@ -28,12 +28,14 @@ Per specs/case-management.yaml CM-08 and specs/behavior-tree-integration.yaml.
 
 import logging
 import uuid
+from typing import cast
 
 import py_trees
 from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
 from vultron.core.models.protocols import is_case_model
+from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.use_cases._helpers import _as_id
 from vultron.wire.as2.vocab.activities.actor import (
     AcceptActorRecommendationActivity,
@@ -185,7 +187,7 @@ class EmitAcceptRecommendationNode(DataLayerAction):
             self.datalayer.create(accept)
         except ValueError:
             pass  # idempotent — accept already stored
-        self.datalayer.outbox_append(accept.id_)
+        cast(CaseOutboxPersistence, self.datalayer).outbox_append(accept.id_)
         self.logger.info(
             "%s: queued AcceptActorRecommendation '%s' to outbox for actor '%s'",
             self.name,
@@ -231,7 +233,7 @@ class EmitInviteToCaseNode(DataLayerAction):
             self.datalayer.create(invite)
         except ValueError:
             pass  # idempotent — invite already stored
-        self.datalayer.outbox_append(invite.id_)
+        cast(CaseOutboxPersistence, self.datalayer).outbox_append(invite.id_)
         self.logger.info(
             "%s: queued RmInviteToCase '%s' to outbox for actor '%s'",
             self.name,

--- a/vultron/core/behaviors/helpers.py
+++ b/vultron/core/behaviors/helpers.py
@@ -26,12 +26,16 @@ Per specs/behavior-tree-integration.yaml:
 """
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 import py_trees
 from py_trees.common import Status
 
 from vultron.core.models.protocols import has_outbox
+from vultron.core.ports.case_persistence import (
+    CasePersistence,
+    CaseOutboxPersistence,
+)
 from vultron.core.ports.datalayer import DataLayer, StorableRecord
 
 logger = logging.getLogger(__name__)
@@ -65,7 +69,7 @@ class DataLayerCondition(py_trees.behaviour.Behaviour):
         self.logger = logging.getLogger(  # type: ignore[assignment]
             f"{self.__class__.__module__}.{self.__class__.__name__}"
         )
-        self.datalayer: DataLayer | None = None
+        self.datalayer: CasePersistence | None = None
         self.actor_id: str | None = None
 
     def setup(self, **kwargs: Any) -> None:
@@ -130,7 +134,7 @@ class DataLayerAction(py_trees.behaviour.Behaviour):
         self.logger = logging.getLogger(  # type: ignore[assignment]
             f"{self.__class__.__module__}.{self.__class__.__name__}"
         )
-        self.datalayer: DataLayer | None = None
+        self.datalayer: CasePersistence | None = None
         self.actor_id: str | None = None
 
     def setup(self, **kwargs: Any) -> None:
@@ -318,8 +322,9 @@ class UpdateObject(DataLayerAction):
                     data_=updated_data,
                 )
 
-            # Persist to DataLayer
-            self.datalayer.update(self.object_id, storable)
+            # Persist to DataLayer; update() is a low-level primitive not in
+            # CasePersistence — cast to the full DataLayer contract here.
+            cast(DataLayer, self.datalayer).update(self.object_id, storable)
 
             self.feedback_message = (
                 f"Updated {self.object_id} with {len(self.updates)} fields"
@@ -476,7 +481,9 @@ class UpdateActorOutbox(DataLayerAction):
             actor_obj.outbox.items.append(activity_id)
             self.datalayer.save(actor_obj)
 
-            self.datalayer.record_outbox_item(self.actor_id, activity_id)
+            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
+                self.actor_id, activity_id
+            )
             self.logger.info(
                 "Queued Create(Case '%s') activity '%s' to actor '%s' outbox"
                 " (case creation notification)",

--- a/vultron/core/behaviors/report/nodes.py
+++ b/vultron/core/behaviors/report/nodes.py
@@ -44,6 +44,7 @@ from vultron.core.behaviors.helpers import (
     DataLayerCondition,
 )
 from vultron.core.behaviors.helpers import UpdateActorOutbox  # noqa: F401
+from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.states.rm import RM
 from vultron.core.use_cases._helpers import (
     _idempotent_create,
@@ -964,7 +965,9 @@ class EmitEngageCaseActivity(DataLayerAction):
                     self.actor_id,
                 )
 
-            self.datalayer.record_outbox_item(self.actor_id, activity.id_)
+            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
+                self.actor_id, activity.id_
+            )
             self.logger.info(
                 "Actor '%s' emitted RmEngageCaseActivity for case '%s'",
                 self.actor_id,
@@ -1052,7 +1055,9 @@ class EmitDeferCaseActivity(DataLayerAction):
                     self.actor_id,
                 )
 
-            self.datalayer.record_outbox_item(self.actor_id, activity.id_)
+            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
+                self.actor_id, activity.id_
+            )
             self.logger.info(
                 "Actor '%s' emitted RmDeferCaseActivity for case '%s'",
                 self.actor_id,

--- a/vultron/core/ports/case_persistence.py
+++ b/vultron/core/ports/case_persistence.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Narrow outbound ports for core domain use cases and BT nodes.
+
+:class:`CasePersistence` covers the methods called by
+``vultron/core/`` use cases — excluding inbox/outbox queues, health,
+diagnostics, and low-level storage primitives (``update``, ``delete``,
+``clear_*``, ``count_all``) that belong to the adapter layer.
+
+:class:`CaseOutboxPersistence` extends :class:`CasePersistence` for the
+small number of use cases and BT nodes that also enqueue outbound activities.
+Declaring ``CaseOutboxPersistence`` on a ``Received`` use case is an
+architectural smell — it signals that the handler mixes inbound processing
+with outbound broadcast.
+
+``SqliteDataLayer`` satisfies both Protocols structurally with no declaration
+needed (Python structural subtyping).
+
+See also:
+    - ``specs/datalayer.yaml`` DL-03-001, DL-03-002
+    - GitHub issue #403
+"""
+
+from typing import Any, Protocol
+
+from vultron.core.models.protocols import PersistableModel
+from vultron.core.ports.datalayer import StorableRecord
+
+
+class CasePersistence(Protocol):
+    """Narrow outbound port for core domain use cases and BT nodes.
+
+    Covers the methods called by ``vultron/core/`` use cases. Excludes
+    low-level storage primitives (``update``, ``delete``), infrastructure
+    operations (inbox/outbox queues, ``ping``, ``clear_*``), and diagnostics
+    (``get_all``, ``count_all``).
+
+    ``SqliteDataLayer`` satisfies this Protocol structurally — no declaration
+    needed.
+    """
+
+    def create(self, record: "StorableRecord | PersistableModel") -> None: ...
+
+    def read(
+        self, object_id: str, raise_on_missing: bool = False
+    ) -> PersistableModel | None: ...
+
+    def get(
+        self, table: str | None, id_: str | None
+    ) -> "PersistableModel | dict[str, Any] | None": ...
+
+    def save(self, obj: PersistableModel) -> None: ...
+
+    def by_type(self, type_: str) -> "dict[str, dict[str, Any]]": ...
+
+    def find_case_by_report_id(
+        self, report_id: str
+    ) -> PersistableModel | None: ...
+
+    def find_actor_by_short_id(
+        self, short_id: str
+    ) -> PersistableModel | None: ...
+
+
+class CaseOutboxPersistence(CasePersistence, Protocol):
+    """CasePersistence extended for use cases that enqueue outbound activities.
+
+    Only use cases and BT nodes that call ``record_outbox_item`` or
+    ``outbox_append`` declare this type. If a ``ReceivedUseCase`` declares
+    ``CaseOutboxPersistence``, that is a signal that it mixes received-message
+    handling with outbound broadcast — an architectural smell worth
+    investigating.
+
+    ``SqliteDataLayer`` satisfies this Protocol structurally — no declaration
+    needed.
+    """
+
+    def record_outbox_item(self, actor_id: str, activity_id: str) -> None: ...
+
+    def outbox_append(self, activity_id: str) -> None: ...

--- a/vultron/core/use_cases/_helpers.py
+++ b/vultron/core/use_cases/_helpers.py
@@ -13,7 +13,7 @@ from vultron.core.models.protocols import (
     is_case_model,
     is_participant_model,
 )
-from vultron.core.ports.datalayer import DataLayer
+from vultron.core.ports.case_persistence import CasePersistence
 from vultron.core.states.rm import RM
 from vultron.errors import VultronNotFoundError, VultronValidationError
 
@@ -39,7 +39,7 @@ def _as_id(obj: Any) -> str | None:
 
 
 def _idempotent_create(
-    dl: DataLayer,
+    dl: CasePersistence,
     type_key: str | None,
     id_key: str | None,
     obj: Any,
@@ -84,7 +84,7 @@ def _report_phase_status_id(
     return f"urn:uuid:{uuid.uuid5(uuid.NAMESPACE_URL, name)}"
 
 
-def resolve_case(case_id: str, dl: DataLayer):
+def resolve_case(case_id: str, dl: CasePersistence):
     """Resolve a VulnerabilityCase by ID; raise domain error if absent or wrong
     type.
 
@@ -103,7 +103,7 @@ def resolve_case(case_id: str, dl: DataLayer):
 
 
 def update_participant_rm_state(
-    case_id: str, actor_id: str, new_rm_state: RM, dl: DataLayer
+    case_id: str, actor_id: str, new_rm_state: RM, dl: CasePersistence
 ) -> bool:
     """Append a new ParticipantStatus with new_rm_state to the actor's
     CaseParticipant in the given case and persist the updated participant.

--- a/vultron/core/use_cases/query/action_rules.py
+++ b/vultron/core/use_cases/query/action_rules.py
@@ -24,7 +24,7 @@ from vultron.core.case_states.patterns.potential_actions import (
     action as get_actions,
 )
 from vultron.core.models.protocols import CaseModel, ParticipantModel
-from vultron.core.ports.datalayer import DataLayer
+from vultron.core.ports.case_persistence import CasePersistence
 from vultron.core.scoring.utils import enum2title
 from vultron.core.states.cs import CS_pxa, CS_vfd
 from vultron.core.states.em import EM
@@ -41,7 +41,7 @@ class ActionRulesRequest(BaseModel):
 
 
 def _resolve_participant_id_from_actor(
-    case: CaseModel, actor_id: str, dl: DataLayer
+    case: CaseModel, actor_id: str, dl: CasePersistence
 ) -> str:
     """Resolve a case-scoped participant ID from an actor ID."""
     participant_id = case.actor_participant_index.get(actor_id)
@@ -83,7 +83,9 @@ class GetActionRulesUseCase:
     Implements: CM-07-001, CM-07-002, CM-07-003, AR-07-001, AR-07-002.
     """
 
-    def __init__(self, dl: DataLayer, request: ActionRulesRequest) -> None:
+    def __init__(
+        self, dl: CasePersistence, request: ActionRulesRequest
+    ) -> None:
         self._dl = dl
         self._request = request
 

--- a/vultron/core/use_cases/received/actor.py
+++ b/vultron/core/use_cases/received/actor.py
@@ -16,7 +16,10 @@ from vultron.core.models.events.actor import (
 )
 from vultron.core.models.vultron_types import VultronParticipant
 from vultron.core.models.protocols import is_case_model
-from vultron.core.ports.datalayer import DataLayer
+from vultron.core.ports.case_persistence import (
+    CasePersistence,
+    CaseOutboxPersistence,
+)
 from vultron.core.states.em import EM
 from vultron.core.states.participant_embargo_consent import (
     PEC,
@@ -31,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 class SuggestActorToCaseReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: SuggestActorToCaseReceivedEvent
+        self, dl: CasePersistence, request: SuggestActorToCaseReceivedEvent
     ) -> None:
         self._dl = dl
         self._request: SuggestActorToCaseReceivedEvent = request
@@ -88,7 +91,9 @@ class SuggestActorToCaseReceivedUseCase:
 
 class AcceptSuggestActorToCaseReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: AcceptSuggestActorToCaseReceivedEvent
+        self,
+        dl: CasePersistence,
+        request: AcceptSuggestActorToCaseReceivedEvent,
     ) -> None:
         self._dl = dl
         self._request: AcceptSuggestActorToCaseReceivedEvent = request
@@ -107,7 +112,9 @@ class AcceptSuggestActorToCaseReceivedUseCase:
 
 class RejectSuggestActorToCaseReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: RejectSuggestActorToCaseReceivedEvent
+        self,
+        dl: CasePersistence,
+        request: RejectSuggestActorToCaseReceivedEvent,
     ) -> None:
         self._dl = dl
         self._request: RejectSuggestActorToCaseReceivedEvent = request
@@ -123,7 +130,9 @@ class RejectSuggestActorToCaseReceivedUseCase:
 
 class OfferCaseOwnershipTransferReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: OfferCaseOwnershipTransferReceivedEvent
+        self,
+        dl: CasePersistence,
+        request: OfferCaseOwnershipTransferReceivedEvent,
     ) -> None:
         self._dl = dl
         self._request: OfferCaseOwnershipTransferReceivedEvent = request
@@ -142,7 +151,9 @@ class OfferCaseOwnershipTransferReceivedUseCase:
 
 class AcceptCaseOwnershipTransferReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: AcceptCaseOwnershipTransferReceivedEvent
+        self,
+        dl: CasePersistence,
+        request: AcceptCaseOwnershipTransferReceivedEvent,
     ) -> None:
         self._dl = dl
         self._request: AcceptCaseOwnershipTransferReceivedEvent = request
@@ -186,7 +197,9 @@ class AcceptCaseOwnershipTransferReceivedUseCase:
 
 class RejectCaseOwnershipTransferReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: RejectCaseOwnershipTransferReceivedEvent
+        self,
+        dl: CasePersistence,
+        request: RejectCaseOwnershipTransferReceivedEvent,
     ) -> None:
         self._dl = dl
         self._request: RejectCaseOwnershipTransferReceivedEvent = request
@@ -202,7 +215,7 @@ class RejectCaseOwnershipTransferReceivedUseCase:
 
 class InviteActorToCaseReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: InviteActorToCaseReceivedEvent
+        self, dl: CasePersistence, request: InviteActorToCaseReceivedEvent
     ) -> None:
         self._dl = dl
         self._request: InviteActorToCaseReceivedEvent = request
@@ -231,7 +244,9 @@ class InviteActorToCaseReceivedUseCase:
 
 class AcceptInviteActorToCaseReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: AcceptInviteActorToCaseReceivedEvent
+        self,
+        dl: CaseOutboxPersistence,
+        request: AcceptInviteActorToCaseReceivedEvent,
     ) -> None:
         self._dl = dl
         self._request: AcceptInviteActorToCaseReceivedEvent = request
@@ -372,7 +387,9 @@ class AcceptInviteActorToCaseReceivedUseCase:
 
 class RejectInviteActorToCaseReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: RejectInviteActorToCaseReceivedEvent
+        self,
+        dl: CasePersistence,
+        request: RejectInviteActorToCaseReceivedEvent,
     ) -> None:
         self._dl = dl
         self._request: RejectInviteActorToCaseReceivedEvent = request
@@ -396,7 +413,7 @@ class AnnounceVulnerabilityCaseReceivedUseCase:
 
     def __init__(
         self,
-        dl: DataLayer,
+        dl: CasePersistence,
         request: AnnounceVulnerabilityCaseReceivedEvent,
     ) -> None:
         self._dl = dl

--- a/vultron/core/use_cases/received/case.py
+++ b/vultron/core/use_cases/received/case.py
@@ -14,7 +14,10 @@ from vultron.core.models.events.case import (
     UpdateCaseReceivedEvent,
 )
 from vultron.core.models.vultron_types import VultronActivity
-from vultron.core.ports.datalayer import DataLayer
+from vultron.core.ports.case_persistence import (
+    CasePersistence,
+    CaseOutboxPersistence,
+)
 from vultron.core.models.protocols import (
     CaseModel,
     is_case_model,
@@ -27,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 def _check_participant_embargo_acceptance(
-    case: CaseModel, dl: DataLayer
+    case: CaseModel, dl: CasePersistence
 ) -> set[str]:
     """Check which participants have not accepted the active embargo.
 
@@ -64,7 +67,7 @@ def _check_participant_embargo_acceptance(
 
 class CreateCaseReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: CreateCaseReceivedEvent
+        self, dl: CasePersistence, request: CreateCaseReceivedEvent
     ) -> None:
         self._dl = dl
         self._request: CreateCaseReceivedEvent = request
@@ -107,7 +110,7 @@ class CreateCaseReceivedUseCase:
 
 class UpdateCaseReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: UpdateCaseReceivedEvent
+        self, dl: CaseOutboxPersistence, request: UpdateCaseReceivedEvent
     ) -> None:
         self._dl = dl
         self._request: UpdateCaseReceivedEvent = request
@@ -233,7 +236,7 @@ class UpdateCaseReceivedUseCase:
 
 class EngageCaseReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: EngageCaseReceivedEvent
+        self, dl: CasePersistence, request: EngageCaseReceivedEvent
     ) -> None:
         self._dl = dl
         self._request: EngageCaseReceivedEvent = request
@@ -273,7 +276,9 @@ class EngageCaseReceivedUseCase:
 
 
 class DeferCaseReceivedUseCase:
-    def __init__(self, dl: DataLayer, request: DeferCaseReceivedEvent) -> None:
+    def __init__(
+        self, dl: CasePersistence, request: DeferCaseReceivedEvent
+    ) -> None:
         self._dl = dl
         self._request: DeferCaseReceivedEvent = request
 
@@ -313,7 +318,7 @@ class DeferCaseReceivedUseCase:
 
 class AddReportToCaseReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: AddReportToCaseReceivedEvent
+        self, dl: CasePersistence, request: AddReportToCaseReceivedEvent
     ) -> None:
         self._dl = dl
         self._request: AddReportToCaseReceivedEvent = request
@@ -346,7 +351,9 @@ class AddReportToCaseReceivedUseCase:
 
 
 class CloseCaseReceivedUseCase:
-    def __init__(self, dl: DataLayer, request: CloseCaseReceivedEvent) -> None:
+    def __init__(
+        self, dl: CaseOutboxPersistence, request: CloseCaseReceivedEvent
+    ) -> None:
         self._dl = dl
         self._request: CloseCaseReceivedEvent = request
 
@@ -392,7 +399,9 @@ class InvalidateCaseUseCase:
     report_id to case_id (CM-12-005).
     """
 
-    def __init__(self, dl: DataLayer, case_id: str, actor_id: str) -> None:
+    def __init__(
+        self, dl: CasePersistence, case_id: str, actor_id: str
+    ) -> None:
         self._dl = dl
         self._case_id = case_id
         self._actor_id = actor_id
@@ -422,7 +431,9 @@ class CloseCaseUseCase:
     report_id to case_id (CM-12-005).
     """
 
-    def __init__(self, dl: DataLayer, case_id: str, actor_id: str) -> None:
+    def __init__(
+        self, dl: CasePersistence, case_id: str, actor_id: str
+    ) -> None:
         self._dl = dl
         self._case_id = case_id
         self._actor_id = actor_id
@@ -459,7 +470,7 @@ class ValidateCaseUseCase:
 
     def __init__(
         self,
-        dl: DataLayer,
+        dl: CasePersistence,
         actor_id: str,
         report_id: str,
         offer_id: str,

--- a/vultron/core/use_cases/received/case_participant.py
+++ b/vultron/core/use_cases/received/case_participant.py
@@ -7,7 +7,7 @@ from vultron.core.models.events.case_participant import (
     CreateCaseParticipantReceivedEvent,
     RemoveCaseParticipantFromCaseReceivedEvent,
 )
-from vultron.core.ports.datalayer import DataLayer
+from vultron.core.ports.case_persistence import CasePersistence
 from vultron.core.models.protocols import is_case_model
 from vultron.core.use_cases._helpers import _as_id, _idempotent_create
 
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 class CreateCaseParticipantReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: CreateCaseParticipantReceivedEvent
+        self, dl: CasePersistence, request: CreateCaseParticipantReceivedEvent
     ) -> None:
         self._dl = dl
         self._request: CreateCaseParticipantReceivedEvent = request
@@ -35,7 +35,9 @@ class CreateCaseParticipantReceivedUseCase:
 
 class AddCaseParticipantToCaseReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: AddCaseParticipantToCaseReceivedEvent
+        self,
+        dl: CasePersistence,
+        request: AddCaseParticipantToCaseReceivedEvent,
     ) -> None:
         self._dl = dl
         self._request: AddCaseParticipantToCaseReceivedEvent = request
@@ -84,7 +86,7 @@ class AddCaseParticipantToCaseReceivedUseCase:
 class RemoveCaseParticipantFromCaseReceivedUseCase:
     def __init__(
         self,
-        dl: DataLayer,
+        dl: CasePersistence,
         request: RemoveCaseParticipantFromCaseReceivedEvent,
     ) -> None:
         self._dl = dl

--- a/vultron/core/use_cases/received/embargo.py
+++ b/vultron/core/use_cases/received/embargo.py
@@ -24,7 +24,7 @@ from vultron.core.models.events.embargo import (
     RejectInviteToEmbargoOnCaseReceivedEvent,
     RemoveEmbargoEventFromCaseReceivedEvent,
 )
-from vultron.core.ports.datalayer import DataLayer
+from vultron.core.ports.case_persistence import CasePersistence
 from vultron.core.use_cases._helpers import _as_id, _idempotent_create
 from vultron.core.models.protocols import (
     is_case_model,
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 
 class CreateEmbargoEventReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: CreateEmbargoEventReceivedEvent
+        self, dl: CasePersistence, request: CreateEmbargoEventReceivedEvent
     ) -> None:
         self._dl = dl
         self._request: CreateEmbargoEventReceivedEvent = request
@@ -55,7 +55,7 @@ class CreateEmbargoEventReceivedUseCase:
 
 class AddEmbargoEventToCaseReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: AddEmbargoEventToCaseReceivedEvent
+        self, dl: CasePersistence, request: AddEmbargoEventToCaseReceivedEvent
     ) -> None:
         self._dl = dl
         self._request: AddEmbargoEventToCaseReceivedEvent = request
@@ -107,7 +107,9 @@ class AddEmbargoEventToCaseReceivedUseCase:
 
 class RemoveEmbargoEventFromCaseReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: RemoveEmbargoEventFromCaseReceivedEvent
+        self,
+        dl: CasePersistence,
+        request: RemoveEmbargoEventFromCaseReceivedEvent,
     ) -> None:
         self._dl = dl
         self._request: RemoveEmbargoEventFromCaseReceivedEvent = request
@@ -196,7 +198,9 @@ class RemoveEmbargoEventFromCaseReceivedUseCase:
 
 class AnnounceEmbargoEventToCaseReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: AnnounceEmbargoEventToCaseReceivedEvent
+        self,
+        dl: CasePersistence,
+        request: AnnounceEmbargoEventToCaseReceivedEvent,
     ) -> None:
         self._dl = dl
         self._request: AnnounceEmbargoEventToCaseReceivedEvent = request
@@ -212,7 +216,7 @@ class AnnounceEmbargoEventToCaseReceivedUseCase:
 
 class InviteToEmbargoOnCaseReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: InviteToEmbargoOnCaseReceivedEvent
+        self, dl: CasePersistence, request: InviteToEmbargoOnCaseReceivedEvent
     ) -> None:
         self._dl = dl
         self._request: InviteToEmbargoOnCaseReceivedEvent = request
@@ -263,7 +267,9 @@ class InviteToEmbargoOnCaseReceivedUseCase:
 
 class AcceptInviteToEmbargoOnCaseReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: AcceptInviteToEmbargoOnCaseReceivedEvent
+        self,
+        dl: CasePersistence,
+        request: AcceptInviteToEmbargoOnCaseReceivedEvent,
     ) -> None:
         self._dl = dl
         self._request: AcceptInviteToEmbargoOnCaseReceivedEvent = request
@@ -389,7 +395,9 @@ class AcceptInviteToEmbargoOnCaseReceivedUseCase:
 
 class RejectInviteToEmbargoOnCaseReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: RejectInviteToEmbargoOnCaseReceivedEvent
+        self,
+        dl: CasePersistence,
+        request: RejectInviteToEmbargoOnCaseReceivedEvent,
     ) -> None:
         self._dl = dl
         self._request: RejectInviteToEmbargoOnCaseReceivedEvent = request

--- a/vultron/core/use_cases/received/note.py
+++ b/vultron/core/use_cases/received/note.py
@@ -10,7 +10,10 @@ from vultron.core.models.events.note import (
     CreateNoteReceivedEvent,
     RemoveNoteFromCaseReceivedEvent,
 )
-from vultron.core.ports.datalayer import DataLayer
+from vultron.core.ports.case_persistence import (
+    CasePersistence,
+    CaseOutboxPersistence,
+)
 from vultron.core.models.protocols import is_case_model
 from vultron.core.use_cases._helpers import _as_id
 from vultron.wire.as2.vocab.activities.case import AddNoteToCaseActivity
@@ -20,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 class CreateNoteReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: CreateNoteReceivedEvent
+        self, dl: CasePersistence, request: CreateNoteReceivedEvent
     ) -> None:
         self._dl = dl
         self._request: CreateNoteReceivedEvent = request
@@ -60,7 +63,7 @@ class CreateNoteReceivedUseCase:
 
 class AddNoteToCaseReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: AddNoteToCaseReceivedEvent
+        self, dl: CaseOutboxPersistence, request: AddNoteToCaseReceivedEvent
     ) -> None:
         self._dl = dl
         self._request: AddNoteToCaseReceivedEvent = request
@@ -175,7 +178,7 @@ class AddNoteToCaseReceivedUseCase:
 
 class RemoveNoteFromCaseReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: RemoveNoteFromCaseReceivedEvent
+        self, dl: CasePersistence, request: RemoveNoteFromCaseReceivedEvent
     ) -> None:
         self._dl = dl
         self._request: RemoveNoteFromCaseReceivedEvent = request

--- a/vultron/core/use_cases/received/report.py
+++ b/vultron/core/use_cases/received/report.py
@@ -11,7 +11,7 @@ from vultron.core.models.events.report import (
     ValidateReportReceivedEvent,
 )
 from vultron.core.models.protocols import is_case_model
-from vultron.core.ports.datalayer import DataLayer
+from vultron.core.ports.case_persistence import CasePersistence
 from vultron.core.use_cases.received.case import (
     CloseCaseUseCase,
     InvalidateCaseUseCase,
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 class CreateReportReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: CreateReportReceivedEvent
+        self, dl: CasePersistence, request: CreateReportReceivedEvent
     ) -> None:
         self._dl = dl
         self._request: CreateReportReceivedEvent = request
@@ -66,7 +66,7 @@ class CreateReportReceivedUseCase:
 
 class SubmitReportReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: SubmitReportReceivedEvent
+        self, dl: CasePersistence, request: SubmitReportReceivedEvent
     ) -> None:
         self._dl = dl
         self._request: SubmitReportReceivedEvent = request
@@ -187,7 +187,7 @@ class SubmitReportReceivedUseCase:
 
 class ValidateReportReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: ValidateReportReceivedEvent
+        self, dl: CasePersistence, request: ValidateReportReceivedEvent
     ) -> None:
         self._dl = dl
         self._request: ValidateReportReceivedEvent = request
@@ -230,7 +230,7 @@ class ValidateReportReceivedUseCase:
 
 class InvalidateReportReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: InvalidateReportReceivedEvent
+        self, dl: CasePersistence, request: InvalidateReportReceivedEvent
     ) -> None:
         self._dl = dl
         self._request: InvalidateReportReceivedEvent = request
@@ -272,7 +272,9 @@ class InvalidateReportReceivedUseCase:
 
 
 class AckReportReceivedUseCase:
-    def __init__(self, dl: DataLayer, request: AckReportReceivedEvent) -> None:
+    def __init__(
+        self, dl: CasePersistence, request: AckReportReceivedEvent
+    ) -> None:
         self._dl = dl
         self._request: AckReportReceivedEvent = request
 
@@ -302,7 +304,7 @@ class AckReportReceivedUseCase:
 
 class CloseReportReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: CloseReportReceivedEvent
+        self, dl: CasePersistence, request: CloseReportReceivedEvent
     ) -> None:
         self._dl = dl
         self._request: CloseReportReceivedEvent = request

--- a/vultron/core/use_cases/received/status.py
+++ b/vultron/core/use_cases/received/status.py
@@ -9,7 +9,7 @@ from vultron.core.models.events.status import (
     CreateCaseStatusReceivedEvent,
     CreateParticipantStatusReceivedEvent,
 )
-from vultron.core.ports.datalayer import DataLayer
+from vultron.core.ports.case_persistence import CasePersistence
 from vultron.core.states.cs import is_valid_pxa_transition
 from vultron.core.states.em import is_valid_em_transition
 from vultron.core.states.rm import is_valid_rm_transition
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 class CreateCaseStatusReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: CreateCaseStatusReceivedEvent
+        self, dl: CasePersistence, request: CreateCaseStatusReceivedEvent
     ) -> None:
         self._dl = dl
         self._request: CreateCaseStatusReceivedEvent = request
@@ -44,7 +44,7 @@ class CreateCaseStatusReceivedUseCase:
 
 class AddCaseStatusToCaseReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: AddCaseStatusToCaseReceivedEvent
+        self, dl: CasePersistence, request: AddCaseStatusToCaseReceivedEvent
     ) -> None:
         self._dl = dl
         self._request: AddCaseStatusToCaseReceivedEvent = request
@@ -123,7 +123,9 @@ class AddCaseStatusToCaseReceivedUseCase:
 
 class CreateParticipantStatusReceivedUseCase:
     def __init__(
-        self, dl: DataLayer, request: CreateParticipantStatusReceivedEvent
+        self,
+        dl: CasePersistence,
+        request: CreateParticipantStatusReceivedEvent,
     ) -> None:
         self._dl = dl
         self._request: CreateParticipantStatusReceivedEvent = request
@@ -143,7 +145,7 @@ class CreateParticipantStatusReceivedUseCase:
 class AddParticipantStatusToParticipantReceivedUseCase:
     def __init__(
         self,
-        dl: DataLayer,
+        dl: CasePersistence,
         request: AddParticipantStatusToParticipantReceivedEvent,
     ) -> None:
         self._dl = dl

--- a/vultron/core/use_cases/received/sync.py
+++ b/vultron/core/use_cases/received/sync.py
@@ -27,12 +27,17 @@ from vultron.core.models.events.sync import (
     RejectLogEntryReceivedEvent,
 )
 from vultron.core.models.replication_state import VultronReplicationState
-from vultron.core.ports.datalayer import DataLayer
+from vultron.core.ports.case_persistence import (
+    CasePersistence,
+    CaseOutboxPersistence,
+)
 
 logger = logging.getLogger(__name__)
 
 
-def _reconstruct_tail_hash(case_id: str, dl: DataLayer) -> tuple[str, int]:
+def _reconstruct_tail_hash(
+    case_id: str, dl: CasePersistence
+) -> tuple[str, int]:
     """Return the hash and index of the last accepted log entry for *case_id*.
 
     Queries all :class:`~vultron.core.models.case_log_entry.VultronCaseLogEntry`
@@ -61,7 +66,7 @@ def _reconstruct_tail_hash(case_id: str, dl: DataLayer) -> tuple[str, int]:
     return last.entry_hash, last.log_index
 
 
-def _find_local_actor_id(dl: DataLayer) -> str | None:
+def _find_local_actor_id(dl: CasePersistence) -> str | None:
     """Find the local actor's ID from the DataLayer.
 
     Looks for actor records (Service, Person, Organization) in the
@@ -78,7 +83,7 @@ def _update_replication_state(
     case_id: str,
     peer_id: str,
     last_acknowledged_hash: str,
-    dl: DataLayer,
+    dl: CasePersistence,
 ) -> None:
     """Upsert the :class:`VultronReplicationState` for *peer_id* in *case_id*.
 
@@ -131,7 +136,7 @@ class AnnounceLogEntryReceivedUseCase:
 
     def __init__(
         self,
-        dl: DataLayer,
+        dl: CaseOutboxPersistence,
         request: AnnounceLogEntryReceivedEvent,
     ) -> None:
         self._dl = dl
@@ -252,7 +257,7 @@ class RejectLogEntryReceivedUseCase:
 
     def __init__(
         self,
-        dl: DataLayer,
+        dl: CaseOutboxPersistence,
         request: RejectLogEntryReceivedEvent,
     ) -> None:
         self._dl = dl

--- a/vultron/core/use_cases/received/unknown.py
+++ b/vultron/core/use_cases/received/unknown.py
@@ -7,7 +7,7 @@ from vultron.core.models.events.unknown import (
     UnknownReceivedEvent,
     UnresolvableObjectReceivedEvent,
 )
-from vultron.core.ports.datalayer import DataLayer
+from vultron.core.ports.case_persistence import CasePersistence
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +17,9 @@ class UnknownUseCase:
     semantic type.
     """
 
-    def __init__(self, dl: DataLayer, request: UnknownReceivedEvent) -> None:
+    def __init__(
+        self, dl: CasePersistence, request: UnknownReceivedEvent
+    ) -> None:
         self._dl = dl
         self._request: UnknownReceivedEvent = request
 
@@ -34,7 +36,7 @@ class UnresolvableObjectUseCase:
     """
 
     def __init__(
-        self, dl: DataLayer, request: UnresolvableObjectReceivedEvent
+        self, dl: CasePersistence, request: UnresolvableObjectReceivedEvent
     ) -> None:
         self._dl = dl
         self._request = request

--- a/vultron/core/use_cases/triggers/_helpers.py
+++ b/vultron/core/use_cases/triggers/_helpers.py
@@ -30,13 +30,16 @@ from vultron.core.models.protocols import (
     is_participant_model,
 )
 from vultron.core.states.rm import RM
-from vultron.core.ports.datalayer import DataLayer
+from vultron.core.ports.case_persistence import (
+    CasePersistence,
+    CaseOutboxPersistence,
+)
 from vultron.errors import VultronNotFoundError, VultronValidationError
 
 logger = logging.getLogger(__name__)
 
 
-def resolve_actor(actor_id: str, dl: DataLayer):
+def resolve_actor(actor_id: str, dl: CasePersistence):
     """Resolve actor by full ID or short ID; raise VultronNotFoundError if absent."""
     actor = dl.read(actor_id)
     if actor is None:
@@ -46,7 +49,7 @@ def resolve_actor(actor_id: str, dl: DataLayer):
     return actor
 
 
-def resolve_case(case_id: str, dl: DataLayer) -> CaseModel:
+def resolve_case(case_id: str, dl: CasePersistence) -> CaseModel:
     """Resolve a VulnerabilityCase by ID; raise domain error if absent or wrong type."""
     case_raw = dl.read(case_id)
     if case_raw is None:
@@ -59,7 +62,7 @@ def resolve_case(case_id: str, dl: DataLayer) -> CaseModel:
 
 
 def update_participant_rm_state(
-    case_id: str, actor_id: str, new_rm_state: RM, dl: DataLayer
+    case_id: str, actor_id: str, new_rm_state: RM, dl: CasePersistence
 ) -> bool:
     """
     Append a new ParticipantStatus with new_rm_state to the actor's
@@ -147,7 +150,7 @@ def outbox_ids(actor) -> set[str]:
 
 
 def add_activity_to_outbox(
-    actor_id: str, activity_id: str, dl: DataLayer
+    actor_id: str, activity_id: str, dl: CaseOutboxPersistence
 ) -> None:
     """Append an activity ID to an actor's outbox and queue it for delivery.
 
@@ -186,7 +189,7 @@ def add_activity_to_outbox(
     )
 
 
-def find_embargo_proposal(case_id: str, dl: DataLayer):
+def find_embargo_proposal(case_id: str, dl: CasePersistence):
     """
     Find the first stored EmProposeEmbargoActivity for the given case.
 

--- a/vultron/core/use_cases/triggers/actor.py
+++ b/vultron/core/use_cases/triggers/actor.py
@@ -22,7 +22,7 @@ No HTTP framework imports permitted here.
 import logging
 from typing import Any, cast
 
-from vultron.core.ports.datalayer import DataLayer
+from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.use_cases.triggers._helpers import (
     add_activity_to_outbox,
     resolve_actor,
@@ -58,7 +58,9 @@ class SvcSuggestActorToCaseUseCase:
     """
 
     def __init__(
-        self, dl: DataLayer, request: SuggestActorToCaseTriggerRequest
+        self,
+        dl: CaseOutboxPersistence,
+        request: SuggestActorToCaseTriggerRequest,
     ) -> None:
         self._dl = dl
         self._request = request
@@ -104,7 +106,9 @@ class SvcInviteActorToCaseUseCase:
     """
 
     def __init__(
-        self, dl: DataLayer, request: InviteActorToCaseTriggerRequest
+        self,
+        dl: CaseOutboxPersistence,
+        request: InviteActorToCaseTriggerRequest,
     ) -> None:
         self._dl = dl
         self._request = request
@@ -150,7 +154,9 @@ class SvcAcceptCaseInviteUseCase:
     """
 
     def __init__(
-        self, dl: DataLayer, request: AcceptCaseInviteTriggerRequest
+        self,
+        dl: CaseOutboxPersistence,
+        request: AcceptCaseInviteTriggerRequest,
     ) -> None:
         self._dl = dl
         self._request = request

--- a/vultron/core/use_cases/triggers/case.py
+++ b/vultron/core/use_cases/triggers/case.py
@@ -23,7 +23,7 @@ import logging
 from typing import Any, cast
 
 from vultron.core.states.rm import RM
-from vultron.core.ports.datalayer import DataLayer
+from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.use_cases._helpers import update_participant_rm_state
 from vultron.core.use_cases._helpers import case_addressees
 from vultron.core.use_cases.triggers._helpers import (
@@ -56,7 +56,7 @@ class SvcEngageCaseUseCase:
     """Engage a case (RM → ACCEPTED)."""
 
     def __init__(
-        self, dl: DataLayer, request: EngageCaseTriggerRequest
+        self, dl: CaseOutboxPersistence, request: EngageCaseTriggerRequest
     ) -> None:
         self._dl = dl
         self._request: EngageCaseTriggerRequest = request
@@ -104,7 +104,7 @@ class SvcDeferCaseUseCase:
     """Defer a case (RM → DEFERRED)."""
 
     def __init__(
-        self, dl: DataLayer, request: DeferCaseTriggerRequest
+        self, dl: CaseOutboxPersistence, request: DeferCaseTriggerRequest
     ) -> None:
         self._dl = dl
         self._request: DeferCaseTriggerRequest = request
@@ -157,7 +157,7 @@ class SvcCreateCaseUseCase:
     """
 
     def __init__(
-        self, dl: DataLayer, request: CreateCaseTriggerRequest
+        self, dl: CaseOutboxPersistence, request: CreateCaseTriggerRequest
     ) -> None:
         self._dl = dl
         self._request = request
@@ -214,7 +214,7 @@ class SvcAddReportToCaseUseCase:
     """
 
     def __init__(
-        self, dl: DataLayer, request: AddReportToCaseTriggerRequest
+        self, dl: CaseOutboxPersistence, request: AddReportToCaseTriggerRequest
     ) -> None:
         self._dl = dl
         self._request = request

--- a/vultron/core/use_cases/triggers/embargo.py
+++ b/vultron/core/use_cases/triggers/embargo.py
@@ -30,7 +30,10 @@ from vultron.core.models.protocols import (
     is_case_model,
     is_participant_model,
 )
-from vultron.core.ports.datalayer import DataLayer
+from vultron.core.ports.case_persistence import (
+    CasePersistence,
+    CaseOutboxPersistence,
+)
 from vultron.core.states.participant_embargo_consent import (
     PEC,
     PEC_Trigger,
@@ -88,7 +91,9 @@ def _coerce_embargo_event(
         ) from exc
 
 
-def _cascade_pec_revise(case: PersistableModel | None, dl: DataLayer) -> None:
+def _cascade_pec_revise(
+    case: PersistableModel | None, dl: CasePersistence
+) -> None:
     """Transition all SIGNATORY participants to LAPSED.
 
     Called when an embargo transitions to REVISE state, meaning the embargo
@@ -108,7 +113,9 @@ def _cascade_pec_revise(case: PersistableModel | None, dl: DataLayer) -> None:
             dl.save(participant)
 
 
-def _cascade_pec_reset(case: PersistableModel | None, dl: DataLayer) -> None:
+def _cascade_pec_reset(
+    case: PersistableModel | None, dl: CasePersistence
+) -> None:
     """Reset all participants' embargo consent state to NO_EMBARGO.
 
     Called when an embargo is terminated or removed.
@@ -143,7 +150,7 @@ def _update_participant_embargo_acceptance(
     case: PersistableModel | None,
     actor_id: str,
     embargo_id: str,
-    dl: DataLayer,
+    dl: CaseOutboxPersistence,
 ) -> None:
     """Persist a participant-level embargo acceptance without re-driving EM."""
     if not is_case_model(case):
@@ -185,7 +192,7 @@ def _update_participant_embargo_rejection(
     case: PersistableModel | None,
     actor_id: str,
     embargo_id: str,
-    dl: DataLayer,
+    dl: CaseOutboxPersistence,
 ) -> None:
     """Persist a participant-level embargo rejection without re-driving EM."""
     if not is_case_model(case):
@@ -226,7 +233,7 @@ class SvcProposeEmbargoUseCase:
     """Propose an embargo on a case."""
 
     def __init__(
-        self, dl: DataLayer, request: ProposeEmbargoTriggerRequest
+        self, dl: CaseOutboxPersistence, request: ProposeEmbargoTriggerRequest
     ) -> None:
         self._dl = dl
         self._request: ProposeEmbargoTriggerRequest = request
@@ -328,7 +335,7 @@ class SvcAcceptEmbargoUseCase:
     """Accept an embargo proposal (accept-embargo)."""
 
     def __init__(
-        self, dl: DataLayer, request: AcceptEmbargoTriggerRequest
+        self, dl: CaseOutboxPersistence, request: AcceptEmbargoTriggerRequest
     ) -> None:
         self._dl = dl
         self._request: AcceptEmbargoTriggerRequest = request
@@ -458,7 +465,9 @@ class SvcTerminateEmbargoUseCase:
     """Terminate the active embargo on a case."""
 
     def __init__(
-        self, dl: DataLayer, request: TerminateEmbargoTriggerRequest
+        self,
+        dl: CaseOutboxPersistence,
+        request: TerminateEmbargoTriggerRequest,
     ) -> None:
         self._dl = dl
         self._request: TerminateEmbargoTriggerRequest = request
@@ -563,7 +572,7 @@ class SvcRejectEmbargoUseCase:
     """
 
     def __init__(
-        self, dl: DataLayer, request: RejectEmbargoTriggerRequest
+        self, dl: CaseOutboxPersistence, request: RejectEmbargoTriggerRequest
     ) -> None:
         self._dl = dl
         self._request: RejectEmbargoTriggerRequest = request
@@ -689,7 +698,7 @@ class SvcProposeEmbargoRevisionUseCase:
 
     def __init__(
         self,
-        dl: DataLayer,
+        dl: CaseOutboxPersistence,
         request: ProposeEmbargoRevisionTriggerRequest,
     ) -> None:
         self._dl = dl

--- a/vultron/core/use_cases/triggers/note.py
+++ b/vultron/core/use_cases/triggers/note.py
@@ -22,7 +22,7 @@ No HTTP framework imports permitted here.
 import logging
 
 from vultron.core.models.protocols import is_case_model
-from vultron.core.ports.datalayer import DataLayer
+from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.use_cases._helpers import case_addressees
 from vultron.core.use_cases.triggers._helpers import (
     add_activity_to_outbox,
@@ -48,7 +48,7 @@ class SvcAddNoteToCaseUseCase:
     """
 
     def __init__(
-        self, dl: DataLayer, request: AddNoteToCaseTriggerRequest
+        self, dl: CaseOutboxPersistence, request: AddNoteToCaseTriggerRequest
     ) -> None:
         self._dl = dl
         self._request = request

--- a/vultron/core/use_cases/triggers/report.py
+++ b/vultron/core/use_cases/triggers/report.py
@@ -33,7 +33,7 @@ from vultron.core.behaviors.report.validate_tree import (
     create_validate_report_tree,
 )
 from vultron.core.models.participant_status import VultronParticipantStatus
-from vultron.core.ports.datalayer import DataLayer
+from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.use_cases._helpers import (
     _idempotent_create,
     _report_phase_status_id,
@@ -70,7 +70,7 @@ logger = logging.getLogger(__name__)
 
 
 def _resolve_offer_and_report(
-    offer_id: str, dl: DataLayer
+    offer_id: str, dl: CaseOutboxPersistence
 ) -> tuple["RmSubmitReportActivity", VulnerabilityReport]:
     """Resolve offer and its embedded report; raise domain errors on failure.
 
@@ -96,7 +96,7 @@ def _resolve_offer_and_report(
 
 
 def _report_addressees(
-    report_id: str, actor_id: str, offer, dl: DataLayer
+    report_id: str, actor_id: str, offer, dl: CaseOutboxPersistence
 ) -> list[str] | None:
     """Return the ``to`` recipient list for a report-phase outbound activity.
 
@@ -128,7 +128,7 @@ class SvcValidateReportUseCase:
     """Validate a report offer using the ValidateReportBT behavior tree."""
 
     def __init__(
-        self, dl: DataLayer, request: ValidateReportTriggerRequest
+        self, dl: CaseOutboxPersistence, request: ValidateReportTriggerRequest
     ) -> None:
         self._dl = dl
         self._request: ValidateReportTriggerRequest = request
@@ -186,7 +186,9 @@ class SvcInvalidateReportUseCase:
     """Emit RmInvalidateReportActivity (TentativeReject) for the given offer."""
 
     def __init__(
-        self, dl: DataLayer, request: InvalidateReportTriggerRequest
+        self,
+        dl: CaseOutboxPersistence,
+        request: InvalidateReportTriggerRequest,
     ) -> None:
         self._dl = dl
         self._request: InvalidateReportTriggerRequest = request
@@ -251,7 +253,7 @@ class SvcRejectReportUseCase:
     """Hard-close a report offer by emitting RmCloseReportActivity (Reject)."""
 
     def __init__(
-        self, dl: DataLayer, request: RejectReportTriggerRequest
+        self, dl: CaseOutboxPersistence, request: RejectReportTriggerRequest
     ) -> None:
         self._dl = dl
         self._request: RejectReportTriggerRequest = request
@@ -314,7 +316,7 @@ class SvcCloseReportUseCase:
     """Close a report via the RM lifecycle (RM → C transition)."""
 
     def __init__(
-        self, dl: DataLayer, request: CloseReportTriggerRequest
+        self, dl: CaseOutboxPersistence, request: CloseReportTriggerRequest
     ) -> None:
         self._dl = dl
         self._request: CloseReportTriggerRequest = request
@@ -397,7 +399,7 @@ class SvcSubmitReportUseCase:
     """
 
     def __init__(
-        self, dl: DataLayer, request: SubmitReportTriggerRequest
+        self, dl: CaseOutboxPersistence, request: SubmitReportTriggerRequest
     ) -> None:
         self._dl = dl
         self._request = request

--- a/vultron/core/use_cases/triggers/sync.py
+++ b/vultron/core/use_cases/triggers/sync.py
@@ -29,7 +29,9 @@ from typing import Any
 from vultron.core.models.case_log import CaseLogEntry
 from vultron.core.models.case_log_entry import VultronCaseLogEntry
 from vultron.core.models.protocols import is_case_model
-from vultron.core.ports.datalayer import DataLayer
+from vultron.core.ports.case_persistence import (
+    CaseOutboxPersistence,
+)
 from vultron.core.use_cases._helpers import case_addressees
 from vultron.core.use_cases.received.sync import _reconstruct_tail_hash
 from vultron.core.use_cases.triggers._helpers import add_activity_to_outbox
@@ -67,7 +69,7 @@ def _fan_out_log_entry(
     case_id: str,
     entry: VultronCaseLogEntry,
     actor_id: str,
-    dl: DataLayer,
+    dl: CaseOutboxPersistence,
 ) -> None:
     """Create one ``Announce(CaseLogEntry)`` per peer and queue for delivery.
 
@@ -117,7 +119,7 @@ def commit_log_entry_trigger(
     object_id: str,
     event_type: str,
     actor_id: str,
-    dl: DataLayer,
+    dl: CaseOutboxPersistence,
     payload_snapshot: dict[str, Any] | None = None,
     term: int | None = None,
     reason_code: str | None = None,
@@ -137,7 +139,7 @@ def commit_log_entry_trigger(
         object_id: URI of the asserted activity or primary object.
         event_type: Short machine-readable event descriptor.
         actor_id: URI of the CaseActor performing the commit.
-        dl: DataLayer instance for persistence and outbox access.
+        dl: CaseOutboxPersistence instance for persistence and outbox access.
         payload_snapshot: Optional normalised payload snapshot.
         term: Optional Raft cluster term (single-node → ``None``).
         reason_code: Required when *disposition* is ``"rejected"``.
@@ -189,7 +191,7 @@ def replay_missing_entries_trigger(
     peer_id: str,
     from_hash: str,
     case_actor_id: str,
-    dl: DataLayer,
+    dl: CaseOutboxPersistence,
 ) -> int:
     """Replay all log entries after *from_hash* to a specific peer.
 
@@ -206,7 +208,7 @@ def replay_missing_entries_trigger(
         peer_id: URI of the participant who needs the missing entries.
         from_hash: ``entry_hash`` of the last entry acknowledged by *peer_id*.
         case_actor_id: URI of the CaseActor sending the announcements.
-        dl: DataLayer instance for persistence and outbox access.
+        dl: CaseOutboxPersistence instance for persistence and outbox access.
 
     Returns:
         The number of entries replayed (i.e. queued for delivery).

--- a/vultron/metadata/history/cli.py
+++ b/vultron/metadata/history/cli.py
@@ -31,7 +31,9 @@ import sys
 from pathlib import Path
 
 import frontmatter
+from pydantic import ValidationError
 
+from vultron.metadata.history.models import HistoryEntryFrontmatter
 from vultron.metadata.history.readme_gen import regenerate_readme
 from vultron.metadata.history.types import HistoryEntryType
 
@@ -55,21 +57,33 @@ def _find_repo_root(start: Path | None = None) -> Path:
     )
 
 
-def _extract_entry_id(content: str, entry_type: str) -> str:
-    """Extract the ``source`` field from YAML frontmatter as the entry ID.
+def _validate_frontmatter(content: str) -> HistoryEntryFrontmatter:
+    """Parse and validate YAML frontmatter from *content*.
 
-    Falls back to ``<type>-<YYMMDDHHMMSS>`` if ``source`` is absent or empty.
+    Raises:
+        ValueError: If the frontmatter is malformed, missing, or fails
+            required-field validation (HM-02-001).
     """
     try:
         post = frontmatter.loads(content)
-        source = str(post.metadata.get("source", "")).strip()
-        if source:
-            return source
-    except Exception:  # noqa: BLE001
-        pass
+    except Exception as exc:  # noqa: BLE001
+        raise ValueError(f"malformed YAML frontmatter: {exc}") from exc
 
-    timestamp = datetime.datetime.now().strftime("%y%m%d%H%M%S")
-    return f"{entry_type}-{timestamp}"
+    if not post.metadata:
+        raise ValueError(
+            "missing frontmatter block: entry must begin with a YAML "
+            "frontmatter block containing title, type, date, and source"
+        )
+
+    try:
+        return HistoryEntryFrontmatter.model_validate(post.metadata)
+    except ValidationError as exc:
+        # Collect field names for a concise, actionable error message.
+        missing = [e["loc"][0] for e in exc.errors() if e["loc"]]
+        fields = ", ".join(str(f) for f in missing) if missing else str(exc)
+        raise ValueError(
+            f"invalid history frontmatter: missing or invalid field(s): {fields}"
+        ) from exc
 
 
 def _sanitize_entry_id(entry_id: str) -> str:
@@ -154,17 +168,24 @@ def append_history_entry(
         Path to the written history entry.
 
     Raises:
-        ValueError: If content is empty.
+        ValueError: If content is empty, frontmatter is invalid, or the
+            frontmatter ``type`` field does not match *entry_type*.
         FileExistsError: If the target entry file already exists.
     """
     if not content.strip():
         raise ValueError("entry content is empty")
 
+    validated = _validate_frontmatter(content)
+    if validated.type != entry_type:
+        raise ValueError(
+            f"type mismatch: CLI argument is '{entry_type}' but frontmatter "
+            f"'type' field is '{validated.type}'"
+        )
+
     resolved_root = _find_repo_root(repo_root)
     resolved_date = target_date or datetime.date.today()
     yymm = resolved_date.strftime("%y%m")
-    raw_entry_id = _extract_entry_id(content, entry_type.value)
-    entry_id = _sanitize_entry_id(raw_entry_id)
+    entry_id = _sanitize_entry_id(validated.source)
 
     entry_dir = resolved_root / "plan" / "history" / yymm / entry_type.value
     entry_dir.mkdir(parents=True, exist_ok=True)
@@ -176,7 +197,13 @@ def append_history_entry(
     entry_file.write_text(content, encoding="utf-8")
 
     month_dir = resolved_root / "plan" / "history" / yymm
-    regenerate_readme(month_dir)
+    try:
+        regenerate_readme(month_dir)
+    except Exception as exc:
+        entry_file.unlink(missing_ok=True)
+        raise ValueError(
+            f"README generation failed; entry rolled back: {exc}"
+        ) from exc
     return entry_file
 
 

--- a/vultron/metadata/history/models.py
+++ b/vultron/metadata/history/models.py
@@ -1,0 +1,33 @@
+"""Pydantic model for history entry YAML frontmatter.
+
+Defines the required-field contract for ``append-history`` entries
+(HM-02-001). Used by both the CLI (``cli.py``) and the README generator
+(``readme_gen.py``) so the validation rule is a single source of truth.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+from pydantic import BaseModel, field_validator
+
+from vultron.metadata.history.types import HistoryEntryType
+
+
+class HistoryEntryFrontmatter(BaseModel):
+    """Required frontmatter fields for every history entry file (HM-02-001)."""
+
+    title: str
+    type: HistoryEntryType
+    date: datetime.date
+    source: str
+
+    @field_validator("title", "source", mode="before")
+    @classmethod
+    def must_be_non_empty(cls, v: object) -> str:
+        if not isinstance(v, str):
+            raise ValueError("must be a string")
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("must not be empty or whitespace-only")
+        return stripped

--- a/vultron/metadata/history/readme_gen.py
+++ b/vultron/metadata/history/readme_gen.py
@@ -13,6 +13,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import frontmatter
+from pydantic import ValidationError
+
+from vultron.metadata.history.models import HistoryEntryFrontmatter
 
 
 @dataclass
@@ -27,17 +30,38 @@ class _EntryMeta:
 
 
 def _parse_entry(path: Path) -> _EntryMeta:
-    """Read YAML frontmatter from a history entry file."""
+    """Read and validate YAML frontmatter from a history entry file.
+
+    Raises:
+        ValueError: If the frontmatter is malformed, missing, or fails
+            required-field validation (HM-02-001).
+    """
     try:
         post = frontmatter.load(str(path))
-    except Exception:  # noqa: BLE001  # malformed frontmatter → skip
-        return _EntryMeta(path=path)
+    except Exception as exc:  # noqa: BLE001
+        raise ValueError(f"{path}: malformed YAML frontmatter: {exc}") from exc
+
+    if not post.metadata:
+        raise ValueError(
+            f"{path}: missing frontmatter block — entry must begin with a "
+            "YAML frontmatter block containing title, type, date, and source"
+        )
+
+    try:
+        meta = HistoryEntryFrontmatter.model_validate(post.metadata)
+    except ValidationError as exc:
+        missing = [e["loc"][0] for e in exc.errors() if e["loc"]]
+        fields = ", ".join(str(f) for f in missing) if missing else str(exc)
+        raise ValueError(
+            f"{path}: invalid history frontmatter: missing or invalid "
+            f"field(s): {fields}"
+        ) from exc
 
     return _EntryMeta(
-        title=str(post.metadata.get("title", "")),
-        entry_type=str(post.metadata.get("type", "")),
-        date=str(post.metadata.get("date", "")),
-        source=str(post.metadata.get("source", "")),
+        title=meta.title,
+        entry_type=meta.type.value,
+        date=meta.date.isoformat(),
+        source=meta.source,
         path=path,
     )
 
@@ -67,8 +91,7 @@ def regenerate_readme(month_dir: Path) -> Path:
         if md_file.name == "README.md":
             continue
         meta = _parse_entry(md_file)
-        if meta.title or meta.source:
-            entries.append(meta)
+        entries.append(meta)
 
     # Sort by date descending, then type ascending for stable ordering.
     entries.sort(key=lambda e: (e.date, e.entry_type), reverse=True)

--- a/vultron/semantic_registry.py
+++ b/vultron/semantic_registry.py
@@ -652,7 +652,7 @@ __all__ = [
 
 
 def extract_event(
-    activity: "as_Activity",  # type annotation — as_Activity imported below
+    activity: as_Activity,
 ) -> VultronEvent:
     """Extract a typed ``VultronEvent`` from an AS2 activity.
 
@@ -698,13 +698,6 @@ def semantics_to_activity_class() -> dict[MessageSemantics, type[as_Activity]]:
         for e in SEMANTIC_REGISTRY
         if e.wire_activity_class is not None
     }
-
-
-# Imported after registry build to avoid hoisting the as_Activity import into
-# the top-level namespace where it would appear to callers as a registry symbol.
-from vultron.wire.as2.vocab.base.objects.activities.base import (  # noqa: E402
-    as_Activity,
-)
 
 
 def find_matching_semantics(activity: as_Activity) -> MessageSemantics:

--- a/vultron/semantic_registry.py
+++ b/vultron/semantic_registry.py
@@ -23,7 +23,7 @@ code.  ``extractor.py`` must NOT import from this module (it provides the
 Public API
 ----------
 ``SEMANTIC_REGISTRY`` — ordered list of ``SemanticEntry`` values
-``find_matching_semantics(activity)`` — re-exported from ``extractor``
+``find_matching_semantics(activity)`` — iterates ``SEMANTIC_REGISTRY`` directly
 ``extract_event(activity)`` — convenience wrapper: pattern-match + extract
 ``lookup_entry(semantics)`` — O(1) entry lookup by ``MessageSemantics``
 """
@@ -616,6 +616,15 @@ _ENTRY_MAP: dict[MessageSemantics, SemanticEntry] = {
     e.semantics: e for e in SEMANTIC_REGISTRY
 }
 
+# Frozenset of activity type strings that have at least one registered pattern.
+# Used by find_matching_semantics() to distinguish "known type with unresolvable
+# object_" from "genuinely unknown activity type".
+_ACTIVITY_TYPES_WITH_PATTERNS: frozenset[str] = frozenset(
+    str(e.pattern.activity_)
+    for e in SEMANTIC_REGISTRY
+    if e.pattern is not None
+)
+
 
 def lookup_entry(semantics: MessageSemantics) -> SemanticEntry:
     """Return the ``SemanticEntry`` for *semantics*.
@@ -626,14 +635,6 @@ def lookup_entry(semantics: MessageSemantics) -> SemanticEntry:
     return _ENTRY_MAP.get(semantics, _ENTRY_MAP[MessageSemantics.UNKNOWN])
 
 
-# ---------------------------------------------------------------------------
-# Re-export find_matching_semantics from the wire layer for callers that only
-# need pattern matching without the full registry.
-# ---------------------------------------------------------------------------
-
-from vultron.wire.as2.extractor import (  # noqa: E402  (after registry build)
-    find_matching_semantics,
-)
 from vultron.wire.as2.extractor import (  # noqa: E402
     extract_intent as _extract_intent,
 )
@@ -643,6 +644,7 @@ __all__ = [
     "SEMANTIC_REGISTRY",
     "lookup_entry",
     "find_matching_semantics",
+    "matches_semantics",
     "extract_event",
     "use_case_map",
     "semantics_to_activity_class",
@@ -703,3 +705,51 @@ def semantics_to_activity_class() -> dict[MessageSemantics, type[as_Activity]]:
 from vultron.wire.as2.vocab.base.objects.activities.base import (  # noqa: E402
     as_Activity,
 )
+
+
+def find_matching_semantics(activity: as_Activity) -> MessageSemantics:
+    """Find the MessageSemantics for the given AS2 activity.
+
+    Iterates ``SEMANTIC_REGISTRY`` in order and returns the first match.
+    Returns ``MessageSemantics.UNKNOWN_UNRESOLVABLE_OBJECT`` when no pattern
+    matches, the activity type is registered (has patterns), and ``object_``
+    is still a bare string URI (rehydration did not resolve it).
+    Returns ``MessageSemantics.UNKNOWN`` when the activity type is not
+    registered at all.
+
+    ``SEMANTIC_REGISTRY`` is the single source of truth for pattern-match order;
+    more specific patterns must appear before general ones.
+
+    Args:
+        activity: The AS2 activity to classify.
+
+    Returns:
+        The matching MessageSemantics value, or MessageSemantics.UNKNOWN.
+    """
+    for entry in SEMANTIC_REGISTRY:
+        if entry.pattern is not None and entry.pattern.match(activity):
+            return entry.semantics
+    obj = getattr(activity, "object_", None)
+    activity_type = str(activity.type_) if activity.type_ else ""
+    if isinstance(obj, str) and activity_type in _ACTIVITY_TYPES_WITH_PATTERNS:
+        return MessageSemantics.UNKNOWN_UNRESOLVABLE_OBJECT
+    return MessageSemantics.UNKNOWN
+
+
+def matches_semantics(
+    activity: as_Activity,
+    expected: MessageSemantics,
+) -> bool:
+    """Return True if *activity* matches the *expected* MessageSemantics.
+
+    Convenience predicate for test authors — eliminates the need to import
+    named ``*Pattern`` constants just to assert semantic identity.
+
+    Args:
+        activity: The AS2 activity to classify.
+        expected: The expected ``MessageSemantics`` value.
+
+    Returns:
+        True when ``find_matching_semantics(activity) == expected``.
+    """
+    return find_matching_semantics(activity) == expected

--- a/vultron/wire/as2/extractor.py
+++ b/vultron/wire/as2/extractor.py
@@ -5,8 +5,8 @@ location where AS2 vocabulary is translated to domain concepts (ARCH-03-001).
 This is stage 3 of the inbound pipeline: typed AS2 activity → MessageSemantics.
 
 Consolidates ActivityPattern definitions (formerly in vultron/activity_patterns.py)
-and the SEMANTICS_ACTIVITY_PATTERNS mapping + find_matching_semantics function
-(formerly in vultron/semantic_map.py) into a single extractor module.
+into a single module.  Pattern-to-semantics matching lives in
+``vultron.semantic_registry``, which iterates ``SEMANTIC_REGISTRY`` directly.
 """
 
 from datetime import datetime
@@ -336,112 +336,6 @@ AddParticipantStatusToParticipantPattern = ActivityPattern(
 )
 
 
-# ---------------------------------------------------------------------------
-# Pattern → semantics ordered lookup list (private).
-# The order of entries matters: find_matching_semantics returns the first match.
-# Specific patterns must appear before general ones that could also match.
-# ---------------------------------------------------------------------------
-
-_PATTERN_SEMANTICS: list[tuple[ActivityPattern, MessageSemantics]] = [
-    (CreateReportPattern, MessageSemantics.CREATE_REPORT),
-    (ReportSubmissionPattern, MessageSemantics.SUBMIT_REPORT),
-    (AckReportPattern, MessageSemantics.ACK_REPORT),
-    (ValidateReportPattern, MessageSemantics.VALIDATE_REPORT),
-    (InvalidateReportPattern, MessageSemantics.INVALIDATE_REPORT),
-    (CloseReportPattern, MessageSemantics.CLOSE_REPORT),
-    (CreateCaseActivityPattern, MessageSemantics.CREATE_CASE),
-    (UpdateCaseActivityPattern, MessageSemantics.UPDATE_CASE),
-    (EngageCasePattern, MessageSemantics.ENGAGE_CASE),
-    (DeferCasePattern, MessageSemantics.DEFER_CASE),
-    (AddReportToCaseActivityPattern, MessageSemantics.ADD_REPORT_TO_CASE),
-    (SuggestActorToCasePattern, MessageSemantics.SUGGEST_ACTOR_TO_CASE),
-    (
-        AcceptSuggestActorToCasePattern,
-        MessageSemantics.ACCEPT_SUGGEST_ACTOR_TO_CASE,
-    ),
-    (
-        RejectSuggestActorToCasePattern,
-        MessageSemantics.REJECT_SUGGEST_ACTOR_TO_CASE,
-    ),
-    (
-        OfferCaseOwnershipTransferActivityPattern,
-        MessageSemantics.OFFER_CASE_OWNERSHIP_TRANSFER,
-    ),
-    (
-        AcceptCaseOwnershipTransferActivityPattern,
-        MessageSemantics.ACCEPT_CASE_OWNERSHIP_TRANSFER,
-    ),
-    (
-        RejectCaseOwnershipTransferActivityPattern,
-        MessageSemantics.REJECT_CASE_OWNERSHIP_TRANSFER,
-    ),
-    (InviteActorToCasePattern, MessageSemantics.INVITE_ACTOR_TO_CASE),
-    (
-        AcceptInviteActorToCasePattern,
-        MessageSemantics.ACCEPT_INVITE_ACTOR_TO_CASE,
-    ),
-    (
-        RejectInviteActorToCasePattern,
-        MessageSemantics.REJECT_INVITE_ACTOR_TO_CASE,
-    ),
-    (CreateEmbargoEventPattern, MessageSemantics.CREATE_EMBARGO_EVENT),
-    (AddEmbargoEventToCasePattern, MessageSemantics.ADD_EMBARGO_EVENT_TO_CASE),
-    (
-        RemoveEmbargoEventFromCasePattern,
-        MessageSemantics.REMOVE_EMBARGO_EVENT_FROM_CASE,
-    ),
-    (
-        AnnounceEmbargoEventToCasePattern,
-        MessageSemantics.ANNOUNCE_EMBARGO_EVENT_TO_CASE,
-    ),
-    (InviteToEmbargoOnCasePattern, MessageSemantics.INVITE_TO_EMBARGO_ON_CASE),
-    (
-        AcceptInviteToEmbargoOnCasePattern,
-        MessageSemantics.ACCEPT_INVITE_TO_EMBARGO_ON_CASE,
-    ),
-    (
-        RejectInviteToEmbargoOnCasePattern,
-        MessageSemantics.REJECT_INVITE_TO_EMBARGO_ON_CASE,
-    ),
-    (CloseCasePattern, MessageSemantics.CLOSE_CASE),
-    (AnnounceLogEntryPattern, MessageSemantics.ANNOUNCE_CASE_LOG_ENTRY),
-    (
-        AnnounceVulnerabilityCasePattern,
-        MessageSemantics.ANNOUNCE_VULNERABILITY_CASE,
-    ),
-    (RejectLogEntryPattern, MessageSemantics.REJECT_CASE_LOG_ENTRY),
-    (CreateCaseParticipantPattern, MessageSemantics.CREATE_CASE_PARTICIPANT),
-    (
-        AddCaseParticipantToCasePattern,
-        MessageSemantics.ADD_CASE_PARTICIPANT_TO_CASE,
-    ),
-    (
-        RemoveCaseParticipantFromCasePattern,
-        MessageSemantics.REMOVE_CASE_PARTICIPANT_FROM_CASE,
-    ),
-    (CreateNotePattern, MessageSemantics.CREATE_NOTE),
-    (AddNoteToCaseActivityPattern, MessageSemantics.ADD_NOTE_TO_CASE),
-    (RemoveNoteFromCasePattern, MessageSemantics.REMOVE_NOTE_FROM_CASE),
-    (CreateCaseStatusActivityPattern, MessageSemantics.CREATE_CASE_STATUS),
-    (AddCaseStatusToCasePattern, MessageSemantics.ADD_CASE_STATUS_TO_CASE),
-    (
-        CreateParticipantStatusPattern,
-        MessageSemantics.CREATE_PARTICIPANT_STATUS,
-    ),
-    (
-        AddParticipantStatusToParticipantPattern,
-        MessageSemantics.ADD_PARTICIPANT_STATUS_TO_PARTICIPANT,
-    ),
-]
-
-# Frozenset of activity type strings that have at least one registered pattern.
-# Used by find_matching_semantics() to distinguish "known type with unresolvable
-# object_" from "genuinely unknown activity type".
-_ACTIVITY_TYPES_WITH_PATTERNS: frozenset[str] = frozenset(
-    str(pattern.activity_) for pattern, _ in _PATTERN_SEMANTICS
-)
-
-
 def extract_intent(
     activity: as_Activity,
     semantics: MessageSemantics,
@@ -720,33 +614,3 @@ def extract_intent(
         in_reply_to=_get_id(getattr(activity, "in_reply_to", None)),
         **extra_kwargs,
     )
-
-
-def find_matching_semantics(activity: as_Activity) -> MessageSemantics:
-    """Find the MessageSemantics for the given AS2 activity.
-
-    Iterates ``_PATTERN_SEMANTICS`` in order and returns the first match.
-    Returns ``MessageSemantics.UNKNOWN_UNRESOLVABLE_OBJECT`` when no pattern
-    matches, the activity type is registered (has patterns), and ``object_``
-    is still a bare string URI (rehydration did not resolve it).
-    Returns ``MessageSemantics.UNKNOWN`` when the activity type is not
-    registered at all.
-
-    Note:
-        Pattern ordering matters when patterns overlap. More specific patterns
-        must appear before more general ones.
-
-    Args:
-        activity: The AS2 activity to classify.
-
-    Returns:
-        The matching MessageSemantics value, or MessageSemantics.UNKNOWN.
-    """
-    for pattern, semantics in _PATTERN_SEMANTICS:
-        if pattern.match(activity):
-            return semantics
-    obj = getattr(activity, "object_", None)
-    activity_type = str(activity.type_) if activity.type_ else ""
-    if isinstance(obj, str) and activity_type in _ACTIVITY_TYPES_WITH_PATTERNS:
-        return MessageSemantics.UNKNOWN_UNRESOLVABLE_OBJECT
-    return MessageSemantics.UNKNOWN


### PR DESCRIPTION
---
Please note: Pull request submissions are subject to our
[Contribution Instructions](https://github.com/CERTCC/Vultron/blob/main/ContributionInstructions.md)

---

## Summary

Two Priority 473 architecture/refactor changes plus one review-driven
follow-up fix:

1. **Consolidate `find_matching_semantics` into `semantic_registry`**
   (closes #402)
2. **Introduce `CasePersistence` and `CaseOutboxPersistence` narrow Protocols**
   (closes #403)
3. **Harden `append-history` frontmatter validation and migrate the malformed
   RFC-403 history entry** (review follow-up)

---

## Changes

### Refactor: Consolidate semantic pattern matching (closes #402)

`extractor.py` contained a duplicate of `SEMANTIC_REGISTRY`
(`_PATTERN_SEMANTICS`) and a standalone `find_matching_semantics()` that
iterated it. This made `SEMANTIC_REGISTRY` in `semantic_registry.py` only a
partial source of truth.

- delete `_PATTERN_SEMANTICS`, `_ACTIVITY_TYPES_WITH_PATTERNS`, and
  `find_matching_semantics()` from `extractor.py`
- move `find_matching_semantics()` and `_ACTIVITY_TYPES_WITH_PATTERNS` into
  `semantic_registry.py`, derived from `SEMANTIC_REGISTRY`
- add `matches_semantics(activity, expected)` to `semantic_registry.py`
- update `datalayer_sqlite.py` and test imports to use the new location
- remove the redundant late `as_Activity` re-import in `semantic_registry.py`

### Narrow DataLayer port with CasePersistence Protocols (closes #403)

`DataLayer` exposes 20+ methods but most core use cases use 3-6. Replacing
`DataLayer` in function signatures with narrow Protocols enables
`MagicMock(spec=CasePersistence)` in tests and enforces dependency inversion
at the port boundary.

**New file**: `vultron/core/ports/case_persistence.py`

- `CasePersistence` - 7-method Protocol:
  `create`, `read`, `get`, `save`, `by_type`,
  `find_case_by_report_id`, `find_actor_by_short_id`
- `CaseOutboxPersistence(CasePersistence)` - adds `record_outbox_item`,
  `outbox_append`

`SqliteDataLayer` and `TinydbDataLayer` satisfy both structurally - no adapter
changes needed.

### Review follow-up: validate history entry frontmatter

The PR initially contained one malformed history entry without required
frontmatter. This follow-up:

- adds `HistoryEntryFrontmatter` as the single source of truth for required
  history-entry metadata
- makes `append-history` reject missing required fields instead of silently
  falling back
- makes monthly README generation fail loudly on malformed history entries
- migrates `implementation-260430111518.md` to
  `plan/history/2604/implementation/TASK-RFC-403.md` with valid frontmatter

---

## Test Results

Black, flake8, mypy, pyright, markdown lint, and pytest all pass locally.
Current pytest summary: `1986 passed, 12 skipped, 182 deselected`.

---

## Checklist

- [x] All linters pass (`black`, `flake8`, `mypy`, `pyright`, markdown lint)
- [x] All tests pass (`pytest`)
- [x] `SEMANTIC_REGISTRY` is now the single source of truth for pattern
      matching
- [x] Core domain code no longer imports the full `DataLayer` port
- [x] `append-history` now validates required frontmatter and the malformed
      RFC-403 history entry has been migrated
