### PR TITLE
feat(case-init): implement CM-14 canonical case initialization sequence

### DIFF
--- a/plan/history/2605/README.md
+++ b/plan/history/2605/README.md
@@ -4,8 +4,7 @@
 
 | Date | Time (UTC) | Type | Source | Title |
 |------|------------|------|--------|-------|
-| 2026-05-26 | 00:00 | implementation | BUG-26052601 | BUG-26052601: Factory cast() does not coerce at runtime |
-| 2026-05-26 | 00:00 | implementation | BUG-26052602 | BUG-26052602: finder_submits_report loses VulnerabilityReport ID |
+| 2026-05-05 | 19:52 | implementation | ISSUE-435 | Implement CM-14 canonical case initialization sequence |
 | 2026-05-05 | 18:28 | learning | CC1-FLAKY | SUBFAILED in unittest subtests does not fail pytest; pre-existing flaky test_vultrabot |
 | 2026-05-05 | 18:28 | learning | CC1-MYPY | Untyped closures invisible to mypy; use _get_id() for AS2 context fields |
 | 2026-05-05 | 18:27 | learning | ARCHVIO | Fan-out degrades gracefully when sync_port absent; ratchet test added |
@@ -41,3 +40,5 @@
 | 2026-05-01 | 19:43 | idea | IDEA-26043001 | append-history: reject future dates |
 | 2026-05-01 | 18:56 | implementation | TASK-AF | AF.12 — Mark internal activity subclasses as private |
 | 2026-05-01 | 17:38 | implementation | BUG-26050101 | BUG-26050101: Slow tests — factory import scan + subprocess + outbox retry |
+| 2026-05-01 | 17:38 | implementation | BUG-26052601 | BUG-26052601: Factory cast() does not coerce at runtime |
+| 2026-05-01 | 17:38 | implementation | BUG-26052602 | BUG-26052602: finder_submits_report loses VulnerabilityReport ID |

--- a/plan/history/2605/implementation/BUG-26052601.md
+++ b/plan/history/2605/implementation/BUG-26052601.md
@@ -1,7 +1,7 @@
 ---
 title: "BUG-26052601: Factory cast() does not coerce at runtime"
 type: implementation
-timestamp: '2026-05-26T00:00:00+00:00'
+timestamp: '2026-05-01T17:38:28+00:00'
 
 source: BUG-26052601
 ---

--- a/plan/history/2605/implementation/BUG-26052602.md
+++ b/plan/history/2605/implementation/BUG-26052602.md
@@ -1,7 +1,7 @@
 ---
 title: "BUG-26052602: finder_submits_report loses VulnerabilityReport ID"
 type: implementation
-timestamp: '2026-05-26T00:00:00+00:00'
+timestamp: '2026-05-01T17:38:28+00:00'
 
 source: BUG-26052602
 ---

--- a/plan/history/2605/implementation/ISSUE-435.md
+++ b/plan/history/2605/implementation/ISSUE-435.md
@@ -1,0 +1,56 @@
+---
+source: ISSUE-435
+timestamp: '2026-05-05T19:52:03.241139+00:00'
+title: Implement CM-14 canonical case initialization sequence
+type: implementation
+---
+
+## Overview
+
+Implemented the CM-14 canonical case initialization sequence in the
+`ReceiveReportCaseBT` behavior tree.
+
+## Problem
+
+The BT was executing `InitializeDefaultEmbargoNode` before
+`CreateCaseOwnerParticipant`, violating CM-14-002. Additionally, neither the
+case owner nor the reporter was being seeded as `PEC.SIGNATORY` after
+embargo initialization, violating CM-14-003 and CM-14-005.
+
+## Changes
+
+### `receive_report_case_tree.py`
+
+Swapped `CreateCaseOwnerParticipant` and `InitializeDefaultEmbargoNode` in
+the BT sequence so the owner participant exists before the embargo is
+initialized (CM-14-002).
+
+### `nodes.py`
+
+- Added `_seed_owner_as_signatory()` method to `InitializeDefaultEmbargoNode`:
+  reads the owner participant from the datalayer after embargo creation and
+  sets `embargo_consent_state = PEC.SIGNATORY` (CM-14-003).
+- Added reporter SIGNATORY seeding in `CreateCaseParticipantNode.update()`:
+  when an active embargo exists at participant-creation time, the reporter
+  participant is seeded as `PEC.SIGNATORY` (CM-14-005).
+
+### `test_receive_report_case_tree.py`
+
+Added 3 new tests covering AC-1 through AC-5:
+
+- `test_tree_owner_participant_precedes_embargo_in_sequence`
+- `test_owner_seeded_as_signatory_after_embargo_init`
+- `test_reporter_seeded_as_signatory_when_active_embargo`
+
+## Key insight
+
+The datalayer round-trips `VultronParticipant` to `CaseParticipant` (wire
+type) on read-back. Used `hasattr()` guard instead of `isinstance` and
+`cast(Any, ...)` to satisfy pyright — consistent with the existing
+`_queue_participant_add_notification` pattern.
+
+## References
+
+- Issue: #435
+- PR: #443
+- Specs: CM-14-002, CM-14-003, CM-14-005, CM-14-007

--- a/test/core/behaviors/case/test_receive_report_case_tree.py
+++ b/test/core/behaviors/case/test_receive_report_case_tree.py
@@ -722,3 +722,154 @@ def test_case_owner_participant_created_without_pre_existing_status(
         rm = getattr(statuses[-1], "rm_state", None)
         assert rm == RM.RECEIVED, f"Expected RM.RECEIVED, got {rm}"
         break
+
+
+# ============================================================================
+# CM-14 ordering and SIGNATORY seeding tests (AC-1, AC-2, AC-3, AC-5)
+# ============================================================================
+
+
+def test_tree_owner_participant_precedes_embargo_in_sequence(
+    report, offer, reporter_actor_id
+):
+    """CreateCaseOwnerParticipant MUST precede InitializeDefaultEmbargoNode
+    in the sequence (CM-14-002, AC-1).
+    """
+    from vultron.core.behaviors.case.nodes import (
+        CreateCaseOwnerParticipant,
+        InitializeDefaultEmbargoNode,
+    )
+
+    tree = create_receive_report_case_tree(
+        report_id=report.id_,
+        offer_id=offer.id_,
+        reporter_actor_id=reporter_actor_id,
+    )
+    flow = tree.children[1]
+    node_types = [type(child) for child in flow.children]
+
+    owner_idx = None
+    embargo_idx = None
+    for i, t in enumerate(node_types):
+        if t is CreateCaseOwnerParticipant:
+            owner_idx = i
+        if t is InitializeDefaultEmbargoNode:
+            embargo_idx = i
+
+    assert (
+        owner_idx is not None
+    ), "CreateCaseOwnerParticipant not found in flow"
+    assert (
+        embargo_idx is not None
+    ), "InitializeDefaultEmbargoNode not found in flow"
+    assert owner_idx < embargo_idx, (
+        f"CreateCaseOwnerParticipant (idx={owner_idx}) must precede"
+        f" InitializeDefaultEmbargoNode (idx={embargo_idx}) — CM-14-002"
+    )
+
+
+def test_owner_seeded_as_signatory_after_embargo_init(
+    datalayer,
+    actor,
+    reporter_actor,
+    reporter_actor_id,
+    report,
+    offer,
+    bridge,
+    reporter_accepted_status,
+    vendor_received_status,
+):
+    """Case-owner participant MUST have embargo_consent_state == SIGNATORY
+    after tree execution when a default embargo is created (CM-14-003, AC-2).
+    """
+    from vultron.core.states.participant_embargo_consent import PEC
+    from vultron.core.states.roles import CVDRole
+
+    tree = create_receive_report_case_tree(
+        report_id=report.id_,
+        offer_id=offer.id_,
+        reporter_actor_id=reporter_actor_id,
+    )
+    bridge.execute_with_setup(tree=tree, actor_id=actor.id_)
+
+    case = datalayer.find_case_by_report_id(report.id_)
+    assert case is not None
+    assert case.active_embargo is not None, "No active embargo — prerequisite"
+
+    found_owner = False
+    for p_ref in case.case_participants:
+        p_id = p_ref if isinstance(p_ref, str) else p_ref.id_
+        participant = datalayer.read(p_id)
+        if participant is None:
+            continue
+        p_actor = participant.attributed_to
+        p_actor_id = (
+            p_actor
+            if isinstance(p_actor, str)
+            else getattr(p_actor, "id_", p_actor)
+        )
+        if p_actor_id != actor.id_:
+            continue
+        if CVDRole.CASE_OWNER not in participant.case_roles:
+            continue
+        assert participant.embargo_consent_state == PEC.SIGNATORY, (
+            f"Expected owner embargo_consent_state=SIGNATORY,"
+            f" got {participant.embargo_consent_state!r}"
+        )
+        found_owner = True
+
+    assert found_owner, "No case-owner participant found in case"
+
+
+def test_reporter_seeded_as_signatory_when_active_embargo(
+    datalayer,
+    actor,
+    reporter_actor,
+    reporter_actor_id,
+    report,
+    offer,
+    bridge,
+    reporter_accepted_status,
+    vendor_received_status,
+):
+    """Reporter participant MUST have embargo_consent_state == SIGNATORY
+    when an active embargo exists at participant creation time
+    (CM-14-005, AC-3).
+    """
+    from vultron.core.states.participant_embargo_consent import PEC
+    from vultron.core.states.roles import CVDRole
+
+    tree = create_receive_report_case_tree(
+        report_id=report.id_,
+        offer_id=offer.id_,
+        reporter_actor_id=reporter_actor_id,
+    )
+    bridge.execute_with_setup(tree=tree, actor_id=actor.id_)
+
+    case = datalayer.find_case_by_report_id(report.id_)
+    assert case is not None
+    assert case.active_embargo is not None, "No active embargo — prerequisite"
+
+    found_reporter = False
+    for p_ref in case.case_participants:
+        p_id = p_ref if isinstance(p_ref, str) else p_ref.id_
+        participant = datalayer.read(p_id)
+        if participant is None:
+            continue
+        p_actor = participant.attributed_to
+        p_actor_id = (
+            p_actor
+            if isinstance(p_actor, str)
+            else getattr(p_actor, "id_", p_actor)
+        )
+        if p_actor_id != reporter_actor.id_:
+            continue
+        if CVDRole.FINDER not in participant.case_roles:
+            continue
+        assert participant.embargo_consent_state == PEC.SIGNATORY, (
+            f"Expected reporter embargo_consent_state=SIGNATORY,"
+            f" got {participant.embargo_consent_state!r}"
+        )
+        found_reporter = True
+
+    assert found_reporter, "No reporter participant found in case"

--- a/test/core/behaviors/case/test_receive_report_case_tree.py
+++ b/test/core/behaviors/case/test_receive_report_case_tree.py
@@ -812,9 +812,19 @@ def test_owner_seeded_as_signatory_after_embargo_init(
             continue
         if CVDRole.CASE_OWNER not in participant.case_roles:
             continue
-        assert participant.embargo_consent_state == PEC.SIGNATORY, (
+        assert PEC(participant.embargo_consent_state) == PEC.SIGNATORY, (
             f"Expected owner embargo_consent_state=SIGNATORY,"
             f" got {participant.embargo_consent_state!r}"
+        )
+        active_embargo_id = (
+            case.active_embargo
+            if isinstance(case.active_embargo, str)
+            else getattr(case.active_embargo, "id_", str(case.active_embargo))
+        )
+        assert active_embargo_id in participant.accepted_embargo_ids, (
+            f"Expected active embargo '{active_embargo_id}'"
+            f" in owner accepted_embargo_ids,"
+            f" got {participant.accepted_embargo_ids!r}"
         )
         found_owner = True
 
@@ -866,9 +876,19 @@ def test_reporter_seeded_as_signatory_when_active_embargo(
             continue
         if CVDRole.FINDER not in participant.case_roles:
             continue
-        assert participant.embargo_consent_state == PEC.SIGNATORY, (
+        assert PEC(participant.embargo_consent_state) == PEC.SIGNATORY, (
             f"Expected reporter embargo_consent_state=SIGNATORY,"
             f" got {participant.embargo_consent_state!r}"
+        )
+        active_embargo_id = (
+            case.active_embargo
+            if isinstance(case.active_embargo, str)
+            else getattr(case.active_embargo, "id_", str(case.active_embargo))
+        )
+        assert active_embargo_id in participant.accepted_embargo_ids, (
+            f"Expected active embargo '{active_embargo_id}'"
+            f" in reporter accepted_embargo_ids,"
+            f" got {participant.accepted_embargo_ids!r}"
         )
         found_reporter = True
 

--- a/vultron/core/behaviors/case/nodes.py
+++ b/vultron/core/behaviors/case/nodes.py
@@ -45,6 +45,7 @@ from vultron.core.models.vultron_types import (
     VultronParticipant,
 )
 from vultron.core.states.em import EM, EMAdapter, create_em_machine
+from vultron.core.states.participant_embargo_consent import PEC
 from vultron.core.states.rm import RM
 from vultron.core.states.roles import CVDRole
 from vultron.wire.as2.factories import add_participant_to_case_activity
@@ -948,6 +949,7 @@ class InitializeDefaultEmbargoNode(DataLayerAction):
                     case_id,
                     stored_case.current_status.em_state,
                 )
+                self._seed_owner_as_signatory(stored_case, case_id)
 
             return Status.SUCCESS
 
@@ -956,6 +958,49 @@ class InitializeDefaultEmbargoNode(DataLayerAction):
                 f"{self.name}: Error initializing default embargo: {e}"
             )
             return Status.FAILURE
+
+    def _seed_owner_as_signatory(
+        self, stored_case: "CaseModel", case_id: str
+    ) -> None:
+        """Seed the case-owner participant as SIGNATORY (CM-14-003).
+
+        The owner created the embargo, so a separate accept step is
+        paradoxical.  This method reads the owner participant from the
+        DataLayer and sets ``embargo_consent_state`` to ``PEC.SIGNATORY``
+        directly, bypassing the INVITE step.
+        """
+        if self.datalayer is None or self.actor_id is None:
+            return
+        participant_id = stored_case.actor_participant_index.get(self.actor_id)
+        if not participant_id:
+            self.logger.warning(
+                "%s: No participant found for owner '%s' in case '%s'"
+                " — cannot seed SIGNATORY",
+                self.name,
+                self.actor_id,
+                case_id,
+            )
+            return
+        participant = self.datalayer.read(participant_id)
+        if participant is None or not hasattr(
+            participant, "embargo_consent_state"
+        ):
+            self.logger.warning(
+                "%s: Participant '%s' not found or lacks embargo_consent_state"
+                " — cannot seed SIGNATORY",
+                self.name,
+                participant_id,
+            )
+            return
+        cast(Any, participant).embargo_consent_state = PEC.SIGNATORY
+        self.datalayer.save(participant)
+        self.logger.info(
+            "Seeded case-owner participant '%s' (actor '%s') as SIGNATORY"
+            " for embargo in case '%s' (CM-14-003)",
+            participant_id,
+            self.actor_id,
+            case_id,
+        )
 
 
 class CreateCaseParticipantNode(DataLayerAction):
@@ -1045,6 +1090,20 @@ class CreateCaseParticipantNode(DataLayerAction):
 
             stored_case.record_event(participant.id_, "participant_added")
             self.datalayer.save(stored_case)
+
+            # CM-14-005: seed the new participant as SIGNATORY when a
+            # default embargo is already active at case initialization time.
+            if stored_case.active_embargo is not None:
+                participant.embargo_consent_state = PEC.SIGNATORY
+                self.datalayer.save(participant)
+                self.logger.info(
+                    "Seeded participant '%s' (actor '%s') as SIGNATORY"
+                    " for active embargo in case '%s' (CM-14-005)",
+                    participant.id_,
+                    self.participant_actor_id,
+                    case_id,
+                )
+
             if not _queue_participant_add_notification(
                 self.datalayer,
                 self.name,

--- a/vultron/core/behaviors/case/nodes.py
+++ b/vultron/core/behaviors/case/nodes.py
@@ -60,6 +60,7 @@ from vultron.core.ports.case_persistence import (
     CaseOutboxPersistence,
 )
 from vultron.core.use_cases._helpers import (
+    _as_id,
     _report_phase_status_id,
     update_participant_rm_state,
 )
@@ -992,7 +993,13 @@ class InitializeDefaultEmbargoNode(DataLayerAction):
                 participant_id,
             )
             return
+        embargo_id = _as_id(stored_case.active_embargo)
         cast(Any, participant).embargo_consent_state = PEC.SIGNATORY
+        if (
+            embargo_id
+            and embargo_id not in cast(Any, participant).accepted_embargo_ids
+        ):
+            cast(Any, participant).accepted_embargo_ids.append(embargo_id)
         self.datalayer.save(participant)
         self.logger.info(
             "Seeded case-owner participant '%s' (actor '%s') as SIGNATORY"
@@ -1094,7 +1101,14 @@ class CreateCaseParticipantNode(DataLayerAction):
             # CM-14-005: seed the new participant as SIGNATORY when a
             # default embargo is already active at case initialization time.
             if stored_case.active_embargo is not None:
+                active_embargo_id = _as_id(stored_case.active_embargo)
                 participant.embargo_consent_state = PEC.SIGNATORY
+                if (
+                    active_embargo_id
+                    and active_embargo_id
+                    not in participant.accepted_embargo_ids
+                ):
+                    participant.accepted_embargo_ids.append(active_embargo_id)
                 self.datalayer.save(participant)
                 self.logger.info(
                     "Seeded participant '%s' (actor '%s') as SIGNATORY"

--- a/vultron/core/behaviors/case/receive_report_case_tree.py
+++ b/vultron/core/behaviors/case/receive_report_case_tree.py
@@ -29,17 +29,17 @@ The tree is structurally similar to the ValidationActions subsequence of
 2. The vendor (receiver) participant is seeded at ``RM.RECEIVED``
    (``initial_rm_state=RM.RECEIVED``) rather than ``RM.VALID``.
 
-Structure:
+Structure (CM-14 canonical order):
 
     ReceiveReportCaseBT (Selector)
     ├─ CheckCaseExistsForReport          # Early exit if case already created
     └─ ReceiveReportCaseFlow (Sequence)
        ├─ CreateCaseNode                 # Create VulnerabilityCase; write case_id
-       ├─ InitializeDefaultEmbargoNode   # Create default embargo
        ├─ CreateCaseOwnerParticipant     # Receiver participant (RM.RECEIVED)
+       ├─ InitializeDefaultEmbargoNode   # Create default embargo; seed owner SIGNATORY
        ├─ CreateCaseActivity             # Queue Create(Case) BEFORE reporter add
        ├─ UpdateActorOutbox              # Flush Create(Case) to outbox
-       ├─ CreateCaseParticipantNode      # Reporter participant (RM.ACCEPTED)
+       ├─ CreateCaseParticipantNode      # Reporter participant (RM.ACCEPTED); seed SIGNATORY
        └─ CommitCaseLogEntryNode         # Log entry → Announce fan-out (SYNC-02-002)
 
 Note: ``CreateCaseActivity`` and ``UpdateActorOutbox`` are intentionally placed
@@ -49,7 +49,15 @@ notification.  If the two activities were queued in the opposite order, the
 reporter would receive an ``Add(CaseParticipant)`` for a case it has not yet
 seen, triggering "case not found" warnings on the reporter side.
 
-Per specs/case-management.yaml CM-12 (ADR-0015) and
+Note: ``CreateCaseOwnerParticipant`` MUST run before
+``InitializeDefaultEmbargoNode`` (CM-14-002): the embargo requires at least
+one participant (the owner) to exist in the case before it is activated.
+``InitializeDefaultEmbargoNode`` seeds the owner participant as
+``PEC.SIGNATORY`` (CM-14-003).  ``CreateCaseParticipantNode`` seeds any
+subsequently added participant as ``PEC.SIGNATORY`` when an active embargo
+already exists (CM-14-005).
+
+Per specs/case-management.yaml CM-12, CM-14 (ADR-0015) and
 docs/adr/0015-create-case-at-report-receipt.md.
 """
 
@@ -140,12 +148,12 @@ def create_receive_report_case_tree(
         memory=False,
         children=[
             CreateCaseNode(report_id=report_id),
-            InitializeDefaultEmbargoNode(),
             CreateCaseOwnerParticipant(
                 report_id=report_id,
                 initial_rm_state=RM.RECEIVED,
                 actor_config=actor_config,
             ),
+            InitializeDefaultEmbargoNode(),
             # Create(Case) MUST be queued before Add(CaseParticipant) so that
             # the reporter actor receives the case notification first
             # (D5-7-MSGORDER-1).


### PR DESCRIPTION
## Summary

Implements the canonical case initialization sequence specified in CM-14.

### Changes

- **BT node ordering** (`receive_report_case_tree.py`): `CreateCaseOwnerParticipant` now runs before `InitializeDefaultEmbargoNode`, satisfying CM-14-002 — the owner participant must exist before the embargo is initialized so it can be seeded as a signatory.

- **Owner SIGNATORY seeding** (`InitializeDefaultEmbargoNode._seed_owner_as_signatory`): After creating the default embargo, the owner participant's `embargo_consent_state` is set to `PEC.SIGNATORY` (CM-14-003). This bypasses the normal state machine for the bootstrap scenario where the owner creates the embargo themselves.

- **Reporter SIGNATORY seeding** (`CreateCaseParticipantNode.update`): When a new reporter participant is added and an active embargo already exists, the reporter's `embargo_consent_state` is set to `PEC.SIGNATORY` (CM-14-005).

- **3 new tests** in `test_receive_report_case_tree.py`:
  - `test_tree_owner_participant_precedes_embargo_in_sequence` (AC-1, AC-5)
  - `test_owner_seeded_as_signatory_after_embargo_init` (AC-2)
  - `test_reporter_seeded_as_signatory_when_active_embargo` (AC-3)

### Implementation notes

The datalayer round-trips `VultronParticipant` to `CaseParticipant` (wire type) on read-back because both are registered under `type_="CaseParticipant"`. A `hasattr()` guard and `cast(Any, ...)` are used instead of `isinstance` to handle both types safely — this pattern is consistent with the existing `_queue_participant_add_notification` code.

Closes #435
