### PR TITLE
specs: ingest IDEA-26050404 and IDEA-26050501 — spec vs ADR delineation and case-creation sequence

### DIFF
--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -28,8 +28,8 @@ Concretely, write an ADR when:
 **ADR vs. spec**: an ADR records *why* a choice was made; a spec entry records
 *what* the system must do going forward. When a significant decision also
 generates recurring testable requirements, create both — see
-[notes/specs-vs-adrs.md](../../notes/specs-vs-adrs.md) for the full
-delineation guidelines and worked examples.
+`notes/specs-vs-adrs.md` for the full delineation guidelines and worked
+examples.
 
 You do **not** need an ADR for:
 

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -10,10 +10,35 @@ We use [Markdown Any Decision Records (MADR)](https://adr.github.io/madr/) to do
 
 ### When to write an ADR
 
-Write an ADR whenever you make an important decision that affects the project.
-This includes decisions about the architecture, design, or implementation of the project, as well as decisions about the project's processes, tools, or infrastructure.
-If you're not sure whether a decision is important enough to warrant an ADR, err on the side of writing one.
-Discussing the decision with the team in a pull request, issue, or discussion is a good way to determine whether it's important enough to warrant an ADR.
+The primary signal for an ADR is **evaluated alternatives**: if you considered
+more than one option and rejected at least one, document the decision. The
+record preserves context for future maintainers who might otherwise re-open
+a settled question.
+
+Concretely, write an ADR when:
+
+- You adopted a structural or architectural approach over one or more
+  alternatives (e.g., hexagonal architecture over layered, SQLModel over
+  TinyDB).
+- You made a one-time process or tooling decision with lasting project-wide
+  impact (e.g., CalVer over SemVer, pinning CI action SHAs).
+- A decision will be hard or costly to reverse, so the rationale should be
+  preserved explicitly.
+
+**ADR vs. spec**: an ADR records *why* a choice was made; a spec entry records
+*what* the system must do going forward. When a significant decision also
+generates recurring testable requirements, create both — see
+[notes/specs-vs-adrs.md](../../notes/specs-vs-adrs.md) for the full
+delineation guidelines and worked examples.
+
+You do **not** need an ADR for:
+
+- Uncontested conventions with no real alternatives (write a spec entry
+  instead).
+- Small tactical choices where the rationale is obvious from the code.
+
+If you're unsure, err on the side of writing one — a brief ADR is better than
+losing context.
 
 ### How to write an ADR
 

--- a/notes/specs-vs-adrs.md
+++ b/notes/specs-vs-adrs.md
@@ -1,0 +1,115 @@
+---
+title: Specs vs. ADRs — Delineation Guidelines
+status: active
+related_specs:
+  - specs/meta-specifications.yaml
+---
+
+# Specs vs. ADRs — Delineation Guidelines
+
+Implementation guidance for deciding when to write a spec entry, an ADR, or
+both. Formalizes the decision tree captured in `specs/meta-specifications.yaml`
+MS-11-001 through MS-11-006.
+
+---
+
+## Decision Table
+
+| Question | Decision | Rationale |
+|---|---|---|
+| Primary purpose of a spec | Capture testable requirements (what the system must do) | Specs are consumed by implementation agents; they need RFC 2119 language, not narrative |
+| Primary purpose of an ADR | Record why a choice was made over alternatives that were evaluated | The key signal is "options were weighed and one was rejected" |
+| When to create both | When a significant architectural decision also generates recurring testable requirements | The ADR answers "why?"; the spec answers "what must I do?" |
+| When a spec alone suffices | When the approach is uncontested — no real fork existed | Creating an ADR for an obvious choice adds noise to the decision log |
+| When an ADR alone suffices | When the decision is a one-time structural/process choice with no per-change requirement | Not every decision produces enforceable requirements |
+| Cross-referencing | Spec description SHOULD cite the ADR; ADR "More Information" SHOULD list spec IDs | Bidirectional links preserve traceability in both directions |
+
+---
+
+## Decision-Tree Heuristic
+
+Use this self-check before committing a change:
+
+```text
+1. Am I capturing what the system must/should/may do?
+   YES → Write a spec entry.
+
+2. Did I evaluate and reject at least one meaningful alternative?
+   YES → Write an ADR.
+
+3. Does the decision also produce recurring testable requirements?
+   YES (to 2) → Write both an ADR and a spec entry.
+
+4. Is the approach obvious/uncontested with no real fork?
+   YES → Spec entry only. No ADR needed.
+
+5. Is this a one-time structural choice with no per-change requirement?
+   YES → ADR only. No spec entry needed.
+```
+
+---
+
+## Worked Examples
+
+### ADR only
+
+- **ADR-0006 Use CalVer for Project Versioning** — this is a binary,
+  one-time choice ("we use CalVer, not SemVer"). There is no recurring
+  per-change requirement for agents to check, so no spec entry is needed.
+- **ADR-0014 Pin GitHub Actions to Full Commit SHAs** — once the policy is
+  set, there is a CI enforcement mechanism; agents do not need a spec entry
+  to implement it per-change.
+
+### Spec only
+
+- `MS-04-001` "Requirement IDs MUST follow `PREFIX-NN-NNN` format" — this
+  is an uncontested formatting rule. No alternatives were evaluated; it is
+  simply the chosen convention. A spec entry captures the rule for agents
+  without requiring ADR justification.
+- `CS-08-002` "Optional string fields MUST reject empty strings" — a
+  practical validation rule with no meaningful opposing design.
+
+### Both ADR and spec
+
+- **ADR-0009 Hexagonal Architecture** generated multiple
+  `architecture.yaml` ARCH-01 through ARCH-12 requirements. The ADR records
+  why hexagonal was chosen over a layered or transaction-script architecture;
+  the spec entries define the per-change layer-separation rules that agents
+  must enforce.
+- **ADR-0016 SQLModel/SQLite DataLayer** generated DataLayer spec entries
+  covering type-safe writes, auto-rehydration, and port isolation. The ADR
+  records why SQLModel was preferred over TinyDB or raw SQLite; the spec
+  entries give agents enforceable rules.
+
+---
+
+## Cross-Referencing Pattern
+
+When creating both an ADR and spec entries, wire them together:
+
+**In the spec description field:**
+
+```yaml
+description: >
+  Rules for DataLayer writes derived from ADR-0016
+  (docs/adr/0016-sqlmodel-sqlite-datalayer.md).
+```
+
+**In the ADR "More Information" section:**
+
+```markdown
+## More Information
+
+Generated spec requirements: `datalayer.yaml` DL-01 through DL-03.
+```
+
+---
+
+## Where the Authoritative Rules Live
+
+| Artifact | Location |
+|---|---|
+| Normative requirements (MS-11-001 – MS-11-006) | `specs/meta-specifications.yaml` |
+| Human-facing guidance ("when to write an ADR") | `docs/adr/index.md` |
+| This decision table and heuristic | `notes/specs-vs-adrs.md` (this file) |
+| Agent-facing shorthand | `AGENTS.md` "Change Protocol" section |

--- a/plan/IDEAS.md
+++ b/plan/IDEAS.md
@@ -1,11 +1,3 @@
 # Project Ideas
 
 ID format: IDEA-YYMMDDNN
-
-## IDEA-26050404 Clearly delineate specs vs ADRs
-
-We have both specs in `specs/` and any decision records in `docs/adr`, and
-we have mechanisms in place for ingesting ideas and learnings into `specs/`
-but we're less clear on when a spec goes beyond just being a spec and should
-be an ADR instead (or both?). We should clarify the distinction and
-establish guidelines for when creating an ADR is warranted.

--- a/plan/history/2605/README.md
+++ b/plan/history/2605/README.md
@@ -6,6 +6,7 @@
 |------|------------|------|--------|-------|
 | 2026-05-26 | 00:00 | implementation | BUG-26052601 | BUG-26052601: Factory cast() does not coerce at runtime |
 | 2026-05-26 | 00:00 | implementation | BUG-26052602 | BUG-26052602: finder_submits_report loses VulnerabilityReport ID |
+| 2026-05-05 | 18:00 | idea | IDEA-26050404 | Clearly delineate specs vs ADRs |
 | 2026-05-05 | 17:46 | idea | IDEA-26050501 | Clarify order of operations on case creation |
 | 2026-05-05 | 16:46 | idea | IDEA-26050502 | Integrate docs/codebase into study skill |
 | 2026-05-05 | 16:09 | idea | PAD-design-session-26050501 | Parallel Agentic Development: GitHub Issue-based coordination |

--- a/plan/history/2605/idea/IDEA-26050404.md
+++ b/plan/history/2605/idea/IDEA-26050404.md
@@ -1,0 +1,18 @@
+---
+source: IDEA-26050404
+timestamp: '2026-05-05T18:00:31.457869+00:00'
+title: Clearly delineate specs vs ADRs
+type: idea
+---
+
+## IDEA-26050404 Clearly delineate specs vs ADRs
+
+We have both specs in `specs/` and any decision records in `docs/adr`, and
+we have mechanisms in place for ingesting ideas and learnings into `specs/`
+but we're less clear on when a spec goes beyond just being a spec and should
+be an ADR instead (or both?). We should clarify the distinction and
+establish guidelines for when creating an ADR is warranted.
+
+**Processed**: 2026-05-05 — design decisions captured in
+`specs/meta-specifications.yaml` (MS-11-001 through MS-11-006) and
+`notes/specs-vs-adrs.md`.

--- a/specs/README.md
+++ b/specs/README.md
@@ -8,7 +8,7 @@ models in `vultron/metadata/specs/`.  Each specification defines
 requirements using RFC 2119 keywords (MUST, SHOULD, MAY) with unique
 requirement IDs and verification criteria.
 
-**How to read specifications**: See `meta-specifications.md` for style
+**How to read specifications**: See `meta-specifications.yaml` for style
 guide and conventions.
 
 ---
@@ -295,7 +295,7 @@ Specifications are organized by topic with minimal overlap. Cross-references lin
 - **`use-case-organization.yaml`** - Package layout for `vultron/core/use_cases/`
   (received/ vs triggers/), registry synchronization, test mirroring, and
   information flow documentation (UCORG-01 through UCORG-04)
-- **`meta-specifications.md`** - How to write and maintain specifications:
+- **`meta-specifications.yaml`** - How to write and maintain specifications:
   file structure, requirement format, ID scheme, writing rules, lifecycle,
   quality criteria, and spec vs. ADR delineation guidelines
   (MS-01 through MS-11)
@@ -359,7 +359,7 @@ Specifications are organized by topic with minimal overlap. Cross-references lin
 
 **For new contributors**:
 
-1. Start with `meta-specifications.md` to understand spec structure
+1. Start with `meta-specifications.yaml` to understand spec structure
 2. Read handler pipeline specs in order (inbox → validation → extraction → dispatch → handler)
 3. Consult cross-cutting specs as needed
 
@@ -496,7 +496,7 @@ specification.
 
 When updating specifications:
 
-1. Follow `meta-specifications.md` style guide
+1. Follow `meta-specifications.yaml` style guide
 2. Keep requirements atomic and testable
 3. Update verification criteria when changing requirements
 4. Add cross-references for related requirements

--- a/specs/README.md
+++ b/specs/README.md
@@ -96,6 +96,7 @@ Load additional files only when the task touches the relevant area. See the
 | Notes frontmatter / metadata tooling | `notes-frontmatter.yaml` |
 | Spec registry / YAML requirement files | `spec-registry.yaml` |
 | Bugfix skill / bug lifecycle | `bugfix-workflow.yaml` |
+| Spec vs. ADR delineation / when to write each | `meta-specifications.yaml`, `notes/specs-vs-adrs.md` |
 
 ---
 
@@ -294,7 +295,10 @@ Specifications are organized by topic with minimal overlap. Cross-references lin
 - **`use-case-organization.yaml`** - Package layout for `vultron/core/use_cases/`
   (received/ vs triggers/), registry synchronization, test mirroring, and
   information flow documentation (UCORG-01 through UCORG-04)
-- **`meta-specifications.md`** - How to write and maintain specifications
+- **`meta-specifications.md`** - How to write and maintain specifications:
+  file structure, requirement format, ID scheme, writing rules, lifecycle,
+  quality criteria, and spec vs. ADR delineation guidelines
+  (MS-01 through MS-11)
 
 ### Documentation Content and Organization
 

--- a/specs/meta-specifications.yaml
+++ b/specs/meta-specifications.yaml
@@ -1,7 +1,7 @@
 id: MS
 title: Meta-Specification Style Guide
 description: Normative rules for authoring specification files in this project. Covers file structure, requirement format,
-  IDs, writing rules, cross-references, lifecycle, and quality criteria.
+  IDs, writing rules, cross-references, lifecycle, quality criteria, and the delineation between spec files and ADRs.
 version: 1.0.0
 kind: general
 scope:
@@ -208,5 +208,60 @@ groups:
     statement: Spec entries SHOULD require only `id`, `priority`, and `statement` to be complete; optional fields (`rationale`,
       `tags`, `relationships`) SHOULD be added only when they provide clear value, not by default.
     rationale: Requiring optional fields on every entry creates boilerplate that discourages keeping specs current.
+    tags:
+    - documentation
+- id: MS-11
+  title: Spec vs. ADR Delineation
+  specs:
+  - id: MS-11-001
+    priority: MUST
+    statement: A spec file MUST be used to capture testable requirements — what the system MUST, SHOULD, or MAY do — using
+      RFC 2119 keywords. Specs define the intended behaviour of the system; they do not record the rationale for choosing one
+      approach over another.
+    rationale: Mixing decision rationale into spec files blurs the distinction between requirements and design history, making
+      both harder to maintain and trace.
+    tags:
+    - documentation
+  - id: MS-11-002
+    priority: MUST
+    statement: An Architecture Decision Record (ADR) MUST be created whenever a meaningful alternative was evaluated and
+      rejected. The primary signal for an ADR is the presence of options considered and discarded — "we weighed X, Y, and Z
+      and chose X because …"
+    rationale: If no real fork existed, there is no decision to record. An ADR without evaluated alternatives is just prose
+      documentation and belongs in notes/ instead.
+    tags:
+    - documentation
+  - id: MS-11-003
+    priority: SHOULD
+    statement: When a significant architectural decision generates recurring testable requirements, both an ADR and a spec
+      entry SHOULD be created. The ADR captures the why (context, options, consequences); the spec captures the what
+      (requirements agents and reviewers must satisfy going forward).
+    rationale: The two documents serve different audiences. The ADR is for human reviewers asking "why was this chosen?";
+      the spec is for implementation agents asking "what must I do?". Collapsing them into one document serves neither well.
+    tags:
+    - documentation
+  - id: MS-11-004
+    priority: SHOULD
+    statement: A spec entry that was motivated by an ADR-backed decision SHOULD reference the ADR in its description field.
+      The corresponding ADR SHOULD list the generated spec IDs in its "More Information" section.
+    rationale: Bidirectional cross-references make it possible to trace a requirement back to its decision rationale and
+      forward from a decision to its testable consequences.
+    tags:
+    - documentation
+  - id: MS-11-005
+    priority: SHOULD
+    statement: When the correct approach is uncontested and no alternative was seriously considered, a spec entry alone is
+      sufficient. An ADR SHOULD NOT be created merely to document an obvious or unchallenged choice.
+    rationale: Writing ADRs for trivial decisions adds noise to the decision log and devalues the records that capture
+      genuine trade-offs.
+    tags:
+    - documentation
+  - id: MS-11-006
+    priority: SHOULD
+    statement: When a decision is a one-time structural or process choice with no recurring testable requirements (e.g.,
+      "use CalVer for project versioning", "pin CI actions to full commit SHAs"), an ADR alone is sufficient. A spec entry
+      SHOULD NOT be created if there is no per-change requirement for agents to check.
+    rationale: Not every decision produces enforceable requirements. Creating spec entries for binary one-time choices
+      inflates the spec corpus without providing testable value.
     tags:
     - documentation

--- a/specs/meta-specifications.yaml
+++ b/specs/meta-specifications.yaml
@@ -242,7 +242,7 @@ groups:
     - documentation
   - id: MS-11-004
     priority: SHOULD
-    statement: A spec entry that was motivated by an ADR-backed decision SHOULD reference the ADR in its description field.
+    statement: A spec entry that was motivated by an ADR-backed decision SHOULD reference the ADR in its rationale field.
       The corresponding ADR SHOULD list the generated spec IDs in its "More Information" section.
     rationale: Bidirectional cross-references make it possible to trace a requirement back to its decision rationale and
       forward from a decision to its testable consequences.


### PR DESCRIPTION
This pull request clarifies and formalizes the distinction between specifications (specs) and Architecture Decision Records (ADRs) throughout the documentation and process. It introduces normative rules, decision heuristics, and cross-referencing patterns to help contributors determine when to write a spec, an ADR, or both, and updates related documentation to reflect these guidelines.

**Spec vs. ADR delineation guidelines and documentation:**

* Added a new section (MS-11-001 through MS-11-006) to `meta-specifications.yaml` defining when to use spec files vs. ADRs, including requirements for cross-referencing and rationale documentation.
* Added a new guidance document `notes/specs-vs-adrs.md` with a decision table, worked examples, and cross-referencing patterns for writing specs and ADRs.
* Significantly expanded the "When to write an ADR" section in `docs/adr/index.md` to focus on evaluated alternatives, provide concrete triggers for ADRs, and clarify the difference between ADRs and specs.

**Documentation and metadata updates:**

* Updated `specs/README.md` to reference `meta-specifications.yaml` and `notes/specs-vs-adrs.md` as the authoritative sources for spec/ADR delineation, and replaced outdated references to `meta-specifications.md`. [[1]](diffhunk://#diff-00b1d791c652b7d601291cb1555d2feebfc02c6681602802ac272c1ce52295b3L11-R11) [[2]](diffhunk://#diff-00b1d791c652b7d601291cb1555d2feebfc02c6681602802ac272c1ce52295b3R99) [[3]](diffhunk://#diff-00b1d791c652b7d601291cb1555d2feebfc02c6681602802ac272c1ce52295b3L297-R301) [[4]](diffhunk://#diff-00b1d791c652b7d601291cb1555d2feebfc02c6681602802ac272c1ce52295b3L358-R362) [[5]](diffhunk://#diff-00b1d791c652b7d601291cb1555d2feebfc02c6681602802ac272c1ce52295b3L495-R499)
* Updated the description of `meta-specifications.yaml` to include spec vs. ADR delineation.

**Project history and ideas tracking:**

* Migrated IDEA-26050404 ("Clearly delineate specs vs ADRs") from `plan/IDEAS.md` to a dedicated idea file and recorded its processing and resolution in `plan/history/2605/idea/IDEA-26050404.md` and the history log. [[1]](diffhunk://#diff-47866fbd31995b56c127c217e28419bc89142c05b550822c52de55390ecdfd84R1-R18) [[2]](diffhunk://#diff-17ce0e194d6814fe80ff48a66c806588f063022fb5f800a77c6b60fb98244335R9)
* Removed the now-processed idea from `plan/IDEAS.md`.