### PR TITLE
feat: wire as_Base/as_Object onto shared VultronBase/VultronObject roots (ARCH-12-001/002)

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -71,3 +71,13 @@ No code changes in this session.
 
 `vultron/core/models/status.py` had no live importers anywhere in `vultron/`
 or `test/`, so deleting the file was the smallest safe cleanup.
+
+### 2026-06-05 ISSUE-799 — Rebase worktree branch to origin/main before opening PR
+
+When creating a task branch inside a worktree slot (e.g. `wt/pinky`), always
+check that the worktree branch is up to date with `origin/main` before branching.
+In this session `wt/pinky` was behind `origin/main` by one commit; the naive
+`git rebase origin/main` reported "already up to date" because the worktree tip
+was the merge-base of `origin/main`, not its descendant. The fix:
+`git merge-base origin/main <worktree-branch>` to diagnose, then
+`git rebase origin/main` from the task branch after confirming the base is correct.

--- a/plan/history/2606/implementation/ISSUE-799.md
+++ b/plan/history/2606/implementation/ISSUE-799.md
@@ -1,0 +1,31 @@
+---
+source: ISSUE-799
+timestamp: '2026-06-05T20:18:31.580776+00:00'
+title: Wire as_Base/as_Object onto shared VultronBase/VultronObject roots
+type: implementation
+---
+
+## Issue #799 — Wire base wiring: as_Base inherits VultronBase, as_Object inherits VultronObject
+
+Implemented ARCH-12-001 and ARCH-12-002: connected the AS2 wire base class
+hierarchy to the shared core root established by the #699 migration chain.
+
+### Changes
+
+- `vultron/wire/as2/vocab/base/base.py`: `as_Base` now inherits `VultronBase`
+  instead of `BaseModel` directly.
+- `vultron/wire/as2/vocab/base/objects/base.py`: `as_Object` now inherits
+  `(as_Base, VultronObject)` — diamond via `VultronBase`.
+- `vultron/core/models/base.py`: `VultronObject` extended with all shared AS2
+  object fields at lenient types to satisfy ARCH-12-002.
+- `test/wire/as2/vocab/base/test_wire_base_hierarchy.py`: 16 new boundary tests
+  covering all 4 acceptance criteria (AC-1 through AC-4), including MRO shape,
+  field-precedence runtime checks, and registry isolation.
+
+### Outcome
+
+All 4 acceptance criteria met. 3021 unit tests pass; all four linters clean.
+MRO is `as_Object → as_Base → VultronObject → VultronBase → BaseModel`.
+Wire lenient types win over core narrowed types via MRO for all shared fields.
+
+PR: [#814](https://github.com/CERTCC/Vultron/pull/814)

--- a/test/wire/as2/vocab/base/test_wire_base_hierarchy.py
+++ b/test/wire/as2/vocab/base/test_wire_base_hierarchy.py
@@ -22,7 +22,7 @@ AC-4: All existing tests pass; inheritance chain confirmed here.
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
 from datetime import datetime
-from typing import Any, Literal
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -117,14 +117,24 @@ def test_as_object_datetime_roundtrip():
     assert obj.published.tzinfo is not None
 
 
-def test_as_object_attributed_to_is_any():
-    """Wire field attributed_to remains Any|None (not narrowed by VultronObject)."""
-    field = as_Object.model_fields["attributed_to"]
-    annotation = field.annotation
-    # as_Object re-declares attributed_to as Any | None; VultronObject has
-    # NonEmptyString | None.  The wire declaration must win.
-    args = getattr(annotation, "__args__", None)
-    assert annotation is Any or (args is not None and type(None) in args)
+def test_as_object_attributed_to_accepts_non_string():
+    """Wire field attributed_to remains Any|None — non-string values must be accepted.
+
+    VultronObject narrows attributed_to to NonEmptyString | None, but as_Object
+    re-declares it as Any | None.  The wire declaration must win via MRO so that
+    AS2 payloads carrying nested objects or dicts are accepted without validation
+    errors.  A plain annotation check (looking for NoneType in __args__) would
+    pass even if NonEmptyString | None took over, so we use a runtime round-trip.
+    """
+    # dict (inline AS2 object) must not raise
+    obj = as_Object.model_validate(
+        {"attributed_to": {"id": "https://example.org/alice"}}
+    )
+    assert obj.attributed_to == {"id": "https://example.org/alice"}
+
+    # integer must not raise (fully lenient Any)
+    obj2 = as_Object.model_validate({"attributed_to": 42})
+    assert obj2.attributed_to == 42
 
 
 def test_as_object_id_uses_wire_default():

--- a/test/wire/as2/vocab/base/test_wire_base_hierarchy.py
+++ b/test/wire/as2/vocab/base/test_wire_base_hierarchy.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python
+"""Boundary tests verifying the wire base hierarchy inherits from the shared
+root (ARCH-12-001, ARCH-12-002, issue #799).
+
+AC-1: issubclass(as_Base, VultronBase) is True.
+AC-2: issubclass(as_Object, VultronObject) is True.
+AC-3: No new mypy or pyright errors (validated via linters, not here).
+AC-4: All existing tests pass; inheritance chain confirmed here.
+"""
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from vultron.core.models.base import VultronBase, VultronObject
+from vultron.wire.as2.vocab.base.base import as_Base
+from vultron.wire.as2.vocab.base.objects.base import as_Object
+from vultron.wire.as2.vocab.base.registry import VOCABULARY
+from vultron.wire.as2.vocab.base.utils import URN_UUID_PREFIX
+
+# --- AC-1/AC-2: Inheritance chain (ARCH-12-001) ----------------------------
+
+
+def test_as_base_inherits_vultron_base():
+    """AC-1: issubclass(as_Base, VultronBase) is True."""
+    assert issubclass(as_Base, VultronBase)
+
+
+def test_as_object_inherits_vultron_object():
+    """AC-2: issubclass(as_Object, VultronObject) is True."""
+    assert issubclass(as_Object, VultronObject)
+
+
+def test_as_base_still_inherits_base_model():
+    """Transitive: as_Base -> VultronBase -> BaseModel."""
+    assert issubclass(as_Base, BaseModel)
+
+
+def test_as_object_still_inherits_as_base():
+    """Wire-branch shape preserved: as_Object -> as_Base."""
+    assert issubclass(as_Object, as_Base)
+
+
+def test_as_object_inherits_vultron_base():
+    """as_Object transitively inherits VultronBase via both branches."""
+    assert issubclass(as_Object, VultronBase)
+
+
+def test_as_object_mro():
+    """MRO confirms diamond linearisation: as_Object -> as_Base -> VultronObject -> VultronBase."""
+    mro_names = [cls.__name__ for cls in as_Object.__mro__]
+    assert mro_names.index("as_Object") < mro_names.index("as_Base")
+    assert mro_names.index("as_Base") < mro_names.index("VultronObject")
+    assert mro_names.index("VultronObject") < mro_names.index("VultronBase")
+
+
+# --- Field-precedence / wire-semantics preserved ---------------------------
+
+
+def test_as_base_id_uses_wire_default():
+    """as_Base.id_ still uses generate_new_id (urn:uuid: prefix)."""
+    obj = as_Base()
+    assert obj.id_.startswith(URN_UUID_PREFIX)
+
+
+def test_as_base_context_is_as2_namespace():
+    """Wire branch: context_ defaults to the AS2 namespace, not None."""
+    obj = as_Base()
+    assert obj.context_ == "https://www.w3.org/ns/activitystreams"
+
+
+def test_as_base_type_set_from_class_name():
+    """Wire model_validator sets type_ from stripped class name."""
+    obj = as_Base()
+    assert obj.type_ == "Base"
+
+
+def test_as_base_context_alias_accepted():
+    """@context validation alias still accepted on as_Base."""
+    obj = as_Base.model_validate(
+        {"@context": "https://www.w3.org/ns/activitystreams"}
+    )
+    assert obj.context_ == "https://www.w3.org/ns/activitystreams"
+
+
+def test_as_object_type_set_from_class_name():
+    """Wire model_validator sets type_ from stripped class name on as_Object."""
+    obj = as_Object()
+    assert obj.type_ == "Object"
+
+
+def test_as_object_published_defaults_to_now():
+    """as_Object.published default still provided (from as_Object field def)."""
+    obj = as_Object()
+    assert obj.published is not None
+
+
+def test_as_object_datetime_roundtrip():
+    """as_Object wire datetime validators still accept ISO strings."""
+    iso = "2026-01-15T12:00:00+00:00"
+    obj = as_Object.model_validate({"published": iso})
+    assert isinstance(obj.published, datetime)
+    assert obj.published.tzinfo is not None
+
+
+def test_as_object_attributed_to_is_any():
+    """Wire field attributed_to remains Any|None (not narrowed by VultronObject)."""
+    field = as_Object.model_fields["attributed_to"]
+    annotation = field.annotation
+    # as_Object re-declares attributed_to as Any | None; VultronObject has
+    # NonEmptyString | None.  The wire declaration must win.
+    args = getattr(annotation, "__args__", None)
+    assert annotation is Any or (args is not None and type(None) in args)
+
+
+def test_as_object_id_uses_wire_default():
+    """as_Object.id_ still uses wire generate_new_id."""
+    obj = as_Object()
+    assert obj.id_.startswith(URN_UUID_PREFIX)
+
+
+# --- Registry: __init_subclass__ still fires for wire concrete types --------
+
+
+def test_concrete_wire_subclass_still_registers():
+    """A concrete as_Object subclass with Literal type_ is still auto-registered.
+
+    Regression: the inheritance change must not break VOCABULARY registration
+    via as_Base.__init_subclass__.
+    """
+
+    class as_HierarchyTestProbe(as_Object):
+        type_: Literal["HierarchyTestProbe"] = Field(
+            default="HierarchyTestProbe",
+            validation_alias="type",
+            serialization_alias="type",
+        )
+
+    assert "HierarchyTestProbe" in VOCABULARY
+    assert VOCABULARY["HierarchyTestProbe"] is as_HierarchyTestProbe
+
+    # Cleanup to avoid polluting VOCABULARY across tests
+    del VOCABULARY["HierarchyTestProbe"]

--- a/vultron/core/models/base.py
+++ b/vultron/core/models/base.py
@@ -82,15 +82,15 @@ class VultronObject(VultronBase):
     replies: Any | None = None
     url: NonEmptyString | None = None
     generator: Any | None = None
-    context: NonEmptyString | None = None
+    context: Any | None = None
     tag: Any | None = None
-    in_reply_to: NonEmptyString | None = None
+    in_reply_to: Any | None = None
 
     duration: timedelta | None = None
     start_time: datetime | None = None
     end_time: datetime | None = None
-    published: datetime = Field(default_factory=_now_utc)
-    updated: datetime = Field(default_factory=_now_utc)
+    published: datetime | None = Field(default_factory=_now_utc)
+    updated: datetime | None = Field(default_factory=_now_utc)
 
     # content
     content: Any | None = None
@@ -138,6 +138,12 @@ class CoreObject(VultronObject):
         serialization_alias="@context",
         exclude=True,
     )
+
+    # Re-narrow published/updated: the core branch guarantees these are always
+    # populated (default_factory ensures it).  VultronObject uses datetime|None
+    # (per ARCH-12-002: shared base must be lenient for the wire branch).
+    published: datetime = Field(default_factory=_now_utc)
+    updated: datetime = Field(default_factory=_now_utc)
 
     def __init_subclass__(cls, **kwargs: object) -> None:
         super().__init_subclass__(**kwargs)  # type: ignore[arg-type]

--- a/vultron/wire/as2/vocab/base/base.py
+++ b/vultron/wire/as2/vocab/base/base.py
@@ -18,9 +18,10 @@ import types as _types
 import typing as _typing
 from typing import ClassVar
 
-from pydantic import BaseModel, Field, model_validator, ConfigDict
+from pydantic import Field, model_validator, ConfigDict
 from pydantic.alias_generators import to_camel
 
+from vultron.core.models.base import VultronBase
 from vultron.wire.as2.vocab.base.enums import VocabNamespace
 from vultron.wire.as2.vocab.base.registry import VOCABULARY
 from vultron.wire.as2.vocab.base.utils import generate_new_id
@@ -28,7 +29,7 @@ from vultron.wire.as2.vocab.base.utils import generate_new_id
 ACTIVITY_STREAMS_NS = "https://www.w3.org/ns/activitystreams"
 
 
-class as_Base(BaseModel):
+class as_Base(VultronBase):
     model_config = ConfigDict(
         alias_generator=to_camel,
         validate_by_name=True,

--- a/vultron/wire/as2/vocab/base/objects/base.py
+++ b/vultron/wire/as2/vocab/base/objects/base.py
@@ -20,7 +20,7 @@ from typing import Any, TypeAlias, cast
 import isodate  # type: ignore[import-untyped]
 from pydantic import field_serializer, field_validator, Field
 
-from vultron.core.models.base import CoreObject
+from vultron.core.models.base import CoreObject, VultronObject
 from vultron.wire.as2.vocab.base.base import as_Base
 from vultron.wire.as2.vocab.base.dt_utils import (
     now_utc,
@@ -31,7 +31,7 @@ from vultron.wire.as2.vocab.base.links import (
 )
 
 
-class as_Object(as_Base):
+class as_Object(as_Base, VultronObject):
     """Base class for all ActivityPub objects.
     See definition in ActivityStreams Vocabulary <https://www.w3.org/TR/activitystreams-vocabulary/#object>
     """


### PR DESCRIPTION
Closes #799

## Summary

Wire the AS2 base class hierarchy onto the shared core root as required by ARCH-12-001 and ARCH-12-002:

- `as_Base` now inherits `VultronBase` (shared root in `vultron/core/models/base.py`)
- `as_Object` now inherits `as_Base` + `VultronObject` (diamond via `VultronBase`)
- MRO: `as_Object → as_Base → VultronObject → VultronBase → BaseModel`

All wire field redeclarations are preserved; wire lenient types (`Any | None`, `str | None`) win via MRO over the core branch's narrowed types (`NonEmptyString | None`).

## Changes

- `vultron/wire/as2/vocab/base/base.py`: `as_Base` base changed from `BaseModel` to `VultronBase`
- `vultron/wire/as2/vocab/base/objects/base.py`: `as_Object` bases changed to `(as_Base, VultronObject)`
- `vultron/core/models/base.py`: minor additions to `VultronObject` to carry all shared AS2 object fields at the lenient shared-base level
- `test/wire/as2/vocab/base/test_wire_base_hierarchy.py`: 16 new boundary tests covering all 4 acceptance criteria

## Acceptance Criteria

- [x] AC-1: `issubclass(as_Base, VultronBase)` is True
- [x] AC-2: `issubclass(as_Object, VultronObject)` is True
- [x] AC-3: All four linters pass clean (black, flake8, mypy, pyright)
- [x] AC-4: 3021 tests pass; 16 new boundary tests added