### PR TITLE
docs: ingest concern #632 — BT idiom anti-patterns (god nodes, layer inversions)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,6 +294,22 @@ Short entries are reproduced here; longer ones are referenced below.
 - **All Protocol-Significant Behavior MUST Be in the BT** — see [notes/bt-integration.md](notes/bt-integration.md)
 - **Protocol Event Cascades (Cascading Automation)** — see [notes/bt-integration.md](notes/bt-integration.md)
 - **Post-BT Procedural Cascade Anti-Pattern** — see [notes/bt-integration.md](notes/bt-integration.md)
+- **BT Node MUST NOT Call a Use Case** — A BT node's `update()` MUST NOT
+  instantiate or call a use-case class. Use cases create BTs; BT nodes are
+  leaves of those trees. Calling a use case from inside a node creates an
+  auditable-breaking BT→UseCase→BT chain. Compose the sub-behavior as a
+  child subtree instead. See [notes/bt-integration.md](notes/bt-integration.md)
+  § "DO NOT: BT node calling a use case".
+- **BT Node MUST NOT Import From Use Case Modules** — Dependency direction is
+  `use_cases/ → behaviors/`, never the reverse. If a helper is needed in
+  both layers, extract it to a shared utility. See
+  [notes/bt-integration.md](notes/bt-integration.md)
+  § "DO NOT: BT node importing from use case modules".
+- **Avoid God BT Nodes: `update()` MUST Stay Small** — An `update()` method
+  exceeding ~20–30 lines is a god node. Decompose into a named subtree of
+  simple leaf nodes; the tree structure becomes the workflow documentation.
+  See [notes/bt-integration.md](notes/bt-integration.md)
+  § "DO NOT: God BT nodes with long `update()` methods".
 - **py_trees Blackboard Global State** — see [notes/bt-integration.md](notes/bt-integration.md)
 - **py_trees `blackboard.get()` Raises KeyError for Unwritten READ Keys** — see [notes/bt-integration.md](notes/bt-integration.md)
 - **Duplicate Method Definitions Silently Shadow Correct BT Logic** — see [notes/bt-integration.md](notes/bt-integration.md)

--- a/notes/bt-integration.md
+++ b/notes/bt-integration.md
@@ -640,6 +640,89 @@ def create_validate_and_prioritize_tree(report_id, offer_id):
 The full behavior — validate then prioritize (engage or defer) — is visible
 by reading the tree. No domain logic lives in `execute()`.
 
+#### DO NOT: BT node calling a use case
+
+(BT-IDM-01, 2026-06-03)
+
+A BT node's `update()` method MUST NOT directly instantiate and call a use
+case. Use cases are the handlers that *create* BTs, not work items *inside*
+BTs. Calling a use case from inside a BT node creates a BT→UseCase→BT→UseCase
+call chain that is impossible to audit or preempt.
+
+```python
+# BAD — BT node calling a use case (PublicDisclosureBranchNode anti-pattern)
+class PublicDisclosureBranchNode(py_trees.behaviour.Behaviour):
+    def update(self):
+        # ...
+        SvcTerminateEmbargoUseCase(self._dl, ...).execute()  # ANTI-PATTERN
+        return Status.SUCCESS
+```
+
+Instead, compose the behavior as a child subtree of the calling BT. The
+sub-behavior becomes a set of leaf nodes in a `Sequence` or `Selector` — not
+a use case call embedded inside another node.
+
+**Rule**: BT leaf nodes MUST NOT instantiate or call use-case classes.
+If a node needs to trigger a multi-step workflow, that workflow MUST be
+modeled as a child subtree of the current tree. See BT-06-001 and
+BT-06-006.
+
+---
+
+#### DO NOT: BT node importing from use case modules
+
+(BT-IDM-02, 2026-06-03)
+
+BT nodes in `vultron/core/behaviors/` MUST NOT import private helpers or
+functions from `vultron/core/use_cases/`. The dependency direction MUST be:
+
+```text
+use_cases/ → behaviors/ (use cases call BTs)
+```
+
+Not:
+
+```text
+behaviors/ → use_cases/ (BT nodes importing from use cases — WRONG)
+```
+
+**Why**: Importing a use-case helper into a BT node inverts the layer
+boundary and creates circular dependency risk. If a helper is needed in
+both a use case and a BT node, it MUST be extracted to a shared utility
+module (e.g., `vultron/core/behaviors/shared/` or a domain-model method).
+
+Example violation: `ApplyEmbargoTeardownNode` in
+`vultron/core/behaviors/embargo/nodes.py` imported
+`_reset_case_participant_embargo_consent` from
+`vultron.core.use_cases.received.embargo`. Fix: move the helper to a
+shared location importable by both layers.
+
+---
+
+#### DO NOT: God BT nodes with long `update()` methods
+
+(BT-IDM-03, 2026-06-03)
+
+A BT leaf node's `update()` method SHOULD NOT exceed ~20–30 lines of
+logic. If a node's `update()` is 60–100+ lines, it is doing too much and
+defeats the core purpose of BTs: simple, auditable, composable leaves with
+the complexity visible in tree *structure*, not in individual nodes.
+
+**Smell signals** that a node is a god node:
+
+- More than 3–4 distinct responsibilities (read, validate, create,
+  persist, broadcast, …)
+- Multiple `dl.save()` calls in one `update()`
+- Boolean constructor parameters (`advance_to_accepted=True`) that
+  silently activate optional branches
+- Internal `if/else` chains that should be separate `Sequence`/`Selector`
+  child nodes
+
+**Fix**: Decompose into a named subtree of simple leaf nodes, each with a
+single responsibility. The subtree factory function becomes the visible
+documentation of the workflow. See also `specs/behavior-tree-node-design.yaml`
+BTND-02-001 and `notes/bt-design-patterns.md`.
+
 ---
 
 ### BT Failure Reason Propagation

--- a/plan/history/2606/learning/CONCERN-632.md
+++ b/plan/history/2606/learning/CONCERN-632.md
@@ -1,0 +1,87 @@
+---
+source: CONCERN-632
+timestamp: '2026-06-03T19:55:11.844215+00:00'
+title: 'BT idiom audit: pervasive anti-patterns across use cases and BT nodes'
+type: learning
+---
+
+## Summary
+
+`vultron/core/use_cases/` and `vultron/core/behaviors/` contain pervasive BT
+anti-patterns across 10 findings (severity: high) that undermine auditability,
+composability, and spec compliance.
+
+## Original Concern Body
+
+### Finding 1 — Embargo received-side: NO BTs at all (HIGHEST severity)
+
+`vultron/core/use_cases/received/embargo.py` has 4 of 6 use cases doing
+protocol-significant work with zero BT involvement:
+`AddEmbargoEventToCaseReceivedUseCase`, `InviteToEmbargoOnCaseReceivedUseCase`,
+`AcceptInviteToEmbargoOnCaseReceivedUseCase`,
+`RejectInviteToEmbargoOnCaseReceivedUseCase` — all procedural. Compare:
+`RemoveEmbargoEventFromCaseReceivedUseCase` in the same file correctly uses a BT.
+
+### Finding 2 — Post-BT log cascade anti-pattern (HIGH severity)
+
+`_commit_embargo_log_cascade()` called after BT execution in 5 use cases instead
+of as a BT child subtree — violates BT-06-006.
+
+### Finding 3 — EM state machine manipulation in trigger use cases (HIGH severity)
+
+`triggers/embargo.py` directly drives `EMAdapter`/`create_em_machine()` inside
+`execute()` for `SvcProposeEmbargoUseCase`, `SvcAcceptEmbargoUseCase`,
+`SvcRejectEmbargoUseCase`, `SvcTerminateEmbargoUseCase`. PEC cascades also called
+procedurally. Cross-reference: extends #622 scope.
+
+### Finding 4 — Domain work done in execute() before BT runs (MEDIUM-HIGH severity)
+
+`SvcEngageCaseUseCase`/`SvcDeferCaseUseCase` (`triggers/case.py`): RM transition
+before BT. `SvcAddNoteToCaseUseCase` (`triggers/note.py`): note creation + save
+before BT. `SvcAddParticipantStatusUseCase`: entire execute() procedural — no BT.
+
+### Finding 5 — BT node calling a use case (layer boundary violation, MEDIUM)
+
+`PublicDisclosureBranchNode` in `vultron/core/behaviors/status/nodes.py` directly
+instantiates and calls `SvcTerminateEmbargoUseCase` from within `update()`.
+
+### Finding 6 — BT node importing from use case module (layer inversion, MEDIUM)
+
+`ApplyEmbargoTeardownNode` in `vultron/core/behaviors/embargo/nodes.py` imports
+`_reset_case_participant_embargo_consent` from `vultron.core.use_cases.received.embargo`.
+
+### Finding 7 — "God nodes" doing too much (MEDIUM severity)
+
+`CreateCaseActorNode.update()` (~100 lines), `InitializeDefaultEmbargoNode.update()`
+(~60 lines), `CreateCaseOwnerParticipant.update()`, `BroadcastStatusToPeersNode.update()`
+— all in `vultron/core/behaviors/case/nodes.py`.
+
+### Finding 8 — Non-BT use cases with BT-appropriate structure (MEDIUM)
+
+`AddCaseStatusToCaseReceivedUseCase`, four report received use cases
+(`CreateReport`, `AckReport`, `CloseReport`, `InvalidateReport`),
+`UpdateCaseReceivedUseCase` — all fully procedural PPA candidates.
+
+### Finding 9 — memory=False: generally correct but needs audit (LOW)
+
+Inline composites in `case/nodes.py` should be verified.
+
+### Finding 10 — ValidateCaseObject node is redundant (LOW)
+
+Checks invariants that should be enforced at Pydantic construction time per
+ARCH-10-001.
+
+## Resolution
+
+**Resolved**: 2026-06-03 — implementation tracked in #710 (embargo received-side
+BT adoption), #711 (trigger-side EM BT integration), #712 (pre-BT domain work
+refactoring), #713 (layer boundary fixes), #714 (god node decomposition), #715
+(remaining procedural use cases), #716 (BT cleanup).
+
+Three new AGENTS.md pitfalls documented (BT-IDM-01 through BT-IDM-03): BT node
+calling a use case, BT node importing from use case module, god BT nodes.
+
+Issue #622 (trigger-side inline state machine, Finding 3) wired as blocked-by
+\#711 (superseded in scope).
+
+Docs PR: <https://github.com/CERTCC/Vultron/pull/709>.


### PR DESCRIPTION
Docs-only PR: addresses concern #632 at the spec/notes level.

## Changes

- **`notes/bt-integration.md`**: 3 new anti-pattern entries (BT-IDM-01 through BT-IDM-03):
  - BT-IDM-01: BT node MUST NOT call a use case (found in `PublicDisclosureBranchNode`)
  - BT-IDM-02: BT node MUST NOT import from use case modules (found in `ApplyEmbargoTeardownNode`)
  - BT-IDM-03: God BT nodes with 60–100 line `update()` methods must be decomposed
- **`AGENTS.md`** (root): 3 new pitfall references pointing to the new bt-integration.md sections

Implementation tracked in issues to be created (see concern #632 decomposition).

Closes #632

No .py files changed.