### PR TITLE
Canonicalize participant resolution on case_participants

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -84,3 +84,11 @@ header.
   callers previously imported transitively from the old module.
 - Mirror the source split in test layout with a matching subdirectory to keep
   file organization aligned and reduce future merge-conflict hotspots.
+
+### 2026-06-09 ISSUE-825 — Actor-participant cache checks should fail only on contradictions
+
+- Canonical actor→participant resolution should use `case_participants` as the
+  source of truth and treat `actor_participant_index` as a derived cache.
+- Fail fast when the cache contradicts canonical data (wrong/stale participant),
+  but do not treat a missing cache entry as fatal when canonical participant
+  data exists.

--- a/test/adapters/driving/fastapi/routers/test_actors.py
+++ b/test/adapters/driving/fastapi/routers/test_actors.py
@@ -149,14 +149,6 @@ def test_get_actors_does_not_log_raw_records_at_info_level(
 
 def _seed_action_rules_data(dl):
     """Insert a minimal valid VulnerabilityCase / CaseParticipant pair."""
-    case = VulnerabilityCase(
-        id_=_URN_CASE_ID,
-        name="Test Case",
-        actor_participant_index={_URN_ACTOR_ID: _URN_PARTICIPANT_ID},
-        case_statuses=[CaseStatus(em_state=EM.ACTIVE, pxa_state=CS_pxa.Pxa)],
-    )
-    dl.create(case)
-
     participant = CaseParticipant(
         id_=_URN_PARTICIPANT_ID,
         attributed_to=_URN_ACTOR_ID,
@@ -171,6 +163,14 @@ def _seed_action_rules_data(dl):
         ],
     )
     dl.create(participant)
+
+    case = VulnerabilityCase(
+        id_=_URN_CASE_ID,
+        name="Test Case",
+        case_statuses=[CaseStatus(em_state=EM.ACTIVE, pxa_state=CS_pxa.Pxa)],
+    )
+    case.add_participant(participant)
+    dl.create(case)
 
 
 def test_get_action_rules_returns_200_with_expected_fields(client_actors, dl):

--- a/test/core/behaviors/status/test_add_participant_status_bt.py
+++ b/test/core/behaviors/status/test_add_participant_status_bt.py
@@ -120,8 +120,8 @@ def case_manager_participant():
 def case(participant, case_manager_participant):
     """VulnerabilityCase with vendor and Case Manager participants."""
     obj = VulnerabilityCase(id_=CASE_ID, name="Test Case")
-    obj.actor_participant_index[ACTOR_ID] = PARTICIPANT_ID
-    obj.actor_participant_index[CASE_MANAGER_ID] = CM_PARTICIPANT_ID
+    obj.add_participant(participant)
+    obj.add_participant(case_manager_participant)
     return obj
 
 

--- a/test/core/behaviors/test_helpers.py
+++ b/test/core/behaviors/test_helpers.py
@@ -206,6 +206,7 @@ def test_find_participant_by_actor_id_success_writes_blackboard(
         id_="https://example.org/cases/case-1",
         name="Case 1",
         case_participants=[participant.id_],
+        actor_participant_index={actor_id: participant.id_},
         attributed_to="https://example.org/actors/case-manager",
     )
     datalayer.save(participant)
@@ -283,6 +284,31 @@ def test_find_participant_by_actor_id_fails_when_actor_not_participant(
         node, actor_id="https://example.org/actors/vendor-1"
     )
     assert result.status == Status.FAILURE
+
+
+def test_find_participant_by_actor_id_fails_on_index_divergence(
+    bridge, datalayer
+):
+    """FindParticipantByActorIdNode fails fast on participant/index mismatch."""
+    actor_id = "https://example.org/actors/vendor-1"
+    case = VultronCase(
+        id_="https://example.org/cases/case-diverge",
+        name="Case Divergence",
+        case_participants=[],
+        actor_participant_index={
+            actor_id: "https://example.org/participants/p1"
+        },
+        attributed_to="https://example.org/actors/case-manager",
+    )
+    datalayer.save(case)
+
+    node = FindParticipantByActorIdNode(
+        case_id=case.id_,
+        target_actor_id=actor_id,
+    )
+    result = bridge.execute_with_setup(node, actor_id=actor_id)
+    assert result.status == Status.FAILURE
+    assert "divergence" in result.feedback_message
 
 
 def test_read_object_success(bridge, datalayer, sample_record):

--- a/test/core/models/test_case.py
+++ b/test/core/models/test_case.py
@@ -24,6 +24,7 @@ from vultron.core.models.case_participant import (
 )
 from vultron.core.models.case_status import CaseStatus
 from vultron.core.models.registry import CORE_VOCABULARY
+from vultron.errors import VultronValidationError
 
 _ACTOR = "https://example.org/actor"
 _CASE_ID = "urn:uuid:case-test"
@@ -157,7 +158,7 @@ class TestVulnerabilityCaseAddParticipant:
             attributed_to="https://example.org/finder",
         )
         case.add_participant(p)
-        assert p in case.case_participants
+        assert p.id_ in case.case_participants
 
     def test_add_participant_updates_index(self, case: VulnerabilityCase):
         p = FinderParticipant(
@@ -177,6 +178,18 @@ class TestVulnerabilityCaseAddParticipant:
         case.add_participant(p)
         assert "urn:uuid:part-2" not in case.actor_participant_index
 
+    def test_add_participant_raises_on_actor_index_divergence(
+        self, case: VulnerabilityCase
+    ):
+        actor_id = "https://example.org/finder"
+        case.actor_participant_index[actor_id] = "urn:uuid:part-existing"
+        participant = FinderParticipant(
+            id_="urn:uuid:part-new",
+            attributed_to=actor_id,
+        )
+        with pytest.raises(VultronValidationError, match="divergence"):
+            case.add_participant(participant)
+
 
 class TestVulnerabilityCaseRemoveParticipant:
     """remove_participant removes from list and index."""
@@ -190,7 +203,7 @@ class TestVulnerabilityCaseRemoveParticipant:
         )
         case.add_participant(p)
         case.remove_participant("urn:uuid:part-1")
-        assert p not in case.case_participants
+        assert p.id_ not in case.case_participants
 
     def test_remove_participant_clears_from_index(
         self, case: VulnerabilityCase

--- a/test/core/use_cases/query/test_action_rules.py
+++ b/test/core/use_cases/query/test_action_rules.py
@@ -28,7 +28,7 @@ from vultron.core.use_cases.query.action_rules import (
     ActionRulesRequest,
     GetActionRulesUseCase,
 )
-from vultron.errors import VultronNotFoundError
+from vultron.errors import VultronNotFoundError, VultronValidationError
 from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
 from vultron.wire.as2.vocab.objects.case_status import (
     CaseStatus,
@@ -51,6 +51,7 @@ def dl():
     case = VulnerabilityCase(
         id_=CASE_ID,
         name="Test Case",
+        case_participants=[PARTICIPANT_ID],
         actor_participant_index={ACTOR_ID: PARTICIPANT_ID},
         case_statuses=[CaseStatus(em_state=EM.ACTIVE, pxa_state=CS_pxa.Pxa)],
     )
@@ -169,6 +170,7 @@ class TestGetActionRulesUseCase:
         case = VulnerabilityCase(
             id_=CASE_ID,
             name="Empty Status Case",
+            case_participants=[PARTICIPANT_ID],
             actor_participant_index={ACTOR_ID: PARTICIPANT_ID},
             case_statuses=[],
         )
@@ -202,6 +204,7 @@ class TestGetActionRulesUseCase:
         case = VulnerabilityCase(
             id_=CASE_ID,
             name="Default Participant Status Case",
+            case_participants=[PARTICIPANT_ID],
             actor_participant_index={ACTOR_ID: PARTICIPANT_ID},
             case_statuses=[CaseStatus(em_state=EM.NO_EMBARGO)],
         )
@@ -236,6 +239,7 @@ class TestGetActionRulesUseCase:
             layer = SqliteDataLayer("sqlite:///:memory:")
             case = VulnerabilityCase(
                 id_=CASE_ID,
+                case_participants=[PARTICIPANT_ID],
                 actor_participant_index={ACTOR_ID: PARTICIPANT_ID},
                 case_statuses=[CaseStatus(em_state=em, pxa_state=CS_pxa.pxa)],
             )
@@ -255,3 +259,45 @@ class TestGetActionRulesUseCase:
             assert (
                 result["em_state"] == em
             ), f"Expected {em!r}, got {result['em_state']!r}"
+
+    def test_participant_lookup_raises_on_index_mismatch(self):
+        layer = SqliteDataLayer("sqlite:///:memory:")
+        participant = CaseParticipant(
+            id_=PARTICIPANT_ID,
+            attributed_to=ACTOR_ID,
+            case_roles=[CVDRole.VENDOR],
+            participant_statuses=[ParticipantStatus(context=CASE_ID)],
+        )
+        layer.create(participant)
+        case = VulnerabilityCase(
+            id_=CASE_ID,
+            case_participants=[PARTICIPANT_ID],
+            actor_participant_index={ACTOR_ID: "https://example.org/p/wrong"},
+            case_statuses=[CaseStatus()],
+        )
+        layer.create(case)
+
+        req = ActionRulesRequest(case_id=CASE_ID, actor_id=ACTOR_ID)
+        with pytest.raises(VultronValidationError, match="divergence"):
+            GetActionRulesUseCase(dl=layer, request=req).execute()
+
+    def test_participant_lookup_succeeds_without_index_entry(self):
+        layer = SqliteDataLayer("sqlite:///:memory:")
+        participant = CaseParticipant(
+            id_=PARTICIPANT_ID,
+            attributed_to=ACTOR_ID,
+            case_roles=[CVDRole.VENDOR],
+            participant_statuses=[ParticipantStatus(context=CASE_ID)],
+        )
+        layer.create(participant)
+        case = VulnerabilityCase(
+            id_=CASE_ID,
+            case_participants=[PARTICIPANT_ID],
+            actor_participant_index={},
+            case_statuses=[CaseStatus()],
+        )
+        layer.create(case)
+
+        req = ActionRulesRequest(case_id=CASE_ID, actor_id=ACTOR_ID)
+        result = GetActionRulesUseCase(dl=layer, request=req).execute()
+        assert result["participant_id"] == PARTICIPANT_ID

--- a/vultron/core/behaviors/case/nodes/case_setup.py
+++ b/vultron/core/behaviors/case/nodes/case_setup.py
@@ -370,8 +370,7 @@ class CreateCaseActorNode(DataLayerAction):
         except ValueError:
             pass  # already exists — idempotent
 
-        case.case_participants.append(participant_id)
-        case.actor_participant_index[case_actor_id] = participant_id
+        case.add_participant(participant)
         self.datalayer.save(case)
         self.logger.info(
             f"{self.name}: Registered CaseActor participant '{participant_id}'"

--- a/vultron/core/behaviors/case/nodes/participant.py
+++ b/vultron/core/behaviors/case/nodes/participant.py
@@ -103,19 +103,21 @@ def _create_and_attach_participant(
         node_logger.error("Case %s not found in DataLayer", case_id)
         return None
 
-    existing_ids = {
-        p.id_ if hasattr(p, "id_") else p
-        for p in stored_case.case_participants
-    }
-    if participant.id_ not in existing_ids:
-        stored_case.case_participants.append(participant.id_)
-    if (
-        stored_case.actor_participant_index.get(actor_id_for_index)
-        != participant.id_
-    ):
-        stored_case.actor_participant_index[actor_id_for_index] = (
-            participant.id_
-        )
+    existing_participant_id = stored_case.actor_participant_index.get(
+        actor_id_for_index
+    )
+    if existing_participant_id is not None:
+        existing_participant = dl.read(existing_participant_id)
+        if existing_participant is not None:
+            stored_case.add_participant(existing_participant)
+            node_logger.debug(
+                "Participant already registered for actor '%s' in case '%s'",
+                actor_id_for_index,
+                case_id,
+            )
+            return stored_case
+
+    stored_case.add_participant(participant)
 
     node_logger.info(
         "CaseParticipant '%s' attached to case '%s'",

--- a/vultron/core/behaviors/helpers.py
+++ b/vultron/core/behaviors/helpers.py
@@ -228,6 +228,51 @@ class FindParticipantByActorIdNode(DataLayerCondition):
             else getattr(actor_ref, "id_", str(actor_ref))
         )
 
+    def _participant_id(self, participant: object) -> str:
+        return str(getattr(participant, "id_", participant))
+
+    def _fail(self, message: str) -> Status:
+        self.feedback_message = message
+        self.logger.error("%s: %s", self.name, self.feedback_message)
+        return Status.FAILURE
+
+    def _find_matching_participant(
+        self, case_obj: object
+    ) -> tuple[object | None, str | None, str | None]:
+        assert self.datalayer is not None
+        matched_participant: object | None = None
+        matched_participant_id: str | None = None
+        for participant_ref in getattr(case_obj, "case_participants", []):
+            participant_obj = participant_ref
+            if isinstance(participant_ref, str):
+                participant_obj = self.datalayer.read(
+                    participant_ref, raise_on_missing=False
+                )
+            if not is_participant_model(participant_obj):
+                continue
+            if (
+                self._participant_actor_id(participant_obj)
+                != self.target_actor_id
+            ):
+                continue
+
+            participant_id = self._participant_id(participant_obj)
+            if (
+                matched_participant_id is not None
+                and participant_id != matched_participant_id
+            ):
+                return (
+                    None,
+                    None,
+                    "Participant-index divergence: actor "
+                    f"{self.target_actor_id} resolves to multiple "
+                    "case_participants.",
+                )
+            matched_participant = participant_obj
+            matched_participant_id = participant_id
+
+        return matched_participant, matched_participant_id, None
+
     def update(self) -> Status:
         if self.datalayer is None:
             self.feedback_message = "DataLayer not available"
@@ -240,38 +285,50 @@ class FindParticipantByActorIdNode(DataLayerCondition):
             self.logger.debug("%s: %s", self.name, self.feedback_message)
             return Status.FAILURE
 
-        participant_refs: list[object] = list(case_obj.case_participants)
         index_match = case_obj.actor_participant_index.get(
             self.target_actor_id
         )
-        if index_match is not None:
-            participant_refs.insert(0, index_match)
+        matched_participant, matched_participant_id, error_message = (
+            self._find_matching_participant(case_obj)
+        )
+        if error_message is not None:
+            return self._fail(error_message)
 
-        for participant_ref in participant_refs:
-            participant_obj = participant_ref
-            if isinstance(participant_ref, str):
-                participant_obj = self.datalayer.read(
-                    participant_ref, raise_on_missing=False
+        if matched_participant is None:
+            if index_match is not None:
+                return self._fail(
+                    "Participant-index divergence: actor "
+                    f"{self.target_actor_id} mapped to {index_match} in "
+                    "actor_participant_index but missing from "
+                    "case_participants."
                 )
-            if not is_participant_model(participant_obj):
-                continue
-
-            if (
-                self._participant_actor_id(participant_obj)
-                != self.target_actor_id
-            ):
-                continue
-
-            setattr(self.blackboard, self.participant_key, participant_obj)
-            self.feedback_message = (
-                f"Found participant for actor {self.target_actor_id}"
-            )
+            self.feedback_message = f"No participant for actor {self.target_actor_id} in case {self.case_id}"
             self.logger.debug("%s: %s", self.name, self.feedback_message)
-            return Status.SUCCESS
+            return Status.FAILURE
 
-        self.feedback_message = f"No participant for actor {self.target_actor_id} in case {self.case_id}"
+        if index_match != matched_participant_id:
+            if index_match is None:
+                setattr(
+                    self.blackboard, self.participant_key, matched_participant
+                )
+                self.feedback_message = (
+                    f"Found participant for actor {self.target_actor_id}"
+                )
+                self.logger.debug("%s: %s", self.name, self.feedback_message)
+                return Status.SUCCESS
+            return self._fail(
+                "Participant-index divergence: actor "
+                f"{self.target_actor_id} resolves to "
+                f"{matched_participant_id} from case_participants but "
+                f"actor_participant_index maps to {index_match}."
+            )
+
+        setattr(self.blackboard, self.participant_key, matched_participant)
+        self.feedback_message = (
+            f"Found participant for actor {self.target_actor_id}"
+        )
         self.logger.debug("%s: %s", self.name, self.feedback_message)
-        return Status.FAILURE
+        return Status.SUCCESS
 
 
 class ReadObject(DataLayerCondition):

--- a/vultron/core/models/case.py
+++ b/vultron/core/models/case.py
@@ -26,6 +26,7 @@ from vultron.core.models.base import CoreObject
 from vultron.core.models.case_event import CaseEvent
 from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.models.case_status import CaseStatus
+from vultron.errors import VultronValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -110,11 +111,31 @@ class VulnerabilityCase(CoreObject):
             participant: A full :class:`CaseParticipant` object (full object
                 required to update the index).
         """
-        self.case_participants.append(participant)
-        if participant.attributed_to is not None:
-            self.actor_participant_index[participant.attributed_to] = (
-                participant.id_
+        participant_id = participant.id_
+        existing_ids = {
+            p.id_ if isinstance(p, CaseParticipant) else str(p)
+            for p in self.case_participants
+        }
+        if participant_id not in existing_ids:
+            self.case_participants.append(participant_id)
+
+        actor_ref = participant.attributed_to
+        actor_id = (
+            actor_ref
+            if isinstance(actor_ref, str)
+            else getattr(actor_ref, "id_", None)
+        )
+        if actor_id is None:
+            return
+
+        existing_mapping = self.actor_participant_index.get(actor_id)
+        if existing_mapping is not None and existing_mapping != participant_id:
+            raise VultronValidationError(
+                "Participant-index divergence: "
+                f"actor '{actor_id}' already mapped to '{existing_mapping}' "
+                f"but add_participant received '{participant_id}'."
             )
+        self.actor_participant_index[actor_id] = participant_id
 
     def remove_participant(self, participant_id: str) -> None:
         """Remove a participant and update the actor→participant index.

--- a/vultron/core/use_cases/_helpers.py
+++ b/vultron/core/use_cases/_helpers.py
@@ -216,6 +216,64 @@ def _resolve_case_manager_id(
     return None
 
 
+def resolve_case_participant_id_for_actor(
+    case: CaseModel,
+    actor_id: str,
+    dl: CasePersistence,
+) -> str | None:
+    """Resolve participant ID from actor ID using ``case_participants`` as truth.
+
+    The lookup canonical source is ``case.case_participants``. The derived
+    ``actor_participant_index`` mapping is validated against that source and
+    any divergence raises :class:`VultronValidationError`.
+    """
+    resolved_ids: list[str] = []
+    for participant_ref in case.case_participants:
+        participant_id = _as_id(participant_ref)
+        if participant_id is None:
+            continue
+        participant_obj = (
+            participant_ref
+            if is_participant_model(participant_ref)
+            else dl.read(participant_id)
+        )
+        if not is_participant_model(participant_obj):
+            continue
+        participant_actor_id = _as_id(participant_obj.attributed_to)
+        if participant_actor_id == actor_id:
+            resolved_ids.append(participant_id)
+
+    unique_ids = sorted(set(resolved_ids))
+    if len(unique_ids) > 1:
+        raise VultronValidationError(
+            "Participant-index divergence: actor "
+            f"'{actor_id}' resolves to multiple participants "
+            f"{unique_ids!r} in case_participants."
+        )
+
+    indexed_id = case.actor_participant_index.get(actor_id)
+    if not unique_ids:
+        if indexed_id is not None:
+            raise VultronValidationError(
+                "Participant-index divergence: actor "
+                f"'{actor_id}' maps to '{indexed_id}' in "
+                "actor_participant_index but has no matching participant in "
+                "case_participants."
+            )
+        return None
+
+    canonical_id = unique_ids[0]
+    if indexed_id is not None and indexed_id != canonical_id:
+        raise VultronValidationError(
+            "Participant-index divergence: actor "
+            f"'{actor_id}' resolves to '{canonical_id}' from "
+            f"case_participants but actor_participant_index maps to "
+            f"'{indexed_id}'."
+        )
+
+    return canonical_id
+
+
 def reset_case_participant_embargo_consent(
     dl: CasePersistence, case: CaseModel
 ) -> None:

--- a/vultron/core/use_cases/query/action_rules.py
+++ b/vultron/core/use_cases/query/action_rules.py
@@ -30,6 +30,9 @@ from vultron.core.states.cs import CS_pxa, CS_vfd
 from vultron.core.states.em import EM
 from vultron.core.states.rm import RM
 from vultron.core.use_cases.triggers._helpers import resolve_case
+from vultron.core.use_cases._helpers import (
+    resolve_case_participant_id_for_actor,
+)
 from vultron.errors import VultronNotFoundError, VultronValidationError
 
 
@@ -44,30 +47,10 @@ def _resolve_participant_id_from_actor(
     case: CaseModel, actor_id: str, dl: CasePersistence
 ) -> str:
     """Resolve a case-scoped participant ID from an actor ID."""
-    participant_id = case.actor_participant_index.get(actor_id)
-    if participant_id is not None:
-        return participant_id
-
-    for participant_ref in case.case_participants:
-        resolved_participant_id = (
-            participant_ref.id_
-            if hasattr(participant_ref, "id_")
-            else str(participant_ref)
-        )
-        participant = cast(
-            ParticipantModel | None, dl.read(resolved_participant_id)
-        )
-        if participant is None:
-            continue
-        participant_actor_id = (
-            participant.attributed_to
-            if isinstance(participant.attributed_to, str)
-            else getattr(participant.attributed_to, "id_", None)
-        )
-        if participant_actor_id == actor_id:
-            return resolved_participant_id
-
-    raise VultronNotFoundError("CaseParticipant", actor_id)
+    participant_id = resolve_case_participant_id_for_actor(case, actor_id, dl)
+    if participant_id is None:
+        raise VultronNotFoundError("CaseParticipant", actor_id)
+    return participant_id
 
 
 class GetActionRulesUseCase:

--- a/vultron/core/use_cases/received/actor.py
+++ b/vultron/core/use_cases/received/actor.py
@@ -611,9 +611,7 @@ class AcceptInviteActorToCaseReceivedUseCase:
             )
         self._dl.create(participant)
 
-        # Use string IDs to avoid wire-type serialization incompatibility
-        case.case_participants.append(participant.id_)
-        case.actor_participant_index[invitee_id] = participant.id_
+        case.add_participant(participant)
         case.record_event(invitee_id, "participant_joined")
         if active_embargo_id and em_state == EM.ACTIVE:
             case.record_event(active_embargo_id, "embargo_accepted")

--- a/vultron/core/use_cases/received/case_participant.py
+++ b/vultron/core/use_cases/received/case_participant.py
@@ -8,7 +8,7 @@ from vultron.core.models.events.case_participant import (
     RemoveCaseParticipantFromCaseReceivedEvent,
 )
 from vultron.core.ports.case_persistence import CasePersistence
-from vultron.core.models.protocols import is_case_model
+from vultron.core.models.protocols import is_case_model, is_participant_model
 from vultron.core.use_cases._helpers import _as_id, _idempotent_create
 
 logger = logging.getLogger(__name__)
@@ -61,21 +61,14 @@ class AddCaseParticipantToCaseReceivedUseCase:
             )
             return
 
-        existing_ids = [_as_id(p) for p in case.case_participants]
-        if participant_id in existing_ids:
-            logger.info(
-                "Participant '%s' already in case '%s' — skipping (idempotent)",
+        if not is_participant_model(participant):
+            logger.warning(
+                "add_case_participant_to_case: participant '%s' not found",
                 participant_id,
-                case_id,
             )
             return
 
-        # Use string ID to avoid wire-type serialization incompatibility
-        case.case_participants.append(participant_id)
-        if participant is not None:
-            actor_id = _as_id(getattr(participant, "attributed_to", None))
-            if actor_id is not None:
-                case.actor_participant_index[actor_id] = participant_id
+        case.add_participant(participant)
         case.record_event(participant_id, "participant_added")
         self._dl.save(case)
         logger.info(

--- a/vultron/wire/as2/vocab/objects/vulnerability_case.py
+++ b/vultron/wire/as2/vocab/objects/vulnerability_case.py
@@ -23,6 +23,7 @@ from pydantic import Field, model_validator
 
 from vultron.core.models.base import NonEmptyString
 from vultron.core.models.case import VulnerabilityCase as CoreVulnerabilityCase
+from vultron.errors import VultronValidationError
 from vultron.wire.as2.vocab.base.links import ActivityStreamRef
 from vultron.wire.as2.vocab.base.objects.activities.base import as_Activity
 from vultron.wire.as2.vocab.base.objects.object_types import as_NoteRef
@@ -147,16 +148,35 @@ class VulnerabilityCase(VultronAS2Object):
             participant: a CaseParticipant object (full object required to
                          update the index)
         """
-        self.case_participants.append(participant)
+        participant_id = participant.id_
+        existing_ids = {
+            str(getattr(p, "id_", p)) for p in self.case_participants
+        }
+        if participant_id not in existing_ids:
+            if isinstance(participant, CaseParticipant):
+                self.case_participants.append(participant)
+            else:
+                self.case_participants.append(participant_id)
 
         attributed_to = participant.attributed_to
         if attributed_to is not None:
-            actor_id = (
-                attributed_to.id_
-                if hasattr(attributed_to, "id_")
-                else str(attributed_to)
-            )
-            self.actor_participant_index[actor_id] = participant.id_
+            actor_id: str
+            if isinstance(attributed_to, str):
+                actor_id = attributed_to
+            else:
+                actor_id = str(getattr(attributed_to, "id_", attributed_to))
+            existing_mapping = self.actor_participant_index.get(actor_id)
+            if (
+                existing_mapping is not None
+                and existing_mapping != participant_id
+            ):
+                raise VultronValidationError(
+                    "Participant-index divergence: "
+                    f"actor '{actor_id}' already mapped to "
+                    f"'{existing_mapping}' but add_participant received "
+                    f"'{participant_id}'."
+                )
+            self.actor_participant_index[actor_id] = participant_id
 
     def remove_participant(self, participant_id: str) -> None:
         """Remove a participant from the case, maintaining the actor_participant_index.


### PR DESCRIPTION
Closes #825

## Summary
- canonicalized actor-to-participant resolution helpers to treat case_participants as authoritative and detect contradictory actor_participant_index mappings
- moved participant write paths to shared add_participant/remove_participant helpers in core received and behavior flows so index maintenance is centralized
- updated BT and router/action-rules tests and fixtures to seed both participant surfaces consistently, and added divergence-focused assertions