### PR TITLE
skill: add ingest-concern — process a single Concern issue into impl plan

### DIFF
--- a/.agents/skills/archive-history/SKILL.md
+++ b/.agents/skills/archive-history/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: archive-history
+description: >
+  Archive a single completed work item to plan/history/ using the append-history
+  tool, then lint, stage, commit, and push the resulting files. Always call this
+  skill AFTER a PR has been created (so the PR URL can be included in the entry
+  body). Caller constructs the entry body and passes it as a heredoc. Handles
+  one entry at a time; callers that need to archive multiple items (e.g., learn)
+  invoke this skill once per item in a loop. Use whenever any other skill calls
+  `uv run append-history`.
+---
+
+# Skill: Archive History
+
+Archive one completed work item to `plan/history/`, lint the new files, and
+commit + push them to the current branch.
+
+**Always invoke this skill AFTER the PR is opened** — so the PR URL can be
+embedded in the entry body. Since history entries are immutable once committed,
+completeness matters.
+
+---
+
+## Interface
+
+The caller provides four pieces of information:
+
+| Parameter | Description | Example |
+|---|---|---|
+| `TYPE` | Entry type passed to `append-history` | `idea`, `implementation`, `learning`, `priority` |
+| `TITLE` | Short human-readable summary | `AGENTS.md routing policy` |
+| `SOURCE` | Originating identifier | `CONCERN-507`, `IDEA-42`, `ISSUE-576` |
+| Body | Full entry text piped via heredoc | See caller templates below |
+
+---
+
+## Procedure
+
+### Step 1 — Pipe entry body to `append-history`
+
+```bash
+cat <<'ENDOFENTRY' | uv run append-history <TYPE> \
+    --title "<TITLE>" \
+    --source "<SOURCE>"
+
+<Full entry body — include PR URL, impl issue links, and outcome summary>
+
+ENDOFENTRY
+```text
+
+The tool writes `plan/history/YYMM/<type>/<source>.md` and regenerates
+`plan/history/YYMM/README.md`.
+
+### Step 2 — Lint the new history files
+
+```bash
+npx markdownlint-cli2 "plan/history/$(date +%y%m)/**/*.md"
+```text
+
+Fix any lint errors in the generated files before continuing.
+
+### Step 3 — Stage history files
+
+```bash
+git add plan/history/
+```text
+
+### Step 4 — Commit
+
+```bash
+git commit -m "history: archive <TYPE> <SOURCE> — <TITLE>
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```text
+
+### Step 5 — Push
+
+```bash
+git push
+```text
+
+---
+
+## Caller templates
+
+Each caller skill should replace its inline `uv run append-history` +
+`git add plan/history/` + `git commit` sequence with an invocation of
+this skill. The caller is responsible for constructing the entry body;
+this skill owns the tool invocation, lint, stage, commit, and push.
+
+### ingest-idea
+
+```text
+TYPE    = idea
+TITLE   = <short idea title>
+SOURCE  = IDEA-<IDEA_NUMBER>
+BODY    = Full original idea text + "**Processed**: YYYY-MM-DD — ..." line
+          + "Docs PR: <PR_URL>."
+```text
+
+### ingest-concern
+
+```text
+TYPE    = learning
+TITLE   = <short concern title>
+SOURCE  = CONCERN-<CONCERN_NUMBER>
+BODY    = Full original concern body + "**Resolved**: YYYY-MM-DD — ..."
+          + "Docs PR: <PR_URL>. Implementation tracked in #<IMPL_ISSUE>."
+```text
+
+### learn
+
+```text
+TYPE    = learning
+TITLE   = <short observation title>
+SOURCE  = <label from the BUILD_LEARNINGS header, e.g. TRIGGER-ACTIVITY-PORT>
+BODY    = Full original BUILD_LEARNINGS entry text
+          + "**Promoted**: YYYY-MM-DD — captured in <destination files>."
+          + "Docs PR: <PR_URL>."
+```text
+
+Call once per archived entry in a loop.
+
+### build
+
+```text
+TYPE    = implementation
+TITLE   = <short task title>
+SOURCE  = ISSUE-<N>   (or full GitHub URL)
+BODY    = "## Issue #<N> — <title>\n\n<completion summary, PR link>"
+```text
+
+### update-priorities
+
+```text
+TYPE    = priority
+TITLE   = <priority group title>
+SOURCE  = PRIORITY-<number>
+BODY    = <priority summary and completion notes>
+```text
+
+---
+
+## Constraints
+
+- **Always call after PR creation** — the entry body should include the PR URL.
+- **One entry per invocation** — for multiple entries, call this skill in a loop.
+- **Do not call `git push` separately** — this skill always pushes as its final
+  step.
+- **Do not amend** — if the commit already exists, open a new commit via a fresh
+  invocation rather than amending.
+- History files are **immutable** once pushed — do not edit them after this
+  skill completes.

--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -177,8 +177,9 @@ Invoke the `code-review` agent against the current branch diff relative to
    (e.g., `### 2026-04-28 LABEL — Short description`). Do **not** write
    completion summaries here.
 
-6. Invoke the `commit` skill if any local files (BUILD_LEARNINGS.md) were
-   updated. The implementation changes themselves are on the PR branch.
+6. Invoke the `commit` skill to stage and commit any locally modified files
+   (BUILD_LEARNINGS.md and the new `plan/history/` entry). The implementation
+   changes themselves are on the PR branch.
 
 ### Phase 8 - Merge conflict recovery (if needed)
 

--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -54,11 +54,12 @@ docs/adr/, notes/, and AGENTS.md files, and scans vultron/ and test/.
        }
      }
    }'
-   ```
+   ```text
 
    An issue is unblocked only if all entries in `blockedBy.nodes` have
    `state: CLOSED`.
 4. Fetch the Issue body and comments using `github-mcp-server-issue_read`
+
    (`method: get` then `method: get_comments`). Use the combined content as
    implementation context throughout Phases 3–5.
 5. **Claim the Issue**:
@@ -67,9 +68,10 @@ docs/adr/, notes/, and AGENTS.md files, and scans vultron/ and test/.
      ```bash
      FRESHEN="$HOME/.copilot/skills/manage-worktree/scripts/manage_worktree.sh"
      [ -f "$FRESHEN" ] && bash "$FRESHEN" freshen
-     ```
+     ```text
 
    - Create a branch: `git switch -c task/<issue-number>-<slug>`
+
    - If the branch already exists, abort — the task is already claimed.
    - Assign the Issue to the triggering user:
      `gh issue edit <N> --add-assignee @me --repo CERTCC/Vultron`
@@ -148,9 +150,10 @@ Invoke the `code-review` agent against the current branch diff relative to
 
    <summary of changes>" \
      --label "size:<X>"
-   ```
+   ```text
 
 3. If there were `[ADVISORY]` findings from the code review, post them as a
+
    PR comment:
 
    ```bash
@@ -158,28 +161,25 @@ Invoke the `code-review` agent against the current branch diff relative to
      --body "Code review advisory findings: ..."
    ```
 
-4. Append a completion summary to `plan/history/` using the `append-history`
-   tool:
+4. Invoke the `archive-history` skill now that the PR URL is known:
 
-   ```bash
-   cat <<'EOF' | uv run append-history implementation \
-       --title "<short task title>" \
-       --source "https://github.com/CERTCC/Vultron/issues/<N>"
-
-   ## Issue #<N> — <title>
-
-   <completion summary: what was done, outcome, PR link>
-   EOF
+   ```text
+   TYPE    = implementation
+   TITLE   = <short task title>
+   SOURCE  = ISSUE-<N>
+   BODY    = "## Issue #<N> — <title>\n\n<completion summary, PR link>"
    ```
+
+   The skill runs `uv run append-history implementation`, lints the new
+   history files, stages `plan/history/`, commits, and pushes.
 
 5. Record **observations, open questions, and constraints** discovered during
    implementation in `plan/BUILD_LEARNINGS.md`. Use a dated header per entry
    (e.g., `### 2026-04-28 LABEL — Short description`). Do **not** write
    completion summaries here.
 
-6. Invoke the `commit` skill to stage and commit any locally modified files
-   (BUILD_LEARNINGS.md and the new `plan/history/` entry). The implementation
-   changes themselves are on the PR branch.
+6. Invoke the `commit` skill if any local files (BUILD_LEARNINGS.md) were
+   updated. The implementation changes themselves are on the PR branch.
 
 ### Phase 8 - Merge conflict recovery (if needed)
 
@@ -190,9 +190,10 @@ If the PR reports merge conflicts:
    ```bash
    git fetch origin main
    git rebase origin/main
-   ```
+   ```text
 
 2. If the rebase succeeds: `git push --force-with-lease`. CI re-runs.
+
 3. If the rebase fails: post a comment on the PR explaining the conflict, add
    the `needs-rebase` label, and stop. Human intervention is required.
 
@@ -222,4 +223,4 @@ When creating prerequisite Issues or updating `group:` labels on any issue:
     --repo CERTCC/Vultron \
     --description "<Priority group title (no number)>" \
     --color "#1d76db"
-  ```
+  ```text

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -55,3 +55,6 @@ Commit message conventions:
 - Never amend an existing commit unless the user explicitly asks.
 - Run all validation (`format-code`, `run-linters`, `run-tests`,
   `format-markdown`) and complete all finalization before calling this skill.
+- **Always include `plan/history/` when `append-history` was called** — the
+  tool creates new entry files and regenerates `plan/history/YYMM/README.md`;
+  both must be staged.

--- a/.agents/skills/ingest-concern/SKILL.md
+++ b/.agents/skills/ingest-concern/SKILL.md
@@ -156,7 +156,7 @@ Only if Phase 4 produced file changes:
 FRESHEN="$HOME/.copilot/skills/manage-worktree/scripts/manage_worktree.sh"
 [ -f "$FRESHEN" ] && bash "$FRESHEN" freshen
 git switch -c ingest/concern-${CONCERN_NUMBER}-<slug>
-git add specs/ notes/ AGENTS.md
+git add specs/ notes/ AGENTS.md plan/history/
 git commit -m "docs: ingest concern #${CONCERN_NUMBER} — <short title>
 
 - <bullet: what spec/notes/AGENTS.md was added or changed>
@@ -210,6 +210,17 @@ $([ -n "${NOTES_FILE}" ] && echo "Notes: \`notes/${NOTES_FILE}\`.")"
 gh issue close "${CONCERN_NUMBER}" --repo CERTCC/Vultron
 ```
 
+Then stage and push the history entry to the PR branch (or to `main` directly
+if no docs-only PR was opened):
+
+```bash
+git add plan/history/
+git commit -m "history: archive concern #${CONCERN_NUMBER} via append-history
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push
+```
+
 ---
 
 ## Checklist
@@ -226,7 +237,7 @@ gh issue close "${CONCERN_NUMBER}" --repo CERTCC/Vultron
 - [ ] Docs-only PR opened with `specs-notes` label — or skipped (no doc
   changes)
 - [ ] Concern archived via `uv run append-history learning
-  --source "CONCERN-<N>"`
+  --source "CONCERN-<N>"`; history files staged and pushed to branch
 - [ ] Concern issue commented with impl issue(s) + optional PR URL, then
   closed
 

--- a/.agents/skills/ingest-concern/SKILL.md
+++ b/.agents/skills/ingest-concern/SKILL.md
@@ -1,0 +1,264 @@
+---
+name: ingest-concern
+description: >
+  Process a single open GitHub Concern-type issue into a concrete action plan:
+  runs a grill-me interview to understand root cause, options, and fix scope,
+  then creates one or more GitHub implementation issues and optionally updates
+  specs/ or notes/ when the concern reveals missing documentation. Archives the
+  concern via `uv run append-history learning`, comments resolution links on
+  the concern issue, and closes it. Opens a docs-only PR (specs-notes label)
+  only when specs/notes/AGENTS.md files are changed. Use when the user says
+  "ingest concern", references an open Concern-type GitHub issue number, or
+  wants to convert a tracked concern into an implementation plan with tickets.
+---
+
+# Skill: Ingest Concern
+
+Convert a single open GitHub `type:Concern` issue into a concrete action plan.
+Interview → explore → create impl issues → optionally update docs → archive +
+close the concern.
+
+## Constants
+
+```text
+REPO           = CERTCC/Vultron
+REPO_NODE_ID   = R_kgDOIn77fA
+CONCERN_TYPE   = IT_kwDOAjf0s84B_2VT
+```
+
+---
+
+## Workflow
+
+### Phase 0 — Select the Concern
+
+If the user provided a GitHub issue number (e.g., `#42` or just `42`),
+skip to Phase 1.
+
+Otherwise, query open Concern-type issues and present them as a
+multiple-choice list via `ask_user`:
+
+```bash
+gh issue list \
+  --repo CERTCC/Vultron \
+  --state open \
+  --limit 200 \
+  --json number,title,issueType \
+  --jq '.[] | select(.issueType.name == "Concern") | "#\(.number): \(.title)"'
+```
+
+Build a `choices` array from the results and wait for the user's selection.
+
+### Phase 1 — Read the Concern
+
+Fetch the full issue:
+
+```bash
+gh issue view "${CONCERN_NUMBER}" \
+  --repo CERTCC/Vultron \
+  --json number,title,body,labels
+```
+
+Use the title and body as source material for all subsequent steps.
+
+### Phase 2 — Study Context
+
+Invoke the `study-project-docs` skill. It loads all specs, reads `plan/`,
+`docs/adr/`, `notes/`, `AGENTS.md`, and `docs/reference/codebase/`.
+
+Explore the codebase files referenced in the concern's **Evidence** section.
+Answer questions from exploration rather than asking the user where possible.
+
+### Phase 3 — Grill-Me Exploration
+
+Invoke the `grill-me` skill. Resolve every decision branch one at a time via
+`ask_user`, providing a recommendation for each. Cover:
+
+1. **Root cause** — What is actually broken, risky, or missing? Is the concern
+   accurately scoped?
+2. **Impact** — If left unaddressed, what fails or degrades?
+3. **Options** — What are 2–3 ways to address this concern?
+4. **Recommended approach** — Which option do we go with, and why?
+5. **Acceptance criteria** — How do we verify the concern is fully resolved?
+   (Drive one GitHub issue per distinct AC cluster.)
+6. **Spec / notes gaps** — Does this concern reveal a missing requirement in
+   `specs/` or a missing design decision in `notes/`? If so, which file and
+   what should be added or changed?
+7. **AGENTS.md gap** — Is there a recurring implementation pitfall that agents
+   need to know about? If so, what's the canonical pitfall text?
+
+Do **not** write anything until grill-me is complete.
+
+### Phase 4 — Update Specs / Notes (optional)
+
+Only proceed if Phase 3 established a concrete spec or notes gap.
+
+- **`specs/<topic>.yaml`** — Add or amend requirements that the concern
+  reveals are missing. Follow `specs/meta-specifications.yaml` conventions
+  (ID scheme `PREFIX-NN-NNN`, RFC 2119 keywords, YAML structure).
+  Update `specs/README.md` if a new file is added.
+- **`notes/<topic>.md`** — Add a design decision or pitfall entry derived
+  from the concern. Every `notes/*.md` must have valid YAML frontmatter
+  (`title`, `status`). Update `notes/README.md` if a new file is added.
+- **`AGENTS.md`** — Append a new pitfall entry in the
+  **Common Pitfalls (Lessons Learned)** section if Phase 3 identified a
+  recurring agent guidance gap.
+
+Skip this phase entirely if grill-me did not surface a documentation gap.
+
+### Phase 5 — Create Implementation Issues
+
+Create one GitHub issue per distinct cluster of acceptance criteria identified
+in Phase 3. Use the `manage-github-issue` skill for each issue so structured
+relationships are wired correctly.
+
+Wire the concern issue as the **parent** of each implementation issue. If the
+implementation issues have a natural sequence, wire the later ones as
+`--blocked-by` the earlier ones.
+
+```bash
+IMPL_ISSUE_NUMBER=$(
+  .agents/skills/manage-github-issue/manage_github_issue.sh \
+    --title "<Implementation title from grill-me>" \
+    --body "## Summary
+
+<One paragraph describing what needs to be done, derived from grill-me.>
+
+## Acceptance Criteria
+
+- [ ] AC-1: <from grill-me>
+- [ ] AC-2: <from grill-me>
+
+## Reference
+
+Concern: #${CONCERN_NUMBER}
+$([ -n "${SPEC_FILE}" ] && echo "Spec: \`specs/${SPEC_FILE}\`")
+$([ -n "${NOTES_FILE}" ] && echo "Notes: \`notes/${NOTES_FILE}\`")" \
+    --label "group:unscheduled,size:<S|M|L>" \
+    --parent "${CONCERN_NUMBER}"
+    # Add --blocked-by N for sequenced issues
+)
+echo "Created impl issue #${IMPL_ISSUE_NUMBER}"
+```
+
+Set `size:` based on AC count: 1–2 → `size:S`; 3–6 → `size:M`; 7+ → `size:L`.
+
+### Phase 6 — Lint Markdown (if docs changed)
+
+If Phase 4 modified any files, invoke the `format-markdown` skill on all
+new/modified markdown files. Fix all errors before proceeding.
+
+### Phase 7 — Open a Docs-Only PR (if docs changed)
+
+Only if Phase 4 produced file changes:
+
+```bash
+FRESHEN="$HOME/.copilot/skills/manage-worktree/scripts/manage_worktree.sh"
+[ -f "$FRESHEN" ] && bash "$FRESHEN" freshen
+git switch -c ingest/concern-${CONCERN_NUMBER}-<slug>
+git add specs/ notes/ AGENTS.md
+git commit -m "docs: ingest concern #${CONCERN_NUMBER} — <short title>
+
+- <bullet: what spec/notes/AGENTS.md was added or changed>
+- Concern originated in #${CONCERN_NUMBER}
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push -u origin ingest/concern-${CONCERN_NUMBER}-<slug>
+
+gh pr create --repo CERTCC/Vultron \
+  --title "docs: ingest concern #${CONCERN_NUMBER} — <short title>" \
+  --body "Docs-only PR: addresses concern #${CONCERN_NUMBER} at the spec/notes
+level. Implementation tracked in #${IMPL_ISSUE_NUMBER}.
+
+Ref #${CONCERN_NUMBER}
+
+No .py files changed." \
+  --label "specs-notes"
+```
+
+### Phase 8 — Archive and Close the Concern
+
+Archive the concern via `uv run append-history learning`:
+
+```bash
+cat <<'EOF' | uv run append-history learning \
+    --title "<short concern title>" \
+    --source "CONCERN-${CONCERN_NUMBER}"
+
+## #${CONCERN_NUMBER} <concern title>
+
+<full original concern body here>
+
+**Resolved**: YYYY-MM-DD — implementation tracked in #${IMPL_ISSUE_NUMBER}.
+$([ -n "${PR_URL}" ] && echo "Docs PR: ${PR_URL}.")
+EOF
+```
+
+Then post a resolution comment and close the concern:
+
+```bash
+gh issue comment "${CONCERN_NUMBER}" --repo CERTCC/Vultron \
+  --body "✅ Ingested.
+
+$([ -n "${PR_URL}" ] && echo "- Docs PR: ${PR_URL}")
+$(for n in ${IMPL_ISSUE_NUMBERS}; do echo "- Implementation issue: #${n}"; done)
+
+Root cause and fix plan captured via grill-me session.
+$([ -n "${SPEC_FILE}" ] && echo "Spec: \`specs/${SPEC_FILE}\`.")
+$([ -n "${NOTES_FILE}" ] && echo "Notes: \`notes/${NOTES_FILE}\`.")"
+
+gh issue close "${CONCERN_NUMBER}" --repo CERTCC/Vultron
+```
+
+---
+
+## Checklist
+
+- [ ] Concern issue identified (user-specified or selected from list)
+- [ ] Concern body fetched from GitHub
+- [ ] `study-project-docs` invoked; evidence files explored
+- [ ] All grill-me branches resolved (root cause, options, ACs, doc gaps)
+- [ ] `specs/` and/or `notes/` updated — or consciously skipped
+- [ ] `AGENTS.md` updated — or consciously skipped
+- [ ] Markdown lint clean (if docs changed)
+- [ ] One or more implementation issues created via `manage-github-issue`
+  with `group:unscheduled` + `size:` labels; concern wired as parent
+- [ ] Docs-only PR opened with `specs-notes` label — or skipped (no doc
+  changes)
+- [ ] Concern archived via `uv run append-history learning
+  --source "CONCERN-<N>"`
+- [ ] Concern issue commented with impl issue(s) + optional PR URL, then
+  closed
+
+---
+
+## Conventions
+
+- **Branch name**: `ingest/concern-<N>-<slug>` (only created if docs changed)
+- **History source ID**: `CONCERN-<github_issue_number>`
+  (e.g., `CONCERN-42`)
+- **`append-history` command**: `uv run append-history learning`
+  (same category as `learn` — resolved concerns are learning outcomes)
+- **Spec file names**: lowercase hyphenated `.yaml` in `specs/`
+- **Notes file names**: same base name as spec, `.md` in `notes/`
+- **Label rules** (PAD-02-007): `group:unscheduled` by default; if a
+  specific `group:` label is needed, derive slug from priority title in
+  kebab-case — no priority numbers in label names. Create the label if
+  missing:
+
+  ```bash
+  gh label create "group:<slug>" \
+    --repo CERTCC/Vultron \
+    --description "<Priority group title>" \
+    --color "#1d76db"
+  ```
+
+## Relationship to Other Skills
+
+| Skill | Input | Docs output | Closes issue? |
+|---|---|---|---|
+| `ingest-concern` | One Concern issue | Optional specs/notes/AGENTS | Yes |
+| `learn` | BUILD_LEARNINGS + all Concern issues | specs/notes/AGENTS | Yes (batch) |
+| `new-concern` | Freeform text | None | N/A (creates, not resolves) |
+| `process-concerns` | CONCERNS.md file | None | No |
+| `ingest-idea` | One Idea issue | Required specs + notes | Yes |

--- a/.agents/skills/ingest-concern/SKILL.md
+++ b/.agents/skills/ingest-concern/SKILL.md
@@ -24,7 +24,7 @@ close the concern.
 REPO           = CERTCC/Vultron
 REPO_NODE_ID   = R_kgDOIn77fA
 CONCERN_TYPE   = IT_kwDOAjf0s84B_2VT
-```
+```text
 
 ---
 
@@ -45,7 +45,7 @@ gh issue list \
   --limit 200 \
   --json number,title,issueType \
   --jq '.[] | select(.issueType.name == "Concern") | "#\(.number): \(.title)"'
-```
+```text
 
 Build a `choices` array from the results and wait for the user's selection.
 
@@ -57,7 +57,7 @@ Fetch the full issue:
 gh issue view "${CONCERN_NUMBER}" \
   --repo CERTCC/Vultron \
   --json number,title,body,labels
-```
+```text
 
 Use the title and body as source material for all subsequent steps.
 
@@ -139,7 +139,7 @@ $([ -n "${NOTES_FILE}" ] && echo "Notes: \`notes/${NOTES_FILE}\`")" \
     # Add --blocked-by N for sequenced issues
 )
 echo "Created impl issue #${IMPL_ISSUE_NUMBER}"
-```
+```text
 
 Set `size:` based on AC count: 1–2 → `size:S`; 3–6 → `size:M`; 7+ → `size:L`.
 
@@ -156,7 +156,7 @@ Only if Phase 4 produced file changes:
 FRESHEN="$HOME/.copilot/skills/manage-worktree/scripts/manage_worktree.sh"
 [ -f "$FRESHEN" ] && bash "$FRESHEN" freshen
 git switch -c ingest/concern-${CONCERN_NUMBER}-<slug>
-git add specs/ notes/ AGENTS.md plan/history/
+git add specs/ notes/ AGENTS.md
 git commit -m "docs: ingest concern #${CONCERN_NUMBER} — <short title>
 
 - <bullet: what spec/notes/AGENTS.md was added or changed>
@@ -174,25 +174,24 @@ Ref #${CONCERN_NUMBER}
 
 No .py files changed." \
   --label "specs-notes"
-```
+```text
 
 ### Phase 8 — Archive and Close the Concern
 
-Archive the concern via `uv run append-history learning`:
+Invoke the `archive-history` skill now that the PR URL is known:
 
-```bash
-cat <<'EOF' | uv run append-history learning \
-    --title "<short concern title>" \
-    --source "CONCERN-${CONCERN_NUMBER}"
+```text
+TYPE    = learning
+TITLE   = <short concern title>
+SOURCE  = CONCERN-<CONCERN_NUMBER>
+BODY    = Full original concern body
+          + "**Resolved**: YYYY-MM-DD — implementation tracked in
+            #<IMPL_ISSUE_NUMBER>."
+          + "Docs PR: <PR_URL>." (if docs-only PR was opened)
+```text
 
-## #${CONCERN_NUMBER} <concern title>
-
-<full original concern body here>
-
-**Resolved**: YYYY-MM-DD — implementation tracked in #${IMPL_ISSUE_NUMBER}.
-$([ -n "${PR_URL}" ] && echo "Docs PR: ${PR_URL}.")
-EOF
-```
+The `archive-history` skill handles `uv run append-history`, mdlint,
+`git add plan/history/`, commit, and push.
 
 Then post a resolution comment and close the concern:
 
@@ -208,18 +207,7 @@ $([ -n "${SPEC_FILE}" ] && echo "Spec: \`specs/${SPEC_FILE}\`.")
 $([ -n "${NOTES_FILE}" ] && echo "Notes: \`notes/${NOTES_FILE}\`.")"
 
 gh issue close "${CONCERN_NUMBER}" --repo CERTCC/Vultron
-```
-
-Then stage and push the history entry to the PR branch (or to `main` directly
-if no docs-only PR was opened):
-
-```bash
-git add plan/history/
-git commit -m "history: archive concern #${CONCERN_NUMBER} via append-history
-
-Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
-git push
-```
+```text
 
 ---
 
@@ -236,8 +224,8 @@ git push
   with `group:unscheduled` + `size:` labels; concern wired as parent
 - [ ] Docs-only PR opened with `specs-notes` label — or skipped (no doc
   changes)
-- [ ] Concern archived via `uv run append-history learning
-  --source "CONCERN-<N>"`; history files staged and pushed to branch
+- [ ] Concern archived via `archive-history` skill (after PR creation, so
+  entry body includes PR URL); history files staged and pushed to branch
 - [ ] Concern issue commented with impl issue(s) + optional PR URL, then
   closed
 
@@ -248,7 +236,8 @@ git push
 - **Branch name**: `ingest/concern-<N>-<slug>` (only created if docs changed)
 - **History source ID**: `CONCERN-<github_issue_number>`
   (e.g., `CONCERN-42`)
-- **`append-history` command**: `uv run append-history learning`
+- **`append-history` command**: use the `archive-history` skill — do not
+  call `uv run append-history` directly
   (same category as `learn` — resolved concerns are learning outcomes)
 - **Spec file names**: lowercase hyphenated `.yaml` in `specs/`
 - **Notes file names**: same base name as spec, `.md` in `notes/`

--- a/.agents/skills/ingest-concern/SKILL.md
+++ b/.agents/skills/ingest-concern/SKILL.md
@@ -5,7 +5,7 @@ description: >
   runs a grill-me interview to understand root cause, options, and fix scope,
   then creates one or more GitHub implementation issues and optionally updates
   specs/ or notes/ when the concern reveals missing documentation. Archives the
-  concern via `uv run append-history learning`, comments resolution links on
+  concern via the `archive-history` skill, comments resolution links on
   the concern issue, and closes it. Opens a docs-only PR (specs-notes label)
   only when specs/notes/AGENTS.md files are changed. Use when the user says
   "ingest concern", references an open Concern-type GitHub issue number, or
@@ -24,7 +24,7 @@ close the concern.
 REPO           = CERTCC/Vultron
 REPO_NODE_ID   = R_kgDOIn77fA
 CONCERN_TYPE   = IT_kwDOAjf0s84B_2VT
-```text
+```
 
 ---
 
@@ -45,21 +45,34 @@ gh issue list \
   --limit 200 \
   --json number,title,issueType \
   --jq '.[] | select(.issueType.name == "Concern") | "#\(.number): \(.title)"'
-```text
+```
 
 Build a `choices` array from the results and wait for the user's selection.
 
-### Phase 1 — Read the Concern
+### Phase 1 — Read and Validate the Concern
 
-Fetch the full issue:
+Fetch the full issue and validate it is an open Concern before proceeding:
 
 ```bash
-gh issue view "${CONCERN_NUMBER}" \
+ISSUE_JSON=$(gh issue view "${CONCERN_NUMBER}" \
   --repo CERTCC/Vultron \
-  --json number,title,body,labels
-```text
+  --json number,title,body,labels,state,issueType)
 
-Use the title and body as source material for all subsequent steps.
+ISSUE_STATE=$(echo "${ISSUE_JSON}" | jq -r '.state')
+ISSUE_TYPE=$(echo "${ISSUE_JSON}"  | jq -r '.issueType.name // ""')
+
+if [ "${ISSUE_STATE}" != "OPEN" ] || [ "${ISSUE_TYPE}" != "Concern" ]; then
+  echo "Error: #${CONCERN_NUMBER} is not an open Concern issue \
+(state=${ISSUE_STATE}, type=${ISSUE_TYPE}). Stopping."
+  exit 1
+fi
+```
+
+Stop here (do not proceed to Phase 2) if validation fails. Report the actual
+state and type to the user so they can correct the issue number.
+
+Use the title and body from `${ISSUE_JSON}` as source material for all
+subsequent steps.
 
 ### Phase 2 — Study Context
 
@@ -89,6 +102,22 @@ Invoke the `grill-me` skill. Resolve every decision branch one at a time via
 
 Do **not** write anything until grill-me is complete.
 
+### Phase 3b — Create Task Branch (if docs changes are expected)
+
+If Phase 3 established a concrete spec, notes, or `AGENTS.md` gap (i.e.,
+Phase 4 will produce file writes), create the task branch **now** — before
+writing any files — so uncommitted changes are never at risk of being
+clobbered by `freshen`:
+
+```bash
+FRESHEN="$HOME/.copilot/skills/manage-worktree/scripts/manage_worktree.sh"
+[ -f "$FRESHEN" ] && bash "$FRESHEN" freshen
+git switch -c ingest/concern-${CONCERN_NUMBER}-<slug>
+```
+
+If Phase 3 found no doc gaps (Phase 4 will be skipped entirely), skip
+this step. The branch is only needed when there are files to commit.
+
 ### Phase 4 — Update Specs / Notes (optional)
 
 Only proceed if Phase 3 established a concrete spec or notes gap.
@@ -106,6 +135,14 @@ Only proceed if Phase 3 established a concrete spec or notes gap.
 
 Skip this phase entirely if grill-me did not surface a documentation gap.
 
+After completing any file writes, record the created filenames for use in
+later phases:
+
+```bash
+SPEC_FILE="<topic>.yaml"    # e.g., "actor-discovery.yaml"; leave empty if no spec created
+NOTES_FILE="<topic>.md"     # e.g., "actor-discovery.md"; leave empty if no notes created
+```
+
 ### Phase 5 — Create Implementation Issues
 
 Create one GitHub issue per distinct cluster of acceptance criteria identified
@@ -116,8 +153,12 @@ Wire the concern issue as the **parent** of each implementation issue. If the
 implementation issues have a natural sequence, wire the later ones as
 `--blocked-by` the earlier ones.
 
+Accumulate all created issue numbers in a list:
+
 ```bash
-IMPL_ISSUE_NUMBER=$(
+IMPL_ISSUE_NUMBERS=()   # will hold one or more issue numbers
+
+NEW_ISSUE=$(
   .agents/skills/manage-github-issue/manage_github_issue.sh \
     --title "<Implementation title from grill-me>" \
     --body "## Summary
@@ -138,8 +179,10 @@ $([ -n "${NOTES_FILE}" ] && echo "Notes: \`notes/${NOTES_FILE}\`")" \
     --parent "${CONCERN_NUMBER}"
     # Add --blocked-by N for sequenced issues
 )
-echo "Created impl issue #${IMPL_ISSUE_NUMBER}"
-```text
+IMPL_ISSUE_NUMBERS+=("${NEW_ISSUE}")
+echo "Created impl issue #${NEW_ISSUE}"
+# Repeat for each additional issue
+```
 
 Set `size:` based on AC count: 1–2 → `size:S`; 3–6 → `size:M`; 7+ → `size:L`.
 
@@ -153,9 +196,6 @@ new/modified markdown files. Fix all errors before proceeding.
 Only if Phase 4 produced file changes:
 
 ```bash
-FRESHEN="$HOME/.copilot/skills/manage-worktree/scripts/manage_worktree.sh"
-[ -f "$FRESHEN" ] && bash "$FRESHEN" freshen
-git switch -c ingest/concern-${CONCERN_NUMBER}-<slug>
 git add specs/ notes/ AGENTS.md
 git commit -m "docs: ingest concern #${CONCERN_NUMBER} — <short title>
 
@@ -165,16 +205,19 @@ git commit -m "docs: ingest concern #${CONCERN_NUMBER} — <short title>
 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
 git push -u origin ingest/concern-${CONCERN_NUMBER}-<slug>
 
+IMPL_REFS=$(printf 'Implementation tracked in #%s\n' "${IMPL_ISSUE_NUMBERS[@]}" \
+  | paste -sd ', ')
+
 gh pr create --repo CERTCC/Vultron \
   --title "docs: ingest concern #${CONCERN_NUMBER} — <short title>" \
   --body "Docs-only PR: addresses concern #${CONCERN_NUMBER} at the spec/notes
-level. Implementation tracked in #${IMPL_ISSUE_NUMBER}.
+level. ${IMPL_REFS}.
 
 Ref #${CONCERN_NUMBER}
 
 No .py files changed." \
   --label "specs-notes"
-```text
+```
 
 ### Phase 8 — Archive and Close the Concern
 
@@ -186,9 +229,9 @@ TITLE   = <short concern title>
 SOURCE  = CONCERN-<CONCERN_NUMBER>
 BODY    = Full original concern body
           + "**Resolved**: YYYY-MM-DD — implementation tracked in
-            #<IMPL_ISSUE_NUMBER>."
+            #<N> [, #<M> ...]."
           + "Docs PR: <PR_URL>." (if docs-only PR was opened)
-```text
+```
 
 The `archive-history` skill handles `uv run append-history`, mdlint,
 `git add plan/history/`, commit, and push.
@@ -200,21 +243,22 @@ gh issue comment "${CONCERN_NUMBER}" --repo CERTCC/Vultron \
   --body "✅ Ingested.
 
 $([ -n "${PR_URL}" ] && echo "- Docs PR: ${PR_URL}")
-$(for n in ${IMPL_ISSUE_NUMBERS}; do echo "- Implementation issue: #${n}"; done)
+$(for n in "${IMPL_ISSUE_NUMBERS[@]}"; do echo "- Implementation issue: #${n}"; done)
 
 Root cause and fix plan captured via grill-me session.
 $([ -n "${SPEC_FILE}" ] && echo "Spec: \`specs/${SPEC_FILE}\`.")
 $([ -n "${NOTES_FILE}" ] && echo "Notes: \`notes/${NOTES_FILE}\`.")"
 
 gh issue close "${CONCERN_NUMBER}" --repo CERTCC/Vultron
-```text
+```
 
 ---
 
 ## Checklist
 
 - [ ] Concern issue identified (user-specified or selected from list)
-- [ ] Concern body fetched from GitHub
+- [ ] Concern body fetched from GitHub; issue validated as open + type:Concern
+- [ ] Task branch created (if doc gaps identified in grill-me) — before any file writes
 - [ ] `study-project-docs` invoked; evidence files explored
 - [ ] All grill-me branches resolved (root cause, options, ACs, doc gaps)
 - [ ] `specs/` and/or `notes/` updated — or consciously skipped

--- a/.agents/skills/ingest-idea/SKILL.md
+++ b/.agents/skills/ingest-idea/SKILL.md
@@ -184,7 +184,8 @@ Commit all spec/notes/README changes and open a PR carrying the
 Reference the originating idea issue in the PR body so GitHub auto-links them:
 
 ```bash
-git add specs/<topic>.yaml notes/<topic>.md specs/README.md
+git add specs/<topic>.yaml notes/<topic>.md specs/README.md \
+    plan/history/
 git commit -m "specs: ingest idea #<IDEA_NUMBER> — <short title>
 
 - Add specs/<topic>.yaml (ID-01 through ID-NN)

--- a/.agents/skills/ingest-idea/SKILL.md
+++ b/.agents/skills/ingest-idea/SKILL.md
@@ -33,7 +33,7 @@ gh issue list --repo CERTCC/Vultron \
   --limit 200 \
   --json number,title,issueType \
   --jq '.[] | select(.issueType.name == "Idea") | "#\(.number): \(.title)"'
-```
+```text
 
 Build a `choices` array from the results (e.g. `["#42: Actor discovery",
 "#51: Config refactor", "Create a new idea"]`). Wait for the user's
@@ -68,7 +68,7 @@ mutation {
   }
 }" --jq '.data.createIssue.issue.number')
 echo "Created idea issue #${IDEA_NUMBER}"
-```
+```text
 
 Continue with step 2 using `IDEA_NUMBER`.
 
@@ -78,7 +78,7 @@ Fetch the idea from GitHub:
 
 ```bash
 gh issue view "${IDEA_NUMBER}" --repo CERTCC/Vultron --json number,title,body
-```
+```text
 
 Use the issue title and body as the idea content for all subsequent steps.
 
@@ -106,7 +106,7 @@ happen on this branch so they are never at risk from a subsequent
 FRESHEN="$HOME/.copilot/skills/manage-worktree/scripts/manage_worktree.sh"
 [ -f "$FRESHEN" ] && bash "$FRESHEN" freshen
 git switch -c ingest/idea-<IDEA_NUMBER>-<slug>
-```
+```text
 
 ### 5. Write the spec file
 
@@ -140,52 +140,14 @@ Add the new spec to both:
 Invoke the `format-markdown` skill on all new/modified markdown files. Fix
 any errors before proceeding.
 
-### 9. Archive the idea
-
-Build the entry body — the full original idea text with a `**Processed**`
-line at the end — and pipe it to `uv run append-history idea` with
-`--title` and `--source` flags. Use `IDEA-<number>` (the GitHub issue
-number) as the source identifier:
-
-```bash
-cat <<'ENDOFENTRY' | uv run append-history idea \
-    --title "<short idea title>" \
-    --source "IDEA-<IDEA_NUMBER>"
-
-## #<IDEA_NUMBER> <short title>
-
-<full idea title and body here>
-
-**Processed**: YYYY-MM-DD — design decisions captured in
-`specs/<topic>.yaml` (ID-01 through ID-NN) and `notes/<topic>.md`.
-ENDOFENTRY
-```
-
-Then close the idea issue with a comment linking to the docs-only PR and
-the implementation issue. (Create the PR first in step 10, then add the
-comment after step 11 once both numbers are known.)
-
-```bash
-gh issue comment "${IDEA_NUMBER}" --repo CERTCC/Vultron \
-  --body "✅ Ingested.
-
-- Docs PR: <PR_URL>
-- Implementation issue: #<IMPL_ISSUE_NUMBER>
-
-Design decisions captured in \`specs/<topic>.yaml\` and \`notes/<topic>.md\`."
-
-gh issue close "${IDEA_NUMBER}" --repo CERTCC/Vultron
-```
-
-### 10. Open a docs-only PR
+### 9. Open a docs-only PR
 
 Commit all spec/notes/README changes and open a PR carrying the
 `specs-notes` label. The branch was already created in step 4b.
 Reference the originating idea issue in the PR body so GitHub auto-links them:
 
 ```bash
-git add specs/<topic>.yaml notes/<topic>.md specs/README.md \
-    plan/history/
+git add specs/<topic>.yaml notes/<topic>.md specs/README.md
 git commit -m "specs: ingest idea #<IDEA_NUMBER> — <short title>
 
 - Add specs/<topic>.yaml (ID-01 through ID-NN)
@@ -203,7 +165,7 @@ Ref #<IDEA_NUMBER>
 
 No .py files changed." \
   --label "specs-notes"
-```
+```text
 
 This PR carries the `specs-notes` label for reviewer awareness. This ensures
 spec and notes files are on `main` and
@@ -238,7 +200,7 @@ Notes: \`notes/<topic>.md\`" \
   --parent "${IDEA_NUMBER}")
   # Add --blocked-by N if this issue has known blockers at creation time
 echo "Created implementation issue #${IMPL_ISSUE_NUMBER}"
-```
+```text
 
 Set the `size:` label based on AC checkbox count:
 1–2 ACs → `size:S`; 3–6 ACs → `size:M`; 7+ ACs → `size:L`.
@@ -246,8 +208,23 @@ Set the `size:` label based on AC checkbox count:
 The implementation Issue sits in `group:unscheduled` until a human runs
 `review-priorities` to slot it into `plan/PRIORITIES.md`.
 
-After creating the implementation issue, post the closing comment on the
-idea issue and close it (see end of step 9):
+### 12. Archive the idea and close the issue
+
+Now that both the PR URL and implementation issue number are known, invoke
+the `archive-history` skill with the full original idea body:
+
+```text
+TYPE    = idea
+TITLE   = <short idea title>
+SOURCE  = IDEA-<IDEA_NUMBER>
+BODY    = Full original idea text
+          + "**Processed**: YYYY-MM-DD — design decisions captured in
+            `specs/<topic>.yaml` (ID-01 through ID-NN) and `notes/<topic>.md`."
+          + "Docs PR: <PR_URL>. Implementation tracked in #<IMPL_ISSUE_NUMBER>."
+```text
+
+After the `archive-history` skill completes, post the closing comment and
+close the idea issue:
 
 ```bash
 gh issue comment "${IDEA_NUMBER}" --repo CERTCC/Vultron \
@@ -259,7 +236,7 @@ gh issue comment "${IDEA_NUMBER}" --repo CERTCC/Vultron \
 Design decisions captured in \`specs/<topic>.yaml\` and \`notes/<topic>.md\`."
 
 gh issue close "${IDEA_NUMBER}" --repo CERTCC/Vultron
-```
+```text
 
 ## Checklist
 
@@ -272,7 +249,8 @@ gh issue close "${IDEA_NUMBER}" --repo CERTCC/Vultron
 - [ ] `notes/<topic>.md` created with decision table + examples
 - [ ] `specs/README.md` updated (both tables)
 - [ ] Markdown lint clean
-- [ ] Idea archived via `uv run append-history idea --source "IDEA-<number>"`
+- [ ] Idea archived via `archive-history` skill (after PR + impl issue created,
+  so entry body includes PR URL and impl issue number)
 - [ ] Docs-only PR opened with `specs-notes` label and `Ref #<idea_number>`
   in body
 - [ ] Implementation GitHub Issue created via `manage-github-issue` with
@@ -289,9 +267,9 @@ gh issue close "${IDEA_NUMBER}" --repo CERTCC/Vultron
 - **Notes file name**: same as spec file name with `.md` extension, in `notes/`
   instead of `specs/` (e.g., `configuration.md`, `actor-discovery.md`)
 - **History source ID**: use `IDEA-<github_issue_number>` (e.g., `IDEA-42`)
-  as the `--source` argument to `uv run append-history idea`
-- **History archiving**: use `uv run append-history idea` to archive processed
-  ideas — do not append directly to any `plan/history/*.md` file
+  as the `--source` argument to the `archive-history` skill
+- **History archiving**: use the `archive-history` skill — do not call
+  `uv run append-history` directly or append to `plan/history/*.md` files
 
 ## Creating a New Idea Issue
 
@@ -318,7 +296,7 @@ mutation {
     issue { number url }
   }
 }"
-```
+```text
 
 The issue will appear as an Idea type in GitHub and will be picked up by
 `ingest-idea` the next time it runs.

--- a/.agents/skills/learn/SKILL.md
+++ b/.agents/skills/learn/SKILL.md
@@ -63,7 +63,7 @@ all subsequent writes land on a clean, up-to-date baseline:
 ```bash
 FRESHEN="$HOME/.copilot/skills/manage-worktree/scripts/manage_worktree.sh"
 [ -f "$FRESHEN" ] && bash "$FRESHEN" freshen
-```
+```text
 
 Do this **before** `acquire-codebase-knowledge` runs — the scan regenerates
 files in `docs/reference/codebase/` (uncommitted), and those outputs must not
@@ -93,9 +93,9 @@ that the cost of a full scan is justified on every invocation.
      --state open \
      --label concern \
      --json number,title,body
-   ```
+   ```text
 
-3. Invoke the `study-project-docs` skill for full context: specs JSON,
+1. Invoke the `study-project-docs` skill for full context: specs JSON,
    plan files, docs/adr/, notes/, AGENTS.md, and a code scan. Because
    Phase 0 has already refreshed the codebase docs, `study-project-docs`
    will read up-to-date architecture and structure information.
@@ -141,7 +141,7 @@ Answer questions from codebase exploration where possible.
 
 ```bash
 git switch -c learn/<YYYYMMDD>-<slug>
-```
+```text
 
 The worktree was already freshened in Phase 0. All file writes (Phases 4–7)
 happen on this branch so they are never at risk from a `git reset --hard`.
@@ -173,30 +173,30 @@ Promote recurring implementation patterns and conventions from
 `BUILD_LEARNINGS.md` into `AGENTS.md`. Keep entries precise, actionable,
 and minimal.
 
-### Phase 7 — Archive and Close Processed Entries
+### Phase 7 — Prepare Archive Content and Close Processed Entries
 
 For each BUILD_LEARNINGS entry and each resolved GitHub Concern issue that
 has been fully promoted to `specs/`, `notes/`, or `AGENTS.md`:
 
-1. Archive the entry via `uv run append-history learning`:
+1. Draft the archive body for each item (store in memory — the actual
+   `archive-history` invocations happen in Phase 9 after the PR URL is known):
 
-   ```bash
-   cat <<'EOF' | uv run append-history learning \
-       --title "<short observation title>" \
-       --source "<label from the entry header, e.g. LABEL>"
+   ```text
 
-   <full original entry text here>
+   TYPE    = learning
+   TITLE   = <short observation title>
+   SOURCE  = <label from the entry header, e.g. LABEL>
+   BODY    = <full original BUILD_LEARNINGS entry or Concern body>
+             + "**Promoted**: YYYY-MM-DD — captured in <destination file(s)>."
+             + "Docs PR: <PR_URL>."  ← filled in after PR is opened
 
-   **Promoted**: YYYY-MM-DD — captured in <destination file(s)>.
-   EOF
-   ```
+   ```text
 
 2. **For BUILD_LEARNINGS entries**: delete the entry from
    `plan/BUILD_LEARNINGS.md` entirely — no strike-through, no tombstone.
 
 3. **For resolved GitHub Concern issues**: close the issue and add a
-   resolution comment linking to the docs PR and the spec/notes files it
-   was promoted into. Do this after the PR is open (so the URL is known):
+   resolution comment after the PR is open (step in Phase 9):
 
    ```bash
    gh issue comment "${ISSUE_NUMBER}" --repo CERTCC/Vultron \
@@ -208,7 +208,7 @@ has been fully promoted to `specs/`, `notes/`, or `AGENTS.md`:
    Design decisions are now captured in durable documentation."
 
    gh issue close "${ISSUE_NUMBER}" --repo CERTCC/Vultron
-   ```
+   ```text
 
 Do **not** reference `plan/BUILD_LEARNINGS.md` from durable docs.
 
@@ -223,11 +223,11 @@ Do **not** reference `plan/BUILD_LEARNINGS.md` from durable docs.
 
    ```bash
    git add specs/<changed-files> notes/<changed-files> AGENTS.md \
-       plan/BUILD_LEARNINGS.md plan/history/ docs/reference/codebase/
+       plan/BUILD_LEARNINGS.md docs/reference/codebase/
    git commit -m "docs: promote BUILD_LEARNINGS — <topic>
 
    - <bullet: what was promoted and where>
-   - Archive <N> entr[y/ies] via append-history learning
+   - Archive <N> entr[y/ies] via archive-history (after PR)
    - Close <N> resolved GitHub Concern issue(s) with resolution comments
    - Refresh docs/reference/codebase/ via acquire-codebase-knowledge
 
@@ -241,11 +241,31 @@ Do **not** reference `plan/BUILD_LEARNINGS.md` from durable docs.
 
    No .py files changed." \
      --label "specs-notes"
-   ```
+   ```text
 
    Use multiple commits for thematically distinct changes (e.g., spec
    refinements, notes promoted, AGENTS.md updates). This PR carries the
    `specs-notes` label for reviewer awareness.
+
+### Phase 9 — Archive Entries and Close Issues
+
+Now that the PR URL is known, archive each item by invoking the
+`archive-history` skill once per entry. For each item, pass:
+
+```text
+TYPE    = learning
+TITLE   = <short observation title>
+SOURCE  = <label from the BUILD_LEARNINGS header>
+BODY    = <full original entry text>
+          + "**Promoted**: YYYY-MM-DD — captured in <destination file(s)>."
+          + "Docs PR: <PR_URL>."
+```text
+
+The `archive-history` skill runs `uv run append-history`, lints the new
+files, stages `plan/history/`, commits, and pushes — once per entry.
+
+For resolved GitHub Concern issues, post the resolution comment and close
+the issue (see Phase 7 step 3 for the comment template).
 
 ## Constraints
 
@@ -253,7 +273,8 @@ Do **not** reference `plan/BUILD_LEARNINGS.md` from durable docs.
 - Do not process GitHub Idea-type issues — that is `ingest-idea`'s domain.
 - Do not skip the grill-me phase — it must complete before any writing.
 - Do not reference `plan/BUILD_LEARNINGS.md` from durable docs.
-- Archive processed entries via `uv run append-history learning`; do not
-  leave them in the file after promoting.
+- Archive processed entries via the `archive-history` skill; do not
+  call `uv run append-history` directly or leave entries in the file
+  after promoting.
 - Verify assumptions against the codebase; do not assert absence without
   evidence.

--- a/.agents/skills/learn/SKILL.md
+++ b/.agents/skills/learn/SKILL.md
@@ -223,7 +223,7 @@ Do **not** reference `plan/BUILD_LEARNINGS.md` from durable docs.
 
    ```bash
    git add specs/<changed-files> notes/<changed-files> AGENTS.md \
-       plan/BUILD_LEARNINGS.md docs/reference/codebase/
+       plan/BUILD_LEARNINGS.md plan/history/ docs/reference/codebase/
    git commit -m "docs: promote BUILD_LEARNINGS — <topic>
 
    - <bullet: what was promoted and where>

--- a/.agents/skills/update-priorities/SKILL.md
+++ b/.agents/skills/update-priorities/SKILL.md
@@ -61,7 +61,14 @@ When a priority group is fully completed:
 2. Confirm all linked issues are closed
 3. Run `uv run append-history priority` (auto-generates history entry with timestamp)
 4. Remove from `plan/PRIORITIES.md`
-5. Commit
+5. Stage all changes and commit:
+
+   ```bash
+   git add plan/PRIORITIES.md plan/history/
+   git commit -m "plan: archive completed priority — <title>
+
+   Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+   ```
 
 ### View Current State
 

--- a/.agents/skills/update-priorities/SKILL.md
+++ b/.agents/skills/update-priorities/SKILL.md
@@ -59,16 +59,25 @@ When a priority group is fully completed:
 
 1. Select the priority to archive
 2. Confirm all linked issues are closed
-3. Run `uv run append-history priority` (auto-generates history entry with timestamp)
-4. Remove from `plan/PRIORITIES.md`
-5. Stage all changes and commit:
+3. Invoke the `archive-history` skill:
+
+   ```text
+   TYPE    = priority
+   TITLE   = <priority group title>
+   SOURCE  = PRIORITY-<number>
+   BODY    = <priority summary, linked issues, completion notes>
+   ```text
+
+   The skill runs `uv run append-history priority`, lints the new history
+   files, stages `plan/history/`, commits, and pushes.
+4. Remove from `plan/PRIORITIES.md` and commit that change separately:
 
    ```bash
-   git add plan/PRIORITIES.md plan/history/
-   git commit -m "plan: archive completed priority — <title>
+   git add plan/PRIORITIES.md
+   git commit -m "plan: remove completed priority <N> — <title>
 
    Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
-   ```
+   ```text
 
 ### View Current State
 
@@ -80,7 +89,7 @@ Priority | Title                          | Issues | Status
 470      | Two-Actor Demo Redesign        | 5      | 🟡 In Progress
 475      | Participant Case Replica Safety| 1      | 🟡 In Progress
 476      | Bug Fixes and Demo Polish      | 7      | 🟢 On Track
-```
+```text
 
 ## Priority Number Assignment
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,6 +214,11 @@ to relevant tests and design notes.
 4. `build-docs` — only when `docs/` files were modified
 5. `commit` skill — include Co-authored-by trailer
 
+**Always stage `plan/history/` when `append-history` was called.** The tool
+creates a new entry file and regenerates `plan/history/YYMM/README.md` — both
+are untracked until staged. Omitting them is the most common cause of history
+files being left out of PRs.
+
 See each skill's SKILL.md for the exact commands. If the pre-commit hook
 reformats files: `git add -A && git commit -m "Same message"`.
 

--- a/plan/history/2605/implementation/ISSUE-576.md
+++ b/plan/history/2605/implementation/ISSUE-576.md
@@ -1,0 +1,23 @@
+---
+source: ISSUE-576
+timestamp: '2026-05-20T13:31:59.074121+00:00'
+title: AGENTS.md per-directory files + root condensed to 398 lines
+type: implementation
+---
+
+## Issue #576 — AGENTS.md routing: add per-directory files + migrate root content
+
+Implemented the AGENTS.md routing policy from notes/agents-md-structure.md
+(PR #575). Created three new per-directory AGENTS.md files:
+
+- vultron/core/AGENTS.md: handler/use-case naming, use-case protocol,
+  add-a-message-type checklist, core key files map, pitfalls
+- vultron/wire/as2/AGENTS.md: wire-layer naming, pattern ordering, outbound
+  activity factory boundary, AS2 pitfall index
+- vultron/adapters/AGENTS.md: FastAPI conventions, adapter key files map,
+  demo script pattern, adapter pitfall index
+
+Root AGENTS.md condensed from 527 → 398 lines. Reviewed 4 agent-related
+notes for overlap; added cross-ref to agentic-workflow.md.
+
+PR: <https://github.com/CERTCC/Vultron/pull/581>

--- a/plan/history/2605/learning/CONCERN-501.md
+++ b/plan/history/2605/learning/CONCERN-501.md
@@ -1,0 +1,32 @@
+---
+source: CONCERN-501
+timestamp: '2026-05-19T20:00:08.038567+00:00'
+title: Demo HTTP calls use requests which is not declared in project.dependencies
+type: learning
+---
+
+## #501 Demo HTTP calls use `requests` which is not declared in `project.dependencies`
+
+`vultron/demo/utils.py` and `vultron/demo/helpers/verification.py` import `requests`,
+but `requests` is not listed in `project.dependencies` in `pyproject.toml`. The `httpx`
+library (`>=0.28.1`) is already a declared runtime dependency and could serve as a
+drop-in replacement.
+
+**Category**: Top risk
+
+**Severity**: high
+
+**Evidence**:
+
+- `vultron/demo/utils.py`
+- `vultron/demo/helpers/verification.py`
+- `vultron/demo/scenario/two_actor_demo.py`
+- `pyproject.toml`
+
+**Impact if Ignored**: Fresh non-dev installs may fail at runtime when demos run
+outbound HTTP calls, since `requests` is not guaranteed to be installed.
+
+**Suggested Action**: Migrate demo HTTP calls from `requests` to `httpx` (already
+a declared runtime dep), or formally add `requests` to `project.dependencies`.
+
+**Resolved**: 2026-05-19 — implementation tracked in #517.

--- a/plan/history/2605/learning/CONCERN-507.md
+++ b/plan/history/2605/learning/CONCERN-507.md
@@ -1,0 +1,23 @@
+---
+source: CONCERN-507
+timestamp: '2026-05-19T20:18:39.672591+00:00'
+title: AGENTS.md routing policy and per-directory structure
+type: learning
+---
+
+## #507 Planning and specification files change so frequently that agent guidance goes stale quickly
+
+`plan/` and guidance docs (`AGENTS.md`, `specs/README.md`) are among the highest-churn
+files in the repository (386, 306, and 87+ changes respectively in the last 90 days).
+Agents and contributors working from cached or slightly-stale copies may apply
+outdated rules.
+
+**Root cause**: AGENTS.md is a monolith with no routing policy — pitfalls and
+conventions that belong in per-directory AGENTS.md files or notes/ accumulate at root,
+driving high churn and stale agent context. plan/ churn is by design (ephemeral files),
+but AGENTS.md and specs/README.md staleness is a structural problem.
+
+**Resolution**: 2026-05-19 — added routing policy note `notes/agents-md-structure.md`
+(PR #575) and AGENTS.md Common Pitfalls entry for routing awareness.
+Implementation tracked in #576 (per-directory AGENTS.md stubs + content migration).
+Docs PR: <https://github.com/CERTCC/Vultron/pull/575>5>.


### PR DESCRIPTION
Add `ingest-concern` skill — process a single Concern issue into an implementation plan

---
Please note: Pull request submissions are subject to our
[Contribution Instructions](https://github.com/CERTCC/Vultron/blob/main/ContributionInstructions.md)

---

## Summary

Adds the `ingest-concern` skill to `.agents/skills/ingest-concern/SKILL.md`.

This skill was originally written in session `bfa8cd75` (commit `4095f9d9`,
May 19 2026) but was lost when the `wt/clyde` worktree branch was reset before
the commit was pushed. Recovered from the git reflog and committed here.

## What the skill does

Converts a single open GitHub `type:Concern` issue into a concrete action plan:

| Phase | Action |
|---|---|
| 0 | Select a concern (from list or user-supplied `#N`) |
| 1 | `study-project-docs` — load specs and context |
| 2 | Fetch and read the concern issue body + evidence files |
| 3 | `grill-me` interview — root cause, options, acceptance criteria, doc gaps |
| 4 | Optionally update `specs/`, `notes/`, or `AGENTS.md` |
| 5 | Create ≥1 implementation issues via `manage-github-issue` (concern as parent) |
| 6 | Open docs-only PR (with `specs-notes` label) only when files changed |
| 7 | Archive via `uv run append-history learning`, comment on concern, close it |

## Relationship to existing skills

| Skill | Scope | Driven by |
|---|---|---|
| `process-concerns` | Batch | Codebase scan → CONCERNS.md |
| `learn` | Batch | BUILD_LEARNINGS.md + open Concern issues |
| **`ingest-concern`** | **Single** | **One open Concern issue** |
| `new-concern` | Capture only | Freeform description → new issue (no resolution) |

Fills the gap for focused, single-concern investigation and resolution without
triggering a full batch workflow.

## Files changed

- `.agents/skills/ingest-concern/SKILL.md` — new skill (264 lines)
