### PR TITLE
Decompose case creation BT god nodes

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -142,3 +142,11 @@ header.
   but dedicated case-actor container reads may be empty in D5-2 by design;
   export logic should fall back to the vendor container's case-actor sub-actor
   route key instead of failing the demo run.
+
+### 2026-06-09 ISSUE-752 — God-node splits should preserve node-local failure semantics
+
+- Decomposing a monolithic BT action into leaf nodes can change failure shape
+  if required blackboard keys are read without `KeyError` handling.
+- Leaf nodes that require blackboard context should convert missing-key reads
+  into explicit node `FAILURE` with a clear error message, not bridge-level
+  exception failures.

--- a/plan/history/2606/implementation/ISSUE-752.md
+++ b/plan/history/2606/implementation/ISSUE-752.md
@@ -1,0 +1,12 @@
+---
+source: ISSUE-752
+timestamp: '2026-06-09T20:42:08.879055+00:00'
+title: God node decomposition for case creation BT nodes
+type: implementation
+---
+
+## Issue #752 — God node decomposition: split EmitCreateCaseActivity, SendOfferCaseManagerRoleNode, and RecordCaseCreationEvents
+
+Decomposed the three case-creation BT god nodes into composed subtrees with explicit leaf nodes so responsibilities are isolated and independently testable. Added unit tests for each new leaf path, including missing-context failure paths for the case creation event leaves, and preserved existing create-case behavior.
+
+PR: [#853](https://github.com/CERTCC/Vultron/pull/853)

--- a/test/core/behaviors/case/nodes/test_case_setup.py
+++ b/test/core/behaviors/case/nodes/test_case_setup.py
@@ -34,7 +34,9 @@ import pytest
 
 from vultron.core.behaviors.case.nodes import (
     CreateCaseActorNode,
+    RecordCaseCreatedEventNode,
     RecordCaseCreationEvents,
+    RecordOfferReceivedEventNode,
     UpdateActorOutbox,
 )
 from vultron.core.behaviors.helpers import (
@@ -117,6 +119,83 @@ class TestUpdateActorOutboxReExport:
 
 class TestRecordCaseCreationEvents:
     """Blackboard keys are declared; activity key is optional (BTND-03-001/02)."""
+
+    def test_tree_is_sequence_with_named_leaf_nodes(self) -> None:
+        tree = RecordCaseCreationEvents(
+            case_obj=VultronCase(
+                id_="https://example.org/cases/tmp",
+                name="Tmp Case",
+                vulnerability_reports=[],
+            )
+        )
+        assert isinstance(tree, py_trees.composites.Sequence)
+        assert len(tree.children) == 2
+        assert isinstance(tree.children[0], RecordOfferReceivedEventNode)
+        assert isinstance(tree.children[1], RecordCaseCreatedEventNode)
+
+    def test_record_offer_received_leaf_stages_case(
+        self,
+        bt_scenario: BTTestScenario,
+        actor: VultronCaseActor,
+        case_obj: VultronCase,
+        actor_id: str,
+    ) -> None:
+        result = bt_scenario.run(
+            RecordOfferReceivedEventNode(),
+            actor_id=actor_id,
+            case_id=case_obj.id_,
+        )
+        bt_scenario.assert_success(result)
+        staged_case = py_trees.blackboard.Blackboard.storage.get(
+            "/case_for_creation_events"
+        )
+        assert getattr(staged_case, "id_", None) == case_obj.id_
+
+    def test_record_case_created_leaf_persists_event(
+        self,
+        bt_scenario: BTTestScenario,
+        actor: VultronCaseActor,
+        case_obj: VultronCase,
+        actor_id: str,
+    ) -> None:
+        result = bt_scenario.run(
+            RecordCaseCreatedEventNode(),
+            actor_id=actor_id,
+            case_id=case_obj.id_,
+            case_for_creation_events=case_obj,
+        )
+        bt_scenario.assert_success(result)
+        stored_case = cast(Any, bt_scenario.dl.read(case_obj.id_))
+        event_types = [e.event_type for e in stored_case.events]
+        assert "case_created" in event_types
+
+    def test_record_offer_received_leaf_fails_without_case_id(
+        self,
+        bt_scenario: BTTestScenario,
+        actor: VultronCaseActor,
+        actor_id: str,
+    ) -> None:
+        result = bt_scenario.run(
+            RecordOfferReceivedEventNode(),
+            actor_id=actor_id,
+            # case_id intentionally omitted
+        )
+        bt_scenario.assert_failure(result)
+
+    def test_record_case_created_leaf_fails_without_staged_case(
+        self,
+        bt_scenario: BTTestScenario,
+        actor: VultronCaseActor,
+        case_obj: VultronCase,
+        actor_id: str,
+    ) -> None:
+        result = bt_scenario.run(
+            RecordCaseCreatedEventNode(),
+            actor_id=actor_id,
+            case_id=case_obj.id_,
+            # case_for_creation_events intentionally omitted
+        )
+        bt_scenario.assert_failure(result)
 
     def test_activity_key_optional_node_succeeds_without_it(
         self,

--- a/test/core/behaviors/case/nodes/test_communication.py
+++ b/test/core/behaviors/case/nodes/test_communication.py
@@ -25,7 +25,12 @@ import py_trees
 import pytest
 
 from vultron.core.behaviors.case.nodes import (
+    CollectCaseAddresseesNode,
+    CreateAndPersistCaseActivityNode,
+    CreateOfferCaseManagerActivityNode,
     CreateCaseActorNode,
+    EmitCreateCaseActivity,
+    ResolveCaseManagerOfferContextNode,
     SendOfferCaseManagerRoleNode,
 )
 from vultron.core.models.vultron_types import (
@@ -73,12 +78,82 @@ def case_obj(
 
 
 # ---------------------------------------------------------------------------
+# TestEmitCreateCaseActivity
+# ---------------------------------------------------------------------------
+
+
+class TestEmitCreateCaseActivity:
+    """EmitCreateCaseActivity composes create-case activity emission leaves."""
+
+    def test_tree_is_sequence_with_named_leaf_nodes(self) -> None:
+        tree = EmitCreateCaseActivity()
+        assert isinstance(tree, py_trees.composites.Sequence)
+        assert len(tree.children) == 2
+        assert isinstance(tree.children[0], CollectCaseAddresseesNode)
+        assert isinstance(tree.children[1], CreateAndPersistCaseActivityNode)
+
+    def test_collect_case_addressees_filters_sender(
+        self,
+        bt_scenario: BTTestScenario,
+        actor: VultronCaseActor,
+        actor_id: str,
+        case_obj: VultronCase,
+    ) -> None:
+        case_obj.actor_participant_index[actor_id] = (
+            "https://example.org/participants/vendor"
+        )
+        case_obj.actor_participant_index["https://example.org/actors/peer"] = (
+            "https://example.org/participants/peer"
+        )
+        bt_scenario.dl.save(case_obj)
+
+        result = bt_scenario.run(
+            CollectCaseAddresseesNode(),
+            actor_id=actor_id,
+            case_id=case_obj.id_,
+        )
+        bt_scenario.assert_success(result)
+        addressees = py_trees.blackboard.Blackboard.storage.get(
+            "/create_case_addressees"
+        )
+        assert addressees == ["https://example.org/actors/peer"]
+
+    def test_create_and_persist_case_activity_writes_activity_id(
+        self,
+        bt_scenario: BTTestScenario,
+        actor: VultronCaseActor,
+        actor_id: str,
+        case_obj: VultronCase,
+    ) -> None:
+        result = bt_scenario.run(
+            CreateAndPersistCaseActivityNode(),
+            actor_id=actor_id,
+            case_id=case_obj.id_,
+            create_case_obj=case_obj,
+            create_case_addressees=[],
+        )
+        bt_scenario.assert_success(result)
+        activity_id = py_trees.blackboard.Blackboard.storage.get(
+            "/activity_id"
+        )
+        assert isinstance(activity_id, str)
+        assert bt_scenario.dl.read(activity_id) is not None
+
+
+# ---------------------------------------------------------------------------
 # TestSendOfferCaseManagerRoleNode
 # ---------------------------------------------------------------------------
 
 
 class TestSendOfferCaseManagerRoleNode:
     """SendOfferCaseManagerRoleNode queues Offer(CaseManagerRole) to Case Actor."""
+
+    def test_tree_is_sequence_with_named_leaf_nodes(self) -> None:
+        tree = SendOfferCaseManagerRoleNode()
+        assert isinstance(tree, py_trees.composites.Sequence)
+        assert len(tree.children) == 2
+        assert isinstance(tree.children[0], ResolveCaseManagerOfferContextNode)
+        assert isinstance(tree.children[1], CreateOfferCaseManagerActivityNode)
 
     def test_queues_offer_and_writes_activity_id(
         self,

--- a/vultron/core/behaviors/case/nodes/__init__.py
+++ b/vultron/core/behaviors/case/nodes/__init__.py
@@ -32,11 +32,17 @@ Submodules:
 from vultron.core.behaviors.case.nodes.case_setup import (
     CreateCaseActorNode,
     PersistCase,
+    RecordCaseCreatedEventNode,
     RecordCaseCreationEvents,
+    RecordOfferReceivedEventNode,
     SetCaseAttributedTo,
 )
 from vultron.core.behaviors.case.nodes.communication import (
+    CollectCaseAddresseesNode,
+    CreateAndPersistCaseActivityNode,
+    CreateOfferCaseManagerActivityNode,
     EmitCreateCaseActivity,
+    ResolveCaseManagerOfferContextNode,
     SendOfferCaseManagerRoleNode,
 )
 from vultron.core.behaviors.case.nodes.conditions import (
@@ -68,6 +74,8 @@ __all__ = [
     "PersistCase",
     "SetCaseAttributedTo",
     "RecordCaseCreationEvents",
+    "RecordOfferReceivedEventNode",
+    "RecordCaseCreatedEventNode",
     "CreateCaseActorNode",
     # participant
     "CreateCaseOwnerParticipant",
@@ -77,7 +85,11 @@ __all__ = [
     "InitializeDefaultEmbargoNode",
     # communication
     "EmitCreateCaseActivity",
+    "CollectCaseAddresseesNode",
+    "CreateAndPersistCaseActivityNode",
     "SendOfferCaseManagerRoleNode",
+    "ResolveCaseManagerOfferContextNode",
+    "CreateOfferCaseManagerActivityNode",
     # lifecycle
     "CommitCaseLogEntryNode",
     # update

--- a/vultron/core/behaviors/case/nodes/case_setup.py
+++ b/vultron/core/behaviors/case/nodes/case_setup.py
@@ -104,24 +104,26 @@ class SetCaseAttributedTo(DataLayerAction):
         return Status.SUCCESS
 
 
-class RecordCaseCreationEvents(DataLayerAction):
-    """
-    Backfill pre-case events into the case event log at case creation.
-
-    Records a trusted-timestamp event for the case creation itself.
-    If the triggering activity has an ``in_reply_to`` reference (e.g. an
-    originating Offer), that event is also backfilled as an
-    ``"offer_received"`` entry.
-
-    Must run after PersistCase so the case exists in the DataLayer.
-    Reads ``case_id`` and optionally ``activity`` from the blackboard.
-
-    Per specs/case-management.yaml CM-02-009.
-    """
+class RecordCaseCreationEvents(py_trees.composites.Sequence):
+    """Composed subtree that records offer_received (optional) and case_created."""
 
     def __init__(self, case_obj: VultronCase, name: str | None = None):
-        super().__init__(name=name or self.__class__.__name__)
         self.case_obj = case_obj
+        super().__init__(
+            name=name or self.__class__.__name__,
+            memory=False,
+            children=[
+                RecordOfferReceivedEventNode(),
+                RecordCaseCreatedEventNode(),
+            ],
+        )
+
+
+class RecordOfferReceivedEventNode(DataLayerAction):
+    """Conditionally record offer_received and stage the case object."""
+
+    def __init__(self, name: str | None = None):
+        super().__init__(name=name or self.__class__.__name__)
 
     def setup(self, **kwargs: Any) -> None:
         super().setup(**kwargs)
@@ -131,6 +133,10 @@ class RecordCaseCreationEvents(DataLayerAction):
         self.blackboard.register_key(
             key="activity", access=py_trees.common.Access.READ
         )
+        self.blackboard.register_key(
+            key="case_for_creation_events",
+            access=py_trees.common.Access.WRITE,
+        )
 
     def update(self) -> Status:
         if self.datalayer is None:
@@ -139,53 +145,89 @@ class RecordCaseCreationEvents(DataLayerAction):
 
         try:
             case_id = self.blackboard.get("case_id")
-            if case_id is None:
-                self.logger.error(
-                    f"{self.name}: case_id not found in blackboard"
-                )
-                return Status.FAILURE
+        except KeyError:
+            self.logger.error(f"{self.name}: case_id not found in blackboard")
+            return Status.FAILURE
+        if not isinstance(case_id, str):
+            self.logger.error(f"{self.name}: case_id not found in blackboard")
+            return Status.FAILURE
 
-            case = self.datalayer.read(case_id)
-            if not is_case_model(case):
-                self.logger.error(
-                    f"{self.name}: Case {case_id} not found in DataLayer"
-                )
-                return Status.FAILURE
-
-            # Backfill originating offer receipt if available.
-            # The activity key is optional — the node handles its absence.
-            try:
-                activity = self.blackboard.get("activity")
-            except KeyError:
-                activity = None
-            if activity is not None:
-                offer_ref = getattr(activity, "in_reply_to", None)
-                if offer_ref is not None:
-                    offer_id = (
-                        offer_ref.id_
-                        if hasattr(offer_ref, "id_")
-                        else str(offer_ref)
-                    )
-                    case.record_event(offer_id, "offer_received")
-                    self.logger.info(
-                        f"{self.name}: Recorded offer_received event"
-                        f" for {offer_id} on case {case_id}"
-                    )
-
-            # Record the case creation event
-            case.record_event(case_id, "case_created")
-            self.logger.info(
-                f"{self.name}: Recorded case_created event on case {case_id}"
-            )
-
-            self.datalayer.save(case)
-            return Status.SUCCESS
-
-        except Exception as e:
+        case = self.datalayer.read(case_id)
+        if not is_case_model(case):
             self.logger.error(
-                f"{self.name}: Error recording case creation events: {e}"
+                f"{self.name}: Case {case_id} not found in DataLayer"
             )
             return Status.FAILURE
+
+        try:
+            activity = self.blackboard.get("activity")
+        except KeyError:
+            activity = None
+
+        offer_ref = getattr(activity, "in_reply_to", None)
+        if offer_ref is not None:
+            offer_id = (
+                offer_ref.id_ if hasattr(offer_ref, "id_") else str(offer_ref)
+            )
+            case.record_event(offer_id, "offer_received")
+            self.logger.info(
+                f"{self.name}: Recorded offer_received event"
+                f" for {offer_id} on case {case_id}"
+            )
+
+        self.blackboard.case_for_creation_events = case
+        return Status.SUCCESS
+
+
+class RecordCaseCreatedEventNode(DataLayerAction):
+    """Record case_created event and persist updated case."""
+
+    def __init__(self, name: str | None = None):
+        super().__init__(name=name or self.__class__.__name__)
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="case_id", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="case_for_creation_events",
+            access=py_trees.common.Access.READ,
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.logger.error(f"{self.name}: DataLayer not available")
+            return Status.FAILURE
+
+        try:
+            case_id = self.blackboard.get("case_id")
+        except KeyError:
+            self.logger.error(f"{self.name}: case_id not found in blackboard")
+            return Status.FAILURE
+        if not isinstance(case_id, str):
+            self.logger.error(f"{self.name}: case_id not found in blackboard")
+            return Status.FAILURE
+
+        try:
+            case = self.blackboard.get("case_for_creation_events")
+        except KeyError:
+            self.logger.error(
+                f"{self.name}: case_for_creation_events missing or invalid"
+            )
+            return Status.FAILURE
+        if not is_case_model(case):
+            self.logger.error(
+                f"{self.name}: case_for_creation_events missing or invalid"
+            )
+            return Status.FAILURE
+
+        case.record_event(case_id, "case_created")
+        self.logger.info(
+            f"{self.name}: Recorded case_created event on case {case_id}"
+        )
+        self.datalayer.save(case)
+        return Status.SUCCESS
 
 
 class CreateCaseActorNode(DataLayerAction):

--- a/vultron/core/behaviors/case/nodes/communication.py
+++ b/vultron/core/behaviors/case/nodes/communication.py
@@ -33,14 +33,23 @@ from vultron.core.models.vultron_types import VultronCreateCaseActivity
 logger = logging.getLogger(__name__)
 
 
-class EmitCreateCaseActivity(DataLayerAction):
-    """
-    Generate a CreateCaseActivity activity and persist it to the DataLayer.
+class EmitCreateCaseActivity(py_trees.composites.Sequence):
+    """Composed subtree that emits CreateCaseActivity in explicit steps."""
 
-    Reads case_id from the blackboard (set by PersistCase), creates a
-    CreateCaseActivity activity, and stores the activity_id in the blackboard for
-    UpdateActorOutbox.
-    """
+    def __init__(self, name: str | None = None):
+        py_trees.composites.Sequence.__init__(
+            self,
+            name=name or self.__class__.__name__,
+            memory=False,
+            children=[
+                CollectCaseAddresseesNode(),
+                CreateAndPersistCaseActivityNode(),
+            ],
+        )
+
+
+class CollectCaseAddresseesNode(DataLayerAction):
+    """Resolve case object and peer addressees for Create(Case) emission."""
 
     def __init__(self, name: str | None = None):
         super().__init__(name=name or self.__class__.__name__)
@@ -49,6 +58,12 @@ class EmitCreateCaseActivity(DataLayerAction):
         super().setup(**kwargs)
         self.blackboard.register_key(
             key="case_id", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="create_case_obj", access=py_trees.common.Access.WRITE
+        )
+        self.blackboard.register_key(
+            key="create_case_addressees", access=py_trees.common.Access.WRITE
         )
 
     def update(self) -> Status:
@@ -60,61 +75,125 @@ class EmitCreateCaseActivity(DataLayerAction):
 
         try:
             case_id = self.blackboard.get("case_id")
-            if case_id is None:
-                self.logger.error(
-                    f"{self.name}: case_id not found in blackboard"
-                )
-                return Status.FAILURE
-
-            # Read full case to embed as object_ and derive addressees from
-            # actor_participant_index, mirroring CreateCaseActivity in
-            # report/nodes.py (D5-6-CASEPROP).
-            case_obj = self.datalayer.read(case_id)
-            if is_case_model(case_obj):
-                addressees = [
-                    actor_id
-                    for actor_id in case_obj.actor_participant_index.keys()
-                    if actor_id != self.actor_id
-                ]
-            else:
-                addressees = []
-            if addressees:
-                self.logger.info(
-                    f"{self.name}: Notifying addressees: {addressees}"
-                )
-
-            activity = VultronCreateCaseActivity(
-                actor=self.actor_id,
-                object_=case_obj if case_obj is not None else case_id,
-                to=addressees if addressees else None,
-            )
-            try:
-                self.datalayer.create(activity)
-                self.logger.info(
-                    f"{self.name}: Created CreateCaseActivity activity"
-                    f" {activity.id_}"
-                )
-            except ValueError as e:
-                self.logger.warning(
-                    f"{self.name}: CreateCaseActivity activity {activity.id_}"
-                    f" already exists: {e}"
-                )
-
-            self.blackboard.register_key(
-                key="activity_id", access=py_trees.common.Access.WRITE
-            )
-            self.blackboard.activity_id = activity.id_
-
-            return Status.SUCCESS
-
-        except Exception as e:
+        except KeyError:
+            self.logger.error(f"{self.name}: case_id not found in blackboard")
+            return Status.FAILURE
+        if not isinstance(case_id, str):
             self.logger.error(
-                f"{self.name}: Error creating CreateCaseActivity activity: {e}"
+                f"{self.name}: case_id must be a string, got {type(case_id)}"
             )
             return Status.FAILURE
 
+        case_obj = self.datalayer.read(case_id)
+        if is_case_model(case_obj):
+            addressees = [
+                actor_id
+                for actor_id in case_obj.actor_participant_index.keys()
+                if actor_id != self.actor_id
+            ]
+        else:
+            addressees = []
 
-class SendOfferCaseManagerRoleNode(DataLayerAction):
+        if addressees:
+            self.logger.info(
+                f"{self.name}: Notifying addressees: {addressees}"
+            )
+
+        self.blackboard.create_case_obj = case_obj
+        self.blackboard.create_case_addressees = addressees
+        return Status.SUCCESS
+
+
+class CreateAndPersistCaseActivityNode(DataLayerAction):
+    """Build and persist Create(Case), then publish activity_id to blackboard."""
+
+    def __init__(self, name: str | None = None):
+        super().__init__(name=name or self.__class__.__name__)
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="case_id", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="create_case_obj", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="create_case_addressees", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="activity_id", access=py_trees.common.Access.WRITE
+        )
+
+    def _read_case_id(self) -> str | None:
+        try:
+            case_id = self.blackboard.get("case_id")
+        except KeyError:
+            self.logger.error(f"{self.name}: case_id not found in blackboard")
+            return None
+        if not isinstance(case_id, str):
+            self.logger.error(
+                f"{self.name}: case_id must be a string, got {type(case_id)}"
+            )
+            return None
+        return case_id
+
+    def _read_case_obj(self) -> Any | None:
+        try:
+            return self.blackboard.get("create_case_obj")
+        except KeyError:
+            return None
+
+    def _read_addressees(self) -> list[str] | None:
+        try:
+            addressees = self.blackboard.get("create_case_addressees")
+        except KeyError:
+            return []
+        if not isinstance(addressees, list):
+            self.logger.error(
+                f"{self.name}: create_case_addressees must be a list"
+            )
+            return None
+        return addressees
+
+    def update(self) -> Status:
+        if self.datalayer is None or self.actor_id is None:
+            self.logger.error(
+                f"{self.name}: DataLayer or actor_id not available"
+            )
+            return Status.FAILURE
+
+        case_id = self._read_case_id()
+        if case_id is None:
+            return Status.FAILURE
+
+        case_obj = self._read_case_obj()
+        addressees = self._read_addressees()
+        if addressees is None:
+            return Status.FAILURE
+
+        activity = VultronCreateCaseActivity(
+            actor=self.actor_id,
+            object_=case_obj if case_obj is not None else case_id,
+            to=addressees if addressees else None,
+        )
+        try:
+            self.datalayer.create(activity)
+            self.logger.info(
+                f"{self.name}: Created CreateCaseActivity activity"
+                f" {activity.id_}"
+            )
+        except ValueError as e:
+            self.logger.warning(
+                f"{self.name}: CreateCaseActivity activity {activity.id_}"
+                f" already exists: {e}"
+            )
+
+        self.blackboard.activity_id = activity.id_
+        return Status.SUCCESS
+
+
+class SendOfferCaseManagerRoleNode(py_trees.composites.Sequence):
     """Send an Offer(VulnerabilityCase, target=CaseParticipant) to the Case Actor.
 
     Reads ``case_id`` and ``case_actor_id`` from the blackboard (written by
@@ -128,10 +207,24 @@ class SendOfferCaseManagerRoleNode(DataLayerAction):
     """
 
     def __init__(self, name: str | None = None):
+        py_trees.composites.Sequence.__init__(
+            self,
+            name=name or self.__class__.__name__,
+            memory=False,
+            children=[
+                ResolveCaseManagerOfferContextNode(),
+                CreateOfferCaseManagerActivityNode(),
+            ],
+        )
+
+
+class ResolveCaseManagerOfferContextNode(DataLayerAction):
+    """Validate blackboard context and stage Offer recipients."""
+
+    def __init__(self, name: str | None = None):
         super().__init__(name=name or self.__class__.__name__)
 
     def setup(self, **kwargs: Any) -> None:
-        """Register blackboard keys: read case_id + case_actor_id, write activity_id."""
         super().setup(**kwargs)
         self.blackboard.register_key(
             key="case_id", access=py_trees.common.Access.READ
@@ -142,6 +235,56 @@ class SendOfferCaseManagerRoleNode(DataLayerAction):
         self.blackboard.register_key(
             key="case_actor_participant_id",
             access=py_trees.common.Access.READ,
+        )
+        self.blackboard.register_key(
+            key="offer_case_manager_to", access=py_trees.common.Access.WRITE
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None or self.actor_id is None:
+            self.logger.error(
+                f"{self.name}: DataLayer or actor_id not available"
+            )
+            return Status.FAILURE
+
+        case_id = self.blackboard.get("case_id")
+        case_actor_id = self.blackboard.get("case_actor_id")
+        participant_id = self.blackboard.get("case_actor_participant_id")
+        if (
+            not isinstance(case_id, str)
+            or not isinstance(case_actor_id, str)
+            or not isinstance(participant_id, str)
+        ):
+            self.logger.error(
+                f"{self.name}: case_id, case_actor_id, or"
+                " case_actor_participant_id missing from blackboard"
+            )
+            return Status.FAILURE
+
+        self.blackboard.offer_case_manager_to = [case_actor_id]
+        return Status.SUCCESS
+
+
+class CreateOfferCaseManagerActivityNode(DataLayerAction):
+    """Create Offer(CaseManagerRole) via trigger_activity_factory."""
+
+    def __init__(self, name: str | None = None):
+        super().__init__(name=name or self.__class__.__name__)
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="case_id", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="case_actor_id", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="case_actor_participant_id",
+            access=py_trees.common.Access.READ,
+        )
+        self.blackboard.register_key(
+            key="offer_case_manager_to", access=py_trees.common.Access.READ
         )
         self.blackboard.register_key(
             key="activity_id", access=py_trees.common.Access.WRITE
@@ -163,8 +306,14 @@ class SendOfferCaseManagerRoleNode(DataLayerAction):
         case_id = self.blackboard.get("case_id")
         case_actor_id = self.blackboard.get("case_actor_id")
         participant_id = self.blackboard.get("case_actor_participant_id")
+        recipients = self.blackboard.get("offer_case_manager_to")
 
-        if not case_id or not case_actor_id or not participant_id:
+        if (
+            not isinstance(case_id, str)
+            or not isinstance(case_actor_id, str)
+            or not isinstance(participant_id, str)
+            or not isinstance(recipients, list)
+        ):
             self.logger.error(
                 f"{self.name}: case_id, case_actor_id, or"
                 " case_actor_participant_id missing from blackboard"
@@ -177,7 +326,7 @@ class SendOfferCaseManagerRoleNode(DataLayerAction):
                     case_id=case_id,
                     participant_id=participant_id,
                     actor=self.actor_id,
-                    to=[case_actor_id],
+                    to=recipients,
                 )
             )
             self.blackboard.activity_id = activity_id


### PR DESCRIPTION
- Closes #752

## Summary

Decomposes three case-creation god nodes into explicit composed BT subtrees so each responsibility is isolated in named leaf nodes while preserving existing behavior.

## Changes

- vultron/core/behaviors/case/nodes/communication.py: Split EmitCreateCaseActivity into CollectCaseAddresseesNode + CreateAndPersistCaseActivityNode; split SendOfferCaseManagerRoleNode into ResolveCaseManagerOfferContextNode + CreateOfferCaseManagerActivityNode.
- vultron/core/behaviors/case/nodes/case_setup.py: Split RecordCaseCreationEvents into RecordOfferReceivedEventNode + RecordCaseCreatedEventNode, keeping optional offer-event behavior and explicit node-level failure handling.
- vultron/core/behaviors/case/nodes/__init__.py: Re-export new case node classes.
- test/core/behaviors/case/nodes/test_communication.py: Added unit tests for new communication subtree structure and leaf behavior.
- test/core/behaviors/case/nodes/test_case_setup.py: Added unit tests for new case-setup subtree structure, leaf behavior, and missing-context failure paths.
- plan/BUILD_LEARNINGS.md: Added implementation observation for ISSUE-752.

## Verification

- 3089 passed, 11 skipped, 219 deselected, 5633 subtests passed
- Black, flake8, mypy, and pyright clean