### PR TITLE
feat: wrap AddCaseStatusToCaseReceivedUseCase in BT (#758)

### DIFF
--- a/plan/history/2606/implementation/ISSUE-758.md
+++ b/plan/history/2606/implementation/ISSUE-758.md
@@ -1,0 +1,33 @@
+---
+source: ISSUE-758
+timestamp: '2026-06-04T16:44:17.434601+00:00'
+title: Add BT to AddCaseStatusToCaseReceivedUseCase
+type: implementation
+---
+
+## Issue #758 — Add BT to AddCaseStatusToCaseReceivedUseCase (case status received)
+
+Migrated `AddCaseStatusToCaseReceivedUseCase` from a fully procedural
+implementation to the canonical BT delegation pattern used throughout the
+status workflow.
+
+### Changes
+
+- **New** `vultron/core/behaviors/status/add_case_status_tree.py`:
+  `add_case_status_tree()` factory composing a 3-node `AddCaseStatusToCaseBT`
+  Sequence.
+- **Updated** `vultron/core/behaviors/status/nodes.py`: added
+  `CheckCaseStatusIdempotencyNode` (AC-1), `ValidateCaseStatusTransitionNode`
+  (EM/PXA, AC-2), `AppendCaseStatusToCaseNode`, and
+  `CASE_STATUS_ALREADY_PRESENT` sentinel constant.
+- **Updated** `vultron/core/use_cases/received/status.py`: rewrote `execute()`
+  to delegate via `BTBridge`; removed 3 dead private helpers and 4 unused
+  imports.
+- **New** `test/core/behaviors/status/test_add_case_status_bt.py`: 18 tests
+  covering all nodes, tree factory, and use-case integration (AC-3).
+
+### Outcome
+
+All 2783 tests pass. mypy and pyright clean. PR #776 opened.
+
+PR: [#776](https://github.com/CERTCC/Vultron/pull/776)

--- a/test/core/behaviors/status/test_add_case_status_bt.py
+++ b/test/core/behaviors/status/test_add_case_status_bt.py
@@ -1,0 +1,510 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Tests for AddCaseStatus BT nodes and tree factory.
+
+Covers all three steps of the AddCaseStatusToCaseBT sequence:
+  1. CheckCaseStatusIdempotencyNode  — duplicate skipped, new status passes
+  2. ValidateCaseStatusTransitionNode — invalid EM/PXA rejected, valid passes
+  3. AppendCaseStatusToCaseNode      — status appended and persisted
+
+Also covers the full tree factory and use-case-level integration.
+
+Per issue #758 AC-1, AC-2, AC-3.
+"""
+
+from typing import cast
+
+import py_trees
+import pytest
+from py_trees.common import Status
+
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.core.behaviors.bridge import BTBridge
+from vultron.core.behaviors.status.add_case_status_tree import (
+    add_case_status_tree,
+)
+from vultron.core.behaviors.status.nodes import (
+    CASE_STATUS_ALREADY_PRESENT,
+    AppendCaseStatusToCaseNode,
+    CheckCaseStatusIdempotencyNode,
+    ValidateCaseStatusTransitionNode,
+)
+from vultron.core.states.cs import CS_pxa
+from vultron.core.states.em import EM
+from vultron.core.use_cases.received.status import (
+    AddCaseStatusToCaseReceivedUseCase,
+)
+from vultron.wire.as2.factories import add_status_to_case_activity
+from vultron.wire.as2.vocab.objects.case_status import CaseStatus
+from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+ACTOR_ID = "https://example.org/actors/vendor"
+CASE_ID = "https://example.org/cases/case-bt-01"
+STATUS_ID = "https://example.org/cases/case-bt-01/statuses/s1"
+STATUS2_ID = "https://example.org/cases/case-bt-01/statuses/s2"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def clear_blackboard():
+    """Clear py_trees global blackboard storage between tests."""
+    py_trees.blackboard.Blackboard.storage.clear()
+
+
+@pytest.fixture
+def dl():
+    return SqliteDataLayer("sqlite:///:memory:")
+
+
+@pytest.fixture
+def bridge(dl):
+    return BTBridge(datalayer=dl)
+
+
+@pytest.fixture
+def case():
+    return VulnerabilityCase(id_=CASE_ID, name="BT Case")
+
+
+@pytest.fixture
+def status_obj():
+    return CaseStatus(id_=STATUS_ID, context=CASE_ID)
+
+
+@pytest.fixture
+def populated_dl(dl, case, status_obj):
+    dl.create(case)
+    dl.create(status_obj)
+    return dl
+
+
+@pytest.fixture
+def populated_bridge(populated_dl):
+    return BTBridge(datalayer=populated_dl)
+
+
+# ---------------------------------------------------------------------------
+# CheckCaseStatusIdempotencyNode
+# ---------------------------------------------------------------------------
+
+
+class TestCheckCaseStatusIdempotencyNode:
+    def test_new_status_succeeds(self, populated_bridge):
+        """Status not yet in case → SUCCESS, Sequence should continue."""
+        node = CheckCaseStatusIdempotencyNode(
+            case_id=CASE_ID, status_id=STATUS_ID
+        )
+        result = populated_bridge.execute_with_setup(
+            tree=node, actor_id=ACTOR_ID
+        )
+        assert result.status == Status.SUCCESS
+
+    def test_duplicate_status_fails_with_sentinel(self, populated_dl):
+        """Status already present → FAILURE with CASE_STATUS_ALREADY_PRESENT."""
+        # Pre-load the status onto the case
+        case = cast(VulnerabilityCase, populated_dl.read(CASE_ID))
+        status = populated_dl.read(STATUS_ID)
+        case.case_statuses.append(status)
+        populated_dl.save(case)
+
+        bridge = BTBridge(datalayer=populated_dl)
+        node = CheckCaseStatusIdempotencyNode(
+            case_id=CASE_ID, status_id=STATUS_ID
+        )
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+        assert result.status == Status.FAILURE
+        assert node.feedback_message == CASE_STATUS_ALREADY_PRESENT
+
+    def test_case_not_found_fails(self, bridge):
+        """Case not in DataLayer → FAILURE (not idempotent sentinel)."""
+        node = CheckCaseStatusIdempotencyNode(
+            case_id="https://example.org/cases/nonexistent",
+            status_id=STATUS_ID,
+        )
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+        assert result.status == Status.FAILURE
+        assert node.feedback_message != CASE_STATUS_ALREADY_PRESENT
+
+
+# ---------------------------------------------------------------------------
+# ValidateCaseStatusTransitionNode
+# ---------------------------------------------------------------------------
+
+
+class TestValidateCaseStatusTransitionNode:
+    def test_first_status_always_valid(self, populated_bridge):
+        """No current_status → transition always allowed (first status)."""
+        node = ValidateCaseStatusTransitionNode(
+            case_id=CASE_ID,
+            status_id=STATUS_ID,
+            status_obj_fallback=None,
+        )
+        result = populated_bridge.execute_with_setup(
+            tree=node, actor_id=ACTOR_ID
+        )
+        assert result.status == Status.SUCCESS
+
+    def test_valid_em_transition_succeeds(self, dl):
+        """NONE → PROPOSED is a valid EM transition → SUCCESS."""
+        case = VulnerabilityCase(id_=CASE_ID, name="EM Valid")
+        initial = CaseStatus(
+            id_=f"{CASE_ID}/statuses/init",
+            context=CASE_ID,
+            em_state=EM.NONE,
+        )
+        case.case_statuses.append(initial)
+        dl.create(case)
+
+        good_status = CaseStatus(
+            id_=STATUS_ID, context=CASE_ID, em_state=EM.PROPOSED
+        )
+        dl.create(good_status)
+
+        bridge = BTBridge(datalayer=dl)
+        node = ValidateCaseStatusTransitionNode(
+            case_id=CASE_ID,
+            status_id=STATUS_ID,
+            status_obj_fallback=good_status,
+        )
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+        assert result.status == Status.SUCCESS
+
+    def test_invalid_em_transition_fails(self, dl):
+        """NONE → ACTIVE skips PROPOSED — invalid EM transition → FAILURE."""
+        case = VulnerabilityCase(id_=CASE_ID, name="EM Invalid")
+        initial = CaseStatus(
+            id_=f"{CASE_ID}/statuses/init",
+            context=CASE_ID,
+            em_state=EM.NONE,
+        )
+        case.case_statuses.append(initial)
+        dl.create(case)
+
+        bad_status = CaseStatus(
+            id_=STATUS_ID, context=CASE_ID, em_state=EM.ACTIVE
+        )
+        dl.create(bad_status)
+
+        bridge = BTBridge(datalayer=dl)
+        node = ValidateCaseStatusTransitionNode(
+            case_id=CASE_ID,
+            status_id=STATUS_ID,
+            status_obj_fallback=bad_status,
+        )
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+        assert result.status == Status.FAILURE
+
+    def test_invalid_pxa_transition_fails(self, dl):
+        """pxa → PXA skips intermediate steps — invalid PXA transition → FAILURE."""
+        # The default seed CaseStatus already has pxa_state=CS_pxa.pxa.
+        # A direct jump from pxa to PXA (all bits set at once) is invalid.
+        case = VulnerabilityCase(id_=CASE_ID, name="PXA Invalid")
+        dl.create(case)
+
+        bad_status = CaseStatus(
+            id_=STATUS_ID, context=CASE_ID, pxa_state=CS_pxa.PXA
+        )
+        dl.create(bad_status)
+
+        bridge = BTBridge(datalayer=dl)
+        node = ValidateCaseStatusTransitionNode(
+            case_id=CASE_ID,
+            status_id=STATUS_ID,
+            status_obj_fallback=bad_status,
+        )
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+        assert result.status == Status.FAILURE
+
+    def test_case_not_found_fails(self, bridge):
+        """Case not in DataLayer → FAILURE."""
+        node = ValidateCaseStatusTransitionNode(
+            case_id="https://example.org/cases/nonexistent",
+            status_id=STATUS_ID,
+            status_obj_fallback=None,
+        )
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+        assert result.status == Status.FAILURE
+
+
+# ---------------------------------------------------------------------------
+# AppendCaseStatusToCaseNode
+# ---------------------------------------------------------------------------
+
+
+class TestAppendCaseStatusToCaseNode:
+    def test_appends_status_to_case(self, populated_dl):
+        """Status is appended to case.case_statuses and case is saved."""
+        bridge = BTBridge(datalayer=populated_dl)
+        node = AppendCaseStatusToCaseNode(
+            case_id=CASE_ID,
+            status_id=STATUS_ID,
+            status_obj_fallback=None,
+        )
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+        assert result.status == Status.SUCCESS
+
+        case = cast(VulnerabilityCase, populated_dl.read(CASE_ID))
+        status_ids = [getattr(s, "id_", s) for s in case.case_statuses]
+        assert STATUS_ID in status_ids
+
+    def test_case_not_found_fails(self, bridge):
+        """Case not in DataLayer → FAILURE."""
+        node = AppendCaseStatusToCaseNode(
+            case_id="https://example.org/cases/nonexistent",
+            status_id=STATUS_ID,
+            status_obj_fallback=None,
+        )
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+        assert result.status == Status.FAILURE
+
+    def test_status_not_in_dl_uses_fallback(self, dl):
+        """Status not in DL; fallback inline object is saved and used."""
+        case = VulnerabilityCase(id_=CASE_ID, name="Fallback Case")
+        dl.create(case)
+
+        inline_status = CaseStatus(id_=STATUS_ID, context=CASE_ID)
+        bridge = BTBridge(datalayer=dl)
+        node = AppendCaseStatusToCaseNode(
+            case_id=CASE_ID,
+            status_id=STATUS_ID,
+            status_obj_fallback=inline_status,
+        )
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+        assert result.status == Status.SUCCESS
+
+        case = cast(VulnerabilityCase, dl.read(CASE_ID))
+        status_ids = [getattr(s, "id_", s) for s in case.case_statuses]
+        assert STATUS_ID in status_ids
+
+
+# ---------------------------------------------------------------------------
+# Full tree: add_case_status_tree
+# ---------------------------------------------------------------------------
+
+
+class TestAddCaseStatusTree:
+    def test_happy_path_appends_status(self, populated_dl, make_payload):
+        """Full Sequence: new status is appended to case."""
+        status_obj = cast(CaseStatus, populated_dl.read(STATUS_ID))
+        case_obj = cast(VulnerabilityCase, populated_dl.read(CASE_ID))
+
+        activity = add_status_to_case_activity(
+            status_obj, target=case_obj, actor=ACTOR_ID
+        )
+        event = make_payload(activity)
+
+        tree = add_case_status_tree(request=event)
+        bridge = BTBridge(datalayer=populated_dl)
+        result = bridge.execute_with_setup(tree=tree, actor_id=ACTOR_ID)
+        assert result.status == Status.SUCCESS
+
+        case = cast(VulnerabilityCase, populated_dl.read(CASE_ID))
+        status_ids = [getattr(s, "id_", s) for s in case.case_statuses]
+        assert STATUS_ID in status_ids
+
+    def test_idempotent_duplicate_fails_with_sentinel(
+        self, populated_dl, make_payload
+    ):
+        """Duplicate status → BT FAILURE with CASE_STATUS_ALREADY_PRESENT."""
+        # Pre-load the status onto the case
+        case = cast(VulnerabilityCase, populated_dl.read(CASE_ID))
+        status = populated_dl.read(STATUS_ID)
+        case.case_statuses.append(status)
+        populated_dl.save(case)
+
+        status_obj = cast(CaseStatus, populated_dl.read(STATUS_ID))
+        case_obj = cast(VulnerabilityCase, populated_dl.read(CASE_ID))
+
+        activity = add_status_to_case_activity(
+            status_obj, target=case_obj, actor=ACTOR_ID
+        )
+        event = make_payload(activity)
+
+        tree = add_case_status_tree(request=event)
+        bridge = BTBridge(datalayer=populated_dl)
+        result = bridge.execute_with_setup(tree=tree, actor_id=ACTOR_ID)
+        assert result.status == Status.FAILURE
+        assert BTBridge.get_failure_reason(tree) == CASE_STATUS_ALREADY_PRESENT
+
+    def test_invalid_em_transition_fails(self, dl, make_payload):
+        """Invalid EM transition → BT FAILURE; status not appended."""
+        case = VulnerabilityCase(id_=CASE_ID, name="EM Guard")
+        initial = CaseStatus(
+            id_=f"{CASE_ID}/statuses/init",
+            context=CASE_ID,
+            em_state=EM.NONE,
+        )
+        case.case_statuses.append(initial)
+        dl.create(case)
+
+        bad_status = CaseStatus(
+            id_=STATUS_ID, context=CASE_ID, em_state=EM.ACTIVE
+        )
+        dl.create(bad_status)
+
+        activity = add_status_to_case_activity(
+            bad_status, target=case, actor=ACTOR_ID
+        )
+        event = make_payload(activity)
+
+        tree = add_case_status_tree(request=event)
+        bridge = BTBridge(datalayer=dl)
+        result = bridge.execute_with_setup(tree=tree, actor_id=ACTOR_ID)
+        assert result.status == Status.FAILURE
+
+        updated_case = cast(VulnerabilityCase, dl.read(CASE_ID))
+        status_ids = [getattr(s, "id_", s) for s in updated_case.case_statuses]
+        assert STATUS_ID not in status_ids
+
+
+# ---------------------------------------------------------------------------
+# Use-case level (integration with BT)
+# ---------------------------------------------------------------------------
+
+
+class TestAddCaseStatusToCaseReceivedUseCase:
+    def test_use_case_appends_status(self, make_payload):
+        """Use case succeeds: status is appended to case."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case = VulnerabilityCase(id_=CASE_ID, name="UC Case")
+        status_obj = CaseStatus(id_=STATUS_ID, context=CASE_ID)
+        dl.create(case)
+        dl.create(status_obj)
+
+        activity = add_status_to_case_activity(
+            status_obj, target=case, actor=ACTOR_ID
+        )
+        event = make_payload(activity)
+
+        AddCaseStatusToCaseReceivedUseCase(dl, event).execute()
+
+        updated_case = cast(VulnerabilityCase, dl.read(CASE_ID))
+        status_ids = [getattr(s, "id_", s) for s in updated_case.case_statuses]
+        assert STATUS_ID in status_ids
+
+    def test_use_case_idempotent_logs_info(self, make_payload, caplog):
+        """Duplicate status → no append; use case logs at INFO not WARNING."""
+        import logging
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case = VulnerabilityCase(id_=CASE_ID, name="Idempotent Case")
+        status_obj = CaseStatus(id_=STATUS_ID, context=CASE_ID)
+        case.case_statuses.append(status_obj)
+        dl.create(case)
+        dl.create(status_obj)
+
+        activity = add_status_to_case_activity(
+            status_obj, target=case, actor=ACTOR_ID
+        )
+        event = make_payload(activity)
+
+        with caplog.at_level(logging.DEBUG):
+            AddCaseStatusToCaseReceivedUseCase(dl, event).execute()
+
+        info_msgs = [
+            r.message for r in caplog.records if r.levelno == logging.INFO
+        ]
+        warn_msgs = [
+            r.message for r in caplog.records if r.levelno == logging.WARNING
+        ]
+
+        assert any(
+            "idempotent" in m.lower() for m in info_msgs
+        ), "Expected INFO log for idempotent duplicate"
+        assert not any(
+            "idempotent" in m.lower() for m in warn_msgs
+        ), "Should not WARNING for idempotent duplicate"
+
+    def test_use_case_invalid_em_logs_warning(self, make_payload, caplog):
+        """Invalid EM transition → no append; use case logs at WARNING."""
+        import logging
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case = VulnerabilityCase(id_=CASE_ID, name="EM Guard Case")
+        initial = CaseStatus(
+            id_=f"{CASE_ID}/statuses/init",
+            context=CASE_ID,
+            em_state=EM.NONE,
+        )
+        case.case_statuses.append(initial)
+        dl.create(case)
+
+        bad_status = CaseStatus(
+            id_=STATUS_ID, context=CASE_ID, em_state=EM.ACTIVE
+        )
+        dl.create(bad_status)
+
+        activity = add_status_to_case_activity(
+            bad_status, target=case, actor=ACTOR_ID
+        )
+        event = make_payload(activity)
+
+        with caplog.at_level(logging.DEBUG):
+            AddCaseStatusToCaseReceivedUseCase(dl, event).execute()
+
+        warn_msgs = [
+            r.message for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert any(
+            "AddCaseStatusToCaseBT" in m or "invalid" in m.lower()
+            for m in warn_msgs
+        ), "Expected WARNING for invalid transition"
+
+        updated_case = cast(VulnerabilityCase, dl.read(CASE_ID))
+        status_ids = [getattr(s, "id_", s) for s in updated_case.case_statuses]
+        assert STATUS_ID not in status_ids
+
+    def test_use_case_missing_status_id_logs_warning(
+        self, make_payload, caplog
+    ):
+        """Missing status_id in event → WARNING; no BT executed."""
+        import logging
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case = VulnerabilityCase(id_=CASE_ID, name="Missing ID Case")
+        dl.create(case)
+
+        # Construct a status with no ID to force status_id=None via factory
+        status_obj = CaseStatus(id_=STATUS_ID, context=CASE_ID)
+        activity = add_status_to_case_activity(
+            status_obj, target=case, actor=ACTOR_ID
+        )
+        event = make_payload(activity)
+
+        # Patch status_id to None to simulate the missing-ID edge case
+        from unittest.mock import PropertyMock, patch
+
+        with patch.object(
+            type(event),
+            "status_id",
+            new_callable=PropertyMock,
+            return_value=None,
+        ):
+            with caplog.at_level(logging.DEBUG):
+                AddCaseStatusToCaseReceivedUseCase(dl, event).execute()
+
+        warn_msgs = [
+            r.message for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert any("missing" in m.lower() for m in warn_msgs)

--- a/vultron/core/behaviors/status/add_case_status_tree.py
+++ b/vultron/core/behaviors/status/add_case_status_tree.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""
+AddCaseStatus behavior tree composition.
+
+Composes the three-step AddCaseStatus workflow as a Sequence BT:
+
+    AddCaseStatusToCaseBT (Sequence)
+    ├─ CheckCaseStatusIdempotencyNode   # AC-1: status not already present
+    ├─ ValidateCaseStatusTransitionNode # AC-2: EM/PXA transitions are valid
+    └─ AppendCaseStatusToCaseNode       # AC-1: append status and persist
+
+Per issue #758 (BT-SM Integration: AddCaseStatusToCaseReceivedUseCase).
+"""
+
+import logging
+
+import py_trees
+
+from vultron.core.models.events.status import AddCaseStatusToCaseReceivedEvent
+from vultron.core.behaviors.status.nodes import (
+    AppendCaseStatusToCaseNode,
+    CheckCaseStatusIdempotencyNode,
+    ValidateCaseStatusTransitionNode,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def add_case_status_tree(
+    request: AddCaseStatusToCaseReceivedEvent,
+) -> py_trees.behaviour.Behaviour:
+    """Create the behavior tree for the AddCaseStatusToCase workflow.
+
+    Handles receipt of an ``Add(CaseStatus, VulnerabilityCase)`` activity.
+    Implements three steps as BT nodes in a Sequence:
+
+    1. Idempotency check — fail fast if the status is already present.
+    2. Transition validation — reject invalid EM or PXA state transitions.
+    3. Append and persist — write the new CaseStatus to the case record.
+
+    Args:
+        request: The parsed inbound domain event.
+
+    Returns:
+        Root node of the ``AddCaseStatusToCaseBT`` Sequence.
+    """
+    status_id = request.status_id or ""
+    case_id = request.case_id or ""
+    status_obj = request.status
+
+    root = py_trees.composites.Sequence(
+        name="AddCaseStatusToCaseBT",
+        memory=False,
+        children=[
+            CheckCaseStatusIdempotencyNode(
+                case_id=case_id,
+                status_id=status_id,
+            ),
+            ValidateCaseStatusTransitionNode(
+                case_id=case_id,
+                status_id=status_id,
+                status_obj_fallback=status_obj,
+            ),
+            AppendCaseStatusToCaseNode(
+                case_id=case_id,
+                status_id=status_id,
+                status_obj_fallback=status_obj,
+            ),
+        ],
+    )
+    logger.debug(
+        "Created AddCaseStatusToCaseBT for status=%s case=%s actor=%s",
+        status_id,
+        case_id,
+        request.actor_id,
+    )
+    return root

--- a/vultron/core/behaviors/status/nodes.py
+++ b/vultron/core/behaviors/status/nodes.py
@@ -14,9 +14,11 @@
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
 """
-BT nodes for the AddParticipantStatusToParticipant workflow.
+BT nodes for status-related workflows.
 
-Implements all five steps of DEMOMA-07-003:
+Contains nodes for two workflows:
+
+AddParticipantStatusToParticipant (DEMOMA-07-003):
   1. Verify the activity actor is a known case participant.
   2. Append the ParticipantStatus to the CaseParticipant record.
   3. Announce the update to all other case participants.
@@ -24,8 +26,10 @@ Implements all five steps of DEMOMA-07-003:
   5. If all participants are RM.CLOSED, close the case automatically
      (log-only for prototype).
 
-These nodes are composed by ``add_participant_status_tree`` into the
-``AddParticipantStatusBT`` sequence.
+AddCaseStatusToCase (issue #758):
+  1. Check idempotency: CaseStatus not yet in case.case_statuses.
+  2. Validate EM/PXA state transitions.
+  3. Append CaseStatus to the VulnerabilityCase record.
 
 Per specs/multi-actor-demo.yaml DEMOMA-07-003,
     specs/behavior-tree-integration.yaml BT-06-001.
@@ -44,6 +48,8 @@ from vultron.core.models.protocols import (
     is_case_model,
     is_participant_model,
 )
+from vultron.core.states.cs import is_valid_pxa_transition
+from vultron.core.states.em import is_valid_em_transition
 from vultron.core.states.rm import (
     RM,
     is_monotonic_rm_forward,
@@ -51,6 +57,11 @@ from vultron.core.states.rm import (
 )
 from vultron.core.states.roles import CVDRole
 from vultron.core.use_cases._helpers import _as_id
+
+# Stable sentinel used as feedback_message when a CaseStatus duplicate is
+# detected.  The use case imports this constant to distinguish idempotent
+# no-ops (log at INFO) from real failures (log at WARNING).
+CASE_STATUS_ALREADY_PRESENT = "case_status_already_present"
 
 if TYPE_CHECKING:
     from vultron.core.ports.case_persistence import CasePersistence
@@ -583,6 +594,227 @@ class AutoCloseBranchNode(DataLayerAction):
             "AutoCloseBranch: Case Manager '%s' auto-closing case '%s'"
             " — all participants CLOSED (DEMOMA-07-003 step 5)",
             case_manager_id,
+            self.case_id,
+        )
+        return Status.SUCCESS
+
+
+# ---------------------------------------------------------------------------
+# AddCaseStatusToCase nodes (issue #758)
+# ---------------------------------------------------------------------------
+
+
+class CheckCaseStatusIdempotencyNode(DataLayerCondition):
+    """AC-1: Verify the CaseStatus has not already been added to the case.
+
+    Returns FAILURE with ``feedback_message == CASE_STATUS_ALREADY_PRESENT``
+    when *status_id* is already in ``case.case_statuses`` — a benign no-op.
+
+    Returns FAILURE with a distinct message when the case itself is not found.
+
+    Returns SUCCESS when the status is not yet present and the Sequence should
+    continue.
+
+    Per issue #758 AC-1.
+    """
+
+    def __init__(
+        self,
+        case_id: str,
+        status_id: str,
+        name: str | None = None,
+    ):
+        super().__init__(name=name or self.__class__.__name__)
+        self.case_id = case_id
+        self.status_id = status_id
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.feedback_message = "DataLayer not available"
+            return Status.FAILURE
+
+        case = self.datalayer.read(self.case_id)
+        if not is_case_model(case):
+            self.feedback_message = f"Case '{self.case_id}' not found"
+            self.logger.warning(
+                "CheckCaseStatusIdempotency: %s", self.feedback_message
+            )
+            return Status.FAILURE
+
+        existing_ids = [_as_id(s) for s in case.case_statuses]
+        if self.status_id in existing_ids:
+            self.feedback_message = CASE_STATUS_ALREADY_PRESENT
+            self.logger.debug(
+                "CheckCaseStatusIdempotency: status '%s' already in case '%s'"
+                " — skipping (idempotent)",
+                self.status_id,
+                self.case_id,
+            )
+            return Status.FAILURE
+
+        return Status.SUCCESS
+
+
+class ValidateCaseStatusTransitionNode(DataLayerCondition):
+    """AC-2: Validate that the new CaseStatus represents a legal state transition.
+
+    Uses ``case.current_status`` as the reference point.  When the case has no
+    current status (first status ever), the transition is unconditionally
+    allowed.  Otherwise both the EM state and PXA state transitions are
+    validated independently.
+
+    Returns SUCCESS when the transition is valid (or there is no prior status).
+    Returns FAILURE when an invalid EM or PXA transition is detected.
+
+    Per issue #758 AC-2.
+    """
+
+    def __init__(
+        self,
+        case_id: str,
+        status_id: str,
+        status_obj_fallback: PersistableModel | None,
+        name: str | None = None,
+    ):
+        super().__init__(name=name or self.__class__.__name__)
+        self.case_id = case_id
+        self.status_id = status_id
+        self.status_obj_fallback = status_obj_fallback
+
+    def _resolve_status(self) -> object | None:
+        assert self.datalayer is not None
+        status_obj = self.datalayer.read(self.status_id)
+        if hasattr(status_obj, "id_"):
+            return status_obj
+        return self.status_obj_fallback
+
+    def _check_transition(
+        self,
+        label: str,
+        current: object,
+        new: object,
+        validator: Any,
+    ) -> bool:
+        if new is None or current == new:
+            return True
+        if validator(current, new):
+            return True
+        self.feedback_message = (
+            f"Invalid {label} transition {current} → {new}"
+            f" for case '{self.case_id}'"
+        )
+        self.logger.warning(
+            "ValidateCaseStatusTransition: %s — rejecting",
+            self.feedback_message,
+        )
+        return False
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.feedback_message = "DataLayer not available"
+            return Status.FAILURE
+
+        case = self.datalayer.read(self.case_id)
+        if not is_case_model(case):
+            self.feedback_message = f"Case '{self.case_id}' not found"
+            self.logger.warning(
+                "ValidateCaseStatusTransition: %s", self.feedback_message
+            )
+            return Status.FAILURE
+
+        current_status = getattr(case, "current_status", None)
+        if current_status is None:
+            return Status.SUCCESS
+
+        status_obj = self._resolve_status()
+        if status_obj is None:
+            self.feedback_message = f"Status '{self.status_id}' not found"
+            self.logger.warning(
+                "ValidateCaseStatusTransition: %s", self.feedback_message
+            )
+            return Status.FAILURE
+
+        if not self._check_transition(
+            "EM",
+            current_status.em_state,
+            getattr(status_obj, "em_state", None),
+            is_valid_em_transition,
+        ):
+            return Status.FAILURE
+
+        if not self._check_transition(
+            "PXA",
+            current_status.pxa_state,
+            getattr(status_obj, "pxa_state", None),
+            is_valid_pxa_transition,
+        ):
+            return Status.FAILURE
+
+        return Status.SUCCESS
+
+
+class AppendCaseStatusToCaseNode(DataLayerAction):
+    """Append the resolved CaseStatus to ``case.case_statuses`` and persist.
+
+    Resolves the status object from the DataLayer first; if not found there,
+    saves the inline fallback and re-reads so the stored canonical record is
+    used.
+
+    Returns SUCCESS on successful append.
+    Returns FAILURE if the case or status cannot be resolved.
+
+    Per issue #758 AC-1.
+    """
+
+    def __init__(
+        self,
+        case_id: str,
+        status_id: str,
+        status_obj_fallback: PersistableModel | None,
+        name: str | None = None,
+    ):
+        super().__init__(name=name or self.__class__.__name__)
+        self.case_id = case_id
+        self.status_id = status_id
+        self.status_obj_fallback = status_obj_fallback
+
+    def _resolve_status(self) -> "PersistableModel | None":
+        assert self.datalayer is not None
+        status_obj = self.datalayer.read(self.status_id)
+        if hasattr(status_obj, "id_"):
+            return status_obj
+        status_obj = self.status_obj_fallback
+        if status_obj is not None:
+            self.datalayer.save(status_obj)
+            status_obj = self.datalayer.read(self.status_id) or status_obj
+        return status_obj if hasattr(status_obj, "id_") else None
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.feedback_message = "DataLayer not available"
+            return Status.FAILURE
+
+        case = self.datalayer.read(self.case_id)
+        if not is_case_model(case):
+            self.feedback_message = f"Case '{self.case_id}' not found"
+            self.logger.warning(
+                "AppendCaseStatusToCase: %s", self.feedback_message
+            )
+            return Status.FAILURE
+
+        status_obj = self._resolve_status()
+        if status_obj is None:
+            self.feedback_message = f"Status '{self.status_id}' not found"
+            self.logger.warning(
+                "AppendCaseStatusToCase: %s", self.feedback_message
+            )
+            return Status.FAILURE
+
+        case.case_statuses.append(status_obj)
+        self.datalayer.save(case)
+        self.logger.info(
+            "AppendCaseStatusToCase: added status '%s' to case '%s'",
+            self.status_id,
             self.case_id,
         )
         return Status.SUCCESS

--- a/vultron/core/use_cases/received/status.py
+++ b/vultron/core/use_cases/received/status.py
@@ -1,7 +1,7 @@
 """Use cases for case and participant status activities."""
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from py_trees.common import Status
 
@@ -15,76 +15,13 @@ from vultron.core.ports.case_persistence import (
     CasePersistence,
     CaseOutboxPersistence,
 )
-from vultron.core.states.cs import is_valid_pxa_transition
-from vultron.core.states.em import is_valid_em_transition
-from vultron.core.use_cases._helpers import _as_id, _idempotent_create
-from vultron.core.models.protocols import (
-    is_case_model,
-)
+from vultron.core.use_cases._helpers import _idempotent_create
 
 if TYPE_CHECKING:
     from vultron.core.ports.sync_activity import SyncActivityPort
     from vultron.core.ports.trigger_activity import TriggerActivityPort
 
 logger = logging.getLogger(__name__)
-
-
-def _resolve_case_status_object(
-    dl: CasePersistence,
-    status_id: str,
-    request: AddCaseStatusToCaseReceivedEvent,
-) -> object:
-    status_obj = dl.read(status_id)
-    if hasattr(status_obj, "id_"):
-        return status_obj
-    return request.status
-
-
-def _validate_case_status_transition(
-    case: object, status_obj: object, case_id: str
-) -> bool:
-    current_status = getattr(case, "current_status", None)
-    if current_status is None:
-        return True
-
-    if not _validate_optional_case_transition(
-        "EM",
-        current_status.em_state,
-        getattr(status_obj, "em_state", None),
-        case_id,
-        is_valid_em_transition,
-    ):
-        return False
-
-    return _validate_optional_case_transition(
-        "PXA",
-        current_status.pxa_state,
-        getattr(status_obj, "pxa_state", None),
-        case_id,
-        is_valid_pxa_transition,
-    )
-
-
-def _validate_optional_case_transition(
-    label: str,
-    current_state: object,
-    new_state: object,
-    case_id: str,
-    validator: Any,
-) -> bool:
-    if new_state is None or current_state == new_state:
-        return True
-    if validator(current_state, new_state):
-        return True
-
-    logger.warning(
-        "Invalid %s transition %s → %s for case '%s'; skipping status append",
-        label,
-        current_state,
-        new_state,
-        case_id,
-    )
-    return False
 
 
 class CreateCaseStatusReceivedUseCase:
@@ -122,32 +59,40 @@ class AddCaseStatusToCaseReceivedUseCase:
                 "add_case_status_to_case: missing status_id or case_id"
             )
             return
-        case = self._dl.read(case_id)
 
-        if not is_case_model(case):
-            logger.warning(
-                "add_case_status_to_case: case '%s' not found", case_id
-            )
-            return
+        from vultron.core.behaviors.bridge import BTBridge
+        from vultron.core.behaviors.status.add_case_status_tree import (
+            add_case_status_tree,
+        )
+        from vultron.core.behaviors.status.nodes import (
+            CASE_STATUS_ALREADY_PRESENT,
+        )
 
-        existing_ids = [_as_id(s) for s in case.case_statuses]
-        if status_id in existing_ids:
-            logger.info(
-                "CaseStatus '%s' already in case '%s' — skipping (idempotent)",
-                status_id,
-                case_id,
-            )
-            return
+        tree = add_case_status_tree(request=request)
+        bridge = BTBridge(datalayer=self._dl)
+        result = bridge.execute_with_setup(
+            tree=tree,
+            actor_id=request.actor_id,
+            activity=request,
+        )
 
-        status_obj = _resolve_case_status_object(self._dl, status_id, request)
-        if case.case_statuses and not _validate_case_status_transition(
-            case, status_obj, case_id
-        ):
-            return
-
-        case.case_statuses.append(status_obj)
-        self._dl.save(case)
-        logger.info("Added CaseStatus '%s' to case '%s'", status_id, case_id)
+        if result.status != Status.SUCCESS:
+            reason = BTBridge.get_failure_reason(tree)
+            reason_str = reason or result.feedback_message or ""
+            if reason_str == CASE_STATUS_ALREADY_PRESENT:
+                logger.info(
+                    "CaseStatus '%s' already in case '%s'"
+                    " — skipping (idempotent)",
+                    status_id,
+                    case_id,
+                )
+            else:
+                logger.warning(
+                    "AddCaseStatusToCaseBT did not succeed for activity"
+                    " '%s': %s",
+                    request.activity_id,
+                    reason_str,
+                )
 
 
 class CreateParticipantStatusReceivedUseCase:


### PR DESCRIPTION
## Summary

Wraps `AddCaseStatusToCaseReceivedUseCase` in a py_trees behavior tree, migrating it from a fully procedural implementation to the canonical BT delegation pattern (same as `AddParticipantStatusToParticipantReceivedUseCase`).

## Changes

### New: `vultron/core/behaviors/status/add_case_status_tree.py`
Factory function `add_case_status_tree()` composing a 3-node `AddCaseStatusToCaseBT` Sequence.

### Updated: `vultron/core/behaviors/status/nodes.py`
Three new BT node classes:
- `CheckCaseStatusIdempotencyNode` — FAILURE if status already present (AC-1)
- `ValidateCaseStatusTransitionNode` — FAILURE if EM/PXA transition is invalid (AC-2)
- `AppendCaseStatusToCaseNode` — appends and persists status on SUCCESS

Added `CASE_STATUS_ALREADY_PRESENT` sentinel constant for stable idempotency detection.

### Updated: `vultron/core/use_cases/received/status.py`
- Rewrote `AddCaseStatusToCaseReceivedUseCase.execute()` to delegate to BT via `BTBridge`
- Removed 3 dead private helpers (`_resolve_case_status_object`, `_validate_case_status_transition`, `_validate_optional_case_transition`) and 4 unused imports

### New: `test/core/behaviors/status/test_add_case_status_bt.py`
18 tests covering all 3 nodes, the tree factory, and use-case integration (AC-3).

## Acceptance Criteria

- [x] AC-1: Idempotency check as BT Condition node (`CheckCaseStatusIdempotencyNode`)
- [x] AC-2: EM/PXA transition validation as BT Condition node (`ValidateCaseStatusTransitionNode`)
- [x] AC-3: Tests cover BT execution paths (18 new tests)

Closes #758