### PR TITLE
docs: plan issue #427 — demo/fuzzer py_trees simulation node layout

### DIFF
--- a/notes/bt-integration.md
+++ b/notes/bt-integration.md
@@ -295,6 +295,42 @@ be needed or additional implementation work may be required to handle the
 real-world logic that these nodes represent. See `bt-fuzzer-nodes.md`
 for more discussion on this topic.
 
+### py_trees Fuzzer Node Home: `vultron/demo/fuzzer/`
+
+When re-implementing the `vultron/bt/` fuzzer nodes using `py_trees`,
+the correct target location is **`vultron/demo/fuzzer/`** — NOT
+`vultron/core/behaviors/`.
+
+**Why demo, not core?** Fuzzer nodes are simulation/demo stubs standing
+in for real external-dependency touchpoints (system integrations, human
+decisions, environmental checks). They are not production protocol
+behaviors and MUST NOT pollute `vultron/core/behaviors/`.
+
+**Module layout** (see BT-16-004):
+
+| Module | Source | Nodes |
+|---|---|---|
+| `vultron/demo/fuzzer/base.py` | `vultron/bt/base/fuzzer.py` | Probabilistic base types |
+| `vultron/demo/fuzzer/embargo.py` | `vultron/bt/embargo_management/fuzzer.py` | ~15 embargo nodes |
+| `vultron/demo/fuzzer/messaging.py` | `vultron/bt/messaging/inbound/_behaviors/fuzzer.py` | ~1 messaging node |
+| `vultron/demo/fuzzer/report_management/` | `vultron/bt/report_management/fuzzer/` | ~70 nodes in submodules |
+
+**Note**: `vultron/bt/vul_discovery/fuzzer.py` is intentionally excluded —
+the `DiscoverVulnerabilityBt` tree operates upstream of real Vultron
+(which starts at `Offer(VulnerabilityReport)`). There is no corresponding
+real workflow in `vultron/core/` to target.
+
+Each fuzzer node MUST include a docstring identifying:
+
+1. Its semantic function in the CVD process
+2. The category of external input it simulates:
+   - **System integration** — automatable via API calls, metadata queries,
+     or policy-rule evaluation
+   - **Human decision** — requires analyst judgment or policy oversight
+   - **Environmental check** — real-world state observable automatically
+3. Its approximate success probability (maps to `WeightedBehavior` subclass)
+4. Its automation potential (High / Medium / Low / N/A) per BT-16-005
+
 **Source of truth priority** when conflicts arise:
 
 1. **Primary**: `docs/howto/activitypub/activities/*.md` — process

--- a/plan/history/2606/idea/IDEA-427.md
+++ b/plan/history/2606/idea/IDEA-427.md
@@ -1,0 +1,45 @@
+---
+source: IDEA-427
+timestamp: '2026-06-10T14:14:09.356271+00:00'
+title: 'FUZZ: Re-implement fuzzer nodes as py_trees simulation stubs'
+type: idea
+---
+
+## Summary
+
+Re-implement the fuzzer/placeholder BT nodes from the original `vultron/bt/`
+simulator as `py_trees`-based probabilistic simulation stubs in
+`vultron/demo/fuzzer/`. These nodes are **external-dependency touchpoints**:
+named integration points where production logic (system integrations, human
+decisions, environmental checks) will eventually replace probabilistic stubs.
+
+`vultron/bt/vul_discovery/fuzzer.py` is intentionally excluded — the
+`DiscoverVulnerabilityBt` tree operates upstream of real Vultron (which
+starts at `Offer(VulnerabilityReport)`).
+
+## Module Layout
+
+| Target module | Source | Nodes |
+|---|---|---|
+| `vultron/demo/fuzzer/base.py` | `vultron/bt/base/fuzzer.py` | Probabilistic base types |
+| `vultron/demo/fuzzer/embargo.py` | `vultron/bt/embargo_management/fuzzer.py` | ~15 embargo nodes |
+| `vultron/demo/fuzzer/messaging.py` | `vultron/bt/messaging/inbound/_behaviors/fuzzer.py` | ~1 messaging node |
+| `vultron/demo/fuzzer/report_management/` | `vultron/bt/report_management/fuzzer/` | ~70 nodes in submodules |
+
+## Implementation Issues
+
+- #860 FUZZ-01: Base probabilistic infrastructure (blocks all others)
+- #861 FUZZ-02: Embargo management nodes
+- #862 FUZZ-03: Report validate + prioritize + messaging inbound
+- #863 FUZZ-04: VUL ID + fix develop + close + other-work
+- #864 FUZZ-05: Fix deploy + monitor threats + acquire exploit
+- #865 FUZZ-06: Publication workflow
+- #866 FUZZ-07: Report-to-others workflow
+- #867 FUZZ-08 (type:Idea): Wire into demo scenarios (deferred)
+
+**Processed**: 2026-06-10 — Epic #427 updated; implementation tracked in
+issues #860, #861, #862, #863, #864, #865, #866. Demo wiring deferred to
+issue #867 (type:Idea, blocked by all impl issues).
+Docs PR: <https://github.com/CERTCC/Vultron/pull/859>.
+Spec: `specs/behavior-tree-integration.yaml` BT-16-001–BT-16-005.
+Notes: `notes/bt-integration.md` § *py_trees Fuzzer Node Home*.

--- a/specs/behavior-tree-integration.yaml
+++ b/specs/behavior-tree-integration.yaml
@@ -332,3 +332,73 @@ groups:
     relationships:
     - rel_type: refines
       spec_id: BT-06-006
+- id: BT-16
+  title: Simulation Fuzzer Node Layout
+  kind: pattern
+  specs:
+  - id: BT-16-001
+    priority: MUST
+    statement: >-
+      Probabilistic simulation (fuzzer) BT nodes MUST reside in
+      `vultron/demo/fuzzer/` and MUST NOT be placed in
+      `vultron/core/behaviors/` or `vultron/bt/`.
+    rationale: >-
+      Demo/simulation nodes are external-dependency touchpoints, not
+      production protocol behaviors. Keeping them in `vultron/demo/fuzzer/`
+      makes the simulation/production boundary explicit and prevents
+      simulation artifacts from leaking into core protocol logic.
+  - id: BT-16-002
+    priority: MUST
+    statement: >-
+      The probabilistic base types (WeightedBehavior subclasses) for
+      simulation nodes MUST be defined in `vultron/demo/fuzzer/base.py`
+      using the `py_trees.behaviour.Behaviour` base class.
+    rationale: >-
+      All py_trees-based BT execution uses the standard py_trees library
+      (ADR-0008). Centralizing probabilistic base types in one module
+      provides a single implementation point for all weighted-probability
+      simulation nodes and avoids duplication across domain modules.
+    relationships:
+    - rel_type: implements
+      spec_id: BT-02-001
+      note: py_trees.behaviour.Behaviour is the required base for all prototype BT nodes
+  - id: BT-16-003
+    priority: MUST
+    statement: >-
+      Each simulation fuzzer node MUST be named after the external-dependency
+      touchpoint it represents (e.g., `EvaluateEmbargoProposal`, `DeployFix`)
+      and MUST include a docstring describing its semantic function in the CVD
+      process, the category of external input it simulates (system
+      integration, human decision, or environmental check), and its
+      approximate success probability.
+    rationale: >-
+      Fuzzer nodes are named integration points where production logic will
+      eventually replace the probabilistic stub. Explicit naming and
+      documentation preserves the connection between simulation behavior and
+      future implementation targets.
+  - id: BT-16-004
+    priority: MUST
+    statement: >-
+      Simulation fuzzer modules MUST be organized by CVD domain:
+      `vultron/demo/fuzzer/base.py` (probabilistic infrastructure),
+      `vultron/demo/fuzzer/embargo.py` (embargo management),
+      `vultron/demo/fuzzer/messaging.py` (inbound message handling), and
+      `vultron/demo/fuzzer/report_management/` (report lifecycle sub-workflows
+      as parallel submodules).
+    rationale: >-
+      Domain-aligned module organization mirrors the workflow structure of the
+      existing `vultron/bt/` simulation and makes cross-references between
+      simulation stubs and production use cases straightforward for future
+      implementers.
+  - id: BT-16-005
+    priority: SHOULD
+    statement: >-
+      Each simulation fuzzer node SHOULD be categorized in its docstring by
+      automation potential: High (fully automatable via API or policy rule),
+      Medium (partially automatable with human oversight required), Low
+      (inherently human-driven; automation limited to notifications or task
+      triggers), or N/A (terminal placeholder with no real decision logic).
+    rationale: >-
+      Automation-potential categorization guides future implementers toward the
+      correct integration pattern when replacing stubs with production logic,
+      supporting the future real-integration roadmap.


### PR DESCRIPTION
- Supports #427

## Summary

Plans issue #427 by establishing the spec and design-note conventions for
where and how the `vultron/bt/` fuzzer nodes should be re-implemented as
`py_trees`-based simulation stubs in `vultron/demo/fuzzer/`.

## Changes

- **`specs/behavior-tree-integration.yaml`**: Add BT-16 group (BT-16-001
  through BT-16-005) defining module placement rules, py_trees base-class
  requirements, node naming/docstring requirements, domain module layout,
  and automation-potential categorization guidance.
- **`notes/bt-integration.md`**: Add subsection documenting the
  `vultron/demo/fuzzer/` module layout, rationale for excluding
  `vul_discovery` nodes, and per-node docstring requirements for
  semantic function, input category, probability, and automation potential.