### PR TITLE
Prevent status self-broadcast loops

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -32,3 +32,10 @@ The code-review agent identified two tree creation functions in receive_report_c
   and notes. This task updated onboarding docs only; script help-text cleanup
   remains a separate follow-up candidate if those strings become user-facing
   blockers.
+
+### 2026-06-02 ISSUE-663 — Case-actor-only broadcast guard
+
+- `BroadcastStatusToPeersNode` needs the current executing actor to match the
+  Case Manager before it should fan out participant status updates.
+- Tests for the positive broadcast path need a third participant so the case
+  manager has at least one non-sender peer to address.

--- a/plan/history/2606/implementation/ISSUE-663.md
+++ b/plan/history/2606/implementation/ISSUE-663.md
@@ -1,0 +1,12 @@
+---
+source: ISSUE-663
+timestamp: '2026-06-02T20:06:57.732305+00:00'
+title: Prevent status self-broadcast loops
+type: implementation
+---
+
+## Issue #663 — BroadcastStatusToPeersNode: participants re-broadcast to themselves (self-loop)
+
+Fixed `BroadcastStatusToPeersNode` so the current actor is excluded from the recipient list, preventing participant self-broadcast loops while preserving normal fan-out to other peers.
+
+PR: [#677](https://github.com/CERTCC/Vultron/pull/677)

--- a/test/core/behaviors/status/test_add_participant_status_bt.py
+++ b/test/core/behaviors/status/test_add_participant_status_bt.py
@@ -25,6 +25,8 @@ Covers all five DEMOMA-07-003 steps:
 Per specs/multi-actor-demo.yaml DEMOMA-07-003.
 """
 
+from unittest.mock import MagicMock
+
 import py_trees
 import pytest
 from py_trees.common import Status
@@ -336,6 +338,74 @@ class TestBroadcastStatusToPeersNode:
         )
         result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
         assert result.status == Status.SUCCESS
+
+    def test_skips_when_current_actor_is_the_only_peer(self, populated_dl):
+        trigger_activity = MagicMock()
+        peer_actor_id = "https://example.org/actors/finder"
+        peer_participant_id = (
+            "https://example.org/cases/case-01/participants/finder"
+        )
+        peer_participant = CaseParticipant(
+            id_=peer_participant_id,
+            context=CASE_ID,
+            attributed_to=peer_actor_id,
+            case_roles=[CVDRole.FINDER],
+        )
+        populated_dl.create(peer_participant)
+        case = populated_dl.read(CASE_ID)
+        assert case is not None
+        case.actor_participant_index[peer_actor_id] = peer_participant_id
+        populated_dl.save(case)
+        bridge = BTBridge(
+            datalayer=populated_dl, trigger_activity=trigger_activity
+        )
+        node = BroadcastStatusToPeersNode(
+            status_id=STATUS_ID,
+            participant_id=PARTICIPANT_ID,
+            sender_actor_id=ACTOR_ID,
+            case_id=CASE_ID,
+        )
+        result = bridge.execute_with_setup(tree=node, actor_id=peer_actor_id)
+        assert result.status == Status.SUCCESS
+        trigger_activity.add_participant_status_to_participant.assert_not_called()
+
+    def test_broadcasts_from_case_manager_only(self, populated_dl):
+        trigger_activity = MagicMock()
+        trigger_activity.add_participant_status_to_participant.return_value = (
+            "urn:uuid:activity-1"
+        )
+        peer_actor_id = "https://example.org/actors/finder"
+        peer_participant_id = (
+            "https://example.org/cases/case-01/participants/finder"
+        )
+        peer_participant = CaseParticipant(
+            id_=peer_participant_id,
+            context=CASE_ID,
+            attributed_to=peer_actor_id,
+            case_roles=[CVDRole.FINDER],
+        )
+        populated_dl.create(peer_participant)
+        case = populated_dl.read(CASE_ID)
+        assert case is not None
+        case.actor_participant_index[peer_actor_id] = peer_participant_id
+        populated_dl.save(case)
+        bridge = BTBridge(
+            datalayer=populated_dl, trigger_activity=trigger_activity
+        )
+        node = BroadcastStatusToPeersNode(
+            status_id=STATUS_ID,
+            participant_id=PARTICIPANT_ID,
+            sender_actor_id=ACTOR_ID,
+            case_id=CASE_ID,
+        )
+        result = bridge.execute_with_setup(tree=node, actor_id=CASE_MANAGER_ID)
+        assert result.status == Status.SUCCESS
+        trigger_activity.add_participant_status_to_participant.assert_called_once_with(
+            status_id=STATUS_ID,
+            participant_id=PARTICIPANT_ID,
+            actor=CASE_MANAGER_ID,
+            to=[peer_actor_id],
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/vultron/core/behaviors/status/nodes.py
+++ b/vultron/core/behaviors/status/nodes.py
@@ -283,10 +283,10 @@ class AppendParticipantStatusNode(DataLayerAction):
 class BroadcastStatusToPeersNode(DataLayerAction):
     """Step 3: Broadcast Add(ParticipantStatus, CaseParticipant) to peers.
 
-    The Case Manager re-sends the status update to all other participants
-    (excluding the original sender).  Skips silently when no
-    ``trigger_activity_factory`` is available or when there are no eligible
-    recipients.
+    The current actor re-sends the status update to all other participants,
+    excluding the original sender, itself, and the Case Manager. Skips
+    silently when no ``trigger_activity_factory`` is available or when there
+    are no eligible recipients.
 
     Always returns SUCCESS (failure to broadcast is not fatal).
 
@@ -342,7 +342,11 @@ class BroadcastStatusToPeersNode(DataLayerAction):
         recipient_ids = [
             a_id
             for a_id in case.actor_participant_index.keys()
-            if a_id != self.sender_actor_id and a_id != case_manager_id
+            if (
+                a_id != self.sender_actor_id
+                and a_id != self.actor_id
+                and a_id != case_manager_id
+            )
         ]
         if not recipient_ids:
             self.logger.debug(


### PR DESCRIPTION
Closes #663

## Problem

When a participant (non-Case Manager) received an incoming `Add(ParticipantStatus)`
activity, `BroadcastStatusToPeersNode` re-broadcast the update to all other case
actors — including itself. This created a same-actor message loop visible in two-actor
demo CI runs (finder re-broadcasting to `finder_actor` in addition to the intended
peers). While idempotency prevented data corruption, the self-loop drove extra inbox
processing and obscured log analysis.

**Root cause:** the recipient-exclusion filter only removed the original sender and the
Case Manager; it did not exclude the actor currently executing the BT node.

## Fix

Add `self.actor_id` to the exclusion filter in `BroadcastStatusToPeersNode.update()`:

```python
recipient_ids = [
    a_id
    for a_id in case.actor_participant_index.keys()
    if (
        a_id != self.sender_actor_id
        and a_id != self.actor_id          # ← new: exclude self
        and a_id != case_manager_id
    )
]
```

This is a minimal, targeted change that does not alter the broadcast path — the
node still fans out normally to all other eligible peers.

## Tests added

- `test_skips_when_current_actor_is_the_only_peer` — verifies a non-sender
  participant receives no broadcast when it would be the only remaining recipient
  after self-exclusion.
- `test_broadcasts_from_case_manager_only` — verifies the Case Manager still
  fans out to all non-sender, non-self peers (regression guard).

## Notes

The initial implementation used an actor-must-be-Case-Manager gate, which would
have silently blocked broadcasts in the normal received-handler path (where
`actor_id` is the incoming message sender, not the Case Manager). That approach
was caught by the pre-PR code review and corrected to the recipient-list exclusion
approach above.

Per `notes/case-communication-model.md` PCR-08-001 / PCR-08-002.