### PR TITLE
fix: seed reporter participant at RM.ACCEPTED on case bootstrap (#589)

### DIFF
--- a/test/core/use_cases/received/test_case_bootstrap_trust.py
+++ b/test/core/use_cases/received/test_case_bootstrap_trust.py
@@ -28,8 +28,10 @@ from typing import cast
 import pytest
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.core.models.report import VultronReport
 from vultron.core.models.report_case_link import VultronReportCaseLink
 from vultron.core.states.cs import CS_vfd
+from vultron.core.states.rm import RM
 from vultron.core.use_cases.received.actor import (
     AnnounceVulnerabilityCaseReceivedUseCase,
     _find_case_actor_id,
@@ -516,4 +518,133 @@ class TestM4AddParticipantStatusAfterBootstrap:
         assert stored_status is not None, (
             "ParticipantStatus must be persisted as an independent DataLayer"
             " record by AddParticipantStatusToParticipantReceivedUseCase"
+        )
+
+
+# ---------------------------------------------------------------------------
+# CBT-05-006: Reporter participant seeded with RM.ACCEPTED on bootstrap (#589)
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrapCreateReporterParticipant:
+    """Bootstrap Create must seed the reporter's participant at RM.ACCEPTED.
+
+    When Create(VulnerabilityCase) arrives with participant IDs as bare
+    strings, _store_embedded_participants skips them.  The reporter's own
+    participant record would then be absent from their DataLayer, causing
+    SvcAddParticipantStatusUseCase._resolve_current_participant_state to
+    fall back to RM.START — the root cause of #589.
+
+    The fix: _handle_bootstrap infers from the reporter's submitted report
+    that they have already RM.ACCEPTED and creates the participant record
+    with that state if it is not already present.
+    """
+
+    _VENDOR_ID = "https://vendor.example.org/actors/vendor-589"
+    _FINDER_ID = "https://finder.example.org/actors/finder-589"
+    _CASE_ID = "https://example.org/cases/case-589"
+    _REPORT_ID = "https://example.org/reports/report-589"
+    _FINDER_PARTICIPANT_ID = f"{_CASE_ID}/participants/finder-589"
+    _VENDOR_PARTICIPANT_ID = f"{_CASE_ID}/participants/vendor-589"
+
+    @pytest.fixture()
+    def dl(self):
+        return SqliteDataLayer("sqlite:///:memory:")
+
+    @pytest.fixture()
+    def seeded_dl(self, dl):
+        """DataLayer with the Finder's pre-existing report and case link."""
+        report = VultronReport(
+            id_=self._REPORT_ID,
+            attributed_to=self._FINDER_ID,
+        )
+        dl.create(report)
+
+        link = VultronReportCaseLink(
+            report_id=self._REPORT_ID,
+            trusted_case_creator_id=self._VENDOR_ID,
+        )
+        dl.save(link)
+        return dl
+
+    @pytest.fixture()
+    def case_with_string_participants(self):
+        """VulnerabilityCase whose participants are bare string IDs.
+
+        This is the common wire representation when the sender serialises the
+        domain VultronCase (which stores participant IDs, not objects).
+        The fixture also includes a CASE_MANAGER participant inline so that
+        the bootstrap trust path extracts a trusted_case_actor_id.
+        """
+        case_actor_participant = CaseActorParticipant(
+            id_=self._VENDOR_PARTICIPANT_ID,
+            attributed_to=self._VENDOR_ID,
+            context=self._CASE_ID,
+        )
+        case = VulnerabilityCase(
+            id_=self._CASE_ID,
+            name="Bug #589 regression case",
+            case_participants=[
+                case_actor_participant,  # inline so CBT-01-003 can extract it
+                self._FINDER_PARTICIPANT_ID,  # bare string — typical case
+            ],
+        )
+        case.actor_participant_index[self._VENDOR_ID] = (
+            self._VENDOR_PARTICIPANT_ID
+        )
+        case.actor_participant_index[self._FINDER_ID] = (
+            self._FINDER_PARTICIPANT_ID
+        )
+        return case
+
+    @pytest.fixture()
+    def create_event(self, make_payload, case_with_string_participants):
+        activity = create_case_activity(
+            case_with_string_participants, actor=self._VENDOR_ID
+        )
+        return make_payload(activity)
+
+    def test_reporter_participant_created_after_bootstrap(
+        self, seeded_dl, create_event
+    ):
+        """Reporter participant must exist in DataLayer after bootstrap (#589).
+
+        When the bootstrap Create(VulnerabilityCase) carries the reporter's
+        participant as a bare string ID, the DataLayer must still produce a
+        standalone participant record for the reporter so that subsequent
+        SvcAddParticipantStatusUseCase calls can read it.
+        """
+        CreateCaseReceivedUseCase(seeded_dl, create_event).execute()
+
+        stored = seeded_dl.read(self._FINDER_PARTICIPANT_ID)
+        assert stored is not None, (
+            "Reporter participant must be created in the DataLayer after "
+            "bootstrap even when case_participants contains a bare string ID "
+            "(regression #589)"
+        )
+
+    def test_reporter_participant_has_rm_accepted_after_bootstrap(
+        self, seeded_dl, create_event
+    ):
+        """Reporter participant must start at RM.ACCEPTED after bootstrap.
+
+        The reporter submitted a report — by definition they have accepted the
+        vulnerability from their own RM perspective.  The seeded participant
+        must reflect this so that _resolve_current_participant_state returns
+        RM.ACCEPTED rather than RM.START (#589).
+        """
+        CreateCaseReceivedUseCase(seeded_dl, create_event).execute()
+
+        stored = seeded_dl.read(self._FINDER_PARTICIPANT_ID)
+        assert stored is not None
+        statuses = getattr(stored, "participant_statuses", [])
+        assert statuses, (
+            "Reporter participant must have at least one ParticipantStatus "
+            "after bootstrap (#589)"
+        )
+        latest = statuses[-1]
+        rm_state = getattr(latest, "rm_state", None)
+        assert rm_state == RM.ACCEPTED, (
+            f"Reporter participant must have rm_state=RM.ACCEPTED after "
+            f"bootstrap; got {rm_state!r} (#589)"
         )

--- a/vultron/core/use_cases/received/case.py
+++ b/vultron/core/use_cases/received/case.py
@@ -201,7 +201,7 @@ def _ensure_reporter_participant(
         )
         return
 
-    reporter_actor_id = getattr(report, "attributed_to", None)
+    reporter_actor_id = _as_id(getattr(report, "attributed_to", None))
     if not reporter_actor_id:
         logger.warning(
             "ensure_reporter_participant: report '%s' has no attributed_to "

--- a/vultron/core/use_cases/received/case.py
+++ b/vultron/core/use_cases/received/case.py
@@ -13,6 +13,8 @@ from vultron.core.models.events.case import (
     EngageCaseReceivedEvent,
     UpdateCaseReceivedEvent,
 )
+from vultron.core.models.participant import VultronParticipant
+from vultron.core.models.participant_status import VultronParticipantStatus
 from vultron.core.models.report_case_link import VultronReportCaseLink
 from vultron.core.models.vultron_types import VultronActivity
 from vultron.core.ports.case_persistence import (
@@ -157,6 +159,100 @@ def _store_embedded_participants(
             " for case '%s' (CBT-05-005, #566)",
             pid,
             case_id,
+        )
+
+
+def _ensure_reporter_participant(
+    dl: CasePersistence,
+    link: VultronReportCaseLink,
+    case_obj: CaseModel,
+    case_id: str,
+) -> None:
+    """Seed the reporter's participant record at RM.ACCEPTED if absent (#589).
+
+    When ``Create(VulnerabilityCase)`` carries participant IDs as bare
+    strings, ``_store_embedded_participants`` skips them.  Without an
+    explicit participant record in the DataLayer,
+    ``SvcAddParticipantStatusUseCase._resolve_current_participant_state``
+    falls back to ``RM.START``, causing the Vendor's Case Actor to reject the
+    subsequent ``Add(ParticipantStatus)`` as a backwards transition.
+
+    The reporter submitted the original report, which implies they have
+    already ``RM.ACCEPTED`` from their own perspective.  We infer this and
+    create the missing record with that initial state.
+
+    Idempotent: no-op when the participant already exists in the DataLayer
+    (e.g., it was embedded as a full object and saved by
+    ``_store_embedded_participants``).
+
+    Args:
+        dl: The reporter's local DataLayer.
+        link: The ``VultronReportCaseLink`` associating the report to this
+            case bootstrap.
+        case_obj: The bootstrapped ``VulnerabilityCase`` snapshot.
+        case_id: ID of the case (for log context and status context).
+    """
+    report = dl.read(link.report_id)
+    if report is None:
+        logger.warning(
+            "ensure_reporter_participant: report '%s' not found "
+            "— cannot seed reporter participant (#589)",
+            link.report_id,
+        )
+        return
+
+    reporter_actor_id = getattr(report, "attributed_to", None)
+    if not reporter_actor_id:
+        logger.warning(
+            "ensure_reporter_participant: report '%s' has no attributed_to "
+            "— cannot seed reporter participant (#589)",
+            link.report_id,
+        )
+        return
+
+    index = getattr(case_obj, "actor_participant_index", {}) or {}
+    participant_id = index.get(reporter_actor_id)
+    if not participant_id:
+        logger.warning(
+            "ensure_reporter_participant: reporter '%s' not in "
+            "actor_participant_index for case '%s' — skipping (#589)",
+            reporter_actor_id,
+            case_id,
+        )
+        return
+
+    if dl.read(participant_id) is not None:
+        logger.debug(
+            "ensure_reporter_participant: participant '%s' already exists "
+            "— skipping (#589)",
+            participant_id,
+        )
+        return
+
+    status = VultronParticipantStatus(
+        rm_state=RM.ACCEPTED,
+        context=case_id,
+        attributed_to=reporter_actor_id,
+    )
+    participant = VultronParticipant(
+        id_=participant_id,
+        attributed_to=reporter_actor_id,
+        context=case_id,
+        participant_statuses=[status],
+    )
+    try:
+        dl.create(participant)
+        logger.info(
+            "ensure_reporter_participant: created participant '%s' for "
+            "reporter '%s' at RM.ACCEPTED (#589)",
+            participant_id,
+            reporter_actor_id,
+        )
+    except ValueError:
+        logger.debug(
+            "ensure_reporter_participant: participant '%s' was concurrently "
+            "created — idempotent (#589)",
+            participant_id,
         )
 
 
@@ -306,6 +402,12 @@ class CreateCaseReceivedUseCase:
         # This must happen regardless of the idempotency guard above because
         # the inbox router may have already seeded the case before dispatch.
         _store_embedded_participants(case_obj, self._dl, case_id)
+
+        # #589: when participants arrive as bare string IDs (the common case),
+        # _store_embedded_participants cannot create records for them.  Ensure
+        # the reporter's own participant is seeded at RM.ACCEPTED — inferred
+        # from the fact that they submitted a report.
+        _ensure_reporter_participant(self._dl, link, case_obj, case_id)
 
 
 class UpdateCaseReceivedUseCase:


### PR DESCRIPTION
## Summary

Fixes #589. Also see #608.

## Root Cause

When `Create(VulnerabilityCase)` arrives at the reporter's (Finder's) actor,
`EmitCreateCaseActivity` serialises the domain `VultronCase` whose
`case_participants` are bare string IDs.  `_store_embedded_participants`
skips all of them, so the reporter's own participant record never lands in
their DataLayer.

`SvcAddParticipantStatusUseCase._resolve_current_participant_state` then
does `dl.read(participant_id)` → `None` → falls back to `RM.START`.
The Vendor's Case Actor rejects the resulting `Add(ParticipantStatus)` as
a backwards transition (ACCEPTED → START).

## Fix

Added `_ensure_reporter_participant()` called from `_handle_bootstrap`
after `_store_embedded_participants`.  It:

1. Reads the report via `link.report_id` to determine the reporter's `actor_id`
2. Looks up the `participant_id` in `actor_participant_index`
3. Creates a `VultronParticipant` at `RM.ACCEPTED` if absent (idempotent)

The inference is sound: submitting a report implies the reporter has already
accepted the vulnerability from their own RM perspective.

## Relation to #608

Issue #608 describes the same class of failure for `vfd_state`.  The fix
here seeds the participant with `vfd_state=CS_vfd.vfd` (the correct initial
state).  A comment on #608 notes that M4 already passed in the PR #616 CI
run; this PR should confirm whether #608 can be closed as well.

## Tests

Two new regression tests in `TestBootstrapCreateReporterParticipant`:
- `test_reporter_participant_created_after_bootstrap`
- `test_reporter_participant_has_rm_accepted_after_bootstrap`

Both use a realistic setup: `VulnerabilityCase` with bare string participant
IDs, a pre-stored `VultronReport`, and a `VultronReportCaseLink`.

## Test Results

```
1 failed, 2468 passed, 12 skipped
```

The 1 failure is `test_bt_execution_performance_percentiles` — a timing-sensitive
test that passes in isolation; unrelated to this change.