### PR TITLE
docs: plan issue #782 — peer broadcast failure semantics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,6 +313,12 @@ Short entries are reproduced here; longer ones are referenced below.
 - **All Protocol-Significant Behavior MUST Be in the BT** — see [notes/bt-integration.md](notes/bt-integration.md)
 - **Protocol Event Cascades (Cascading Automation)** — see [notes/bt-integration.md](notes/bt-integration.md)
 - **Post-BT Procedural Cascade Anti-Pattern** — see [notes/bt-integration.md](notes/bt-integration.md)
+- **Peer Broadcast Nodes Must Not Mask Delivery Failure with SUCCESS** — For
+  protocol-visible fan-out, BT nodes/subtrees MUST return `FAILURE` when
+  activity construction or outbox enqueue fails. A guaranteed SUCCESS fallback
+  causes silent state divergence across peers. See
+  [notes/peer-broadcast-failure-semantics.md](notes/peer-broadcast-failure-semantics.md)
+  and `specs/behavior-tree-integration.yaml` BT-14-001.
 - **BT Node MUST NOT Call a Use Case** — A BT node's `update()` MUST NOT
   instantiate or call a use-case class. Use cases create BTs; BT nodes are
   leaves of those trees. Calling a use case from inside a node creates an

--- a/notes/README.md
+++ b/notes/README.md
@@ -175,6 +175,14 @@ and subtree composition examples.
 uses py_trees, deciding whether a new use case needs a BT, or diagnosing BT
 execution issues.
 
+**`peer-broadcast-failure-semantics.md`**
+Fail-fast requirements for protocol-visible peer fan-out in BT paths:
+broadcast preparation/enqueue errors must return `FAILURE`, and success
+fallbacks must not mask delivery failure. Includes scope boundaries for this
+phase and shared-helper guidance.
+**Load when**: modifying status/embargo broadcast paths, defining fan-out
+error behavior, or planning delivery-reliability follow-on work.
+
 **`bt-composability.md`**
 Fractal composability pattern for BT nodes and subtrees (formerly split between
 `bt-composability.md` and `bt-reusability.md`): the "trunkless branch" model,

--- a/notes/peer-broadcast-failure-semantics.md
+++ b/notes/peer-broadcast-failure-semantics.md
@@ -1,0 +1,54 @@
+---
+title: Peer Broadcast Failure Semantics
+status: active
+related_specs:
+  - specs/behavior-tree-integration.yaml
+related_issues:
+  - https://github.com/CERTCC/Vultron/issues/782
+---
+
+# Peer Broadcast Failure Semantics
+
+## Problem
+
+Some behavior-tree fan-out paths treat broadcast delivery failures as
+non-fatal and still report `SUCCESS`. This creates a false-success condition:
+local workflows appear complete while peers miss state updates.
+
+In a federated CVD protocol, this is a correctness risk because participant
+state can silently diverge without any explicit signal to callers.
+
+## Required Behavior
+
+For protocol-visible peer fan-out:
+
+1. Broadcast preparation or enqueue failure must return `FAILURE`.
+2. Parent BT control flow must be able to react to that failure.
+3. A guaranteed-success fallback that masks delivery failure is not allowed.
+
+These rules are captured in `BT-14-001`.
+
+## Design Direction
+
+Use a shared helper/subtree for fan-out phases:
+
+1. Resolve sender/manager context.
+2. Filter recipient set.
+3. Construct broadcast activity.
+4. Enqueue to outbox.
+
+This keeps failure semantics consistent across domains (status, embargo, and
+future peer-broadcast paths). This direction is captured in `BT-14-002`.
+
+## Scope Boundary
+
+This guidance addresses fail-fast semantics and consistency of existing
+broadcast paths.
+
+Out of scope for this phase:
+
+- Protocol-level delivery guarantees (`at-least-once`, `exactly-once`)
+- Queue durability redesign
+- Full dead-letter pipeline design
+
+Those can be layered later without reintroducing silent success behavior.

--- a/plan/history/2606/learning/CONCERN-782.md
+++ b/plan/history/2606/learning/CONCERN-782.md
@@ -1,0 +1,44 @@
+---
+source: CONCERN-782
+timestamp: '2026-06-08T20:25:22.624469+00:00'
+title: Silent broadcast failure allows undetected peer state divergence
+type: learning
+---
+
+## Summary
+
+`BroadcastStatusToPeersNode` and similar broadcast nodes treat delivery failures as non-fatal: the BT node always returns `SUCCESS` regardless of whether peers actually received the update. Because there is no retry, dead-letter queue, or visibility mechanism, a failed broadcast leaves peers in a silently diverged state with no observable signal. The same "non-fatal" pattern appears in at least two places, suggesting broadcast logic is not yet centralized.
+
+## Category
+
+- [x] Top risk
+- [ ] Technical debt
+- [ ] Security
+- [ ] Performance / scaling
+- [ ] Fragile / high-churn area
+- [ ] Other
+
+## Severity
+
+high
+
+## Evidence
+
+- `vultron/core/behaviors/status/nodes.py` — line 630: `BroadcastStatusToPeersNode` docstring "Always returns SUCCESS (failure to broadcast is not fatal)"; `py_trees.behaviours.Success` fallback at line 683 enforces this contract
+- `vultron/core/behaviors/embargo/nodes.py` — line 265: same "non-fatal" pattern in embargo broadcast path
+- Two independent broadcast sites suggest fan-out delivery is not yet centralized, making a systematic fix harder
+
+## Impact if Ignored
+
+Peers receive no notification when a broadcast fails, so state silently diverges. There is no retry, dead-letter queue, or observability mechanism. In a federated protocol whose purpose is to synchronize independent actors around a shared case log, undetected delivery failure is a top-level correctness risk.
+
+## Suggested Action
+
+1. Change broadcast nodes to return `FAILURE` on delivery errors so the parent BT can react (retry, alert, or abort the workflow).
+2. Centralize all peer fan-out broadcast logic into a single shared module so retry and dead-letter support can be added in one place rather than patched at each call site.
+3. Evaluate whether a dead-letter or at-least-once delivery guarantee is needed at the protocol level (relates to #766 — Federation & Delivery Infrastructure).
+
+**Resolved**: 2026-06-08 — implementation tracked in #834, #835.
+Docs PR: [#833](https://github.com/CERTCC/Vultron/pull/833).
+Spec: `specs/behavior-tree-integration.yaml`.
+Notes: `notes/peer-broadcast-failure-semantics.md`.

--- a/specs/behavior-tree-integration.yaml
+++ b/specs/behavior-tree-integration.yaml
@@ -264,3 +264,33 @@ groups:
       - rel_type: refines
         spec_id: BT-13-001
         note: Scope is all BT execution sites, not just sync
+- id: BT-14
+  title: Peer Broadcast Failure Semantics
+  kind: domain
+  specs:
+  - id: BT-14-001
+    priority: MUST
+    statement: >-
+      Any BT node or subtree that performs protocol-visible peer broadcast
+      fan-out MUST return FAILURE when broadcast preparation or outbox
+      enqueueing fails. A guaranteed SUCCESS fallback that masks delivery
+      failure MUST_NOT be used.
+    rationale: >-
+      Silent success on failed fan-out causes undetected peer state divergence
+      and hides correctness faults from parent tree control flow.
+    relationships:
+    - rel_type: refines
+      spec_id: BT-06-001
+      note: Broadcast fan-out is protocol-significant behavior
+    - rel_type: refines
+      spec_id: BT-04-004
+      note: Delivery failures must propagate to handler error paths
+  - id: BT-14-002
+    priority: SHOULD
+    statement: >-
+      Peer broadcast fan-out paths SHOULD reuse a shared helper/subtree for
+      recipient filtering, activity construction, and outbox enqueueing so the
+      failure contract is consistent across workflow domains.
+    rationale: >-
+      Duplicated fan-out implementations drift over time and re-introduce
+      silent-failure behavior in only some pathways.


### PR DESCRIPTION
Docs-only PR for issue #782.

Closes #782

No .py files changed.