### PR TITLE
docs(specs,notes): capture CaseLogEntry convergence plan from #788

### DIFF
--- a/docs/adr/0018-canonical-case-history-convergence.md
+++ b/docs/adr/0018-canonical-case-history-convergence.md
@@ -1,0 +1,75 @@
+---
+status: accepted
+date: 2026-06-05
+deciders: Vultron maintainers
+consulted: notes/case-log-authority.md
+---
+
+# Canonical Case History Convergence on `CaseLogEntry`
+
+## Context and Problem Statement
+
+`CaseEvent` was introduced earlier as a lightweight per-case event record.
+`CaseLogEntry` later established a richer canonical log model with
+single-writer CaseActor authority, hash-chain semantics, and replication
+alignment.
+
+The project must now decide how to converge these parallel history paths while
+preserving protocol correctness and practical actor behavior during replication
+round-trip delays and restart recovery.
+
+## Decision Drivers
+
+- Preserve CaseActor single-writer authority for canonical shared history.
+- Avoid long-term dual-history drift between `CaseEvent` and `CaseLogEntry`.
+- Support actor behavior during canonical round-trip windows without creating a
+  second source of truth.
+- Ensure restart safety by preventing new actions from stale local case views.
+
+## Considered Options
+
+- A. Keep `CaseEvent` and `CaseLogEntry` as permanent parallel models.
+- B. Immediately remove `CaseEvent` and switch all reads/writes at once.
+- C. Converge in phases: canonicalize writes first, add bounded local pending
+  suppression, gate actions on catch-up, then remove `CaseEvent`.
+
+## Decision Outcome
+
+Chosen option: **C — phased convergence to canonical `CaseLogEntry`**.
+
+The project will converge on `CaseLogEntry` as the authoritative
+protocol-significant case history path, while using a temporary local
+`pending_assertions` mechanism only for duplicate-suppression during canonical
+round-trip windows.
+
+### Consequences
+
+- Good, because canonical history authority remains explicit and aligned with
+  CaseActor single-writer semantics.
+- Good, because phased migration lowers risk compared to a big-bang removal.
+- Good, because actors can avoid duplicate near-term re-emits while still
+  treating canonical entries as the only source of truth.
+- Bad, because migration work must touch multiple write/read paths before
+  `CaseEvent` can be removed cleanly.
+- Bad, because `pending_assertions` adds short-term complexity that must be
+  explicitly bounded and non-authoritative.
+
+## Validation
+
+- Specs define normative requirements for pending suppression semantics and
+  catch-up gating.
+- Implementation work is tracked in Epic #788 and child issues #789–#792.
+- Tests must verify canonical-write routing, pending timeout behavior, and
+  catch-up-before-action blocking semantics.
+
+## More Information
+
+- Epic #788 — Converge CaseEvent flow onto canonical CaseLogEntry.
+- #789 — Migrate write paths to CaseActor-authorized canonical commits.
+- #790 — Add `pending_assertions` suppression model.
+- #791 — Require catch-up before new actions.
+- #792 — Deprecate and remove `CaseEvent` path after convergence.
+- notes/case-log-authority.md — design rationale and boundary model.
+
+Generated spec requirements: `case-log-processing.yaml` CLP-06-001 through
+CLP-06-006; `sync-log-replication.yaml` SYNC-10-001 through SYNC-10-003.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -70,6 +70,8 @@ General information about architectural decision records is available at <https:
   Adapter](0016-sqlmodel-sqlite-datalayer.md)
 - [ADR-0017 Domain/Wire Object Separation: Parallel Core Class
   Hierarchy](0017-domain-wire-object-separation.md)
+- [ADR-0018 Canonical Case History Convergence on
+  `CaseLogEntry`](0018-canonical-case-history-convergence.md)
 
 ## Proposed ADRs
 

--- a/notes/case-log-authority.md
+++ b/notes/case-log-authority.md
@@ -197,6 +197,37 @@ because replicas need the actual asserted content to reconstruct state.
 
 ---
 
+## Post-#787 Convergence Decisions (Epic #788)
+
+Issue #787 intentionally kept `CaseEvent` as a lightweight inline value object.
+That merged decision remains valid as a short-term compatibility step while the
+project converges on canonical `CaseLogEntry` history.
+
+Follow-on plan (Epic #788):
+
+- #789 migrates remaining `record_event()`-only write paths to CaseActor
+  canonical log commits.
+- #790 introduces actor-local `pending_assertions` to suppress duplicate emits
+  during canonical round-trip windows.
+- #791 adds a hard catch-up gate so actors must re-establish case-log freshness
+  before taking new case actions after restart.
+- #792 removes `CaseEvent` once canonical log reads/writes fully cover
+  protocol-significant history.
+
+`pending_assertions` is temporary local memory for decision suppression, not a
+second source of truth. Canonical `CaseLogEntry` remains authoritative.
+
+Initial policy decisions for pending assertions:
+
+- default timeout is 180 seconds and configurable
+- timeout marks the assertion as `timed_out` and logs an error
+- timeout does not auto-retry; future behavior may decide to re-emit if still
+  needed
+- entries clear when matching canonical `CaseLogEntry(recorded|rejected)`
+  arrives
+
+---
+
 ## Consequences for Future Design Work
 
 This framing has several practical consequences:

--- a/specs/case-log-processing.yaml
+++ b/specs/case-log-processing.yaml
@@ -146,3 +146,36 @@ groups:
       The system SHOULD provide a convenient way to retrieve the recorded-only history projection
       without requiring consumers to manually filter rejected entries from the broader audit
       log
+- id: CLP-06
+  title: Pending Assertion Suppression
+  specs:
+  - id: CLP-06-001
+    priority: SHOULD
+    statement: >-
+      Participant actors SHOULD maintain actor-local pending assertion state for recently
+      emitted case-scoped assertions that are awaiting canonical `CaseLogEntry` confirmation
+  - id: CLP-06-002
+    priority: MUST_NOT
+    statement: >-
+      Pending assertion state MUST NOT be treated as canonical case history and MUST NOT be
+      used as the authoritative source for participant membership or case state reconstruction
+  - id: CLP-06-003
+    priority: MUST
+    statement: >-
+      Implementations that provide pending assertion suppression MUST support a configurable
+      timeout; the default timeout SHOULD be 180 seconds
+  - id: CLP-06-004
+    priority: MUST
+    statement: >-
+      When a pending assertion reaches timeout without matching canonical confirmation, it MUST
+      transition to a timed-out state and the system MUST emit an error log
+  - id: CLP-06-005
+    priority: MUST_NOT
+    statement: >-
+      Pending assertion timeout handling MUST NOT automatically retry assertion emission;
+      follow-up emission decisions MUST be made by subsequent behavior evaluation
+  - id: CLP-06-006
+    priority: MUST
+    statement: >-
+      A pending assertion entry MUST be cleared when a matching canonical
+      `CaseLogEntry(recorded|rejected)` is observed

--- a/specs/sync-log-replication.yaml
+++ b/specs/sync-log-replication.yaml
@@ -161,3 +161,22 @@ groups:
     priority: MUST
     statement: 'Reject-on-divergence: entries that do not extend the current hash chain MUST be rejected and MUST trigger
       resynchronization'
+- id: SYNC-10
+  title: Catch-Up Gate Before New Actions
+  specs:
+  - id: SYNC-10-001
+    priority: MUST
+    statement: >-
+      After actor process restart or recovery, an actor with case state in scope MUST re-establish
+      case-log freshness with the CaseActor before taking new protocol-significant case actions
+  - id: SYNC-10-002
+    priority: MUST
+    statement: >-
+      While catch-up freshness is not established, the actor MUST block or defer new
+      protocol-significant case actions and surface an explicit stale-or-catching-up condition
+  - id: SYNC-10-003
+    priority: SHOULD
+    statement: >-
+      Catch-up freshness checks SHOULD use the actor's last acknowledged canonical hash and
+      replay mechanisms so that action gating is based on canonical log position, not local
+      wall-clock assumptions


### PR DESCRIPTION
## Summary
- add a post-#787 decision record to notes/case-log-authority.md
- add normative CLP requirements for actor-local pending_assertions suppression semantics
- add normative SYNC requirements for catch-up-before-new-actions gating

## Why
We have finalized design decisions for CaseEvent/CaseLogEntry convergence and should capture them before implementation work proceeds.

## Tracking
- Epic: #788
- Child issues: #789, #790, #791, #792

## Scope
Docs/specs only (no runtime code changes).
