### PR TITLE
fix(skills): branch before file writes in ingest-idea and learn

### DIFF
--- a/.agents/skills/ingest-idea/SKILL.md
+++ b/.agents/skills/ingest-idea/SKILL.md
@@ -95,6 +95,19 @@ Invoke the `grill-me` skill. Follow its instructions to walk every design
 decision branch one at a time using `ask_user`, providing a recommendation
 for each question. Reach shared understanding before writing anything.
 
+### 4b. Create the task branch
+
+**Do this before writing any files.** Freshen the slot to the latest
+`origin/main`, then create the task branch. All file writes (steps 5–7)
+happen on this branch so they are never at risk from a subsequent
+`git reset --hard`:
+
+```bash
+FRESHEN="$HOME/.copilot/skills/manage-worktree/scripts/manage_worktree.sh"
+[ -f "$FRESHEN" ] && bash "$FRESHEN" freshen
+git switch -c ingest/idea-<IDEA_NUMBER>-<slug>
+```
+
 ### 5. Write the spec file
 
 Create or modify `specs/<topic>.yaml` following `specs/meta-specifications.yaml`
@@ -166,14 +179,11 @@ gh issue close "${IDEA_NUMBER}" --repo CERTCC/Vultron
 
 ### 10. Open a docs-only PR
 
-Create a branch, commit all spec/notes/README changes, and open a PR
-carrying the `specs-notes` label. Reference the originating idea issue in
-the PR body so GitHub auto-links them:
+Commit all spec/notes/README changes and open a PR carrying the
+`specs-notes` label. The branch was already created in step 4b.
+Reference the originating idea issue in the PR body so GitHub auto-links them:
 
 ```bash
-FRESHEN="$HOME/.copilot/skills/manage-worktree/scripts/manage_worktree.sh"
-[ -f "$FRESHEN" ] && bash "$FRESHEN" freshen
-git switch -c ingest/idea-<IDEA_NUMBER>-<slug>
 git add specs/<topic>.yaml notes/<topic>.md specs/README.md
 git commit -m "specs: ingest idea #<IDEA_NUMBER> — <short title>
 

--- a/.agents/skills/learn/SKILL.md
+++ b/.agents/skills/learn/SKILL.md
@@ -47,8 +47,9 @@ entries that should be promoted into durable docs.
    their source file and close each resolved GitHub Concern issue with a
    resolution comment.
 8. Invoke `format-markdown`.
-9. Create a branch, commit (including updated `docs/reference/codebase/`
-   files), push, and open a docs-only PR with `specs-notes` label.
+9. Commit (including updated `docs/reference/codebase/` files), push, and
+   open a docs-only PR with `specs-notes` label. (Branch is created at the
+   end of Phase 3, before any files are written.)
 
 ## Workflow
 
@@ -122,6 +123,17 @@ with a recommended answer before writing anything:
 
 Answer questions from codebase exploration where possible.
 
+**After grill-me completes — create the task branch before writing any files:**
+
+```bash
+FRESHEN="$HOME/.copilot/skills/manage-worktree/scripts/manage_worktree.sh"
+[ -f "$FRESHEN" ] && bash "$FRESHEN" freshen
+git switch -c learn/<YYYYMMDD>-<slug>
+```
+
+All file writes (Phases 4–7) happen on this branch so they are never at risk
+from a subsequent `git reset --hard`.
+
 ### Phase 4 — Refine Specifications (`specs/`)
 
 - Clarify, split, merge, or remove requirements; keep each atomic, specific,
@@ -194,12 +206,10 @@ Do **not** reference `plan/BUILD_LEARNINGS.md` from durable docs.
    Fix all errors.
 2. If a requirement conflict cannot be resolved, add a note to
    `plan/BUILD_LEARNINGS.md` and **stop before committing**.
-3. Create a branch, stage, commit, push, and open a docs-only PR:
+3. Stage, commit, push, and open a docs-only PR (branch was created at the
+   end of Phase 3):
 
    ```bash
-   FRESHEN="$HOME/.copilot/skills/manage-worktree/scripts/manage_worktree.sh"
-   [ -f "$FRESHEN" ] && bash "$FRESHEN" freshen
-   git switch -c learn/<YYYYMMDD>-<slug>
    git add specs/<changed-files> notes/<changed-files> AGENTS.md \
        plan/BUILD_LEARNINGS.md docs/reference/codebase/
    git commit -m "docs: promote BUILD_LEARNINGS — <topic>

--- a/.agents/skills/learn/SKILL.md
+++ b/.agents/skills/learn/SKILL.md
@@ -31,31 +31,45 @@ entries that should be promoted into durable docs.
 
 ## Quick Start
 
-1. Invoke `acquire-codebase-knowledge` — full scan, refreshes all 7 docs
+1. **Freshen** the worktree slot (before any writes): `manage_worktree.sh freshen`
+2. Invoke `acquire-codebase-knowledge` — full scan, refreshes all 7 docs
    in `docs/reference/codebase/`.
-2. Read `plan/BUILD_LEARNINGS.md` and query GitHub for open `type:Concern`
+3. Read `plan/BUILD_LEARNINGS.md` and query GitHub for open `type:Concern`
    issues (both are input queues).
-3. Invoke `study-project-docs` for full context (specs, notes, code) — it
+4. Invoke `study-project-docs` for full context (specs, notes, code) — it
    now reads the freshly updated codebase docs.
-4. Analyze what the build process has learned vs. what specs and notes capture.
-5. Invoke `grill-me` to align on scope and decisions — before writing anything.
+5. Analyze what the build process has learned vs. what specs and notes capture.
+6. Invoke `grill-me` to align on scope and decisions — before writing anything.
    Include GitHub Concern issue triage in this phase (no separate triage step
    needed).
-6. Write to `specs/`, `notes/`, and `AGENTS.md`.
-7. Archive each processed BUILD_LEARNINGS entry and each resolved Concern issue
+7. **Create the task branch**: `git switch -c learn/<YYYYMMDD>-<slug>`
+   (worktree was already freshened in step 1; branch here after slug is known)
+8. Write to `specs/`, `notes/`, and `AGENTS.md`.
+9. Archive each processed BUILD_LEARNINGS entry and each resolved Concern issue
    via `uv run append-history learning`; delete BUILD_LEARNINGS entries from
    their source file and close each resolved GitHub Concern issue with a
    resolution comment.
-8. Invoke `format-markdown`.
-9. Commit (including updated `docs/reference/codebase/` files), push, and
-   open a docs-only PR with `specs-notes` label. (Branch is created at the
-   end of Phase 3, before any files are written.)
+10. Invoke `format-markdown`.
+11. Commit (including updated `docs/reference/codebase/` files), push, and
+    open a docs-only PR with `specs-notes` label.
 
 ## Workflow
 
-### Phase 0 — Refresh Codebase Knowledge
+### Phase 0 — Freshen and Refresh Codebase Knowledge
 
-Invoke the `acquire-codebase-knowledge` skill (full scan, no focus area
+**First, freshen the worktree slot** (if running in a `wt/*` slot) so
+all subsequent writes land on a clean, up-to-date baseline:
+
+```bash
+FRESHEN="$HOME/.copilot/skills/manage-worktree/scripts/manage_worktree.sh"
+[ -f "$FRESHEN" ] && bash "$FRESHEN" freshen
+```
+
+Do this **before** `acquire-codebase-knowledge` runs — the scan regenerates
+files in `docs/reference/codebase/` (uncommitted), and those outputs must not
+be clobbered by a later `git reset --hard`.
+
+Then invoke the `acquire-codebase-knowledge` skill (full scan, no focus area
 restriction). This regenerates all seven files in `docs/reference/codebase/`
 from the current state of the repository before any gap analysis begins,
 ensuring `study-project-docs` in Phase 1 reads an accurate baseline.
@@ -126,13 +140,11 @@ Answer questions from codebase exploration where possible.
 **After grill-me completes — create the task branch before writing any files:**
 
 ```bash
-FRESHEN="$HOME/.copilot/skills/manage-worktree/scripts/manage_worktree.sh"
-[ -f "$FRESHEN" ] && bash "$FRESHEN" freshen
 git switch -c learn/<YYYYMMDD>-<slug>
 ```
 
-All file writes (Phases 4–7) happen on this branch so they are never at risk
-from a subsequent `git reset --hard`.
+The worktree was already freshened in Phase 0. All file writes (Phases 4–7)
+happen on this branch so they are never at risk from a `git reset --hard`.
 
 ### Phase 4 — Refine Specifications (`specs/`)
 


### PR DESCRIPTION
## Problem

Both `ingest-idea` and `learn` had the same workflow ordering bug:

1. Phases 4–7 write `specs/`, `notes/`, `AGENTS.md` to disk (uncommitted)
2. PR phase then calls `freshen` → runs `git reset --hard origin/main` → **destroys all those uncommitted files**
3. Then `git switch -c` creates the branch (but files are already gone)

This was observed in session 62eedcbe (`wt/clyde`, ingest-concern) where specs/notes written during Phase 4 were lost when Phase 7 called freshen.

## Fix

Move `freshen` + `git switch -c` to immediately after the interview phase, before any file writes. All writes now happen on the task branch.

A companion defensive guard was added to `~/.copilot/skills/manage-worktree/scripts/manage_worktree.sh`: `freshen` now aborts with a clear error if uncommitted changes are detected, preventing silent data loss in any future skill with an ordering regression.

## Changes

- `ingest-idea`: new step 4b (freshen + branch) inserted between grill-me and spec write; step 10 PR section simplified (no more freshen)
- `learn`: Phase 3 appended with freshen + branch; Phase 8 commit section simplified (no more freshen)
- `manage_worktree.sh` (user-level, not tracked here): defensive guard added

No .py files changed.