### PR TITLE
plan: priorities review — archive P470, update Epic headings, add #643/#644 to P485

### DIFF
--- a/plan/PRIORITIES.md
+++ b/plan/PRIORITIES.md
@@ -16,58 +16,7 @@ own child issues, etc.) The list of child issues in GitHub is
 authoritative regardless what is listed below, this file is a high-level
 index and summary.
 
-## Priority 470 — Two-Actor Demo Redesign
-
-Redesign the two-actor (Reporter + Vendor) CVD demo to implement a complete,
-correct end-to-end CVD workflow: report submission, case creation with Case
-Actor handoff, embargo bootstrap, fix lifecycle (VF → VFD → VFDPxa),
-embargo teardown, and case closure.
-
-See `notes/two-actor-demo.md` for the authoritative design; `specs/multi-actor-demo.yaml`
-groups DEMOMA-06, DEMOMA-07, DEMOMA-08 for formal requirements.
-
-- Epic: [#464](https://github.com/CERTCC/Vultron/issues/464)
-- [#460](https://github.com/CERTCC/Vultron/issues/460) — Sub-issue A: Documentation and spec updates ✅
-- [#461](https://github.com/CERTCC/Vultron/issues/461) — Sub-issue B: Core capabilities ✅
-- [#462](https://github.com/CERTCC/Vultron/issues/462) — Sub-issue C: CASE_MANAGER role delegation protocol ✅
-- [#469](https://github.com/CERTCC/Vultron/issues/469) — Case Actor spawning and CASE_MANAGER delegation automation ✅
-- [#463](https://github.com/CERTCC/Vultron/issues/463) — Sub-issue D: Demo replacement ✅
-- [#475](https://github.com/CERTCC/Vultron/issues/475) — Case Actor URN-based ID makes it unreachable via HTTP delivery ✅
-- [#476](https://github.com/CERTCC/Vultron/issues/476) — Remove spec-violating workarounds from SvcAddParticipantStatusUseCase ✅
-- [#483](https://github.com/CERTCC/Vultron/issues/483) — two\_actor\_demo.py: participant fetch, status check, and exception
-  handling bugs ✅
-- [#484](https://github.com/CERTCC/Vultron/issues/484) — Type narrowing: `_resolve_current_participant_state()` returns
-  `tuple[Any, Any]` ✅
-- [#467](https://github.com/CERTCC/Vultron/issues/467) — BT refactor: AddParticipantStatusToParticipant handler (also fixes RM
-  transition validation regression) ✅
-- [#489](https://github.com/CERTCC/Vultron/issues/489) — Extract shared helpers into vultron/demo/helpers/ ✅
-- [#521](https://github.com/CERTCC/Vultron/issues/521) — PCR-07: Integration tests for case-replica bootstrap and late-joiner
-  sequences (parent) ✅
-  - [#522](https://github.com/CERTCC/Vultron/issues/522) — PCR-07-006: bootstrap sequence (Create → Announce → replica) ✅
-  - [#523](https://github.com/CERTCC/Vultron/issues/523) — PCR-07-007: late-joiner sequence (Invite → Accept → Announce →
-    replica) ✅
-- [#527](https://github.com/CERTCC/Vultron/issues/527) — Integration demo suite takes 17+ min in CI — polling helpers not
-  patched ✅
-- [#530](https://github.com/CERTCC/Vultron/issues/530) — Demo integration tests share a single DataLayer across actors —
-  delivery path untested ✅
-- [#534](https://github.com/CERTCC/Vultron/issues/534) — Co-located actors in same process share module-level singletons
-  (emitter, dispatcher, DataLayer) ✅
-- [#570](https://github.com/CERTCC/Vultron/issues/570) — Demo CI: GitHub Actions integration workflow + demo runner
-  hardening ✅
-- [#589](https://github.com/CERTCC/Vultron/issues/589) — SvcAddParticipantStatusUseCase sends RM.START after notify-published ✅
-- [#593](https://github.com/CERTCC/Vultron/issues/593) — Post-case-creation participant messages bypass Case Actor —
-  outbound routing model missing from spec and broken in implementation ✅
-  - [#594](https://github.com/CERTCC/Vultron/issues/594) — Fix outbound routing: participant trigger use cases must address
-    Case Actor only, not all participants ✅
-  - [#595](https://github.com/CERTCC/Vultron/issues/595) — Implement automatic CaseLogEntry + Announce(CaseLogEntry)
-    broadcast cascade in all Case Actor received handlers ✅
-  - [#596](https://github.com/CERTCC/Vultron/issues/596) — Refactor sender-side trigger use cases into Behavior Trees ✅
-- [#466](https://github.com/CERTCC/Vultron/issues/466) — Docs: two-actor-demo tutorial + technical reference (blocked by demo
-  running end-to-end)
-- [#471](https://github.com/CERTCC/Vultron/issues/471) — Tutorial: docs/tutorials/two-actor-demo.md
-- [#472](https://github.com/CERTCC/Vultron/issues/472) — Technical reference: docs/reference/two-actor-demo-protocol.md
-
-## Priority 476 — Bug Fixes and Demo Polish
+## Priority 476 — Epic #446: Bug Fixes and Demo Polish
 
 Fix issues affecting demo execution and correctness.
 
@@ -115,7 +64,7 @@ CBT-05-003 and `notes/case-bootstrap-trust.md` §Out-of-Order Handling.
 - [#500](https://github.com/CERTCC/Vultron/issues/500) — CBT-03: Implement
   bounded pre-bootstrap queue expiry and replay request
 
-## Priority 485 — Architecture Hardening
+## Priority 485 — Epic #539: Architecture Hardening
 
 Resolve structural fragilities in the core architecture: import boundary
 violations, order-sensitive dispatch, fragile DataLayer scope conventions,
@@ -154,6 +103,10 @@ outbox polling, and oversized centralized dispatch tables.
   should be in the BT
 - [#632](https://github.com/CERTCC/Vultron/issues/632) — Concern:
   BT idiom audit: pervasive anti-patterns across use cases and BT nodes
+- [#643](https://github.com/CERTCC/Vultron/issues/643) — SYNC-07-002/003:
+  Integration tests for single-peer log replication cycle
+- [#644](https://github.com/CERTCC/Vultron/issues/644) — TRACE-01-003:
+  Update user-stories traceability matrix for newer spec topics
 
 ## Priority 490 — Epic #611: Test File Refactoring
 

--- a/plan/history/2606/README.md
+++ b/plan/history/2606/README.md
@@ -5,6 +5,7 @@
 | Date | Time (UTC) | Type | Source | Title |
 |------|------------|------|--------|-------|
 | 2026-06-01 | 18:01 | implementation | 412 | Fix _is_case_owner fail-open (issue #412) |
+| 2026-06-01 | 17:56 | priority | PRIORITIES.md#470 | Priority 470: Two-Actor Demo Redesign |
 | 2026-06-01 | 15:43 | implementation | ISSUE-471 | Two-actor demo tutorial |
 | 2026-06-01 | 13:51 | implementation | ISSUE-472 | Two-actor demo technical reference documentation |
 | 2026-06-01 | 13:47 | learning | ISSUE-610 | Starlette {key:path} for URL-keyed endpoints |

--- a/plan/history/2606/README.md
+++ b/plan/history/2606/README.md
@@ -5,7 +5,7 @@
 | Date | Time (UTC) | Type | Source | Title |
 |------|------------|------|--------|-------|
 | 2026-06-01 | 18:01 | implementation | 412 | Fix _is_case_owner fail-open (issue #412) |
-| 2026-06-01 | 17:56 | priority | PRIORITIES.md#470 | Priority 470: Two-Actor Demo Redesign |
+| 2026-06-01 | 17:56 | priority | Priority 470 | Priority 470: Two-Actor Demo Redesign |
 | 2026-06-01 | 15:43 | implementation | ISSUE-471 | Two-actor demo tutorial |
 | 2026-06-01 | 13:51 | implementation | ISSUE-472 | Two-actor demo technical reference documentation |
 | 2026-06-01 | 13:47 | learning | ISSUE-610 | Starlette {key:path} for URL-keyed endpoints |

--- a/plan/history/2606/priority/PRIORITIES.md#470.md
+++ b/plan/history/2606/priority/PRIORITIES.md#470.md
@@ -1,0 +1,41 @@
+---
+source: PRIORITIES.md#470
+timestamp: '2026-06-01T17:56:24.617105+00:00'
+title: 'Priority 470: Two-Actor Demo Redesign'
+type: priority
+---
+
+Completed redesign of the two-actor (Reporter + Vendor) CVD demo implementing a complete,
+correct end-to-end CVD workflow: report submission, case creation with Case Actor handoff,
+embargo bootstrap, fix lifecycle (VF → VFD → VFDPxa), embargo teardown, and case closure.
+
+Epic: #464
+
+## Completed issues
+
+- #460 — Sub-issue A: Documentation and spec updates
+- #461 — Sub-issue B: Core capabilities
+- #462 — Sub-issue C: CASE_MANAGER role delegation protocol
+- #469 — Case Actor spawning and CASE_MANAGER delegation automation
+- #463 — Sub-issue D: Demo replacement
+- #475 — Case Actor URN-based ID makes it unreachable via HTTP delivery
+- #476 — Remove spec-violating workarounds from SvcAddParticipantStatusUseCase
+- #483 — two_actor_demo.py: participant fetch, status check, and exception handling bugs
+- #484 — Type narrowing: _resolve_current_participant_state() returns tuple[Any, Any]
+- #467 — BT refactor: AddParticipantStatusToParticipant handler
+- #489 — Extract shared helpers into vultron/demo/helpers/
+- #521 — PCR-07: Integration tests for case-replica bootstrap and late-joiner sequences (parent)
+  - #522 — PCR-07-006: bootstrap sequence
+  - #523 — PCR-07-007: late-joiner sequence
+- #527 — Integration demo suite takes 17+ min in CI — polling helpers not patched
+- #530 — Demo integration tests share a single DataLayer across actors
+- #534 — Co-located actors in same process share module-level singletons
+- #570 — Demo CI: GitHub Actions integration workflow + demo runner hardening
+- #589 — SvcAddParticipantStatusUseCase sends RM.START after notify-published
+- #593 — Post-case-creation participant messages bypass Case Actor (parent)
+  - #594 — Fix outbound routing: participant trigger use cases must address Case Actor only
+  - #595 — Implement automatic CaseLogEntry + Announce(CaseLogEntry) broadcast cascade
+  - #596 — Refactor sender-side trigger use cases into Behavior Trees
+- #466 — Docs: two-actor-demo tutorial + technical reference
+- #471 — Tutorial: docs/tutorials/two-actor-demo.md
+- #472 — Technical reference: docs/reference/two-actor-demo-protocol.md

--- a/plan/history/2606/priority/Priority 470.md
+++ b/plan/history/2606/priority/Priority 470.md
@@ -1,5 +1,5 @@
 ---
-source: PRIORITIES.md#470
+source: Priority 470
 timestamp: '2026-06-01T17:56:24.617105+00:00'
 title: 'Priority 470: Two-Actor Demo Redesign'
 type: priority


### PR DESCRIPTION
## Summary

Priorities review session (2026-06-01).

### Changes

- **Archive Priority 470** (Two-Actor Demo Redesign) — all issues are closed,
  including #466, #471, #472 which were still listed without ✅. History entry
  written to `plan/history/2606/priority/`.
- **Update heading formats** for P476 and P485 to the standard
  `## Priority NNN — Epic #M: Title` format.
- **Add #643 and #644 to Priority 485** (Architecture Hardening) — two new
  `group:unscheduled` issues now covered. Also wired as sub-issues of
  Epic #539 on GitHub.

### GitHub changes (already applied)

- Epic #446 (P476): wired #486, #487, #501, #518 as sub-issues
- Epic #539 (P485): wired #643, #644 as sub-issues + applied
  `group:architecture-hardening` label
- PR #642: applied `group:miscellaneous-tasks` label (now merged)