### PR TITLE
docs(skills): require evidence before pre-existing failure triage

### DIFF
--- a/.agents/skills/bugfix/SKILL.md
+++ b/.agents/skills/bugfix/SKILL.md
@@ -118,8 +118,15 @@ focus hints from Phase 2 (e.g., `"wire layer"`, `"BT integration"`), then:
    Follow all project conventions.
 
 4. **Iterate** — Invoke `format-code`, `run-linters`, `run-tests`; refine
-   until all relevant tests pass. File incidental bugs via `manage-github-issue`;
-   do not pursue them now.
+   until all relevant tests pass.
+   - Format/lint/type failures are branch-owned and must be fixed directly.
+     Do not file incidental Bug issues for these categories.
+   - Test failures are assumed branch-owned until disproven with evidence.
+   - "Pre-existing/unrelated" is allowed only with clean-base proof plus at
+     least one causality check against the branch diff.
+   - If pre-existing is proven, create/update a Bug issue with evidence,
+     wire structured blockers via `manage-github-issue`, and add a handoff
+     comment with pickup context.
 
 5. **Finalize**:
    - Invoke `archive-history`:

--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -108,8 +108,29 @@ Invoke `deepen-context` with focus hints derived from the issue body
 
 1. Invoke `format-code`, then `run-linters`, then `run-tests`.
 2. Do not skip or delegate validation.
-3. File incidental bugs as Bug-type GitHub issues via `manage-github-issue`;
-   do not pursue them unless they block the current task.
+3. During validation failures, ownership defaults to the current branch:
+   - **Format/lint/type failures**: fix them directly; do not file incidental
+     bug issues for these categories.
+   - **Test failures**: assume the failure is caused by current changes until
+     disproven with evidence.
+4. A test failure may be classified as pre-existing/unrelated **only** after:
+   - A clean-base proof on current `main` (or equivalent documented evidence)
+     reproduces the same failure.
+   - At least one causality check against the branch diff is performed
+     (e.g., isolate or temporarily revert suspect hunks and re-run relevant
+     tests).
+5. If pre-existing is proven:
+   - Create or update a Bug issue via `manage-github-issue` with evidence:
+     failing command/output, clean-base proof, causality check, and explicit
+     blocked/unblocked impact on the current issue.
+   - Wire blocking relationships with `manage-github-issue` (use structured
+     blockers, not body-text markers).
+   - Add a handoff comment on that Bug issue with pickup context for the next
+     agent.
+   - Record the Bug link and blocked/unblocked decision in
+     `plan/BUILD_LEARNINGS.md`.
+6. If clean-base proof cannot be obtained in-session, do **not** classify the
+   failure as unrelated; continue treating it as branch-owned.
 
 ### Phase 7 — Pre-PR Code Review
 

--- a/.agents/skills/pr-comprehensive-fix/REFERENCE.md
+++ b/.agents/skills/pr-comprehensive-fix/REFERENCE.md
@@ -54,7 +54,8 @@ See [RESOLUTION-GUIDE.md](RESOLUTION-GUIDE.md) for strategies and examples.
 ## When Things Go Wrong
 
 - **Stuck PR** (multiple fix attempts, no progress) → Stop and report
-- **Integration test failure** (unclear cause) → Stop, don't auto-loop
+- **Integration test failure** (unclear cause) → Treat as PR-owned until
+  disproven; do not label unrelated without evidence
 - **Partial fix success** → Ask if you want to continue or iterate manually
 - **Comment is architectural** → Reply, don't mark resolved
 

--- a/.agents/skills/pr-comprehensive-fix/SKILL.md
+++ b/.agents/skills/pr-comprehensive-fix/SKILL.md
@@ -73,8 +73,14 @@ Based on Step 1 decision point:
 If tests fail:
 
 - Parse failure output
-- Offer to re-run `/pr fix ci` if compilation/test errors
-- Stop and report if human judgment needed
+- Keep ownership on current PR changes by default
+- Fix format/lint/type failures directly (no incidental Bug issue for these)
+- Allow "pre-existing/unrelated" only with clean-base proof + at least one
+  causality check against the branch diff
+- If pre-existing is proven, file/update a Bug issue with evidence and wire
+  structured blocking relationships via `manage-github-issue`
+- Add a handoff comment on the Bug issue, then continue or stop explicitly as
+  blocked/unblocked
 
 Proceed to resolve comments? (yes/no)
 
@@ -130,5 +136,5 @@ See [REFERENCE.md](REFERENCE.md) for:
 
 ---
 
-**Tip**: If CI failures are cryptic or suggest architectural issues, the skill
-will stop and ask for human judgment rather than loop endlessly on fixes.
+**Tip**: "Cryptic" failures are still branch-owned until disproven by evidence.
+Do not classify as unrelated without clean-base and causality proof.

--- a/.agents/skills/pr-comprehensive-fix/TESTING-LOGIC.md
+++ b/.agents/skills/pr-comprehensive-fix/TESTING-LOGIC.md
@@ -63,36 +63,42 @@ needs_integration = any(
 
 **Symptoms**: Test errors, assertion failures, import errors
 
-**Likely cause**: Code changes broke tests
+**Default assumption**: Current PR changes caused the failure until disproven.
 
 **Action**:
 
 1. Display failure output
-2. Ask if you want to rerun `/pr fix ci` to fix test errors
-3. If yes, rerun tests
-4. If still failing after 2 attempts, stop and ask for human intervention
+2. Fix branch-owned issues directly and rerun relevant validations
+3. Classify as pre-existing only after:
+   - clean-base proof on `main` (or equivalent documented evidence), and
+   - at least one causality check against the current PR diff
+4. If pre-existing is proven, create/update a Bug issue with evidence, wire
+   structured blockers via `manage-github-issue`, and post a handoff comment
+5. If evidence is incomplete, keep treating as PR-owned and continue debugging
 
 ### Integration Tests Fail ❌
 
 **Symptoms**: Demo startup failures, protocol errors, CI job timeout
 
-**Likely cause**: Demo or adapter changes broke the integration workflow
+**Default assumption**: Current PR changes caused the failure until disproven.
 
 **Action**:
 
 1. Display failure output (first 50 lines + last 20 for context)
-2. **Stop** — do not auto-retry
-3. Report the issue and suggest manual debugging
-4. Integration test failures usually indicate architectural issues
+2. Perform targeted causality checks against the PR diff
+3. Allow "unrelated/pre-existing" only with clean-base + causality evidence
+4. If pre-existing is proven, create/update a Bug issue with evidence, wire
+   blockers via `manage-github-issue`, and add a handoff comment
+5. Stop only after recording blocked/unblocked status with linked evidence
 
-**Why not auto-retry**: Integration tests are slow and often fail due to:
+**Why caution is needed**: Integration tests are slow and can fail due to:
 
 - Missing environment setup
 - Timing issues in demo orchestration
 - Architectural breaking changes
 - Infrastructure problems (docker, network)
 
-These need human judgment to diagnose.
+These still require evidence-based triage before any unrelated classification.
 
 ## Handling Partial Fixes
 
@@ -109,15 +115,15 @@ not all):
 
 ## When Test Results Suggest Stopping
 
-The skill will **stop and report** rather than auto-loop if:
+The skill may **stop and report** after evidence capture if:
 
-- Integration test failure with unclear root cause
+- Integration test failure with unclear root cause after causality checks
 - 2+ consecutive test failures after `/pr fix ci` attempts
 - Test output suggests missing context (env vars, setup, infrastructure)
 - Error suggests architectural issue (breaking change to core logic)
 
-In these cases, the skill reports the state and recommends manual investigation
-or discussion with reviewers.
+In these cases, the skill reports the state with linked Bug issue evidence,
+structured blockers, and explicit blocked/unblocked status.
 
 ## Future Enhancement: Integrate with `build` Skill
 

--- a/.agents/skills/run-tests/SKILL.md
+++ b/.agents/skills/run-tests/SKILL.md
@@ -73,6 +73,11 @@ uv run pytest --tb=short 2>&1 | tail -5
 - Integration tests are excluded from the default run by design (they involve
   network/disk I/O and run separately). Run them with `-m integration` when
   validating demo workflows or file-backed datalayer behavior.
+- This skill reports test output only; it does not authorize pre-existing/
+  unrelated conclusions from a single failure snippet.
+- Calling skills (`build`, `bugfix`, `pr-comprehensive-fix`) must treat test
+  failures as branch-owned by default and require evidence before labeling
+  failures as pre-existing.
 
 ## Examples
 


### PR DESCRIPTION
## Problem
Build-oriented workflows were too quick to classify failing validations—especially tests—as pre-existing or unrelated. In practice, that conclusion is rarely correct on `main` and was often reversed after deeper inspection, causing wasted cycles and weak handoffs.

## What this PR changes
This PR updates failure-triage guidance across four skills so the default behavior is **ownership-first** and unrelated classification is an **evidence-gated exception**.

1. **`build` skill**
- Makes Phase 6 explicit: validation failures are owned by the current branch by default.
- Separates policy by failure class:
  - format/lint/type → fix directly (no incidental bug filing)
  - tests → assume branch-caused until disproven
- Requires proof before "pre-existing/unrelated":
  - clean-base repro on current `main` (or equivalent documented evidence)
  - at least one causality check against current diff
- If pre-existing is proven, requires:
  - Bug issue create/update with concrete evidence
  - structured blocker wiring via `manage-github-issue`
  - handoff comment for next agent
  - blocked/unblocked decision recorded in `BUILD_LEARNINGS`

2. **`bugfix` skill**
- Aligns iterate-phase triage with the same ownership + evidence policy.
- Explicitly bans incidental Bug filing for format/lint/type failures.
- Requires structured blocker wiring + handoff when pre-existing test failures are proven.

3. **`pr-comprehensive-fix` skill docs (`SKILL.md`, `REFERENCE.md`, `TESTING-LOGIC.md`)**
- Rewrites test-failure handling to avoid early "unclear cause → stop" behavior.
- Adds evidence requirements before unrelated classification.
- Requires issue-backed documentation and blocker wiring when pre-existing is proven.
- Keeps stop conditions, but only after evidence capture and explicit blocked/unblocked reporting.

4. **`run-tests` skill**
- Clarifies scope: this skill reports test output; it does not authorize unrelated conclusions from a single snippet.
- Points calling skills to ownership-first triage rules.

## Why this structure
The intent is to prevent a recurring anti-pattern: "tests failed, probably pre-existing" before causality work is done. These changes force triage to move through a concrete decision path:

1. Own the failure
2. Attempt direct fix / causality checks
3. Only then classify as pre-existing (with proof)
4. If pre-existing, leave durable issue-linked handoff state

## Expected outcome
- Fewer premature "unrelated" conclusions
- Better first-pass fix rates in build flows
- Better continuity when true pre-existing blockers are discovered
- Cleaner dependency state on GitHub issues through structured blocker wiring

## Scope and non-goals
- **In scope:** skill guidance and triage policy language only
- **Out of scope:** runtime behavior changes to validation commands, CI config, or project test infrastructure