### PR TITLE
docs: ingest concern #652 — triggers/case.py test coverage and PR scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -395,6 +395,18 @@ Short entries are reproduced here; longer ones are referenced below.
   silent no-op. A docstring-only stub is indistinguishable from a real empty module
   and can hide integration gaps in production-like deployments. See
   `specs/outbox.yaml` OX-10-004, OX-11-004.
+- **Trigger Use Cases Need Per-Use-Case Tests; Don't Bundle Case + Embargo
+  Trigger Changes in One PR** — Every use case in
+  `vultron/core/use_cases/triggers/` SHOULD have a dedicated unit test that
+  exercises its `execute()` path (state transition + outbox + documented
+  failure modes). Incidental coverage via `test_trignotify.py` or scenario
+  demos is insufficient — when `triggers/case.py` accumulated 26 commits in
+  90 days (#652), half its use cases had no dedicated test and regressions
+  in case logic shipped behind embargo fixes. Also avoid bundling
+  case-trigger and embargo-trigger changes in the same PR unless the change
+  is intrinsically cross-cutting; bundled diffs let reviewers miss
+  regressions in the half they aren't focused on. See
+  [notes/triggers-test-coverage.md](notes/triggers-test-coverage.md).
 - **Adding a New Pitfall: Check the Routing Policy First** — see
   [notes/agents-md-structure.md](notes/agents-md-structure.md)
 

--- a/notes/README.md
+++ b/notes/README.md
@@ -357,6 +357,15 @@ rules, naming conventions, and `ActorConfig`-driven trigger dispatch guidance.
 is demo-specific or protocol-general, or working on trigger routing in
 `vultron/adapters/driving/fastapi/routers/`.
 
+**`triggers-test-coverage.md`**
+Coverage expectations for trigger use cases in
+`vultron/core/use_cases/triggers/` and PR-scope discipline for files that
+co-evolve with embargo logic. Anchors which trigger use cases have dedicated
+tests and which are missing.
+**Load when**: adding a trigger use case, modifying `triggers/case.py` or
+`triggers/embargo.py`, or scoping a PR that touches both case and embargo
+triggers.
+
 ---
 
 ## Project Management and Planning

--- a/notes/triggers-test-coverage.md
+++ b/notes/triggers-test-coverage.md
@@ -1,0 +1,86 @@
+---
+title: "Trigger Use-Case Test Coverage and PR Scope"
+status: active
+description: >
+  Coverage expectations and PR-scope discipline for trigger use cases in
+  vultron/core/use_cases/triggers/, motivated by repeated high-churn in
+  case.py without per-use-case regression tests.
+---
+
+# Trigger Use-Case Test Coverage and PR Scope
+
+## Background
+
+`vultron/core/use_cases/triggers/case.py` accumulated 26 commits in 90 days
+(originating concern: [#652](https://github.com/CERTCC/Vultron/issues/652)).
+Two structural properties amplify the risk of regressions in this file:
+
+1. **Multiple use cases per module.** As of the originating concern, `case.py`
+   contained six trigger use cases (`SvcEngageCaseUseCase`,
+   `SvcDeferCaseUseCase`, `SvcCreateCaseUseCase`, `SvcAddObjectToCaseUseCase`,
+   `SvcAddReportToCaseUseCase`, `SvcAddParticipantStatusUseCase`). Half of
+   them lacked dedicated unit tests — coverage was incidental, via
+   `test_trignotify.py` and `test_svc_add_participant_status.py` only.
+2. **Co-evolution with embargo logic.** Case-state and embargo-state
+   transitions are tightly coupled in the protocol, so many PRs touch case
+   triggers and embargo triggers together. When tests are sparse, a regression
+   in one can ship silently behind a fix to the other.
+
+## Coverage expectation
+
+Every trigger use case in `vultron/core/use_cases/triggers/` SHOULD have at
+least one dedicated unit test that exercises its `execute()` path against a
+real (in-memory) `DataLayer` and asserts:
+
+- the use case's state mutation (RM, EM, CS, or PEC transition as applicable);
+- the outbox effect (activity queued, addressed correctly per PCR-08-001); and
+- the failure modes the use case is documented to raise
+  (`VultronValidationError`, `VultronNotFoundError`).
+
+Existing coverage anchors:
+
+| Use case | Dedicated test file |
+|---|---|
+| `SvcEngageCaseUseCase` | `test/core/use_cases/triggers/test_trignotify.py` |
+| `SvcDeferCaseUseCase` | `test/core/use_cases/triggers/test_trignotify.py` |
+| `SvcAddParticipantStatusUseCase` | `test/core/use_cases/triggers/test_svc_add_participant_status.py` |
+| `SvcCreateCaseUseCase` | *missing — tracked in test-backfill issue* |
+| `SvcAddObjectToCaseUseCase` | *missing — tracked in test-backfill issue* |
+| `SvcAddReportToCaseUseCase` | *missing — tracked in test-backfill issue* |
+
+When you add a new trigger use case, create the matching `test_<use_case>.py`
+file in the same PR. Do not rely on integration coverage in
+`test_trignotify.py` or scenario demos to substitute for per-use-case tests.
+
+## PR-scope discipline
+
+Avoid bundling case-trigger and embargo-trigger changes in the same PR
+unless the change is intrinsically cross-cutting (e.g., a renaming sweep,
+or an `EmbargoLifecycle` (#538) seam refactor that necessarily touches both).
+Bundled diffs are the primary failure mode that the originating concern
+documented: a reviewer focused on the case-trigger change misses the
+embargo regression and vice versa.
+
+When a single PR must touch both, call it out explicitly in the PR body and
+list the integration test(s) that exercise the combined path.
+
+## Structural follow-up
+
+The module structure of `triggers/case.py` mirrors the `nodes.py` smell that
+[`specs/behavior-tree-node-design.yaml`](../specs/behavior-tree-node-design.yaml)
+BTND-07-001 addresses for BT nodes: a flat module accumulating many classes
+becomes high-blast-radius and review-hostile. A future split into a
+`triggers/case/` subpackage — one submodule per use case — is tracked
+separately and is intentionally sequenced **after**
+[#711](https://github.com/CERTCC/Vultron/issues/711) lands, so the split
+operates on the post-refactor file rather than fighting it.
+
+## References
+
+- Originating concern: [#652](https://github.com/CERTCC/Vultron/issues/652)
+- Parallel BT-nodes pattern: `specs/behavior-tree-node-design.yaml`
+  BTND-07-001, BTND-07-002
+- PCR-08-001 (participant → CaseActor addressing): see
+  `notes/case-communication-model.md`
+- Trigger-side state machine BT integration: [#711](https://github.com/CERTCC/Vultron/issues/711)
+- EmbargoLifecycle consolidation: [#538](https://github.com/CERTCC/Vultron/issues/538)

--- a/plan/history/2606/learning/CONCERN-652.md
+++ b/plan/history/2606/learning/CONCERN-652.md
@@ -1,0 +1,49 @@
+---
+source: CONCERN-652
+timestamp: '2026-06-04T13:36:25.897305+00:00'
+title: triggers/case.py high-churn — test coverage and PR scope
+type: learning
+---
+
+## Summary
+
+`vultron/core/use_cases/triggers/case.py` has accumulated 31 commits in the
+last 90 days. It co-evolves with embargo and participant trigger logic and
+is frequently modified as the case-creation and delegation protocols change.
+
+## Category
+
+- [x] Fragile / high-churn area
+
+## Severity
+
+low
+
+## Evidence
+
+- `vultron/core/use_cases/triggers/case.py` (31 churn hits / 90 days; 26
+  commits visible at ingest time, 520 lines, 6 trigger use cases)
+- Half of the file's use cases (`SvcCreateCase`, `SvcAddObjectToCase`,
+  `SvcAddReportToCase`) had no dedicated unit test at ingest time; coverage
+  was incidental via `test_trignotify.py` and scenario demos only.
+
+## Impact if Ignored
+
+Case trigger logic changes made without integration test coverage can silently
+break the case-creation → actor delegation → announcement pipeline, especially
+when a PR bundles case and embargo trigger changes (the common pattern).
+
+## Suggested Action
+
+Narrow PRs with explicit integration tests for each case state transition.
+Avoid bundling case and embargo trigger changes in the same PR.
+
+**Resolved**: 2026-06-04 — captured as a durable countermeasure in
+`notes/triggers-test-coverage.md` and `AGENTS.md` pitfall index. Two
+implementation issues opened: #741 (test backfill for the three
+uncovered use cases; independent, ready now) and #742 (split case.py
+into a `triggers/case/` subpackage following the BTND-07 pattern;
+sequenced after #711 so the split operates on the post-refactor file).
+
+Docs PR: <https://github.com/CERTCC/Vultron/pull/743>. Implementation
+tracked in #741 and #742.


### PR DESCRIPTION
Docs-only PR: addresses concern #652 at the spec/notes level.
Implementation tracked in #741 (test backfill, ready now) and #742
(structural split, sequenced after #711).

## Changes

- New `notes/triggers-test-coverage.md` captures per-use-case test
  expectations for `vultron/core/use_cases/triggers/` and the PR-scope
  discipline (don't bundle case + embargo trigger changes) that the
  concern recommended.
- `notes/README.md` indexes the new note.
- New `AGENTS.md` pitfall entry so future agents see the rule alongside
  other lessons learned.

## Why

`triggers/case.py` accumulated 26 commits in 90 days (concern #652) and
half its six use cases lacked dedicated unit tests. The documented coverage
expectation + bundling guidance is the lightweight, durable countermeasure;
the actual test backfill and module split are tracked as their own issues.

Closes #652

No .py files changed.