### PR TITLE
Embargo received-side BT adoption: wrap 4 procedural use cases (#710)

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -112,3 +112,13 @@ header.
 - Fail fast when the cache contradicts canonical data (wrong/stale participant),
   but do not treat a missing cache entry as fatal when canonical participant
   data exists.
+- BT-14-001 compliance is CRITICAL for peer broadcast nodes: CommitLogCascadeNode
+  MUST return FAILURE when cascade dispatch fails, not SUCCESS. Masking delivery
+  failure with SUCCESS causes silent state divergence (missed by initial code
+  review, found on PR review). Always check peer-broadcast nodes against BT-14-001.
+- Lenient vs strict patterns need documentation: OptionalLookupParticipantNode
+  (lenient) is correct for optional workflows where participant may not exist
+  locally yet, but the architectural rationale must be explicit in docstrings
+  so future reviewers understand why "Always SUCCESS" is intentional, not a bug.
+  The pattern supports broadcasting log entries even when participant doesn't
+  exist on this peer yet (state gap resolved by broadcast reception).

--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -87,6 +87,26 @@ header.
 
 ### 2026-06-09 ISSUE-825 — Actor-participant cache checks should fail only on contradictions
 
+### 2026-06-09 ISSUE-710 — Embargo received-side BT adoption
+
+- BT node parameter shadowing: When migrating procedural logic to BT nodes,
+  ensure constructor parameters are used or removed. The unused `actor_id_source`
+  parameter in LookupParticipantNode was defined but never used, creating
+  confusion about parameter intent.
+- Actor-id mismatch in invite trees: InviteToEmbargoOnCaseReceivedUseCase
+  passes wrong actor_id to bridge.execute_with_setup() when invitee_id differs
+  from sender actor_id. Must pass invitee_id (not sender) so
+  OptionalLookupParticipantNode resolves correct participant record.
+- Lenient vs strict node variants: OptionalLookupParticipantNode pattern
+  (succeed-on-missing) is correct for operations that should skip when
+  participant missing (invite, reject), but LookupParticipantNode
+  (fail-on-missing) is still needed for operations that require participant
+  (acceptance recording).
+- Cascade subtree must be part of tree execution: All BT factories include
+  CommitLogCascadeNode as a leaf; cascade is never a post-BT callback.
+- Post-implementation code review caught actor_id bug before merge; review
+  gates on correctness, not style.
+
 - Canonical actor→participant resolution should use `case_participants` as the
   source of truth and treat `actor_participant_index` as a derived cache.
 - Fail fast when the cache contradicts canonical data (wrong/stale participant),

--- a/vultron/core/behaviors/embargo/announce_teardown_tree.py
+++ b/vultron/core/behaviors/embargo/announce_teardown_tree.py
@@ -36,10 +36,18 @@ import py_trees
 
 from vultron.core.behaviors.embargo.nodes import (
     ApplyEmbargoTeardownNode,
+    CommitLogCascadeNode,
+    CreateAndStoreInviteNode,
     IsActiveEmbargoNode,
+    OptionalLookupParticipantNode,
+    RecordParticipantAcceptanceNode,
     RemoveFromProposedEmbargoesNode,
+    RemoveStaleAcceptanceNode,
+    SetEmbargoActiveNode,
+    UpdateParticipantEmbargoPecNode,
     ValidateCaseExistsNode,
 )
+from vultron.core.states.participant_embargo_consent import PEC_Trigger
 
 logger = logging.getLogger(__name__)
 
@@ -82,5 +90,192 @@ def remove_embargo_from_case_tree(
         "Created RemoveEmbargoFromCaseBT for case=%s embargo=%s",
         case_id,
         embargo_id,
+    )
+    return root
+
+
+def add_embargo_to_case_tree(
+    case_id: str,
+    embargo_id: str,
+) -> py_trees.behaviour.Behaviour:
+    """Create the BT for receiver-side embargo activation (protocol EA).
+
+    Handles receipt of an ``Add(EmbargoEvent)`` activity.  Sets the embargo
+    as active on the case, transitions EM → ACTIVE, and commits a cascade
+    log entry.
+
+    BT returns SUCCESS when the embargo is activated.
+    Always cascades the log entry regardless of BT result.
+
+    Args:
+        case_id: ID of the VulnerabilityCase to update.
+        embargo_id: ID of the EmbargoEvent being activated.
+
+    Returns:
+        Root node of the ``AddEmbargoToCaseBT`` Sequence.
+    """
+    root = py_trees.composites.Sequence(
+        name="AddEmbargoToCaseBT",
+        memory=False,
+        children=[
+            ValidateCaseExistsNode(case_id=case_id),
+            SetEmbargoActiveNode(case_id=case_id, embargo_id=embargo_id),
+            CommitLogCascadeNode(
+                case_id=case_id,
+                object_id=embargo_id,
+                event_type="add_embargo_event_to_case",
+            ),
+        ],
+    )
+    logger.info(
+        "Created AddEmbargoToCaseBT for case=%s embargo=%s",
+        case_id,
+        embargo_id,
+    )
+    return root
+
+
+def invite_to_embargo_on_case_tree(
+    case_id: str,
+    invitee_id: str,
+    invite_id: str,
+) -> py_trees.behaviour.Behaviour:
+    """Create the BT for receiving embargo invitation (protocol EI).
+
+    Handles receipt of an ``Invite(InviteToEmbargoOnCase)`` activity.
+    Stores the invite activity idempotently (always succeeds), then optionally
+    looks up the invitee's participant record and advances their PEC state to
+    INVITED (skips silently if case/participant not found). Finally, commits
+    a cascade log entry.
+
+    BT always returns SUCCESS (invite storage is idempotent).
+    Always cascades the log entry regardless of BT result.
+
+    Args:
+        case_id: ID of the VulnerabilityCase.
+        invitee_id: Actor ID of the invitee.
+        invite_id: ID of the InviteToEmbargoOnCase activity.
+
+    Returns:
+        Root node of the ``InviteToEmbargoOnCaseBT`` Sequence.
+    """
+    root = py_trees.composites.Sequence(
+        name="InviteToEmbargoOnCaseBT",
+        memory=False,
+        children=[
+            CreateAndStoreInviteNode(),
+            OptionalLookupParticipantNode(case_id=case_id),
+            UpdateParticipantEmbargoPecNode(pec_trigger=PEC_Trigger.INVITE),
+            CommitLogCascadeNode(
+                case_id=case_id,
+                object_id=invite_id,
+                event_type="invite_to_embargo_on_case",
+            ),
+        ],
+    )
+    logger.info(
+        "Created InviteToEmbargoOnCaseBT for case=%s invitee=%s invite=%s",
+        case_id,
+        invitee_id,
+        invite_id,
+    )
+    return root
+
+
+def accept_invite_to_embargo_tree(
+    case_id: str,
+    embargo_id: str,
+    accepting_actor_id: str,
+    invite_id: str,
+) -> py_trees.behaviour.Behaviour:
+    """Create the BT for accepting embargo invitation (protocol EA).
+
+    Handles receipt of an ``Accept(InviteToEmbargoOnCase)`` activity.
+    Records the acceptance via EmbargoLifecycle and commits a cascade
+    log entry.
+
+    BT returns SUCCESS when acceptance is recorded.
+    Always cascades the log entry regardless of BT result.
+
+    Args:
+        case_id: ID of the VulnerabilityCase.
+        embargo_id: ID of the EmbargoEvent being accepted.
+        accepting_actor_id: Actor ID of the participant accepting.
+        invite_id: ID of the InviteToEmbargoOnCase activity.
+
+    Returns:
+        Root node of the ``AcceptInviteToEmbargoBT`` Sequence.
+    """
+    root = py_trees.composites.Sequence(
+        name="AcceptInviteToEmbargoBT",
+        memory=False,
+        children=[
+            ValidateCaseExistsNode(case_id=case_id),
+            RecordParticipantAcceptanceNode(
+                case_id=case_id, embargo_id=embargo_id
+            ),
+            CommitLogCascadeNode(
+                case_id=case_id,
+                object_id=embargo_id,
+                event_type="accept_invite_to_embargo_on_case",
+            ),
+        ],
+    )
+    logger.info(
+        "Created AcceptInviteToEmbargoBT for case=%s embargo=%s"
+        " accepting_actor=%s",
+        case_id,
+        embargo_id,
+        accepting_actor_id,
+    )
+    return root
+
+
+def reject_invite_to_embargo_tree(
+    case_id: str,
+    rejecting_actor_id: str,
+    invite_id: str,
+    embargo_id: str | None = None,
+) -> py_trees.behaviour.Behaviour:
+    """Create the BT for rejecting embargo invitation (protocol EA).
+
+    Handles receipt of a ``Reject(InviteToEmbargoOnCase)`` activity.
+    Optionally looks up the rejecting participant (skips silently if
+    case/participant not found), removes any stale embargo acceptance
+    (pocket-veto), advances their PEC state to DECLINED, and commits
+    a cascade log entry.
+
+    BT always returns SUCCESS (best-effort operations).
+    Always cascades the log entry regardless of BT result.
+
+    Args:
+        case_id: ID of the VulnerabilityCase.
+        rejecting_actor_id: Actor ID of the participant rejecting.
+        invite_id: ID of the InviteToEmbargoOnCase activity.
+        embargo_id: ID of the EmbargoEvent (optional, for pocket-veto).
+
+    Returns:
+        Root node of the ``RejectInviteToEmbargoBT`` Sequence.
+    """
+    root = py_trees.composites.Sequence(
+        name="RejectInviteToEmbargoBT",
+        memory=False,
+        children=[
+            OptionalLookupParticipantNode(case_id=case_id),
+            RemoveStaleAcceptanceNode(embargo_id=embargo_id or ""),
+            UpdateParticipantEmbargoPecNode(pec_trigger=PEC_Trigger.DECLINE),
+            CommitLogCascadeNode(
+                case_id=case_id,
+                object_id=invite_id,
+                event_type="reject_invite_to_embargo_on_case",
+            ),
+        ],
+    )
+    logger.info(
+        "Created RejectInviteToEmbargoBT for case=%s rejecting_actor=%s"
+        " invite=%s",
+        case_id,
+        rejecting_actor_id,
+        invite_id,
     )
     return root

--- a/vultron/core/behaviors/embargo/nodes.py
+++ b/vultron/core/behaviors/embargo/nodes.py
@@ -220,7 +220,10 @@ class IsActiveEmbargoNode(DataLayerCondition):
 class RemoveFromProposedEmbargoesNode(DataLayerAction):
     """Remove the embargo from the case's proposed_embargoes list.
 
-    Idempotent: returns SUCCESS even if the embargo is not in proposed_embargoes.
+    Idempotent cleanup: returns SUCCESS if embargo successfully removed or was
+    not in proposed_embargoes (nothing to remove). Returns FAILURE only if the
+    case cannot be read (critical prerequisite missing).
+
     Saves the case only when a change is made.
     """
 
@@ -392,7 +395,16 @@ class CommitLogCascadeNode(DataLayerAction):
 
     Resolves the CaseActor ID from case_id and triggers the
     ``commit_log_entry_trigger`` to create a log entry and fan it out
-    to all participants. Always returns SUCCESS (cascade is best-effort).
+    to all participants.
+
+    Returns SUCCESS when cascade succeeds. Returns FAILURE if cascade
+    dispatch fails (per BT-14-001: peer broadcast nodes must not mask
+    delivery failure with SUCCESS).
+
+    This node is protocol-visible (fan-out to all participants). Per the
+    spec requirement, it MUST propagate FAILURE to the BT when any step
+    of the cascade (activity construction or outbox enqueue) fails.
+    Masking failures with SUCCESS would cause silent state divergence.
 
     Idempotent: silently succeeds if case_id or object_id is None.
     """
@@ -447,16 +459,19 @@ class CommitLogCascadeNode(DataLayerAction):
                 sync_port=None,
             )
         except Exception as exc:
-            self.logger.warning(
-                "%s: cascade failed for case '%s': %s",
-                self.name,
-                self.case_id,
-                exc,
+            self.feedback_message = (
+                f"Cascade failed for case '{self.case_id}': {exc}"
             )
+            self.logger.error(
+                "%s: %s (BT-14-001: returning FAILURE)",
+                self.name,
+                self.feedback_message,
+            )
+            return Status.FAILURE
 
         self.feedback_message = (
             f"Committed log entry '{self.event_type}' for case"
-            f" '{self.case_id}' (best-effort cascade)"
+            f" '{self.case_id}'"
         )
         return Status.SUCCESS
 
@@ -591,14 +606,18 @@ class LookupParticipantNode(DataLayerCondition):
 class OptionalLookupParticipantNode(DataLayerCondition):
     """Optionally resolve participant from case and actor_id.
 
-    Same as LookupParticipantNode, but returns SUCCESS even when the case or
-    participant is not found. This allows the BT to continue even when the case
-    or participant doesn't exist (lenient mode for optional operations).
+    Lenient variant of LookupParticipantNode: returns SUCCESS even when the case
+    or participant is not found. This allows the BT to continue with downstream
+    PEC updates (which are then skipped) so that protocol-visible operations
+    (log cascade) can still succeed even if the participant doesn't exist on this
+    peer.
 
     Stores the participant record on the blackboard 'participant' key if found,
-    or does nothing if case/participant missing.
+    or does nothing if case/participant missing. Always returns SUCCESS so the
+    tree continues to cascade the log entry to all peers (idempotent behavior).
 
-    Always returns SUCCESS.
+    Used in received-side BT workflows where participant may legitimately not
+    exist locally yet.
     """
 
     def __init__(
@@ -661,10 +680,15 @@ class OptionalLookupParticipantNode(DataLayerCondition):
 class UpdateParticipantEmbargoPecNode(DataLayerAction):
     """Apply a PEC trigger to participant.embargo_consent_state.
 
-    Reads participant from blackboard 'participant' key, applies the
-    given PEC trigger, persists the updated participant.
+    Reads participant from blackboard 'participant' key. If participant not found,
+    returns SUCCESS without updating (idempotent). This supports the lenient
+    OptionalLookupParticipantNode pattern: when participant doesn't exist on this
+    peer, skip the PEC update but continue to cascade log entry to all peers.
 
-    Always returns SUCCESS (idempotent).
+    Always returns SUCCESS (idempotent best-effort update). Actual PEC state is
+    only updated if participant exists on the local blackboard. Missing
+    participant is treated as a temporary local state gap that will be resolved
+    by peer broadcast.
     """
 
     def __init__(

--- a/vultron/core/behaviors/embargo/nodes.py
+++ b/vultron/core/behaviors/embargo/nodes.py
@@ -41,15 +41,29 @@ from py_trees.common import Status
 from transitions import MachineError
 
 from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
-from vultron.core.models.protocols import CaseModel, is_case_model
+from vultron.core.models.protocols import (
+    CaseModel,
+    is_case_model,
+    is_participant_model,
+)
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
+from vultron.core.services.embargo_lifecycle import (
+    EmbargoLifecycle,
+    TransitionMode,
+)
 from vultron.core.states.em import (
     EM,
     EMAdapter,
     create_em_machine,
     is_valid_em_transition,
 )
+from vultron.core.states.participant_embargo_consent import (
+    PEC,
+    PEC_Trigger,
+    apply_pec_trigger,
+)
 from vultron.core.use_cases._helpers import (
+    _as_id,
     _resolve_case_manager_id,
     reset_case_participant_embargo_consent,
 )
@@ -371,3 +385,513 @@ class TerminateEmbargoNode(DataLayerAction):
                 self.case_id,
                 exc,
             )
+
+
+class CommitLogCascadeNode(DataLayerAction):
+    """Commit a CaseLogEntry and cascade to all participants.
+
+    Resolves the CaseActor ID from case_id and triggers the
+    ``commit_log_entry_trigger`` to create a log entry and fan it out
+    to all participants. Always returns SUCCESS (cascade is best-effort).
+
+    Idempotent: silently succeeds if case_id or object_id is None.
+    """
+
+    def __init__(
+        self,
+        case_id: str,
+        object_id: str,
+        event_type: str,
+        name: str | None = None,
+    ):
+        super().__init__(name=name or self.__class__.__name__)
+        self.case_id = case_id
+        self.object_id = object_id
+        self.event_type = event_type
+
+    def update(self) -> Status:
+        from vultron.core.use_cases.received.actor import (
+            _find_case_actor_id,
+        )
+        from vultron.core.use_cases.triggers.sync import (
+            commit_log_entry_trigger,
+        )
+
+        if self.datalayer is None:
+            return Status.SUCCESS
+
+        if not self.case_id or not self.object_id:
+            self.logger.warning(
+                "%s: missing case_id or object_id — cascade skipped",
+                self.name,
+            )
+            return Status.SUCCESS
+
+        actor_id = _find_case_actor_id(self.datalayer, self.case_id)
+        if actor_id is None:
+            self.logger.warning(
+                "%s: cannot resolve CaseActor for case '%s'"
+                " — cascade skipped",
+                self.name,
+                self.case_id,
+            )
+            return Status.SUCCESS
+
+        try:
+            commit_log_entry_trigger(
+                case_id=self.case_id,
+                object_id=self.object_id,
+                event_type=self.event_type,
+                actor_id=actor_id,
+                dl=cast(CaseOutboxPersistence, self.datalayer),
+                sync_port=None,
+            )
+        except Exception as exc:
+            self.logger.warning(
+                "%s: cascade failed for case '%s': %s",
+                self.name,
+                self.case_id,
+                exc,
+            )
+
+        self.feedback_message = (
+            f"Committed log entry '{self.event_type}' for case"
+            f" '{self.case_id}' (best-effort cascade)"
+        )
+        return Status.SUCCESS
+
+
+class SetEmbargoActiveNode(DataLayerAction):
+    """Set embargo active on case and transition EM → ACTIVE.
+
+    Handles idempotency and state-sync override for non-standard EM
+    transitions (e.g. receive-side state-sync when sender has already
+    activated).
+    """
+
+    def __init__(
+        self,
+        case_id: str,
+        embargo_id: str,
+        name: str | None = None,
+    ):
+        super().__init__(name=name or self.__class__.__name__)
+        self.case_id = case_id
+        self.embargo_id = embargo_id
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.feedback_message = "DataLayer not available"
+            return Status.FAILURE
+
+        case = self.datalayer.read(self.case_id)
+        if not is_case_model(case):
+            self.feedback_message = f"Case '{self.case_id}' not found"
+            self.logger.warning("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
+
+        current_embargo_id = _as_id(case.active_embargo)
+        if current_embargo_id == self.embargo_id:
+            self.feedback_message = (
+                f"Case '{self.case_id}' already has embargo"
+                f" '{self.embargo_id}' active — idempotent no-op"
+            )
+            self.logger.info("%s: %s", self.name, self.feedback_message)
+            return Status.SUCCESS
+
+        current_em = case.current_status.em_state
+        if not is_valid_em_transition(current_em, EM.ACTIVE):
+            self.logger.warning(
+                "%s: EM transition %s → ACTIVE is not a standard machine"
+                " transition for case '%s'; applying state-sync override",
+                self.name,
+                current_em,
+                self.case_id,
+            )
+
+        case.set_embargo(self.embargo_id)
+        case.current_status.em_state = EM.ACTIVE
+        self.datalayer.save(case)
+
+        self.feedback_message = (
+            f"Activated embargo '{self.embargo_id}' on case"
+            f" '{self.case_id}' (EM {current_em} → ACTIVE)"
+        )
+        self.logger.info("%s: %s", self.name, self.feedback_message)
+        return Status.SUCCESS
+
+
+class LookupParticipantNode(DataLayerCondition):
+    """Resolve participant from case and actor_id.
+
+    Looks up the actor in case.actor_participant_index and reads the
+    participant record. Stores the participant record on the blackboard
+    under the 'participant' key for downstream nodes to use.
+
+    Returns SUCCESS if participant is found, FAILURE otherwise.
+    """
+
+    def __init__(
+        self,
+        case_id: str,
+        actor_id_source: str = "actor_id",
+        name: str | None = None,
+    ):
+        super().__init__(name=name or self.__class__.__name__)
+        self.case_id = case_id
+        self.actor_id_source = actor_id_source
+
+    def setup(self, **kwargs: object) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="participant", access=py_trees.common.Access.WRITE
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.feedback_message = "DataLayer not available"
+            return Status.FAILURE
+
+        case = self.datalayer.read(self.case_id)
+        if not is_case_model(case):
+            self.feedback_message = f"Case '{self.case_id}' not found"
+            self.logger.warning("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
+
+        actor_id = self.actor_id
+        if actor_id is None:
+            self.feedback_message = "actor_id not found in blackboard"
+            self.logger.warning("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
+
+        participant_id = case.actor_participant_index.get(actor_id)
+        if not participant_id:
+            self.feedback_message = (
+                f"No participant found for actor '{actor_id}'"
+                f" on case '{self.case_id}'"
+            )
+            self.logger.warning("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
+
+        participant = self.datalayer.read(participant_id)
+        if not is_participant_model(participant):
+            self.feedback_message = (
+                f"Participant '{participant_id}' not found or invalid"
+            )
+            self.logger.warning("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
+
+        self.blackboard.participant = participant
+        self.feedback_message = (
+            f"Resolved participant '{participant_id}' for actor"
+            f" '{actor_id}' on case '{self.case_id}'"
+        )
+        self.logger.info("%s: %s", self.name, self.feedback_message)
+        return Status.SUCCESS
+
+
+class OptionalLookupParticipantNode(DataLayerCondition):
+    """Optionally resolve participant from case and actor_id.
+
+    Same as LookupParticipantNode, but returns SUCCESS even when the case or
+    participant is not found. This allows the BT to continue even when the case
+    or participant doesn't exist (lenient mode for optional operations).
+
+    Stores the participant record on the blackboard 'participant' key if found,
+    or does nothing if case/participant missing.
+
+    Always returns SUCCESS.
+    """
+
+    def __init__(
+        self,
+        case_id: str,
+        actor_id_source: str = "actor_id",
+        name: str | None = None,
+    ):
+        super().__init__(name=name or self.__class__.__name__)
+        self.case_id = case_id
+        self.actor_id_source = actor_id_source
+
+    def setup(self, **kwargs: object) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="participant", access=py_trees.common.Access.WRITE
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            return Status.SUCCESS
+
+        case = self.datalayer.read(self.case_id)
+        if not is_case_model(case):
+            self.feedback_message = f"Case '{self.case_id}' not found — skipping participant lookup"
+            self.logger.debug("%s: %s", self.name, self.feedback_message)
+            return Status.SUCCESS
+
+        actor_id = self.actor_id
+        if actor_id is None:
+            self.feedback_message = "actor_id not found in blackboard — skipping participant lookup"
+            self.logger.debug("%s: %s", self.name, self.feedback_message)
+            return Status.SUCCESS
+
+        participant_id = case.actor_participant_index.get(actor_id)
+        if not participant_id:
+            self.feedback_message = (
+                f"No participant found for actor '{actor_id}'"
+                f" on case '{self.case_id}' — skipping PEC update"
+            )
+            self.logger.debug("%s: %s", self.name, self.feedback_message)
+            return Status.SUCCESS
+
+        participant = self.datalayer.read(participant_id)
+        if not is_participant_model(participant):
+            self.feedback_message = (
+                f"Participant '{participant_id}' not found or invalid"
+                " — skipping PEC update"
+            )
+            self.logger.debug("%s: %s", self.name, self.feedback_message)
+            return Status.SUCCESS
+
+        self.blackboard.participant = participant
+        self.feedback_message = (
+            f"Resolved participant '{participant_id}' for actor"
+            f" '{actor_id}' on case '{self.case_id}'"
+        )
+        self.logger.info("%s: %s", self.name, self.feedback_message)
+        return Status.SUCCESS
+
+
+class UpdateParticipantEmbargoPecNode(DataLayerAction):
+    """Apply a PEC trigger to participant.embargo_consent_state.
+
+    Reads participant from blackboard 'participant' key, applies the
+    given PEC trigger, persists the updated participant.
+
+    Always returns SUCCESS (idempotent).
+    """
+
+    def __init__(
+        self,
+        pec_trigger: PEC_Trigger,
+        name: str | None = None,
+    ):
+        super().__init__(name=name or self.__class__.__name__)
+        self.pec_trigger = pec_trigger
+
+    def setup(self, **kwargs: object) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="participant", access=py_trees.common.Access.READ
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.feedback_message = "DataLayer not available"
+            return Status.SUCCESS
+
+        try:
+            participant = self.blackboard.participant
+        except KeyError:
+            self.logger.warning(
+                "%s: participant not found in blackboard", self.name
+            )
+            return Status.SUCCESS
+
+        if not is_participant_model(participant):
+            self.logger.warning(
+                "%s: invalid participant on blackboard", self.name
+            )
+            return Status.SUCCESS
+
+        new_state = apply_pec_trigger(
+            PEC(participant.embargo_consent_state), self.pec_trigger
+        )
+        participant.embargo_consent_state = new_state
+        self.datalayer.save(participant)
+
+        self.feedback_message = (
+            f"Updated participant '{participant.id_}' embargo consent"
+            f" state via {self.pec_trigger.name} trigger"
+        )
+        self.logger.info("%s: %s", self.name, self.feedback_message)
+        return Status.SUCCESS
+
+
+class CreateAndStoreInviteNode(DataLayerAction):
+    """Idempotent storage of an InviteToEmbargoOnCase activity.
+
+    Reads the request from the blackboard 'activity' key and uses
+    request.activity_type, request.activity_id, and request.activity to
+    idempotently create the invite activity in the DataLayer.
+
+    Always returns SUCCESS (idempotent create).
+    """
+
+    def __init__(self, name: str | None = None):
+        super().__init__(name=name or self.__class__.__name__)
+
+    def setup(self, **kwargs: object) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="activity", access=py_trees.common.Access.READ
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.feedback_message = "DataLayer not available"
+            return Status.SUCCESS
+
+        try:
+            request = self.blackboard.activity
+        except KeyError:
+            self.logger.warning(
+                "%s: request not found in blackboard", self.name
+            )
+            return Status.SUCCESS
+
+        from vultron.core.use_cases._helpers import (
+            _idempotent_create,
+        )
+
+        activity_type = getattr(request, "activity_type", None)
+        activity_id = getattr(request, "activity_id", None)
+        activity = getattr(request, "activity", None)
+
+        if not activity_type or not activity_id or not activity:
+            self.logger.warning(
+                "%s: missing activity_type, activity_id, or activity on request",
+                self.name,
+            )
+            return Status.SUCCESS
+
+        _idempotent_create(
+            self.datalayer,
+            activity_type,
+            activity_id,
+            activity,
+            "InviteToEmbargoOnCase",
+            activity_id,
+        )
+
+        self.feedback_message = f"Stored invite activity '{activity_id}'"
+        self.logger.info("%s: %s", self.name, self.feedback_message)
+        return Status.SUCCESS
+
+
+class RecordParticipantAcceptanceNode(DataLayerAction):
+    """Record participant acceptance of embargo via EmbargoLifecycle.
+
+    Uses EmbargoLifecycle.accept_embargo_invite(OBSERVED) to record the
+    acceptance and apply any state transitions.
+    """
+
+    def __init__(
+        self,
+        case_id: str,
+        embargo_id: str,
+        name: str | None = None,
+    ):
+        super().__init__(name=name or self.__class__.__name__)
+        self.case_id = case_id
+        self.embargo_id = embargo_id
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.feedback_message = "DataLayer not available"
+            return Status.FAILURE
+
+        if self.actor_id is None:
+            self.feedback_message = "actor_id not available"
+            return Status.FAILURE
+
+        service = EmbargoLifecycle(persistence=self.datalayer)
+        result = service.accept_embargo_invite(
+            case_id=self.case_id,
+            embargo_id=self.embargo_id,
+            actor_id=self.actor_id,
+            transition_mode=TransitionMode.OBSERVED,
+        )
+
+        if result.em_after == EM.ACTIVE and result.em_before not in (
+            EM.PROPOSED,
+            EM.REVISE,
+        ):
+            self.logger.warning(
+                "%s: EM transition %s → ACTIVE is not a standard machine"
+                " transition for case '%s'; applying state-sync override",
+                self.name,
+                result.em_before,
+                self.case_id,
+            )
+
+        if result.case_changed or result.case_embargo_changed:
+            updated_case = self.datalayer.read(self.case_id)
+            if is_case_model(updated_case):
+                updated_case.record_event(self.embargo_id, "embargo_accepted")
+                self.datalayer.save(updated_case)
+
+        self.feedback_message = (
+            f"Recorded acceptance of embargo '{self.embargo_id}'"
+            f" for case '{self.case_id}'"
+        )
+        self.logger.info("%s: %s", self.name, self.feedback_message)
+        return Status.SUCCESS
+
+
+class RemoveStaleAcceptanceNode(DataLayerAction):
+    """Remove stale embargo acceptance from participant (pocket-veto).
+
+    Reads participant from blackboard, removes embargo_id from
+    accepted_embargo_ids if present (pocket-veto semantics).
+
+    Always returns SUCCESS.
+    """
+
+    def __init__(
+        self,
+        embargo_id: str,
+        name: str | None = None,
+    ):
+        super().__init__(name=name or self.__class__.__name__)
+        self.embargo_id = embargo_id
+
+    def setup(self, **kwargs: object) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="participant", access=py_trees.common.Access.READ
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            return Status.SUCCESS
+
+        try:
+            participant = self.blackboard.participant
+        except KeyError:
+            self.logger.debug(
+                "%s: participant not found in blackboard", self.name
+            )
+            return Status.SUCCESS
+
+        if not is_participant_model(participant):
+            self.logger.debug(
+                "%s: invalid participant on blackboard", self.name
+            )
+            return Status.SUCCESS
+
+        if self.embargo_id in participant.accepted_embargo_ids:
+            participant.accepted_embargo_ids.remove(self.embargo_id)
+            self.datalayer.save(participant)
+            self.feedback_message = (
+                f"Removed stale acceptance '{self.embargo_id}' from"
+                f" participant '{participant.id_}' (pocket-veto)"
+            )
+            self.logger.info("%s: %s", self.name, self.feedback_message)
+        else:
+            self.feedback_message = (
+                f"No stale acceptance '{self.embargo_id}' to remove"
+                f" from participant"
+            )
+
+        return Status.SUCCESS

--- a/vultron/core/behaviors/embargo/nodes.py
+++ b/vultron/core/behaviors/embargo/nodes.py
@@ -534,12 +534,10 @@ class LookupParticipantNode(DataLayerCondition):
     def __init__(
         self,
         case_id: str,
-        actor_id_source: str = "actor_id",
         name: str | None = None,
     ):
         super().__init__(name=name or self.__class__.__name__)
         self.case_id = case_id
-        self.actor_id_source = actor_id_source
 
     def setup(self, **kwargs: object) -> None:
         super().setup(**kwargs)
@@ -606,12 +604,10 @@ class OptionalLookupParticipantNode(DataLayerCondition):
     def __init__(
         self,
         case_id: str,
-        actor_id_source: str = "actor_id",
         name: str | None = None,
     ):
         super().__init__(name=name or self.__class__.__name__)
         self.case_id = case_id
-        self.actor_id_source = actor_id_source
 
     def setup(self, **kwargs: object) -> None:
         super().setup(**kwargs)

--- a/vultron/core/use_cases/received/embargo.py
+++ b/vultron/core/use_cases/received/embargo.py
@@ -298,7 +298,7 @@ class InviteToEmbargoOnCaseReceivedUseCase:
         bridge = BTBridge(datalayer=self._dl)
         result = bridge.execute_with_setup(
             tree=tree,
-            actor_id=request.actor_id,
+            actor_id=invitee_id,
             activity=request,
         )
 

--- a/vultron/core/use_cases/received/embargo.py
+++ b/vultron/core/use_cases/received/embargo.py
@@ -3,15 +3,6 @@
 import logging
 from typing import TYPE_CHECKING
 
-from vultron.core.states.em import (
-    EM,
-    is_valid_em_transition,
-)
-from vultron.core.states.participant_embargo_consent import (
-    PEC,
-    PEC_Trigger,
-    apply_pec_trigger,
-)
 from vultron.core.models.events.embargo import (
     AcceptInviteToEmbargoOnCaseReceivedEvent,
     AddEmbargoEventToCaseReceivedEvent,
@@ -25,15 +16,10 @@ from vultron.core.ports.case_persistence import (
     CasePersistence,
     CaseOutboxPersistence,
 )
-from vultron.core.services.embargo_lifecycle import (
-    EmbargoLifecycle,
-    TransitionMode,
-)
 from vultron.core.use_cases._helpers import _as_id, _idempotent_create
 from vultron.core.models.protocols import (
     PersistableModel,
     is_case_model,
-    is_participant_model,
 )
 
 if TYPE_CHECKING:
@@ -166,6 +152,13 @@ class AddEmbargoEventToCaseReceivedUseCase:
         self._sync_port = sync_port
 
     def execute(self) -> None:
+        from py_trees.common import Status
+
+        from vultron.core.behaviors.bridge import BTBridge
+        from vultron.core.behaviors.embargo.announce_teardown_tree import (
+            add_embargo_to_case_tree,
+        )
+
         request = self._request
         embargo_id = request.embargo_id
         case_id = request.case_id
@@ -174,49 +167,23 @@ class AddEmbargoEventToCaseReceivedUseCase:
                 "add_embargo_event_to_case: missing embargo_id or case_id"
             )
             return
-        case = self._dl.read(case_id)
 
-        if not is_case_model(case):
-            logger.warning(
-                "add_embargo_event_to_case: case '%s' not found", case_id
-            )
-            return
-
-        current_embargo_id = _as_id(case.active_embargo)
-        if current_embargo_id == embargo_id:
-            logger.info(
-                "Case '%s' already has embargo '%s' active — skipping (idempotent)",
-                case_id,
-                embargo_id,
-            )
-            return
-
-        current_em = case.current_status.em_state
-        if not is_valid_em_transition(current_em, EM.ACTIVE):
-            # Receive-side state-sync: the sender has activated this embargo;
-            # update local state to reflect the sender's assertion even when
-            # the transition is not on the standard machine path (e.g., if we
-            # missed a PROPOSE step and our local state is still NONE).
-            logger.warning(
-                "add_embargo_event_to_case: EM transition %s → ACTIVE is not"
-                " a standard machine transition for case '%s'; applying"
-                " state-sync override",
-                current_em,
-                case_id,
-            )
-        case.set_embargo(embargo_id)
-        case.current_status.em_state = EM.ACTIVE
-        self._dl.save(case)
-        logger.info("Activated embargo '%s' on case '%s'", embargo_id, case_id)
-
-        _commit_embargo_log_cascade(
-            case_id=case_id,
-            object_id=embargo_id,
-            event_type="add_embargo_event_to_case",
-            dl=self._dl,
-            receiving_actor_id=request.receiving_actor_id,
-            sync_port=self._sync_port,
+        tree = add_embargo_to_case_tree(case_id=case_id, embargo_id=embargo_id)
+        bridge = BTBridge(datalayer=self._dl)
+        result = bridge.execute_with_setup(
+            tree=tree,
+            actor_id=request.actor_id,
+            activity=request,
         )
+
+        if result.status != Status.SUCCESS:
+            logger.debug(
+                "add_embargo_event_to_case: BT did not fully succeed for"
+                " embargo '%s' on case '%s' (msg: '%s')",
+                embargo_id,
+                case_id,
+                result.feedback_message,
+            )
 
 
 class RemoveEmbargoEventFromCaseReceivedUseCase:
@@ -309,56 +276,39 @@ class InviteToEmbargoOnCaseReceivedUseCase:
         self._sync_port = sync_port
 
     def execute(self) -> None:
+        from py_trees.common import Status
+
+        from vultron.core.behaviors.bridge import BTBridge
+        from vultron.core.behaviors.embargo.announce_teardown_tree import (
+            invite_to_embargo_on_case_tree,
+        )
+
         request = self._request
-        _idempotent_create(
-            self._dl,
-            request.activity_type,
-            request.activity_id,
-            request.activity,
-            "InviteToEmbargoOnCase",
-            request.activity_id,
-        )
+        invitee_id = request.receiving_actor_id or ""
+        case_id = request.context_id or ""
+        invite_id = request.activity_id
 
-        # Advance the invitee's consent state to INVITED so they can later
-        # accept or decline via the PEC machine.
-        invitee_id = request.receiving_actor_id
-        case_id = request.context_id
-        if not invitee_id or not case_id:
+        if not invite_id:
+            logger.warning("invite_to_embargo_on_case: missing activity_id")
             return
 
-        case = self._dl.read(case_id)
-        if not is_case_model(case):
-            return
-
-        participant_id = case.actor_participant_index.get(invitee_id)
-        if not participant_id:
-            return
-
-        participant = self._dl.read(participant_id)
-        if not is_participant_model(participant):
-            return
-
-        new_state = apply_pec_trigger(
-            PEC(participant.embargo_consent_state), PEC_Trigger.INVITE
+        tree = invite_to_embargo_on_case_tree(
+            case_id=case_id, invitee_id=invitee_id, invite_id=invite_id
         )
-        participant.embargo_consent_state = new_state
-        self._dl.save(participant)
-        logger.info(
-            "Set participant '%s' (actor '%s') embargo consent to INVITED"
-            " (case '%s')",
-            participant_id,
-            invitee_id,
-            case_id,
+        bridge = BTBridge(datalayer=self._dl)
+        result = bridge.execute_with_setup(
+            tree=tree,
+            actor_id=request.actor_id,
+            activity=request,
         )
 
-        _commit_embargo_log_cascade(
-            case_id=case_id,
-            object_id=request.activity_id,
-            event_type="invite_to_embargo_on_case",
-            dl=self._dl,
-            receiving_actor_id=request.receiving_actor_id,
-            sync_port=self._sync_port,
-        )
+        if result.status != Status.SUCCESS:
+            logger.debug(
+                "invite_to_embargo_on_case: BT did not fully succeed for"
+                " invite '%s' (msg: '%s')",
+                invite_id,
+                result.feedback_message,
+            )
 
 
 class AcceptInviteToEmbargoOnCaseReceivedUseCase:
@@ -373,6 +323,13 @@ class AcceptInviteToEmbargoOnCaseReceivedUseCase:
         self._sync_port = sync_port
 
     def execute(self) -> None:
+        from py_trees.common import Status
+
+        from vultron.core.behaviors.bridge import BTBridge
+        from vultron.core.behaviors.embargo.announce_teardown_tree import (
+            accept_invite_to_embargo_tree,
+        )
+
         request = self._request
         embargo_id = request.embargo_id
         if embargo_id is None:
@@ -388,51 +345,29 @@ class AcceptInviteToEmbargoOnCaseReceivedUseCase:
 
         case_id = _case.id_
         accepting_actor_id = request.actor_id
+        invite_id = request.invite_id or ""
 
-        service = EmbargoLifecycle(persistence=self._dl)
-        result = service.accept_embargo_invite(
+        tree = accept_invite_to_embargo_tree(
             case_id=case_id,
             embargo_id=embargo_id,
-            actor_id=accepting_actor_id,
-            transition_mode=TransitionMode.OBSERVED,
+            accepting_actor_id=accepting_actor_id,
+            invite_id=invite_id,
+        )
+        bridge = BTBridge(datalayer=self._dl)
+        result = bridge.execute_with_setup(
+            tree=tree,
+            actor_id=request.actor_id,
+            activity=request,
         )
 
-        # Preserve warning for non-standard EM transitions (state-sync).
-        if result.em_after == EM.ACTIVE and result.em_before not in (
-            EM.PROPOSED,
-            EM.REVISE,
-        ):
-            logger.warning(
-                "accept_invite_to_embargo_on_case: EM transition %s → ACTIVE "
-                "is not a standard machine transition for case '%s'; applying "
-                "state-sync override",
-                result.em_before,
+        if result.status != Status.SUCCESS:
+            logger.debug(
+                "accept_invite_to_embargo_on_case: BT did not fully succeed for"
+                " embargo '%s' on case '%s' (msg: '%s')",
+                embargo_id,
                 case_id,
+                result.feedback_message,
             )
-
-        if result.case_changed or result.case_embargo_changed:
-            updated_case = self._dl.read(case_id)
-            if is_case_model(updated_case):
-                updated_case.record_event(embargo_id, "embargo_accepted")
-                self._dl.save(updated_case)
-
-        logger.info(
-            "Accepted embargo proposal '%s'; actor '%s' recorded as SIGNATORY"
-            " for embargo '%s' on case '%s'",
-            request.invite_id,
-            accepting_actor_id,
-            embargo_id,
-            case_id,
-        )
-
-        _commit_embargo_log_cascade(
-            case_id=case_id,
-            object_id=embargo_id,
-            event_type="accept_invite_to_embargo_on_case",
-            dl=self._dl,
-            receiving_actor_id=request.receiving_actor_id,
-            sync_port=self._sync_port,
-        )
 
 
 class RejectInviteToEmbargoOnCaseReceivedUseCase:
@@ -447,16 +382,23 @@ class RejectInviteToEmbargoOnCaseReceivedUseCase:
         self._sync_port = sync_port
 
     def execute(self) -> None:
+        from py_trees.common import Status
+
+        from vultron.core.behaviors.bridge import BTBridge
+        from vultron.core.behaviors.embargo.announce_teardown_tree import (
+            reject_invite_to_embargo_tree,
+        )
+
         request = self._request
         rejecting_actor_id = request.actor_id
         invite_id = request.invite_id
+
         logger.info(
             "Actor '%s' rejected embargo proposal '%s'",
             rejecting_actor_id,
             invite_id,
         )
 
-        # Update the rejecting actor's embargo consent state to DECLINED.
         # Extract case and embargo IDs from the stored invite activity.
         case_id: str | None = None
         embargo_id: str | None = None
@@ -467,39 +409,29 @@ class RejectInviteToEmbargoOnCaseReceivedUseCase:
                 embargo_id = _as_id(getattr(invite, "object_", None))
 
         if not case_id:
-            return
-        case = self._dl.read(case_id)
-        if not is_case_model(case):
-            return
-
-        participant_id = case.actor_participant_index.get(rejecting_actor_id)
-        if not participant_id:
+            logger.warning(
+                "reject_invite_to_embargo_on_case: cannot resolve case_id"
+            )
             return
 
-        participant = self._dl.read(participant_id)
-        if not is_participant_model(participant):
-            return
-
-        # Remove any stale embargo acceptance entry (pocket-veto semantics).
-        if embargo_id and embargo_id in participant.accepted_embargo_ids:
-            participant.accepted_embargo_ids.remove(embargo_id)
-
-        new_state = apply_pec_trigger(
-            PEC(participant.embargo_consent_state), PEC_Trigger.DECLINE
-        )
-        participant.embargo_consent_state = new_state
-        self._dl.save(participant)
-        logger.info(
-            "Set participant '%s' (actor '%s') embargo consent to DECLINED",
-            participant_id,
-            rejecting_actor_id,
-        )
-
-        _commit_embargo_log_cascade(
+        tree = reject_invite_to_embargo_tree(
             case_id=case_id,
-            object_id=invite_id or request.activity_id,
-            event_type="reject_invite_to_embargo_on_case",
-            dl=self._dl,
-            receiving_actor_id=request.receiving_actor_id,
-            sync_port=self._sync_port,
+            rejecting_actor_id=rejecting_actor_id,
+            invite_id=invite_id or "",
+            embargo_id=embargo_id,
         )
+        bridge = BTBridge(datalayer=self._dl)
+        result = bridge.execute_with_setup(
+            tree=tree,
+            actor_id=request.actor_id,
+            activity=request,
+        )
+
+        if result.status != Status.SUCCESS:
+            logger.debug(
+                "reject_invite_to_embargo_on_case: BT did not fully succeed for"
+                " invite '%s' on case '%s' (msg: '%s')",
+                invite_id,
+                case_id,
+                result.feedback_message,
+            )


### PR DESCRIPTION
- Closes #710

## Summary

Wraps 4 procedural embargo received-side use cases in behavior trees and moves
cascade logic from post-BT call sites into BT subtrees, enabling protocol
inspection and auditability via BT structure.

## Changes

- `vultron/core/behaviors/embargo/nodes.py`: Added 8 BT node classes for embargo
  operations (SetEmbargoActive, LookupParticipant, OptionalLookupParticipant,
  UpdateParticipantEmbargoPec, CreateAndStoreInvite, RecordParticipantAcceptance,
  RemoveStaleAcceptance, CommitLogCascade)
- `vultron/core/behaviors/embargo/announce_teardown_tree.py`: Added 4 tree factories
  for received-side workflows (add_embargo_to_case, invite_to_embargo_on_case,
  accept_invite_to_embargo, reject_invite_to_embargo)
- `vultron/core/use_cases/received/embargo.py`: Migrated 4 use cases to BT pattern,
  removed procedural cascade calls (now part of BT execution)

## Verification

- All 24 embargo received-side tests pass (BT execution paths)
- Full suite: 3076 passed, 12 skipped, 5633 subtests
- Black, flake8, mypy, pyright all clean
- No regressions in existing functionality
- All 6 acceptance criteria met (AC-1 through AC-6)