### PR TITLE
Document canonical FastAPI deployment entrypoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,11 @@ Agents MUST follow these rules when generating, modifying, or reviewing code.
   (`vultron/core/use_cases/`).
 - Use-Case Protocol: `__init__(dl, request)` + `execute() -> None`; routing
   is via `USE_CASE_MAP` key lookup, not per-handler decorators.
+- FastAPI deployment entrypoint: use
+  `vultron.adapters.driving.fastapi.main:app` for uvicorn/ASGI startup.
+  The mounted `app_v2` object in
+  `vultron.adapters.driving.fastapi.app` is for local test/dev patterns
+  (for example, isolated app-factory tests).
 - Tests: `uv run pytest --tb=short 2>&1 | tail -5` — run **once**, read output.
   See `.agents/skills/run-tests/SKILL.md` for the single-run rule and suite
   variants (unit / integration / all).

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ together to coordinate appropriate responses to vulnerabilities.
 
 Vultron is a collection of ideas, models, code, and work in progress, and is not yet ready for production use.
 
+## API entrypoint reference
+
+For uvicorn/ASGI deployment, use
+`vultron.adapters.driving.fastapi.main:app` as the canonical API entrypoint.
+The `app_v2` object in `vultron.adapters.driving.fastapi.app` is the mounted
+sub-application commonly used directly in local development and tests.
+
 ## Background and related work
 
 Vultron is a continuation of the [CERT/CC](https://www.sei.cmu.edu/about/divisions/cert/index.cfm)'s work on improving the coordination of vulnerability disclosure and response.

--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -22,3 +22,13 @@ The code-review agent identified two tree creation functions in receive_report_c
 - `.github/scripts/mkdocs-build-strict.sh` suppresses several known griffe
   false positives but still treats unknown-key warnings like `context` and
   `pytest` as real build failures.
+
+### 2026-06-02 ISSUE-518 — Entrypoint docs drift in demo-facing text
+
+- The canonical API deployment entrypoint is
+  `vultron.adapters.driving.fastapi.main:app`, but demo-facing text can drift
+  back to legacy module paths if not centrally referenced.
+- We found stale `vultron.api.main:app` strings in demo exchange script output
+  and notes. This task updated onboarding docs only; script help-text cleanup
+  remains a separate follow-up candidate if those strings become user-facing
+  blockers.

--- a/plan/history/2606/implementation/ISSUE-518.md
+++ b/plan/history/2606/implementation/ISSUE-518.md
@@ -1,0 +1,14 @@
+---
+source: ISSUE-518
+timestamp: '2026-06-02T18:30:59.028880+00:00'
+title: Document canonical FastAPI deployment entrypoint
+type: implementation
+---
+
+## Issue #518 — Document `vultron.adapters.driving.fastapi.main:app` as the canonical deployment entrypoint
+
+Documented `vultron.adapters.driving.fastapi.main:app` as the canonical uvicorn/ASGI deployment entrypoint and clarified that `app_v2` is the mounted sub-application used directly in local development and tests.
+
+Updated onboarding docs in `README.md`, `AGENTS.md`, and `vultron/demo/README.md` to keep startup guidance consistent.
+
+PR: <https://github.com/CERTCC/Vultron/pull/673>

--- a/vultron/demo/README.md
+++ b/vultron/demo/README.md
@@ -95,8 +95,13 @@ First install the package and start the API server:
 
 ```bash
 uv pip install -e .
-uv run uvicorn vultron.api.main:app --host localhost --port 7999 --reload
+uv run uvicorn vultron.adapters.driving.fastapi.main:app --host localhost --port 7999 --reload
 ```
+
+`vultron.adapters.driving.fastapi.main:app` is the canonical deployment
+entrypoint. `app_v2` in
+`vultron.adapters.driving.fastapi.app` is the mounted sub-app used directly
+in local dev/test patterns.
 
 Then in a separate terminal, run the unified CLI:
 


### PR DESCRIPTION
Closes #518\n\n## Summary\n- add explicit API entrypoint guidance to README\n- add AGENTS.md quickstart note distinguishing deployment entrypoint vs app_v2\n- update demo README local run command and note the same distinction