### PR TITLE
refactor: migrate VulnerabilityReport, VulnerabilityRecord, CaseLogEntry to CoreObject

### DIFF
--- a/plan/history/2606/implementation/ISSUE-727.md
+++ b/plan/history/2606/implementation/ISSUE-727.md
@@ -1,0 +1,43 @@
+---
+source: ISSUE-727
+timestamp: '2026-06-04T16:43:06.410750+00:00'
+title: Migrate VulnerabilityReport, VulnerabilityRecord, CaseLogEntry to CoreObject
+type: implementation
+---
+
+## Issue #727 — Refactor #699 step 4: migrate VulnerabilityReport + VulnerabilityRecord + CaseLogEntry to core
+
+Step 4 of 7 in the #699 domain-object migration epic.
+
+### What was done
+
+- **`VulnerabilityReport`** (`core/models/report.py`): renamed from
+  `VultronReport(VultronObject)`, now inherits `CoreObject`. Auto-registers in
+  `CORE_VOCABULARY`. Backward-compat alias `VultronReport = VulnerabilityReport`
+  preserved so the ~30 existing importers need no changes.
+- **`VulnerabilityRecord`** (`core/models/vulnerability_record.py`): new module;
+  `VulnerabilityRecord(CoreObject)` with `name` (required), `aliases`, and `url`
+  fields. Mirrors the wire class that previously had no core counterpart.
+- **`CaseLogEntry`** (`core/models/case_log_entry.py`): renamed from
+  `VultronCaseLogEntry(VultronObject)`, now inherits `CoreObject`. The
+  `model_validator` that auto-computes `id_` from `case_id/log_index` is
+  preserved. Backward-compat alias `VultronCaseLogEntry = CaseLogEntry` keeps
+  all existing importers working. Note: distinct from `case_log.CaseLogEntry`
+  (in-memory hash-chain record).
+- **Wire layer** (`wire/as2/vocab/objects/`): all three wire files updated to
+  import core types under `CoreXxx` aliases; `VulnerabilityRecord` gained
+  `from_core`/`to_core` methods it previously lacked; all three `to_core()`
+  methods explicitly pop `context_` (wire/JSON-LD `@context` concern) before
+  constructing the core domain object.
+- **`vultron_types.py`**: exports `VulnerabilityReport` alongside `VultronReport`.
+- **Tests**: `test_core_object.py` updated — `VultronReport` removed from the
+  "not yet migrated" sentinel; positive `CORE_VOCABULARY` assertions added for
+  all three new `CoreObject` subclasses.
+
+### Key design note
+
+`CoreObject.context_` is the JSON-LD `@context` field. Popping it in `to_core()`
+prevents the wire value (`"https://www.w3.org/ns/activitystreams"`) from leaking
+into the domain object, keeping the hexagonal boundary clean.
+
+PR: [#775](https://github.com/CERTCC/Vultron/pull/775)

--- a/test/core/models/test_core_object.py
+++ b/test/core/models/test_core_object.py
@@ -13,8 +13,10 @@ from vultron.core.models import (
 )
 from vultron.core.models.base import VultronBase
 from vultron.core.models.case import VultronCase
+from vultron.core.models.case_log_entry import CaseLogEntry as CoreCaseLogEntry
 from vultron.core.models.note import VultronNote
-from vultron.core.models.report import VultronReport
+from vultron.core.models.report import VulnerabilityReport, VultronReport
+from vultron.core.models.vulnerability_record import VulnerabilityRecord
 
 # --- Inheritance shape ------------------------------------------------------
 
@@ -191,15 +193,47 @@ def test_registry_robust_under_future_annotations(tmp_path, isolated_vocab):
 
 
 def test_legacy_vultron_stubs_do_not_inherit_core_object():
-    """AC-4: existing Vultron* core stubs are not migrated yet.
+    """AC-4: existing Vultron* core stubs not yet migrated.
 
-    They must still inherit from VultronObject (not CoreObject), and
-    therefore must not appear in CORE_VOCABULARY.
+    VultronCase and VultronNote still inherit VultronObject (not CoreObject)
+    and must not appear in CORE_VOCABULARY.  VultronReport is now an alias
+    for VulnerabilityReport (migrated in #727) so it IS a CoreObject.
     """
-    for cls in (VultronCase, VultronReport, VultronNote):
+    for cls in (VultronCase, VultronNote):
         assert issubclass(cls, VultronObject)
         assert not issubclass(cls, CoreObject), (
             f"{cls.__name__} prematurely inherits CoreObject; "
-            "issue #724 AC-4 forbids migrating legacy stubs in this change."
+            "it has not been migrated yet."
         )
         assert cls.__name__ not in CORE_VOCABULARY
+
+
+# --- AC-1/#727: migrated types inherit CoreObject ---------------------------
+
+
+def test_vulnerability_report_inherits_core_object():
+    """VulnerabilityReport (migrated in #727) must be a CoreObject subclass."""
+    assert issubclass(VulnerabilityReport, CoreObject)
+    assert "VulnerabilityReport" in CORE_VOCABULARY
+    assert CORE_VOCABULARY["VulnerabilityReport"] is VulnerabilityReport
+
+
+def test_vultron_report_alias_is_vulnerability_report():
+    """VultronReport backward-compat alias must resolve to VulnerabilityReport."""
+    assert VultronReport is VulnerabilityReport
+
+
+def test_vulnerability_record_inherits_core_object():
+    """VulnerabilityRecord (new in #727) must be a CoreObject subclass."""
+    assert issubclass(VulnerabilityRecord, CoreObject)
+    assert "VulnerabilityRecord" in CORE_VOCABULARY
+    assert CORE_VOCABULARY["VulnerabilityRecord"] is VulnerabilityRecord
+
+
+def test_core_case_log_entry_inherits_core_object():
+    """CaseLogEntry from case_log_entry (migrated in #727) must be a CoreObject
+    subclass.
+    """
+    assert issubclass(CoreCaseLogEntry, CoreObject)
+    assert "CaseLogEntry" in CORE_VOCABULARY
+    assert CORE_VOCABULARY["CaseLogEntry"] is CoreCaseLogEntry

--- a/vultron/core/models/case_log_entry.py
+++ b/vultron/core/models/case_log_entry.py
@@ -13,19 +13,26 @@
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 """Core domain model for a canonical case log entry (SYNC-2).
 
-:class:`VultronCaseLogEntry` is the authoritative domain representation of a
+:class:`CaseLogEntry` is the authoritative domain representation of a
 single hash-chained log entry used for replication via
 ``Announce(CaseLogEntry)`` activities.
 
-It extends :class:`~vultron.core.models.base.VultronObject` so that it can be
+It extends :class:`~vultron.core.models.base.CoreObject` so that it can be
 placed in :attr:`~vultron.core.models.events.base.VultronEvent.object_` and
 used by :class:`~vultron.core.use_cases.received.sync.AnnounceLogEntryReceivedUseCase`.
 
 The wire-layer module ``vultron.wire.as2.vocab.objects.case_log_entry``
-re-exports this class and registers it in the wire vocabulary under the
-``"CaseLogEntry"`` key so that DataLayer round-trips work correctly.
+imports this class and registers the wire projection in the wire vocabulary
+under the ``"CaseLogEntry"`` key so that DataLayer round-trips work correctly.
 
 Spec: SYNC-01-002, SYNC-02-003, SYNC-03-001 through SYNC-03-003.
+
+.. note::
+   :class:`CaseLogEntry` (this module) is the wire-serialisable domain
+   model.  :class:`~vultron.core.models.case_log.CaseLogEntry` in
+   ``vultron.core.models.case_log`` is a distinct in-memory hash-chain
+   record used for local SYNC processing; the two types serve different
+   abstraction layers.
 """
 
 from __future__ import annotations
@@ -36,12 +43,18 @@ from typing import Any, Literal, TypeAlias
 from pydantic import Field, model_validator
 
 from vultron.core.models._helpers import _now_utc
-from vultron.core.models.base import VultronObject
+from vultron.core.models.base import CoreObject
 from vultron.core.models.case_log import GENESIS_HASH
 
 
-class VultronCaseLogEntry(VultronObject):
+class CaseLogEntry(CoreObject):
     """Core domain model for a single canonical case log entry.
+
+    .. note::
+       The similarly-named :class:`~vultron.core.models.case_log.CaseLogEntry`
+       in ``vultron.core.models.case_log`` is a distinct in-memory log record
+       used for local hash-chain processing.  This class is the
+       wire-serialisable counterpart.
 
     The ``id_`` is auto-computed as ``{case_id}/log/{log_index}`` when not
     explicitly provided.
@@ -134,13 +147,16 @@ class VultronCaseLogEntry(VultronObject):
     )
 
     @model_validator(mode="after")
-    def _set_id_from_case(self) -> "VultronCaseLogEntry":
+    def _set_id_from_case(self) -> "CaseLogEntry":
         """Compute ``id_`` from ``case_id`` and ``log_index``."""
         self.id_ = f"{self.case_id}/log/{self.log_index}"
         return self
 
 
-#: Convenience type alias for optional references in use-case code.
-VultronCaseLogEntryRef: TypeAlias = VultronCaseLogEntry | None
+#: Backward-compatibility alias; prefer :class:`CaseLogEntry` in new code.
+VultronCaseLogEntry = CaseLogEntry
 
-__all__ = ["VultronCaseLogEntry", "VultronCaseLogEntryRef"]
+#: Convenience type alias for optional references in use-case code.
+VultronCaseLogEntryRef: TypeAlias = CaseLogEntry | None
+
+__all__ = ["CaseLogEntry", "VultronCaseLogEntry", "VultronCaseLogEntryRef"]

--- a/vultron/core/models/report.py
+++ b/vultron/core/models/report.py
@@ -19,16 +19,21 @@ from typing import Literal
 
 from pydantic import Field
 
-from vultron.core.models.base import VultronObject
+from vultron.core.models.base import CoreObject
 
 
-class VultronReport(VultronObject):
+class VulnerabilityReport(CoreObject):
     """Domain representation of a vulnerability report.
 
-    Mirrors the Vultron-specific fields of ``VulnerabilityReport``.
-    Policy implementations receive this type when evaluating credibility and
-    validity.
-    ``type_`` is ``"VulnerabilityReport"`` to match the wire value.
+    Canonical core type for the Vultron ``VulnerabilityReport`` object.
+    ``type_`` is ``"VulnerabilityReport"`` to match the wire value and to
+    auto-register this class in :data:`CORE_VOCABULARY`.
+
+    Policy implementations receive this type when evaluating credibility
+    and validity.  The wire-layer class in
+    ``vultron.wire.as2.vocab.objects.vulnerability_report`` re-exports
+    this type and adds AS2-specific serialization via :meth:`from_core`
+    and :meth:`to_core`.
     """
 
     type_: Literal["VulnerabilityReport"] = Field(
@@ -36,3 +41,10 @@ class VultronReport(VultronObject):
         validation_alias="type",
         serialization_alias="type",
     )
+
+
+#: Backward-compatibility alias; prefer :class:`VulnerabilityReport` in new code.
+VultronReport = VulnerabilityReport
+
+
+__all__ = ["VulnerabilityReport", "VultronReport"]

--- a/vultron/core/models/vulnerability_record.py
+++ b/vultron/core/models/vulnerability_record.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Domain representation of a vulnerability record (persistent identifier)."""
+
+from typing import Literal
+
+from pydantic import Field
+
+from vultron.core.models.base import CoreObject, NonEmptyString
+
+
+class VulnerabilityRecord(CoreObject):
+    """Domain representation of a persistent identifier record for a
+    confirmed vulnerability.
+
+    A ``VulnerabilityRecord`` may carry one or more identifiers from
+    different namespaces (e.g., CVE ID, CERT/CC VU#, vendor-specific ID)
+    and SHOULD support a list of alias identifiers for the same
+    vulnerability.
+
+    ``type_`` is ``"VulnerabilityRecord"`` to match the wire value and to
+    auto-register this class in :data:`CORE_VOCABULARY`.
+
+    Fields:
+        name: Primary identifier for the vulnerability (required; e.g.,
+            ``"CVE-2024-1234"`` or ``"VU#123456"``).
+        aliases: Optional list of alternative identifiers from different
+            namespaces for the same vulnerability.
+        url: Optional URL reference for the vulnerability record.
+    """
+
+    type_: Literal["VulnerabilityRecord"] = Field(
+        default="VulnerabilityRecord",
+        validation_alias="type",
+        serialization_alias="type",
+    )
+
+    name: NonEmptyString = Field(  # pyright: ignore[reportGeneralTypeIssues]
+        ...,
+        description=(
+            "Primary identifier for the vulnerability "
+            "(e.g., CVE-2024-1234, VU#123456)"
+        ),
+    )
+    aliases: list[NonEmptyString] = Field(
+        default_factory=list,
+        description="Alternative identifiers from different namespaces",
+    )
+    url: NonEmptyString | None = Field(
+        default=None,
+        description="Optional URL reference for the vulnerability record",
+    )
+
+
+__all__ = ["VulnerabilityRecord"]

--- a/vultron/core/models/vultron_types.py
+++ b/vultron/core/models/vultron_types.py
@@ -29,7 +29,7 @@ Import directly from those modules for new code:
 - ``vultron.core.models.note`` — VultronNote
 - ``vultron.core.models.participant`` — VultronParticipant
 - ``vultron.core.models.participant_status`` — ParticipantStatus
-- ``vultron.core.models.report`` — VultronReport
+- ``vultron.core.models.report`` — VulnerabilityReport (VultronReport is an alias)
 """
 
 from vultron.core.models.activity import (
@@ -47,7 +47,7 @@ from vultron.core.models.embargo_policy import EmbargoPolicy
 from vultron.core.models.note import VultronNote
 from vultron.core.models.participant import VultronParticipant
 from vultron.core.models.participant_status import ParticipantStatus
-from vultron.core.models.report import VultronReport
+from vultron.core.models.report import VulnerabilityReport, VultronReport
 
 __all__ = [
     "VultronAccept",
@@ -65,5 +65,6 @@ __all__ = [
     "VultronOutbox",
     "VultronParticipant",
     "ParticipantStatus",
+    "VulnerabilityReport",
     "VultronReport",
 ]

--- a/vultron/wire/as2/vocab/objects/case_log_entry.py
+++ b/vultron/wire/as2/vocab/objects/case_log_entry.py
@@ -48,6 +48,7 @@ from pydantic import Field
 from vultron.core.models._helpers import _now_utc
 from vultron.core.models.case_log import GENESIS_HASH
 from vultron.core.models.case_log_entry import (
+    CaseLogEntry as CoreCaseLogEntry,
     VultronCaseLogEntry,
     VultronCaseLogEntryRef,
 )
@@ -140,17 +141,19 @@ class CaseLogEntry(VultronAS2Object):
     )
 
     @classmethod
-    def from_core(cls, entry: VultronCaseLogEntry) -> "CaseLogEntry":
+    def from_core(cls, entry: CoreCaseLogEntry) -> "CaseLogEntry":
         """Create a wire :class:`CaseLogEntry` from a domain
-        :class:`~vultron.core.models.case_log_entry.VultronCaseLogEntry`.
+        :class:`~vultron.core.models.case_log_entry.CaseLogEntry`.
 
         Conversion ownership belongs in the wire layer so that core modules
         do not embed wire-format knowledge (ARCH-01-001).
         """
         return cls.model_validate(entry.model_dump(mode="json"))
 
-    def to_core(self) -> VultronCaseLogEntry:
-        return VultronCaseLogEntry.model_validate(self._to_core_data())
+    def to_core(self) -> CoreCaseLogEntry:
+        data = self._to_core_data()
+        data.pop("context_", None)  # context_ is a wire/JSON-LD concern
+        return CoreCaseLogEntry.model_validate(data)
 
 
 __all__ = ["CaseLogEntry", "VultronCaseLogEntry", "VultronCaseLogEntryRef"]

--- a/vultron/wire/as2/vocab/objects/vulnerability_record.py
+++ b/vultron/wire/as2/vocab/objects/vulnerability_record.py
@@ -16,24 +16,27 @@ Provides a VulnerabilityRecord object for the Vultron ActivityStreams Vocabulary
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-from typing import TypeAlias
+from typing import TypeAlias, cast
 
 from pydantic import Field
 
 from vultron.core.models.base import NonEmptyString
 from vultron.core.models.enums import VultronObjectType as VO_type
+from vultron.core.models.vulnerability_record import (
+    VulnerabilityRecord as CoreVulnerabilityRecord,
+)
 from vultron.wire.as2.vocab.base.links import ActivityStreamRef
 from vultron.wire.as2.vocab.objects.base import VultronAS2Object
 
 
 class VulnerabilityRecord(VultronAS2Object):
-    """
-    Represents a persistent identifier record for a confirmed vulnerability.
+    """Wire projection of the core VulnerabilityRecord domain object.
 
-    A VulnerabilityRecord may carry one or more identifiers from different
-    namespaces (e.g., CVE ID, CERT/CC VU#, vendor-specific ID) and SHOULD
-    support a list of alias identifiers from different namespaces for the
-    same vulnerability.
+    Represents a persistent identifier record for a confirmed vulnerability
+    as an ActivityStreams Object.
+
+    Domain logic (field definitions and validation) lives in
+    :class:`vultron.core.models.vulnerability_record.VulnerabilityRecord`.
 
     Fields:
         name: A human-readable identifier for the vulnerability (required).
@@ -60,6 +63,23 @@ class VulnerabilityRecord(VultronAS2Object):
         default=None,
         description="Optional URL reference for the vulnerability record",
     )
+
+    @classmethod
+    def from_core(
+        cls, core_obj: CoreVulnerabilityRecord
+    ) -> "VulnerabilityRecord":
+        """Create a wire :class:`VulnerabilityRecord` from a core domain
+        :class:`~vultron.core.models.vulnerability_record.VulnerabilityRecord`.
+        """
+        return cast("VulnerabilityRecord", super().from_core(core_obj))
+
+    def to_core(self) -> CoreVulnerabilityRecord:
+        """Convert this wire object to a core domain
+        :class:`~vultron.core.models.vulnerability_record.VulnerabilityRecord`.
+        """
+        data = self._to_core_data()
+        data.pop("context_", None)  # context_ is a wire/JSON-LD concern
+        return CoreVulnerabilityRecord.model_validate(data)
 
 
 VulnerabilityRecordRef: TypeAlias = ActivityStreamRef[VulnerabilityRecord]

--- a/vultron/wire/as2/vocab/objects/vulnerability_report.py
+++ b/vultron/wire/as2/vocab/objects/vulnerability_report.py
@@ -20,7 +20,9 @@ from typing import TypeAlias, cast
 
 from pydantic import Field
 
-from vultron.core.models.report import VultronReport
+from vultron.core.models.report import (
+    VulnerabilityReport as CoreVulnerabilityReport,
+)
 from vultron.wire.as2.vocab.base.links import ActivityStreamRef
 from vultron.wire.as2.vocab.objects.base import (
     VultronAS2Object,
@@ -41,16 +43,19 @@ class VulnerabilityReport(VultronAS2Object):
     )
 
     @classmethod
-    def from_core(cls, core_obj: VultronReport) -> "VulnerabilityReport":
+    def from_core(
+        cls, core_obj: CoreVulnerabilityReport
+    ) -> "VulnerabilityReport":
         return cast("VulnerabilityReport", super().from_core(core_obj))
 
-    def to_core(self) -> VultronReport:
+    def to_core(self) -> CoreVulnerabilityReport:
         data = self._to_core_data()
+        data.pop("context_", None)  # context_ is a wire/JSON-LD concern
         data["attributed_to"] = _scalar_ref_id_or_value(
             data.get("attributed_to")
         )
         data["context"] = _scalar_ref_id_or_value(data.get("context"))
-        return VultronReport.model_validate(data)
+        return CoreVulnerabilityReport.model_validate(data)
 
 
 VulnerabilityReportRef: TypeAlias = ActivityStreamRef[VulnerabilityReport]


### PR DESCRIPTION
Closes #727

## Summary

Step 4 of #699 — migrates three domain object types from wire-coupled stubs to proper `CoreObject` subclasses:

### Core layer changes
- **`VulnerabilityReport`** (`core/models/report.py`): renamed from `VultronReport(VultronObject)`, now inherits `CoreObject`; `VultronReport` alias preserved for backward compat
- **`VulnerabilityRecord`** (`core/models/vulnerability_record.py`): new file; `VulnerabilityRecord(CoreObject)` with `name`, `aliases`, `url` fields
- **`CaseLogEntry`** (`core/models/case_log_entry.py`): renamed from `VultronCaseLogEntry(VultronObject)`, now inherits `CoreObject`; `VultronCaseLogEntry` alias preserved; `model_validator` kept
- **`vultron_types.py`**: exports `VulnerabilityReport` alongside the `VultronReport` alias

### Wire layer changes
- `wire/.../vulnerability_report.py`: imports `VulnerabilityReport as CoreVulnerabilityReport`; `to_core()` strips `context_` (wire/JSON-LD concern)
- `wire/.../vulnerability_record.py`: adds `from_core()`/`to_core()` with core import; `to_core()` strips `context_`
- `wire/.../case_log_entry.py`: imports `CaseLogEntry as CoreCaseLogEntry`; `to_core()` strips `context_`

### Tests
- `test/core/models/test_core_object.py`: removes `VultronReport` from legacy-stub sentinel; adds positive assertions for `VulnerabilityReport`, `VulnerabilityRecord`, and `CaseLogEntry` in `CORE_VOCABULARY`

### Key design note
The `context_` pop in all `to_core()` methods is intentional: `CoreObject.context_` is the JSON-LD `@context` field, a wire-layer concern. Domain objects should not carry the wire's `"https://www.w3.org/ns/activitystreams"` value.