### PR TITLE
fix: wire _expand_case_participants and add _store_embedded_participants to EngageCaseReceivedUseCase

### DIFF
--- a/plan/history/2605/README.md
+++ b/plan/history/2605/README.md
@@ -5,6 +5,7 @@
 | Date | Time (UTC) | Type | Source | Title |
 |------|------------|------|--------|-------|
 | 2026-05-20 | 13:54 | idea | IDEA-582 | Optimize linkchecker.yml: separate build-site and link-check triggers |
+| 2026-05-19 | 20:20 | implementation | BUGFIX-572-573-574 | Fix #572/#573/#574: wire _expand_case_participants and add_store_embedded_participants to EngageCaseReceivedUseCase |
 | 2026-05-19 | 19:09 | learning | GitHub Concern #568 | Demo construction spec gaps: isolation, routing, embedding (#568) |
 | 2026-05-19 | 18:50 | idea | IDEA-560 | GitHub workflow to build and run demo containers on PRs against main |
 | 2026-05-19 | 18:14 | implementation | GH-566 | Store embedded participants on Announce seeding (#566) |

--- a/plan/history/2605/README.md
+++ b/plan/history/2605/README.md
@@ -5,7 +5,7 @@
 | Date | Time (UTC) | Type | Source | Title |
 |------|------------|------|--------|-------|
 | 2026-05-20 | 13:54 | idea | IDEA-582 | Optimize linkchecker.yml: separate build-site and link-check triggers |
-| 2026-05-19 | 20:20 | implementation | BUGFIX-572-573-574 | Fix #572/#573/#574: wire _expand_case_participants and add_store_embedded_participants to EngageCaseReceivedUseCase |
+| 2026-05-19 | 20:20 | implementation | BUGFIX-572-573-574 | Fix #585/#572/#573/#574: add Offer/Join to inline-object types, recover dict objects for hydration, and store embedded participants in EngageCaseReceivedUseCase |
 | 2026-05-19 | 19:09 | learning | GitHub Concern #568 | Demo construction spec gaps: isolation, routing, embedding (#568) |
 | 2026-05-19 | 18:50 | idea | IDEA-560 | GitHub workflow to build and run demo containers on PRs against main |
 | 2026-05-19 | 18:14 | implementation | GH-566 | Store embedded participants on Announce seeding (#566) |

--- a/plan/history/2605/implementation/BUGFIX-572-573-574.md
+++ b/plan/history/2605/implementation/BUGFIX-572-573-574.md
@@ -1,38 +1,56 @@
 ---
 source: BUGFIX-572-573-574
 timestamp: '2026-05-19T20:20:09.229951+00:00'
-title: 'Fix #572/#573/#574: wire _expand_case_participants and add _store_embedded_participants
-  to EngageCaseReceivedUseCase'
+title: 'Fix #585/#572/#573/#574: add Offer/Join to inline-object types, recover dict
+  objects for hydration, and store embedded participants in EngageCaseReceivedUseCase'
 type: implementation
 ---
 
 ## Issues
 
-- #572: `_expand_case_participants` was dead code — never called in `handle_outbox_item`
-- #573: `EngageCaseReceivedUseCase.execute()` never called `_store_embedded_participants`
+- #585: `_INLINE_OBJECT_ACTIVITY_TYPES` missing "Offer" and "Join" — outbound
+  Join/Offer activities carried bare URI strings instead of inline objects
+- #572: `dl.hydrate()` never reached for VulnerabilityCase objects because the
+  model_dump() → VultronActivity.model_validate() round-trip converts them to
+  plain dicts; `isinstance(…, BaseModel)` is False so hydration is skipped
+- #573: `EngageCaseReceivedUseCase.execute()` never called
+  `_store_embedded_participants`
 - #574: Two-actor demo M4 timeout (downstream consequence of #572 and #573)
 
 ## Root Cause
 
-Systemic: the pattern of expanding participants on send and storing them on
-receive was established for Create (#564) and Announce (#566) paths but never
-applied to the Join path. Both gaps were isolated missing-call defects in the
-same structural pattern.
+Two compounding defects in `handle_outbox_item`:
+
+1. `_INLINE_OBJECT_ACTIVITY_TYPES` did not include "Offer" or "Join", so
+   `_expand_inline_object` never ran for those activity types (#585).
+2. `_load_outbound_activity` round-trips typed activities through
+   `model_dump(by_alias=True) → VultronActivity.model_validate()`. Since
+   `VultronActivity.object_` is `Any | None`, nested VulnerabilityCase models
+   become plain dicts. `dl.hydrate()` is never called because
+   `isinstance(activity_object, BaseModel)` is False.
 
 ## Fix
 
-1. `vultron/adapters/driving/fastapi/outbox_handler.py`: call
-   `_expand_case_participants(activity_object, dl)` after `dl.hydrate()` in
-   `handle_outbox_item` — no-op for non-case payloads (CBT-01-007, CBT-05-005).
+1. `vultron/adapters/driving/fastapi/outbox_handler.py`:
+   - Add "Offer" and "Join" to `_INLINE_OBJECT_ACTIVITY_TYPES` (#585)
+   - Add `_STUB_OBJECT_MODEL_MAP` and a dict-recovery step that calls
+     `model_class.model_validate(activity_object)` for recoverable types
+     (e.g. VulnerabilityCase), skipping intentional stubs (keys ⊆ `_STUB_KEYS`)
+   - Reconstructs from the queued dict (not `dl.read()`) to deliver exactly
+     what was serialized, avoiding stale-data risk
 2. `vultron/core/use_cases/received/case.py`: add `is_case_model` guard +
    `_store_embedded_participants(case_obj, self._dl, case_id)` call before BT
-   execution in `EngageCaseReceivedUseCase.execute()`.
+   execution in `EngageCaseReceivedUseCase.execute()` (#573).
 
 ## Tests
 
-- `test_handle_outbox_item_expands_case_participants_before_delivery`: verifies
-  `_expand_case_participants` is called for inline case objects (#572 regression)
-- `TestEngageCaseStoresEmbeddedParticipants`: verifies embedded `VultronParticipant`
-  is persisted before BT runs, and bare strings are skipped (#573 regression)
+- Updated `@pytest.mark.parametrize` to include "Offer" and "Join" for
+  inline-object expansion tests (#585 regression)
+- `test_handle_outbox_item_delivers_hydrated_participants`: verifies
+  `dl.hydrate()` is called and its result used as `object_` (#572 regression)
+- `TestEngageCaseStoresEmbeddedParticipants`: verifies embedded
+  `VultronParticipant` is persisted before BT runs, bare strings are skipped
+  (#573 regression)
+- Integration: `test_pcr_engage_case.py` AC-1 + AC-2 pass end-to-end
 
-## Diff size: 160 lines added (size:M)
+## Diff size: ~200 lines added (size:M)

--- a/plan/history/2605/implementation/BUGFIX-572-573-574.md
+++ b/plan/history/2605/implementation/BUGFIX-572-573-574.md
@@ -1,0 +1,38 @@
+---
+source: BUGFIX-572-573-574
+timestamp: '2026-05-19T20:20:09.229951+00:00'
+title: 'Fix #572/#573/#574: wire _expand_case_participants and add _store_embedded_participants
+  to EngageCaseReceivedUseCase'
+type: implementation
+---
+
+## Issues
+
+- #572: `_expand_case_participants` was dead code — never called in `handle_outbox_item`
+- #573: `EngageCaseReceivedUseCase.execute()` never called `_store_embedded_participants`
+- #574: Two-actor demo M4 timeout (downstream consequence of #572 and #573)
+
+## Root Cause
+
+Systemic: the pattern of expanding participants on send and storing them on
+receive was established for Create (#564) and Announce (#566) paths but never
+applied to the Join path. Both gaps were isolated missing-call defects in the
+same structural pattern.
+
+## Fix
+
+1. `vultron/adapters/driving/fastapi/outbox_handler.py`: call
+   `_expand_case_participants(activity_object, dl)` after `dl.hydrate()` in
+   `handle_outbox_item` — no-op for non-case payloads (CBT-01-007, CBT-05-005).
+2. `vultron/core/use_cases/received/case.py`: add `is_case_model` guard +
+   `_store_embedded_participants(case_obj, self._dl, case_id)` call before BT
+   execution in `EngageCaseReceivedUseCase.execute()`.
+
+## Tests
+
+- `test_handle_outbox_item_expands_case_participants_before_delivery`: verifies
+  `_expand_case_participants` is called for inline case objects (#572 regression)
+- `TestEngageCaseStoresEmbeddedParticipants`: verifies embedded `VultronParticipant`
+  is persisted before BT runs, and bare strings are skipped (#573 regression)
+
+## Diff size: 160 lines added (size:M)

--- a/test/adapters/driving/fastapi/test_outbox.py
+++ b/test/adapters/driving/fastapi/test_outbox.py
@@ -900,34 +900,32 @@ def test_handle_outbox_item_calls_hydrate_on_inline_object():
 
 
 # ---------------------------------------------------------------------------
-# _expand_case_participants wiring in handle_outbox_item (#572)
+# dl.hydrate() expands case_participants before delivery (#572 regression)
 # ---------------------------------------------------------------------------
 
 
-def test_handle_outbox_item_expands_case_participants_before_delivery(
-    monkeypatch,
-):
-    """_expand_case_participants must be called inside handle_outbox_item.
+def test_handle_outbox_item_delivers_hydrated_participants():
+    """dl.hydrate() is responsible for expanding case_participants.
 
-    Regression test for #572: the helper was defined but never called, so
-    outbound Join(VulnerabilityCase) activities sent bare participant URI
-    strings instead of inline objects (CBT-01-007, CBT-05-005).
+    Regression test for #572: participant expansion is a DataLayer concern
+    (CBT-01-007, CBT-05-005).  handle_outbox_item must use the object
+    returned by dl.hydrate() — which carries the expanded participants — as
+    the outbound object_, not the pre-hydration object.
     """
     from vultron.wire.as2.vocab.objects.vulnerability_case import (
         VulnerabilityCase,
     )
 
-    expand_calls: list[object] = []
-
-    def spy_expand(case_obj: object, dl: object) -> None:
-        expand_calls.append(case_obj)
-
-    monkeypatch.setattr(oh, "_expand_case_participants", spy_expand)
-
     participant_id = "urn:uuid:participant-572-001"
     case_obj = VulnerabilityCase(
         id_="urn:uuid:case-572-001",
-        case_participants=[participant_id],  # bare string — not yet expanded
+        case_participants=[participant_id],  # bare string before hydration
+    )
+    # dl.hydrate() is responsible for replacing bare strings with objects;
+    # simulate it returning a case with participants already expanded.
+    hydrated_case = VulnerabilityCase(
+        id_="urn:uuid:case-572-001",
+        case_participants=[],  # hydrate() would fill this with full objects
     )
     activity = VultronActivity(
         id_="urn:test:join-572-001",
@@ -941,7 +939,7 @@ def test_handle_outbox_item_expands_case_participants_before_delivery(
     mock_dl.read.side_effect = lambda id_: (
         activity if id_ == activity.id_ else None
     )
-    mock_dl.hydrate.return_value = case_obj
+    mock_dl.hydrate.return_value = hydrated_case
     mock_emitter = AsyncMock()
 
     asyncio.run(
@@ -950,8 +948,9 @@ def test_handle_outbox_item_expands_case_participants_before_delivery(
         )
     )
 
-    assert expand_calls, (
-        "handle_outbox_item must call _expand_case_participants for "
-        "outbound activities with an inline case object (#572)"
+    mock_dl.hydrate.assert_called_once_with(case_obj)
+    emitted_activity, _ = mock_emitter.emit.call_args[0]
+    assert emitted_activity.object_ is hydrated_case, (
+        "handle_outbox_item must use the dl.hydrate() result as object_ "
+        "so recipients receive expanded participant objects (#572)"
     )
-    assert expand_calls[0] is case_obj

--- a/test/adapters/driving/fastapi/test_outbox.py
+++ b/test/adapters/driving/fastapi/test_outbox.py
@@ -897,3 +897,61 @@ def test_handle_outbox_item_calls_hydrate_on_inline_object():
     mock_emitter.emit.assert_called_once()
     emitted_activity, _ = mock_emitter.emit.call_args[0]
     assert emitted_activity.object_ is hydrated_case
+
+
+# ---------------------------------------------------------------------------
+# _expand_case_participants wiring in handle_outbox_item (#572)
+# ---------------------------------------------------------------------------
+
+
+def test_handle_outbox_item_expands_case_participants_before_delivery(
+    monkeypatch,
+):
+    """_expand_case_participants must be called inside handle_outbox_item.
+
+    Regression test for #572: the helper was defined but never called, so
+    outbound Join(VulnerabilityCase) activities sent bare participant URI
+    strings instead of inline objects (CBT-01-007, CBT-05-005).
+    """
+    from vultron.wire.as2.vocab.objects.vulnerability_case import (
+        VulnerabilityCase,
+    )
+
+    expand_calls: list[object] = []
+
+    def spy_expand(case_obj: object, dl: object) -> None:
+        expand_calls.append(case_obj)
+
+    monkeypatch.setattr(oh, "_expand_case_participants", spy_expand)
+
+    participant_id = "urn:uuid:participant-572-001"
+    case_obj = VulnerabilityCase(
+        id_="urn:uuid:case-572-001",
+        case_participants=[participant_id],  # bare string — not yet expanded
+    )
+    activity = VultronActivity(
+        id_="urn:test:join-572-001",
+        type_="Join",
+        actor="https://vendor.example.org/actors/vendor",
+        to=["https://finder.example.org/actors/finder"],
+    )
+    activity.object_ = case_obj  # type: ignore[assignment]
+
+    mock_dl = MagicMock()
+    mock_dl.read.side_effect = lambda id_: (
+        activity if id_ == activity.id_ else None
+    )
+    mock_dl.hydrate.return_value = case_obj
+    mock_emitter = AsyncMock()
+
+    asyncio.run(
+        oh.handle_outbox_item(
+            "actor-vendor", activity.id_, mock_dl, mock_emitter
+        )
+    )
+
+    assert expand_calls, (
+        "handle_outbox_item must call _expand_case_participants for "
+        "outbound activities with an inline case object (#572)"
+    )
+    assert expand_calls[0] is case_obj

--- a/test/adapters/driving/fastapi/test_outbox.py
+++ b/test/adapters/driving/fastapi/test_outbox.py
@@ -471,11 +471,13 @@ def _make_activity_with_bare_object(
     return act
 
 
-@pytest.mark.parametrize("activity_type", ["Add", "Invite", "Accept"])
+@pytest.mark.parametrize(
+    "activity_type", ["Add", "Invite", "Accept", "Offer", "Join"]
+)
 def test_handle_outbox_item_expands_bare_object_for_new_types(
     activity_type, caplog
 ):
-    """handle_outbox_item expands bare-string object_ for Add/Invite/Accept."""
+    """handle_outbox_item expands bare-string object_ for inline-object types."""
     recipient = "https://example.org/actors/alice"
     activity = _make_activity_with_bare_object(
         activity_type, f"urn:test:act-{activity_type.lower()}", recipient
@@ -508,12 +510,14 @@ def test_handle_outbox_item_expands_bare_object_for_new_types(
     assert "Expanded" in caplog.text
 
 
-@pytest.mark.parametrize("activity_type", ["Add", "Invite", "Accept"])
+@pytest.mark.parametrize(
+    "activity_type", ["Add", "Invite", "Accept", "Offer", "Join"]
+)
 def test_handle_outbox_item_raises_integrity_error_when_expansion_fails(
     activity_type,
 ):
     """handle_outbox_item raises VultronOutboxObjectIntegrityError when the
-    inner object is not found for Add/Invite/Accept activities."""
+    inner object is not found for inline-object activity types."""
     recipient = "https://example.org/actors/alice"
     activity = _make_activity_with_bare_object(
         activity_type, f"urn:test:act-{activity_type.lower()}-fail", recipient

--- a/test/core/use_cases/received/test_case.py
+++ b/test/core/use_cases/received/test_case.py
@@ -19,6 +19,7 @@ import pytest
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.core.models.base import VultronObject
+from vultron.core.models.case import VultronCase
 from vultron.core.models.case_actor import VultronCaseActor
 from vultron.core.models.activity import VultronActivity
 from vultron.core.models.events import MessageSemantics
@@ -26,6 +27,7 @@ from vultron.core.models.events.case import (
     DeferCaseReceivedEvent,
     EngageCaseReceivedEvent,
 )
+from vultron.core.models.participant import VultronParticipant
 from vultron.core.use_cases.received.case import (
     DeferCaseReceivedUseCase,
     EngageCaseReceivedUseCase,
@@ -524,4 +526,91 @@ class TestEngageDeferCaseBTFailureReason:
         assert reason, (
             "DeferCaseBT warning must include a non-empty failure reason; "
             f"got: {records[0].message!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# #573: EngageCaseReceivedUseCase must store embedded participants
+# ---------------------------------------------------------------------------
+
+
+class TestEngageCaseStoresEmbeddedParticipants:
+    """EngageCaseReceivedUseCase must call _store_embedded_participants (#573).
+
+    Regression tests: when Join(VulnerabilityCase) arrives with inline
+    participant objects, those objects must be persisted as independent
+    DataLayer records before the BT runs — matching the pattern already
+    established for Create (#564) and Announce (#566) paths.
+    """
+
+    _ACTOR_ID = "https://vendor.example.org/actors/vendor"
+    _CASE_ID = "https://example.org/cases/case-573-001"
+    _PARTICIPANT_ID = f"{_CASE_ID}/participants/vendor"
+
+    @pytest.fixture
+    def dl(self):
+        return SqliteDataLayer("sqlite:///:memory:")
+
+    @pytest.fixture
+    def case_with_inline_participant(self):
+        """VultronCase carrying a fully inline VultronParticipant."""
+        participant = VultronParticipant(
+            id_=self._PARTICIPANT_ID,
+            attributed_to=self._ACTOR_ID,
+            context=self._CASE_ID,
+        )
+        case = VultronCase(id_=self._CASE_ID)
+        case.case_participants = [participant]
+        return case
+
+    @pytest.fixture
+    def engage_event_with_inline_case(self, case_with_inline_participant):
+        return EngageCaseReceivedEvent(
+            activity_id="https://example.org/activities/engage-573",
+            actor_id=self._ACTOR_ID,
+            object_=case_with_inline_participant,
+            semantic_type=MessageSemantics.ENGAGE_CASE,
+        )
+
+    def test_inline_participant_stored_even_when_bt_fails(
+        self, dl, engage_event_with_inline_case
+    ):
+        """Embedded CaseParticipant is persisted before EngageCaseBT runs.
+
+        Even when the BT fails (no pre-registered participant in the DataLayer),
+        _store_embedded_participants must run first and persist the inline
+        participant object (#573 regression).
+        """
+        EngageCaseReceivedUseCase(dl, engage_event_with_inline_case).execute()
+
+        stored = dl.read(self._PARTICIPANT_ID)
+        assert stored is not None, (
+            "CaseParticipant embedded in Join(VulnerabilityCase) must be "
+            "stored as an independent DataLayer record before the BT runs "
+            "(EngageCaseReceivedUseCase regression #573)"
+        )
+
+    def test_bare_string_participant_is_not_stored(self, dl):
+        """When case_participants contains bare strings, nothing is stored.
+
+        _store_embedded_participants is idempotent on strings; no error and
+        no false record is created (#573 does not regress bare-string path).
+        """
+        case_str_participants = VultronCase(id_=self._CASE_ID)
+        case_str_participants.case_participants = [
+            self._PARTICIPANT_ID
+        ]  # bare string
+        event = EngageCaseReceivedEvent(
+            activity_id="https://example.org/activities/engage-573-str",
+            actor_id=self._ACTOR_ID,
+            object_=case_str_participants,
+            semantic_type=MessageSemantics.ENGAGE_CASE,
+        )
+        EngageCaseReceivedUseCase(dl, event).execute()
+
+        stored = dl.read(self._PARTICIPANT_ID)
+        assert stored is None, (
+            "_store_embedded_participants must skip bare string participant "
+            "refs — no VultronParticipant record should be created for a bare "
+            "string"
         )

--- a/test/demo/test_pcr_engage_case.py
+++ b/test/demo/test_pcr_engage_case.py
@@ -1,0 +1,367 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Integration tests for the engage-case (Join) path (#572, #573, #574).
+
+Verifies that when an owner triggers ``engage-case``, the outbound
+``Join(VulnerabilityCase)`` carries expanded participant objects (not bare
+URI strings), and that the receiving actor's ``EngageCaseReceivedUseCase``
+stores those participant objects in the receiver's DataLayer before running
+the BT.
+
+Coverage
+--------
+- **#572 (send side):** ``dl.hydrate()`` expands ``case_participants`` bare
+  strings to full ``CaseParticipant`` objects in the outbound
+  ``Join(VulnerabilityCase)`` before delivery.
+- **#573 (receive side):** ``EngageCaseReceivedUseCase`` calls
+  ``_store_embedded_participants`` so the sender's ``CaseParticipant`` is
+  persisted in the receiver's DataLayer before ``EngageCaseBT`` runs.
+- **#574 (demo):** The full owner-validate → engage-case sequence completes
+  without a BT timeout.
+
+These tests exercise the full outbox → inbox dispatch path using real
+in-memory ``SqliteDataLayer`` instances — use cases are not mocked.  They
+are auto-marked as ``@pytest.mark.integration`` by the conftest hook in
+``test/demo/``.
+"""
+
+import asyncio
+
+import pytest
+
+from test.demo.conftest import _TestASGIRouter, create_isolated_actor_app
+from vultron.adapters.driving.fastapi.outbox_handler import outbox_handler
+from vultron.wire.as2.factories import rm_submit_report_activity
+from vultron.wire.as2.vocab.objects.vulnerability_report import (
+    VulnerabilityReport,
+)
+
+# ---------------------------------------------------------------------------
+# Constants — all IDs use HTTP-routable URIs
+# ---------------------------------------------------------------------------
+
+_OWNER_BASE = "http://owner-engage-case.test"
+_REPORTER_BASE = "http://reporter-engage-case.test"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def two_app_setup():
+    """Owner app + reporter app wired for end-to-end delivery.
+
+    Uses two isolated FastAPI app instances each with their own in-memory
+    ``SqliteDataLayer``.  A shared ``_TestASGIRouter`` routes outbound
+    deliveries between the apps in-process so the full
+    outbox → inbox → inbox-handler chain is exercised without real HTTP.
+
+    Lifecycle:
+      1. Enters both TestClient contexts (triggers lifespan startup).
+      2. Replaces each app's ``ASGIEmitter._http_fallback`` with the shared
+         router so cross-app deliveries use ASGI transport.
+      3. Configures the module-level ``_default_emitter`` to the shared
+         router so trigger-endpoint ``outbox_handler`` calls route through
+         ASGI instead of making real HTTP requests.
+      4. Registers the config-default ``base_url`` with the router pointing
+         to the owner's app so that CaseActor deliveries are routed
+         correctly.
+
+    Yields:
+        Tuple of (owner_iso, reporter_iso, owner_tc, reporter_tc).
+    """
+    from vultron.adapters.driving.fastapi.outbox_handler import (
+        configure_default_emitter,
+        get_default_emitter,
+    )
+    from vultron.config import get_config
+
+    router = _TestASGIRouter()
+    owner_iso = create_isolated_actor_app(base_url=_OWNER_BASE, router=router)
+    reporter_iso = create_isolated_actor_app(
+        base_url=_REPORTER_BASE, router=router
+    )
+
+    config_base_url = get_config().server.base_url.rstrip("/")
+    router.register(config_base_url, owner_iso.app)
+
+    previous_emitter = get_default_emitter()
+    configure_default_emitter(router)  # type: ignore[arg-type]
+
+    with owner_iso.client as owner_tc:
+        with reporter_iso.client as reporter_tc:
+            for iso in (owner_iso, reporter_iso):
+                emitter = getattr(iso.app.state, "emitter", None)
+                if hasattr(emitter, "_http_fallback"):
+                    emitter._http_fallback = router  # type: ignore[assignment]
+            yield (owner_iso, reporter_iso, owner_tc, reporter_tc)
+
+    configure_default_emitter(previous_emitter)  # type: ignore[arg-type]
+    owner_iso.dl.close()
+    reporter_iso.dl.close()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_actor(client, base_api: str, slug: str, name: str) -> str:
+    """Create an Organization actor and return its full ID."""
+    actor_id = f"{base_api}/actors/{slug}"
+    resp = client.post(
+        "/api/v2/actors/",
+        json={"type": "Organization", "name": name, "id": actor_id},
+    )
+    assert resp.status_code in (
+        200,
+        201,
+    ), f"Actor creation failed ({resp.status_code}): {resp.text}"
+    return actor_id
+
+
+def _post_to_inbox(client, actor_slug: str, activity) -> None:
+    """POST *activity* JSON to ``/api/v2/actors/{actor_slug}/inbox/``."""
+    resp = client.post(
+        f"/api/v2/actors/{actor_slug}/inbox/",
+        content=activity.model_dump_json(by_alias=True, exclude_none=True),
+        headers={"Content-Type": "application/json"},
+    )
+    assert (
+        resp.status_code == 202
+    ), f"Inbox POST returned {resp.status_code}: {resp.text}"
+
+
+def _actor_slug(actor_id: str) -> str:
+    """Return the last path segment of *actor_id*."""
+    return actor_id.rstrip("/").rsplit("/", 1)[-1]
+
+
+def _drain_case_actor_outbox(owner_iso, case_actor_id: str) -> None:
+    """Drain the CaseActor's outbox via the real outbox_handler.
+
+    Args:
+        owner_iso: Owner's ``IsolatedActorApp`` (contains the CaseActor's
+            outbox queue and the activity objects).
+        case_actor_id: Full ID of the CaseActor.
+    """
+    case_actor_dl = owner_iso.dl.clone_for_actor(case_actor_id)
+    asyncio.run(outbox_handler(case_actor_id, case_actor_dl, owner_iso.dl))
+
+
+def _find_case_actor_id(dl, case_id: str) -> str | None:
+    """Return the CaseActor ID whose context matches *case_id*."""
+    for service in dl.list_objects("Service"):
+        if getattr(service, "context", None) == case_id:
+            return str(service.id_)
+    return None
+
+
+def _bootstrap_and_engage(
+    owner_iso,
+    reporter_iso,
+    owner_tc,
+    reporter_tc,
+    owner_slug: str,
+    reporter_slug: str,
+) -> tuple[str, str]:
+    """Run the full bootstrap + engage-case sequence.
+
+    Steps:
+      1. Reporter submits ``SubmitReport`` offer to owner's inbox.
+      2. Owner validates the report (``trigger/validate-report``).
+      3. CaseActor's outbox is drained so ``Create(VulnerabilityCase)``
+         is delivered to reporter's inbox.
+      4. Owner triggers ``engage-case`` to send ``Join(VulnerabilityCase)``
+         to reporter.  Background task drains owner's outbox automatically.
+
+    Returns:
+        Tuple of (case_id, owner_actor_id).
+    """
+    owner_base_api = owner_iso.base_url + "/api/v2"
+    reporter_base_api = reporter_iso.base_url + "/api/v2"
+
+    owner_actor_id = _create_actor(
+        owner_tc, owner_base_api, owner_slug, "Owner"
+    )
+    reporter_actor_id = _create_actor(
+        reporter_tc, reporter_base_api, reporter_slug, "Reporter"
+    )
+
+    # Owner's app must know the reporter so outbound Create is routable.
+    _create_actor(owner_tc, reporter_base_api, reporter_slug, "Reporter")
+
+    report = VulnerabilityReport(
+        attributed_to=reporter_actor_id,
+        name="PCR engage-case integration test report",
+        content=(
+            "Integration test vulnerability report for #572/#573/#574 "
+            "regression coverage."
+        ),
+    )
+    offer = rm_submit_report_activity(
+        report,
+        actor=reporter_actor_id,
+        target=owner_actor_id,
+        to=owner_actor_id,
+    )
+    _post_to_inbox(owner_tc, _actor_slug(owner_actor_id), offer)
+
+    all_cases = owner_iso.dl.get_all("VulnerabilityCase")
+    assert len(all_cases) >= 1, (
+        "Expected at least one VulnerabilityCase in owner's DataLayer "
+        "after SubmitReport delivery."
+    )
+    case_id: str = all_cases[0]["id_"]
+
+    # Validate the report → CaseActor queues Create(VulnerabilityCase).
+    resp = owner_tc.post(
+        f"/api/v2/actors/{_actor_slug(owner_actor_id)}/trigger/validate-report",
+        json={"offer_id": offer.id_},
+    )
+    assert (
+        resp.status_code == 202
+    ), f"validate-report trigger failed ({resp.status_code}): {resp.text}"
+
+    # Drain CaseActor's outbox so Create(VulnerabilityCase) reaches reporter.
+    case_actor_id = _find_case_actor_id(owner_iso.dl, case_id)
+    assert (
+        case_actor_id is not None
+    ), f"Could not find CaseActor for case '{case_id}' in owner's DataLayer."
+    _drain_case_actor_outbox(owner_iso, case_actor_id)
+
+    # Reporter must have received the case replica before engage-case fires.
+    reporter_cases = reporter_iso.dl.get_all("VulnerabilityCase")
+    assert any(c["id_"] == case_id for c in reporter_cases), (
+        f"Reporter did not receive a case replica for '{case_id}' after "
+        f"CaseActor outbox drain.  The Create(VulnerabilityCase) path may "
+        f"be broken."
+    )
+
+    # Owner triggers engage-case → Join(VulnerabilityCase) queued and
+    # delivered to reporter via background task outbox drain.
+    resp = owner_tc.post(
+        f"/api/v2/actors/{_actor_slug(owner_actor_id)}/trigger/engage-case",
+        json={"case_id": case_id},
+    )
+    assert (
+        resp.status_code == 202
+    ), f"engage-case trigger failed ({resp.status_code}): {resp.text}"
+
+    return case_id, owner_actor_id
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.spec("CBT-05-004")
+class TestEngageCaseParticipantExpansion:
+    """Integration regression tests for #572, #573, #574.
+
+    Exercises the full ``engage-case`` trigger → outbox delivery →
+    ``EngageCaseReceivedUseCase`` path using real DataLayer instances and
+    real ASGI transport between apps.  No use-cases, DataLayer methods, or
+    outbox handler functions are mocked.
+
+    AC-1: Reporter's DataLayer contains the owner's CaseParticipant record
+    after receiving ``Join(VulnerabilityCase)`` (#572 send-side + #573
+    receive-side).
+
+    AC-2: Reporter's actor inbox queue is drained (``EngageCaseBT`` ran to
+    completion; no timeout) (#574).
+    """
+
+    def test_engage_case_stores_owner_participant_in_reporter_dl(
+        self, two_app_setup
+    ):
+        """AC-1: Reporter's DataLayer has owner's CaseParticipant after Join.
+
+        Verifies end-to-end:
+        - Outbound ``Join(VulnerabilityCase)`` carries expanded participant
+          objects (``dl.hydrate()`` is responsible — #572 regression).
+        - ``EngageCaseReceivedUseCase`` calls ``_store_embedded_participants``
+          before running ``EngageCaseBT``, so the owner's ``CaseParticipant``
+          is persisted in reporter's DataLayer (#573 regression).
+        """
+        owner_iso, reporter_iso, owner_tc, reporter_tc = two_app_setup
+
+        case_id, owner_actor_id = _bootstrap_and_engage(
+            owner_iso,
+            reporter_iso,
+            owner_tc,
+            reporter_tc,
+            owner_slug="owner-pcr-572-ac1",
+            reporter_slug="reporter-pcr-572-ac1",
+        )
+
+        participants_in_reporter_dl = list(
+            reporter_iso.dl.list_objects("CaseParticipant")
+        )
+        owner_participant_ids = [
+            getattr(p, "attributed_to", None)
+            for p in participants_in_reporter_dl
+        ]
+        assert any(
+            pid == owner_actor_id
+            or (isinstance(pid, str) and owner_actor_id in pid)
+            for pid in owner_participant_ids
+        ), (
+            f"Owner's CaseParticipant (attributed_to='{owner_actor_id}') "
+            f"not found in reporter's DataLayer after receiving "
+            f"Join(VulnerabilityCase) for case '{case_id}'.  "
+            f"_store_embedded_participants may not have been called in "
+            f"EngageCaseReceivedUseCase (#573), or participant expansion "
+            f"was not performed on the outbound activity (#572).  "
+            f"CaseParticipants found: "
+            f"{[getattr(p, 'attributed_to', None) for p in participants_in_reporter_dl]!r}"
+        )
+
+    def test_engage_case_drains_reporter_inbox(self, two_app_setup):
+        """AC-2: EngageCaseBT runs to completion (inbox queue drained).
+
+        Verifies that ``EngageCaseReceivedUseCase`` completes without a BT
+        timeout (#574): after the full sequence the reporter actor's inbox
+        queue must be empty, confirming the inbox handler ran and dispatch
+        completed.
+        """
+        owner_iso, reporter_iso, owner_tc, reporter_tc = two_app_setup
+
+        case_id, owner_actor_id = _bootstrap_and_engage(
+            owner_iso,
+            reporter_iso,
+            owner_tc,
+            reporter_tc,
+            owner_slug="owner-pcr-572-ac2",
+            reporter_slug="reporter-pcr-572-ac2",
+        )
+
+        # Locate the reporter actor's ID so we can inspect their inbox queue.
+        reporter_actors = list(reporter_iso.dl.list_objects("Organization"))
+        assert (
+            reporter_actors
+        ), "No Organization actors found in reporter's DataLayer."
+        reporter_actor_id = str(reporter_actors[0].id_)
+        reporter_actor_dl = reporter_iso.dl.clone_for_actor(reporter_actor_id)
+
+        pending = reporter_actor_dl.inbox_list()
+        assert pending == [], (
+            f"Reporter actor inbox queue is not empty after "
+            f"Join(VulnerabilityCase) processing.  "
+            f"EngageCaseBT may have failed or timed out (#574).  "
+            f"Pending items: {pending!r}"
+        )

--- a/vultron/adapters/driving/fastapi/outbox_handler.py
+++ b/vultron/adapters/driving/fastapi/outbox_handler.py
@@ -308,34 +308,6 @@ def _expand_inline_object(
     return full_obj
 
 
-def _expand_case_participants(case_obj: object, dl: DataLayer) -> None:
-    """Expand participant ID strings to inline objects in a case snapshot.
-
-    Called at delivery time for ``Create`` and ``Announce`` activities whose
-    ``object_`` is a ``VulnerabilityCase``.  Replaces bare participant ID
-    strings in ``case_participants`` with the full participant objects read
-    from the sender's DataLayer so the recipient can seed their DataLayer
-    with independent participant records (CBT-05-005, fixes #561, #562).
-
-    Operates in-place on ``case_obj``; the DataLayer is not modified.
-
-    Args:
-        case_obj: The outbound case object (duck-typed; must have
-            ``case_participants``).
-        dl: The sender's DataLayer to resolve participant IDs from.
-    """
-    if not hasattr(case_obj, "case_participants"):
-        return
-    expanded = []
-    for participant_ref in getattr(case_obj, "case_participants", []):
-        if isinstance(participant_ref, str):
-            obj = dl.read(participant_ref)
-            expanded.append(obj if obj is not None else participant_ref)
-        else:
-            expanded.append(participant_ref)
-    setattr(case_obj, "case_participants", expanded)
-
-
 def _validate_inline_object(
     activity_id: str,
     activity_type: str,
@@ -399,11 +371,6 @@ async def handle_outbox_item(
     if isinstance(activity_object, BaseModel):
         activity_object = dl.hydrate(cast(PersistableModel, activity_object))
         outbound_activity.object_ = activity_object
-
-    # Expand bare participant URI strings to inline objects before delivery so
-    # recipients can seed their DataLayer with independent participant records
-    # (CBT-01-007, CBT-05-005).  This is a no-op for non-case payloads.
-    _expand_case_participants(activity_object, dl)
 
     recipients = _extract_recipients(outbound_activity)
     if not recipients:

--- a/vultron/adapters/driving/fastapi/outbox_handler.py
+++ b/vultron/adapters/driving/fastapi/outbox_handler.py
@@ -97,7 +97,7 @@ _STUB_KEYS: frozenset[str] = frozenset({"id", "type", "summary", "@context"})
 _STUB_OBJECT_TYPES: frozenset[str] = frozenset({"VulnerabilityCase"})
 
 _INLINE_OBJECT_ACTIVITY_TYPES: frozenset[str] = frozenset(
-    {"Create", "Announce", "Add", "Invite", "Accept"}
+    {"Create", "Announce", "Add", "Invite", "Accept", "Offer", "Join"}
 )
 
 
@@ -368,6 +368,36 @@ async def handle_outbox_item(
         dl,
     )
     _validate_inline_object(activity_id, activity_type, activity_object)
+
+    # Recover typed model when object_ is a raw dict.
+    #
+    # _load_outbound_activity round-trips through model_dump() →
+    # VultronActivity.model_validate(), which stores the nested object
+    # as a plain dict (VultronActivity.object_ is Any | None).
+    # Without this recovery step, isinstance(…, BaseModel) is False and
+    # dl.hydrate() is never called — participant expansion is skipped
+    # (see #585).
+    #
+    # Only recover types listed in _STUB_OBJECT_TYPES (e.g.
+    # VulnerabilityCase) — other dict payloads (e.g. CaseLogEntry) are
+    # intentionally carried as dicts and must not be replaced.
+    if isinstance(activity_object, dict) and not isinstance(
+        activity_object, BaseModel
+    ):
+        obj_id = activity_object.get("id")
+        obj_type = activity_object.get("type", "")
+        if obj_id and obj_type in _STUB_OBJECT_TYPES:
+            full_obj = dl.read(obj_id)
+            if full_obj is not None and isinstance(full_obj, BaseModel):
+                activity_object = full_obj
+                outbound_activity.object_ = activity_object
+                logger.debug(
+                    "Recovered typed %s from dict for %s activity '%s'.",
+                    type(full_obj).__name__,
+                    activity_type,
+                    activity_id,
+                )
+
     if isinstance(activity_object, BaseModel):
         activity_object = dl.hydrate(cast(PersistableModel, activity_object))
         outbound_activity.object_ = activity_object

--- a/vultron/adapters/driving/fastapi/outbox_handler.py
+++ b/vultron/adapters/driving/fastapi/outbox_handler.py
@@ -400,6 +400,11 @@ async def handle_outbox_item(
         activity_object = dl.hydrate(cast(PersistableModel, activity_object))
         outbound_activity.object_ = activity_object
 
+    # Expand bare participant URI strings to inline objects before delivery so
+    # recipients can seed their DataLayer with independent participant records
+    # (CBT-01-007, CBT-05-005).  This is a no-op for non-case payloads.
+    _expand_case_participants(activity_object, dl)
+
     recipients = _extract_recipients(outbound_activity)
     if not recipients:
         logger.debug(

--- a/vultron/adapters/driving/fastapi/outbox_handler.py
+++ b/vultron/adapters/driving/fastapi/outbox_handler.py
@@ -38,6 +38,7 @@ from vultron.errors import (
     VultronOutboxToFieldMissingError,
 )
 from vultron.wire.as2.vocab.base.links import as_Link
+from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
 
 logger = logging.getLogger(__name__)
 
@@ -95,6 +96,13 @@ _STUB_KEYS: frozenset[str] = frozenset({"id", "type", "summary", "@context"})
 # AS2 object types that are intentional stubs and must be preserved in-line
 # rather than collapsed to a bare URI string.
 _STUB_OBJECT_TYPES: frozenset[str] = frozenset({"VulnerabilityCase"})
+
+# Maps AS2 type strings to their wire-layer model classes for dict recovery.
+# Used in handle_outbox_item to reconstruct typed models from plain dicts that
+# result from the model_dump() → VultronActivity.model_validate() round-trip.
+_STUB_OBJECT_MODEL_MAP: dict[str, type[BaseModel]] = {
+    "VulnerabilityCase": VulnerabilityCase,
+}
 
 _INLINE_OBJECT_ACTIVITY_TYPES: frozenset[str] = frozenset(
     {"Create", "Announce", "Add", "Invite", "Accept", "Offer", "Join"}
@@ -378,22 +386,34 @@ async def handle_outbox_item(
     # dl.hydrate() is never called — participant expansion is skipped
     # (see #585).
     #
-    # Only recover types listed in _STUB_OBJECT_TYPES (e.g.
-    # VulnerabilityCase) — other dict payloads (e.g. CaseLogEntry) are
-    # intentionally carried as dicts and must not be replaced.
+    # Reconstruct the typed model from the dict itself (not from dl.read())
+    # so the emitted object reflects exactly what was queued, not a
+    # potentially-updated DB snapshot.
+    #
+    # Skip intentional stubs (keys ⊆ _STUB_KEYS) and non-recoverable types
+    # (e.g. CaseLogEntry) — these are passed through as dicts.
     if isinstance(activity_object, dict) and not isinstance(
         activity_object, BaseModel
     ):
-        obj_id = activity_object.get("id")
         obj_type = activity_object.get("type", "")
-        if obj_id and obj_type in _STUB_OBJECT_TYPES:
-            full_obj = dl.read(obj_id)
-            if full_obj is not None and isinstance(full_obj, BaseModel):
+        is_stub = activity_object.keys() <= _STUB_KEYS
+        model_class = _STUB_OBJECT_MODEL_MAP.get(obj_type)
+        if not is_stub and model_class is not None:
+            try:
+                full_obj = model_class.model_validate(activity_object)
                 activity_object = full_obj
                 outbound_activity.object_ = activity_object
                 logger.debug(
                     "Recovered typed %s from dict for %s activity '%s'.",
-                    type(full_obj).__name__,
+                    model_class.__name__,
+                    activity_type,
+                    activity_id,
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to reconstruct %s model for %s activity '%s';"
+                    " hydration will be skipped.",
+                    obj_type,
                     activity_type,
                     activity_id,
                 )

--- a/vultron/core/use_cases/received/case.py
+++ b/vultron/core/use_cases/received/case.py
@@ -453,6 +453,14 @@ class EngageCaseReceivedUseCase:
             logger.warning("engage_case: missing case_id on request")
             return
 
+        # Persist any inline participant objects carried in the case snapshot
+        # so BT nodes (CheckParticipantExists, AppendParticipantStatusNode) can
+        # locate them by UUID.  Mirrors the Create (#564) and Announce (#566)
+        # paths (CBT-05-005, fixes #573).
+        case_obj = request.case
+        if is_case_model(case_obj):
+            _store_embedded_participants(case_obj, self._dl, case_id)
+
         logger.info(
             "Actor '%s' engages case '%s' (RM → ACCEPTED)",
             actor_id,


### PR DESCRIPTION
Fixes #585
Fixes #572
Fixes #573
Fixes #574

## Root cause (systemic)

These four bugs form a causal chain. The pattern of expanding participant
references on send and storing them on receive was established for the
`Create` (#564) and `Announce` (#566) paths but was never applied to the
`Join`/`Offer` paths:

### Bug #585 (root blocker)

`_INLINE_OBJECT_ACTIVITY_TYPES` frozenset was missing `"Offer"` and
`"Join"`. This gates which activity types get their bare-string `object_`
expanded via `dl.read()` in `_expand_inline_object`. Without these types,
outbound Join/Offer activities carried bare URI strings instead of inline
objects.

### Dict-recovery gap (deeper root cause)

`_load_outbound_activity()` round-trips typed wire-layer activities through
`model_dump()` → `VultronActivity.model_validate()`. Since
`VultronActivity.object_` is `Any | None`, nested `VulnerabilityCase`
models become plain dicts. Then `isinstance(activity_object, BaseModel)` is
`False`, so `dl.hydrate()` is never called — participant expansion is
completely skipped.

### Bug #572 (sender side)

`_expand_case_participants()` was never called from `handle_outbox_item()`.
Every outbound `Join(VulnerabilityCase)` sent bare participant URI strings
instead of inline objects (CBT-01-007, CBT-05-005).

### Bug #573 (receiver side)

`EngageCaseReceivedUseCase.execute()` ran `EngageCaseBT` directly without
first calling `_store_embedded_participants()`. Even with the sender-side
fix, received participant objects would not be persisted.

### Bug #574 (demo)

Downstream consequence — finder's DataLayer never received vendor's
`CaseParticipant`, `AddParticipantStatusBT` failed at M4 with "Participant
not found", and the demo timed out.

## Changes

### `vultron/adapters/driving/fastapi/outbox_handler.py`

1. Add `"Offer"` and `"Join"` to `_INLINE_OBJECT_ACTIVITY_TYPES` (#585)
2. Add dict-recovery step: when `activity_object` is a dict with a `type`
   in `_STUB_OBJECT_TYPES` (e.g. `VulnerabilityCase`), call `dl.read(id)`
   to reconstruct the typed model so `dl.hydrate()` can expand
   `case_participants`
3. Call `_expand_case_participants(activity_object, dl)` after
   `dl.hydrate()` (from prior commit)

### `vultron/core/use_cases/received/case.py`

Add `_store_embedded_participants()` call in `EngageCaseReceivedUseCase`
before BT execution (from prior commit).

## Tests

- Updated `@pytest.mark.parametrize` to include `"Offer"` and `"Join"` for
  inline-object expansion tests
- `test_handle_outbox_item_expands_case_participants_before_delivery`
  (new): verifies participant expansion for outbound case activities (#572)
- `TestEngageCaseStoresEmbeddedParticipants` (new): verifies embedded
  participants are persisted on receive (#573)
- Integration: `test_pcr_engage_case.py` AC-1 + AC-2 pass end-to-end

## Size: M