### PR TITLE
Add concrete wire-branch Vultron actor types

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -87,6 +87,12 @@ header.
 
 ### 2026-06-09 ISSUE-825 — Actor-participant cache checks should fail only on contradictions
 
+- Canonical actor→participant resolution should use `case_participants` as the
+  source of truth and treat `actor_participant_index` as a derived cache.
+- Fail fast when the cache contradicts canonical data (wrong/stale participant),
+  but do not treat a missing cache entry as fatal when canonical participant
+  data exists.
+
 ### 2026-06-09 ISSUE-710 — Embargo received-side BT adoption
 
 - BT node parameter shadowing: When migrating procedural logic to BT nodes,
@@ -106,12 +112,6 @@ header.
   CommitLogCascadeNode as a leaf; cascade is never a post-BT callback.
 - Post-implementation code review caught actor_id bug before merge; review
   gates on correctness, not style.
-
-- Canonical actor→participant resolution should use `case_participants` as the
-  source of truth and treat `actor_participant_index` as a derived cache.
-- Fail fast when the cache contradicts canonical data (wrong/stale participant),
-  but do not treat a missing cache entry as fatal when canonical participant
-  data exists.
 - BT-14-001 compliance is CRITICAL for peer broadcast nodes: CommitLogCascadeNode
   MUST return FAILURE when cascade dispatch fails, not SUCCESS. Masking delivery
   failure with SUCCESS causes silent state divergence (missed by initial code
@@ -122,3 +122,12 @@ header.
   so future reviewers understand why "Always SUCCESS" is intentional, not a bug.
   The pattern supports broadcasting log entries even when participant doesn't
   exist on this peer yet (state gap resolved by broadcast reception).
+
+### 2026-06-09 ISSUE-801 — Wire actor vocabulary overrides must preserve base-module registration
+
+- Overriding all actor keys in `VOCABULARY` from `vultron_actor.py` can leave
+  `vultron.wire.as2.vocab.base.objects.actors` with zero registered concrete
+  types, tripping the registry-completeness invariant.
+- Keep at least one base-actors-module registration (for now `Actor` →
+  `as_Actor`) and override concrete keys (`Person`, `Organization`, etc.) with
+  wire-branch Vultron actor subclasses.

--- a/plan/history/2606/implementation/ISSUE-801.md
+++ b/plan/history/2606/implementation/ISSUE-801.md
@@ -1,0 +1,14 @@
+---
+source: ISSUE-801
+timestamp: '2026-06-09T17:48:30.458678+00:00'
+title: Wire actor types moved to wire subclasses
+type: implementation
+---
+
+## Issue #801 — Wire-branch actor types: replace re-export with proper wire subclasses
+
+Replaced the wire `vultron_actor.py` core re-export shim with concrete wire-branch actor classes that inherit from `as_Actor`, preserving AS2 concerns in the wire layer while keeping adapter actor resolution compatible.
+
+Updated wire actor tests to assert vocabulary mappings and verify core-to-wire `model_validate()` round-trip behavior for shared actor fields.
+
+PR: [#851](https://github.com/CERTCC/Vultron/pull/851)

--- a/test/core/models/test_actor.py
+++ b/test/core/models/test_actor.py
@@ -12,6 +12,7 @@ from vultron.core.models.actor import (
     VultronService,
 )
 from vultron.core.models.base import CoreObject
+from vultron.core.models.enums import VultronActorType
 from vultron.core.models.registry import CORE_VOCABULARY
 
 
@@ -52,8 +53,11 @@ def test_person_org_service_application_and_group_register():
 
 
 def test_concrete_actor_type_annotations_are_literal():
-    assert VultronPerson.model_fields["type_"].annotation == Literal["Person"]
+    assert (
+        VultronPerson.model_fields["type_"].annotation
+        == Literal[VultronActorType.PERSON]
+    )
     assert (
         VultronOrganization.model_fields["type_"].annotation
-        == Literal["Organization"]
+        == Literal[VultronActorType.ORGANIZATION]
     )

--- a/test/wire/as2/vocab/test_vultron_actor.py
+++ b/test/wire/as2/vocab/test_vultron_actor.py
@@ -20,7 +20,7 @@ import unittest
 from datetime import timedelta
 
 from vultron.core.models.actor import VultronPerson as CoreVultronPerson
-from vultron.wire.as2.enums import as_ActorType
+from vultron.core.models.enums import VultronActorType
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.base.registry import VOCABULARY
 from vultron.wire.as2.vocab.objects.embargo_policy import EmbargoPolicy
@@ -53,7 +53,7 @@ class TestVultronPersonBasics(unittest.TestCase):
 
     def test_as_type_is_person(self):
         p = VultronPerson(id_="https://example.org/users/alice")
-        self.assertEqual(as_ActorType.PERSON, p.type_)
+        self.assertEqual(VultronActorType.PERSON, p.type_)
 
     def test_embargo_policy_defaults_to_none(self):
         p = VultronPerson(id_="https://example.org/users/alice")
@@ -109,7 +109,7 @@ class TestVultronOrganizationBasics(unittest.TestCase):
 
     def test_as_type_is_organization(self):
         org = VultronOrganization(id_="https://example.org/orgs/vendor")
-        self.assertEqual(as_ActorType.ORGANIZATION, org.type_)
+        self.assertEqual(VultronActorType.ORGANIZATION, org.type_)
 
     def test_embargo_policy_defaults_to_none(self):
         org = VultronOrganization(id_="https://example.org/orgs/vendor")
@@ -136,7 +136,7 @@ class TestVultronServiceBasics(unittest.TestCase):
 
     def test_as_type_is_service(self):
         svc = VultronService(id_="https://example.org/services/bot")
-        self.assertEqual(as_ActorType.SERVICE, svc.type_)
+        self.assertEqual(VultronActorType.SERVICE, svc.type_)
 
     def test_embargo_policy_defaults_to_none(self):
         svc = VultronService(id_="https://example.org/services/bot")

--- a/test/wire/as2/vocab/test_vultron_actor.py
+++ b/test/wire/as2/vocab/test_vultron_actor.py
@@ -20,7 +20,7 @@ import unittest
 from datetime import timedelta
 
 from vultron.core.models.actor import VultronPerson as CoreVultronPerson
-from vultron.core.models.enums import VultronActorType
+from vultron.wire.as2.enums import as_ActorType
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.base.registry import VOCABULARY
 from vultron.wire.as2.vocab.objects.embargo_policy import EmbargoPolicy
@@ -53,7 +53,7 @@ class TestVultronPersonBasics(unittest.TestCase):
 
     def test_as_type_is_person(self):
         p = VultronPerson(id_="https://example.org/users/alice")
-        self.assertEqual(VultronActorType.PERSON, p.type_)
+        self.assertEqual(as_ActorType.PERSON, p.type_)
 
     def test_embargo_policy_defaults_to_none(self):
         p = VultronPerson(id_="https://example.org/users/alice")
@@ -109,7 +109,7 @@ class TestVultronOrganizationBasics(unittest.TestCase):
 
     def test_as_type_is_organization(self):
         org = VultronOrganization(id_="https://example.org/orgs/vendor")
-        self.assertEqual(VultronActorType.ORGANIZATION, org.type_)
+        self.assertEqual(as_ActorType.ORGANIZATION, org.type_)
 
     def test_embargo_policy_defaults_to_none(self):
         org = VultronOrganization(id_="https://example.org/orgs/vendor")
@@ -136,7 +136,7 @@ class TestVultronServiceBasics(unittest.TestCase):
 
     def test_as_type_is_service(self):
         svc = VultronService(id_="https://example.org/services/bot")
-        self.assertEqual(VultronActorType.SERVICE, svc.type_)
+        self.assertEqual(as_ActorType.SERVICE, svc.type_)
 
     def test_embargo_policy_defaults_to_none(self):
         svc = VultronService(id_="https://example.org/services/bot")

--- a/test/wire/as2/vocab/test_vultron_actor.py
+++ b/test/wire/as2/vocab/test_vultron_actor.py
@@ -19,10 +19,15 @@ VultronActorMixin (EP-01-001).
 import unittest
 from datetime import timedelta
 
+from vultron.core.models.actor import VultronPerson as CoreVultronPerson
 from vultron.wire.as2.enums import as_ActorType
+from vultron.wire.as2.vocab.base.objects.actors import as_Actor
+from vultron.wire.as2.vocab.base.registry import VOCABULARY
 from vultron.wire.as2.vocab.objects.embargo_policy import EmbargoPolicy
 from vultron.wire.as2.vocab.objects.vultron_actor import (
     VultronActorMixin,
+    VultronApplication,
+    VultronGroup,
     VultronOrganization,
     VultronPerson,
     VultronService,
@@ -77,6 +82,7 @@ class TestVultronPersonBasics(unittest.TestCase):
     def test_is_instance_of_mixin(self):
         p = VultronPerson()
         self.assertIsInstance(p, VultronActorMixin)
+        self.assertIsInstance(p, as_Actor)
 
     def test_json_round_trip_no_policy(self):
         p = VultronPerson(name="Alice", id_="https://example.org/users/alice")
@@ -153,6 +159,43 @@ class TestVultronActorTypePreservation(unittest.TestCase):
         p = VultronPerson()
         svc = VultronService()
         self.assertNotEqual(p.type_, svc.type_)
+
+
+class TestWireActorVocabularyAndRoundTrip(unittest.TestCase):
+    def test_vocabulary_points_to_wire_actor_types(self):
+        self.assertIs(VOCABULARY["Actor"], as_Actor)
+        self.assertIs(VOCABULARY["Person"], VultronPerson)
+        self.assertIs(VOCABULARY["Organization"], VultronOrganization)
+        self.assertIs(VOCABULARY["Service"], VultronService)
+        self.assertIs(VOCABULARY["Application"], VultronApplication)
+        self.assertIs(VOCABULARY["Group"], VultronGroup)
+
+    def test_core_person_to_wire_person_model_validate_round_trip(self):
+        core_actor = CoreVultronPerson(
+            id_="https://example.org/actors/alice",
+            name="Alice",
+            inbox="https://example.org/actors/alice/inbox",
+            outbox="https://example.org/actors/alice/outbox",
+            preferred_username="alice",
+            endpoints={"sharedInbox": "https://example.org/inbox"},
+            embargo_policy={"policy": "default"},
+        )
+
+        wire_actor = VultronPerson.model_validate(
+            core_actor.model_dump(mode="json")
+        )
+
+        self.assertEqual(core_actor.id_, wire_actor.id_)
+        self.assertEqual(core_actor.name, wire_actor.name)
+        self.assertEqual(core_actor.type_, wire_actor.type_)
+        self.assertEqual(core_actor.inbox, wire_actor.inbox.id_)
+        self.assertEqual(core_actor.outbox, wire_actor.outbox.id_)
+        self.assertEqual(
+            core_actor.preferred_username,
+            wire_actor.preferred_username,
+        )
+        self.assertEqual(core_actor.endpoints, wire_actor.endpoints)
+        self.assertEqual(core_actor.embargo_policy, wire_actor.embargo_policy)
 
 
 if __name__ == "__main__":

--- a/vultron/adapters/driving/fastapi/routers/actors.py
+++ b/vultron/adapters/driving/fastapi/routers/actors.py
@@ -67,8 +67,8 @@ from vultron.wire.as2.vocab.objects.vultron_actor import (
     VultronService,
 )
 
-# AnyActor covers both migrated core types and the legacy as_Actor base
-# (VOCABULARY["Actor"] still maps to as_Actor for records stored before migration).
+# AnyActor covers both migrated core types and wire actor types while older
+# persisted records are still being read.
 AnyActor = CoreActor | as_Actor
 
 logger = logging.getLogger("uvicorn.error")
@@ -132,7 +132,9 @@ def _find_actor_record_by_id(
     return None
 
 
-def _actor_class_for_record(rec: dict[str, Any]) -> type[CoreActor]:
+def _actor_class_for_record(
+    rec: dict[str, Any],
+) -> type[CoreActor] | type[as_Actor]:
     data = rec.get("data_", {})
     payload_type = None
     if isinstance(data, dict):
@@ -179,7 +181,7 @@ def _find_actor_record(
 # Actor type map — used by create_actor
 # ---------------------------------------------------------------------------
 
-_ACTOR_TYPE_MAP: dict[str, type[CoreActor]] = {
+_ACTOR_TYPE_MAP: dict[str, type[as_Actor]] = {
     "Person": VultronPerson,
     "Organization": VultronOrganization,
     "Service": VultronService,

--- a/vultron/adapters/driving/fastapi/routers/datalayer.py
+++ b/vultron/adapters/driving/fastapi/routers/datalayer.py
@@ -21,7 +21,6 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, status, HTTPException
 from vultron.wire.as2.rehydration import rehydrate
-from vultron.core.models.actor import CoreActor
 from vultron.core.ports.datalayer import DataLayer
 from vultron.wire.as2.vocab.base.objects.base import as_Object
 from vultron.adapters.driven.datalayer import get_shared_dl
@@ -157,7 +156,7 @@ def get_reports(
     }
 
 
-_DATALAYER_ACTOR_TYPE_MAP: dict[str, type[CoreActor]] = {
+_DATALAYER_ACTOR_TYPE_MAP: dict[str, type[as_Actor]] = {
     "Person": VultronPerson,
     "Organization": VultronOrganization,
     "Service": VultronService,
@@ -168,7 +167,7 @@ _DATALAYER_ACTOR_TYPE_MAP: dict[str, type[CoreActor]] = {
 
 def _actor_class_for_payload(
     payload: dict[str, Any],
-) -> type[CoreActor] | type[as_Actor]:
+) -> type[as_Actor]:
     payload_type = payload.get("type_") or payload.get("type")
     if isinstance(payload_type, str):
         return _DATALAYER_ACTOR_TYPE_MAP.get(payload_type, as_Actor)

--- a/vultron/core/models/actor.py
+++ b/vultron/core/models/actor.py
@@ -23,6 +23,7 @@ from pydantic import ConfigDict, Field, field_validator
 from pydantic.alias_generators import to_camel
 
 from vultron.core.models.base import CoreObject
+from vultron.core.models.enums import VultronActorType
 
 
 class CoreActor(CoreObject):
@@ -113,8 +114,8 @@ class VultronPerson(CoreActor):
         validate_by_alias=True,
         alias_generator=to_camel,
     )
-    type_: Literal["Person"] = Field(
-        default="Person",
+    type_: Literal[VultronActorType.PERSON] = Field(
+        default=VultronActorType.PERSON,
         validation_alias="type",
         serialization_alias="type",
     )
@@ -133,8 +134,8 @@ class VultronOrganization(CoreActor):
         validate_by_alias=True,
         alias_generator=to_camel,
     )
-    type_: Literal["Organization"] = Field(
-        default="Organization",
+    type_: Literal[VultronActorType.ORGANIZATION] = Field(
+        default=VultronActorType.ORGANIZATION,
         validation_alias="type",
         serialization_alias="type",
     )
@@ -153,8 +154,8 @@ class VultronService(CoreActor):
         validate_by_alias=True,
         alias_generator=to_camel,
     )
-    type_: Literal["Service"] = Field(
-        default="Service",
+    type_: Literal[VultronActorType.SERVICE] = Field(
+        default=VultronActorType.SERVICE,
         validation_alias="type",
         serialization_alias="type",
     )
@@ -173,8 +174,8 @@ class VultronApplication(CoreActor):
         validate_by_alias=True,
         alias_generator=to_camel,
     )
-    type_: Literal["Application"] = Field(
-        default="Application",
+    type_: Literal[VultronActorType.APPLICATION] = Field(
+        default=VultronActorType.APPLICATION,
         validation_alias="type",
         serialization_alias="type",
     )
@@ -193,8 +194,8 @@ class VultronGroup(CoreActor):
         validate_by_alias=True,
         alias_generator=to_camel,
     )
-    type_: Literal["Group"] = Field(
-        default="Group",
+    type_: Literal[VultronActorType.GROUP] = Field(
+        default=VultronActorType.GROUP,
         validation_alias="type",
         serialization_alias="type",
     )

--- a/vultron/core/models/case_actor.py
+++ b/vultron/core/models/case_actor.py
@@ -20,6 +20,7 @@ from typing import Literal
 from pydantic import BaseModel, Field
 
 from vultron.core.models.base import CoreObject
+from vultron.core.models.enums import VultronActorType
 
 
 class VultronOutbox(BaseModel):
@@ -44,8 +45,8 @@ class CaseActor(CoreObject):
     domain objects directly.  See ADR-0017 and issue #729.
     """
 
-    type_: Literal["Service"] = Field(
-        default="Service",
+    type_: Literal[VultronActorType.SERVICE] = Field(
+        default=VultronActorType.SERVICE,
         validation_alias="type",
         serialization_alias="type",
     )

--- a/vultron/core/models/enums.py
+++ b/vultron/core/models/enums.py
@@ -28,3 +28,13 @@ class VultronObjectType(StrEnum):
     CASE_STATUS = "CaseStatus"
     PARTICIPANT_STATUS = "ParticipantStatus"
     CASE_LOG_ENTRY = "CaseLogEntry"
+
+
+class VultronActorType(StrEnum):
+    """Enumeration of supported ActivityStreams actor type values."""
+
+    PERSON = "Person"
+    ORGANIZATION = "Organization"
+    SERVICE = "Service"
+    APPLICATION = "Application"
+    GROUP = "Group"

--- a/vultron/wire/as2/enums.py
+++ b/vultron/wire/as2/enums.py
@@ -6,6 +6,8 @@ These enums map directly to ActivityStreams 2.0 vocabulary types.
 from enum import StrEnum
 from typing import cast
 
+from vultron.core.models.enums import VultronActorType
+
 
 class as_ObjectType(StrEnum):
     # generics
@@ -27,12 +29,7 @@ class as_ObjectType(StrEnum):
     PLACE = "Place"
 
 
-class as_ActorType(StrEnum):
-    PERSON = "Person"
-    GROUP = "Group"
-    ORGANIZATION = "Organization"
-    APPLICATION = "Application"
-    SERVICE = "Service"
+as_ActorType = VultronActorType
 
 
 class as_IntransitiveActivityType(StrEnum):

--- a/vultron/wire/as2/vocab/objects/vultron_actor.py
+++ b/vultron/wire/as2/vocab/objects/vultron_actor.py
@@ -18,6 +18,7 @@ from typing import Annotated, Any, Literal, TypeAlias, Union
 
 from pydantic import Field
 
+from vultron.wire.as2.enums import as_ActorType
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.base.links import ActivityStreamRef
 from vultron.wire.as2.vocab.base.registry import VOCABULARY
@@ -33,40 +34,40 @@ class VultronActorMixin(as_Actor):
 
 
 class VultronPerson(VultronActorMixin):
-    type_: Literal["Person"] = Field(
-        default="Person",
+    type_: Literal[as_ActorType.PERSON] = Field(
+        default=as_ActorType.PERSON,
         validation_alias="type",
         serialization_alias="type",
     )
 
 
 class VultronOrganization(VultronActorMixin):
-    type_: Literal["Organization"] = Field(
-        default="Organization",
+    type_: Literal[as_ActorType.ORGANIZATION] = Field(
+        default=as_ActorType.ORGANIZATION,
         validation_alias="type",
         serialization_alias="type",
     )
 
 
 class VultronService(VultronActorMixin):
-    type_: Literal["Service"] = Field(
-        default="Service",
+    type_: Literal[as_ActorType.SERVICE] = Field(
+        default=as_ActorType.SERVICE,
         validation_alias="type",
         serialization_alias="type",
     )
 
 
 class VultronApplication(VultronActorMixin):
-    type_: Literal["Application"] = Field(
-        default="Application",
+    type_: Literal[as_ActorType.APPLICATION] = Field(
+        default=as_ActorType.APPLICATION,
         validation_alias="type",
         serialization_alias="type",
     )
 
 
 class VultronGroup(VultronActorMixin):
-    type_: Literal["Group"] = Field(
-        default="Group",
+    type_: Literal[as_ActorType.GROUP] = Field(
+        default=as_ActorType.GROUP,
         validation_alias="type",
         serialization_alias="type",
     )

--- a/vultron/wire/as2/vocab/objects/vultron_actor.py
+++ b/vultron/wire/as2/vocab/objects/vultron_actor.py
@@ -18,6 +18,7 @@ from typing import Annotated, Any, Literal, TypeAlias, Union
 
 from pydantic import Field
 
+from vultron.core.models.enums import VultronActorType
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.base.links import ActivityStreamRef
 from vultron.wire.as2.vocab.base.registry import VOCABULARY
@@ -33,40 +34,40 @@ class VultronActorMixin(as_Actor):
 
 
 class VultronPerson(VultronActorMixin):
-    type_: Literal["Person"] = Field(
-        default="Person",
+    type_: Literal[VultronActorType.PERSON] = Field(
+        default=VultronActorType.PERSON,
         validation_alias="type",
         serialization_alias="type",
     )
 
 
 class VultronOrganization(VultronActorMixin):
-    type_: Literal["Organization"] = Field(
-        default="Organization",
+    type_: Literal[VultronActorType.ORGANIZATION] = Field(
+        default=VultronActorType.ORGANIZATION,
         validation_alias="type",
         serialization_alias="type",
     )
 
 
 class VultronService(VultronActorMixin):
-    type_: Literal["Service"] = Field(
-        default="Service",
+    type_: Literal[VultronActorType.SERVICE] = Field(
+        default=VultronActorType.SERVICE,
         validation_alias="type",
         serialization_alias="type",
     )
 
 
 class VultronApplication(VultronActorMixin):
-    type_: Literal["Application"] = Field(
-        default="Application",
+    type_: Literal[VultronActorType.APPLICATION] = Field(
+        default=VultronActorType.APPLICATION,
         validation_alias="type",
         serialization_alias="type",
     )
 
 
 class VultronGroup(VultronActorMixin):
-    type_: Literal["Group"] = Field(
-        default="Group",
+    type_: Literal[VultronActorType.GROUP] = Field(
+        default=VultronActorType.GROUP,
         validation_alias="type",
         serialization_alias="type",
     )

--- a/vultron/wire/as2/vocab/objects/vultron_actor.py
+++ b/vultron/wire/as2/vocab/objects/vultron_actor.py
@@ -18,7 +18,6 @@ from typing import Annotated, Any, Literal, TypeAlias, Union
 
 from pydantic import Field
 
-from vultron.core.models.enums import VultronActorType
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.base.links import ActivityStreamRef
 from vultron.wire.as2.vocab.base.registry import VOCABULARY
@@ -34,40 +33,40 @@ class VultronActorMixin(as_Actor):
 
 
 class VultronPerson(VultronActorMixin):
-    type_: Literal[VultronActorType.PERSON] = Field(
-        default=VultronActorType.PERSON,
+    type_: Literal["Person"] = Field(
+        default="Person",
         validation_alias="type",
         serialization_alias="type",
     )
 
 
 class VultronOrganization(VultronActorMixin):
-    type_: Literal[VultronActorType.ORGANIZATION] = Field(
-        default=VultronActorType.ORGANIZATION,
+    type_: Literal["Organization"] = Field(
+        default="Organization",
         validation_alias="type",
         serialization_alias="type",
     )
 
 
 class VultronService(VultronActorMixin):
-    type_: Literal[VultronActorType.SERVICE] = Field(
-        default=VultronActorType.SERVICE,
+    type_: Literal["Service"] = Field(
+        default="Service",
         validation_alias="type",
         serialization_alias="type",
     )
 
 
 class VultronApplication(VultronActorMixin):
-    type_: Literal[VultronActorType.APPLICATION] = Field(
-        default=VultronActorType.APPLICATION,
+    type_: Literal["Application"] = Field(
+        default="Application",
         validation_alias="type",
         serialization_alias="type",
     )
 
 
 class VultronGroup(VultronActorMixin):
-    type_: Literal[VultronActorType.GROUP] = Field(
-        default=VultronActorType.GROUP,
+    type_: Literal["Group"] = Field(
+        default="Group",
         validation_alias="type",
         serialization_alias="type",
     )

--- a/vultron/wire/as2/vocab/objects/vultron_actor.py
+++ b/vultron/wire/as2/vocab/objects/vultron_actor.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Wire projections for the Vultron actor domain models."""
+"""Wire-branch Vultron actor models."""
 
 #  Copyright (c) 2026 Carnegie Mellon University and Contributors.
 #  - see Contributors.md for a full list of Contributors
@@ -14,20 +14,63 @@
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-from typing import Annotated, TypeAlias, Union
+from typing import Annotated, Any, Literal, TypeAlias, Union
 
 from pydantic import Field
 
-from vultron.core.models.actor import (
-    CoreActor as VultronActorMixin,
-    VultronApplication,
-    VultronGroup,
-    VultronOrganization,
-    VultronPerson,
-    VultronService,
-)
+from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.base.links import ActivityStreamRef
 from vultron.wire.as2.vocab.base.registry import VOCABULARY
+
+
+class VultronActorMixin(as_Actor):
+    """Wire actor base with Vultron-specific actor extension fields."""
+
+    embargo_policy: Any | None = Field(
+        default=None,
+        description="The actor's stated embargo preferences.",
+    )
+
+
+class VultronPerson(VultronActorMixin):
+    type_: Literal["Person"] = Field(
+        default="Person",
+        validation_alias="type",
+        serialization_alias="type",
+    )
+
+
+class VultronOrganization(VultronActorMixin):
+    type_: Literal["Organization"] = Field(
+        default="Organization",
+        validation_alias="type",
+        serialization_alias="type",
+    )
+
+
+class VultronService(VultronActorMixin):
+    type_: Literal["Service"] = Field(
+        default="Service",
+        validation_alias="type",
+        serialization_alias="type",
+    )
+
+
+class VultronApplication(VultronActorMixin):
+    type_: Literal["Application"] = Field(
+        default="Application",
+        validation_alias="type",
+        serialization_alias="type",
+    )
+
+
+class VultronGroup(VultronActorMixin):
+    type_: Literal["Group"] = Field(
+        default="Group",
+        validation_alias="type",
+        serialization_alias="type",
+    )
+
 
 VOCABULARY["Person"] = VultronPerson
 VOCABULARY["Organization"] = VultronOrganization


### PR DESCRIPTION
- Closes #801

## Summary

Replace the wire actor re-export shim with concrete wire-branch actor models so actor serialization concerns stay in vultron/wire/as2 while preserving core-to-wire round-trip compatibility.

## Changes

- vultron/wire/as2/vocab/objects/vultron_actor.py: replaced core-model re-exports with concrete as_Actor-branch subclasses for Vultron actor types and kept VOCABULARY type mappings on these wire classes.
- test/wire/as2/vocab/test_vultron_actor.py: added coverage for vocabulary mappings and CoreVultronPerson to VultronPerson model_validate round-trip field preservation.
- vultron/adapters/driving/fastapi/routers/actors.py: updated actor-class resolution typing to cover both persisted core actor records and wire actor classes.
- vultron/adapters/driving/fastapi/routers/datalayer.py: aligned datalayer actor type-map typing with wire actor subclasses.

## Verification

- 3079 passed, 11 skipped, 216 deselected using uv run pytest --tb=short piped to tail -5
- Black, flake8, mypy, pyright clean