### PR TITLE
Remove stale ReplicationState(BaseModel) from case_log.py

### DIFF
--- a/plan/history/2606/implementation/ISSUE-807.md
+++ b/plan/history/2606/implementation/ISSUE-807.md
@@ -1,0 +1,29 @@
+---
+source: ISSUE-807
+timestamp: '2026-06-10T14:45:04.557114+00:00'
+title: Remove stale ReplicationState from case_log.py
+type: implementation
+---
+
+## Issue #807 — Remove stale ReplicationState(BaseModel) from case_log.py
+
+Removed the stale `ReplicationState(BaseModel)` class from
+`vultron/core/models/case_log.py`. The class was superseded by
+`VultronReplicationState(VultronObject)` in
+`vultron/core/models/replication_state.py`, which has a stable
+auto-computed `id_` and is properly in the shared-base hierarchy
+(ARCH-12-007, source issue #804).
+
+Changes:
+
+- Removed `ReplicationState` class from `case_log.py`; updated module
+  docstring to reference `VultronReplicationState` instead
+- Fixed stale `CaseLogEntry` reference in a `ValueError` message (class
+  was renamed to `HashChainLogRecord` in #806)
+- Updated `test/core/models/test_case_log.py` to import and test
+  `VultronReplicationState` (with required `case_id` + `peer_id` fields
+  and `by_alias=True` in the round-trip test)
+
+All 3124 unit tests pass; Black, flake8, mypy, pyright all clean.
+
+PR: <https://github.com/CERTCC/Vultron/pull/869>

--- a/test/core/models/test_case_log.py
+++ b/test/core/models/test_case_log.py
@@ -12,7 +12,7 @@
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-"""Unit tests for CaseLogEntry, CaseEventLog, ReplicationState, and BTBridge
+"""Unit tests for CaseLogEntry, CaseEventLog, and BTBridge
 leadership guard.
 
 Covers:
@@ -23,7 +23,7 @@ Covers:
   ``tail_hash``, ``recorded_entries`` projection, and ``verify_chain``
   (SYNC-01-001, SYNC-01-002, SYNC-01-003, SYNC-07-001,
   CLP-04-001, CLP-04-003).
-- ``ReplicationState`` construction and DataLayer serialisation
+- ``VultronReplicationState`` construction and DataLayer serialisation
   (SYNC-04-001, SYNC-04-002).
 - ``BTBridge`` leadership guard port — default always-True behaviour and
   non-leader short-circuit (SYNC-09-003).
@@ -41,10 +41,10 @@ from vultron.core.models.case_log import (
     GENESIS_HASH,
     CaseEventLog,
     HashChainLogRecord,
-    ReplicationState,
     _canonical_bytes,
     _sha256_hex,
 )
+from vultron.core.models.replication_state import VultronReplicationState
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -469,36 +469,45 @@ class TestCaseEventLogVerifyChain:
 
 
 # ---------------------------------------------------------------------------
-# ReplicationState
+# VultronReplicationState
 # ---------------------------------------------------------------------------
+
+CASE_URI = "urn:uuid:case-abcd"
 
 
 class TestReplicationState:
     def test_construction_with_peer_id(self):
         peer = "https://example.org/vendor"
-        state = ReplicationState(peer_id=peer)
+        state = VultronReplicationState(case_id=CASE_URI, peer_id=peer)
         assert state.peer_id == peer
 
     def test_default_last_acknowledged_hash_is_genesis(self):
-        state = ReplicationState(peer_id="https://example.org/finder")
+        state = VultronReplicationState(
+            case_id=CASE_URI, peer_id="https://example.org/finder"
+        )
         assert state.last_acknowledged_hash == GENESIS_HASH
 
     def test_custom_last_acknowledged_hash(self):
         digest = "a" * 64
-        state = ReplicationState(
+        state = VultronReplicationState(
+            case_id=CASE_URI,
             peer_id="https://example.org/finder",
             last_acknowledged_hash=digest,
         )
         assert state.last_acknowledged_hash == digest
 
     def test_updated_at_is_set(self):
-        state = ReplicationState(peer_id="https://example.org/finder")
+        state = VultronReplicationState(
+            case_id=CASE_URI, peer_id="https://example.org/finder"
+        )
         assert state.updated_at is not None
 
     def test_pydantic_serialisation_round_trip(self):
-        state = ReplicationState(peer_id="https://example.org/finder")
-        dumped = state.model_dump()
-        restored = ReplicationState.model_validate(dumped)
+        state = VultronReplicationState(
+            case_id=CASE_URI, peer_id="https://example.org/finder"
+        )
+        dumped = state.model_dump(by_alias=True)
+        restored = VultronReplicationState.model_validate(dumped)
         assert restored.peer_id == state.peer_id
         assert restored.last_acknowledged_hash == state.last_acknowledged_hash
 

--- a/vultron/core/models/case_log.py
+++ b/vultron/core/models/case_log.py
@@ -19,8 +19,10 @@ This module provides:
 - :class:`HashChainLogRecord` — a single canonical log entry with hash-chain
   linkage and an optional embedded activity payload snapshot.
 - :class:`CaseEventLog` — an append-only, hash-chained log for a single case.
-- :class:`ReplicationState` — per-peer last-acknowledged log hash for
-  replication state tracking.
+
+Per-peer replication state tracking is provided by
+:class:`~vultron.core.models.replication_state.VultronReplicationState`
+in ``vultron.core.models.replication_state``.
 
 Design follows the single-writer CaseActor architecture described in
 ``notes/sync-log-replication.md`` and the requirements in
@@ -378,7 +380,7 @@ class CaseEventLog:
         """
         if disposition == "rejected" and reason_code is None:
             raise ValueError(
-                "reason_code is required for rejected CaseLogEntry objects"
+                "reason_code is required for rejected HashChainLogRecord objects"
             )
 
         entry = HashChainLogRecord(
@@ -420,40 +422,3 @@ class CaseEventLog:
                     return False
                 prev_recorded_hash = entry.entry_hash
         return True
-
-
-# ---------------------------------------------------------------------------
-# ReplicationState
-# ---------------------------------------------------------------------------
-
-
-class ReplicationState(BaseModel):
-    """Per-peer replication state tracked by the replication leader.
-
-    Stores the last log entry hash acknowledged by a participant peer, so
-    the leader can efficiently identify and replay missing entries on demand.
-
-    Fields:
-        peer_id: Full URI of the participant actor this state belongs to.
-        last_acknowledged_hash: ``entry_hash`` of the last
-            :class:`CaseLogEntry` the peer has confirmed receiving.
-            Initialised to :data:`GENESIS_HASH` for new peers that have
-            never received a replication message.
-        updated_at: Server-generated TZ-aware UTC timestamp of the last
-            acknowledgement.
-
-    Spec: SYNC-04-001, SYNC-04-002.
-    """
-
-    peer_id: str = Field(..., description="Full URI of the participant actor")
-    last_acknowledged_hash: str = Field(
-        default=GENESIS_HASH,
-        description=(
-            "entry_hash of the last CaseLogEntry acknowledged by this peer; "
-            "GENESIS_HASH for peers that have never received a replication message"
-        ),
-    )
-    updated_at: datetime = Field(
-        default_factory=_now_utc,
-        description="Timestamp of the last acknowledgement from this peer",
-    )


### PR DESCRIPTION
- Closes #807

## Summary

Removes the stale `ReplicationState(BaseModel)` class from `vultron/core/models/case_log.py`, which was superseded by `VultronReplicationState(VultronObject)` in `vultron/core/models/replication_state.py`. The replacement has a stable auto-computed `id_` and is properly in the shared-base hierarchy (ARCH-12-007).

## Changes

- `vultron/core/models/case_log.py`: Remove `ReplicationState` class; update module docstring; fix stale `CaseLogEntry` reference in `ValueError` message (class was renamed to `HashChainLogRecord` in #806)
- `test/core/models/test_case_log.py`: Remove import of stale `ReplicationState`; add import of `VultronReplicationState`; update `TestReplicationState` class to construct with required `case_id` + `peer_id` fields and use `by_alias=True` in the serialization round-trip test

## Verification

- AC-1 ✅ Confirmed no production callers of `ReplicationState` from `case_log.py`
- AC-2 ✅ `ReplicationState` class removed
- AC-3 ✅ Tests updated to use `VultronReplicationState`
- AC-4 ✅ 3124 unit tests pass (Black, flake8, mypy, pyright all clean)