### PR TITLE
perf(test): patch outbox_handler in trigger case/embargo tests to eliminate retry backoff

### DIFF
--- a/test/adapters/driving/fastapi/routers/test_trigger_case.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_case.py
@@ -23,6 +23,7 @@ Verifies TB-01 through TB-07 requirements from specs/triggerable-behaviors.yaml.
 import pytest
 from fastapi import FastAPI, status
 from fastapi.testclient import TestClient
+from unittest.mock import AsyncMock, patch
 
 from vultron.adapters.driving.fastapi.deps import (
     get_canonical_actor_dl,
@@ -61,6 +62,32 @@ def _add_case_manager(case: VulnerabilityCase, dl) -> as_Service:
     case.actor_participant_index[case_actor.id_] = cm_participant.id_
     dl.save(case)
     return case_actor
+
+
+# ---------------------------------------------------------------------------
+# Module-level fixture: suppress outbox delivery retries
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _no_outbox_delivery():
+    """Suppress real outbox delivery for every test in this module.
+
+    ``outbox_handler`` uses HTTP with exponential-backoff retries. When
+    tests run with non-existent recipient URLs the retry sleeps add ~3.5 s
+    per test. Patching to a no-op ``AsyncMock`` eliminates that overhead
+    while keeping the scheduler logic testable.
+
+    Tests in ``TestCaseTriggerOutboxScheduling`` that need a trackable mock
+    use ``unittest.mock.patch`` as a context manager inside the test body,
+    which overrides this fixture's patch for the duration of that context.
+    """
+    with patch(
+        "vultron.adapters.driving.fastapi.routers"
+        ".trigger_case.outbox_handler",
+        new_callable=AsyncMock,
+    ):
+        yield
 
 
 # ---------------------------------------------------------------------------

--- a/test/adapters/driving/fastapi/routers/test_trigger_embargo.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_embargo.py
@@ -23,6 +23,7 @@ Verifies TB-01 through TB-07 requirements from specs/triggerable-behaviors.yaml.
 import pytest
 from fastapi import FastAPI, status
 from fastapi.testclient import TestClient
+from unittest.mock import AsyncMock, patch
 
 from vultron.adapters.driven.db_record import object_to_record
 from vultron.adapters.driving.fastapi.deps import (
@@ -61,6 +62,33 @@ def _add_case_manager(case: VulnerabilityCase, dl) -> as_Service:
     case.actor_participant_index[case_actor.id_] = cm_participant.id_
     dl.save(case)
     return case_actor
+
+
+# ---------------------------------------------------------------------------
+# Module-level fixture: suppress outbox delivery retries
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _no_outbox_delivery():
+    """Suppress real outbox delivery for every test in this module.
+
+    ``outbox_handler`` uses HTTP with exponential-backoff retries. When
+    tests run with non-existent recipient URLs the retry sleeps add ~3.5 s
+    per test. Patching to a no-op ``AsyncMock`` eliminates that overhead
+    while keeping the scheduler logic testable.
+
+    Tests in ``TestEmbargoTriggerOutboxScheduling`` that need a trackable
+    mock use ``unittest.mock.patch`` as a context manager inside the test
+    body, which overrides this fixture's patch for the duration of that
+    context.
+    """
+    with patch(
+        "vultron.adapters.driving.fastapi.routers"
+        ".trigger_embargo.outbox_handler",
+        new_callable=AsyncMock,
+    ):
+        yield
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`test_trigger_case.py` and `test_trigger_embargo.py` were missing the no-op `AsyncMock` patch on `outbox_handler` that was already applied to `test_demo_triggers.py` (6d0fb25c) and `test_trigger_report.py`.

Without the patch, each test that exercises a use case which queues to the outbox waits through `DeliveryQueueAdapter`'s 3× exponential backoff (0.5 + 1.0 + 2.0 s = **3.5 s per test**) when the `urn:uuid:` inbox URL raises `UnsupportedProtocol`.

This caused pytest to balloon from ~2 min → ~3.5 min between recent PRs (visible between runs [26250737981](https://github.com/CERTCC/Vultron/actions/runs/26250737981) and [26253366016](https://github.com/CERTCC/Vultron/actions/runs/26253366016/job/77269919290)).

## Fix

Adds a module-level `autouse` fixture `_no_outbox_delivery` (same pattern as `test_trigger_report.py`) to both affected files. Tests in `TestCaseTriggerOutboxScheduling` / `TestEmbargoTriggerOutboxScheduling` that need a trackable mock already patch `outbox_handler` inside their own bodies; those inner patches override the autouse fixture.

## Impact

- **Before**: ~3.55 s × 20 slow tests ≈ 71 s extra in trigger test files
- **After**: <0.15 s max per test
- **Full suite**: ~3.5 min → ~50 s locally (`uv run pytest -m "" --tb=short`)

All 2674 tests pass, 12 skipped, 3 xfailed.