### PR TITLE
Migrate demo HTTP helpers from requests to httpx

### DIFF
--- a/plan/history/2606/README.md
+++ b/plan/history/2606/README.md
@@ -4,7 +4,6 @@
 
 | Date | Time (UTC) | Type | Source | Title |
 |------|------------|------|--------|-------|
-
 | 2026-06-02 | 16:38 | implementation | BUG-659-FIX2 | Bug #659 follow-up — participant_status append-order fix |
 | 2026-06-02 | 15:22 | implementation | BUG-659 | BUG-659 — Fix SQLite read-after-write staleness causing M4 timeout |
 | 2026-06-02 | 13:41 | implementation | ISSUE-517 | Issue #517 migrate demo HTTP calls from requests to httpx |

--- a/plan/history/2606/README.md
+++ b/plan/history/2606/README.md
@@ -4,8 +4,10 @@
 
 | Date | Time (UTC) | Type | Source | Title |
 |------|------------|------|--------|-------|
+
 | 2026-06-02 | 16:38 | implementation | BUG-659-FIX2 | Bug #659 follow-up — participant_status append-order fix |
 | 2026-06-02 | 15:22 | implementation | BUG-659 | BUG-659 — Fix SQLite read-after-write staleness causing M4 timeout |
+| 2026-06-02 | 13:41 | implementation | ISSUE-517 | Issue #517 migrate demo HTTP calls from requests to httpx |
 | 2026-06-01 | 19:11 | implementation | 659-vfd-timeout-increase | fix: increase wait_for_participant_vfd_state timeout to 30 s (#659) |
 | 2026-06-01 | 18:47 | learning | CONCERN-502 | Actor-scoped vs shared DataLayer scope boundaries |
 | 2026-06-01 | 18:33 | implementation | ISSUE-437 | Enforce spec vs. ADR delineation guidelines (MS-11) |

--- a/plan/history/2606/implementation/ISSUE-517.md
+++ b/plan/history/2606/implementation/ISSUE-517.md
@@ -1,0 +1,28 @@
+---
+source: ISSUE-517
+timestamp: '2026-06-02T13:41:45.543479+00:00'
+title: 'Issue #517 migrate demo HTTP calls from requests to httpx'
+type: implementation
+---
+
+## Summary
+
+Replaced demo-layer HTTP usage from requests to httpx for runtime code and aligned demo health-check tests with the new transport calls.
+
+## Changes
+
+- Switched `vultron/demo/utils.py` DataLayerClient and server availability helpers from requests APIs to httpx APIs.
+- Updated `vultron/demo/helpers/verification.py` to catch `httpx.HTTPStatusError`.
+- Updated demo logging config references from `requests` logger to `httpx` logger in exchange/scenario demo scripts.
+- Migrated `test/demo/test_health_check_retry.py` mocks and exception types from requests to httpx.
+
+## Validation
+
+- Ran black and flake8 successfully.
+- Ran mypy and pyright successfully.
+- Ran full pytest including integration tests successfully (`2722 passed, 12 skipped, 3 xfailed`).
+
+## Links
+
+- Issue: <https://github.com/CERTCC/Vultron/issues/517>
+- PR: <https://github.com/CERTCC/Vultron/pull/661>

--- a/test/demo/test_health_check_retry.py
+++ b/test/demo/test_health_check_retry.py
@@ -13,7 +13,7 @@ to be ready before proceeding.
 import logging
 from unittest.mock import Mock, patch
 
-import requests  # type: ignore[import-untyped]
+import httpx
 
 from vultron.demo.exchange.receive_report_demo import (
     DataLayerClient,
@@ -27,9 +27,9 @@ def test_check_server_availability_succeeds_immediately():
 
     mock_response = Mock()
     mock_response.status_code = 200
-    mock_response.ok = True
+    mock_response.is_success = True
 
-    with patch("requests.get", return_value=mock_response):
+    with patch("httpx.get", return_value=mock_response):
         result = check_server_availability(
             client, max_retries=1, retry_delay=0.1
         )
@@ -42,8 +42,8 @@ def test_check_server_availability_fails_permanently():
     client = DataLayerClient(base_url="http://test:7999/api/v2")
 
     with patch(
-        "requests.get",
-        side_effect=requests.exceptions.ConnectionError("Connection refused"),
+        "httpx.get",
+        side_effect=httpx.ConnectError("Connection refused"),
     ):
         result = check_server_availability(
             client, max_retries=2, retry_delay=0.1
@@ -59,15 +59,15 @@ def test_check_server_availability_succeeds_after_retry():
     # First 2 calls fail, third succeeds
     mock_response = Mock()
     mock_response.status_code = 200
-    mock_response.ok = True
+    mock_response.is_success = True
 
     side_effects = [
-        requests.exceptions.ConnectionError("Connection refused"),
-        requests.exceptions.ConnectionError("Connection refused"),
+        httpx.ConnectError("Connection refused"),
+        httpx.ConnectError("Connection refused"),
         mock_response,
     ]
 
-    with patch("requests.get", side_effect=side_effects):
+    with patch("httpx.get", side_effect=side_effects):
         result = check_server_availability(
             client, max_retries=3, retry_delay=0.1
         )
@@ -81,15 +81,15 @@ def test_check_server_availability_logs_retry_attempts(caplog):
 
     mock_response = Mock()
     mock_response.status_code = 200
-    mock_response.ok = True
+    mock_response.is_success = True
 
     side_effects = [
-        requests.exceptions.ConnectionError("Connection refused"),
+        httpx.ConnectError("Connection refused"),
         mock_response,
     ]
 
     with caplog.at_level(logging.DEBUG):
-        with patch("requests.get", side_effect=side_effects):
+        with patch("httpx.get", side_effect=side_effects):
             result = check_server_availability(
                 client, max_retries=3, retry_delay=0.1
             )
@@ -112,9 +112,9 @@ def test_check_server_availability_respects_max_retries():
     def side_effect(*args, **kwargs):
         nonlocal call_count
         call_count += 1
-        raise requests.exceptions.ConnectionError("Connection refused")
+        raise httpx.ConnectError("Connection refused")
 
-    with patch("requests.get", side_effect=side_effect):
+    with patch("httpx.get", side_effect=side_effect):
         result = check_server_availability(
             client, max_retries=3, retry_delay=0.1
         )

--- a/vultron/demo/exchange/acknowledge_demo.py
+++ b/vultron/demo/exchange/acknowledge_demo.py
@@ -422,7 +422,7 @@ def main(
 
 def _setup_logging():
     """Configure console logging for standalone script execution."""
-    logging.getLogger("requests").setLevel(logging.WARNING)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
     _logger = logging.getLogger()
     hdlr = logging.StreamHandler(sys.stdout)
     formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")

--- a/vultron/demo/exchange/establish_embargo_demo.py
+++ b/vultron/demo/exchange/establish_embargo_demo.py
@@ -454,7 +454,7 @@ def main(
 
 def _setup_logging():
     """Configure console logging for standalone script execution."""
-    logging.getLogger("requests").setLevel(logging.WARNING)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
     logger_ = logging.getLogger()
     hdlr = logging.StreamHandler(sys.stdout)
     import logging as _logging

--- a/vultron/demo/exchange/initialize_case_demo.py
+++ b/vultron/demo/exchange/initialize_case_demo.py
@@ -309,7 +309,7 @@ def main(
 
 def _setup_logging():
     """Configure console logging for standalone script execution."""
-    logging.getLogger("requests").setLevel(logging.WARNING)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
     logger_ = logging.getLogger()
     hdlr = logging.StreamHandler(sys.stdout)
     formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")

--- a/vultron/demo/exchange/initialize_participant_demo.py
+++ b/vultron/demo/exchange/initialize_participant_demo.py
@@ -338,7 +338,7 @@ def main(
 
 def _setup_logging():
     """Configure console logging for standalone script execution."""
-    logging.getLogger("requests").setLevel(logging.WARNING)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
     logger_ = logging.getLogger()
     hdlr = logging.StreamHandler(sys.stdout)
     formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")

--- a/vultron/demo/exchange/invite_actor_demo.py
+++ b/vultron/demo/exchange/invite_actor_demo.py
@@ -365,7 +365,7 @@ def main(
 
 def _setup_logging():
     """Configure console logging for standalone script execution."""
-    logging.getLogger("requests").setLevel(logging.WARNING)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
     logger_ = logging.getLogger()
     hdlr = logging.StreamHandler(sys.stdout)
     import logging as _logging

--- a/vultron/demo/exchange/manage_case_demo.py
+++ b/vultron/demo/exchange/manage_case_demo.py
@@ -433,7 +433,7 @@ def main(
 
 def _setup_logging():
     """Configure console logging for standalone script execution."""
-    logging.getLogger("requests").setLevel(logging.WARNING)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
     _logger = logging.getLogger()
     hdlr = logging.StreamHandler(sys.stdout)
     formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")

--- a/vultron/demo/exchange/manage_embargo_demo.py
+++ b/vultron/demo/exchange/manage_embargo_demo.py
@@ -555,7 +555,7 @@ def main(
 
 def _setup_logging():
     """Configure console logging for standalone script execution."""
-    logging.getLogger("requests").setLevel(logging.WARNING)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
     logger_ = logging.getLogger()
     hdlr = logging.StreamHandler(sys.stdout)
     import logging as _logging

--- a/vultron/demo/exchange/manage_participants_demo.py
+++ b/vultron/demo/exchange/manage_participants_demo.py
@@ -450,7 +450,7 @@ def main(
 
 def _setup_logging():
     """Configure console logging for standalone script execution."""
-    logging.getLogger("requests").setLevel(logging.WARNING)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
     logger_ = logging.getLogger()
     hdlr = logging.StreamHandler(sys.stdout)
     import logging as _logging

--- a/vultron/demo/exchange/receive_report_demo.py
+++ b/vultron/demo/exchange/receive_report_demo.py
@@ -596,8 +596,8 @@ def main(
 
 def _setup_logging():
     """Configure console logging for standalone script execution."""
-    # turn down requests logging
-    logging.getLogger("requests").setLevel(logging.WARNING)
+    # turn down httpx logging
+    logging.getLogger("httpx").setLevel(logging.WARNING)
 
     logger = logging.getLogger()
     hdlr = logging.StreamHandler(sys.stdout)

--- a/vultron/demo/exchange/status_updates_demo.py
+++ b/vultron/demo/exchange/status_updates_demo.py
@@ -396,7 +396,7 @@ def main(
 
 def _setup_logging():
     """Configure console logging for standalone script execution."""
-    logging.getLogger("requests").setLevel(logging.WARNING)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
     logger_ = logging.getLogger()
     hdlr = logging.StreamHandler(sys.stdout)
     import logging as _logging

--- a/vultron/demo/exchange/suggest_actor_demo.py
+++ b/vultron/demo/exchange/suggest_actor_demo.py
@@ -363,7 +363,7 @@ def main(
 
 def _setup_logging():
     """Configure console logging for standalone script execution."""
-    logging.getLogger("requests").setLevel(logging.WARNING)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
     logger_ = logging.getLogger()
     hdlr = logging.StreamHandler(sys.stdout)
     import logging as _logging

--- a/vultron/demo/exchange/transfer_ownership_demo.py
+++ b/vultron/demo/exchange/transfer_ownership_demo.py
@@ -368,7 +368,7 @@ def main(
 
 def _setup_logging():
     """Configure console logging for standalone script execution."""
-    logging.getLogger("requests").setLevel(logging.WARNING)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
     logger_ = logging.getLogger()
     hdlr = logging.StreamHandler(sys.stdout)
     import logging as _logging

--- a/vultron/demo/exchange/trigger_demo.py
+++ b/vultron/demo/exchange/trigger_demo.py
@@ -362,7 +362,7 @@ def main(
 
 def _setup_logging() -> None:
     """Configure console logging for standalone script execution."""
-    logging.getLogger("requests").setLevel(logging.WARNING)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
     _logger = logging.getLogger()
     hdlr = logging.StreamHandler(sys.stdout)
     hdlr.setFormatter(

--- a/vultron/demo/helpers/verification.py
+++ b/vultron/demo/helpers/verification.py
@@ -21,7 +21,7 @@ avoids duplication when future multi-actor scenarios need the same checks.
 import logging
 from typing import Optional
 
-import requests  # type: ignore[import-untyped]
+import httpx
 
 from vultron.core.states.cs import CS_pxa, CS_vfd
 from vultron.core.states.em import EM
@@ -64,7 +64,7 @@ def _fetch_participant(
             return None
         p_data = client.get(f"/datalayer/{_dl_key(participant_id)}")
         return CaseParticipant(**p_data)
-    except (requests.HTTPError, AssertionError):
+    except (httpx.HTTPStatusError, AssertionError):
         return None
 
 
@@ -75,7 +75,7 @@ def _fetch_participant_data(client: DataLayerClient, p_id: str) -> dict | None:
     """
     try:
         return client.get(f"/datalayer/{_dl_key(p_id)}")
-    except requests.HTTPError as e:
+    except httpx.HTTPStatusError as e:
         if e.response is not None and e.response.status_code == 404:
             return None
         raise

--- a/vultron/demo/scenario/multi_vendor_demo.py
+++ b/vultron/demo/scenario/multi_vendor_demo.py
@@ -774,7 +774,7 @@ def main(
 
 def _setup_logging() -> None:
     """Configure console logging for standalone execution."""
-    logging.getLogger("requests").setLevel(logging.WARNING)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
     root = logging.getLogger()
     handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(

--- a/vultron/demo/scenario/three_actor_demo.py
+++ b/vultron/demo/scenario/three_actor_demo.py
@@ -750,7 +750,7 @@ def main(
 
 def _setup_logging() -> None:
     """Configure console logging for standalone execution."""
-    logging.getLogger("requests").setLevel(logging.WARNING)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
     root = logging.getLogger()
     handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(

--- a/vultron/demo/scenario/two_actor_demo.py
+++ b/vultron/demo/scenario/two_actor_demo.py
@@ -846,7 +846,7 @@ def main(
 
 def _setup_logging() -> None:
     """Configure console logging for standalone script execution."""
-    logging.getLogger("requests").setLevel(logging.WARNING)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
     _logger = logging.getLogger()
     hdlr = logging.StreamHandler(sys.stdout)
     hdlr.setFormatter(

--- a/vultron/demo/utils.py
+++ b/vultron/demo/utils.py
@@ -30,7 +30,7 @@ from http import HTTPMethod
 from typing import Any, Generator, Optional, Sequence, Tuple, cast
 
 # Third-party imports
-import requests  # type: ignore[import-untyped]
+import httpx
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel
 
@@ -150,7 +150,7 @@ def postfmt(obj: object) -> dict[str, object]:
 class DataLayerClient(BaseModel):
     """HTTP client for the Vultron DataLayer REST API.
 
-    Wraps ``requests`` with convenience methods for GET, PUT, POST, and DELETE
+    Wraps ``httpx`` with convenience methods for GET, PUT, POST, and DELETE
     calls to the DataLayer endpoint, with automatic JSON parsing and error logging.
     """
 
@@ -162,29 +162,27 @@ class DataLayerClient(BaseModel):
         Args:
             method: HTTP method (GET, PUT, POST, DELETE).
             path: API path relative to ``base_url``.
-            **kwargs: Additional keyword arguments forwarded to ``requests.request``.
+            **kwargs: Additional keyword arguments forwarded to ``httpx.request``.
 
         Returns:
             Parsed JSON response body as a dict.
 
         Raises:
-            requests.HTTPError: When the response status is not OK.
+            httpx.HTTPStatusError: When the response status is not OK.
         """
         if method.upper() not in HTTPMethod.__members__:
             raise ValueError(f"Unsupported HTTP method: {method}")
 
         url = f"{self.base_url}{path}"
         logger.debug(f"Calling {method.upper()} {url}")
-        response = requests.request(method, url, **kwargs)
+        response = httpx.request(method, url, **kwargs)
         logger.debug(f"Response status: {response.status_code}")
 
         data = {}
         try:
             data = response.json()
             logger.debug(f"Response JSON: {json.dumps(data, indent=2)}")
-        except requests.exceptions.HTTPError as e:
-            logger.error(f"HTTP error: {e}")
-        except Exception as e:
+        except ValueError as e:
             logger.error(f"Exception: {e}")
             logger.error(f"Response text: {response.text}")
 
@@ -193,7 +191,7 @@ class DataLayerClient(BaseModel):
                 f"HTTP 404 from {response.url} ({method.upper()} {path})"
             )
 
-        if not response.ok:
+        if not response.is_success:
             logger.error(f"Error response: {response.text}")
             response.raise_for_status()
 
@@ -347,7 +345,7 @@ def verify_object_stored(client: DataLayerClient, obj_id: str) -> as_Object:
         The retrieved ``as_Object``.
 
     Raises:
-        requests.HTTPError: If the object is not found.
+        httpx.HTTPStatusError: If the object is not found.
     """
 
     def _drop_nulls(value: object) -> object:
@@ -498,12 +496,12 @@ def check_server_availability(
             logger.debug(
                 f"Checking server at: {url} (attempt {attempt + 1}/{max_retries})"
             )
-            response = requests.get(url, timeout=2)
+            response = httpx.get(url, timeout=2)
             if response.status_code == 200:
                 return True
-        except requests.exceptions.ConnectionError:
+        except httpx.ConnectError:
             pass
-        except requests.exceptions.Timeout:
+        except httpx.TimeoutException:
             pass
         except Exception:
             pass


### PR DESCRIPTION
Summary:
- replace demo HTTP client calls and exception handling with httpx in vultron/demo/utils.py
- migrate demo verification helper HTTP exception types to httpx
- update demo health-check retry tests and demo logging configuration to align with httpx

Closes #517