### PR TITLE
docs: plan issue #804 — ARCH-12-007 non-actor hierarchy scope and CaseLogEntry pitfall

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -416,7 +416,7 @@ Short entries are reproduced here; longer ones are referenced below.
   `Announce(CaseLogEntry)` replication activities — it has an auto-computed
   `id_` and registers in `CORE_VOCABULARY`. Importing from the wrong module
   silently produces incorrect behaviour. The local class is tracked for renaming
-  in issue #805 to eliminate this ambiguity. Until it is renamed, always import
+  in issue #806 to eliminate this ambiguity. Until it is renamed, always import
   by full module path and verify which class you need. See `specs/architecture.yaml`
   ARCH-12-007 and concern #804.
 - **Adding a New Pitfall: Check the Routing Policy First** — see

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -407,6 +407,18 @@ Short entries are reproduced here; longer ones are referenced below.
   is intrinsically cross-cutting; bundled diffs let reviewers miss
   regressions in the half they aren't focused on. See
   [notes/triggers-test-coverage.md](notes/triggers-test-coverage.md).
+- **Two `CaseLogEntry` Classes With the Same Name** — There are two classes named
+  `CaseLogEntry` in `vultron/core/models/` that serve completely different purposes.
+  `vultron.core.models.case_log.CaseLogEntry` (`BaseModel`) is the in-memory
+  hash-chain record used by `CaseEventLog` for local SYNC-1 processing — it is
+  **not** persisted or shared over the wire. `vultron.core.models.case_log_entry.CaseLogEntry`
+  (`CoreObject`) is the wire-serialisable domain model used in
+  `Announce(CaseLogEntry)` replication activities — it has an auto-computed
+  `id_` and registers in `CORE_VOCABULARY`. Importing from the wrong module
+  silently produces incorrect behaviour. The local class is tracked for renaming
+  in issue #805 to eliminate this ambiguity. Until it is renamed, always import
+  by full module path and verify which class you need. See `specs/architecture.yaml`
+  ARCH-12-007 and concern #804.
 - **Adding a New Pitfall: Check the Routing Policy First** — see
   [notes/agents-md-structure.md](notes/agents-md-structure.md)
 

--- a/plan/history/2606/learning/CONCERN-804.md
+++ b/plan/history/2606/learning/CONCERN-804.md
@@ -1,0 +1,35 @@
+---
+source: CONCERN-804
+timestamp: '2026-06-05T19:48:32.899665+00:00'
+title: 'ADR-0017 Option D scope gap: shared-base hierarchy for non-actor objects'
+type: learning
+---
+
+## Concern #804 — ADR-0017 Option D scope gap
+
+The #798 epic (implementing ADR-0017 Option D) and its children (#799–#802) were
+scoped to actor-related infrastructure only. The broader intent of ADR-0017 Option D —
+that `VultronBase`/`VultronObject` is the shared root for **all** core and wire objects —
+was not tracked for non-actor types.
+
+Investigation found:
+
+- Six core non-actor objects (`CaseEvent`, `ActorConfig`, `ObjectStatus`,
+  `VultronOutbox`, `VultronEvent`, `CaseLogEntry`, `ReplicationState`) inherit
+  directly from `BaseModel` without documented rationale.
+- Most are intentional BaseModel (config/DTO/transient envelope): `ActorConfig`,
+  `VultronEvent`, and the local `CaseLogEntry` in `case_log.py` (a separate class
+  from the wire-serialisable `CaseLogEntry(CoreObject)` in `case_log_entry.py`).
+- `ReplicationState(BaseModel)` in `case_log.py` is stale — superseded by
+  `VultronReplicationState(VultronObject)` in `replication_state.py`.
+- `ObjectStatus`/`OfferStatus` in `status.py` appear unused (no importers found).
+- `CaseEvent` deprecation is tracked in epic #788 / issue #792 — not re-tracked here.
+
+The naming collision between `case_log.py:CaseLogEntry(BaseModel)` (local hash-chain
+processor) and `case_log_entry.py:CaseLogEntry(CoreObject)` (wire-serialisable domain
+model) is a recurring agent confusion hazard.
+
+**Resolved**: 2026-06-05 — implementation tracked in #806, #807, #808, #809
+(all children of #798, blocked by #804).
+Docs PR: [#805](https://github.com/CERTCC/Vultron/pull/805).
+Spec: `specs/architecture.yaml` ARCH-12-007.

--- a/specs/architecture.yaml
+++ b/specs/architecture.yaml
@@ -209,6 +209,32 @@ groups:
       collection shape is an AS2 protocol concern, not a domain concern.
       This resolves the most structurally irreconcilable field-type conflict
       that blocked the original ARCH-12 from_core()/to_core() approach.
+  - id: ARCH-12-007
+    priority: MUST
+    statement: >-
+      All core domain objects that represent protocol-significant entities
+      (cases, reports, participants, actors, log entries, embargo policies,
+      etc.) MUST inherit from `CoreObject` (or `VultronObject` when
+      CORE_VOCABULARY registration is not needed). Objects that exist solely
+      as local configuration, transient dispatch envelopes, or internal
+      processing records that are never shared across the wire MAY remain
+      plain `BaseModel` subclasses; such classes MUST include a docstring
+      explaining the rationale for not inheriting from the shared-base
+      hierarchy.
+    rationale: >-
+      Consistent use of the shared-base hierarchy ensures that all
+      protocol-significant domain objects share aligned field names,
+      can participate in model_validate() round-trips (ARCH-12-005), and
+      are discoverable via CORE_VOCABULARY. Intentional BaseModel classes
+      are the exception, not the default; requiring a documented rationale
+      prevents accidental hierarchy bypass as the codebase evolves.
+    verification: >-
+      Static analysis or a test asserts that all classes in
+      `vultron/core/models/` that contain protocol-significant fields
+      (`id_`, `type_`, `published`, `attributed_to`) inherit from
+      `CoreObject` or `VultronObject`. Intentional `BaseModel` subclasses
+      are listed in a registry or identified by a marker mixin/comment
+      pattern.
 - id: ARCH-09
   title: Domain Model Richness Constraint
   specs:


### PR DESCRIPTION
Docs-only PR for concern #804: ADR-0017 Option D scope gap for non-actor objects.

## Changes

- **ARCH-12-007** (new spec in `specs/architecture.yaml`): All protocol-significant
  core domain objects MUST inherit from `CoreObject`/`VultronObject`. Objects that
  are local config, transient dispatch envelopes, or internal processing records MAY
  stay as plain `BaseModel` subclasses but MUST document the rationale.
- **AGENTS.md pitfall**: Two `CaseLogEntry` classes with the same name serve
  completely different purposes; documents the distinction and references #805
  (the rename tracking issue).

## Background

Concern #804 found that ARCH-12 (after the #796 amendment) was actor-centric and
did not explicitly scope the shared-base hierarchy rule to all core domain objects.
This PR codifies the three-bucket classification (CoreObject / VultronObject /
intentional BaseModel) and adds an agent pitfall for the naming ambiguity.

Closes #804

No .py files changed.