### PR TITLE
skills: replace freshen with ensure-synced in branch-creating skills

### DIFF
--- a/.agents/skills/bugfix/SKILL.md
+++ b/.agents/skills/bugfix/SKILL.md
@@ -66,14 +66,26 @@ bug is being fixed and why.
    - One-sentence description of the observed vs. expected behaviour
    - The file(s) / component(s) most likely involved
 6. **Claim the issue**:
-   - Freshen the worktree slot if running in one:
+   - Ensure the worktree is synced to `origin/main` before branching:
 
      ```bash
-     FRESHEN="$HOME/.copilot/skills/manage-worktree/scripts/manage_worktree.sh"
-     [ -f "$FRESHEN" ] && bash "$FRESHEN" freshen
-     ```
+     SCRIPT="$HOME/.copilot/skills/manage-worktree/scripts/manage_worktree.sh"
+     if [ -f "$SCRIPT" ]; then
+       bash "$SCRIPT" ensure-synced || { echo "❌ Bugfix aborted — sync check failed." >&2; exit 1; }
+     else
+       git fetch origin --quiet 2>/dev/null || true
+       BEHIND=$(git rev-list --count HEAD..origin/main 2>/dev/null || echo 0)
+       if [ "$BEHIND" -gt 0 ]; then
+         echo "❌ Bugfix aborted: $BEHIND commit(s) behind origin/main. Run: git rebase origin/main" >&2
+         exit 1
+       fi
+     fi
+     ```text
+
+     If `ensure-synced` exits non-zero, **abort immediately** — do not create the bug branch.
 
    - Create a branch: `git switch -c bug/<issue-number>-<slug>`
+
    - If the branch already exists, abort — the bug is already claimed.
    - Assign the issue to the triggering user:
      `gh issue edit <N> --add-assignee @me --repo CERTCC/Vultron`

--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -63,12 +63,23 @@ docs/adr/, notes/, and AGENTS.md files, and scans vultron/ and test/.
    (`method: get` then `method: get_comments`). Use the combined content as
    implementation context throughout Phases 3–5.
 5. **Claim the Issue**:
-   - Freshen the worktree slot if running in one:
+   - Ensure the worktree is synced to `origin/main` before branching:
 
      ```bash
-     FRESHEN="$HOME/.copilot/skills/manage-worktree/scripts/manage_worktree.sh"
-     [ -f "$FRESHEN" ] && bash "$FRESHEN" freshen
+     SCRIPT="$HOME/.copilot/skills/manage-worktree/scripts/manage_worktree.sh"
+     if [ -f "$SCRIPT" ]; then
+       bash "$SCRIPT" ensure-synced || { echo "❌ Build aborted — sync check failed." >&2; exit 1; }
+     else
+       git fetch origin --quiet 2>/dev/null || true
+       BEHIND=$(git rev-list --count HEAD..origin/main 2>/dev/null || echo 0)
+       if [ "$BEHIND" -gt 0 ]; then
+         echo "❌ Build aborted: $BEHIND commit(s) behind origin/main. Run: git rebase origin/main" >&2
+         exit 1
+       fi
+     fi
      ```text
+
+     If `ensure-synced` exits non-zero, **abort immediately** — do not create the task branch.
 
    - Create a branch: `git switch -c task/<issue-number>-<slug>`
 

--- a/.agents/skills/ingest-concern/SKILL.md
+++ b/.agents/skills/ingest-concern/SKILL.md
@@ -107,11 +107,17 @@ Do **not** write anything until grill-me is complete.
 If Phase 3 established a concrete spec, notes, or `AGENTS.md` gap (i.e.,
 Phase 4 will produce file writes), create the task branch **now** — before
 writing any files — so uncommitted changes are never at risk of being
-clobbered by `freshen`:
+clobbered by `git reset --hard`:
 
 ```bash
-FRESHEN="$HOME/.copilot/skills/manage-worktree/scripts/manage_worktree.sh"
-[ -f "$FRESHEN" ] && bash "$FRESHEN" freshen
+SCRIPT="$HOME/.copilot/skills/manage-worktree/scripts/manage_worktree.sh"
+if [ -f "$SCRIPT" ]; then
+  bash "$SCRIPT" ensure-synced || { echo "❌ Aborted — sync check failed." >&2; exit 1; }
+else
+  git fetch origin --quiet 2>/dev/null || true
+  BEHIND=$(git rev-list --count HEAD..origin/main 2>/dev/null || echo 0)
+  [ "$BEHIND" -gt 0 ] && { echo "❌ Aborted: $BEHIND commit(s) behind origin/main. Run: git rebase origin/main" >&2; exit 1; }
+fi
 git switch -c ingest/concern-${CONCERN_NUMBER}-<slug>
 ```
 

--- a/.agents/skills/ingest-idea/SKILL.md
+++ b/.agents/skills/ingest-idea/SKILL.md
@@ -97,14 +97,20 @@ for each question. Reach shared understanding before writing anything.
 
 ### 4b. Create the task branch
 
-**Do this before writing any files.** Freshen the slot to the latest
-`origin/main`, then create the task branch. All file writes (steps 5–7)
+**Do this before writing any files.** Ensure the worktree is synced to the
+latest `origin/main`, then create the task branch. All file writes (steps 5–7)
 happen on this branch so they are never at risk from a subsequent
 `git reset --hard`:
 
 ```bash
-FRESHEN="$HOME/.copilot/skills/manage-worktree/scripts/manage_worktree.sh"
-[ -f "$FRESHEN" ] && bash "$FRESHEN" freshen
+SCRIPT="$HOME/.copilot/skills/manage-worktree/scripts/manage_worktree.sh"
+if [ -f "$SCRIPT" ]; then
+  bash "$SCRIPT" ensure-synced || { echo "❌ Aborted — sync check failed." >&2; exit 1; }
+else
+  git fetch origin --quiet 2>/dev/null || true
+  BEHIND=$(git rev-list --count HEAD..origin/main 2>/dev/null || echo 0)
+  [ "$BEHIND" -gt 0 ] && { echo "❌ Aborted: $BEHIND commit(s) behind origin/main. Run: git rebase origin/main" >&2; exit 1; }
+fi
 git switch -c ingest/idea-<IDEA_NUMBER>-<slug>
 ```text
 

--- a/.agents/skills/learn/SKILL.md
+++ b/.agents/skills/learn/SKILL.md
@@ -31,7 +31,7 @@ entries that should be promoted into durable docs.
 
 ## Quick Start
 
-1. **Freshen** the worktree slot (before any writes): `manage_worktree.sh freshen`
+1. **Ensure synced** (before any writes): `manage_worktree.sh ensure-synced`
 2. Invoke `acquire-codebase-knowledge` — full scan, refreshes all 7 docs
    in `docs/reference/codebase/`.
 3. Read `plan/BUILD_LEARNINGS.md` and query GitHub for open `type:Concern`
@@ -43,7 +43,7 @@ entries that should be promoted into durable docs.
    Include GitHub Concern issue triage in this phase (no separate triage step
    needed).
 7. **Create the task branch**: `git switch -c learn/<YYYYMMDD>-<slug>`
-   (worktree was already freshened in step 1; branch here after slug is known)
+   (worktree was already synced in step 1; branch here after slug is known)
 8. Write to `specs/`, `notes/`, and `AGENTS.md`.
 9. Archive each processed BUILD_LEARNINGS entry and each resolved Concern issue
    via `uv run append-history learning`; delete BUILD_LEARNINGS entries from
@@ -55,14 +55,20 @@ entries that should be promoted into durable docs.
 
 ## Workflow
 
-### Phase 0 — Freshen and Refresh Codebase Knowledge
+### Phase 0 — Sync and Refresh Codebase Knowledge
 
-**First, freshen the worktree slot** (if running in a `wt/*` slot) so
-all subsequent writes land on a clean, up-to-date baseline:
+**First, ensure the worktree is synced to `origin/main`** before any file
+writes, so all subsequent changes land on an up-to-date baseline:
 
 ```bash
-FRESHEN="$HOME/.copilot/skills/manage-worktree/scripts/manage_worktree.sh"
-[ -f "$FRESHEN" ] && bash "$FRESHEN" freshen
+SCRIPT="$HOME/.copilot/skills/manage-worktree/scripts/manage_worktree.sh"
+if [ -f "$SCRIPT" ]; then
+  bash "$SCRIPT" ensure-synced || { echo "❌ Aborted — sync check failed." >&2; exit 1; }
+else
+  git fetch origin --quiet 2>/dev/null || true
+  BEHIND=$(git rev-list --count HEAD..origin/main 2>/dev/null || echo 0)
+  [ "$BEHIND" -gt 0 ] && { echo "❌ Aborted: $BEHIND commit(s) behind origin/main. Run: git rebase origin/main" >&2; exit 1; }
+fi
 ```text
 
 Do this **before** `acquire-codebase-knowledge` runs — the scan regenerates
@@ -143,7 +149,7 @@ Answer questions from codebase exploration where possible.
 git switch -c learn/<YYYYMMDD>-<slug>
 ```text
 
-The worktree was already freshened in Phase 0. All file writes (Phases 4–7)
+The worktree was already synced to `origin/main` in Phase 0. All file writes (Phases 4–7)
 happen on this branch so they are never at risk from a `git reset --hard`.
 
 ### Phase 4 — Refine Specifications (`specs/`)


### PR DESCRIPTION
## Summary

Replaces `freshen` with the new `ensure-synced` subcommand in all five
branch-creating skills: `build`, `bugfix`, `ingest-idea`, `ingest-concern`,
and `learn`.

## Problem

`freshen` silently skips sync when the current branch is not a `wt/*`
placeholder. If another worktree merges a PR to `main`, a slot that wasn't
properly reset could start a new task from stale code.

## Changes

- `build/SKILL.md`, `bugfix/SKILL.md`, `ingest-idea/SKILL.md`,
  `ingest-concern/SKILL.md`, `learn/SKILL.md`: call `ensure-synced`
  with a hard abort on failure, plus an inline behind-check fallback when
  the manage-worktree script is absent.

The `manage_worktree.sh` changes (new `ensure-synced` subcommand + `reset`
auto-detecting merged/closed PRs) live in `~/.copilot/skills/` which is
not version-controlled in this repo.