### PR TITLE
Decompose SYNC replay, fan-out, and hash-check BT nodes

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -166,3 +166,10 @@ header.
 - Leaf nodes that require blackboard context should convert missing-key reads
   into explicit node `FAILURE` with a clear error message, not bridge-level
   exception failures.
+
+### 2026-06-10 ISSUE-755 — SYNC god-node decomposition works best as context handoff leaves
+
+- For replay/fan-out flows, split nodes around blackboard context boundaries:
+  collect context, derive index/recipients, then perform side effects.
+- Condition+action hybrid nodes are clearer and safer as `Selector` composites:
+  a pure condition leaf first, then side-effect action fallback.

--- a/plan/history/2606/implementation/ISSUE-755.md
+++ b/plan/history/2606/implementation/ISSUE-755.md
@@ -1,0 +1,18 @@
+---
+source: ISSUE-755
+timestamp: '2026-06-10T16:18:25.093604+00:00'
+title: SYNC BT god-node decomposition for replay/fan-out/hash-check
+type: implementation
+---
+
+## Issue #755 — God node decomposition: split ReplayMissingEntriesNode, FanOutLogEntryNode, and CheckHashOrRejectOnMismatchNode
+
+Decomposed three SYNC behavior nodes into explicit composite trees with named leaf nodes:
+
+- `ReplayMissingEntriesNode` now delegates to collect/sort, divergence-find, and send leaves.
+- `FanOutLogEntryNode` now delegates to recipient-collection and send leaves.
+- `CheckHashOrRejectOnMismatchNode` now delegates to a pure hash-check condition and a reject action leaf.
+
+Added node-level tests covering composite structure, blackboard wiring, send behavior, and selector short-circuit behavior.
+
+PR: <https://github.com/CERTCC/Vultron/pull/871>

--- a/test/core/behaviors/sync/nodes/test_receive.py
+++ b/test/core/behaviors/sync/nodes/test_receive.py
@@ -10,9 +10,54 @@ from test.core.behaviors.sync.nodes.conftest import (
     _make_entry,
     _make_event,
 )
-from vultron.core.behaviors.sync.nodes import CheckHashOrRejectOnMismatchNode
+from vultron.core.behaviors.sync.nodes import (
+    CheckHashMatchesNode,
+    CheckHashOrRejectOnMismatchNode,
+    SendRejectLogEntryNode,
+)
 from vultron.core.models.case_log import GENESIS_HASH
 from vultron.core.ports.sync_activity import SyncActivityPort
+
+
+def test_check_hash_or_reject_on_mismatch_is_selector_with_condition_and_action():
+    tree = CheckHashOrRejectOnMismatchNode(name="CheckHashOrRejectOnMismatch")
+    assert tree.name == "CheckHashOrRejectOnMismatch"
+    assert len(tree.children) == 2
+    assert isinstance(tree.children[0], CheckHashMatchesNode)
+    assert isinstance(tree.children[1], SendRejectLogEntryNode)
+
+
+def test_check_hash_matches_node_succeeds_when_hash_matches(
+    bridge, case_actor
+):
+    entry = _make_entry(0, GENESIS_HASH)
+    event = _make_event(entry, actor_id=case_actor.id_)
+
+    result = bridge.execute_with_setup(
+        tree=CheckHashMatchesNode(name="CheckHashMatches"),
+        actor_id=PARTICIPANT_ACTOR_ID,
+        activity=event,
+        tail_hash=GENESIS_HASH,
+    )
+
+    assert result.status == Status.SUCCESS
+
+
+def test_send_reject_log_entry_node_sends_reject(bridge, case_actor):
+    entry = _make_entry(1, "deadbeef" * 8)
+    event = _make_event(entry, actor_id=case_actor.id_)
+    sync_port = MagicMock(spec=SyncActivityPort)
+
+    result = bridge.execute_with_setup(
+        tree=SendRejectLogEntryNode(name="SendRejectLogEntry"),
+        actor_id=PARTICIPANT_ACTOR_ID,
+        activity=event,
+        tail_hash=GENESIS_HASH,
+        sync_port=sync_port,
+    )
+
+    assert result.status == Status.FAILURE
+    sync_port.send_reject_log_entry.assert_called_once()
 
 
 def test_check_hash_or_reject_on_mismatch_sends_reject(bridge, case_actor):
@@ -32,3 +77,24 @@ def test_check_hash_or_reject_on_mismatch_sends_reject(bridge, case_actor):
 
     assert result.status == Status.FAILURE
     sync_port.send_reject_log_entry.assert_called_once()
+
+
+def test_check_hash_or_reject_on_mismatch_short_circuits_on_match(
+    bridge, case_actor
+):
+    entry = _make_entry(0, GENESIS_HASH)
+    event = _make_event(entry, actor_id=case_actor.id_)
+    sync_port = MagicMock(spec=SyncActivityPort)
+
+    result = bridge.execute_with_setup(
+        tree=CheckHashOrRejectOnMismatchNode(
+            name="CheckHashOrRejectOnMismatch"
+        ),
+        actor_id=PARTICIPANT_ACTOR_ID,
+        activity=event,
+        tail_hash=GENESIS_HASH,
+        sync_port=sync_port,
+    )
+
+    assert result.status == Status.SUCCESS
+    sync_port.send_reject_log_entry.assert_not_called()

--- a/test/core/behaviors/sync/nodes/test_replay.py
+++ b/test/core/behaviors/sync/nodes/test_replay.py
@@ -1,7 +1,184 @@
 #!/usr/bin/env python
-"""Unit tests for sync replay nodes."""
+"""Unit tests for sync replay and fan-out nodes."""
+
+from typing import cast
+from unittest.mock import MagicMock
+
+import py_trees
+from py_trees.common import Status
+
+from test.core.behaviors.sync.nodes.conftest import (
+    CASE_ID,
+    OWNER_ACTOR_ID,
+    PARTICIPANT_ACTOR_ID,
+    _make_entry,
+)
+from vultron.core.behaviors.sync.nodes import (
+    CollectAndSortCaseLogEntriesNode,
+    CollectLogEntryRecipientsNode,
+    FanOutLogEntryNode,
+    FindDivergenceIndexNode,
+    ReplayMissingEntriesNode,
+    SendLogEntryToEachNode,
+    SendMissingEntriesNode,
+)
+from vultron.core.models.case import VultronCase
+from vultron.core.models.case_log import GENESIS_HASH
+from vultron.core.models.events.sync import RejectLogEntryReceivedEvent
+from vultron.core.ports.sync_activity import SyncActivityPort
+from vultron.semantic_registry import extract_event
+from vultron.wire.as2.factories import reject_log_entry_activity
+from vultron.wire.as2.vocab.objects.case_log_entry import (
+    CaseLogEntry as WireCaseLogEntry,
+)
 
 
-def test_replay_nodes_placeholder():
-    """Placeholder test for replay nodes. Full coverage in integration tests."""
-    pass
+def _make_reject_event(
+    *, tail_hash: str, entry_log_index: int = 1
+) -> RejectLogEntryReceivedEvent:
+    prev_hash = GENESIS_HASH if entry_log_index == 0 else "deadbeef" * 8
+    entry = _make_entry(entry_log_index, prev_hash)
+    wire_entry = WireCaseLogEntry.model_validate(entry.model_dump(mode="json"))
+    activity = reject_log_entry_activity(
+        entry=wire_entry,
+        context=tail_hash,
+        actor=PARTICIPANT_ACTOR_ID,
+        to=[OWNER_ACTOR_ID],
+    )
+    return cast(RejectLogEntryReceivedEvent, extract_event(activity))
+
+
+def test_replay_missing_entries_node_is_sequence_with_named_leaf_nodes():
+    tree = ReplayMissingEntriesNode(name="ReplayMissingEntries")
+    assert isinstance(tree, py_trees.composites.Sequence)
+    assert len(tree.children) == 3
+    assert isinstance(tree.children[0], CollectAndSortCaseLogEntriesNode)
+    assert isinstance(tree.children[1], FindDivergenceIndexNode)
+    assert isinstance(tree.children[2], SendMissingEntriesNode)
+
+
+def test_send_missing_entries_node_replays_entries_after_divergence(
+    bridge, case_actor
+):
+    first_entry = _make_entry(0, GENESIS_HASH)
+    second_entry = _make_entry(1, first_entry.entry_hash)
+    sync_port = MagicMock(spec=SyncActivityPort)
+
+    result = bridge.execute_with_setup(
+        tree=SendMissingEntriesNode(name="SendMissingEntries"),
+        actor_id=OWNER_ACTOR_ID,
+        sync_port=sync_port,
+        case_actor_id=case_actor.id_,
+        replay_entry=second_entry,
+        replay_peer_id=PARTICIPANT_ACTOR_ID,
+        replay_case_log_entries=[first_entry, second_entry],
+        replay_from_index=0,
+    )
+
+    assert result.status == Status.SUCCESS
+    sync_port.send_announce_log_entry.assert_called_once()
+    kwargs = sync_port.send_announce_log_entry.call_args.kwargs
+    assert kwargs["entry"].id_ == second_entry.id_
+    assert kwargs["actor_id"] == case_actor.id_
+    assert kwargs["to"] == [PARTICIPANT_ACTOR_ID]
+
+
+def test_collect_and_find_replay_context_writes_blackboard(bridge, datalayer):
+    first_entry = _make_entry(0, GENESIS_HASH)
+    second_entry = _make_entry(1, first_entry.entry_hash)
+    datalayer.save(second_entry)
+    datalayer.save(first_entry)
+    event = _make_reject_event(tail_hash=first_entry.entry_hash)
+
+    collect_result = bridge.execute_with_setup(
+        tree=CollectAndSortCaseLogEntriesNode(
+            name="CollectAndSortCaseLogEntries"
+        ),
+        actor_id=OWNER_ACTOR_ID,
+        activity=event,
+    )
+
+    assert collect_result.status == Status.SUCCESS
+    replay_entries = py_trees.blackboard.Blackboard.storage.get(
+        "/replay_case_log_entries"
+    )
+    assert replay_entries is not None
+    assert [entry.log_index for entry in replay_entries] == [0, 1]
+    assert (
+        py_trees.blackboard.Blackboard.storage.get("/replay_peer_id")
+        == PARTICIPANT_ACTOR_ID
+    )
+
+    find_result = bridge.execute_with_setup(
+        tree=FindDivergenceIndexNode(name="FindDivergenceIndex"),
+        actor_id=OWNER_ACTOR_ID,
+        activity=event,
+        replay_case_log_entries=replay_entries,
+    )
+
+    assert find_result.status == Status.SUCCESS
+    assert (
+        py_trees.blackboard.Blackboard.storage.get("/replay_from_index") == 0
+    )
+
+
+def test_fanout_log_entry_node_is_sequence_with_named_leaf_nodes():
+    tree = FanOutLogEntryNode(case_id=CASE_ID, name="FanOutLogEntry")
+    assert isinstance(tree, py_trees.composites.Sequence)
+    assert len(tree.children) == 2
+    assert isinstance(tree.children[0], CollectLogEntryRecipientsNode)
+    assert isinstance(tree.children[1], SendLogEntryToEachNode)
+
+
+def test_replay_missing_entries_node_replays_from_divergence(
+    bridge, datalayer, case_actor
+):
+    first_entry = _make_entry(0, GENESIS_HASH)
+    second_entry = _make_entry(1, first_entry.entry_hash)
+    datalayer.save(first_entry)
+    datalayer.save(second_entry)
+    event = _make_reject_event(tail_hash=first_entry.entry_hash)
+    sync_port = MagicMock(spec=SyncActivityPort)
+
+    result = bridge.execute_with_setup(
+        tree=ReplayMissingEntriesNode(name="ReplayMissingEntries"),
+        actor_id=OWNER_ACTOR_ID,
+        activity=event,
+        case_actor_id=case_actor.id_,
+        sync_port=sync_port,
+    )
+
+    assert result.status == Status.SUCCESS
+    sync_port.send_announce_log_entry.assert_called_once()
+    kwargs = sync_port.send_announce_log_entry.call_args.kwargs
+    assert kwargs["entry"].id_ == second_entry.id_
+    assert kwargs["actor_id"] == case_actor.id_
+    assert kwargs["to"] == [PARTICIPANT_ACTOR_ID]
+
+
+def test_fanout_log_entry_node_sends_to_case_addressees(bridge, datalayer):
+    case_obj = VultronCase(
+        id_=CASE_ID,
+        attributed_to=OWNER_ACTOR_ID,
+        actor_participant_index={
+            OWNER_ACTOR_ID: f"{CASE_ID}/participants/vendor",
+            PARTICIPANT_ACTOR_ID: f"{CASE_ID}/participants/reporter",
+        },
+    )
+    datalayer.save(case_obj)
+    entry = _make_entry(0, GENESIS_HASH)
+    sync_port = MagicMock(spec=SyncActivityPort)
+
+    result = bridge.execute_with_setup(
+        tree=FanOutLogEntryNode(case_id=CASE_ID, name="FanOutLogEntry"),
+        actor_id=OWNER_ACTOR_ID,
+        log_entry=entry,
+        sync_port=sync_port,
+    )
+
+    assert result.status == Status.SUCCESS
+    sync_port.send_announce_log_entry.assert_called_once()
+    kwargs = sync_port.send_announce_log_entry.call_args.kwargs
+    assert kwargs["entry"].id_ == entry.id_
+    assert kwargs["actor_id"] == OWNER_ACTOR_ID
+    assert kwargs["to"] == [PARTICIPANT_ACTOR_ID]

--- a/vultron/core/behaviors/sync/nodes/__init__.py
+++ b/vultron/core/behaviors/sync/nodes/__init__.py
@@ -44,14 +44,21 @@ from vultron.core.behaviors.sync.nodes.conditions import (
     _require_log_entry,  # noqa: F401
 )
 from vultron.core.behaviors.sync.nodes.receive import (
+    CheckHashMatchesNode,
     CheckHashOrRejectOnMismatchNode,
     LogDeliveryConfirmationNode,
     PersistReceivedLogEntryNode,
+    SendRejectLogEntryNode,
 )
 from vultron.core.behaviors.sync.nodes.replay import (
+    CollectAndSortCaseLogEntriesNode,
+    CollectLogEntryRecipientsNode,
     FanOutLogEntryNode,
     FindCaseActorNode,
+    FindDivergenceIndexNode,
     ReplayMissingEntriesNode,
+    SendLogEntryToEachNode,
+    SendMissingEntriesNode,
 )
 
 __all__ = [
@@ -64,6 +71,8 @@ __all__ = [
     # receive
     "LogDeliveryConfirmationNode",
     "PersistReceivedLogEntryNode",
+    "CheckHashMatchesNode",
+    "SendRejectLogEntryNode",
     "CheckHashOrRejectOnMismatchNode",
     # chain
     "ReconstructChainTailNode",
@@ -72,7 +81,12 @@ __all__ = [
     "PersistLogEntryNode",
     # replay
     "FindCaseActorNode",
+    "CollectAndSortCaseLogEntriesNode",
+    "FindDivergenceIndexNode",
+    "SendMissingEntriesNode",
     "ReplayMissingEntriesNode",
+    "CollectLogEntryRecipientsNode",
+    "SendLogEntryToEachNode",
     "FanOutLogEntryNode",
     # re-exported helper functions (backward compat)
     "_find_case_actor",

--- a/vultron/core/behaviors/sync/nodes/receive.py
+++ b/vultron/core/behaviors/sync/nodes/receive.py
@@ -22,7 +22,7 @@ from typing import Any, cast
 import py_trees
 from py_trees.common import Status
 
-from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
 from vultron.core.models.case_log_entry import VultronCaseLogEntry
 from vultron.core.models.protocols import is_log_entry_model
 from vultron.core.ports.sync_activity import SyncActivityPort
@@ -86,7 +86,25 @@ class PersistReceivedLogEntryNode(DataLayerAction):
         return Status.SUCCESS
 
 
-class CheckHashOrRejectOnMismatchNode(DataLayerAction):
+class CheckHashMatchesNode(DataLayerCondition):
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="activity", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="tail_hash", access=py_trees.common.Access.READ
+        )
+
+    def update(self) -> Status:
+        entry = _require_log_entry(self.blackboard.activity, self.name)
+        tail_hash = self.blackboard.tail_hash
+        if entry.prev_log_hash == tail_hash:
+            return Status.SUCCESS
+        return Status.FAILURE
+
+
+class SendRejectLogEntryNode(DataLayerAction):
     def __init__(self, name: str | None = None) -> None:
         super().__init__(name=name or self.__class__.__name__)
         self._sync_port: SyncActivityPort | None = None
@@ -117,8 +135,6 @@ class CheckHashOrRejectOnMismatchNode(DataLayerAction):
 
         entry = _require_log_entry(self.blackboard.activity, self.name)
         tail_hash = self.blackboard.tail_hash
-        if entry.prev_log_hash == tail_hash:
-            return Status.SUCCESS
 
         sender_id = getattr(self.blackboard.activity, "actor_id", None)
         if self._sync_port is None:
@@ -145,3 +161,15 @@ class CheckHashOrRejectOnMismatchNode(DataLayerAction):
             to=[sender_id],
         )
         return Status.FAILURE
+
+
+class CheckHashOrRejectOnMismatchNode(py_trees.composites.Selector):
+    def __init__(self, name: str | None = None) -> None:
+        super().__init__(
+            name=name or self.__class__.__name__,
+            memory=False,
+            children=[
+                CheckHashMatchesNode(name="CheckHashMatches"),
+                SendRejectLogEntryNode(name="SendRejectLogEntry"),
+            ],
+        )

--- a/vultron/core/behaviors/sync/nodes/replay.py
+++ b/vultron/core/behaviors/sync/nodes/replay.py
@@ -122,7 +122,79 @@ class FindCaseActorNode(DataLayerAction):
         return Status.SUCCESS
 
 
-class ReplayMissingEntriesNode(DataLayerAction):
+class CollectAndSortCaseLogEntriesNode(DataLayerAction):
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="activity", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="replay_entry", access=py_trees.common.Access.WRITE
+        )
+        self.blackboard.register_key(
+            key="replay_peer_id", access=py_trees.common.Access.WRITE
+        )
+        self.blackboard.register_key(
+            key="replay_case_log_entries",
+            access=py_trees.common.Access.WRITE,
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.logger.error("%s: DataLayer not available", self.name)
+            return Status.FAILURE
+
+        activity = self.blackboard.activity
+        entry = _require_rejected_entry(activity, self.name)
+        peer_id = activity.actor_id
+        if not peer_id:
+            raise VultronError(
+                f"{self.name}: Reject(CaseLogEntry) missing peer actor_id"
+            )
+
+        entries: list[LogEntryModel] = [
+            obj
+            for obj in self.datalayer.list_objects("CaseLogEntry")
+            if is_log_entry_model(obj) and obj.case_id == entry.case_id
+        ]
+        entries.sort(key=lambda log_entry: log_entry.log_index)
+
+        self.blackboard.replay_entry = entry
+        self.blackboard.replay_peer_id = peer_id
+        self.blackboard.replay_case_log_entries = entries
+        return Status.SUCCESS
+
+
+class FindDivergenceIndexNode(DataLayerAction):
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="activity", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="replay_case_log_entries",
+            access=py_trees.common.Access.READ,
+        )
+        self.blackboard.register_key(
+            key="replay_from_index", access=py_trees.common.Access.WRITE
+        )
+
+    def update(self) -> Status:
+        entries = cast(
+            list[LogEntryModel], self.blackboard.replay_case_log_entries
+        )
+        from_hash = self.blackboard.activity.last_accepted_hash
+        from_index = -1
+        for log_entry in entries:
+            if log_entry.entry_hash == from_hash:
+                from_index = log_entry.log_index
+                break
+
+        self.blackboard.replay_from_index = from_index
+        return Status.SUCCESS
+
+
+class SendMissingEntriesNode(DataLayerAction):
     def __init__(self, name: str | None = None) -> None:
         super().__init__(name=name or self.__class__.__name__)
         self._sync_port: SyncActivityPort | None = None
@@ -130,10 +202,20 @@ class ReplayMissingEntriesNode(DataLayerAction):
     def setup(self, **kwargs: Any) -> None:
         super().setup(**kwargs)
         self.blackboard.register_key(
-            key="activity", access=py_trees.common.Access.READ
+            key="case_actor_id", access=py_trees.common.Access.READ
         )
         self.blackboard.register_key(
-            key="case_actor_id", access=py_trees.common.Access.READ
+            key="replay_entry", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="replay_peer_id", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="replay_case_log_entries",
+            access=py_trees.common.Access.READ,
+        )
+        self.blackboard.register_key(
+            key="replay_from_index", access=py_trees.common.Access.READ
         )
         self.blackboard.register_key(
             key="sync_port", access=py_trees.common.Access.READ
@@ -155,27 +237,12 @@ class ReplayMissingEntriesNode(DataLayerAction):
                 f"{self.name}: sync_port must be injected to replay entries"
             )
 
-        activity = self.blackboard.activity
-        entry = _require_rejected_entry(activity, self.name)
-        peer_id = activity.actor_id
-        if not peer_id:
-            raise VultronError(
-                f"{self.name}: Reject(CaseLogEntry) missing peer actor_id"
-            )
-
-        entries: list[LogEntryModel] = [
-            obj
-            for obj in self.datalayer.list_objects("CaseLogEntry")
-            if is_log_entry_model(obj) and obj.case_id == entry.case_id
-        ]
-        entries.sort(key=lambda e: e.log_index)
-
-        from_hash = activity.last_accepted_hash
-        from_index = -1
-        for log_entry in entries:
-            if log_entry.entry_hash == from_hash:
-                from_index = log_entry.log_index
-                break
+        entry = cast(VultronCaseLogEntry, self.blackboard.replay_entry)
+        peer_id = cast(str, self.blackboard.replay_peer_id)
+        entries = cast(
+            list[LogEntryModel], self.blackboard.replay_case_log_entries
+        )
+        from_index = cast(int, self.blackboard.replay_from_index)
 
         replayed = 0
         for log_entry in entries:
@@ -198,16 +265,73 @@ class ReplayMissingEntriesNode(DataLayerAction):
         return Status.SUCCESS
 
 
-class FanOutLogEntryNode(DataLayerAction):
+class ReplayMissingEntriesNode(py_trees.composites.Sequence):
+    def __init__(self, name: str | None = None) -> None:
+        super().__init__(
+            name=name or self.__class__.__name__,
+            memory=False,
+            children=[
+                CollectAndSortCaseLogEntriesNode(
+                    name="CollectAndSortCaseLogEntries"
+                ),
+                FindDivergenceIndexNode(name="FindDivergenceIndex"),
+                SendMissingEntriesNode(name="SendMissingEntries"),
+            ],
+        )
+
+
+class CollectLogEntryRecipientsNode(DataLayerAction):
     def __init__(self, case_id: str, name: str | None = None) -> None:
         super().__init__(name=name or self.__class__.__name__)
         self.case_id = case_id
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="log_entry", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="fanout_recipients", access=py_trees.common.Access.WRITE
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None or self.actor_id is None:
+            self.logger.error(
+                "%s: DataLayer or actor_id not available", self.name
+            )
+            return Status.FAILURE
+
+        entry = cast(VultronCaseLogEntry, self.blackboard.log_entry)
+        case_obj = self.datalayer.read(self.case_id)
+        if not is_case_model(case_obj):
+            self.logger.warning(
+                "%s: case '%s' not found; skipping fan-out for '%s'",
+                self.name,
+                self.case_id,
+                entry.id_,
+            )
+            self.blackboard.fanout_recipients = []
+            return Status.SUCCESS
+
+        recipients = case_addressees(
+            case_obj, excluding_actor_id=self.actor_id
+        )
+        self.blackboard.fanout_recipients = recipients
+        return Status.SUCCESS
+
+
+class SendLogEntryToEachNode(DataLayerAction):
+    def __init__(self, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
         self._sync_port: SyncActivityPort | None = None
 
     def setup(self, **kwargs: Any) -> None:
         super().setup(**kwargs)
         self.blackboard.register_key(
             key="log_entry", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="fanout_recipients", access=py_trees.common.Access.READ
         )
         self.blackboard.register_key(
             key="sync_port", access=py_trees.common.Access.READ
@@ -221,13 +345,12 @@ class FanOutLogEntryNode(DataLayerAction):
             self._sync_port = None
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.logger.error(
-                "%s: DataLayer or actor_id not available", self.name
-            )
+        if self.actor_id is None:
+            self.logger.error("%s: actor_id not available", self.name)
             return Status.FAILURE
 
         entry = cast(VultronCaseLogEntry, self.blackboard.log_entry)
+        recipients = cast(list[str], self.blackboard.fanout_recipients)
         if self._sync_port is None:
             self.logger.debug(
                 "%s: sync_port not injected; skipping fan-out for '%s'",
@@ -236,19 +359,6 @@ class FanOutLogEntryNode(DataLayerAction):
             )
             return Status.SUCCESS
 
-        case_obj = self.datalayer.read(self.case_id)
-        if not is_case_model(case_obj):
-            self.logger.warning(
-                "%s: case '%s' not found; skipping fan-out for '%s'",
-                self.name,
-                self.case_id,
-                entry.id_,
-            )
-            return Status.SUCCESS
-
-        recipients = case_addressees(
-            case_obj, excluding_actor_id=self.actor_id
-        )
         for recipient_id in recipients:
             self._sync_port.send_announce_log_entry(
                 entry=entry,
@@ -262,3 +372,18 @@ class FanOutLogEntryNode(DataLayerAction):
             len(recipients),
         )
         return Status.SUCCESS
+
+
+class FanOutLogEntryNode(py_trees.composites.Sequence):
+    def __init__(self, case_id: str, name: str | None = None) -> None:
+        super().__init__(
+            name=name or self.__class__.__name__,
+            memory=False,
+            children=[
+                CollectLogEntryRecipientsNode(
+                    case_id=case_id,
+                    name="CollectLogEntryRecipients",
+                ),
+                SendLogEntryToEachNode(name="SendLogEntryToEach"),
+            ],
+        )


### PR DESCRIPTION
- Closes #755

## Summary

Decomposes three SYNC behavior-tree god nodes into smaller leaf nodes composed as explicit Sequence/Selector subtrees. This preserves behavior while improving single-responsibility and testability.

## Changes

- `vultron/core/behaviors/sync/nodes/replay.py`: split replay and fan-out logic into named leaf nodes and composite wrappers (`ReplayMissingEntriesNode`, `FanOutLogEntryNode`).
- `vultron/core/behaviors/sync/nodes/receive.py`: split hash validation and reject send side effects into `CheckHashMatchesNode` + `SendRejectLogEntryNode` under selector wrapper.
- `vultron/core/behaviors/sync/nodes/__init__.py`: re-export new leaf node classes.
- `test/core/behaviors/sync/nodes/test_replay.py`: add structure and behavior tests for replay/fan-out decomposition.
- `test/core/behaviors/sync/nodes/test_receive.py`: add structure, leaf behavior, and selector short-circuit tests.
- `plan/BUILD_LEARNINGS.md`: add ISSUE-755 implementation observation.

## Verification

- 3133 passed, 12 skipped, 219 deselected, 5633 subtests passed
- Black, flake8, mypy, pyright clean