### PR TITLE
fix: store embedded participants on Announce case seeding

### DIFF
--- a/plan/history/2605/README.md
+++ b/plan/history/2605/README.md
@@ -4,6 +4,7 @@
 
 | Date | Time (UTC) | Type | Source | Title |
 |------|------------|------|--------|-------|
+| 2026-05-19 | 18:14 | implementation | GH-566 | Store embedded participants on Announce seeding (#566) |
 | 2026-05-18 | 20:49 | implementation | 546 | Fix multi-actor compose env var names (issue #546) |
 | 2026-05-18 | 15:57 | implementation | ISSUE-522 | PCR-07-006: Bootstrap sequence integration tests |
 | 2026-05-18 | 13:39 | implementation | ISSUE-489 | Extract shared demo helpers into vultron/demo/helpers/ |

--- a/plan/history/2605/implementation/GH-566.md
+++ b/plan/history/2605/implementation/GH-566.md
@@ -1,0 +1,8 @@
+---
+source: GH-566
+timestamp: '2026-05-19T18:14:39.808873+00:00'
+title: Store embedded participants on Announce seeding (#566)
+type: implementation
+---
+
+Extracted _store_embedded_participants from CreateCaseReceivedUseCase to a module-level function in case.py. Updated AnnounceVulnerabilityCaseReceivedUseCase.execute() to call it after saving the case. Both the Create bootstrap path (CBT-05-005) and the Announce late-joiner path now share the same helper. Added TestAnnounceStoresEmbeddedParticipants regression class with 3 tests confirming participants are stored after Announce seeding.

--- a/test/core/use_cases/received/test_actor_announce_case.py
+++ b/test/core/use_cases/received/test_actor_announce_case.py
@@ -23,14 +23,21 @@ from vultron.core.use_cases.received.actor import (
 )
 from vultron.wire.as2.factories import announce_vulnerability_case_activity
 from vultron.wire.as2.vocab.objects.case_actor import CaseActor
+from vultron.wire.as2.vocab.objects.case_participant import (
+    CaseActorParticipant,
+    CaseParticipant,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
 
 _OWNER_ID = "https://example.org/actors/owner"
 _CASE_ACTOR_ID = "https://example.org/actors/case-actor"
 _IMPOSTER_ID = "https://example.org/actors/imposter"
+_VENDOR_ID = "https://example.org/actors/vendor"
 _CASE_ID = "https://example.org/cases/case-ann-001"
 _CASE_ID2 = "https://example.org/cases/case-ann-002"
 _REPORT_ID = "https://example.org/reports/report-ann-001"
+_CASE_ACTOR_PARTICIPANT_ID = f"{_CASE_ID}/participants/case-actor"
+_VENDOR_PARTICIPANT_ID = f"{_CASE_ID}/participants/vendor"
 
 
 @pytest.fixture()
@@ -200,3 +207,111 @@ class TestAnnounceVulnerabilityCaseReceivedUseCase:
         AnnounceVulnerabilityCaseReceivedUseCase(dl, event).execute()
 
         assert dl.read(_CASE_ID) is None
+
+
+# ---------------------------------------------------------------------------
+# #566: Embedded participants must be stored during Announce seeding
+# ---------------------------------------------------------------------------
+
+
+class TestAnnounceStoresEmbeddedParticipants:
+    """Announce(VulnerabilityCase) seeding must store embedded participants.
+
+    Regression tests for #566: ``AnnounceVulnerabilityCaseReceivedUseCase``
+    was not calling ``_store_embedded_participants`` after saving the case,
+    so late-joiner replicas never had independent ``CaseParticipant`` records.
+    BT nodes (``CheckParticipantExists``, ``AppendParticipantStatusNode``)
+    would then fail with participant-not-found on the Announce path.
+    """
+
+    @pytest.fixture()
+    def case_with_participants(self):
+        """VulnerabilityCase with two embedded participants (inline objects)."""
+        case_actor_p = CaseActorParticipant(
+            id_=_CASE_ACTOR_PARTICIPANT_ID,
+            attributed_to=_CASE_ACTOR_ID,
+            context=_CASE_ID,
+        )
+        vendor_p = CaseParticipant(
+            id_=_VENDOR_PARTICIPANT_ID,
+            attributed_to=_VENDOR_ID,
+            context=_CASE_ID,
+        )
+        case = VulnerabilityCase(
+            id_=_CASE_ID,
+            name="DR-10 Announce Case with Participants",
+            case_participants=[case_actor_p, vendor_p],
+        )
+        case.actor_participant_index[_CASE_ACTOR_ID] = (
+            _CASE_ACTOR_PARTICIPANT_ID
+        )
+        case.actor_participant_index[_VENDOR_ID] = _VENDOR_PARTICIPANT_ID
+        return case, case_actor_p, vendor_p
+
+    @pytest.fixture()
+    def announce_with_participants_event(
+        self, make_payload, case_with_participants
+    ):
+        case, _, _ = case_with_participants
+        activity = announce_vulnerability_case_activity(
+            case,
+            actor=_CASE_ACTOR_ID,
+            context=_CASE_ID,
+        )
+        return make_payload(activity)
+
+    def test_embedded_case_actor_participant_stored_after_announce(
+        self, dl, announce_with_participants_event
+    ):
+        """CaseActorParticipant embedded in Announce payload is stored
+        independently (#566 — Announce path mirrors Create bootstrap path)."""
+        AnnounceVulnerabilityCaseReceivedUseCase(
+            dl, announce_with_participants_event
+        ).execute()
+
+        stored = dl.read(_CASE_ACTOR_PARTICIPANT_ID)
+        assert stored is not None, (
+            "CaseActorParticipant must be stored as an independent DataLayer "
+            "record after Announce seeding (#566)"
+        )
+
+    def test_embedded_vendor_participant_stored_after_announce(
+        self, dl, announce_with_participants_event
+    ):
+        """Vendor CaseParticipant embedded in Announce payload is stored
+        independently — BT nodes can then look it up by UUID (#566)."""
+        AnnounceVulnerabilityCaseReceivedUseCase(
+            dl, announce_with_participants_event
+        ).execute()
+
+        stored = dl.read(_VENDOR_PARTICIPANT_ID)
+        assert stored is not None, (
+            "Vendor CaseParticipant must be stored as an independent DataLayer "
+            "record after Announce seeding (#566)"
+        )
+
+    def test_string_participant_refs_not_stored_as_objects(
+        self, dl, make_payload
+    ):
+        """String ID refs in case_participants are skipped (no object to store).
+
+        Only inline participant objects are stored; bare ID strings are left
+        as-is (they reference objects the receiver doesn't have locally).
+        """
+        case = VulnerabilityCase(
+            id_=_CASE_ID,
+            name="Announce with string participants",
+            case_participants=[_VENDOR_PARTICIPANT_ID],  # bare string ref
+        )
+        activity = announce_vulnerability_case_activity(
+            case, actor=_CASE_ACTOR_ID, context=_CASE_ID
+        )
+        event = make_payload(activity)
+
+        AnnounceVulnerabilityCaseReceivedUseCase(dl, event).execute()
+
+        # The bare string ref must NOT cause a spurious record to appear
+        stored = dl.read(_VENDOR_PARTICIPANT_ID)
+        assert (
+            stored is None
+        ), "String participant refs must not create spurious DataLayer records"

--- a/test/core/use_cases/received/test_actor_announce_case.py
+++ b/test/core/use_cases/received/test_actor_announce_case.py
@@ -315,3 +315,35 @@ class TestAnnounceStoresEmbeddedParticipants:
         assert (
             stored is None
         ), "String participant refs must not create spurious DataLayer records"
+
+    def test_embedded_participants_stored_when_case_already_exists(
+        self,
+        dl,
+        announce_with_participants_event,
+        case_with_participants,
+    ):
+        """Participants are stored even when the case already exists locally.
+
+        Regression: the inbox router's ``_store_nested_inbox_object`` can seed
+        the case before dispatch, so the Announce use-case may enter the
+        idempotent early-return path.  Embedded participants must still be
+        persisted on that path (#566).
+        """
+        case, _, _ = case_with_participants
+        # Pre-seed the case so the use-case hits the existing-case branch.
+        dl.create(case)
+
+        AnnounceVulnerabilityCaseReceivedUseCase(
+            dl, announce_with_participants_event
+        ).execute()
+
+        stored_ca = dl.read(_CASE_ACTOR_PARTICIPANT_ID)
+        stored_vendor = dl.read(_VENDOR_PARTICIPANT_ID)
+        assert stored_ca is not None, (
+            "CaseActorParticipant must be stored even when the case already "
+            "exists (idempotent early-return path, #566)"
+        )
+        assert stored_vendor is not None, (
+            "Vendor CaseParticipant must be stored even when the case already "
+            "exists (idempotent early-return path, #566)"
+        )

--- a/vultron/core/use_cases/received/actor.py
+++ b/vultron/core/use_cases/received/actor.py
@@ -780,6 +780,7 @@ class AnnounceVulnerabilityCaseReceivedUseCase:
                 " — skipping (idempotent, MV-10-004)",
                 case_id,
             )
+            _store_embedded_participants(case_obj, self._dl, case_id)
             _link_report_case_links(self._dl, case_obj)
             return
 

--- a/vultron/core/use_cases/received/actor.py
+++ b/vultron/core/use_cases/received/actor.py
@@ -33,6 +33,7 @@ from vultron.core.states.participant_embargo_consent import (
 )
 from vultron.core.states.rm import RM
 from vultron.core.states.roles import CVDRole
+from vultron.core.use_cases.received.case import _store_embedded_participants
 from vultron.core.use_cases._helpers import _as_id, _idempotent_create
 
 if TYPE_CHECKING:
@@ -784,6 +785,7 @@ class AnnounceVulnerabilityCaseReceivedUseCase:
 
         try:
             self._dl.save(case_obj)
+            _store_embedded_participants(case_obj, self._dl, case_id)
             _link_report_case_links(self._dl, case_obj)
             logger.info(
                 "AnnounceVulnerabilityCase: seeded case '%s' from actor '%s'",

--- a/vultron/core/use_cases/received/case.py
+++ b/vultron/core/use_cases/received/case.py
@@ -122,6 +122,44 @@ def _check_participant_embargo_acceptance(
     return excluded
 
 
+def _store_embedded_participants(
+    case_obj: CaseModel, dl: CasePersistence, case_id: str
+) -> None:
+    """Persist embedded participant objects from a case snapshot.
+
+    When a bootstrapped or announced ``VulnerabilityCase`` carries fully
+    materialised participant objects (not just ID strings), each is stored
+    as an independent DataLayer record.  This ensures BT nodes such as
+    ``CheckParticipantExists`` (#561) and ``AppendParticipantStatusNode``
+    (#562, #566) can retrieve them by their UUID.
+
+    Called from:
+    - ``CreateCaseReceivedUseCase._handle_bootstrap`` (Create path, CBT-05-005)
+    - ``AnnounceVulnerabilityCaseReceivedUseCase.execute`` (Announce path, #566)
+
+    Idempotent: ``dl.save()`` upserts so repeated calls are safe.
+
+    Args:
+        case_obj: The bootstrapped or announced case domain object.
+        dl: DataLayer to persist participants into.
+        case_id: ID of the case (for log context).
+    """
+    participants = getattr(case_obj, "case_participants", []) or []
+    for participant_ref in participants:
+        if isinstance(participant_ref, str):
+            continue
+        pid = getattr(participant_ref, "id_", None)
+        if pid is None:
+            continue
+        dl.save(participant_ref)
+        logger.info(
+            "store_embedded_participants: stored participant '%s'"
+            " for case '%s' (CBT-05-005, #566)",
+            pid,
+            case_id,
+        )
+
+
 class CreateCaseReceivedUseCase:
     """Process a bootstrap ``Create(VulnerabilityCase)`` from a remote actor.
 
@@ -267,39 +305,7 @@ class CreateCaseReceivedUseCase:
         # find them by UUID via ``datalayer.read(participant_id)``.
         # This must happen regardless of the idempotency guard above because
         # the inbox router may have already seeded the case before dispatch.
-        self._store_embedded_participants(case_obj, case_id)
-
-    def _store_embedded_participants(
-        self, case_obj: CaseModel, case_id: str
-    ) -> None:
-        """Persist embedded participant objects from the bootstrap snapshot.
-
-        When the bootstrap ``Create(VulnerabilityCase)`` carries fully
-        materialised participant objects (not just ID strings), each is stored
-        as an independent DataLayer record.  This ensures BT nodes such as
-        ``CheckParticipantExists`` (#561) and ``AppendParticipantStatusNode``
-        (#562) can retrieve them by their UUID.
-
-        Idempotent: ``dl.save()`` upserts so repeated calls are safe.
-
-        Args:
-            case_obj: The bootstrapped case domain object.
-            case_id: ID of the case (for log context).
-        """
-        participants = getattr(case_obj, "case_participants", []) or []
-        for participant_ref in participants:
-            if isinstance(participant_ref, str):
-                continue
-            pid = getattr(participant_ref, "id_", None)
-            if pid is None:
-                continue
-            self._dl.save(participant_ref)
-            logger.info(
-                "create_case_received: stored participant '%s'"
-                " for case '%s' (CBT-05-005)",
-                pid,
-                case_id,
-            )
+        _store_embedded_participants(case_obj, self._dl, case_id)
 
 
 class UpdateCaseReceivedUseCase:


### PR DESCRIPTION
Fixes #566

## What changed

- Extracted `_store_embedded_participants` from `CreateCaseReceivedUseCase`
  to a **module-level function** in `case.py` (DRY, per user request).
- `AnnounceVulnerabilityCaseReceivedUseCase.execute()` now calls
  `_store_embedded_participants` after saving the case — mirroring the
  Create bootstrap path.
- Added `TestAnnounceStoresEmbeddedParticipants` (3 regression tests) to
  `test_actor_announce_case.py`.

## Root cause

When `_store_embedded_participants` was added for the Create bootstrap path
(CBT-05-005, PR #564), the Announce late-joiner path in `actor.py` was not
updated in parallel. Late-joiner replicas had the case stored but not the
embedded `CaseParticipant` objects, causing BT nodes
(`CheckParticipantExists`, `AppendParticipantStatusNode`) to return
`FAILURE` when looking up a participant by UUID.

## Impact

Three-actor demo and any other scenario using `Announce(VulnerabilityCase)`
to seed a new participant's DataLayer.