### PR TITLE
docs: plan issue #504 — module size and organization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -354,6 +354,16 @@ Short entries are reproduced here; longer ones are referenced below.
   suite: a `test/…/nodes/` directory with one `test_<submodule>.py` per
   submodule. See `specs/behavior-tree-node-design.yaml` BTND-07-001 and
   BTND-07-002.
+- **Splits Must Not Produce New God Modules** — When splitting a large
+  module into a subpackage, each resulting submodule must itself stay under
+  500 lines (CS-18-002). The split pattern is **recursive**: a submodule
+  that re-accumulates size across multiple concerns must be further
+  decomposed. For example, splitting `case/nodes.py` into a `nodes/`
+  package produced `nodes/participant.py` at 816 lines — that file is itself
+  a candidate for further splitting. Monitor new submodule line counts after
+  every split PR and open a follow-up issue when any submodule exceeds 500
+  lines and mixes responsibilities. See `specs/code-style.yaml` CS-18-001
+  through CS-18-004.
 - **py_trees Blackboard Global State** — see [notes/bt-integration.md](notes/bt-integration.md)
 - **py_trees `blackboard.get()` Raises KeyError for Unwritten READ Keys** — see [notes/bt-integration.md](notes/bt-integration.md)
 - **Duplicate Method Definitions Silently Shadow Correct BT Logic** — see [notes/bt-integration.md](notes/bt-integration.md)

--- a/plan/history/2606/learning/CONCERN-504.md
+++ b/plan/history/2606/learning/CONCERN-504.md
@@ -1,0 +1,57 @@
+---
+source: CONCERN-504
+timestamp: '2026-06-10T16:58:55.574720+00:00'
+title: Module size and organization — large files in all layers
+type: learning
+---
+
+## Summary
+
+Five production source files exceeding 500 lines and mixing multiple
+responsibilities were identified. Three are also high-churn, increasing
+merge-conflict risk.
+
+## Category
+
+- [x] Top risk
+- [x] Technical debt
+
+## Severity
+
+medium
+
+## Evidence (at time of filing)
+
+- `vultron/demo/scenario/two_actor_demo.py` (2050 lines)
+- `vultron/core/behaviors/case/nodes.py` (1502 lines)
+- `vultron/adapters/driven/datalayer_sqlite.py` (1042 lines)
+- `vultron/wire/as2/extractor.py` (821 lines)
+- `vultron/semantic_registry.py` (783 lines)
+
+## Progress since filing
+
+- `case/nodes.py` → split into `nodes/` subpackage (#514, closed)
+- `semantic_registry.py` → split into package (#702)
+- `triggers/embargo.py` → split (#516, closed)
+- `two_actor_demo.py` reduced from 2050 → 989 lines
+
+## Remaining large files (at planning date 2026-06-10)
+
+- `adapters/driven/datalayer_sqlite.py` — 1296 lines (grew)
+- `core/behaviors/status/nodes.py` — 1281 lines (new)
+- `demo/scenario/two_actor_demo.py` — 989 lines (integration complexity; skipped)
+- `core/behaviors/embargo/nodes.py` — 920 lines (new)
+- `wire/as2/extractor.py` — 826 lines (unchanged)
+- `core/use_cases/received/case.py` — 819 lines (new)
+- `core/behaviors/case/nodes/participant.py` — 816 lines (emerged from split)
+- `core/use_cases/received/actor.py` — 803 lines (new)
+
+## Impact if Ignored
+
+Large, multi-responsibility files accumulate technical debt, slow review
+cycles, and make targeted test coverage difficult. High-churn large files
+are especially prone to merge conflicts.
+
+**Resolved**: 2026-06-10 — implementation tracked in issues 876, 877, 878, 879, 880, and 881.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/875>.
+Spec: `specs/code-style.yaml` (CS-18-001 through CS-18-004).

--- a/specs/code-style.yaml
+++ b/specs/code-style.yaml
@@ -252,3 +252,66 @@ groups:
       field", silently allows invalid data through, and scatters validation logic across callers. A Pydantic model with
       `ValidationError` on missing required fields is the single source of truth and forces callers to handle the error
       path explicitly.
+- id: CS-18
+  title: Module Size and Organization
+  kind: general
+  specs:
+  - id: CS-18-001
+    priority: SHOULD
+    statement: >-
+      (**SHOULD**) A Python source file SHOULD NOT exceed 500 lines when it mixes multiple
+      distinct responsibilities. When the 500-line threshold is crossed, the module MUST
+      be split into a subpackage whose submodules are grouped by semantic concern.
+    rationale: >-
+      Large, multi-responsibility files accumulate technical debt, slow review cycles,
+      and make targeted test coverage difficult. High-churn large files are especially
+      prone to merge conflicts. The 500-line threshold is a practical signal, not a hard
+      language constraint — a coherent single-responsibility module MAY exceed it if all
+      concerns are tightly related. The key signal is mixed responsibility.
+    verification: >-
+      Any production source file exceeding 500 lines SHOULD be reviewed for
+      mixed-responsibility concerns. A codebase scan MAY flag such files for
+      triage. Applies to all layers: core, wire, adapters, use cases, and demo.
+    relationships:
+    - rel_type: refines
+      spec_id: BTND-07-001
+  - id: CS-18-002
+    priority: MUST
+    statement: >-
+      When a module is split into a subpackage, the resulting submodules MUST themselves
+      comply with CS-18-001. The split pattern applies recursively: a submodule that
+      exceeds 500 lines and mixes responsibilities MUST be further decomposed.
+    rationale: >-
+      Splitting a god module into a package does not eliminate the problem if individual
+      submodules re-accumulate size. A recursive constraint closes this loophole.
+    verification: >-
+      After any split, confirm that each resulting submodule is below 500 lines or
+      has a single well-defined responsibility.
+    relationships:
+    - rel_type: refines
+      spec_id: CS-18-001
+  - id: CS-18-003
+    priority: MUST
+    statement: >-
+      A subpackage created by splitting a flat module MUST re-export all previously
+      public names from its `__init__.py` to preserve import compatibility with callers.
+    rationale: >-
+      Callers that previously imported `from vultron.foo.nodes import SomeNode` MUST
+      continue to work without modification. Exposing all names via `__init__.py`
+      prevents a split from becoming a breaking change.
+    relationships:
+    - rel_type: refines
+      spec_id: CS-15-001
+  - id: CS-18-004
+    priority: SHOULD
+    statement: >-
+      (**SHOULD**) The test suite for a subpackage created by splitting a flat module
+      SHOULD mirror the subpackage structure: a `test/…/nodes/` (or equivalent)
+      directory with one `test_<submodule>.py` per submodule.
+    rationale: >-
+      A monolithic test file grows in parallel with the flat module and inherits the
+      same blast-radius problem. Mirrored test files scope failures to the affected
+      concern and make it easier to add focused per-unit tests.
+    relationships:
+    - rel_type: refines
+      spec_id: BTND-07-002


### PR DESCRIPTION
- Closes #504

## Summary

Plans issue #504 by capturing the 500-line / mixed-responsibility splitting
rule in a new `CS-18` spec group and extending the AGENTS.md pitfall for
flat `nodes.py` files with a recursive-split requirement.

## Changes

- `specs/code-style.yaml`: New CS-18 group (CS-18-001–CS-18-004) generalizing
  the module-size rule to all codebase layers (adapters, use cases, wire,
  demo) and requiring recursive compliance after splits
- `AGENTS.md`: New pitfall entry — **Splits Must Not Produce New God
  Modules** — referencing CS-18-001 through CS-18-004