### PR TITLE
docs: ingest concern #650 — delivery stubs lack explicit failure signal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -358,6 +358,14 @@ Short entries are reproduced here; longer ones are referenced below.
 
 > **Parallelism and Single-Agent Testing** has moved to `test/AGENTS.md`.
 >
+- **Stub Adapter Files Must Raise `NotImplementedError`, Not Silently No-Op** — Adapter
+  files that are intentional future-work placeholders (e.g.,
+  `adapters/driven/http_delivery.py`, `adapters/driving/shared_inbox.py`) MUST contain
+  a class or function that raises `NotImplementedError` when called, so any code that
+  accidentally references the stub gets an immediate, explicit signal instead of a
+  silent no-op. A docstring-only stub is indistinguishable from a real empty module
+  and can hide integration gaps in production-like deployments. See
+  `specs/outbox.yaml` OX-10-004, OX-11-004.
 - **Adding a New Pitfall: Check the Routing Policy First** — see
   [notes/agents-md-structure.md](notes/agents-md-structure.md)
 

--- a/notes/architecture-adapters.md
+++ b/notes/architecture-adapters.md
@@ -81,8 +81,15 @@ Track ongoing violations in the associated ARCH-01-001 issue and spec links.
 
 Architectural placeholders exist (tracked in GitHub issue #650):
 
-- `adapters/driven/http_delivery.py` (future signed remote HTTP delivery).
-- `adapters/driving/shared_inbox.py` (future ActivityPub shared-inbox fan-out).
+- `adapters/driven/http_delivery.py` — future signed remote HTTP delivery
+  (`specs/outbox.yaml` OX-10-001–OX-10-004). **Must raise `NotImplementedError`
+  if instantiated until implemented** (OX-10-004).
+- `adapters/driving/shared_inbox.py` — future ActivityPub shared-inbox fan-out
+  (`specs/outbox.yaml` OX-11-001–OX-11-004). **Must raise `NotImplementedError`
+  if instantiated until implemented** (OX-11-004).
+
+Both stubs are transport-only concerns. The core layer must not reference them
+directly; they are driven/driving adapter responsibilities only.
 
 ### Architecture boundary ratchet test
 

--- a/plan/history/2606/learning/CONCERN-650.md
+++ b/plan/history/2606/learning/CONCERN-650.md
@@ -1,0 +1,51 @@
+---
+source: CONCERN-650
+timestamp: '2026-06-03T19:59:13.695772+00:00'
+title: Remote HTTP delivery and shared-inbox are architectural stubs with no implementation
+type: learning
+---
+
+## Summary
+
+`vultron/adapters/driven/http_delivery.py` and
+`vultron/adapters/driving/shared_inbox.py` are placeholder files with no
+working implementation. Current remote delivery uses plain unauthenticated
+HTTP POST via `DeliveryQueueAdapter`. Message signing and shared-inbox
+fan-out remain unimplemented stubs.
+
+## Category
+
+- Top risk
+- Technical debt
+
+## Severity
+
+medium
+
+## Evidence
+
+- `vultron/adapters/driven/http_delivery.py` — stub, no implementation
+- `vultron/adapters/driving/shared_inbox.py` — stub, no implementation
+- `vultron/adapters/driven/delivery_queue.py` — plain HTTP POST delivery path
+
+## Impact if Ignored
+
+Multi-party interoperability and security posture are limited until signed
+delivery paths exist. Callers may assume these modules are functional,
+leading to silent no-ops in production-like deployments.
+
+## Resolution
+
+Root cause: signed remote delivery and shared-inbox fan-out are intentionally
+deferred prototype shortcuts, but were not visibly marked at the code or spec
+level — creating a silent-failure risk.
+
+Fix: spec entries added (OX-10-\* for signed delivery, OX-11-\* for
+shared-inbox fan-out) requiring `NotImplementedError` in stubs until
+implemented. `notes/architecture-adapters.md` updated with spec references.
+`AGENTS.md` pitfall added: stub adapter files must raise `NotImplementedError`,
+not silently no-op.
+
+**Resolved**: 2026-06-03 — implementation tracked in #717 (signed HTTP
+delivery) and #718 (shared-inbox fan-out).
+Docs PR: <https://github.com/CERTCC/Vultron/pull/719>.

--- a/specs/outbox.yaml
+++ b/specs/outbox.yaml
@@ -158,3 +158,92 @@ groups:
     statement: >-
       If any single actor's outbox depth exceeds a configurable threshold, the outbox
       monitor SHOULD emit a WARNING-level log entry identifying the actor and depth
+- id: OX-10
+  title: Signed Remote Delivery
+  scope:
+  - production
+  rationale: >-
+    Plain unauthenticated HTTP POST (current DeliveryQueueAdapter) is acceptable for
+    prototype use. Production federation requires HTTP Message Signatures so recipient
+    actors can verify the sender's identity and reject spoofed activities.
+    vultron/adapters/driven/http_delivery.py is a documented stub for this capability.
+  specs:
+  - id: OX-10-001
+    priority: SHOULD
+    statement: >-
+      For remote actor delivery, the outgoing HTTP POST SHOULD be signed using HTTP
+      Message Signatures (RFC 9421) with the sending actor's private key
+    scope:
+    - production
+  - id: OX-10-002
+    priority: MUST
+    statement: >-
+      The signing key pair MUST be per-actor and MUST NOT be shared across actors
+    scope:
+    - production
+    relationships:
+    - rel_type: depends_on
+      spec_id: OX-10-001
+  - id: OX-10-003
+    priority: MUST
+    statement: >-
+      The signed delivery adapter MUST be transport-only: it MUST NOT construct or
+      inspect ActivityStreams objects; serialization happens before the payload reaches
+      the adapter
+    rationale: Preserves the hexagonal layer boundary
+    relationships:
+    - rel_type: depends_on
+      spec_id: OX-10-001
+  - id: OX-10-004
+    priority: MUST
+    statement: >-
+      Until signed delivery is implemented, adapters/driven/http_delivery.py MUST
+      raise NotImplementedError if instantiated, so that callers receive an explicit
+      signal rather than a silent no-op
+    scope:
+    - prototype
+- id: OX-11
+  title: Shared-Inbox Fan-Out
+  scope:
+  - production
+  rationale: >-
+    ActivityPub shared-inbox delivers a single activity addressed to multiple local
+    actors via one HTTP POST, avoiding N separate deliveries for large groups. This
+    reduces network overhead for multi-party cases with many co-located participants.
+    vultron/adapters/driving/shared_inbox.py is a documented stub for this capability.
+  specs:
+  - id: OX-11-001
+    priority: MAY
+    statement: >-
+      The system MAY expose a shared inbox endpoint that accepts activities addressed
+      to multiple local actors in a single HTTP request
+    scope:
+    - production
+  - id: OX-11-002
+    priority: MUST
+    statement: >-
+      If a shared inbox is implemented, it MUST validate the HTTP Signature on the
+      inbound request before any fan-out processing
+    scope:
+    - production
+    relationships:
+    - rel_type: depends_on
+      spec_id: OX-11-001
+  - id: OX-11-003
+    priority: MUST
+    statement: >-
+      If a shared inbox is implemented, it MUST enqueue one per-actor inbox delivery
+      for each addressed local actor identified in the activity to/cc fields
+    scope:
+    - production
+    relationships:
+    - rel_type: depends_on
+      spec_id: OX-11-001
+  - id: OX-11-004
+    priority: MUST
+    statement: >-
+      Until shared-inbox is implemented, adapters/driving/shared_inbox.py MUST raise
+      NotImplementedError if instantiated, so that callers receive an explicit signal
+      rather than a silent no-op
+    scope:
+    - prototype


### PR DESCRIPTION
Docs-only PR: addresses concern #650 at the spec/notes/AGENTS.md level.
Implementation tracked in #717, #718.

## Changes

- `specs/outbox.yaml`: new OX-10-* group (signed HTTP delivery) and
  OX-11-* group (shared-inbox fan-out), including a `prototype`-scoped
  MUST requiring `NotImplementedError` until each stub is implemented
  (OX-10-004, OX-11-004)
- `notes/architecture-adapters.md`: updated § Future delivery stubs with
  spec references and explicit `NotImplementedError` requirement
- `AGENTS.md`: new pitfall entry — stub adapter files must raise
  `NotImplementedError`, not silently no-op

No .py files changed.

Closes #650