### PR TITLE
chore: migrate project tracking from PRIORITIES.md+group: labels to GitHub Project #24

### DIFF
--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -36,28 +36,73 @@ docs/adr/, notes/, and AGENTS.md files, and scans vultron/ and test/.
 
 ### Phase 2 - Select and claim work
 
-1. Read `plan/PRIORITIES.md` to identify the current top-priority group name.
-2. Query GitHub for open, unblocked **leaf Issues** (no sub-issues) with that
-   `group:` label, excluding Issues that have `stale-claim` set or are already
-   assigned. Use `github-mcp-server-list_issues` with the appropriate label
-   filter.
-3. From the resulting list, pick the highest-priority unblocked Issue. Account
-   for blockers, prerequisites, and whether the work fits in a single run.
-   **Detect blockers via the structured GraphQL API** — do not parse the issue
-   body for text markers like `Blocked by #N`:
+1. Query Project #24 ("Vultron Planning") for open Epics with `Schedule=Now`,
+   ordered by board position. The top-priority group is the first such Epic
+   that has at least one unblocked open leaf sub-issue:
+
+   ```bash
+   gh api graphql --jq '
+     .data.node.items.nodes[]
+     | select(
+         .content.state == "OPEN" and
+         .content.issueType.name == "Epic" and
+         (
+           .fieldValues.nodes[]
+           | select(.field.name == "Schedule")
+           | .name
+         ) == "Now"
+       )
+     | "#\(.content.number): \(.content.title)"
+   ' -f query='{
+     node(id: "PVT_kwDOAjf0s84BZnre") {
+       ... on ProjectV2 {
+         items(first: 100) {
+           nodes {
+             content {
+               ... on Issue {
+                 number title state
+                 issueType { name }
+               }
+             }
+             fieldValues(first: 10) { nodes {
+               ... on ProjectV2ItemFieldSingleSelectValue {
+                 name field { ... on ProjectV2SingleSelectField { name } }
+               }
+             }}
+           }
+         }
+       }
+     }
+   }'
+   ```
+
+2. Query GitHub for open, unblocked **leaf Issues** (no sub-issues) that are
+   sub-issues of the top-priority Now-Epic, excluding Issues with `stale-claim`
+   set or already assigned:
 
    ```bash
    gh api graphql -f query='{
      repository(owner:"CERTCC", name:"Vultron") {
-       issue(number: <N>) {
-         blockedBy(first: 50) { nodes { number title state } }
+       issue(number: <EPIC_NUMBER>) {
+         subIssues(first: 50) {
+           nodes {
+             number title state
+             assignees(first: 1) { nodes { login } }
+             blockedBy(first: 10) { nodes { number state } }
+             subIssues(first: 1) { totalCount }
+             labels(first: 10) { nodes { name } }
+           }
+         }
        }
      }
    }'
-   ```text
+   ```
 
-   An issue is unblocked only if all entries in `blockedBy.nodes` have
-   `state: CLOSED`.
+   An issue is a candidate if: `state=OPEN`, no assignees, no `stale-claim`
+   label, all `blockedBy` entries are `CLOSED`, and `subIssues.totalCount==0`.
+
+3. From the resulting list, pick the highest-priority unblocked Issue.
+
 4. Fetch the Issue body and comments using `github-mcp-server-issue_read`
 
    (`method: get` then `method: get_comments`). Use the combined content as
@@ -94,18 +139,39 @@ docs/adr/, notes/, and AGENTS.md files, and scans vultron/ and test/.
 1. Search `vultron/` and `test/` to confirm the current implementation.
 2. Do not assume missing functionality; verify it in code.
 3. If a blocking prerequisite is discovered, create a new GitHub Issue for it
-   with `group:unscheduled` and the appropriate `size:` label, then
-   immediately link it as a sub-issue of the current task Issue
-   (PAD-01-003). Use the `manage-github-issue` skill to create the issue
-   and wire the sub-issue relationship in one step:
+   with the appropriate `size:` label, then immediately link it as a sub-issue
+   of the current task Issue (PAD-01-003). Use the `manage-github-issue` skill
+   to create and wire the issue, then add it to Project #24 with
+   `Schedule=Someday`:
 
    ```bash
    NEW_ISSUE=$(.agents/skills/manage-github-issue/manage_github_issue.sh \
      --title "<prerequisite title>" \
      --body "<description>" \
-     --label "group:unscheduled,size:<S|M|L>" \
+     --label "size:<S|M|L>" \
      --parent <CURRENT_TASK_NUMBER>)
    echo "Created prerequisite #${NEW_ISSUE}"
+
+   # Add to Project #24 with Schedule=Someday
+   NODE_ID=$(gh api graphql -f query='{
+     repository(owner:"CERTCC", name:"Vultron") {
+       issue(number: '"${NEW_ISSUE}"') { id }
+     }
+   }' --jq '.data.repository.issue.id')
+   ITEM_ID=$(gh api graphql -f query="mutation {
+     addProjectV2ItemById(input: {
+       projectId: \"PVT_kwDOAjf0s84BZnre\"
+       contentId: \"${NODE_ID}\"
+     }) { item { id } }
+   }" --jq '.data.addProjectV2ItemById.item.id')
+   gh api graphql -f query="mutation {
+     updateProjectV2ItemFieldValue(input: {
+       projectId: \"PVT_kwDOAjf0s84BZnre\"
+       itemId: \"${ITEM_ID}\"
+       fieldId: \"PVTSSF_lADOAjf0s84BZnrezhUlFOM\"
+       value: { singleSelectOptionId: \"fcffa79d\" }
+     }) { projectV2Item { id } }
+   }" >/dev/null
    ```
 
    Record the dependency in `plan/BUILD_LEARNINGS.md` and stop.
@@ -214,21 +280,3 @@ If the PR reports merge conflicts:
 - Do not skip validation or the pre-PR code review.
 - Each run starts in a fresh context.
 - Do not commit directly to `main`. All work goes through a PR.
-
-## Label Naming Rules (PAD-02-007)
-
-When creating prerequisite Issues or updating `group:` labels on any issue:
-
-- **Never include a priority number** in the `group:` label name.
-  Use `group:architecture-hardening`, **not** `group:473-architecture-hardening`.
-  Priority numbers in PRIORITIES.md can change; label names must remain stable.
-- **Derive the slug** from the priority group title in kebab-case
-  (e.g., "Bug Fixes and Demo Polish" → `group:bug-fixes-demo-polish`).
-- **Check for label existence** before assigning. Create it if missing:
-
-  ```bash
-  gh label create "group:<slug>" \
-    --repo CERTCC/Vultron \
-    --description "<Priority group title (no number)>" \
-    --color "#1d76db"
-  ```text

--- a/.agents/skills/check-priority-status/REFERENCE.md
+++ b/.agents/skills/check-priority-status/REFERENCE.md
@@ -4,48 +4,54 @@ title: check-priority-status Reference
 
 # Check Priority Status — Reference
 
-Technical details, configuration, and implementation notes for the priority status check.
+Technical details, configuration, and implementation notes for the priority
+status check.
+
+## Project Board Constants
+
+| Name | Value |
+|---|---|
+| Project node ID | `PVT_kwDOAjf0s84BZnre` |
+| Schedule field ID | `PVTSSF_lADOAjf0s84BZnrezhUlFOM` |
+| Schedule: Now | `1e84189c` |
+| Schedule: Next | `9fca00b2` |
+| Schedule: Later | `e2149d3e` |
+| Schedule: Someday | `fcffa79d` |
 
 ## Data Model
 
-### Priority Group Structure
+### Board Item Structure
 
-Parsed from `plan/PRIORITIES.md`:
+Queried from Project #24:
 
 ```yaml
-Priority: <number>
-Title: <string>
-Description: <string>
-Issues:
-  - Epic or root issue (GitHub URL or #<number>)
-  - Child issues (sub-tasks, linked via GitHub sub-issue relationships)
-  - Related issues (mentioned in description, marked as related)
-Dependencies:
-  - Prerequisite issues (noted as "Prerequisite:")
-  - Blocked items (issues with "blocked by" annotation)
+ScheduleTier: Now | Next | Later | Someday | null
+IssueNumber: <int>
+IssueTitle: <string>
+IssueState: open | closed
+IssueType: Epic | Task | Bug | Concern | Idea
+SubIssues: (for Epics) list of child issue numbers
 ```
+
+Items with `ScheduleTier = null` are on the board but have no Schedule value
+set — treat as uncategorized.
 
 ### Issue State
 
-For each issue linked to a priority:
+For each issue on the board:
 
-- **State**: Open, closed
-- **Type**: Epic, bug, feature, chore
+- **State**: open, closed
+- **Type**: Epic, Task, Bug, Concern, Idea
 - **Activity**: Last update timestamp, last actor
 - **PRs**: List of open/closed PRs that reference this issue
-- **Sub-issues**: For epics, aggregated state of linked issues
-- **Blockers**: Explicit dependencies or prerequisite tags
+- **Sub-issues**: For Epics, aggregated state of linked issues
+- **Blockers**: Formal "blocked by" relationships
 
 ### Blocker Detection
 
 Blockers are sourced **exclusively** from formal GitHub issue relationship
-metadata — specifically the "blocked by" relationship on an issue (as set via
-GitHub's issue relationship feature). Body text mentioning "blocked by" is
-**not** parsed and MUST NOT be used as a blocker source.
-
-`PRIORITIES.md` MUST NOT contain blocker or dependency text. Any blocker
-information found there is stale and should be ignored; the authoritative
-source is GitHub issue relationships.
+metadata — specifically the "blocked by" relationship on an issue.
+Body text mentioning "blocked by" is **not** parsed.
 
 For each issue with a "blocked by" relationship:
 
@@ -55,29 +61,30 @@ For each issue with a "blocked by" relationship:
 
 ### Coverage Analysis
 
-**Uncovered issues**:
+**Issues not on board**:
 
 ```text
-Open issues (all types) NOT in any priority group
-= All open issues - Union of all issues linked to priorities
-```text
+Open issues (all types) NOT in Project #24
+= All open issues − Union of all issues on the board
+```
 
-**Empty priorities**:
+**Empty tiers**:
 
 ```text
-Priorities with:
-- Zero linked open issues (all linked issues are closed)
-- No open PRs addressing the priority
+Schedule tiers with no open issues
+```
+
+**Epics with no open sub-issues**:
+
 ```text
+Epic issues on the board where all sub-issues are closed or none exist
+```
 
 **Orphaned PRs**:
 
 ```text
-Open PRs where:
-- PR does not reference any GitHub issue
-- PR references only closed issues
-- Referenced issue(s) not in any priority group
-```text
+Open PRs where referenced issue(s) are not in Project #24
+```
 
 ### Activity Age
 
@@ -89,20 +96,20 @@ Measured from **most recent event** among:
 
 Does **not** include creation date.
 
-**Stale threshold**: 1 week (7 days) — items inactive for 7+ days are flagged
+**Stale threshold**: 1 week (7 days)
 
 ### Progress Calculation
 
-For each priority group (or epic):
+For each Epic (or tier):
 
 ```text
-Done         = Count of closed issues
-Pending      = Count of open issues with no PR (and not blocked by an open issue)
-PR Pending   = Count of open issues with ≥1 open PR
-Blocked      = Count of issues with ≥1 open "blocked by" relationship
+Done         = Count of closed sub-issues
+Pending      = Count of open sub-issues with no PR (not blocked)
+PR Pending   = Count of open sub-issues with ≥1 open PR
+Blocked      = Count of sub-issues with ≥1 open "blocked by" relationship
 Total        = Done + Pending + PR Pending + Blocked
 
-% Complete = Done / (Done + Pending + PR Pending + Blocked)
+% Complete = Done / Total
 Status:
   🟢 ≥75% done OR all sub-items have active PRs
   🟡 25–75% done with some pending items
@@ -111,124 +118,93 @@ Status:
 
 ### Readiness
 
-A priority group is **actionable** (eligible for "Next up") only when ALL of
-the following are true:
+A Now-tier Epic is **actionable** ("Next up") only when it has at least one
+unblocked open sub-issue with no open PR.
 
-1. It has at least one unblocked pending issue (open, no open "blocked by"
-   relationship, no open PR yet).
-2. Every priority group with a **lower priority number** (higher urgency) has
-   no unblocked pending work — i.e., all their open issues are either blocked,
-   have open PRs, or are closed.
+## GitHub Query Examples
 
-The **"Next up"** callout in the Summary names the single group with the lowest
-priority number that satisfies both conditions.
-
-## Configuration
-
-### Staleness Threshold
-
-Environment variable or config file:
-
-```text
-PRIORITY_STATUS_STALE_DAYS=7  # Default: 1 week
-```
-
-Activity age measured from status change, commit, or comment—not creation date.
-
-### Date Range Filtering
-
-Optional: Report only on activity within a date range:
-
-```text
-PRIORITY_STATUS_FROM=2025-01-01
-PRIORITY_STATUS_TO=2025-12-31
-```
-
-### Issue Type Filters
-
-By default, all types (bug, feature, chore, epic) are included. To focus on specific types:
-
-```text
-PRIORITY_STATUS_TYPES=bug,epic  # Comma-separated
-```
-
-## Computation
-
-### GitHub Query Examples
-
-**All open issues in a repo**:
+### All items in Project #24 with Schedule tier
 
 ```graphql
-GET /repos/{owner}/{repo}/issues?state=open&per_page=100
-```text
-
-**Issues linked to an epic** (via GitHub GraphQL):
-
-```graphql
-query {
-  repository(name: "Vultron", owner: "CERTCC") {
-    issue(number: 464) {
-      epic {
-        issues(first: 20) {
-          edges {
-            node { number, title, state }
+{
+  node(id: "PVT_kwDOAjf0s84BZnre") {
+    ... on ProjectV2 {
+      items(first: 100) {
+        nodes {
+          content {
+            ... on Issue { number title state }
+          }
+          fieldValueByName(name: "Schedule") {
+            ... on ProjectV2ItemFieldSingleSelectValue { name optionId }
           }
         }
       }
     }
   }
 }
-```text
+```
 
-**PRs referencing an issue**:
+### Sub-issues of an Epic
 
 ```graphql
-GET /repos/{owner}/{repo}/issues/{issue_number}/pull_requests
+{
+  repository(owner:"CERTCC", name:"Vultron") {
+    issue(number: <N>) {
+      subIssues(first: 50) {
+        nodes { number title state }
+      }
+    }
+  }
+}
 ```
+
+### All open issues in repo
+
+```bash
+gh issue list --repo CERTCC/Vultron \
+  --state open --json number,title,labels --limit 500
+```
+
+### PRs referencing an issue
+
+```bash
+gh pr list --repo CERTCC/Vultron \
+  --search "linked:issue:<number>" --json number,title,state
+```
+
+## Configuration
+
+### Staleness Threshold
+
+Default: 7 days. Items with no activity (status change, commit, comment)
+for 7+ days are flagged as stale.
 
 ## Limitations
 
-- **Stale is approximate**: Activity age is based on visible GitHub events; local work not pushed is invisible.
-- **Nested epics not flattened**: If an epic contains child epics, only direct child issues are counted (not transitive).
-- **Manual dependencies**: Dependencies noted in text (e.g., "Prerequisite: #440") are parsed via regex; format must be consistent.
-- **Cross-repo dependencies**: If Vultron has dependencies on other repos, those are not tracked.
+- **Stale is approximate**: Activity age is based on visible GitHub events;
+  local work not pushed is invisible.
+- **Nested Epics not flattened**: Only direct sub-issues are counted, not
+  transitive.
+- **Cross-repo dependencies**: External repo dependencies are not tracked.
+- **100-item pagination**: Board queries fetch up to 100 items by default;
+  paginate if the board grows beyond that.
 
-## Extending the Skill
+## Hard Stop
 
-### Custom Report Sections
-
-Add a new section by:
-
-1. Write a query function to gather data (e.g., `fetch_recent_label_changes()`)
-2. Add a section render function
-3. Insert into report output sequence
-
-Extend output to JSON, CSV, or Markdown table for downstream tooling:
-
-```text
-check-priority-status --format json --output report.json
-```
-
-### Hard Stop
-
-This skill MUST stop after delivering its report. It MUST NOT invoke any other
-skill or take any follow-up action. The report is the complete, final output.
+This skill MUST stop after delivering its report. It MUST NOT invoke any
+other skill or take any follow-up action. The report is the complete,
+final output.
 
 ## Troubleshooting
 
 ### Issue not showing in report
 
-1. Check `plan/PRIORITIES.md` has correct GitHub issue links (format: `#123` or full URL)
-2. Verify the issue is open (closed issues should appear under "Done", not "pending")
-3. Check GitHub API token has sufficient permissions (`repo` scope required)
+1. Check that the issue is in Project #24 (visit the board or run the
+   items query above).
+2. Verify the issue is open (closed issues appear under "Done").
+3. Check that your GitHub token has sufficient permissions (`repo` scope).
 
 ### Stale items showing as active
 
-Activity age is computed from GitHub events. If a PR has been stale locally but not pushed, it won't show as stale. Push regularly to keep the report accurate.
-
-### Empty priority with open PRs
-
-This indicates PRs are not linked to the priority's issues. Add a link by:
-
-1. Update PR description to reference the issue: `Fixes #<issue_number>`
-2. Re-run the check
+Activity age is computed from GitHub events. Push branches regularly to
+keep the report accurate.

--- a/.agents/skills/check-priority-status/SKILL.md
+++ b/.agents/skills/check-priority-status/SKILL.md
@@ -1,11 +1,18 @@
 ---
 name: check-priority-status
-description: Audit and report on priority group status against open issues and PRs, tracking progress, coverage gaps, stale items, and readiness. Use when reviewing where the project stands relative to documented priorities, or before updating PRIORITIES.md.
+description: >
+  Audit and report on priority status against the GitHub Project #24 board,
+  open issues, and PRs — tracking progress, coverage gaps, stale items, and
+  readiness by Schedule tier (Now/Next/Later/Someday). Use when reviewing where
+  the project stands relative to the board, or before running review-priorities.
 ---
 
 # Check Priority Status
 
-Generate a comprehensive status report comparing `plan/PRIORITIES.md` against current open issues and pull requests. Provides developer, architect, and supervisor perspective on progress, coverage gaps, stale work, and decision points.
+Generate a comprehensive status report from GitHub Project #24 ("Vultron
+Planning") and current open issues and pull requests. Provides developer,
+architect, and supervisor perspective on progress, coverage gaps, stale work,
+and decision points.
 
 > **HARD STOP — READ FIRST**
 >
@@ -14,108 +21,159 @@ Generate a comprehensive status report comparing `plan/PRIORITIES.md` against cu
 > prompt any next step beyond printing the report. No exceptions, even when
 > running in autopilot or background mode.
 
-## Quick start
+## Quick Start
 
 Run this when you want to understand:
 
-- **Progress**: Where are priority groups? How many issues/PRs closed, pending, or in-progress?
-- **Coverage**: Issues open but not linked to any priority? Priorities without corresponding issues?
-- **Health**: Items claimed but stale (no recent activity)? PRs pending (waiting for review)?
-- **Readiness**: What needs updating before next steps?
+- **Progress**: What is in Now/Next/Later? How many issues/PRs are
+  closed, pending, or in-progress in each tier?
+- **Coverage**: Issues not yet on the board? Epics with no sub-issues?
+- **Health**: Items claimed but stale? PRs pending review?
+- **Readiness**: What is blocking work in the Now tier?
+- **Triage**: How many Someday items need scheduling?
 
 Output is a detailed narrative with tables, organized by section.
 
 ## Usage
 
-Run the check-priority-status skill.
+Run the check-priority-status skill. The skill will:
 
-The skill will:
-
-1. **Parse** `plan/PRIORITIES.md` to extract priority groups, linked issues, and epic structure
-2. **Query GitHub** for live current state of every linked issue/PR — do not rely on text in `PRIORITIES.md` for status, open/closed state, or blocker relationships
-3. **Resolve blockers** from GitHub issue relationship metadata only (formal "blocked by" relationships on the issue, not body text); verify every referenced blocker is currently open before reporting it as blocking
-4. **Analyze** uncovered issues (open but not in PRIORITIES.md), orphaned priorities (groups with no active issues), and staleness
+1. **Query Project #24** for all items grouped by Schedule field
+   (Now / Next / Later / Someday / unset)
+2. **Query GitHub** for live current state of every linked issue/PR
+3. **Resolve blockers** from GitHub issue relationship metadata only
+   (formal "blocked by" relationships, not body text)
+4. **Analyze** uncovered issues (open but not on the board), empty
+   Schedule tiers, and staleness
 5. **Generate** a detailed status report with:
-   - Summary statistics (groups, coverage %, activity age) and a **"Next up"** callout identifying the highest-priority group with unblocked pending work
-   - Per-group progress (done ✅, pending, PR pending, blocked)
-   - Coverage audit (uncovered open issues, empty priorities, orphans)
-   - Health check (stale items, long-pending PRs, dependency blockers)
-6. **Stop** — the report is the complete output; no further actions are taken
+   - Summary statistics and a **"Next up"** callout (first unblocked
+     open issue in the Now tier)
+   - Per-tier and per-Epic progress
+   - Coverage audit (issues not on board, Epics with no open sub-issues)
+   - Health check (stale items, long-pending PRs, blockers)
+6. **Stop** — the report is the complete output; no further actions taken
+
+## Data Sources
+
+### Querying Project #24 by Schedule Tier
+
+```bash
+gh api graphql -f query='{
+  node(id: "PVT_kwDOAjf0s84BZnre") {
+    ... on ProjectV2 {
+      items(first: 100) {
+        nodes {
+          content {
+            ... on Issue { number title state }
+          }
+          fieldValueByName(name: "Schedule") {
+            ... on ProjectV2ItemFieldSingleSelectValue { name }
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+Group results by `fieldValueByName.name` (Now / Next / Later / Someday /
+null = unset).
+
+### Querying Sub-Issues of an Epic
+
+```bash
+gh api graphql -f query='{
+  repository(owner:"CERTCC", name:"Vultron") {
+    issue(number: <EPIC_NUMBER>) {
+      subIssues(first: 50) {
+        nodes { number title state }
+      }
+    }
+  }
+}'
+```
+
+### Listing All Open Issues Not on Board
+
+```bash
+# Get all open issues
+ALL_OPEN=$(gh issue list --repo CERTCC/Vultron \
+  --state open --json number,title,labels --limit 500)
+
+# Get all issue numbers from Project #24
+BOARD_ISSUES=$(gh api graphql ... # items query above, extract numbers)
+
+# Difference = uncovered issues
+```
 
 ## Report Sections
 
 ### Summary
 
-- Total priority groups and linked items
-- Overall coverage (% of open issues in a priority group)
+- Total items on board by tier (Now / Next / Later / Someday)
+- Overall coverage (% of open issues on the board)
 - Status distribution (closed, open with PR, open pending, blocked)
 - Most recent activity age
 - Stale threshold: **1 week** (last status change, commit, or activity)
-- **Next up**: The single highest-priority group (lowest priority number) that has at least one unblocked pending issue
+- **Next up**: The first unblocked, open, PR-less issue in the Now tier
 
-### Per-Priority-Group Progress
+### Per-Tier Progress
 
-Table with columns:
+For each Schedule tier (Now → Next → Later → Someday):
 
-| Priority | Title | Issues | PRs | Done | Pending | PR Pending | Blocked | Status |
-|----------|-------|--------|-----|------|---------|-----------|---------|--------|
+| Epic / Issue | #   | Sub-Issues | Done | Pending | PR Pending | Blocked | Status |
+|---|---|---|---|---|---|---|---|
 
-- **Issues**: Count of linked GitHub issues
-- **PRs**: Count of linked open PRs
-- **Done**: Closed issues (completed)
-- **Pending**: Open issues with no PR
-- **PR Pending**: Open issues with open PR(s) awaiting merge
-- **Blocked**: Issues marked blocked or dependent on others
-- **Status**: Summary icon: 🟢 on track, 🟡 stalled, 🔴 at risk
+- **Status**: 🟢 on track (≥75% done or all have PRs), 🟡 stalled
+  (25–75% done), 🔴 at risk (<25% done or blocked items)
 
 ### Coverage Audit
 
-#### Uncovered Issues
+#### Issues Not on Board
 
-All open issues (bugs, features, chores) not linked to any priority group. Organized by type, with age and activity status to highlight urgent or stale items.
+All open issues (bugs, features, chores) not in Project #24. Organized
+by type, with age and activity status.
 
-#### Empty Priorities
+#### Empty Tiers / Empty Epics
 
-Priority groups with no linked open issues (work may be completed or stalled).
+- Tiers with no open issues
+- Epics on the board with no open sub-issues
 
 #### Orphaned PRs
 
-Open PRs not linked to any priority group or issue.
+Open PRs not linked to any issue on the board.
 
 ### Health Check
 
 #### Stale Items
 
-Claimed work with no activity (comments, commits, status updates) for N+ days.
+Work with no activity (comments, commits, status updates) for 7+ days.
 
 #### Long-Pending PRs
 
-Open PRs awaiting merge for N+ days.
+Open PRs awaiting merge for 7+ days.
 
 #### Dependencies & Blockers
 
-Issues or PRs with explicit blocker relationships or prerequisite notes.
+Issues with explicit "blocked by" relationships that are still open.
+
+### Triage Summary
+
+Count of Someday items on board — these need to be scheduled or assigned
+to an Epic via `review-priorities`.
 
 ### Next Steps
 
-This section is intentionally omitted. The skill generates a report and stops.
-Decisions about what to do with the findings are left entirely to the user.
-
-## Advanced Features
-
-See [REFERENCE.md](REFERENCE.md) for:
-
-- Technical data model and computation details
-- Query structure and GitHub API usage
-- Limitations and extension points
+This section is intentionally omitted. The skill generates a report and
+stops. Decisions about what to do with the findings are left to the user.
 
 ## Notes
 
-- **Epics are aggregators only**: An epic's status reflects its linked sub-issues. Individual sub-issues are rolled up; the report shows epic-level aggregates only.
-- **PR linking**: A PR is linked to a priority if the PR mentions an issue that's linked to the priority.
-- **Activity age**: Measured from last status change, commit push, or comment. Creation date is not considered.
-- **Stale threshold**: 1 week (7 days) — items with no activity in 7+ days are flagged
-- **Blocker source**: Blockers are sourced exclusively from formal GitHub issue relationship metadata (the "blocked by" relationship field on the issue). Body text mentioning "blocked by" is not parsed. Do not read blocker information from `PRIORITIES.md`.
-- **Live state required**: All issue/PR open-or-closed state and blocker relationships MUST be verified against live GitHub data. Never assume a state based on what `PRIORITIES.md` text says.
-- **Readiness**: A priority group is considered available for work only if (a) it has at least one unblocked pending issue AND (b) no priority group with a lower priority number has unblocked pending work. "No dependency blockage" alone does not make a group ready.
-- **Hard stop**: This skill MUST stop after producing its report. It MUST NOT invoke any other skill or take any action.
+- **Epics are aggregators**: An Epic's status reflects its sub-issues.
+- **Activity age**: Measured from last status change, commit, or comment.
+  Creation date is not counted.
+- **Stale threshold**: 7 days with no activity.
+- **Blocker source**: Exclusively from formal GitHub "blocked by"
+  relationships — never from body text.
+- **Live state required**: All issue/PR states MUST be verified live.
+- **Hard stop**: This skill MUST stop after producing its report.

--- a/.agents/skills/create-epic/SKILL.md
+++ b/.agents/skills/create-epic/SKILL.md
@@ -3,77 +3,55 @@ name: create-epic
 description: >
   Create a GitHub Epic issue for a priority group and wire existing leaf
   issues as its sub-issues. Uses the GitHub Epic issue type (via GraphQL)
-  and the GraphQL addSubIssue mutation. Invoke this skill whenever a priority
-  group needs an Epic created or updated (PAD-02-008, PAD-02-009).
+  and the GraphQL addSubIssue mutation. Invoke this skill whenever a
+  thematic group needs an Epic created or updated.
 ---
 
 # Skill: Create Epic
 
-Create a GitHub Epic issue for a priority group and link leaf issues as
+Create a GitHub Epic issue for a thematic group and link leaf issues as
 sub-issues. This skill is the canonical way to create Epics to ensure
-consistent use of the `Epic` issue type, `group:` label, and sub-issue wiring.
+consistent use of the `Epic` issue type and sub-issue wiring.
 
 ## Inputs
 
-- `GROUP_LABEL`: the `group:` label slug, e.g. `architecture-hardening`
 - `EPIC_TITLE`: one-line Epic title, e.g.
   `Architecture Hardening (Phase 2): Import violations and BT sync`
 - `EPIC_BODY`: multi-line body text (summary, open tasks list, rationale)
 - `LEAF_ISSUES`: space-separated issue numbers to link as sub-issues,
   e.g. `428 439 429`
+- `SCHEDULE`: initial Schedule value for Project #24 — one of `Now`, `Next`,
+  `Later`, `Someday` (default: `Someday`)
 - `REPO`: `CERTCC/Vultron` (default)
 
 ## Workflow
 
-### Step 1 — Verify no existing open Epic
+### Step 1 — Verify no existing open Epic for this theme
 
-Query GitHub for existing open Epics in this group to avoid duplicates
-(PAD-02-008):
+Search for open Epics with similar titles to avoid duplicates:
 
 ```bash
 gh issue list --repo CERTCC/Vultron \
-  --label "group:${GROUP_LABEL}" \
   --state open \
   --json number,title,issueType \
   | python3 -c "
 import json, sys
 issues = json.load(sys.stdin)
 epics = [i for i in issues if (i.get('issueType') or {}).get('name') == 'Epic']
-if len(epics) > 1:
-    nums = ', '.join(str(e['number']) for e in epics)
-    print(f'ERROR: {len(epics)} open Epics found for this group: {nums}')
-    print('Resolve to exactly one open Epic before proceeding (PAD-02-008).')
-    raise SystemExit(1)
-elif len(epics) == 1:
-    print('EPIC_EXISTS:', epics[0]['number'])
-else:
-    print('NO_EPIC')
+for e in epics:
+    print(f'  #{e[\"number\"]}: {e[\"title\"]}')
 "
 ```
 
-If multiple open Epics are found, stop and report the conflict — do **not**
-silently pick one. Close or merge the duplicate Epics manually until exactly
-one remains.
-
-If exactly one Epic already exists, skip Step 2 and proceed to Step 3 (link any
-unparented leaf issues).
+If a matching Epic already exists, skip Step 2 and proceed to Step 3.
 
 ### Step 2 — Create the Epic issue via GraphQL
 
 Use the bash helper script in this skill's directory:
 
 ```bash
-.agents/skills/create-epic/create_epic.sh \
-  "${GROUP_LABEL}" \
-  "${EPIC_TITLE}" \
-  "${EPIC_BODY}"
-```
-
-The script prints the new issue number on stdout (e.g. `443`). Capture it:
-
-```bash
 EPIC_NUMBER=$(.agents/skills/create-epic/create_epic.sh \
-  "${GROUP_LABEL}" "${EPIC_TITLE}" "${EPIC_BODY}")
+  "${EPIC_TITLE}" "${EPIC_BODY}")
 echo "Created Epic #${EPIC_NUMBER}"
 ```
 
@@ -90,35 +68,38 @@ of the Epic. All wiring is idempotent — already-linked issues are skipped.
   --sub-issue <LEAF_3>
 ```
 
-The script prints the Epic number on stdout and progress on stderr.
+### Step 4 — Add Epic to Project #24 with Schedule
 
-> **Note**: If you need to wire more than a handful of leaves, you can also
-> call the script once per leaf in a loop, or pass all leaf numbers as
-> multiple `--sub-issue` flags in one invocation.
+```bash
+# Get Epic node ID
+EPIC_NODE_ID=$(gh api graphql -f query='{
+  repository(owner:"CERTCC", name:"Vultron") {
+    issue(number: '"${EPIC_NUMBER}"') { id }
+  }
+}' --jq '.data.repository.issue.id')
 
-### Step 4 — Update PRIORITIES.md
+# Add to project
+ITEM_ID=$(gh api graphql -f query="mutation {
+  addProjectV2ItemById(input: {
+    projectId: \"PVT_kwDOAjf0s84BZnre\"
+    contentId: \"${EPIC_NODE_ID}\"
+  }) { item { id } }
+}" --jq '.data.addProjectV2ItemById.item.id')
 
-Record the Epic issue number next to the group heading in
-`plan/PRIORITIES.md` (PAD-02-010). Change the heading from:
-
-```markdown
-## Priority NNN: Title
+# Set Schedule field (Now=1e84189c Next=9fca00b2 Later=e2149d3e Someday=fcffa79d)
+SCHEDULE_ID="fcffa79d"  # default: Someday
+gh api graphql -f query="mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: \"PVT_kwDOAjf0s84BZnre\"
+    itemId: \"${ITEM_ID}\"
+    fieldId: \"PVTSSF_lADOAjf0s84BZnrezhUlFOM\"
+    value: { singleSelectOptionId: \"${SCHEDULE_ID}\" }
+  }) { projectV2Item { id } }
+}" >/dev/null
+echo "  Added to Project #24 with Schedule=${SCHEDULE}"
 ```
-
-to:
-
-```markdown
-## Priority NNN — Epic #M: Title
-```
-
-**Note**: `PRIORITIES.md` may only be modified by the `review-priorities`
-skill or a human. If invoking `create-epic` from another skill, pass the
-Epic number back to the caller and let `review-priorities` perform the
-PRIORITIES.md update.
 
 ### Step 5 — Return Epic number
-
-Output the Epic issue number so the caller can record it:
 
 ```bash
 echo "${EPIC_NUMBER}"
@@ -126,7 +107,6 @@ echo "${EPIC_NUMBER}"
 
 ## Constraints
 
-- Never create more than one open Epic per `group:` label (PAD-02-008).
 - Always check for an existing open Epic before creating a new one.
 - The `Epic` issue type ID for `CERTCC/Vultron` is `IT_kwDOAjf0s84B_E1A`.
   If this ID changes (e.g. after repo transfer), re-query:
@@ -137,5 +117,6 @@ echo "${EPIC_NUMBER}"
   ```
 
 - The repo node ID for `CERTCC/Vultron` is `R_kgDOIn77fA`.
-- Do not call this skill for groups with fewer than 2 open leaf issues
-  (PAD-02-008).
+- Project #24 node ID: `PVT_kwDOAjf0s84BZnre`
+- Schedule field ID: `PVTSSF_lADOAjf0s84BZnrezhUlFOM`
+- Schedule option IDs: `Now=1e84189c`, `Next=9fca00b2`, `Later=e2149d3e`, `Someday=fcffa79d`

--- a/.agents/skills/create-epic/create_epic.sh
+++ b/.agents/skills/create-epic/create_epic.sh
@@ -1,26 +1,28 @@
 #!/usr/bin/env bash
 # create_epic.sh — Create a GitHub Epic issue for CERTCC/Vultron
 #
-# Usage: create_epic.sh <group-label-slug> <title> <body>
+# Usage: create_epic.sh <title> <body>
 #
 # Prints the new issue number on stdout.
 # All other output goes to stderr.
 #
 # Example:
-#   EPIC_NUM=$(./create_epic.sh "architecture-hardening" \
+#   EPIC_NUM=$(./create_epic.sh \
 #     "Architecture Hardening (Phase 2): Import violations and BT sync" \
 #     "$(cat body.md)")
 
 set -euo pipefail
 
-GROUP_LABEL="${1:?Usage: create_epic.sh <group-label-slug> <title> <body>}"
-EPIC_TITLE="${2:?Usage: create_epic.sh <group-label-slug> <title> <body>}"
-EPIC_BODY="${3:?Usage: create_epic.sh <group-label-slug> <title> <body>}"
+EPIC_TITLE="${1:?Usage: create_epic.sh <title> <body>}"
+EPIC_BODY="${2:?Usage: create_epic.sh <title> <body>}"
 
 REPO_OWNER="CERTCC"
 REPO_NAME="Vultron"
 REPO_NODE_ID="R_kgDOIn77fA"
 EPIC_TYPE_ID="IT_kwDOAjf0s84B_E1A"
+PROJECT_ID="PVT_kwDOAjf0s84BZnre"
+SCHEDULE_FIELD_ID="PVTSSF_lADOAjf0s84BZnrezhUlFOM"
+SCHEDULE_SOMEDAY="fcffa79d"
 
 # JSON-encode title and body for safe GraphQL embedding
 TITLE_JSON=$(printf '%s' "${EPIC_TITLE}" \
@@ -29,7 +31,6 @@ BODY_JSON=$(printf '%s' "${EPIC_BODY}" \
   | python3 -c "import sys,json; print(json.dumps(sys.stdin.read()))")
 
 echo "Creating Epic issue: ${EPIC_TITLE}" >&2
-echo "  group:${GROUP_LABEL}" >&2
 
 # Step 1: Create the issue via GraphQL with Epic issue type
 RESULT=$(gh api graphql -f query="
@@ -53,12 +54,26 @@ EPIC_URL=$(echo "${RESULT}" | python3 -c \
 
 echo "  Created Epic #${EPIC_NUMBER}: ${EPIC_URL}" >&2
 
-# Step 2: Apply the group: label
-gh issue edit "${EPIC_NUMBER}" \
-  --repo "${REPO_OWNER}/${REPO_NAME}" \
-  --add-label "group:${GROUP_LABEL}" >&2
+# Step 2: Add to Project #24 with Schedule=Someday
+ITEM_ID=$(gh api graphql -f query="
+mutation {
+  addProjectV2ItemById(input: {
+    projectId: \"${PROJECT_ID}\"
+    contentId: \"${EPIC_ID}\"
+  }) { item { id } }
+}" --jq '.data.addProjectV2ItemById.item.id')
 
-echo "  Applied label: group:${GROUP_LABEL}" >&2
+gh api graphql -f query="
+mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: \"${PROJECT_ID}\"
+    itemId: \"${ITEM_ID}\"
+    fieldId: \"${SCHEDULE_FIELD_ID}\"
+    value: { singleSelectOptionId: \"${SCHEDULE_SOMEDAY}\" }
+  }) { projectV2Item { id } }
+}" >/dev/null
+
+echo "  Added to Project #24 with Schedule=Someday" >&2
 
 # Output only the Epic issue number on stdout so callers can capture it directly
 echo "${EPIC_NUMBER}"

--- a/.agents/skills/dev-status/REFERENCE.md
+++ b/.agents/skills/dev-status/REFERENCE.md
@@ -55,48 +55,95 @@ gh issue list --repo CERTCC/Vultron \
 For the full list (not just count), omit `| length` and add
 `"\(.number): \(.title)"` projection.
 
-## Query: Unscheduled Issues
+## Query: Triage Count (Schedule=Someday, no Epic parent)
 
 ```bash
-gh issue list --repo CERTCC/Vultron \
-  --limit 200 \
-  --label "group:unscheduled" \
-  --json number,title \
-  --jq 'length'
+# Get all project items with Schedule=Someday
+gh api graphql --jq '
+  [ .data.node.items.nodes[]
+    | select(
+        .content.state == "OPEN" and
+        ( .fieldValues.nodes[]
+          | select(.field.name == "Schedule")
+          | .name
+        ) == "Someday"
+      )
+    | .content.number
+  ] | length
+' -f query='{
+  node(id: "PVT_kwDOAjf0s84BZnre") {
+    ... on ProjectV2 {
+      items(first: 200) {
+        nodes {
+          content { ... on Issue { number state } }
+          fieldValues(first: 10) { nodes {
+            ... on ProjectV2ItemFieldSingleSelectValue {
+              name field { ... on ProjectV2SingleSelectField { name } }
+            }
+          }}
+        }
+      }
+    }
+  }
+}'
 ```
 
 ## Query: Ready-to-Build Count
 
-> ⚠️ **PRIORITIES.md is not authoritative for issue status.**
-> It is read **only** to extract the group label for the top-priority group.
-> Issue open/closed state MUST always be determined by the GitHub API.
-> Do NOT use ✅ markers, absence of ✅, or any other PRIORITIES.md text to
-> infer whether an issue is open or closed.
-
-1. Read `plan/PRIORITIES.md` to identify the **group label** for the
-   top-priority group (e.g., `group:architecture-hardening`). This is the
-   only information taken from the file.
-2. Query open leaf issues in that group with no open blockers using the
-   GitHub API:
+1. Find the first open Epic with `Schedule=Now` on Project #24 (lowest board
+   position = highest priority).
+2. Query its open leaf sub-issues with no open blockers:
 
 ```bash
-# Step 1: list open issues with the top-priority group label
-gh issue list --repo CERTCC/Vultron \
-  --limit 200 \
-  --label "<top-priority-group-label>" \
-  --json number,title \
-  --jq '.[].number'
+# Step 1: get Now-Epic numbers in board order
+gh api graphql --jq '
+  [ .data.node.items.nodes[]
+    | select(
+        .content.state == "OPEN" and
+        .content.issueType.name == "Epic" and
+        ( .fieldValues.nodes[]
+          | select(.field.name == "Schedule")
+          | .name
+        ) == "Now"
+      )
+    | .content.number
+  ][]
+' -f query='{
+  node(id: "PVT_kwDOAjf0s84BZnre") {
+    ... on ProjectV2 {
+      items(first: 100) {
+        nodes {
+          content {
+            ... on Issue { number state issueType { name } }
+          }
+          fieldValues(first: 10) { nodes {
+            ... on ProjectV2ItemFieldSingleSelectValue {
+              name field { ... on ProjectV2SingleSelectField { name } }
+            }
+          }}
+        }
+      }
+    }
+  }
+}'
 
-# Step 2: for each issue N, check blockers via GraphQL
+# Step 2: for each Epic, query sub-issues; for each sub-issue N, check leaf + blockers
 gh api graphql -f query='{
   repository(owner:"CERTCC", name:"Vultron") {
-    issue(number: N) {
-      blockedBy(first: 50) { nodes { number state } }
-      subIssues(first: 1) { totalCount }
+    issue(number: <EPIC_N>) {
+      subIssues(first: 50) {
+        nodes {
+          number state
+          blockedBy(first: 10) { nodes { number state } }
+          subIssues(first: 1) { totalCount }
+          labels(first: 10) { nodes { name } }
+        }
+      }
     }
   }
 }'
 # An issue is "ready" if:
+#   - state: OPEN, no stale-claim label, no assignee
 #   - all blockedBy nodes have state: CLOSED (or blockedBy is empty)
 #   - subIssues.totalCount == 0 (leaf issue, not a parent task)
 ```
@@ -133,24 +180,6 @@ grep -c '^### ' plan/BUILD_LEARNINGS.md 2>/dev/null || echo 0
 Returns the number of dated entry headers. Zero means the file contains only
 the preamble — no actionable entries.
 
-## Query: PRIORITIES.md Staleness
-
-```bash
-git log --format="%cr" --max-count=1 -- plan/PRIORITIES.md
-```
-
-Returns a human-readable relative time (e.g., `3 days ago`, `2 weeks ago`).
-Warn in the report if the value exceeds 14 days.
-
-To get the age in days for threshold comparisons:
-
-```bash
-git log --format="%ct" --max-count=1 -- plan/PRIORITIES.md \
-  | xargs -I{} python3 -c "
-import time; age=(time.time()-{})/86400; print(f'{age:.0f}')
-"
-```
-
 ## Report Template
 
 ```text
@@ -163,17 +192,15 @@ import time; age=(time.time()-{})/86400; print(f'{age:.0f}')
 | Bugs (open)           |  {n}  | bugfix               |
 | Concerns (open)       |  {n}  | process-concerns     |
 | Open PRs              |  {n}  | pr-comprehensive-fix |
-| Unscheduled issues    |  {n}  | review-priorities    |
+| Triage (Someday)      |  {n}  | review-priorities    |
 | Ready to build        |  {n}  | build                |
 
-PRIORITIES.md last updated: {relative_time}{staleness_warning}
+Now: {epic_titles}
 
 **Next up**: {skill} — {reason}
 ```
 
-`{staleness_warning}` is omitted when age ≤ 14 days; otherwise append
-`⚠️ consider running review-priorities`.
-
+`{epic_titles}` lists the titles of all open `Schedule=Now` Epics on Project #24.
 When all counts are zero and BUILD_LEARNINGS is empty, replace the "Next up"
 line with:
 

--- a/.agents/skills/dev-status/SKILL.md
+++ b/.agents/skills/dev-status/SKILL.md
@@ -37,10 +37,9 @@ Read these in parallel:
 | GitHub Issues — type: Idea | Count of open issues |
 | GitHub Issues — type: Bug | Count of open issues |
 | GitHub Issues — type: Concern | Count of open issues — **this is the only concern source; do not read `docs/reference/codebase/CONCERNS.md`** |
-| GitHub Issues — label: `group:unscheduled` | Count of open issues |
+| GitHub Project #24 — `Schedule=Someday` (Triage) | Count of issues needing scheduling |
 | GitHub Pull Requests — open | Count of open PRs |
-| `plan/PRIORITIES.md` | Extract group labels only — **never trust issue status from this file** |
-| `git log -- plan/PRIORITIES.md` | Days since last commit to PRIORITIES.md |
+| GitHub Project #24 — `Schedule=Now` Epics | List of open Epics driving current work |
 
 See [REFERENCE.md](REFERENCE.md) for the exact `gh` and `git` commands.
 
@@ -58,20 +57,20 @@ Print a single table followed by a "Next up" callout:
 | Bugs (open)            |   3   | bugfix               |
 | Concerns (open)        |   0   | —                    |
 | Open PRs               |   2   | pr-comprehensive-fix |
-| Unscheduled issues     |   5   | review-priorities    |
+| Triage (Someday)       |   5   | review-priorities    |
 | Ready to build         |   4   | build                |
 
-PRIORITIES.md last updated: 3 days ago
+Now: #691 Migrate project tracking | #476 Bug Fixes and Demo Polish
 
 **Next up**: learn — BUILD_LEARNINGS.md has unprocessed entries.
 ```
 
 - **BUILD_LEARNINGS count**: number of `###` entry headers in the file
   (zero if only the preamble is present)
-- **Ready to build**: open leaf issues in the top-priority group that have no
-  open blockers — determined entirely from the GitHub API, **not** from
-  PRIORITIES.md text or ✅ markers
-- **PRIORITIES.md staleness**: warn if last commit > 14 days ago
+- **Ready to build**: open leaf issues in a Now-scheduled Epic that have no
+  open blockers — determined entirely from the GitHub API
+- **Triage**: issues in Project #24 with `Schedule=Someday` and no Epic parent
+- **Now** line: titles of all open Epics with `Schedule=Now` on Project #24
 
 ## Recommendation Logic
 
@@ -83,7 +82,7 @@ list all non-zero conditions as `ask_user` choices):
 3. `ingest-idea` — open Idea issues
 4. `bugfix` — open Bug issues
 5. `pr-comprehensive-fix` — open PRs > 0
-6. `review-priorities` — unscheduled issues > 0
+6. `review-priorities` — triage items > 0 (Schedule=Someday with no Epic)
 7. `build` — ready-to-build count > 0
 8. *(stop)* — all queues empty, nothing actionable
 

--- a/.agents/skills/ingest-concern/SKILL.md
+++ b/.agents/skills/ingest-concern/SKILL.md
@@ -181,7 +181,7 @@ NEW_ISSUE=$(
 Concern: #${CONCERN_NUMBER}
 $([ -n "${SPEC_FILE}" ] && echo "Spec: \`specs/${SPEC_FILE}\`")
 $([ -n "${NOTES_FILE}" ] && echo "Notes: \`notes/${NOTES_FILE}\`")" \
-    --label "group:unscheduled,size:<S|M|L>" \
+    --label "size:<S|M|L>" \
     --parent "${CONCERN_NUMBER}"
     # Add --blocked-by N for sequenced issues
 )
@@ -191,6 +191,30 @@ echo "Created impl issue #${NEW_ISSUE}"
 ```
 
 Set `size:` based on AC count: 1–2 → `size:S`; 3–6 → `size:M`; 7+ → `size:L`.
+
+Then add each new issue to Project #24 with `Schedule=Someday`:
+
+```bash
+NODE_ID=$(gh api graphql -f query='{
+  repository(owner:"CERTCC", name:"Vultron") {
+    issue(number: '"${NEW_ISSUE}"') { id }
+  }
+}' --jq '.data.repository.issue.id')
+ITEM_ID=$(gh api graphql -f query="mutation {
+  addProjectV2ItemById(input: {
+    projectId: \"PVT_kwDOAjf0s84BZnre\"
+    contentId: \"${NODE_ID}\"
+  }) { item { id } }
+}" --jq '.data.addProjectV2ItemById.item.id')
+gh api graphql -f query="mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: \"PVT_kwDOAjf0s84BZnre\"
+    itemId: \"${ITEM_ID}\"
+    fieldId: \"PVTSSF_lADOAjf0s84BZnrezhUlFOM\"
+    value: { singleSelectOptionId: \"fcffa79d\" }
+  }) { projectV2Item { id } }
+}" >/dev/null
+```
 
 ### Phase 6 — Lint Markdown (if docs changed)
 
@@ -276,7 +300,8 @@ fi
 - [ ] `AGENTS.md` updated — or consciously skipped
 - [ ] Markdown lint clean (if docs changed)
 - [ ] One or more implementation issues created via `manage-github-issue`
-  with `group:unscheduled` + `size:` labels; concern wired as parent
+  with `size:` label, added to Project #24 with `Schedule=Someday`;
+  concern wired as parent
 - [ ] Docs-only PR opened with `specs-notes` label — or skipped (no doc
   changes)
 - [ ] Concern archived via `archive-history` skill (after PR creation, so
@@ -297,17 +322,9 @@ fi
   (same category as `learn` — resolved concerns are learning outcomes)
 - **Spec file names**: lowercase hyphenated `.yaml` in `specs/`
 - **Notes file names**: same base name as spec, `.md` in `notes/`
-- **Label rules** (PAD-02-007): `group:unscheduled` by default; if a
-  specific `group:` label is needed, derive slug from priority title in
-  kebab-case — no priority numbers in label names. Create the label if
-  missing:
-
-  ```bash
-  gh label create "group:<slug>" \
-    --repo CERTCC/Vultron \
-    --description "<Priority group title>" \
-    --color "#1d76db"
-  ```
+- **Project board**: Add all new issues to Project #24 ("Vultron Planning")
+  with `Schedule=Someday`. Use `review-priorities` to promote them to
+  Now/Next/Later when they are ready to be scheduled.
 
 ## Relationship to Other Skills
 

--- a/.agents/skills/ingest-idea/SKILL.md
+++ b/.agents/skills/ingest-idea/SKILL.md
@@ -6,9 +6,10 @@ description: >
   and create a GitHub implementation Issue as a sub-issue of the idea issue.
   Runs a structured interview (grill-me), writes specs/<topic>.yaml and
   notes/<topic>.md, archives the idea via `uv run append-history idea`, opens
-  a docs-only PR with the specs-notes label, and creates a GitHub Issue tagged
-  group:unscheduled. Use when the user says "ingest idea", references a GitHub
-  Idea issue number, or wants to convert an idea into spec and notes files.
+  a docs-only PR with the specs-notes label, and creates a GitHub Issue added
+  to Project #24 with Schedule=Someday. Use when the user says "ingest idea",
+  references a GitHub Idea issue number, or wants to convert an idea into spec
+  and notes files.
 ---
 
 # Skill: Ingest Idea
@@ -214,7 +215,7 @@ IMPL_ISSUE_NUMBER=$(.agents/skills/manage-github-issue/manage_github_issue.sh \
 
 Spec: \`specs/<topic>.yaml\` (ID-01 through ID-NN)
 Notes: \`notes/<topic>.md\`" \
-  --label "group:unscheduled,size:<S|M|L>" \
+  --label "size:<S|M|L>" \
   --parent "${IDEA_NUMBER}")
   # Add --blocked-by N if this issue has known blockers at creation time
 echo "Created implementation issue #${IMPL_ISSUE_NUMBER}"
@@ -223,8 +224,32 @@ echo "Created implementation issue #${IMPL_ISSUE_NUMBER}"
 Set the `size:` label based on AC checkbox count:
 1–2 ACs → `size:S`; 3–6 ACs → `size:M`; 7+ ACs → `size:L`.
 
-The implementation Issue sits in `group:unscheduled` until a human runs
-`review-priorities` to slot it into `plan/PRIORITIES.md`.
+Then add the implementation Issue to Project #24 with `Schedule=Someday`:
+
+```bash
+NODE_ID=$(gh api graphql -f query='{
+  repository(owner:"CERTCC", name:"Vultron") {
+    issue(number: '"${IMPL_ISSUE_NUMBER}"') { id }
+  }
+}' --jq '.data.repository.issue.id')
+ITEM_ID=$(gh api graphql -f query="mutation {
+  addProjectV2ItemById(input: {
+    projectId: \"PVT_kwDOAjf0s84BZnre\"
+    contentId: \"${NODE_ID}\"
+  }) { item { id } }
+}" --jq '.data.addProjectV2ItemById.item.id')
+gh api graphql -f query="mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: \"PVT_kwDOAjf0s84BZnre\"
+    itemId: \"${ITEM_ID}\"
+    fieldId: \"PVTSSF_lADOAjf0s84BZnrezhUlFOM\"
+    value: { singleSelectOptionId: \"fcffa79d\" }
+  }) { projectV2Item { id } }
+}" >/dev/null
+```
+
+The issue appears in the "Triage" view of Project #24 until a human runs
+`review-priorities` to move it to Now/Next/Later.
 
 ### 12. Archive the idea and close the issue
 
@@ -272,7 +297,7 @@ gh issue close "${IDEA_NUMBER}" --repo CERTCC/Vultron
 - [ ] Docs-only PR opened with `specs-notes` label and `Ref #<idea_number>`
   in body
 - [ ] Implementation GitHub Issue created via `manage-github-issue` with
-  `group:unscheduled` and `size:` labels; idea issue wired as parent;
+  `size:` labels; idea issue wired as parent;
   other blockers wired as structured relationships
 - [ ] Idea issue commented with links to PR and implementation issue, then
   closed
@@ -319,20 +344,8 @@ mutation {
 The issue will appear as an Idea type in GitHub and will be picked up by
 `ingest-idea` the next time it runs.
 
-## Label Naming Rules (PAD-02-007)
+## Project Board
 
-All new Issues created by this skill use `group:unscheduled` by default — no
-priority number or slug is needed at creation time. However, if you are
-assigning a specific `group:` label for any reason:
-
-- **Never include a priority number** in the label name.
-  Use `group:architecture-hardening`, **not** `group:473-architecture-hardening`.
-- **Derive the slug** from the priority group title in kebab-case.
-- **Check for label existence** before assigning. Create it if missing:
-
-  ```bash
-  gh label create "group:<slug>" \
-    --repo CERTCC/Vultron \
-    --description "<Priority group title (no number)>" \
-    --color "#1d76db"
-  ```
+All new Issues created by this skill are added to Project #24 ("Vultron
+Planning") with `Schedule=Someday`. Use `review-priorities` to move them
+to Now/Next/Later when they are ready to be scheduled.

--- a/.agents/skills/manage-github-issue/SKILL.md
+++ b/.agents/skills/manage-github-issue/SKILL.md
@@ -27,7 +27,7 @@ Use the structured GitHub relationship APIs documented here instead.
 | `ISSUE_NUMBER` | — | Issue # to update; omit to create a new issue |
 | `TITLE` | — | Issue title (required for create, optional for update) |
 | `BODY` | — | Issue body markdown |
-| `LABELS` | — | Comma-separated label names (e.g. `group:unscheduled,size:M`) |
+| `LABELS` | — | Comma-separated label names (e.g. `size:M`) |
 | `ASSIGNEES` | — | Comma-separated GitHub usernames |
 | `ISSUE_TYPE_ID` | — | GraphQL node ID of the issue type (see Constants) |
 | `PARENT_ISSUE` | — | Parent issue number (sets parent/child sub-issue link) |

--- a/.agents/skills/new-concern/SKILL.md
+++ b/.agents/skills/new-concern/SKILL.md
@@ -4,9 +4,9 @@ description: >
   Create a single GitHub Concern-type issue from a freeform description.
   Runs a grill-me interview to flesh out category, severity, evidence, impact,
   and suggested action, then creates the issue using the concern.md template
-  format with the group:unscheduled and concern labels. Use when a developer
-  spots a concern that isn't in the current CONCERNS.md scan, or wants to
-  capture a concern immediately without running process-concerns.
+  format with the `concern` label. Use when a developer spots a concern that
+  isn't in the current CONCERNS.md scan, or wants to capture a concern
+  immediately without running process-concerns.
 ---
 
 # Skill: New Concern
@@ -130,18 +130,13 @@ TITLE_JSON=$(printf '%s' "${TITLE}" \
 BODY_JSON=$(printf '%s' "${BODY}" \
   | python3 -c "import sys,json; print(json.dumps(sys.stdin.read()))")
 
-# Ensure labels exist before applying them
-gh label create "group:unscheduled" \
-  --repo CERTCC/Vultron \
-  --description "Not yet scheduled in PRIORITIES.md" \
-  --color "#e4e669" 2>/dev/null || true
-
+# Ensure concern label exists before applying it
 gh label create "concern" \
   --repo CERTCC/Vultron \
   --description "Technical risk, debt, or fragile area" \
   --color "#d93f0b" 2>/dev/null || true
 
-ISSUE_NUMBER=$(gh api graphql -f query="
+RESULT=$(gh api graphql -f query="
 mutation {
   createIssue(input: {
     repositoryId: \"${REPO_NODE_ID}\"
@@ -149,13 +144,33 @@ mutation {
     body: ${BODY_JSON}
     issueTypeId: \"${CONCERN_TYPE}\"
   }) {
-    issue { number url }
+    issue { number id url }
   }
-}" --jq '.data.createIssue.issue.number')
+}")
+ISSUE_NUMBER=$(echo "${RESULT}" | python3 -c \
+  "import json,sys; print(json.load(sys.stdin)['data']['createIssue']['issue']['number'])")
+ISSUE_NODE_ID=$(echo "${RESULT}" | python3 -c \
+  "import json,sys; print(json.load(sys.stdin)['data']['createIssue']['issue']['id'])")
 
 gh issue edit "${ISSUE_NUMBER}" \
   --repo CERTCC/Vultron \
-  --add-label "group:unscheduled,concern"
+  --add-label "concern"
+
+# Add to Project #24 with Schedule=Someday
+ITEM_ID=$(gh api graphql -f query="mutation {
+  addProjectV2ItemById(input: {
+    projectId: \"PVT_kwDOAjf0s84BZnre\"
+    contentId: \"${ISSUE_NODE_ID}\"
+  }) { item { id } }
+}" --jq '.data.addProjectV2ItemById.item.id')
+gh api graphql -f query="mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: \"PVT_kwDOAjf0s84BZnre\"
+    itemId: \"${ITEM_ID}\"
+    fieldId: \"PVTSSF_lADOAjf0s84BZnrezhUlFOM\"
+    value: { singleSelectOptionId: \"fcffa79d\" }
+  }) { projectV2Item { id } }
+}" >/dev/null
 
 echo "Created concern issue #${ISSUE_NUMBER}"
 ```
@@ -201,6 +216,6 @@ Print a one-line confirmation:
 - [ ] If near-duplicate found, user chose create-new or update-existing
 - [ ] All template fields resolved via grill-me interview
 - [ ] Issue body built from concern template format
-- [ ] Issue created (with `group:unscheduled` + `concern` labels) or
+- [ ] Issue created (with `concern` label, added to Project #24) or
       updated (with refresh comment)
 - [ ] Confirmation URL printed

--- a/.agents/skills/process-concerns/SKILL.md
+++ b/.agents/skills/process-concerns/SKILL.md
@@ -5,9 +5,10 @@ description: >
   issues. Optionally runs a focused acquire-codebase-knowledge scan first.
   Deduplicates against existing open Concern issues — updating the body and
   appending a refresh comment on matches, creating new issues otherwise.
-  Handles the [ASK USER] Questions section interactively. Labels all new
-  issues group:unscheduled. Does not write to specs/, notes/, or open a PR.
-  Use when you want to turn a codebase scan into a set of tracked GitHub issues.
+  Handles the [ASK USER] Questions section interactively. Adds all new
+  issues to Project #24 with Schedule=Someday. Does not write to specs/,
+  notes/, or open a PR. Use when you want to turn a codebase scan into a
+  set of tracked GitHub issues.
 ---
 
 # Skill: Process Concerns
@@ -125,18 +126,13 @@ TITLE_JSON=$(printf '%s' "${TITLE}" \
 BODY_JSON=$(printf '%s' "${BODY}" \
   | python3 -c "import sys,json; print(json.dumps(sys.stdin.read()))")
 
-# Ensure labels exist before applying them
-gh label create "group:unscheduled" \
-  --repo CERTCC/Vultron \
-  --description "Not yet scheduled in PRIORITIES.md" \
-  --color "#e4e669" 2>/dev/null || true
-
+# Ensure concern label exists before applying it
 gh label create "concern" \
   --repo CERTCC/Vultron \
   --description "Technical risk, debt, or fragile area" \
   --color "#d93f0b" 2>/dev/null || true
 
-ISSUE_NUMBER=$(gh api graphql -f query="
+RESULT=$(gh api graphql -f query="
 mutation {
   createIssue(input: {
     repositoryId: \"${REPO_NODE_ID}\"
@@ -144,13 +140,33 @@ mutation {
     body: ${BODY_JSON}
     issueTypeId: \"${CONCERN_TYPE}\"
   }) {
-    issue { number url }
+    issue { number id url }
   }
-}" --jq '.data.createIssue.issue.number')
+}")
+ISSUE_NUMBER=$(echo "${RESULT}" | python3 -c \
+  "import json,sys; print(json.load(sys.stdin)['data']['createIssue']['issue']['number'])")
+ISSUE_NODE_ID=$(echo "${RESULT}" | python3 -c \
+  "import json,sys; print(json.load(sys.stdin)['data']['createIssue']['issue']['id'])")
 
 gh issue edit "${ISSUE_NUMBER}" \
   --repo CERTCC/Vultron \
-  --add-label "group:unscheduled,concern"
+  --add-label "concern"
+
+# Add to Project #24 with Schedule=Someday
+ITEM_ID=$(gh api graphql -f query="mutation {
+  addProjectV2ItemById(input: {
+    projectId: \"PVT_kwDOAjf0s84BZnre\"
+    contentId: \"${ISSUE_NODE_ID}\"
+  }) { item { id } }
+}" --jq '.data.addProjectV2ItemById.item.id')
+gh api graphql -f query="mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: \"PVT_kwDOAjf0s84BZnre\"
+    itemId: \"${ITEM_ID}\"
+    fieldId: \"PVTSSF_lADOAjf0s84BZnrezhUlFOM\"
+    value: { singleSelectOptionId: \"fcffa79d\" }
+  }) { projectV2Item { id } }
+}" >/dev/null
 
 echo "Created concern issue #${ISSUE_NUMBER}"
 ```
@@ -164,14 +180,19 @@ user's response:
 - If the question reveals a **Concern** (a technical risk or gap) →
   create a `type:Concern` issue using the same flow as Phase 3c.
 - If the question reveals a **Task** (a decision or action item) →
-  create a `type:Task` issue using:
+  create a `type:Task` issue and add to Project #24 with Schedule=Someday:
 
   ```bash
-  gh issue create \
+  RESULT=$(gh issue create \
     --repo CERTCC/Vultron \
     --title "${TITLE}" \
     --body "${BODY}" \
-    --label "group:unscheduled"
+    --json number,id)
+  TASK_NUMBER=$(echo "${RESULT}" | python3 -c \
+    "import json,sys; print(json.load(sys.stdin)['number'])")
+  TASK_NODE_ID=$(echo "${RESULT}" | python3 -c \
+    "import json,sys; print(json.load(sys.stdin)['id'])")
+  # Then add to project with Schedule=Someday (same snippet as above)
   ```
 
 - If the question is resolved by the user's answer (no issue needed) →
@@ -258,8 +279,8 @@ Map CONCERNS.md section names to Category checkboxes:
 - [ ] CONCERNS.md parsed into per-row items
 - [ ] Each item deduplicated against open issues (by title similarity)
 - [ ] Matched items: body updated + refresh comment added
-- [ ] New items: Concern issue created with `group:unscheduled` + `concern`
-      labels
+- [ ] New items: Concern issue created with `concern` label, added to
+      Project #24 with Schedule=Someday
 - [ ] `[ASK USER]` questions surfaced via `ask_user`; issues created or
       decisions noted
 - [ ] Summary table printed

--- a/.agents/skills/review-priorities/REFERENCE.md
+++ b/.agents/skills/review-priorities/REFERENCE.md
@@ -6,206 +6,138 @@ title: review-priorities Reference
 
 Technical implementation details for the combined audit-and-update workflow.
 
-## Architecture: Daisy-Chained Skills
+## Architecture
 
 ```text
-review-priorities (outer coordinator)
+review-priorities (coordinator)
   ├─ Phase 1: Invoke check-priority-status
-  │  └─ Output: Detailed status report
-  ├─ Phase 2: Parse report findings
-  │  ├─ Extract uncovered issues
-  │  ├─ Identify empty priorities
-  │  ├─ Flag stale items
-  │  └─ Summarize for user
-  ├─ Phase 3: Offer interactive updates
-  │  └─ For each action: Invoke update-priorities workflows
-  │     ├─ Add new priority
-  │     ├─ Refine existing
-  │     └─ Remove priority
-  └─ Phase 4: Commit (if changes made)
+  │  └─ Output: Status report (by tier, per Epic, coverage, health)
+  ├─ Phase 2: Summarize significant findings for user
+  ├─ Phase 3: Interactive update loop (ask_user per action)
+  │  ├─ Move item between tiers (API mutation)
+  │  ├─ Promote triage item (API mutation)
+  │  ├─ Create Epic (invoke create-epic skill)
+  │  └─ Archive Epic (invoke archive-history, close issue)
+  └─ Phase 4: Commit if notes/history files changed
 ```
 
-### Phase 1: Run check-priority-status
+## Project Board Constants
 
-Call the `check-priority-status` skill (or invoke its logic directly):
+| Name | Value |
+|---|---|
+| Project node ID | `PVT_kwDOAjf0s84BZnre` |
+| Schedule field ID | `PVTSSF_lADOAjf0s84BZnrezhUlFOM` |
+| Now option ID | `1e84189c` |
+| Next option ID | `9fca00b2` |
+| Later option ID | `e2149d3e` |
+| Someday option ID | `fcffa79d` |
 
-```python
-status_report = check_priority_status()
-# Returns structured report with:
-#   - summary (coverage %, status distribution)
-#   - per_priority_progress (table data)
-#   - uncovered_issues (list)
-#   - empty_priorities (list)
-#   - orphaned_prs (list)
-#   - stale_items (list)
-#   - health_flags (list of concerns)
+## Phase 1: Run check-priority-status
+
+Invoke the `check-priority-status` skill and capture its output. The report
+provides:
+
+- Items per tier (Now/Next/Later/Someday)
+- Per-Epic sub-issue progress
+- Coverage (issues on board vs. off board)
+- Triage count (Someday items needing scheduling)
+- Stale items (>7 days no activity)
+- Orphaned PRs
+
+## Phase 2: Summarize Findings
+
+Surface significant findings via plain text before asking for action:
+
+```text
+📊 Board status:
+  Now:     3 Epics (12 open sub-issues, 2 blocked)
+  Next:    2 Epics (8 open sub-issues)
+  Later:   1 Epic  (4 open sub-issues)
+  Someday: 7 items (triage needed)
+
+⚠ 14 open issues not yet on board
+⚠ 3 stale items (>1 week inactive)
 ```
 
-### Phase 2: Analyze Findings
+## Phase 3: Interactive Update Loop
 
-Extract key insights from report:
-
-```python
-def summarize_findings(report):
-    """Return user-facing summary of significant findings."""
-    issues = []
-
-    if len(report['uncovered_issues']) > 5:
-        issues.append(f"⚠ {len(report['uncovered_issues'])} uncovered open issues")
-
-    if report['empty_priorities']:
-        issues.append(f"⚠ {len(report['empty_priorities'])} priorities with no active work")
-
-    if len(report['stale_items']) > 2:
-        issues.append(f"⚠ {len(report['stale_items'])} items stale (>1 week)")
-
-    return issues  # Sorted by severity
-```
-
-### Phase 3: Interactive Update Loop
-
-After showing report, offer update options:
+Use `ask_user` for every choice — never ask questions in plain text.
 
 ```python
 while True:
-    action = ask_user([
-        "Add new priority group",
-        "Refine existing priority",
-        "Remove a priority",
-        "No changes, exit"
-    ])
-
-    if action == "Add new priority group":
-        # Delegate to update-priorities logic
-        add_priority_workflow()
-        modified = True
-    elif action == "Refine existing priority":
-        refine_priority_workflow()
-        modified = True
-    elif action == "Remove a priority":
-        remove_priority_workflow()
-        modified = True
-    else:
+    action = ask_user(
+        question="What would you like to do?",
+        choices=[
+            "Move item(s) between Schedule tiers (Recommended)",
+            "Promote Triage items to Now/Next/Later",
+            "Create a new Epic for uncovered issues",
+            "Archive a completed Epic",
+            "No changes, exit",
+        ]
+    )
+    if action == "No changes, exit":
         break
+    # ... delegate to sub-workflow
 ```
 
-Within each action, reuse `update-priorities` logic:
+### Move Item Between Tiers
 
-- Gather input (title, description, issues, dependencies)
-- Validate (GitHub API checks, link validation)
-- Apply changes in-memory
-- Offer "Another change? [Yes/No]"
+1. Ask which issue/Epic number to move.
+2. Ask which tier (Now / Next / Later / Someday).
+3. Look up the item's project item ID via board items query.
+4. Call `updateProjectV2ItemFieldValue` with the chosen option ID.
+5. Confirm to user.
 
-### Phase 4: Unified Preview & Commit
+### Promote Triage Items
 
-After all updates, show single diff of all changes:
+1. List all Someday items for user to choose from.
+2. Ask which tier to promote to.
+3. Apply the move (same mutation as above).
 
-```diff
---- plan/PRIORITIES.md (before)
-+++ plan/PRIORITIES.md (after)
+### Create Epic
 
-  ## Priority 475 — Participant Case Replica Safety
-  ...
--  - [#440](...)
-+  - [#440](...)
-+  - [#500](...)
+1. Ask for Epic title and description.
+2. Ask which leaf issues to include.
+3. Invoke `create-epic` skill.
+4. Wire sub-issues via `manage-github-issue`.
 
-+ ## Priority 480 — New Feature
-+
-+ Description...
+### Archive Completed Epic
 
-  ## Priority 476 — Bug Fixes
-```
+1. Confirm all sub-issues are closed.
+2. Invoke `archive-history` skill with type `priority`.
+3. Close the Epic: `gh issue close <N> --repo CERTCC/Vultron`.
 
-Then:
+## Phase 4: Commit (if needed)
 
-1. Ask: "Write these changes?"
-2. If yes:
-   - Generate commit message: `"Review and update priorities\n\nAdded: 1 group\nModified: 1 group\nRemoved: 0 groups"`
-   - Add co-author trailer
-   - Commit
-3. If no:
-   - Save draft to session workspace
-   - Exit
+Board changes (Schedule field updates) happen live via API — no file commit
+needed.
 
-## Integration Points
-
-### With check-priority-status
-
-- Call its core logic (or invoke via subprocess if separate implementation)
-- Parse its report format
-- Summarize findings in user-friendly language
-
-### With update-priorities
-
-- Reuse all validation logic (GitHub API, link checking, format validation)
-- Reuse all user prompts and workflows
-- Share diff generation logic
-- Share commit message templates
+If `archive-history` was invoked (creates a file under `plan/history/`),
+or if notes files were modified, invoke the `commit` skill.
 
 ## Error Handling
 
-### If check-priority-status Fails
+### GitHub API Failure
 
 ```text
-❌ Failed to fetch GitHub issues
-   Likely cause: No GitHub token or insufficient permissions
-   Action: Exit with guidance ("Check your GITHUB_TOKEN environment variable")
+❌ Failed to fetch board items
+   Cause: No token or insufficient permissions
+   Action: Exit with guidance ("Check your GitHub token")
 ```
 
-### If update-priorities Validation Fails
+### Item Not on Board
 
-User is already in an update workflow. Offer to:
-
-- Fix the issue (e.g., correct a typo)
-- Skip this change (go back to menu)
-- Abort (exit without writing)
-
-## Performance Considerations
-
-- **check-priority-status**: May take 10–30s to fetch all issues and compute aggregates (GitHub API rate limits)
-- **update-priorities workflows**: Fast (mostly user input gathering), validation happens async
-- **Overall**: Expect 30–60s for a full session (status check + 1–2 updates)
+If the user references an issue not in Project #24, offer to add it first
+with `Schedule=Someday` before moving it to the desired tier.
 
 ## Configuration
 
-Environment variables (optional):
-
 ```bash
-GITHUB_TOKEN=ghp_...                  # Required for API access
-PRIORITY_STATUS_STALE_DAYS=7          # Staleness threshold (default: 7)
-PRIORITY_GITHUB_OWNER=CERTCC          # GitHub org (default: CERTCC)
-PRIORITY_GITHUB_REPO=Vultron          # GitHub repo (default: Vultron)
+GITHUB_TOKEN=ghp_...   # Required for API access
 ```
 
-## State Management
+## Rollback
 
-### In-Memory Changes
-
-During interactive update loop, accumulate changes in-memory:
-
-```python
-changes = {
-    'added': [],      # New priority groups
-    'modified': {},   # Existing groups and their changes
-    'removed': []     # Removed priority IDs
-}
-```
-
-Before committing, reconstruct full `plan/PRIORITIES.md` from original + changes.
-
-### Rollback
-
-- If user cancels before commit: changes are discarded (in-memory only)
-- If commit fails: changes are not lost but file state uncertain; user should check Git status
-- If commit succeeds: tracked in Git (use `git revert` to undo)
-
-## Extensibility
-
-Future enhancements:
-
-- **Batch import**: Load priorities from CSV/JSON file
-- **Priority renumbering**: Consolidate gaps in priority numbers
-- **Report export**: Save findings to JSON/CSV for external tools
-- **Scheduled checks**: Hook into CI to run status check on PRs/pushes
-- **Integration with project boards**: Auto-sync GitHub project board based on priorities
+- Board moves: re-run the move mutation with the previous tier option ID.
+- Closed Epics: `gh issue reopen <N> --repo CERTCC/Vultron`.
+- History entries: immutable; document corrections in a new entry.

--- a/.agents/skills/review-priorities/SKILL.md
+++ b/.agents/skills/review-priorities/SKILL.md
@@ -1,219 +1,144 @@
 ---
 name: review-priorities
-description: Audit and update PRIORITIES.md in one workflow. Runs a comprehensive status check against open issues and PRs, then offers interactive options to add, refine, or remove priority groups. Use when you want to review where the project stands relative to plans and make any necessary updates.
+description: >
+  Audit and update Project #24 ("Vultron Planning") in one workflow. Runs a
+  comprehensive status check against the board and open issues/PRs, then
+  offers interactive options to move items between Schedule tiers (Now/Next/
+  Later/Someday), promote Triage items, archive completed Epics, and wire
+  sub-issue relationships. Use when you want to review where the project
+  stands and make any necessary board updates.
 ---
 
 # Review Priorities
 
-Complete audit-and-update workflow for `plan/PRIORITIES.md`. Combines status checking and interactive updates into a single guided workflow.
+Complete audit-and-update workflow for GitHub Project #24 ("Vultron
+Planning"). Combines status checking and interactive updates into a single
+guided workflow.
 
-## Quick start
+## Quick Start
 
-Run the review-priorities skill.
-
-The skill will:
+Run the review-priorities skill. The skill will:
 
 1. **Check status** (via `check-priority-status`):
-   - Audit current priorities against open GitHub issues and PRs
-   - Generate detailed report: coverage %, progress per group, uncovered issues, stale work
+   - Audit current board tiers against open GitHub issues and PRs
+   - Generate report: tier coverage, per-Epic progress, triage count,
+     stale items
 2. **Review findings** with you:
-   - Highlight significant gaps, empty priorities, stale items
+   - Highlight significant gaps, empty tiers, stale items, triage backlog
    - Offer insights on what might need updating
 3. **Offer interactive update options**:
-   - Add new priority groups (for uncovered work)
-   - Refine existing groups (add/remove issues, update description)
-   - Remove completed priorities (archive via `append-history`)
+   - Move items between Schedule tiers (Now / Next / Later / Someday)
+   - Promote Triage (Someday) items to a schedule tier
+   - Create a new Epic for related leaf issues
+   - Archive a completed Epic (close issue + log history entry)
    - Skip updates and just review
-4. **Stage and commit** any changes made
+4. **Commit** any notes or history changes made (board changes happen live
+   via API — no file commit needed for pure scheduling changes)
 
 ## Workflows
 
 ### Typical Session: Review Only
 
-If the status report shows everything on track:
+1. Run skill → review report → exit (no changes needed)
 
-1. Run skill
-2. Review findings
-3. Exit (no changes needed)
-4. Done
+### Typical Session: Schedule Triage Items
 
-### Typical Session: Review + Update
+1. Run skill → review triage backlog
+2. For each Someday item that is ready: move to Now / Next / Later
+3. Done (changes applied live via API)
 
-If the status report flags uncovered issues or stale work:
+### Typical Session: Rebalance Tiers
 
-1. Run skill
-2. Review findings
-3. Choose: "Add new priority for uncovered issues? [Yes/No]"
-4. Interactively add/refine groups (uses `update-priorities` logic)
-5. Preview changes
-6. Commit
-7. Done
-
-### Typical Session: Review + Multiple Updates
-
-If multiple changes are warranted:
-
-1. Run skill
-2. Review findings
-3. Add new priority #480 for uncovered issues
-4. Ask: "Make more updates? [Add another / Refine existing / Remove / No]"
-5. Refine existing priority #475
-6. Ask again: "More updates?"
-7. Done adding
-8. Preview all changes together
-9. Commit
-10. Done
+1. Run skill → see Now tier is overcrowded
+2. Move lower-urgency Epics from Now → Next
+3. Preview changes → confirm → apply
 
 ## Report Sections (from check-priority-status)
 
 ### Summary
 
-- Total priority groups, linked items, coverage %
-- Status distribution (closed, pending, PR-pending, blocked)
-- Activity age and stale items (1-week threshold)
+- Items per tier (Now / Next / Later / Someday), triage count
+- Coverage % (open issues on board vs. off board)
+- Stale items (no activity for 1 week)
 
-### Per-Priority Progress
+### Per-Tier Progress
 
-Table: each group's progress toward completion, with status indicators.
+Table: each Epic's sub-issue progress by tier.
 
 ### Coverage Audit
 
-- **Uncovered issues**: All open issues not in any priority (with labels, age, activity)
-- **Empty priorities**: Groups with no active work
-- **Orphaned PRs**: Open PRs not linked to any priority
+- Issues not yet on board
+- Empty tiers / Epics with no open sub-issues
+- Orphaned PRs
 
 ### Health Check
 
-- Stale items (no activity for 1+ week)
-- Long-pending PRs
-- Dependency chains and blockers
+- Stale items, long-pending PRs, open blockers
 
 ## Interactive Update Options
 
-After reviewing the status report, you're offered:
+After reviewing the status report:
 
 ```text
-Based on the report:
-  - 12 uncovered open issues
-  - 1 empty priority (476)
-  - 2 stale items (>1 week inactive)
-
 What would you like to do?
-  [A] Add new priority group(s)
-  [B] Refine existing priority
-  [C] Remove a priority
-  [D] No changes, exit
+  [A] Move item(s) between Schedule tiers
+  [B] Promote Triage items to Now/Next/Later
+  [C] Create a new Epic for uncovered issues
+  [D] Archive a completed Epic
+  [E] No changes, exit
 ```
 
-### Add New Priority
-
-- Identify root issue (epic or feature)
-- List related work
-- Clarify dependencies
-- Assign or auto-suggest priority number
-- Validate all issues exist and are open
-- Add to PRIORITIES.md
-
-### Refine Existing Priority
-
-- Select priority to update
-- Choose: title, description, add/remove issues, adjust priority number
-- Validate
-- Update in PRIORITIES.md
-
-### Remove Priority
-
-- Confirm all linked issues are closed
-- Archive via `append-history priority`
-- Remove from PRIORITIES.md
-
-### Epic Hierarchy Maintenance (PAD-02-008 – PAD-02-010)
-
-After adding, refining, or removing priority groups, enforce the Epic
-hierarchy for every group that has **2 or more open leaf Issues** (a leaf
-Issue is any Issue with no open sub-issues).
-
-For each such group:
-
-1. **Check for an existing open Epic** with the group's `group:` label:
-
-   ```bash
-   gh issue list --repo CERTCC/Vultron \
-     --label "group:<slug>" \
-     --state open \
-     --json number,title,issueType \
-     | python3 -c "
-   import json, sys
-   issues = json.load(sys.stdin)
-   epics = [i for i in issues if (i.get('issueType') or {}).get('name') == 'Epic']
-   print(epics[0]['number'] if epics else 'NONE')
-   "
-   ```
-
-2. **If no Epic exists**, invoke the `create-epic` skill. Provide the group
-   label slug, an Epic title derived from the PRIORITIES.md group heading,
-   a body listing the open leaf Issues, and the list of leaf issue numbers.
-   The skill returns the new Epic number.
-
-3. **If an Epic exists**, use the `manage-github-issue` skill to link any
-   open leaf Issues not yet wired as sub-issues.
-
-4. **Record the Epic number** in `plan/PRIORITIES.md` next to the group
-   heading (PAD-02-010):
-
-   ```markdown
-   ## Priority NNN — Epic #M: Title
-   ```
-
-   If the heading already has `— Epic #M:`, update the number only if the
-   old Epic was closed and a new one was created.
-
-Run this step for every group touched during the session, plus any group
-whose Epic number is missing from PRIORITIES.md.
-
-## Preview & Commit
-
-Before writing to disk:
-
-1. Show **diff preview** of all changes
-2. Ask for confirmation
-3. If yes:
-   - Stage `plan/PRIORITIES.md`
-   - Generate commit message (or prompt user for custom message)
-   - Add co-author trailer and commit
-4. If no:
-   - Save draft to session workspace
-   - Exit for manual review later
-
-## Advanced Features
-
-See [REFERENCE.md](REFERENCE.md) for:
-
-- Batch operations (add multiple priorities from structured input)
-- Priority renumbering (consolidate gaps)
-- Report export (JSON, CSV)
-- History queries
-
-## Component Skills
-
-This skill is built on two independent sub-skills:
-
-- **check-priority-status** — Status auditing (read-only, reports findings)
-- **update-priorities** — Interactive updates (write, validates, commits)
-
-You can run these independently if you prefer to separate concerns:
+### Move Item Between Tiers
 
 ```bash
-# Status check only
-check-priority-status
+# Set Schedule field on an Epic or issue in Project #24
+ITEM_ID=$(gh api graphql -f query='{
+  node(id:"PVT_kwDOAjf0s84BZnre") {
+    ... on ProjectV2 {
+      items(first:100) {
+        nodes {
+          id
+          content { ... on Issue { number } }
+        }
+      }
+    }
+  }
+}' --jq ".data.node.items.nodes[] | select(.content.number == ${ISSUE_NUMBER}) | .id")
 
-# Updates only (assuming you already know what to change)
-update-priorities
+gh api graphql -f query="mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: \"PVT_kwDOAjf0s84BZnre\"
+    itemId: \"${ITEM_ID}\"
+    fieldId: \"PVTSSF_lADOAjf0s84BZnrezhUlFOM\"
+    value: { singleSelectOptionId: \"${SCHEDULE_OPTION_ID}\" }
+  }) { projectV2Item { id } }
+}"
 ```
+
+Schedule option IDs:
+
+- Now: `1e84189c`
+- Next: `9fca00b2`
+- Later: `e2149d3e`
+- Someday: `fcffa79d`
+
+### Create a New Epic
+
+Invoke the `create-epic` skill. Provide title, body, and the list of
+leaf issue numbers to wire as sub-issues.
+
+### Archive a Completed Epic
+
+1. Verify all sub-issues are closed.
+2. Invoke `archive-history` skill with type `priority`.
+3. Close the Epic issue via `gh issue close`.
 
 ## Notes
 
-- **Review-first philosophy**: Always check status before updating. Findings inform decisions.
-- **User control**: No automatic changes. You decide what updates are warranted based on report.
-- **Archival requirement**: Completed priorities must be archived to `plan/history/` before removal.
-- **Undo via git**: If changes are committed incorrectly, use `git revert` or `git reset --soft`.
+- **Review-first**: Always check status before updating. Findings inform
+  decisions.
+- **User control**: No automatic changes — you decide what to update.
+- **Board changes are live**: Schedule moves take effect immediately via API.
+  No file commit is needed for pure scheduling changes.
+- **Undo**: Board moves can be undone by moving the item back. Closed Epics
+  can be reopened with `gh issue reopen`.

--- a/.agents/skills/study-project-docs/SKILL.md
+++ b/.agents/skills/study-project-docs/SKILL.md
@@ -29,10 +29,46 @@ output. Do **not** read raw `specs/*.yaml` files directly.
 
 ### Step 2 — Read plan context
 
-Read all of the following in parallel (do **not** recurse into `plan/history/`):
+Read the following (do **not** recurse into `plan/history/`):
 
-- `plan/PRIORITIES.md` — authoritative priority ordering
 - `plan/BUILD_LEARNINGS.md` — ephemeral build/bugfix observations (queue for `learn`)
+
+Then query Project #24 ("Vultron Planning") for open items with `Schedule=Now`
+to understand current top-priority work:
+
+```bash
+gh api graphql --jq '
+  .data.node.items.nodes[]
+  | select(.content.state == "OPEN")
+  | {
+      number: .content.number,
+      title:  .content.title,
+      type:   .content.issueType.name,
+      schedule: (
+        .fieldValues.nodes[]
+        | select(.field.name == "Schedule")
+        | .name
+      )
+    }
+  | select(.schedule == "Now")
+  | "#\(.number) [\(.type)]: \(.title)"
+' -f query='{
+  node(id: "PVT_kwDOAjf0s84BZnre") {
+    ... on ProjectV2 {
+      items(first: 100) {
+        nodes {
+          content { ... on Issue { number title state issueType { name } } }
+          fieldValues(first: 10) { nodes {
+            ... on ProjectV2ItemFieldSingleSelectValue {
+              name field { ... on ProjectV2SingleSelectField { name } }
+            }
+          }}
+        }
+      }
+    }
+  }
+}'
+```
 
 > **`plan/history/` is excluded from this step.** It is an archive of
 > completed work, not active planning context. Read it only when specifically

--- a/.agents/skills/update-plan/SKILL.md
+++ b/.agents/skills/update-plan/SKILL.md
@@ -2,10 +2,9 @@
 name: update-plan
 description: >
   Perform a gap analysis between current specs/notes and the codebase, then
-  create GitHub Issues for any untracked gaps and update PRIORITIES.md
-  references as needed. Observations and open questions go directly to
-  notes/ files. Use after learn or ingest-idea has updated specs/notes, and
-  before running build.
+  create GitHub Issues for any untracked gaps and add them to Project #24.
+  Observations and open questions go directly to notes/ files. Use after
+  learn or ingest-idea has updated specs/notes, and before running build.
 ---
 
 # Skill: Update Plan
@@ -28,8 +27,8 @@ to keep open Issues aligned with the codebase.
 1. Invoke `study-project-docs` to load all specs and context.
 2. Run a gap analysis: compare `specs/` + `notes/` against `vultron/` and
    `test/`.
-3. For each gap, create a GitHub Issue (group:unscheduled) rather than a plan
-   entry.
+3. For each gap, create a GitHub Issue (added to Project #24 with
+   Schedule=Someday) rather than a plan entry.
 4. Write any significant observations or open questions directly to the
    appropriate `notes/*.md` file (not to `BUILD_LEARNINGS.md`).
 5. Invoke `commit`.
@@ -90,13 +89,37 @@ ISSUE_NUMBER=$(.agents/skills/manage-github-issue/manage_github_issue.sh \
 ## Reference
 
 Spec: \`specs/<topic>.yaml\` <ID range>" \
-  --label "group:unscheduled,size:<S|M|L>")
+  --label "size:<S|M|L>")
   # Add --blocked-by N for known blockers
 echo "Created gap issue #${ISSUE_NUMBER}"
 ```
 
 Set the `size:` label from AC count: 1–2 → `size:S`; 3–6 → `size:M`;
 7+ → `size:L`.
+
+Then add the issue to Project #24 with `Schedule=Someday`:
+
+```bash
+NODE_ID=$(gh api graphql -f query='{
+  repository(owner:"CERTCC", name:"Vultron") {
+    issue(number: '"${ISSUE_NUMBER}"') { id }
+  }
+}' --jq '.data.repository.issue.id')
+ITEM_ID=$(gh api graphql -f query="mutation {
+  addProjectV2ItemById(input: {
+    projectId: \"PVT_kwDOAjf0s84BZnre\"
+    contentId: \"${NODE_ID}\"
+  }) { item { id } }
+}" --jq '.data.addProjectV2ItemById.item.id')
+gh api graphql -f query="mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: \"PVT_kwDOAjf0s84BZnre\"
+    itemId: \"${ITEM_ID}\"
+    fieldId: \"PVTSSF_lADOAjf0s84BZnrezhUlFOM\"
+    value: { singleSelectOptionId: \"fcffa79d\" }
+  }) { projectV2Item { id } }
+}" >/dev/null
+```
 
 Do **not** add tasks to GitHub Issues outside the `manage-github-issue`
 workflow documented above.
@@ -114,17 +137,17 @@ PARENT_NUMBER=$(.agents/skills/manage-github-issue/manage_github_issue.sh \
   --title "<Parent task title>" \
   --body "<Summary of the related gaps>" \
   --issue-type-id "IT_kwDOAjf0s84AcFLo" \
-  --label "group:unscheduled,size:<S|M|L>")
+  --label "size:<S|M|L>")
 
 # 2. Create each gap issue and wire as sub-issue of the parent
 CHILD_1=$(.agents/skills/manage-github-issue/manage_github_issue.sh \
   --title "<Gap 1>" --body "..." \
-  --label "group:unscheduled,size:S" \
+  --label "size:S" \
   --parent "${PARENT_NUMBER}")
 
 CHILD_2=$(.agents/skills/manage-github-issue/manage_github_issue.sh \
   --title "<Gap 2>" --body "..." \
-  --label "group:unscheduled,size:S" \
+  --label "size:S" \
   --parent "${PARENT_NUMBER}")
 ```
 
@@ -154,22 +177,8 @@ specific message (e.g.,
 - Use `uv run append-history implementation` only via `build` — never from
   within `update-plan`.
 
-## Label Naming Rules (PAD-02-007)
+## Project Board
 
-All Issues created by this skill use `group:unscheduled` — no priority number
-or slug needed at creation time. However, if you assign a specific `group:`
-label for any reason:
-
-- **Never include a priority number** in the label name.
-  Use `group:architecture-hardening`, **not** `group:473-architecture-hardening`.
-  Priority numbers can change when PRIORITIES.md is reordered.
-- **Derive the slug** from the priority group title in kebab-case
-  (e.g., "Cyclomatic Complexity Enforcement" → `group:cyclomatic-complexity`).
-- **Check for label existence** before assigning. Create it if missing:
-
-  ```bash
-  gh label create "group:<slug>" \
-    --repo CERTCC/Vultron \
-    --description "<Priority group title (no number)>" \
-    --color "#1d76db"
-  ```
+All Issues created by this skill are added to Project #24 ("Vultron Planning")
+with `Schedule=Someday`. Use `review-priorities` to move them to Now/Next/Later
+when they are ready to be scheduled.

--- a/.agents/skills/update-priorities/REFERENCE.md
+++ b/.agents/skills/update-priorities/REFERENCE.md
@@ -4,242 +4,103 @@ title: update-priorities Reference
 
 # Update Priorities — Reference
 
-Technical details and implementation guidance for the priority update workflow.
+Technical details for the priority update workflow.
 
-## Data Model
+## Project Board Constants
 
-### Priority Group Structure
+| Name | Value |
+|---|---|
+| Project node ID | `PVT_kwDOAjf0s84BZnre` |
+| Schedule field ID | `PVTSSF_lADOAjf0s84BZnrezhUlFOM` |
+| Now option ID | `1e84189c` |
+| Next option ID | `9fca00b2` |
+| Later option ID | `e2149d3e` |
+| Someday option ID | `fcffa79d` |
 
-```yaml
-Priority: <number>
-Title: <string>
-Description: <string> (markdown, may span multiple lines)
-Issues:
-  - Epic (root issue, typically)
-  - Related issues (sub-issues, linked work)
-Dependencies:
-  Prerequisite: <issue_link>
-  Blocks: [<issue_list>]
-```
+## Querying All Board Items
 
-### Parsing
-
-When loading `plan/PRIORITIES.md`:
-
-1. Parse heading `## Priority <N> — <Title>` → extract number and title
-2. Read text until next heading or EOF → description (may include notes, PR links)
-3. Extract issue links: `#123`, `[link text](#123)`, or full URLs
-4. Parse dependency annotations:
-   - `Prerequisite: #<N>` or `Prerequisite: [text](#N)`
-   - `Blocks: #<N>, #<M>` (comma-separated)
-5. Build structured list of priority groups
-
-### Modification
-
-When applying changes:
-
-1. Reconstruct markdown from modified structure
-2. Preserve formatting (indentation, list markers)
-3. Validate section order (priority numbers ascending)
-4. Write backup before overwriting
-
-## Workflows in Detail
-
-### Add New Priority
-
-1. **Prompt user** for key info:
-   - Root issue link (e.g., epic #464)
-   - Title and description
-   - Related issues (sub-issues, PRs)
-   - Dependencies: "Does this block or depend on other priorities?"
-2. **Determine priority number**:
-   - Ask: "Higher or lower priority than [group X]?"
-   - Calculate gap: suggest a number between existing boundaries
-   - Validate: confirm no duplicates after insertion
-3. **Construct markdown section**:
-
-   ```markdown
-   ## Priority <N> — <Title>
-
-   <Description>
-
-   - Epic: [text](#<epic_number>)
-   - Related: #<related_1>, #<related_2>
-
-   Prerequisite: #<prereq>
-
-   ```
-
-4. **Insert at correct position** (maintain ascending order)
-5. **Validate**, preview, commit
-
-### Refine Existing Group
-
-1. **Select priority** from interactive list
-2. **Choose action**:
-   - Update title or description
-   - Add/remove linked issues
-   - Update dependencies
-   - Change priority number (re-sort)
-3. **Gather changes** and apply to structure
-4. **Validate**, preview, commit
-
-### Remove Priority
-
-1. **Confirm all issues closed**:
-   - Query GitHub: verify every linked issue is closed
-   - If any open issues remain, abort (user must close or move to new priority first)
-2. **Archive to history**:
-   - Auto-generate history entry via `uv run append-history priority`
-   - Entry will be written to `plan/history/YYMM/priority/<priority_id>.md`
-3. **Remove from PRIORITIES.md** and commit
-
-## Validation
-
-### GitHub API Checks
-
-For each issue link:
-
-```graphql
-GET /repos/CERTCC/Vultron/issues/<number>
-→ Check: state == "open" (for ADD/REFINE operations)
-→ Check: epic_type or issue exists (verify link structure)
-```text
-
-Epic sub-issue query (GraphQL):
-
-```graphql
-query {
-  repository(owner: "CERTCC", name: "Vultron") {
-    issue(number: <N>) {
-      children: linkedIssues(first: 100, direction: OUT) {
-        edges { node { number, title } }
+```bash
+gh api graphql -f query='{
+  node(id: "PVT_kwDOAjf0s84BZnre") {
+    ... on ProjectV2 {
+      items(first: 100) {
+        nodes {
+          id
+          content {
+            ... on Issue { number title state }
+          }
+          fieldValueByName(name: "Schedule") {
+            ... on ProjectV2ItemFieldSingleSelectValue { name optionId }
+          }
+        }
       }
     }
   }
-}
-```text
-
-### Format Validation
-
-- Issue links: `#<digits>` or `https://github.com/CERTCC/Vultron/issues/<digits>`
-- Priority numbers: positive integers, ascending
-- No duplicate links across priority groups
-- Prerequisite issues: must exist and be open
-
-### Markdown Validation
-
-- Headings: `## Priority <N> — <Title>`
-- Lists: consistent bullet markers (dash or asterisk)
-- Links: valid markdown syntax, no broken references
-
-### Error Handling
-
-If validation fails:
-
-```text
-❌ Issue #999 not found (404)
-   Fix: Correct the issue number, or skip this link
-
-❌ Issue #440 is already linked to Priority 475
-   Fix: Remove from Priority 475 first, or remove from this group
-
-❌ Priority number 475 already exists
-   Fix: Choose a different number
-```text
-
-Offer to **fix, skip, or abort**.
-
-## Preview & Diff
-
-Before writing:
-
-```markdown
---- plan/PRIORITIES.md (before)
-+++ plan/PRIORITIES.md (after)
-
-## Priority 475 — Participant Case Replica Safety
-...
--  - [#440](https://github.com/CERTCC/Vultron/issues/440)
-+  - [#440](https://github.com/CERTCC/Vultron/issues/440) — Core rules
-+  - [#500](https://github.com/CERTCC/Vultron/issues/500) — Validation tests
-
-## Priority 480 — New Feature (NEW)
-+
-+Description here...
-```text
-
-## Commit Message
-
-Auto-generated or user-provided. Include:
-
-- Action: "Add Priority <N>", "Refine Priority <N>", "Archive Priority <N>"
-- Summary of changes
-- Co-author trailer
-
-Example:
-
+}'
 ```
 
-Add Priority 480 — Performance Optimization
+## Moving an Item Between Tiers
 
-Addresses uncovered issues #550, #551, #552.
-Depends on Priority 475 (case replica safety).
+```bash
+# Look up item ID by issue number (from items query above)
+ITEM_ID="<project item node ID>"
 
-Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+gh api graphql -f query="mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: \"PVT_kwDOAjf0s84BZnre\"
+    itemId: \"${ITEM_ID}\"
+    fieldId: \"PVTSSF_lADOAjf0s84BZnrezhUlFOM\"
+    value: { singleSelectOptionId: \"${SCHEDULE_OPTION_ID}\" }
+  }) { projectV2Item { id } }
+}"
+```
+
+## Adding an Issue to the Board
+
+```bash
+NODE_ID=$(gh api graphql -f query='{
+  repository(owner:"CERTCC", name:"Vultron") {
+    issue(number: '"${ISSUE_NUMBER}"') { id }
+  }
+}' --jq '.data.repository.issue.id')
+
+ITEM_ID=$(gh api graphql -f query="mutation {
+  addProjectV2ItemById(input: {
+    projectId: \"PVT_kwDOAjf0s84BZnre\"
+    contentId: \"${NODE_ID}\"
+  }) { item { id } }
+}" --jq '.data.addProjectV2ItemById.item.id')
+
+# Then set Schedule field as above
+```
+
+## Archiving a Completed Epic
+
+1. Verify all sub-issues closed via GraphQL `subIssues` query.
+2. Call `uv run append-history priority` via the `archive-history` skill.
+3. Close the Epic: `gh issue close <N> --repo CERTCC/Vultron`.
+
+## Error Handling
+
+### Item Not on Board
+
+If an issue referenced by the user is not in Project #24, offer to add it
+with `Schedule=Someday` first.
+
+### API Authentication
 
 ```text
+❌ GraphQL API error: Must have push access to repository
+   Action: Verify GITHUB_TOKEN has `project` scope
+```
 
 ## Integration with check-priority-status
 
-**Typical workflow**:
+Typical workflow:
 
 1. Run `check-priority-status` → get status report
-2. Identify uncovered issues, empty priorities, stale work
-3. Run `update-priorities` → add new groups or refine existing ones
+2. Identify items to reschedule, promote from triage, etc.
+3. Run `update-priorities` → apply changes
 4. Repeat as needed
 
-The skills do **not chain automatically**; user must run them sequentially and decide when updates are warranted based on findings.
-
-## Advanced Features
-
-### Batch Import
-
-Import priorities from structured input (CSV, JSON):
-
-```json
-[
-  {
-    "priority": 480,
-    "title": "Performance Optimization",
-    "description": "...",
-    "issues": [550, 551, 552],
-    "prerequisites": [475]
-  }
-]
-```text
-
-### Priority Renumbering
-
-If gaps have accumulated (e.g., 470, 475, 476, 500):
-
-- Offer to consolidate (470, 475, 476, 477)
-- Validate no external references (e.g., ADR documents)
-- Generate commit
-
-### Export
-
-Save current state to JSON or CSV for external tools (project boards, reports):
-
-```bash
-update-priorities --export json > priorities.json
-```text
-
-### History Query
-
-View archived priorities (completed work):
-
-```bash
-update-priorities --show-history
-```text
-
+The skills do **not chain automatically**; run them sequentially.

--- a/.agents/skills/update-priorities/SKILL.md
+++ b/.agents/skills/update-priorities/SKILL.md
@@ -1,150 +1,140 @@
 ---
 name: update-priorities
-description: Interactively update PRIORITIES.md by adding, removing, or refining priority groups. Gathers user input about new work, priorities, dependencies, and links to GitHub issues. Use when you want to add new priorities, reorganize existing groups, or update priority descriptions based on findings from check-priority-status.
+description: >
+  Interactively update GitHub Project #24 ("Vultron Planning") by moving
+  items between Schedule tiers (Now/Next/Later/Someday) via the GitHub
+  Projects API. Use when you want to schedule issues, promote triage items,
+  or rebalance tiers based on findings from check-priority-status.
 ---
 
 # Update Priorities
 
-Interactively update `plan/PRIORITIES.md` by adding, removing, or refining priority groups. Designed as a companion to `check-priority-status`—run the status check first to understand gaps and uncovered work, then use this skill to modify the priority list.
+Interactively update the Schedule field on issues and Epics in GitHub
+Project #24. Designed as a companion to `check-priority-status` — run the
+status check first to understand the current state, then use this skill to
+apply scheduling changes.
 
-## Quick start
+## Quick Start
 
 Run the update-priorities skill.
 
 The skill will:
 
-1. Load current `plan/PRIORITIES.md`
+1. Query Project #24 for all items and their current Schedule tiers
 2. Present options:
-   - **Add a new priority group** (for uncovered issues or new work)
-   - **Refine an existing group** (update description, add/remove issues, adjust priority number)
-   - **Remove a priority** (archive completed work via `append-history`)
-   - **View current state** (quick reference before editing)
-3. For each action, gather details:
-   - Priority number (or suggest auto-assigned number)
-   - Title and description
-   - Root issue/epic link
-   - Sub-issues and related work
-   - Dependencies and prerequisites
-4. Validate updates (check links are live, epic relationships exist)
-5. Preview changes before writing
-6. Stage and commit (or save draft for manual review)
+   - **Move item(s) to a different tier** (Now / Next / Later / Someday)
+   - **Promote Triage items** (Someday items to a schedule tier)
+   - **Add an issue to the board** (assign Schedule=Someday)
+   - **Archive a completed Epic** (close issue + history entry)
+3. For each action, apply the change live via GitHub API
+4. Commit if any notes/history files changed (board changes need no commit)
+
+## Project Board Constants
+
+| Name | Value |
+|---|---|
+| Project node ID | `PVT_kwDOAjf0s84BZnre` |
+| Schedule field ID | `PVTSSF_lADOAjf0s84BZnrezhUlFOM` |
+| Now option ID | `1e84189c` |
+| Next option ID | `9fca00b2` |
+| Later option ID | `e2149d3e` |
+| Someday option ID | `fcffa79d` |
 
 ## Workflows
 
-### Add a New Priority Group
+### Move Item to a Different Tier
 
-When you have uncovered work that should be tracked:
+1. Identify the issue or Epic number.
+2. Find the item's project item ID:
 
-1. Identify the root issue (epic or feature request)
-2. List sub-issues/related work
-3. Clarify dependencies (does it block or depend on other priorities?)
-4. Choose or auto-assign a priority number
-5. Write a clear title and description
-6. Validate that all linked issues exist and are open
-7. Insert into `plan/PRIORITIES.md` (maintain ascending priority numbers)
+   ```bash
+   ITEM_ID=$(gh api graphql -f query='{
+     node(id:"PVT_kwDOAjf0s84BZnre") {
+       ... on ProjectV2 {
+         items(first:100) {
+           nodes {
+             id
+             content { ... on Issue { number } }
+           }
+         }
+       }
+     }
+   }' --jq ".data.node.items.nodes[] \
+     | select(.content.number == ${ISSUE_NUMBER}) | .id")
+   ```
 
-### Refine an Existing Group
+3. Apply the Schedule field update:
 
-When a priority needs updates (status change, new linked issues, dependency shifts):
+   ```bash
+   gh api graphql -f query="mutation {
+     updateProjectV2ItemFieldValue(input: {
+       projectId: \"PVT_kwDOAjf0s84BZnre\"
+       itemId: \"${ITEM_ID}\"
+       fieldId: \"PVTSSF_lADOAjf0s84BZnrezhUlFOM\"
+       value: { singleSelectOptionId: \"${SCHEDULE_OPTION_ID}\" }
+     }) { projectV2Item { id } }
+   }"
+   ```
 
-1. Select the priority from list
-2. Choose what to update: title, description, linked issues, dependencies
-3. Make changes interactively
-4. Validate links and relationships
-5. Preview diff before writing
+### Add Issue to Board
 
-### Remove a Priority (Archive)
+1. Resolve the issue's node ID:
 
-When a priority group is fully completed:
+   ```bash
+   NODE_ID=$(gh api graphql -f query='{
+     repository(owner:"CERTCC", name:"Vultron") {
+       issue(number: '"${ISSUE_NUMBER}"') { id }
+     }
+   }' --jq '.data.repository.issue.id')
+   ```
 
-1. Select the priority to archive
-2. Confirm all linked issues are closed
-3. Invoke the `archive-history` skill:
+2. Add to project and set Schedule:
+
+   ```bash
+   ITEM_ID=$(gh api graphql -f query="mutation {
+     addProjectV2ItemById(input: {
+       projectId: \"PVT_kwDOAjf0s84BZnre\"
+       contentId: \"${NODE_ID}\"
+     }) { item { id } }
+   }" --jq '.data.addProjectV2ItemById.item.id')
+
+   gh api graphql -f query="mutation {
+     updateProjectV2ItemFieldValue(input: {
+       projectId: \"PVT_kwDOAjf0s84BZnre\"
+       itemId: \"${ITEM_ID}\"
+       fieldId: \"PVTSSF_lADOAjf0s84BZnrezhUlFOM\"
+       value: { singleSelectOptionId: \"fcffa79d\" }
+     }) { projectV2Item { id } }
+   }" >/dev/null
+   ```
+
+### Archive a Completed Epic
+
+1. Confirm all sub-issues are closed.
+2. Invoke the `archive-history` skill:
 
    ```text
    TYPE    = priority
-   TITLE   = <priority group title>
-   SOURCE  = PRIORITY-<number>
-   BODY    = <priority summary, linked issues, completion notes>
-   ```text
+   TITLE   = <Epic title>
+   SOURCE  = EPIC-<number>
+   BODY    = <Epic summary, linked issues, completion notes>
+   ```
 
-   The skill runs `uv run append-history priority`, lints the new history
-   files, stages `plan/history/`, commits, and pushes.
-4. Remove from `plan/PRIORITIES.md` and commit that change separately:
+3. Close the Epic issue:
 
    ```bash
-   git add plan/PRIORITIES.md
-   git commit -m "plan: remove completed priority <N> — <title>
+   gh issue close <EPIC_NUMBER> --repo CERTCC/Vultron
+   ```
 
-   Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
-   ```text
-
-### View Current State
-
-Quick reference table of all priorities (like the start of `check-priority-status` summary):
-
-```text
-Priority | Title                          | Issues | Status
----------|--------------------------------|--------|--------
-470      | Two-Actor Demo Redesign        | 5      | 🟡 In Progress
-475      | Participant Case Replica Safety| 1      | 🟡 In Progress
-476      | Bug Fixes and Demo Polish      | 7      | 🟢 On Track
-```text
-
-## Priority Number Assignment
-
-**Rules** (from `plan/PRIORITIES.md` header):
-
-- Ascending numbers = higher priority
-- Scale is not linear (allows gaps for future insertion)
-- When adding a new priority:
-  - Choose a number between two existing numbers, or
-  - Choose a new number higher than the max if it's lower priority
-  - Example: if current max is 476, a new lower-priority item could be 480 or 500
-
-Skill will suggest placements based on your answer: "Higher or lower priority than [group X]?"
-
-## Validation
-
-Before writing `plan/PRIORITIES.md`, validate:
-
-- ✓ All issue links are valid (GitHub API check: issue exists, is open)
-- ✓ Epic links have actual sub-issues (for epics, show issue count)
-- ✓ Priority numbers are unique and ascending
-- ✓ No duplicate issue links across groups
-- ✓ Prerequisite issues exist and are open
-- ✓ Text formatting (relative links, markdown syntax)
-
-If any validation fails, report it and offer to fix or skip.
-
-## Preview & Commit
-
-Before writing to disk:
-
-1. Show a **diff preview** (additions, removals, changes highlighted)
-2. Ask for confirmation: "Write these changes?"
-3. If yes:
-   - Stage `plan/PRIORITIES.md`
-   - Prompt user for commit message (or auto-generate one)
-   - Add co-author trailer and commit
-4. If no:
-   - Save draft to session workspace (e.g., `updates.md`)
-   - Prompt to review and re-run skill later
-
-## Advanced Features
-
-See [REFERENCE.md](REFERENCE.md) for:
-
-- Batch import (add multiple priorities from a CSV or structured list)
-- Priority renumbering (if gaps have accumulated)
-- Report generation (export current state as JSON/CSV)
-- Integration with GitHub project boards
-- History query (view archived priorities)
+4. The `archive-history` skill commits and pushes the history entry file.
 
 ## Notes
 
-- **No deletion without archiving**: Completed priorities must be archived to `plan/history/` via `append-history` before removal from `PRIORITIES.md`
-- **Validation is strict**: Bad links or formatting issues block writes; fix or skip before proceeding
-- **Preview before commit**: Always show a diff; never write silently
-- **Skill is independent**: Does not automatically run `check-priority-status`; user should run status check *first* to identify gaps
-- **Undo via git**: If changes are committed incorrectly, undo with `git revert` or `git reset --soft`
+- **Board changes are live**: Schedule field updates take effect immediately
+  via API — no file commit is needed.
+- **Skill is independent**: Does not automatically run
+  `check-priority-status`; run it first to identify what needs changing.
+- **Undo**: Re-run the move mutation with the previous option ID, or use
+  `gh issue reopen` for closed Epics.
+- **Someday = Triage**: Issues on the board with `Schedule=Someday` (or no
+  Schedule) appear in the Triage view and should be reviewed regularly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,13 +182,12 @@ All outbound activities MUST use factory functions in
 
 ### GitHub Issue Labels
 
-When adding a `group:` label to an issue, the label name MUST NOT include a
-priority number (PAD-02-007). Use a short, descriptive kebab-case slug derived
-from the priority group title — e.g., `group:architecture-hardening`, never
-`group:473-architecture-hardening`. Priority numbers in `plan/PRIORITIES.md`
-can be reordered; label names must remain stable. Before assigning a
-`group:` label, verify it exists on GitHub and create it with `gh label create`
-if not. See `notes/parallel-development.md` §Group Label Conventions.
+Priority tracking is managed via **GitHub Project #24 ("Vultron Planning")**
+using a `Schedule` field with values: `Now`, `Next`, `Later`, `Someday`.
+New issues are added to the project with `Schedule=Someday` by default.
+Reprioritize by updating the `Schedule` field via the API or by dragging cards
+on the board. `group:` labels are no longer used — do not create or assign them.
+See `notes/parallel-development.md` for the project board model and API reference.
 
 ## Change Protocol
 

--- a/notes/agentic-workflow.md
+++ b/notes/agentic-workflow.md
@@ -78,9 +78,9 @@ codebase, then create GitHub Issues for any untracked gaps.
 | | |
 |---|---|
 | **Trigger** | `specs/` or `notes/` have changed since the last plan update |
-| **Input** | `specs/`, `notes/`, `vultron/`, `test/`, `plan/PRIORITIES.md`, open GitHub Issues |
-| **Process** | Load context → gap analysis → create GitHub Issues for gaps → write observations to `notes/` |
-| **Output** | New GitHub Issues (group:unscheduled), updated `notes/` |
+| **Input** | `specs/`, `notes/`, `vultron/`, `test/`, Project #24 board, open GitHub Issues |
+| **Process** | Load context → gap analysis → create GitHub Issues → add to board → write observations to `notes/` |
+| **Output** | New GitHub Issues (added to Project #24 with Schedule=Someday), updated `notes/` |
 | **Side effects** | None — does not commit code or close issues |
 
 `update-plan` is the **third-priority** skill. It translates the current
@@ -151,7 +151,7 @@ flowchart TD
 | `specs/*.yaml` | Authoritative requirements | Permanent |
 | `notes/*.md` | Durable design insights | Permanent |
 | `AGENTS.md` | Agent conventions and patterns | Permanent |
-| `plan/PRIORITIES.md` | Authoritative priority ordering | Permanent |
+| GitHub Project #24 | Authoritative priority scheduling (Now/Next/Later/Someday) | Live — updated via API |
 | GitHub Task/Subtask Issues | Pending + in-progress tasks | Yes — closed when PR merges |
 | `plan/BUILD_LEARNINGS.md` | Ephemeral build/bugfix observations | Yes — processed and archived by `learn` |
 | `vultron/`, `test/` | Implementation | Permanent |

--- a/notes/parallel-development.md
+++ b/notes/parallel-development.md
@@ -34,22 +34,22 @@ building Vultron.
 | Question | Decision | Rationale |
 |---|---|---|
 | What is the task coordination primitive? | GitHub Issues | Native assignment, labels, PR linking, dependency notation — no new infra |
-| What is the authoritative priority ordering? | PRIORITIES.md | Human-readable, freely reorderable without touching GitHub API |
+| What is the authoritative priority ordering? | GitHub Project #24 Schedule field | Live board in the browser; single source of truth; no file to maintain |
 | How are tasks claimed? | Branch creation (`task/<N>-slug`) | Git branch creation is atomic — ideal distributed lock |
 | Should there be a `claimed` label? | No | Adds a second source of truth that can drift from branch state |
 | Stale-claim threshold | 3 days since last branch commit | Short enough to keep the queue clean; tune if agent sessions are longer |
 | Diff-size thresholds | ≤50 lines = S, 51–300 = M, 301+ = L | Common open-source convention; aligns with maintainability expectations |
 | Two-pass code review? | Single-pass with [BLOCKING]/[ADVISORY] tags | Same signal, less process theater; build agent acts on tags |
-| Where do `update-plan` gap findings go? | GitHub Issues (group:unscheduled) | Consistent with the GitHub Issues model |
+| Where do `update-plan` gap findings go? | GitHub Issues (added to Project #24) | Consistent with the GitHub Issues model |
 
 ---
 
 ## Issue Hierarchy
 
 ```text
-Epic Issue (group:<name>)        ← maps to a PRIORITIES.md group
-  └── Task Issue                 ← coherent unit of work
-        └── Subtask Issue        ← atomic PR-sized chunk (leaf = claimable)
+Epic Issue                           ← on Project #24 board, grouped by Schedule tier
+  └── Task Issue                     ← coherent unit of work
+        └── Subtask Issue            ← atomic PR-sized chunk (leaf = claimable)
 ```
 
 Use minimum depth. Many Epics will have leaf Tasks with no Subtasks.
@@ -60,22 +60,25 @@ Use minimum depth. Many Epics will have leaf Tasks with no Subtasks.
 
 | Label | Applied by | Meaning |
 |---|---|---|
-| `group:<name>` | ingest-idea, update-plan, agents | Priority group membership |
-| `group:unscheduled` | ingest-idea, update-plan, agents | Not yet in PRIORITIES.md |
 | `size:S` | Agent at issue creation + PR open | ≤2 ACs or ≤50 diff lines |
 | `size:M` | Agent at issue creation + PR open | 3–6 ACs or 51–300 diff lines |
 | `size:L` | Agent at issue creation + PR open | 7+ ACs or 301+ diff lines |
 | `stale-claim` | Stale-claim sweeper (GH Actions) | Orphaned claim; skip until human clears |
 | `needs-rebase` | Build agent | PR has unresolvable merge conflicts |
 | `specs-notes` | ingest-idea, learn | Docs-only PR containing only specs/ and notes/ changes |
+| `concern` | process-concerns, new-concern, ingest-concern | Technical risk, debt, or fragile area |
+
+**Note**: `group:<name>` and `group:unscheduled` labels were retired in June
+2026. Priority grouping is now tracked via GitHub Project #24 Schedule field
+and Epic sub-issue relationships instead of labels.
 
 ---
 
 ## Task Claiming Protocol
 
 ```text
-1. Read PRIORITIES.md → identify top-priority group name
-2. Query GitHub: open leaf Issues with that group: label,
+1. Query Project #24 → identify first Epic in Now tier
+2. Query GitHub: open leaf Issues that are sub-issues of that Epic,
    no stale-claim, unassigned
 3. Pick the highest-priority unblocked leaf Issue
 4. git switch -c task/<issue-number>-<slug>
@@ -148,36 +151,36 @@ PR-time detection is sufficient.
 | Skill | Change |
 |---|---|
 | `build` | Phase 2: select from GitHub Issues; add claiming, pre-PR code review ([BLOCKING]/[ADVISORY]), size labeling, PR creation, auto-rebase |
-| `ingest-idea` | Add: open docs-only PR with `specs-notes` label; create GitHub Issue with `group:unscheduled` |
-| `review-priorities` | Add Phase 2.5: fetch `group:unscheduled` Issues, interview user for placement |
-| `study-project-docs` | Task source is GitHub Issues (read from PRIORITIES.md + GitHub query) |
-| `update-plan` | Rewrite: create GitHub Issues for gaps |
+| `ingest-idea` | Add: open docs-only PR with `specs-notes` label; create GitHub Issue; add to Project #24 |
+| `review-priorities` | Rewritten: audit Project #24 board tiers; move items via API instead of editing PRIORITIES.md |
+| `study-project-docs` | Task source is GitHub Issues (query Project #24 Now tier) |
+| `update-plan` | Rewrite: create GitHub Issues for gaps; add to Project #24 |
 
 ---
 
-## Group Label Conventions (gap-analysis finding, 2026-05-05)
+## Project Board Conventions (updated June 2026)
 
-A `group:<name>` label MUST correspond to exactly one priority group in
-`PRIORITIES.md`. Labels MUST use descriptive names only — **never embed a
-priority number** in the label name or description. Priority ordering lives
-in `PRIORITIES.md` and can change without touching issue labels.
+`group:<name>` labels and `plan/PRIORITIES.md` were retired in June 2026.
+Priority grouping and scheduling are now tracked via:
 
-### Implications
+1. **GitHub Project #24** ("Vultron Planning") — the authoritative
+   scheduling board.
+2. **Schedule field** (Now / Next / Later / Someday) on Epics and issues —
+   the single source of truth for priority ordering within each tier.
+3. **Epic sub-issue relationships** — group leaf issues under an Epic rather
+   than using `group:` labels.
 
-- Each `group:*` label maps to one entry in `PRIORITIES.md`. If two priority
-  entries need separate work-streams, create two labels.
-- The label description should name the work-stream (e.g.,
-  "Re-implement fuzzer nodes from original simulator"), not the priority
-  number. This was corrected for `group:fuzzer-nodes` in May 2026.
-- `group:unscheduled` is the holding label for Issues not yet slotted into
-  `PRIORITIES.md`. Use `review-priorities` to assign them.
+### Triage
 
-### Label compliance for older issues
+Issues added to Project #24 receive `Schedule=Someday` by default. These
+appear in the "Triage" view. Use `review-priorities` to promote them to
+Now/Next/Later when they are ready to be scheduled.
 
-Issues predating the PAD label requirements (opened before Priority 473
-work began) may lack `group:*` and/or `size:*` labels. These are not
-retroactively wrong — they should be updated when touched. Issues #5, #6,
-and #294 were missing labels and were updated in May 2026.
+### Previous conventions (archived)
+
+Before June 2026, issues used `group:<slug>` labels to mark priority group
+membership and `group:unscheduled` to mark items not yet in `PRIORITIES.md`.
+These labels have been deleted. Do not recreate them.
 
 ---
 

--- a/plan/history/2606/priority/TASK-693.md
+++ b/plan/history/2606/priority/TASK-693.md
@@ -1,3 +1,10 @@
+---
+source: TASK-693
+timestamp: '2026-06-03T16:08:00+00:00'
+title: 'PRIORITIES.md archived: migrating to GitHub Project board (project #24)'
+type: priority
+---
+
 # Priorities
 
 ## Important note about priority numbers


### PR DESCRIPTION
## Summary

Replaces three overlapping tracking systems (PRIORITIES.md, `group:` labels, Epic issues) with a single source of truth: **GitHub Project #24** ("Vultron Planning") using a `Schedule` field (Now/Next/Later/Someday).

## What changed

### Deleted
- `plan/PRIORITIES.md` — archived to `plan/history/2606/priority/TASK-693.md`
- All 19 `group:` labels — deleted from GitHub

### Updated skills
- `create-epic`: removes GROUP_LABEL arg and `group:` label step; adds item to Project #24 with Schedule=Someday
- `manage-github-issue`: fixes label example (drops group:unscheduled)
- `ingest-idea`, `ingest-concern`, `new-concern`, `process-concerns`, `update-plan`: replace `group:unscheduled` label with project board add snippet
- `check-priority-status`, `review-priorities`, `update-priorities`: full rewrites to use board Schedule tier API instead of PRIORITIES.md parsing
- `build`, `dev-status`, `study-project-docs`, `create-epic`: updated to query Project #24 first

### Updated notes
- `notes/agentic-workflow.md`: File Roles table and update-plan I/O row
- `notes/parallel-development.md`: design decisions, issue hierarchy, label taxonomy, task claiming protocol, skill evolution table; Group Label Conventions → Project Board Conventions

## New model

| Old | New |
|---|---|
| `group:unscheduled` label | Add to Project #24 with Schedule=Someday |
| `group:<slug>` label | Sub-issues under an Epic |
| Top priority = first group in PRIORITIES.md | Top priority = first open Epic in Schedule=Now tier |

## Closes

- Closes #693
- Closes #694
- Closes #695
- Closes #691