### PR TITLE
Rename hash-chain CaseLogEntry to HashChainLogRecord (#806)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -438,18 +438,15 @@ Short entries are reproduced here; longer ones are referenced below.
   is intrinsically cross-cutting; bundled diffs let reviewers miss
   regressions in the half they aren't focused on. See
   [notes/triggers-test-coverage.md](notes/triggers-test-coverage.md).
-- **Two `CaseLogEntry` Classes With the Same Name** — There are two classes named
-  `CaseLogEntry` in `vultron/core/models/` that serve completely different purposes.
-  `vultron.core.models.case_log.CaseLogEntry` (`BaseModel`) is the in-memory
-  hash-chain record used by `CaseEventLog` for local SYNC-1 processing — it is
-  **not** persisted or shared over the wire. `vultron.core.models.case_log_entry.CaseLogEntry`
+- **Hash-Chain Log Record vs. Domain Model** — Two distinct classes exist for case
+  log entries. `vultron.core.models.case_log.HashChainLogRecord` (`BaseModel`) is
+  the in-memory hash-chain record used by `CaseEventLog` for local SYNC-1 processing
+  — it is **not** persisted or shared over the wire. `vultron.core.models.case_log_entry.CaseLogEntry`
   (`CoreObject`) is the wire-serialisable domain model used in
   `Announce(CaseLogEntry)` replication activities — it has an auto-computed
-  `id_` and registers in `CORE_VOCABULARY`. Importing from the wrong module
-  silently produces incorrect behaviour. The local class is tracked for renaming
-  in issue #806 to eliminate this ambiguity. Until it is renamed, always import
-  by full module path and verify which class you need. See `specs/architecture.yaml`
-  ARCH-12-007 and concern #804.
+  `id_` and registers in `CORE_VOCABULARY`. Always import by full module path and
+  verify which class you need. See `specs/architecture.yaml` ARCH-12-007 and
+  issue #806.
 - **Adding a New Pitfall: Check the Routing Policy First** — see
   [notes/agents-md-structure.md](notes/agents-md-structure.md)
 - **Trigger-Side execute() Must Delegate SM Transitions to BTBridge** — A

--- a/plan/history/2606/implementation/ISSUE-806.md
+++ b/plan/history/2606/implementation/ISSUE-806.md
@@ -1,0 +1,28 @@
+---
+source: ISSUE-806
+timestamp: '2026-06-10T13:50:08.763802+00:00'
+title: Rename hash-chain CaseLogEntry to HashChainLogRecord
+type: implementation
+---
+
+## Issue #806 — Rename local hash-chain CaseLogEntry to eliminate naming ambiguity
+
+Renamed `vultron.core.models.case_log.CaseLogEntry` → `HashChainLogRecord` to
+eliminate confusion with the wire-serializable `CaseLogEntry(CoreObject)` in
+`case_log_entry.py`. The hash-chain record is a local in-memory model used by
+`CaseEventLog` for SYNC-1 processing and is never persisted or sent over the wire.
+
+### Changes
+
+- **case_log.py**: class renamed; docstring updated
+- **chain.py**: import and 3 instantiations updated
+- **sync.py** (triggers): import and 3 type signatures updated
+- **conftest.py** (sync nodes): fixture updated
+- **8 test files**: all imports and assertions updated
+- **AGENTS.md**: pitfall entry updated with new name
+
+### Outcome
+
+All 3100 unit tests pass. All 4 linters clean.
+
+PR: [https://github.com/CERTCC/Vultron/pull/857](https://github.com/CERTCC/Vultron/pull/857)

--- a/test/adapters/driven/test_sqlite_backend.py
+++ b/test/adapters/driven/test_sqlite_backend.py
@@ -881,13 +881,16 @@ class TestCoerceToSemanticClass:
 
     def test_announce_log_entry_round_trip_returns_specific_class(self, dl):
         """dl.read returns AnnounceLogEntryActivity with CaseLogEntry object_."""
-        from vultron.core.models.case_log import GENESIS_HASH, CaseLogEntry
+        from vultron.core.models.case_log import (
+            GENESIS_HASH,
+            HashChainLogRecord,
+        )
         from vultron.core.use_cases.triggers.sync import _to_persistable_entry
         from vultron.wire.as2.vocab.objects.case_log_entry import (
             CaseLogEntry as WireCaseLogEntry,
         )
 
-        chain_entry = CaseLogEntry(
+        chain_entry = HashChainLogRecord(
             case_id="https://example.org/cases/case-sync-1",
             log_index=0,
             object_id="https://example.org/activities/logged-1",

--- a/test/adapters/driving/fastapi/test_outbox.py
+++ b/test/adapters/driving/fastapi/test_outbox.py
@@ -684,7 +684,7 @@ def test_handle_outbox_item_converts_typed_activity_with_full_target():
 
 def test_handle_outbox_item_preserves_inline_case_log_entry_fields():
     """Announce(CaseLogEntry) delivery keeps full inline log-entry fields."""
-    from vultron.core.models.case_log import GENESIS_HASH, CaseLogEntry
+    from vultron.core.models.case_log import GENESIS_HASH, HashChainLogRecord
     from vultron.core.use_cases.triggers.sync import _to_persistable_entry
     from vultron.wire.as2.factories import announce_log_entry_activity
     from vultron.wire.as2.vocab.objects.case_log_entry import (
@@ -692,7 +692,7 @@ def test_handle_outbox_item_preserves_inline_case_log_entry_fields():
     )
 
     recipient = "https://example.org/actors/participant"
-    chain_entry = CaseLogEntry(
+    chain_entry = HashChainLogRecord(
         case_id="https://example.org/cases/case-sync-2",
         log_index=0,
         object_id="https://example.org/activities/logged-2",

--- a/test/core/behaviors/sync/nodes/conftest.py
+++ b/test/core/behaviors/sync/nodes/conftest.py
@@ -9,7 +9,7 @@ import pytest
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.models.case_actor import VultronCaseActor
-from vultron.core.models.case_log import CaseLogEntry
+from vultron.core.models.case_log import HashChainLogRecord
 from vultron.core.models.case_log_entry import VultronCaseLogEntry
 from vultron.core.models.events.sync import AnnounceLogEntryReceivedEvent
 from vultron.core.use_cases.triggers.sync import _to_persistable_entry
@@ -54,7 +54,7 @@ def case_actor(datalayer):
 
 def _make_entry(log_index: int, prev_hash: str) -> VultronCaseLogEntry:
     return _to_persistable_entry(
-        CaseLogEntry(
+        HashChainLogRecord(
             case_id=CASE_ID,
             log_index=log_index,
             object_id=f"https://example.org/activities/log-{log_index}",

--- a/test/core/behaviors/sync/test_announce_tree.py
+++ b/test/core/behaviors/sync/test_announce_tree.py
@@ -14,7 +14,7 @@ from vultron.core.behaviors.sync.announce_tree import (
     create_announce_log_entry_tree,
 )
 from vultron.core.models.case_actor import VultronCaseActor
-from vultron.core.models.case_log import GENESIS_HASH, CaseLogEntry
+from vultron.core.models.case_log import GENESIS_HASH, HashChainLogRecord
 from vultron.core.models.case_log_entry import VultronCaseLogEntry
 from vultron.core.models.events.sync import AnnounceLogEntryReceivedEvent
 from vultron.core.ports.sync_activity import SyncActivityPort
@@ -65,7 +65,7 @@ def case_actor(datalayer):
 
 def _make_entry(log_index: int, prev_hash: str) -> VultronCaseLogEntry:
     return _to_persistable_entry(
-        CaseLogEntry(
+        HashChainLogRecord(
             case_id=CASE_ID,
             log_index=log_index,
             object_id=f"https://example.org/activities/log-{log_index}",
@@ -164,7 +164,7 @@ def _make_remove_embargo_entry(
     log_index: int, prev_hash: str
 ) -> VultronCaseLogEntry:
     return _to_persistable_entry(
-        CaseLogEntry(
+        HashChainLogRecord(
             case_id=CASE_ID,
             log_index=log_index,
             object_id=f"https://example.org/activities/log-{log_index}",

--- a/test/core/behaviors/sync/test_commit_tree.py
+++ b/test/core/behaviors/sync/test_commit_tree.py
@@ -13,7 +13,7 @@ from vultron.core.behaviors.sync.commit_tree import (
     create_commit_log_entry_tree,
 )
 from vultron.core.models.case import VultronCase
-from vultron.core.models.case_log import GENESIS_HASH, CaseLogEntry
+from vultron.core.models.case_log import GENESIS_HASH, HashChainLogRecord
 from vultron.core.ports.sync_activity import SyncActivityPort
 from vultron.core.use_cases.triggers.sync import _to_persistable_entry
 
@@ -55,7 +55,7 @@ def case_obj(datalayer):
 
 def _make_entry(log_index: int, prev_hash: str):
     return _to_persistable_entry(
-        CaseLogEntry(
+        HashChainLogRecord(
             case_id=CASE_ID,
             log_index=log_index,
             object_id=f"https://example.org/activities/log-{log_index}",

--- a/test/core/behaviors/sync/test_reject_tree.py
+++ b/test/core/behaviors/sync/test_reject_tree.py
@@ -14,7 +14,7 @@ from vultron.core.behaviors.sync.reject_tree import (
     create_reject_log_entry_tree,
 )
 from vultron.core.models.case_actor import VultronCaseActor
-from vultron.core.models.case_log import GENESIS_HASH, CaseLogEntry
+from vultron.core.models.case_log import GENESIS_HASH, HashChainLogRecord
 from vultron.core.models.case_log_entry import VultronCaseLogEntry
 from vultron.core.models.events.sync import RejectLogEntryReceivedEvent
 from vultron.core.models.replication_state import VultronReplicationState
@@ -61,7 +61,7 @@ def case_actor(datalayer):
 
 def _make_entry(log_index: int, prev_hash: str) -> VultronCaseLogEntry:
     return _to_persistable_entry(
-        CaseLogEntry(
+        HashChainLogRecord(
             case_id=CASE_ID,
             log_index=log_index,
             object_id=f"https://example.org/activities/log-{log_index}",

--- a/test/core/models/test_case_log.py
+++ b/test/core/models/test_case_log.py
@@ -40,7 +40,7 @@ from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.models.case_log import (
     GENESIS_HASH,
     CaseEventLog,
-    CaseLogEntry,
+    HashChainLogRecord,
     ReplicationState,
     _canonical_bytes,
     _sha256_hex,
@@ -139,7 +139,7 @@ class TestGenesisHash:
 
 class TestCaseLogEntry:
     def test_construction_sets_required_fields(self):
-        entry = CaseLogEntry(
+        entry = HashChainLogRecord(
             case_id=CASE_ID,
             log_index=0,
             object_id=OBJECT_ID,
@@ -153,7 +153,7 @@ class TestCaseLogEntry:
         assert entry.prev_log_hash == GENESIS_HASH
 
     def test_entry_hash_auto_computed(self):
-        entry = CaseLogEntry(
+        entry = HashChainLogRecord(
             case_id=CASE_ID,
             log_index=0,
             object_id=OBJECT_ID,
@@ -164,7 +164,7 @@ class TestCaseLogEntry:
         assert len(entry.entry_hash) == 64
 
     def test_entry_hash_verify_hash_passes(self):
-        entry = CaseLogEntry(
+        entry = HashChainLogRecord(
             case_id=CASE_ID,
             log_index=0,
             object_id=OBJECT_ID,
@@ -174,7 +174,7 @@ class TestCaseLogEntry:
         assert entry.verify_hash()
 
     def test_entry_hash_tamper_detection(self):
-        entry = CaseLogEntry(
+        entry = HashChainLogRecord(
             case_id=CASE_ID,
             log_index=0,
             object_id=OBJECT_ID,
@@ -186,7 +186,7 @@ class TestCaseLogEntry:
         assert not entry.verify_hash()
 
     def test_default_disposition_is_recorded(self):
-        entry = CaseLogEntry(
+        entry = HashChainLogRecord(
             case_id=CASE_ID,
             log_index=0,
             object_id=OBJECT_ID,
@@ -196,7 +196,7 @@ class TestCaseLogEntry:
         assert entry.disposition == "recorded"
 
     def test_rejected_disposition(self):
-        entry = CaseLogEntry(
+        entry = HashChainLogRecord(
             case_id=CASE_ID,
             log_index=0,
             object_id=OBJECT_ID,
@@ -209,7 +209,7 @@ class TestCaseLogEntry:
         assert entry.reason_code == "INVALID_STATE"
 
     def test_term_defaults_to_none(self):
-        entry = CaseLogEntry(
+        entry = HashChainLogRecord(
             case_id=CASE_ID,
             log_index=0,
             object_id=OBJECT_ID,
@@ -219,14 +219,14 @@ class TestCaseLogEntry:
         assert entry.term is None
 
     def test_different_entries_have_different_hashes(self):
-        e1 = CaseLogEntry(
+        e1 = HashChainLogRecord(
             case_id=CASE_ID,
             log_index=0,
             object_id="urn:uuid:obj1",
             event_type="test",
             prev_log_hash=GENESIS_HASH,
         )
-        e2 = CaseLogEntry(
+        e2 = HashChainLogRecord(
             case_id=CASE_ID,
             log_index=0,
             object_id="urn:uuid:obj2",
@@ -237,7 +237,7 @@ class TestCaseLogEntry:
 
     def test_entry_hash_not_in_hashable_dict(self):
         """entry_hash MUST be excluded from the content that is hashed."""
-        entry = CaseLogEntry(
+        entry = HashChainLogRecord(
             case_id=CASE_ID,
             log_index=0,
             object_id=OBJECT_ID,
@@ -249,7 +249,7 @@ class TestCaseLogEntry:
 
     def test_payload_snapshot_stored_as_dict(self):
         snap = {"id": OBJECT_ID, "type": "Offer"}
-        entry = CaseLogEntry(
+        entry = HashChainLogRecord(
             case_id=CASE_ID,
             log_index=0,
             object_id=OBJECT_ID,
@@ -260,7 +260,7 @@ class TestCaseLogEntry:
         assert entry.payload_snapshot == snap
 
     def test_reason_detail_optional(self):
-        entry = CaseLogEntry(
+        entry = HashChainLogRecord(
             case_id=CASE_ID,
             log_index=0,
             object_id=OBJECT_ID,

--- a/test/core/use_cases/received/test_reject_sync.py
+++ b/test/core/use_cases/received/test_reject_sync.py
@@ -21,7 +21,7 @@ from unittest.mock import MagicMock
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.adapters.driven.sync_activity_adapter import SyncActivityAdapter
-from vultron.core.models.case_log import GENESIS_HASH, CaseLogEntry
+from vultron.core.models.case_log import GENESIS_HASH, HashChainLogRecord
 from vultron.core.models.case_log_entry import VultronCaseLogEntry
 from vultron.core.use_cases.triggers.sync import _to_persistable_entry
 from vultron.core.models.events import MessageSemantics
@@ -49,7 +49,7 @@ CASE_URI = "https://example.org/cases/case1"
 def _make_entry(
     case_id: str, log_index: int, prev_hash: str
 ) -> VultronCaseLogEntry:
-    chain = CaseLogEntry(
+    chain = HashChainLogRecord(
         case_id=case_id,
         log_index=log_index,
         object_id="https://example.org/activities/act1",

--- a/test/core/use_cases/received/test_sync.py
+++ b/test/core/use_cases/received/test_sync.py
@@ -18,7 +18,7 @@ from unittest.mock import MagicMock
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.adapters.driven.sync_activity_adapter import SyncActivityAdapter
-from vultron.core.models.case_log import GENESIS_HASH, CaseLogEntry
+from vultron.core.models.case_log import GENESIS_HASH, HashChainLogRecord
 from vultron.core.models.case_log_entry import VultronCaseLogEntry
 from vultron.core.use_cases.triggers.sync import _to_persistable_entry
 from vultron.core.models.events import MessageSemantics
@@ -44,7 +44,7 @@ CASE_URI = "https://example.org/cases/case1"
 def _make_entry(
     case_id: str, log_index: int, prev_hash: str
 ) -> VultronCaseLogEntry:
-    chain = CaseLogEntry(
+    chain = HashChainLogRecord(
         case_id=case_id,
         log_index=log_index,
         object_id="https://example.org/activities/act1",

--- a/vultron/core/behaviors/sync/nodes/chain.py
+++ b/vultron/core/behaviors/sync/nodes/chain.py
@@ -24,7 +24,7 @@ from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerAction
 from vultron.core.models._helpers import _now_utc
-from vultron.core.models.case_log import CaseLogEntry
+from vultron.core.models.case_log import HashChainLogRecord
 from vultron.core.models.case_log_entry import VultronCaseLogEntry
 from vultron.core.models.protocols import is_log_entry_model
 from vultron.core.sync_helpers import _reconstruct_tail_hash
@@ -59,7 +59,9 @@ def _require_case_id_from_activity(activity: Any, node_name: str) -> str:
     raise VultronError(f"{node_name}: could not resolve case_id from activity")
 
 
-def _to_persistable_entry(chain_entry: CaseLogEntry) -> VultronCaseLogEntry:
+def _to_persistable_entry(
+    chain_entry: HashChainLogRecord,
+) -> VultronCaseLogEntry:
     return VultronCaseLogEntry(
         case_id=chain_entry.case_id,
         log_index=chain_entry.log_index,
@@ -213,7 +215,7 @@ class CreateLogEntryNode(DataLayerAction):
     def update(self) -> Status:
         tail_hash = self.blackboard.tail_hash
         tail_index = self.blackboard.tail_index
-        chain_entry = CaseLogEntry(
+        chain_entry = HashChainLogRecord(
             case_id=self.case_id,
             log_index=tail_index + 1,
             object_id=self.object_id,

--- a/vultron/core/models/case_log.py
+++ b/vultron/core/models/case_log.py
@@ -16,7 +16,7 @@
 
 This module provides:
 
-- :class:`CaseLogEntry` — a single canonical log entry with hash-chain
+- :class:`HashChainLogRecord` — a single canonical log entry with hash-chain
   linkage and an optional embedded activity payload snapshot.
 - :class:`CaseEventLog` — an append-only, hash-chained log for a single case.
 - :class:`ReplicationState` — per-peer last-acknowledged log hash for
@@ -29,7 +29,7 @@ Design follows the single-writer CaseActor architecture described in
 
 Hash chain:
 
-- Each :class:`CaseLogEntry` stores the SHA-256 hash of its own canonical
+- Each :class:`HashChainLogRecord` stores the SHA-256 hash of its own canonical
   content (``entry_hash``) and the hash of its immediate predecessor
   (``prev_log_hash``).
 - The first entry uses :data:`GENESIS_HASH` as ``prev_log_hash``.
@@ -116,7 +116,7 @@ def _sha256_hex(data: dict[str, Any]) -> str:
 # ---------------------------------------------------------------------------
 
 
-class CaseLogEntry(BaseModel):
+class HashChainLogRecord(BaseModel):
     """A single canonical case log entry.
 
     Each entry is created by the CaseActor's single authoritative write path
@@ -203,7 +203,7 @@ class CaseLogEntry(BaseModel):
     )
 
     @model_validator(mode="after")
-    def _compute_entry_hash(self) -> "CaseLogEntry":
+    def _compute_entry_hash(self) -> "HashChainLogRecord":
         """Compute ``entry_hash`` from canonical content if not already set."""
         if not self.entry_hash:
             self.entry_hash = self._hash_content()
@@ -290,7 +290,7 @@ class CaseEventLog:
             case_id: URI of the :class:`VulnerabilityCase` this log tracks.
         """
         self._case_id = case_id
-        self._entries: list[CaseLogEntry] = []
+        self._entries: list[HashChainLogRecord] = []
 
     # ------------------------------------------------------------------
     # Properties
@@ -302,12 +302,12 @@ class CaseEventLog:
         return self._case_id
 
     @property
-    def entries(self) -> tuple[CaseLogEntry, ...]:
+    def entries(self) -> tuple[HashChainLogRecord, ...]:
         """All entries (recorded *and* rejected) as an immutable tuple."""
         return tuple(self._entries)
 
     @property
-    def recorded_entries(self) -> tuple[CaseLogEntry, ...]:
+    def recorded_entries(self) -> tuple[HashChainLogRecord, ...]:
         """Projection of entries whose disposition is ``"recorded"``.
 
         Used for hash-chain computation and canonical state reconstruction.
@@ -353,7 +353,7 @@ class CaseEventLog:
         term: int | None = None,
         reason_code: str | None = None,
         reason_detail: str | None = None,
-    ) -> CaseLogEntry:
+    ) -> HashChainLogRecord:
         """Append a new entry to the log and return it.
 
         Assigns ``log_index``, sets ``prev_log_hash`` from
@@ -381,7 +381,7 @@ class CaseEventLog:
                 "reason_code is required for rejected CaseLogEntry objects"
             )
 
-        entry = CaseLogEntry(
+        entry = HashChainLogRecord(
             case_id=self._case_id,
             log_index=self.next_index,
             disposition=disposition,

--- a/vultron/core/use_cases/triggers/sync.py
+++ b/vultron/core/use_cases/triggers/sync.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, cast
 
-from vultron.core.models.case_log import CaseLogEntry
+from vultron.core.models.case_log import HashChainLogRecord
 from vultron.core.models.case_log_entry import VultronCaseLogEntry
 from vultron.core.models.protocols import (
     LogEntryModel,
@@ -78,9 +78,9 @@ def extract_activity_snapshot(request: "VultronEvent") -> dict[str, Any]:
 
 
 def _to_persistable_entry(
-    chain_entry: CaseLogEntry,
+    chain_entry: HashChainLogRecord,
 ) -> VultronCaseLogEntry:
-    """Convert a hash-chained :class:`CaseLogEntry` to a :class:`VultronCaseLogEntry`.
+    """Convert a hash-chained :class:`HashChainLogRecord` to a :class:`VultronCaseLogEntry`.
 
     Copies all fields so that the entry can be stored via the DataLayer.
     """
@@ -195,11 +195,11 @@ def commit_log_entry_trigger(
     """
     tail_hash, tail_index = _reconstruct_tail_hash(case_id, dl)
 
-    # Create the new entry directly using CaseLogEntry so the entry_hash is
+    # Create the new entry directly using HashChainLogRecord so the entry_hash is
     # auto-computed by the model_validator.  We do not use CaseEventLog.append()
     # here because that always starts a fresh log at index 0; we carry forward
     # the DataLayer state via tail_hash and tail_index instead.
-    chain_entry = CaseLogEntry(
+    chain_entry = HashChainLogRecord(
         case_id=case_id,
         log_index=tail_index + 1,
         object_id=object_id,


### PR DESCRIPTION
- Closes #806

## Summary

Eliminate naming ambiguity between two distinct `CaseLogEntry` classes by renaming
the local in-memory hash-chain record class from `CaseLogEntry` to
`HashChainLogRecord`. The wire-serializable domain model in
`case_log_entry.py` retains the name `CaseLogEntry` and is used in
`Announce(CaseLogEntry)` replication activities.

## Changes

- `vultron/core/models/case_log.py`: renamed class, updated docstring
- `vultron/core/behaviors/sync/nodes/chain.py`: updated imports and 3 uses
- `vultron/core/use_cases/triggers/sync.py`: updated imports and 3 uses
- `test/core/behaviors/sync/nodes/conftest.py`: updated fixture
- 8 test files: updated imports and assertions
- `AGENTS.md`: updated pitfall entry with new class name

## Verification

- All 3100 unit tests pass (36.01s)
- Black, flake8, mypy, pyright all clean