### PR TITLE
docs: plan concern #622 — trigger-side BTBridge delegation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -452,6 +452,21 @@ Short entries are reproduced here; longer ones are referenced below.
   ARCH-12-007 and concern #804.
 - **Adding a New Pitfall: Check the Routing Policy First** — see
   [notes/agents-md-structure.md](notes/agents-md-structure.md)
+- **Trigger-Side execute() Must Delegate SM Transitions to BTBridge** — A
+  trigger-side `execute()` method that calls `EmbargoLifecycle`, `EMAdapter`,
+  or creates `ParticipantStatus` records with a specific `rm_state`/`em_state`
+  directly (outside a BT execution context) is a BT-06-006 violation.
+  State machine transitions — RM transitions (e.g., `RM.INVALID`, `RM.CLOSED`),
+  EM lifecycle transitions (e.g., `propose_embargo`, `terminate_embargo`) — are
+  protocol-significant behavior (BT-15-001) and MUST live in BT leaf nodes
+  accessed via `bridge.execute_with_setup()`. Only infrastructure glue
+  (instantiate BT → set up blackboard → call bridge → check status → extract
+  output) is permitted directly in `execute()`. The historical asymmetry between
+  `received/` (BTBridge-delegating) and `triggers/` (inline) arose from the
+  now-retired "simple CRUD" guidance. See
+  [notes/bt-integration.md](notes/bt-integration.md)
+  § "Trigger/Received Parity" and `specs/behavior-tree-integration.yaml`
+  BT-15-001, BT-15-002.
 
 ## Skill Interaction Rules
 

--- a/notes/bt-integration.md
+++ b/notes/bt-integration.md
@@ -209,6 +209,45 @@ The `execute()` method MAY contain infrastructure glue only:
 
 Nothing domain-significant lives outside the tree.
 
+### Trigger/Received Parity
+
+The BTBridge requirement applies equally to **trigger-side** and
+**received-side** `execute()` methods. There is no carve-out for trigger
+use cases.
+
+State machine transitions — RM transitions (e.g., `RM.INVALID`, `RM.CLOSED`),
+EM lifecycle calls (e.g., `EmbargoLifecycle.propose_embargo()`), direct
+`ParticipantStatus` writes with a specific `rm_state` — are all
+protocol-significant behavior (BT-15-001, BT-06-006). They MUST live in BT
+leaf nodes executed via `bridge.execute_with_setup()`, not directly in
+`execute()`.
+
+```python
+# ❌ WRONG — trigger-side inline RM state transition
+def execute(self) -> dict:
+    set_status = ParticipantStatus(rm_state=RM.INVALID, ...)
+    _idempotent_create(dl, ..., set_status, ...)
+    add_activity_to_outbox(actor_id, activity_id, dl)
+    return {"activity": activity_dict}
+```
+
+```python
+# ✅ CORRECT — trigger-side SM transition in BTBridge
+def execute(self) -> dict:
+    bridge = BTBridge(datalayer=dl, trigger_activity=factory)
+    tree = invalidate_report_trigger_bt(...)
+    result = bridge.execute_with_setup(tree, actor_id=actor_id)
+    if result.status != Status.SUCCESS:
+        raise VultronValidationError(
+            f"InvalidateReport failed: {BTBridge.get_failure_reason(tree)}"
+        )
+    return {"activity": captured.get("activity")}
+```
+
+The historical asymmetry — where `received/` use cases used BTBridge and
+`triggers/` did not — arose from the now-retired "simple CRUD" guidance.
+See BT-15-001 in `specs/behavior-tree-integration.yaml`.
+
 ### Historical Decision Table (Retired)
 
 The "When to Use BTs vs. Procedural Code" table that previously appeared in

--- a/plan/history/2606/learning/CONCERN-622.md
+++ b/plan/history/2606/learning/CONCERN-622.md
@@ -1,0 +1,47 @@
+---
+source: CONCERN-622
+timestamp: '2026-06-09T17:22:55.060873+00:00'
+title: Trigger-side execute() must delegate SM transitions to BTBridge
+type: learning
+---
+
+## Concern #622 — Trigger-side execute() methods contain inline state machine logic that should live in Behavior Tree nodes
+
+**Category**: Technical debt
+**Severity**: Medium
+
+### Summary
+
+Trigger-side use-case `execute()` methods in `triggers/embargo.py`,
+`triggers/case.py` (now `triggers/case/`), and `triggers/report.py`
+contained substantial EM/RM state machine logic (state validation,
+transition, cascade, and persistence) instead of delegating to Behavior
+Trees via the BTBridge pattern. The existing guidance in
+`notes/bt-integration.md` — "use procedural code for simple CRUD" — had
+been used to justify this, but state machine transitions are not simple
+CRUD, and that guidance has now been fully retired.
+
+### Evidence
+
+- `vultron/core/use_cases/triggers/embargo.py` — `SvcProposeEmbargoRevisionUseCase` calls `EmbargoLifecycle.propose_embargo()` and `send_case_actor_activity()` directly without BTBridge
+- `vultron/core/use_cases/triggers/report.py` — `SvcInvalidateReportUseCase`, `SvcRejectReportUseCase`, `SvcCloseReportUseCase` create `ParticipantStatus` records with explicit `rm_state` fields outside any BT context
+- `vultron/core/behaviors/bridge.py` — `BTBridge` + `execute_with_setup()` already exist and are used correctly on the `received/` side
+- Four of five `triggers/embargo.py` `execute()` methods had already been migrated to BTBridge before this concern was planned
+
+### Impact if Ignored
+
+State machine transitions that bypass BTs cannot be audited, logged by
+node, or observed at the BT level. Failure reasons are opaque (bare
+raises rather than structured BT FAILURE status with
+`get_failure_reason()`). The inconsistency between `received/`
+(BT-delegating) and `triggers/` (procedural) makes the codebase harder
+to reason about and extends, and undermines the core design goal of
+having all business logic implemented in auditable behavior trees.
+
+### Resolution
+
+**Resolved**: 2026-06-09 — implementation tracked in #848, #849, #850.
+
+Docs PR: [#847](https://github.com/CERTCC/Vultron/pull/847).
+Spec: `specs/behavior-tree-integration.yaml` BT-15-001, BT-15-002.
+Notes: `notes/bt-integration.md` § Trigger/Received Parity.

--- a/specs/behavior-tree-integration.yaml
+++ b/specs/behavior-tree-integration.yaml
@@ -294,3 +294,41 @@ groups:
     rationale: >-
       Duplicated fan-out implementations drift over time and re-introduce
       silent-failure behavior in only some pathways.
+- id: BT-15
+  title: Trigger-Side Use-Case Contract
+  kind: domain
+  specs:
+  - id: BT-15-001
+    priority: MUST
+    statement: >-
+      Trigger-side execute() methods MUST delegate state-machine transitions
+      (RM, EM, CS) to BT leaf nodes via BTBridge, following the same pattern
+      as received-side use cases.
+    rationale: >-
+      State machine transitions are protocol-significant behavior (BT-06-001).
+      Inline transitions in execute() bypass BT audit, logging, and failure
+      introspection via get_failure_reason(). The historical asymmetry between
+      trigger-side and received-side use cases arose from the now-retired
+      "simple CRUD" guidance.
+    relationships:
+    - rel_type: refines
+      spec_id: BT-06-001
+      note: SM transitions are protocol-significant behavior with no skip threshold
+    - rel_type: refines
+      spec_id: BT-06-006
+      note: SM transitions performed outside a BT violate BT-06-006
+  - id: BT-15-002
+    priority: MUST_NOT
+    statement: >-
+      Trigger-side execute() methods MUST NOT call domain lifecycle methods
+      (e.g., EmbargoLifecycle, EMAdapter, direct ParticipantStatus writes with
+      rm_state/em_state) outside a BT execution context.
+    rationale: >-
+      Direct lifecycle calls in execute() make protocol transitions invisible
+      to BT-level audit and observability tooling. The BTBridge pattern
+      (instantiate BT → execute_with_setup() → introspect result) is the
+      required contract for all use-case execute() methods that perform state
+      transitions.
+    relationships:
+    - rel_type: refines
+      spec_id: BT-06-006


### PR DESCRIPTION
- Closes #622

## Summary

Plans concern #622 by formalising the trigger/received parity rule: trigger-side execute() methods must delegate all state-machine transitions to BT leaf nodes via BTBridge, just like received-side use cases. Adds a spec group, notes clarification, and AGENTS.md pitfall.

## Changes

- specs/behavior-tree-integration.yaml: Add BT-15 group (Trigger-Side Use-Case Contract) with BT-15-001 (MUST delegate SM transitions via BTBridge) and BT-15-002 (MUST NOT call domain lifecycle methods outside BT context)
- notes/bt-integration.md: Add Trigger/Received Parity section with anti-pattern/correct code examples and historical context on the retired simple CRUD guidance
- AGENTS.md: Add pitfall entry capturing the inline SM transition anti-pattern with spec cross-references