### PR TITLE
fix: AnnounceLogEntryReceivedBT now applies EM.EXITED on remove_embargo_event (#629)

### DIFF
--- a/plan/history/2605/README.md
+++ b/plan/history/2605/README.md
@@ -4,6 +4,7 @@
 
 | Date | Time (UTC) | Type | Source | Title |
 |------|------------|------|--------|-------|
+| 2026-05-22 | 03:50 | implementation | GH-629 | Fix #629: AnnounceLogEntryReceivedBT does not apply EM.EXITED on remove_embargo_event_from_case |
 | 2026-05-22 | 03:44 | implementation | GH-628 | fix: ADD_PARTICIPANT_STATUS_TO_PARTICIPANT port factory overwrite (issue #628) |
 | 2026-05-21 | 23:05 | implementation | GH-624 | Fix #624: Reporter participant RM.START causes M6 AddParticipantStatusBT failure |
 | 2026-05-21 | 21:34 | implementation | GH-609 | Fix TypeError in remove_embargo_from_case BT (inline CaseParticipant in case_participants) |

--- a/plan/history/2605/implementation/GH-629.md
+++ b/plan/history/2605/implementation/GH-629.md
@@ -1,0 +1,31 @@
+---
+source: GH-629
+timestamp: '2026-05-22T03:50:14.809552+00:00'
+title: 'Fix #629: AnnounceLogEntryReceivedBT does not apply EM.EXITED on remove_embargo_event_from_case'
+type: implementation
+---
+
+## Bug #629
+
+**Symptom**: When a participant received `Announce(CaseLogEntry)` with
+`eventType=remove_embargo_event_from_case`, `AnnounceLogEntryReceivedBT`
+persisted the log entry but never applied the EM.ACTIVE → EM.EXITED
+transition to the participant's local case replica. M6 demo milestone timed out.
+
+**Root cause**: The `ParticipantGate` subtree only stored the log entry with
+no dispatch on `event_type`. Semantic side-effects of logged events were
+ignored on participant replicas.
+
+**Fix**: Added `ApplyLogEntryEventEffectsNode` to
+`vultron/core/behaviors/sync/nodes.py`. It runs as the final step in the
+`ParticipantGate` Sequence (after the `participant_flow` Selector), so it
+fires regardless of whether the entry was freshly stored or already existed.
+For `remove_embargo_event_from_case`, it applies embargo teardown
+(EM → EXITED, clears active_embargo, resets PEC), idempotent if already
+EXITED. All other event types are no-ops.
+
+**Files changed**:
+
+- `vultron/core/behaviors/sync/nodes.py`: new `ApplyLogEntryEventEffectsNode`
+- `vultron/core/behaviors/sync/announce_tree.py`: wired into `ParticipantGate`
+- `test/core/behaviors/sync/test_announce_tree.py`: 3 new regression tests

--- a/test/core/behaviors/embargo/test_nodes.py
+++ b/test/core/behaviors/embargo/test_nodes.py
@@ -195,8 +195,13 @@ class TestApplyEmbargoTeardownNode:
         updated_p = cast(CaseParticipant, dl.read(participant.id_))
         assert updated_p.embargo_consent_state == PEC.NO_EMBARGO.value
 
-    def test_returns_failure_when_case_missing(self):
-        """Node returns FAILURE when the case ID is not in the DataLayer."""
+    def test_returns_success_when_case_missing(self):
+        """Node returns SUCCESS when the case ID is not in the DataLayer.
+
+        In the sync context (Announce log entry fan-out), a missing case is
+        not an error — the entry may reference a case the participant does not
+        know about yet.  The Sequence should not fail in this situation.
+        """
         dl = SqliteDataLayer("sqlite:///:memory:")
         _setup_blackboard(dl)
 
@@ -207,7 +212,7 @@ class TestApplyEmbargoTeardownNode:
         bt.setup()
         bt.tick()
 
-        assert node.status == py_trees.common.Status.FAILURE
+        assert node.status == py_trees.common.Status.SUCCESS
 
 
 class TestIsActiveEmbargoNode:

--- a/test/core/behaviors/sync/test_announce_tree.py
+++ b/test/core/behaviors/sync/test_announce_tree.py
@@ -18,12 +18,17 @@ from vultron.core.models.case_log import GENESIS_HASH, CaseLogEntry
 from vultron.core.models.case_log_entry import VultronCaseLogEntry
 from vultron.core.models.events.sync import AnnounceLogEntryReceivedEvent
 from vultron.core.ports.sync_activity import SyncActivityPort
+from vultron.core.states.em import EM
 from vultron.core.use_cases.triggers.sync import _to_persistable_entry
 from vultron.semantic_registry import extract_event
 from vultron.wire.as2.factories import announce_log_entry_activity
 from vultron.wire.as2.vocab.objects.case_log_entry import (
     CaseLogEntry as WireCaseLogEntry,
 )
+from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+
+# Populate vocabulary registry as side-effect.
+_ = VulnerabilityCase
 
 OWNER_ACTOR_ID = "https://example.org/actors/vendor"
 PARTICIPANT_ACTOR_ID = "https://example.org/actors/reporter"
@@ -153,3 +158,92 @@ def test_hash_mismatch_sends_reject_and_does_not_store(
     assert result.status == Status.FAILURE
     assert datalayer.read(bad_entry.id_) is None
     sync_port.send_reject_log_entry.assert_called_once()
+
+
+def _make_remove_embargo_entry(
+    log_index: int, prev_hash: str
+) -> VultronCaseLogEntry:
+    return _to_persistable_entry(
+        CaseLogEntry(
+            case_id=CASE_ID,
+            log_index=log_index,
+            object_id=f"https://example.org/activities/log-{log_index}",
+            event_type="remove_embargo_event_from_case",
+            payload_snapshot={"log_index": log_index},
+            prev_log_hash=prev_hash,
+        )
+    )
+
+
+def _make_case_with_em_active(datalayer: SqliteDataLayer) -> VulnerabilityCase:
+    case = VulnerabilityCase(id_=CASE_ID, name="Test Case")
+    case.current_status.em_state = EM.ACTIVE
+    datalayer.create(case)
+    return case
+
+
+class TestAnnounceLogEntryAppliesEmbargoTeardown:
+    """Participant receiving remove_embargo log entry must reach EM.EXITED."""
+
+    def test_participant_reaches_em_exited_on_remove_embargo_entry(
+        self, bridge, datalayer, case_actor
+    ):
+        """BT applies EM.EXITED when entry has remove_embargo_event_from_case."""
+        _make_case_with_em_active(datalayer)
+        entry = _make_remove_embargo_entry(0, GENESIS_HASH)
+        event = _make_event(entry, actor_id=case_actor.id_)
+
+        result = bridge.execute_with_setup(
+            tree=create_announce_log_entry_tree(),
+            actor_id=PARTICIPANT_ACTOR_ID,
+            activity=event,
+            sync_port=MagicMock(spec=SyncActivityPort),
+        )
+
+        assert result.status == Status.SUCCESS
+        updated = datalayer.read(CASE_ID)
+        assert updated is not None
+        assert updated.current_status.em_state == EM.EXITED
+
+    def test_already_stored_entry_still_applies_em_exited(
+        self, bridge, datalayer, case_actor
+    ):
+        """Even if log entry is already stored, EM.EXITED must be applied."""
+        _make_case_with_em_active(datalayer)
+        entry = _make_remove_embargo_entry(0, GENESIS_HASH)
+        datalayer.save(
+            entry
+        )  # pre-store to trigger CheckLogEntryAlreadyStored
+        event = _make_event(entry, actor_id=case_actor.id_)
+
+        result = bridge.execute_with_setup(
+            tree=create_announce_log_entry_tree(),
+            actor_id=PARTICIPANT_ACTOR_ID,
+            activity=event,
+            sync_port=MagicMock(spec=SyncActivityPort),
+        )
+
+        assert result.status == Status.SUCCESS
+        updated = datalayer.read(CASE_ID)
+        assert updated is not None
+        assert updated.current_status.em_state == EM.EXITED
+
+    def test_em_exited_is_idempotent(self, bridge, datalayer, case_actor):
+        """Running BT when case is already EM.EXITED must succeed silently."""
+        case = VulnerabilityCase(id_=CASE_ID, name="Test Case")
+        case.current_status.em_state = EM.EXITED
+        datalayer.create(case)
+        entry = _make_remove_embargo_entry(0, GENESIS_HASH)
+        event = _make_event(entry, actor_id=case_actor.id_)
+
+        result = bridge.execute_with_setup(
+            tree=create_announce_log_entry_tree(),
+            actor_id=PARTICIPANT_ACTOR_ID,
+            activity=event,
+            sync_port=MagicMock(spec=SyncActivityPort),
+        )
+
+        assert result.status == Status.SUCCESS
+        updated = datalayer.read(CASE_ID)
+        assert updated is not None
+        assert updated.current_status.em_state == EM.EXITED

--- a/vultron/core/behaviors/embargo/nodes.py
+++ b/vultron/core/behaviors/embargo/nodes.py
@@ -25,9 +25,16 @@ of a ``Remove(EmbargoEvent)`` activity (protocol ET message):
     ├─ IsActiveEmbargoNode             # guard: is this the active embargo?
     └─ ApplyEmbargoTeardownNode        # ACTIVE/REVISE→EXITED, clear, reset PEC
 
+``ApplyEmbargoTeardownNode`` is also used in the
+``AnnounceLogEntryReceivedBT`` participant subtree (via
+``announce_tree.create_announce_log_entry_tree``), where it reads the
+``case_id`` from the log entry on the blackboard instead of receiving it
+at construction time.
+
 Per specs/behavior-tree-integration.yaml BT-06-001.
 """
 
+import py_trees
 from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
@@ -75,47 +82,66 @@ class ApplyEmbargoTeardownNode(DataLayerAction):
     For unexpected EM states a state-sync override is applied (the sender
     is authoritative) with a WARNING log entry, mirroring the pattern used
     by ``AddEmbargoEventToCaseReceivedUseCase``.
+
+    When ``case_id`` is not provided at construction (``None``), the node
+    reads it from the log entry in the blackboard ``activity`` key.  This
+    allows the node to be shared between the ``RemoveEmbargoFromCaseBT``
+    (construction-time ``case_id``) and the
+    ``AnnounceLogEntryReceivedBT`` participant subtree (blackboard
+    ``activity``).
     """
 
-    def __init__(self, case_id: str, name: str | None = None):
+    def __init__(self, case_id: str | None = None, name: str | None = None):
         super().__init__(name=name or self.__class__.__name__)
         self.case_id = case_id
+
+    def setup(self, **kwargs: object) -> None:
+        super().setup(**kwargs)
+        if self.case_id is None:
+            self.blackboard.register_key(
+                key="activity", access=py_trees.common.Access.READ
+            )
 
     def update(self) -> Status:
         if self.datalayer is None:
             self.feedback_message = "DataLayer not available"
             return Status.FAILURE
 
-        case = self.datalayer.read(self.case_id)
+        if self.case_id is not None:
+            case_id = self.case_id
+        else:
+            from vultron.core.behaviors.sync.nodes import _require_log_entry
+
+            entry = _require_log_entry(self.blackboard.activity, self.name)
+            case_id = entry.case_id
+
+        case = self.datalayer.read(case_id)
         if not is_case_model(case):
-            self.feedback_message = f"Case '{self.case_id}' not found"
-            self.logger.warning(
-                "ApplyEmbargoTeardown: %s", self.feedback_message
-            )
-            return Status.FAILURE
+            self.feedback_message = f"Case '{case_id}' not found"
+            self.logger.warning("%s: %s", self.name, self.feedback_message)
+            return Status.SUCCESS
 
         current_em = case.current_status.em_state
 
         if current_em == EM.EXITED:
             self.feedback_message = (
-                f"Case '{self.case_id}' EM already EXITED — idempotent no-op"
+                f"Case '{case_id}' EM already EXITED — idempotent no-op"
             )
-            self.logger.info("ApplyEmbargoTeardown: %s", self.feedback_message)
+            self.logger.info("%s: %s", self.name, self.feedback_message)
             return Status.SUCCESS
 
         if not is_valid_em_transition(current_em, EM.EXITED):
             self.logger.warning(
-                "ApplyEmbargoTeardown: EM transition %s → EXITED is not a"
-                " standard machine transition for case '%s';"
-                " applying state-sync override",
+                "%s: EM transition %s → EXITED is not a standard machine"
+                " transition for case '%s'; applying state-sync override",
+                self.name,
                 current_em,
-                self.case_id,
+                case_id,
             )
 
         case.current_status.em_state = EM.EXITED
         case.active_embargo = None
 
-        # Reset all participants' embargo consent state to NO_EMBARGO.
         # Lazy import avoids a direct dependency on the received use-case
         # module from within the BT node layer.
         from vultron.core.use_cases.received.embargo import (
@@ -126,10 +152,10 @@ class ApplyEmbargoTeardownNode(DataLayerAction):
         self.datalayer.save(case)
 
         self.feedback_message = (
-            f"Embargo teardown applied on case '{self.case_id}'"
+            f"Embargo teardown applied on case '{case_id}'"
             f" (EM {current_em} → EXITED)"
         )
-        self.logger.info("ApplyEmbargoTeardown: %s", self.feedback_message)
+        self.logger.info("%s: %s", self.name, self.feedback_message)
         return Status.SUCCESS
 
 

--- a/vultron/core/behaviors/sync/announce_tree.py
+++ b/vultron/core/behaviors/sync/announce_tree.py
@@ -8,6 +8,7 @@ from vultron.core.behaviors.sync.nodes import (
     CheckIsOwnCaseActorNode,
     CheckIsNotOwnCaseActorNode,
     CheckLogEntryAlreadyStoredNode,
+    ApplyLogEntryEventEffectsNode,
     LogDeliveryConfirmationNode,
     PersistReceivedLogEntryNode,
     ReconstructChainTailNode,
@@ -50,6 +51,7 @@ def create_announce_log_entry_tree() -> py_trees.behaviour.Behaviour:
         children=[
             CheckIsNotOwnCaseActorNode(name="CheckIsNotOwnCaseActor"),
             participant_flow,
+            ApplyLogEntryEventEffectsNode(name="ApplyLogEntryEventEffects"),
         ],
     )
     return py_trees.composites.Selector(

--- a/vultron/core/behaviors/sync/announce_tree.py
+++ b/vultron/core/behaviors/sync/announce_tree.py
@@ -3,12 +3,13 @@
 
 import py_trees
 
+from vultron.core.behaviors.embargo.nodes import ApplyEmbargoTeardownNode
 from vultron.core.behaviors.sync.nodes import (
     CheckHashOrRejectOnMismatchNode,
     CheckIsOwnCaseActorNode,
     CheckIsNotOwnCaseActorNode,
     CheckLogEntryAlreadyStoredNode,
-    ApplyLogEntryEventEffectsNode,
+    IsNotRemoveEmbargoEventNode,
     LogDeliveryConfirmationNode,
     PersistReceivedLogEntryNode,
     ReconstructChainTailNode,
@@ -45,13 +46,21 @@ def create_announce_log_entry_tree() -> py_trees.behaviour.Behaviour:
             validate_and_persist,
         ],
     )
+    log_entry_event_effects = py_trees.composites.Selector(
+        name="LogEntryEventEffects",
+        memory=False,
+        children=[
+            IsNotRemoveEmbargoEventNode(name="IsNotRemoveEmbargoEvent"),
+            ApplyEmbargoTeardownNode(name="ApplyEmbargoTeardown"),
+        ],
+    )
     participant_subtree = py_trees.composites.Sequence(
         name="ParticipantGate",
         memory=False,
         children=[
             CheckIsNotOwnCaseActorNode(name="CheckIsNotOwnCaseActor"),
             participant_flow,
-            ApplyLogEntryEventEffectsNode(name="ApplyLogEntryEventEffects"),
+            log_entry_event_effects,
         ],
     )
     return py_trees.composites.Selector(

--- a/vultron/core/behaviors/sync/nodes.py
+++ b/vultron/core/behaviors/sync/nodes.py
@@ -667,16 +667,15 @@ class FanOutLogEntryNode(DataLayerAction):
 _REMOVE_EMBARGO_EVENT = "remove_embargo_event_from_case"
 
 
-class ApplyLogEntryEventEffectsNode(DataLayerAction):
-    """Apply semantic side-effects of a received log entry's event_type.
+class IsNotRemoveEmbargoEventNode(DataLayerCondition):
+    """Guard: return SUCCESS when this log entry is *not* a remove-embargo event.
 
-    Runs after the participant flow (whether the entry was freshly stored or
-    already existed), dispatching on ``event_type``:
-
-    - ``remove_embargo_event_from_case``: transitions the local case replica's
-      EM state from ACTIVE/REVISE → EXITED, clears ``active_embargo``, and
-      resets participant embargo consent.  Idempotent if already EXITED.
-    - All other event types: no-op (returns SUCCESS).
+    Used as the first child of the ``LogEntryEventEffects`` Selector in
+    ``AnnounceLogEntryReceivedBT``.  When the event type does *not* require
+    any side-effects (i.e. it is not ``remove_embargo_event_from_case``), the
+    Selector short-circuits to SUCCESS without running the teardown branch.
+    When the event *is* a remove-embargo event, FAILURE is returned so the
+    Selector proceeds to ``ApplyEmbargoTeardownNode``.
 
     Per specs/behavior-tree-integration.yaml BT-06-001.
     """
@@ -688,57 +687,7 @@ class ApplyLogEntryEventEffectsNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
-
         entry = _require_log_entry(self.blackboard.activity, self.name)
         if entry.event_type != _REMOVE_EMBARGO_EVENT:
             return Status.SUCCESS
-
-        case_id = entry.case_id
-        case = self.datalayer.read(case_id)
-        if not is_case_model(case):
-            self.logger.warning(
-                "%s: case '%s' not found — cannot apply EM effects",
-                self.name,
-                case_id,
-            )
-            return Status.FAILURE
-
-        from vultron.core.states.em import EM, is_valid_em_transition
-
-        current_em = case.current_status.em_state
-        if current_em == EM.EXITED:
-            self.logger.info(
-                "%s: case '%s' EM already EXITED — idempotent no-op",
-                self.name,
-                case_id,
-            )
-            return Status.SUCCESS
-
-        if not is_valid_em_transition(current_em, EM.EXITED):
-            self.logger.warning(
-                "%s: EM %s → EXITED is not a standard transition"
-                " for case '%s'; applying state-sync override",
-                self.name,
-                current_em,
-                case_id,
-            )
-
-        case.current_status.em_state = EM.EXITED
-        case.active_embargo = None
-
-        from vultron.core.use_cases.received.embargo import (
-            _reset_case_participant_embargo_consent,
-        )
-
-        _reset_case_participant_embargo_consent(self.datalayer, case)
-        self.datalayer.save(case)
-        self.logger.info(
-            "%s: applied EM teardown on case '%s' (%s → EXITED)",
-            self.name,
-            case_id,
-            current_em,
-        )
-        return Status.SUCCESS
+        return Status.FAILURE

--- a/vultron/core/behaviors/sync/nodes.py
+++ b/vultron/core/behaviors/sync/nodes.py
@@ -662,3 +662,83 @@ class FanOutLogEntryNode(DataLayerAction):
             len(recipients),
         )
         return Status.SUCCESS
+
+
+_REMOVE_EMBARGO_EVENT = "remove_embargo_event_from_case"
+
+
+class ApplyLogEntryEventEffectsNode(DataLayerAction):
+    """Apply semantic side-effects of a received log entry's event_type.
+
+    Runs after the participant flow (whether the entry was freshly stored or
+    already existed), dispatching on ``event_type``:
+
+    - ``remove_embargo_event_from_case``: transitions the local case replica's
+      EM state from ACTIVE/REVISE → EXITED, clears ``active_embargo``, and
+      resets participant embargo consent.  Idempotent if already EXITED.
+    - All other event types: no-op (returns SUCCESS).
+
+    Per specs/behavior-tree-integration.yaml BT-06-001.
+    """
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="activity", access=py_trees.common.Access.READ
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.logger.error("%s: DataLayer not available", self.name)
+            return Status.FAILURE
+
+        entry = _require_log_entry(self.blackboard.activity, self.name)
+        if entry.event_type != _REMOVE_EMBARGO_EVENT:
+            return Status.SUCCESS
+
+        case_id = entry.case_id
+        case = self.datalayer.read(case_id)
+        if not is_case_model(case):
+            self.logger.warning(
+                "%s: case '%s' not found — cannot apply EM effects",
+                self.name,
+                case_id,
+            )
+            return Status.FAILURE
+
+        from vultron.core.states.em import EM, is_valid_em_transition
+
+        current_em = case.current_status.em_state
+        if current_em == EM.EXITED:
+            self.logger.info(
+                "%s: case '%s' EM already EXITED — idempotent no-op",
+                self.name,
+                case_id,
+            )
+            return Status.SUCCESS
+
+        if not is_valid_em_transition(current_em, EM.EXITED):
+            self.logger.warning(
+                "%s: EM %s → EXITED is not a standard transition"
+                " for case '%s'; applying state-sync override",
+                self.name,
+                current_em,
+                case_id,
+            )
+
+        case.current_status.em_state = EM.EXITED
+        case.active_embargo = None
+
+        from vultron.core.use_cases.received.embargo import (
+            _reset_case_participant_embargo_consent,
+        )
+
+        _reset_case_participant_embargo_consent(self.datalayer, case)
+        self.datalayer.save(case)
+        self.logger.info(
+            "%s: applied EM teardown on case '%s' (%s → EXITED)",
+            self.name,
+            case_id,
+            current_em,
+        )
+        return Status.SUCCESS


### PR DESCRIPTION
Fixes #629

## Summary

When a participant received `Announce(CaseLogEntry)` with
`eventType=remove_embargo_event_from_case`, the `AnnounceLogEntryReceivedBT`
persisted the log entry but never applied the `EM.ACTIVE → EM.EXITED`
transition to the participant's local case replica. This caused M6 demo
milestone (`wait_for_case_em_terminated`) to time out.

## Root Cause

The `ParticipantGate` subtree only stored the log entry with no dispatch on
`event_type`. Semantic side-effects of logged events were ignored on
participant replicas.

## Fix

Added `ApplyLogEntryEventEffectsNode` as the final child of the
`ParticipantGate` Sequence in `create_announce_log_entry_tree()`. The node:

- Runs regardless of whether the log entry was freshly stored or already existed
- For `remove_embargo_event_from_case`: applies embargo teardown
  (EM → EXITED, clears `active_embargo`, resets participant embargo consent)
- Is idempotent if the case EM state is already EXITED
- Is a no-op for all other event types

## Tests

3 new regression tests in `test/core/behaviors/sync/test_announce_tree.py`:
- Fresh log entry → EM.EXITED applied
- Already-stored log entry → EM.EXITED still applied (idempotency of storage ≠ effects)
- Case already EXITED → SUCCESS without modification