### PR TITLE
fix(embargo): make _is_case_owner fail-closed when attributed_to is None

### DIFF
--- a/docker/docker-compose-multi-actor.yml
+++ b/docker/docker-compose-multi-actor.yml
@@ -1,7 +1,7 @@
 # Multi-Actor Vultron Demo — Docker Compose Configuration
 #
-# Defines four isolated actor services (finder, vendor, coordinator,
-# case-actor), each
+# Defines five isolated actor services (finder, vendor, coordinator,
+# coordinator2, case-actor), each
 # with its own DataLayer volume, health check, and network membership.
 #
 # DEMO-MA-02-001: Each actor service has a /health/ready healthcheck.
@@ -59,11 +59,10 @@
 #   vultron-network   Shared bridge network connecting all services.
 #
 # ─── Startup and seeding ──────────────────────────────────────────────────
-# The API server containers (finder, vendor, coordinator, case-actor) do NOT
-# auto-seed
-# actor records on startup.  The `demo-runner` two-actor scenario resets
-# the relevant containers and seeds Finder/Vendor automatically, producing
-# a deterministic acceptance run with a single `docker compose up
+# The API server containers (finder, vendor, coordinator, coordinator2,
+# case-actor) do NOT auto-seed actor records on startup. The `demo-runner`
+# service resets the relevant containers and seeds actors automatically,
+# producing a deterministic acceptance run with a single `docker compose up
 # --abort-on-container-exit demo-runner` command. Manual seed commands
 # remain available when debugging individual services. Each service's
 # seed configuration is pre-built in docker/seed-configs/ and mounted

--- a/docker/docker-compose-multi-actor.yml
+++ b/docker/docker-compose-multi-actor.yml
@@ -1,7 +1,7 @@
 # Multi-Actor Vultron Demo — Docker Compose Configuration
 #
 # Defines five isolated actor services (finder, vendor, coordinator,
-# coordinator2, case-actor), each
+# vendor2, case-actor), each
 # with its own DataLayer volume, health check, and network membership.
 #
 # DEMO-MA-02-001: Each actor service has a /health/ready healthcheck.
@@ -59,7 +59,7 @@
 #   vultron-network   Shared bridge network connecting all services.
 #
 # ─── Startup and seeding ──────────────────────────────────────────────────
-# The API server containers (finder, vendor, coordinator, coordinator2,
+# The API server containers (finder, vendor, coordinator, vendor2,
 # case-actor) do NOT auto-seed actor records on startup. The `demo-runner`
 # service resets the relevant containers and seeds actors automatically,
 # producing a deterministic acceptance run with a single `docker compose up

--- a/plan/history/2606/README.md
+++ b/plan/history/2606/README.md
@@ -4,6 +4,7 @@
 
 | Date | Time (UTC) | Type | Source | Title |
 |------|------------|------|--------|-------|
+| 2026-06-01 | 18:01 | implementation | 412 | Fix _is_case_owner fail-open (issue #412) |
 | 2026-06-01 | 15:43 | implementation | ISSUE-471 | Two-actor demo tutorial |
 | 2026-06-01 | 13:51 | implementation | ISSUE-472 | Two-actor demo technical reference documentation |
 | 2026-06-01 | 13:47 | learning | ISSUE-610 | Starlette {key:path} for URL-keyed endpoints |

--- a/plan/history/2606/implementation/412.md
+++ b/plan/history/2606/implementation/412.md
@@ -1,0 +1,18 @@
+---
+source: '412'
+timestamp: '2026-06-01T18:01:51.620216+00:00'
+title: 'Fix _is_case_owner fail-open (issue #412)'
+type: implementation
+---
+
+Fixed bug #412: `_is_case_owner()` had a fail-open fallback that treated
+any actor as the case owner when `case.attributed_to` was `None`. Changed
+to fail-closed (returns `False` when `attributed_to is None`). Also fixed
+the wrong embargo acceptance ordering in `multi_vendor_demo.py` (Vendor
+must accept before Finder) and corrected stale comments in
+`docker-compose-multi-actor.yml`. Added two regression tests. Updated
+three test fixtures that relied on the fail-open behavior to explicitly
+set `attributed_to=actor.id_`.
+
+PR: <https://github.com/CERTCC/Vultron/pull/645>
+Fixes: <https://github.com/CERTCC/Vultron/issues/412>

--- a/test/adapters/driving/fastapi/routers/test_trigger_embargo.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_embargo.py
@@ -172,7 +172,10 @@ def case_with_embargo(dl, actor):
 @pytest.fixture
 def case_with_proposal(dl, actor):
     """A VulnerabilityCase with a pending EmProposeEmbargoActivity in EM.PROPOSED state."""
-    case_obj = VulnerabilityCase(name="PROPOSAL-CASE-001")
+    case_obj = VulnerabilityCase(
+        name="PROPOSAL-CASE-001",
+        attributed_to=actor.id_,
+    )
     embargo = EmbargoEvent(context=case_obj.id_)
     dl.create(embargo)
     proposal = em_propose_embargo_activity(

--- a/test/core/use_cases/received/test_embargo.py
+++ b/test/core/use_cases/received/test_embargo.py
@@ -608,6 +608,7 @@ class TestEmbargoUseCases:
         case = VulnerabilityCase(
             id_="https://example.org/cases/case_eval_invalid",
             name="Evaluate Invalid EM State",
+            attributed_to=actor.id_,
         )
         embargo = EmbargoEvent(
             id_="https://example.org/cases/case_eval_invalid/embargo_events/e1",

--- a/test/core/use_cases/triggers/test_embargo.py
+++ b/test/core/use_cases/triggers/test_embargo.py
@@ -9,12 +9,16 @@ from vultron.adapters.driven.datalayer_sqlite import (
     SqliteDataLayer,
     reset_datalayer,
 )
+from vultron.adapters.driven.trigger_activity_adapter import (
+    TriggerActivityAdapter,
+)
 from vultron.core.states.em import EM
 from vultron.core.states.participant_embargo_consent import PEC
 from vultron.core.states.roles import CVDRole
 from vultron.core.use_cases.triggers.embargo import (
     SvcAcceptEmbargoUseCase,
     SvcRejectEmbargoUseCase,
+    _is_case_owner,
 )
 from vultron.core.use_cases.triggers.requests import (
     AcceptEmbargoTriggerRequest,
@@ -30,9 +34,6 @@ from vultron.wire.as2.vocab.objects.case_participant import (
 )
 from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
-from vultron.adapters.driven.trigger_activity_adapter import (
-    TriggerActivityAdapter,
-)
 
 
 def _persist_actor(dl: SqliteDataLayer, name: str) -> as_Service:
@@ -82,6 +83,59 @@ def _build_active_embargo_case(
     dl.create(participant)
 
     return case, proposal, participant.id_
+
+
+def _build_proposed_embargo_case_no_owner_attribution(
+    dl: SqliteDataLayer,
+    actor_id: str,
+    case_manager_id: str,
+) -> tuple[VulnerabilityCase, as_Invite, str]:
+    """Build a PROPOSED embargo case with ``attributed_to=None``.
+
+    Simulates the historical case where owner attribution was not consistently
+    populated. The case has a CASE_MANAGER participant (so sender_side_bt can
+    run) but ``attributed_to`` is unset on the case itself.
+    """
+    case = VulnerabilityCase(name="No-attribution proposed embargo case")
+    # attributed_to intentionally NOT set — this is the bug state
+
+    embargo = EmbargoEvent(context=case.id_)
+    proposal = em_propose_embargo_activity(
+        embargo, context=case.id_, actor=case_manager_id
+    )
+
+    case_manager_participant = VendorParticipant(
+        attributed_to=case_manager_id,
+        context=case.id_,
+        embargo_consent_state=PEC.SIGNATORY.value,
+        accepted_embargo_ids=[embargo.id_],
+    )
+    case_manager_participant.add_role(CVDRole.CASE_MANAGER)
+
+    actor_participant = FinderParticipant(
+        attributed_to=actor_id,
+        context=case.id_,
+        embargo_consent_state=PEC.INVITED.value,
+    )
+
+    case.case_participants = [
+        case_manager_participant.id_,
+        actor_participant.id_,
+    ]
+    case.actor_participant_index = {
+        case_manager_id: case_manager_participant.id_,
+        actor_id: actor_participant.id_,
+    }
+    case.current_status.em_state = EM.PROPOSED
+    case.proposed_embargoes.append(embargo.id_)
+
+    dl.create(case)
+    dl.create(embargo)
+    dl.create(proposal)
+    dl.create(case_manager_participant)
+    dl.create(actor_participant)
+
+    return case, proposal, actor_participant.id_
 
 
 @pytest.fixture
@@ -167,3 +221,63 @@ def test_non_owner_reject_embargo_on_active_case_updates_participant_only(
     assert updated_case.current_status.em_state == EM.ACTIVE
     assert updated_case.active_embargo == case.active_embargo
     assert updated_participant.embargo_consent_state == PEC.DECLINED.value
+
+
+def test_is_case_owner_fail_closed_when_attributed_to_is_none() -> None:
+    """_is_case_owner must return False when case.attributed_to is None.
+
+    This prevents any actor from being granted owner privileges on a case with
+    missing owner attribution. The function must be fail-closed, not fail-open.
+    """
+    case = VulnerabilityCase(name="Orphan case")
+    assert case.attributed_to is None
+
+    assert _is_case_owner(case, "https://example.org/alice") is False
+    assert _is_case_owner(case, "https://example.org/bob") is False
+
+
+def test_accept_embargo_when_attributed_to_is_none_does_not_activate_em(
+    finder_actor_and_dl: tuple[as_Service, SqliteDataLayer],
+) -> None:
+    """_is_case_owner must fail-closed: attributed_to=None must not activate EM.
+
+    Guards against the fail-open bug where an unset attributed_to caused any
+    calling actor to be treated as the case owner, allowing a non-owner to
+    drive EM from PROPOSED to ACTIVE.
+    """
+    finder, finder_dl = finder_actor_and_dl
+    case_manager = _persist_actor(finder_dl, "Vendor Co")
+    case, proposal, participant_id = (
+        _build_proposed_embargo_case_no_owner_attribution(
+            finder_dl, finder.id_, case_manager.id_
+        )
+    )
+
+    assert case.attributed_to is None
+    assert case.current_status.em_state == EM.PROPOSED
+
+    request = AcceptEmbargoTriggerRequest(
+        actor_id=finder.id_,
+        case_id=case.id_,
+        proposal_id=proposal.id_,
+    )
+
+    result = SvcAcceptEmbargoUseCase(
+        finder_dl, request, trigger_activity=TriggerActivityAdapter(finder_dl)
+    ).execute()
+
+    assert "activity" in result
+
+    updated_case = finder_dl.read(case.id_)
+    updated_participant = finder_dl.read(participant_id)
+
+    assert updated_case is not None
+    assert updated_participant is not None
+    updated_case = cast(VulnerabilityCase, updated_case)
+    updated_participant = cast(CaseParticipant, updated_participant)
+
+    # With fail-closed behavior, EM must stay PROPOSED — no actor qualifies as
+    # owner when attributed_to is None.
+    assert updated_case.current_status.em_state == EM.PROPOSED
+    # Participant consent IS updated (they accepted as a non-owner participant).
+    assert updated_participant.embargo_consent_state == PEC.SIGNATORY.value

--- a/test/core/use_cases/triggers/test_service.py
+++ b/test/core/use_cases/triggers/test_service.py
@@ -221,7 +221,10 @@ def case_with_embargo(dl, actor):
 
 @pytest.fixture
 def case_with_proposal(dl, actor):
-    case_obj = VulnerabilityCase(name="PROPOSAL-CASE-001")
+    case_obj = VulnerabilityCase(
+        name="PROPOSAL-CASE-001",
+        attributed_to=actor.id_,
+    )
     embargo = EmbargoEvent(context=case_obj.id_)
     dl.create(embargo)
     proposal = em_propose_embargo_activity(

--- a/vultron/core/use_cases/triggers/embargo.py
+++ b/vultron/core/use_cases/triggers/embargo.py
@@ -135,14 +135,14 @@ def _cascade_pec_reset(
 def _is_case_owner(case: PersistableModel | None, actor_id: str) -> bool:
     """Return True when ``actor_id`` matches the case owner.
 
-    Cases created before owner attribution was consistently populated still
-    need a sensible single-actor default, so ``None`` falls back to treating
-    the triggering actor as the owner.
+    This check is fail-closed: when ``attributed_to`` is ``None`` (ownership
+    unknown), no actor is treated as the owner. Only an exact match between
+    the resolved owner ID and the given ``actor_id`` returns True.
     """
     if not is_case_model(case):
         return False
     owner_id = _as_id(case.attributed_to)
-    return owner_id is None or owner_id == actor_id
+    return owner_id is not None and owner_id == actor_id
 
 
 def _update_participant_embargo_acceptance(

--- a/vultron/demo/scenario/multi_vendor_demo.py
+++ b/vultron/demo/scenario/multi_vendor_demo.py
@@ -27,7 +27,7 @@ Workflow (five containers: finder, vendor, coordinator, vendor2, case-actor):
     (case.attributed_to = Vendor).
 5.  Vendor links the report to the case.
 6.  Vendor invites Finder to the case; Finder accepts.
-7.  Vendor proposes an embargo; Finder accepts; Vendor self-accepts.
+7.  Vendor proposes an embargo; Vendor self-accepts; Finder accepts.
 8.  Vendor offers case ownership to Coordinator; Coordinator accepts
     (case.attributed_to is updated to Coordinator on the CaseActor).
 9.  Coordinator invites Vendor2 to the case; Vendor2 accepts.
@@ -610,16 +610,17 @@ def run_multi_vendor_demo(
         recipient=finder_in_finder,
         proposal=embargo_proposal,
     )
-    actor_accepts_embargo(
-        case_actor_client=case_actor_client,
-        actor=finder_in_finder,
-        case=case,
-        proposal=embargo_proposal,
-    )
-    # Vendor also accepts the embargo they proposed.
+    # Vendor (case owner) self-accepts the embargo they proposed first.
     actor_accepts_embargo(
         case_actor_client=case_actor_client,
         actor=vendor_in_vendor,
+        case=case,
+        proposal=embargo_proposal,
+    )
+    # Finder accepts the delivered proposal (non-owner participant).
+    actor_accepts_embargo(
+        case_actor_client=case_actor_client,
+        actor=finder_in_finder,
         case=case,
         proposal=embargo_proposal,
     )


### PR DESCRIPTION
## Summary

Fixes #412.

### Root Cause

`_is_case_owner()` in `vultron/core/use_cases/triggers/embargo.py` had a fail-open fallback: when `case.attributed_to` was `None`, any calling actor was treated as the case owner. This allowed non-owner actors to drive embargo state transitions (PROPOSED → ACTIVE).

Additionally, `multi_vendor_demo.py` had the wrong acceptance ordering — Finder (non-owner) accepted before Vendor (owner) — which, combined with the fail-open bug, was the specific 409 Conflict trigger described in the issue.

### Changes

- **`vultron/core/use_cases/triggers/embargo.py`**: Changed `_is_case_owner()` from fail-open to fail-closed. When `attributed_to is None`, no actor qualifies as owner.
- **`vultron/demo/scenario/multi_vendor_demo.py`**: Fixed embargo acceptance order so Vendor (owner) accepts before Finder (non-owner). Updated module docstring.
- **`docker/docker-compose-multi-actor.yml`**: Fixed stale comments (actor count 4→5; removed 'two-actor scenario' description).
- **`test/core/use_cases/triggers/test_embargo.py`**: Added two regression tests — one unit test for `_is_case_owner` directly, one integration test through `SvcAcceptEmbargoUseCase`.
- **Three test fixtures updated**: `test_service.py`, `test_trigger_embargo.py`, `test_embargo.py` (received) — all had cases with `attributed_to=None` relying on fail-open behavior; updated to set `attributed_to=actor.id_` explicitly.

### Test Results

2717 passed, 12 skipped, 3 xfailed — 0 failures.