### PR TITLE
docs: ingest concern #515 — SEMANTIC_REGISTRY order guard and design notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,6 +289,7 @@ Short entries are reproduced here; longer ones are referenced below.
 
 - **Circular Imports** — see [notes/codebase-structure.md](notes/codebase-structure.md)
 - **Pattern Matching with ActivityStreams** — see [notes/activitystreams-semantics.md](notes/activitystreams-semantics.md)
+- **`SEMANTIC_REGISTRY` Order Errors Fail Silently — `_validate_registry_order()` Required** — A misplaced pattern causes the wrong use case to run with no error. The import-time guard `_validate_registry_order()` raises `RegistryOrderError` immediately. Until it lands, always run `test/test_semantic_activity_patterns.py` after editing the registry. See [notes/semantic-registry.md](notes/semantic-registry.md)
 - **Test Data Quality** — moved to `test/AGENTS.md`
 - **All Protocol-Significant Behavior MUST Be in the BT** — see [notes/bt-integration.md](notes/bt-integration.md)
 - **Protocol Event Cascades (Cascading Automation)** — see [notes/bt-integration.md](notes/bt-integration.md)

--- a/notes/README.md
+++ b/notes/README.md
@@ -137,6 +137,14 @@ vocabulary examples.
 **Load when**: implementing any inbound or outbound message handler, debugging
 semantic extraction, or writing new ActivityStreams vocabulary classes.
 
+**`semantic-registry.md`**
+Design notes for `SEMANTIC_REGISTRY` in `vultron/semantic_registry.py`:
+ordering invariant (specific before general, `UNKNOWN` last), group
+structure, the import-time `_validate_registry_order()` guard, and
+the step-by-step checklist for adding a new `ActivityPattern`.
+**Load when**: adding or debugging a `SemanticEntry`, investigating a
+wrong-handler dispatch, or reasoning about pattern ordering.
+
 **`stub-objects.md`**
 Design notes for the AS2 minimalist object pattern (stub/stub-object): using
 minimal `{"id": "...", "type": "..."}` references to reduce wire verbosity,

--- a/notes/semantic-registry.md
+++ b/notes/semantic-registry.md
@@ -1,0 +1,124 @@
+---
+title: Semantic Registry Design Notes
+status: active
+description: >
+  Design decisions for SEMANTIC_REGISTRY in vultron/semantic_registry.py:
+  ordering rules, group structure, the import-time order guard, and
+  how ActivityPattern definitions in extractor.py relate to the registry.
+related_specs:
+  - specs/semantic-extraction.yaml
+related_notes:
+  - notes/activitystreams-semantics.md
+  - notes/architecture-hexagonal.md
+relevant_packages:
+  - vultron/semantic_registry.py
+  - vultron/wire/as2/extractor.py
+  - test/test_semantic_activity_patterns.py
+---
+
+# Semantic Registry Design Notes
+
+## Overview
+
+`SEMANTIC_REGISTRY` in `vultron/semantic_registry.py` is the single ordered
+list that maps every AS2 activity structure to a `MessageSemantics` value,
+a `VultronEvent` subclass, and a use-case class. It is iterated by
+`find_matching_semantics()`, which returns the **first** match.
+
+`ActivityPattern` objects — one per `MessageSemantics` value — are defined in
+`vultron/wire/as2/extractor.py` and imported into `semantic_registry.py`.
+
+---
+
+## The Ordering Invariant
+
+**More-specific patterns MUST precede more-general ones. `UNKNOWN` must be
+last.**
+
+A pattern is *more specific* than another if its dump is a proper superset of
+the other's dump (within the same `activity_` group). If a general pattern
+appears first, the specific one is never reached — the wrong use case is
+invoked with no error signal.
+
+This invariant is captured by spec `SE-03-002`.
+
+### Group ordering within `SEMANTIC_REGISTRY`
+
+Entries are grouped by domain area; within each group, specific patterns come
+before general ones:
+
+| # | Group | Example semantics |
+|---|---|---|
+| 1 | Embargo events | `CREATE_EMBARGO_EVENT`, `INVITE_TO_EMBARGO`, `ACCEPT_INVITE_TO_EMBARGO` |
+| 2 | Reports | `CREATE_REPORT`, `SUBMIT_REPORT`, `ACK_REPORT`, `VALIDATE_REPORT`, … |
+| 3 | Cases | `CREATE_CASE`, `UPDATE_CASE`, `ENGAGE_CASE`, `DEFER_CASE`, … |
+| 4 | Case membership | `INVITE_ACTOR_TO_CASE`, `ACCEPT_INVITE_ACTOR_TO_CASE`, … |
+| 5 | Case manager role | `OFFER_CASE_MANAGER_ROLE`, `ACCEPT_CASE_MANAGER_ROLE`, … |
+| 6 | Ownership transfer | `OFFER_CASE_OWNERSHIP_TRANSFER`, `ACCEPT_CASE_OWNERSHIP_TRANSFER`, … |
+| 7 | Case log entries | `ANNOUNCE_LOG_ENTRY`, `REJECT_LOG_ENTRY` |
+| 8 | Vulnerability case announcements | `ANNOUNCE_VULNERABILITY_CASE` |
+| 9 | Notes | `CREATE_NOTE`, `ADD_NOTE_TO_CASE`, `REMOVE_NOTE_FROM_CASE` |
+| 10 | Participants | `CREATE_CASE_PARTICIPANT`, `ADD_CASE_PARTICIPANT`, … |
+| 11 | Fallback sentinels | `UNKNOWN_UNRESOLVABLE_OBJECT`, `UNKNOWN` (must be last) |
+
+When adding a new pattern, place it in the correct group. If it is more
+specific than an existing entry in the same `activity_` group, place it
+**before** that entry.
+
+---
+
+## Import-Time Order Guard
+
+Because a misplaced pattern fails silently at runtime,
+`semantic_registry.py` calls `_validate_registry_order(SEMANTIC_REGISTRY)`
+at module load time. If any less-specific entry precedes a more-specific
+one within the same `activity_` group, the validator raises
+`RegistryOrderError` (defined in `vultron/errors.py`) immediately on import.
+
+This is a hard guard: a mis-ordered registry **prevents the module from
+loading**, making the error impossible to miss.
+
+### Algorithm
+
+The validator uses the same subset logic as
+`test_non_overlapping_activity_patterns` in
+`test/test_semantic_activity_patterns.py`:
+
+1. Group entries by `activity_` type.
+2. For every pair `(A, B)` where A appears before B in the registry:
+   - If `dump(B)` is a strict subset of `dump(A)` (B is more specific),
+     A should have appeared after B — raise `RegistryOrderError`.
+3. Pass if no out-of-order pairs are found.
+
+The test `test_non_overlapping_activity_patterns` is a belt-and-suspenders
+check that also catches edge cases the runtime validator might miss (e.g.,
+patterns whose `model_dump()` raises). Both should remain.
+
+---
+
+## Common Pitfall: Adding a Pattern Without Running Tests
+
+When adding a new `ActivityPattern` to `extractor.py`:
+
+1. Define the pattern object (named `<TypeName>Pattern`).
+2. Add a `SemanticEntry` to `SEMANTIC_REGISTRY` in the correct group
+   position (specific before general).
+3. Run `test/test_semantic_activity_patterns.py` immediately — the import-
+   time guard fires in CI but running the test file locally is faster
+   feedback.
+4. If the import raises `RegistryOrderError`, move the new entry earlier in
+   the registry (before the more-general entry it conflicts with).
+
+The `test_non_overlapping_activity_patterns` test will also catch ordering
+errors that the runtime validator might not catch in all edge cases.
+
+---
+
+## File Locations
+
+| File | Role |
+|---|---|
+| `vultron/wire/as2/extractor.py` | `ActivityPattern` class + all `*Pattern` instances |
+| `vultron/semantic_registry.py` (current) / `vultron/semantic_registry/` (planned split — see concern #508 impl issues) | `SEMANTIC_REGISTRY`, `find_matching_semantics()`, `_validate_registry_order()` |
+| `vultron/errors.py` | `RegistryOrderError(VultronError)` |
+| `test/test_semantic_activity_patterns.py` | Pattern ordering + dispatch tests |

--- a/plan/history/2606/learning/CONCERN-515.md
+++ b/plan/history/2606/learning/CONCERN-515.md
@@ -1,0 +1,46 @@
+---
+source: CONCERN-515
+timestamp: '2026-06-03T19:29:46.546754+00:00'
+title: SEMANTIC_REGISTRY order guard and design notes
+type: learning
+---
+
+## Summary
+
+`vultron/wire/as2/extractor.py` (821 lines, 36 changes in 90 days) contains the
+ordered list of `ActivityPattern` definitions used for AS2 semantic extraction.
+Pattern ordering is order-sensitive: more-specific patterns must precede
+more-general ones. Ordering errors can cause the wrong use case to be invoked
+silently.
+
+## Category
+
+- [x] Fragile / high-churn area
+
+## Severity
+
+medium
+
+## Evidence
+
+- `vultron/wire/as2/extractor.py` (821 lines, 36 changes in 90 days)
+- `test/test_semantic_activity_patterns.py`
+
+## Impact if Ignored
+
+A misplaced pattern causes the wrong handler to be invoked for an incoming activity,
+silently corrupting protocol state with no immediate error signal.
+
+## Resolution
+
+**Root cause**: No structural guard exists to prevent a less-specific
+`SemanticEntry` from preceding a more-specific one in `SEMANTIC_REGISTRY`, AND
+the ordering rationale (groups, specific-before-general rule) was undocumented.
+
+**Approach**: Add an import-time `_validate_registry_order()` call at the bottom
+of the semantic registry module that raises `RegistryOrderError` if ordering
+is violated — making mis-ordering impossible to miss. Document the group
+structure and ordering rationale inline and in a new notes file.
+
+**Resolved**: 2026-06-03 — implementation tracked in #708.
+Docs PR: [#707](https://github.com/CERTCC/Vultron/pull/707).

--- a/vultron/wire/as2/AGENTS.md
+++ b/vultron/wire/as2/AGENTS.md
@@ -65,6 +65,16 @@ by `test/architecture/test_activity_factory_imports.py`.
 
 ## Common Pitfalls — wire layer
 
+**`SEMANTIC_REGISTRY` ordering errors fail silently — `_validate_registry_order()` required** —
+see [notes/semantic-registry.md](../../../notes/semantic-registry.md)
+
+A misplaced pattern (less-specific before more-specific within the same
+`activity_` group) causes the wrong use case to execute with no error signal.
+`_validate_registry_order()` raises `RegistryOrderError` at import time to
+make this impossible to miss. Until that guard lands, run
+`test/test_semantic_activity_patterns.py` immediately after editing the
+registry.
+
 See [notes/activitystreams-semantics.md](../../../notes/activitystreams-semantics.md)
 for:
 


### PR DESCRIPTION
Docs-only PR: addresses concern #515 at the spec/notes level.

## Changes

- **`notes/semantic-registry.md`** (new): ordering invariant, group
  structure, planned import-time `_validate_registry_order()` guard,
  and step-by-step checklist for adding patterns
- **`notes/README.md`**: register the new notes file
- **`vultron/wire/as2/AGENTS.md`**: new pitfall entry — order errors
  fail silently; run tests immediately after editing the registry
- **`AGENTS.md`** (root): same pitfall at the project level

Implementation tracked in #704 (TBD — created by this PR workflow).

Closes #515

No .py files changed.