### PR TITLE
docs: ingest concern #514 — split case BT nodes into nodes/ subpackage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,6 +310,19 @@ Short entries are reproduced here; longer ones are referenced below.
   simple leaf nodes; the tree structure becomes the workflow documentation.
   See [notes/bt-integration.md](notes/bt-integration.md)
   § "DO NOT: God BT nodes with long `update()` methods".
+- **Flat `nodes.py` with 10+ BT Classes Is a Code Smell** — A single
+  `nodes.py` accumulating ten or more BT node classes is a high-churn,
+  high-blast-radius module. Every change — regardless of which workflow step
+  it touches — modifies the same file, making review shallow and increasing
+  the risk of duplicate method definitions silently shadowing correct logic.
+  When a `nodes.py` reaches this threshold, convert it to a `nodes/`
+  subpackage with submodules grouped by semantic concern (e.g.,
+  `conditions.py`, `case_setup.py`, `participant.py`, `embargo.py`,
+  `communication.py`, `lifecycle.py`). The `__init__.py` MUST re-export all
+  public names to preserve caller import paths. Mirror the split in the test
+  suite: a `test/…/nodes/` directory with one `test_<submodule>.py` per
+  submodule. See `specs/behavior-tree-node-design.yaml` BTND-07-001 and
+  BTND-07-002.
 - **py_trees Blackboard Global State** — see [notes/bt-integration.md](notes/bt-integration.md)
 - **py_trees `blackboard.get()` Raises KeyError for Unwritten READ Keys** — see [notes/bt-integration.md](notes/bt-integration.md)
 - **Duplicate Method Definitions Silently Shadow Correct BT Logic** — see [notes/bt-integration.md](notes/bt-integration.md)

--- a/plan/history/2606/learning/CONCERN-514.md
+++ b/plan/history/2606/learning/CONCERN-514.md
@@ -1,0 +1,44 @@
+---
+source: CONCERN-514
+timestamp: '2026-06-04T13:12:34.045887+00:00'
+title: Split case BT nodes into nodes/ subpackage by semantic domain
+type: learning
+---
+
+## Summary
+
+`vultron/core/behaviors/case/nodes.py` was the highest-churn source file in
+the repository at 1502 lines, 13 BT node classes, and 47 commits in 90 days.
+Every change to any workflow step required touching the same monolithic module,
+making code review shallow and increasing regression risk (including the
+silent-duplicate-method pitfall already documented in AGENTS.md).
+
+## Category
+
+- [x] Fragile / high-churn area
+
+## Severity
+
+medium
+
+## Root Cause
+
+All case-protocol BT nodes live in one flat module. Any change — regardless of
+which workflow step it touches — modifies the same file, making code review
+shallow and raising the risk that duplicate method definitions silently shadow
+correct logic (an existing AGENTS.md pitfall).
+
+## Resolution
+
+**Resolved**: 2026-06-03 — implementation tracked in #736.
+
+Docs PR: <https://github.com/CERTCC/Vultron/pull/737>.
+
+- Added `specs/behavior-tree-node-design.yaml` BTND-07 group with two new
+  requirements (BTND-07-001, BTND-07-002) formalizing the "one concern per
+  module" rule for BT node packages and mirrored test structure.
+- Added AGENTS.md pitfall entry: "Flat `nodes.py` with 10+ BT Classes Is a
+  Code Smell" with refactoring guidance referencing BTND-07-001 and
+  BTND-07-002.
+- Implementation issue #736 created as child of epic #539, blocked by concern
+  #514, added to Project #24 with Schedule=Someday.

--- a/specs/behavior-tree-node-design.yaml
+++ b/specs/behavior-tree-node-design.yaml
@@ -7,6 +7,7 @@ description: >-
 version: 1.0.0
 kind: pattern
 scope:
+
 - prototype
 - production
 groups:
@@ -248,3 +249,46 @@ groups:
     relationships:
     - rel_type: refines
       spec_id: BT-06-004
+- id: BTND-07
+  title: BT Node Module Organization
+  kind: pattern
+  specs:
+  - id: BTND-07-001
+    priority: SHOULD
+    statement: >-
+      (**SHOULD**) BT node classes for a given protocol step SHOULD be organized into a
+      `nodes/` subpackage rather than a single flat `nodes.py` module. Submodules MUST
+      be grouped by semantic concern (e.g., `conditions.py`, `case_setup.py`,
+      `participant.py`, `embargo.py`, `communication.py`, `lifecycle.py`). The package
+      `__init__.py` MUST re-export all public node names to preserve import compatibility
+      with callers.
+    rationale: >-
+      A flat `nodes.py` accumulating ten or more BT node classes becomes a high-churn,
+      high-blast-radius file where every change — regardless of which workflow step it
+      touches — modifies the same module. This makes code review shallow, increases the
+      risk of duplicate method definitions silently shadowing correct logic, and degrades
+      test maintainability. Grouping by semantic concern reduces diff scope, improves
+      discoverability, and lets reviewers focus on the affected concern in isolation.
+    relationships:
+    - rel_type: refines
+      spec_id: BT-06-004
+    verification: >-
+      Any `nodes.py` containing ten or more BT node classes SHOULD be flagged for
+      refactoring into a `nodes/` subpackage. CI or a codebase-scan tool MAY enforce this
+      threshold.
+  - id: BTND-07-002
+    priority: SHOULD
+    statement: >-
+      (**SHOULD**) The test suite for a `nodes/` subpackage SHOULD mirror the subpackage
+      structure: a `test/…/nodes/` directory with one `test_<submodule>.py` per submodule,
+      so that each concern's tests are co-located and independently runnable.
+    rationale: >-
+      A monolithic `test_nodes.py` grows in parallel with the flat `nodes.py` and
+      inherits the same blast-radius problem. Mirrored test files scope test failures to
+      the affected concern and make it easier to add focused per-node unit tests.
+    relationships:
+    - rel_type: refines
+      spec_id: BTND-07-001
+    verification: >-
+      For any `nodes/` subpackage, confirm that a matching `test/…/nodes/` directory
+      exists with per-submodule test files.

--- a/ui/README.md
+++ b/ui/README.md
@@ -9,11 +9,13 @@ Interactive visualization demo for the Vultron protocol state machines.
 ## Getting Started
 
 1. **Install dependencies:**
+
    ```bash
    npm install
    ```
 
 2. **Run the development server:**
+
    ```bash
    npm run dev
    ```


### PR DESCRIPTION
Docs-only PR: addresses concern #514 at the spec/notes level.
Implementation tracked in #736.

## Changes

- **`specs/behavior-tree-node-design.yaml`**: Added BTND-07 group
  ("BT Node Module Organization") with two new requirements:
  - BTND-07-001: BT nodes for a given protocol step SHOULD be organized
    into a `nodes/` subpackage with submodules grouped by semantic concern;
    `__init__.py` MUST re-export all public names
  - BTND-07-002: Test suite SHOULD mirror the subpackage structure with
    per-submodule test files
- **`AGENTS.md`**: Added "Flat `nodes.py` with 10+ BT Classes Is a Code
  Smell" pitfall entry with refactoring guidance and spec cross-reference

No .py files changed.

Closes #514