### PR TITLE
Rename HTTP delivery adapters to demo/prod roles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -408,7 +408,7 @@ Short entries are reproduced here; longer ones are referenced below.
 >
 - **Stub Adapter Files Must Raise `NotImplementedError`, Not Silently No-Op** — Adapter
   files that are intentional future-work placeholders (e.g.,
-  `adapters/driven/http_delivery.py`, `adapters/driving/shared_inbox.py`) MUST contain
+  `adapters/driven/prod_http_delivery.py`, `adapters/driving/shared_inbox.py`) MUST contain
   a class or function that raises `NotImplementedError` when called, so any code that
   accidentally references the stub gets an immediate, explicit signal instead of a
   silent no-op. A docstring-only stub is indistinguishable from a real empty module

--- a/docs/adr/0012-per-actor-datalayer-isolation.md
+++ b/docs/adr/0012-per-actor-datalayer-isolation.md
@@ -115,7 +115,8 @@ the hexagonal architecture. IO-B formalizes the violation; IO-A removes it.
 
 **OUTBOX-1 scope: OX-B — defer outbound delivery until ACT-3 is complete.**
 
-The `ActivityEmitter` port stub (OX-1.0) and `DeliveryQueueAdapter` stub
+The `ActivityEmitter` port stub (OX-1.0) and the (then-stubbed)
+`DemoHttpDeliveryAdapter`
 are already in place. Local delivery (OX-1.1–OX-1.4) requires the per-actor
 DataLayer inbox collection to exist (IO-A decision above), so OX-1.1 MUST
 follow ACT-2. Deferring OUTBOX-1 until after ACT-3 keeps each task's scope
@@ -228,4 +229,4 @@ clear and avoids implementing delivery against a still-changing DataLayer.
 - `plan/IMPLEMENTATION_PLAN.md` — ACT-1, ACT-2, ACT-3, VCR-014, OX-1.1–OX-1.4.
 - `specs/case-management.yaml` — CM-01-001 (actor isolation requirement).
 - `vultron/core/ports/emitter.py` — `ActivityEmitter` Protocol (OX-1.0).
-- `vultron/adapters/driven/delivery_queue.py` — stub emitter adapter.
+- `vultron/adapters/driven/demo_http_delivery.py` — HTTP emitter adapter.

--- a/docs/reference/codebase/ARCHITECTURE.md
+++ b/docs/reference/codebase/ARCHITECTURE.md
@@ -22,7 +22,7 @@
 HTTP request -> FastAPI app/router -> inbox handler + rehydration ->
 semantic extraction -> dispatcher/use case -> DataLayer + outbox ->
 OutboxMonitor -> outbox_handler ->
-ASGIEmitter (co-located) | DeliveryQueueAdapter (remote) ->
+ASGIEmitter (co-located) | DemoHttpDeliveryAdapter (remote) ->
 peer inbox HTTP POST
 ```
 
@@ -36,7 +36,7 @@ Evidence-backed flow:
 4. The dispatcher looks up the use-case class from the semantic registry map.
 5. Use cases persist/read state through the `DataLayer` port and adapter.
 6. Outbox processing is drained by a background monitor, then delivered via
-   `ASGIEmitter` for co-located actors or `DeliveryQueueAdapter` for remote ones.
+   `ASGIEmitter` for co-located actors or `DemoHttpDeliveryAdapter` for remote ones.
 7. Multi-actor trust bootstrap now relies on a creator-signed
    `Create(VulnerabilityCase)` handoff before receivers trust subsequent
    CaseActor `Announce(VulnerabilityCase)` updates.
@@ -48,7 +48,7 @@ Evidence-backed flow:
 | `vultron/core/` | Domain events, ports, dispatcher, use cases | FastAPI and adapter details, wire-layer factory imports | `AGENTS.md`, `vultron/core/ports/datalayer.py`, `vultron/core/dispatcher.py` |
 | `vultron/wire/as2/` | AS2 vocabulary, pattern matching, semantic extraction | Case lifecycle behavior | `vultron/wire/as2/extractor.py` |
 | `vultron/adapters/driving/fastapi/` | HTTP routing, dependency injection, background task scheduling | Persistent model ownership | `vultron/adapters/driving/fastapi/app.py`, `vultron/adapters/driving/fastapi/deps.py` |
-| `vultron/adapters/driven/` | SQLite persistence, outbound HTTP delivery, ASGI-first co-located delivery, sync/trigger activity translation | FastAPI request translation | `vultron/adapters/driven/datalayer_sqlite.py`, `vultron/adapters/driven/delivery_queue.py`, `vultron/adapters/driven/sync_activity_adapter.py`, `vultron/adapters/driven/trigger_activity_adapter.py` |
+| `vultron/adapters/driven/` | SQLite persistence, outbound HTTP delivery, ASGI-first co-located delivery, sync/trigger activity translation | FastAPI request translation | `vultron/adapters/driven/datalayer_sqlite.py`, `vultron/adapters/driven/demo_http_delivery.py`, `vultron/adapters/driven/sync_activity_adapter.py`, `vultron/adapters/driven/trigger_activity_adapter.py` |
 | `vultron/demo/` | Operator/demo CLI workflows and seeding | Authoritative storage API | `vultron/demo/cli.py`, `vultron/demo/utils.py` |
 
 ### 4) Reused Patterns

--- a/docs/reference/codebase/CONCERNS.md
+++ b/docs/reference/codebase/CONCERNS.md
@@ -10,14 +10,14 @@
 | high | Legacy globals and cached DataLayers still influence the deployed FastAPI path despite newer `create_app()` isolation rules | `vultron/adapters/driving/fastapi/main.py`, `vultron/adapters/driving/fastapi/app.py`, `vultron/adapters/driving/fastapi/inbox_handler.py`, `vultron/adapters/driving/fastapi/outbox_handler.py`, `vultron/adapters/driven/datalayer_sqlite.py` | Cross-app state leakage or startup-order bugs can still appear in co-located or shared-process setups | Continue migrating the mounted app path toward per-app state and keep regression tests around actor isolation |
 | medium | Outbox draining is implemented as a 1-second polling loop over all actor DataLayers | `vultron/adapters/driving/fastapi/outbox_monitor.py` | Polling cost grows with actor count and can hide queue-depth issues | Consider event-driven wakeups or queue metrics if actor count grows |
 | medium | Several source files still exceed 500 lines and mix multiple responsibilities | `vultron/core/behaviors/case/nodes.py` (1502 lines), `vultron/adapters/driven/datalayer_sqlite.py` (1108 lines), `vultron/demo/scenario/two_actor_demo.py` (863 lines), `vultron/wire/as2/extractor.py` (821 lines), `vultron/core/use_cases/triggers/embargo.py` (902 lines) | Large, multi-responsibility files are harder to test, review, and maintain; several are also high-churn | Incrementally extract cohesive sub-modules; prioritize `nodes.py`, `extractor.py`, and `datalayer_sqlite.py` |
-| medium | Current remote delivery uses plain HTTP POST via `DeliveryQueueAdapter`; signing and shared-inbox support remain stubbed | `vultron/adapters/driven/delivery_queue.py`, `vultron/adapters/driven/http_delivery.py`, `vultron/adapters/driving/shared_inbox.py` | Multi-party interoperability and security posture are limited until signed delivery paths exist | Treat signed delivery/shared inbox as explicit future work and avoid implying these flows are production-ready |
+| medium | Current remote delivery uses plain HTTP POST via `DemoHttpDeliveryAdapter`; signing and shared-inbox support remain stubbed | `vultron/adapters/driven/demo_http_delivery.py`, `vultron/adapters/driven/prod_http_delivery.py`, `vultron/adapters/driving/shared_inbox.py` | Multi-party interoperability and security posture are limited until signed delivery paths exist | Treat signed delivery/shared inbox as explicit future work and avoid implying these flows are production-ready |
 
 ### 2) Technical Debt
 
 | Debt item | Why it exists | Where | Risk if ignored | Suggested fix |
 |-----------|---------------|-------|-----------------|---------------|
 | 15 outstanding TODO/FIXME/HACK comments remain in the production package | Incremental development; partially-finished refactors remain in core, wire, example, and legacy BT modules | `vultron/core/states/cs.py`, `vultron/wire/as2/vocab/objects/embargo_event.py`, `vultron/wire/as2/vocab/examples/*.py`, `vultron/wire/as2/vocab/activities/case_participant.py`, `vultron/wire/as2/vocab/base/objects/*.py`, `vultron/bt/report_management/_behaviors/report_to_others.py`, `vultron/bt/base/bt_node.py`, `vultron/bt/base/demo/pacman.py` | Ambiguous future work and partially-finished refactors accumulate silently | Triage each TODO into a tracked issue or remove it; do not leave long-lived TODOs in protocol-significant paths |
-| `http_delivery.py` and `shared_inbox.py` are stubs with no implementation | Placeholder-driven design for future signed HTTP delivery and shared-inbox fan-out | `vultron/adapters/driven/http_delivery.py`, `vultron/adapters/driving/shared_inbox.py` | No production delivery path for signed or shared-inbox flows; callers may assume these are functional | Implement or clearly gate behind feature flags before any production use |
+| `prod_http_delivery.py` and `shared_inbox.py` are stubs with no implementation | Placeholder-driven design for future signed HTTP delivery and shared-inbox fan-out | `vultron/adapters/driven/prod_http_delivery.py`, `vultron/adapters/driving/shared_inbox.py` | No production delivery path for signed or shared-inbox flows; callers may assume these are functional | Implement or clearly gate behind feature flags before any production use |
 | Documentation/code drift around architecture targets | Notes describe both target and current structure; new ASGIEmitter rules now live in a separate note | `notes/architecture-hexagonal.md`, `vultron/core/ports/AGENTS.md`, `notes/architecture-adapters.md`, `vultron/adapters/driven/AGENTS.md`, `AGENTS.md` | New contributors may confuse target layout with what exists today | Keep onboarding docs explicitly split into "current reality" vs "target direction" and cite the ASGIEmitter note where relevant |
 | High churn in planning and guidance files | Planning/spec docs evolve rapidly during active development | `plan/BUILD_LEARNINGS.md`, `AGENTS.md` (79) in the latest scan window | Agent guidance and task context can go stale quickly | Treat `plan/` and guidance docs as volatile areas during onboarding; re-read before each session |
 | `vultron/semantic_registry/` was a 783-line centralized dispatch table | Single module consolidated all message-type to handler wiring | `vultron/semantic_registry/` (refactored in #702) | Previously any new message type required editing one large file; now split into domain sub-modules | Split completed — see `vultron/semantic_registry/` package |
@@ -26,7 +26,7 @@
 
 | Risk | OWASP category (if applicable) | Evidence | Current mitigation | Gap |
 |------|--------------------------------|----------|--------------------|-----|
-| No explicit auth/signing was evident in sampled outbound or inbound HTTP delivery paths | A01 / N/A | `vultron/adapters/driven/delivery_queue.py`, `vultron/adapters/driving/fastapi/app.py`, `vultron/adapters/driving/fastapi/routers/actors.py` | Local actor IDs and inbox URLs are explicit | Authentication, authorization, or message-signing behavior was not evident in sampled files |
+| No explicit auth/signing was evident in sampled outbound or inbound HTTP delivery paths | A01 / N/A | `vultron/adapters/driven/demo_http_delivery.py`, `vultron/adapters/driving/fastapi/app.py`, `vultron/adapters/driving/fastapi/routers/actors.py` | Local actor IDs and inbox URLs are explicit | Authentication, authorization, or message-signing behavior was not evident in sampled files |
 | Secret handling appears to rely on plain env vars and Compose files | A05 / N/A | `.env.example`, `docker/docker-compose.yml`, `docker/docker-compose-multi-actor.yml` | Example files avoid committed secrets | No secret-rotation or secret-manager integration was found |
 
 ### 4) Performance and Scaling Concerns
@@ -51,7 +51,7 @@
 1. Demo HTTP helpers still use `requests`, while the declared runtime HTTP
    client is `httpx`. Migration is tracked in GitHub issue #517 (child of
    bug #501). No timeline is set.
-2. `http_delivery.py` and `shared_inbox.py` remain architectural placeholders;
+2. `prod_http_delivery.py` and `shared_inbox.py` remain architectural placeholders;
    confirm whether they are near-term deliverables or intentionally dormant.
 3. The `{key:path}` Starlette path converter is the current tactical mitigation
    for full-URI IDs in URL path segments (see GitHub concern #618). The deeper
@@ -72,9 +72,9 @@
 - `vultron/adapters/driving/shared_inbox.py`
 - `vultron/adapters/driven/datalayer.py`
 - `vultron/adapters/driven/datalayer_sqlite.py`
-- `vultron/adapters/driven/delivery_queue.py`
+- `vultron/adapters/driven/demo_http_delivery.py`
 - `vultron/adapters/driven/asgi_emitter.py`
-- `vultron/adapters/driven/http_delivery.py`
+- `vultron/adapters/driven/prod_http_delivery.py`
 - `vultron/adapters/driven/sync_activity_adapter.py`
 - `vultron/adapters/driven/trigger_activity_adapter.py`
 - `vultron/demo/utils.py`

--- a/docs/reference/codebase/CONVENTIONS.md
+++ b/docs/reference/codebase/CONVENTIONS.md
@@ -7,11 +7,11 @@
 | Item | Rule | Example | Evidence |
 |------|------|---------|----------|
 | Files | Snake_case Python module names | `datalayer_sqlite.py`, `outbox_monitor.py` | `docs/reference/codebase/.codebase-scan.txt`, `vultron/adapters/driven/datalayer_sqlite.py` |
-| Functions/methods | Snake_case verbs; internal/private helpers use leading `_` | `get_trigger_service`, `_deliver_with_retry` | `vultron/adapters/driving/fastapi/deps.py`, `vultron/adapters/driven/delivery_queue.py` |
+| Functions/methods | Snake_case verbs; internal/private helpers use leading `_` | `get_trigger_service`, `_deliver_with_retry` | `vultron/adapters/driving/fastapi/deps.py`, `vultron/adapters/driven/demo_http_delivery.py` |
 | Types/interfaces | PascalCase for classes and Protocols | `SqliteDataLayer`, `OutboxMonitor`, `DataLayer` | `vultron/adapters/driven/datalayer_sqlite.py`, `vultron/core/ports/datalayer.py` |
 | AS2 wire-layer classes | Use the `as_` prefix in the wire layer | `as_Activity`, `as_Actor` | `AGENTS.md`, `vultron/wire/as2/vocab/base/objects/activities/base.py` |
 | Reserved-word field names | Use a trailing underscore with a Pydantic alias | `id_`, `type_`, `object_`, `context_` | `AGENTS.md`, `specs/code-style.yaml`, `vultron/wire/as2/vocab/base/objects/base.py` |
-| Constants/env vars | UPPER_CASE module constants and env names | `DEFAULT_MAX_RETRIES`, `VULTRON_DB_URL` | `vultron/adapters/driven/delivery_queue.py`, `vultron/adapters/driven/datalayer_sqlite.py` |
+| Constants/env vars | UPPER_CASE module constants and env names | `DEFAULT_MAX_RETRIES`, `VULTRON_DB_URL` | `vultron/adapters/driven/demo_http_delivery.py`, `vultron/adapters/driven/datalayer_sqlite.py` |
 
 ### 2) Formatting and Linting
 
@@ -66,4 +66,4 @@
 - `.pre-commit-config.yaml`
 - `.markdownlint-cli2.yaml`
 - `vultron/adapters/driving/fastapi/deps.py`
-- `vultron/adapters/driven/delivery_queue.py`
+- `vultron/adapters/driven/demo_http_delivery.py`

--- a/docs/reference/codebase/INTEGRATIONS.md
+++ b/docs/reference/codebase/INTEGRATIONS.md
@@ -8,8 +8,8 @@
 |--------|---------------------------|---------|------------|-------------|----------|
 | SQLite via SQLModel | DB | Persist Vultron objects plus inbox/outbox queue entries | Local file or in-memory DB URL; no separate DB auth shown | high | `vultron/adapters/driven/datalayer_sqlite.py`, `docker/docker-compose-multi-actor.yml` |
 | ASGIEmitter (in-process) | API | Deliver outbound AS2 activities to co-located actors via ASGI, stripping mount prefixes when mounted under `/api/v2` | None required (same-process) | high | `vultron/adapters/driven/asgi_emitter.py`, `vultron/adapters/driving/fastapi/main.py`, `vultron/adapters/driven/AGENTS.md` |
-| Peer actor inboxes via `DeliveryQueueAdapter` | API | Deliver outbound AS2 activities, including bootstrap and follow-on case-sync traffic, to remote actors with HTTP POST | No auth/signing is implemented in the current adapter | high | `vultron/adapters/driven/delivery_queue.py`, `specs/case-bootstrap-trust.yaml` |
-| HTTP delivery (stub) | API | Future signed HTTP delivery to remote inboxes | Intended to use HTTP Signature signing; not yet implemented | medium | `vultron/adapters/driven/http_delivery.py` |
+| Peer actor inboxes via `DemoHttpDeliveryAdapter` | API | Deliver outbound AS2 activities, including bootstrap and follow-on case-sync traffic, to remote actors with HTTP POST | No auth/signing is implemented in the current adapter | high | `vultron/adapters/driven/demo_http_delivery.py`, `specs/case-bootstrap-trust.yaml` |
+| HTTP delivery (stub) | API | Future signed HTTP delivery to remote inboxes | Intended to use HTTP Signature signing; not yet implemented | medium | `vultron/adapters/driven/prod_http_delivery.py` |
 | Shared inbox (stub) | API | Future ActivityPub shared-inbox fan-out to multiple local actors | HTTP Signature validation planned; not yet implemented | medium | `vultron/adapters/driving/shared_inbox.py` |
 | Demo HTTP clients (`requests`) | API client | Drive seeded/demo scenarios and verification helpers over HTTP | None shown beyond base URL config | medium | `vultron/demo/utils.py`, `vultron/demo/helpers/verification.py` |
 | MCP trigger adapter functions | Tool/API surface | Expose trigger use cases as in-process tool functions pending MCP SDK registration | None; no network transport is registered in-tree yet | low | `vultron/adapters/driving/mcp_server.py` |
@@ -39,7 +39,7 @@
   delivery uses a 5.0 second timeout; Docker health checks probe readiness with
   short `curl -f` timeouts
 - Circuit-breaker or fallback behavior: `ASGIEmitter` falls back to
-  `DeliveryQueueAdapter` on 404 or other local-delivery failures; no broader
+  `DemoHttpDeliveryAdapter` on 404 or other local-delivery failures; no broader
   circuit breaker was found
 
 ### 5) Observability for Integrations
@@ -54,9 +54,9 @@
 ### 6) Evidence
 
 - `vultron/adapters/driven/datalayer_sqlite.py`
-- `vultron/adapters/driven/delivery_queue.py`
+- `vultron/adapters/driven/demo_http_delivery.py`
 - `vultron/adapters/driven/asgi_emitter.py`
-- `vultron/adapters/driven/http_delivery.py`
+- `vultron/adapters/driven/prod_http_delivery.py`
 - `vultron/adapters/driving/shared_inbox.py`
 - `vultron/adapters/driving/mcp_server.py`
 - `vultron/demo/utils.py`

--- a/docs/reference/codebase/STACK.md
+++ b/docs/reference/codebase/STACK.md
@@ -20,7 +20,7 @@
 | `pydantic` | `==2.13.4` | Model validation and typed request/object models | `pyproject.toml`, `vultron/core/ports/datalayer.py` |
 | `pydantic-settings` | `>=2.14.1` | Environment-variable config loading | `pyproject.toml`, `vultron/config.py` |
 | `sqlmodel` | `>=0.0.38` | SQLite-backed persistence adapter | `pyproject.toml`, `vultron/adapters/driven/datalayer_sqlite.py` |
-| `httpx` | `>=0.28.1` | HTTP client for outbound inbox delivery | `pyproject.toml`, `vultron/adapters/driven/delivery_queue.py` |
+| `httpx` | `>=0.28.1` | HTTP client for outbound inbox delivery | `pyproject.toml`, `vultron/adapters/driven/demo_http_delivery.py` |
 | `py-trees` | `>=2.2.0` | Behavior-tree implementation support | `pyproject.toml`, `docs/adr/0002-model-processes-with-behavior-trees.md` |
 | `transitions` | `>=0.9.3` | State-machine support | `pyproject.toml` |
 | `pyyaml` | `>=6.0` | YAML-backed config and metadata loading | `pyproject.toml`, `vultron/demo/cli.py` |

--- a/docs/reference/codebase/STRUCTURE.md
+++ b/docs/reference/codebase/STRUCTURE.md
@@ -50,7 +50,7 @@ Notable adapter files added since last scan:
 
 - `vultron/adapters/driven/sync_activity_adapter.py` — implements `SyncActivityPort`; sole domain→wire translation point for sync-related activities (ARCH-01-001)
 - `vultron/adapters/driven/trigger_activity_adapter.py` — implements `TriggerActivityPort`; sole domain→wire translation point for trigger-originated activities
-- `vultron/adapters/driven/http_delivery.py` — **stub** for future signed HTTP delivery to remote inboxes
+- `vultron/adapters/driven/prod_http_delivery.py` — **stub** for future signed HTTP delivery to remote inboxes
 - `vultron/adapters/driving/shared_inbox.py` — **stub** for ActivityPub shared-inbox fan-out
 
 ### 4) Naming and Organization Rules

--- a/notes/architecture-adapters.md
+++ b/notes/architecture-adapters.md
@@ -81,7 +81,7 @@ Track ongoing violations in the associated ARCH-01-001 issue and spec links.
 
 Architectural placeholders exist (tracked in GitHub issue #650):
 
-- `adapters/driven/http_delivery.py` — future signed remote HTTP delivery
+- `adapters/driven/prod_http_delivery.py` — future signed remote HTTP delivery
   (`specs/outbox.yaml` OX-10-001–OX-10-004). **Must raise `NotImplementedError`
   if instantiated until implemented** (OX-10-004).
 - `adapters/driving/shared_inbox.py` — future ActivityPub shared-inbox fan-out

--- a/notes/domain-model-separation.md
+++ b/notes/domain-model-separation.md
@@ -415,14 +415,14 @@ directly access another actor's DataLayer.
 
 - Outbox delivery cannot assume local access to other actors' data or state.
 - Outbox delivery MUST use HTTP POST to remote inboxes via the FastAPI
-  adapter (`DeliveryQueueAdapter.emit()` POSTs to `{actor_uri}/inbox/`).
+  adapter (`DemoHttpDeliveryAdapter.emit()` POSTs to `{actor_uri}/inbox/`).
 - Idempotency cannot be checked by inspecting a remote DataLayer. The inbox
   handler itself MUST handle duplicates — checking `actor.inbox.items` and
   returning HTTP 202 immediately on a duplicate activity ID.
 
 ### Outbox Delivery is HTTP POST
 
-`DeliveryQueueAdapter.emit()` delivers outbound activities via async
+`DemoHttpDeliveryAdapter.emit()` delivers outbound activities via async
 `httpx.AsyncClient` HTTP POST to `{actor_uri}/inbox/`. Direct DataLayer
 writes to recipient inboxes are **not** used.
 

--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -33,6 +33,14 @@ header.
   `NotImplementedError` in `__init__` with spec reference context so failures
   are immediate and diagnosable.
 
+### 2026-06-08 ISSUE-721 — Transport-role naming must stay explicit in paths and classes
+
+- Outbound adapter names that imply behavior (`delivery_queue`) instead of role
+  (`demo_http_delivery`) create broad documentation and import drift.
+- When renaming protocol-significant adapter modules, update parallel
+  references together (core ports docs, adapter notes, ADR references, and
+  codebase reference pages) to keep agent guidance aligned with runtime code.
+
 ### 2026-06-08 ISSUE-750 — Embargo subtree decomposition must preserve idempotent side effects
 
 - Decomposing a god node into sequential BT leaves can silently change

--- a/plan/history/2606/implementation/ISSUE-721.md
+++ b/plan/history/2606/implementation/ISSUE-721.md
@@ -1,0 +1,16 @@
+---
+source: ISSUE-721
+timestamp: '2026-06-08T14:46:45.521557+00:00'
+title: Rename HTTP delivery adapters for demo/prod roles
+type: implementation
+---
+
+## Issue #721 — Rename delivery_queue.py → demo_http_delivery.py and http_delivery.py → prod_http_delivery.py with class renames
+
+Completed adapter/module renaming to make transport roles explicit:
+
+- renamed `vultron/adapters/driven/delivery_queue.py` to `demo_http_delivery.py` and `DeliveryQueueAdapter` to `DemoHttpDeliveryAdapter`
+- renamed `vultron/adapters/driven/http_delivery.py` to `prod_http_delivery.py` and added `ProdHttpDeliveryAdapter` as a fail-fast `NotImplementedError` stub
+- updated all import sites, tests, specs, and active docs/notes references
+
+PR: <https://github.com/CERTCC/Vultron/pull/828>

--- a/specs/outbox.yaml
+++ b/specs/outbox.yaml
@@ -163,10 +163,10 @@ groups:
   scope:
   - production
   rationale: >-
-    Plain unauthenticated HTTP POST (current DeliveryQueueAdapter) is acceptable for
+    Plain unauthenticated HTTP POST (current DemoHttpDeliveryAdapter) is acceptable for
     prototype use. Production federation requires HTTP Message Signatures so recipient
     actors can verify the sender's identity and reject spoofed activities.
-    vultron/adapters/driven/http_delivery.py is a documented stub for this capability.
+    vultron/adapters/driven/prod_http_delivery.py is a documented stub for this capability.
   specs:
   - id: OX-10-001
     priority: SHOULD
@@ -197,7 +197,7 @@ groups:
   - id: OX-10-004
     priority: MUST
     statement: >-
-      Until signed delivery is implemented, adapters/driven/http_delivery.py MUST
+      Until signed delivery is implemented, adapters/driven/prod_http_delivery.py MUST
       raise NotImplementedError if instantiated, so that callers receive an explicit
       signal rather than a silent no-op
     scope:

--- a/test/adapters/driven/test_delivery_backoff.py
+++ b/test/adapters/driven/test_delivery_backoff.py
@@ -11,7 +11,7 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Tests for SYNC-5: DeliveryQueueAdapter retry/backoff behaviour.
+"""Tests for SYNC-5: DemoHttpDeliveryAdapter retry/backoff behaviour.
 
 Spec: SYNC-05-001, SYNC-05-002.
 """
@@ -21,12 +21,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 
-from vultron.adapters.driven.delivery_queue import (
+from vultron.adapters.driven.demo_http_delivery import (
     DEFAULT_BACKOFF_MULTIPLIER,
     DEFAULT_INITIAL_DELAY,
     DEFAULT_MAX_DELAY,
     DEFAULT_MAX_RETRIES,
-    DeliveryQueueAdapter,
+    DemoHttpDeliveryAdapter,
 )
 from vultron.core.models.activity import VultronActivity
 
@@ -58,18 +58,18 @@ class TestDefaultConstants:
         assert DEFAULT_MAX_DELAY == 30.0
 
 
-class TestDeliveryQueueAdapterInit:
-    """DeliveryQueueAdapter accepts configurable retry parameters (SYNC-05-002)."""
+class TestDemoHttpDeliveryAdapterInit:
+    """DemoHttpDeliveryAdapter accepts configurable retry parameters (SYNC-05-002)."""
 
     def test_default_params(self):
-        adapter = DeliveryQueueAdapter()
+        adapter = DemoHttpDeliveryAdapter()
         assert adapter._max_retries == DEFAULT_MAX_RETRIES
         assert adapter._initial_delay == DEFAULT_INITIAL_DELAY
         assert adapter._backoff_multiplier == DEFAULT_BACKOFF_MULTIPLIER
         assert adapter._max_delay == DEFAULT_MAX_DELAY
 
     def test_custom_params(self):
-        adapter = DeliveryQueueAdapter(
+        adapter = DemoHttpDeliveryAdapter(
             max_retries=5,
             initial_delay=1.0,
             backoff_multiplier=3.0,
@@ -81,7 +81,7 @@ class TestDeliveryQueueAdapterInit:
         assert adapter._max_delay == 60.0
 
     def test_zero_retries_disables_retry(self):
-        adapter = DeliveryQueueAdapter(max_retries=0)
+        adapter = DemoHttpDeliveryAdapter(max_retries=0)
         assert adapter._max_retries == 0
 
 
@@ -89,7 +89,7 @@ class TestDeliverySuccess:
     """Successful delivery requires no retries."""
 
     def test_delivers_on_first_attempt(self):
-        adapter = DeliveryQueueAdapter(max_retries=2, initial_delay=0.0)
+        adapter = DemoHttpDeliveryAdapter(max_retries=2, initial_delay=0.0)
         activity = _make_activity()
 
         mock_response = MagicMock()
@@ -105,7 +105,7 @@ class TestDeliverySuccess:
         mock_post.assert_called_once()
 
     def test_delivers_to_all_recipients(self):
-        adapter = DeliveryQueueAdapter(max_retries=0, initial_delay=0.0)
+        adapter = DemoHttpDeliveryAdapter(max_retries=0, initial_delay=0.0)
         activity = _make_activity()
         recipients = [
             "https://example.org/actors/alice",
@@ -129,7 +129,7 @@ class TestDeliveryRetry:
     """Failed delivery is retried with exponential backoff (SYNC-05-001)."""
 
     def test_retries_on_failure_then_succeeds(self):
-        adapter = DeliveryQueueAdapter(
+        adapter = DemoHttpDeliveryAdapter(
             max_retries=2, initial_delay=0.0, backoff_multiplier=2.0
         )
         activity = _make_activity()
@@ -155,7 +155,7 @@ class TestDeliveryRetry:
         assert mock_sleep.call_count == 2
 
     def test_exponential_backoff_delay_sequence(self):
-        adapter = DeliveryQueueAdapter(
+        adapter = DemoHttpDeliveryAdapter(
             max_retries=3,
             initial_delay=1.0,
             backoff_multiplier=2.0,
@@ -178,7 +178,7 @@ class TestDeliveryRetry:
         assert sleep_calls == [1.0, 2.0, 4.0]
 
     def test_delay_capped_at_max_delay(self):
-        adapter = DeliveryQueueAdapter(
+        adapter = DemoHttpDeliveryAdapter(
             max_retries=5,
             initial_delay=10.0,
             backoff_multiplier=10.0,
@@ -202,7 +202,7 @@ class TestDeliveryRetry:
             assert delay <= 30.0
 
     def test_exhaust_retries_logs_error(self, caplog):
-        adapter = DeliveryQueueAdapter(
+        adapter = DemoHttpDeliveryAdapter(
             max_retries=1, initial_delay=0.0, backoff_multiplier=1.0
         )
         activity = _make_activity()
@@ -219,7 +219,7 @@ class TestDeliveryRetry:
 
     def test_one_failed_recipient_does_not_block_others(self):
         """Delivery failure for one recipient does not abort others."""
-        adapter = DeliveryQueueAdapter(max_retries=0, initial_delay=0.0)
+        adapter = DemoHttpDeliveryAdapter(max_retries=0, initial_delay=0.0)
         activity = _make_activity()
 
         delivered: list[str] = []
@@ -245,7 +245,7 @@ class TestDeliveryRetry:
         assert "bob" in delivered[0]
 
     def test_zero_retries_attempts_once_only(self):
-        adapter = DeliveryQueueAdapter(max_retries=0, initial_delay=0.0)
+        adapter = DemoHttpDeliveryAdapter(max_retries=0, initial_delay=0.0)
         activity = _make_activity()
 
         call_count = 0

--- a/test/adapters/driven/test_delivery_inbox_url.py
+++ b/test/adapters/driven/test_delivery_inbox_url.py
@@ -13,7 +13,7 @@
 
 """Integration test: inbox URL derivation consistency (D5-1-G6).
 
-Verifies that ``DeliveryQueueAdapter``'s inbox URL derivation formula
+Verifies that ``DemoHttpDeliveryAdapter``'s inbox URL derivation formula
 (``{actor_id}/inbox/``) produces URLs that are routable by the FastAPI
 actors router registered in
 ``vultron/adapters/driving/fastapi/routers/actors.py``.
@@ -43,7 +43,7 @@ _ACTOR_ID = f"{_CONTAINER_BASE}/actors/{_ACTOR_UUID}"
 
 
 def _derive_inbox_url(actor_id: str) -> str:
-    """Mirror of the DeliveryQueueAdapter inbox URL derivation logic."""
+    """Mirror of the DemoHttpDeliveryAdapter inbox URL derivation logic."""
     return actor_id.rstrip("/") + "/inbox/"
 
 
@@ -110,7 +110,7 @@ def test_derived_inbox_path_matches_fastapi_route(dl):
 
     client = TestClient(app, raise_server_exceptions=False)
 
-    # Derive inbox URL using the same formula as DeliveryQueueAdapter.
+    # Derive inbox URL using the same formula as DemoHttpDeliveryAdapter.
     inbox_url = _derive_inbox_url(_ACTOR_ID)
 
     # Strip the container prefix to get the path relative to app_v2.

--- a/test/demo/conftest.py
+++ b/test/demo/conftest.py
@@ -50,10 +50,10 @@ logger = logging.getLogger(__name__)
 class _NullDeliveryAdapter:
     """No-op ``ActivityEmitter`` that silently drops deliveries.
 
-    Used in tests to replace ``DeliveryQueueAdapter`` as the HTTP fallback
+    Used in tests to replace ``DemoHttpDeliveryAdapter`` as the HTTP fallback
     inside ``ASGIEmitter``.  Demo actors use fictional URLs
     (e.g. ``https://vultron.example/users/finndervul``) that are unreachable
-    in the test environment.  The default ``DeliveryQueueAdapter`` attempts
+    in the test environment.  The default ``DemoHttpDeliveryAdapter`` attempts
     real HTTP POST requests with a 5 s timeout and 3 retries (3.5 s of
     ``asyncio.sleep`` per recipient), which caused the integration suite to
     take 17+ minutes in CI (#527).
@@ -261,7 +261,7 @@ def client():
     replaced with a ``_NullDeliveryAdapter`` that silently drops deliveries.
     Demo actors use fictional URLs
     (e.g. ``https://vultron.example/users/finndervul``) that are unreachable
-    in the test environment.  The default ``DeliveryQueueAdapter`` retries
+    in the test environment.  The default ``DemoHttpDeliveryAdapter`` retries
     3 × with exponential backoff (≈ 3.5 s per recipient), causing 17+ min
     CI slowdowns (#527).  The no-op adapter eliminates that overhead.
 

--- a/test/demo/test_delivery_fallback_speed.py
+++ b/test/demo/test_delivery_fallback_speed.py
@@ -16,7 +16,7 @@
 
 Demo actors use fictional URLs (e.g. ``https://vultron.example/...``) that
 cannot be reached via HTTP.  The ``ASGIEmitter`` correctly classifies these
-as non-local and delegates to a ``DeliveryQueueAdapter`` HTTP fallback.
+as non-local and delegates to a ``DemoHttpDeliveryAdapter`` HTTP fallback.
 
 In production the fallback's retry/backoff (3 retries, 3.5 s sleep total
 per recipient) is appropriate.  In tests it is catastrophic — the demo

--- a/test/demo/test_pcr_bootstrap.py
+++ b/test/demo/test_pcr_bootstrap.py
@@ -117,7 +117,7 @@ def two_app_setup():
       3. Configures the module-level ``_default_emitter`` to the shared
          router so that trigger-endpoint ``outbox_handler`` calls (which
          don't pass an explicit emitter) route through ASGI instead of
-         making real HTTP requests via ``DeliveryQueueAdapter``.
+         making real HTTP requests via ``DemoHttpDeliveryAdapter``.
       4. Registers the config-default base_url with the router pointing to
          the owner's app so that deliveries to the CaseActor (whose ID uses
          the config base_url) are routed correctly.
@@ -151,7 +151,7 @@ def two_app_setup():
 
     # Save and replace the module-level default emitter so outbox_handler
     # calls from trigger endpoints use the router instead of
-    # DeliveryQueueAdapter (real HTTP with retry backoff).
+    # DemoHttpDeliveryAdapter (real HTTP with retry backoff).
     previous_emitter = get_default_emitter()
     configure_default_emitter(router)  # type: ignore[arg-type]
 

--- a/test/demo/test_pcr_late_joiner.py
+++ b/test/demo/test_pcr_late_joiner.py
@@ -128,7 +128,7 @@ def three_app_setup():
 
     # Save and replace the module-level default emitter so outbox_handler
     # calls from trigger endpoints use the router instead of
-    # DeliveryQueueAdapter (real HTTP with retry backoff).
+    # DemoHttpDeliveryAdapter (real HTTP with retry backoff).
     previous_emitter = get_default_emitter()
     configure_default_emitter(router)  # type: ignore[arg-type]
 

--- a/vultron/adapters/driven/AGENTS.md
+++ b/vultron/adapters/driven/AGENTS.md
@@ -5,7 +5,7 @@
 `ASGIEmitter` (`vultron/adapters/driven/asgi_emitter.py`) is the
 production `ActivityEmitter` implementation for the FastAPI server. It
 delivers activities to co-located actors in-process via the ASGI
-interface and falls back to `DeliveryQueueAdapter` (HTTP POST) for
+interface and falls back to `DemoHttpDeliveryAdapter` (HTTP POST) for
 remote recipients.
 
 References: `specs/multi-actor-demo.yaml` DEMOMA-01-004,

--- a/vultron/adapters/driven/__init__.py
+++ b/vultron/adapters/driven/__init__.py
@@ -9,11 +9,11 @@ implementation.
 Modules:
 
 - ``datalayer.py``  — Concrete activity persistence (e.g., TinyDB).
-- ``http_delivery.py``   — HTTP transport for outbound ActivityStreams
-                           payloads (transport only — receives serialized
-                           AS2 from the wire layer).
-- ``delivery_queue.py`` — Stub implementation of the ``ActivityEmitter``
-                           port (``core/ports/emitter.py``); queues
-                           outbound activities for local or remote delivery.
+- ``demo_http_delivery.py`` — Unsigned HTTP transport for outbound
+                           ActivityStreams payloads; receives serialized
+                           AS2 from the wire layer.
+- ``prod_http_delivery.py`` — Stub implementation for future signed remote
+                           delivery; raises ``NotImplementedError`` when
+                           instantiated (OX-10-004).
 
 """

--- a/vultron/adapters/driven/asgi_emitter.py
+++ b/vultron/adapters/driven/asgi_emitter.py
@@ -3,7 +3,7 @@
 Attempts to deliver every recipient via the local ASGI application first.
 If the ASGI app returns a non-success status (e.g. 404 when the actor is
 not hosted locally), the recipient is retried via HTTP through the standard
-``DeliveryQueueAdapter``.
+``DemoHttpDeliveryAdapter``.
 
 This strategy is URL-scheme agnostic: it works whether actor IDs use the
 production ``base_url`` or a test-client URL like ``http://testserver``.
@@ -12,7 +12,7 @@ A reentrancy guard (``_asgi_delivery_depth``) prevents recursive ASGI
 transport calls.  When ``_try_deliver_local`` is invoked from within an
 already-active delivery chain (same asyncio task), subsequent deliveries
 fall through to the HTTP fallback instead of re-entering the ASGI app.
-In production the fallback is ``DeliveryQueueAdapter`` (normal HTTP POST
+In production the fallback is ``DemoHttpDeliveryAdapter`` (normal HTTP POST
 handled by uvicorn as a new request/task); in tests it is typically a
 ``NullDeliveryAdapter`` that silently drops unreachable deliveries.
 
@@ -25,7 +25,7 @@ import logging
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
-from vultron.adapters.driven.delivery_queue import DeliveryQueueAdapter
+from vultron.adapters.driven.demo_http_delivery import DemoHttpDeliveryAdapter
 from vultron.config import get_config
 from vultron.core.models.activity import VultronActivity
 
@@ -69,7 +69,7 @@ class ASGIEmitter:
         self._app = app
         self._base_url = (base_url or get_config().server.base_url).rstrip("/")
         self._mount_prefix = mount_prefix.rstrip("/")
-        self._http_fallback = DeliveryQueueAdapter()
+        self._http_fallback = DemoHttpDeliveryAdapter()
 
     async def emit(
         self,

--- a/vultron/adapters/driven/demo_http_delivery.py
+++ b/vultron/adapters/driven/demo_http_delivery.py
@@ -1,4 +1,4 @@
-"""Delivery queue driven adapter — OX-1.1 implementation.
+"""Demo HTTP delivery driven adapter — OX-1.1 implementation.
 
 Implements the ``ActivityEmitter`` port (``core/ports/emitter.py``) by
 delivering outbound ActivityStreams activities to recipient actor inboxes
@@ -56,7 +56,7 @@ DEFAULT_BACKOFF_MULTIPLIER: float = 2.0
 DEFAULT_MAX_DELAY: float = 30.0
 
 
-class DeliveryQueueAdapter:
+class DemoHttpDeliveryAdapter:
     """``ActivityEmitter`` driven-port implementation.
 
     Delivers outbound activities to recipient actor inboxes via HTTP POST

--- a/vultron/adapters/driven/prod_http_delivery.py
+++ b/vultron/adapters/driven/prod_http_delivery.py
@@ -16,3 +16,13 @@ This adapter is transport-only — it must not construct or inspect AS2
 objects. Serialization is handled by ``wire/as2/serializer.py`` before
 the payload reaches this adapter.
 """
+
+
+class ProdHttpDeliveryAdapter:
+    """Stub for signed remote HTTP delivery (OX-10-004)."""
+
+    def __init__(self) -> None:
+        raise NotImplementedError(
+            "ProdHttpDeliveryAdapter is not implemented yet. "
+            "See specs/outbox.yaml OX-10-004."
+        )

--- a/vultron/adapters/driving/fastapi/outbox_handler.py
+++ b/vultron/adapters/driving/fastapi/outbox_handler.py
@@ -28,7 +28,7 @@ import logging
 from typing import cast
 
 from pydantic import BaseModel
-from vultron.adapters.driven.delivery_queue import DeliveryQueueAdapter
+from vultron.adapters.driven.demo_http_delivery import DemoHttpDeliveryAdapter
 from vultron.core.models.activity import VultronActivity
 from vultron.core.models.protocols import PersistableModel
 from vultron.core.ports.datalayer import ActorScopedDataLayer, DataLayer
@@ -47,7 +47,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Set via ``configure_default_emitter()`` during app startup so all
 # ``outbox_handler`` calls use local ASGI delivery for co-located actors.
-# Falls back to ``DeliveryQueueAdapter`` (HTTP-only) when not configured.
+# Falls back to ``DemoHttpDeliveryAdapter`` (HTTP-only) when not configured.
 _default_emitter: ActivityEmitter | None = None
 
 
@@ -63,8 +63,8 @@ def configure_default_emitter(emitter: ActivityEmitter) -> None:
 
 
 def get_default_emitter() -> ActivityEmitter:
-    """Return the configured default emitter, or ``DeliveryQueueAdapter``."""
-    return _default_emitter or DeliveryQueueAdapter()
+    """Return the configured default emitter, or ``DemoHttpDeliveryAdapter``."""
+    return _default_emitter or DemoHttpDeliveryAdapter()
 
 
 # Reference fields that must be collapsed to URI strings before validating as
@@ -458,7 +458,7 @@ async def outbox_handler(
     ``ActivityEmitter`` port (OX-03-001).
 
     Delivery is performed by the emitter (HTTP POST for
-    ``DeliveryQueueAdapter``) and does not block the HTTP response because
+    ``DemoHttpDeliveryAdapter``) and does not block the HTTP response because
     this coroutine is scheduled as a FastAPI BackgroundTask (OX-03-003).
 
     OX-1.3 idempotency is enforced at the receiving inbox endpoint, not
@@ -473,7 +473,7 @@ async def outbox_handler(
             actor's own DL).
         emitter: The ActivityEmitter port to use for delivery. Defaults to
             the configured emitter (``ASGIEmitter`` when available, otherwise
-            ``DeliveryQueueAdapter``).
+            ``DemoHttpDeliveryAdapter``).
     """
     _emitter = cast(
         ActivityEmitter,

--- a/vultron/adapters/driving/fastapi/outbox_monitor.py
+++ b/vultron/adapters/driving/fastapi/outbox_monitor.py
@@ -78,7 +78,7 @@ class OutboxMonitor:
             ``record_outbox_item`` calls on the shared DL trigger immediate
             wakeup.
         emitter: ``ActivityEmitter`` implementation for HTTP delivery.
-            Defaults to ``DeliveryQueueAdapter`` (resolved inside
+            Defaults to ``DemoHttpDeliveryAdapter`` (resolved inside
             :func:`outbox_handler`).
     """
 

--- a/vultron/core/ports/AGENTS.md
+++ b/vultron/core/ports/AGENTS.md
@@ -31,7 +31,7 @@ Use these terms consistently:
 
 Two emitter adapters are currently used:
 
-- `DeliveryQueueAdapter` (remote HTTP delivery path).
+- `DemoHttpDeliveryAdapter` (remote HTTP delivery path).
 - `ASGIEmitter` (co-located ASGI delivery, HTTP fallback when non-local).
 
 ## Use Cases as Incoming Ports

--- a/vultron/core/ports/__init__.py
+++ b/vultron/core/ports/__init__.py
@@ -33,5 +33,5 @@ pattern (see ``vultron/core/ports/AGENTS.md``
 - ``DataLayer`` (``datalayer.py``) — persistence interface; implemented by
   ``SqliteDataLayer`` in ``vultron/adapters/driven/``.
 - ``ActivityEmitter`` (``emitter.py``) — outbound activity delivery;
-  implemented by ``DeliveryQueueAdapter`` in ``vultron/adapters/driven/``.
+  implemented by ``DemoHttpDeliveryAdapter`` in ``vultron/adapters/driven/``.
 """


### PR DESCRIPTION
Closes #721

## Summary
- renamed vultron/adapters/driven/delivery_queue.py to demo_http_delivery.py
- renamed DeliveryQueueAdapter to DemoHttpDeliveryAdapter and updated import sites (asgi_emitter, outbox_handler, outbox_monitor, core/ports, tests)
- renamed vultron/adapters/driven/http_delivery.py to prod_http_delivery.py
- added ProdHttpDeliveryAdapter stub that raises NotImplementedError (OX-10-004)
- updated specs and documentation references (specs/outbox.yaml, AGENTS.md, notes/, docs/reference/codebase/, docs/adr/0012-*)
