### PR TITLE
feat(sync): cascade CaseLogEntry + Announce to all Case Actor received handlers

### DIFF
--- a/plan/history/2605/README.md
+++ b/plan/history/2605/README.md
@@ -4,6 +4,7 @@
 
 | Date | Time (UTC) | Type | Source | Title |
 |------|------------|------|--------|-------|
+| 2026-05-21 | 21:04 | implementation | ISSUE-595 | Cascade CaseLogEntry + Announce to all Case Actor received handlers |
 | 2026-05-21 | 20:57 | implementation | ISSUE-596 | Refactor sender-side trigger use cases into SenderSideBT |
 | 2026-05-21 | 19:19 | implementation | 610 | Fix DataLayer and actors endpoints for HTTP URL keys (#610) |
 | 2026-05-21 | 18:10 | implementation | ISSUE-594 | Fix outbound routing: participant triggers address Case Actor only |

--- a/plan/history/2605/implementation/ISSUE-595.md
+++ b/plan/history/2605/implementation/ISSUE-595.md
@@ -1,0 +1,75 @@
+---
+source: ISSUE-595
+timestamp: '2026-05-21T21:04:35.246076+00:00'
+title: Cascade CaseLogEntry + Announce to all Case Actor received handlers
+type: implementation
+---
+
+## Issue #595 — Implement automatic CaseLogEntry + Announce(CaseLogEntry) broadcast cascade in all Case Actor received handlers
+
+Wired the CaseLogEntry commit-and-fan-out cascade into all Case Actor
+received-side handlers that were missing it. Previously, only the
+SYNC-2/SYNC-3 handlers produced log entries; note, status, and embargo
+handlers silently accepted messages without broadcasting state changes
+to participants.
+
+### Handlers updated
+
+- **AC-1 — Note**: `AddNoteToCaseReceivedUseCase` — commits a
+  `CaseLogEntry` (event_type `add_note_to_case`) after the note is
+  accepted and saved.
+- **AC-2 — Status**: `AddParticipantStatusToParticipantReceivedUseCase`
+  — commits on BT SUCCESS only; returns early on BT FAILURE (rejected
+  update must not be broadcast to peers as an accepted state change).
+- **AC-3 — Embargo** (all 5 handlers via shared
+  `_commit_embargo_log_cascade()` helper):
+  - `AddEmbargoEventToCaseReceivedUseCase`
+  - `RemoveEmbargoEventFromCaseReceivedUseCase` — cascades on both
+    SUCCESS and FAILURE (FAILURE = embargo already cleared = idempotent
+    non-error)
+  - `InviteToEmbargoOnCaseReceivedUseCase`
+  - `AcceptInviteToEmbargoOnCaseReceivedUseCase`
+  - `RejectInviteToEmbargoOnCaseReceivedUseCase`
+- **AC-4 — Demo endpoint**: `demo_sync_log_entry` docstring updated
+  with `TEST SCAFFOLD ONLY` note.
+
+### Bugfixes discovered during testing
+
+Two pre-existing silent bugs in the embargo handlers were uncovered:
+
+- **`InviteToEmbargoOnCaseReceivedUseCase`**: used
+  `activity.context_` (JSON-LD `@context` = AS2 namespace URI) instead
+  of `request.context_id` (AS2 `context` property = case URI). The
+  participant consent-state update and cascade were both silently
+  skipped for every inbound invite.
+- **`RejectInviteToEmbargoOnCaseReceivedUseCase`**: used
+  `invite.context_` instead of `invite.context` when reading back the
+  stored proposal from the DataLayer, causing `case_id` to resolve to
+  the AS2 namespace and the participant update/cascade to be skipped.
+
+### Adapter wiring
+
+`_SYNC_PORT_SEMANTICS` in `inbox_handler.py` expanded from 2 to 9
+entries: `ADD_EMBARGO_EVENT_TO_CASE`, `ADD_NOTE_TO_CASE`,
+`ADD_PARTICIPANT_STATUS_TO_PARTICIPANT`,
+`ACCEPT_INVITE_TO_EMBARGO_ON_CASE`, `INVITE_TO_EMBARGO_ON_CASE`,
+`REJECT_INVITE_TO_EMBARGO_ON_CASE`, `REMOVE_EMBARGO_EVENT_FROM_CASE`.
+
+### Tests
+
+10 new cascade tests across 3 test files:
+
+- `TestNoteUseCases` — log entry committed; no outbox messages without
+  sync_port
+- `TestParticipantStatusLogEntryCascade` — cascade on BT success; no
+  outbox messages without sync_port
+- `TestEmbargoLogEntryCascade` — one test per handler; BT-failure
+  cascade for `RemoveEmbargo`
+
+Code review flagged an apparent inconsistency between `RemoveEmbargo`
+(cascades on failure) and `AddParticipantStatus` (success-only). The
+difference is intentional and was documented in a follow-up commit.
+
+All 2477 tests pass; Black, flake8, mypy, and pyright clean.
+
+**PR**: [#620](https://github.com/CERTCC/Vultron/pull/620)

--- a/test/core/use_cases/received/test_embargo.py
+++ b/test/core/use_cases/received/test_embargo.py
@@ -17,6 +17,11 @@ from typing import Any, cast
 from unittest.mock import MagicMock
 
 from vultron.adapters.driven.db_record import StorableRecord
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.adapters.driven.sync_activity_adapter import SyncActivityAdapter
+from vultron.core.models.case_actor import VultronCaseActor
+from vultron.core.models.case_log_entry import VultronCaseLogEntry
+from vultron.core.models.protocols import is_log_entry_model
 from vultron.core.states.em import EM
 from vultron.core.use_cases.received.embargo import (
     AnnounceEmbargoEventToCaseReceivedUseCase,
@@ -43,6 +48,8 @@ from vultron.wire.as2.factories import (
 from vultron.adapters.driven.trigger_activity_adapter import (
     TriggerActivityAdapter,
 )
+from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
 
 
 class TestEmbargoUseCases:
@@ -709,4 +716,295 @@ class TestAnnounceEmbargoEventToCaseReceivedUseCase:
         assert any(
             "no receiver-side state change required" in r.message
             for r in caplog.records
+        )
+
+
+# ---------------------------------------------------------------------------
+# CaseLogEntry cascade tests (PCR-08-003, PCR-08-004) — AC-3
+# ---------------------------------------------------------------------------
+
+
+def _make_embargo_case_with_actor(
+    case_id: str,
+    author_id: str,
+    extra_participants: list[str] | None = None,
+) -> tuple[SqliteDataLayer, VultronCaseActor, VulnerabilityCase, EmbargoEvent]:
+    """Return (dl, case_actor, case, embargo) ready for cascade tests.
+
+    Also creates ``CaseParticipant`` objects so actor → participant lookups
+    in the embargo handlers succeed.
+    """
+    from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+
+    dl = SqliteDataLayer("sqlite:///:memory:")
+    case_actor_id = f"{case_id}/actor"
+
+    case_actor = VultronCaseActor(
+        id_=case_actor_id,
+        name=f"CaseActor for {case_id}",
+        attributed_to=author_id,
+        context=case_id,
+    )
+    dl.create(case_actor)
+
+    case = VulnerabilityCase(
+        id_=case_id,
+        name="Embargo Cascade Case",
+        attributed_to=author_id,
+    )
+    p1_id = f"{case_id}/participants/p1"
+    case.actor_participant_index[author_id] = p1_id
+    p1 = CaseParticipant(id_=p1_id, context=case_id, attributed_to=author_id)
+    dl.create(p1)
+
+    for pid in extra_participants or []:
+        short = pid.rsplit("/", 1)[-1]
+        pn_id = f"{case_id}/participants/{short}"
+        case.actor_participant_index[pid] = pn_id
+        pn = CaseParticipant(id_=pn_id, context=case_id, attributed_to=pid)
+        dl.create(pn)
+
+    dl.create(case)
+
+    embargo = EmbargoEvent(
+        id_=f"{case_id}/embargo_events/e1",
+        content="Cascade test embargo",
+        context=case_id,
+    )
+    dl.create(embargo)
+
+    return dl, case_actor, case, embargo
+
+
+class TestEmbargoLogEntryCascade:
+    """CaseLogEntry cascade for each embargo received-side handler (AC-3)."""
+
+    def test_add_embargo_event_commits_log_entry(self, make_payload):
+        """AddEmbargoEventToCaseReceivedUseCase commits a CaseLogEntry."""
+        author_id = "https://example.org/users/coord"
+        case_id = "https://example.org/cases/em_cas_add"
+        dl, case_actor, case, embargo = _make_embargo_case_with_actor(
+            case_id, author_id
+        )
+        case = cast(VulnerabilityCase, dl.read(case.id_))
+        assert case is not None
+        case.current_status.em_state = EM.PROPOSED
+        dl.save(case)
+
+        activity = add_embargo_to_case_activity(
+            embargo, target=case, actor=author_id
+        )
+        event = make_payload(activity, receiving_actor_id=case_actor.id_)
+        sync_port = SyncActivityAdapter(dl)
+        AddEmbargoEventToCaseReceivedUseCase(
+            dl, event, sync_port=sync_port
+        ).execute()
+
+        entries = [
+            obj
+            for obj in dl.list_objects("CaseLogEntry")
+            if is_log_entry_model(obj)
+            and cast(VultronCaseLogEntry, obj).case_id == case_id
+        ]
+        assert len(entries) == 1
+        assert cast(VultronCaseLogEntry, entries[0]).event_type == (
+            "add_embargo_event_to_case"
+        )
+
+    def test_remove_embargo_event_commits_log_entry(self, make_payload):
+        """RemoveEmbargoEventFromCaseReceivedUseCase commits a CaseLogEntry."""
+        import py_trees
+
+        py_trees.blackboard.Blackboard.enable_activity_stream()
+        py_trees.blackboard.Blackboard.storage.clear()
+
+        author_id = "https://example.org/users/coord"
+        case_id = "https://example.org/cases/em_cas_rem"
+        dl, case_actor, case, embargo = _make_embargo_case_with_actor(
+            case_id, author_id
+        )
+        case = cast(VulnerabilityCase, dl.read(case.id_))
+        assert case is not None
+        case.current_status.em_state = EM.ACTIVE
+        case.proposed_embargoes.append(embargo.id_)
+        case.active_embargo = embargo.id_  # type: ignore[assignment]
+        dl.save(case)
+
+        activity = remove_embargo_from_case_activity(
+            embargo, origin=case, actor=author_id
+        )
+        event = make_payload(activity, receiving_actor_id=case_actor.id_)
+        sync_port = SyncActivityAdapter(dl)
+        RemoveEmbargoEventFromCaseReceivedUseCase(
+            dl, event, sync_port=sync_port
+        ).execute()
+
+        entries = [
+            obj
+            for obj in dl.list_objects("CaseLogEntry")
+            if is_log_entry_model(obj)
+            and cast(VultronCaseLogEntry, obj).case_id == case_id
+        ]
+        assert len(entries) == 1
+        assert cast(VultronCaseLogEntry, entries[0]).event_type == (
+            "remove_embargo_event_from_case"
+        )
+
+    def test_remove_embargo_commits_log_entry_on_bt_failure(
+        self, make_payload
+    ):
+        """RemoveEmbargoEventFromCaseReceivedUseCase cascades even when BT fails.
+
+        BT FAILURE means "embargo already cleared" — it is not an error. The
+        CaseLogEntry MUST be committed regardless so participants learn the
+        current state.
+        """
+        import py_trees
+
+        py_trees.blackboard.Blackboard.enable_activity_stream()
+        py_trees.blackboard.Blackboard.storage.clear()
+
+        author_id = "https://example.org/users/coord"
+        case_id = "https://example.org/cases/em_cas_rem_fail"
+        dl, case_actor, case, embargo = _make_embargo_case_with_actor(
+            case_id, author_id
+        )
+        # EM.NONE: no active embargo — BT will FAIL (IsActiveEmbargoNode)
+        case = cast(VulnerabilityCase, dl.read(case.id_))
+        assert case is not None
+        case.current_status.em_state = EM.NONE
+        dl.save(case)
+
+        activity = remove_embargo_from_case_activity(
+            embargo, origin=case, actor=author_id
+        )
+        event = make_payload(activity, receiving_actor_id=case_actor.id_)
+        sync_port = SyncActivityAdapter(dl)
+        RemoveEmbargoEventFromCaseReceivedUseCase(
+            dl, event, sync_port=sync_port
+        ).execute()
+
+        entries = [
+            obj
+            for obj in dl.list_objects("CaseLogEntry")
+            if is_log_entry_model(obj)
+            and cast(VultronCaseLogEntry, obj).case_id == case_id
+        ]
+        # Cascade must fire even on BT FAILURE.
+        assert len(entries) == 1
+
+    def test_invite_to_embargo_commits_log_entry(self, make_payload):
+        """InviteToEmbargoOnCaseReceivedUseCase commits a CaseLogEntry."""
+        author_id = "https://example.org/users/coord"
+        case_id = "https://example.org/cases/em_cas_invite"
+        invitee_id = "https://example.org/users/vendor"
+        dl, case_actor, case, embargo = _make_embargo_case_with_actor(
+            case_id, author_id, extra_participants=[invitee_id]
+        )
+
+        proposal = em_propose_embargo_activity(
+            embargo,
+            context=case_id,
+            actor=author_id,
+            id_=f"{case_id}/embargo_proposals/1",
+        )
+        dl.create(proposal)
+
+        # receiving_actor_id must be a participant actor so the handler can
+        # look up the participant's consent state.
+        event = make_payload(proposal, receiving_actor_id=invitee_id)
+        sync_port = SyncActivityAdapter(dl)
+        InviteToEmbargoOnCaseReceivedUseCase(
+            dl, event, sync_port=sync_port
+        ).execute()
+
+        entries = [
+            obj
+            for obj in dl.list_objects("CaseLogEntry")
+            if is_log_entry_model(obj)
+            and cast(VultronCaseLogEntry, obj).case_id == case_id
+        ]
+        assert len(entries) == 1
+        assert cast(VultronCaseLogEntry, entries[0]).event_type == (
+            "invite_to_embargo_on_case"
+        )
+
+    def test_accept_invite_to_embargo_commits_log_entry(self, make_payload):
+        """AcceptInviteToEmbargoOnCaseReceivedUseCase commits a CaseLogEntry."""
+        coordinator_id = "https://example.org/users/coordinator"
+        case_id = "https://example.org/cases/em_cas_accept"
+        dl, case_actor, case, embargo = _make_embargo_case_with_actor(
+            case_id, coordinator_id
+        )
+        case = cast(VulnerabilityCase, dl.read(case.id_))
+        assert case is not None
+        case.current_status.em_state = EM.PROPOSED
+        dl.save(case)
+
+        proposal = em_propose_embargo_activity(
+            embargo,
+            context=case,
+            actor="https://example.org/users/vendor",
+            id_=f"{case_id}/embargo_proposals/1",
+        )
+        dl.create(proposal)
+
+        accept = em_accept_embargo_activity(
+            proposal,
+            context=case,
+            actor=coordinator_id,
+        )
+        event = make_payload(accept, receiving_actor_id=case_actor.id_)
+        sync_port = SyncActivityAdapter(dl)
+        AcceptInviteToEmbargoOnCaseReceivedUseCase(
+            dl, event, sync_port=sync_port
+        ).execute()
+
+        entries = [
+            obj
+            for obj in dl.list_objects("CaseLogEntry")
+            if is_log_entry_model(obj)
+            and cast(VultronCaseLogEntry, obj).case_id == case_id
+        ]
+        assert len(entries) == 1
+        assert cast(VultronCaseLogEntry, entries[0]).event_type == (
+            "accept_invite_to_embargo_on_case"
+        )
+
+    def test_reject_invite_to_embargo_commits_log_entry(self, make_payload):
+        """RejectInviteToEmbargoOnCaseReceivedUseCase commits a CaseLogEntry."""
+        coordinator_id = "https://example.org/users/coordinator"
+        case_id = "https://example.org/cases/em_cas_reject"
+        dl, case_actor, case, embargo = _make_embargo_case_with_actor(
+            case_id, coordinator_id
+        )
+
+        proposal = em_propose_embargo_activity(
+            embargo,
+            context=case_id,
+            actor="https://example.org/users/vendor",
+            id_=f"{case_id}/embargo_proposals/1",
+        )
+        dl.create(proposal)
+
+        reject = em_reject_embargo_activity(
+            proposal,
+            context=case_id,
+            actor=coordinator_id,
+        )
+        event = make_payload(reject, receiving_actor_id=case_actor.id_)
+        sync_port = SyncActivityAdapter(dl)
+        RejectInviteToEmbargoOnCaseReceivedUseCase(
+            dl, event, sync_port=sync_port
+        ).execute()
+
+        entries = [
+            obj
+            for obj in dl.list_objects("CaseLogEntry")
+            if is_log_entry_model(obj)
+            and cast(VultronCaseLogEntry, obj).case_id == case_id
+        ]
+        assert len(entries) == 1
+        assert cast(VultronCaseLogEntry, entries[0]).event_type == (
+            "reject_invite_to_embargo_on_case"
         )

--- a/test/core/use_cases/received/test_note.py
+++ b/test/core/use_cases/received/test_note.py
@@ -15,7 +15,10 @@
 from typing import Any, cast
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.adapters.driven.sync_activity_adapter import SyncActivityAdapter
 from vultron.core.models.case_actor import VultronCaseActor
+from vultron.core.models.case_log_entry import VultronCaseLogEntry
+from vultron.core.models.protocols import is_log_entry_model
 from vultron.core.use_cases.received.note import (
     AddNoteToCaseReceivedUseCase,
     CreateNoteReceivedUseCase,
@@ -401,3 +404,130 @@ class TestNoteUseCases:
         assert refreshed is not None
         refreshed = cast(VulnerabilityCase, refreshed)
         assert note.id_ in refreshed.notes
+
+    # ------------------------------------------------------------------
+    # CaseLogEntry cascade tests (PCR-08-003, PCR-08-004) — AC-1
+    # ------------------------------------------------------------------
+
+    def test_add_note_commits_log_entry_when_sync_port_provided(
+        self, make_payload
+    ):
+        """AddNoteToCaseReceivedUseCase commits a CaseLogEntry (PCR-08-003).
+
+        When a sync_port is injected and receiving_actor_id is set, the use
+        case MUST commit one VultronCaseLogEntry after accepting a note
+        addition.
+        """
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case_actor_id = "https://example.org/cases/case_le1/actor"
+        author_id = "https://example.org/users/vendor"
+        participant_id = "https://example.org/users/finder"
+        case_id = "https://example.org/cases/case_le1"
+
+        case_actor = VultronCaseActor(
+            id_=case_actor_id,
+            name="CaseActor le1",
+            attributed_to=author_id,
+            context=case_id,
+        )
+        dl.create(case_actor)
+
+        case = VulnerabilityCase(
+            id_=case_id,
+            name="Log Entry Cascade Case",
+            attributed_to=author_id,
+        )
+        case.actor_participant_index[author_id] = (
+            "https://example.org/participants/p-le1-vendor"
+        )
+        case.actor_participant_index[participant_id] = (
+            "https://example.org/participants/p-le1-finder"
+        )
+        dl.create(case)
+
+        note = as_Note(
+            id_="https://example.org/notes/note_le1",
+            content="Log entry cascade note",
+            context=case_id,
+        )
+        dl.create(note)
+
+        activity = add_note_to_case_activity(
+            note, target=case, actor=author_id
+        )
+        event = make_payload(activity, receiving_actor_id=case_actor_id)
+
+        sync_port = SyncActivityAdapter(dl)
+        AddNoteToCaseReceivedUseCase(dl, event, sync_port=sync_port).execute()
+
+        # Exactly one CaseLogEntry should be persisted for this case.
+        entries = [
+            obj
+            for obj in dl.list_objects("CaseLogEntry")
+            if is_log_entry_model(obj)
+            and cast(VultronCaseLogEntry, obj).case_id == case_id
+        ]
+        assert len(entries) == 1
+        entry = cast(VultronCaseLogEntry, entries[0])
+        assert entry.event_type == "add_note_to_case"
+        assert entry.log_object_id == note.id_
+
+    def test_add_note_no_fanout_without_sync_port(self, make_payload):
+        """No fan-out Announce(CaseLogEntry) is sent when sync_port is None.
+
+        The log entry IS committed locally, but no outbox messages are queued
+        for delivery to participants.
+        """
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case_actor_id = "https://example.org/cases/case_le2/actor"
+        author_id = "https://example.org/users/vendor"
+        participant_id = "https://example.org/users/finder"
+        case_id = "https://example.org/cases/case_le2"
+
+        case_actor = VultronCaseActor(
+            id_=case_actor_id,
+            name="CaseActor le2",
+            attributed_to=author_id,
+            context=case_id,
+        )
+        dl.create(case_actor)
+
+        case = VulnerabilityCase(
+            id_=case_id,
+            name="No Sync Port Case",
+            attributed_to=author_id,
+        )
+        case.actor_participant_index[author_id] = (
+            "https://example.org/participants/p-le2-vendor"
+        )
+        case.actor_participant_index[participant_id] = (
+            "https://example.org/participants/p-le2-finder"
+        )
+        dl.create(case)
+
+        note = as_Note(
+            id_="https://example.org/notes/note_le2",
+            content="No cascade note",
+            context=case_id,
+        )
+        dl.create(note)
+
+        activity = add_note_to_case_activity(
+            note, target=case, actor=author_id
+        )
+        event = make_payload(activity, receiving_actor_id=case_actor_id)
+
+        # No sync_port — log entry is committed but fan-out is skipped.
+        AddNoteToCaseReceivedUseCase(dl, event, sync_port=None).execute()
+
+        # Log entry MUST be committed locally even without a sync_port.
+        entries = [
+            obj
+            for obj in dl.list_objects("CaseLogEntry")
+            if is_log_entry_model(obj)
+            and cast(VultronCaseLogEntry, obj).case_id == case_id
+        ]
+        assert len(entries) == 1
+
+        # But no outbox activities should be queued for fan-out.
+        assert dl.outbox_list() == []

--- a/test/core/use_cases/received/test_status.py
+++ b/test/core/use_cases/received/test_status.py
@@ -15,6 +15,10 @@
 from typing import cast
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.adapters.driven.sync_activity_adapter import SyncActivityAdapter
+from vultron.core.models.case_actor import VultronCaseActor
+from vultron.core.models.case_log_entry import VultronCaseLogEntry
+from vultron.core.models.protocols import is_log_entry_model
 from vultron.core.states.em import EM
 from vultron.core.use_cases.received.status import (
     AddCaseStatusToCaseReceivedUseCase,
@@ -265,3 +269,129 @@ class TestStatusUseCases:
             getattr(s, "id_", s) for s in participant.participant_statuses
         ]
         assert pstatus.id_ in status_ids
+
+
+# ---------------------------------------------------------------------------
+# CaseLogEntry cascade tests (PCR-08-003, PCR-08-004) — AC-2
+# ---------------------------------------------------------------------------
+
+
+class TestParticipantStatusLogEntryCascade:
+    """CaseLogEntry cascade for AddParticipantStatusToParticipantReceivedUseCase."""
+
+    def _make_dl(self, case_id: str, actor_id: str) -> tuple:
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case_actor_id = f"{case_id}/actor"
+        case_actor = VultronCaseActor(
+            id_=case_actor_id,
+            name=f"CaseActor for {case_id}",
+            attributed_to=actor_id,
+            context=case_id,
+        )
+        dl.create(case_actor)
+
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+
+        case = VulnerabilityCase(
+            id_=case_id,
+            name="Status Cascade Case",
+            attributed_to=actor_id,
+        )
+        case.case_participants.append(f"{case_id}/participants/p1")
+        case.actor_participant_index[actor_id] = f"{case_id}/participants/p1"
+        dl.create(case)
+
+        participant = CaseParticipant(
+            id_=f"{case_id}/participants/p1",
+            context=case_id,
+            attributed_to=actor_id,
+        )
+        dl.create(participant)
+
+        pstatus = ParticipantStatus(
+            id_=f"{case_id}/participants/p1/statuses/s1",
+            context=case_id,
+        )
+        dl.create(pstatus)
+
+        return dl, case_actor_id, participant, pstatus
+
+    def test_cascade_commits_log_entry_on_success(self, make_payload):
+        """Cascade commits a CaseLogEntry when BT succeeds (AC-2)."""
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+
+        actor_id = "https://example.org/users/vendor"
+        case_id = "https://example.org/cases/st_le1"
+        dl, case_actor_id, participant, pstatus = self._make_dl(
+            case_id, actor_id
+        )
+        case = cast(VulnerabilityCase, dl.read(case_id))
+        assert case is not None
+
+        activity = add_status_to_participant_activity(
+            pstatus,
+            target=participant,
+            actor=actor_id,
+            context=case,
+        )
+        event = make_payload(activity, receiving_actor_id=case_actor_id)
+        sync_port = SyncActivityAdapter(dl)
+        AddParticipantStatusToParticipantReceivedUseCase(
+            dl, event, sync_port=sync_port
+        ).execute()
+
+        entries = [
+            obj
+            for obj in dl.list_objects("CaseLogEntry")
+            if is_log_entry_model(obj)
+            and cast(VultronCaseLogEntry, obj).case_id == case_id
+        ]
+        assert len(entries) == 1
+        assert cast(VultronCaseLogEntry, entries[0]).event_type == (
+            "add_participant_status"
+        )
+
+    def test_no_fanout_without_sync_port(self, make_payload):
+        """No fan-out Announce(CaseLogEntry) is sent when sync_port is None.
+
+        The log entry IS committed locally, but no outbox messages are queued
+        for delivery to participants.
+        """
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+
+        actor_id = "https://example.org/users/vendor"
+        case_id = "https://example.org/cases/st_le2"
+        dl, case_actor_id, participant, pstatus = self._make_dl(
+            case_id, actor_id
+        )
+        case = cast(VulnerabilityCase, dl.read(case_id))
+        assert case is not None
+
+        activity = add_status_to_participant_activity(
+            pstatus,
+            target=participant,
+            actor=actor_id,
+            context=case,
+        )
+        event = make_payload(activity, receiving_actor_id=case_actor_id)
+        AddParticipantStatusToParticipantReceivedUseCase(
+            dl, event, sync_port=None
+        ).execute()
+
+        # Log entry MUST be committed locally even without a sync_port.
+        entries = [
+            obj
+            for obj in dl.list_objects("CaseLogEntry")
+            if is_log_entry_model(obj)
+            and cast(VultronCaseLogEntry, obj).case_id == case_id
+        ]
+        assert len(entries) == 1
+
+        # But no outbox activities should be queued for fan-out.
+        assert dl.outbox_list() == []

--- a/vultron/adapters/driving/fastapi/inbox_handler.py
+++ b/vultron/adapters/driving/fastapi/inbox_handler.py
@@ -76,8 +76,15 @@ def _trigger_activity_port_factory(dl: DataLayer) -> dict[str, Any]:
 
 _SYNC_PORT_SEMANTICS = frozenset(
     {
+        MessageSemantics.ADD_EMBARGO_EVENT_TO_CASE,
+        MessageSemantics.ADD_NOTE_TO_CASE,
+        MessageSemantics.ADD_PARTICIPANT_STATUS_TO_PARTICIPANT,
+        MessageSemantics.ACCEPT_INVITE_TO_EMBARGO_ON_CASE,
         MessageSemantics.ANNOUNCE_CASE_LOG_ENTRY,
+        MessageSemantics.INVITE_TO_EMBARGO_ON_CASE,
         MessageSemantics.REJECT_CASE_LOG_ENTRY,
+        MessageSemantics.REJECT_INVITE_TO_EMBARGO_ON_CASE,
+        MessageSemantics.REMOVE_EMBARGO_EVENT_FROM_CASE,
     }
 )
 

--- a/vultron/adapters/driving/fastapi/routers/demo_triggers.py
+++ b/vultron/adapters/driving/fastapi/routers/demo_triggers.py
@@ -128,6 +128,12 @@ def demo_sync_log_entry(
         TRIG-09-001, TRIG-09-004, TRIG-10-004,
         SYNC-02-002, SYNC-02-003, TB-01-001, TB-01-002, TB-04-001,
         TB-06-001, TB-06-002, TB-07-001
+
+    TEST SCAFFOLD ONLY — do not call from normal protocol flows.
+    In production, CaseLogEntry commits fire automatically as a cascade
+    consequence of every accepted participant message (PCR-08-003, PCR-08-004).
+    This endpoint exists only to let demo/test scripts inject log entries
+    manually during verification.
     """
     actor = dl.read(actor_id) or dl.find_actor_by_short_id(actor_id)
     canonical_actor_id = (

--- a/vultron/core/use_cases/received/embargo.py
+++ b/vultron/core/use_cases/received/embargo.py
@@ -66,7 +66,21 @@ def _commit_embargo_log_cascade(
         )
         return
 
-    actor_id = receiving_actor_id
+    # Resolve the CaseActor ID.  Only use receiving_actor_id if it
+    # resolves to a Service (CaseActor) whose context matches case_id.
+    # Some handlers (e.g. InviteToEmbargoOnCaseReceivedUseCase) set
+    # receiving_actor_id to the invitee's actor ID; using that would
+    # attribute the log entry to the wrong actor and exclude the wrong
+    # recipient from fan-out.
+    actor_id: str | None = None
+    if receiving_actor_id is not None:
+        obj = dl.read(receiving_actor_id)
+        if (
+            obj is not None
+            and getattr(obj, "type_", None) == "Service"
+            and str(getattr(obj, "context", None)) == case_id
+        ):
+            actor_id = receiving_actor_id
     if actor_id is None:
         actor_id = _find_case_actor_id(dl, case_id)
     if actor_id is None:

--- a/vultron/core/use_cases/received/embargo.py
+++ b/vultron/core/use_cases/received/embargo.py
@@ -1,6 +1,7 @@
 """Use cases for embargo management activities."""
 
 import logging
+from typing import TYPE_CHECKING
 
 from vultron.core.states.em import (
     EM,
@@ -20,7 +21,10 @@ from vultron.core.models.events.embargo import (
     RejectInviteToEmbargoOnCaseReceivedEvent,
     RemoveEmbargoEventFromCaseReceivedEvent,
 )
-from vultron.core.ports.case_persistence import CasePersistence
+from vultron.core.ports.case_persistence import (
+    CasePersistence,
+    CaseOutboxPersistence,
+)
 from vultron.core.use_cases._helpers import _as_id, _idempotent_create
 from vultron.core.models.protocols import (
     CaseModel,
@@ -29,7 +33,58 @@ from vultron.core.models.protocols import (
     is_participant_model,
 )
 
+if TYPE_CHECKING:
+    from vultron.core.ports.sync_activity import SyncActivityPort
+
 logger = logging.getLogger(__name__)
+
+
+def _commit_embargo_log_cascade(
+    case_id: str | None,
+    object_id: str | None,
+    event_type: str,
+    dl: CaseOutboxPersistence,
+    receiving_actor_id: str | None,
+    sync_port: "SyncActivityPort | None",
+) -> None:
+    """Commit a CaseLogEntry and fan it out to all case participants.
+
+    Shared helper for all embargo received-side handlers that need to fire
+    the ``commit_log_entry → fan_out`` cascade after accepting an embargo
+    operation (PCR-08-003, PCR-08-004).
+
+    Silently skips when *case_id* or *object_id* is ``None``, or when no
+    CaseActor can be resolved.
+    """
+    from vultron.core.use_cases.received.actor import _find_case_actor_id
+    from vultron.core.use_cases.triggers.sync import commit_log_entry_trigger
+
+    if case_id is None or object_id is None:
+        logger.warning(
+            "embargo cascade: missing case_id or object_id"
+            " — skipping log entry cascade (PCR-08-003)"
+        )
+        return
+
+    actor_id = receiving_actor_id
+    if actor_id is None:
+        actor_id = _find_case_actor_id(dl, case_id)
+    if actor_id is None:
+        logger.warning(
+            "embargo cascade: cannot resolve CaseActor for case '%s'"
+            " — skipping log entry cascade (PCR-08-003)",
+            case_id,
+        )
+        return
+
+    commit_log_entry_trigger(
+        case_id=case_id,
+        object_id=object_id,
+        event_type=event_type,
+        actor_id=actor_id,
+        dl=dl,
+        sync_port=sync_port,
+    )
 
 
 def _reset_case_participant_embargo_consent(
@@ -176,10 +231,14 @@ class CreateEmbargoEventReceivedUseCase:
 
 class AddEmbargoEventToCaseReceivedUseCase:
     def __init__(
-        self, dl: CasePersistence, request: AddEmbargoEventToCaseReceivedEvent
+        self,
+        dl: CaseOutboxPersistence,
+        request: AddEmbargoEventToCaseReceivedEvent,
+        sync_port: "SyncActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: AddEmbargoEventToCaseReceivedEvent = request
+        self._sync_port = sync_port
 
     def execute(self) -> None:
         request = self._request
@@ -225,15 +284,26 @@ class AddEmbargoEventToCaseReceivedUseCase:
         self._dl.save(case)
         logger.info("Activated embargo '%s' on case '%s'", embargo_id, case_id)
 
+        _commit_embargo_log_cascade(
+            case_id=case_id,
+            object_id=embargo_id,
+            event_type="add_embargo_event_to_case",
+            dl=self._dl,
+            receiving_actor_id=request.receiving_actor_id,
+            sync_port=self._sync_port,
+        )
+
 
 class RemoveEmbargoEventFromCaseReceivedUseCase:
     def __init__(
         self,
-        dl: CasePersistence,
+        dl: CaseOutboxPersistence,
         request: RemoveEmbargoEventFromCaseReceivedEvent,
+        sync_port: "SyncActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: RemoveEmbargoEventFromCaseReceivedEvent = request
+        self._sync_port = sync_port
 
     def execute(self) -> None:
         from py_trees.common import Status
@@ -272,6 +342,18 @@ class RemoveEmbargoEventFromCaseReceivedUseCase:
                 result.feedback_message,
             )
 
+        # Always commit a log entry regardless of BT result.  FAILURE means
+        # the embargo was already cleared or only in proposed_embargoes —
+        # both are non-error outcomes that still require fan-out (PCR-08-003).
+        _commit_embargo_log_cascade(
+            case_id=case_id,
+            object_id=embargo_id,
+            event_type="remove_embargo_event_from_case",
+            dl=self._dl,
+            receiving_actor_id=request.receiving_actor_id,
+            sync_port=self._sync_port,
+        )
+
 
 class AnnounceEmbargoEventToCaseReceivedUseCase:
     def __init__(
@@ -292,10 +374,14 @@ class AnnounceEmbargoEventToCaseReceivedUseCase:
 
 class InviteToEmbargoOnCaseReceivedUseCase:
     def __init__(
-        self, dl: CasePersistence, request: InviteToEmbargoOnCaseReceivedEvent
+        self,
+        dl: CaseOutboxPersistence,
+        request: InviteToEmbargoOnCaseReceivedEvent,
+        sync_port: "SyncActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: InviteToEmbargoOnCaseReceivedEvent = request
+        self._sync_port = sync_port
 
     def execute(self) -> None:
         request = self._request
@@ -311,7 +397,7 @@ class InviteToEmbargoOnCaseReceivedUseCase:
         # Advance the invitee's consent state to INVITED so they can later
         # accept or decline via the PEC machine.
         invitee_id = request.receiving_actor_id
-        case_id = _as_id(getattr(request.activity, "context_", None))
+        case_id = request.context_id
         if not invitee_id or not case_id:
             return
 
@@ -340,15 +426,26 @@ class InviteToEmbargoOnCaseReceivedUseCase:
             case_id,
         )
 
+        _commit_embargo_log_cascade(
+            case_id=case_id,
+            object_id=request.activity_id,
+            event_type="invite_to_embargo_on_case",
+            dl=self._dl,
+            receiving_actor_id=request.receiving_actor_id,
+            sync_port=self._sync_port,
+        )
+
 
 class AcceptInviteToEmbargoOnCaseReceivedUseCase:
     def __init__(
         self,
-        dl: CasePersistence,
+        dl: CaseOutboxPersistence,
         request: AcceptInviteToEmbargoOnCaseReceivedEvent,
+        sync_port: "SyncActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: AcceptInviteToEmbargoOnCaseReceivedEvent = request
+        self._sync_port = sync_port
 
     def execute(self) -> None:
         request = self._request
@@ -386,15 +483,26 @@ class AcceptInviteToEmbargoOnCaseReceivedUseCase:
             case.id_,
         )
 
+        _commit_embargo_log_cascade(
+            case_id=case.id_,
+            object_id=embargo_id,
+            event_type="accept_invite_to_embargo_on_case",
+            dl=self._dl,
+            receiving_actor_id=request.receiving_actor_id,
+            sync_port=self._sync_port,
+        )
+
 
 class RejectInviteToEmbargoOnCaseReceivedUseCase:
     def __init__(
         self,
-        dl: CasePersistence,
+        dl: CaseOutboxPersistence,
         request: RejectInviteToEmbargoOnCaseReceivedEvent,
+        sync_port: "SyncActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: RejectInviteToEmbargoOnCaseReceivedEvent = request
+        self._sync_port = sync_port
 
     def execute(self) -> None:
         request = self._request
@@ -413,7 +521,7 @@ class RejectInviteToEmbargoOnCaseReceivedUseCase:
         if invite_id:
             invite = self._dl.read(invite_id)
             if invite is not None:
-                case_id = _as_id(getattr(invite, "context_", None))
+                case_id = _as_id(getattr(invite, "context", None))
                 embargo_id = _as_id(getattr(invite, "object_", None))
 
         if not case_id:
@@ -443,4 +551,13 @@ class RejectInviteToEmbargoOnCaseReceivedUseCase:
             "Set participant '%s' (actor '%s') embargo consent to DECLINED",
             participant_id,
             rejecting_actor_id,
+        )
+
+        _commit_embargo_log_cascade(
+            case_id=case_id,
+            object_id=invite_id or request.activity_id,
+            event_type="reject_invite_to_embargo_on_case",
+            dl=self._dl,
+            receiving_actor_id=request.receiving_actor_id,
+            sync_port=self._sync_port,
         )

--- a/vultron/core/use_cases/received/note.py
+++ b/vultron/core/use_cases/received/note.py
@@ -1,7 +1,7 @@
 """Use cases for case note activities."""
 
 import logging
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from py_trees.common import Status
 
@@ -17,6 +17,9 @@ from vultron.core.ports.case_persistence import (
 from vultron.core.models.protocols import is_case_model
 from vultron.core.use_cases._helpers import _as_id
 from vultron.wire.as2.factories import add_note_to_case_activity
+
+if TYPE_CHECKING:
+    from vultron.core.ports.sync_activity import SyncActivityPort
 
 logger = logging.getLogger(__name__)
 
@@ -63,10 +66,14 @@ class CreateNoteReceivedUseCase:
 
 class AddNoteToCaseReceivedUseCase:
     def __init__(
-        self, dl: CaseOutboxPersistence, request: AddNoteToCaseReceivedEvent
+        self,
+        dl: CaseOutboxPersistence,
+        request: AddNoteToCaseReceivedEvent,
+        sync_port: "SyncActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: AddNoteToCaseReceivedEvent = request
+        self._sync_port = sync_port
 
     def execute(self) -> None:
         request = self._request
@@ -99,6 +106,10 @@ class AddNoteToCaseReceivedUseCase:
             case_id=case_id,
             author_id=request.actor_id,
             case=case,
+        )
+        self._commit_log_cascade(
+            case_id=case_id,
+            note_id=note_id,
         )
 
     def _broadcast_note_to_participants(
@@ -172,6 +183,42 @@ class AddNoteToCaseReceivedUseCase:
             note_id,
             case_id,
             len(recipient_ids),
+        )
+
+    def _commit_log_cascade(
+        self,
+        case_id: str,
+        note_id: str,
+    ) -> None:
+        """Commit a CaseLogEntry and fan it out to all participants (PCR-08-003).
+
+        Uses ``receiving_actor_id`` (the CaseActor's canonical ID) when
+        available.  Falls back to a DataLayer lookup for the Service object
+        whose ``context`` matches *case_id*.
+        """
+        from vultron.core.use_cases.received.actor import _find_case_actor_id
+        from vultron.core.use_cases.triggers.sync import (
+            commit_log_entry_trigger,
+        )
+
+        actor_id = self._request.receiving_actor_id
+        if actor_id is None:
+            actor_id = _find_case_actor_id(self._dl, case_id)
+        if actor_id is None:
+            logger.warning(
+                "add_note_to_case: cannot resolve CaseActor for case '%s'"
+                " — skipping log entry cascade (PCR-08-003)",
+                case_id,
+            )
+            return
+
+        commit_log_entry_trigger(
+            case_id=case_id,
+            object_id=note_id,
+            event_type="add_note_to_case",
+            actor_id=actor_id,
+            dl=self._dl,
+            sync_port=self._sync_port,
         )
 
 

--- a/vultron/core/use_cases/received/status.py
+++ b/vultron/core/use_cases/received/status.py
@@ -23,6 +23,7 @@ from vultron.core.models.protocols import (
 )
 
 if TYPE_CHECKING:
+    from vultron.core.ports.sync_activity import SyncActivityPort
     from vultron.core.ports.trigger_activity import TriggerActivityPort
 
 logger = logging.getLogger(__name__)
@@ -192,10 +193,12 @@ class AddParticipantStatusToParticipantReceivedUseCase:
         dl: CaseOutboxPersistence,
         request: AddParticipantStatusToParticipantReceivedEvent,
         trigger_activity: "TriggerActivityPort | None" = None,
+        sync_port: "SyncActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: AddParticipantStatusToParticipantReceivedEvent = request
         self._trigger_activity = trigger_activity
+        self._sync_port = sync_port
 
     def execute(self) -> None:
         request = self._request
@@ -231,3 +234,55 @@ class AddParticipantStatusToParticipantReceivedUseCase:
                 request.activity_id,
                 reason or result.feedback_message,
             )
+            return
+
+        self._commit_log_cascade()
+
+    def _commit_log_cascade(self) -> None:
+        """Commit a CaseLogEntry and fan it out to all participants (PCR-08-003).
+
+        Derives case_id from the inline status object's ``context`` field.
+        Uses ``receiving_actor_id`` (the CaseActor's canonical ID) when
+        available, falling back to a DataLayer lookup for the Service object
+        whose ``context`` matches *case_id*.
+        """
+        from vultron.core.use_cases.received.actor import _find_case_actor_id
+        from vultron.core.use_cases.triggers.sync import (
+            commit_log_entry_trigger,
+        )
+
+        request = self._request
+
+        # Derive case_id from the inline status object (same approach as BT).
+        case_id: str | None = None
+        if request.status is not None:
+            context = getattr(request.status, "context", None)
+            if context:
+                case_id = str(context)
+
+        if case_id is None:
+            logger.warning(
+                "add_participant_status: cannot determine case_id"
+                " — skipping log entry cascade (PCR-08-003)"
+            )
+            return
+
+        actor_id = request.receiving_actor_id
+        if actor_id is None:
+            actor_id = _find_case_actor_id(self._dl, case_id)
+        if actor_id is None:
+            logger.warning(
+                "add_participant_status: cannot resolve CaseActor for case '%s'"
+                " — skipping log entry cascade (PCR-08-003)",
+                case_id,
+            )
+            return
+
+        commit_log_entry_trigger(
+            case_id=case_id,
+            object_id=request.status_id or request.activity_id,
+            event_type="add_participant_status",
+            actor_id=actor_id,
+            dl=self._dl,
+            sync_port=self._sync_port,
+        )

--- a/vultron/core/use_cases/received/status.py
+++ b/vultron/core/use_cases/received/status.py
@@ -266,6 +266,22 @@ class AddParticipantStatusToParticipantReceivedUseCase:
             if context:
                 case_id = str(context)
 
+        # Fallback 1: activity-level context (populated when activity.context
+        # is set to the case object by the caller, e.g. add_status_to_participant
+        # sets context=case).
+        if case_id is None:
+            case_id = request.context_id
+
+        # Fallback 2: read the stored ParticipantStatus and check its context.
+        # Handles cases where the inline object was omitted and the BT resolved
+        # it via a DataLayer lookup (VerifySenderIsParticipantNode._resolve_case_id).
+        if case_id is None and request.status_id:
+            stored_status = self._dl.read(request.status_id)
+            if stored_status is not None:
+                ctx = getattr(stored_status, "context", None)
+                if ctx:
+                    case_id = str(ctx)
+
         if case_id is None:
             logger.warning(
                 "add_participant_status: cannot determine case_id"

--- a/vultron/core/use_cases/received/status.py
+++ b/vultron/core/use_cases/received/status.py
@@ -234,6 +234,12 @@ class AddParticipantStatusToParticipantReceivedUseCase:
                 request.activity_id,
                 reason or result.feedback_message,
             )
+            # Do NOT cascade on BT failure here.  Unlike RemoveEmbargo (where
+            # FAILURE means "already cleared" — an idempotent, non-error
+            # outcome), a status-update BT failure means the update itself was
+            # rejected (e.g., participant not found, invalid state transition).
+            # Broadcasting a log entry for a rejected update would mislead
+            # peers into believing the status was accepted.
             return
 
         self._commit_log_cascade()


### PR DESCRIPTION
## Summary

Implements automatic CaseLogEntry commit and `Announce(CaseLogEntry)` fan-out cascade in all Case Actor received handlers.

**Closes #595**

## Changes

### Cascade wiring (AC-1, AC-2, AC-3)

- **`AddNoteToCaseReceivedUseCase`** — commits a log entry after the note is accepted (AC-1)
- **`AddParticipantStatusToParticipantReceivedUseCase`** — commits on BT success only; early-returns on BT failure (AC-2)
- **5 embargo received-side handlers** — commit via shared `_commit_embargo_log_cascade()` helper (AC-3):
  - `AddEmbargoEventToCaseReceivedUseCase`
  - `RemoveEmbargoEventFromCaseReceivedUseCase` (fires on both SUCCESS and FAILURE — FAILURE = already cleared, not an error)
  - `InviteToEmbargoOnCaseReceivedUseCase`
  - `AcceptInviteToEmbargoOnCaseReceivedUseCase`
  - `RejectInviteToEmbargoOnCaseReceivedUseCase`

### Bugfixes discovered during testing

- **`InviteToEmbargoOnCaseReceivedUseCase`**: was using `activity.context_` (JSON-LD @context = `https://www.w3.org/ns/activitystreams`) instead of `request.context_id` (AS2 context property = case URI). Participant state update and cascade were silently skipped.
- **`RejectInviteToEmbargoOnCaseReceivedUseCase`**: same issue — used `invite.context_` instead of `invite.context` when reading back the stored proposal.

### Adapter wiring (inbox_handler.py)

Expanded `_SYNC_PORT_SEMANTICS` frozenset from 2 to 9 entries: adds `ADD_EMBARGO_EVENT_TO_CASE`, `ADD_NOTE_TO_CASE`, `ADD_PARTICIPANT_STATUS_TO_PARTICIPANT`, `ACCEPT_INVITE_TO_EMBARGO_ON_CASE`, `INVITE_TO_EMBARGO_ON_CASE`, `REJECT_INVITE_TO_EMBARGO_ON_CASE`, `REMOVE_EMBARGO_EVENT_FROM_CASE`.

### Demo endpoint documentation (AC-4)

Added `TEST SCAFFOLD ONLY` docstring note to `demo_sync_log_entry`.

## Tests

New cascade test classes added:
- `TestNoteUseCases` — 2 new cascade tests (log entry committed, no fan-out without sync_port)
- `TestParticipantStatusLogEntryCascade` — 2 new tests (cascade on success, no fan-out without sync_port)  
- `TestEmbargoLogEntryCascade` — 6 new tests (one per embargo handler + BT-failure case for RemoveEmbargo)

All 2477 tests pass.