### PR TITLE
Add InboxPipeline test seam and routing safety-net tests

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -50,3 +50,11 @@ header.
 - When moving EM transition logic to `EmbargoLifecycle.propose_embargo`,
   keep event creation and participant-seeding behavior aligned with existing
   duplicate-report tests to avoid introducing warning-level regressions.
+
+### 2026-06-08 ISSUE-769 — Inbox test seam must preserve production deferral semantics
+
+- A test-only inbox pipeline that reimplements defer/replay logic can drift
+  from production behavior unless it reuses the same expiry path.
+- Case deferral tests should set canonical `to` recipients so actor-scoped
+  queues are exercised under the same addressing assumptions as inbox
+  processing.

--- a/plan/history/2606/implementation/ISSUE-769.md
+++ b/plan/history/2606/implementation/ISSUE-769.md
@@ -1,0 +1,14 @@
+---
+source: ISSUE-769
+timestamp: '2026-06-08T15:11:44.323963+00:00'
+title: InboxPipeline test seam and routing safety-net
+type: implementation
+---
+
+## Issue #769 — Implement InboxPipeline to surface inbox→dispatcher seam as testable unit
+
+Implemented an injectable InboxPipeline in the FastAPI driving adapter with full single-item processing (rehydrate, semantic extraction, defer-or-dispatch, replay handling) and a build_test_pipeline factory wired with the production dispatcher map.
+
+Added test_pipeline fixture support and new routing safety-net tests covering report, case, embargo, note, actor, status, and sync semantic domains, plus a deferral-path assertion for unknown case context.
+
+PR: [#830](https://github.com/CERTCC/Vultron/pull/830)

--- a/test/adapters/driving/fastapi/conftest.py
+++ b/test/adapters/driving/fastapi/conftest.py
@@ -15,10 +15,17 @@
 Provides pytest fixtures for testing the FastAPI v2 application.
 """
 
+from collections.abc import Generator
+
 import pytest
 from fastapi.testclient import TestClient
 
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.adapters.driving.fastapi.app import app_v2 as app
+from vultron.adapters.driving.fastapi.inbox_pipeline import (
+    InboxPipeline,
+    build_test_pipeline,
+)
 
 
 @pytest.fixture
@@ -50,3 +57,14 @@ def datalayer():
     datalayer.clear_all()
     # Reset singleton for next test
     reset_datalayer()
+
+
+@pytest.fixture
+def test_pipeline() -> (
+    Generator[tuple[InboxPipeline, SqliteDataLayer], None, None]
+):
+    dl = SqliteDataLayer("sqlite:///:memory:")
+    try:
+        yield build_test_pipeline(dl), dl
+    finally:
+        dl.close()

--- a/test/adapters/driving/fastapi/test_inbox_pipeline.py
+++ b/test/adapters/driving/fastapi/test_inbox_pipeline.py
@@ -1,0 +1,261 @@
+from typing import TypeAlias
+
+from pytest import MonkeyPatch
+
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.adapters.driving.fastapi.inbox_pipeline import InboxPipeline
+from vultron.core.models.protocols import PersistableModel
+from vultron.core.models.pending_case_inbox import VultronPendingCaseInbox
+from vultron.core.use_cases.received.actor import (
+    AnnounceVulnerabilityCaseReceivedUseCase,
+)
+from vultron.core.use_cases.received.case import CreateCaseReceivedUseCase
+from vultron.core.use_cases.received.embargo import (
+    InviteToEmbargoOnCaseReceivedUseCase,
+)
+from vultron.core.use_cases.received.note import AddNoteToCaseReceivedUseCase
+from vultron.core.use_cases.received.report import CreateReportReceivedUseCase
+from vultron.core.use_cases.received.status import (
+    AddCaseStatusToCaseReceivedUseCase,
+)
+from vultron.core.use_cases.received.sync import (
+    AnnounceLogEntryReceivedUseCase,
+)
+from vultron.wire.as2.factories import (
+    add_note_to_case_activity,
+    add_status_to_case_activity,
+    announce_log_entry_activity,
+    announce_vulnerability_case_activity,
+    create_case_activity,
+    em_propose_embargo_activity,
+    rm_create_report_activity,
+)
+from vultron.wire.as2.vocab.base.objects.object_types import as_Note
+from vultron.wire.as2.vocab.objects.case_log_entry import CaseLogEntry
+from vultron.wire.as2.vocab.objects.case_status import CaseStatus
+from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    VulnerabilityCase,
+)
+from vultron.wire.as2.vocab.objects.vulnerability_report import (
+    VulnerabilityReport,
+)
+
+PipelineFixture: TypeAlias = tuple[InboxPipeline, SqliteDataLayer]
+
+SENDER_ID = "https://example.org/actors/sender"
+RECEIVER_ID = "https://example.org/actors/receiver"
+CASE_ID = "https://example.org/cases/case-ibp"
+UNKNOWN_CASE_ID = "https://example.org/cases/case-unknown"
+
+
+def _patch_execute_with_marker(
+    monkeypatch: MonkeyPatch, use_case_class: type, marker_id: str
+) -> None:
+    def _execute(self) -> None:
+        self._dl.save(as_Note(id_=marker_id, content=marker_id))
+
+    monkeypatch.setattr(use_case_class, "execute", _execute)
+
+
+def _base_case(case_id: str = CASE_ID) -> VulnerabilityCase:
+    return VulnerabilityCase(id_=case_id, name="CASE-IBP")
+
+
+def _save_and_process(
+    test_pipeline: PipelineFixture,
+    *,
+    activity: PersistableModel,
+    objects: list[PersistableModel],
+):
+    pipeline, dl = test_pipeline
+    for obj in objects:
+        dl.save(obj)
+    dl.save(activity)
+    return pipeline.process(activity.id_), dl
+
+
+def test_routing_safety_net_report_domain(test_pipeline, monkeypatch):
+    marker_id = "https://example.org/markers/report"
+    _patch_execute_with_marker(
+        monkeypatch, CreateReportReceivedUseCase, marker_id
+    )
+    report = VulnerabilityReport(
+        id_="https://example.org/reports/r-ibp-1",
+        content="report content",
+    )
+    activity = rm_create_report_activity(
+        report, actor=SENDER_ID, to=[RECEIVER_ID]
+    )
+
+    event, dl = _save_and_process(
+        test_pipeline, activity=activity, objects=[report]
+    )
+
+    assert event is not None
+    assert event.semantic_type.name == "CREATE_REPORT"
+    assert dl.read(marker_id) is not None
+
+
+def test_routing_safety_net_case_domain(test_pipeline, monkeypatch):
+    marker_id = "https://example.org/markers/case"
+    _patch_execute_with_marker(
+        monkeypatch, CreateCaseReceivedUseCase, marker_id
+    )
+    case = _base_case()
+    activity = create_case_activity(case, actor=SENDER_ID, to=[RECEIVER_ID])
+
+    event, dl = _save_and_process(
+        test_pipeline, activity=activity, objects=[case]
+    )
+
+    assert event is not None
+    assert event.semantic_type.name == "CREATE_CASE"
+    assert dl.read(marker_id) is not None
+
+
+def test_routing_safety_net_embargo_domain(test_pipeline, monkeypatch):
+    marker_id = "https://example.org/markers/embargo"
+    _patch_execute_with_marker(
+        monkeypatch, InviteToEmbargoOnCaseReceivedUseCase, marker_id
+    )
+    case = _base_case()
+    embargo = EmbargoEvent(
+        id_="https://example.org/embargoes/e-ibp-1",
+        context=case,
+    )
+    activity = em_propose_embargo_activity(
+        embargo, context=case.id_, actor=SENDER_ID, to=[RECEIVER_ID]
+    )
+
+    event, dl = _save_and_process(
+        test_pipeline, activity=activity, objects=[case, embargo]
+    )
+
+    assert event is not None
+    assert event.semantic_type.name == "INVITE_TO_EMBARGO_ON_CASE"
+    assert dl.read(marker_id) is not None
+
+
+def test_routing_safety_net_note_domain(test_pipeline, monkeypatch):
+    marker_id = "https://example.org/markers/note"
+    _patch_execute_with_marker(
+        monkeypatch, AddNoteToCaseReceivedUseCase, marker_id
+    )
+    case = _base_case()
+    note = as_Note(id_="https://example.org/notes/n-ibp-1", content="hello")
+    activity = add_note_to_case_activity(
+        note,
+        target=case,
+        context=case.id_,
+        actor=SENDER_ID,
+        to=[RECEIVER_ID],
+    )
+
+    event, dl = _save_and_process(
+        test_pipeline, activity=activity, objects=[case, note]
+    )
+
+    assert event is not None
+    assert event.semantic_type.name == "ADD_NOTE_TO_CASE"
+    assert dl.read(marker_id) is not None
+
+
+def test_routing_safety_net_actor_domain(test_pipeline, monkeypatch):
+    marker_id = "https://example.org/markers/actor"
+    _patch_execute_with_marker(
+        monkeypatch, AnnounceVulnerabilityCaseReceivedUseCase, marker_id
+    )
+    case = _base_case()
+    activity = announce_vulnerability_case_activity(
+        case,
+        actor=SENDER_ID,
+        to=[RECEIVER_ID],
+    )
+
+    event, dl = _save_and_process(
+        test_pipeline, activity=activity, objects=[case]
+    )
+
+    assert event is not None
+    assert event.semantic_type.name == "ANNOUNCE_VULNERABILITY_CASE"
+    assert dl.read(marker_id) is not None
+
+
+def test_routing_safety_net_status_domain(test_pipeline, monkeypatch):
+    marker_id = "https://example.org/markers/status"
+    _patch_execute_with_marker(
+        monkeypatch, AddCaseStatusToCaseReceivedUseCase, marker_id
+    )
+    case = _base_case()
+    status = CaseStatus(
+        id_="https://example.org/status/cs-ibp-1", context=case.id_
+    )
+    activity = add_status_to_case_activity(
+        status,
+        target=case,
+        context=case.id_,
+        actor=SENDER_ID,
+        to=[RECEIVER_ID],
+    )
+
+    event, dl = _save_and_process(
+        test_pipeline, activity=activity, objects=[case, status]
+    )
+
+    assert event is not None
+    assert event.semantic_type.name == "ADD_CASE_STATUS_TO_CASE"
+    assert dl.read(marker_id) is not None
+
+
+def test_routing_safety_net_sync_domain(test_pipeline, monkeypatch):
+    marker_id = "https://example.org/markers/sync"
+    _patch_execute_with_marker(
+        monkeypatch, AnnounceLogEntryReceivedUseCase, marker_id
+    )
+    entry = CaseLogEntry(
+        id_="https://example.org/log/entry-ibp-1",
+        case_id=CASE_ID,
+        log_index=0,
+        log_object_id="https://example.org/activities/a-1",
+        event_type="announce",
+        prev_log_hash="0",
+        entry_hash="1",
+    )
+    activity = announce_log_entry_activity(
+        entry,
+        context=CASE_ID,
+        actor=SENDER_ID,
+        to=[RECEIVER_ID],
+    )
+
+    event, dl = _save_and_process(
+        test_pipeline, activity=activity, objects=[_base_case(), entry]
+    )
+
+    assert event is not None
+    assert event.semantic_type.name == "ANNOUNCE_CASE_LOG_ENTRY"
+    assert dl.read(marker_id) is not None
+
+
+def test_process_defers_unknown_case_activity(test_pipeline):
+    pipeline, dl = test_pipeline
+    note = as_Note(id_="https://example.org/notes/n-ibp-def", content="defer")
+    activity = add_note_to_case_activity(
+        note,
+        target=UNKNOWN_CASE_ID,
+        context=UNKNOWN_CASE_ID,
+        actor=SENDER_ID,
+        to=[RECEIVER_ID],
+    )
+
+    dl.save(note)
+    dl.save(activity)
+
+    result = pipeline.process(activity.id_)
+
+    assert result is None
+    queue_dl = dl.clone_for_actor(RECEIVER_ID)
+    pending = queue_dl.read(VultronPendingCaseInbox.build_id(UNKNOWN_CASE_ID))
+    assert isinstance(pending, VultronPendingCaseInbox)
+    assert activity.id_ in pending.activity_ids

--- a/vultron/adapters/driving/fastapi/inbox_pipeline.py
+++ b/vultron/adapters/driving/fastapi/inbox_pipeline.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python
+"""Injectable inbox pipeline for unit-level routing and deferral tests."""
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+import logging
+from typing import cast
+
+from vultron.adapters.driving.fastapi.inbox_handler import (
+    _expire_pending_case_activities,
+    _replay_pending_case_activities,
+    dispatch,
+    make_dispatcher,
+    prepare_for_dispatch,
+)
+from vultron.core.models.events import MessageSemantics, VultronEvent
+from vultron.core.models.pending_case_inbox import VultronPendingCaseInbox
+from vultron.core.models.protocols import is_case_model
+from vultron.core.ports.datalayer import ActorScopedDataLayer, DataLayer
+from vultron.core.ports.dispatcher import ActivityDispatcher
+from vultron.wire.as2.rehydration import rehydrate
+from vultron.wire.as2.vocab.base.objects.activities.base import as_Activity
+
+logger = logging.getLogger(__name__)
+
+
+def _scalar_actor_ref(value: object) -> str | None:
+    """Return an actor ID string from a scalar ref-like value."""
+    if isinstance(value, str) and value:
+        return value
+    actor_id = getattr(value, "id_", None)
+    if isinstance(actor_id, str) and actor_id:
+        return actor_id
+    return None
+
+
+def _receiving_actor_id(activity: as_Activity) -> str | None:
+    """Extract the canonical receiving actor ID from ``activity.to``."""
+    to_value = getattr(activity, "to", None)
+    if isinstance(to_value, list):
+        for item in to_value:
+            actor_id = _scalar_actor_ref(item)
+            if actor_id is not None:
+                return actor_id
+        return None
+    return _scalar_actor_ref(to_value)
+
+
+def _activity_context_id(
+    activity: as_Activity, event: VultronEvent
+) -> str | None:
+    """Return the case context ID carried by an activity, if any."""
+    if event.context_id is not None:
+        return event.context_id
+    context = getattr(activity, "context", None)
+    if isinstance(context, str) and context:
+        return context
+    return getattr(context, "id_", None)
+
+
+def _queue_pending_case_activity(
+    queue_dl: ActorScopedDataLayer,
+    case_id: str,
+    activity_id: str,
+    case_actor_id: str | None = None,
+) -> None:
+    """Append an activity ID to the per-case deferred queue."""
+    pending_id = VultronPendingCaseInbox.build_id(case_id)
+    pending = queue_dl.read(pending_id)
+    if isinstance(pending, VultronPendingCaseInbox):
+        if activity_id not in pending.activity_ids:
+            pending.activity_ids.append(activity_id)
+            queue_dl.save(pending)
+        return
+
+    queue_dl.save(
+        VultronPendingCaseInbox(
+            case_id=case_id,
+            activity_ids=[activity_id],
+            case_actor_id=case_actor_id,
+        )
+    )
+
+
+class InboxPipeline:
+    """Process one inbox item through rehydrate → extract → defer/dispatch."""
+
+    def __init__(self, dispatcher: ActivityDispatcher, dl: DataLayer) -> None:
+        self._dispatcher = dispatcher
+        self._dl = dl
+
+    def process(self, activity_id: str) -> VultronEvent | None:
+        """Process one queued activity ID.
+
+        Returns the dispatched ``VultronEvent`` or ``None`` when processing is
+        deferred or an error prevents dispatch.
+        """
+        obj = rehydrate(activity_id, dl=self._dl)
+        if not isinstance(obj, as_Activity):
+            logger.error(
+                "Rehydrated inbox item %s is not an Activity: %s",
+                activity_id,
+                type(obj).__name__,
+            )
+            return None
+
+        receiving_actor_id = _receiving_actor_id(obj)
+        if receiving_actor_id is None:
+            logger.error(
+                "InboxPipeline could not resolve receiving actor for '%s'",
+                activity_id,
+            )
+            return None
+
+        queue_dl = cast(
+            ActorScopedDataLayer, self._dl.clone_for_actor(receiving_actor_id)
+        )
+        try:
+            event = prepare_for_dispatch(activity=obj)
+            event = event.model_copy(
+                update={"receiving_actor_id": receiving_actor_id}
+            )
+            case_id = _activity_context_id(obj, event)
+
+            if (
+                case_id is not None
+                and event.semantic_type
+                != MessageSemantics.ANNOUNCE_VULNERABILITY_CASE
+                and not is_case_model(self._dl.read(case_id))
+            ):
+                if _expire_pending_case_activities(
+                    case_id=case_id,
+                    actor_id=receiving_actor_id,
+                    dl=self._dl,
+                    queue_dl=queue_dl,
+                ):
+                    return None
+                _queue_pending_case_activity(
+                    queue_dl=queue_dl,
+                    case_id=case_id,
+                    activity_id=event.activity_id,
+                    case_actor_id=event.actor_id,
+                )
+                return None
+
+            dispatch(event=event, dl=self._dl, dispatcher=self._dispatcher)
+            if (
+                event.semantic_type
+                == MessageSemantics.ANNOUNCE_VULNERABILITY_CASE
+                and case_id is not None
+            ):
+                _replay_pending_case_activities(
+                    case_id=case_id,
+                    dl=self._dl,
+                    queue_dl=queue_dl,
+                    actor_id=receiving_actor_id,
+                )
+            return event
+        except Exception:
+            queue_dl.inbox_append(activity_id)
+            logger.error(
+                "Error processing inbox item '%s' in InboxPipeline",
+                activity_id,
+                exc_info=True,
+            )
+            return None
+
+
+def build_test_pipeline(dl: DataLayer) -> InboxPipeline:
+    """Build a test pipeline with production dispatcher wiring."""
+    return InboxPipeline(dispatcher=make_dispatcher(), dl=dl)


### PR DESCRIPTION
Closes #769

Added an InboxPipeline class for single-item inbox processing with injected dispatcher and datalayer, plus a build_test_pipeline factory using production dispatcher wiring.

Added a test_pipeline fixture backed by in-memory SqliteDataLayer and new routing safety-net tests covering report, case, embargo, note, actor, status, and sync domains, plus deferral behavior for unknown case context.

The pipeline now reuses inbox-handler expiry and replay behavior to keep defer/replay semantics aligned with production.