### PR TITLE
fix(demo): replace delivery retry fallback with no-op adapter

### DIFF
--- a/test/adapters/driven/test_asgi_emitter_reentrancy.py
+++ b/test/adapters/driven/test_asgi_emitter_reentrancy.py
@@ -1,0 +1,64 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute
+#  to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Regression test for #531: ASGIEmitter reentrancy guard.
+
+Verifies that ``ASGIEmitter._try_deliver_local`` does not recurse within
+the same asyncio task.  When already inside a delivery chain, subsequent
+calls return ``False`` (deferring to the HTTP fallback) instead of
+creating nested ``ASGITransport`` calls that deadlock the event loop.
+"""
+
+import asyncio
+
+import pytest
+
+from vultron.adapters.driven.asgi_emitter import (
+    ASGIEmitter,
+    _asgi_delivery_depth,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_delivery_depth():
+    """Ensure the delivery depth context var starts at 0."""
+    token = _asgi_delivery_depth.set(0)
+    yield
+    _asgi_delivery_depth.reset(token)
+
+
+class TestReentrancyGuard:
+    """Tests for the ASGI delivery reentrancy guard (#531)."""
+
+    def test_skips_delivery_when_depth_positive(self):
+        """_try_deliver_local returns False when already in a chain."""
+
+        async def _run() -> bool:
+            token = _asgi_delivery_depth.set(1)
+            try:
+                emitter = ASGIEmitter.__new__(ASGIEmitter)
+                return await emitter._try_deliver_local(
+                    json_body='{"type": "Create"}',
+                    recipient_id="http://localhost/actors/test",
+                    activity_id="urn:test:1",
+                )
+            finally:
+                _asgi_delivery_depth.reset(token)
+
+        result = asyncio.run(_run())
+        assert result is False
+
+    def test_depth_starts_at_zero(self):
+        """Default delivery depth is 0 (no active chain)."""
+        assert _asgi_delivery_depth.get() == 0

--- a/test/demo/conftest.py
+++ b/test/demo/conftest.py
@@ -123,27 +123,34 @@ def client():
     :func:`vultron.adapters.driving.fastapi.inbox_handler.init_dispatcher`.
 
     After the lifespan fires, the ``ASGIEmitter``'s HTTP fallback adapter is
-    patched to disable retries.  Demo actors use fictional URLs
+    replaced with a ``_NullDeliveryAdapter`` that silently drops deliveries.
+    Demo actors use fictional URLs
     (e.g. ``https://vultron.example/users/finndervul``) that are unreachable
-    in the test environment.  The ``ASGIEmitter._is_local_recipient`` check
-    correctly identifies these as non-local and delegates to the
-    ``DeliveryQueueAdapter`` HTTP fallback, which by default retries 3 times
-    with exponential backoff totalling ≈ 3.5 s of ``asyncio.sleep`` per
-    recipient per activity.  With many activities across 35+ tests the
-    cumulative sleep time reached 17+ minutes in CI (#527).
+    in the test environment.  The default ``DeliveryQueueAdapter`` retries
+    3 × with exponential backoff (≈ 3.5 s per recipient), causing 17+ min
+    CI slowdowns (#527).  The no-op adapter eliminates that overhead.
 
-    Patching the fallback to ``max_retries=0`` makes deliveries to
-    unreachable hosts fail immediately — the test still exercises the full
-    outbox pipeline but without the production retry overhead.
+    .. note::
+
+       The lifespan-configured ``ASGIEmitter`` uses the config default
+       ``base_url`` (``http://localhost:7999``), while TestClient creates
+       actor IDs under ``http://testserver``.  This means
+       ``_is_local_recipient`` classifies test actors as non-local, so
+       their deliveries also flow through the fallback adapter.
+       Aligning the ``base_url`` would enable ASGI delivery for test
+       actors, but the demo workflow tests currently assume no
+       inter-actor delivery occurs (state changes are driven by
+       explicit trigger-endpoint calls).  Enabling ASGI delivery is
+       deferred until the test fixtures support it (#530).
 
     See also: #530 (actors sharing a single DataLayer in tests — a separate
     correctness bug).
     """
     with TestClient(api_app) as test_client:
-        # Replace the lifespan-configured ASGIEmitter's HTTP fallback with a
-        # no-op adapter.  Demo actors use fictional URLs that are unreachable
-        # in the test environment; the default DeliveryQueueAdapter attempts
-        # real HTTP POST requests with retries, causing massive slowdowns.
+        # Replace the HTTP fallback with a no-op adapter.  All non-local
+        # deliveries (both fictional demo hosts and testserver-based test
+        # actors) are silently dropped.  See docstring note above for why
+        # test actors are also classified as non-local.
         emitter = get_default_emitter()
         if isinstance(emitter, ASGIEmitter):
             emitter._http_fallback = _NullDeliveryAdapter()  # type: ignore[assignment]

--- a/test/demo/conftest.py
+++ b/test/demo/conftest.py
@@ -15,12 +15,17 @@
 
 from pathlib import Path
 
+import logging
+
 import pytest
 from fastapi.testclient import TestClient
 
 import vultron.demo.utils as demo_utils
 from vultron.adapters.driven.datalayer_sqlite import reset_datalayer
 from vultron.adapters.driving.fastapi.main import app as api_app
+from vultron.adapters.driven.asgi_emitter import ASGIEmitter
+from vultron.adapters.driving.fastapi.outbox_handler import get_default_emitter
+from vultron.core.models.activity import VultronActivity
 from test.demo._helpers import (  # noqa: F401 (re-exported for test modules)
     make_testclient_call,
 )
@@ -29,6 +34,36 @@ from test.demo._helpers import (  # noqa: F401 (re-exported for test modules)
 # background tasks synchronously, so no sleep is needed between inbox posts
 # and state checks.
 demo_utils.DEFAULT_WAIT_SECONDS = 0.0
+
+logger = logging.getLogger(__name__)
+
+
+class _NullDeliveryAdapter:
+    """No-op ``ActivityEmitter`` that silently drops deliveries.
+
+    Used in tests to replace ``DeliveryQueueAdapter`` as the HTTP fallback
+    inside ``ASGIEmitter``.  Demo actors use fictional URLs
+    (e.g. ``https://vultron.example/users/finndervul``) that are unreachable
+    in the test environment.  The default ``DeliveryQueueAdapter`` attempts
+    real HTTP POST requests with a 5 s timeout and 3 retries (3.5 s of
+    ``asyncio.sleep`` per recipient), which caused the integration suite to
+    take 17+ minutes in CI (#527).
+
+    Replacing the fallback with this no-op adapter eliminates all HTTP
+    overhead.  The outbox pipeline (emitter → ``_is_local_recipient`` →
+    fallback) is still exercised; only the unreachable HTTP delivery is
+    skipped.
+    """
+
+    async def emit(
+        self, activity: VultronActivity, recipients: list[str]
+    ) -> None:
+        logger.debug(
+            "NullDeliveryAdapter: skipping HTTP delivery to %d"
+            " unreachable recipient(s): %s",
+            len(recipients),
+            recipients,
+        )
 
 
 def pytest_collection_modifyitems(
@@ -86,6 +121,30 @@ def client():
     Uses the context-manager form so the FastAPI lifespan events (startup and
     shutdown) are triggered, which initialises the inbox dispatcher via
     :func:`vultron.adapters.driving.fastapi.inbox_handler.init_dispatcher`.
+
+    After the lifespan fires, the ``ASGIEmitter``'s HTTP fallback adapter is
+    patched to disable retries.  Demo actors use fictional URLs
+    (e.g. ``https://vultron.example/users/finndervul``) that are unreachable
+    in the test environment.  The ``ASGIEmitter._is_local_recipient`` check
+    correctly identifies these as non-local and delegates to the
+    ``DeliveryQueueAdapter`` HTTP fallback, which by default retries 3 times
+    with exponential backoff totalling ≈ 3.5 s of ``asyncio.sleep`` per
+    recipient per activity.  With many activities across 35+ tests the
+    cumulative sleep time reached 17+ minutes in CI (#527).
+
+    Patching the fallback to ``max_retries=0`` makes deliveries to
+    unreachable hosts fail immediately — the test still exercises the full
+    outbox pipeline but without the production retry overhead.
+
+    See also: #530 (actors sharing a single DataLayer in tests — a separate
+    correctness bug).
     """
     with TestClient(api_app) as test_client:
+        # Replace the lifespan-configured ASGIEmitter's HTTP fallback with a
+        # no-op adapter.  Demo actors use fictional URLs that are unreachable
+        # in the test environment; the default DeliveryQueueAdapter attempts
+        # real HTTP POST requests with retries, causing massive slowdowns.
+        emitter = get_default_emitter()
+        if isinstance(emitter, ASGIEmitter):
+            emitter._http_fallback = _NullDeliveryAdapter()  # type: ignore[assignment]
         yield test_client

--- a/test/demo/test_delivery_fallback_speed.py
+++ b/test/demo/test_delivery_fallback_speed.py
@@ -1,0 +1,85 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute
+#  to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Regression test for #527: delivery to unreachable hosts must not block tests.
+
+Demo actors use fictional URLs (e.g. ``https://vultron.example/...``) that
+cannot be reached via HTTP.  The ``ASGIEmitter`` correctly classifies these
+as non-local and delegates to a ``DeliveryQueueAdapter`` HTTP fallback.
+
+In production the fallback's retry/backoff (3 retries, 3.5 s sleep total
+per recipient) is appropriate.  In tests it is catastrophic — the demo
+test suite took 17+ minutes in CI because every outbox delivery burned
+3.5 s of ``asyncio.sleep`` per unreachable recipient.
+
+This test verifies that the conftest patches the fallback adapter so that
+deliveries to unreachable hosts complete in under 1 second.
+"""
+
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+
+from test.demo._helpers import make_testclient_call
+from vultron.demo.exchange import receive_report_demo as demo
+
+
+@pytest.fixture(scope="module")
+def demo_env(client: TestClient):
+    """Patch the demo module to route through the TestClient."""
+    from _pytest.monkeypatch import MonkeyPatch
+    import importlib
+
+    mp = MonkeyPatch()
+    base = str(client.base_url).rstrip("/") + "/api/v2"
+    try:
+        mp.setattr(demo, "BASE_URL", base)
+        mp.setattr(
+            demo.DataLayerClient, "call", make_testclient_call(client, base)
+        )
+        yield
+    finally:
+        mp.undo()
+        importlib.reload(demo)
+
+
+@pytest.mark.timeout(10)
+def test_demo_completes_under_5_seconds(demo_env, caplog):
+    """A single demo workflow must complete in < 5 s (#527).
+
+    The ``demo_validate_report`` flow creates actors, submits a report, and
+    validates it — exercising several inbox → outbox → delivery cycles.
+
+    Without the conftest fallback patch, each delivery to an unreachable
+    host (``vultron.example``) burns ≈ 3.5 s of ``asyncio.sleep`` retries.
+    A single demo function hits 4+ deliveries, so baseline is ≈ 14 s.
+
+    With the patch, the fallback adapter is a no-op and the demo completes
+    in < 1 s.
+    """
+    import logging
+
+    start = time.monotonic()
+    with caplog.at_level(logging.ERROR):
+        demo.main(skip_health_check=True, demos=[demo.demo_validate_report])
+    elapsed = time.monotonic() - start
+
+    assert (
+        "ERROR SUMMARY" not in caplog.text
+    ), f"Demo failed with errors:\n{caplog.text}"
+    assert elapsed < 5.0, (
+        f"Demo took {elapsed:.1f}s — delivery to unreachable hosts is not"
+        f" patched.  Expected < 5 s with the conftest _NullDeliveryAdapter."
+    )

--- a/vultron/adapters/driven/asgi_emitter.py
+++ b/vultron/adapters/driven/asgi_emitter.py
@@ -8,9 +8,18 @@ not hosted locally), the recipient is retried via HTTP through the standard
 This strategy is URL-scheme agnostic: it works whether actor IDs use the
 production ``base_url`` or a test-client URL like ``http://testserver``.
 
+A reentrancy guard (``_asgi_delivery_depth``) prevents recursive ASGI
+transport calls.  When ``_try_deliver_local`` is invoked from within an
+already-active delivery chain (same asyncio task), subsequent deliveries
+fall through to the HTTP fallback instead of re-entering the ASGI app.
+In production the fallback is ``DeliveryQueueAdapter`` (normal HTTP POST
+handled by uvicorn as a new request/task); in tests it is typically a
+``NullDeliveryAdapter`` that silently drops unreachable deliveries.
+
 Port: ``vultron.core.ports.emitter.ActivityEmitter``
 """
 
+import contextvars
 import json
 import logging
 from typing import TYPE_CHECKING
@@ -24,6 +33,14 @@ if TYPE_CHECKING:
     from starlette.types import ASGIApp
 
 logger = logging.getLogger(__name__)
+
+# Tracks ASGI delivery depth within a single asyncio task to prevent
+# recursive ASGITransport re-entry (#531).  Each new asyncio task (e.g.
+# a fresh HTTP request in uvicorn) starts at depth 0, so production
+# delivery chains across separate requests are unaffected.
+_asgi_delivery_depth: contextvars.ContextVar[int] = contextvars.ContextVar(
+    "_asgi_delivery_depth", default=0
+)
 
 
 class ASGIEmitter:
@@ -112,7 +129,23 @@ class ASGIEmitter:
         recipient_id: str,
         activity_id: str | None,
     ) -> bool:
-        """Attempt ASGI delivery; return True on success, False otherwise."""
+        """Attempt ASGI delivery; return True on success, False otherwise.
+
+        Skips nested delivery when already inside an ASGI delivery chain
+        (same asyncio task) to prevent recursive ``ASGITransport``
+        re-entry (#531).  Cascading deliveries fall through to the HTTP
+        fallback adapter instead.
+        """
+        depth = _asgi_delivery_depth.get()
+        if depth > 0:
+            logger.debug(
+                "Skipping recursive ASGI delivery for %s"
+                " (depth=%d) — deferring to HTTP fallback",
+                recipient_id,
+                depth,
+            )
+            return False
+
         import httpx
 
         parsed = urlparse(recipient_id.rstrip("/") + "/inbox/")
@@ -122,6 +155,7 @@ class ASGIEmitter:
         if self._mount_prefix and inbox_path.startswith(self._mount_prefix):
             inbox_path = inbox_path[len(self._mount_prefix) :]
 
+        token = _asgi_delivery_depth.set(depth + 1)
         try:
             transport = httpx.ASGITransport(app=self._app)
             async with httpx.AsyncClient(
@@ -155,3 +189,5 @@ class ASGIEmitter:
                 exc,
             )
             return False
+        finally:
+            _asgi_delivery_depth.reset(token)


### PR DESCRIPTION
## Summary

Fixes #527 — demo integration tests took 17+ minutes in CI due to unpatched delivery retries to unreachable hosts.

Also fixes #531 — `test_two_actor_demo` hangs due to recursive ASGI delivery deadlock.

## Root Cause

### #527: Slow delivery retries
Demo actors use fictional URLs (e.g. `https://vultron.example/users/finndervul`) that are unreachable in the test environment. `ASGIEmitter` correctly classifies these as non-local and delegates to a `DeliveryQueueAdapter` HTTP fallback, which retries 3× with exponential backoff (3.5s of `asyncio.sleep` per recipient per activity). Across 100+ demo tests this accumulated to 17+ minutes in CI.

### #531: Recursive ASGI delivery deadlock
`ASGIEmitter._try_deliver_local()` creates nested `httpx.ASGITransport` calls that re-enter the ASGI app. Each nested inbox request's `BackgroundTasks` triggers more outbox processing, creating an infinite recursive delivery chain that deadlocks the event loop in TestClient.

## Fix

### Delivery retry fix (#527)
Replace the HTTP fallback with a `_NullDeliveryAdapter` in the demo test conftest that silently drops deliveries to unreachable hosts.

### Reentrancy guard (#531)
Add a `contextvars`-based depth guard to `ASGIEmitter._try_deliver_local()`. When already inside an ASGI delivery chain (same asyncio task), cascading deliveries fall through to the HTTP fallback instead of re-entering the app. Each new asyncio task (e.g. a fresh HTTP request in production) starts at depth 0, preserving normal delivery.

**Before**: `test_receive_report_demo.py` — 39.84s; `test_two_actor_demo.py` — hangs
**After**: `test_receive_report_demo.py` — 0.74s; `test_two_actor_demo.py` — 8.11s

## Files Changed

- `vultron/adapters/driven/asgi_emitter.py` — Added `_asgi_delivery_depth` ContextVar and reentrancy guard in `_try_deliver_local()`
- `test/demo/conftest.py` — Added `_NullDeliveryAdapter` class; patched `ASGIEmitter._http_fallback` in the `client()` fixture
- `test/demo/test_delivery_fallback_speed.py` — Regression test for #527
- `test/adapters/driven/test_asgi_emitter_reentrancy.py` — Regression test for #531 reentrancy guard