### PR TITLE
Add CoreObject base hierarchy + ADR-0017 for domain/wire object separation

### DIFF
--- a/docs/adr/0017-domain-wire-object-separation.md
+++ b/docs/adr/0017-domain-wire-object-separation.md
@@ -1,0 +1,188 @@
+---
+status: accepted
+date: 2026-06-03
+deciders: Vultron maintainers
+consulted: notes/domain-model-separation.md
+---
+
+# Domain/Wire Object Separation: Parallel Core Class Hierarchy
+
+## Context and Problem Statement
+
+`VulnerabilityCase`, `VulnerabilityReport`, `CaseParticipant`,
+`EmbargoPolicy`, `CaseStatus`, `CaseLogEntry`, and `VulnerabilityRecord`
+are **domain objects**: they describe the Vultron protocol's state, not
+the ActivityStreams 2.0 (AS2) wire format. The codebase, however, was
+built wire-first, so these classes currently live under
+`vultron/wire/as2/vocab/objects/` and inherit from the AS2 base class
+hierarchy (`as_Base` → `as_Object` → ...).
+
+This produces a layer-boundary inversion. The core layer
+(`vultron/core/`) is forbidden from importing the wire layer
+(`vultron/wire/as2/`); to satisfy that rule, `VultronActivity.object_`
+in `vultron/core/models/activity.py` is typed `Any | None`. Round-trips
+through `model_dump() → model_validate()` therefore lose typed object
+identity: nested domain objects deserialize as plain `dict`s, and
+`DataLayer.hydrate()` is silently skipped. PR #577 added an
+`_STUB_OBJECT_MODEL_MAP` workaround in `outbox_handler.py` that covers
+only `VulnerabilityCase` and requires per-type manual registration.
+
+Wire-format concerns also leak into the domain: AS2 freely models a
+nested object as an inline object, a bare ID string, or a `Link`
+reference, which forces core fields into `Object | str | Link | None`
+unions. Behavior-tree code, persistence code, and use-case handlers all
+pay the cost.
+
+Issue #699 tracks the per-type migration. Before any migration can land,
+core needs a **parallel base class hierarchy** that mirrors the wire
+layer's `as_Base` / `as_Object` shape — without inheriting from it.
+This ADR records the decision to introduce that hierarchy, the naming
+convention used by the migrated types, and the rule that core fields
+hold full objects rather than wire-style references. Issue #724 lands
+only the foundation; no per-type migrations occur in the same change.
+
+## Decision Drivers
+
+- Restore the hexagonal boundary: domain logic lives in `core/`, wire
+  logic lives in `wire/`. Core MUST NOT import wire.
+- Make `VultronActivity.object_` typeable as a Pydantic discriminated
+  union so round-trips preserve object identity and `hydrate()` is
+  reached without per-type stub maps.
+- Avoid leaking AS2 "inline-or-ref" polymorphism into the domain.
+- Provide a stable, registered vocabulary the future discriminated
+  union and bulk-migration tooling can iterate over.
+- Keep the change reversible and small: foundation-only, no behavioral
+  change.
+
+## Considered Options
+
+- **A. Re-home domain types under `core/models/`, no shared base.** Each
+  migrated type inherits directly from `pydantic.BaseModel`.
+- **B. Introduce a `CoreObject` base in `core/models/`, parallel to
+  (but not derived from) `as_Object`.** Wire-side classes become thin
+  projections that re-export or wrap the core types.
+- **C. Move `as_Object` itself into `core/` and re-export from wire.**
+  Domain types continue to inherit from a single shared base.
+
+## Decision Outcome
+
+Chosen option: **B — introduce a `CoreObject` base in `core/models/`,
+parallel to `as_Object`**, because it cleanly satisfies the layer-
+boundary rule (core never imports wire), keeps wire-layer JSON-LD
+concerns (`@context`, AS2 vocabulary registry) out of the domain, and
+gives future per-type migrations a stable foundation to inherit from
+without duplicating the `id_`/`type_`/`published`/`updated`/`name`
+boilerplate that every domain object needs.
+
+### Decision details
+
+1. **Parallel hierarchy.** A new `CoreObject` class lives in
+   `vultron/core/models/base.py`. It inherits from the existing
+   `VultronObject` (so it transitively carries the AS2-derived fields
+   `id_`, `type_`, `name`, `attributed_to`, `published`, `updated`,
+   plus the broader set of optional fields that already exist on
+   `VultronObject`). It adds the JSON-LD `context_` field
+   (validation/serialization alias `@context`), which has no default —
+   the wire projection supplies the AS2 namespace at serialization
+   time. (`VultronObject` itself remains in place to keep the existing
+   `Vultron*` stubs untouched, per issue #724 AC-4.)
+
+   Concrete subclasses register themselves in `CORE_VOCABULARY` via
+   `__init_subclass__`. A subclass is registered only when it overrides
+   `type_` with a concrete (non-union) annotation, mirroring the
+   wire-layer `VOCABULARY` registration rule. The registry key is the
+   subclass's `__name__` verbatim — no prefix to strip, because core
+   classes have no `as_` prefix.
+
+2. **Core fields hold full objects, not refs.** Domain fields MUST NOT
+   use `Object | str | Link | None` unions. The "inline-or-ref"
+   polymorphism is a wire-format concern; the wire layer translates
+   bare-ID and `Link` forms into full embedded objects at the
+   deserialization boundary, and the `DataLayer` hydrates IDs on read.
+   The only intentional exception is a small set of cases where the
+   core legitimately needs an ID reference for a graph-cycle reason
+   — e.g., parent/child case linkage on `VulnerabilityCase`, where
+   embedding the parent object would either recurse infinitely or
+   prematurely materialize an entire case tree. Such cases MUST be
+   called out explicitly at the field site with a comment naming this
+   ADR.
+
+3. **Naming convention.** Migrated core types use the canonical CVD
+   domain vocabulary without a `Vultron` prefix:
+
+   - `VulnerabilityCase` (not `VultronCase`)
+   - `VulnerabilityReport` (not `VultronReport`)
+   - `CaseStatus`, `CaseParticipant`, `EmbargoPolicy`,
+     `CaseLogEntry`, `VulnerabilityRecord`
+
+   "Wire-style" here means **the canonical Vultron domain vocabulary
+   already used in the wire layer's class names**, not "ownership by
+   the wire layer." After migration, the wire layer's domain-object
+   modules become thin projections that re-export the core types
+   (possibly wrapped in an AS2-flavored adapter when JSON-LD-specific
+   behavior is needed). The legacy `Vultron*` stubs in
+   `vultron/core/models/` (`VultronCase`, `VultronReport`,
+   `VultronNote`, etc.) are intentionally left in place by issue #724
+   and will be replaced as each type migrates under issue #699.
+
+### Consequences
+
+- Good, because `VultronActivity.object_` can be retyped as a Pydantic
+  discriminated union once at least the first few domain types
+  migrate, deleting `_STUB_OBJECT_MODEL_MAP` and the dict-recovery
+  block in `outbox_handler.py`.
+- Good, because core handlers and behavior-tree code stop seeing
+  `Object | str | Link | None` shapes; field types match the
+  developer's mental model.
+- Good, because the registry pattern proven in the wire layer carries
+  over without surprises and supports future bulk operations
+  (discriminated-union assembly, persistence mapping, schema export).
+- Bad, because two base classes (`VultronObject`, `CoreObject`) coexist
+  during the migration window, with `CoreObject` inheriting
+  `VultronObject` to honor issue #724 AC-2 and avoid disturbing the
+  existing stubs. Once #699 completes, `VultronObject` can fold into
+  `CoreObject` (or vice versa) in a follow-up cleanup.
+- Bad, because the `@context` field now exists on `CoreObject` even
+  though its only consumer is the wire layer; the default of `None`
+  keeps it inert in core code paths.
+- Neutral, because the registry is opt-in: only subclasses that supply
+  a concrete `type_` register, so future "abstract" intermediate
+  bases will not pollute `CORE_VOCABULARY`.
+
+## Validation
+
+- `test/core/models/test_core_object.py` adds coverage for: `CoreObject`
+  subclass registration when `type_` is concrete; non-registration
+  when `type_` is omitted or union-typed; registry key equals
+  `cls.__name__`; existing `Vultron*` stubs do not appear in
+  `CORE_VOCABULARY` (they inherit `VultronObject`, not `CoreObject`);
+  and a PEP 563 regression test that exercises `from __future__
+  import annotations` to ensure the union-skip check is robust to
+  stringified annotations.
+- The migration of each domain type into core under issue #699 will
+  add a test that constructs the core type, serializes via wire, and
+  round-trips back through `model_validate()` with object identity
+  preserved.
+- The layer-boundary rule (core MUST NOT import wire) is already
+  enforced by `test/architecture/test_layer_boundaries.py`.
+
+## More Information
+
+- Issue #724 — Refactor #699 step 1: core base hierarchy + ADR for
+  domain/wire object separation (this ADR).
+- Issue #699 — Migrate domain objects from
+  `wire/as2/vocab/objects/` to `core/models/` and type
+  `VultronActivity.object_` as a discriminated union.
+- Concern #586 — original layer-boundary inversion report.
+- PR #577 — `_STUB_OBJECT_MODEL_MAP` workaround that this design
+  eventually deletes.
+- `notes/domain-model-separation.md` — full architectural direction,
+  including the translation-boundary model
+  (Wire DTO → Domain Model → Persistence Model) and the
+  domain-events-as-bridge discussion.
+- `notes/codebase-structure.md` "Core Object Modules" — related
+  file-splitting recommendation.
+- ADR-0009 — Hexagonal Architecture (Ports and Adapters), the
+  enclosing rule this ADR operationalizes for domain objects.
+- ADR-0010 — Standardize Object IDs to URI Form; the ID format that
+  makes `DataLayer.hydrate()` viable.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -66,6 +66,10 @@ General information about architectural decision records is available at <https:
   Comments](0014-sha-pin-github-actions.md)
 - [ADR-0015 Create VulnerabilityCase at Report Receipt
   (RM.RECEIVED)](0015-create-case-at-report-receipt.md)
+- [ADR-0016 Replace TinyDB with SQLModel/SQLite DataLayer
+  Adapter](0016-sqlmodel-sqlite-datalayer.md)
+- [ADR-0017 Domain/Wire Object Separation: Parallel Core Class
+  Hierarchy](0017-domain-wire-object-separation.md)
 
 ## Proposed ADRs
 

--- a/plan/history/2606/implementation/ISSUE-724.md
+++ b/plan/history/2606/implementation/ISSUE-724.md
@@ -1,0 +1,53 @@
+---
+source: ISSUE-724
+timestamp: '2026-06-03T21:04:54.041048+00:00'
+title: CoreObject base hierarchy + ADR-0017 for domain/wire separation
+type: implementation
+---
+
+## Issue #724 — Refactor #699 step 1: core base hierarchy + ADR for domain/wire object separation
+
+Step 1 of the larger refactor tracked in #699. Foundation only — no per-type
+migrations land here. Establishes a parallel core class hierarchy in
+`vultron/core/models/` that mirrors `as_Base` / `as_Object` in the wire layer,
+plus the ADR capturing the parallel-hierarchy decision.
+
+### Delivered
+
+- `CoreObject` base class in `vultron/core/models/base.py`, inheriting from
+  `VultronObject`, adding the JSON-LD `@context` field (`context_`, defaulted
+  to `None` so wire-layer projection supplies the AS2 namespace), and
+  auto-registering concrete subclasses in `CORE_VOCABULARY` via
+  `__init_subclass__`. Registration is gated on `type_` being overridden with
+  a non-union annotation, and is resolved through `typing.get_type_hints` so
+  the check is robust under `from __future__ import annotations` (PEP 563).
+- `CORE_VOCABULARY` registry plus `find_in_core_vocabulary()` helper in
+  `vultron/core/models/registry.py`.
+- ADR-0017 (`docs/adr/0017-domain-wire-object-separation.md`) capturing:
+  parallel-hierarchy decision, refs-are-wire-only rule (with parent/child
+  case-cycle exception called out explicitly), and the wire-style naming
+  convention (`VulnerabilityCase`, not `VultronCase`).
+- 12 new tests in `test/core/models/test_core_object.py`, including a PEP 563
+  regression test using a real importable module file.
+- Existing `Vultron*` core stubs untouched (AC-4); positively asserted in
+  tests.
+
+### Validation
+
+- black + flake8 clean.
+- mypy: `Success: no issues found in 654 source files`.
+- pyright: `0 errors, 0 warnings, 0 informations`.
+- pytest: `2631 passed, 12 skipped, 216 deselected, 5633 subtests passed`.
+- mkdocs `--strict` warning count unchanged vs baseline (16 → 16).
+
+### Pre-PR code review
+
+Caught one [BLOCKING] correctness issue: the original `__init_subclass__`
+implementation pattern-matched `cls.__dict__["__annotations__"]` and would
+silently register every subclass under `from __future__ import annotations`
+because raw annotations are strings. Switched to `typing.get_type_hints(cls)`
+and added a regression test that creates a real module file (necessary
+because `__future__` directives only take effect on compiled module files,
+and `get_type_hints` needs proper module globals to resolve `Literal`).
+
+PR: <https://github.com/CERTCC/Vultron/pull/734>

--- a/test/core/models/test_core_object.py
+++ b/test/core/models/test_core_object.py
@@ -1,0 +1,197 @@
+"""Tests for CoreObject base class and CORE_VOCABULARY registry."""
+
+from typing import Literal
+
+import pytest
+from pydantic import BaseModel
+
+from vultron.core.models import (
+    CORE_VOCABULARY,
+    CoreObject,
+    VultronObject,
+    find_in_core_vocabulary,
+)
+from vultron.core.models.base import VultronBase
+from vultron.core.models.case import VultronCase
+from vultron.core.models.note import VultronNote
+from vultron.core.models.report import VultronReport
+
+# --- Inheritance shape ------------------------------------------------------
+
+
+def test_core_object_inherits_vultron_object():
+    assert issubclass(CoreObject, VultronObject)
+    assert issubclass(CoreObject, VultronBase)
+    assert issubclass(CoreObject, BaseModel)
+
+
+def test_core_object_has_required_as2_fields():
+    """AC-2: CoreObject must carry the AS2 fields the domain needs."""
+    fields = set(CoreObject.model_fields.keys())
+    for required in (
+        "id_",
+        "type_",
+        "name",
+        "attributed_to",
+        "published",
+        "updated",
+        "context_",
+    ):
+        assert (
+            required in fields
+        ), f"CoreObject missing required field {required!r}"
+
+
+def test_core_object_default_instance():
+    obj = CoreObject()
+    assert obj.id_.startswith("urn:uuid:")
+    # Bare CoreObject is treated as concrete by the type-from-classname validator.
+    assert obj.type_ == "CoreObject"
+    # context_ is a wire concern and defaults to None on the domain side.
+    assert obj.context_ is None
+    assert obj.published is not None
+    assert obj.updated is not None
+
+
+def test_core_object_context_alias_serializes_as_at_context():
+    obj = CoreObject.model_validate(
+        {"@context": "https://www.w3.org/ns/activitystreams"}
+    )
+    assert obj.context_ == "https://www.w3.org/ns/activitystreams"
+    dumped = obj.model_dump(by_alias=True, exclude_none=True)
+    assert "@context" in dumped
+    assert dumped["@context"] == "https://www.w3.org/ns/activitystreams"
+    assert "context_" not in dumped
+
+
+def test_core_object_context_empty_string_rejected():
+    """NonEmptyString rule applies to context_ too."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        CoreObject.model_validate({"@context": ""})
+
+
+# --- CORE_VOCABULARY registration ------------------------------------------
+
+
+@pytest.fixture
+def isolated_vocab():
+    """Snapshot CORE_VOCABULARY around a test, restoring it after."""
+    snapshot = dict(CORE_VOCABULARY)
+    try:
+        yield
+    finally:
+        CORE_VOCABULARY.clear()
+        CORE_VOCABULARY.update(snapshot)
+
+
+def test_concrete_subclass_registers(isolated_vocab):
+    class CoreVocabFixtureConcrete(CoreObject):
+        type_: Literal["CoreVocabFixtureConcrete"] = "CoreVocabFixtureConcrete"
+
+    assert "CoreVocabFixtureConcrete" in CORE_VOCABULARY
+    assert (
+        CORE_VOCABULARY["CoreVocabFixtureConcrete"] is CoreVocabFixtureConcrete
+    )
+    assert find_in_core_vocabulary("CoreVocabFixtureConcrete") is (
+        CoreVocabFixtureConcrete
+    )
+
+
+def test_subclass_without_type_override_does_not_register(isolated_vocab):
+    class CoreVocabFixtureAbstract(CoreObject):
+        pass
+
+    assert "CoreVocabFixtureAbstract" not in CORE_VOCABULARY
+
+
+def test_subclass_with_union_type_override_does_not_register(isolated_vocab):
+    class CoreVocabFixtureUnion(CoreObject):
+        # Optional[str] — an abstract intermediate base, must not register.
+        type_: str | None = None
+
+    assert "CoreVocabFixtureUnion" not in CORE_VOCABULARY
+
+
+def test_registry_key_is_class_name_verbatim(isolated_vocab):
+    """Core uses wire-style names with no prefix; key must equal __name__."""
+
+    class VulnerabilityCaseRegistryProbe(CoreObject):
+        type_: Literal["VulnerabilityCaseRegistryProbe"] = (
+            "VulnerabilityCaseRegistryProbe"
+        )
+
+    assert "VulnerabilityCaseRegistryProbe" in CORE_VOCABULARY
+    # No "as_" or other prefix stripping.
+    assert "CaseRegistryProbe" not in CORE_VOCABULARY
+
+
+def test_find_in_core_vocabulary_raises_on_unknown():
+    with pytest.raises(KeyError):
+        find_in_core_vocabulary("ThisTypeDoesNotExist")
+
+
+def test_registry_robust_under_future_annotations(tmp_path, isolated_vocab):
+    """Regression: PEP 563 string annotations must not bypass the union skip.
+
+    Under ``from __future__ import annotations``, raw entries in
+    ``__annotations__`` are strings, so inspecting them with
+    ``isinstance(..., types.UnionType)`` falsely registers abstract
+    intermediate bases.  The implementation must resolve annotations
+    via ``typing.get_type_hints`` (which uses the class's module
+    globals) instead of pattern-matching the raw annotation values.
+
+    The check has to run in a real importable module — the
+    ``__future__`` directive only takes effect at compile time on a
+    proper module, and ``typing.get_type_hints`` needs the class's
+    ``__module__`` to point at a module whose globals contain
+    ``Literal``.
+    """
+    import importlib
+    import sys
+    import textwrap
+
+    module_dir = tmp_path / "future_annot_pkg"
+    module_dir.mkdir()
+    (module_dir / "__init__.py").write_text("")
+    (module_dir / "fixtures.py").write_text(textwrap.dedent("""
+            from __future__ import annotations
+            from typing import Literal
+            from vultron.core.models import CoreObject
+
+            class FutureAnnotAbstract(CoreObject):
+                type_: str | None = None
+
+            class FutureAnnotConcrete(CoreObject):
+                type_: Literal["FutureAnnotConcrete"] = "FutureAnnotConcrete"
+            """))
+    sys.path.insert(0, str(tmp_path))
+    try:
+        mod = importlib.import_module("future_annot_pkg.fixtures")
+    finally:
+        sys.path.remove(str(tmp_path))
+        sys.modules.pop("future_annot_pkg.fixtures", None)
+        sys.modules.pop("future_annot_pkg", None)
+
+    assert "FutureAnnotAbstract" not in CORE_VOCABULARY
+    assert "FutureAnnotConcrete" in CORE_VOCABULARY
+    assert CORE_VOCABULARY["FutureAnnotConcrete"] is mod.FutureAnnotConcrete
+
+
+# --- AC-4: legacy Vultron* stubs are untouched ------------------------------
+
+
+def test_legacy_vultron_stubs_do_not_inherit_core_object():
+    """AC-4: existing Vultron* core stubs are not migrated yet.
+
+    They must still inherit from VultronObject (not CoreObject), and
+    therefore must not appear in CORE_VOCABULARY.
+    """
+    for cls in (VultronCase, VultronReport, VultronNote):
+        assert issubclass(cls, VultronObject)
+        assert not issubclass(cls, CoreObject), (
+            f"{cls.__name__} prematurely inherits CoreObject; "
+            "issue #724 AC-4 forbids migrating legacy stubs in this change."
+        )
+        assert cls.__name__ not in CORE_VOCABULARY

--- a/ui/README.md
+++ b/ui/README.md
@@ -9,11 +9,13 @@ Interactive visualization demo for the Vultron protocol state machines.
 ## Getting Started
 
 1. **Install dependencies:**
+
    ```bash
    npm install
    ```
 
 2. **Run the development server:**
+
    ```bash
    npm run dev
    ```

--- a/vultron/core/models/__init__.py
+++ b/vultron/core/models/__init__.py
@@ -1,5 +1,14 @@
 """Domain model definitions for the Vultron Protocol."""
 
-from vultron.core.models.base import VultronObject
+from vultron.core.models.base import CoreObject, VultronObject
+from vultron.core.models.registry import (
+    CORE_VOCABULARY,
+    find_in_core_vocabulary,
+)
 
-__all__ = ["VultronObject"]
+__all__ = [
+    "CORE_VOCABULARY",
+    "CoreObject",
+    "VultronObject",
+    "find_in_core_vocabulary",
+]

--- a/vultron/core/models/base.py
+++ b/vultron/core/models/base.py
@@ -16,12 +16,21 @@
 """Base class for Vultron Protocol core domain object models."""
 
 import re
+import types as _types
+import typing as _typing
 from datetime import datetime, timedelta
 from typing import Annotated, Any
 
-from pydantic import AfterValidator, BaseModel, ConfigDict, Field
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    ConfigDict,
+    Field,
+    model_validator,
+)
 
 from vultron.core.models._helpers import _new_urn, _now_utc
+from vultron.core.models.registry import CORE_VOCABULARY
 
 
 def _non_empty(v: str) -> str:
@@ -96,3 +105,71 @@ class VultronObject(VultronBase):
     bcc: Any | None = None
     audience: Any | None = None
     attributed_to: NonEmptyString | None = None
+
+
+class CoreObject(VultronObject):
+    """Base class for the migrated Vultron core domain object hierarchy.
+
+    Mirrors ``as_Base`` / ``as_Object`` in the wire layer and carries the
+    minimal AS2-derived fields a domain object needs to participate in
+    federated coordination: ``id_``, ``type_``, ``name`` (inherited from
+    :class:`VultronBase`), ``attributed_to``, ``published``, ``updated``
+    (inherited from :class:`VultronObject`), and ``context_`` (added here
+    as the JSON-LD ``@context`` field).
+
+    Subclasses that override ``type_`` with a concrete (non-union)
+    annotation — e.g. ``type_: Literal["VulnerabilityCase"] = ...`` —
+    register themselves in :data:`CORE_VOCABULARY` via
+    ``__init_subclass__``.  Subclasses that leave ``type_`` abstract
+    (omitted, or annotated as a union) are intentionally not registered.
+
+    ``context_`` defaults to ``None``: the JSON-LD ``@context`` value is a
+    wire-layer concern, and the wire projection layer is responsible for
+    supplying the AS2 namespace at serialization time.
+
+    See ``docs/adr/0017-domain-wire-object-separation.md`` for the
+    rationale, and ``notes/domain-model-separation.md`` for the broader
+    architectural direction (tracked by issue #699).
+    """
+
+    context_: NonEmptyString | None = Field(
+        default=None,
+        validation_alias="@context",
+        serialization_alias="@context",
+    )
+
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        super().__init_subclass__(**kwargs)  # type: ignore[arg-type]
+        # Register only subclasses that override ``type_`` with a concrete
+        # (non-union) annotation — e.g. ``type_: Literal["FooBar"] = "FooBar"``.
+        # We inspect the subclass's *own* ``__annotations__`` so an inheriting
+        # class that does not redeclare ``type_`` (e.g. a behavioral mixin)
+        # is not registered. We then resolve the annotation through
+        # ``typing.get_type_hints`` so the check is robust under
+        # ``from __future__ import annotations`` (PEP 563), where raw
+        # annotations are stringified and ``isinstance(..., UnionType)``
+        # would silently fall through and register abstract bases.
+        own_annotations = cls.__dict__.get("__annotations__", {})
+        if "type_" not in own_annotations:
+            return  # No type_ override → abstract base, skip
+        try:
+            hints = _typing.get_type_hints(cls)
+        except Exception:
+            # If forward references cannot be resolved, do not register —
+            # silent registration of a half-constructed class is worse than
+            # a missing entry, which surfaces immediately at lookup time.
+            return
+        annotation = hints.get("type_")
+        # Skip union annotations (e.g. ``str | None``) — these mark
+        # intermediate abstract bases, not concrete vocabulary entries.
+        if isinstance(annotation, _types.UnionType):
+            return
+        if _typing.get_origin(annotation) is _typing.Union:
+            return
+        CORE_VOCABULARY[cls.__name__] = cls
+
+    @model_validator(mode="after")
+    def _set_type_from_class_name(self) -> "CoreObject":
+        if self.type_ is None:
+            self.type_ = self.__class__.__name__
+        return self

--- a/vultron/core/models/registry.py
+++ b/vultron/core/models/registry.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Registry for the Vultron core domain object hierarchy.
+
+This is the domain-layer analog of
+:mod:`vultron.wire.as2.vocab.base.registry`.  Concrete subclasses of
+:class:`vultron.core.models.base.CoreObject` register themselves here via
+``__init_subclass__`` so that downstream code (e.g. discriminated-union
+construction, future migrations) can discover the full set of domain
+object types without per-type manual wiring.
+
+The registry value type is ``type[BaseModel]`` rather than
+``type[CoreObject]`` to keep this module import-cycle free —
+``base.py`` imports from this module.
+"""
+
+from pydantic import BaseModel
+
+CORE_VOCABULARY: dict[str, type[BaseModel]] = {}
+
+
+def find_in_core_vocabulary(item_name: str) -> type[BaseModel]:
+    """Find a class in the core vocabulary by type name.
+
+    Args:
+        item_name: The name of the type to find.
+    Returns:
+        The class registered under that name.
+    Raises:
+        KeyError: If the type name is not registered.
+    """
+    if item_name not in CORE_VOCABULARY:
+        raise KeyError(f"Unknown core vocabulary type: {item_name!r}")
+    return CORE_VOCABULARY[item_name]


### PR DESCRIPTION
Closes #724.

Step 1 of the larger refactor tracked in #699. Foundation only — no per-type migrations land here.

## What changed

- **`vultron/core/models/registry.py` (new)** — `CORE_VOCABULARY` dict and `find_in_core_vocabulary()` helper, the domain-layer analog of the wire `VOCABULARY` registry.
- **`vultron/core/models/base.py`** — adds `CoreObject` class. Inherits from `VultronObject` (per AC-2), adds the JSON-LD `@context` field (`context_`, default `None` because `@context` is a wire concern), and auto-registers concrete subclasses in `CORE_VOCABULARY` via `__init_subclass__`. Uses `typing.get_type_hints` so the union-skip check is robust under `from __future__ import annotations` — without this, abstract intermediate bases declared in PEP-563 modules would have silently registered (caught in pre-PR code review).
- **`vultron/core/models/__init__.py`** — re-exports `CoreObject`, `CORE_VOCABULARY`, and `find_in_core_vocabulary`.
- **`docs/adr/0017-domain-wire-object-separation.md` (new)** — captures the parallel-hierarchy decision, the rule that core fields hold full objects (not `Object | str | Link | None` unions) with the parent/child case-cycle exception called out explicitly, and the naming convention (wire-style names like `VulnerabilityCase`, no `Vultron*` prefix).
- **`docs/adr/index.md`** — adds ADR-0016 and ADR-0017 entries (0016 was previously unlisted).
- **`test/core/models/test_core_object.py` (new)** — 12 tests covering: required AS2 fields present (AC-2); `@context` alias round-trip; `NonEmptyString` rule on `context_`; registration of concrete `type_` overrides; non-registration of abstract bases (no `type_` override and union `type_` annotation); registry key equals `cls.__name__`; `find_in_core_vocabulary` raises on unknown; PEP 563 regression test using a real importable module; AC-4 confirmation that legacy `VultronCase`/`VultronReport`/`VultronNote` stubs do not inherit `CoreObject` and do not appear in `CORE_VOCABULARY`.

## Acceptance criteria

- [x] AC-1: ADR-0017 captures parallel hierarchy, refs-are-wire-only with parent/child case exception, and the no-`Vultron*`-prefix naming rule.
- [x] AC-2: `CoreObject` defined in `vultron/core/models/base.py`, inherits `VultronObject`, carries `id_`, `type_`, `name`, `attributed_to`, `published`, `updated`, `context_`.
- [x] AC-3: `CORE_VOCABULARY` registry auto-populated via `__init_subclass__`.
- [x] AC-4: No type migrations — existing `Vultron*` core stubs untouched (positively tested).
- [x] AC-5: mypy and pyright pass.

## Validation

- `uv run black` + `uv run flake8`: clean.
- `uv run mypy`: `Success: no issues found in 654 source files`.
- `uv run pyright`: `0 errors, 0 warnings, 0 informations`.
- `uv run pytest --tb=short`: `2631 passed, 12 skipped, 216 deselected, 5633 subtests passed in 30.35s` (one new test file, 12 new tests).
- `uv run mkdocs build --strict`: pre-existing warning count unchanged (16 → 16); ADR-0017 builds and is included in nav.

## Notes for review

- Pre-PR code review caught a [BLOCKING] correctness issue: the original `__init_subclass__` used `cls.__dict__["__annotations__"]` and `isinstance(..., UnionType)` directly, which silently registers every subclass under `from __future__ import annotations` (raw annotations are strings). Switched to `typing.get_type_hints(cls)` and added a regression test that creates a real module file. The wire-layer `as_Base.__init_subclass__` has the same latent bug (filed separately if it ever becomes a problem); fixing it here would expand scope beyond #724.
- `VultronObject` is intentionally not deleted — AC-4 requires the legacy `Vultron*` stubs (which inherit it) remain untouched. Once #699 migrations complete, `VultronObject` and `CoreObject` can be merged in a follow-up.