### PR TITLE
specs: ingest IDEA-26050501 — case initialization sequence

### DIFF
--- a/notes/case-creation-sequence.md
+++ b/notes/case-creation-sequence.md
@@ -1,0 +1,166 @@
+---
+title: Case Creation Sequence
+status: active
+description: >
+  Design decisions and BT implementation mapping for the canonical case
+  initialization sequence at Offer(Report) receipt (CM-14, ADR-0015).
+related_specs:
+  - specs/case-management.yaml
+related_notes:
+  - notes/case-state-model.md
+  - notes/embargo-default-semantics.md
+  - notes/protocol-event-cascades.md
+  - notes/participant-embargo-consent.md
+relevant_packages:
+  - vultron/core/behaviors/case
+  - vultron/core/behaviors/report
+  - vultron/core/use_cases/received
+---
+
+# Case Creation Sequence
+
+## Overview
+
+When a vendor actor receives an `Offer(Report)` activity, it immediately
+creates a `VulnerabilityCase` (ADR-0015, CM-12-001) and runs a canonical
+initialization sequence before any other case activity can proceed.
+
+This note captures the ordering decisions, their rationale, and the
+mapping to the behavior tree nodes that implement each step.
+
+**Spec reference**: `specs/case-management.yaml` CM-14 (source: IDEA-26050501).
+
+---
+
+## Decision Table
+
+| Question | Decision | Rationale |
+|---|---|---|
+| When is the case created? | At `Offer(Report)` receipt (RM.RECEIVED) | ADR-0015; eliminates pre-case tracking complexity |
+| Who is the first participant? | Case owner (receiving actor) | Embargo must be created by an existing participant |
+| Does the owner participant exist before the embargo? | Yes — owner MUST precede embargo | An embargo without a participant lacks an owning actor |
+| When is the default embargo initialized? | After owner participant exists, before reporter is added | Owner initiates the embargo on behalf of the case |
+| Is the owner seeded as SIGNATORY? | Yes — automatically at embargo initialization | Case owner created the embargo; separate accept step is paradoxical |
+| Is the reporter seeded as SIGNATORY? | Yes — automatically when added as participant | Reporter already holds the information; requiring explicit accept before content access is a deadlock |
+| When is `Create(Case)` sent to reporter? | After embargo init, before reporter is added as participant | Reporter must have case object before receiving fan-out log entries |
+| Can additional parties be invited before initialization completes? | No — initialization MUST complete first (CM-14-007) | Prevents race conditions and protocol violations |
+
+---
+
+## Canonical Sequence (CM-14-001)
+
+The following steps MUST execute in order:
+
+| Step | Action | Key Constraint |
+|---|---|---|
+| 1 | Create `VulnerabilityCase` with receiving actor as `attributed_to` | — |
+| 2 | Create case-owner `VultronParticipant` (RM.RECEIVED, `CVDRole.CASE_OWNER`) | **Must precede step 3** |
+| 3 | Initialize default embargo → `EM.ACTIVE`; seed owner as `SIGNATORY` | Conditional on embargo policy being configured (CM-12-004) |
+| 4 | Queue `Create(Case)` activity addressed to reporter; flush outbox | **Must precede step 5** |
+| 5 | Add reporter `VultronParticipant` (RM.ACCEPTED, `CVDRole.FINDER`/`REPORTER`); seed as `SIGNATORY` | — |
+| 6 | Commit case log entry → `Announce(CaseLogEntry)` fan-out to all participants | Reporter is now a participant and receives the fan-out |
+
+Steps 3 and 6 are each conditional (embargo policy must exist for step 3;
+fan-out only reaches the participants who exist at that point for step 6),
+but their *position* in the sequence is fixed.
+
+---
+
+## BT Node Mapping
+
+The `receive_report_case_tree.py` (`create_receive_report_case_tree`) is the
+canonical implementation of this sequence. The current node order does **not**
+match the required ordering above (step 2 and step 3 are swapped). See
+**Implementation Gap** below.
+
+**Target (spec-correct) node order:**
+
+| Step | BT Node | Module |
+|---|---|---|
+| 1 | `CreateCaseNode` | `vultron/core/behaviors/report/nodes.py` |
+| 2 | `CreateCaseOwnerParticipant` | `vultron/core/behaviors/case/nodes.py` |
+| 3 | `InitializeDefaultEmbargoNode` + owner SIGNATORY seed | `vultron/core/behaviors/case/nodes.py` |
+| 4a | `CreateCaseActivity` | `vultron/core/behaviors/report/nodes.py` |
+| 4b | `UpdateActorOutbox` | `vultron/core/behaviors/case/nodes.py` |
+| 5 | `CreateCaseParticipantNode` + reporter SIGNATORY seed | `vultron/core/behaviors/case/nodes.py` |
+| 6 | `CommitCaseLogEntryNode` | `vultron/core/behaviors/case/nodes.py` |
+
+**Current (incorrect) node order in `receive_report_case_tree.py`:**
+
+```text
+CreateCaseNode
+InitializeDefaultEmbargoNode        ← BUG: runs before owner participant exists
+CreateCaseOwnerParticipant
+CreateCaseActivity
+UpdateActorOutbox
+CreateCaseParticipantNode
+CommitCaseLogEntryNode
+```
+
+The `InitializeDefaultEmbargoNode` must move to after
+`CreateCaseOwnerParticipant`. Fixing this tree is the primary
+implementation task for CM-14.
+
+---
+
+## Implementation Gaps
+
+### Gap 1: Wrong step ordering in `receive_report_case_tree.py`
+
+`InitializeDefaultEmbargoNode` currently runs before
+`CreateCaseOwnerParticipant`. Per CM-14-002, the embargo MUST be created
+after at least one participant (the case owner) exists.
+
+**Fix**: Swap the positions of `InitializeDefaultEmbargoNode` and
+`CreateCaseOwnerParticipant` in the sequence.
+
+### Gap 2: Owner not seeded as SIGNATORY (BUG-26042204)
+
+`InitializeDefaultEmbargoNode` and `CreateCaseOwnerParticipant` do not
+seed the owner's `embargo_adherence` consent state as `SIGNATORY`.
+
+**Fix**: After the default embargo reaches `EM.ACTIVE`, set the case
+owner's `ParticipantStatus.embargo_adherence` to `SIGNATORY` via the
+PEC state machine (CM-14-003, CM-13-006). This must happen in
+`InitializeDefaultEmbargoNode` (once it runs after the owner participant
+exists) or in an immediately following sibling BT node.
+
+### Gap 3: Reporter not seeded as SIGNATORY
+
+`CreateCaseParticipantNode` does not set the reporter's
+`embargo_adherence` to `SIGNATORY` when there is an active embargo.
+
+**Fix**: After adding the reporter participant, check whether
+`case.active_embargo is not None`; if so, transition the reporter's
+consent state to `SIGNATORY` (CM-14-005).
+
+### Gap 4: Reporter embargo proposal (forward-looking)
+
+No wire-format mechanism exists for a reporter to include an embargo
+proposal in an `Offer(Report)`. CM-14-006 captures this as a SHOULD
+requirement for future implementation.
+
+**See**: `notes/embargo-default-semantics.md` "Known Gap: No Reporter
+Embargo Proposal Mechanism"; `specs/embargo-policy.yaml` EP-04-003.
+
+---
+
+## Boundary Rule (CM-14-007)
+
+Additional participants MUST NOT be invited and embargo modifications
+MUST NOT be initiated until all six initialization steps are complete.
+The case-initialization BT is an atomic unit from the protocol's
+perspective. Any trigger endpoint (e.g., `suggest-actor-to-case`,
+`propose-embargo`) that arrives while initialization is in progress MUST
+be deferred or rejected with a retriable error.
+
+---
+
+## Cross-references
+
+- `specs/case-management.yaml` CM-14 (normative requirements)
+- `docs/adr/0015-create-case-at-report-receipt.md` (timing decision)
+- `notes/embargo-default-semantics.md` (embargo init semantics and gaps)
+- `notes/participant-embargo-consent.md` (PEC state machine)
+- `notes/protocol-event-cascades.md` (cascade automation principles)
+- `vultron/core/behaviors/case/receive_report_case_tree.py` (implementation)

--- a/plan/IDEAS.md
+++ b/plan/IDEAS.md
@@ -9,22 +9,3 @@ we have mechanisms in place for ingesting ideas and learnings into `specs/`
 but we're less clear on when a spec goes beyond just being a spec and should
 be an ADR instead (or both?). We should clarify the distinction and
 establish guidelines for when creating an ADR is warranted.
-
-## IDEA-26050501 Clarify order of operations on case creation
-
-When a case is created, there are a number of consequences/side
-effects/cascade of events that need to happen in a specific order. In
-general, the principle is that the case creator is the first participant
-added to the case, and has the case owner role from the start. If there is
-either an embargo already proposed or a default embargo available, then this
-should also be added to the case immediately upon case creation, with the
-case creator accepting it as the case owner, (which means that the embargo
-is active on the case from the start). Adding the reporter to the case is
-also automatic as it is assumed that by submitting a report they are already
-expressing their intent to participate in the case, and that they expect to
-accept the embargo (they already have the information so there's no reason
-to ask them to accept the embargo before sharing information with them).
-This happens AFTER the case creator does their initialization routine thing.
-
-Everything else (inviting additional parties, embargo changes, etc.) happens
-after there is already a case owner and reporter in place.

--- a/plan/history/2605/README.md
+++ b/plan/history/2605/README.md
@@ -6,6 +6,7 @@
 |------|------------|------|--------|-------|
 | 2026-05-26 | 00:00 | implementation | BUG-26052601 | BUG-26052601: Factory cast() does not coerce at runtime |
 | 2026-05-26 | 00:00 | implementation | BUG-26052602 | BUG-26052602: finder_submits_report loses VulnerabilityReport ID |
+| 2026-05-05 | 17:46 | idea | IDEA-26050501 | Clarify order of operations on case creation |
 | 2026-05-05 | 16:46 | idea | IDEA-26050502 | Integrate docs/codebase into study skill |
 | 2026-05-05 | 16:09 | idea | PAD-design-session-26050501 | Parallel Agentic Development: GitHub Issue-based coordination |
 | 2026-05-05 | 14:13 | implementation | TASK-CC | CC.2: Reduce all CC 11-15 functions to CC<=10 and tighten gate |

--- a/plan/history/2605/idea/IDEA-26050501.md
+++ b/plan/history/2605/idea/IDEA-26050501.md
@@ -1,0 +1,29 @@
+---
+source: IDEA-26050501
+timestamp: '2026-05-05T17:46:39.284768+00:00'
+title: Clarify order of operations on case creation
+type: idea
+---
+
+## IDEA-26050501 Clarify order of operations on case creation
+
+When a case is created, there are a number of consequences/side
+effects/cascade of events that need to happen in a specific order. In
+general, the principle is that the case creator is the first participant
+added to the case, and has the case owner role from the start. If there is
+either an embargo already proposed or a default embargo available, then this
+should also be added to the case immediately upon case creation, with the
+case creator accepting it as the case owner, (which means that the embargo
+is active on the case from the start). Adding the reporter to the case is
+also automatic as it is assumed that by submitting a report they are already
+expressing their intent to participate in the case, and that they expect to
+accept the embargo (they already have the information so there's no reason
+to ask them to accept the embargo before sharing information with them).
+This happens AFTER the case creator does their initialization routine thing.
+
+Everything else (inviting additional parties, embargo changes, etc.) happens
+after there is already a case owner and reporter in place.
+
+**Processed**: 2026-05-05 — design decisions captured in
+`specs/case-management.yaml` (CM-14-001 through CM-14-007) and
+`notes/case-creation-sequence.md`.

--- a/specs/README.md
+++ b/specs/README.md
@@ -189,7 +189,8 @@ Specifications are organized by topic with minimal overlap. Cross-references lin
 - **`case-management.yaml`** - CaseActor lifecycle, actor isolation, RM/EM/CS/VFD state model,
   object model relationships (Report/Case/CaseReference/VulnerabilityRecord), case update
   broadcast, CVD action rules API, redacted case view (CM-09), per-participant embargo
-  acceptance tracking (CM-10)
+  acceptance tracking (CM-10), invitation acceptance lifecycle (CM-11), case creation timing
+  (CM-12), embargo acceptance ownership (CM-13), case initialization sequence (CM-14)
 - **`participant-role-management.yaml`** - Role read/mutation API on
   `VultronParticipant` and `CaseParticipant`: `add_role()`, `remove_role()`,
   `has_role()`, `roles` property, core-layer no-direct-mutation rule, wire-layer

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -5,7 +5,7 @@ description: >-
   the RM/EM/CS/VFD state model. Covers actor isolation at the protocol level and the distinction
   between participant-specific and participant-agnostic state. `notes/bt-integration.md`,
   ActivityPub specification `handler-protocol.md` (HP-00-001, HP-00-002), `actor-knowledge-model.md`
-  (AKM-01-001, AKM-01-002)
+  (AKM-01-001, AKM-01-002). CM-14 (case initialization sequence) sourced from IDEA-26050501.
 version: 1.0.0
 kind: domain
 scope:
@@ -571,7 +571,7 @@ groups:
   description: >-
     Defines the canonical ordered sequence of initialization steps that MUST occur when a
     VulnerabilityCase is created at Offer(Report) receipt (CM-12-001). All steps MUST complete
-    before the case is considered fully initialized. Source: IDEA-26050501.
+    before the case is considered fully initialized.
   specs:
   - id: CM-14-001
     priority: MUST
@@ -676,8 +676,8 @@ groups:
     priority: MUST
     statement: >-
       Additional participants MUST NOT be invited and embargo modifications MUST NOT be
-      initiated until the case initialization sequence (CM-14-001 through CM-14-006) is
-      complete
+      initiated until the case initialization sequence defined in CM-14-001 (including any
+      applicable conditional steps) is complete
     rationale: >-
       The initialization sequence establishes the minimum valid case state: a case
       object, an owner, an optional embargo, and a reporter. Inviting third parties or

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -463,12 +463,15 @@ groups:
   - id: CM-12-002
     priority: MUST
     statement: >-
-      At case creation, the system MUST create two initial `VultronParticipant` records:
+      At case creation, the system MUST create two initial `VultronParticipant` records
+      in the order defined by CM-14-001
     relationships:
     - rel_type: depends_on
       spec_id: CM-03-001
     - rel_type: depends_on
       spec_id: CM-02-008
+    - rel_type: part_of
+      spec_id: CM-14-001
   - id: CM-12-003
     priority: MUST
     statement: >-
@@ -478,12 +481,16 @@ groups:
     - rel_type: depends_on
       spec_id: OX-02-001
   - id: CM-12-004
-    priority: SHOULD
-    statement: A default embargo SHOULD be initialized at case creation (RM.RECEIVED)
+    priority: MUST
+    statement: >-
+      If a default embargo policy is configured, a default embargo MUST be initialized
+      at case creation (RM.RECEIVED) following the sequence in CM-14-001
     relationships:
     - rel_type: refines
       spec_id: DUR-07-002
       note: which now applies at case receipt
+    - rel_type: part_of
+      spec_id: CM-14-001
   - id: CM-12-005
     priority: MUST
     statement: >-
@@ -559,3 +566,123 @@ groups:
     rationale: >-
       A note may be stored in the DataLayer by one path and never attached to `case.notes`
       by another path. Checking DataLayer existence produces false idempotency.
+- id: CM-14
+  title: Case Initialization Sequence
+  description: >-
+    Defines the canonical ordered sequence of initialization steps that MUST occur when a
+    VulnerabilityCase is created at Offer(Report) receipt (CM-12-001). All steps MUST complete
+    before the case is considered fully initialized. Source: IDEA-26050501.
+  specs:
+  - id: CM-14-001
+    priority: MUST
+    statement: >-
+      The case initialization sequence MUST execute in the following order:
+      (1) create the `VulnerabilityCase` with the receiving actor set as `attributed_to`;
+      (2) create the case-owner `VultronParticipant` (RM.RECEIVED, `CVDRole.CASE_OWNER`);
+      (3) initialize the default embargo to `EM.ACTIVE` and seed the case owner as `SIGNATORY`,
+      if a default embargo policy is configured;
+      (4) queue a `Create(Case)` activity addressed to the reporter and flush the outbox;
+      (5) add the reporter as a `VultronParticipant` (RM.ACCEPTED, `CVDRole.FINDER`/`REPORTER`)
+      and seed them as `SIGNATORY` on any active embargo;
+      (6) commit a case log entry (triggering `Announce(CaseLogEntry)` fan-out to all participants).
+    rationale: >-
+      Step 2 precedes step 3 so that the embargo is always created by a participant
+      (the case owner). The Create(Case) notification in step 4 is flushed before the
+      reporter is added in step 5 so the reporter's system receives the case object
+      before any subsequent Announce(CaseLogEntry) fan-out that references it.
+    relationships:
+    - rel_type: depends_on
+      spec_id: CM-12-001
+    - rel_type: refines
+      spec_id: CM-12-002
+    - rel_type: refines
+      spec_id: CM-12-004
+  - id: CM-14-002
+    priority: MUST
+    statement: >-
+      The case-owner `VultronParticipant` MUST be created before the default embargo is
+      initialized, so that the embargo is always associated with an existing participant
+    rationale: >-
+      An embargo without any participant lacks an owning actor. Creating the owner
+      participant first ensures that the embargo is initialized in the context of an
+      actor who can be responsible for it.
+    relationships:
+    - rel_type: depends_on
+      spec_id: CM-14-001
+  - id: CM-14-003
+    priority: MUST
+    statement: >-
+      When the case initialization sequence creates a default embargo, the case owner
+      MUST be seeded as `SIGNATORY` on that embargo immediately after the embargo reaches
+      `EM.ACTIVE` state
+    rationale: >-
+      The case owner initiated the embargo by accepting the default policy on behalf of
+      the case. Requiring a separate accept step would leave the case owner as a
+      non-signatory on their own active embargo.
+    relationships:
+    - rel_type: depends_on
+      spec_id: CM-14-001
+    - rel_type: refines
+      spec_id: CM-13-006
+  - id: CM-14-004
+    priority: MUST
+    statement: >-
+      The `Create(Case)` notification MUST be queued and the outbox flushed before the
+      reporter is added as a `VultronParticipant` in step 5 of CM-14-001
+    rationale: >-
+      The reporter's system must receive and store the case object before any
+      Announce(CaseLogEntry) fan-out that lists them as a participant. Reversing this
+      order causes "case not found" errors on the reporter side when the log entry
+      arrives referencing a case the reporter has not yet seen.
+    relationships:
+    - rel_type: depends_on
+      spec_id: CM-14-001
+    - rel_type: depends_on
+      spec_id: CM-12-003
+  - id: CM-14-005
+    priority: MUST
+    statement: >-
+      When the reporter is added as a `VultronParticipant` during case initialization,
+      they MUST be seeded as `SIGNATORY` on any active embargo
+    rationale: >-
+      The reporter already possesses the vulnerability information before the case is
+      created. Requiring an explicit embargo acceptance before sharing case content
+      would create a paradoxical deadlock: the reporter has the information that the
+      embargo is meant to protect, yet cannot receive case updates until they accept
+      the embargo. Seeding them as SIGNATORY reflects their implicit consent, expressed
+      by submitting the report.
+    relationships:
+    - rel_type: depends_on
+      spec_id: CM-14-001
+  - id: CM-14-006
+    priority: SHOULD
+    statement: >-
+      If the reporter included an embargo proposal with their `Offer(Report)`, the case
+      initialization SHOULD reconcile the reporter's proposed duration against the
+      receiver's default embargo policy and initialize the embargo at the shorter of
+      the two durations
+    note: >-
+      No wire-format mechanism currently exists for a reporter to include an embargo
+      proposal in an `Offer(Report)`. This requirement is forward-looking and cannot
+      be exercised until that mechanism is implemented. See
+      notes/embargo-default-semantics.md "Known Gap: No Reporter Embargo Proposal
+      Mechanism" and specs/embargo-policy.yaml EP-04-003.
+    relationships:
+    - rel_type: depends_on
+      spec_id: CM-14-001
+    - rel_type: depends_on
+      spec_id: CM-12-004
+  - id: CM-14-007
+    priority: MUST
+    statement: >-
+      Additional participants MUST NOT be invited and embargo modifications MUST NOT be
+      initiated until the case initialization sequence (CM-14-001 through CM-14-006) is
+      complete
+    rationale: >-
+      The initialization sequence establishes the minimum valid case state: a case
+      object, an owner, an optional embargo, and a reporter. Inviting third parties or
+      modifying the embargo before this baseline is in place creates race conditions
+      and protocol violations.
+    relationships:
+    - rel_type: depends_on
+      spec_id: CM-14-001


### PR DESCRIPTION
Docs-only PR: adds spec and notes for IDEA-26050501.

## What's in this PR

- **`specs/case-management.yaml` CM-14** (CM-14-001 through CM-14-007): canonical
  ordered case initialization sequence
  - Step ordering: create case → create owner participant → init embargo → notify
    reporter → add reporter participant → commit log entry
  - Corrects the current implementation's bug: embargo MUST be initialized after
    the owner participant exists (not before)
  - Owner and reporter both auto-seeded as SIGNATORY on the default embargo
  - Initialization boundary: no additional invitations or embargo modifications
    until all 6 steps complete
- **CM-12-002** updated to reference CM-14-001 as the normative ordered sequence
- **CM-12-004** upgraded from SHOULD to MUST (conditional on embargo policy)
- **`notes/case-creation-sequence.md`**: decision table, BT node mapping,
  gap inventory (ordering bug, SIGNATORY seeding gaps, forward-looking reporter
  embargo proposal)
- IDEA-26050501 archived via `append-history idea`

No .py files changed.