### PR TITLE
Refactor #699 step 2: migrate CaseStatus + ParticipantStatus to core (#725)

### DIFF
--- a/plan/history/2606/implementation/725.md
+++ b/plan/history/2606/implementation/725.md
@@ -1,0 +1,8 @@
+---
+source: '725'
+timestamp: '2026-06-04T14:33:59.466427+00:00'
+title: Migrate CaseStatus and ParticipantStatus to core domain models
+type: implementation
+---
+
+Replaced stub VultronCaseStatus/VultronParticipantStatus with proper CaseStatus(CoreObject) and ParticipantStatus(CoreObject) domain types. Wire layer became thin projections with from_core/to_core. Fixed DataLayer round-trip by marking CoreObject.context_ with exclude=True (wire-layer concern). Renamed all references across 18 source files and 14 test files. PR: <https://github.com/CERTCC/Vultron/pull/763>. All 2661 tests pass; all linters clean.

--- a/test/adapters/driving/fastapi/routers/test_trigger_report.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_report.py
@@ -26,7 +26,7 @@ import pytest
 from fastapi import FastAPI, status
 from fastapi.testclient import TestClient
 
-from vultron.core.models.participant_status import VultronParticipantStatus
+from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.use_cases._helpers import _report_phase_status_id
 from vultron.adapters.driving.fastapi.deps import (
     get_canonical_actor_dl,
@@ -187,7 +187,7 @@ def accepted_report(report):
 @pytest.fixture
 def closed_report(dl, report, actor):
     """Put the report into RM.CLOSED state (triggers 409 on close-report)."""
-    status = VultronParticipantStatus(
+    status = ParticipantStatus(
         id_=_report_phase_status_id(actor.id_, report.id_, RM.CLOSED.value),
         context=report.id_,
         attributed_to=actor.id_,

--- a/test/core/behaviors/case/test_bug_26040902_regression.py
+++ b/test/core/behaviors/case/test_bug_26040902_regression.py
@@ -84,7 +84,7 @@ def test_receive_report_case_bt_succeeds_without_conftest_imports(
     from vultron.core.behaviors.case.receive_report_case_tree import (
         create_receive_report_case_tree,
     )
-    from vultron.core.models.participant_status import VultronParticipantStatus
+    from vultron.core.models.participant_status import ParticipantStatus
     from vultron.core.models.vultron_types import (
         VultronCaseActor,
         VultronOffer,
@@ -130,7 +130,7 @@ def test_receive_report_case_bt_succeeds_without_conftest_imports(
     )
     dl.create(offer)
 
-    reporter_status = VultronParticipantStatus(
+    reporter_status = ParticipantStatus(
         id_=_report_phase_status_id(
             _reporter_actor_id, _report_id, RM.ACCEPTED.value
         ),
@@ -140,7 +140,7 @@ def test_receive_report_case_bt_succeeds_without_conftest_imports(
     )
     dl.create(reporter_status)
 
-    vendor_status = VultronParticipantStatus(
+    vendor_status = ParticipantStatus(
         id_=_report_phase_status_id(_actor_id, _report_id, RM.RECEIVED.value),
         context=_report_id,
         attributed_to=_actor_id,

--- a/test/core/behaviors/case/test_receive_report_case_tree.py
+++ b/test/core/behaviors/case/test_receive_report_case_tree.py
@@ -32,7 +32,7 @@ from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.case.receive_report_case_tree import (
     create_receive_report_case_tree,
 )
-from vultron.core.models.participant_status import VultronParticipantStatus
+from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models.vultron_types import (
     VultronCaseActor,
     VultronOffer,
@@ -98,7 +98,7 @@ def reporter_accepted_status(datalayer, reporter_actor_id, report):
 
     SubmitReportReceivedUseCase creates this record before the tree runs.
     """
-    status = VultronParticipantStatus(
+    status = ParticipantStatus(
         id_=_report_phase_status_id(
             reporter_actor_id, report.id_, RM.ACCEPTED.value
         ),
@@ -117,7 +117,7 @@ def vendor_received_status(datalayer, actor_id, report):
     CreateReportReceivedUseCase or AckReportReceivedUseCase creates this
     record before the tree runs.
     """
-    status = VultronParticipantStatus(
+    status = ParticipantStatus(
         id_=_report_phase_status_id(actor_id, report.id_, RM.RECEIVED.value),
         context=report.id_,
         attributed_to=actor_id,

--- a/test/core/behaviors/report/test_nodes.py
+++ b/test/core/behaviors/report/test_nodes.py
@@ -28,7 +28,7 @@ from py_trees.composites import Sequence
 from typing import cast, Any
 
 from vultron.core.models.case_actor import VultronCaseActor
-from vultron.core.models.participant_status import VultronParticipantStatus
+from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.use_cases._helpers import _report_phase_status_id
 from vultron.core.models.vultron_types import (
     VultronOffer,
@@ -91,7 +91,7 @@ def test_check_rm_state_valid_when_valid(
     bt_scenario: BTTestScenario, actor: VultronCaseActor, report: VultronReport
 ) -> None:
     """CheckRMStateValid returns SUCCESS when report is VALID."""
-    status = VultronParticipantStatus(
+    status = ParticipantStatus(
         id_=_report_phase_status_id(actor.id_, report.id_, RM.VALID.value),
         context=report.id_,
         attributed_to=actor.id_,
@@ -109,7 +109,7 @@ def test_check_rm_state_valid_when_received(
     bt_scenario: BTTestScenario, actor: VultronCaseActor, report: VultronReport
 ) -> None:
     """CheckRMStateValid returns FAILURE when report is RECEIVED (no VALID record)."""
-    status = VultronParticipantStatus(
+    status = ParticipantStatus(
         id_=_report_phase_status_id(actor.id_, report.id_, RM.RECEIVED.value),
         context=report.id_,
         attributed_to=actor.id_,
@@ -137,7 +137,7 @@ def test_check_rm_state_received_or_invalid_when_received(
     bt_scenario: BTTestScenario, actor: VultronCaseActor, report: VultronReport
 ) -> None:
     """CheckRMStateReceivedOrInvalid returns SUCCESS when RECEIVED."""
-    status = VultronParticipantStatus(
+    status = ParticipantStatus(
         id_=_report_phase_status_id(actor.id_, report.id_, RM.RECEIVED.value),
         context=report.id_,
         attributed_to=actor.id_,
@@ -155,7 +155,7 @@ def test_check_rm_state_received_or_invalid_when_invalid(
     bt_scenario: BTTestScenario, actor: VultronCaseActor, report: VultronReport
 ) -> None:
     """CheckRMStateReceivedOrInvalid returns SUCCESS when INVALID."""
-    status = VultronParticipantStatus(
+    status = ParticipantStatus(
         id_=_report_phase_status_id(actor.id_, report.id_, RM.INVALID.value),
         context=report.id_,
         attributed_to=actor.id_,
@@ -173,7 +173,7 @@ def test_check_rm_state_received_or_invalid_when_valid(
     bt_scenario: BTTestScenario, actor: VultronCaseActor, report: VultronReport
 ) -> None:
     """CheckRMStateReceivedOrInvalid returns FAILURE when VALID."""
-    status = VultronParticipantStatus(
+    status = ParticipantStatus(
         id_=_report_phase_status_id(actor.id_, report.id_, RM.VALID.value),
         context=report.id_,
         attributed_to=actor.id_,

--- a/test/core/behaviors/report/test_prioritize_tree.py
+++ b/test/core/behaviors/report/test_prioritize_tree.py
@@ -25,7 +25,7 @@ import pytest
 from py_trees.common import Status
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
-from vultron.core.models.participant_status import VultronParticipantStatus
+from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models.vultron_types import (
     VultronCase,
     VultronCaseActor,
@@ -54,12 +54,12 @@ def _make_participant_in_valid_state(
         attributed_to=attributed_to,
         context=context,
         participant_statuses=[
-            VultronParticipantStatus(
+            ParticipantStatus(
                 attributed_to=attributed_to,
                 context=context,
                 rm_state=RM.RECEIVED,
             ),
-            VultronParticipantStatus(
+            ParticipantStatus(
                 attributed_to=attributed_to,
                 context=context,
                 rm_state=RM.VALID,

--- a/test/core/behaviors/report/test_validate_tree.py
+++ b/test/core/behaviors/report/test_validate_tree.py
@@ -26,7 +26,7 @@ import pytest
 from py_trees.common import Status
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
-from vultron.core.models.participant_status import VultronParticipantStatus
+from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.use_cases._helpers import _report_phase_status_id
 from vultron.core.models.vultron_types import (
     VultronCaseActor,
@@ -292,7 +292,7 @@ def test_tree_execution_early_exit_already_valid(
 ):
     """Tree short-circuits if report already in VALID state."""
     # Arrange: Set report to VALID state in DataLayer
-    valid_status = VultronParticipantStatus(
+    valid_status = ParticipantStatus(
         id_=_report_phase_status_id(actor_id, report.id_, RM.VALID.value),
         context=report.id_,
         attributed_to=actor_id,
@@ -321,7 +321,7 @@ def test_tree_execution_invalid_state_transitions_to_valid(
 ):
     """Tree can validate report from INVALID state."""
     # Arrange: Set report to INVALID state in DataLayer (no VALID record present)
-    invalid_status = VultronParticipantStatus(
+    invalid_status = ParticipantStatus(
         id_=_report_phase_status_id(actor_id, report.id_, RM.INVALID.value),
         context=report.id_,
         attributed_to=actor_id,

--- a/test/core/models/events/test_event_property_aliases.py
+++ b/test/core/models/events/test_event_property_aliases.py
@@ -12,7 +12,7 @@ import pytest
 from vultron.core.models.activity import VultronActivity
 from vultron.core.models.base import VultronObject
 from vultron.core.models.case import VultronCase
-from vultron.core.models.case_status import VultronCaseStatus
+from vultron.core.models.case_status import CaseStatus
 from vultron.core.models.embargo_event import VultronEmbargoEvent
 from vultron.core.models.events.actor import (
     AcceptCaseManagerRoleReceivedEvent,
@@ -66,7 +66,7 @@ from vultron.core.models.events.status import (
 )
 from vultron.core.models.note import VultronNote
 from vultron.core.models.participant import VultronParticipant
-from vultron.core.models.participant_status import VultronParticipantStatus
+from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models.report import VultronReport
 
 # Shared required fields for all VultronEvent instances.
@@ -88,12 +88,12 @@ _participant = VultronParticipant(
     context=_CASE_URI,
     attributed_to=_ACTOR_URI,
 )
-_case_status = VultronCaseStatus(
+_case_status = CaseStatus(
     id_="https://example.org/statuses/cs1",
     context=_CASE_URI,
     attributed_to=_ACTOR_URI,
 )
-_participant_status = VultronParticipantStatus(
+_participant_status = ParticipantStatus(
     id_="https://example.org/statuses/ps1",
     context=_CASE_URI,
 )

--- a/test/core/models/test_base.py
+++ b/test/core/models/test_base.py
@@ -14,11 +14,11 @@ from vultron.core.models.activity import (
 from vultron.core.models.base import VultronObject
 from vultron.core.models.case import VultronCase
 from vultron.core.models.case_actor import VultronCaseActor
-from vultron.core.models.case_status import VultronCaseStatus
+from vultron.core.models.case_status import CaseStatus
 from vultron.core.models.embargo_event import VultronEmbargoEvent
 from vultron.core.models.note import VultronNote
 from vultron.core.models.participant import VultronParticipant
-from vultron.core.models.participant_status import VultronParticipantStatus
+from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models.report import VultronReport
 
 DOMAIN_OBJECT_CLASSES = [
@@ -26,7 +26,7 @@ DOMAIN_OBJECT_CLASSES = [
     VultronCase,
     VultronNote,
     VultronParticipant,
-    VultronCaseStatus,
+    CaseStatus,
     VultronEmbargoEvent,
     VultronCaseActor,
     VultronActivity,
@@ -43,7 +43,7 @@ REQUIRED_KWARGS: dict[type, dict] = {
         "context": "urn:uuid:case-123",
         "attributed_to": "urn:uuid:actor-456",
     },
-    VultronCaseStatus: {
+    CaseStatus: {
         "context": "urn:uuid:case-123",
         "attributed_to": "urn:uuid:actor-456",
     },
@@ -95,9 +95,9 @@ def test_has_name_field(cls):
 
 def test_vultron_participant_status_context_required():
     with pytest.raises(ValidationError):
-        VultronParticipantStatus()
-    ps = VultronParticipantStatus(context="urn:uuid:case-123")
-    assert issubclass(VultronParticipantStatus, VultronObject)
+        ParticipantStatus()
+    ps = ParticipantStatus(context="urn:uuid:case-123")
+    assert issubclass(ParticipantStatus, VultronObject)
     assert ps.id_.startswith("urn:uuid:")
     assert ps.type_ == "ParticipantStatus"
     assert ps.context == "urn:uuid:case-123"
@@ -129,9 +129,7 @@ def test_domain_object_expected_as_types():
         == "CaseParticipant"
     )
     assert (
-        VultronCaseStatus(
-            context="urn:uuid:c", attributed_to="urn:uuid:a"
-        ).type_
+        CaseStatus(context="urn:uuid:c", attributed_to="urn:uuid:a").type_
         == "CaseStatus"
     )
     assert (
@@ -166,10 +164,12 @@ def test_vultron_participant_required_fields():
 
 def test_vultron_case_status_required_fields():
     with pytest.raises(Exception):
-        VultronCaseStatus()
-    with pytest.raises(Exception):
-        VultronCaseStatus(context="urn:uuid:case-123")
-    cs = VultronCaseStatus(
+        CaseStatus()
+    # attributed_to is optional; context alone is sufficient
+    cs_no_attr = CaseStatus(context="urn:uuid:case-123")
+    assert cs_no_attr.context == "urn:uuid:case-123"
+    assert cs_no_attr.attributed_to is None
+    cs = CaseStatus(
         context="urn:uuid:case-123", attributed_to="urn:uuid:actor-456"
     )
     assert cs.context == "urn:uuid:case-123"
@@ -196,7 +196,7 @@ def test_vultron_case_init_case_statuses():
 
     case_with_actor = VultronCase(attributed_to="urn:uuid:actor-123")
     assert len(case_with_actor.case_statuses) == 1
-    assert isinstance(case_with_actor.case_statuses[0], VultronCaseStatus)
+    assert isinstance(case_with_actor.case_statuses[0], CaseStatus)
     assert case_with_actor.case_statuses[0].context == case_with_actor.id_
     assert (
         case_with_actor.case_statuses[0].attributed_to == "urn:uuid:actor-123"
@@ -205,15 +205,13 @@ def test_vultron_case_init_case_statuses():
     case_existing_statuses = VultronCase(
         attributed_to="urn:uuid:actor-123",
         case_statuses=[
-            VultronCaseStatus(
+            CaseStatus(
                 context="urn:uuid:case-123", attributed_to="urn:uuid:actor-456"
             )
         ],
     )
     assert len(case_existing_statuses.case_statuses) == 1
-    assert isinstance(
-        case_existing_statuses.case_statuses[0], VultronCaseStatus
-    )
+    assert isinstance(case_existing_statuses.case_statuses[0], CaseStatus)
     assert case_existing_statuses.case_statuses[0].attributed_to is not None
     assert (
         case_existing_statuses.case_statuses[0].attributed_to

--- a/test/core/models/test_core_object.py
+++ b/test/core/models/test_core_object.py
@@ -53,14 +53,22 @@ def test_core_object_default_instance():
     assert obj.updated is not None
 
 
-def test_core_object_context_alias_serializes_as_at_context():
+def test_core_object_context_alias_accepted_but_excluded_from_dump():
+    """@context is accepted on input but excluded from serialization.
+
+    ``context_`` is a wire-layer concern (JSON-LD ``@context``); it is
+    validated when present in incoming data but intentionally omitted from
+    ``model_dump()`` output so that core objects can be round-tripped
+    through the DataLayer without colliding with the wire base's required
+    ``context_: str`` field.
+    """
     obj = CoreObject.model_validate(
         {"@context": "https://www.w3.org/ns/activitystreams"}
     )
     assert obj.context_ == "https://www.w3.org/ns/activitystreams"
+    # excluded from serialization — neither alias nor field name appears
     dumped = obj.model_dump(by_alias=True, exclude_none=True)
-    assert "@context" in dumped
-    assert dumped["@context"] == "https://www.w3.org/ns/activitystreams"
+    assert "@context" not in dumped
     assert "context_" not in dumped
 
 

--- a/test/core/use_cases/received/test_case_bootstrap_trust.py
+++ b/test/core/use_cases/received/test_case_bootstrap_trust.py
@@ -29,7 +29,10 @@ import pytest
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.core.models.participant import VultronParticipant
-from vultron.core.models.participant_status import VultronParticipantStatus
+from vultron.core.models.participant_status import ParticipantStatus
+from vultron.wire.as2.vocab.objects.case_status import (
+    ParticipantStatus as WireParticipantStatus,
+)
 from vultron.core.models.report import VultronReport
 from vultron.core.models.report_case_link import VultronReportCaseLink
 from vultron.core.states.cs import CS_vfd
@@ -53,7 +56,6 @@ from vultron.wire.as2.vocab.objects.case_participant import (
     CaseActorParticipant,
     CaseParticipant,
 )
-from vultron.wire.as2.vocab.objects.case_status import ParticipantStatus
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
 
 # ---------------------------------------------------------------------------
@@ -488,7 +490,7 @@ class TestM4AddParticipantStatusAfterBootstrap:
         # The status is NOT pre-created — it arrives inline in the activity, so
         # AppendParticipantStatusNode must resolve it from the fallback and
         # persist it independently.
-        status = ParticipantStatus(
+        status = WireParticipantStatus(
             id_=_vfd_status_id,
             context=_CASE_ID,
             vfd_state=CS_vfd.VFd,
@@ -722,7 +724,7 @@ class TestBootstrapReporterUpgradesFromStart:
 
     def _pre_seed_participant(self, dl, rm_state: RM) -> VultronParticipant:
         """Store a finder participant at the given rm_state before bootstrap."""
-        status = VultronParticipantStatus(
+        status = ParticipantStatus(
             rm_state=rm_state,
             context=self._CASE_ID,
             attributed_to=self._FINDER_ID,

--- a/test/core/use_cases/received/test_report.py
+++ b/test/core/use_cases/received/test_report.py
@@ -637,7 +637,7 @@ class TestCaseLevelUseeCases:
     ):
         """Helper: create a VulnerabilityCase with one participant."""
         from vultron.core.models.participant_status import (
-            VultronParticipantStatus,
+            ParticipantStatus,
         )
 
         participant = VultronParticipant(
@@ -645,7 +645,7 @@ class TestCaseLevelUseeCases:
             attributed_to=actor_id,
             context="https://example.org/cases/c1",
             participant_statuses=[
-                VultronParticipantStatus(
+                ParticipantStatus(
                     rm_state=initial_rm,
                     context="https://example.org/cases/c1",
                     attributed_to=actor_id,
@@ -737,7 +737,7 @@ class TestDereferencePatternInReportUseCases:
     ):
         """Create a case linked to a report via find_case_by_report_id."""
         from vultron.core.models.participant_status import (
-            VultronParticipantStatus,
+            ParticipantStatus,
         )
         from vultron.core.models.report import VultronReport as CoreReport
 
@@ -749,7 +749,7 @@ class TestDereferencePatternInReportUseCases:
             attributed_to=actor_id,
             context="https://example.org/cases/c-deref",
             participant_statuses=[
-                VultronParticipantStatus(
+                ParticipantStatus(
                     rm_state=initial_rm,
                     context="https://example.org/cases/c-deref",
                     attributed_to=actor_id,

--- a/test/core/use_cases/triggers/test_service.py
+++ b/test/core/use_cases/triggers/test_service.py
@@ -40,7 +40,7 @@ try:
 except ImportError:
     from pydantic_core import ValidationError as PydanticValidationError
 from vultron.core.models.report_case_link import VultronReportCaseLink
-from vultron.core.models.participant_status import VultronParticipantStatus
+from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.use_cases._helpers import _report_phase_status_id
 from vultron.core.states.em import EM
 from vultron.core.states.rm import RM
@@ -160,7 +160,7 @@ def accepted_report(report):
 
 @pytest.fixture
 def closed_report(dl, report, actor):
-    status = VultronParticipantStatus(
+    status = ParticipantStatus(
         id_=_report_phase_status_id(actor.id_, report.id_, RM.CLOSED.value),
         context=report.id_,
         attributed_to=actor.id_,

--- a/test/core/use_cases/triggers/test_svc_add_participant_status.py
+++ b/test/core/use_cases/triggers/test_svc_add_participant_status.py
@@ -32,7 +32,7 @@ from vultron.core.states.rm import RM
 
 
 class _FakeParticipantStatus:
-    """Minimal stand-in for VultronParticipantStatus."""
+    """Minimal stand-in for ParticipantStatus."""
 
     def __init__(self, rm_state: RM, vfd_state: CS_vfd) -> None:
         self.rm_state = rm_state

--- a/test/wire/as2/test_extractor.py
+++ b/test/wire/as2/test_extractor.py
@@ -240,7 +240,7 @@ def test_extract_intent_participant_case_roles():
 
 
 def test_extract_intent_case_status_name():
-    """VultronCaseStatus.name is populated from the wire CaseStatus."""
+    """CaseStatus.name is populated from the wire CaseStatus."""
     from vultron.wire.as2.vocab.base.objects.activities.transitive import (
         as_Create,
     )
@@ -261,7 +261,7 @@ def test_extract_intent_case_status_name():
 
 
 def test_extract_intent_participant_status_vfd_state():
-    """VultronParticipantStatus.vfd_state is populated from the wire ParticipantStatus."""
+    """ParticipantStatus.vfd_state is populated from the wire ParticipantStatus."""
     from vultron.wire.as2.vocab.base.objects.activities.transitive import (
         as_Create,
     )

--- a/test/wire/as2/vocab/test_wire_domain_translation.py
+++ b/test/wire/as2/vocab/test_wire_domain_translation.py
@@ -21,9 +21,11 @@ from pydantic import ValidationError
 from vultron.core.models.case import VultronCase
 from vultron.core.models.case_actor import VultronCaseActor
 from vultron.core.models.case_log_entry import VultronCaseLogEntry
-from vultron.core.models.case_status import VultronCaseStatus
+from vultron.core.models.case_status import CaseStatus as CoreCaseStatus
 from vultron.core.models.participant import VultronParticipant
-from vultron.core.models.participant_status import VultronParticipantStatus
+from vultron.core.models.participant_status import (
+    ParticipantStatus as CoreParticipantStatus,
+)
 from vultron.core.models.report import VultronReport
 from vultron.core.states.em import EM
 from vultron.core.states.rm import RM
@@ -57,7 +59,7 @@ def test_vulnerability_report_round_trips_between_core_and_wire():
 
 
 def test_case_status_round_trips_between_core_and_wire():
-    core = VultronCaseStatus(
+    core = CoreCaseStatus(
         id_="https://example.org/cases/1/status/1",
         attributed_to="https://example.org/actors/vendor",
         context="https://example.org/cases/1",
@@ -77,13 +79,13 @@ def test_case_status_round_trips_between_core_and_wire():
 
 
 def test_participant_status_from_core_materializes_case_status_reference():
-    core_case_status = VultronCaseStatus(
+    core_case_status = CoreCaseStatus(
         id_="https://example.org/cases/1/status/1",
         context="https://example.org/cases/1",
         attributed_to="https://example.org/actors/vendor",
         em_state=EM.NO_EMBARGO,
     )
-    core = VultronParticipantStatus(
+    core = CoreParticipantStatus(
         id_="https://example.org/cases/1/participants/1/status/1",
         attributed_to="https://example.org/actors/vendor",
         context="https://example.org/cases/1",
@@ -101,7 +103,7 @@ def test_participant_status_from_core_materializes_case_status_reference():
     assert round_tripped.context == core.context
     assert round_tripped.rm_state == core.rm_state
     assert round_tripped.vfd_state == core.vfd_state
-    assert isinstance(round_tripped.case_status, VultronCaseStatus)
+    assert isinstance(round_tripped.case_status, CoreCaseStatus)
     assert round_tripped.case_status.id_ == core_case_status.id_
     assert round_tripped.case_status.em_state == core_case_status.em_state
 
@@ -113,7 +115,7 @@ def test_case_participant_round_trips_between_core_and_wire():
         context="https://example.org/cases/1",
         case_roles=[],
         participant_statuses=[
-            VultronParticipantStatus(
+            CoreParticipantStatus(
                 id_="https://example.org/cases/1/participants/vendor/status/1",
                 attributed_to="https://example.org/actors/vendor",
                 context="https://example.org/cases/1",
@@ -137,7 +139,7 @@ def test_case_participant_round_trips_between_core_and_wire():
 
 
 def test_vulnerability_case_round_trips_between_core_and_wire():
-    case_status = VultronCaseStatus(
+    case_status = CoreCaseStatus(
         id_="https://example.org/cases/1/status/1",
         attributed_to="https://example.org/actors/vendor",
         context="https://example.org/cases/1",
@@ -180,7 +182,7 @@ def test_vulnerability_case_round_trips_between_core_and_wire():
     assert round_tripped.parent_cases == core.parent_cases
     assert round_tripped.child_cases == core.child_cases
     assert round_tripped.sibling_cases == core.sibling_cases
-    assert isinstance(round_tripped.case_statuses[0], VultronCaseStatus)
+    assert isinstance(round_tripped.case_statuses[0], CoreCaseStatus)
     assert round_tripped.case_statuses[0].id_ == case_status.id_
 
 

--- a/vultron/adapters/driven/trigger_activity_adapter.py
+++ b/vultron/adapters/driven/trigger_activity_adapter.py
@@ -468,23 +468,18 @@ class TriggerActivityAdapter:
                 "ParticipantStatus",
                 f"status '{status_id}' not found",
             )
-        # Convert from core VultronParticipantStatus to wire ParticipantStatus
+        # Convert from core ParticipantStatus to wire ParticipantStatus
         # so that nested fields (case_status, pxa_state) survive the boundary.
-        if not isinstance(raw, ParticipantStatus):
-            from vultron.wire.as2.vocab.objects.case_status import (
-                ParticipantStatus as WirePS,
-            )
-            from vultron.core.models.participant_status import (
-                VultronParticipantStatus,
-            )
+        from vultron.core.models.participant_status import (
+            ParticipantStatus as CorePS,
+        )
 
-            if isinstance(raw, VultronParticipantStatus):
-                raw = WirePS.from_core(raw)
-            else:
-                raw = cast(ParticipantStatus, raw)
-        status: ParticipantStatus = raw
+        if isinstance(raw, CorePS):
+            wire_status: ParticipantStatus = ParticipantStatus.from_core(raw)
+        else:
+            wire_status = cast(ParticipantStatus, raw)
         activity = add_status_to_participant_activity(
-            status=status, target=participant_id, actor=actor, to=to
+            status=wire_status, target=participant_id, actor=actor, to=to
         )
         try:
             self._dl.create(activity)

--- a/vultron/core/behaviors/case/nodes/participant.py
+++ b/vultron/core/behaviors/case/nodes/participant.py
@@ -31,7 +31,7 @@ from py_trees.common import Status
 from vultron.core.behaviors.helpers import DataLayerAction
 from vultron.core.models.actor_config import ActorConfig
 from vultron.core.models.enums import VultronObjectType
-from vultron.core.models.participant_status import VultronParticipantStatus
+from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models.protocols import CaseModel, has_outbox, is_case_model
 from vultron.core.models.vultron_types import VultronCase, VultronParticipant
 from vultron.core.ports.case_persistence import (
@@ -138,7 +138,7 @@ def _build_owner_initial_status(
     case_id: str,
     report_id: str | None,
     initial_rm_state: RM,
-) -> VultronParticipantStatus:
+) -> ParticipantStatus:
     if report_id is not None:
         status_id = _report_phase_status_id(
             actor_id,
@@ -146,14 +146,14 @@ def _build_owner_initial_status(
             initial_rm_state.value,
         )
         if dl.read(status_id) is not None:
-            return VultronParticipantStatus(
+            return ParticipantStatus(
                 id_=status_id,
                 context=case_id,
                 rm_state=initial_rm_state,
                 attributed_to=actor_id,
             )
 
-    return VultronParticipantStatus(
+    return ParticipantStatus(
         context=case_id,
         rm_state=initial_rm_state,
         attributed_to=actor_id,
@@ -202,7 +202,7 @@ def _get_or_create_accepted_status(
     report_id: str | None,
     node_name: str,
     node_logger: logging.Logger,
-) -> VultronParticipantStatus | None:
+) -> ParticipantStatus | None:
     if report_id is None:
         return None
 
@@ -212,7 +212,7 @@ def _get_or_create_accepted_status(
         RM.ACCEPTED.value,
     )
     existing = dl.read(accepted_status_id)
-    if isinstance(existing, VultronParticipantStatus):
+    if isinstance(existing, ParticipantStatus):
         return existing
 
     node_logger.info(
@@ -221,7 +221,7 @@ def _get_or_create_accepted_status(
         node_name,
         actor_id,
     )
-    accepted_status = VultronParticipantStatus(
+    accepted_status = ParticipantStatus(
         id_=accepted_status_id,
         context=report_id,
         rm_state=RM.ACCEPTED,
@@ -310,7 +310,7 @@ class CreateCaseOwnerParticipant(DataLayerAction):
     ``report_id`` is provided, the node first looks for an existing status
     record in the DataLayer (created by an earlier use case) and reuses it
     to avoid duplicating history. If no existing record is found, a fresh
-    ``VultronParticipantStatus`` is created.
+    ``ParticipantStatus`` is created.
 
     Optionally advances the actor's RM to ACCEPTED
     (``advance_to_accepted=True``) after the participant is created — use
@@ -414,7 +414,7 @@ class CreateCaseParticipantNode(DataLayerAction):
     and ``roles`` (the CVD roles to assign).
 
     When ``report_id`` is supplied, the node reuses the deterministic
-    report-phase ``VultronParticipantStatus`` for ``RM.ACCEPTED`` that was
+    report-phase ``ParticipantStatus`` for ``RM.ACCEPTED`` that was
     created during ``SubmitReportReceivedUseCase``, preserving engagement
     history.
 

--- a/vultron/core/behaviors/report/nodes.py
+++ b/vultron/core/behaviors/report/nodes.py
@@ -32,7 +32,7 @@ from py_trees.common import Status
 from vultron.core.models.vultron_types import (
     VultronCase,
     VultronCreateCaseActivity,
-    VultronParticipantStatus,
+    ParticipantStatus,
 )
 from vultron.core.models.protocols import (
     has_outbox,
@@ -295,7 +295,7 @@ class TransitionRMtoValid(DataLayerAction):
         """
         Update report and offer statuses.
 
-        Creates a standalone VultronParticipantStatus record for RM.VALID and
+        Creates a standalone ParticipantStatus record for RM.VALID and
         also updates the CaseParticipant.participant_statuses list (via
         ``update_participant_rm_state``) so that the engage-case trigger can
         advance to RM.ACCEPTED from VALID rather than RECEIVED.
@@ -310,7 +310,7 @@ class TransitionRMtoValid(DataLayerAction):
             return Status.FAILURE
 
         try:
-            status = VultronParticipantStatus(
+            status = ParticipantStatus(
                 id_=_report_phase_status_id(
                     self.actor_id, self.report_id, RM.VALID.value
                 ),
@@ -386,7 +386,7 @@ class TransitionRMtoInvalid(DataLayerAction):
             return Status.FAILURE
 
         try:
-            status = VultronParticipantStatus(
+            status = ParticipantStatus(
                 id_=_report_phase_status_id(
                     self.actor_id, self.report_id, RM.INVALID.value
                 ),

--- a/vultron/core/models/base.py
+++ b/vultron/core/models/base.py
@@ -136,6 +136,7 @@ class CoreObject(VultronObject):
         default=None,
         validation_alias="@context",
         serialization_alias="@context",
+        exclude=True,
     )
 
     def __init_subclass__(cls, **kwargs: object) -> None:

--- a/vultron/core/models/case.py
+++ b/vultron/core/models/case.py
@@ -21,7 +21,7 @@ from pydantic import Field, model_validator
 
 from vultron.core.models.base import VultronObject
 from vultron.core.models.case_event import VultronCaseEvent
-from vultron.core.models.case_status import VultronCaseStatus
+from vultron.core.models.case_status import CaseStatus
 from vultron.core.models.participant import VultronParticipant
 
 
@@ -39,7 +39,7 @@ class VultronCase(VultronObject):
     it via the wire vocabulary registry.
 
     When first created with an ``attributed_to`` actor and an empty
-    ``case_statuses`` list, an initial ``VultronCaseStatus`` is appended
+    ``case_statuses`` list, an initial ``CaseStatus`` is appended
     automatically so that ``current_status`` (on the wire
     ``VulnerabilityCase``) never encounters an empty history list.
     """
@@ -54,7 +54,7 @@ class VultronCase(VultronObject):
     )
     actor_participant_index: dict[str, str] = Field(default_factory=dict)
     vulnerability_reports: list[str] = Field(default_factory=list)
-    case_statuses: list[str | VultronCaseStatus] = Field(default_factory=list)
+    case_statuses: list[str | CaseStatus] = Field(default_factory=list)
     notes: list[str] = Field(default_factory=list)
     active_embargo: str | None = None
     proposed_embargoes: list[str] = Field(default_factory=list)
@@ -68,7 +68,7 @@ class VultronCase(VultronObject):
     def init_case_statuses(self) -> "VultronCase":
         if not self.case_statuses and self.attributed_to:
             self.case_statuses = [
-                VultronCaseStatus(
+                CaseStatus(
                     context=self.id_,
                     attributed_to=self.attributed_to,
                 )

--- a/vultron/core/models/case_status.py
+++ b/vultron/core/models/case_status.py
@@ -15,32 +15,59 @@
 
 """Domain representation of a case status snapshot."""
 
-from typing import Any
+from typing import Literal
 
-from pydantic import Field, field_serializer
+from pydantic import Field, field_serializer, field_validator
 
 from vultron.core.states.em import EM
 from vultron.core.states.cs import CS_pxa
-from vultron.core.models.base import NonEmptyString, VultronObject
+from vultron.core.models.base import CoreObject, NonEmptyString
 
 
-class VultronCaseStatus(VultronObject):
+class CaseStatus(CoreObject):
     """Domain representation of a case status snapshot.
 
-    Mirrors the Vultron-specific fields of ``CaseStatus``.
-    ``type_`` is ``"CaseStatus"`` to match the wire value.
+    Canonical core type for the Vultron ``CaseStatus`` object.
+    ``type_`` is ``"CaseStatus"`` to match the wire value and
+    to auto-register this class in :data:`CORE_VOCABULARY`.
+
+    ``context`` (case ID) is required — a status snapshot without a case
+    context is not meaningful.  ``attributed_to`` (reporting actor) is
+    optional but must be non-empty when present.
     """
 
-    type_: str = Field(
+    type_: Literal["CaseStatus"] = Field(
         default="CaseStatus",
         validation_alias="type",
         serialization_alias="type",
     )
     context: NonEmptyString  # pyright: ignore[reportGeneralTypeIssues]
-    attributed_to: Any  # pyright: ignore[reportGeneralTypeIssues]
-    em_state: EM = EM.EMBARGO_MANAGEMENT_NONE
+    attributed_to: NonEmptyString | None = (
+        None  # pyright: ignore[reportGeneralTypeIssues]
+    )
+    em_state: EM = EM.NO_EMBARGO
     pxa_state: CS_pxa = CS_pxa.pxa
+
+    @field_serializer("em_state")
+    def _serialize_em_state(self, v: EM) -> str:
+        return v.name
 
     @field_serializer("pxa_state")
     def _serialize_pxa_state(self, v: CS_pxa) -> str:
         return v.name
+
+    @field_validator("em_state", mode="before")
+    @classmethod
+    def _validate_em_state(cls, v: object) -> EM:
+        if isinstance(v, str):
+            if v in EM.__members__:
+                return EM[v]
+            return EM(v)
+        return v  # type: ignore[return-value]
+
+    @field_validator("pxa_state", mode="before")
+    @classmethod
+    def _validate_pxa_state(cls, v: object) -> CS_pxa:
+        if isinstance(v, str):
+            return CS_pxa[v]
+        return v  # type: ignore[return-value]

--- a/vultron/core/models/events/status.py
+++ b/vultron/core/models/events/status.py
@@ -6,14 +6,14 @@ from vultron.core.models.events.base import MessageSemantics, VultronEvent
 
 if TYPE_CHECKING:
     from vultron.core.models.case import VultronCase
-    from vultron.core.models.case_status import VultronCaseStatus
+    from vultron.core.models.case_status import CaseStatus
     from vultron.core.models.participant import VultronParticipant
-    from vultron.core.models.participant_status import VultronParticipantStatus
+    from vultron.core.models.participant_status import ParticipantStatus
 else:
     VultronCase = object
-    VultronCaseStatus = object
+    CaseStatus = object
     VultronParticipant = object
-    VultronParticipantStatus = object
+    ParticipantStatus = object
 
 
 class CreateCaseStatusReceivedEvent(VultronEvent):
@@ -28,10 +28,8 @@ class CreateCaseStatusReceivedEvent(VultronEvent):
         return self.object_id
 
     @property
-    def status(self) -> "VultronCaseStatus | VultronParticipantStatus | None":
-        return cast(
-            "VultronCaseStatus | VultronParticipantStatus | None", self.object_
-        )
+    def status(self) -> "CaseStatus | ParticipantStatus | None":
+        return cast("CaseStatus | ParticipantStatus | None", self.object_)
 
 
 class AddCaseStatusToCaseReceivedEvent(VultronEvent):
@@ -46,10 +44,8 @@ class AddCaseStatusToCaseReceivedEvent(VultronEvent):
         return self.object_id
 
     @property
-    def status(self) -> "VultronCaseStatus | VultronParticipantStatus | None":
-        return cast(
-            "VultronCaseStatus | VultronParticipantStatus | None", self.object_
-        )
+    def status(self) -> "CaseStatus | ParticipantStatus | None":
+        return cast("CaseStatus | ParticipantStatus | None", self.object_)
 
     @property
     def case_id(self) -> str | None:
@@ -72,10 +68,8 @@ class CreateParticipantStatusReceivedEvent(VultronEvent):
         return self.object_id
 
     @property
-    def status(self) -> "VultronCaseStatus | VultronParticipantStatus | None":
-        return cast(
-            "VultronCaseStatus | VultronParticipantStatus | None", self.object_
-        )
+    def status(self) -> "CaseStatus | ParticipantStatus | None":
+        return cast("CaseStatus | ParticipantStatus | None", self.object_)
 
 
 class AddParticipantStatusToParticipantReceivedEvent(VultronEvent):
@@ -90,10 +84,8 @@ class AddParticipantStatusToParticipantReceivedEvent(VultronEvent):
         return self.object_id
 
     @property
-    def status(self) -> "VultronCaseStatus | VultronParticipantStatus | None":
-        return cast(
-            "VultronCaseStatus | VultronParticipantStatus | None", self.object_
-        )
+    def status(self) -> "CaseStatus | ParticipantStatus | None":
+        return cast("CaseStatus | ParticipantStatus | None", self.object_)
 
     @property
     def participant_id(self) -> str | None:

--- a/vultron/core/models/participant.py
+++ b/vultron/core/models/participant.py
@@ -20,7 +20,7 @@ import logging
 from pydantic import Field, field_serializer, field_validator
 
 from vultron.core.models.base import NonEmptyString, VultronObject
-from vultron.core.models.participant_status import VultronParticipantStatus
+from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.states.participant_embargo_consent import PEC
 from vultron.core.states.rm import RM, is_valid_rm_transition
 from vultron.core.states.roles import CVDRole, serialize_roles, validate_roles
@@ -45,9 +45,7 @@ class VultronParticipant(VultronObject):
     attributed_to: NonEmptyString  # pyright: ignore[reportGeneralTypeIssues]
     context: NonEmptyString  # pyright: ignore[reportGeneralTypeIssues]
     case_roles: list[CVDRole] = Field(default_factory=list)
-    participant_statuses: list[VultronParticipantStatus] = Field(
-        default_factory=list
-    )
+    participant_statuses: list[ParticipantStatus] = Field(default_factory=list)
     accepted_embargo_ids: list[NonEmptyString] = Field(default_factory=list)
     embargo_consent_state: PEC = Field(default=PEC.NO_EMBARGO)
     participant_case_name: NonEmptyString | None = None
@@ -62,7 +60,7 @@ class VultronParticipant(VultronObject):
         return validate_roles(value)
 
     def append_rm_state(self, rm_state: RM, actor: str, context: str) -> bool:
-        """Append a new VultronParticipantStatus with the given RM state.
+        """Append a new ParticipantStatus with the given RM state.
 
         Validates the transition against the RM state machine.
         Returns True when the status was appended, False when blocked.
@@ -81,7 +79,7 @@ class VultronParticipant(VultronObject):
             )
             return False
         self.participant_statuses.append(
-            VultronParticipantStatus(
+            ParticipantStatus(
                 rm_state=rm_state,
                 context=context,
                 attributed_to=actor,

--- a/vultron/core/models/participant_status.py
+++ b/vultron/core/models/participant_status.py
@@ -17,24 +17,26 @@
 
 from typing import Literal
 
-from pydantic import Field, field_serializer
+from pydantic import Field, field_serializer, field_validator
 
 from vultron.core.states.rm import RM
 from vultron.core.states.cs import CS_vfd
-from vultron.core.models.base import NonEmptyString, VultronObject
-from vultron.core.models.case_status import VultronCaseStatus
+from vultron.core.models.base import CoreObject, NonEmptyString
+from vultron.core.models.case_status import CaseStatus
 
 
-class VultronParticipantStatus(VultronObject):
+class ParticipantStatus(CoreObject):
     """Domain representation of a participant RM-state status record.
 
-    Mirrors the Vultron-specific fields of ``ParticipantStatus``.
-    ``type_`` is ``"ParticipantStatus"`` to match the wire value.
+    Canonical core type for the Vultron ``ParticipantStatus`` object.
+    ``type_`` is ``"ParticipantStatus"`` to match the wire value and
+    to auto-register this class in :data:`CORE_VOCABULARY`.
 
-    ``context`` (case ID) is required, matching the wire type's constraint.
+    ``context`` (case ID) is required — a participant status is always
+    associated with a specific case.
 
     ``case_status`` embeds the participant's perspective on the case-level
-    state (em_state and pxa_state) via a nested ``VultronCaseStatus`` object.
+    state (em_state and pxa_state) via a nested :class:`CaseStatus` object.
     """
 
     type_: Literal["ParticipantStatus"] = Field(
@@ -48,8 +50,26 @@ class VultronParticipantStatus(VultronObject):
     case_engagement: bool = True
     embargo_adherence: bool = True
     tracking_id: NonEmptyString | None = None
-    case_status: VultronCaseStatus | None = None
+    case_status: CaseStatus | None = None
+
+    @field_serializer("rm_state")
+    def _serialize_rm_state(self, v: RM) -> str:
+        return v.name
 
     @field_serializer("vfd_state")
     def _serialize_vfd_state(self, v: CS_vfd) -> str:
         return v.name
+
+    @field_validator("rm_state", mode="before")
+    @classmethod
+    def _validate_rm_state(cls, v: object) -> RM:
+        if isinstance(v, str):
+            return RM[v]
+        return v  # type: ignore[return-value]
+
+    @field_validator("vfd_state", mode="before")
+    @classmethod
+    def _validate_vfd_state(cls, v: object) -> CS_vfd:
+        if isinstance(v, str):
+            return CS_vfd[v]
+        return v  # type: ignore[return-value]

--- a/vultron/core/models/vultron_types.py
+++ b/vultron/core/models/vultron_types.py
@@ -23,11 +23,11 @@ Import directly from those modules for new code:
 - ``vultron.core.models.case`` — VultronCase
 - ``vultron.core.models.case_actor`` — VultronCaseActor, VultronOutbox
 - ``vultron.core.models.case_event`` — VultronCaseEvent
-- ``vultron.core.models.case_status`` — VultronCaseStatus
+- ``vultron.core.models.case_status`` — CaseStatus
 - ``vultron.core.models.embargo_event`` — VultronEmbargoEvent
 - ``vultron.core.models.note`` — VultronNote
 - ``vultron.core.models.participant`` — VultronParticipant
-- ``vultron.core.models.participant_status`` — VultronParticipantStatus
+- ``vultron.core.models.participant_status`` — ParticipantStatus
 - ``vultron.core.models.report`` — VultronReport
 """
 
@@ -40,11 +40,11 @@ from vultron.core.models.activity import (
 from vultron.core.models.case import VultronCase
 from vultron.core.models.case_actor import VultronCaseActor, VultronOutbox
 from vultron.core.models.case_event import VultronCaseEvent
-from vultron.core.models.case_status import VultronCaseStatus
+from vultron.core.models.case_status import CaseStatus
 from vultron.core.models.embargo_event import VultronEmbargoEvent
 from vultron.core.models.note import VultronNote
 from vultron.core.models.participant import VultronParticipant
-from vultron.core.models.participant_status import VultronParticipantStatus
+from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models.report import VultronReport
 
 __all__ = [
@@ -53,13 +53,13 @@ __all__ = [
     "VultronCase",
     "VultronCaseActor",
     "VultronCaseEvent",
-    "VultronCaseStatus",
+    "CaseStatus",
     "VultronCreateCaseActivity",
     "VultronEmbargoEvent",
     "VultronNote",
     "VultronOffer",
     "VultronOutbox",
     "VultronParticipant",
-    "VultronParticipantStatus",
+    "ParticipantStatus",
     "VultronReport",
 ]

--- a/vultron/core/use_cases/received/case.py
+++ b/vultron/core/use_cases/received/case.py
@@ -14,7 +14,7 @@ from vultron.core.models.events.case import (
     UpdateCaseReceivedEvent,
 )
 from vultron.core.models.participant import VultronParticipant
-from vultron.core.models.participant_status import VultronParticipantStatus
+from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models.report_case_link import VultronReportCaseLink
 from vultron.core.models.vultron_types import VultronActivity
 from vultron.core.ports.case_persistence import (
@@ -247,7 +247,7 @@ def _ensure_reporter_participant(
         )
         return
 
-    status = VultronParticipantStatus(
+    status = ParticipantStatus(
         rm_state=RM.ACCEPTED,
         context=case_id,
         attributed_to=reporter_actor_id,
@@ -289,7 +289,7 @@ def _upgrade_participant_to_accepted(
     participant container expects.  This avoids wire/domain type mismatches when
     appending to ``CaseParticipant.participant_statuses``.
     """
-    upgrade_status = VultronParticipantStatus(
+    upgrade_status = ParticipantStatus(
         rm_state=RM.ACCEPTED,
         context=case_id,
         attributed_to=reporter_actor_id,

--- a/vultron/core/use_cases/triggers/case.py
+++ b/vultron/core/use_cases/triggers/case.py
@@ -364,7 +364,7 @@ class SvcAddReportToCaseUseCase:
 class SvcAddParticipantStatusUseCase:
     """Self-report actor RM/VFD/PXA state to the Case Manager.
 
-    Creates a VultronParticipantStatus object, saves it, then emits an
+    Creates a ParticipantStatus object, saves it, then emits an
     Add(ParticipantStatus, target=CaseParticipant) activity addressed to the
     Case Manager (DEMOMA-07-001).
     """
@@ -403,9 +403,9 @@ class SvcAddParticipantStatusUseCase:
 
     def execute(self) -> dict[str, Any]:
         from vultron.core.models.participant_status import (
-            VultronParticipantStatus,
+            ParticipantStatus,
         )
-        from vultron.core.models.case_status import VultronCaseStatus
+        from vultron.core.models.case_status import CaseStatus
 
         request = self._request
         actor_id = request.actor_id
@@ -432,14 +432,14 @@ class SvcAddParticipantStatusUseCase:
 
         # Build embedded CaseStatus if a participant-perspective pxa_state was
         # provided; inherit em_state from the current case-level status.
-        case_status: VultronCaseStatus | None = None
+        case_status: CaseStatus | None = None
         if request.pxa_state is not None:
             current_em = getattr(
                 getattr(case, "current_status", None), "em_state", None
             )
             from vultron.core.states.em import EM
 
-            case_status = VultronCaseStatus(
+            case_status = CaseStatus(
                 context=case_id,
                 attributed_to=actor_id,
                 em_state=current_em if current_em is not None else EM.NONE,
@@ -452,7 +452,7 @@ class SvcAddParticipantStatusUseCase:
         )
 
         # Build and persist the status object
-        status = VultronParticipantStatus(
+        status = ParticipantStatus(
             context=case_id,
             attributed_to=actor_id,
             rm_state=(

--- a/vultron/core/use_cases/triggers/report.py
+++ b/vultron/core/use_cases/triggers/report.py
@@ -32,7 +32,7 @@ from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.report.validate_tree import (
     create_validate_report_tree,
 )
-from vultron.core.models.participant_status import VultronParticipantStatus
+from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models.report_case_link import VultronReportCaseLink
 from vultron.core.models.report import VultronReport
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
@@ -215,7 +215,7 @@ class SvcInvalidateReportUseCase:
             to=_report_addressees(report.id_, actor_id, offer, dl),
         )
 
-        set_status_invalidate = VultronParticipantStatus(
+        set_status_invalidate = ParticipantStatus(
             id_=_report_phase_status_id(
                 actor_id, report.id_, RM.INVALID.value
             ),
@@ -280,7 +280,7 @@ class SvcRejectReportUseCase:
             to=_report_addressees(report.id_, actor_id, offer, dl),
         )
 
-        set_status_reject = VultronParticipantStatus(
+        set_status_reject = ParticipantStatus(
             id_=_report_phase_status_id(actor_id, report.id_, RM.CLOSED.value),
             context=report.id_,
             attributed_to=actor_id,
@@ -359,7 +359,7 @@ class SvcCloseReportUseCase:
             to=_report_addressees(report.id_, actor_id, offer, dl),
         )
 
-        set_status_close = VultronParticipantStatus(
+        set_status_close = ParticipantStatus(
             id_=closed_id,
             context=report.id_,
             attributed_to=actor_id,

--- a/vultron/wire/as2/extractor.py
+++ b/vultron/wire/as2/extractor.py
@@ -28,11 +28,11 @@ from vultron.core.models.enums import VultronObjectType as VOtype
 from vultron.core.models.vultron_types import (
     VultronActivity,
     VultronCase,
-    VultronCaseStatus,
+    CaseStatus,
     VultronEmbargoEvent,
     VultronNote,
     VultronParticipant,
-    VultronParticipantStatus,
+    ParticipantStatus,
     VultronReport,
 )
 from vultron.wire.as2.enums import (
@@ -510,7 +510,7 @@ def _build_case_object(obj: object) -> dict[str, Any]:
         )
         active_embargo = _get_id(getattr(obj, "active_embargo", None))
         raw_statuses = getattr(obj, "case_statuses", []) or []
-        case_statuses: list[str | VultronCaseStatus] = []
+        case_statuses: list[str | CaseStatus] = []
         for cs in raw_statuses:
             if hasattr(cs, "to_core"):
                 case_statuses.append(cs.to_core())
@@ -641,17 +641,18 @@ def _build_case_log_entry_object(obj: object) -> dict[str, Any]:
 def _build_case_status_object(obj: object) -> dict[str, Any]:
     object_id = _get_id(obj)
     case_context = _get_id(getattr(obj, "context", None))
+    attributed_to = _get_id(getattr(obj, "attributed_to", None))
     if object_id and case_context:
         return {
-            "object_": VultronCaseStatus(
+            "object_": CaseStatus(
                 id_=object_id,
                 name=getattr(obj, "name", None),
                 context=case_context,
-                attributed_to=_get_id(getattr(obj, "attributed_to", None)),
+                attributed_to=attributed_to,
                 em_state=getattr(obj, "em_state", None)
-                or VultronCaseStatus.model_fields["em_state"].default,
+                or CaseStatus.model_fields["em_state"].default,
                 pxa_state=getattr(obj, "pxa_state", None)
-                or VultronCaseStatus.model_fields["pxa_state"].default,
+                or CaseStatus.model_fields["pxa_state"].default,
             )
         }
     return {}
@@ -662,36 +663,37 @@ def _build_participant_status_object(obj: object) -> dict[str, Any]:
     ctx = _get_id(getattr(obj, "context", None)) or ""
     wire_case_status = getattr(obj, "case_status", None)
     if object_id:
-        # Extract embedded CaseStatus into a VultronCaseStatus core object so
+        # Extract embedded CaseStatus into a CaseStatus core object so
         # that pxa_state and em_state are propagated across the wire boundary.
-        core_case_status: VultronCaseStatus | None = None
+        core_case_status: CaseStatus | None = None
         if wire_case_status is not None:
             cs_id = _get_id(wire_case_status)
             cs_context = (
                 _get_id(getattr(wire_case_status, "context", None)) or ctx
             )
+            cs_attributed_to = _get_id(
+                getattr(wire_case_status, "attributed_to", None)
+            )
             if cs_id and cs_context:
-                core_case_status = VultronCaseStatus(
+                core_case_status = CaseStatus(
                     id_=cs_id,
                     context=cs_context,
-                    attributed_to=_get_id(
-                        getattr(wire_case_status, "attributed_to", None)
-                    ),
+                    attributed_to=cs_attributed_to,
                     em_state=getattr(wire_case_status, "em_state", None)
-                    or VultronCaseStatus.model_fields["em_state"].default,
+                    or CaseStatus.model_fields["em_state"].default,
                     pxa_state=getattr(wire_case_status, "pxa_state", None)
-                    or VultronCaseStatus.model_fields["pxa_state"].default,
+                    or CaseStatus.model_fields["pxa_state"].default,
                 )
         return {
-            "object_": VultronParticipantStatus(
+            "object_": ParticipantStatus(
                 id_=object_id,
                 name=getattr(obj, "name", None),
                 context=ctx,
                 attributed_to=_get_id(getattr(obj, "attributed_to", None)),
                 rm_state=getattr(obj, "rm_state", None)
-                or VultronParticipantStatus.model_fields["rm_state"].default,
+                or ParticipantStatus.model_fields["rm_state"].default,
                 vfd_state=getattr(obj, "vfd_state", None)
-                or VultronParticipantStatus.model_fields["vfd_state"].default,
+                or ParticipantStatus.model_fields["vfd_state"].default,
                 case_status=core_case_status,
             )
         }

--- a/vultron/wire/as2/vocab/objects/base.py
+++ b/vultron/wire/as2/vocab/objects/base.py
@@ -41,6 +41,24 @@ def _scalar_ref_id_or_value(value: Any) -> Any:
     return _ref_id_or_value(value)
 
 
+def _strip_core_context(data: dict[str, Any]) -> None:
+    """Recursively remove the CoreObject ``context_`` field from serialized data.
+
+    ``CoreObject`` adds a ``context_: None`` field for JSON-LD ``@context``
+    that conflicts with the wire base's required ``context_: str`` field.
+    This helper strips ``context_`` from the top-level dict and any nested
+    dicts (e.g. serialised ``case_statuses`` or ``participant_statuses``).
+    """
+    data.pop("context_", None)
+    for value in data.values():
+        if isinstance(value, dict):
+            _strip_core_context(value)
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, dict):
+                    _strip_core_context(item)
+
+
 class VultronAS2Object(as_Object):
     """Base class for all Vultron ActivityStreams Objects.
 
@@ -91,6 +109,7 @@ class VultronAS2Object(as_Object):
             A new instance of this wire type populated from ``core_obj``.
         """
         data: dict[str, Any] = core_obj.model_dump(mode="json")
+        _strip_core_context(data)
         for domain_field, wire_field in cls._field_map.items():
             if domain_field in data:
                 data[wire_field] = data.pop(domain_field)

--- a/vultron/wire/as2/vocab/objects/case_status.py
+++ b/vultron/wire/as2/vocab/objects/case_status.py
@@ -22,8 +22,10 @@ from typing import TypeAlias, cast
 
 from pydantic import Field, field_serializer, field_validator, model_validator
 
-from vultron.core.models.case_status import VultronCaseStatus
-from vultron.core.models.participant_status import VultronParticipantStatus
+from vultron.core.models.case_status import CaseStatus as CoreCaseStatus
+from vultron.core.models.participant_status import (
+    ParticipantStatus as CoreParticipantStatus,
+)
 from vultron.core.states.em import EM
 from vultron.core.states.rm import RM
 from vultron.core.states.cs import CS_pxa, CS_vfd
@@ -34,6 +36,7 @@ from vultron.wire.as2.vocab.base.objects.base import as_Object
 from vultron.wire.as2.vocab.objects.base import (
     VultronAS2Object,
     _scalar_ref_id_or_value,
+    _strip_core_context,
 )
 
 
@@ -82,10 +85,12 @@ class CaseStatus(VultronAS2Object):
         return self
 
     @classmethod
-    def from_core(cls, core_obj: VultronCaseStatus) -> "CaseStatus":
-        return cast("CaseStatus", super().from_core(core_obj))
+    def from_core(cls, core_obj: CoreCaseStatus) -> "CaseStatus":
+        data = core_obj.model_dump(mode="json")
+        _strip_core_context(data)
+        return cast("CaseStatus", cls.model_validate(data))
 
-    def to_core(self) -> VultronCaseStatus:
+    def to_core(self) -> CoreCaseStatus:
         data = self._to_core_data()
         data["attributed_to"] = _scalar_ref_id_or_value(
             data.get("attributed_to")
@@ -93,7 +98,7 @@ class CaseStatus(VultronAS2Object):
         data["context"] = _scalar_ref_id_or_value(data.get("context"))
         if isinstance(data.get("pxa_state"), str):
             data["pxa_state"] = CS_pxa[data["pxa_state"]]
-        return VultronCaseStatus.model_validate(data)
+        return CoreCaseStatus.model_validate(data)
 
 
 CaseStatusRef: TypeAlias = ActivityStreamRef[CaseStatus]
@@ -151,10 +156,9 @@ class ParticipantStatus(VultronAS2Object):
         return self
 
     @classmethod
-    def from_core(
-        cls, core_obj: VultronParticipantStatus
-    ) -> "ParticipantStatus":
+    def from_core(cls, core_obj: CoreParticipantStatus) -> "ParticipantStatus":
         data = core_obj.model_dump(mode="json")
+        _strip_core_context(data)
         case_status = data.get("case_status")
         if isinstance(case_status, str):
             # Legacy: case_status stored as bare ID string
@@ -163,18 +167,18 @@ class ParticipantStatus(VultronAS2Object):
                 context=data.get("context"),
                 attributed_to=data.get("attributed_to"),
             )
-        # If case_status is a dict (from VultronCaseStatus serialisation),
+        # If case_status is a dict (from CoreCaseStatus serialisation),
         # cls.model_validate will hydrate it into a CaseStatus instance.
         return cls.model_validate(data)
 
-    def to_core(self) -> VultronParticipantStatus:
+    def to_core(self) -> CoreParticipantStatus:
         data = self._to_core_data()
         data["attributed_to"] = _scalar_ref_id_or_value(
             data.get("attributed_to")
         )
         data["context"] = _scalar_ref_id_or_value(data.get("context"))
         # Convert embedded CaseStatus wire object (or its serialised dict) to
-        # VultronCaseStatus so pxa_state and em_state cross the boundary.
+        # CoreCaseStatus so pxa_state and em_state cross the boundary.
         wire_case_status = data.get("case_status")
         if isinstance(wire_case_status, CaseStatus):
             data["case_status"] = wire_case_status.to_core()
@@ -187,7 +191,7 @@ class ParticipantStatus(VultronAS2Object):
             data["case_status"] = None
         if isinstance(data.get("vfd_state"), str):
             data["vfd_state"] = CS_vfd[data["vfd_state"]]
-        return VultronParticipantStatus.model_validate(data)
+        return CoreParticipantStatus.model_validate(data)
 
 
 ParticipantStatusRef: TypeAlias = ActivityStreamRef[ParticipantStatus]

--- a/vultron/wire/as2/vocab/objects/vulnerability_case.py
+++ b/vultron/wire/as2/vocab/objects/vulnerability_case.py
@@ -30,6 +30,7 @@ from vultron.wire.as2.vocab.objects.base import (
     VultronAS2Object,
     _ref_id_or_value,
     _scalar_ref_id_or_value,
+    _strip_core_context,
 )
 from vultron.wire.as2.vocab.objects.case_event import CaseEvent
 from vultron.wire.as2.vocab.objects.case_participant import (
@@ -241,6 +242,7 @@ class VulnerabilityCase(VultronAS2Object):
     @classmethod
     def from_core(cls, core_obj: VultronCase) -> "VulnerabilityCase":
         data = core_obj.model_dump(mode="json")
+        _strip_core_context(data)
         data["case_activity"] = [
             (
                 as_Activity(

--- a/wip_notes
+++ b/wip_notes
@@ -1,0 +1,1 @@
+../../vultron_pub/wip_notes


### PR DESCRIPTION
Closes #725

## Summary

Replaces stub VultronCaseStatus / VultronParticipantStatus with proper
CaseStatus(CoreObject) and ParticipantStatus(CoreObject) domain types,
and makes the wire layer thin projections.

## Core changes

- **vultron/core/models/case_status.py**: New CaseStatus(CoreObject) with
  context (required), attributed_to (optional), em_state, pxa_state
- **vultron/core/models/participant_status.py**: New ParticipantStatus(CoreObject)
  with context (required), rm_state, vfd_state, case_status, tracking_id
- **CoreObject.context_ marked exclude=True**: prevents DataLayer round-trip
  failures; @context is a wire-layer concern, accepted on input but excluded
  from serialization output

## Wire layer

- CaseStatus / ParticipantStatus in the wire vocabulary become thin projections
  with from_core() / to_core() methods
- Added _strip_core_context() helper in wire base (defensive; context_ is now
  excluded at source)

## Rename

All VultronCaseStatus / VultronParticipantStatus references renamed across
18 source files and 14 test files.