### PR TITLE
docs: DataLayer scope boundaries — specs, notes, AGENTS.md (concern #502)

### DIFF
--- a/notes/architecture-ports-and-adapters.md
+++ b/notes/architecture-ports-and-adapters.md
@@ -877,16 +877,16 @@ allowed locations: `vultron/wire/as2/vocab/activities/`,
 `SqliteDataLayer` operates in two modes controlled by the `actor_id`
 constructor argument:
 
-- **Shared** (`actor_id=None`): A global view — `read`, `save`, and `list`
-  operations see all rows regardless of which actor wrote them. Used for
-  domain object storage (Cases, Activities, Actors, Reports) and for the
-  trigger service.
+- **Shared** (`actor_id=None`): A global view — `read` and `list`
+  operations see all rows regardless of which actor wrote them; `save` and
+  `create` write rows with `actor_id=None`. Used for domain object storage
+  (Cases, Activities, Actors, Reports) and for the trigger service.
 - **Actor-scoped** (`actor_id="https://example.org/actors/alice"`): Filters
   all reads and writes to rows belonging to that actor. **Required for
   inbox and outbox queue operations.**
 
 Queue methods (`inbox_list`, `inbox_pop`, `inbox_append`, `outbox_list`,
-`outbox_pop`) use `self._actor_id` as the queue key. Calling these on a
+`outbox_pop`, `outbox_append`) use `self._actor_id` as the queue key. Calling these on a
 shared DataLayer (`_actor_id=None`) silently operates on a queue keyed by
 `""` — not any actor's real queue. Items will be written and read from a
 phantom queue, making the actor's real queue appear perpetually empty.

--- a/notes/architecture-ports-and-adapters.md
+++ b/notes/architecture-ports-and-adapters.md
@@ -867,3 +867,59 @@ internal activity subclasses are not imported directly except from the
 allowed locations: `vultron/wire/as2/vocab/activities/`,
 `vultron/wire/as2/factories/`, `test/wire/as2/vocab/`,
 `test/architecture/`, and `vultron/semantic_registry.py`.
+
+---
+
+## DataLayer Scope Boundaries
+
+### Shared vs. Actor-Scoped DataLayer
+
+`SqliteDataLayer` operates in two modes controlled by the `actor_id`
+constructor argument:
+
+- **Shared** (`actor_id=None`): A global view — `read`, `save`, and `list`
+  operations see all rows regardless of which actor wrote them. Used for
+  domain object storage (Cases, Activities, Actors, Reports) and for the
+  trigger service.
+- **Actor-scoped** (`actor_id="https://example.org/actors/alice"`): Filters
+  all reads and writes to rows belonging to that actor. **Required for
+  inbox and outbox queue operations.**
+
+Queue methods (`inbox_list`, `inbox_pop`, `inbox_append`, `outbox_list`,
+`outbox_pop`) use `self._actor_id` as the queue key. Calling these on a
+shared DataLayer (`_actor_id=None`) silently operates on a queue keyed by
+`""` — not any actor's real queue. Items will be written and read from a
+phantom queue, making the actor's real queue appear perpetually empty.
+
+See `specs/architecture.yaml` ARCH-13-001 through ARCH-13-002.
+
+### The Identity Contract — Canonical URI Must Match
+
+`record_outbox_item(actor_id, activity_id)` writes a queue row keyed by
+the string value of `actor_id`. Later, `outbox_list()` on an actor-scoped
+DataLayer looks for rows where the stored key equals `self._actor_id`
+exactly (plain string equality — no normalization). If the two strings
+differ in any way — including `"alice"` vs.
+`"https://example.org/actors/alice"` — the outbox appears empty and the
+outbound activity is silently dropped.
+
+**Rule**: The actor_id used to construct an `ActorScopedDataLayer` for
+queue reads MUST be the actor's canonical URI (`actor.id_`), and it must
+match exactly the string passed to `record_outbox_item` by the use case.
+Use `get_canonical_actor_dl()` in `deps.py` (which resolves the short-UUID
+path parameter to `actor.id_` before constructing the scoped DataLayer)
+rather than passing the raw path segment.
+
+This bug was fixed for trigger routes in BUG-2026040901. Any new trigger
+route or inbox handler that constructs an actor-scoped DataLayer manually
+MUST follow the same normalization pattern.
+
+See `specs/architecture.yaml` ARCH-13-003 through ARCH-13-004.
+
+### Future: ActorScopedDataLayer Protocol
+
+`ARCH-13-005` requires that `ActorScopedDataLayer` be defined as a formal
+Protocol type in `vultron/core/ports/datalayer.py` so that mypy and
+pyright can enforce the scope boundary at type-check time. Until that is
+implemented, the scope contract is enforced by convention and by the
+regression tests in `test/adapters/driven/test_datalayer_isolation.py`.

--- a/plan/history/2606/README.md
+++ b/plan/history/2606/README.md
@@ -4,6 +4,7 @@
 
 | Date | Time (UTC) | Type | Source | Title |
 |------|------------|------|--------|-------|
+| 2026-06-01 | 18:47 | learning | CONCERN-502 | Actor-scoped vs shared DataLayer scope boundaries |
 | 2026-06-01 | 18:33 | implementation | ISSUE-437 | Enforce spec vs. ADR delineation guidelines (MS-11) |
 | 2026-06-01 | 18:04 | implementation | ISSUE-584 | Rename linkchecker.yml to docs-build-check.yml with narrowed triggers |
 | 2026-06-01 | 18:01 | implementation | 412 | Fix _is_case_owner fail-open (issue #412) |

--- a/plan/history/2606/learning/CONCERN-502.md
+++ b/plan/history/2606/learning/CONCERN-502.md
@@ -1,0 +1,43 @@
+---
+source: CONCERN-502
+timestamp: '2026-06-01T18:47:07.493365+00:00'
+title: Actor-scoped vs shared DataLayer scope boundaries
+type: learning
+---
+
+## Concern #502 — Actor-scoped vs shared DataLayer scope boundaries are fragile and under-tested
+
+**Category**: Top risk
+**Severity**: High
+
+### Root Cause
+
+`SqliteDataLayer` serves two distinct roles — shared object storage and
+actor-scoped queue operations — conflated in a single `DataLayer` Protocol.
+Queue methods use `self._actor_id or ""` as the key, so calling them on a
+shared (unscoped) DL silently operates on a phantom `""` queue. The codebase
+has no type-level enforcement that prevents callers from passing a shared DL
+where an actor-scoped one is required.
+
+A second, related bug (BUG-2026040901): `record_outbox_item(actor_id, …)`
+writes a queue row keyed by the exact string passed as `actor_id`. If a
+short-UUID path param is used to write but the canonical URI is used to read
+(or vice versa), the queue appears empty and outbound activities are silently
+dropped. `get_canonical_actor_dl()` is the existing fix, but it has no
+dedicated unit tests.
+
+### Resolution
+
+- Added ARCH-13 spec group (ARCH-13-001 through ARCH-13-005) to
+  `specs/architecture.yaml` formalizing the shared-vs-actor-scoped contract
+  and the canonical URI identity rule.
+- Added §DataLayer Scope Boundaries to
+  `notes/architecture-ports-and-adapters.md` documenting the split, the
+  identity contract, and the planned `ActorScopedDataLayer` Protocol.
+- Added two pitfall entries to `vultron/adapters/AGENTS.md`.
+
+**Resolved**: 2025-07-16 — specs, notes, and AGENTS.md updated.
+Docs PR: [#657](https://github.com/CERTCC/Vultron/pull/657).
+Implementation tracked in [#655](https://github.com/CERTCC/Vultron/issues/655)
+(Protocol split, size:M) and [#656](https://github.com/CERTCC/Vultron/issues/656)
+(regression tests, size:S, blocked by #655).

--- a/specs/architecture.yaml
+++ b/specs/architecture.yaml
@@ -207,12 +207,14 @@ groups:
       inbox or outbox queue operations.
     rationale: >
       Inbox and outbox queue operations are actor-scoped; using the shared DataLayer
-      (actor_id=None) for queue reads silently returns an empty queue and discards items.
+      (actor_id=None) silently operates on a phantom queue keyed by the empty string
+      ("") rather than the actor's real queue, causing reads to appear empty and
+      writes to be unreadable by the correct actor.
   - id: ARCH-13-002
     priority: MUST
     statement: >
       Inbox and outbox queue operations (inbox_list, inbox_pop, inbox_append,
-      outbox_list, outbox_pop) MUST be performed on an `ActorScopedDataLayer`
+      outbox_list, outbox_pop, outbox_append) MUST be performed on an `ActorScopedDataLayer`
       instance — a DataLayer whose actor_id is set to a non-empty canonical URI.
     rationale: >
       Queue rows are stored with actor_id as a column key; an unscoped DataLayer

--- a/specs/architecture.yaml
+++ b/specs/architecture.yaml
@@ -196,3 +196,55 @@ groups:
   - id: ARCH-11-001
     priority: SHOULD
     statement: Core ports SHOULD be organized into inbound (driving) and outbound (driven) categories
+- id: ARCH-13
+  title: DataLayer Scope Contract
+  specs:
+  - id: ARCH-13-001
+    priority: MUST
+    statement: >
+      The base `DataLayer` protocol MUST be used only for shared object storage operations
+      (read, write, save, list). It MUST NOT be passed to functions that perform
+      inbox or outbox queue operations.
+    rationale: >
+      Inbox and outbox queue operations are actor-scoped; using the shared DataLayer
+      (actor_id=None) for queue reads silently returns an empty queue and discards items.
+  - id: ARCH-13-002
+    priority: MUST
+    statement: >
+      Inbox and outbox queue operations (inbox_list, inbox_pop, inbox_append,
+      outbox_list, outbox_pop) MUST be performed on an `ActorScopedDataLayer`
+      instance — a DataLayer whose actor_id is set to a non-empty canonical URI.
+    rationale: >
+      Queue rows are stored with actor_id as a column key; an unscoped DataLayer
+      (actor_id=None) cannot address per-actor queue rows correctly.
+  - id: ARCH-13-003
+    priority: MUST
+    statement: >
+      The actor_id used when constructing an `ActorScopedDataLayer` MUST be the
+      actor's canonical URI (the value of actor.id_), not a short ID, UUID
+      path segment, or any other derived identifier.
+    rationale: >
+      record_outbox_item writes queue rows keyed by the actor_id string it receives.
+      If outbox_list is called on a DataLayer scoped to a different string (e.g., a
+      short UUID when the writer used a full URI), the queue appears empty and
+      outbound activities are silently dropped (see BUG-2026040901).
+  - id: ARCH-13-004
+    priority: MUST
+    statement: >
+      The actor_id argument passed to record_outbox_item MUST match exactly the
+      actor_id used to construct the `ActorScopedDataLayer` that will later call
+      outbox_list or outbox_pop for that actor.
+    rationale: >
+      The queue key is a plain string equality check. Any mismatch — including
+      full-URI vs. short-UUID — produces a silent empty read.
+  - id: ARCH-13-005
+    priority: SHOULD
+    statement: >
+      The `ActorScopedDataLayer` protocol type SHOULD be defined in
+      `vultron/core/ports/datalayer.py` as a refinement of `DataLayer` so that
+      type-checkers (mypy, pyright) can enforce scope boundaries at
+      function-signature level.
+    rationale: >
+      An explicit Protocol type converts a convention-only rule into a
+      compile-time-enforced boundary, making violations visible without running
+      the code.

--- a/vultron/adapters/AGENTS.md
+++ b/vultron/adapters/AGENTS.md
@@ -60,9 +60,10 @@ for:
 - ASGIEmitter Path Construction: Use Scheme+Netloc Only as `httpx` Base URL
 - `create_app()` MUST NOT Mutate Module-Level Singletons
 - **DataLayer Scope Boundaries: Shared vs. Actor-Scoped** — queue methods
-  (`inbox_list`, `inbox_pop`, `outbox_list`, `outbox_pop`) MUST use an
-  actor-scoped DataLayer, not the shared one. An unscoped DL silently
-  operates on the wrong (empty) queue.
+  (`inbox_list`, `inbox_pop`, `inbox_append`, `outbox_list`, `outbox_pop`,
+  `outbox_append`) MUST use an actor-scoped DataLayer, not the shared one.
+  An unscoped DL (`actor_id=None`) silently operates on a phantom queue
+  keyed by `""` — not any actor's real queue.
 - **DataLayer Identity Contract: Canonical URI Must Match** — the actor_id
   used to construct an actor-scoped DataLayer for queue reads MUST be the
   actor's canonical URI (`actor.id_`), and MUST exactly match the string

--- a/vultron/adapters/AGENTS.md
+++ b/vultron/adapters/AGENTS.md
@@ -59,6 +59,17 @@ for:
   Startup
 - ASGIEmitter Path Construction: Use Scheme+Netloc Only as `httpx` Base URL
 - `create_app()` MUST NOT Mutate Module-Level Singletons
+- **DataLayer Scope Boundaries: Shared vs. Actor-Scoped** — queue methods
+  (`inbox_list`, `inbox_pop`, `outbox_list`, `outbox_pop`) MUST use an
+  actor-scoped DataLayer, not the shared one. An unscoped DL silently
+  operates on the wrong (empty) queue.
+- **DataLayer Identity Contract: Canonical URI Must Match** — the actor_id
+  used to construct an actor-scoped DataLayer for queue reads MUST be the
+  actor's canonical URI (`actor.id_`), and MUST exactly match the string
+  passed to `record_outbox_item` by the use case. Use
+  `get_canonical_actor_dl()` from `deps.py`; do NOT pass the raw URL path
+  segment. Violating this causes outbound activities to be silently dropped
+  (BUG-2026040901).
 
 See [notes/codebase-structure.md](../../notes/codebase-structure.md) for:
 


### PR DESCRIPTION
## Summary

Ingests concern #502 (Actor-scoped vs shared DataLayer scope boundaries are
fragile and under-tested) into formal specs and design notes.

## Changes

- **`specs/architecture.yaml`** — New ARCH-13 spec group (5 requirements)
  formalizing the shared-vs-actor-scoped DataLayer contract:
  - ARCH-13-001: Shared DL MUST NOT be used for queue operations
  - ARCH-13-002: Queue operations require `ActorScopedDataLayer`
  - ARCH-13-003: `actor_id` used for queue keys MUST be the canonical URI
  - ARCH-13-004: `record_outbox_item` key MUST match scoped DL's actor_id
  - ARCH-13-005: `ActorScopedDataLayer` SHOULD be a Protocol type in
    `vultron/core/ports/datalayer.py`

- **`notes/architecture-ports-and-adapters.md`** — New §DataLayer Scope
  Boundaries section documenting the shared/scoped split, the identity
  contract (BUG-2026040901), and the planned `ActorScopedDataLayer` Protocol.

- **`vultron/adapters/AGENTS.md`** — Two new pitfall entries pointing agents
  at the notes section for scope and identity contract rules.

## Implementation Issues

- #655: Introduce `ActorScopedDataLayer` Protocol (size:M, unblocked)
- #656: Add regression tests for scope contract (size:S, blocked by #655)

## Related

Closes #502
Part of Epic #539 (Architecture Hardening)