### PR TITLE
docs: ingest concern #503 — add OX-09 Outbox Monitor Efficiency spec

### DIFF
--- a/plan/history/2606/learning/CONCERN-503.md
+++ b/plan/history/2606/learning/CONCERN-503.md
@@ -1,0 +1,50 @@
+---
+source: CONCERN-503
+timestamp: '2026-06-02T20:28:29.409378+00:00'
+title: Outbox drain loop uses fixed 1-second polling over all actor DataLayers
+type: learning
+---
+
+## Summary
+
+The `OutboxMonitor` polls all registered actor-scoped `DataLayer` instances once per
+second regardless of queue depth. Polling cost grows linearly with actor count and
+can mask queue-depth problems.
+
+## Category
+
+- Top risk
+- Performance / scaling
+
+## Severity
+
+medium
+
+## Evidence
+
+- `vultron/adapters/driving/fastapi/outbox_monitor.py`
+
+## Impact if Ignored
+
+More actors mean more unnecessary wakeups and DataLayer reads per second, and
+queue-depth issues become harder to observe.
+
+## Suggested Action
+
+Consider event-driven wakeups (e.g., an asyncio Event set on enqueue) or adaptive
+polling with backoff; add queue-depth metrics if actor count grows beyond demo scale.
+
+## Resolution
+
+**Resolved**: 2026-06-02 — root cause confirmed as O(N) idle DataLayer iteration on
+every tick. Agreed approach: callback injection pattern — `SqliteDataLayer.outbox_add()`
+accepts an optional `enqueue_callback: Callable[[str], None]`; `OutboxMonitor` owns an
+`asyncio.Event`, provides `_notify()` as the callback, and uses
+`asyncio.wait_for(event.wait(), timeout=poll_interval)` instead of bare
+`asyncio.sleep`. Safety-net polling retained. Spec updated with OX-09 "Outbox Monitor
+Efficiency" group (OX-09-001 through OX-09-005).
+
+Docs PR: [#681](https://github.com/CERTCC/Vultron/pull/681).
+Implementation tracked in [#679](https://github.com/CERTCC/Vultron/issues/679)
+(event-driven wakeup) and [#680](https://github.com/CERTCC/Vultron/issues/680)
+(queue-depth observability, blocked by #679).

--- a/specs/outbox.yaml
+++ b/specs/outbox.yaml
@@ -120,3 +120,41 @@ groups:
     statement: >-
       If an outbound activity carries non-empty `cc:`, `bto:`, or `bcc:` fields, the outbox
       handler SHOULD log a WARNING
+- id: OX-09
+  title: Outbox Monitor Efficiency
+  rationale: >-
+    Fixed-interval polling grows O(N) with actor count: every tick iterates all registered
+    actor DataLayers regardless of queue depth. Event-driven wakeup eliminates idle
+    iteration cost and scales to large deployments.
+  specs:
+  - id: OX-09-001
+    priority: SHOULD
+    statement: >-
+      The outbox monitor SHOULD use event-driven wakeup so that it drains actor outboxes
+      immediately when an activity is enqueued, rather than waiting for the next fixed
+      polling interval
+    rationale: >-
+      Reduces median delivery latency from up to poll_interval to near-zero at no extra
+      CPU cost
+  - id: OX-09-002
+    priority: MUST
+    statement: >-
+      Even when event-driven wakeup is enabled, the outbox monitor MUST retain a
+      safety-net polling interval so that outbox items are eventually delivered even if
+      an enqueue notification is missed
+  - id: OX-09-003
+    priority: SHOULD
+    statement: >-
+      The enqueue notification mechanism SHOULD be injected into the DataLayer adapter as
+      a callback so that the DataLayer does not import from the monitor layer
+    rationale: Preserves the hexagonal architecture boundary between driven adapters
+  - id: OX-09-004
+    priority: SHOULD
+    statement: >-
+      The outbox monitor SHOULD log the total number of pending outbox items across all
+      actors at DEBUG level on each drain pass
+  - id: OX-09-005
+    priority: SHOULD
+    statement: >-
+      If any single actor's outbox depth exceeds a configurable threshold, the outbox
+      monitor SHOULD emit a WARNING-level log entry identifying the actor and depth


### PR DESCRIPTION
Docs-only PR: addresses concern #503 at the spec level by adding OX-09
"Outbox Monitor Efficiency" to `specs/outbox.yaml`.

Implementation tracked in #679, #680.

Ref #503

No .py files changed.