### PR TITLE
infra: enforce PAD-01 issue hierarchy — Epic issues and sub-issue wiring

### DIFF
--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -60,9 +60,29 @@ docs/adr/, notes/, and AGENTS.md files, and scans vultron/ and test/.
 1. Search `vultron/` and `test/` to confirm the current implementation.
 2. Do not assume missing functionality; verify it in code.
 3. If a blocking prerequisite is discovered, create a new GitHub Issue for it
-   with `group:unscheduled` and the appropriate `size:` label, then record the
-   dependency in `plan/BUILD_LEARNINGS.md` and stop. Do not add prerequisite
-   tasks to `plan/IMPLEMENTATION_PLAN.md`.
+   with `group:unscheduled` and the appropriate `size:` label, then
+   immediately link it as a sub-issue of the current task Issue
+   (PAD-01-003). First resolve the node IDs, then use GraphQL `addSubIssue`:
+
+   ```bash
+   # Resolve node IDs
+   gh api graphql -f query='{ repository(owner:"CERTCC", name:"Vultron") {
+     parent: issue(number: <CURRENT_TASK_NUMBER>) { id }
+     child:  issue(number: <NEW_ISSUE_NUMBER>) { id }
+   } }'
+
+   # Link as sub-issue
+   gh api graphql -f query='
+   mutation {
+     addSubIssue(input: {
+       issueId: "<PARENT_NODE_ID>"
+       subIssueId: "<CHILD_NODE_ID>"
+     }) { issue { number } subIssue { number } }
+   }'
+   ```
+
+   Record the dependency in `plan/BUILD_LEARNINGS.md` and stop. Do not add
+   prerequisite tasks to `plan/IMPLEMENTATION_PLAN.md`.
 4. If more than one prerequisite is required, or the prerequisite work is
    non-trivial, update `plan/BUILD_LEARNINGS.md` with details and stop.
 

--- a/.agents/skills/create-epic/SKILL.md
+++ b/.agents/skills/create-epic/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: create-epic
+description: >
+  Create a GitHub Epic issue for a priority group and wire existing leaf
+  issues as its sub-issues. Uses the GitHub Epic issue type (via GraphQL)
+  and the sub-issues REST API. Invoke this skill whenever a priority group
+  needs an Epic created or updated (PAD-02-008, PAD-02-009).
+---
+
+# Skill: Create Epic
+
+Create a GitHub Epic issue for a priority group and link leaf issues as
+sub-issues. This skill is the canonical way to create Epics to ensure
+consistent use of the `Epic` issue type, `group:` label, and sub-issue wiring.
+
+## Inputs
+
+- `GROUP_LABEL`: the `group:` label slug, e.g. `architecture-hardening`
+- `EPIC_TITLE`: one-line Epic title, e.g.
+  `Architecture Hardening (Phase 2): Import violations and BT sync`
+- `EPIC_BODY`: multi-line body text (summary, open tasks list, rationale)
+- `LEAF_ISSUES`: space-separated issue numbers to link as sub-issues,
+  e.g. `428 439 429`
+- `REPO`: `CERTCC/Vultron` (default)
+
+## Workflow
+
+### Step 1 — Verify no existing open Epic
+
+Query GitHub for an existing open Epic in this group to avoid duplicates
+(PAD-02-008):
+
+```bash
+gh issue list --repo CERTCC/Vultron \
+  --label "group:${GROUP_LABEL}" \
+  --state open \
+  --json number,title,issueType \
+  | python3 -c "
+import json, sys
+issues = json.load(sys.stdin)
+epics = [i for i in issues if (i.get('issueType') or {}).get('name') == 'Epic']
+if epics:
+    print('EPIC_EXISTS:', epics[0]['number'])
+else:
+    print('NO_EPIC')
+"
+```
+
+If an Epic already exists, skip Step 2 and proceed to Step 3 (link any
+unparented leaf issues).
+
+### Step 2 — Create the Epic issue via GraphQL
+
+Use the bash helper script in this skill's directory:
+
+```bash
+.agents/skills/create-epic/create_epic.sh \
+  "${GROUP_LABEL}" \
+  "${EPIC_TITLE}" \
+  "${EPIC_BODY}"
+```
+
+The script prints the new issue number on stdout (e.g. `443`). Capture it:
+
+```bash
+EPIC_NUMBER=$(.agents/skills/create-epic/create_epic.sh \
+  "${GROUP_LABEL}" "${EPIC_TITLE}" "${EPIC_BODY}")
+echo "Created Epic #${EPIC_NUMBER}"
+```
+
+### Step 3 — Link leaf issues as sub-issues
+
+Leaf issues must be linked via the GraphQL `addSubIssue` mutation (the REST
+sub-issues API is not available for this repo). First, resolve the node IDs
+for the Epic and each leaf issue:
+
+```bash
+# Get node IDs for the Epic and leaf issues
+gh api graphql -f query='{ repository(owner:"CERTCC", name:"Vultron") {
+  epic: issue(number: <EPIC_NUMBER>) { id }
+  i1: issue(number: <LEAF_1>) { id }
+  i2: issue(number: <LEAF_2>) { id }
+} }'
+```
+
+Then link each leaf:
+
+```bash
+gh api graphql -f query='
+mutation {
+  addSubIssue(input: {
+    issueId: "<EPIC_NODE_ID>"
+    subIssueId: "<LEAF_NODE_ID>"
+  }) {
+    issue { number }
+    subIssue { number }
+  }
+}'
+```
+
+### Step 4 — Update PRIORITIES.md
+
+Record the Epic issue number next to the group heading in
+`plan/PRIORITIES.md` (PAD-02-010). Change the heading from:
+
+```markdown
+## Priority NNN: Title
+```
+
+to:
+
+```markdown
+## Priority NNN — Epic #M: Title
+```
+
+**Note**: `PRIORITIES.md` may only be modified by the `review-priorities`
+skill or a human. If invoking `create-epic` from another skill, pass the
+Epic number back to the caller and let `review-priorities` perform the
+PRIORITIES.md update.
+
+### Step 5 — Return Epic number
+
+Output the Epic issue number so the caller can record it:
+
+```bash
+echo "${EPIC_NUMBER}"
+```
+
+## Constraints
+
+- Never create more than one open Epic per `group:` label (PAD-02-008).
+- Always check for an existing open Epic before creating a new one.
+- The `Epic` issue type ID for `CERTCC/Vultron` is `IT_kwDOAjf0s84B_E1A`.
+  If this ID changes (e.g. after repo transfer), re-query:
+
+  ```bash
+  gh api graphql -f query='{ repository(owner:"CERTCC", name:"Vultron") {
+    issueTypes(first:10) { nodes { id name } } } }'
+  ```
+
+- The repo node ID for `CERTCC/Vultron` is `R_kgDOIn77fA`.
+- Do not call this skill for groups with fewer than 2 open leaf issues
+  (PAD-02-008).

--- a/.agents/skills/create-epic/SKILL.md
+++ b/.agents/skills/create-epic/SKILL.md
@@ -3,8 +3,8 @@ name: create-epic
 description: >
   Create a GitHub Epic issue for a priority group and wire existing leaf
   issues as its sub-issues. Uses the GitHub Epic issue type (via GraphQL)
-  and the sub-issues REST API. Invoke this skill whenever a priority group
-  needs an Epic created or updated (PAD-02-008, PAD-02-009).
+  and the GraphQL addSubIssue mutation. Invoke this skill whenever a priority
+  group needs an Epic created or updated (PAD-02-008, PAD-02-009).
 ---
 
 # Skill: Create Epic
@@ -27,7 +27,7 @@ consistent use of the `Epic` issue type, `group:` label, and sub-issue wiring.
 
 ### Step 1 — Verify no existing open Epic
 
-Query GitHub for an existing open Epic in this group to avoid duplicates
+Query GitHub for existing open Epics in this group to avoid duplicates
 (PAD-02-008):
 
 ```bash
@@ -39,14 +39,23 @@ gh issue list --repo CERTCC/Vultron \
 import json, sys
 issues = json.load(sys.stdin)
 epics = [i for i in issues if (i.get('issueType') or {}).get('name') == 'Epic']
-if epics:
+if len(epics) > 1:
+    nums = ', '.join(str(e['number']) for e in epics)
+    print(f'ERROR: {len(epics)} open Epics found for this group: {nums}')
+    print('Resolve to exactly one open Epic before proceeding (PAD-02-008).')
+    raise SystemExit(1)
+elif len(epics) == 1:
     print('EPIC_EXISTS:', epics[0]['number'])
 else:
     print('NO_EPIC')
 "
 ```
 
-If an Epic already exists, skip Step 2 and proceed to Step 3 (link any
+If multiple open Epics are found, stop and report the conflict — do **not**
+silently pick one. Close or merge the duplicate Epics manually until exactly
+one remains.
+
+If exactly one Epic already exists, skip Step 2 and proceed to Step 3 (link any
 unparented leaf issues).
 
 ### Step 2 — Create the Epic issue via GraphQL

--- a/.agents/skills/create-epic/create_epic.sh
+++ b/.agents/skills/create-epic/create_epic.sh
@@ -60,6 +60,5 @@ gh issue edit "${EPIC_NUMBER}" \
 
 echo "  Applied label: group:${GROUP_LABEL}" >&2
 
-# Output the Epic issue number and node ID (tab-separated) for the caller
-# Callers that only need the number can use: EPIC_NUM=$(... | cut -f1)
-printf '%s\t%s\n' "${EPIC_NUMBER}" "${EPIC_ID}"
+# Output only the Epic issue number on stdout so callers can capture it directly
+echo "${EPIC_NUMBER}"

--- a/.agents/skills/create-epic/create_epic.sh
+++ b/.agents/skills/create-epic/create_epic.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# create_epic.sh — Create a GitHub Epic issue for CERTCC/Vultron
+#
+# Usage: create_epic.sh <group-label-slug> <title> <body>
+#
+# Prints the new issue number on stdout.
+# All other output goes to stderr.
+#
+# Example:
+#   EPIC_NUM=$(./create_epic.sh "architecture-hardening" \
+#     "Architecture Hardening (Phase 2): Import violations and BT sync" \
+#     "$(cat body.md)")
+
+set -euo pipefail
+
+GROUP_LABEL="${1:?Usage: create_epic.sh <group-label-slug> <title> <body>}"
+EPIC_TITLE="${2:?Usage: create_epic.sh <group-label-slug> <title> <body>}"
+EPIC_BODY="${3:?Usage: create_epic.sh <group-label-slug> <title> <body>}"
+
+REPO_OWNER="CERTCC"
+REPO_NAME="Vultron"
+REPO_NODE_ID="R_kgDOIn77fA"
+EPIC_TYPE_ID="IT_kwDOAjf0s84B_E1A"
+
+# JSON-encode title and body for safe GraphQL embedding
+TITLE_JSON=$(printf '%s' "${EPIC_TITLE}" \
+  | python3 -c "import sys,json; print(json.dumps(sys.stdin.read()))")
+BODY_JSON=$(printf '%s' "${EPIC_BODY}" \
+  | python3 -c "import sys,json; print(json.dumps(sys.stdin.read()))")
+
+echo "Creating Epic issue: ${EPIC_TITLE}" >&2
+echo "  group:${GROUP_LABEL}" >&2
+
+# Step 1: Create the issue via GraphQL with Epic issue type
+RESULT=$(gh api graphql -f query="
+mutation {
+  createIssue(input: {
+    repositoryId: \"${REPO_NODE_ID}\"
+    title: ${TITLE_JSON}
+    body: ${BODY_JSON}
+    issueTypeId: \"${EPIC_TYPE_ID}\"
+  }) {
+    issue { number id url }
+  }
+}")
+
+EPIC_NUMBER=$(echo "${RESULT}" | python3 -c \
+  "import json,sys; print(json.load(sys.stdin)['data']['createIssue']['issue']['number'])")
+EPIC_ID=$(echo "${RESULT}" | python3 -c \
+  "import json,sys; print(json.load(sys.stdin)['data']['createIssue']['issue']['id'])")
+EPIC_URL=$(echo "${RESULT}" | python3 -c \
+  "import json,sys; print(json.load(sys.stdin)['data']['createIssue']['issue']['url'])")
+
+echo "  Created Epic #${EPIC_NUMBER}: ${EPIC_URL}" >&2
+
+# Step 2: Apply the group: label
+gh issue edit "${EPIC_NUMBER}" \
+  --repo "${REPO_OWNER}/${REPO_NAME}" \
+  --add-label "group:${GROUP_LABEL}" >&2
+
+echo "  Applied label: group:${GROUP_LABEL}" >&2
+
+# Output the Epic issue number and node ID (tab-separated) for the caller
+# Callers that only need the number can use: EPIC_NUM=$(... | cut -f1)
+printf '%s\t%s\n' "${EPIC_NUMBER}" "${EPIC_ID}"

--- a/.agents/skills/review-priorities/SKILL.md
+++ b/.agents/skills/review-priorities/SKILL.md
@@ -128,7 +128,7 @@ priority group that now has **2 or more open leaf Issues**.
 
 For each such group:
 
-1. **Find the existing open Epic** for the group:
+1. **Find existing open Epics** for the group:
 
    ```bash
    gh issue list --repo CERTCC/Vultron \
@@ -139,14 +139,30 @@ For each such group:
    import json, sys
    issues = json.load(sys.stdin)
    epics = [i for i in issues if (i.get('issueType') or {}).get('name') == 'Epic']
+   if len(epics) > 1:
+       nums = ', '.join(str(e['number']) for e in epics)
+       print(f'ERROR: {len(epics)} open Epics: {nums}')
+       raise SystemExit(1)
    print(epics[0]['number'] if epics else 'NONE')
    "
    ```
 
+   If the query returns `ERROR: …`, stop and report the duplicate-Epic
+   conflict to the user. Do **not** silently pick one; PAD-02-008 requires
+   exactly one open Epic per group. Close or merge duplicates manually, then
+   re-run this phase.
+
 2. **If no Epic exists**, invoke the `create-epic` skill. Provide the group
    label slug, a suitable Epic title (derived from the PRIORITIES.md group
    heading), a body listing the open leaf Issues, and the list of open leaf
-   issue numbers. The skill returns the new Epic number.
+   issue numbers. The skill prints a single plain issue number on stdout;
+   capture it directly:
+
+   ```bash
+   EPIC_NUMBER=$(invoke_skill create-epic \
+     "${GROUP_LABEL}" "${EPIC_TITLE}" "${EPIC_BODY}")
+   # EPIC_NUMBER now holds a plain integer string, e.g. "443"
+   ```
 
 3. **If an Epic exists**, link any open leaf Issues that are not yet
    sub-issues of it. First resolve node IDs, then use GraphQL `addSubIssue`:

--- a/.agents/skills/review-priorities/SKILL.md
+++ b/.agents/skills/review-priorities/SKILL.md
@@ -121,6 +121,69 @@ Apply the agreed placements:
 Preserve the ascending-number ordering of priority blocks. Do not renumber
 existing blocks.
 
+### Phase 5b — Epic maintenance (PAD-02-008, PAD-02-009, PAD-02-010)
+
+After updating PRIORITIES.md labels, enforce the Epic hierarchy for every
+priority group that now has **2 or more open leaf Issues**.
+
+For each such group:
+
+1. **Find the existing open Epic** for the group:
+
+   ```bash
+   gh issue list --repo CERTCC/Vultron \
+     --label "group:<slug>" \
+     --state open \
+     --json number,title,issueType \
+     | python3 -c "
+   import json, sys
+   issues = json.load(sys.stdin)
+   epics = [i for i in issues if (i.get('issueType') or {}).get('name') == 'Epic']
+   print(epics[0]['number'] if epics else 'NONE')
+   "
+   ```
+
+2. **If no Epic exists**, invoke the `create-epic` skill. Provide the group
+   label slug, a suitable Epic title (derived from the PRIORITIES.md group
+   heading), a body listing the open leaf Issues, and the list of open leaf
+   issue numbers. The skill returns the new Epic number.
+
+3. **If an Epic exists**, link any open leaf Issues that are not yet
+   sub-issues of it. First resolve node IDs, then use GraphQL `addSubIssue`:
+
+   ```bash
+   # Get node IDs
+   gh api graphql -f query='{ repository(owner:"CERTCC", name:"Vultron") {
+     epic: issue(number: <EPIC_NUMBER>) { id }
+     leaf: issue(number: <LEAF_NUMBER>) { id }
+   } }'
+
+   # Link as sub-issue
+   gh api graphql -f query='
+   mutation {
+     addSubIssue(input: {
+       issueId: "<EPIC_NODE_ID>"
+       subIssueId: "<LEAF_NODE_ID>"
+     }) { issue { number } subIssue { number } }
+   }'
+   ```
+
+4. **Record the Epic number in PRIORITIES.md** next to the group heading
+   (PAD-02-010). Change:
+
+   ```markdown
+   ## Priority NNN: Title
+   ```
+
+   to:
+
+   ```markdown
+   ## Priority NNN — Epic #M: Title
+   ```
+
+   If the heading already contains `— Epic #M:`, update the number only if
+   it has changed (e.g., the old Epic was closed and a new one was created).
+
 ### Phase 6 — Commit
 
 Invoke the `commit` skill with a message like

--- a/.agents/skills/update-plan/SKILL.md
+++ b/.agents/skills/update-plan/SKILL.md
@@ -96,6 +96,54 @@ Set the `size:` label from AC count: 1–2 → `size:S`; 3–6 → `size:M`;
 
 Do **not** add tasks to `plan/IMPLEMENTATION_PLAN.md`.
 
+**Grouping related gaps (PAD-01-002, PAD-01-003):** When the gap analysis
+identifies **2 or more closely related gaps** in the same spec area (e.g.,
+multiple missing implementations of the same protocol feature), consider
+creating a **parent Task Issue** first using the `Task` issue type, then
+wire the individual gap Issues as sub-issues. This keeps the hierarchy
+shallow and right-sized (PAD-01-004).
+
+To create a parent Task Issue:
+
+```bash
+# 1. Get the repo node ID and Task type ID
+REPO_NODE_ID="R_kgDOIn77fA"
+TASK_TYPE_ID="IT_kwDOAjf0s84AcFLo"
+
+# 2. Create the parent Task via GraphQL
+gh api graphql -f query='
+mutation {
+  createIssue(input: {
+    repositoryId: "'"${REPO_NODE_ID}"'"
+    title: "<Parent task title>"
+    body: "<Summary of the related gaps>"
+    issueTypeId: "'"${TASK_TYPE_ID}"'"
+  }) { issue { number url } }
+}'
+
+# 3. Label the parent
+gh issue edit <PARENT_NUMBER> --repo CERTCC/Vultron \
+  --add-label "group:unscheduled,size:<S|M|L>"
+
+# 4. Link each gap Issue as a sub-issue (GraphQL addSubIssue)
+# First resolve node IDs for the parent and child:
+gh api graphql -f query='{ repository(owner:"CERTCC", name:"Vultron") {
+  parent: issue(number: <PARENT_NUMBER>) { id }
+  child: issue(number: <CHILD_NUMBER>) { id }
+} }'
+# Then link:
+gh api graphql -f query='
+mutation {
+  addSubIssue(input: {
+    issueId: "<PARENT_NODE_ID>"
+    subIssueId: "<CHILD_NODE_ID>"
+  }) { issue { number } subIssue { number } }
+}'
+```
+
+Only create a parent Task if the gaps are genuinely related and benefit from
+grouping. Independent gaps MUST remain flat leaf Issues.
+
 ### Phase 4 — Write Observations to notes/
 
 - Any gap-analysis observations, open questions, clarified assumptions, or

--- a/plan/PRIORITIES.md
+++ b/plan/PRIORITIES.md
@@ -10,7 +10,7 @@ relative order. Completed priorities should be archived via `uv run append-histo
 (writes to `plan/history/YYMM/priority/`) and then removed from this file to keep
 `plan/PRIORITIES.md` focused on pending and in-progress work.
 
-## Priority 473: Architecture Hardening
+## Priority 473 — Epic #445: Architecture Hardening
 
 RFC-level improvements that deepen module design, reduce coupling, and
 improve testability. Tracked under parent issue
@@ -58,7 +58,7 @@ propagation, as specified in `specs/participant-case-replica.yaml`.
 - [#440](https://github.com/CERTCC/Vultron/issues/440) — PCR: Implement
   participant case replica safety rules (PCR-03, PCR-05, PCR-06)
 
-## Priority 476: Bug Fixes and Demo Polish
+## Priority 476 — Epic #446: Bug Fixes and Demo Polish
 
 Fix issues affecting demo execution and correctness.
 
@@ -183,7 +183,7 @@ the current plugin ecosystem and configuration format.
 
 - [#294](https://github.com/CERTCC/Vultron/issues/294) — Plan migration to Zensical for MkDocs 2.0 compatibility
 
-## Priority 99999: Remaining Requirements and Documentation Updates
+## Priority 99999 — Epic #447: Remaining Requirements and Documentation Updates
 
 The project is currently in prototype development mode, therefore requirements
 that are marked as `PROD_ONLY` are temporarily a lower priority than other

--- a/specs/parallel-development.yaml
+++ b/specs/parallel-development.yaml
@@ -88,6 +88,28 @@ groups:
           when priorities are reordered. When creating a new `group:` label on
           GitHub, the label description MUST use the priority group title (not
           the number) so it remains accurate if the priority number changes.
+      - id: PAD-02-008
+        priority: MUST
+        statement: >-
+          Every priority group that has two or more open leaf Issues MUST have
+          exactly one open Epic Issue. A leaf Issue is any Issue with no open
+          sub-issues.
+      - id: PAD-02-009
+        priority: MUST
+        statement: >-
+          Epic Issues MUST be created using the GitHub `Epic` issue type (via
+          GraphQL `createIssue` with the appropriate `issueTypeId`) and MUST
+          carry the `group:<name>` label matching their priority group. The
+          `create-epic` skill MUST be used to create Epic Issues to ensure
+          consistent wiring of sub-issues.
+      - id: PAD-02-010
+        priority: MUST
+        statement: >-
+          The Epic Issue number for each priority group MUST be recorded in
+          `PRIORITIES.md` next to the group heading, e.g.
+          `## Priority 473 — Epic #NNN: Architecture Hardening`. This serves
+          as the authoritative lookup for agents that need to find or link to
+          the Epic for a given group.
 
   - id: PAD-03
     title: Priority Ordering Authority


### PR DESCRIPTION
## Summary

Implements PAD-02-008/009/010 to enforce the three-level issue hierarchy
required by PAD-01-002/003. Previously, no skills created or maintained
parent-Epic links and no Epics existed for most priority groups.

## Changes

### Spec: `specs/parallel-development.yaml`
- PAD-02-007: Codifies existing label-naming rule (group: slugs must not
  contain priority numbers)
- PAD-02-008: Priority groups with 2+ open leaf issues MUST have exactly
  one open Epic
- PAD-02-009: Epics MUST use the GitHub `Epic` issue type (created via
  GraphQL `createIssue` with `issueTypeId`)
- PAD-02-010: Epic issue number MUST be recorded in PRIORITIES.md next to
  the group heading

### New skill: `.agents/skills/create-epic/`
- `SKILL.md`: step-by-step instructions for Epic creation and sub-issue
  wiring using GraphQL `addSubIssue`
- `create_epic.sh`: bash helper wrapping the GraphQL calls

### Updated skills
- `build`: links new prerequisite issues as sub-issues of the current task
- `review-priorities`: Phase 5b — Epic maintenance after each triage run
- `update-plan`: guidance for creating Task-level parents for gap clusters

### Retroactive fix: `plan/PRIORITIES.md`
Three Epics created and sub-issues linked:
- **#445** — Architecture Hardening (P473): parents #428, #439, #429
- **#446** — Bug Fixes and Demo Polish (P476): parents #412, #437
- **#447** — Remaining Requirements (P99999): parents #422, #423, #424, #425

## Notes
- No Python source files changed
- The REST sub-issues API (`POST /issues/{N}/sub_issues`) returned 404;
  the correct method is GraphQL `addSubIssue` mutation — skills updated
  accordingly