### PR TITLE
Implement sync behavior trees

### DIFF
--- a/test/core/behaviors/case/test_commit_log_entry_node.py
+++ b/test/core/behaviors/case/test_commit_log_entry_node.py
@@ -13,15 +13,7 @@
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-"""
-Unit tests for CommitCaseLogEntryNode (BUG-26041602).
-
-Verifies that the node calls ``commit_log_entry_trigger`` with the correct
-arguments when a case_id is available, and returns SUCCESS silently when
-no case_id is present.
-
-Per specs/sync-log-replication.yaml SYNC-02-002, SYNC-02-003.
-"""
+"""Unit tests for CommitCaseLogEntryNode."""
 
 from unittest.mock import patch
 
@@ -30,12 +22,15 @@ import pytest
 from py_trees.common import Status
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
-from vultron.core.behaviors.bridge import BTBridge
+from vultron.core.behaviors.bridge import BTBridge, BTExecutionResult
 from vultron.core.behaviors.case.nodes import CommitCaseLogEntryNode
 from vultron.core.models.events.base import MessageSemantics
 from vultron.core.models.vultron_types import VultronCaseActor
 
-_TRIGGER_PATH = "vultron.core.behaviors.case.nodes.commit_log_entry_trigger"
+_FACTORY_PATH = (
+    "vultron.core.behaviors.case.nodes.create_commit_log_entry_tree"
+)
+_INNER_BRIDGE_PATH = "vultron.core.behaviors.case.nodes.BTBridge"
 
 ACTOR_ID = "https://example.org/actors/vendor"
 CASE_ID = "https://example.org/cases/case-001"
@@ -105,29 +100,42 @@ def test_node_instantiates_without_case_id():
 # ---------------------------------------------------------------------------
 
 
-def test_no_case_id_returns_success_without_calling_trigger(bridge):
+def test_no_case_id_returns_success_without_building_inner_tree(bridge):
     """Node returns SUCCESS silently when no case_id is available (no-op)."""
     node = CommitCaseLogEntryNode()
-    with patch(_TRIGGER_PATH) as mock_trigger:
+    with patch(_FACTORY_PATH) as mock_factory, patch(
+        _INNER_BRIDGE_PATH
+    ) as mock_bridge:
         result = bridge.execute_with_setup(
             tree=node, actor_id=ACTOR_ID, activity=None
         )
     assert result.status == Status.SUCCESS
-    mock_trigger.assert_not_called()
+    mock_factory.assert_not_called()
+    mock_bridge.assert_not_called()
 
 
-def test_constructor_case_id_calls_trigger(bridge):
-    """Node calls trigger with correct args when case_id is given at build."""
+def test_constructor_case_id_builds_inner_commit_tree(bridge):
+    """Node composes CommitLogEntryBT when case_id is given at build."""
     node = CommitCaseLogEntryNode(case_id=CASE_ID)
-    with patch(_TRIGGER_PATH) as mock_trigger:
+    with patch(_FACTORY_PATH) as mock_factory, patch(
+        _INNER_BRIDGE_PATH
+    ) as mock_bridge_cls:
+        mock_bridge_cls.return_value.execute_with_setup.return_value = (
+            BTExecutionResult(status=Status.SUCCESS)
+        )
         bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID, activity=None)
-    mock_trigger.assert_called_once()
-    call_kwargs = mock_trigger.call_args[1]
-    assert call_kwargs["case_id"] == CASE_ID
-    assert call_kwargs["actor_id"] == ACTOR_ID
+    mock_factory.assert_called_once_with(
+        case_id=CASE_ID,
+        object_id=CASE_ID,
+        event_type="case_event",
+    )
+    execute_kwargs = (
+        mock_bridge_cls.return_value.execute_with_setup.call_args.kwargs
+    )
+    assert execute_kwargs["actor_id"] == ACTOR_ID
 
 
-def test_blackboard_case_id_calls_trigger(bridge, datalayer):
+def test_blackboard_case_id_builds_inner_commit_tree(bridge, datalayer):
     """Node reads case_id from blackboard written by a prior node."""
     node = CommitCaseLogEntryNode()  # no constructor param
 
@@ -152,12 +160,19 @@ def test_blackboard_case_id_calls_trigger(bridge, datalayer):
         name="TestSeq", memory=False, children=[_WriteCaseId(), node]
     )
 
-    with patch(_TRIGGER_PATH) as mock_trigger:
+    with patch(_FACTORY_PATH) as mock_factory, patch(
+        _INNER_BRIDGE_PATH
+    ) as mock_bridge_cls:
+        mock_bridge_cls.return_value.execute_with_setup.return_value = (
+            BTExecutionResult(status=Status.SUCCESS)
+        )
         bridge.execute_with_setup(tree=seq, actor_id=ACTOR_ID, activity=None)
 
-    mock_trigger.assert_called_once()
-    call_kwargs = mock_trigger.call_args[1]
-    assert call_kwargs["case_id"] == CASE_ID
+    mock_factory.assert_called_once_with(
+        case_id=CASE_ID,
+        object_id=CASE_ID,
+        event_type="case_event",
+    )
 
 
 def test_activity_on_blackboard_uses_semantic_type_as_event_type(bridge):
@@ -167,21 +182,49 @@ def test_activity_on_blackboard_uses_semantic_type_as_event_type(bridge):
         semantic_type=MessageSemantics.CREATE_CASE,
     )
     node = CommitCaseLogEntryNode(case_id=CASE_ID)
-    with patch(_TRIGGER_PATH) as mock_trigger:
+    with patch(_FACTORY_PATH) as mock_factory, patch(
+        _INNER_BRIDGE_PATH
+    ) as mock_bridge_cls:
+        mock_bridge_cls.return_value.execute_with_setup.return_value = (
+            BTExecutionResult(status=Status.SUCCESS)
+        )
         bridge.execute_with_setup(
             tree=node, actor_id=ACTOR_ID, activity=activity
         )
-    mock_trigger.assert_called_once()
-    call_kwargs = mock_trigger.call_args[1]
-    assert call_kwargs["event_type"] == MessageSemantics.CREATE_CASE.value
-    assert call_kwargs["object_id"] == ACTIVITY_ID
+    mock_factory.assert_called_once_with(
+        case_id=CASE_ID,
+        object_id=ACTIVITY_ID,
+        event_type=MessageSemantics.CREATE_CASE.value,
+    )
 
 
 def test_no_activity_falls_back_to_case_event(bridge):
     """When no activity on blackboard, event_type defaults to 'case_event'."""
     node = CommitCaseLogEntryNode(case_id=CASE_ID)
-    with patch(_TRIGGER_PATH) as mock_trigger:
+    with patch(_FACTORY_PATH) as mock_factory, patch(
+        _INNER_BRIDGE_PATH
+    ) as mock_bridge_cls:
+        mock_bridge_cls.return_value.execute_with_setup.return_value = (
+            BTExecutionResult(status=Status.SUCCESS)
+        )
         bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID, activity=None)
-    mock_trigger.assert_called_once()
-    call_kwargs = mock_trigger.call_args[1]
-    assert call_kwargs["event_type"] == "case_event"
+    mock_factory.assert_called_once_with(
+        case_id=CASE_ID,
+        object_id=CASE_ID,
+        event_type="case_event",
+    )
+
+
+def test_inner_commit_bt_failure_propagates(bridge):
+    node = CommitCaseLogEntryNode(case_id=CASE_ID)
+    with patch(_FACTORY_PATH) as mock_factory, patch(
+        _INNER_BRIDGE_PATH
+    ) as mock_bridge_cls:
+        mock_factory.return_value = object()
+        mock_bridge_cls.return_value.execute_with_setup.return_value = (
+            BTExecutionResult(
+                status=Status.FAILURE, feedback_message="commit failed"
+            )
+        )
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+    assert result.status == Status.FAILURE

--- a/test/core/behaviors/sync/__init__.py
+++ b/test/core/behaviors/sync/__init__.py
@@ -1,0 +1,1 @@
+#!/usr/bin/env python

--- a/test/core/behaviors/sync/test_announce_tree.py
+++ b/test/core/behaviors/sync/test_announce_tree.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python
+"""Integration tests for AnnounceLogEntryReceivedBT."""
+
+from typing import cast
+from unittest.mock import MagicMock
+
+import py_trees
+import pytest
+from py_trees.common import Status
+
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.core.behaviors.bridge import BTBridge
+from vultron.core.behaviors.sync.announce_tree import (
+    create_announce_log_entry_tree,
+)
+from vultron.core.models.case_actor import VultronCaseActor
+from vultron.core.models.case_log import GENESIS_HASH, CaseLogEntry
+from vultron.core.models.case_log_entry import VultronCaseLogEntry
+from vultron.core.models.events.sync import AnnounceLogEntryReceivedEvent
+from vultron.core.ports.sync_activity import SyncActivityPort
+from vultron.core.use_cases.triggers.sync import _to_persistable_entry
+from vultron.semantic_registry import extract_event
+from vultron.wire.as2.factories import announce_log_entry_activity
+from vultron.wire.as2.vocab.objects.case_log_entry import (
+    CaseLogEntry as WireCaseLogEntry,
+)
+
+OWNER_ACTOR_ID = "https://example.org/actors/vendor"
+PARTICIPANT_ACTOR_ID = "https://example.org/actors/reporter"
+CASE_ID = "https://example.org/cases/case-sync"
+
+
+@pytest.fixture(autouse=True)
+def clear_blackboard():
+    py_trees.blackboard.Blackboard.storage.clear()
+    yield
+    py_trees.blackboard.Blackboard.storage.clear()
+
+
+@pytest.fixture
+def datalayer():
+    return SqliteDataLayer("sqlite:///:memory:")
+
+
+@pytest.fixture
+def bridge(datalayer):
+    return BTBridge(datalayer=datalayer)
+
+
+@pytest.fixture
+def case_actor(datalayer):
+    actor = VultronCaseActor(
+        name="Case Actor",
+        attributed_to=OWNER_ACTOR_ID,
+        context=CASE_ID,
+    )
+    datalayer.create(actor)
+    return actor
+
+
+def _make_entry(log_index: int, prev_hash: str) -> VultronCaseLogEntry:
+    return _to_persistable_entry(
+        CaseLogEntry(
+            case_id=CASE_ID,
+            log_index=log_index,
+            object_id=f"https://example.org/activities/log-{log_index}",
+            event_type="test_event",
+            payload_snapshot={"log_index": log_index},
+            prev_log_hash=prev_hash,
+        )
+    )
+
+
+def _make_event(
+    entry: VultronCaseLogEntry, actor_id: str
+) -> AnnounceLogEntryReceivedEvent:
+    wire_entry = WireCaseLogEntry.model_validate(entry.model_dump(mode="json"))
+    activity = announce_log_entry_activity(entry=wire_entry, actor=actor_id)
+    return cast(AnnounceLogEntryReceivedEvent, extract_event(activity))
+
+
+def test_create_announce_log_entry_tree_returns_selector():
+    tree = create_announce_log_entry_tree()
+    assert tree.name == "AnnounceLogEntryReceivedBT"
+    assert len(tree.children) == 2
+
+
+def test_participant_persists_valid_entry(bridge, datalayer, case_actor):
+    entry = _make_entry(0, GENESIS_HASH)
+    event = _make_event(entry, actor_id=case_actor.id_)
+
+    result = bridge.execute_with_setup(
+        tree=create_announce_log_entry_tree(),
+        actor_id=PARTICIPANT_ACTOR_ID,
+        activity=event,
+        sync_port=MagicMock(spec=SyncActivityPort),
+    )
+
+    assert result.status == Status.SUCCESS
+    assert datalayer.read(entry.id_) is not None
+
+
+def test_case_actor_round_trip_logs_delivery_without_repersisting(
+    bridge, datalayer, case_actor
+):
+    entry = _make_entry(0, GENESIS_HASH)
+    datalayer.save(entry)
+    event = _make_event(entry, actor_id=case_actor.id_)
+
+    result = bridge.execute_with_setup(
+        tree=create_announce_log_entry_tree(),
+        actor_id=OWNER_ACTOR_ID,
+        activity=event,
+    )
+
+    assert result.status == Status.SUCCESS
+    entries = list(datalayer.list_objects("CaseLogEntry"))
+    assert len(entries) == 1
+
+
+def test_case_actor_spoofed_sender_fails(bridge, datalayer, case_actor):
+    entry = _make_entry(0, GENESIS_HASH)
+    event = _make_event(
+        entry, actor_id="https://example.org/actors/attacker-service"
+    )
+
+    result = bridge.execute_with_setup(
+        tree=create_announce_log_entry_tree(),
+        actor_id=OWNER_ACTOR_ID,
+        activity=event,
+    )
+
+    assert result.status == Status.FAILURE
+    assert datalayer.read(entry.id_) is None
+
+
+def test_hash_mismatch_sends_reject_and_does_not_store(
+    bridge, datalayer, case_actor
+):
+    first_entry = _make_entry(0, GENESIS_HASH)
+    datalayer.save(first_entry)
+    bad_entry = _make_entry(1, "badbadbadbadbad0" * 4)
+    event = _make_event(bad_entry, actor_id=case_actor.id_)
+    sync_port = MagicMock(spec=SyncActivityPort)
+
+    result = bridge.execute_with_setup(
+        tree=create_announce_log_entry_tree(),
+        actor_id=PARTICIPANT_ACTOR_ID,
+        activity=event,
+        sync_port=sync_port,
+    )
+
+    assert result.status == Status.FAILURE
+    assert datalayer.read(bad_entry.id_) is None
+    sync_port.send_reject_log_entry.assert_called_once()

--- a/test/core/behaviors/sync/test_commit_tree.py
+++ b/test/core/behaviors/sync/test_commit_tree.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+"""Integration tests for CommitLogEntryBT."""
+
+from unittest.mock import MagicMock
+
+import py_trees
+import pytest
+from py_trees.common import Status
+
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.core.behaviors.bridge import BTBridge
+from vultron.core.behaviors.sync.commit_tree import (
+    create_commit_log_entry_tree,
+)
+from vultron.core.models.case import VultronCase
+from vultron.core.models.case_log import GENESIS_HASH, CaseLogEntry
+from vultron.core.ports.sync_activity import SyncActivityPort
+from vultron.core.use_cases.triggers.sync import _to_persistable_entry
+
+OWNER_ACTOR_ID = "https://example.org/actors/vendor"
+PEER_ID = "https://example.org/actors/reporter"
+CASE_ID = "https://example.org/cases/case-sync"
+
+
+@pytest.fixture(autouse=True)
+def clear_blackboard():
+    py_trees.blackboard.Blackboard.storage.clear()
+    yield
+    py_trees.blackboard.Blackboard.storage.clear()
+
+
+@pytest.fixture
+def datalayer():
+    return SqliteDataLayer("sqlite:///:memory:")
+
+
+@pytest.fixture
+def bridge(datalayer):
+    return BTBridge(datalayer=datalayer)
+
+
+@pytest.fixture
+def case_obj(datalayer):
+    case = VultronCase(
+        id_=CASE_ID,
+        attributed_to=OWNER_ACTOR_ID,
+        actor_participant_index={
+            OWNER_ACTOR_ID: f"{CASE_ID}/participants/vendor",
+            PEER_ID: f"{CASE_ID}/participants/reporter",
+        },
+    )
+    datalayer.save(case)
+    return case
+
+
+def _make_entry(log_index: int, prev_hash: str):
+    return _to_persistable_entry(
+        CaseLogEntry(
+            case_id=CASE_ID,
+            log_index=log_index,
+            object_id=f"https://example.org/activities/log-{log_index}",
+            event_type="test_event",
+            payload_snapshot={},
+            prev_log_hash=prev_hash,
+        )
+    )
+
+
+def test_create_commit_log_entry_tree_returns_sequence():
+    tree = create_commit_log_entry_tree(
+        case_id=CASE_ID,
+        object_id="https://example.org/activities/act-1",
+        event_type="case_created",
+    )
+    assert tree.name == "CommitLogEntryBT"
+    assert len(tree.children) == 4
+
+
+def test_commit_tree_persists_entry_and_fans_out(bridge, datalayer, case_obj):
+    sync_port = MagicMock(spec=SyncActivityPort)
+    tree = create_commit_log_entry_tree(
+        case_id=CASE_ID,
+        object_id="https://example.org/activities/act-1",
+        event_type="case_created",
+    )
+
+    result = bridge.execute_with_setup(
+        tree=tree,
+        actor_id=OWNER_ACTOR_ID,
+        sync_port=sync_port,
+    )
+
+    assert result.status == Status.SUCCESS
+    entries = list(datalayer.list_objects("CaseLogEntry"))
+    assert len(entries) == 1
+    assert entries[0].log_index == 0
+    assert entries[0].prev_log_hash == GENESIS_HASH
+    sync_port.send_announce_log_entry.assert_called_once()
+    call_kwargs = sync_port.send_announce_log_entry.call_args.kwargs
+    assert call_kwargs["to"] == [PEER_ID]
+
+
+def test_commit_tree_uses_existing_tail_hash(bridge, datalayer, case_obj):
+    first_entry = _make_entry(0, GENESIS_HASH)
+    datalayer.save(first_entry)
+    sync_port = MagicMock(spec=SyncActivityPort)
+
+    result = bridge.execute_with_setup(
+        tree=create_commit_log_entry_tree(
+            case_id=CASE_ID,
+            object_id="https://example.org/activities/act-2",
+            event_type="case_updated",
+        ),
+        actor_id=OWNER_ACTOR_ID,
+        sync_port=sync_port,
+    )
+
+    assert result.status == Status.SUCCESS
+    entries = sorted(
+        datalayer.list_objects("CaseLogEntry"),
+        key=lambda entry: entry.log_index,
+    )
+    assert len(entries) == 2
+    assert entries[1].log_index == 1
+    assert entries[1].prev_log_hash == first_entry.entry_hash

--- a/test/core/behaviors/sync/test_nodes.py
+++ b/test/core/behaviors/sync/test_nodes.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+"""Unit tests for sync BT nodes."""
+
+from typing import cast
+from unittest.mock import MagicMock
+
+import py_trees
+import pytest
+from py_trees.common import Status
+
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.core.behaviors.bridge import BTBridge
+from vultron.core.behaviors.sync.nodes import (
+    CheckHashOrRejectOnMismatchNode,
+    CheckIsOwnCaseActorNode,
+    CreateLogEntryNode,
+)
+from vultron.core.models.case_actor import VultronCaseActor
+from vultron.core.models.case_log import GENESIS_HASH, CaseLogEntry
+from vultron.core.models.case_log_entry import VultronCaseLogEntry
+from vultron.core.models.events.sync import AnnounceLogEntryReceivedEvent
+from vultron.core.ports.sync_activity import SyncActivityPort
+from vultron.core.use_cases.triggers.sync import _to_persistable_entry
+from vultron.semantic_registry import extract_event
+from vultron.wire.as2.factories import announce_log_entry_activity
+from vultron.wire.as2.vocab.objects.case_log_entry import (
+    CaseLogEntry as WireCaseLogEntry,
+)
+
+OWNER_ACTOR_ID = "https://example.org/actors/vendor"
+PARTICIPANT_ACTOR_ID = "https://example.org/actors/reporter"
+CASE_ID = "https://example.org/cases/case-sync"
+
+
+@pytest.fixture(autouse=True)
+def clear_blackboard():
+    py_trees.blackboard.Blackboard.storage.clear()
+    yield
+    py_trees.blackboard.Blackboard.storage.clear()
+
+
+@pytest.fixture
+def datalayer():
+    return SqliteDataLayer("sqlite:///:memory:")
+
+
+@pytest.fixture
+def bridge(datalayer):
+    return BTBridge(datalayer=datalayer)
+
+
+@pytest.fixture
+def case_actor(datalayer):
+    actor = VultronCaseActor(
+        name="Case Actor",
+        attributed_to=OWNER_ACTOR_ID,
+        context=CASE_ID,
+    )
+    datalayer.create(actor)
+    return actor
+
+
+def _make_entry(log_index: int, prev_hash: str) -> VultronCaseLogEntry:
+    return _to_persistable_entry(
+        CaseLogEntry(
+            case_id=CASE_ID,
+            log_index=log_index,
+            object_id=f"https://example.org/activities/log-{log_index}",
+            event_type="test_event",
+            payload_snapshot={"log_index": log_index},
+            prev_log_hash=prev_hash,
+        )
+    )
+
+
+def _make_event(
+    entry: VultronCaseLogEntry, actor_id: str
+) -> AnnounceLogEntryReceivedEvent:
+    wire_entry = WireCaseLogEntry.model_validate(entry.model_dump(mode="json"))
+    activity = announce_log_entry_activity(entry=wire_entry, actor=actor_id)
+    return cast(AnnounceLogEntryReceivedEvent, extract_event(activity))
+
+
+def test_check_is_own_case_actor_succeeds_for_case_owner(bridge, case_actor):
+    entry = _make_entry(0, GENESIS_HASH)
+    event = _make_event(entry, actor_id=case_actor.id_)
+
+    result = bridge.execute_with_setup(
+        tree=CheckIsOwnCaseActorNode(name="CheckIsOwnCaseActor"),
+        actor_id=OWNER_ACTOR_ID,
+        activity=event,
+    )
+
+    assert result.status == Status.SUCCESS
+
+
+def test_check_hash_or_reject_on_mismatch_sends_reject(bridge, case_actor):
+    entry = _make_entry(1, "deadbeef" * 8)
+    event = _make_event(entry, actor_id=case_actor.id_)
+    sync_port = MagicMock(spec=SyncActivityPort)
+
+    result = bridge.execute_with_setup(
+        tree=CheckHashOrRejectOnMismatchNode(
+            name="CheckHashOrRejectOnMismatch"
+        ),
+        actor_id=PARTICIPANT_ACTOR_ID,
+        activity=event,
+        tail_hash=GENESIS_HASH,
+        sync_port=sync_port,
+    )
+
+    assert result.status == Status.FAILURE
+    sync_port.send_reject_log_entry.assert_called_once()
+
+
+def test_create_log_entry_node_writes_log_entry_to_blackboard(bridge):
+    result = bridge.execute_with_setup(
+        tree=CreateLogEntryNode(
+            case_id=CASE_ID,
+            object_id="https://example.org/activities/act-1",
+            event_type="case_created",
+            name="CreateLogEntry",
+        ),
+        actor_id=OWNER_ACTOR_ID,
+        tail_hash=GENESIS_HASH,
+        tail_index=-1,
+    )
+
+    assert result.status == Status.SUCCESS
+    blackboard = py_trees.blackboard.Client(name="assert-log-entry")
+    blackboard.register_key(
+        key="log_entry", access=py_trees.common.Access.READ
+    )
+    assert blackboard.log_entry.case_id == CASE_ID
+    assert blackboard.log_entry.log_index == 0

--- a/test/core/behaviors/sync/test_reject_tree.py
+++ b/test/core/behaviors/sync/test_reject_tree.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+"""Integration tests for RejectLogEntryReceivedBT."""
+
+from typing import cast
+from unittest.mock import MagicMock
+
+import py_trees
+import pytest
+from py_trees.common import Status
+
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.core.behaviors.bridge import BTBridge
+from vultron.core.behaviors.sync.reject_tree import (
+    create_reject_log_entry_tree,
+)
+from vultron.core.models.case_actor import VultronCaseActor
+from vultron.core.models.case_log import GENESIS_HASH, CaseLogEntry
+from vultron.core.models.case_log_entry import VultronCaseLogEntry
+from vultron.core.models.events.sync import RejectLogEntryReceivedEvent
+from vultron.core.models.replication_state import VultronReplicationState
+from vultron.core.ports.sync_activity import SyncActivityPort
+from vultron.core.use_cases.triggers.sync import _to_persistable_entry
+from vultron.semantic_registry import extract_event
+from vultron.wire.as2.factories import reject_log_entry_activity
+from vultron.wire.as2.vocab.objects.case_log_entry import (
+    CaseLogEntry as WireCaseLogEntry,
+)
+
+OWNER_ACTOR_ID = "https://example.org/actors/vendor"
+PEER_ID = "https://example.org/actors/reporter"
+CASE_ID = "https://example.org/cases/case-sync"
+
+
+@pytest.fixture(autouse=True)
+def clear_blackboard():
+    py_trees.blackboard.Blackboard.storage.clear()
+    yield
+    py_trees.blackboard.Blackboard.storage.clear()
+
+
+@pytest.fixture
+def datalayer():
+    return SqliteDataLayer("sqlite:///:memory:")
+
+
+@pytest.fixture
+def bridge(datalayer):
+    return BTBridge(datalayer=datalayer)
+
+
+@pytest.fixture
+def case_actor(datalayer):
+    actor = VultronCaseActor(
+        name="Case Actor",
+        attributed_to=OWNER_ACTOR_ID,
+        context=CASE_ID,
+    )
+    datalayer.create(actor)
+    return actor
+
+
+def _make_entry(log_index: int, prev_hash: str) -> VultronCaseLogEntry:
+    return _to_persistable_entry(
+        CaseLogEntry(
+            case_id=CASE_ID,
+            log_index=log_index,
+            object_id=f"https://example.org/activities/log-{log_index}",
+            event_type="test_event",
+            payload_snapshot={"log_index": log_index},
+            prev_log_hash=prev_hash,
+        )
+    )
+
+
+def _make_event(
+    entry: VultronCaseLogEntry, tail_hash: str
+) -> RejectLogEntryReceivedEvent:
+    wire_entry = WireCaseLogEntry.model_validate(entry.model_dump(mode="json"))
+    activity = reject_log_entry_activity(
+        entry=wire_entry,
+        context=tail_hash,
+        actor=PEER_ID,
+        to=[OWNER_ACTOR_ID],
+    )
+    return cast(RejectLogEntryReceivedEvent, extract_event(activity))
+
+
+def test_create_reject_log_entry_tree_returns_sequence():
+    tree = create_reject_log_entry_tree()
+    assert tree.name == "RejectLogEntryReceivedBT"
+    assert len(tree.children) == 3
+
+
+def test_reject_tree_updates_replication_state_and_replays_entries(
+    bridge, datalayer, case_actor
+):
+    first_entry = _make_entry(0, GENESIS_HASH)
+    second_entry = _make_entry(1, first_entry.entry_hash)
+    datalayer.save(first_entry)
+    datalayer.save(second_entry)
+    event = _make_event(second_entry, tail_hash=first_entry.entry_hash)
+    sync_port = MagicMock(spec=SyncActivityPort)
+
+    result = bridge.execute_with_setup(
+        tree=create_reject_log_entry_tree(),
+        actor_id=OWNER_ACTOR_ID,
+        activity=event,
+        sync_port=sync_port,
+    )
+
+    assert result.status == Status.SUCCESS
+    state_id = VultronReplicationState(
+        case_id=CASE_ID,
+        peer_id=PEER_ID,
+        last_acknowledged_hash=first_entry.entry_hash,
+    ).id_
+    state = datalayer.read(state_id)
+    assert state is not None
+    assert state.last_acknowledged_hash == first_entry.entry_hash
+    sync_port.send_announce_log_entry.assert_called_once()
+    call_kwargs = sync_port.send_announce_log_entry.call_args.kwargs
+    assert call_kwargs["entry"].id_ == second_entry.id_
+    assert call_kwargs["actor_id"] == case_actor.id_
+    assert call_kwargs["to"] == [PEER_ID]
+
+
+def test_reject_tree_replays_all_entries_when_hash_not_found(
+    bridge, datalayer, case_actor
+):
+    first_entry = _make_entry(0, GENESIS_HASH)
+    second_entry = _make_entry(1, first_entry.entry_hash)
+    datalayer.save(first_entry)
+    datalayer.save(second_entry)
+    event = _make_event(second_entry, tail_hash="deadbeef" * 8)
+    sync_port = MagicMock(spec=SyncActivityPort)
+
+    result = bridge.execute_with_setup(
+        tree=create_reject_log_entry_tree(),
+        actor_id=OWNER_ACTOR_ID,
+        activity=event,
+        sync_port=sync_port,
+    )
+
+    assert result.status == Status.SUCCESS
+    assert sync_port.send_announce_log_entry.call_count == 2

--- a/vultron/core/behaviors/case/nodes.py
+++ b/vultron/core/behaviors/case/nodes.py
@@ -53,6 +53,10 @@ from vultron.core.behaviors.helpers import (
     DataLayerCondition,
 )
 from vultron.core.behaviors.helpers import UpdateActorOutbox  # noqa: F401
+from vultron.core.behaviors.bridge import BTBridge
+from vultron.core.behaviors.sync.commit_tree import (
+    create_commit_log_entry_tree,
+)
 from vultron.core.ports.case_persistence import (
     CasePersistence,
     CaseOutboxPersistence,
@@ -62,7 +66,6 @@ from vultron.core.use_cases._helpers import (
     _report_phase_status_id,
     update_participant_rm_state,
 )
-from vultron.core.use_cases.triggers.sync import commit_log_entry_trigger
 
 if TYPE_CHECKING:
     from vultron.core.ports.trigger_activity import TriggerActivityPort
@@ -1241,15 +1244,19 @@ class CommitCaseLogEntryNode(DataLayerAction):
             object_id = case_id
             event_type = "case_event"
 
-        try:
-            commit_log_entry_trigger(
-                case_id=case_id,
-                object_id=object_id,
-                event_type=event_type,
-                actor_id=self.actor_id,
-                dl=cast(CaseOutboxPersistence, self.datalayer),
-                sync_port=self._sync_port,
-            )
+        tree = create_commit_log_entry_tree(
+            case_id=case_id,
+            object_id=object_id,
+            event_type=event_type,
+        )
+        result = BTBridge(
+            datalayer=cast(CaseOutboxPersistence, self.datalayer)
+        ).execute_with_setup(
+            tree=tree,
+            actor_id=self.actor_id,
+            sync_port=self._sync_port,
+        )
+        if result.status == Status.SUCCESS:
             self.logger.info(
                 "%s: committed log entry '%s' for case '%s'",
                 self.name,
@@ -1257,11 +1264,10 @@ class CommitCaseLogEntryNode(DataLayerAction):
                 case_id,
             )
             return Status.SUCCESS
-        except Exception as e:
-            self.logger.error(
-                "%s: failed to commit log entry for case '%s': %s",
-                self.name,
-                case_id,
-                e,
-            )
-            return Status.FAILURE
+        self.logger.error(
+            "%s: failed to commit log entry for case '%s': %s",
+            self.name,
+            case_id,
+            result.feedback_message,
+        )
+        return Status.FAILURE

--- a/vultron/core/behaviors/sync/__init__.py
+++ b/vultron/core/behaviors/sync/__init__.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Sync protocol behavior trees.
+
+Provides BT nodes and tree factories for SYNC-2/SYNC-3 log-entry
+replication flows:
+
+- :func:`~vultron.core.behaviors.sync.announce_tree.create_announce_log_entry_tree`
+  — handles inbound ``Announce(CaseLogEntry)``
+- :func:`~vultron.core.behaviors.sync.reject_tree.create_reject_log_entry_tree`
+  — handles inbound ``Reject(CaseLogEntry)``
+- :func:`~vultron.core.behaviors.sync.commit_tree.create_commit_log_entry_tree`
+  — commits a new log entry and fans it out to peers
+
+Spec: SBT-01 through SBT-05.
+"""
+
+from vultron.core.behaviors.sync.announce_tree import (
+    create_announce_log_entry_tree,
+)
+from vultron.core.behaviors.sync.commit_tree import (
+    create_commit_log_entry_tree,
+)
+from vultron.core.behaviors.sync.reject_tree import (
+    create_reject_log_entry_tree,
+)
+
+__all__ = [
+    "create_announce_log_entry_tree",
+    "create_commit_log_entry_tree",
+    "create_reject_log_entry_tree",
+]

--- a/vultron/core/behaviors/sync/announce_tree.py
+++ b/vultron/core/behaviors/sync/announce_tree.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+"""Behavior tree factory for inbound Announce(CaseLogEntry) handling."""
+
+import py_trees
+
+from vultron.core.behaviors.sync.nodes import (
+    CheckHashOrRejectOnMismatchNode,
+    CheckIsOwnCaseActorNode,
+    CheckIsNotOwnCaseActorNode,
+    CheckLogEntryAlreadyStoredNode,
+    LogDeliveryConfirmationNode,
+    PersistReceivedLogEntryNode,
+    ReconstructChainTailNode,
+    VerifySenderIsOwnIdNode,
+)
+
+
+def create_announce_log_entry_tree() -> py_trees.behaviour.Behaviour:
+    case_actor_subtree = py_trees.composites.Sequence(
+        name="CaseActorSubtree",
+        memory=False,
+        children=[
+            CheckIsOwnCaseActorNode(name="CheckIsOwnCaseActor"),
+            VerifySenderIsOwnIdNode(name="VerifySenderIsOwnId"),
+            LogDeliveryConfirmationNode(name="LogDeliveryConfirmation"),
+        ],
+    )
+    validate_and_persist = py_trees.composites.Sequence(
+        name="ValidateAndPersistFlow",
+        memory=False,
+        children=[
+            ReconstructChainTailNode(name="ReconstructChainTail"),
+            CheckHashOrRejectOnMismatchNode(
+                name="CheckHashOrRejectOnMismatch"
+            ),
+            PersistReceivedLogEntryNode(name="PersistReceivedLogEntry"),
+        ],
+    )
+    participant_flow = py_trees.composites.Selector(
+        name="ParticipantSubtree",
+        memory=False,
+        children=[
+            CheckLogEntryAlreadyStoredNode(name="CheckLogEntryAlreadyStored"),
+            validate_and_persist,
+        ],
+    )
+    participant_subtree = py_trees.composites.Sequence(
+        name="ParticipantGate",
+        memory=False,
+        children=[
+            CheckIsNotOwnCaseActorNode(name="CheckIsNotOwnCaseActor"),
+            participant_flow,
+        ],
+    )
+    return py_trees.composites.Selector(
+        name="AnnounceLogEntryReceivedBT",
+        memory=False,
+        children=[case_actor_subtree, participant_subtree],
+    )

--- a/vultron/core/behaviors/sync/commit_tree.py
+++ b/vultron/core/behaviors/sync/commit_tree.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+"""Behavior tree factory for committing and fanning out case log entries."""
+
+import py_trees
+
+from vultron.core.behaviors.sync.nodes import (
+    CreateLogEntryNode,
+    FanOutLogEntryNode,
+    PersistLogEntryNode,
+    ReconstructChainTailNode,
+)
+
+
+def create_commit_log_entry_tree(
+    case_id: str, object_id: str, event_type: str
+) -> py_trees.behaviour.Behaviour:
+    return py_trees.composites.Sequence(
+        name="CommitLogEntryBT",
+        memory=False,
+        children=[
+            ReconstructChainTailNode(
+                case_id=case_id, name="ReconstructChainTail"
+            ),
+            CreateLogEntryNode(
+                case_id=case_id,
+                object_id=object_id,
+                event_type=event_type,
+                name="CreateLogEntry",
+            ),
+            PersistLogEntryNode(name="PersistLogEntry"),
+            FanOutLogEntryNode(case_id=case_id, name="FanOutLogEntry"),
+        ],
+    )

--- a/vultron/core/behaviors/sync/nodes.py
+++ b/vultron/core/behaviors/sync/nodes.py
@@ -1,0 +1,664 @@
+#!/usr/bin/env python
+#
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Behavior tree nodes for SYNC log-replication workflows."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Literal, cast
+
+import py_trees
+from py_trees.common import Status
+
+from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
+from vultron.core.models._helpers import _now_utc
+from vultron.core.models.case_log import CaseLogEntry
+from vultron.core.models.case_log_entry import VultronCaseLogEntry
+from vultron.core.models.protocols import (
+    LogEntryModel,
+    is_case_model,
+    is_log_entry_model,
+)
+from vultron.core.models.replication_state import VultronReplicationState
+from vultron.core.ports.case_persistence import CasePersistence
+from vultron.core.ports.sync_activity import SyncActivityPort
+from vultron.core.sync_helpers import _reconstruct_tail_hash
+from vultron.core.use_cases._helpers import case_addressees
+from vultron.errors import VultronError
+
+logger = logging.getLogger(__name__)
+
+
+def _to_persistable_entry(chain_entry: CaseLogEntry) -> VultronCaseLogEntry:
+    return VultronCaseLogEntry(
+        case_id=chain_entry.case_id,
+        log_index=chain_entry.log_index,
+        disposition=chain_entry.disposition,
+        term=chain_entry.term,
+        log_object_id=chain_entry.object_id,
+        event_type=chain_entry.event_type,
+        payload_snapshot=dict(chain_entry.payload_snapshot),
+        prev_log_hash=chain_entry.prev_log_hash,
+        entry_hash=chain_entry.entry_hash,
+        reason_code=chain_entry.reason_code,
+        reason_detail=chain_entry.reason_detail,
+    )
+
+
+def _find_case_actor(
+    dl: CasePersistence, case_id: str, owner_actor_id: str | None = None
+) -> object | None:
+    fallback: object | None = None
+    for service in dl.list_objects("Service"):
+        if fallback is None:
+            fallback = service
+        if getattr(service, "context", None) != case_id:
+            continue
+        if owner_actor_id is None:
+            return service
+        if getattr(service, "attributed_to", None) == owner_actor_id:
+            return service
+    if owner_actor_id is None:
+        return fallback
+    return None
+
+
+def _require_log_entry(activity: Any, node_name: str) -> VultronCaseLogEntry:
+    entry = getattr(activity, "log_entry", None)
+    if entry is None:
+        entry = getattr(activity, "object_", None)
+    if is_log_entry_model(entry):
+        if isinstance(entry, VultronCaseLogEntry):
+            return entry
+        return VultronCaseLogEntry.model_validate(
+            entry.model_dump(mode="json")
+        )
+    raise VultronError(
+        f"{node_name}: activity did not carry a VultronCaseLogEntry"
+    )
+
+
+def _require_rejected_entry(
+    activity: Any, node_name: str
+) -> VultronCaseLogEntry:
+    entry = getattr(activity, "rejected_entry", None)
+    if entry is None:
+        entry = getattr(activity, "object_", None)
+    if is_log_entry_model(entry):
+        if isinstance(entry, VultronCaseLogEntry):
+            return entry
+        return VultronCaseLogEntry.model_validate(
+            entry.model_dump(mode="json")
+        )
+    raise VultronError(
+        f"{node_name}: activity did not carry a rejected VultronCaseLogEntry"
+    )
+
+
+def _require_case_actor_id(case_actor: object, node_name: str) -> str:
+    case_actor_id = getattr(case_actor, "id_", None)
+    if isinstance(case_actor_id, str):
+        return case_actor_id
+    raise VultronError(f"{node_name}: resolved CaseActor had no id_")
+
+
+def _require_case_id_from_activity(activity: Any, node_name: str) -> str:
+    entry = getattr(activity, "log_entry", None)
+    if entry is None:
+        entry = getattr(activity, "rejected_entry", None)
+    if entry is None:
+        entry = getattr(activity, "object_", None)
+    if is_log_entry_model(entry):
+        return entry.case_id
+    raise VultronError(f"{node_name}: could not resolve case_id from activity")
+
+
+class CheckIsOwnCaseActorNode(DataLayerCondition):
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="activity", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="case_actor_id", access=py_trees.common.Access.WRITE
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None or self.actor_id is None:
+            self.logger.error(
+                "%s: DataLayer or actor_id not available", self.name
+            )
+            return Status.FAILURE
+
+        entry = _require_log_entry(self.blackboard.activity, self.name)
+        case_actor = _find_case_actor(
+            self.datalayer, entry.case_id, self.actor_id
+        )
+        if case_actor is None:
+            return Status.FAILURE
+
+        case_actor_id = _require_case_actor_id(case_actor, self.name)
+        self.blackboard.case_actor_id = case_actor_id
+        self.logger.debug(
+            "%s: actor '%s' owns CaseActor '%s' for case '%s'",
+            self.name,
+            self.actor_id,
+            case_actor_id,
+            entry.case_id,
+        )
+        return Status.SUCCESS
+
+
+class CheckIsNotOwnCaseActorNode(DataLayerCondition):
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="activity", access=py_trees.common.Access.READ
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None or self.actor_id is None:
+            self.logger.error(
+                "%s: DataLayer or actor_id not available", self.name
+            )
+            return Status.FAILURE
+
+        entry = _require_log_entry(self.blackboard.activity, self.name)
+        case_actor = _find_case_actor(
+            self.datalayer, entry.case_id, self.actor_id
+        )
+        if case_actor is None:
+            return Status.SUCCESS
+        return Status.FAILURE
+
+
+class VerifySenderIsOwnIdNode(DataLayerCondition):
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="activity", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="case_actor_id", access=py_trees.common.Access.READ
+        )
+
+    def update(self) -> Status:
+        sender_id = getattr(self.blackboard.activity, "actor_id", None)
+        case_actor_id = self.blackboard.case_actor_id
+        if sender_id == case_actor_id:
+            return Status.SUCCESS
+
+        self.logger.warning(
+            "%s: rejected spoofed announce sender '%s' for CaseActor '%s'",
+            self.name,
+            sender_id,
+            case_actor_id,
+        )
+        return Status.FAILURE
+
+
+class LogDeliveryConfirmationNode(DataLayerAction):
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="activity", access=py_trees.common.Access.READ
+        )
+
+    def update(self) -> Status:
+        entry = _require_log_entry(self.blackboard.activity, self.name)
+        self.logger.debug(
+            "%s: received round-trip delivery confirmation for log entry '%s'",
+            self.name,
+            entry.id_,
+        )
+        return Status.SUCCESS
+
+
+class CheckLogEntryAlreadyStoredNode(DataLayerCondition):
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="activity", access=py_trees.common.Access.READ
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.logger.error("%s: DataLayer not available", self.name)
+            return Status.FAILURE
+
+        entry = _require_log_entry(self.blackboard.activity, self.name)
+        if self.datalayer.read(entry.id_) is None:
+            return Status.FAILURE
+
+        self.logger.debug(
+            "%s: log entry '%s' already stored", self.name, entry.id_
+        )
+        return Status.SUCCESS
+
+
+class ReconstructChainTailNode(DataLayerAction):
+    def __init__(
+        self, case_id: str | None = None, name: str | None = None
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._case_id = case_id
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="tail_hash", access=py_trees.common.Access.WRITE
+        )
+        self.blackboard.register_key(
+            key="tail_index", access=py_trees.common.Access.WRITE
+        )
+        if self._case_id is None:
+            self.blackboard.register_key(
+                key="activity", access=py_trees.common.Access.READ
+            )
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.logger.error("%s: DataLayer not available", self.name)
+            return Status.FAILURE
+
+        if self._case_id is not None:
+            case_id = self._case_id
+        else:
+            case_id = _require_case_id_from_activity(
+                self.blackboard.activity, self.name
+            )
+
+        tail_hash, tail_index = _reconstruct_tail_hash(case_id, self.datalayer)
+        self.blackboard.tail_hash = tail_hash
+        self.blackboard.tail_index = tail_index
+        self.logger.debug(
+            "%s: reconstructed case '%s' tail hash %.16s… at index %d",
+            self.name,
+            case_id,
+            tail_hash,
+            tail_index,
+        )
+        return Status.SUCCESS
+
+
+class CheckHashOrRejectOnMismatchNode(DataLayerAction):
+    def __init__(self, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._sync_port: SyncActivityPort | None = None
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="activity", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="tail_hash", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="sync_port", access=py_trees.common.Access.READ
+        )
+
+    def initialise(self) -> None:
+        super().initialise()
+        try:
+            self._sync_port = cast(SyncActivityPort, self.blackboard.sync_port)
+        except (AttributeError, KeyError):
+            self._sync_port = None
+
+    def update(self) -> Status:
+        if self.actor_id is None:
+            self.logger.error("%s: actor_id not available", self.name)
+            return Status.FAILURE
+
+        entry = _require_log_entry(self.blackboard.activity, self.name)
+        tail_hash = self.blackboard.tail_hash
+        if entry.prev_log_hash == tail_hash:
+            return Status.SUCCESS
+
+        sender_id = getattr(self.blackboard.activity, "actor_id", None)
+        if self._sync_port is None:
+            raise VultronError(
+                f"{self.name}: sync_port must be injected to send rejection"
+            )
+        if not sender_id:
+            raise VultronError(
+                f"{self.name}: activity.actor_id missing for rejection target"
+            )
+
+        self.logger.warning(
+            "%s: log entry '%s' prev_log_hash %.16s… does not match local tail "
+            "%.16s…; sending Reject(CaseLogEntry)",
+            self.name,
+            entry.id_,
+            entry.prev_log_hash,
+            tail_hash,
+        )
+        self._sync_port.send_reject_log_entry(
+            entry=entry,
+            tail_hash=tail_hash,
+            actor_id=self.actor_id,
+            to=[sender_id],
+        )
+        return Status.FAILURE
+
+
+class PersistReceivedLogEntryNode(DataLayerAction):
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="activity", access=py_trees.common.Access.READ
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.logger.error("%s: DataLayer not available", self.name)
+            return Status.FAILURE
+
+        entry = _require_log_entry(self.blackboard.activity, self.name)
+        self.datalayer.save(entry)
+        self.logger.info(
+            "%s: stored received log entry '%s' for case '%s'",
+            self.name,
+            entry.id_,
+            entry.case_id,
+        )
+        return Status.SUCCESS
+
+
+class FindCaseActorNode(DataLayerAction):
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="activity", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="case_actor_id", access=py_trees.common.Access.WRITE
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.logger.error("%s: DataLayer not available", self.name)
+            return Status.FAILURE
+
+        entry = _require_rejected_entry(self.blackboard.activity, self.name)
+        case_actor = _find_case_actor(self.datalayer, entry.case_id)
+        if case_actor is None:
+            self.logger.warning(
+                "%s: no CaseActor found for case '%s'",
+                self.name,
+                entry.case_id,
+            )
+            return Status.FAILURE
+
+        self.blackboard.case_actor_id = _require_case_actor_id(
+            case_actor, self.name
+        )
+        return Status.SUCCESS
+
+
+class UpdateReplicationStateNode(DataLayerAction):
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="activity", access=py_trees.common.Access.READ
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.logger.error("%s: DataLayer not available", self.name)
+            return Status.FAILURE
+
+        activity = self.blackboard.activity
+        entry = _require_rejected_entry(activity, self.name)
+        peer_id = activity.actor_id
+        if not peer_id:
+            raise VultronError(
+                f"{self.name}: Reject(CaseLogEntry) missing peer actor_id"
+            )
+
+        state = VultronReplicationState(
+            case_id=entry.case_id,
+            peer_id=peer_id,
+            last_acknowledged_hash=activity.last_accepted_hash,
+        )
+        existing = self.datalayer.read(state.id_)
+        if existing is not None:
+            existing_state = cast(VultronReplicationState, existing)
+            existing_state.last_acknowledged_hash = activity.last_accepted_hash
+            existing_state.updated_at = _now_utc()
+            self.datalayer.save(existing_state)
+        else:
+            self.datalayer.save(state)
+        return Status.SUCCESS
+
+
+class ReplayMissingEntriesNode(DataLayerAction):
+    def __init__(self, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._sync_port: SyncActivityPort | None = None
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="activity", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="case_actor_id", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="sync_port", access=py_trees.common.Access.READ
+        )
+
+    def initialise(self) -> None:
+        super().initialise()
+        try:
+            self._sync_port = cast(SyncActivityPort, self.blackboard.sync_port)
+        except (AttributeError, KeyError):
+            self._sync_port = None
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.logger.error("%s: DataLayer not available", self.name)
+            return Status.FAILURE
+        if self._sync_port is None:
+            raise VultronError(
+                f"{self.name}: sync_port must be injected to replay entries"
+            )
+
+        activity = self.blackboard.activity
+        entry = _require_rejected_entry(activity, self.name)
+        peer_id = activity.actor_id
+        if not peer_id:
+            raise VultronError(
+                f"{self.name}: Reject(CaseLogEntry) missing peer actor_id"
+            )
+
+        entries: list[LogEntryModel] = [
+            obj
+            for obj in self.datalayer.list_objects("CaseLogEntry")
+            if is_log_entry_model(obj) and obj.case_id == entry.case_id
+        ]
+        entries.sort(key=lambda e: e.log_index)
+
+        from_hash = activity.last_accepted_hash
+        from_index = -1
+        for log_entry in entries:
+            if log_entry.entry_hash == from_hash:
+                from_index = log_entry.log_index
+                break
+
+        replayed = 0
+        for log_entry in entries:
+            if log_entry.log_index <= from_index:
+                continue
+            self._sync_port.send_announce_log_entry(
+                entry=log_entry,
+                actor_id=self.blackboard.case_actor_id,
+                to=[peer_id],
+            )
+            replayed += 1
+
+        self.logger.info(
+            "%s: replayed %d entries to peer '%s' for case '%s'",
+            self.name,
+            replayed,
+            peer_id,
+            entry.case_id,
+        )
+        return Status.SUCCESS
+
+
+class CreateLogEntryNode(DataLayerAction):
+    def __init__(
+        self,
+        case_id: str,
+        object_id: str,
+        event_type: str,
+        *,
+        payload_snapshot: dict[str, Any] | None = None,
+        term: int | None = None,
+        reason_code: str | None = None,
+        reason_detail: str | None = None,
+        disposition: Literal["recorded", "rejected"] = "recorded",
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self.case_id = case_id
+        self.object_id = object_id
+        self.event_type = event_type
+        self.payload_snapshot = payload_snapshot or {}
+        self.term = term
+        self.reason_code = reason_code
+        self.reason_detail = reason_detail
+        self.disposition: Literal["recorded", "rejected"] = disposition
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="tail_hash", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="tail_index", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="log_entry", access=py_trees.common.Access.WRITE
+        )
+
+    def update(self) -> Status:
+        tail_hash = self.blackboard.tail_hash
+        tail_index = self.blackboard.tail_index
+        chain_entry = CaseLogEntry(
+            case_id=self.case_id,
+            log_index=tail_index + 1,
+            object_id=self.object_id,
+            event_type=self.event_type,
+            disposition=self.disposition,
+            payload_snapshot=self.payload_snapshot,
+            prev_log_hash=tail_hash,
+            term=self.term,
+            reason_code=self.reason_code,
+            reason_detail=self.reason_detail,
+        )
+        self.blackboard.log_entry = _to_persistable_entry(chain_entry)
+        return Status.SUCCESS
+
+
+class PersistLogEntryNode(DataLayerAction):
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="log_entry", access=py_trees.common.Access.READ
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.logger.error("%s: DataLayer not available", self.name)
+            return Status.FAILURE
+
+        entry = cast(VultronCaseLogEntry, self.blackboard.log_entry)
+        self.datalayer.save(entry)
+        self.logger.info(
+            "%s: committed log entry '%s' for case '%s'",
+            self.name,
+            entry.id_,
+            entry.case_id,
+        )
+        return Status.SUCCESS
+
+
+class FanOutLogEntryNode(DataLayerAction):
+    def __init__(self, case_id: str, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self.case_id = case_id
+        self._sync_port: SyncActivityPort | None = None
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="log_entry", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="sync_port", access=py_trees.common.Access.READ
+        )
+
+    def initialise(self) -> None:
+        super().initialise()
+        try:
+            self._sync_port = cast(SyncActivityPort, self.blackboard.sync_port)
+        except (AttributeError, KeyError):
+            self._sync_port = None
+
+    def update(self) -> Status:
+        if self.datalayer is None or self.actor_id is None:
+            self.logger.error(
+                "%s: DataLayer or actor_id not available", self.name
+            )
+            return Status.FAILURE
+
+        entry = cast(VultronCaseLogEntry, self.blackboard.log_entry)
+        if self._sync_port is None:
+            self.logger.debug(
+                "%s: sync_port not injected; skipping fan-out for '%s'",
+                self.name,
+                entry.id_,
+            )
+            return Status.SUCCESS
+
+        case_obj = self.datalayer.read(self.case_id)
+        if not is_case_model(case_obj):
+            self.logger.warning(
+                "%s: case '%s' not found; skipping fan-out for '%s'",
+                self.name,
+                self.case_id,
+                entry.id_,
+            )
+            return Status.SUCCESS
+
+        recipients = case_addressees(
+            case_obj, excluding_actor_id=self.actor_id
+        )
+        for recipient_id in recipients:
+            self._sync_port.send_announce_log_entry(
+                entry=entry,
+                actor_id=self.actor_id,
+                to=[recipient_id],
+            )
+        self.logger.info(
+            "%s: fanned out log entry '%s' to %d recipients",
+            self.name,
+            entry.id_,
+            len(recipients),
+        )
+        return Status.SUCCESS

--- a/vultron/core/behaviors/sync/reject_tree.py
+++ b/vultron/core/behaviors/sync/reject_tree.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+"""Behavior tree factory for inbound Reject(CaseLogEntry) handling."""
+
+import py_trees
+
+from vultron.core.behaviors.sync.nodes import (
+    FindCaseActorNode,
+    ReplayMissingEntriesNode,
+    UpdateReplicationStateNode,
+)
+
+
+def create_reject_log_entry_tree() -> py_trees.behaviour.Behaviour:
+    return py_trees.composites.Sequence(
+        name="RejectLogEntryReceivedBT",
+        memory=False,
+        children=[
+            UpdateReplicationStateNode(name="UpdateReplicationState"),
+            FindCaseActorNode(name="FindCaseActor"),
+            ReplayMissingEntriesNode(name="ReplayMissingEntries"),
+        ],
+    )

--- a/vultron/core/sync_helpers.py
+++ b/vultron/core/sync_helpers.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+"""Shared helpers for SYNC log-replication workflows."""
+
+from vultron.core.models.case_log import GENESIS_HASH
+from vultron.core.models.protocols import LogEntryModel, is_log_entry_model
+from vultron.core.ports.case_persistence import CasePersistence
+
+
+def _reconstruct_tail_hash(
+    case_id: str, dl: CasePersistence
+) -> tuple[str, int]:
+    """Return the hash and index of the last accepted log entry for *case_id*."""
+    entries: list[LogEntryModel] = [
+        obj
+        for obj in dl.list_objects("CaseLogEntry")
+        if is_log_entry_model(obj) and obj.case_id == case_id
+    ]
+
+    if not entries:
+        return GENESIS_HASH, -1
+
+    entries.sort(key=lambda entry: entry.log_index)
+    last = entries[-1]
+    return last.entry_hash, last.log_index

--- a/vultron/core/use_cases/received/sync.py
+++ b/vultron/core/use_cases/received/sync.py
@@ -20,55 +20,32 @@ Spec: SYNC-02-003, SYNC-03-001 through SYNC-03-003, SYNC-04-001, SYNC-04-002.
 import logging
 from typing import cast
 
-from vultron.core.models.case_log import GENESIS_HASH
-from vultron.core.models.case_log_entry import VultronCaseLogEntry
+from py_trees.common import Status
+
+from vultron.core.behaviors.bridge import BTBridge
+from vultron.core.behaviors.sync.announce_tree import (
+    create_announce_log_entry_tree,
+)
+from vultron.core.behaviors.sync.reject_tree import (
+    create_reject_log_entry_tree,
+)
 from vultron.core.models.events.sync import (
     AnnounceLogEntryReceivedEvent,
     RejectLogEntryReceivedEvent,
 )
-from vultron.core.models.protocols import LogEntryModel, is_log_entry_model
 from vultron.core.models.replication_state import VultronReplicationState
 from vultron.core.ports.case_persistence import (
     CasePersistence,
     CaseOutboxPersistence,
 )
 from vultron.core.ports.sync_activity import SyncActivityPort
-from vultron.errors import VultronError
+from vultron.core.sync_helpers import _reconstruct_tail_hash  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
 
-def _reconstruct_tail_hash(
-    case_id: str, dl: CasePersistence
-) -> tuple[str, int]:
-    """Return the hash and index of the last accepted log entry for *case_id*.
-
-    Queries all :class:`~vultron.core.models.case_log_entry.VultronCaseLogEntry`
-    records for *case_id* and returns ``(tail_hash, tail_index)`` where
-    ``tail_index`` is the highest ``log_index`` among recorded entries.
-
-    Returns ``(GENESIS_HASH, -1)`` if no entries exist yet.
-    """
-    entries: list[LogEntryModel] = [
-        obj
-        for obj in dl.list_objects("CaseLogEntry")
-        if is_log_entry_model(obj) and obj.case_id == case_id
-    ]
-
-    if not entries:
-        return GENESIS_HASH, -1
-
-    entries.sort(key=lambda e: e.log_index)
-    last = entries[-1]
-    return last.entry_hash, last.log_index
-
-
 def _find_local_actor_id(dl: CasePersistence) -> str | None:
-    """Find the local actor's ID from the DataLayer.
-
-    Looks for actor records (Service, Person, Organization) in the
-    actor-scoped DataLayer.  Returns the first match, or ``None``.
-    """
+    """Find the local actor's ID from the DataLayer."""
     for actor_type in ("Service", "Person", "Organization"):
         actors = list(dl.list_objects(actor_type))
         if actors:
@@ -144,7 +121,6 @@ class AnnounceLogEntryReceivedUseCase:
     def execute(self) -> None:
         request = self._request
         entry = request.log_entry
-
         if entry is None:
             logger.warning(
                 "sync: received ANNOUNCE_CASE_LOG_ENTRY activity '%s' "
@@ -153,90 +129,26 @@ class AnnounceLogEntryReceivedUseCase:
             )
             return
 
-        if not isinstance(entry, VultronCaseLogEntry):
-            logger.warning(
-                "sync: received ANNOUNCE_CASE_LOG_ENTRY activity '%s' "
-                "with unexpected object type %s — ignoring",
-                request.activity_id,
-                type(entry).__name__,
-            )
-            return
-
-        case_id: str = entry.case_id
-        actor_id: str | None = request.actor_id
-
         logger.info(
             "sync: received log-entry announcement '%s' for case '%s' "
             "from actor '%s' (log_index=%d)",
             request.activity_id,
-            case_id,
-            actor_id,
+            entry.case_id,
+            request.actor_id,
             entry.log_index,
         )
-
-        # Idempotency: skip if entry already stored
-        existing = self._dl.read(entry.id_)
-        if existing is not None:
+        result = BTBridge(datalayer=self._dl).execute_with_setup(
+            tree=create_announce_log_entry_tree(),
+            actor_id=request.receiving_actor_id or "unknown",
+            activity=request,
+            sync_port=self._sync_port,
+        )
+        if result.status == Status.FAILURE:
             logger.debug(
-                "sync: log entry '%s' already stored — skipping", entry.id_
+                "sync: announce BT returned FAILURE for '%s': %s",
+                request.activity_id,
+                result.feedback_message,
             )
-            return
-
-        tail_hash, _tail_index = _reconstruct_tail_hash(case_id, self._dl)
-
-        if entry.prev_log_hash != tail_hash:
-            logger.warning(
-                "sync: log-entry '%s' (log_index=%d) has prev_log_hash "
-                "'%.16s…' but local tail is '%.16s…' — rejecting; "
-                "sending Reject(CaseLogEntry) to sender (SYNC-03-001)",
-                entry.id_,
-                entry.log_index,
-                entry.prev_log_hash,
-                tail_hash,
-            )
-            self._send_rejection(entry, tail_hash, request.actor_id)
-            return
-
-        self._dl.save(entry)
-        logger.info(
-            "sync: accepted and stored log entry '%s' for case '%s' "
-            "(log_index=%d, entry_hash=%.16s…)",
-            entry.id_,
-            case_id,
-            entry.log_index,
-            entry.entry_hash,
-        )
-
-    def _send_rejection(
-        self,
-        entry: VultronCaseLogEntry,
-        tail_hash: str,
-        case_actor_id: str,
-    ) -> None:
-        """Queue a ``Reject(CaseLogEntry)`` back to the CaseActor.
-
-        Spec: SYNC-03-001.
-        """
-        if self._sync_port is None:
-            raise VultronError(
-                "AnnounceLogEntryReceivedUseCase: sync_port must be injected "
-                "before calling _send_rejection — no adapter fallback is "
-                "available in the core layer."
-            )
-
-        local_actor_id = self._request.receiving_actor_id or "unknown"
-        self._sync_port.send_reject_log_entry(
-            entry=entry,
-            tail_hash=tail_hash,
-            actor_id=local_actor_id,
-            to=[case_actor_id],
-        )
-        logger.info(
-            "sync: sent Reject(CaseLogEntry) to '%s' "
-            "with last_accepted_hash=%.16s…",
-            case_actor_id,
-            tail_hash,
-        )
 
 
 class RejectLogEntryReceivedUseCase:
@@ -264,80 +176,32 @@ class RejectLogEntryReceivedUseCase:
         self._sync_port = sync_port
 
     def execute(self) -> None:
-        from vultron.core.use_cases.triggers.sync import (
-            replay_missing_entries_trigger,
-        )
-
         request = self._request
-        peer_id = request.actor_id
-        last_accepted_hash = request.last_accepted_hash
-
         rejected_entry = request.rejected_entry
         if rejected_entry is None:
             logger.warning(
                 "sync: received REJECT_CASE_LOG_ENTRY from '%s' "
                 "with no log entry object — ignoring",
-                peer_id,
+                request.actor_id,
             )
             return
-
-        case_id = rejected_entry.case_id
 
         logger.info(
             "sync: received Reject(CaseLogEntry) from peer '%s' "
             "for case '%s', last_accepted_hash=%.16s…",
-            peer_id,
-            case_id,
-            last_accepted_hash,
+            request.actor_id,
+            rejected_entry.case_id,
+            request.last_accepted_hash,
         )
-
-        # Update per-peer replication state (SYNC-04-001, SYNC-04-002)
-        _update_replication_state(
-            case_id=case_id,
-            peer_id=peer_id,
-            last_acknowledged_hash=last_accepted_hash,
-            dl=self._dl,
-        )
-
-        # Find the CaseActor for this case to use as announce actor
-        case_actor_id = self._find_case_actor(case_id)
-        if case_actor_id is None:
-            logger.warning(
-                "sync: no CaseActor found for case '%s' — "
-                "cannot replay entries to peer '%s'",
-                case_id,
-                peer_id,
-            )
-            return
-
-        # Replay missing entries (SYNC-03-002)
-        replayed = replay_missing_entries_trigger(
-            case_id=case_id,
-            peer_id=peer_id,
-            from_hash=last_accepted_hash,
-            case_actor_id=case_actor_id,
-            dl=self._dl,
+        result = BTBridge(datalayer=self._dl).execute_with_setup(
+            tree=create_reject_log_entry_tree(),
+            actor_id=request.receiving_actor_id or "unknown",
+            activity=request,
             sync_port=self._sync_port,
         )
-        logger.info(
-            "sync: replayed %d entries to peer '%s' for case '%s'",
-            replayed,
-            peer_id,
-            case_id,
-        )
-
-    def _find_case_actor(self, case_id: str) -> str | None:
-        """Locate the CaseActor (Service) associated with *case_id*.
-
-        Searches ``Service``-type records in the DataLayer for one whose
-        ``context`` equals *case_id* (same pattern as
-        ``AddNoteToCaseReceivedUseCase._broadcast_note_to_participants``).
-        """
-        services = list(self._dl.list_objects("Service"))
-        for service in services:
-            if getattr(service, "context", None) == case_id:
-                return service.id_
-        # Fall back: return any Service actor if none has a matching context
-        if services:
-            return services[0].id_
-        return None
+        if result.status == Status.FAILURE:
+            logger.debug(
+                "sync: reject BT returned FAILURE for '%s': %s",
+                request.activity_id,
+                result.feedback_message,
+            )

--- a/vultron/core/use_cases/triggers/_helpers.py
+++ b/vultron/core/use_cases/triggers/_helpers.py
@@ -175,7 +175,7 @@ def add_activity_to_outbox(
             actor_id,
         )
     else:
-        logger.warning(
+        logger.debug(
             "add_activity_to_outbox: actor '%s' not found or has no"
             " outbox field; skipping outbox.items update",
             actor_id,


### PR DESCRIPTION
Closes #439

## Summary
- add sync behavior tree nodes and tree factories for announce, reject, and commit flows
- route sync received use cases and CommitCaseLogEntryNode through BTBridge
- add sync BT coverage plus updated CommitCaseLogEntryNode tests