### PR TITLE
docs: ingest concern #593 — case actor outbound routing model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,6 +321,14 @@ Short entries are reproduced here; longer ones are referenced below.
 - **Invite Response Parsing Requires Recursive Rehydration** — see [notes/activitystreams-semantics.md](notes/activitystreams-semantics.md)
 - **Scenario Demos Must Puppeteer via Trigger Endpoints, Not Spoof Inboxes** — see [notes/event-driven-control-flow.md](notes/event-driven-control-flow.md)
 - **Role Taxonomies Must Not Leak Into Parameter Names** — When renaming a role concept (e.g., "finder" → "reporter"), search adapter and demo layers as well as core. Demo helpers often mirror public parameter names; leaving them behind creates naming inconsistency. See `notes/bugfix-workflow.md`.
+- **`case_addressees()` Is the Wrong Recipient for Participant Outbound Messages** — After
+  case creation, participant-originated activities MUST be addressed only to the Case Actor
+  (`CVDRole.CASE_MANAGER` participant's `attributed_to`), not to `case_addressees()`.
+  Using `case_addressees()` on the sender side bypasses the CaseActor and violates the
+  `participant → CaseActor → CaseLogEntry → broadcast → participants` model
+  (PCR-08-001, PCR-08-002). `case_addressees()` is correct only on the Case Actor's
+  **outbound fan-out** side (broadcasting to all participants). See
+  [notes/case-communication-model.md](notes/case-communication-model.md).
 - **Close Bugs With Evidence, Not Assumption** — see [notes/bt-integration.md](notes/bt-integration.md)
 - **Use `isinstance` for Pyright Attribute Narrowing, Not `# type: ignore`** — see [`vultron/core/AGENTS.md`](vultron/core/AGENTS.md)
 - **Untyped Closures Are Invisible to mypy — Extract to Named Functions** — see [`vultron/core/AGENTS.md`](vultron/core/AGENTS.md)

--- a/notes/README.md
+++ b/notes/README.md
@@ -224,6 +224,17 @@ lifecycle, pre-case event backfill, and multi-vendor action rules.
 embargo status transitions, adding `record_event()` calls, or debugging action
 rule filtering.
 
+**`case-communication-model.md`**
+Canonical communication model for post-case-creation participant messaging:
+all messages route through the Case Actor only
+(`participant → CaseActor → CaseLogEntry → broadcast → participants`). Covers
+the routing rule, its rationale, the `case_addressees()` antipattern, how to
+resolve the Case Actor ID, and the automatic `CaseLogEntry + broadcast`
+cascade. Normative requirements: `specs/participant-case-replica.yaml` PCR-08.
+**Load when**: implementing any trigger use case or BT that causes a
+participant to send a case-scoped message, debugging out-of-band note or
+embargo delivery, or auditing outbound activity addressing.
+
 **`case-log-authority.md`**
 Assertion recording model for report / proto-case / case flows: implicit
 participant assertions, `CaseActor`-authored `CaseLogEntry`, local audit log

--- a/notes/case-communication-model.md
+++ b/notes/case-communication-model.md
@@ -1,0 +1,202 @@
+---
+title: Case Communication Model
+status: active
+description: >
+  Canonical communication model for post-case-creation participant messaging:
+  all participant messages route through the Case Actor exclusively, and all
+  state updates propagate via CaseLogEntry broadcast. Captures the routing
+  rule, its rationale, common antipatterns, and BT implementation guidance.
+related_specs:
+  - specs/participant-case-replica.yaml
+  - specs/sync-log-replication.yaml
+  - specs/case-log-processing.yaml
+  - specs/case-management.yaml
+related_notes:
+  - notes/sync-log-replication.md
+  - notes/case-log-authority.md
+  - notes/event-driven-control-flow.md
+  - notes/participant-case-replica.md
+  - notes/two-actor-demo.md
+relevant_packages:
+  - vultron/core/use_cases/triggers
+  - vultron/core/use_cases/received
+  - vultron/core/behaviors/case
+  - vultron/core/behaviors/note
+---
+
+# Case Communication Model
+
+**Source**: 2026-05-21 grill-me session. Normative requirements: `PCR-08`.
+
+---
+
+## The Canonical Communication Flow
+
+Once a case is created and the Case Actor has been introduced to all
+participants, **all case-scoped participant messages MUST flow through
+the Case Actor exclusively**. The canonical flow is:
+
+```text
+Participant → Case Actor → CaseLogEntry → Announce(CaseLogEntry) → all Participants
+```
+
+No participant may send a case-scoped message directly to another
+participant. The Case Actor is the single intermediary and single writer
+of authoritative case history.
+
+### Three-Phase Breakdown
+
+1. **Participant → Case Actor**: The originating participant sends
+   `Add(Note)`, `Add(ParticipantStatus)`, `Offer(Embargo)`, or any other
+   case-scoped activity addressed **only** to the Case Actor
+   (`to: [case_actor_id]`).
+
+2. **Case Actor processes + commits**: On receipt, the Case Actor validates
+   the activity, updates local case state, and commits a `CaseLogEntry`
+   recording the outcome (accepted or rejected).
+
+3. **Automatic broadcast**: The `CaseLogEntry` commit automatically triggers
+   `Announce(CaseLogEntry)` to all case participants. This is the **only**
+   mechanism by which participants learn of accepted case-state changes.
+
+---
+
+## Scope: When Does This Rule Apply?
+
+| Phase | Rule |
+|---|---|
+| **Before case creation** | Finder sends `Offer(Report)` directly to Vendor — no Case Actor exists yet. This direct peer message is the **only** exception. |
+| **Case creation / bootstrap** | Vendor sends `Create(VulnerabilityCase)` to Finder to introduce the Case Actor. This is the trust-bootstrap handshake (one-time exception). |
+| **After case is active** | ALL subsequent messages from any participant go to the Case Actor only. No direct peer messaging. |
+
+---
+
+## Why This Model
+
+The Case Actor is the single writer of authoritative shared history
+(see `notes/case-log-authority.md`). If participants send messages
+directly to each other:
+
+- Content arrives outside the canonical log, so replicas cannot
+  be rebuilt deterministically from the log alone.
+- The hash chain is not authoritative because state-changing events
+  are not all recorded in it.
+- The Case Actor cannot enforce validation, reject malformed assertions,
+  or maintain consistent ordering.
+- Demo and protocol analysis become unreliable because the actual
+  message flow diverges from the specified model.
+
+---
+
+## Antipattern: `case_addressees()` as Recipient List
+
+`case_addressees(case, excluding_actor_id)` returns **all** actor IDs in
+the case participant index except the caller. Using this as the sole
+`to:` recipient list for outbound participant activities is incorrect
+after case creation:
+
+```python
+# ❌ WRONG — sends to all participants directly, bypassing Case Actor
+addressees = case_addressees(case, actor_id)   # [vendor, finder, case_actor]
+activity = add_note_to_case_activity(
+    note=note, target=case_id, actor=actor_id, to=addressees
+)
+```
+
+```python
+# ✅ CORRECT — send only to the Case Actor
+case_manager_id = _resolve_case_manager_id(case, dl)  # only the CASE_MANAGER actor
+activity = add_note_to_case_activity(
+    note=note, target=case_id, actor=actor_id, to=[case_manager_id]
+)
+```
+
+`case_addressees()` is still correct for the Case Actor's **outbound
+broadcast** (when the Case Actor fans out a `CaseLogEntry` to all
+participants). It is wrong on the **participant sender** side.
+
+---
+
+## Implementation: Resolving the Case Actor ID
+
+The Case Actor is the participant with `CVDRole.CASE_MANAGER`. To resolve
+its actor ID from a known case:
+
+```python
+from vultron.core.states.roles import CVDRole
+
+def _resolve_case_manager_id(case, dl) -> str | None:
+    for p_id in case.actor_participant_index.values():
+        p = dl.read(p_id)
+        roles = getattr(p, "case_roles", [])
+        if CVDRole.CASE_MANAGER in roles:
+            manager_actor_id = getattr(p, "attributed_to", None)
+            return str(manager_actor_id) if manager_actor_id else None
+    return None
+```
+
+This pattern already exists in `SvcAddParticipantStatusUseCase` (which
+correctly routes to the Case Actor only) and should be extracted as a
+shared helper used by all sender-side trigger use cases.
+
+---
+
+## Automatic CaseLogEntry + Broadcast Cascade
+
+Every Case Actor received-side handler that accepts a participant message
+MUST trigger the cascade automatically — not via a manual demo endpoint.
+The expected flow:
+
+1. Case Actor inbox receives participant activity.
+2. Case Actor's received-side use case (or BT) processes the assertion.
+3. On acceptance: `commit_log_entry()` → `_fan_out_log_entry()` (queues
+   `Announce(CaseLogEntry)` to all participants via Case Actor outbox).
+4. `OutboxMonitor` drains the Case Actor outbox → delivers to each
+   participant's inbox.
+5. Participant's `AnnounceVulnerabilityCaseReceivedUseCase` (or future
+   `AnnounceCaseLogEntryReceivedUseCase`) processes the entry and updates
+   the local replica.
+
+The `demo/demo_triggers.py` `sync-log-entry` endpoint exists only as a
+**test scaffold** for manually injecting log entries during demo
+verification. It MUST NOT be part of the normal message flow — the
+cascade must fire automatically as a consequence of any accepted
+participant message.
+
+---
+
+## BT Implementation Guidance
+
+Sender-side trigger use cases (`SvcAddNoteToCaseUseCase`,
+`SvcAddParticipantStatusUseCase`, embargo triggers, etc.) currently contain
+routing logic and activity-construction code that belongs in Behavior Trees.
+The correct architecture:
+
+```text
+TriggerUseCase.execute()
+  └── Sets blackboard context (actor_id, case_id, payload)
+  └── Ticks BT
+
+SenderBT (Sequence)
+  ├── ResolveCaseManagerNode      # looks up CASE_MANAGER actor ID
+  ├── ConstructActivityNode       # builds the AS2 activity addressed to Case Actor
+  └── QueueToOutboxNode           # adds to actor outbox
+```
+
+Until BTs are implemented, the interim fix is to ensure all trigger use
+cases use `_resolve_case_manager_id()` instead of `case_addressees()` as
+the recipient when building outbound participant activities.
+
+---
+
+## Known Implementation Gaps (as of 2026-05-21)
+
+| Gap | Location | Status |
+|---|---|---|
+| Notes trigger sends to all participants | `triggers/note.py:102` | Open — tracked in impl issues |
+| Embargo triggers send to all participants | `triggers/embargo.py:399,472,589,657,773` | Open |
+| Engage/defer-case triggers send to all participants | `triggers/case.py:84,132` | Open |
+| No sender-side BTs | All of the above | Open — BT refactor issue |
+| Auto CaseLogEntry cascade not wired to all received handlers | Multiple | Open |
+
+See GitHub issues under parent concern #593.

--- a/notes/case-communication-model.md
+++ b/notes/case-communication-model.md
@@ -97,7 +97,7 @@ after case creation:
 
 ```python
 # ❌ WRONG — sends to all participants directly, bypassing Case Actor
-addressees = case_addressees(case, actor_id)   # [vendor, finder, case_actor]
+addressees = case_addressees(case, actor_id)   # [vendor, finder]  (excludes caller)
 activity = add_note_to_case_activity(
     note=note, target=case_id, actor=actor_id, to=addressees
 )
@@ -153,11 +153,11 @@ The expected flow:
    `Announce(CaseLogEntry)` to all participants via Case Actor outbox).
 4. `OutboxMonitor` drains the Case Actor outbox → delivers to each
    participant's inbox.
-5. Participant's `AnnounceVulnerabilityCaseReceivedUseCase` (or future
-   `AnnounceCaseLogEntryReceivedUseCase`) processes the entry and updates
-   the local replica.
+5. Participant's `AnnounceLogEntryReceivedUseCase` (`received/sync.py`)
+   processes the entry and updates the local replica.
 
-The `demo/demo_triggers.py` `sync-log-entry` endpoint exists only as a
+The `vultron/adapters/driving/fastapi/routers/demo_triggers.py`
+`sync-log-entry` endpoint exists only as a
 **test scaffold** for manually injecting log entries during demo
 verification. It MUST NOT be part of the normal message flow — the
 cascade must fire automatically as a consequence of any accepted

--- a/plan/history/2605/README.md
+++ b/plan/history/2605/README.md
@@ -4,6 +4,7 @@
 
 | Date | Time (UTC) | Type | Source | Title |
 |------|------------|------|--------|-------|
+| 2026-05-21 | 16:33 | learning | CONCERN-593 | Case Actor outbound routing model |
 | 2026-05-21 | 14:58 | implementation | ISSUE-570 | Demo CI: GitHub Actions integration workflow + demo runner hardening |
 | 2026-05-20 | 13:54 | idea | IDEA-582 | Optimize linkchecker.yml: separate build-site and link-check triggers |
 | 2026-05-20 | 13:31 | implementation | ISSUE-576 | AGENTS.md per-directory files + root condensed to 398 lines |

--- a/plan/history/2605/learning/CONCERN-593.md
+++ b/plan/history/2605/learning/CONCERN-593.md
@@ -1,0 +1,62 @@
+---
+source: CONCERN-593
+timestamp: '2026-05-21T16:33:14.215677+00:00'
+title: Case Actor outbound routing model
+type: learning
+---
+
+## Concern #593 — Case Actor Outbound Routing Model
+
+**Category**: Architecture / Protocol Correctness
+**Severity**: High
+**Affected areas**: `vultron/core/use_cases/triggers/note.py`,
+`vultron/core/use_cases/triggers/embargo.py`,
+`vultron/core/use_cases/triggers/case.py`
+
+### Root Cause
+
+Sender-side trigger use cases (`SvcAddNoteToCaseUseCase`, embargo triggers,
+`SvcEngageCaseUseCase`, `SvcDeferCaseUseCase`) use `case_addressees()` to
+address outbound activities. This function returns ALL participants in the case
+excluding the caller, causing participant-originated messages to be delivered
+directly to all peers rather than routing exclusively through the Case Actor.
+
+This violates the canonical CVD communication model:
+
+```text
+participant → CaseActor → CaseLogEntry → Announce(CaseLogEntry) → participants
+```
+
+The only correct use of `case_addressees()` is on the Case Actor's outbound
+fan-out side (broadcasting `Announce(CaseLogEntry)` to all participants).
+
+### Impact
+
+- Demo and protocol flows show incorrect peer-to-peer communication after case
+  creation
+- Case Actor is bypassed, so CaseLogEntry commits and Announce broadcasts do
+  not occur for most protocol messages
+- The `sync-log-entry` demo endpoint masks the problem by manually injecting
+  entries as a workaround
+
+### Fix Plan
+
+Three implementation issues created:
+
+- #594 (size:M): Fix outbound routing in all trigger use cases — replace
+  `case_addressees()` with the Case Actor ID (CVDRole.CASE_MANAGER participant)
+- #595 (size:M): Implement automatic CaseLogEntry + Announce broadcast cascade
+  in all Case Actor received handlers — blocked by #594
+- #596 (size:L): Refactor sender-side trigger use cases into Behavior Trees —
+  blocked by #594
+
+### Documentation
+
+- Added PCR-08 requirement group to `specs/participant-case-replica.yaml`
+  (6 requirements, PCR-08-001 through PCR-08-006)
+- Created `notes/case-communication-model.md` with the canonical communication
+  model, scope table, antipattern analysis, and known gaps
+- Added `case_addressees()` antipattern pitfall entry to `AGENTS.md`
+
+**Resolved**: 2025-07-14 — implementation tracked in #594, #595, #596.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/597>.

--- a/specs/participant-case-replica.yaml
+++ b/specs/participant-case-replica.yaml
@@ -180,6 +180,49 @@ groups:
     relationships:
     - rel_type: refines
       spec_id: PCR-06-002
+- id: PCR-08
+  title: Outbound Participant Message Routing
+  specs:
+  - id: PCR-08-001
+    priority: MUST
+    statement: >-
+      After a case is created and the Case Actor is introduced, a participant actor MUST address
+      all case-scoped outbound messages (notes, status updates, embargo proposals, RM transitions,
+      and any other protocol messages targeting the case) exclusively to the Case Actor for that
+      case. A participant actor MUST NOT send these messages directly to other participants.
+  - id: PCR-08-002
+    priority: MUST_NOT
+    statement: >-
+      A participant actor MUST NOT assume that other participants will receive its case-scoped
+      messages through any channel other than the Case Actor's `Announce(CaseLogEntry)` broadcast.
+      Sending to `case_addressees()` or any multi-recipient list that includes non-CaseActor actors
+      is a violation of this rule.
+  - id: PCR-08-003
+    priority: MUST
+    statement: >-
+      The Case Actor MUST, for every participant message it receives and accepts, commit a
+      `CaseLogEntry` recording the outcome and broadcast `Announce(CaseLogEntry)` to all case
+      participants as the standard cascade. This cascade is the only mechanism by which participants
+      learn of accepted case-state changes.
+  - id: PCR-08-004
+    priority: MUST_NOT
+    statement: >-
+      The `CaseLogEntry + broadcast` cascade MUST NOT be manually triggered by demo scripts or
+      external clients. It MUST fire automatically as a consequence of the Case Actor processing
+      any accepted participant message, not only via explicit demo endpoint invocation.
+  - id: PCR-08-005
+    priority: MUST
+    statement: >-
+      Trigger use cases and their supporting BTs that cause a participant to send a case-scoped
+      message MUST resolve the Case Actor's actor ID from the case's participant list (the
+      participant with `CVDRole.CASE_MANAGER`) and use that ID as the sole `to:` recipient.
+      Any helper that returns all participants (e.g. `case_addressees()`) MUST NOT be used as
+      the sole source of recipients for outbound participant activities.
+  - id: PCR-08-006
+    priority: MUST
+    statement: >-
+      Unit and integration tests MUST verify that a participant's outbound activity is addressed
+      only to the Case Actor, and that no direct peer-to-peer delivery is attempted.
 - id: PCR-07
   title: Testing
   specs:


### PR DESCRIPTION
Docs-only PR: addresses concern #593 at the spec/notes level.
Implementation tracked in #594, #595, #596.

**Changes:**
- `specs/participant-case-replica.yaml`: Added PCR-08 requirement group
  (6 requirements for outbound participant message routing through Case Actor)
- `notes/case-communication-model.md`: New canonical design note for the
  `participant → CaseActor → CaseLogEntry → broadcast → participants` model
- `notes/README.md`: Added index entry for case-communication-model.md
- `AGENTS.md`: Added `case_addressees()` antipattern pitfall entry

Ref #593

No .py files changed.