### PR TITLE
Move pre-BT domain work into BT nodes for engage/defer/add-note (#712)

### DIFF
--- a/plan/history/2606/implementation/ISSUE-712.md
+++ b/plan/history/2606/implementation/ISSUE-712.md
@@ -1,0 +1,69 @@
+---
+source: ISSUE-712
+timestamp: '2026-06-04T15:30:35.994232+00:00'
+title: Move pre-BT domain work into BT nodes for engage/defer/add-note
+type: implementation
+---
+
+## Issue #712 — Move pre-BT domain work into BT leaf nodes
+
+Moved protocol-significant domain operations out of pre-BT procedural
+sections in trigger use cases and into BT leaf nodes, making them
+visible to BT analysis and auditing tools.
+
+### Changes
+
+**New BT nodes** (`vultron/core/behaviors/note/nodes.py`):
+
+- `CreateNoteNode` — creates and persists a note via `TriggerActivityPort`,
+  writes `note_id`/`note_dict` to a shared `result_out` dict
+- `AttachNoteFromResultNode` — reads `note_id` from `result_out` at
+  execution time and appends it to the case's `notes` list (idempotent)
+
+**New BT factory functions**:
+
+- `engage_case_trigger_bt()` in
+  `vultron/core/behaviors/case/engage_defer_trigger_tree.py` — sequences
+  `TransitionParticipantRMtoAccepted → sender_side_bt`
+- `defer_case_trigger_bt()` — sequences
+  `TransitionParticipantRMtoDeferred → sender_side_bt`
+- `add_note_to_case_trigger_bt()` in
+  `vultron/core/behaviors/note/add_note_trigger_tree.py` — sequences
+  `CreateNoteNode → AttachNoteFromResultNode → sender_side_bt`
+
+**Use case changes**:
+
+- `SvcEngageCaseUseCase`: removed pre-BT `update_participant_rm_state`
+  call; now uses `engage_case_trigger_bt()`
+- `SvcDeferCaseUseCase`: removed pre-BT `update_participant_rm_state`
+  call; now uses `defer_case_trigger_bt()`
+- `SvcAddNoteToCaseUseCase`: removed pre-BT `factory.create_note()` and
+  inline case attachment block; now uses `add_note_to_case_trigger_bt()`
+  with `result_out` dict pattern
+
+**Test fixture fixes**:
+
+- Fixed `case_participants` not populated in `_make_case_with_case_manager`
+  helpers in `test_trignotify.py` and `test_note_trigger.py` — the helpers
+  only populated `actor_participant_index` but `update_participant_rm_state`
+  iterates `case.case_participants`; this was a silent bug in all prior tests
+- Pre-advance actor participants to `RM.VALID` so engage/defer transitions
+  (`VALID → ACCEPTED`, `VALID → DEFERRED`) are state-machine-valid
+
+**Behavior change**: engage-case with no participant record now raises
+`VultronValidationError` (HTTP 422) instead of silently succeeding.
+The old test `test_trigger_engage_case_no_participant_returns_202_with_warning`
+was renamed and updated to assert 422.
+
+**New BT-path tests** (`test/core/use_cases/triggers/test_case_engage_defer.py`):
+
+- `test_engage_case_updates_rm_to_accepted_via_bt` — verifies RM.ACCEPTED
+  via DataLayer re-read after execute()
+- `test_defer_case_updates_rm_to_deferred_via_bt` — verifies RM.DEFERRED
+- `test_add_note_creates_note_via_bt` — verifies note in result and note_id
+  in `case.notes`
+- `test_add_note_returns_activity_via_bt` — verifies activity dict returned
+- `test_engage_case_rm_not_updated_when_no_participant` — documents failure
+  semantics
+
+All 2680 tests pass. PR: [#770](https://github.com/CERTCC/Vultron/pull/770)

--- a/test/adapters/driving/fastapi/routers/test_trigger_case.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_case.py
@@ -322,10 +322,15 @@ def test_trigger_engage_case_updates_participant_rm_state(
     assert found_accepted, "Participant RM state was not updated to ACCEPTED"
 
 
-def test_trigger_engage_case_no_participant_returns_202_with_warning(
+def test_trigger_engage_case_no_participant_returns_422(
     client_triggers, actor, case_without_participant, caplog
 ):
-    """engage-case succeeds and warns when actor has no participant record."""
+    """engage-case returns 422 when actor has no participant record in the case.
+
+    Pre-#712: the RM update silently failed and 202 was returned anyway.
+    Post-#712: the RM transition node is inside the BT; when it fails the BT
+    raises VultronValidationError which the router translates to HTTP 422.
+    """
     import logging
 
     with caplog.at_level(logging.WARNING):
@@ -333,7 +338,7 @@ def test_trigger_engage_case_no_participant_returns_202_with_warning(
             f"/actors/{actor.id_}/trigger/engage-case",
             json={"case_id": case_without_participant.id_},
         )
-    assert resp.status_code == status.HTTP_202_ACCEPTED
+    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
     assert any("participant" in r.message.lower() for r in caplog.records)
 
 

--- a/test/core/use_cases/triggers/test_case_engage_defer.py
+++ b/test/core/use_cases/triggers/test_case_engage_defer.py
@@ -170,6 +170,7 @@ class TestEngageCaseRMTransitionViaBT:
         # Re-read participant from DataLayer to confirm BT wrote the change
         updated = self.dl.read(self.vendor_participant.id_)
         assert updated is not None
+        assert isinstance(updated, CaseParticipant)
         assert (
             updated.participant_statuses
         ), "Expected at least one ParticipantStatus after engage"
@@ -246,6 +247,7 @@ class TestDeferCaseRMTransitionViaBT:
         # Re-read participant from DataLayer to confirm BT wrote the change
         updated = self.dl.read(self.vendor_participant.id_)
         assert updated is not None
+        assert isinstance(updated, CaseParticipant)
         assert (
             updated.participant_statuses
         ), "Expected at least one ParticipantStatus after defer"
@@ -307,6 +309,7 @@ class TestAddNoteToCaseViaBT:
         # The case's notes list should contain the new note id
         updated_case = self.dl.read(self.case.id_)
         assert updated_case is not None
+        assert isinstance(updated_case, VulnerabilityCase)
         assert (
             len(updated_case.notes) >= 1
         ), "Expected case.notes to contain the new note after BT-driven attachment"

--- a/test/core/use_cases/triggers/test_case_engage_defer.py
+++ b/test/core/use_cases/triggers/test_case_engage_defer.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""
+BT-path tests for engage-case, defer-case, and add-note-to-case trigger use cases.
+
+Satisfies #712 AC-3: verifies that RM state transitions (engage/defer) and note
+creation/attachment are performed *inside* the behavior tree, not in pre-BT
+procedural code.
+
+Failure semantics (documented by design):
+- If the sender subtree fails (no Case Manager in DL), the RM state IS updated
+  but no activity is sent.  This preserves the old behavior where the pre-BT
+  RM update always ran before the BT.
+"""
+
+import pytest
+
+from vultron.adapters.driven.datalayer_sqlite import (
+    SqliteDataLayer,
+    reset_datalayer,
+)
+from vultron.adapters.driven.trigger_activity_adapter import (
+    TriggerActivityAdapter,
+)
+from vultron.core.states.rm import RM
+from vultron.core.states.roles import CVDRole
+from vultron.errors import VultronValidationError
+from vultron.core.use_cases.triggers.case import (
+    DeferCaseTriggerRequest,
+    EngageCaseTriggerRequest,
+    SvcDeferCaseUseCase,
+    SvcEngageCaseUseCase,
+)
+from vultron.core.use_cases.triggers.note import (
+    AddNoteToCaseTriggerRequest,
+    SvcAddNoteToCaseUseCase,
+)
+from vultron.wire.as2.vocab.base.objects.actors import as_Service
+from vultron.wire.as2.vocab.objects.case_participant import (
+    CaseParticipant,
+    FinderParticipant,
+)
+from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_actor(name: str) -> as_Service:
+    return as_Service(name=name, url=f"https://example.org/{name.lower()}")
+
+
+def _make_actor_dl(name: str) -> tuple[as_Service, SqliteDataLayer]:
+    actor = _make_actor(name)
+    dl = SqliteDataLayer("sqlite:///:memory:", actor_id=actor.id_)
+    dl.clear_all()
+    dl.create(actor)
+    return actor, dl
+
+
+def _make_case_with_case_manager(
+    dl: SqliteDataLayer,
+    actor_id: str,
+    finder_id: str,
+    case_actor_id: str,
+) -> tuple[VulnerabilityCase, CaseParticipant]:
+    """Create a VulnerabilityCase with all participants in both index and list.
+
+    The actor participant is pre-initialized to RM.VALID so that
+    engage (→ ACCEPTED) and defer (→ DEFERRED) transitions are valid.
+    """
+    case = VulnerabilityCase(name="Test Case")
+
+    actor_participant = CaseParticipant(
+        attributed_to=actor_id,
+        context=case.id_,
+        case_roles=[CVDRole.VENDOR],
+    )
+    # Pre-advance actor to RM.VALID so engage/defer transitions will succeed
+    from vultron.wire.as2.vocab.objects.case_status import (
+        ParticipantStatus as WireParticipantStatus,
+    )
+
+    actor_participant.participant_statuses.append(
+        WireParticipantStatus(context=case.id_, rm_state=RM.RECEIVED)
+    )
+    actor_participant.participant_statuses.append(
+        WireParticipantStatus(context=case.id_, rm_state=RM.VALID)
+    )
+
+    finder_participant = FinderParticipant(
+        attributed_to=finder_id,
+        context=case.id_,
+    )
+    case_manager_participant = CaseParticipant(
+        attributed_to=case_actor_id,
+        context=case.id_,
+        case_roles=[CVDRole.CASE_MANAGER],
+    )
+
+    case.actor_participant_index[actor_id] = actor_participant.id_
+    case.actor_participant_index[finder_id] = finder_participant.id_
+    case.actor_participant_index[case_actor_id] = case_manager_participant.id_
+
+    # Required so update_participant_rm_state() can find the participant
+    case.case_participants.append(actor_participant.id_)
+    case.case_participants.append(finder_participant.id_)
+    case.case_participants.append(case_manager_participant.id_)
+
+    dl.create(case)
+    dl.create(actor_participant)
+    dl.create(finder_participant)
+    dl.create(case_manager_participant)
+    return case, actor_participant
+
+
+# ---------------------------------------------------------------------------
+# Engage-case BT-path tests (AC-3, #712)
+# ---------------------------------------------------------------------------
+
+
+class TestEngageCaseRMTransitionViaBT:
+    """RM state transition for engage-case happens inside the BT (AC-1 + AC-3)."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.vendor, self.dl = _make_actor_dl("Vendor Co")
+        self.finder, _ = _make_actor_dl("Finder Co")
+        self.case_actor, _ = _make_actor_dl("Case Actor")
+        self.case, self.vendor_participant = _make_case_with_case_manager(
+            self.dl,
+            self.vendor.id_,
+            self.finder.id_,
+            self.case_actor.id_,
+        )
+        yield
+        self.dl.clear_all()
+        reset_datalayer(self.vendor.id_)
+        reset_datalayer(self.finder.id_)
+        reset_datalayer(self.case_actor.id_)
+
+    def test_engage_case_updates_rm_to_accepted_via_bt(self):
+        """After SvcEngageCaseUseCase.execute(), the actor's RM state is ACCEPTED.
+
+        This verifies AC-1 + AC-3: the RM transition now runs inside the BT
+        (TransitionParticipantRMtoAccepted node), not in pre-BT procedural code.
+        """
+        request = EngageCaseTriggerRequest(
+            actor_id=self.vendor.id_,
+            case_id=self.case.id_,
+        )
+        SvcEngageCaseUseCase(
+            self.dl, request, trigger_activity=TriggerActivityAdapter(self.dl)
+        ).execute()
+
+        # Re-read participant from DataLayer to confirm BT wrote the change
+        updated = self.dl.read(self.vendor_participant.id_)
+        assert updated is not None
+        assert (
+            updated.participant_statuses
+        ), "Expected at least one ParticipantStatus after engage"
+        assert (
+            updated.participant_statuses[-1].rm_state == RM.ACCEPTED
+        ), f"Expected RM.ACCEPTED, got {updated.participant_statuses[-1].rm_state}"
+
+    def test_engage_case_rm_not_updated_when_no_participant(self):
+        """When participant is NOT in case_participants, the BT transitions
+        RM FAIL path and VultronValidationError is raised.
+
+        Documents failure semantics: the old code silently skipped the RM
+        update when the participant was absent; the BT now surfaces this as
+        an explicit failure.
+        """
+        # Build a case with only actor_participant_index (not case_participants)
+        case_solo = VulnerabilityCase(name="Solo Case")
+        case_solo.actor_participant_index[self.vendor.id_] = (
+            f"{case_solo.id_}/participants/vendor"
+        )
+        self.dl.create(case_solo)
+
+        request = EngageCaseTriggerRequest(
+            actor_id=self.vendor.id_,
+            case_id=case_solo.id_,
+        )
+        with pytest.raises(VultronValidationError):
+            SvcEngageCaseUseCase(
+                self.dl,
+                request,
+                trigger_activity=TriggerActivityAdapter(self.dl),
+            ).execute()
+
+
+# ---------------------------------------------------------------------------
+# Defer-case BT-path tests (AC-3, #712)
+# ---------------------------------------------------------------------------
+
+
+class TestDeferCaseRMTransitionViaBT:
+    """RM state transition for defer-case happens inside the BT (AC-1 + AC-3)."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.vendor, self.dl = _make_actor_dl("Vendor Co")
+        self.finder, _ = _make_actor_dl("Finder Co")
+        self.case_actor, _ = _make_actor_dl("Case Actor")
+        self.case, self.vendor_participant = _make_case_with_case_manager(
+            self.dl,
+            self.vendor.id_,
+            self.finder.id_,
+            self.case_actor.id_,
+        )
+        yield
+        self.dl.clear_all()
+        reset_datalayer(self.vendor.id_)
+        reset_datalayer(self.finder.id_)
+        reset_datalayer(self.case_actor.id_)
+
+    def test_defer_case_updates_rm_to_deferred_via_bt(self):
+        """After SvcDeferCaseUseCase.execute(), the actor's RM state is DEFERRED.
+
+        This verifies AC-1 + AC-3: the RM transition now runs inside the BT
+        (TransitionParticipantRMtoDeferred node), not in pre-BT procedural code.
+        """
+        request = DeferCaseTriggerRequest(
+            actor_id=self.vendor.id_,
+            case_id=self.case.id_,
+        )
+        SvcDeferCaseUseCase(
+            self.dl, request, trigger_activity=TriggerActivityAdapter(self.dl)
+        ).execute()
+
+        # Re-read participant from DataLayer to confirm BT wrote the change
+        updated = self.dl.read(self.vendor_participant.id_)
+        assert updated is not None
+        assert (
+            updated.participant_statuses
+        ), "Expected at least one ParticipantStatus after defer"
+        assert (
+            updated.participant_statuses[-1].rm_state == RM.DEFERRED
+        ), f"Expected RM.DEFERRED, got {updated.participant_statuses[-1].rm_state}"
+
+
+# ---------------------------------------------------------------------------
+# Add-note-to-case BT-path tests (AC-2 + AC-3, #712)
+# ---------------------------------------------------------------------------
+
+
+class TestAddNoteToCaseViaBT:
+    """Note creation and attachment happen inside the BT (AC-2 + AC-3)."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.vendor, self.dl = _make_actor_dl("Vendor Co")
+        self.finder, _ = _make_actor_dl("Finder Co")
+        self.case_actor, _ = _make_actor_dl("Case Actor")
+        self.case, self.vendor_participant = _make_case_with_case_manager(
+            self.dl,
+            self.vendor.id_,
+            self.finder.id_,
+            self.case_actor.id_,
+        )
+        yield
+        self.dl.clear_all()
+        reset_datalayer(self.vendor.id_)
+        reset_datalayer(self.finder.id_)
+        reset_datalayer(self.case_actor.id_)
+
+    def test_add_note_creates_note_via_bt(self):
+        """SvcAddNoteToCaseUseCase returns a note object and the note_id is in
+        the case's notes list.
+
+        This verifies AC-2 + AC-3: note creation now runs inside the BT
+        (CreateNoteNode), and attachment runs inside the BT
+        (AttachNoteFromResultNode), not in pre-BT procedural code.
+        """
+        request = AddNoteToCaseTriggerRequest(
+            actor_id=self.vendor.id_,
+            case_id=self.case.id_,
+            note_name="Test Note",
+            note_content="This is a test note content.",
+        )
+        result = SvcAddNoteToCaseUseCase(
+            self.dl,
+            request,
+            trigger_activity=TriggerActivityAdapter(self.dl),
+        ).execute()
+
+        # The returned note should be non-None (BT created it)
+        assert (
+            result.get("note") is not None
+        ), "Expected note dict in result after BT-driven creation"
+
+        # The case's notes list should contain the new note id
+        updated_case = self.dl.read(self.case.id_)
+        assert updated_case is not None
+        assert (
+            len(updated_case.notes) >= 1
+        ), "Expected case.notes to contain the new note after BT-driven attachment"
+
+    def test_add_note_returns_activity_via_bt(self):
+        """SvcAddNoteToCaseUseCase returns an activity dict built inside the BT."""
+        request = AddNoteToCaseTriggerRequest(
+            actor_id=self.vendor.id_,
+            case_id=self.case.id_,
+            note_name="Activity Note",
+            note_content="Content for activity test.",
+        )
+        result = SvcAddNoteToCaseUseCase(
+            self.dl,
+            request,
+            trigger_activity=TriggerActivityAdapter(self.dl),
+        ).execute()
+
+        assert (
+            result.get("activity") is not None
+        ), "Expected activity dict in result"

--- a/test/core/use_cases/triggers/test_note_trigger.py
+++ b/test/core/use_cases/triggers/test_note_trigger.py
@@ -73,7 +73,15 @@ def _make_case_with_case_manager(
     participant (CVDRole.CASE_MANAGER).
 
     Returns the case and the Case Manager CaseParticipant.
+
+    The actor participant is pre-initialized to RM.VALID so that
+    engage (→ ACCEPTED) and defer (→ DEFERRED) transitions are valid.
     """
+    from vultron.core.states.rm import RM
+    from vultron.wire.as2.vocab.objects.case_status import (
+        ParticipantStatus as WireParticipantStatus,
+    )
+
     case = VulnerabilityCase(name="Test Case")
 
     finder_participant = FinderParticipant(
@@ -90,10 +98,22 @@ def _make_case_with_case_manager(
         context=case.id_,
         case_roles=[CVDRole.VENDOR],
     )
+    # Pre-advance actor to RM.VALID so engage/defer transitions will succeed
+
+    actor_participant.participant_statuses.append(
+        WireParticipantStatus(context=case.id_, rm_state=RM.RECEIVED)
+    )
+    actor_participant.participant_statuses.append(
+        WireParticipantStatus(context=case.id_, rm_state=RM.VALID)
+    )
 
     case.actor_participant_index[actor_id] = actor_participant.id_
     case.actor_participant_index[finder_id] = finder_participant.id_
     case.actor_participant_index[case_actor_id] = case_manager_participant.id_
+
+    case.case_participants.append(actor_participant.id_)
+    case.case_participants.append(finder_participant.id_)
+    case.case_participants.append(case_manager_participant.id_)
 
     dl.create(case)
     dl.create(finder_participant)

--- a/test/core/use_cases/triggers/test_trignotify.py
+++ b/test/core/use_cases/triggers/test_trignotify.py
@@ -101,7 +101,15 @@ def _make_case_with_case_manager(
 ) -> VulnerabilityCase:
     """Create a VulnerabilityCase with a Finder participant and a Case Actor
     (CVDRole.CASE_MANAGER).  Persists all objects in *dl*.
+
+    The actor participant is pre-initialized to RM.VALID so that
+    engage (→ ACCEPTED) and defer (→ DEFERRED) transitions are valid.
     """
+    from vultron.core.states.rm import RM
+    from vultron.wire.as2.vocab.objects.case_status import (
+        ParticipantStatus as WireParticipantStatus,
+    )
+
     case = VulnerabilityCase(name="Test Case")
 
     actor_participant = CaseParticipant(
@@ -109,6 +117,15 @@ def _make_case_with_case_manager(
         context=case.id_,
         case_roles=[CVDRole.VENDOR],
     )
+    # Pre-advance actor to RM.VALID so engage/defer transitions will succeed
+
+    actor_participant.participant_statuses.append(
+        WireParticipantStatus(context=case.id_, rm_state=RM.RECEIVED)
+    )
+    actor_participant.participant_statuses.append(
+        WireParticipantStatus(context=case.id_, rm_state=RM.VALID)
+    )
+
     finder_participant = FinderParticipant(
         attributed_to=finder_id,
         context=case.id_,
@@ -122,6 +139,10 @@ def _make_case_with_case_manager(
     case.actor_participant_index[actor_id] = actor_participant.id_
     case.actor_participant_index[finder_id] = finder_participant.id_
     case.actor_participant_index[case_actor_id] = case_manager_participant.id_
+
+    case.case_participants.append(actor_participant.id_)
+    case.case_participants.append(finder_participant.id_)
+    case.case_participants.append(case_manager_participant.id_)
 
     dl.create(case)
     dl.create(actor_participant)

--- a/vultron/core/behaviors/case/engage_defer_trigger_tree.py
+++ b/vultron/core/behaviors/case/engage_defer_trigger_tree.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""
+Trigger-side behavior trees for the engage-case and defer-case workflows.
+
+Each tree runs two steps in sequence:
+
+1. **TransitionParticipantRMtoAccepted / TransitionParticipantRMtoDeferred** —
+   updates the actor's RM state in the DataLayer (visible in the BT).
+2. **sender_side_bt** — resolves the Case Manager, constructs the outbound
+   Engage/Defer activity, and queues it in the actor's outbox (PCR-08-001).
+
+This refactoring satisfies #712 AC-1: RM state transitions are performed
+inside the BT so they are visible to BT analysis and auditing tools.
+"""
+
+from typing import Callable
+
+import py_trees
+
+from vultron.core.behaviors.report.nodes import (
+    TransitionParticipantRMtoAccepted,
+    TransitionParticipantRMtoDeferred,
+)
+from vultron.core.behaviors.sender.send_tree import sender_side_bt
+
+
+def engage_case_trigger_bt(
+    case_id: str,
+    actor_id: str,
+    activity_builder: Callable[[str], list[str]],
+) -> py_trees.behaviour.Behaviour:
+    """Return the trigger-side BT for the engage-case (RM → ACCEPTED) workflow.
+
+    Args:
+        case_id: ID of the VulnerabilityCase to engage.
+        actor_id: ID of the actor engaging the case; passed to the RM
+            transition node (overridden at runtime by the blackboard).
+        activity_builder: Callable invoked by the sender subtree with the
+            resolved Case Manager actor ID; should return a list of outbound
+            activity IDs to queue.
+
+    Returns:
+        A ``py_trees.composites.Sequence`` that:
+
+        - Transitions the actor's RM state to ACCEPTED.
+        - Resolves the Case Manager, builds the Engage(Case) activity, and
+          queues it in the actor's outbox.
+    """
+    return py_trees.composites.Sequence(
+        name="EngageCaseTriggerBT",
+        memory=False,
+        children=[
+            TransitionParticipantRMtoAccepted(
+                case_id=case_id, actor_id=actor_id
+            ),
+            sender_side_bt(case_id=case_id, activity_builder=activity_builder),
+        ],
+    )
+
+
+def defer_case_trigger_bt(
+    case_id: str,
+    actor_id: str,
+    activity_builder: Callable[[str], list[str]],
+) -> py_trees.behaviour.Behaviour:
+    """Return the trigger-side BT for the defer-case (RM → DEFERRED) workflow.
+
+    Args:
+        case_id: ID of the VulnerabilityCase to defer.
+        actor_id: ID of the actor deferring the case; passed to the RM
+            transition node (overridden at runtime by the blackboard).
+        activity_builder: Callable invoked by the sender subtree with the
+            resolved Case Manager actor ID; should return a list of outbound
+            activity IDs to queue.
+
+    Returns:
+        A ``py_trees.composites.Sequence`` that:
+
+        - Transitions the actor's RM state to DEFERRED.
+        - Resolves the Case Manager, builds the Defer(Case) activity, and
+          queues it in the actor's outbox.
+    """
+    return py_trees.composites.Sequence(
+        name="DeferCaseTriggerBT",
+        memory=False,
+        children=[
+            TransitionParticipantRMtoDeferred(
+                case_id=case_id, actor_id=actor_id
+            ),
+            sender_side_bt(case_id=case_id, activity_builder=activity_builder),
+        ],
+    )

--- a/vultron/core/behaviors/note/add_note_trigger_tree.py
+++ b/vultron/core/behaviors/note/add_note_trigger_tree.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""
+Trigger-side behavior tree for the add-note-to-case workflow.
+
+The tree runs three steps in sequence:
+
+1. **CreateNoteNode** — calls ``TriggerActivityPort.create_note()`` via the
+   blackboard factory, persists the note, and writes ``note_id``/``note_dict``
+   to *result_out*.
+2. **AttachNoteFromResultNode** — reads ``note_id`` from *result_out* and
+   appends it to the case's ``notes`` list (idempotent).
+3. **sender_side_bt** — resolves the Case Manager, constructs the outbound
+   ``Add(Note, Case)`` activity, and queues it in the actor's outbox
+   (PCR-08-001).
+
+This refactoring satisfies #712 AC-2: all protocol-significant domain work
+(note creation, persistence, case attachment) is performed inside the BT so
+it is visible to BT analysis and auditing tools.
+"""
+
+from typing import Callable
+
+import py_trees
+
+from vultron.core.behaviors.note.nodes import (
+    AttachNoteFromResultNode,
+    CreateNoteNode,
+)
+from vultron.core.behaviors.sender.send_tree import sender_side_bt
+
+
+def add_note_to_case_trigger_bt(
+    case_id: str,
+    note_name: str,
+    note_content: str,
+    result_out: dict,
+    activity_builder: Callable[[str], list[str]],
+    in_reply_to: str | None = None,
+) -> py_trees.behaviour.Behaviour:
+    """Return the trigger-side BT for the add-note-to-case workflow.
+
+    Args:
+        case_id: ID of the VulnerabilityCase to attach the note to.
+        note_name: Human-readable name/subject for the note.
+        note_content: Full text content of the note.
+        result_out: Mutable dict; ``note_id`` and ``note_dict`` are written by
+            ``CreateNoteNode`` so the enclosing use case can return them and
+            the ``activity_builder`` closure can read ``note_id`` after it
+            runs.
+        activity_builder: Callable invoked by the sender subtree with the
+            resolved Case Manager actor ID; should return a list of outbound
+            activity IDs to queue.
+        in_reply_to: Optional ID of a parent note being replied to.
+
+    Returns:
+        A ``py_trees.composites.Sequence`` that:
+
+        - Creates and persists the note (via TriggerActivityPort).
+        - Attaches the note to the local case copy.
+        - Resolves the Case Manager, builds outbound activities, and queues
+          them in the actor's outbox.
+    """
+    return py_trees.composites.Sequence(
+        name="AddNoteToCaseTriggerBT",
+        memory=False,
+        children=[
+            CreateNoteNode(
+                note_name=note_name,
+                note_content=note_content,
+                case_id=case_id,
+                result_out=result_out,
+                in_reply_to=in_reply_to,
+            ),
+            AttachNoteFromResultNode(case_id=case_id, result_out=result_out),
+            sender_side_bt(case_id=case_id, activity_builder=activity_builder),
+        ],
+    )

--- a/vultron/core/behaviors/note/nodes.py
+++ b/vultron/core/behaviors/note/nodes.py
@@ -16,8 +16,8 @@
 """
 BT nodes for the note workflow.
 
-Provides ``SaveNoteNode`` and ``AttachNoteToCaseNode``, composed by
-``create_note_tree`` into the ``CreateNoteBT`` behavior tree.
+Provides ``SaveNoteNode``, ``AttachNoteToCaseNode``, ``CreateNoteNode``, and
+``AttachNoteFromResultNode``, composed into the note behavior trees.
 
 Per specs/case-management.yaml CM-06.
 """
@@ -117,5 +117,160 @@ class AttachNoteToCaseNode(DataLayerAction):
         self.logger.info(
             f"{self.name}: Attached note '{self.note_id}'"
             f" to case '{self.case_id}'"
+        )
+        return Status.SUCCESS
+
+
+class CreateNoteNode(DataLayerAction):
+    """Create and persist a Note via the TriggerActivityPort.
+
+    Uses ``trigger_activity_factory`` from the blackboard to create the note
+    object, then writes ``note_id`` and ``note_dict`` to *result_out* for use
+    by downstream BT nodes and the enclosing use case.
+
+    ``actor_id`` is read from the blackboard at execution time so the note is
+    attributed to the requesting actor.
+
+    Per specs/case-management.yaml CM-06; satisfies #712 AC-2.
+    """
+
+    def __init__(
+        self,
+        note_name: str,
+        note_content: str,
+        case_id: str,
+        result_out: dict,
+        in_reply_to: str | None = None,
+        name: str | None = None,
+    ):
+        """
+        Initialize CreateNoteNode.
+
+        Args:
+            note_name: Human-readable name/subject for the note.
+            note_content: Full text content of the note.
+            case_id: ID of the VulnerabilityCase the note belongs to.
+            result_out: Mutable dict; ``note_id`` and ``note_dict`` are written
+                here after successful creation so the enclosing use case can
+                return them.
+            in_reply_to: Optional ID of a parent note being replied to.
+            name: Optional custom node name (defaults to class name).
+        """
+        super().__init__(name=name or self.__class__.__name__)
+        self.note_name = note_name
+        self.note_content = note_content
+        self.case_id = case_id
+        self.result_out = result_out
+        self.in_reply_to = in_reply_to
+
+    def update(self) -> Status:
+        """Create note via TriggerActivityPort and store result in result_out.
+
+        Returns:
+            SUCCESS if note created, FAILURE if factory unavailable or error
+        """
+        if self.datalayer is None:
+            self.feedback_message = "DataLayer not available"
+            self.logger.error(f"{self.name}: {self.feedback_message}")
+            return Status.FAILURE
+
+        if self.trigger_activity_factory is None:
+            self.feedback_message = (
+                "trigger_activity_factory not available in blackboard"
+            )
+            self.logger.error(f"{self.name}: {self.feedback_message}")
+            return Status.FAILURE
+
+        if self.actor_id is None:
+            self.feedback_message = "actor_id not available in blackboard"
+            self.logger.error(f"{self.name}: {self.feedback_message}")
+            return Status.FAILURE
+
+        try:
+            note_id, note_dict = self.trigger_activity_factory.create_note(
+                name=self.note_name,
+                content=self.note_content,
+                context_id=self.case_id,
+                attributed_to=self.actor_id,
+                in_reply_to=self.in_reply_to,
+            )
+            self.result_out["note_id"] = note_id
+            self.result_out["note_dict"] = note_dict
+            self.feedback_message = f"Created note '{note_id}'"
+            self.logger.info(f"{self.name}: {self.feedback_message}")
+            return Status.SUCCESS
+        except Exception as e:
+            self.feedback_message = f"Error creating note: {e}"
+            self.logger.error(f"{self.name}: {self.feedback_message}")
+            return Status.FAILURE
+
+
+class AttachNoteFromResultNode(DataLayerAction):
+    """Attach a note to a VulnerabilityCase, reading note_id from result_out.
+
+    Reads ``note_id`` from *result_out* at execution time, allowing it to be
+    used downstream of a ``CreateNoteNode`` in the same BT Sequence without
+    requiring the note_id to be known at tree construction time.
+
+    Idempotent: if the note is already attached, the node succeeds without
+    writing.
+
+    Per specs/case-management.yaml CM-06; satisfies #712 AC-2.
+    """
+
+    def __init__(
+        self,
+        case_id: str,
+        result_out: dict,
+        name: str | None = None,
+    ):
+        """
+        Initialize AttachNoteFromResultNode.
+
+        Args:
+            case_id: ID of the VulnerabilityCase to attach the note to.
+            result_out: Shared dict containing ``note_id`` written by the
+                preceding ``CreateNoteNode``.
+            name: Optional custom node name (defaults to class name).
+        """
+        super().__init__(name=name or self.__class__.__name__)
+        self.case_id = case_id
+        self.result_out = result_out
+
+    def update(self) -> Status:
+        """Attach note from result_out to case in DataLayer.
+
+        Returns:
+            SUCCESS if attached (or already attached), FAILURE on error
+        """
+        note_id = self.result_out.get("note_id")
+        if not note_id:
+            self.feedback_message = "note_id not available in result_out"
+            self.logger.error(f"{self.name}: {self.feedback_message}")
+            return Status.FAILURE
+
+        if self.datalayer is None:
+            self.feedback_message = "DataLayer not available"
+            self.logger.error(f"{self.name}: {self.feedback_message}")
+            return Status.FAILURE
+
+        case: Any = self.datalayer.read(self.case_id)
+        if not is_case_model(case):
+            self.feedback_message = f"case '{self.case_id}' not found"
+            self.logger.warning(f"{self.name}: {self.feedback_message}")
+            return Status.FAILURE
+
+        existing_ids = [_as_id(n) for n in case.notes]
+        if note_id in existing_ids:
+            self.logger.info(
+                f"{self.name}: note '{note_id}' already in"
+                f" case '{self.case_id}' — skipping (idempotent)"
+            )
+            return Status.SUCCESS
+
+        case.notes.append(note_id)
+        self.datalayer.save(case)
+        self.logger.info(
+            f"{self.name}: Attached note '{note_id}' to case '{self.case_id}'"
         )
         return Status.SUCCESS

--- a/vultron/core/use_cases/triggers/case.py
+++ b/vultron/core/use_cases/triggers/case.py
@@ -25,14 +25,16 @@ from typing import TYPE_CHECKING, Any
 from py_trees.common import Status
 
 from vultron.core.behaviors.bridge import BTBridge
-from vultron.core.behaviors.sender.send_tree import sender_side_bt
+from vultron.core.behaviors.case.engage_defer_trigger_tree import (
+    defer_case_trigger_bt,
+    engage_case_trigger_bt,
+)
 from vultron.core.models.case import VultronCase
 from vultron.core.states.cs import CS_vfd
 from vultron.core.states.rm import RM
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.use_cases._helpers import (
     _resolve_case_manager_id,
-    update_participant_rm_state,
 )
 from vultron.core.use_cases.triggers._helpers import (
     add_activity_to_outbox,
@@ -88,8 +90,6 @@ class SvcEngageCaseUseCase:
                 "SvcEngageCaseUseCase requires a TriggerActivityPort"
             )
 
-        update_participant_rm_state(case_id, actor_id, RM.ACCEPTED, dl)
-
         factory = self._trigger_activity
         captured: dict = {}
 
@@ -103,8 +103,10 @@ class SvcEngageCaseUseCase:
             return [activity_id]
 
         bridge = BTBridge(datalayer=dl, trigger_activity=factory)
-        tree = sender_side_bt(
-            case_id=case_id, activity_builder=_build_activities
+        tree = engage_case_trigger_bt(
+            case_id=case_id,
+            actor_id=actor_id,
+            activity_builder=_build_activities,
         )
         result = bridge.execute_with_setup(tree, actor_id=actor_id)
 
@@ -155,8 +157,6 @@ class SvcDeferCaseUseCase:
                 "SvcDeferCaseUseCase requires a TriggerActivityPort"
             )
 
-        update_participant_rm_state(case_id, actor_id, RM.DEFERRED, dl)
-
         factory = self._trigger_activity
         captured: dict = {}
 
@@ -170,8 +170,10 @@ class SvcDeferCaseUseCase:
             return [activity_id]
 
         bridge = BTBridge(datalayer=dl, trigger_activity=factory)
-        tree = sender_side_bt(
-            case_id=case_id, activity_builder=_build_activities
+        tree = defer_case_trigger_bt(
+            case_id=case_id,
+            actor_id=actor_id,
+            activity_builder=_build_activities,
         )
         result = bridge.execute_with_setup(tree, actor_id=actor_id)
 

--- a/vultron/core/use_cases/triggers/note.py
+++ b/vultron/core/use_cases/triggers/note.py
@@ -25,8 +25,9 @@ from typing import TYPE_CHECKING
 from py_trees.common import Status
 
 from vultron.core.behaviors.bridge import BTBridge
-from vultron.core.behaviors.sender.send_tree import sender_side_bt
-from vultron.core.models.protocols import is_case_model
+from vultron.core.behaviors.note.add_note_trigger_tree import (
+    add_note_to_case_trigger_bt,
+)
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.errors import VultronValidationError
 from vultron.core.use_cases.triggers._helpers import (
@@ -81,34 +82,12 @@ class SvcAddNoteToCaseUseCase:
             )
         factory = self._trigger_activity
 
-        note_id, note_dict = factory.create_note(
-            name=request.note_name,
-            content=request.note_content,
-            context_id=case_id,
-            attributed_to=actor_id,
-            in_reply_to=request.in_reply_to,
-        )
-
-        # Add note to the actor's local copy of the case.
-        case_obj = dl.read(case_id)
-        if is_case_model(case_obj):
-            existing_ids = [
-                n if isinstance(n, str) else getattr(n, "id_", str(n))
-                for n in case_obj.notes
-            ]
-            if note_id not in existing_ids:
-                case_obj.notes.append(note_id)
-                dl.save(case_obj)
-                logger.debug(
-                    "AddNoteToCase: added note '%s' to local case '%s'",
-                    note_id,
-                    case_id,
-                )
-
-        # Mutable capture so the closure can pass back the activity dict.
-        captured: dict = {}
+        # result_out is written by CreateNoteNode and AttachNoteFromResultNode
+        # inside the BT; the closure and the return statement read from it.
+        result_out: dict = {}
 
         def _build_activities(case_manager_id: str) -> list[str]:
+            note_id = result_out["note_id"]
             create_id = factory.create_note_activity(
                 actor=actor_id,
                 note_id=note_id,
@@ -120,20 +99,26 @@ class SvcAddNoteToCaseUseCase:
                 actor=actor_id,
                 to=[case_manager_id],
             )
-            captured["activity"] = add_dict
+            result_out["activity"] = add_dict
             return [create_id, add_id]
 
         bridge = BTBridge(datalayer=dl, trigger_activity=factory)
-        tree = sender_side_bt(
-            case_id=case_id, activity_builder=_build_activities
+        tree = add_note_to_case_trigger_bt(
+            case_id=case_id,
+            note_name=request.note_name,
+            note_content=request.note_content,
+            in_reply_to=request.in_reply_to,
+            result_out=result_out,
+            activity_builder=_build_activities,
         )
-        result = bridge.execute_with_setup(tree, actor_id=actor_id)
+        result_status = bridge.execute_with_setup(tree, actor_id=actor_id)
 
-        if result.status != Status.SUCCESS:
+        if result_status.status != Status.SUCCESS:
             raise VultronValidationError(
                 f"AddNoteToCase failed: {BTBridge.get_failure_reason(tree)}"
             )
 
+        note_id = result_out.get("note_id", "")
         logger.info(
             "Actor '%s' added note '%s' to case '%s'",
             actor_id,
@@ -142,6 +127,6 @@ class SvcAddNoteToCaseUseCase:
         )
 
         return {
-            "note": note_dict,
-            "activity": captured.get("activity"),
+            "note": result_out.get("note_dict"),
+            "activity": result_out.get("activity"),
         }


### PR DESCRIPTION
## Summary

Implements #712: moves protocol-significant domain work out of pre-BT procedural code in trigger use cases and into BT leaf nodes, making it visible to BT analysis and auditing tools.

## Changes

### New BT nodes
- `CreateNoteNode` — creates and persists a note via `TriggerActivityPort`, writes `note_id`/`note_dict` to a shared `result_out` dict
- `AttachNoteFromResultNode` — reads `note_id` from `result_out` and appends it to the case's `notes` list (idempotent)

### New BT factory functions
- `engage_case_trigger_bt()` — sequences `TransitionParticipantRMtoAccepted → sender_side_bt`
- `defer_case_trigger_bt()` — sequences `TransitionParticipantRMtoDeferred → sender_side_bt`
- `add_note_to_case_trigger_bt()` — sequences `CreateNoteNode → AttachNoteFromResultNode → sender_side_bt`

### Use case changes
- `SvcEngageCaseUseCase`: removed pre-BT `update_participant_rm_state(..., RM.ACCEPTED)` call; uses `engage_case_trigger_bt()`
- `SvcDeferCaseUseCase`: removed pre-BT `update_participant_rm_state(..., RM.DEFERRED)` call; uses `defer_case_trigger_bt()`
- `SvcAddNoteToCaseUseCase`: removed pre-BT `factory.create_note()` and inline case attachment; uses `add_note_to_case_trigger_bt()`

## Acceptance Criteria

- [x] AC-1: RM state transitions for engage/defer run inside the BT
- [x] AC-2: Note creation, persistence, and attachment run inside the BT
- [x] AC-3: BT-path tests verify state changes via DataLayer re-reads

## Behavior Change

Engage-case with no participant record now raises `VultronValidationError` (HTTP 422) instead of silently succeeding with a warning (old silent-fail behavior). One test updated accordingly.

## Test fixtures
- Fixed `case_participants` not being populated in `_make_case_with_case_manager` helpers (was bug: `update_participant_rm_state` iterates `case.case_participants`, not `actor_participant_index`)
- Pre-advance actor participants to `RM.VALID` so engage/defer transitions are valid

Closes #712