### PR TITLE
feat(#759): add BTs to CreateReport, AckReport, CloseReport, InvalidateReport received use cases

### DIFF
--- a/plan/history/2606/implementation/ISSUE-759.md
+++ b/plan/history/2606/implementation/ISSUE-759.md
@@ -1,0 +1,49 @@
+---
+source: ISSUE-759
+timestamp: '2026-06-04T17:18:13.153754+00:00'
+title: Add BTs to CreateReport, AckReport, CloseReport, InvalidateReport received
+  use cases
+type: implementation
+---
+
+## Issue #759 — Add BTs to report received use cases: CreateReport, AckReport, CloseReport, InvalidateReport
+
+Wrapped the four procedural received-side report use cases in Behavior Trees,
+following the pattern established in #758.
+
+### Delivered
+
+**New files:**
+
+- `vultron/core/behaviors/report/nodes/storage.py` — `StoreReportNode` and
+  `StoreActivityNode` (idempotent storage nodes)
+- `vultron/core/behaviors/report/received_report_trees.py` — four BT factory
+  functions
+
+**Modified files:**
+
+- `vultron/core/behaviors/report/nodes/rm_transitions.py` — added
+  `TransitionCaseParticipantRMtoClosed` and `TransitionCaseParticipantRMtoInvalid`
+  with shared `_transition_case_participant_rm()` helper (soft-pass on no-case-found;
+  FAILURE only when transition is blocked)
+- `vultron/core/behaviors/report/nodes/__init__.py` — re-exports new node classes
+- `vultron/core/use_cases/received/report.py` — all four target use cases delegate
+  to BTBridge (deferred imports pattern)
+- `test/core/behaviors/report/conftest.py` — adds `make_payload` fixture
+- `test/core/behaviors/report/test_received_report_trees.py` — 33 tests covering
+  node, tree, and use-case levels
+
+### Key learnings
+
+`StoreActivityNode` uses a narrow `ValueError` catch instead of the
+`_idempotent_create()` pattern because `dl.read()` cannot retrieve
+`VultronActivity` by URI — they are stored in type-keyed collections (e.g.
+`"Create"`, `"Read"`). The `ValueError` from `dl.create()` always means
+"duplicate" for activities. `StoreReportNode` correctly uses
+`_idempotent_create()` since `dl.read()` works for `VulnerabilityReport`.
+
+### Outcome
+
+2823 tests passing, all 4 linters clean.
+
+PR: [#779](https://github.com/CERTCC/Vultron/pull/779)

--- a/test/core/behaviors/report/conftest.py
+++ b/test/core/behaviors/report/conftest.py
@@ -8,7 +8,23 @@ in isolation, causing TinyDB's record_to_object() to fall back to returning a
 raw Document instead of a deserialized domain object.
 """
 
+import pytest
+
 # noqa: F401 — imported for vocabulary registration side-effect
 from vultron.wire.as2.vocab.objects.vulnerability_case import (  # noqa: F401
     VulnerabilityCase,
 )
+from vultron.semantic_registry import extract_event
+
+
+@pytest.fixture
+def make_payload():
+    """Return a helper that extracts a VultronEvent from an AS2 activity."""
+
+    def _make_payload(activity, **extra_fields):
+        event = extract_event(activity)
+        if extra_fields:
+            return event.model_copy(update=extra_fields)
+        return event
+
+    return _make_payload

--- a/test/core/behaviors/report/test_received_report_trees.py
+++ b/test/core/behaviors/report/test_received_report_trees.py
@@ -1,0 +1,678 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Tests for received-report behavior trees and use-case integration.
+
+Covers all four report-lifecycle BTs (issue #759 AC-1 through AC-5):
+  - ``CreateReportReceivedBT``    — stores report + activity
+  - ``AckReportReceivedBT``      — stores activity
+  - ``CloseReportReceivedBT``    — stores activity + RM → CLOSED
+  - ``InvalidateReportReceivedBT`` — stores activity + RM → INVALID
+
+Each BT is tested at three levels:
+  1. Node-level (individual storage / transition nodes)
+  2. Tree-level (full factory via BTBridge)
+  3. Use-case-level (``*ReceivedUseCase.execute()``)
+"""
+
+import logging
+from typing import cast
+
+import pytest
+from py_trees.common import Status
+
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.core.behaviors.bridge import BTBridge
+from vultron.core.behaviors.report.nodes.rm_transitions import (
+    TransitionCaseParticipantRMtoClosed,
+    TransitionCaseParticipantRMtoInvalid,
+)
+from vultron.core.behaviors.report.nodes.storage import (
+    StoreActivityNode,
+    StoreReportNode,
+)
+from vultron.core.behaviors.report.received_report_trees import (
+    create_ack_report_received_tree,
+    create_close_report_received_tree,
+    create_create_report_received_tree,
+    create_invalidate_report_received_tree,
+)
+from vultron.core.models.activity import VultronActivity
+from vultron.core.models.events import MessageSemantics
+from vultron.core.models.events.report import (
+    AckReportReceivedEvent,
+    CloseReportReceivedEvent,
+    CreateReportReceivedEvent,
+    InvalidateReportReceivedEvent,
+)
+from vultron.core.models.participant import VultronParticipant
+from vultron.core.models.participant_status import ParticipantStatus
+from vultron.core.models.report import VultronReport as CoreReport
+from vultron.core.states.rm import RM
+from vultron.core.use_cases.received.report import (
+    AckReportReceivedUseCase,
+    CloseReportReceivedUseCase,
+    CreateReportReceivedUseCase,
+    InvalidateReportReceivedUseCase,
+)
+from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+ACTOR_ID = "https://example.org/actors/vendor"
+FINDER_ID = "https://example.org/actors/finder"
+REPORT_ID = "https://example.org/reports/rpt-bt-01"
+ACTIVITY_ID = "https://example.org/activities/act-bt-01"
+CASE_ID = "https://example.org/cases/case-bt-01"
+PARTICIPANT_ID = "https://example.org/participants/p-bt-01"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _activity_stored(dl: SqliteDataLayer, activity_id: str) -> bool:
+    """Return True if any activity with *activity_id* is in the DataLayer.
+
+    Activities are stored in type-keyed collections (e.g. ``"Create"``),
+    so ``dl.read(id)`` does not work for them.  This helper tries each
+    known activity type used in these tests.
+    """
+    for type_key in ("Create", "Read", "Reject", "TentativeReject", "Offer"):
+        for record in dl.get_all(type_key):
+            if record.get("id_") == activity_id:
+                return True
+    return False
+
+
+def _make_activity(
+    id_: str = ACTIVITY_ID,
+    type_: str = "Create",
+    actor: str = ACTOR_ID,
+) -> VultronActivity:
+    """Build a minimal VultronActivity with sensible defaults."""
+    return VultronActivity(id_=id_, type_=type_, actor=actor)
+
+
+def _setup_case_with_participant(
+    dl: SqliteDataLayer,
+    report_id: str = REPORT_ID,
+    actor_id: str = ACTOR_ID,
+    initial_rm: RM = RM.RECEIVED,
+) -> tuple[VulnerabilityCase, VultronParticipant]:
+    """Create and persist a VulnerabilityCase linked to a report.
+
+    Adds a CaseParticipant for *actor_id* so RM transition nodes can find
+    the participant record.
+
+    Returns:
+        Tuple of (case, participant) as persisted in *dl*.
+    """
+    report = CoreReport(id_=report_id)
+    dl.save(report)
+
+    participant = VultronParticipant(
+        id_=PARTICIPANT_ID,
+        attributed_to=actor_id,
+        context=CASE_ID,
+        participant_statuses=[
+            ParticipantStatus(
+                rm_state=initial_rm,
+                context=CASE_ID,
+                attributed_to=actor_id,
+            )
+        ],
+    )
+    case = VulnerabilityCase(id_=CASE_ID, name="BT Test Case")
+    case.vulnerability_reports.append(report_id)
+    case.case_participants.append(participant.id_)
+    case.actor_participant_index[actor_id] = participant.id_
+
+    dl.save(participant)
+    dl.save(case)
+    return case, participant
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def dl() -> SqliteDataLayer:
+    return SqliteDataLayer("sqlite:///:memory:")
+
+
+@pytest.fixture
+def bridge(dl: SqliteDataLayer) -> BTBridge:
+    return BTBridge(datalayer=dl)
+
+
+# ---------------------------------------------------------------------------
+# StoreReportNode
+# ---------------------------------------------------------------------------
+
+
+class TestStoreReportNode:
+    def test_stores_report_in_dl(self, dl, bridge):
+        """StoreReportNode persists a VulnerabilityReport → SUCCESS."""
+        report = CoreReport(id_=REPORT_ID)
+        node = StoreReportNode(report_id=REPORT_ID, report_obj=report)
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+
+        assert result.status == Status.SUCCESS
+        stored = dl.read(REPORT_ID)
+        assert stored is not None
+
+    def test_idempotent_second_store(self, dl, bridge):
+        """StoreReportNode is idempotent — second call is a no-op SUCCESS."""
+        report = CoreReport(id_=REPORT_ID)
+        dl.create(report)  # pre-store
+
+        node = StoreReportNode(report_id=REPORT_ID, report_obj=report)
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+        assert result.status == Status.SUCCESS
+
+    def test_no_report_obj_succeeds_with_warning(self, dl, bridge, caplog):
+        """StoreReportNode with report_obj=None logs warning → SUCCESS."""
+        node = StoreReportNode(report_id=REPORT_ID, report_obj=None)
+        with caplog.at_level(logging.WARNING):
+            result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+
+        assert result.status == Status.SUCCESS
+        assert dl.read(REPORT_ID) is None
+
+    def test_empty_report_id_is_no_op(self, bridge):
+        """StoreReportNode with empty report_id is a no-op SUCCESS."""
+        node = StoreReportNode(
+            report_id="", report_obj=CoreReport(id_=REPORT_ID)
+        )
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+        assert result.status == Status.SUCCESS
+
+
+# ---------------------------------------------------------------------------
+# StoreActivityNode
+# ---------------------------------------------------------------------------
+
+
+class TestStoreActivityNode:
+    def test_stores_activity_in_dl(self, dl, bridge):
+        """StoreActivityNode persists an activity → SUCCESS."""
+        activity = _make_activity()
+        node = StoreActivityNode(
+            activity_id=ACTIVITY_ID,
+            activity_obj=activity,
+            label="TestActivity",
+        )
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+
+        assert result.status == Status.SUCCESS
+        # Activities are stored in type-keyed collections; dl.read() won't find them.
+        stored = dl.get_all(activity.type_)
+        assert any(r["id_"] == ACTIVITY_ID for r in stored)
+
+    def test_idempotent_second_store(self, dl, bridge):
+        """StoreActivityNode is idempotent — second call is a no-op SUCCESS."""
+        activity = _make_activity()
+        dl.create(activity)  # pre-store
+
+        node = StoreActivityNode(
+            activity_id=ACTIVITY_ID,
+            activity_obj=activity,
+        )
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+        assert result.status == Status.SUCCESS
+
+    def test_no_activity_obj_succeeds_with_warning(self, dl, bridge, caplog):
+        """StoreActivityNode with activity_obj=None logs warning → SUCCESS."""
+        node = StoreActivityNode(
+            activity_id=ACTIVITY_ID,
+            activity_obj=None,
+        )
+        with caplog.at_level(logging.WARNING):
+            result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+
+        assert result.status == Status.SUCCESS
+        assert dl.get_all("Create") == []
+
+    def test_empty_activity_id_is_no_op(self, bridge):
+        """StoreActivityNode with empty activity_id is a no-op SUCCESS."""
+        node = StoreActivityNode(
+            activity_id="",
+            activity_obj=_make_activity(),
+        )
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+        assert result.status == Status.SUCCESS
+
+
+# ---------------------------------------------------------------------------
+# TransitionCaseParticipantRMtoClosed
+# ---------------------------------------------------------------------------
+
+
+class TestTransitionCaseParticipantRMtoClosed:
+    def test_transitions_rm_to_closed(self, dl, bridge):
+        """Participant RM → CLOSED when case found for report."""
+        case, _ = _setup_case_with_participant(
+            dl, REPORT_ID, ACTOR_ID, RM.INVALID
+        )
+
+        node = TransitionCaseParticipantRMtoClosed(report_id=REPORT_ID)
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+
+        assert result.status == Status.SUCCESS
+        updated_case = cast(VulnerabilityCase, dl.read(CASE_ID))
+        p_id = updated_case.actor_participant_index[ACTOR_ID]
+        participant = cast(VultronParticipant, dl.read(p_id))
+        assert participant.participant_statuses[-1].rm_state == RM.CLOSED
+
+    def test_no_case_is_soft_pass(self, dl, bridge, caplog):
+        """No case for report → WARNING logged, SUCCESS returned (soft pass)."""
+        report = CoreReport(id_=REPORT_ID)
+        dl.save(report)
+
+        node = TransitionCaseParticipantRMtoClosed(report_id=REPORT_ID)
+        with caplog.at_level(logging.WARNING):
+            result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+
+        assert result.status == Status.SUCCESS
+        warn_msgs = [
+            r.message for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert any("no case found" in m.lower() for m in warn_msgs)
+
+    def test_no_report_id_is_no_op(self, bridge):
+        """report_id=None → no-op SUCCESS (debug only)."""
+        node = TransitionCaseParticipantRMtoClosed(report_id=None)
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+        assert result.status == Status.SUCCESS
+
+
+# ---------------------------------------------------------------------------
+# TransitionCaseParticipantRMtoInvalid
+# ---------------------------------------------------------------------------
+
+
+class TestTransitionCaseParticipantRMtoInvalid:
+    def test_transitions_rm_to_invalid(self, dl, bridge):
+        """Participant RM → INVALID when case found for report."""
+        case, _ = _setup_case_with_participant(
+            dl, REPORT_ID, ACTOR_ID, RM.RECEIVED
+        )
+
+        node = TransitionCaseParticipantRMtoInvalid(report_id=REPORT_ID)
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+
+        assert result.status == Status.SUCCESS
+        updated_case = cast(VulnerabilityCase, dl.read(CASE_ID))
+        p_id = updated_case.actor_participant_index[ACTOR_ID]
+        participant = cast(VultronParticipant, dl.read(p_id))
+        assert participant.participant_statuses[-1].rm_state == RM.INVALID
+
+    def test_no_case_is_soft_pass(self, dl, bridge, caplog):
+        """No case for report → WARNING logged, SUCCESS returned (soft pass)."""
+        report = CoreReport(id_=REPORT_ID)
+        dl.save(report)
+
+        node = TransitionCaseParticipantRMtoInvalid(report_id=REPORT_ID)
+        with caplog.at_level(logging.WARNING):
+            result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+
+        assert result.status == Status.SUCCESS
+        warn_msgs = [
+            r.message for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert any("no case found" in m.lower() for m in warn_msgs)
+
+    def test_no_report_id_is_no_op(self, bridge):
+        """report_id=None → no-op SUCCESS (debug only)."""
+        node = TransitionCaseParticipantRMtoInvalid(report_id=None)
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+        assert result.status == Status.SUCCESS
+
+
+# ---------------------------------------------------------------------------
+# Helpers: build events for tree / use-case tests
+# ---------------------------------------------------------------------------
+
+
+def _make_create_report_event() -> CreateReportReceivedEvent:
+    # object_ IS the report for CreateReport (report_id = object_id)
+    return CreateReportReceivedEvent(
+        semantic_type=MessageSemantics.CREATE_REPORT,
+        activity_id=ACTIVITY_ID,
+        actor_id=ACTOR_ID,
+        object_=CoreReport(id_=REPORT_ID),
+        inner_object=CoreReport(id_=REPORT_ID),
+        activity=_make_activity(type_="Create"),
+    )
+
+
+def _make_ack_report_event() -> AckReportReceivedEvent:
+    return AckReportReceivedEvent(
+        semantic_type=MessageSemantics.ACK_REPORT,
+        activity_id=ACTIVITY_ID,
+        actor_id=ACTOR_ID,
+        object_=CoreReport(id_=ACTIVITY_ID),
+        inner_object=CoreReport(id_=REPORT_ID),
+        activity=_make_activity(type_="Read"),
+    )
+
+
+def _make_close_report_event() -> CloseReportReceivedEvent:
+    return CloseReportReceivedEvent(
+        semantic_type=MessageSemantics.CLOSE_REPORT,
+        activity_id=ACTIVITY_ID,
+        actor_id=ACTOR_ID,
+        object_=CoreReport(id_=ACTIVITY_ID),
+        inner_object=CoreReport(id_=REPORT_ID),
+        activity=_make_activity(type_="Reject"),
+    )
+
+
+def _make_invalidate_report_event() -> InvalidateReportReceivedEvent:
+    return InvalidateReportReceivedEvent(
+        semantic_type=MessageSemantics.INVALIDATE_REPORT,
+        activity_id=ACTIVITY_ID,
+        actor_id=ACTOR_ID,
+        object_=CoreReport(id_=ACTIVITY_ID),
+        inner_object=CoreReport(id_=REPORT_ID),
+        activity=_make_activity(type_="TentativeReject"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# CreateReportReceivedBT (tree factory + use case)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateReportReceivedTree:
+    def test_happy_path_stores_report_and_activity(self, dl):
+        """Full BT stores both VulnerabilityReport and CreateReport activity."""
+        event = _make_create_report_event()
+        tree = create_create_report_received_tree(event)
+        bridge = BTBridge(datalayer=dl)
+        result = bridge.execute_with_setup(
+            tree=tree, actor_id=ACTOR_ID, activity=event
+        )
+
+        assert result.status == Status.SUCCESS
+        assert dl.read(REPORT_ID) is not None
+        assert _activity_stored(dl, ACTIVITY_ID)
+
+    def test_idempotent_run_succeeds(self, dl):
+        """Second BT execution is idempotent — no-op SUCCESS."""
+        event = _make_create_report_event()
+        bridge = BTBridge(datalayer=dl)
+
+        for _ in range(2):
+            tree = create_create_report_received_tree(event)
+            result = bridge.execute_with_setup(
+                tree=tree, actor_id=ACTOR_ID, activity=event
+            )
+            assert result.status == Status.SUCCESS
+
+
+class TestCreateReportReceivedUseCase:
+    def test_use_case_stores_report_and_activity(self):
+        """Use case delegates to BT; report and activity are persisted."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        event = _make_create_report_event()
+        CreateReportReceivedUseCase(dl, event).execute()
+
+        assert dl.read(REPORT_ID) is not None
+        assert _activity_stored(dl, ACTIVITY_ID)
+
+    def test_use_case_is_idempotent(self):
+        """Calling use case twice does not raise and stays consistent."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        event = _make_create_report_event()
+        CreateReportReceivedUseCase(dl, event).execute()
+        CreateReportReceivedUseCase(dl, event).execute()
+
+        assert dl.read(REPORT_ID) is not None
+        assert _activity_stored(dl, ACTIVITY_ID)
+
+
+# ---------------------------------------------------------------------------
+# AckReportReceivedBT (tree factory + use case)
+# ---------------------------------------------------------------------------
+
+
+class TestAckReportReceivedTree:
+    def test_happy_path_stores_activity(self, dl):
+        """Full BT stores AckReport activity → SUCCESS."""
+        event = _make_ack_report_event()
+        tree = create_ack_report_received_tree(event)
+        bridge = BTBridge(datalayer=dl)
+        result = bridge.execute_with_setup(
+            tree=tree, actor_id=ACTOR_ID, activity=event
+        )
+
+        assert result.status == Status.SUCCESS
+        assert _activity_stored(dl, ACTIVITY_ID)
+
+    def test_does_not_create_participant_status(self, dl):
+        """AckReportReceivedBT must NOT create standalone ParticipantStatus."""
+        event = _make_ack_report_event()
+        tree = create_ack_report_received_tree(event)
+        bridge = BTBridge(datalayer=dl)
+        bridge.execute_with_setup(tree=tree, actor_id=ACTOR_ID, activity=event)
+
+        all_statuses = dl.get_all("ParticipantStatus")
+        assert all_statuses == [], (
+            "AckReportReceivedBT must not create standalone "
+            "ParticipantStatus records"
+        )
+
+    def test_idempotent_run_succeeds(self, dl):
+        """Second BT execution is idempotent — no-op SUCCESS."""
+        event = _make_ack_report_event()
+        bridge = BTBridge(datalayer=dl)
+        for _ in range(2):
+            tree = create_ack_report_received_tree(event)
+            result = bridge.execute_with_setup(
+                tree=tree, actor_id=ACTOR_ID, activity=event
+            )
+            assert result.status == Status.SUCCESS
+
+
+class TestAckReportReceivedUseCase:
+    def test_use_case_stores_activity(self):
+        """Use case delegates to BT; activity is persisted."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        event = _make_ack_report_event()
+        AckReportReceivedUseCase(dl, event).execute()
+
+        assert _activity_stored(dl, ACTIVITY_ID)
+
+    def test_use_case_does_not_create_participant_status(self):
+        """Use case must NOT create standalone ParticipantStatus records."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        event = _make_ack_report_event()
+        AckReportReceivedUseCase(dl, event).execute()
+
+        all_statuses = dl.get_all("ParticipantStatus")
+        assert all_statuses == []
+
+
+# ---------------------------------------------------------------------------
+# CloseReportReceivedBT (tree factory + use case)
+# ---------------------------------------------------------------------------
+
+
+class TestCloseReportReceivedTree:
+    def test_happy_path_stores_activity_and_transitions_rm(self, dl):
+        """Full BT stores activity and transitions participant RM → CLOSED."""
+        _setup_case_with_participant(dl, REPORT_ID, ACTOR_ID, RM.INVALID)
+        event = _make_close_report_event()
+        tree = create_close_report_received_tree(event)
+        bridge = BTBridge(datalayer=dl)
+        result = bridge.execute_with_setup(
+            tree=tree, actor_id=ACTOR_ID, activity=event
+        )
+
+        assert result.status == Status.SUCCESS
+        assert _activity_stored(dl, ACTIVITY_ID)
+
+        updated_case = cast(VulnerabilityCase, dl.read(CASE_ID))
+        p_id = updated_case.actor_participant_index[ACTOR_ID]
+        participant = cast(VultronParticipant, dl.read(p_id))
+        assert participant.participant_statuses[-1].rm_state == RM.CLOSED
+
+    def test_no_case_soft_pass_with_warning(self, dl, caplog):
+        """No case linked to report → WARNING, BT still SUCCESS."""
+        event = _make_close_report_event()
+        tree = create_close_report_received_tree(event)
+        bridge = BTBridge(datalayer=dl)
+
+        with caplog.at_level(logging.WARNING):
+            result = bridge.execute_with_setup(
+                tree=tree, actor_id=ACTOR_ID, activity=event
+            )
+
+        assert result.status == Status.SUCCESS
+        warn_msgs = [
+            r.message for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert any("no case found" in m.lower() for m in warn_msgs)
+
+    def test_idempotent_rm_transition(self, dl):
+        """Already-CLOSED participant stays CLOSED; BT still SUCCESS."""
+        _setup_case_with_participant(dl, REPORT_ID, ACTOR_ID, RM.INVALID)
+        event = _make_close_report_event()
+        bridge = BTBridge(datalayer=dl)
+
+        for _ in range(2):
+            tree = create_close_report_received_tree(event)
+            result = bridge.execute_with_setup(
+                tree=tree, actor_id=ACTOR_ID, activity=event
+            )
+            assert result.status == Status.SUCCESS
+
+
+class TestCloseReportReceivedUseCase:
+    def test_use_case_stores_activity_and_transitions_rm(self):
+        """Use case delegates to BT; activity stored + RM → CLOSED."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        _setup_case_with_participant(dl, REPORT_ID, ACTOR_ID, RM.INVALID)
+        event = _make_close_report_event()
+        CloseReportReceivedUseCase(dl, event).execute()
+
+        assert _activity_stored(dl, ACTIVITY_ID)
+        updated_case = cast(VulnerabilityCase, dl.read(CASE_ID))
+        p_id = updated_case.actor_participant_index[ACTOR_ID]
+        participant = cast(VultronParticipant, dl.read(p_id))
+        assert participant.participant_statuses[-1].rm_state == RM.CLOSED
+
+    def test_use_case_warns_when_no_case(self, caplog):
+        """Use case logs WARNING when no case is found for the report."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        event = _make_close_report_event()
+
+        with caplog.at_level(logging.WARNING):
+            CloseReportReceivedUseCase(dl, event).execute()
+
+        warn_msgs = [
+            r.message for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert any("no case found" in m.lower() for m in warn_msgs)
+
+
+# ---------------------------------------------------------------------------
+# InvalidateReportReceivedBT (tree factory + use case)
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidateReportReceivedTree:
+    def test_happy_path_stores_activity_and_transitions_rm(self, dl):
+        """Full BT stores activity and transitions participant RM → INVALID."""
+        _setup_case_with_participant(dl, REPORT_ID, ACTOR_ID, RM.RECEIVED)
+        event = _make_invalidate_report_event()
+        tree = create_invalidate_report_received_tree(event)
+        bridge = BTBridge(datalayer=dl)
+        result = bridge.execute_with_setup(
+            tree=tree, actor_id=ACTOR_ID, activity=event
+        )
+
+        assert result.status == Status.SUCCESS
+        assert _activity_stored(dl, ACTIVITY_ID)
+
+        updated_case = cast(VulnerabilityCase, dl.read(CASE_ID))
+        p_id = updated_case.actor_participant_index[ACTOR_ID]
+        participant = cast(VultronParticipant, dl.read(p_id))
+        assert participant.participant_statuses[-1].rm_state == RM.INVALID
+
+    def test_no_case_soft_pass_with_warning(self, dl, caplog):
+        """No case linked to report → WARNING, BT still SUCCESS."""
+        event = _make_invalidate_report_event()
+        tree = create_invalidate_report_received_tree(event)
+        bridge = BTBridge(datalayer=dl)
+
+        with caplog.at_level(logging.WARNING):
+            result = bridge.execute_with_setup(
+                tree=tree, actor_id=ACTOR_ID, activity=event
+            )
+
+        assert result.status == Status.SUCCESS
+        warn_msgs = [
+            r.message for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert any("no case found" in m.lower() for m in warn_msgs)
+
+    def test_idempotent_rm_transition(self, dl):
+        """Already-INVALID participant stays INVALID; BT still SUCCESS."""
+        _setup_case_with_participant(dl, REPORT_ID, ACTOR_ID, RM.RECEIVED)
+        event = _make_invalidate_report_event()
+        bridge = BTBridge(datalayer=dl)
+
+        for _ in range(2):
+            tree = create_invalidate_report_received_tree(event)
+            result = bridge.execute_with_setup(
+                tree=tree, actor_id=ACTOR_ID, activity=event
+            )
+            assert result.status == Status.SUCCESS
+
+
+class TestInvalidateReportReceivedUseCase:
+    def test_use_case_stores_activity_and_transitions_rm(self):
+        """Use case delegates to BT; activity stored + RM → INVALID."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        _setup_case_with_participant(dl, REPORT_ID, ACTOR_ID, RM.RECEIVED)
+        event = _make_invalidate_report_event()
+        InvalidateReportReceivedUseCase(dl, event).execute()
+
+        assert _activity_stored(dl, ACTIVITY_ID)
+        updated_case = cast(VulnerabilityCase, dl.read(CASE_ID))
+        p_id = updated_case.actor_participant_index[ACTOR_ID]
+        participant = cast(VultronParticipant, dl.read(p_id))
+        assert participant.participant_statuses[-1].rm_state == RM.INVALID
+
+    def test_use_case_warns_when_no_case(self, caplog):
+        """Use case logs WARNING when no case is found for the report."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        event = _make_invalidate_report_event()
+
+        with caplog.at_level(logging.WARNING):
+            InvalidateReportReceivedUseCase(dl, event).execute()
+
+        warn_msgs = [
+            r.message for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert any("no case found" in m.lower() for m in warn_msgs)

--- a/test/core/behaviors/report/test_received_report_trees.py
+++ b/test/core/behaviors/report/test_received_report_trees.py
@@ -239,16 +239,16 @@ class TestStoreActivityNode:
         result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
         assert result.status == Status.SUCCESS
 
-    def test_no_activity_obj_succeeds_with_warning(self, dl, bridge, caplog):
-        """StoreActivityNode with activity_obj=None logs warning → SUCCESS."""
+    def test_no_activity_obj_is_failure(self, dl, bridge, caplog):
+        """StoreActivityNode with activity_obj=None and a set id → FAILURE."""
         node = StoreActivityNode(
             activity_id=ACTIVITY_ID,
             activity_obj=None,
         )
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.ERROR):
             result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
 
-        assert result.status == Status.SUCCESS
+        assert result.status == Status.FAILURE
         assert dl.get_all("Create") == []
 
     def test_empty_activity_id_is_no_op(self, bridge):

--- a/vultron/core/behaviors/report/nodes/__init__.py
+++ b/vultron/core/behaviors/report/nodes/__init__.py
@@ -26,6 +26,7 @@ Submodules:
 - ``case_creation``: Case creation and Create(Case) activity nodes
 - ``participant``: Case participant RM transition action nodes
 - ``emit``: Outbound engage/defer activity emission nodes
+- ``storage``: Idempotent storage nodes for inbound report objects
 """
 
 from vultron.core.behaviors.helpers import UpdateActorOutbox  # noqa: F401
@@ -51,8 +52,14 @@ from vultron.core.behaviors.report.nodes.participant import (
     TransitionParticipantRMtoDeferred,
 )
 from vultron.core.behaviors.report.nodes.rm_transitions import (
+    TransitionCaseParticipantRMtoClosed,
+    TransitionCaseParticipantRMtoInvalid,
     TransitionRMtoInvalid,
     TransitionRMtoValid,
+)
+from vultron.core.behaviors.report.nodes.storage import (
+    StoreActivityNode,
+    StoreReportNode,
 )
 
 __all__ = [
@@ -67,6 +74,8 @@ __all__ = [
     # rm_transitions
     "TransitionRMtoValid",
     "TransitionRMtoInvalid",
+    "TransitionCaseParticipantRMtoClosed",
+    "TransitionCaseParticipantRMtoInvalid",
     # case_creation
     "CreateCaseNode",
     "CreateCaseActivity",
@@ -76,6 +85,9 @@ __all__ = [
     # emit
     "EmitEngageCaseActivity",
     "EmitDeferCaseActivity",
+    # storage
+    "StoreReportNode",
+    "StoreActivityNode",
     # re-exported from helpers (backward compat)
     "UpdateActorOutbox",
 ]

--- a/vultron/core/behaviors/report/nodes/rm_transitions.py
+++ b/vultron/core/behaviors/report/nodes/rm_transitions.py
@@ -28,6 +28,71 @@ from vultron.core.use_cases._helpers import (
 )
 
 
+def _transition_case_participant_rm(
+    node: "DataLayerAction",
+    report_id: str | None,
+    new_rm_state: RM,
+) -> "Status":
+    """Shared logic for case-participant RM transitions triggered by report.
+
+    Finds the VulnerabilityCase associated with *report_id* and advances the
+    actor's RM state in that case.
+
+    Soft-passes (SUCCESS) when no report_id is provided or when no case is
+    found for the report — matching the log-and-continue behavior of the
+    original procedural handlers.  Returns FAILURE only when a case is found
+    but ``update_participant_rm_state`` reports the transition was blocked.
+
+    Args:
+        node: Calling DataLayerAction node (provides datalayer and actor_id).
+        report_id: ID of the VulnerabilityReport; may be None.
+        new_rm_state: Target RM state to transition the participant to.
+
+    Returns:
+        SUCCESS or FAILURE (py_trees Status).
+    """
+    from py_trees.common import Status
+
+    if not report_id:
+        node.logger.debug(
+            "%s: no report_id — skipping RM transition", node.name
+        )
+        return Status.SUCCESS
+
+    if node.datalayer is None:
+        node.logger.error("%s: DataLayer not available", node.name)
+        return Status.FAILURE
+
+    case = node.datalayer.find_case_by_report_id(report_id)
+    if not is_case_model(case):
+        node.logger.warning(
+            "%s: no case found for report '%s' — RM state not updated",
+            node.name,
+            report_id,
+        )
+        return Status.SUCCESS
+
+    actor_id = node.actor_id
+    if actor_id is None:
+        node.logger.error("%s: actor_id not set on blackboard", node.name)
+        return Status.FAILURE
+
+    ok = update_participant_rm_state(
+        case.id_, actor_id, new_rm_state, node.datalayer
+    )
+    if not ok:
+        node.logger.warning(
+            "%s: RM transition to %s blocked for actor '%s' in case '%s'",
+            node.name,
+            new_rm_state,
+            actor_id,
+            case.id_,
+        )
+        return Status.FAILURE
+
+    return Status.SUCCESS
+
+
 class TransitionRMtoValid(DataLayerAction):
     """
     Transition report to RM.VALID and offer to ACCEPTED.
@@ -172,3 +237,81 @@ class TransitionRMtoInvalid(DataLayerAction):
                 f"{self.name}: Error transitioning to INVALID: {e}"
             )
             return Status.FAILURE
+
+
+class TransitionCaseParticipantRMtoClosed(DataLayerAction):
+    """Transition the actor's RM state to CLOSED in the case for a report.
+
+    Looks up the VulnerabilityCase by ``report_id`` and advances the actor's
+    RM state to ``RM.CLOSED`` via ``update_participant_rm_state``.
+
+    Soft-passes (SUCCESS) when no ``report_id`` is set or no case is found,
+    matching the log-and-continue behavior of ``CloseReportReceivedUseCase``.
+    """
+
+    def __init__(self, report_id: str | None, name: str | None = None):
+        """Initialize TransitionCaseParticipantRMtoClosed.
+
+        Args:
+            report_id: ID of the VulnerabilityReport whose case should be
+                updated; may be None for a no-op soft pass.
+            name: Optional custom node name.
+        """
+        super().__init__(name=name or self.__class__.__name__)
+        self.report_id = report_id
+
+    def update(self) -> Status:
+        """Transition participant RM state → CLOSED.
+
+        Returns:
+            SUCCESS if transitioned (or no case found — soft pass);
+            FAILURE if the DataLayer is unavailable or the transition is
+            blocked.
+        """
+        if self.datalayer is None or self.actor_id is None:
+            self.logger.error(
+                "%s: DataLayer or actor_id not available", self.name
+            )
+            return Status.FAILURE
+
+        return _transition_case_participant_rm(self, self.report_id, RM.CLOSED)
+
+
+class TransitionCaseParticipantRMtoInvalid(DataLayerAction):
+    """Transition the actor's RM state to INVALID in the case for a report.
+
+    Looks up the VulnerabilityCase by ``report_id`` and advances the actor's
+    RM state to ``RM.INVALID`` via ``update_participant_rm_state``.
+
+    Soft-passes (SUCCESS) when no ``report_id`` is set or no case is found,
+    matching the log-and-continue behavior of ``InvalidateReportReceivedUseCase``.
+    """
+
+    def __init__(self, report_id: str | None, name: str | None = None):
+        """Initialize TransitionCaseParticipantRMtoInvalid.
+
+        Args:
+            report_id: ID of the VulnerabilityReport whose case should be
+                updated; may be None for a no-op soft pass.
+            name: Optional custom node name.
+        """
+        super().__init__(name=name or self.__class__.__name__)
+        self.report_id = report_id
+
+    def update(self) -> Status:
+        """Transition participant RM state → INVALID.
+
+        Returns:
+            SUCCESS if transitioned (or no case found — soft pass);
+            FAILURE if the DataLayer is unavailable or the transition is
+            blocked.
+        """
+        if self.datalayer is None or self.actor_id is None:
+            self.logger.error(
+                "%s: DataLayer or actor_id not available", self.name
+            )
+            return Status.FAILURE
+
+        return _transition_case_participant_rm(
+            self, self.report_id, RM.INVALID
+        )

--- a/vultron/core/behaviors/report/nodes/storage.py
+++ b/vultron/core/behaviors/report/nodes/storage.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Idempotent storage action nodes for the report behavior tree.
+
+These nodes persist inbound report-related objects (VulnerabilityReport and
+protocol activities) to the DataLayer in an idempotent way.
+
+``StoreReportNode`` delegates existence checks to ``_idempotent_create()``,
+which uses ``dl.read()`` to avoid a silent catch-all on ``ValueError``.
+
+``StoreActivityNode`` uses a guarded ``dl.create()`` with a narrow ``ValueError``
+catch.  The ``dl.read()`` approach does not work for ``VultronActivity``
+objects because they are stored in type-keyed collections (e.g. ``"Create"``)
+and cannot be retrieved by URI alone.  A ``ValueError`` from ``dl.create()``
+always means "duplicate" for activities — the SQLite DL raises precisely this
+error on duplicate IDs within a typed collection.
+
+Per issue #759 AC-1, AC-2, AC-3, AC-4.
+"""
+
+from typing import Any
+
+from py_trees.common import Status
+
+from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.use_cases._helpers import _idempotent_create
+
+
+class StoreReportNode(DataLayerAction):
+    """Idempotently store a VulnerabilityReport in the DataLayer.
+
+    Returns SUCCESS (no-op) when ``report_id`` is empty or ``report_obj`` is
+    None — this matches the guard logic in the original procedural handler
+    where a missing embedded report is logged and skipped.
+    """
+
+    def __init__(
+        self,
+        report_id: str,
+        report_obj: Any,
+        name: str | None = None,
+    ):
+        """Initialize StoreReportNode.
+
+        Args:
+            report_id: ID of the VulnerabilityReport to store.
+            report_obj: The report object to persist (may be None if absent
+                in the inbound activity).
+            name: Optional custom node name.
+        """
+        super().__init__(name=name or self.__class__.__name__)
+        self.report_id = report_id
+        self.report_obj = report_obj
+
+    def update(self) -> Status:
+        """Store the report idempotently.
+
+        Returns:
+            SUCCESS always (including no-op if report_id is empty or
+            report_obj is None); FAILURE if the DataLayer is unavailable.
+        """
+        if self.datalayer is None:
+            self.logger.error("%s: DataLayer not available", self.name)
+            return Status.FAILURE
+
+        if not self.report_id:
+            self.logger.debug("%s: no report_id — skipping store", self.name)
+            return Status.SUCCESS
+
+        _idempotent_create(
+            self.datalayer,
+            "VulnerabilityReport",
+            self.report_id,
+            self.report_obj,
+            "VulnerabilityReport",
+        )
+        return Status.SUCCESS
+
+
+class StoreActivityNode(DataLayerAction):
+    """Idempotently store an inbound protocol activity in the DataLayer.
+
+    Returns SUCCESS (no-op) when ``activity_id`` is empty or
+    ``activity_obj`` is None — matching the guard logic in the original
+    procedural handlers.
+    """
+
+    def __init__(
+        self,
+        activity_id: str,
+        activity_obj: Any,
+        label: str = "activity",
+        name: str | None = None,
+    ):
+        """Initialize StoreActivityNode.
+
+        Args:
+            activity_id: ID of the activity to store.
+            activity_obj: The activity object to persist (may be None if
+                absent in the inbound event).
+            label: Human-readable label used in log messages (e.g.
+                ``"CreateReport"``).
+            name: Optional custom node name.
+        """
+        super().__init__(name=name or self.__class__.__name__)
+        self.activity_id = activity_id
+        self.activity_obj = activity_obj
+        self.label = label
+
+    def update(self) -> Status:
+        """Store the activity idempotently.
+
+        Uses a narrow ``ValueError`` catch because ``dl.read()`` cannot look
+        up ``VultronActivity`` objects by URI — they are stored in type-keyed
+        collections (e.g. ``"Create"``, ``"Read"``).  A ``ValueError`` from
+        ``dl.create()`` always indicates a duplicate for activities.
+
+        Returns:
+            SUCCESS always (including no-op if activity_id is empty or
+            activity_obj is None); FAILURE if the DataLayer is unavailable.
+        """
+        if self.datalayer is None:
+            self.logger.error("%s: DataLayer not available", self.name)
+            return Status.FAILURE
+
+        if not self.activity_id:
+            self.logger.debug("%s: no activity_id — skipping store", self.name)
+            return Status.SUCCESS
+
+        if self.activity_obj is None:
+            self.logger.warning(
+                "%s: activity_obj is None for id '%s' — skipping store",
+                self.name,
+                self.activity_id,
+            )
+            return Status.SUCCESS
+
+        try:
+            self.datalayer.create(self.activity_obj)
+            self.logger.info(
+                "Stored %s activity '%s'", self.label, self.activity_id
+            )
+        except ValueError:
+            # Duplicate: inbox endpoint may pre-store activities before
+            # dispatching.  This is expected and not an error condition.
+            self.logger.debug(
+                "%s activity '%s' already stored — skipping (idempotent)",
+                self.label,
+                self.activity_id,
+            )
+        return Status.SUCCESS

--- a/vultron/core/behaviors/report/nodes/storage.py
+++ b/vultron/core/behaviors/report/nodes/storage.py
@@ -129,8 +129,9 @@ class StoreActivityNode(DataLayerAction):
         ``dl.create()`` always indicates a duplicate for activities.
 
         Returns:
-            SUCCESS always (including no-op if activity_id is empty or
-            activity_obj is None); FAILURE if the DataLayer is unavailable.
+            SUCCESS when the activity is stored (or already exists);
+            FAILURE if the DataLayer is unavailable or activity_obj is None
+            when activity_id is set (precondition violation).
         """
         if self.datalayer is None:
             self.logger.error("%s: DataLayer not available", self.name)
@@ -141,12 +142,12 @@ class StoreActivityNode(DataLayerAction):
             return Status.SUCCESS
 
         if self.activity_obj is None:
-            self.logger.warning(
-                "%s: activity_obj is None for id '%s' — skipping store",
+            self.logger.error(
+                "%s: activity_obj is None for id '%s' — cannot store",
                 self.name,
                 self.activity_id,
             )
-            return Status.SUCCESS
+            return Status.FAILURE
 
         try:
             self.datalayer.create(self.activity_obj)

--- a/vultron/core/behaviors/report/received_report_trees.py
+++ b/vultron/core/behaviors/report/received_report_trees.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""
+Behavior tree factories for received-side report use cases.
+
+Each factory produces a ``py_trees.composites.Sequence`` that implements the
+inbound protocol handling for one of the four report-lifecycle activities:
+
+- ``CreateReport`` — store VulnerabilityReport + CreateReport activity
+- ``AckReport``    — store AckReport activity
+- ``CloseReport``  — store CloseReport activity + transition RM → CLOSED
+- ``InvalidateReport`` — store InvalidateReport activity + RM → INVALID
+
+Trees are run via ``BTBridge.execute_with_setup()`` in the corresponding use
+case.
+
+Per issue #759 AC-1 through AC-4.
+"""
+
+import logging
+
+import py_trees
+
+from vultron.core.models.events.report import (
+    AckReportReceivedEvent,
+    CloseReportReceivedEvent,
+    CreateReportReceivedEvent,
+    InvalidateReportReceivedEvent,
+)
+from vultron.core.behaviors.report.nodes.rm_transitions import (
+    TransitionCaseParticipantRMtoClosed,
+    TransitionCaseParticipantRMtoInvalid,
+)
+from vultron.core.behaviors.report.nodes.storage import (
+    StoreActivityNode,
+    StoreReportNode,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def create_create_report_received_tree(
+    request: CreateReportReceivedEvent,
+) -> py_trees.behaviour.Behaviour:
+    """Create the BT for the CreateReportReceived workflow.
+
+    Handles receipt of a ``Create(VulnerabilityReport)`` activity.
+
+    Steps (Sequence):
+    1. Store VulnerabilityReport idempotently.
+    2. Store CreateReport activity idempotently.
+
+    Args:
+        request: The parsed inbound domain event.
+
+    Returns:
+        Root node of the ``CreateReportReceivedBT`` Sequence.
+    """
+    report_id = request.report_id or ""
+    activity_id = request.activity_id or ""
+
+    root = py_trees.composites.Sequence(
+        name="CreateReportReceivedBT",
+        memory=False,
+        children=[
+            StoreReportNode(
+                report_id=report_id,
+                report_obj=request.report,
+            ),
+            StoreActivityNode(
+                activity_id=activity_id,
+                activity_obj=request.activity,
+                label="CreateReport",
+            ),
+        ],
+    )
+    logger.debug(
+        "Created CreateReportReceivedBT for report=%s activity=%s",
+        report_id,
+        activity_id,
+    )
+    return root
+
+
+def create_ack_report_received_tree(
+    request: AckReportReceivedEvent,
+) -> py_trees.behaviour.Behaviour:
+    """Create the BT for the AckReportReceived workflow.
+
+    Handles receipt of a ``Read(VulnerabilityReport)`` (AckReport) activity.
+
+    Steps (Sequence):
+    1. Store AckReport activity idempotently.
+
+    Args:
+        request: The parsed inbound domain event.
+
+    Returns:
+        Root node of the ``AckReportReceivedBT`` Sequence.
+    """
+    activity_id = request.activity_id or ""
+
+    root = py_trees.composites.Sequence(
+        name="AckReportReceivedBT",
+        memory=False,
+        children=[
+            StoreActivityNode(
+                activity_id=activity_id,
+                activity_obj=request.activity,
+                label="AckReport",
+            ),
+        ],
+    )
+    logger.debug(
+        "Created AckReportReceivedBT for activity=%s",
+        activity_id,
+    )
+    return root
+
+
+def create_close_report_received_tree(
+    request: CloseReportReceivedEvent,
+) -> py_trees.behaviour.Behaviour:
+    """Create the BT for the CloseReportReceived workflow.
+
+    Handles receipt of a ``Reject(VulnerabilityReport)`` (CloseReport) activity.
+
+    Steps (Sequence):
+    1. Store CloseReport activity idempotently.
+    2. Transition actor's RM state → CLOSED in the associated case (soft pass
+       if no case is found).
+
+    Args:
+        request: The parsed inbound domain event.
+
+    Returns:
+        Root node of the ``CloseReportReceivedBT`` Sequence.
+    """
+    activity_id = request.activity_id or ""
+
+    root = py_trees.composites.Sequence(
+        name="CloseReportReceivedBT",
+        memory=False,
+        children=[
+            StoreActivityNode(
+                activity_id=activity_id,
+                activity_obj=request.activity,
+                label="CloseReport",
+            ),
+            TransitionCaseParticipantRMtoClosed(
+                report_id=request.report_id,
+            ),
+        ],
+    )
+    logger.debug(
+        "Created CloseReportReceivedBT for report=%s activity=%s",
+        request.report_id,
+        activity_id,
+    )
+    return root
+
+
+def create_invalidate_report_received_tree(
+    request: InvalidateReportReceivedEvent,
+) -> py_trees.behaviour.Behaviour:
+    """Create the BT for the InvalidateReportReceived workflow.
+
+    Handles receipt of a ``TentativeReject(VulnerabilityReport)``
+    (InvalidateReport) activity.
+
+    Steps (Sequence):
+    1. Store InvalidateReport activity idempotently.
+    2. Transition actor's RM state → INVALID in the associated case (soft
+       pass if no case is found).
+
+    Args:
+        request: The parsed inbound domain event.
+
+    Returns:
+        Root node of the ``InvalidateReportReceivedBT`` Sequence.
+    """
+    activity_id = request.activity_id or ""
+
+    root = py_trees.composites.Sequence(
+        name="InvalidateReportReceivedBT",
+        memory=False,
+        children=[
+            StoreActivityNode(
+                activity_id=activity_id,
+                activity_obj=request.activity,
+                label="InvalidateReport",
+            ),
+            TransitionCaseParticipantRMtoInvalid(
+                report_id=request.report_id,
+            ),
+        ],
+    )
+    logger.debug(
+        "Created InvalidateReportReceivedBT for report=%s activity=%s",
+        request.report_id,
+        activity_id,
+    )
+    return root

--- a/vultron/core/use_cases/received/report.py
+++ b/vultron/core/use_cases/received/report.py
@@ -14,8 +14,6 @@ from vultron.core.models.events.report import (
 from vultron.core.models.protocols import is_case_model
 from vultron.core.ports.case_persistence import CasePersistence
 from vultron.core.use_cases.received.case import (
-    CloseCaseUseCase,
-    InvalidateCaseUseCase,
     ValidateCaseUseCase,
 )
 from vultron.errors import VultronValidationError
@@ -155,38 +153,28 @@ class CreateReportReceivedUseCase:
         self._request: CreateReportReceivedEvent = request
 
     def execute(self) -> None:
-        request = self._request
-        obj_to_store = request.report
-        if obj_to_store is not None:
-            try:
-                self._dl.create(obj_to_store)
-                logger.info(
-                    "Stored VulnerabilityReport with ID: %s", request.report_id
-                )
-            except ValueError as e:
-                # The inbox endpoint pre-stores inline nested objects before
-                # dispatching (actors.py), so a duplicate here is expected
-                # and not an error condition.
-                logger.debug(
-                    "VulnerabilityReport %s already exists (pre-stored by "
-                    "inbox endpoint): %s",
-                    request.report_id,
-                    e,
-                )
+        from py_trees.common import Status
 
-        if request.activity is not None:
-            try:
-                self._dl.create(request.activity)
-                logger.info(
-                    "Stored CreateReport activity with ID: %s",
-                    request.activity_id,
-                )
-            except ValueError as e:
-                logger.warning(
-                    "CreateReport activity %s already exists: %s",
-                    request.activity_id,
-                    e,
-                )
+        from vultron.core.behaviors.bridge import BTBridge
+        from vultron.core.behaviors.report.received_report_trees import (
+            create_create_report_received_tree,
+        )
+
+        request = self._request
+        tree = create_create_report_received_tree(request)
+        bridge = BTBridge(datalayer=self._dl)
+        result = bridge.execute_with_setup(
+            tree=tree,
+            actor_id=request.actor_id,
+            activity=request,
+        )
+        if result.status != Status.SUCCESS:
+            reason = BTBridge.get_failure_reason(tree)
+            logger.warning(
+                "CreateReportReceivedBT did not succeed for activity '%s': %s",
+                request.activity_id,
+                reason or result.feedback_message or "",
+            )
 
 
 class SubmitReportReceivedUseCase:
@@ -285,39 +273,29 @@ class InvalidateReportReceivedUseCase:
         self._request: InvalidateReportReceivedEvent = request
 
     def execute(self) -> None:
-        request = self._request
-        actor_id = request.actor_id
-        logger.info(
-            "Actor '%s' tentatively rejects offer '%s' of "
-            "VulnerabilityReport '%s'",
-            actor_id,
-            request.offer_id,
-            request.report_id,
-        )
-        if request.activity is not None:
-            try:
-                self._dl.create(request.activity)
-                logger.info(
-                    "Stored InvalidateReport activity with ID: %s",
-                    request.activity_id,
-                )
-            except ValueError as e:
-                logger.warning(
-                    "InvalidateReport activity %s already exists: %s",
-                    request.activity_id,
-                    e,
-                )
+        from py_trees.common import Status
 
-        if request.report_id:
-            case = self._dl.find_case_by_report_id(request.report_id)
-            if is_case_model(case):
-                InvalidateCaseUseCase(self._dl, case.id_, actor_id).execute()
-            else:
-                logger.warning(
-                    "InvalidateReportReceivedUseCase: no case found for "
-                    "report '%s' — RM state not updated",
-                    request.report_id,
-                )
+        from vultron.core.behaviors.bridge import BTBridge
+        from vultron.core.behaviors.report.received_report_trees import (
+            create_invalidate_report_received_tree,
+        )
+
+        request = self._request
+        tree = create_invalidate_report_received_tree(request)
+        bridge = BTBridge(datalayer=self._dl)
+        result = bridge.execute_with_setup(
+            tree=tree,
+            actor_id=request.actor_id,
+            activity=request,
+        )
+        if result.status != Status.SUCCESS:
+            reason = BTBridge.get_failure_reason(tree)
+            logger.warning(
+                "InvalidateReportReceivedBT did not succeed for activity"
+                " '%s': %s",
+                request.activity_id,
+                reason or result.feedback_message or "",
+            )
 
 
 class AckReportReceivedUseCase:
@@ -328,27 +306,28 @@ class AckReportReceivedUseCase:
         self._request: AckReportReceivedEvent = request
 
     def execute(self) -> None:
-        request = self._request
-        logger.info(
-            "Actor '%s' acknowledges receipt of offer '%s' of "
-            "VulnerabilityReport '%s'",
-            request.actor_id,
-            request.offer_id,
-            request.report_id,
+        from py_trees.common import Status
+
+        from vultron.core.behaviors.bridge import BTBridge
+        from vultron.core.behaviors.report.received_report_trees import (
+            create_ack_report_received_tree,
         )
-        if request.activity is not None:
-            try:
-                self._dl.create(request.activity)
-                logger.info(
-                    "Stored AckReport activity with ID: %s",
-                    request.activity_id,
-                )
-            except ValueError as e:
-                logger.warning(
-                    "AckReport activity %s already exists: %s",
-                    request.activity_id,
-                    e,
-                )
+
+        request = self._request
+        tree = create_ack_report_received_tree(request)
+        bridge = BTBridge(datalayer=self._dl)
+        result = bridge.execute_with_setup(
+            tree=tree,
+            actor_id=request.actor_id,
+            activity=request,
+        )
+        if result.status != Status.SUCCESS:
+            reason = BTBridge.get_failure_reason(tree)
+            logger.warning(
+                "AckReportReceivedBT did not succeed for activity '%s': %s",
+                request.activity_id,
+                reason or result.feedback_message or "",
+            )
 
 
 class CloseReportReceivedUseCase:
@@ -359,35 +338,25 @@ class CloseReportReceivedUseCase:
         self._request: CloseReportReceivedEvent = request
 
     def execute(self) -> None:
-        request = self._request
-        actor_id = request.actor_id
-        logger.info(
-            "Actor '%s' rejects offer '%s' of VulnerabilityReport '%s'",
-            actor_id,
-            request.offer_id,
-            request.report_id,
-        )
-        if request.activity is not None:
-            try:
-                self._dl.create(request.activity)
-                logger.info(
-                    "Stored CloseReport activity with ID: %s",
-                    request.activity_id,
-                )
-            except ValueError as e:
-                logger.warning(
-                    "CloseReport activity %s already exists: %s",
-                    request.activity_id,
-                    e,
-                )
+        from py_trees.common import Status
 
-        if request.report_id:
-            case = self._dl.find_case_by_report_id(request.report_id)
-            if is_case_model(case):
-                CloseCaseUseCase(self._dl, case.id_, actor_id).execute()
-            else:
-                logger.warning(
-                    "CloseReportReceivedUseCase: no case found for report "
-                    "'%s' — RM state not updated",
-                    request.report_id,
-                )
+        from vultron.core.behaviors.bridge import BTBridge
+        from vultron.core.behaviors.report.received_report_trees import (
+            create_close_report_received_tree,
+        )
+
+        request = self._request
+        tree = create_close_report_received_tree(request)
+        bridge = BTBridge(datalayer=self._dl)
+        result = bridge.execute_with_setup(
+            tree=tree,
+            actor_id=request.actor_id,
+            activity=request,
+        )
+        if result.status != Status.SUCCESS:
+            reason = BTBridge.get_failure_reason(tree)
+            logger.warning(
+                "CloseReportReceivedBT did not succeed for activity '%s': %s",
+                request.activity_id,
+                reason or result.feedback_message or "",
+            )


### PR DESCRIPTION
## Summary

Wraps the four procedural received-side report use cases in Behavior Trees,
following the pattern established in #758.

### Changes

**New files:**
- `vultron/core/behaviors/report/nodes/storage.py` — `StoreReportNode` and `StoreActivityNode`
  - `StoreReportNode` uses `_idempotent_create()` (dl.read-based guard)
  - `StoreActivityNode` uses a narrow `ValueError` catch because `dl.read()` cannot look up `VultronActivity` by URI (they are stored in type-keyed collections)
- `vultron/core/behaviors/report/received_report_trees.py` — four BT factory functions

**Modified files:**
- `vultron/core/behaviors/report/nodes/rm_transitions.py` — adds `TransitionCaseParticipantRMtoClosed` and `TransitionCaseParticipantRMtoInvalid` with shared `_transition_case_participant_rm()` helper
  - Soft-pass (SUCCESS) when no case found for report; FAILURE only when transition is blocked
- `vultron/core/behaviors/report/nodes/__init__.py` — re-exports new node classes
- `vultron/core/use_cases/received/report.py` — all four target use cases now delegate to BTBridge (deferred imports pattern)
- `test/core/behaviors/report/conftest.py` — adds `make_payload` fixture
- `test/core/behaviors/report/test_received_report_trees.py` — 33 tests covering node, tree, and use-case levels

### Testing

- 2823 passed, 0 failures (unit suite)
- All 4 linters clean (black, flake8, mypy, pyright)

Closes #759