### PR TITLE
fix: add _sync_and_trigger_port_factory for ADD_PARTICIPANT_STATUS_TO_PARTICIPANT

### DIFF
--- a/plan/history/2605/README.md
+++ b/plan/history/2605/README.md
@@ -4,6 +4,7 @@
 
 | Date | Time (UTC) | Type | Source | Title |
 |------|------------|------|--------|-------|
+| 2026-05-22 | 03:44 | implementation | GH-628 | fix: ADD_PARTICIPANT_STATUS_TO_PARTICIPANT port factory overwrite (issue #628) |
 | 2026-05-21 | 23:05 | implementation | GH-624 | Fix #624: Reporter participant RM.START causes M6 AddParticipantStatusBT failure |
 | 2026-05-21 | 21:34 | implementation | GH-609 | Fix TypeError in remove_embargo_from_case BT (inline CaseParticipant in case_participants) |
 | 2026-05-21 | 21:04 | implementation | ISSUE-595 | Cascade CaseLogEntry + Announce to all Case Actor received handlers |

--- a/plan/history/2605/implementation/GH-628.md
+++ b/plan/history/2605/implementation/GH-628.md
@@ -1,0 +1,39 @@
+---
+source: GH-628
+timestamp: '2026-05-22T03:44:46.318060+00:00'
+title: 'fix: ADD_PARTICIPANT_STATUS_TO_PARTICIPANT port factory overwrite (issue #628)'
+type: implementation
+---
+
+## Summary
+
+Fixed silent overwrite of `sync_port` factory for
+`ADD_PARTICIPANT_STATUS_TO_PARTICIPANT` in `make_dispatcher()`.
+
+## Symptoms
+
+`SvcAddParticipantStatusReceivedUseCase` received `sync_port=None` because
+`dict.update()` in `make_dispatcher()` overwrote the `_sync_port_factory`
+entry with `_trigger_activity_port_factory`. The log-entry fan-out was
+silently skipped, leaving the finder's DataLayer replica with a stale
+`RM.START` seed. On the next `notify-published` trigger the CaseActor
+rejected the backwards transition.
+
+## Root Cause
+
+`ADD_PARTICIPANT_STATUS_TO_PARTICIPANT` appeared in both `_SYNC_PORT_SEMANTICS`
+and `_TRIGGER_ACTIVITY_PORT_SEMANTICS`. The second `dict.update()` in
+`make_dispatcher()` clobbered the sync entry.
+
+## Fix
+
+Added `_sync_and_trigger_port_factory` that merges both adapters. Removed
+`ADD_PARTICIPANT_STATUS_TO_PARTICIPANT` from both individual sets and
+introduced a new `_SYNC_AND_TRIGGER_PORT_SEMANTICS` frozenset mapped to the
+combined factory. Added a regression test that asserts the factory returns
+both `sync_port` and `trigger_activity` for that semantic.
+
+## Files Changed
+
+- `vultron/adapters/driving/fastapi/inbox_handler.py`
+- `test/adapters/driving/fastapi/test_inbox_handler.py`

--- a/test/adapters/driving/fastapi/test_inbox_handler.py
+++ b/test/adapters/driving/fastapi/test_inbox_handler.py
@@ -133,6 +133,43 @@ def test_dispatch_uses_explicit_dispatcher(monkeypatch):
     explicit_dispatcher.dispatch.assert_called_once_with(fake_event, mock_dl)
 
 
+def test_make_dispatcher_add_participant_status_has_both_ports(monkeypatch):
+    """make_dispatcher() must inject *both* sync_port and trigger_activity for
+    ADD_PARTICIPANT_STATUS_TO_PARTICIPANT.
+
+    Before the fix, dict.update() overwrote the sync factory with the trigger
+    factory for this semantic, leaving sync_port=None and silently skipping the
+    log-entry fan-out (issue #628).
+    """
+    mock_dl = MagicMock()
+
+    # Capture which port_factories map was supplied to get_dispatcher
+    captured: dict = {}
+
+    def fake_get_dispatcher(use_case_map, port_factories=None):
+        captured["port_factories"] = port_factories
+        return Mock()
+
+    monkeypatch.setattr(ih, "get_dispatcher", fake_get_dispatcher)
+
+    ih.make_dispatcher()
+
+    sem = MessageSemantics.ADD_PARTICIPANT_STATUS_TO_PARTICIPANT
+    assert (
+        sem in captured["port_factories"]
+    ), f"{sem} must have a port factory registered"
+
+    factory = captured["port_factories"][sem]
+    kwargs = factory(mock_dl)
+
+    assert (
+        "sync_port" in kwargs
+    ), "ADD_PARTICIPANT_STATUS_TO_PARTICIPANT factory must provide sync_port"
+    assert (
+        "trigger_activity" in kwargs
+    ), "ADD_PARTICIPANT_STATUS_TO_PARTICIPANT factory must provide trigger_activity"
+
+
 def test_make_dispatcher_does_not_mutate_global(monkeypatch):
     """make_dispatcher() must not touch the module-level _DISPATCHER."""
     sentinel = object()

--- a/test/adapters/driving/fastapi/test_inbox_handler.py
+++ b/test/adapters/driving/fastapi/test_inbox_handler.py
@@ -141,7 +141,15 @@ def test_make_dispatcher_add_participant_status_has_both_ports(monkeypatch):
     factory for this semantic, leaving sync_port=None and silently skipping the
     log-entry fan-out (issue #628).
     """
-    mock_dl = MagicMock()
+    from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+    from vultron.adapters.driven.sync_activity_adapter import (
+        SyncActivityAdapter,
+    )
+    from vultron.adapters.driven.trigger_activity_adapter import (
+        TriggerActivityAdapter,
+    )
+
+    real_dl = SqliteDataLayer("sqlite:///:memory:")
 
     # Capture which port_factories map was supplied to get_dispatcher
     captured: dict = {}
@@ -160,14 +168,37 @@ def test_make_dispatcher_add_participant_status_has_both_ports(monkeypatch):
     ), f"{sem} must have a port factory registered"
 
     factory = captured["port_factories"][sem]
-    kwargs = factory(mock_dl)
+    kwargs = factory(real_dl)
 
     assert (
         "sync_port" in kwargs
     ), "ADD_PARTICIPANT_STATUS_TO_PARTICIPANT factory must provide sync_port"
+    assert isinstance(
+        kwargs["sync_port"], SyncActivityAdapter
+    ), "sync_port must be a SyncActivityAdapter instance, not None"
     assert (
         "trigger_activity" in kwargs
     ), "ADD_PARTICIPANT_STATUS_TO_PARTICIPANT factory must provide trigger_activity"
+    assert isinstance(
+        kwargs["trigger_activity"], TriggerActivityAdapter
+    ), "trigger_activity must be a TriggerActivityAdapter instance, not None"
+
+
+def test_make_dispatcher_overlapping_semantics_raises(monkeypatch):
+    """make_dispatcher() must raise AssertionError when semantics sets overlap.
+
+    This guards against a recurrence of issue #628, where a silent dict.update()
+    overwrite dropped a required port.
+    """
+    from vultron.core.models.events import MessageSemantics
+
+    # Inject an artificial overlap: put one sync-only semantic into the
+    # trigger set as well.
+    overlapping = frozenset({MessageSemantics.ADD_NOTE_TO_CASE})
+    monkeypatch.setattr(ih, "_TRIGGER_ACTIVITY_PORT_SEMANTICS", overlapping)
+
+    with pytest.raises(AssertionError, match="overlap"):
+        ih.make_dispatcher()
 
 
 def test_make_dispatcher_does_not_mutate_global(monkeypatch):

--- a/vultron/adapters/driving/fastapi/inbox_handler.py
+++ b/vultron/adapters/driving/fastapi/inbox_handler.py
@@ -124,6 +124,24 @@ def make_dispatcher() -> ActivityDispatcher:
     :func:`init_dispatcher` so the global is set for backward-compatible
     callers such as the CLI.
     """
+    # Guard: the three semantics sets must be mutually disjoint.  An overlap
+    # would cause a silent dict.update() overwrite — exactly the class of bug
+    # that #628 introduced — so fail fast with an actionable message.
+    _all_sets = (
+        _SYNC_PORT_SEMANTICS,
+        _TRIGGER_ACTIVITY_PORT_SEMANTICS,
+        _SYNC_AND_TRIGGER_PORT_SEMANTICS,
+    )
+    for i, left in enumerate(_all_sets):
+        for right in _all_sets[i + 1 :]:
+            overlap = left & right
+            if overlap:
+                raise AssertionError(
+                    f"Port-semantics sets overlap: {overlap!r}. "
+                    "Add the semantic to _SYNC_AND_TRIGGER_PORT_SEMANTICS "
+                    "and remove it from both individual sets."
+                )
+
     port_factories: dict = {
         sem: _sync_port_factory for sem in _SYNC_PORT_SEMANTICS
     }

--- a/vultron/adapters/driving/fastapi/inbox_handler.py
+++ b/vultron/adapters/driving/fastapi/inbox_handler.py
@@ -74,11 +74,20 @@ def _trigger_activity_port_factory(dl: DataLayer) -> dict[str, Any]:
     return {"trigger_activity": TriggerActivityAdapter(dl)}
 
 
+def _sync_and_trigger_port_factory(dl: DataLayer) -> dict[str, Any]:
+    """Create both a ``SyncActivityAdapter`` and a ``TriggerActivityAdapter``.
+
+    Used for semantics that require both ports — specifically
+    ``ADD_PARTICIPANT_STATUS_TO_PARTICIPANT``, which must sync the log entry to
+    participants *and* trigger the downstream participant-status activity.
+    """
+    return {**_sync_port_factory(dl), **_trigger_activity_port_factory(dl)}
+
+
 _SYNC_PORT_SEMANTICS = frozenset(
     {
         MessageSemantics.ADD_EMBARGO_EVENT_TO_CASE,
         MessageSemantics.ADD_NOTE_TO_CASE,
-        MessageSemantics.ADD_PARTICIPANT_STATUS_TO_PARTICIPANT,
         MessageSemantics.ACCEPT_INVITE_TO_EMBARGO_ON_CASE,
         MessageSemantics.ANNOUNCE_CASE_LOG_ENTRY,
         MessageSemantics.INVITE_TO_EMBARGO_ON_CASE,
@@ -91,11 +100,17 @@ _SYNC_PORT_SEMANTICS = frozenset(
 _TRIGGER_ACTIVITY_PORT_SEMANTICS = frozenset(
     {
         MessageSemantics.ACCEPT_CASE_MANAGER_ROLE,
-        MessageSemantics.ADD_PARTICIPANT_STATUS_TO_PARTICIPANT,
         MessageSemantics.OFFER_CASE_MANAGER_ROLE,
         MessageSemantics.SUBMIT_REPORT,
         MessageSemantics.SUGGEST_ACTOR_TO_CASE,
         MessageSemantics.ACCEPT_INVITE_ACTOR_TO_CASE,
+    }
+)
+
+# Semantics that require both a sync port and a trigger-activity port.
+_SYNC_AND_TRIGGER_PORT_SEMANTICS = frozenset(
+    {
+        MessageSemantics.ADD_PARTICIPANT_STATUS_TO_PARTICIPANT,
     }
 )
 
@@ -116,6 +131,12 @@ def make_dispatcher() -> ActivityDispatcher:
         {
             sem: _trigger_activity_port_factory
             for sem in _TRIGGER_ACTIVITY_PORT_SEMANTICS
+        }
+    )
+    port_factories.update(
+        {
+            sem: _sync_and_trigger_port_factory
+            for sem in _SYNC_AND_TRIGGER_PORT_SEMANTICS
         }
     )
     d = get_dispatcher(


### PR DESCRIPTION
Fixes #628

## Problem

`ADD_PARTICIPANT_STATUS_TO_PARTICIPANT` appeared in both `_SYNC_PORT_SEMANTICS` and `_TRIGGER_ACTIVITY_PORT_SEMANTICS`. In `make_dispatcher()`, the second `dict.update()` silently overwrote the sync factory with the trigger factory, so `SvcAddParticipantStatusReceivedUseCase` always received `sync_port=None`. As a result `_commit_log_cascade()` skipped the log-entry fan-out and the finder's DataLayer replica was never updated with the confirmed participant status. On the next `notify-published` trigger the stale `RM.START` seed caused the CaseActor to reject the backwards transition.

## Fix

- Added `_sync_and_trigger_port_factory` that merges both adapter dicts
- Removed `ADD_PARTICIPANT_STATUS_TO_PARTICIPANT` from both individual frozensets
- Added a new `_SYNC_AND_TRIGGER_PORT_SEMANTICS` frozenset mapped to the combined factory
- Added a regression test verifying the factory returns both `sync_port` and `trigger_activity` for that semantic

## Testing

All 2498 unit tests pass. All four linters (Black, flake8, mypy, pyright) clean.