### PR TITLE
fix: tolerate inline CaseParticipant objects in embargo consent reset

### DIFF
--- a/plan/history/2605/README.md
+++ b/plan/history/2605/README.md
@@ -4,6 +4,7 @@
 
 | Date | Time (UTC) | Type | Source | Title |
 |------|------------|------|--------|-------|
+| 2026-05-21 | 21:34 | implementation | GH-609 | Fix TypeError in remove_embargo_from_case BT (inline CaseParticipant in case_participants) |
 | 2026-05-21 | 21:04 | implementation | ISSUE-595 | Cascade CaseLogEntry + Announce to all Case Actor received handlers |
 | 2026-05-21 | 20:57 | implementation | ISSUE-596 | Refactor sender-side trigger use cases into SenderSideBT |
 | 2026-05-21 | 19:19 | implementation | 610 | Fix DataLayer and actors endpoints for HTTP URL keys (#610) |

--- a/plan/history/2605/implementation/GH-609.md
+++ b/plan/history/2605/implementation/GH-609.md
@@ -1,0 +1,37 @@
+---
+source: GH-609
+timestamp: '2026-05-21T21:34:45+00:00'
+title: Fix TypeError in remove_embargo_from_case BT (inline CaseParticipant in case_participants)
+type: implementation
+---
+
+## Summary
+
+Fixes [#609](https://github.com/CERTCC/Vultron/issues/609).
+PR: [#625](https://github.com/CERTCC/Vultron/pull/625)
+
+### Symptoms
+
+`remove_embargo_from_case` BT failed with:
+`TypeError: expected string or bytes-like object, got 'CaseParticipant'`
+The finder's EM state never reached EXITED, causing M6 milestone timeout.
+
+### Root cause
+
+Three loops in embargo use-case helpers iterated over `case.case_participants`
+and passed each entry directly to `dl.read()`. After fixes #572/#573, the
+receiver side stores inline `CaseParticipant` objects rather than string IDs.
+`dl.read()` calls `re.match()` on its argument and raised TypeError.
+
+Affected: `_reset_case_participant_embargo_consent` (received/embargo.py),
+`_cascade_pec_revise` and `_cascade_pec_reset` (triggers/embargo.py).
+
+### Fix
+
+Applied the existing `_as_id()` helper to extract the string ID before calling
+`dl.read()` in all three loops.
+
+### Tests added
+
+`TestResetEmbargoConsentWithInlineParticipants` — two regression tests in
+`test/core/use_cases/received/test_embargo.py`.

--- a/test/core/use_cases/received/test_embargo.py
+++ b/test/core/use_cases/received/test_embargo.py
@@ -1008,3 +1008,147 @@ class TestEmbargoLogEntryCascade:
         assert cast(VultronCaseLogEntry, entries[0]).event_type == (
             "reject_invite_to_embargo_on_case"
         )
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for #609: inline CaseParticipant in case_participants
+# ---------------------------------------------------------------------------
+
+
+class TestResetEmbargoConsentWithInlineParticipants:
+    """Regression tests for #609: _reset_case_participant_embargo_consent
+    must tolerate inline CaseParticipant objects in case.case_participants,
+    not just plain string IDs.
+    """
+
+    def test_remove_active_embargo_with_inline_participant_no_type_error(
+        self, make_payload
+    ):
+        """remove_embargo_from_case must not raise TypeError when
+        case.case_participants holds inline CaseParticipant objects
+        (as stored on receiver side after fixes #572/#573).
+
+        Regression test for #609.
+        """
+        import py_trees
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+        from vultron.core.states.participant_embargo_consent import PEC
+        from vultron.wire.as2.vocab.objects.case_participant import (
+            CaseParticipant,
+        )
+        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+
+        py_trees.blackboard.Blackboard.enable_activity_stream()
+        py_trees.blackboard.Blackboard.storage.clear()
+
+        actor_id = "https://example.org/users/finder"
+        case_id = "https://example.org/cases/case_609_inline"
+        participant_id = f"{case_id}/participants/p1"
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+
+        # Build a participant and store it — it also appears inline in case
+        participant = CaseParticipant(
+            id_=participant_id,
+            context=case_id,
+            attributed_to=actor_id,
+        )
+        # Simulate receiver-side: participant's consent state is SIGNATORY
+        participant.embargo_consent_state = PEC.SIGNATORY
+        dl.create(participant)
+
+        embargo = EmbargoEvent(
+            id_=f"{case_id}/embargo_events/e1",
+            context=case_id,
+        )
+        dl.create(embargo)
+
+        # Store inline CaseParticipant object (not string ID) in
+        # case_participants — this is the condition that caused #609.
+        case = VulnerabilityCase(
+            id_=case_id,
+            name="Inline Participant Regression Test",
+            attributed_to=actor_id,
+        )
+        case.active_embargo = embargo.id_
+        case.current_status.em_state = EM.ACTIVE
+        case.case_participants.append(participant)  # inline object, not str
+        case.actor_participant_index[actor_id] = participant_id
+        dl.create(case)
+
+        activity = remove_embargo_from_case_activity(
+            embargo,
+            origin=case,
+            actor=actor_id,
+        )
+        event = make_payload(activity)
+
+        # Must not raise TypeError
+        RemoveEmbargoEventFromCaseReceivedUseCase(dl, event).execute()
+
+        updated = cast(VulnerabilityCase, dl.read(case_id))
+        assert updated is not None
+        assert updated.active_embargo is None
+        assert updated.current_status.em_state == EM.EXITED
+
+    def test_reset_consent_with_inline_participant_resets_state(self):
+        """_reset_case_participant_embargo_consent resets consent state even
+        when case_participants entries are inline wire-layer CaseParticipant
+        objects (not string IDs).
+
+        Regression test for #609.
+        """
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+        from vultron.core.models.protocols import is_case_model
+        from vultron.core.states.participant_embargo_consent import PEC
+        from vultron.core.use_cases.received.embargo import (
+            _reset_case_participant_embargo_consent,
+        )
+        from vultron.wire.as2.vocab.objects.case_participant import (
+            CaseParticipant,
+        )
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+
+        actor_id = "https://example.org/users/finder"
+        case_id = "https://example.org/cases/case_609_reset"
+        participant_id = f"{case_id}/participants/p1"
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+
+        # Wire-layer CaseParticipant with non-default consent state.
+        # Stored in the DataLayer separately so dl.read(participant_id) works.
+        participant = CaseParticipant(
+            id_=participant_id,
+            context=case_id,
+            attributed_to=actor_id,
+        )
+        participant.embargo_consent_state = PEC.SIGNATORY.value
+        dl.create(participant)
+
+        # Inline wire-layer object in case_participants — this is the condition
+        # that caused #609 on the receiver side after fixes #572/#573.
+        case = VulnerabilityCase(
+            id_=case_id,
+            name="Reset Consent Inline",
+        )
+        case.case_participants.append(participant)
+        dl.create(case)
+
+        assert is_case_model(
+            case
+        ), "VulnerabilityCase should satisfy CaseModel"
+
+        # Must not raise TypeError
+        _reset_case_participant_embargo_consent(dl, case)
+
+        updated_participant = dl.read(participant_id)
+        assert updated_participant is not None
+        assert (
+            getattr(updated_participant, "embargo_consent_state", None)
+            == PEC.NO_EMBARGO.value
+        )

--- a/vultron/core/use_cases/received/embargo.py
+++ b/vultron/core/use_cases/received/embargo.py
@@ -104,7 +104,10 @@ def _commit_embargo_log_cascade(
 def _reset_case_participant_embargo_consent(
     dl: CasePersistence, case: CaseModel
 ) -> None:
-    for participant_id in case.case_participants:
+    for entry in case.case_participants:
+        participant_id = _as_id(entry)
+        if participant_id is None:
+            continue
         participant = dl.read(participant_id)
         if not is_participant_model(participant):
             continue

--- a/vultron/core/use_cases/triggers/embargo.py
+++ b/vultron/core/use_cases/triggers/embargo.py
@@ -95,7 +95,10 @@ def _cascade_pec_revise(
     """
     if not is_case_model(case):
         return
-    for participant_id in case.case_participants:
+    for entry in case.case_participants:
+        participant_id = _as_id(entry)
+        if participant_id is None:
+            continue
         participant = dl.read(participant_id)
         if not is_participant_model(participant):
             continue
@@ -115,7 +118,10 @@ def _cascade_pec_reset(
     """
     if not is_case_model(case):
         return
-    for participant_id in case.case_participants:
+    for entry in case.case_participants:
+        participant_id = _as_id(entry)
+        if participant_id is None:
+            continue
         participant = dl.read(participant_id)
         if not is_participant_model(participant):
             continue


### PR DESCRIPTION
Fixes #609

## Summary

`_reset_case_participant_embargo_consent` (and the equivalent
`_cascade_pec_revise`/`_cascade_pec_reset` helpers in
`triggers/embargo.py`) iterated over `case.case_participants` and
passed each entry directly to `dl.read()`.  On the receiver side,
after fixes #572/#573, that list can contain inline `CaseParticipant`
objects rather than plain string IDs.  `dl.read()` calls
`re.match()` on its argument and raised:

```
TypeError: expected string or bytes-like object, got 'CaseParticipant'
```

This prevented `remove_embargo_from_case` BT from completing, leaving
EM state stuck at ACTIVE (M6 timeout).

## Fix

Apply the existing `_as_id()` helper — already used by other
consumers of `case.case_participants` — to extract the string ID
before calling `dl.read()`.  Three loops fixed across two files.

## Tests

Added `TestResetEmbargoConsentWithInlineParticipants` with two
regression tests: one via the full BT path
(`RemoveEmbargoEventFromCaseReceivedUseCase`) and one unit test
directly targeting `_reset_case_participant_embargo_consent`.