### PR TITLE
fix: promote Final BT state log from DEBUG to INFO

### DIFF
--- a/plan/history/2606/implementation/ISSUE-683.md
+++ b/plan/history/2606/implementation/ISSUE-683.md
@@ -1,0 +1,32 @@
+---
+source: ISSUE-683
+timestamp: '2026-06-02T21:05:17.682026+00:00'
+title: 'fix: promote Final BT state log from DEBUG to INFO'
+type: implementation
+---
+
+## fix: promote Final BT state log from DEBUG to INFO
+
+**Issue**: #683 (incomplete fix from #667/#669)
+
+### Symptoms
+
+`Final BT state:` tree visualization logs appeared at DEBUG level in
+demo output, even though the PR #669 acceptance criteria for #667 stated
+"BT structure logs moved to INFO".
+
+### Root cause
+
+PR #669 had an explicit comment "Log transition result at INFO; final
+structure at DEBUG" — an intentional but incorrect decision. The single
+`self.logger.debug(f"Final BT state:\n{tree_repr}")` call in
+`vultron/core/behaviors/bridge.py` was never promoted.
+
+### Fix
+
+- Changed `logger.debug` → `logger.info` for the Final BT state log in
+  `BTBridge.execute_tree()` and removed the misleading comment.
+- Added two regression tests asserting log level is INFO for both
+  SUCCESS and FAILURE outcomes.
+
+**Validation**: All 2561 unit tests pass. All four linters clean.

--- a/test/core/behaviors/test_bridge.py
+++ b/test/core/behaviors/test_bridge.py
@@ -410,3 +410,48 @@ def test_get_failure_reason_finds_first_failing_child():
     root.tick_once()
     result = BTBridge.get_failure_reason(root)
     assert result == "Failure"
+
+
+# Log-level tests
+
+
+def test_final_bt_state_logged_at_info_on_success(
+    bridge, test_actor_id, caplog
+):
+    """Final BT state tree visualization is logged at INFO on SUCCESS."""
+    import logging
+
+    tree = AlwaysSucceed()
+    bt = bridge.setup_tree(tree=tree, actor_id=test_actor_id)
+
+    with caplog.at_level(logging.DEBUG):
+        bridge.execute_tree(bt)
+
+    final_state_records = [
+        r for r in caplog.records if "Final BT state" in r.message
+    ]
+    assert final_state_records, "Expected 'Final BT state' log entry"
+    assert all(
+        r.levelno == logging.INFO for r in final_state_records
+    ), f"Expected INFO but got {final_state_records[0].levelname}"
+
+
+def test_final_bt_state_logged_at_info_on_failure(
+    bridge, test_actor_id, caplog
+):
+    """Final BT state tree visualization is logged at INFO on FAILURE."""
+    import logging
+
+    tree = AlwaysFail()
+    bt = bridge.setup_tree(tree=tree, actor_id=test_actor_id)
+
+    with caplog.at_level(logging.DEBUG):
+        bridge.execute_tree(bt)
+
+    final_state_records = [
+        r for r in caplog.records if "Final BT state" in r.message
+    ]
+    assert final_state_records, "Expected 'Final BT state' log entry"
+    assert all(
+        r.levelno == logging.INFO for r in final_state_records
+    ), f"Expected INFO but got {final_state_records[0].levelname}"

--- a/vultron/core/behaviors/bridge.py
+++ b/vultron/core/behaviors/bridge.py
@@ -220,12 +220,11 @@ class BTBridge:
                 if root_status in (Status.SUCCESS, Status.FAILURE):
                     feedback = bt.root.feedback_message
 
-                    # Log transition result at INFO; final structure at DEBUG
                     self.logger.info(
                         f"BT execution completed: {root_status} after {iteration} ticks - {feedback}"
                     )
                     tree_repr = unicode_tree(bt.root, show_status=True)
-                    self.logger.debug(f"Final BT state:\n{tree_repr}")
+                    self.logger.info(f"Final BT state:\n{tree_repr}")
 
                     return BTExecutionResult(
                         status=root_status,


### PR DESCRIPTION
Fixes #683

## Summary

The `Final BT state:` tree visualization in `BTBridge.execute_tree()` was
logged at DEBUG level. PR #669 (which closed #667) had an explicit comment
keeping it at DEBUG, but this contradicted the acceptance criteria in #667:
"BT structure logs moved to INFO".

## Changes

- `vultron/core/behaviors/bridge.py`: `logger.debug` → `logger.info` for
  the Final BT state tree repr; removed misleading comment
- `test/core/behaviors/test_bridge.py`: two regression tests asserting the
  log is emitted at INFO for both SUCCESS and FAILURE outcomes

## Validation

- All 2561 unit tests pass
- All four linters clean (Black, flake8, mypy, pyright)