### PR TITLE
feat: EmbargoLifecycle scaffold — service module + types + propose_embargo (STRICT)

### DIFF
--- a/plan/history/2606/implementation/ISSUE-746.md
+++ b/plan/history/2606/implementation/ISSUE-746.md
@@ -1,0 +1,49 @@
+---
+source: ISSUE-746
+timestamp: '2026-06-04T16:53:19.217525+00:00'
+title: 'EmbargoLifecycle scaffold: service module + types + propose_embargo (STRICT)'
+type: implementation
+---
+
+## Issue #746 — EmbargoLifecycle scaffold: service module + types + propose_embargo (STRICT)
+
+Scaffolded the `EmbargoLifecycle` service as the first delivery of Epic #538
+(RFC: Introduce EmbargoLifecycle service).
+
+### New files
+
+- `vultron/core/services/__init__.py` — new `core/services/` package
+- `vultron/core/services/embargo_lifecycle.py` — `TransitionMode`,
+  `ParticipantPECChange`, `EmbargoLifecycleResult`, `EmbargoLifecycle`
+- `test/core/services/__init__.py` — test package marker
+- `test/core/services/test_embargo_lifecycle.py` — 8 boundary tests via
+  in-memory `SqliteDataLayer`
+
+### What was implemented
+
+- `TransitionMode(StrEnum)`: `STRICT` | `OBSERVED`
+- `EmbargoLifecycleResult(BaseModel)`: full result model with `em_before`,
+  `em_after`, `case_changed`, `case_embargo_changed`, `pec_reset`,
+  `participant_changes`
+- `EmbargoLifecycle.propose_embargo()` (STRICT mode): drives EM state machine
+  via `EMAdapter`; cascades PEC `SIGNATORY→LAPSED` on `ACTIVE→REVISE`;
+  raises `VultronInvalidStateTransitionError` on invalid transitions;
+  raises `NotImplementedError` for OBSERVED mode (deferred to #747);
+  no ownership gate — authorization is caller responsibility
+
+### Test coverage (AC-5)
+
+8 boundary tests: NONE→PROPOSED, idempotent re-propose (no duplicate entry),
+ACTIVE→REVISE PEC cascade, REVISE→REVISE (no cascade), EXITED raises
+`VultronInvalidStateTransitionError`, OBSERVED mode raises `NotImplementedError`,
+owner actor succeeds, non-owner actor also succeeds.
+
+### Key design decisions
+
+- `_as_id()` duplicated from `use_cases/_helpers.py` with a TODO to consolidate
+  in `vultron.core.utils` — avoids services→use_cases cross-package dependency
+- `case_changed` is derived from actual mutations (em_state changed OR
+  embargo_id newly appended), not hardcoded True
+- `case_embargo_changed = False` for propose (active_embargo set only on accept)
+
+PR: [#777](https://github.com/CERTCC/Vultron/pull/777)

--- a/test/core/services/test_embargo_lifecycle.py
+++ b/test/core/services/test_embargo_lifecycle.py
@@ -1,0 +1,341 @@
+"""Boundary tests for EmbargoLifecycle.propose_embargo (STRICT mode).
+
+These tests exercise the service through a real in-memory SqliteDataLayer so
+that persistence invariants are validated without mocking internals.
+
+Coverage required by #746 AC-5:
+  - valid transition (NO_EMBARGO → PROPOSED)
+  - invalid transition raises VultronInvalidStateTransitionError
+  - idempotent re-propose (PROPOSED → PROPOSED)
+  - owner vs. non-owner actors (propose is not ownership-gated)
+  - ACTIVE → REVISE cascade (PEC signatory → lapsed)
+"""
+
+from collections.abc import Generator
+from typing import cast
+
+import pytest
+
+# noqa: F401 — imported for vocabulary registration side-effect
+from vultron.wire.as2.vocab.objects.vulnerability_case import (  # noqa: F401
+    VulnerabilityCase,
+)
+
+from vultron.adapters.driven.datalayer_sqlite import (
+    SqliteDataLayer,
+    reset_datalayer,
+)
+from vultron.core.services.embargo_lifecycle import (
+    EmbargoLifecycle,
+    EmbargoLifecycleResult,
+    TransitionMode,
+)
+from vultron.core.states.em import EM
+from vultron.core.states.participant_embargo_consent import PEC
+from vultron.core.states.roles import CVDRole
+from vultron.errors import VultronInvalidStateTransitionError
+from vultron.wire.as2.vocab.base.objects.actors import as_Service
+from vultron.wire.as2.vocab.objects.case_participant import (
+    CaseParticipant,
+    FinderParticipant,
+    VendorParticipant,
+)
+from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_actor(dl: SqliteDataLayer, name: str) -> as_Service:
+    actor = as_Service(name=name)
+    dl.create(actor)
+    return actor
+
+
+def _make_case(
+    dl: SqliteDataLayer,
+    owner_id: str,
+    extra_participant_ids: list[str] | None = None,
+    em_state: EM = EM.NONE,
+) -> tuple[VulnerabilityCase, list[CaseParticipant]]:
+    """Create a VulnerabilityCase with an owner participant.
+
+    Returns the case and the list of CaseParticipant objects created.
+    """
+    case = VulnerabilityCase(
+        name="Test embargo case",
+        attributed_to=owner_id,
+    )
+    case.current_status.em_state = em_state
+
+    owner_participant = VendorParticipant(
+        attributed_to=owner_id,
+        context=case.id_,
+        embargo_consent_state=PEC.NO_EMBARGO.value,
+    )
+    owner_participant.add_role(CVDRole.CASE_MANAGER)
+
+    participants: list[CaseParticipant] = [owner_participant]
+    case.case_participants = [owner_participant.id_]
+    case.actor_participant_index = {owner_id: owner_participant.id_}
+
+    for pid in extra_participant_ids or []:
+        p = FinderParticipant(
+            attributed_to=pid,
+            context=case.id_,
+            embargo_consent_state=PEC.NO_EMBARGO.value,
+        )
+        case.case_participants.append(p.id_)
+        case.actor_participant_index[pid] = p.id_
+        participants.append(p)
+
+    dl.create(case)
+    for participant in participants:
+        dl.create(participant)
+
+    return case, participants
+
+
+def _make_embargo(dl: SqliteDataLayer, case_id: str) -> EmbargoEvent:
+    embargo = EmbargoEvent(context=case_id)
+    dl.create(embargo)
+    return embargo
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def owner_and_dl() -> (
+    Generator[tuple[as_Service, SqliteDataLayer], None, None]
+):
+    owner = as_Service(name="Owner Org")
+    reset_datalayer(owner.id_)
+    dl = SqliteDataLayer("sqlite:///:memory:", actor_id=owner.id_)
+    dl.clear_all()
+    dl.create(owner)
+    try:
+        yield owner, dl
+    finally:
+        dl.close()
+        reset_datalayer(owner.id_)
+
+
+# ---------------------------------------------------------------------------
+# Tests: valid transitions
+# ---------------------------------------------------------------------------
+
+
+def test_propose_embargo_none_to_proposed(
+    owner_and_dl: tuple[as_Service, SqliteDataLayer],
+) -> None:
+    """propose_embargo from NO_EMBARGO transitions case to PROPOSED."""
+    owner, dl = owner_and_dl
+    case, _ = _make_case(dl, owner.id_, em_state=EM.NONE)
+    embargo = _make_embargo(dl, case.id_)
+
+    lifecycle = EmbargoLifecycle(persistence=dl)
+    result = lifecycle.propose_embargo(
+        case_id=case.id_,
+        embargo_id=embargo.id_,
+        actor_id=owner.id_,
+    )
+
+    assert isinstance(result, EmbargoLifecycleResult)
+    assert result.em_before == EM.NONE
+    assert result.em_after == EM.PROPOSED
+    assert result.case_changed is True
+    assert result.case_embargo_changed is False
+    assert result.pec_reset is False
+    assert result.participant_changes == []
+
+    updated = cast(VulnerabilityCase, dl.read(case.id_))
+    assert updated.current_status.em_state == EM.PROPOSED
+    assert embargo.id_ in updated.proposed_embargoes
+
+
+def test_propose_embargo_idempotent_repropse(
+    owner_and_dl: tuple[as_Service, SqliteDataLayer],
+) -> None:
+    """propose_embargo from PROPOSED → PROPOSED is valid (counter-proposal).
+
+    Calling with the same embargo_id twice must not duplicate the entry in
+    proposed_embargoes.
+    """
+    owner, dl = owner_and_dl
+    case, _ = _make_case(dl, owner.id_, em_state=EM.PROPOSED)
+    embargo = _make_embargo(dl, case.id_)
+
+    # Seed the case as already having this embargo proposed
+    case.proposed_embargoes.append(embargo.id_)
+    dl.save(case)
+
+    lifecycle = EmbargoLifecycle(persistence=dl)
+    result = lifecycle.propose_embargo(
+        case_id=case.id_,
+        embargo_id=embargo.id_,
+        actor_id=owner.id_,
+    )
+
+    assert result.em_before == EM.PROPOSED
+    assert result.em_after == EM.PROPOSED
+    # EM state did not change, embargo_id already present → nothing mutated
+    assert result.case_changed is False
+
+    updated = cast(VulnerabilityCase, dl.read(case.id_))
+    # Must not have been duplicated
+    assert updated.proposed_embargoes.count(embargo.id_) == 1
+
+
+def test_propose_embargo_active_to_revise_cascades_pec(
+    owner_and_dl: tuple[as_Service, SqliteDataLayer],
+) -> None:
+    """propose_embargo from ACTIVE transitions to REVISE and cascades PEC.
+
+    Participants in SIGNATORY state must be transitioned to LAPSED.
+    """
+    owner, dl = owner_and_dl
+    finder = _make_actor(dl, "Finder Org")
+    case, participants = _make_case(
+        dl, owner.id_, extra_participant_ids=[finder.id_], em_state=EM.ACTIVE
+    )
+    # Set both participants to SIGNATORY (active embargo consent)
+    for p in participants:
+        p.embargo_consent_state = PEC.SIGNATORY.value
+        dl.save(p)
+
+    embargo = _make_embargo(dl, case.id_)
+
+    lifecycle = EmbargoLifecycle(persistence=dl)
+    result = lifecycle.propose_embargo(
+        case_id=case.id_,
+        embargo_id=embargo.id_,
+        actor_id=owner.id_,
+    )
+
+    assert result.em_before == EM.ACTIVE
+    assert result.em_after == EM.REVISE
+    assert result.case_changed is True
+    assert len(result.participant_changes) == 2  # both signatories lapsed
+    for change in result.participant_changes:
+        assert change.pec_before == PEC.SIGNATORY.value
+        assert change.pec_after == PEC.LAPSED.value
+
+    # DataLayer state matches
+    updated = cast(VulnerabilityCase, dl.read(case.id_))
+    assert updated.current_status.em_state == EM.REVISE
+    for p in participants:
+        updated_p = cast(CaseParticipant, dl.read(p.id_))
+        assert updated_p.embargo_consent_state == PEC.LAPSED.value
+
+
+def test_propose_embargo_revise_to_revise_no_pec_cascade(
+    owner_and_dl: tuple[as_Service, SqliteDataLayer],
+) -> None:
+    """propose_embargo from REVISE → REVISE does not cascade PEC."""
+    owner, dl = owner_and_dl
+    case, _ = _make_case(dl, owner.id_, em_state=EM.REVISE)
+    embargo = _make_embargo(dl, case.id_)
+
+    lifecycle = EmbargoLifecycle(persistence=dl)
+    result = lifecycle.propose_embargo(
+        case_id=case.id_,
+        embargo_id=embargo.id_,
+        actor_id=owner.id_,
+    )
+
+    assert result.em_before == EM.REVISE
+    assert result.em_after == EM.REVISE
+    assert result.participant_changes == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: invalid transitions
+# ---------------------------------------------------------------------------
+
+
+def test_propose_embargo_invalid_state_raises(
+    owner_and_dl: tuple[as_Service, SqliteDataLayer],
+) -> None:
+    """propose_embargo from EXITED raises VultronInvalidStateTransitionError."""
+    owner, dl = owner_and_dl
+    case, _ = _make_case(dl, owner.id_, em_state=EM.EXITED)
+    embargo = _make_embargo(dl, case.id_)
+
+    lifecycle = EmbargoLifecycle(persistence=dl)
+    with pytest.raises(VultronInvalidStateTransitionError):
+        lifecycle.propose_embargo(
+            case_id=case.id_,
+            embargo_id=embargo.id_,
+            actor_id=owner.id_,
+        )
+
+
+def test_propose_embargo_observed_mode_raises_not_implemented(
+    owner_and_dl: tuple[as_Service, SqliteDataLayer],
+) -> None:
+    """OBSERVED mode is not yet implemented and must raise NotImplementedError."""
+    owner, dl = owner_and_dl
+    case, _ = _make_case(dl, owner.id_, em_state=EM.NONE)
+    embargo = _make_embargo(dl, case.id_)
+
+    lifecycle = EmbargoLifecycle(persistence=dl)
+    with pytest.raises(NotImplementedError):
+        lifecycle.propose_embargo(
+            case_id=case.id_,
+            embargo_id=embargo.id_,
+            actor_id=owner.id_,
+            transition_mode=TransitionMode.OBSERVED,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: owner vs. non-owner
+# ---------------------------------------------------------------------------
+
+
+def test_propose_embargo_owner_succeeds(
+    owner_and_dl: tuple[as_Service, SqliteDataLayer],
+) -> None:
+    """The case owner can propose an embargo."""
+    owner, dl = owner_and_dl
+    case, _ = _make_case(dl, owner.id_, em_state=EM.NONE)
+    embargo = _make_embargo(dl, case.id_)
+
+    lifecycle = EmbargoLifecycle(persistence=dl)
+    result = lifecycle.propose_embargo(
+        case_id=case.id_,
+        embargo_id=embargo.id_,
+        actor_id=owner.id_,
+    )
+
+    assert result.em_after == EM.PROPOSED
+
+
+def test_propose_embargo_non_owner_succeeds(
+    owner_and_dl: tuple[as_Service, SqliteDataLayer],
+) -> None:
+    """A non-owner participant can also propose an embargo (no ownership gate).
+
+    The EmbargoLifecycle service enforces EM state validity but does not
+    restrict who may propose.  Ownership gates on outbound activity sending
+    are the caller's responsibility.
+    """
+    owner, dl = owner_and_dl
+    finder = _make_actor(dl, "Finder Org")
+    case, _ = _make_case(
+        dl, owner.id_, extra_participant_ids=[finder.id_], em_state=EM.NONE
+    )
+    embargo = _make_embargo(dl, case.id_)
+
+    lifecycle = EmbargoLifecycle(persistence=dl)
+    result = lifecycle.propose_embargo(
+        case_id=case.id_,
+        embargo_id=embargo.id_,
+        actor_id=finder.id_,  # non-owner
+    )
+
+    assert result.em_after == EM.PROPOSED

--- a/vultron/core/services/__init__.py
+++ b/vultron/core/services/__init__.py
@@ -1,0 +1,18 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Domain services for the Vultron core layer.
+
+Services encapsulate multi-step domain logic that spans multiple use-cases
+or state machines, keeping individual use-case and BT node classes thin.
+"""

--- a/vultron/core/services/embargo_lifecycle.py
+++ b/vultron/core/services/embargo_lifecycle.py
@@ -1,0 +1,339 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""EmbargoLifecycle service — consolidated EM + PEC state management.
+
+This service is the single authoritative place for all Embargo Management (EM)
+and Participant Embargo Consent (PEC) state transitions.  Callers — trigger use
+cases, received use cases, and BT nodes — inject an ``EmbargoLifecycle`` instance
+and call named operations; they never instantiate ``EMAdapter`` or
+``create_em_machine()`` directly.
+
+Usage::
+
+    from vultron.core.services.embargo_lifecycle import (
+        EmbargoLifecycle,
+        EmbargoLifecycleResult,
+        TransitionMode,
+    )
+
+    lifecycle = EmbargoLifecycle(persistence=dl)
+    result = lifecycle.propose_embargo(
+        case_id=case.id_,
+        embargo_id=embargo.id_,
+        actor_id=actor.id_,
+    )
+    # result.em_before, result.em_after, result.case_changed, ...
+
+Tracked in: https://github.com/CERTCC/Vultron/issues/538
+This issue: https://github.com/CERTCC/Vultron/issues/746
+"""
+
+import logging
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, Field
+from transitions import MachineError
+
+from vultron.core.models.protocols import is_case_model, is_participant_model
+from vultron.core.ports.case_persistence import CasePersistence
+from vultron.core.states.em import EM, EM_Trigger, EMAdapter, create_em_machine
+from vultron.core.states.participant_embargo_consent import (
+    PEC,
+    PEC_Trigger,
+    apply_pec_trigger,
+)
+from vultron.errors import (
+    VultronInvalidStateTransitionError,
+    VultronNotFoundError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Private utility
+# ---------------------------------------------------------------------------
+
+
+def _as_id(obj: Any) -> str | None:
+    """Return the string ID of *obj*, whether it is a str or an AS2 object.
+
+    Mirrors the same utility in ``vultron.core.use_cases._helpers``.
+    TODO: move both copies to a neutral ``vultron.core.utils`` module (#538).
+    """
+    if obj is None:
+        return None
+    id_ = getattr(obj, "id_", None)
+    if isinstance(id_, str):
+        return id_
+    return str(obj)
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+class TransitionMode(StrEnum):
+    """Controls how strict the EM state machine is during a transition.
+
+    ``STRICT``   — Used by BT behaviors and trigger use cases.  The service
+                   enforces that the requested transition is valid for the
+                   current EM state and raises
+                   :exc:`~vultron.errors.VultronInvalidStateTransitionError`
+                   otherwise.
+
+    ``OBSERVED`` — Used by received use cases.  The remote party has already
+                   asserted the new state; the service syncs local state even
+                   if the local machine would not have initiated that
+                   transition.  Implemented in follow-up issue #747.
+    """
+
+    STRICT = "STRICT"
+    OBSERVED = "OBSERVED"
+
+
+class ParticipantPECChange(BaseModel):
+    """Records a single participant's PEC state change during a lifecycle op."""
+
+    participant_id: str
+    pec_before: str
+    pec_after: str
+
+
+class EmbargoLifecycleResult(BaseModel):
+    """Structured result returned by every :class:`EmbargoLifecycle` operation.
+
+    Enables test assertions at the service boundary without inspecting
+    DataLayer internals.
+
+    Attributes:
+        em_before: EM state before the operation.
+        em_after: EM state after the operation.
+        case_changed: True if the case object was mutated and persisted.
+        case_embargo_changed: True if ``case.active_embargo`` was modified
+            (e.g. an embargo was activated or cleared).
+        pec_reset: True if a full PEC reset was performed across all
+            participants (e.g. on embargo termination).
+        participant_changes: Per-participant PEC state changes that occurred
+            during the operation (e.g. signatories lapsed on REVISE).
+    """
+
+    em_before: EM
+    em_after: EM
+    case_changed: bool
+    case_embargo_changed: bool
+    pec_reset: bool
+    participant_changes: list[ParticipantPECChange] = Field(
+        default_factory=list
+    )
+
+
+# ---------------------------------------------------------------------------
+# Service class
+# ---------------------------------------------------------------------------
+
+
+class EmbargoLifecycle:
+    """Consolidated EM + PEC state management service.
+
+    Owns all Embargo Management (EM) and Participant Embargo Consent (PEC)
+    state transition logic.  Hides ``create_em_machine()``, ``EMAdapter``,
+    ``MachineError`` handling, actor-to-participant lookup via
+    ``actor_participant_index``, PEC trigger application, and idempotent
+    ``proposed_embargoes`` / ``accepted_embargo_ids`` management.
+
+    Callers inject a :class:`~vultron.core.ports.case_persistence.CasePersistence`
+    instance once at construction.  ``SqliteDataLayer`` satisfies the protocol
+    structurally.
+
+    Currently implemented (this issue #746):
+        - :meth:`propose_embargo` — ``STRICT`` mode only
+
+    Deferred to #747:
+        - :meth:`accept_embargo_invite`
+        - :meth:`reject_embargo_invite`
+        - :meth:`terminate_active_embargo`
+        - :meth:`record_participant_consent`
+        - ``OBSERVED`` mode across all operations
+    """
+
+    def __init__(self, persistence: CasePersistence) -> None:
+        self._persistence = persistence
+
+    # ------------------------------------------------------------------
+    # Public operations
+    # ------------------------------------------------------------------
+
+    def propose_embargo(
+        self,
+        *,
+        case_id: str,
+        embargo_id: str,
+        actor_id: str | None = None,
+        transition_mode: TransitionMode = TransitionMode.STRICT,
+    ) -> EmbargoLifecycleResult:
+        """Propose or counter-propose an embargo on a case.
+
+        Valid EM transitions (STRICT mode):
+            - ``NO_EMBARGO → PROPOSED``  (initial proposal)
+            - ``PROPOSED → PROPOSED``    (counter-proposal / idempotent)
+            - ``ACTIVE → REVISE``        (revision proposal; cascades PEC)
+            - ``REVISE → REVISE``        (counter-revision / idempotent)
+
+        The ``EmbargoEvent`` identified by *embargo_id* MUST already exist in
+        the DataLayer before this method is called; the caller is responsible
+        for creating it.
+
+        Args:
+            case_id: ID of the :class:`~...VulnerabilityCase` to update.
+            embargo_id: ID of the pre-existing ``EmbargoEvent`` being proposed.
+            actor_id: Optional ID of the actor initiating the proposal (used
+                for logging only; no ownership gate on propose).
+            transition_mode: ``STRICT`` (default) enforces valid transitions.
+                ``OBSERVED`` is not yet implemented (tracked in #747).
+
+        Returns:
+            :class:`EmbargoLifecycleResult` describing what changed.
+
+        Raises:
+            NotImplementedError: If *transition_mode* is ``OBSERVED``
+                (deferred to #747).
+            VultronNotFoundError: If *case_id* does not resolve to a case.
+            VultronInvalidStateTransitionError: If the current EM state does
+                not allow a PROPOSE transition (``STRICT`` mode only).
+        """
+        if transition_mode == TransitionMode.OBSERVED:
+            raise NotImplementedError(
+                "OBSERVED mode for propose_embargo is not yet implemented; "
+                "tracked in https://github.com/CERTCC/Vultron/issues/747"
+            )
+
+        # Load and validate case
+        case = self._persistence.read(case_id)
+        if not is_case_model(case):
+            raise VultronNotFoundError("VulnerabilityCase", case_id)
+
+        em_before = EM(case.current_status.em_state)
+
+        # Drive EM state machine
+        adapter = EMAdapter(em_before)
+        em_machine = create_em_machine()
+        em_machine.add_model(adapter, initial=em_before)
+
+        try:
+            getattr(adapter, EM_Trigger.PROPOSE)()
+        except MachineError:
+            logger.warning(
+                "Invalid EM transition: actor '%s' cannot PROPOSE on case"
+                " '%s' (EM state '%s').",
+                actor_id,
+                case_id,
+                em_before,
+            )
+            raise VultronInvalidStateTransitionError(
+                f"Cannot propose embargo: case '{case_id}' EM state"
+                f" '{em_before}' does not allow a PROPOSE transition."
+            )
+
+        em_after = EM(adapter.state)
+
+        # Cascade PEC: ACTIVE → REVISE transitions SIGNATORY participants to LAPSED
+        participant_changes: list[ParticipantPECChange] = []
+        if em_before == EM.ACTIVE and em_after == EM.REVISE:
+            participant_changes = self._cascade_pec_revise(case)
+
+        # Mutate case — track whether anything actually changed
+        case_mutated = False
+
+        if em_after != em_before:
+            case.current_status.em_state = em_after
+            case_mutated = True
+
+        # Idempotent append: normalise existing refs to strings before checking
+        existing_embargo_ids = {
+            _as_id(e) for e in case.proposed_embargoes if _as_id(e) is not None
+        }
+        if embargo_id not in existing_embargo_ids:
+            case.proposed_embargoes.append(embargo_id)
+            case_mutated = True
+
+        if case_mutated or participant_changes:
+            self._persistence.save(case)
+
+        if em_after != em_before:
+            logger.info(
+                "Actor '%s' proposed embargo '%s' on case '%s' (EM %s → %s)",
+                actor_id,
+                embargo_id,
+                case_id,
+                em_before,
+                em_after,
+            )
+        else:
+            logger.info(
+                "Actor '%s' counter-proposed embargo '%s' on case '%s'"
+                " (EM %s, no state change)",
+                actor_id,
+                embargo_id,
+                case_id,
+                em_before,
+            )
+
+        return EmbargoLifecycleResult(
+            em_before=em_before,
+            em_after=em_after,
+            case_changed=case_mutated or bool(participant_changes),
+            case_embargo_changed=False,
+            pec_reset=False,
+            participant_changes=participant_changes,
+        )
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _cascade_pec_revise(self, case: Any) -> list[ParticipantPECChange]:
+        """Transition all SIGNATORY participants to LAPSED.
+
+        Called when an embargo transitions to REVISE state, meaning the
+        embargo terms are being renegotiated.  Existing signatories temporarily
+        lapse until they accept the revised terms.
+
+        Returns a list of :class:`ParticipantPECChange` records for each
+        participant whose PEC state was updated.
+        """
+        changes: list[ParticipantPECChange] = []
+        for entry in case.case_participants:
+            participant_id = _as_id(entry)
+            if participant_id is None:
+                continue
+            participant = self._persistence.read(participant_id)
+            if not is_participant_model(participant):
+                continue
+            if participant.embargo_consent_state == PEC.SIGNATORY.value:
+                pec_before = participant.embargo_consent_state
+                participant.embargo_consent_state = apply_pec_trigger(
+                    PEC.SIGNATORY, PEC_Trigger.REVISE
+                )
+                self._persistence.save(participant)
+                changes.append(
+                    ParticipantPECChange(
+                        participant_id=participant_id,
+                        pec_before=pec_before,
+                        pec_after=participant.embargo_consent_state,
+                    )
+                )
+        return changes


### PR DESCRIPTION
## Summary

Scaffolds the `EmbargoLifecycle` service as specified in #538 (RFC: Introduce EmbargoLifecycle service).

### New files

| File | Purpose |
|---|---|
| `vultron/core/services/__init__.py` | New `core/services/` package |
| `vultron/core/services/embargo_lifecycle.py` | `TransitionMode`, `EmbargoLifecycleResult`, `EmbargoLifecycle` |
| `test/core/services/test_embargo_lifecycle.py` | Boundary tests via in-memory `SqliteDataLayer` |

### What's implemented (AC-1 through AC-6)

- **`TransitionMode(StrEnum)`**: `STRICT` | `OBSERVED`
- **`EmbargoLifecycleResult`**: `em_before`, `em_after`, `case_changed`, `case_embargo_changed`, `pec_reset`, `participant_changes`
- **`EmbargoLifecycle.propose_embargo()`** in STRICT mode:
  - Drives EM state machine via `EMAdapter`
  - On `ACTIVE→REVISE`: cascades PEC `SIGNATORY→LAPSED` for all participants
  - Raises `VultronInvalidStateTransitionError` on invalid transitions
  - Raises `NotImplementedError` for OBSERVED mode (deferred to #747)
  - No ownership gate — caller enforces actor authorization

### Test coverage

8 boundary tests covering: NONE→PROPOSED, idempotent re-propose, ACTIVE→REVISE PEC cascade, REVISE→REVISE (no cascade), invalid state, OBSERVED mode, owner and non-owner actors.

Closes #746