### PR TITLE
feat: BT test harness, codebase docs, outbox enforcement, CASE_OWNER, factories scaffold

### DIFF
--- a/docs/codebase/ARCHITECTURE.md
+++ b/docs/codebase/ARCHITECTURE.md
@@ -1,0 +1,73 @@
+# Architecture
+
+## Core Sections (Required)
+
+### 1) Architectural Style
+
+- Primary style: layered hexagonal architecture with an explicit wire-format
+  layer and event-driven background processing
+- Why this classification: the repository guidance and sampled modules separate
+  `core`, `wire`, and `adapters`, with `DataLayer` and dispatcher protocols in
+  `core/ports/`, AS2 translation in `wire/`, and FastAPI/SQLite/HTTP delivery
+  code in adapters.
+- Primary constraints:
+  1. Core code must remain isolated from FastAPI and adapter types.
+  2. AS2-to-domain mapping is centralized in the semantic extraction path.
+  3. HTTP processing uses background tasks and outbox draining instead of doing
+     all work inline in the request handler.
+
+### 2) System Flow
+
+```text
+HTTP request -> FastAPI app/router -> inbox handler + rehydration ->
+semantic extraction -> dispatcher/use case -> DataLayer + outbox ->
+outbox monitor/delivery queue -> peer inbox HTTP POST
+```
+
+Evidence-backed flow:
+
+1. Docker and local API startup target
+   `vultron.adapters.driving.fastapi.main:app`.
+2. The root app mounts `app_v2` at `/api/v2`.
+3. Actor inbox handling rehydrates AS2 activities and extracts a domain event.
+4. The dispatcher looks up the use-case class from the semantic registry map.
+5. Use cases persist/read state through the `DataLayer` port and adapter.
+6. Outbox processing is drained by a background monitor and delivered over HTTP.
+
+### 3) Layer/Module Responsibilities
+
+| Layer or module | Owns | Must not own | Evidence |
+|-----------------|------|--------------|----------|
+| `vultron/core/` | Domain events, ports, dispatcher, use cases | FastAPI and adapter details | `AGENTS.md`, `vultron/core/ports/datalayer.py`, `vultron/core/dispatcher.py` |
+| `vultron/wire/as2/` | AS2 vocabulary, pattern matching, semantic extraction | Case lifecycle behavior | `vultron/wire/as2/extractor.py` |
+| `vultron/adapters/driving/fastapi/` | HTTP routing, dependency injection, background task scheduling | Persistent model ownership | `vultron/adapters/driving/fastapi/app.py`, `vultron/adapters/driving/fastapi/deps.py` |
+| `vultron/adapters/driven/` | SQLite persistence and outbound HTTP delivery | FastAPI request translation | `vultron/adapters/driven/datalayer_sqlite.py`, `vultron/adapters/driven/delivery_queue.py` |
+| `vultron/demo/` | Operator/demo CLI workflows and seeding | Authoritative storage API | `vultron/demo/cli.py`, `vultron/demo/utils.py` |
+
+### 4) Reused Patterns
+
+| Pattern | Where found | Why it exists |
+|---------|-------------|---------------|
+| Port/adapter split | `vultron/core/ports/datalayer.py`, `vultron/adapters/driven/datalayer.py` | Keep core independent of storage implementation |
+| Dispatcher + routing table | `vultron/core/dispatcher.py`, `vultron/semantic_registry.py` | Route semantic events to use cases without router-specific logic |
+| Dependency injection | `vultron/adapters/driving/fastapi/deps.py` | Centralize shared/shared-scoped DataLayer and TriggerService seams |
+| Background worker loop | `vultron/adapters/driving/fastapi/outbox_monitor.py` | Drain outboxes asynchronously for all actors |
+| Behavior trees | `docs/adr/0002-model-processes-with-behavior-trees.md`, `AGENTS.md` | Model multi-state CVD workflows and automation paths |
+
+### 5) Known Architectural Risks
+
+- Process-local singleton/stateful wiring: the module-level dispatcher and
+  process-local DataLayer façade make startup order and process model important.
+- Shared-vs-actor-scoped DataLayer behavior is subtle and requires canonical
+  actor-ID normalization to keep inbox/outbox operations consistent.
+
+### 6) Evidence
+
+- `AGENTS.md`
+- `notes/architecture-ports-and-adapters.md`
+- `vultron/adapters/driving/fastapi/main.py`
+- `vultron/adapters/driving/fastapi/app.py`
+- `vultron/adapters/driving/fastapi/inbox_handler.py`
+- `vultron/core/dispatcher.py`
+- `vultron/semantic_registry.py`
+- `vultron/adapters/driving/fastapi/outbox_monitor.py`

--- a/docs/codebase/CONCERNS.md
+++ b/docs/codebase/CONCERNS.md
@@ -1,0 +1,63 @@
+# Codebase Concerns
+
+## Core Sections (Required)
+
+### 1) Top Risks (Prioritized)
+
+| Severity | Concern | Evidence | Impact | Suggested action |
+|----------|---------|----------|--------|------------------|
+| high | Runtime modules import `httpx` and `requests`, but those packages are not declared in `project.dependencies` | `vultron/adapters/driven/delivery_queue.py`, `vultron/demo/utils.py`, `pyproject.toml`, `docker/Dockerfile` | Fresh non-dev installs may fail when outbound delivery or demos run | Decide whether these are supported runtime paths, then add the packages to the appropriate dependency set |
+| high | Shared and actor-scoped DataLayer behavior depends on canonical actor-ID resolution and process-local façades | `vultron/adapters/driving/fastapi/deps.py`, `vultron/adapters/driving/fastapi/inbox_handler.py`, `vultron/adapters/driven/datalayer.py` | Subtle routing/storage bugs can appear when queue and object reads use different scopes | Keep scope boundaries explicit and add regression tests around actor-ID normalization |
+| medium | The automated scan over-reports generated/cache artifacts and under-reports real infra/security files | `docs/codebase/.codebase-scan.txt`, `docker/docker-compose.yml`, `.github/dependabot.yml` | Repository mapping or metrics can mislead maintainers if consumed without manual correction | Update the scan ignore list or post-processing rules before using it as a durable source |
+| medium | Outbox draining is implemented as a 1-second polling loop over all actor DataLayers | `vultron/adapters/driving/fastapi/outbox_monitor.py` | Polling cost grows with actor count and can hide queue-depth issues | Consider event-driven wakeups or queue metrics if actor count grows |
+
+### 2) Technical Debt
+
+| Debt item | Why it exists | Where | Risk if ignored | Suggested fix |
+|-----------|---------------|-------|-----------------|---------------|
+| Outstanding TODOs in protocol/state code | Several production modules still carry TODO markers | `docs/codebase/.codebase-scan.txt` | Ambiguous future work and partially-finished refactors accumulate | Triage TODOs into tracked issues or implementation-plan items |
+| Documentation/code drift around architecture targets | Notes describe target architecture as well as current structure | `notes/architecture-ports-and-adapters.md`, `AGENTS.md` | New contributors may confuse target layout with what exists today | Keep onboarding docs explicitly split into “current reality” vs “target direction” |
+| High churn in planning and specification files | Planning/spec docs change frequently | `docs/codebase/.codebase-scan.txt` | Agent guidance and task context can go stale quickly | Treat `plan/` and guidance docs as volatile areas during onboarding |
+
+### 3) Security Concerns
+
+| Risk | OWASP category (if applicable) | Evidence | Current mitigation | Gap |
+|------|--------------------------------|----------|--------------------|-----|
+| No explicit auth/signing was evident in sampled outbound or inbound HTTP delivery paths | A01 / N/A | `vultron/adapters/driven/delivery_queue.py`, `vultron/adapters/driving/fastapi/app.py`, `vultron/adapters/driving/fastapi/routers/actors.py` | Local actor IDs and inbox URLs are explicit | Authentication, authorization, or message-signing behavior was not evident in sampled files |
+| Secret handling appears to rely on plain env vars and Compose files | A05 / N/A | `.env.example`, `docker/docker-compose.yml`, `docker/docker-compose-multi-actor.yml` | Example files avoid committed secrets | No secret-rotation or secret-manager integration was found |
+
+### 4) Performance and Scaling Concerns
+
+| Concern | Evidence | Current symptom | Scaling risk | Suggested improvement |
+|---------|----------|-----------------|-------------|-----------------------|
+| Polling outbox monitor scans every actor DataLayer once per second | `vultron/adapters/driving/fastapi/outbox_monitor.py` | Constant polling work even when queues are empty | More actors mean more unnecessary wakeups and reads | Add queue-driven wakeups or adaptive polling |
+| SQLite is the only active persistence backend exposed by the façade | `vultron/adapters/driven/datalayer.py`, `vultron/adapters/driven/datalayer_sqlite.py` | Local-file DB is simple for tests and demos | Multi-writer or higher-volume deployments may hit SQLite limits | Define the next backend/operational profile before scaling beyond demos |
+
+### 5) Fragile/High-Churn Areas
+
+| Area | Why fragile | Churn signal | Safe change strategy |
+|------|-------------|-------------|----------------------|
+| `plan/` documentation set | Planning/history docs change very frequently | `plan/IMPLEMENTATION_PLAN.md`, `plan/IMPLEMENTATION_NOTES.md`, `plan/IMPLEMENTATION_HISTORY.md` top the 90-day churn list in `docs/codebase/.codebase-scan.txt` | Read current files immediately before editing; expect stale assumptions |
+| `AGENTS.md` and spec guidance | Repo rules change often and affect coding behavior | `AGENTS.md`, `specs/README.md` both appear in high-churn output | Re-read guidance before non-trivial changes |
+| Behavior and semantic extraction code | These modules encode protocol/state semantics and have recent churn | `vultron/core/behaviors/case/nodes.py`, `vultron/core/behaviors/report/nodes.py`, `vultron/wire/as2/extractor.py` appear in high-churn output | Make narrow changes with focused tests and explicit evidence checks |
+
+### 6) `[ASK USER]` Questions
+
+1. [ASK USER] Which HTTP entrypoint should onboarding docs treat as canonical:
+   `vultron.adapters.driving.fastapi.main:app` for deployment, or direct
+   `app_v2` usage for local development and tests?
+2. [ASK USER] Should `httpx` and `requests` be documented as supported runtime
+   dependencies and moved into `project.dependencies`, or are the delivery/demo
+   code paths intentionally outside the supported packaged runtime?
+
+### 7) Evidence
+
+- `docs/codebase/.codebase-scan.txt`
+- `pyproject.toml`
+- `docker/Dockerfile`
+- `vultron/adapters/driving/fastapi/deps.py`
+- `vultron/adapters/driving/fastapi/inbox_handler.py`
+- `vultron/adapters/driving/fastapi/outbox_monitor.py`
+- `vultron/adapters/driven/datalayer.py`
+- `vultron/adapters/driven/delivery_queue.py`
+- `vultron/demo/utils.py`

--- a/docs/codebase/CONVENTIONS.md
+++ b/docs/codebase/CONVENTIONS.md
@@ -1,0 +1,62 @@
+# Coding Conventions
+
+## Core Sections (Required)
+
+### 1) Naming Rules
+
+| Item | Rule | Example | Evidence |
+|------|------|---------|----------|
+| Files | Snake_case Python module names | `datalayer_sqlite.py`, `outbox_monitor.py` | `docs/codebase/.codebase-scan.txt`, `vultron/adapters/driven/datalayer_sqlite.py` |
+| Functions/methods | Snake_case verbs; internal/private helpers use leading `_` | `get_trigger_service`, `_deliver_with_retry` | `vultron/adapters/driving/fastapi/deps.py`, `vultron/adapters/driven/delivery_queue.py` |
+| Types/interfaces | PascalCase for classes and Protocols | `SqliteDataLayer`, `OutboxMonitor`, `DataLayer` | `vultron/adapters/driven/datalayer_sqlite.py`, `vultron/core/ports/datalayer.py` |
+| Constants/env vars | UPPER_CASE module constants and env names | `DEFAULT_MAX_RETRIES`, `VULTRON_DB_URL` | `vultron/adapters/driven/delivery_queue.py`, `vultron/adapters/driven/datalayer_sqlite.py` |
+
+### 2) Formatting and Linting
+
+- Formatter: `black` with line length `79` in `pyproject.toml`
+- Linter: `flake8` in `.flake8`; markdown is linted by `markdownlint-cli2`
+- Most relevant enforced rules: `E203` and `E501` are ignored in flake8,
+  `__init__.py` may ignore `F401`, markdown uses dash-style unordered lists
+- Run commands: `uv run black vultron/ test/`, `uv run flake8 vultron/ test/`,
+  `uv run mypy`, `uv run pyright`, `./mdlint.sh`
+
+### 3) Import and Module Conventions
+
+- Import grouping/order: standard library, third-party, then Vultron package
+  imports is the dominant pattern in sampled files.
+- Alias vs relative import policy: package-qualified absolute imports dominate;
+  thin façade modules re-export selected symbols for callers.
+- Public exports/barrel policy: small `__init__.py` re-exports exist, but a
+  repo-wide barrel-export policy was not explicitly documented in sampled files.
+  `[TODO]`
+
+### 4) Error and Logging Conventions
+
+- Error strategy by layer: core raises domain-specific exceptions; driving
+  adapters translate failures into HTTP errors or log-and-retry behavior.
+- Logging style and required context fields: the repo guidance expects log
+  levels `DEBUG`/`INFO`/`WARNING`/`ERROR`/`CRITICAL` and encourages
+  `activity_id` and `actor_id`; FastAPI logging is wired through Uvicorn
+  handlers and `LOG_LEVEL`.
+- Sensitive-data redaction rules: `[TODO]` no explicit redaction policy was
+  found in the sampled runtime/config files.
+
+### 5) Testing Conventions
+
+- Test file naming/location rule: `test/` mirrors `vultron/`, and test modules
+  use `test_*.py`
+- Mocking strategy norm: prefer `monkeypatch`, dependency overrides, and cheap
+  real components such as in-memory SQLite where possible
+- Coverage expectation: `test/AGENTS.md` states 80%+ overall coverage and 100%
+  for several critical paths; no committed coverage-report config was found
+
+### 6) Evidence
+
+- `AGENTS.md`
+- `test/AGENTS.md`
+- `pyproject.toml`
+- `.flake8`
+- `.pre-commit-config.yaml`
+- `.markdownlint-cli2.yaml`
+- `vultron/adapters/driving/fastapi/deps.py`
+- `vultron/adapters/driven/delivery_queue.py`

--- a/docs/codebase/INTEGRATIONS.md
+++ b/docs/codebase/INTEGRATIONS.md
@@ -1,0 +1,54 @@
+# External Integrations
+
+## Core Sections (Required)
+
+### 1) Integration Inventory
+
+| System | Type (API/DB/Queue/etc) | Purpose | Auth model | Criticality | Evidence |
+|--------|---------------------------|---------|------------|-------------|----------|
+| SQLite via SQLModel | DB | Persist Vultron objects and inbox/outbox queue entries | Local file or in-memory DB URL; no separate DB auth shown | high | `vultron/adapters/driven/datalayer_sqlite.py`, `docker/docker-compose-multi-actor.yml` |
+| Peer actor inboxes | API | Deliver outbound AS2 activities with HTTP POST | `[TODO]` no auth/signing shown in sampled delivery code | high | `vultron/adapters/driven/delivery_queue.py` |
+| Demo client to local API | API | Drive seeded/demo scenarios over HTTP | None shown beyond local base URL config | medium | `vultron/demo/utils.py`, `vultron/demo/cli.py` |
+| MCP trigger adapter | Tool/API surface | Expose trigger use cases to MCP-compatible callers once registered | `[TODO]` not shown in current file | low | `vultron/adapters/driving/mcp_server.py` |
+
+### 2) Data Stores
+
+| Store | Role | Access layer | Key risk | Evidence |
+|-------|------|--------------|----------|----------|
+| SQLite `vultron_objects` | Primary object store | `SqliteDataLayer` | Single-node/local-file scaling and runtime dependency on local disk/SQLite semantics | `vultron/adapters/driven/datalayer_sqlite.py` |
+| SQLite `vultron_queue` | Inbox/outbox queue persistence | `SqliteDataLayer` plus outbox/inbox handlers | Queue semantics are process-local and rely on actor scoping consistency | `vultron/adapters/driven/datalayer_sqlite.py`, `vultron/adapters/driving/fastapi/inbox_handler.py` |
+| Named Docker volumes per actor | Persist per-actor SQLite DBs in multi-actor demos | Docker Compose | Operational complexity grows with actor count | `docker/docker-compose-multi-actor.yml` |
+
+### 3) Secrets and Credentials Handling
+
+- Credential sources: environment variables and Docker Compose env blocks
+- Hardcoding checks: no API keys or secrets were present in the sampled config
+  files; committed examples mostly define names and base URLs
+- Rotation or lifecycle notes: `[TODO]` no secret-rotation or external secret
+  manager configuration was found
+
+### 4) Reliability and Failure Behavior
+
+- Retry/backoff behavior: implemented for outbound HTTP delivery with
+  exponential backoff and per-recipient failure isolation
+- Timeout policy: outbound inbox delivery uses a 5.0 second HTTP timeout;
+  Docker health checks define 2-5 second probe timeouts
+- Circuit-breaker or fallback behavior: none found in sampled runtime files
+
+### 5) Observability for Integrations
+
+- Logging around external calls: yes; delivery attempts and demo HTTP calls log
+  status and failures
+- Metrics/tracing coverage: no metrics or tracing integration was found in the
+  sampled runtime files
+- Missing visibility gaps: no structured metrics/tracing for delivery retries,
+  queue depth, or DB latency were found
+
+### 6) Evidence
+
+- `vultron/adapters/driven/datalayer_sqlite.py`
+- `vultron/adapters/driven/delivery_queue.py`
+- `vultron/demo/utils.py`
+- `docker/docker-compose.yml`
+- `docker/docker-compose-multi-actor.yml`
+- `.env.example`

--- a/docs/codebase/STACK.md
+++ b/docs/codebase/STACK.md
@@ -1,0 +1,68 @@
+# Technology Stack
+
+## Core Sections (Required)
+
+### 1) Runtime Summary
+
+| Area | Value | Evidence |
+|------|-------|----------|
+| Primary language | Python | `pyproject.toml`, `docs/codebase/.codebase-scan.txt` |
+| Runtime + version | Python `>=3.12`; Docker and CI use Python 3.13 | `pyproject.toml`, `docker/Dockerfile`, `.github/workflows/python-app.yml` |
+| Package manager | `uv` for dependency sync and command execution | `Makefile`, `.github/workflows/python-app.yml`, `docker/Dockerfile` |
+| Module/build system | Setuptools build backend with `uv build` packaging | `pyproject.toml`, `.github/workflows/python-app.yml` |
+
+### 2) Production Frameworks and Dependencies
+
+| Dependency | Version | Role in system | Evidence |
+|------------|---------|----------------|----------|
+| `fastapi` | `>=0.136.0` | HTTP API and router layer | `pyproject.toml`, `vultron/adapters/driving/fastapi/app.py` |
+| `uvicorn` | `>=0.46.0` | ASGI server for the API | `pyproject.toml`, `docker/Dockerfile` |
+| `pydantic` | `==2.13.3` | Model validation and typed request/object models | `pyproject.toml`, `vultron/core/ports/datalayer.py` |
+| `sqlmodel` | `>=0.0.38` | SQLite-backed persistence adapter | `pyproject.toml`, `vultron/adapters/driven/datalayer_sqlite.py` |
+| `py-trees` | `>=2.2.0` | Behavior-tree implementation support | `pyproject.toml`, `docs/adr/0002-model-processes-with-behavior-trees.md` |
+| `transitions` | `>=0.9.3` | State-machine support | `pyproject.toml` |
+| `pyyaml` | `>=6.0` | YAML-backed config and metadata loading | `pyproject.toml`, `vultron/demo/cli.py` |
+| `mkdocs` + Material plugins | mixed | Built documentation site and reference docs | `pyproject.toml`, `mkdocs.yml` |
+
+### 3) Development Toolchain
+
+| Tool | Purpose | Evidence |
+|------|---------|----------|
+| `black` | Python formatting | `pyproject.toml`, `.pre-commit-config.yaml` |
+| `flake8` | Python linting | `pyproject.toml`, `.flake8`, `.github/workflows/python-app.yml` |
+| `mypy` | Static type checking | `pyproject.toml`, `.github/workflows/python-app.yml` |
+| `pyright` | Static type checking | `pyproject.toml`, `pyrightconfig.json`, `.github/workflows/python-app.yml` |
+| `pytest` | Automated tests | `pyproject.toml`, `test/AGENTS.md` |
+| `markdownlint-cli2` | Markdown linting/fixing | `.pre-commit-config.yaml`, `.markdownlint-cli2.yaml` |
+| `pre-commit` | Hook orchestration | `pyproject.toml`, `.pre-commit-config.yaml` |
+| `npm` packages `markdownlint` and `madr` | Markdown/ADR authoring support | `package.json` |
+
+### 4) Key Commands
+
+```bash
+uv sync --dev
+uv build
+uv run pytest --tb=short 2>&1 | tail -5
+uv run flake8 vultron/ test/
+```
+
+### 5) Environment and Config
+
+- Config sources: `.env.example`, `pyproject.toml`, `docker/docker-compose.yml`,
+  `docker/docker-compose-multi-actor.yml`
+- Required env vars seen in committed files: `PROJECT_NAME`, `LOG_LEVEL`,
+  `VULTRON_DB_URL`, `VULTRON_BASE_URL`, `VULTRON_API_BASE_URL`,
+  `VULTRON_ACTOR_ID`, `VULTRON_SEED_CONFIG`, `VULTRON_ACTOR_NAME`,
+  `VULTRON_ACTOR_TYPE`
+- Deployment/runtime constraints: default persistence is SQLite; Docker Compose
+  runs the API with `uvicorn vultron.adapters.driving.fastapi.main:app`; the
+  multi-actor setup expects one SQLite volume per actor service.
+
+### 6) Evidence
+
+- `pyproject.toml`
+- `docker/Dockerfile`
+- `.github/workflows/python-app.yml`
+- `Makefile`
+- `package.json`
+- `docs/codebase/.codebase-scan.txt`

--- a/docs/codebase/STRUCTURE.md
+++ b/docs/codebase/STRUCTURE.md
@@ -1,0 +1,59 @@
+# Codebase Structure
+
+## Core Sections (Required)
+
+### 1) Top-Level Map
+
+| Path | Purpose | Evidence |
+|------|---------|----------|
+| `vultron/` | Main application package: adapters, core logic, wire models, demos, metadata tooling | `AGENTS.md`, `docs/codebase/.codebase-scan.txt` |
+| `test/` | Pytest suite mirroring `vultron/` | `test/AGENTS.md`, `pyproject.toml` |
+| `docs/` | MkDocs source for published documentation site | `mkdocs.yml`, `docs/codebase/.codebase-scan.txt` |
+| `doc/` | Example and legacy supporting docs distinct from MkDocs site | `README.md`, `doc/README.md` |
+| `notes/` | Durable design notes and architecture guidance | `notes/README.md`, `AGENTS.md` |
+| `specs/` | Formal requirement files and spec tooling inputs | `specs/README.md` |
+| `docker/` | Dockerfiles, compose stacks, and seed configs for demos | `docker/README.md`, `docker/docker-compose.yml` |
+| `integration_tests/` | Manual acceptance/integration scripts outside pytest | `integration_tests/README.md` |
+| `plan/` | Priorities, history, and implementation planning artifacts | `docs/codebase/.codebase-scan.txt`, `AGENTS.md` |
+| `.github/` | CI workflows, repo automation, and authoring instructions | `.github/workflows/python-app.yml`, `.github/dependabot.yml` |
+
+### 2) Entry Points
+
+- Main runtime entry: `vultron/adapters/driving/fastapi/main.py:app`
+- Secondary entry points (worker/cli/jobs): `vultron/adapters/driving/fastapi/app.py:app_v2`,
+  `vultron/demo/cli.py:main`, MCP adapter functions in
+  `vultron/adapters/driving/mcp_server.py`
+- How entry is selected (script/config): Docker runs
+  `uvicorn vultron.adapters.driving.fastapi.main:app`; CLI entry points are
+  declared under `[project.scripts]` in `pyproject.toml`.
+
+### 3) Module Boundaries
+
+| Boundary | What belongs here | What must not be here |
+|----------|-------------------|------------------------|
+| `vultron/core/` | Domain models, ports, dispatch, use cases, behavior trees | FastAPI imports, adapter types, direct AS2 parsing |
+| `vultron/wire/` | AS2 parsing, vocabulary, semantic extraction, rehydration | Case-handling business logic |
+| `vultron/adapters/driving/` | HTTP/MCP-facing translation into core calls | Persistent domain state ownership |
+| `vultron/adapters/driven/` | Persistence and outbound delivery implementations | Framework-facing request handling |
+| `vultron/demo/` | CLI demos and workflow scripts | Authoritative domain interfaces |
+| `test/` | Mirrored test modules and fixture layers | Production runtime code |
+
+### 4) Naming and Organization Rules
+
+- File naming pattern: snake_case Python modules, for example
+  `datalayer_sqlite.py`, `outbox_monitor.py`, `three_actor_demo.py`
+- Directory organization pattern: primarily layer/domain based
+  (`core/`, `wire/`, `adapters/`, `demo/`, `metadata/`)
+- Import aliasing or path conventions: package-qualified imports dominate;
+  thin re-export modules exist for convenience, for example
+  `vultron.adapters.driven.datalayer` and
+  `vultron.adapters.driving.fastapi.routers.__init__`.
+
+### 5) Evidence
+
+- `docs/codebase/.codebase-scan.txt`
+- `pyproject.toml`
+- `docker/Dockerfile`
+- `AGENTS.md`
+- `test/AGENTS.md`
+- `vultron/adapters/driving/fastapi/main.py`

--- a/docs/codebase/TESTING.md
+++ b/docs/codebase/TESTING.md
@@ -1,0 +1,60 @@
+# Testing Patterns
+
+## Core Sections (Required)
+
+### 1) Test Stack and Commands
+
+- Primary test framework: `pytest` (declared in dev dependencies)
+- Assertion/mocking tools: builtin `assert`, `monkeypatch`, `caplog`,
+  FastAPI dependency overrides, local `conftest.py` fixtures
+- Commands:
+
+```bash
+uv run pytest --tb=short 2>&1 | tail -5
+uv run pytest
+uv run pytest -m integration
+make integration-test
+```
+
+### 2) Test Layout
+
+- Test file placement pattern: dedicated `test/` tree mirroring `vultron/`
+- Naming convention: `test_*.py`
+- Setup files and where they run: root `test/conftest.py` establishes an
+  in-memory SQLite default and spec marker behavior; nested `conftest.py`
+  files add area-specific fixtures
+
+### 3) Test Scope Matrix
+
+| Scope | Covered? | Typical target | Notes |
+|-------|----------|----------------|-------|
+| Unit | yes | core use cases, adapters, vocabulary, behavior nodes | default pytest run excludes `integration` marker |
+| Integration | yes | full HTTP stack and demo flows | `integration` marker exists in pytest config |
+| E2E | yes | Docker-backed acceptance scenarios | manual scripts under `integration_tests/` are outside pytest |
+
+### 4) Mocking and Isolation Strategy
+
+- Main mocking approach: `monkeypatch`, dependency overrides, and fixture-based
+  DataLayer setup
+- Isolation guarantees: root test config sets `VULTRON_DB_URL` to in-memory
+  SQLite and resets cached DataLayer instances before and after the session
+- Common failure mode in tests: fixture scope matters because shared and
+  actor-scoped DataLayer seams are injected through layered `conftest.py`
+  files
+
+### 5) Coverage and Quality Signals
+
+- Coverage tool + threshold: threshold expectations are documented in
+  `test/AGENTS.md` (80%+ overall; 100% on several critical paths); coverage
+  tool/config file is `[TODO]`
+- Current reported coverage: `[TODO]` no committed coverage report was found
+- Known gaps/flaky areas: acceptance tests in `integration_tests/` are manual
+  and not part of the default pytest run
+
+### 6) Evidence
+
+- `pyproject.toml`
+- `test/AGENTS.md`
+- `test/conftest.py`
+- `integration_tests/README.md`
+- `.github/workflows/python-app.yml`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -168,11 +168,11 @@ nav:
       - VFDPXa: 'reference/case_states/state__v__f__d__p__x_a.md'
       - VFDPXA: 'reference/case_states/state__v__f__d__p__x__a_.md'
     - Code:
-        - vultron: 'reference/code/index.md'
-        - case_states: 'reference/code/case_states.md'
-        - API:
-            - Actor Inbox Handler: 'reference/code/api/actor_inbox_handler.md'
-        - Behavior Trees:
+      - vultron: 'reference/code/index.md'
+      - case_states: 'reference/code/case_states.md'
+      - API:
+          - Actor Inbox Handler: 'reference/code/api/actor_inbox_handler.md'
+      - Behavior Trees:
           - BT: 'reference/code/bt/behavior_trees.md'
           - Base: 'reference/code/bt//bt_base.md'
           - Nodes: 'reference/code/bt/bt_base_nodes.md'
@@ -180,7 +180,7 @@ nav:
           - Robot Demo: 'reference/code/bt/robot_demo.md'
           - Vultrabot Demo: 'reference/code/bt/vultrabot_demo.md'
           - Vultron Case State BT: 'reference/code/bt/case_states.md'
-        - ActivityStreams Vocabulary:
+      - ActivityStreams Vocabulary:
           - 'reference/code/as_vocab/index.md'
           - Base Package: 'reference/code/as_vocab/as_base.md'
           - Base Objects: 'reference/code/as_vocab/as_objects.md'
@@ -189,11 +189,19 @@ nav:
           - Vultron Extensions: 'reference/code/as_vocab/vultron.md'
           - Vultron Objects: 'reference/code/as_vocab/v_objects.md'
           - Vultron Activities: 'reference/code/as_vocab/v_activities.md'
-        - Demo Package:
+      - Demo Package:
           - 'reference/code/demo/index.md'
           - CLI: 'reference/code/demo/cli.md'
           - Utilities: 'reference/code/demo/utils.md'
           - Demo Scripts: 'reference/code/demo/demos.md'
+    - Codebase:
+      - 'codebase/STACK.md'
+      - 'codebase/STRUCTURE.md'
+      - 'codebase/ARCHITECTURE.md'
+      - 'codebase/CONVENTIONS.md'
+      - 'codebase/INTEGRATIONS.md'
+      - 'codebase/TESTING.md'
+      - 'codebase/CONCERNS.md'
     - Ontology:
       - 'reference/ontology/index.md'
       - Vultron_AS: 'reference/ontology/vultron_as.md'

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -65,7 +65,7 @@ backward-compat alias.
   value combinable with VENDOR, COORDINATOR, etc.
 - All existing CVDRoles-based tests pass.
 
-- [ ] BTND5.1: Add `CASE_OWNER` flag to `CVDRoles` (BTND-05-001)
+- [x] BTND5.1: Add `CASE_OWNER` flag to `CVDRoles` (BTND-05-001)
 
 ### BTND5.2 — Replace `CreateInitialVendorParticipant` with `CreateCaseOwnerParticipant`
 
@@ -207,7 +207,7 @@ only inside factory functions.
   `EmProposeEmbargoRef` renamed to `_EmProposeEmbargoRef`
 - All linters and tests pass
 
-- [ ] AF.1 Create `factories/errors.py` with `VultronActivityConstructionError`
+- [x] AF.1 Create `factories/errors.py` with `VultronActivityConstructionError`
 - [ ] AF.2 Create `factories/report.py` (6 report activity factory functions)
 - [ ] AF.3 Create `factories/case.py` (16 case activity factory functions)
 - [ ] AF.4 Create `factories/embargo.py` (8 embargo activity factory functions)
@@ -299,34 +299,6 @@ Refactor `SeedConfig`/`LocalActorConfig` to `pydantic-settings`.
 
 - [ ] TRIGCLASS.2: Implement `add-object-to-case` trigger; update
   `add-report-to-case` to delegate to it (TRIG-10-001, TRIG-10-002)
-
----
-
-## TASK-OUTBOX-TO — Outbox `to:` Field Enforcement
-
-**Source**: `specs/outbox.yaml` OX-08-001, OX-08-002, OX-08-004;
-`notes/outbox.md`
-
-All outbound Vultron activities are direct messages and MUST have a non-empty
-`to:` field. Enforce this at `handle_outbox_item` so no activity can leave the
-outbox without an addressee.
-
-**Acceptance criteria:**
-
-- `VultronOutboxToFieldMissingError(VultronError)` exists in `vultron/errors.py`
-  with `activity_id` and `activity_type` attributes.
-- `handle_outbox_item` in `vultron/adapters/driving/fastapi/outbox_handler.py`
-  raises `VultronOutboxToFieldMissingError` when `to:` is absent or an empty
-  list; logs `WARNING` when `cc`/`bto`/`bcc` are non-empty.
-- Existing `VultronOutboxObjectIntegrityError` check is unmodified.
-- Unit tests cover the missing-`to:` raise and the `cc`/`bto`/`bcc` warning
-  branches.
-
-- [ ] OUTBOX-TO.1 Add `VultronOutboxToFieldMissingError` to `vultron/errors.py`
-  (OX-08-001, OX-08-002)
-- [ ] OUTBOX-TO.2 Add `to:` presence check and `cc`/`bto`/`bcc` warning to
-  `handle_outbox_item` (OX-08-001, OX-08-002, OX-08-004)
-- [ ] OUTBOX-TO.3 Add unit tests for both branches
 
 ---
 

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -14,31 +14,6 @@ PD-06). Do not infer priority from section order.
 
 ---
 
-## TASK-RFC-401 — BTTestScenario Deep-Module Test Harness
-
-**Source**: <https://github.com/CERTCC/Vultron/issues/401>
-
-`test/core/behaviors/report/test_nodes.py` and
-`test/core/behaviors/case/test_nodes.py` bypass the
-`BTBridge.execute_with_setup()` lifecycle via duplicated
-`setup_node_blackboard()` helpers. Introduce `BTTestScenario` in
-`test/core/behaviors/bt_harness.py` as the single correct path for all BT
-tests (leaf nodes and trees alike).
-
-**Acceptance criteria:**
-
-- `test/core/behaviors/bt_harness.py` exists with `BTTestScenario` class and
-  `bt_scenario`, `bt_scenario_factory`, `shared_dl_actors` fixtures.
-- No `setup_node_blackboard()` / direct `node.update()` /
-  `node.blackboard.register_key()` patterns in `test_nodes.py` files.
-- All existing tests pass.
-
-- [ ] RFC-401.1: Create `test/core/behaviors/bt_harness.py`
-- [ ] RFC-401.2: Rewrite `test/core/behaviors/report/test_nodes.py` using harness
-- [ ] RFC-401.3: Rewrite `test/core/behaviors/case/test_nodes.py` using harness
-
----
-
 ## TASK-CP-CLEANUP — Remove Deprecated `CasePersistence` Compatibility Methods
 
 **Source**: `specs/datalayer.yaml` DL-04-005;

--- a/plan/history/2604/README.md
+++ b/plan/history/2604/README.md
@@ -7,9 +7,11 @@
 | 2026-04-30 | priority | Priority 472 | Priority 472 — Docs Batch (LaTeX Fixes and Versioning Updates) |
 | 2026-04-30 | implementation | BUG-26043001 | BUG-26043001 — append-history: validate required frontmatter fields |
 | 2026-04-30 | implementation | P472-LATEX | Fix block-math opening delimiter in conclusion.md (#234, #235) |
+| 2026-04-30 | implementation | RFC-400 | RFC-400 TriggerService Facade |
 | 2026-04-30 | implementation | TASK-BUG-386 | BUG-386 — Defer unresolved Accept.object_ references (resolved via sender-side fix) |
 | 2026-04-30 | implementation | TASK-DL-REHYDRATE | DataLayer list_objects() method and model_validate cleanup |
 | 2026-04-30 | implementation | TASK-DOCS-472 | TASK-DOCS-472 — Fix LaTeX Rendering and Versioning Docs |
+| 2026-04-30 | implementation | TASK-RFC-401 | TASK-RFC-401 BTTestScenario deep-module test harness |
 | 2026-04-30 | implementation | TASK-RFC-402 | Consolidate find_matching_semantics into semantic_registry |
 | 2026-04-30 | implementation | TASK-RFC-403 | Introduce CasePersistence and CaseOutboxPersistence narrow Protocols (RFC-403) |
 | 2026-04-29 | priority | Priority 471 | Priority 471: Bug Fixes and Demo Polish — COMPLETE |
@@ -145,4 +147,3 @@
 | 2026-04-01 | implementation | D5-4 | D5-4 — Multi-Vendor Demo with Ownership Transfer (Completed 2026-04-01) |
 | 2026-04-01 | implementation | D5-5 | D5-5 — Multi-Actor Integration Tests (2026-04-01) |
 | 2026-04-01 | implementation | LEGACY-2026-04-01-bug-2026040102-fix-circular-import-in-validate-t | BUG-2026040102 Fix — Circular Import in validate_tree |
-| 2026-04-30 | implementation | RFC-400 | RFC-400 TriggerService Facade |

--- a/plan/history/2604/README.md
+++ b/plan/history/2604/README.md
@@ -8,9 +8,12 @@
 | 2026-04-30 | implementation | BUG-26043001 | BUG-26043001 — append-history: validate required frontmatter fields |
 | 2026-04-30 | implementation | P472-LATEX | Fix block-math opening delimiter in conclusion.md (#234, #235) |
 | 2026-04-30 | implementation | RFC-400 | RFC-400 TriggerService Facade |
+| 2026-04-30 | implementation | TASK-AF | TASK-AF.1: Create factories/errors.py |
+| 2026-04-30 | implementation | TASK-BTND5 | TASK-BTND5.1: Add CVDRoles.CASE_OWNER |
 | 2026-04-30 | implementation | TASK-BUG-386 | BUG-386 — Defer unresolved Accept.object_ references (resolved via sender-side fix) |
 | 2026-04-30 | implementation | TASK-DL-REHYDRATE | DataLayer list_objects() method and model_validate cleanup |
 | 2026-04-30 | implementation | TASK-DOCS-472 | TASK-DOCS-472 — Fix LaTeX Rendering and Versioning Docs |
+| 2026-04-30 | implementation | TASK-OUTBOX-TO | TASK-OUTBOX-TO: Outbox to: Field Enforcement |
 | 2026-04-30 | implementation | TASK-RFC-401 | TASK-RFC-401 BTTestScenario deep-module test harness |
 | 2026-04-30 | implementation | TASK-RFC-402 | Consolidate find_matching_semantics into semantic_registry |
 | 2026-04-30 | implementation | TASK-RFC-403 | Introduce CasePersistence and CaseOutboxPersistence narrow Protocols (RFC-403) |

--- a/plan/history/2604/implementation/TASK-AF.md
+++ b/plan/history/2604/implementation/TASK-AF.md
@@ -1,0 +1,16 @@
+---
+title: "TASK-AF.1: Create factories/errors.py"
+type: implementation
+date: 2026-04-30
+source: TASK-AF
+---
+
+## TASK-AF.1 — Create `factories/errors.py` with `VultronActivityConstructionError`
+
+Created `vultron/wire/as2/factories/` package with `errors.py` defining
+`VultronActivityConstructionError(VultronError)` and `__init__.py`
+re-exporting it. Added `test/wire/as2/factories/test_errors.py` with four
+tests covering inheritance, re-export identity, chained cause, and
+catchability as VultronError. Subsequent AF steps (AF.2–AF.13) will add
+domain factory modules, migrate call sites, and enforce the import boundary.
+Specs satisfied: AF-04-002, AF-02-004 (partial — only errors module present).

--- a/plan/history/2604/implementation/TASK-BTND5.md
+++ b/plan/history/2604/implementation/TASK-BTND5.md
@@ -1,0 +1,15 @@
+---
+title: "TASK-BTND5.1: Add CVDRoles.CASE_OWNER"
+type: implementation
+date: 2026-04-30
+source: TASK-BTND5
+---
+
+## TASK-BTND5.1 — Add `CVDRoles.CASE_OWNER`
+
+Added `CASE_OWNER = auto()` to the `CVDRoles` Flag enum in
+`vultron/core/states/roles.py`. The new value (64) is distinct from all
+existing roles and is combinable via bitwise OR. Created
+`test/core/states/test_cvd_roles.py` with four tests covering existence,
+distinctness, combinability, and stability of existing role values.
+Spec satisfied: BTND-05-001.

--- a/plan/history/2604/implementation/TASK-OUTBOX-TO.md
+++ b/plan/history/2604/implementation/TASK-OUTBOX-TO.md
@@ -1,0 +1,19 @@
+---
+title: "TASK-OUTBOX-TO: Outbox to: Field Enforcement"
+type: implementation
+date: 2026-04-30
+source: TASK-OUTBOX-TO
+---
+
+## TASK-OUTBOX-TO — Outbox `to:` Field Enforcement
+
+Added `VultronOutboxToFieldMissingError` to `vultron/errors.py` and enforced
+the `to:` presence check in `handle_outbox_item` before the object-expansion
+block. Activities with a `None` or empty-list `to:` raise the new error
+immediately; activities with non-empty `cc`/`bto`/`bcc` log a WARNING but
+still deliver. Added 6 new unit tests in `test/adapters/driving/fastapi/test_outbox.py`
+covering both raise branches (None and []) and the three warning branches
+(cc, bto, bcc), including assertions on exception attributes. Fixed one
+pre-existing test that built a `VultronActivity` without a `to:` field
+(`test_handle_outbox_item_raises_on_bare_string_object`).
+Specs satisfied: OX-08-001, OX-08-002, OX-08-003, OX-08-004.

--- a/plan/history/2604/implementation/TASK-RFC-401.md
+++ b/plan/history/2604/implementation/TASK-RFC-401.md
@@ -1,0 +1,15 @@
+---
+title: TASK-RFC-401 BTTestScenario deep-module test harness
+type: implementation
+date: 2026-04-30
+source: TASK-RFC-401
+---
+
+Created `test/core/behaviors/bt_harness.py` with `BTTestScenario` class and
+three pytest fixtures (`bt_scenario`, `bt_scenario_factory`, `shared_dl_actors`).
+Rewrote `test/core/behaviors/report/test_nodes.py` and
+`test/core/behaviors/case/test_nodes.py` to eliminate duplicated
+`setup_node_blackboard()` boilerplate and direct `node.update()` calls,
+routing all BT execution through `BTBridge.execute_with_setup()`.
+Updated `test/core/behaviors/conftest.py` to export harness fixtures.
+1991 tests passing. Resolves GitHub issue #401.

--- a/test/adapters/driving/fastapi/test_outbox.py
+++ b/test/adapters/driving/fastapi/test_outbox.py
@@ -29,6 +29,8 @@ Spec coverage:
 - OX-03-002/003: Delivery occurs after handler; MUST NOT block HTTP response.
 - OX-1.1: Delivery via async HTTP POST to recipient inbox URLs.
 - OX-1.3: Idempotency enforced at inbox endpoint (not delivery side).
+- OX-08-001/002/003: `to:` field MUST be non-empty; raises VultronOutboxToFieldMissingError.
+- OX-08-004: `cc`/`bto`/`bcc` presence logs a WARNING.
 """
 
 import asyncio
@@ -40,7 +42,10 @@ import pytest
 
 from vultron.adapters.driving.fastapi import outbox_handler as oh
 from vultron.core.models.activity import VultronActivity
-from vultron.errors import VultronOutboxObjectIntegrityError
+from vultron.errors import (
+    VultronOutboxObjectIntegrityError,
+    VultronOutboxToFieldMissingError,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -715,3 +720,138 @@ def test_handle_outbox_item_preserves_inline_case_log_entry_fields():
     assert emitted_activity.object_["caseId"] == entry.case_id
     assert emitted_activity.object_["logObjectId"] == entry.log_object_id
     assert emitted_activity.object_["eventType"] == entry.event_type
+
+
+# ---------------------------------------------------------------------------
+# handle_outbox_item — to: field enforcement (OX-08)
+# ---------------------------------------------------------------------------
+
+
+def _make_vultron_activity(
+    to=None, cc=None, bto=None, bcc=None, activity_type="Offer"
+) -> VultronActivity:
+    """Build a VultronActivity with the given addressing fields."""
+    act = VultronActivity(
+        id_="urn:test:act-to-check",
+        type_=activity_type,
+        actor="https://example.org/actors/sender",
+        to=to,
+        cc=cc,
+        bto=bto,
+        bcc=bcc,
+    )
+    return act
+
+
+def test_handle_outbox_item_raises_when_to_is_none():
+    """handle_outbox_item raises VultronOutboxToFieldMissingError when to is None (OX-08-003)."""
+    activity = _make_vultron_activity(to=None)
+    mock_dl = MagicMock()
+    mock_dl.read.return_value = activity
+    mock_emitter = AsyncMock()
+
+    with pytest.raises(VultronOutboxToFieldMissingError) as exc_info:
+        asyncio.run(
+            oh.handle_outbox_item(
+                "actor-abc", activity.id_, mock_dl, mock_emitter
+            )
+        )
+
+    assert exc_info.value.activity_id == activity.id_
+    assert exc_info.value.activity_type == "Offer"
+    mock_emitter.emit.assert_not_called()
+
+
+def test_handle_outbox_item_raises_when_to_is_empty_list():
+    """handle_outbox_item raises VultronOutboxToFieldMissingError when to is [] (OX-08-002)."""
+    activity = _make_vultron_activity(to=[])
+    mock_dl = MagicMock()
+    mock_dl.read.return_value = activity
+    mock_emitter = AsyncMock()
+
+    with pytest.raises(VultronOutboxToFieldMissingError) as exc_info:
+        asyncio.run(
+            oh.handle_outbox_item(
+                "actor-abc", activity.id_, mock_dl, mock_emitter
+            )
+        )
+
+    assert exc_info.value.activity_id == activity.id_
+    assert exc_info.value.activity_type == "Offer"
+    mock_emitter.emit.assert_not_called()
+
+
+@pytest.mark.parametrize("addr_field", ["cc", "bto", "bcc"])
+def test_handle_outbox_item_warns_when_non_standard_addr_field_present(
+    addr_field, caplog
+):
+    """handle_outbox_item logs WARNING when cc/bto/bcc set, but still delivers (OX-08-004)."""
+    recipient = "https://example.org/actors/alice"
+    other = "https://example.org/actors/charlie"
+    if addr_field == "cc":
+        activity = VultronActivity(
+            id_="urn:test:act-warn",
+            type_="Create",
+            actor="https://example.org/actors/sender",
+            to=[recipient],
+            cc=[other],
+        )
+    elif addr_field == "bto":
+        activity = VultronActivity(
+            id_="urn:test:act-warn",
+            type_="Create",
+            actor="https://example.org/actors/sender",
+            to=[recipient],
+            bto=[other],
+        )
+    else:
+        activity = VultronActivity(
+            id_="urn:test:act-warn",
+            type_="Create",
+            actor="https://example.org/actors/sender",
+            to=[recipient],
+            bcc=[other],
+        )
+    mock_dl = MagicMock()
+    mock_dl.read.return_value = activity
+    mock_emitter = AsyncMock()
+
+    with caplog.at_level("WARNING"):
+        asyncio.run(
+            oh.handle_outbox_item(
+                "actor-abc", activity.id_, mock_dl, mock_emitter
+            )
+        )
+
+    assert any(
+        addr_field in r.message for r in caplog.records
+    ), f"Expected WARNING mentioning '{addr_field}'"
+    mock_emitter.emit.assert_called_once()
+
+
+def test_handle_outbox_item_no_warning_when_only_to_set(caplog):
+    """handle_outbox_item logs no cc/bto/bcc WARNING when only to: is set."""
+    recipient = "https://example.org/actors/alice"
+    activity = VultronActivity(
+        id_="urn:test:act-no-warn",
+        type_="Create",
+        actor="https://example.org/actors/sender",
+        to=[recipient],
+    )
+    mock_dl = MagicMock()
+    mock_dl.read.return_value = activity
+    mock_emitter = AsyncMock()
+
+    with caplog.at_level("WARNING"):
+        asyncio.run(
+            oh.handle_outbox_item(
+                "actor-abc", activity.id_, mock_dl, mock_emitter
+            )
+        )
+
+    warning_texts = [
+        r.message for r in caplog.records if r.levelname == "WARNING"
+    ]
+    assert not any(
+        any(f in msg for f in ("cc", "bto", "bcc")) for msg in warning_texts
+    )

--- a/test/core/behaviors/bt_harness.py
+++ b/test/core/behaviors/bt_harness.py
@@ -262,7 +262,13 @@ class BTTestScenario:
             len(cases) == 1
         ), f"Expected exactly 1 VulnerabilityCase in DataLayer, found {len(cases)}"
         case_id = next(iter(cases))
-        return self.dl.read(case_id)
+        case = self.dl.read(case_id)
+        assert case is not None, (
+            "Expected VulnerabilityCase id "
+            f"{case_id!r} from DataLayer.by_type('VulnerabilityCase') "
+            "to be readable, but DataLayer.read() returned None"
+        )
+        return cast(Any, case)
 
     def assert_note_attached_to_case(self, note_id: str, case_id: str) -> None:
         """Assert that ``note_id`` appears in the case's notes list.

--- a/test/core/behaviors/bt_harness.py
+++ b/test/core/behaviors/bt_harness.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""
+BTTestScenario — deep-module test harness for Behavior Tree tests.
+
+Encapsulates the correct BTBridge path for all BT tests (leaf nodes and
+composite trees alike). Eliminates duplicated ``setup_node_blackboard()``
+boilerplate that bypasses the proper BT lifecycle.
+
+Per specs/testability.yaml TB-06 requirements and GitHub issue #401.
+
+Usage
+-----
+.. code-block:: python
+
+    def test_example(bt_scenario, report, offer):
+        result = bt_scenario.run(TransitionRMtoValid(report_id=report.id_, offer_id=offer.id_))
+        bt_scenario.assert_success(result)
+        bt_scenario.assert_rm_state(report.id_, RM.VALID, actor_id=actor.id_)
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, cast
+
+import py_trees
+import pytest
+
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.core.behaviors.bridge import BTBridge, BTExecutionResult
+from vultron.core.states.rm import RM
+from vultron.core.use_cases._helpers import _report_phase_status_id
+
+
+class BTTestScenario:
+    """Deep-module harness for BT test scenarios.
+
+    Provides the single correct execution path for all BT tests: leaf nodes
+    and composite trees alike. Eliminates duplicated blackboard-setup
+    boilerplate and ensures every test exercises the real BTBridge lifecycle
+    (setup → initialise → update → shutdown).
+
+    Attributes:
+        actor_id: Default actor ID used when none is supplied to ``run()``.
+        dl: In-memory SQLite DataLayer shared across all seed/run/assert calls.
+        bridge: ``BTBridge`` wired to ``dl``.
+    """
+
+    def __init__(
+        self,
+        actor_id: str = "https://example.org/actors/vendor",
+        *,
+        dl: SqliteDataLayer | None = None,
+        is_leader: bool = True,
+    ) -> None:
+        self.actor_id = actor_id
+        self.dl = dl or SqliteDataLayer("sqlite:///:memory:")
+        self.bridge = BTBridge(
+            datalayer=self.dl,
+            is_leader=lambda: is_leader,
+        )
+
+    # ------------------------------------------------------------------
+    # Precondition setup
+    # ------------------------------------------------------------------
+
+    def seed(self, *objects: Any) -> "BTTestScenario":
+        """Persist domain objects as preconditions; returns self for chaining.
+
+        Args:
+            *objects: Persistable domain objects to create in the DataLayer.
+
+        Returns:
+            self, enabling method chaining.
+        """
+        for obj in objects:
+            self.dl.create(obj)
+        return self
+
+    # ------------------------------------------------------------------
+    # Execution
+    # ------------------------------------------------------------------
+
+    def run(
+        self,
+        tree: py_trees.behaviour.Behaviour,
+        actor_id: str | None = None,
+        activity: Any = None,
+        **context_data: Any,
+    ) -> BTExecutionResult:
+        """Execute a node or tree through BTBridge; clears blackboard first.
+
+        Args:
+            tree: Root behavior node or composite tree to execute.
+            actor_id: Actor ID to bind on the blackboard; defaults to
+                ``self.actor_id``.
+            activity: Optional ActivityStreams activity being processed.
+            **context_data: Additional key/value pairs to populate on the
+                blackboard (e.g., ``case_id="https://..."``).
+
+        Returns:
+            BTExecutionResult with status, feedback, and any errors.
+        """
+        py_trees.blackboard.Blackboard.storage.clear()
+        return self.bridge.execute_with_setup(
+            tree=tree,
+            actor_id=actor_id if actor_id is not None else self.actor_id,
+            activity=activity,
+            **context_data,
+        )
+
+    # ------------------------------------------------------------------
+    # Status assertions
+    # ------------------------------------------------------------------
+
+    def assert_success(self, result: BTExecutionResult) -> None:
+        """Assert that the execution result is SUCCESS.
+
+        Args:
+            result: BTExecutionResult to check.
+        """
+        assert (
+            result.status == py_trees.common.Status.SUCCESS
+        ), f"Expected SUCCESS but got {result.status}: {result.feedback_message}"
+
+    def assert_failure(self, result: BTExecutionResult) -> None:
+        """Assert that the execution result is FAILURE.
+
+        Args:
+            result: BTExecutionResult to check.
+        """
+        assert (
+            result.status == py_trees.common.Status.FAILURE
+        ), f"Expected FAILURE but got {result.status}: {result.feedback_message}"
+
+    def assert_failure_reason(
+        self,
+        tree: py_trees.behaviour.Behaviour,
+        expected_substr: str,
+    ) -> None:
+        """Assert that the first FAILURE node's message contains expected_substr.
+
+        Args:
+            tree: Root behavior node to inspect (after a failed run).
+            expected_substr: Substring expected in the failure reason.
+        """
+        reason = BTBridge.get_failure_reason(tree)
+        assert (
+            expected_substr in reason
+        ), f"Expected {expected_substr!r} in failure reason, got {reason!r}"
+
+    # ------------------------------------------------------------------
+    # DataLayer assertions
+    # ------------------------------------------------------------------
+
+    def assert_object_in_dl(
+        self, obj_id: str, type_key: str | None = None
+    ) -> Any:
+        """Assert object exists in the DataLayer; return it.
+
+        Args:
+            obj_id: ID of the object to look up.
+            type_key: Optional type key for additional membership check.
+
+        Returns:
+            The stored object.
+        """
+        obj = self.dl.read(obj_id)
+        assert obj is not None, f"Expected object {obj_id!r} in DataLayer"
+        if type_key is not None:
+            records = self.dl.by_type(type_key)
+            assert (
+                obj_id in records
+            ), f"Expected object {obj_id!r} of type {type_key!r} in DataLayer"
+        return obj
+
+    def assert_object_absent(self, obj_id: str) -> None:
+        """Assert that an object does NOT exist in the DataLayer.
+
+        Args:
+            obj_id: ID of the object that must be absent.
+        """
+        obj = self.dl.read(obj_id)
+        assert (
+            obj is None
+        ), f"Expected object {obj_id!r} to be absent from DataLayer"
+
+    def assert_type_count(self, type_key: str, expected: int) -> None:
+        """Assert the DataLayer contains exactly ``expected`` objects of type.
+
+        Args:
+            type_key: Type discriminator string (e.g., ``"VulnerabilityCase"``).
+            expected: Expected number of matching records.
+        """
+        actual = len(self.dl.by_type(type_key))
+        assert (
+            actual == expected
+        ), f"Expected {expected} object(s) of type {type_key!r}, got {actual}"
+
+    # ------------------------------------------------------------------
+    # Domain assertions
+    # ------------------------------------------------------------------
+
+    def assert_rm_state(
+        self,
+        report_id: str,
+        expected_rm: RM,
+        actor_id: str | None = None,
+    ) -> None:
+        """Assert that a RM-state record exists for the given actor and report.
+
+        Uses ``_report_phase_status_id`` to derive the deterministic record
+        ID, then verifies the record is present in the DataLayer.
+
+        Args:
+            report_id: Report ID.
+            expected_rm: Expected RM enum value (e.g., ``RM.VALID``).
+            actor_id: Actor ID; defaults to ``self.actor_id``.
+        """
+        actor = actor_id if actor_id is not None else self.actor_id
+        status_id = _report_phase_status_id(
+            actor, report_id, expected_rm.value
+        )
+        obj = self.dl.read(status_id)
+        assert obj is not None, (
+            f"Expected RM state {expected_rm!r} for report {report_id!r} "
+            f"actor {actor!r} not found in DataLayer (looked up id={status_id!r})"
+        )
+
+    def assert_case_count(self, expected: int) -> None:
+        """Assert exactly ``expected`` VulnerabilityCase objects in DataLayer.
+
+        Args:
+            expected: Expected case count.
+        """
+        self.assert_type_count("VulnerabilityCase", expected)
+
+    def assert_case_exists(self) -> Any:
+        """Assert exactly one VulnerabilityCase in DataLayer and return it.
+
+        Returns:
+            The single VulnerabilityCase object.
+
+        Raises:
+            AssertionError: If there is not exactly one VulnerabilityCase.
+        """
+        cases = self.dl.by_type("VulnerabilityCase")
+        assert (
+            len(cases) == 1
+        ), f"Expected exactly 1 VulnerabilityCase in DataLayer, found {len(cases)}"
+        case_id = next(iter(cases))
+        return self.dl.read(case_id)
+
+    def assert_note_attached_to_case(self, note_id: str, case_id: str) -> None:
+        """Assert that ``note_id`` appears in the case's notes list.
+
+        Args:
+            note_id: ID of the note to look for.
+            case_id: ID of the VulnerabilityCase to inspect.
+        """
+        case = cast(Any, self.dl.read(case_id))
+        assert case is not None, f"Case {case_id!r} not found in DataLayer"
+        assert (
+            note_id in case.notes
+        ), f"Note {note_id!r} not attached to case {case_id!r}"
+
+    def assert_participant_in_case(self, actor_id: str, case_id: str) -> None:
+        """Assert that ``actor_id`` appears in the case's participant index.
+
+        Args:
+            actor_id: Actor ID expected as a case participant.
+            case_id: ID of the VulnerabilityCase to inspect.
+        """
+        case = cast(Any, self.dl.read(case_id))
+        assert case is not None, f"Case {case_id!r} not found in DataLayer"
+        assert (
+            actor_id in case.actor_participant_index
+        ), f"Actor {actor_id!r} is not a participant in case {case_id!r}"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def bt_scenario() -> BTTestScenario:
+    """Return a BTTestScenario with a fresh in-memory DataLayer."""
+    return BTTestScenario()
+
+
+@pytest.fixture
+def bt_scenario_factory() -> Callable[..., BTTestScenario]:
+    """Return a factory for BTTestScenario instances.
+
+    The factory signature is:
+    ``factory(actor_id=..., *, dl=None, is_leader=True) -> BTTestScenario``
+
+    This is useful when a test needs multiple scenario instances (e.g.,
+    leadership-guard rejection tests or multi-actor scenarios with a shared
+    DataLayer).
+    """
+
+    def _factory(
+        actor_id: str = "https://example.org/actors/vendor",
+        *,
+        dl: SqliteDataLayer | None = None,
+        is_leader: bool = True,
+    ) -> BTTestScenario:
+        return BTTestScenario(actor_id=actor_id, dl=dl, is_leader=is_leader)
+
+    return _factory
+
+
+@pytest.fixture
+def shared_dl_actors() -> tuple[BTTestScenario, BTTestScenario]:
+    """Return two BTTestScenario instances (vendor + reporter) sharing one DL.
+
+    Both ``VultronCaseActor`` objects are persisted in the shared DataLayer
+    so BT nodes that look up actor records can find them.
+    """
+    from vultron.core.models.case_actor import VultronCaseActor
+
+    dl = SqliteDataLayer("sqlite:///:memory:")
+    vendor_id = "https://example.org/actors/vendor"
+    reporter_id = "https://example.org/actors/reporter"
+
+    vendor_actor = VultronCaseActor(id_=vendor_id, name="Vendor Co")
+    reporter_actor = VultronCaseActor(id_=reporter_id, name="Reporter Co")
+    dl.create(vendor_actor)
+    dl.create(reporter_actor)
+
+    vendor = BTTestScenario(actor_id=vendor_id, dl=dl)
+    reporter = BTTestScenario(actor_id=reporter_id, dl=dl)
+    return vendor, reporter

--- a/test/core/behaviors/case/test_nodes.py
+++ b/test/core/behaviors/case/test_nodes.py
@@ -22,16 +22,20 @@ Covers:
 - CreateInitialVendorParticipant and CreateCaseParticipantNode use of helper
 - RecordCaseCreationEvents blackboard key contract (P360-FIX-3)
 
-Per specs/behavior-tree-node-design.yaml BTND-02-001, BTND-03-001, BTND-04-001.
+Uses BTTestScenario (from ``test.core.behaviors.bt_harness``) as the single
+execution path for BT node tests; no direct ``node.update()`` /
+``node.blackboard.register_key()`` calls appear here.
+
+Per specs/behavior-tree-node-design.yaml BTND-02-001, BTND-03-001, BTND-04-001
+and GitHub issue #401.
 """
 
 import logging
+from typing import cast, Any
+from unittest.mock import MagicMock
 
-import py_trees
 import pytest
-from py_trees.common import Status
 
-from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.core.behaviors.case.nodes import (
     CreateCaseParticipantNode,
     CreateInitialVendorParticipant,
@@ -55,6 +59,7 @@ from vultron.core.states.roles import CVDRoles
 from vultron.wire.as2.vocab.activities.case_participant import (
     AddParticipantToCaseActivity,
 )
+from test.core.behaviors.bt_harness import BTTestScenario
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -62,62 +67,38 @@ from vultron.wire.as2.vocab.activities.case_participant import (
 
 
 @pytest.fixture
-def datalayer():
-    """In-memory DataLayer for testing."""
-    return SqliteDataLayer("sqlite:///:memory:")
-
-
-@pytest.fixture
-def actor_id():
+def actor_id() -> str:
     return "https://example.org/actors/vendor"
 
 
 @pytest.fixture
-def actor(datalayer, actor_id):
+def actor(bt_scenario: BTTestScenario, actor_id: str) -> VultronCaseActor:
     obj = VultronCaseActor(id_=actor_id, name="Vendor Co")
-    datalayer.create(obj)
+    bt_scenario.dl.create(obj)
     return obj
 
 
 @pytest.fixture
-def report(datalayer):
+def report(bt_scenario: BTTestScenario) -> VultronReport:
     obj = VultronReport(
         name="TEST-001",
         content="Test vulnerability report",
     )
-    datalayer.create(obj)
+    bt_scenario.dl.create(obj)
     return obj
 
 
 @pytest.fixture
-def case_obj(datalayer, report):
+def case_obj(
+    bt_scenario: BTTestScenario, report: VultronReport
+) -> VultronCase:
     case = VultronCase(
         id_="https://example.org/cases/case-001",
         name="Test Case",
         vulnerability_reports=[report.id_],
     )
-    datalayer.create(case)
+    bt_scenario.dl.create(case)
     return case
-
-
-def setup_node_blackboard(node, datalayer, actor_id, extra_keys=None):
-    """Set up a node's blackboard with DataLayer and actor_id."""
-    node.setup()
-    node.blackboard.register_key(
-        key="datalayer", access=py_trees.common.Access.WRITE
-    )
-    node.blackboard.register_key(
-        key="actor_id", access=py_trees.common.Access.WRITE
-    )
-    node.blackboard.datalayer = datalayer
-    node.blackboard.actor_id = actor_id
-    if extra_keys:
-        for key, value in extra_keys.items():
-            node.blackboard.register_key(
-                key=key, access=py_trees.common.Access.WRITE
-            )
-            node.blackboard.set(key, value, overwrite=True)
-    node.initialise()
 
 
 # ---------------------------------------------------------------------------
@@ -128,13 +109,13 @@ def setup_node_blackboard(node, datalayer, actor_id, extra_keys=None):
 class TestUpdateActorOutboxReExport:
     """UpdateActorOutbox is the same object in all three modules (BTND-04-001)."""
 
-    def test_case_nodes_re_exports_from_helpers(self):
+    def test_case_nodes_re_exports_from_helpers(self) -> None:
         assert UpdateActorOutbox is UpdateActorOutboxHelper
 
-    def test_report_nodes_re_exports_from_helpers(self):
+    def test_report_nodes_re_exports_from_helpers(self) -> None:
         assert UpdateActorOutboxReport is UpdateActorOutboxHelper
 
-    def test_shared_class_is_not_duplicate(self):
+    def test_shared_class_is_not_duplicate(self) -> None:
         """There is exactly one UpdateActorOutbox class definition."""
         assert (
             UpdateActorOutbox
@@ -152,31 +133,39 @@ class TestCreateAndAttachParticipant:
     """Unit tests for the shared _create_and_attach_participant helper."""
 
     def test_creates_participant_in_datalayer(
-        self, datalayer, case_obj, actor_id
-    ):
+        self,
+        bt_scenario: BTTestScenario,
+        case_obj: VultronCase,
+        actor_id: str,
+    ) -> None:
         participant = VultronParticipant(
             attributed_to=actor_id,
             context=case_obj.id_,
             case_roles=[CVDRoles.VENDOR],
         )
         result = _create_and_attach_participant(
-            datalayer,
+            bt_scenario.dl,
             participant,
             case_obj.id_,
             actor_id,
             logging.getLogger("test"),
         )
         assert result is not None
-        assert datalayer.read(participant.id_) is not None
+        assert bt_scenario.dl.read(participant.id_) is not None
 
-    def test_attaches_participant_to_case(self, datalayer, case_obj, actor_id):
+    def test_attaches_participant_to_case(
+        self,
+        bt_scenario: BTTestScenario,
+        case_obj: VultronCase,
+        actor_id: str,
+    ) -> None:
         participant = VultronParticipant(
             attributed_to=actor_id,
             context=case_obj.id_,
             case_roles=[CVDRoles.VENDOR],
         )
         result = _create_and_attach_participant(
-            datalayer,
+            bt_scenario.dl,
             participant,
             case_obj.id_,
             actor_id,
@@ -186,15 +175,18 @@ class TestCreateAndAttachParticipant:
         assert participant.id_ in result.case_participants
 
     def test_updates_actor_participant_index(
-        self, datalayer, case_obj, actor_id
-    ):
+        self,
+        bt_scenario: BTTestScenario,
+        case_obj: VultronCase,
+        actor_id: str,
+    ) -> None:
         participant = VultronParticipant(
             attributed_to=actor_id,
             context=case_obj.id_,
             case_roles=[CVDRoles.VENDOR],
         )
         result = _create_and_attach_participant(
-            datalayer,
+            bt_scenario.dl,
             participant,
             case_obj.id_,
             actor_id,
@@ -203,7 +195,12 @@ class TestCreateAndAttachParticipant:
         assert result is not None
         assert result.actor_participant_index.get(actor_id) == participant.id_
 
-    def test_returns_unsaved_case(self, datalayer, case_obj, actor_id):
+    def test_returns_unsaved_case(
+        self,
+        bt_scenario: BTTestScenario,
+        case_obj: VultronCase,
+        actor_id: str,
+    ) -> None:
         """The returned case is unsaved; the caller controls the final save."""
         participant = VultronParticipant(
             attributed_to=actor_id,
@@ -211,20 +208,22 @@ class TestCreateAndAttachParticipant:
             case_roles=[CVDRoles.VENDOR],
         )
         result = _create_and_attach_participant(
-            datalayer,
+            bt_scenario.dl,
             participant,
             case_obj.id_,
             actor_id,
             logging.getLogger("test"),
         )
         assert result is not None
-        # Before the caller saves, the persisted version has no participant yet
-        persisted = datalayer.read(case_obj.id_)
+        persisted = cast(Any, bt_scenario.dl.read(case_obj.id_))
         assert participant.id_ not in persisted.case_participants
 
     def test_idempotent_participant_creation(
-        self, datalayer, case_obj, actor_id
-    ):
+        self,
+        bt_scenario: BTTestScenario,
+        case_obj: VultronCase,
+        actor_id: str,
+    ) -> None:
         """Calling twice does not create a duplicate participant."""
         participant = VultronParticipant(
             attributed_to=actor_id,
@@ -233,25 +232,26 @@ class TestCreateAndAttachParticipant:
         )
         node_logger = logging.getLogger("test")
         _create_and_attach_participant(
-            datalayer, participant, case_obj.id_, actor_id, node_logger
+            bt_scenario.dl, participant, case_obj.id_, actor_id, node_logger
         )
-        datalayer.save(datalayer.read(case_obj.id_))  # simulate caller save
+        bt_scenario.dl.save(cast(Any, bt_scenario.dl.read(case_obj.id_)))
 
         result2 = _create_and_attach_participant(
-            datalayer, participant, case_obj.id_, actor_id, node_logger
+            bt_scenario.dl, participant, case_obj.id_, actor_id, node_logger
         )
         assert result2 is not None
-        # Still only one entry for this participant
         assert result2.case_participants.count(participant.id_) == 1
 
-    def test_returns_none_when_case_not_found(self, datalayer, actor_id):
+    def test_returns_none_when_case_not_found(
+        self, bt_scenario: BTTestScenario, actor_id: str
+    ) -> None:
         participant = VultronParticipant(
             attributed_to=actor_id,
             context="https://example.org/cases/missing",
             case_roles=[CVDRoles.VENDOR],
         )
         result = _create_and_attach_participant(
-            datalayer,
+            bt_scenario.dl,
             participant,
             "https://example.org/cases/missing",
             actor_id,
@@ -269,48 +269,54 @@ class TestCreateInitialVendorParticipant:
     """CreateInitialVendorParticipant preserves semantics after refactor."""
 
     def test_creates_and_attaches_vendor_participant(
-        self, datalayer, actor, case_obj
-    ):
-        node = CreateInitialVendorParticipant()
-        setup_node_blackboard(
-            node,
-            datalayer,
-            actor.id_,
-            extra_keys={"case_id": case_obj.id_},
+        self,
+        bt_scenario: BTTestScenario,
+        actor: VultronCaseActor,
+        case_obj: VultronCase,
+        actor_id: str,
+    ) -> None:
+        result = bt_scenario.run(
+            CreateInitialVendorParticipant(),
+            actor_id=actor_id,
+            case_id=case_obj.id_,
         )
-        result = node.update()
-        assert result == Status.SUCCESS
+        bt_scenario.assert_success(result)
+        bt_scenario.assert_participant_in_case(actor_id, case_obj.id_)
 
-        stored_case = datalayer.read(case_obj.id_)
-        assert any(
-            p == stored_case.actor_participant_index.get(actor.id_)
-            for p in stored_case.case_participants
-        )
-
-    def test_idempotent(self, datalayer, actor, case_obj):
+    def test_idempotent(
+        self,
+        bt_scenario: BTTestScenario,
+        actor: VultronCaseActor,
+        case_obj: VultronCase,
+        actor_id: str,
+    ) -> None:
         """Running twice does not error."""
-        node1 = CreateInitialVendorParticipant()
-        setup_node_blackboard(
-            node1, datalayer, actor.id_, extra_keys={"case_id": case_obj.id_}
+        result1 = bt_scenario.run(
+            CreateInitialVendorParticipant(),
+            actor_id=actor_id,
+            case_id=case_obj.id_,
         )
-        assert node1.update() == Status.SUCCESS
+        bt_scenario.assert_success(result1)
 
-        node2 = CreateInitialVendorParticipant()
-        setup_node_blackboard(
-            node2, datalayer, actor.id_, extra_keys={"case_id": case_obj.id_}
+        result2 = bt_scenario.run(
+            CreateInitialVendorParticipant(),
+            actor_id=actor_id,
+            case_id=case_obj.id_,
         )
-        assert node2.update() == Status.SUCCESS
+        bt_scenario.assert_success(result2)
 
-    def test_fails_when_case_not_found(self, datalayer, actor):
-        node = CreateInitialVendorParticipant()
-        setup_node_blackboard(
-            node,
-            datalayer,
-            actor.id_,
-            extra_keys={"case_id": "https://example.org/cases/missing"},
+    def test_fails_when_case_not_found(
+        self,
+        bt_scenario: BTTestScenario,
+        actor: VultronCaseActor,
+        actor_id: str,
+    ) -> None:
+        result = bt_scenario.run(
+            CreateInitialVendorParticipant(),
+            actor_id=actor_id,
+            case_id="https://example.org/cases/missing",
         )
-        result = node.update()
-        assert result == Status.FAILURE
+        bt_scenario.assert_failure(result)
 
 
 # ---------------------------------------------------------------------------
@@ -322,80 +328,90 @@ class TestCreateCaseParticipantNode:
     """CreateCaseParticipantNode preserves its distinct semantics after refactor."""
 
     @pytest.fixture
-    def finder_actor_id(self):
+    def finder_actor_id(self) -> str:
         return "https://example.org/actors/finder"
 
     def test_creates_and_attaches_participant(
-        self, datalayer, actor, case_obj, finder_actor_id
-    ):
-        node = CreateCaseParticipantNode(
-            actor_id=finder_actor_id, roles=[CVDRoles.FINDER]
+        self,
+        bt_scenario: BTTestScenario,
+        actor: VultronCaseActor,
+        case_obj: VultronCase,
+        actor_id: str,
+        finder_actor_id: str,
+    ) -> None:
+        result = bt_scenario.run(
+            CreateCaseParticipantNode(
+                actor_id=finder_actor_id, roles=[CVDRoles.FINDER]
+            ),
+            actor_id=actor_id,
+            case_id=case_obj.id_,
         )
-        setup_node_blackboard(
-            node,
-            datalayer,
-            actor.id_,
-            extra_keys={"case_id": case_obj.id_},
-        )
-        result = node.update()
-        assert result == Status.SUCCESS
+        bt_scenario.assert_success(result)
 
-        stored_case = datalayer.read(case_obj.id_)
+        stored_case = cast(Any, bt_scenario.dl.read(case_obj.id_))
         assert finder_actor_id in stored_case.actor_participant_index
 
     def test_records_participant_added_event(
-        self, datalayer, actor, case_obj, finder_actor_id
-    ):
+        self,
+        bt_scenario: BTTestScenario,
+        actor: VultronCaseActor,
+        case_obj: VultronCase,
+        actor_id: str,
+        finder_actor_id: str,
+    ) -> None:
         """CreateCaseParticipantNode records 'participant_added' on the case."""
-        node = CreateCaseParticipantNode(
-            actor_id=finder_actor_id, roles=[CVDRoles.FINDER]
+        bt_scenario.run(
+            CreateCaseParticipantNode(
+                actor_id=finder_actor_id, roles=[CVDRoles.FINDER]
+            ),
+            actor_id=actor_id,
+            case_id=case_obj.id_,
         )
-        setup_node_blackboard(
-            node,
-            datalayer,
-            actor.id_,
-            extra_keys={"case_id": case_obj.id_},
-        )
-        node.update()
 
-        stored_case = datalayer.read(case_obj.id_)
+        stored_case = cast(Any, bt_scenario.dl.read(case_obj.id_))
         event_types = [e.event_type for e in stored_case.events]
         assert "participant_added" in event_types
 
     def test_emits_add_participant_activity(
-        self, datalayer, actor, case_obj, finder_actor_id
-    ):
+        self,
+        bt_scenario: BTTestScenario,
+        actor: VultronCaseActor,
+        case_obj: VultronCase,
+        actor_id: str,
+        finder_actor_id: str,
+    ) -> None:
         """CreateCaseParticipantNode queues AddParticipantToCaseActivity."""
-        node = CreateCaseParticipantNode(
-            actor_id=finder_actor_id, roles=[CVDRoles.FINDER]
+        bt_scenario.run(
+            CreateCaseParticipantNode(
+                actor_id=finder_actor_id, roles=[CVDRoles.FINDER]
+            ),
+            actor_id=actor_id,
+            case_id=case_obj.id_,
         )
-        setup_node_blackboard(
-            node,
-            datalayer,
-            actor.id_,
-            extra_keys={"case_id": case_obj.id_},
-        )
-        node.update()
 
-        stored_actor = datalayer.read(actor.id_)
+        stored_actor = cast(Any, bt_scenario.dl.read(actor_id))
         outbox_ids = stored_actor.outbox.items if stored_actor else []
         found = any(
-            isinstance(datalayer.read(oid), AddParticipantToCaseActivity)
+            isinstance(bt_scenario.dl.read(oid), AddParticipantToCaseActivity)
             for oid in outbox_ids
         )
         assert found
 
     def test_does_not_record_participant_added_event_for_vendor(
-        self, datalayer, actor, case_obj
-    ):
+        self,
+        bt_scenario: BTTestScenario,
+        actor: VultronCaseActor,
+        case_obj: VultronCase,
+        actor_id: str,
+    ) -> None:
         """CreateInitialVendorParticipant does NOT record 'participant_added'."""
-        node = CreateInitialVendorParticipant()
-        setup_node_blackboard(
-            node, datalayer, actor.id_, extra_keys={"case_id": case_obj.id_}
+        bt_scenario.run(
+            CreateInitialVendorParticipant(),
+            actor_id=actor_id,
+            case_id=case_obj.id_,
         )
-        node.update()
 
-        stored_case = datalayer.read(case_obj.id_)
+        stored_case = cast(Any, bt_scenario.dl.read(case_obj.id_))
         event_types = [e.event_type for e in stored_case.events]
         assert "participant_added" not in event_types
 
@@ -408,92 +424,93 @@ class TestCreateCaseParticipantNode:
 class TestRecordCaseCreationEvents:
     """Blackboard keys are declared; activity key is optional (BTND-03-001/02)."""
 
-    def test_registers_activity_key_in_setup(self, datalayer, actor, case_obj):
-        """setup() must register 'activity' as a READ key (BTND-03-001).
+    def test_activity_key_optional_node_succeeds_without_it(
+        self,
+        bt_scenario: BTTestScenario,
+        actor: VultronCaseActor,
+        case_obj: VultronCase,
+        actor_id: str,
+    ) -> None:
+        """Node runs successfully with no 'activity' on the blackboard.
 
-        Verify that accessing the 'activity' key via the blackboard client
-        raises KeyError (unset) rather than AttributeError (unregistered),
-        confirming the key was properly declared in setup().
+        This behavioral test verifies BTND-03-001: if the 'activity' key were
+        not properly registered by setup(), accessing it would raise
+        AttributeError (unregistered) rather than being handled gracefully.
+        Succeeding without an activity proves the key contract is correct.
         """
-        node = RecordCaseCreationEvents(case_obj=case_obj)
-        setup_node_blackboard(
-            node, datalayer, actor.id_, extra_keys={"case_id": case_obj.id_}
+        result = bt_scenario.run(
+            RecordCaseCreationEvents(case_obj=case_obj),
+            actor_id=actor_id,
+            case_id=case_obj.id_,
         )
-        # The key is registered READ; accessing an unset registered key
-        # raises KeyError, NOT AttributeError.
-        with pytest.raises(KeyError):
-            node.blackboard.get("activity")
+        bt_scenario.assert_success(result)
 
     def test_records_case_created_event_without_activity(
-        self, datalayer, actor, case_obj
-    ):
+        self,
+        bt_scenario: BTTestScenario,
+        actor: VultronCaseActor,
+        case_obj: VultronCase,
+        actor_id: str,
+    ) -> None:
         """Without activity on blackboard, case_created event is recorded."""
-        node = RecordCaseCreationEvents(case_obj=case_obj)
-        setup_node_blackboard(
-            node,
-            datalayer,
-            actor.id_,
-            extra_keys={"case_id": case_obj.id_},
+        result = bt_scenario.run(
+            RecordCaseCreationEvents(case_obj=case_obj),
+            actor_id=actor_id,
+            case_id=case_obj.id_,
         )
-        result = node.update()
-        assert result == Status.SUCCESS
+        bt_scenario.assert_success(result)
 
-        stored_case = datalayer.read(case_obj.id_)
+        stored_case = cast(Any, bt_scenario.dl.read(case_obj.id_))
         event_types = [e.event_type for e in stored_case.events]
         assert "case_created" in event_types
 
     def test_records_offer_received_event_when_activity_has_in_reply_to(
-        self, datalayer, actor, case_obj, report
-    ):
+        self,
+        bt_scenario: BTTestScenario,
+        actor: VultronCaseActor,
+        case_obj: VultronCase,
+        report: VultronReport,
+        actor_id: str,
+    ) -> None:
         """With activity.in_reply_to set, offer_received event is backfilled."""
-        from unittest.mock import MagicMock
-
         offer_mock = MagicMock()
         offer_mock.id_ = "https://example.org/activities/offer-001"
         activity_mock = MagicMock()
         activity_mock.in_reply_to = offer_mock
 
-        node = RecordCaseCreationEvents(case_obj=case_obj)
-        setup_node_blackboard(
-            node,
-            datalayer,
-            actor.id_,
-            extra_keys={
-                "case_id": case_obj.id_,
-                "activity": activity_mock,
-            },
+        result = bt_scenario.run(
+            RecordCaseCreationEvents(case_obj=case_obj),
+            actor_id=actor_id,
+            case_id=case_obj.id_,
+            activity=activity_mock,
         )
-        result = node.update()
-        assert result == Status.SUCCESS
+        bt_scenario.assert_success(result)
 
-        stored_case = datalayer.read(case_obj.id_)
+        stored_case = cast(Any, bt_scenario.dl.read(case_obj.id_))
         event_types = [e.event_type for e in stored_case.events]
         assert "offer_received" in event_types
         assert "case_created" in event_types
 
     def test_no_offer_received_when_activity_lacks_in_reply_to(
-        self, datalayer, actor, case_obj
-    ):
+        self,
+        bt_scenario: BTTestScenario,
+        actor: VultronCaseActor,
+        case_obj: VultronCase,
+        actor_id: str,
+    ) -> None:
         """Activity without in_reply_to produces only case_created event."""
-        from unittest.mock import MagicMock
-
         activity_mock = MagicMock()
         activity_mock.in_reply_to = None
 
-        node = RecordCaseCreationEvents(case_obj=case_obj)
-        setup_node_blackboard(
-            node,
-            datalayer,
-            actor.id_,
-            extra_keys={
-                "case_id": case_obj.id_,
-                "activity": activity_mock,
-            },
+        result = bt_scenario.run(
+            RecordCaseCreationEvents(case_obj=case_obj),
+            actor_id=actor_id,
+            case_id=case_obj.id_,
+            activity=activity_mock,
         )
-        result = node.update()
-        assert result == Status.SUCCESS
+        bt_scenario.assert_success(result)
 
-        stored_case = datalayer.read(case_obj.id_)
+        stored_case = cast(Any, bt_scenario.dl.read(case_obj.id_))
         event_types = [e.event_type for e in stored_case.events]
         assert "offer_received" not in event_types
         assert "case_created" in event_types

--- a/test/core/behaviors/conftest.py
+++ b/test/core/behaviors/conftest.py
@@ -1,6 +1,13 @@
 import pytest
 import py_trees
 
+# Re-export harness fixtures so they are available to all sub-directories.
+from test.core.behaviors.bt_harness import (  # noqa: F401
+    bt_scenario,
+    bt_scenario_factory,
+    shared_dl_actors,
+)
+
 
 @pytest.fixture(autouse=True, scope="function")
 def clear_py_trees_blackboard() -> None:

--- a/test/core/behaviors/report/test_nodes.py
+++ b/test/core/behaviors/report/test_nodes.py
@@ -15,18 +15,22 @@
 
 """
 Tests for report validation behavior tree nodes.
+
+Uses BTTestScenario (from ``test.core.behaviors.bt_harness``) as the single
+execution path; no direct ``node.update()`` / ``node.blackboard.register_key()``
+calls appear here.
+
+Per GitHub issue #401 and specs/behavior-tree-node-design.yaml.
 """
 
-import py_trees
 import pytest
-from py_trees.blackboard import Client as BlackboardClient
-from py_trees.common import Status
+from py_trees.composites import Sequence
+from typing import cast, Any
 
+from vultron.core.models.case_actor import VultronCaseActor
 from vultron.core.models.participant_status import VultronParticipantStatus
 from vultron.core.use_cases._helpers import _report_phase_status_id
-from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.core.models.vultron_types import (
-    VultronCaseActor,
     VultronOffer,
     VultronReport,
 )
@@ -42,67 +46,40 @@ from vultron.core.behaviors.report.nodes import (
     UpdateActorOutbox,
 )
 from vultron.core.states.rm import RM
+from test.core.behaviors.bt_harness import BTTestScenario
+
+# ============================================================================
+# Fixtures
+# ============================================================================
 
 
 @pytest.fixture
-def datalayer():
-    """In-memory DataLayer for testing."""
-    return SqliteDataLayer("sqlite:///:memory:")
+def actor(bt_scenario: BTTestScenario) -> VultronCaseActor:
+    """Create a test actor and persist it in the scenario DataLayer."""
+    obj = VultronCaseActor(name="Test Actor")
+    bt_scenario.dl.create(obj)
+    return obj
 
 
 @pytest.fixture
-def actor(datalayer):
-    """Create test actor."""
-    actor = VultronCaseActor(
-        name="Test Actor",
-    )
-    datalayer.create(actor)
-    return actor
-
-
-@pytest.fixture
-def report(datalayer):
-    """Create test report."""
-    report = VultronReport(
+def report(bt_scenario: BTTestScenario) -> VultronReport:
+    """Create a test report and persist it in the scenario DataLayer."""
+    obj = VultronReport(
         name="TEST-001",
         content="Test vulnerability report",
     )
-    datalayer.create(report)
-    return report
+    bt_scenario.dl.create(obj)
+    return obj
 
 
 @pytest.fixture
-def offer(datalayer, report, actor):
-    """Create test offer activity."""
-    offer = VultronOffer(actor=actor.id_, object_=report.id_)
-    datalayer.create(offer)
-    return offer
-
-
-@pytest.fixture
-def blackboard_client(datalayer, actor):
-    """Set up blackboard with DataLayer and actor_id."""
-    client = BlackboardClient(name="TestClient")
-    client.register_key(key="datalayer", access=py_trees.common.Access.WRITE)
-    client.register_key(key="actor_id", access=py_trees.common.Access.WRITE)
-    client.datalayer = datalayer
-    client.actor_id = actor.id_
-    return client
-
-
-def setup_node_blackboard(node, datalayer, actor_id):
-    """Helper to set up node with blackboard."""
-    node.setup()
-    # Register and set blackboard keys with WRITE access
-    node.blackboard.register_key(
-        key="datalayer", access=py_trees.common.Access.WRITE
-    )
-    node.blackboard.register_key(
-        key="actor_id", access=py_trees.common.Access.WRITE
-    )
-    node.blackboard.datalayer = datalayer
-    node.blackboard.actor_id = actor_id
-    node.initialise()
+def offer(
+    bt_scenario: BTTestScenario, report: VultronReport, actor: VultronCaseActor
+) -> VultronOffer:
+    """Create a test offer and persist it in the scenario DataLayer."""
+    obj = VultronOffer(actor=actor.id_, object_=report.id_)
+    bt_scenario.dl.create(obj)
+    return obj
 
 
 # ============================================================================
@@ -110,7 +87,9 @@ def setup_node_blackboard(node, datalayer, actor_id):
 # ============================================================================
 
 
-def test_check_rm_state_valid_when_valid(datalayer, actor, report):
+def test_check_rm_state_valid_when_valid(
+    bt_scenario: BTTestScenario, actor: VultronCaseActor, report: VultronReport
+) -> None:
     """CheckRMStateValid returns SUCCESS when report is VALID."""
     status = VultronParticipantStatus(
         id_=_report_phase_status_id(actor.id_, report.id_, RM.VALID.value),
@@ -118,16 +97,17 @@ def test_check_rm_state_valid_when_valid(datalayer, actor, report):
         attributed_to=actor.id_,
         rm_state=RM.VALID,
     )
-    datalayer.create(status)
+    bt_scenario.seed(status)
 
-    node = CheckRMStateValid(report_id=report.id_)
-    setup_node_blackboard(node, datalayer, actor.id_)
+    result = bt_scenario.run(
+        CheckRMStateValid(report_id=report.id_), actor_id=actor.id_
+    )
+    bt_scenario.assert_success(result)
 
-    result = node.update()
-    assert result == Status.SUCCESS
 
-
-def test_check_rm_state_valid_when_received(datalayer, actor, report):
+def test_check_rm_state_valid_when_received(
+    bt_scenario: BTTestScenario, actor: VultronCaseActor, report: VultronReport
+) -> None:
     """CheckRMStateValid returns FAILURE when report is RECEIVED (no VALID record)."""
     status = VultronParticipantStatus(
         id_=_report_phase_status_id(actor.id_, report.id_, RM.RECEIVED.value),
@@ -135,27 +115,27 @@ def test_check_rm_state_valid_when_received(datalayer, actor, report):
         attributed_to=actor.id_,
         rm_state=RM.RECEIVED,
     )
-    datalayer.create(status)
+    bt_scenario.seed(status)
 
-    node = CheckRMStateValid(report_id=report.id_)
-    setup_node_blackboard(node, datalayer, actor.id_)
+    result = bt_scenario.run(
+        CheckRMStateValid(report_id=report.id_), actor_id=actor.id_
+    )
+    bt_scenario.assert_failure(result)
 
-    result = node.update()
-    assert result == Status.FAILURE
 
-
-def test_check_rm_state_valid_when_no_status(datalayer, actor, report):
+def test_check_rm_state_valid_when_no_status(
+    bt_scenario: BTTestScenario, actor: VultronCaseActor, report: VultronReport
+) -> None:
     """CheckRMStateValid returns FAILURE when no status exists."""
-    node = CheckRMStateValid(report_id=report.id_)
-    setup_node_blackboard(node, datalayer, actor.id_)
-
-    result = node.update()
-    assert result == Status.FAILURE
+    result = bt_scenario.run(
+        CheckRMStateValid(report_id=report.id_), actor_id=actor.id_
+    )
+    bt_scenario.assert_failure(result)
 
 
 def test_check_rm_state_received_or_invalid_when_received(
-    datalayer, actor, report
-):
+    bt_scenario: BTTestScenario, actor: VultronCaseActor, report: VultronReport
+) -> None:
     """CheckRMStateReceivedOrInvalid returns SUCCESS when RECEIVED."""
     status = VultronParticipantStatus(
         id_=_report_phase_status_id(actor.id_, report.id_, RM.RECEIVED.value),
@@ -163,18 +143,17 @@ def test_check_rm_state_received_or_invalid_when_received(
         attributed_to=actor.id_,
         rm_state=RM.RECEIVED,
     )
-    datalayer.create(status)
+    bt_scenario.seed(status)
 
-    node = CheckRMStateReceivedOrInvalid(report_id=report.id_)
-    setup_node_blackboard(node, datalayer, actor.id_)
-
-    result = node.update()
-    assert result == Status.SUCCESS
+    result = bt_scenario.run(
+        CheckRMStateReceivedOrInvalid(report_id=report.id_), actor_id=actor.id_
+    )
+    bt_scenario.assert_success(result)
 
 
 def test_check_rm_state_received_or_invalid_when_invalid(
-    datalayer, actor, report
-):
+    bt_scenario: BTTestScenario, actor: VultronCaseActor, report: VultronReport
+) -> None:
     """CheckRMStateReceivedOrInvalid returns SUCCESS when INVALID."""
     status = VultronParticipantStatus(
         id_=_report_phase_status_id(actor.id_, report.id_, RM.INVALID.value),
@@ -182,18 +161,17 @@ def test_check_rm_state_received_or_invalid_when_invalid(
         attributed_to=actor.id_,
         rm_state=RM.INVALID,
     )
-    datalayer.create(status)
+    bt_scenario.seed(status)
 
-    node = CheckRMStateReceivedOrInvalid(report_id=report.id_)
-    setup_node_blackboard(node, datalayer, actor.id_)
-
-    result = node.update()
-    assert result == Status.SUCCESS
+    result = bt_scenario.run(
+        CheckRMStateReceivedOrInvalid(report_id=report.id_), actor_id=actor.id_
+    )
+    bt_scenario.assert_success(result)
 
 
 def test_check_rm_state_received_or_invalid_when_valid(
-    datalayer, actor, report
-):
+    bt_scenario: BTTestScenario, actor: VultronCaseActor, report: VultronReport
+) -> None:
     """CheckRMStateReceivedOrInvalid returns FAILURE when VALID."""
     status = VultronParticipantStatus(
         id_=_report_phase_status_id(actor.id_, report.id_, RM.VALID.value),
@@ -201,24 +179,22 @@ def test_check_rm_state_received_or_invalid_when_valid(
         attributed_to=actor.id_,
         rm_state=RM.VALID,
     )
-    datalayer.create(status)
+    bt_scenario.seed(status)
 
-    node = CheckRMStateReceivedOrInvalid(report_id=report.id_)
-    setup_node_blackboard(node, datalayer, actor.id_)
-
-    result = node.update()
-    assert result == Status.FAILURE
+    result = bt_scenario.run(
+        CheckRMStateReceivedOrInvalid(report_id=report.id_), actor_id=actor.id_
+    )
+    bt_scenario.assert_failure(result)
 
 
 def test_check_rm_state_received_or_invalid_when_no_status(
-    datalayer, actor, report
-):
+    bt_scenario: BTTestScenario, actor: VultronCaseActor, report: VultronReport
+) -> None:
     """CheckRMStateReceivedOrInvalid returns SUCCESS when no status (default RECEIVED)."""
-    node = CheckRMStateReceivedOrInvalid(report_id=report.id_)
-    setup_node_blackboard(node, datalayer, actor.id_)
-
-    result = node.update()
-    assert result == Status.SUCCESS
+    result = bt_scenario.run(
+        CheckRMStateReceivedOrInvalid(report_id=report.id_), actor_id=actor.id_
+    )
+    bt_scenario.assert_success(result)
 
 
 # ============================================================================
@@ -226,108 +202,101 @@ def test_check_rm_state_received_or_invalid_when_no_status(
 # ============================================================================
 
 
-def test_transition_rm_to_valid(datalayer, actor, report, offer):
+def test_transition_rm_to_valid(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    report: VultronReport,
+    offer: VultronOffer,
+) -> None:
     """TransitionRMtoValid updates statuses correctly."""
-    node = TransitionRMtoValid(report_id=report.id_, offer_id=offer.id_)
-    setup_node_blackboard(node, datalayer, actor.id_)
-
-    result = node.update()
-    assert result == Status.SUCCESS
-
-    valid_id = _report_phase_status_id(actor.id_, report.id_, RM.VALID.value)
-    assert datalayer.get("ParticipantStatus", valid_id) is not None
-
-
-def test_transition_rm_to_invalid(datalayer, actor, report, offer):
-    """TransitionRMtoInvalid updates report status to INVALID in DataLayer."""
-    node = TransitionRMtoInvalid(report_id=report.id_, offer_id=offer.id_)
-    setup_node_blackboard(node, datalayer, actor.id_)
-
-    result = node.update()
-    assert result == Status.SUCCESS
-
-    invalid_id = _report_phase_status_id(
-        actor.id_, report.id_, RM.INVALID.value
+    result = bt_scenario.run(
+        TransitionRMtoValid(report_id=report.id_, offer_id=offer.id_),
+        actor_id=actor.id_,
     )
-    assert datalayer.get("ParticipantStatus", invalid_id) is not None
+    bt_scenario.assert_success(result)
+    bt_scenario.assert_rm_state(report.id_, RM.VALID, actor_id=actor.id_)
 
 
-def test_create_case_node(datalayer, actor, report):
-    """CreateCaseNode creates VulnerabilityCase and stores case_id."""
-    node = CreateCaseNode(report_id=report.id_)
-    setup_node_blackboard(node, datalayer, actor.id_)
-
-    result = node.update()
-    assert result == Status.SUCCESS
-
-    # Verify case_id in blackboard
-    case_id = node.blackboard.get("case_id")
-    assert case_id is not None
-
-    # Verify case exists in DataLayer
-    case_obj = datalayer.read(case_id, raise_on_missing=True)
-    assert case_obj.name == f"Case for Report {report.id_}"
-    assert case_obj.attributed_to == actor.id_
+def test_transition_rm_to_invalid(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    report: VultronReport,
+    offer: VultronOffer,
+) -> None:
+    """TransitionRMtoInvalid updates report status to INVALID in DataLayer."""
+    result = bt_scenario.run(
+        TransitionRMtoInvalid(report_id=report.id_, offer_id=offer.id_),
+        actor_id=actor.id_,
+    )
+    bt_scenario.assert_success(result)
+    bt_scenario.assert_rm_state(report.id_, RM.INVALID, actor_id=actor.id_)
 
 
-def test_create_case_node_idempotency(datalayer, actor, report):
+def test_create_case_node(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    report: VultronReport,
+) -> None:
+    """CreateCaseNode creates a VulnerabilityCase in the DataLayer."""
+    result = bt_scenario.run(
+        CreateCaseNode(report_id=report.id_), actor_id=actor.id_
+    )
+    bt_scenario.assert_success(result)
+    bt_scenario.assert_case_count(1)
+
+    case = bt_scenario.assert_case_exists()
+    assert case.name == f"Case for Report {report.id_}"
+    assert case.attributed_to == actor.id_
+
+
+def test_create_case_node_idempotency(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    report: VultronReport,
+) -> None:
     """CreateCaseNode handles duplicate case creation gracefully."""
-    node = CreateCaseNode(report_id=report.id_)
-    setup_node_blackboard(node, datalayer, actor.id_)
+    result1 = bt_scenario.run(
+        CreateCaseNode(report_id=report.id_), actor_id=actor.id_
+    )
+    bt_scenario.assert_success(result1)
 
-    # First creation
-    result1 = node.update()
-    assert result1 == Status.SUCCESS
-
-    # Second creation (should log warning but still succeed)
-    result2 = node.update()
-    assert result2 == Status.SUCCESS
+    result2 = bt_scenario.run(
+        CreateCaseNode(report_id=report.id_), actor_id=actor.id_
+    )
+    bt_scenario.assert_success(result2)
 
 
-def test_create_case_activity(datalayer, actor, report, offer):
+def test_create_case_activity(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    report: VultronReport,
+    offer: VultronOffer,
+) -> None:
     """CreateCaseActivity creates activity with recipients and embedded case."""
-    # Add a finder actor whose ID will be collected as an addressee.
-    from vultron.core.models.case_actor import VultronCaseActor
-
     finder = VultronCaseActor(name="Finder Actor")
-    datalayer.create(finder)
+    bt_scenario.dl.create(finder)
 
     # Set report.attributed_to so the finder appears in the addressees list.
     report.attributed_to = finder.id_
-    datalayer.save(report)
+    bt_scenario.dl.save(report)
 
-    # First create case to populate case_id in blackboard
-    case_node = CreateCaseNode(report_id=report.id_)
-    setup_node_blackboard(case_node, datalayer, actor.id_)
-    case_node.update()
-
-    # Create activity node
-    activity_node = CreateCaseActivity(
-        report_id=report.id_, offer_id=offer.id_
+    chain = Sequence(
+        "CreateAndNotify",
+        memory=True,
+        children=[
+            CreateCaseNode(report_id=report.id_),
+            CreateCaseActivity(report_id=report.id_, offer_id=offer.id_),
+        ],
     )
-    activity_node.blackboard = (
-        case_node.blackboard
-    )  # Reuse blackboard with case_id
-    activity_node.initialise()
+    result = bt_scenario.run(chain, actor_id=actor.id_)
+    bt_scenario.assert_success(result)
 
-    result = activity_node.update()
-    assert result == Status.SUCCESS
-
-    # Verify activity_id in blackboard
-    activity_id = activity_node.blackboard.get("activity_id")
-    assert activity_id is not None
-
-    # VultronCreateCaseActivity (type_="Create") cannot be round-tripped via
-    # datalayer.read() because the "Create" wire class is not imported in the
-    # test environment.  Use by_type("Create") to get the raw stored data dict.
-    create_activities = datalayer.by_type("Create")
-    assert (
-        activity_id in create_activities
-    ), f"Expected Create activity {activity_id!r} in DataLayer"
+    create_activities = bt_scenario.dl.by_type("Create")
+    assert len(create_activities) == 1, "Expected exactly one Create activity"
+    activity_id = next(iter(create_activities))
     activity_data = create_activities[activity_id]
-    assert activity_data.get("type_") == "Create"
 
-    # Verify the activity carries recipients (to field) excluding the sender.
+    assert activity_data.get("type_") == "Create"
     assert activity_data.get(
         "to"
     ), "CreateCaseActivity should have 'to' recipients"
@@ -337,70 +306,62 @@ def test_create_case_activity(datalayer, actor, report, offer):
     assert (
         finder.id_ in activity_data["to"]
     ), "Finder (report.attributed_to) should be in 'to' recipients"
-
-    # object_ is dehydrated to the case ID string at storage time; re-expansion
-    # to the full case happens in outbox_handler at delivery time.
     assert isinstance(
         activity_data.get("object_"), str
     ), "CreateCaseActivity object_ should be stored as the case ID string"
 
 
-def test_create_case_activity_missing_case_id(datalayer, actor, report, offer):
-    """CreateCaseActivity fails if case_id not in blackboard."""
-    node = CreateCaseActivity(report_id=report.id_, offer_id=offer.id_)
-    setup_node_blackboard(node, datalayer, actor.id_)
-    # Register case_id with WRITE access for testing
-    node.blackboard.register_key(
-        key="case_id", access=py_trees.common.Access.WRITE
+def test_create_case_activity_missing_case_id(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    report: VultronReport,
+    offer: VultronOffer,
+) -> None:
+    """CreateCaseActivity fails if no preceding CreateCaseNode set case_id."""
+    result = bt_scenario.run(
+        CreateCaseActivity(report_id=report.id_, offer_id=offer.id_),
+        actor_id=actor.id_,
     )
-    # Explicitly set case_id to None to test error handling
-    node.blackboard.set("case_id", None, overwrite=True)
-
-    result = node.update()
-    assert result == Status.FAILURE
+    bt_scenario.assert_failure(result)
 
 
-def test_update_actor_outbox(datalayer, actor, report, offer):
+def test_update_actor_outbox(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    report: VultronReport,
+    offer: VultronOffer,
+) -> None:
     """UpdateActorOutbox appends activity to actor's outbox."""
-    # First create case and activity to populate blackboard
-    case_node = CreateCaseNode(report_id=report.id_)
-    setup_node_blackboard(case_node, datalayer, actor.id_)
-    case_node.update()
-
-    activity_node = CreateCaseActivity(
-        report_id=report.id_, offer_id=offer.id_
+    chain = Sequence(
+        "CreateAndPost",
+        memory=True,
+        children=[
+            CreateCaseNode(report_id=report.id_),
+            CreateCaseActivity(report_id=report.id_, offer_id=offer.id_),
+            UpdateActorOutbox(),
+        ],
     )
-    activity_node.blackboard = case_node.blackboard
-    activity_node.initialise()
-    activity_node.update()
+    result = bt_scenario.run(chain, actor_id=actor.id_)
+    bt_scenario.assert_success(result)
 
-    # Update outbox
-    outbox_node = UpdateActorOutbox()
-    outbox_node.blackboard = activity_node.blackboard
-    outbox_node.initialise()
-
-    result = outbox_node.update()
-    assert result == Status.SUCCESS
-
-    # Verify activity in actor's outbox
-    updated_actor = datalayer.read(actor.id_, raise_on_missing=True)
-    activity_id = outbox_node.blackboard.get("activity_id")
+    updated_actor = cast(
+        Any, bt_scenario.dl.read(actor.id_, raise_on_missing=True)
+    )
+    create_activities = bt_scenario.dl.by_type("Create")
+    assert (
+        create_activities
+    ), "Expected at least one Create activity in DataLayer"
+    activity_id = next(iter(create_activities))
     assert activity_id in updated_actor.outbox.items
 
 
-def test_update_actor_outbox_missing_activity_id(datalayer, actor):
-    """UpdateActorOutbox fails if activity_id not in blackboard."""
-    node = UpdateActorOutbox()
-    setup_node_blackboard(node, datalayer, actor.id_)
-    # Register activity_id with WRITE access for testing
-    node.blackboard.register_key(
-        key="activity_id", access=py_trees.common.Access.WRITE
-    )
-    # Explicitly set activity_id to None to test error handling
-    node.blackboard.set("activity_id", None, overwrite=True)
-
-    result = node.update()
-    assert result == Status.FAILURE
+def test_update_actor_outbox_missing_activity_id(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+) -> None:
+    """UpdateActorOutbox fails if no preceding node set activity_id."""
+    result = bt_scenario.run(UpdateActorOutbox(), actor_id=actor.id_)
+    bt_scenario.assert_failure(result)
 
 
 # ============================================================================
@@ -408,22 +369,28 @@ def test_update_actor_outbox_missing_activity_id(datalayer, actor):
 # ============================================================================
 
 
-def test_evaluate_report_credibility(datalayer, actor, report):
+def test_evaluate_report_credibility(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    report: VultronReport,
+) -> None:
     """EvaluateReportCredibility always returns SUCCESS (stub)."""
-    node = EvaluateReportCredibility(report_id=report.id_)
-    setup_node_blackboard(node, datalayer, actor.id_)
+    result = bt_scenario.run(
+        EvaluateReportCredibility(report_id=report.id_), actor_id=actor.id_
+    )
+    bt_scenario.assert_success(result)
 
-    result = node.update()
-    assert result == Status.SUCCESS
 
-
-def test_evaluate_report_validity(datalayer, actor, report):
+def test_evaluate_report_validity(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    report: VultronReport,
+) -> None:
     """EvaluateReportValidity always returns SUCCESS (stub)."""
-    node = EvaluateReportValidity(report_id=report.id_)
-    setup_node_blackboard(node, datalayer, actor.id_)
-
-    result = node.update()
-    assert result == Status.SUCCESS
+    result = bt_scenario.run(
+        EvaluateReportValidity(report_id=report.id_), actor_id=actor.id_
+    )
+    bt_scenario.assert_success(result)
 
 
 # ============================================================================
@@ -431,57 +398,64 @@ def test_evaluate_report_validity(datalayer, actor, report):
 # ============================================================================
 
 
-def test_full_validation_workflow(datalayer, actor, report, offer):
+def test_full_validation_workflow(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    report: VultronReport,
+    offer: VultronOffer,
+) -> None:
     """Test full validation workflow using all nodes in sequence."""
     # 1. Check if already valid (should fail initially)
-    check_valid = CheckRMStateValid(report_id=report.id_)
-    setup_node_blackboard(check_valid, datalayer, actor.id_)
-    assert check_valid.update() == Status.FAILURE
+    bt_scenario.assert_failure(
+        bt_scenario.run(
+            CheckRMStateValid(report_id=report.id_), actor_id=actor.id_
+        )
+    )
 
-    # 2. Check preconditions (should succeed)
-    check_precond = CheckRMStateReceivedOrInvalid(report_id=report.id_)
-    setup_node_blackboard(check_precond, datalayer, actor.id_)
-    assert check_precond.update() == Status.SUCCESS
+    # 2. Check preconditions (should succeed — no status = default RECEIVED)
+    bt_scenario.assert_success(
+        bt_scenario.run(
+            CheckRMStateReceivedOrInvalid(report_id=report.id_),
+            actor_id=actor.id_,
+        )
+    )
 
     # 3. Evaluate credibility (stub: always succeeds)
-    eval_cred = EvaluateReportCredibility(report_id=report.id_)
-    setup_node_blackboard(eval_cred, datalayer, actor.id_)
-    assert eval_cred.update() == Status.SUCCESS
+    bt_scenario.assert_success(
+        bt_scenario.run(
+            EvaluateReportCredibility(report_id=report.id_), actor_id=actor.id_
+        )
+    )
 
     # 4. Evaluate validity (stub: always succeeds)
-    eval_valid = EvaluateReportValidity(report_id=report.id_)
-    setup_node_blackboard(eval_valid, datalayer, actor.id_)
-    assert eval_valid.update() == Status.SUCCESS
+    bt_scenario.assert_success(
+        bt_scenario.run(
+            EvaluateReportValidity(report_id=report.id_), actor_id=actor.id_
+        )
+    )
 
     # 5. Transition to VALID
-    transition = TransitionRMtoValid(report_id=report.id_, offer_id=offer.id_)
-    setup_node_blackboard(transition, datalayer, actor.id_)
-    assert transition.update() == Status.SUCCESS
-
-    # 6. Create case
-    create_case = CreateCaseNode(report_id=report.id_)
-    create_case.blackboard = transition.blackboard
-    create_case.initialise()
-    assert create_case.update() == Status.SUCCESS
-
-    # 7. Create activity
-    create_activity = CreateCaseActivity(
-        report_id=report.id_, offer_id=offer.id_
+    bt_scenario.assert_success(
+        bt_scenario.run(
+            TransitionRMtoValid(report_id=report.id_, offer_id=offer.id_),
+            actor_id=actor.id_,
+        )
     )
-    create_activity.blackboard = create_case.blackboard
-    create_activity.initialise()
-    assert create_activity.update() == Status.SUCCESS
 
-    # 8. Update outbox
-    update_outbox = UpdateActorOutbox()
-    update_outbox.blackboard = create_activity.blackboard
-    update_outbox.initialise()
-    assert update_outbox.update() == Status.SUCCESS
+    # 6. Create case, activity, update outbox — share blackboard via Sequence
+    actions = Sequence(
+        "ValidationActions",
+        memory=True,
+        children=[
+            CreateCaseNode(report_id=report.id_),
+            CreateCaseActivity(report_id=report.id_, offer_id=offer.id_),
+            UpdateActorOutbox(),
+        ],
+    )
+    bt_scenario.assert_success(bt_scenario.run(actions, actor_id=actor.id_))
 
-    # 9. Verify final state
-    check_valid_final = CheckRMStateValid(report_id=report.id_)
-    setup_node_blackboard(check_valid_final, datalayer, actor.id_)
-    assert check_valid_final.update() == Status.SUCCESS
+    # 7. Verify final state
+    bt_scenario.assert_rm_state(report.id_, RM.VALID, actor_id=actor.id_)
 
 
 # ============================================================================
@@ -490,56 +464,49 @@ def test_full_validation_workflow(datalayer, actor, report, offer):
 
 
 def test_update_actor_outbox_logs_create_activity_type(
-    datalayer, actor, report, offer, caplog
-):
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    report: VultronReport,
+    offer: VultronOffer,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """UpdateActorOutbox MUST log 'Create' activity type (D5-6-LOGCTX)."""
-    case_node = CreateCaseNode(report_id=report.id_)
-    setup_node_blackboard(case_node, datalayer, actor.id_)
-    case_node.update()
-
-    activity_node = CreateCaseActivity(
-        report_id=report.id_, offer_id=offer.id_
+    chain = Sequence(
+        "CreateAndPost",
+        memory=True,
+        children=[
+            CreateCaseNode(report_id=report.id_),
+            CreateCaseActivity(report_id=report.id_, offer_id=offer.id_),
+            UpdateActorOutbox(),
+        ],
     )
-    activity_node.blackboard = case_node.blackboard
-    activity_node.initialise()
-    activity_node.update()
-
-    outbox_node = UpdateActorOutbox()
-    outbox_node.blackboard = activity_node.blackboard
-    outbox_node.initialise()
-
     with caplog.at_level("INFO"):
-        outbox_node.update()
+        bt_scenario.run(chain, actor_id=actor.id_)
 
     assert "Create" in caplog.text
 
 
 def test_update_actor_outbox_logs_case_id_in_message(
-    datalayer, actor, report, offer, caplog
-):
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    report: VultronReport,
+    offer: VultronOffer,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """UpdateActorOutbox MUST log the case ID in the outbox message (D5-6-LOGCTX)."""
-    case_node = CreateCaseNode(report_id=report.id_)
-    setup_node_blackboard(case_node, datalayer, actor.id_)
-    case_node.update()
-
-    # Capture case_id from blackboard
-    case_node.blackboard.register_key(
-        key="case_id", access=py_trees.common.Access.READ
+    chain = Sequence(
+        "CreateAndPost",
+        memory=True,
+        children=[
+            CreateCaseNode(report_id=report.id_),
+            CreateCaseActivity(report_id=report.id_, offer_id=offer.id_),
+            UpdateActorOutbox(),
+        ],
     )
-    case_id = case_node.blackboard.get("case_id")
-
-    activity_node = CreateCaseActivity(
-        report_id=report.id_, offer_id=offer.id_
-    )
-    activity_node.blackboard = case_node.blackboard
-    activity_node.initialise()
-    activity_node.update()
-
-    outbox_node = UpdateActorOutbox()
-    outbox_node.blackboard = activity_node.blackboard
-    outbox_node.initialise()
-
     with caplog.at_level("INFO"):
-        outbox_node.update()
+        bt_scenario.run(chain, actor_id=actor.id_)
 
+    cases = bt_scenario.dl.by_type("VulnerabilityCase")
+    assert cases, "Expected VulnerabilityCase to be created"
+    case_id = next(iter(cases))
     assert case_id in caplog.text

--- a/test/core/behaviors/test_bt_harness.py
+++ b/test/core/behaviors/test_bt_harness.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""
+Tests for the BTTestScenario harness itself.
+
+Covers:
+- bt_scenario_factory: leadership guard (SYNC-09-003), custom actor IDs, shared DL
+- shared_dl_actors: multi-actor shared DataLayer fixture
+"""
+
+from typing import Callable
+
+import py_trees
+
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from test.core.behaviors.bt_harness import BTTestScenario
+
+
+class TestBTScenarioFactory:
+    """Tests for the bt_scenario_factory fixture (SYNC-09-003 leadership guard)."""
+
+    def test_non_leader_returns_failure(
+        self,
+        bt_scenario_factory: Callable[..., BTTestScenario],
+    ) -> None:
+        """When is_leader=False, execute_with_setup returns FAILURE immediately."""
+        scenario = bt_scenario_factory(is_leader=False)
+        node = py_trees.behaviours.Success("dummy")
+        result = scenario.bridge.execute_with_setup(
+            node, actor_id=scenario.actor_id
+        )
+        assert result.status == py_trees.common.Status.FAILURE
+        assert "not the replication leader" in result.feedback_message
+
+    def test_leader_returns_success(
+        self,
+        bt_scenario_factory: Callable[..., BTTestScenario],
+    ) -> None:
+        """When is_leader=True (default), a Success node returns SUCCESS."""
+        scenario = bt_scenario_factory(is_leader=True)
+        node = py_trees.behaviours.Success("dummy")
+        result = scenario.bridge.execute_with_setup(
+            node, actor_id=scenario.actor_id
+        )
+        assert result.status == py_trees.common.Status.SUCCESS
+
+    def test_custom_actor_id(
+        self,
+        bt_scenario_factory: Callable[..., BTTestScenario],
+    ) -> None:
+        """Factory respects the actor_id argument."""
+        custom_id = "https://example.org/actors/custom"
+        scenario = bt_scenario_factory(actor_id=custom_id)
+        assert scenario.actor_id == custom_id
+
+    def test_shared_dl_parameter(
+        self,
+        bt_scenario_factory: Callable[..., BTTestScenario],
+    ) -> None:
+        """Two factory instances created with the same dl share data."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        s1 = bt_scenario_factory(
+            actor_id="https://example.org/actors/a1", dl=dl
+        )
+        s2 = bt_scenario_factory(
+            actor_id="https://example.org/actors/a2", dl=dl
+        )
+        assert s1.dl is s2.dl
+
+
+class TestSharedDlActors:
+    """Tests for the shared_dl_actors fixture (multi-actor shared DataLayer)."""
+
+    def test_both_scenarios_share_same_dl(
+        self,
+        shared_dl_actors: tuple[BTTestScenario, BTTestScenario],
+    ) -> None:
+        """vendor and reporter operate on the same DataLayer instance."""
+        vendor, reporter = shared_dl_actors
+        assert vendor.dl is reporter.dl
+
+    def test_vendor_actor_persisted(
+        self,
+        shared_dl_actors: tuple[BTTestScenario, BTTestScenario],
+    ) -> None:
+        """Vendor actor record is readable from the shared DataLayer."""
+        vendor, _ = shared_dl_actors
+        record = vendor.dl.read(vendor.actor_id)
+        assert record is not None
+
+    def test_reporter_actor_persisted(
+        self,
+        shared_dl_actors: tuple[BTTestScenario, BTTestScenario],
+    ) -> None:
+        """Reporter actor record is readable from the shared DataLayer."""
+        _, reporter = shared_dl_actors
+        record = reporter.dl.read(reporter.actor_id)
+        assert record is not None
+
+    def test_reporter_visible_from_vendor_dl(
+        self,
+        shared_dl_actors: tuple[BTTestScenario, BTTestScenario],
+    ) -> None:
+        """Reporter actor is visible when looked up via vendor's DataLayer."""
+        vendor, reporter = shared_dl_actors
+        record = vendor.dl.read(reporter.actor_id)
+        assert record is not None
+
+    def test_distinct_actor_ids(
+        self,
+        shared_dl_actors: tuple[BTTestScenario, BTTestScenario],
+    ) -> None:
+        """Vendor and reporter have different actor IDs."""
+        vendor, reporter = shared_dl_actors
+        assert vendor.actor_id != reporter.actor_id

--- a/test/core/states/test_cvd_roles.py
+++ b/test/core/states/test_cvd_roles.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""
+Unit tests for CVDRoles enum.
+
+Spec coverage:
+- BTND-05-001: CVDRoles MUST include a CASE_OWNER flag value.
+"""
+
+from vultron.core.states.roles import CVDRoles
+
+
+def test_case_owner_exists():
+    """CVDRoles.CASE_OWNER must exist (BTND-05-001)."""
+    assert hasattr(CVDRoles, "CASE_OWNER")
+    assert CVDRoles.CASE_OWNER in CVDRoles
+
+
+def test_case_owner_is_distinct():
+    """CVDRoles.CASE_OWNER must be distinct from all other role values."""
+    other_roles = [
+        CVDRoles.FINDER,
+        CVDRoles.REPORTER,
+        CVDRoles.VENDOR,
+        CVDRoles.DEPLOYER,
+        CVDRoles.COORDINATOR,
+        CVDRoles.OTHER,
+    ]
+    for role in other_roles:
+        assert CVDRoles.CASE_OWNER != role, f"CASE_OWNER must not equal {role}"
+
+
+def test_case_owner_combinable_with_other_roles():
+    """CVDRoles.CASE_OWNER can be combined with other roles via bitwise OR."""
+    combined = CVDRoles.VENDOR | CVDRoles.CASE_OWNER
+    assert CVDRoles.CASE_OWNER in combined
+    assert CVDRoles.VENDOR in combined
+
+
+def test_existing_roles_unchanged():
+    """Adding CASE_OWNER must not change the values of existing roles."""
+    assert CVDRoles.NO_ROLE.value == 0
+    assert CVDRoles.FINDER.value == 1
+    assert CVDRoles.REPORTER.value == 2
+    assert CVDRoles.VENDOR.value == 4
+    assert CVDRoles.DEPLOYER.value == 8
+    assert CVDRoles.COORDINATOR.value == 16
+    assert CVDRoles.OTHER.value == 32

--- a/test/wire/as2/factories/test_errors.py
+++ b/test/wire/as2/factories/test_errors.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""
+Unit tests for vultron.wire.as2.factories.errors.
+
+Spec coverage:
+- AF-04-001: Factory functions MUST wrap ValidationError in
+  VultronActivityConstructionError.
+- AF-04-002: VultronActivityConstructionError MUST be defined in
+  factories/errors.py and re-exported from factories/__init__.py.
+"""
+
+import pytest
+
+from vultron.errors import VultronError
+from vultron.wire.as2.factories import VultronActivityConstructionError
+from vultron.wire.as2.factories.errors import (
+    VultronActivityConstructionError as DirectImport,
+)
+
+
+def test_construction_error_is_vultron_error():
+    """VultronActivityConstructionError must inherit from VultronError (AF-04-002)."""
+    assert issubclass(VultronActivityConstructionError, VultronError)
+
+
+def test_construction_error_reexported_from_package():
+    """VultronActivityConstructionError must be importable from factories __init__ (AF-04-002)."""
+    assert VultronActivityConstructionError is DirectImport
+
+
+def test_construction_error_can_be_raised_with_cause():
+    """VultronActivityConstructionError supports chained __cause__ (AF-04-001)."""
+    original = ValueError("bad field")
+    try:
+        raise VultronActivityConstructionError("factory failed") from original
+    except VultronActivityConstructionError as exc:
+        assert str(exc) == "factory failed"
+        assert exc.__cause__ is original
+
+
+def test_construction_error_is_catchable_as_vultron_error():
+    """VultronActivityConstructionError is catchable as VultronError."""
+    with pytest.raises(VultronError):
+        raise VultronActivityConstructionError("test")

--- a/test/wire/as2/vocab/test_actvitities/test_object_types.py
+++ b/test/wire/as2/vocab/test_actvitities/test_object_types.py
@@ -536,6 +536,7 @@ def test_handle_outbox_item_raises_on_bare_string_object(caplog):
     activity = VultronActivity(
         type_="Create",
         actor=ACTOR_ID,
+        to=[ACTOR_ID],
         object_=_STR_URI,
     )
 

--- a/vultron/adapters/driving/fastapi/outbox_handler.py
+++ b/vultron/adapters/driving/fastapi/outbox_handler.py
@@ -31,7 +31,10 @@ from vultron.adapters.driven.delivery_queue import DeliveryQueueAdapter
 from vultron.core.models.activity import VultronActivity
 from vultron.core.ports.datalayer import DataLayer
 from vultron.core.ports.emitter import ActivityEmitter
-from vultron.errors import VultronOutboxObjectIntegrityError
+from vultron.errors import (
+    VultronOutboxObjectIntegrityError,
+    VultronOutboxToFieldMissingError,
+)
 from vultron.wire.as2.vocab.base.links import as_Link
 
 logger = logging.getLogger(__name__)
@@ -225,6 +228,33 @@ async def handle_outbox_item(
 
     activity_type = getattr(outbound_activity, "type_", "Activity")
     activity_object = getattr(outbound_activity, "object_", None)
+
+    # Validate to: field (OX-08-001, OX-08-002, OX-08-003)
+    to_field = getattr(outbound_activity, "to", None)
+    _to_empty = to_field is None or (
+        isinstance(to_field, list) and len(to_field) == 0
+    )
+    if _to_empty:
+        raise VultronOutboxToFieldMissingError(
+            f"Outbound {activity_type} activity '{activity_id}' has no"
+            " `to:` field. All outbound Vultron activities MUST address"
+            " at least one recipient via `to:` (OX-08-001).",
+            activity_id=activity_id,
+            activity_type=activity_type,
+        )
+
+    # Warn if cc/bto/bcc are set (OX-08-004)
+    for _addr_field in ("cc", "bto", "bcc"):
+        _val = getattr(outbound_activity, _addr_field, None)
+        if _val is not None and _val != []:
+            logger.warning(
+                "Outbound %s activity '%s' has `%s:` set."
+                " Vultron direct messages should only use `to:` for"
+                " addressing (OX-08-004).",
+                activity_type,
+                activity_id,
+                _addr_field,
+            )
 
     # For initiating activity types, expand an ID-string object_ to the full
     # domain object so the recipient inbox endpoint can store it separately

--- a/vultron/adapters/driving/fastapi/outbox_handler.py
+++ b/vultron/adapters/driving/fastapi/outbox_handler.py
@@ -237,8 +237,9 @@ async def handle_outbox_item(
     if _to_empty:
         raise VultronOutboxToFieldMissingError(
             f"Outbound {activity_type} activity '{activity_id}' has no"
-            " `to:` field. All outbound Vultron activities MUST address"
-            " at least one recipient via `to:` (OX-08-001).",
+            " `to:` field or has an empty `to:` list. All outbound"
+            " Vultron activities MUST address at least one recipient via"
+            " `to:` (OX-08-001).",
             activity_id=activity_id,
             activity_type=activity_type,
         )

--- a/vultron/core/states/roles.py
+++ b/vultron/core/states/roles.py
@@ -35,6 +35,7 @@ class CVDRoles(Flag):
     DEPLOYER = auto()
     COORDINATOR = auto()
     OTHER = auto()
+    CASE_OWNER = auto()
 
     # shorthand
     F = FINDER

--- a/vultron/errors.py
+++ b/vultron/errors.py
@@ -54,6 +54,25 @@ class VultronApiHandlerNotFoundError(VultronError, KeyError):
     """Raised when no handler is found for a given activity type."""
 
 
+class VultronOutboxToFieldMissingError(VultronError):
+    """Raised when an outbound activity lacks a non-empty ``to:`` field.
+
+    All Vultron protocol exchanges are direct messages.  Every outbound
+    activity MUST address at least one recipient via ``to:``.
+    See specs/outbox.yaml OX-08-001, OX-08-002, OX-08-003.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        activity_id: str | None = None,
+        activity_type: str | None = None,
+    ):
+        self.activity_id = activity_id
+        self.activity_type = activity_type
+        super().__init__(message)
+
+
 class VultronOutboxObjectIntegrityError(VultronError):
     """Raised when an outbound activity's object_ is a bare string URI or
     Link reference instead of the required inline domain object.

--- a/vultron/wire/as2/factories/__init__.py
+++ b/vultron/wire/as2/factories/__init__.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""
+Public construction API for outbound Vultron protocol activities.
+
+Factory functions in this package are the sole public API for building
+outbound Vultron activities.  Internal activity subclasses in
+``vultron/wire/as2/vocab/activities/`` are implementation details used
+only inside factory functions — callers MUST NOT import them directly.
+See ``specs/activity-factories.yaml`` AF-01-001, AF-02-001 through
+AF-02-004.
+
+Domain modules (``report.py``, ``case.py``, ``embargo.py``,
+``case_participant.py``, ``actor.py``, ``sync.py``) will be added as
+factory functions are implemented (AF.2 through AF.6).
+"""
+
+from vultron.wire.as2.factories.errors import VultronActivityConstructionError
+
+__all__ = [
+    "VultronActivityConstructionError",
+]

--- a/vultron/wire/as2/factories/errors.py
+++ b/vultron/wire/as2/factories/errors.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""
+Exceptions raised by Vultron activity factory functions.
+"""
+
+from vultron.errors import VultronError
+
+
+class VultronActivityConstructionError(VultronError):
+    """Raised when a factory function cannot construct the requested activity.
+
+    Wraps a Pydantic ``ValidationError`` as ``__cause__`` so that callers
+    can inspect the original validation details if needed.  Factory
+    functions MUST catch ``pydantic.ValidationError`` and re-raise as this
+    exception to keep internal activity class names out of public error
+    messages.  See ``specs/activity-factories.yaml`` AF-04-001, AF-04-002.
+    """


### PR DESCRIPTION
Please note: Pull request submissions are subject to our
[Contribution Instructions](https://github.com/CERTCC/Vultron/blob/main/ContributionInstructions.md)

---

## Summary

This branch delivers four related improvements across test infrastructure, BT harness design, codebase documentation, and protocol enforcement:

1. **BTTestScenario harness** (closes #401) — deep-module test harness eliminating boilerplate from BT node tests
2. **Codebase onboarding docs** — seven evidence-backed reference pages under `docs/codebase/`
3. **BT harness coverage** — dedicated test file for the harness fixtures themselves
4. **Protocol enforcement + scaffolding** — outbox `to:` field enforcement, `CVDRoles.CASE_OWNER`, and activity factories package

---

## Changes

### `ead413b4` — Introduce BTTestScenario deep-module test harness (closes #401)

- Creates `test/core/behaviors/bt_harness.py` with `BTTestScenario` class and three pytest fixtures: `bt_scenario`, `bt_scenario_factory`, and `shared_dl_actors`
- Rewrites `test/core/behaviors/report/test_nodes.py` and `test/core/behaviors/case/test_nodes.py` to eliminate duplicated `setup_node_blackboard()` boilerplate and direct `node.update()` anti-patterns
- All BT execution now routes through `BTBridge.execute_with_setup()`, exercising the full `setup() → initialise() → update() → shutdown()` lifecycle in tests
- Exports the three harness fixtures from `conftest.py`

### `5470d4db` — Add codebase onboarding reference docs

- Adds seven evidence-backed pages under `docs/codebase/`: STACK, STRUCTURE, ARCHITECTURE, CONVENTIONS, INTEGRATIONS, TESTING, CONCERNS
- Adds all new pages to the MkDocs navigation

### `21912ecd` — Add test_bt_harness.py: cover harness fixtures

- Adds `test/core/behaviors/test_bt_harness.py` covering `bt_scenario_factory` (leadership guard rejection, success path, custom actor ID, shared DataLayer) and `shared_dl_actors` (DataLayer identity, cross-actor visibility)

### `ed65eacd` — Enforce outbox `to:` field; add `CVDRoles.CASE_OWNER`; scaffold factories package

**TASK-OUTBOX-TO** (OX-08-001–004):
- Adds `VultronOutboxToFieldMissingError` to `vultron/errors.py`
- Enforces `to:` presence check in `handle_outbox_item` before object expansion
- Logs `WARNING` when `cc`/`bto`/`bcc` are non-empty
- Adds 6 new tests in `test_outbox.py` covering raise branches and warning branches

**TASK-BTND5.1** (BTND-05-001):
- Adds `CASE_OWNER = auto()` to `CVDRoles` Flag enum
- Adds `test/core/states/test_cvd_roles.py` with 4 tests

**TASK-AF.1** (AF-02-004, AF-04-002):
- Creates `vultron/wire/as2/factories/` package with `errors.py` defining `VultronActivityConstructionError` and `__init__.py` re-exporting it
- Adds `test/wire/as2/factories/test_errors.py` with 4 tests

---

## Test results

2000 tests pass, all linters clean.

---

## Related

- Closes #401 (BTTestScenario harness)
- Implements TASK-OUTBOX-TO (`specs/outbox.yaml` OX-08-001–004)
- Implements TASK-BTND5.1 (`specs/behavior-tree-node-design.yaml` BTND-05-001)
- Implements TASK-AF.1 (`specs/activity-factories.yaml` AF-02-004, AF-04-002)
