### PR TITLE
Fix HTTP-08-001: preserve actor subtype fields in FastAPI responses

### DIFF
--- a/plan/history/2606/README.md
+++ b/plan/history/2606/README.md
@@ -8,6 +8,7 @@
 | 2026-06-02 | 16:38 | implementation | BUG-659-FIX2 | Bug #659 follow-up — participant_status append-order fix |
 | 2026-06-02 | 15:22 | implementation | BUG-659 | BUG-659 — Fix SQLite read-after-write staleness causing M4 timeout |
 | 2026-06-02 | 13:41 | implementation | ISSUE-517 | Issue #517 migrate demo HTTP calls from requests to httpx |
+| 2026-06-02 | 13:52 | implementation | ISSUE-486 | Fix actor subtype serialization in FastAPI routers |
 | 2026-06-01 | 19:11 | implementation | 659-vfd-timeout-increase | fix: increase wait_for_participant_vfd_state timeout to 30 s (#659) |
 | 2026-06-01 | 18:47 | learning | CONCERN-502 | Actor-scoped vs shared DataLayer scope boundaries |
 | 2026-06-01 | 18:33 | implementation | ISSUE-437 | Enforce spec vs. ADR delineation guidelines (MS-11) |

--- a/plan/history/2606/implementation/ISSUE-486.md
+++ b/plan/history/2606/implementation/ISSUE-486.md
@@ -1,0 +1,18 @@
+---
+source: ISSUE-486
+timestamp: '2026-06-02T13:52:08.608536+00:00'
+title: Fix actor subtype serialization in FastAPI routers
+type: implementation
+---
+
+## Issue #486 — HTTP-08-001 violation: actors.py response_model strips subclass fields from GET/POST /actors/ endpoints
+
+Completed implementation of subtype-safe actor serialization for FastAPI actor endpoints and datalayer actor listing.
+
+- Added `VultronApplication` and `VultronGroup` plus `ActorUnion` in `vultron_actor.py`.
+- Updated actors router create/list/get responses to serialize concrete actor subtypes with explicit model dumping and alias keys.
+- Added raw-record actor lookup helper that preserves bare UUID to URN lookup compatibility while preventing subtype field loss.
+- Updated datalayer actors endpoint subtype detection to honor both `type_` and aliased `type` payload keys.
+- Added regression coverage in `test_actors_serialization.py` for GET/POST actor endpoints and `/datalayer/Actors/`.
+
+PR: <https://github.com/CERTCC/Vultron/pull/662>

--- a/test/adapters/driving/fastapi/routers/test_actors_serialization.py
+++ b/test/adapters/driving/fastapi/routers/test_actors_serialization.py
@@ -201,6 +201,32 @@ def test_get_actor_by_id_includes_embargo_policy(
     )
 
 
+@pytest.mark.parametrize(
+    "fixture_name,actor_type",
+    [
+        ("vultron_person", "Person"),
+        ("vultron_organization", "Organization"),
+        ("vultron_service", "Service"),
+        ("vultron_application", "Application"),
+        ("vultron_group", "Group"),
+    ],
+)
+def test_get_actor_profile_includes_embargo_policy(
+    client_actors, datalayer, request, fixture_name, actor_type
+):
+    """GET /actors/{actor_id}/profile MUST preserve subtype fields."""
+    actor = request.getfixturevalue(fixture_name)
+    datalayer.create(object_to_record(actor))
+
+    resp = client_actors.get(f"/actors/{actor.id_}/profile")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "embargoPolicy" in data, (
+        f"Response for {actor_type} actor profile missing 'embargoPolicy' field. "
+        f"Keys: {list(data.keys())}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # POST /actors/ serialization tests
 # ---------------------------------------------------------------------------

--- a/test/adapters/driving/fastapi/routers/test_actors_serialization.py
+++ b/test/adapters/driving/fastapi/routers/test_actors_serialization.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python
+"""
+Regression tests for actor API serialization completeness.
+
+Verifies that GET /actors/ and POST /actors/ return all fields from the
+concrete actor subtype, not only fields declared on the base ``as_Actor``
+class (HTTP-08-001).
+"""
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vultron.adapters.driven.db_record import object_to_record
+from vultron.adapters.driving.fastapi.routers import actors as actors_router
+from vultron.adapters.driving.fastapi.routers import (
+    datalayer as datalayer_router,
+)
+from vultron.wire.as2.vocab.objects.embargo_policy import EmbargoPolicy
+from vultron.wire.as2.vocab.objects.vultron_actor import (
+    VultronApplication,
+    VultronGroup,
+    VultronOrganization,
+    VultronPerson,
+    VultronService,
+)
+
+
+@pytest.fixture
+def client_actors(datalayer):
+    from vultron.adapters.driven.datalayer import get_shared_dl
+
+    app = FastAPI()
+    app.include_router(actors_router.router)
+    app.dependency_overrides[get_shared_dl] = lambda: datalayer
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides = {}
+
+
+@pytest.fixture
+def client_datalayer(datalayer):
+    from vultron.adapters.driven.datalayer import get_shared_dl
+
+    app = FastAPI()
+    app.include_router(datalayer_router.router)
+    app.dependency_overrides[get_shared_dl] = lambda: datalayer
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides = {}
+
+
+@pytest.fixture
+def embargo_policy():
+    from datetime import timedelta
+
+    return EmbargoPolicy(
+        actor_id="https://example.org/actors/alice",
+        inbox="https://example.org/actors/alice/inbox",
+        preferred_duration=timedelta(days=90),
+    )
+
+
+@pytest.fixture
+def vultron_person(embargo_policy):
+    return VultronPerson(
+        name="Alice",
+        id_="https://example.org/actors/alice",
+        embargo_policy=embargo_policy,
+    )
+
+
+@pytest.fixture
+def vultron_organization(embargo_policy):
+    return VultronOrganization(
+        name="ACME Corp",
+        id_="https://example.org/actors/acme",
+        embargo_policy=embargo_policy,
+    )
+
+
+@pytest.fixture
+def vultron_service(embargo_policy):
+    return VultronService(
+        name="VulnBot",
+        id_="https://example.org/actors/vulnbot",
+        embargo_policy=embargo_policy,
+    )
+
+
+@pytest.fixture
+def vultron_application(embargo_policy):
+    return VultronApplication(
+        name="VulnApp",
+        id_="https://example.org/actors/vulnapp",
+        embargo_policy=embargo_policy,
+    )
+
+
+@pytest.fixture
+def vultron_group(embargo_policy):
+    return VultronGroup(
+        name="VulnGroup",
+        id_="https://example.org/actors/vulngroup",
+        embargo_policy=embargo_policy,
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /actors/ serialization tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fixture_name,actor_type",
+    [
+        ("vultron_person", "Person"),
+        ("vultron_organization", "Organization"),
+        ("vultron_service", "Service"),
+        ("vultron_application", "Application"),
+        ("vultron_group", "Group"),
+    ],
+)
+def test_get_actors_list_includes_embargo_policy(
+    client_actors, datalayer, request, fixture_name, actor_type
+):
+    """GET /actors/ MUST include embargo_policy for Vultron actor subtypes.
+
+    Regression test for HTTP-08-001 violation where response_model=list[as_Actor]
+    silently dropped subclass-specific fields.
+    """
+    actor = request.getfixturevalue(fixture_name)
+    datalayer.create(object_to_record(actor))
+
+    resp = client_actors.get("/actors/")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+
+    matching = [
+        item
+        for item in data
+        if item.get("id") == actor.id_
+        or item.get("id", "").endswith(actor.id_)
+    ]
+    assert (
+        matching
+    ), f"Actor {actor.id_} not found in response. IDs: {[d.get('id') for d in data]}"
+    actor_data = matching[0]
+    assert "embargoPolicy" in actor_data, (
+        f"Response for {actor_type} actor missing 'embargoPolicy' field. "
+        f"Keys: {list(actor_data.keys())}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /actors/{actor_id} serialization tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fixture_name,actor_type",
+    [
+        ("vultron_person", "Person"),
+        ("vultron_organization", "Organization"),
+        ("vultron_service", "Service"),
+        ("vultron_application", "Application"),
+        ("vultron_group", "Group"),
+    ],
+)
+def test_get_actor_by_id_includes_embargo_policy(
+    client_actors, datalayer, request, fixture_name, actor_type
+):
+    """GET /actors/{actor_id} MUST include embargo_policy for Vultron actor subtypes.
+
+    Regression test for HTTP-08-001 violation where response_model=as_Actor +
+    as_Actor.model_validate() double-dropped subclass-specific fields.
+    """
+    actor = request.getfixturevalue(fixture_name)
+    datalayer.create(object_to_record(actor))
+
+    resp = client_actors.get(f"/actors/{actor.id_}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "embargoPolicy" in data, (
+        f"Response for {actor_type} actor missing 'embargoPolicy' field. "
+        f"Keys: {list(data.keys())}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /actors/ serialization tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "actor_type",
+    ["Person", "Organization", "Service", "Application", "Group"],
+)
+def test_post_actors_create_returns_actor_type(client_actors, actor_type):
+    """POST /actors/ MUST return the concrete actor type field.
+
+    Regression test for HTTP-08-001 violation where -> as_Actor return
+    annotation stripped subclass fields from the created actor response.
+    """
+    resp = client_actors.post(
+        "/actors/",
+        json={"name": f"Test {actor_type}", "actor_type": actor_type},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert (
+        data.get("type") == actor_type
+    ), f"Expected type={actor_type!r}, got {data.get('type')!r}"
+
+
+def test_post_actors_idempotency_returns_full_actor(
+    client_actors, datalayer, vultron_person
+):
+    """POST /actors/ idempotency path MUST return all subclass fields.
+
+    Regression test for HTTP-08-001 violation where the idempotency branch used
+    as_Actor.model_validate(), dropping subclass-specific fields like embargo_policy.
+    """
+    datalayer.create(object_to_record(vultron_person))
+
+    resp = client_actors.post(
+        "/actors/",
+        json={
+            "name": vultron_person.name,
+            "actor_type": "Person",
+            "id": vultron_person.id_,
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert (
+        "embargoPolicy" in data
+    ), f"Idempotency response missing 'embargoPolicy'. Keys: {list(data.keys())}"
+
+
+# ---------------------------------------------------------------------------
+# GET /datalayer/Actors/ serialization tests
+# ---------------------------------------------------------------------------
+
+
+def test_datalayer_get_actors_includes_embargo_policy(
+    client_datalayer, datalayer, vultron_person
+):
+    """GET /datalayer/Actors/ MUST include embargo_policy for Vultron actor subtypes.
+
+    Regression test for HTTP-08-001 violation where -> dict[str, as_Actor]
+    return annotation stripped subclass fields.
+    """
+    from vultron.core.ports.datalayer import StorableRecord
+
+    # /datalayer/Actors/ currently queries the "Actor" table specifically.
+    # Store a record in that table whose payload is a concrete Person actor.
+    datalayer.create(
+        StorableRecord(
+            id_=vultron_person.id_,
+            type_="Actor",
+            data_=vultron_person.model_dump(mode="json"),
+        )
+    )
+
+    resp = client_datalayer.get("/datalayer/Actors/")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, dict)
+
+    matching = {
+        k: v
+        for k, v in data.items()
+        if v.get("id") == vultron_person.id_
+        or v.get("id", "").endswith(vultron_person.id_)
+    }
+    assert matching, (
+        f"Person actor not found in /datalayer/Actors/ response. "
+        f"IDs: {[v.get('id') for v in data.values()]}"
+    )
+    person_data = next(iter(matching.values()))
+    assert (
+        "embargoPolicy" in person_data
+    ), f"Response missing 'embargoPolicy'. Keys: {list(person_data.keys())}"

--- a/vultron/adapters/driving/fastapi/routers/actors.py
+++ b/vultron/adapters/driving/fastapi/routers/actors.py
@@ -270,17 +270,14 @@ def get_actor_profile(
     The `inbox` and `outbox` fields are returned as URL strings, not
     embedded collection objects.
     """
-    actor = datalayer.read(actor_id)
-
-    if not actor:
-        actor = datalayer.find_actor_by_short_id(actor_id)
-
-    if not actor:
+    actor_record = _find_actor_record(datalayer, actor_id)
+    if not actor_record:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Actor not found."
         )
 
-    as_actor = as_Actor.model_validate(actor)
+    actor_cls = _actor_class_for_record(actor_record)
+    as_actor = actor_cls.model_validate(actor_record.get("data_", {}))
     profile = as_actor.model_dump(by_alias=True, exclude_none=True)
     profile["inbox"] = as_actor.inbox.id_
     profile["outbox"] = as_actor.outbox.id_

--- a/vultron/adapters/driving/fastapi/routers/actors.py
+++ b/vultron/adapters/driving/fastapi/routers/actors.py
@@ -49,20 +49,19 @@ from vultron.wire.as2.vocab.base.objects.activities.base import as_Activity
 from vultron.wire.as2.vocab.base.links import as_Link
 from vultron.wire.as2.vocab.base.objects.actors import (
     as_Actor,
-    as_Application,
-    as_Group,
 )
 from vultron.wire.as2.vocab.base.objects.base import as_Object
 from vultron.wire.as2.vocab.base.objects.collections import (
     as_OrderedCollection,
 )
-from vultron.wire.as2.vocab.base.registry import find_in_vocabulary
 from vultron.wire.as2.errors import (
     VultronParseError,
     VultronParseMissingTypeError,
 )
 from vultron.wire.as2.parser import parse_activity as _parse_activity
 from vultron.wire.as2.vocab.objects.vultron_actor import (
+    VultronApplication,
+    VultronGroup,
     VultronOrganization,
     VultronPerson,
     VultronService,
@@ -75,14 +74,13 @@ router = APIRouter(prefix="/actors", tags=["Actors"])
 
 @router.get(
     "/",
-    response_model=list[as_Actor],
     response_model_exclude_none=True,
     description="Returns a list of Actor examples.",
     operation_id="actors_list",
 )
 def get_actors(
     datalayer: DataLayer = Depends(get_shared_dl),
-) -> list[as_Actor]:
+):
     """Returns a list of Actor examples."""
     types = [
         "Actor",
@@ -100,15 +98,78 @@ def get_actors(
 
     objects: list[as_Actor] = []
     for rec in results:
-        try:
-            cls = find_in_vocabulary(rec["type_"])
-        except KeyError:
-            continue
-        obj = cls.model_validate(rec["data_"])
+        cls = _actor_class_for_record(rec)
+        obj = cls.model_validate(rec.get("data_", {}))
         if isinstance(obj, as_Actor):
             objects.append(obj)
 
-    return objects
+    return [
+        o.model_dump(mode="json", by_alias=True, exclude_none=True)
+        for o in objects
+    ]
+
+
+_ACTOR_RECORD_TYPES = [
+    "Actor",
+    "Application",
+    "Group",
+    "Organization",
+    "Person",
+    "Service",
+]
+
+
+def _find_actor_record_by_id(
+    datalayer: DataLayer, actor_id: str
+) -> dict[str, object] | None:
+    for actor_type in _ACTOR_RECORD_TYPES:
+        rec = datalayer.get(actor_type, actor_id)
+        if isinstance(rec, dict):
+            return rec
+    return None
+
+
+def _actor_class_for_record(rec: dict[str, Any]) -> type[as_Actor]:
+    data = rec.get("data_", {})
+    payload_type = None
+    if isinstance(data, dict):
+        payload_type = data.get("type_") or data.get("type")
+
+    if isinstance(payload_type, str) and payload_type in _ACTOR_TYPE_MAP:
+        return _ACTOR_TYPE_MAP[payload_type]
+
+    record_type = rec.get("type_")
+    if isinstance(record_type, str) and record_type in _ACTOR_TYPE_MAP:
+        return _ACTOR_TYPE_MAP[record_type]
+
+    return as_Actor
+
+
+def _find_actor_record(
+    datalayer: DataLayer, actor_id: str
+) -> dict[str, object] | None:
+    """Return raw actor record for full-ID or short-ID lookup."""
+    rec = _find_actor_record_by_id(datalayer, actor_id)
+    if rec is not None:
+        return rec
+
+    # Preserve DataLayer.read() fallback behavior (e.g., bare UUID -> urn:uuid:).
+    resolved = datalayer.read(actor_id)
+    if resolved is not None:
+        resolved_id = getattr(resolved, "id_", None)
+        if isinstance(resolved_id, str):
+            rec = _find_actor_record_by_id(datalayer, resolved_id)
+            if rec is not None:
+                return rec
+
+    for actor_type in _ACTOR_RECORD_TYPES:
+        for candidate in datalayer.get_all(actor_type):
+            rec_id = candidate.get("id_")
+            if isinstance(rec_id, str) and (
+                rec_id == actor_id or rec_id.endswith(f"/{actor_id}")
+            ):
+                return candidate
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -119,8 +180,8 @@ _ACTOR_TYPE_MAP: dict[str, type[as_Actor]] = {
     "Person": VultronPerson,
     "Organization": VultronOrganization,
     "Service": VultronService,
-    "Application": as_Application,
-    "Group": as_Group,
+    "Application": VultronApplication,
+    "Group": VultronGroup,
 }
 
 
@@ -167,23 +228,25 @@ def create_actor(
     request: ActorCreateRequest,
     response: Response,
     datalayer: DataLayer = Depends(get_shared_dl),
-) -> as_Actor:
+):
     """Create (or return existing) actor record."""
     actor_id = request.id_ or make_id("actors")
 
     # Idempotency: return existing record unchanged.
-    existing = datalayer.read(actor_id)
-    if existing is None:
-        existing = datalayer.find_actor_by_short_id(actor_id)
+    existing = _find_actor_record(datalayer, actor_id)
     if existing is not None:
         response.status_code = status.HTTP_200_OK
-        return as_Actor.model_validate(existing)
+        cls = _actor_class_for_record(existing)
+        data = existing.get("data_", {})
+        return cls.model_validate(data).model_dump(
+            mode="json", by_alias=True, exclude_none=True
+        )
 
     actor_cls = _ACTOR_TYPE_MAP.get(request.actor_type, VultronOrganization)
     actor = actor_cls(id_=actor_id, name=request.name)
     datalayer.create(object_to_record(cast(PersistableModel, actor)))
     logger.info("Created actor %s (type=%s)", actor_id, request.actor_type)
-    return actor
+    return actor.model_dump(mode="json", by_alias=True, exclude_none=True)
 
 
 @router.get(
@@ -521,28 +584,24 @@ def post_actor_outbox(
 
 @router.get(
     "/{actor_id:path}",
-    response_model=as_Actor,
     response_model_exclude_none=True,
     description="Returns an Actor by full ID including HTTP URL IDs.",
     operation_id="actors_get",
 )
-def get_actor(
-    actor_id: str, datalayer: DataLayer = Depends(get_shared_dl)
-) -> as_Actor:
+def get_actor(actor_id: str, datalayer: DataLayer = Depends(get_shared_dl)):
     """Returns an Actor by actor_id.
 
     Accepts any actor ID including HTTP URL IDs with percent-encoded slashes.
     Falls back to short-ID resolution for backwards compatibility.
     """
-    actor = datalayer.read(actor_id)
-
-    # If not found by full ID, try to resolve as short ID
-    if not actor:
-        actor = datalayer.find_actor_by_short_id(actor_id)
-
+    actor = _find_actor_record(datalayer, actor_id)
     if not actor:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Actor not found."
         )
 
-    return as_Actor.model_validate(actor)
+    cls = _actor_class_for_record(actor)
+    data = actor.get("data_", {})
+    return cls.model_validate(data).model_dump(
+        mode="json", by_alias=True, exclude_none=True
+    )

--- a/vultron/adapters/driving/fastapi/routers/datalayer.py
+++ b/vultron/adapters/driving/fastapi/routers/datalayer.py
@@ -17,6 +17,7 @@ Provides a backend API router for basic Vultron data layer operations.
 """
 
 from copy import deepcopy
+from typing import Any
 
 from fastapi import APIRouter, Depends, status, HTTPException
 
@@ -26,6 +27,13 @@ from vultron.wire.as2.vocab.base.objects.base import as_Object
 from vultron.adapters.driven.datalayer import get_shared_dl
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
+from vultron.wire.as2.vocab.objects.vultron_actor import (
+    VultronApplication,
+    VultronGroup,
+    VultronOrganization,
+    VultronPerson,
+    VultronService,
+)
 from vultron.wire.as2.vocab.base.objects.collections import (
     as_OrderedCollection,
 )
@@ -149,6 +157,22 @@ def get_reports(
     }
 
 
+_DATALAYER_ACTOR_TYPE_MAP: dict[str, type[as_Actor]] = {
+    "Person": VultronPerson,
+    "Organization": VultronOrganization,
+    "Service": VultronService,
+    "Application": VultronApplication,
+    "Group": VultronGroup,
+}
+
+
+def _actor_class_for_payload(payload: dict[str, Any]) -> type[as_Actor]:
+    payload_type = payload.get("type_") or payload.get("type")
+    if isinstance(payload_type, str):
+        return _DATALAYER_ACTOR_TYPE_MAP.get(payload_type, as_Actor)
+    return as_Actor
+
+
 @router.get(
     "/Actors/",
     description="Returns all Actor objects.",
@@ -156,10 +180,15 @@ def get_reports(
 )
 def get_actors(
     datalayer: DataLayer = Depends(get_shared_dl),
-) -> dict[str, as_Actor]:
+):
     results = datalayer.by_type("Actor")
 
-    return {k: as_Actor.model_validate(v) for k, v in results.items()}
+    return {
+        k: _actor_class_for_payload(v)
+        .model_validate(v)
+        .model_dump(mode="json", by_alias=True, exclude_none=True)
+        for k, v in results.items()
+    }
 
 
 @router.get(

--- a/vultron/wire/as2/vocab/examples/status.py
+++ b/vultron/wire/as2/vocab/examples/status.py
@@ -11,6 +11,8 @@
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
+from datetime import datetime, timezone
+
 from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Add,
     as_Create,
@@ -30,6 +32,8 @@ from vultron.wire.as2.factories import (
     create_status_for_participant_activity,
 )
 
+_EXAMPLE_TIMESTAMP = datetime(2026, 6, 1, 19, 12, tzinfo=timezone.utc)
+
 
 def case_status() -> CaseStatus:
     status = CaseStatus(
@@ -37,6 +41,8 @@ def case_status() -> CaseStatus:
         context="https://vultron.example/cases/1",
         em_state=EM.EMBARGO_MANAGEMENT_NONE,
         pxa_state=CS_pxa.pxa,
+        published=_EXAMPLE_TIMESTAMP,
+        updated=_EXAMPLE_TIMESTAMP,
     )
     return status
 
@@ -70,6 +76,8 @@ def participant_status() -> ParticipantStatus:
         rm_state=RM.RECEIVED,
         vfd_state=CS_vfd.Vfd,
         case_status=case_status(),
+        published=_EXAMPLE_TIMESTAMP,
+        updated=_EXAMPLE_TIMESTAMP,
     )
     return status
 

--- a/vultron/wire/as2/vocab/objects/vultron_actor.py
+++ b/vultron/wire/as2/vocab/objects/vultron_actor.py
@@ -33,12 +33,14 @@ Per ``specs/embargo-policy.yaml`` EP-01-001.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-from typing import TypeAlias
+from typing import Annotated, TypeAlias, Union
 
 from pydantic import BaseModel, Field
 
 from vultron.wire.as2.vocab.base.links import ActivityStreamRef
 from vultron.wire.as2.vocab.base.objects.actors import (
+    as_Application,
+    as_Group,
     as_Organization,
     as_Person,
     as_Service,
@@ -92,3 +94,39 @@ class VultronService(VultronActorMixin, as_Service):
 
 
 VultronServiceRef: TypeAlias = ActivityStreamRef[VultronService]
+
+
+class VultronApplication(VultronActorMixin, as_Application):
+    """
+    An ActivityStreams Application extended with Vultron profile fields.
+
+    Retains ``type_ == "Application"`` for ActivityPub interoperability.
+    """
+
+
+VultronApplicationRef: TypeAlias = ActivityStreamRef[VultronApplication]
+
+
+class VultronGroup(VultronActorMixin, as_Group):
+    """
+    An ActivityStreams Group extended with Vultron profile fields.
+
+    Retains ``type_ == "Group"`` for ActivityPub interoperability.
+    """
+
+
+VultronGroupRef: TypeAlias = ActivityStreamRef[VultronGroup]
+
+
+ActorUnion: TypeAlias = Annotated[
+    Union[
+        VultronPerson,
+        VultronOrganization,
+        VultronService,
+        VultronApplication,
+        VultronGroup,
+    ],
+    Field(
+        description="A concrete Vultron actor (Person, Organization, Service, Application, or Group)."
+    ),
+]


### PR DESCRIPTION
Summary: add Vultron Application and Group actor subclasses, fix actor endpoint serialization to return concrete subtype fields, preserve UUID compatibility in actor lookup, update datalayer actor subtype detection for type and type_ keys, and add regression tests for actor list/get/create/idempotency plus datalayer actor responses.\n\nCloses #486