### PR TITLE
Migrate SvcInvalidateReportUseCase, SvcRejectReportUseCase, SvcCloseReportUseCase to BTBridge

### DIFF
--- a/plan/history/2606/implementation/ISSUE-849.md
+++ b/plan/history/2606/implementation/ISSUE-849.md
@@ -1,0 +1,41 @@
+---
+source: ISSUE-849
+timestamp: '2026-06-10T14:11:36.847172+00:00'
+title: Migrate SvcInvalidateReportUseCase, SvcRejectReportUseCase, SvcCloseReportUseCase
+  to BTBridge
+type: implementation
+---
+
+## Issue #849 — Migrate SvcInvalidateReportUseCase, SvcRejectReportUseCase, SvcCloseReportUseCase to BTBridge
+
+Replaced inline `ParticipantStatus` creation and procedural state transitions
+in three report-lifecycle trigger use cases with proper BT factory functions
+and `BTBridge.execute_with_setup()` calls. Satisfies BT-15-001 and BT-15-002.
+
+### New BT nodes (`vultron/core/behaviors/report/nodes/`)
+
+- `TransitionRMtoClosed` — persists report-phase `ParticipantStatus(rm_state=RM.CLOSED)`
+- `CheckReportNotClosed` — duplicate-close guard; writes
+  `VultronInvalidStateTransitionError` into `result_out["error"]` on FAILURE
+- `EmitInvalidateReportActivity` — creates and queues `TentativeReject(Offer)`
+- `EmitCloseReportActivity` — creates and queues `Reject(Offer)` (shared by
+  reject/close paths)
+
+### New BT factories (`vultron/core/behaviors/report/trigger_report_trees.py`)
+
+- `create_invalidate_report_trigger_tree` — Emit → TransitionRMtoInvalid
+- `create_reject_report_trigger_tree` — Emit → TransitionRMtoClosed (no guard)
+- `create_close_report_trigger_tree` — CheckNotClosed → Emit → TransitionRMtoClosed
+
+### Bug fixed during implementation
+
+`py_trees.common.Status.SUCCESS.value` is `'SUCCESS'` (uppercase), not
+`"success"`. Three use cases had fragile `result.status.value != "success"`
+comparisons that always evaluated True regardless of BT outcome. Fixed by
+importing `Status` and comparing `result.status != Status.SUCCESS`.
+
+### Outcome
+
+3113 tests passing, all linters clean (Black, flake8, mypy, pyright).
+
+PR: [#858](https://github.com/CERTCC/Vultron/pull/858)

--- a/test/core/behaviors/report/test_trigger_report_trees.py
+++ b/test/core/behaviors/report/test_trigger_report_trees.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see Contributors.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Tests for the report trigger BT factories (issue #849 AC-4).
+
+Covers SUCCESS and FAILURE paths for:
+  - ``InvalidateReportTriggerBT`` (create_invalidate_report_trigger_tree)
+  - ``RejectReportTriggerBT``     (create_reject_report_trigger_tree)
+  - ``CloseReportTriggerBT``      (create_close_report_trigger_tree)
+"""
+
+import pytest
+from py_trees.common import Status
+
+from test.core.behaviors.bt_harness import BTTestScenario
+from vultron.core.behaviors.report.trigger_report_trees import (
+    create_close_report_trigger_tree,
+    create_invalidate_report_trigger_tree,
+    create_reject_report_trigger_tree,
+)
+from vultron.core.models.activity import VultronOffer
+from vultron.core.models.case_actor import VultronCaseActor
+from vultron.core.models.participant_status import ParticipantStatus
+from vultron.core.models.report import VultronReport
+from vultron.core.states.rm import RM
+from vultron.core.use_cases._helpers import _report_phase_status_id
+from vultron.errors import VultronInvalidStateTransitionError
+
+# noqa: F401 — vocabulary registration side-effect
+from vultron.wire.as2.vocab.objects.vulnerability_case import (  # noqa: F401
+    VulnerabilityCase,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+ACTOR_ID = "https://example.org/actors/vendor"
+REPORTER_ID = "https://example.org/actors/reporter"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def scenario() -> BTTestScenario:
+    return BTTestScenario(actor_id=ACTOR_ID)
+
+
+@pytest.fixture
+def actor(scenario: BTTestScenario) -> VultronCaseActor:
+    obj = VultronCaseActor(id_=ACTOR_ID, name="Vendor Co")
+    scenario.dl.create(obj)
+    return obj
+
+
+@pytest.fixture
+def report(scenario: BTTestScenario) -> VultronReport:
+    obj = VultronReport(name="TEST-001", content="Test vuln")
+    scenario.dl.create(obj)
+    return obj
+
+
+@pytest.fixture
+def offer(
+    scenario: BTTestScenario, report: VultronReport, actor: VultronCaseActor
+) -> VultronOffer:
+    obj = VultronOffer(actor=REPORTER_ID, object_=report.id_, target=ACTOR_ID)
+    scenario.dl.create(obj)
+    return obj
+
+
+@pytest.fixture
+def closed_status(
+    scenario: BTTestScenario, report: VultronReport
+) -> ParticipantStatus:
+    """Pre-seed RM.CLOSED so the duplicate-close guard fires."""
+    status = ParticipantStatus(
+        id_=_report_phase_status_id(ACTOR_ID, report.id_, RM.CLOSED.value),
+        context=report.id_,
+        attributed_to=ACTOR_ID,
+        rm_state=RM.CLOSED,
+    )
+    scenario.dl.create(status)
+    return status
+
+
+# ---------------------------------------------------------------------------
+# InvalidateReportTriggerBT tests
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidateReportTriggerTree:
+    def test_success_emits_activity_and_sets_rm_invalid(
+        self, scenario: BTTestScenario, actor, report, offer
+    ):
+        """SUCCESS: emits activity and persists RM.INVALID ParticipantStatus."""
+        tree = create_invalidate_report_trigger_tree(
+            offer_id=offer.id_, report_id=report.id_
+        )
+        result = scenario.run(tree)
+        scenario.assert_success(result)
+        scenario.assert_rm_state(report.id_, RM.INVALID)
+
+    def test_success_adds_to_outbox(
+        self, scenario: BTTestScenario, actor, report, offer
+    ):
+        """SUCCESS: activity is added to the actor's outbox."""
+        before = set(scenario.dl.outbox_list_for_actor(ACTOR_ID))
+        tree = create_invalidate_report_trigger_tree(
+            offer_id=offer.id_, report_id=report.id_
+        )
+        scenario.run(tree)
+        after = set(scenario.dl.outbox_list_for_actor(ACTOR_ID))
+        assert len(after - before) >= 1
+
+    def test_failure_no_trigger_activity_factory(
+        self, scenario: BTTestScenario, actor, report, offer
+    ):
+        """FAILURE: no TriggerActivityPort on the blackboard → tree fails."""
+        import py_trees
+
+        from vultron.core.behaviors.bridge import BTBridge
+
+        # Build a bridge without trigger_activity
+        bridge_no_factory = BTBridge(datalayer=scenario.dl)
+        tree = create_invalidate_report_trigger_tree(
+            offer_id=offer.id_, report_id=report.id_
+        )
+        py_trees.blackboard.Blackboard.storage.clear()
+        result = bridge_no_factory.execute_with_setup(tree, actor_id=ACTOR_ID)
+        assert result.status == Status.FAILURE
+
+    def test_idempotent_second_run(
+        self, scenario: BTTestScenario, actor, report, offer
+    ):
+        """Running the tree twice must not raise — idempotent create guard."""
+        for _ in range(2):
+            py_trees_module = pytest.importorskip("py_trees")
+            py_trees_module.blackboard.Blackboard.storage.clear()
+            tree = create_invalidate_report_trigger_tree(
+                offer_id=offer.id_, report_id=report.id_
+            )
+            result = scenario.run(tree)
+        # Second run should succeed (idempotent) or at minimum not raise
+        assert result.status in (Status.SUCCESS, Status.FAILURE)
+
+
+# ---------------------------------------------------------------------------
+# RejectReportTriggerBT tests
+# ---------------------------------------------------------------------------
+
+
+class TestRejectReportTriggerTree:
+    def test_success_emits_activity_and_sets_rm_closed(
+        self, scenario: BTTestScenario, actor, report, offer
+    ):
+        """SUCCESS: emits activity and persists RM.CLOSED ParticipantStatus."""
+        tree = create_reject_report_trigger_tree(
+            offer_id=offer.id_, report_id=report.id_
+        )
+        result = scenario.run(tree)
+        scenario.assert_success(result)
+        scenario.assert_rm_state(report.id_, RM.CLOSED)
+
+    def test_success_adds_to_outbox(
+        self, scenario: BTTestScenario, actor, report, offer
+    ):
+        """SUCCESS: activity is added to the actor's outbox."""
+        before = set(scenario.dl.outbox_list_for_actor(ACTOR_ID))
+        tree = create_reject_report_trigger_tree(
+            offer_id=offer.id_, report_id=report.id_
+        )
+        scenario.run(tree)
+        after = set(scenario.dl.outbox_list_for_actor(ACTOR_ID))
+        assert len(after - before) >= 1
+
+    def test_no_pre_close_guard(
+        self,
+        scenario: BTTestScenario,
+        actor,
+        report,
+        offer,
+        closed_status: ParticipantStatus,
+    ):
+        """Reject does NOT guard against already-closed — hard-close always allowed."""
+        tree = create_reject_report_trigger_tree(
+            offer_id=offer.id_, report_id=report.id_
+        )
+        result = scenario.run(tree)
+        # Should still succeed (idempotent create) — no guard node in this tree
+        assert result.status == Status.SUCCESS
+
+    def test_failure_no_trigger_activity_factory(
+        self, scenario: BTTestScenario, actor, report, offer
+    ):
+        """FAILURE: no TriggerActivityPort on the blackboard → tree fails."""
+        import py_trees
+
+        from vultron.core.behaviors.bridge import BTBridge
+
+        bridge_no_factory = BTBridge(datalayer=scenario.dl)
+        tree = create_reject_report_trigger_tree(
+            offer_id=offer.id_, report_id=report.id_
+        )
+        py_trees.blackboard.Blackboard.storage.clear()
+        result = bridge_no_factory.execute_with_setup(tree, actor_id=ACTOR_ID)
+        assert result.status == Status.FAILURE
+
+
+# ---------------------------------------------------------------------------
+# CloseReportTriggerBT tests
+# ---------------------------------------------------------------------------
+
+
+class TestCloseReportTriggerTree:
+    def test_success_emits_activity_and_sets_rm_closed(
+        self, scenario: BTTestScenario, actor, report, offer
+    ):
+        """SUCCESS: emits activity and persists RM.CLOSED ParticipantStatus."""
+        result_out: dict = {}
+        tree = create_close_report_trigger_tree(
+            offer_id=offer.id_, report_id=report.id_, result_out=result_out
+        )
+        result = scenario.run(tree)
+        scenario.assert_success(result)
+        scenario.assert_rm_state(report.id_, RM.CLOSED)
+        assert "error" not in result_out
+
+    def test_success_adds_to_outbox(
+        self, scenario: BTTestScenario, actor, report, offer
+    ):
+        """SUCCESS: activity is added to the actor's outbox."""
+        before = set(scenario.dl.outbox_list_for_actor(ACTOR_ID))
+        result_out: dict = {}
+        tree = create_close_report_trigger_tree(
+            offer_id=offer.id_, report_id=report.id_, result_out=result_out
+        )
+        scenario.run(tree)
+        after = set(scenario.dl.outbox_list_for_actor(ACTOR_ID))
+        assert len(after - before) >= 1
+
+    def test_failure_already_closed_writes_error(
+        self,
+        scenario: BTTestScenario,
+        actor,
+        report,
+        offer,
+        closed_status: ParticipantStatus,
+    ):
+        """FAILURE: already-closed report writes VultronInvalidStateTransitionError."""
+        result_out: dict = {}
+        tree = create_close_report_trigger_tree(
+            offer_id=offer.id_, report_id=report.id_, result_out=result_out
+        )
+        result = scenario.run(tree)
+        scenario.assert_failure(result)
+        assert "error" in result_out
+        assert isinstance(
+            result_out["error"], VultronInvalidStateTransitionError
+        )
+
+    def test_failure_already_closed_error_message(
+        self,
+        scenario: BTTestScenario,
+        actor,
+        report,
+        offer,
+        closed_status: ParticipantStatus,
+    ):
+        """The error message references the report ID."""
+        result_out: dict = {}
+        tree = create_close_report_trigger_tree(
+            offer_id=offer.id_, report_id=report.id_, result_out=result_out
+        )
+        scenario.run(tree)
+        error = result_out.get("error")
+        assert error is not None
+        assert report.id_ in str(error)
+
+    def test_failure_no_trigger_activity_factory(
+        self, scenario: BTTestScenario, actor, report, offer
+    ):
+        """FAILURE: no TriggerActivityPort on the blackboard → tree fails."""
+        import py_trees
+
+        from vultron.core.behaviors.bridge import BTBridge
+
+        bridge_no_factory = BTBridge(datalayer=scenario.dl)
+        result_out: dict = {}
+        tree = create_close_report_trigger_tree(
+            offer_id=offer.id_, report_id=report.id_, result_out=result_out
+        )
+        py_trees.blackboard.Blackboard.storage.clear()
+        result = bridge_no_factory.execute_with_setup(tree, actor_id=ACTOR_ID)
+        assert result.status == Status.FAILURE

--- a/vultron/core/behaviors/report/nodes/__init__.py
+++ b/vultron/core/behaviors/report/nodes/__init__.py
@@ -36,6 +36,7 @@ from vultron.core.behaviors.report.nodes.case_creation import (
 )
 from vultron.core.behaviors.report.nodes.conditions import (
     CheckParticipantExists,
+    CheckReportNotClosed,
     CheckRMStateReceivedOrInvalid,
     CheckRMStateValid,
     EnsureEmbargoExists,
@@ -44,8 +45,10 @@ from vultron.core.behaviors.report.nodes.conditions import (
     EvaluateReportValidity,
 )
 from vultron.core.behaviors.report.nodes.emit import (
+    EmitCloseReportActivity,
     EmitDeferCaseActivity,
     EmitEngageCaseActivity,
+    EmitInvalidateReportActivity,
 )
 from vultron.core.behaviors.report.nodes.participant import (
     TransitionParticipantRMtoAccepted,
@@ -54,6 +57,7 @@ from vultron.core.behaviors.report.nodes.participant import (
 from vultron.core.behaviors.report.nodes.rm_transitions import (
     TransitionCaseParticipantRMtoClosed,
     TransitionCaseParticipantRMtoInvalid,
+    TransitionRMtoClosed,
     TransitionRMtoInvalid,
     TransitionRMtoValid,
 )
@@ -66,6 +70,7 @@ __all__ = [
     # conditions
     "CheckRMStateValid",
     "CheckRMStateReceivedOrInvalid",
+    "CheckReportNotClosed",
     "EnsureEmbargoExists",
     "EvaluateReportCredibility",
     "EvaluateReportValidity",
@@ -74,6 +79,7 @@ __all__ = [
     # rm_transitions
     "TransitionRMtoValid",
     "TransitionRMtoInvalid",
+    "TransitionRMtoClosed",
     "TransitionCaseParticipantRMtoClosed",
     "TransitionCaseParticipantRMtoInvalid",
     # case_creation
@@ -85,6 +91,8 @@ __all__ = [
     # emit
     "EmitEngageCaseActivity",
     "EmitDeferCaseActivity",
+    "EmitInvalidateReportActivity",
+    "EmitCloseReportActivity",
     # storage
     "StoreReportNode",
     "StoreActivityNode",

--- a/vultron/core/behaviors/report/nodes/conditions.py
+++ b/vultron/core/behaviors/report/nodes/conditions.py
@@ -23,6 +23,7 @@ from vultron.core.behaviors.helpers import (
 )
 from vultron.core.states.rm import RM
 from vultron.core.use_cases._helpers import _report_phase_status_id
+from vultron.errors import VultronInvalidStateTransitionError
 
 
 class CheckRMStateValid(DataLayerCondition):
@@ -321,3 +322,74 @@ class CheckParticipantExists(FindParticipantByActorIdNode):
             participant_key="participant",
             name=name or self.__class__.__name__,
         )
+
+
+class CheckReportNotClosed(DataLayerCondition):
+    """Check that the report does NOT already have an RM.CLOSED status record.
+
+    Returns SUCCESS when the report is not yet closed (the transition is
+    permitted).  Returns FAILURE and writes a
+    :class:`~vultron.errors.VultronInvalidStateTransitionError` into
+    ``result_out["error"]`` when the report is already closed, so the calling
+    use case can re-raise the domain exception.
+
+    Per issue #849 AC-3: the duplicate-close guard must be expressed as a BT
+    condition node, not as a procedural raise in ``execute()``.
+    """
+
+    def __init__(
+        self,
+        report_id: str,
+        result_out: dict,
+        name: str | None = None,
+    ) -> None:
+        """Initialize CheckReportNotClosed.
+
+        Args:
+            report_id: ID of the VulnerabilityReport to check.
+            result_out: Mutable dict; on FAILURE, the
+                ``VultronInvalidStateTransitionError`` is written to
+                ``result_out["error"]`` so the use case can re-raise it.
+            name: Optional custom node name.
+        """
+        super().__init__(name=name or self.__class__.__name__)
+        self.report_id = report_id
+        self._result_out = result_out
+
+    def update(self) -> Status:
+        """Guard against closing an already-closed report.
+
+        Returns:
+            SUCCESS when not yet closed;
+            FAILURE (+ ``result_out["error"]``) when already closed or
+            the DataLayer/actor_id is unavailable.
+        """
+        if self.datalayer is None:
+            self.logger.error("%s: DataLayer not available", self.name)
+            return Status.FAILURE
+        if self.actor_id is None:
+            self.logger.error("%s: actor_id not available", self.name)
+            return Status.FAILURE
+
+        closed_id = _report_phase_status_id(
+            self.actor_id, self.report_id, RM.CLOSED.value
+        )
+        if self.datalayer.read(closed_id) is not None:
+            error = VultronInvalidStateTransitionError(
+                f"Report '{self.report_id}' is already CLOSED."
+            )
+            self._result_out["error"] = error
+            self.feedback_message = str(error)
+            self.logger.warning(
+                "%s: Report '%s' is already CLOSED — transition blocked",
+                self.name,
+                self.report_id,
+            )
+            return Status.FAILURE
+
+        self.logger.debug(
+            "%s: Report '%s' not yet closed — proceeding",
+            self.name,
+            self.report_id,
+        )
+        return Status.SUCCESS

--- a/vultron/core/behaviors/report/nodes/emit.py
+++ b/vultron/core/behaviors/report/nodes/emit.py
@@ -25,6 +25,45 @@ from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.use_cases._helpers import case_addressees
 
 
+def _compute_report_addressees(
+    report_id: str,
+    actor_id: str,
+    offer: object | None,
+    dl: CaseOutboxPersistence,
+) -> list[str] | None:
+    """Compute outbound recipient list for a report-phase trigger activity.
+
+    Tries case participants first; falls back to the offer submitter when no
+    case is found.
+
+    Args:
+        report_id: VulnerabilityReport ID used to locate the linked case.
+        actor_id: Sender's actor ID (excluded from recipient list).
+        offer: The Offer activity object (used for fallback addressing).
+        dl: DataLayer for case lookup.
+
+    Returns:
+        List of recipient URIs, or None when no recipients can be determined.
+    """
+    case = dl.find_case_by_report_id(report_id)
+    if is_case_model(case):
+        recipients = case_addressees(case, actor_id)
+        if recipients:
+            return recipients
+
+    offer_actor = getattr(offer, "actor", None)
+    if offer_actor is None:
+        return None
+    offer_actor_id = (
+        offer_actor
+        if isinstance(offer_actor, str)
+        else getattr(offer_actor, "id_", None)
+    )
+    if offer_actor_id and offer_actor_id != actor_id:
+        return [offer_actor_id]
+    return None
+
+
 class EmitEngageCaseActivity(DataLayerAction):
     """Emit RmEngageCaseActivity (Join(VulnerabilityCase)) to the actor outbox.
 
@@ -175,5 +214,160 @@ class EmitDeferCaseActivity(DataLayerAction):
         except Exception as e:
             self.logger.error(
                 f"{self.name}: Error emitting defer activity: {e}"
+            )
+            return Status.FAILURE
+
+
+class EmitInvalidateReportActivity(DataLayerAction):
+    """Emit RmInvalidateReportActivity (TentativeReject) to the actor outbox.
+
+    Calls ``trigger_activity_factory.invalidate_report()`` and queues the
+    resulting activity ID via ``record_outbox_item``.
+
+    Per issue #849 AC-1, AC-2: emit nodes must be BT leaf nodes, not inline
+    procedural calls in ``execute()``.
+    """
+
+    def __init__(
+        self, offer_id: str, report_id: str, name: str | None = None
+    ) -> None:
+        """Initialize EmitInvalidateReportActivity.
+
+        Args:
+            offer_id: ID of the Offer activity being invalidated.
+            report_id: ID of the VulnerabilityReport (for address resolution).
+            name: Optional custom node name.
+        """
+        super().__init__(name=name or self.__class__.__name__)
+        self.offer_id = offer_id
+        self.report_id = report_id
+
+    def update(self) -> Status:
+        """Create and queue RmInvalidateReportActivity.
+
+        Returns:
+            SUCCESS if activity created and outbox updated, FAILURE on error.
+        """
+        if self.datalayer is None or self.actor_id is None:
+            self.logger.error(
+                "%s: DataLayer or actor_id not available", self.name
+            )
+            return Status.FAILURE
+
+        if self.trigger_activity_factory is None:
+            self.logger.warning(
+                "%s: no TriggerActivityPort — cannot emit InvalidateReport activity",
+                self.name,
+            )
+            return Status.FAILURE
+
+        try:
+            offer = self.datalayer.read(self.offer_id)
+            addressees = _compute_report_addressees(
+                self.report_id,
+                self.actor_id,
+                offer,
+                cast(CaseOutboxPersistence, self.datalayer),
+            )
+
+            activity_id, _ = self.trigger_activity_factory.invalidate_report(
+                offer_id=self.offer_id,
+                actor=self.actor_id,
+                to=addressees,
+            )
+
+            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
+                self.actor_id, activity_id
+            )
+            self.logger.info(
+                "Actor '%s' emitted RmInvalidateReportActivity for offer '%s'",
+                self.actor_id,
+                self.offer_id,
+            )
+            return Status.SUCCESS
+
+        except Exception as e:
+            self.logger.error(
+                "%s: Error emitting invalidate-report activity: %s",
+                self.name,
+                e,
+            )
+            return Status.FAILURE
+
+
+class EmitCloseReportActivity(DataLayerAction):
+    """Emit RmCloseReportActivity (Reject) to the actor outbox.
+
+    Calls ``trigger_activity_factory.close_report()`` and queues the
+    resulting activity ID via ``record_outbox_item``.
+
+    Used by both the reject-report and close-report trigger workflows.
+
+    Per issue #849 AC-1, AC-2: emit nodes must be BT leaf nodes, not inline
+    procedural calls in ``execute()``.
+    """
+
+    def __init__(
+        self, offer_id: str, report_id: str, name: str | None = None
+    ) -> None:
+        """Initialize EmitCloseReportActivity.
+
+        Args:
+            offer_id: ID of the Offer activity being closed/rejected.
+            report_id: ID of the VulnerabilityReport.
+            name: Optional custom node name.
+        """
+        super().__init__(name=name or self.__class__.__name__)
+        self.offer_id = offer_id
+        self.report_id = report_id
+
+    def update(self) -> Status:
+        """Create and queue RmCloseReportActivity.
+
+        Returns:
+            SUCCESS if activity created and outbox updated, FAILURE on error.
+        """
+        if self.datalayer is None or self.actor_id is None:
+            self.logger.error(
+                "%s: DataLayer or actor_id not available", self.name
+            )
+            return Status.FAILURE
+
+        if self.trigger_activity_factory is None:
+            self.logger.warning(
+                "%s: no TriggerActivityPort — cannot emit CloseReport activity",
+                self.name,
+            )
+            return Status.FAILURE
+
+        try:
+            offer = self.datalayer.read(self.offer_id)
+            addressees = _compute_report_addressees(
+                self.report_id,
+                self.actor_id,
+                offer,
+                cast(CaseOutboxPersistence, self.datalayer),
+            )
+
+            activity_id, _ = self.trigger_activity_factory.close_report(
+                offer_id=self.offer_id,
+                report_id=self.report_id,
+                actor=self.actor_id,
+                to=addressees,
+            )
+
+            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
+                self.actor_id, activity_id
+            )
+            self.logger.info(
+                "Actor '%s' emitted RmCloseReportActivity for offer '%s'",
+                self.actor_id,
+                self.offer_id,
+            )
+            return Status.SUCCESS
+
+        except Exception as e:
+            self.logger.error(
+                "%s: Error emitting close-report activity: %s", self.name, e
             )
             return Status.FAILURE

--- a/vultron/core/behaviors/report/nodes/rm_transitions.py
+++ b/vultron/core/behaviors/report/nodes/rm_transitions.py
@@ -239,6 +239,73 @@ class TransitionRMtoInvalid(DataLayerAction):
             return Status.FAILURE
 
 
+class TransitionRMtoClosed(DataLayerAction):
+    """
+    Transition report to RM.CLOSED (report-phase ParticipantStatus).
+
+    Persists a ParticipantStatus record with RM.CLOSED for the actor and
+    report in the DataLayer.
+    Logs state transitions at INFO level.
+
+    Used by both the reject-report and close-report trigger workflows.
+    """
+
+    def __init__(self, report_id: str, offer_id: str, name: str | None = None):
+        """
+        Initialize TransitionRMtoClosed node.
+
+        Args:
+            report_id: ID of VulnerabilityReport to update
+            offer_id: ID of Offer being closed/rejected
+            name: Optional custom node name (defaults to class name)
+        """
+        super().__init__(name=name or self.__class__.__name__)
+        self.report_id = report_id
+        self.offer_id = offer_id
+
+    def update(self) -> Status:
+        """
+        Update report status to CLOSED in DataLayer.
+
+        Returns:
+            SUCCESS if status updated, FAILURE on error
+        """
+        if self.datalayer is None or self.actor_id is None:
+            self.logger.error(
+                "%s: DataLayer or actor_id not available", self.name
+            )
+            return Status.FAILURE
+
+        try:
+            status = ParticipantStatus(
+                id_=_report_phase_status_id(
+                    self.actor_id, self.report_id, RM.CLOSED.value
+                ),
+                context=self.report_id,
+                attributed_to=self.actor_id,
+                rm_state=RM.CLOSED,
+            )
+            _idempotent_create(
+                self.datalayer,
+                "ParticipantStatus",
+                status.id_,
+                status,
+                "ParticipantStatus (report-phase RM.CLOSED)",
+            )
+            self.logger.info(
+                "RM → CLOSED for report '%s' (actor '%s')",
+                self.report_id,
+                self.actor_id,
+            )
+            return Status.SUCCESS
+
+        except Exception as e:
+            self.logger.error(
+                "%s: Error transitioning to CLOSED: %s", self.name, e
+            )
+            return Status.FAILURE
+
+
 class TransitionCaseParticipantRMtoClosed(DataLayerAction):
     """Transition the actor's RM state to CLOSED in the case for a report.
 

--- a/vultron/core/behaviors/report/trigger_report_trees.py
+++ b/vultron/core/behaviors/report/trigger_report_trees.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""
+Behavior tree factories for report-lifecycle trigger use cases.
+
+Each factory produces a ``py_trees.composites.Sequence`` that implements the
+outbound protocol handling for one of the three report-lifecycle trigger
+operations:
+
+- ``InvalidateReport`` — emit TentativeReject activity + transition RM → INVALID
+- ``RejectReport``     — emit CloseReport activity + transition RM → CLOSED
+- ``CloseReport``      — guard (not already closed) + emit CloseReport + RM → CLOSED
+
+Trees are run via ``BTBridge.execute_with_setup()`` in the corresponding
+trigger use case.
+
+Per issue #849 AC-1 through AC-3 and specs/behavior-tree-integration.yaml
+BT-15-001, BT-15-002.
+"""
+
+import logging
+
+import py_trees
+
+from vultron.core.behaviors.report.nodes.conditions import CheckReportNotClosed
+from vultron.core.behaviors.report.nodes.emit import (
+    EmitCloseReportActivity,
+    EmitInvalidateReportActivity,
+)
+from vultron.core.behaviors.report.nodes.rm_transitions import (
+    TransitionRMtoClosed,
+    TransitionRMtoInvalid,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def create_invalidate_report_trigger_tree(
+    offer_id: str,
+    report_id: str,
+) -> py_trees.behaviour.Behaviour:
+    """Create the BT for the invalidate-report trigger workflow.
+
+    Emits ``RmInvalidateReportActivity`` (TentativeReject) and records the
+    actor's RM state as INVALID for the report.
+
+    Structure::
+
+        InvalidateReportTriggerBT (Sequence)
+        ├─ EmitInvalidateReportActivity  # emit activity + queue in outbox
+        └─ TransitionRMtoInvalid         # persist report-phase RM.INVALID
+
+    Args:
+        offer_id: ID of the Offer being invalidated.
+        report_id: ID of the VulnerabilityReport.
+
+    Returns:
+        Root node of the ``InvalidateReportTriggerBT`` Sequence.
+    """
+    root = py_trees.composites.Sequence(
+        name="InvalidateReportTriggerBT",
+        memory=False,
+        children=[
+            EmitInvalidateReportActivity(
+                offer_id=offer_id,
+                report_id=report_id,
+            ),
+            TransitionRMtoInvalid(
+                report_id=report_id,
+                offer_id=offer_id,
+            ),
+        ],
+    )
+    logger.debug(
+        "Created InvalidateReportTriggerBT for offer=%s report=%s",
+        offer_id,
+        report_id,
+    )
+    return root
+
+
+def create_reject_report_trigger_tree(
+    offer_id: str,
+    report_id: str,
+) -> py_trees.behaviour.Behaviour:
+    """Create the BT for the reject-report trigger workflow.
+
+    Emits ``RmCloseReportActivity`` (hard-close/Reject) and records the
+    actor's RM state as CLOSED for the report.  Unlike the close-report
+    workflow, this path does NOT check for a prior CLOSED state — callers
+    can hard-reject an offer regardless of its current status.
+
+    Structure::
+
+        RejectReportTriggerBT (Sequence)
+        ├─ EmitCloseReportActivity  # emit activity + queue in outbox
+        └─ TransitionRMtoClosed     # persist report-phase RM.CLOSED
+
+    Args:
+        offer_id: ID of the Offer being rejected.
+        report_id: ID of the VulnerabilityReport.
+
+    Returns:
+        Root node of the ``RejectReportTriggerBT`` Sequence.
+    """
+    root = py_trees.composites.Sequence(
+        name="RejectReportTriggerBT",
+        memory=False,
+        children=[
+            EmitCloseReportActivity(
+                offer_id=offer_id,
+                report_id=report_id,
+            ),
+            TransitionRMtoClosed(
+                report_id=report_id,
+                offer_id=offer_id,
+            ),
+        ],
+    )
+    logger.debug(
+        "Created RejectReportTriggerBT for offer=%s report=%s",
+        offer_id,
+        report_id,
+    )
+    return root
+
+
+def create_close_report_trigger_tree(
+    offer_id: str,
+    report_id: str,
+    result_out: dict,
+) -> py_trees.behaviour.Behaviour:
+    """Create the BT for the close-report trigger workflow.
+
+    Guards against duplicate-close, emits ``RmCloseReportActivity``, and
+    records the actor's RM state as CLOSED.  On a duplicate-close attempt
+    ``CheckReportNotClosed`` writes a
+    :class:`~vultron.errors.VultronInvalidStateTransitionError` into
+    ``result_out["error"]`` so the calling use case can re-raise the domain
+    exception.
+
+    Structure::
+
+        CloseReportTriggerBT (Sequence)
+        ├─ CheckReportNotClosed     # guard: FAILURE + error if already CLOSED
+        ├─ EmitCloseReportActivity  # emit activity + queue in outbox
+        └─ TransitionRMtoClosed     # persist report-phase RM.CLOSED
+
+    Per issue #849 AC-3: the duplicate-close guard is a BT condition node, not
+    a procedural ``raise`` in ``execute()``.
+
+    Args:
+        offer_id: ID of the Offer being closed.
+        report_id: ID of the VulnerabilityReport.
+        result_out: Mutable dict for surfacing domain errors back to the caller.
+            ``result_out["error"]`` is set to a
+            ``VultronInvalidStateTransitionError`` when the report is already
+            closed.
+
+    Returns:
+        Root node of the ``CloseReportTriggerBT`` Sequence.
+    """
+    root = py_trees.composites.Sequence(
+        name="CloseReportTriggerBT",
+        memory=False,
+        children=[
+            CheckReportNotClosed(
+                report_id=report_id,
+                result_out=result_out,
+            ),
+            EmitCloseReportActivity(
+                offer_id=offer_id,
+                report_id=report_id,
+            ),
+            TransitionRMtoClosed(
+                report_id=report_id,
+                offer_id=offer_id,
+            ),
+        ],
+    )
+    logger.debug(
+        "Created CloseReportTriggerBT for offer=%s report=%s",
+        offer_id,
+        report_id,
+    )
+    return root

--- a/vultron/core/use_cases/triggers/report.py
+++ b/vultron/core/use_cases/triggers/report.py
@@ -27,21 +27,21 @@ No HTTP framework imports (FastAPI, Starlette) are permitted here.
 import logging
 from typing import TYPE_CHECKING, Any
 
-from vultron.core.states.rm import RM
+from py_trees.common import Status
+
 from vultron.core.behaviors.bridge import BTBridge
+from vultron.core.behaviors.report.trigger_report_trees import (
+    create_close_report_trigger_tree,
+    create_invalidate_report_trigger_tree,
+    create_reject_report_trigger_tree,
+)
 from vultron.core.behaviors.report.validate_tree import (
     create_validate_report_tree,
 )
-from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models.report_case_link import VultronReportCaseLink
 from vultron.core.models.report import VultronReport
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
-from vultron.core.use_cases._helpers import (
-    _idempotent_create,
-    _report_phase_status_id,
-)
 from vultron.core.models.protocols import is_case_model
-from vultron.core.use_cases._helpers import case_addressees
 from vultron.core.use_cases.triggers._helpers import (
     add_activity_to_outbox,
     outbox_ids,
@@ -55,7 +55,6 @@ from vultron.core.use_cases.triggers.requests import (
     ValidateReportTriggerRequest,
 )
 from vultron.errors import (
-    VultronInvalidStateTransitionError,
     VultronNotFoundError,
     VultronValidationError,
 )
@@ -91,35 +90,6 @@ def _resolve_offer_and_report(
             f" '{getattr(report, 'type_', 'None' if report is None else 'unknown')}'."
         )
     return offer, report
-
-
-def _report_addressees(
-    report_id: str, actor_id: str, offer: Any, dl: CaseOutboxPersistence
-) -> list[str] | None:
-    """Return the ``to`` recipient list for a report-phase outbound activity.
-
-    Looks up the case linked to *report_id* via ``find_case_by_report_id``.
-    If a case is found, returns all case participants except *actor_id*.
-    Falls back to the offer submitter when no case exists yet.
-
-    Returns ``None`` when no addressees can be determined.
-    """
-    case = dl.find_case_by_report_id(report_id)
-    if case is not None and is_case_model(case):
-        recipients = case_addressees(case, actor_id)
-        if recipients:
-            return recipients
-    offer_actor = getattr(offer, "actor", None)
-    if offer_actor is None:
-        return None
-    offer_actor_id = (
-        offer_actor
-        if isinstance(offer_actor, str)
-        else getattr(offer_actor, "id_", None)
-    )
-    if offer_actor_id and offer_actor_id != actor_id:
-        return [offer_actor_id]
-    return None
 
 
 class SvcValidateReportUseCase:
@@ -209,29 +179,31 @@ class SvcInvalidateReportUseCase:
                 "SvcInvalidateReportUseCase requires a TriggerActivityPort"
             )
 
-        activity_id, activity_dict = self._trigger_activity.invalidate_report(
+        before = outbox_ids(actor_id, dl)
+
+        bridge = BTBridge(
+            datalayer=dl, trigger_activity=self._trigger_activity
+        )
+        tree = create_invalidate_report_trigger_tree(
             offer_id=offer.id_,
-            actor=actor_id,
-            to=_report_addressees(report.id_, actor_id, offer, dl),
+            report_id=report.id_,
         )
+        result = bridge.execute_with_setup(tree, actor_id=actor_id)
+        if result.status != Status.SUCCESS:
+            raise VultronValidationError(
+                f"InvalidateReport failed: {BTBridge.get_failure_reason(tree)}"
+            )
 
-        set_status_invalidate = ParticipantStatus(
-            id_=_report_phase_status_id(
-                actor_id, report.id_, RM.INVALID.value
-            ),
-            context=report.id_,
-            attributed_to=actor_id,
-            rm_state=RM.INVALID,
-        )
-        _idempotent_create(
-            dl,
-            "ParticipantStatus",
-            set_status_invalidate.id_,
-            set_status_invalidate,
-            "ParticipantStatus (report-phase RM.INVALID)",
-        )
-
-        add_activity_to_outbox(actor_id, activity_id, dl)
+        activity = None
+        after = outbox_ids(actor_id, dl)
+        new_items = after - before
+        if new_items:
+            activity_id = next(iter(new_items))
+            activity_obj = dl.read(activity_id)
+            if activity_obj is not None:
+                activity = activity_obj.model_dump(
+                    by_alias=True, exclude_none=True
+                )
 
         logger.info(
             "Actor '%s' invalidated offer '%s' (report '%s')",
@@ -240,7 +212,7 @@ class SvcInvalidateReportUseCase:
             report.id_,
         )
 
-        return {"activity": activity_dict}
+        return {"activity": activity}
 
 
 class SvcRejectReportUseCase:
@@ -273,28 +245,31 @@ class SvcRejectReportUseCase:
                 "SvcRejectReportUseCase requires a TriggerActivityPort"
             )
 
-        activity_id, activity_dict = self._trigger_activity.close_report(
+        before = outbox_ids(actor_id, dl)
+
+        bridge = BTBridge(
+            datalayer=dl, trigger_activity=self._trigger_activity
+        )
+        tree = create_reject_report_trigger_tree(
             offer_id=offer.id_,
             report_id=report.id_,
-            actor=actor_id,
-            to=_report_addressees(report.id_, actor_id, offer, dl),
         )
+        result = bridge.execute_with_setup(tree, actor_id=actor_id)
+        if result.status != Status.SUCCESS:
+            raise VultronValidationError(
+                f"RejectReport failed: {BTBridge.get_failure_reason(tree)}"
+            )
 
-        set_status_reject = ParticipantStatus(
-            id_=_report_phase_status_id(actor_id, report.id_, RM.CLOSED.value),
-            context=report.id_,
-            attributed_to=actor_id,
-            rm_state=RM.CLOSED,
-        )
-        _idempotent_create(
-            dl,
-            "ParticipantStatus",
-            set_status_reject.id_,
-            set_status_reject,
-            "ParticipantStatus (report-phase RM.CLOSED)",
-        )
-
-        add_activity_to_outbox(actor_id, activity_id, dl)
+        activity = None
+        after = outbox_ids(actor_id, dl)
+        new_items = after - before
+        if new_items:
+            activity_id = next(iter(new_items))
+            activity_obj = dl.read(activity_id)
+            if activity_obj is not None:
+                activity = activity_obj.model_dump(
+                    by_alias=True, exclude_none=True
+                )
 
         logger.info(
             "Actor '%s' hard-closed offer '%s' (report '%s'); note: %s",
@@ -304,7 +279,7 @@ class SvcRejectReportUseCase:
             note,
         )
 
-        return {"activity": activity_dict}
+        return {"activity": activity}
 
 
 class SvcCloseReportUseCase:
@@ -332,48 +307,41 @@ class SvcCloseReportUseCase:
 
         offer, report = _resolve_offer_and_report(offer_id, dl)
 
-        closed_id = _report_phase_status_id(
-            actor_id, report.id_, RM.CLOSED.value
-        )
-        if dl.read(closed_id) is not None:
-            logger.warning(
-                "Invalid RM state transition: actor '%s' cannot CLOSE offer"
-                " '%s' — report '%s' is already CLOSED.",
-                actor_id,
-                offer.id_,
-                report.id_,
-            )
-            raise VultronInvalidStateTransitionError(
-                f"Report '{report.id_}' is already CLOSED."
-            )
-
         if self._trigger_activity is None:
             raise RuntimeError(
                 "SvcCloseReportUseCase requires a TriggerActivityPort"
             )
 
-        activity_id, activity_dict = self._trigger_activity.close_report(
+        before = outbox_ids(actor_id, dl)
+        result_out: dict[str, object] = {}
+
+        bridge = BTBridge(
+            datalayer=dl, trigger_activity=self._trigger_activity
+        )
+        tree = create_close_report_trigger_tree(
             offer_id=offer.id_,
             report_id=report.id_,
-            actor=actor_id,
-            to=_report_addressees(report.id_, actor_id, offer, dl),
+            result_out=result_out,
         )
+        result = bridge.execute_with_setup(tree, actor_id=actor_id)
+        if result.status != Status.SUCCESS:
+            error = result_out.get("error")
+            if isinstance(error, Exception):
+                raise error
+            raise VultronValidationError(
+                f"CloseReport failed: {BTBridge.get_failure_reason(tree)}"
+            )
 
-        set_status_close = ParticipantStatus(
-            id_=closed_id,
-            context=report.id_,
-            attributed_to=actor_id,
-            rm_state=RM.CLOSED,
-        )
-        _idempotent_create(
-            dl,
-            "ParticipantStatus",
-            set_status_close.id_,
-            set_status_close,
-            "ParticipantStatus (report-phase RM.CLOSED)",
-        )
-
-        add_activity_to_outbox(actor_id, activity_id, dl)
+        activity = None
+        after = outbox_ids(actor_id, dl)
+        new_items = after - before
+        if new_items:
+            activity_id = next(iter(new_items))
+            activity_obj = dl.read(activity_id)
+            if activity_obj is not None:
+                activity = activity_obj.model_dump(
+                    by_alias=True, exclude_none=True
+                )
 
         logger.info(
             "Actor '%s' closed offer '%s' (report '%s') via RM lifecycle;"
@@ -384,7 +352,7 @@ class SvcCloseReportUseCase:
             note,
         )
 
-        return {"activity": activity_dict}
+        return {"activity": activity}
 
 
 class SvcSubmitReportUseCase:


### PR DESCRIPTION
- Closes #849

## Summary

Migrates three report-lifecycle trigger use cases to `BTBridge.execute_with_setup()`, replacing inline `ParticipantStatus` creation and procedural state transitions with proper BT leaf nodes. Satisfies BT-15-001 and BT-15-002.

## Changes

**New BT nodes** (`vultron/core/behaviors/report/nodes/`):
- `TransitionRMtoClosed` — persists report-phase `ParticipantStatus(rm_state=RM.CLOSED)`
- `CheckReportNotClosed` — duplicate-close guard; writes `VultronInvalidStateTransitionError` into `result_out["error"]` on FAILURE
- `EmitInvalidateReportActivity` — creates and queues `TentativeReject(Offer)` activity
- `EmitCloseReportActivity` — creates and queues `Reject(Offer)` activity (shared by reject/close paths)

**New BT factories** (`vultron/core/behaviors/report/trigger_report_trees.py`):
- `create_invalidate_report_trigger_tree` — Emit → TransitionRMtoInvalid
- `create_reject_report_trigger_tree` — Emit → TransitionRMtoClosed (no duplicate guard)
- `create_close_report_trigger_tree` — CheckNotClosed → Emit → TransitionRMtoClosed

**Refactored use cases** (`vultron/core/use_cases/triggers/report.py`):
- All three use cases now delegate via BTBridge
- Status check uses `result.status != Status.SUCCESS` (enum comparison, not fragile string)
- Removed `_report_addressees()` module helper; address resolution moved to `emit.py`

**New tests** (`test/core/behaviors/report/test_trigger_report_trees.py`):
- 13 tests covering SUCCESS and FAILURE paths for each tree factory

## Verification

3113 passed, 12 skipped, 219 deselected, 5633 subtests passed in 34.40s