### PR TITLE
docs: ingest concern #516 — embargo.py high-churn/mixed-responsibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,6 +323,13 @@ Short entries are reproduced here; longer ones are referenced below.
 - **Accept.object_ Must Be the Invite Activity, Not the Case Object** — see [notes/activitystreams-semantics.md](notes/activitystreams-semantics.md)
 - **Actor ID Normalization in Trigger Paths: Resolve Path Params Before Outbox** — see [notes/codebase-structure.md](notes/codebase-structure.md)
 - **Trigger-Side Embargo Ownership Gate (Owner vs. Participant)** — see [notes/participant-embargo-consent.md](notes/participant-embargo-consent.md)
+- **Inline `EMAdapter` Instantiation Is an Anti-Pattern** — Trigger and received
+  use cases MUST NOT instantiate `create_em_machine()` + `EMAdapter` inline in
+  `execute()` methods. Once `EmbargoLifecycle` (#538) lands, delegate all EM +
+  PEC transitions to it. Until then, add a `# TODO(#538)` comment so the
+  duplication is discoverable. Always cascade PEC alongside EM transitions
+  (`_cascade_pec_revise` on `ACTIVE → REVISE`; `_cascade_pec_reset` on
+  termination). See [notes/embargo-lifecycle.md](notes/embargo-lifecycle.md).
 - **Note Attachment Idempotency: Check `case.notes`, Not DataLayer Existence** — see [notes/bt-integration.md](notes/bt-integration.md)
 - **Transitive Activity `object_` Contract at Base Type** — see [notes/activitystreams-semantics.md](notes/activitystreams-semantics.md)
 - **Base-Typed Serialization Drops Subtype Fields: Use `serialize_as_any=True`** — see [notes/activitystreams-semantics.md](notes/activitystreams-semantics.md)

--- a/notes/README.md
+++ b/notes/README.md
@@ -281,6 +281,16 @@ embargo meta-protocol delivery to `DECLINED`/`LAPSED` participants, and the
 embargo consent state machine in `vultron/core/states/`, or debugging
 `embargo_adherence` field semantics.
 
+**`embargo-lifecycle.md`**
+Target architecture for EM state management: the inline-`EMAdapter`
+instantiation anti-pattern, the current fragmentation across trigger use cases,
+received use cases, and BT behaviors, and the planned `EmbargoLifecycle`
+service (#538) that will consolidate all EM + PEC transitions.
+**Load when**: implementing any embargo state transition in trigger or received
+use cases, designing the `EmbargoLifecycle` service (#538), auditing inline
+`create_em_machine()` instantiations, or working on the post-#538
+`triggers/embargo.py` cleanup (#516).
+
 ---
 
 ## Codebase, Infrastructure, and Demos

--- a/notes/embargo-lifecycle.md
+++ b/notes/embargo-lifecycle.md
@@ -1,0 +1,153 @@
+---
+title: Embargo Lifecycle — Architecture and Implementation Notes
+status: active
+description: >
+  Target architecture for EM state management; the inline-EMAdapter
+  instantiation anti-pattern in trigger use cases; and the fragmentation
+  concern that motivates the EmbargoLifecycle service (see #538).
+related_specs:
+  - specs/case-management.yaml
+  - specs/embargo-policy.yaml
+related_notes:
+  - notes/embargo-default-semantics.md
+  - notes/participant-embargo-consent.md
+relevant_packages:
+  - vultron/core/states/em.py
+  - vultron/core/use_cases/triggers/embargo.py
+  - vultron/core/use_cases/received/embargo.py
+  - vultron/bt/embargo_management
+---
+
+# Embargo Lifecycle — Architecture and Implementation Notes
+
+**Status**: Design decision — target architecture tracked in
+[#538](https://github.com/CERTCC/Vultron/issues/538)
+**See also**: `notes/embargo-default-semantics.md`,
+`notes/participant-embargo-consent.md`
+
+---
+
+## Background
+
+The embargo lifecycle involves three interacting state machines:
+
+1. **EM** (`vultron/core/states/em.py`) — the case-level embargo state:
+   `NO_EMBARGO → PROPOSED → ACTIVE ↔ REVISE → EXITED`
+2. **PEC** (`vultron/core/states/participant_embargo_consent.py`) — the
+   per-participant consent state:
+   `NO_EMBARGO → INVITED → SIGNATORY / DECLINED / LAPSED`
+3. **`VulnerabilityCase.active_embargo`** — the pointer to the currently
+   active `VultronEmbargoEvent` object
+
+A correct embargo lifecycle transition must update **all three** consistently.
+
+---
+
+## Current Fragmentation (the problem)
+
+EM state transition logic is currently duplicated in four places:
+
+| Module | Role | Lines |
+|---|---|---|
+| `vultron/core/states/em.py` | EM state machine definition | ~150 |
+| `vultron/core/states/participant_embargo_consent.py` | PEC machine | ~155 |
+| `vultron/core/use_cases/triggers/embargo.py` | Trigger-side (5 use-case classes + 10 module-level helpers) | ~902 |
+| `vultron/core/use_cases/received/embargo.py` | Receive-side (7 use-case classes) | ~482 |
+| `vultron/bt/embargo_management/` | BT-side autonomous management | ~548 |
+
+There is **no single authoritative place** that owns what it means to
+"accept an embargo offer" or "terminate an embargo." The trigger-side and
+BT-side implementations are logically parallel but structurally independent —
+bugs fixed in one will not propagate to the other.
+
+---
+
+## Anti-Pattern: Inline `EMAdapter` Instantiation in Use Cases
+
+**Do not** instantiate `create_em_machine()` + `EMAdapter` inline inside
+trigger or received use-case `execute()` methods. Example of the anti-pattern:
+
+```python
+# ❌ WRONG: inline EM machine in execute()
+adapter = EMAdapter(em_state)
+em_machine = create_em_machine()
+em_machine.add_model(adapter, initial=em_state)
+try:
+    getattr(adapter, "accept")()
+except MachineError:
+    ...
+new_em_state = EM(adapter.state)
+```
+
+This pattern appears repeatedly across `triggers/embargo.py` and
+`received/embargo.py`. Each repetition is an independent copy of the
+transition logic with no shared validation or invariant enforcement.
+
+**Why this is risky:**
+
+- A bug fix or rule change requires updating N copies instead of one.
+- The transition validity rules are not documented or enforced by type — a
+  typo in the trigger name (e.g., `"accept"` vs `"activate"`) fails silently
+  at runtime.
+- PEC cascade operations (`_cascade_pec_revise`, `_cascade_pec_reset`) are
+  co-located with the EM machine setup but are not guaranteed to run whenever
+  the EM state changes.
+
+---
+
+## Target Architecture
+
+[#538](https://github.com/CERTCC/Vultron/issues/538) proposes a single
+`vultron/core/services/embargo_lifecycle.py` module with an
+`EmbargoLifecycle` service class that owns all EM + PEC transition logic.
+
+**Planned interface sketch** (from #538):
+
+```python
+class EmbargoLifecycle:
+    def __init__(self, persistence: CasePersistence) -> None: ...
+    def propose(self, case_id: str, actor_id: str, ...) -> EM: ...
+    def accept(self, case_id: str, actor_id: str, proposal_id: str) -> EM: ...
+    def reject(self, case_id: str, actor_id: str, proposal_id: str) -> EM: ...
+    def terminate(self, case_id: str, actor_id: str) -> EM: ...
+```
+
+Once `EmbargoLifecycle` exists:
+
+- Trigger use cases become thin orchestrators: resolve actors/cases → call
+  `EmbargoLifecycle` → build and send the outbound activity.
+- Received use cases call the same service in `OBSERVED` mode (state-sync
+  without re-enforcing proposal workflow).
+- BT behaviors call the same service, eliminating the parallel BT-side
+  implementation.
+
+---
+
+## File Size / Complexity Concern
+
+`vultron/core/use_cases/triggers/embargo.py` is tracked in
+[#516](https://github.com/CERTCC/Vultron/issues/516) as a high-churn,
+high-complexity file. After `EmbargoLifecycle` (#538) lands, a follow-up
+audit should confirm:
+
+- File is under 500 lines
+- Each testable concern (helper logic, use-case orchestration) is in its own
+  module
+- No inline `EMAdapter` instantiation remains in use-case `execute()` methods
+
+This follow-up is tracked in a separate issue blocked by #538.
+
+---
+
+## Guidance for Agents
+
+When implementing any code that transitions embargo state:
+
+1. **Check whether `EmbargoLifecycle` exists** (`vultron/core/services/`).
+   If it does, use it — do not re-instantiate `create_em_machine()` inline.
+2. **If `EmbargoLifecycle` is not yet implemented** (pre-#538), follow the
+   existing pattern in `triggers/embargo.py` but leave a `# TODO(#538)`
+   comment so the inline instantiation is discoverable for cleanup.
+3. **Always cascade PEC** when EM state changes: `ACTIVE → REVISE` must
+   trigger `_cascade_pec_revise`; termination must trigger `_cascade_pec_reset`.
+   The PEC cascade is not optional.

--- a/plan/history/2606/learning/CONCERN-516.md
+++ b/plan/history/2606/learning/CONCERN-516.md
@@ -1,0 +1,46 @@
+---
+source: CONCERN-516
+timestamp: '2026-06-03T17:26:02.923544+00:00'
+title: embargo.py high-churn/mixed-responsibility concern
+type: learning
+---
+
+## Summary
+
+`vultron/core/use_cases/triggers/embargo.py` has grown to 902 lines and
+accumulated 38 commits in the last 90 days, making it one of the highest-churn
+source files. It encodes complex embargo state-transition logic inline in
+trigger use-case methods.
+
+## Category
+
+- [x] Fragile / high-churn area
+
+## Severity
+
+medium
+
+## Evidence
+
+- `vultron/core/use_cases/triggers/embargo.py` (902 lines, 38 churn hits / 90 days)
+- Scan output: top source-file churn ranking
+
+## Impact if Ignored
+
+State-machine logic embedded in trigger methods is hard to audit against the
+protocol spec and harder to test in isolation. Regressions in embargo
+state transitions are difficult to catch without comprehensive integration
+tests.
+
+## Suggested Action
+
+Write narrow PRs with explicit test coverage for each embargo state
+transition. Consider migrating inline state logic to BT nodes where the
+protocol requires conditional branching.
+
+**Resolved**: 2026-06-03 — structural concern absorbed by #538
+(EmbargoLifecycle service RFC). Concern is now blocked-by #538; post-#538
+cleanup tracked in #696. Documentation added in `notes/embargo-lifecycle.md`
+capturing the inline-EMAdapter anti-pattern and target architecture.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/697>.
+Implementation tracked in #696 (blocked by #538).


### PR DESCRIPTION
Docs-only PR: addresses concern #516 at the spec/notes level.
Implementation tracked in #696 (blocked by #538).

## Changes

- `notes/embargo-lifecycle.md` (new): EM state management architecture,
  inline-`EMAdapter` instantiation anti-pattern, target `EmbargoLifecycle`
  design (see #538), and guidance for agents on how to handle embargo transitions
  pre- and post-#538.
- `notes/README.md`: added entry for new file in Case and Data Model section.
- `AGENTS.md`: added pitfall entry — **Inline `EMAdapter` Instantiation Is an
  Anti-Pattern** — pointing to the new notes file.

## Sequencing

- #538 (`EmbargoLifecycle` service) is blocked-by the same concern (#516) and
  will make the structural changes. After #538 merges, #696 audits what's left.

Closes #516

No .py files changed.