### PR TITLE
fix(#534): eliminate per-app singleton sharing in create_app()

### DIFF
--- a/plan/history/2605/README.md
+++ b/plan/history/2605/README.md
@@ -4,7 +4,9 @@
 
 | Date | Time (UTC) | Type | Source | Title |
 |------|------------|------|--------|-------|
+| 2026-05-15 | 23:29 | implementation | 534 | fix(#534): eliminate per-app singleton sharing in create_app() |
 | 2026-05-15 | 16:07 | implementation | issue-528 | Add pytest-timeout guardrail: 30s default per-test ceiling |
+| 2026-05-15 | 13:43 | implementation | GH-467 | Refactor AddParticipantStatus handler to Behavior Tree |
 | 2026-05-14 | 20:07 | learning | TASK-ARCHVIO-CLEANUP | ARCH-01-001 sync.py violation fix: SyncActivityPort implementation tasks (cleanup) |
 | 2026-05-13 | 20:28 | learning | PCR | PCR: Announce trust guard, actor-scoped deferral, report-to-case link |
 | 2026-05-13 | 20:27 | learning | TWO-ACTOR-DEMO-2 | Case Actor spawning: CASE_MANAGER role delegation automation (#469) |

--- a/plan/history/2605/implementation/534.md
+++ b/plan/history/2605/implementation/534.md
@@ -1,0 +1,8 @@
+---
+source: '534'
+timestamp: '2026-05-15T23:29:28.492541+00:00'
+title: 'fix(#534): eliminate per-app singleton sharing in create_app()'
+type: implementation
+---
+
+Added make_dispatcher() factory that creates an ActivityDispatcher without touching_DISPATCHER global. Threaded dispatcher param through dispatch(), handle_inbox_item(), _dispatch_or_defer_inbox_item(),_process_inbox_item(), inbox_handler(). Updated_make_lifespan(configure_globals=False) to call make_dispatcher() and store on app.state.dispatcher; auto-inject isolated SqliteDataLayer via dependency_overrides[get_shared_dl] when not already overridden; teardown cleans up on shutdown. Added _auto_inject_isolated_datalayer() and _teardown_per_app_state() helpers to keep complexity at or below 10. Updated actors.py to pass per-app dispatcher to inbox_handler. Added 10 new tests. 2592 tests pass. PR #540.

--- a/test/adapters/driving/fastapi/test_app_isolation.py
+++ b/test/adapters/driving/fastapi/test_app_isolation.py
@@ -1,0 +1,125 @@
+"""Tests for per-app singleton isolation in create_app() (issue #534).
+
+Verifies that each create_app() call produces an independent application
+with its own DataLayer and dispatcher — no shared module-level state.
+"""
+
+#  Copyright (c) 2025-2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute
+#    to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype
+#  is licensed under a MIT (SEI)-style license, please see LICENSE.md
+#  distributed with this Software or contact permission@sei.cmu.edu for full
+#  terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+import pytest
+from fastapi.testclient import TestClient
+
+from vultron.adapters.driving.fastapi import inbox_handler as ih
+from vultron.adapters.driving.fastapi.app import create_app
+
+
+@pytest.fixture
+def app1():
+    return create_app(docs_url=None, openapi_url=None)
+
+
+@pytest.fixture
+def app2():
+    return create_app(docs_url=None, openapi_url=None)
+
+
+def test_create_app_auto_injects_datalayer(app1):
+    """create_app() lifespan should auto-inject a DataLayer override."""
+    from vultron.adapters.driven.datalayer import get_shared_dl
+
+    with TestClient(app1):
+        assert get_shared_dl in app1.dependency_overrides
+
+
+def test_create_app_datalayers_are_distinct(app1, app2):
+    """Two create_app() instances must not share the same DataLayer."""
+    from vultron.adapters.driven.datalayer import get_shared_dl
+
+    with TestClient(app1), TestClient(app2):
+        dl1 = app1.dependency_overrides[get_shared_dl]()
+        dl2 = app2.dependency_overrides[get_shared_dl]()
+        assert dl1 is not dl2
+
+
+def test_create_app_datalayers_are_isolated(app1, app2):
+    """An actor created via app1 must not be visible to app2."""
+    from vultron.wire.as2.vocab.base.objects.actors import as_Service
+
+    actor_id = "https://example.org/actors/isolated-test-actor"
+    actor = as_Service(id_=actor_id, name="IsolatedTestActor")
+
+    with TestClient(app1), TestClient(app2):
+        from vultron.adapters.driven.datalayer import get_shared_dl
+
+        dl1 = app1.dependency_overrides[get_shared_dl]()
+        dl2 = app2.dependency_overrides[get_shared_dl]()
+
+        dl1.save(actor)
+
+        assert dl1.read(actor_id) is not None
+        assert dl2.read(actor_id) is None
+
+
+def test_create_app_datalayer_override_not_clobbered(app1):
+    """A pre-registered dependency_overrides entry is not overwritten."""
+    from vultron.adapters.driven.datalayer import get_shared_dl
+    from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+
+    custom_dl = SqliteDataLayer(db_url="sqlite:///:memory:")
+    app1.dependency_overrides[get_shared_dl] = lambda: custom_dl
+
+    with TestClient(app1):
+        resolved = app1.dependency_overrides[get_shared_dl]()
+        assert resolved is custom_dl
+
+
+def test_create_app_per_app_dispatcher_on_state(app1):
+    """create_app() lifespan stores a dispatcher on app.state.dispatcher."""
+    with TestClient(app1):
+        d = getattr(app1.state, "dispatcher", None)
+        assert d is not None
+        assert hasattr(d, "dispatch") and callable(d.dispatch)
+
+
+def test_create_app_does_not_mutate_global_dispatcher(app1):
+    """create_app() lifespan must not overwrite the module-level _DISPATCHER."""
+    original = ih._DISPATCHER
+
+    with TestClient(app1):
+        assert ih._DISPATCHER is original
+
+
+def test_create_app_dispatchers_are_distinct(app1, app2):
+    """Two create_app() instances must each have their own dispatcher."""
+    with TestClient(app1), TestClient(app2):
+        d1 = app1.state.dispatcher
+        d2 = app2.state.dispatcher
+        assert d1 is not None
+        assert d2 is not None
+        assert d1 is not d2
+
+
+def test_create_app_lifespan_cleanup(app1):
+    """After TestClient exits the lifespan, per-app state is cleared."""
+    from vultron.adapters.driven.datalayer import get_shared_dl
+
+    with TestClient(app1):
+        pass
+
+    assert app1.state.emitter is None
+    assert app1.state.dispatcher is None
+    assert getattr(app1.state, "shared_dl", None) is None
+    assert get_shared_dl not in app1.dependency_overrides

--- a/test/adapters/driving/fastapi/test_inbox_handler.py
+++ b/test/adapters/driving/fastapi/test_inbox_handler.py
@@ -100,7 +100,13 @@ def test_inbox_handler_retries_and_aborts_after_too_many_errors(monkeypatch):
     monkeypatch.setattr(ih, "rehydrate", lambda x, dl=None: item)
 
     def fail_and_requeue(
-        actor_id, canonical_actor_id, item_id, item, dl, queue_dl
+        actor_id,
+        canonical_actor_id,
+        item_id,
+        item,
+        dl,
+        queue_dl,
+        dispatcher=None,
     ):
         queue_dl.inbox_append(item_id)
         return False
@@ -113,7 +119,32 @@ def test_inbox_handler_retries_and_aborts_after_too_many_errors(monkeypatch):
     assert item_id in _queue
 
 
-def test_dispatch_raises_if_not_initialised(monkeypatch):
+def test_dispatch_uses_explicit_dispatcher(monkeypatch):
+    """dispatch() should use the provided dispatcher, not the global."""
+    from types import SimpleNamespace
+    from typing import cast
+
+    monkeypatch.setattr(ih, "_DISPATCHER", None)
+    explicit_dispatcher = Mock()
+    fake_event = cast(
+        VultronEvent, SimpleNamespace(activity_id="x", semantic_type="y")
+    )
+    mock_dl = MagicMock()
+
+    ih.dispatch(fake_event, mock_dl, dispatcher=explicit_dispatcher)
+
+    explicit_dispatcher.dispatch.assert_called_once_with(fake_event, mock_dl)
+
+
+def test_make_dispatcher_does_not_mutate_global(monkeypatch):
+    """make_dispatcher() must not touch the module-level _DISPATCHER."""
+    sentinel = object()
+    monkeypatch.setattr(ih, "_DISPATCHER", sentinel)
+
+    result = ih.make_dispatcher()
+
+    assert ih._DISPATCHER is sentinel
+    assert result is not sentinel
     monkeypatch.setattr(ih, "_DISPATCHER", None)
     fake_event = cast(
         VultronEvent, SimpleNamespace(activity_id="x", semantic_type="y")

--- a/test/adapters/driving/fastapi/test_inbox_handler.py
+++ b/test/adapters/driving/fastapi/test_inbox_handler.py
@@ -121,9 +121,6 @@ def test_inbox_handler_retries_and_aborts_after_too_many_errors(monkeypatch):
 
 def test_dispatch_uses_explicit_dispatcher(monkeypatch):
     """dispatch() should use the provided dispatcher, not the global."""
-    from types import SimpleNamespace
-    from typing import cast
-
     monkeypatch.setattr(ih, "_DISPATCHER", None)
     explicit_dispatcher = Mock()
     fake_event = cast(

--- a/vultron/adapters/driving/fastapi/app.py
+++ b/vultron/adapters/driving/fastapi/app.py
@@ -63,6 +63,41 @@ def configure_logging() -> None:
         uvicorn_access_logger.propagate = True
 
 
+def _auto_inject_isolated_datalayer(application: FastAPI) -> None:
+    """Auto-inject an in-memory DataLayer if none is already registered.
+
+    Called during :func:`_make_lifespan` startup when ``configure_globals``
+    is ``False``.  If the caller has already registered an override (e.g. a
+    test fixture's ``SqliteDataLayer``), it is left untouched.  Otherwise a
+    fresh in-memory database is created and stored on ``app.state.shared_dl``
+    so it can be closed on shutdown.
+    """
+    from vultron.adapters.driven.datalayer import get_shared_dl
+
+    if get_shared_dl in application.dependency_overrides:
+        return
+
+    from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+
+    isolated_dl = SqliteDataLayer(db_url="sqlite:///:memory:")
+    application.dependency_overrides[get_shared_dl] = lambda: isolated_dl
+    application.state.shared_dl = isolated_dl
+
+
+def _teardown_per_app_state(application: FastAPI) -> None:
+    """Clean up per-app dispatcher and DataLayer state on lifespan shutdown."""
+    from vultron.adapters.driven.datalayer import get_shared_dl
+
+    application.state.dispatcher = None
+    dl_to_close = getattr(application.state, "shared_dl", None)
+    if dl_to_close is None:
+        return
+    application.state.shared_dl = None
+    if get_shared_dl in application.dependency_overrides:
+        del application.dependency_overrides[get_shared_dl]
+    dl_to_close.close()
+
+
 def _make_lifespan(
     *, configure_globals: bool = True, mount_prefix: str = "/api/v2"
 ):
@@ -93,11 +128,19 @@ def _make_lifespan(
         from vultron.adapters.driven.asgi_emitter import ASGIEmitter
         from vultron.adapters.driving.fastapi.inbox_handler import (
             init_dispatcher,
+            make_dispatcher,
         )
 
-        init_dispatcher()
+        if configure_globals:
+            init_dispatcher()
+        else:
+            application.state.dispatcher = make_dispatcher()
+
         emitter = ASGIEmitter(app=application, mount_prefix=mount_prefix)
         application.state.emitter = emitter
+
+        if not configure_globals:
+            _auto_inject_isolated_datalayer(application)
 
         monitor = None
         if configure_globals:
@@ -120,6 +163,9 @@ def _make_lifespan(
         # cannot leak between TestClient lifetimes on the same app
         # singleton (e.g. unit tests followed by integration tests).
         application.state.emitter = None
+
+        if not configure_globals:
+            _teardown_per_app_state(application)
 
     return _lifespan
 
@@ -168,14 +214,26 @@ def create_app(
     """Factory that creates a fresh, isolated FastAPI application instance.
 
     Each call produces an independent application with its own lifespan
-    context (emitter stored on ``app.state.emitter``).  Global singletons
-    (the module-level default emitter, ``OutboxMonitor``) are NOT modified
-    so that multiple ``create_app()`` instances can coexist in the same
-    process without contaminating each other.  The inbox dispatcher is
-    always initialised so inbox delivery works out of the box.
+    context.  During startup the lifespan automatically:
 
-    Override ``app.dependency_overrides[get_shared_dl]`` after calling this
-    factory to inject a per-actor in-memory DataLayer for full test isolation.
+    - Creates a per-app inbox dispatcher (stored on ``app.state.dispatcher``)
+      so that multiple ``create_app()`` instances in the same process never
+      share the module-level ``_DISPATCHER`` global (issue #534).
+    - Injects a fresh in-memory ``SqliteDataLayer`` via
+      ``app.dependency_overrides[get_shared_dl]`` when no override has
+      already been registered, giving each instance its own isolated
+      storage (issue #534).
+
+    If you need a specific DataLayer (e.g. a file-backed SQLite database or
+    a test-fixture instance), register the override *before* the lifespan
+    starts (i.e. before calling ``TestClient.__enter__()``):
+
+    .. code-block:: python
+
+        app = create_app(docs_url=None, openapi_url=None)
+        app.dependency_overrides[get_shared_dl] = lambda: my_dl
+        with TestClient(app) as client:
+            ...
 
     Args:
         title: OpenAPI title.

--- a/vultron/adapters/driving/fastapi/app.py
+++ b/vultron/adapters/driving/fastapi/app.py
@@ -88,6 +88,10 @@ def _teardown_per_app_state(application: FastAPI) -> None:
     """Clean up per-app dispatcher and DataLayer state on lifespan shutdown."""
     from vultron.adapters.driven.datalayer import get_shared_dl
 
+    # Clear dispatcher BEFORE the early return: even when the DataLayer was
+    # supplied by a pre-registered override (app.state.shared_dl is None),
+    # the per-app dispatcher was still created by this lifespan and must be
+    # released so it cannot leak across lifespan restarts on the same app.
     application.state.dispatcher = None
     dl_to_close = getattr(application.state, "shared_dl", None)
     if dl_to_close is None:

--- a/vultron/adapters/driving/fastapi/inbox_handler.py
+++ b/vultron/adapters/driving/fastapi/inbox_handler.py
@@ -93,6 +93,32 @@ _TRIGGER_ACTIVITY_PORT_SEMANTICS = frozenset(
 )
 
 
+def make_dispatcher() -> ActivityDispatcher:
+    """Create and return a new inbox dispatcher without mutating any global.
+
+    Use this in :func:`create_app` lifespans to build a per-app dispatcher
+    that is stored on ``app.state.dispatcher`` instead of the module-level
+    ``_DISPATCHER``.  Production code (``app_v2``) continues to call
+    :func:`init_dispatcher` so the global is set for backward-compatible
+    callers such as the CLI.
+    """
+    port_factories: dict = {
+        sem: _sync_port_factory for sem in _SYNC_PORT_SEMANTICS
+    }
+    port_factories.update(
+        {
+            sem: _trigger_activity_port_factory
+            for sem in _TRIGGER_ACTIVITY_PORT_SEMANTICS
+        }
+    )
+    d = get_dispatcher(
+        use_case_map=_use_case_map(),
+        port_factories=port_factories,
+    )
+    logger.debug("Created inbox dispatcher: %s", type(d).__name__)
+    return d
+
+
 def init_dispatcher(dl: DataLayer | None = None) -> None:
     """Initialise the module-level dispatcher.
 
@@ -105,31 +131,33 @@ def init_dispatcher(dl: DataLayer | None = None) -> None:
             passed at dispatch time via :func:`dispatch`.
     """
     global _DISPATCHER
-    port_factories = {sem: _sync_port_factory for sem in _SYNC_PORT_SEMANTICS}
-    port_factories.update(
-        {
-            sem: _trigger_activity_port_factory
-            for sem in _TRIGGER_ACTIVITY_PORT_SEMANTICS
-        }
-    )
-    _DISPATCHER = get_dispatcher(
-        use_case_map=_use_case_map(),
-        port_factories=port_factories,
-    )
+    _DISPATCHER = make_dispatcher()
     logger.info("Initialised inbox dispatcher: %s", type(_DISPATCHER).__name__)
 
 
-def dispatch(event: VultronEvent, dl: DataLayer) -> None:
-    """Dispatch the given domain event using the module-level dispatcher.
+def dispatch(
+    event: VultronEvent,
+    dl: DataLayer,
+    dispatcher: ActivityDispatcher | None = None,
+) -> None:
+    """Dispatch the given domain event.
+
+    Uses *dispatcher* when provided; otherwise falls back to the module-level
+    ``_DISPATCHER`` (set by :func:`init_dispatcher`).  Passing an explicit
+    dispatcher enables per-app isolation when multiple :func:`create_app`
+    instances coexist in the same process (issue #534).
 
     Args:
         event: The domain event to dispatch.
         dl: The DataLayer instance scoped to the current actor.
+        dispatcher: Optional per-app dispatcher.  When ``None`` the
+            module-level ``_DISPATCHER`` is used (backward-compatible).
     Raises:
-        RuntimeError: If the dispatcher has not been initialised via
-            :func:`init_dispatcher`.
+        RuntimeError: If no dispatcher is available (neither *dispatcher*
+            nor the module-level ``_DISPATCHER`` has been initialised).
     """
-    if _DISPATCHER is None:
+    _d = dispatcher or _DISPATCHER
+    if _d is None:
         raise RuntimeError(
             "Inbox dispatcher not initialised. "
             "Call init_dispatcher() during application startup."
@@ -139,16 +167,23 @@ def dispatch(event: VultronEvent, dl: DataLayer) -> None:
         event.activity_id,
         event.semantic_type,
     )
-    _DISPATCHER.dispatch(event, dl)
+    _d.dispatch(event, dl)
 
 
-def handle_inbox_item(actor_id: str, obj: as_Activity, dl: DataLayer) -> None:
+def handle_inbox_item(
+    actor_id: str,
+    obj: as_Activity,
+    dl: DataLayer,
+    dispatcher: ActivityDispatcher | None = None,
+) -> None:
     """Handle a single item in the Actor's inbox.
 
     Args:
         actor_id: The canonical URI of the Actor whose inbox is being processed.
         obj: The Activity item to process.
         dl: The DataLayer instance used for reads and dispatch.
+        dispatcher: Optional per-app dispatcher.  When ``None`` the
+            module-level ``_DISPATCHER`` is used (backward-compatible).
     """
     logger.info("Processing item '%s' for actor '%s'", obj.name, actor_id)
     logger.debug(
@@ -157,7 +192,7 @@ def handle_inbox_item(actor_id: str, obj: as_Activity, dl: DataLayer) -> None:
     )
     event = prepare_for_dispatch(activity=obj)
     event = event.model_copy(update={"receiving_actor_id": actor_id})
-    dispatch(event=event, dl=dl)
+    dispatch(event=event, dl=dl, dispatcher=dispatcher)
 
 
 def _activity_context_id(
@@ -217,6 +252,7 @@ def _dispatch_or_defer_inbox_item(
     obj: as_Activity,
     dl: DataLayer,
     queue_dl: DataLayer,
+    dispatcher: ActivityDispatcher | None = None,
 ) -> VultronEvent | None:
     """Dispatch an inbox item or defer it until its case replica exists."""
     event = prepare_for_dispatch(activity=obj)
@@ -236,7 +272,7 @@ def _dispatch_or_defer_inbox_item(
         _queue_pending_case_activity(queue_dl, case_id, event.activity_id)
         return None
 
-    dispatch(event=event, dl=dl)
+    dispatch(event=event, dl=dl, dispatcher=dispatcher)
     return event
 
 
@@ -263,6 +299,7 @@ def _process_inbox_item(
     item: as_Activity,
     dl: DataLayer,
     queue_dl: DataLayer,
+    dispatcher: ActivityDispatcher | None = None,
 ) -> bool:
     """Dispatch one inbox activity and return ``True`` on success."""
     _log_rehydrated_item(item)
@@ -273,6 +310,7 @@ def _process_inbox_item(
             obj=item,
             dl=dl,
             queue_dl=queue_dl,
+            dispatcher=dispatcher,
         )
         if event is not None:
             case_id = _activity_context_id(item, event)
@@ -300,6 +338,7 @@ async def inbox_handler(
     dl: DataLayer,
     actor_dl: DataLayer | None = None,
     emitter: ActivityEmitter | None = None,
+    dispatcher: ActivityDispatcher | None = None,
 ) -> None:
     """Process the inbox for the given actor.
 
@@ -321,6 +360,11 @@ async def inbox_handler(
             this emitter instead of the module-level default.  This enables
             per-app delivery routing so that co-located actors in the same
             process can each use their own isolated emitter configuration.
+        dispatcher: Optional per-app dispatcher (from
+            ``request.app.state.dispatcher``).  When provided, inbox items
+            are routed through this dispatcher instead of the module-level
+            ``_DISPATCHER``, giving each :func:`create_app` instance its
+            own fully isolated routing table (issue #534).
     """
     queue_dl = actor_dl if actor_dl is not None else dl
     actor = dl.read(actor_id)
@@ -359,6 +403,7 @@ async def inbox_handler(
             item=item,
             dl=dl,
             queue_dl=queue_dl,
+            dispatcher=dispatcher,
         ):
             err_count += 1
             if err_count > 3:

--- a/vultron/adapters/driving/fastapi/routers/actors.py
+++ b/vultron/adapters/driving/fastapi/routers/actors.py
@@ -469,8 +469,9 @@ def post_actor_inbox(
     actor_dl = dl.clone_for_actor(canonical_actor_id)
     actor_dl.inbox_append(activity.id_)
     emitter = getattr(request.app.state, "emitter", None)
+    dispatcher = getattr(request.app.state, "dispatcher", None)
     background_tasks.add_task(
-        inbox_handler, canonical_actor_id, dl, actor_dl, emitter
+        inbox_handler, canonical_actor_id, dl, actor_dl, emitter, dispatcher
     )
     return None
 


### PR DESCRIPTION
## Summary

Fixes #534 — co-located actors in the same process sharing module-level singletons (emitter, dispatcher, DataLayer).

## Root cause

Three module-level singletons caused isolation failures when multiple `create_app()` instances ran in the same Python process:

1. **`_DISPATCHER`** (`inbox_handler.py`): `init_dispatcher()` mutated the global on every `create_app()` startup — all instances shared the same routing table.
2. **DataLayer `_shared_instance`** (`datalayer_sqlite.py`): without a manual `dependency_overrides` entry, all `create_app()` instances shared the same SQLite engine. A Case Actor could see a report-receiver's data directly without inbox delivery.

## Fix

### `inbox_handler.py`
- **New `make_dispatcher()`**: creates an `ActivityDispatcher` without touching `_DISPATCHER`. `init_dispatcher()` now delegates to it (backward compat for CLI and production `app_v2`).
- **Thread `dispatcher` param**: added `dispatcher: ActivityDispatcher | None = None` to `dispatch()`, `handle_inbox_item()`, `_dispatch_or_defer_inbox_item()`, `_process_inbox_item()`, and `inbox_handler()`. Falls back to `_DISPATCHER` when not provided.

### `app.py`
- `_make_lifespan(configure_globals=False)` now:
  - Calls `make_dispatcher()` and stores result on `app.state.dispatcher` (never touches global)
  - Auto-injects a fresh `SqliteDataLayer('sqlite:///:memory:')` via `dependency_overrides[get_shared_dl]` when not already overridden
  - Cleans up both on shutdown (closes DL, removes override, clears state)
- Helpers `_auto_inject_isolated_datalayer()` and `_teardown_per_app_state()` keep `_make_lifespan` complexity ≤ 10.
- Pre-existing manual `dependency_overrides` (e.g. from `create_isolated_actor_app()`) take precedence — the lifespan skips auto-injection when an override is already registered.

### `actors.py`
- `post_actor_inbox` reads `request.app.state.dispatcher` and passes it to `inbox_handler` alongside the emitter.

## Tests added
- **`test_app_isolation.py`** (8 tests): `create_app()` auto-injects DataLayer, two instances are isolated, manual overrides not clobbered, per-app dispatcher on `app.state`, global `_DISPATCHER` untouched, lifespan cleanup works.
- **`test_inbox_handler.py`** (2 new): `make_dispatcher()` does not mutate global; `dispatch(dispatcher=...)` uses provided dispatcher.

## Test results
```
2592 passed, 12 skipped, 3 xfailed in 46.49s
```

## Size
~300 lines net diff (5 files)