### PR TITLE
docs: plan issue #882 — BT node module organization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -341,19 +341,22 @@ Short entries are reproduced here; longer ones are referenced below.
   simple leaf nodes; the tree structure becomes the workflow documentation.
   See [notes/bt-integration.md](notes/bt-integration.md)
   § "DO NOT: God BT nodes with long `update()` methods".
-- **Flat `nodes.py` with 10+ BT Classes Is a Code Smell** — A single
-  `nodes.py` accumulating ten or more BT node classes is a high-churn,
-  high-blast-radius module. Every change — regardless of which workflow step
-  it touches — modifies the same file, making review shallow and increasing
-  the risk of duplicate method definitions silently shadowing correct logic.
-  When a `nodes.py` reaches this threshold, convert it to a `nodes/`
-  subpackage with submodules grouped by semantic concern (e.g.,
-  `conditions.py`, `case_setup.py`, `participant.py`, `embargo.py`,
-  `communication.py`, `lifecycle.py`). The `__init__.py` MUST re-export all
-  public names to preserve caller import paths. Mirror the split in the test
-  suite: a `test/…/nodes/` directory with one `test_<submodule>.py` per
-  submodule. See `specs/behavior-tree-node-design.yaml` BTND-07-001 and
-  BTND-07-002.
+- **Large `nodes.py` Files Are a Code Smell — Split at 500 Lines** — A
+  `nodes.py` that has grown large is a high-churn, high-blast-radius module.
+  Every change — regardless of which workflow step it touches — modifies the
+  same file, making review shallow and increasing the risk of duplicate method
+  definitions silently shadowing correct logic. The trigger is file size, not
+  class count: any `nodes.py` approaching or exceeding 500 lines
+  (CS-18-002) SHOULD be converted to a `nodes/` subpackage with submodules
+  grouped by semantic concern (e.g., `conditions.py`, `case_setup.py`,
+  `participant.py`, `embargo.py`, `communication.py`, `lifecycle.py`). The
+  `__init__.py` MUST re-export all public names to preserve caller import paths.
+  Mirror the split in the test suite: a `test/…/nodes/` directory with one
+  `test_<submodule>.py` per submodule. More broadly, every process area under
+  `vultron/core/behaviors/` SHOULD use a `nodes/` subpackage even for small
+  modules — the `nodes/` subpackage is the standard structural unit for leaf
+  nodes regardless of current size. See `specs/behavior-tree-node-design.yaml`
+  BTND-07-001, BTND-07-002, and BTND-07-003.
 - **Splits Must Not Produce New God Modules** — When splitting a large
   module into a subpackage, each resulting submodule must itself stay under
   500 lines (CS-18-002). The split pattern is **recursive**: a submodule

--- a/plan/history/2606/idea/IDEA-882.md
+++ b/plan/history/2606/idea/IDEA-882.md
@@ -1,0 +1,50 @@
+---
+source: IDEA-882
+timestamp: '2026-06-10T17:32:48.561382+00:00'
+title: Standardize BT node module organization across vultron/core/behaviors/
+type: idea
+---
+
+## Motivation
+
+The codebase has organically evolved to split behavior trees into two layers:
+tree factory functions (composition/structure) and leaf node modules
+(implementation/details). This pattern has been successfully proven in case/,
+report/, and sync/ areas using nodes/ subpackages with semantic modules.
+However, embargo/, note/, sender/, and status/ still use flat nodes.py files.
+This inconsistency creates maintenance friction and code-smell risks — notably
+status/nodes.py (1,281 lines, 17 classes) and embargo/nodes.py (920 lines, 13
+classes) both exceed the 10-class threshold documented in AGENTS.md.
+Standardizing across all areas would improve code clarity, reduce review
+friction, and prevent duplicate method definitions silently shadowing logic.
+
+## Rough Approach
+
+1. **embargo/** — Convert nodes.py to nodes/ subpackage with semantic modules:
+   validation.py, em_transitions.py, pec_management.py, broadcast.py,
+   trigger.py. Merge existing trigger_nodes.py.
+2. **status/** — Convert nodes.py to nodes/ subpackage with semantic modules:
+   participant_status.py, case_status.py (separating two workflows).
+3. **note/** — Convert nodes.py to nodes/ subpackage (size is manageable but
+   should follow standard).
+4. **sender/** — Audit and standardize if needed.
+5. **Test mirroring** — Create test/core/behaviors/{embargo,status,note,sender}/nodes/
+   with one test file per semantic module.
+6. Re-export all public names in `nodes/__init__.py` to preserve existing imports.
+
+## References
+
+- Related implementation issues: #876, #877, #878, #879, #880, #881
+- AGENTS.md pitfall: "Flat nodes.py with 10+ BT Classes Is a Code Smell"
+- Related specs: specs/behavior-tree-node-design.yaml (BTND-07-001, BTND-07-002)
+- Related notes: notes/bt-integration.md (BT-related pitfalls reference)
+
+**Processed**: 2026-06-10 — The split is universal (not size-triggered): all
+process areas under `vultron/core/behaviors/` SHOULD use a `nodes/` subpackage
+regardless of current size (BTND-07-001 updated). BTND-07-003 added to
+formalize the tree/node structural split requirement. AGENTS.md pitfall
+updated to focus on 500-line file-size threshold (CS-18-002) rather than
+class count. Implementation tracked in #876 (status), #877 (embargo, incl.
+`trigger_nodes.py` merge), #878 (`case/nodes/participant.py` further split),
+\#883 (note + sender combined).
+Docs PR: [#884](https://github.com/CERTCC/Vultron/pull/884).

--- a/specs/behavior-tree-node-design.yaml
+++ b/specs/behavior-tree-node-design.yaml
@@ -257,25 +257,31 @@ groups:
     priority: SHOULD
     statement: >-
       (**SHOULD**) BT node classes for a given protocol step SHOULD be organized into a
-      `nodes/` subpackage rather than a single flat `nodes.py` module. Submodules MUST
-      be grouped by semantic concern (e.g., `conditions.py`, `case_setup.py`,
-      `participant.py`, `embargo.py`, `communication.py`, `lifecycle.py`). The package
-      `__init__.py` MUST re-export all public node names to preserve import compatibility
-      with callers.
+      `nodes/` subpackage rather than a single flat `nodes.py` module. This applies to
+      all process areas in `vultron/core/behaviors/` regardless of the current number of
+      node classes or total file size — the `nodes/` subpackage is the standard
+      organizational unit for leaf node implementations. Submodules MUST be grouped by
+      semantic concern (e.g., `conditions.py`, `case_setup.py`, `participant.py`,
+      `embargo.py`, `communication.py`, `lifecycle.py`). The package `__init__.py` MUST
+      re-export all public node names to preserve import compatibility with callers.
     rationale: >-
-      A flat `nodes.py` accumulating ten or more BT node classes becomes a high-churn,
-      high-blast-radius file where every change — regardless of which workflow step it
-      touches — modifies the same module. This makes code review shallow, increases the
-      risk of duplicate method definitions silently shadowing correct logic, and degrades
-      test maintainability. Grouping by semantic concern reduces diff scope, improves
-      discoverability, and lets reviewers focus on the affected concern in isolation.
+      A flat `nodes.py` becomes a high-churn, high-blast-radius file where every change
+      — regardless of which workflow step it touches — modifies the same module. This
+      makes code review shallow, increases the risk of duplicate method definitions
+      silently shadowing correct logic, and degrades test maintainability. Applying the
+      `nodes/` subpackage pattern uniformly (not just when a file grows large) keeps the
+      hierarchy consistent across all process areas and prevents gradual accumulation that
+      creates a large-file problem later. Grouping by semantic concern reduces diff scope,
+      improves discoverability, and lets reviewers focus on the affected concern in
+      isolation.
     relationships:
     - rel_type: refines
       spec_id: BT-06-004
     verification: >-
-      Any `nodes.py` containing ten or more BT node classes SHOULD be flagged for
-      refactoring into a `nodes/` subpackage. CI or a codebase-scan tool MAY enforce this
-      threshold.
+      Every process area directory under `vultron/core/behaviors/` that contains BT
+      node classes SHOULD have a `nodes/` subpackage. Any flat `nodes.py` in a process
+      area directory is a candidate for conversion, with priority given to files
+      exceeding 500 lines (CS-18-002).
   - id: BTND-07-002
     priority: SHOULD
     statement: >-
@@ -292,3 +298,30 @@ groups:
     verification: >-
       For any `nodes/` subpackage, confirm that a matching `test/…/nodes/` directory
       exists with per-submodule test files.
+  - id: BTND-07-003
+    priority: SHOULD
+    statement: >-
+      (**SHOULD**) Each process area directory under `vultron/core/behaviors/` SHOULD
+      maintain a clear structural split between tree factory modules and leaf node
+      modules. Tree factory modules (files named `*_tree.py` at the area root) define
+      BT composition and structure. Leaf node modules (files in the `nodes/` subpackage)
+      define BT `Behaviour` subclasses. Supporting files (e.g., `policy.py`,
+      `update_support.py`) MAY exist at the area root alongside tree modules. This
+      two-level hierarchy MAY be deepened further: a `nodes/` subpackage MAY itself
+      contain sub-subpackages when a semantic concern grows large, following the same
+      split pattern recursively.
+    rationale: >-
+      Mixing tree factory functions and leaf node class definitions in the same module
+      conflates two separate concerns: composition/structure (how the tree is assembled)
+      and implementation/detail (what each leaf node does). Keeping them in separate
+      modules makes the tree structure immediately readable without navigating past
+      implementation details, and lets each concern evolve independently without
+      cross-contaminating diffs.
+    relationships:
+    - rel_type: refines
+      spec_id: BTND-07-001
+    verification: >-
+      For each process area under `vultron/core/behaviors/`, confirm that `*_tree.py`
+      modules do not define `Behaviour` subclasses inline (except trivial one-off
+      composites), and that `nodes/` submodules do not define top-level tree factory
+      functions.


### PR DESCRIPTION
- Closes #882

## Summary

Plans issue #882 (Idea: standardize tree vs. leaf node organization across
`vultron/core/behaviors/`). Updates BTND-07-001 to make the `nodes/`
subpackage the universal standard for all process areas (not size-triggered),
adds BTND-07-003 formalizing the tree/node structural split requirement, and
updates the AGENTS.md pitfall to focus on file size rather than class count.

## Changes

- `specs/behavior-tree-node-design.yaml`: Update BTND-07-001 to remove the
  10-class threshold; apply `nodes/` subpackage as the standard for all
  process areas regardless of size. Add BTND-07-003: tree factory modules
  (`*_tree.py`) and leaf node modules (`nodes/`) must be structurally
  separated within each process area.
- `AGENTS.md`: Reframe the `nodes.py` pitfall from class-count trigger
  (10+ classes) to file-size trigger (500-line threshold per CS-18-002);
  add guidance that the `nodes/` subpackage is the standard structural
  unit for all process areas regardless of current size.