### PR TITLE
Refactor trigger embargo transitions into BT nodes

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -58,3 +58,12 @@ header.
 - Case deferral tests should set canonical `to` recipients so actor-scoped
   queues are exercised under the same addressing assumptions as inbox
   processing.
+
+### 2026-06-09 ISSUE-711 — Surface domain transition failures from BT action nodes
+
+- When strict state-machine transitions move into BT action nodes, use cases
+  still need original domain exception types (for example
+  `VultronInvalidStateTransitionError`) to preserve caller/test semantics.
+- A small BT node result channel (`result_out["error"]`) lets the use case
+  re-raise lifecycle domain errors directly instead of collapsing everything
+  into a generic BT failure message.

--- a/plan/history/2606/implementation/ISSUE-711.md
+++ b/plan/history/2606/implementation/ISSUE-711.md
@@ -1,0 +1,16 @@
+---
+source: ISSUE-711
+timestamp: '2026-06-09T15:34:45.378118+00:00'
+title: Trigger embargo BT action-node integration
+type: implementation
+---
+
+## Issue #711 — Trigger-side state machine BT integration: move EM/PEC transitions out of execute() into BT Action nodes
+
+Implemented trigger-side embargo BT integration for propose/accept/reject/terminate flows by adding dedicated embargo lifecycle BT action nodes and trigger trees, then routing the four `Svc*EmbargoUseCase` paths through `BTBridge` + those trees.
+
+This preserves strict EmbargoLifecycle transition semantics while ensuring the state-machine transition path is represented as BT actions before outbound sender fan-out.
+
+Added trigger-use-case coverage for propose and terminate paths in `test/core/use_cases/triggers/test_embargo.py`, so all four trigger embargo use cases now execute through BT-covered paths.
+
+PR: [#841](https://github.com/CERTCC/Vultron/pull/841)

--- a/test/core/use_cases/triggers/test_embargo.py
+++ b/test/core/use_cases/triggers/test_embargo.py
@@ -20,12 +20,14 @@ from vultron.core.use_cases.triggers.embargo import (
     SvcAcceptEmbargoUseCase,
     SvcProposeEmbargoUseCase,
     SvcRejectEmbargoUseCase,
+    SvcTerminateEmbargoUseCase,
     _is_case_owner,
 )
 from vultron.core.use_cases.triggers.requests import (
     AcceptEmbargoTriggerRequest,
     ProposeEmbargoTriggerRequest,
     RejectEmbargoTriggerRequest,
+    TerminateEmbargoTriggerRequest,
 )
 from vultron.errors import VultronInvalidStateTransitionError
 from vultron.wire.as2.factories import em_propose_embargo_activity
@@ -151,6 +153,28 @@ def _build_exited_case(
     )
     case.current_status.em_state = EM.EXITED
     dl.create(case)
+    return case
+
+
+def _build_no_embargo_case_with_case_manager(
+    dl: SqliteDataLayer, owner_id: str
+) -> VulnerabilityCase:
+    case = VulnerabilityCase(
+        name="No embargo case",
+        attributed_to=owner_id,
+    )
+    owner_participant = VendorParticipant(
+        attributed_to=owner_id,
+        context=case.id_,
+        embargo_consent_state=PEC.NO_EMBARGO,
+    )
+    owner_participant.add_role(CVDRole.CASE_MANAGER)
+    case.case_participants = [owner_participant.id_]
+    case.actor_participant_index = {owner_id: owner_participant.id_}
+    case.current_status.em_state = EM.NONE
+    case.active_embargo = None
+    dl.create(case)
+    dl.create(owner_participant)
     return case
 
 
@@ -322,3 +346,51 @@ def test_propose_embargo_invalid_state_does_not_persist_embargo(
 
     after = len(list(finder_dl.list_objects("EmbargoEvent")))
     assert after == before
+
+
+def test_propose_embargo_updates_case_state_via_bt_path(
+    finder_actor_and_dl: tuple[as_Service, SqliteDataLayer],
+) -> None:
+    """ProposeEmbargo transitions EM.NONE → EM.PROPOSED and queues activity."""
+    finder, finder_dl = finder_actor_and_dl
+    case = _build_no_embargo_case_with_case_manager(finder_dl, finder.id_)
+    request = ProposeEmbargoTriggerRequest(
+        actor_id=finder.id_,
+        case_id=case.id_,
+        end_time=datetime.now(tz=timezone.utc) + timedelta(days=7),
+    )
+
+    result = SvcProposeEmbargoUseCase(
+        finder_dl, request, trigger_activity=TriggerActivityAdapter(finder_dl)
+    ).execute()
+
+    assert "activity" in result
+    updated_case = cast(VulnerabilityCase, finder_dl.read(case.id_))
+    assert updated_case.current_status.em_state == EM.PROPOSED
+    assert len(updated_case.proposed_embargoes) == 1
+
+
+def test_terminate_embargo_transitions_case_to_exited_via_bt_path(
+    finder_actor_and_dl: tuple[as_Service, SqliteDataLayer],
+) -> None:
+    """TerminateEmbargo transitions ACTIVE → EXITED and clears active_embargo."""
+    finder, finder_dl = finder_actor_and_dl
+    owner = _persist_actor(finder_dl, "Vendor Co")
+    case, _, participant_id = _build_active_embargo_case(
+        finder_dl, owner.id_, finder.id_
+    )
+    request = TerminateEmbargoTriggerRequest(
+        actor_id=owner.id_,
+        case_id=case.id_,
+    )
+
+    result = SvcTerminateEmbargoUseCase(
+        finder_dl, request, trigger_activity=TriggerActivityAdapter(finder_dl)
+    ).execute()
+
+    assert "activity" in result
+    updated_case = cast(VulnerabilityCase, finder_dl.read(case.id_))
+    updated_participant = cast(CaseParticipant, finder_dl.read(participant_id))
+    assert updated_case.current_status.em_state == EM.EXITED
+    assert updated_case.active_embargo is None
+    assert updated_participant.embargo_consent_state == PEC.NO_EMBARGO.value

--- a/vultron/core/behaviors/embargo/trigger_nodes.py
+++ b/vultron/core/behaviors/embargo/trigger_nodes.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Trigger-side embargo lifecycle action nodes."""
+
+from py_trees.common import Status
+
+from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.models.embargo_event import EmbargoEvent
+from vultron.core.services.embargo_lifecycle import (
+    EmbargoLifecycle,
+    EmbargoLifecycleResult,
+    TransitionMode,
+)
+from vultron.errors import VultronError
+
+
+class PersistEmbargoEventNode(DataLayerAction):
+    """Persist the trigger-created embargo event before outbound fan-out."""
+
+    def __init__(self, embargo: EmbargoEvent, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._embargo = embargo
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.feedback_message = "DataLayer not available"
+            return Status.FAILURE
+        try:
+            self.datalayer.create(self._embargo)
+        except ValueError:
+            self.logger.warning(
+                "EmbargoEvent '%s' already exists", self._embargo.id_
+            )
+        return Status.SUCCESS
+
+
+class _EmbargoLifecycleNode(DataLayerAction):
+    """Base node for EmbargoLifecycle strict-mode transitions."""
+
+    def __init__(
+        self, result_out: dict[str, object], name: str | None = None
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._result_out = result_out
+
+    def _transition(
+        self, lifecycle: EmbargoLifecycle, actor_id: str
+    ) -> EmbargoLifecycleResult:
+        raise NotImplementedError
+
+    def update(self) -> Status:
+        if self.datalayer is None or self.actor_id is None:
+            self.feedback_message = "DataLayer or actor_id not available"
+            return Status.FAILURE
+
+        lifecycle = EmbargoLifecycle(persistence=self.datalayer)
+        try:
+            result = self._transition(lifecycle, self.actor_id)
+        except VultronError as exc:
+            self._result_out["error"] = exc
+            self.feedback_message = str(exc)
+            return Status.FAILURE
+
+        self._result_out["lifecycle_result"] = result
+        return Status.SUCCESS
+
+
+class ProposeEmbargoLifecycleNode(_EmbargoLifecycleNode):
+    """Apply STRICT propose/counter-propose transition."""
+
+    def __init__(
+        self,
+        case_id: str,
+        embargo_id: str,
+        result_out: dict[str, object],
+        name: str | None = None,
+    ) -> None:
+        super().__init__(result_out=result_out, name=name)
+        self._case_id = case_id
+        self._embargo_id = embargo_id
+
+    def _transition(
+        self, lifecycle: EmbargoLifecycle, actor_id: str
+    ) -> EmbargoLifecycleResult:
+        return lifecycle.propose_embargo(
+            case_id=self._case_id,
+            embargo_id=self._embargo_id,
+            actor_id=actor_id,
+            transition_mode=TransitionMode.STRICT,
+        )
+
+
+class AcceptEmbargoLifecycleNode(_EmbargoLifecycleNode):
+    """Apply STRICT accept-invite transition."""
+
+    def __init__(
+        self,
+        case_id: str,
+        embargo_id: str,
+        result_out: dict[str, object],
+        name: str | None = None,
+    ) -> None:
+        super().__init__(result_out=result_out, name=name)
+        self._case_id = case_id
+        self._embargo_id = embargo_id
+
+    def _transition(
+        self, lifecycle: EmbargoLifecycle, actor_id: str
+    ) -> EmbargoLifecycleResult:
+        return lifecycle.accept_embargo_invite(
+            case_id=self._case_id,
+            embargo_id=self._embargo_id,
+            actor_id=actor_id,
+            transition_mode=TransitionMode.STRICT,
+        )
+
+
+class RejectEmbargoLifecycleNode(_EmbargoLifecycleNode):
+    """Apply STRICT reject-invite transition."""
+
+    def __init__(
+        self,
+        case_id: str,
+        embargo_id: str,
+        result_out: dict[str, object],
+        name: str | None = None,
+    ) -> None:
+        super().__init__(result_out=result_out, name=name)
+        self._case_id = case_id
+        self._embargo_id = embargo_id
+
+    def _transition(
+        self, lifecycle: EmbargoLifecycle, actor_id: str
+    ) -> EmbargoLifecycleResult:
+        return lifecycle.reject_embargo_invite(
+            case_id=self._case_id,
+            embargo_id=self._embargo_id,
+            actor_id=actor_id,
+            transition_mode=TransitionMode.STRICT,
+        )
+
+
+class TerminateEmbargoLifecycleNode(_EmbargoLifecycleNode):
+    """Apply STRICT terminate-active-embargo transition."""
+
+    def __init__(
+        self,
+        case_id: str,
+        result_out: dict[str, object],
+        name: str | None = None,
+    ) -> None:
+        super().__init__(result_out=result_out, name=name)
+        self._case_id = case_id
+
+    def _transition(
+        self, lifecycle: EmbargoLifecycle, actor_id: str
+    ) -> EmbargoLifecycleResult:
+        return lifecycle.terminate_active_embargo(
+            case_id=self._case_id,
+            actor_id=actor_id,
+            transition_mode=TransitionMode.STRICT,
+        )

--- a/vultron/core/behaviors/embargo/trigger_tree.py
+++ b/vultron/core/behaviors/embargo/trigger_tree.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Trigger-side embargo BT compositions."""
+
+from collections.abc import Callable
+
+import py_trees
+
+from vultron.core.behaviors.embargo.trigger_nodes import (
+    AcceptEmbargoLifecycleNode,
+    PersistEmbargoEventNode,
+    ProposeEmbargoLifecycleNode,
+    RejectEmbargoLifecycleNode,
+    TerminateEmbargoLifecycleNode,
+)
+from vultron.core.behaviors.sender.send_tree import sender_side_bt
+from vultron.core.models.embargo_event import EmbargoEvent
+
+
+def propose_embargo_trigger_bt(
+    *,
+    case_id: str,
+    embargo: EmbargoEvent,
+    result_out: dict[str, object],
+    activity_builder: Callable[[str], list[str]],
+) -> py_trees.behaviour.Behaviour:
+    """Build trigger-side BT for proposing or revising an embargo."""
+    return py_trees.composites.Sequence(
+        name="ProposeEmbargoTriggerBT",
+        memory=False,
+        children=[
+            ProposeEmbargoLifecycleNode(
+                case_id=case_id,
+                embargo_id=embargo.id_,
+                result_out=result_out,
+            ),
+            PersistEmbargoEventNode(embargo=embargo),
+            sender_side_bt(case_id=case_id, activity_builder=activity_builder),
+        ],
+    )
+
+
+def accept_embargo_trigger_bt(
+    *,
+    case_id: str,
+    embargo_id: str,
+    result_out: dict[str, object],
+    activity_builder: Callable[[str], list[str]],
+) -> py_trees.behaviour.Behaviour:
+    """Build trigger-side BT for accepting an embargo invite."""
+    return py_trees.composites.Sequence(
+        name="AcceptEmbargoTriggerBT",
+        memory=False,
+        children=[
+            AcceptEmbargoLifecycleNode(
+                case_id=case_id,
+                embargo_id=embargo_id,
+                result_out=result_out,
+            ),
+            sender_side_bt(case_id=case_id, activity_builder=activity_builder),
+        ],
+    )
+
+
+def reject_embargo_trigger_bt(
+    *,
+    case_id: str,
+    embargo_id: str,
+    result_out: dict[str, object],
+    activity_builder: Callable[[str], list[str]],
+) -> py_trees.behaviour.Behaviour:
+    """Build trigger-side BT for rejecting an embargo invite."""
+    return py_trees.composites.Sequence(
+        name="RejectEmbargoTriggerBT",
+        memory=False,
+        children=[
+            RejectEmbargoLifecycleNode(
+                case_id=case_id,
+                embargo_id=embargo_id,
+                result_out=result_out,
+            ),
+            sender_side_bt(case_id=case_id, activity_builder=activity_builder),
+        ],
+    )
+
+
+def terminate_embargo_trigger_bt(
+    *,
+    case_id: str,
+    result_out: dict[str, object],
+    activity_builder: Callable[[str], list[str]],
+) -> py_trees.behaviour.Behaviour:
+    """Build trigger-side BT for terminating the active embargo."""
+    return py_trees.composites.Sequence(
+        name="TerminateEmbargoTriggerBT",
+        memory=False,
+        children=[
+            TerminateEmbargoLifecycleNode(
+                case_id=case_id, result_out=result_out
+            ),
+            sender_side_bt(case_id=case_id, activity_builder=activity_builder),
+        ],
+    )

--- a/vultron/core/use_cases/triggers/embargo.py
+++ b/vultron/core/use_cases/triggers/embargo.py
@@ -15,9 +15,19 @@
 
 import logging
 
+from py_trees.common import Status
+
+from vultron.core.behaviors.bridge import BTBridge
+from vultron.core.behaviors.embargo.trigger_tree import (
+    accept_embargo_trigger_bt,
+    propose_embargo_trigger_bt,
+    reject_embargo_trigger_bt,
+    terminate_embargo_trigger_bt,
+)
 from vultron.core.models.embargo_event import EmbargoEvent
 from vultron.core.services.embargo_lifecycle import (
     EmbargoLifecycle,
+    EmbargoLifecycleResult,
     TransitionMode,
 )
 from vultron.core.states.em import EM
@@ -81,21 +91,9 @@ class SvcProposeEmbargoUseCase:
                 "SvcProposeEmbargoUseCase requires a TriggerActivityPort"
             )
 
-        lifecycle = EmbargoLifecycle(persistence=dl)
-        lifecycle_result = lifecycle.propose_embargo(
-            case_id=case.id_,
-            embargo_id=embargo.id_,
-            actor_id=actor_id,
-            transition_mode=TransitionMode.STRICT,
-        )
-
-        try:
-            dl.create(embargo)
-        except ValueError:
-            logger.warning("EmbargoEvent '%s' already exists", embargo.id_)
-
         factory = self._trigger_activity
         captured: dict = {}
+        result_out: dict[str, object] = {}
 
         def _build_activities(case_manager_id: str) -> list[str]:
             proposal_id, proposal_dict = factory.propose_embargo(
@@ -107,14 +105,26 @@ class SvcProposeEmbargoUseCase:
             captured["activity"] = proposal_dict
             return [proposal_id]
 
-        send_case_actor_activity(
-            dl=dl,
+        bridge = BTBridge(datalayer=dl, trigger_activity=factory)
+        tree = propose_embargo_trigger_bt(
             case_id=case.id_,
-            actor_id=actor_id,
-            trigger_activity=factory,
-            failure_label="ProposeEmbargo",
+            embargo=embargo,
+            result_out=result_out,
             activity_builder=_build_activities,
         )
+        result = bridge.execute_with_setup(tree, actor_id=actor_id)
+        if result.status != Status.SUCCESS:
+            error = result_out.get("error")
+            if isinstance(error, Exception):
+                raise error
+            raise VultronValidationError(
+                f"ProposeEmbargo failed: {BTBridge.get_failure_reason(tree)}"
+            )
+        lifecycle_result = result_out.get("lifecycle_result")
+        if not isinstance(lifecycle_result, EmbargoLifecycleResult):
+            raise RuntimeError(
+                "ProposeEmbargo did not capture lifecycle result in BT output"
+            )
 
         if lifecycle_result.em_after != lifecycle_result.em_before:
             logger.info(
@@ -170,16 +180,9 @@ class SvcAcceptEmbargoUseCase:
                 "SvcAcceptEmbargoUseCase requires a TriggerActivityPort"
             )
 
-        lifecycle = EmbargoLifecycle(persistence=dl)
-        lifecycle_result = lifecycle.accept_embargo_invite(
-            case_id=case.id_,
-            embargo_id=embargo_id,
-            actor_id=actor_id,
-            transition_mode=TransitionMode.STRICT,
-        )
-
         factory = self._trigger_activity
         captured: dict = {}
+        result_out: dict[str, object] = {}
 
         def _build_activities(case_manager_id: str) -> list[str]:
             accept_id, accept_dict = factory.accept_embargo(
@@ -191,14 +194,26 @@ class SvcAcceptEmbargoUseCase:
             captured["activity"] = accept_dict
             return [accept_id]
 
-        send_case_actor_activity(
-            dl=dl,
+        bridge = BTBridge(datalayer=dl, trigger_activity=factory)
+        tree = accept_embargo_trigger_bt(
             case_id=case.id_,
-            actor_id=actor_id,
-            trigger_activity=factory,
-            failure_label="AcceptEmbargo",
+            embargo_id=embargo_id,
+            result_out=result_out,
             activity_builder=_build_activities,
         )
+        result = bridge.execute_with_setup(tree, actor_id=actor_id)
+        if result.status != Status.SUCCESS:
+            error = result_out.get("error")
+            if isinstance(error, Exception):
+                raise error
+            raise VultronValidationError(
+                f"AcceptEmbargo failed: {BTBridge.get_failure_reason(tree)}"
+            )
+        lifecycle_result = result_out.get("lifecycle_result")
+        if not isinstance(lifecycle_result, EmbargoLifecycleResult):
+            raise RuntimeError(
+                "AcceptEmbargo did not capture lifecycle result in BT output"
+            )
 
         if (
             _is_case_owner(case, actor_id)
@@ -279,15 +294,9 @@ class SvcTerminateEmbargoUseCase:
                 "SvcTerminateEmbargoUseCase requires a TriggerActivityPort"
             )
 
-        lifecycle = EmbargoLifecycle(persistence=dl)
-        lifecycle_result = lifecycle.terminate_active_embargo(
-            case_id=case.id_,
-            actor_id=actor_id,
-            transition_mode=TransitionMode.STRICT,
-        )
-
         factory = self._trigger_activity
         captured: dict = {}
+        result_out: dict[str, object] = {}
 
         def _build_activities(case_manager_id: str) -> list[str]:
             announce_id, announce_dict = factory.terminate_embargo(
@@ -299,14 +308,25 @@ class SvcTerminateEmbargoUseCase:
             captured["activity"] = announce_dict
             return [announce_id]
 
-        send_case_actor_activity(
-            dl=dl,
+        bridge = BTBridge(datalayer=dl, trigger_activity=factory)
+        tree = terminate_embargo_trigger_bt(
             case_id=case.id_,
-            actor_id=actor_id,
-            trigger_activity=factory,
-            failure_label="TerminateEmbargo",
+            result_out=result_out,
             activity_builder=_build_activities,
         )
+        result = bridge.execute_with_setup(tree, actor_id=actor_id)
+        if result.status != Status.SUCCESS:
+            error = result_out.get("error")
+            if isinstance(error, Exception):
+                raise error
+            raise VultronValidationError(
+                f"TerminateEmbargo failed: {BTBridge.get_failure_reason(tree)}"
+            )
+        lifecycle_result = result_out.get("lifecycle_result")
+        if not isinstance(lifecycle_result, EmbargoLifecycleResult):
+            raise RuntimeError(
+                "TerminateEmbargo did not capture lifecycle result in BT output"
+            )
 
         logger.info(
             "Actor '%s' terminated embargo '%s' on case '%s' (EM %s → %s)",
@@ -349,16 +369,9 @@ class SvcRejectEmbargoUseCase:
                 "SvcRejectEmbargoUseCase requires a TriggerActivityPort"
             )
 
-        lifecycle = EmbargoLifecycle(persistence=dl)
-        lifecycle_result = lifecycle.reject_embargo_invite(
-            case_id=case.id_,
-            embargo_id=embargo_id,
-            actor_id=actor_id,
-            transition_mode=TransitionMode.STRICT,
-        )
-
         factory = self._trigger_activity
         captured: dict = {}
+        result_out: dict[str, object] = {}
 
         def _build_activities(case_manager_id: str) -> list[str]:
             reject_id, reject_dict = factory.reject_embargo(
@@ -370,14 +383,26 @@ class SvcRejectEmbargoUseCase:
             captured["activity"] = reject_dict
             return [reject_id]
 
-        send_case_actor_activity(
-            dl=dl,
+        bridge = BTBridge(datalayer=dl, trigger_activity=factory)
+        tree = reject_embargo_trigger_bt(
             case_id=case.id_,
-            actor_id=actor_id,
-            trigger_activity=factory,
-            failure_label="RejectEmbargo",
+            embargo_id=embargo_id,
+            result_out=result_out,
             activity_builder=_build_activities,
         )
+        result = bridge.execute_with_setup(tree, actor_id=actor_id)
+        if result.status != Status.SUCCESS:
+            error = result_out.get("error")
+            if isinstance(error, Exception):
+                raise error
+            raise VultronValidationError(
+                f"RejectEmbargo failed: {BTBridge.get_failure_reason(tree)}"
+            )
+        lifecycle_result = result_out.get("lifecycle_result")
+        if not isinstance(lifecycle_result, EmbargoLifecycleResult):
+            raise RuntimeError(
+                "RejectEmbargo did not capture lifecycle result in BT output"
+            )
 
         if (
             _is_case_owner(case, actor_id)


### PR DESCRIPTION
Closes #711

- add trigger-side embargo BT action nodes and trigger tree compositions for propose/accept/reject/terminate flows
- route SvcProposeEmbargoUseCase, SvcAcceptEmbargoUseCase, SvcRejectEmbargoUseCase, and SvcTerminateEmbargoUseCase through BTBridge + embargo trigger trees
- preserve lifecycle error semantics by surfacing EmbargoLifecycle domain errors from BT action nodes
- expand trigger embargo tests with propose and terminate BT-path coverage