### PR TITLE
fix: use /{key:path} catch-all for DataLayer and actors endpoints

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -6,3 +6,12 @@ insights, issues, and learnings during the implementation process.
 
 Append new items below any existing ones, marking them with the date and a
 header.
+
+### 2026-05-21 — #610: Starlette path parameter type for URL-keyed endpoints
+
+When a FastAPI/Starlette endpoint needs to accept keys that may contain
+forward slashes (e.g., HTTP URL IDs), use `{key:path}` instead of `{key}`.
+Register the catch-all route **last** so specific literal routes (e.g.,
+`/Offers/`, `/Actors/`) are matched first. The `%2F`-decoding-before-routing
+behaviour in Starlette means there is no client-side workaround; only the
+server-side `path` converter fixes the root cause.

--- a/plan/history/2605/README.md
+++ b/plan/history/2605/README.md
@@ -4,6 +4,7 @@
 
 | Date | Time (UTC) | Type | Source | Title |
 |------|------------|------|--------|-------|
+| 2026-05-21 | 19:19 | implementation | 610 | Fix DataLayer and actors endpoints for HTTP URL keys (#610) |
 | 2026-05-21 | 16:33 | learning | CONCERN-593 | Case Actor outbound routing model |
 | 2026-05-21 | 14:58 | implementation | ISSUE-570 | Demo CI: GitHub Actions integration workflow + demo runner hardening |
 | 2026-05-20 | 13:54 | idea | IDEA-582 | Optimize linkchecker.yml: separate build-site and link-check triggers |

--- a/plan/history/2605/implementation/610.md
+++ b/plan/history/2605/implementation/610.md
@@ -42,3 +42,5 @@ route.  The failure was documented in the `_dl_key()` docstring but never fixed.
 - `test/adapters/driving/fastapi/routers/test_datalayer.py`
 - `test/adapters/driving/fastapi/routers/test_actors.py`
 - `test/demo/test_two_actor_demo.py`
+
+PR: <https://github.com/CERTCC/Vultron/pull/617>

--- a/plan/history/2605/implementation/610.md
+++ b/plan/history/2605/implementation/610.md
@@ -1,0 +1,44 @@
+---
+source: '610'
+timestamp: '2026-05-21T19:19:33.603435+00:00'
+title: Fix DataLayer and actors endpoints for HTTP URL keys (#610)
+type: implementation
+---
+
+## Summary
+
+Fixed HTTP 404 returned by `GET /api/v2/datalayer/{key}` and
+`GET /api/v2/actors/{actor_id}` for URL-format (HTTP URL) IDs.
+
+## Symptoms
+
+- `DataLayer.save(CaseParticipant)` succeeded for IDs like
+  `http://vendor:7999/api/v2/actors/case-actor-{uuid}/participant`
+- `GET /datalayer/{url-encoded-id}` always returned 404 for those same IDs
+- Same bug existed in `GET /actors/{actor_id}` for HTTP URL actor IDs
+
+## Root cause
+
+Both endpoints used a single-segment path parameter (`/{key}` / `/{actor_id}`).
+Starlette decodes `%2F` to `/` before routing, so a percent-encoded HTTP URL
+key decoded into multiple path segments that never matched the single-segment
+route.  The failure was documented in the `_dl_key()` docstring but never fixed.
+
+## Fix
+
+1. **`datalayer.py`**: Removed `/{key}` from the top of the router and added
+   `/{key:path}` as a catch-all at the bottom.
+2. **`actors.py`**: Same pattern with `/{actor_id:path}` as last route.
+3. **`seeding.py`**: Updated `_dl_key()` docstring to remove the
+   "known limitation" language.
+4. **Tests**: Added regression tests; updated the integration test that
+   previously asserted the broken workaround behaviour.
+
+## Files changed
+
+- `vultron/adapters/driving/fastapi/routers/datalayer.py`
+- `vultron/adapters/driving/fastapi/routers/actors.py`
+- `vultron/demo/helpers/seeding.py`
+- `test/adapters/driving/fastapi/routers/test_datalayer.py`
+- `test/adapters/driving/fastapi/routers/test_actors.py`
+- `test/demo/test_two_actor_demo.py`

--- a/test/adapters/driving/fastapi/routers/test_actors.py
+++ b/test/adapters/driving/fastapi/routers/test_actors.py
@@ -30,11 +30,10 @@ from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
 
 _ACTOR_ID = "https://example.org/actors/alice"
 
-# URN IDs used in action-rules tests (retain urn: format for those routes
-# which still have single-segment path params for actor_id sub-paths).
-_HTTP_ACTOR_ID = "urn:uuid:aaaaaaaa-0000-0000-0000-000000000001"
-_HTTP_CASE_ID = "urn:uuid:aaaaaaaa-0000-0000-0000-000000000003"
-_HTTP_PARTICIPANT_ID = "urn:uuid:aaaaaaaa-0000-0000-0000-000000000004"
+# URN IDs used in action-rules and sub-route tests.
+_URN_ACTOR_ID = "urn:uuid:aaaaaaaa-0000-0000-0000-000000000001"
+_URN_CASE_ID = "urn:uuid:aaaaaaaa-0000-0000-0000-000000000003"
+_URN_PARTICIPANT_ID = "urn:uuid:aaaaaaaa-0000-0000-0000-000000000004"
 
 
 def test_created_actors_fixture_has_expected_count(created_actors):
@@ -142,21 +141,21 @@ def test_get_actors_does_not_log_raw_records_at_info_level(
 def _seed_action_rules_data(dl):
     """Insert a minimal valid VulnerabilityCase / CaseParticipant pair."""
     case = VulnerabilityCase(
-        id_=_HTTP_CASE_ID,
+        id_=_URN_CASE_ID,
         name="Test Case",
-        actor_participant_index={_HTTP_ACTOR_ID: _HTTP_PARTICIPANT_ID},
+        actor_participant_index={_URN_ACTOR_ID: _URN_PARTICIPANT_ID},
         case_statuses=[CaseStatus(em_state=EM.ACTIVE, pxa_state=CS_pxa.Pxa)],
     )
     dl.create(case)
 
     participant = CaseParticipant(
-        id_=_HTTP_PARTICIPANT_ID,
-        attributed_to=_HTTP_ACTOR_ID,
-        context=_HTTP_CASE_ID,
+        id_=_URN_PARTICIPANT_ID,
+        attributed_to=_URN_ACTOR_ID,
+        context=_URN_CASE_ID,
         case_roles=[CVDRole.VENDOR],
         participant_statuses=[
             ParticipantStatus(
-                context=_HTTP_CASE_ID,
+                context=_URN_CASE_ID,
                 rm_state=RM.ACCEPTED,
                 vfd_state=CS_vfd.VFd,
             )
@@ -170,7 +169,7 @@ def test_get_action_rules_returns_200_with_expected_fields(client_actors, dl):
     _seed_action_rules_data(dl)
 
     resp = client_actors.get(
-        f"/actors/{_HTTP_ACTOR_ID}/cases/{_HTTP_CASE_ID}/action-rules"
+        f"/actors/{_URN_ACTOR_ID}/cases/{_URN_CASE_ID}/action-rules"
     )
     assert resp.status_code == status.HTTP_200_OK
 
@@ -188,15 +187,15 @@ def test_get_action_rules_returns_200_with_expected_fields(client_actors, dl):
         "actions",
     }
     assert expected_keys.issubset(body.keys())
-    assert body["case_id"] == _HTTP_CASE_ID
-    assert body["participant_id"] == _HTTP_PARTICIPANT_ID
-    assert body["participant_actor_id"] == _HTTP_ACTOR_ID
+    assert body["case_id"] == _URN_CASE_ID
+    assert body["participant_id"] == _URN_PARTICIPANT_ID
+    assert body["participant_actor_id"] == _URN_ACTOR_ID
 
 
 def test_get_action_rules_case_not_found_returns_404(client_actors):
     """Missing case returns 404."""
     resp = client_actors.get(
-        f"/actors/{_HTTP_ACTOR_ID}/cases/"
+        f"/actors/{_URN_ACTOR_ID}/cases/"
         "urn:uuid:00000000-0000-0000-0000-000000000000/action-rules"
     )
     assert resp.status_code == status.HTTP_404_NOT_FOUND
@@ -208,7 +207,7 @@ def test_get_action_rules_actor_not_in_case_returns_404(client_actors, dl):
 
     resp = client_actors.get(
         "/actors/urn:uuid:99999999-0000-0000-0000-000000000000/cases/"
-        f"{_HTTP_CASE_ID}/action-rules"
+        f"{_URN_CASE_ID}/action-rules"
     )
     assert resp.status_code == status.HTTP_404_NOT_FOUND
 

--- a/test/adapters/driving/fastapi/routers/test_actors.py
+++ b/test/adapters/driving/fastapi/routers/test_actors.py
@@ -30,7 +30,8 @@ from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
 
 _ACTOR_ID = "https://example.org/actors/alice"
 
-# Use urn:uuid IDs for HTTP endpoint tests to avoid path-segment issues.
+# URN IDs used in action-rules tests (retain urn: format for those routes
+# which still have single-segment path params for actor_id sub-paths).
 _HTTP_ACTOR_ID = "urn:uuid:aaaaaaaa-0000-0000-0000-000000000001"
 _HTTP_CASE_ID = "urn:uuid:aaaaaaaa-0000-0000-0000-000000000003"
 _HTTP_PARTICIPANT_ID = "urn:uuid:aaaaaaaa-0000-0000-0000-000000000004"
@@ -318,8 +319,43 @@ class TestCreateActor:
             "id": custom_id,
         }
         client_actors.post("/actors/", json=payload)
-        # GET /actors/{short_id} — path parameters cannot contain '/', so use
-        # the last URL segment; find_actor_by_short_id resolves to the full ID.
+        # Short-ID lookup still works; find_actor_by_short_id resolves to the full ID.
         resp = client_actors.get("/actors/fetchable")
         assert resp.status_code == status.HTTP_200_OK
         assert resp.json()["id"] == custom_id
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for #610: HTTP URL actor IDs must be fetchable
+# ---------------------------------------------------------------------------
+
+_HTTP_URL_ACTOR_ID = "http://vendor:7999/api/v2/actors/alice"
+
+
+def test_get_actor_by_http_url_id_returns_actor(client_actors, dl):
+    """GET /actors/{url-encoded-http-id} must return the stored actor.
+
+    Regression: Starlette decodes %2F to / before routing, so single-segment
+    /{actor_id} never matched HTTP URL actor IDs.  Fix: /{actor_id:path}.
+    """
+    from urllib.parse import quote
+
+    from vultron.adapters.driven.db_record import object_to_record
+    from vultron.wire.as2.vocab.base.objects.actors import as_Organization
+
+    actor = as_Organization(id_=_HTTP_URL_ACTOR_ID, name="VendorActor")
+    dl.create(object_to_record(actor))
+
+    encoded = quote(_HTTP_URL_ACTOR_ID, safe="")
+    resp = client_actors.get(f"/actors/{encoded}")
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["id"] == _HTTP_URL_ACTOR_ID
+
+
+def test_specific_actor_routes_not_shadowed_by_catch_all(
+    client_actors, created_actors
+):
+    """Sub-routes like /{actor_id}/profile still resolve correctly."""
+    for actor in created_actors:
+        resp = client_actors.get(f"/actors/{actor.id_}/profile")
+        assert resp.status_code == status.HTTP_200_OK

--- a/test/adapters/driving/fastapi/routers/test_datalayer.py
+++ b/test/adapters/driving/fastapi/routers/test_datalayer.py
@@ -11,9 +11,12 @@
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
+from urllib.parse import quote
+
 from fastapi import status
 
 from vultron.adapters.driven.db_record import object_to_record
+from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
 
 
 def test_get_offers_returns_empty_dict_when_no_offers(client_datalayer):
@@ -102,3 +105,47 @@ def test_reset_endpoint_clears_all_data(client_datalayer, dl, report, offer):
     resp_reports = client_datalayer.get("/datalayer/Reports/")
     assert resp_reports.status_code == status.HTTP_200_OK
     assert len(resp_reports.json()) == 0
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for #610: URL-format (HTTP URL) keys must be fetchable
+# ---------------------------------------------------------------------------
+
+_HTTP_PARTICIPANT_ID = (
+    "http://vendor:7999/api/v2/actors/case-actor-abc/participant"
+)
+
+
+def test_get_by_http_url_key_returns_stored_record(client_datalayer, dl):
+    """GET /datalayer/{url-encoded-http-id} must return the stored record.
+
+    Regression: Starlette decodes %2F to / before routing, so single-segment
+    /{key} never matched URL-format IDs.  Fix: use /{key:path} as catch-all.
+    """
+    participant = CaseParticipant(id_=_HTTP_PARTICIPANT_ID)
+    dl.create(object_to_record(participant))
+
+    encoded = quote(_HTTP_PARTICIPANT_ID, safe="")
+    response = client_datalayer.get(f"/datalayer/{encoded}")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["id"] == _HTTP_PARTICIPANT_ID
+
+
+def test_get_by_http_url_key_not_found_returns_404(client_datalayer):
+    """Non-existent HTTP URL key returns 404 (not a routing error)."""
+    encoded = quote(
+        "http://vendor:7999/api/v2/actors/missing/participant", safe=""
+    )
+    response = client_datalayer.get(f"/datalayer/{encoded}")
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_specific_routes_not_shadowed_by_catch_all(
+    client_datalayer, dl, offer
+):
+    """Specific routes (e.g. /Offers/) still resolve correctly after fix."""
+    dl.create(object_to_record(offer))
+    response = client_datalayer.get("/datalayer/Offers/")
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert offer.id_ in data

--- a/test/demo/test_two_actor_demo.py
+++ b/test/demo/test_two_actor_demo.py
@@ -874,14 +874,16 @@ class TestWaitForAllParticipantsRmClosed:
     def test_url_based_participant_id_handled_gracefully(
         self, client: TestClient, base: str
     ):
-        """URL-based participant IDs (HTTP URLs with slashes) are handled gracefully.
+        """URL-based participant IDs (HTTP URLs with slashes) are now fetchable.
 
-        The Case Actor's participant ID is an HTTP URL.  The DataLayer
-        ``/{key}`` route cannot serve it — Starlette decodes ``%2F`` before
-        path matching, so encoded slashes still break the single-segment route.
-        ``_all_fetchable_participants_rm_closed`` must catch the resulting
-        exception and skip the participant rather than propagating the error.
+        Regression test for #610.  The Case Actor's participant ID is an HTTP
+        URL.  After the fix (``/{key:path}`` catch-all route), the DataLayer
+        endpoint correctly decodes the URL key and returns the stored record.
+        ``_all_fetchable_participants_rm_closed`` must also handle URL-based
+        IDs without error.
         """
+        from urllib.parse import quote
+
         finder_client, vendor_client, finder, vendor, case = (
             _setup_case_with_3_participants(base)
         )
@@ -899,14 +901,18 @@ class TestWaitForAllParticipantsRmClosed:
         assert (
             url_based_ids
         ), "Expected at least one URL-based participant ID (Case Actor)"
-        # Confirm that a direct fetch of the URL-based participant ID raises an
-        # exception — slashes make the /{key} route unreachable.
-        p_id = url_based_ids[0]
-        with pytest.raises(Exception):
-            vendor_client.get(f"/datalayer/{p_id}")
 
-        # _all_fetchable_participants_rm_closed must not propagate the
-        # exception; it catches and skips unfetchable participant IDs.
+        # After fix: URL-based participant IDs must be fetchable via
+        # the DataLayer endpoint with percent-encoded slashes.
+        p_id = url_based_ids[0]
+        encoded = quote(p_id, safe="")
+        result = vendor_client.get(f"/datalayer/{encoded}")
+        assert (
+            isinstance(result, dict) and result.get("id") == p_id
+        ), f"Expected participant record for URL-format ID {p_id!r}, got {result!r}"
+
+        # _all_fetchable_participants_rm_closed must also handle URL-based
+        # participant IDs without error.
         try:
             demo._all_fetchable_participants_rm_closed(
                 vendor_client, fetched_case

--- a/vultron/adapters/driving/fastapi/routers/actors.py
+++ b/vultron/adapters/driving/fastapi/routers/actors.py
@@ -187,31 +187,6 @@ def create_actor(
 
 
 @router.get(
-    "/{actor_id}",
-    response_model=as_Actor,
-    response_model_exclude_none=True,
-    description="Returns an Actor. (stub implementation).",
-    operation_id="actors_get",
-)
-def get_actor(
-    actor_id: str, datalayer: DataLayer = Depends(get_shared_dl)
-) -> as_Actor:
-    """Returns an Actor example based on the provided actor_id."""
-    actor = datalayer.read(actor_id)
-
-    # If not found by full ID, try to resolve as short ID
-    if not actor:
-        actor = datalayer.find_actor_by_short_id(actor_id)
-
-    if not actor:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Actor not found."
-        )
-
-    return as_Actor.model_validate(actor)
-
-
-@router.get(
     "/{actor_id}/profile",
     response_model_exclude_none=True,
     summary="Get Actor Profile",
@@ -542,3 +517,32 @@ def post_actor_outbox(
     )
 
     return None
+
+
+@router.get(
+    "/{actor_id:path}",
+    response_model=as_Actor,
+    response_model_exclude_none=True,
+    description="Returns an Actor by full ID including HTTP URL IDs.",
+    operation_id="actors_get",
+)
+def get_actor(
+    actor_id: str, datalayer: DataLayer = Depends(get_shared_dl)
+) -> as_Actor:
+    """Returns an Actor by actor_id.
+
+    Accepts any actor ID including HTTP URL IDs with percent-encoded slashes.
+    Falls back to short-ID resolution for backwards compatibility.
+    """
+    actor = datalayer.read(actor_id)
+
+    # If not found by full ID, try to resolve as short ID
+    if not actor:
+        actor = datalayer.find_actor_by_short_id(actor_id)
+
+    if not actor:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Actor not found."
+        )
+
+    return as_Actor.model_validate(actor)

--- a/vultron/adapters/driving/fastapi/routers/actors.py
+++ b/vultron/adapters/driving/fastapi/routers/actors.py
@@ -187,7 +187,7 @@ def create_actor(
 
 
 @router.get(
-    "/{actor_id}/profile",
+    "/{actor_id:path}/profile",
     response_model_exclude_none=True,
     summary="Get Actor Profile",
     description=(
@@ -225,7 +225,7 @@ def get_actor_profile(
 
 
 @router.get(
-    "/{actor_id}/cases/{case_id}/action-rules",
+    "/{actor_id:path}/cases/{case_id}/action-rules",
     summary="Get CVD Action Rules for an Actor in a Case",
     description=(
         "Returns the set of valid CVD actions available to an actor in a "
@@ -256,7 +256,7 @@ def get_action_rules(
 
 
 @router.get(
-    "/{actor_id}/inbox",
+    "/{actor_id:path}/inbox",
     response_model=as_OrderedCollection,
     response_model_exclude_none=True,
     summary="Get Actor Inbox",
@@ -393,7 +393,7 @@ def _record_inbox_receipt(
 
 
 @router.post(
-    "/{actor_id}/inbox/",
+    "/{actor_id:path}/inbox/",
     summary="Add an Activity to the Actor's Inbox.",
     description="Adds an Activity to the Actor's Inbox. (stub implementation).",
     status_code=status.HTTP_202_ACCEPTED,
@@ -452,7 +452,7 @@ def post_actor_inbox(
 
 
 @router.post(
-    "/{actor_id}/outbox/",
+    "/{actor_id:path}/outbox/",
     summary="Add an Activity to the Actor's Outbox.",
     description="Adds an Activity to the Actor's Outbox. (stub implementation).",
     status_code=status.HTTP_200_OK,

--- a/vultron/adapters/driving/fastapi/routers/datalayer.py
+++ b/vultron/adapters/driving/fastapi/routers/datalayer.py
@@ -37,20 +37,6 @@ router = APIRouter(prefix="/datalayer", tags=["datalayer"])
 
 
 @router.get(
-    "/{key}",
-    description="Returns a specific object by key.",
-    operation_id="datalayer_get_by_key",
-)
-def get_object_by_key(key: str, datalayer: DataLayer = Depends(get_shared_dl)):
-    obj = datalayer.read(key)
-
-    if not obj:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
-
-    return obj
-
-
-@router.get(
     "/{object_type}/{object_id}",
     description="Returns a specific object by type and ID.",
     operation_id="datalayer_get_by_type_and_id",
@@ -239,3 +225,18 @@ def reset_datalayer(
         "status": "datalayer reset successfully",
         "n_items": datalayer.count_all(),
     }
+
+
+@router.get(
+    "/{key:path}",
+    description="Returns a specific object by key. Accepts any key including "
+    "HTTP URL keys with percent-encoded slashes.",
+    operation_id="datalayer_get_by_key",
+)
+def get_object_by_key(key: str, datalayer: DataLayer = Depends(get_shared_dl)):
+    obj = datalayer.read(key)
+
+    if not obj:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+
+    return obj

--- a/vultron/demo/helpers/seeding.py
+++ b/vultron/demo/helpers/seeding.py
@@ -40,13 +40,9 @@ def _dl_key(key: str) -> str:
     """URL-encode a DataLayer key for safe embedding in an API path segment.
 
     Encodes characters that are illegal in URL path segments (e.g., colons in
-    URN-style keys like ``urn:uuid:...``).
-
-    Note: HTTP URL-based participant IDs (which contain literal slashes)
-    cannot be fetched via the single-segment ``/{key}`` DataLayer route even
-    after URL-encoding, because Starlette decodes ``%2F`` back to ``/`` before
-    path matching.  Such IDs must be handled via exception catching at the
-    call site.
+    URN-style keys like ``urn:uuid:...``) and slashes in HTTP URL keys.
+    The DataLayer ``/{key:path}`` route accepts percent-encoded slashes and
+    correctly reconstructs the original key before the DataLayer lookup.
     """
     return quote(str(key), safe="")
 


### PR DESCRIPTION
Fixes #610

## Problem

`GET /api/v2/datalayer/{url-encoded-id}` returned 404 for CaseParticipant IDs
stored with HTTP URL keys (e.g. `http://vendor:7999/.../participant`). Starlette
decodes `%2F` → `/` before path matching, so the single-segment `/{key}` route
never matched. The same bug existed in `GET /actors/{actor_id}`.

## Fix

- **`datalayer.py`**: Replace `/{key}` (first route) with `/{key:path}` registered
  last — specific routes (/Offers/, /Reports/, /Actors/, etc.) continue to
  match before the catch-all.
- **`actors.py`**: Same — `/{actor_id:path}` appended as last route.
- **`seeding.py`**: Remove "known limitation" from `_dl_key()` docstring.

## Tests

- Added unit regression tests for URL-format key lookup in both routers.
- Updated `test_url_based_participant_id_handled_gracefully` integration test
  to assert the now-correct behaviour (fetch succeeds) rather than the old
  workaround (fetch raises).