### PR TITLE
fix: rename legacy env vars to correct pydantic-settings names in multi-actor compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,61 @@
+# Version control
+.git
+.gitignore
+.gitattributes
+
+# Python artifacts
+__pycache__
+**/__pycache__
+*.py[cod]
+*$py.class
+*.egg-info
+vultron.egg-info
+.eggs
+
+# Virtual environments
+.venv
+**/.venv
+
+# Build and test caches
+.pytest_cache
+**/.pytest_cache
+.mypy_cache
+**/.mypy_cache
+.ruff_cache
+.coverage
+coverage.xml
+htmlcov
+
+# MkDocs build output
+site
+
+# Node.js
+node_modules
+package-lock.json
+
+# IDE / editor metadata
+.idea
+.vscode
+
+# Database files (runtime data, not source)
+*.db
+*.sqlite
+
+# Log files
+*.log
+devlogs
+diosts.log
+
+# Notes and docs not needed in runtime images
+archived_notes
+wip_notes
+
+# macOS metadata
+.DS_Store
+**/.DS_Store
+
+# Dev-environment files
+.env
+.agents
+.github
+.copilot

--- a/docker/README.md
+++ b/docker/README.md
@@ -111,8 +111,8 @@ variable to use a fixed host port, or inspect the assigned port with
 |:----------------------|:--------------------------|:--------------------------------------|
 | `PROJECT_NAME`        | `vultron`                 | Docker resource name prefix           |
 | `COMPOSE_PROJECT_NAME`| `vultron`                 | Docker Compose project name           |
-| `VULTRON_BASE_URL`    | *(set per service)*       | Container's own API base URL          |
-| `VULTRON_DB_URL`      | `sqlite:////app/data/mydb.sqlite` | SQLAlchemy connection URL for the DataLayer |
+| `VULTRON_SERVER__BASE_URL` | *(set per service)*       | Container's own API base URL          |
+| `VULTRON_DATABASE__DB_URL` | `sqlite:////app/data/mydb.sqlite` | SQLAlchemy connection URL for the DataLayer |
 | `VULTRON_ACTOR_ID`    | *(set per service)*       | Deterministic full actor URI          |
 | `VULTRON_SEED_CONFIG` | *(set per service)*       | Seed config JSON for local + peers    |
 
@@ -234,7 +234,7 @@ The containers communicate via a dedicated Docker bridge network
 service name `api-dev` as the hostname, which Docker resolves internally.
 
 For multi-actor setups, each container uses its service name as the hostname
-in `VULTRON_BASE_URL` (e.g., `http://finder:7999/api/v2/`) so that peer
+in `VULTRON_SERVER__BASE_URL` (e.g., `http://finder:7999/api/v2/`) so that peer
 containers can derive inbox URLs that route correctly on the Docker network.
 
 ## Customizing the docker setup

--- a/docker/docker-compose-multi-actor.yml
+++ b/docker/docker-compose-multi-actor.yml
@@ -29,13 +29,20 @@
 #   COMPOSE_PROJECT_NAME  Docker Compose project name   (default: vultron)
 #
 # ─── Per-service environment variables (set below) ────────────────────────
-#   VULTRON_BASE_URL    Full base URL for this container's API server.
+#   VULTRON_SERVER__BASE_URL
+#                       Full base URL for this container's API server.
 #                       Must use the Docker service name as hostname so that
 #                       peer containers can route to it (e.g.,
 #                       http://finder:7999/api/v2/).
-#   VULTRON_DB_URL      SQLAlchemy connection URL for the DataLayer (default: sqlite:////app/data/mydb.sqlite).
+#                       Corresponds to ServerConfig.base_url in vultron/config.py.
+#                       (pydantic-settings nested delimiter: VULTRON_SERVER__BASE_URL)
+#   VULTRON_DATABASE__DB_URL
+#                       SQLAlchemy connection URL for the DataLayer
+#                       (default: sqlite:////app/data/mydb.sqlite).
 #                       Each service mounts a named volume at /app/data so
 #                       the database persists across container restarts.
+#                       Corresponds to DatabaseConfig.db_url in vultron/config.py.
+#                       (pydantic-settings nested delimiter: VULTRON_DATABASE__DB_URL)
 #   VULTRON_ACTOR_ID    Deterministic full URI for the local actor (D5-1-G3).
 #                       Pre-configured so peer containers can register each
 #                       other without discovery.  The ID is stable across
@@ -98,9 +105,9 @@ services:
       - PYTHONPATH=/app
       # Identity: each container gets a unique base URL so peer actors can
       # derive inbox URLs using the Docker service name as hostname.
-      - VULTRON_BASE_URL=http://finder:7999/api/v2/
+      - VULTRON_SERVER__BASE_URL=http://finder:7999/api/v2/
       # DataLayer: persist the SQLite file under the named volume.
-      - VULTRON_DB_URL=sqlite:////app/data/mydb.sqlite
+      - VULTRON_DATABASE__DB_URL=sqlite:////app/data/mydb.sqlite
       # Deterministic actor ID (D5-1-G3): fixed URI used by vultron-demo seed
       # so peer containers can pre-register this actor without discovery.
       - VULTRON_ACTOR_ID=http://finder:7999/api/v2/actors/finder
@@ -108,6 +115,9 @@ services:
       - VULTRON_SEED_CONFIG=/app/docker/seed-configs/seed-finder.yaml
       - LOG_LEVEL=INFO
     volumes:
+      # Bind-mount application source so code changes take effect without
+      # rebuilding the image.  uvicorn --reload picks them up automatically.
+      - "../vultron:/app/vultron"
       - finder-data:/app/data
     ports:
       # Ephemeral host port (auto-assigned by Docker) → container 7999.
@@ -121,12 +131,13 @@ services:
     <<: *actor-service
     environment:
       - PYTHONPATH=/app
-      - VULTRON_BASE_URL=http://vendor:7999/api/v2/
-      - VULTRON_DB_URL=sqlite:////app/data/mydb.sqlite
+      - VULTRON_SERVER__BASE_URL=http://vendor:7999/api/v2/
+      - VULTRON_DATABASE__DB_URL=sqlite:////app/data/mydb.sqlite
       - VULTRON_ACTOR_ID=http://vendor:7999/api/v2/actors/vendor
       - VULTRON_SEED_CONFIG=/app/docker/seed-configs/seed-vendor.yaml
       - LOG_LEVEL=INFO
     volumes:
+      - "../vultron:/app/vultron"
       - vendor-data:/app/data
     ports:
       # Ephemeral host port → container 7999.  Set VENDOR_HOST_PORT to pin.
@@ -137,12 +148,13 @@ services:
     <<: *actor-service
     environment:
       - PYTHONPATH=/app
-      - VULTRON_BASE_URL=http://coordinator:7999/api/v2/
-      - VULTRON_DB_URL=sqlite:////app/data/mydb.sqlite
+      - VULTRON_SERVER__BASE_URL=http://coordinator:7999/api/v2/
+      - VULTRON_DATABASE__DB_URL=sqlite:////app/data/mydb.sqlite
       - VULTRON_ACTOR_ID=http://coordinator:7999/api/v2/actors/coordinator
       - VULTRON_SEED_CONFIG=/app/docker/seed-configs/seed-coordinator.yaml
       - LOG_LEVEL=INFO
     volumes:
+      - "../vultron:/app/vultron"
       - coordinator-data:/app/data
     ports:
       # Ephemeral host port → container 7999.  Set COORDINATOR_HOST_PORT to pin.
@@ -165,12 +177,13 @@ services:
     <<: *actor-service
     environment:
       - PYTHONPATH=/app
-      - VULTRON_BASE_URL=http://case-actor:7999/api/v2/
-      - VULTRON_DB_URL=sqlite:////app/data/mydb.sqlite
+      - VULTRON_SERVER__BASE_URL=http://case-actor:7999/api/v2/
+      - VULTRON_DATABASE__DB_URL=sqlite:////app/data/mydb.sqlite
       - VULTRON_ACTOR_ID=http://case-actor:7999/api/v2/actors/case-actor
       - VULTRON_SEED_CONFIG=/app/docker/seed-configs/seed-case-actor.yaml
       - LOG_LEVEL=INFO
     volumes:
+      - "../vultron:/app/vultron"
       - case-actor-data:/app/data
     ports:
       # Host port → container port 7999 (for debugging from host only).
@@ -185,12 +198,13 @@ services:
     <<: *actor-service
     environment:
       - PYTHONPATH=/app
-      - VULTRON_BASE_URL=http://vendor2:7999/api/v2/
-      - VULTRON_DB_URL=sqlite:////app/data/mydb.sqlite
+      - VULTRON_SERVER__BASE_URL=http://vendor2:7999/api/v2/
+      - VULTRON_DATABASE__DB_URL=sqlite:////app/data/mydb.sqlite
       - VULTRON_ACTOR_ID=http://vendor2:7999/api/v2/actors/vendor2
       - VULTRON_SEED_CONFIG=/app/docker/seed-configs/seed-vendor2.yaml
       - LOG_LEVEL=INFO
     volumes:
+      - "../vultron:/app/vultron"
       - vendor2-data:/app/data
     ports:
       # Ephemeral host port → container 7999.  Set VENDOR2_HOST_PORT to pin.
@@ -244,7 +258,7 @@ networks:
 
 # ─── Named volumes ────────────────────────────────────────────────────────
 # One volume per actor service.  Each volume stores the SQLite database at
-# /app/data/mydb.sqlite (controlled by VULTRON_DB_URL).
+# /app/data/mydb.sqlite (controlled by VULTRON_DATABASE__DB_URL).
 #
 # To reset all actor state between demo runs:
 #   docker compose -f docker-compose-multi-actor.yml down -v

--- a/docker/docker-compose-multi-actor.yml
+++ b/docker/docker-compose-multi-actor.yml
@@ -35,14 +35,16 @@
 #                       peer containers can route to it (e.g.,
 #                       http://finder:7999/api/v2/).
 #                       Corresponds to ServerConfig.base_url in vultron/config.py.
-#                       (pydantic-settings nested delimiter: VULTRON_SERVER__BASE_URL)
+#                       Uses pydantic-settings env_nested_delimiter='__'
+#                       (for example: VULTRON_SERVER__BASE_URL).
 #   VULTRON_DATABASE__DB_URL
 #                       SQLAlchemy connection URL for the DataLayer
 #                       (default: sqlite:////app/data/mydb.sqlite).
 #                       Each service mounts a named volume at /app/data so
 #                       the database persists across container restarts.
 #                       Corresponds to DatabaseConfig.db_url in vultron/config.py.
-#                       (pydantic-settings nested delimiter: VULTRON_DATABASE__DB_URL)
+#                       Uses pydantic-settings env_nested_delimiter='__'
+#                       (for example: VULTRON_DATABASE__DB_URL).
 #   VULTRON_ACTOR_ID    Deterministic full URI for the local actor (D5-1-G3).
 #                       Pre-configured so peer containers can register each
 #                       other without discovery.  The ID is stable across

--- a/integration_tests/demo/run_multi_actor_integration_test.sh
+++ b/integration_tests/demo/run_multi_actor_integration_test.sh
@@ -9,9 +9,14 @@
 # outcome.
 #
 # Usage:
-#   ./integration_tests/demo/run_multi_actor_integration_test.sh [SCENARIO]
+#   ./integration_tests/demo/run_multi_actor_integration_test.sh [--no-build] [SCENARIO]
 #
-#   SCENARIO   One of: two-actor (default), three-actor, multi-vendor
+#   --no-build  Skip the image build step.  Use this when images are already
+#               up to date (e.g., only vultron/ source changed and the actor
+#               services use a bind mount) to save significant startup time.
+#               Run without --no-build at least once, or after changing
+#               pyproject.toml, uv.lock, or docker/Dockerfile.
+#   SCENARIO    One of: two-actor (default), three-actor, multi-vendor
 #
 # Environment variables:
 #   DEMO                  Alternative way to specify the scenario (overridden by
@@ -54,7 +59,27 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 COMPOSE_FILE="${REPO_ROOT}/docker/docker-compose-multi-actor.yml"
 COLORIZER="${SCRIPT_DIR}/colorize_compose_logs.py"
 PROJECT_NAME="${PROJECT_NAME:-vultron-it}"
-DEMO="${1:-${DEMO:-two-actor}}"
+
+# Parse arguments: optional --no-build flag followed by optional scenario name.
+NO_BUILD=false
+SCENARIO_ARG=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --no-build)
+            NO_BUILD=true
+            shift
+            ;;
+        -*)
+            echo "ERROR: unknown flag '$1'. Valid flags: --no-build" >&2
+            exit 1
+            ;;
+        *)
+            SCENARIO_ARG="$1"
+            shift
+            ;;
+    esac
+done
+DEMO="${SCENARIO_ARG:-${DEMO:-two-actor}}"
 
 VALID_SCENARIOS="two-actor three-actor multi-vendor"
 if ! echo "${VALID_SCENARIOS}" | grep -qw "${DEMO}"; then
@@ -74,13 +99,20 @@ cleanup() {
 }
 trap cleanup EXIT
 
-log "Scenario : ${DEMO}"
-log "Project  : ${PROJECT_NAME}"
-log "Compose  : ${COMPOSE_FILE}"
+log "Scenario  : ${DEMO}"
+log "Project   : ${PROJECT_NAME}"
+log "Compose   : ${COMPOSE_FILE}"
+log "No-build  : ${NO_BUILD}"
 
 # Build all images required by the multi-actor stack.
-log "Building images..."
-docker compose -f "${COMPOSE_FILE}" -p "${PROJECT_NAME}" build
+# Skip with --no-build when images are already current (e.g., only
+# vultron/ source changed and the actor services use a bind mount).
+if [ "${NO_BUILD}" = false ]; then
+    log "Building images..."
+    docker compose -f "${COMPOSE_FILE}" -p "${PROJECT_NAME}" build
+else
+    log "Skipping image build (--no-build)."
+fi
 
 # Start the full stack.  demo-runner declares condition: service_healthy for
 # every actor service (DEMO-MA-02-002), so it only launches once all actors

--- a/plan/history/2605/README.md
+++ b/plan/history/2605/README.md
@@ -4,6 +4,7 @@
 
 | Date | Time (UTC) | Type | Source | Title |
 |------|------------|------|--------|-------|
+| 2026-05-18 | 20:49 | implementation | 546 | Fix multi-actor compose env var names (issue #546) |
 | 2026-05-18 | 15:57 | implementation | ISSUE-522 | PCR-07-006: Bootstrap sequence integration tests |
 | 2026-05-18 | 13:39 | implementation | ISSUE-489 | Extract shared demo helpers into vultron/demo/helpers/ |
 | 2026-05-15 | 23:29 | implementation | 534 | fix(#534): eliminate per-app singleton sharing in create_app() |

--- a/plan/history/2605/implementation/546.md
+++ b/plan/history/2605/implementation/546.md
@@ -1,0 +1,8 @@
+---
+source: '546'
+timestamp: '2026-05-18T20:49:27.915702+00:00'
+title: 'Fix multi-actor compose env var names (issue #546)'
+type: implementation
+---
+
+Fixed a config env-var naming mismatch in docker-compose-multi-actor.yml introduced when config was unified (commit 44885146, May 2026). AppConfig uses pydantic-settings with env_prefix='VULTRON_' and env_nested_delimiter='__', so the correct names are VULTRON_SERVER__BASE_URL and VULTRON_DATABASE__DB_URL. The compose file still used legacy names (VULTRON_BASE_URL / VULTRON_DB_URL) which are silently ignored, causing make_id() to fall back to <http://localhost:7999> and all actors to be seeded with localhost-based IDs — breaking cross-container routing. Fixed by renaming the env vars for all 5 actor services and adding a parametrised regression test (test/docker/test_compose_env_vars.py, 20 tests).

--- a/test/adapters/driving/fastapi/routers/test_info.py
+++ b/test/adapters/driving/fastapi/routers/test_info.py
@@ -13,7 +13,7 @@
 
 """Tests for the /info endpoint (D5-1-G1).
 
-Verifies that GET /info returns the configured VULTRON_BASE_URL and the
+Verifies that GET /info returns the configured VULTRON_SERVER__BASE_URL and the
 list of actor IDs registered in the shared DataLayer.
 """
 

--- a/test/docker/test_compose_env_vars.py
+++ b/test/docker/test_compose_env_vars.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Tests that docker-compose-multi-actor.yml uses the correct env var names.
+
+The config unification (TASK-CFG) introduced pydantic-settings with
+``env_prefix="VULTRON_"`` and ``env_nested_delimiter="__"``, meaning the
+correct env var names are:
+
+- ``VULTRON_SERVER__BASE_URL`` for ``ServerConfig.base_url``
+- ``VULTRON_DATABASE__DB_URL`` for ``DatabaseConfig.db_url``
+
+The old names ``VULTRON_BASE_URL`` and ``VULTRON_DB_URL`` are silently
+ignored by the config system. If docker-compose uses them, each container's
+``make_id()`` falls back to the default ``http://localhost:7999``, causing
+every actor to be seeded with a ``localhost`` ID — breaking cross-container
+routing in the multi-actor integration test.
+
+See GitHub issue #546.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+COMPOSE_FILE = (
+    Path(__file__).parent.parent.parent
+    / "docker"
+    / "docker-compose-multi-actor.yml"
+)
+
+ACTOR_SERVICES = ("finder", "vendor", "coordinator", "case-actor", "vendor2")
+
+#: Legacy env var names that must not appear in actor-service environments.
+LEGACY_ENV_VARS = ("VULTRON_BASE_URL", "VULTRON_DB_URL")
+
+#: Correct pydantic-settings names that must be present instead.
+REQUIRED_ENV_VARS = ("VULTRON_SERVER__BASE_URL", "VULTRON_DATABASE__DB_URL")
+
+
+@pytest.fixture(scope="module")
+def compose_config() -> dict[str, Any]:
+    """Load the multi-actor docker-compose YAML once for the module."""
+    with COMPOSE_FILE.open() as fh:
+        result: dict[str, Any] = yaml.safe_load(fh)
+        return result
+
+
+@pytest.fixture(scope="module")
+def actor_service_envs(compose_config: dict) -> dict[str, list[str]]:
+    """Return mapping of service name → list of environment strings."""
+    services = compose_config.get("services", {})
+    result = {}
+    for name in ACTOR_SERVICES:
+        svc = services.get(name, {})
+        result[name] = svc.get("environment", [])
+    return result
+
+
+@pytest.mark.parametrize("service", ACTOR_SERVICES)
+@pytest.mark.parametrize("legacy_var", LEGACY_ENV_VARS)
+def test_actor_service_does_not_use_legacy_env_var(
+    actor_service_envs: dict[str, list[str]],
+    service: str,
+    legacy_var: str,
+) -> None:
+    """Actor services must NOT use legacy env var names.
+
+    ``VULTRON_BASE_URL`` and ``VULTRON_DB_URL`` are silently ignored by the
+    pydantic-settings config; using them causes actors to be seeded with
+    ``localhost`` IDs, breaking cross-container routing (#546).
+    """
+    env_lines = actor_service_envs[service]
+    matching = [
+        line for line in env_lines if line.startswith(f"{legacy_var}=")
+    ]
+    assert not matching, (
+        f"Service '{service}' still uses legacy env var '{legacy_var}'. "
+        f"Replace with the pydantic-settings name "
+        f"('VULTRON_SERVER__BASE_URL' or 'VULTRON_DATABASE__DB_URL')."
+    )
+
+
+@pytest.mark.parametrize("service", ACTOR_SERVICES)
+@pytest.mark.parametrize("required_var", REQUIRED_ENV_VARS)
+def test_actor_service_has_required_env_var(
+    actor_service_envs: dict[str, list[str]],
+    service: str,
+    required_var: str,
+) -> None:
+    """Actor services must declare the correct pydantic-settings env vars.
+
+    ``VULTRON_SERVER__BASE_URL`` and ``VULTRON_DATABASE__DB_URL`` are the
+    names recognised by ``AppConfig`` (see ``vultron/config.py``).
+    """
+    env_lines = actor_service_envs[service]
+    matching = [
+        line for line in env_lines if line.startswith(f"{required_var}=")
+    ]
+    assert matching, (
+        f"Service '{service}' is missing required env var '{required_var}'. "
+        f"Ensure docker-compose-multi-actor.yml sets this for every actor "
+        f"service so the config system picks it up correctly."
+    )

--- a/vultron/adapters/driving/fastapi/routers/actors.py
+++ b/vultron/adapters/driving/fastapi/routers/actors.py
@@ -144,7 +144,7 @@ class ActorCreateRequest(BaseModel):
         alias="id",
         description=(
             "Full URI for the actor.  Omit to let the server derive one "
-            "from ``VULTRON_BASE_URL``."
+            "from ``VULTRON_SERVER__BASE_URL``."
         ),
     )
 

--- a/vultron/adapters/driving/fastapi/routers/info.py
+++ b/vultron/adapters/driving/fastapi/routers/info.py
@@ -2,7 +2,7 @@
 """
 Info endpoint for the Vultron API (D5-1-G1).
 
-Returns the configured ``VULTRON_BASE_URL`` and the list of actor IDs
+Returns the configured ``VULTRON_SERVER__BASE_URL`` and the list of actor IDs
 registered in the shared DataLayer so that demo scripts and operators
 can confirm container identity at startup.
 
@@ -45,7 +45,7 @@ _ACTOR_TABLE_NAMES = [
 def get_info(dl: DataLayer = Depends(get_shared_dl)) -> dict:
     """Returns server identity information (D5-1-G1).
 
-    Response includes the configured ``VULTRON_BASE_URL`` and the list of
+    Response includes the configured ``VULTRON_SERVER__BASE_URL`` and the list of
     actor IDs registered in this container's shared DataLayer.  Useful
     for demo scripts and operators to confirm which container they are
     talking to at startup.

--- a/vultron/demo/helpers/seeding.py
+++ b/vultron/demo/helpers/seeding.py
@@ -92,9 +92,9 @@ def seed_containers(
         finder_client: DataLayerClient connected to the Finder container.
         vendor_client: DataLayerClient connected to the Vendor container.
         reporter_actor_id: Optional deterministic URI for the Finder actor.
-            When absent the server derives one from ``VULTRON_BASE_URL``.
+            When absent the server derives one from ``VULTRON_SERVER__BASE_URL``.
         vendor_actor_id: Optional deterministic URI for the Vendor actor.
-            When absent the server derives one from ``VULTRON_BASE_URL``.
+            When absent the server derives one from ``VULTRON_SERVER__BASE_URL``.
 
     Returns:
         Tuple of ``(finder, vendor)`` ``as_Actor`` objects as created on their

--- a/vultron/demo/seed_config.py
+++ b/vultron/demo/seed_config.py
@@ -28,7 +28,7 @@ Environment variables
     ``"Organization"``).
 ``VULTRON_ACTOR_ID``
     Optional full URI for the local actor.  When absent the server derives
-    one from ``VULTRON_BASE_URL``.
+    one from ``VULTRON_SERVER__BASE_URL``.
 ``VULTRON_SEED_CONFIG``
     Path to a YAML file that overrides the individual env-var values above
     (see ``SeedConfig`` for the expected schema).
@@ -61,7 +61,7 @@ class LocalActorConfig(ActorConfig):
         alias="id",
         description=(
             "Full URI of the local actor. "
-            "Omit to let the server derive one from ``VULTRON_BASE_URL``."
+            "Omit to let the server derive one from ``VULTRON_SERVER__BASE_URL``."
         ),
     )
 

--- a/vultron/demo/utils.py
+++ b/vultron/demo/utils.py
@@ -423,7 +423,7 @@ def seed_actor(
         name: Display name for the actor.
         actor_type: ActivityStreams actor type string (default: ``"Organization"``).
         actor_id: Optional full URI for the actor.  When absent the server
-            derives one from ``VULTRON_BASE_URL``.
+            derives one from ``VULTRON_SERVER__BASE_URL``.
 
     Returns:
         The created (or pre-existing) ``as_Actor`` object.


### PR DESCRIPTION
## Summary

Fixes #546

In the multi-actor integration test, every actor was seeded with an ID of
`http://localhost:7999/actors/<uuid>` instead of the container-specific
hostname (e.g. `http://finder:7999/...`). This broke cross-container inbox
routing.

## Root cause

`AppConfig` uses pydantic-settings with:

```python
env_prefix = "VULTRON_"
env_nested_delimiter = "__"
```

So the correct env var names are:

| Setting | Correct env var |
|---|---|
| `server.base_url` | `VULTRON_SERVER__BASE_URL` |
| `database.db_url` | `VULTRON_DATABASE__DB_URL` |

`docker-compose-multi-actor.yml` was still using the legacy names
(`VULTRON_BASE_URL` / `VULTRON_DB_URL`) which pydantic-settings silently
ignores. As a result, `make_id()` always fell back to
`http://localhost:7999`.

The config unification (commit `44885146`, May 2026) updated test fixtures
and `conftest.py` but missed the docker-compose file.

## Changes

- **`docker/docker-compose-multi-actor.yml`**: rename env vars for all 5
  actor services (`finder`, `vendor`, `coordinator`, `case-actor`,
  `vendor2`)
- **`test/docker/test_compose_env_vars.py`** _(new)_: 20 parametrised
  regression tests asserting legacy names are absent and correct names are
  present
- **Docstrings** updated in `seeding.py`, `utils.py`, `seed_config.py`,
  `actors.py`, `info.py`, `test_info.py`
- **`docker/README.md`**: env var table updated

Also includes pre-existing WIP:
- Bind-mount `vultron/` source into all actor containers
- `--no-build` flag in integration test runner script

## Testing

- 20 new compose env-var tests: ✅ all pass
- Full unit suite (2417 tests): ✅ all pass
- All four linters (black, flake8, mypy, pyright): ✅ clean