### PR TITLE
feat: Case Actor spawning and CASE_MANAGER delegation automation (#469)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,6 +39,57 @@ Always format Python sources with Black and run `flake8` before staging
 changes for commit. Do not run Black on markdown files — use
 `markdownlint-cli2` for those.
 
+## Deep Reference
+
+For Vultron-specific architectural rules, naming conventions, validation patterns,
+GitHub label naming, and the complete reference index, see **`AGENTS.md`** — the
+authoritative guide for Vultron coding agents. This file focuses on platform-agnostic
+setup and quick tactical guidance.
+
+---
+
+## Common Pitfalls & Type Checking
+
+### mypy/pyright: dict Variance and Protocol Types
+
+mypy and pyright are strict about type variance. If you encounter an error like
+"`dict[K, V]` is not assignable to `dict[K, V] | None`", the issue is likely
+that `V` involves a callable with a `Protocol` type parameter. **Fix this by
+switching to `Mapping[K, V]` (covariant in value type) instead of `dict`.**
+Both `mypy` and `pyright` must pass before committing.
+
+### Spec File Format & References
+
+All Vultron specifications are **YAML files** (`.yaml`, not `.md`). When you
+need to reference a spec, use `uv run spec-dump` or invoke the `load-specs`
+skill to get the authoritative, inheritance-resolved JSON view. **Never
+construct spec file paths manually** — the load-specs output is the source of
+truth.
+
+### History File Immutability Exceptions
+
+`plan/history/` files are normally immutable (enforced by pre-commit), but you
+**SHOULD override immutability in two cases**:
+1. **Corrupt or impossible dates** — fix entries with future dates or other data
+   errors using git blame to determine correct timestamps
+2. **Explicit user override** — when the user explicitly asks you to override
+   immutability rules
+
+Use `uv run append-history` to add new history entries (never append directly).
+Reference: `specs/history-management.yaml` § HM-03.
+
+### Test Suite Runtime Expectations
+
+The full pytest suite can take **60–120+ seconds** to complete. Use
+`initial_wait: 180` when running `pytest` in sync mode. Long-running tests are
+normal. For faster feedback during development, run a single test file:
+`uv run pytest test/test_semantic_activity_patterns.py -v`.
+
+For the single-run rule and full test suite guidance, see **`AGENTS.md`**
+§ Agent Quickstart and § Commit Workflow.
+
+---
+
 ## Architecture
 
 ### Hexagonal (Ports and Adapters)
@@ -86,12 +137,10 @@ Handlers never inspect AS2 types directly.
 
 ### Naming
 
-- Wire-layer AS2 fields/types use `as_` prefix (e.g., `as_Activity`, `as_type`)
-- Core domain models do **not** use `as_` prefix; use `field_: str = Field(alias="field")` for reserved-word conflicts
-- Vulnerability abbreviation: **`vul`** (not `vuln`)
-- Handler use cases (processing received messages): `XxxReceivedUseCase`
-- Trigger use cases (actor-initiated): `SvcXxxUseCase` (class) / `xxx_trigger` (function)
-- `ActivityPattern` objects: `<TypeName>Pattern` (e.g., `CreateReportPattern`)
+See **`AGENTS.md`** § Naming Conventions for the complete set of Vultron naming
+rules (22 detailed conventions): `as_` prefix usage, field naming with
+reserved-word conflicts, handler vs. trigger case naming, pattern object
+naming, and more. All conventions are binding and enforced by tests.
 
 ### Use-Case Protocol
 
@@ -160,9 +209,15 @@ require an ADR before merging.
 
 ## Further Reference
 
-- `AGENTS.md` — comprehensive agent rules and common pitfalls
-- `specs/` — formal requirements with unique IDs (e.g., `HP-01-001`)
-- `notes/` — durable design insights (architecture, BT integration, AS2 semantics)
-- `docs/adr/` — architecture decision records
+**Primary reference for Vultron agents:**
+- **`AGENTS.md`** — Comprehensive guide with: naming conventions, validation rules,
+  architecture deep-dive, key files map, common pitfalls reference index, complete
+  GitHub label naming rules, change protocol, and skill interaction rules. This is
+  the authoritative source for Vultron-specific guidance.
+
+**Supplementary:**
+- `specs/` — Formal requirements with unique IDs (e.g., `HP-01-001`)
+- `notes/` — Durable design insights (architecture, BT integration, AS2 semantics)
+- `docs/adr/` — Architecture decision records
 - `.agents/skills/format-code/SKILL.md`, `.agents/skills/run-linters/SKILL.md`,
-  `.agents/skills/run-tests/SKILL.md` — canonical format, lint, and test commands
+  `.agents/skills/run-tests/SKILL.md` — Canonical format, lint, and test commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,7 +253,9 @@ to relevant tests and design notes.
 
 1. `format-code` — Black + flake8
 2. `run-linters` — all four linters (Black, flake8, mypy, pyright); all MUST pass
-3. `run-tests` — unit suite once; read output
+3. `run-tests` — unit suite once; read output.
+   **If any `vultron/demo/` or `test/demo/` files were modified**, also run
+   the full suite (CI always does): `uv run pytest -m "" --tb=short 2>&1 | tail -5`
 4. `build-docs` — only when `docs/` files were modified
 5. `commit` skill — include Co-authored-by trailer
 
@@ -361,6 +363,15 @@ provides unique ID constraints. Report handlers (`create_report`,
   `in_reply_to`) MUST be converted to `str | None` using `_get_id(field)` before
   assigning to a `NonEmptyString | None` snapshot field — passing the raw AS2
   object directly is a type error that mypy will catch only after extraction.
+- **CI Runs All Tests; Default Local Run Omits Integration** — `pytest` (default
+  local, via `addopts`) excludes `@pytest.mark.integration` tests. CI always
+  runs `pytest -m ""` which includes them. Demo scenario files
+  (`vultron/demo/scenario/`) contain assertion functions (e.g.,
+  `verify_vendor_case_state`) with hardcoded participant counts and state
+  expectations that break silently in the unit suite but fail in CI. Whenever
+  you touch any file under `vultron/demo/` or `test/demo/`, you MUST run the
+  full suite before committing: `uv run pytest -m "" --tb=short 2>&1 | tail -5`.
+  See the Commit Workflow section above.
 
 > **Parallelism and Single-Agent Testing** has moved to `test/AGENTS.md`.
 >

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -316,6 +316,8 @@ provides unique ID constraints. Report handlers (`create_report`,
 - **Protocol Event Cascades (Cascading Automation)** — see [notes/bt-integration.md](notes/bt-integration.md)
 - **Post-BT Procedural Cascade Anti-Pattern** — see [notes/bt-integration.md](notes/bt-integration.md)
 - **py_trees Blackboard Global State** — see [notes/bt-integration.md](notes/bt-integration.md)
+- **py_trees `blackboard.get()` Raises KeyError for Unwritten READ Keys** — see [notes/bt-integration.md](notes/bt-integration.md)
+- **Duplicate Method Definitions Silently Shadow Correct BT Logic** — see [notes/bt-integration.md](notes/bt-integration.md)
 - **BT Blackboard Key Naming** — see [notes/bt-integration.md](notes/bt-integration.md)
 - **Health Check Readiness Gap** — see [notes/codebase-structure.md](notes/codebase-structure.md)
 - **Docker Health Check Coordination** — see [notes/codebase-structure.md](notes/codebase-structure.md)

--- a/notes/bt-integration.md
+++ b/notes/bt-integration.md
@@ -734,3 +734,41 @@ When a backlog bug may already be fixed by unrelated work, close it with
 **Anti-pattern**: Treating "I can't reproduce it" as sufficient closure — the
 fix may be coincidental and fragile. Concrete evidence ensures it won't
 silently regress.
+
+### py_trees `blackboard.get()` Raises KeyError for Unwritten READ Keys
+
+`Client.get(key)` does **not** return `None` when a key is registered for
+`Access.READ` but has not yet been written to `Blackboard.storage`. It raises
+`KeyError`. This has two consequences:
+
+1. **Test nodes return wrong status** — if `update()` calls `get()` on an
+   unwritten key, the `KeyError` propagates out of `update()`. If the node
+   has a broad `except Exception` block, it catches the error and returns
+   `FAILURE` — but if the `KeyError` propagates all the way to `execute_tree()`
+   and the outer `except Exception` there returns `FAILURE`, a test expecting
+   `SUCCESS` will correctly fail. However if the `KeyError` is caught somewhere
+   that swallows it silently, status can be wrong.
+
+2. **Silent node shadowing** — a more insidious variant occurred during
+   development of `SendOfferCaseManagerRoleNode`: the class body of
+   `EmitCreateCaseActivity` was accidentally embedded *inside*
+   `SendOfferCaseManagerRoleNode` (as a duplicate `__init__`, `setup`, and
+   `update()` defined later in the same class body). Python resolves to the
+   *last* definition, so the correct `update()` was silently replaced by the
+   embedded one. The embedded `setup()` only registered `case_id`, so
+   `get("case_actor_id")` never raised — it was never even called. The node
+   returned `SUCCESS` whenever `case_id` was present, masking the real logic
+   entirely.
+
+**Rules**:
+
+- Use `Blackboard.storage.get("/key")` (with the leading `/` prefix that
+  py_trees uses internally) only in tests to inspect raw storage — never in
+  production node code.
+- In production `update()`, use `self.blackboard.get(key)` knowing it will
+  raise if the key is unset. Guard with an explicit `try/except KeyError` or
+  ensure the key is always written before being read (i.e., the writing node
+  precedes the reading node in the sequence).
+- When a new node class is added to a file, **always verify class boundaries
+  with `grep -n "^class " <file>`** before committing. Python silently accepts
+  duplicate method definitions within a class; the last definition wins.

--- a/plan/PRIORITIES.md
+++ b/plan/PRIORITIES.md
@@ -26,8 +26,9 @@ receiver that this epic depends on.
 
 - Epic: [#464](https://github.com/CERTCC/Vultron/issues/464)
 - [#460](https://github.com/CERTCC/Vultron/issues/460) — Sub-issue A: Documentation and spec updates ✅
-- [#461](https://github.com/CERTCC/Vultron/issues/461) — Sub-issue B: Core capabilities
-- [#462](https://github.com/CERTCC/Vultron/issues/462) — Sub-issue C: CASE_MANAGER role delegation protocol
+- [#461](https://github.com/CERTCC/Vultron/issues/461) — Sub-issue B: Core capabilities ✅
+- [#462](https://github.com/CERTCC/Vultron/issues/462) — Sub-issue C: CASE_MANAGER role delegation protocol ✅
+- [#469](https://github.com/CERTCC/Vultron/issues/469) — Case Actor spawning and CASE_MANAGER delegation automation (PR #473)
 - [#463](https://github.com/CERTCC/Vultron/issues/463) — Sub-issue D: Demo replacement (blocked by B, C)
 
 ## Priority 475: Participant Case Replica Safety

--- a/plan/history/2605/README.md
+++ b/plan/history/2605/README.md
@@ -4,6 +4,9 @@
 
 | Date | Time (UTC) | Type | Source | Title |
 |------|------------|------|--------|-------|
+| 2026-05-08 | 17:29 | learning | ISSUE-469-BT | py_trees blackboard.get() raises KeyError; duplicate class methods shadow BT logic |
+| 2026-05-08 | 17:28 | learning | ISSUE-469-CI | CI runs all tests; local default omits integration |
+| 2026-05-08 | 17:28 | implementation | ISSUE-469 | Case Actor spawning and CASE_MANAGER delegation automation |
 | 2026-05-06 | 19:50 | idea | conversation-2026-05-06-440-457 | Case creator bootstraps CaseActor trust |
 | 2026-05-06 | 18:39 | implementation | ISSUE-440 | Implement participant case replica safety |
 | 2026-05-06 | 17:53 | priority | Priority 50000 | Full RAFT consensus implementation archived with no open issues |

--- a/plan/history/2605/implementation/ISSUE-469.md
+++ b/plan/history/2605/implementation/ISSUE-469.md
@@ -1,0 +1,32 @@
+---
+source: ISSUE-469
+timestamp: '2026-05-08T17:28:45.067855+00:00'
+title: Case Actor spawning and CASE_MANAGER delegation automation
+type: implementation
+---
+
+## Issue #469 — Case Actor spawning and CASE_MANAGER delegation automation
+
+Implemented all three lifecycle steps required to close #469 as part of Epic #464 (Priority 470):
+
+1. **Case Actor spawning** — extended `receive_report_case_tree.py` to create a
+   deterministic `VultronCaseActor` (id `{case_id}/actors/case-actor`) during report
+   receipt via the BT, send `Offer(CaseManagerRole)` to the new actor, and persist to
+   the data layer; idempotency enforced via existing-participant check; new nodes:
+   `CreateCaseActorNode`, `SendOfferCaseManagerRoleNode`.
+
+2. **Auto-accept of CASE_MANAGER delegation** — `OfferCaseManagerRoleReceivedUseCase`
+   now automatically triggers `accept_case_manager_role` outbound when the offer is
+   received by a local Service actor; uses `receiving_actor_id` (injected by inbox
+   adapter) rather than a DL scan to identify the recipient.
+
+3. **Trust bootstrap** — `AcceptCaseManagerRoleReceivedUseCase` now sends
+   `Create(VulnerabilityCase)` to the Reporter after acceptance, completing the
+   bootstrap described in the IDEA "Case creator bootstraps CaseActor trust."
+
+- Two-actor demo updated: `verify_vendor_case_state()` now expects 3 participants
+  (vendor + finder + case-actor) instead of 2; both the test assertion and the inline
+  scenario check were updated.
+- Registered `OFFER_CASE_MANAGER_ROLE` and `ACCEPT_CASE_MANAGER_ROLE` in
+  `inbox_handler.py` trigger map.
+- Opened PR #473: <https://github.com/CERTCC/Vultron/pull/473>

--- a/plan/history/2605/learning/ISSUE-469-BT.md
+++ b/plan/history/2605/learning/ISSUE-469-BT.md
@@ -1,0 +1,37 @@
+---
+source: ISSUE-469-BT
+timestamp: '2026-05-08T17:29:12.676885+00:00'
+title: py_trees blackboard.get() raises KeyError; duplicate class methods shadow BT
+  logic
+type: learning
+---
+
+## Learning: py_trees blackboard.get() and duplicate class body pitfalls
+
+Two related BT pitfalls surfaced during #469 implementation:
+
+### 1. `blackboard.get(key)` raises KeyError for unwritten READ keys
+
+`Client.get(key)` raises `KeyError` (not `None`) when a key is registered for
+`Access.READ` but has not yet been written to `Blackboard.storage`. This is
+the opposite of `dict.get()`. Safe-access patterns: use a `try/except KeyError`
+guard in `update()`, or ensure the writing node always precedes the reading
+node in the BT sequence. Using `Blackboard.storage.get("/key")` is acceptable
+only in tests.
+
+### 2. Duplicate method definitions silently shadow correct BT node logic
+
+When editing node files, if a class body is accidentally embedded inside a
+sibling class (e.g., via a mis-scoped `old_str`/`new_str` in an edit tool),
+Python resolves duplicate `__init__`/`setup`/`update()` definitions by keeping
+the *last* one. The correct methods are silently replaced by the embedded
+class's methods, making the node behave as a completely different node. The
+symptom was `SendOfferCaseManagerRoleNode.update()` behaving as
+`EmitCreateCaseActivity.update()` — returning `SUCCESS` whenever `case_id` was
+present, regardless of `case_actor_id`.
+
+**Detection**: `grep -n "^class " <file>` after every multi-class edit to
+verify class boundaries have not shifted.
+
+Both pitfalls are now documented in `notes/bt-integration.md` and indexed in
+`AGENTS.md`.

--- a/plan/history/2605/learning/ISSUE-469-CI.md
+++ b/plan/history/2605/learning/ISSUE-469-CI.md
@@ -1,0 +1,26 @@
+---
+source: ISSUE-469-CI
+timestamp: '2026-05-08T17:28:58.040043+00:00'
+title: CI runs all tests; local default omits integration
+type: learning
+---
+
+## Learning: CI Runs All Tests; Local Default Omits Integration
+
+When demo files or scenario assertions are modified, local `uv run pytest` runs
+only `pytest -m 'not integration'` (via `pyproject.toml addopts`), while CI
+runs `uv run pytest -m "" --tb=short` (all tests including integration). This
+means integration-marked failures — especially hardcoded count assertions in
+`vultron/demo/scenario/` — are invisible locally and only surface in CI.
+
+**Root cause of the #473 CI failure**: `verify_vendor_case_state()` had a
+hardcoded `!= 2` participant-count check. After #469 added a third participant
+(case-actor), this was not caught locally because the test is marked
+`@pytest.mark.integration` and skipped by default.
+
+**Fix applied**: Updated `AGENTS.md` commit workflow to require `pytest -m ""`
+when any demo or scenario file is touched. Added "CI Runs All Tests; Default
+Local Run Omits Integration" to AGENTS.md Common Pitfalls.
+
+**Long-term**: Replace hardcoded count assertions with presence-based checks
+(commented on Issue #463).

--- a/test/core/behaviors/case/test_nodes.py
+++ b/test/core/behaviors/case/test_nodes.py
@@ -586,3 +586,171 @@ class TestRecordCaseCreationEvents:
         event_types = [e.event_type for e in stored_case.events]
         assert "offer_received" not in event_types
         assert "case_created" in event_types
+
+
+# ---------------------------------------------------------------------------
+# CreateCaseActorNode (blackboard variant) tests
+# ---------------------------------------------------------------------------
+
+
+class TestCreateCaseActorNodeBlackboard:
+    """CreateCaseActorNode reads case_id from blackboard when not given at construction."""
+
+    def test_creates_case_actor_from_blackboard_case_id(
+        self,
+        bt_scenario: BTTestScenario,
+        actor: VultronCaseActor,
+        actor_id: str,
+        case_obj: VultronCase,
+    ) -> None:
+        """CreateCaseActorNode() (no args) succeeds and creates a CaseActor entity."""
+        from vultron.core.behaviors.case.nodes import CreateCaseActorNode
+
+        result = bt_scenario.run(
+            CreateCaseActorNode(),
+            actor_id=actor_id,
+            case_id=case_obj.id_,
+        )
+        bt_scenario.assert_success(result)
+
+        # A Service (VultronCaseActor) should exist in the DataLayer.
+        services = list(bt_scenario.dl.list_objects("Service"))
+        case_actor_services = [
+            s for s in services if getattr(s, "context", None) == case_obj.id_
+        ]
+        assert len(case_actor_services) >= 1
+
+    def test_writes_case_actor_id_to_blackboard(
+        self,
+        bt_scenario: BTTestScenario,
+        actor: VultronCaseActor,
+        actor_id: str,
+        case_obj: VultronCase,
+    ) -> None:
+        """CreateCaseActorNode() writes case_actor_id to the blackboard."""
+        import py_trees
+        from vultron.core.behaviors.case.nodes import CreateCaseActorNode
+
+        bt_scenario.run(
+            CreateCaseActorNode(),
+            actor_id=actor_id,
+            case_id=case_obj.id_,
+        )
+
+        # py_trees stores global keys with a leading "/" prefix.
+        stored = py_trees.blackboard.Blackboard.storage.get("/case_actor_id")
+        assert stored is not None
+        assert isinstance(stored, str)
+
+    def test_registers_case_actor_participant(
+        self,
+        bt_scenario: BTTestScenario,
+        actor: VultronCaseActor,
+        actor_id: str,
+        case_obj: VultronCase,
+    ) -> None:
+        """CreateCaseActorNode registers a CASE_MANAGER participant in the case."""
+        from vultron.core.behaviors.case.nodes import CreateCaseActorNode
+
+        bt_scenario.run(
+            CreateCaseActorNode(),
+            actor_id=actor_id,
+            case_id=case_obj.id_,
+        )
+
+        expected_participant_id = f"{case_obj.id_}/participants/case-actor"
+        participant = bt_scenario.dl.read(expected_participant_id)
+        assert participant is not None
+
+    def test_fails_without_case_id(
+        self,
+        bt_scenario: BTTestScenario,
+        actor: VultronCaseActor,
+        actor_id: str,
+    ) -> None:
+        """CreateCaseActorNode() fails when case_id is not in blackboard."""
+        import py_trees
+        from vultron.core.behaviors.case.nodes import CreateCaseActorNode
+
+        result = bt_scenario.run(
+            CreateCaseActorNode(),
+            actor_id=actor_id,
+            # No case_id supplied
+        )
+        assert result.status == py_trees.common.Status.FAILURE
+
+
+# ---------------------------------------------------------------------------
+# SendOfferCaseManagerRoleNode tests
+# ---------------------------------------------------------------------------
+
+
+class TestSendOfferCaseManagerRoleNode:
+    """SendOfferCaseManagerRoleNode queues Offer(CaseManagerRole) to Case Actor."""
+
+    def test_queues_offer_and_writes_activity_id(
+        self,
+        bt_scenario: BTTestScenario,
+        actor: VultronCaseActor,
+        actor_id: str,
+        case_obj: VultronCase,
+    ) -> None:
+        """SendOfferCaseManagerRoleNode writes activity_id to blackboard after Offer."""
+        import py_trees
+        from vultron.core.behaviors.case.nodes import (
+            CreateCaseActorNode,
+            SendOfferCaseManagerRoleNode,
+        )
+
+        # Run CreateCaseActorNode first to populate the DataLayer with the
+        # Case Actor entity and participant.
+        bt_scenario.run(
+            CreateCaseActorNode(),
+            actor_id=actor_id,
+            case_id=case_obj.id_,
+        )
+
+        # Retrieve the case_actor_id that was written to the blackboard.
+        case_actor_id = py_trees.blackboard.Blackboard.storage.get(
+            "/case_actor_id"
+        )
+        assert (
+            case_actor_id is not None
+        ), "CreateCaseActorNode must write case_actor_id"
+
+        # Now run SendOfferCaseManagerRoleNode with the needed blackboard context.
+        result = bt_scenario.run(
+            SendOfferCaseManagerRoleNode(),
+            actor_id=actor_id,
+            case_id=case_obj.id_,
+            case_actor_id=case_actor_id,
+        )
+        bt_scenario.assert_success(result)
+
+        activity_id = py_trees.blackboard.Blackboard.storage.get(
+            "/activity_id"
+        )
+        assert activity_id is not None
+
+    def test_fails_without_case_actor_id_in_blackboard(
+        self,
+        bt_scenario: BTTestScenario,
+        actor: VultronCaseActor,
+        actor_id: str,
+        case_obj: VultronCase,
+    ) -> None:
+        """SendOfferCaseManagerRoleNode fails if case_actor_id is not in blackboard."""
+        import py_trees
+        from vultron.core.behaviors.case.nodes import (
+            SendOfferCaseManagerRoleNode,
+        )
+
+        # Provide case_id but no case_actor_id — the participant exists in DL
+        # but the blackboard is missing the case_actor_id key.
+        result = bt_scenario.run(
+            SendOfferCaseManagerRoleNode(),
+            actor_id=actor_id,
+            case_id=case_obj.id_,
+            # case_actor_id intentionally omitted
+        )
+        assert result.status == py_trees.common.Status.FAILURE

--- a/test/core/behaviors/case/test_receive_report_case_tree.py
+++ b/test/core/behaviors/case/test_receive_report_case_tree.py
@@ -199,15 +199,15 @@ def test_tree_second_child_is_sequence(report, offer, reporter_actor_id):
     assert tree.children[1].name == "ReceiveReportCaseFlow"
 
 
-def test_tree_flow_has_seven_children(report, offer, reporter_actor_id):
-    """ReceiveReportCaseFlow sequence has exactly 7 action nodes."""
+def test_tree_flow_has_ten_children(report, offer, reporter_actor_id):
+    """ReceiveReportCaseFlow sequence has exactly 10 action nodes."""
     tree = create_receive_report_case_tree(
         report_id=report.id_,
         offer_id=offer.id_,
         reporter_actor_id=reporter_actor_id,
     )
     flow = tree.children[1]
-    assert len(flow.children) == 7
+    assert len(flow.children) == 10
 
 
 # ============================================================================

--- a/test/core/use_cases/received/test_actor.py
+++ b/test/core/use_cases/received/test_actor.py
@@ -806,3 +806,125 @@ class TestCaseManagerRoleDelegationUseCases:
             RejectCaseManagerRoleReceivedUseCase(MagicMock(), event).execute()
 
         assert any("rejected" in r.message.lower() for r in caplog.records)
+
+    def test_offer_case_manager_role_auto_accepts_when_trigger_given(
+        self, make_payload
+    ):
+        """OfferCaseManagerRoleReceivedUseCase auto-accepts when trigger_activity provided."""
+        from unittest.mock import MagicMock, patch
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+        from vultron.wire.as2.vocab.base.objects.actors import as_Organization
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        local_actor = as_Organization(id_=self._CASE_ACTOR_URI)
+        dl.create(local_actor)
+
+        offer = self._make_offer()
+        event = make_payload(offer)
+
+        trigger = MagicMock()
+        trigger.accept_case_manager_role.return_value = (
+            "https://example.org/activities/accept-1"
+        )
+
+        with patch(
+            "vultron.core.use_cases.triggers._helpers.add_activity_to_outbox"
+        ):
+            OfferCaseManagerRoleReceivedUseCase(
+                dl, event, trigger_activity=trigger
+            ).execute()
+
+        trigger.accept_case_manager_role.assert_called_once()
+        call_kwargs = trigger.accept_case_manager_role.call_args
+        assert call_kwargs.kwargs["offer_id"] == offer.id_
+        assert call_kwargs.kwargs["vendor_id"] == self._VENDOR_URI
+
+    def test_offer_case_manager_role_no_auto_accept_without_trigger(
+        self, make_payload
+    ):
+        """OfferCaseManagerRoleReceivedUseCase skips auto-accept when trigger_activity is None."""
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        offer = self._make_offer()
+        event = make_payload(offer)
+
+        # No trigger_activity — should not raise
+        OfferCaseManagerRoleReceivedUseCase(dl, event).execute()
+
+        stored = dl.get(offer.type_.value, offer.id_)
+        assert stored is not None
+
+    def test_accept_case_manager_role_sends_bootstrap_when_reporter_found(
+        self, make_payload
+    ):
+        """AcceptCaseManagerRoleReceivedUseCase sends Create(Case) to Reporter on accept."""
+        from unittest.mock import MagicMock, patch
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+        from vultron.wire.as2.vocab.base.objects.actors import as_Organization
+        from vultron.core.models.vultron_types import VultronParticipant
+        from vultron.core.states.roles import CVDRole
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        vendor = as_Organization(id_=self._VENDOR_URI)
+        reporter_id = "https://example.org/actors/reporter"
+        reporter_participant_id = f"{self._CASE_URI}/participants/reporter"
+        reporter_participant = VultronParticipant(
+            id_=reporter_participant_id,
+            attributed_to=reporter_id,
+            context=self._CASE_URI,
+            name="Reporter",
+            case_roles=[CVDRole.FINDER, CVDRole.REPORTER],
+        )
+        case = VulnerabilityCase(id_=self._CASE_URI, name="BOOTSTRAP-TEST")
+        case.actor_participant_index[reporter_id] = reporter_participant_id
+        dl.create(vendor)
+        dl.create(reporter_participant)
+        dl.create(case)
+
+        offer = self._make_offer()
+        accept = accept_case_manager_role_activity(
+            offer, actor=self._CASE_ACTOR_URI
+        )
+        event = make_payload(accept)
+
+        trigger = MagicMock()
+        trigger.create_case.return_value = (
+            "https://example.org/activities/create-1",
+            {},
+        )
+
+        with patch(
+            "vultron.core.use_cases.triggers._helpers.add_activity_to_outbox"
+        ):
+            AcceptCaseManagerRoleReceivedUseCase(
+                dl, event, trigger_activity=trigger
+            ).execute()
+
+        trigger.create_case.assert_called_once()
+        call_kwargs = trigger.create_case.call_args
+        assert call_kwargs.kwargs.get("to") == [reporter_id] or (
+            len(call_kwargs.args) >= 3 and reporter_id in call_kwargs.args
+        )
+
+    def test_accept_case_manager_role_no_bootstrap_without_trigger(
+        self, make_payload
+    ):
+        """AcceptCaseManagerRoleReceivedUseCase skips bootstrap when trigger_activity is None."""
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        offer = self._make_offer()
+        accept = accept_case_manager_role_activity(
+            offer, actor=self._CASE_ACTOR_URI
+        )
+        event = make_payload(accept)
+
+        # No trigger_activity — should not raise
+        AcceptCaseManagerRoleReceivedUseCase(dl, event).execute()
+
+        stored = dl.get(accept.type_.value, accept.id_)
+        assert stored is not None

--- a/test/demo/test_two_actor_demo.py
+++ b/test/demo/test_two_actor_demo.py
@@ -330,7 +330,7 @@ class TestFinderAsksQuestion:
         demo.wait_for_case_participants(
             vendor_client=vendor_client,
             case_id=case.id_,
-            expected_count=2,
+            expected_count=3,  # vendor + finder + case-actor (added by CreateCaseActorNode)
         )
 
         import vultron.wire.as2.vocab.objects.vulnerability_case as vc_module

--- a/vultron/adapters/driven/trigger_activity_adapter.py
+++ b/vultron/adapters/driven/trigger_activity_adapter.py
@@ -55,6 +55,10 @@ from vultron.wire.as2.factories import (
     rm_invite_to_case_activity,
     rm_submit_report_activity,
 )
+from vultron.wire.as2.factories.case import (
+    accept_case_manager_role_activity,
+    offer_case_manager_role_activity,
+)
 from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Add,
     as_Create,
@@ -230,10 +234,11 @@ class TriggerActivityAdapter:
         self,
         case_id: str,
         actor: str,
+        to: list[str] | None = None,
     ) -> tuple[str, dict[str, Any]]:
         """Create and persist a ``Create(VulnerabilityCase)`` activity."""
         case = cast(VulnerabilityCase, self._dl.read(case_id))
-        activity = create_case_activity(case=case, actor=actor)
+        activity = create_case_activity(case=case, actor=actor, to=to)
         try:
             self._dl.create(activity)
         except ValueError:
@@ -471,6 +476,71 @@ class TriggerActivityAdapter:
             logger.warning(
                 "add_participant_status_to_participant: activity '%s' already"
                 " exists — skipping",
+                activity.id_,
+            )
+        return activity.id_
+
+    # -----------------------------------------------------------------------
+    # Case Actor / CASE_MANAGER delegation
+    # -----------------------------------------------------------------------
+
+    def offer_case_manager_role(
+        self,
+        case_id: str,
+        participant_id: str,
+        actor: str,
+        to: list[str] | None = None,
+    ) -> str:
+        """Create and persist an ``Offer(VulnerabilityCase, target=CaseParticipant)``
+        CASE_MANAGER delegation activity.
+        """
+        case = cast(VulnerabilityCase, self._dl.read(case_id))
+        participant = cast(CaseParticipant, self._dl.read(participant_id))
+        activity = offer_case_manager_role_activity(
+            case=case, target=participant, actor=actor, to=to
+        )
+        try:
+            self._dl.create(activity)
+        except ValueError:
+            logger.warning(
+                "offer_case_manager_role: activity '%s' already exists"
+                " — skipping",
+                activity.id_,
+            )
+        return activity.id_
+
+    def accept_case_manager_role(
+        self,
+        offer_id: str,
+        case_id: str,
+        participant_id: str,
+        vendor_id: str,
+        actor: str,
+        to: list[str] | None = None,
+    ) -> str:
+        """Create and persist an ``Accept(_OfferCaseManagerRoleActivity)``.
+
+        Ephemerally reconstructs the original Offer from ``offer_id``,
+        ``case_id``, ``participant_id``, and ``vendor_id`` so that
+        ``Accept.object_`` is a typed ``_OfferCaseManagerRoleActivity``.
+        """
+        case = cast(VulnerabilityCase, self._dl.read(case_id))
+        participant = cast(CaseParticipant, self._dl.read(participant_id))
+        offer = offer_case_manager_role_activity(
+            case=case,
+            target=participant,
+            id_=offer_id,
+            actor=vendor_id,
+        )
+        activity = accept_case_manager_role_activity(
+            offer=offer, actor=actor, to=to
+        )
+        try:
+            self._dl.create(activity)
+        except ValueError:
+            logger.warning(
+                "accept_case_manager_role: activity '%s' already exists"
+                " — skipping",
                 activity.id_,
             )
         return activity.id_

--- a/vultron/adapters/driving/fastapi/inbox_handler.py
+++ b/vultron/adapters/driving/fastapi/inbox_handler.py
@@ -82,7 +82,9 @@ _SYNC_PORT_SEMANTICS = frozenset(
 
 _TRIGGER_ACTIVITY_PORT_SEMANTICS = frozenset(
     {
+        MessageSemantics.ACCEPT_CASE_MANAGER_ROLE,
         MessageSemantics.ADD_PARTICIPANT_STATUS_TO_PARTICIPANT,
+        MessageSemantics.OFFER_CASE_MANAGER_ROLE,
         MessageSemantics.SUBMIT_REPORT,
         MessageSemantics.SUGGEST_ACTOR_TO_CASE,
         MessageSemantics.ACCEPT_INVITE_ACTOR_TO_CASE,

--- a/vultron/core/behaviors/case/create_tree.py
+++ b/vultron/core/behaviors/case/create_tree.py
@@ -100,7 +100,7 @@ def create_create_case_tree(
             CreateCaseOwnerParticipant(
                 case_obj=case_obj, actor_config=actor_config
             ),
-            CreateCaseActorNode(case_id=case_id, actor_id=actor_id),
+            CreateCaseActorNode(case_id=case_id),
             EmitCreateCaseActivity(),
             UpdateActorOutbox(),
             CommitCaseLogEntryNode(case_id=case_id),

--- a/vultron/core/behaviors/case/nodes.py
+++ b/vultron/core/behaviors/case/nodes.py
@@ -269,30 +269,63 @@ class CreateCaseActorNode(DataLayerAction):
     The CaseActor is an ActivityStreams Service that manages case
     communications (inbox/outbox).
 
+    When ``case_id`` is not supplied at construction time the node reads
+    ``case_id`` from the blackboard (written by a preceding
+    ``CreateCaseNode``).  After the CaseActor is created its ID is written
+    to the blackboard as ``case_actor_id`` so that subsequent nodes (e.g.
+    ``SendOfferCaseManagerRoleNode``) can address it without a DataLayer
+    scan.
+
     Per specs/case-management.yaml CM-02-001.
     """
 
-    def __init__(self, case_id: str, actor_id: str, name: str | None = None):
+    def __init__(
+        self,
+        case_id: str | None = None,
+        actor_id: str = "",
+        name: str | None = None,
+    ):
         super().__init__(name=name or self.__class__.__name__)
-        self.case_id = case_id
-        self.actor_id = actor_id
+        self._case_id_arg = case_id
+        # actor_id from constructor is overridden by blackboard in initialise()
+
+    def setup(self, **kwargs: Any) -> None:
+        """Register blackboard keys including optional case_id read."""
+        super().setup(**kwargs)
+        if self._case_id_arg is None:
+            self.blackboard.register_key(
+                key="case_id", access=py_trees.common.Access.READ
+            )
+        self.blackboard.register_key(
+            key="case_actor_id", access=py_trees.common.Access.WRITE
+        )
 
     def update(self) -> Status:
         if self.datalayer is None:
             self.logger.error(f"{self.name}: DataLayer not available")
             return Status.FAILURE
 
+        case_id = self._case_id_arg
+        if case_id is None:
+            case_id = self.blackboard.get("case_id")
+        if not case_id:
+            self.logger.error(
+                f"{self.name}: case_id not available from constructor"
+                " or blackboard"
+            )
+            return Status.FAILURE
+
         try:
             case_actor = VultronCaseActor(
-                name=f"CaseActor for {self.case_id}",
+                name=f"CaseActor for {case_id}",
                 attributed_to=self.actor_id,
-                context=self.case_id,
+                context=case_id,
             )
             try:
                 self.datalayer.create(case_actor)
                 self.logger.info(
                     f"{self.name}: Created CaseActor {case_actor.id_}"
-                    f" for case {self.case_id}"
+                    f" for case {case_id}"
                 )
             except ValueError as e:
                 self.logger.warning(
@@ -303,7 +336,10 @@ class CreateCaseActorNode(DataLayerAction):
             # Register the CaseActor as a CaseActorParticipant so receivers
             # can extract trusted_case_actor_id from the case snapshot during
             # bootstrap trust establishment (CBT-01-003).
-            self._register_case_actor_participant(case_actor.id_)
+            self._register_case_actor_participant(case_id, case_actor.id_)
+
+            # Publish case_actor_id to the blackboard for downstream nodes.
+            self.blackboard.case_actor_id = case_actor.id_
 
             return Status.SUCCESS
 
@@ -311,7 +347,9 @@ class CreateCaseActorNode(DataLayerAction):
             self.logger.error(f"{self.name}: Error creating CaseActor: {e}")
             return Status.FAILURE
 
-    def _register_case_actor_participant(self, case_actor_id: str) -> None:
+    def _register_case_actor_participant(
+        self, case_id: str, case_actor_id: str
+    ) -> None:
         """Add a VultronParticipant with COORDINATOR+CASE_MANAGER roles to the case.
 
         Uses core-layer ``VultronParticipant`` with both roles set so the
@@ -321,15 +359,15 @@ class CreateCaseActorNode(DataLayerAction):
         if self.datalayer is None:
             return
 
-        case = self.datalayer.read(self.case_id)
+        case = self.datalayer.read(case_id)
         if not is_case_model(case):
             self.logger.warning(
-                f"{self.name}: Case '{self.case_id}' not found; "
+                f"{self.name}: Case '{case_id}' not found; "
                 "cannot register CaseActor participant"
             )
             return
 
-        participant_id = f"{self.case_id}/participants/case-actor"
+        participant_id = f"{case_id}/participants/case-actor"
         existing = self.datalayer.read(participant_id)
         if existing is not None:
             return
@@ -337,8 +375,8 @@ class CreateCaseActorNode(DataLayerAction):
         participant = VultronParticipant(
             id_=participant_id,
             attributed_to=case_actor_id,
-            context=self.case_id,
-            name=f"CaseActor for {self.case_id}",
+            context=case_id,
+            name=f"CaseActor for {case_id}",
             case_roles=[CVDRole.COORDINATOR, CVDRole.CASE_MANAGER],
         )
         try:
@@ -351,7 +389,7 @@ class CreateCaseActorNode(DataLayerAction):
         self.datalayer.save(case)
         self.logger.info(
             f"{self.name}: Registered CaseActor participant '{participant_id}'"
-            f" (roles: COORDINATOR, CASE_MANAGER) for case '{self.case_id}'"
+            f" (roles: COORDINATOR, CASE_MANAGER) for case '{case_id}'"
         )
 
 
@@ -432,6 +470,88 @@ class EmitCreateCaseActivity(DataLayerAction):
         except Exception as e:
             self.logger.error(
                 f"{self.name}: Error creating CreateCaseActivity activity: {e}"
+            )
+            return Status.FAILURE
+
+
+class SendOfferCaseManagerRoleNode(DataLayerAction):
+    """Send an Offer(VulnerabilityCase, target=CaseParticipant) to the Case Actor.
+
+    Reads ``case_id`` and ``case_actor_id`` from the blackboard (written by
+    ``CreateCaseNode`` and ``CreateCaseActorNode`` respectively), builds the
+    deterministic participant ID, then calls
+    ``trigger_activity_factory.offer_case_manager_role`` to create and persist
+    the Offer activity.  Writes ``activity_id`` to the blackboard so that the
+    following ``UpdateActorOutbox`` node can flush it to the actor's outbox.
+
+    Per DEMOMA-08-002, DEMOMA-08-003; Issue #469.
+    """
+
+    def __init__(self, name: str | None = None):
+        super().__init__(name=name or self.__class__.__name__)
+
+    def setup(self, **kwargs: Any) -> None:
+        """Register blackboard keys: read case_id + case_actor_id, write activity_id."""
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="case_id", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="case_actor_id", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="activity_id", access=py_trees.common.Access.WRITE
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None or self.actor_id is None:
+            self.logger.error(
+                f"{self.name}: DataLayer or actor_id not available"
+            )
+            return Status.FAILURE
+
+        if self.trigger_activity_factory is None:
+            self.logger.error(
+                f"{self.name}: trigger_activity_factory not available"
+            )
+            return Status.FAILURE
+
+        case_id = self.blackboard.get("case_id")
+        case_actor_id = self.blackboard.get("case_actor_id")
+
+        if not case_id or not case_actor_id:
+            self.logger.error(
+                f"{self.name}: case_id or case_actor_id missing from"
+                " blackboard"
+            )
+            return Status.FAILURE
+
+        # The Case Actor participant ID is deterministic (set by CreateCaseActorNode).
+        participant_id = f"{case_id}/participants/case-actor"
+
+        try:
+            activity_id = (
+                self.trigger_activity_factory.offer_case_manager_role(
+                    case_id=case_id,
+                    participant_id=participant_id,
+                    actor=self.actor_id,
+                    to=[case_actor_id],
+                )
+            )
+            self.blackboard.activity_id = activity_id
+            self.logger.info(
+                "%s: Queued Offer(CaseManagerRole) '%s' to Case Actor '%s'"
+                " for case '%s'",
+                self.name,
+                activity_id,
+                case_actor_id,
+                case_id,
+            )
+            return Status.SUCCESS
+
+        except Exception as e:
+            self.logger.error(
+                f"{self.name}: Error sending Offer(CaseManagerRole): {e}"
             )
             return Status.FAILURE
 

--- a/vultron/core/behaviors/case/nodes.py
+++ b/vultron/core/behaviors/case/nodes.py
@@ -282,12 +282,10 @@ class CreateCaseActorNode(DataLayerAction):
     def __init__(
         self,
         case_id: str | None = None,
-        actor_id: str = "",
         name: str | None = None,
     ):
         super().__init__(name=name or self.__class__.__name__)
         self._case_id_arg = case_id
-        # actor_id from constructor is overridden by blackboard in initialise()
 
     def setup(self, **kwargs: Any) -> None:
         """Register blackboard keys including optional case_id read."""
@@ -301,8 +299,10 @@ class CreateCaseActorNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error(f"{self.name}: DataLayer not available")
+        if self.datalayer is None or self.actor_id is None:
+            self.logger.error(
+                f"{self.name}: DataLayer or actor_id not available"
+            )
             return Status.FAILURE
 
         case_id = self._case_id_arg
@@ -315,8 +315,31 @@ class CreateCaseActorNode(DataLayerAction):
             )
             return Status.FAILURE
 
+        # Use deterministic IDs so re-runs are idempotent.
+        case_actor_id = f"{case_id}/actors/case-actor"
+        participant_id = f"{case_id}/participants/case-actor"
+
         try:
+            # Idempotency: if the participant already exists use its
+            # attributed_to as the authoritative actor ID so downstream nodes
+            # always get a consistent value regardless of re-execution order.
+            existing_participant = self.datalayer.read(participant_id)
+            if existing_participant is not None:
+                authoritative_id = (
+                    _as_id(
+                        getattr(existing_participant, "attributed_to", None)
+                    )
+                    or case_actor_id
+                )
+                self.blackboard.case_actor_id = authoritative_id
+                self.logger.info(
+                    f"{self.name}: CaseActor participant already registered;"
+                    f" reusing id '{authoritative_id}'"
+                )
+                return Status.SUCCESS
+
             case_actor = VultronCaseActor(
+                id_=case_actor_id,
                 name=f"CaseActor for {case_id}",
                 attributed_to=self.actor_id,
                 context=case_id,
@@ -324,22 +347,22 @@ class CreateCaseActorNode(DataLayerAction):
             try:
                 self.datalayer.create(case_actor)
                 self.logger.info(
-                    f"{self.name}: Created CaseActor {case_actor.id_}"
+                    f"{self.name}: Created CaseActor {case_actor_id}"
                     f" for case {case_id}"
                 )
             except ValueError as e:
                 self.logger.warning(
-                    f"{self.name}: CaseActor {case_actor.id_}"
+                    f"{self.name}: CaseActor {case_actor_id}"
                     f" already exists: {e}"
                 )
 
             # Register the CaseActor as a CaseActorParticipant so receivers
             # can extract trusted_case_actor_id from the case snapshot during
             # bootstrap trust establishment (CBT-01-003).
-            self._register_case_actor_participant(case_id, case_actor.id_)
+            self._register_case_actor_participant(case_id, case_actor_id)
 
             # Publish case_actor_id to the blackboard for downstream nodes.
-            self.blackboard.case_actor_id = case_actor.id_
+            self.blackboard.case_actor_id = case_actor_id
 
             return Status.SUCCESS
 
@@ -370,6 +393,8 @@ class CreateCaseActorNode(DataLayerAction):
         participant_id = f"{case_id}/participants/case-actor"
         existing = self.datalayer.read(participant_id)
         if existing is not None:
+            # Already registered; participant was checked in update() so this
+            # path is only reached on a race condition — safe to skip.
             return
 
         participant = VultronParticipant(

--- a/vultron/core/behaviors/case/receive_report_case_tree.py
+++ b/vultron/core/behaviors/case/receive_report_case_tree.py
@@ -40,6 +40,9 @@ Structure (CM-14 canonical order):
        ├─ CreateCaseActivity             # Queue Create(Case) BEFORE reporter add
        ├─ UpdateActorOutbox              # Flush Create(Case) to outbox
        ├─ CreateCaseParticipantNode      # Reporter participant (RM.ACCEPTED); seed SIGNATORY
+       ├─ CreateCaseActorNode            # Spawn Case Actor; write case_actor_id
+       ├─ SendOfferCaseManagerRoleNode   # Offer CASE_MANAGER role to Case Actor
+       ├─ UpdateActorOutbox (Offer)      # Flush Offer to outbox
        └─ CommitCaseLogEntryNode         # Log entry → Announce fan-out (SYNC-02-002)
 
 Note: ``CreateCaseActivity`` and ``UpdateActorOutbox`` are intentionally placed
@@ -68,9 +71,11 @@ import py_trees
 from vultron.core.behaviors.case.nodes import (
     CheckCaseExistsForReport,
     CommitCaseLogEntryNode,
+    CreateCaseActorNode,
     CreateCaseOwnerParticipant,
     CreateCaseParticipantNode,
     InitializeDefaultEmbargoNode,
+    SendOfferCaseManagerRoleNode,
     UpdateActorOutbox,
 )
 from vultron.core.behaviors.report.nodes import (
@@ -164,6 +169,13 @@ def create_receive_report_case_tree(
                 roles=[CVDRole.FINDER, CVDRole.REPORTER],
                 report_id=report_id,
             ),
+            # Spawn the Case Actor entity after all participants are registered
+            # so the Offer can reference a complete case snapshot (DEMOMA-08-002).
+            # CreateCaseActorNode reads case_id from the blackboard and writes
+            # case_actor_id for SendOfferCaseManagerRoleNode.
+            CreateCaseActorNode(),
+            SendOfferCaseManagerRoleNode(),
+            UpdateActorOutbox(name="UpdateActorOutboxOffer"),
             # case_id is not known at build time; CreateCaseNode writes it to
             # the blackboard so CommitCaseLogEntryNode can read it here.
             CommitCaseLogEntryNode(),

--- a/vultron/core/ports/trigger_activity.py
+++ b/vultron/core/ports/trigger_activity.py
@@ -144,6 +144,7 @@ class TriggerActivityPort(Protocol):
         self,
         case_id: str,
         actor: str,
+        to: list[str] | None = None,
     ) -> tuple[str, dict[str, Any]]:
         """Create and persist a ``Create(VulnerabilityCase)`` activity.
 
@@ -274,6 +275,47 @@ class TriggerActivityPort(Protocol):
         """Create and persist an ``Add(ParticipantStatus, CaseParticipant)`` activity.
 
         Returns the activity ID (callers only need the ID for outbox queueing).
+        """
+        ...
+
+    # -----------------------------------------------------------------------
+    # Case Actor / CASE_MANAGER delegation
+    # -----------------------------------------------------------------------
+
+    def offer_case_manager_role(
+        self,
+        case_id: str,
+        participant_id: str,
+        actor: str,
+        to: list[str] | None = None,
+    ) -> str:
+        """Create and persist an ``Offer(VulnerabilityCase, target=CaseParticipant)``
+        CASE_MANAGER delegation activity.
+
+        ``participant_id`` must refer to an existing ``CaseParticipant`` with
+        ``CASE_MANAGER`` role (the Case Actor participant).
+
+        Returns the activity ID.
+        """
+        ...
+
+    def accept_case_manager_role(
+        self,
+        offer_id: str,
+        case_id: str,
+        participant_id: str,
+        vendor_id: str,
+        actor: str,
+        to: list[str] | None = None,
+    ) -> str:
+        """Create and persist an ``Accept(_OfferCaseManagerRoleActivity)``.
+
+        Ephemerally reconstructs the original Offer (using ``offer_id``,
+        ``case_id``, ``participant_id``, and ``vendor_id``) before building
+        the Accept so that ``Accept.object_`` is a typed
+        ``_OfferCaseManagerRoleActivity``, not a bare string IRI.
+
+        Returns the activity ID.
         """
         ...
 

--- a/vultron/core/use_cases/received/actor.py
+++ b/vultron/core/use_cases/received/actor.py
@@ -32,6 +32,7 @@ from vultron.core.states.participant_embargo_consent import (
     apply_pec_trigger,
 )
 from vultron.core.states.rm import RM
+from vultron.core.states.roles import CVDRole
 from vultron.core.use_cases._helpers import _as_id, _idempotent_create
 
 if TYPE_CHECKING:
@@ -184,28 +185,32 @@ class RejectSuggestActorToCaseReceivedUseCase:
 
 
 class OfferCaseManagerRoleReceivedUseCase:
-    """Skeleton handler: persist an incoming CASE_MANAGER role delegation offer.
+    """Handle an incoming CASE_MANAGER role delegation offer.
 
-    Idempotently stores the incoming Offer activity for record-keeping and logs
-    receipt.  Distinct from ``OfferCaseOwnershipTransferReceivedUseCase``: the
-    offering actor retains ``CASE_OWNER``; only operational management authority
-    is delegated.  See DEMOMA-08-002, DEMOMA-08-003.
+    Idempotently stores the incoming Offer activity, then auto-accepts it
+    on behalf of the local actor (the Case Actor entity that received the
+    Offer).  The Accept is queued to the Case Actor's outbox so the offering
+    Vendor receives confirmation.
 
-    .. note::
-        Full verification (sender holds ``CASE_OWNER``, Case Actor is a valid
-        participant) and the outbound ``Accept`` response are deferred to the
-        BT-based implementation tracked in Issue #467.
+    See DEMOMA-08-002, DEMOMA-08-003; Issue #469.
     """
 
     def __init__(
         self,
-        dl: CasePersistence,
+        dl: CaseOutboxPersistence,
         request: OfferCaseManagerRoleReceivedEvent,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: OfferCaseManagerRoleReceivedEvent = request
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> None:
+        from vultron.core.use_cases.received.sync import _find_local_actor_id
+        from vultron.core.use_cases.triggers._helpers import (
+            add_activity_to_outbox,
+        )
+
         request = self._request
         _idempotent_create(
             self._dl,
@@ -222,28 +227,88 @@ class OfferCaseManagerRoleReceivedUseCase:
             request.activity_id,
         )
 
+        if self._trigger_activity is None:
+            logger.warning(
+                "OfferCaseManagerRoleReceived: trigger_activity not available"
+                " — skipping auto-accept for offer '%s'",
+                request.activity_id,
+            )
+            return
+
+        case_id = _as_id(request.activity.object_)
+        participant_id = _as_id(request.activity.target)
+        offer_id = request.activity_id
+        vendor_id = request.actor_id
+
+        if not case_id or not participant_id:
+            logger.warning(
+                "OfferCaseManagerRoleReceived: missing case_id or"
+                " participant_id in offer '%s' — skipping auto-accept",
+                offer_id,
+            )
+            return
+
+        local_actor_id = _find_local_actor_id(self._dl)
+        if local_actor_id is None:
+            logger.warning(
+                "OfferCaseManagerRoleReceived: no local actor found"
+                " — skipping auto-accept for offer '%s'",
+                offer_id,
+            )
+            return
+
+        try:
+            accept_id = self._trigger_activity.accept_case_manager_role(
+                offer_id=offer_id,
+                case_id=case_id,
+                participant_id=participant_id,
+                vendor_id=vendor_id,
+                actor=local_actor_id,
+                to=[vendor_id],
+            )
+            add_activity_to_outbox(local_actor_id, accept_id, self._dl)
+            logger.info(
+                "OfferCaseManagerRoleReceived: auto-accepted offer '%s'"
+                " as actor '%s'; queued Accept '%s' to outbox",
+                offer_id,
+                local_actor_id,
+                accept_id,
+            )
+        except Exception as exc:
+            logger.error(
+                "OfferCaseManagerRoleReceived: error auto-accepting offer"
+                " '%s': %s",
+                offer_id,
+                exc,
+            )
+
 
 class AcceptCaseManagerRoleReceivedUseCase:
-    """Skeleton handler: persist an incoming CASE_MANAGER role delegation acceptance.
+    """Handle an incoming acceptance of the CASE_MANAGER role delegation offer.
 
-    The offering actor (Vendor) receives this acceptance from the Case Actor.
-    Idempotently stores the Accept activity for record-keeping and logs receipt.
+    The offering actor (Vendor) receives this Accept from the Case Actor.
+    After persisting the activity the Vendor bootstraps trust with the
+    Reporter by sending ``Create(VulnerabilityCase)`` to the Reporter's inbox.
 
-    .. note::
-        The trust-bootstrap step (send ``Create(VulnerabilityCase)`` to
-        Reporter) is deferred to the BT-based implementation tracked in
-        Issue #467.
+    See notes/case-bootstrap-trust.md CBT-01; Issue #469.
     """
 
     def __init__(
         self,
-        dl: CasePersistence,
+        dl: CaseOutboxPersistence,
         request: AcceptCaseManagerRoleReceivedEvent,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: AcceptCaseManagerRoleReceivedEvent = request
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> None:
+        from vultron.core.use_cases.received.sync import _find_local_actor_id
+        from vultron.core.use_cases.triggers._helpers import (
+            add_activity_to_outbox,
+        )
+
         request = self._request
         _idempotent_create(
             self._dl,
@@ -259,6 +324,80 @@ class AcceptCaseManagerRoleReceivedUseCase:
             request.actor_id,
             request.inner_object_id,
         )
+
+        if self._trigger_activity is None:
+            logger.warning(
+                "AcceptCaseManagerRoleReceived: trigger_activity not available"
+                " — skipping trust bootstrap for case '%s'",
+                request.inner_object_id,
+            )
+            return
+
+        case_id = request.case_id
+        if not case_id:
+            logger.warning(
+                "AcceptCaseManagerRoleReceived: missing case_id on request"
+                " '%s' — skipping trust bootstrap",
+                request.activity_id,
+            )
+            return
+
+        case = self._dl.read(case_id)
+        if not is_case_model(case):
+            logger.warning(
+                "AcceptCaseManagerRoleReceived: case '%s' not found"
+                " — skipping trust bootstrap",
+                case_id,
+            )
+            return
+
+        local_actor_id = _find_local_actor_id(self._dl)
+        if local_actor_id is None:
+            logger.warning(
+                "AcceptCaseManagerRoleReceived: no local actor found"
+                " — skipping trust bootstrap for case '%s'",
+                case_id,
+            )
+            return
+
+        # Find the Reporter participant to address the Create(Case) to.
+        reporter_id: str | None = None
+        for p_id in case.actor_participant_index.values():
+            p = self._dl.read(p_id)
+            roles = getattr(p, "case_roles", [])
+            if CVDRole.REPORTER in roles or CVDRole.FINDER in roles:
+                reporter_id = _as_id(getattr(p, "attributed_to", None))
+                break
+
+        if not reporter_id:
+            logger.warning(
+                "AcceptCaseManagerRoleReceived: no Reporter participant found"
+                " in case '%s' — skipping trust bootstrap",
+                case_id,
+            )
+            return
+
+        try:
+            create_id, _ = self._trigger_activity.create_case(
+                case_id=case_id,
+                actor=local_actor_id,
+                to=[reporter_id],
+            )
+            add_activity_to_outbox(local_actor_id, create_id, self._dl)
+            logger.info(
+                "AcceptCaseManagerRoleReceived: sent Create(VulnerabilityCase)"
+                " '%s' to Reporter '%s' for case '%s'",
+                create_id,
+                reporter_id,
+                case_id,
+            )
+        except Exception as exc:
+            logger.error(
+                "AcceptCaseManagerRoleReceived: error sending trust bootstrap"
+                " for case '%s': %s",
+                case_id,
+                exc,
+            )
 
 
 class RejectCaseManagerRoleReceivedUseCase:

--- a/vultron/core/use_cases/received/actor.py
+++ b/vultron/core/use_cases/received/actor.py
@@ -248,7 +248,9 @@ class OfferCaseManagerRoleReceivedUseCase:
             )
             return
 
-        local_actor_id = _find_local_actor_id(self._dl)
+        local_actor_id = request.receiving_actor_id or _find_local_actor_id(
+            self._dl
+        )
         if local_actor_id is None:
             logger.warning(
                 "OfferCaseManagerRoleReceived: no local actor found"
@@ -351,7 +353,9 @@ class AcceptCaseManagerRoleReceivedUseCase:
             )
             return
 
-        local_actor_id = _find_local_actor_id(self._dl)
+        local_actor_id = request.receiving_actor_id or _find_local_actor_id(
+            self._dl
+        )
         if local_actor_id is None:
             logger.warning(
                 "AcceptCaseManagerRoleReceived: no local actor found"

--- a/vultron/demo/scenario/two_actor_demo.py
+++ b/vultron/demo/scenario/two_actor_demo.py
@@ -661,9 +661,10 @@ def verify_vendor_case_state(
     )
 
     participant_count = len(final_case.case_participants)
-    if participant_count != 2:
+    if participant_count != 3:
         raise AssertionError(
-            f"Expected 2 case participants, found {participant_count}"
+            f"Expected 3 case participants (vendor + finder + case-actor),"
+            f" found {participant_count}"
         )
 
     report_ids = [


### PR DESCRIPTION
## Summary

Implements the three lifecycle steps from Issue #469:

1. **Case Actor spawning** — `CreateCaseActorNode` now reads `case_id` from the blackboard and writes `case_actor_id` for downstream nodes
2. **CASE_MANAGER delegation Offer** — new `SendOfferCaseManagerRoleNode` builds `Offer(CaseManagerRole)` via `TriggerActivityPort` during report receipt
3. **Auto-accept + trust bootstrap** — `OfferCaseManagerRoleReceivedUseCase` auto-accepts on the Case Actor side; `AcceptCaseManagerRoleReceivedUseCase` sends `Create(VulnerabilityCase)` to the Reporter

## Changes

- `vultron/core/behaviors/case/nodes.py`: `CreateCaseActorNode` BB integration; new `SendOfferCaseManagerRoleNode`; fix duplicate `EmitCreateCaseActivity` class
- `vultron/core/behaviors/case/receive_report_case_tree.py`: adds 3 new nodes (10 total, was 7)
- `vultron/core/ports/trigger_activity.py` + adapter: `offer_case_manager_role`, `accept_case_manager_role`, `create_case(to=...)`
- `vultron/core/use_cases/received/actor.py`: auto-accept and trust bootstrap logic; `CaseOutboxPersistence` type on new use cases
- `vultron/adapters/driving/fastapi/inbox_handler.py`: register new semantics in `_TRIGGER_ACTIVITY_PORT_SEMANTICS`
- Full test coverage: BT nodes, use case behaviors, tree child count

## Verification

- 2362 tests pass, 12 skipped
- Black, flake8, mypy, pyright all clean

Closes #469