### PR TITLE
feat(CBT-03): implement bounded pre-bootstrap queue expiry and replay

### DIFF
--- a/plan/history/2606/implementation/ISSUE-500.md
+++ b/plan/history/2606/implementation/ISSUE-500.md
@@ -1,0 +1,42 @@
+---
+source: ISSUE-500
+timestamp: '2026-06-02T19:41:09.608578+00:00'
+title: 'CBT-03: bounded pre-bootstrap queue expiry and replay'
+type: implementation
+---
+
+## Issue #500 — CBT-03: Implement bounded pre-bootstrap queue expiry and replay
+
+Implemented configurable expiry for the `VultronPendingCaseInbox` pre-bootstrap
+queue so that CaseActor-originated activities held without a bootstrap
+`Create(VulnerabilityCase)` are dropped with a warning after a configurable
+timeout and a replay `Question` is sent to request re-bootstrap.
+
+### Changes
+
+- **`VultronPendingCaseInbox`**: added `queued_at` (UTC datetime,
+  `default_factory=_now_utc`) and `case_actor_id` (`UriString | None`)
+  fields to track queue age and originating CaseActor.
+- **`AppConfig`**: added `pre_bootstrap_queue_timeout_seconds` (default 300 s,
+  configurable via env var `VULTRON_PRE_BOOTSTRAP_QUEUE_TIMEOUT_SECONDS`).
+- **`factories/case.py`**: added `bootstrap_replay_question_activity()` factory
+  for the outbound replay `Question` (CBT-03-004 SHOULD); exported from
+  `factories/__init__.py`.
+- **`inbox_handler.py`**:
+  - `_expire_pending_case_activities()` — checks queue age, drops expired
+    queues with per-item WARNING logs, and emits a replay `Question`
+    (CBT-03-003 MUST, CBT-03-004 SHOULD).
+  - `_dispatch_or_defer_inbox_item()` — calls expiry check before queuing;
+    if expired, drops the triggering activity (resend-required semantics).
+  - `_replay_pending_case_activities()` — guards against late-arriving
+    bootstrap for an already-expired queue; accepts optional `actor_id` for
+    Question construction.
+- **Tests**: 3 new tests covering AC-5 (queued not dispatched), AC-6
+  (expiry drops + warns), AC-7 (expiry emits Question); all per CBT-05-003.
+
+### Outcome
+
+2557 unit tests pass. All linters clean (Black, flake8, mypy, pyright).
+Code reviewed by rubber-duck and code-review agents — no issues found.
+
+PR: [#674](https://github.com/CERTCC/Vultron/pull/674)

--- a/test/adapters/driving/fastapi/test_inbox_handler.py
+++ b/test/adapters/driving/fastapi/test_inbox_handler.py
@@ -334,3 +334,144 @@ def test_inbox_handler_replays_deferred_items_after_case_announce(monkeypatch):
 
     assert dispatched == [announce_id, note_id]
     assert queue_dl.read(VultronPendingCaseInbox.build_id(case_id)) is None
+
+
+# ---------------------------------------------------------------------------
+# CBT-03 / CBT-05-003: Pre-bootstrap queue expiry tests (issue #500)
+# ---------------------------------------------------------------------------
+
+
+def test_pre_bootstrap_activity_queued_not_dispatched(monkeypatch):
+    """AC-5: Pre-bootstrap CaseActor activities are queued but NOT dispatched.
+
+    Covers CBT-05-003 (first bullet): pre-bootstrap messages remain unapplied.
+    """
+    actor_id = "https://example.org/actors/reporter"
+    case_id = "https://example.org/cases/cbt-ac5"
+    activity_id = "https://example.org/activities/cbt-ac5-note"
+    shared_dl = SqliteDataLayer("sqlite:///:memory:")
+    queue_dl = shared_dl.clone_for_actor(actor_id)
+
+    item = as_Activity(
+        id_=activity_id,
+        type_="Add",
+        actor="https://example.org/actors/case-actor",
+        context=case_id,
+        name="pre-bootstrap-note",
+    )
+    fake_event = VultronEvent(
+        semantic_type=MessageSemantics.ADD_NOTE_TO_CASE,
+        activity_id=activity_id,
+        actor_id="https://example.org/actors/case-actor",
+    )
+    monkeypatch.setattr(
+        ih, "prepare_for_dispatch", lambda activity: fake_event
+    )
+    mock_dispatcher = Mock()
+    monkeypatch.setattr(ih, "_DISPATCHER", mock_dispatcher)
+
+    result = ih._dispatch_or_defer_inbox_item(
+        actor_id=actor_id,
+        obj=item,
+        dl=shared_dl,
+        queue_dl=queue_dl,
+    )
+
+    assert (
+        result is None
+    ), "Pre-bootstrap activity should be deferred, not dispatched"
+    mock_dispatcher.dispatch.assert_not_called()
+
+    pending = queue_dl.read(VultronPendingCaseInbox.build_id(case_id))
+    assert isinstance(pending, VultronPendingCaseInbox)
+    assert activity_id in pending.activity_ids
+    assert pending.case_actor_id == "https://example.org/actors/case-actor"
+
+
+def test_pending_case_queue_expires_drops_and_warns(monkeypatch, caplog):
+    """AC-6: Expired pre-bootstrap queue is dropped with a WARNING.
+
+    Covers CBT-05-003 (second bullet): expire safely.
+    """
+    import logging
+    from datetime import datetime, timedelta, timezone
+
+    actor_id = "https://example.org/actors/reporter"
+    case_id = "https://example.org/cases/cbt-ac6"
+    activity_id = "https://example.org/activities/cbt-ac6-note"
+    shared_dl = SqliteDataLayer("sqlite:///:memory:")
+    queue_dl = shared_dl.clone_for_actor(actor_id)
+
+    # Create a pending queue entry that is already "old" (queued 10 minutes ago)
+    old_time = datetime.now(timezone.utc) - timedelta(minutes=10)
+    pending = VultronPendingCaseInbox(
+        case_id=case_id,
+        activity_ids=[activity_id],
+        case_actor_id="https://example.org/actors/case-actor",
+    )
+    pending.queued_at = old_time
+    queue_dl.save(pending)
+
+    with caplog.at_level(logging.WARNING, logger="vultron"):
+        expired = ih._expire_pending_case_activities(
+            case_id=case_id,
+            actor_id=actor_id,
+            dl=shared_dl,
+            queue_dl=queue_dl,
+            timeout_seconds=60,  # 1 minute; queue is 10 minutes old
+        )
+
+    assert expired is True
+    assert queue_dl.read(VultronPendingCaseInbox.build_id(case_id)) is None
+    assert any("Dropping expired" in r.message for r in caplog.records)
+    assert any(activity_id in r.message for r in caplog.records)
+
+
+def test_pending_case_queue_expiry_emits_question(monkeypatch):
+    """AC-7: A replay Question is appended to the actor outbox on expiry.
+
+    Covers CBT-05-003 (third bullet): generate a replay request.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    actor_id = "https://example.org/actors/reporter"
+    case_id = "https://example.org/cases/cbt-ac7"
+    activity_id = "https://example.org/activities/cbt-ac7-note"
+    case_actor_id = "https://example.org/actors/case-actor"
+    shared_dl = SqliteDataLayer("sqlite:///:memory:")
+    queue_dl = shared_dl.clone_for_actor(actor_id)
+
+    old_time = datetime.now(timezone.utc) - timedelta(minutes=10)
+    pending = VultronPendingCaseInbox(
+        case_id=case_id,
+        activity_ids=[activity_id],
+        case_actor_id=case_actor_id,
+    )
+    pending.queued_at = old_time
+    queue_dl.save(pending)
+
+    expired = ih._expire_pending_case_activities(
+        case_id=case_id,
+        actor_id=actor_id,
+        dl=shared_dl,
+        queue_dl=queue_dl,
+        timeout_seconds=60,
+    )
+
+    assert expired is True
+
+    outbox = queue_dl.outbox_list()
+    assert (
+        len(outbox) == 1
+    ), "One Question should have been queued in the outbox"
+
+    question_id = outbox[0]
+    from vultron.wire.as2.vocab.base.objects.activities.intransitive import (
+        as_Question,
+    )
+
+    question = shared_dl.read(question_id)
+    assert isinstance(question, as_Question)
+    assert question.context == case_id
+    assert question.actor == actor_id
+    assert question.to == case_actor_id

--- a/vultron/adapters/driving/fastapi/inbox_handler.py
+++ b/vultron/adapters/driving/fastapi/inbox_handler.py
@@ -17,9 +17,12 @@ Vultron Actor Inbox Handler
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
 import logging
+from datetime import timezone
 from typing import Any, cast
 
+from vultron.config import get_config
 from vultron.core.models.pending_case_inbox import VultronPendingCaseInbox
+from vultron.wire.as2.factories.case import bootstrap_replay_question_activity
 from vultron.wire.as2.rehydration import rehydrate
 from vultron.core.dispatcher import get_dispatcher
 from vultron.core.models.events import MessageSemantics, VultronEvent
@@ -254,9 +257,16 @@ def _activity_context_id(
 
 
 def _queue_pending_case_activity(
-    queue_dl: DataLayer, case_id: str, activity_id: str
+    queue_dl: DataLayer,
+    case_id: str,
+    activity_id: str,
+    case_actor_id: str | None = None,
 ) -> None:
-    """Persist *activity_id* in the deferred queue for *case_id*."""
+    """Persist *activity_id* in the deferred queue for *case_id*.
+
+    Records *case_actor_id* on the first write so that the expiry handler
+    knows where to send a replay ``Question`` (CBT-03-004).
+    """
     pending_id = VultronPendingCaseInbox.build_id(case_id)
     pending = queue_dl.read(pending_id)
     if isinstance(pending, VultronPendingCaseInbox):
@@ -267,20 +277,162 @@ def _queue_pending_case_activity(
         return
 
     queue_dl.save(
-        VultronPendingCaseInbox(case_id=case_id, activity_ids=[activity_id])
+        VultronPendingCaseInbox(
+            case_id=case_id,
+            activity_ids=[activity_id],
+            case_actor_id=case_actor_id,
+        )
     )
 
 
+def _expire_pending_case_activities(
+    case_id: str,
+    actor_id: str,
+    dl: DataLayer,
+    queue_dl: DataLayer,
+    timeout_seconds: int | None = None,
+) -> bool:
+    """Drop an expired pre-bootstrap queue and emit a replay ``Question``.
+
+    Checks whether the ``VultronPendingCaseInbox`` for *case_id* has been
+    held for longer than *timeout_seconds* (defaults to
+    ``AppConfig.pre_bootstrap_queue_timeout_seconds``).  When expired:
+
+    1. Logs a WARNING for each dropped activity ID (CBT-03-003).
+    2. Deletes the queue record.
+    3. Emits a ``Question`` to the recorded ``case_actor_id`` asking for
+       the bootstrap ``Create(VulnerabilityCase)`` to be resent
+       (CBT-03-004, SHOULD).
+
+    Args:
+        case_id: URI of the case whose pending queue should be checked.
+        actor_id: Canonical URI of the receiving actor (Question sender).
+        dl: Shared DataLayer used to save the outbound Question.
+        queue_dl: Actor-scoped DataLayer used to read/delete the queue
+            and enqueue the outbound Question.
+        timeout_seconds: Expiry window in seconds.  ``None`` reads from
+            ``get_config().pre_bootstrap_queue_timeout_seconds``.
+
+    Returns:
+        ``True`` if the queue was expired and dropped; ``False`` if the
+        queue is still within the window or does not exist.
+
+    Trigger: this check is called on inbox receipt so that any inbound
+    activity for a pending case triggers expiry cleanup (AC-4).  Cold
+    queues (no subsequent traffic) are reclaimed when bootstrap or a new
+    activity arrives.
+    """
+    from datetime import datetime
+
+    if timeout_seconds is None:
+        timeout_seconds = get_config().pre_bootstrap_queue_timeout_seconds
+
+    pending_id = VultronPendingCaseInbox.build_id(case_id)
+    pending = queue_dl.read(pending_id)
+    if not isinstance(pending, VultronPendingCaseInbox):
+        return False
+
+    now = datetime.now(timezone.utc)
+    queued_at = pending.queued_at
+    if queued_at.tzinfo is None:
+        queued_at = queued_at.replace(tzinfo=timezone.utc)
+    age_seconds = (now - queued_at).total_seconds()
+    if age_seconds < timeout_seconds:
+        return False
+
+    for activity_id in pending.activity_ids:
+        logger.warning(
+            "Dropping expired pre-bootstrap activity '%s' for case '%s' "
+            "(age %.0fs > timeout %ds) — resend required after bootstrap "
+            "(CBT-03-003)",
+            activity_id,
+            case_id,
+            age_seconds,
+            timeout_seconds,
+        )
+    queue_dl.delete("PendingCaseInbox", pending_id)
+    logger.warning(
+        "Pre-bootstrap queue for case '%s' expired after %.0fs; "
+        "%d activity ID(s) dropped",
+        case_id,
+        age_seconds,
+        len(pending.activity_ids),
+    )
+
+    if pending.case_actor_id:
+        try:
+            question = bootstrap_replay_question_activity(
+                actor=actor_id,
+                to=pending.case_actor_id,
+                case_id=case_id,
+            )
+            dl.save(question)
+            queue_dl.outbox_append(question.id_)
+            logger.info(
+                "Sent bootstrap replay Question '%s' to '%s' for case '%s'",
+                question.id_,
+                pending.case_actor_id,
+                case_id,
+            )
+        except Exception:
+            logger.warning(
+                "Could not construct replay Question for case '%s'; "
+                "manual intervention required (CBT-03-004)",
+                case_id,
+                exc_info=True,
+            )
+    else:
+        logger.warning(
+            "No case_actor_id recorded for case '%s'; "
+            "cannot send replay Question (CBT-03-004)",
+            case_id,
+        )
+
+    return True
+
+
 def _replay_pending_case_activities(
-    case_id: str, dl: DataLayer, queue_dl: DataLayer
+    case_id: str,
+    dl: DataLayer,
+    queue_dl: DataLayer,
+    actor_id: str | None = None,
 ) -> None:
-    """Move deferred activities for *case_id* back onto the live inbox queue."""
+    """Move deferred activities for *case_id* back onto the live inbox queue.
+
+    Before replaying, checks whether the pending queue has expired.  If it
+    has, the queue is dropped instead of replayed (CBT-03-003).  This
+    handles the case where bootstrap arrives after the expiry window — the
+    bootstrap itself is accepted, but the stale queued items are discarded.
+
+    Args:
+        case_id: URI of the case whose pending queue should be drained.
+        dl: Shared DataLayer used for case lookup and Question persistence.
+        queue_dl: Actor-scoped DataLayer for queue management.
+        actor_id: Canonical URI of the receiving actor, used when building
+            a replay Question on expiry.  Defaults to ``""`` when not
+            provided (best-effort; expiry Warning is still logged).
+    """
     if not is_case_model(dl.read(case_id)):
         return
 
     pending_id = VultronPendingCaseInbox.build_id(case_id)
     pending = queue_dl.read(pending_id)
     if not isinstance(pending, VultronPendingCaseInbox):
+        return
+
+    if _expire_pending_case_activities(
+        case_id=case_id,
+        actor_id=actor_id or "",
+        dl=dl,
+        queue_dl=queue_dl,
+    ):
+        logger.warning(
+            "Bootstrap arrived for case '%s' but pre-bootstrap queue had "
+            "already expired; dropped %d activity ID(s) — a fresh "
+            "re-delivery is required",
+            case_id,
+            len(pending.activity_ids),
+        )
         return
 
     for activity_id in pending.activity_ids:
@@ -300,7 +452,14 @@ def _dispatch_or_defer_inbox_item(
     queue_dl: DataLayer,
     dispatcher: ActivityDispatcher | None = None,
 ) -> VultronEvent | None:
-    """Dispatch an inbox item or defer it until its case replica exists."""
+    """Dispatch an inbox item or defer it until its case replica exists.
+
+    When deferring, first checks whether the existing pending queue for
+    this case has expired.  If the queue has expired, the existing items
+    are dropped, a replay ``Question`` is emitted, and the new item is
+    also dropped (resend-required semantics, CBT-03-003).  If within the
+    window, the item is appended to the existing queue as before.
+    """
     event = prepare_for_dispatch(activity=obj)
     event = event.model_copy(update={"receiving_actor_id": actor_id})
 
@@ -310,12 +469,32 @@ def _dispatch_or_defer_inbox_item(
         and event.semantic_type != MessageSemantics.ANNOUNCE_VULNERABILITY_CASE
         and not is_case_model(dl.read(case_id))
     ):
+        expired = _expire_pending_case_activities(
+            case_id=case_id,
+            actor_id=actor_id,
+            dl=dl,
+            queue_dl=queue_dl,
+        )
+        if expired:
+            logger.warning(
+                "Activity '%s' for expired case queue '%s' dropped — "
+                "resend required after new bootstrap",
+                event.activity_id,
+                case_id,
+            )
+            return None
+
         logger.warning(
             "Unknown case context '%s' for activity '%s' — queuing for replay",
             case_id,
             event.activity_id,
         )
-        _queue_pending_case_activity(queue_dl, case_id, event.activity_id)
+        _queue_pending_case_activity(
+            queue_dl,
+            case_id,
+            event.activity_id,
+            case_actor_id=event.actor_id,
+        )
         return None
 
     dispatch(event=event, dl=dl, dispatcher=dispatcher)
@@ -365,7 +544,9 @@ def _process_inbox_item(
                 == MessageSemantics.ANNOUNCE_VULNERABILITY_CASE
                 and case_id is not None
             ):
-                _replay_pending_case_activities(case_id, dl, queue_dl)
+                _replay_pending_case_activities(
+                    case_id, dl, queue_dl, actor_id=canonical_actor_id
+                )
         return True
     except Exception as e:
         logger.error(

--- a/vultron/config.py
+++ b/vultron/config.py
@@ -161,11 +161,19 @@ class AppConfig(BaseSettings):
         server: HTTP server settings.
         database: Database connection settings.
         mode: Operational mode (``prototype`` or ``prod``).
+        pre_bootstrap_queue_timeout_seconds: How long (in seconds) a
+            pre-bootstrap inbox queue is held before it expires.  When the
+            window lapses, queued activity IDs are dropped and a replay
+            ``Question`` is sent to the case creator (CBT-03-003,
+            CBT-03-004).  Override via
+            ``VULTRON_PRE_BOOTSTRAP_QUEUE_TIMEOUT_SECONDS``.  Defaults to
+            300 (5 minutes).
     """
 
     server: ServerConfig = ServerConfig()
     database: DatabaseConfig = DatabaseConfig()
     mode: RunMode = RunMode.PROTOTYPE
+    pre_bootstrap_queue_timeout_seconds: int = 300
 
     model_config = SettingsConfigDict(
         env_prefix="VULTRON_",

--- a/vultron/core/models/pending_case_inbox.py
+++ b/vultron/core/models/pending_case_inbox.py
@@ -17,15 +17,21 @@
 from __future__ import annotations
 
 import urllib.parse
+from datetime import datetime
 from typing import Literal
 
 from pydantic import Field, model_validator
 
+from vultron.core.models._helpers import _now_utc
 from vultron.core.models.base import UriString, VultronObject
 
 
 class VultronPendingCaseInbox(VultronObject):
-    """Store deferred inbox activity IDs keyed by case ID."""
+    """Store deferred inbox activity IDs keyed by case ID.
+
+    Tracks when the queue was created (``queued_at``) so that a bounded
+    expiry window can be enforced (CBT-03-001, CBT-03-003).
+    """
 
     type_: Literal["PendingCaseInbox"] = Field(  # type: ignore[assignment]
         default="PendingCaseInbox",
@@ -36,6 +42,18 @@ class VultronPendingCaseInbox(VultronObject):
     activity_ids: list[UriString] = Field(
         default_factory=list,
         description="Deferred inbox activity IDs awaiting the case replica",
+    )
+    queued_at: datetime = Field(
+        default_factory=_now_utc,
+        description="UTC timestamp when the first activity was queued for this case",
+    )
+    case_actor_id: UriString | None = Field(
+        default=None,
+        description=(
+            "URI of the actor that sent the first pre-bootstrap activity. "
+            "Used as the replay-request target when bootstrap times out "
+            "(CBT-03-004)."
+        ),
     )
 
     @classmethod

--- a/vultron/wire/as2/factories/__init__.py
+++ b/vultron/wire/as2/factories/__init__.py
@@ -35,6 +35,7 @@ from vultron.wire.as2.factories.case import (
     add_report_to_case_activity,
     add_status_to_case_activity,
     announce_vulnerability_case_activity,
+    bootstrap_replay_question_activity,
     create_case_activity,
     create_case_status_activity,
     offer_case_manager_role_activity,

--- a/vultron/wire/as2/factories/case.py
+++ b/vultron/wire/as2/factories/case.py
@@ -28,6 +28,9 @@ from typing import cast
 from pydantic import ValidationError
 
 from vultron.wire.as2.factories.errors import VultronActivityConstructionError
+from vultron.wire.as2.vocab.base.objects.activities.intransitive import (
+    as_Question,
+)
 from vultron.wire.as2.vocab.activities.case import (
     _AcceptCaseManagerRoleActivity,
     _AcceptCaseOwnershipTransferActivity,
@@ -717,4 +720,51 @@ def announce_vulnerability_case_activity(
         )
         raise VultronActivityConstructionError(
             "announce_vulnerability_case_activity: invalid arguments"
+        ) from exc
+
+
+def bootstrap_replay_question_activity(
+    actor: str,
+    to: str,
+    case_id: str,
+    **kwargs,
+) -> as_Question:
+    """Build a Question requesting replay of the bootstrap Create(VulnerabilityCase).
+
+    Sent by the receiving actor to the (suspected) case creator when the
+    pre-bootstrap inbox queue expires without a valid bootstrap arriving
+    (CBT-03-004).
+
+    Args:
+        actor: URI of the actor sending the Question (the one waiting for
+            bootstrap).
+        to: URI of the actor that should resend the bootstrap (the case
+            creator / original report receiver).
+        case_id: URI of the case whose bootstrap is being requested.
+        **kwargs: Optional AS2 fields forwarded to the constructor
+            (e.g. ``name``).
+
+    Returns:
+        An ``as_Question`` whose ``context`` is the case URI.
+
+    Raises:
+        VultronActivityConstructionError: If Pydantic validation fails.
+    """
+    try:
+        return as_Question(
+            actor=actor,
+            to=to,
+            context=case_id,
+            name=kwargs.pop(
+                "name",
+                f"Please resend bootstrap Create(VulnerabilityCase) for {case_id}",
+            ),
+            **kwargs,
+        )
+    except ValidationError as exc:
+        logger.warning(
+            "bootstrap_replay_question_activity: invalid arguments: %s", exc
+        )
+        raise VultronActivityConstructionError(
+            "bootstrap_replay_question_activity: invalid arguments"
         ) from exc


### PR DESCRIPTION
## Summary

Implements CBT-03 (issue 500): bounded expiry for the pre-bootstrap pending
case inbox queue.

## Changes

- **VultronPendingCaseInbox**: add queued_at (UTC datetime) and case_actor_id fields
- **AppConfig**: add pre_bootstrap_queue_timeout_seconds (default 300s)
- **factories/case.py**: add bootstrap_replay_question_activity() factory (CBT-03-004 SHOULD)
- **inbox_handler.py**:
  - _expire_pending_case_activities() drops expired queues with WARNING logs + emits replay Question
  - _dispatch_or_defer_inbox_item() checks expiry before queuing; drops triggering activity if expired
  - _replay_pending_case_activities() guards against late bootstrap for expired queue
- **Tests**: 3 new tests for AC-5 (queued not dispatched), AC-6 (drops+warns), AC-7 (emits Question)

## Validation

- 2557 unit tests pass, all linters clean (Black, flake8, mypy, pyright)
- Code reviewed by rubber-duck and code-review agents

Closes #500