### PR TITLE
Migrate SvcProposeEmbargoRevisionUseCase to BTBridge pattern

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -142,3 +142,19 @@ header.
   but dedicated case-actor container reads may be empty in D5-2 by design;
   export logic should fall back to the vendor container's case-actor sub-actor
   route key instead of failing the demo run.
+
+### 2026-06-09 ISSUE-848 — BTBridge migration for embargo revision use case
+
+- The pre-condition EM state check (ACTIVE/REVISE guard) can move cleanly
+  into a `DataLayerAction` node (`ValidateEmbargoRevisionStateNode`) that
+  reads the case, checks `current_status.em_state`, and writes the domain
+  error into `result_out["error"]` for re-raise by the use case.
+- Avoid reusing a local variable `error` across two branches with different
+  concrete types (e.g., `VultronValidationError` then
+  `VultronInvalidStateTransitionError`) — mypy infers the type from the first
+  assignment and flags the second as incompatible. Use distinct variable names
+  per branch.
+- The counter-revision path (EM.REVISE → EM.REVISE) must be tested separately
+  from ACTIVE → REVISE because `_cascade_pec_revise` only fires on the
+  ACTIVE → REVISE transition; a counter-revision must leave PEC states
+  unchanged.

--- a/plan/history/2606/implementation/ISSUE-848.md
+++ b/plan/history/2606/implementation/ISSUE-848.md
@@ -1,0 +1,33 @@
+---
+source: ISSUE-848
+timestamp: '2026-06-09T20:49:21.724996+00:00'
+title: Migrate SvcProposeEmbargoRevisionUseCase to BTBridge pattern
+type: implementation
+---
+
+## Issue #848 — Migrate SvcProposeEmbargoRevisionUseCase to BTBridge pattern
+
+Migrated `SvcProposeEmbargoRevisionUseCase` from inline `EmbargoLifecycle` +
+`send_case_actor_activity` calls to the BTBridge pattern, fixing BT-15-001
+and BT-15-002 violations and bringing the use case into parity with all other
+embargo trigger use cases.
+
+**Changes:**
+
+- Added `ValidateEmbargoRevisionStateNode` to `trigger_nodes.py` — guards
+  that case EM state is ACTIVE or REVISE before a revision proposal proceeds;
+  captures domain error in `result_out` for clean re-raise
+- Added `propose_embargo_revision_trigger_bt()` factory to `trigger_tree.py`
+  — sequences the state guard, `ProposeEmbargoLifecycleNode`,
+  `PersistEmbargoEventNode`, and `sender_side_bt`
+- Refactored `SvcProposeEmbargoRevisionUseCase.execute()` to use BTBridge;
+  removed inline `EmbargoLifecycle`, `TransitionMode`, `EM`, and
+  `send_case_actor_activity`
+- Added 12 new tests: 7 for `ValidateEmbargoRevisionStateNode`
+  (SUCCESS/FAILURE per EM state, error type assertion, missing case) and 5
+  for the migrated use case (ACTIVE→REVISE, REVISE→REVISE counter-revision,
+  outbox enqueued, invalid state raises, invalid state does not persist)
+
+**Verification:** 3091 passed, 11 skipped; Black, flake8, mypy, pyright clean.
+
+PR: [#854](https://github.com/CERTCC/Vultron/pull/854)

--- a/test/core/behaviors/embargo/test_nodes.py
+++ b/test/core/behaviors/embargo/test_nodes.py
@@ -493,3 +493,119 @@ class TestTerminateEmbargoNode:
 
         assert node.status == py_trees.common.Status.SUCCESS
         factory.terminate_embargo.assert_called_once()
+
+
+class TestValidateEmbargoRevisionStateNode:
+    """Tests for ValidateEmbargoRevisionStateNode."""
+
+    def _setup_blackboard(self, dl: SqliteDataLayer) -> None:
+        py_trees.blackboard.Blackboard.enable_activity_stream()
+        py_trees.blackboard.Blackboard.storage.clear()
+        blackboard = py_trees.blackboard.Client(name="test-ver")
+        for key in ("datalayer", "actor_id"):
+            blackboard.register_key(
+                key=key, access=py_trees.common.Access.WRITE
+            )
+        blackboard.datalayer = dl
+        blackboard.actor_id = "https://example.org/actors/alice"
+
+    def _run_node(
+        self, dl: SqliteDataLayer, case_id: str
+    ) -> tuple[py_trees.common.Status, dict]:
+        result_out: dict = {}
+        self._setup_blackboard(dl)
+
+        from vultron.core.behaviors.embargo.trigger_nodes import (
+            ValidateEmbargoRevisionStateNode,
+        )
+
+        node = ValidateEmbargoRevisionStateNode(
+            case_id=case_id, result_out=result_out
+        )
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+        return node.status, result_out
+
+    def test_returns_success_when_em_state_is_active(self):
+        """SUCCESS when case EM state is ACTIVE."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = _make_case_and_embargo("rev1", em_state=EM.ACTIVE)
+        dl.create(case)
+
+        status, result_out = self._run_node(dl, case.id_)
+
+        assert status == py_trees.common.Status.SUCCESS
+        assert "error" not in result_out
+
+    def test_returns_success_when_em_state_is_revise(self):
+        """SUCCESS when case EM state is REVISE."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = _make_case_and_embargo("rev2", em_state=EM.REVISE)
+        dl.create(case)
+
+        status, result_out = self._run_node(dl, case.id_)
+
+        assert status == py_trees.common.Status.SUCCESS
+        assert "error" not in result_out
+
+    def test_returns_failure_when_em_state_is_none(self):
+        """FAILURE when case EM state is NONE (no active embargo)."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = _make_case_and_embargo("rev3", em_state=EM.NONE)
+        case.active_embargo = None
+        dl.create(case)
+
+        status, result_out = self._run_node(dl, case.id_)
+
+        assert status == py_trees.common.Status.FAILURE
+        assert "error" in result_out
+
+    def test_returns_failure_when_em_state_is_proposed(self):
+        """FAILURE when case EM state is PROPOSED (initial proposal, not revision)."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = _make_case_and_embargo("rev4", em_state=EM.PROPOSED)
+        dl.create(case)
+
+        status, result_out = self._run_node(dl, case.id_)
+
+        assert status == py_trees.common.Status.FAILURE
+        assert "error" in result_out
+
+    def test_returns_failure_when_em_state_is_exited(self):
+        """FAILURE when case EM state is EXITED."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = _make_case_and_embargo("rev5", em_state=EM.EXITED)
+        dl.create(case)
+
+        status, result_out = self._run_node(dl, case.id_)
+
+        assert status == py_trees.common.Status.FAILURE
+        assert "error" in result_out
+
+    def test_error_is_invalid_state_transition(self):
+        """Error in result_out is VultronInvalidStateTransitionError for bad state."""
+        from vultron.errors import VultronInvalidStateTransitionError
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = _make_case_and_embargo("rev6", em_state=EM.NONE)
+        case.active_embargo = None
+        dl.create(case)
+
+        _, result_out = self._run_node(dl, case.id_)
+
+        assert isinstance(
+            result_out["error"], VultronInvalidStateTransitionError
+        )
+
+    def test_returns_failure_when_case_not_found(self):
+        """FAILURE when the case ID does not exist in the DataLayer."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        self._setup_blackboard(dl)
+
+        status, result_out = self._run_node(
+            dl, "https://example.org/cases/nonexistent"
+        )
+
+        assert status == py_trees.common.Status.FAILURE
+        assert "error" in result_out

--- a/test/core/use_cases/triggers/test_embargo.py
+++ b/test/core/use_cases/triggers/test_embargo.py
@@ -573,7 +573,7 @@ def test_propose_embargo_revision_in_revise_state_succeeds(
     case.current_status.em_state = EM.REVISE
     dl.save(case)
 
-    participant_id = case.case_participants[0]
+    participant_id = case.actor_participant_index[actor.id_]
     participant_before = cast(CaseParticipant, dl.read(participant_id))
     pec_before = participant_before.embargo_consent_state
 

--- a/test/core/use_cases/triggers/test_embargo.py
+++ b/test/core/use_cases/triggers/test_embargo.py
@@ -394,3 +394,204 @@ def test_terminate_embargo_transitions_case_to_exited_via_bt_path(
     assert updated_case.current_status.em_state == EM.EXITED
     assert updated_case.active_embargo is None
     assert updated_participant.embargo_consent_state == PEC.NO_EMBARGO.value
+
+
+# ---------------------------------------------------------------------------
+# Tests for SvcProposeEmbargoRevisionUseCase (BTBridge path)
+# ---------------------------------------------------------------------------
+
+
+def _build_active_embargo_case_with_case_manager(
+    dl: SqliteDataLayer, actor_id: str
+) -> VulnerabilityCase:
+    """Build a case in EM.ACTIVE state with ``actor`` as owner/case-manager."""
+    case = VulnerabilityCase(
+        name="Active embargo revision case",
+        attributed_to=actor_id,
+    )
+    embargo = EmbargoEvent(context=case.id_)
+
+    owner_participant = VendorParticipant(
+        attributed_to=actor_id,
+        context=case.id_,
+        embargo_consent_state=PEC.SIGNATORY,
+        accepted_embargo_ids=[embargo.id_],
+    )
+    owner_participant.add_role(CVDRole.CASE_MANAGER)
+
+    case.case_participants = [owner_participant.id_]
+    case.actor_participant_index = {actor_id: owner_participant.id_}
+    case.current_status.em_state = EM.ACTIVE
+    case.proposed_embargoes.append(embargo.id_)
+    case.set_embargo(embargo.id_)
+
+    dl.create(case)
+    dl.create(embargo)
+    dl.create(owner_participant)
+    return case
+
+
+def test_propose_embargo_revision_transitions_em_to_revise(
+    finder_actor_and_dl: tuple[as_Service, SqliteDataLayer],
+) -> None:
+    """SvcProposeEmbargoRevisionUseCase transitions EM.ACTIVE → EM.REVISE via BTBridge."""
+    from vultron.core.use_cases.triggers.embargo import (
+        SvcProposeEmbargoRevisionUseCase,
+    )
+    from vultron.core.use_cases.triggers.requests import (
+        ProposeEmbargoRevisionTriggerRequest,
+    )
+
+    actor, dl = finder_actor_and_dl
+    case = _build_active_embargo_case_with_case_manager(dl, actor.id_)
+
+    request = ProposeEmbargoRevisionTriggerRequest(
+        actor_id=actor.id_,
+        case_id=case.id_,
+        end_time=datetime.now(tz=timezone.utc) + timedelta(days=14),
+    )
+
+    result = SvcProposeEmbargoRevisionUseCase(
+        dl, request, trigger_activity=TriggerActivityAdapter(dl)
+    ).execute()
+
+    assert "activity" in result
+    updated_case = cast(VulnerabilityCase, dl.read(case.id_))
+    assert updated_case.current_status.em_state == EM.REVISE
+    assert len(updated_case.proposed_embargoes) == 2
+
+
+def test_propose_embargo_revision_queues_outbox_activity(
+    finder_actor_and_dl: tuple[as_Service, SqliteDataLayer],
+) -> None:
+    """SvcProposeEmbargoRevisionUseCase enqueues a propose-embargo activity."""
+    from vultron.core.use_cases.triggers.embargo import (
+        SvcProposeEmbargoRevisionUseCase,
+    )
+    from vultron.core.use_cases.triggers.requests import (
+        ProposeEmbargoRevisionTriggerRequest,
+    )
+
+    actor, dl = finder_actor_and_dl
+    case = _build_active_embargo_case_with_case_manager(dl, actor.id_)
+
+    outbox_before = dl.outbox_list_for_actor(actor.id_)
+
+    request = ProposeEmbargoRevisionTriggerRequest(
+        actor_id=actor.id_,
+        case_id=case.id_,
+        end_time=datetime.now(tz=timezone.utc) + timedelta(days=14),
+    )
+
+    SvcProposeEmbargoRevisionUseCase(
+        dl, request, trigger_activity=TriggerActivityAdapter(dl)
+    ).execute()
+
+    outbox_after = dl.outbox_list_for_actor(actor.id_)
+    assert len(outbox_after) > len(outbox_before)
+
+
+def test_propose_embargo_revision_invalid_em_state_raises_error(
+    finder_actor_and_dl: tuple[as_Service, SqliteDataLayer],
+) -> None:
+    """SvcProposeEmbargoRevisionUseCase raises error when EM state is not ACTIVE/REVISE."""
+    from vultron.core.use_cases.triggers.embargo import (
+        SvcProposeEmbargoRevisionUseCase,
+    )
+    from vultron.core.use_cases.triggers.requests import (
+        ProposeEmbargoRevisionTriggerRequest,
+    )
+
+    actor, dl = finder_actor_and_dl
+    # Use a case in EM.NONE — revision should be rejected
+    case = _build_no_embargo_case_with_case_manager(dl, actor.id_)
+
+    request = ProposeEmbargoRevisionTriggerRequest(
+        actor_id=actor.id_,
+        case_id=case.id_,
+        end_time=datetime.now(tz=timezone.utc) + timedelta(days=14),
+    )
+
+    with pytest.raises(VultronInvalidStateTransitionError):
+        SvcProposeEmbargoRevisionUseCase(
+            dl, request, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
+
+
+def test_propose_embargo_revision_invalid_state_does_not_persist_embargo(
+    finder_actor_and_dl: tuple[as_Service, SqliteDataLayer],
+) -> None:
+    """Failed revision must not leave behind a persisted EmbargoEvent."""
+    from vultron.core.use_cases.triggers.embargo import (
+        SvcProposeEmbargoRevisionUseCase,
+    )
+    from vultron.core.use_cases.triggers.requests import (
+        ProposeEmbargoRevisionTriggerRequest,
+    )
+
+    actor, dl = finder_actor_and_dl
+    case = _build_no_embargo_case_with_case_manager(dl, actor.id_)
+
+    before = len(list(dl.list_objects("EmbargoEvent")))
+
+    request = ProposeEmbargoRevisionTriggerRequest(
+        actor_id=actor.id_,
+        case_id=case.id_,
+        end_time=datetime.now(tz=timezone.utc) + timedelta(days=14),
+    )
+
+    with pytest.raises(VultronInvalidStateTransitionError):
+        SvcProposeEmbargoRevisionUseCase(
+            dl, request, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
+
+    after = len(list(dl.list_objects("EmbargoEvent")))
+    assert after == before
+
+
+def test_propose_embargo_revision_in_revise_state_succeeds(
+    finder_actor_and_dl: tuple[as_Service, SqliteDataLayer],
+) -> None:
+    """SvcProposeEmbargoRevisionUseCase succeeds when EM is already REVISE.
+
+    Guards against a regression where EM.REVISE → EM.REVISE counter-revision
+    is incorrectly blocked.  Participant PEC states MUST NOT be reset on this
+    path (only ACTIVE → REVISE triggers _cascade_pec_revise).
+    """
+    from vultron.core.use_cases.triggers.embargo import (
+        SvcProposeEmbargoRevisionUseCase,
+    )
+    from vultron.core.use_cases.triggers.requests import (
+        ProposeEmbargoRevisionTriggerRequest,
+    )
+
+    actor, dl = finder_actor_and_dl
+
+    # Build a case already in EM.REVISE with a SIGNATORY participant.
+    case = _build_active_embargo_case_with_case_manager(dl, actor.id_)
+    # Manually advance to REVISE so we start in the right state.
+    case.current_status.em_state = EM.REVISE
+    dl.save(case)
+
+    participant_id = case.case_participants[0]
+    participant_before = cast(CaseParticipant, dl.read(participant_id))
+    pec_before = participant_before.embargo_consent_state
+
+    request = ProposeEmbargoRevisionTriggerRequest(
+        actor_id=actor.id_,
+        case_id=case.id_,
+        end_time=datetime.now(tz=timezone.utc) + timedelta(days=21),
+    )
+
+    result = SvcProposeEmbargoRevisionUseCase(
+        dl, request, trigger_activity=TriggerActivityAdapter(dl)
+    ).execute()
+
+    assert "activity" in result
+    updated_case = cast(VulnerabilityCase, dl.read(case.id_))
+    assert updated_case.current_status.em_state == EM.REVISE
+    assert len(updated_case.proposed_embargoes) == 2
+
+    # PEC must not cascade on REVISE → REVISE; participant stays SIGNATORY.
+    participant_after = cast(CaseParticipant, dl.read(participant_id))
+    assert participant_after.embargo_consent_state == pec_before

--- a/vultron/core/behaviors/embargo/trigger_nodes.py
+++ b/vultron/core/behaviors/embargo/trigger_nodes.py
@@ -19,12 +19,18 @@ from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerAction
 from vultron.core.models.embargo_event import EmbargoEvent
+from vultron.core.models.protocols import is_case_model
 from vultron.core.services.embargo_lifecycle import (
     EmbargoLifecycle,
     EmbargoLifecycleResult,
     TransitionMode,
 )
-from vultron.errors import VultronError
+from vultron.core.states.em import EM
+from vultron.errors import (
+    VultronError,
+    VultronInvalidStateTransitionError,
+    VultronValidationError,
+)
 
 
 class PersistEmbargoEventNode(DataLayerAction):
@@ -44,6 +50,52 @@ class PersistEmbargoEventNode(DataLayerAction):
             self.logger.warning(
                 "EmbargoEvent '%s' already exists", self._embargo.id_
             )
+        return Status.SUCCESS
+
+
+class ValidateEmbargoRevisionStateNode(DataLayerAction):
+    """Guard that the case EM state permits a revision proposal.
+
+    Returns SUCCESS when EM state is ACTIVE or REVISE.  Returns FAILURE
+    (with error in ``result_out``) for any other state — revision proposals
+    require an active embargo; use propose-embargo for initial proposals.
+    """
+
+    def __init__(
+        self,
+        case_id: str,
+        result_out: dict[str, object],
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._case_id = case_id
+        self._result_out = result_out
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.feedback_message = "DataLayer not available"
+            return Status.FAILURE
+
+        case = self.datalayer.read(self._case_id)
+        if not is_case_model(case):
+            not_found = VultronValidationError(
+                f"Case '{self._case_id}' not found or invalid."
+            )
+            self._result_out["error"] = not_found
+            self.feedback_message = str(not_found)
+            return Status.FAILURE
+
+        em_state = case.current_status.em_state
+        if em_state not in (EM.ACTIVE, EM.REVISE):
+            bad_state = VultronInvalidStateTransitionError(
+                f"Cannot propose embargo revision: case '{self._case_id}'"
+                f" EM state '{em_state}' does not allow a revision proposal."
+                f" Use propose-embargo for initial proposals."
+            )
+            self._result_out["error"] = bad_state
+            self.feedback_message = str(bad_state)
+            return Status.FAILURE
+
         return Status.SUCCESS
 
 

--- a/vultron/core/behaviors/embargo/trigger_tree.py
+++ b/vultron/core/behaviors/embargo/trigger_tree.py
@@ -25,6 +25,7 @@ from vultron.core.behaviors.embargo.trigger_nodes import (
     ProposeEmbargoLifecycleNode,
     RejectEmbargoLifecycleNode,
     TerminateEmbargoLifecycleNode,
+    ValidateEmbargoRevisionStateNode,
 )
 from vultron.core.behaviors.sender.send_tree import sender_side_bt
 from vultron.core.models.embargo_event import EmbargoEvent
@@ -42,6 +43,39 @@ def propose_embargo_trigger_bt(
         name="ProposeEmbargoTriggerBT",
         memory=False,
         children=[
+            ProposeEmbargoLifecycleNode(
+                case_id=case_id,
+                embargo_id=embargo.id_,
+                result_out=result_out,
+            ),
+            PersistEmbargoEventNode(embargo=embargo),
+            sender_side_bt(case_id=case_id, activity_builder=activity_builder),
+        ],
+    )
+
+
+def propose_embargo_revision_trigger_bt(
+    *,
+    case_id: str,
+    embargo: EmbargoEvent,
+    result_out: dict[str, object],
+    activity_builder: Callable[[str], list[str]],
+) -> py_trees.behaviour.Behaviour:
+    """Build trigger-side BT for proposing an embargo revision.
+
+    Differs from :func:`propose_embargo_trigger_bt` by first asserting that
+    the case EM state is ACTIVE or REVISE (a revision requires an existing
+    active embargo).  The lifecycle and outbound fan-out nodes are otherwise
+    identical.
+    """
+    return py_trees.composites.Sequence(
+        name="ProposeEmbargoRevisionTriggerBT",
+        memory=False,
+        children=[
+            ValidateEmbargoRevisionStateNode(
+                case_id=case_id,
+                result_out=result_out,
+            ),
             ProposeEmbargoLifecycleNode(
                 case_id=case_id,
                 embargo_id=embargo.id_,

--- a/vultron/core/use_cases/triggers/embargo.py
+++ b/vultron/core/use_cases/triggers/embargo.py
@@ -20,17 +20,15 @@ from py_trees.common import Status
 from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.embargo.trigger_tree import (
     accept_embargo_trigger_bt,
+    propose_embargo_revision_trigger_bt,
     propose_embargo_trigger_bt,
     reject_embargo_trigger_bt,
     terminate_embargo_trigger_bt,
 )
 from vultron.core.models.embargo_event import EmbargoEvent
 from vultron.core.services.embargo_lifecycle import (
-    EmbargoLifecycle,
     EmbargoLifecycleResult,
-    TransitionMode,
 )
-from vultron.core.states.em import EM
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.ports.trigger_activity import TriggerActivityPort
 from vultron.core.use_cases.triggers._helpers import (
@@ -40,7 +38,6 @@ from vultron.core.use_cases.triggers._helpers import (
     _resolve_embargo_proposal,
     resolve_actor,
     resolve_case,
-    send_case_actor_activity,
 )
 from vultron.core.use_cases.triggers.requests import (
     AcceptEmbargoTriggerRequest,
@@ -455,14 +452,6 @@ class SvcProposeEmbargoRevisionUseCase:
 
         case = resolve_case(case_id, dl)
 
-        em_state = case.current_status.em_state
-        if em_state not in (EM.ACTIVE, EM.REVISE):
-            raise VultronInvalidStateTransitionError(
-                f"Cannot propose embargo revision: case '{case.id_}' EM state"
-                f" '{em_state}' does not allow a revision proposal."
-                f" Use propose-embargo for initial proposals."
-            )
-
         embargo_kwargs: dict = {"context": case.id_}
         if end_time is not None:
             embargo_kwargs["end_time"] = end_time
@@ -475,21 +464,9 @@ class SvcProposeEmbargoRevisionUseCase:
                 " TriggerActivityPort"
             )
 
-        lifecycle = EmbargoLifecycle(persistence=dl)
-        lifecycle_result = lifecycle.propose_embargo(
-            case_id=case.id_,
-            embargo_id=embargo.id_,
-            actor_id=actor_id,
-            transition_mode=TransitionMode.STRICT,
-        )
-
-        try:
-            dl.create(embargo)
-        except ValueError:
-            logger.warning("EmbargoEvent '%s' already exists", embargo.id_)
-
         factory = self._trigger_activity
         captured: dict = {}
+        result_out: dict[str, object] = {}
 
         def _build_activities(case_manager_id: str) -> list[str]:
             proposal_id, proposal_dict = factory.propose_embargo(
@@ -501,14 +478,28 @@ class SvcProposeEmbargoRevisionUseCase:
             captured["activity"] = proposal_dict
             return [proposal_id]
 
-        send_case_actor_activity(
-            dl=dl,
+        bridge = BTBridge(datalayer=dl, trigger_activity=factory)
+        tree = propose_embargo_revision_trigger_bt(
             case_id=case.id_,
-            actor_id=actor_id,
-            trigger_activity=factory,
-            failure_label="ProposeEmbargoRevision",
+            embargo=embargo,
+            result_out=result_out,
             activity_builder=_build_activities,
         )
+        result = bridge.execute_with_setup(tree, actor_id=actor_id)
+        if result.status != Status.SUCCESS:
+            error = result_out.get("error")
+            if isinstance(error, Exception):
+                raise error
+            raise VultronValidationError(
+                f"ProposeEmbargoRevision failed:"
+                f" {BTBridge.get_failure_reason(tree)}"
+            )
+        lifecycle_result = result_out.get("lifecycle_result")
+        if not isinstance(lifecycle_result, EmbargoLifecycleResult):
+            raise RuntimeError(
+                "ProposeEmbargoRevision did not capture lifecycle result"
+                " in BT output"
+            )
 
         logger.info(
             "Actor '%s' proposed embargo revision '%s' on case '%s'"


### PR DESCRIPTION
- Closes #848

## Summary

Migrates `SvcProposeEmbargoRevisionUseCase` from inline `EmbargoLifecycle` +
`send_case_actor_activity` calls to the BTBridge pattern, bringing it into
parity with all other embargo trigger use cases and fixing BT-15-001/BT-15-002
violations.

## Changes

- `vultron/core/behaviors/embargo/trigger_nodes.py`: Add
  `ValidateEmbargoRevisionStateNode` — guards that case EM state is ACTIVE or
  REVISE before allowing a revision proposal; captures domain error in
  `result_out` for clean re-raise
- `vultron/core/behaviors/embargo/trigger_tree.py`: Add
  `propose_embargo_revision_trigger_bt()` factory — sequences the state guard,
  `ProposeEmbargoLifecycleNode`, `PersistEmbargoEventNode`, and
  `sender_side_bt`
- `vultron/core/use_cases/triggers/embargo.py`: Refactor
  `SvcProposeEmbargoRevisionUseCase.execute()` to use BTBridge; remove inline
  `EmbargoLifecycle`, `TransitionMode`, `EM`, and `send_case_actor_activity`
- `test/core/behaviors/embargo/test_nodes.py`: Add
  `TestValidateEmbargoRevisionStateNode` (7 tests: SUCCESS for ACTIVE/REVISE,
  FAILURE for NONE/PROPOSED/EXITED/missing, error type assertion)
- `test/core/use_cases/triggers/test_embargo.py`: Add 5 new tests for the
  migrated use case (EM.ACTIVE→REVISE, EM.REVISE→REVISE counter-revision, outbox
  enqueued, invalid state raises without persisting, invalid state rollback)

## Verification

- 3091 passed, 11 skipped in 37.88s (5 new tests: use-case suite; 7 new tests: BT node suite)
- Black, flake8, mypy, pyright all clean