### PR TITLE
Add BT to update-case received use case

### DIFF
--- a/plan/history/2606/implementation/ISSUE-760.md
+++ b/plan/history/2606/implementation/ISSUE-760.md
@@ -1,0 +1,12 @@
+---
+source: ISSUE-760
+timestamp: '2026-06-09T13:54:24.821869+00:00'
+title: Update-case BT integration
+type: implementation
+---
+
+## Issue #760 — Add BT to UpdateCaseReceivedUseCase and fix post-BT cascade anti-pattern
+
+Implemented a BT-backed update-case workflow with ownership and embargo checks, plus in-tree broadcast delivery. `UpdateCaseReceivedUseCase` now delegates to `BTBridge`, and the new tree keeps the broadcast inside the sequence instead of a post-execute cascade.
+
+PR: [#837](https://github.com/CERTCC/Vultron/pull/837)

--- a/test/core/use_cases/received/test_case.py
+++ b/test/core/use_cases/received/test_case.py
@@ -33,6 +33,15 @@ from vultron.core.use_cases.received.case import (
     EngageCaseReceivedUseCase,
     UpdateCaseReceivedUseCase,
 )
+from vultron.core.behaviors.case.update_tree import (
+    create_update_case_received_tree,
+)
+from vultron.core.behaviors.case.nodes.update import (
+    ApplyCaseUpdateNode,
+    BroadcastCaseUpdateNode,
+    CaptureCaseUpdateBroadcastExclusionsNode,
+    CheckCaseUpdateOwnerNode,
+)
 from vultron.wire.as2.rehydration import rehydrate as real_rehydrate
 from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
 from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
@@ -275,6 +284,63 @@ class TestCaseUseCases:
 
         assert not any("has not accepted" in r.message for r in caplog.records)
 
+    def test_update_case_ignores_non_participant_objects_in_embargo_check(
+        self, make_payload
+    ):
+        """Non-participant objects referenced by the case must not be excluded."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        owner_id = "https://example.org/users/owner"
+        actor_id = "https://example.org/users/alice"
+        case_id = "https://example.org/cases/uc6b"
+        embargo = EmbargoEvent(id_="https://example.org/embargoes/em6b")
+        dl.create(embargo)
+
+        bogus_ref = VultronActivity(
+            type_="Announce",
+            actor=owner_id,
+            object_=case_id,
+        )
+        dl.create(bogus_ref)
+
+        case_actor = VultronCaseActor(
+            id_=f"{case_id}/actor",
+            name=f"CaseActor for {case_id}",
+            attributed_to=owner_id,
+            context=case_id,
+        )
+        dl.create(case_actor)
+
+        case = VulnerabilityCase(
+            id_=case_id,
+            name="Original",
+            attributed_to=owner_id,
+            active_embargo=embargo.id_,
+        )
+        case.actor_participant_index[actor_id] = bogus_ref.id_
+        dl.create(case)
+
+        updated_case = VulnerabilityCase(
+            id_=case_id,
+            name="Updated",
+            attributed_to=owner_id,
+        )
+        activity = update_case_activity(updated_case, actor=owner_id)
+        event = make_payload(activity)
+
+        UpdateCaseReceivedUseCase(dl, event).execute()
+
+        refreshed_actor = dl.read(case_actor.id_)
+        assert refreshed_actor is not None
+        refreshed_actor = cast(VultronCaseActor, refreshed_actor)
+        assert len(refreshed_actor.outbox.items) == 1
+
+        broadcast_id = refreshed_actor.outbox.items[0]
+        broadcast = dl.read(broadcast_id)
+        assert broadcast is not None
+        broadcast = cast(VultronActivity, broadcast)
+        assert broadcast.to is not None
+        assert actor_id in broadcast.to
+
     # ------------------------------------------------------------------
     # Broadcast tests (CM-06-001, CM-06-002)
     # ------------------------------------------------------------------
@@ -436,6 +502,83 @@ class TestCaseUseCases:
         broadcast = cast(VultronActivity, broadcast)
         assert broadcast.to is not None
         assert set(broadcast.to) == {alice, bob}
+
+    def test_update_case_bt_structure_includes_broadcast_node(
+        self, make_payload
+    ):
+        """UpdateCaseBT keeps ownership, embargo, update, and broadcast in-tree."""
+        owner_id = "https://example.org/users/owner"
+        case_id = "https://example.org/cases/bt1"
+        updated_case = VulnerabilityCase(
+            id_=case_id, name="Updated", attributed_to=owner_id
+        )
+        activity = update_case_activity(updated_case, actor=owner_id)
+        event = make_payload(activity)
+
+        tree = create_update_case_received_tree(
+            case_id=case_id,
+            actor_id=owner_id,
+            request=event,
+        )
+
+        assert tree.name == "UpdateCaseBT"
+        assert [child.__class__ for child in tree.children] == [
+            CheckCaseUpdateOwnerNode,
+            CaptureCaseUpdateBroadcastExclusionsNode,
+            ApplyCaseUpdateNode,
+            BroadcastCaseUpdateNode,
+        ]
+
+    def test_update_case_bt_executes_without_post_bt_broadcast(
+        self, make_payload, monkeypatch
+    ):
+        """UpdateCaseBT handles the broadcast internally instead of after execute()."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        owner_id = "https://example.org/users/owner"
+        participant_id = "https://example.org/users/alice"
+        case_id = "https://example.org/cases/bt2"
+
+        case_actor = VultronCaseActor(
+            id_=f"{case_id}/actor",
+            name=f"CaseActor for {case_id}",
+            attributed_to=owner_id,
+            context=case_id,
+        )
+        dl.create(case_actor)
+
+        case = VulnerabilityCase(
+            id_=case_id,
+            name="Original",
+            attributed_to=owner_id,
+        )
+        case.actor_participant_index[participant_id] = (
+            "https://example.org/participants/p-bt2"
+        )
+        dl.create(case)
+
+        updated_case = VulnerabilityCase(
+            id_=case_id,
+            name="Updated",
+            attributed_to=owner_id,
+        )
+        activity = update_case_activity(updated_case, actor=owner_id)
+        event = make_payload(activity)
+
+        def _should_not_be_called(*args, **kwargs):
+            raise AssertionError("post-BT broadcast helper should not run")
+
+        monkeypatch.setattr(
+            UpdateCaseReceivedUseCase,
+            "_broadcast_case_update",
+            _should_not_be_called,
+        )
+
+        UpdateCaseReceivedUseCase(dl, event).execute()
+
+        refreshed_actor = dl.read(case_actor.id_)
+        assert refreshed_actor is not None
+        refreshed_actor = cast(VultronCaseActor, refreshed_actor)
+        assert len(refreshed_actor.outbox.items) == 1
 
 
 class TestEngageDeferCaseBTFailureReason:

--- a/vultron/core/behaviors/case/nodes/__init__.py
+++ b/vultron/core/behaviors/case/nodes/__init__.py
@@ -52,6 +52,12 @@ from vultron.core.behaviors.case.nodes.participant import (
     CreateCaseParticipantNode,
     _create_and_attach_participant,
 )
+from vultron.core.behaviors.case.nodes.update import (
+    ApplyCaseUpdateNode,
+    BroadcastCaseUpdateNode,
+    CaptureCaseUpdateBroadcastExclusionsNode,
+    CheckCaseUpdateOwnerNode,
+)
 from vultron.core.behaviors.helpers import UpdateActorOutbox  # noqa: F401
 
 __all__ = [
@@ -74,6 +80,11 @@ __all__ = [
     "SendOfferCaseManagerRoleNode",
     # lifecycle
     "CommitCaseLogEntryNode",
+    # update
+    "CheckCaseUpdateOwnerNode",
+    "CaptureCaseUpdateBroadcastExclusionsNode",
+    "ApplyCaseUpdateNode",
+    "BroadcastCaseUpdateNode",
     # re-exported from helpers (backward compat)
     "UpdateActorOutbox",
 ]

--- a/vultron/core/behaviors/case/nodes/update.py
+++ b/vultron/core/behaviors/case/nodes/update.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Action and condition nodes for case update behavior trees."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import py_trees
+from py_trees.common import Status
+
+from vultron.core.behaviors.case.update_support import (
+    apply_update_case_fields,
+    broadcast_case_update,
+    find_excluded_actor_ids,
+)
+from vultron.core.behaviors.helpers import (
+    DataLayerAction,
+    DataLayerCondition,
+)
+from vultron.core.models.events.case import UpdateCaseReceivedEvent
+from vultron.core.models.protocols import is_case_model
+from vultron.core.use_cases._helpers import _as_id
+
+
+class CheckCaseUpdateOwnerNode(DataLayerCondition):
+    """Return SUCCESS when the current actor owns the case."""
+
+    def __init__(self, case_id: str, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self.case_id = case_id
+
+    def update(self) -> Status:
+        if self.datalayer is None or self.actor_id is None:
+            self.feedback_message = "DataLayer or actor_id not available"
+            self.logger.error(
+                "%s: DataLayer or actor_id not available", self.name
+            )
+            return Status.FAILURE
+
+        case = self.datalayer.read(self.case_id)
+        if not is_case_model(case):
+            self.feedback_message = f"case '{self.case_id}' not found"
+            self.logger.warning(
+                "%s: case '%s' not found in DataLayer",
+                self.name,
+                self.case_id,
+            )
+            return Status.FAILURE
+
+        owner_id = _as_id(case.attributed_to)
+        if owner_id != self.actor_id:
+            self.feedback_message = f"actor '{self.actor_id}' is not the owner of case '{self.case_id}'"
+            self.logger.info(
+                "%s: actor '%s' is not the owner of case '%s' (owner: '%s')"
+                " — skipping update-case handling",
+                self.name,
+                self.actor_id,
+                self.case_id,
+                owner_id,
+            )
+            return Status.FAILURE
+        return Status.SUCCESS
+
+
+class CaptureCaseUpdateBroadcastExclusionsNode(DataLayerCondition):
+    """Resolve embargo-based broadcast exclusions for the case update."""
+
+    def __init__(self, case_id: str, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self.case_id = case_id
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="excluded_actor_ids", access=py_trees.common.Access.WRITE
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.feedback_message = "DataLayer not available"
+            self.logger.error("%s: DataLayer not available", self.name)
+            return Status.FAILURE
+
+        case = self.datalayer.read(self.case_id)
+        if not is_case_model(case):
+            self.feedback_message = f"case '{self.case_id}' not found"
+            self.logger.warning(
+                "%s: case '%s' not found in DataLayer",
+                self.name,
+                self.case_id,
+            )
+            return Status.FAILURE
+
+        self.blackboard.excluded_actor_ids = find_excluded_actor_ids(
+            case, self.datalayer
+        )
+        return Status.SUCCESS
+
+
+class ApplyCaseUpdateNode(DataLayerAction):
+    """Apply mutable fields from the inbound update payload to the case."""
+
+    def __init__(
+        self,
+        case_id: str,
+        request: UpdateCaseReceivedEvent,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self.case_id = case_id
+        self.request = request
+
+    def update(self) -> Status:
+        if self.datalayer is None or self.actor_id is None:
+            self.logger.error(
+                "%s: DataLayer or actor_id not available", self.name
+            )
+            return Status.FAILURE
+
+        stored_case = self.datalayer.read(self.case_id)
+        if not is_case_model(stored_case):
+            self.logger.warning(
+                "%s: case '%s' not found in DataLayer",
+                self.name,
+                self.case_id,
+            )
+            return Status.FAILURE
+
+        if apply_update_case_fields(stored_case, self.request):
+            self.datalayer.save(stored_case)
+            self.logger.info(
+                "%s: Actor '%s' updated case '%s'",
+                self.name,
+                self.actor_id,
+                self.case_id,
+            )
+        else:
+            self.logger.info(
+                "%s: object for case '%s' is a reference only — no fields to apply",
+                self.name,
+                self.case_id,
+            )
+        return Status.SUCCESS
+
+
+class BroadcastCaseUpdateNode(DataLayerAction):
+    """Broadcast the updated case to eligible participants."""
+
+    def __init__(self, case_id: str, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self.case_id = case_id
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="excluded_actor_ids", access=py_trees.common.Access.READ
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.feedback_message = "DataLayer not available"
+            self.logger.error("%s: DataLayer not available", self.name)
+            return Status.FAILURE
+
+        case = self.datalayer.read(self.case_id)
+        if not is_case_model(case):
+            self.feedback_message = f"case '{self.case_id}' not found"
+            self.logger.warning(
+                "%s: case '%s' not found in DataLayer",
+                self.name,
+                self.case_id,
+            )
+            return Status.FAILURE
+
+        try:
+            excluded_actor_ids = self.blackboard.get("excluded_actor_ids")
+        except KeyError:
+            self.feedback_message = (
+                "excluded_actor_ids not found in blackboard"
+            )
+            self.logger.error(
+                "%s: excluded_actor_ids not found in blackboard", self.name
+            )
+            return Status.FAILURE
+
+        if not isinstance(excluded_actor_ids, set):
+            self.feedback_message = "excluded_actor_ids is not a set"
+            self.logger.error("%s: excluded_actor_ids is not a set", self.name)
+            return Status.FAILURE
+
+        broadcast_case_update(
+            self.datalayer,
+            self.case_id,
+            case,
+            excluded_actor_ids=excluded_actor_ids,
+        )
+        return Status.SUCCESS

--- a/vultron/core/behaviors/case/update_support.py
+++ b/vultron/core/behaviors/case/update_support.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Shared helpers for update-case BT nodes."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, cast
+
+from vultron.core.models.events.case import UpdateCaseReceivedEvent
+from vultron.core.models.protocols import is_participant_model
+from vultron.core.models.vultron_types import VultronActivity
+from vultron.core.ports.case_persistence import (
+    CaseOutboxPersistence,
+    CasePersistence,
+)
+from vultron.core.use_cases._helpers import _as_id
+
+logger = logging.getLogger(__name__)
+
+
+def apply_update_case_fields(
+    stored_case: Any, request: UpdateCaseReceivedEvent
+) -> bool:
+    """Apply mutable case fields from *request* onto *stored_case*."""
+    if request.object_type != "VulnerabilityCase" or request.case is None:
+        return False
+
+    for field in ("name", "summary", "content"):
+        value = getattr(request.case, field, None)
+        if value is not None:
+            setattr(stored_case, field, value)
+    return True
+
+
+def find_excluded_actor_ids(case: Any, dl: CasePersistence) -> set[str]:
+    """Return actor IDs excluded from case-update broadcast by active embargo."""
+    excluded: set[str] = set()
+    active_embargo = getattr(case, "active_embargo", None)
+    if active_embargo is None:
+        return excluded
+
+    embargo_id = _as_id(active_embargo)
+    for actor_id, participant_id in getattr(
+        case, "actor_participant_index", {}
+    ).items():
+        participant = dl.read(participant_id)
+        if participant is None:
+            logger.warning(
+                "update_case: could not read participant '%s' for embargo acceptance check",
+                participant_id,
+            )
+            continue
+        if not is_participant_model(participant):
+            continue
+        accepted_ids = getattr(participant, "accepted_embargo_ids", []) or []
+        if embargo_id not in accepted_ids:
+            logger.warning(
+                "update_case: participant '%s' (actor '%s') has not accepted the active "
+                "embargo '%s' — case update will not be broadcast to this participant "
+                "(CM-10-004)",
+                participant_id,
+                actor_id,
+                embargo_id,
+            )
+            excluded.add(actor_id)
+    return excluded
+
+
+def resolve_case_actor_id(case_id: str, dl: CasePersistence) -> str | None:
+    """Return the CaseActor ID associated with *case_id* if present."""
+    for service in dl.list_objects("Service"):
+        if getattr(service, "context", None) == case_id:
+            service_id = getattr(service, "id_", None)
+            if isinstance(service_id, str):
+                return service_id
+            return None
+    return None
+
+
+def broadcast_case_update(
+    dl: CasePersistence,
+    case_id: str,
+    case: Any,
+    excluded_actor_ids: set[str] | None = None,
+) -> None:
+    """Create and queue an Announce(activity) for a case update."""
+    excluded = excluded_actor_ids or set()
+    case_actor_id = resolve_case_actor_id(case_id, dl)
+    if case_actor_id is None:
+        logger.debug(
+            "update_case: no CaseActor found for case '%s' — skipping broadcast",
+            case_id,
+        )
+        return
+
+    participant_ids = [
+        actor_id
+        for actor_id in getattr(case, "actor_participant_index", {}).keys()
+        if actor_id not in excluded
+    ]
+    if not participant_ids:
+        logger.debug(
+            "update_case: no eligible participants in case '%s' — skipping broadcast",
+            case_id,
+        )
+        return
+
+    broadcast = VultronActivity(
+        type_="Announce",
+        actor=case_actor_id,
+        object_=case_id,
+        to=participant_ids,
+    )
+    try:
+        dl.create(broadcast)
+    except ValueError:
+        logger.debug(
+            "update_case: broadcast activity %s already exists — skipping",
+            broadcast.id_,
+        )
+        return
+
+    case_actor_obj = dl.read(case_actor_id)
+    if case_actor_obj is not None and hasattr(case_actor_obj, "outbox"):
+        cast(Any, case_actor_obj).outbox.items.append(broadcast.id_)
+        dl.save(case_actor_obj)
+
+    cast(CaseOutboxPersistence, dl).record_outbox_item(
+        case_actor_id, broadcast.id_
+    )
+    logger.info(
+        "update_case: CaseActor '%s' broadcast Announce for case '%s' to %d participants (CM-06-001)",
+        case_actor_id,
+        case_id,
+        len(participant_ids),
+    )

--- a/vultron/core/behaviors/case/update_tree.py
+++ b/vultron/core/behaviors/case/update_tree.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Case update behavior tree composition."""
+
+from __future__ import annotations
+
+import logging
+
+import py_trees
+
+from vultron.core.behaviors.case.nodes.update import (
+    ApplyCaseUpdateNode,
+    BroadcastCaseUpdateNode,
+    CaptureCaseUpdateBroadcastExclusionsNode,
+    CheckCaseUpdateOwnerNode,
+)
+from vultron.core.models.events.case import UpdateCaseReceivedEvent
+
+logger = logging.getLogger(__name__)
+
+
+def create_update_case_received_tree(
+    case_id: str,
+    actor_id: str,
+    request: UpdateCaseReceivedEvent,
+) -> py_trees.behaviour.Behaviour:
+    """Create the BT for UpdateCaseReceivedUseCase."""
+    root = py_trees.composites.Sequence(
+        name="UpdateCaseBT",
+        memory=False,
+        children=[
+            CheckCaseUpdateOwnerNode(case_id=case_id),
+            CaptureCaseUpdateBroadcastExclusionsNode(case_id=case_id),
+            ApplyCaseUpdateNode(case_id=case_id, request=request),
+            BroadcastCaseUpdateNode(case_id=case_id),
+        ],
+    )
+    logger.info(
+        "Created UpdateCaseBT for case=%s, actor=%s", case_id, actor_id
+    )
+    return root

--- a/vultron/core/use_cases/received/case.py
+++ b/vultron/core/use_cases/received/case.py
@@ -24,11 +24,14 @@ from vultron.core.ports.case_persistence import (
 from vultron.core.models.protocols import (
     CaseModel,
     is_case_model,
-    is_participant_model,
 )
 from vultron.core.states.rm import RM, is_rm_at_least
 from vultron.core.states.roles import CVDRole
 from vultron.core.use_cases._helpers import _as_id, update_participant_rm_state
+from vultron.core.behaviors.case.update_support import (
+    broadcast_case_update,
+    find_excluded_actor_ids,
+)
 
 if TYPE_CHECKING:
     from vultron.core.ports.trigger_activity import TriggerActivityPort
@@ -99,32 +102,7 @@ def _check_participant_embargo_acceptance(
     Returns a set of actor IDs whose case updates should be withheld per
     CM-10-004 (participants that have not accepted the active embargo).
     """
-    excluded: set[str] = set()
-    active_embargo = case.active_embargo
-    if active_embargo is None:
-        return excluded
-    embargo_id = _as_id(active_embargo)
-    for actor_id, participant_id in case.actor_participant_index.items():
-        participant = dl.read(participant_id)
-        if participant is None:
-            logger.warning(
-                "update_case: could not read participant '%s' for embargo acceptance check",
-                participant_id,
-            )
-            continue
-        if not is_participant_model(participant):
-            continue
-        if embargo_id not in participant.accepted_embargo_ids:
-            logger.warning(
-                "update_case: participant '%s' (actor '%s') has not accepted the active "
-                "embargo '%s' — case update will not be broadcast to this participant "
-                "(CM-10-004)",
-                participant_id,
-                actor_id,
-                embargo_id,
-            )
-            excluded.add(actor_id)
-    return excluded
+    return find_excluded_actor_ids(case, dl)
 
 
 def _store_embedded_participants(
@@ -485,44 +463,31 @@ class UpdateCaseReceivedUseCase:
             logger.warning("update_case: missing case_id on request")
             return
 
-        stored_case = self._dl.read(case_id)
-        if not is_case_model(stored_case):
-            logger.warning(
-                "update_case: case '%s' not found in DataLayer — skipping",
-                case_id,
-            )
-            return
+        from py_trees.common import Status
 
-        owner_id = _as_id(stored_case.attributed_to)
-        if owner_id != actor_id:
-            logger.warning(
-                "update_case: actor '%s' is not the owner of case '%s' — skipping update",
-                actor_id,
-                case_id,
-            )
-            return
-
-        excluded_actor_ids = _check_participant_embargo_acceptance(
-            stored_case, self._dl
+        from vultron.core.behaviors.bridge import BTBridge
+        from vultron.core.behaviors.case.update_tree import (
+            create_update_case_received_tree,
         )
 
-        if (
-            request.object_type == "VulnerabilityCase"
-            and request.case is not None
-        ):
-            for field in ("name", "summary", "content"):
-                value = getattr(request.case, field, None)
-                if value is not None:
-                    setattr(stored_case, field, value)
-            self._dl.save(stored_case)
-            logger.info("Actor '%s' updated case '%s'", actor_id, case_id)
-        else:
-            logger.info(
-                "update_case: object for case '%s' is a reference only — no fields to apply",
+        tree = create_update_case_received_tree(
+            case_id=case_id,
+            actor_id=actor_id,
+            request=request,
+        )
+        bridge = BTBridge(datalayer=self._dl)
+        result = bridge.execute_with_setup(
+            tree=tree,
+            actor_id=actor_id,
+            activity=request,
+        )
+        if result.status != Status.SUCCESS:
+            logger.warning(
+                "UpdateCaseBT did not succeed for actor '%s' / case '%s': %s",
+                actor_id,
                 case_id,
+                BTBridge.get_failure_reason(tree),
             )
-
-        self._broadcast_case_update(case_id, stored_case, excluded_actor_ids)
 
     def _broadcast_case_update(
         self,
@@ -537,62 +502,7 @@ class UpdateCaseReceivedUseCase:
         Per CM-10-004, participants who have not accepted the active embargo are
         excluded from the broadcast.
         """
-        excluded = excluded_actor_ids or set()
-        # Locate the CaseActor (type_="Service") associated with this case
-        case_actor_id: str | None = None
-        for service in self._dl.list_objects("Service"):
-            if getattr(service, "context", None) == case_id:
-                case_actor_id = service.id_
-                break
-
-        if case_actor_id is None:
-            logger.debug(
-                "update_case: no CaseActor found for case '%s' — skipping broadcast",
-                case_id,
-            )
-            return
-
-        participant_ids = [
-            actor_id
-            for actor_id in case.actor_participant_index.keys()
-            if actor_id not in excluded
-        ]
-        if not participant_ids:
-            logger.debug(
-                "update_case: no eligible participants in case '%s' — skipping broadcast",
-                case_id,
-            )
-            return
-
-        broadcast = VultronActivity(
-            type_="Announce",
-            actor=case_actor_id,
-            object_=case_id,
-            to=participant_ids,
-        )
-        try:
-            self._dl.create(broadcast)
-        except ValueError:
-            logger.debug(
-                "update_case: broadcast activity %s already exists — skipping",
-                broadcast.id_,
-            )
-            return
-
-        case_actor_obj = self._dl.read(case_actor_id)
-        if case_actor_obj is not None and hasattr(case_actor_obj, "outbox"):
-            cast(Any, case_actor_obj).outbox.items.append(broadcast.id_)
-            self._dl.save(case_actor_obj)
-
-        # Enqueue for delivery via outbox_handler
-        self._dl.record_outbox_item(case_actor_id, broadcast.id_)
-
-        logger.info(
-            "update_case: CaseActor '%s' broadcast Announce for case '%s' to %d participants (CM-06-001)",
-            case_actor_id,
-            case_id,
-            len(participant_ids),
-        )
+        broadcast_case_update(self._dl, case_id, case, excluded_actor_ids)
 
 
 class EngageCaseReceivedUseCase:


### PR DESCRIPTION
Closes #760

Adds a dedicated update-case BT with ownership and embargo checks, moves the case-update broadcast into the tree, and routes UpdateCaseReceivedUseCase through BTBridge instead of a post-execute cascade.