### PR TITLE
Fix case-log payload snapshots and case-actor dump coverage

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -122,3 +122,14 @@ header.
   so future reviewers understand why "Always SUCCESS" is intentional, not a bug.
   The pattern supports broadcasting log entries even when participant doesn't
   exist on this peer yet (state gap resolved by broadcast reception).
+
+### 2026-06-09 ISSUE-690 — Case-log snapshots and demo log exports need source-aware fallbacks
+
+- `CommitCaseLogEntryNode` must forward a serialized activity payload snapshot
+  from the BT blackboard into `create_commit_log_entry_tree()`; otherwise
+  `CaseLogEntry.payloadSnapshot` silently defaults to `{}` despite valid
+  inbound activity context.
+- Two-actor demo log export should always emit a `case-actor` JSONL artifact,
+  but dedicated case-actor container reads may be empty in D5-2 by design;
+  export logic should fall back to the vendor container's case-actor sub-actor
+  route key instead of failing the demo run.

--- a/plan/history/2606/implementation/ISSUE-690.md
+++ b/plan/history/2606/implementation/ISSUE-690.md
@@ -1,0 +1,12 @@
+---
+source: ISSUE-690
+timestamp: '2026-06-09T16:19:08.145144+00:00'
+title: Fix case log observability artifacts
+type: implementation
+---
+
+## Issue #690 — [Feature] Fix case log observability: missing case-actor log, empty payloadSnapshot, replication gaps
+
+Implemented payload snapshot propagation from `CommitCaseLogEntryNode` into the commit tree so case-log entries receive normalized activity payloads instead of defaulting to empty objects. Updated two-actor demo log dumping to always emit a case-actor JSONL artifact, using the dedicated case-actor client when available and falling back to the vendor container's case-actor sub-actor route key when the dedicated service has no entries.
+
+PR: <https://github.com/CERTCC/Vultron/pull/845>

--- a/test/core/behaviors/case/nodes/test_lifecycle.py
+++ b/test/core/behaviors/case/nodes/test_lifecycle.py
@@ -74,9 +74,18 @@ class _FakeActivity:
         self,
         activity_id: str = ACTIVITY_ID,
         semantic_type: MessageSemantics = MessageSemantics.CREATE_CASE,
+        activity: object | None = None,
     ):
         self.activity_id = activity_id
         self.semantic_type = semantic_type
+        self.activity = activity
+
+
+class _FakeWireActivity:
+    """Minimal stand-in for a serialized wire activity payload."""
+
+    def model_dump(self, **_: object) -> dict[str, str]:
+        return {"id": ACTIVITY_ID, "type": "Create"}
 
 
 # ---------------------------------------------------------------------------
@@ -128,6 +137,7 @@ def test_constructor_case_id_builds_inner_commit_tree(bridge):
         case_id=CASE_ID,
         object_id=CASE_ID,
         event_type="case_event",
+        payload_snapshot={},
     )
     execute_kwargs = (
         mock_bridge_cls.return_value.execute_with_setup.call_args.kwargs
@@ -172,6 +182,7 @@ def test_blackboard_case_id_builds_inner_commit_tree(bridge, datalayer):
         case_id=CASE_ID,
         object_id=CASE_ID,
         event_type="case_event",
+        payload_snapshot={},
     )
 
 
@@ -195,6 +206,31 @@ def test_activity_on_blackboard_uses_semantic_type_as_event_type(bridge):
         case_id=CASE_ID,
         object_id=ACTIVITY_ID,
         event_type=MessageSemantics.CREATE_CASE.value,
+        payload_snapshot={},
+    )
+
+
+def test_activity_payload_is_forwarded_as_payload_snapshot(bridge):
+    activity = _FakeActivity(
+        activity_id=ACTIVITY_ID,
+        semantic_type=MessageSemantics.CREATE_CASE,
+        activity=_FakeWireActivity(),
+    )
+    node = CommitCaseLogEntryNode(case_id=CASE_ID)
+    with patch(_FACTORY_PATH) as mock_factory, patch(
+        _INNER_BRIDGE_PATH
+    ) as mock_bridge_cls:
+        mock_bridge_cls.return_value.execute_with_setup.return_value = (
+            BTExecutionResult(status=Status.SUCCESS)
+        )
+        bridge.execute_with_setup(
+            tree=node, actor_id=ACTOR_ID, activity=activity
+        )
+    mock_factory.assert_called_once_with(
+        case_id=CASE_ID,
+        object_id=ACTIVITY_ID,
+        event_type=MessageSemantics.CREATE_CASE.value,
+        payload_snapshot={"id": ACTIVITY_ID, "type": "Create"},
     )
 
 
@@ -212,6 +248,7 @@ def test_no_activity_falls_back_to_case_event(bridge):
         case_id=CASE_ID,
         object_id=CASE_ID,
         event_type="case_event",
+        payload_snapshot={},
     )
 
 

--- a/test/demo/test_two_actor_demo.py
+++ b/test/demo/test_two_actor_demo.py
@@ -24,6 +24,7 @@ True multi-container isolation is validated by the acceptance test runnable via:
 
 import importlib
 import logging
+from unittest.mock import MagicMock
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
@@ -995,6 +996,147 @@ class TestRunTwoActorDemo:
 
         assert "ERROR SUMMARY" not in caplog.text, (
             "Expected demo to succeed, but got errors:\n" + caplog.text
+        )
+
+
+class TestDumpCaseLogs:
+    """Case-log dump behavior for participant and case-actor outputs."""
+
+    def test_falls_back_to_vendor_case_actor_sub_actor(
+        self, tmp_path, monkeypatch
+    ):
+        finder_client = MagicMock()
+        vendor_client = MagicMock()
+        finder_client.get_list.return_value = [{"logIndex": 0}]
+        vendor_client.get_list.return_value = [{"logIndex": 0}]
+
+        case = demo.VulnerabilityCase(
+            id_="https://example.org/cases/case-dump-fallback",
+            actor_participant_index={
+                "https://example.org/actors/vendor": (
+                    "https://example.org/cases/case-dump-fallback/"
+                    "participants/vendor"
+                ),
+                "https://example.org/actors/finder": (
+                    "https://example.org/cases/case-dump-fallback/"
+                    "participants/finder"
+                ),
+                "https://example.org/actors/case-actor-demo": (
+                    "https://example.org/cases/case-dump-fallback/"
+                    "participants/case-actor"
+                ),
+            },
+        )
+        finder = demo.as_Actor(
+            id_="https://example.org/actors/finder", name="Finder"
+        )
+        vendor = demo.as_Actor(
+            id_="https://example.org/actors/vendor", name="Vendor"
+        )
+        monkeypatch.setenv("DEVLOGS_DIR", str(tmp_path))
+
+        demo._phase_dump_case_logs(
+            finder_client=finder_client,
+            vendor_client=vendor_client,
+            finder=finder,
+            vendor=vendor,
+            case=case,
+            case_actor_client=None,
+        )
+
+        case_slug = "https_example.org_cases_case-dump-fallback"
+        assert (
+            tmp_path / "two-actor" / "finder" / f"{case_slug}-case-log.jsonl"
+        ).exists()
+        assert (
+            tmp_path / "two-actor" / "vendor" / f"{case_slug}-case-log.jsonl"
+        ).exists()
+        assert (
+            tmp_path
+            / "two-actor"
+            / "case-actor"
+            / f"{case_slug}-case-log.jsonl"
+        ).exists()
+        assert any(
+            "/actors/case-actor-demo/demo/cases/case-dump-fallback/log"
+            in call.args[0]
+            for call in vendor_client.get_list.call_args_list
+        )
+
+    def test_prefers_dedicated_case_actor_client_when_provided(
+        self, tmp_path, monkeypatch
+    ):
+        finder_client = MagicMock()
+        vendor_client = MagicMock()
+        case_actor_client = MagicMock()
+        finder_client.get_list.return_value = [{"logIndex": 0}]
+        vendor_client.get_list.return_value = [{"logIndex": 0}]
+        case_actor_client.get_list.return_value = [{"logIndex": 0}]
+
+        case = demo.VulnerabilityCase(
+            id_="https://example.org/cases/case-dump-dedicated"
+        )
+        finder = demo.as_Actor(
+            id_="https://example.org/actors/finder", name="Finder"
+        )
+        vendor = demo.as_Actor(
+            id_="https://example.org/actors/vendor", name="Vendor"
+        )
+        monkeypatch.setenv("DEVLOGS_DIR", str(tmp_path))
+
+        demo._phase_dump_case_logs(
+            finder_client=finder_client,
+            vendor_client=vendor_client,
+            finder=finder,
+            vendor=vendor,
+            case=case,
+            case_actor_client=case_actor_client,
+        )
+
+        case_actor_client.get_list.assert_called_once_with(
+            "/actors/case-actor/demo/cases/case-dump-dedicated/log"
+        )
+
+    def test_falls_back_when_dedicated_case_actor_log_is_empty(
+        self, tmp_path, monkeypatch
+    ):
+        finder_client = MagicMock()
+        vendor_client = MagicMock()
+        case_actor_client = MagicMock()
+        finder_client.get_list.return_value = [{"logIndex": 0}]
+        vendor_client.get_list.return_value = [{"logIndex": 0}]
+        case_actor_client.get_list.return_value = []
+
+        case = demo.VulnerabilityCase(
+            id_="https://example.org/cases/case-dump-empty-dedicated",
+            actor_participant_index={
+                "https://example.org/actors/case-actor-fallback": (
+                    "https://example.org/cases/case-dump-empty-dedicated/"
+                    "participants/case-actor"
+                )
+            },
+        )
+        finder = demo.as_Actor(
+            id_="https://example.org/actors/finder", name="Finder"
+        )
+        vendor = demo.as_Actor(
+            id_="https://example.org/actors/vendor", name="Vendor"
+        )
+        monkeypatch.setenv("DEVLOGS_DIR", str(tmp_path))
+
+        demo._phase_dump_case_logs(
+            finder_client=finder_client,
+            vendor_client=vendor_client,
+            finder=finder,
+            vendor=vendor,
+            case=case,
+            case_actor_client=case_actor_client,
+        )
+
+        assert any(
+            "/actors/case-actor-fallback/demo/cases/"
+            "case-dump-empty-dedicated/log" in call.args[0]
+            for call in vendor_client.get_list.call_args_list
         )
 
 

--- a/vultron/adapters/driving/fastapi/routers/actors.py
+++ b/vultron/adapters/driving/fastapi/routers/actors.py
@@ -29,7 +29,7 @@ from fastapi import (
     Response,
     status,
 )
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 from vultron.adapters.utils import make_id, strip_id_prefix
 from vultron.adapters.driving.fastapi.inbox_handler import (
@@ -53,6 +53,7 @@ from vultron.wire.as2.vocab.base.objects.base import as_Object
 from vultron.wire.as2.vocab.base.objects.collections import (
     as_OrderedCollection,
 )
+from vultron.wire.as2.vocab.base.registry import find_in_vocabulary
 from vultron.wire.as2.errors import (
     VultronParseError,
     VultronParseMissingTypeError,
@@ -453,7 +454,77 @@ def _activity_already_received(
     )
 
 
-def _store_nested_inbox_object(dl: DataLayer, activity: as_Activity) -> None:
+def _get_body(body: dict[str, Any]) -> dict[str, Any]:
+    """FastAPI dependency: return the raw JSON request body dict."""
+    return body
+
+
+def _reparse_as_specific_type(
+    nested: as_Object,
+    raw_obj: dict[str, Any],
+) -> PersistableModel:
+    """Re-parse *raw_obj* with the correct specific vocabulary class.
+
+    When the wire parser validates an inline object as the base ``as_Object``
+    type, domain-specific fields are silently dropped.  This helper looks up
+    the specific vocabulary class for ``nested.type_`` and re-parses
+    *raw_obj* (the raw dict from the wire body) with it so all fields are
+    preserved.
+
+    Returns the re-parsed specific instance, or the original *nested* cast
+    to ``PersistableModel`` when re-parsing fails or is unnecessary.
+    """
+    base: PersistableModel = cast(PersistableModel, nested)
+    obj_type: str | None = nested.type_
+    if obj_type is None:
+        return base
+    try:
+        specific_cls = find_in_vocabulary(obj_type)
+    except KeyError:
+        return base
+    if isinstance(nested, specific_cls):
+        return base
+    try:
+        result = cast(PersistableModel, specific_cls.model_validate(raw_obj))
+        logger.debug(
+            "Re-parsed inline '%s' as specific class %s.",
+            obj_type,
+            specific_cls.__name__,
+        )
+        return result
+    except ValidationError:
+        logger.debug(
+            "Could not re-parse inline '%s' as %s; using base as_Object.",
+            obj_type,
+            specific_cls.__name__,
+        )
+        return base
+
+
+def _store_nested_inbox_object(
+    dl: DataLayer,
+    activity: as_Activity,
+    body: dict[str, Any] | None = None,
+) -> None:
+    """Store the inline nested ``object_`` of an inbox activity.
+
+    When the wire parser parses an Announce or other transitive activity, the
+    inline ``object_`` is validated as the base ``as_Object`` type, which
+    silently drops domain-specific fields (``case_id``, ``event_type``, etc.).
+    This function uses the raw request body to re-parse the nested object with
+    the correct specific vocabulary class so that all fields are preserved.
+    Without this, a subsequent DataLayer round-trip would fail Pydantic
+    validation on the specific class (missing required fields), causing
+    rehydration to return ``None`` and pattern matching to fall back to a
+    less specific pattern (e.g. ``announce_vulnerability_case`` instead of
+    ``announce_case_log_entry``).
+
+    Args:
+        dl: The shared DataLayer for storing the nested object.
+        activity: The parsed AS2 activity whose ``object_`` to store.
+        body: Optional raw JSON request body dict.  When present, used to
+            re-parse the nested object with the correct specific class.
+    """
     nested = getattr(activity, "object_", None)
     if nested is None or isinstance(nested, str):
         return
@@ -465,8 +536,15 @@ def _store_nested_inbox_object(dl: DataLayer, activity: as_Activity) -> None:
     ):
         return
 
+    raw_obj = body.get("object") if body is not None else None
+    typed_nested: PersistableModel = (
+        _reparse_as_specific_type(nested, raw_obj)
+        if isinstance(raw_obj, dict)
+        else cast(PersistableModel, nested)
+    )
+
     try:
-        dl.create(object_to_record(cast(PersistableModel, nested)))
+        dl.create(object_to_record(typed_nested))
     except ValueError:
         pass
 
@@ -520,6 +598,7 @@ def post_actor_inbox(
     background_tasks: BackgroundTasks,
     activity: as_Activity = Depends(parse_activity),
     dl: DataLayer = Depends(get_shared_dl),
+    body: dict[str, Any] = Depends(_get_body),
 ) -> None:
     """Adds an item to the Actor's Inbox.
     The 202 Accepted status code indicates that the request has been accepted for
@@ -530,6 +609,8 @@ def post_actor_inbox(
         request: The FastAPI Request (used to resolve the per-app emitter).
         activity: The Activity item to add to the Inbox.
         background_tasks: FastAPI BackgroundTasks instance to schedule background tasks.
+        body: Raw JSON request body dict, used to re-parse inline nested
+            objects with their specific vocabulary classes.
     Returns:
         None
     Raises:
@@ -546,7 +627,7 @@ def post_actor_inbox(
         )
         return None
 
-    _store_nested_inbox_object(dl, activity)
+    _store_nested_inbox_object(dl, activity, body)
     _store_inbox_activity(dl, activity)
 
     logger.debug(

--- a/vultron/adapters/driving/fastapi/routers/demo_triggers.py
+++ b/vultron/adapters/driving/fastapi/routers/demo_triggers.py
@@ -378,7 +378,10 @@ def demo_get_case_log(
         and e.case_id == canonical_case_id
     ]
     raw_entries.sort(key=lambda e: e.log_index)
-    payloads = [e.model_dump(mode="json", by_alias=True) for e in raw_entries]
+    payloads = [
+        e.model_dump(mode="json", by_alias=True, exclude_none=True)
+        for e in raw_entries
+    ]
 
     accept = request.headers.get("accept", "")
     if fmt == "ndjson" or "application/x-ndjson" in accept:

--- a/vultron/core/behaviors/case/nodes/lifecycle.py
+++ b/vultron/core/behaviors/case/nodes/lifecycle.py
@@ -37,6 +37,33 @@ from vultron.core.ports.case_persistence import CaseOutboxPersistence
 logger = logging.getLogger(__name__)
 
 
+def _extract_payload_snapshot(activity: Any) -> dict[str, Any]:
+    """Build a normalized payload snapshot for case-log commits."""
+    event_activity = getattr(activity, "activity", None)
+    if event_activity is not None and hasattr(event_activity, "model_dump"):
+        return cast(
+            dict[str, Any],
+            event_activity.model_dump(
+                mode="json",
+                by_alias=True,
+                serialize_as_any=True,
+                exclude_none=True,
+            ),
+        )
+
+    if hasattr(activity, "model_dump"):
+        return cast(
+            dict[str, Any],
+            activity.model_dump(
+                mode="json",
+                by_alias=True,
+                serialize_as_any=True,
+                exclude_none=True,
+            ),
+        )
+    return {}
+
+
 class CommitCaseLogEntryNode(DataLayerAction):
     """
     Commit a hash-chained CaseLogEntry and fan it out to all case participants.
@@ -129,11 +156,15 @@ class CommitCaseLogEntryNode(DataLayerAction):
         else:
             object_id = case_id
             event_type = "case_event"
+        payload_snapshot = (
+            _extract_payload_snapshot(activity) if activity is not None else {}
+        )
 
         tree = create_commit_log_entry_tree(
             case_id=case_id,
             object_id=object_id,
             event_type=event_type,
+            payload_snapshot=payload_snapshot,
         )
         result = BTBridge(
             datalayer=cast(CaseOutboxPersistence, self.datalayer)

--- a/vultron/core/behaviors/embargo/announce_teardown_tree.py
+++ b/vultron/core/behaviors/embargo/announce_teardown_tree.py
@@ -31,6 +31,7 @@ Per specs/behavior-tree-integration.yaml BT-06-001.
 """
 
 import logging
+from typing import Any
 
 import py_trees
 
@@ -97,6 +98,7 @@ def remove_embargo_from_case_tree(
 def add_embargo_to_case_tree(
     case_id: str,
     embargo_id: str,
+    payload_snapshot: dict[str, Any] | None = None,
 ) -> py_trees.behaviour.Behaviour:
     """Create the BT for receiver-side embargo activation (protocol EA).
 
@@ -124,6 +126,7 @@ def add_embargo_to_case_tree(
                 case_id=case_id,
                 object_id=embargo_id,
                 event_type="add_embargo_event_to_case",
+                payload_snapshot=payload_snapshot,
             ),
         ],
     )
@@ -139,6 +142,7 @@ def invite_to_embargo_on_case_tree(
     case_id: str,
     invitee_id: str,
     invite_id: str,
+    payload_snapshot: dict[str, Any] | None = None,
 ) -> py_trees.behaviour.Behaviour:
     """Create the BT for receiving embargo invitation (protocol EI).
 
@@ -170,6 +174,7 @@ def invite_to_embargo_on_case_tree(
                 case_id=case_id,
                 object_id=invite_id,
                 event_type="invite_to_embargo_on_case",
+                payload_snapshot=payload_snapshot,
             ),
         ],
     )
@@ -187,6 +192,7 @@ def accept_invite_to_embargo_tree(
     embargo_id: str,
     accepting_actor_id: str,
     invite_id: str,
+    payload_snapshot: dict[str, Any] | None = None,
 ) -> py_trees.behaviour.Behaviour:
     """Create the BT for accepting embargo invitation (protocol EA).
 
@@ -218,6 +224,7 @@ def accept_invite_to_embargo_tree(
                 case_id=case_id,
                 object_id=embargo_id,
                 event_type="accept_invite_to_embargo_on_case",
+                payload_snapshot=payload_snapshot,
             ),
         ],
     )
@@ -236,6 +243,7 @@ def reject_invite_to_embargo_tree(
     rejecting_actor_id: str,
     invite_id: str,
     embargo_id: str | None = None,
+    payload_snapshot: dict[str, Any] | None = None,
 ) -> py_trees.behaviour.Behaviour:
     """Create the BT for rejecting embargo invitation (protocol EA).
 
@@ -268,6 +276,7 @@ def reject_invite_to_embargo_tree(
                 case_id=case_id,
                 object_id=invite_id,
                 event_type="reject_invite_to_embargo_on_case",
+                payload_snapshot=payload_snapshot,
             ),
         ],
     )

--- a/vultron/core/behaviors/embargo/nodes.py
+++ b/vultron/core/behaviors/embargo/nodes.py
@@ -34,7 +34,7 @@ at construction time.
 Per specs/behavior-tree-integration.yaml BT-06-001.
 """
 
-from typing import cast
+from typing import Any, cast
 
 import py_trees
 from py_trees.common import Status
@@ -415,11 +415,13 @@ class CommitLogCascadeNode(DataLayerAction):
         object_id: str,
         event_type: str,
         name: str | None = None,
+        payload_snapshot: dict[str, Any] | None = None,
     ):
         super().__init__(name=name or self.__class__.__name__)
         self.case_id = case_id
         self.object_id = object_id
         self.event_type = event_type
+        self.payload_snapshot = payload_snapshot
 
     def update(self) -> Status:
         from vultron.core.use_cases.received.actor import (
@@ -457,6 +459,7 @@ class CommitLogCascadeNode(DataLayerAction):
                 actor_id=actor_id,
                 dl=cast(CaseOutboxPersistence, self.datalayer),
                 sync_port=None,
+                payload_snapshot=self.payload_snapshot,
             )
         except Exception as exc:
             self.feedback_message = (

--- a/vultron/core/behaviors/sync/commit_tree.py
+++ b/vultron/core/behaviors/sync/commit_tree.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 """Behavior tree factory for committing and fanning out case log entries."""
 
+from typing import Any
+
 import py_trees
 
 from vultron.core.behaviors.sync.nodes import (
@@ -12,7 +14,11 @@ from vultron.core.behaviors.sync.nodes import (
 
 
 def create_commit_log_entry_tree(
-    case_id: str, object_id: str, event_type: str
+    case_id: str,
+    object_id: str,
+    event_type: str,
+    *,
+    payload_snapshot: dict[str, Any] | None = None,
 ) -> py_trees.behaviour.Behaviour:
     return py_trees.composites.Sequence(
         name="CommitLogEntryBT",
@@ -25,6 +31,7 @@ def create_commit_log_entry_tree(
                 case_id=case_id,
                 object_id=object_id,
                 event_type=event_type,
+                payload_snapshot=payload_snapshot,
                 name="CreateLogEntry",
             ),
             PersistLogEntryNode(name="PersistLogEntry"),

--- a/vultron/core/use_cases/received/embargo.py
+++ b/vultron/core/use_cases/received/embargo.py
@@ -1,7 +1,7 @@
 """Use cases for embargo management activities."""
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from vultron.core.models.events.embargo import (
     AcceptInviteToEmbargoOnCaseReceivedEvent,
@@ -21,6 +21,10 @@ from vultron.core.models.protocols import (
     PersistableModel,
     is_case_model,
 )
+from vultron.core.use_cases.triggers.sync import (
+    commit_log_entry_trigger,
+    extract_activity_snapshot,
+)
 
 if TYPE_CHECKING:
     from vultron.core.ports.sync_activity import SyncActivityPort
@@ -35,6 +39,7 @@ def _commit_embargo_log_cascade(
     dl: CaseOutboxPersistence,
     receiving_actor_id: str | None,
     sync_port: "SyncActivityPort | None",
+    payload_snapshot: dict[str, Any] | None = None,
 ) -> None:
     """Commit a CaseLogEntry and fan it out to all case participants.
 
@@ -44,9 +49,13 @@ def _commit_embargo_log_cascade(
 
     Silently skips when *case_id* or *object_id* is ``None``, or when no
     CaseActor can be resolved.
+
+    Args:
+        payload_snapshot: Optional normalised AS2 activity snapshot.  Pass
+            the result of ``extract_activity_snapshot(request)`` to ensure
+            each log entry carries the full inbound AS2 activity payload.
     """
     from vultron.core.use_cases.received.actor import _find_case_actor_id
-    from vultron.core.use_cases.triggers.sync import commit_log_entry_trigger
 
     if case_id is None or object_id is None:
         logger.warning(
@@ -86,6 +95,7 @@ def _commit_embargo_log_cascade(
         event_type=event_type,
         actor_id=actor_id,
         dl=dl,
+        payload_snapshot=payload_snapshot,
         sync_port=sync_port,
     )
 
@@ -168,7 +178,11 @@ class AddEmbargoEventToCaseReceivedUseCase:
             )
             return
 
-        tree = add_embargo_to_case_tree(case_id=case_id, embargo_id=embargo_id)
+        tree = add_embargo_to_case_tree(
+            case_id=case_id,
+            embargo_id=embargo_id,
+            payload_snapshot=extract_activity_snapshot(request),
+        )
         bridge = BTBridge(datalayer=self._dl)
         result = bridge.execute_with_setup(
             tree=tree,
@@ -244,6 +258,7 @@ class RemoveEmbargoEventFromCaseReceivedUseCase:
             dl=self._dl,
             receiving_actor_id=request.receiving_actor_id,
             sync_port=self._sync_port,
+            payload_snapshot=extract_activity_snapshot(request),
         )
 
 
@@ -293,7 +308,10 @@ class InviteToEmbargoOnCaseReceivedUseCase:
             return
 
         tree = invite_to_embargo_on_case_tree(
-            case_id=case_id, invitee_id=invitee_id, invite_id=invite_id
+            case_id=case_id,
+            invitee_id=invitee_id,
+            invite_id=invite_id,
+            payload_snapshot=extract_activity_snapshot(request),
         )
         bridge = BTBridge(datalayer=self._dl)
         result = bridge.execute_with_setup(
@@ -352,6 +370,7 @@ class AcceptInviteToEmbargoOnCaseReceivedUseCase:
             embargo_id=embargo_id,
             accepting_actor_id=accepting_actor_id,
             invite_id=invite_id,
+            payload_snapshot=extract_activity_snapshot(request),
         )
         bridge = BTBridge(datalayer=self._dl)
         result = bridge.execute_with_setup(
@@ -419,6 +438,7 @@ class RejectInviteToEmbargoOnCaseReceivedUseCase:
             rejecting_actor_id=rejecting_actor_id,
             invite_id=invite_id or "",
             embargo_id=embargo_id,
+            payload_snapshot=extract_activity_snapshot(request),
         )
         bridge = BTBridge(datalayer=self._dl)
         result = bridge.execute_with_setup(

--- a/vultron/core/use_cases/received/status.py
+++ b/vultron/core/use_cases/received/status.py
@@ -200,6 +200,7 @@ class AddParticipantStatusToParticipantReceivedUseCase:
         from vultron.core.use_cases.received.actor import _find_case_actor_id
         from vultron.core.use_cases.triggers.sync import (
             commit_log_entry_trigger,
+            extract_activity_snapshot,
         )
 
         request = self._request
@@ -252,4 +253,5 @@ class AddParticipantStatusToParticipantReceivedUseCase:
             actor_id=actor_id,
             dl=self._dl,
             sync_port=self._sync_port,
+            payload_snapshot=extract_activity_snapshot(request),
         )

--- a/vultron/core/use_cases/triggers/sync.py
+++ b/vultron/core/use_cases/triggers/sync.py
@@ -24,7 +24,7 @@ Spec: SYNC-02-002, SYNC-02-003, SYNC-03-001, SYNC-03-002.
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 from vultron.core.models.case_log import CaseLogEntry
 from vultron.core.models.case_log_entry import VultronCaseLogEntry
@@ -41,7 +41,40 @@ from vultron.core.use_cases._helpers import case_addressees
 from vultron.core.use_cases.received.sync import _reconstruct_tail_hash
 from vultron.errors import VultronError
 
+if TYPE_CHECKING:
+    from vultron.core.models.events.base import VultronEvent
+
 logger = logging.getLogger(__name__)
+
+
+def extract_activity_snapshot(request: "VultronEvent") -> dict[str, Any]:
+    """Return a normalised AS2 payload snapshot from a ``VultronEvent``.
+
+    When ``request.activity`` is populated (``include_activity=True`` in
+    the registry entry), returns its ``model_dump`` as the snapshot so
+    that case-log entries carry the full inbound AS2 activity object.
+    Returns an empty dict when no activity snapshot is available.
+
+    Args:
+        request: The inbound domain event produced by ``extract_intent()``.
+
+    Returns:
+        A JSON-serialisable dict suitable for ``payload_snapshot``.
+
+    Spec: SYNC-02-002, SYNC-02-003.
+    """
+    activity = request.activity
+    if activity is None or not hasattr(activity, "model_dump"):
+        return {}
+    return cast(
+        dict[str, Any],
+        activity.model_dump(
+            mode="json",
+            by_alias=True,
+            serialize_as_any=True,
+            exclude_none=True,
+        ),
+    )
 
 
 def _to_persistable_entry(

--- a/vultron/demo/scenario/two_actor_demo.py
+++ b/vultron/demo/scenario/two_actor_demo.py
@@ -28,6 +28,8 @@ import pathlib
 import sys
 from typing import Optional, Tuple
 
+import httpx
+
 from vultron.adapters.utils import strip_id_prefix
 from vultron.core.states.cs import CS_vfd
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
@@ -776,7 +778,21 @@ def _phase_dump_case_logs(
         with demo_step(f"Dumping case log for {actor_name}"):
             case_key = strip_id_prefix(case_id)
             log_path = f"/actors/{actor_route_key}/demo/cases/{case_key}/log"
-            entries = client.get_list(log_path)
+            try:
+                entries = client.get_list(log_path)
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code != 404:
+                    raise
+                # D5-2: the dedicated case-actor container does not hold the
+                # case; the case-actor sub-actor runs inside the vendor
+                # container. Treat 404 the same as an empty list so the
+                # sub-actor fallback below can supply the entries.
+                logger.info(
+                    "Case not found on dedicated %s container (HTTP 404, D5-2);"
+                    " will attempt vendor sub-actor fallback.",
+                    actor_name,
+                )
+                entries = []
             if (
                 not entries
                 and actor_name == "case-actor"
@@ -788,7 +804,7 @@ def _phase_dump_case_logs(
                     f"{case_actor_sub_actor_key}/demo/cases/{case_key}/log"
                 )
                 logger.info(
-                    "Dedicated case-actor log is empty; "
+                    "Dedicated case-actor log unavailable; "
                     "falling back to vendor sub-actor route key '%s'",
                     case_actor_sub_actor_key,
                 )

--- a/vultron/demo/scenario/two_actor_demo.py
+++ b/vultron/demo/scenario/two_actor_demo.py
@@ -725,9 +725,11 @@ def _phase_dump_case_logs(
 
         {DEVLOGS_DIR}/{demo_name}/{actor_name}/{case_id_slug}-case-log.jsonl
 
-    The case-actor container is included only when *case_actor_client* is
-    provided.  Each dump step is wrapped in ``demo_step`` so that a failure
-    is recorded and ultimately surfaced by ``assert_demo_success()``.
+    The case-actor log is always included: from *case_actor_client* when a
+    dedicated case-actor service is configured, otherwise from the vendor
+    container using the in-container case-actor sub-actor route key. Each
+    dump step is wrapped in ``demo_step`` so that a failure is recorded and
+    ultimately surfaced by ``assert_demo_success()``.
 
     Args:
         finder_client: DataLayerClient for the Finder container.
@@ -752,18 +754,45 @@ def _phase_dump_case_logs(
         .strip("_")
     )
 
-    actors: list[tuple[str, DataLayerClient]] = [
-        ("finder", finder_client),
-        ("vendor", vendor_client),
+    case_actor_sub_actor_key = next(
+        (
+            strip_id_prefix(actor_id)
+            for actor_id in case.actor_participant_index
+            if strip_id_prefix(actor_id).startswith("case-actor")
+        ),
+        None,
+    )
+
+    actors: list[tuple[str, DataLayerClient, str]] = [
+        ("finder", finder_client, "finder"),
+        ("vendor", vendor_client, "vendor"),
     ]
     if case_actor_client is not None:
-        actors.append(("case-actor", case_actor_client))
+        actors.append(("case-actor", case_actor_client, "case-actor"))
+    elif case_actor_sub_actor_key is not None:
+        actors.append(("case-actor", vendor_client, case_actor_sub_actor_key))
 
-    for actor_name, client in actors:
+    for actor_name, client, actor_route_key in actors:
         with demo_step(f"Dumping case log for {actor_name}"):
             case_key = strip_id_prefix(case_id)
-            log_path = f"/actors/{actor_name}/demo/cases/{case_key}/log"
+            log_path = f"/actors/{actor_route_key}/demo/cases/{case_key}/log"
             entries = client.get_list(log_path)
+            if (
+                not entries
+                and actor_name == "case-actor"
+                and client is case_actor_client
+                and case_actor_sub_actor_key is not None
+            ):
+                fallback_path = (
+                    "/actors/"
+                    f"{case_actor_sub_actor_key}/demo/cases/{case_key}/log"
+                )
+                logger.info(
+                    "Dedicated case-actor log is empty; "
+                    "falling back to vendor sub-actor route key '%s'",
+                    case_actor_sub_actor_key,
+                )
+                entries = vendor_client.get_list(fallback_path)
             if not entries:
                 raise ValueError(
                     f"No case log entries for actor={actor_name!r}, "
@@ -854,10 +883,7 @@ def run_two_actor_demo(
         finder=finder,
         vendor=vendor,
         case=case,
-        # The two-actor demo uses the vendor container as case manager;
-        # the dedicated case-actor service carries no log entries for this
-        # case, so we only dump finder and vendor.
-        case_actor_client=None,
+        case_actor_client=case_actor_client,
     )
 
     logger.info("=" * 80)

--- a/vultron/semantic_registry/case.py
+++ b/vultron/semantic_registry/case.py
@@ -71,6 +71,7 @@ ENTRIES: list[SemanticEntry] = [
         event_class=EngageCaseReceivedEvent,
         use_case_class=EngageCaseReceivedUseCase,
         wire_activity_class=_RmEngageCaseActivity,
+        include_activity=True,
     ),
     SemanticEntry(
         semantics=MessageSemantics.DEFER_CASE,

--- a/vultron/semantic_registry/embargo.py
+++ b/vultron/semantic_registry/embargo.py
@@ -64,6 +64,7 @@ ENTRIES: list[SemanticEntry] = [
         event_class=AddEmbargoEventToCaseReceivedEvent,
         use_case_class=AddEmbargoEventToCaseReceivedUseCase,
         wire_activity_class=_AddEmbargoToCaseActivity,
+        include_activity=True,
     ),
     SemanticEntry(
         semantics=MessageSemantics.REMOVE_EMBARGO_EVENT_FROM_CASE,
@@ -71,6 +72,7 @@ ENTRIES: list[SemanticEntry] = [
         event_class=RemoveEmbargoEventFromCaseReceivedEvent,
         use_case_class=RemoveEmbargoEventFromCaseReceivedUseCase,
         wire_activity_class=_RemoveEmbargoFromCaseActivity,
+        include_activity=True,
     ),
     SemanticEntry(
         semantics=MessageSemantics.ANNOUNCE_EMBARGO_EVENT_TO_CASE,
@@ -93,6 +95,7 @@ ENTRIES: list[SemanticEntry] = [
         event_class=AcceptInviteToEmbargoOnCaseReceivedEvent,
         use_case_class=AcceptInviteToEmbargoOnCaseReceivedUseCase,
         wire_activity_class=_EmAcceptEmbargoActivity,
+        include_activity=True,
     ),
     SemanticEntry(
         semantics=MessageSemantics.REJECT_INVITE_TO_EMBARGO_ON_CASE,
@@ -100,5 +103,6 @@ ENTRIES: list[SemanticEntry] = [
         event_class=RejectInviteToEmbargoOnCaseReceivedEvent,
         use_case_class=RejectInviteToEmbargoOnCaseReceivedUseCase,
         wire_activity_class=_EmRejectEmbargoActivity,
+        include_activity=True,
     ),
 ]

--- a/vultron/semantic_registry/status.py
+++ b/vultron/semantic_registry/status.py
@@ -75,5 +75,6 @@ ENTRIES: list[SemanticEntry] = [
         event_class=AddParticipantStatusToParticipantReceivedEvent,
         use_case_class=AddParticipantStatusToParticipantReceivedUseCase,
         wire_activity_class=_AddStatusToParticipantActivity,
+        include_activity=True,
     ),
 ]


### PR DESCRIPTION
Closes #690

- Threaded payload_snapshot through create_commit_log_entry_tree() and wired CommitCaseLogEntryNode to serialize inbound blackboard activity payloads.
- Added case-node tests that assert payload snapshot forwarding.
- Updated two-actor demo log export to always produce a case-actor JSONL artifact, with vendor-sub-actor fallback when dedicated case-actor logs are empty.
- Added demo tests for fallback and dedicated case-actor export paths.
- Recorded build learnings for #690.