### PR TITLE
feat: add import-time order guard to SEMANTIC_REGISTRY

### DIFF
--- a/plan/history/2606/implementation/ISSUE-708.md
+++ b/plan/history/2606/implementation/ISSUE-708.md
@@ -1,0 +1,47 @@
+---
+source: ISSUE-708
+timestamp: '2026-06-04T14:26:39.499910+00:00'
+title: Add import-time order guard to SEMANTIC_REGISTRY
+type: implementation
+---
+
+## Issue #708 — Add import-time order guard to SEMANTIC_REGISTRY
+
+Added a hard import-time guard that prevents `SEMANTIC_REGISTRY` from loading
+when any less-specific pattern precedes a more-specific one in the same
+`activity_` group. A mis-ordered registry silently dispatches to the wrong
+use case with no error signal; this makes that impossible to miss.
+
+### Changes
+
+- **`vultron/errors.py`**: Added `RegistryOrderError(VultronError)` with
+  docstring referencing SE-03-002 and `notes/semantic-registry.md`.
+- **`vultron/semantic_registry/__init__.py`**:
+  - Added `_strip_description()` to recursively remove the doc-only
+    `description` annotation from pattern dumps before comparison (fixes a
+    latent false-negative/false-positive bug in subset comparisons).
+  - Added `_elem_matches()` and `_is_subset()` for recursive pattern dump
+    comparison.
+  - Added `_check_group_order()` and `_validate_registry_order()` which
+    groups entries by `activity_` type and raises `RegistryOrderError` on
+    any strict-subset violation where the less-specific entry appears first.
+  - `_validate_registry_order(SEMANTIC_REGISTRY)` is called at module load
+    immediately after `SEMANTIC_REGISTRY` is assembled.
+  - Added an ordering-rationale comment block above `SEMANTIC_REGISTRY`
+    listing all 9 domain groups and the specific-before-general rule.
+- **`test/test_semantic_registry.py`**: Added 4 new tests — valid ordering
+  passes, reversed pair raises `RegistryOrderError`, same-specificity passes
+  (guard is intentionally narrower than the belt-and-suspenders test), and an
+  `importlib.reload` smoke test that exercises the live import-time guard.
+
+### Key design decisions
+
+- The guard raises on strict-subset violations only (less-specific before
+  more-specific). Equal-specificity (ambiguous duplicate) pairs are left to
+  `test_non_overlapping_activity_patterns()` which serves as belt-and-suspenders.
+- `_strip_description()` is recursive — the code review caught that a flat
+  `dict.pop("description")` leaves nested descriptions in sub-pattern dumps,
+  causing false negatives and false positives for entries like
+  `ACCEPT_CASE_MANAGER_ROLE` that carry nested `in_reply_to_` descriptions.
+
+PR: [#761](https://github.com/CERTCC/Vultron/pull/761)

--- a/test/test_semantic_registry.py
+++ b/test/test_semantic_registry.py
@@ -1,12 +1,23 @@
 """Tests for the unified SemanticRegistry module."""
 
+import importlib
+
+import pytest
+
 from vultron.core.models.events import MessageSemantics
+from vultron.core.models.events.base import VultronEvent
+from vultron.errors import RegistryOrderError
 from vultron.semantic_registry import (
     SEMANTIC_REGISTRY,
+    _validate_registry_order,
     lookup_entry,
-    use_case_map,
     semantics_to_activity_class,
+    use_case_map,
 )
+from vultron.semantic_registry._entry import SemanticEntry
+from vultron.wire.as2.enums import as_TransitiveActivityType as TAtype
+from vultron.wire.as2.extractor import ActivityPattern
+from vultron.core.models.enums import VultronObjectType as VOtype
 
 
 def test_registry_covers_all_semantics():
@@ -86,3 +97,98 @@ def test_no_duplicate_semantics():
     for entry in SEMANTIC_REGISTRY:
         assert entry.semantics not in seen, f"Duplicate: {entry.semantics}"
         seen.add(entry.semantics)
+
+
+# ---------------------------------------------------------------------------
+# _validate_registry_order() unit tests
+# ---------------------------------------------------------------------------
+
+
+class _StubEvent(VultronEvent):
+    """Minimal VultronEvent subclass for use in validator unit tests."""
+
+
+class _StubUseCase:
+    """Minimal use-case stub for use in validator unit tests."""
+
+
+def _make_entry(
+    semantics: MessageSemantics, pattern: ActivityPattern
+) -> SemanticEntry:
+    return SemanticEntry(
+        semantics=semantics,
+        pattern=pattern,
+        event_class=_StubEvent,
+        use_case_class=_StubUseCase,
+    )
+
+
+def test_validate_registry_order_valid_ordering_passes():
+    """Specific-before-general ordering must not raise."""
+    # specific: Create + VulnerabilityReport object
+    specific = _make_entry(
+        MessageSemantics.CREATE_REPORT,
+        ActivityPattern(
+            activity_=TAtype.CREATE,
+            object_=VOtype.VULNERABILITY_REPORT,
+        ),
+    )
+    # general: Create only
+    general = _make_entry(
+        MessageSemantics.CREATE_CASE,
+        ActivityPattern(activity_=TAtype.CREATE),
+    )
+    # specific first — correct order
+    _validate_registry_order([specific, general])
+
+
+def test_validate_registry_order_reversed_pair_raises():
+    """General-before-specific ordering must raise RegistryOrderError."""
+    specific = _make_entry(
+        MessageSemantics.CREATE_REPORT,
+        ActivityPattern(
+            activity_=TAtype.CREATE,
+            object_=VOtype.VULNERABILITY_REPORT,
+        ),
+    )
+    general = _make_entry(
+        MessageSemantics.CREATE_CASE,
+        ActivityPattern(activity_=TAtype.CREATE),
+    )
+    # general first — wrong order
+    with pytest.raises(RegistryOrderError):
+        _validate_registry_order([general, specific])
+
+
+def test_validate_registry_order_same_specificity_passes():
+    """Entries with identical pattern dumps must not raise.
+
+    The import-time guard checks only strict-subset violations; equal-specificity
+    (ambiguous) pairs are left to test_non_overlapping_activity_patterns().
+    """
+    pattern_a = _make_entry(
+        MessageSemantics.CREATE_REPORT,
+        ActivityPattern(
+            activity_=TAtype.CREATE,
+            object_=VOtype.VULNERABILITY_REPORT,
+        ),
+    )
+    pattern_b = _make_entry(
+        MessageSemantics.CREATE_CASE,
+        ActivityPattern(
+            activity_=TAtype.CREATE,
+            object_=VOtype.VULNERABILITY_REPORT,
+        ),
+    )
+    _validate_registry_order([pattern_a, pattern_b])
+
+
+def test_live_registry_import_guard_passes():
+    """Reload semantic_registry to exercise the import-time order guard.
+
+    Verifies that _validate_registry_order(SEMANTIC_REGISTRY) is called at
+    module load and does not raise for the live registry.
+    """
+    import vultron.semantic_registry
+
+    importlib.reload(vultron.semantic_registry)

--- a/vultron/errors.py
+++ b/vultron/errors.py
@@ -138,6 +138,17 @@ class VultronActivityConstructionError(VultronError):
     """
 
 
+class RegistryOrderError(VultronError):
+    """Raised when ``SEMANTIC_REGISTRY`` contains a less-specific pattern
+    that precedes a more-specific one in the same ``activity_`` group.
+
+    Raised at import time by ``_validate_registry_order()`` in
+    ``vultron.semantic_registry`` so that ordering violations fail fast and
+    are impossible to miss.  See ``specs/semantic-extraction.yaml`` SE-03-002
+    and ``notes/semantic-registry.md``.
+    """
+
+
 class DemoFailureError(VultronError):
     """Raised when a demo scenario completes with one or more step failures.
 

--- a/vultron/semantic_registry/__init__.py
+++ b/vultron/semantic_registry/__init__.py
@@ -56,7 +56,11 @@ Public API
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
+from itertools import combinations
+from typing import Any
+
 from vultron.core.models.events.base import MessageSemantics, VultronEvent
+from vultron.errors import RegistryOrderError
 from vultron.semantic_registry._entry import SemanticEntry
 from vultron.wire.as2.vocab.base.objects.activities.base import as_Activity
 from . import (
@@ -72,9 +76,138 @@ from . import (
 )
 
 # ---------------------------------------------------------------------------
+# Import-time order guard: ensures specific patterns precede general ones.
+# ---------------------------------------------------------------------------
+
+
+def _strip_description(d: dict[str, Any]) -> dict[str, Any]:
+    """Recursively remove ``description`` keys from a pattern dump dict.
+
+    ``ActivityPattern.description`` is a documentation annotation, not a
+    semantic constraint.  Removing it at all levels ensures subset comparisons
+    reflect only the fields that actually influence pattern matching.
+    """
+    result: dict[str, Any] = {}
+    for k, v in d.items():
+        if k == "description":
+            continue
+        if isinstance(v, dict):
+            result[k] = _strip_description(v)
+        else:
+            result[k] = v
+    return result
+
+
+def _elem_matches(a: Any, b: Any) -> bool:
+    """Return True if element *a* can be covered by element *b*.
+
+    Dicts: every key/value in *a* must appear in *b* (recursive).
+    Lists: every element in *a* must match some element in *b*.
+    Scalars: equality.
+    """
+    if isinstance(a, dict) and isinstance(b, dict):
+        return _is_subset(a, b)
+    if isinstance(a, list) and isinstance(b, list):
+        return all(
+            any(_elem_matches(item_a, item_b) for item_b in b) for item_a in a
+        )
+    return bool(a == b)
+
+
+def _is_subset(a: dict[str, Any], b: dict[str, Any]) -> bool:
+    """Return True if *a* is a subset of *b* — every key/value in *a* is
+    present in *b* (recursively).  Extra keys in *b* are ignored."""
+    if not set(a.keys()).issubset(b.keys()):
+        return False
+    return all(_elem_matches(a[k], b[k]) for k in a)
+
+
+def _check_group_order(
+    act_type: str, indexed_entries: list[tuple[int, SemanticEntry]]
+) -> None:
+    """Check ordering for one ``activity_`` group; raise ``RegistryOrderError``
+    if a less-specific entry precedes a more-specific one."""
+    enriched: list[tuple[int, SemanticEntry, dict[str, Any]]] = []
+    for idx, entry in indexed_entries:
+        if entry.pattern is None:
+            continue
+        try:
+            dump = _strip_description(
+                entry.pattern.model_dump(exclude_none=True)
+            )
+            enriched.append((idx, entry, dump))
+        except Exception:
+            continue
+
+    for (idx_a, entry_a, dump_a), (idx_b, entry_b, dump_b) in combinations(
+        enriched, 2
+    ):
+        # idx_a < idx_b by construction (combinations preserves order).
+        # If dump_a ⊂ dump_b strictly, then a is less specific but appears
+        # first — the more-specific b would never be reached.
+        if _is_subset(dump_a, dump_b) and not _is_subset(dump_b, dump_a):
+            raise RegistryOrderError(
+                f"Registry ordering violation in '{act_type}' group: "
+                f"{entry_a.semantics.name!r} (index {idx_a}) is less specific "
+                f"than {entry_b.semantics.name!r} (index {idx_b}) but appears "
+                f"first. Move {entry_b.semantics.name!r} before "
+                f"{entry_a.semantics.name!r}."
+            )
+
+
+def _validate_registry_order(registry: list[SemanticEntry]) -> None:
+    """Raise ``RegistryOrderError`` if any less-specific pattern precedes a
+    more-specific one within the same ``activity_`` group.
+
+    Called at module load time so that ordering violations are impossible to
+    miss.  A pattern *A* is considered less specific than *B* when
+    ``dump(A) ⊂ dump(B)`` strictly (A has fewer constraints than B).  When
+    A appears before B in the registry, ``find_matching_semantics()`` would
+    never reach B — the wrong use case would run silently.
+
+    See ``notes/semantic-registry.md`` for the ordering invariant and
+    ``specs/semantic-extraction.yaml`` SE-03-002.
+
+    Args:
+        registry: Ordered ``SemanticEntry`` list to validate.
+
+    Raises:
+        RegistryOrderError: When a more-specific entry appears after a
+            less-specific entry in the same ``activity_`` group.
+    """
+    groups: dict[str, list[tuple[int, SemanticEntry]]] = {}
+    for idx, entry in enumerate(registry):
+        if entry.pattern is None:
+            continue
+        act_type = str(entry.pattern.activity_)
+        groups.setdefault(act_type, []).append((idx, entry))
+
+    for act_type, indexed_entries in groups.items():
+        if len(indexed_entries) >= 2:
+            _check_group_order(act_type, indexed_entries)
+
+
+# ---------------------------------------------------------------------------
 # The registry.  Order matters: find_matching_semantics() returns the first
 # pattern that matches, so more specific patterns must appear before general
-# ones.  The unknown fallback entries (pattern=None) must be last.
+# ones.  The unknown fallback sentinels (pattern=None) must be last.
+#
+# Domain groups (in assembly order):
+#   1. Reports        — CREATE_REPORT, SUBMIT_REPORT, ACK_REPORT, …
+#   2. Cases          — CREATE_CASE, UPDATE_CASE, ENGAGE_CASE, DEFER_CASE, …
+#   3. Actors         — actor-related entries
+#   4. Embargo        — CREATE_EMBARGO_EVENT, INVITE_TO_EMBARGO, …
+#   5. Sync           — CLOSE_CASE, case-log sync entries
+#   6. Case members   — INVITE_ACTOR_TO_CASE, ACCEPT_INVITE_ACTOR_TO_CASE, …
+#   7. Notes          — CREATE_NOTE, ADD_NOTE_TO_CASE, REMOVE_NOTE_FROM_CASE
+#   8. Status         — participant status entries
+#   9. Fallback       — UNKNOWN_UNRESOLVABLE_OBJECT, UNKNOWN (must be last)
+#
+# Within each group, more-specific patterns MUST come before less-specific
+# ones.  The import-time call to _validate_registry_order() below enforces
+# this at module load, and test_non_overlapping_activity_patterns() in
+# test/test_semantic_activity_patterns.py provides belt-and-suspenders
+# coverage for edge cases.  See notes/semantic-registry.md SE-03-002.
 # ---------------------------------------------------------------------------
 
 SEMANTIC_REGISTRY: list[SemanticEntry] = (
@@ -88,6 +221,8 @@ SEMANTIC_REGISTRY: list[SemanticEntry] = (
     + status.ENTRIES
     + unknown.ENTRIES  # MUST be last — catch-all sentinels
 )
+
+_validate_registry_order(SEMANTIC_REGISTRY)
 
 # ---------------------------------------------------------------------------
 # Fast-lookup index: O(1) entry access by MessageSemantics value.


### PR DESCRIPTION
Closes #708

## Summary

Adds a hard import-time guard that prevents `SEMANTIC_REGISTRY` from loading when any less-specific pattern precedes a more-specific one in the same `activity_` group. A mis-ordered registry silently dispatches to the wrong use case with no error signal; this makes that impossible to miss.

## Changes

- **`vultron/errors.py`**: Add `RegistryOrderError(VultronError)`
- **`vultron/semantic_registry/__init__.py`**:
  - Add `_strip_description()` (recursively removes doc-only annotation before comparison)
  - Add `_elem_matches()` and `_is_subset()` for pattern dump comparison
  - Add `_check_group_order()` and `_validate_registry_order()`
  - Call `_validate_registry_order(SEMANTIC_REGISTRY)` at module load after registry assembly
  - Add ordering-rationale comment block listing the 9 domain groups + specific-before-general rule
- **`test/test_semantic_registry.py`**: 4 new tests — valid ordering passes, reversed pair raises, same-specificity passes, `importlib.reload` smoke test for the live registry import-time guard