### PR TITLE
fix(#659): use append-order for CaseParticipant.participant_status (+ NullPool/WAL hardening)

### DIFF
--- a/plan/history/2606/README.md
+++ b/plan/history/2606/README.md
@@ -4,6 +4,7 @@
 
 | Date | Time (UTC) | Type | Source | Title |
 |------|------------|------|--------|-------|
+| 2026-06-01 | 19:11 | implementation | 659-vfd-timeout-increase | fix: increase wait_for_participant_vfd_state timeout to 30 s (#659) |
 | 2026-06-01 | 18:47 | learning | CONCERN-502 | Actor-scoped vs shared DataLayer scope boundaries |
 | 2026-06-01 | 18:33 | implementation | ISSUE-437 | Enforce spec vs. ADR delineation guidelines (MS-11) |
 | 2026-06-01 | 18:04 | implementation | ISSUE-584 | Rename linkchecker.yml to docs-build-check.yml with narrowed triggers |

--- a/plan/history/2606/README.md
+++ b/plan/history/2606/README.md
@@ -4,6 +4,7 @@
 
 | Date | Time (UTC) | Type | Source | Title |
 |------|------------|------|--------|-------|
+| 2026-06-02 | 16:38 | implementation | BUG-659-FIX2 | Bug #659 follow-up — participant_status append-order fix |
 | 2026-06-02 | 15:22 | implementation | BUG-659 | BUG-659 — Fix SQLite read-after-write staleness causing M4 timeout |
 | 2026-06-01 | 19:11 | implementation | 659-vfd-timeout-increase | fix: increase wait_for_participant_vfd_state timeout to 30 s (#659) |
 | 2026-06-01 | 18:47 | learning | CONCERN-502 | Actor-scoped vs shared DataLayer scope boundaries |

--- a/plan/history/2606/README.md
+++ b/plan/history/2606/README.md
@@ -4,6 +4,7 @@
 
 | Date | Time (UTC) | Type | Source | Title |
 |------|------------|------|--------|-------|
+| 2026-06-02 | 15:22 | implementation | BUG-659 | BUG-659 — Fix SQLite read-after-write staleness causing M4 timeout |
 | 2026-06-01 | 19:11 | implementation | 659-vfd-timeout-increase | fix: increase wait_for_participant_vfd_state timeout to 30 s (#659) |
 | 2026-06-01 | 18:47 | learning | CONCERN-502 | Actor-scoped vs shared DataLayer scope boundaries |
 | 2026-06-01 | 18:33 | implementation | ISSUE-437 | Enforce spec vs. ADR delineation guidelines (MS-11) |

--- a/plan/history/2606/implementation/659-vfd-timeout-increase.md
+++ b/plan/history/2606/implementation/659-vfd-timeout-increase.md
@@ -1,0 +1,8 @@
+---
+source: 659-vfd-timeout-increase
+timestamp: '2026-06-01T19:11:41.913314+00:00'
+title: 'fix: increase wait_for_participant_vfd_state timeout to 30 s (#659)'
+type: implementation
+---
+
+fix: increase wait_for_participant_vfd_state timeout to 30 s to accommodate cross-container async delivery pipeline latency under CI load. Also add DEBUG diagnostic log before AssertionError.

--- a/plan/history/2606/implementation/BUG-659-FIX2.md
+++ b/plan/history/2606/implementation/BUG-659-FIX2.md
@@ -1,0 +1,58 @@
+---
+source: BUG-659-FIX2
+timestamp: '2026-06-02T16:38:58.835298+00:00'
+title: 'Bug #659 follow-up — participant_status append-order fix'
+type: implementation
+---
+
+## Context
+
+Follow-up to the initial BUG-659.md entry. The NullPool + WAL adapter
+hardening (commit aafaa868) was necessary but did not eliminate the
+M4 timeout. Diagnostic logging added in commit 7e3fc52b localised the
+real root cause to the wire-layer `CaseParticipant.participant_status`
+property.
+
+## Symptoms
+
+`vultron-demo two-actor` flaked in CI: M4
+(`wait_for_participant_vfd_state`) timed out waiting for the vendor's
+vfd_state to reach `VFd` on the finder replica, even though
+adapter-side diagnostic logs confirmed the `VFd` ParticipantStatus
+was correctly persisted and read back from SQLite on every poll.
+
+## Root cause
+
+`CaseParticipant.participant_status` selected the "current" status by
+`max(participant_statuses, key=(updated or published, index))`. The
+`init_participant_status_if_empty` model validator constructs the
+initial vfd locally with `published=now_utc()` *at construction time*.
+When the M3 `Add(VFd)` activity arrived and the BT appended a new
+`ParticipantStatus`, that status carried sender-authored timestamps
+that could be *earlier* than the finder's local default on the initial
+entry (any clock skew or processing gap is enough). The tiebreaker
+then selected index-0 initial vfd despite a freshly appended VFd at
+index 1.
+
+## Fix
+
+Return `self.participant_statuses[-1]` from the property. Append order
+IS this replica's authoritative chronology; it is robust to sender
+clock skew and matches what `VultronParticipant` already does in the
+core layer.
+
+## Validation
+
+- Local repro via `jsonable_encoder` round-trip demonstrated the bug
+  deterministically and confirmed the fix.
+- New unit tests in `test/wire/as2/vocab/test_case_participant.py`
+  (`TestParticipantStatusProperty`): 3 tests, first one fails on old
+  property, all pass with the fix.
+- Full pytest suite: 2725 passed, 12 skipped, 3 xfailed.
+- Kept diagnostic DEBUG logs in `datalayer_sqlite.py` and
+  `wait_for_participant_vfd_state` — cheap insurance for next time.
+
+## Related
+
+- #663 (`BroadcastStatusToPeersNode` self-loop) still open and out of
+  scope here.

--- a/plan/history/2606/implementation/BUG-659.md
+++ b/plan/history/2606/implementation/BUG-659.md
@@ -1,0 +1,57 @@
+---
+source: BUG-659
+timestamp: '2026-06-02T15:22:31.481660+00:00'
+title: BUG-659 — Fix SQLite read-after-write staleness causing M4 timeout
+type: implementation
+---
+
+## Summary
+
+Fixed root cause of intermittent CI timeout in
+`_phase_fix_lifecycle` / `wait_for_participant_vfd_state` (#659). The
+previous fix (PR #660, commit 364a8de3) bumped the polling timeout from
+10 s to 30 s; CI run 26776168609 confirmed the 30 s timeout still
+expired, ruling out a pure timing issue.
+
+## Root cause
+
+`SqliteDataLayer._make_engine` used SQLAlchemy's default pool for
+file-backed SQLite (`SingletonThreadPool`), which reuses a single
+DB-API connection per thread. In the FastAPI driving adapter, a
+`BackgroundTask` (BT save of a `CaseParticipant`) and a concurrent GET
+handler can end up sharing the same connection. Combined with SQLite's
+default journaling, a transaction started before a commit can fail to
+observe the committed writes — producing read-after-write staleness for
+arbitrarily long under CI load, which is exactly what M4 saw.
+
+## Fix
+
+In `vultron/adapters/driven/datalayer_sqlite.py::_make_engine`:
+
+- File-backed SQLite now uses `NullPool` (fresh connection per
+  `Session`), removing connection-reuse visibility issues.
+- A `connect` event listener enables `PRAGMA journal_mode=WAL` and
+  `PRAGMA synchronous=NORMAL` on every new connection so committed
+  writes are immediately visible to subsequent readers.
+- In-memory SQLite continues to use `StaticPool` (required so the
+  single ephemeral DB is shared across sessions).
+
+In `vultron/demo/helpers/polling.py`:
+
+- Reverted `wait_for_participant_vfd_state` default `timeout_seconds`
+  from 30 s back to 10 s, and removed the rationale paragraph in the
+  docstring since the underlying issue is fixed at the adapter layer.
+
+## Spinoffs
+
+Filed #663 — separate `BroadcastStatusToPeersNode` self-loop
+correctness bug noticed during investigation (finder re-broadcasts
+ParticipantStatus to itself). Out of scope for this PR.
+
+## Verification
+
+- All linters pass (black, flake8, mypy, pyright).
+- Full pytest suite including `-m ""` integration tests: 2722 passed,
+  12 skipped, 3 xfailed, 5633 subtests passed in 46.22 s.
+- Authoritative verification remains the CI Demo Integration job on the
+  PR — re-run after merge of this commit.

--- a/test/wire/as2/vocab/test_case_participant.py
+++ b/test/wire/as2/vocab/test_case_participant.py
@@ -203,5 +203,89 @@ class TestCaseParticipantNameField(unittest.TestCase):
         assert "must be a non-empty string" in str(exc_info.value)
 
 
+class TestParticipantStatusProperty(unittest.TestCase):
+    """Tests for CaseParticipant.participant_status selection (bug #659).
+
+    The property must return the most recently *appended* status, which
+    represents this replica's current view. Wire-layer timestamps
+    (``published``/``updated``) on appended statuses are sender-authored
+    and cannot be relied on to order strictly after locally-constructed
+    defaults (e.g. the initial vfd status auto-created by
+    ``init_participant_status_if_empty``).
+    """
+
+    def setUp(self):
+        from datetime import datetime, timezone
+
+        from vultron.core.states.cs import CS_vfd
+        from vultron.core.states.rm import RM
+        from vultron.wire.as2.vocab.objects.case_status import (
+            ParticipantStatus,
+        )
+
+        self.CS_vfd = CS_vfd
+        self.RM = RM
+        self.ParticipantStatus = ParticipantStatus
+        self.dt = datetime
+        self.tz = timezone
+        self.actor_id = "https://example.org/actors/vendor"
+        self.case_id = "https://example.org/cases/case-001"
+
+    def test_returns_last_appended_even_when_earlier_status_has_newer_timestamp(
+        self,
+    ):
+        """Bug #659: tiebreaker must prefer append-order over timestamp.
+
+        Initial vfd status is created locally with ``published=now()``.
+        A subsequently appended VFd status carries a sender-supplied
+        ``published`` that may be *earlier* than the local initial value
+        (clock skew, batched processing, etc.). The property must still
+        return the appended VFd entry.
+        """
+        appended = self.ParticipantStatus(
+            context=self.case_id,
+            attributed_to=self.actor_id,
+            rm_state=self.RM.ACCEPTED,
+            vfd_state=self.CS_vfd.VFd,
+            published=self.dt(2026, 6, 2, 16, 26, 48, tzinfo=self.tz.utc),
+            updated=self.dt(2026, 6, 2, 16, 26, 48, tzinfo=self.tz.utc),
+        )
+        # Construct participant with empty list so the validator creates
+        # the initial vfd with published=now() (which will be > appended's).
+        participant = CaseParticipant(
+            attributed_to=self.actor_id, context=self.case_id
+        )
+        self.assertEqual(1, len(participant.participant_statuses))
+        participant.participant_statuses.append(appended)
+
+        latest = participant.participant_status
+        self.assertIsNotNone(latest)
+        assert latest is not None  # narrow for type checker
+        self.assertEqual(self.CS_vfd.VFd, latest.vfd_state)
+        self.assertEqual(self.RM.ACCEPTED, latest.rm_state)
+
+    def test_returns_none_when_empty(self):
+        """participant_status returns None when the list is empty."""
+        participant = CaseParticipant(
+            attributed_to=self.actor_id, context=self.case_id
+        )
+        # init_participant_status_if_empty populates one status by default;
+        # explicitly clear to exercise the empty branch.
+        participant.participant_statuses = []
+        self.assertIsNone(participant.participant_status)
+
+    def test_returns_single_status_when_only_one_present(self):
+        only = self.ParticipantStatus(
+            context=self.case_id,
+            attributed_to=self.actor_id,
+        )
+        participant = CaseParticipant(
+            attributed_to=self.actor_id,
+            context=self.case_id,
+            participant_statuses=[only],
+        )
+        self.assertIs(only, participant.participant_status)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/vultron/adapters/driven/datalayer_sqlite.py
+++ b/vultron/adapters/driven/datalayer_sqlite.py
@@ -104,16 +104,19 @@ def _participant_status_summary(data: Any) -> str:
         return ""
     if not statuses:
         return "n_statuses=0"
-    last = statuses[-1]
-    if not isinstance(last, dict):
-        return f"n_statuses={len(statuses)}"
-    return (
-        f"n_statuses={len(statuses)} "
-        f"last_vfd={last.get('vfd_state') or last.get('vfdState')!r} "
-        f"last_rm={last.get('rm_state') or last.get('rmState')!r} "
-        f"last_pub={last.get('published')!r} "
-        f"last_upd={last.get('updated')!r}"
-    )
+    entries = []
+    for i, s in enumerate(statuses):
+        if isinstance(s, dict):
+            vfd = s.get("vfd_state") or s.get("vfdState")
+            rm = s.get("rm_state") or s.get("rmState")
+            pub = s.get("published")
+            upd = s.get("updated")
+            entries.append(
+                f"[{i}]vfd={vfd!r},rm={rm!r},pub={pub!r},upd={upd!r}"
+            )
+        else:
+            entries.append(f"[{i}]<{type(s).__name__}>")
+    return f"n_statuses={len(statuses)} " + " ".join(entries)
 
 
 def _json_default(obj: Any) -> Any:

--- a/vultron/adapters/driven/datalayer_sqlite.py
+++ b/vultron/adapters/driven/datalayer_sqlite.py
@@ -32,9 +32,9 @@ from datetime import date, datetime
 from typing import Any, cast
 
 from pydantic import ValidationError
-from sqlalchemy import Column, Engine, func
+from sqlalchemy import Column, Engine, event, func
 from sqlalchemy.dialects.sqlite import JSON
-from sqlalchemy.pool import StaticPool
+from sqlalchemy.pool import NullPool, StaticPool
 from sqlmodel import Field, Session, SQLModel, col, create_engine, select
 
 from vultron.adapters.driven.db_record import (
@@ -106,6 +106,14 @@ def _make_engine(db_url: str) -> Engine:
 
     For in-memory databases uses ``StaticPool`` so every connection
     shares the same in-memory database instead of creating a fresh one.
+    For file-backed SQLite uses ``NullPool`` (one fresh connection per
+    ``Session``) and enables WAL mode so that concurrent readers always
+    observe the most recently committed writes. Together these prevent
+    read-after-write staleness in the asyncio + ``BackgroundTasks`` +
+    SQLite combination used by the FastAPI driving adapter, which
+    otherwise can return stale rows for tens of seconds under CI load
+    (see issue #659).
+
     A custom ``json_serializer`` ensures that ``datetime`` values stored in
     JSON columns are serialised as ISO-8601 strings instead of raising
     ``TypeError``.
@@ -120,9 +128,29 @@ def _make_engine(db_url: str) -> Engine:
         "connect_args": {"check_same_thread": False},
         "json_serializer": _json_serializer,
     }
-    if db_url == "sqlite:///:memory:":
+    is_memory = db_url == "sqlite:///:memory:"
+    if is_memory:
         kwargs["poolclass"] = StaticPool
-    return create_engine(db_url, **kwargs)
+    else:
+        # NullPool gives a fresh DB-API connection per Session. This avoids
+        # the SingletonThreadPool default in which a BackgroundTask and a
+        # concurrent GET handler can share one SQLite connection and observe
+        # stale data across transactions.
+        kwargs["poolclass"] = NullPool
+    engine = create_engine(db_url, **kwargs)
+    if not is_memory:
+        # Enable WAL + NORMAL synchronous on every new connection so that
+        # committed writes are immediately visible to subsequent readers.
+        @event.listens_for(engine, "connect")
+        def _set_sqlite_pragmas(dbapi_connection: Any, _record: Any) -> None:
+            cursor = dbapi_connection.cursor()
+            try:
+                cursor.execute("PRAGMA journal_mode=WAL")
+                cursor.execute("PRAGMA synchronous=NORMAL")
+            finally:
+                cursor.close()
+
+    return engine
 
 
 class SqliteDataLayer:

--- a/vultron/adapters/driven/datalayer_sqlite.py
+++ b/vultron/adapters/driven/datalayer_sqlite.py
@@ -87,6 +87,35 @@ class QueueEntry(SQLModel, table=True):
     activity_id: str
 
 
+def _participant_status_summary(data: Any) -> str:
+    """Return a short debug summary of a CaseParticipant row's status list.
+
+    Used by adapter logging on read/save to make read-after-write
+    visibility issues directly diagnosable from container logs without
+    dumping full JSON. Returns ``""`` (empty string) for non-participant
+    rows or malformed data so callers can branch cheaply.
+    """
+    if not isinstance(data, dict):
+        return ""
+    statuses = data.get("participant_statuses") or data.get(
+        "participantStatuses"
+    )
+    if not isinstance(statuses, list):
+        return ""
+    if not statuses:
+        return "n_statuses=0"
+    last = statuses[-1]
+    if not isinstance(last, dict):
+        return f"n_statuses={len(statuses)}"
+    return (
+        f"n_statuses={len(statuses)} "
+        f"last_vfd={last.get('vfd_state') or last.get('vfdState')!r} "
+        f"last_rm={last.get('rm_state') or last.get('rmState')!r} "
+        f"last_pub={last.get('published')!r} "
+        f"last_upd={last.get('updated')!r}"
+    )
+
+
 def _json_default(obj: Any) -> Any:
     """JSON encoder fallback that serializes ``datetime`` / ``date`` objects."""
     if isinstance(obj, (datetime, date)):
@@ -484,6 +513,16 @@ class SqliteDataLayer:
                 )
                 row = session.exec(stmt).first()
                 if row is not None:
+                    if row.type_ == "CaseParticipant":
+                        summary = _participant_status_summary(row.data)
+                        logger.debug(
+                            "DataLayer read CaseParticipant '%s' (row "
+                            "actor_id=%r dl_actor_id=%r): %s",
+                            row.id_,
+                            row.actor_id,
+                            self._actor_id,
+                            summary,
+                        )
                     obj = self._from_row(row)
                     if obj is not None:
                         return obj
@@ -609,6 +648,13 @@ class SqliteDataLayer:
             session.add(row)
             session.commit()
         logger.info("DataLayer saved %s '%s'", rec.type_, rec.id_)
+        if rec.type_ == "CaseParticipant":
+            logger.debug(
+                "DataLayer saved CaseParticipant '%s' (dl_actor_id=%r): %s",
+                rec.id_,
+                self._actor_id,
+                _participant_status_summary(rec.data_),
+            )
 
     def delete(self, table: str, id_: str) -> bool:
         """Delete a record by type and ID.

--- a/vultron/demo/helpers/polling.py
+++ b/vultron/demo/helpers/polling.py
@@ -274,24 +274,18 @@ def wait_for_participant_vfd_state(
     case_id: str,
     actor_id: str,
     expected_states: "set",
-    timeout_seconds: float = 30.0,
+    timeout_seconds: float = 10.0,
     poll_interval: float = 0.25,
 ) -> None:
     """Poll until *actor_id*'s latest participant ``vfd_state`` is in
     *expected_states*.
-
-    The default timeout is 30 s to accommodate cross-container propagation
-    latency: after a trigger fires the outbox monitor delivers the activity
-    asynchronously (up to ~1 s polling lag), then the receiving container
-    processes its inbox and persists the updated participant status.  10 s was
-    too tight under CI load.
 
     Args:
         client: DataLayerClient for the target container.
         case_id: Full URI of the ``VulnerabilityCase``.
         actor_id: Full URI of the actor to check.
         expected_states: Set of ``CS_vfd`` values that satisfy the condition.
-        timeout_seconds: Maximum time to wait (default: 30 s).
+        timeout_seconds: Maximum time to wait (default: 10 s).
         poll_interval: Seconds between DataLayer poll attempts.
 
     Raises:

--- a/vultron/demo/helpers/polling.py
+++ b/vultron/demo/helpers/polling.py
@@ -297,12 +297,38 @@ def wait_for_participant_vfd_state(
     )
 
     deadline = time.monotonic() + timeout_seconds
+    poll_count = 0
     while time.monotonic() < deadline:
+        poll_count += 1
         participant = _fetch_participant(client, case_id, actor_id)
         if participant is not None:
             latest = participant.participant_status
+            n_statuses = len(participant.participant_statuses or [])
+            latest_vfd = latest.vfd_state if latest is not None else None
+            latest_rm = latest.rm_state if latest is not None else None
+            logger.debug(
+                "wait_for_participant_vfd_state poll #%d: "
+                "actor=%r case=%r participant=%r "
+                "n_statuses=%d latest_vfd=%r latest_rm=%r expected=%r",
+                poll_count,
+                actor_id,
+                case_id,
+                participant.id_,
+                n_statuses,
+                latest_vfd,
+                latest_rm,
+                expected_states,
+            )
             if latest is not None and latest.vfd_state in expected_states:
                 return
+        else:
+            logger.debug(
+                "wait_for_participant_vfd_state poll #%d: "
+                "actor=%r case=%r participant=<not found>",
+                poll_count,
+                actor_id,
+                case_id,
+            )
         time.sleep(poll_interval)
 
     participant = _fetch_participant(client, case_id, actor_id)

--- a/vultron/demo/helpers/polling.py
+++ b/vultron/demo/helpers/polling.py
@@ -274,18 +274,24 @@ def wait_for_participant_vfd_state(
     case_id: str,
     actor_id: str,
     expected_states: "set",
-    timeout_seconds: float = 10.0,
+    timeout_seconds: float = 30.0,
     poll_interval: float = 0.25,
 ) -> None:
     """Poll until *actor_id*'s latest participant ``vfd_state`` is in
     *expected_states*.
+
+    The default timeout is 30 s to accommodate cross-container propagation
+    latency: after a trigger fires the outbox monitor delivers the activity
+    asynchronously (up to ~1 s polling lag), then the receiving container
+    processes its inbox and persists the updated participant status.  10 s was
+    too tight under CI load.
 
     Args:
         client: DataLayerClient for the target container.
         case_id: Full URI of the ``VulnerabilityCase``.
         actor_id: Full URI of the actor to check.
         expected_states: Set of ``CS_vfd`` values that satisfy the condition.
-        timeout_seconds: Maximum time to wait.
+        timeout_seconds: Maximum time to wait (default: 30 s).
         poll_interval: Seconds between DataLayer poll attempts.
 
     Raises:
@@ -310,6 +316,17 @@ def wait_for_participant_vfd_state(
         participant.participant_status if participant is not None else None
     )
     current = latest.vfd_state if latest is not None else "unknown"
+    rm_state = latest.rm_state if latest is not None else "unknown"
+    logger.debug(
+        "wait_for_participant_vfd_state timed out after %.1f s: "
+        "actor=%r case=%r vfd_state=%r rm_state=%r expected=%r",
+        timeout_seconds,
+        actor_id,
+        case_id,
+        current,
+        rm_state,
+        expected_states,
+    )
     raise AssertionError(
         f"Timed out waiting for actor '{actor_id}' vfd_state to be in "
         f"{expected_states!r}; current={current!r}"

--- a/vultron/wire/as2/vocab/objects/case_participant.py
+++ b/vultron/wire/as2/vocab/objects/case_participant.py
@@ -19,7 +19,6 @@ Provides various CaseParticipant objects for the Vultron ActivityStreams Vocabul
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
 from typing import TypeAlias, cast
 
 from pydantic import Field, field_serializer, field_validator, model_validator
@@ -37,8 +36,6 @@ from vultron.wire.as2.vocab.objects.base import (
 from vultron.wire.as2.vocab.objects.case_status import ParticipantStatus
 
 logger = logging.getLogger(__name__)
-
-_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
 
 
 class CaseParticipant(VultronAS2Object):
@@ -130,22 +127,24 @@ class CaseParticipant(VultronAS2Object):
 
     @property
     def participant_status(self) -> ParticipantStatus | None:
-        """Return the most recent ParticipantStatus (read-only; see participant_statuses for history).
+        """Return the most recently appended ParticipantStatus.
 
-        Selection is by descending timestamp (``updated`` then ``published``),
-        with list-index as a tiebreaker so that same-second entries resolve to
-        the last-appended element. This is robust even if ``now_utc()``
-        truncates sub-second precision.
+        The list represents this replica's append-only history of status
+        observations. Append order is the authoritative local chronology.
+
+        Earlier implementations used timestamp ordering with a list-index
+        tiebreaker, but wire-layer timestamps on appended statuses are
+        sender-authored and may be *earlier* than locally-constructed
+        defaults (e.g. the initial vfd auto-created by
+        ``init_participant_status_if_empty`` gets ``published=now()`` on
+        construction). That caused the property to return the stale
+        initial entry even after a newer status was appended (bug #659).
+        Using ``[-1]`` matches ``VultronParticipant.rm_state`` in the
+        core layer and is robust to clock skew and timestamp gaps.
         """
         if not self.participant_statuses:
             return None
-        return max(
-            enumerate(self.participant_statuses),
-            key=lambda i_ps: (
-                i_ps[1].updated or i_ps[1].published or _EPOCH,
-                i_ps[0],
-            ),
-        )[1]
+        return self.participant_statuses[-1]
 
     def append_rm_state(self, rm_state: RM, actor: str, context: str) -> bool:
         """Append a new ParticipantStatus with the given RM state.


### PR DESCRIPTION
Fixes #659

## Root cause

`CaseParticipant.participant_status` selected the "current" status via
`max(participant_statuses, key=(updated or published, index))`. The
`init_participant_status_if_empty` validator constructs the initial vfd
with `published=now_utc()` *at local construction time*. When the BT
later appended a sender-authored `ParticipantStatus` (e.g. vendor's VFd
from an M3 `Add` activity), that wire timestamp could be *earlier* than
the finder's local default on the initial entry. The tiebreaker then
selected the stale index-0 initial vfd despite a newer append at index 1.

Result: M4 (`wait_for_participant_vfd_state`) timed out polling for
`VFd` even though the adapter correctly persisted and returned both
statuses.

## Fix

Return `self.participant_statuses[-1]` from the property. Append order
is this replica's authoritative chronology, robust to sender clock skew,
and aligns wire with core (`VultronParticipant` already uses `[-1]`).

## Also in this PR

- **NullPool + WAL** for file-backed SQLite in
  `vultron/adapters/driven/datalayer_sqlite.py` (necessary hardening
  against read-after-write staleness on shared file-backed engines, even
  though it wasn't the root cause of #659).
- **Diagnostic DEBUG logs** in `datalayer_sqlite.py`
  (`_participant_status_summary` on every `read`/`save` of a
  CaseParticipant) and `wait_for_participant_vfd_state` (per-poll
  observed state). Kept in tree — cheap, useful for future demo
  flakiness.
- M4 polling default reverted to 10s.

## Validation

- New unit tests in `TestParticipantStatusProperty` (3 tests; first
  fails on old property, all pass on new).
- Full pytest suite: 2725 passed, 12 skipped, 3 xfailed.
- **Demo Integration CI: 4 consecutive runs passed** on `b80c0587`
  (compared with 3 consecutive failures on the prior diagnostic commit).

## Related

- #663 (`BroadcastStatusToPeersNode` self-loop) — separate concern,
  filed during this investigation, out of scope here.