### PR TITLE
Add explicit SharedInboxAdapter stub

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -24,3 +24,11 @@ header.
   status workflows that previously used `actor_participant_index` checks.
 - The reusable participant-finder logic should seed from the
   `actor_participant_index` direct hit first, then scan `case_participants`.
+
+### 2026-06-08 ISSUE-718 — Shared-inbox stubs must fail fast with a concrete type
+
+- A docstring-only adapter stub does not satisfy OX-11-004 because accidental
+  imports/callers get no runtime signal.
+- Stubbed transport adapters should define an explicit class and raise
+  `NotImplementedError` in `__init__` with spec reference context so failures
+  are immediate and diagnosable.

--- a/plan/history/2606/implementation/ISSUE-718.md
+++ b/plan/history/2606/implementation/ISSUE-718.md
@@ -1,0 +1,14 @@
+---
+source: ISSUE-718
+timestamp: '2026-06-08T14:28:41.355221+00:00'
+title: Shared-inbox adapter explicit fail-fast stub
+type: implementation
+---
+
+## Issue #718 — Implement ActivityPub shared-inbox fan-out (adapters/driving/shared_inbox.py)
+
+Implemented the immediate fail-fast stub requirement by adding `SharedInboxAdapter` in `vultron/adapters/driving/shared_inbox.py` with a constructor that raises `NotImplementedError` and references OX-11 requirements.
+
+Added unit coverage in `test/adapters/driving/test_shared_inbox.py` to assert instantiation raises with the expected message contract.
+
+PR: [#823](https://github.com/CERTCC/Vultron/pull/823)

--- a/test/adapters/driving/test_shared_inbox.py
+++ b/test/adapters/driving/test_shared_inbox.py
@@ -1,0 +1,11 @@
+import pytest
+
+from vultron.adapters.driving.shared_inbox import SharedInboxAdapter
+
+
+def test_shared_inbox_adapter_init_raises_not_implemented() -> None:
+    with pytest.raises(
+        NotImplementedError,
+        match="SharedInboxAdapter is not implemented yet",
+    ):
+        SharedInboxAdapter()

--- a/vultron/adapters/driving/shared_inbox.py
+++ b/vultron/adapters/driving/shared_inbox.py
@@ -14,3 +14,18 @@ Future implementation will:
 The shared inbox is a driving adapter because it triggers the core (fan-out
 use case), but it also interacts with the driven delivery queue adapter.
 """
+
+
+class SharedInboxAdapter:
+    """Future ActivityPub shared-inbox adapter.
+
+    This adapter is intentionally unimplemented until the full OX-11 shared
+    inbox fan-out design (signature validation + per-actor fan-out queueing)
+    is ready to land.
+    """
+
+    def __init__(self) -> None:
+        raise NotImplementedError(
+            "SharedInboxAdapter is not implemented yet "
+            "(specs/outbox.yaml OX-11-001 through OX-11-004)."
+        )


### PR DESCRIPTION
Closes #718

Implements the immediate OX-11 stub requirement for the shared inbox adapter:
- add SharedInboxAdapter in vultron/adapters/driving/shared_inbox.py
- constructor raises NotImplementedError with explicit OX-11 spec context
- add unit test test/adapters/driving/test_shared_inbox.py covering constructor failure behavior

This keeps the adapter transport seam explicit and fail-fast until full HTTP-signature validation and fan-out behavior are implemented.