### PR TITLE
fix: reporter participant RM.START causes M6 AddParticipantStatusBT failure (#624)

### DIFF
--- a/plan/history/2605/README.md
+++ b/plan/history/2605/README.md
@@ -4,6 +4,7 @@
 
 | Date | Time (UTC) | Type | Source | Title |
 |------|------------|------|--------|-------|
+| 2026-05-21 | 23:05 | implementation | GH-624 | Fix #624: Reporter participant RM.START causes M6 AddParticipantStatusBT failure |
 | 2026-05-21 | 21:34 | implementation | GH-609 | Fix TypeError in remove_embargo_from_case BT (inline CaseParticipant in case_participants) |
 | 2026-05-21 | 21:04 | implementation | ISSUE-595 | Cascade CaseLogEntry + Announce to all Case Actor received handlers |
 | 2026-05-21 | 20:57 | implementation | ISSUE-596 | Refactor sender-side trigger use cases into SenderSideBT |

--- a/plan/history/2605/implementation/GH-624.md
+++ b/plan/history/2605/implementation/GH-624.md
@@ -1,0 +1,56 @@
+---
+source: GH-624
+timestamp: '2026-05-21T23:05:16.603682+00:00'
+title: 'Fix #624: Reporter participant RM.START causes M6 AddParticipantStatusBT failure'
+type: implementation
+---
+
+## Bug #624: Reporter Participant RM.START Causes AddParticipantStatusBT Failure at M6
+
+### Symptoms
+
+M6 demo milestone timed out because vendor's `AddParticipantStatusBT` rejected
+an inbound `Add(ParticipantStatus)` from finder carrying `rmState: START`.
+Vendor correctly rejected it as a backwards `ACCEPTED → START` transition.
+
+### Root Cause
+
+Two compounding defects:
+
+1. **`_ensure_reporter_participant`** (`received/case.py`) had a skip-if-exists
+   guard. When `_store_embedded_participants` saved the reporter's participant
+   with the wire-layer default seed (`rm_state=RM.START`), the skip guard
+   prevented the RM.ACCEPTED invariant from being applied.
+
+2. **`SvcAddParticipantStatusUseCase.execute()`** (`triggers/case.py`) created
+   a `VultronParticipantStatus` and saved it to the DataLayer but never
+   appended it to the sender's own `participant_statuses` list.
+   `_resolve_current_participant_state` therefore always read the stale
+   `RM.START` seed, causing every subsequent outbound status to inherit
+   `RM.START`.
+
+Per protocol docs (`rm_interactions.md`): the reporter's
+`START→RECEIVED→VALID→ACCEPTED` arc is hidden — their first observable action
+(`Offer(Report)`) already implies `RM.ACCEPTED`. This invariant applies only
+to the reporter (`attributed_to` of the `Offer(Report)`).
+
+### Fix
+
+**Fix 1** — `_ensure_reporter_participant` (`received/case.py`): Replace
+skip-if-exists with upgrade-if-below-ACCEPTED. When the reporter's participant
+exists but its latest `rm_state` is below `RM.ACCEPTED` (per `_RM_PROGRESS`
+scores), save a new status record at `RM.ACCEPTED` and append the read-back
+wire-layer object to `participant_statuses`.
+
+**Fix 2** — `SvcAddParticipantStatusUseCase.execute()` (`triggers/case.py`):
+After saving the new status, read it back from the DataLayer (wire-layer type),
+then append it to the sender's own `participant_statuses` list and save. This
+makes `_resolve_current_participant_state` track the sender's actual latest
+emitted state on all subsequent calls.
+
+### Files Changed
+
+- `vultron/core/use_cases/received/case.py`
+- `vultron/core/use_cases/triggers/case.py`
+- `test/core/use_cases/received/test_case_bootstrap_trust.py`
+- `test/core/use_cases/triggers/test_svc_add_participant_status.py`

--- a/test/core/use_cases/received/test_case_bootstrap_trust.py
+++ b/test/core/use_cases/received/test_case_bootstrap_trust.py
@@ -28,6 +28,8 @@ from typing import cast
 import pytest
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.core.models.participant import VultronParticipant
+from vultron.core.models.participant_status import VultronParticipantStatus
 from vultron.core.models.report import VultronReport
 from vultron.core.models.report_case_link import VultronReportCaseLink
 from vultron.core.states.cs import CS_vfd
@@ -648,3 +650,149 @@ class TestBootstrapCreateReporterParticipant:
             f"Reporter participant must have rm_state=RM.ACCEPTED after "
             f"bootstrap; got {rm_state!r} (#589)"
         )
+
+
+# ---------------------------------------------------------------------------
+# CBT-05-007: Reporter participant upgraded from RM.START to RM.ACCEPTED (#624)
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrapReporterUpgradesFromStart:
+    """Bootstrap Create upgrades an existing RM.START participant to RM.ACCEPTED.
+
+    When ``_store_embedded_participants`` stores the wire-layer snapshot, it may
+    seed the reporter's participant with ``rm_state=RM.START`` (the wire default).
+    ``_ensure_reporter_participant`` must detect this and upgrade the participant
+    to ``RM.ACCEPTED``.  See issue #624.
+    """
+
+    _VENDOR_ID = "https://vendor.example.org/actors/vendor-624"
+    _FINDER_ID = "https://finder.example.org/actors/finder-624"
+    _CASE_ID = "https://example.org/cases/case-624"
+    _REPORT_ID = "https://example.org/reports/report-624"
+    _FINDER_PARTICIPANT_ID = f"{_CASE_ID}/participants/finder-624"
+    _VENDOR_PARTICIPANT_ID = f"{_CASE_ID}/participants/vendor-624"
+
+    @pytest.fixture()
+    def dl(self):
+        return SqliteDataLayer("sqlite:///:memory:")
+
+    @pytest.fixture()
+    def base_dl(self, dl):
+        """DataLayer with report and link pre-seeded."""
+        report = VultronReport(
+            id_=self._REPORT_ID,
+            attributed_to=self._FINDER_ID,
+        )
+        dl.create(report)
+
+        link = VultronReportCaseLink(
+            report_id=self._REPORT_ID,
+            trusted_case_creator_id=self._VENDOR_ID,
+        )
+        dl.save(link)
+        return dl
+
+    @pytest.fixture()
+    def case_with_string_participants(self):
+        case_actor_participant = CaseActorParticipant(
+            id_=self._VENDOR_PARTICIPANT_ID,
+            attributed_to=self._VENDOR_ID,
+            context=self._CASE_ID,
+        )
+        case = VulnerabilityCase(
+            id_=self._CASE_ID,
+            name="Bug #624 regression case",
+            case_participants=[
+                case_actor_participant,
+                self._FINDER_PARTICIPANT_ID,  # bare string
+            ],
+        )
+        case.actor_participant_index[self._VENDOR_ID] = (
+            self._VENDOR_PARTICIPANT_ID
+        )
+        case.actor_participant_index[self._FINDER_ID] = (
+            self._FINDER_PARTICIPANT_ID
+        )
+        return case
+
+    def _create_event(self, make_payload, case):
+        activity = create_case_activity(case, actor=self._VENDOR_ID)
+        return make_payload(activity)
+
+    def _pre_seed_participant(self, dl, rm_state: RM) -> VultronParticipant:
+        """Store a finder participant at the given rm_state before bootstrap."""
+        status = VultronParticipantStatus(
+            rm_state=rm_state,
+            context=self._CASE_ID,
+            attributed_to=self._FINDER_ID,
+        )
+        participant = VultronParticipant(
+            id_=self._FINDER_PARTICIPANT_ID,
+            attributed_to=self._FINDER_ID,
+            context=self._CASE_ID,
+            participant_statuses=[status],
+        )
+        dl.create(participant)
+        return participant
+
+    def test_reporter_participant_upgraded_from_start_to_accepted(
+        self, base_dl, make_payload, case_with_string_participants
+    ):
+        """Reporter participant at RM.START must be upgraded to RM.ACCEPTED (#624).
+
+        Pre-condition: reporter's participant is already in the DataLayer at
+        RM.START (seeded by _store_embedded_participants or a prior bootstrap).
+        Post-condition: after CreateCaseReceivedUseCase, the participant's latest
+        rm_state is RM.ACCEPTED.
+        """
+        self._pre_seed_participant(base_dl, RM.START)
+        event = self._create_event(make_payload, case_with_string_participants)
+
+        CreateCaseReceivedUseCase(base_dl, event).execute()
+
+        stored = base_dl.read(self._FINDER_PARTICIPANT_ID)
+        assert stored is not None
+        statuses = getattr(stored, "participant_statuses", [])
+        assert statuses, "Reporter participant must have at least one status"
+        latest_rm = statuses[-1].rm_state
+        assert latest_rm == RM.ACCEPTED, (
+            f"Reporter participant must be upgraded to RM.ACCEPTED from "
+            f"RM.START; got {latest_rm!r} (#624)"
+        )
+
+    def test_reporter_participant_noop_if_already_accepted(
+        self, base_dl, make_payload, case_with_string_participants
+    ):
+        """Reporter participant already at RM.ACCEPTED must not be modified (#624)."""
+        self._pre_seed_participant(base_dl, RM.ACCEPTED)
+        event = self._create_event(make_payload, case_with_string_participants)
+
+        CreateCaseReceivedUseCase(base_dl, event).execute()
+
+        stored = base_dl.read(self._FINDER_PARTICIPANT_ID)
+        assert stored is not None
+        statuses = getattr(stored, "participant_statuses", [])
+        assert len(statuses) == 1, (
+            "Reporter participant already at RM.ACCEPTED must not gain extra "
+            f"statuses; got {len(statuses)} (#624)"
+        )
+        assert statuses[0].rm_state == RM.ACCEPTED
+
+    def test_reporter_participant_noop_if_already_closed(
+        self, base_dl, make_payload, case_with_string_participants
+    ):
+        """Reporter participant already at RM.CLOSED must not be downgraded (#624)."""
+        self._pre_seed_participant(base_dl, RM.CLOSED)
+        event = self._create_event(make_payload, case_with_string_participants)
+
+        CreateCaseReceivedUseCase(base_dl, event).execute()
+
+        stored = base_dl.read(self._FINDER_PARTICIPANT_ID)
+        assert stored is not None
+        statuses = getattr(stored, "participant_statuses", [])
+        assert len(statuses) == 1, (
+            "Reporter participant at RM.CLOSED must not gain extra statuses "
+            f"(it is already beyond ACCEPTED); got {len(statuses)} (#624)"
+        )
+        assert statuses[0].rm_state == RM.CLOSED

--- a/test/core/use_cases/triggers/test_svc_add_participant_status.py
+++ b/test/core/use_cases/triggers/test_svc_add_participant_status.py
@@ -21,6 +21,8 @@ that extracts the latest ``(RM, CS_vfd)`` pair from a participant record.
 
 from typing import cast
 
+import pytest
+
 from vultron.core.states.cs import CS_vfd
 from vultron.core.states.rm import RM
 
@@ -188,3 +190,157 @@ def test_resolve_participant_state_defaults_when_invalid_vfd_type():
 
     assert isinstance(rm, RM)
     assert vfd == CS_vfd.vfd
+
+
+# ---------------------------------------------------------------------------
+# execute() — sender's participant record is updated after SvcAdd (#624)
+# ---------------------------------------------------------------------------
+
+
+class TestSvcAddParticipantStatusExecuteUpdatesSenderRecord:
+    """SvcAddParticipantStatusUseCase.execute() appends to sender's own record.
+
+    Without this, ``_resolve_current_participant_state`` always reads the
+    bootstrap seed (RM.START), never the actual latest state the sender
+    has reported.  See issue #624.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        from vultron.adapters.driven.datalayer_sqlite import (
+            SqliteDataLayer,
+            reset_datalayer,
+        )
+        from vultron.adapters.driven.trigger_activity_adapter import (
+            TriggerActivityAdapter,
+        )
+        from vultron.core.states.roles import CVDRole
+        from vultron.wire.as2.vocab.base.objects.actors import as_Service
+        from vultron.wire.as2.vocab.objects.case_participant import (
+            CaseParticipant,
+        )
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+
+        # Finder actor
+        self.actor = as_Service(name="Finder Actor")
+        actor_id = self.actor.id_
+        reset_datalayer(actor_id)
+        self.dl = SqliteDataLayer("sqlite:///:memory:", actor_id=actor_id)
+        self.dl.clear_all()
+        self.dl.create(self.actor)
+
+        # Case Actor (CASE_MANAGER)
+        self.case_actor = as_Service(name="Case Actor")
+        reset_datalayer(self.case_actor.id_)
+        self.dl.create(self.case_actor)
+
+        # Case
+        self.case = VulnerabilityCase(name="Test Case #624")
+
+        self.actor_participant = CaseParticipant(
+            attributed_to=actor_id,
+            context=self.case.id_,
+            case_roles=[CVDRole.FINDER],
+        )
+        self.case_manager_participant = CaseParticipant(
+            attributed_to=self.case_actor.id_,
+            context=self.case.id_,
+            case_roles=[CVDRole.CASE_MANAGER],
+        )
+
+        self.case.actor_participant_index[actor_id] = (
+            self.actor_participant.id_
+        )
+        self.case.actor_participant_index[self.case_actor.id_] = (
+            self.case_manager_participant.id_
+        )
+
+        self.dl.create(self.case)
+        self.dl.create(self.actor_participant)
+        self.dl.create(self.case_manager_participant)
+
+        self.trigger_activity = TriggerActivityAdapter(self.dl)
+        yield
+        self.dl.clear_all()
+        reset_datalayer(actor_id)
+        reset_datalayer(self.case_actor.id_)
+
+    def test_execute_appends_status_to_sender_participant(self):
+        """After execute(), sender's participant_statuses contains the new status.
+
+        Without this, _resolve_current_participant_state would always read the
+        initial seed (RM.START / CS_vfd.vfd), causing subsequent calls to report
+        stale RM.START — the root cause of #624.
+        """
+        from vultron.core.states.rm import RM
+        from vultron.core.use_cases.triggers.case import (
+            SvcAddParticipantStatusUseCase,
+        )
+        from vultron.core.use_cases.triggers.requests import (
+            AddParticipantStatusTriggerRequest,
+        )
+
+        request = AddParticipantStatusTriggerRequest(
+            actor_id=self.actor.id_,
+            case_id=self.case.id_,
+            rm_state=RM.ACCEPTED,
+        )
+        result = SvcAddParticipantStatusUseCase(
+            self.dl,
+            request,
+            trigger_activity=self.trigger_activity,
+        ).execute()
+
+        status_id = result.get("status_id")
+        assert status_id is not None, "execute() must return a status_id"
+
+        # The sender's own participant record must now contain the status.
+        participant = self.dl.read(self.actor_participant.id_)
+        assert participant is not None
+        statuses = getattr(participant, "participant_statuses", [])
+        status_ids = [getattr(s, "id_", s) for s in statuses]
+        assert status_id in status_ids, (
+            "Sender's participant_statuses must include the newly created "
+            f"status '{status_id}' after execute() (#624). Got: {status_ids}"
+        )
+
+    def test_resolve_current_state_returns_emitted_rm_after_execute(self):
+        """_resolve_current_participant_state returns the emitted RM after execute.
+
+        This is the proxy check for the M6 bug: if execute() does NOT update the
+        sender's record, _resolve_current_participant_state will still return
+        RM.START on the next call, causing the next outbound status to carry
+        RM.START and be rejected as a backwards transition by the vendor.
+        """
+        from vultron.core.states.rm import RM
+        from vultron.core.use_cases.triggers.case import (
+            SvcAddParticipantStatusUseCase,
+        )
+        from vultron.core.use_cases.triggers.requests import (
+            AddParticipantStatusTriggerRequest,
+        )
+
+        request = AddParticipantStatusTriggerRequest(
+            actor_id=self.actor.id_,
+            case_id=self.case.id_,
+            rm_state=RM.ACCEPTED,
+        )
+        use_case = SvcAddParticipantStatusUseCase(
+            self.dl,
+            request,
+            trigger_activity=self.trigger_activity,
+        )
+        use_case.execute()
+
+        # On a second call, _resolve_current_participant_state must return
+        # RM.ACCEPTED (the state we just emitted), not RM.START.
+        rm, _ = use_case._resolve_current_participant_state(
+            self.dl, self.actor_participant.id_
+        )
+        assert rm == RM.ACCEPTED, (
+            f"After execute() with rm_state=RM.ACCEPTED, "
+            f"_resolve_current_participant_state must return RM.ACCEPTED; "
+            f"got {rm!r} (#624)"
+        )

--- a/test/core/use_cases/triggers/test_svc_add_participant_status.py
+++ b/test/core/use_cases/triggers/test_svc_add_participant_status.py
@@ -263,9 +263,12 @@ class TestSvcAddParticipantStatusExecuteUpdatesSenderRecord:
 
         self.trigger_activity = TriggerActivityAdapter(self.dl)
         yield
-        self.dl.clear_all()
-        reset_datalayer(actor_id)
-        reset_datalayer(self.case_actor.id_)
+        try:
+            self.dl.clear_all()
+        finally:
+            self.dl.close()
+            reset_datalayer(actor_id)
+            reset_datalayer(self.case_actor.id_)
 
     def test_execute_appends_status_to_sender_participant(self):
         """After execute(), sender's participant_statuses contains the new status.

--- a/vultron/core/states/rm.py
+++ b/vultron/core/states/rm.py
@@ -182,6 +182,21 @@ def is_monotonic_rm_forward(source: RM, dest: RM) -> bool:
     return _RM_PROGRESS.get(dest, 0) > _RM_PROGRESS.get(source, 0)
 
 
+def is_rm_at_least(state: RM, threshold: RM) -> bool:
+    """Return True if *state* is at or beyond *threshold* on the RM progress scale.
+
+    Used to guard "already at ACCEPTED or beyond" checks without coupling call
+    sites to the private ``_RM_PROGRESS`` mapping.
+
+    Examples::
+
+        is_rm_at_least(RM.ACCEPTED, RM.ACCEPTED)  # True
+        is_rm_at_least(RM.CLOSED,   RM.ACCEPTED)  # True
+        is_rm_at_least(RM.START,    RM.ACCEPTED)  # False
+    """
+    return _RM_PROGRESS.get(state, 0) >= _RM_PROGRESS.get(threshold, 0)
+
+
 def create_rm_machine() -> Machine:
     """
     Generates a new Report Management State Machine object

--- a/vultron/core/use_cases/received/case.py
+++ b/vultron/core/use_cases/received/case.py
@@ -26,7 +26,7 @@ from vultron.core.models.protocols import (
     is_case_model,
     is_participant_model,
 )
-from vultron.core.states.rm import RM, _RM_PROGRESS
+from vultron.core.states.rm import RM, is_rm_at_least
 from vultron.core.states.roles import CVDRole
 from vultron.core.use_cases._helpers import _as_id, update_participant_rm_state
 
@@ -235,7 +235,7 @@ def _ensure_reporter_participant(
     if existing is not None:
         statuses = getattr(existing, "participant_statuses", []) or []
         latest_rm = statuses[-1].rm_state if statuses else RM.START
-        if _RM_PROGRESS.get(latest_rm, 0) >= _RM_PROGRESS[RM.ACCEPTED]:
+        if is_rm_at_least(latest_rm, RM.ACCEPTED):
             logger.debug(
                 "ensure_reporter_participant: participant '%s' already "
                 "≥ RM.ACCEPTED — skipping (#589, #624)",

--- a/vultron/core/use_cases/received/case.py
+++ b/vultron/core/use_cases/received/case.py
@@ -26,7 +26,7 @@ from vultron.core.models.protocols import (
     is_case_model,
     is_participant_model,
 )
-from vultron.core.states.rm import RM
+from vultron.core.states.rm import RM, _RM_PROGRESS
 from vultron.core.states.roles import CVDRole
 from vultron.core.use_cases._helpers import _as_id, update_participant_rm_state
 
@@ -168,7 +168,7 @@ def _ensure_reporter_participant(
     case_obj: CaseModel,
     case_id: str,
 ) -> None:
-    """Seed the reporter's participant record at RM.ACCEPTED if absent (#589).
+    """Ensure the reporter's participant record is at RM.ACCEPTED (#589, #624).
 
     When ``Create(VulnerabilityCase)`` carries participant IDs as bare
     strings, ``_store_embedded_participants`` skips them.  Without an
@@ -178,12 +178,22 @@ def _ensure_reporter_participant(
     subsequent ``Add(ParticipantStatus)`` as a backwards transition.
 
     The reporter submitted the original report, which implies they have
-    already ``RM.ACCEPTED`` from their own perspective.  We infer this and
-    create the missing record with that initial state.
+    already ``RM.ACCEPTED`` from their own perspective.  The reporter is
+    identified as ``attributed_to`` of the ``Offer(Report)`` activity
+    (``report.attributed_to``).  Their ``START→RECEIVED→VALID→ACCEPTED`` arc
+    is hidden from the protocol — their first observable action already
+    implies ``RM.ACCEPTED`` (#624).
 
-    Idempotent: no-op when the participant already exists in the DataLayer
-    (e.g., it was embedded as a full object and saved by
-    ``_store_embedded_participants``).
+    This function:
+
+    * Creates the participant record at ``RM.ACCEPTED`` if it is absent.
+    * Upgrades an existing participant from any state below ``RM.ACCEPTED``
+      (e.g. ``RM.START`` seeded by the wire-layer default) to ``RM.ACCEPTED``.
+    * No-ops if the participant is already at or beyond ``RM.ACCEPTED``.
+
+    This invariant applies **only** to the reporter/finder.  All other
+    participants enter through a visible protocol interaction and their RM
+    lifecycle proceeds normally from ``RM.RECEIVED``.
 
     Args:
         dl: The reporter's local DataLayer.
@@ -221,11 +231,19 @@ def _ensure_reporter_participant(
         )
         return
 
-    if dl.read(participant_id) is not None:
-        logger.debug(
-            "ensure_reporter_participant: participant '%s' already exists "
-            "— skipping (#589)",
-            participant_id,
+    existing = dl.read(participant_id)
+    if existing is not None:
+        statuses = getattr(existing, "participant_statuses", []) or []
+        latest_rm = statuses[-1].rm_state if statuses else RM.START
+        if _RM_PROGRESS.get(latest_rm, 0) >= _RM_PROGRESS[RM.ACCEPTED]:
+            logger.debug(
+                "ensure_reporter_participant: participant '%s' already "
+                "≥ RM.ACCEPTED — skipping (#589, #624)",
+                participant_id,
+            )
+            return
+        _upgrade_participant_to_accepted(
+            dl, existing, participant_id, case_id, reporter_actor_id, latest_rm
         )
         return
 
@@ -254,6 +272,45 @@ def _ensure_reporter_participant(
             "created — idempotent (#589)",
             participant_id,
         )
+
+
+def _upgrade_participant_to_accepted(
+    dl: CasePersistence,
+    existing: Any,
+    participant_id: str,
+    case_id: str,
+    reporter_actor_id: str,
+    latest_rm: "RM",
+) -> None:
+    """Upgrade an existing participant record from below RM.ACCEPTED to RM.ACCEPTED.
+
+    Saves the new status as an independent DataLayer record, then reads it back
+    via the vocabulary registry so the serialised type matches what the
+    participant container expects.  This avoids wire/domain type mismatches when
+    appending to ``CaseParticipant.participant_statuses``.
+    """
+    upgrade_status = VultronParticipantStatus(
+        rm_state=RM.ACCEPTED,
+        context=case_id,
+        attributed_to=reporter_actor_id,
+    )
+    try:
+        dl.create(upgrade_status)
+    except ValueError:
+        dl.save(upgrade_status)
+    wire_status = dl.read(upgrade_status.id_)
+    participant_statuses = getattr(existing, "participant_statuses", None)
+    if participant_statuses is not None:
+        participant_statuses.append(
+            wire_status if wire_status is not None else upgrade_status
+        )
+    dl.save(existing)
+    logger.info(
+        "ensure_reporter_participant: upgraded participant '%s' from "
+        "%s to RM.ACCEPTED (#589, #624)",
+        participant_id,
+        latest_rm,
+    )
 
 
 class CreateCaseReceivedUseCase:

--- a/vultron/core/use_cases/triggers/case.py
+++ b/vultron/core/use_cases/triggers/case.py
@@ -472,6 +472,23 @@ class SvcAddParticipantStatusUseCase:
         except ValueError:
             dl.save(status)
 
+        # Append the newly emitted status to the sender's own participant
+        # record so that _resolve_current_participant_state reads the actual
+        # latest state on future calls (not a stale bootstrap seed).
+        # Read back the persisted status via the vocabulary registry so that
+        # the type matches what the participant container expects.
+        participant_obj = dl.read(participant_id)
+        wire_status = dl.read(status.id_)
+        participant_statuses = (
+            getattr(participant_obj, "participant_statuses", None)
+            if participant_obj is not None
+            else None
+        )
+        if participant_statuses is not None and wire_status is not None:
+            participant_statuses.append(wire_status)
+            if participant_obj is not None:
+                dl.save(participant_obj)
+
         # Find Case Manager ID to address activity
         case_manager_id = _resolve_case_manager_id(case, dl)
 


### PR DESCRIPTION
Fixes #624

## Summary

Two compounding bugs caused M6 demo to time out: vendor's `AddParticipantStatusBT`
rejected finder's inbound `Add(ParticipantStatus)` as a backwards `ACCEPTED → START`
transition.

### Business logic invariant

Per `docs/topics/process_models/rm/rm_interactions.md`: the reporter's
`START→RECEIVED→VALID→ACCEPTED` arc is **hidden** from the protocol. By the time
they send `Offer(Report)` — their first observable action — they have already
internally reached `RM.ACCEPTED`. This invariant applies **only** to the reporter
(`attributed_to` of the `Offer(Report)`).

### Root cause

1. **`_ensure_reporter_participant`** had a skip-if-exists guard. When
   `_store_embedded_participants` stored the reporter's participant with the wire
   default seed (`rm_state=RM.START`), the skip guard prevented the RM.ACCEPTED
   invariant from being applied.

2. **`SvcAddParticipantStatusUseCase.execute()`** created a status but never
   appended it to the sender's own `participant_statuses` list.
   `_resolve_current_participant_state` always read the stale `RM.START` seed,
   causing every outbound status to inherit `RM.START`.

### Fix

**Fix 1** (`received/case.py`): Replace skip-if-exists with upgrade-if-below-ACCEPTED.
When reporter's participant exists but its latest `rm_state` is below `RM.ACCEPTED`
(per `_RM_PROGRESS` scores), save an `RM.ACCEPTED` status record and append it.
Extract `_upgrade_participant_to_accepted` helper to keep complexity in check.

**Fix 2** (`triggers/case.py`): After persisting the new status, read it back
through the DataLayer vocabulary registry (returns wire-layer type), then append it
to the sender's own `participant_statuses` list. This ensures
`_resolve_current_participant_state` tracks the actual latest emitted state.

Both fixes use the DataLayer read-back to avoid a wire/domain type mismatch when
appending to `CaseParticipant.participant_statuses`.