### PR TITLE
specs: ingest idea #582 — docs build and link check workflow

### DIFF
--- a/notes/docs-build-workflow.md
+++ b/notes/docs-build-workflow.md
@@ -1,0 +1,147 @@
+---
+title: Docs Build and Link Check Workflow
+status: active
+---
+
+# Docs Build and Link Check Workflow
+
+Design decisions and implementation guidance for `DOCBW-01` through
+`DOCBW-05` (`specs/docs-build-workflow.yaml`). Addresses the gap where
+the `linkchecker.yml` workflow ran on any markdown change anywhere in the
+repository, causing unnecessary CI runs on changes to `plan/`, `specs/`,
+and `notes/` that have no effect on the published MkDocs site.
+
+---
+
+## Decision Table
+
+| Question | Decision | Rationale |
+|---|---|---|
+| Split into two workflow files or keep as one? | One workflow file | Two jobs on the same runner share the filesystem, avoiding artifact upload/download overhead and keeping the build step DRY |
+| Should the build step always run? | Yes | Python macro/plugin failures (e.g., `pyproject.toml` or `mkdocs.yml` changes) need to be caught even if no `docs/` content changed |
+| When should the link-check step run? | Only when `docs/**` changed (or `workflow_dispatch`) | Link-checking crawls the entire site and is slow; triggering it on every pyproject.toml bump is wasteful |
+| How to detect if `docs/` changed? | `git diff --name-only` against the PR base | No third-party action needed; keeps the SHA-pinned `uses:` surface minimal (CISEC-01-001) |
+| What paths trigger the workflow at all? | `docs/**`, `mkdocs.yml`, `pyproject.toml`, `uv.lock`, workflow file | These are the only files that can break the site build or introduce broken links |
+| Should `**/*.md` remain as a trigger? | No — remove it | `plan/`, `specs/`, `notes/` changes never affect the built site; the old trigger caused excessive runs |
+| Workflow filename | `docs-build-check.yml` | More descriptive than `linkchecker.yml`; the file covers both build and link-check phases |
+| Workflow display name | `Docs Build and Link Check` | Matches the two-phase job structure |
+
+---
+
+## Workflow Structure
+
+```yaml
+name: Docs Build and Link Check
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/docs-build-check.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  docs-build-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@<SHA> # vX.Y.Z
+        with:
+          fetch-depth: 0  # needed for git diff against base
+
+      - name: Check if docs/ changed
+        id: filter
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "docs_changed=true" >> "$GITHUB_OUTPUT"
+          elif git diff --name-only origin/${{ github.base_ref }}...HEAD \
+               | grep -q '^docs/'; then
+            echo "docs_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docs_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@<SHA> # vX.Y.Z
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip uv
+          uv sync --dev
+
+      - name: Build Site
+        run: |
+          uv run mkdocs build --verbose --clean --config-file mkdocs.yml
+
+      - name: Check links
+        if: steps.filter.outputs.docs_changed == 'true'
+        run: |
+          uv run linkchecker site/index.html
+```
+
+### Why `fetch-depth: 0`
+
+The filter step uses `git diff ... origin/${{ github.base_ref }}...HEAD`.
+This three-dot diff requires the base ref to be present locally. The
+default `fetch-depth: 1` (shallow clone) does not include the base ref,
+causing `git diff` to fail. Setting `fetch-depth: 0` fetches the full
+history.
+
+### `workflow_dispatch` always runs link check
+
+Manual runs are typically invoked to investigate a link problem or verify
+a fix. Always running the link-check step on `workflow_dispatch` avoids
+confusion where a manual run skips the check because no `docs/` file was
+diff'd.
+
+---
+
+## What Changed and Why
+
+### Before (linkchecker.yml)
+
+```yaml
+on:
+  pull_request:
+    paths:
+      - '**/*.md'           # ← too broad: plan/, specs/, notes/ all match
+      - .github/workflows/linkchecker.yml
+      - pyproject.toml
+```
+
+- Ran on any markdown change anywhere — plan/, specs/, notes/ updates all
+  triggered an expensive site build + full link crawl.
+- The link-check step ran unconditionally, wasting ~5–10 minutes on PRs
+  that only touched non-docs markdown.
+
+### After (docs-build-check.yml)
+
+- Trigger narrowed to `docs/**`, `mkdocs.yml`, `pyproject.toml`,
+  `uv.lock`, and the workflow file itself.
+- Build Site step still runs on every trigger (guards against plugin
+  breakage from `pyproject.toml`/`mkdocs.yml` changes).
+- Link-check step only runs when `docs/` content actually changed.
+
+---
+
+## Relationship to Other Workflows
+
+| Workflow | Purpose | Trigger |
+|---|---|---|
+| `python-app.yml` | Python tests + linters | `vultron/**`, `test/**`, Python config |
+| `docs-build-check.yml` | MkDocs build + link check | `docs/**`, `mkdocs.yml`, Python config |
+| `lint_md_all.yml` | Markdown lint | `**/*.md` |
+| `demo-ci.yaml` | Docker integration demo | `vultron/**`, `docker/**`, etc. |
+| `deploy_site.yml` | Deploy to GitHub Pages | Push to `publish` branch |
+
+Note: `lint_md_all.yml` intentionally retains `**/*.md` as its trigger
+because its purpose is to lint all markdown files including `plan/`,
+`specs/`, and `notes/`.

--- a/notes/docs-build-workflow.md
+++ b/notes/docs-build-workflow.md
@@ -17,7 +17,7 @@ and `notes/` that have no effect on the published MkDocs site.
 
 | Question | Decision | Rationale |
 |---|---|---|
-| Split into two workflow files or keep as one? | One workflow file | Two jobs on the same runner share the filesystem, avoiding artifact upload/download overhead and keeping the build step DRY |
+| Split into two workflow files or keep as one? | One workflow file | Multiple steps within the same job share the workspace, avoiding artifact upload/download overhead and keeping the build step DRY |
 | Should the build step always run? | Yes | Python macro/plugin failures (e.g., `pyproject.toml` or `mkdocs.yml` changes) need to be caught even if no `docs/` content changed |
 | When should the link-check step run? | Only when `docs/**` changed (or `workflow_dispatch`) | Link-checking crawls the entire site and is slow; triggering it on every pyproject.toml bump is wasteful |
 | How to detect if `docs/` changed? | `git diff --name-only` against the PR base | No third-party action needed; keeps the SHA-pinned `uses:` surface minimal (CISEC-01-001) |
@@ -139,7 +139,7 @@ on:
 | `python-app.yml` | Python tests + linters | `vultron/**`, `test/**`, Python config |
 | `docs-build-check.yml` | MkDocs build + link check | `docs/**`, `mkdocs.yml`, Python config |
 | `lint_md_all.yml` | Markdown lint | `**/*.md` |
-| `demo-ci.yaml` | Docker integration demo | `vultron/**`, `docker/**`, etc. |
+| `demo-integration.yml` | Docker integration demo | `vultron/**`, `docker/**`, etc. |
 | `deploy_site.yml` | Deploy to GitHub Pages | Push to `publish` branch |
 
 Note: `lint_md_all.yml` intentionally retains `**/*.md` as its trigger

--- a/plan/history/2605/README.md
+++ b/plan/history/2605/README.md
@@ -4,6 +4,8 @@
 
 | Date | Time (UTC) | Type | Source | Title |
 |------|------------|------|--------|-------|
+| 2026-05-20 | 13:54 | idea | IDEA-582 | Optimize linkchecker.yml: separate build-site and link-check triggers |
+| 2026-05-19 | 19:09 | learning | GitHub Concern #568 | Demo construction spec gaps: isolation, routing, embedding (#568) |
 | 2026-05-19 | 18:50 | idea | IDEA-560 | GitHub workflow to build and run demo containers on PRs against main |
 | 2026-05-19 | 18:14 | implementation | GH-566 | Store embedded participants on Announce seeding (#566) |
 | 2026-05-19 | 17:58 | implementation | GH-563 | M4 regression test for AddParticipantStatus after bootstrap (#563) |

--- a/plan/history/2605/idea/IDEA-582.md
+++ b/plan/history/2605/idea/IDEA-582.md
@@ -1,0 +1,23 @@
+---
+source: IDEA-582
+timestamp: '2026-05-20T13:54:12.117904+00:00'
+title: 'Optimize linkchecker.yml: separate build-site and link-check triggers'
+type: idea
+---
+
+## #582 Optimize linkchecker.yml: separate build-site and link-check triggers
+
+The `.github/workflows/linkchecker.yml` workflow is set to run on any change
+to markdown files anywhere, when it was originally intended to ensure that the
+mkdocs site (almost entirely contained within `docs/`) (a) Builds successfully
+and (b) doesn't have any broken links. The link checker step itself is slow
+because it requires crawling the site. We shouldn't try to speed it up, but
+we are running it on too many changes (e.g., to `plan/` `specs/` `notes/`
+etc.) and should narrow the trigger conditions and separate the build-site step
+(always run that to make sure python changes don't break ability to use
+embedded python in mkdocs site) versus the link-checker (only needed when
+something in `docs/` changes).
+
+**Processed**: 2026-05-20 — design decisions captured in
+`specs/docs-build-workflow.yaml` (DOCBW-01 through DOCBW-05) and
+`notes/docs-build-workflow.md`.

--- a/specs/README.md
+++ b/specs/README.md
@@ -88,6 +88,7 @@ Load additional files only when the task touches the relevant area. See the
 | Observability | `observability.yaml` |
 | Security / CI | `ci-security.yaml`, `encryption.yaml` |
 | Demo CI / GitHub Actions demo workflow | `demo-ci.yaml` |
+| Docs build and link-check CI workflow | `docs-build-workflow.yaml`, `notes/docs-build-workflow.md` |
 | Agentic API | `agentic-readiness.yaml` |
 | Documentation work | `diataxis-requirements.yaml`, `project-documentation.yaml`, `traceability.yaml` |
 | Build/bugfix workflow / learnings queue | `build-workflow.yaml` |
@@ -293,6 +294,9 @@ Specifications are organized by topic with minimal overlap. Cross-references lin
 
 - **`ci-security.yaml`** - GitHub Actions security: SHA pinning, secrets
   management, artifact integrity (CISEC-01 through CISEC-04)
+- **`docs-build-workflow.yaml`** - Docs Build and Link Check workflow:
+  trigger conditions, job structure, docs-changed filter, link-check
+  conditionality, and security compliance (DOCBW-01 through DOCBW-05)
 - **`encryption.yaml`** - ActivityPub encryption and key management (`PROD_ONLY`)
 
 ### Code Standards
@@ -419,6 +423,7 @@ is reserved for `testability.yaml`).
 | `BTND` | `behavior-tree-node-design.yaml` |
 | `BW` | `build-workflow.yaml` |
 | `CISEC` | `ci-security.yaml` |
+| `DOCBW` | `docs-build-workflow.yaml` |
 | `CLP` | `case-log-processing.yaml` |
 | `CM` | `case-management.yaml` |
 | `CS` | `code-style.yaml` |

--- a/specs/docs-build-workflow.yaml
+++ b/specs/docs-build-workflow.yaml
@@ -5,7 +5,8 @@ description: >
   builds cleanly and that all links in the published documentation are valid.
   The workflow lives at `.github/workflows/docs-build-check.yml`.
   It is distinct from `python-app.yml` (Python unit tests and linting) and
-  `demo-ci.yaml` (demo container integration tests).
+  `.github/workflows/demo-integration.yml` (demo container integration tests,
+  specified in `specs/demo-ci.yaml`).
 version: 1.0.0
 kind: general
 scope:

--- a/specs/docs-build-workflow.yaml
+++ b/specs/docs-build-workflow.yaml
@@ -1,0 +1,124 @@
+id: DOCBW
+title: Docs Build and Link Check Workflow
+description: >
+  Requirements for the GitHub Actions workflow that verifies the MkDocs site
+  builds cleanly and that all links in the published documentation are valid.
+  The workflow lives at `.github/workflows/docs-build-check.yml`.
+  It is distinct from `python-app.yml` (Python unit tests and linting) and
+  `demo-ci.yaml` (demo container integration tests).
+version: 1.0.0
+kind: general
+scope:
+  - prototype
+  - production
+groups:
+  - id: DOCBW-01
+    title: Workflow File Name and Display Name
+    specs:
+      - id: DOCBW-01-001
+        priority: MUST
+        statement: >
+          The workflow file MUST be named
+          `.github/workflows/docs-build-check.yml`.
+      - id: DOCBW-01-002
+        priority: MUST
+        statement: >
+          The workflow `name:` field MUST be `Docs Build and Link Check`.
+
+  - id: DOCBW-02
+    title: Trigger Conditions
+    specs:
+      - id: DOCBW-02-001
+        priority: MUST
+        statement: >
+          The workflow MUST trigger on `pull_request` events whose changed
+          paths include at least one of: `docs/**`, `mkdocs.yml`,
+          `pyproject.toml`, `uv.lock`, or the workflow file itself
+          (`.github/workflows/docs-build-check.yml`).
+        rationale: >
+          These are the files that can break the site build or introduce
+          broken links. Changes limited to `plan/`, `specs/`, `notes/`, or
+          other non-site markdown do not affect the built site and MUST NOT
+          trigger the workflow.
+      - id: DOCBW-02-002
+        priority: MUST
+        statement: >
+          The workflow MUST trigger on `workflow_dispatch` events to allow
+          manual runs at any time.
+      - id: DOCBW-02-003
+        priority: MUST_NOT
+        statement: >
+          The `pull_request` trigger MUST NOT use `**/*.md` as a path
+          pattern, as this would cause the workflow to run on changes to
+          `plan/`, `specs/`, `notes/`, and other non-site markdown files
+          that have no effect on the published documentation.
+
+  - id: DOCBW-03
+    title: Job Structure
+    specs:
+      - id: DOCBW-03-001
+        priority: MUST
+        statement: >
+          The workflow MUST contain a single job that runs both the
+          build-site and link-check phases sequentially, sharing the same
+          runner filesystem to avoid artifact upload/download overhead.
+      - id: DOCBW-03-002
+        priority: MUST
+        statement: >
+          The Build Site step MUST run on every workflow trigger regardless
+          of which paths changed, so that Python-macro and plugin failures
+          introduced by `pyproject.toml` or `mkdocs.yml` changes are always
+          caught.
+      - id: DOCBW-03-003
+        priority: MUST
+        statement: >
+          The Check Links step MUST carry a step-level `if:` condition that
+          skips it unless the `docs_changed` filter output is `'true'`.
+        rationale: >
+          Link-checking requires crawling the entire built site and is
+          significantly slower than the build step alone. Running it on
+          every trigger (e.g., `pyproject.toml` bumps) wastes CI time
+          without providing additional safety.
+
+  - id: DOCBW-04
+    title: Docs-Changed Filter Step
+    specs:
+      - id: DOCBW-04-001
+        priority: MUST
+        statement: >
+          A filter step MUST appear before the Build Site step. It MUST
+          set a step output `docs_changed` to `true` or `false` using
+          `echo "docs_changed=<value>" >> "$GITHUB_OUTPUT"`.
+      - id: DOCBW-04-002
+        priority: MUST
+        statement: >
+          On `workflow_dispatch` events the filter step MUST set
+          `docs_changed=true` unconditionally, ensuring that manual runs
+          always execute the full link-check.
+      - id: DOCBW-04-003
+        priority: MUST
+        statement: >
+          On `pull_request` events the filter step MUST use
+          `git diff --name-only origin/${{ github.base_ref }}...HEAD`
+          (or equivalent) to list changed files and set
+          `docs_changed=true` if any path starts with `docs/`, otherwise
+          `docs_changed=false`.
+        rationale: >
+          Using `git diff` against the PR base avoids introducing a
+          third-party path-filter action and keeps the SHA-pinning surface
+          minimal (CISEC-01-001).
+
+  - id: DOCBW-05
+    title: Security Compliance
+    specs:
+      - id: DOCBW-05-001
+        priority: MUST
+        statement: >
+          All `uses:` references in `docs-build-check.yml` MUST be pinned
+          to a specific commit SHA with an inline human-readable version
+          comment, per CISEC-01-001 and CISEC-01-002.
+      - id: DOCBW-05-002
+        priority: MUST
+        statement: >
+          The workflow MUST declare `permissions: contents: read` at the
+          workflow level and no additional permissions, per CISEC-02-002.


### PR DESCRIPTION
Docs-only PR: adds spec and notes for idea #582.

Ref #582

## What's here

- `specs/docs-build-workflow.yaml` — DOCBW-01 through DOCBW-05: trigger
  conditions, job structure, docs-changed filter, link-check conditionality,
  security compliance
- `notes/docs-build-workflow.md` — decision table, annotated workflow
  structure, before/after comparison, relationship to other workflows

## Key decisions

- **Single workflow file** renamed to `docs-build-check.yml`
- **Triggers narrowed** from `**/*.md` to `docs/**`, `mkdocs.yml`,
  `pyproject.toml`, `uv.lock`, and the workflow file itself
- **Build Site always runs** (guards Python macro/plugin breakage)
- **Link check conditional** via step-level `if:` using `git diff` to detect
  if `docs/` changed; always runs on `workflow_dispatch`

No .py files changed.