### PR TITLE
specs: ingest idea #537 — InboxPipeline testable inbox seam

### DIFF
--- a/notes/inbox-pipeline.md
+++ b/notes/inbox-pipeline.md
@@ -1,0 +1,226 @@
+---
+title: Inbox Pipeline — InboxPipeline Design Notes
+status: active
+description: >
+  Design decisions, implementation guidance, and test patterns for the
+  `InboxPipeline` class and `build_test_pipeline()` factory that surface
+  the `inbox_handler → dispatcher` seam as a testable unit.
+related_notes:
+  - notes/architecture-ports.md
+  - notes/architecture-hexagonal.md
+  - notes/architecture-adapters.md
+relevant_packages:
+  - vultron/adapters/driving/fastapi
+  - vultron/core/ports
+  - test/adapters/driving/fastapi
+---
+
+# Inbox Pipeline — InboxPipeline Design Notes
+
+## Context
+
+`vultron/adapters/driving/fastapi/inbox_handler.py` implements the full inbox
+processing pipeline:
+
+```text
+inbox queue (activity ID string)
+  → rehydrate(id, dl)              # fetch + reconstruct full AS2 object
+  → extract_event(activity)        # AS2 → domain VultronEvent
+  → _dispatch_or_defer_inbox_item  # check case context, maybe defer
+  → dispatcher.dispatch(event, dl) # route to use-case
+  → use_case.execute()
+```
+
+All existing unit tests mock either `_DISPATCHER` or `prepare_for_dispatch`.
+No unit test exercises the real chain end-to-end. That flow is covered only
+by slow demo integration tests in `test/demo/`.
+
+**The risk**: if a new semantic type is added but its `USE_CASE_MAP` registration
+is forgotten, all mock-based unit tests pass and the failure only surfaces in
+production or the slow integration suite.
+
+---
+
+## Decision Table
+
+| Question | Decision | Rationale |
+|----------|----------|-----------|
+| Which pipeline path to wrap? | Full `_process_inbox_item` path | Surfaces deferral and error-requeue — the untested behaviors listed in the RFC |
+| Where should the class live? | `vultron/adapters/driving/fastapi/inbox_pipeline.py` | Co-located with `inbox_handler.py`; avoids a new layer |
+| Return type of `process()`? | `VultronEvent \| None` | `None` = clean signal that dispatch did not occur (deferred or error) |
+| Should `_DISPATCHER` global change? | No — pipeline is additive | `InboxPipeline` is a parallel path; production lifespan wiring is unchanged |
+| Factory function vs. fixture? | Both | Module-level `build_test_pipeline()` + `conftest.py` pytest fixture |
+| ADR needed? | No | Purely additive; no evaluated alternative was rejected (MS-11-005) |
+| Spec ID prefix? | `IBP` in `specs/inbox-pipeline.yaml` | Self-contained spec for the pipeline contract |
+| Test coverage scope? | One routing-safety-net test per semantic domain | ~7 tests catch registration gaps without full enum-value matrix |
+
+---
+
+## Class Design
+
+```python
+# vultron/adapters/driving/fastapi/inbox_pipeline.py
+
+class InboxPipeline:
+    """Single-item inbox processing seam for tests and adapter variants.
+
+    Wraps the full _process_inbox_item chain (rehydrate → extract → defer
+    or dispatch → requeue on error) with injected ports so callers do not
+    need to monkeypatch module-level globals.
+    """
+
+    def __init__(
+        self,
+        dispatcher: ActivityDispatcher,
+        dl: DataLayer,
+    ) -> None:
+        self._dispatcher = dispatcher
+        self._dl = dl
+
+    def process(self, activity_id: str) -> VultronEvent | None:
+        """Rehydrate + extract + dispatch one activity.
+
+        Returns the VultronEvent if the activity was dispatched, or None
+        if it was deferred or an error prevented dispatch.
+        """
+        ...
+
+
+def build_test_pipeline(dl: DataLayer) -> InboxPipeline:
+    """Construct a pipeline with real production wiring for test use.
+
+    Uses DirectActivityDispatcher with the real use_case_map() and the
+    same port factories that make_dispatcher() uses, so that routing-
+    safety-net tests fail immediately on USE_CASE_MAP registration gaps.
+    """
+    ...
+```
+
+---
+
+## Factory and Fixture Pattern
+
+### Module-level factory (in `inbox_pipeline.py`)
+
+```python
+def build_test_pipeline(dl: DataLayer) -> InboxPipeline:
+    from vultron.adapters.driving.fastapi.inbox_handler import (
+        _sync_port_factory,
+        _trigger_activity_port_factory,
+        make_dispatcher,
+    )
+    dispatcher = make_dispatcher()  # real use_case_map() + port factories
+    return InboxPipeline(dispatcher=dispatcher, dl=dl)
+```
+
+### pytest fixture (in `test/adapters/driving/fastapi/conftest.py`)
+
+```python
+import pytest
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.adapters.driving.fastapi.inbox_pipeline import (
+    InboxPipeline,
+    build_test_pipeline,
+)
+
+@pytest.fixture
+def test_pipeline() -> tuple[InboxPipeline, SqliteDataLayer]:
+    dl = SqliteDataLayer("sqlite:///:memory:")
+    pipeline = build_test_pipeline(dl)
+    return pipeline, dl
+```
+
+---
+
+## Routing-Safety-Net Test Pattern
+
+One test per semantic domain. Each test:
+
+1. Constructs the required domain objects with full URIs
+2. Saves them to the in-memory DataLayer
+3. Calls `pipeline.process(activity.id_)`
+4. Asserts `event.semantic_type == MessageSemantics.<EXPECTED>`
+5. Asserts the expected DataLayer side effect occurred
+
+```python
+def test_create_report_routes_correctly(test_pipeline):
+    pipeline, dl = test_pipeline
+
+    report = VulnerabilityReport(
+        id_="https://example.org/reports/r-1", ...
+    )
+    activity = rm_create_report_activity(
+        report=report,
+        actor="https://example.org/actors/reporter",
+        to=["https://example.org/actors/coordinator"],
+    )
+    dl.save(report)
+    dl.save(activity)
+
+    event = pipeline.process(activity.id_)
+
+    assert event is not None
+    assert event.semantic_type == MessageSemantics.CREATE_REPORT
+    # assert expected DataLayer side effect
+    assert dl.read(report.id_) is not None
+```
+
+### Semantic domains and representative test cases
+
+| Domain | Representative semantic type | Key side effect to assert |
+|--------|------------------------------|--------------------------|
+| Report | `CREATE_REPORT` | Report saved in DataLayer |
+| Case | `ANNOUNCE_VULNERABILITY_CASE` | Case saved or deferred |
+| Embargo | `OFFER_EMBARGO` | Embargo offer recorded |
+| Note | `CREATE_NOTE` | Note attached to case |
+| Actor | `ANNOUNCE_ACTOR` | Actor profile saved |
+| Status | `ANNOUNCE_CASE_STATUS` | Case status updated |
+| Sync | `ANNOUNCE_LOG_ENTRY` | Log entry persisted |
+
+### Deferral path test pattern
+
+```python
+def test_activity_with_unknown_case_is_deferred(test_pipeline):
+    pipeline, dl = test_pipeline
+    # activity referencing a case not yet in dl
+    ...
+    result = pipeline.process(activity.id_)
+
+    assert result is None  # not dispatched
+    # activity ID appears in pending-case inbox
+    pending = dl.get("pending_case_inbox", ...)
+    assert activity.id_ in pending
+```
+
+---
+
+## Layer and Import Rules
+
+- `InboxPipeline` is an **adapter-layer** class; it MAY import from
+  `inbox_handler.py` helpers and core ports.
+- `InboxPipeline` MUST NOT be imported by any core-layer module
+  (`vultron/core/`).
+- `build_test_pipeline()` MAY import `make_dispatcher()` from
+  `inbox_handler.py` since both are in the same adapter package.
+- The pytest fixture belongs in
+  `test/adapters/driving/fastapi/conftest.py` — not in a top-level
+  conftest — to keep its scope narrow.
+
+---
+
+## Migration Guide for Existing Tests
+
+Existing mock-based tests in
+`test/adapters/driving/fastapi/test_inbox_handler.py` remain valid for
+fast unit coverage of `inbox_handler.py` internals. Do **not** delete them.
+
+New routing-safety-net tests go in the separate
+`test/adapters/driving/fastapi/test_inbox_pipeline.py` file. They
+complement, not replace, the mock-based tests.
+
+```text
+test/adapters/driving/fastapi/
+  test_inbox_handler.py       # existing — keep as-is
+  test_inbox_pipeline.py      # new — routing safety net
+  conftest.py                 # add test_pipeline fixture here
+```

--- a/plan/history/2606/idea/IDEA-537.md
+++ b/plan/history/2606/idea/IDEA-537.md
@@ -1,0 +1,64 @@
+---
+source: IDEA-537
+timestamp: '2026-06-04T15:06:53.199636+00:00'
+title: InboxPipeline testable inbox seam
+type: idea
+---
+
+## RFC: Add `InboxPipeline` to surface the `inbox_handler → dispatcher` seam as a testable unit
+
+### Problem
+
+`vultron/adapters/driving/fastapi/inbox_handler.py` (372 lines) implements the
+full inbox processing pipeline:
+
+```text
+inbox queue (activity ID string)
+  → rehydrate(id, dl)              # fetch + reconstruct full AS2 object
+  → extract_event(activity)        # AS2 → domain VultronEvent
+  → _dispatch_or_defer_inbox_item  # check case context, maybe defer
+  → dispatcher.dispatch(event, dl) # route to use-case
+  → use_case.execute()
+```
+
+All 7 existing unit tests mock either `_DISPATCHER` or `prepare_for_dispatch`.
+No unit test exercises the real chain end-to-end. That flow is only covered by
+slow demo integration tests (`test/demo/`).
+
+**The risk this creates**: if a new semantic type is added but its
+`use_case_map()` registration is forgotten, all existing unit tests pass and
+the failure only surfaces in production (or the slow integration suite).
+
+**Untested behaviors in the real pipeline:**
+
+- The correct use-case fires for each semantic type
+- Activity with unknown case context → deferred, not dispatched
+- `ANNOUNCE_VULNERABILITY_CASE` → deferred activities replayed
+- Error handling: use-case raises → activity re-queued, error count tracked
+
+The `ActivityDispatcher` and `DataLayer` ports already exist and are the right
+injection points — they are just not used this way today because the dispatcher
+is a module-level global (`_DISPATCHER`) initialized at startup.
+
+### Proposed Interface
+
+Add a small `InboxPipeline` class and `build_test_pipeline()` factory that
+honour the existing ports and make the real pipeline testable without mocks.
+
+The existing `inbox_handler.py` module-level global `_DISPATCHER` is unchanged
+— `InboxPipeline` is a parallel path for tests and future adapter variants,
+not a rewrite.
+
+### Design decisions (resolved during ingestion)
+
+- Pipeline path: full `_process_inbox_item` (deferral + error requeue)
+- Location: `vultron/adapters/driving/fastapi/inbox_pipeline.py`
+- Return type: `VultronEvent | None` (None on deferral or error)
+- Factory + pytest fixture in conftest.py
+- No ADR (purely additive, no evaluated alternatives)
+- Spec prefix: IBP in `specs/inbox-pipeline.yaml`
+- Test scope: one routing-safety-net test per semantic domain (~7 tests)
+
+**Processed**: 2026-06-04 — design decisions captured in
+`specs/inbox-pipeline.yaml` (IBP-01 through IBP-04) and `notes/inbox-pipeline.md`.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/768>. Implementation tracked in #769.

--- a/specs/README.md
+++ b/specs/README.md
@@ -70,6 +70,7 @@ Load additional files only when the task touches the relevant area. See the
 | Case bootstrap trust establishment | `case-bootstrap-trust.yaml`, `participant-case-replica.yaml`, `actor-knowledge-model.yaml` |
 | DataLayer adapter | `datalayer.md` |
 | Handler pipeline | `inbox-endpoint.yaml`, `message-validation.yaml`, `semantic-extraction.yaml`, `dispatch-routing.yaml` |
+| Inbox pipeline testability | `inbox-pipeline.yaml` |
 | Behavior Trees | `behavior-tree-integration.yaml`, `behavior-tree-node-design.yaml`, `bt-composability.yaml`, `triggerable-behaviors.yaml`, `notes/trigger-classification.md` |
 | Case / state management | `case-management.yaml`, `state-machine.yaml`, `case-log-processing.yaml` |
 | Protocol conformance | `vultron-protocol-spec.yaml`, `vultron-as2-mapping.yaml` |
@@ -139,6 +140,10 @@ Specifications are organized by topic with minimal overlap. Cross-references lin
 3. **`semantic-extraction.yaml`** - Pattern matching to determine message semantics
 4. **`dispatch-routing.yaml`** - Routing DispatchEvent to handler functions
 5. **`handler-protocol.yaml`** - Handler function contract and implementation patterns
+
+- **`inbox-pipeline.yaml`** - `InboxPipeline` class contract and `build_test_pipeline()`
+  factory that surface the `inbox_handler → dispatcher` seam as a testable unit;
+  routing-safety-net test coverage requirements (IBP-01 through IBP-04)
 
 **DataLayer Port**:
 
@@ -434,6 +439,7 @@ is reserved for `testability.yaml`).
 | `EP` | `embargo-policy.yaml` |
 | `HP` | `handler-protocol.yaml` |
 | `HTTP` | `http-protocol.yaml` |
+| `IBP` | `inbox-pipeline.yaml` |
 | `IE` | `inbox-endpoint.yaml` |
 | `IMPLTS` | `tech-stack.yaml` |
 | `MV` | `message-validation.yaml` |

--- a/specs/inbox-pipeline.yaml
+++ b/specs/inbox-pipeline.yaml
@@ -1,0 +1,166 @@
+id: IBP
+title: Inbox Pipeline
+description: >-
+  `InboxPipeline` is a small injectable class that exposes the full
+  `rehydrate → prepare_for_dispatch → _dispatch_or_defer` chain as a single
+  testable unit. It honours the existing `ActivityDispatcher` and `DataLayer`
+  ports so that tests can drive the real pipeline with in-memory adapters
+  instead of mocking internal functions.  The module-level `_DISPATCHER`
+  global in `inbox_handler.py` is unchanged; `InboxPipeline` is a parallel
+  surface for tests and future adapter variants.
+version: 1.0.0
+kind: domain
+scope:
+- prototype
+- production
+groups:
+- id: IBP-01
+  title: InboxPipeline Class Contract
+  specs:
+  - id: IBP-01-001
+    priority: MUST
+    statement: >-
+      `InboxPipeline` MUST accept an `ActivityDispatcher` and a `DataLayer`
+      as constructor parameters and store them as private attributes.
+    rationale: >-
+      Injection via constructor makes the pipeline testable with any
+      compliant adapter pair — including in-memory test doubles — without
+      monkeypatching module-level globals.
+  - id: IBP-01-002
+    priority: MUST
+    statement: >-
+      `InboxPipeline.process(activity_id: str)` MUST execute the full inbox
+      processing chain: rehydrate the activity from the DataLayer, extract
+      the domain event, check case context, defer or dispatch as appropriate,
+      and handle errors with requeue logic.
+    rationale: >-
+      Wrapping the full `_process_inbox_item` path (not the simpler
+      `handle_inbox_item`) ensures that deferral and error-requeue behaviours
+      are exercisable in unit tests.
+    relationships:
+    - rel_type: depends_on
+      spec_id: DR-01-001
+  - id: IBP-01-003
+    priority: MUST
+    statement: >-
+      `InboxPipeline.process()` MUST return the `VultronEvent` when the
+      activity was dispatched, and MUST return `None` when the activity was
+      deferred or an error prevented dispatch.
+    rationale: >-
+      A `None` return is an unambiguous signal to routing-safety-net tests
+      that dispatch did not occur, without requiring the test to inspect
+      DataLayer side-effects.
+  - id: IBP-01-004
+    priority: MUST_NOT
+    statement: >-
+      `InboxPipeline` MUST NOT replace or modify the module-level `_DISPATCHER`
+      global or the `init_dispatcher()` / `dispatch()` functions in
+      `inbox_handler.py`.
+    rationale: >-
+      The pipeline is a parallel path; the existing lifespan wiring remains
+      the canonical production entry point.
+- id: IBP-02
+  title: Factory Functions
+  specs:
+  - id: IBP-02-001
+    priority: MUST
+    statement: >-
+      A `build_test_pipeline(dl: DataLayer) -> InboxPipeline` module-level
+      factory function MUST be provided in the same module as `InboxPipeline`.
+    rationale: >-
+      A named factory hides `DirectActivityDispatcher` construction,
+      `use_case_map()` lookup, and port-factory wiring so that tests remain
+      focused on behaviour rather than plumbing.
+  - id: IBP-02-002
+    priority: MUST
+    statement: >-
+      `build_test_pipeline()` MUST construct a `DirectActivityDispatcher`
+      with the real `use_case_map()` and the same port factories that
+      `make_dispatcher()` uses in production.
+    rationale: >-
+      Using production wiring guarantees that routing-safety-net tests fail
+      immediately when a `USE_CASE_MAP` registration is missing or a
+      use-case constructor signature drifts.
+    relationships:
+    - rel_type: depends_on
+      spec_id: DR-02-001
+  - id: IBP-02-003
+    priority: SHOULD
+    statement: >-
+      A pytest fixture named `test_pipeline` SHOULD be provided in a
+      `conftest.py` file in the test directory that exercises `InboxPipeline`,
+      yielding a `(InboxPipeline, DataLayer)` tuple backed by an in-memory
+      `SqliteDataLayer("sqlite:///:memory:")`.
+    rationale: >-
+      A shared fixture eliminates per-test boilerplate and ensures every
+      routing-safety-net test starts with an identical, isolated DataLayer.
+- id: IBP-03
+  title: Module Location
+  kind: implementation
+  specs:
+  - id: IBP-03-001
+    priority: MUST
+    statement: >-
+      `InboxPipeline` and `build_test_pipeline()` MUST be defined in
+      `vultron/adapters/driving/fastapi/inbox_pipeline.py`.
+    rationale: >-
+      Co-locating the pipeline with `inbox_handler.py` makes the seam
+      explicit and avoids introducing a new adapter layer just for
+      testability.
+  - id: IBP-03-002
+    priority: MUST_NOT
+    statement: >-
+      `inbox_pipeline.py` MUST NOT import from `inbox_handler.py`'s private
+      helpers (`_DISPATCHER`, `_process_inbox_item`, `_dispatch_or_defer_inbox_item`)
+      by name as module-level globals.
+    rationale: >-
+      The pipeline MUST call the helpers as functions, not bind to their
+      module-level identities, so that future refactoring of `inbox_handler.py`
+      does not silently break the pipeline.
+- id: IBP-04
+  title: Routing-Safety-Net Test Coverage
+  kind: implementation
+  specs:
+  - id: IBP-04-001
+    priority: MUST
+    statement: >-
+      At least one routing-safety-net test MUST exist per semantic domain
+      (report, case, embargo, note, actor, status, sync) asserting that the
+      correct use case fires and produces the expected DataLayer side effect.
+    rationale: >-
+      Per-domain coverage catches `USE_CASE_MAP` registration gaps immediately
+      without requiring exhaustive per-enum-value tests.
+    relationships:
+    - rel_type: depends_on
+      spec_id: DR-02-002
+    - rel_type: depends_on
+      spec_id: TB-02-002
+  - id: IBP-04-002
+    priority: MUST
+    statement: >-
+      A routing-safety-net test MUST use `build_test_pipeline()` (real wiring)
+      and MUST NOT mock `_DISPATCHER`, `prepare_for_dispatch`, or
+      `USE_CASE_MAP`.
+    rationale: >-
+      Mocking the exact symbols the test is supposed to exercise defeats the
+      purpose of a routing safety net.
+  - id: IBP-04-003
+    priority: MUST
+    statement: >-
+      Tests that exercise the deferral path MUST assert that `process()`
+      returns `None` and that the activity ID appears in the pending-case
+      inbox after the call.
+  - id: IBP-04-004
+    priority: SHOULD
+    statement: >-
+      Routing-safety-net tests SHOULD be placed in
+      `test/adapters/driving/fastapi/test_inbox_pipeline.py` and SHOULD NOT
+      require the `@pytest.mark.integration` marker, since they use only
+      in-memory adapters.
+    rationale: >-
+      Keeping these tests in the unit suite ensures they run on every local
+      `pytest` invocation, providing fast feedback without needing the full
+      integration environment.
+    relationships:
+    - rel_type: depends_on
+      spec_id: TB-04-001


### PR DESCRIPTION
Docs-only PR: adds spec and notes for idea #537.

Adds `InboxPipeline` contract and `build_test_pipeline()` factory spec
so that the inbox→dispatcher seam can be tested with real adapters rather
than mocks.

**Changes:**
- `specs/inbox-pipeline.yaml` (IBP-01 through IBP-04, 13 requirements)
- `notes/inbox-pipeline.md` with decision table, test patterns, migration guide
- `specs/README.md` updated (Load Contextually table + Specification Structure)

Ref #537

No .py files changed.