### PR TITLE
fix(arch): resolve all ARCH-01-001 core→wire import violations (#519)

### DIFF
--- a/plan/history/2606/implementation/ISSUE-519.md
+++ b/plan/history/2606/implementation/ISSUE-519.md
@@ -1,0 +1,46 @@
+---
+source: ISSUE-519
+timestamp: '2026-06-04T14:28:48.308544+00:00'
+title: Resolve all ARCH-01-001 core→wire import violations
+type: implementation
+---
+
+## Issue #519 — Resolve all ARCH-01-001 core→wire import violations
+
+Removed the three remaining `vultron.wire` imports from `vultron/core/`,
+completing ARCH-01-001 compliance with zero known violations.
+
+### Files fixed
+
+- **`vultron/core/behaviors/report/nodes.py`** — removed `rm_engage_case_activity`
+  / `rm_defer_case_activity` imports; `EmitEngageCaseActivity` and
+  `EmitDeferCaseActivity` now delegate to `TriggerActivityPort.engage_case` /
+  `defer_case` and return `FAILURE` if the port is not injected.
+- **`vultron/core/use_cases/received/actor.py`** — removed deferred inline import
+  of `announce_vulnerability_case_activity`; `_emit_announce_case` now calls
+  `self._trigger_activity.announce_vulnerability_case`.
+- **`vultron/core/use_cases/received/note.py`** — removed top-level import of
+  `add_note_to_case_activity`; `_broadcast_note_to_participants` delegates to
+  `self._trigger_activity.add_note_to_case` and skips if port is absent.
+
+### Supporting changes
+
+- **`TriggerActivityPort`** — added `announce_vulnerability_case(case_id, actor,
+  context_id, to) -> str` method.
+- **`TriggerActivityAdapter`** — implemented `announce_vulnerability_case` via
+  DataLayer read + `announce_vulnerability_case_activity` factory.
+- **`inbox_handler.py`** — moved `ADD_NOTE_TO_CASE` from `_SYNC_PORT_SEMANTICS`
+  to `_SYNC_AND_TRIGGER_PORT_SEMANTICS`; added `DEFER_CASE`, `ENGAGE_CASE`, and
+  `VALIDATE_REPORT` to `_TRIGGER_ACTIVITY_PORT_SEMANTICS`.
+- **`ValidateReportReceivedUseCase`**, **`ValidateCaseUseCase`**,
+  **`EngageCaseReceivedUseCase`**, **`DeferCaseReceivedUseCase`** — accept
+  optional `trigger_activity` and thread it through to `BTBridge`.
+- Architecture ratchet test — `KNOWN_VIOLATIONS` cleared to `frozenset()`.
+- Test fixtures updated in `test_prioritize_tree.py`, `test_validate_tree.py`,
+  `test_actor.py`, `test_note.py`, and `test_report.py`.
+
+### Outcome
+
+2574 tests pass, 12 skipped. mypy and pyright both report zero issues.
+
+PR: [#762](https://github.com/CERTCC/Vultron/pull/762)

--- a/test/architecture/test_core_no_wire_imports.py
+++ b/test/architecture/test_core_no_wire_imports.py
@@ -89,13 +89,7 @@ def _collect_violations() -> frozenset[str]:
 # These files import wire types that have not yet been abstracted behind ports.
 # Remove an entry from this set when the violation is resolved.
 # ---------------------------------------------------------------------------
-KNOWN_VIOLATIONS: frozenset[str] = frozenset(
-    {
-        "vultron/core/behaviors/report/nodes.py",
-        "vultron/core/use_cases/received/actor.py",
-        "vultron/core/use_cases/received/note.py",
-    }
-)
+KNOWN_VIOLATIONS: frozenset[str] = frozenset()
 
 
 def test_core_does_not_import_wire():

--- a/test/core/behaviors/report/test_prioritize_tree.py
+++ b/test/core/behaviors/report/test_prioritize_tree.py
@@ -135,7 +135,19 @@ def case_without_participant(datalayer, report):
 
 @pytest.fixture
 def bridge(datalayer):
-    return BTBridge(datalayer=datalayer)
+    from typing import cast
+
+    from vultron.adapters.driven.trigger_activity_adapter import (
+        TriggerActivityAdapter,
+    )
+    from vultron.core.ports.case_persistence import CaseOutboxPersistence
+
+    return BTBridge(
+        datalayer=datalayer,
+        trigger_activity=TriggerActivityAdapter(
+            cast(CaseOutboxPersistence, datalayer)
+        ),
+    )
 
 
 # ============================================================================

--- a/test/core/behaviors/report/test_validate_tree.py
+++ b/test/core/behaviors/report/test_validate_tree.py
@@ -110,7 +110,19 @@ def reporter_actor(datalayer, reporter_actor_id):
 @pytest.fixture
 def bridge(datalayer):
     """Create BT bridge for execution."""
-    return BTBridge(datalayer=datalayer)
+    from typing import cast
+
+    from vultron.adapters.driven.trigger_activity_adapter import (
+        TriggerActivityAdapter,
+    )
+    from vultron.core.ports.case_persistence import CaseOutboxPersistence
+
+    return BTBridge(
+        datalayer=datalayer,
+        trigger_activity=TriggerActivityAdapter(
+            cast(CaseOutboxPersistence, datalayer)
+        ),
+    )
 
 
 @pytest.fixture

--- a/test/core/use_cases/received/test_actor.py
+++ b/test/core/use_cases/received/test_actor.py
@@ -262,7 +262,18 @@ class TestInviteActorUseCases:
             actor=invitee_id,
         )
         event = make_payload(accept)
-        AcceptInviteActorToCaseReceivedUseCase(dl, event).execute()
+        from vultron.adapters.driven.trigger_activity_adapter import (
+            TriggerActivityAdapter,
+        )
+        from vultron.core.ports.case_persistence import CaseOutboxPersistence
+
+        AcceptInviteActorToCaseReceivedUseCase(
+            dl,
+            event,
+            trigger_activity=TriggerActivityAdapter(
+                cast(CaseOutboxPersistence, dl)
+            ),
+        ).execute()
 
         updated_case = cast(Any, dl.read(case.id_))
         participant_id = updated_case.actor_participant_index.get(invitee_id)
@@ -304,8 +315,18 @@ class TestInviteActorUseCases:
             actor=invitee_id,
         )
         event = make_payload(accept)
+        from vultron.adapters.driven.trigger_activity_adapter import (
+            TriggerActivityAdapter,
+        )
+        from vultron.core.ports.case_persistence import CaseOutboxPersistence
 
-        AcceptInviteActorToCaseReceivedUseCase(dl, event).execute()
+        AcceptInviteActorToCaseReceivedUseCase(
+            dl,
+            event,
+            trigger_activity=TriggerActivityAdapter(
+                cast(CaseOutboxPersistence, dl)
+            ),
+        ).execute()
 
         updated_actor = cast(Any, dl.read(invitee_id))
         assert updated_actor is not None

--- a/test/core/use_cases/received/test_note.py
+++ b/test/core/use_cases/received/test_note.py
@@ -16,9 +16,13 @@ from typing import Any, cast
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.adapters.driven.sync_activity_adapter import SyncActivityAdapter
+from vultron.adapters.driven.trigger_activity_adapter import (
+    TriggerActivityAdapter,
+)
 from vultron.core.models.case_actor import VultronCaseActor
 from vultron.core.models.case_log_entry import VultronCaseLogEntry
 from vultron.core.models.protocols import is_log_entry_model
+from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.use_cases.received.note import (
     AddNoteToCaseReceivedUseCase,
     CreateNoteReceivedUseCase,
@@ -290,7 +294,13 @@ class TestNoteUseCases:
         )
         event = make_payload(activity)
 
-        AddNoteToCaseReceivedUseCase(dl, event).execute()
+        AddNoteToCaseReceivedUseCase(
+            dl,
+            event,
+            trigger_activity=TriggerActivityAdapter(
+                cast(CaseOutboxPersistence, dl)
+            ),
+        ).execute()
 
         # CaseActor outbox should contain the broadcast activity.
         refreshed_actor = dl.read(case_actor.id_)
@@ -356,7 +366,13 @@ class TestNoteUseCases:
         )
         event = make_payload(activity)
 
-        AddNoteToCaseReceivedUseCase(dl, event).execute()
+        AddNoteToCaseReceivedUseCase(
+            dl,
+            event,
+            trigger_activity=TriggerActivityAdapter(
+                cast(CaseOutboxPersistence, dl)
+            ),
+        ).execute()
 
         refreshed_actor = dl.read(case_actor.id_)
         assert refreshed_actor is not None

--- a/test/core/use_cases/received/test_report.py
+++ b/test/core/use_cases/received/test_report.py
@@ -1075,7 +1075,9 @@ class TestFullReportFlow:
         dl = self._setup_dl()
         SubmitReportReceivedUseCase(dl, self._make_submit_event()).execute()
         ValidateReportReceivedUseCase(
-            dl, self._make_validate_event()
+            dl,
+            self._make_validate_event(),
+            trigger_activity=TriggerActivityAdapter(dl),
         ).execute()
 
         case_obj = cast(

--- a/vultron/adapters/driven/trigger_activity_adapter.py
+++ b/vultron/adapters/driven/trigger_activity_adapter.py
@@ -59,6 +59,7 @@ from vultron.wire.as2.factories import (
 )
 from vultron.wire.as2.factories.case import (
     accept_case_manager_role_activity,
+    announce_vulnerability_case_activity,
     offer_case_manager_role_activity,
 )
 from vultron.wire.as2.vocab.base.objects.activities.transitive import (
@@ -669,3 +670,40 @@ class TriggerActivityAdapter:
                 activity.id_,
             )
         return activity.id_, activity.model_dump(**_DUMP_KWARGS)
+
+    # -----------------------------------------------------------------------
+    # Cases (continued) — Announce
+    # -----------------------------------------------------------------------
+
+    def announce_vulnerability_case(
+        self,
+        case_id: str,
+        actor: str,
+        context_id: str,
+        to: list[str],
+    ) -> str:
+        """Create and persist an ``Announce(VulnerabilityCase)`` activity.
+
+        Reads the full case from the DataLayer, constructs the activity with
+        the case inline, and persists it.  Returns the activity ID for outbox
+        queueing.
+
+        Per MV-10-003: the case owner sends this after an ``Accept(Invite)``
+        is received and the invitee's embargo consent has been verified.
+        """
+        case = cast(VulnerabilityCase, self._dl.read(case_id))
+        activity = announce_vulnerability_case_activity(
+            case=case,
+            actor=actor,
+            context=context_id,
+            to=to,
+        )
+        try:
+            self._dl.create(activity)
+        except ValueError:
+            logger.warning(
+                "announce_vulnerability_case: activity '%s' already exists"
+                " — skipping",
+                activity.id_,
+            )
+        return activity.id_

--- a/vultron/adapters/driving/fastapi/inbox_handler.py
+++ b/vultron/adapters/driving/fastapi/inbox_handler.py
@@ -90,7 +90,6 @@ def _sync_and_trigger_port_factory(dl: DataLayer) -> dict[str, Any]:
 _SYNC_PORT_SEMANTICS = frozenset(
     {
         MessageSemantics.ADD_EMBARGO_EVENT_TO_CASE,
-        MessageSemantics.ADD_NOTE_TO_CASE,
         MessageSemantics.ACCEPT_INVITE_TO_EMBARGO_ON_CASE,
         MessageSemantics.ANNOUNCE_CASE_LOG_ENTRY,
         MessageSemantics.INVITE_TO_EMBARGO_ON_CASE,
@@ -103,16 +102,20 @@ _SYNC_PORT_SEMANTICS = frozenset(
 _TRIGGER_ACTIVITY_PORT_SEMANTICS = frozenset(
     {
         MessageSemantics.ACCEPT_CASE_MANAGER_ROLE,
+        MessageSemantics.DEFER_CASE,
+        MessageSemantics.ENGAGE_CASE,
         MessageSemantics.OFFER_CASE_MANAGER_ROLE,
         MessageSemantics.SUBMIT_REPORT,
         MessageSemantics.SUGGEST_ACTOR_TO_CASE,
         MessageSemantics.ACCEPT_INVITE_ACTOR_TO_CASE,
+        MessageSemantics.VALIDATE_REPORT,
     }
 )
 
 # Semantics that require both a sync port and a trigger-activity port.
 _SYNC_AND_TRIGGER_PORT_SEMANTICS = frozenset(
     {
+        MessageSemantics.ADD_NOTE_TO_CASE,
         MessageSemantics.ADD_PARTICIPANT_STATUS_TO_PARTICIPANT,
     }
 )

--- a/vultron/core/behaviors/report/nodes.py
+++ b/vultron/core/behaviors/report/nodes.py
@@ -54,10 +54,6 @@ from vultron.core.use_cases._helpers import (
     case_addressees,
     update_participant_rm_state,
 )
-from vultron.wire.as2.factories import (
-    rm_defer_case_activity,
-    rm_engage_case_activity,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -922,6 +918,13 @@ class EmitEngageCaseActivity(DataLayerAction):
             )
             return Status.FAILURE
 
+        if self.trigger_activity_factory is None:
+            self.logger.warning(
+                "%s: no TriggerActivityPort — cannot emit EngageCase activity",
+                self.name,
+            )
+            return Status.FAILURE
+
         try:
             case = self.datalayer.read(self.case_id)
             addressees: list[str] | None = None
@@ -930,24 +933,15 @@ class EmitEngageCaseActivity(DataLayerAction):
                 if recipients:
                     addressees = recipients
 
-            activity = rm_engage_case_activity(
-                case=cast(Any, case),
+            activity_id, _ = self.trigger_activity_factory.engage_case(
+                case_id=self.case_id,
                 actor=self.actor_id,
                 to=addressees,
             )
 
-            try:
-                self.datalayer.create(activity)
-            except ValueError:
-                self.logger.warning(
-                    "%s: EngageCase activity '%s' already exists",
-                    self.name,
-                    activity.id_,
-                )
-
             actor_obj = self.datalayer.read(self.actor_id)
             if has_outbox(actor_obj):
-                actor_obj.outbox.items.append(activity.id_)
+                actor_obj.outbox.items.append(activity_id)
                 self.datalayer.save(actor_obj)
             else:
                 self.logger.warning(
@@ -957,7 +951,7 @@ class EmitEngageCaseActivity(DataLayerAction):
                 )
 
             cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
-                self.actor_id, activity.id_
+                self.actor_id, activity_id
             )
             self.logger.info(
                 "Actor '%s' emitted RmEngageCaseActivity for case '%s'",
@@ -1012,6 +1006,13 @@ class EmitDeferCaseActivity(DataLayerAction):
             )
             return Status.FAILURE
 
+        if self.trigger_activity_factory is None:
+            self.logger.warning(
+                "%s: no TriggerActivityPort — cannot emit DeferCase activity",
+                self.name,
+            )
+            return Status.FAILURE
+
         try:
             case = self.datalayer.read(self.case_id)
             addressees: list[str] | None = None
@@ -1020,24 +1021,15 @@ class EmitDeferCaseActivity(DataLayerAction):
                 if recipients:
                     addressees = recipients
 
-            activity = rm_defer_case_activity(
-                case=cast(Any, case),
+            activity_id, _ = self.trigger_activity_factory.defer_case(
+                case_id=self.case_id,
                 actor=self.actor_id,
                 to=addressees,
             )
 
-            try:
-                self.datalayer.create(activity)
-            except ValueError:
-                self.logger.warning(
-                    "%s: DeferCase activity '%s' already exists",
-                    self.name,
-                    activity.id_,
-                )
-
             actor_obj = self.datalayer.read(self.actor_id)
             if has_outbox(actor_obj):
-                actor_obj.outbox.items.append(activity.id_)
+                actor_obj.outbox.items.append(activity_id)
                 self.datalayer.save(actor_obj)
             else:
                 self.logger.warning(
@@ -1047,7 +1039,7 @@ class EmitDeferCaseActivity(DataLayerAction):
                 )
 
             cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
-                self.actor_id, activity.id_
+                self.actor_id, activity_id
             )
             self.logger.info(
                 "Actor '%s' emitted RmDeferCaseActivity for case '%s'",

--- a/vultron/core/ports/trigger_activity.py
+++ b/vultron/core/ports/trigger_activity.py
@@ -388,3 +388,20 @@ class TriggerActivityPort(Protocol):
         Returns ``(activity_id, activity_dict)``.
         """
         ...
+
+    def announce_vulnerability_case(
+        self,
+        case_id: str,
+        actor: str,
+        context_id: str,
+        to: list[str],
+    ) -> str:
+        """Create and persist an ``Announce(VulnerabilityCase)`` activity.
+
+        Sent by the case owner to a newly accepted participant after their
+        embargo consent is resolved (MV-10-003).  The full case object is
+        sent inline so the recipient can seed their local DataLayer.
+
+        Returns the activity ID.
+        """
+        ...

--- a/vultron/core/use_cases/received/actor.py
+++ b/vultron/core/use_cases/received/actor.py
@@ -653,9 +653,14 @@ class AcceptInviteActorToCaseReceivedUseCase:
         from vultron.core.use_cases.triggers._helpers import (
             add_activity_to_outbox,
         )
-        from vultron.wire.as2.factories import (
-            announce_vulnerability_case_activity,
-        )
+
+        if self._trigger_activity is None:
+            logger.warning(
+                "AcceptInviteActorToCase: no TriggerActivityPort;"
+                " cannot emit AnnounceVulnerabilityCase for case '%s'",
+                case_id,
+            )
+            return
 
         case_actor_id = _find_case_actor_id(self._dl, case_id)
         if case_actor_id is None:
@@ -667,17 +672,16 @@ class AcceptInviteActorToCaseReceivedUseCase:
             return
 
         try:
-            announce = announce_vulnerability_case_activity(
-                case=case,
+            activity_id = self._trigger_activity.announce_vulnerability_case(
+                case_id=case_id,
                 actor=case_actor_id,
-                context=case_id,
+                context_id=case_id,
                 to=[invitee_id],
             )
-            self._dl.create(announce)
-            add_activity_to_outbox(case_actor_id, announce.id_, self._dl)
+            add_activity_to_outbox(case_actor_id, activity_id, self._dl)
             logger.info(
                 "Emitted AnnounceVulnerabilityCase '%s' to '%s' for case '%s'",
-                announce.id_,
+                activity_id,
                 invitee_id,
                 case_id,
             )

--- a/vultron/core/use_cases/received/case.py
+++ b/vultron/core/use_cases/received/case.py
@@ -1,7 +1,7 @@
 """Use cases for vulnerability case activities."""
 
 import logging
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from py_trees.common import Status
 
@@ -29,6 +29,9 @@ from vultron.core.models.protocols import (
 from vultron.core.states.rm import RM, is_rm_at_least
 from vultron.core.states.roles import CVDRole
 from vultron.core.use_cases._helpers import _as_id, update_participant_rm_state
+
+if TYPE_CHECKING:
+    from vultron.core.ports.trigger_activity import TriggerActivityPort
 
 logger = logging.getLogger(__name__)
 
@@ -594,10 +597,14 @@ class UpdateCaseReceivedUseCase:
 
 class EngageCaseReceivedUseCase:
     def __init__(
-        self, dl: CasePersistence, request: EngageCaseReceivedEvent
+        self,
+        dl: CasePersistence,
+        request: EngageCaseReceivedEvent,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: EngageCaseReceivedEvent = request
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> None:
         request = self._request
@@ -626,7 +633,9 @@ class EngageCaseReceivedUseCase:
             case_id,
         )
 
-        bridge = BTBridge(datalayer=self._dl)
+        bridge = BTBridge(
+            datalayer=self._dl, trigger_activity=self._trigger_activity
+        )
         tree = create_engage_case_tree(case_id=case_id, actor_id=actor_id)
         result = bridge.execute_with_setup(
             tree=tree, actor_id=actor_id, activity=request
@@ -643,10 +652,14 @@ class EngageCaseReceivedUseCase:
 
 class DeferCaseReceivedUseCase:
     def __init__(
-        self, dl: CasePersistence, request: DeferCaseReceivedEvent
+        self,
+        dl: CasePersistence,
+        request: DeferCaseReceivedEvent,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: DeferCaseReceivedEvent = request
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> None:
         request = self._request
@@ -667,7 +680,9 @@ class DeferCaseReceivedUseCase:
             case_id,
         )
 
-        bridge = BTBridge(datalayer=self._dl)
+        bridge = BTBridge(
+            datalayer=self._dl, trigger_activity=self._trigger_activity
+        )
         tree = create_defer_case_tree(case_id=case_id, actor_id=actor_id)
         result = bridge.execute_with_setup(
             tree=tree, actor_id=actor_id, activity=request
@@ -841,12 +856,14 @@ class ValidateCaseUseCase:
         report_id: str,
         offer_id: str,
         case_id: str | None = None,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._actor_id = actor_id
         self._report_id = report_id
         self._offer_id = offer_id
         self._case_id = case_id
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> None:
         from vultron.core.behaviors.bridge import BTBridge
@@ -861,7 +878,9 @@ class ValidateCaseUseCase:
             f" (case '{self._case_id}')" if self._case_id else "",
         )
 
-        bridge = BTBridge(datalayer=self._dl)
+        bridge = BTBridge(
+            datalayer=self._dl, trigger_activity=self._trigger_activity
+        )
         tree = create_validate_report_tree(
             report_id=self._report_id,
             offer_id=self._offer_id,

--- a/vultron/core/use_cases/received/note.py
+++ b/vultron/core/use_cases/received/note.py
@@ -16,10 +16,10 @@ from vultron.core.ports.case_persistence import (
 )
 from vultron.core.models.protocols import is_case_model
 from vultron.core.use_cases._helpers import _as_id
-from vultron.wire.as2.factories import add_note_to_case_activity
 
 if TYPE_CHECKING:
     from vultron.core.ports.sync_activity import SyncActivityPort
+    from vultron.core.ports.trigger_activity import TriggerActivityPort
 
 logger = logging.getLogger(__name__)
 
@@ -70,10 +70,12 @@ class AddNoteToCaseReceivedUseCase:
         dl: CaseOutboxPersistence,
         request: AddNoteToCaseReceivedEvent,
         sync_port: "SyncActivityPort | None" = None,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: AddNoteToCaseReceivedEvent = request
         self._sync_port = sync_port
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> None:
         request = self._request
@@ -125,6 +127,14 @@ class AddNoteToCaseReceivedUseCase:
         MUST broadcast the note to all participants (excluding the author).
         Recipients are derived from VulnerabilityCase.actor_participant_index.
         """
+        if self._trigger_activity is None:
+            logger.debug(
+                "add_note_to_case: no TriggerActivityPort for case '%s'"
+                " — skipping broadcast (CM-06-005)",
+                case_id,
+            )
+            return
+
         # Locate the CaseActor (type_="Service") for this case.
         case_actor_id: str | None = None
         for service in self._dl.list_objects("Service"):
@@ -153,28 +163,19 @@ class AddNoteToCaseReceivedUseCase:
             )
             return
 
-        broadcast = add_note_to_case_activity(
-            note=cast(Any, self._dl.read(note_id)),
-            target=case_id,
+        activity_id, _ = self._trigger_activity.add_note_to_case(
+            note_id=note_id,
+            case_id=case_id,
             actor=case_actor_id,
             to=recipient_ids,
         )
-        try:
-            self._dl.create(broadcast)
-        except ValueError:
-            logger.debug(
-                "add_note_to_case: broadcast activity %s already exists"
-                " — skipping",
-                broadcast.id_,
-            )
-            return
 
         case_actor_obj = self._dl.read(case_actor_id)
         if case_actor_obj is not None and hasattr(case_actor_obj, "outbox"):
-            cast(Any, case_actor_obj).outbox.items.append(broadcast.id_)
+            cast(Any, case_actor_obj).outbox.items.append(activity_id)
             self._dl.save(case_actor_obj)
 
-        self._dl.record_outbox_item(case_actor_id, broadcast.id_)
+        self._dl.record_outbox_item(case_actor_id, activity_id)
 
         logger.info(
             "add_note_to_case: CaseActor '%s' broadcast AddNoteToCase for"

--- a/vultron/core/use_cases/received/report.py
+++ b/vultron/core/use_cases/received/report.py
@@ -231,10 +231,14 @@ class SubmitReportReceivedUseCase:
 
 class ValidateReportReceivedUseCase:
     def __init__(
-        self, dl: CasePersistence, request: ValidateReportReceivedEvent
+        self,
+        dl: CasePersistence,
+        request: ValidateReportReceivedEvent,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: ValidateReportReceivedEvent = request
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> None:
         request = self._request
@@ -269,6 +273,7 @@ class ValidateReportReceivedUseCase:
             report_id=report_id,
             offer_id=offer_id,
             case_id=case_id,
+            trigger_activity=self._trigger_activity,
         ).execute()
 
 

--- a/wip_notes
+++ b/wip_notes
@@ -1,0 +1,1 @@
+../../vultron_pub/wip_notes


### PR DESCRIPTION
## Summary

Resolves the three remaining `vultron.wire` import violations in `vultron/core/` per ARCH-01-001.

Closes #519

## Changes

### Core violations removed
- **`vultron/core/behaviors/report/nodes.py`** — removed `rm_engage_case_activity` / `rm_defer_case_activity` imports; `EmitEngageCaseActivity` and `EmitDeferCaseActivity` now delegate to `TriggerActivityPort.engage_case` / `defer_case` and return `FAILURE` if the port is not injected.
- **`vultron/core/use_cases/received/actor.py`** — removed deferred inline import of `announce_vulnerability_case_activity`; `_emit_announce_case` now calls `self._trigger_activity.announce_vulnerability_case`.
- **`vultron/core/use_cases/received/note.py`** — removed top-level import of `add_note_to_case_activity`; `_broadcast_note_to_participants` delegates to `self._trigger_activity.add_note_to_case` and skips if port is absent.

### Supporting changes
- **`TriggerActivityPort`** — added `announce_vulnerability_case(case_id, actor, context_id, to) -> str` method.
- **`TriggerActivityAdapter`** — implemented `announce_vulnerability_case` via DataLayer read + wire factory.
- **`inbox_handler.py`** — moved `ADD_NOTE_TO_CASE` to `_SYNC_AND_TRIGGER_PORT_SEMANTICS`; added `DEFER_CASE`, `ENGAGE_CASE`, `VALIDATE_REPORT` to `_TRIGGER_ACTIVITY_PORT_SEMANTICS`.
- **`ValidateReportReceivedUseCase`**, **`ValidateCaseUseCase`**, **`EngageCaseReceivedUseCase`**, **`DeferCaseReceivedUseCase`** — accept optional `trigger_activity` and thread it to `BTBridge`.
- **Architecture ratchet test** — `KNOWN_VIOLATIONS` cleared to `frozenset()`.

## Test results
- 2574 passed, 12 skipped — all green
- mypy: no issues
- pyright: 0 errors