### PR TITLE
docs: ingest concern #586 — VultronActivity.object_ dict round-trip bypass

### DIFF
--- a/plan/history/2606/learning/CONCERN-586.md
+++ b/plan/history/2606/learning/CONCERN-586.md
@@ -1,0 +1,46 @@
+---
+source: CONCERN-586
+timestamp: '2026-06-03T18:01:15.014148+00:00'
+title: VultronActivity.object_ dict round-trip bypass
+type: learning
+---
+
+## Category
+
+Type safety / architecture
+
+## Severity
+
+Medium — currently worked around but fragile
+
+## Evidence
+
+`VultronActivity.object_` is `Any | None` (line 56 of `vultron/core/models/activity.py`).
+When `_load_outbound_activity()` round-trips a typed wire-layer activity
+(`_RmEngageCaseActivity`) through `model_dump()` → `VultronActivity.model_validate()`,
+the nested `VulnerabilityCase` model becomes a plain dict. This caused `dl.hydrate()`
+to be skipped entirely in the outbox handler, leading to #585/#572/#573/#574.
+
+A targeted dict-recovery workaround was added in PR #577, but it only handles types
+listed in `_STUB_OBJECT_TYPES` and relies on re-reading from the DataLayer.
+
+## Impact
+
+- Fragile: any new object type that needs hydration must be added to `_STUB_OBJECT_TYPES`
+- The root issue is that wire-layer types (`VulnerabilityCase`, `VulnerabilityReport`,
+  `CaseParticipant`) inherit from `as_Object` (wire base), not `VultronObject` (core base).
+  Both are `BaseModel` subclasses but have no common Vultron-specific ancestor.
+- Narrowing `object_` to `BaseModel | None` breaks Pydantic validation because
+  the round-trip produces dicts, not BaseModel instances.
+
+## Suggested action
+
+Consider whether wire-layer objects should be projections of core objects into AS2
+vocabulary, sharing a common abstract base. Alternatively, use a discriminated union
+or custom validator that can reconstruct typed models from dicts during validation.
+This is an architectural decision that may warrant an ADR.
+
+**Resolved**: 2026-06-03 — root cause is domain objects placed in `wire/as2/vocab/objects/`
+instead of `core/models/`. The correct fix is to migrate those objects to core and type
+`VultronActivity.object_` as a Pydantic discriminated union. Implementation tracked in #699.
+Docs PR: [#700](https://github.com/CERTCC/Vultron/pull/700).

--- a/plan/history/2606/priority/TASK-693.md
+++ b/plan/history/2606/priority/TASK-693.md
@@ -71,6 +71,9 @@ outbox polling, and oversized centralized dispatch tables.
   `EmbargoLifecycle` service to consolidate fragmented embargo state management
 - [#586](https://github.com/CERTCC/Vultron/issues/586) — Concern:
   `VultronActivity.object_` typed as `Any|None` causes dict round-trip bypass
+- [#699](https://github.com/CERTCC/Vultron/issues/699) — Migrate domain
+  objects from `wire/as2/vocab/objects/` to `core/models/` and type
+  `VultronActivity.object_` as discriminated union
 - [#618](https://github.com/CERTCC/Vultron/issues/618) — Concern:
   Full-URI actor/case IDs embedded in URL path segments cause routing
   fragility

--- a/vultron/core/AGENTS.md
+++ b/vultron/core/AGENTS.md
@@ -116,6 +116,23 @@ bodies. Specifically: AS2 fields that carry an object or ID reference (e.g.,
 field — passing the raw AS2 object directly is a type error that mypy will
 catch only after extraction.
 
+### Domain Objects Belong in `core/models/`, Not `wire/as2/vocab/objects/`
+
+`VulnerabilityCase`, `VulnerabilityReport`, `CaseParticipant`,
+`EmbargoPolicy`, `CaseStatus`, `CaseLogEntry`, and `VulnerabilityRecord` are
+**domain objects**. They currently live in `vultron/wire/as2/vocab/objects/`
+because the codebase was built wire-first, but their correct home is
+`vultron/core/models/`. The wire layer should import and project from core,
+not the other way around.
+
+Consequence: `VultronActivity.object_` is typed `Any | None` because core
+cannot import wire types. Referencing wire-layer domain objects in core code
+is a layer-boundary violation. Do **not** add new cross-layer imports from
+`vultron/core/` into `vultron/wire/as2/`. The migration of these objects to
+core is tracked in issue #539. See
+[notes/domain-model-separation.md](../../notes/domain-model-separation.md)
+for the full architectural direction.
+
 ### BT-related pitfalls
 
 See [notes/bt-integration.md](../../notes/bt-integration.md) for:


### PR DESCRIPTION
Docs-only PR: addresses concern #586 at the spec/notes/agent-guidance level.
Implementation tracked in #699.

Changes:
- `vultron/core/AGENTS.md`: add pitfall entry for domain objects placed in
  wire layer; pointer to `notes/domain-model-separation.md`
- `plan/PRIORITIES.md`: add #699 under Priority 485 (Architecture Hardening)

Closes #586

No .py files changed.