### PR TITLE
fix: participant trigger use cases address Case Actor only (PCR-08-001)

### DIFF
--- a/plan/history/2605/README.md
+++ b/plan/history/2605/README.md
@@ -5,6 +5,7 @@
 | Date | Time (UTC) | Type | Source | Title |
 |------|------------|------|--------|-------|
 | 2026-05-21 | 19:19 | implementation | 610 | Fix DataLayer and actors endpoints for HTTP URL keys (#610) |
+| 2026-05-21 | 18:10 | implementation | ISSUE-594 | Fix outbound routing: participant triggers address Case Actor only |
 | 2026-05-21 | 16:33 | learning | CONCERN-593 | Case Actor outbound routing model |
 | 2026-05-21 | 14:58 | implementation | ISSUE-570 | Demo CI: GitHub Actions integration workflow + demo runner hardening |
 | 2026-05-20 | 13:54 | idea | IDEA-582 | Optimize linkchecker.yml: separate build-site and link-check triggers |

--- a/plan/history/2605/implementation/ISSUE-594.md
+++ b/plan/history/2605/implementation/ISSUE-594.md
@@ -1,0 +1,33 @@
+---
+source: ISSUE-594
+timestamp: '2026-05-21T18:10:30.921129+00:00'
+title: 'Fix outbound routing: participant triggers address Case Actor only'
+type: implementation
+---
+
+## Issue #594 — Fix outbound routing: participant trigger use cases must address Case Actor only, not all participants
+
+All post-case-creation participant-originated trigger use cases were using
+`case_addressees()` to address outbound activities, delivering them directly
+to ALL participants instead of routing exclusively through the Case Actor.
+This violated the canonical communication model (PCR-08-001, PCR-08-002):
+`participant → CaseActor → CaseLogEntry → broadcast → participants`.
+
+### Changes
+
+- Extracted `_resolve_case_manager_id(case, dl) -> str | None` as a shared
+  helper in `vultron/core/use_cases/_helpers.py`. Resolves the actor ID of
+  the `CVDRole.CASE_MANAGER` participant; includes null-check for orphaned
+  participant references.
+- Fixed `SvcAddNoteToCaseUseCase` (`triggers/note.py`)
+- Fixed `SvcEngageCaseUseCase`, `SvcDeferCaseUseCase` (`triggers/case.py`)
+- Fixed `SvcProposeEmbargoUseCase`, `SvcAcceptEmbargoUseCase`,
+  `SvcTerminateEmbargoUseCase`, `SvcRejectEmbargoUseCase`,
+  `SvcProposeEmbargoRevisionUseCase` (`triggers/embargo.py`)
+- Refactored `SvcAddParticipantStatusUseCase` to use the shared helper
+  instead of inline loop
+- Updated `test_note_trigger.py` and `test_trignotify.py` with proper
+  `CaseParticipant(case_roles=[CVDRole.CASE_MANAGER])` setup and
+  assertions that `to == [case_actor_id]`
+
+PR: [#616](https://github.com/CERTCC/Vultron/pull/616)

--- a/test/adapters/driving/fastapi/routers/test_demo_triggers.py
+++ b/test/adapters/driving/fastapi/routers/test_demo_triggers.py
@@ -99,7 +99,15 @@ def dl(actor_and_dl):
 
 @pytest.fixture
 def client_demo(dl):
-    """Test client with only the demo router mounted."""
+    """Test client with only the demo router mounted.
+
+    Patches ``get_default_emitter`` with a no-op ``AsyncMock`` so that the
+    ``outbox_handler`` background task completes immediately without making
+    real HTTP delivery attempts (which would add retry-backoff delays and
+    exceed the CI per-test timeout).
+    """
+    from unittest.mock import AsyncMock, patch
+
     from vultron.adapters.driven.sync_activity_adapter import (
         SyncActivityAdapter,
     )
@@ -113,7 +121,12 @@ def client_demo(dl):
     )
     app.dependency_overrides[get_trigger_dl] = lambda: dl
     app.dependency_overrides[get_canonical_actor_dl] = lambda: dl
-    yield TestClient(app)
+    mock_emitter = AsyncMock()
+    with patch(
+        "vultron.adapters.driving.fastapi.outbox_handler.get_default_emitter",
+        return_value=mock_emitter,
+    ):
+        yield TestClient(app)
     app.dependency_overrides = {}
 
 

--- a/test/adapters/driving/fastapi/routers/test_demo_triggers.py
+++ b/test/adapters/driving/fastapi/routers/test_demo_triggers.py
@@ -40,9 +40,26 @@ from vultron.core.use_cases.triggers.service import TriggerService
 from vultron.adapters.driven.trigger_activity_adapter import (
     TriggerActivityAdapter,
 )
+from vultron.core.states.roles import CVDRole
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+
+
+def _add_case_manager(case: VulnerabilityCase, dl) -> as_Service:
+    """Add a CASE_MANAGER participant to *case* and return the case actor."""
+    case_actor = as_Service(name=f"Case Actor for {case.name}")
+    dl.create(case_actor)
+    cm_participant = CaseParticipant(
+        attributed_to=case_actor.id_,
+        context=case.id_,
+        case_roles=[CVDRole.CASE_MANAGER],
+    )
+    dl.create(cm_participant)
+    case.actor_participant_index[case_actor.id_] = cm_participant.id_
+    dl.save(case)
+    return case_actor
+
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -126,6 +143,7 @@ def case_with_actor(dl, actor):
     case_obj.actor_participant_index[actor.id_] = participant.id_
     dl.create(case_obj)
     dl.create(participant)
+    _add_case_manager(case_obj, dl)
     return case_obj
 
 

--- a/test/adapters/driving/fastapi/routers/test_trigger_case.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_case.py
@@ -38,9 +38,30 @@ from vultron.adapters.driven.trigger_activity_adapter import (
 )
 from vultron.adapters.utils import parse_id
 from vultron.core.states.rm import RM
+from vultron.core.states.roles import CVDRole
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _add_case_manager(case: VulnerabilityCase, dl) -> as_Service:
+    """Add a CASE_MANAGER participant to *case* and return the case actor."""
+    case_actor = as_Service(name=f"Case Actor for {case.name}")
+    dl.create(case_actor)
+    cm_participant = CaseParticipant(
+        attributed_to=case_actor.id_,
+        context=case.id_,
+        case_roles=[CVDRole.CASE_MANAGER],
+    )
+    dl.create(cm_participant)
+    case.actor_participant_index[case_actor.id_] = cm_participant.id_
+    dl.save(case)
+    return case_actor
+
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -119,14 +140,16 @@ def case_with_participant(dl, actor):
     case_obj.case_participants.append(participant.id_)
     dl.create(case_obj)
     dl.create(participant)
+    _add_case_manager(case_obj, dl)
     return case_obj
 
 
 @pytest.fixture
 def case_without_participant(dl):
-    """Create a VulnerabilityCase with no CaseParticipant for the actor."""
+    """Create a VulnerabilityCase with a Case Manager but no participant for the actor."""
     case_obj = VulnerabilityCase(name="TEST-CASE-NO-PARTICIPANT")
     dl.create(case_obj)
+    _add_case_manager(case_obj, dl)
     return case_obj
 
 

--- a/test/adapters/driving/fastapi/routers/test_trigger_embargo.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_embargo.py
@@ -39,11 +39,29 @@ from vultron.adapters.driven.trigger_activity_adapter import (
 )
 from vultron.wire.as2.factories import em_propose_embargo_activity
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
+from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
 from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
 from vultron.core.states.em import EM
+from vultron.core.states.roles import CVDRole
 
 FUTURE_END_TIME = "2099-12-01T00:00:00Z"
+
+
+def _add_case_manager(case: VulnerabilityCase, dl) -> as_Service:
+    """Add a CASE_MANAGER participant to *case* and return the case actor."""
+    case_actor = as_Service(name=f"Case Actor for {case.name}")
+    dl.create(case_actor)
+    cm_participant = CaseParticipant(
+        attributed_to=case_actor.id_,
+        context=case.id_,
+        case_roles=[CVDRole.CASE_MANAGER],
+    )
+    dl.create(cm_participant)
+    case.actor_participant_index[case_actor.id_] = cm_participant.id_
+    dl.save(case)
+    return case_actor
+
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -103,9 +121,10 @@ def client_triggers(dl):
 
 @pytest.fixture
 def case_without_participant(dl):
-    """Create a VulnerabilityCase with no CaseParticipant for the actor."""
+    """A VulnerabilityCase with a Case Manager but no participant for the actor."""
     case_obj = VulnerabilityCase(name="TEST-CASE-NO-PARTICIPANT")
     dl.create(case_obj)
+    _add_case_manager(case_obj, dl)
     return case_obj
 
 
@@ -118,6 +137,7 @@ def case_with_embargo(dl, actor):
     case_obj.set_embargo(embargo.id_)
     case_obj.current_status.em_state = EM.ACTIVE
     dl.create(case_obj)
+    _add_case_manager(case_obj, dl)
     return case_obj, embargo
 
 
@@ -134,6 +154,7 @@ def case_with_proposal(dl, actor):
     case_obj.current_status.em_state = EM.PROPOSED
     case_obj.proposed_embargoes.append(embargo.id_)
     dl.create(case_obj)
+    _add_case_manager(case_obj, dl)
     return case_obj, proposal, embargo
 
 

--- a/test/core/use_cases/received/test_embargo.py
+++ b/test/core/use_cases/received/test_embargo.py
@@ -593,6 +593,7 @@ class TestEmbargoUseCases:
         )
         from vultron.wire.as2.vocab.base.objects.actors import (
             as_Actor as Actor,
+            as_Service,
         )
 
         dl = SqliteDataLayer("sqlite:///:memory:")
@@ -622,6 +623,27 @@ class TestEmbargoUseCases:
         dl.create(case)
         dl.create(embargo)
         dl.create(proposal)
+
+        # Add a Case Manager participant so routing proceeds to the
+        # EM-state validation check (the test's actual assertion target).
+        from vultron.core.states.roles import CVDRole
+        from vultron.wire.as2.vocab.objects.case_participant import (
+            CaseParticipant as CP,
+        )
+
+        case_actor = as_Service(
+            id_="https://example.org/actors/case-manager",
+            name="Case Manager",
+        )
+        dl.create(case_actor)
+        cm_p = CP(
+            attributed_to=case_actor.id_,
+            context=case.id_,
+            case_roles=[CVDRole.CASE_MANAGER],
+        )
+        dl.create(cm_p)
+        case.actor_participant_index[case_actor.id_] = cm_p.id_
+        dl.save(case)
 
         request = AcceptEmbargoTriggerRequest(
             actor_id=actor.id_,

--- a/test/core/use_cases/triggers/test_embargo.py
+++ b/test/core/use_cases/triggers/test_embargo.py
@@ -11,6 +11,7 @@ from vultron.adapters.driven.datalayer_sqlite import (
 )
 from vultron.core.states.em import EM
 from vultron.core.states.participant_embargo_consent import PEC
+from vultron.core.states.roles import CVDRole
 from vultron.core.use_cases.triggers.embargo import (
     SvcAcceptEmbargoUseCase,
     SvcRejectEmbargoUseCase,
@@ -58,6 +59,7 @@ def _build_active_embargo_case(
         embargo_consent_state=PEC.SIGNATORY.value,
         accepted_embargo_ids=[embargo.id_],
     )
+    owner_participant.add_role(CVDRole.CASE_MANAGER)
     participant = FinderParticipant(
         attributed_to=participant_id,
         context=case.id_,

--- a/test/core/use_cases/triggers/test_note_trigger.py
+++ b/test/core/use_cases/triggers/test_note_trigger.py
@@ -36,6 +36,7 @@ from vultron.core.use_cases.triggers.note import SvcAddNoteToCaseUseCase
 from vultron.core.use_cases.triggers.requests import (
     AddNoteToCaseTriggerRequest,
 )
+from vultron.errors import VultronValidationError
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.objects.case_participant import (
     CaseParticipant,
@@ -275,8 +276,8 @@ class TestSvcAddNoteToCaseUseCase:
             self.vendor.id_ not in recipients
         ), "Actor must not address themselves"
 
-    def test_to_field_is_none_when_no_case_manager(self):
-        """to is None when the case has no CASE_MANAGER participant."""
+    def test_raises_when_no_case_manager(self):
+        """SvcAddNoteToCaseUseCase raises VultronValidationError when no CASE_MANAGER."""
         solo_case = VulnerabilityCase(name="No Manager Case")
         solo_case.actor_participant_index[self.vendor.id_] = (
             f"{solo_case.id_}/participants/vendor"
@@ -289,17 +290,12 @@ class TestSvcAddNoteToCaseUseCase:
             note_name=self.NOTE_NAME,
             note_content=self.NOTE_CONTENT,
         )
-        result = SvcAddNoteToCaseUseCase(
-            self.dl, request, trigger_activity=TriggerActivityAdapter(self.dl)
-        ).execute()
-
-        activity_id = result["activity"].get("id")
-        act_obj = self.dl.read(activity_id)
-        recipients = _to_field(act_obj)
-
-        assert (
-            not recipients
-        ), "to should be empty/None when no Case Manager exists"
+        with pytest.raises(VultronValidationError):
+            SvcAddNoteToCaseUseCase(
+                self.dl,
+                request,
+                trigger_activity=TriggerActivityAdapter(self.dl),
+            ).execute()
 
     # ------------------------------------------------------------------
     # Optional in_reply_to field

--- a/test/core/use_cases/triggers/test_note_trigger.py
+++ b/test/core/use_cases/triggers/test_note_trigger.py
@@ -14,13 +14,14 @@
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
 """
-Tests for SvcAddNoteToCaseUseCase (D5-7-DEMONOTECLEAN-1).
+Tests for SvcAddNoteToCaseUseCase.
 
 Verifies that the add-note-to-case trigger:
 - creates the note in the DataLayer,
 - adds the note ID to the actor's local case.notes list,
 - queues Create(Note) and AddNoteToCase activities in the actor's outbox,
-- populates the ``to`` field with case participants (excluding the actor),
+- addresses the Add(Note) activity only to the Case Actor (PCR-08-001),
+- does NOT address any non-CaseActor participant directly,
 - handles the optional in_reply_to field correctly.
 """
 
@@ -30,18 +31,23 @@ from vultron.adapters.driven.datalayer_sqlite import (
     SqliteDataLayer,
     reset_datalayer,
 )
+from vultron.core.states.roles import CVDRole
 from vultron.core.use_cases.triggers.note import SvcAddNoteToCaseUseCase
 from vultron.core.use_cases.triggers.requests import (
     AddNoteToCaseTriggerRequest,
 )
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
+from vultron.wire.as2.vocab.objects.case_participant import (
+    CaseParticipant,
+    FinderParticipant,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
 from vultron.adapters.driven.trigger_activity_adapter import (
     TriggerActivityAdapter,
 )
 
 # ---------------------------------------------------------------------------
-# Helpers (mirrors pattern in test_trignotify.py)
+# Helpers
 # ---------------------------------------------------------------------------
 
 
@@ -56,15 +62,43 @@ def _make_actor_dl(actor_name: str):
     return actor, dl
 
 
-def _make_two_actor_case(
-    dl, actor1_id: str, actor2_id: str
-) -> VulnerabilityCase:
-    """Create a VulnerabilityCase with two actors in actor_participant_index."""
+def _make_case_with_case_manager(
+    dl: SqliteDataLayer,
+    actor_id: str,
+    finder_id: str,
+    case_actor_id: str,
+) -> tuple[VulnerabilityCase, CaseParticipant]:
+    """Create a VulnerabilityCase with a Finder participant and a Case Actor
+    participant (CVDRole.CASE_MANAGER).
+
+    Returns the case and the Case Manager CaseParticipant.
+    """
     case = VulnerabilityCase(name="Test Case")
-    case.actor_participant_index[actor1_id] = f"{case.id_}/participants/actor1"
-    case.actor_participant_index[actor2_id] = f"{case.id_}/participants/actor2"
+
+    finder_participant = FinderParticipant(
+        attributed_to=finder_id,
+        context=case.id_,
+    )
+    case_manager_participant = CaseParticipant(
+        attributed_to=case_actor_id,
+        context=case.id_,
+        case_roles=[CVDRole.CASE_MANAGER],
+    )
+    actor_participant = CaseParticipant(
+        attributed_to=actor_id,
+        context=case.id_,
+        case_roles=[CVDRole.VENDOR],
+    )
+
+    case.actor_participant_index[actor_id] = actor_participant.id_
+    case.actor_participant_index[finder_id] = finder_participant.id_
+    case.actor_participant_index[case_actor_id] = case_manager_participant.id_
+
     dl.create(case)
-    return case
+    dl.create(finder_participant)
+    dl.create(case_manager_participant)
+    dl.create(actor_participant)
+    return case, case_manager_participant
 
 
 def _to_field(activity_obj) -> list[str] | None:
@@ -86,9 +120,6 @@ def _to_field(activity_obj) -> list[str] | None:
 
 def _outbox_activity_ids(actor_id: str, dl: SqliteDataLayer) -> list[str]:
     """Return all activity IDs in the actor's outbox."""
-    # Create a scoped view sharing dl's engine.  The temporary in-memory
-    # engine allocated by __init__ is disposed immediately before being
-    # replaced, so no sqlite3 connection leaks.
     scoped = SqliteDataLayer("sqlite:///:memory:", actor_id=actor_id)
     scoped._engine.dispose()
     scoped._engine = dl._engine
@@ -111,13 +142,20 @@ class TestSvcAddNoteToCaseUseCase:
     def setup(self):
         self.vendor, self.dl = _make_actor_dl("Vendor Co")
         self.finder, _ = _make_actor_dl("Finder Co")
-        self.case = _make_two_actor_case(
-            self.dl, self.vendor.id_, self.finder.id_
+        self.case_actor, _ = _make_actor_dl("Case Actor")
+        self.case, self.case_manager_participant = (
+            _make_case_with_case_manager(
+                self.dl,
+                self.vendor.id_,
+                self.finder.id_,
+                self.case_actor.id_,
+            )
         )
         yield
         self.dl.clear_all()
         reset_datalayer(self.vendor.id_)
         reset_datalayer(self.finder.id_)
+        reset_datalayer(self.case_actor.id_)
 
     def _execute(self, actor_id=None, in_reply_to=None):
         """Build and execute the use case; return the result dict."""
@@ -198,11 +236,11 @@ class TestSvcAddNoteToCaseUseCase:
             assert self.dl.read(activity_id) is not None
 
     # ------------------------------------------------------------------
-    # ``to`` field population
+    # ``to`` field: must address Case Actor only (PCR-08-001)
     # ------------------------------------------------------------------
 
-    def test_add_note_activity_to_field_contains_other_participant(self):
-        """AddNoteToCase activity has to=[finder.id_] (excludes the actor)."""
+    def test_add_note_activity_to_field_addresses_case_actor_only(self):
+        """AddNoteToCase activity has to=[case_actor.id_] (PCR-08-001)."""
         result = self._execute(actor_id=self.vendor.id_)
         activity_id = result["activity"].get("id")
         assert activity_id is not None
@@ -211,13 +249,35 @@ class TestSvcAddNoteToCaseUseCase:
         recipients = _to_field(act_obj)
 
         assert recipients is not None, "to field must not be None"
-        assert len(recipients) > 0, "to field must be non-empty"
-        assert self.finder.id_ in recipients
-        assert self.vendor.id_ not in recipients
+        assert len(recipients) == 1, (
+            f"Expected exactly 1 recipient, got {len(recipients)}: "
+            f"{recipients}"
+        )
+        assert recipients[0] == self.case_actor.id_, (
+            f"Expected Case Actor '{self.case_actor.id_}' as sole recipient, "
+            f"got {recipients}"
+        )
 
-    def test_to_field_is_none_when_actor_is_only_participant(self):
-        """to is empty/None when the actor is the sole case participant."""
-        solo_case = VulnerabilityCase(name="Solo Case")
+    def test_add_note_activity_does_not_address_non_case_actor_participants(
+        self,
+    ):
+        """AddNoteToCase must not include finder or vendor in the to field."""
+        result = self._execute(actor_id=self.vendor.id_)
+        activity_id = result["activity"].get("id")
+        act_obj = self.dl.read(activity_id)
+        recipients = _to_field(act_obj) or []
+
+        assert self.finder.id_ not in recipients, (
+            "Finder must not be directly addressed — routing goes through"
+            " Case Actor"
+        )
+        assert (
+            self.vendor.id_ not in recipients
+        ), "Actor must not address themselves"
+
+    def test_to_field_is_none_when_no_case_manager(self):
+        """to is None when the case has no CASE_MANAGER participant."""
+        solo_case = VulnerabilityCase(name="No Manager Case")
         solo_case.actor_participant_index[self.vendor.id_] = (
             f"{solo_case.id_}/participants/vendor"
         )
@@ -239,7 +299,7 @@ class TestSvcAddNoteToCaseUseCase:
 
         assert (
             not recipients
-        ), "to should be empty/None for solo-participant case"
+        ), "to should be empty/None when no Case Manager exists"
 
     # ------------------------------------------------------------------
     # Optional in_reply_to field
@@ -254,7 +314,6 @@ class TestSvcAddNoteToCaseUseCase:
 
     def test_in_reply_to_set_when_provided(self):
         """Note carries the supplied in_reply_to value."""
-        # Create a parent note to reply to.
         from vultron.wire.as2.vocab.base.objects.object_types import as_Note
 
         parent = as_Note(
@@ -275,13 +334,9 @@ class TestSvcAddNoteToCaseUseCase:
 
     def test_duplicate_execute_does_not_duplicate_note_in_case(self):
         """Calling execute() twice with the same note does not add it twice."""
-        # We need to execute the same request twice — reuse _execute(), which
-        # creates a new note each time (different IDs). Test the idempotency
-        # guard for note IDs already in case.notes instead.
         result = self._execute()
         note_id = result["note"]["id"]
 
-        # Manually call the idempotency guard path by appending note_id again.
         case_obj = self.dl.read(self.case.id_)
         assert isinstance(case_obj, VulnerabilityCase)
         count_before = sum(
@@ -292,7 +347,6 @@ class TestSvcAddNoteToCaseUseCase:
         )
         assert count_before == 1
 
-        # Simulate a second save attempt via the use case guard logic.
         existing_ids = [
             n if isinstance(n, str) else getattr(n, "id_", str(n))
             for n in case_obj.notes
@@ -301,7 +355,6 @@ class TestSvcAddNoteToCaseUseCase:
             case_obj.notes.append(note_id)
             self.dl.save(case_obj)
 
-        # Re-read and confirm still exactly one occurrence.
         case_obj2 = self.dl.read(self.case.id_)
         assert isinstance(case_obj2, VulnerabilityCase)
         count_after = sum(

--- a/test/core/use_cases/triggers/test_service.py
+++ b/test/core/use_cases/triggers/test_service.py
@@ -44,6 +44,7 @@ from vultron.core.models.participant_status import VultronParticipantStatus
 from vultron.core.use_cases._helpers import _report_phase_status_id
 from vultron.core.states.em import EM
 from vultron.core.states.rm import RM
+from vultron.core.states.roles import CVDRole
 from vultron.wire.as2.factories import em_propose_embargo_activity
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
@@ -55,6 +56,21 @@ from vultron.wire.as2.vocab.objects.vulnerability_report import (
 )
 
 FUTURE_DATETIME = datetime(2099, 12, 1, tzinfo=timezone.utc)
+
+
+def _add_case_manager(case: VulnerabilityCase, dl) -> as_Service:
+    """Add a CASE_MANAGER participant to *case* and return the case actor."""
+    case_actor = as_Service(name=f"Case Actor for {case.name}")
+    dl.create(case_actor)
+    cm_participant = CaseParticipant(
+        attributed_to=case_actor.id_,
+        context=case.id_,
+        case_roles=[CVDRole.CASE_MANAGER],
+    )
+    dl.create(cm_participant)
+    case.actor_participant_index[case_actor.id_] = cm_participant.id_
+    dl.save(case)
+    return case_actor
 
 
 def test_submit_report_trigger_creates_report_case_link(dl, actor):
@@ -171,6 +187,7 @@ def case_with_participant(dl, actor):
     case_obj.case_participants.append(participant.id_)
     dl.create(case_obj)
     dl.create(participant)
+    _add_case_manager(case_obj, dl)
     return case_obj
 
 
@@ -182,6 +199,15 @@ def case_no_participant(dl):
 
 
 @pytest.fixture
+def case_with_case_manager(dl):
+    """A bare case with a single CASE_MANAGER participant, no other participants."""
+    case_obj = VulnerabilityCase(name="TEST-CASE-WITH-CM")
+    dl.create(case_obj)
+    _add_case_manager(case_obj, dl)
+    return case_obj
+
+
+@pytest.fixture
 def case_with_embargo(dl, actor):
     case_obj = VulnerabilityCase(name="EMBARGO-CASE-001")
     embargo = EmbargoEvent(context=case_obj.id_)
@@ -189,6 +215,7 @@ def case_with_embargo(dl, actor):
     case_obj.set_embargo(embargo.id_)
     case_obj.current_status.em_state = EM.ACTIVE
     dl.create(case_obj)
+    _add_case_manager(case_obj, dl)
     return case_obj, embargo
 
 
@@ -204,6 +231,7 @@ def case_with_proposal(dl, actor):
     case_obj.current_status.em_state = EM.PROPOSED
     case_obj.proposed_embargoes.append(embargo.id_)
     dl.create(case_obj)
+    _add_case_manager(case_obj, dl)
     return case_obj, proposal, embargo
 
 
@@ -601,24 +629,24 @@ def test_defer_case_trigger_updates_participant_rm_state(
 
 
 def test_propose_embargo_trigger_returns_activity_dict(
-    dl, actor, case_no_participant
+    dl, actor, case_with_case_manager
 ):
     """propose_embargo_trigger returns dict with non-None 'activity'."""
     result = TriggerService(
         dl, trigger_activity=TriggerActivityAdapter(dl)
-    ).propose_embargo(actor.id_, case_no_participant.id_, FUTURE_DATETIME)
+    ).propose_embargo(actor.id_, case_with_case_manager.id_, FUTURE_DATETIME)
     assert isinstance(result, dict)
     assert result["activity"] is not None
 
 
 def test_propose_embargo_trigger_transitions_em_state_to_proposed(
-    dl, actor, case_no_participant
+    dl, actor, case_with_case_manager
 ):
     """propose_embargo_trigger transitions case EM state from N to P."""
     TriggerService(
         dl, trigger_activity=TriggerActivityAdapter(dl)
-    ).propose_embargo(actor.id_, case_no_participant.id_, FUTURE_DATETIME)
-    updated = dl.read(case_no_participant.id_)
+    ).propose_embargo(actor.id_, case_with_case_manager.id_, FUTURE_DATETIME)
+    updated = dl.read(case_with_case_manager.id_)
     assert updated.current_status.em_state == EM.PROPOSED
 
 

--- a/test/core/use_cases/triggers/test_trignotify.py
+++ b/test/core/use_cases/triggers/test_trignotify.py
@@ -28,6 +28,7 @@ from vultron.adapters.driven.datalayer_sqlite import (
 )
 from vultron.core.states.em import EM
 from vultron.core.states.roles import CVDRole
+from vultron.errors import VultronValidationError
 from vultron.core.use_cases.triggers.case import (
     SvcDeferCaseUseCase,
     SvcEngageCaseUseCase,
@@ -247,8 +248,8 @@ class TestCaseTriggerToField:
         assert self.finder.id_ not in recipients
         assert self.vendor.id_ not in recipients
 
-    def test_engage_case_to_field_none_when_no_case_manager(self):
-        """SvcEngageCaseUseCase sets to=None when case has no CASE_MANAGER."""
+    def test_engage_case_raises_when_no_case_manager(self):
+        """SvcEngageCaseUseCase raises VultronValidationError when no CASE_MANAGER."""
         case_solo = VulnerabilityCase(name="Solo Case")
         case_solo.actor_participant_index[self.vendor.id_] = (
             f"{case_solo.id_}/participants/vendor"
@@ -259,16 +260,12 @@ class TestCaseTriggerToField:
             actor_id=self.vendor.id_,
             case_id=case_solo.id_,
         )
-        result = SvcEngageCaseUseCase(
-            self.dl, request, trigger_activity=TriggerActivityAdapter(self.dl)
-        ).execute()
-
-        _, act_obj = _new_outbox_activity(self.vendor, self.dl, result)
-        recipients = _to_field(act_obj)
-
-        assert (
-            not recipients
-        ), "to should be empty/None when no Case Manager participant"
+        with pytest.raises(VultronValidationError):
+            SvcEngageCaseUseCase(
+                self.dl,
+                request,
+                trigger_activity=TriggerActivityAdapter(self.dl),
+            ).execute()
 
 
 # ---------------------------------------------------------------------------

--- a/test/core/use_cases/triggers/test_trignotify.py
+++ b/test/core/use_cases/triggers/test_trignotify.py
@@ -27,6 +27,7 @@ from vultron.adapters.driven.datalayer_sqlite import (
     reset_datalayer,
 )
 from vultron.core.states.em import EM
+from vultron.core.states.roles import CVDRole
 from vultron.core.use_cases.triggers.case import (
     SvcDeferCaseUseCase,
     SvcEngageCaseUseCase,
@@ -56,6 +57,10 @@ from vultron.wire.as2.factories import (
     rm_submit_report_activity,
 )
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
+from vultron.wire.as2.vocab.objects.case_participant import (
+    CaseParticipant,
+    FinderParticipant,
+)
 from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
 from vultron.adapters.driven.trigger_activity_adapter import (
@@ -87,10 +92,51 @@ def _make_actor_dl(actor_name: str):
     return actor, dl
 
 
+def _make_case_with_case_manager(
+    dl: SqliteDataLayer,
+    actor_id: str,
+    finder_id: str,
+    case_actor_id: str,
+) -> VulnerabilityCase:
+    """Create a VulnerabilityCase with a Finder participant and a Case Actor
+    (CVDRole.CASE_MANAGER).  Persists all objects in *dl*.
+    """
+    case = VulnerabilityCase(name="Test Case")
+
+    actor_participant = CaseParticipant(
+        attributed_to=actor_id,
+        context=case.id_,
+        case_roles=[CVDRole.VENDOR],
+    )
+    finder_participant = FinderParticipant(
+        attributed_to=finder_id,
+        context=case.id_,
+    )
+    case_manager_participant = CaseParticipant(
+        attributed_to=case_actor_id,
+        context=case.id_,
+        case_roles=[CVDRole.CASE_MANAGER],
+    )
+
+    case.actor_participant_index[actor_id] = actor_participant.id_
+    case.actor_participant_index[finder_id] = finder_participant.id_
+    case.actor_participant_index[case_actor_id] = case_manager_participant.id_
+
+    dl.create(case)
+    dl.create(actor_participant)
+    dl.create(finder_participant)
+    dl.create(case_manager_participant)
+    return case
+
+
 def _make_two_actor_case(
     dl, vendor_id: str, finder_id: str
 ) -> VulnerabilityCase:
-    """Create a VulnerabilityCase with vendor and finder in actor_participant_index."""
+    """Create a VulnerabilityCase with vendor and finder in actor_participant_index.
+
+    Note: no CASE_MANAGER participant — use _make_case_with_case_manager for
+    tests that verify PCR-08-001 routing.
+    """
     case = VulnerabilityCase(name="Test Case")
     case.actor_participant_index[vendor_id] = f"{case.id_}/participants/vendor"
     case.actor_participant_index[finder_id] = f"{case.id_}/participants/finder"
@@ -144,16 +190,22 @@ class TestCaseTriggerToField:
     def setup(self):
         self.vendor, self.dl = _make_actor_dl("Vendor Co")
         self.finder, _ = _make_actor_dl("Finder Co")
-        self.case = _make_two_actor_case(
-            self.dl, self.vendor.id_, self.finder.id_
+        self.case_actor, _ = _make_actor_dl("Case Actor")
+        self.case = _make_case_with_case_manager(
+            self.dl,
+            self.vendor.id_,
+            self.finder.id_,
+            self.case_actor.id_,
         )
         yield
         self.dl.clear_all()
         reset_datalayer(self.vendor.id_)
         reset_datalayer(self.finder.id_)
+        reset_datalayer(self.case_actor.id_)
 
-    def test_engage_case_to_field_contains_other_participant(self):
-        """SvcEngageCaseUseCase queues RmEngageCaseActivity with non-empty to."""
+    def test_engage_case_to_field_addresses_case_actor_only(self):
+        """SvcEngageCaseUseCase queues activity addressed only to Case Actor
+        (PCR-08-001)."""
         request = EngageCaseTriggerRequest(
             actor_id=self.vendor.id_,
             case_id=self.case.id_,
@@ -166,12 +218,16 @@ class TestCaseTriggerToField:
         recipients = _to_field(act_obj)
 
         assert recipients is not None, "to field must not be None"
-        assert len(recipients) > 0, "to field must be non-empty"
-        assert self.finder.id_ in recipients
+        assert (
+            len(recipients) == 1
+        ), f"Expected exactly 1 recipient, got {len(recipients)}: {recipients}"
+        assert recipients[0] == self.case_actor.id_
+        assert self.finder.id_ not in recipients
         assert self.vendor.id_ not in recipients
 
-    def test_defer_case_to_field_contains_other_participant(self):
-        """SvcDeferCaseUseCase queues RmDeferCaseActivity with non-empty to."""
+    def test_defer_case_to_field_addresses_case_actor_only(self):
+        """SvcDeferCaseUseCase queues activity addressed only to Case Actor
+        (PCR-08-001)."""
         request = DeferCaseTriggerRequest(
             actor_id=self.vendor.id_,
             case_id=self.case.id_,
@@ -184,12 +240,15 @@ class TestCaseTriggerToField:
         recipients = _to_field(act_obj)
 
         assert recipients is not None, "to field must not be None"
-        assert len(recipients) > 0, "to field must be non-empty"
-        assert self.finder.id_ in recipients
+        assert (
+            len(recipients) == 1
+        ), f"Expected exactly 1 recipient, got {len(recipients)}: {recipients}"
+        assert recipients[0] == self.case_actor.id_
+        assert self.finder.id_ not in recipients
         assert self.vendor.id_ not in recipients
 
-    def test_engage_case_to_field_none_when_no_other_participants(self):
-        """SvcEngageCaseUseCase sets to=None when vendor is the only participant."""
+    def test_engage_case_to_field_none_when_no_case_manager(self):
+        """SvcEngageCaseUseCase sets to=None when case has no CASE_MANAGER."""
         case_solo = VulnerabilityCase(name="Solo Case")
         case_solo.actor_participant_index[self.vendor.id_] = (
             f"{case_solo.id_}/participants/vendor"
@@ -209,7 +268,7 @@ class TestCaseTriggerToField:
 
         assert (
             not recipients
-        ), "to should be empty/None when no other participants"
+        ), "to should be empty/None when no Case Manager participant"
 
 
 # ---------------------------------------------------------------------------
@@ -218,22 +277,27 @@ class TestCaseTriggerToField:
 
 
 class TestEmbargoTriggerToField:
-    """All three embargo trigger use cases populate ``to``."""
+    """All embargo trigger use cases address only the Case Actor (PCR-08-001)."""
 
     @pytest.fixture(autouse=True)
     def setup(self):
         self.vendor, self.dl = _make_actor_dl("Vendor Co")
         self.finder, _ = _make_actor_dl("Finder Co")
-        self.case = _make_two_actor_case(
-            self.dl, self.vendor.id_, self.finder.id_
+        self.case_actor, _ = _make_actor_dl("Case Actor")
+        self.case = _make_case_with_case_manager(
+            self.dl,
+            self.vendor.id_,
+            self.finder.id_,
+            self.case_actor.id_,
         )
         yield
         self.dl.clear_all()
         reset_datalayer(self.vendor.id_)
         reset_datalayer(self.finder.id_)
+        reset_datalayer(self.case_actor.id_)
 
-    def test_propose_embargo_to_field_contains_other_participant(self):
-        """SvcProposeEmbargoUseCase queues EmProposeEmbargoActivity with to."""
+    def test_propose_embargo_to_field_addresses_case_actor_only(self):
+        """SvcProposeEmbargoUseCase queues activity addressed only to Case Actor."""
         request = ProposeEmbargoTriggerRequest(
             actor_id=self.vendor.id_,
             case_id=self.case.id_,
@@ -247,11 +311,15 @@ class TestEmbargoTriggerToField:
         recipients = _to_field(act_obj)
 
         assert recipients is not None
-        assert self.finder.id_ in recipients
+        assert (
+            len(recipients) == 1
+        ), f"Expected exactly 1 recipient, got {len(recipients)}: {recipients}"
+        assert recipients[0] == self.case_actor.id_
+        assert self.finder.id_ not in recipients
         assert self.vendor.id_ not in recipients
 
-    def test_evaluate_embargo_to_field_contains_other_participant(self):
-        """SvcAcceptEmbargoUseCase queues EmAcceptEmbargoActivity with to."""
+    def test_evaluate_embargo_to_field_addresses_case_actor_only(self):
+        """SvcAcceptEmbargoUseCase queues activity addressed only to Case Actor."""
         embargo = EmbargoEvent(context=self.case.id_)
         self.dl.create(embargo)
         proposal = em_propose_embargo_activity(
@@ -275,11 +343,15 @@ class TestEmbargoTriggerToField:
         recipients = _to_field(act_obj)
 
         assert recipients is not None
-        assert self.finder.id_ in recipients
+        assert (
+            len(recipients) == 1
+        ), f"Expected exactly 1 recipient, got {len(recipients)}: {recipients}"
+        assert recipients[0] == self.case_actor.id_
+        assert self.finder.id_ not in recipients
         assert self.vendor.id_ not in recipients
 
-    def test_terminate_embargo_to_field_contains_other_participant(self):
-        """SvcTerminateEmbargoUseCase queues AnnounceEmbargoActivity with to."""
+    def test_terminate_embargo_to_field_addresses_case_actor_only(self):
+        """SvcTerminateEmbargoUseCase queues activity addressed only to Case Actor."""
         embargo = EmbargoEvent(context=self.case.id_)
         self.dl.create(embargo)
         self.case.set_embargo(embargo.id_)
@@ -298,7 +370,11 @@ class TestEmbargoTriggerToField:
         recipients = _to_field(act_obj)
 
         assert recipients is not None
-        assert self.finder.id_ in recipients
+        assert (
+            len(recipients) == 1
+        ), f"Expected exactly 1 recipient, got {len(recipients)}: {recipients}"
+        assert recipients[0] == self.case_actor.id_
+        assert self.finder.id_ not in recipients
         assert self.vendor.id_ not in recipients
 
 

--- a/vultron/core/use_cases/_helpers.py
+++ b/vultron/core/use_cases/_helpers.py
@@ -15,6 +15,7 @@ from vultron.core.models.protocols import (
 )
 from vultron.core.ports.case_persistence import CasePersistence
 from vultron.core.states.rm import RM
+from vultron.core.states.roles import CVDRole
 from vultron.errors import VultronNotFoundError, VultronValidationError
 
 logger = logging.getLogger(__name__)
@@ -184,6 +185,30 @@ def update_participant_rm_state(
         case_id,
     )
     return False
+
+
+def _resolve_case_manager_id(
+    case: CaseModel, dl: CasePersistence
+) -> str | None:
+    """Return the actor ID of the Case Manager (CVDRole.CASE_MANAGER).
+
+    Iterates over all participants in the case's ``actor_participant_index``
+    and returns the ``attributed_to`` actor ID of the first participant that
+    holds ``CVDRole.CASE_MANAGER``.  Returns ``None`` when no Case Manager
+    participant is found.
+
+    This is the correct recipient for all participant-originated outbound
+    activities after case creation (PCR-08-001, PCR-08-002).
+    """
+    for p_id in case.actor_participant_index.values():
+        p = dl.read(p_id)
+        if p is None:
+            continue
+        roles = getattr(p, "case_roles", [])
+        if CVDRole.CASE_MANAGER in roles:
+            manager_actor_id = getattr(p, "attributed_to", None)
+            return str(manager_actor_id) if manager_actor_id else None
+    return None
 
 
 def case_addressees(case: CaseModel, excluding_actor_id: str) -> list[str]:

--- a/vultron/core/use_cases/_helpers.py
+++ b/vultron/core/use_cases/_helpers.py
@@ -207,7 +207,7 @@ def _resolve_case_manager_id(
         roles = getattr(p, "case_roles", [])
         if CVDRole.CASE_MANAGER in roles:
             manager_actor_id = getattr(p, "attributed_to", None)
-            return str(manager_actor_id) if manager_actor_id else None
+            return _as_id(manager_actor_id)
     return None
 
 

--- a/vultron/core/use_cases/triggers/case.py
+++ b/vultron/core/use_cases/triggers/case.py
@@ -79,11 +79,16 @@ class SvcEngageCaseUseCase:
             )
 
         case_manager_id = _resolve_case_manager_id(case, dl)
+        if case_manager_id is None:
+            raise VultronValidationError(
+                f"Cannot route engage-case activity: no Case Manager participant"
+                f" found in case '{case_id}'"
+            )
 
         activity_id, activity_dict = self._trigger_activity.engage_case(
             case_id=case_id,
             actor=actor_id,
-            to=[case_manager_id] if case_manager_id else None,
+            to=[case_manager_id],
         )
 
         update_participant_rm_state(case.id_, actor_id, RM.ACCEPTED, dl)
@@ -129,11 +134,16 @@ class SvcDeferCaseUseCase:
             )
 
         case_manager_id = _resolve_case_manager_id(case, dl)
+        if case_manager_id is None:
+            raise VultronValidationError(
+                f"Cannot route defer-case activity: no Case Manager participant"
+                f" found in case '{case_id}'"
+            )
 
         activity_id, activity_dict = self._trigger_activity.defer_case(
             case_id=case_id,
             actor=actor_id,
-            to=[case_manager_id] if case_manager_id else None,
+            to=[case_manager_id],
         )
 
         update_participant_rm_state(case.id_, actor_id, RM.DEFERRED, dl)

--- a/vultron/core/use_cases/triggers/case.py
+++ b/vultron/core/use_cases/triggers/case.py
@@ -27,7 +27,7 @@ from vultron.core.states.cs import CS_vfd
 from vultron.core.states.rm import RM
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.use_cases._helpers import update_participant_rm_state
-from vultron.core.use_cases._helpers import case_addressees
+from vultron.core.use_cases._helpers import _resolve_case_manager_id
 from vultron.core.use_cases.triggers._helpers import (
     add_activity_to_outbox,
     resolve_actor,
@@ -78,10 +78,12 @@ class SvcEngageCaseUseCase:
                 "SvcEngageCaseUseCase requires a TriggerActivityPort"
             )
 
+        case_manager_id = _resolve_case_manager_id(case, dl)
+
         activity_id, activity_dict = self._trigger_activity.engage_case(
             case_id=case_id,
             actor=actor_id,
-            to=case_addressees(case, actor_id) or None,
+            to=[case_manager_id] if case_manager_id else None,
         )
 
         update_participant_rm_state(case.id_, actor_id, RM.ACCEPTED, dl)
@@ -126,10 +128,12 @@ class SvcDeferCaseUseCase:
                 "SvcDeferCaseUseCase requires a TriggerActivityPort"
             )
 
+        case_manager_id = _resolve_case_manager_id(case, dl)
+
         activity_id, activity_dict = self._trigger_activity.defer_case(
             case_id=case_id,
             actor=actor_id,
-            to=case_addressees(case, actor_id) or None,
+            to=[case_manager_id] if case_manager_id else None,
         )
 
         update_participant_rm_state(case.id_, actor_id, RM.DEFERRED, dl)
@@ -429,17 +433,7 @@ class SvcAddParticipantStatusUseCase:
             dl.save(status)
 
         # Find Case Manager ID to address activity
-        from vultron.core.states.roles import CVDRole
-
-        case_manager_id: str | None = None
-        for p_id in case.actor_participant_index.values():
-            p = dl.read(p_id)
-            roles = getattr(p, "case_roles", [])
-            if CVDRole.CASE_MANAGER in roles:
-                case_manager_id = getattr(p, "attributed_to", None)
-                if case_manager_id:
-                    case_manager_id = str(case_manager_id)
-                break
+        case_manager_id = _resolve_case_manager_id(case, dl)
 
         if case_manager_id is None:
             raise VultronNotFoundError(

--- a/vultron/core/use_cases/triggers/embargo.py
+++ b/vultron/core/use_cases/triggers/embargo.py
@@ -41,7 +41,7 @@ from vultron.core.states.participant_embargo_consent import (
     PEC_Trigger,
     apply_pec_trigger,
 )
-from vultron.core.use_cases._helpers import _as_id, case_addressees
+from vultron.core.use_cases._helpers import _as_id, _resolve_case_manager_id
 from vultron.core.use_cases.triggers._helpers import (
     add_activity_to_outbox,
     find_embargo_proposal,
@@ -392,11 +392,12 @@ class SvcProposeEmbargoUseCase:
                 "SvcProposeEmbargoUseCase requires a TriggerActivityPort"
             )
 
+        case_manager_id = _resolve_case_manager_id(case, dl)
         proposal_id, proposal_dict = self._trigger_activity.propose_embargo(
             embargo_id=embargo.id_,
             case_id=case.id_,
             actor=actor_id,
-            to=case_addressees(case, actor_id) or None,
+            to=[case_manager_id] if case_manager_id else None,
         )
 
         case.current_status.em_state = new_em_state
@@ -465,11 +466,12 @@ class SvcAcceptEmbargoUseCase:
                 "SvcAcceptEmbargoUseCase requires a TriggerActivityPort"
             )
 
+        case_manager_id = _resolve_case_manager_id(case, dl)
         accept_id, accept_dict = self._trigger_activity.accept_embargo(
             proposal_id=proposal.id_,
             case_id=case.id_,
             actor=actor_id,
-            to=case_addressees(case, actor_id) or None,
+            to=[case_manager_id] if case_manager_id else None,
         )
 
         em_state = case.current_status.em_state
@@ -582,11 +584,12 @@ class SvcTerminateEmbargoUseCase:
                 "SvcTerminateEmbargoUseCase requires a TriggerActivityPort"
             )
 
+        case_manager_id = _resolve_case_manager_id(case, dl)
         announce_id, announce_dict = self._trigger_activity.terminate_embargo(
             embargo_id=embargo_id,
             case_id=case.id_,
             actor=actor_id,
-            to=case_addressees(case, actor_id) or None,
+            to=[case_manager_id] if case_manager_id else None,
         )
 
         case.current_status.em_state = EM(adapter.state)
@@ -650,11 +653,12 @@ class SvcRejectEmbargoUseCase:
                 "SvcRejectEmbargoUseCase requires a TriggerActivityPort"
             )
 
+        case_manager_id = _resolve_case_manager_id(case, dl)
         reject_id, reject_dict = self._trigger_activity.reject_embargo(
             proposal_id=proposal.id_,
             case_id=case.id_,
             actor=actor_id,
-            to=case_addressees(case, actor_id) or None,
+            to=[case_manager_id] if case_manager_id else None,
         )
 
         _update_participant_embargo_rejection(case, actor_id, embargo_id, dl)
@@ -766,11 +770,12 @@ class SvcProposeEmbargoRevisionUseCase:
                 " TriggerActivityPort"
             )
 
+        case_manager_id = _resolve_case_manager_id(case, dl)
         proposal_id, proposal_dict = self._trigger_activity.propose_embargo(
             embargo_id=embargo.id_,
             case_id=case.id_,
             actor=actor_id,
-            to=case_addressees(case, actor_id) or None,
+            to=[case_manager_id] if case_manager_id else None,
         )
 
         case.current_status.em_state = new_em_state

--- a/vultron/core/use_cases/triggers/embargo.py
+++ b/vultron/core/use_cases/triggers/embargo.py
@@ -393,11 +393,16 @@ class SvcProposeEmbargoUseCase:
             )
 
         case_manager_id = _resolve_case_manager_id(case, dl)
+        if case_manager_id is None:
+            raise VultronValidationError(
+                f"Cannot route propose-embargo activity: no Case Manager"
+                f" participant found in case '{case.id_}'"
+            )
         proposal_id, proposal_dict = self._trigger_activity.propose_embargo(
             embargo_id=embargo.id_,
             case_id=case.id_,
             actor=actor_id,
-            to=[case_manager_id] if case_manager_id else None,
+            to=[case_manager_id],
         )
 
         case.current_status.em_state = new_em_state
@@ -467,11 +472,16 @@ class SvcAcceptEmbargoUseCase:
             )
 
         case_manager_id = _resolve_case_manager_id(case, dl)
+        if case_manager_id is None:
+            raise VultronValidationError(
+                f"Cannot route accept-embargo activity: no Case Manager"
+                f" participant found in case '{case.id_}'"
+            )
         accept_id, accept_dict = self._trigger_activity.accept_embargo(
             proposal_id=proposal.id_,
             case_id=case.id_,
             actor=actor_id,
-            to=[case_manager_id] if case_manager_id else None,
+            to=[case_manager_id],
         )
 
         em_state = case.current_status.em_state
@@ -585,11 +595,16 @@ class SvcTerminateEmbargoUseCase:
             )
 
         case_manager_id = _resolve_case_manager_id(case, dl)
+        if case_manager_id is None:
+            raise VultronValidationError(
+                f"Cannot route terminate-embargo activity: no Case Manager"
+                f" participant found in case '{case.id_}'"
+            )
         announce_id, announce_dict = self._trigger_activity.terminate_embargo(
             embargo_id=embargo_id,
             case_id=case.id_,
             actor=actor_id,
-            to=[case_manager_id] if case_manager_id else None,
+            to=[case_manager_id],
         )
 
         case.current_status.em_state = EM(adapter.state)
@@ -654,11 +669,16 @@ class SvcRejectEmbargoUseCase:
             )
 
         case_manager_id = _resolve_case_manager_id(case, dl)
+        if case_manager_id is None:
+            raise VultronValidationError(
+                f"Cannot route reject-embargo activity: no Case Manager"
+                f" participant found in case '{case.id_}'"
+            )
         reject_id, reject_dict = self._trigger_activity.reject_embargo(
             proposal_id=proposal.id_,
             case_id=case.id_,
             actor=actor_id,
-            to=[case_manager_id] if case_manager_id else None,
+            to=[case_manager_id],
         )
 
         _update_participant_embargo_rejection(case, actor_id, embargo_id, dl)
@@ -771,11 +791,16 @@ class SvcProposeEmbargoRevisionUseCase:
             )
 
         case_manager_id = _resolve_case_manager_id(case, dl)
+        if case_manager_id is None:
+            raise VultronValidationError(
+                f"Cannot route propose-embargo-revision activity: no Case"
+                f" Manager participant found in case '{case.id_}'"
+            )
         proposal_id, proposal_dict = self._trigger_activity.propose_embargo(
             embargo_id=embargo.id_,
             case_id=case.id_,
             actor=actor_id,
-            to=[case_manager_id] if case_manager_id else None,
+            to=[case_manager_id],
         )
 
         case.current_status.em_state = new_em_state

--- a/vultron/core/use_cases/triggers/note.py
+++ b/vultron/core/use_cases/triggers/note.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING
 
 from vultron.core.models.protocols import is_case_model
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
-from vultron.core.use_cases._helpers import case_addressees
+from vultron.core.use_cases._helpers import _resolve_case_manager_id
 from vultron.core.use_cases.triggers._helpers import (
     add_activity_to_outbox,
     resolve_actor,
@@ -99,7 +99,8 @@ class SvcAddNoteToCaseUseCase:
                     case_id,
                 )
 
-        addressees = case_addressees(case, actor_id) or None
+        case_manager_id = _resolve_case_manager_id(case, dl)
+        addressees = [case_manager_id] if case_manager_id else None
 
         create_activity_id = factory.create_note_activity(
             actor=actor_id,

--- a/vultron/core/use_cases/triggers/note.py
+++ b/vultron/core/use_cases/triggers/note.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING
 from vultron.core.models.protocols import is_case_model
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.use_cases._helpers import _resolve_case_manager_id
+from vultron.errors import VultronValidationError
 from vultron.core.use_cases.triggers._helpers import (
     add_activity_to_outbox,
     resolve_actor,
@@ -100,7 +101,12 @@ class SvcAddNoteToCaseUseCase:
                 )
 
         case_manager_id = _resolve_case_manager_id(case, dl)
-        addressees = [case_manager_id] if case_manager_id else None
+        if case_manager_id is None:
+            raise VultronValidationError(
+                f"Cannot route note activity: no Case Manager participant"
+                f" found in case '{case_id}'"
+            )
+        addressees = [case_manager_id]
 
         create_activity_id = factory.create_note_activity(
             actor=actor_id,


### PR DESCRIPTION
Closes #594

## Summary

All post-case-creation participant-originated trigger use cases were using `case_addressees()` to address outbound activities, delivering them directly to ALL participants instead of routing through the Case Actor exclusively. This violates PCR-08-001.

## Changes

- **New helper**: `_resolve_case_manager_id(case, dl) -> str | None` in `vultron/core/use_cases/_helpers.py` — resolves the actor ID of the `CVDRole.CASE_MANAGER` participant; includes null-check for orphaned participant references.
- **Fixed**: `SvcAddNoteToCaseUseCase` (`triggers/note.py`)
- **Fixed**: `SvcEngageCaseUseCase`, `SvcDeferCaseUseCase` (`triggers/case.py`)
- **Fixed**: `SvcProposeEmbargoUseCase`, `SvcAcceptEmbargoUseCase`, `SvcTerminateEmbargoUseCase`, `SvcRejectEmbargoUseCase`, `SvcProposeEmbargoRevisionUseCase` (`triggers/embargo.py`)
- **Refactored**: `SvcAddParticipantStatusUseCase` — removes duplicate inline loop, uses shared helper
- **Tests updated**: `test_note_trigger.py`, `test_trignotify.py` — now use proper `CaseParticipant(case_roles=[CVDRole.CASE_MANAGER])` in setup and assert `to == [case_actor_id]` (AC-5, AC-6)

## Acceptance Criteria

- [x] AC-1: `_resolve_case_manager_id(case, dl)` extracted as shared helper
- [x] AC-2: `SvcAddNoteToCaseUseCase` addresses Case Actor only
- [x] AC-3: All embargo triggers address Case Actor only
- [x] AC-4: `SvcEngageCaseUseCase` and `SvcDeferCaseUseCase` address Case Actor only
- [x] AC-5: Tests assert `to == [case_actor_id]`
- [x] AC-6: Pattern matches `SvcAddParticipantStatusUseCase` reference implementation