### PR TITLE
fix(arch): eliminate ARCH-01-001 core->wire import violations

### DIFF
--- a/test/adapters/driving/fastapi/routers/test_demo_triggers.py
+++ b/test/adapters/driving/fastapi/routers/test_demo_triggers.py
@@ -37,6 +37,9 @@ from vultron.adapters.driving.fastapi.routers import (
     trigger_case as trigger_case_router,
 )
 from vultron.core.use_cases.triggers.service import TriggerService
+from vultron.adapters.driven.trigger_activity_adapter import (
+    TriggerActivityAdapter,
+)
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
@@ -87,7 +90,9 @@ def client_demo(dl):
     app = FastAPI()
     app.include_router(demo_triggers_router.router)
     app.dependency_overrides[get_trigger_service] = lambda: TriggerService(
-        dl, sync_port=SyncActivityAdapter(dl)
+        dl,
+        sync_port=SyncActivityAdapter(dl),
+        trigger_activity=TriggerActivityAdapter(dl),
     )
     app.dependency_overrides[get_trigger_dl] = lambda: dl
     app.dependency_overrides[get_canonical_actor_dl] = lambda: dl
@@ -100,7 +105,9 @@ def client_trigger_only(dl):
     """Test client with only general trigger router — no demo routes."""
     app = FastAPI()
     app.include_router(trigger_case_router.router)
-    app.dependency_overrides[get_trigger_service] = lambda: TriggerService(dl)
+    app.dependency_overrides[get_trigger_service] = lambda: TriggerService(
+        dl, trigger_activity=TriggerActivityAdapter(dl)
+    )
     app.dependency_overrides[get_trigger_dl] = lambda: dl
     app.dependency_overrides[get_canonical_actor_dl] = lambda: dl
     yield TestClient(app)

--- a/test/adapters/driving/fastapi/routers/test_trigger_actor.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_actor.py
@@ -33,6 +33,9 @@ from vultron.adapters.driving.fastapi.deps import (
     get_trigger_service,
 )
 from vultron.core.use_cases.triggers.service import TriggerService
+from vultron.adapters.driven.trigger_activity_adapter import (
+    TriggerActivityAdapter,
+)
 from vultron.wire.as2.factories import rm_invite_to_case_activity
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
@@ -86,7 +89,9 @@ def dl(actor_and_dl):
 def client_triggers(dl):
     app = FastAPI()
     app.include_router(trigger_actor_router.router)
-    app.dependency_overrides[get_trigger_service] = lambda: TriggerService(dl)
+    app.dependency_overrides[get_trigger_service] = lambda: TriggerService(
+        dl, trigger_activity=TriggerActivityAdapter(dl)
+    )
     app.dependency_overrides[get_trigger_dl] = lambda: dl
     app.dependency_overrides[get_canonical_actor_dl] = lambda: dl
     client = TestClient(app)

--- a/test/adapters/driving/fastapi/routers/test_trigger_case.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_case.py
@@ -33,6 +33,9 @@ from vultron.adapters.driving.fastapi.routers import (
     trigger_case as trigger_case_router,
 )
 from vultron.core.use_cases.triggers.service import TriggerService
+from vultron.adapters.driven.trigger_activity_adapter import (
+    TriggerActivityAdapter,
+)
 from vultron.adapters.utils import parse_id
 from vultron.core.states.rm import RM
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
@@ -85,7 +88,9 @@ def dl(actor_and_dl):
 def client_triggers(dl):
     app = FastAPI()
     app.include_router(trigger_case_router.router)
-    app.dependency_overrides[get_trigger_service] = lambda: TriggerService(dl)
+    app.dependency_overrides[get_trigger_service] = lambda: TriggerService(
+        dl, trigger_activity=TriggerActivityAdapter(dl)
+    )
     app.dependency_overrides[get_trigger_dl] = lambda: dl
     app.dependency_overrides[get_canonical_actor_dl] = lambda: dl
     client = TestClient(app)
@@ -509,7 +514,7 @@ class TestTriggerCaseOutboxCanonicalId:
         app = FastAPI()
         app.include_router(trigger_case_router.router)
         app.dependency_overrides[get_trigger_service] = lambda: TriggerService(
-            dl
+            dl, trigger_activity=TriggerActivityAdapter(dl)
         )
         app.dependency_overrides[get_trigger_dl] = lambda: dl
         # get_canonical_actor_dl intentionally NOT overridden.

--- a/test/adapters/driving/fastapi/routers/test_trigger_embargo.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_embargo.py
@@ -34,6 +34,9 @@ from vultron.adapters.driving.fastapi.routers import (
     trigger_embargo as trigger_embargo_router,
 )
 from vultron.core.use_cases.triggers.service import TriggerService
+from vultron.adapters.driven.trigger_activity_adapter import (
+    TriggerActivityAdapter,
+)
 from vultron.wire.as2.factories import em_propose_embargo_activity
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
@@ -88,7 +91,9 @@ def dl(actor_and_dl):
 def client_triggers(dl):
     app = FastAPI()
     app.include_router(trigger_embargo_router.router)
-    app.dependency_overrides[get_trigger_service] = lambda: TriggerService(dl)
+    app.dependency_overrides[get_trigger_service] = lambda: TriggerService(
+        dl, trigger_activity=TriggerActivityAdapter(dl)
+    )
     app.dependency_overrides[get_trigger_dl] = lambda: dl
     app.dependency_overrides[get_canonical_actor_dl] = lambda: dl
     client = TestClient(app)

--- a/test/adapters/driving/fastapi/routers/test_trigger_report.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_report.py
@@ -37,6 +37,9 @@ from vultron.adapters.driving.fastapi.routers import (
     trigger_report as trigger_report_router,
 )
 from vultron.core.use_cases.triggers.service import TriggerService
+from vultron.adapters.driven.trigger_activity_adapter import (
+    TriggerActivityAdapter,
+)
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
@@ -116,7 +119,9 @@ def dl(actor_and_dl):
 def client_triggers(dl):
     app = FastAPI()
     app.include_router(trigger_report_router.router)
-    app.dependency_overrides[get_trigger_service] = lambda: TriggerService(dl)
+    app.dependency_overrides[get_trigger_service] = lambda: TriggerService(
+        dl, trigger_activity=TriggerActivityAdapter(dl)
+    )
     app.dependency_overrides[get_trigger_dl] = lambda: dl
     app.dependency_overrides[get_canonical_actor_dl] = lambda: dl
     client = TestClient(app)
@@ -307,7 +312,7 @@ def test_trigger_validate_report_uses_injected_datalayer(
 
     def tracking_service():
         call_log.append("called")
-        return TriggerService(dl)
+        return TriggerService(dl, trigger_activity=TriggerActivityAdapter(dl))
 
     app.dependency_overrides[get_trigger_service] = tracking_service
     app.dependency_overrides[get_trigger_dl] = lambda: dl

--- a/test/adapters/driving/fastapi/routers/test_trigger_sync.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_sync.py
@@ -34,6 +34,9 @@ from vultron.adapters.driving.fastapi.routers import (
     demo_triggers as demo_triggers_router,
 )
 from vultron.core.use_cases.triggers.service import TriggerService
+from vultron.adapters.driven.trigger_activity_adapter import (
+    TriggerActivityAdapter,
+)
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
 
@@ -82,7 +85,9 @@ def client_triggers(dl):
     app = FastAPI()
     app.include_router(demo_triggers_router.router)
     app.dependency_overrides[get_trigger_service] = lambda: TriggerService(
-        dl, sync_port=SyncActivityAdapter(dl)
+        dl,
+        sync_port=SyncActivityAdapter(dl),
+        trigger_activity=TriggerActivityAdapter(dl),
     )
     app.dependency_overrides[get_trigger_dl] = lambda: dl
     app.dependency_overrides[get_canonical_actor_dl] = lambda: dl

--- a/test/architecture/test_core_no_wire_imports.py
+++ b/test/architecture/test_core_no_wire_imports.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Architecture boundary test: core layer must not import from wire layer.
+
+``vultron/core/`` is the innermost layer in the hexagonal architecture.  It
+MUST NOT import from ``vultron/wire/`` — neither at module level nor via
+deferred (local) imports.  The wire layer is an adapter and depends on core,
+not the other way around.
+
+Spec: ARCH-01-001
+
+Ratchet pattern
+---------------
+``KNOWN_VIOLATIONS`` documents every pre-existing violation awaiting
+migration.  The test asserts::
+
+    actual_violations == KNOWN_VIOLATIONS
+
+This means:
+
+* **Adding a new violation** causes the test to **fail** immediately.
+* **Fixing a violation** also causes the test to **fail** until the resolved
+  entry is removed from ``KNOWN_VIOLATIONS``.
+
+Remove entries from ``KNOWN_VIOLATIONS`` one by one as each violation is
+fixed.  When the set is empty the boundary is completely clean.
+"""
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parents[2]  # test/architecture/ → test/ → repo root
+
+_WIRE_MODULE = "vultron.wire"
+
+_CORE_ROOT = REPO_ROOT / "vultron" / "core"
+
+
+def _imports_from_wire(source_path: Path) -> bool:
+    """Return True if *source_path* contains any import from vultron.wire.
+
+    Detects both top-level and deferred (local) imports, catching violations
+    like ``from vultron.wire.as2.factories import ...`` placed inside a
+    function body.
+    """
+    try:
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module == _WIRE_MODULE or module.startswith(_WIRE_MODULE + "."):
+                return True
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == _WIRE_MODULE or alias.name.startswith(
+                    _WIRE_MODULE + "."
+                ):
+                    return True
+    return False
+
+
+def _collect_violations() -> frozenset[str]:
+    """Return repo-relative paths of core files that import from wire."""
+    violations: set[str] = set()
+    for py_file in _CORE_ROOT.rglob("*.py"):
+        if "__pycache__" in py_file.parts:
+            continue
+        if _imports_from_wire(py_file):
+            violations.add(py_file.relative_to(REPO_ROOT).as_posix())
+    return frozenset(violations)
+
+
+# ---------------------------------------------------------------------------
+# Known pre-existing violations awaiting migration.
+# These files import wire types that have not yet been abstracted behind ports.
+# Remove an entry from this set when the violation is resolved.
+# ---------------------------------------------------------------------------
+KNOWN_VIOLATIONS: frozenset[str] = frozenset(
+    {
+        "vultron/core/behaviors/report/nodes.py",
+        "vultron/core/use_cases/received/actor.py",
+        "vultron/core/use_cases/received/note.py",
+    }
+)
+
+
+def test_core_does_not_import_wire():
+    """vultron/core/ must not import from vultron/wire/ at any code path.
+
+    Spec: ARCH-01-001
+
+    See module docstring for the ratchet strategy.
+    """
+    actual = _collect_violations()
+    new_violations = actual - KNOWN_VIOLATIONS
+    resolved = KNOWN_VIOLATIONS - actual
+
+    diff_lines: list[str] = []
+    if new_violations:
+        diff_lines.append("NEW violations (core must not import from wire):")
+        diff_lines.extend(f"  + {v}" for v in sorted(new_violations))
+    if resolved:
+        diff_lines.append(
+            "RESOLVED violations (remove these entries from KNOWN_VIOLATIONS):"
+        )
+        diff_lines.extend(f"  - {v}" for v in sorted(resolved))
+
+    assert actual == KNOWN_VIOLATIONS, "\n\n" + "\n".join(diff_lines)

--- a/test/core/behaviors/bt_harness.py
+++ b/test/core/behaviors/bt_harness.py
@@ -40,6 +40,9 @@ import py_trees
 import pytest
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.adapters.driven.trigger_activity_adapter import (
+    TriggerActivityAdapter,
+)
 from vultron.core.behaviors.bridge import BTBridge, BTExecutionResult
 from vultron.core.states.rm import RM
 from vultron.core.use_cases._helpers import _report_phase_status_id
@@ -71,6 +74,7 @@ class BTTestScenario:
         self.bridge = BTBridge(
             datalayer=self.dl,
             is_leader=lambda: is_leader,
+            trigger_activity=TriggerActivityAdapter(self.dl),
         )
 
     # ------------------------------------------------------------------

--- a/test/core/behaviors/case/test_bug_26040902_regression.py
+++ b/test/core/behaviors/case/test_bug_26040902_regression.py
@@ -149,7 +149,13 @@ def test_receive_report_case_bt_succeeds_without_conftest_imports(
     dl.create(vendor_status)
 
     # Run the BT — must succeed without conftest side-effect imports
-    bridge = BTBridge(datalayer=dl)
+    from vultron.adapters.driven.trigger_activity_adapter import (
+        TriggerActivityAdapter,
+    )
+
+    bridge = BTBridge(
+        datalayer=dl, trigger_activity=TriggerActivityAdapter(dl)
+    )
     tree = create_receive_report_case_tree(
         report_id=_report_id,
         offer_id=_offer_id,

--- a/test/core/behaviors/case/test_receive_report_case_tree.py
+++ b/test/core/behaviors/case/test_receive_report_case_tree.py
@@ -143,7 +143,13 @@ def offer(datalayer, report, actor_id, reporter_actor_id):
 @pytest.fixture
 def bridge(datalayer):
     """BT bridge for tree execution."""
-    return BTBridge(datalayer=datalayer)
+    from vultron.adapters.driven.trigger_activity_adapter import (
+        TriggerActivityAdapter,
+    )
+
+    return BTBridge(
+        datalayer=datalayer, trigger_activity=TriggerActivityAdapter(datalayer)
+    )
 
 
 # ============================================================================

--- a/test/core/models/test_base.py
+++ b/test/core/models/test_base.py
@@ -177,10 +177,14 @@ def test_vultron_case_status_required_fields():
 
 
 def test_vultron_embargo_event_required_fields():
+    # context is required; omitting it must raise
     with pytest.raises(Exception):
         VultronEmbargoEvent()
-    with pytest.raises(Exception):
-        VultronEmbargoEvent(context="urn:uuid:case-123")
+    # end_time is optional (has a default); context alone is sufficient
+    em_default = VultronEmbargoEvent(context="urn:uuid:case-123")
+    assert em_default.context == "urn:uuid:case-123"
+    assert em_default.end_time is not None
+    # explicit end_time is also accepted
     em = VultronEmbargoEvent(context="urn:uuid:case-123", end_time=_FUTURE_DT)
     assert em.context == "urn:uuid:case-123"
     assert em.end_time == _FUTURE_DT

--- a/test/core/use_cases/received/test_actor.py
+++ b/test/core/use_cases/received/test_actor.py
@@ -46,6 +46,9 @@ from vultron.wire.as2.factories import (
     rm_invite_to_case_activity,
     rm_reject_invite_to_case_activity,
 )
+from vultron.adapters.driven.trigger_activity_adapter import (
+    TriggerActivityAdapter,
+)
 
 
 class TestInviteActorUseCases:
@@ -521,7 +524,9 @@ class TestSuggestActorUseCases:
         )
         event = make_payload(recommendation)
 
-        SuggestActorToCaseReceivedUseCase(dl, event).execute()
+        SuggestActorToCaseReceivedUseCase(
+            dl, event, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
 
         outbox = dl.outbox_list()
         assert (
@@ -575,12 +580,16 @@ class TestSuggestActorUseCases:
         event = make_payload(recommendation)
 
         # First execution
-        SuggestActorToCaseReceivedUseCase(dl, event).execute()
+        SuggestActorToCaseReceivedUseCase(
+            dl, event, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
         outbox_after_first = len(dl.outbox_list())
 
         # Second execution (should be a no-op)
         py_trees.blackboard.Blackboard.storage.clear()
-        SuggestActorToCaseReceivedUseCase(dl, event).execute()
+        SuggestActorToCaseReceivedUseCase(
+            dl, event, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
         outbox_after_second = len(dl.outbox_list())
 
         assert (

--- a/test/core/use_cases/received/test_embargo.py
+++ b/test/core/use_cases/received/test_embargo.py
@@ -38,6 +38,9 @@ from vultron.wire.as2.factories import (
     em_reject_embargo_activity,
     remove_embargo_from_case_activity,
 )
+from vultron.adapters.driven.trigger_activity_adapter import (
+    TriggerActivityAdapter,
+)
 
 
 class TestEmbargoUseCases:
@@ -618,4 +621,6 @@ class TestEmbargoUseCases:
             proposal_id=proposal.id_,
         )
         with pytest.raises(VultronInvalidStateTransitionError):
-            SvcAcceptEmbargoUseCase(dl, request).execute()
+            SvcAcceptEmbargoUseCase(
+                dl, request, trigger_activity=TriggerActivityAdapter(dl)
+            ).execute()

--- a/test/core/use_cases/received/test_report.py
+++ b/test/core/use_cases/received/test_report.py
@@ -15,6 +15,9 @@
 from typing import cast
 from unittest.mock import MagicMock
 
+from vultron.adapters.driven.trigger_activity_adapter import (
+    TriggerActivityAdapter,
+)
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.core.models.activity import VultronActivity
 from vultron.core.models.base import VultronObject
@@ -207,7 +210,9 @@ class TestDuplicateReportHandling:
         dl.save(VultronCaseActor(id_="https://example.org/actors/vendor"))
 
         with caplog.at_level(logging.WARNING):
-            SubmitReportReceivedUseCase(dl, event).execute()
+            SubmitReportReceivedUseCase(
+                dl, event, trigger_activity=TriggerActivityAdapter(dl)
+            ).execute()
 
         warning_records = [
             r for r in caplog.records if r.levelno >= logging.WARNING
@@ -290,7 +295,9 @@ class TestSubmitReportLogMessages:
         dl.save(VultronCaseActor(id_="https://example.org/actors/vendor"))
 
         with caplog.at_level(logging.INFO):
-            SubmitReportReceivedUseCase(dl, event).execute()
+            SubmitReportReceivedUseCase(
+                dl, event, trigger_activity=TriggerActivityAdapter(dl)
+            ).execute()
 
         log_text = " ".join(r.message for r in caplog.records)
         assert (
@@ -352,7 +359,9 @@ class TestSubmitReportCreatesCase:
         RM.RECEIVED processing.
         """
         event, dl = self._make_event_and_dl()
-        SubmitReportReceivedUseCase(dl, event).execute()
+        SubmitReportReceivedUseCase(
+            dl, event, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
 
         all_cases = dl.get_all("VulnerabilityCase")
         assert len(all_cases) >= 1, "Expected at least one VulnerabilityCase"
@@ -371,7 +380,9 @@ class TestSubmitReportCreatesCase:
     def test_submit_report_creates_vendor_participant_at_received(self):
         """SubmitReportReceivedUseCase creates vendor CaseParticipant at RM.RECEIVED."""
         event, dl = self._make_event_and_dl()
-        SubmitReportReceivedUseCase(dl, event).execute()
+        SubmitReportReceivedUseCase(
+            dl, event, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
 
         participants = dl.get_all("CaseParticipant")
         vendor_participants = [
@@ -391,7 +402,9 @@ class TestSubmitReportCreatesCase:
         them via CreateCaseParticipantNode.
         """
         event, dl = self._make_event_and_dl()
-        SubmitReportReceivedUseCase(dl, event).execute()
+        SubmitReportReceivedUseCase(
+            dl, event, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
 
         all_statuses = dl.get_all("ParticipantStatus")
         finder_accepted = [
@@ -408,8 +421,12 @@ class TestSubmitReportCreatesCase:
     def test_submit_report_case_creation_is_idempotent(self):
         """Calling SubmitReportReceivedUseCase twice creates only one case."""
         event, dl = self._make_event_and_dl()
-        SubmitReportReceivedUseCase(dl, event).execute()
-        SubmitReportReceivedUseCase(dl, event).execute()
+        SubmitReportReceivedUseCase(
+            dl, event, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
+        SubmitReportReceivedUseCase(
+            dl, event, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
 
         all_cases = dl.get_all("VulnerabilityCase")
         report_cases = [
@@ -445,7 +462,9 @@ class TestSubmitReportCreatesCase:
         )
         dl = SqliteDataLayer("sqlite:///:memory:")
 
-        SubmitReportReceivedUseCase(dl, event).execute()
+        SubmitReportReceivedUseCase(
+            dl, event, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
 
         all_cases = dl.get_all("VulnerabilityCase")
         assert (
@@ -502,7 +521,9 @@ class TestOfferAddressingSemantics:
         )
         dl = self._make_dl()
 
-        SubmitReportReceivedUseCase(dl, event).execute()
+        SubmitReportReceivedUseCase(
+            dl, event, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
 
         all_cases = dl.get_all("VulnerabilityCase")
         assert len(all_cases) >= 1, "Expected case when receiving actor in to"
@@ -517,7 +538,9 @@ class TestOfferAddressingSemantics:
         dl = self._make_dl()
 
         with caplog.at_level(logging.WARNING):
-            SubmitReportReceivedUseCase(dl, event).execute()
+            SubmitReportReceivedUseCase(
+                dl, event, trigger_activity=TriggerActivityAdapter(dl)
+            ).execute()
 
         all_cases = dl.get_all("VulnerabilityCase")
         assert (
@@ -541,7 +564,9 @@ class TestOfferAddressingSemantics:
         dl = self._make_dl()
 
         with caplog.at_level(logging.WARNING):
-            SubmitReportReceivedUseCase(dl, event).execute()
+            SubmitReportReceivedUseCase(
+                dl, event, trigger_activity=TriggerActivityAdapter(dl)
+            ).execute()
 
         all_cases = dl.get_all("VulnerabilityCase")
         assert (
@@ -568,7 +593,9 @@ class TestOfferAddressingSemantics:
         )
         dl = self._make_dl()
 
-        SubmitReportReceivedUseCase(dl, event).execute()
+        SubmitReportReceivedUseCase(
+            dl, event, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
 
         all_cases = dl.get_all("VulnerabilityCase")
         assert (
@@ -588,7 +615,9 @@ class TestOfferAddressingSemantics:
         )
         dl = self._make_dl()
 
-        SubmitReportReceivedUseCase(dl, event).execute()
+        SubmitReportReceivedUseCase(
+            dl, event, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
 
         all_cases = dl.get_all("VulnerabilityCase")
         assert (

--- a/test/core/use_cases/triggers/test_actor_triggers.py
+++ b/test/core/use_cases/triggers/test_actor_triggers.py
@@ -44,6 +44,9 @@ from vultron.wire.as2.vocab.objects.vulnerability_case import (
     VulnerabilityCase,
     VulnerabilityCaseStub,
 )
+from vultron.adapters.driven.trigger_activity_adapter import (
+    TriggerActivityAdapter,
+)
 
 _BASE = "http://coordinator:7999/api/v2/actors"
 _UUID = "24d63c7d-6b1e-4f61-a5e1-180d27192d0b"
@@ -92,7 +95,9 @@ class TestSvcInviteActorToCaseUseCase:
             case_id=case.id_,
             invitee_id=invitee.id_,
         )
-        result = SvcInviteActorToCaseUseCase(dl, request).execute()
+        result = SvcInviteActorToCaseUseCase(
+            dl, request, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
 
         assert "activity" in result
         activity_data = result["activity"]
@@ -114,7 +119,9 @@ class TestSvcInviteActorToCaseUseCase:
             case_id=case.id_,
             invitee_id=invitee.id_,
         )
-        result = SvcInviteActorToCaseUseCase(dl, request).execute()
+        result = SvcInviteActorToCaseUseCase(
+            dl, request, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
 
         invite_id = result["activity"]["id"]
         stored = dl.read(invite_id)
@@ -136,7 +143,9 @@ class TestSvcInviteActorToCaseUseCase:
             invitee_id=missing_id,
         )
         with pytest.raises(VultronNotFoundError):
-            SvcInviteActorToCaseUseCase(dl, request).execute()
+            SvcInviteActorToCaseUseCase(
+                dl, request, trigger_activity=TriggerActivityAdapter(dl)
+            ).execute()
 
     def test_invite_raises_when_case_not_in_dl(self):
         actor, dl = _make_actor_dl("Coordinator")
@@ -151,7 +160,9 @@ class TestSvcInviteActorToCaseUseCase:
             invitee_id=invitee.id_,
         )
         with pytest.raises(Exception):
-            SvcInviteActorToCaseUseCase(dl, request).execute()
+            SvcInviteActorToCaseUseCase(
+                dl, request, trigger_activity=TriggerActivityAdapter(dl)
+            ).execute()
 
     def test_invite_normalises_short_uuid_actor_id(self):
         """DR-09: short UUID in actor_id is resolved to full URI."""
@@ -169,7 +180,9 @@ class TestSvcInviteActorToCaseUseCase:
             case_id=case.id_,
             invitee_id=invitee.id_,
         )
-        result = SvcInviteActorToCaseUseCase(dl, request).execute()
+        result = SvcInviteActorToCaseUseCase(
+            dl, request, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
 
         # Activity actor field must be the full canonical URI, not the short UUID
         assert result["activity"]["actor"] == _HTTP_ACTOR_ID
@@ -192,7 +205,9 @@ class TestSvcSuggestActorToCaseUseCase:
             case_id=case.id_,
             suggested_actor_id=suggested.id_,
         )
-        result = SvcSuggestActorToCaseUseCase(dl, request).execute()
+        result = SvcSuggestActorToCaseUseCase(
+            dl, request, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
 
         assert "activity" in result
         assert result["activity"]["actor"] == actor.id_
@@ -210,7 +225,9 @@ class TestSvcSuggestActorToCaseUseCase:
             suggested_actor_id="https://example.org/actors/ghost",
         )
         with pytest.raises(VultronNotFoundError):
-            SvcSuggestActorToCaseUseCase(dl, request).execute()
+            SvcSuggestActorToCaseUseCase(
+                dl, request, trigger_activity=TriggerActivityAdapter(dl)
+            ).execute()
 
     def test_suggest_normalises_short_uuid_actor_id(self):
         """DR-09: short UUID in actor_id is resolved to full URI."""
@@ -227,7 +244,9 @@ class TestSvcSuggestActorToCaseUseCase:
             case_id=case.id_,
             suggested_actor_id=suggested.id_,
         )
-        result = SvcSuggestActorToCaseUseCase(dl, request).execute()
+        result = SvcSuggestActorToCaseUseCase(
+            dl, request, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
 
         assert result["activity"]["actor"] == _HTTP_ACTOR_ID
 
@@ -258,7 +277,11 @@ class TestSvcAcceptCaseInviteUseCase:
             actor_id=invitee.id_,
             invite_id=invite.id_,
         )
-        result = SvcAcceptCaseInviteUseCase(dl_invitee, request).execute()
+        result = SvcAcceptCaseInviteUseCase(
+            dl_invitee,
+            request,
+            trigger_activity=TriggerActivityAdapter(dl_invitee),
+        ).execute()
 
         assert "activity" in result
         assert result["activity"]["actor"] == invitee.id_
@@ -275,7 +298,9 @@ class TestSvcAcceptCaseInviteUseCase:
         dl.create(actor)
 
         with pytest.raises(VultronNotFoundError):
-            SvcAcceptCaseInviteUseCase(dl, request).execute()
+            SvcAcceptCaseInviteUseCase(
+                dl, request, trigger_activity=TriggerActivityAdapter(dl)
+            ).execute()
 
     def test_accept_normalises_short_uuid_actor_id(self):
         """DR-09: short UUID in actor_id is resolved to full URI."""
@@ -304,6 +329,10 @@ class TestSvcAcceptCaseInviteUseCase:
             actor_id=_UUID,
             invite_id=invite.id_,
         )
-        result = SvcAcceptCaseInviteUseCase(dl_invitee, request).execute()
+        result = SvcAcceptCaseInviteUseCase(
+            dl_invitee,
+            request,
+            trigger_activity=TriggerActivityAdapter(dl_invitee),
+        ).execute()
 
         assert result["activity"]["actor"] == _HTTP_ACTOR_ID

--- a/test/core/use_cases/triggers/test_embargo.py
+++ b/test/core/use_cases/triggers/test_embargo.py
@@ -29,6 +29,9 @@ from vultron.wire.as2.vocab.objects.case_participant import (
 )
 from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.adapters.driven.trigger_activity_adapter import (
+    TriggerActivityAdapter,
+)
 
 
 def _persist_actor(dl: SqliteDataLayer, name: str) -> as_Service:
@@ -111,7 +114,9 @@ def test_non_owner_accept_embargo_on_active_case_updates_participant_only(
         proposal_id=proposal.id_,
     )
 
-    result = SvcAcceptEmbargoUseCase(finder_dl, request).execute()
+    result = SvcAcceptEmbargoUseCase(
+        finder_dl, request, trigger_activity=TriggerActivityAdapter(finder_dl)
+    ).execute()
 
     assert "activity" in result
 
@@ -144,7 +149,9 @@ def test_non_owner_reject_embargo_on_active_case_updates_participant_only(
         proposal_id=proposal.id_,
     )
 
-    result = SvcRejectEmbargoUseCase(finder_dl, request).execute()
+    result = SvcRejectEmbargoUseCase(
+        finder_dl, request, trigger_activity=TriggerActivityAdapter(finder_dl)
+    ).execute()
 
     assert "activity" in result
 

--- a/test/core/use_cases/triggers/test_note_trigger.py
+++ b/test/core/use_cases/triggers/test_note_trigger.py
@@ -36,6 +36,9 @@ from vultron.core.use_cases.triggers.requests import (
 )
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.adapters.driven.trigger_activity_adapter import (
+    TriggerActivityAdapter,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers (mirrors pattern in test_trignotify.py)
@@ -126,7 +129,9 @@ class TestSvcAddNoteToCaseUseCase:
             note_content=self.NOTE_CONTENT,
             in_reply_to=in_reply_to,
         )
-        return SvcAddNoteToCaseUseCase(self.dl, request).execute()
+        return SvcAddNoteToCaseUseCase(
+            self.dl, request, trigger_activity=TriggerActivityAdapter(self.dl)
+        ).execute()
 
     # ------------------------------------------------------------------
     # Return-value structure
@@ -224,7 +229,9 @@ class TestSvcAddNoteToCaseUseCase:
             note_name=self.NOTE_NAME,
             note_content=self.NOTE_CONTENT,
         )
-        result = SvcAddNoteToCaseUseCase(self.dl, request).execute()
+        result = SvcAddNoteToCaseUseCase(
+            self.dl, request, trigger_activity=TriggerActivityAdapter(self.dl)
+        ).execute()
 
         activity_id = result["activity"].get("id")
         act_obj = self.dl.read(activity_id)

--- a/test/core/use_cases/triggers/test_service.py
+++ b/test/core/use_cases/triggers/test_service.py
@@ -31,6 +31,9 @@ from vultron.errors import (
     VultronValidationError,
 )
 from vultron.core.use_cases.triggers.service import TriggerService
+from vultron.adapters.driven.trigger_activity_adapter import (
+    TriggerActivityAdapter,
+)
 
 try:
     from pydantic import ValidationError as PydanticValidationError
@@ -199,7 +202,9 @@ def test_validate_report_trigger_returns_activity_dict(
     dl, actor, offer, received_report
 ):
     """validate_report_trigger returns dict with 'activity' key."""
-    result = TriggerService(dl).validate_report(actor.id_, offer.id_, None)
+    result = TriggerService(
+        dl, trigger_activity=TriggerActivityAdapter(dl)
+    ).validate_report(actor.id_, offer.id_, None)
     assert isinstance(result, dict)
     assert "activity" in result
 
@@ -207,17 +212,17 @@ def test_validate_report_trigger_returns_activity_dict(
 def test_validate_report_trigger_unknown_actor_raises_404(dl, offer):
     """validate_report_trigger raises VultronNotFoundError 404 for unknown actor."""
     with pytest.raises(VultronNotFoundError):
-        TriggerService(dl).validate_report(
-            "urn:uuid:no-such-actor", offer.id_, None
-        )
+        TriggerService(
+            dl, trigger_activity=TriggerActivityAdapter(dl)
+        ).validate_report("urn:uuid:no-such-actor", offer.id_, None)
 
 
 def test_validate_report_trigger_unknown_offer_raises_404(dl, actor):
     """validate_report_trigger raises VultronNotFoundError 404 for unknown offer."""
     with pytest.raises(VultronNotFoundError):
-        TriggerService(dl).validate_report(
-            actor.id_, "urn:uuid:no-such-offer", None
-        )
+        TriggerService(
+            dl, trigger_activity=TriggerActivityAdapter(dl)
+        ).validate_report(actor.id_, "urn:uuid:no-such-offer", None)
 
 
 def test_validate_report_trigger_transitions_rm_to_valid(
@@ -229,7 +234,9 @@ def test_validate_report_trigger_transitions_rm_to_valid(
     RM.RECEIVED via receive_report_case_tree.  The validate-report trigger
     is responsible only for the RM.RECEIVED → RM.VALID transition.
     """
-    TriggerService(dl).validate_report(actor.id_, offer.id_, None)
+    TriggerService(
+        dl, trigger_activity=TriggerActivityAdapter(dl)
+    ).validate_report(actor.id_, offer.id_, None)
 
     valid_status_id = _report_phase_status_id(
         actor.id_, offer.object_, RM.VALID.value
@@ -245,9 +252,9 @@ def test_validate_report_trigger_non_report_offer_raises_422(
 ):
     """validate_report_trigger raises 422 when offer_id is not a report Offer."""
     with pytest.raises(VultronValidationError):
-        TriggerService(dl).validate_report(
-            actor.id_, non_report_object.id_, None
-        )
+        TriggerService(
+            dl, trigger_activity=TriggerActivityAdapter(dl)
+        ).validate_report(actor.id_, non_report_object.id_, None)
 
 
 # ===========================================================================
@@ -259,7 +266,9 @@ def test_invalidate_report_trigger_returns_activity_dict(
     dl, actor, offer, received_report
 ):
     """invalidate_report_trigger returns dict with non-None 'activity'."""
-    result = TriggerService(dl).invalidate_report(actor.id_, offer.id_, None)
+    result = TriggerService(
+        dl, trigger_activity=TriggerActivityAdapter(dl)
+    ).invalidate_report(actor.id_, offer.id_, None)
     assert isinstance(result, dict)
     assert result["activity"] is not None
 
@@ -267,17 +276,17 @@ def test_invalidate_report_trigger_returns_activity_dict(
 def test_invalidate_report_trigger_unknown_actor_raises_404(dl, offer):
     """invalidate_report_trigger raises VultronNotFoundError 404 for unknown actor."""
     with pytest.raises(VultronNotFoundError):
-        TriggerService(dl).invalidate_report(
-            "urn:uuid:no-such", offer.id_, None
-        )
+        TriggerService(
+            dl, trigger_activity=TriggerActivityAdapter(dl)
+        ).invalidate_report("urn:uuid:no-such", offer.id_, None)
 
 
 def test_invalidate_report_trigger_unknown_offer_raises_404(dl, actor):
     """invalidate_report_trigger raises VultronNotFoundError 404 for unknown offer."""
     with pytest.raises(VultronNotFoundError):
-        TriggerService(dl).invalidate_report(
-            actor.id_, "urn:uuid:no-such", None
-        )
+        TriggerService(
+            dl, trigger_activity=TriggerActivityAdapter(dl)
+        ).invalidate_report(actor.id_, "urn:uuid:no-such", None)
 
 
 def test_invalidate_report_trigger_adds_activity_to_outbox(
@@ -289,7 +298,9 @@ def test_invalidate_report_trigger_adds_activity_to_outbox(
         item for item in actor_before.outbox.items if isinstance(item, str)
     }
 
-    TriggerService(dl).invalidate_report(actor.id_, offer.id_, None)
+    TriggerService(
+        dl, trigger_activity=TriggerActivityAdapter(dl)
+    ).invalidate_report(actor.id_, offer.id_, None)
 
     actor_after = dl.read(actor.id_)
     after = {
@@ -303,9 +314,9 @@ def test_invalidate_report_trigger_non_report_offer_raises_422(
 ):
     """invalidate_report_trigger raises 422 when offer_id is not a report Offer."""
     with pytest.raises(VultronValidationError):
-        TriggerService(dl).invalidate_report(
-            actor.id_, non_report_object.id_, None
-        )
+        TriggerService(
+            dl, trigger_activity=TriggerActivityAdapter(dl)
+        ).invalidate_report(actor.id_, non_report_object.id_, None)
 
 
 # ===========================================================================
@@ -317,9 +328,9 @@ def test_reject_report_trigger_returns_activity_dict(
     dl, actor, offer, received_report
 ):
     """reject_report_trigger returns dict with non-None 'activity'."""
-    result = TriggerService(dl).reject_report(
-        actor.id_, offer.id_, "Out of scope."
-    )
+    result = TriggerService(
+        dl, trigger_activity=TriggerActivityAdapter(dl)
+    ).reject_report(actor.id_, offer.id_, "Out of scope.")
     assert isinstance(result, dict)
     assert result["activity"] is not None
 
@@ -327,17 +338,17 @@ def test_reject_report_trigger_returns_activity_dict(
 def test_reject_report_trigger_unknown_actor_raises_404(dl, offer):
     """reject_report_trigger raises VultronNotFoundError 404 for unknown actor."""
     with pytest.raises(VultronNotFoundError):
-        TriggerService(dl).reject_report(
-            "urn:uuid:no-such", offer.id_, "Reason."
-        )
+        TriggerService(
+            dl, trigger_activity=TriggerActivityAdapter(dl)
+        ).reject_report("urn:uuid:no-such", offer.id_, "Reason.")
 
 
 def test_reject_report_trigger_unknown_offer_raises_404(dl, actor):
     """reject_report_trigger raises VultronNotFoundError 404 for unknown offer."""
     with pytest.raises(VultronNotFoundError):
-        TriggerService(dl).reject_report(
-            actor.id_, "urn:uuid:no-such", "Reason."
-        )
+        TriggerService(
+            dl, trigger_activity=TriggerActivityAdapter(dl)
+        ).reject_report(actor.id_, "urn:uuid:no-such", "Reason.")
 
 
 def test_reject_report_trigger_adds_activity_to_outbox(
@@ -349,7 +360,9 @@ def test_reject_report_trigger_adds_activity_to_outbox(
         item for item in actor_before.outbox.items if isinstance(item, str)
     }
 
-    TriggerService(dl).reject_report(actor.id_, offer.id_, "Reason.")
+    TriggerService(
+        dl, trigger_activity=TriggerActivityAdapter(dl)
+    ).reject_report(actor.id_, offer.id_, "Reason.")
 
     actor_after = dl.read(actor.id_)
     after = {
@@ -363,9 +376,9 @@ def test_reject_report_trigger_non_report_offer_raises_422(
 ):
     """reject_report_trigger raises 422 when offer_id is not a report Offer."""
     with pytest.raises(VultronValidationError):
-        TriggerService(dl).reject_report(
-            actor.id_, non_report_object.id_, "reason"
-        )
+        TriggerService(
+            dl, trigger_activity=TriggerActivityAdapter(dl)
+        ).reject_report(actor.id_, non_report_object.id_, "reason")
 
 
 # ===========================================================================
@@ -377,7 +390,9 @@ def test_close_report_trigger_returns_activity_dict(
     dl, actor, offer, accepted_report
 ):
     """close_report_trigger returns dict with non-None 'activity'."""
-    result = TriggerService(dl).close_report(actor.id_, offer.id_, None)
+    result = TriggerService(
+        dl, trigger_activity=TriggerActivityAdapter(dl)
+    ).close_report(actor.id_, offer.id_, None)
     assert isinstance(result, dict)
     assert result["activity"] is not None
 
@@ -387,13 +402,17 @@ def test_close_report_trigger_already_closed_raises_409(
 ):
     """close_report_trigger raises VultronInvalidStateTransitionError when report is CLOSED."""
     with pytest.raises(VultronInvalidStateTransitionError):
-        TriggerService(dl).close_report(actor.id_, offer.id_, None)
+        TriggerService(
+            dl, trigger_activity=TriggerActivityAdapter(dl)
+        ).close_report(actor.id_, offer.id_, None)
 
 
 def test_close_report_trigger_unknown_actor_raises_404(dl, offer):
     """close_report_trigger raises VultronNotFoundError 404 for unknown actor."""
     with pytest.raises(VultronNotFoundError):
-        TriggerService(dl).close_report("urn:uuid:no-such", offer.id_, None)
+        TriggerService(
+            dl, trigger_activity=TriggerActivityAdapter(dl)
+        ).close_report("urn:uuid:no-such", offer.id_, None)
 
 
 def test_close_report_trigger_non_report_offer_raises_422(
@@ -401,7 +420,9 @@ def test_close_report_trigger_non_report_offer_raises_422(
 ):
     """close_report_trigger raises 422 when offer_id is not a report Offer."""
     with pytest.raises(VultronValidationError):
-        TriggerService(dl).close_report(actor.id_, non_report_object.id_, None)
+        TriggerService(
+            dl, trigger_activity=TriggerActivityAdapter(dl)
+        ).close_report(actor.id_, non_report_object.id_, None)
 
 
 # ===========================================================================
@@ -413,9 +434,9 @@ def test_engage_case_trigger_returns_activity_dict(
     dl, actor, case_with_participant
 ):
     """engage_case_trigger returns dict with non-None 'activity'."""
-    result = TriggerService(dl).engage_case(
-        actor.id_, case_with_participant.id_
-    )
+    result = TriggerService(
+        dl, trigger_activity=TriggerActivityAdapter(dl)
+    ).engage_case(actor.id_, case_with_participant.id_)
     assert isinstance(result, dict)
     assert result["activity"] is not None
 
@@ -425,28 +446,34 @@ def test_engage_case_trigger_unknown_actor_raises_404(
 ):
     """engage_case_trigger raises VultronNotFoundError 404 for unknown actor."""
     with pytest.raises(VultronNotFoundError):
-        TriggerService(dl).engage_case(
-            "urn:uuid:no-such", case_with_participant.id_
-        )
+        TriggerService(
+            dl, trigger_activity=TriggerActivityAdapter(dl)
+        ).engage_case("urn:uuid:no-such", case_with_participant.id_)
 
 
 def test_engage_case_trigger_unknown_case_raises_404(dl, actor):
     """engage_case_trigger raises VultronNotFoundError 404 for unknown case."""
     with pytest.raises(VultronNotFoundError):
-        TriggerService(dl).engage_case(actor.id_, "urn:uuid:no-such-case")
+        TriggerService(
+            dl, trigger_activity=TriggerActivityAdapter(dl)
+        ).engage_case(actor.id_, "urn:uuid:no-such-case")
 
 
 def test_engage_case_trigger_invalid_case_id_raises_422(dl, actor):
     """engage_case_trigger raises PydanticValidationError for a non-URI case_id."""
     with pytest.raises(PydanticValidationError):
-        TriggerService(dl).engage_case(actor.id_, "not-a-uri")
+        TriggerService(
+            dl, trigger_activity=TriggerActivityAdapter(dl)
+        ).engage_case(actor.id_, "not-a-uri")
 
 
 def test_engage_case_trigger_updates_participant_rm_state(
     dl, actor, case_with_participant
 ):
     """engage_case_trigger transitions actor's CaseParticipant RM state to ACCEPTED."""
-    TriggerService(dl).engage_case(actor.id_, case_with_participant.id_)
+    TriggerService(
+        dl, trigger_activity=TriggerActivityAdapter(dl)
+    ).engage_case(actor.id_, case_with_participant.id_)
 
     updated_case = dl.read(case_with_participant.id_)
     for p_ref in updated_case.case_participants:
@@ -475,7 +502,9 @@ def test_engage_case_trigger_adds_activity_to_outbox(
         item for item in actor_before.outbox.items if isinstance(item, str)
     }
 
-    TriggerService(dl).engage_case(actor.id_, case_with_participant.id_)
+    TriggerService(
+        dl, trigger_activity=TriggerActivityAdapter(dl)
+    ).engage_case(actor.id_, case_with_participant.id_)
 
     actor_after = dl.read(actor.id_)
     after = {
@@ -493,9 +522,9 @@ def test_defer_case_trigger_returns_activity_dict(
     dl, actor, case_with_participant
 ):
     """defer_case_trigger returns dict with non-None 'activity'."""
-    result = TriggerService(dl).defer_case(
-        actor.id_, case_with_participant.id_
-    )
+    result = TriggerService(
+        dl, trigger_activity=TriggerActivityAdapter(dl)
+    ).defer_case(actor.id_, case_with_participant.id_)
     assert isinstance(result, dict)
     assert result["activity"] is not None
 
@@ -505,22 +534,26 @@ def test_defer_case_trigger_unknown_actor_raises_404(
 ):
     """defer_case_trigger raises VultronNotFoundError 404 for unknown actor."""
     with pytest.raises(VultronNotFoundError):
-        TriggerService(dl).defer_case(
-            "urn:uuid:no-such", case_with_participant.id_
-        )
+        TriggerService(
+            dl, trigger_activity=TriggerActivityAdapter(dl)
+        ).defer_case("urn:uuid:no-such", case_with_participant.id_)
 
 
 def test_defer_case_trigger_invalid_case_id_raises_422(dl, actor):
     """defer_case_trigger raises PydanticValidationError for a non-URI case_id."""
     with pytest.raises(PydanticValidationError):
-        TriggerService(dl).defer_case(actor.id_, "not-a-uri")
+        TriggerService(
+            dl, trigger_activity=TriggerActivityAdapter(dl)
+        ).defer_case(actor.id_, "not-a-uri")
 
 
 def test_defer_case_trigger_updates_participant_rm_state(
     dl, actor, case_with_participant
 ):
     """defer_case_trigger transitions actor's CaseParticipant RM state to DEFERRED."""
-    TriggerService(dl).defer_case(actor.id_, case_with_participant.id_)
+    TriggerService(dl, trigger_activity=TriggerActivityAdapter(dl)).defer_case(
+        actor.id_, case_with_participant.id_
+    )
 
     updated_case = dl.read(case_with_participant.id_)
     for p_ref in updated_case.case_participants:
@@ -549,9 +582,9 @@ def test_propose_embargo_trigger_returns_activity_dict(
     dl, actor, case_no_participant
 ):
     """propose_embargo_trigger returns dict with non-None 'activity'."""
-    result = TriggerService(dl).propose_embargo(
-        actor.id_, case_no_participant.id_, FUTURE_DATETIME
-    )
+    result = TriggerService(
+        dl, trigger_activity=TriggerActivityAdapter(dl)
+    ).propose_embargo(actor.id_, case_no_participant.id_, FUTURE_DATETIME)
     assert isinstance(result, dict)
     assert result["activity"] is not None
 
@@ -560,9 +593,9 @@ def test_propose_embargo_trigger_transitions_em_state_to_proposed(
     dl, actor, case_no_participant
 ):
     """propose_embargo_trigger transitions case EM state from N to P."""
-    TriggerService(dl).propose_embargo(
-        actor.id_, case_no_participant.id_, FUTURE_DATETIME
-    )
+    TriggerService(
+        dl, trigger_activity=TriggerActivityAdapter(dl)
+    ).propose_embargo(actor.id_, case_no_participant.id_, FUTURE_DATETIME)
     updated = dl.read(case_no_participant.id_)
     assert updated.current_status.em_state == EM.PROPOSED
 
@@ -576,9 +609,9 @@ def test_propose_embargo_trigger_exited_raises_409(
     dl.update(case_obj.id_, object_to_record(case_obj))
 
     with pytest.raises(VultronInvalidStateTransitionError):
-        TriggerService(dl).propose_embargo(
-            actor.id_, case_no_participant.id_, FUTURE_DATETIME
-        )
+        TriggerService(
+            dl, trigger_activity=TriggerActivityAdapter(dl)
+        ).propose_embargo(actor.id_, case_no_participant.id_, FUTURE_DATETIME)
 
 
 def test_propose_embargo_trigger_unknown_actor_raises_404(
@@ -586,7 +619,9 @@ def test_propose_embargo_trigger_unknown_actor_raises_404(
 ):
     """propose_embargo_trigger raises 404 for unknown actor."""
     with pytest.raises(VultronNotFoundError):
-        TriggerService(dl).propose_embargo(
+        TriggerService(
+            dl, trigger_activity=TriggerActivityAdapter(dl)
+        ).propose_embargo(
             "urn:uuid:no-such",
             case_no_participant.id_,
             FUTURE_DATETIME,
@@ -599,9 +634,9 @@ def test_propose_embargo_trigger_naive_end_time_raises_422(
     """propose_embargo_trigger raises PydanticValidationError for a timezone-naive end_time."""
     naive_dt = datetime(2099, 12, 1)
     with pytest.raises(PydanticValidationError):
-        TriggerService(dl).propose_embargo(
-            actor.id_, case_no_participant.id_, naive_dt
-        )
+        TriggerService(
+            dl, trigger_activity=TriggerActivityAdapter(dl)
+        ).propose_embargo(actor.id_, case_no_participant.id_, naive_dt)
 
 
 def test_propose_embargo_trigger_past_end_time_raises_422(
@@ -610,17 +645,17 @@ def test_propose_embargo_trigger_past_end_time_raises_422(
     """propose_embargo_trigger raises PydanticValidationError for a past end_time."""
     past_dt = datetime(2020, 1, 1, tzinfo=timezone.utc)
     with pytest.raises(PydanticValidationError):
-        TriggerService(dl).propose_embargo(
-            actor.id_, case_no_participant.id_, past_dt
-        )
+        TriggerService(
+            dl, trigger_activity=TriggerActivityAdapter(dl)
+        ).propose_embargo(actor.id_, case_no_participant.id_, past_dt)
 
 
 def test_propose_embargo_trigger_invalid_case_id_raises_422(dl, actor):
     """propose_embargo_trigger raises PydanticValidationError for a non-URI case_id."""
     with pytest.raises(PydanticValidationError):
-        TriggerService(dl).propose_embargo(
-            actor.id_, "not-a-uri", FUTURE_DATETIME
-        )
+        TriggerService(
+            dl, trigger_activity=TriggerActivityAdapter(dl)
+        ).propose_embargo(actor.id_, "not-a-uri", FUTURE_DATETIME)
 
 
 # ===========================================================================
@@ -633,9 +668,9 @@ def test_evaluate_embargo_trigger_returns_activity_dict(
 ):
     """evaluate_embargo_trigger returns dict with non-None 'activity'."""
     case_obj, proposal, _ = case_with_proposal
-    result = TriggerService(dl).accept_embargo(
-        actor.id_, case_obj.id_, proposal.id_
-    )
+    result = TriggerService(
+        dl, trigger_activity=TriggerActivityAdapter(dl)
+    ).accept_embargo(actor.id_, case_obj.id_, proposal.id_)
     assert isinstance(result, dict)
     assert result["activity"] is not None
 
@@ -645,7 +680,9 @@ def test_evaluate_embargo_trigger_activates_embargo(
 ):
     """evaluate_embargo_trigger sets EM state to ACTIVE."""
     case_obj, proposal, _ = case_with_proposal
-    TriggerService(dl).accept_embargo(actor.id_, case_obj.id_, proposal.id_)
+    TriggerService(
+        dl, trigger_activity=TriggerActivityAdapter(dl)
+    ).accept_embargo(actor.id_, case_obj.id_, proposal.id_)
     updated = dl.read(case_obj.id_)
     assert updated.current_status.em_state == EM.ACTIVE
     assert updated.active_embargo is not None
@@ -656,7 +693,9 @@ def test_evaluate_embargo_trigger_without_proposal_id_finds_first(
 ):
     """evaluate_embargo_trigger finds the first proposal when proposal_id is None."""
     case_obj, _, _ = case_with_proposal
-    result = TriggerService(dl).accept_embargo(actor.id_, case_obj.id_, None)
+    result = TriggerService(
+        dl, trigger_activity=TriggerActivityAdapter(dl)
+    ).accept_embargo(actor.id_, case_obj.id_, None)
     assert isinstance(result, dict)
     updated = dl.read(case_obj.id_)
     assert updated.current_status.em_state == EM.ACTIVE
@@ -667,9 +706,9 @@ def test_evaluate_embargo_trigger_no_proposal_raises_404(
 ):
     """evaluate_embargo_trigger raises 404 when no proposal is found."""
     with pytest.raises(VultronNotFoundError):
-        TriggerService(dl).accept_embargo(
-            actor.id_, case_no_participant.id_, None
-        )
+        TriggerService(
+            dl, trigger_activity=TriggerActivityAdapter(dl)
+        ).accept_embargo(actor.id_, case_no_participant.id_, None)
 
 
 def test_evaluate_embargo_trigger_unknown_proposal_raises_404(
@@ -677,7 +716,9 @@ def test_evaluate_embargo_trigger_unknown_proposal_raises_404(
 ):
     """evaluate_embargo_trigger raises 404 when explicit proposal_id is not found."""
     with pytest.raises(VultronNotFoundError):
-        TriggerService(dl).accept_embargo(
+        TriggerService(
+            dl, trigger_activity=TriggerActivityAdapter(dl)
+        ).accept_embargo(
             actor.id_,
             case_no_participant.id_,
             "urn:uuid:no-such-proposal",
@@ -694,7 +735,9 @@ def test_terminate_embargo_trigger_returns_activity_dict(
 ):
     """terminate_embargo_trigger returns dict with non-None 'activity'."""
     case_obj, _ = case_with_embargo
-    result = TriggerService(dl).terminate_embargo(actor.id_, case_obj.id_)
+    result = TriggerService(
+        dl, trigger_activity=TriggerActivityAdapter(dl)
+    ).terminate_embargo(actor.id_, case_obj.id_)
     assert isinstance(result, dict)
     assert result["activity"] is not None
 
@@ -704,7 +747,9 @@ def test_terminate_embargo_trigger_sets_em_state_to_exited(
 ):
     """terminate_embargo_trigger transitions case EM state to EXITED."""
     case_obj, _ = case_with_embargo
-    TriggerService(dl).terminate_embargo(actor.id_, case_obj.id_)
+    TriggerService(
+        dl, trigger_activity=TriggerActivityAdapter(dl)
+    ).terminate_embargo(actor.id_, case_obj.id_)
     updated = dl.read(case_obj.id_)
     assert updated.current_status.em_state == EM.EXITED
 
@@ -714,7 +759,9 @@ def test_terminate_embargo_trigger_clears_active_embargo(
 ):
     """terminate_embargo_trigger clears active_embargo on the case."""
     case_obj, _ = case_with_embargo
-    TriggerService(dl).terminate_embargo(actor.id_, case_obj.id_)
+    TriggerService(
+        dl, trigger_activity=TriggerActivityAdapter(dl)
+    ).terminate_embargo(actor.id_, case_obj.id_)
     updated = dl.read(case_obj.id_)
     assert updated.active_embargo is None
 
@@ -724,9 +771,9 @@ def test_terminate_embargo_trigger_no_active_embargo_raises_409(
 ):
     """terminate_embargo_trigger raises 409 when no active embargo."""
     with pytest.raises(VultronInvalidStateTransitionError):
-        TriggerService(dl).terminate_embargo(
-            actor.id_, case_no_participant.id_
-        )
+        TriggerService(
+            dl, trigger_activity=TriggerActivityAdapter(dl)
+        ).terminate_embargo(actor.id_, case_no_participant.id_)
 
 
 def test_terminate_embargo_trigger_unknown_actor_raises_404(
@@ -735,7 +782,9 @@ def test_terminate_embargo_trigger_unknown_actor_raises_404(
     """terminate_embargo_trigger raises 404 for unknown actor."""
     case_obj, _ = case_with_embargo
     with pytest.raises(VultronNotFoundError):
-        TriggerService(dl).terminate_embargo("urn:uuid:no-such", case_obj.id_)
+        TriggerService(
+            dl, trigger_activity=TriggerActivityAdapter(dl)
+        ).terminate_embargo("urn:uuid:no-such", case_obj.id_)
 
 
 def test_terminate_embargo_trigger_adds_activity_to_outbox(
@@ -748,7 +797,9 @@ def test_terminate_embargo_trigger_adds_activity_to_outbox(
         item for item in actor_before.outbox.items if isinstance(item, str)
     }
 
-    TriggerService(dl).terminate_embargo(actor.id_, case_obj.id_)
+    TriggerService(
+        dl, trigger_activity=TriggerActivityAdapter(dl)
+    ).terminate_embargo(actor.id_, case_obj.id_)
 
     actor_after = dl.read(actor.id_)
     after = {

--- a/test/core/use_cases/triggers/test_trignotify.py
+++ b/test/core/use_cases/triggers/test_trignotify.py
@@ -58,6 +58,9 @@ from vultron.wire.as2.factories import (
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.adapters.driven.trigger_activity_adapter import (
+    TriggerActivityAdapter,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
     VulnerabilityReport,
 )
@@ -155,7 +158,9 @@ class TestCaseTriggerToField:
             actor_id=self.vendor.id_,
             case_id=self.case.id_,
         )
-        result = SvcEngageCaseUseCase(self.dl, request).execute()
+        result = SvcEngageCaseUseCase(
+            self.dl, request, trigger_activity=TriggerActivityAdapter(self.dl)
+        ).execute()
 
         _, act_obj = _new_outbox_activity(self.vendor, self.dl, result)
         recipients = _to_field(act_obj)
@@ -171,7 +176,9 @@ class TestCaseTriggerToField:
             actor_id=self.vendor.id_,
             case_id=self.case.id_,
         )
-        result = SvcDeferCaseUseCase(self.dl, request).execute()
+        result = SvcDeferCaseUseCase(
+            self.dl, request, trigger_activity=TriggerActivityAdapter(self.dl)
+        ).execute()
 
         _, act_obj = _new_outbox_activity(self.vendor, self.dl, result)
         recipients = _to_field(act_obj)
@@ -193,7 +200,9 @@ class TestCaseTriggerToField:
             actor_id=self.vendor.id_,
             case_id=case_solo.id_,
         )
-        result = SvcEngageCaseUseCase(self.dl, request).execute()
+        result = SvcEngageCaseUseCase(
+            self.dl, request, trigger_activity=TriggerActivityAdapter(self.dl)
+        ).execute()
 
         _, act_obj = _new_outbox_activity(self.vendor, self.dl, result)
         recipients = _to_field(act_obj)
@@ -230,7 +239,9 @@ class TestEmbargoTriggerToField:
             case_id=self.case.id_,
             end_time=FUTURE_END_DATETIME,
         )
-        result = SvcProposeEmbargoUseCase(self.dl, request).execute()
+        result = SvcProposeEmbargoUseCase(
+            self.dl, request, trigger_activity=TriggerActivityAdapter(self.dl)
+        ).execute()
 
         _, act_obj = _new_outbox_activity(self.vendor, self.dl, result)
         recipients = _to_field(act_obj)
@@ -256,7 +267,9 @@ class TestEmbargoTriggerToField:
             case_id=self.case.id_,
             proposal_id=proposal.id_,
         )
-        result = SvcAcceptEmbargoUseCase(self.dl, request).execute()
+        result = SvcAcceptEmbargoUseCase(
+            self.dl, request, trigger_activity=TriggerActivityAdapter(self.dl)
+        ).execute()
 
         _, act_obj = _new_outbox_activity(self.vendor, self.dl, result)
         recipients = _to_field(act_obj)
@@ -277,7 +290,9 @@ class TestEmbargoTriggerToField:
             actor_id=self.vendor.id_,
             case_id=self.case.id_,
         )
-        result = SvcTerminateEmbargoUseCase(self.dl, request).execute()
+        result = SvcTerminateEmbargoUseCase(
+            self.dl, request, trigger_activity=TriggerActivityAdapter(self.dl)
+        ).execute()
 
         _, act_obj = _new_outbox_activity(self.vendor, self.dl, result)
         recipients = _to_field(act_obj)
@@ -326,7 +341,9 @@ class TestReportTriggerToField:
             actor_id=self.vendor.id_,
             offer_id=self.offer.id_,
         )
-        result = SvcCloseReportUseCase(self.dl, request).execute()
+        result = SvcCloseReportUseCase(
+            self.dl, request, trigger_activity=TriggerActivityAdapter(self.dl)
+        ).execute()
 
         _, act_obj = _new_outbox_activity(self.vendor, self.dl, result)
         recipients = _to_field(act_obj)
@@ -341,7 +358,9 @@ class TestReportTriggerToField:
             actor_id=self.vendor.id_,
             offer_id=self.offer.id_,
         )
-        result = SvcInvalidateReportUseCase(self.dl, request).execute()
+        result = SvcInvalidateReportUseCase(
+            self.dl, request, trigger_activity=TriggerActivityAdapter(self.dl)
+        ).execute()
 
         _, act_obj = _new_outbox_activity(self.vendor, self.dl, result)
         recipients = _to_field(act_obj)
@@ -356,7 +375,9 @@ class TestReportTriggerToField:
             actor_id=self.vendor.id_,
             offer_id=self.offer.id_,
         )
-        result = SvcRejectReportUseCase(self.dl, request).execute()
+        result = SvcRejectReportUseCase(
+            self.dl, request, trigger_activity=TriggerActivityAdapter(self.dl)
+        ).execute()
 
         _, act_obj = _new_outbox_activity(self.vendor, self.dl, result)
         recipients = _to_field(act_obj)
@@ -377,7 +398,9 @@ class TestReportTriggerToField:
             actor_id=self.vendor.id_,
             offer_id=self.offer.id_,
         )
-        result = SvcCloseReportUseCase(self.dl, request).execute()
+        result = SvcCloseReportUseCase(
+            self.dl, request, trigger_activity=TriggerActivityAdapter(self.dl)
+        ).execute()
 
         _, act_obj = _new_outbox_activity(self.vendor, self.dl, result)
         recipients = _to_field(act_obj)

--- a/vultron/adapters/driven/trigger_activity_adapter.py
+++ b/vultron/adapters/driven/trigger_activity_adapter.py
@@ -1,0 +1,519 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Adapter implementing
+:class:`~vultron.core.ports.trigger_activity.TriggerActivityPort`.
+
+Reads persisted objects from the DataLayer, calls the appropriate wire-layer
+factory functions to construct outbound ActivityStreams activities, persists
+the activities, and returns ``(activity_id, activity_dict)`` or
+``activity_id`` to callers.
+
+This adapter is the **sole** location where trigger-related domain→wire
+translation occurs for activity construction, keeping ``vultron/core/`` free
+of wire-layer factory imports (ARCH-01-001).
+
+See also:
+    - ``vultron/core/ports/trigger_activity.py`` — port Protocol
+    - ``vultron/wire/as2/factories/`` — factory functions
+    - ``notes/activity-factories.md``
+"""
+
+import logging
+from typing import Any, cast
+
+from vultron.core.ports.case_persistence import CaseOutboxPersistence
+from vultron.wire.as2.factories import (
+    accept_actor_recommendation_activity,
+    add_note_to_case_activity,
+    add_participant_to_case_activity,
+    announce_embargo_activity,
+    create_case_activity,
+    em_accept_embargo_activity,
+    em_propose_embargo_activity,
+    em_reject_embargo_activity,
+    recommend_actor_activity,
+    rm_accept_invite_to_case_activity,
+    rm_close_report_activity,
+    rm_defer_case_activity,
+    rm_engage_case_activity,
+    rm_invalidate_report_activity,
+    rm_invite_to_case_activity,
+    rm_submit_report_activity,
+)
+from vultron.wire.as2.vocab.base.objects.activities.transitive import (
+    as_Add,
+    as_Create,
+)
+from vultron.wire.as2.vocab.base.objects.actors import as_Actor
+from vultron.wire.as2.vocab.base.objects.object_types import as_Note
+from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    VulnerabilityCase,
+    VulnerabilityCaseStub,
+)
+from vultron.wire.as2.vocab.objects.vulnerability_report import (
+    VulnerabilityReport,
+)
+
+logger = logging.getLogger(__name__)
+
+_DUMP_KWARGS: dict[str, Any] = {"by_alias": True, "exclude_none": True}
+
+
+class TriggerActivityAdapter:
+    """Driven adapter for constructing and persisting outbound wire activities.
+
+    Instantiate once per request with the DataLayer for that request; pass to
+    :class:`~vultron.core.use_cases.triggers.service.TriggerService` as
+    ``trigger_activity``.
+
+    Args:
+        dl: The DataLayer for reading persisted objects and creating activities.
+    """
+
+    def __init__(self, dl: CaseOutboxPersistence) -> None:
+        self._dl = dl
+
+    # -----------------------------------------------------------------------
+    # Notes
+    # -----------------------------------------------------------------------
+
+    def create_note(
+        self,
+        name: str,
+        content: str,
+        context_id: str,
+        attributed_to: str,
+        in_reply_to: str | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist a Note object; return ``(note_id, note_dict)``."""
+        note = as_Note(
+            name=name,
+            content=content,
+            context=context_id,
+            attributed_to=attributed_to,
+            in_reply_to=in_reply_to,
+        )
+        try:
+            self._dl.create(note)
+        except ValueError:
+            logger.warning(
+                "create_note: note '%s' already exists — skipping", note.id_
+            )
+        return note.id_, note.model_dump(**_DUMP_KWARGS)
+
+    def create_note_activity(
+        self,
+        actor: str,
+        note_id: str,
+        to: list[str] | None = None,
+    ) -> str:
+        """Create and persist a ``Create(Note)`` activity; return activity_id."""
+        note = cast(as_Note, self._dl.read(note_id))
+        activity = as_Create(actor=actor, object_=note, to=to)
+        try:
+            self._dl.create(activity)
+        except ValueError:
+            logger.warning(
+                "create_note_activity: activity '%s' already exists — skipping",
+                activity.id_,
+            )
+        return activity.id_
+
+    def add_note_to_case(
+        self,
+        note_id: str,
+        case_id: str,
+        actor: str,
+        to: list[str] | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist an ``Add(Note, Case)`` activity."""
+        note = cast(as_Note, self._dl.read(note_id))
+        activity = add_note_to_case_activity(
+            note=note, target=case_id, actor=actor, to=to
+        )
+        try:
+            self._dl.create(activity)
+        except ValueError:
+            logger.warning(
+                "add_note_to_case: activity '%s' already exists — skipping",
+                activity.id_,
+            )
+        return activity.id_, activity.model_dump(**_DUMP_KWARGS)
+
+    # -----------------------------------------------------------------------
+    # Reports
+    # -----------------------------------------------------------------------
+
+    def submit_report(
+        self,
+        report_id: str,
+        actor: str,
+        to: str,
+        target: str,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist an ``Offer(VulnerabilityReport)`` activity."""
+        report = cast(VulnerabilityReport, self._dl.read(report_id))
+        activity = rm_submit_report_activity(
+            report=report, to=to, actor=actor, target=target
+        )
+        try:
+            self._dl.create(activity)
+        except ValueError:
+            logger.warning(
+                "submit_report: activity '%s' already exists — skipping",
+                activity.id_,
+            )
+        return activity.id_, activity.model_dump(**_DUMP_KWARGS)
+
+    def close_report(
+        self,
+        offer_id: str,
+        report_id: str,
+        actor: str,
+        to: list[str] | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist a ``Reject(Offer)`` close-report activity."""
+        offer = cast(Any, self._dl.read(offer_id))
+        activity = rm_close_report_activity(offer=offer, actor=actor, to=to)
+        try:
+            self._dl.create(activity)
+        except ValueError:
+            logger.warning(
+                "close_report: activity '%s' already exists — skipping",
+                activity.id_,
+            )
+        return activity.id_, activity.model_dump(**_DUMP_KWARGS)
+
+    def invalidate_report(
+        self,
+        offer_id: str,
+        actor: str,
+        to: list[str] | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist a ``TentativeReject(Offer)`` activity."""
+        offer = cast(Any, self._dl.read(offer_id))
+        activity = rm_invalidate_report_activity(
+            offer=offer, actor=actor, to=to
+        )
+        try:
+            self._dl.create(activity)
+        except ValueError:
+            logger.warning(
+                "invalidate_report: activity '%s' already exists — skipping",
+                activity.id_,
+            )
+        return activity.id_, activity.model_dump(**_DUMP_KWARGS)
+
+    # -----------------------------------------------------------------------
+    # Cases
+    # -----------------------------------------------------------------------
+
+    def create_case(
+        self,
+        case_id: str,
+        actor: str,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist a ``Create(VulnerabilityCase)`` activity."""
+        case = cast(VulnerabilityCase, self._dl.read(case_id))
+        activity = create_case_activity(case=case, actor=actor)
+        try:
+            self._dl.create(activity)
+        except ValueError:
+            logger.warning(
+                "create_case: activity '%s' already exists — skipping",
+                activity.id_,
+            )
+        return activity.id_, activity.model_dump(**_DUMP_KWARGS)
+
+    def engage_case(
+        self,
+        case_id: str,
+        actor: str,
+        to: list[str] | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist an ``Accept(VulnerabilityCase)`` engage activity."""
+        case = cast(VulnerabilityCase, self._dl.read(case_id))
+        activity = rm_engage_case_activity(case=case, actor=actor, to=to)
+        try:
+            self._dl.create(activity)
+        except ValueError:
+            logger.warning(
+                "engage_case: activity '%s' already exists — skipping",
+                activity.id_,
+            )
+        return activity.id_, activity.model_dump(**_DUMP_KWARGS)
+
+    def defer_case(
+        self,
+        case_id: str,
+        actor: str,
+        to: list[str] | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist a ``TentativeReject(VulnerabilityCase)`` activity."""
+        case = cast(VulnerabilityCase, self._dl.read(case_id))
+        activity = rm_defer_case_activity(case=case, actor=actor, to=to)
+        try:
+            self._dl.create(activity)
+        except ValueError:
+            logger.warning(
+                "defer_case: activity '%s' already exists — skipping",
+                activity.id_,
+            )
+        return activity.id_, activity.model_dump(**_DUMP_KWARGS)
+
+    def add_object_to_case(
+        self,
+        actor: str,
+        object_id: str,
+        case_id: str,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist an ``Add(object, Case)`` activity."""
+        case = cast(Any, self._dl.read(case_id))
+        obj = cast(Any, self._dl.read(object_id))
+        activity = as_Add(actor=actor, object_=obj, target=case)
+        try:
+            self._dl.create(activity)
+        except ValueError:
+            logger.warning(
+                "add_object_to_case: activity '%s' already exists — skipping",
+                activity.id_,
+            )
+        return activity.id_, activity.model_dump(**_DUMP_KWARGS)
+
+    # -----------------------------------------------------------------------
+    # Actors (invitations, recommendations)
+    # -----------------------------------------------------------------------
+
+    def invite_actor_to_case(
+        self,
+        invitee_id: str,
+        case_id: str,
+        actor: str,
+        to: list[str] | None = None,
+        id_: str | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist an ``Invite(Actor, Case)`` activity."""
+        extra: dict[str, Any] = {"actor": actor, "to": to}
+        if id_ is not None:
+            extra["id_"] = id_
+        activity = rm_invite_to_case_activity(
+            invitee=as_Actor(id_=invitee_id),
+            target=VulnerabilityCaseStub(id_=case_id),
+            **extra,
+        )
+        try:
+            self._dl.create(activity)
+        except ValueError:
+            logger.warning(
+                "invite_actor_to_case: activity '%s' already exists — skipping",
+                activity.id_,
+            )
+        return activity.id_, activity.model_dump(**_DUMP_KWARGS)
+
+    def accept_case_invite(
+        self,
+        invite_id: str,
+        actor: str,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist an ``Accept(Invite)`` activity."""
+        invite = cast(Any, self._dl.read(invite_id))
+        activity = rm_accept_invite_to_case_activity(
+            invite=invite, actor=actor
+        )
+        try:
+            self._dl.create(activity)
+        except ValueError:
+            logger.warning(
+                "accept_case_invite: activity '%s' already exists — skipping",
+                activity.id_,
+            )
+        return activity.id_, activity.model_dump(**_DUMP_KWARGS)
+
+    def suggest_actor_to_case(
+        self,
+        recommended_id: str,
+        case_id: str,
+        actor: str,
+        id_: str | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist a ``Offer(Actor, Case)`` recommendation activity."""
+        extra: dict[str, Any] = {"actor": actor}
+        if id_ is not None:
+            extra["id_"] = id_
+        # The factory accepts a string for target (case ID).
+        activity = recommend_actor_activity(
+            recommended=as_Actor(id_=recommended_id),
+            target=case_id,
+            **extra,
+        )
+        try:
+            self._dl.create(activity)
+        except ValueError:
+            logger.warning(
+                "suggest_actor_to_case: activity '%s' already exists — skipping",
+                activity.id_,
+            )
+        return activity.id_, activity.model_dump(**_DUMP_KWARGS)
+
+    def accept_actor_recommendation(
+        self,
+        recommended_id: str,
+        recommender_id: str,
+        recommendation_id: str,
+        case_id: str,
+        actor: str,
+        to: list[str] | None = None,
+        id_: str | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist an ``Accept(Offer)`` actor-recommendation activity.
+
+        The recommendation offer is reconstructed ephemerally (not read from
+        DataLayer) to allow callers that never stored the offer to still
+        accept it, provided they know its deterministic ID.
+        """
+        recommendation = recommend_actor_activity(
+            recommended=as_Actor(id_=recommended_id),
+            target=case_id,
+            id_=recommendation_id,
+            actor=recommender_id,
+        )
+        extra: dict[str, Any] = {"actor": actor, "to": to}
+        if id_ is not None:
+            extra["id_"] = id_
+        activity = accept_actor_recommendation_activity(
+            offer=recommendation, target=case_id, **extra
+        )
+        try:
+            self._dl.create(activity)
+        except ValueError:
+            logger.warning(
+                "accept_actor_recommendation: activity '%s' already exists"
+                " — skipping",
+                activity.id_,
+            )
+        return activity.id_, activity.model_dump(**_DUMP_KWARGS)
+
+    def add_participant_to_case(
+        self,
+        participant_id: str,
+        case_id: str,
+        actor: str,
+        to: list[str] | None = None,
+    ) -> str:
+        """Create and persist an ``Add(CaseParticipant, Case)`` activity."""
+        participant = cast(CaseParticipant, self._dl.read(participant_id))
+        activity = add_participant_to_case_activity(
+            participant=participant, target=case_id, actor=actor, to=to
+        )
+        try:
+            self._dl.create(activity)
+        except ValueError:
+            logger.warning(
+                "add_participant_to_case: activity '%s' already exists"
+                " — skipping",
+                activity.id_,
+            )
+        return activity.id_
+
+    # -----------------------------------------------------------------------
+    # Embargo
+    # -----------------------------------------------------------------------
+
+    def propose_embargo(
+        self,
+        embargo_id: str,
+        case_id: str,
+        actor: str,
+        to: list[str] | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist an ``Invite(EmbargoEvent, Case)`` proposal."""
+        embargo = cast(EmbargoEvent, self._dl.read(embargo_id))
+        activity = em_propose_embargo_activity(
+            embargo=embargo, context=case_id, actor=actor, to=to
+        )
+        try:
+            self._dl.create(activity)
+        except ValueError:
+            logger.warning(
+                "propose_embargo: activity '%s' already exists — skipping",
+                activity.id_,
+            )
+        return activity.id_, activity.model_dump(**_DUMP_KWARGS)
+
+    def accept_embargo(
+        self,
+        proposal_id: str,
+        case_id: str,
+        actor: str,
+        to: list[str] | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist an ``Accept(Invite)`` embargo-accept activity."""
+        proposal = cast(Any, self._dl.read(proposal_id))
+        activity = em_accept_embargo_activity(
+            proposal=proposal, context=case_id, actor=actor, to=to
+        )
+        try:
+            self._dl.create(activity)
+        except ValueError:
+            logger.warning(
+                "accept_embargo: activity '%s' already exists — skipping",
+                activity.id_,
+            )
+        return activity.id_, activity.model_dump(**_DUMP_KWARGS)
+
+    def reject_embargo(
+        self,
+        proposal_id: str,
+        case_id: str,
+        actor: str,
+        to: list[str] | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist a ``Reject(Invite)`` embargo-reject activity."""
+        proposal = cast(Any, self._dl.read(proposal_id))
+        activity = em_reject_embargo_activity(
+            proposal=proposal, context=case_id, actor=actor, to=to
+        )
+        try:
+            self._dl.create(activity)
+        except ValueError:
+            logger.warning(
+                "reject_embargo: activity '%s' already exists — skipping",
+                activity.id_,
+            )
+        return activity.id_, activity.model_dump(**_DUMP_KWARGS)
+
+    def announce_embargo(
+        self,
+        embargo_id: str,
+        case_id: str,
+        actor: str,
+        to: list[str] | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist an ``Announce(EmbargoEvent)`` activity."""
+        embargo = cast(EmbargoEvent, self._dl.read(embargo_id))
+        activity = announce_embargo_activity(
+            embargo=embargo, context=case_id, actor=actor, to=to
+        )
+        try:
+            self._dl.create(activity)
+        except ValueError:
+            logger.warning(
+                "announce_embargo: activity '%s' already exists — skipping",
+                activity.id_,
+            )
+        return activity.id_, activity.model_dump(**_DUMP_KWARGS)

--- a/vultron/adapters/driving/fastapi/deps.py
+++ b/vultron/adapters/driving/fastapi/deps.py
@@ -34,6 +34,9 @@ from fastapi import Depends, Path
 
 from vultron.adapters.driven.datalayer import get_datalayer
 from vultron.adapters.driven.sync_activity_adapter import SyncActivityAdapter
+from vultron.adapters.driven.trigger_activity_adapter import (
+    TriggerActivityAdapter,
+)
 from vultron.core.ports.datalayer import DataLayer
 from vultron.core.ports.trigger_service import TriggerServicePort
 from vultron.core.use_cases.triggers.service import TriggerService
@@ -76,4 +79,8 @@ def get_trigger_service(
     Inject ``app.dependency_overrides[get_trigger_service] = lambda: mock``
     in tests to replace the service with a ``Mock(spec=TriggerServicePort)``.
     """
-    return TriggerService(dl, sync_port=SyncActivityAdapter(dl))
+    return TriggerService(
+        dl,
+        sync_port=SyncActivityAdapter(dl),
+        trigger_activity=TriggerActivityAdapter(dl),
+    )

--- a/vultron/adapters/driving/fastapi/inbox_handler.py
+++ b/vultron/adapters/driving/fastapi/inbox_handler.py
@@ -62,10 +62,27 @@ def _sync_port_factory(dl: DataLayer) -> dict[str, Any]:
     return {"sync_port": SyncActivityAdapter(dl)}
 
 
+def _trigger_activity_port_factory(dl: DataLayer) -> dict[str, Any]:
+    """Create a ``TriggerActivityAdapter`` from the current DataLayer."""
+    from vultron.adapters.driven.trigger_activity_adapter import (
+        TriggerActivityAdapter,
+    )
+
+    return {"trigger_activity": TriggerActivityAdapter(dl)}
+
+
 _SYNC_PORT_SEMANTICS = frozenset(
     {
         MessageSemantics.ANNOUNCE_CASE_LOG_ENTRY,
         MessageSemantics.REJECT_CASE_LOG_ENTRY,
+    }
+)
+
+_TRIGGER_ACTIVITY_PORT_SEMANTICS = frozenset(
+    {
+        MessageSemantics.SUBMIT_REPORT,
+        MessageSemantics.SUGGEST_ACTOR_TO_CASE,
+        MessageSemantics.ACCEPT_INVITE_ACTOR_TO_CASE,
     }
 )
 
@@ -83,6 +100,12 @@ def init_dispatcher(dl: DataLayer | None = None) -> None:
     """
     global _DISPATCHER
     port_factories = {sem: _sync_port_factory for sem in _SYNC_PORT_SEMANTICS}
+    port_factories.update(
+        {
+            sem: _trigger_activity_port_factory
+            for sem in _TRIGGER_ACTIVITY_PORT_SEMANTICS
+        }
+    )
     _DISPATCHER = get_dispatcher(
         use_case_map=_use_case_map(),
         port_factories=port_factories,

--- a/vultron/adapters/driving/mcp_server.py
+++ b/vultron/adapters/driving/mcp_server.py
@@ -20,6 +20,9 @@ import logging
 from typing import Any
 
 from vultron.adapters.driven.datalayer import get_datalayer
+from vultron.adapters.driven.trigger_activity_adapter import (
+    TriggerActivityAdapter,
+)
 from vultron.core.use_cases.triggers.case import (
     SvcDeferCaseUseCase,
     SvcEngageCaseUseCase,
@@ -70,10 +73,11 @@ def mcp_invalidate_report(
 ) -> dict[str, Any]:
     """MCP tool: tentatively reject a report offer for an actor."""
     dl = get_datalayer()
+    trigger_activity = TriggerActivityAdapter(dl)
     request = InvalidateReportTriggerRequest(
         actor_id=actor_id, offer_id=offer_id, note=note
     )
-    return SvcInvalidateReportUseCase(dl, request).execute()
+    return SvcInvalidateReportUseCase(dl, request, trigger_activity).execute()
 
 
 def mcp_reject_report(
@@ -81,10 +85,11 @@ def mcp_reject_report(
 ) -> dict[str, Any]:
     """MCP tool: hard-reject a report offer for an actor."""
     dl = get_datalayer()
+    trigger_activity = TriggerActivityAdapter(dl)
     request = RejectReportTriggerRequest(
         actor_id=actor_id, offer_id=offer_id, note=note
     )
-    return SvcRejectReportUseCase(dl, request).execute()
+    return SvcRejectReportUseCase(dl, request, trigger_activity).execute()
 
 
 def mcp_close_report(
@@ -92,24 +97,27 @@ def mcp_close_report(
 ) -> dict[str, Any]:
     """MCP tool: close a report via the RM lifecycle for an actor."""
     dl = get_datalayer()
+    trigger_activity = TriggerActivityAdapter(dl)
     request = CloseReportTriggerRequest(
         actor_id=actor_id, offer_id=offer_id, note=note
     )
-    return SvcCloseReportUseCase(dl, request).execute()
+    return SvcCloseReportUseCase(dl, request, trigger_activity).execute()
 
 
 def mcp_engage_case(actor_id: str, case_id: str) -> dict[str, Any]:
     """MCP tool: engage a case for an actor."""
     dl = get_datalayer()
+    trigger_activity = TriggerActivityAdapter(dl)
     request = EngageCaseTriggerRequest(actor_id=actor_id, case_id=case_id)
-    return SvcEngageCaseUseCase(dl, request).execute()
+    return SvcEngageCaseUseCase(dl, request, trigger_activity).execute()
 
 
 def mcp_defer_case(actor_id: str, case_id: str) -> dict[str, Any]:
     """MCP tool: defer a case for an actor."""
     dl = get_datalayer()
+    trigger_activity = TriggerActivityAdapter(dl)
     request = DeferCaseTriggerRequest(actor_id=actor_id, case_id=case_id)
-    return SvcDeferCaseUseCase(dl, request).execute()
+    return SvcDeferCaseUseCase(dl, request, trigger_activity).execute()
 
 
 def mcp_propose_embargo(
@@ -128,13 +136,14 @@ def mcp_propose_embargo(
     if parsed_end_time is None:
         raise ValueError("end_time is required for propose_embargo")
     dl = get_datalayer()
+    trigger_activity = TriggerActivityAdapter(dl)
     request = ProposeEmbargoTriggerRequest(
         actor_id=actor_id,
         case_id=case_id,
         note=note,
         end_time=parsed_end_time,
     )
-    return SvcProposeEmbargoUseCase(dl, request).execute()
+    return SvcProposeEmbargoUseCase(dl, request, trigger_activity).execute()
 
 
 def mcp_accept_embargo(
@@ -142,10 +151,11 @@ def mcp_accept_embargo(
 ) -> dict[str, Any]:
     """MCP tool: accept an embargo proposal for an actor."""
     dl = get_datalayer()
+    trigger_activity = TriggerActivityAdapter(dl)
     request = AcceptEmbargoTriggerRequest(
         actor_id=actor_id, case_id=case_id, proposal_id=proposal_id
     )
-    return SvcAcceptEmbargoUseCase(dl, request).execute()
+    return SvcAcceptEmbargoUseCase(dl, request, trigger_activity).execute()
 
 
 def mcp_reject_embargo(
@@ -153,10 +163,11 @@ def mcp_reject_embargo(
 ) -> dict[str, Any]:
     """MCP tool: reject an embargo proposal for an actor."""
     dl = get_datalayer()
+    trigger_activity = TriggerActivityAdapter(dl)
     request = RejectEmbargoTriggerRequest(
         actor_id=actor_id, case_id=case_id, proposal_id=proposal_id
     )
-    return SvcRejectEmbargoUseCase(dl, request).execute()
+    return SvcRejectEmbargoUseCase(dl, request, trigger_activity).execute()
 
 
 def mcp_propose_embargo_revision(
@@ -174,22 +185,26 @@ def mcp_propose_embargo_revision(
 
     parsed_end_time = datetime.fromisoformat(end_time)
     dl = get_datalayer()
+    trigger_activity = TriggerActivityAdapter(dl)
     request = ProposeEmbargoRevisionTriggerRequest(
         actor_id=actor_id,
         case_id=case_id,
         note=note,
         end_time=parsed_end_time,
     )
-    return SvcProposeEmbargoRevisionUseCase(dl, request).execute()
+    return SvcProposeEmbargoRevisionUseCase(
+        dl, request, trigger_activity
+    ).execute()
 
 
 def mcp_terminate_embargo(actor_id: str, case_id: str) -> dict[str, Any]:
     """MCP tool: terminate the active embargo on a case for an actor."""
     dl = get_datalayer()
+    trigger_activity = TriggerActivityAdapter(dl)
     request = TerminateEmbargoTriggerRequest(
         actor_id=actor_id, case_id=case_id
     )
-    return SvcTerminateEmbargoUseCase(dl, request).execute()
+    return SvcTerminateEmbargoUseCase(dl, request, trigger_activity).execute()
 
 
 MCP_TOOLS = [

--- a/vultron/core/behaviors/bridge.py
+++ b/vultron/core/behaviors/bridge.py
@@ -38,13 +38,16 @@ Per specs/sync-log-replication.yaml:
 
 import logging
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 import py_trees
 from py_trees.common import Status
 from py_trees.display import unicode_tree
 
 from vultron.core.ports.case_persistence import CasePersistence
+
+if TYPE_CHECKING:
+    from vultron.core.ports.trigger_activity import TriggerActivityPort
 
 logger = logging.getLogger(__name__)
 
@@ -88,6 +91,7 @@ class BTBridge:
         self,
         datalayer: CasePersistence,
         is_leader: Callable[[], bool] = _default_is_leader,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ):
         """
         Initialize BT bridge with DataLayer access and optional leadership guard.
@@ -97,9 +101,15 @@ class BTBridge:
             is_leader: Callable returning True iff this node is the
                 replication leader.  Defaults to a function that always
                 returns True (single-node behaviour).  Per SYNC-09-003.
+            trigger_activity: Optional port for constructing outbound wire
+                activities from BT nodes (ARCH-01-004).  When provided it is
+                placed on the py_trees blackboard under the key
+                ``trigger_activity_factory`` so that BT nodes can call it
+                without importing from the wire layer.
         """
         self.datalayer = datalayer
         self.is_leader = is_leader
+        self.trigger_activity = trigger_activity
         self.logger = logging.getLogger(
             f"{__name__}.{self.__class__.__name__}"
         )
@@ -143,6 +153,13 @@ class BTBridge:
 
         blackboard.datalayer = self.datalayer
         blackboard.actor_id = actor_id
+
+        if self.trigger_activity is not None:
+            blackboard.register_key(
+                key="trigger_activity_factory",
+                access=py_trees.common.Access.WRITE,
+            )
+            blackboard.trigger_activity_factory = self.trigger_activity
 
         if activity is not None:
             blackboard.register_key(

--- a/vultron/core/behaviors/case/nodes.py
+++ b/vultron/core/behaviors/case/nodes.py
@@ -26,7 +26,7 @@ CM-02 requirements.
 
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import isodate  # type: ignore[import-untyped]
 
@@ -48,8 +48,6 @@ from vultron.core.states.em import EM, EMAdapter, create_em_machine
 from vultron.core.states.participant_embargo_consent import PEC
 from vultron.core.states.rm import RM
 from vultron.core.states.roles import CVDRole
-from vultron.wire.as2.factories import add_participant_to_case_activity
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
 from vultron.core.behaviors.helpers import (
     DataLayerAction,
     DataLayerCondition,
@@ -65,6 +63,9 @@ from vultron.core.use_cases._helpers import (
     update_participant_rm_state,
 )
 from vultron.core.use_cases.triggers.sync import commit_log_entry_trigger
+
+if TYPE_CHECKING:
+    from vultron.core.ports.trigger_activity import TriggerActivityPort
 
 logger = logging.getLogger(__name__)
 
@@ -628,9 +629,13 @@ def _queue_participant_add_notification(
     participant_actor_id: str,
     participant_id: str,
     case_id: str,
+    trigger_activity: "TriggerActivityPort | None" = None,
 ) -> bool:
     stored_participant = dl.read(participant_id)
-    if not isinstance(stored_participant, CaseParticipant):
+    if (
+        getattr(stored_participant, "type_", None)
+        != VultronObjectType.CASE_PARTICIPANT
+    ):
         node_logger.error(
             "%s: Could not resolve stored CaseParticipant '%s'",
             node_name,
@@ -638,23 +643,27 @@ def _queue_participant_add_notification(
         )
         return False
 
-    add_notification = add_participant_to_case_activity(
-        participant=stored_participant,
-        target=case_id,
+    if trigger_activity is None:
+        node_logger.error(
+            "%s: trigger_activity_factory not available for participant"
+            " add notification",
+            node_name,
+        )
+        return False
+
+    add_notification_id = trigger_activity.add_participant_to_case(
+        participant_id=participant_id,
+        case_id=case_id,
         actor=sender_actor_id,
         to=[participant_actor_id],
     )
-    try:
-        dl.create(add_notification)
-    except ValueError:
-        pass
 
     actor_obj = dl.read(sender_actor_id, raise_on_missing=True)
     if has_outbox(actor_obj):
-        actor_obj.outbox.items.append(add_notification.id_)
+        actor_obj.outbox.items.append(add_notification_id)
         dl.save(actor_obj)
     cast(CaseOutboxPersistence, dl).record_outbox_item(
-        sender_actor_id, add_notification.id_
+        sender_actor_id, add_notification_id
     )
     node_logger.info(
         "Queued Add(CaseParticipant '%s' for actor '%s' to case '%s') "
@@ -662,7 +671,7 @@ def _queue_participant_add_notification(
         participant_id,
         participant_actor_id,
         case_id,
-        add_notification.id_,
+        add_notification_id,
         sender_actor_id,
     )
     return True
@@ -1126,6 +1135,7 @@ class CreateCaseParticipantNode(DataLayerAction):
                 self.participant_actor_id,
                 participant.id_,
                 case_id,
+                trigger_activity=self.trigger_activity_factory,
             ):
                 return Status.FAILURE
 

--- a/vultron/core/behaviors/case/suggest_actor_tree.py
+++ b/vultron/core/behaviors/case/suggest_actor_tree.py
@@ -37,12 +37,6 @@ from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
 from vultron.core.models.protocols import is_case_model
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.use_cases._helpers import _as_id
-from vultron.wire.as2.factories import (
-    accept_actor_recommendation_activity,
-    recommend_actor_activity,
-    rm_invite_to_case_activity,
-)
-from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 
 logger = logging.getLogger(__name__)
 
@@ -167,31 +161,33 @@ class EmitAcceptRecommendationNode(DataLayerAction):
         if self.datalayer is None or self.actor_id is None:
             return Status.FAILURE
 
-        recommendation = recommend_actor_activity(
-            recommended=as_Actor(id_=self.invitee_id),
-            target=self.case_id,
-            id_=self.recommendation_id,
-            actor=self.recommender_id,
-        )
+        factory = self.trigger_activity_factory
+        if factory is None:
+            self.logger.error(
+                "%s: trigger_activity_factory not found in blackboard",
+                self.name,
+            )
+            return Status.FAILURE
+
         accept_id = _deterministic_accept_id(
             self.recommendation_id, self.actor_id
         )
-        accept = accept_actor_recommendation_activity(
-            offer=recommendation,
-            target=self.case_id,
-            id_=accept_id,
+        accept_activity_id, _ = factory.accept_actor_recommendation(
+            recommended_id=self.invitee_id,
+            recommender_id=self.recommender_id,
+            recommendation_id=self.recommendation_id,
+            case_id=self.case_id,
             actor=self.actor_id,
             to=[self.recommender_id],
+            id_=accept_id,
         )
-        try:
-            self.datalayer.create(accept)
-        except ValueError:
-            pass  # idempotent — accept already stored
-        cast(CaseOutboxPersistence, self.datalayer).outbox_append(accept.id_)
+        cast(CaseOutboxPersistence, self.datalayer).outbox_append(
+            accept_activity_id
+        )
         self.logger.info(
             "%s: queued AcceptActorRecommendation '%s' to outbox for actor '%s'",
             self.name,
-            accept.id_,
+            accept_activity_id,
             self.actor_id,
         )
         return Status.SUCCESS
@@ -219,25 +215,31 @@ class EmitInviteToCaseNode(DataLayerAction):
         if self.datalayer is None or self.actor_id is None:
             return Status.FAILURE
 
+        factory = self.trigger_activity_factory
+        if factory is None:
+            self.logger.error(
+                "%s: trigger_activity_factory not found in blackboard",
+                self.name,
+            )
+            return Status.FAILURE
+
         invite_id = _deterministic_invite_id(
             self.case_id, self.invitee_id, self.actor_id
         )
-        invite = rm_invite_to_case_activity(
-            invitee=as_Actor(id_=self.invitee_id),
-            target=self.case_id,
-            id_=invite_id,
+        invite_activity_id, _ = factory.invite_actor_to_case(
+            invitee_id=self.invitee_id,
+            case_id=self.case_id,
             actor=self.actor_id,
             to=[self.invitee_id],
+            id_=invite_id,
         )
-        try:
-            self.datalayer.create(invite)
-        except ValueError:
-            pass  # idempotent — invite already stored
-        cast(CaseOutboxPersistence, self.datalayer).outbox_append(invite.id_)
+        cast(CaseOutboxPersistence, self.datalayer).outbox_append(
+            invite_activity_id
+        )
         self.logger.info(
             "%s: queued RmInviteToCase '%s' to outbox for actor '%s'",
             self.name,
-            invite.id_,
+            invite_activity_id,
             self.actor_id,
         )
         return Status.SUCCESS

--- a/vultron/core/behaviors/helpers.py
+++ b/vultron/core/behaviors/helpers.py
@@ -26,7 +26,7 @@ Per specs/behavior-tree-integration.yaml:
 """
 
 import logging
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import py_trees
 from pydantic import BaseModel
@@ -38,6 +38,9 @@ from vultron.core.ports.case_persistence import (
     CaseOutboxPersistence,
 )
 from vultron.core.ports.datalayer import DataLayer, StorableRecord
+
+if TYPE_CHECKING:
+    from vultron.core.ports.trigger_activity import TriggerActivityPort
 
 logger = logging.getLogger(__name__)
 
@@ -137,9 +140,10 @@ class DataLayerAction(py_trees.behaviour.Behaviour):
         )
         self.datalayer: CasePersistence | None = None
         self.actor_id: str | None = None
+        self.trigger_activity_factory: "TriggerActivityPort | None" = None
 
     def setup(self, **kwargs: Any) -> None:
-        """Set up blackboard access for DataLayer and actor_id."""
+        """Set up blackboard access for DataLayer, actor_id, and trigger_activity_factory."""
         self.blackboard = self.attach_blackboard_client(name=self.name)
         self.blackboard.register_key(
             key="datalayer", access=py_trees.common.Access.READ
@@ -147,11 +151,25 @@ class DataLayerAction(py_trees.behaviour.Behaviour):
         self.blackboard.register_key(
             key="actor_id", access=py_trees.common.Access.READ
         )
+        try:
+            self.blackboard.register_key(
+                key="trigger_activity_factory",
+                access=py_trees.common.Access.READ,
+            )
+        except Exception:
+            pass
 
     def initialise(self) -> None:
         """Initialize action node by reading blackboard state."""
         self.datalayer = self.blackboard.datalayer
         self.actor_id = self.blackboard.actor_id
+
+        try:
+            self.trigger_activity_factory = (
+                self.blackboard.trigger_activity_factory
+            )
+        except Exception:
+            self.trigger_activity_factory = None
 
         if self.datalayer is None:
             self.logger.error(

--- a/vultron/core/models/embargo_event.py
+++ b/vultron/core/models/embargo_event.py
@@ -15,11 +15,21 @@
 
 """Domain representation of an EmbargoEvent."""
 
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
 from pydantic import Field
 
 from vultron.core.models.base import NonEmptyString, VultronObject
+
+
+def _now_utc() -> datetime:
+    """Return the current UTC datetime (timezone-aware)."""
+    return datetime.now(tz=timezone.utc)
+
+
+def _45_days_hence() -> datetime:
+    """Return a datetime 45 days in the future (UTC)."""
+    return _now_utc() + timedelta(days=45)
 
 
 class VultronEmbargoEvent(VultronObject):
@@ -34,5 +44,6 @@ class VultronEmbargoEvent(VultronObject):
         validation_alias="type",
         serialization_alias="type",
     )
-    end_time: datetime  # pyright: ignore[reportGeneralTypeIssues]
+    start_time: datetime = Field(default_factory=_now_utc)
+    end_time: datetime = Field(default_factory=_45_days_hence)
     context: NonEmptyString  # pyright: ignore[reportGeneralTypeIssues]

--- a/vultron/core/ports/trigger_activity.py
+++ b/vultron/core/ports/trigger_activity.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Driven port for creating and storing trigger-related wire activities.
+
+:class:`TriggerActivityPort` is the interface core trigger use cases and BT
+nodes use to create, store, and queue outbound ActivityStreams activities.
+Defining the port here keeps ``vultron/core/`` completely free of wire-layer
+imports (ARCH-01-001).
+
+Methods return ``(activity_id, activity_dict)`` so callers can:
+
+1. Queue the ``activity_id`` to the actor's outbox.
+2. Include the ``activity_dict`` in the HTTP response.
+
+Methods that create domain objects (notes, reports, cases) return
+``(object_id, object_dict)`` using the same convention.
+
+Methods only used for outbox queueing (no response body needed) return
+``str`` (the activity ID alone).
+
+Port direction: **outbound (driven)** — core constructs trigger requests and
+the adapter handles wire-format construction, DataLayer persistence, and
+returns the serialized result.
+
+See also:
+    - ``vultron/adapters/driven/trigger_activity_adapter.py`` — adapter
+    - ``specs/architecture.yaml`` ARCH-01-001, ARCH-01-004
+    - ``notes/activity-factories.md``
+"""
+
+from typing import Any, Protocol
+
+
+class TriggerActivityPort(Protocol):
+    """Driven port for trigger-related outbound wire activity construction.
+
+    Core trigger use cases and BT nodes call these methods with domain-level
+    parameters (string IDs, primitive types) and receive activity IDs and
+    serialized dictionaries in return.  The adapter handles all wire-format
+    construction and DataLayer persistence.
+
+    All methods that create an activity persist it to the DataLayer and return
+    at minimum the activity's ID.  Methods whose results are included in HTTP
+    responses also return a serialized ``dict``.
+    """
+
+    # -----------------------------------------------------------------------
+    # Notes
+    # -----------------------------------------------------------------------
+
+    def create_note(
+        self,
+        name: str,
+        content: str,
+        context_id: str,
+        attributed_to: str,
+        in_reply_to: str | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist a Note object; return ``(note_id, note_dict)``."""
+        ...
+
+    def create_note_activity(
+        self,
+        actor: str,
+        note_id: str,
+        to: list[str] | None = None,
+    ) -> str:
+        """Create and persist a ``Create(Note)`` activity; return activity_id."""
+        ...
+
+    def add_note_to_case(
+        self,
+        note_id: str,
+        case_id: str,
+        actor: str,
+        to: list[str] | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist an ``Add(Note, Case)`` activity.
+
+        Returns ``(activity_id, activity_dict)``.
+        """
+        ...
+
+    # -----------------------------------------------------------------------
+    # Reports
+    # -----------------------------------------------------------------------
+
+    def submit_report(
+        self,
+        report_id: str,
+        actor: str,
+        to: str,
+        target: str,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist an ``Offer(VulnerabilityReport)`` activity.
+
+        Returns ``(offer_id, offer_dict)``.
+        """
+        ...
+
+    def close_report(
+        self,
+        offer_id: str,
+        report_id: str,
+        actor: str,
+        to: list[str] | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist a ``Reject(Offer)`` close-report activity.
+
+        Returns ``(activity_id, activity_dict)``.
+        """
+        ...
+
+    def invalidate_report(
+        self,
+        offer_id: str,
+        actor: str,
+        to: list[str] | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist a ``TentativeReject(Offer)`` activity.
+
+        Returns ``(activity_id, activity_dict)``.
+        """
+        ...
+
+    # -----------------------------------------------------------------------
+    # Cases
+    # -----------------------------------------------------------------------
+
+    def create_case(
+        self,
+        case_id: str,
+        actor: str,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist a ``Create(VulnerabilityCase)`` activity.
+
+        Returns ``(activity_id, activity_dict)``.
+        """
+        ...
+
+    def engage_case(
+        self,
+        case_id: str,
+        actor: str,
+        to: list[str] | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist an ``Accept(VulnerabilityCase)`` engage activity.
+
+        Returns ``(activity_id, activity_dict)``.
+        """
+        ...
+
+    def defer_case(
+        self,
+        case_id: str,
+        actor: str,
+        to: list[str] | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist a ``TentativeReject(VulnerabilityCase)`` activity.
+
+        Returns ``(activity_id, activity_dict)``.
+        """
+        ...
+
+    def add_object_to_case(
+        self,
+        actor: str,
+        object_id: str,
+        case_id: str,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist an ``Add(object, Case)`` activity.
+
+        Returns ``(activity_id, activity_dict)``.
+        """
+        ...
+
+    # -----------------------------------------------------------------------
+    # Actors (invitations, recommendations)
+    # -----------------------------------------------------------------------
+
+    def invite_actor_to_case(
+        self,
+        invitee_id: str,
+        case_id: str,
+        actor: str,
+        to: list[str] | None = None,
+        id_: str | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist an ``Invite(Actor, Case)`` activity.
+
+        ``id_`` allows callers to supply a deterministic ID for idempotency.
+        Returns ``(activity_id, activity_dict)``.
+        """
+        ...
+
+    def accept_case_invite(
+        self,
+        invite_id: str,
+        actor: str,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist an ``Accept(Invite)`` activity.
+
+        Returns ``(activity_id, activity_dict)``.
+        """
+        ...
+
+    def suggest_actor_to_case(
+        self,
+        recommended_id: str,
+        case_id: str,
+        actor: str,
+        id_: str | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist a ``Offer(Actor, Case)`` recommendation activity.
+
+        ``id_`` allows callers to supply a deterministic ID for idempotency.
+        Returns ``(activity_id, activity_dict)``.
+        """
+        ...
+
+    def accept_actor_recommendation(
+        self,
+        recommended_id: str,
+        recommender_id: str,
+        recommendation_id: str,
+        case_id: str,
+        actor: str,
+        to: list[str] | None = None,
+        id_: str | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist an ``Accept(Offer)`` actor-recommendation activity.
+
+        The recommendation offer is reconstructed ephemerally from
+        ``recommended_id``, ``recommender_id``, ``recommendation_id``, and
+        ``case_id``; it does not need to already exist in the DataLayer.
+        ``id_`` allows callers to supply a deterministic ID for idempotency.
+        Returns ``(activity_id, activity_dict)``.
+        """
+        ...
+
+    def add_participant_to_case(
+        self,
+        participant_id: str,
+        case_id: str,
+        actor: str,
+        to: list[str] | None = None,
+    ) -> str:
+        """Create and persist an ``Add(CaseParticipant, Case)`` activity.
+
+        Returns the activity ID (callers only need the ID for outbox queueing).
+        """
+        ...
+
+    # -----------------------------------------------------------------------
+    # Embargo
+    # -----------------------------------------------------------------------
+
+    def propose_embargo(
+        self,
+        embargo_id: str,
+        case_id: str,
+        actor: str,
+        to: list[str] | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist an ``Invite(EmbargoEvent, Case)`` proposal.
+
+        Returns ``(activity_id, activity_dict)``.
+        """
+        ...
+
+    def accept_embargo(
+        self,
+        proposal_id: str,
+        case_id: str,
+        actor: str,
+        to: list[str] | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist an ``Accept(Invite)`` embargo-accept activity.
+
+        Returns ``(activity_id, activity_dict)``.
+        """
+        ...
+
+    def reject_embargo(
+        self,
+        proposal_id: str,
+        case_id: str,
+        actor: str,
+        to: list[str] | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist a ``Reject(Invite)`` embargo-reject activity.
+
+        Returns ``(activity_id, activity_dict)``.
+        """
+        ...
+
+    def announce_embargo(
+        self,
+        embargo_id: str,
+        case_id: str,
+        actor: str,
+        to: list[str] | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist an ``Announce(EmbargoEvent)`` activity.
+
+        Returns ``(activity_id, activity_dict)``.
+        """
+        ...

--- a/vultron/core/use_cases/received/actor.py
+++ b/vultron/core/use_cases/received/actor.py
@@ -1,6 +1,7 @@
 """Use cases for case actor/participant invitation and suggestion activities."""
 
 import logging
+from typing import TYPE_CHECKING
 
 from vultron.core.models.events.actor import (
     AcceptCaseOwnershipTransferReceivedEvent,
@@ -29,15 +30,22 @@ from vultron.core.states.participant_embargo_consent import (
 from vultron.core.states.rm import RM
 from vultron.core.use_cases._helpers import _as_id, _idempotent_create
 
+if TYPE_CHECKING:
+    from vultron.core.ports.trigger_activity import TriggerActivityPort
+
 logger = logging.getLogger(__name__)
 
 
 class SuggestActorToCaseReceivedUseCase:
     def __init__(
-        self, dl: CasePersistence, request: SuggestActorToCaseReceivedEvent
+        self,
+        dl: CasePersistence,
+        request: SuggestActorToCaseReceivedEvent,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: SuggestActorToCaseReceivedEvent = request
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> None:
         request = self._request
@@ -85,7 +93,9 @@ class SuggestActorToCaseReceivedUseCase:
             invitee_id=invitee_id,
             case_id=case_id,
         )
-        bridge = BTBridge(datalayer=self._dl)
+        bridge = BTBridge(
+            datalayer=self._dl, trigger_activity=self._trigger_activity
+        )
         bridge.execute_with_setup(tree, actor_id=local_actor_id)
 
 
@@ -247,9 +257,11 @@ class AcceptInviteActorToCaseReceivedUseCase:
         self,
         dl: CaseOutboxPersistence,
         request: AcceptInviteActorToCaseReceivedEvent,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: AcceptInviteActorToCaseReceivedEvent = request
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> None:
         request = self._request
@@ -326,7 +338,9 @@ class AcceptInviteActorToCaseReceivedUseCase:
             create_prioritize_subtree,
         )
 
-        bridge = BTBridge(datalayer=self._dl)
+        bridge = BTBridge(
+            datalayer=self._dl, trigger_activity=self._trigger_activity
+        )
         prioritize_tree = create_prioritize_subtree(
             case_id=case_id, actor_id=invitee_id
         )

--- a/vultron/core/use_cases/received/report.py
+++ b/vultron/core/use_cases/received/report.py
@@ -1,6 +1,7 @@
 """Use cases for vulnerability report activities."""
 
 import logging
+from typing import TYPE_CHECKING
 
 from vultron.core.models.events.report import (
     AckReportReceivedEvent,
@@ -18,6 +19,9 @@ from vultron.core.use_cases.received.case import (
     ValidateCaseUseCase,
 )
 from vultron.errors import VultronValidationError
+
+if TYPE_CHECKING:
+    from vultron.core.ports.trigger_activity import TriggerActivityPort
 
 logger = logging.getLogger(__name__)
 
@@ -85,6 +89,7 @@ def _run_submit_report_case_creation(
     request: SubmitReportReceivedEvent,
     receiving_actor_id: str,
     report_id: str,
+    trigger_activity: "TriggerActivityPort | None" = None,
 ) -> None:
     from py_trees.common import Status
 
@@ -99,7 +104,7 @@ def _run_submit_report_case_creation(
         request.report_id,
     )
 
-    bridge = BTBridge(datalayer=dl)
+    bridge = BTBridge(datalayer=dl, trigger_activity=trigger_activity)
     tree = create_receive_report_case_tree(
         report_id=report_id,
         offer_id=request.activity_id,
@@ -176,10 +181,14 @@ class CreateReportReceivedUseCase:
 
 class SubmitReportReceivedUseCase:
     def __init__(
-        self, dl: CasePersistence, request: SubmitReportReceivedEvent
+        self,
+        dl: CasePersistence,
+        request: SubmitReportReceivedEvent,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: SubmitReportReceivedEvent = request
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> None:
         request = self._request
@@ -202,7 +211,11 @@ class SubmitReportReceivedUseCase:
             return
 
         _run_submit_report_case_creation(
-            self._dl, request, receiving_actor_id, request.report_id
+            self._dl,
+            request,
+            receiving_actor_id,
+            request.report_id,
+            trigger_activity=self._trigger_activity,
         )
 
 

--- a/vultron/core/use_cases/triggers/actor.py
+++ b/vultron/core/use_cases/triggers/actor.py
@@ -20,7 +20,7 @@ No HTTP framework imports permitted here.
 """
 
 import logging
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any
 
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.use_cases.triggers._helpers import (
@@ -34,18 +34,9 @@ from vultron.core.use_cases.triggers.requests import (
     SuggestActorToCaseTriggerRequest,
 )
 from vultron.errors import VultronNotFoundError, VultronValidationError
-from vultron.wire.as2.factories import (
-    recommend_actor_activity,
-    rm_accept_invite_to_case_activity,
-    rm_invite_to_case_activity,
-)
-from vultron.wire.as2.factories.errors import VultronActivityConstructionError
-from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Invite
-from vultron.wire.as2.vocab.base.objects.actors import as_Actor
-from vultron.wire.as2.vocab.objects.vulnerability_case import (
-    VulnerabilityCase,
-    VulnerabilityCaseStub,
-)
+
+if TYPE_CHECKING:
+    from vultron.core.ports.trigger_activity import TriggerActivityPort
 
 logger = logging.getLogger(__name__)
 
@@ -63,9 +54,11 @@ class SvcSuggestActorToCaseUseCase:
         self,
         dl: CaseOutboxPersistence,
         request: SuggestActorToCaseTriggerRequest,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request = request
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> dict[str, Any]:
         actor_id = self._request.actor_id
@@ -79,14 +72,20 @@ class SvcSuggestActorToCaseUseCase:
                 "Actor", self._request.suggested_actor_id
             )
 
-        activity = recommend_actor_activity(
-            recommended=cast(as_Actor, suggested_raw),
-            target=cast(VulnerabilityCase, case),
-            actor=actor_id,
-        )
-        self._dl.create(activity)
+        if self._trigger_activity is None:
+            raise RuntimeError(
+                "SvcSuggestActorToCaseUseCase requires a TriggerActivityPort"
+            )
 
-        add_activity_to_outbox(actor_id, activity.id_, self._dl)
+        activity_id, activity_dict = (
+            self._trigger_activity.suggest_actor_to_case(
+                recommended_id=self._request.suggested_actor_id,
+                case_id=case.id_,
+                actor=actor_id,
+            )
+        )
+
+        add_activity_to_outbox(actor_id, activity_id, self._dl)
 
         logger.info(
             "Actor '%s' suggested actor '%s' for case '%s'",
@@ -95,9 +94,7 @@ class SvcSuggestActorToCaseUseCase:
             case.id_,
         )
 
-        return {
-            "activity": activity.model_dump(by_alias=True, exclude_none=True)
-        }
+        return {"activity": activity_dict}
 
 
 class SvcInviteActorToCaseUseCase:
@@ -111,9 +108,11 @@ class SvcInviteActorToCaseUseCase:
         self,
         dl: CaseOutboxPersistence,
         request: InviteActorToCaseTriggerRequest,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request = request
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> dict[str, Any]:
         actor_id = self._request.actor_id
@@ -125,15 +124,21 @@ class SvcInviteActorToCaseUseCase:
         if invitee_raw is None:
             raise VultronNotFoundError("Actor", self._request.invitee_id)
 
-        activity = rm_invite_to_case_activity(
-            invitee=cast(as_Actor, invitee_raw),
-            target=VulnerabilityCaseStub(id_=case.id_),
-            actor=actor_id,
-            to=[self._request.invitee_id],
-        )
-        self._dl.create(activity)
+        if self._trigger_activity is None:
+            raise RuntimeError(
+                "SvcInviteActorToCaseUseCase requires a TriggerActivityPort"
+            )
 
-        add_activity_to_outbox(actor_id, activity.id_, self._dl)
+        activity_id, activity_dict = (
+            self._trigger_activity.invite_actor_to_case(
+                invitee_id=self._request.invitee_id,
+                case_id=case.id_,
+                actor=actor_id,
+                to=[self._request.invitee_id],
+            )
+        )
+
+        add_activity_to_outbox(actor_id, activity_id, self._dl)
 
         logger.info(
             "Actor '%s' invited actor '%s' to case '%s'",
@@ -142,9 +147,7 @@ class SvcInviteActorToCaseUseCase:
             case.id_,
         )
 
-        return {
-            "activity": activity.model_dump(by_alias=True, exclude_none=True)
-        }
+        return {"activity": activity_dict}
 
 
 class SvcAcceptCaseInviteUseCase:
@@ -159,9 +162,11 @@ class SvcAcceptCaseInviteUseCase:
         self,
         dl: CaseOutboxPersistence,
         request: AcceptCaseInviteTriggerRequest,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request = request
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> dict[str, Any]:
         actor_id = self._request.actor_id
@@ -174,33 +179,29 @@ class SvcAcceptCaseInviteUseCase:
                 "RmInviteToCaseActivity", self._request.invite_id
             )
 
-        if not isinstance(raw_invite, as_Invite):
+        invite_type = getattr(raw_invite, "type_", "")
+        if invite_type != "Invite":
             raise VultronValidationError(
                 f"'{self._request.invite_id}' is not an"
                 " RmInviteToCaseActivity"
             )
-        invite = raw_invite
 
-        try:
-            activity = rm_accept_invite_to_case_activity(
-                invite=invite,
-                actor=actor_id,
+        if self._trigger_activity is None:
+            raise RuntimeError(
+                "SvcAcceptCaseInviteUseCase requires a TriggerActivityPort"
             )
-        except VultronActivityConstructionError as exc:
-            raise VultronValidationError(
-                f"'{self._request.invite_id}' is not a valid"
-                " RmInviteToCaseActivity"
-            ) from exc
-        self._dl.create(activity)
 
-        add_activity_to_outbox(actor_id, activity.id_, self._dl)
+        activity_id, activity_dict = self._trigger_activity.accept_case_invite(
+            invite_id=self._request.invite_id,
+            actor=actor_id,
+        )
+
+        add_activity_to_outbox(actor_id, activity_id, self._dl)
 
         logger.info(
             "Actor '%s' accepted case invite '%s'",
             actor_id,
-            invite.id_,
+            self._request.invite_id,
         )
 
-        return {
-            "activity": activity.model_dump(by_alias=True, exclude_none=True)
-        }
+        return {"activity": activity_dict}

--- a/vultron/core/use_cases/triggers/case.py
+++ b/vultron/core/use_cases/triggers/case.py
@@ -20,8 +20,9 @@ No HTTP framework imports permitted here.
 """
 
 import logging
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any
 
+from vultron.core.models.case import VultronCase
 from vultron.core.states.rm import RM
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.use_cases._helpers import update_participant_rm_state
@@ -39,16 +40,9 @@ from vultron.core.use_cases.triggers.requests import (
     EngageCaseTriggerRequest,
 )
 from vultron.errors import VultronNotFoundError, VultronValidationError
-from vultron.wire.as2.factories import (
-    create_case_activity,
-    rm_defer_case_activity,
-    rm_engage_case_activity,
-)
-from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Add
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
-from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
-)
+
+if TYPE_CHECKING:
+    from vultron.core.ports.trigger_activity import TriggerActivityPort
 
 logger = logging.getLogger(__name__)
 
@@ -57,10 +51,14 @@ class SvcEngageCaseUseCase:
     """Engage a case (RM → ACCEPTED)."""
 
     def __init__(
-        self, dl: CaseOutboxPersistence, request: EngageCaseTriggerRequest
+        self,
+        dl: CaseOutboxPersistence,
+        request: EngageCaseTriggerRequest,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: EngageCaseTriggerRequest = request
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> dict:
         request = self._request
@@ -73,23 +71,20 @@ class SvcEngageCaseUseCase:
 
         case = resolve_case(case_id, dl)
 
-        engage_activity = rm_engage_case_activity(
-            case=cast(Any, case),
+        if self._trigger_activity is None:
+            raise RuntimeError(
+                "SvcEngageCaseUseCase requires a TriggerActivityPort"
+            )
+
+        activity_id, activity_dict = self._trigger_activity.engage_case(
+            case_id=case_id,
             actor=actor_id,
             to=case_addressees(case, actor_id) or None,
         )
 
-        try:
-            dl.create(engage_activity)
-        except ValueError:
-            logger.warning(
-                "EngageCase activity '%s' already exists",
-                engage_activity.id_,
-            )
-
         update_participant_rm_state(case.id_, actor_id, RM.ACCEPTED, dl)
 
-        add_activity_to_outbox(actor_id, engage_activity.id_, dl)
+        add_activity_to_outbox(actor_id, activity_id, dl)
 
         logger.info(
             "Actor '%s' engaged case '%s' (RM → ACCEPTED)",
@@ -97,18 +92,21 @@ class SvcEngageCaseUseCase:
             case.id_,
         )
 
-        activity = engage_activity.model_dump(by_alias=True, exclude_none=True)
-        return {"activity": activity}
+        return {"activity": activity_dict}
 
 
 class SvcDeferCaseUseCase:
     """Defer a case (RM → DEFERRED)."""
 
     def __init__(
-        self, dl: CaseOutboxPersistence, request: DeferCaseTriggerRequest
+        self,
+        dl: CaseOutboxPersistence,
+        request: DeferCaseTriggerRequest,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: DeferCaseTriggerRequest = request
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> dict:
         request = self._request
@@ -121,23 +119,20 @@ class SvcDeferCaseUseCase:
 
         case = resolve_case(case_id, dl)
 
-        defer_activity = rm_defer_case_activity(
-            case=cast(Any, case),
+        if self._trigger_activity is None:
+            raise RuntimeError(
+                "SvcDeferCaseUseCase requires a TriggerActivityPort"
+            )
+
+        activity_id, activity_dict = self._trigger_activity.defer_case(
+            case_id=case_id,
             actor=actor_id,
             to=case_addressees(case, actor_id) or None,
         )
 
-        try:
-            dl.create(defer_activity)
-        except ValueError:
-            logger.warning(
-                "DeferCase activity '%s' already exists",
-                defer_activity.id_,
-            )
-
         update_participant_rm_state(case.id_, actor_id, RM.DEFERRED, dl)
 
-        add_activity_to_outbox(actor_id, defer_activity.id_, dl)
+        add_activity_to_outbox(actor_id, activity_id, dl)
 
         logger.info(
             "Actor '%s' deferred case '%s' (RM → DEFERRED)",
@@ -145,8 +140,7 @@ class SvcDeferCaseUseCase:
             case.id_,
         )
 
-        activity = defer_activity.model_dump(by_alias=True, exclude_none=True)
-        return {"activity": activity}
+        return {"activity": activity_dict}
 
 
 class SvcCreateCaseUseCase:
@@ -158,17 +152,21 @@ class SvcCreateCaseUseCase:
     """
 
     def __init__(
-        self, dl: CaseOutboxPersistence, request: CreateCaseTriggerRequest
+        self,
+        dl: CaseOutboxPersistence,
+        request: CreateCaseTriggerRequest,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request = request
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> dict[str, Any]:
         actor_id = self._request.actor_id
         actor = resolve_actor(actor_id, self._dl)
         actor_id = actor.id_
 
-        case = VulnerabilityCase(
+        case = VultronCase(
             name=self._request.name,
             content=self._request.content,
             attributed_to=actor.id_,
@@ -180,32 +178,35 @@ class SvcCreateCaseUseCase:
                 raise VultronNotFoundError(
                     "VulnerabilityReport", self._request.report_id
                 )
-            if not isinstance(raw, VulnerabilityReport):
+            if getattr(raw, "type_", "") != "VulnerabilityReport":
                 raise VultronValidationError(
                     f"'{self._request.report_id}' is not a VulnerabilityReport"
                 )
-            case.vulnerability_reports.append(raw.id_)
+            raw_id = getattr(raw, "id_", None) or self._request.report_id
+            case.vulnerability_reports.append(raw_id)
 
         self._dl.create(case)
 
-        activity = create_case_activity(
-            case=case,
+        if self._trigger_activity is None:
+            raise RuntimeError(
+                "SvcCreateCaseUseCase requires a TriggerActivityPort"
+            )
+
+        activity_id, activity_dict = self._trigger_activity.create_case(
+            case_id=case.id_,
             actor=actor.id_,
         )
-        self._dl.create(activity)
 
-        add_activity_to_outbox(actor_id, activity.id_, self._dl)
+        add_activity_to_outbox(actor_id, activity_id, self._dl)
 
         logger.info(
             "Actor '%s' created case '%s' (CreateCaseActivity '%s')",
             actor_id,
             case.id_,
-            activity.id_,
+            activity_id,
         )
 
-        return {
-            "activity": activity.model_dump(by_alias=True, exclude_none=True)
-        }
+        return {"activity": activity_dict}
 
 
 class SvcAddObjectToCaseUseCase:
@@ -225,9 +226,11 @@ class SvcAddObjectToCaseUseCase:
         self,
         dl: CaseOutboxPersistence,
         request: AddObjectToCaseTriggerRequest,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request = request
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> dict[str, Any]:
         actor_id = self._request.actor_id
@@ -238,38 +241,33 @@ class SvcAddObjectToCaseUseCase:
         actor = resolve_actor(actor_id, dl)
         actor_id = actor.id_
 
-        case = resolve_case(case_id, dl)
+        resolve_case(case_id, dl)
 
         raw = dl.read(object_id)
         if raw is None:
             raise VultronNotFoundError("AS2Object", object_id)
 
-        activity = as_Add(
-            actor=actor_id,
-            object_=cast(Any, raw),
-            target=cast(Any, case),
-        )
-
-        try:
-            dl.create(activity)
-        except ValueError:
-            logger.warning(
-                "AddObjectToCase: activity '%s' already exists — skipping",
-                activity.id_,
+        if self._trigger_activity is None:
+            raise RuntimeError(
+                "SvcAddObjectToCaseUseCase requires a TriggerActivityPort"
             )
 
-        add_activity_to_outbox(actor_id, activity.id_, dl)
+        activity_id, activity_dict = self._trigger_activity.add_object_to_case(
+            actor=actor_id,
+            object_id=object_id,
+            case_id=case_id,
+        )
+
+        add_activity_to_outbox(actor_id, activity_id, dl)
 
         logger.info(
             "Actor '%s' added object '%s' to case '%s'",
             actor_id,
             object_id,
-            case.id_,
+            case_id,
         )
 
-        return {
-            "activity": activity.model_dump(by_alias=True, exclude_none=True)
-        }
+        return {"activity": activity_dict}
 
 
 class SvcAddReportToCaseUseCase:
@@ -282,10 +280,14 @@ class SvcAddReportToCaseUseCase:
     """
 
     def __init__(
-        self, dl: CaseOutboxPersistence, request: AddReportToCaseTriggerRequest
+        self,
+        dl: CaseOutboxPersistence,
+        request: AddReportToCaseTriggerRequest,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request = request
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> dict[str, Any]:
         actor_id = self._request.actor_id
@@ -296,7 +298,7 @@ class SvcAddReportToCaseUseCase:
             raise VultronNotFoundError(
                 "VulnerabilityReport", self._request.report_id
             )
-        if not isinstance(raw, VulnerabilityReport):
+        if getattr(raw, "type_", "") != "VulnerabilityReport":
             raise VultronValidationError(
                 f"'{self._request.report_id}' is not a VulnerabilityReport"
             )
@@ -308,5 +310,6 @@ class SvcAddReportToCaseUseCase:
                 case_id=self._request.case_id,
                 object_id=self._request.report_id,
             ),
+            trigger_activity=self._trigger_activity,
         )
         return inner.execute()

--- a/vultron/core/use_cases/triggers/embargo.py
+++ b/vultron/core/use_cases/triggers/embargo.py
@@ -20,9 +20,11 @@ No HTTP framework imports permitted here.
 """
 
 import logging
+from typing import TYPE_CHECKING, Any
 
 from transitions import MachineError
 
+from vultron.core.models.embargo_event import VultronEmbargoEvent
 from vultron.core.states.em import EM, EMAdapter, create_em_machine
 from vultron.core.models.protocols import (
     CaseModel,
@@ -58,28 +60,20 @@ from vultron.errors import (
     VultronNotFoundError,
     VultronValidationError,
 )
-from vultron.wire.as2.factories import (
-    announce_embargo_activity,
-    em_accept_embargo_activity,
-    em_propose_embargo_activity,
-    em_reject_embargo_activity,
-)
-from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Invite
-from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+
+if TYPE_CHECKING:
+    from vultron.core.ports.trigger_activity import TriggerActivityPort
 
 logger = logging.getLogger(__name__)
 
 
-def _coerce_embargo_event(
-    raw_embargo: object, embargo_id: str
-) -> EmbargoEvent:
-    """Normalize a persisted embargo record to an ``EmbargoEvent`` instance.
+def _coerce_embargo_event(raw_embargo: object, embargo_id: str) -> Any:
+    """Normalize a persisted embargo record; raise domain errors on failure.
 
-    Since ``EmbargoEvent`` has ``type_ = "EmbargoEvent"`` and is registered in
-    the wire vocabulary, ``dl.read()`` returns a fully typed ``EmbargoEvent``
-    directly. This function validates that the result is the expected type.
+    Validates that the result has type ``"EmbargoEvent"`` by checking the
+    ``type_`` attribute rather than using a wire-type isinstance check.
     """
-    if isinstance(raw_embargo, EmbargoEvent):
+    if getattr(raw_embargo, "type_", "") == "EmbargoEvent":
         return raw_embargo
     if raw_embargo is None:
         raise VultronNotFoundError("EmbargoEvent", embargo_id)
@@ -228,7 +222,7 @@ def _update_participant_embargo_rejection(
 
 def _resolve_embargo_proposal(
     case: CaseModel, proposal_id: str | None, dl: CaseOutboxPersistence
-) -> as_Invite:
+) -> Any:
     if proposal_id:
         proposal = dl.read(proposal_id)
         if proposal is None:
@@ -241,15 +235,15 @@ def _resolve_embargo_proposal(
                 f"(pending for case '{case.id_}')",
             )
 
-    if not isinstance(proposal, as_Invite):
+    if getattr(proposal, "type_", "") != "Invite":
         raise VultronValidationError(
             f"Expected an EmProposeEmbargoActivity (embargo proposal), got "
-            f"{type(proposal).__name__}."
+            f"type '{getattr(proposal, 'type_', 'unknown')}'."
         )
     return proposal
 
 
-def _resolve_embargo_id_from_proposal(proposal: as_Invite) -> str:
+def _resolve_embargo_id_from_proposal(proposal: Any) -> str:
     embargo_id = getattr(proposal.object_, "id_", None)
     if embargo_id is not None and not isinstance(embargo_id, str):
         raise VultronValidationError(
@@ -336,10 +330,14 @@ class SvcProposeEmbargoUseCase:
     """Propose an embargo on a case."""
 
     def __init__(
-        self, dl: CaseOutboxPersistence, request: ProposeEmbargoTriggerRequest
+        self,
+        dl: CaseOutboxPersistence,
+        request: ProposeEmbargoTriggerRequest,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: ProposeEmbargoTriggerRequest = request
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> dict:
         request = self._request
@@ -380,26 +378,26 @@ class SvcProposeEmbargoUseCase:
         if end_time is not None:
             embargo_kwargs["end_time"] = end_time
 
-        embargo = EmbargoEvent(**embargo_kwargs)
+        embargo = VultronEmbargoEvent(**embargo_kwargs)
 
         try:
             dl.create(embargo)
         except ValueError:
-            logger.warning("EmbargoEvent '%s' already exists", embargo.id_)
+            logger.warning(
+                "VultronEmbargoEvent '%s' already exists", embargo.id_
+            )
 
-        proposal = em_propose_embargo_activity(
-            embargo=embargo,
-            context=case.id_,
+        if self._trigger_activity is None:
+            raise RuntimeError(
+                "SvcProposeEmbargoUseCase requires a TriggerActivityPort"
+            )
+
+        proposal_id, proposal_dict = self._trigger_activity.propose_embargo(
+            embargo_id=embargo.id_,
+            case_id=case.id_,
             actor=actor_id,
             to=case_addressees(case, actor_id) or None,
         )
-
-        try:
-            dl.create(proposal)
-        except ValueError:
-            logger.warning(
-                "em_propose_embargo_activity '%s' already exists", proposal.id_
-            )
 
         case.current_status.em_state = new_em_state
         # When transitioning from ACTIVE to REVISE, all current signatories
@@ -428,20 +426,23 @@ class SvcProposeEmbargoUseCase:
         case.proposed_embargoes.append(embargo.id_)
         dl.save(case)
 
-        add_activity_to_outbox(actor_id, proposal.id_, dl)
+        add_activity_to_outbox(actor_id, proposal_id, dl)
 
-        activity = proposal.model_dump(by_alias=True, exclude_none=True)
-        return {"activity": activity}
+        return {"activity": proposal_dict}
 
 
 class SvcAcceptEmbargoUseCase:
     """Accept an embargo proposal (accept-embargo)."""
 
     def __init__(
-        self, dl: CaseOutboxPersistence, request: AcceptEmbargoTriggerRequest
+        self,
+        dl: CaseOutboxPersistence,
+        request: AcceptEmbargoTriggerRequest,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: AcceptEmbargoTriggerRequest = request
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> dict:
         request = self._request
@@ -459,19 +460,17 @@ class SvcAcceptEmbargoUseCase:
                 f"Could not resolve EmbargoEvent '{embargo_id}'."
             )
 
-        accept = em_accept_embargo_activity(
-            proposal=proposal,
-            context=case.id_,
+        if self._trigger_activity is None:
+            raise RuntimeError(
+                "SvcAcceptEmbargoUseCase requires a TriggerActivityPort"
+            )
+
+        accept_id, accept_dict = self._trigger_activity.accept_embargo(
+            proposal_id=proposal.id_,
+            case_id=case.id_,
             actor=actor_id,
             to=case_addressees(case, actor_id) or None,
         )
-
-        try:
-            dl.create(accept)
-        except ValueError:
-            logger.warning(
-                "em_accept_embargo_activity '%s' already exists", accept.id_
-            )
 
         em_state = case.current_status.em_state
         new_em_state, owner_activated = _apply_owner_embargo_acceptance(
@@ -483,7 +482,7 @@ class SvcAcceptEmbargoUseCase:
 
         _update_participant_embargo_acceptance(case, actor_id, embargo_id, dl)
         dl.save(case)
-        add_activity_to_outbox(actor_id, accept.id_, dl)
+        add_activity_to_outbox(actor_id, accept_id, dl)
 
         if owner_activated:
             logger.info(
@@ -508,8 +507,7 @@ class SvcAcceptEmbargoUseCase:
                 new_em_state,
             )
 
-        activity = accept.model_dump(by_alias=True, exclude_none=True)
-        return {"activity": activity}
+        return {"activity": accept_dict}
 
 
 class SvcTerminateEmbargoUseCase:
@@ -519,9 +517,11 @@ class SvcTerminateEmbargoUseCase:
         self,
         dl: CaseOutboxPersistence,
         request: TerminateEmbargoTriggerRequest,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: TerminateEmbargoTriggerRequest = request
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> dict:
         request = self._request
@@ -575,21 +575,19 @@ class SvcTerminateEmbargoUseCase:
                 f"Active embargo on case '{case.id_}' is missing an ID."
             )
 
-        embargo = _coerce_embargo_event(dl.read(embargo_id), embargo_id)
+        _coerce_embargo_event(dl.read(embargo_id), embargo_id)
 
-        announce = announce_embargo_activity(
-            embargo=embargo,
-            context=case.id_,
+        if self._trigger_activity is None:
+            raise RuntimeError(
+                "SvcTerminateEmbargoUseCase requires a TriggerActivityPort"
+            )
+
+        announce_id, announce_dict = self._trigger_activity.announce_embargo(
+            embargo_id=embargo_id,
+            case_id=case.id_,
             actor=actor_id,
             to=case_addressees(case, actor_id) or None,
         )
-
-        try:
-            dl.create(announce)
-        except ValueError:
-            logger.warning(
-                "announce_embargo_activity '%s' already exists", announce.id_
-            )
 
         case.current_status.em_state = EM(adapter.state)
         case.active_embargo = None
@@ -597,7 +595,7 @@ class SvcTerminateEmbargoUseCase:
         _cascade_pec_reset(case, dl)
         dl.save(case)
 
-        add_activity_to_outbox(actor_id, announce.id_, dl)
+        add_activity_to_outbox(actor_id, announce_id, dl)
 
         logger.info(
             "Actor '%s' terminated embargo '%s' on case '%s' (EM %s → %s)",
@@ -608,8 +606,7 @@ class SvcTerminateEmbargoUseCase:
             adapter.state,
         )
 
-        activity = announce.model_dump(by_alias=True, exclude_none=True)
-        return {"activity": activity}
+        return {"activity": announce_dict}
 
 
 # Backward-compatible alias
@@ -623,10 +620,14 @@ class SvcRejectEmbargoUseCase:
     """
 
     def __init__(
-        self, dl: CaseOutboxPersistence, request: RejectEmbargoTriggerRequest
+        self,
+        dl: CaseOutboxPersistence,
+        request: RejectEmbargoTriggerRequest,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: RejectEmbargoTriggerRequest = request
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> dict:
         request = self._request
@@ -644,24 +645,22 @@ class SvcRejectEmbargoUseCase:
             proposal.id_,
         )
 
-        reject = em_reject_embargo_activity(
-            proposal=proposal,
-            context=case.id_,
+        if self._trigger_activity is None:
+            raise RuntimeError(
+                "SvcRejectEmbargoUseCase requires a TriggerActivityPort"
+            )
+
+        reject_id, reject_dict = self._trigger_activity.reject_embargo(
+            proposal_id=proposal.id_,
+            case_id=case.id_,
             actor=actor_id,
             to=case_addressees(case, actor_id) or None,
         )
 
-        try:
-            dl.create(reject)
-        except ValueError:
-            logger.warning(
-                "em_reject_embargo_activity '%s' already exists", reject.id_
-            )
-
         _update_participant_embargo_rejection(case, actor_id, embargo_id, dl)
         dl.save(case)
 
-        add_activity_to_outbox(actor_id, reject.id_, dl)
+        add_activity_to_outbox(actor_id, reject_id, dl)
 
         if owner_rejected:
             logger.info(
@@ -685,8 +684,7 @@ class SvcRejectEmbargoUseCase:
                 new_em_state,
             )
 
-        activity = reject.model_dump(by_alias=True, exclude_none=True)
-        return {"activity": activity}
+        return {"activity": reject_dict}
 
 
 class SvcProposeEmbargoRevisionUseCase:
@@ -701,9 +699,11 @@ class SvcProposeEmbargoRevisionUseCase:
         self,
         dl: CaseOutboxPersistence,
         request: ProposeEmbargoRevisionTriggerRequest,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: ProposeEmbargoRevisionTriggerRequest = request
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> dict:
         request = self._request
@@ -751,32 +751,33 @@ class SvcProposeEmbargoRevisionUseCase:
         if end_time is not None:
             embargo_kwargs["end_time"] = end_time
 
-        embargo = EmbargoEvent(**embargo_kwargs)
+        embargo = VultronEmbargoEvent(**embargo_kwargs)
 
         try:
             dl.create(embargo)
         except ValueError:
-            logger.warning("EmbargoEvent '%s' already exists", embargo.id_)
+            logger.warning(
+                "VultronEmbargoEvent '%s' already exists", embargo.id_
+            )
 
-        proposal = em_propose_embargo_activity(
-            embargo=embargo,
-            context=case.id_,
+        if self._trigger_activity is None:
+            raise RuntimeError(
+                "SvcProposeEmbargoRevisionUseCase requires a"
+                " TriggerActivityPort"
+            )
+
+        proposal_id, proposal_dict = self._trigger_activity.propose_embargo(
+            embargo_id=embargo.id_,
+            case_id=case.id_,
             actor=actor_id,
             to=case_addressees(case, actor_id) or None,
         )
-
-        try:
-            dl.create(proposal)
-        except ValueError:
-            logger.warning(
-                "em_propose_embargo_activity '%s' already exists", proposal.id_
-            )
 
         case.current_status.em_state = new_em_state
         case.proposed_embargoes.append(embargo.id_)
         dl.save(case)
 
-        add_activity_to_outbox(actor_id, proposal.id_, dl)
+        add_activity_to_outbox(actor_id, proposal_id, dl)
 
         logger.info(
             "Actor '%s' proposed embargo revision '%s' on case '%s'"
@@ -788,5 +789,4 @@ class SvcProposeEmbargoRevisionUseCase:
             new_em_state,
         )
 
-        activity = proposal.model_dump(by_alias=True, exclude_none=True)
-        return {"activity": activity}
+        return {"activity": proposal_dict}

--- a/vultron/core/use_cases/triggers/note.py
+++ b/vultron/core/use_cases/triggers/note.py
@@ -20,6 +20,7 @@ No HTTP framework imports permitted here.
 """
 
 import logging
+from typing import TYPE_CHECKING
 
 from vultron.core.models.protocols import is_case_model
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
@@ -32,9 +33,9 @@ from vultron.core.use_cases.triggers._helpers import (
 from vultron.core.use_cases.triggers.requests import (
     AddNoteToCaseTriggerRequest,
 )
-from vultron.wire.as2.factories import add_note_to_case_activity
-from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Create
-from vultron.wire.as2.vocab.base.objects.object_types import as_Note
+
+if TYPE_CHECKING:
+    from vultron.core.ports.trigger_activity import TriggerActivityPort
 
 logger = logging.getLogger(__name__)
 
@@ -48,10 +49,14 @@ class SvcAddNoteToCaseUseCase:
     """
 
     def __init__(
-        self, dl: CaseOutboxPersistence, request: AddNoteToCaseTriggerRequest
+        self,
+        dl: CaseOutboxPersistence,
+        request: AddNoteToCaseTriggerRequest,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request = request
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> dict:
         request = self._request
@@ -64,21 +69,19 @@ class SvcAddNoteToCaseUseCase:
 
         case = resolve_case(case_id, dl)
 
-        note = as_Note(
+        if self._trigger_activity is None:
+            raise RuntimeError(
+                "SvcAddNoteToCaseUseCase requires a TriggerActivityPort"
+            )
+        factory = self._trigger_activity
+
+        note_id, note_dict = factory.create_note(
             name=request.note_name,
             content=request.note_content,
-            context=case_id,
+            context_id=case_id,
             attributed_to=actor_id,
             in_reply_to=request.in_reply_to,
         )
-
-        try:
-            dl.create(note)
-        except ValueError:
-            logger.warning(
-                "AddNoteToCase: note '%s' already exists — skipping create",
-                note.id_,
-            )
 
         # Add note to the actor's local copy of the case.
         case_obj = dl.read(case_id)
@@ -87,49 +90,42 @@ class SvcAddNoteToCaseUseCase:
                 n if isinstance(n, str) else getattr(n, "id_", str(n))
                 for n in case_obj.notes
             ]
-            if note.id_ not in existing_ids:
-                case_obj.notes.append(note.id_)
+            if note_id not in existing_ids:
+                case_obj.notes.append(note_id)
                 dl.save(case_obj)
                 logger.debug(
                     "AddNoteToCase: added note '%s' to local case '%s'",
-                    note.id_,
+                    note_id,
                     case_id,
                 )
 
         addressees = case_addressees(case, actor_id) or None
 
-        create_activity = as_Create(
+        create_activity_id = factory.create_note_activity(
             actor=actor_id,
-            object_=note,
+            note_id=note_id,
             to=addressees,
         )
-        add_note_activity = add_note_to_case_activity(
-            note=note,
-            target=case_id,
-            actor=actor_id,
-            to=addressees,
+        add_note_activity_id, add_note_activity_dict = (
+            factory.add_note_to_case(
+                note_id=note_id,
+                case_id=case_id,
+                actor=actor_id,
+                to=addressees,
+            )
         )
 
-        for activity in (create_activity, add_note_activity):
-            try:
-                dl.create(activity)
-            except ValueError:
-                logger.warning(
-                    "AddNoteToCase: activity '%s' already exists — skipping",
-                    activity.id_,
-                )
-            add_activity_to_outbox(actor_id, activity.id_, dl)
+        for activity_id in (create_activity_id, add_note_activity_id):
+            add_activity_to_outbox(actor_id, activity_id, dl)
 
         logger.info(
             "Actor '%s' added note '%s' to case '%s'",
             actor_id,
-            note.id_,
+            note_id,
             case_id,
         )
 
         return {
-            "note": note.model_dump(by_alias=True, exclude_none=True),
-            "activity": add_note_activity.model_dump(
-                by_alias=True, exclude_none=True
-            ),
+            "note": note_dict,
+            "activity": add_note_activity_dict,
         }

--- a/vultron/core/use_cases/triggers/report.py
+++ b/vultron/core/use_cases/triggers/report.py
@@ -25,7 +25,7 @@ No HTTP framework imports (FastAPI, Starlette) are permitted here.
 """
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from vultron.core.states.rm import RM
 from vultron.core.behaviors.bridge import BTBridge
@@ -33,6 +33,7 @@ from vultron.core.behaviors.report.validate_tree import (
     create_validate_report_tree,
 )
 from vultron.core.models.participant_status import VultronParticipantStatus
+from vultron.core.models.report import VultronReport
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.use_cases._helpers import (
     _idempotent_create,
@@ -57,22 +58,16 @@ from vultron.errors import (
     VultronNotFoundError,
     VultronValidationError,
 )
-from vultron.wire.as2.factories import (
-    rm_close_report_activity,
-    rm_invalidate_report_activity,
-    rm_submit_report_activity,
-)
-from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
-from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
-)
+
+if TYPE_CHECKING:
+    from vultron.core.ports.trigger_activity import TriggerActivityPort
 
 logger = logging.getLogger(__name__)
 
 
 def _resolve_offer_and_report(
     offer_id: str, dl: CaseOutboxPersistence
-) -> tuple[as_Offer, VulnerabilityReport]:
+) -> tuple[Any, Any]:
     """Resolve offer and its embedded report; raise domain errors on failure.
 
     After the DataLayer rehydration pipeline, ``dl.read(offer_id)`` returns an
@@ -82,22 +77,23 @@ def _resolve_offer_and_report(
     offer = dl.read(offer_id)
     if offer is None:
         raise VultronNotFoundError("Offer", offer_id)
-    if not isinstance(offer, as_Offer):
+    if getattr(offer, "type_", "") != "Offer":
         raise VultronValidationError(
             f"Expected RmSubmitReportActivity for offer '{offer_id}', "
-            f"got {type(offer).__name__}."
+            f"got type '{getattr(offer, 'type_', 'unknown')}'."
         )
-    report = offer.object_
-    if not isinstance(report, VulnerabilityReport):
+    report = getattr(offer, "object_", None)
+    if getattr(report, "type_", "") != "VulnerabilityReport":
         raise VultronValidationError(
             f"Expected VulnerabilityReport embedded in offer '{offer_id}', "
-            f"got {type(report).__name__ if report is not None else 'None'}."
+            f"got type"
+            f" '{getattr(report, 'type_', 'None' if report is None else 'unknown')}'."
         )
     return offer, report
 
 
 def _report_addressees(
-    report_id: str, actor_id: str, offer, dl: CaseOutboxPersistence
+    report_id: str, actor_id: str, offer: Any, dl: CaseOutboxPersistence
 ) -> list[str] | None:
     """Return the ``to`` recipient list for a report-phase outbound activity.
 
@@ -190,9 +186,11 @@ class SvcInvalidateReportUseCase:
         self,
         dl: CaseOutboxPersistence,
         request: InvalidateReportTriggerRequest,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: InvalidateReportTriggerRequest = request
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> dict:
         request = self._request
@@ -205,19 +203,16 @@ class SvcInvalidateReportUseCase:
 
         offer, report = _resolve_offer_and_report(offer_id, dl)
 
-        invalidate_activity = rm_invalidate_report_activity(
-            offer=offer,
+        if self._trigger_activity is None:
+            raise RuntimeError(
+                "SvcInvalidateReportUseCase requires a TriggerActivityPort"
+            )
+
+        activity_id, activity_dict = self._trigger_activity.invalidate_report(
+            offer_id=offer.id_,
             actor=actor_id,
             to=_report_addressees(report.id_, actor_id, offer, dl),
         )
-
-        try:
-            dl.create(invalidate_activity)
-        except ValueError:
-            logger.warning(
-                "InvalidateReport activity '%s' already exists",
-                invalidate_activity.id_,
-            )
 
         set_status_invalidate = VultronParticipantStatus(
             id_=_report_phase_status_id(
@@ -235,7 +230,7 @@ class SvcInvalidateReportUseCase:
             "ParticipantStatus (report-phase RM.INVALID)",
         )
 
-        add_activity_to_outbox(actor_id, invalidate_activity.id_, dl)
+        add_activity_to_outbox(actor_id, activity_id, dl)
 
         logger.info(
             "Actor '%s' invalidated offer '%s' (report '%s')",
@@ -244,20 +239,21 @@ class SvcInvalidateReportUseCase:
             report.id_,
         )
 
-        activity = invalidate_activity.model_dump(
-            by_alias=True, exclude_none=True
-        )
-        return {"activity": activity}
+        return {"activity": activity_dict}
 
 
 class SvcRejectReportUseCase:
     """Hard-close a report offer by emitting RmCloseReportActivity (Reject)."""
 
     def __init__(
-        self, dl: CaseOutboxPersistence, request: RejectReportTriggerRequest
+        self,
+        dl: CaseOutboxPersistence,
+        request: RejectReportTriggerRequest,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: RejectReportTriggerRequest = request
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> dict:
         request = self._request
@@ -271,19 +267,17 @@ class SvcRejectReportUseCase:
 
         offer, report = _resolve_offer_and_report(offer_id, dl)
 
-        reject_activity = rm_close_report_activity(
-            offer=offer,
+        if self._trigger_activity is None:
+            raise RuntimeError(
+                "SvcRejectReportUseCase requires a TriggerActivityPort"
+            )
+
+        activity_id, activity_dict = self._trigger_activity.close_report(
+            offer_id=offer.id_,
+            report_id=report.id_,
             actor=actor_id,
             to=_report_addressees(report.id_, actor_id, offer, dl),
         )
-
-        try:
-            dl.create(reject_activity)
-        except ValueError:
-            logger.warning(
-                "CloseReport activity '%s' already exists",
-                reject_activity.id_,
-            )
 
         set_status_reject = VultronParticipantStatus(
             id_=_report_phase_status_id(actor_id, report.id_, RM.CLOSED.value),
@@ -299,7 +293,7 @@ class SvcRejectReportUseCase:
             "ParticipantStatus (report-phase RM.CLOSED)",
         )
 
-        add_activity_to_outbox(actor_id, reject_activity.id_, dl)
+        add_activity_to_outbox(actor_id, activity_id, dl)
 
         logger.info(
             "Actor '%s' hard-closed offer '%s' (report '%s'); note: %s",
@@ -309,18 +303,21 @@ class SvcRejectReportUseCase:
             note,
         )
 
-        activity = reject_activity.model_dump(by_alias=True, exclude_none=True)
-        return {"activity": activity}
+        return {"activity": activity_dict}
 
 
 class SvcCloseReportUseCase:
     """Close a report via the RM lifecycle (RM → C transition)."""
 
     def __init__(
-        self, dl: CaseOutboxPersistence, request: CloseReportTriggerRequest
+        self,
+        dl: CaseOutboxPersistence,
+        request: CloseReportTriggerRequest,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: CloseReportTriggerRequest = request
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> dict:
         request = self._request
@@ -349,19 +346,17 @@ class SvcCloseReportUseCase:
                 f"Report '{report.id_}' is already CLOSED."
             )
 
-        close_activity = rm_close_report_activity(
-            offer=offer,
+        if self._trigger_activity is None:
+            raise RuntimeError(
+                "SvcCloseReportUseCase requires a TriggerActivityPort"
+            )
+
+        activity_id, activity_dict = self._trigger_activity.close_report(
+            offer_id=offer.id_,
+            report_id=report.id_,
             actor=actor_id,
             to=_report_addressees(report.id_, actor_id, offer, dl),
         )
-
-        try:
-            dl.create(close_activity)
-        except ValueError:
-            logger.warning(
-                "CloseReport activity '%s' already exists",
-                close_activity.id_,
-            )
 
         set_status_close = VultronParticipantStatus(
             id_=closed_id,
@@ -377,18 +372,18 @@ class SvcCloseReportUseCase:
             "ParticipantStatus (report-phase RM.CLOSED)",
         )
 
-        add_activity_to_outbox(actor_id, close_activity.id_, dl)
+        add_activity_to_outbox(actor_id, activity_id, dl)
 
         logger.info(
-            "Actor '%s' closed offer '%s' (report '%s') via RM lifecycle; note: %s",
+            "Actor '%s' closed offer '%s' (report '%s') via RM lifecycle;"
+            " note: %s",
             actor_id,
             offer.id_,
             report.id_,
             note,
         )
 
-        activity = close_activity.model_dump(by_alias=True, exclude_none=True)
-        return {"activity": activity}
+        return {"activity": activity_dict}
 
 
 class SvcSubmitReportUseCase:
@@ -400,10 +395,14 @@ class SvcSubmitReportUseCase:
     """
 
     def __init__(
-        self, dl: CaseOutboxPersistence, request: SubmitReportTriggerRequest
+        self,
+        dl: CaseOutboxPersistence,
+        request: SubmitReportTriggerRequest,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request = request
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> dict:
         request = self._request
@@ -412,7 +411,7 @@ class SvcSubmitReportUseCase:
         actor = resolve_actor(request.actor_id, dl)
         actor_id = actor.id_
 
-        report = VulnerabilityReport(
+        report = VultronReport(
             name=request.report_name,
             content=request.report_content,
             attributed_to=actor_id,
@@ -430,26 +429,25 @@ class SvcSubmitReportUseCase:
             report.id_,
         )
 
-        offer = rm_submit_report_activity(
-            report=report,
-            to=request.recipient_id,
+        if self._trigger_activity is None:
+            raise RuntimeError(
+                "SvcSubmitReportUseCase requires a TriggerActivityPort"
+            )
+
+        offer_id, offer_dict = self._trigger_activity.submit_report(
+            report_id=report.id_,
             actor=actor_id,
+            to=request.recipient_id,
             target=request.recipient_id,
         )
-        try:
-            dl.create(offer)
-        except ValueError:
-            logger.warning(
-                "RmSubmitReportActivity '%s' already exists", offer.id_
-            )
 
         logger.info(
             "Offering report '%s' to '%s' (offer: '%s')",
             report.id_,
             request.recipient_id,
-            offer.id_,
+            offer_id,
         )
 
-        add_activity_to_outbox(actor_id, offer.id_, dl)
+        add_activity_to_outbox(actor_id, offer_id, dl)
 
-        return {"offer": offer.model_dump(by_alias=True, exclude_none=True)}
+        return {"offer": offer_dict}

--- a/vultron/core/use_cases/triggers/service.py
+++ b/vultron/core/use_cases/triggers/service.py
@@ -35,7 +35,7 @@ No HTTP framework imports permitted in this module.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from vultron.core.models.case_log_entry import VultronCaseLogEntry
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
@@ -91,6 +91,9 @@ from vultron.core.use_cases.triggers.requests import (
 from vultron.core.ports.sync_activity import SyncActivityPort
 from vultron.core.use_cases.triggers.sync import commit_log_entry_trigger
 
+if TYPE_CHECKING:
+    from vultron.core.ports.trigger_activity import TriggerActivityPort
+
 
 class TriggerService:
     """Facade over all actor-initiated trigger use cases.
@@ -109,9 +112,11 @@ class TriggerService:
         self,
         dl: DataLayer,
         sync_port: SyncActivityPort | None = None,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._sync_port = sync_port
+        self._trigger_activity = trigger_activity
 
     # -----------------------------------------------------------------------
     # Report triggers
@@ -131,7 +136,9 @@ class TriggerService:
             report_content=report_content,
             recipient_id=recipient_id,
         )
-        return SvcSubmitReportUseCase(self._dl, req).execute()
+        return SvcSubmitReportUseCase(
+            self._dl, req, trigger_activity=self._trigger_activity
+        ).execute()
 
     def validate_report(
         self,
@@ -155,7 +162,9 @@ class TriggerService:
         req = InvalidateReportTriggerRequest(
             actor_id=actor_id, offer_id=offer_id, note=note
         )
-        return SvcInvalidateReportUseCase(self._dl, req).execute()
+        return SvcInvalidateReportUseCase(
+            self._dl, req, trigger_activity=self._trigger_activity
+        ).execute()
 
     def reject_report(
         self,
@@ -167,7 +176,9 @@ class TriggerService:
         req = RejectReportTriggerRequest(
             actor_id=actor_id, offer_id=offer_id, note=note or None
         )
-        return SvcRejectReportUseCase(self._dl, req).execute()
+        return SvcRejectReportUseCase(
+            self._dl, req, trigger_activity=self._trigger_activity
+        ).execute()
 
     def close_report(
         self,
@@ -179,7 +190,9 @@ class TriggerService:
         req = CloseReportTriggerRequest(
             actor_id=actor_id, offer_id=offer_id, note=note
         )
-        return SvcCloseReportUseCase(self._dl, req).execute()
+        return SvcCloseReportUseCase(
+            self._dl, req, trigger_activity=self._trigger_activity
+        ).execute()
 
     # -----------------------------------------------------------------------
     # Case triggers
@@ -199,7 +212,9 @@ class TriggerService:
             content=content,
             report_id=report_id,
         )
-        return SvcCreateCaseUseCase(self._dl, req).execute()
+        return SvcCreateCaseUseCase(
+            self._dl, req, trigger_activity=self._trigger_activity
+        ).execute()
 
     def engage_case(
         self,
@@ -208,7 +223,9 @@ class TriggerService:
     ) -> dict[str, Any]:
         """Accept a case, transitioning RM state to ACCEPTED."""
         req = EngageCaseTriggerRequest(actor_id=actor_id, case_id=case_id)
-        return SvcEngageCaseUseCase(self._dl, req).execute()
+        return SvcEngageCaseUseCase(
+            self._dl, req, trigger_activity=self._trigger_activity
+        ).execute()
 
     def defer_case(
         self,
@@ -217,7 +234,9 @@ class TriggerService:
     ) -> dict[str, Any]:
         """Defer a case, transitioning RM state to DEFERRED."""
         req = DeferCaseTriggerRequest(actor_id=actor_id, case_id=case_id)
-        return SvcDeferCaseUseCase(self._dl, req).execute()
+        return SvcDeferCaseUseCase(
+            self._dl, req, trigger_activity=self._trigger_activity
+        ).execute()
 
     def add_report_to_case(
         self,
@@ -231,7 +250,9 @@ class TriggerService:
             case_id=case_id,
             report_id=report_id,
         )
-        return SvcAddReportToCaseUseCase(self._dl, req).execute()
+        return SvcAddReportToCaseUseCase(
+            self._dl, req, trigger_activity=self._trigger_activity
+        ).execute()
 
     def add_object_to_case(
         self,
@@ -245,7 +266,9 @@ class TriggerService:
             case_id=case_id,
             object_id=object_id,
         )
-        return SvcAddObjectToCaseUseCase(self._dl, req).execute()
+        return SvcAddObjectToCaseUseCase(
+            self._dl, req, trigger_activity=self._trigger_activity
+        ).execute()
 
     def add_note_to_case(
         self,
@@ -263,7 +286,9 @@ class TriggerService:
             note_content=note_content,
             in_reply_to=in_reply_to,
         )
-        return SvcAddNoteToCaseUseCase(self._dl, req).execute()
+        return SvcAddNoteToCaseUseCase(
+            self._dl, req, trigger_activity=self._trigger_activity
+        ).execute()
 
     # -----------------------------------------------------------------------
     # Embargo triggers
@@ -283,7 +308,9 @@ class TriggerService:
             end_time=end_time,
             note=note,
         )
-        return SvcProposeEmbargoUseCase(self._dl, req).execute()
+        return SvcProposeEmbargoUseCase(
+            self._dl, req, trigger_activity=self._trigger_activity
+        ).execute()
 
     def accept_embargo(
         self,
@@ -297,7 +324,9 @@ class TriggerService:
             case_id=case_id,
             proposal_id=proposal_id,
         )
-        return SvcAcceptEmbargoUseCase(self._dl, req).execute()
+        return SvcAcceptEmbargoUseCase(
+            self._dl, req, trigger_activity=self._trigger_activity
+        ).execute()
 
     def reject_embargo(
         self,
@@ -311,7 +340,9 @@ class TriggerService:
             case_id=case_id,
             proposal_id=proposal_id,
         )
-        return SvcRejectEmbargoUseCase(self._dl, req).execute()
+        return SvcRejectEmbargoUseCase(
+            self._dl, req, trigger_activity=self._trigger_activity
+        ).execute()
 
     def propose_embargo_revision(
         self,
@@ -327,7 +358,9 @@ class TriggerService:
             end_time=end_time,
             note=note,
         )
-        return SvcProposeEmbargoRevisionUseCase(self._dl, req).execute()
+        return SvcProposeEmbargoRevisionUseCase(
+            self._dl, req, trigger_activity=self._trigger_activity
+        ).execute()
 
     def terminate_embargo(
         self,
@@ -338,7 +371,9 @@ class TriggerService:
         req = TerminateEmbargoTriggerRequest(
             actor_id=actor_id, case_id=case_id
         )
-        return SvcTerminateEmbargoUseCase(self._dl, req).execute()
+        return SvcTerminateEmbargoUseCase(
+            self._dl, req, trigger_activity=self._trigger_activity
+        ).execute()
 
     # -----------------------------------------------------------------------
     # Actor / participant triggers
@@ -356,7 +391,9 @@ class TriggerService:
             case_id=case_id,
             suggested_actor_id=suggested_actor_id,
         )
-        return SvcSuggestActorToCaseUseCase(self._dl, req).execute()
+        return SvcSuggestActorToCaseUseCase(
+            self._dl, req, trigger_activity=self._trigger_activity
+        ).execute()
 
     def accept_case_invite(
         self,
@@ -368,7 +405,9 @@ class TriggerService:
             actor_id=actor_id,
             invite_id=invite_id,
         )
-        return SvcAcceptCaseInviteUseCase(self._dl, req).execute()
+        return SvcAcceptCaseInviteUseCase(
+            self._dl, req, trigger_activity=self._trigger_activity
+        ).execute()
 
     def invite_actor_to_case(
         self,
@@ -382,7 +421,9 @@ class TriggerService:
             case_id=case_id,
             invitee_id=invitee_id,
         )
-        return SvcInviteActorToCaseUseCase(self._dl, req).execute()
+        return SvcInviteActorToCaseUseCase(
+            self._dl, req, trigger_activity=self._trigger_activity
+        ).execute()
 
     # -----------------------------------------------------------------------
     # Sync / log-replication triggers

--- a/vultron/errors.py
+++ b/vultron/errors.py
@@ -125,3 +125,14 @@ class HistoryValidationError(ValidationError):
 
 class TransitionValidationError(ValidationError):
     pass
+
+
+class VultronActivityConstructionError(VultronError):
+    """Raised when a factory function cannot construct the requested activity.
+
+    Wraps a Pydantic ``ValidationError`` as ``__cause__`` so that callers
+    can inspect the original validation details if needed.  Factory
+    functions MUST catch ``pydantic.ValidationError`` and re-raise as this
+    exception to keep internal activity class names out of public error
+    messages.  See ``specs/activity-factories.yaml`` AF-04-001, AF-04-002.
+    """

--- a/vultron/wire/as2/extractor.py
+++ b/vultron/wire/as2/extractor.py
@@ -457,17 +457,18 @@ def _build_embargo_event_object(
         or _get_id(target)
     )
     if isinstance(end_time, datetime) and embargo_context and object_id:
-        return {
-            "object_": VultronEmbargoEvent(
-                id_=object_id,
-                name=getattr(obj, "name", None),
-                start_time=getattr(obj, "start_time", None),
-                end_time=end_time,
-                published=getattr(obj, "published", None),
-                updated=getattr(obj, "updated", None),
-                context=embargo_context,
-            )
+        raw_start = getattr(obj, "start_time", None)
+        kwargs: dict[str, Any] = {
+            "id_": object_id,
+            "name": getattr(obj, "name", None),
+            "end_time": end_time,
+            "published": getattr(obj, "published", None),
+            "updated": getattr(obj, "updated", None),
+            "context": embargo_context,
         }
+        if isinstance(raw_start, datetime):
+            kwargs["start_time"] = raw_start
+        return {"object_": VultronEmbargoEvent(**kwargs)}
     return {}
 
 

--- a/vultron/wire/as2/factories/errors.py
+++ b/vultron/wire/as2/factories/errors.py
@@ -14,17 +14,11 @@
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 """
 Exceptions raised by Vultron activity factory functions.
+
+``VultronActivityConstructionError`` is defined in ``vultron.errors`` and
+re-exported here for backward compatibility.
 """
 
-from vultron.errors import VultronError
+from vultron.errors import VultronActivityConstructionError  # noqa: F401
 
-
-class VultronActivityConstructionError(VultronError):
-    """Raised when a factory function cannot construct the requested activity.
-
-    Wraps a Pydantic ``ValidationError`` as ``__cause__`` so that callers
-    can inspect the original validation details if needed.  Factory
-    functions MUST catch ``pydantic.ValidationError`` and re-raise as this
-    exception to keep internal activity class names out of public error
-    messages.  See ``specs/activity-factories.yaml`` AF-04-001, AF-04-002.
-    """
+__all__ = ["VultronActivityConstructionError"]


### PR DESCRIPTION
## Summary

Closes #428.

Introduces a `TriggerActivityPort` driven port and `TriggerActivityAdapter` concrete implementation to remove all 7 ARCH-01-001-violating wire imports from `vultron/core/`.

## Changes

### New files
- `vultron/core/ports/trigger_activity.py` — `TriggerActivityPort` Protocol (~20 methods)
- `vultron/adapters/driven/trigger_activity_adapter.py` — Concrete adapter
- `test/architecture/test_core_no_wire_imports.py` — Ratchet test; 3 documented KNOWN_VIOLATIONS for future cleanup

### Core changes (violations removed)
- `vultron/core/behaviors/case/nodes.py` — removed wire imports
- `vultron/core/behaviors/case/suggest_actor_tree.py` — removed wire imports
- `vultron/core/use_cases/triggers/actor.py` — removed wire imports
- `vultron/core/use_cases/triggers/case.py` — removed wire imports
- `vultron/core/use_cases/triggers/embargo.py` — removed wire imports
- `vultron/core/use_cases/triggers/note.py` — removed wire imports
- `vultron/core/use_cases/triggers/report.py` — removed wire imports

### Infrastructure changes
- `BTBridge`: accepts optional `trigger_activity` param; injects to blackboard
- `TriggerService`: accepts `trigger_activity` param; threads to all use case constructors
- `deps.py`: provides `TriggerActivityAdapter(dl)` to `TriggerService`
- `inbox_handler.py`: port_factories for `SUBMIT_REPORT`, `SUGGEST_ACTOR_TO_CASE`, `ACCEPT_INVITE_ACTOR_TO_CASE`
- Received handlers `report.py` and `actor.py`: optional `trigger_activity` threaded to `BTBridge`
- `VultronEmbargoEvent`: added `start_time`/`end_time` defaults
- `VultronActivityConstructionError`: moved to `vultron/errors.py`

### KNOWN_VIOLATIONS (documented for future PRs)
Three core files remain in scope for follow-up work:
- `vultron/core/behaviors/report/nodes.py`
- `vultron/core/use_cases/received/actor.py`
- `vultron/core/use_cases/received/note.py`

## Validation

- 2306 tests pass (0 failures)
- Black + flake8 clean
- mypy: no issues in 597 source files
- pyright: 0 errors, 0 warnings
