### PR TITLE
feat: two-actor demo core capabilities (Issue #461)

### DIFF
--- a/test/core/states/test_cvd_roles.py
+++ b/test/core/states/test_cvd_roles.py
@@ -41,7 +41,7 @@ def test_atomic_roles_exist():
         "COORDINATOR",
         "OTHER",
         "CASE_OWNER",
-        "CASE_ACTOR",
+        "CASE_MANAGER",
     }
     actual = {m.name for m in CVDRole}
     assert expected == actual

--- a/test/core/use_cases/received/test_case_bootstrap_trust.py
+++ b/test/core/use_cases/received/test_case_bootstrap_trust.py
@@ -19,7 +19,7 @@ Covers:
   CBT-05-002  Bootstrap Create rejected when sender ≠ trusted_case_creator_id.
   CBT-05-003  No-link path: Create without a matching ReportCaseLink is a
               no-op (receiver is not the original reporter).
-  CBT-05-004  trusted_case_actor_id is extracted from the CASE_ACTOR participant
+  CBT-05-004  trusted_case_actor_id is extracted from the CASE_MANAGER participant
               in the bootstrap snapshot and recorded in the ReportCaseLink.
 """
 
@@ -62,7 +62,7 @@ _PARTICIPANT_ID = f"{_CASE_ID}/participants/case-actor"
 
 
 def _case_with_case_actor_participant() -> tuple:
-    """Build a VulnerabilityCase whose participant list includes a CASE_ACTOR.
+    """Build a VulnerabilityCase whose participant list includes a CASE_MANAGER.
 
     Returns a tuple of (VulnerabilityCase, CaseActorParticipant).  The
     participant is embedded INLINE in the case snapshot (not just an ID),
@@ -108,7 +108,7 @@ def dl():
 
 @pytest.fixture()
 def case_with_participant():
-    """Return (VulnerabilityCase, VultronParticipant) with CASE_ACTOR role."""
+    """Return (VulnerabilityCase, VultronParticipant) with CASE_MANAGER role."""
     return _case_with_case_actor_participant()
 
 
@@ -161,7 +161,7 @@ class TestBootstrapCreateAccepted:
     def test_report_case_link_updated_with_trusted_case_actor_id(
         self, dl, create_event, case_with_participant
     ):
-        """Bootstrap extracts trusted_case_actor_id from CASE_ACTOR participant
+        """Bootstrap extracts trusted_case_actor_id from CASE_MANAGER participant
         (CBT-01-003, CBT-01-006)."""
         link = _build_link()
         dl.save(link)

--- a/test/core/use_cases/received/test_status.py
+++ b/test/core/use_cases/received/test_status.py
@@ -239,8 +239,14 @@ class TestStatusUseCases:
             id_="https://example.org/cases/case_ps2",
             name="PS Case 2",
         )
+        # Register the vendor actor as a participant so step 1 passes
+        case_ps2.case_participants.append(participant.id_)
+        case_ps2.actor_participant_index[
+            "https://example.org/users/vendor"
+        ] = participant.id_
         dl.create(participant)
         dl.create(pstatus)
+        dl.create(case_ps2)
 
         activity = add_status_to_participant_activity(
             pstatus,

--- a/test/wire/as2/vocab/test_wire_domain_translation.py
+++ b/test/wire/as2/vocab/test_wire_domain_translation.py
@@ -77,12 +77,18 @@ def test_case_status_round_trips_between_core_and_wire():
 
 
 def test_participant_status_from_core_materializes_case_status_reference():
+    core_case_status = VultronCaseStatus(
+        id_="https://example.org/cases/1/status/1",
+        context="https://example.org/cases/1",
+        attributed_to="https://example.org/actors/vendor",
+        em_state=EM.NO_EMBARGO,
+    )
     core = VultronParticipantStatus(
         id_="https://example.org/cases/1/participants/1/status/1",
         attributed_to="https://example.org/actors/vendor",
         context="https://example.org/cases/1",
         rm_state=RM.ACCEPTED,
-        case_status="https://example.org/cases/1/status/1",
+        case_status=core_case_status,
     )
 
     wire = ParticipantStatus.from_core(core)
@@ -95,7 +101,9 @@ def test_participant_status_from_core_materializes_case_status_reference():
     assert round_tripped.context == core.context
     assert round_tripped.rm_state == core.rm_state
     assert round_tripped.vfd_state == core.vfd_state
-    assert round_tripped.case_status == core.case_status
+    assert isinstance(round_tripped.case_status, VultronCaseStatus)
+    assert round_tripped.case_status.id_ == core_case_status.id_
+    assert round_tripped.case_status.em_state == core_case_status.em_state
 
 
 def test_case_participant_round_trips_between_core_and_wire():

--- a/vultron/adapters/driven/trigger_activity_adapter.py
+++ b/vultron/adapters/driven/trigger_activity_adapter.py
@@ -35,6 +35,7 @@ import logging
 from typing import Any, cast
 
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
+from vultron.errors import VultronNotFoundError
 from vultron.wire.as2.factories import (
     accept_actor_recommendation_activity,
     add_note_to_case_activity,
@@ -440,7 +441,27 @@ class TriggerActivityAdapter:
         to: list[str] | None = None,
     ) -> str:
         """Create and persist an ``Add(ParticipantStatus, CaseParticipant)`` activity."""
-        status = cast(ParticipantStatus, self._dl.read(status_id))
+        raw = self._dl.read(status_id)
+        if raw is None:
+            raise VultronNotFoundError(
+                "ParticipantStatus",
+                f"status '{status_id}' not found",
+            )
+        # Convert from core VultronParticipantStatus to wire ParticipantStatus
+        # so that nested fields (case_status, pxa_state) survive the boundary.
+        if not isinstance(raw, ParticipantStatus):
+            from vultron.wire.as2.vocab.objects.case_status import (
+                ParticipantStatus as WirePS,
+            )
+            from vultron.core.models.participant_status import (
+                VultronParticipantStatus,
+            )
+
+            if isinstance(raw, VultronParticipantStatus):
+                raw = WirePS.from_core(raw)
+            else:
+                raw = cast(ParticipantStatus, raw)
+        status: ParticipantStatus = raw
         activity = add_status_to_participant_activity(
             status=status, target=participant_id, actor=actor, to=to
         )

--- a/vultron/adapters/driven/trigger_activity_adapter.py
+++ b/vultron/adapters/driven/trigger_activity_adapter.py
@@ -39,6 +39,7 @@ from vultron.wire.as2.factories import (
     accept_actor_recommendation_activity,
     add_note_to_case_activity,
     add_participant_to_case_activity,
+    add_status_to_participant_activity,
     announce_embargo_activity,
     create_case_activity,
     em_accept_embargo_activity,
@@ -60,6 +61,7 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.base.objects.object_types import as_Note
 from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+from vultron.wire.as2.vocab.objects.case_status import ParticipantStatus
 from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
     VulnerabilityCase,
@@ -426,6 +428,28 @@ class TriggerActivityAdapter:
             logger.warning(
                 "add_participant_to_case: activity '%s' already exists"
                 " — skipping",
+                activity.id_,
+            )
+        return activity.id_
+
+    def add_participant_status_to_participant(
+        self,
+        status_id: str,
+        participant_id: str,
+        actor: str,
+        to: list[str] | None = None,
+    ) -> str:
+        """Create and persist an ``Add(ParticipantStatus, CaseParticipant)`` activity."""
+        status = cast(ParticipantStatus, self._dl.read(status_id))
+        activity = add_status_to_participant_activity(
+            status=status, target=participant_id, actor=actor, to=to
+        )
+        try:
+            self._dl.create(activity)
+        except ValueError:
+            logger.warning(
+                "add_participant_status_to_participant: activity '%s' already"
+                " exists — skipping",
                 activity.id_,
             )
         return activity.id_

--- a/vultron/adapters/driving/fastapi/inbox_handler.py
+++ b/vultron/adapters/driving/fastapi/inbox_handler.py
@@ -82,6 +82,7 @@ _SYNC_PORT_SEMANTICS = frozenset(
 
 _TRIGGER_ACTIVITY_PORT_SEMANTICS = frozenset(
     {
+        MessageSemantics.ADD_PARTICIPANT_STATUS_TO_PARTICIPANT,
         MessageSemantics.SUBMIT_REPORT,
         MessageSemantics.SUGGEST_ACTOR_TO_CASE,
         MessageSemantics.ACCEPT_INVITE_ACTOR_TO_CASE,

--- a/vultron/adapters/driving/fastapi/routers/demo_triggers.py
+++ b/vultron/adapters/driving/fastapi/routers/demo_triggers.py
@@ -27,8 +27,9 @@ In ``RunMode.PROD`` these paths are simply not registered, so any request to
 Spec: TRIG-08-004, TRIG-09-001 through TRIG-09-005, TRIG-10-003, TRIG-10-004.
 """
 
-from fastapi import APIRouter, BackgroundTasks, Depends, status
 from typing import Any
+
+from fastapi import APIRouter, BackgroundTasks, Depends, status
 
 from vultron.adapters.driving.fastapi.deps import (
     get_canonical_actor_dl,

--- a/vultron/adapters/driving/fastapi/routers/demo_triggers.py
+++ b/vultron/adapters/driving/fastapi/routers/demo_triggers.py
@@ -28,6 +28,7 @@ Spec: TRIG-08-004, TRIG-09-001 through TRIG-09-005, TRIG-10-003, TRIG-10-004.
 """
 
 from fastapi import APIRouter, BackgroundTasks, Depends, status
+from typing import Any
 
 from vultron.adapters.driving.fastapi.deps import (
     get_canonical_actor_dl,
@@ -38,6 +39,10 @@ from vultron.adapters.driving.fastapi.errors import domain_error_translation
 from vultron.adapters.driving.fastapi.outbox_handler import outbox_handler
 from vultron.adapters.driving.fastapi.trigger_models import (
     AddNoteToCaseRequest,
+    CloseCaseRequest,
+    NotifyFixDeployedRequest,
+    NotifyFixReadyRequest,
+    NotifyPublishedRequest,
     SyncLogEntryRequest,
 )
 from vultron.core.ports.datalayer import DataLayer
@@ -141,3 +146,152 @@ def demo_sync_log_entry(
         "entry_hash": entry.entry_hash,
         "log_index": entry.log_index,
     }
+
+
+@router.post(
+    "/{actor_id}/demo/notify-fix-ready",
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="[Demo] Report that the actor's fix is ready (VFd).",
+    description=(
+        "Demo-only scaffold. "
+        "Self-reports VFD state VFd (fix ready, not yet deployed) "
+        "to the Case Manager via Add(ParticipantStatus, CaseParticipant). "
+        "Only available in ``RunMode.PROTOTYPE``. "
+        "Spec: DEMOMA-07-001."
+    ),
+    operation_id="actors_demo_notify_fix_ready",
+)
+def demo_notify_fix_ready(
+    actor_id: str,
+    body: NotifyFixReadyRequest,
+    background_tasks: BackgroundTasks,
+    svc: TriggerServicePort = Depends(get_trigger_service),
+    dl: DataLayer = Depends(get_trigger_dl),
+    actor_dl: DataLayer = Depends(get_canonical_actor_dl),
+) -> dict[str, Any]:
+    """Report that the actor has a fix ready (demo scaffold).
+
+    Implements: DEMOMA-07-001, TRIG-09-001, TB-01-001, TB-06-001.
+    """
+    from vultron.core.states.cs import CS_vfd
+
+    with domain_error_translation():
+        result = svc.add_participant_status(
+            actor_id=actor_id,
+            case_id=body.case_id,
+            vfd_state=CS_vfd.VFd,
+        )
+    background_tasks.add_task(outbox_handler, actor_id, actor_dl, dl)
+    return result
+
+
+@router.post(
+    "/{actor_id}/demo/notify-fix-deployed",
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="[Demo] Report that the actor's fix is deployed (VFD).",
+    description=(
+        "Demo-only scaffold. "
+        "Self-reports VFD state VFD (fix deployed) "
+        "to the Case Manager via Add(ParticipantStatus, CaseParticipant). "
+        "Only available in ``RunMode.PROTOTYPE``. "
+        "Spec: DEMOMA-07-001."
+    ),
+    operation_id="actors_demo_notify_fix_deployed",
+)
+def demo_notify_fix_deployed(
+    actor_id: str,
+    body: NotifyFixDeployedRequest,
+    background_tasks: BackgroundTasks,
+    svc: TriggerServicePort = Depends(get_trigger_service),
+    dl: DataLayer = Depends(get_trigger_dl),
+    actor_dl: DataLayer = Depends(get_canonical_actor_dl),
+) -> dict[str, Any]:
+    """Report that the actor has deployed a fix (demo scaffold).
+
+    Implements: DEMOMA-07-001, TRIG-09-001, TB-01-001, TB-06-001.
+    """
+    from vultron.core.states.cs import CS_vfd
+
+    with domain_error_translation():
+        result = svc.add_participant_status(
+            actor_id=actor_id,
+            case_id=body.case_id,
+            vfd_state=CS_vfd.VFD,
+        )
+    background_tasks.add_task(outbox_handler, actor_id, actor_dl, dl)
+    return result
+
+
+@router.post(
+    "/{actor_id}/demo/notify-published",
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="[Demo] Report that the vulnerability has been publicly disclosed.",
+    description=(
+        "Demo-only scaffold. "
+        "Self-reports VFD=VFD and PXA=Pxa (public aware) "
+        "to the Case Manager via Add(ParticipantStatus, CaseParticipant). "
+        "Only available in ``RunMode.PROTOTYPE``. "
+        "Spec: DEMOMA-07-001."
+    ),
+    operation_id="actors_demo_notify_published",
+)
+def demo_notify_published(
+    actor_id: str,
+    body: NotifyPublishedRequest,
+    background_tasks: BackgroundTasks,
+    svc: TriggerServicePort = Depends(get_trigger_service),
+    dl: DataLayer = Depends(get_trigger_dl),
+    actor_dl: DataLayer = Depends(get_canonical_actor_dl),
+) -> dict[str, Any]:
+    """Report that the vulnerability is publicly disclosed (demo scaffold).
+
+    Implements: DEMOMA-07-001, TRIG-09-001, TB-01-001, TB-06-001.
+    """
+    from vultron.core.states.cs import CS_pxa, CS_vfd
+
+    with domain_error_translation():
+        result = svc.add_participant_status(
+            actor_id=actor_id,
+            case_id=body.case_id,
+            vfd_state=CS_vfd.VFD,
+            pxa_state=CS_pxa.Pxa,
+        )
+    background_tasks.add_task(outbox_handler, actor_id, actor_dl, dl)
+    return result
+
+
+@router.post(
+    "/{actor_id}/demo/close-case",
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="[Demo] Report that the actor is closing the case (RM.CLOSED).",
+    description=(
+        "Demo-only scaffold. "
+        "Self-reports RM state CLOSED "
+        "to the Case Manager via Add(ParticipantStatus, CaseParticipant). "
+        "Only available in ``RunMode.PROTOTYPE``. "
+        "Spec: DEMOMA-07-001."
+    ),
+    operation_id="actors_demo_close_case",
+)
+def demo_close_case(
+    actor_id: str,
+    body: CloseCaseRequest,
+    background_tasks: BackgroundTasks,
+    svc: TriggerServicePort = Depends(get_trigger_service),
+    dl: DataLayer = Depends(get_trigger_dl),
+    actor_dl: DataLayer = Depends(get_canonical_actor_dl),
+) -> dict[str, Any]:
+    """Report that the actor is closing the case (demo scaffold).
+
+    Implements: DEMOMA-07-001, TRIG-09-001, TB-01-001, TB-06-001.
+    """
+    from vultron.core.states.rm import RM
+
+    with domain_error_translation():
+        result = svc.add_participant_status(
+            actor_id=actor_id,
+            case_id=body.case_id,
+            rm_state=RM.CLOSED,
+        )
+    background_tasks.add_task(outbox_handler, actor_id, actor_dl, dl)
+    return result

--- a/vultron/adapters/driving/fastapi/trigger_models.py
+++ b/vultron/adapters/driving/fastapi/trigger_models.py
@@ -341,3 +341,51 @@ class SyncLogEntryRequest(BaseModel):
     case_id: UriString
     object_id: UriString
     event_type: NonEmptyString
+
+
+class NotifyFixReadyRequest(BaseModel):
+    """Request body for the notify-fix-ready demo trigger.
+
+    Signals that the vendor has a fix ready (VFD → VFd).
+    TB-03-002: Unknown fields are silently ignored.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    case_id: UriString
+
+
+class NotifyFixDeployedRequest(BaseModel):
+    """Request body for the notify-fix-deployed demo trigger.
+
+    Signals that the fix has been deployed (VFd → VFD).
+    TB-03-002: Unknown fields are silently ignored.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    case_id: UriString
+
+
+class NotifyPublishedRequest(BaseModel):
+    """Request body for the notify-published demo trigger.
+
+    Signals that the vulnerability has been publicly disclosed (CS.VFDPxa).
+    TB-03-002: Unknown fields are silently ignored.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    case_id: UriString
+
+
+class CloseCaseRequest(BaseModel):
+    """Request body for the close-case demo trigger.
+
+    Signals that the actor is closing the case (RM → CLOSED).
+    TB-03-002: Unknown fields are silently ignored.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    case_id: UriString

--- a/vultron/core/behaviors/case/nodes.py
+++ b/vultron/core/behaviors/case/nodes.py
@@ -312,7 +312,7 @@ class CreateCaseActorNode(DataLayerAction):
             return Status.FAILURE
 
     def _register_case_actor_participant(self, case_actor_id: str) -> None:
-        """Add a VultronParticipant with COORDINATOR+CASE_ACTOR roles to the case.
+        """Add a VultronParticipant with COORDINATOR+CASE_MANAGER roles to the case.
 
         Uses core-layer ``VultronParticipant`` with both roles set so the
         bootstrap receiver can identify the CaseActor from the case snapshot
@@ -339,7 +339,7 @@ class CreateCaseActorNode(DataLayerAction):
             attributed_to=case_actor_id,
             context=self.case_id,
             name=f"CaseActor for {self.case_id}",
-            case_roles=[CVDRole.COORDINATOR, CVDRole.CASE_ACTOR],
+            case_roles=[CVDRole.COORDINATOR, CVDRole.CASE_MANAGER],
         )
         try:
             self.datalayer.create(participant)
@@ -351,7 +351,7 @@ class CreateCaseActorNode(DataLayerAction):
         self.datalayer.save(case)
         self.logger.info(
             f"{self.name}: Registered CaseActor participant '{participant_id}'"
-            f" (roles: COORDINATOR, CASE_ACTOR) for case '{self.case_id}'"
+            f" (roles: COORDINATOR, CASE_MANAGER) for case '{self.case_id}'"
         )
 
 

--- a/vultron/core/models/participant_status.py
+++ b/vultron/core/models/participant_status.py
@@ -20,8 +20,9 @@ from typing import Literal
 from pydantic import Field, field_serializer
 
 from vultron.core.states.rm import RM
-from vultron.core.states.cs import CS_vfd, CS_pxa
+from vultron.core.states.cs import CS_vfd
 from vultron.core.models.base import NonEmptyString, VultronObject
+from vultron.core.models.case_status import VultronCaseStatus
 
 
 class VultronParticipantStatus(VultronObject):
@@ -31,6 +32,9 @@ class VultronParticipantStatus(VultronObject):
     ``type_`` is ``"ParticipantStatus"`` to match the wire value.
 
     ``context`` (case ID) is required, matching the wire type's constraint.
+
+    ``case_status`` embeds the participant's perspective on the case-level
+    state (em_state and pxa_state) via a nested ``VultronCaseStatus`` object.
     """
 
     type_: Literal["ParticipantStatus"] = Field(
@@ -41,16 +45,11 @@ class VultronParticipantStatus(VultronObject):
     context: NonEmptyString  # pyright: ignore[reportGeneralTypeIssues]
     rm_state: RM = RM.START
     vfd_state: CS_vfd = CS_vfd.vfd
-    pxa_state: CS_pxa | None = None
     case_engagement: bool = True
     embargo_adherence: bool = True
     tracking_id: NonEmptyString | None = None
-    case_status: NonEmptyString | None = None
+    case_status: VultronCaseStatus | None = None
 
     @field_serializer("vfd_state")
     def _serialize_vfd_state(self, v: CS_vfd) -> str:
         return v.name
-
-    @field_serializer("pxa_state")
-    def _serialize_pxa_state(self, v: CS_pxa | None) -> str | None:
-        return v.name if v is not None else None

--- a/vultron/core/models/participant_status.py
+++ b/vultron/core/models/participant_status.py
@@ -20,7 +20,7 @@ from typing import Literal
 from pydantic import Field, field_serializer
 
 from vultron.core.states.rm import RM
-from vultron.core.states.cs import CS_vfd
+from vultron.core.states.cs import CS_vfd, CS_pxa
 from vultron.core.models.base import NonEmptyString, VultronObject
 
 
@@ -41,6 +41,7 @@ class VultronParticipantStatus(VultronObject):
     context: NonEmptyString  # pyright: ignore[reportGeneralTypeIssues]
     rm_state: RM = RM.START
     vfd_state: CS_vfd = CS_vfd.vfd
+    pxa_state: CS_pxa | None = None
     case_engagement: bool = True
     embargo_adherence: bool = True
     tracking_id: NonEmptyString | None = None
@@ -49,3 +50,7 @@ class VultronParticipantStatus(VultronObject):
     @field_serializer("vfd_state")
     def _serialize_vfd_state(self, v: CS_vfd) -> str:
         return v.name
+
+    @field_serializer("pxa_state")
+    def _serialize_pxa_state(self, v: CS_pxa | None) -> str | None:
+        return v.name if v is not None else None

--- a/vultron/core/models/report_case_link.py
+++ b/vultron/core/models/report_case_link.py
@@ -49,7 +49,7 @@ class VultronReportCaseLink(VultronObject):
         default=None,
         description=(
             "URI of the CaseActor trusted for this case after bootstrap "
-            "validation.  Extracted from the CASE_ACTOR participant in the "
+            "validation.  Extracted from the CASE_MANAGER participant in the "
             "bootstrap snapshot; used to validate subsequent "
             "Announce(VulnerabilityCase) senders (CBT-01-006)."
         ),

--- a/vultron/core/ports/trigger_activity.py
+++ b/vultron/core/ports/trigger_activity.py
@@ -264,6 +264,19 @@ class TriggerActivityPort(Protocol):
         """
         ...
 
+    def add_participant_status_to_participant(
+        self,
+        status_id: str,
+        participant_id: str,
+        actor: str,
+        to: list[str] | None = None,
+    ) -> str:
+        """Create and persist an ``Add(ParticipantStatus, CaseParticipant)`` activity.
+
+        Returns the activity ID (callers only need the ID for outbox queueing).
+        """
+        ...
+
     # -----------------------------------------------------------------------
     # Embargo
     # -----------------------------------------------------------------------

--- a/vultron/core/ports/trigger_service.py
+++ b/vultron/core/ports/trigger_service.py
@@ -133,6 +133,15 @@ class TriggerServicePort(Protocol):
         in_reply_to: str | None = None,
     ) -> dict[str, Any]: ...
 
+    def add_participant_status(
+        self,
+        actor_id: str,
+        case_id: str,
+        rm_state: Any = None,
+        vfd_state: Any = None,
+        pxa_state: Any = None,
+    ) -> dict[str, Any]: ...
+
     # -----------------------------------------------------------------------
     # Embargo triggers
     # -----------------------------------------------------------------------

--- a/vultron/core/states/roles.py
+++ b/vultron/core/states/roles.py
@@ -33,9 +33,10 @@ class CVDRole(StrEnum):
         COORDINATOR: Entity that coordinates the CVD process.
         OTHER: Any other CVD role not captured above.
         CASE_OWNER: Actor who owns and manages a VulnerabilityCase (BTND-05-001).
-        CASE_ACTOR: The ActivityStreams Service actor that performs ongoing case
-            replica synchronisation on behalf of the case owner.  A CaseActor
-            participant always also holds the COORDINATOR role (CBT-01-003).
+        CASE_MANAGER: The ActivityStreams Service actor that performs ongoing case
+            replica synchronisation and manages the case on behalf of the case
+            owner.  A CaseManager participant always also holds the COORDINATOR
+            role (CBT-01-003).
     """
 
     FINDER = auto()
@@ -45,7 +46,7 @@ class CVDRole(StrEnum):
     COORDINATOR = auto()
     OTHER = auto()
     CASE_OWNER = auto()
-    CASE_ACTOR = auto()
+    CASE_MANAGER = auto()
 
 
 def serialize_roles(roles: list[CVDRole]) -> list[str]:

--- a/vultron/core/states/roles.py
+++ b/vultron/core/states/roles.py
@@ -33,10 +33,11 @@ class CVDRole(StrEnum):
         COORDINATOR: Entity that coordinates the CVD process.
         OTHER: Any other CVD role not captured above.
         CASE_OWNER: Actor who owns and manages a VulnerabilityCase (BTND-05-001).
-        CASE_MANAGER: The ActivityStreams Service actor that performs ongoing case
+        CASE_MANAGER: The ActivityStreams Actor that performs ongoing case
             replica synchronisation and manages the case on behalf of the case
             owner.  A CaseManager participant always also holds the COORDINATOR
-            role (CBT-01-003).
+            role (CBT-01-003).  While the demo uses a Service actor type, any
+            Actor type (e.g. Person) may hold this role.
     """
 
     FINDER = auto()

--- a/vultron/core/use_cases/received/case.py
+++ b/vultron/core/use_cases/received/case.py
@@ -34,11 +34,11 @@ logger = logging.getLogger(__name__)
 def _find_case_actor_id_from_participants(
     case_obj: CaseModel, dl: CasePersistence
 ) -> str | None:
-    """Find the CaseActor ID from the CASE_ACTOR participant in the case.
+    """Find the CaseActor ID from the CASE_MANAGER participant in the case.
 
     Uses duck-typing on ``case_roles`` to avoid importing wire-layer types.
     Returns the ``attributed_to`` URI of the first participant holding
-    ``CVDRole.CASE_ACTOR`` (CBT-01-003).
+    ``CVDRole.CASE_MANAGER`` (CBT-01-003).
 
     Handles both inline objects and ID-only references stored in
     ``case_participants``.
@@ -47,7 +47,7 @@ def _find_case_actor_id_from_participants(
         # Try inline object first (participant embedded in snapshot)
         if not isinstance(participant_ref, str):
             roles = getattr(participant_ref, "case_roles", [])
-            if CVDRole.CASE_ACTOR in roles:
+            if CVDRole.CASE_MANAGER in roles:
                 attributed = getattr(participant_ref, "attributed_to", None)
                 if attributed:
                     return str(attributed)
@@ -58,7 +58,7 @@ def _find_case_actor_id_from_participants(
         if participant is None:
             continue
         roles = getattr(participant, "case_roles", [])
-        if CVDRole.CASE_ACTOR in roles:
+        if CVDRole.CASE_MANAGER in roles:
             attributed = getattr(participant, "attributed_to", None)
             if attributed:
                 return str(attributed)
@@ -131,7 +131,7 @@ class CreateCaseReceivedUseCase:
     Bootstrap trust path (CBT-01-005 / CBT-01-006):
     1. Locate the ``VultronReportCaseLink`` for any report listed in the case.
     2. Validate that the sender matches ``link.trusted_case_creator_id``.
-    3. Extract the ``CaseActor`` ID from the ``CASE_ACTOR`` participant.
+    3. Extract the ``CaseActor`` ID from the ``CASE_MANAGER`` participant.
     4. Seed a local replica of the case via the case-replica BT.
     5. Update the link with ``case_id`` and ``trusted_case_actor_id``.
     """
@@ -207,13 +207,13 @@ class CreateCaseReceivedUseCase:
                 case_id,
             )
 
-        # CBT-01-003: extract CaseActor from CASE_ACTOR participant
+        # CBT-01-003: extract CaseActor from CASE_MANAGER participant
         case_actor_id = _find_case_actor_id_from_participants(
             case_obj, self._dl
         )
         if case_actor_id is None:
             logger.warning(
-                "create_case_received: no CASE_ACTOR participant found in "
+                "create_case_received: no CASE_MANAGER participant found in "
                 "bootstrap snapshot for case '%s'; Announce validation will "
                 "be bypassed",
                 case_id,

--- a/vultron/core/use_cases/received/status.py
+++ b/vultron/core/use_cases/received/status.py
@@ -22,6 +22,7 @@ from vultron.core.models.protocols import (
     is_case_model,
     is_participant_model,
 )
+from vultron.errors import VultronError
 
 if TYPE_CHECKING:
     from vultron.core.ports.trigger_activity import TriggerActivityPort
@@ -407,6 +408,16 @@ class AddParticipantStatusToParticipantReceivedUseCase:
                     to=recipient_ids,
                 )
             )
+            # Update the Case Manager actor's outbox to reflect the pending
+            # send, mirroring the pattern used by other received broadcast
+            # handlers (e.g. received/note.py).
+            case_manager_actor = self._dl.read(case_manager_id)
+            if case_manager_actor is not None and hasattr(
+                case_manager_actor, "outbox"
+            ):
+                cast(Any, case_manager_actor).outbox.items.append(activity_id)
+                self._dl.save(case_manager_actor)
+
             self._dl.record_outbox_item(case_manager_id, activity_id)
             logger.info(
                 "add_participant_status_to_participant: Case Manager '%s' "
@@ -415,7 +426,7 @@ class AddParticipantStatusToParticipantReceivedUseCase:
                 status_id,
                 len(recipient_ids),
             )
-        except Exception as exc:
+        except VultronError as exc:
             logger.warning(
                 "add_participant_status_to_participant: broadcast failed: %s",
                 exc,
@@ -436,7 +447,9 @@ class AddParticipantStatusToParticipantReceivedUseCase:
         from vultron.core.states.cs import CS_pxa
         from vultron.core.states.roles import CVDRole
 
-        pxa_state = getattr(status_obj, "pxa_state", None)
+        pxa_state = getattr(
+            getattr(status_obj, "case_status", None), "pxa_state", None
+        )
         if pxa_state is None:
             return
 
@@ -517,7 +530,15 @@ class AddParticipantStatusToParticipantReceivedUseCase:
             statuses = getattr(p, "participant_statuses", [])
             if not statuses:
                 return False
-            latest = statuses[-1]
+            latest_ref = statuses[-1]
+            # Resolve to an object when stored as an ID/ref string.
+            latest = (
+                self._dl.read(_as_id(latest_ref))
+                if isinstance(latest_ref, str)
+                else latest_ref
+            )
+            if latest is None:
+                return False
             rm_state = getattr(latest, "rm_state", None)
             if rm_state is None or rm_state != RM.CLOSED:
                 return False
@@ -527,9 +548,10 @@ class AddParticipantStatusToParticipantReceivedUseCase:
         """Record case-closed event for all case participants (DEMOMA-07-003 step 5).
 
         SvcCloseReportUseCase requires an offer_id (not a report_id), which
-        is unavailable in the received-handler context.  Instead this method
-        emits a log entry to record the auto-close intent, which is sufficient
-        for the prototype demo.
+        is unavailable in the received-handler context.  This method emits a
+        log entry to record the auto-close intent.  Actual case closure is
+        **not** persisted here; this is log-only behaviour for the prototype
+        demo.
         """
         logger.info(
             "add_participant_status_to_participant: Case Manager '%s' "

--- a/vultron/core/use_cases/received/status.py
+++ b/vultron/core/use_cases/received/status.py
@@ -532,11 +532,13 @@ class AddParticipantStatusToParticipantReceivedUseCase:
                 return False
             latest_ref = statuses[-1]
             # Resolve to an object when stored as an ID/ref string.
-            latest = (
-                self._dl.read(_as_id(latest_ref))
-                if isinstance(latest_ref, str)
-                else latest_ref
-            )
+            if isinstance(latest_ref, str):
+                ref_id = _as_id(latest_ref)
+                if ref_id is None:
+                    return False
+                latest = self._dl.read(ref_id)
+            else:
+                latest = latest_ref
             if latest is None:
                 return False
             rm_state = getattr(latest, "rm_state", None)

--- a/vultron/core/use_cases/received/status.py
+++ b/vultron/core/use_cases/received/status.py
@@ -1,7 +1,7 @@
 """Use cases for case and participant status activities."""
 
 import logging
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from vultron.core.models.events.status import (
     AddCaseStatusToCaseReceivedEvent,
@@ -9,7 +9,10 @@ from vultron.core.models.events.status import (
     CreateCaseStatusReceivedEvent,
     CreateParticipantStatusReceivedEvent,
 )
-from vultron.core.ports.case_persistence import CasePersistence
+from vultron.core.ports.case_persistence import (
+    CasePersistence,
+    CaseOutboxPersistence,
+)
 from vultron.core.states.cs import is_valid_pxa_transition
 from vultron.core.states.em import is_valid_em_transition
 from vultron.core.states.rm import is_valid_rm_transition
@@ -19,6 +22,9 @@ from vultron.core.models.protocols import (
     is_case_model,
     is_participant_model,
 )
+
+if TYPE_CHECKING:
+    from vultron.core.ports.trigger_activity import TriggerActivityPort
 
 logger = logging.getLogger(__name__)
 
@@ -166,13 +172,28 @@ class CreateParticipantStatusReceivedUseCase:
 
 
 class AddParticipantStatusToParticipantReceivedUseCase:
+    """Process a received Add(ParticipantStatus, CaseParticipant) message.
+
+    Implements all DEMOMA-07-003 steps:
+    1. Verify sender is a known case participant.
+    2. Append the ParticipantStatus to the CaseParticipant record.
+    3. Broadcast the status update to all other case participants (Case Manager
+       re-sends Add(ParticipantStatus, CaseParticipant) on behalf of the
+       sender).
+    4. If the new status signals public awareness (pxa_state.P) and the sender
+       holds the CASE_OWNER role, initiate embargo teardown.
+    5. If all participant RM states are CLOSED, mark the case closed.
+    """
+
     def __init__(
         self,
-        dl: CasePersistence,
+        dl: CaseOutboxPersistence,
         request: AddParticipantStatusToParticipantReceivedEvent,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: AddParticipantStatusToParticipantReceivedEvent = request
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> None:
         request = self._request
@@ -183,14 +204,83 @@ class AddParticipantStatusToParticipantReceivedUseCase:
                 "add_participant_status_to_participant: missing status_id or participant_id"
             )
             return
-        participant = self._dl.read(participant_id)
 
+        # Steps 1+2: verify sender, then append status
+        result = self._verify_and_append(request, status_id, participant_id)
+        if result is None:
+            return
+        actor_id, case_id, case, status_obj = result
+
+        # ---- Step 3: broadcast to peers -----------------------------------
+        self._broadcast_status_to_peers(
+            status_id, participant_id, actor_id, case_id, case
+        )
+
+        # ---- Step 4: embargo teardown on public disclosure ----------------
+        self._check_public_disclosure(status_obj, actor_id, case_id, case)
+
+        # ---- Step 5: auto-close if all participants CLOSED ----------------
+        self._check_all_closed(case_id, case)
+
+    def _verify_and_append(
+        self,
+        request: AddParticipantStatusToParticipantReceivedEvent,
+        status_id: str,
+        participant_id: str,
+    ) -> "tuple[str, str, Any, Any] | None":
+        """Verify sender is a known participant and append status to participant.
+
+        Returns ``(actor_id, case_id, case, status_obj)`` on success, else None.
+        """
+        # ---- Step 1: verify sender is a known case participant ------------
+        actor_id = request.actor_id
+        status_raw = self._dl.read(status_id) or request.status
+        case_id = str(getattr(status_raw, "context", "")) or None
+
+        if case_id is None:
+            logger.warning(
+                "add_participant_status_to_participant: cannot determine case_id"
+            )
+            return None
+
+        case = self._dl.read(case_id)
+        if not is_case_model(case):
+            logger.warning(
+                "add_participant_status_to_participant: case '%s' not found",
+                case_id,
+            )
+            return None
+
+        if actor_id not in case.actor_participant_index:
+            logger.warning(
+                "add_participant_status_to_participant: actor '%s' is not a "
+                "known participant of case '%s' — rejecting",
+                actor_id,
+                case_id,
+            )
+            return None
+
+        # ---- Step 2: append status to participant -------------------------
+        status_obj = self._append_status(request, status_id, participant_id)
+        if status_obj is None:
+            return None
+
+        return actor_id, case_id, case, status_obj
+
+    def _append_status(
+        self,
+        request: AddParticipantStatusToParticipantReceivedEvent,
+        status_id: str,
+        participant_id: str,
+    ) -> Any:
+        """Append ParticipantStatus to participant; return status object or None."""
+        participant = self._dl.read(participant_id)
         if not is_participant_model(participant):
             logger.warning(
                 "add_participant_status_to_participant: participant '%s' not found",
                 participant_id,
             )
-            return
+            return None
 
         existing_ids = [_as_id(s) for s in participant.participant_statuses]
         if status_id in existing_ids:
@@ -199,11 +289,8 @@ class AddParticipantStatusToParticipantReceivedUseCase:
                 status_id,
                 participant_id,
             )
-            return
+            return None
 
-        # Prefer the domain object from the event over dl.read, which may
-        # return a raw TinyDB Document when VultronParticipantStatus
-        # reconstitution fails.
         status_obj = self._dl.read(status_id)
         if not hasattr(status_obj, "id_"):
             status_obj = request.status
@@ -212,7 +299,7 @@ class AddParticipantStatusToParticipantReceivedUseCase:
                 "add_participant_status_to_participant: status '%s' not found",
                 status_id,
             )
-            return
+            return None
         if not hasattr(status_obj, "rm_state") or not hasattr(
             status_obj, "vfd_state"
         ):
@@ -220,7 +307,7 @@ class AddParticipantStatusToParticipantReceivedUseCase:
                 "add_participant_status_to_participant: status '%s' is not a ParticipantStatus",
                 status_id,
             )
-            return
+            return None
 
         new_rm_state = getattr(status_obj, "rm_state", None)
         if new_rm_state is not None and participant.participant_statuses:
@@ -241,7 +328,7 @@ class AddParticipantStatusToParticipantReceivedUseCase:
                     new_rm_state,
                     participant_id,
                 )
-                return
+                return None
 
         participant.participant_statuses.append(
             cast(ParticipantStatusModel, status_obj)
@@ -252,3 +339,230 @@ class AddParticipantStatusToParticipantReceivedUseCase:
             status_id,
             participant_id,
         )
+        return status_obj
+
+    def _find_case_manager_id(self, case: Any) -> str | None:
+        """Return the attributed_to actor ID for the CASE_MANAGER participant."""
+        from vultron.core.states.roles import CVDRole
+
+        for p_id in case.actor_participant_index.values():
+            p = self._dl.read(p_id)
+            if p is None:
+                continue
+            roles = getattr(p, "case_roles", [])
+            if CVDRole.CASE_MANAGER in roles:
+                attr = getattr(p, "attributed_to", None)
+                if attr:
+                    return str(attr)
+        return None
+
+    def _broadcast_status_to_peers(
+        self,
+        status_id: str,
+        participant_id: str,
+        sender_actor_id: str,
+        case_id: str,
+        case: Any,
+    ) -> None:
+        """Broadcast Add(ParticipantStatus, CaseParticipant) to other participants.
+
+        The Case Manager re-sends the status to all participants except the
+        original sender (DEMOMA-07-003 step 3).
+        """
+        if self._trigger_activity is None:
+            logger.debug(
+                "add_participant_status_to_participant: no trigger_activity "
+                "— skipping broadcast (DEMOMA-07-003 step 3)"
+            )
+            return
+
+        case_manager_id = self._find_case_manager_id(case)
+        if case_manager_id is None:
+            logger.debug(
+                "add_participant_status_to_participant: no CASE_MANAGER found "
+                "in case '%s' — skipping broadcast",
+                case_id,
+            )
+            return
+
+        recipient_ids = [
+            a_id
+            for a_id in case.actor_participant_index.keys()
+            if a_id != sender_actor_id and a_id != case_manager_id
+        ]
+        if not recipient_ids:
+            logger.debug(
+                "add_participant_status_to_participant: no eligible recipients "
+                "in case '%s' — skipping broadcast",
+                case_id,
+            )
+            return
+
+        try:
+            activity_id = (
+                self._trigger_activity.add_participant_status_to_participant(
+                    status_id=status_id,
+                    participant_id=participant_id,
+                    actor=case_manager_id,
+                    to=recipient_ids,
+                )
+            )
+            self._dl.record_outbox_item(case_manager_id, activity_id)
+            logger.info(
+                "add_participant_status_to_participant: Case Manager '%s' "
+                "broadcast status '%s' to %d peer(s) (DEMOMA-07-003 step 3)",
+                case_manager_id,
+                status_id,
+                len(recipient_ids),
+            )
+        except Exception as exc:
+            logger.warning(
+                "add_participant_status_to_participant: broadcast failed: %s",
+                exc,
+            )
+
+    def _check_public_disclosure(
+        self,
+        status_obj: Any,
+        actor_id: str,
+        case_id: str,
+        case: Any,
+    ) -> None:
+        """Trigger embargo teardown if public disclosure detected (DEMOMA-07-003 step 4).
+
+        Condition: new status pxa_state has PUBLIC_AWARE set AND sender holds
+        CASE_OWNER role.
+        """
+        from vultron.core.states.cs import CS_pxa
+        from vultron.core.states.roles import CVDRole
+
+        pxa_state = getattr(status_obj, "pxa_state", None)
+        if pxa_state is None:
+            return
+
+        # Check if P (public aware) is set
+        try:
+            public_aware = pxa_state in (
+                CS_pxa.Pxa,
+                CS_pxa.PxA,
+                CS_pxa.PXa,
+                CS_pxa.PXA,
+            )
+        except Exception:
+            return
+
+        if not public_aware:
+            return
+
+        # Check sender is CASE_OWNER
+        sender_participant_id = case.actor_participant_index.get(actor_id)
+        if sender_participant_id is None:
+            return
+
+        sender_participant = self._dl.read(sender_participant_id)
+        roles = getattr(sender_participant, "case_roles", [])
+        if CVDRole.CASE_OWNER not in roles:
+            return
+
+        logger.info(
+            "add_participant_status_to_participant: public disclosure detected "
+            "from CASE_OWNER '%s' — initiating embargo teardown for case '%s' "
+            "(DEMOMA-07-003 step 4)",
+            actor_id,
+            case_id,
+        )
+
+        case_manager_id = self._find_case_manager_id(case)
+        if case_manager_id is None:
+            logger.warning(
+                "add_participant_status_to_participant: no Case Manager found "
+                "— cannot initiate embargo teardown for case '%s'",
+                case_id,
+            )
+            return
+
+        try:
+            from vultron.core.use_cases.triggers.embargo import (
+                SvcTerminateEmbargoUseCase,
+            )
+            from vultron.core.use_cases.triggers.requests import (
+                TerminateEmbargoTriggerRequest,
+            )
+
+            req = TerminateEmbargoTriggerRequest(
+                actor_id=case_manager_id,
+                case_id=case_id,
+            )
+            SvcTerminateEmbargoUseCase(
+                self._dl,
+                req,
+                trigger_activity=self._trigger_activity,
+            ).execute()
+        except Exception as exc:
+            logger.warning(
+                "add_participant_status_to_participant: embargo teardown "
+                "failed for case '%s': %s",
+                case_id,
+                exc,
+            )
+
+    def _all_participants_closed(self, case: Any) -> bool:
+        """Return True if every participant has RM.CLOSED as their latest status."""
+        from vultron.core.states.rm import RM
+
+        for p_id in case.actor_participant_index.values():
+            p = self._dl.read(p_id)
+            if p is None:
+                return False
+            statuses = getattr(p, "participant_statuses", [])
+            if not statuses:
+                return False
+            latest = statuses[-1]
+            rm_state = getattr(latest, "rm_state", None)
+            if rm_state is None or rm_state != RM.CLOSED:
+                return False
+        return True
+
+    def _close_case_reports(self, case_manager_id: str, case: Any) -> None:
+        """Record case-closed event for all case participants (DEMOMA-07-003 step 5).
+
+        SvcCloseReportUseCase requires an offer_id (not a report_id), which
+        is unavailable in the received-handler context.  Instead this method
+        emits a log entry to record the auto-close intent, which is sufficient
+        for the prototype demo.
+        """
+        logger.info(
+            "add_participant_status_to_participant: Case Manager '%s' "
+            "auto-closing case '%s' — all participants CLOSED",
+            case_manager_id,
+            getattr(case, "id_", "?"),
+        )
+
+    def _check_all_closed(self, case_id: str, case: Any) -> None:
+        """Close the case if all participants have RM.CLOSED (DEMOMA-07-003 step 5)."""
+        if not self._all_participants_closed(case):
+            return
+
+        logger.info(
+            "add_participant_status_to_participant: all participants CLOSED "
+            "in case '%s' — marking case closed (DEMOMA-07-003 step 5)",
+            case_id,
+        )
+        case_manager_id = self._find_case_manager_id(case)
+        if case_manager_id is None:
+            logger.warning(
+                "add_participant_status_to_participant: no Case Manager found "
+                "— cannot auto-close case '%s'",
+                case_id,
+            )
+            return
+
+        try:
+            self._close_case_reports(case_manager_id, case)
+        except Exception as exc:
+            logger.warning(
+                "add_participant_status_to_participant: auto-close failed for "
+                "case '%s': %s",
+                case_id,
+                exc,
+            )

--- a/vultron/core/use_cases/triggers/case.py
+++ b/vultron/core/use_cases/triggers/case.py
@@ -338,6 +338,7 @@ class SvcAddParticipantStatusUseCase:
         from vultron.core.models.participant_status import (
             VultronParticipantStatus,
         )
+        from vultron.core.models.case_status import VultronCaseStatus
         from vultron.core.states.rm import RM
         from vultron.core.states.cs import CS_vfd
 
@@ -364,6 +365,22 @@ class SvcAddParticipantStatusUseCase:
                 f"actor '{actor_id}' not in case '{case_id}'",
             )
 
+        # Build embedded CaseStatus if a participant-perspective pxa_state was
+        # provided; inherit em_state from the current case-level status.
+        case_status: VultronCaseStatus | None = None
+        if request.pxa_state is not None:
+            current_em = getattr(
+                getattr(case, "current_status", None), "em_state", None
+            )
+            from vultron.core.states.em import EM
+
+            case_status = VultronCaseStatus(
+                context=case_id,
+                attributed_to=actor_id,
+                em_state=current_em if current_em is not None else EM.NONE,
+                pxa_state=request.pxa_state,
+            )
+
         # Build and persist the status object
         status = VultronParticipantStatus(
             context=case_id,
@@ -376,7 +393,7 @@ class SvcAddParticipantStatusUseCase:
                 if request.vfd_state is not None
                 else CS_vfd.vfd
             ),
-            pxa_state=request.pxa_state,
+            case_status=case_status,
         )
         try:
             dl.create(status)
@@ -396,14 +413,19 @@ class SvcAddParticipantStatusUseCase:
                     case_manager_id = str(case_manager_id)
                 break
 
-        to = [case_manager_id] if case_manager_id else None
+        if case_manager_id is None:
+            raise VultronNotFoundError(
+                "CaseParticipant",
+                f"no CASE_MANAGER found in case '{case_id}'"
+                " — cannot send status update",
+            )
 
         activity_id = (
             self._trigger_activity.add_participant_status_to_participant(
                 status_id=status.id_,
                 participant_id=participant_id,
                 actor=actor_id,
-                to=to,
+                to=[case_manager_id],
             )
         )
 

--- a/vultron/core/use_cases/triggers/case.py
+++ b/vultron/core/use_cases/triggers/case.py
@@ -34,6 +34,7 @@ from vultron.core.use_cases.triggers._helpers import (
 )
 from vultron.core.use_cases.triggers.requests import (
     AddObjectToCaseTriggerRequest,
+    AddParticipantStatusTriggerRequest,
     AddReportToCaseTriggerRequest,
     CreateCaseTriggerRequest,
     DeferCaseTriggerRequest,
@@ -313,3 +314,106 @@ class SvcAddReportToCaseUseCase:
             trigger_activity=self._trigger_activity,
         )
         return inner.execute()
+
+
+class SvcAddParticipantStatusUseCase:
+    """Self-report actor RM/VFD/PXA state to the Case Manager.
+
+    Creates a VultronParticipantStatus object, saves it, then emits an
+    Add(ParticipantStatus, target=CaseParticipant) activity addressed to the
+    Case Manager (DEMOMA-07-001).
+    """
+
+    def __init__(
+        self,
+        dl: CaseOutboxPersistence,
+        request: AddParticipantStatusTriggerRequest,
+        trigger_activity: "TriggerActivityPort | None" = None,
+    ) -> None:
+        self._dl = dl
+        self._request = request
+        self._trigger_activity = trigger_activity
+
+    def execute(self) -> dict[str, Any]:
+        from vultron.core.models.participant_status import (
+            VultronParticipantStatus,
+        )
+        from vultron.core.states.rm import RM
+        from vultron.core.states.cs import CS_vfd
+
+        request = self._request
+        actor_id = request.actor_id
+        case_id = request.case_id
+        dl = self._dl
+
+        actor = resolve_actor(actor_id, dl)
+        actor_id = actor.id_
+
+        case = resolve_case(case_id, dl)
+
+        if self._trigger_activity is None:
+            raise RuntimeError(
+                "SvcAddParticipantStatusUseCase requires a TriggerActivityPort"
+            )
+
+        # Look up the actor's participant record ID
+        participant_id = case.actor_participant_index.get(actor_id)
+        if participant_id is None:
+            raise VultronNotFoundError(
+                "CaseParticipant",
+                f"actor '{actor_id}' not in case '{case_id}'",
+            )
+
+        # Build and persist the status object
+        status = VultronParticipantStatus(
+            context=case_id,
+            attributed_to=actor_id,
+            rm_state=(
+                request.rm_state if request.rm_state is not None else RM.START
+            ),
+            vfd_state=(
+                request.vfd_state
+                if request.vfd_state is not None
+                else CS_vfd.vfd
+            ),
+            pxa_state=request.pxa_state,
+        )
+        try:
+            dl.create(status)
+        except ValueError:
+            dl.save(status)
+
+        # Find Case Manager ID to address activity
+        from vultron.core.states.roles import CVDRole
+
+        case_manager_id: str | None = None
+        for p_id in case.actor_participant_index.values():
+            p = dl.read(p_id)
+            roles = getattr(p, "case_roles", [])
+            if CVDRole.CASE_MANAGER in roles:
+                case_manager_id = getattr(p, "attributed_to", None)
+                if case_manager_id:
+                    case_manager_id = str(case_manager_id)
+                break
+
+        to = [case_manager_id] if case_manager_id else None
+
+        activity_id = (
+            self._trigger_activity.add_participant_status_to_participant(
+                status_id=status.id_,
+                participant_id=participant_id,
+                actor=actor_id,
+                to=to,
+            )
+        )
+
+        add_activity_to_outbox(actor_id, activity_id, dl)
+
+        logger.info(
+            "Actor '%s' reported status to participant '%s' in case '%s'",
+            actor_id,
+            participant_id,
+            case_id,
+        )
+
+        return {"activity_id": activity_id, "status_id": status.id_}

--- a/vultron/core/use_cases/triggers/requests.py
+++ b/vultron/core/use_cases/triggers/requests.py
@@ -17,6 +17,8 @@ from datetime import datetime, timezone
 from pydantic import BaseModel, ConfigDict, field_validator
 
 from vultron.core.models.base import NonEmptyString, UriString
+from vultron.core.states.cs import CS_vfd, CS_pxa
+from vultron.core.states.rm import RM
 
 
 class TriggerRequest(BaseModel):
@@ -198,3 +200,15 @@ class InviteActorToCaseTriggerRequest(CaseTriggerRequest):
     """
 
     invitee_id: NonEmptyString
+
+
+class AddParticipantStatusTriggerRequest(CaseTriggerRequest):
+    """Trigger request to send a ParticipantStatus update to the case.
+
+    The actor self-reports their current RM/VFD/PXA state to the Case Manager.
+    Emits an Add(ParticipantStatus, target=CaseParticipant) activity.
+    """
+
+    rm_state: RM | None = None
+    vfd_state: CS_vfd | None = None
+    pxa_state: CS_pxa | None = None

--- a/vultron/core/use_cases/triggers/service.py
+++ b/vultron/core/use_cases/triggers/service.py
@@ -47,6 +47,7 @@ from vultron.core.use_cases.triggers.actor import (
 )
 from vultron.core.use_cases.triggers.case import (
     SvcAddObjectToCaseUseCase,
+    SvcAddParticipantStatusUseCase,
     SvcAddReportToCaseUseCase,
     SvcCreateCaseUseCase,
     SvcDeferCaseUseCase,
@@ -72,6 +73,7 @@ from vultron.core.use_cases.triggers.requests import (
     AcceptEmbargoTriggerRequest,
     AddNoteToCaseTriggerRequest,
     AddObjectToCaseTriggerRequest,
+    AddParticipantStatusTriggerRequest,
     AddReportToCaseTriggerRequest,
     CloseReportTriggerRequest,
     CreateCaseTriggerRequest,
@@ -287,6 +289,26 @@ class TriggerService:
             in_reply_to=in_reply_to,
         )
         return SvcAddNoteToCaseUseCase(
+            self._dl, req, trigger_activity=self._trigger_activity
+        ).execute()
+
+    def add_participant_status(
+        self,
+        actor_id: str,
+        case_id: str,
+        rm_state: Any = None,
+        vfd_state: Any = None,
+        pxa_state: Any = None,
+    ) -> dict[str, Any]:
+        """Self-report actor RM/VFD/PXA state to the Case Manager (DEMOMA-07-001)."""
+        req = AddParticipantStatusTriggerRequest(
+            actor_id=actor_id,
+            case_id=case_id,
+            rm_state=rm_state,
+            vfd_state=vfd_state,
+            pxa_state=pxa_state,
+        )
+        return SvcAddParticipantStatusUseCase(
             self._dl, req, trigger_activity=self._trigger_activity
         ).execute()
 

--- a/vultron/wire/as2/extractor.py
+++ b/vultron/wire/as2/extractor.py
@@ -610,6 +610,26 @@ def _build_participant_status_object(obj: object) -> dict[str, Any]:
     ctx = _get_id(getattr(obj, "context", None)) or ""
     wire_case_status = getattr(obj, "case_status", None)
     if object_id:
+        # Extract embedded CaseStatus into a VultronCaseStatus core object so
+        # that pxa_state and em_state are propagated across the wire boundary.
+        core_case_status: VultronCaseStatus | None = None
+        if wire_case_status is not None:
+            cs_id = _get_id(wire_case_status)
+            cs_context = (
+                _get_id(getattr(wire_case_status, "context", None)) or ctx
+            )
+            if cs_id and cs_context:
+                core_case_status = VultronCaseStatus(
+                    id_=cs_id,
+                    context=cs_context,
+                    attributed_to=_get_id(
+                        getattr(wire_case_status, "attributed_to", None)
+                    ),
+                    em_state=getattr(wire_case_status, "em_state", None)
+                    or VultronCaseStatus.model_fields["em_state"].default,
+                    pxa_state=getattr(wire_case_status, "pxa_state", None)
+                    or VultronCaseStatus.model_fields["pxa_state"].default,
+                )
         return {
             "object_": VultronParticipantStatus(
                 id_=object_id,
@@ -620,12 +640,7 @@ def _build_participant_status_object(obj: object) -> dict[str, Any]:
                 or VultronParticipantStatus.model_fields["rm_state"].default,
                 vfd_state=getattr(obj, "vfd_state", None)
                 or VultronParticipantStatus.model_fields["vfd_state"].default,
-                pxa_state=getattr(obj, "pxa_state", None),
-                case_status=(
-                    _get_id(wire_case_status)
-                    if wire_case_status is not None
-                    else None
-                ),
+                case_status=core_case_status,
             )
         }
     return {}

--- a/vultron/wire/as2/extractor.py
+++ b/vultron/wire/as2/extractor.py
@@ -435,7 +435,7 @@ def _participant_ref_to_domain(ref: object) -> str | VultronParticipant | None:
     a plain string if it is a URI reference, or ``None`` if the ref is
     unusable.  This preserves participant metadata — including role lists —
     across the wire→domain extraction boundary so bootstrap trust logic can
-    inspect ``CVDRole.CASE_ACTOR`` on the extracted case (CBT-01-003).
+    inspect ``CVDRole.CASE_MANAGER`` on the extracted case (CBT-01-003).
     """
     if isinstance(ref, str):
         return ref if ref else None
@@ -620,6 +620,7 @@ def _build_participant_status_object(obj: object) -> dict[str, Any]:
                 or VultronParticipantStatus.model_fields["rm_state"].default,
                 vfd_state=getattr(obj, "vfd_state", None)
                 or VultronParticipantStatus.model_fields["vfd_state"].default,
+                pxa_state=getattr(obj, "pxa_state", None),
                 case_status=(
                     _get_id(wire_case_status)
                     if wire_case_status is not None

--- a/vultron/wire/as2/vocab/objects/case_participant.py
+++ b/vultron/wire/as2/vocab/objects/case_participant.py
@@ -378,7 +378,7 @@ class OtherParticipant(CaseParticipant):
 class CaseActorParticipant(CaseParticipant):
     """A participant that acts as the CaseActor service for a VulnerabilityCase.
 
-    Holds both ``COORDINATOR`` and ``CASE_ACTOR`` roles (CBT-01-003).  The
+    Holds both ``COORDINATOR`` and ``CASE_MANAGER`` roles (CBT-01-003).  The
     ``attributed_to`` field identifies the ActivityStreams Service URI that
     will send ``Announce(VulnerabilityCase)`` updates on behalf of the case
     owner.  Receivers use this participant to establish trusted CaseActor
@@ -387,10 +387,10 @@ class CaseActorParticipant(CaseParticipant):
 
     @model_validator(mode="after")
     def set_role(self):
-        """Set both COORDINATOR and CASE_ACTOR roles."""
+        """Set both COORDINATOR and CASE_MANAGER roles."""
         self.case_roles = []
         self.add_role(CVDRole.COORDINATOR)
-        self.add_role(CVDRole.CASE_ACTOR)
+        self.add_role(CVDRole.CASE_MANAGER)
         return self
 
 

--- a/vultron/wire/as2/vocab/objects/case_status.py
+++ b/vultron/wire/as2/vocab/objects/case_status.py
@@ -157,11 +157,14 @@ class ParticipantStatus(VultronAS2Object):
         data = core_obj.model_dump(mode="json")
         case_status = data.get("case_status")
         if isinstance(case_status, str):
+            # Legacy: case_status stored as bare ID string
             data["case_status"] = CaseStatus(
                 id_=case_status,
                 context=data.get("context"),
                 attributed_to=data.get("attributed_to"),
             )
+        # If case_status is a dict (from VultronCaseStatus serialisation),
+        # cls.model_validate will hydrate it into a CaseStatus instance.
         return cls.model_validate(data)
 
     def to_core(self) -> VultronParticipantStatus:
@@ -170,7 +173,18 @@ class ParticipantStatus(VultronAS2Object):
             data.get("attributed_to")
         )
         data["context"] = _scalar_ref_id_or_value(data.get("context"))
-        data["case_status"] = _scalar_ref_id_or_value(data.get("case_status"))
+        # Convert embedded CaseStatus wire object (or its serialised dict) to
+        # VultronCaseStatus so pxa_state and em_state cross the boundary.
+        wire_case_status = data.get("case_status")
+        if isinstance(wire_case_status, CaseStatus):
+            data["case_status"] = wire_case_status.to_core()
+        elif isinstance(wire_case_status, dict):
+            # _to_core_data() with round_trip=True serialises nested objects
+            # as dicts; re-validate and convert.
+            cs_obj = CaseStatus.model_validate(wire_case_status)
+            data["case_status"] = cs_obj.to_core()
+        else:
+            data["case_status"] = None
         if isinstance(data.get("vfd_state"), str):
             data["vfd_state"] = CS_vfd[data["vfd_state"]]
         return VultronParticipantStatus.model_validate(data)


### PR DESCRIPTION
## Summary

Implements Sub-issue B (Issue #461) of Priority 470 (Two-Actor Demo Redesign).

## Changes

### CVDRole.CASE_ACTOR → CVDRole.CASE_MANAGER rename
Renamed the enum member across all 20 files (code, comments, tests).

### pxa_state added to VultronParticipantStatus
Added `pxa_state: CS_pxa | None = None` with field_serializer; extractor updated to extract it.

### SvcAddParticipantStatusUseCase (new trigger use case)
Self-reports actor RM/VFD/PXA state to the Case Manager via `Add(ParticipantStatus, target=CaseParticipant)`.

### 4 demo trigger endpoints
- `POST /actors/{id}/demo/notify-fix-ready` — VFD state VFd
- `POST /actors/{id}/demo/notify-fix-deployed` — VFD state VFD
- `POST /actors/{id}/demo/notify-published` — VFD=VFD + PXA=Pxa
- `POST /actors/{id}/demo/close-case` — RM.CLOSED

### Enhanced AddParticipantStatusToParticipantReceivedUseCase
Full DEMOMA-07-003 implementation:
1. Verify sender is known case participant
2. Append status (existing behavior)
3. Broadcast status to peers via Case Manager's outbox
4. Trigger embargo teardown on public disclosure (if sender is CASE_OWNER)
5. Log auto-close intent when all participants RM.CLOSED

Closes #461