### PR TITLE
fix: implement AnnounceEmbargoEventToCaseReceivedUseCase via BT (#588)

### DIFF
--- a/.github/workflows/demo-integration.yml
+++ b/.github/workflows/demo-integration.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Build Docker images
         run: |
           docker buildx bake \
+            --allow=fs.read=.. \
             -f docker/docker-compose-multi-actor.yml \
             --set "*.cache-from=type=gha" \
             --set "*.cache-to=type=gha,mode=max" \

--- a/.github/workflows/demo-integration.yml
+++ b/.github/workflows/demo-integration.yml
@@ -46,11 +46,14 @@ jobs:
       # cache-from/cache-to through to BuildKit, which writes/reads the GHA
       # cache natively.  --load ensures all built images are available to the
       # docker daemon for the subsequent docker compose up step.
+      # Run from the docker/ directory so that context: .. resolves to the
+      # repo root and ../docker/Dockerfile resolves to docker/Dockerfile.
       - name: Build Docker images
+        working-directory: docker
         run: |
           docker buildx bake \
             --allow=fs.read=.. \
-            -f docker/docker-compose-multi-actor.yml \
+            -f docker-compose-multi-actor.yml \
             --set "*.cache-from=type=gha" \
             --set "*.cache-to=type=gha,mode=max" \
             --load

--- a/test/core/behaviors/embargo/__init__.py
+++ b/test/core/behaviors/embargo/__init__.py
@@ -1,0 +1,12 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University

--- a/test/core/behaviors/embargo/test_nodes.py
+++ b/test/core/behaviors/embargo/test_nodes.py
@@ -1,0 +1,208 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Unit tests for vultron/core/behaviors/embargo/nodes.py."""
+
+from typing import cast
+
+import py_trees
+
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.core.behaviors.embargo.nodes import (
+    ApplyEmbargoTeardownNode,
+    ValidateCaseExistsNode,
+)
+from vultron.core.states.em import EM
+from vultron.core.states.participant_embargo_consent import PEC
+from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+
+# Populate the vocabulary registry as a side-effect.
+_ = VulnerabilityCase
+
+
+def _setup_blackboard(
+    dl: SqliteDataLayer, actor_id: str = "https://example.org/users/vendor"
+) -> None:
+    """Populate the py_trees blackboard with the DataLayer and actor_id."""
+    py_trees.blackboard.Blackboard.enable_activity_stream()
+    blackboard = py_trees.blackboard.Client(name="test-setup")
+    blackboard.register_key(
+        key="datalayer", access=py_trees.common.Access.WRITE
+    )
+    blackboard.register_key(
+        key="actor_id", access=py_trees.common.Access.WRITE
+    )
+    blackboard.datalayer = dl
+    blackboard.actor_id = actor_id
+
+
+def _make_case_and_embargo(
+    case_suffix: str,
+    em_state: EM = EM.ACTIVE,
+) -> tuple[VulnerabilityCase, EmbargoEvent]:
+    case = VulnerabilityCase(
+        id_=f"https://example.org/cases/case_{case_suffix}",
+        name=f"Test Case {case_suffix}",
+    )
+    embargo = EmbargoEvent(
+        id_=f"https://example.org/cases/case_{case_suffix}/embargo_events/e1",
+        context=case.id_,
+    )
+    case.active_embargo = embargo.id_
+    case.current_status.em_state = em_state
+    return case, embargo
+
+
+class TestValidateCaseExistsNode:
+    """Tests for ValidateCaseExistsNode."""
+
+    def test_returns_success_when_case_found(self):
+        """Node returns SUCCESS when case exists in the DataLayer."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = _make_case_and_embargo("vcn1")
+        dl.create(case)
+
+        _setup_blackboard(dl)
+        node = ValidateCaseExistsNode(case_id=case.id_)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.SUCCESS
+
+    def test_returns_failure_when_case_missing(self):
+        """Node returns FAILURE when the case ID is not in the DataLayer."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        _setup_blackboard(dl)
+
+        node = ValidateCaseExistsNode(
+            case_id="https://example.org/cases/nonexistent"
+        )
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.FAILURE
+
+
+class TestApplyEmbargoTeardownNode:
+    """Tests for ApplyEmbargoTeardownNode."""
+
+    def test_transitions_em_active_to_exited(self):
+        """Node transitions EM.ACTIVE → EM.EXITED and saves the case."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = _make_case_and_embargo("atn1", em_state=EM.ACTIVE)
+        dl.create(case)
+
+        _setup_blackboard(dl)
+        node = ApplyEmbargoTeardownNode(case_id=case.id_)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.SUCCESS
+        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        assert updated.current_status.em_state == EM.EXITED
+        assert updated.active_embargo is None
+
+    def test_transitions_em_revise_to_exited(self):
+        """Node transitions EM.REVISE → EM.EXITED (also a valid terminate path)."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = _make_case_and_embargo("atn2", em_state=EM.REVISE)
+        dl.create(case)
+
+        _setup_blackboard(dl)
+        node = ApplyEmbargoTeardownNode(case_id=case.id_)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.SUCCESS
+        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        assert updated.current_status.em_state == EM.EXITED
+
+    def test_idempotent_when_already_exited(self):
+        """Node returns SUCCESS without modifying state when already EXITED."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = _make_case_and_embargo("atn3", em_state=EM.EXITED)
+        case.active_embargo = None
+        dl.create(case)
+
+        _setup_blackboard(dl)
+        node = ApplyEmbargoTeardownNode(case_id=case.id_)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.SUCCESS
+        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        assert updated.current_status.em_state == EM.EXITED
+
+    def test_state_sync_override_for_unexpected_em_state(self, caplog):
+        """Node logs WARNING and applies override for non-standard EM state."""
+        import logging
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = _make_case_and_embargo("atn4", em_state=EM.NONE)
+        dl.create(case)
+
+        _setup_blackboard(dl)
+        node = ApplyEmbargoTeardownNode(case_id=case.id_)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+
+        with caplog.at_level(logging.WARNING):
+            bt.tick()
+
+        assert node.status == py_trees.common.Status.SUCCESS
+        assert any("state-sync override" in r.message for r in caplog.records)
+        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        assert updated.current_status.em_state == EM.EXITED
+
+    def test_resets_participant_embargo_consent(self):
+        """Node resets participant PEC state to NO_EMBARGO."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = _make_case_and_embargo("atn5", em_state=EM.ACTIVE)
+        participant = CaseParticipant(
+            id_=f"{case.id_}/participants/p1",
+            attributed_to="https://example.org/users/finder",
+        )
+        participant.embargo_consent_state = PEC.SIGNATORY.value
+        case.case_participants.append(participant.id_)
+        dl.create(case)
+        dl.create(participant)
+
+        _setup_blackboard(dl)
+        node = ApplyEmbargoTeardownNode(case_id=case.id_)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.SUCCESS
+        updated_p = cast(CaseParticipant, dl.read(participant.id_))
+        assert updated_p.embargo_consent_state == PEC.NO_EMBARGO.value
+
+    def test_returns_failure_when_case_missing(self):
+        """Node returns FAILURE when the case ID is not in the DataLayer."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        _setup_blackboard(dl)
+
+        node = ApplyEmbargoTeardownNode(
+            case_id="https://example.org/cases/nonexistent"
+        )
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.FAILURE

--- a/test/core/behaviors/embargo/test_nodes.py
+++ b/test/core/behaviors/embargo/test_nodes.py
@@ -19,6 +19,8 @@ import py_trees
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.core.behaviors.embargo.nodes import (
     ApplyEmbargoTeardownNode,
+    IsActiveEmbargoNode,
+    RemoveFromProposedEmbargoesNode,
     ValidateCaseExistsNode,
 )
 from vultron.core.states.em import EM
@@ -200,6 +202,115 @@ class TestApplyEmbargoTeardownNode:
 
         node = ApplyEmbargoTeardownNode(
             case_id="https://example.org/cases/nonexistent"
+        )
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.FAILURE
+
+
+class TestIsActiveEmbargoNode:
+    """Tests for IsActiveEmbargoNode."""
+
+    def test_returns_success_when_embargo_is_active(self):
+        """Node returns SUCCESS when case.active_embargo matches embargo_id."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, embargo = _make_case_and_embargo("ian1", em_state=EM.ACTIVE)
+        dl.create(case)
+
+        _setup_blackboard(dl)
+        node = IsActiveEmbargoNode(case_id=case.id_, embargo_id=embargo.id_)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.SUCCESS
+
+    def test_returns_failure_when_embargo_not_active(self):
+        """Node returns FAILURE when active_embargo does not match."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, embargo = _make_case_and_embargo("ian2", em_state=EM.PROPOSED)
+        case.active_embargo = None
+        dl.create(case)
+
+        _setup_blackboard(dl)
+        node = IsActiveEmbargoNode(
+            case_id=case.id_,
+            embargo_id=embargo.id_,
+        )
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.FAILURE
+
+    def test_returns_failure_when_case_missing(self):
+        """Node returns FAILURE when the case ID is not in the DataLayer."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        _setup_blackboard(dl)
+
+        node = IsActiveEmbargoNode(
+            case_id="https://example.org/cases/nonexistent",
+            embargo_id="https://example.org/cases/nonexistent/embargo_events/e1",
+        )
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.FAILURE
+
+
+class TestRemoveFromProposedEmbargoesNode:
+    """Tests for RemoveFromProposedEmbargoesNode."""
+
+    def test_removes_embargo_from_proposed_list(self):
+        """Node removes embargo_id from proposed_embargoes and returns SUCCESS."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, embargo = _make_case_and_embargo("rfp1", em_state=EM.PROPOSED)
+        case.proposed_embargoes.append(embargo.id_)
+        dl.create(case)
+
+        _setup_blackboard(dl)
+        node = RemoveFromProposedEmbargoesNode(
+            case_id=case.id_, embargo_id=embargo.id_
+        )
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.SUCCESS
+        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        assert embargo.id_ not in [
+            e if isinstance(e, str) else getattr(e, "id_", None)
+            for e in updated.proposed_embargoes
+        ]
+
+    def test_idempotent_when_not_in_proposed(self):
+        """Node returns SUCCESS even if embargo_id is not in proposed_embargoes."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, embargo = _make_case_and_embargo("rfp2", em_state=EM.ACTIVE)
+        # embargo NOT in proposed_embargoes
+        dl.create(case)
+
+        _setup_blackboard(dl)
+        node = RemoveFromProposedEmbargoesNode(
+            case_id=case.id_, embargo_id=embargo.id_
+        )
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.SUCCESS
+
+    def test_returns_failure_when_case_missing(self):
+        """Node returns FAILURE when the case ID is not in the DataLayer."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        _setup_blackboard(dl)
+
+        node = RemoveFromProposedEmbargoesNode(
+            case_id="https://example.org/cases/nonexistent",
+            embargo_id="https://example.org/cases/nonexistent/embargo_events/e1",
         )
         bt = py_trees.trees.BehaviourTree(root=node)
         bt.setup()

--- a/test/core/use_cases/received/test_embargo.py
+++ b/test/core/use_cases/received/test_embargo.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock
 from vultron.adapters.driven.db_record import StorableRecord
 from vultron.core.states.em import EM
 from vultron.core.use_cases.received.embargo import (
+    AnnounceEmbargoEventToCaseReceivedUseCase,
     CreateEmbargoEventReceivedUseCase,
     AddEmbargoEventToCaseReceivedUseCase,
     RemoveEmbargoEventFromCaseReceivedUseCase,
@@ -33,6 +34,7 @@ from vultron.core.use_cases.triggers.requests import (
 from vultron.errors import VultronInvalidStateTransitionError
 from vultron.wire.as2.factories import (
     add_embargo_to_case_activity,
+    announce_embargo_activity,
     em_accept_embargo_activity,
     em_propose_embargo_activity,
     em_reject_embargo_activity,
@@ -624,3 +626,203 @@ class TestEmbargoUseCases:
             SvcAcceptEmbargoUseCase(
                 dl, request, trigger_activity=TriggerActivityAdapter(dl)
             ).execute()
+
+
+class TestAnnounceEmbargoEventToCaseReceivedUseCase:
+    """Tests for AnnounceEmbargoEventToCaseReceivedUseCase."""
+
+    def test_announce_embargo_transitions_em_to_exited(self, make_payload):
+        """execute() transitions case EM state from ACTIVE to EXITED."""
+        import py_trees
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+
+        py_trees.blackboard.Blackboard.enable_activity_stream()
+        py_trees.blackboard.Blackboard.storage.clear()
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case = VulnerabilityCase(
+            id_="https://example.org/cases/case_aem1",
+            name="Announce Embargo Teardown Test",
+        )
+        embargo = EmbargoEvent(
+            id_="https://example.org/cases/case_aem1/embargo_events/e1",
+            context=case.id_,
+        )
+        case.active_embargo = embargo.id_
+        case.current_status.em_state = EM.ACTIVE
+        dl.create(case)
+
+        activity = announce_embargo_activity(
+            embargo=embargo,
+            context=case,
+            actor="https://example.org/users/vendor",
+        )
+        event = make_payload(activity)
+
+        AnnounceEmbargoEventToCaseReceivedUseCase(dl, event).execute()
+
+        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        assert updated is not None
+        assert updated.current_status.em_state == EM.EXITED
+        assert updated.active_embargo is None
+
+    def test_announce_embargo_clears_active_embargo(self, make_payload):
+        """execute() clears active_embargo on the case."""
+        import py_trees
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+
+        py_trees.blackboard.Blackboard.enable_activity_stream()
+        py_trees.blackboard.Blackboard.storage.clear()
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case = VulnerabilityCase(
+            id_="https://example.org/cases/case_aem2",
+            name="Announce Embargo Clear Test",
+        )
+        embargo = EmbargoEvent(
+            id_="https://example.org/cases/case_aem2/embargo_events/e2",
+            context=case.id_,
+        )
+        case.active_embargo = embargo.id_
+        case.current_status.em_state = EM.ACTIVE
+        dl.create(case)
+
+        activity = announce_embargo_activity(
+            embargo=embargo,
+            context=case,
+            actor="https://example.org/users/vendor",
+        )
+        event = make_payload(activity)
+
+        AnnounceEmbargoEventToCaseReceivedUseCase(dl, event).execute()
+
+        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        assert updated is not None
+        assert updated.active_embargo is None
+
+    def test_announce_embargo_resets_participant_consent(self, make_payload):
+        """execute() resets participant embargo consent states to NO_EMBARGO."""
+        import py_trees
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+        from vultron.wire.as2.vocab.objects.case_participant import (
+            CaseParticipant,
+        )
+        from vultron.core.states.participant_embargo_consent import PEC
+
+        py_trees.blackboard.Blackboard.enable_activity_stream()
+        py_trees.blackboard.Blackboard.storage.clear()
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case = VulnerabilityCase(
+            id_="https://example.org/cases/case_aem3",
+            name="Announce Embargo Participant Reset Test",
+        )
+        embargo = EmbargoEvent(
+            id_="https://example.org/cases/case_aem3/embargo_events/e3",
+            context=case.id_,
+        )
+        participant = CaseParticipant(
+            id_="https://example.org/cases/case_aem3/participants/p1",
+            attributed_to="https://example.org/users/finder",
+        )
+        participant.embargo_consent_state = PEC.SIGNATORY.value
+        case.active_embargo = embargo.id_
+        case.current_status.em_state = EM.ACTIVE
+        case.case_participants.append(participant.id_)
+        case.actor_participant_index["https://example.org/users/finder"] = (
+            participant.id_
+        )
+        dl.create(case)
+        dl.create(participant)
+
+        activity = announce_embargo_activity(
+            embargo=embargo,
+            context=case,
+            actor="https://example.org/users/vendor",
+        )
+        event = make_payload(activity)
+
+        AnnounceEmbargoEventToCaseReceivedUseCase(dl, event).execute()
+
+        from vultron.wire.as2.vocab.objects.case_participant import (
+            CaseParticipant as CP,
+        )
+
+        updated_p = cast(CP, dl.read(participant.id_))
+        assert updated_p is not None
+        assert updated_p.embargo_consent_state == PEC.NO_EMBARGO.value
+
+    def test_announce_embargo_idempotent_when_already_exited(
+        self, make_payload
+    ):
+        """execute() is a no-op when case EM state is already EXITED."""
+        import py_trees
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+
+        py_trees.blackboard.Blackboard.enable_activity_stream()
+        py_trees.blackboard.Blackboard.storage.clear()
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case = VulnerabilityCase(
+            id_="https://example.org/cases/case_aem4",
+            name="Announce Embargo Idempotent Test",
+        )
+        embargo = EmbargoEvent(
+            id_="https://example.org/cases/case_aem4/embargo_events/e4",
+            context=case.id_,
+        )
+        case.active_embargo = None
+        case.current_status.em_state = EM.EXITED
+        dl.create(case)
+
+        activity = announce_embargo_activity(
+            embargo=embargo,
+            context=case,
+            actor="https://example.org/users/vendor",
+        )
+        event = make_payload(activity)
+
+        # Should not raise and case state should remain EXITED
+        AnnounceEmbargoEventToCaseReceivedUseCase(dl, event).execute()
+
+        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        assert updated is not None
+        assert updated.current_status.em_state == EM.EXITED
+
+    def test_announce_embargo_missing_case_id_logs_warning(
+        self, make_payload, caplog
+    ):
+        """execute() logs a warning and exits early if case_id is missing."""
+        import py_trees
+        from unittest.mock import MagicMock
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+
+        py_trees.blackboard.Blackboard.enable_activity_stream()
+        py_trees.blackboard.Blackboard.storage.clear()
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        mock_event = MagicMock()
+        mock_event.case_id = None
+        mock_event.activity_id = "https://example.org/activities/ann1"
+        mock_event.actor_id = "https://example.org/users/vendor"
+
+        with caplog.at_level(logging.WARNING):
+            AnnounceEmbargoEventToCaseReceivedUseCase(dl, mock_event).execute()
+
+        assert any("missing case_id" in r.message for r in caplog.records)

--- a/test/core/use_cases/received/test_embargo.py
+++ b/test/core/use_cases/received/test_embargo.py
@@ -497,23 +497,69 @@ class TestEmbargoUseCases:
             for e in updated.proposed_embargoes
         ]
 
-    def test_remove_active_embargo_proposed_state_transitions_to_none(
+    def test_remove_active_embargo_transitions_em_to_exited(
         self, make_payload
     ):
-        """remove_embargo_event uses REJECT machine trigger when EM is PROPOSED."""
+        """remove_embargo_event transitions EM from ACTIVE to EXITED via BT."""
+        import py_trees
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
         from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
             VulnerabilityCase,
         )
 
+        py_trees.blackboard.Blackboard.enable_activity_stream()
+        py_trees.blackboard.Blackboard.storage.clear()
+
         dl = SqliteDataLayer("sqlite:///:memory:")
         case = VulnerabilityCase(
             id_="https://example.org/cases/case_rem2",
-            name="Remove Embargo PROPOSED→NONE",
+            name="Remove Embargo ACTIVE→EXITED",
         )
         embargo = EmbargoEvent(
             id_="https://example.org/cases/case_rem2/embargo_events/e2",
+            context=case.id_,
+        )
+        case.active_embargo = embargo.id_
+        case.current_status.em_state = EM.ACTIVE
+        dl.create(case)
+
+        activity = remove_embargo_from_case_activity(
+            embargo,
+            origin=case,
+            actor="https://example.org/users/coord",
+        )
+        event = make_payload(activity)
+
+        RemoveEmbargoEventFromCaseReceivedUseCase(dl, event).execute()
+
+        updated = dl.read(case.id_)
+        assert updated is not None
+        updated = cast(VulnerabilityCase, updated)
+        assert updated.active_embargo is None
+        assert updated.current_status.em_state == EM.EXITED
+
+    def test_remove_active_embargo_unusual_state_uses_override(
+        self, caplog, make_payload
+    ):
+        """remove_embargo_event uses state-sync override when EM is PROPOSED but embargo is active."""
+        import py_trees
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+
+        py_trees.blackboard.Blackboard.enable_activity_stream()
+        py_trees.blackboard.Blackboard.storage.clear()
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case = VulnerabilityCase(
+            id_="https://example.org/cases/case_rem3",
+            name="Remove Embargo unusual state override",
+        )
+        embargo = EmbargoEvent(
+            id_="https://example.org/cases/case_rem3/embargo_events/e3",
             context=case.id_,
         )
         case.active_embargo = embargo.id_
@@ -533,47 +579,7 @@ class TestEmbargoUseCases:
         assert updated is not None
         updated = cast(VulnerabilityCase, updated)
         assert updated.active_embargo is None
-        assert updated.current_status.em_state == EM.NONE
-
-    def test_remove_active_embargo_active_state_admin_override(
-        self, caplog, make_payload
-    ):
-        """remove_embargo_event logs WARNING when EM state is ACTIVE (admin override)."""
-        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
-        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
-        from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
-        )
-
-        dl = SqliteDataLayer("sqlite:///:memory:")
-        case = VulnerabilityCase(
-            id_="https://example.org/cases/case_rem3",
-            name="Remove Active Embargo Admin Override",
-        )
-        embargo = EmbargoEvent(
-            id_="https://example.org/cases/case_rem3/embargo_events/e3",
-            context=case.id_,
-        )
-        case.active_embargo = embargo.id_
-        case.current_status.em_state = EM.ACTIVE
-        dl.create(case)
-
-        activity = remove_embargo_from_case_activity(
-            embargo,
-            origin=case,
-            actor="https://example.org/users/coord",
-        )
-        event = make_payload(activity)
-
-        with caplog.at_level(logging.WARNING):
-            RemoveEmbargoEventFromCaseReceivedUseCase(dl, event).execute()
-
-        updated = dl.read(case.id_)
-        assert updated is not None
-        updated = cast(VulnerabilityCase, updated)
-        assert updated.active_embargo is None
-        assert updated.current_status.em_state == EM.NONE
-        assert any("Admin override" in r.message for r in caplog.records)
+        assert updated.current_status.em_state == EM.EXITED
 
     def test_evaluate_embargo_raises_invalid_state_transition_when_em_state_invalid(
         self,
@@ -629,24 +635,20 @@ class TestEmbargoUseCases:
 
 
 class TestAnnounceEmbargoEventToCaseReceivedUseCase:
-    """Tests for AnnounceEmbargoEventToCaseReceivedUseCase."""
+    """Tests for AnnounceEmbargoEventToCaseReceivedUseCase (no-op receiver)."""
 
-    def test_announce_embargo_transitions_em_to_exited(self, make_payload):
-        """execute() transitions case EM state from ACTIVE to EXITED."""
-        import py_trees
+    def test_announce_embargo_is_noop(self, make_payload):
+        """execute() is a no-op: EM state and active_embargo are unchanged."""
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
         from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
             VulnerabilityCase,
         )
 
-        py_trees.blackboard.Blackboard.enable_activity_stream()
-        py_trees.blackboard.Blackboard.storage.clear()
-
         dl = SqliteDataLayer("sqlite:///:memory:")
         case = VulnerabilityCase(
             id_="https://example.org/cases/case_aem1",
-            name="Announce Embargo Teardown Test",
+            name="Announce Embargo No-Op Test",
         )
         embargo = EmbargoEvent(
             id_="https://example.org/cases/case_aem1/embargo_events/e1",
@@ -667,162 +669,22 @@ class TestAnnounceEmbargoEventToCaseReceivedUseCase:
 
         updated = cast(VulnerabilityCase, dl.read(case.id_))
         assert updated is not None
-        assert updated.current_status.em_state == EM.EXITED
-        assert updated.active_embargo is None
+        # State is UNCHANGED — Announce is not the ET message
+        assert updated.current_status.em_state == EM.ACTIVE
+        assert updated.active_embargo is not None
 
-    def test_announce_embargo_clears_active_embargo(self, make_payload):
-        """execute() clears active_embargo on the case."""
-        import py_trees
-        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
-        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
-        from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
-        )
-
-        py_trees.blackboard.Blackboard.enable_activity_stream()
-        py_trees.blackboard.Blackboard.storage.clear()
-
-        dl = SqliteDataLayer("sqlite:///:memory:")
-        case = VulnerabilityCase(
-            id_="https://example.org/cases/case_aem2",
-            name="Announce Embargo Clear Test",
-        )
-        embargo = EmbargoEvent(
-            id_="https://example.org/cases/case_aem2/embargo_events/e2",
-            context=case.id_,
-        )
-        case.active_embargo = embargo.id_
-        case.current_status.em_state = EM.ACTIVE
-        dl.create(case)
-
-        activity = announce_embargo_activity(
-            embargo=embargo,
-            context=case,
-            actor="https://example.org/users/vendor",
-        )
-        event = make_payload(activity)
-
-        AnnounceEmbargoEventToCaseReceivedUseCase(dl, event).execute()
-
-        updated = cast(VulnerabilityCase, dl.read(case.id_))
-        assert updated is not None
-        assert updated.active_embargo is None
-
-    def test_announce_embargo_resets_participant_consent(self, make_payload):
-        """execute() resets participant embargo consent states to NO_EMBARGO."""
-        import py_trees
-        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
-        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
-        from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
-        )
-        from vultron.wire.as2.vocab.objects.case_participant import (
-            CaseParticipant,
-        )
-        from vultron.core.states.participant_embargo_consent import PEC
-
-        py_trees.blackboard.Blackboard.enable_activity_stream()
-        py_trees.blackboard.Blackboard.storage.clear()
-
-        dl = SqliteDataLayer("sqlite:///:memory:")
-        case = VulnerabilityCase(
-            id_="https://example.org/cases/case_aem3",
-            name="Announce Embargo Participant Reset Test",
-        )
-        embargo = EmbargoEvent(
-            id_="https://example.org/cases/case_aem3/embargo_events/e3",
-            context=case.id_,
-        )
-        participant = CaseParticipant(
-            id_="https://example.org/cases/case_aem3/participants/p1",
-            attributed_to="https://example.org/users/finder",
-        )
-        participant.embargo_consent_state = PEC.SIGNATORY.value
-        case.active_embargo = embargo.id_
-        case.current_status.em_state = EM.ACTIVE
-        case.case_participants.append(participant.id_)
-        case.actor_participant_index["https://example.org/users/finder"] = (
-            participant.id_
-        )
-        dl.create(case)
-        dl.create(participant)
-
-        activity = announce_embargo_activity(
-            embargo=embargo,
-            context=case,
-            actor="https://example.org/users/vendor",
-        )
-        event = make_payload(activity)
-
-        AnnounceEmbargoEventToCaseReceivedUseCase(dl, event).execute()
-
-        from vultron.wire.as2.vocab.objects.case_participant import (
-            CaseParticipant as CP,
-        )
-
-        updated_p = cast(CP, dl.read(participant.id_))
-        assert updated_p is not None
-        assert updated_p.embargo_consent_state == PEC.NO_EMBARGO.value
-
-    def test_announce_embargo_idempotent_when_already_exited(
-        self, make_payload
-    ):
-        """execute() is a no-op when case EM state is already EXITED."""
-        import py_trees
-        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
-        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
-        from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
-        )
-
-        py_trees.blackboard.Blackboard.enable_activity_stream()
-        py_trees.blackboard.Blackboard.storage.clear()
-
-        dl = SqliteDataLayer("sqlite:///:memory:")
-        case = VulnerabilityCase(
-            id_="https://example.org/cases/case_aem4",
-            name="Announce Embargo Idempotent Test",
-        )
-        embargo = EmbargoEvent(
-            id_="https://example.org/cases/case_aem4/embargo_events/e4",
-            context=case.id_,
-        )
-        case.active_embargo = None
-        case.current_status.em_state = EM.EXITED
-        dl.create(case)
-
-        activity = announce_embargo_activity(
-            embargo=embargo,
-            context=case,
-            actor="https://example.org/users/vendor",
-        )
-        event = make_payload(activity)
-
-        # Should not raise and case state should remain EXITED
-        AnnounceEmbargoEventToCaseReceivedUseCase(dl, event).execute()
-
-        updated = cast(VulnerabilityCase, dl.read(case.id_))
-        assert updated is not None
-        assert updated.current_status.em_state == EM.EXITED
-
-    def test_announce_embargo_missing_case_id_logs_warning(
-        self, make_payload, caplog
-    ):
-        """execute() logs a warning and exits early if case_id is missing."""
-        import py_trees
+    def test_announce_embargo_logs_info(self, make_payload, caplog):
+        """execute() logs receipt at INFO level."""
         from unittest.mock import MagicMock
-        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 
-        py_trees.blackboard.Blackboard.enable_activity_stream()
-        py_trees.blackboard.Blackboard.storage.clear()
-
-        dl = SqliteDataLayer("sqlite:///:memory:")
+        dl = MagicMock()
         mock_event = MagicMock()
-        mock_event.case_id = None
         mock_event.activity_id = "https://example.org/activities/ann1"
-        mock_event.actor_id = "https://example.org/users/vendor"
 
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.INFO):
             AnnounceEmbargoEventToCaseReceivedUseCase(dl, mock_event).execute()
 
-        assert any("missing case_id" in r.message for r in caplog.records)
+        assert any(
+            "no receiver-side state change required" in r.message
+            for r in caplog.records
+        )

--- a/vultron/adapters/driven/trigger_activity_adapter.py
+++ b/vultron/adapters/driven/trigger_activity_adapter.py
@@ -48,6 +48,7 @@ from vultron.wire.as2.factories import (
     em_propose_embargo_activity,
     em_reject_embargo_activity,
     recommend_actor_activity,
+    remove_embargo_from_case_activity,
     rm_accept_invite_to_case_activity,
     rm_close_report_activity,
     rm_defer_case_activity,
@@ -644,6 +645,27 @@ class TriggerActivityAdapter:
         except ValueError:
             logger.warning(
                 "announce_embargo: activity '%s' already exists — skipping",
+                activity.id_,
+            )
+        return activity.id_, activity.model_dump(**_DUMP_KWARGS)
+
+    def terminate_embargo(
+        self,
+        embargo_id: str,
+        case_id: str,
+        actor: str,
+        to: list[str] | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist a ``Remove(EmbargoEvent, origin=case)`` ET activity."""
+        embargo = cast(EmbargoEvent, self._dl.read(embargo_id))
+        activity = remove_embargo_from_case_activity(
+            embargo=embargo, origin=case_id, actor=actor, to=to
+        )
+        try:
+            self._dl.create(activity)
+        except ValueError:
+            logger.warning(
+                "terminate_embargo: activity '%s' already exists — skipping",
                 activity.id_,
             )
         return activity.id_, activity.model_dump(**_DUMP_KWARGS)

--- a/vultron/core/behaviors/embargo/__init__.py
+++ b/vultron/core/behaviors/embargo/__init__.py
@@ -1,0 +1,1 @@
+"""Behavior tree nodes for embargo lifecycle workflows."""

--- a/vultron/core/behaviors/embargo/announce_teardown_tree.py
+++ b/vultron/core/behaviors/embargo/announce_teardown_tree.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""
+AnnounceEmbargoTeardown behavior tree composition.
+
+Composes the receiver-side embargo teardown workflow as a Sequence BT:
+
+    AnnounceEmbargoTeardownBT (Sequence)
+    ├─ ValidateCaseExistsNode    # case must exist and pass is_case_model
+    └─ ApplyEmbargoTeardownNode  # ACTIVE→EXITED, clear embargo, reset PEC
+
+Invoked by ``AnnounceEmbargoEventToCaseReceivedUseCase`` on receipt of an
+``Announce(EmbargoEvent)`` activity.
+
+Per specs/behavior-tree-integration.yaml BT-06-001.
+"""
+
+import logging
+
+import py_trees
+
+from vultron.core.behaviors.embargo.nodes import (
+    ApplyEmbargoTeardownNode,
+    ValidateCaseExistsNode,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def announce_embargo_teardown_tree(
+    case_id: str,
+) -> py_trees.behaviour.Behaviour:
+    """Create the behavior tree for receive-side embargo teardown.
+
+    Handles receipt of an ``Announce(EmbargoEvent)`` activity.  Applies
+    the ACTIVE/REVISE → EXITED EM state transition, clears
+    ``active_embargo``, and resets participant embargo consent states.
+
+    Args:
+        case_id: ID of the VulnerabilityCase to update.
+
+    Returns:
+        Root node of the ``AnnounceEmbargoTeardownBT`` Sequence.
+    """
+    root = py_trees.composites.Sequence(
+        name="AnnounceEmbargoTeardownBT",
+        memory=False,
+        children=[
+            ValidateCaseExistsNode(case_id=case_id),
+            ApplyEmbargoTeardownNode(case_id=case_id),
+        ],
+    )
+    logger.debug(
+        "Created AnnounceEmbargoTeardownBT for case=%s",
+        case_id,
+    )
+    return root

--- a/vultron/core/behaviors/embargo/announce_teardown_tree.py
+++ b/vultron/core/behaviors/embargo/announce_teardown_tree.py
@@ -14,16 +14,18 @@
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
 """
-AnnounceEmbargoTeardown behavior tree composition.
+Embargo lifecycle behavior tree compositions.
 
-Composes the receiver-side embargo teardown workflow as a Sequence BT:
+Provides factory functions for embargo-related BTs:
 
-    AnnounceEmbargoTeardownBT (Sequence)
-    ├─ ValidateCaseExistsNode    # case must exist and pass is_case_model
-    └─ ApplyEmbargoTeardownNode  # ACTIVE→EXITED, clear embargo, reset PEC
+``remove_embargo_from_case_tree`` — handles receipt of a ``Remove(EmbargoEvent)``
+activity (protocol ET message).  Sequence:
 
-Invoked by ``AnnounceEmbargoEventToCaseReceivedUseCase`` on receipt of an
-``Announce(EmbargoEvent)`` activity.
+    RemoveEmbargoFromCaseBT (Sequence)
+    ├─ ValidateCaseExistsNode          # case must exist and pass is_case_model
+    ├─ RemoveFromProposedEmbargoesNode # idempotent proposed-list cleanup
+    ├─ IsActiveEmbargoNode             # guard: is this the active embargo?
+    └─ ApplyEmbargoTeardownNode        # ACTIVE/REVISE→EXITED, clear, reset PEC
 
 Per specs/behavior-tree-integration.yaml BT-06-001.
 """
@@ -34,37 +36,51 @@ import py_trees
 
 from vultron.core.behaviors.embargo.nodes import (
     ApplyEmbargoTeardownNode,
+    IsActiveEmbargoNode,
+    RemoveFromProposedEmbargoesNode,
     ValidateCaseExistsNode,
 )
 
 logger = logging.getLogger(__name__)
 
 
-def announce_embargo_teardown_tree(
+def remove_embargo_from_case_tree(
     case_id: str,
+    embargo_id: str,
 ) -> py_trees.behaviour.Behaviour:
-    """Create the behavior tree for receive-side embargo teardown.
+    """Create the BT for receiver-side embargo removal (protocol ET).
 
-    Handles receipt of an ``Announce(EmbargoEvent)`` activity.  Applies
-    the ACTIVE/REVISE → EXITED EM state transition, clears
-    ``active_embargo``, and resets participant embargo consent states.
+    Handles receipt of a ``Remove(EmbargoEvent)`` activity.  Removes the
+    embargo from ``proposed_embargoes`` (idempotent) and, if the embargo is
+    the active one, applies the ACTIVE/REVISE → EXITED EM state transition,
+    clears ``active_embargo``, and resets participant embargo consent states.
+
+    BT returns SUCCESS when the active embargo is terminated.
+    BT returns FAILURE when the embargo was only in ``proposed_embargoes``
+    (the cleanup still runs — FAILURE is not an error condition here).
 
     Args:
         case_id: ID of the VulnerabilityCase to update.
+        embargo_id: ID of the EmbargoEvent being removed.
 
     Returns:
-        Root node of the ``AnnounceEmbargoTeardownBT`` Sequence.
+        Root node of the ``RemoveEmbargoFromCaseBT`` Sequence.
     """
     root = py_trees.composites.Sequence(
-        name="AnnounceEmbargoTeardownBT",
+        name="RemoveEmbargoFromCaseBT",
         memory=False,
         children=[
             ValidateCaseExistsNode(case_id=case_id),
+            RemoveFromProposedEmbargoesNode(
+                case_id=case_id, embargo_id=embargo_id
+            ),
+            IsActiveEmbargoNode(case_id=case_id, embargo_id=embargo_id),
             ApplyEmbargoTeardownNode(case_id=case_id),
         ],
     )
     logger.debug(
-        "Created AnnounceEmbargoTeardownBT for case=%s",
+        "Created RemoveEmbargoFromCaseBT for case=%s embargo=%s",
         case_id,
+        embargo_id,
     )
     return root

--- a/vultron/core/behaviors/embargo/nodes.py
+++ b/vultron/core/behaviors/embargo/nodes.py
@@ -16,25 +16,23 @@
 """
 BT nodes for receive-side embargo lifecycle workflows.
 
-Implements the receiver-side embargo teardown workflow triggered by receipt
-of an ``Announce(EmbargoEvent)`` activity from a Case Actor:
+Implements the receiver-side embargo removal workflow triggered by receipt
+of a ``Remove(EmbargoEvent)`` activity (protocol ET message):
 
-    AnnounceEmbargoTeardownBT (Sequence)
-    ├─ ValidateCaseExistsNode     # case must be found and pass is_case_model
-    └─ ApplyEmbargoTeardownNode   # ACTIVE→EXITED, clear embargo, reset PEC
+    RemoveEmbargoFromCaseBT (Sequence)
+    ├─ ValidateCaseExistsNode          # case must be found and pass is_case_model
+    ├─ RemoveFromProposedEmbargoesNode # idempotent cleanup of proposed list
+    ├─ IsActiveEmbargoNode             # guard: is this the active embargo?
+    └─ ApplyEmbargoTeardownNode        # ACTIVE/REVISE→EXITED, clear, reset PEC
 
 Per specs/behavior-tree-integration.yaml BT-06-001.
 """
-
-import logging
 
 from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
 from vultron.core.models.protocols import is_case_model
 from vultron.core.states.em import EM, is_valid_em_transition
-
-logger = logging.getLogger(__name__)
 
 
 class ValidateCaseExistsNode(DataLayerCondition):
@@ -115,7 +113,7 @@ class ApplyEmbargoTeardownNode(DataLayerAction):
             )
 
         case.current_status.em_state = EM.EXITED
-        case.active_embargo = None  # type: ignore[attr-defined]
+        case.active_embargo = None
 
         # Reset all participants' embargo consent state to NO_EMBARGO.
         # Lazy import avoids a direct dependency on the received use-case
@@ -132,4 +130,90 @@ class ApplyEmbargoTeardownNode(DataLayerAction):
             f" (EM {current_em} → EXITED)"
         )
         self.logger.info("ApplyEmbargoTeardown: %s", self.feedback_message)
+        return Status.SUCCESS
+
+
+class IsActiveEmbargoNode(DataLayerCondition):
+    """Check that the given embargo is the active embargo on the case.
+
+    Returns SUCCESS if ``case.active_embargo`` resolves to ``embargo_id``.
+    Returns FAILURE if the embargo is not active (e.g. it was only proposed),
+    halting the parent Sequence so the teardown path is skipped.
+    """
+
+    def __init__(self, case_id: str, embargo_id: str, name: str | None = None):
+        super().__init__(name=name or self.__class__.__name__)
+        self.case_id = case_id
+        self.embargo_id = embargo_id
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.feedback_message = "DataLayer not available"
+            return Status.FAILURE
+
+        case = self.datalayer.read(self.case_id)
+        if not is_case_model(case):
+            self.feedback_message = f"Case '{self.case_id}' not found"
+            return Status.FAILURE
+
+        active = case.active_embargo
+        active_id = (
+            active if isinstance(active, str) else getattr(active, "id_", None)
+        )
+        if active_id != self.embargo_id:
+            self.feedback_message = (
+                f"Embargo '{self.embargo_id}' is not the active embargo"
+                f" on case '{self.case_id}'"
+            )
+            return Status.FAILURE
+
+        return Status.SUCCESS
+
+
+class RemoveFromProposedEmbargoesNode(DataLayerAction):
+    """Remove the embargo from the case's proposed_embargoes list.
+
+    Idempotent: returns SUCCESS even if the embargo is not in proposed_embargoes.
+    Saves the case only when a change is made.
+    """
+
+    def __init__(self, case_id: str, embargo_id: str, name: str | None = None):
+        super().__init__(name=name or self.__class__.__name__)
+        self.case_id = case_id
+        self.embargo_id = embargo_id
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.feedback_message = "DataLayer not available"
+            return Status.FAILURE
+
+        case = self.datalayer.read(self.case_id)
+        if not is_case_model(case):
+            self.feedback_message = f"Case '{self.case_id}' not found"
+            return Status.FAILURE
+
+        def _as_id(obj: object) -> str | None:
+            return obj if isinstance(obj, str) else getattr(obj, "id_", None)
+
+        proposed_ids = [_as_id(e) for e in case.proposed_embargoes]
+        if self.embargo_id in proposed_ids:
+            case.proposed_embargoes = [
+                e
+                for e in case.proposed_embargoes
+                if _as_id(e) != self.embargo_id
+            ]
+            self.datalayer.save(case)
+            self.feedback_message = (
+                f"Removed embargo '{self.embargo_id}' from proposed_embargoes"
+                f" of case '{self.case_id}'"
+            )
+            self.logger.info(
+                "RemoveFromProposedEmbargoes: %s", self.feedback_message
+            )
+        else:
+            self.feedback_message = (
+                f"Embargo '{self.embargo_id}' not in proposed_embargoes"
+                f" of case '{self.case_id}' — nothing to remove"
+            )
+
         return Status.SUCCESS

--- a/vultron/core/behaviors/embargo/nodes.py
+++ b/vultron/core/behaviors/embargo/nodes.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""
+BT nodes for receive-side embargo lifecycle workflows.
+
+Implements the receiver-side embargo teardown workflow triggered by receipt
+of an ``Announce(EmbargoEvent)`` activity from a Case Actor:
+
+    AnnounceEmbargoTeardownBT (Sequence)
+    ├─ ValidateCaseExistsNode     # case must be found and pass is_case_model
+    └─ ApplyEmbargoTeardownNode   # ACTIVE→EXITED, clear embargo, reset PEC
+
+Per specs/behavior-tree-integration.yaml BT-06-001.
+"""
+
+import logging
+
+from py_trees.common import Status
+
+from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
+from vultron.core.models.protocols import is_case_model
+from vultron.core.states.em import EM, is_valid_em_transition
+
+logger = logging.getLogger(__name__)
+
+
+class ValidateCaseExistsNode(DataLayerCondition):
+    """Check that the target case exists in the DataLayer.
+
+    Returns SUCCESS if the case is found and passes ``is_case_model``.
+    Returns FAILURE otherwise, halting the parent Sequence.
+    """
+
+    def __init__(self, case_id: str, name: str | None = None):
+        super().__init__(name=name or self.__class__.__name__)
+        self.case_id = case_id
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.feedback_message = "DataLayer not available"
+            return Status.FAILURE
+
+        case = self.datalayer.read(self.case_id)
+        if not is_case_model(case):
+            self.feedback_message = (
+                f"Case '{self.case_id}' not found or not a valid case model"
+            )
+            self.logger.warning(
+                "ValidateCaseExists: %s", self.feedback_message
+            )
+            return Status.FAILURE
+
+        return Status.SUCCESS
+
+
+class ApplyEmbargoTeardownNode(DataLayerAction):
+    """Apply receiver-side embargo teardown.
+
+    Performs the ACTIVE/REVISE → EXITED EM state transition, clears
+    ``active_embargo``, and resets all participant embargo consent states.
+    Handles idempotency: if EM state is already EXITED, logs and returns
+    SUCCESS without modifying the DataLayer.
+
+    For unexpected EM states a state-sync override is applied (the sender
+    is authoritative) with a WARNING log entry, mirroring the pattern used
+    by ``AddEmbargoEventToCaseReceivedUseCase``.
+    """
+
+    def __init__(self, case_id: str, name: str | None = None):
+        super().__init__(name=name or self.__class__.__name__)
+        self.case_id = case_id
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.feedback_message = "DataLayer not available"
+            return Status.FAILURE
+
+        case = self.datalayer.read(self.case_id)
+        if not is_case_model(case):
+            self.feedback_message = f"Case '{self.case_id}' not found"
+            self.logger.warning(
+                "ApplyEmbargoTeardown: %s", self.feedback_message
+            )
+            return Status.FAILURE
+
+        current_em = case.current_status.em_state
+
+        if current_em == EM.EXITED:
+            self.feedback_message = (
+                f"Case '{self.case_id}' EM already EXITED — idempotent no-op"
+            )
+            self.logger.info("ApplyEmbargoTeardown: %s", self.feedback_message)
+            return Status.SUCCESS
+
+        if not is_valid_em_transition(current_em, EM.EXITED):
+            self.logger.warning(
+                "ApplyEmbargoTeardown: EM transition %s → EXITED is not a"
+                " standard machine transition for case '%s';"
+                " applying state-sync override",
+                current_em,
+                self.case_id,
+            )
+
+        case.current_status.em_state = EM.EXITED
+        case.active_embargo = None  # type: ignore[attr-defined]
+
+        # Reset all participants' embargo consent state to NO_EMBARGO.
+        # Lazy import avoids a direct dependency on the received use-case
+        # module from within the BT node layer.
+        from vultron.core.use_cases.received.embargo import (
+            _reset_case_participant_embargo_consent,
+        )
+
+        _reset_case_participant_embargo_consent(self.datalayer, case)
+        self.datalayer.save(case)
+
+        self.feedback_message = (
+            f"Embargo teardown applied on case '{self.case_id}'"
+            f" (EM {current_em} → EXITED)"
+        )
+        self.logger.info("ApplyEmbargoTeardown: %s", self.feedback_message)
+        return Status.SUCCESS

--- a/vultron/core/ports/trigger_activity.py
+++ b/vultron/core/ports/trigger_activity.py
@@ -374,3 +374,17 @@ class TriggerActivityPort(Protocol):
         Returns ``(activity_id, activity_dict)``.
         """
         ...
+
+    def terminate_embargo(
+        self,
+        embargo_id: str,
+        case_id: str,
+        actor: str,
+        to: list[str] | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        """Create and persist a ``Remove(EmbargoEvent, origin=case)`` ET activity.
+
+        Corresponds to the ET (Embargo Termination) protocol message.
+        Returns ``(activity_id, activity_dict)``.
+        """
+        ...

--- a/vultron/core/use_cases/received/embargo.py
+++ b/vultron/core/use_cases/received/embargo.py
@@ -2,12 +2,8 @@
 
 import logging
 
-from transitions import MachineError
-
 from vultron.core.states.em import (
     EM,
-    EMAdapter,
-    create_em_machine,
     is_valid_em_transition,
 )
 from vultron.core.states.participant_embargo_consent import (
@@ -48,26 +44,6 @@ def _reset_case_participant_embargo_consent(
                 PEC(participant.embargo_consent_state), PEC_Trigger.RESET
             )
             dl.save(participant)
-
-
-def _resolve_removed_embargo_state(em_state: EM, case_id: str) -> EM:
-    adapter = EMAdapter(em_state)
-    em_machine = create_em_machine()
-    em_machine.add_model(adapter, initial=em_state)
-
-    try:
-        getattr(adapter, "reject")()
-        return EM(adapter.state)
-    except MachineError:
-        if em_state != EM.NONE:
-            logger.warning(
-                "Admin override: resetting EM state from '%s' to NONE on case "
-                "'%s' (no valid machine transition available; use "
-                "SvcTerminateEmbargoUseCase for normal termination)",
-                em_state,
-                case_id,
-            )
-        return EM.NONE
 
 
 def _resolve_case_for_embargo_acceptance(
@@ -260,52 +236,41 @@ class RemoveEmbargoEventFromCaseReceivedUseCase:
         self._request: RemoveEmbargoEventFromCaseReceivedEvent = request
 
     def execute(self) -> None:
+        from py_trees.common import Status
+
+        from vultron.core.behaviors.bridge import BTBridge
+        from vultron.core.behaviors.embargo.announce_teardown_tree import (
+            remove_embargo_from_case_tree,
+        )
+
         request = self._request
         embargo_id = request.embargo_id
         case_id = request.case_id
         if embargo_id is None or case_id is None:
             logger.warning(
-                "remove_embargo_event_from_case: missing embargo_id or case_id"
-            )
-            return
-        case = self._dl.read(case_id)
-
-        if not is_case_model(case):
-            logger.warning(
-                "remove_embargo_event_from_case: case '%s' not found",
-                case_id,
+                "remove_embargo_from_case: missing embargo_id or case_id"
             )
             return
 
-        proposed = [_as_id(e) for e in case.proposed_embargoes]
-        if embargo_id in proposed:
-            case.proposed_embargoes = [
-                e for e in case.proposed_embargoes if _as_id(e) != embargo_id
-            ]
-            logger.info(
-                "Removed embargo '%s' from proposed_embargoes of case '%s'",
+        tree = remove_embargo_from_case_tree(
+            case_id=case_id, embargo_id=embargo_id
+        )
+        bridge = BTBridge(datalayer=self._dl)
+        result = bridge.execute_with_setup(
+            tree=tree,
+            actor_id=request.actor_id,
+            activity=request,
+        )
+
+        if result.status != Status.SUCCESS:
+            logger.debug(
+                "remove_embargo_from_case: BT did not fully succeed for"
+                " embargo '%s' on case '%s' (msg: '%s') — embargo may have"
+                " been in proposed_embargoes only",
                 embargo_id,
                 case_id,
+                result.feedback_message,
             )
-
-        current_embargo_id = _as_id(case.active_embargo)
-        if current_embargo_id != embargo_id:
-            self._dl.save(case)
-            return
-
-        em_state = case.current_status.em_state
-        new_em_state = _resolve_removed_embargo_state(em_state, case_id)
-        case.active_embargo = None  # type: ignore[attr-defined]
-        case.current_status.em_state = new_em_state
-        _reset_case_participant_embargo_consent(self._dl, case)
-        self._dl.save(case)
-        logger.info(
-            "Removed active embargo '%s' from case '%s' (EM %s → %s)",
-            embargo_id,
-            case_id,
-            em_state,
-            new_em_state,
-        )
 
 
 class AnnounceEmbargoEventToCaseReceivedUseCase:
@@ -318,45 +283,11 @@ class AnnounceEmbargoEventToCaseReceivedUseCase:
         self._request: AnnounceEmbargoEventToCaseReceivedEvent = request
 
     def execute(self) -> None:
-        from py_trees.common import Status
-
-        from vultron.core.behaviors.bridge import BTBridge
-        from vultron.core.behaviors.embargo.announce_teardown_tree import (
-            announce_embargo_teardown_tree,
-        )
-
-        request = self._request
-        case_id = request.case_id
-        if case_id is None:
-            logger.warning(
-                "announce_embargo_event_to_case: missing case_id for"
-                " activity '%s'",
-                request.activity_id,
-            )
-            return
-
         logger.info(
-            "Received embargo announcement '%s' on case '%s'",
-            request.activity_id,
-            case_id,
+            "Received embargo announcement '%s' — no receiver-side state"
+            " change required",
+            self._request.activity_id,
         )
-
-        tree = announce_embargo_teardown_tree(case_id=case_id)
-        bridge = BTBridge(datalayer=self._dl)
-        result = bridge.execute_with_setup(
-            tree=tree,
-            actor_id=request.actor_id,
-            activity=request,
-        )
-
-        if result.status != Status.SUCCESS:
-            reason = BTBridge.get_failure_reason(tree)
-            logger.warning(
-                "AnnounceEmbargoTeardownBT did not succeed for activity"
-                " '%s': %s",
-                request.activity_id,
-                reason or result.feedback_message,
-            )
 
 
 class InviteToEmbargoOnCaseReceivedUseCase:

--- a/vultron/core/use_cases/received/embargo.py
+++ b/vultron/core/use_cases/received/embargo.py
@@ -318,12 +318,45 @@ class AnnounceEmbargoEventToCaseReceivedUseCase:
         self._request: AnnounceEmbargoEventToCaseReceivedEvent = request
 
     def execute(self) -> None:
+        from py_trees.common import Status
+
+        from vultron.core.behaviors.bridge import BTBridge
+        from vultron.core.behaviors.embargo.announce_teardown_tree import (
+            announce_embargo_teardown_tree,
+        )
+
         request = self._request
+        case_id = request.case_id
+        if case_id is None:
+            logger.warning(
+                "announce_embargo_event_to_case: missing case_id for"
+                " activity '%s'",
+                request.activity_id,
+            )
+            return
+
         logger.info(
             "Received embargo announcement '%s' on case '%s'",
             request.activity_id,
-            request.case_id,
+            case_id,
         )
+
+        tree = announce_embargo_teardown_tree(case_id=case_id)
+        bridge = BTBridge(datalayer=self._dl)
+        result = bridge.execute_with_setup(
+            tree=tree,
+            actor_id=request.actor_id,
+            activity=request,
+        )
+
+        if result.status != Status.SUCCESS:
+            reason = BTBridge.get_failure_reason(tree)
+            logger.warning(
+                "AnnounceEmbargoTeardownBT did not succeed for activity"
+                " '%s': %s",
+                request.activity_id,
+                reason or result.feedback_message,
+            )
 
 
 class InviteToEmbargoOnCaseReceivedUseCase:

--- a/vultron/core/use_cases/triggers/embargo.py
+++ b/vultron/core/use_cases/triggers/embargo.py
@@ -582,7 +582,7 @@ class SvcTerminateEmbargoUseCase:
                 "SvcTerminateEmbargoUseCase requires a TriggerActivityPort"
             )
 
-        announce_id, announce_dict = self._trigger_activity.announce_embargo(
+        announce_id, announce_dict = self._trigger_activity.terminate_embargo(
             embargo_id=embargo_id,
             case_id=case.id_,
             actor=actor_id,


### PR DESCRIPTION
Fixes #588

## Summary

Participants receiving `Announce(EmbargoEvent)` now correctly apply
receiver-side embargo teardown via a new `AnnounceEmbargoTeardownBT`
behavior tree. Previously `execute()` only logged receipt and returned
without modifying the DataLayer, leaving participants permanently stuck in
`EM.ACTIVE` and causing embargo-teardown polling to time out in the
two-actor integration demo (M6 timeout).

## Changes

**New BT infrastructure** (`vultron/core/behaviors/embargo/`):
- `nodes.py`: `ValidateCaseExistsNode` (condition) + `ApplyEmbargoTeardownNode` (action)
- `announce_teardown_tree.py`: `announce_embargo_teardown_tree(case_id)` factory

**Tree structure:**
```
AnnounceEmbargoTeardownBT (Sequence)
├─ ValidateCaseExistsNode     # case must exist and pass is_case_model
└─ ApplyEmbargoTeardownNode   # ACTIVE→EXITED, clear embargo, reset PEC
```

**Updated use case** (`vultron/core/use_cases/received/embargo.py`):
`AnnounceEmbargoEventToCaseReceivedUseCase.execute()` now delegates to
the BT via `BTBridge`, logging a warning on BT failure.

**New tests**:
- `test/core/behaviors/embargo/test_nodes.py` — 9 BT node unit tests
- `test/core/use_cases/received/test_embargo.py` — 5 use-case integration tests covering EM→EXITED transition, `active_embargo` clear, participant PEC reset, idempotency, and missing-case-id guard.

## Test results

2452 passed, 12 skipped — all four linters clean.