### PR TITLE
specs: ingest conversation — case bootstrap trust

### DIFF
--- a/notes/case-bootstrap-trust.md
+++ b/notes/case-bootstrap-trust.md
@@ -1,0 +1,206 @@
+---
+title: Case Bootstrap Trust — Implementation Notes
+status: active
+description: >
+  Design notes for trust establishment at non-owner sites: creator-signed
+  bootstrap for the original report path, invite-based bootstrap for
+  late joiners, and CaseActor authority after trust establishment.
+related_specs:
+  - specs/case-bootstrap-trust.yaml
+  - specs/participant-case-replica.yaml
+  - specs/actor-knowledge-model.yaml
+  - specs/case-management.yaml
+related_notes:
+  - notes/participant-case-replica.md
+  - notes/activitystreams-semantics.md
+  - notes/actor-knowledge-model.md
+relevant_packages:
+  - vultron/core/use_cases/received
+  - vultron/core/use_cases/triggers
+  - vultron/adapters/driving/fastapi
+  - vultron/wire/as2/factories
+---
+
+# Case Bootstrap Trust — Implementation Notes
+
+**Relates to**: `specs/case-bootstrap-trust.yaml`
+
+**Source**: 2026-05-06 design conversation about #440 and #457.
+
+---
+
+## Decision Table
+
+| Question | Decision | Rationale |
+|---|---|---|
+| What establishes first trust for the original report-submission path? | The case creator sends a one-time `Create(VulnerabilityCase)` to the report submitter. | The report submitter already knows who received the report; the bootstrap reuses that trust anchor to introduce the CaseActor safely. |
+| Is `Announce(VulnerabilityCase)` still the first snapshot for that path? | No. After bootstrap, later snapshots come from the CaseActor via `Announce`. | Keeps initial trust establishment separate from ongoing single-writer replication. |
+| What must be in the bootstrap payload? | A full case snapshot naming the case creator/owner, the CaseActor, and the report submitter when they are already in the loop. | The receiver needs both the case state and the identities required for future trust checks. |
+| What roles should those participants carry? | Case creator/owner gets `CASE_OWNER`; CaseActor gets `COORDINATOR`. | Distinguishes ownership from coordination authority. |
+| Is an extra ack needed before CaseActor updates are trusted? | No. Local validation of the bootstrap is enough. | Avoids an unnecessary extra round trip. |
+| What if a CaseActor update arrives before bootstrap? | Queue briefly, do not apply it, then drop and warn if bootstrap never arrives. | Tolerates reordering without making ordering skew a protocol failure. |
+| Who gets the replay request if bootstrap times out? | The original report receiver / case creator. | The CaseActor is not trusted yet; the replay request asks for the trust-establishing message. |
+| How do late joiners establish trust? | `InviteActorToCase` from the case creator establishes trust; then the CaseActor may `Announce` the case. | Late joiners have no prior report relationship to anchor trust. |
+| Can ordinary updates replace the trusted CaseActor? | No. CaseActor rotation requires an explicit transfer workflow. | Prevents silent authority takeover. |
+| Do encrypted/authenticated DMs replace this bootstrap? | No. They secure transport, but they do not authorize a newly introduced CaseActor for a case. | Sender authenticity alone is weaker than case-specific authority. |
+
+---
+
+## Two Bootstrap Paths
+
+### 1. Original report-submission path
+
+The original report submitter already has a trust anchor: they know who
+received the report. The bootstrap uses that known actor to introduce the
+case and its CaseActor.
+
+```text
+report_submitter -> Offer(VulnerabilityReport) -> report_receiver
+report_receiver == case_creator
+
+case_creator -> Create(VulnerabilityCase full snapshot) -> report_submitter
+report_submitter validates:
+  - sender == report_receiver
+  - case references the submitted report
+  - case identifies the CaseActor
+
+CaseActor -> Announce(VulnerabilityCase updates) -> report_submitter
+```
+
+### 2. Late-joiner path
+
+Late joiners do not have a prior report exchange with the case creator, so the
+creator-signed invite becomes the trust-establishing message.
+
+```text
+case_creator -> InviteActorToCase -> late_joiner
+late_joiner validates invite + CaseActor identity
+late_joiner -> Accept(InviteActorToCase) -> case_creator
+CaseActor -> Announce(VulnerabilityCase full snapshot) -> late_joiner
+```
+
+---
+
+## Required Bootstrap Payload Shape
+
+For the original report-submission path, the bootstrap `Create(VulnerabilityCase)`
+should already contain enough information for the receiver to accept future
+CaseActor updates without another handshake:
+
+1. The full inline `VulnerabilityCase`
+2. A participant record for the case creator / owner with `CASE_OWNER`
+3. A participant record for the CaseActor with `COORDINATOR`
+4. A participant record for the report submitter when they are already a live
+   participant in the case
+5. A reference to the submitted report so the receiver can link
+   report-to-case state
+
+The important consequence is that the CaseActor is not merely an opaque
+service reference. It is an identity the receiver must learn and bind to the
+case during bootstrap.
+
+---
+
+## Trust Anchors to Persist
+
+After a valid bootstrap, persist all of the following together:
+
+- `report_id -> case_id`
+- `case_id -> trusted_case_creator_id`
+- `case_id -> trusted_case_actor_id`
+
+This prevents the receiver from having to re-derive trust from later traffic
+and gives handlers a stable basis for rejecting spoofed or stale senders.
+
+---
+
+## Out-of-Order Handling
+
+Permanent rejection of pre-bootstrap CaseActor messages is cleaner, but it
+makes delivery order part of protocol correctness. The agreed design instead
+uses a short bounded queue:
+
+1. A CaseActor message arrives before bootstrap.
+2. The receiver verifies that the CaseActor is not yet trusted for this case.
+3. The message is queued briefly and remains unapplied.
+4. If bootstrap arrives in time, normal validation may resume.
+5. If bootstrap does not arrive, drop the queued message, log a warning, and
+   ask the case creator to replay bootstrap.
+
+The replay request should be a generic `Question` directed to the original
+report receiver / case creator. The semantics are "please resend the
+bootstrap `Create(VulnerabilityCase)` for this report/case relationship."
+
+---
+
+## Migration Guidance
+
+This design supersedes the non-owner bootstrap assumptions currently written in
+`notes/participant-case-replica.md` and the corresponding PCR bootstrap rules:
+
+- Original participants do **not** start with `Announce(VulnerabilityCase)`
+  from the CaseActor.
+- `Create(VulnerabilityCase)` is no longer forbidden as a snapshot vehicle in
+  all cases; it is allowed exactly once for creator-signed bootstrap on the
+  original report path.
+- Late joiners still converge on CaseActor-authored `Announce` after their
+  invite-based trust handoff.
+
+When implementation work begins, update these call sites consistently:
+
+1. Case creation at report receipt
+2. Outbound bootstrap activity construction
+3. Participant-side bootstrap validation and trust persistence
+4. Unknown-context / pre-bootstrap queueing and replay request behavior
+5. Invite-to-case handling for late-joiner trust establishment
+
+---
+
+## Layer and Import Rules
+
+- Trust-establishment rules belong in core use-case / behavior logic, not in
+  FastAPI routers.
+- Outbound bootstrap activities must be built through
+  `vultron.wire.as2.factories`, not by importing internal activity subclasses.
+- Persisted trust anchors should live in core models / ports, not in
+  wire-specific helper objects.
+- Transport security checks may support the decision, but they must not become
+  the sole authority check for a new CaseActor.
+
+---
+
+## Testing Patterns
+
+```python
+def test_bootstrap_create_establishes_trusted_case_actor(
+    dl, report_submitter, report_receiver, submitted_report, bootstrap_activity
+):
+    event = build_event(bootstrap_activity, actor_id=report_submitter.id_)
+    CreateVulnerabilityCaseReceivedUseCase(dl, event).execute()
+
+    trust = dl.read(case_bootstrap_trust_id(submitted_report.id_))
+    assert trust.trusted_case_creator_id == report_receiver.id_
+    assert trust.trusted_case_actor_id is not None
+```
+
+```python
+def test_pre_bootstrap_case_actor_announce_is_queued_not_applied(
+    dl, queue_dl, case_actor_announce
+):
+    process_inbox_item(case_actor_announce, dl, queue_dl)
+
+    assert local_case_not_updated(dl, case_actor_announce.context)
+    assert queued_for_bootstrap(queue_dl, case_actor_announce.id_)
+```
+
+```python
+def test_late_joiner_invite_establishes_case_actor_trust(
+    dl, invite_activity, announce_activity
+):
+    InviteActorToCaseReceivedUseCase(dl, build_event(invite_activity)).execute()
+    AnnounceVulnerabilityCaseReceivedUseCase(
+        dl, build_event(announce_activity)
+    ).execute()
+
+    assert late_joiner_replica_created(dl, announce_activity.context)
+```

--- a/notes/participant-case-replica.md
+++ b/notes/participant-case-replica.md
@@ -4,6 +4,7 @@ status: active
 description: "Design notes for participant case replicas: per-actor case copies and synchronization model."
 related_specs:
   - specs/participant-case-replica.yaml
+  - specs/case-bootstrap-trust.yaml
   - specs/case-management.yaml
   - specs/sync-log-replication.yaml
 relevant_packages:
@@ -17,7 +18,14 @@ relevant_packages:
 **Relates to**: `specs/participant-case-replica.yaml`
 
 **Cross-references**: `specs/case-management.yaml`,
-`specs/sync-log-replication.yaml`, `specs/actor-knowledge-model.yaml`
+`specs/sync-log-replication.yaml`, `specs/actor-knowledge-model.yaml`,
+`specs/case-bootstrap-trust.yaml`
+
+> **Supersession note**: The non-owner bootstrap guidance in this file is
+> partially superseded by `specs/case-bootstrap-trust.yaml` and
+> `notes/case-bootstrap-trust.md`. For the original report-submission path,
+> trust now starts with creator-signed `Create(VulnerabilityCase)`, not with
+> `Announce(VulnerabilityCase)` from the CaseActor.
 
 ---
 
@@ -26,14 +34,14 @@ relevant_packages:
 | Question | Decision | Rationale |
 |---|---|---|
 | Does each participant need a stub CaseActor clone? | No — one Actor, one inbox; routing is an internal concern. | Separate per-participant-per-case actors would explode the actor registry and add wire-protocol complexity with no protocol benefit. |
-| What is the unified mechanism for delivering a full case snapshot? | `Announce(VulnerabilityCase)` at all lifecycle stages. | `Announce` is semantically correct ("I am telling you about this") for both initial delivery and ongoing updates. `Create(Case)` retains its "case was created" semantics but is not the snapshot vehicle. |
-| Who triggers initial sync for the original participants? | CaseActor sends `Announce(VulnerabilityCase)` as part of case initialization. | Consistent with the unified mechanism; no special-casing required. |
-| Who triggers initial sync for late-joining participants? | CaseActor auto-sends `Announce(VulnerabilityCase)` as a cascade when it processes `Accept(Invite)`. | Implements the protocol-event-cascade pattern: acceptance implies participant is added implies snapshot is sent. |
+| What is the bootstrap mechanism for delivering a full case snapshot? | Split by path: creator-signed `Create(VulnerabilityCase)` for the original report path; `Announce(VulnerabilityCase)` from the CaseActor after trust is established; invite-based bootstrap for late joiners. | Original report submitters already trust the report receiver, so that actor should introduce the CaseActor. Late joiners need trust establishment through invitation rather than report history. |
+| Who triggers initial sync for the original participants? | The case creator sends one-time `Create(VulnerabilityCase)` to the original report submitter. | This establishes trust in the CaseActor before later updates arrive from a different identity. |
+| Who triggers initial sync for late-joining participants? | The case creator establishes trust through `InviteActorToCase`, then the CaseActor sends `Announce(VulnerabilityCase)` after acceptance. | Keeps late-joiner trust establishment tied to the invite flow while preserving CaseActor-authoritative replication afterward. |
 | Who may update a participant's local case replica? | Only the CaseActor. Reject and log at WARNING for any other sender. | Enforces the single-writer invariant (CM-02-002). Matches the idea's explicit requirement. |
 | Does the case owner follow the same replica rules? | Yes. Even the case owner routes through the CaseActor and never writes directly to its local copy. | Reinforces CM-02-010 (distinct CaseActor and owner actor identities). |
 | Which field routes a case-scoped message to the right local handler? | `context` field, set to the case ID. | Already the established pattern in all demos. Consistent with AS2 semantics. |
 | What happens when an activity arrives with an unknown case context? | Queue, warn, request resync. Drop if no snapshot arrives within timeout. | Handles out-of-order delivery (snapshot and follow-up arrive in wrong order) without silently dropping or corrupting state. |
-| Should an actor maintain a report-to-case mapping? | Yes. Allows reporter actors to recognize that an `Announce(Case)` is a response to their prior `Offer(Report)`. | Enables the "reporter checks their open submissions" flow described in the idea. |
+| Should an actor maintain a report-to-case mapping? | Yes. Allows reporter actors to recognize that bootstrap `Create(Case)` and later `Announce(Case)` traffic belong to their prior `Offer(Report)`. | Enables the "reporter checks their open submissions" flow described in the idea. |
 
 ---
 
@@ -53,32 +61,35 @@ entity that may update participant replicas.
 ```text
 Case Lifecycle:
   Case created
-    └── CaseActor sends Announce(VulnerabilityCase) to each initial participant
-          └── Participant creates local replica on first receipt
-          └── Participant updates local replica on subsequent receipt
+    └── Case creator sends Create(VulnerabilityCase) to original report submitter
+          └── Submitter validates report linkage + CaseActor identity
+          └── Trusted CaseActor sends Announce(VulnerabilityCase) updates
 
   New participant invited and accepts
-    └── CaseActor processes Accept(Invite)
-          └── CaseActor adds participant to case
+    └── Case creator sends InviteActorToCase
+          └── Invitee validates invite + CaseActor identity
           └── CaseActor sends Announce(VulnerabilityCase) to new participant
                 └── New participant creates local replica
 ```
 
 ---
 
-## `Announce(VulnerabilityCase)` as Unified Bootstrap
+## Bootstrap Split by Participant Origin
 
-The `Announce` activity is the correct AS2 verb for "I am informing you about
-this object." This covers both:
+`Announce(VulnerabilityCase)` is still the right vehicle for CaseActor-led
+ongoing synchronization, but it is no longer the universal first-bootstrap
+message for non-owner participants.
 
-- **Initial delivery**: participant does not yet have a local copy; the
-  `Announce` handler checks for an existing replica, finds none, and creates
-  one.
-- **Subsequent updates**: participant already has a local copy; the `Announce`
-  handler merges the received state.
+- **Original report path**: the case creator sends one-time
+  `Create(VulnerabilityCase)` to the original report submitter to introduce the
+  case and the CaseActor.
+- **Post-bootstrap updates**: the trusted CaseActor sends
+  `Announce(VulnerabilityCase)` for ongoing synchronization.
+- **Late joiners**: `InviteActorToCase` establishes trust first, then the
+  CaseActor may send `Announce(VulnerabilityCase)`.
 
-The receiver's handler does NOT need to know which case of its lifecycle the
-delivery is at:
+The receiver therefore needs bootstrap-state awareness before treating a
+CaseActor-originated snapshot as authoritative:
 
 ```python
 class AnnounceVulnerabilityCaseReceivedUseCase:

--- a/plan/history/2605/README.md
+++ b/plan/history/2605/README.md
@@ -4,6 +4,7 @@
 
 | Date | Time (UTC) | Type | Source | Title |
 |------|------------|------|--------|-------|
+| 2026-05-06 | 19:50 | idea | conversation-2026-05-06-440-457 | Case creator bootstraps CaseActor trust |
 | 2026-05-06 | 17:53 | priority | Priority 50000 | Full RAFT consensus implementation archived with no open issues |
 | 2026-05-06 | 17:53 | priority | Priority 480 | Cyclomatic Complexity Enforcement archived with no open issues |
 | 2026-05-06 | 17:53 | priority | Priority 474 | Trigger Classification archived with no remaining open issues |

--- a/plan/history/2605/idea/conversation-2026-05-06-440-457.md
+++ b/plan/history/2605/idea/conversation-2026-05-06-440-457.md
@@ -1,0 +1,32 @@
+---
+source: conversation-2026-05-06-440-457
+timestamp: '2026-05-06T19:50:04.149997+00:00'
+title: Case creator bootstraps CaseActor trust
+type: idea
+---
+
+## Conversation idea: Case creator bootstraps CaseActor trust
+
+About #440 and #457, the question is whether we have the right protocol for
+how to initialize a case at a non-case-owner site. When a report submitter
+sends a vulnerability report to another actor and that receiver creates a case,
+there is concern that the receiver should introduce the case and the CaseActor
+in a way that lets the submitter trust later case updates without spoofing.
+
+The desired direction is:
+
+- the report receiver, acting as case creator, sends `Create(VulnerabilityCase)`
+  to the original report submitter
+- that case should already identify the case creator / owner and the CaseActor
+  as participants, with the CaseActor potentially holding coordinator role
+- once the report submitter validates that bootstrap against the report they
+  previously sent, they can trust later `Announce(VulnerabilityCase)` updates
+  from the CaseActor
+- this should prevent spoofing where a submitter receives case updates from a
+  previously unknown actor identity
+- the exact logistics differ for later-added participants, whose trust
+  establishment likely belongs in the invite-to-case workflow instead
+
+**Processed**: 2026-05-06 — design decisions captured in
+`specs/case-bootstrap-trust.yaml` (CBT-01 through CBT-05) and
+`notes/case-bootstrap-trust.md`.

--- a/specs/README.md
+++ b/specs/README.md
@@ -67,6 +67,7 @@ Load additional files only when the task touches the relevant area. See the
 | Topic | Files to add |
 |-------|-------------|
 | Inter-actor communication / knowledge model | `actor-knowledge-model.yaml` |
+| Case bootstrap trust establishment | `case-bootstrap-trust.yaml`, `participant-case-replica.yaml`, `actor-knowledge-model.yaml` |
 | DataLayer adapter | `datalayer.md` |
 | Handler pipeline | `inbox-endpoint.yaml`, `message-validation.yaml`, `semantic-extraction.yaml`, `dispatch-routing.yaml` |
 | Behavior Trees | `behavior-tree-integration.yaml`, `behavior-tree-node-design.yaml`, `bt-composability.yaml`, `triggerable-behaviors.yaml`, `notes/trigger-classification.md` |
@@ -192,6 +193,11 @@ Specifications are organized by topic with minimal overlap. Cross-references lin
   broadcast, CVD action rules API, redacted case view (CM-09), per-participant embargo
   acceptance tracking (CM-10), invitation acceptance lifecycle (CM-11), case creation timing
   (CM-12), embargo acceptance ownership (CM-13), case initialization sequence (CM-14)
+- **`case-bootstrap-trust.yaml`** - Trust establishment for non-owner
+  participants: creator-signed `Create(VulnerabilityCase)` bootstrap on the
+  original report path, invite-based trust establishment for late joiners,
+  pre-bootstrap queue / replay rules, and trusted CaseActor persistence
+  (CBT-01 through CBT-05)
 - **`participant-role-management.yaml`** - Role read/mutation API on
   `VultronParticipant` and `CaseParticipant`: `add_role()`, `remove_role()`,
   `has_role()`, `roles` property, core-layer no-direct-mutation rule, wire-layer
@@ -255,8 +261,9 @@ Specifications are organized by topic with minimal overlap. Cross-references lin
   and port-injection-via-blackboard pattern
   (SBT-01 through SBT-05)
 - **`participant-case-replica.yaml`** - Participant case replica lifecycle:
-  bootstrap via `Announce(VulnerabilityCase)`, single-writer update authority,
-  case-context routing, reporter case discovery, and unknown-context handling
+  replica identity, single-writer update authority, case-context routing,
+  reporter case discovery, and unknown-context handling; see
+  `case-bootstrap-trust.yaml` for non-owner trust establishment
   (PCR-01 through PCR-07)
 
 ### Demo and Tooling

--- a/specs/case-bootstrap-trust.yaml
+++ b/specs/case-bootstrap-trust.yaml
@@ -1,0 +1,203 @@
+id: CBT
+title: Case Bootstrap Trust
+description: >-
+  Requirements for establishing trust in a `VulnerabilityCase` and its
+  `CaseActor` at non-owner sites. Source: 2026-05-06 design conversation about
+  #440 and #457. Scope note: this spec governs trust establishment for
+  non-owner participants and refines the bootstrap assumptions in
+  `specs/participant-case-replica.yaml`; it does not replace the ongoing
+  single-writer and replica-routing rules in PCR or the log-replication
+  transport rules in `specs/sync-log-replication.yaml`.
+version: 1.0.0
+kind: domain
+scope:
+  - prototype
+  - production
+groups:
+  - id: CBT-01
+    title: Original Report-Submission Bootstrap
+    specs:
+      - id: CBT-01-001
+        priority: MUST
+        statement: >-
+          When an actor creates a case in response to an inbound
+          `Offer(VulnerabilityReport)`, that case creator MUST establish trust
+          at the original report submitter by sending a one-time
+          `Create(VulnerabilityCase)` activity.
+        relationships:
+          - rel_type: refines
+            spec_id: CM-12-001
+          - rel_type: refines
+            spec_id: PCR-02-005
+      - id: CBT-01-002
+        priority: MUST
+        statement: >-
+          The bootstrap `Create(VulnerabilityCase)` activity MUST carry a full
+          inline `VulnerabilityCase` snapshot rather than a minimal stub or
+          partial trust-only payload.
+        relationships:
+          - rel_type: implements
+            spec_id: AKM-03-001
+      - id: CBT-01-003
+        priority: MUST
+        statement: >-
+          The bootstrap case snapshot MUST identify the case creator/owner as a
+          participant with `CASE_OWNER` role and MUST identify the CaseActor as
+          a participant with `COORDINATOR` role.
+        relationships:
+          - rel_type: refines
+            spec_id: CM-02-001
+          - rel_type: refines
+            spec_id: CM-02-010
+      - id: CBT-01-004
+        priority: MUST
+        statement: >-
+          When the original report submitter is intended to receive ongoing
+          case updates immediately, the bootstrap case snapshot MUST include
+          that actor as a participant from the start.
+      - id: CBT-01-005
+        priority: MUST
+        statement: >-
+          A report submitter MUST NOT trust a newly introduced CaseActor unless
+          the bootstrap `Create(VulnerabilityCase)` both comes from the same
+          actor that received the report and references the previously
+          submitted report.
+        relationships:
+          - rel_type: refines
+            spec_id: PCR-05-001
+          - rel_type: refines
+            spec_id: AKM-02-001
+      - id: CBT-01-006
+        priority: MUST
+        statement: >-
+          After validating the bootstrap `Create(VulnerabilityCase)`, the
+          receiving actor MUST persist the report-to-case link, the trusted
+          case-creator identity, and the trusted CaseActor identity for that
+          relationship.
+        relationships:
+          - rel_type: refines
+            spec_id: PCR-05-001
+  - id: CBT-02
+    title: Post-Bootstrap Update Authority
+    specs:
+      - id: CBT-02-001
+        priority: MUST
+        statement: >-
+          For the original report-submission path, `Create(VulnerabilityCase)`
+          is a one-time bootstrap message only; subsequent full-case
+          synchronization MUST use `Announce(VulnerabilityCase)` from the
+          trusted CaseActor.
+        relationships:
+          - rel_type: refines
+            spec_id: PCR-02-001
+          - rel_type: refines
+            spec_id: PCR-03-001
+      - id: CBT-02-002
+        priority: MUST_NOT
+        statement: >-
+          Transport authentication or encrypted direct messaging alone MUST NOT
+          be treated as sufficient authority to trust a previously unknown
+          CaseActor without the explicit bootstrap trust handoff.
+        relationships:
+          - rel_type: refines
+            spec_id: AKM-01-002
+      - id: CBT-02-003
+        priority: MUST
+        statement: >-
+          Once a CaseActor has been trusted for a case, that identity MUST NOT
+          be replaced implicitly by ordinary case-update traffic; CaseActor
+          rotation or transfer MUST use an explicit transfer workflow.
+        relationships:
+          - rel_type: refines
+            spec_id: CM-02-010
+  - id: CBT-03
+    title: Out-of-Order Handling and Replay Requests
+    specs:
+      - id: CBT-03-001
+        priority: SHOULD
+        statement: >-
+          If a CaseActor-originated case message arrives before the required
+          bootstrap trust handoff, the receiving actor SHOULD queue it only for
+          a short bounded interval rather than accepting or permanently
+          trusting it immediately.
+        relationships:
+          - rel_type: refines
+            spec_id: PCR-06-002
+      - id: CBT-03-002
+        priority: MUST_NOT
+        statement: >-
+          A pre-bootstrap CaseActor message MUST NOT update local case state
+          before the corresponding trust-establishing bootstrap message has been
+          validated.
+        relationships:
+          - rel_type: refines
+            spec_id: PCR-06-003
+      - id: CBT-03-003
+        priority: MUST
+        statement: >-
+          When the bounded pre-bootstrap queue expires, the receiver MUST drop
+          the queued message, log a warning, and require a resend after
+          bootstrap.
+      - id: CBT-03-004
+        priority: SHOULD
+        statement: >-
+          When bootstrap has not arrived in time, the receiver SHOULD request a
+          replay from the original report receiver / case creator by sending a
+          generic `Question` asking for the bootstrap `Create(VulnerabilityCase)`
+          to be resent.
+  - id: CBT-04
+    title: Late-Joiner Bootstrap
+    specs:
+      - id: CBT-04-001
+        priority: MUST
+        statement: >-
+          For a participant added after case creation, the trust-establishing
+          message MUST be `InviteActorToCase` from the case creator/owner rather
+          than `Create(VulnerabilityCase)`.
+        relationships:
+          - rel_type: refines
+            spec_id: CM-11-001
+      - id: CBT-04-002
+        priority: MUST
+        statement: >-
+          The trust-establishing invite for a late joiner MUST identify both
+          the case and the CaseActor that will send subsequent
+          `Announce(VulnerabilityCase)` updates.
+      - id: CBT-04-003
+        priority: MUST
+        statement: >-
+          After the late joiner has validated and accepted that invitation, the
+          CaseActor MAY send `Announce(VulnerabilityCase)` without a separate
+          `Create(VulnerabilityCase)` bootstrap.
+        relationships:
+          - rel_type: refines
+            spec_id: PCR-07-007
+  - id: CBT-05
+    title: Verification
+    specs:
+      - id: CBT-05-001
+        priority: MUST
+        statement: >-
+          Tests MUST verify that the original report submitter accepts
+          CaseActor-originated `Announce(VulnerabilityCase)` updates only after
+          a valid creator-signed bootstrap `Create(VulnerabilityCase)` has
+          established trust.
+      - id: CBT-05-002
+        priority: MUST
+        statement: >-
+          Tests MUST verify that a bootstrap `Create(VulnerabilityCase)` is
+          rejected when the sender does not match the actor that received the
+          report or when the case does not reference the known submitted report.
+      - id: CBT-05-003
+        priority: MUST
+        statement: >-
+          Tests MUST verify that pre-bootstrap CaseActor messages remain
+          unapplied, expire safely, and lead to a replay request to the case
+          creator.
+      - id: CBT-05-004
+        priority: MUST
+        statement: >-
+          Tests MUST verify that late joiners establish trust through
+          `InviteActorToCase` and may then accept CaseActor-originated
+          `Announce(VulnerabilityCase)` updates without an intermediate
+          `Create(VulnerabilityCase)` bootstrap.


### PR DESCRIPTION
Docs-only PR: adds spec and notes for the 2026-05-06 bootstrap-trust conversation and updates related replica guidance.

No .py files changed.