### PR TITLE
Add dev-only maintainer docs in docs/developer

### DIFF
--- a/.github/workflows/docs-build-check.yml
+++ b/.github/workflows/docs-build-check.yml
@@ -6,6 +6,7 @@ on:
       - 'overrides/**'
       - 'references.bib'
       - 'mkdocs.yml'
+      - 'mkdocs.dev.yml'
       - 'pyproject.toml'
       - 'uv.lock'
       - 'CONTRIBUTING.md'
@@ -59,3 +60,7 @@ jobs:
         if: steps.filter.outputs.docs_changed == 'true'
         run: |
           uv run linkchecker site/index.html
+
+      - name: Build Developer Docs Overlay
+        run: |
+          uv run mkdocs build --verbose --clean --config-file mkdocs.dev.yml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -460,6 +460,11 @@ Links in `docs/` MUST be relative to the current file and MUST NOT go above
 the `docs/` root. Run `uv run mkdocs build --strict` before committing any
 `docs/` changes (see `build-docs` skill).
 
+Maintainer docs under `docs/developer/` are intentionally excluded from the
+published site (`mkdocs.yml`). To view or validate them locally, use
+`mkdocs.dev.yml` (for example: `uv run mkdocs serve --config-file
+mkdocs.dev.yml`).
+
 ### Demo script lifecycle logging
 
 See [`vultron/adapters/AGENTS.md`](vultron/adapters/AGENTS.md) for the

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,7 @@ RUN uv sync --frozen --dev
 CMD ["uv", "run", "pytest"]
 
 FROM dependencies AS docs
-CMD ["uv", "run", "mkdocs", "serve", "--dev-addr", "0.0.0.0:8000"]
+CMD ["sh", "-lc", "uv run mkdocs serve --dev-addr 0.0.0.0:8000 --config-file ${MKDOCS_CONFIG_FILE:-mkdocs.yml}"]
 
 FROM dependencies AS vultrabot_demo
 CMD ["uv", "run", "vultrabot"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -40,6 +40,8 @@ services:
       - dependencies
     ports:
       - "8000:8000"
+    environment:
+      - MKDOCS_CONFIG_FILE=mkdocs.dev.yml
 
   vultrabot-demo:
     build:

--- a/docs/developer/how-to/find-your-way-around.md
+++ b/docs/developer/how-to/find-your-way-around.md
@@ -1,0 +1,42 @@
+# How to find your way around the codebase
+
+Use this guide when you need a fast orientation to the files maintainers touch
+most often.
+
+## Start from the architecture pipeline
+
+Use this request path as your map:
+
+`FastAPI inbox -> AS2 parser/extractor -> dispatcher -> use-case`
+
+Primary files:
+
+- `vultron/adapters/driving/fastapi/routers/actors.py`
+- `vultron/wire/as2/parser.py`
+- `vultron/wire/as2/extractor.py`
+- `vultron/core/dispatcher.py`
+- `vultron/core/use_cases/`
+
+## Find semantic routing points
+
+Check these first when adding or debugging message types:
+
+- `vultron/core/models/events/base.py` (`MessageSemantics`)
+- `vultron/wire/as2/extractor.py` (`SEMANTICS_ACTIVITY_PATTERNS`)
+- `vultron/core/use_cases/use_case_map.py` (`USE_CASE_MAP`)
+
+## Find canonical maintainer guidance
+
+Use these as source-of-truth jump points:
+
+- Codebase reference: `docs/reference/codebase/index.md`
+- Durable design notes: `notes/README.md` (in-repo path)
+- Agent operating rules: `AGENTS.md` (in-repo path)
+- Skill procedures: `.agents/skills/*/SKILL.md` (in-repo path)
+
+## Troubleshooting
+
+- If behavior seems to cross layers incorrectly, verify imports against
+  hexagonal rules before debugging runtime symptoms.
+- If naming seems inconsistent, check AGENTS naming conventions before
+  introducing new terms.

--- a/docs/developer/how-to/index.md
+++ b/docs/developer/how-to/index.md
@@ -1,0 +1,9 @@
+# Developer How-to Guides
+
+These guides are task-focused directions for maintainers working in this repo.
+
+## Available guides
+
+- [How to run maintainer tests](run-tests.md)
+- [How to run formatters and linters](run-linters-and-formatters.md)
+- [How to find your way around the codebase](find-your-way-around.md)

--- a/docs/developer/how-to/run-linters-and-formatters.md
+++ b/docs/developer/how-to/run-linters-and-formatters.md
@@ -1,0 +1,45 @@
+# How to run formatters and linters
+
+Use this guide to run the same formatting and linting flow maintainers expect
+before commit.
+
+## Format Python code first
+
+Run:
+
+```bash
+uv run black vultron/ test/
+```
+
+## Run flake8 next
+
+Run:
+
+```bash
+uv run flake8 vultron/ test/
+```
+
+## Run the full lint set
+
+Run:
+
+```bash
+uv run mypy
+uv run pyright
+```
+
+## Lint markdown separately
+
+Run:
+
+```bash
+./mdlint.sh
+```
+
+Do not use Black for markdown files.
+
+## Troubleshooting
+
+- If `black` reformats files, rerun the relevant linters after formatting.
+- If type checks fail unexpectedly, confirm your virtual environment is synced
+  with `uv sync --dev`.

--- a/docs/developer/how-to/run-tests.md
+++ b/docs/developer/how-to/run-tests.md
@@ -1,0 +1,41 @@
+# How to run maintainer tests
+
+Use this guide when you need CI-aligned test execution from a maintainer
+workflow.
+
+## Default command (maintainer baseline)
+
+Run:
+
+```bash
+uv run pytest --tb=short 2>&1 | tail -5
+```
+
+This is the default local maintainer command.
+
+## Run a focused file while iterating
+
+If you need faster feedback during implementation, run:
+
+```bash
+uv run pytest test/test_semantic_activity_patterns.py -v
+```
+
+Replace the test path with your target file.
+
+## Include integration tests when required
+
+If you touched any file under `vultron/demo/` or `test/demo/`, run:
+
+```bash
+uv run pytest -m "" --tb=short 2>&1 | tail -5
+```
+
+Use this to mirror CI behavior for demo/integration-sensitive changes.
+
+## Troubleshooting
+
+- If pytest selection is surprising, check markers in test files and rerun with
+  explicit `-m` as needed.
+- If local output differs from CI, rerun with the integration-inclusive command
+  above.

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -1,0 +1,28 @@
+# Vultron Developer Docs
+
+This section is for **Vultron maintainers and contributors** working inside
+this repository.
+
+It is separate from the public protocol docs aimed at Vultron protocol users
+and implementers.
+
+## Start here
+
+1. Follow the first-day tutorial:
+   [First day maintainer setup](tutorials/first-day-setup.md).
+1. Use the task guides in [How-to](how-to/index.md) for day-to-day work.
+1. Use [Developer reference links](reference/index.md) as your map to canonical
+   architecture and workflow sources.
+
+## Scope
+
+- Focus: local setup, tests, linting, and finding key code paths quickly.
+- Non-goal: re-explaining protocol semantics already covered in public
+  Explanation and Reference docs.
+
+## Troubleshooting
+
+- If a command in this section drifts from reality, open or link a docs issue
+  in the same PR that changed the workflow.
+- If links here feel stale, start at `docs/reference/codebase/index.md` and
+  repair cross-links from there.

--- a/docs/developer/reference/index.md
+++ b/docs/developer/reference/index.md
@@ -1,0 +1,28 @@
+# Developer reference links
+
+This page is a curated maintainer jump-off into existing shared Reference and
+Explanation material.
+
+## Shared reference pages in this docs site
+
+- [Codebase reference index](../../reference/codebase/index.md)
+- [Codebase structure](../../reference/codebase/STRUCTURE.md)
+- [Codebase architecture](../../reference/codebase/ARCHITECTURE.md)
+- [Codebase conventions](../../reference/codebase/CONVENTIONS.md)
+- [Codebase testing](../../reference/codebase/TESTING.md)
+
+## Maintainer source-of-truth files in the repository
+
+Use these repository paths directly in your editor:
+
+- `AGENTS.md`
+- `notes/README.md`
+- `.agents/skills/run-tests/SKILL.md`
+- `.agents/skills/run-linters/SKILL.md`
+- `.agents/skills/build-docs/SKILL.md`
+- `.github/workflows/docs-build-check.yml`
+
+## Why this page exists
+
+Maintainer docs in `docs/developer/` summarize workflows. The files above
+remain canonical for deeper rules and ongoing evolution.

--- a/docs/developer/tutorials/first-day-setup.md
+++ b/docs/developer/tutorials/first-day-setup.md
@@ -1,0 +1,78 @@
+# First day maintainer setup
+
+By the end of this tutorial, we will have a working local maintainer
+environment: dependencies installed, baseline tests running, and local docs
+available.
+
+## Prerequisites
+
+- Python 3.12+
+- `uv`
+- Git
+
+## Step 1: clone and enter the repo
+
+Run:
+
+```bash
+git clone https://github.com/CERTCC/Vultron.git
+cd Vultron
+```
+
+Notice that the repository root contains `vultron/`, `test/`, `docs/`,
+`notes/`, and `specs/`.
+
+## Step 2: install the dev environment
+
+Run:
+
+```bash
+uv sync --dev
+```
+
+Notice that `.venv/` is created and synced.
+
+## Step 3: run the baseline maintainer test command
+
+Run:
+
+```bash
+uv run pytest --tb=short 2>&1 | tail -5
+```
+
+Notice that the final lines report the pytest summary.
+
+## Step 4: run local docs with maintainer pages enabled
+
+Run:
+
+```bash
+uv run mkdocs serve --config-file mkdocs.dev.yml
+```
+
+Now open <http://127.0.0.1:8000/developer/>.
+
+Notice that the maintainer docs under `docs/developer/` are available locally.
+
+## Step 5: optional Docker docs path
+
+If you prefer containerized docs development, run:
+
+```bash
+docker compose -f docker/docker-compose.yml up docs
+```
+
+Then open <http://127.0.0.1:8000/developer/>.
+
+## What we accomplished
+
+We now have a local maintainer setup that supports code changes, test runs, and
+dev-only maintainer docs.
+
+## Troubleshooting
+
+- If `uv sync --dev` fails, verify Python 3.12+ and rerun `uv sync --dev`.
+- If `mkdocs serve` starts but `/developer/` is missing, confirm
+  `--config-file mkdocs.dev.yml` was used.
+- If Docker docs do not include maintainer pages, ensure you started the
+  `docs` service from `docker/docker-compose.yml`.

--- a/docs/developer/tutorials/index.md
+++ b/docs/developer/tutorials/index.md
@@ -1,0 +1,9 @@
+# Developer Tutorials
+
+These tutorials teach maintainers by doing, with a single guided path per
+tutorial.
+
+## Available tutorials
+
+- [First day maintainer setup](first-day-setup.md) — get a fresh checkout
+  running with dependencies installed, tests passing, and local docs served.

--- a/mkdocs.dev.yml
+++ b/mkdocs.dev.yml
@@ -1,0 +1,9 @@
+INHERIT: mkdocs.yml
+
+# Local/dev-only docs overlay.
+# MkDocs cannot append to list-based nav entries via inheritance, so we keep
+# maintainer docs out of nav and expose them by direct path/search in dev.
+exclude_docs: ""
+
+not_in_nav: |
+  developer/**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -244,6 +244,7 @@ not_in_nav: |
   *table*.md
   *.ttl
 exclude_docs: |
+  # Maintainer-focused docs are available in local/dev builds via mkdocs.dev.yml
   docs/developer/
 theme:
   logo: 'assets/Software_Engineering_Institute_Unitmark_White.svg'

--- a/notes/docs-build-workflow.md
+++ b/notes/docs-build-workflow.md
@@ -21,7 +21,8 @@ and `notes/` that have no effect on the published MkDocs site.
 | Should the build step always run? | Yes | Python macro/plugin failures (e.g., `pyproject.toml` or `mkdocs.yml` changes) need to be caught even if no `docs/` content changed |
 | When should the link-check step run? | Only when `docs/**` changed (or `workflow_dispatch`) | Link-checking crawls the entire site and is slow; triggering it on every pyproject.toml bump is wasteful |
 | How to detect if `docs/` changed? | `git diff --name-only` against the PR base | No third-party action needed; keeps the SHA-pinned `uses:` surface minimal (CISEC-01-001) |
-| What paths trigger the workflow at all? | `docs/**`, `mkdocs.yml`, `pyproject.toml`, `uv.lock`, workflow file | These are the only files that can break the site build or introduce broken links |
+| What paths trigger the workflow at all? | `docs/**`, `mkdocs.yml`, `mkdocs.dev.yml`, `pyproject.toml`, `uv.lock`, workflow file | These are the files that can break the publish build or the dev overlay build |
+| Should dev-only docs overlays be validated in CI? | Yes | `mkdocs.dev.yml` changes can break local maintainer docs even when publish docs still build |
 | Should `**/*.md` remain as a trigger? | No — remove it | `plan/`, `specs/`, `notes/` changes never affect the built site; the old trigger caused excessive runs |
 | Workflow filename | `docs-build-check.yml` | More descriptive than `linkchecker.yml`; the file covers both build and link-check phases |
 | Workflow display name | `Docs Build and Link Check` | Matches the two-phase job structure |
@@ -38,6 +39,7 @@ on:
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
+      - 'mkdocs.dev.yml'
       - 'pyproject.toml'
       - 'uv.lock'
       - '.github/workflows/docs-build-check.yml'
@@ -85,6 +87,10 @@ jobs:
         if: steps.filter.outputs.docs_changed == 'true'
         run: |
           uv run linkchecker site/index.html
+
+      - name: Build Developer Docs Overlay
+        run: |
+          uv run mkdocs build --verbose --clean --config-file mkdocs.dev.yml
 ```
 
 ### Why `fetch-depth: 0`
@@ -124,10 +130,13 @@ on:
 
 ### After (docs-build-check.yml)
 
-- Trigger narrowed to `docs/**`, `mkdocs.yml`, `pyproject.toml`,
+- Trigger narrowed to `docs/**`, `mkdocs.yml`, `mkdocs.dev.yml`,
+  `pyproject.toml`,
   `uv.lock`, and the workflow file itself.
 - Build Site step still runs on every trigger (guards against plugin
   breakage from `pyproject.toml`/`mkdocs.yml` changes).
+- Developer overlay build now runs on every trigger to keep local maintainer
+  docs (`docs/developer/`) buildable.
 - Link-check step only runs when `docs/` content actually changed.
 
 ---
@@ -137,7 +146,7 @@ on:
 | Workflow | Purpose | Trigger |
 |---|---|---|
 | `python-app.yml` | Python tests + linters | `vultron/**`, `test/**`, Python config |
-| `docs-build-check.yml` | MkDocs build + link check | `docs/**`, `mkdocs.yml`, Python config |
+| `docs-build-check.yml` | MkDocs build + link check | `docs/**`, `mkdocs*.yml`, Python config |
 | `lint_md_all.yml` | Markdown lint | `**/*.md` |
 | `demo-integration.yml` | Docker integration demo | `vultron/**`, `docker/**`, etc. |
 | `deploy_site.yml` | Deploy to GitHub Pages | Push to `publish` branch |

--- a/specs/docs-build-workflow.yaml
+++ b/specs/docs-build-workflow.yaml
@@ -34,7 +34,7 @@ groups:
         statement: >
           The workflow MUST trigger on `pull_request` events whose changed
           paths include at least one of: `docs/**`, `mkdocs.yml`,
-          `pyproject.toml`, `uv.lock`, or the workflow file itself
+          `mkdocs.dev.yml`, `pyproject.toml`, `uv.lock`, or the workflow file itself
           (`.github/workflows/docs-build-check.yml`).
         rationale: >
           These are the files that can break the site build or introduce
@@ -80,6 +80,16 @@ groups:
           significantly slower than the build step alone. Running it on
           every trigger (e.g., `pyproject.toml` bumps) wastes CI time
           without providing additional safety.
+      - id: DOCBW-03-004
+        priority: SHOULD
+        statement: >
+          The workflow SHOULD include a second MkDocs build step that validates
+          `mkdocs.dev.yml` in addition to the publish build (`mkdocs.yml`),
+          so dev-only documentation overlays remain buildable.
+        rationale: >
+          Maintainer-focused docs may be intentionally excluded from publish
+          builds. Validating the dev overlay in CI prevents local docs breakage
+          from going undetected.
 
   - id: DOCBW-04
     title: Docs-Changed Filter Step

--- a/specs/project-documentation.yaml
+++ b/specs/project-documentation.yaml
@@ -38,6 +38,10 @@ groups:
     priority: MUST
     statement: Module paths referenced in `notes/` MUST be updated to reflect canonical current locations whenever those paths
       change
+  - id: PD-03-006
+    priority: SHOULD
+    statement: Workflow or tooling PRs SHOULD update maintainer-facing documentation in the same PR; when this is not feasible,
+      the PR MUST include a linked follow-up docs issue before merge.
 - id: PD-04
   title: Documentation Build Validation
   specs:


### PR DESCRIPTION
## Summary
- add a new maintainer-focused docs/developer section with a tutorial, how-to guides, and a curated reference landing page
- add mkdocs.dev.yml as a dev overlay so maintainer docs are available locally but still excluded from publish builds
- wire Docker docs service to use the dev overlay by default and make docs CI validate both mkdocs.yml and mkdocs.dev.yml
- update specs/docs-build-workflow.yaml, specs/project-documentation.yaml, notes/docs-build-workflow.md, and AGENTS.md so agents maintain the new pattern

## Notes
- per current MkDocs inheritance limits, nav lists cannot be appended via INHERIT; to avoid maintaining duplicate nav trees, developer docs are intentionally dev-only and discoverable by direct path (/developer/) and search
