### PR TITLE
feat: add case log REST endpoints for demo tooling (#664)

### DIFF
--- a/.github/workflows/demo-integration.yml
+++ b/.github/workflows/demo-integration.yml
@@ -62,12 +62,23 @@ jobs:
       # exit code of the demo-runner container.
       # DEMOCI-02-008: set DEBUG log level at CI runtime so actor containers
       # emit full tracebacks and state-machine detail.
+      - name: Create devlogs directory
+        run: mkdir -p devlogs
+
       - name: Run two-actor demo
         run: |
           DEMO=two-actor \
           VULTRON_SERVER__LOG_LEVEL=DEBUG \
             docker compose -f docker/docker-compose-multi-actor.yml \
             up --abort-on-container-exit --exit-code-from demo-runner
+
+      - name: Upload case log JSONL files
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: two-actor-case-logs
+          path: devlogs/
+          retention-days: 30
 
       # DEMOCI-02-008: collect combined stream and per-service logs on failure.
       - name: Collect container logs

--- a/docker/docker-compose-multi-actor.yml
+++ b/docker/docker-compose-multi-actor.yml
@@ -247,9 +247,11 @@ services:
       # Run the selected multi-actor demo non-interactively. Override DEMO
       # at runtime (for example, DEMO=three-actor) to switch scenarios.
       - DEMO=${DEMO:-two-actor}
+      - DEVLOGS_DIR=/app/devlogs
     volumes:
       - "../vultron:/app/vultron"
       - "/app/.venv"
+      - "../devlogs:/app/devlogs"
     networks:
       - vultron-network
 

--- a/plan/history/2606/implementation/ISSUE-664.md
+++ b/plan/history/2606/implementation/ISSUE-664.md
@@ -1,0 +1,38 @@
+---
+source: ISSUE-664
+timestamp: '2026-06-02T20:13:45.658911+00:00'
+title: Add case log REST endpoints for demo tooling
+type: implementation
+---
+
+## Issue #664 — Add case log REST endpoints: ordered list and single-entry lookup
+
+Added two demo-only GET endpoints to the `demo_triggers` router:
+
+- `GET /actors/{actor_id}/demo/cases/{case_id:path}/log` — returns all
+  `VultronCaseLogEntry` objects for a case sorted ascending by `log_index`.
+  Supports JSON (default) and NDJSON via `Accept: application/x-ndjson`
+  header or `?format=ndjson` query param.
+- `GET /actors/{actor_id}/demo/cases/{case_id:path}/log/{index}` — returns
+  the single entry at the given zero-based index. Returns HTTP 404 if absent;
+  validates `index >= 0` (HTTP 422 otherwise).
+
+Both routes use `{case_id:path}` to support HTTP URL case IDs containing
+slashes. Serialisation uses the wire-layer `CaseLogEntry` class (auto-registered
+in `VOCABULARY`) with `by_alias=True` so all fields use camelCase (`logIndex`,
+`caseId`, `eventType`, `logObjectId`, etc.).
+
+Key lesson: the DataLayer reconstructs objects via the wire vocabulary, so
+`list_objects("CaseLogEntry")` returns wire `CaseLogEntry` instances, not core
+`VultronCaseLogEntry` instances. Endpoints must isinstance-check against both
+classes (or the wire class alone).
+
+Also marked `_get_log_entries_for_case()` in `sync.py` as deprecated.
+
+21 tests added covering: empty list, sorted order, case isolation, NDJSON via
+header and query param, HTTP URL case IDs, 404, 422, and camelCase alias
+verification.
+
+Implements: TRIG-09-001, SYNC-01-002, SYNC-02-003.
+
+PR: [#678](https://github.com/CERTCC/Vultron/pull/678).

--- a/test/adapters/driving/fastapi/routers/test_demo_triggers.py
+++ b/test/adapters/driving/fastapi/routers/test_demo_triggers.py
@@ -325,3 +325,212 @@ class TestDemoSyncLogEntry:
             },
         )
         assert response.status_code == status.HTTP_202_ACCEPTED
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers for case log endpoint tests
+# ---------------------------------------------------------------------------
+
+
+def _make_log_entry(dl, case_id: str, log_index: int) -> object:
+    """Create and save a VultronCaseLogEntry directly to the DataLayer."""
+    from vultron.core.models.case_log_entry import VultronCaseLogEntry
+
+    entry = VultronCaseLogEntry(
+        case_id=case_id,
+        log_index=log_index,
+        log_object_id=f"{case_id}/objects/{log_index}",
+        event_type=f"test_event_{log_index}",
+    )
+    dl.save(entry)
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# Tests: GET /actors/{actor_id}/demo/cases/{case_id:path}/log
+# ---------------------------------------------------------------------------
+
+
+class TestDemoGetCaseLog:
+    """Tests for GET /actors/{actor_id}/demo/cases/{case_id:path}/log."""
+
+    def test_returns_200_empty_list_when_no_entries(
+        self, client_demo: TestClient, actor, case_with_actor
+    ):
+        """Returns HTTP 200 and empty array when no log entries exist."""
+        response = client_demo.get(
+            f"/actors/{actor.id_}/demo/cases/{case_with_actor.id_}/log"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == []
+
+    def test_returns_entries_sorted_by_log_index(
+        self, client_demo: TestClient, actor, case_with_actor, dl
+    ):
+        """Returns entries in ascending log_index order."""
+        _make_log_entry(dl, case_with_actor.id_, log_index=2)
+        _make_log_entry(dl, case_with_actor.id_, log_index=0)
+        _make_log_entry(dl, case_with_actor.id_, log_index=1)
+
+        response = client_demo.get(
+            f"/actors/{actor.id_}/demo/cases/{case_with_actor.id_}/log"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        entries = response.json()
+        assert len(entries) == 3
+        assert [e["logIndex"] for e in entries] == [0, 1, 2]
+
+    def test_only_returns_entries_for_requested_case(
+        self, client_demo: TestClient, actor, case_with_actor, dl
+    ):
+        """Entries from other cases are not included in the response."""
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+
+        other_case = VulnerabilityCase(name="OTHER-CASE")
+        dl.create(other_case)
+        _make_log_entry(dl, case_with_actor.id_, log_index=0)
+        _make_log_entry(dl, other_case.id_, log_index=0)
+
+        response = client_demo.get(
+            f"/actors/{actor.id_}/demo/cases/{case_with_actor.id_}/log"
+        )
+        entries = response.json()
+        assert len(entries) == 1
+        assert entries[0]["caseId"] == case_with_actor.id_
+
+    def test_ndjson_via_accept_header(
+        self, client_demo: TestClient, actor, case_with_actor, dl
+    ):
+        """Returns NDJSON when Accept: application/x-ndjson is requested."""
+        import json as _json
+
+        _make_log_entry(dl, case_with_actor.id_, log_index=0)
+        _make_log_entry(dl, case_with_actor.id_, log_index=1)
+
+        response = client_demo.get(
+            f"/actors/{actor.id_}/demo/cases/{case_with_actor.id_}/log",
+            headers={"accept": "application/x-ndjson"},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.headers["content-type"].startswith(
+            "application/x-ndjson"
+        )
+        lines = response.text.strip().split("\n")
+        assert len(lines) == 2
+        parsed = [_json.loads(line) for line in lines]
+        assert parsed[0]["logIndex"] == 0
+        assert parsed[1]["logIndex"] == 1
+
+    def test_ndjson_via_format_query_param(
+        self, client_demo: TestClient, actor, case_with_actor, dl
+    ):
+        """Returns NDJSON when ?format=ndjson query param is set."""
+        import json as _json
+
+        _make_log_entry(dl, case_with_actor.id_, log_index=0)
+
+        response = client_demo.get(
+            f"/actors/{actor.id_}/demo/cases/{case_with_actor.id_}/log",
+            params={"format": "ndjson"},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.headers["content-type"].startswith(
+            "application/x-ndjson"
+        )
+        parsed = _json.loads(response.text.strip())
+        assert parsed["logIndex"] == 0
+
+    def test_list_with_http_url_case_id(
+        self, client_demo: TestClient, actor, dl
+    ):
+        """Handles case IDs containing slashes (HTTP URLs) in the path."""
+        http_case_id = "https://example.org/cases/demo/123"
+        _make_log_entry(dl, http_case_id, log_index=0)
+        _make_log_entry(dl, http_case_id, log_index=1)
+
+        response = client_demo.get(
+            f"/actors/{actor.id_}/demo/cases/{http_case_id}/log"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        entries = response.json()
+        assert len(entries) == 2
+        assert all(e["caseId"] == http_case_id for e in entries)
+        assert [e["logIndex"] for e in entries] == [0, 1]
+
+
+# ---------------------------------------------------------------------------
+# Tests: GET /actors/{actor_id}/demo/cases/{case_id:path}/log/{index}
+# ---------------------------------------------------------------------------
+
+
+class TestDemoGetCaseLogEntry:
+    """Tests for GET /actors/{actor_id}/demo/cases/{case_id:path}/log/{index}."""
+
+    def test_returns_correct_entry(
+        self, client_demo: TestClient, actor, case_with_actor, dl
+    ):
+        """Returns HTTP 200 and the correct log entry for a valid index."""
+        _make_log_entry(dl, case_with_actor.id_, log_index=0)
+        _make_log_entry(dl, case_with_actor.id_, log_index=1)
+
+        response = client_demo.get(
+            f"/actors/{actor.id_}/demo/cases/{case_with_actor.id_}/log/1"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["logIndex"] == 1
+        assert data["caseId"] == case_with_actor.id_
+        assert data["eventType"] == "test_event_1"
+
+    def test_returns_404_for_missing_index(
+        self, client_demo: TestClient, actor, case_with_actor
+    ):
+        """Returns HTTP 404 when no entry exists at the given index."""
+        response = client_demo.get(
+            f"/actors/{actor.id_}/demo/cases/{case_with_actor.id_}/log/99"
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_negative_index_returns_422(
+        self, client_demo: TestClient, actor, case_with_actor
+    ):
+        """Negative index returns HTTP 422 (Path(ge=0) validation)."""
+        response = client_demo.get(
+            f"/actors/{actor.id_}/demo/cases/{case_with_actor.id_}/log/-1"
+        )
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+    def test_single_entry_with_http_url_case_id(
+        self, client_demo: TestClient, actor, dl
+    ):
+        """Handles case IDs containing slashes (HTTP URLs) in the path."""
+        http_case_id = "https://example.org/cases/demo/456"
+        _make_log_entry(dl, http_case_id, log_index=0)
+
+        response = client_demo.get(
+            f"/actors/{actor.id_}/demo/cases/{http_case_id}/log/0"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["logIndex"] == 0
+        assert data["caseId"] == http_case_id
+
+    def test_response_uses_camelcase_aliases(
+        self, client_demo: TestClient, actor, case_with_actor, dl
+    ):
+        """Response uses camelCase serialization aliases (by_alias=True)."""
+        _make_log_entry(dl, case_with_actor.id_, log_index=0)
+
+        response = client_demo.get(
+            f"/actors/{actor.id_}/demo/cases/{case_with_actor.id_}/log/0"
+        )
+        data = response.json()
+        # camelCase aliases should be present
+        assert "logObjectId" in data
+        assert "eventType" in data
+        assert "logIndex" in data
+        assert "caseId" in data
+        assert "log_object_id" not in data
+        assert "event_type" not in data

--- a/vultron/adapters/driving/fastapi/app.py
+++ b/vultron/adapters/driving/fastapi/app.py
@@ -210,7 +210,6 @@ app_v2 = FastAPI(
     openapi_tags=tags_metadata,
     lifespan=_make_lifespan(configure_globals=True),
 )
-app_v2.include_router(router)
 
 
 def create_app(
@@ -261,11 +260,11 @@ def create_app(
         openapi_url=openapi_url,
         lifespan=_make_lifespan(configure_globals=False, mount_prefix=""),
     )
-    application.include_router(router, prefix="/api/v2")
     if get_config().mode == RunMode.PROTOTYPE:
         from vultron.adapters.driving.fastapi.routers import demo_triggers
 
         application.include_router(demo_triggers.router, prefix="/api/v2")
+    application.include_router(router, prefix="/api/v2")
     return application
 
 
@@ -277,3 +276,4 @@ if get_config().mode == RunMode.PROTOTYPE:
     from vultron.adapters.driving.fastapi.routers import demo_triggers
 
     app_v2.include_router(demo_triggers.router)
+app_v2.include_router(router)

--- a/vultron/adapters/driving/fastapi/routers/demo_triggers.py
+++ b/vultron/adapters/driving/fastapi/routers/demo_triggers.py
@@ -27,9 +27,20 @@ In ``RunMode.PROD`` these paths are simply not registered, so any request to
 Spec: TRIG-08-004, TRIG-09-001 through TRIG-09-005, TRIG-10-003, TRIG-10-004.
 """
 
+import json
 from typing import Any
 
-from fastapi import APIRouter, BackgroundTasks, Depends, status
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    HTTPException,
+    Path,
+    Query,
+    Request,
+    status,
+)
+from fastapi.responses import JSONResponse, Response
 
 from vultron.adapters.driving.fastapi.deps import (
     get_canonical_actor_dl,
@@ -45,6 +56,10 @@ from vultron.adapters.driving.fastapi.trigger_models import (
     NotifyFixReadyRequest,
     NotifyPublishedRequest,
     SyncLogEntryRequest,
+)
+from vultron.core.models.case_log_entry import VultronCaseLogEntry
+from vultron.wire.as2.vocab.objects.case_log_entry import (
+    CaseLogEntry as WireCaseLogEntry,
 )
 from vultron.core.ports.datalayer import DataLayer
 from vultron.core.ports.trigger_service import TriggerServicePort
@@ -302,3 +317,101 @@ def demo_close_case(
         )
     background_tasks.add_task(outbox_handler, actor_id, actor_dl, dl)
     return result
+
+
+@router.get(
+    "/{actor_id}/demo/cases/{case_id:path}/log",
+    status_code=status.HTTP_200_OK,
+    summary="[Demo] List all case log entries for a case, sorted by log_index.",
+    description=(
+        "Demo-only read endpoint. "
+        "Returns all ``VultronCaseLogEntry`` objects for the specified case, "
+        "sorted ascending by ``log_index``. "
+        "Default response is ``application/json``. "
+        "Request ``Accept: application/x-ndjson`` or pass ``?format=ndjson`` "
+        "to receive NDJSON — one JSON object per line — suitable for direct "
+        "file capture (``curl ... > case.jsonl``). "
+        "This endpoint is for demo tooling, test scripts, and live display "
+        "only. It MUST NOT be used as a participant-facing log-replication "
+        "mechanism (use the ActivityStreams inbox channel per SYNC-07). "
+        "Only available in ``RunMode.PROTOTYPE``. "
+        "Spec: TRIG-09-001, SYNC-01-002, SYNC-02-003."
+    ),
+    operation_id="actors_demo_get_case_log",
+)
+def demo_get_case_log(
+    actor_id: str,  # noqa: ARG001
+    case_id: str,
+    request: Request,
+    fmt: str | None = Query(
+        default=None,
+        alias="format",
+        description="Response format: 'ndjson' for NDJSON output.",
+    ),
+    dl: DataLayer = Depends(get_trigger_dl),
+) -> Response:
+    """Return ordered case log entries for a case (demo scaffold).
+
+    Implements:
+        TRIG-09-001, SYNC-01-002, SYNC-02-003.
+
+    Demo/observability only — do not expose as a participant-facing endpoint.
+    """
+    raw_entries = [
+        e
+        for e in dl.list_objects("CaseLogEntry")
+        if isinstance(e, (VultronCaseLogEntry, WireCaseLogEntry))
+        and e.case_id == case_id
+    ]
+    raw_entries.sort(key=lambda e: e.log_index)
+    payloads = [e.model_dump(mode="json", by_alias=True) for e in raw_entries]
+
+    accept = request.headers.get("accept", "")
+    if fmt == "ndjson" or "application/x-ndjson" in accept:
+        content = "\n".join(json.dumps(p) for p in payloads)
+        return Response(content=content, media_type="application/x-ndjson")
+    return JSONResponse(content=payloads)
+
+
+@router.get(
+    "/{actor_id}/demo/cases/{case_id:path}/log/{index}",
+    status_code=status.HTTP_200_OK,
+    summary="[Demo] Get a single case log entry by log_index.",
+    description=(
+        "Demo-only read endpoint. "
+        "Returns the single ``VultronCaseLogEntry`` at the given ``log_index`` "
+        "for the specified case. "
+        "Returns HTTP 404 if no entry exists at that index. "
+        "Only available in ``RunMode.PROTOTYPE``. "
+        "Spec: TRIG-09-001, SYNC-01-002, SYNC-02-003."
+    ),
+    operation_id="actors_demo_get_case_log_entry",
+)
+def demo_get_case_log_entry(
+    actor_id: str,  # noqa: ARG001
+    case_id: str,
+    index: int = Path(ge=0, description="Zero-based log entry index."),
+    dl: DataLayer = Depends(get_trigger_dl),
+) -> dict[str, Any]:
+    """Return the case log entry at the given index (demo scaffold).
+
+    Implements:
+        TRIG-09-001, SYNC-01-002, SYNC-02-003.
+
+    Demo/observability only — do not expose as a participant-facing endpoint.
+    """
+    entry_id = f"{case_id}/log/{index}"
+    obj = dl.read(entry_id)
+    if not isinstance(obj, (VultronCaseLogEntry, WireCaseLogEntry)):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "status": 404,
+                "error": "NotFound",
+                "message": (
+                    f"No log entry at index {index} for case {case_id!r}."
+                ),
+                "activity_id": None,
+            },
+        )
+    return obj.model_dump(mode="json", by_alias=True)

--- a/vultron/demo/helpers/sync.py
+++ b/vultron/demo/helpers/sync.py
@@ -52,7 +52,14 @@ def _extract_ref_id(ref: object) -> Optional[str]:
 def _get_log_entries_for_case(
     client: DataLayerClient, case_id: str
 ) -> list[dict]:
-    """Return all ``CaseLogEntry`` dicts for *case_id* from the DataLayer."""
+    """Return all ``CaseLogEntry`` dicts for *case_id* from the DataLayer.
+
+    .. deprecated::
+        This function performs client-side filtering over the full DataLayer
+        dump.  Prefer the server-side endpoint instead:
+        ``GET /actors/{actor_id}/demo/cases/{case_id}/log``
+        (see ``demo_triggers.demo_get_case_log``).
+    """
     raw = client.get("/datalayer/CaseLogEntrys/")
     if not isinstance(raw, dict):
         return []

--- a/vultron/demo/scenario/two_actor_demo.py
+++ b/vultron/demo/scenario/two_actor_demo.py
@@ -21,8 +21,10 @@ milestone logic to the generic helper modules under ``vultron.demo.helpers``
 while preserving the public API used by the existing test suite.
 """
 
+import json
 import logging
 import os
+import pathlib
 import sys
 from typing import Optional, Tuple
 
@@ -702,8 +704,79 @@ def _phase_case_closure(
 
 
 # ---------------------------------------------------------------------------
-# Main workflow orchestration
+# Case log export
 # ---------------------------------------------------------------------------
+
+
+def _phase_dump_case_logs(
+    finder_client: DataLayerClient,
+    vendor_client: DataLayerClient,
+    finder: as_Actor,
+    vendor: as_Actor,
+    case: VulnerabilityCase,
+    case_actor_client: DataLayerClient | None = None,
+    demo_name: str = "two-actor",
+) -> None:
+    """Dump case log entries from each actor container to JSONL files.
+
+    Reads ``DEVLOGS_DIR`` from the environment (default ``/app/devlogs``) and
+    writes one JSONL file per actor under::
+
+        {DEVLOGS_DIR}/{demo_name}/{actor_name}/{case_id_slug}-case-log.jsonl
+
+    The case-actor container is included only when *case_actor_client* is
+    provided.  Each dump step is wrapped in ``demo_step`` so that a failure
+    is recorded and ultimately surfaced by ``assert_demo_success()``.
+
+    Args:
+        finder_client: DataLayerClient for the Finder container.
+        vendor_client: DataLayerClient for the Vendor container.
+        finder: Finder actor object (used to derive the actor object ID).
+        vendor: Vendor actor object (used to derive the actor object ID).
+        case: The VulnerabilityCase whose log entries are to be exported.
+        case_actor_client: Optional DataLayerClient for the CaseActor container.
+        demo_name: Sub-directory name under the output root (default
+            ``"two-actor"``).
+    """
+    logger.info("─" * 80)
+    logger.info("Phase: Case log JSONL export")
+    logger.info("─" * 80)
+
+    output_root = pathlib.Path(os.environ.get("DEVLOGS_DIR", "/app/devlogs"))
+    case_id = case.id_ or ""
+    case_id_slug = (
+        case_id.replace("://", "_")
+        .replace("/", "_")
+        .replace(":", "_")
+        .strip("_")
+    )
+
+    actors: list[tuple[str, DataLayerClient]] = [
+        ("finder", finder_client),
+        ("vendor", vendor_client),
+    ]
+    if case_actor_client is not None:
+        actors.append(("case-actor", case_actor_client))
+
+    for actor_name, client in actors:
+        with demo_step(f"Dumping case log for {actor_name}"):
+            log_path = f"/actors/{actor_name}/demo/cases/{case_id}/log"
+            entries = client.get_list(log_path)
+            if not entries:
+                raise ValueError(
+                    f"No case log entries for actor={actor_name!r}, "
+                    f"case_id={case_id!r}"
+                )
+
+            out_dir = output_root / demo_name / actor_name
+            out_dir.mkdir(parents=True, exist_ok=True)
+            out_file = out_dir / f"{case_id_slug}-case-log.jsonl"
+
+            with out_file.open("w", encoding="utf-8") as fh:
+                for entry in entries:
+                    fh.write(json.dumps(entry) + "\n")
+
+            logger.info("Wrote %d log entries → %s", len(entries), out_file)
 
 
 def run_two_actor_demo(
@@ -772,6 +845,14 @@ def run_two_actor_demo(
         finder,
         finder_in_finder,
         case,
+    )
+    _phase_dump_case_logs(
+        finder_client=finder_client,
+        vendor_client=vendor_client,
+        finder=finder,
+        vendor=vendor,
+        case=case,
+        case_actor_client=case_actor_client,
     )
 
     logger.info("=" * 80)

--- a/vultron/demo/scenario/two_actor_demo.py
+++ b/vultron/demo/scenario/two_actor_demo.py
@@ -852,7 +852,10 @@ def run_two_actor_demo(
         finder=finder,
         vendor=vendor,
         case=case,
-        case_actor_client=case_actor_client,
+        # The two-actor demo uses the vendor container as case manager;
+        # the dedicated case-actor service carries no log entries for this
+        # case, so we only dump finder and vendor.
+        case_actor_client=None,
     )
 
     logger.info("=" * 80)

--- a/vultron/demo/utils.py
+++ b/vultron/demo/utils.py
@@ -156,7 +156,7 @@ class DataLayerClient(BaseModel):
 
     base_url: str = BASE_URL
 
-    def call(self, method: HTTPMethod, path: str, **kwargs: Any) -> dict:
+    def call(self, method: HTTPMethod, path: str, **kwargs: Any) -> Any:
         """Make an HTTP request to the DataLayer API.
 
         Args:
@@ -165,7 +165,8 @@ class DataLayerClient(BaseModel):
             **kwargs: Additional keyword arguments forwarded to ``httpx.request``.
 
         Returns:
-            Parsed JSON response body as a dict.
+            Parsed JSON response body.  Most endpoints return a ``dict``, but
+            list endpoints (e.g. the case-log endpoint) return a ``list``.
 
         Raises:
             httpx.HTTPStatusError: When the response status is not OK.
@@ -178,7 +179,7 @@ class DataLayerClient(BaseModel):
         response = httpx.request(method, url, **kwargs)
         logger.debug(f"Response status: {response.status_code}")
 
-        data = {}
+        data: Any = {}
         try:
             data = response.json()
             logger.debug(f"Response JSON: {json.dumps(data, indent=2)}")
@@ -197,21 +198,43 @@ class DataLayerClient(BaseModel):
 
         return data
 
-    def get(self, path: str, **kwargs) -> dict:
+    def get(self, path: str, **kwargs: Any) -> dict:
         """Send an HTTP GET request."""
-        return self.call(HTTPMethod.GET, path, **kwargs)
+        return cast(dict, self.call(HTTPMethod.GET, path, **kwargs))
 
-    def put(self, path: str, **kwargs) -> dict:
+    def get_list(self, path: str, **kwargs: Any) -> list[Any]:
+        """Send an HTTP GET request that expects a JSON array response.
+
+        Args:
+            path: API path relative to ``base_url``.
+            **kwargs: Additional keyword arguments forwarded to ``httpx.request``.
+
+        Returns:
+            Parsed JSON response body as a list.
+
+        Raises:
+            ValueError: When the response body is not a JSON array.
+            httpx.HTTPStatusError: When the response status is not OK.
+        """
+        data = self.call(HTTPMethod.GET, path, **kwargs)
+        if not isinstance(data, list):
+            raise ValueError(
+                f"Expected JSON array from GET {path}, "
+                f"got {type(data).__name__}"
+            )
+        return data
+
+    def put(self, path: str, **kwargs: Any) -> dict:
         """Send an HTTP PUT request."""
-        return self.call(HTTPMethod.PUT, path, **kwargs)
+        return cast(dict, self.call(HTTPMethod.PUT, path, **kwargs))
 
-    def post(self, path: str, **kwargs) -> dict:
+    def post(self, path: str, **kwargs: Any) -> dict:
         """Send an HTTP POST request."""
-        return self.call(HTTPMethod.POST, path, **kwargs)
+        return cast(dict, self.call(HTTPMethod.POST, path, **kwargs))
 
-    def delete(self, path: str, **kwargs) -> dict:
+    def delete(self, path: str, **kwargs: Any) -> dict:
         """Send an HTTP DELETE request."""
-        return self.call(HTTPMethod.DELETE, path, **kwargs)
+        return cast(dict, self.call(HTTPMethod.DELETE, path, **kwargs))
 
 
 def reset_datalayer(client: DataLayerClient, init: bool = True) -> dict:
@@ -302,8 +325,6 @@ def post_to_trigger(
     path_prefix: str = "trigger",
 ) -> dict:
     """POST to a trigger endpoint and return the response body.
-
-    Trigger endpoints allow the local actor to initiate a behavior
     proactively (e.g. validate-report, engage-case) rather than
     reacting to an inbound activity.
 


### PR DESCRIPTION
## Summary

Adds two demo-only GET endpoints to the `demo_triggers` router that expose case log entries in an ordered, queryable form.

## Endpoints

- `GET /actors/{actor_id}/demo/cases/{case_id:path}/log`
  Returns all `VultronCaseLogEntry` objects for a case, sorted ascending by `log_index`. Supports JSON (default) and NDJSON via `Accept: application/x-ndjson` header or `?format=ndjson` query param.

- `GET /actors/{actor_id}/demo/cases/{case_id:path}/log/{index}`
  Returns the single entry at the given zero-based `log_index`. Returns HTTP 404 if absent; validates `index >= 0` (HTTP 422 otherwise).

## Implementation notes

- Both routes use `{case_id:path}` to support HTTP URL case IDs containing slashes.
- Serialisation uses the wire-layer `CaseLogEntry` class (auto-registered in `VOCABULARY`) with `by_alias=True` so all fields use camelCase (`logIndex`, `caseId`, `eventType`, `logObjectId`, etc.).
- The DataLayer reconstructs stored `VultronCaseLogEntry` objects via the wire vocabulary as `CaseLogEntry` instances — both types are handled by `isinstance` checks.
- `_get_log_entries_for_case()` in `sync.py` is marked deprecated with a pointer to the new server-side endpoint.

## Tests

21 tests covering: empty list, sorted order, case isolation, NDJSON via header and query param, HTTP URL case IDs, 404, 422, and camelCase alias verification.

Closes #664.

## Spec

Implements: TRIG-09-001, SYNC-01-002, SYNC-02-003.