### PR TITLE
feat(core): migrate VulnerabilityCase, CaseEvent, CaseReference, CaseActor to core

### DIFF
--- a/plan/history/2606/implementation/ISSUE-729.md
+++ b/plan/history/2606/implementation/ISSUE-729.md
@@ -1,0 +1,45 @@
+---
+source: ISSUE-729
+timestamp: '2026-06-04T20:13:16.142810+00:00'
+title: Migrate VulnerabilityCase, CaseEvent, CaseReference, CaseActor to core
+type: implementation
+---
+
+## Issue #729 — Refactor #699 step 6: migrate VulnerabilityCase + CaseEvent + CaseReference + CaseActor to core
+
+Step 6 of the domain object migration (#699). Promoted four types from wire
+stubs to full core implementations:
+
+- **`VulnerabilityCase(CoreObject)`** — renamed from `VultronCase(VultronObject)`
+  stub; added all domain methods: `add_report`, `add_participant`,
+  `remove_participant`, `set_embargo`, `record_activity`, `record_event`,
+  `current_status`, `case_status`; `_init_case_statuses` model_validator seeds
+  initial `CaseStatus` on construction; `VultronCase` alias preserved
+- **`CaseEvent(BaseModel)`** — renamed from `VultronCaseEvent`; stays `BaseModel`
+  (inline value object, not federated identity — schema change deferred);
+  added `NonEmptyString` fields, `field_validator` for ISO parsing,
+  `field_serializer`; `VultronCaseEvent` alias preserved
+- **`CaseActor(CoreObject)`** — renamed from `VultronCaseActor(VultronObject)`;
+  `type_="Service"` registry mismatch documented; `VultronCaseActor` alias
+  preserved
+- **`CaseReference(CoreObject)`** — new type with `url`/`name`/`tags` and
+  `CASE_REFERENCE_TAG_VOCABULARY` (canonical location moved from wire to core)
+
+Wire layer updated: `case_event.py` → single re-export; `case_actor.py` →
+updated import alias; `case_reference.py` → added `from_core`/`to_core`;
+`vulnerability_case.py` → updated to `CoreVulnerabilityCase`.
+
+`core/models/events/*.py` (6 files) updated to import via `VulnerabilityCase as
+VultronCase` alias. `vultron_types.py` updated to export new canonical names.
+
+84 new unit tests across `test/core/models/test_case*.py`. Existing
+`test_core_object.py` AC-4 guard updated (VulnerabilityCase now migrated);
+positive assertions added for `VulnerabilityCase` and `VultronCase` alias.
+
+**AC-2 deferred**: wire types keep all methods. Thinning wire projections to
+pure projections is deferred to the #699 finale when the DataLayer is also
+updated.
+
+All 3000 unit tests pass. Black, flake8, mypy, pyright all clean.
+
+PR: [#787](https://github.com/CERTCC/Vultron/pull/787)

--- a/test/core/models/test_case.py
+++ b/test/core/models/test_case.py
@@ -1,0 +1,332 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Tests for the core VulnerabilityCase domain model (step 6 of issue #699)."""
+
+import pytest
+
+from vultron.core.models.base import CoreObject
+from vultron.core.models.case import VulnerabilityCase, VultronCase
+from vultron.core.models.case_event import CaseEvent
+from vultron.core.models.case_participant import (
+    FinderParticipant,
+    VendorParticipant,
+)
+from vultron.core.models.case_status import CaseStatus
+from vultron.core.models.registry import CORE_VOCABULARY
+
+_ACTOR = "https://example.org/actor"
+_CASE_ID = "urn:uuid:case-test"
+
+
+@pytest.fixture
+def case() -> VulnerabilityCase:
+    return VulnerabilityCase(
+        id_=_CASE_ID,
+        attributed_to=_ACTOR,
+    )
+
+
+class TestVulnerabilityCaseBasics:
+    """VulnerabilityCase is a CoreObject with the canonical type."""
+
+    def test_inherits_core_object(self):
+        assert issubclass(VulnerabilityCase, CoreObject)
+
+    def test_type_literal(self, case: VulnerabilityCase):
+        assert case.type_ == "VulnerabilityCase"
+
+    def test_id_preserved(self, case: VulnerabilityCase):
+        assert case.id_ == _CASE_ID
+
+    def test_id_auto_generated_when_not_given(self):
+        c = VulnerabilityCase()
+        assert c.id_.startswith("urn:uuid:")
+
+    def test_attributed_to_stored(self, case: VulnerabilityCase):
+        assert case.attributed_to == _ACTOR
+
+    def test_default_fields_empty(self, case: VulnerabilityCase):
+        assert case.case_participants == []
+        assert case.vulnerability_reports == []
+        assert case.notes == []
+        assert case.case_activity == []
+        assert case.events == []
+        assert case.parent_cases == []
+        assert case.child_cases == []
+        assert case.sibling_cases == []
+
+
+class TestVulnerabilityCaseInitialStatus:
+    """An initial CaseStatus is seeded when attributed_to is set."""
+
+    def test_case_statuses_seeded_with_attributed_to(
+        self, case: VulnerabilityCase
+    ):
+        assert len(case.case_statuses) == 1
+        assert isinstance(case.case_statuses[0], CaseStatus)
+
+    def test_initial_status_context_is_case_id(self, case: VulnerabilityCase):
+        status = case.case_statuses[0]
+        assert isinstance(status, CaseStatus)
+        assert status.context == _CASE_ID
+
+    def test_initial_status_attributed_to_is_actor(
+        self, case: VulnerabilityCase
+    ):
+        status = case.case_statuses[0]
+        assert isinstance(status, CaseStatus)
+        assert status.attributed_to == _ACTOR
+
+    def test_no_seeding_without_attributed_to(self):
+        c = VulnerabilityCase(id_=_CASE_ID)
+        assert c.case_statuses == []
+
+
+class TestVulnerabilityCaseRegistration:
+    """VulnerabilityCase auto-registers in CORE_VOCABULARY — ADR-0017."""
+
+    def test_registered_in_core_vocabulary(self):
+        assert "VulnerabilityCase" in CORE_VOCABULARY
+        assert CORE_VOCABULARY["VulnerabilityCase"] is VulnerabilityCase
+
+
+class TestVulnerabilityCaseBackwardCompatAlias:
+    """VultronCase must be an alias for VulnerabilityCase."""
+
+    def test_alias_is_same_class(self):
+        assert VultronCase is VulnerabilityCase
+
+    def test_alias_construction_works(self):
+        c = VultronCase(attributed_to=_ACTOR)
+        assert isinstance(c, VulnerabilityCase)
+        assert c.type_ == "VulnerabilityCase"
+
+
+class TestVulnerabilityCaseCurrentStatus:
+    """current_status returns the most recent materialized CaseStatus."""
+
+    def test_current_status_returns_case_status(self, case: VulnerabilityCase):
+        assert isinstance(case.current_status, CaseStatus)
+
+    def test_case_status_property_alias(self, case: VulnerabilityCase):
+        assert case.case_status is case.current_status
+
+    def test_current_status_raises_when_no_materialized(self):
+        c = VulnerabilityCase(id_=_CASE_ID)
+        c.case_statuses = ["urn:uuid:some-id"]  # only str refs
+        with pytest.raises(ValueError, match="no materialized CaseStatus"):
+            _ = c.current_status
+
+    def test_current_status_raises_when_empty(self):
+        c = VulnerabilityCase(id_=_CASE_ID)
+        with pytest.raises(ValueError):
+            _ = c.current_status
+
+
+class TestVulnerabilityCaseAddReport:
+    """add_report appends a report ID to vulnerability_reports."""
+
+    def test_add_report_appends_id(self, case: VulnerabilityCase):
+        report_id = "urn:uuid:report-1"
+        case.add_report(report_id)
+        assert report_id in case.vulnerability_reports
+
+    def test_add_multiple_reports(self, case: VulnerabilityCase):
+        case.add_report("urn:uuid:report-1")
+        case.add_report("urn:uuid:report-2")
+        assert len(case.vulnerability_reports) == 2
+
+
+class TestVulnerabilityCaseAddParticipant:
+    """add_participant updates case_participants and actor_participant_index."""
+
+    def test_add_participant_appends(self, case: VulnerabilityCase):
+        p = FinderParticipant(
+            id_="urn:uuid:part-1",
+            attributed_to="https://example.org/finder",
+        )
+        case.add_participant(p)
+        assert p in case.case_participants
+
+    def test_add_participant_updates_index(self, case: VulnerabilityCase):
+        p = FinderParticipant(
+            id_="urn:uuid:part-1",
+            attributed_to="https://example.org/finder",
+        )
+        case.add_participant(p)
+        assert (
+            case.actor_participant_index.get("https://example.org/finder")
+            == "urn:uuid:part-1"
+        )
+
+    def test_add_participant_without_attributed_to_no_index(
+        self, case: VulnerabilityCase
+    ):
+        p = FinderParticipant(id_="urn:uuid:part-2")
+        case.add_participant(p)
+        assert "urn:uuid:part-2" not in case.actor_participant_index
+
+
+class TestVulnerabilityCaseRemoveParticipant:
+    """remove_participant removes from list and index."""
+
+    def test_remove_participant_clears_from_list(
+        self, case: VulnerabilityCase
+    ):
+        p = VendorParticipant(
+            id_="urn:uuid:part-1",
+            attributed_to="https://example.org/vendor",
+        )
+        case.add_participant(p)
+        case.remove_participant("urn:uuid:part-1")
+        assert p not in case.case_participants
+
+    def test_remove_participant_clears_from_index(
+        self, case: VulnerabilityCase
+    ):
+        p = VendorParticipant(
+            id_="urn:uuid:part-1",
+            attributed_to="https://example.org/vendor",
+        )
+        case.add_participant(p)
+        case.remove_participant("urn:uuid:part-1")
+        assert "https://example.org/vendor" not in case.actor_participant_index
+
+    def test_remove_nonexistent_participant_is_noop(
+        self, case: VulnerabilityCase
+    ):
+        case.remove_participant("urn:uuid:no-such")
+        assert case.case_participants == []
+
+
+class TestVulnerabilityCaseSetEmbargo:
+    """set_embargo updates active_embargo field."""
+
+    def test_set_embargo_stores_id(self, case: VulnerabilityCase):
+        case.set_embargo("urn:uuid:embargo-1")
+        assert case.active_embargo == "urn:uuid:embargo-1"
+
+    def test_set_embargo_clears_with_none(self, case: VulnerabilityCase):
+        case.set_embargo("urn:uuid:embargo-1")
+        case.set_embargo(None)
+        assert case.active_embargo is None
+
+
+class TestVulnerabilityCaseRecordActivity:
+    """record_activity appends activity IDs idempotently."""
+
+    def test_record_activity_appends(self, case: VulnerabilityCase):
+        case.record_activity("urn:uuid:activity-1")
+        assert "urn:uuid:activity-1" in case.case_activity
+
+    def test_record_activity_is_idempotent(self, case: VulnerabilityCase):
+        case.record_activity("urn:uuid:activity-1")
+        case.record_activity("urn:uuid:activity-1")
+        assert case.case_activity.count("urn:uuid:activity-1") == 1
+
+    def test_record_multiple_activities(self, case: VulnerabilityCase):
+        case.record_activity("urn:uuid:activity-1")
+        case.record_activity("urn:uuid:activity-2")
+        assert len(case.case_activity) == 2
+
+
+class TestVulnerabilityCaseRecordEvent:
+    """record_event creates and appends a CaseEvent."""
+
+    def test_record_event_returns_case_event(self, case: VulnerabilityCase):
+        event = case.record_event("urn:uuid:obj-1", "embargo_accepted")
+        assert isinstance(event, CaseEvent)
+
+    def test_record_event_appended_to_events(self, case: VulnerabilityCase):
+        event = case.record_event("urn:uuid:obj-1", "embargo_accepted")
+        assert event in case.events
+
+    def test_record_event_stores_object_id(self, case: VulnerabilityCase):
+        event = case.record_event("urn:uuid:obj-1", "embargo_accepted")
+        assert event.object_id == "urn:uuid:obj-1"
+
+    def test_record_event_stores_event_type(self, case: VulnerabilityCase):
+        event = case.record_event("urn:uuid:obj-1", "participant_joined")
+        assert event.event_type == "participant_joined"
+
+    def test_record_event_sets_trusted_timestamp(
+        self, case: VulnerabilityCase
+    ):
+        event = case.record_event("urn:uuid:obj-1", "embargo_accepted")
+        assert event.received_at.tzinfo is not None
+
+    def test_multiple_events_accumulate(self, case: VulnerabilityCase):
+        case.record_event("urn:uuid:obj-1", "event_one")
+        case.record_event("urn:uuid:obj-2", "event_two")
+        assert len(case.events) == 2
+
+
+class TestVulnerabilityCaseWireRoundTrip:
+    """Wire VulnerabilityCase.to_core preserves domain data."""
+
+    def test_to_core_produces_vulnerability_case(self):
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase as WireVC,
+        )
+
+        wire_case = WireVC(
+            id_="urn:uuid:vc-roundtrip",
+            attributed_to="https://example.org/actor",
+        )
+        core_case = wire_case.to_core()
+        assert isinstance(core_case, VulnerabilityCase)
+        assert core_case.id_ == "urn:uuid:vc-roundtrip"
+
+    def test_from_core_preserves_id(self):
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase as WireVC,
+        )
+
+        core_case = VulnerabilityCase(
+            id_="urn:uuid:vc-fromcore",
+            attributed_to="https://example.org/actor",
+        )
+        wire_case = WireVC.from_core(core_case)
+        assert wire_case.id_ == "urn:uuid:vc-fromcore"
+
+    def test_round_trip_preserves_active_embargo(self):
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase as WireVC,
+        )
+
+        core_case = VulnerabilityCase(
+            id_="urn:uuid:vc-rt",
+            attributed_to="https://example.org/actor",
+        )
+        core_case.set_embargo("urn:uuid:embargo-1")
+        wire_case = WireVC.from_core(core_case)
+        restored = wire_case.to_core()
+        assert restored.active_embargo == "urn:uuid:embargo-1"
+
+    def test_to_core_events_field_preserved(self):
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase as WireVC,
+        )
+
+        wire_case = WireVC(
+            id_="urn:uuid:vc-events",
+            attributed_to="https://example.org/actor",
+        )
+        wire_case.record_event("urn:uuid:obj", "test_event")
+        core_case = wire_case.to_core()
+        assert isinstance(core_case, VulnerabilityCase)
+        # events are preserved as embedded CaseEvent objects
+        assert len(core_case.events) == 1
+        assert isinstance(core_case.events[0], CaseEvent)
+        assert core_case.events[0].event_type == "test_event"

--- a/test/core/models/test_case_actor.py
+++ b/test/core/models/test_case_actor.py
@@ -1,0 +1,117 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Tests for the core CaseActor domain model (step 6 of issue #699)."""
+
+from vultron.core.models.base import CoreObject
+from vultron.core.models.case_actor import (
+    CaseActor,
+    VultronCaseActor,
+    VultronOutbox,
+)
+from vultron.core.models.registry import CORE_VOCABULARY
+
+
+class TestCaseActorBasics:
+    """CaseActor is a CoreObject with type_='Service'."""
+
+    def test_inherits_core_object(self):
+        assert issubclass(CaseActor, CoreObject)
+
+    def test_type_literal_is_service(self):
+        actor = CaseActor()
+        assert actor.type_ == "Service"
+
+    def test_has_outbox(self):
+        actor = CaseActor()
+        assert isinstance(actor.outbox, VultronOutbox)
+
+    def test_outbox_items_default_empty(self):
+        actor = CaseActor()
+        assert actor.outbox.items == []
+
+    def test_attributed_to_optional(self):
+        actor = CaseActor(attributed_to="https://example.org/owner")
+        assert actor.attributed_to == "https://example.org/owner"
+
+    def test_id_auto_generated_as_urn(self):
+        actor = CaseActor()
+        assert actor.id_.startswith("urn:uuid:")
+
+
+class TestCaseActorRegistration:
+    """CaseActor registers under 'CaseActor' key in CORE_VOCABULARY (ADR-0017)."""
+
+    def test_registered_in_core_vocabulary_by_classname(self):
+        # CaseActor registers by cls.__name__, not by type_ value "Service"
+        assert "CaseActor" in CORE_VOCABULARY
+        assert CORE_VOCABULARY["CaseActor"] is CaseActor
+
+    def test_not_registered_under_service_key(self):
+        # "Service" key belongs to the wire layer, not core
+        assert CORE_VOCABULARY.get("Service") is not CaseActor
+
+
+class TestCaseActorBackwardCompatAlias:
+    """VultronCaseActor must be an alias for CaseActor."""
+
+    def test_alias_is_same_class(self):
+        assert VultronCaseActor is CaseActor
+
+    def test_alias_construction_works(self):
+        actor = VultronCaseActor()
+        assert isinstance(actor, CaseActor)
+        assert actor.type_ == "Service"
+
+
+class TestCaseActorWireRoundTrip:
+    """Wire CaseActor.from_core / .to_core must preserve identity."""
+
+    def test_from_core_preserves_id(self):
+        from vultron.wire.as2.vocab.objects.case_actor import (
+            CaseActor as WireCaseActor,
+        )
+
+        core_actor = CaseActor(
+            id_="urn:uuid:actor-test",
+            attributed_to="https://example.org/owner",
+        )
+        wire_actor = WireCaseActor.from_core(core_actor)
+        assert wire_actor.id_ == "urn:uuid:actor-test"
+
+    def test_to_core_preserves_attributed_to(self):
+        from vultron.wire.as2.vocab.objects.case_actor import (
+            CaseActor as WireCaseActor,
+        )
+
+        wire_actor = WireCaseActor(
+            id_="urn:uuid:actor-test",
+            attributed_to="https://example.org/owner",
+        )
+        core_actor = wire_actor.to_core()
+        assert isinstance(core_actor, CaseActor)
+        assert core_actor.attributed_to == "https://example.org/owner"
+
+    def test_round_trip_preserves_id(self):
+        from vultron.wire.as2.vocab.objects.case_actor import (
+            CaseActor as WireCaseActor,
+        )
+
+        core_actor = CaseActor(
+            id_="urn:uuid:actor-roundtrip",
+            attributed_to="https://example.org/owner",
+        )
+        wire_actor = WireCaseActor.from_core(core_actor)
+        restored = wire_actor.to_core()
+        assert restored.id_ == "urn:uuid:actor-roundtrip"
+        assert isinstance(restored, CaseActor)

--- a/test/core/models/test_case_event.py
+++ b/test/core/models/test_case_event.py
@@ -1,0 +1,107 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Tests for the core CaseEvent domain model (step 6 of issue #699)."""
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from vultron.core.models.case_event import CaseEvent, VultronCaseEvent
+
+
+class TestCaseEventBasics:
+    """CaseEvent is a BaseModel with required fields."""
+
+    def test_object_id_required(self):
+        with pytest.raises(ValidationError):
+            CaseEvent.model_validate({"event_type": "test_event"})
+
+    def test_event_type_required(self):
+        with pytest.raises(ValidationError):
+            CaseEvent.model_validate({"object_id": "urn:uuid:obj-1"})
+
+    def test_object_id_must_be_non_empty(self):
+        with pytest.raises(ValidationError):
+            CaseEvent(object_id="", event_type="test_event")
+
+    def test_event_type_must_be_non_empty(self):
+        with pytest.raises(ValidationError):
+            CaseEvent(object_id="urn:uuid:obj-1", event_type="")
+
+    def test_received_at_defaults_to_utc(self):
+        event = CaseEvent(
+            object_id="urn:uuid:obj-1", event_type="embargo_accepted"
+        )
+        assert event.received_at.tzinfo is not None
+
+    def test_explicit_received_at_accepted(self):
+        dt = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+        event = CaseEvent(
+            object_id="urn:uuid:obj-1",
+            event_type="embargo_accepted",
+            received_at=dt,
+        )
+        assert event.received_at == dt
+
+    def test_received_at_parses_iso_string(self):
+        event = CaseEvent.model_validate(
+            {
+                "object_id": "urn:uuid:obj-1",
+                "event_type": "embargo_accepted",
+                "received_at": "2026-01-01T12:00:00+00:00",
+            }
+        )
+        assert event.received_at.year == 2026
+
+    def test_received_at_parses_z_suffix(self):
+        event = CaseEvent.model_validate(
+            {
+                "object_id": "urn:uuid:obj-1",
+                "event_type": "embargo_accepted",
+                "received_at": "2026-01-01T12:00:00Z",
+            }
+        )
+        assert event.received_at.tzinfo is not None
+
+    def test_json_serialization_includes_received_at(self):
+        event = CaseEvent(
+            object_id="urn:uuid:obj-1", event_type="embargo_accepted"
+        )
+        dumped = event.model_dump(mode="json")
+        assert "received_at" in dumped
+
+
+class TestCaseEventBackwardCompatAlias:
+    """VultronCaseEvent must be an alias for CaseEvent."""
+
+    def test_alias_is_same_class(self):
+        assert VultronCaseEvent is CaseEvent
+
+    def test_alias_construction_works(self):
+        e = VultronCaseEvent(
+            object_id="urn:uuid:obj-1", event_type="participant_joined"
+        )
+        assert isinstance(e, CaseEvent)
+
+
+class TestCaseEventWireReexport:
+    """Wire case_event module re-exports the core CaseEvent."""
+
+    def test_wire_import_is_core_class(self):
+        from vultron.wire.as2.vocab.objects.case_event import (
+            CaseEvent as WireCaseEvent,
+        )
+
+        assert WireCaseEvent is CaseEvent

--- a/test/core/models/test_case_reference.py
+++ b/test/core/models/test_case_reference.py
@@ -1,0 +1,147 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Tests for the core CaseReference domain model (step 6 of issue #699)."""
+
+import pytest
+from pydantic import ValidationError
+
+from vultron.core.models.base import CoreObject
+from vultron.core.models.case_reference import (
+    CASE_REFERENCE_TAG_VOCABULARY,
+    CaseReference,
+)
+from vultron.core.models.registry import CORE_VOCABULARY
+
+_URL = "https://example.org/advisory"
+
+
+class TestCaseReferenceBasics:
+    """CaseReference is a CoreObject with required url field."""
+
+    def test_inherits_core_object(self):
+        assert issubclass(CaseReference, CoreObject)
+
+    def test_type_literal(self):
+        ref = CaseReference(url=_URL)
+        assert ref.type_ == "CaseReference"
+
+    def test_url_required(self):
+        with pytest.raises(ValidationError):
+            CaseReference()
+
+    def test_url_must_be_non_empty(self):
+        with pytest.raises(ValidationError):
+            CaseReference(url="")
+
+    def test_name_optional(self):
+        ref = CaseReference(url=_URL, name="Advisory Title")
+        assert ref.name == "Advisory Title"
+
+    def test_name_none_by_default(self):
+        ref = CaseReference(url=_URL)
+        assert ref.name is None
+
+    def test_tags_optional(self):
+        ref = CaseReference(url=_URL, tags=["patch"])
+        assert ref.tags == ["patch"]
+
+    def test_tags_none_by_default(self):
+        ref = CaseReference(url=_URL)
+        assert ref.tags is None
+
+    def test_id_auto_generated_as_urn(self):
+        ref = CaseReference(url=_URL)
+        assert ref.id_.startswith("urn:uuid:")
+
+
+class TestCaseReferenceTagValidation:
+    """tags field validates against CASE_REFERENCE_TAG_VOCABULARY."""
+
+    def test_valid_single_tag(self):
+        ref = CaseReference(url=_URL, tags=["patch"])
+        assert ref.tags == ["patch"]
+
+    def test_valid_multiple_tags(self):
+        ref = CaseReference(url=_URL, tags=["patch", "vendor-advisory"])
+        assert ref.tags is not None
+        assert len(ref.tags) == 2
+
+    def test_invalid_tag_raises(self):
+        with pytest.raises(ValidationError):
+            CaseReference(url=_URL, tags=["invalid-tag-xyz"])
+
+    def test_empty_tags_list_raises(self):
+        with pytest.raises(ValidationError):
+            CaseReference(url=_URL, tags=[])
+
+    def test_empty_string_tag_raises(self):
+        with pytest.raises(ValidationError):
+            CaseReference(url=_URL, tags=[""])
+
+    def test_all_vocabulary_tags_are_valid(self):
+        for tag in CASE_REFERENCE_TAG_VOCABULARY:
+            ref = CaseReference(url=_URL, tags=[tag])
+            assert ref.tags == [tag]
+
+
+class TestCaseReferenceRegistration:
+    """CaseReference registers in CORE_VOCABULARY — ADR-0017."""
+
+    def test_registered_in_core_vocabulary(self):
+        assert "CaseReference" in CORE_VOCABULARY
+        assert CORE_VOCABULARY["CaseReference"] is CaseReference
+
+
+class TestCaseReferenceWireRoundTrip:
+    """Wire CaseReference.from_core / .to_core must preserve identity."""
+
+    def test_from_core_preserves_url(self):
+        from vultron.wire.as2.vocab.objects.case_reference import (
+            CaseReference as WireCaseReference,
+        )
+
+        core_ref = CaseReference(
+            id_="urn:uuid:ref-test",
+            url=_URL,
+            name="Example Advisory",
+            tags=["patch"],
+        )
+        wire_ref = WireCaseReference.from_core(core_ref)
+        assert wire_ref.url == _URL
+        assert wire_ref.name == "Example Advisory"
+
+    def test_to_core_produces_core_reference(self):
+        from vultron.wire.as2.vocab.objects.case_reference import (
+            CaseReference as WireCaseReference,
+        )
+
+        wire_ref = WireCaseReference(url=_URL, tags=["vendor-advisory"])
+        core_ref = wire_ref.to_core()
+        assert isinstance(core_ref, CaseReference)
+        assert core_ref.url == _URL
+        assert core_ref.tags == ["vendor-advisory"]
+
+    def test_round_trip_preserves_id(self):
+        from vultron.wire.as2.vocab.objects.case_reference import (
+            CaseReference as WireCaseReference,
+        )
+
+        core_ref = CaseReference(
+            id_="urn:uuid:ref-roundtrip",
+            url=_URL,
+        )
+        wire_ref = WireCaseReference.from_core(core_ref)
+        restored = wire_ref.to_core()
+        assert restored.id_ == "urn:uuid:ref-roundtrip"
+        assert isinstance(restored, CaseReference)

--- a/test/core/models/test_core_object.py
+++ b/test/core/models/test_core_object.py
@@ -195,11 +195,11 @@ def test_registry_robust_under_future_annotations(tmp_path, isolated_vocab):
 def test_legacy_vultron_stubs_do_not_inherit_core_object():
     """AC-4: existing Vultron* core stubs not yet migrated.
 
-    VultronCase and VultronNote still inherit VultronObject (not CoreObject)
-    and must not appear in CORE_VOCABULARY.  VultronReport is now an alias
-    for VulnerabilityReport (migrated in #727) so it IS a CoreObject.
+    VultronNote still inherits VultronObject (not CoreObject) and must not
+    appear in CORE_VOCABULARY.  VultronCase is now an alias for
+    VulnerabilityCase (migrated in #729) so it IS a CoreObject.
     """
-    for cls in (VultronCase, VultronNote):
+    for cls in (VultronNote,):
         assert issubclass(cls, VultronObject)
         assert not issubclass(cls, CoreObject), (
             f"{cls.__name__} prematurely inherits CoreObject; "
@@ -237,3 +237,19 @@ def test_core_case_log_entry_inherits_core_object():
     assert issubclass(CoreCaseLogEntry, CoreObject)
     assert "CaseLogEntry" in CORE_VOCABULARY
     assert CORE_VOCABULARY["CaseLogEntry"] is CoreCaseLogEntry
+
+
+def test_vulnerability_case_inherits_core_object():
+    """VulnerabilityCase (migrated in #729) must be a CoreObject subclass."""
+    from vultron.core.models.case import VulnerabilityCase
+
+    assert issubclass(VulnerabilityCase, CoreObject)
+    assert "VulnerabilityCase" in CORE_VOCABULARY
+    assert CORE_VOCABULARY["VulnerabilityCase"] is VulnerabilityCase
+
+
+def test_vultron_case_alias_is_vulnerability_case():
+    """VultronCase backward-compat alias must resolve to VulnerabilityCase."""
+    from vultron.core.models.case import VulnerabilityCase
+
+    assert VultronCase is VulnerabilityCase

--- a/vultron/core/models/case.py
+++ b/vultron/core/models/case.py
@@ -15,33 +15,43 @@
 
 """Domain representation of a vulnerability case."""
 
+from __future__ import annotations
+
+import logging
 from typing import Literal
 
 from pydantic import Field, model_validator
 
-from vultron.core.models.base import VultronObject
-from vultron.core.models.case_event import VultronCaseEvent
+from vultron.core.models.base import CoreObject
+from vultron.core.models.case_event import CaseEvent
 from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.models.case_status import CaseStatus
 
+logger = logging.getLogger(__name__)
 
-class VultronCase(VultronObject):
+
+class VulnerabilityCase(CoreObject):
     """Domain representation of a vulnerability case.
 
-    Mirrors the Vultron-specific fields of ``VulnerabilityCase``.  Cross-
-    references to related objects are stored as ``str`` ID values, which are
-    valid members of the corresponding wire-type union fields (e.g.
-    ``VulnerabilityReportRef``, ``CaseParticipantRef``), ensuring DataLayer
-    round-trip compatibility.
+    Canonical core type for a ``VulnerabilityCase``.  ``type_`` is
+    ``"VulnerabilityCase"`` so TinyDB stores this in the same table as
+    wire-created cases and ``record_to_object`` can round-trip it via the
+    wire vocabulary registry, and so this class auto-registers in
+    :data:`CORE_VOCABULARY`.
 
-    ``type_`` is ``"VulnerabilityCase"`` so that TinyDB stores this in the
-    same table as wire-created cases and ``record_to_object`` can round-trip
-    it via the wire vocabulary registry.
+    Cross-references to related objects are stored as ``str`` ID values,
+    which are valid members of the corresponding wire-type union fields
+    (e.g. ``VulnerabilityReportRef``, ``CaseParticipantRef``), ensuring
+    DataLayer round-trip compatibility.
 
     When first created with an ``attributed_to`` actor and an empty
-    ``case_statuses`` list, an initial ``CaseStatus`` is appended
-    automatically so that ``current_status`` (on the wire
-    ``VulnerabilityCase``) never encounters an empty history list.
+    ``case_statuses`` list, an initial :class:`CaseStatus` is appended
+    automatically so that ``current_status`` never encounters an empty
+    history list.
+
+    Parent/child/sibling cross-references are stored as ID strings to
+    avoid circular-reference issues during serialization.  See ADR-0017
+    for the rationale.
     """
 
     type_: Literal["VulnerabilityCase"] = Field(
@@ -59,13 +69,15 @@ class VultronCase(VultronObject):
     active_embargo: str | None = None
     proposed_embargoes: list[str] = Field(default_factory=list)
     case_activity: list[str] = Field(default_factory=list)
-    events: list[VultronCaseEvent] = Field(default_factory=list)
+    events: list[CaseEvent] = Field(default_factory=list)
+    # ADR-0017: ID-only cross-refs to avoid graph-cycle issues
     parent_cases: list[str] = Field(default_factory=list)
     child_cases: list[str] = Field(default_factory=list)
     sibling_cases: list[str] = Field(default_factory=list)
 
     @model_validator(mode="after")
-    def init_case_statuses(self) -> "VultronCase":
+    def _init_case_statuses(self) -> VulnerabilityCase:
+        """Seed ``case_statuses`` with a default entry when empty."""
         if not self.case_statuses and self.attributed_to:
             self.case_statuses = [
                 CaseStatus(
@@ -75,9 +87,80 @@ class VultronCase(VultronObject):
             ]
         return self
 
-    def record_event(
-        self, object_id: str, event_type: str
-    ) -> VultronCaseEvent:
+    # ------------------------------------------------------------------
+    # Domain methods
+    # ------------------------------------------------------------------
+
+    def add_report(self, report_id: str) -> None:
+        """Append a vulnerability report ID to this case.
+
+        Args:
+            report_id: Full URI of the :class:`VulnerabilityReport` to add.
+        """
+        self.vulnerability_reports.append(report_id)
+
+    def add_participant(self, participant: CaseParticipant) -> None:
+        """Add a participant and update the actor→participant index.
+
+        The participant's ``attributed_to`` actor URI is recorded in
+        ``actor_participant_index`` so callers can quickly look up a
+        participant by actor ID.
+
+        Args:
+            participant: A full :class:`CaseParticipant` object (full object
+                required to update the index).
+        """
+        self.case_participants.append(participant)
+        if participant.attributed_to is not None:
+            self.actor_participant_index[participant.attributed_to] = (
+                participant.id_
+            )
+
+    def remove_participant(self, participant_id: str) -> None:
+        """Remove a participant and update the actor→participant index.
+
+        Args:
+            participant_id: Full URI of the :class:`CaseParticipant` to
+                remove.
+        """
+        self.case_participants = [
+            p
+            for p in self.case_participants
+            if (p.id_ if isinstance(p, CaseParticipant) else p)
+            != participant_id
+        ]
+        actors_to_remove = [
+            actor_id
+            for actor_id, p_id in self.actor_participant_index.items()
+            if p_id == participant_id
+        ]
+        for actor_id in actors_to_remove:
+            del self.actor_participant_index[actor_id]
+
+    def set_embargo(self, embargo: str | None) -> None:
+        """Set the active embargo reference for this case.
+
+        Args:
+            embargo: Full URI of the active :class:`EmbargoEvent`, or
+                ``None`` to clear.
+        """
+        self.active_embargo = embargo
+
+    def record_activity(self, activity_id: str) -> None:
+        """Append an activity ID to the case activity log.
+
+        Idempotent — if *activity_id* is already recorded, the call is
+        a no-op.
+
+        Per AGENTS.md: store activity IDs as strings, not typed objects.
+
+        Args:
+            activity_id: Full URI of the activity to record.
+        """
+        if activity_id not in self.case_activity:
+            self.case_activity.append(activity_id)
+
+    def record_event(self, object_id: str, event_type: str) -> CaseEvent:
         """Append a trusted-timestamp event to the case event log.
 
         The ``received_at`` timestamp is set to the current UTC time at the
@@ -90,8 +173,40 @@ class VultronCase(VultronObject):
                 (e.g. ``"embargo_accepted"``).
 
         Returns:
-            The newly-created VultronCaseEvent.
+            The newly-created :class:`CaseEvent`.
         """
-        event = VultronCaseEvent(object_id=object_id, event_type=event_type)
+        event = CaseEvent(object_id=object_id, event_type=event_type)
         self.events.append(event)
         return event
+
+    @property
+    def current_status(self) -> CaseStatus:
+        """Return the most recent materialized :class:`CaseStatus`.
+
+        Uses ``updated`` then ``published`` then ``id_`` as sort key to
+        handle cases where timestamps may be equal or absent.
+
+        Raises:
+            ValueError: When no materialized :class:`CaseStatus` exists.
+        """
+        materialized = [
+            s for s in self.case_statuses if isinstance(s, CaseStatus)
+        ]
+        if not materialized:
+            raise ValueError(
+                "VulnerabilityCase has no materialized CaseStatus"
+            )
+        return max(
+            materialized,
+            key=lambda cs: cs.updated or cs.published or cs.id_,
+        )
+
+    @property
+    def case_status(self) -> CaseStatus:
+        """Return the most recent :class:`CaseStatus` (alias for ``current_status``)."""
+        return self.current_status
+
+
+#: Backward-compatibility alias.  New code should import
+#: :class:`VulnerabilityCase` directly.
+VultronCase = VulnerabilityCase

--- a/vultron/core/models/case_actor.py
+++ b/vultron/core/models/case_actor.py
@@ -19,7 +19,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
-from vultron.core.models.base import VultronObject
+from vultron.core.models.base import CoreObject
 
 
 class VultronOutbox(BaseModel):
@@ -28,14 +28,20 @@ class VultronOutbox(BaseModel):
     items: list[str] = Field(default_factory=list)
 
 
-class VultronCaseActor(VultronObject):
+class CaseActor(CoreObject):
     """Domain representation of a CaseActor service.
 
     Mirrors the Vultron-specific fields of ``CaseActor`` (which inherits
     ``as_Service``).  The ``outbox`` field carries the actor's outgoing
     activity IDs and is required so that ``UpdateActorOutbox`` can append
     to it via ``datalayer.save``.
-    ``type_`` is ``"Service"`` to match ``CaseActor``'s wire value.
+
+    ``type_`` is ``"Service"`` to match ``CaseActor``'s wire value, which
+    means this class registers in :data:`CORE_VOCABULARY` under the key
+    ``"CaseActor"`` (``cls.__name__``), not ``"Service"``.  DataLayer
+    reconstitution still routes through the wire :data:`VOCABULARY` for
+    ``"Service"`` objects; core ``CaseActor`` is used when constructing
+    domain objects directly.  See ADR-0017 and issue #729.
     """
 
     type_: Literal["Service"] = Field(
@@ -44,3 +50,7 @@ class VultronCaseActor(VultronObject):
         serialization_alias="type",
     )
     outbox: VultronOutbox = Field(default_factory=VultronOutbox)
+
+
+#: Backward-compatibility alias.  New code should import :class:`CaseActor`.
+VultronCaseActor = CaseActor

--- a/vultron/core/models/case_event.py
+++ b/vultron/core/models/case_event.py
@@ -15,20 +15,58 @@
 
 """Domain representation of a case event log entry."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_serializer, field_validator
 
 from vultron.core.models._helpers import _now_utc
+from vultron.core.models.base import NonEmptyString
 
 
-class VultronCaseEvent(BaseModel):
-    """Domain representation of a case event log entry.
+class CaseEvent(BaseModel):
+    """Append-only event log entry for a VulnerabilityCase.
 
-    Mirrors ``CaseEvent`` from ``vultron.wire.as2.vocab.objects.case_event``
-    using identical field names for DataLayer round-trip compatibility.
+    Records a state-changing event with a server-generated trusted timestamp
+    at the time of receipt.  The CaseActor is the sole trusted source of
+    event ordering within a case; ``received_at`` MUST be set by the handler
+    at time of receipt, never copied from an incoming activity payload.
+
+    Fields:
+        object_id: Full URI of the object being acted upon.
+        event_type: Short descriptor of the event kind
+            (e.g. ``"embargo_accepted"``, ``"participant_joined"``).
+        received_at: Server-generated TZ-aware UTC timestamp set at receipt;
+            defaults to the current UTC time.
+
+    Per specs/case-management.yaml CM-02-009, CM-10-002.
     """
 
-    object_id: str
-    event_type: str
-    received_at: datetime = Field(default_factory=_now_utc)
+    object_id: NonEmptyString = Field(
+        ...,
+        description="Full URI of the object being acted upon",
+    )
+    event_type: NonEmptyString = Field(
+        ...,
+        description="Short descriptor of the event kind",
+    )
+    received_at: datetime = Field(
+        default_factory=_now_utc,
+        description="Server-generated TZ-aware UTC timestamp set at receipt",
+    )
+
+    @field_validator("received_at", mode="before")
+    @classmethod
+    def _parse_received_at(cls, v: datetime | str) -> datetime:
+        if isinstance(v, str):
+            return datetime.fromisoformat(v.replace("Z", "+00:00"))
+        return v
+
+    @field_serializer("received_at", when_used="json")
+    def _serialize_received_at(self, value: datetime) -> str:
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.isoformat()
+
+
+#: Backward-compatibility alias.  New code should import :class:`CaseEvent`.
+VultronCaseEvent = CaseEvent

--- a/vultron/core/models/case_reference.py
+++ b/vultron/core/models/case_reference.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Domain representation of a typed external reference on a VulnerabilityCase."""
+
+from typing import Literal
+
+from pydantic import Field, field_validator
+
+from vultron.core.models.base import CoreObject, NonEmptyString
+
+# CVE JSON Schema reference tag vocabulary (mirrors wire layer)
+CASE_REFERENCE_TAG_VOCABULARY = {
+    "broken-link",
+    "customer-entitlement",
+    "exploit",
+    "government-resource",
+    "issue-tracking",
+    "mailing-list",
+    "mitigation",
+    "not-applicable",
+    "patch",
+    "permissions-required",
+    "media-coverage",
+    "product",
+    "related",
+    "release-notes",
+    "signature",
+    "technical-description",
+    "third-party-advisory",
+    "vendor-advisory",
+    "vdb-entry",
+}
+
+
+class CaseReference(CoreObject):
+    """Domain representation of a typed external reference for a case.
+
+    Links to external resources (e.g., public advisory, patch, vendor
+    bulletin) rather than embedding their content.  Aligns with the CVE
+    JSON schema reference format.
+
+    ``type_`` is ``"CaseReference"`` so this class auto-registers in
+    :data:`CORE_VOCABULARY` and round-trips through the DataLayer.
+
+    Fields:
+        url: Required URL reference (must be non-empty string).
+        name: Optional human-readable title for the reference.
+        tags: Optional list of type descriptors from the CVE JSON schema
+            vocabulary (e.g. ``"patch"``, ``"vendor-advisory"``).
+    """
+
+    type_: Literal["CaseReference"] = Field(
+        default="CaseReference",
+        validation_alias="type",
+        serialization_alias="type",
+    )
+    url: NonEmptyString = Field(  # pyright: ignore[reportGeneralTypeIssues]
+        ...,
+        description="URL reference for the external resource",
+    )
+    name: NonEmptyString | None = Field(
+        default=None,
+        description="Human-readable title for the reference",
+    )
+    tags: list[str] | None = Field(
+        default=None,
+        description="Type descriptors from CVE JSON schema vocabulary",
+    )
+
+    @field_validator("tags")
+    @classmethod
+    def _validate_tags(cls, v: list[str] | None) -> list[str] | None:
+        if v is None:
+            return None
+        if not v:
+            raise ValueError("tags must have at least one element")
+        for tag in v:
+            if not isinstance(tag, str) or not tag.strip():
+                raise ValueError("All tags must be non-empty strings")
+            if tag not in CASE_REFERENCE_TAG_VOCABULARY:
+                raise ValueError(
+                    f"Invalid tag '{tag}'. Must be one of: "
+                    f"{sorted(CASE_REFERENCE_TAG_VOCABULARY)}"
+                )
+        return v

--- a/vultron/core/models/events/actor.py
+++ b/vultron/core/models/events/actor.py
@@ -10,7 +10,7 @@ from vultron.core.models.events.base import MessageSemantics, VultronEvent
 
 if TYPE_CHECKING:
     from vultron.core.models.base import VultronObject
-    from vultron.core.models.case import VultronCase
+    from vultron.core.models.case import VulnerabilityCase as VultronCase
 else:
     VultronObject = object
     VultronCase = object

--- a/vultron/core/models/events/case.py
+++ b/vultron/core/models/events/case.py
@@ -6,7 +6,7 @@ from vultron.core.models.activity import VultronActivity
 from vultron.core.models.events.base import MessageSemantics, VultronEvent
 
 if TYPE_CHECKING:
-    from vultron.core.models.case import VultronCase
+    from vultron.core.models.case import VulnerabilityCase as VultronCase
     from vultron.core.models.report import VultronReport
 else:
     VultronCase = object

--- a/vultron/core/models/events/case_participant.py
+++ b/vultron/core/models/events/case_participant.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Literal, cast
 from vultron.core.models.events.base import MessageSemantics, VultronEvent
 
 if TYPE_CHECKING:
-    from vultron.core.models.case import VultronCase
+    from vultron.core.models.case import VulnerabilityCase as VultronCase
     from vultron.core.models.participant import VultronParticipant
 else:
     VultronCase = object

--- a/vultron/core/models/events/embargo.py
+++ b/vultron/core/models/events/embargo.py
@@ -6,7 +6,7 @@ from vultron.core.models.activity import VultronActivity
 from vultron.core.models.events.base import MessageSemantics, VultronEvent
 
 if TYPE_CHECKING:
-    from vultron.core.models.case import VultronCase
+    from vultron.core.models.case import VulnerabilityCase as VultronCase
     from vultron.core.models.embargo_event import (
         EmbargoEvent as VultronEmbargoEvent,
     )

--- a/vultron/core/models/events/note.py
+++ b/vultron/core/models/events/note.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Literal, cast
 from vultron.core.models.events.base import MessageSemantics, VultronEvent
 
 if TYPE_CHECKING:
-    from vultron.core.models.case import VultronCase
+    from vultron.core.models.case import VulnerabilityCase as VultronCase
     from vultron.core.models.note import VultronNote
 else:
     VultronCase = object

--- a/vultron/core/models/events/status.py
+++ b/vultron/core/models/events/status.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Literal, cast
 from vultron.core.models.events.base import MessageSemantics, VultronEvent
 
 if TYPE_CHECKING:
-    from vultron.core.models.case import VultronCase
+    from vultron.core.models.case import VulnerabilityCase as VultronCase
     from vultron.core.models.case_status import CaseStatus
     from vultron.core.models.participant import VultronParticipant
     from vultron.core.models.participant_status import ParticipantStatus

--- a/vultron/core/models/vultron_types.py
+++ b/vultron/core/models/vultron_types.py
@@ -20,11 +20,13 @@ Import directly from those modules for new code:
 
 - ``vultron.core.models.activity`` — VultronActivity, VultronOffer,
   VultronAccept, VultronCreateCaseActivity
-- ``vultron.core.models.case`` — VultronCase
-- ``vultron.core.models.case_actor`` — VultronCaseActor, VultronOutbox
-- ``vultron.core.models.case_event`` — VultronCaseEvent
+- ``vultron.core.models.case`` — VulnerabilityCase (VultronCase is an alias)
+- ``vultron.core.models.case_actor`` — CaseActor (VultronCaseActor is an alias),
+  VultronOutbox
+- ``vultron.core.models.case_event`` — CaseEvent (VultronCaseEvent is an alias)
 - ``vultron.core.models.case_participant`` — CaseParticipant (and role
   subclasses), VultronParticipant (alias)
+- ``vultron.core.models.case_reference`` — CaseReference
 - ``vultron.core.models.case_status`` — CaseStatus
 - ``vultron.core.models.embargo_event`` — EmbargoEvent (VultronEmbargoEvent is an alias)
 - ``vultron.core.models.embargo_policy`` — EmbargoPolicy
@@ -40,9 +42,14 @@ from vultron.core.models.activity import (
     VultronCreateCaseActivity,
     VultronOffer,
 )
-from vultron.core.models.case import VultronCase
-from vultron.core.models.case_actor import VultronCaseActor, VultronOutbox
-from vultron.core.models.case_event import VultronCaseEvent
+from vultron.core.models.case import VulnerabilityCase, VultronCase
+from vultron.core.models.case_actor import (
+    CaseActor,
+    VultronCaseActor,
+    VultronOutbox,
+)
+from vultron.core.models.case_event import CaseEvent, VultronCaseEvent
+from vultron.core.models.case_reference import CaseReference
 from vultron.core.models.case_status import CaseStatus
 from vultron.core.models.embargo_event import EmbargoEvent, VultronEmbargoEvent
 from vultron.core.models.embargo_policy import EmbargoPolicy
@@ -65,6 +72,10 @@ from vultron.core.models.report import VulnerabilityReport, VultronReport
 __all__ = [
     "VultronAccept",
     "VultronActivity",
+    "CaseActor",
+    "CaseEvent",
+    "CaseReference",
+    "VulnerabilityCase",
     "VultronCase",
     "VultronCaseActor",
     "VultronCaseEvent",

--- a/vultron/wire/as2/vocab/objects/case_actor.py
+++ b/vultron/wire/as2/vocab/objects/case_actor.py
@@ -16,7 +16,7 @@ Defines a CaseActor class for the Vultron ActivityStreams Vocabulary.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-from vultron.core.models.case_actor import VultronCaseActor
+from vultron.core.models.case_actor import CaseActor as CoreCaseActor
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.objects.base import _scalar_ref_id_or_value
 
@@ -33,7 +33,7 @@ class CaseActor(as_Service):
     # context: (VulnerabilityCase) The case this actor is associated with
 
     @classmethod
-    def from_core(cls, core_obj: VultronCaseActor) -> "CaseActor":
+    def from_core(cls, core_obj: CoreCaseActor) -> "CaseActor":
         return cls(
             id_=core_obj.id_,
             name=core_obj.name,
@@ -41,8 +41,8 @@ class CaseActor(as_Service):
             context=core_obj.context,
         )
 
-    def to_core(self) -> VultronCaseActor:
-        return VultronCaseActor.model_validate(
+    def to_core(self) -> CoreCaseActor:
+        return CoreCaseActor.model_validate(
             {
                 "id_": self.id_,
                 "type_": self.type_,

--- a/vultron/wire/as2/vocab/objects/case_event.py
+++ b/vultron/wire/as2/vocab/objects/case_event.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python
 """
-Provides a CaseEvent model for trusted-timestamp event logging on VulnerabilityCase objects.
+Re-exports CaseEvent from the core domain layer.
+
+CaseEvent has been migrated to ``vultron.core.models.case_event`` (step 6
+of issue #699).  This module re-exports it for backward compatibility so
+existing ``from vultron.wire.as2.vocab.objects.case_event import CaseEvent``
+imports continue to work unmodified.
 """
 
 #  Copyright (c) 2026 Carnegie Mellon University and Contributors.
@@ -16,58 +21,6 @@ Provides a CaseEvent model for trusted-timestamp event logging on VulnerabilityC
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-from datetime import datetime, timezone
+from vultron.core.models.case_event import CaseEvent  # noqa: F401
 
-from pydantic import BaseModel, Field, field_serializer, field_validator
-
-from vultron.core.models.base import NonEmptyString
-from vultron.wire.as2.vocab.base.dt_utils import now_utc
-
-
-def _now_utc() -> datetime:
-    return now_utc()
-
-
-class CaseEvent(BaseModel):
-    """Append-only event log entry for a VulnerabilityCase.
-
-    Records a state-changing event with a server-generated trusted timestamp
-    at the time of receipt.  The CaseActor is the sole trusted source of
-    event ordering within a case; ``received_at`` MUST be set by the handler
-    at time of receipt, never copied from an incoming activity payload.
-
-    Fields:
-        object_id: Full URI of the object being acted upon.
-        event_type: Short descriptor of the event kind
-            (e.g. ``"embargo_accepted"``, ``"participant_joined"``).
-        received_at: Server-generated TZ-aware UTC timestamp set at receipt;
-            defaults to the current UTC time.
-
-    Per specs/case-management.yaml CM-02-009, CM-10-002.
-    """
-
-    object_id: NonEmptyString = Field(
-        ...,
-        description="Full URI of the object being acted upon",
-    )
-    event_type: NonEmptyString = Field(
-        ...,
-        description="Short descriptor of the event kind",
-    )
-    received_at: datetime = Field(
-        default_factory=_now_utc,
-        description="Server-generated TZ-aware UTC timestamp set at receipt",
-    )
-
-    @field_validator("received_at", mode="before")
-    @classmethod
-    def parse_received_at(cls, v: datetime | str) -> datetime:
-        if isinstance(v, str):
-            return datetime.fromisoformat(v.replace("Z", "+00:00"))
-        return v
-
-    @field_serializer("received_at", when_used="json")
-    def serialize_received_at(self, value: datetime) -> str:
-        if value.tzinfo is None:
-            value = value.replace(tzinfo=timezone.utc)
-        return value.isoformat()
+__all__ = ["CaseEvent"]

--- a/vultron/wire/as2/vocab/objects/case_reference.py
+++ b/vultron/wire/as2/vocab/objects/case_reference.py
@@ -21,32 +21,17 @@ from typing import TypeAlias
 from pydantic import Field, field_validator
 
 from vultron.core.models.base import NonEmptyString
+from vultron.core.models.case_reference import (
+    CASE_REFERENCE_TAG_VOCABULARY,
+    CaseReference as CoreCaseReference,
+)
 from vultron.core.models.enums import VultronObjectType as VO_type
 from vultron.wire.as2.vocab.base.links import ActivityStreamRef
-from vultron.wire.as2.vocab.objects.base import VultronAS2Object
-
-# CVE JSON Schema reference tag vocabulary
-CASE_REFERENCE_TAG_VOCABULARY = {
-    "broken-link",
-    "customer-entitlement",
-    "exploit",
-    "government-resource",
-    "issue-tracking",
-    "mailing-list",
-    "mitigation",
-    "not-applicable",
-    "patch",
-    "permissions-required",
-    "media-coverage",
-    "product",
-    "related",
-    "release-notes",
-    "signature",
-    "technical-description",
-    "third-party-advisory",
-    "vendor-advisory",
-    "vdb-entry",
-}
+from vultron.wire.as2.vocab.objects.base import (
+    VultronAS2Object,
+    _scalar_ref_id_or_value,
+    _strip_core_context,
+)
 
 
 class CaseReference(VultronAS2Object):
@@ -86,7 +71,7 @@ class CaseReference(VultronAS2Object):
 
     @field_validator("tags")
     @classmethod
-    def validate_tags(cls, v):
+    def validate_tags(cls, v: list[str] | None) -> list[str] | None:
         if v is None:
             return None
         if not isinstance(v, list):
@@ -102,6 +87,22 @@ class CaseReference(VultronAS2Object):
                     f"{sorted(CASE_REFERENCE_TAG_VOCABULARY)}"
                 )
         return v
+
+    @classmethod
+    def from_core(cls, core_obj: CoreCaseReference) -> "CaseReference":
+        data = core_obj.model_dump(mode="json")
+        _strip_core_context(data)
+        data["attributed_to"] = _scalar_ref_id_or_value(
+            data.get("attributed_to")
+        )
+        return cls.model_validate(data)
+
+    def to_core(self) -> CoreCaseReference:
+        data = self._to_core_data()
+        data["attributed_to"] = _scalar_ref_id_or_value(
+            data.get("attributed_to")
+        )
+        return CoreCaseReference.model_validate(data)
 
 
 CaseReferenceRef: TypeAlias = ActivityStreamRef[CaseReference]

--- a/vultron/wire/as2/vocab/objects/vulnerability_case.py
+++ b/vultron/wire/as2/vocab/objects/vulnerability_case.py
@@ -22,7 +22,7 @@ from typing import TypeAlias, cast
 from pydantic import Field, model_validator
 
 from vultron.core.models.base import NonEmptyString
-from vultron.core.models.case import VultronCase
+from vultron.core.models.case import VulnerabilityCase as CoreVulnerabilityCase
 from vultron.wire.as2.vocab.base.links import ActivityStreamRef
 from vultron.wire.as2.vocab.base.objects.activities.base import as_Activity
 from vultron.wire.as2.vocab.base.objects.object_types import as_NoteRef
@@ -240,7 +240,7 @@ class VulnerabilityCase(VultronAS2Object):
         return event
 
     @classmethod
-    def from_core(cls, core_obj: VultronCase) -> "VulnerabilityCase":
+    def from_core(cls, core_obj: CoreVulnerabilityCase) -> "VulnerabilityCase":
         data = core_obj.model_dump(mode="json")
         _strip_core_context(data)
         data["case_activity"] = [
@@ -256,7 +256,7 @@ class VulnerabilityCase(VultronAS2Object):
         ]
         return cls.model_validate(data)
 
-    def to_core(self) -> VultronCase:
+    def to_core(self) -> CoreVulnerabilityCase:
         data = self._to_core_data()
         data["attributed_to"] = _scalar_ref_id_or_value(
             data.get("attributed_to")
@@ -292,7 +292,7 @@ class VulnerabilityCase(VultronAS2Object):
         data["parent_cases"] = _ref_id_or_value(data.get("parent_cases", []))
         data["child_cases"] = _ref_id_or_value(data.get("child_cases", []))
         data["sibling_cases"] = _ref_id_or_value(data.get("sibling_cases", []))
-        return VultronCase.model_validate(data)
+        return CoreVulnerabilityCase.model_validate(data)
 
 
 VulnerabilityCaseRef: TypeAlias = ActivityStreamRef[VulnerabilityCase]


### PR DESCRIPTION
## Summary

Implements issue #729 — step 6 of the domain object migration (#699).

Migrates four types to `vultron/core/models/`:

| Type | Before | After |
|---|---|---|
| `VulnerabilityCase` | `VultronCase(VultronObject)` stub | `VulnerabilityCase(CoreObject)` + full domain methods |
| `CaseEvent` | `VultronCaseEvent(BaseModel)` stub | `CaseEvent(BaseModel)` with NonEmptyString fields + validators |
| `CaseActor` | `VultronCaseActor(VultronObject)` stub | `CaseActor(CoreObject)` |
| `CaseReference` | (no core type) | new `CaseReference(CoreObject)` |

### Key decisions
- **`CaseEvent` stays `BaseModel`** (not `CoreObject`): it is an inline value object, not a federated identity. Promoting it to `CoreObject` would add `id_`/`type_`/`published`/`updated` to the stored schema without approval.
- **AC-2 deferred**: wire types keep all methods. Thinning wire projections is deferred to the #699 finale when the DataLayer is also updated.
- **Backward-compat aliases**: `VultronCase`, `VultronCaseEvent`, `VultronCaseActor` all preserved.

### Tests
84 new unit tests across `test/core/models/test_case*.py`; existing `test_core_object.py` AC-4 guard updated (VulnerabilityCase now migrated).

Closes #729
Part of #699