### PR TITLE
Decompose CreateCaseParticipantNode into composed BT subtree

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -58,3 +58,12 @@ header.
 - Case deferral tests should set canonical `to` recipients so actor-scoped
   queues are exercised under the same addressing assumptions as inbox
   processing.
+
+### 2026-06-09 ISSUE-751 — Conditional BT branches can replace inline node `if` logic cleanly
+
+- For god-node decomposition, represent optional behavior as an explicit
+  `Selector` subtree (`active-branch` then `no-active` guard) instead of inline
+  branching in a single `update()` method.
+- Blackboard handoff keys (`new_case_participant`, `participant_case`,
+  `new_participant_id`) make each leaf independently testable while preserving
+  end-to-end behavior.

--- a/plan/history/2606/implementation/ISSUE-751.md
+++ b/plan/history/2606/implementation/ISSUE-751.md
@@ -1,0 +1,16 @@
+---
+source: ISSUE-751
+timestamp: '2026-06-09T15:32:14.472995+00:00'
+title: Decompose CreateCaseParticipantNode into composed subtree
+type: implementation
+---
+
+## Issue #751 — God node decomposition: split CreateCaseParticipantNode into composed subtree
+
+Completed decomposition of CreateCaseParticipantNode into a composed behavior-tree subtree with named leaf nodes for participant status resolution, participant construction, attachment, event recording, conditional embargo signatory seeding, and outbox notification enqueue.
+
+The embargo seeding step now runs as an explicit conditional subtree (Selector + guarded sequence), replacing inline branching while preserving CM-14-005 behavior.
+
+Added unit coverage for subtree composition, conditional branch structure, and active-embargo signatory seeding.
+
+PR: [#840](https://github.com/CERTCC/Vultron/pull/840)

--- a/test/core/behaviors/case/nodes/test_participant.py
+++ b/test/core/behaviors/case/nodes/test_participant.py
@@ -28,12 +28,25 @@ import logging
 from typing import Any, cast
 
 import pytest
+import py_trees
 
 from vultron.core.behaviors.case.nodes import (
     CreateCaseOwnerParticipant,
     CreateCaseParticipantNode,
     _create_and_attach_participant,
 )
+from vultron.core.behaviors.case.nodes.participant import (
+    AttachParticipantToCaseNode,
+    CaseHasActiveEmbargoNode,
+    CaseHasNoActiveEmbargoNode,
+    CreateParticipantNode,
+    QueueAddParticipantNotificationNode,
+    RecordParticipantAddedEventNode,
+    ResolveParticipantAcceptedStatusNode,
+    SeedParticipantAsSignatoryIfEmbargoActiveNode,
+    SeedParticipantAsSignatoryNode,
+)
+from vultron.core.models.embargo_event import EmbargoEvent
 from vultron.core.models.actor_config import ActorConfig
 from vultron.core.models.vultron_types import (
     VultronCase,
@@ -41,6 +54,7 @@ from vultron.core.models.vultron_types import (
     VultronParticipant,
     VultronReport,
 )
+from vultron.core.states.participant_embargo_consent import PEC
 from vultron.core.states.roles import CVDRole
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Add
 from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
@@ -393,6 +407,33 @@ class TestCreateCaseParticipantNode:
         event_types = [e.event_type for e in stored_case.events]
         assert "participant_added" in event_types
 
+    def test_is_composed_subtree_of_named_leaf_nodes(self) -> None:
+        node = CreateCaseParticipantNode(
+            actor_id="https://example.org/actors/finder",
+            roles=[CVDRole.FINDER],
+        )
+
+        assert [type(child) for child in node.children] == [
+            ResolveParticipantAcceptedStatusNode,
+            CreateParticipantNode,
+            AttachParticipantToCaseNode,
+            RecordParticipantAddedEventNode,
+            SeedParticipantAsSignatoryIfEmbargoActiveNode,
+            QueueAddParticipantNotificationNode,
+        ]
+
+    def test_embargo_seed_is_conditional_subtree(self) -> None:
+        node = SeedParticipantAsSignatoryIfEmbargoActiveNode(
+            participant_actor_id="https://example.org/actors/finder"
+        )
+        assert isinstance(node, py_trees.composites.Selector)
+        assert isinstance(node.children[0], py_trees.composites.Sequence)
+        assert [type(child) for child in node.children[0].children] == [
+            CaseHasActiveEmbargoNode,
+            SeedParticipantAsSignatoryNode,
+        ]
+        assert type(node.children[1]) is CaseHasNoActiveEmbargoNode
+
     def test_emits_add_participant_activity(
         self,
         bt_scenario: BTTestScenario,
@@ -423,6 +464,34 @@ class TestCreateCaseParticipantNode:
             and getattr(act.target, "id_", act.target) == case_obj.id_
             for act in add_activities
         )
+
+    def test_seeds_participant_as_signatory_when_embargo_active(
+        self,
+        bt_scenario: BTTestScenario,
+        actor: VultronCaseActor,
+        case_obj: VultronCase,
+        actor_id: str,
+        finder_actor_id: str,
+    ) -> None:
+        embargo = EmbargoEvent(context=case_obj.id_)
+        bt_scenario.dl.create(embargo)
+        stored_case = cast(Any, bt_scenario.dl.read(case_obj.id_))
+        stored_case.active_embargo = embargo.id_
+        bt_scenario.dl.save(stored_case)
+
+        bt_scenario.run(
+            CreateCaseParticipantNode(
+                actor_id=finder_actor_id, roles=[CVDRole.FINDER]
+            ),
+            actor_id=actor_id,
+            case_id=case_obj.id_,
+        )
+
+        stored_case = cast(Any, bt_scenario.dl.read(case_obj.id_))
+        participant_id = stored_case.actor_participant_index[finder_actor_id]
+        participant = cast(Any, bt_scenario.dl.read(participant_id))
+        assert participant.embargo_consent_state == PEC.SIGNATORY
+        assert embargo.id_ in participant.accepted_embargo_ids
 
     def test_does_not_record_participant_added_event_for_case_owner(
         self,

--- a/vultron/core/behaviors/case/nodes/participant.py
+++ b/vultron/core/behaviors/case/nodes/participant.py
@@ -405,27 +405,386 @@ class CreateCaseOwnerParticipant(DataLayerAction):
             return Status.FAILURE
 
 
-class CreateCaseParticipantNode(DataLayerAction):
+class ResolveParticipantAcceptedStatusNode(DataLayerAction):
+    """Resolve or create report-phase RM.ACCEPTED status for the participant."""
+
+    def __init__(
+        self,
+        participant_actor_id: str,
+        report_id: str | None = None,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self.participant_actor_id = participant_actor_id
+        self.report_id = report_id
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="participant_accepted_status",
+            access=py_trees.common.Access.WRITE,
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.logger.error("%s: DataLayer not available", self.name)
+            return Status.FAILURE
+
+        self.blackboard.participant_accepted_status = (
+            _get_or_create_accepted_status(
+                self.datalayer,
+                self.participant_actor_id,
+                self.report_id,
+                self.name,
+                self.logger,
+            )
+        )
+        return Status.SUCCESS
+
+
+class CreateParticipantNode(DataLayerAction):
+    """Create an in-memory VultronParticipant and store it on the blackboard."""
+
+    def __init__(
+        self,
+        participant_actor_id: str,
+        roles: list[CVDRole],
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self.participant_actor_id = participant_actor_id
+        self.roles = roles
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="case_id", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="participant_accepted_status",
+            access=py_trees.common.Access.READ,
+        )
+        self.blackboard.register_key(
+            key="new_case_participant",
+            access=py_trees.common.Access.WRITE,
+        )
+        self.blackboard.register_key(
+            key="new_participant_id",
+            access=py_trees.common.Access.WRITE,
+        )
+
+    def update(self) -> Status:
+        case_id = self.blackboard.get("case_id")
+        if not isinstance(case_id, str):
+            self.logger.error("%s: case_id not found in blackboard", self.name)
+            return Status.FAILURE
+
+        accepted_status = self.blackboard.get("participant_accepted_status")
+        if accepted_status is not None and not isinstance(
+            accepted_status, ParticipantStatus
+        ):
+            self.logger.error(
+                "%s: participant_accepted_status has invalid type",
+                self.name,
+            )
+            return Status.FAILURE
+
+        participant = VultronParticipant(
+            attributed_to=self.participant_actor_id,
+            context=case_id,
+            case_roles=self.roles,
+            participant_statuses=(
+                [accepted_status] if accepted_status is not None else []
+            ),
+        )
+        self.blackboard.new_case_participant = participant
+        self.blackboard.new_participant_id = participant.id_
+        return Status.SUCCESS
+
+
+class AttachParticipantToCaseNode(DataLayerAction):
+    """Attach the participant to case surfaces and persist the participant row."""
+
+    def __init__(self, participant_actor_id: str, name: str | None = None):
+        super().__init__(name=name or self.__class__.__name__)
+        self.participant_actor_id = participant_actor_id
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="case_id", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="new_case_participant",
+            access=py_trees.common.Access.READ,
+        )
+        self.blackboard.register_key(
+            key="participant_case",
+            access=py_trees.common.Access.WRITE,
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.logger.error("%s: DataLayer not available", self.name)
+            return Status.FAILURE
+
+        case_id = self.blackboard.get("case_id")
+        participant = self.blackboard.get("new_case_participant")
+        if not isinstance(case_id, str):
+            self.logger.error("%s: case_id not found in blackboard", self.name)
+            return Status.FAILURE
+        if not isinstance(participant, VultronParticipant):
+            self.logger.error(
+                "%s: new_case_participant not found in blackboard",
+                self.name,
+            )
+            return Status.FAILURE
+
+        stored_case = _create_and_attach_participant(
+            self.datalayer,
+            participant,
+            case_id,
+            self.participant_actor_id,
+            self.logger,
+        )
+        if stored_case is None:
+            self.logger.error(
+                "%s: Case %s not found in DataLayer",
+                self.name,
+                case_id,
+            )
+            return Status.FAILURE
+
+        self.blackboard.participant_case = stored_case
+        return Status.SUCCESS
+
+
+class RecordParticipantAddedEventNode(DataLayerAction):
+    """Record participant_added event and persist case updates."""
+
+    def __init__(self, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="participant_case",
+            access=py_trees.common.Access.READ,
+        )
+        self.blackboard.register_key(
+            key="new_participant_id",
+            access=py_trees.common.Access.READ,
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.logger.error("%s: DataLayer not available", self.name)
+            return Status.FAILURE
+
+        stored_case = self.blackboard.get("participant_case")
+        participant_id = self.blackboard.get("new_participant_id")
+        if not is_case_model(stored_case) or not isinstance(
+            participant_id, str
+        ):
+            self.logger.error(
+                "%s: participant_case/new_participant_id missing in blackboard",
+                self.name,
+            )
+            return Status.FAILURE
+
+        stored_case.record_event(participant_id, "participant_added")
+        self.datalayer.save(stored_case)
+        return Status.SUCCESS
+
+
+class CaseHasActiveEmbargoNode(DataLayerAction):
+    """Condition node: SUCCESS when the case has an active embargo."""
+
+    def __init__(self, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="participant_case",
+            access=py_trees.common.Access.READ,
+        )
+
+    def update(self) -> Status:
+        stored_case = self.blackboard.get("participant_case")
+        if not is_case_model(stored_case):
+            self.logger.error(
+                "%s: participant_case missing in blackboard", self.name
+            )
+            return Status.FAILURE
+        return (
+            Status.SUCCESS
+            if _as_id(stored_case.active_embargo) is not None
+            else Status.FAILURE
+        )
+
+
+class CaseHasNoActiveEmbargoNode(DataLayerAction):
+    """Condition node: SUCCESS when no active embargo exists for this case."""
+
+    def __init__(self, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="participant_case",
+            access=py_trees.common.Access.READ,
+        )
+
+    def update(self) -> Status:
+        stored_case = self.blackboard.get("participant_case")
+        if not is_case_model(stored_case):
+            self.logger.error(
+                "%s: participant_case missing in blackboard", self.name
+            )
+            return Status.FAILURE
+        return (
+            Status.SUCCESS
+            if _as_id(stored_case.active_embargo) is None
+            else Status.FAILURE
+        )
+
+
+class SeedParticipantAsSignatoryNode(DataLayerAction):
+    """Seed the new participant as SIGNATORY when an embargo is active."""
+
+    def __init__(self, participant_actor_id: str, name: str | None = None):
+        super().__init__(name=name or self.__class__.__name__)
+        self.participant_actor_id = participant_actor_id
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="participant_case",
+            access=py_trees.common.Access.READ,
+        )
+        self.blackboard.register_key(
+            key="new_case_participant",
+            access=py_trees.common.Access.READ,
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.logger.error("%s: DataLayer not available", self.name)
+            return Status.FAILURE
+
+        stored_case = self.blackboard.get("participant_case")
+        participant = self.blackboard.get("new_case_participant")
+        if not is_case_model(stored_case) or not isinstance(
+            participant, VultronParticipant
+        ):
+            self.logger.error(
+                "%s: participant_case/new_case_participant missing in blackboard",
+                self.name,
+            )
+            return Status.FAILURE
+
+        active_embargo_id = _as_id(stored_case.active_embargo)
+        if active_embargo_id is None:
+            self.logger.error(
+                "%s: cannot seed SIGNATORY without active embargo",
+                self.name,
+            )
+            return Status.FAILURE
+
+        participant.embargo_consent_state = PEC.SIGNATORY
+        if active_embargo_id not in participant.accepted_embargo_ids:
+            participant.accepted_embargo_ids.append(active_embargo_id)
+        self.datalayer.save(participant)
+        self.logger.info(
+            "Seeded participant '%s' (actor '%s') as SIGNATORY"
+            " for active embargo in case '%s' (CM-14-005)",
+            participant.id_,
+            self.participant_actor_id,
+            stored_case.id_,
+        )
+        return Status.SUCCESS
+
+
+class SeedParticipantAsSignatoryIfEmbargoActiveNode(
+    py_trees.composites.Selector
+):
+    """Conditional subtree for CM-14-005 signatory seeding behavior."""
+
+    def __init__(self, participant_actor_id: str, name: str | None = None):
+        super().__init__(
+            name=name or self.__class__.__name__,
+            memory=False,
+            children=[
+                py_trees.composites.Sequence(
+                    name="SeedWhenActiveEmbargo",
+                    memory=False,
+                    children=[
+                        CaseHasActiveEmbargoNode(),
+                        SeedParticipantAsSignatoryNode(
+                            participant_actor_id=participant_actor_id
+                        ),
+                    ],
+                ),
+                CaseHasNoActiveEmbargoNode(),
+            ],
+        )
+
+
+class QueueAddParticipantNotificationNode(DataLayerAction):
+    """Queue Add(CaseParticipant) outbox notification for the sender actor."""
+
+    def __init__(self, participant_actor_id: str, name: str | None = None):
+        super().__init__(name=name or self.__class__.__name__)
+        self.participant_actor_id = participant_actor_id
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="case_id", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="new_participant_id",
+            access=py_trees.common.Access.READ,
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None or self.actor_id is None:
+            self.logger.error(
+                "%s: DataLayer or actor_id not available", self.name
+            )
+            return Status.FAILURE
+
+        case_id = self.blackboard.get("case_id")
+        participant_id = self.blackboard.get("new_participant_id")
+        if not isinstance(case_id, str) or not isinstance(participant_id, str):
+            self.logger.error(
+                "%s: case_id/new_participant_id not found in blackboard",
+                self.name,
+            )
+            return Status.FAILURE
+
+        if not _queue_participant_add_notification(
+            self.datalayer,
+            self.name,
+            self.logger,
+            self.actor_id,
+            self.participant_actor_id,
+            participant_id,
+            case_id,
+            trigger_activity=self.trigger_activity_factory,
+        ):
+            return Status.FAILURE
+        return Status.SUCCESS
+
+
+class CreateCaseParticipantNode(py_trees.composites.Sequence):
     """
-    Create and persist a CaseParticipant for the given actor, then attach
-    it to the case.
+    Composed subtree that creates and attaches a CaseParticipant.
 
-    Parameterized by ``actor_id`` (the actor being added as a participant)
-    and ``roles`` (the CVD roles to assign).
-
-    When ``report_id`` is supplied, the node reuses the deterministic
-    report-phase ``ParticipantStatus`` for ``RM.ACCEPTED`` that was
-    created during ``SubmitReportReceivedUseCase``, preserving engagement
-    history.
-
-    Emits ``AddParticipantToCaseActivity(object_=<CaseParticipant>)`` to
-    the actor's outbox so downstream actors are notified.  Using the typed
-    activity (not a bare ``VultronActivity``) satisfies MV-09-001 and
-    avoids the ``VultronOutboxObjectIntegrityError`` caused by bare-string
-    ``object_`` fields after dehydration.
-
-    Must run after ``CreateCaseNode`` (so ``case_id`` is on the blackboard)
-    and after ``CreateCaseOwnerParticipant``.
+    This decomposes participant creation into named leaf nodes so each step is
+    explicit and testable per BTND-07-001.
     """
 
     def __init__(
@@ -435,100 +794,25 @@ class CreateCaseParticipantNode(DataLayerAction):
         report_id: str | None = None,
         name: str | None = None,
     ) -> None:
-        super().__init__(name=name or self.__class__.__name__)
-        self.participant_actor_id = actor_id
-        self.roles = roles
-        self.report_id = report_id
-
-    def setup(self, **kwargs: Any) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="case_id", access=py_trees.common.Access.READ
-        )
-
-    def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.logger.error(
-                f"{self.name}: DataLayer or actor_id not available"
-            )
-            return Status.FAILURE
-
-        try:
-            case_id = self.blackboard.get("case_id")
-            if case_id is None:
-                self.logger.error(
-                    f"{self.name}: case_id not found in blackboard"
-                )
-                return Status.FAILURE
-
-            accepted_status = _get_or_create_accepted_status(
-                self.datalayer,
-                self.participant_actor_id,
-                self.report_id,
-                self.name,
-                self.logger,
-            )
-            participant = VultronParticipant(
-                attributed_to=self.participant_actor_id,
-                context=case_id,
-                case_roles=self.roles,
-                participant_statuses=(
-                    [accepted_status] if accepted_status is not None else []
+        super().__init__(
+            name=name or self.__class__.__name__,
+            memory=False,
+            children=[
+                ResolveParticipantAcceptedStatusNode(
+                    participant_actor_id=actor_id,
+                    report_id=report_id,
                 ),
-            )
-
-            stored_case = _create_and_attach_participant(
-                self.datalayer,
-                participant,
-                case_id,
-                self.participant_actor_id,
-                self.logger,
-            )
-            if stored_case is None:
-                self.logger.error(
-                    f"{self.name}: Case {case_id} not found in DataLayer"
-                )
-                return Status.FAILURE
-
-            stored_case.record_event(participant.id_, "participant_added")
-            self.datalayer.save(stored_case)
-
-            # CM-14-005: seed the new participant as SIGNATORY when a
-            # default embargo is already active at case initialization time.
-            if stored_case.active_embargo is not None:
-                active_embargo_id = _as_id(stored_case.active_embargo)
-                participant.embargo_consent_state = PEC.SIGNATORY
-                if (
-                    active_embargo_id
-                    and active_embargo_id
-                    not in participant.accepted_embargo_ids
-                ):
-                    participant.accepted_embargo_ids.append(active_embargo_id)
-                self.datalayer.save(participant)
-                self.logger.info(
-                    "Seeded participant '%s' (actor '%s') as SIGNATORY"
-                    " for active embargo in case '%s' (CM-14-005)",
-                    participant.id_,
-                    self.participant_actor_id,
-                    case_id,
-                )
-
-            if not _queue_participant_add_notification(
-                self.datalayer,
-                self.name,
-                self.logger,
-                self.actor_id,
-                self.participant_actor_id,
-                participant.id_,
-                case_id,
-                trigger_activity=self.trigger_activity_factory,
-            ):
-                return Status.FAILURE
-
-            return Status.SUCCESS
-
-        except Exception as e:
-            self.logger.error(
-                f"{self.name}: Error creating CaseParticipant: {e}"
-            )
-            return Status.FAILURE
+                CreateParticipantNode(
+                    participant_actor_id=actor_id,
+                    roles=roles,
+                ),
+                AttachParticipantToCaseNode(participant_actor_id=actor_id),
+                RecordParticipantAddedEventNode(),
+                SeedParticipantAsSignatoryIfEmbargoActiveNode(
+                    participant_actor_id=actor_id
+                ),
+                QueueAddParticipantNotificationNode(
+                    participant_actor_id=actor_id
+                ),
+            ],
+        )


### PR DESCRIPTION
Closes #751

Refactors CreateCaseParticipantNode from a single large action node into a composed subtree of named leaf nodes.

What changed:
- Added dedicated leaf nodes for status resolution, participant construction, attach, event recording, conditional signatory seeding, and notification enqueue.
- Replaced inline embargo branching with an explicit conditional subtree (Selector plus guarded sequence).
- Added unit tests for subtree structure, conditional branch structure, and active-embargo signatory seeding behavior.

Result:
- Removes the god-node update implementation and preserves behavior while making each step independently testable.