### PR TITLE
docs(skills): add structured PR body template

### DIFF
--- a/.agents/skills/bugfix/SKILL.md
+++ b/.agents/skills/bugfix/SKILL.md
@@ -141,15 +141,27 @@ focus hints from Phase 2 (e.g., `"wire layer"`, `"BT integration"`), then:
    - Record observations in `plan/BUILD_LEARNINGS.md`.
    - Compute diff size: ≤50 → `size:S`; 51–300 → `size:M`; 301+ → `size:L`.
      Update the `size:` label.
-   - Push and open PR:
+   - Push and open PR using the structured body template from
+     `.agents/skills/shared/pr-body-guide.md` (implementation PR shape):
 
      ```bash
      git push -u origin bug/<N>-<slug>
      gh pr create --repo CERTCC/Vultron \
        --title "fix: <short title>" \
-       --body "Fixes #<N>
+       --body "- Fixes #<N>
 
-     <summary of changes>" \
+     ## Summary
+
+     <1–2 sentences: what bug was fixed and how>
+
+     ## Changes
+
+     - \`path/to/file.py\`: <what changed>
+
+     ## Verification
+
+     - All N unit tests pass (M new); regression test added
+     - Black, flake8, mypy, pyright clean" \
        --label "size:<X>"
      ```
 

--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -143,16 +143,28 @@ Findings are tagged `[BLOCKING]` (fix before continuing) or `[ADVISORY]`
 1. Compute diff size: ≤50 lines → `size:S`; 51–300 → `size:M`; 301+ → `size:L`.
    Update the `size:` label on the Issue.
 
-2. Push and open a PR:
+2. Push and open a PR using the structured body template from
+   `.agents/skills/shared/pr-body-guide.md` (implementation PR shape):
 
    ```bash
    git fetch origin main && git rebase origin/main
    git push -u origin task/<N>-<slug>
    gh pr create --repo CERTCC/Vultron \
      --title "<short title>" \
-     --body "Closes #<N>
+     --body "- Closes #<N>
 
-   <summary of changes>" \
+   ## Summary
+
+   <1–2 sentences: what this PR does and why>
+
+   ## Changes
+
+   - \`path/to/file.py\`: <what changed>
+
+   ## Verification
+
+   - All N unit tests pass (M new)
+   - Black, flake8, mypy, pyright clean" \
      --label "size:<X>"
    ```
 

--- a/.agents/skills/learn/SKILL.md
+++ b/.agents/skills/learn/SKILL.md
@@ -250,10 +250,15 @@ Do **not** reference `plan/BUILD_LEARNINGS.md` from durable docs.
 
    gh pr create --repo CERTCC/Vultron \
      --title "docs: promote BUILD_LEARNINGS — <topic>" \
-     --body "Docs-only PR: promotes build learnings to specs/, notes/,
-   and/or AGENTS.md. Includes refreshed docs/reference/codebase/ output.
+     --body "- Closes #<issue if applicable>
 
-   No .py files changed." \
+   ## Summary
+
+   <what build learnings were promoted and to which docs/specs/notes>
+
+   ## Changes
+
+   - <bullet: what was added or changed>" \
      --label "specs-notes"
    ```text
 

--- a/.agents/skills/plan-issue/SKILL.md
+++ b/.agents/skills/plan-issue/SKILL.md
@@ -183,11 +183,15 @@ git push -u origin "plan/${ISSUE_NUMBER}-<slug>"
 
 gh pr create --repo CERTCC/Vultron \
   --title "docs: plan issue #${ISSUE_NUMBER} — <short title>" \
-  --body "Docs-only PR for issue #${ISSUE_NUMBER}.
+  --body "- Closes #${ISSUE_NUMBER}
 
-Closes #${ISSUE_NUMBER}
+## Summary
 
-No .py files changed." \
+<1–2 sentences: what was planned and what docs/specs were produced>
+
+## Changes
+
+- <bullet: what was added or changed>" \
   --label "specs-notes"
 ```
 

--- a/.agents/skills/shared/pr-body-guide.md
+++ b/.agents/skills/shared/pr-body-guide.md
@@ -1,0 +1,76 @@
+# PR Body Guide
+
+All PRs opened by agents MUST use the structured templates below.
+Reference this file from the "Open PR" step of any skill that calls
+`gh pr create`.
+
+---
+
+## Template: Implementation PRs
+
+Use for `build`, `bugfix`, and any PR that modifies `.py` files.
+
+```markdown
+- Closes #N
+- Closes #M   <!-- one line per issue; GitHub expands the title automatically -->
+
+## Summary
+
+<1–2 sentences: what this PR does and why. Present tense: "Adds…", "Fixes…",
+"Replaces…". Focus on the outcome.>
+
+## Motivation
+
+<Why this change is needed. **Omit this section** if the Summary already
+captures the full rationale.>
+
+## Changes
+
+- **`path/to/file.py`**: <what changed and why>
+- **`path/to/other.py`**: <what changed and why>
+- **`test/path/test_file.py`**: <what tests were added or changed>
+
+## Verification
+
+- All N unit tests pass (M new)
+- Black, flake8, mypy, pyright clean
+- [x] AC-1: ...   <!-- include when the closed issue listed acceptance criteria -->
+```
+
+### Implementation PR rules
+
+- Closing references (`Closes #N` / `Fixes #N`) go at the **top**, one per
+  bullet line, so GitHub expands the issue title in the PR sidebar.
+- **Summary**: required; 1–2 sentences, present tense.
+- **Motivation**: optional; omit when Summary is self-explanatory.
+- **Changes**: required; use backtick-wrapped file paths and concrete
+  descriptions. Do not just echo the commit message.
+- **Verification**: required for any PR that modifies `.py` files. Include
+  the actual total test count and the number of new tests added. Tick off
+  acceptance criteria from the issue when they are listed.
+
+---
+
+## Template: Docs-Only PRs
+
+Use for `plan-issue`, `learn`, and any PR that touches only `.md`, `.yaml`,
+or other non-Python files.
+
+```markdown
+- Closes #N
+
+## Summary
+
+<1–2 sentences: what docs, specs, or notes were added or updated and why.>
+
+## Changes
+
+- **`path/to/file.md`**: <what changed>
+- **`specs/file.yaml`**: <what changed>
+```
+
+### Docs-only PR rules
+
+- No Verification section — no Python was changed, no test suite ran.
+- Keep Changes concise; list meaningful files only (not `README.md` unless
+  it was substantively updated).

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,4 +1,30 @@
 
 ---
+
 Please note: Pull request submissions are subject to our
 [Contribution Instructions](https://github.com/CERTCC/Vultron/blob/main/ContributionInstructions.md)
+
+---
+
+<!-- One closing reference per line. GitHub expands the issue title automatically. -->
+- Closes #
+
+## Summary
+
+<!-- 1–2 sentences: what this PR does and why. Present tense: "Adds…", "Fixes…". -->
+
+## Motivation
+
+<!-- Why this change is needed. Delete this section if the Summary covers it. -->
+
+## Changes
+
+<!-- File-by-file bullets with backtick paths. -->
+- **`path/to/file.py`**:
+
+## Verification
+
+<!-- For PRs that modify .py files. Include actual test count + new tests added.
+     Delete this section for docs-only PRs. -->
+- All N unit tests pass (M new)
+- Black, flake8, mypy, pyright clean

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,6 +220,12 @@ change warrants a new ADR, a new spec entry, or both.
 4. `build-docs` — only when `docs/` files were modified
 5. `commit` skill — include Co-authored-by trailer
 
+**When opening a PR**, use the structured body template in
+`.agents/skills/shared/pr-body-guide.md`. Implementation PRs require
+**Summary + Changes + Verification** (with actual test counts); docs-only
+PRs use **Summary + Changes**. Always put closing references
+(`- Closes #N`) at the top, one per line.
+
 **Always stage the new entry file when `append-history` was called.** The tool
 creates a new entry file under `plan/history/YYMM/<type>/` — stage it with
 `git add plan/history/`. The monthly `plan/history/YYMM/README.md` is


### PR DESCRIPTION
## Summary

Adds a canonical PR body template to make PR descriptions consistently
structured and detailed regardless of which AI model creates them.

## Motivation

Weaker models (e.g., GPT-5.3-Codex, as seen in #840) produce thin PR
bodies while stronger models (e.g., Claude Sonnet, as in #704 and #684)
naturally inject richer structure from training. Making the expected
shape explicit in the skill instructions removes the model-capability
dependency.

## Changes

- **`.agents/skills/shared/pr-body-guide.md`** (new): canonical
  template reference — implementation PR shape (Summary, optional
  Motivation, Changes, Verification with test counts) and docs-only
  PR shape (Summary, Changes); closing references as top-of-body bullets
- **`.agents/skills/build/SKILL.md`**: Phase 8 now references the
  guide and shows a richer `--body` example
- **`.agents/skills/bugfix/SKILL.md`**: finalize step now references
  the guide and shows a richer `--body` example
- **`.agents/skills/plan-issue/SKILL.md`**: docs-only PR template
  updated (closing bullet + Summary + Changes)
- **`.agents/skills/learn/SKILL.md`**: docs-only PR template updated
- **`.github/PULL_REQUEST_TEMPLATE/pull_request_template.md`**:
  scaffolds the same four sections for humans creating PRs via GitHub UI
- **`AGENTS.md`**: adds a pointer to the shared guide in the Commit
  Workflow section so ad-hoc agents also find the template