### PR TITLE
refactor(demo): extract shared helpers into vultron/demo/helpers/ (#489)

### DIFF
--- a/plan/history/2605/implementation/ISSUE-489.md
+++ b/plan/history/2605/implementation/ISSUE-489.md
@@ -1,0 +1,16 @@
+---
+source: ISSUE-489
+timestamp: '2026-05-18T13:39:09.660836+00:00'
+title: Extract shared demo helpers into vultron/demo/helpers/
+type: implementation
+---
+
+Extracted scenario-agnostic helper functions from `vultron/demo/scenario/two_actor_demo.py` (~2050 lines) into a new `vultron/demo/helpers/` package.
+
+New sub-modules: polling.py (wait_for_*helpers + *poll_until), actions.py (actor_notifies** wrappers), seeding.py (_dl_key, get_actor_by_id, seed_containers), sync.py (SYNC-2 trigger_log_commit, verify_replica_state), verification.py (assertion primitives). Full re-export **init**.py preserves all module-level names for backward compatibility.
+
+The scenario file shrank from ~2050 to ~1210 lines. reset_containers was retained in-place because tests patch vultron.demo.scenario.two_actor_demo.reset_datalayer.
+
+Key constraint handled: verify_replica_state kept original parameter names (finder_client/vendor_client) to match test call sites.
+
+All 2592 tests pass (full suite including integration). mypy, pyright, black, flake8 clean. PR #541 closes Issue #489.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,8 @@ testpaths = [
 filterwarnings = [
     "always::vultron.metadata.specs.UnknownSpecIdWarning",
     "error",
+    "ignore::DeprecationWarning:vultron.demo.scenario.three_actor_demo",
+    "ignore::DeprecationWarning:vultron.demo.scenario.multi_vendor_demo",
 ]
 markers = [
     "integration: marks tests as integration tests (exercise the full HTTP stack; deselected by default)",

--- a/vultron/demo/helpers/__init__.py
+++ b/vultron/demo/helpers/__init__.py
@@ -13,7 +13,7 @@
 
 """Shared demo helper library.
 
-Re-exports the full public surface of all five sub-modules so callers can
+Re-exports the full public surface of all sub-modules so callers can
 import from ``vultron.demo.helpers`` directly.
 
 Sub-modules
@@ -27,7 +27,14 @@ Sub-modules
 - :mod:`~vultron.demo.helpers.sync` — SYNC-2 ``trigger_log_commit`` and
   ``verify_replica_state``.
 - :mod:`~vultron.demo.helpers.verification` — lower-level participant and
-  case-state assertion primitives.
+  case-state assertion primitives, plus ``verify_coordinator_case_state``
+  and ``verify_case_actor_unused``.
+- :mod:`~vultron.demo.helpers.workflow` — ``reporter_submits_report``,
+  ``coordinator_validates_report``, and ``find_case_for_offer``.
+- :mod:`~vultron.demo.helpers.notes` — ``participant_adds_note_to_case``.
+- :mod:`~vultron.demo.helpers.milestones` — lifecycle milestone verifiers
+  (``verify_case_active``, ``verify_fix_ready``, ``verify_fix_deployed``,
+  ``verify_publicly_disclosed``, ``verify_case_closed``).
 """
 
 from vultron.demo.helpers.actions import (  # noqa: F401
@@ -36,6 +43,16 @@ from vultron.demo.helpers.actions import (  # noqa: F401
     actor_notifies_fix_ready,
     actor_notifies_published,
     actor_notifies_state_change,
+)
+from vultron.demo.helpers.milestones import (  # noqa: F401
+    verify_case_active,
+    verify_case_closed,
+    verify_fix_deployed,
+    verify_fix_ready,
+    verify_publicly_disclosed,
+)
+from vultron.demo.helpers.notes import (  # noqa: F401
+    participant_adds_note_to_case,
 )
 from vultron.demo.helpers.polling import (  # noqa: F401
     _poll_until,
@@ -70,4 +87,13 @@ from vultron.demo.helpers.verification import (  # noqa: F401
     _fetch_participant,
     _fetch_participant_data,
     _require_case_participant_id,
+    verify_case_actor_unused,
+    verify_coordinator_case_state,
+)
+from vultron.demo.helpers.workflow import (  # noqa: F401
+    _load_case_from_datalayer,
+    _report_id_from_offer_data,
+    coordinator_validates_report,
+    find_case_for_offer,
+    reporter_submits_report,
 )

--- a/vultron/demo/helpers/__init__.py
+++ b/vultron/demo/helpers/__init__.py
@@ -1,0 +1,73 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Shared demo helper library.
+
+Re-exports the full public surface of all five sub-modules so callers can
+import from ``vultron.demo.helpers`` directly.
+
+Sub-modules
+-----------
+- :mod:`~vultron.demo.helpers.polling` — ``_poll_until`` and all
+  ``wait_for_*`` helpers.
+- :mod:`~vultron.demo.helpers.actions` — ``actor_notifies_state_change``
+  and named CVD lifecycle action wrappers.
+- :mod:`~vultron.demo.helpers.seeding` — ``_dl_key``, ``get_actor_by_id``,
+  and ``seed_containers``.
+- :mod:`~vultron.demo.helpers.sync` — SYNC-2 ``trigger_log_commit`` and
+  ``verify_replica_state``.
+- :mod:`~vultron.demo.helpers.verification` — lower-level participant and
+  case-state assertion primitives.
+"""
+
+from vultron.demo.helpers.actions import (  # noqa: F401
+    actor_closes_case,
+    actor_notifies_fix_deployed,
+    actor_notifies_fix_ready,
+    actor_notifies_published,
+    actor_notifies_state_change,
+)
+from vultron.demo.helpers.polling import (  # noqa: F401
+    _poll_until,
+    wait_for_all_participants_rm_closed,
+    wait_for_case_em_terminated,
+    wait_for_case_on_container,
+    wait_for_case_participants,
+    wait_for_finder_case,
+    wait_for_finder_log_entry,
+    wait_for_note_in_case,
+    wait_for_participant_vfd_state,
+)
+from vultron.demo.helpers.seeding import (  # noqa: F401
+    _dl_key,
+    get_actor_by_id,
+    seed_containers,
+)
+from vultron.demo.helpers.sync import (  # noqa: F401
+    _extract_ref_id,
+    _get_log_entries_for_case,
+    trigger_log_commit,
+    verify_finder_replica_state,
+    verify_replica_state,
+)
+from vultron.demo.helpers.verification import (  # noqa: F401
+    _all_fetchable_participants_rm_closed,
+    _assert_case_notes,
+    _assert_participant_vfd_pxa,
+    _assert_vendor_case_status,
+    _assert_vendor_participant_state,
+    _check_participant_vfd_state_in,
+    _fetch_participant,
+    _fetch_participant_data,
+    _require_case_participant_id,
+)

--- a/vultron/demo/helpers/__init__.py
+++ b/vultron/demo/helpers/__init__.py
@@ -23,7 +23,7 @@ Sub-modules
 - :mod:`~vultron.demo.helpers.actions` — ``actor_notifies_state_change``
   and named CVD lifecycle action wrappers.
 - :mod:`~vultron.demo.helpers.seeding` — ``_dl_key``, ``get_actor_by_id``,
-  and ``seed_containers``.
+  ``seed_containers``, and ``reset_containers``.
 - :mod:`~vultron.demo.helpers.sync` — SYNC-2 ``trigger_log_commit`` and
   ``verify_replica_state``.
 - :mod:`~vultron.demo.helpers.verification` — lower-level participant and
@@ -68,6 +68,7 @@ from vultron.demo.helpers.polling import (  # noqa: F401
 from vultron.demo.helpers.seeding import (  # noqa: F401
     _dl_key,
     get_actor_by_id,
+    reset_containers,
     seed_containers,
 )
 from vultron.demo.helpers.sync import (  # noqa: F401

--- a/vultron/demo/helpers/actions.py
+++ b/vultron/demo/helpers/actions.py
@@ -1,0 +1,170 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Actor action helpers for demo workflows.
+
+Provides :func:`actor_notifies_state_change` as a generic trigger wrapper and
+named aliases for each concrete CVD lifecycle notification, plus
+:func:`actor_closes_case`.
+"""
+
+import logging
+
+from vultron.demo.utils import (
+    DataLayerClient,
+    demo_step,
+    post_to_trigger,
+    ref_id,
+)
+from vultron.wire.as2.vocab.base.objects.actors import as_Actor
+
+logger = logging.getLogger(__name__)
+
+
+def actor_notifies_state_change(
+    client: DataLayerClient,
+    actor: as_Actor,
+    case_id: str,
+    behavior: str,
+    description: str,
+) -> dict:
+    """Generic wrapper: actor self-reports a CVD lifecycle state change.
+
+    Posts to the ``demo`` trigger endpoint for *behavior* and logs a
+    ``demo_step`` banner with *description*.
+
+    Args:
+        client: DataLayerClient connected to the actor's container.
+        actor: The actor reporting the state change.
+        case_id: Full URI of the ``VulnerabilityCase``.
+        behavior: Trigger endpoint behaviour name
+            (e.g. ``"notify-fix-ready"``).
+        description: Human-readable description for the ``demo_step`` banner.
+
+    Returns:
+        Response dict from the trigger endpoint.
+    """
+    with demo_step(f"Actor {ref_id(actor)} {description}"):
+        return post_to_trigger(
+            client=client,
+            actor_id=actor.id_,
+            behavior=behavior,
+            body={"case_id": case_id},
+            path_prefix="demo",
+        )
+
+
+def actor_notifies_fix_ready(
+    client: DataLayerClient,
+    actor: as_Actor,
+    case_id: str,
+) -> dict:
+    """Self-report fix ready (CS.VFd) via the demo trigger endpoint.
+
+    Sends ``Add(ParticipantStatus(CS.VFd), target=Case)`` to the Case Manager
+    so the Case Actor can update participant state and broadcast to peers.
+
+    Args:
+        client: DataLayerClient connected to the actor's container.
+        actor: The actor that has a fix ready.
+        case_id: Full URI of the ``VulnerabilityCase``.
+
+    Returns:
+        Response dict from the trigger endpoint.
+
+    Spec: DEMOMA-07-001.
+    """
+    return actor_notifies_state_change(
+        client, actor, case_id, "notify-fix-ready", "reports fix ready"
+    )
+
+
+def actor_notifies_fix_deployed(
+    client: DataLayerClient,
+    actor: as_Actor,
+    case_id: str,
+) -> dict:
+    """Self-report fix deployed (CS.VFD) via the demo trigger endpoint.
+
+    Args:
+        client: DataLayerClient connected to the actor's container.
+        actor: The actor that has deployed a fix.
+        case_id: Full URI of the ``VulnerabilityCase``.
+
+    Returns:
+        Response dict from the trigger endpoint.
+
+    Spec: DEMOMA-07-001.
+    """
+    return actor_notifies_state_change(
+        client, actor, case_id, "notify-fix-deployed", "reports fix deployed"
+    )
+
+
+def actor_notifies_published(
+    client: DataLayerClient,
+    actor: as_Actor,
+    case_id: str,
+) -> dict:
+    """Self-report vulnerability publicly disclosed via the demo trigger endpoint.
+
+    When called by the CASE_OWNER (Vendor), the Case Actor automatically
+    initiates embargo teardown on receipt (DEMOMA-07-003 step 4).
+
+    Args:
+        client: DataLayerClient connected to the actor's container.
+        actor: The actor reporting publication.
+        case_id: Full URI of the ``VulnerabilityCase``.
+
+    Returns:
+        Response dict from the trigger endpoint.
+
+    Spec: DEMOMA-07-001.
+    """
+    return actor_notifies_state_change(
+        client,
+        actor,
+        case_id,
+        "notify-published",
+        "reports vulnerability publicly disclosed",
+    )
+
+
+def actor_closes_case(
+    client: DataLayerClient,
+    actor: as_Actor,
+    case_id: str,
+) -> dict:
+    """Self-report case closed (RM.CLOSED) via the demo trigger endpoint.
+
+    When all participants report RM.CLOSED, the Case Actor automatically
+    closes the case (DEMOMA-07-003 step 5).
+
+    Args:
+        client: DataLayerClient connected to the actor's container.
+        actor: The actor closing the case.
+        case_id: Full URI of the ``VulnerabilityCase``.
+
+    Returns:
+        Response dict from the trigger endpoint.
+
+    Spec: DEMOMA-07-001.
+    """
+    with demo_step(f"Actor {ref_id(actor)} closes case"):
+        return post_to_trigger(
+            client=client,
+            actor_id=actor.id_,
+            behavior="close-case",
+            body={"case_id": case_id},
+            path_prefix="demo",
+        )

--- a/vultron/demo/helpers/milestones.py
+++ b/vultron/demo/helpers/milestones.py
@@ -1,0 +1,314 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""CVD lifecycle milestone verification helpers.
+
+Each function verifies the observable system state that corresponds to a named
+milestone in the VFDPxa lifecycle.  Functions are named after the domain event
+they confirm (e.g. ``verify_case_active``, ``verify_fix_ready``) rather than
+opaque milestone numbers (m1–m7).
+
+Specs: DEMOMA-06-002, DEMOMA-06-003.
+"""
+
+import logging
+
+from vultron.core.states.cs import CS_vfd
+from vultron.core.states.em import EM
+from vultron.core.states.rm import RM
+from vultron.core.states.roles import CVDRole
+from vultron.demo.helpers.sync import _extract_ref_id
+from vultron.demo.helpers.verification import (
+    _assert_participant_vfd_pxa,
+    _check_participant_vfd_state_in,
+    _fetch_participant,
+    _fetch_participant_data,
+)
+from vultron.demo.utils import DataLayerClient
+from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+
+logger = logging.getLogger(__name__)
+
+
+def verify_case_active(
+    coordinator_client: DataLayerClient,
+    reporter_client: DataLayerClient,
+    case_id: str,
+    coordinator_actor_id: str,
+    reporter_actor_id: str,
+) -> None:
+    """Verify that the case is active with required participants and EM.ACTIVE.
+
+    Checks the coordinator DataLayer for the required participants (coordinator
+    and reporter) plus at least one Case Actor (≥3 total) with an active
+    embargo, then verifies the reporter DataLayer has a matching case replica.
+
+    Spec: DEMOMA-06-002, DEMOMA-06-003.
+
+    Args:
+        coordinator_client: Client connected to the coordinator container.
+        reporter_client: Client connected to the reporter container.
+        case_id: Full URI of the ``VulnerabilityCase``.
+        coordinator_actor_id: Full URI of the coordinator actor.
+        reporter_actor_id: Full URI of the reporter actor.
+
+    Raises:
+        AssertionError: If any invariant is violated.
+    """
+    # Coordinator side
+    case_data = coordinator_client.get(f"/datalayer/{case_id}")
+    assert (
+        case_data
+    ), f"verify_case_active: coordinator case {case_id!r} not found"
+    case = VulnerabilityCase.model_validate(case_data)
+
+    required = {coordinator_actor_id, reporter_actor_id}
+    missing = required - set(case.actor_participant_index.keys())
+    if missing:
+        raise AssertionError(
+            f"verify_case_active: required participants missing from coordinator"
+            f" case: {missing}"
+        )
+    other_actors = set(case.actor_participant_index.keys()) - required
+    if not other_actors:
+        raise AssertionError(
+            "verify_case_active: expected a Case Actor participant in addition"
+            " to coordinator and reporter"
+        )
+    if case.current_status.em_state != EM.ACTIVE:
+        raise AssertionError(
+            f"verify_case_active coordinator: expected EM.ACTIVE, found"
+            f" {case.current_status.em_state}"
+        )
+    if case.active_embargo is None:
+        raise AssertionError(
+            "verify_case_active coordinator: case has no active_embargo"
+        )
+    logger.info(
+        "✓ case active (coordinator): required participants (coordinator,"
+        " reporter) + case-actor present, EM.ACTIVE, embargo present"
+    )
+
+    # Reporter side: replica must exist with matching participant index and embargo
+    reporter_case_data = reporter_client.get(f"/datalayer/{case_id}")
+    if not reporter_case_data:
+        raise AssertionError(
+            f"verify_case_active: reporter does not have case replica for"
+            f" {case_id!r} — outbox delivery may not have completed"
+        )
+    reporter_case = VulnerabilityCase.model_validate(reporter_case_data)
+
+    coordinator_embargo_id = _extract_ref_id(case.active_embargo)
+    reporter_embargo_id = _extract_ref_id(reporter_case.active_embargo)
+    if (
+        coordinator_embargo_id is not None
+        and coordinator_embargo_id != reporter_embargo_id
+    ):
+        raise AssertionError(
+            f"verify_case_active: reporter active_embargo {reporter_embargo_id!r}"
+            f" != coordinator active_embargo {coordinator_embargo_id!r}"
+        )
+    logger.info(
+        "✓ case active (reporter): case replica present, matching participant"
+        " index and active embargo"
+    )
+
+
+def verify_fix_ready(
+    coordinator_client: DataLayerClient,
+    reporter_client: DataLayerClient,
+    case_id: str,
+    coordinator_actor_id: str,
+) -> None:
+    """Verify that both replicas show CS includes F (fix ready).
+
+    Spec: DEMOMA-06-002.
+
+    Args:
+        coordinator_client: Client connected to the coordinator container.
+        reporter_client: Client connected to the reporter container.
+        case_id: Full URI of the ``VulnerabilityCase``.
+        coordinator_actor_id: Full URI of the coordinator actor whose
+            participant vfd_state to check.
+
+    Raises:
+        AssertionError: If either replica does not reflect fix-ready state.
+    """
+    fix_ready_states = {CS_vfd.VFd, CS_vfd.VFD}
+    _check_participant_vfd_state_in(
+        coordinator_client,
+        case_id,
+        coordinator_actor_id,
+        fix_ready_states,
+        "verify_fix_ready coordinator",
+    )
+    _check_participant_vfd_state_in(
+        reporter_client,
+        case_id,
+        coordinator_actor_id,
+        fix_ready_states,
+        "verify_fix_ready reporter replica",
+    )
+    logger.info("✓ fix ready: both replicas show CS includes F (fix ready)")
+
+
+def verify_fix_deployed(
+    coordinator_client: DataLayerClient,
+    reporter_client: DataLayerClient,
+    case_id: str,
+    coordinator_actor_id: str,
+) -> None:
+    """Verify that both replicas show CS includes D (fix deployed).
+
+    Spec: DEMOMA-06-002.
+
+    Args:
+        coordinator_client: Client connected to the coordinator container.
+        reporter_client: Client connected to the reporter container.
+        case_id: Full URI of the ``VulnerabilityCase``.
+        coordinator_actor_id: Full URI of the coordinator actor whose
+            participant vfd_state to check.
+
+    Raises:
+        AssertionError: If either replica does not reflect fix-deployed state.
+    """
+    deployed_state = {CS_vfd.VFD}
+    _check_participant_vfd_state_in(
+        coordinator_client,
+        case_id,
+        coordinator_actor_id,
+        deployed_state,
+        "verify_fix_deployed coordinator",
+    )
+    _check_participant_vfd_state_in(
+        reporter_client,
+        case_id,
+        coordinator_actor_id,
+        deployed_state,
+        "verify_fix_deployed reporter replica",
+    )
+    logger.info(
+        "✓ fix deployed: both replicas show CS includes D (fix deployed)"
+    )
+
+
+def verify_publicly_disclosed(
+    coordinator_client: DataLayerClient,
+    reporter_client: DataLayerClient,
+    case_id: str,
+    coordinator_actor_id: str,
+) -> None:
+    """Verify that both replicas reflect CS.VFDPxa and EM has terminated.
+
+    Checks:
+    - Both DataLayers reflect ``EM.EXITED`` on the case.
+    - Coordinator participant's latest status has ``vfd_state == VFD`` and
+      a public-aware ``pxa_state``.
+
+    Spec: DEMOMA-06-002.
+
+    Args:
+        coordinator_client: Client connected to the coordinator container.
+        reporter_client: Client connected to the reporter container.
+        case_id: Full URI of the ``VulnerabilityCase``.
+        coordinator_actor_id: Full URI of the coordinator actor.
+
+    Raises:
+        AssertionError: If any disclosure invariant is violated.
+    """
+    for label, client in [
+        ("coordinator", coordinator_client),
+        ("reporter", reporter_client),
+    ]:
+        case_data = client.get(f"/datalayer/{case_id}")
+        assert (
+            case_data
+        ), f"verify_publicly_disclosed {label}: case {case_id!r} not found"
+        case = VulnerabilityCase.model_validate(case_data)
+        if case.current_status.em_state != EM.EXITED:
+            raise AssertionError(
+                f"verify_publicly_disclosed {label}: expected EM.EXITED,"
+                f" found {case.current_status.em_state}"
+            )
+        logger.info("✓ publicly disclosed %s: EM.EXITED", label)
+
+    # Verify coordinator participant's latest status is VFD + public-aware pxa
+    # on both the coordinator's and reporter's DataLayer replicas.
+    for label, c in [
+        ("coordinator", coordinator_client),
+        ("reporter", reporter_client),
+    ]:
+        p = _fetch_participant(c, case_id, coordinator_actor_id)
+        if p is None:
+            raise AssertionError(
+                f"verify_publicly_disclosed {label}: coordinator participant"
+                f" {coordinator_actor_id!r} not found"
+            )
+        _assert_participant_vfd_pxa(p, label, coordinator_actor_id)
+    logger.info("✓ publicly disclosed: both replicas CS.VFDPxa and EM.EXITED")
+
+
+def verify_case_closed(
+    coordinator_client: DataLayerClient,
+    reporter_client: DataLayerClient,
+    case_id: str,
+) -> None:
+    """Verify that all participants are RM.CLOSED on both replicas.
+
+    The Case Actor automatically closes the case once all participants report
+    RM.CLOSED (DEMOMA-07-003 step 5).  This helper verifies the terminal
+    participant state on both DataLayers.
+
+    Spec: DEMOMA-06-002.
+
+    Args:
+        coordinator_client: Client connected to the coordinator container.
+        reporter_client: Client connected to the reporter container.
+        case_id: Full URI of the ``VulnerabilityCase``.
+
+    Raises:
+        AssertionError: If any non-coordinator participant is not RM.CLOSED
+            on either replica.
+    """
+    for label, client in [
+        ("coordinator", coordinator_client),
+        ("reporter", reporter_client),
+    ]:
+        case_data = client.get(f"/datalayer/{case_id}")
+        assert (
+            case_data
+        ), f"verify_case_closed {label}: case {case_id!r} not found"
+        case = VulnerabilityCase.model_validate(case_data)
+        for a_id, p_id in case.actor_participant_index.items():
+            p_data = _fetch_participant_data(client, p_id)
+            if p_data is None:
+                continue  # remote container — not fetchable here
+            p = CaseParticipant(**p_data)
+            # Case Manager is a coordinator; skip RM closure check.
+            if CVDRole.CASE_MANAGER in (p.case_roles or []):
+                continue
+            latest = p.participant_status
+            if latest is None:
+                raise AssertionError(
+                    f"verify_case_closed {label}: actor '{a_id}' has no"
+                    " participant statuses"
+                )
+            rm = latest.rm_state
+            if rm != RM.CLOSED:
+                raise AssertionError(
+                    f"verify_case_closed {label}: actor '{a_id}' RM state is"
+                    f" {rm!r}, expected RM.CLOSED"
+                )
+        logger.info("✓ case closed %s: all participants RM.CLOSED", label)
+    logger.info("✓ case closed: all participants RM.CLOSED on both replicas")

--- a/vultron/demo/helpers/notes.py
+++ b/vultron/demo/helpers/notes.py
@@ -1,0 +1,103 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Note-exchange helpers for demo workflows.
+
+Provides :func:`participant_adds_note_to_case` as a generic ``Add(Note)``
+action wrapper.  Using the AS2 ``Add`` verb (rather than HTTP "post") keeps
+the naming aligned with the ActivityStreams wire format.
+"""
+
+import logging
+from typing import Optional
+
+from vultron.demo.helpers.polling import wait_for_note_in_case
+from vultron.demo.utils import (
+    DataLayerClient,
+    demo_check,
+    demo_step,
+    post_to_trigger,
+    verify_object_stored,
+)
+from vultron.wire.as2.vocab.base.objects.actors import as_Actor
+from vultron.wire.as2.vocab.base.objects.object_types import as_Note
+from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+
+logger = logging.getLogger(__name__)
+
+
+def participant_adds_note_to_case(
+    posting_client: DataLayerClient,
+    watching_client: DataLayerClient,
+    poster: as_Actor,
+    case: VulnerabilityCase,
+    note_name: str,
+    note_content: str,
+    in_reply_to: Optional[str] = None,
+) -> as_Note:
+    """Participant adds a note to a case via the ``add-note-to-case`` trigger.
+
+    Models the AS2 ``Add(Note)`` action: the posting actor uses their own
+    container's trigger endpoint so the note flows through the poster's outbox
+    to the case host's inbox — reflecting real deployment behavior
+    (D5-7-DEMONOTECLEAN-1).
+
+    Args:
+        posting_client: Client connected to the posting actor's container.
+        watching_client: Client connected to the container where note delivery
+            should be verified (typically the case host or coordinator).
+        poster: The ``as_Actor`` adding the note.
+        case: The ``VulnerabilityCase`` the note belongs to.
+        note_name: Short name / subject for the note.
+        note_content: Full text content of the note.
+        in_reply_to: Optional ID of the note being replied to.
+
+    Returns:
+        The ``as_Note`` fetched from the *watching_client* DataLayer after
+        confirmed delivery.
+
+    Raises:
+        AssertionError: If the trigger does not return a note ID, or if the
+            note does not appear in the case within the polling timeout.
+    """
+    body: dict[str, object] = {
+        "case_id": case.id_,
+        "note_name": note_name,
+        "note_content": note_content,
+    }
+    if in_reply_to is not None:
+        body["in_reply_to"] = in_reply_to
+
+    with demo_step(f"Participant adds note '{note_name}' to case"):
+        result = post_to_trigger(
+            client=posting_client,
+            actor_id=poster.id_,
+            behavior="add-note-to-case",
+            body=body,
+            path_prefix="demo",
+        )
+
+    note_id = result.get("note", {}).get("id")
+    if note_id is None:
+        raise AssertionError(
+            "add-note-to-case trigger did not return a note ID"
+        )
+
+    with demo_check("Note delivered to watching container"):
+        wait_for_note_in_case(watching_client, case.id_, note_id)
+        verify_object_stored(watching_client, note_id)
+
+    logger.info("Note added to case: %s", note_id)
+
+    note_data = watching_client.get(f"/datalayer/{note_id}")
+    return as_Note(**note_data)

--- a/vultron/demo/helpers/polling.py
+++ b/vultron/demo/helpers/polling.py
@@ -1,0 +1,388 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Polling helpers for demo workflows.
+
+Provides a generic ``_poll_until`` primitive and all ``wait_for_*`` functions
+used across demo scenarios.  Centralising polling logic here eliminates
+boilerplate and ensures a single place to tune timeout/interval defaults.
+"""
+
+import logging
+import time
+from typing import Callable
+
+from vultron.demo.utils import DataLayerClient
+from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Generic polling primitive
+# ---------------------------------------------------------------------------
+
+
+def _poll_until(
+    condition_fn: Callable[[], bool],
+    timeout_seconds: float,
+    poll_interval: float = 0.5,
+    error_msg: str = "Timed out waiting for condition",
+    swallow_exceptions: bool = True,
+) -> None:
+    """Poll *condition_fn* until it returns ``True`` or the deadline passes.
+
+    Args:
+        condition_fn: Callable returning ``True`` when the condition is met.
+        timeout_seconds: Maximum time to wait in seconds.
+        poll_interval: Seconds between successive calls to *condition_fn*.
+        error_msg: Message for the ``AssertionError`` raised on timeout.
+        swallow_exceptions: When ``True``, exceptions raised by *condition_fn*
+            are caught and treated as ``False`` (poll continues).  When
+            ``False``, exceptions propagate immediately.
+
+    Raises:
+        AssertionError: If *condition_fn* does not return ``True`` within
+            *timeout_seconds*.
+    """
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        try:
+            if condition_fn():
+                return
+        except Exception:  # noqa: BLE001
+            if not swallow_exceptions:
+                raise
+        time.sleep(poll_interval)
+
+    raise AssertionError(error_msg)
+
+
+# ---------------------------------------------------------------------------
+# Container / case polling helpers
+# ---------------------------------------------------------------------------
+
+
+def wait_for_case_on_container(
+    finder_client: DataLayerClient,
+    case_id: str,
+    timeout_seconds: float = 10.0,
+    poll_interval: float = 0.5,
+) -> None:
+    """Poll *client*'s DataLayer until *case_id* appears.
+
+    Proves that an outbox activity (e.g. ``Create(VulnerabilityCase)``) was
+    delivered to the actor on *client* and its inbox handler processed it.
+
+    In single-server integration tests both actors share the same DataLayer so
+    the case is visible immediately.  In a multi-server Docker demo the case
+    arrives after the outbox background task completes.
+
+    Args:
+        finder_client: DataLayerClient connected to the container to poll.
+        case_id: Full URI of the ``VulnerabilityCase`` to wait for.
+        timeout_seconds: Maximum time to wait before raising.
+        poll_interval: Seconds between DataLayer poll attempts.
+
+    Raises:
+        AssertionError: If *case_id* does not appear within *timeout_seconds*.
+    """
+
+    def _check() -> bool:
+        raw = finder_client.get("/datalayer/VulnerabilityCases/")
+        return isinstance(raw, dict) and case_id in raw
+
+    _poll_until(
+        _check,
+        timeout_seconds,
+        poll_interval,
+        f"Timed out waiting for case {case_id!r} to appear in DataLayer "
+        f"at {finder_client.base_url} — outbox delivery may not have completed",
+        swallow_exceptions=True,
+    )
+
+
+# Backward-compatible alias used by ``two_actor_demo.py`` and its tests.
+wait_for_finder_case = wait_for_case_on_container
+
+
+def wait_for_case_participants(
+    vendor_client: DataLayerClient,
+    case_id: str,
+    expected_count: int,
+    timeout_seconds: float = 5.0,
+    poll_interval: float = 0.25,
+) -> None:
+    """Poll until the case on *vendor_client* reflects *expected_count* participants.
+
+    Args:
+        vendor_client: DataLayerClient for the container to poll.
+        case_id: Full URI of the ``VulnerabilityCase``.
+        expected_count: Minimum number of participants to wait for.
+        timeout_seconds: Maximum time to wait before raising.
+        poll_interval: Seconds between DataLayer poll attempts.
+
+    Raises:
+        AssertionError: If the participant count is not reached within
+            *timeout_seconds*.
+    """
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        case_data = vendor_client.get(f"/datalayer/{case_id}")
+        case = VulnerabilityCase(**case_data)
+        if len(case.case_participants) >= expected_count:
+            return
+        time.sleep(poll_interval)
+
+    final_case = VulnerabilityCase(
+        **vendor_client.get(f"/datalayer/{case_id}")
+    )
+    raise AssertionError(
+        "Timed out waiting for participant count "
+        f"{expected_count}; found {len(final_case.case_participants)}"
+    )
+
+
+def wait_for_note_in_case(
+    client: DataLayerClient,
+    case_id: str,
+    note_id: str,
+    timeout_seconds: float = 10.0,
+    poll_interval: float = 0.5,
+) -> None:
+    """Poll until *note_id* appears in the ``notes`` list of the case.
+
+    Used to confirm that an outbox-delivered note has been processed by the
+    receiving actor's inbox handler.
+
+    Args:
+        client: DataLayerClient for the container to poll.
+        case_id: Full URI of the case.
+        note_id: Full URI of the note to wait for.
+        timeout_seconds: Maximum time to wait before raising.
+        poll_interval: Seconds between DataLayer poll attempts.
+
+    Raises:
+        AssertionError: If *note_id* does not appear within *timeout_seconds*.
+    """
+
+    def _check() -> bool:
+        case_data = client.get(f"/datalayer/{case_id}")
+        case = VulnerabilityCase(**case_data)
+        note_ids = [
+            n if isinstance(n, str) else getattr(n, "id_", str(n))
+            for n in case.notes
+        ]
+        return note_id in note_ids
+
+    _poll_until(
+        _check,
+        timeout_seconds,
+        poll_interval,
+        f"Timed out waiting for note {note_id!r} to appear in case "
+        f"{case_id!r}",
+        swallow_exceptions=True,
+    )
+
+
+def wait_for_finder_log_entry(
+    finder_client: DataLayerClient,
+    case_id: str,
+    entry_hash: str,
+    timeout_seconds: float = 15.0,
+    poll_interval: float = 0.5,
+) -> None:
+    """Poll finder's DataLayer until a ``CaseLogEntry`` with *entry_hash* appears.
+
+    Proves that the vendor's ``Announce(CaseLogEntry)`` outbox activity was
+    delivered to the finder's inbox and processed by
+    ``AnnounceLogEntryReceivedUseCase`` (SYNC-2 receive side).
+
+    Args:
+        finder_client: DataLayerClient connected to the Finder container.
+        case_id: Full URI of the ``VulnerabilityCase`` (used for filtering).
+        entry_hash: ``entry_hash`` value of the expected log entry.
+        timeout_seconds: Maximum time to wait before raising.
+        poll_interval: Seconds between DataLayer poll attempts.
+
+    Raises:
+        AssertionError: If the entry does not appear within *timeout_seconds*.
+
+    Spec: SYNC-02-002.
+    """
+
+    def _check() -> bool:
+        raw = finder_client.get("/datalayer/CaseLogEntrys/")
+        if not isinstance(raw, dict):
+            return False
+        return any(
+            isinstance(v, dict)
+            and v.get("case_id") == case_id
+            and v.get("entry_hash") == entry_hash
+            for v in raw.values()
+        )
+
+    def _check_with_log() -> bool:
+        raw = finder_client.get("/datalayer/CaseLogEntrys/")
+        if not isinstance(raw, dict):
+            return False
+        for v in raw.values():
+            if (
+                isinstance(v, dict)
+                and v.get("case_id") == case_id
+                and v.get("entry_hash") == entry_hash
+            ):
+                logger.info(
+                    "Log entry with hash=%s found in finder's DataLayer",
+                    entry_hash[:16],
+                )
+                return True
+        return False
+
+    _poll_until(
+        _check_with_log,
+        timeout_seconds,
+        poll_interval,
+        f"Timed out waiting for log entry (hash={entry_hash!r}) for case "
+        f"{case_id!r} to appear in finder's DataLayer — replication may "
+        "not have completed",
+        swallow_exceptions=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Participant-state polling helpers
+# ---------------------------------------------------------------------------
+
+
+def wait_for_participant_vfd_state(
+    client: DataLayerClient,
+    case_id: str,
+    actor_id: str,
+    expected_states: "set",
+    timeout_seconds: float = 10.0,
+    poll_interval: float = 0.25,
+) -> None:
+    """Poll until *actor_id*'s latest participant ``vfd_state`` is in
+    *expected_states*.
+
+    Args:
+        client: DataLayerClient for the target container.
+        case_id: Full URI of the ``VulnerabilityCase``.
+        actor_id: Full URI of the actor to check.
+        expected_states: Set of ``CS_vfd`` values that satisfy the condition.
+        timeout_seconds: Maximum time to wait.
+        poll_interval: Seconds between DataLayer poll attempts.
+
+    Raises:
+        AssertionError: If the state is not reached within *timeout_seconds*.
+    """
+    # Import here to avoid a circular dependency with verification.py.
+    from vultron.demo.helpers.verification import (  # noqa: PLC0415
+        _fetch_participant,
+    )
+
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        participant = _fetch_participant(client, case_id, actor_id)
+        if participant is not None:
+            latest = participant.participant_status
+            if latest is not None and latest.vfd_state in expected_states:
+                return
+        time.sleep(poll_interval)
+
+    participant = _fetch_participant(client, case_id, actor_id)
+    latest = (
+        participant.participant_status if participant is not None else None
+    )
+    current = latest.vfd_state if latest is not None else "unknown"
+    raise AssertionError(
+        f"Timed out waiting for actor '{actor_id}' vfd_state to be in "
+        f"{expected_states!r}; current={current!r}"
+    )
+
+
+def wait_for_case_em_terminated(
+    client: DataLayerClient,
+    case_id: str,
+    timeout_seconds: float = 10.0,
+    poll_interval: float = 0.25,
+) -> None:
+    """Poll until the case EM state is ``EM.EXITED``.
+
+    After the Vendor (CASE_OWNER) reports public disclosure, the Case Actor
+    automatically initiates embargo teardown.  This helper waits for the
+    teardown to be reflected in the DataLayer.
+
+    Args:
+        client: DataLayerClient for the target container.
+        case_id: Full URI of the ``VulnerabilityCase``.
+        timeout_seconds: Maximum time to wait.
+        poll_interval: Seconds between DataLayer poll attempts.
+
+    Raises:
+        AssertionError: If EM.EXITED is not observed within *timeout_seconds*.
+    """
+    from vultron.core.states.em import EM  # noqa: PLC0415
+
+    def _check() -> bool:
+        case_data = client.get(f"/datalayer/{case_id}")
+        case = VulnerabilityCase.model_validate(case_data)
+        return case.current_status.em_state == EM.EXITED
+
+    _poll_until(
+        _check,
+        timeout_seconds,
+        poll_interval,
+        f"Timed out waiting for case '{case_id}' EM state to reach EXITED"
+        " — embargo teardown may not have completed",
+        swallow_exceptions=True,
+    )
+
+
+def wait_for_all_participants_rm_closed(
+    client: DataLayerClient,
+    case_id: str,
+    timeout_seconds: float = 10.0,
+    poll_interval: float = 0.25,
+) -> None:
+    """Poll until all participants in *case_id* have ``RM.CLOSED`` as their
+    latest status.
+
+    Args:
+        client: DataLayerClient for the target container.
+        case_id: Full URI of the ``VulnerabilityCase``.
+        timeout_seconds: Maximum time to wait.
+        poll_interval: Seconds between DataLayer poll attempts.
+
+    Raises:
+        AssertionError: If any participant is not RM.CLOSED within
+            *timeout_seconds*.
+    """
+    from vultron.demo.helpers.verification import (  # noqa: PLC0415
+        _all_fetchable_participants_rm_closed,
+    )
+
+    def _check() -> bool:
+        case_data = client.get(f"/datalayer/{case_id}")
+        case = VulnerabilityCase.model_validate(case_data)
+        return _all_fetchable_participants_rm_closed(client, case)
+
+    _poll_until(
+        _check,
+        timeout_seconds,
+        poll_interval,
+        f"Timed out waiting for all participants in case '{case_id}' "
+        "to reach RM.CLOSED",
+        swallow_exceptions=True,
+    )

--- a/vultron/demo/helpers/polling.py
+++ b/vultron/demo/helpers/polling.py
@@ -74,7 +74,7 @@ def _poll_until(
 
 
 def wait_for_case_on_container(
-    finder_client: DataLayerClient,
+    client: DataLayerClient,
     case_id: str,
     timeout_seconds: float = 10.0,
     poll_interval: float = 0.5,
@@ -89,7 +89,7 @@ def wait_for_case_on_container(
     arrives after the outbox background task completes.
 
     Args:
-        finder_client: DataLayerClient connected to the container to poll.
+        client: DataLayerClient connected to the container to poll.
         case_id: Full URI of the ``VulnerabilityCase`` to wait for.
         timeout_seconds: Maximum time to wait before raising.
         poll_interval: Seconds between DataLayer poll attempts.
@@ -99,7 +99,7 @@ def wait_for_case_on_container(
     """
 
     def _check() -> bool:
-        raw = finder_client.get("/datalayer/VulnerabilityCases/")
+        raw = client.get("/datalayer/VulnerabilityCases/")
         return isinstance(raw, dict) and case_id in raw
 
     _poll_until(
@@ -107,13 +107,28 @@ def wait_for_case_on_container(
         timeout_seconds,
         poll_interval,
         f"Timed out waiting for case {case_id!r} to appear in DataLayer "
-        f"at {finder_client.base_url} — outbox delivery may not have completed",
+        f"at {client.base_url} — outbox delivery may not have completed",
         swallow_exceptions=True,
     )
 
 
-# Backward-compatible alias used by ``two_actor_demo.py`` and its tests.
-wait_for_finder_case = wait_for_case_on_container
+def wait_for_finder_case(
+    finder_client: DataLayerClient,
+    case_id: str,
+    timeout_seconds: float = 10.0,
+    poll_interval: float = 0.5,
+) -> None:
+    """Backward-compatible alias for :func:`wait_for_case_on_container`.
+
+    Args:
+        finder_client: DataLayerClient connected to the Finder container.
+        case_id: Full URI of the ``VulnerabilityCase`` to wait for.
+        timeout_seconds: Maximum time to wait before raising.
+        poll_interval: Seconds between DataLayer poll attempts.
+    """
+    wait_for_case_on_container(
+        finder_client, case_id, timeout_seconds, poll_interval
+    )
 
 
 def wait_for_case_participants(
@@ -220,17 +235,6 @@ def wait_for_finder_log_entry(
 
     Spec: SYNC-02-002.
     """
-
-    def _check() -> bool:
-        raw = finder_client.get("/datalayer/CaseLogEntrys/")
-        if not isinstance(raw, dict):
-            return False
-        return any(
-            isinstance(v, dict)
-            and v.get("case_id") == case_id
-            and v.get("entry_hash") == entry_hash
-            for v in raw.values()
-        )
 
     def _check_with_log() -> bool:
         raw = finder_client.get("/datalayer/CaseLogEntrys/")

--- a/vultron/demo/helpers/seeding.py
+++ b/vultron/demo/helpers/seeding.py
@@ -14,15 +14,23 @@
 """Container-seeding and actor-lookup helpers for demo workflows.
 
 Provides :func:`_dl_key` for safe DataLayer path encoding,
-:func:`get_actor_by_id` for actor look-ups, and :func:`seed_containers` for
-the two-phase seeding sequence used by multi-actor scenarios.
+:func:`get_actor_by_id` for actor look-ups, :func:`seed_containers` for
+the two-phase seeding sequence used by multi-actor scenarios, and
+:func:`reset_containers` for resetting an arbitrary set of containers to
+a clean baseline before a demo run.
 """
 
 import logging
-from typing import Tuple
+from collections.abc import Callable, Sequence
+from typing import Any, Tuple
 from urllib.parse import quote
 
-from vultron.demo.utils import DataLayerClient, seed_actor
+from vultron.demo.utils import (
+    DataLayerClient,
+    demo_check,
+    demo_step,
+    seed_actor,
+)
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 
 logger = logging.getLogger(__name__)
@@ -127,3 +135,45 @@ def seed_containers(
     logger.info("Finder peer registered on Vendor container: %s", finder.id_)
 
     return finder, vendor
+
+
+def reset_containers(
+    labeled_clients: Sequence[tuple[str, DataLayerClient]],
+    reset_fn: Callable[..., Any],
+) -> None:
+    """Reset a set of labeled containers to a clean baseline.
+
+    This generic helper iterates over *labeled_clients*, calling *reset_fn*
+    on each, then verifies that no ``VulnerabilityCase`` records remain.
+
+    Keeping the reset loop here (rather than in a scenario module) allows any
+    multi-container scenario to reuse it without importing from
+    ``two_actor_demo``.  Callers are responsible for supplying the concrete
+    ``reset_fn`` (typically ``reset_datalayer`` from their own module namespace
+    so that test-suite mock patches continue to intercept the call).
+
+    Args:
+        labeled_clients: Sequence of ``(label, client)`` pairs, one per
+            container.  *label* is used only in log and assertion messages.
+        reset_fn: Callable with the signature
+            ``reset_fn(client: DataLayerClient, init: bool) -> Any``.
+            Pass the module-local reference so test patches take effect.
+
+    Raises:
+        AssertionError: If any container still has ``VulnerabilityCase``
+            records after the reset.
+
+    Spec: D5-2.
+    """
+    with demo_step("Resetting actor containers to a clean baseline"):
+        for label, client in labeled_clients:
+            result = reset_fn(client=client, init=False)
+            logger.debug("%s reset result: %s", label, result)
+
+    with demo_check("All actor containers start with no persisted cases"):
+        for label, client in labeled_clients:
+            cases = client.get("/datalayer/VulnerabilityCases/")
+            if cases:
+                raise AssertionError(
+                    f"{label} container was not reset cleanly: {cases}"
+                )

--- a/vultron/demo/helpers/seeding.py
+++ b/vultron/demo/helpers/seeding.py
@@ -1,0 +1,129 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Container-seeding and actor-lookup helpers for demo workflows.
+
+Provides :func:`_dl_key` for safe DataLayer path encoding,
+:func:`get_actor_by_id` for actor look-ups, and :func:`seed_containers` for
+the two-phase seeding sequence used by multi-actor scenarios.
+"""
+
+import logging
+from typing import Tuple
+from urllib.parse import quote
+
+from vultron.demo.utils import DataLayerClient, seed_actor
+from vultron.wire.as2.vocab.base.objects.actors import as_Actor
+
+logger = logging.getLogger(__name__)
+
+
+def _dl_key(key: str) -> str:
+    """URL-encode a DataLayer key for safe embedding in an API path segment.
+
+    Encodes characters that are illegal in URL path segments (e.g., colons in
+    URN-style keys like ``urn:uuid:...``).
+
+    Note: HTTP URL-based participant IDs (which contain literal slashes)
+    cannot be fetched via the single-segment ``/{key}`` DataLayer route even
+    after URL-encoding, because Starlette decodes ``%2F`` back to ``/`` before
+    path matching.  Such IDs must be handled via exception catching at the
+    call site.
+    """
+    return quote(str(key), safe="")
+
+
+def get_actor_by_id(client: DataLayerClient, actor_id: str) -> as_Actor:
+    """Fetch an actor record from a container by its full URI.
+
+    Args:
+        client: DataLayerClient connected to the target container.
+        actor_id: Full URI of the actor to fetch.
+
+    Returns:
+        The ``as_Actor`` object.
+
+    Raises:
+        ValueError: If the actor is not found.
+    """
+    actors = client.get("/actors/")
+    for a in actors:
+        actor = as_Actor.model_validate(a)
+        if actor.id_ == actor_id:
+            return actor
+    raise ValueError(f"Actor {actor_id!r} not found in container")
+
+
+def seed_containers(
+    finder_client: DataLayerClient,
+    vendor_client: DataLayerClient,
+    reporter_actor_id: str | None = None,
+    vendor_actor_id: str | None = None,
+) -> Tuple[as_Actor, as_Actor]:
+    """Seed both containers: create actor records and register cross-container peers.
+
+    The seeding is done in two phases to avoid ordering issues:
+
+    1. Create the local actor on each container independently.
+    2. Register each actor as a known peer on the other container.
+
+    This function is idempotent: re-running it returns existing actors
+    unchanged (the ``POST /actors/`` endpoint is idempotent).
+
+    Args:
+        finder_client: DataLayerClient connected to the Finder container.
+        vendor_client: DataLayerClient connected to the Vendor container.
+        reporter_actor_id: Optional deterministic URI for the Finder actor.
+            When absent the server derives one from ``VULTRON_BASE_URL``.
+        vendor_actor_id: Optional deterministic URI for the Vendor actor.
+            When absent the server derives one from ``VULTRON_BASE_URL``.
+
+    Returns:
+        Tuple of ``(finder, vendor)`` ``as_Actor`` objects as created on their
+        respective containers.
+    """
+    logger.info("Phase 1: creating local actors on each container...")
+    finder = seed_actor(
+        client=finder_client,
+        name="Finder",
+        actor_type="Person",
+        actor_id=reporter_actor_id,
+    )
+    logger.info("Finder actor seeded on Finder container: %s", finder.id_)
+
+    vendor = seed_actor(
+        client=vendor_client,
+        name="Vendor",
+        actor_type="Organization",
+        actor_id=vendor_actor_id,
+    )
+    logger.info("Vendor actor seeded on Vendor container: %s", vendor.id_)
+
+    logger.info("Phase 2: registering cross-container peers...")
+    seed_actor(
+        client=finder_client,
+        name="Vendor",
+        actor_type="Organization",
+        actor_id=vendor.id_,
+    )
+    logger.info("Vendor peer registered on Finder container: %s", vendor.id_)
+
+    seed_actor(
+        client=vendor_client,
+        name="Finder",
+        actor_type="Person",
+        actor_id=finder.id_,
+    )
+    logger.info("Finder peer registered on Vendor container: %s", finder.id_)
+
+    return finder, vendor

--- a/vultron/demo/helpers/sync.py
+++ b/vultron/demo/helpers/sync.py
@@ -17,7 +17,9 @@ Provides :func:`trigger_log_commit` to commit a log entry and fan it out to
 all case participants, and :func:`verify_replica_state` to assert that a
 replica actor's case state matches the authoritative actor.
 
-``verify_finder_replica_state`` is kept as a backward-compatible alias.
+``verify_finder_replica_state`` is a backward-compatible wrapper that maps
+the two-actor demo roles (Vendor = authoritative, Finder = replica) onto
+the generic ``verify_replica_state`` parameters.
 """
 
 import logging
@@ -115,8 +117,8 @@ def trigger_log_commit(
 
 
 def verify_replica_state(
-    finder_client: DataLayerClient,
-    vendor_client: DataLayerClient,
+    auth_client: DataLayerClient,
+    replica_client: DataLayerClient,
     case_id: str,
     vendor_actor_id: str,
     reporter_actor_id: str,
@@ -131,8 +133,10 @@ def verify_replica_state(
     4. Log-state hash consistency: both sides share the same tail entry hash.
 
     Args:
-        finder_client: DataLayerClient connected to the authoritative container.
-        vendor_client: DataLayerClient connected to the replica container.
+        auth_client: DataLayerClient connected to the authoritative container
+            (the actor that owns/created the case).
+        replica_client: DataLayerClient connected to the replica container
+            (the actor that received a replicated copy).
         case_id: Full URI of the ``VulnerabilityCase`` being verified.
         vendor_actor_id: Full URI of the Vendor actor (retained for symmetry).
         reporter_actor_id: Full URI of the Reporter/Finder actor (retained for
@@ -143,11 +147,11 @@ def verify_replica_state(
 
     Spec: SYNC-02-002, D5-7-DEMOREPLCHECK-1.
     """
-    auth_case_data = finder_client.get(f"/datalayer/{case_id}")
+    auth_case_data = auth_client.get(f"/datalayer/{case_id}")
     assert auth_case_data, f"Authoritative case {case_id!r} not found"
     auth_case = VulnerabilityCase.model_validate(auth_case_data)
 
-    replica_case_data = vendor_client.get(f"/datalayer/{case_id}")
+    replica_case_data = replica_client.get(f"/datalayer/{case_id}")
     assert replica_case_data, (
         f"Replica does not have a copy of case {case_id!r} — "
         "outbox delivery or inbox processing may have failed"
@@ -184,8 +188,8 @@ def verify_replica_state(
         logger.info("✓ Replica active_embargo matches: %s", auth_embargo_id)
 
     # 4. Log-state hash consistency
-    auth_entries = _get_log_entries_for_case(finder_client, case_id)
-    replica_entries = _get_log_entries_for_case(vendor_client, case_id)
+    auth_entries = _get_log_entries_for_case(auth_client, case_id)
+    replica_entries = _get_log_entries_for_case(replica_client, case_id)
     assert len(replica_entries) > 0, (
         "Replica has no CaseLogEntry records for the case — "
         "SYNC-2 replication did not complete"
@@ -204,5 +208,30 @@ def verify_replica_state(
     )
 
 
-# Backward-compatible alias for code that calls verify_finder_replica_state.
-verify_finder_replica_state = verify_replica_state
+def verify_finder_replica_state(
+    finder_client: DataLayerClient,
+    vendor_client: DataLayerClient,
+    case_id: str,
+    vendor_actor_id: str,
+    reporter_actor_id: str,
+) -> None:
+    """Backward-compatible wrapper for :func:`verify_replica_state`.
+
+    In the two-actor demo the Vendor is the authoritative case owner and the
+    Finder holds a replicated copy, so *vendor_client* maps to *auth_client*
+    and *finder_client* maps to *replica_client*.
+
+    Args:
+        finder_client: DataLayerClient connected to the Finder (replica).
+        vendor_client: DataLayerClient connected to the Vendor (authoritative).
+        case_id: Full URI of the ``VulnerabilityCase`` being verified.
+        vendor_actor_id: Full URI of the Vendor actor.
+        reporter_actor_id: Full URI of the Reporter/Finder actor.
+    """
+    verify_replica_state(
+        auth_client=vendor_client,
+        replica_client=finder_client,
+        case_id=case_id,
+        vendor_actor_id=vendor_actor_id,
+        reporter_actor_id=reporter_actor_id,
+    )

--- a/vultron/demo/helpers/sync.py
+++ b/vultron/demo/helpers/sync.py
@@ -1,0 +1,208 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""SYNC-2 log-replication helpers for demo workflows.
+
+Provides :func:`trigger_log_commit` to commit a log entry and fan it out to
+all case participants, and :func:`verify_replica_state` to assert that a
+replica actor's case state matches the authoritative actor.
+
+``verify_finder_replica_state`` is kept as a backward-compatible alias.
+"""
+
+import logging
+from typing import Optional
+
+from vultron.demo.utils import DataLayerClient, post_to_trigger
+from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_ref_id(ref: object) -> Optional[str]:
+    """Extract the string ID from an object, ``as_Link``, or string reference."""
+    if ref is None:
+        return None
+    if isinstance(ref, str):
+        return ref
+    if hasattr(ref, "id_"):
+        return str(ref.id_)  # type: ignore[union-attr]
+    if hasattr(ref, "href"):
+        return str(ref.href)  # type: ignore[union-attr]
+    return str(ref)
+
+
+def _get_log_entries_for_case(
+    client: DataLayerClient, case_id: str
+) -> list[dict]:
+    """Return all ``CaseLogEntry`` dicts for *case_id* from the DataLayer."""
+    raw = client.get("/datalayer/CaseLogEntrys/")
+    if not isinstance(raw, dict):
+        return []
+    return [
+        v
+        for v in raw.values()
+        if isinstance(v, dict) and v.get("case_id") == case_id
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Public SYNC-2 helpers
+# ---------------------------------------------------------------------------
+
+
+def trigger_log_commit(
+    client: DataLayerClient,
+    actor_id: str,
+    case_id: str,
+    event_type: str,
+    object_id: str | None = None,
+) -> str:
+    """Commit a log entry for *case_id* and return the entry hash.
+
+    POSTs to ``/actors/{actor_id}/demo/sync-log-entry`` and returns the
+    ``entry_hash`` from the response.  The entry is also fanned out to all
+    case participants via ``Announce(CaseLogEntry)`` activities queued in the
+    actor's outbox.
+
+    Args:
+        client: DataLayerClient connected to the CaseActor container.
+        actor_id: Full URI of the actor committing the log entry.
+        case_id: Full URI of the ``VulnerabilityCase``.
+        event_type: Short machine-readable event descriptor.
+        object_id: Optional URI of the primary object.  Defaults to
+            *case_id* when not supplied.
+
+    Returns:
+        The ``entry_hash`` of the newly committed log entry.
+
+    Spec: SYNC-02-002, SYNC-02-003.
+    """
+    result = post_to_trigger(
+        client=client,
+        actor_id=actor_id,
+        behavior="sync-log-entry",
+        body={
+            "case_id": case_id,
+            "object_id": object_id if object_id is not None else case_id,
+            "event_type": event_type,
+        },
+        path_prefix="demo",
+    )
+    entry_hash: str = result["entry_hash"]
+    logger.info(
+        "Log entry committed for case '%s': hash=%s, index=%d",
+        case_id,
+        entry_hash[:16],
+        result.get("log_index", -1),
+    )
+    return entry_hash
+
+
+def verify_replica_state(
+    finder_client: DataLayerClient,
+    vendor_client: DataLayerClient,
+    case_id: str,
+    vendor_actor_id: str,
+    reporter_actor_id: str,
+) -> None:
+    """Verify that a replica actor's case state matches the authoritative state.
+
+    Checks four properties:
+
+    1. The same ``case_id`` exists in the replica's DataLayer.
+    2. ``actor_participant_index`` keys are identical (same participant set).
+    3. ``active_embargo`` references the same ID on both sides.
+    4. Log-state hash consistency: both sides share the same tail entry hash.
+
+    Args:
+        finder_client: DataLayerClient connected to the authoritative container.
+        vendor_client: DataLayerClient connected to the replica container.
+        case_id: Full URI of the ``VulnerabilityCase`` being verified.
+        vendor_actor_id: Full URI of the Vendor actor (retained for symmetry).
+        reporter_actor_id: Full URI of the Reporter/Finder actor (retained for
+            future participant-status checks).
+
+    Raises:
+        AssertionError: If any replica invariant is violated.
+
+    Spec: SYNC-02-002, D5-7-DEMOREPLCHECK-1.
+    """
+    auth_case_data = finder_client.get(f"/datalayer/{case_id}")
+    assert auth_case_data, f"Authoritative case {case_id!r} not found"
+    auth_case = VulnerabilityCase.model_validate(auth_case_data)
+
+    replica_case_data = vendor_client.get(f"/datalayer/{case_id}")
+    assert replica_case_data, (
+        f"Replica does not have a copy of case {case_id!r} — "
+        "outbox delivery or inbox processing may have failed"
+    )
+    replica_case = VulnerabilityCase.model_validate(replica_case_data)
+
+    # 1. Same case ID
+    assert (
+        replica_case.id_ == case_id
+    ), f"Replica case ID mismatch: {replica_case.id_!r} != {case_id!r}"
+    logger.info("✓ Replica case ID matches: %s", case_id)
+
+    # 2. actor_participant_index keys match
+    auth_index = auth_case.actor_participant_index or {}
+    replica_index = replica_case.actor_participant_index or {}
+    assert set(auth_index.keys()) == set(replica_index.keys()), (
+        "Replica actor_participant_index key set differs from authoritative: "
+        f"replica={set(replica_index.keys())} "
+        f"auth={set(auth_index.keys())}"
+    )
+    logger.info(
+        "✓ Replica actor_participant_index matches (%d participants)",
+        len(replica_index),
+    )
+
+    # 3. active_embargo ID matches (if present on auth side)
+    auth_embargo_id = _extract_ref_id(auth_case.active_embargo)
+    replica_embargo_id = _extract_ref_id(replica_case.active_embargo)
+    if auth_embargo_id is not None:
+        assert auth_embargo_id == replica_embargo_id, (
+            f"Replica active_embargo {replica_embargo_id!r} != "
+            f"authoritative active_embargo {auth_embargo_id!r}"
+        )
+        logger.info("✓ Replica active_embargo matches: %s", auth_embargo_id)
+
+    # 4. Log-state hash consistency
+    auth_entries = _get_log_entries_for_case(finder_client, case_id)
+    replica_entries = _get_log_entries_for_case(vendor_client, case_id)
+    assert len(replica_entries) > 0, (
+        "Replica has no CaseLogEntry records for the case — "
+        "SYNC-2 replication did not complete"
+    )
+    auth_tail = max(auth_entries, key=lambda e: e["log_index"])
+    replica_tail = max(replica_entries, key=lambda e: e["log_index"])
+    assert auth_tail["entry_hash"] == replica_tail["entry_hash"], (
+        f"Replica log tail hash {replica_tail['entry_hash']!r} != "
+        f"authoritative log tail hash {auth_tail['entry_hash']!r} — "
+        "hash-chain replication integrity failure"
+    )
+    logger.info(
+        "✓ Replica log tail hash matches auth: %s… (index=%d)",
+        replica_tail["entry_hash"][:16],
+        replica_tail["log_index"],
+    )
+
+
+# Backward-compatible alias for code that calls verify_finder_replica_state.
+verify_finder_replica_state = verify_replica_state

--- a/vultron/demo/helpers/verification.py
+++ b/vultron/demo/helpers/verification.py
@@ -28,7 +28,7 @@ from vultron.core.states.em import EM
 from vultron.core.states.rm import RM
 from vultron.core.states.roles import CVDRole
 from vultron.demo.helpers.seeding import _dl_key
-from vultron.demo.utils import DataLayerClient
+from vultron.demo.utils import DataLayerClient, ref_id
 from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
 
@@ -174,8 +174,6 @@ def _assert_case_notes(
     Raises:
         AssertionError: If a provided note ID is missing from the case.
     """
-    from vultron.demo.utils import ref_id  # noqa: PLC0415
-
     if question_note_id is None and reply_note_id is None:
         return
 
@@ -292,3 +290,119 @@ def _all_fetchable_participants_rm_closed(
         if latest.rm_state != RM.CLOSED:
             return False
     return True
+
+
+def verify_coordinator_case_state(
+    coordinator_client: DataLayerClient,
+    case_id: str,
+    report_id: str,
+    coordinator_actor_id: str,
+    reporter_actor_id: str,
+    question_note_id: Optional[str] = None,
+    reply_note_id: Optional[str] = None,
+) -> VulnerabilityCase:
+    """Assert the final authoritative case state on the coordinator container.
+
+    Verifies that the case references the submitted report, that all required
+    participants are present (coordinator, reporter, plus at least one Case
+    Actor), and that the coordinator participant has reached ``RM.ACCEPTED``
+    with ``EM.ACTIVE`` and ``pxa == CS_pxa.pxa``.  Optionally checks that
+    *question_note_id* and *reply_note_id* appear in the case notes.
+
+    Args:
+        coordinator_client: Client connected to the coordinator container.
+        case_id: Full URI of the ``VulnerabilityCase`` to verify.
+        report_id: Full URI of the submitted vulnerability report.
+        coordinator_actor_id: Full URI of the coordinator actor.
+        reporter_actor_id: Full URI of the reporter actor.
+        question_note_id: Optional URI of the question note to assert present.
+        reply_note_id: Optional URI of the reply note to assert present.
+
+    Returns:
+        The fetched and validated ``VulnerabilityCase``.
+
+    Raises:
+        AssertionError: If any invariant is violated.
+    """
+    final_case = VulnerabilityCase(
+        **coordinator_client.get(f"/datalayer/{case_id}")
+    )
+
+    # Verify required participants are present by ID rather than a raw count,
+    # so future changes to the participant set don't silently break CI.
+    required_ids = {coordinator_actor_id, reporter_actor_id}
+    missing = required_ids - set(final_case.actor_participant_index.keys())
+    if missing:
+        raise AssertionError(
+            f"Required participants missing from case: {missing}"
+        )
+    # At least one Case Actor must be present beyond coordinator and reporter.
+    other_actors = (
+        set(final_case.actor_participant_index.keys()) - required_ids
+    )
+    if not other_actors:
+        raise AssertionError(
+            "Expected at least one Case Actor participant in addition to"
+            " coordinator and reporter"
+        )
+
+    report_ids = [
+        ref_id(report) or str(report)
+        for report in final_case.vulnerability_reports
+    ]
+    if report_id not in report_ids:
+        raise AssertionError(
+            "Final case does not reference the submitted report"
+        )
+
+    coordinator_participant_id = _require_case_participant_id(
+        final_case,
+        coordinator_actor_id,
+        "Coordinator",
+    )
+    _require_case_participant_id(final_case, reporter_actor_id, "Reporter")
+    _assert_vendor_participant_state(
+        coordinator_client, coordinator_participant_id
+    )
+
+    event_types = [event.event_type for event in final_case.events]
+    if "participant_added" not in event_types:
+        raise AssertionError(
+            "Expected participant_added event after reporter was added to the"
+            " case"
+        )
+
+    _assert_vendor_case_status(final_case)
+    _assert_case_notes(final_case, question_note_id, reply_note_id)
+    return final_case
+
+
+def verify_case_actor_unused(
+    case_actor_client: Optional[DataLayerClient],
+    case_id: str,
+) -> None:
+    """Verify the dedicated CaseActor container remains unused in D5-2.
+
+    Per D5-1-G3, the per-case ``VultronCaseActor`` co-locates in the
+    coordinator container for D5-2.  The standalone ``case-actor`` service
+    participates in the Docker topology but should not hold the created
+    ``VulnerabilityCase``.
+
+    Args:
+        case_actor_client: Optional client connected to the dedicated
+            CaseActor container.  When ``None`` the check is skipped.
+        case_id: Full URI of the case that should be absent.
+
+    Raises:
+        AssertionError: If the case is unexpectedly present on the dedicated
+            CaseActor container.
+    """
+    if case_actor_client is None:
+        return
+
+    case_actor_cases = case_actor_client.get("/datalayer/VulnerabilityCases/")
+    if case_id in case_actor_cases:
+        raise AssertionError(
+            "Dedicated case-actor container unexpectedly persisted the D5-2"
+            " case"
+        )

--- a/vultron/demo/helpers/verification.py
+++ b/vultron/demo/helpers/verification.py
@@ -1,0 +1,294 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Scenario-verification primitives shared across demo workflows.
+
+Lower-level assertion helpers used by milestone verification functions in the
+individual scenario modules (e.g. ``two_actor_demo.py``).  Keeping them here
+avoids duplication when future multi-actor scenarios need the same checks.
+"""
+
+import logging
+from typing import Optional
+
+import requests  # type: ignore[import-untyped]
+
+from vultron.core.states.cs import CS_pxa, CS_vfd
+from vultron.core.states.em import EM
+from vultron.core.states.rm import RM
+from vultron.core.states.roles import CVDRole
+from vultron.demo.helpers.seeding import _dl_key
+from vultron.demo.utils import DataLayerClient
+from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Participant fetch helpers
+# ---------------------------------------------------------------------------
+
+
+def _fetch_participant(
+    client: DataLayerClient,
+    case_id: str,
+    actor_id: str,
+) -> Optional[CaseParticipant]:
+    """Fetch the CaseParticipant record for *actor_id* in *case_id*.
+
+    Args:
+        client: DataLayerClient for the target container.
+        case_id: Full URI of the ``VulnerabilityCase``.
+        actor_id: Full URI of the actor whose participant record to fetch.
+
+    Returns:
+        The ``CaseParticipant`` or ``None`` if the actor or participant
+        record is not found.
+    """
+    try:
+        case_data = client.get(f"/datalayer/{case_id}")
+        case = VulnerabilityCase.model_validate(case_data)
+        participant_id = case.actor_participant_index.get(actor_id)
+        if participant_id is None:
+            return None
+        p_data = client.get(f"/datalayer/{_dl_key(participant_id)}")
+        return CaseParticipant(**p_data)
+    except (requests.HTTPError, AssertionError):
+        return None
+
+
+def _fetch_participant_data(client: DataLayerClient, p_id: str) -> dict | None:
+    """Fetch a participant record, returning ``None`` for genuine 404s.
+
+    Re-raises for any non-404 error so failures are not silently swallowed.
+    """
+    try:
+        return client.get(f"/datalayer/{_dl_key(p_id)}")
+    except requests.HTTPError as e:
+        if e.response is not None and e.response.status_code == 404:
+            return None
+        raise
+    except AssertionError as e:
+        # TestClient compatibility: make_testclient_call raises AssertionError
+        # for 4xx responses; treat only genuine 404s as "not found".
+        if "404" in str(e):
+            return None
+        raise
+
+
+# ---------------------------------------------------------------------------
+# State-assertion helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_case_participant_id(
+    case: VulnerabilityCase,
+    actor_id: str,
+    label: str,
+) -> str:
+    """Return the participant ID for *actor_id* in *case* or raise.
+
+    Args:
+        case: The ``VulnerabilityCase`` whose index to check.
+        actor_id: Full URI of the actor.
+        label: Human-readable label for the ``AssertionError`` message.
+
+    Returns:
+        The participant ID string.
+
+    Raises:
+        AssertionError: If *actor_id* is missing from
+            ``case.actor_participant_index``.
+    """
+    participant_id = case.actor_participant_index.get(actor_id)
+    if participant_id is None:
+        raise AssertionError(
+            f"{label} actor is missing from actor_participant_index"
+        )
+    return participant_id
+
+
+def _assert_vendor_participant_state(
+    vendor_client: DataLayerClient,
+    participant_id: str,
+) -> None:
+    """Assert that the vendor participant has reached ``RM.ACCEPTED``.
+
+    Args:
+        vendor_client: DataLayerClient connected to the Vendor container.
+        participant_id: Full URI / DataLayer key of the participant record.
+
+    Raises:
+        AssertionError: If the participant has no statuses or the latest
+            RM state is not ``RM.ACCEPTED``.
+    """
+    participant = CaseParticipant(
+        **vendor_client.get(f"/datalayer/{_dl_key(participant_id)}")
+    )
+    latest = participant.participant_status
+    if latest is None:
+        raise AssertionError("Vendor participant has no participant statuses")
+    if latest.rm_state != RM.ACCEPTED:
+        raise AssertionError(
+            "Vendor participant RM state did not transition to ACCEPTED"
+        )
+
+
+def _assert_vendor_case_status(case: VulnerabilityCase) -> None:
+    """Assert that *case* has ``EM.ACTIVE`` and ``pxa == CS_pxa.pxa``.
+
+    Raises:
+        AssertionError: If either invariant is violated.
+    """
+    if case.current_status.em_state != EM.ACTIVE:
+        raise AssertionError(
+            f"Expected ACTIVE final EM state (default embargo activated at"
+            f" case creation per EP-04-001), found {case.current_status.em_state}"
+        )
+    if case.current_status.pxa_state != CS_pxa.pxa:
+        raise AssertionError(
+            f"Expected pxa final case state, found {case.current_status.pxa_state}"
+        )
+
+
+def _assert_case_notes(
+    case: VulnerabilityCase,
+    question_note_id: str | None,
+    reply_note_id: str | None,
+) -> None:
+    """Assert that *question_note_id* and *reply_note_id* are in *case.notes*.
+
+    Both IDs are optional; the check is skipped when both are ``None``.
+
+    Raises:
+        AssertionError: If a provided note ID is missing from the case.
+    """
+    from vultron.demo.utils import ref_id  # noqa: PLC0415
+
+    if question_note_id is None and reply_note_id is None:
+        return
+
+    note_ids = [ref_id(note) or str(note) for note in case.notes]
+    if question_note_id is not None and question_note_id not in note_ids:
+        raise AssertionError(
+            f"Question note {question_note_id!r} not found in case notes"
+        )
+    if reply_note_id is not None and reply_note_id not in note_ids:
+        raise AssertionError(
+            f"Reply note {reply_note_id!r} not found in case notes"
+        )
+
+
+def _check_participant_vfd_state_in(
+    client: DataLayerClient,
+    case_id: str,
+    actor_id: str,
+    expected_states: "set[CS_vfd]",
+    label: str,
+) -> None:
+    """Assert actor's latest participant vfd_state is in *expected_states*.
+
+    Args:
+        client: DataLayerClient for the target container.
+        case_id: Full URI of the ``VulnerabilityCase``.
+        actor_id: Full URI of the actor to check.
+        expected_states: Set of acceptable ``CS_vfd`` values.
+        label: Human-readable label for ``AssertionError`` messages.
+    """
+    participant = _fetch_participant(client, case_id, actor_id)
+    if participant is None:
+        raise AssertionError(
+            f"{label}: participant for actor '{actor_id}' not found"
+        )
+    latest = participant.participant_status
+    if latest is None:
+        raise AssertionError(
+            f"{label}: participant for actor '{actor_id}' has no participant"
+            " statuses"
+        )
+    latest_vfd = latest.vfd_state
+    if latest_vfd not in expected_states:
+        raise AssertionError(
+            f"{label}: expected vfd_state in {expected_states!r}, "
+            f"found {latest_vfd!r}"
+        )
+
+
+def _assert_participant_vfd_pxa(
+    participant: CaseParticipant,
+    label: str,
+    vendor_actor_id: str,
+) -> None:
+    """Assert *participant* has VFD and a public-aware pxa_state.
+
+    Args:
+        participant: The ``CaseParticipant`` to check.
+        label: Human-readable label for ``AssertionError`` messages.
+        vendor_actor_id: Full URI of the vendor actor (used in error messages).
+
+    Raises:
+        AssertionError: If the participant's vfd_state is not VFD or its
+            pxa_state is not public-aware.
+    """
+    public_aware = {CS_pxa.Pxa, CS_pxa.PxA, CS_pxa.PXa, CS_pxa.PXA}
+    latest = participant.participant_status
+    if latest is None:
+        raise AssertionError(
+            f"M6 {label}: participant {vendor_actor_id!r} has no statuses"
+        )
+    if latest.vfd_state != CS_vfd.VFD:
+        raise AssertionError(
+            f"M6 {label}: vfd_state is not VFD, found {latest.vfd_state!r}"
+        )
+    cs = getattr(latest, "case_status", None)
+    pxa = getattr(cs, "pxa_state", None) if cs is not None else None
+    if pxa not in public_aware:
+        raise AssertionError(
+            f"M6 {label}: pxa_state is not public-aware, found {pxa!r}"
+        )
+
+
+def _all_fetchable_participants_rm_closed(
+    client: DataLayerClient,
+    case: VulnerabilityCase,
+) -> bool:
+    """Return ``True`` when every fetchable, non-CASE_MANAGER participant is
+    ``RM.CLOSED``.
+
+    Participants on remote containers (fetch returns ``None``) are skipped
+    since their state is not locally observable.
+
+    Args:
+        client: DataLayerClient for the container to query.
+        case: The ``VulnerabilityCase`` whose participant index to walk.
+
+    Returns:
+        ``True`` if all locally-fetchable non-coordinator participants are
+        ``RM.CLOSED``; ``False`` otherwise.
+    """
+    for p_id in case.actor_participant_index.values():
+        p_data = _fetch_participant_data(client, p_id)
+        if p_data is None:
+            continue  # remote container — not fetchable here
+        if not p_data:
+            return False
+        p = CaseParticipant(**p_data)
+        if CVDRole.CASE_MANAGER in (p.case_roles or []):
+            continue
+        latest = p.participant_status
+        if latest is None:
+            return False
+        if latest.rm_state != RM.CLOSED:
+            return False
+    return True

--- a/vultron/demo/helpers/workflow.py
+++ b/vultron/demo/helpers/workflow.py
@@ -1,0 +1,259 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Workflow step helpers shared across demo scenarios.
+
+Provides generic CVD workflow actions — report submission, report validation,
+and case lookup — that can be reused across two-actor, three-actor, and
+multi-vendor demo scenarios.  Each function is named after the CVD role that
+performs the action (reporter, coordinator) rather than any scenario-specific
+persona (finder, vendor).
+"""
+
+import logging
+from typing import Optional, Tuple
+
+from vultron.adapters.utils import parse_id
+from vultron.demo.utils import (
+    DataLayerClient,
+    demo_check,
+    demo_step,
+    post_to_inbox_and_wait,
+    post_to_trigger,
+    ref_id,
+    verify_object_stored,
+)
+from vultron.wire.as2.factories import (
+    parse_submit_report_offer,
+    rm_submit_report_activity,
+)
+from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
+from vultron.wire.as2.vocab.base.objects.actors import as_Actor
+from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_report import (
+    VulnerabilityReport,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def reporter_submits_report(
+    coordinator_client: DataLayerClient,
+    reporter: as_Actor,
+    coordinator: as_Actor,
+    reporter_client: Optional[DataLayerClient] = None,
+) -> Tuple[VulnerabilityReport, as_Offer]:
+    """Reporter creates a vulnerability report and submits it to the coordinator.
+
+    When ``reporter_client`` is provided (e.g. in a multi-container Docker
+    demo), the report and offer are created via the reporter container's
+    ``submit-report`` trigger endpoint so that the reporter container logs tell
+    the full process-flow story (D5-6a).  The resulting offer is then delivered
+    to the coordinator container's inbox.
+
+    When ``reporter_client`` is ``None`` (e.g. single-container integration
+    tests), the report and offer are constructed in memory and posted directly
+    to the coordinator container (backward-compatible path).
+
+    Args:
+        coordinator_client: Client connected to the coordinator container.
+        reporter: Reporter ``as_Actor``.
+        coordinator: Coordinator ``as_Actor``.
+        reporter_client: Optional client connected to the reporter container.
+            When provided, the submit-report trigger is called on the reporter
+            container; when absent the legacy in-memory path is used.
+
+    Returns:
+        Tuple of ``(report, offer)``.
+    """
+    if reporter_client is not None:
+        report_name = "Remote Code Execution in Network Stack"
+        report_content = (
+            "A critical remote code execution vulnerability was discovered "
+            "in the network stack component. An attacker can exploit this "
+            "issue to execute arbitrary code with elevated privileges."
+        )
+        with demo_step(
+            "Reporter submits vulnerability report to coordinator's inbox"
+        ):
+            result = post_to_trigger(
+                client=reporter_client,
+                actor_id=reporter.id_,
+                behavior="submit-report",
+                body={
+                    "report_name": report_name,
+                    "report_content": report_content,
+                    "recipient_id": coordinator.id_,
+                },
+            )
+        offer_dict = result.get("offer", {})
+        report, offer = parse_submit_report_offer(offer_dict)
+        # Deliver the offer from the reporter to the coordinator's inbox.
+        # Per ADR-0012 (per-actor DataLayer isolation) the trigger stores the
+        # offer only in the reporter's namespace; the coordinator must receive
+        # it explicitly via inbox delivery so SubmitReportReceivedUseCase runs
+        # and creates the case at RM.RECEIVED (ADR-0015).
+        with demo_step("Deliver reporter's offer to coordinator's inbox"):
+            post_to_inbox_and_wait(coordinator_client, coordinator.id_, offer)
+    else:
+        report = VulnerabilityReport(
+            attributed_to=reporter.id_,
+            name="Remote Code Execution in Network Stack",
+            content=(
+                "A critical remote code execution vulnerability was discovered "
+                "in the network stack component. An attacker can exploit this "
+                "issue to execute arbitrary code with elevated privileges."
+            ),
+        )
+        offer = rm_submit_report_activity(
+            report,
+            actor=reporter.id_,
+            target=coordinator.id_,
+            to=coordinator.id_,
+        )
+        with demo_step(
+            "Reporter submits vulnerability report to coordinator's inbox"
+        ):
+            post_to_inbox_and_wait(coordinator_client, coordinator.id_, offer)
+    with demo_check("Report stored in coordinator's DataLayer"):
+        verify_object_stored(coordinator_client, report.id_)
+    with demo_check("Offer stored in coordinator's DataLayer"):
+        verify_object_stored(coordinator_client, offer.id_)
+    logger.info("Report submitted: %s", ref_id(report))
+    return report, offer
+
+
+def coordinator_validates_report(
+    coordinator_client: DataLayerClient,
+    coordinator: as_Actor,
+    offer_id: str,
+) -> dict:
+    """Coordinator validates the submitted report via the trigger endpoint.
+
+    Args:
+        coordinator_client: Client connected to the coordinator container.
+        coordinator: Coordinator ``as_Actor``.
+        offer_id: Full URI of the submit-report ``as_Offer`` to validate.
+
+    Returns:
+        Response dict from the trigger endpoint (contains the validate
+        activity).
+    """
+    coordinator_obj_id = parse_id(coordinator.id_)["object_id"]
+    with demo_step("Coordinator validates the vulnerability report"):
+        result = post_to_trigger(
+            client=coordinator_client,
+            actor_id=coordinator.id_,
+            behavior="validate-report",
+            body={"offer_id": offer_id},
+        )
+    logger.info(
+        "Validate-report trigger result for actor %s", coordinator_obj_id
+    )
+    return result
+
+
+def _report_id_from_offer_data(
+    offer_data: dict[str, object],
+    offer_id: str,
+) -> str | None:
+    """Extract the report ID referenced by an offer.
+
+    Args:
+        offer_data: Raw dict representation of the offer from the DataLayer.
+        offer_id: Full URI of the offer (used in warning log only).
+
+    Returns:
+        The report ID string, or ``None`` if the offer does not reference a
+        report object.
+    """
+    offer_object = offer_data.get("object")
+    if isinstance(offer_object, str):
+        return offer_object
+    if isinstance(offer_object, dict):
+        return offer_object.get("id")
+
+    report_id = ref_id(offer_object)
+    if report_id:
+        return report_id
+
+    logger.warning("Offer %s does not reference a report object", offer_id)
+    return None
+
+
+def _load_case_from_datalayer(
+    client: DataLayerClient,
+    item: str | dict[str, object],
+) -> VulnerabilityCase | None:
+    """Load a VulnerabilityCase from the DataLayer, handling both IDs and dicts.
+
+    Args:
+        client: DataLayerClient for the container to query.
+        item: Either a full case URI string or a raw dict to validate.
+
+    Returns:
+        The ``VulnerabilityCase``, or ``None`` if the fetch fails.
+    """
+    if not isinstance(item, str):
+        return VulnerabilityCase.model_validate(item)
+
+    try:
+        return VulnerabilityCase.model_validate(
+            client.get(f"/datalayer/{item}")
+        )
+    except Exception as exc:
+        logger.warning("Could not fetch case %s: %s", item, exc)
+        return None
+
+
+def find_case_for_offer(
+    client: DataLayerClient,
+    offer_id: str,
+) -> Optional[VulnerabilityCase]:
+    """Find the VulnerabilityCase associated with a report offer.
+
+    Args:
+        client: DataLayerClient connected to the container holding the case.
+        offer_id: Full URI of the ``VultronActivity`` offer.
+
+    Returns:
+        The matching ``VulnerabilityCase``, or ``None`` if not found.
+    """
+    offer_data = client.get(f"/datalayer/{offer_id}")
+    if not offer_data:
+        return None
+
+    report_id = _report_id_from_offer_data(offer_data, offer_id)
+    if not report_id:
+        return None
+
+    cases_data = client.get("/datalayer/VulnerabilityCases/")
+    if not cases_data:
+        return None
+
+    for item in cases_data:
+        case = _load_case_from_datalayer(client, item)
+        if case is None:
+            continue
+
+        report_ids = [
+            (
+                report
+                if isinstance(report, str)
+                else getattr(report, "id_", str(report))
+            )
+            for report in (case.vulnerability_reports or [])
+        ]
+        if report_id in report_ids:
+            return case
+    return None

--- a/vultron/demo/scenario/multi_vendor_demo.py
+++ b/vultron/demo/scenario/multi_vendor_demo.py
@@ -44,6 +44,7 @@ This corresponds to Scenario 3 in ``specs/multi-actor-demo.yaml``
 import logging
 import os
 import sys
+import warnings
 
 from vultron.core.states.em import EM
 from vultron.wire.as2.vocab.base.objects.activities.transitive import (
@@ -87,6 +88,14 @@ from vultron.demo.utils import (
 from vultron.wire.as2.factories import (
     accept_case_ownership_transfer_activity,
     offer_case_ownership_transfer_activity,
+)
+
+warnings.warn(
+    "vultron.demo.scenario.multi_vendor_demo is deprecated and will be removed"
+    " in a future version. A replacement multi-actor scenario is under"
+    " development.",
+    DeprecationWarning,
+    stacklevel=1,
 )
 
 logger = logging.getLogger(__name__)

--- a/vultron/demo/scenario/three_actor_demo.py
+++ b/vultron/demo/scenario/three_actor_demo.py
@@ -35,6 +35,7 @@ from datetime import datetime, timedelta, timezone
 import logging
 import os
 import sys
+import warnings
 
 from vultron.core.states.em import EM
 from vultron.demo.scenario.two_actor_demo import (
@@ -69,6 +70,14 @@ from vultron.wire.as2.vocab.objects.vulnerability_report import (
 )
 from vultron.wire.as2.factories import (
     rm_submit_report_activity,
+)
+
+warnings.warn(
+    "vultron.demo.scenario.three_actor_demo is deprecated and will be removed"
+    " in a future version. A replacement multi-actor scenario is under"
+    " development.",
+    DeprecationWarning,
+    stacklevel=1,
 )
 
 logger = logging.getLogger(__name__)

--- a/vultron/demo/scenario/two_actor_demo.py
+++ b/vultron/demo/scenario/two_actor_demo.py
@@ -15,40 +15,10 @@
 
 """Two-actor (Finder + Vendor) multi-container CVD workflow demo.
 
-Orchestrates a complete CVD workflow across two separate API server containers:
-a Finder who discovers a vulnerability and a Vendor who validates and engages
-the case.  CaseActor is co-located in the Vendor container for this two-actor
-scenario (D5-1-G3).
-
-Environment variables
----------------------
-``VULTRON_FINDER_BASE_URL``
-    Base URL of the Finder container API
-    (default: ``http://localhost:7901/api/v2``).
-``VULTRON_VENDOR_BASE_URL``
-    Base URL of the Vendor container API
-    (default: ``http://localhost:7902/api/v2``).
-
-Workflow
---------
-1. **Reset**: Clear all container state to a known clean baseline.
-2. **Seed**: Create actor records and register peers on both containers.
-3. **Submit**: Finder submits a vulnerability report to the Vendor's inbox.
-4. **Validate**: Vendor validates the report via the ``validate-report``
-   trigger endpoint.
-5. **Engage**: Validation automatically cascades to engage the case
-   (RM.VALID → RM.ACCEPTED) without a separate trigger call
-   (D5-7-AUTOENG-2).
-6. **Add Participant**: Vendor directly adds the Finder as a case participant
-   (the Finder expressed intent to participate by submitting the report;
-   no invite/accept flow is required for initial participants).
-7. **Notes Exchange**: Finder posts a question note to the case; Vendor replies
-   and the case forwards the reply to the Finder.
-8. **Verify**: The Vendor container holds the authoritative case state with
-   two participants and two case notes.
-
-References: ``notes/multi-actor-architecture.md`` §4 G5,
-``specs/multi-actor-demo.yaml`` DEMOMA-03-001 through DEMOMA-04-002.
+Orchestrates the full VFDPxa lifecycle across separate Finder and Vendor
+containers. The scenario module now delegates common workflow, notes, and
+milestone logic to the generic helper modules under ``vultron.demo.helpers``
+while preserving the public API used by the existing test suite.
 """
 
 import logging
@@ -56,19 +26,15 @@ import os
 import sys
 from typing import Optional, Tuple
 
-from vultron.adapters.utils import parse_id
 from vultron.core.states.cs import CS_vfd
-from vultron.core.states.em import EM
-from vultron.core.states.rm import RM
-from vultron.core.states.roles import CVDRole
-from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
+from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.base.objects.object_types import as_Note
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
     VulnerabilityReport,
 )
+
 from vultron.demo.utils import (  # noqa: F401 — re-exported for test monkeypatching
     BASE_URL,
     DataLayerClient,
@@ -83,10 +49,6 @@ from vultron.demo.utils import (  # noqa: F401 — re-exported for test monkeypa
     seed_actor,
     verify_object_stored,
 )
-from vultron.wire.as2.factories import (
-    parse_submit_report_offer,
-    rm_submit_report_activity,
-)
 
 # Re-export shared helpers so that existing imports via this module continue to
 # work and the test suite (which patches symbols in this module's namespace)
@@ -98,6 +60,14 @@ from vultron.demo.helpers.actions import (  # noqa: F401
     actor_notifies_published,
     actor_notifies_state_change,
 )
+from vultron.demo.helpers.milestones import (
+    verify_case_active,
+    verify_case_closed,
+    verify_fix_deployed,
+    verify_fix_ready,
+    verify_publicly_disclosed,
+)
+from vultron.demo.helpers.notes import participant_adds_note_to_case
 from vultron.demo.helpers.polling import (  # noqa: F401
     _poll_until,
     wait_for_all_participants_rm_closed,
@@ -131,6 +101,15 @@ from vultron.demo.helpers.verification import (  # noqa: F401
     _fetch_participant,
     _fetch_participant_data,
     _require_case_participant_id,
+    verify_case_actor_unused,
+    verify_coordinator_case_state,
+)
+from vultron.demo.helpers.workflow import (  # noqa: F401
+    _load_case_from_datalayer,
+    _report_id_from_offer_data,
+    coordinator_validates_report,
+    find_case_for_offer,
+    reporter_submits_report,
 )
 
 logger = logging.getLogger(__name__)
@@ -150,6 +129,8 @@ CASE_ACTOR_BASE_URL = os.environ.get(
 FINDER_ACTOR_ID = "http://finder:7999/api/v2/actors/finder"
 VENDOR_ACTOR_ID = "http://vendor:7999/api/v2/actors/vendor"
 
+_load_vendor_case = _load_case_from_datalayer
+
 
 def reset_containers(
     finder_client: DataLayerClient,
@@ -160,7 +141,7 @@ def reset_containers(
 
     D5-2 requires repeatable, single-command execution. Resetting each
     container's DataLayer at the start of the run ensures the demo does
-    not depend on a prior `docker compose down -v`.
+    not depend on a prior ``docker compose down -v``.
     """
     targets: list[tuple[str, DataLayerClient]] = [
         ("Finder", finder_client),
@@ -184,7 +165,7 @@ def reset_containers(
 
 
 # ---------------------------------------------------------------------------
-# Workflow step functions
+# Backward-compatible scenario wrappers
 # ---------------------------------------------------------------------------
 
 
@@ -194,81 +175,17 @@ def finder_submits_report(
     vendor: as_Actor,
     finder_client: Optional[DataLayerClient] = None,
 ) -> Tuple[VulnerabilityReport, as_Offer]:
-    """Finder creates a vulnerability report and submits it to the Vendor's inbox.
+    """Scenario alias for :func:`~vultron.demo.helpers.workflow.reporter_submits_report`.
 
-    When ``finder_client`` is provided (e.g. in a multi-container Docker demo),
-    the report and offer are created via the Finder container's
-    ``submit-report`` trigger endpoint so that Finder container logs tell the
-    full process-flow story (D5-6a).  The resulting offer is then delivered to
-    the Vendor container's inbox.
-
-    When ``finder_client`` is ``None`` (e.g. single-container integration
-    tests), the report and offer are constructed in memory and posted directly
-    to the Vendor container (backward-compatible path).
-
-    Args:
-        vendor_client: Client connected to the Vendor container.
-        finder: Finder ``as_Actor``.
-        vendor: Vendor ``as_Actor``.
-        finder_client: Optional client connected to the Finder container.
-            When provided, the submit-report trigger is called on the Finder
-            container; when absent the legacy in-memory path is used.
-
-    Returns:
-        Tuple of ``(report, offer)``.
+    Maintained for backward compatibility; prefer ``reporter_submits_report``
+    in new scenarios.
     """
-    if finder_client is not None:
-        report_name = "Remote Code Execution in Network Stack"
-        report_content = (
-            "A critical remote code execution vulnerability was discovered "
-            "in the network stack component. An attacker can exploit this "
-            "issue to execute arbitrary code with elevated privileges."
-        )
-        with demo_step(
-            "Finder submits vulnerability report to Vendor's inbox"
-        ):
-            result = post_to_trigger(
-                client=finder_client,
-                actor_id=finder.id_,
-                behavior="submit-report",
-                body={
-                    "report_name": report_name,
-                    "report_content": report_content,
-                    "recipient_id": vendor.id_,
-                },
-            )
-        offer_dict = result.get("offer", {})
-        report, offer = parse_submit_report_offer(offer_dict)
-        # Deliver the offer from the Finder to the Vendor's inbox.
-        # Per ADR-0012 (per-actor DataLayer isolation) the trigger stores the
-        # offer only in the Finder's namespace; the Vendor must receive it
-        # explicitly via inbox delivery so SubmitReportReceivedUseCase runs and
-        # creates the case at RM.RECEIVED (ADR-0015).
-        with demo_step("Deliver Finder's offer to Vendor's inbox"):
-            post_to_inbox_and_wait(vendor_client, vendor.id_, offer)
-    else:
-        report = VulnerabilityReport(
-            attributed_to=finder.id_,
-            name="Remote Code Execution in Network Stack",
-            content=(
-                "A critical remote code execution vulnerability was discovered "
-                "in the network stack component. An attacker can exploit this "
-                "issue to execute arbitrary code with elevated privileges."
-            ),
-        )
-        offer = rm_submit_report_activity(
-            report, actor=finder.id_, target=vendor.id_, to=vendor.id_
-        )
-        with demo_step(
-            "Finder submits vulnerability report to Vendor's inbox"
-        ):
-            post_to_inbox_and_wait(vendor_client, vendor.id_, offer)
-    with demo_check("Report stored in Vendor's DataLayer"):
-        verify_object_stored(vendor_client, report.id_)
-    with demo_check("Offer stored in Vendor's DataLayer"):
-        verify_object_stored(vendor_client, offer.id_)
-    logger.info("Report submitted: %s", ref_id(report))
-    return report, offer
+    return reporter_submits_report(
+        coordinator_client=vendor_client,
+        reporter=finder,
+        coordinator=vendor,
+        reporter_client=finder_client,
+    )
 
 
 def vendor_validates_report(
@@ -276,26 +193,16 @@ def vendor_validates_report(
     vendor: as_Actor,
     offer_id: str,
 ) -> dict:
-    """Vendor validates the submitted report via the trigger endpoint.
+    """Scenario alias for :func:`~vultron.demo.helpers.workflow.coordinator_validates_report`.
 
-    Args:
-        vendor_client: Client connected to the Vendor container.
-        vendor: Vendor ``as_Actor``.
-        offer_id: Full URI of the submit-report ``as_Offer`` to validate.
-
-    Returns:
-        Response dict from the trigger endpoint (contains the validate activity).
+    Maintained for backward compatibility; prefer
+    ``coordinator_validates_report`` in new scenarios.
     """
-    vendor_obj_id = parse_id(vendor.id_)["object_id"]
-    with demo_step("Vendor validates the vulnerability report"):
-        result = post_to_trigger(
-            client=vendor_client,
-            actor_id=vendor.id_,
-            behavior="validate-report",
-            body={"offer_id": offer_id},
-        )
-    logger.info("Validate-report trigger result for actor %s", vendor_obj_id)
-    return result
+    return coordinator_validates_report(
+        coordinator_client=vendor_client,
+        coordinator=vendor,
+        offer_id=offer_id,
+    )
 
 
 def finder_asks_question(
@@ -305,55 +212,23 @@ def finder_asks_question(
     finder: as_Actor,
     case: VulnerabilityCase,
 ) -> as_Note:
-    """Finder posts a question note to the case via the trigger endpoint.
+    """Scenario alias: finder adds a question note to the case.
 
-    Uses the finder's ``add-note-to-case`` trigger so the note flows through
-    the finder's outbox to the vendor's inbox — reflecting real deployment
-    behavior (D5-7-DEMONOTECLEAN-1).
-
-    Args:
-        vendor_client: Client connected to the Vendor container.
-        finder_client: Client connected to the Finder container.
-        vendor: Vendor ``as_Actor`` (the case host / case actor).
-        finder: Finder ``as_Actor`` (posting the question).
-        case: The ``VulnerabilityCase`` the note belongs to.
-
-    Returns:
-        The ``as_Note`` question note fetched from the Vendor's DataLayer.
+    Maintained for backward compatibility; prefer
+    :func:`~vultron.demo.helpers.notes.participant_adds_note_to_case` in new
+    scenarios.
     """
-    note_name = "Question from Finder"
-    note_content = (
-        "Is there a workaround available while waiting for the patch? "
-        "Our security team needs to provide interim guidance to users."
+    return participant_adds_note_to_case(
+        posting_client=finder_client,
+        watching_client=vendor_client,
+        poster=finder,
+        case=case,
+        note_name="Question from Finder",
+        note_content=(
+            "Is there a workaround available while waiting for the patch? "
+            "Our security team needs to provide interim guidance to users."
+        ),
     )
-
-    with demo_step("Finder posts a question note to the case"):
-        result = post_to_trigger(
-            client=finder_client,
-            actor_id=finder.id_,
-            behavior="add-note-to-case",
-            body={
-                "case_id": case.id_,
-                "note_name": note_name,
-                "note_content": note_content,
-            },
-            path_prefix="demo",
-        )
-
-    note_id = result.get("note", {}).get("id")
-    if note_id is None:
-        raise AssertionError(
-            "add-note-to-case trigger did not return a note ID"
-        )
-
-    with demo_check("Question note delivered to Vendor's DataLayer"):
-        wait_for_note_in_case(vendor_client, case.id_, note_id)
-        verify_object_stored(vendor_client, note_id)
-
-    logger.info("Question note posted to case: %s", note_id)
-
-    note_data = vendor_client.get(f"/datalayer/{note_id}")
-    return as_Note(**note_data)
 
 
 def vendor_replies_to_question(
@@ -364,136 +239,25 @@ def vendor_replies_to_question(
     case: VulnerabilityCase,
     question_note: as_Note,
 ) -> as_Note:
-    """Vendor posts a reply note to the case via the trigger endpoint.
+    """Scenario alias: vendor adds a reply note to the case.
 
-    Uses the vendor's ``add-note-to-case`` trigger so the note flows through
-    the vendor's outbox — reflecting real deployment behavior
-    (D5-7-DEMONOTECLEAN-1).  The case host (CaseActor) then automatically
-    broadcasts the note to all participants via the note broadcast mechanism
-    (CM-06-005).
-
-    Args:
-        vendor_client: Client connected to the Vendor container.
-        finder_client: Client connected to the Finder container.
-        vendor: Vendor ``as_Actor``.
-        finder: Finder ``as_Actor`` (the reply recipient).
-        case: The ``VulnerabilityCase`` the note belongs to.
-        question_note: The original question note being replied to.
-
-    Returns:
-        The ``as_Note`` reply note fetched from the Vendor's DataLayer.
+    Maintained for backward compatibility; prefer
+    :func:`~vultron.demo.helpers.notes.participant_adds_note_to_case` in new
+    scenarios.
     """
-    note_name = "Vendor Response"
-    note_content = (
-        "Yes, disabling the affected network stack component is an effective "
-        "workaround. A patched version is expected within 30 days. "
-        "We will notify all case participants when it is available."
+    return participant_adds_note_to_case(
+        posting_client=vendor_client,
+        watching_client=vendor_client,
+        poster=vendor,
+        case=case,
+        note_name="Vendor Response",
+        note_content=(
+            "Yes, disabling the affected network stack component is an effective "
+            "workaround. A patched version is expected within 30 days. "
+            "We will notify all case participants when it is available."
+        ),
+        in_reply_to=question_note.id_,
     )
-
-    with demo_step("Vendor posts a reply note to the case"):
-        result = post_to_trigger(
-            client=vendor_client,
-            actor_id=vendor.id_,
-            behavior="add-note-to-case",
-            body={
-                "case_id": case.id_,
-                "note_name": note_name,
-                "note_content": note_content,
-                "in_reply_to": question_note.id_,
-            },
-            path_prefix="demo",
-        )
-
-    note_id = result.get("note", {}).get("id")
-    if note_id is None:
-        raise AssertionError(
-            "add-note-to-case trigger did not return a note ID"
-        )
-
-    with demo_check("Reply note stored in Vendor's DataLayer"):
-        verify_object_stored(vendor_client, note_id)
-
-    logger.info("Reply note posted to case: %s", note_id)
-
-    note_data = vendor_client.get(f"/datalayer/{note_id}")
-    return as_Note(**note_data)
-
-
-def _report_id_from_offer_data(
-    offer_data: dict[str, object],
-    offer_id: str,
-) -> str | None:
-    offer_object = offer_data.get("object")
-    if isinstance(offer_object, str):
-        return offer_object
-    if isinstance(offer_object, dict):
-        return offer_object.get("id")
-
-    report_id = ref_id(offer_object)
-    if report_id:
-        return report_id
-
-    logger.warning("Offer %s does not reference a report object", offer_id)
-    return None
-
-
-def _load_vendor_case(
-    vendor_client: DataLayerClient,
-    item: str | dict[str, object],
-) -> VulnerabilityCase | None:
-    if not isinstance(item, str):
-        return VulnerabilityCase.model_validate(item)
-
-    try:
-        return VulnerabilityCase.model_validate(
-            vendor_client.get(f"/datalayer/{item}")
-        )
-    except Exception as exc:
-        logger.warning("Could not fetch case %s: %s", item, exc)
-        return None
-
-
-def find_case_for_offer(
-    vendor_client: DataLayerClient,
-    offer_id: str,
-) -> Optional[VulnerabilityCase]:
-    """Find the VulnerabilityCase associated with a report offer in the Vendor container.
-
-    Args:
-        vendor_client: Client connected to the Vendor container.
-        offer_id: Full URI of the ``VultronActivity`` offer.
-
-    Returns:
-        The matching ``VulnerabilityCase``, or ``None`` if not found.
-    """
-    offer_data = vendor_client.get(f"/datalayer/{offer_id}")
-    if not offer_data:
-        return None
-
-    report_id = _report_id_from_offer_data(offer_data, offer_id)
-    if not report_id:
-        return None
-
-    cases_data = vendor_client.get("/datalayer/VulnerabilityCases/")
-    if not cases_data:
-        return None
-
-    for item in cases_data:
-        case = _load_vendor_case(vendor_client, item)
-        if case is None:
-            continue
-
-        report_ids = [
-            (
-                report
-                if isinstance(report, str)
-                else getattr(report, "id_", str(report))
-            )
-            for report in (case.vulnerability_reports or [])
-        ]
-        if report_id in report_ids:
-            return case
-    return None
 
 
 def verify_vendor_case_state(
@@ -502,83 +266,23 @@ def verify_vendor_case_state(
     report_id: str,
     vendor_actor_id: str,
     reporter_actor_id: str,
-    question_note_id: str | None = None,
-    reply_note_id: str | None = None,
+    question_note_id: Optional[str] = None,
+    reply_note_id: Optional[str] = None,
 ) -> VulnerabilityCase:
-    """Assert the final authoritative case state stored on the Vendor container."""
-    final_case = VulnerabilityCase(
-        **vendor_client.get(f"/datalayer/{case_id}")
-    )
+    """Scenario alias for :func:`~vultron.demo.helpers.verification.verify_coordinator_case_state`.
 
-    # Verify required participants are present by ID rather than a raw count,
-    # so future changes to the participant set don't silently break CI.
-    required_ids = {vendor_actor_id, reporter_actor_id}
-    missing = required_ids - set(final_case.actor_participant_index.keys())
-    if missing:
-        raise AssertionError(
-            f"Required participants missing from case: {missing}"
-        )
-    # At least one Case Actor must be present beyond vendor and finder.
-    other_actors = (
-        set(final_case.actor_participant_index.keys()) - required_ids
-    )
-    if not other_actors:
-        raise AssertionError(
-            "Expected at least one Case Actor participant in addition to"
-            " vendor and finder"
-        )
-
-    report_ids = [
-        ref_id(report) or str(report)
-        for report in final_case.vulnerability_reports
-    ]
-    if report_id not in report_ids:
-        raise AssertionError(
-            "Final case does not reference the submitted report"
-        )
-
-    vendor_participant_id = _require_case_participant_id(
-        final_case,
-        vendor_actor_id,
-        "Vendor",
-    )
-    _require_case_participant_id(final_case, reporter_actor_id, "Finder")
-    _assert_vendor_participant_state(vendor_client, vendor_participant_id)
-
-    event_types = [event.event_type for event in final_case.events]
-    if "participant_added" not in event_types:
-        raise AssertionError(
-            "Expected participant_added event after Finder was added to the case"
-        )
-
-    _assert_vendor_case_status(final_case)
-    _assert_case_notes(final_case, question_note_id, reply_note_id)
-    return final_case
-
-
-def verify_case_actor_unused(
-    case_actor_client: DataLayerClient | None,
-    case_id: str,
-) -> None:
-    """Verify the dedicated CaseActor container remains unused in D5-2.
-
-    Per D5-1-G3, the per-case `VultronCaseActor` co-locates in the Vendor
-    container for D5-2. The standalone `case-actor` service participates in
-    the Docker topology but should not hold the created `VulnerabilityCase`.
+    Maintained for backward compatibility; prefer
+    ``verify_coordinator_case_state`` in new scenarios.
     """
-    if case_actor_client is None:
-        return
-
-    case_actor_cases = case_actor_client.get("/datalayer/VulnerabilityCases/")
-    if case_id in case_actor_cases:
-        raise AssertionError(
-            "Dedicated case-actor container unexpectedly persisted the D5-2 case"
-        )
-
-
-# ---------------------------------------------------------------------------
-# Milestone verification helpers
-# ---------------------------------------------------------------------------
+    return verify_coordinator_case_state(
+        coordinator_client=vendor_client,
+        case_id=case_id,
+        report_id=report_id,
+        coordinator_actor_id=vendor_actor_id,
+        reporter_actor_id=reporter_actor_id,
+        question_note_id=question_note_id,
+        reply_note_id=reply_note_id,
+    )
 
 
 def verify_m1_state(
@@ -588,63 +292,17 @@ def verify_m1_state(
     vendor_actor_id: str,
     reporter_actor_id: str,
 ) -> None:
-    """Verify milestone M1: required participants present, EM.ACTIVE, finder has case replica.
+    """Scenario alias for :func:`~vultron.demo.helpers.milestones.verify_case_active`.
 
-    Checks the Vendor DataLayer for the required participants (Vendor and
-    Reporter) plus at least one Case Actor (≥3 total) with an active embargo,
-    then verifies the Reporter DataLayer has a matching case replica.
-
-    Spec: DEMOMA-06-002, DEMOMA-06-003.
+    Maintained for backward compatibility; prefer ``verify_case_active`` in
+    new scenarios.
     """
-    # Vendor side
-    case_data = vendor_client.get(f"/datalayer/{case_id}")
-    assert case_data, f"M1: Vendor case {case_id!r} not found"
-    case = VulnerabilityCase.model_validate(case_data)
-
-    required = {vendor_actor_id, reporter_actor_id}
-    missing = required - set(case.actor_participant_index.keys())
-    if missing:
-        raise AssertionError(
-            f"M1: Required participants missing from vendor case: {missing}"
-        )
-    other_actors = set(case.actor_participant_index.keys()) - required
-    if not other_actors:
-        raise AssertionError(
-            "M1: Expected a Case Actor participant in addition to vendor and finder"
-        )
-    if case.current_status.em_state != EM.ACTIVE:
-        raise AssertionError(
-            f"M1 vendor: expected EM.ACTIVE, found {case.current_status.em_state}"
-        )
-    if case.active_embargo is None:
-        raise AssertionError("M1 vendor: case has no active_embargo")
-    logger.info(
-        "✓ M1 vendor: required participants (vendor, finder) + case-actor "
-        "present, EM.ACTIVE, embargo present"
-    )
-
-    # Finder side: replica must exist with matching participant index and embargo
-    finder_case_data = finder_client.get(f"/datalayer/{case_id}")
-    if not finder_case_data:
-        raise AssertionError(
-            f"M1: Finder does not have case replica for {case_id!r} — "
-            "outbox delivery may not have completed"
-        )
-    finder_case = VulnerabilityCase.model_validate(finder_case_data)
-
-    vendor_embargo_id = _extract_ref_id(case.active_embargo)
-    finder_embargo_id = _extract_ref_id(finder_case.active_embargo)
-    if (
-        vendor_embargo_id is not None
-        and vendor_embargo_id != finder_embargo_id
-    ):
-        raise AssertionError(
-            f"M1: Finder active_embargo {finder_embargo_id!r} != "
-            f"vendor active_embargo {vendor_embargo_id!r}"
-        )
-    logger.info(
-        "✓ M1 finder: case replica present, matching participant index "
-        "and active embargo"
+    return verify_case_active(
+        coordinator_client=vendor_client,
+        reporter_client=finder_client,
+        case_id=case_id,
+        coordinator_actor_id=vendor_actor_id,
+        reporter_actor_id=reporter_actor_id,
     )
 
 
@@ -654,26 +312,13 @@ def verify_m4_state(
     case_id: str,
     vendor_actor_id: str,
 ) -> None:
-    """Verify milestone M4: both replicas show CS includes F (fix ready).
-
-    Spec: DEMOMA-06-002.
-    """
-    fix_ready_states = {CS_vfd.VFd, CS_vfd.VFD}
-    _check_participant_vfd_state_in(
-        vendor_client,
-        case_id,
-        vendor_actor_id,
-        fix_ready_states,
-        "M4 vendor",
+    """Scenario alias for :func:`~vultron.demo.helpers.milestones.verify_fix_ready`."""
+    return verify_fix_ready(
+        coordinator_client=vendor_client,
+        reporter_client=finder_client,
+        case_id=case_id,
+        coordinator_actor_id=vendor_actor_id,
     )
-    _check_participant_vfd_state_in(
-        finder_client,
-        case_id,
-        vendor_actor_id,
-        fix_ready_states,
-        "M4 finder replica",
-    )
-    logger.info("✓ M4: both replicas show CS includes F (fix ready)")
 
 
 def verify_m5_state(
@@ -682,22 +327,13 @@ def verify_m5_state(
     case_id: str,
     vendor_actor_id: str,
 ) -> None:
-    """Verify milestone M5: both replicas show CS includes D (fix deployed).
-
-    Spec: DEMOMA-06-002.
-    """
-    deployed_state = {CS_vfd.VFD}
-    _check_participant_vfd_state_in(
-        vendor_client, case_id, vendor_actor_id, deployed_state, "M5 vendor"
+    """Scenario alias for :func:`~vultron.demo.helpers.milestones.verify_fix_deployed`."""
+    return verify_fix_deployed(
+        coordinator_client=vendor_client,
+        reporter_client=finder_client,
+        case_id=case_id,
+        coordinator_actor_id=vendor_actor_id,
     )
-    _check_participant_vfd_state_in(
-        finder_client,
-        case_id,
-        vendor_actor_id,
-        deployed_state,
-        "M5 finder replica",
-    )
-    logger.info("✓ M5: both replicas show CS includes D (fix deployed)")
 
 
 def verify_m6_state(
@@ -706,39 +342,13 @@ def verify_m6_state(
     case_id: str,
     vendor_actor_id: str,
 ) -> None:
-    """Verify milestone M6: both replicas CS.VFDPxa and EM terminated.
-
-    Checks:
-    - Both DataLayers reflect ``EM.EXITED`` on the case.
-    - Vendor participant's latest status has ``vfd_state == VFD`` and
-      a public-aware ``pxa_state``.
-
-    Spec: DEMOMA-06-002.
-    """
-    for label, client in [
-        ("vendor", vendor_client),
-        ("finder", finder_client),
-    ]:
-        case_data = client.get(f"/datalayer/{case_id}")
-        assert case_data, f"M6 {label}: case {case_id!r} not found"
-        case = VulnerabilityCase.model_validate(case_data)
-        if case.current_status.em_state != EM.EXITED:
-            raise AssertionError(
-                f"M6 {label}: expected EM.EXITED, "
-                f"found {case.current_status.em_state}"
-            )
-        logger.info("✓ M6 %s: EM.EXITED", label)
-
-    # Verify vendor participant's latest status is VFD + public-aware pxa
-    # on both the vendor's and finder's DataLayer replicas.
-    for label, c in [("vendor", vendor_client), ("finder", finder_client)]:
-        p = _fetch_participant(c, case_id, vendor_actor_id)
-        if p is None:
-            raise AssertionError(
-                f"M6 {label}: vendor participant {vendor_actor_id!r} not found"
-            )
-        _assert_participant_vfd_pxa(p, label, vendor_actor_id)
-    logger.info("✓ M6: both replicas CS.VFDPxa and EM.EXITED")
+    """Scenario alias for :func:`~vultron.demo.helpers.milestones.verify_publicly_disclosed`."""
+    return verify_publicly_disclosed(
+        coordinator_client=vendor_client,
+        reporter_client=finder_client,
+        case_id=case_id,
+        coordinator_actor_id=vendor_actor_id,
+    )
 
 
 def verify_m7_state(
@@ -746,98 +356,44 @@ def verify_m7_state(
     finder_client: DataLayerClient,
     case_id: str,
 ) -> None:
-    """Verify milestone M7: all participants RM.CLOSED on both replicas.
-
-    The Case Actor automatically closes the case once all participants report
-    RM.CLOSED (DEMOMA-07-003 step 5).  This helper verifies the terminal
-    participant state on both DataLayers.
-
-    Spec: DEMOMA-06-002.
-    """
-    for label, client in [
-        ("vendor", vendor_client),
-        ("finder", finder_client),
-    ]:
-        case_data = client.get(f"/datalayer/{case_id}")
-        assert case_data, f"M7 {label}: case {case_id!r} not found"
-        case = VulnerabilityCase.model_validate(case_data)
-        for a_id, p_id in case.actor_participant_index.items():
-            p_data = _fetch_participant_data(client, p_id)
-            if p_data is None:
-                continue  # remote container — not fetchable here
-            p = CaseParticipant(**p_data)
-            # Case Manager is a coordinator; skip RM closure check.
-            if CVDRole.CASE_MANAGER in (p.case_roles or []):
-                continue
-            latest = p.participant_status
-            if latest is None:
-                raise AssertionError(
-                    f"M7 {label}: actor '{a_id}' has no participant statuses"
-                )
-            rm = latest.rm_state
-            if rm != RM.CLOSED:
-                raise AssertionError(
-                    f"M7 {label}: actor '{a_id}' RM state is "
-                    f"{rm!r}, expected RM.CLOSED"
-                )
-        logger.info("✓ M7 %s: all participants RM.CLOSED", label)
-    logger.info("✓ M7: all participants RM.CLOSED on both replicas")
+    """Scenario alias for :func:`~vultron.demo.helpers.milestones.verify_case_closed`."""
+    return verify_case_closed(
+        coordinator_client=vendor_client,
+        reporter_client=finder_client,
+        case_id=case_id,
+    )
 
 
 # ---------------------------------------------------------------------------
-# Main workflow orchestration
+# Phase helpers
 # ---------------------------------------------------------------------------
 
 
-def run_two_actor_demo(
+def _phase_report_submission(
     finder_client: DataLayerClient,
     vendor_client: DataLayerClient,
-    case_actor_client: DataLayerClient | None = None,
-    finder_id: str | None = None,
-    vendor_id: str | None = None,
-) -> None:
-    """Orchestrate the complete two-actor (Finder + Vendor) CVD workflow.
+    case_actor_client: DataLayerClient | None,
+    finder_id: str | None,
+    vendor_id: str | None,
+) -> tuple[
+    as_Actor,
+    as_Actor,
+    as_Actor,
+    VulnerabilityReport,
+    as_Offer,
+    VulnerabilityCase,
+]:
+    """Run reset, seeding, report submission, validation, and M1 verification."""
+    logger.info("─" * 80)
+    logger.info("Phase 1: Report submission and case activation")
+    logger.info("─" * 80)
 
-    Exercises the full VFDPxa lifecycle (M1 → M7) in the D5-1-G5 topology:
-
-    - Phase 1 (M1): Report submission → validation → case creation, default
-      embargo, required participants (Vendor + Finder + Case Actor ≥3 total),
-      EM.ACTIVE.
-    - Phase 2 (M2): Finder receives case replica via outbox delivery; log
-      tail hashes match (SYNC-2).
-    - Phase 3 (M3): Notes exchange — Finder asks a question, Vendor replies.
-    - Phase 4 (M4 → M5): Vendor self-reports fix ready (CS.VFd), then fix
-      deployed (CS.VFD).  Both replicas are verified after each transition.
-    - Phase 5 (M6): Vendor (CASE_OWNER) and Finder report public disclosure.
-      Case Actor triggers embargo teardown (EM.EXITED) automatically.
-    - Phase 6 (M7): Vendor and Finder close their cases (RM.CLOSED).  Case
-      Actor automatically closes the case when all participants report closed.
-
-    Args:
-        finder_client: Client connected to the Finder container.
-        vendor_client: Client connected to the Vendor container.
-        case_actor_client: Optional client connected to a dedicated CaseActor
-            container.  When provided, the demo verifies it remains unused
-            (per D5-2: CaseActor co-locates in Vendor).
-        finder_id: Optional deterministic URI for the Finder actor.
-        vendor_id: Optional deterministic URI for the Vendor actor.
-    """
-    logger.info("=" * 80)
-    logger.info("TWO-ACTOR DEMO: Finder + Vendor CVD Workflow (VFDPxa)")
-    logger.info("=" * 80)
-    logger.info("Finder container: %s", finder_client.base_url)
-    logger.info("Vendor container: %s", vendor_client.base_url)
-    if case_actor_client is not None:
-        logger.info("CaseActor container: %s", case_actor_client.base_url)
-
-    # ── Step 0: Reset containers ───────────────────────────────────────────
     reset_containers(
         finder_client=finder_client,
         vendor_client=vendor_client,
         case_actor_client=case_actor_client,
     )
 
-    # ── Step 1: Seed containers ───────────────────────────────────────────
     with demo_step("Seeding both containers with actor records"):
         finder, vendor = seed_containers(
             finder_client=finder_client,
@@ -846,29 +402,19 @@ def run_two_actor_demo(
             vendor_actor_id=vendor_id,
         )
 
-    # Fetch vendor as seen from the vendor container (same actor, same ID).
     vendor_in_vendor = get_actor_by_id(vendor_client, vendor.id_)
-
-    # ── Step 2: Finder submits report ─────────────────────────────────────
-    report, offer = finder_submits_report(
-        vendor_client=vendor_client,
-        finder=finder,
-        vendor=vendor_in_vendor,
-        finder_client=finder_client,
+    report, offer = reporter_submits_report(
+        coordinator_client=vendor_client,
+        reporter=finder,
+        coordinator=vendor_in_vendor,
+        reporter_client=finder_client,
     )
-
-    # ── Step 3: Vendor validates report ──────────────────────────────────
-    # Per ADR-0015, case creation and participant seeding now happen at
-    # RM.RECEIVED (finder_submits_report above).  validate-report advances
-    # the vendor's RM state from RECEIVED to VALID and then automatically
-    # cascades to engage-case (VALID → ACCEPTED) per D5-7-AUTOENG-2.
-    vendor_validates_report(
-        vendor_client=vendor_client,
-        vendor=vendor_in_vendor,
+    coordinator_validates_report(
+        coordinator_client=vendor_client,
+        coordinator=vendor_in_vendor,
         offer_id=offer.id_,
     )
 
-    # ── Step 3b: Confirm case exists (engage-case now auto-cascades) ──────
     with demo_check("VulnerabilityCase exists in Vendor's DataLayer"):
         case = find_case_for_offer(vendor_client, offer.id_)
         if case is None:
@@ -883,10 +429,6 @@ def run_two_actor_demo(
         expected_count=3,
     )
 
-    # Verify the Finder's container received the case via outbox delivery.
-    # The validate-report trigger queues a Create(VulnerabilityCase) activity
-    # to the Vendor's outbox; the outbox BackgroundTask delivers it to the
-    # Finder's inbox, which then runs CreateCaseReceivedUseCase.
     with demo_check(
         "Finder's DataLayer received case via Vendor outbox delivery"
     ):
@@ -899,30 +441,39 @@ def run_two_actor_demo(
             case.id_,
         )
 
-    # ── Milestone M1: 3 participants, EM.ACTIVE, finder has case replica ──
     with demo_check(
-        "M1: required participants (vendor + finder + case-actor, ≥3), EM.ACTIVE, "
-        "finder has case replica"
+        "M1: required participants (vendor + finder + case-actor, ≥3), "
+        "EM.ACTIVE, finder has case replica"
     ):
-        verify_m1_state(
-            vendor_client=vendor_client,
-            finder_client=finder_client,
+        verify_case_active(
+            coordinator_client=vendor_client,
+            reporter_client=finder_client,
             case_id=case.id_,
-            vendor_actor_id=vendor.id_,
+            coordinator_actor_id=vendor.id_,
             reporter_actor_id=finder.id_,
         )
 
-    # Refresh case after BT completes.
-    case_data = vendor_client.get(f"/datalayer/{case.id_}")
-    case = VulnerabilityCase(**case_data)
+    case = VulnerabilityCase.model_validate(
+        vendor_client.get(f"/datalayer/{case.id_}")
+    )
+    return finder, vendor, vendor_in_vendor, report, offer, case
 
-    # ── Phase 3 (M3): Notes exchange ─────────────────────────────────────
+
+def _phase_notes_exchange(
+    finder_client: DataLayerClient,
+    vendor_client: DataLayerClient,
+    finder: as_Actor,
+    vendor: as_Actor,
+    vendor_in_vendor: as_Actor,
+    case: VulnerabilityCase,
+    report: VulnerabilityReport,
+) -> tuple[as_Note, as_Note, VulnerabilityCase, as_Actor]:
+    """Run the question-and-reply note exchange and verify M3 state."""
     logger.info("─" * 80)
     logger.info("Phase 3: Notes exchange")
     logger.info("─" * 80)
-    # Finder actor from the Finder container.
-    finder_in_finder = get_actor_by_id(finder_client, finder.id_)
 
+    finder_in_finder = get_actor_by_id(finder_client, finder.id_)
     question_note = finder_asks_question(
         vendor_client=vendor_client,
         finder_client=finder_client,
@@ -930,7 +481,6 @@ def run_two_actor_demo(
         finder=finder_in_finder,
         case=case,
     )
-
     reply_note = vendor_replies_to_question(
         vendor_client=vendor_client,
         finder_client=finder_client,
@@ -940,26 +490,36 @@ def run_two_actor_demo(
         question_note=question_note,
     )
 
-    # ── M3: Verify notes are attached to case after exchange ──────────────
     with demo_check(
         "M3: Vendor container holds the authoritative final case state"
     ):
-        final_case = verify_vendor_case_state(
-            vendor_client=vendor_client,
+        final_case = verify_coordinator_case_state(
+            coordinator_client=vendor_client,
             case_id=case.id_,
             report_id=report.id_,
-            vendor_actor_id=vendor.id_,
+            coordinator_actor_id=vendor.id_,
             reporter_actor_id=finder.id_,
             question_note_id=question_note.id_,
             reply_note_id=reply_note.id_,
         )
         logger.info("Final case state (Vendor): %s", logfmt(final_case))
 
-    # ── M2: Commit log entry + verify finder replica ──────────────────────
-    # Per SYNC-2, the CaseActor (co-located in the Vendor container for the
-    # D5-2 topology) commits a log entry that fans out to the Finder via
-    # Announce(CaseLogEntry).  We then poll the Finder for the entry and
-    # compare replica state against the authoritative Vendor view.
+    return question_note, reply_note, final_case, finder_in_finder
+
+
+def _phase_sync_verification(
+    finder_client: DataLayerClient,
+    vendor_client: DataLayerClient,
+    vendor: as_Actor,
+    finder: as_Actor,
+    case: VulnerabilityCase,
+    case_actor_client: DataLayerClient | None,
+) -> None:
+    """Verify SYNC-2 replication and confirm the dedicated case actor is unused."""
+    logger.info("─" * 80)
+    logger.info("Phase 2: Replica synchronization verification")
+    logger.info("─" * 80)
+
     with demo_step("Committing case log entry on Vendor (CaseActor)"):
         entry_hash = trigger_log_commit(
             client=vendor_client,
@@ -984,19 +544,26 @@ def run_two_actor_demo(
             reporter_actor_id=finder.id_,
         )
 
-    logger.info("✓ M2: Finder DataLayer synchronized (SYNC-2 verified)")
-
     with demo_check("Dedicated CaseActor container remains unused for D5-2"):
         verify_case_actor_unused(case_actor_client, case.id_)
 
-    # ── Phase 4: Fix lifecycle (M4 → M5) ─────────────────────────────────
+    logger.info("✓ M2: Finder DataLayer synchronized (SYNC-2 verified)")
+
+
+def _phase_fix_lifecycle(
+    finder_client: DataLayerClient,
+    vendor_client: DataLayerClient,
+    vendor: as_Actor,
+    vendor_in_vendor: as_Actor,
+    case: VulnerabilityCase,
+) -> None:
+    """Advance the case through fix-ready and fix-deployed milestones."""
     logger.info("─" * 80)
     logger.info(
         "Phase 4: Fix lifecycle — VFd (fix ready) → VFD (fix deployed)"
     )
     logger.info("─" * 80)
 
-    # Step 10: Vendor reports fix ready (CS.vfd → CS.VFd)
     actor_notifies_fix_ready(
         client=vendor_client,
         actor=vendor_in_vendor,
@@ -1018,14 +585,13 @@ def run_two_actor_demo(
             actor_id=vendor.id_,
             expected_states={CS_vfd.VFd, CS_vfd.VFD},
         )
-        verify_m4_state(
-            vendor_client=vendor_client,
-            finder_client=finder_client,
+        verify_fix_ready(
+            coordinator_client=vendor_client,
+            reporter_client=finder_client,
             case_id=case.id_,
-            vendor_actor_id=vendor.id_,
+            coordinator_actor_id=vendor.id_,
         )
 
-    # Step 11: Vendor reports fix deployed (CS.VFd → CS.VFD)
     actor_notifies_fix_deployed(
         client=vendor_client,
         actor=vendor_in_vendor,
@@ -1039,22 +605,30 @@ def run_two_actor_demo(
             actor_id=vendor.id_,
             expected_states={CS_vfd.VFD},
         )
-        verify_m5_state(
-            vendor_client=vendor_client,
-            finder_client=finder_client,
+        verify_fix_deployed(
+            coordinator_client=vendor_client,
+            reporter_client=finder_client,
             case_id=case.id_,
-            vendor_actor_id=vendor.id_,
+            coordinator_actor_id=vendor.id_,
         )
 
-    # ── Phase 5: Publication and embargo teardown (M6) ───────────────────
+
+def _phase_publication(
+    finder_client: DataLayerClient,
+    vendor_client: DataLayerClient,
+    vendor: as_Actor,
+    vendor_in_vendor: as_Actor,
+    finder: as_Actor,
+    finder_in_finder: as_Actor,
+    case: VulnerabilityCase,
+) -> None:
+    """Run publication notifications and verify public disclosure state."""
     logger.info("─" * 80)
     logger.info(
         "Phase 5: Publication — CS.VFDPxa + embargo teardown (EM.EXITED)"
     )
     logger.info("─" * 80)
 
-    # Step 12: Vendor (CASE_OWNER) reports public disclosure.
-    # This triggers automatic embargo teardown by the Case Actor.
     actor_notifies_published(
         client=vendor_client,
         actor=vendor_in_vendor,
@@ -1069,7 +643,6 @@ def run_two_actor_demo(
             case_id=case.id_,
         )
 
-    # Step 13: Finder (Reporter) also reports public disclosure.
     actor_notifies_published(
         client=finder_client,
         actor=finder_in_finder,
@@ -1077,32 +650,40 @@ def run_two_actor_demo(
     )
 
     with demo_check(
-        "M6: both replicas CS.VFDPxa, EM.EXITED, vendor participant is public-aware"
+        "M6: both replicas CS.VFDPxa, EM.EXITED, vendor participant is "
+        "public-aware"
     ):
         wait_for_case_em_terminated(
             client=finder_client,
             case_id=case.id_,
         )
-        verify_m6_state(
-            vendor_client=vendor_client,
-            finder_client=finder_client,
+        verify_publicly_disclosed(
+            coordinator_client=vendor_client,
+            reporter_client=finder_client,
             case_id=case.id_,
-            vendor_actor_id=vendor.id_,
+            coordinator_actor_id=vendor.id_,
         )
 
-    # ── Phase 6: Case closure (M7) ───────────────────────────────────────
+
+def _phase_case_closure(
+    finder_client: DataLayerClient,
+    vendor_client: DataLayerClient,
+    vendor: as_Actor,
+    vendor_in_vendor: as_Actor,
+    finder: as_Actor,
+    finder_in_finder: as_Actor,
+    case: VulnerabilityCase,
+) -> None:
+    """Close the case from both participants and verify terminal state."""
     logger.info("─" * 80)
     logger.info("Phase 6: Case closure — all participants RM.CLOSED")
     logger.info("─" * 80)
 
-    # Step 14: Vendor closes case.
     actor_closes_case(
         client=vendor_client,
         actor=vendor_in_vendor,
         case_id=case.id_,
     )
-
-    # Step 15: Finder (Reporter) closes case.
     actor_closes_case(
         client=finder_client,
         actor=finder_in_finder,
@@ -1118,11 +699,85 @@ def run_two_actor_demo(
             client=finder_client,
             case_id=case.id_,
         )
-        verify_m7_state(
-            vendor_client=vendor_client,
-            finder_client=finder_client,
+        verify_case_closed(
+            coordinator_client=vendor_client,
+            reporter_client=finder_client,
             case_id=case.id_,
         )
+
+
+# ---------------------------------------------------------------------------
+# Main workflow orchestration
+# ---------------------------------------------------------------------------
+
+
+def run_two_actor_demo(
+    finder_client: DataLayerClient,
+    vendor_client: DataLayerClient,
+    case_actor_client: DataLayerClient | None = None,
+    finder_id: str | None = None,
+    vendor_id: str | None = None,
+) -> None:
+    """Orchestrate the complete two-actor (Finder + Vendor) CVD workflow."""
+    logger.info("=" * 80)
+    logger.info("TWO-ACTOR DEMO: Reporter + Coordinator CVD Workflow (VFDPxa)")
+    logger.info("=" * 80)
+    logger.info("Finder container: %s", finder_client.base_url)
+    logger.info("Vendor container: %s", vendor_client.base_url)
+    if case_actor_client is not None:
+        logger.info("CaseActor container: %s", case_actor_client.base_url)
+
+    finder, vendor, vendor_in_vendor, report, offer, case = (
+        _phase_report_submission(
+            finder_client,
+            vendor_client,
+            case_actor_client,
+            finder_id,
+            vendor_id,
+        )
+    )
+    _, _, _, finder_in_finder = _phase_notes_exchange(
+        finder_client,
+        vendor_client,
+        finder,
+        vendor,
+        vendor_in_vendor,
+        case,
+        report,
+    )
+    _phase_sync_verification(
+        finder_client,
+        vendor_client,
+        vendor,
+        finder,
+        case,
+        case_actor_client,
+    )
+    _phase_fix_lifecycle(
+        finder_client,
+        vendor_client,
+        vendor,
+        vendor_in_vendor,
+        case,
+    )
+    _phase_publication(
+        finder_client,
+        vendor_client,
+        vendor,
+        vendor_in_vendor,
+        finder,
+        finder_in_finder,
+        case,
+    )
+    _phase_case_closure(
+        finder_client,
+        vendor_client,
+        vendor,
+        vendor_in_vendor,
+        finder,
+        finder_in_finder,
+        case,
+    )
 
     logger.info("=" * 80)
     logger.info("TWO-ACTOR DEMO COMPLETE ✓  (VFDPxa full lifecycle)")

--- a/vultron/demo/scenario/two_actor_demo.py
+++ b/vultron/demo/scenario/two_actor_demo.py
@@ -82,6 +82,7 @@ from vultron.demo.helpers.polling import (  # noqa: F401
 from vultron.demo.helpers.seeding import (  # noqa: F401
     _dl_key,
     get_actor_by_id,
+    reset_containers as _reset_containers,
     seed_containers,
 )
 from vultron.demo.helpers.sync import (  # noqa: F401
@@ -137,11 +138,15 @@ def reset_containers(
     vendor_client: DataLayerClient,
     case_actor_client: DataLayerClient | None = None,
 ) -> None:
-    """Reset all containers used by the demo to a clean baseline.
+    """Reset all containers used by the two-actor demo to a clean baseline.
 
     D5-2 requires repeatable, single-command execution. Resetting each
     container's DataLayer at the start of the run ensures the demo does
     not depend on a prior ``docker compose down -v``.
+
+    The ``reset_datalayer`` reference is passed explicitly so that test-suite
+    patches on this module's ``reset_datalayer`` name are correctly intercepted
+    by the generic helper in ``vultron.demo.helpers.seeding``.
     """
     targets: list[tuple[str, DataLayerClient]] = [
         ("Finder", finder_client),
@@ -149,19 +154,7 @@ def reset_containers(
     ]
     if case_actor_client is not None:
         targets.append(("CaseActor", case_actor_client))
-
-    with demo_step("Resetting actor containers to a clean baseline"):
-        for label, client in targets:
-            result = reset_datalayer(client=client, init=False)
-            logger.debug("%s reset result: %s", label, result)
-
-    with demo_check("All actor containers start with no persisted cases"):
-        for label, client in targets:
-            cases = client.get("/datalayer/VulnerabilityCases/")
-            if cases:
-                raise AssertionError(
-                    f"{label} container was not reset cleanly: {cases}"
-                )
+    _reset_containers(targets, reset_fn=reset_datalayer)
 
 
 # ---------------------------------------------------------------------------

--- a/vultron/demo/scenario/two_actor_demo.py
+++ b/vultron/demo/scenario/two_actor_demo.py
@@ -54,23 +54,17 @@ References: ``notes/multi-actor-architecture.md`` §4 G5,
 import logging
 import os
 import sys
-import time
 from typing import Optional, Tuple
-from urllib.parse import quote
-
-import requests  # type: ignore[import-untyped]
 
 from vultron.adapters.utils import parse_id
-from vultron.core.states.cs import CS_pxa, CS_vfd
+from vultron.core.states.cs import CS_vfd
 from vultron.core.states.em import EM
 from vultron.core.states.rm import RM
 from vultron.core.states.roles import CVDRole
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
 from vultron.wire.as2.vocab.base.objects.object_types import as_Note
-from vultron.wire.as2.vocab.objects.case_participant import (
-    CaseParticipant,
-)
+from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
     VulnerabilityReport,
@@ -94,6 +88,51 @@ from vultron.wire.as2.factories import (
     rm_submit_report_activity,
 )
 
+# Re-export shared helpers so that existing imports via this module continue to
+# work and the test suite (which patches symbols in this module's namespace)
+# remains unchanged.
+from vultron.demo.helpers.actions import (  # noqa: F401
+    actor_closes_case,
+    actor_notifies_fix_deployed,
+    actor_notifies_fix_ready,
+    actor_notifies_published,
+    actor_notifies_state_change,
+)
+from vultron.demo.helpers.polling import (  # noqa: F401
+    _poll_until,
+    wait_for_all_participants_rm_closed,
+    wait_for_case_em_terminated,
+    wait_for_case_on_container,
+    wait_for_case_participants,
+    wait_for_finder_case,
+    wait_for_finder_log_entry,
+    wait_for_note_in_case,
+    wait_for_participant_vfd_state,
+)
+from vultron.demo.helpers.seeding import (  # noqa: F401
+    _dl_key,
+    get_actor_by_id,
+    seed_containers,
+)
+from vultron.demo.helpers.sync import (  # noqa: F401
+    _extract_ref_id,
+    _get_log_entries_for_case,
+    trigger_log_commit,
+    verify_finder_replica_state,
+    verify_replica_state,
+)
+from vultron.demo.helpers.verification import (  # noqa: F401
+    _all_fetchable_participants_rm_closed,
+    _assert_case_notes,
+    _assert_participant_vfd_pxa,
+    _assert_vendor_case_status,
+    _assert_vendor_participant_state,
+    _check_participant_vfd_state_in,
+    _fetch_participant,
+    _fetch_participant_data,
+    _require_case_participant_id,
+)
+
 logger = logging.getLogger(__name__)
 
 # Default container base URLs — override via environment variables.
@@ -110,116 +149,6 @@ CASE_ACTOR_BASE_URL = os.environ.get(
 # Deterministic actor IDs from docker-compose-multi-actor.yml (D5-1-G3).
 FINDER_ACTOR_ID = "http://finder:7999/api/v2/actors/finder"
 VENDOR_ACTOR_ID = "http://vendor:7999/api/v2/actors/vendor"
-
-
-# ---------------------------------------------------------------------------
-# DataLayer path helpers
-# ---------------------------------------------------------------------------
-
-
-def _dl_key(key: str) -> str:
-    """URL-encode a DataLayer key for safe embedding in an API path segment.
-
-    Encodes characters that are illegal in URL path segments (e.g., colons in
-    URN-style keys like ``urn:uuid:...``).
-
-    Note: HTTP URL-based participant IDs (which contain literal slashes) cannot
-    be fetched via the single-segment ``/{key}`` DataLayer route even after
-    URL-encoding, because Starlette decodes ``%2F`` back to ``/`` before path
-    matching.  Such IDs must be handled via exception catching at the call site.
-    """
-    return quote(str(key), safe="")
-
-
-# ---------------------------------------------------------------------------
-# Seeding helpers
-# ---------------------------------------------------------------------------
-
-
-def seed_containers(
-    finder_client: DataLayerClient,
-    vendor_client: DataLayerClient,
-    reporter_actor_id: str | None = None,
-    vendor_actor_id: str | None = None,
-) -> Tuple[as_Actor, as_Actor]:
-    """Seed both containers: create actor records and register cross-container peers.
-
-    The seeding is done in two phases to avoid ordering issues:
-
-    1. Create the local actor on each container independently.
-    2. Register each actor as a known peer on the other container.
-
-    This function is idempotent: re-running it returns existing actors
-    unchanged (the ``POST /actors/`` endpoint is idempotent).
-
-    Args:
-        finder_client: Client connected to the Finder container.
-        vendor_client: Client connected to the Vendor container.
-        reporter_actor_id: Optional deterministic URI for the Finder actor.
-            When absent the server derives one from ``VULTRON_BASE_URL``.
-        vendor_actor_id: Optional deterministic URI for the Vendor actor.
-            When absent the server derives one from ``VULTRON_BASE_URL``.
-
-    Returns:
-        Tuple of ``(finder, vendor)`` ``as_Actor`` objects as created on their
-        respective containers.
-    """
-    logger.info("Phase 1: creating local actors on each container...")
-    finder = seed_actor(
-        client=finder_client,
-        name="Finder",
-        actor_type="Person",
-        actor_id=reporter_actor_id,
-    )
-    logger.info("Finder actor seeded on Finder container: %s", finder.id_)
-
-    vendor = seed_actor(
-        client=vendor_client,
-        name="Vendor",
-        actor_type="Organization",
-        actor_id=vendor_actor_id,
-    )
-    logger.info("Vendor actor seeded on Vendor container: %s", vendor.id_)
-
-    logger.info("Phase 2: registering cross-container peers...")
-    seed_actor(
-        client=finder_client,
-        name="Vendor",
-        actor_type="Organization",
-        actor_id=vendor.id_,
-    )
-    logger.info("Vendor peer registered on Finder container: %s", vendor.id_)
-
-    seed_actor(
-        client=vendor_client,
-        name="Finder",
-        actor_type="Person",
-        actor_id=finder.id_,
-    )
-    logger.info("Finder peer registered on Vendor container: %s", finder.id_)
-
-    return finder, vendor
-
-
-def get_actor_by_id(client: DataLayerClient, actor_id: str) -> as_Actor:
-    """Fetch an actor record from a container by its full URI.
-
-    Args:
-        client: Client connected to the target container.
-        actor_id: Full URI of the actor to fetch.
-
-    Returns:
-        The ``as_Actor`` object.
-
-    Raises:
-        ValueError: If the actor is not found.
-    """
-    actors = client.get("/actors/")
-    for a in actors:
-        actor = as_Actor.model_validate(a)
-        if actor.id_ == actor_id:
-            return actor
-    raise ValueError(f"Actor {actor_id!r} not found in container")
 
 
 def reset_containers(
@@ -367,49 +296,6 @@ def vendor_validates_report(
         )
     logger.info("Validate-report trigger result for actor %s", vendor_obj_id)
     return result
-
-
-def wait_for_note_in_case(
-    client: DataLayerClient,
-    case_id: str,
-    note_id: str,
-    timeout_seconds: float = 10.0,
-    poll_interval: float = 0.5,
-) -> None:
-    """Poll until *note_id* appears in the ``notes`` list of the case.
-
-    Used to confirm that an outbox-delivered note has been processed by
-    the receiving actor's inbox handler.
-
-    Args:
-        client: DataLayerClient for the container to poll.
-        case_id: Full URI of the case.
-        note_id: Full URI of the note to wait for.
-        timeout_seconds: Maximum time to wait before raising.
-        poll_interval: Seconds between DataLayer poll attempts.
-
-    Raises:
-        AssertionError: If *note_id* does not appear within *timeout_seconds*.
-    """
-    deadline = time.monotonic() + timeout_seconds
-    while time.monotonic() < deadline:
-        try:
-            case_data = client.get(f"/datalayer/{case_id}")
-            case = VulnerabilityCase(**case_data)
-            note_ids = [
-                n if isinstance(n, str) else getattr(n, "id_", str(n))
-                for n in case.notes
-            ]
-            if note_id in note_ids:
-                return
-        except Exception:  # noqa: BLE001
-            pass
-        time.sleep(poll_interval)
-
-    raise AssertionError(
-        f"Timed out waiting for note {note_id!r} to appear in case "
-        f"{case_id!r}"
-    )
 
 
 def finder_asks_question(
@@ -610,66 +496,6 @@ def find_case_for_offer(
     return None
 
 
-def _require_case_participant_id(
-    case: VulnerabilityCase,
-    actor_id: str,
-    label: str,
-) -> str:
-    participant_id = case.actor_participant_index.get(actor_id)
-    if participant_id is None:
-        raise AssertionError(
-            f"{label} actor is missing from actor_participant_index"
-        )
-    return participant_id
-
-
-def _assert_vendor_participant_state(
-    vendor_client: DataLayerClient,
-    participant_id: str,
-) -> None:
-    participant = CaseParticipant(
-        **vendor_client.get(f"/datalayer/{_dl_key(participant_id)}")
-    )
-    latest = participant.participant_status
-    if latest is None:
-        raise AssertionError("Vendor participant has no participant statuses")
-    if latest.rm_state != RM.ACCEPTED:
-        raise AssertionError(
-            "Vendor participant RM state did not transition to ACCEPTED"
-        )
-
-
-def _assert_vendor_case_status(case: VulnerabilityCase) -> None:
-    if case.current_status.em_state != EM.ACTIVE:
-        raise AssertionError(
-            f"Expected ACTIVE final EM state (default embargo activated at"
-            f" case creation per EP-04-001), found {case.current_status.em_state}"
-        )
-    if case.current_status.pxa_state != CS_pxa.pxa:
-        raise AssertionError(
-            f"Expected pxa final case state, found {case.current_status.pxa_state}"
-        )
-
-
-def _assert_case_notes(
-    case: VulnerabilityCase,
-    question_note_id: str | None,
-    reply_note_id: str | None,
-) -> None:
-    if question_note_id is None and reply_note_id is None:
-        return
-
-    note_ids = [ref_id(note) or str(note) for note in case.notes]
-    if question_note_id is not None and question_note_id not in note_ids:
-        raise AssertionError(
-            f"Question note {question_note_id!r} not found in case notes"
-        )
-    if reply_note_id is not None and reply_note_id not in note_ids:
-        raise AssertionError(
-            f"Reply note {reply_note_id!r} not found in case notes"
-        )
-
-
 def verify_vendor_case_state(
     vendor_client: DataLayerClient,
     case_id: str,
@@ -750,632 +576,6 @@ def verify_case_actor_unused(
         )
 
 
-def wait_for_case_participants(
-    vendor_client: DataLayerClient,
-    case_id: str,
-    expected_count: int,
-    timeout_seconds: float = 5.0,
-    poll_interval: float = 0.25,
-) -> None:
-    """Poll until the Vendor's case reflects the expected participant count."""
-    deadline = time.monotonic() + timeout_seconds
-    while time.monotonic() < deadline:
-        case_data = vendor_client.get(f"/datalayer/{case_id}")
-        case = VulnerabilityCase(**case_data)
-        if len(case.case_participants) >= expected_count:
-            return
-        time.sleep(poll_interval)
-
-    final_case = VulnerabilityCase(
-        **vendor_client.get(f"/datalayer/{case_id}")
-    )
-    raise AssertionError(
-        "Timed out waiting for participant count "
-        f"{expected_count}; found {len(final_case.case_participants)}"
-    )
-
-
-def wait_for_finder_case(
-    finder_client: DataLayerClient,
-    case_id: str,
-    timeout_seconds: float = 10.0,
-    poll_interval: float = 0.5,
-) -> None:
-    """Poll finder's DataLayer until *case_id* appears.
-
-    This proves that the Vendor's outbox successfully delivered the
-    ``Create(VulnerabilityCase)`` notification to the Finder and that the
-    Finder's inbox handler processed it (D5-6-DEMOAUDIT requirement).
-
-    In single-server integration tests both actors share the same DataLayer,
-    so the case is visible immediately.  In a multi-server Docker demo the
-    case arrives after the outbox background task completes and the Finder
-    inbox handler processes the inbound activity.
-
-    Args:
-        finder_client: Client connected to the Finder container.
-        case_id: Full URI of the ``VulnerabilityCase`` to wait for.
-        timeout_seconds: Maximum time to wait before raising.
-        poll_interval: Seconds between DataLayer poll attempts.
-
-    Raises:
-        AssertionError: If *case_id* does not appear within *timeout_seconds*.
-    """
-    deadline = time.monotonic() + timeout_seconds
-    while time.monotonic() < deadline:
-        raw = finder_client.get("/datalayer/VulnerabilityCases/")
-        # The endpoint returns a dict keyed by case ID (from by_type()).
-        if isinstance(raw, dict) and case_id in raw:
-            return
-        time.sleep(poll_interval)
-
-    raise AssertionError(
-        f"Timed out waiting for case {case_id!r} to appear in "
-        "finder's DataLayer — outbox delivery may not have completed"
-    )
-
-
-# ---------------------------------------------------------------------------
-# SYNC-2 log replication helpers
-# ---------------------------------------------------------------------------
-
-
-def trigger_log_commit(
-    client: DataLayerClient,
-    actor_id: str,
-    case_id: str,
-    event_type: str,
-    object_id: str | None = None,
-) -> str:
-    """Commit a log entry for *case_id* and return the entry hash.
-
-    POSTs to ``/actors/{actor_id}/demo/sync-log-entry`` and returns
-    the ``entry_hash`` from the response.  The entry is also fanned out
-    to all case participants via ``Announce(CaseLogEntry)`` activities
-    queued in the actor's outbox.
-
-    Args:
-        client: DataLayerClient connected to the CaseActor container.
-        actor_id: Full URI of the actor committing the log entry.
-        case_id: Full URI of the ``VulnerabilityCase``.
-        event_type: Short machine-readable event descriptor.
-        object_id: Optional URI of the primary object.  Defaults to
-            *case_id* when not supplied.
-
-    Returns:
-        The ``entry_hash`` of the newly committed log entry.
-
-    Spec: SYNC-02-002, SYNC-02-003.
-    """
-    result = post_to_trigger(
-        client=client,
-        actor_id=actor_id,
-        behavior="sync-log-entry",
-        body={
-            "case_id": case_id,
-            "object_id": object_id if object_id is not None else case_id,
-            "event_type": event_type,
-        },
-        path_prefix="demo",
-    )
-    entry_hash: str = result["entry_hash"]
-    logger.info(
-        "Log entry committed for case '%s': hash=%s, index=%d",
-        case_id,
-        entry_hash[:16],
-        result.get("log_index", -1),
-    )
-    return entry_hash
-
-
-def wait_for_finder_log_entry(
-    finder_client: DataLayerClient,
-    case_id: str,
-    entry_hash: str,
-    timeout_seconds: float = 15.0,
-    poll_interval: float = 0.5,
-) -> None:
-    """Poll finder's DataLayer until a ``CaseLogEntry`` with *entry_hash* appears.
-
-    Proves that the vendor's ``Announce(CaseLogEntry)`` outbox activity was
-    delivered to the finder's inbox and processed by
-    ``AnnounceLogEntryReceivedUseCase`` (SYNC-2 receive side).
-
-    Args:
-        finder_client: Client connected to the Finder container.
-        case_id: Full URI of the ``VulnerabilityCase`` (used for filtering).
-        entry_hash: ``entry_hash`` value of the expected log entry.
-        timeout_seconds: Maximum time to wait before raising.
-        poll_interval: Seconds between DataLayer poll attempts.
-
-    Raises:
-        AssertionError: If the entry does not appear within *timeout_seconds*.
-
-    Spec: SYNC-02-002.
-    """
-    deadline = time.monotonic() + timeout_seconds
-    while time.monotonic() < deadline:
-        raw = finder_client.get("/datalayer/CaseLogEntrys/")
-        if isinstance(raw, dict):
-            for v in raw.values():
-                if (
-                    isinstance(v, dict)
-                    and v.get("case_id") == case_id
-                    and v.get("entry_hash") == entry_hash
-                ):
-                    logger.info(
-                        "Log entry with hash=%s found in finder's DataLayer",
-                        entry_hash[:16],
-                    )
-                    return
-        time.sleep(poll_interval)
-
-    raise AssertionError(
-        f"Timed out waiting for log entry (hash={entry_hash!r}) for case "
-        f"{case_id!r} to appear in finder's DataLayer — replication may "
-        "not have completed"
-    )
-
-
-def _extract_ref_id(ref: object) -> Optional[str]:
-    """Extract the string ID from an object, ``as_Link``, or string reference."""
-    if ref is None:
-        return None
-    if isinstance(ref, str):
-        return ref
-    if hasattr(ref, "id_"):
-        return str(ref.id_)  # type: ignore[union-attr]
-    if hasattr(ref, "href"):
-        return str(ref.href)  # type: ignore[union-attr]
-    return str(ref)
-
-
-def _get_log_entries_for_case(
-    client: DataLayerClient, case_id: str
-) -> list[dict]:
-    """Return all ``CaseLogEntry`` dicts for *case_id* from the DataLayer."""
-    raw = client.get("/datalayer/CaseLogEntrys/")
-    if not isinstance(raw, dict):
-        return []
-    return [
-        v
-        for v in raw.values()
-        if isinstance(v, dict) and v.get("case_id") == case_id
-    ]
-
-
-def verify_finder_replica_state(
-    finder_client: DataLayerClient,
-    vendor_client: DataLayerClient,
-    case_id: str,
-    vendor_actor_id: str,
-    reporter_actor_id: str,
-) -> None:
-    """Verify that the finder's case replica matches the authoritative vendor state.
-
-    Checks four properties:
-
-    1. The same ``case_id`` exists in the finder's DataLayer.
-    2. ``actor_participant_index`` keys are identical (same participant set).
-    3. ``active_embargo`` references the same ID on both sides.
-    4. Log-state hash consistency: both sides share the same tail entry hash.
-
-    Args:
-        finder_client: Client connected to the Finder container.
-        vendor_client: Client connected to the Vendor container.
-        case_id: Full URI of the ``VulnerabilityCase`` being verified.
-        vendor_actor_id: Full URI of the Vendor actor (unused directly but
-            retained for symmetry with *reporter_actor_id*).
-        reporter_actor_id: Full URI of the Finder actor (unused directly but
-            retained for future participant-status checks).
-
-    Raises:
-        AssertionError: If any replica invariant is violated.
-
-    Spec: SYNC-02-002, D5-7-DEMOREPLCHECK-1.
-    """
-    vendor_case_data = vendor_client.get(f"/datalayer/{case_id}")
-    assert vendor_case_data, f"Vendor case {case_id!r} not found"
-    vendor_case = VulnerabilityCase.model_validate(vendor_case_data)
-
-    finder_case_data = finder_client.get(f"/datalayer/{case_id}")
-    assert finder_case_data, (
-        f"Finder does not have a copy of case {case_id!r} — "
-        "outbox delivery or inbox processing may have failed"
-    )
-    finder_case = VulnerabilityCase.model_validate(finder_case_data)
-
-    # 1. Same case ID
-    assert (
-        finder_case.id_ == case_id
-    ), f"Finder case ID mismatch: {finder_case.id_!r} != {case_id!r}"
-    logger.info("✓ Finder case ID matches: %s", case_id)
-
-    # 2. actor_participant_index keys match
-    vendor_index = vendor_case.actor_participant_index or {}
-    finder_index = finder_case.actor_participant_index or {}
-    assert set(vendor_index.keys()) == set(finder_index.keys()), (
-        "Finder actor_participant_index key set differs from vendor: "
-        f"finder={set(finder_index.keys())} "
-        f"vendor={set(vendor_index.keys())}"
-    )
-    logger.info(
-        "✓ Finder actor_participant_index matches (%d participants)",
-        len(finder_index),
-    )
-
-    # 3. active_embargo ID matches (if present on vendor)
-    vendor_embargo_id = _extract_ref_id(vendor_case.active_embargo)
-    finder_embargo_id = _extract_ref_id(finder_case.active_embargo)
-    if vendor_embargo_id is not None:
-        assert vendor_embargo_id == finder_embargo_id, (
-            f"Finder active_embargo {finder_embargo_id!r} != "
-            f"vendor active_embargo {vendor_embargo_id!r}"
-        )
-        logger.info("✓ Finder active_embargo matches: %s", vendor_embargo_id)
-
-    # 4. Log-state hash consistency
-    vendor_entries = _get_log_entries_for_case(vendor_client, case_id)
-    finder_entries = _get_log_entries_for_case(finder_client, case_id)
-    assert len(finder_entries) > 0, (
-        "Finder has no CaseLogEntry records for the case — "
-        "SYNC-2 replication did not complete"
-    )
-    vendor_tail = max(vendor_entries, key=lambda e: e["log_index"])
-    finder_tail = max(finder_entries, key=lambda e: e["log_index"])
-    assert vendor_tail["entry_hash"] == finder_tail["entry_hash"], (
-        f"Finder log tail hash {finder_tail['entry_hash']!r} != "
-        f"vendor log tail hash {vendor_tail['entry_hash']!r} — "
-        "hash-chain replication integrity failure"
-    )
-    logger.info(
-        "✓ Finder log tail hash matches vendor: %s… (index=%d)",
-        finder_tail["entry_hash"][:16],
-        finder_tail["log_index"],
-    )
-
-
-# ---------------------------------------------------------------------------
-# Fix-lifecycle and closure step functions
-# ---------------------------------------------------------------------------
-
-
-def actor_notifies_fix_ready(
-    client: DataLayerClient,
-    actor: as_Actor,
-    case_id: str,
-) -> dict:
-    """Self-report fix ready (CS.VFd) via the demo trigger endpoint.
-
-    Sends ``Add(ParticipantStatus(CS.VFd), target=Case)`` to the Case Manager
-    so the Case Actor can update participant state and broadcast to peers.
-
-    Args:
-        client: Client connected to the actor's container.
-        actor: The actor that has a fix ready.
-        case_id: Full URI of the ``VulnerabilityCase``.
-
-    Returns:
-        Response dict from the trigger endpoint.
-
-    Spec: DEMOMA-07-001.
-    """
-    with demo_step(f"Actor {ref_id(actor)} reports fix ready"):
-        return post_to_trigger(
-            client=client,
-            actor_id=actor.id_,
-            behavior="notify-fix-ready",
-            body={"case_id": case_id},
-            path_prefix="demo",
-        )
-
-
-def actor_notifies_fix_deployed(
-    client: DataLayerClient,
-    actor: as_Actor,
-    case_id: str,
-) -> dict:
-    """Self-report fix deployed (CS.VFD) via the demo trigger endpoint.
-
-    Args:
-        client: Client connected to the actor's container.
-        actor: The actor that has deployed a fix.
-        case_id: Full URI of the ``VulnerabilityCase``.
-
-    Returns:
-        Response dict from the trigger endpoint.
-
-    Spec: DEMOMA-07-001.
-    """
-    with demo_step(f"Actor {ref_id(actor)} reports fix deployed"):
-        return post_to_trigger(
-            client=client,
-            actor_id=actor.id_,
-            behavior="notify-fix-deployed",
-            body={"case_id": case_id},
-            path_prefix="demo",
-        )
-
-
-def actor_notifies_published(
-    client: DataLayerClient,
-    actor: as_Actor,
-    case_id: str,
-) -> dict:
-    """Self-report vulnerability publicly disclosed (CS.VFDPxa) via the
-    demo trigger endpoint.
-
-    When called by the CASE_OWNER (Vendor), the Case Actor automatically
-    initiates embargo teardown on receipt (DEMOMA-07-003 step 4).
-
-    Args:
-        client: Client connected to the actor's container.
-        actor: The actor reporting publication.
-        case_id: Full URI of the ``VulnerabilityCase``.
-
-    Returns:
-        Response dict from the trigger endpoint.
-
-    Spec: DEMOMA-07-001.
-    """
-    with demo_step(
-        f"Actor {ref_id(actor)} reports vulnerability publicly disclosed"
-    ):
-        return post_to_trigger(
-            client=client,
-            actor_id=actor.id_,
-            behavior="notify-published",
-            body={"case_id": case_id},
-            path_prefix="demo",
-        )
-
-
-def actor_closes_case(
-    client: DataLayerClient,
-    actor: as_Actor,
-    case_id: str,
-) -> dict:
-    """Self-report case closed (RM.CLOSED) via the demo trigger endpoint.
-
-    When all participants report RM.CLOSED, the Case Actor automatically
-    closes the case (DEMOMA-07-003 step 5).
-
-    Args:
-        client: Client connected to the actor's container.
-        actor: The actor closing the case.
-        case_id: Full URI of the ``VulnerabilityCase``.
-
-    Returns:
-        Response dict from the trigger endpoint.
-
-    Spec: DEMOMA-07-001.
-    """
-    with demo_step(f"Actor {ref_id(actor)} closes case"):
-        return post_to_trigger(
-            client=client,
-            actor_id=actor.id_,
-            behavior="close-case",
-            body={"case_id": case_id},
-            path_prefix="demo",
-        )
-
-
-# ---------------------------------------------------------------------------
-# Polling helpers for milestone verification
-# ---------------------------------------------------------------------------
-
-
-def _fetch_participant(
-    client: DataLayerClient,
-    case_id: str,
-    actor_id: str,
-) -> Optional[CaseParticipant]:
-    """Fetch the CaseParticipant record for *actor_id* in *case_id*.
-
-    Args:
-        client: DataLayerClient for the target container.
-        case_id: Full URI of the ``VulnerabilityCase``.
-        actor_id: Full URI of the actor whose participant record to fetch.
-
-    Returns:
-        The ``CaseParticipant`` or ``None`` if the actor or participant
-        record is not found.
-    """
-    try:
-        case_data = client.get(f"/datalayer/{case_id}")
-        case = VulnerabilityCase.model_validate(case_data)
-        participant_id = case.actor_participant_index.get(actor_id)
-        if participant_id is None:
-            return None
-        p_data = client.get(f"/datalayer/{_dl_key(participant_id)}")
-        return CaseParticipant(**p_data)
-    except (requests.HTTPError, AssertionError):
-        return None
-
-
-def wait_for_participant_vfd_state(
-    client: DataLayerClient,
-    case_id: str,
-    actor_id: str,
-    expected_states: "set[CS_vfd]",
-    timeout_seconds: float = 10.0,
-    poll_interval: float = 0.25,
-) -> None:
-    """Poll until the actor's latest participant ``vfd_state`` is in
-    *expected_states*.
-
-    Args:
-        client: DataLayerClient for the target container.
-        case_id: Full URI of the ``VulnerabilityCase``.
-        actor_id: Full URI of the actor to check.
-        expected_states: Set of ``CS_vfd`` values that satisfy the condition.
-        timeout_seconds: Maximum time to wait.
-        poll_interval: Seconds between DataLayer poll attempts.
-
-    Raises:
-        AssertionError: If the state is not reached within *timeout_seconds*.
-    """
-    deadline = time.monotonic() + timeout_seconds
-    while time.monotonic() < deadline:
-        participant = _fetch_participant(client, case_id, actor_id)
-        if participant is not None:
-            latest = participant.participant_status
-            if latest is not None and latest.vfd_state in expected_states:
-                return
-        time.sleep(poll_interval)
-
-    participant = _fetch_participant(client, case_id, actor_id)
-    latest = (
-        participant.participant_status if participant is not None else None
-    )
-    current = latest.vfd_state if latest is not None else "unknown"
-    raise AssertionError(
-        f"Timed out waiting for actor '{actor_id}' vfd_state to be in "
-        f"{expected_states!r}; current={current!r}"
-    )
-
-
-def wait_for_case_em_terminated(
-    client: DataLayerClient,
-    case_id: str,
-    timeout_seconds: float = 10.0,
-    poll_interval: float = 0.25,
-) -> None:
-    """Poll until the case EM state is ``EM.EXITED``.
-
-    After the Vendor (CASE_OWNER) reports public disclosure, the Case Actor
-    automatically initiates embargo teardown.  This helper waits for the
-    teardown to be reflected in the DataLayer.
-
-    Args:
-        client: DataLayerClient for the target container.
-        case_id: Full URI of the ``VulnerabilityCase``.
-        timeout_seconds: Maximum time to wait.
-        poll_interval: Seconds between DataLayer poll attempts.
-
-    Raises:
-        AssertionError: If EM.EXITED is not observed within *timeout_seconds*.
-    """
-    deadline = time.monotonic() + timeout_seconds
-    while time.monotonic() < deadline:
-        try:
-            case_data = client.get(f"/datalayer/{case_id}")
-            case = VulnerabilityCase.model_validate(case_data)
-            if case.current_status.em_state == EM.EXITED:
-                return
-        except Exception:  # noqa: BLE001
-            pass
-        time.sleep(poll_interval)
-
-    raise AssertionError(
-        f"Timed out waiting for case '{case_id}' EM state to reach EXITED"
-        " — embargo teardown may not have completed"
-    )
-
-
-def _fetch_participant_data(client: DataLayerClient, p_id: str) -> dict | None:
-    """Fetch a participant record, returning None for genuine 404s.
-
-    Re-raises for any non-404 error so failures are not silently swallowed.
-    """
-    try:
-        return client.get(f"/datalayer/{_dl_key(p_id)}")
-    except requests.HTTPError as e:
-        if e.response is not None and e.response.status_code == 404:
-            return None
-        raise
-    except AssertionError as e:
-        # TestClient compatibility: make_testclient_call raises AssertionError
-        # for 4xx responses; treat only genuine 404s as "not found".
-        if "404" in str(e):
-            return None
-        raise
-
-
-def _assert_participant_vfd_pxa(
-    participant: "CaseParticipant",
-    label: str,
-    vendor_actor_id: str,
-) -> None:
-    """Assert that *participant* (for *vendor_actor_id*) has VFD and a
-    public-aware pxa_state.  *label* is used in error messages."""
-    public_aware = {CS_pxa.Pxa, CS_pxa.PxA, CS_pxa.PXa, CS_pxa.PXA}
-    latest = participant.participant_status
-    if latest is None:
-        raise AssertionError(
-            f"M6 {label}: participant {vendor_actor_id!r} has no statuses"
-        )
-    if latest.vfd_state != CS_vfd.VFD:
-        raise AssertionError(
-            f"M6 {label}: vfd_state is not VFD, found {latest.vfd_state!r}"
-        )
-    cs = getattr(latest, "case_status", None)
-    pxa = getattr(cs, "pxa_state", None) if cs is not None else None
-    if pxa not in public_aware:
-        raise AssertionError(
-            f"M6 {label}: pxa_state is not public-aware, found {pxa!r}"
-        )
-
-
-def _all_fetchable_participants_rm_closed(
-    client: DataLayerClient,
-    case: VulnerabilityCase,
-) -> bool:
-    """Return True when every fetchable, non-coordinator participant is
-    RM.CLOSED."""
-    for p_id in case.actor_participant_index.values():
-        p_data = _fetch_participant_data(client, p_id)
-        if p_data is None:
-            continue  # remote container — not fetchable here
-        if not p_data:
-            return False
-        p = CaseParticipant(**p_data)
-        if CVDRole.CASE_MANAGER in (p.case_roles or []):
-            continue
-        latest = p.participant_status
-        if latest is None:
-            return False
-        if latest.rm_state != RM.CLOSED:
-            return False
-    return True
-
-
-def wait_for_all_participants_rm_closed(
-    client: DataLayerClient,
-    case_id: str,
-    timeout_seconds: float = 10.0,
-    poll_interval: float = 0.25,
-) -> None:
-    """Poll until all participants in *case_id* have ``RM.CLOSED`` as
-    their latest status.
-
-    Args:
-        client: DataLayerClient for the target container.
-        case_id: Full URI of the ``VulnerabilityCase``.
-        timeout_seconds: Maximum time to wait.
-        poll_interval: Seconds between DataLayer poll attempts.
-
-    Raises:
-        AssertionError: If any participant is not RM.CLOSED within
-            *timeout_seconds*.
-    """
-    deadline = time.monotonic() + timeout_seconds
-    while time.monotonic() < deadline:
-        try:
-            case_data = client.get(f"/datalayer/{case_id}")
-            case = VulnerabilityCase.model_validate(case_data)
-            if _all_fetchable_participants_rm_closed(client, case):
-                return
-        except Exception:  # noqa: BLE001
-            pass
-        time.sleep(poll_interval)
-
-    raise AssertionError(
-        f"Timed out waiting for all participants in case '{case_id}' "
-        "to reach RM.CLOSED"
-    )
-
-
 # ---------------------------------------------------------------------------
 # Milestone verification helpers
 # ---------------------------------------------------------------------------
@@ -1446,41 +646,6 @@ def verify_m1_state(
         "✓ M1 finder: case replica present, matching participant index "
         "and active embargo"
     )
-
-
-def _check_participant_vfd_state_in(
-    client: DataLayerClient,
-    case_id: str,
-    actor_id: str,
-    expected_states: "set[CS_vfd]",
-    label: str,
-) -> None:
-    """Assert actor's latest participant vfd_state is in *expected_states*.
-
-    Args:
-        client: DataLayerClient for the target container.
-        case_id: Full URI of the ``VulnerabilityCase``.
-        actor_id: Full URI of the actor to check.
-        expected_states: Set of acceptable ``CS_vfd`` values.
-        label: Human-readable label for AssertionError messages.
-    """
-    participant = _fetch_participant(client, case_id, actor_id)
-    if participant is None:
-        raise AssertionError(
-            f"{label}: participant for actor '{actor_id}' not found"
-        )
-    latest = participant.participant_status
-    if latest is None:
-        raise AssertionError(
-            f"{label}: participant for actor '{actor_id}' has no participant"
-            " statuses"
-        )
-    latest_vfd = latest.vfd_state
-    if latest_vfd not in expected_states:
-        raise AssertionError(
-            f"{label}: expected vfd_state in {expected_states!r}, "
-            f"found {latest_vfd!r}"
-        )
 
 
 def verify_m4_state(


### PR DESCRIPTION
## Summary

Closes #489

Extracts scenario-agnostic helper functions from the 2050-line `two_actor_demo.py` into a structured `vultron/demo/helpers/` package, making them available for reuse across future demo scenarios (part of Priority 470 — Two-Actor Demo Redesign).

## New package: `vultron/demo/helpers/`

| Module | Contents |
|---|---|
| `polling.py` | `_poll_until` generic primitive + all `wait_for_*` helpers |
| `actions.py` | `actor_notifies_*` and `actor_closes_case` wrappers |
| `seeding.py` | `_dl_key`, `get_actor_by_id`, `seed_containers` |
| `sync.py` | SYNC-2 helpers: `trigger_log_commit`, `verify_replica_state` |
| `verification.py` | Assertion primitives used by milestone verifiers |
| `__init__.py` | Full public re-export surface from all sub-modules |

## Changes to `two_actor_demo.py`

- Re-imports all moved functions via helpers package (`noqa: F401`) so all existing module-level names remain accessible
- Retains `reset_containers` (patch target for `TestResetContainers`)
- Retains `finder_submits_report`, `vendor_validates_report`, Q&A helpers, `find_case_for_offer`, `verify_vendor_case_state`, `verify_case_actor_unused`, all `verify_m*_state` milestone verifiers, `run_two_actor_demo`, `main`
- Reduced from ~2050 lines to ~1210 lines (~40% reduction)

## Validation

- ✅ `black` + `flake8` — clean
- ✅ `mypy` — 0 errors
- ✅ `pyright` — 0 errors, 0 warnings
- ✅ `pytest -m ""\ — 2592 passed, 12 skipped, 3 xfailed (full suite including integration tests)