### PR TITLE
fix: remove ValidateCaseObject BT node; fix memory=False on SuggestActorToCaseBT

### DIFF
--- a/plan/history/2606/implementation/ISSUE-716.md
+++ b/plan/history/2606/implementation/ISSUE-716.md
@@ -1,0 +1,35 @@
+---
+source: ISSUE-716
+timestamp: '2026-06-04T16:37:36.632313+00:00'
+title: Remove ValidateCaseObject BT node; fix memory=False on SuggestActorToCaseBT
+type: implementation
+---
+
+## Issue #716 — BT cleanup: audit memory=False on inline composites and remove redundant ValidateCaseObject node
+
+### AC-1: memory=False audit
+
+Audited all inline composites in `vultron/core/behaviors/case/`. Found one
+`memory=True` in `suggest_actor_tree.py` on the `SuggestActorToCaseBT`
+Sequence. Changed to `memory=False` so preconditions (`CheckIsCaseOwnerNode`,
+`CheckNoExistingInviteNode`) are re-evaluated on every tick, maintaining the
+stateless-ticking invariant shared by all other case BTs. All other composites
+already used `memory=False`.
+
+### AC-2 + AC-3: ValidateCaseObject removal
+
+Confirmed that `VultronBase.id_` is typed `NonEmptyString` with
+`default_factory=_new_urn`, so Pydantic enforces a valid non-empty `id_` at
+construction time (ARCH-10-001). The factory function `create_create_case_tree()`
+also reads `case_obj.id_` before building the tree, making the downstream BT
+check unreachable. Removed `ValidateCaseObject` from `nodes/conditions.py`,
+`nodes/__init__.py`, and `create_tree.py`.
+
+### Tests added
+
+- `TestVultronCaseIdContract`: construction-time contract tests proving
+  `VultronCase` rejects empty/whitespace `id_` values with `ValidationError`.
+- `test_suggest_actor_tree.py`: regression test asserting `SuggestActorToCaseBT`
+  uses `memory=False`.
+
+PR: [#774](https://github.com/CERTCC/Vultron/pull/774)

--- a/test/core/behaviors/case/nodes/test_conditions.py
+++ b/test/core/behaviors/case/nodes/test_conditions.py
@@ -16,17 +16,21 @@
 """
 Unit tests for case condition nodes.
 
-Covers CheckCaseAlreadyExists, CheckCaseExistsForReport, and ValidateCaseObject.
+Covers CheckCaseAlreadyExists and CheckCaseExistsForReport.
 Per specs/idempotency.yaml ID-04-004.
+
+Also covers the construction-time guarantee that VultronCase rejects
+invalid id_ values (ARCH-10-001), which made the former ValidateCaseObject
+BT node redundant (removed in issue #716).
 """
 
 import pytest
 from py_trees.common import Status
+from pydantic import ValidationError
 
 from vultron.core.behaviors.case.nodes.conditions import (
     CheckCaseAlreadyExists,
     CheckCaseExistsForReport,
-    ValidateCaseObject,
 )
 from vultron.core.models.vultron_types import (
     VultronCase,
@@ -197,22 +201,26 @@ class TestCheckCaseExistsForReport:
 
 
 # ---------------------------------------------------------------------------
-# ValidateCaseObject
+# VultronCase construction-time id_ contract (ARCH-10-001)
 # ---------------------------------------------------------------------------
 
 
-class TestValidateCaseObject:
-    """ValidateCaseObject returns SUCCESS for valid cases, FAILURE otherwise."""
+class TestVultronCaseIdContract:
+    """VultronCase rejects invalid id_ at construction time (ARCH-10-001).
 
-    def test_succeeds_for_valid_case(
-        self,
-        bt_scenario: BTTestScenario,
-        actor: VultronCaseActor,
-        actor_id: str,
-        case_obj: VultronCase,
-    ) -> None:
-        result = bt_scenario.run(
-            ValidateCaseObject(case_obj=case_obj),
-            actor_id=actor_id,
-        )
-        assert result.status == Status.SUCCESS
+    This guarantees that any VultronCase object that exists at runtime already
+    has a valid non-empty id_, making a runtime BT validation node redundant
+    (see issue #716).
+    """
+
+    def test_empty_id_raises_validation_error(self) -> None:
+        with pytest.raises(ValidationError):
+            VultronCase(id_="")
+
+    def test_whitespace_only_id_raises_validation_error(self) -> None:
+        with pytest.raises(ValidationError):
+            VultronCase(id_="   ")
+
+    def test_auto_generated_id_is_nonempty(self) -> None:
+        case = VultronCase()
+        assert case.id_ and case.id_.strip()

--- a/test/core/behaviors/case/test_suggest_actor_tree.py
+++ b/test/core/behaviors/case/test_suggest_actor_tree.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""
+Tests for the SuggestActorToCase behavior tree factory.
+
+Covers stateless-ticking invariant (memory=False) for the root Sequence.
+Per specs/behavior-tree-integration.yaml and issue #716.
+"""
+
+import py_trees
+
+from vultron.core.behaviors.case.suggest_actor_tree import (
+    create_suggest_actor_tree,
+)
+
+
+class TestCreateSuggestActorTree:
+    """Structural tests for the SuggestActorToCaseBT factory."""
+
+    def test_root_is_sequence_with_memory_false(self) -> None:
+        """Regression guard: root Sequence must use memory=False (#716).
+
+        memory=True would skip re-evaluating preconditions (CheckIsCaseOwnerNode,
+        CheckNoExistingInviteNode) on re-entry after a child returns RUNNING,
+        defeating the stateless-ticking contract of all case BTs.
+        """
+        tree = create_suggest_actor_tree(
+            recommendation_id="https://example.org/recommendations/rec-1",
+            recommender_id="https://example.org/actors/recommender",
+            invitee_id="https://example.org/actors/invitee",
+            case_id="https://example.org/cases/case-1",
+        )
+        assert isinstance(tree, py_trees.composites.Sequence)
+        assert tree.memory is False, (
+            "SuggestActorToCaseBT root Sequence must use memory=False "
+            "to ensure preconditions are re-evaluated on every tick"
+        )

--- a/vultron/core/behaviors/case/create_tree.py
+++ b/vultron/core/behaviors/case/create_tree.py
@@ -17,7 +17,7 @@
 Case creation behavior tree composition.
 
 Composes the create_case workflow as a behavior tree with idempotency
-guard, validation, persistence, CaseActor setup, and outbox update.
+guard, persistence, CaseActor setup, and outbox update.
 
 Per specs/behavior-tree-integration.yaml BT-06 and specs/case-management.yaml
 CM-02 requirements.
@@ -27,7 +27,6 @@ Structure:
     CreateCaseBT (Selector)
     ├─ CheckCaseAlreadyExists          # Early exit if case already in DataLayer
     └─ CreateCaseFlow (Sequence)
-       ├─ ValidateCaseObject           # Check required fields
        ├─ SetCaseAttributedTo          # Set attributed_to to actor_id (CM-02-008)
        ├─ PersistCase                  # Save VulnerabilityCase to DataLayer
        ├─ RecordCaseCreationEvents     # Backfill offer_received + case_created events (CM-02-009)
@@ -36,6 +35,12 @@ Structure:
        ├─ EmitCreateCaseActivity       # Generate CreateCaseActivity activity
        ├─ UpdateActorOutbox            # Append activity to actor outbox
        └─ CommitCaseLogEntryNode       # Log entry → Announce fan-out (SYNC-02-002)
+
+Note: ``ValidateCaseObject`` was removed (#716).  ``VultronBase.id_`` is typed
+``NonEmptyString`` with a ``default_factory``, so Pydantic enforces a valid
+``id_`` at construction time (ARCH-10-001).  Additionally, ``case_obj.id_`` is
+read on entry to this factory function, making a downstream BT validation node
+unreachable.
 """
 
 import logging
@@ -54,7 +59,6 @@ from vultron.core.behaviors.case.nodes import (
     RecordCaseCreationEvents,
     SetCaseAttributedTo,
     UpdateActorOutbox,
-    ValidateCaseObject,
 )
 
 logger = logging.getLogger(__name__)
@@ -93,7 +97,6 @@ def create_create_case_tree(
         name="CreateCaseFlow",
         memory=False,
         children=[
-            ValidateCaseObject(case_obj=case_obj),
             SetCaseAttributedTo(case_obj=case_obj),
             PersistCase(case_obj=case_obj),
             RecordCaseCreationEvents(case_obj=case_obj),

--- a/vultron/core/behaviors/case/nodes/__init__.py
+++ b/vultron/core/behaviors/case/nodes/__init__.py
@@ -42,7 +42,6 @@ from vultron.core.behaviors.case.nodes.communication import (
 from vultron.core.behaviors.case.nodes.conditions import (
     CheckCaseAlreadyExists,
     CheckCaseExistsForReport,
-    ValidateCaseObject,
 )
 from vultron.core.behaviors.case.nodes.embargo import (
     InitializeDefaultEmbargoNode,
@@ -59,7 +58,6 @@ __all__ = [
     # conditions
     "CheckCaseAlreadyExists",
     "CheckCaseExistsForReport",
-    "ValidateCaseObject",
     # case_setup
     "PersistCase",
     "SetCaseAttributedTo",

--- a/vultron/core/behaviors/case/nodes/conditions.py
+++ b/vultron/core/behaviors/case/nodes/conditions.py
@@ -18,12 +18,18 @@ Condition nodes for case management behavior trees.
 
 Provides idempotency guard conditions for the create_case workflow.
 Per specs/idempotency.yaml ID-04-004.
+
+Note: ``ValidateCaseObject`` was removed in issue #716.  ``VultronBase.id_``
+is typed ``NonEmptyString`` with a ``default_factory=_new_urn``, so Pydantic
+rejects invalid ``id_`` values at construction time (ARCH-10-001 fail-fast
+domain objects).  A factory function that calls ``case_obj.id_`` before
+constructing the tree would raise ``AttributeError`` before any BT node runs,
+making a runtime validation node unreachable and redundant.
 """
 
 from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerCondition
-from vultron.core.models.vultron_types import VultronCase
 
 
 class CheckCaseAlreadyExists(DataLayerCondition):
@@ -131,36 +137,4 @@ class CheckCaseExistsForReport(DataLayerCondition):
             self.logger.error(
                 f"{self.name}: Error checking case existence: {e}"
             )
-            return Status.FAILURE
-
-
-class ValidateCaseObject(DataLayerCondition):
-    """
-    Validate the incoming VulnerabilityCase object has required fields.
-
-    Returns SUCCESS if the case object passes validation.
-    Returns FAILURE if required fields are missing.
-    """
-
-    def __init__(self, case_obj: VultronCase, name: str | None = None):
-        super().__init__(name=name or self.__class__.__name__)
-        self.case_obj = case_obj
-
-    def update(self) -> Status:
-        try:
-            if self.case_obj is None:
-                self.logger.error(f"{self.name}: case_obj is None")
-                return Status.FAILURE
-
-            if not getattr(self.case_obj, "id_", None):
-                self.logger.error(f"{self.name}: Case object missing id_")
-                return Status.FAILURE
-
-            self.logger.debug(
-                f"{self.name}: Case {self.case_obj.id_} passes validation"
-            )
-            return Status.SUCCESS
-
-        except Exception as e:
-            self.logger.error(f"{self.name}: Error validating case: {e}")
             return Status.FAILURE

--- a/vultron/core/behaviors/case/suggest_actor_tree.py
+++ b/vultron/core/behaviors/case/suggest_actor_tree.py
@@ -270,9 +270,13 @@ def create_suggest_actor_tree(
         Configured ``py_trees.composites.Sequence`` ready for execution via
         :class:`~vultron.core.behaviors.bridge.BTBridge`.
     """
+    # memory=False so preconditions (CheckIsCaseOwnerNode,
+    # CheckNoExistingInviteNode) are re-evaluated on every tick,
+    # keeping stateless ticking semantics consistent with all other
+    # case BTs (BTND-02-001 stateless ticking invariant).
     return py_trees.composites.Sequence(
         name="SuggestActorToCaseBT",
-        memory=True,
+        memory=False,
         children=[
             CheckIsCaseOwnerNode(case_id=case_id),
             CheckNoExistingInviteNode(invitee_id=invitee_id, case_id=case_id),


### PR DESCRIPTION
Closes #716

## Changes

### AC-1: Audit and fix memory=False on inline composites

- **`suggest_actor_tree.py`**: Changed `memory=True` to `memory=False` on the `SuggestActorToCaseBT` Sequence. With `memory=True`, preconditions (`CheckIsCaseOwnerNode`, `CheckNoExistingInviteNode`) would be skipped on re-entry after a RUNNING child, violating the stateless-ticking invariant. All other case BTs already used `memory=False`.
- **Audit result**: Only one `memory=True` found in all `vultron/core/behaviors/case/` BT files; no others needed changing.

### AC-2 + AC-3: Confirm id_ invariant; remove ValidateCaseObject

- **Confirmed redundancy**: `VultronBase.id_` is typed `NonEmptyString` with `default_factory=_new_urn`. Pydantic rejects empty/whitespace `id_` values at construction time (ARCH-10-001). Additionally, `create_create_case_tree()` reads `case_obj.id_` before constructing the tree, so a None case object would raise `AttributeError` at the factory boundary - not in the BT.
- **Removed `ValidateCaseObject`** from `nodes/conditions.py`, `nodes/__init__.py`, and from `create_tree.py` (import + children list + docstring).

## Tests

- **`TestVultronCaseIdContract`** (new): construction-time contract tests proving `VultronCase` rejects `id_=""` and `id_="   "` with `ValidationError`, and that auto-generated ids are non-empty.
- **`test_suggest_actor_tree.py`** (new): regression test asserting `SuggestActorToCaseBT` root `Sequence` uses `memory=False`.
