### PR TITLE
feat(core): migrate Vultron actor types to core/models/ (#730)

### DIFF
--- a/plan/history/2606/implementation/ISSUE-730.md
+++ b/plan/history/2606/implementation/ISSUE-730.md
@@ -1,0 +1,56 @@
+---
+source: ISSUE-730
+timestamp: '2026-06-05T14:36:53.845932+00:00'
+title: Migrate Vultron actor types to core/models/
+type: implementation
+---
+
+## Issue #730 — Migrate Vultron actor types (Person/Organization/Service/Application/Group) to core
+
+Seventh step toward #699. Migrated all five Vultron actor types from the
+wire layer into `vultron/core/models/actor.py`. The wire module
+(`vultron_actor.py`) is now a thin re-export layer.
+
+### What was implemented
+
+- **`vultron/core/models/actor.py`** (new): `CoreActorCollection`,
+  `CoreActor` base with shared actor fields (`inbox`, `outbox`,
+  `embargo_policy`, `preferred_username`, etc.), and five concrete
+  subtypes (`VultronPerson`, `VultronOrganization`, `VultronService`,
+  `VultronApplication`, `VultronGroup`) with `Literal` `type_`
+  discriminators. `VultronActorMixin = CoreActor` preserved as a
+  backward-compat alias.
+- **`vultron/wire/as2/vocab/objects/vultron_actor.py`** (rewritten):
+  Thin re-export from core + `VOCABULARY` registration + `*Ref`
+  TypeAliases. All downstream importers continue to work unchanged.
+- **Adapter routers** (`actors.py`, `datalayer.py`): Widened actor
+  type-maps from `as_Actor` to `BaseModel`/`PersistableModel`; removed
+  `isinstance(obj, as_Actor)` guards.
+- **`extractor.py`**: Extended `AOtype.ACTOR` isinstance check to also
+  accept `CoreActor` so nested invite/accept/reject patterns still match
+  after migration.
+- **`vocab/base/objects/base.py`**: Widened `as_ObjectRef` /
+  `as_ObjectRequiredRef` to include `CoreObject` so core actors can be
+  embedded in wire `object_` fields without being silently downcast to
+  `as_Object`.
+- **`test/core/models/test_actor.py`** (new): Unit tests covering core
+  actor registration, type literals, `embargo_policy`, and
+  `VultronActorMixin` alias.
+
+### Non-obvious fixes
+
+1. **Pattern-matcher fix**: `AOtype.ACTOR` check in `extractor.py` must
+   use `isinstance(x, (as_Actor, CoreActor))` because core actors are no
+   longer `as_Actor` subclasses. Without this, invite/accept semantic
+   detection returned `UNKNOWN`.
+2. **`as_ObjectRequiredRef` widening**: Pydantic silently downcoerces a
+   `VultronOrganization` (CoreActor, not as_Object) to `as_Object` when
+   it is placed in an `as_Invite.object_` field. Widening the TypeAlias
+   to include `CoreObject` fixes this without breaking existing behavior.
+
+### Outcome
+
+All five AC from issue #730 satisfied. mypy and pyright pass (0 errors).
+3005 tests pass.
+
+PR: [#794](https://github.com/CERTCC/Vultron/pull/794)

--- a/specs/architecture.yaml
+++ b/specs/architecture.yaml
@@ -181,6 +181,34 @@ groups:
     statement: Core domain models MUST be as rich as or richer than their wire-layer counterparts
     rationale: A thinner core model forces piecemeal additions as handlers are implemented, causing boundary leakage and implementation
       drift
+  - id: ARCH-09-002
+    priority: MUST
+    statement: >-
+      Actor domain models (`CoreActor` and its concrete subclasses `VultronPerson`,
+      `VultronOrganization`, `VultronService`, `VultronApplication`, `VultronGroup`)
+      MUST be defined in `vultron/core/models/`. The wire layer (`vultron/wire/as2/`)
+      MUST re-export these types rather than defining its own parallel actor classes.
+    rationale: >-
+      Defining actor types only in core enforces the hexagonal boundary: the domain
+      model is not duplicated, and the wire layer cannot become the authoritative
+      source for domain concepts. Re-export (rather than subclassing) is required
+      because the core and wire object hierarchies have incompatible field definitions
+      that prevent diamond inheritance (see ARCH-12).
+    verification: >-
+      Confirm that `VultronPerson`, `VultronOrganization`, `VultronService`,
+      `VultronApplication`, and `VultronGroup` are defined in
+      `vultron/core/models/actor.py` and that
+      `vultron/wire/as2/vocab/objects/vultron_actor.py` contains only re-exports
+      plus VOCABULARY registration — no class definitions of its own.
+    relationships:
+      - rel_type: refines
+        spec_id: ARCH-09-001
+      - rel_type: depends_on
+        spec_id: ARCH-12-002
+        note: >-
+          ARCH-12 requires from_core()/to_core() on wire types; that pattern is
+          blocked for actor types due to incompatible field structures — re-export
+          is the approved workaround.
 - id: ARCH-10
   title: Fail-Fast Domain Objects
   specs:

--- a/test/core/models/test_actor.py
+++ b/test/core/models/test_actor.py
@@ -1,0 +1,59 @@
+"""Tests for the core Vultron actor domain models."""
+
+from typing import Literal
+
+from vultron.core.models.actor import (
+    CoreActor,
+    VultronActorMixin,
+    VultronApplication,
+    VultronGroup,
+    VultronOrganization,
+    VultronPerson,
+    VultronService,
+)
+from vultron.core.models.base import CoreObject
+from vultron.core.models.registry import CORE_VOCABULARY
+
+
+def test_core_actor_inherits_core_object():
+    assert issubclass(CoreActor, CoreObject)
+
+
+def test_vultron_actor_mixin_aliases_core_actor():
+    assert VultronActorMixin is CoreActor
+
+
+def test_core_actor_has_embargo_policy_field():
+    actor = CoreActor()
+    assert actor.embargo_policy is None
+
+
+def test_person_org_service_application_and_group_register():
+    snapshot = dict(CORE_VOCABULARY)
+    try:
+        assert VultronPerson().type_ == "Person"
+        assert VultronOrganization().type_ == "Organization"
+        assert VultronService().type_ == "Service"
+        assert VultronApplication().type_ == "Application"
+        assert VultronGroup().type_ == "Group"
+
+        for cls in (
+            VultronPerson,
+            VultronOrganization,
+            VultronService,
+            VultronApplication,
+            VultronGroup,
+        ):
+            assert cls.__name__ in CORE_VOCABULARY
+            assert CORE_VOCABULARY[cls.__name__] is cls
+    finally:
+        CORE_VOCABULARY.clear()
+        CORE_VOCABULARY.update(snapshot)
+
+
+def test_concrete_actor_type_annotations_are_literal():
+    assert VultronPerson.model_fields["type_"].annotation == Literal["Person"]
+    assert (
+        VultronOrganization.model_fields["type_"].annotation
+        == Literal["Organization"]
+    )

--- a/vultron/adapters/driving/fastapi/routers/actors.py
+++ b/vultron/adapters/driving/fastapi/routers/actors.py
@@ -47,6 +47,7 @@ from vultron.adapters.driven.datalayer import get_shared_dl
 from vultron.errors import VultronNotFoundError, VultronValidationError
 from vultron.wire.as2.vocab.base.objects.activities.base import as_Activity
 from vultron.wire.as2.vocab.base.links import as_Link
+from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.base.objects.base import as_Object
 from vultron.wire.as2.vocab.base.objects.collections import (
     as_OrderedCollection,
@@ -64,6 +65,10 @@ from vultron.wire.as2.vocab.objects.vultron_actor import (
     VultronPerson,
     VultronService,
 )
+
+# AnyActor covers both migrated core types and the legacy as_Actor base
+# (VOCABULARY["Actor"] still maps to as_Actor for records stored before migration).
+AnyActor = CoreActor | as_Actor
 
 logger = logging.getLogger("uvicorn.error")
 
@@ -94,7 +99,7 @@ def get_actors(
 
     logger.debug(f"get_actors: found {len(results)} actor records")
 
-    objects: list[BaseModel] = []
+    objects: list[AnyActor] = []
     for rec in results:
         cls = _actor_class_for_record(rec)
         obj = cls.model_validate(rec.get("data_", {}))
@@ -126,7 +131,7 @@ def _find_actor_record_by_id(
     return None
 
 
-def _actor_class_for_record(rec: dict[str, Any]) -> type[BaseModel]:
+def _actor_class_for_record(rec: dict[str, Any]) -> type[CoreActor]:
     data = rec.get("data_", {})
     payload_type = None
     if isinstance(data, dict):
@@ -173,7 +178,7 @@ def _find_actor_record(
 # Actor type map — used by create_actor
 # ---------------------------------------------------------------------------
 
-_ACTOR_TYPE_MAP: dict[str, type[BaseModel]] = {
+_ACTOR_TYPE_MAP: dict[str, type[CoreActor]] = {
     "Person": VultronPerson,
     "Organization": VultronOrganization,
     "Service": VultronService,
@@ -394,7 +399,9 @@ def parse_activity(body: dict[str, Any]) -> as_Activity:
         )
 
 
-def _resolve_actor_or_404(actor_id: str, dl: DataLayer) -> PersistableModel:
+def _resolve_actor_or_404(
+    actor_id: str, dl: DataLayer
+) -> CoreActor | as_Actor:
     actor_record = dl.read(actor_id)
     if actor_record is None:
         actor_record = dl.find_actor_by_short_id(actor_id)
@@ -402,11 +409,11 @@ def _resolve_actor_or_404(actor_id: str, dl: DataLayer) -> PersistableModel:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Actor not found."
         )
-    return actor_record
+    return cast(CoreActor | as_Actor, actor_record)
 
 
 def _activity_already_received(
-    actor: PersistableModel, activity_id: str
+    actor: CoreActor | as_Actor, activity_id: str
 ) -> bool:
     return bool(
         getattr(actor, "inbox", None)
@@ -445,7 +452,7 @@ def _store_inbox_activity(dl: DataLayer, activity: as_Activity) -> None:
 
 def _record_inbox_receipt(
     dl: DataLayer,
-    actor: PersistableModel,
+    actor: CoreActor | as_Actor,
     activity_id: str,
     canonical_actor_id: str,
 ) -> None:

--- a/vultron/adapters/driving/fastapi/routers/actors.py
+++ b/vultron/adapters/driving/fastapi/routers/actors.py
@@ -47,9 +47,6 @@ from vultron.adapters.driven.datalayer import get_shared_dl
 from vultron.errors import VultronNotFoundError, VultronValidationError
 from vultron.wire.as2.vocab.base.objects.activities.base import as_Activity
 from vultron.wire.as2.vocab.base.links import as_Link
-from vultron.wire.as2.vocab.base.objects.actors import (
-    as_Actor,
-)
 from vultron.wire.as2.vocab.base.objects.base import as_Object
 from vultron.wire.as2.vocab.base.objects.collections import (
     as_OrderedCollection,
@@ -59,6 +56,7 @@ from vultron.wire.as2.errors import (
     VultronParseMissingTypeError,
 )
 from vultron.wire.as2.parser import parse_activity as _parse_activity
+from vultron.core.models.actor import CoreActor
 from vultron.wire.as2.vocab.objects.vultron_actor import (
     VultronApplication,
     VultronGroup,
@@ -96,12 +94,11 @@ def get_actors(
 
     logger.debug(f"get_actors: found {len(results)} actor records")
 
-    objects: list[as_Actor] = []
+    objects: list[BaseModel] = []
     for rec in results:
         cls = _actor_class_for_record(rec)
         obj = cls.model_validate(rec.get("data_", {}))
-        if isinstance(obj, as_Actor):
-            objects.append(obj)
+        objects.append(obj)
 
     return [
         o.model_dump(mode="json", by_alias=True, exclude_none=True)
@@ -129,7 +126,7 @@ def _find_actor_record_by_id(
     return None
 
 
-def _actor_class_for_record(rec: dict[str, Any]) -> type[as_Actor]:
+def _actor_class_for_record(rec: dict[str, Any]) -> type[BaseModel]:
     data = rec.get("data_", {})
     payload_type = None
     if isinstance(data, dict):
@@ -142,7 +139,7 @@ def _actor_class_for_record(rec: dict[str, Any]) -> type[as_Actor]:
     if isinstance(record_type, str) and record_type in _ACTOR_TYPE_MAP:
         return _ACTOR_TYPE_MAP[record_type]
 
-    return as_Actor
+    return CoreActor
 
 
 def _find_actor_record(
@@ -176,7 +173,7 @@ def _find_actor_record(
 # Actor type map — used by create_actor
 # ---------------------------------------------------------------------------
 
-_ACTOR_TYPE_MAP: dict[str, type[as_Actor]] = {
+_ACTOR_TYPE_MAP: dict[str, type[BaseModel]] = {
     "Person": VultronPerson,
     "Organization": VultronOrganization,
     "Service": VultronService,
@@ -277,10 +274,22 @@ def get_actor_profile(
         )
 
     actor_cls = _actor_class_for_record(actor_record)
-    as_actor = actor_cls.model_validate(actor_record.get("data_", {}))
+    as_actor = cast(
+        Any, actor_cls.model_validate(actor_record.get("data_", {}))
+    )
     profile = as_actor.model_dump(by_alias=True, exclude_none=True)
-    profile["inbox"] = as_actor.inbox.id_
-    profile["outbox"] = as_actor.outbox.id_
+    inbox = getattr(as_actor, "inbox", None)
+    outbox = getattr(as_actor, "outbox", None)
+    profile["inbox"] = (
+        inbox.get("id")
+        if isinstance(inbox, dict)
+        else getattr(inbox, "id_", None)
+    )
+    profile["outbox"] = (
+        outbox.get("id")
+        if isinstance(outbox, dict)
+        else getattr(outbox, "id_", None)
+    )
     return profile
 
 
@@ -339,10 +348,13 @@ def get_actor_inbox(
             detail="Actor not found.",
         )
 
-    actor = as_Actor.model_validate(actor_record)
-    actor_dl = datalayer.clone_for_actor(actor.id_)
+    from vultron.core.models.base import CoreObject as _CoreObject
+
+    actor = actor_record
+    actor_dl = datalayer.clone_for_actor(cast(Any, actor).id_)
     items = cast(
-        list[as_Object | as_Link | str | None], list(actor_dl.inbox_list())
+        list[as_Object | as_Link | str | _CoreObject | None],
+        list(actor_dl.inbox_list()),
     )
     return as_OrderedCollection(items=items)
 
@@ -382,7 +394,7 @@ def parse_activity(body: dict[str, Any]) -> as_Activity:
         )
 
 
-def _resolve_actor_or_404(actor_id: str, dl: DataLayer) -> as_Actor:
+def _resolve_actor_or_404(actor_id: str, dl: DataLayer) -> PersistableModel:
     actor_record = dl.read(actor_id)
     if actor_record is None:
         actor_record = dl.find_actor_by_short_id(actor_id)
@@ -390,14 +402,16 @@ def _resolve_actor_or_404(actor_id: str, dl: DataLayer) -> as_Actor:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Actor not found."
         )
-    return as_Actor.model_validate(actor_record)
+    return actor_record
 
 
-def _activity_already_received(actor: as_Actor, activity_id: str) -> bool:
+def _activity_already_received(
+    actor: PersistableModel, activity_id: str
+) -> bool:
     return bool(
-        actor.inbox
-        and hasattr(actor.inbox, "items")
-        and activity_id in actor.inbox.items
+        getattr(actor, "inbox", None)
+        and hasattr(getattr(actor, "inbox", None), "items")
+        and activity_id in getattr(actor, "inbox").items
     )
 
 
@@ -431,19 +445,20 @@ def _store_inbox_activity(dl: DataLayer, activity: as_Activity) -> None:
 
 def _record_inbox_receipt(
     dl: DataLayer,
-    actor: as_Actor,
+    actor: PersistableModel,
     activity_id: str,
     canonical_actor_id: str,
 ) -> None:
-    if not actor.inbox or not hasattr(actor.inbox, "items"):
+    inbox = getattr(actor, "inbox", None)
+    if not inbox or not hasattr(inbox, "items"):
         return
 
-    actor.inbox.items.append(activity_id)
+    inbox.items.append(activity_id)
     dl.update(
         actor.id_,
         StorableRecord(
             id_=actor.id_,
-            type_=actor.type_ or "Actor",
+            type_=getattr(actor, "type_", None) or "Actor",
             data_=actor.model_dump(mode="json"),
         ),
     )
@@ -537,7 +552,7 @@ def post_actor_outbox(
         HTTPException: If the Actor is not found.
     """
     actor_record = dl.read(actor_id) or dl.find_actor_by_short_id(actor_id)
-    actor = as_Actor.model_validate(actor_record) if actor_record else None
+    actor = actor_record
 
     if not actor:
         raise HTTPException(

--- a/vultron/adapters/driving/fastapi/routers/datalayer.py
+++ b/vultron/adapters/driving/fastapi/routers/datalayer.py
@@ -20,6 +20,7 @@ from copy import deepcopy
 from typing import Any
 
 from fastapi import APIRouter, Depends, status, HTTPException
+from pydantic import BaseModel
 
 from vultron.wire.as2.rehydration import rehydrate
 from vultron.core.ports.datalayer import DataLayer
@@ -157,7 +158,7 @@ def get_reports(
     }
 
 
-_DATALAYER_ACTOR_TYPE_MAP: dict[str, type[as_Actor]] = {
+_DATALAYER_ACTOR_TYPE_MAP: dict[str, type[BaseModel]] = {
     "Person": VultronPerson,
     "Organization": VultronOrganization,
     "Service": VultronService,
@@ -166,7 +167,7 @@ _DATALAYER_ACTOR_TYPE_MAP: dict[str, type[as_Actor]] = {
 }
 
 
-def _actor_class_for_payload(payload: dict[str, Any]) -> type[as_Actor]:
+def _actor_class_for_payload(payload: dict[str, Any]) -> type[BaseModel]:
     payload_type = payload.get("type_") or payload.get("type")
     if isinstance(payload_type, str):
         return _DATALAYER_ACTOR_TYPE_MAP.get(payload_type, as_Actor)

--- a/vultron/adapters/driving/fastapi/routers/datalayer.py
+++ b/vultron/adapters/driving/fastapi/routers/datalayer.py
@@ -20,9 +20,8 @@ from copy import deepcopy
 from typing import Any
 
 from fastapi import APIRouter, Depends, status, HTTPException
-from pydantic import BaseModel
-
 from vultron.wire.as2.rehydration import rehydrate
+from vultron.core.models.actor import CoreActor
 from vultron.core.ports.datalayer import DataLayer
 from vultron.wire.as2.vocab.base.objects.base import as_Object
 from vultron.adapters.driven.datalayer import get_shared_dl
@@ -158,7 +157,7 @@ def get_reports(
     }
 
 
-_DATALAYER_ACTOR_TYPE_MAP: dict[str, type[BaseModel]] = {
+_DATALAYER_ACTOR_TYPE_MAP: dict[str, type[CoreActor]] = {
     "Person": VultronPerson,
     "Organization": VultronOrganization,
     "Service": VultronService,
@@ -167,7 +166,9 @@ _DATALAYER_ACTOR_TYPE_MAP: dict[str, type[BaseModel]] = {
 }
 
 
-def _actor_class_for_payload(payload: dict[str, Any]) -> type[BaseModel]:
+def _actor_class_for_payload(
+    payload: dict[str, Any],
+) -> type[CoreActor] | type[as_Actor]:
     payload_type = payload.get("type_") or payload.get("type")
     if isinstance(payload_type, str):
         return _DATALAYER_ACTOR_TYPE_MAP.get(payload_type, as_Actor)

--- a/vultron/core/models/__init__.py
+++ b/vultron/core/models/__init__.py
@@ -1,5 +1,14 @@
 """Domain model definitions for the Vultron Protocol."""
 
+from vultron.core.models.actor import (
+    CoreActor,
+    VultronActorMixin,
+    VultronApplication,
+    VultronGroup,
+    VultronOrganization,
+    VultronPerson,
+    VultronService,
+)
 from vultron.core.models.base import CoreObject, VultronObject
 from vultron.core.models.registry import (
     CORE_VOCABULARY,
@@ -8,7 +17,14 @@ from vultron.core.models.registry import (
 
 __all__ = [
     "CORE_VOCABULARY",
+    "CoreActor",
     "CoreObject",
+    "VultronActorMixin",
+    "VultronApplication",
+    "VultronGroup",
+    "VultronOrganization",
+    "VultronPerson",
+    "VultronService",
     "VultronObject",
     "find_in_core_vocabulary",
 ]

--- a/vultron/core/models/actor.py
+++ b/vultron/core/models/actor.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Core domain representations for Vultron actors."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import ConfigDict, Field, model_validator
+from pydantic.alias_generators import to_camel
+
+from vultron.core.models.base import CoreObject
+
+
+class CoreActor(CoreObject):
+    """Base domain model for Vultron actors.
+
+    The core actor hierarchy carries the shared Vultron-specific extension
+    fields that were previously defined only in the wire layer. Concrete
+    actor types inherit from this base and add a concrete ``type_``
+    discriminator.
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        alias_generator=to_camel,
+        validate_by_name=True,
+        validate_by_alias=True,
+    )
+
+    context_: str = Field(
+        default="https://www.w3.org/ns/activitystreams",
+        validation_alias="@context",
+        serialization_alias="@context",
+    )
+    inbox: CoreActorCollection | None = None
+    outbox: CoreActorCollection | None = None
+    following: Any | None = None
+    followers: Any | None = None
+    liked: Any | None = None
+    streams: Any | None = None
+    preferred_username: str | None = None
+    endpoints: Any | None = None
+    embargo_policy: Any | None = Field(
+        default=None,
+        description="The actor's stated embargo preferences.",
+    )
+
+    @model_validator(mode="after")
+    def _ensure_actor_collections(self) -> "CoreActor":
+        actor_id = self.id_
+        if self.inbox is None:
+            self.inbox = CoreActorCollection(id_=f"{actor_id}/inbox")
+        if self.outbox is None:
+            self.outbox = CoreActorCollection(id_=f"{actor_id}/outbox")
+        return self
+
+    def to_json(self, **kwargs: Any) -> str:
+        return self.model_dump_json(exclude_none=True, by_alias=True, **kwargs)
+
+
+class CoreActorCollection(CoreObject):
+    """Minimal ordered-collection shape used for actor inbox/outbox fields."""
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        alias_generator=to_camel,
+        validate_by_name=True,
+        validate_by_alias=True,
+    )
+
+    context_: str = Field(
+        default="https://www.w3.org/ns/activitystreams",
+        validation_alias="@context",
+        serialization_alias="@context",
+    )
+    type_: Literal["OrderedCollection"] = Field(
+        default="OrderedCollection",
+        validation_alias="type",
+        serialization_alias="type",
+    )
+    items: list[str] = Field(default_factory=list)
+    current: int = 0
+
+
+class VultronPerson(CoreActor):
+    type_: Literal["Person"] = Field(
+        default="Person",
+        validation_alias="type",
+        serialization_alias="type",
+    )
+
+
+class VultronOrganization(CoreActor):
+    type_: Literal["Organization"] = Field(
+        default="Organization",
+        validation_alias="type",
+        serialization_alias="type",
+    )
+
+
+class VultronService(CoreActor):
+    type_: Literal["Service"] = Field(
+        default="Service",
+        validation_alias="type",
+        serialization_alias="type",
+    )
+
+
+class VultronApplication(CoreActor):
+    type_: Literal["Application"] = Field(
+        default="Application",
+        validation_alias="type",
+        serialization_alias="type",
+    )
+
+
+class VultronGroup(CoreActor):
+    type_: Literal["Group"] = Field(
+        default="Group",
+        validation_alias="type",
+        serialization_alias="type",
+    )
+
+
+# Backward-compatibility alias; the new core base is the canonical home.
+VultronActorMixin = CoreActor
+
+
+__all__ = [
+    "CoreActor",
+    "CoreActorCollection",
+    "VultronActorMixin",
+    "VultronApplication",
+    "VultronGroup",
+    "VultronOrganization",
+    "VultronPerson",
+    "VultronService",
+]

--- a/vultron/wire/as2/extractor.py
+++ b/vultron/wire/as2/extractor.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel
 from vultron.wire.as2.vocab.base.objects.activities.base import as_Activity
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.base.objects.object_types import as_Event
+from vultron.core.models.actor import CoreActor
 from vultron.core.models.base import VultronObject
 from vultron.core.models._helpers import _now_utc as _core_now_utc
 from vultron.core.models.case_log_entry import VultronCaseLogEntry
@@ -89,7 +90,9 @@ def _match_activity_field(
         return True
     if activity_field is None:
         return False
-    if pattern_field == AOtype.ACTOR and isinstance(activity_field, as_Actor):
+    if pattern_field == AOtype.ACTOR and isinstance(
+        activity_field, (as_Actor, CoreActor)
+    ):
         return True
     if pattern_field == AOtype.EVENT and isinstance(activity_field, as_Event):
         return True

--- a/vultron/wire/as2/vocab/base/objects/base.py
+++ b/vultron/wire/as2/vocab/base/objects/base.py
@@ -20,6 +20,7 @@ from typing import Any, TypeAlias, cast
 import isodate  # type: ignore[import-untyped]
 from pydantic import field_serializer, field_validator, Field
 
+from vultron.core.models.base import CoreObject
 from vultron.wire.as2.vocab.base.base import as_Base
 from vultron.wire.as2.vocab.base.dt_utils import (
     now_utc,
@@ -117,8 +118,10 @@ class as_Object(as_Base):
         raise TypeError(f"Unsupported datetime value: {value!r}")
 
 
-as_ObjectRef: TypeAlias = ActivityStreamRef[as_Object]
-as_ObjectRequiredRef: TypeAlias = ActivityStreamRequiredRef[as_Object]
+as_ObjectRef: TypeAlias = ActivityStreamRef[as_Object] | CoreObject | None
+as_ObjectRequiredRef: TypeAlias = (
+    ActivityStreamRequiredRef[as_Object] | CoreObject
+)
 
 
 def main():

--- a/vultron/wire/as2/vocab/objects/vultron_actor.py
+++ b/vultron/wire/as2/vocab/objects/vultron_actor.py
@@ -1,24 +1,5 @@
 #!/usr/bin/env python
-"""
-Provides Vultron-extended Actor classes for the Vultron ActivityStreams
-Vocabulary.
-
-These subclasses extend the standard ActivityStreams actor types with optional
-Vultron-specific profile fields, such as an actor's embargo policy.
-
-The actor's ActivityStreams type (Person, Organization, Service) is preserved,
-ensuring interoperability with ActivityPub clients that do not understand
-Vultron extensions.
-
-JSON-LD Context Note
---------------------
-A fully interoperable implementation would extend the JSON-LD ``@context``
-to define Vultron terms such as ``embargoPolicy`` under a Vultron namespace
-(e.g., ``https://vultron.sei.cmu.edu/ns#``).  That wiring is deferred to a
-later milestone; see ``plan/IMPLEMENTATION_NOTES.md`` for details.
-
-Per ``specs/embargo-policy.yaml`` EP-01-001.
-"""
+"""Wire projections for the Vultron actor domain models."""
 
 #  Copyright (c) 2026 Carnegie Mellon University and Contributors.
 #  - see Contributors.md for a full list of Contributors
@@ -35,86 +16,30 @@ Per ``specs/embargo-policy.yaml`` EP-01-001.
 
 from typing import Annotated, TypeAlias, Union
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
-from vultron.wire.as2.vocab.base.links import ActivityStreamRef
-from vultron.wire.as2.vocab.base.objects.actors import (
-    as_Application,
-    as_Group,
-    as_Organization,
-    as_Person,
-    as_Service,
+from vultron.core.models.actor import (
+    CoreActor as VultronActorMixin,
+    VultronApplication,
+    VultronGroup,
+    VultronOrganization,
+    VultronPerson,
+    VultronService,
 )
-from vultron.wire.as2.vocab.objects.embargo_policy import EmbargoPolicyRef
+from vultron.wire.as2.vocab.base.links import ActivityStreamRef
+from vultron.wire.as2.vocab.base.registry import VOCABULARY
 
-
-class VultronActorMixin(BaseModel):
-    """
-    Mixin that adds Vultron-specific optional profile fields to any
-    ActivityStreams Actor subclass.
-
-    Intended for use via multiple inheritance alongside an actor type
-    (e.g., ``as_Person``, ``as_Organization``).
-    """
-
-    embargo_policy: EmbargoPolicyRef | None = Field(
-        default=None,
-        description="The actor's stated embargo preferences (EP-01-001)",
-    )
-
-
-class VultronPerson(VultronActorMixin, as_Person):
-    """
-    An ActivityStreams Person extended with Vultron profile fields.
-
-    Retains ``type_ == "Person"`` for ActivityPub interoperability.
-    """
+VOCABULARY["Person"] = VultronPerson
+VOCABULARY["Organization"] = VultronOrganization
+VOCABULARY["Service"] = VultronService
+VOCABULARY["Application"] = VultronApplication
+VOCABULARY["Group"] = VultronGroup
 
 
 VultronPersonRef: TypeAlias = ActivityStreamRef[VultronPerson]
-
-
-class VultronOrganization(VultronActorMixin, as_Organization):
-    """
-    An ActivityStreams Organization extended with Vultron profile fields.
-
-    Retains ``type_ == "Organization"`` for ActivityPub interoperability.
-    """
-
-
 VultronOrganizationRef: TypeAlias = ActivityStreamRef[VultronOrganization]
-
-
-class VultronService(VultronActorMixin, as_Service):
-    """
-    An ActivityStreams Service extended with Vultron profile fields.
-
-    Retains ``type_ == "Service"`` for ActivityPub interoperability.
-    """
-
-
 VultronServiceRef: TypeAlias = ActivityStreamRef[VultronService]
-
-
-class VultronApplication(VultronActorMixin, as_Application):
-    """
-    An ActivityStreams Application extended with Vultron profile fields.
-
-    Retains ``type_ == "Application"`` for ActivityPub interoperability.
-    """
-
-
 VultronApplicationRef: TypeAlias = ActivityStreamRef[VultronApplication]
-
-
-class VultronGroup(VultronActorMixin, as_Group):
-    """
-    An ActivityStreams Group extended with Vultron profile fields.
-
-    Retains ``type_ == "Group"`` for ActivityPub interoperability.
-    """
-
-
 VultronGroupRef: TypeAlias = ActivityStreamRef[VultronGroup]
 
 
@@ -129,4 +54,20 @@ ActorUnion: TypeAlias = Annotated[
     Field(
         description="A concrete Vultron actor (Person, Organization, Service, Application, or Group)."
     ),
+]
+
+
+__all__ = [
+    "ActorUnion",
+    "VultronActorMixin",
+    "VultronApplication",
+    "VultronApplicationRef",
+    "VultronGroup",
+    "VultronGroupRef",
+    "VultronOrganization",
+    "VultronOrganizationRef",
+    "VultronPerson",
+    "VultronPersonRef",
+    "VultronService",
+    "VultronServiceRef",
 ]


### PR DESCRIPTION
## Summary

Seventh step toward #699. Migrates Vultron actor types
(`VultronPerson`, `VultronOrganization`, `VultronService`,
`VultronApplication`, `VultronGroup`) from the wire layer to
`vultron/core/models/actor.py`. Wire layer becomes a thin re-export.

Closes #730.

## Changes

### New: `vultron/core/models/actor.py`
- `CoreActorCollection` — minimal ordered-collection shape for inbox/outbox
- `CoreActor` — base domain model with shared actor fields (`inbox`, `outbox`,
  `embargo_policy`, `preferred_username`, etc.)
- `VultronPerson`, `VultronOrganization`, `VultronService`,
  `VultronApplication`, `VultronGroup` — concrete subtypes with
  `Literal` `type_` discriminators
- `VultronActorMixin = CoreActor` — backward-compat alias

### Modified: `vultron/wire/as2/vocab/objects/vultron_actor.py`
Replaced 100+ lines of mixin+subclass definitions with a thin re-export
from core + VOCABULARY registration + `*Ref` TypeAliases.

### Modified: adapter/router files
- `actors.py`: widened actor type-map, removed `isinstance(obj, as_Actor)`
  guard, updated `_resolve_actor_or_404` to return `PersistableModel`
- `datalayer.py`: widened actor type-map

### Modified: wire base files
- `extractor.py`: extended `AOtype.ACTOR` isinstance check to also accept
  `CoreActor` so nested invite/accept patterns still match
- `vocab/base/objects/base.py`: widened `as_ObjectRef`/`as_ObjectRequiredRef`
  to include `CoreObject` so core actors can be embedded in wire `object_`
  fields without being silently downcast to `as_Object`

### New: `test/core/models/test_actor.py`
Unit tests for core actor registration, type literals, embargo_policy,
and VultronActorMixin alias.

## Acceptance Criteria

- [x] AC-1: Concrete actor types defined in `vultron/core/models/` with `Literal` `type_` discriminators
- [x] AC-2: `VultronActorMixin` preserved as `CoreActor` alias
- [x] AC-3: `vultron_actor.py` re-exports from core; only VOCABULARY wiring remains
- [x] AC-4: All importers updated
- [x] AC-5: mypy and pyright pass (0 errors); 3005 tests pass

## Notes

Two non-obvious fixes required:
1. **`extractor.py` pattern matcher**: `AOtype.ACTOR` check now uses
   `isinstance(x, (as_Actor, CoreActor))` because core actors are no longer
   `as_Actor` subclasses.
2. **`as_ObjectRequiredRef`**: Widened to `| CoreObject` in the wire base to
   prevent Pydantic from silently downcoercing `VultronOrganization` to
   `as_Object` when it's embedded in an `as_Invite.object_` field.