### PR TITLE
feat(examples): add actor-subtype GET endpoints with EmbargoPolicy (#487)

### DIFF
--- a/plan/history/2606/README.md
+++ b/plan/history/2606/README.md
@@ -4,11 +4,12 @@
 
 | Date | Time (UTC) | Type | Source | Title |
 |------|------------|------|--------|-------|
+| 2026-06-02 | 17:42 | implementation | 487 | Add actor-subtype example endpoints (#487) |
 | 2026-06-02 | 17:02 | learning | CONCERN-658 | Split notes/architecture-ports-and-adapters.md monolith into focused sub-files |
 | 2026-06-02 | 16:38 | implementation | BUG-659-FIX2 | Bug #659 follow-up — participant_status append-order fix |
 | 2026-06-02 | 15:22 | implementation | BUG-659 | BUG-659 — Fix SQLite read-after-write staleness causing M4 timeout |
-| 2026-06-02 | 13:41 | implementation | ISSUE-517 | Issue #517 migrate demo HTTP calls from requests to httpx |
 | 2026-06-02 | 13:52 | implementation | ISSUE-486 | Fix actor subtype serialization in FastAPI routers |
+| 2026-06-02 | 13:41 | implementation | ISSUE-517 | Issue #517 migrate demo HTTP calls from requests to httpx |
 | 2026-06-01 | 19:11 | implementation | 659-vfd-timeout-increase | fix: increase wait_for_participant_vfd_state timeout to 30 s (#659) |
 | 2026-06-01 | 18:47 | learning | CONCERN-502 | Actor-scoped vs shared DataLayer scope boundaries |
 | 2026-06-01 | 18:33 | implementation | ISSUE-437 | Enforce spec vs. ADR delineation guidelines (MS-11) |

--- a/plan/history/2606/implementation/487.md
+++ b/plan/history/2606/implementation/487.md
@@ -1,0 +1,8 @@
+---
+source: '487'
+timestamp: '2026-06-02T17:42:09.456968+00:00'
+title: Add actor-subtype example endpoints (#487)
+type: implementation
+---
+
+Added five `GET /examples/actors/{subtype}` endpoints to `examples.py` (Person, Organization, Service, Application, Group), each returning a typed Vultron actor with inline `EmbargoPolicy` (actorId, inbox, preferredDuration=P90D). Added 20 parametrized tests in `test_examples.py` verifying HTTP 200, correct type field, embargo policy presence, and actorId/inbox consistency. All linters (black, flake8, mypy, pyright) pass; 2554 tests pass. PR #668.

--- a/test/adapters/driving/fastapi/routers/test_examples.py
+++ b/test/adapters/driving/fastapi/routers/test_examples.py
@@ -1,0 +1,111 @@
+"""
+Tests for GET /examples/actors/{subtype} endpoints.
+"""
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vultron.adapters.driving.fastapi.routers import (
+    examples as examples_router,
+)
+
+
+@pytest.fixture
+def client_examples():
+    app = FastAPI()
+    app.include_router(examples_router.router)
+    return TestClient(app)
+
+
+class TestActorSubtypeExampleEndpoints:
+    """Each actor-subtype GET endpoint returns a valid, typed example actor."""
+
+    _BASE = "https://example.org/actors"
+
+    @pytest.mark.parametrize(
+        "path, expected_type, slug",
+        [
+            ("/examples/actors/person", "Person", "alice"),
+            ("/examples/actors/organization", "Organization", "acme-inc"),
+            ("/examples/actors/service", "Service", "vultron-bot"),
+            ("/examples/actors/application", "Application", "vultron-app"),
+            ("/examples/actors/group", "Group", "security-team"),
+        ],
+    )
+    def test_status_ok(self, client_examples, path, expected_type, slug):
+        resp = client_examples.get(path)
+        assert resp.status_code == 200
+
+    @pytest.mark.parametrize(
+        "path, expected_type, slug",
+        [
+            ("/examples/actors/person", "Person", "alice"),
+            ("/examples/actors/organization", "Organization", "acme-inc"),
+            ("/examples/actors/service", "Service", "vultron-bot"),
+            ("/examples/actors/application", "Application", "vultron-app"),
+            ("/examples/actors/group", "Group", "security-team"),
+        ],
+    )
+    def test_correct_actor_type(
+        self, client_examples, path, expected_type, slug
+    ):
+        data = client_examples.get(path).json()
+        assert (
+            data["type"] == expected_type
+        ), f"Expected type={expected_type!r}, got {data.get('type')!r}"
+
+    @pytest.mark.parametrize(
+        "path, expected_type, slug",
+        [
+            ("/examples/actors/person", "Person", "alice"),
+            ("/examples/actors/organization", "Organization", "acme-inc"),
+            ("/examples/actors/service", "Service", "vultron-bot"),
+            ("/examples/actors/application", "Application", "vultron-app"),
+            ("/examples/actors/group", "Group", "security-team"),
+        ],
+    )
+    def test_embargo_policy_present(
+        self, client_examples, path, expected_type, slug
+    ):
+        data = client_examples.get(path).json()
+        policy = data.get("embargoPolicy")
+        assert policy is not None, "embargoPolicy should be present"
+        assert policy["type"] == "EmbargoPolicy"
+
+    @pytest.mark.parametrize(
+        "path, expected_type, slug",
+        [
+            ("/examples/actors/person", "Person", "alice"),
+            ("/examples/actors/organization", "Organization", "acme-inc"),
+            ("/examples/actors/service", "Service", "vultron-bot"),
+            ("/examples/actors/application", "Application", "vultron-app"),
+            ("/examples/actors/group", "Group", "security-team"),
+        ],
+    )
+    def test_embargo_policy_actor_id_matches(
+        self, client_examples, path, expected_type, slug
+    ):
+        data = client_examples.get(path).json()
+        actor_id = data.get("id")
+        policy = data.get("embargoPolicy", {})
+        assert actor_id is not None
+        assert policy.get("actorId") == actor_id, (
+            f"embargoPolicy.actorId {policy.get('actorId')!r} "
+            f"should match actor id {actor_id!r}"
+        )
+        assert policy.get("inbox") == f"{actor_id}/inbox"
+        assert "preferredDuration" in policy

--- a/vultron/adapters/driving/fastapi/routers/examples.py
+++ b/vultron/adapters/driving/fastapi/routers/examples.py
@@ -16,6 +16,7 @@ Vultron API Object Examples
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
 import random
+from datetime import timedelta
 
 from fastapi import APIRouter
 
@@ -27,11 +28,32 @@ from vultron.wire.as2.vocab.objects.case_status import (
     ParticipantStatus,
 )
 from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+from vultron.wire.as2.vocab.objects.embargo_policy import EmbargoPolicy
+from vultron.wire.as2.vocab.objects.vultron_actor import (
+    VultronApplication,
+    VultronGroup,
+    VultronOrganization,
+    VultronPerson,
+    VultronService,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
     VulnerabilityReport,
 )
 from vultron.wire.as2.vocab.examples import vocab_examples
+
+_ACTORS_BASE = "https://example.org/actors"
+_PREFERRED_DURATION = timedelta(days=90)
+
+
+def _embargo_policy(actor_id: str) -> EmbargoPolicy:
+    """Build a minimal EmbargoPolicy for the given actor ID."""
+    return EmbargoPolicy(
+        actor_id=actor_id,
+        inbox=f"{actor_id}/inbox",
+        preferred_duration=_PREFERRED_DURATION,
+    )
+
 
 router = APIRouter(
     prefix="/examples",
@@ -69,6 +91,91 @@ def get_example_actor() -> as_Actor:
 def validate_actor(actor: as_Actor) -> as_Actor:
     """Validates an Actor object."""
     return actor
+
+
+@router.get(
+    "/actors/person",
+    response_model=VultronPerson,
+    response_model_exclude_none=True,
+    description="Get an example VultronPerson actor object.",
+    operation_id="examples_get_actor_person",
+)
+def get_example_actor_person() -> VultronPerson:
+    """Returns an example VultronPerson actor with an inline EmbargoPolicy."""
+    actor_id = f"{_ACTORS_BASE}/alice"
+    return VultronPerson(
+        id_=actor_id,
+        name="Alice (Example Person)",
+        embargo_policy=_embargo_policy(actor_id),
+    )
+
+
+@router.get(
+    "/actors/organization",
+    response_model=VultronOrganization,
+    response_model_exclude_none=True,
+    description="Get an example VultronOrganization actor object.",
+    operation_id="examples_get_actor_organization",
+)
+def get_example_actor_organization() -> VultronOrganization:
+    """Returns an example VultronOrganization actor with an inline EmbargoPolicy."""
+    actor_id = f"{_ACTORS_BASE}/acme-inc"
+    return VultronOrganization(
+        id_=actor_id,
+        name="ACME Inc. (Example Organization)",
+        embargo_policy=_embargo_policy(actor_id),
+    )
+
+
+@router.get(
+    "/actors/service",
+    response_model=VultronService,
+    response_model_exclude_none=True,
+    description="Get an example VultronService actor object.",
+    operation_id="examples_get_actor_service",
+)
+def get_example_actor_service() -> VultronService:
+    """Returns an example VultronService actor with an inline EmbargoPolicy."""
+    actor_id = f"{_ACTORS_BASE}/vultron-bot"
+    return VultronService(
+        id_=actor_id,
+        name="Vultron Bot (Example Service)",
+        embargo_policy=_embargo_policy(actor_id),
+    )
+
+
+@router.get(
+    "/actors/application",
+    response_model=VultronApplication,
+    response_model_exclude_none=True,
+    description="Get an example VultronApplication actor object.",
+    operation_id="examples_get_actor_application",
+)
+def get_example_actor_application() -> VultronApplication:
+    """Returns an example VultronApplication actor with an inline EmbargoPolicy."""
+    actor_id = f"{_ACTORS_BASE}/vultron-app"
+    return VultronApplication(
+        id_=actor_id,
+        name="Vultron App (Example Application)",
+        embargo_policy=_embargo_policy(actor_id),
+    )
+
+
+@router.get(
+    "/actors/group",
+    response_model=VultronGroup,
+    response_model_exclude_none=True,
+    description="Get an example VultronGroup actor object.",
+    operation_id="examples_get_actor_group",
+)
+def get_example_actor_group() -> VultronGroup:
+    """Returns an example VultronGroup actor with an inline EmbargoPolicy."""
+    actor_id = f"{_ACTORS_BASE}/security-team"
+    return VultronGroup(
+        id_=actor_id,
+        name="Security Team (Example Group)",
+        embargo_policy=_embargo_policy(actor_id),
+    )
 
 
 @router.get(


### PR DESCRIPTION
## Summary

Adds five dedicated `GET /examples/actors/{subtype}` endpoints, each returning a concrete Vultron-extended actor with an inline `EmbargoPolicy`.

| Endpoint | Response model |
|---|---|
| `GET /examples/actors/person` | `VultronPerson` |
| `GET /examples/actors/organization` | `VultronOrganization` |
| `GET /examples/actors/service` | `VultronService` |
| `GET /examples/actors/application` | `VultronApplication` |
| `GET /examples/actors/group` | `VultronGroup` |

Each response uses `response_model_exclude_none=True` and includes a fully-populated inline `EmbargoPolicy` (`actorId`, `inbox`, `preferredDuration=P90D`).

## Changes

- `vultron/adapters/driving/fastapi/routers/examples.py` — 5 new GET endpoints + private `_embargo_policy()` helper
- `test/adapters/driving/fastapi/routers/test_examples.py` — 20 parametrized tests (HTTP 200, correct `type`, embargo policy present, actorId/inbox consistency)

## Test results

```
2554 passed, 12 skipped, 216 deselected, 5633 subtests passed in 31.68s
```

Closes #487