### PR TITLE
Decompose CreateCaseActor and owner-participant BT nodes

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -173,3 +173,10 @@ header.
   collect context, derive index/recipients, then perform side effects.
 - Condition+action hybrid nodes are clearer and safer as `Selector` composites:
   a pure condition leaf first, then side-effect action fallback.
+
+### 2026-06-10 ISSUE-714 — Decomposed BT nodes must preserve alternate context seams
+
+- When replacing a god node with leaf-node sequences, preserve all original
+  input seams (`case_id` from blackboard and `case_obj`-derived context).
+- If downstream leaves rely on blackboard keys, add explicit fallback reads
+  from staged objects/status context to avoid regressing valid call paths.

--- a/plan/history/2606/implementation/ISSUE-714.md
+++ b/plan/history/2606/implementation/ISSUE-714.md
@@ -1,0 +1,12 @@
+---
+source: ISSUE-714
+timestamp: '2026-06-10T18:14:57.614505+00:00'
+title: Decompose CreateCaseActor and owner participant BT nodes
+type: implementation
+---
+
+## Issue #714 — God node decomposition: split CreateCaseActorNode, InitializeDefaultEmbargoNode, CreateCaseOwnerParticipant, and BroadcastStatusToPeersNode into composed subtrees
+
+Completed the in-scope decomposition for `CreateCaseActorNode` and `CreateCaseOwnerParticipant` as composed BT subtrees with named leaf nodes, preserving idempotency and call-path compatibility. Added unit coverage for subtree structure and owner RM advancement behavior.
+
+PR: [#887](https://github.com/CERTCC/Vultron/pull/887)

--- a/test/core/behaviors/case/nodes/test_case_setup.py
+++ b/test/core/behaviors/case/nodes/test_case_setup.py
@@ -405,3 +405,28 @@ class TestCreateCaseActorNodeBlackboard:
             # No case_id supplied
         )
         assert result.status == py_trees.common.Status.FAILURE
+
+
+# ---------------------------------------------------------------------------
+# RegisterCaseActorParticipantNode — precondition failure tests
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterCaseActorParticipantNode:
+    """RegisterCaseActorParticipantNode returns FAILURE when case is absent."""
+
+    def test_fails_when_case_not_in_datalayer(
+        self,
+        bt_scenario: BTTestScenario,
+        actor: VultronCaseActor,
+        actor_id: str,
+    ) -> None:
+        """Node returns FAILURE (not SUCCESS) when the case record is missing."""
+        result = bt_scenario.run(
+            RegisterCaseActorParticipantNode(),
+            actor_id=actor_id,
+            case_id="https://example.org/cases/nonexistent",
+            case_actor_id=f"{actor_id}/case-actor",
+            case_actor_participant_id=f"{actor_id}/case-actor/participant",
+        )
+        assert result.status == py_trees.common.Status.FAILURE

--- a/test/core/behaviors/case/nodes/test_case_setup.py
+++ b/test/core/behaviors/case/nodes/test_case_setup.py
@@ -39,6 +39,12 @@ from vultron.core.behaviors.case.nodes import (
     RecordOfferReceivedEventNode,
     UpdateActorOutbox,
 )
+from vultron.core.behaviors.case.nodes.case_setup import (
+    CreateCaseActorServiceNode,
+    RegisterCaseActorParticipantNode,
+    ResolveCaseActorUrlsNode,
+    ReuseExistingCaseActorParticipantNode,
+)
 from vultron.core.behaviors.helpers import (
     UpdateActorOutbox as UpdateActorOutboxHelper,
 )
@@ -318,6 +324,24 @@ class TestCreateCaseActorNodeBlackboard:
             s for s in services if getattr(s, "context", None) == case_obj.id_
         ]
         assert len(case_actor_services) >= 1
+
+    def test_is_composed_subtree_of_named_leaf_nodes(self) -> None:
+        node = CreateCaseActorNode()
+        assert isinstance(node, py_trees.composites.Sequence)
+        assert isinstance(node.children[0], ResolveCaseActorUrlsNode)
+        assert isinstance(node.children[1], py_trees.composites.Selector)
+
+        idempotency_selector = node.children[1]
+        assert isinstance(
+            idempotency_selector.children[0],
+            ReuseExistingCaseActorParticipantNode,
+        )
+        create_branch = idempotency_selector.children[1]
+        assert isinstance(create_branch, py_trees.composites.Sequence)
+        assert [type(child) for child in create_branch.children] == [
+            CreateCaseActorServiceNode,
+            RegisterCaseActorParticipantNode,
+        ]
 
     def test_writes_case_actor_id_to_blackboard(
         self,

--- a/test/core/behaviors/case/nodes/test_participant.py
+++ b/test/core/behaviors/case/nodes/test_participant.py
@@ -45,6 +45,7 @@ from vultron.core.behaviors.case.nodes.participant import (
     CreateOwnerParticipantNode,
     PersistOwnerCaseNode,
     QueueAddParticipantNotificationNode,
+    RecordOwnerJoinedEventNode,
     RecordParticipantAddedEventNode,
     ResolveParticipantAcceptedStatusNode,
     ResolveOwnerInitialStatusNode,
@@ -363,15 +364,16 @@ class TestCreateCaseOwnerParticipant:
     def test_is_composed_subtree_of_named_leaf_nodes(self) -> None:
         node = CreateCaseOwnerParticipant()
         assert isinstance(node, py_trees.composites.Sequence)
-        assert [type(child) for child in node.children[:4]] == [
+        assert [type(child) for child in node.children[:5]] == [
             ResolveOwnerInitialStatusNode,
             CreateOwnerParticipantNode,
             AttachOwnerParticipantToCaseNode,
             PersistOwnerCaseNode,
+            RecordOwnerJoinedEventNode,
         ]
-        assert isinstance(node.children[4], py_trees.composites.Selector)
+        assert isinstance(node.children[5], py_trees.composites.Selector)
 
-        conditional_selector = node.children[4]
+        conditional_selector = node.children[5]
         assert isinstance(
             conditional_selector.children[0], py_trees.composites.Sequence
         )
@@ -384,6 +386,25 @@ class TestCreateCaseOwnerParticipant:
         assert isinstance(
             conditional_selector.children[1], py_trees.behaviours.Success
         )
+
+    def test_records_owner_joined_event(
+        self,
+        bt_scenario: BTTestScenario,
+        actor: VultronCaseActor,
+        case_obj: VultronCase,
+        actor_id: str,
+    ) -> None:
+        """CreateCaseOwnerParticipant records 'owner_joined' on the case."""
+        result = bt_scenario.run(
+            CreateCaseOwnerParticipant(),
+            actor_id=actor_id,
+            case_id=case_obj.id_,
+        )
+        bt_scenario.assert_success(result)
+
+        stored_case = cast(Any, bt_scenario.dl.read(case_obj.id_))
+        event_types = [e.event_type for e in stored_case.events]
+        assert "owner_joined" in event_types
 
     def test_advances_owner_rm_to_accepted_when_configured(
         self,

--- a/test/core/behaviors/case/nodes/test_participant.py
+++ b/test/core/behaviors/case/nodes/test_participant.py
@@ -36,15 +36,21 @@ from vultron.core.behaviors.case.nodes import (
     _create_and_attach_participant,
 )
 from vultron.core.behaviors.case.nodes.participant import (
+    AdvanceOwnerRmToAcceptedNode,
+    AttachOwnerParticipantToCaseNode,
     AttachParticipantToCaseNode,
     CaseHasActiveEmbargoNode,
     CaseHasNoActiveEmbargoNode,
     CreateParticipantNode,
+    CreateOwnerParticipantNode,
+    PersistOwnerCaseNode,
     QueueAddParticipantNotificationNode,
     RecordParticipantAddedEventNode,
     ResolveParticipantAcceptedStatusNode,
+    ResolveOwnerInitialStatusNode,
     SeedParticipantAsSignatoryIfEmbargoActiveNode,
     SeedParticipantAsSignatoryNode,
+    ShouldAdvanceOwnerToAcceptedNode,
 )
 from vultron.core.models.embargo_event import EmbargoEvent
 from vultron.core.models.actor_config import ActorConfig
@@ -55,6 +61,7 @@ from vultron.core.models.vultron_types import (
     VultronReport,
 )
 from vultron.core.states.participant_embargo_consent import PEC
+from vultron.core.states.rm import RM
 from vultron.core.states.roles import CVDRole
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Add
 from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
@@ -352,6 +359,53 @@ class TestCreateCaseOwnerParticipant:
                 assert CVDRole.COORDINATOR in participant.case_roles
                 return
         pytest.fail("No participant found for actor")
+
+    def test_is_composed_subtree_of_named_leaf_nodes(self) -> None:
+        node = CreateCaseOwnerParticipant()
+        assert isinstance(node, py_trees.composites.Sequence)
+        assert [type(child) for child in node.children[:4]] == [
+            ResolveOwnerInitialStatusNode,
+            CreateOwnerParticipantNode,
+            AttachOwnerParticipantToCaseNode,
+            PersistOwnerCaseNode,
+        ]
+        assert isinstance(node.children[4], py_trees.composites.Selector)
+
+        conditional_selector = node.children[4]
+        assert isinstance(
+            conditional_selector.children[0], py_trees.composites.Sequence
+        )
+        assert [
+            type(child) for child in conditional_selector.children[0].children
+        ] == [
+            ShouldAdvanceOwnerToAcceptedNode,
+            AdvanceOwnerRmToAcceptedNode,
+        ]
+        assert isinstance(
+            conditional_selector.children[1], py_trees.behaviours.Success
+        )
+
+    def test_advances_owner_rm_to_accepted_when_configured(
+        self,
+        bt_scenario: BTTestScenario,
+        actor: VultronCaseActor,
+        case_obj: VultronCase,
+        actor_id: str,
+    ) -> None:
+        result = bt_scenario.run(
+            CreateCaseOwnerParticipant(advance_to_accepted=True),
+            actor_id=actor_id,
+            case_id=case_obj.id_,
+        )
+        bt_scenario.assert_success(result)
+
+        stored_case = cast(Any, bt_scenario.dl.read(case_obj.id_))
+        participant_id = stored_case.actor_participant_index[actor_id]
+        participant = cast(Any, bt_scenario.dl.read(participant_id))
+        rm_states = [
+            status.rm_state for status in participant.participant_statuses
+        ]
+        assert RM.ACCEPTED in rm_states
 
 
 # ---------------------------------------------------------------------------

--- a/vultron/core/behaviors/case/nodes/__init__.py
+++ b/vultron/core/behaviors/case/nodes/__init__.py
@@ -57,6 +57,7 @@ from vultron.core.behaviors.case.nodes.participant import (
     CreateCaseOwnerParticipant,
     CreateCaseParticipantNode,
     CreateParticipantStatusNode,
+    RecordOwnerJoinedEventNode,
     _create_and_attach_participant,
     resolve_participant_state_from_dl,
 )
@@ -83,6 +84,7 @@ __all__ = [
     "CreateCaseOwnerParticipant",
     "CreateCaseParticipantNode",
     "CreateParticipantStatusNode",
+    "RecordOwnerJoinedEventNode",
     "_create_and_attach_participant",
     "resolve_participant_state_from_dl",
     # embargo

--- a/vultron/core/behaviors/case/nodes/case_setup.py
+++ b/vultron/core/behaviors/case/nodes/case_setup.py
@@ -23,6 +23,7 @@ service actor.
 Per specs/case-management.yaml CM-02 requirements.
 """
 
+import hashlib
 from typing import Any
 
 import py_trees
@@ -37,6 +38,23 @@ from vultron.core.models.vultron_types import (
 )
 from vultron.core.states.roles import CVDRole
 from vultron.core.use_cases._helpers import _as_id
+
+
+def _derive_case_slug(case_id: str) -> str:
+    """Derive a short deterministic slug from case_id."""
+    if case_id.startswith("urn:uuid:"):
+        return case_id[len("urn:uuid:") :]
+    return hashlib.sha256(case_id.encode()).hexdigest()[:12]
+
+
+def _resolve_server_base_url(blackboard: Any) -> str:
+    """Read server_base_url from blackboard or fall back to config."""
+    try:
+        return str(blackboard.get("server_base_url")).rstrip("/")
+    except KeyError:
+        from vultron.config import get_config
+
+        return get_config().server.base_url.rstrip("/")
 
 
 class PersistCase(DataLayerAction):
@@ -230,39 +248,26 @@ class RecordCaseCreatedEventNode(DataLayerAction):
         return Status.SUCCESS
 
 
-class CreateCaseActorNode(DataLayerAction):
-    """
-    Create a CaseActor (Service) for the new VulnerabilityCase.
+class ResolveCaseActorUrlsNode(DataLayerAction):
+    """Resolve case_id + deterministic CaseActor IDs and publish to blackboard."""
 
-    Each VulnerabilityCase MUST have exactly one associated CaseActor.
-    The CaseActor is an ActivityStreams Service that manages case
-    communications (inbox/outbox).
-
-    When ``case_id`` is not supplied at construction time the node reads
-    ``case_id`` from the blackboard (written by a preceding
-    ``CreateCaseNode``).  After the CaseActor is created its ID is written
-    to the blackboard as ``case_actor_id`` so that subsequent nodes (e.g.
-    ``SendOfferCaseManagerRoleNode``) can address it without a DataLayer
-    scan.
-
-    Per specs/case-management.yaml CM-02-001.
-    """
-
-    def __init__(
-        self,
-        case_id: str | None = None,
-        name: str | None = None,
-    ):
+    def __init__(self, case_id: str | None = None, name: str | None = None):
         super().__init__(name=name or self.__class__.__name__)
         self._case_id_arg = case_id
 
     def setup(self, **kwargs: Any) -> None:
-        """Register blackboard keys including optional case_id read."""
         super().setup(**kwargs)
         if self._case_id_arg is None:
             self.blackboard.register_key(
                 key="case_id", access=py_trees.common.Access.READ
             )
+        else:
+            self.blackboard.register_key(
+                key="case_id", access=py_trees.common.Access.WRITE
+            )
+        self.blackboard.register_key(
+            key="server_base_url", access=py_trees.common.Access.READ
+        )
         self.blackboard.register_key(
             key="case_actor_id", access=py_trees.common.Access.WRITE
         )
@@ -270,135 +275,182 @@ class CreateCaseActorNode(DataLayerAction):
             key="case_actor_participant_id",
             access=py_trees.common.Access.WRITE,
         )
-        self.blackboard.register_key(
-            key="server_base_url", access=py_trees.common.Access.READ
-        )
-
-    def _derive_case_slug(self, case_id: str) -> str:
-        """Derive a short deterministic slug from case_id."""
-        import hashlib
-
-        if case_id.startswith("urn:uuid:"):
-            return case_id[len("urn:uuid:") :]
-        return hashlib.sha256(case_id.encode()).hexdigest()[:12]
-
-    def _resolve_server_base_url(self) -> str:
-        """Read server_base_url from blackboard or fall back to config."""
-        try:
-            return str(self.blackboard.get("server_base_url")).rstrip("/")
-        except KeyError:
-            from vultron.config import get_config
-
-            return get_config().server.base_url.rstrip("/")
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.logger.error(
-                f"{self.name}: DataLayer or actor_id not available"
-            )
-            return Status.FAILURE
-
         case_id = self._case_id_arg
         if case_id is None:
-            case_id = self.blackboard.get("case_id")
-        if not case_id:
+            try:
+                case_id = self.blackboard.get("case_id")
+            except KeyError:
+                case_id = None
+        if not isinstance(case_id, str) or case_id == "":
             self.logger.error(
-                f"{self.name}: case_id not available from constructor"
-                " or blackboard"
+                "%s: case_id not available from constructor or blackboard",
+                self.name,
             )
             return Status.FAILURE
 
-        # Use deterministic IDs so re-runs are idempotent.
-        # Derive a short slug from the case_id to create a flat,
-        # HTTP-routable actor ID.
-        case_slug = self._derive_case_slug(case_id)
-        server_base_url = self._resolve_server_base_url()
-
+        case_slug = _derive_case_slug(case_id)
+        server_base_url = _resolve_server_base_url(self.blackboard)
         case_actor_id = f"{server_base_url}/actors/case-actor-{case_slug}"
         participant_id = (
             f"{server_base_url}/actors/case-actor-{case_slug}/participant"
         )
 
-        try:
-            # Idempotency: if the participant already exists use its
-            # attributed_to as the authoritative actor ID so downstream nodes
-            # always get a consistent value regardless of re-execution order.
-            existing_participant = self.datalayer.read(participant_id)
-            if existing_participant is not None:
-                authoritative_id = (
-                    _as_id(
-                        getattr(existing_participant, "attributed_to", None)
-                    )
-                    or case_actor_id
-                )
-                self.blackboard.case_actor_id = authoritative_id
-                self.blackboard.case_actor_participant_id = participant_id
-                self.logger.info(
-                    f"{self.name}: CaseActor participant already registered;"
-                    f" reusing id '{authoritative_id}'"
-                )
-                return Status.SUCCESS
+        if self._case_id_arg is not None:
+            self.blackboard.case_id = case_id
+        self.blackboard.case_actor_id = case_actor_id
+        self.blackboard.case_actor_participant_id = participant_id
+        return Status.SUCCESS
 
-            case_actor = VultronCaseActor(
-                id_=case_actor_id,
-                name=f"CaseActor for {case_id}",
-                attributed_to=self.actor_id,
-                context=case_id,
+
+class ReuseExistingCaseActorParticipantNode(DataLayerAction):
+    """Idempotency guard: succeed if CaseActor participant already exists."""
+
+    def __init__(self, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="case_actor_id", access=py_trees.common.Access.WRITE
+        )
+        self.blackboard.register_key(
+            key="case_actor_participant_id",
+            access=py_trees.common.Access.READ,
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.logger.error("%s: DataLayer not available", self.name)
+            return Status.FAILURE
+        participant_id = self.blackboard.get("case_actor_participant_id")
+        case_actor_id = self.blackboard.get("case_actor_id")
+        if not isinstance(participant_id, str) or not isinstance(
+            case_actor_id, str
+        ):
+            self.logger.error(
+                "%s: case_actor ids missing in blackboard",
+                self.name,
             )
-            try:
-                self.datalayer.create(case_actor)
-                self.logger.info(
-                    f"{self.name}: Created CaseActor {case_actor_id}"
-                    f" for case {case_id}"
-                )
-            except ValueError as e:
-                self.logger.warning(
-                    f"{self.name}: CaseActor {case_actor_id}"
-                    f" already exists: {e}"
-                )
-
-            # Register the CaseActor as a CaseActorParticipant so receivers
-            # can extract trusted_case_actor_id from the case snapshot during
-            # bootstrap trust establishment (CBT-01-003).
-            self._register_case_actor_participant(
-                case_id, case_actor_id, participant_id
-            )
-
-            # Publish IDs to the blackboard for downstream nodes.
-            self.blackboard.case_actor_id = case_actor_id
-            self.blackboard.case_actor_participant_id = participant_id
-
-            return Status.SUCCESS
-
-        except Exception as e:
-            self.logger.error(f"{self.name}: Error creating CaseActor: {e}")
             return Status.FAILURE
 
-    def _register_case_actor_participant(
-        self, case_id: str, case_actor_id: str, participant_id: str
-    ) -> None:
-        """Add a VultronParticipant with COORDINATOR+CASE_MANAGER roles to the case.
+        existing_participant = self.datalayer.read(participant_id)
+        if existing_participant is None:
+            return Status.FAILURE
 
-        Uses core-layer ``VultronParticipant`` with both roles set so the
-        bootstrap receiver can identify the CaseActor from the case snapshot
-        without requiring a wire-layer import (CBT-01-003).
-        """
+        authoritative_id = (
+            _as_id(getattr(existing_participant, "attributed_to", None))
+            or case_actor_id
+        )
+        self.blackboard.case_actor_id = authoritative_id
+        self.logger.info(
+            "%s: CaseActor participant already registered; reusing id '%s'",
+            self.name,
+            authoritative_id,
+        )
+        return Status.SUCCESS
+
+
+class CreateCaseActorServiceNode(DataLayerAction):
+    """Create (or reuse) the CaseActor service object."""
+
+    def __init__(self, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="case_id", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="case_actor_id", access=py_trees.common.Access.READ
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None or self.actor_id is None:
+            self.logger.error(
+                "%s: DataLayer or actor_id not available",
+                self.name,
+            )
+            return Status.FAILURE
+        case_id = self.blackboard.get("case_id")
+        case_actor_id = self.blackboard.get("case_actor_id")
+        if not isinstance(case_id, str) or not isinstance(case_actor_id, str):
+            self.logger.error("%s: case_id/case_actor_id missing", self.name)
+            return Status.FAILURE
+
+        case_actor = VultronCaseActor(
+            id_=case_actor_id,
+            name=f"CaseActor for {case_id}",
+            attributed_to=self.actor_id,
+            context=case_id,
+        )
+        try:
+            self.datalayer.create(case_actor)
+            self.logger.info(
+                "%s: Created CaseActor %s for case %s",
+                self.name,
+                case_actor_id,
+                case_id,
+            )
+        except ValueError as e:
+            self.logger.warning(
+                "%s: CaseActor %s already exists: %s",
+                self.name,
+                case_actor_id,
+                e,
+            )
+        return Status.SUCCESS
+
+
+class RegisterCaseActorParticipantNode(DataLayerAction):
+    """Attach the CaseActor participant to the case when absent."""
+
+    def __init__(self, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="case_id", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="case_actor_id", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="case_actor_participant_id",
+            access=py_trees.common.Access.READ,
+        )
+
+    def update(self) -> Status:
         if self.datalayer is None:
-            return
+            self.logger.error("%s: DataLayer not available", self.name)
+            return Status.FAILURE
+
+        case_id = self.blackboard.get("case_id")
+        case_actor_id = self.blackboard.get("case_actor_id")
+        participant_id = self.blackboard.get("case_actor_participant_id")
+        if (
+            not isinstance(case_id, str)
+            or not isinstance(case_actor_id, str)
+            or not isinstance(participant_id, str)
+        ):
+            self.logger.error("%s: CaseActor context missing", self.name)
+            return Status.FAILURE
 
         case = self.datalayer.read(case_id)
         if not is_case_model(case):
             self.logger.warning(
-                f"{self.name}: Case '{case_id}' not found; "
-                "cannot register CaseActor participant"
+                "%s: Case '%s' not found; cannot register CaseActor participant",
+                self.name,
+                case_id,
             )
-            return
+            return Status.SUCCESS
 
         existing = self.datalayer.read(participant_id)
         if existing is not None:
-            # Already registered; participant was checked in update() so this
-            # path is only reached on a race condition — safe to skip.
-            return
+            return Status.SUCCESS
 
         participant = VultronParticipant(
             id_=participant_id,
@@ -410,11 +462,45 @@ class CreateCaseActorNode(DataLayerAction):
         try:
             self.datalayer.create(participant)
         except ValueError:
-            pass  # already exists — idempotent
-
+            pass
         case.add_participant(participant)
         self.datalayer.save(case)
         self.logger.info(
-            f"{self.name}: Registered CaseActor participant '{participant_id}'"
-            f" (roles: COORDINATOR, CASE_MANAGER) for case '{case_id}'"
+            "%s: Registered CaseActor participant '%s' for case '%s'",
+            self.name,
+            participant_id,
+            case_id,
+        )
+        return Status.SUCCESS
+
+
+class CreateCaseActorNode(py_trees.composites.Sequence):
+    """
+    Composed subtree that creates and registers the CaseActor for a case.
+
+    Per specs/case-management.yaml CM-02-001 and BTND-07-001.
+    """
+
+    def __init__(self, case_id: str | None = None, name: str | None = None):
+        super().__init__(
+            name=name or self.__class__.__name__,
+            memory=False,
+            children=[
+                ResolveCaseActorUrlsNode(case_id=case_id),
+                py_trees.composites.Selector(
+                    name="EnsureCaseActorRegistered",
+                    memory=False,
+                    children=[
+                        ReuseExistingCaseActorParticipantNode(),
+                        py_trees.composites.Sequence(
+                            name="CreateAndRegisterCaseActor",
+                            memory=False,
+                            children=[
+                                CreateCaseActorServiceNode(),
+                                RegisterCaseActorParticipantNode(),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
         )

--- a/vultron/core/behaviors/case/nodes/case_setup.py
+++ b/vultron/core/behaviors/case/nodes/case_setup.py
@@ -441,12 +441,12 @@ class RegisterCaseActorParticipantNode(DataLayerAction):
 
         case = self.datalayer.read(case_id)
         if not is_case_model(case):
-            self.logger.warning(
+            self.logger.error(
                 "%s: Case '%s' not found; cannot register CaseActor participant",
                 self.name,
                 case_id,
             )
-            return Status.SUCCESS
+            return Status.FAILURE
 
         existing = self.datalayer.read(participant_id)
         if existing is not None:

--- a/vultron/core/behaviors/case/nodes/participant.py
+++ b/vultron/core/behaviors/case/nodes/participant.py
@@ -170,37 +170,6 @@ def _effective_case_roles(actor_config: ActorConfig | None) -> list[CVDRole]:
     return list(dict.fromkeys(base_roles + [CVDRole.CASE_OWNER]))
 
 
-def _save_owner_case(
-    dl: CasePersistence,
-    stored_case: CaseModel,
-    case_id: str,
-    actor_id: str,
-    advance_to_accepted: bool,
-    node_name: str,
-    node_logger: logging.Logger,
-) -> None:
-    dl.save(stored_case)
-    if not advance_to_accepted:
-        return
-
-    advanced = update_participant_rm_state(case_id, actor_id, RM.ACCEPTED, dl)
-    if advanced:
-        node_logger.info(
-            "Owner RM: VALID → ACCEPTED for actor '%s' in case '%s' "
-            "(case creation = case engagement)",
-            actor_id,
-            case_id,
-        )
-        return
-
-    node_logger.warning(
-        "%s: Could not advance owner RM to ACCEPTED for actor '%s' in case '%s'",
-        node_name,
-        actor_id,
-        case_id,
-    )
-
-
 def _get_or_create_accepted_status(
     dl: CasePersistence,
     actor_id: str,
@@ -329,34 +298,278 @@ def _queue_participant_add_notification(
 # ============================================================================
 
 
-class CreateCaseOwnerParticipant(DataLayerAction):
+class ResolveOwnerInitialStatusNode(DataLayerAction):
+    """Resolve/create the owner's initial ParticipantStatus."""
+
+    def __init__(
+        self,
+        report_id: str | None,
+        case_obj: VultronCase | None,
+        initial_rm_state: RM,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self.report_id = report_id
+        self.case_obj = case_obj
+        self.initial_rm_state = initial_rm_state
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="case_id", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="owner_initial_status", access=py_trees.common.Access.WRITE
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None or self.actor_id is None:
+            self.logger.error(
+                "%s: DataLayer or actor_id not available",
+                self.name,
+            )
+            return Status.FAILURE
+
+        try:
+            case_id = _resolve_case_id(self.blackboard, self.case_obj)
+        except KeyError:
+            case_id = None
+        if case_id is None:
+            self.logger.error("%s: case_id not available", self.name)
+            return Status.FAILURE
+
+        self.blackboard.owner_initial_status = _build_owner_initial_status(
+            self.datalayer,
+            self.actor_id,
+            case_id,
+            self.report_id,
+            self.initial_rm_state,
+        )
+        return Status.SUCCESS
+
+
+class CreateOwnerParticipantNode(DataLayerAction):
+    """Create the in-memory owner participant and stage it on blackboard."""
+
+    def __init__(
+        self,
+        actor_config: ActorConfig | None,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self.actor_config = actor_config
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="case_id", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="owner_initial_status", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="new_case_participant",
+            access=py_trees.common.Access.WRITE,
+        )
+
+    def update(self) -> Status:
+        if self.actor_id is None:
+            self.logger.error("%s: actor_id not available", self.name)
+            return Status.FAILURE
+        try:
+            case_id_obj = self.blackboard.get("case_id")
+        except KeyError:
+            case_id_obj = None
+        initial_status = self.blackboard.get("owner_initial_status")
+        if not isinstance(initial_status, ParticipantStatus):
+            self.logger.error(
+                "%s: case_id/owner_initial_status missing in blackboard",
+                self.name,
+            )
+            return Status.FAILURE
+        case_id = case_id_obj
+        if not isinstance(case_id, str):
+            status_context = _as_id(initial_status.context)
+            case_id = status_context if status_context is not None else None
+        if case_id is None:
+            self.logger.error("%s: case_id not available", self.name)
+            return Status.FAILURE
+
+        self.blackboard.new_case_participant = VultronParticipant(
+            attributed_to=self.actor_id,
+            context=case_id,
+            case_roles=_effective_case_roles(self.actor_config),
+            participant_statuses=[initial_status],
+        )
+        return Status.SUCCESS
+
+
+class AttachOwnerParticipantToCaseNode(DataLayerAction):
+    """Persist and attach staged owner participant to the case."""
+
+    def __init__(self, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="case_id", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="new_case_participant",
+            access=py_trees.common.Access.READ,
+        )
+        self.blackboard.register_key(
+            key="participant_case", access=py_trees.common.Access.WRITE
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None or self.actor_id is None:
+            self.logger.error(
+                "%s: DataLayer or actor_id not available",
+                self.name,
+            )
+            return Status.FAILURE
+        try:
+            case_id_obj = self.blackboard.get("case_id")
+        except KeyError:
+            case_id_obj = None
+        participant = self.blackboard.get("new_case_participant")
+        if not isinstance(participant, VultronParticipant):
+            self.logger.error(
+                "%s: case_id/new_case_participant missing in blackboard",
+                self.name,
+            )
+            return Status.FAILURE
+        case_id = case_id_obj
+        if not isinstance(case_id, str):
+            case_id = _as_id(participant.context)
+        if case_id is None:
+            self.logger.error("%s: case_id not available", self.name)
+            return Status.FAILURE
+
+        stored_case = _create_and_attach_participant(
+            self.datalayer,
+            participant,
+            case_id,
+            self.actor_id,
+            self.logger,
+        )
+        if stored_case is None:
+            self.logger.error(
+                "%s: Case %s not found in DataLayer",
+                self.name,
+                case_id,
+            )
+            return Status.FAILURE
+
+        self.blackboard.participant_case = stored_case
+        return Status.SUCCESS
+
+
+class PersistOwnerCaseNode(DataLayerAction):
+    """Persist the updated case after owner participant attachment."""
+
+    def __init__(self, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="participant_case", access=py_trees.common.Access.READ
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.logger.error("%s: DataLayer not available", self.name)
+            return Status.FAILURE
+        stored_case = self.blackboard.get("participant_case")
+        if not is_case_model(stored_case):
+            self.logger.error(
+                "%s: participant_case missing in blackboard",
+                self.name,
+            )
+            return Status.FAILURE
+        self.datalayer.save(stored_case)
+        return Status.SUCCESS
+
+
+class ShouldAdvanceOwnerToAcceptedNode(py_trees.behaviour.Behaviour):
+    """Condition leaf for owner RM advancement branch selection."""
+
+    def __init__(
+        self, advance_to_accepted: bool, name: str | None = None
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._advance_to_accepted = advance_to_accepted
+
+    def update(self) -> Status:
+        return Status.SUCCESS if self._advance_to_accepted else Status.FAILURE
+
+
+class AdvanceOwnerRmToAcceptedNode(DataLayerAction):
+    """Advance owner RM to ACCEPTED when case creation means engagement."""
+
+    def __init__(self, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="case_id", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="participant_case", access=py_trees.common.Access.READ
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None or self.actor_id is None:
+            self.logger.error(
+                "%s: DataLayer or actor_id not available",
+                self.name,
+            )
+            return Status.FAILURE
+        try:
+            case_id_obj = self.blackboard.get("case_id")
+        except KeyError:
+            case_id_obj = None
+        case_id = case_id_obj if isinstance(case_id_obj, str) else None
+        if case_id is None:
+            stored_case = self.blackboard.get("participant_case")
+            case_id = stored_case.id_ if is_case_model(stored_case) else None
+        if case_id is None:
+            self.logger.error("%s: case_id not available", self.name)
+            return Status.FAILURE
+
+        advanced = update_participant_rm_state(
+            case_id,
+            self.actor_id,
+            RM.ACCEPTED,
+            self.datalayer,
+        )
+        if advanced:
+            self.logger.info(
+                "Owner RM: VALID → ACCEPTED for actor '%s' in case '%s' "
+                "(case creation = case engagement)",
+                self.actor_id,
+                case_id,
+            )
+        else:
+            self.logger.warning(
+                "%s: Could not advance owner RM to ACCEPTED for actor '%s'"
+                " in case '%s'",
+                self.name,
+                self.actor_id,
+                case_id,
+            )
+        return Status.SUCCESS
+
+
+class CreateCaseOwnerParticipant(py_trees.composites.Sequence):
     """
-    Create and persist a case-owner participant for the receiving actor,
-    then add it to the case's case_participants list.
+    Composed subtree that creates and attaches the case-owner participant.
 
-    Roles are sourced from ``actor_config.default_case_roles``
-    (CFG-07-004); ``CVDRole.CASE_OWNER`` is always appended
-    (BTND-05-002).  When ``actor_config`` is ``None`` the participant
-    receives only the ``CASE_OWNER`` role.
-
-    Seeds the participant with the deterministic status record for the
-    given ``initial_rm_state`` (defaulting to ``RM.VALID``). When
-    ``report_id`` is provided, the node first looks for an existing status
-    record in the DataLayer (created by an earlier use case) and reuses it
-    to avoid duplicating history. If no existing record is found, a fresh
-    ``ParticipantStatus`` is created.
-
-    Optionally advances the actor's RM to ACCEPTED
-    (``advance_to_accepted=True``) after the participant is created — use
-    this in the validate-report BT where case creation is the act of
-    engaging the case.
-
-    Must run after the case exists in the DataLayer (``PersistCase`` or
-    ``CreateCaseNode``).
-
-    Per specs/case-management.yaml CM-02-008 (SHOULD),
-    specs/behavior-tree-node-design.yaml BTND-05-002 (MUST), and
-    specs/configuration.yaml CFG-07-004 (MUST).
+    Per specs/case-management.yaml CM-02-008, BTND-05-002, and BTND-07-001.
     """
 
     def __init__(
@@ -368,75 +581,37 @@ class CreateCaseOwnerParticipant(DataLayerAction):
         initial_rm_state: RM = RM.VALID,
         name: str | None = None,
     ):
-        super().__init__(name=name or self.__class__.__name__)
-        self.actor_config = actor_config
-        self.report_id = report_id
-        self.case_obj = case_obj
-        self.advance_to_accepted = advance_to_accepted
-        self.initial_rm_state = initial_rm_state
-
-    def setup(self, **kwargs: Any) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="case_id", access=py_trees.common.Access.READ
+        super().__init__(
+            name=name or self.__class__.__name__,
+            memory=False,
+            children=[
+                ResolveOwnerInitialStatusNode(
+                    report_id=report_id,
+                    case_obj=case_obj,
+                    initial_rm_state=initial_rm_state,
+                ),
+                CreateOwnerParticipantNode(actor_config=actor_config),
+                AttachOwnerParticipantToCaseNode(),
+                PersistOwnerCaseNode(),
+                py_trees.composites.Selector(
+                    name="AdvanceOwnerRmIfConfigured",
+                    memory=False,
+                    children=[
+                        py_trees.composites.Sequence(
+                            name="AdvanceOwnerRmBranch",
+                            memory=False,
+                            children=[
+                                ShouldAdvanceOwnerToAcceptedNode(
+                                    advance_to_accepted=advance_to_accepted
+                                ),
+                                AdvanceOwnerRmToAcceptedNode(),
+                            ],
+                        ),
+                        py_trees.behaviours.Success(name="SkipAdvanceOwnerRm"),
+                    ],
+                ),
+            ],
         )
-
-    def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.logger.error(
-                f"{self.name}: DataLayer or actor_id not available"
-            )
-            return Status.FAILURE
-
-        try:
-            case_id = _resolve_case_id(self.blackboard, self.case_obj)
-            if case_id is None:
-                self.logger.error(f"{self.name}: case_id not available")
-                return Status.FAILURE
-
-            initial_status = _build_owner_initial_status(
-                self.datalayer,
-                self.actor_id,
-                case_id,
-                self.report_id,
-                self.initial_rm_state,
-            )
-            participant = VultronParticipant(
-                attributed_to=self.actor_id,
-                context=case_id,
-                case_roles=_effective_case_roles(self.actor_config),
-                participant_statuses=[initial_status],
-            )
-
-            stored_case = _create_and_attach_participant(
-                self.datalayer,
-                participant,
-                case_id,
-                self.actor_id,
-                self.logger,
-            )
-            if stored_case is None:
-                self.logger.error(
-                    f"{self.name}: Case {case_id} not found in DataLayer"
-                )
-                return Status.FAILURE
-
-            _save_owner_case(
-                self.datalayer,
-                stored_case,
-                case_id,
-                self.actor_id,
-                self.advance_to_accepted,
-                self.name,
-                self.logger,
-            )
-            return Status.SUCCESS
-
-        except Exception as e:
-            self.logger.error(
-                f"{self.name}: Error creating case-owner participant: {e}"
-            )
-            return Status.FAILURE
 
 
 class ResolveParticipantAcceptedStatusNode(DataLayerAction):

--- a/vultron/core/behaviors/case/nodes/participant.py
+++ b/vultron/core/behaviors/case/nodes/participant.py
@@ -565,6 +565,51 @@ class AdvanceOwnerRmToAcceptedNode(DataLayerAction):
         return Status.SUCCESS
 
 
+class RecordOwnerJoinedEventNode(DataLayerAction):
+    """Record owner_joined event and persist the case update.
+
+    Per notes/bt-integration.md, all protocol-significant behavior MUST be in
+    the BT.  This node records the case history event for the owner's initial
+    participation, analogous to ``RecordParticipantAddedEventNode`` in the
+    non-owner path (CM-02-008).
+    """
+
+    def __init__(self, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="participant_case",
+            access=py_trees.common.Access.READ,
+        )
+        self.blackboard.register_key(
+            key="new_case_participant",
+            access=py_trees.common.Access.READ,
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.logger.error("%s: DataLayer not available", self.name)
+            return Status.FAILURE
+
+        stored_case = self.blackboard.get("participant_case")
+        participant = self.blackboard.get("new_case_participant")
+        if not is_case_model(stored_case) or not isinstance(
+            participant, VultronParticipant
+        ):
+            self.logger.error(
+                "%s: participant_case/new_case_participant missing in"
+                " blackboard",
+                self.name,
+            )
+            return Status.FAILURE
+
+        stored_case.record_event(participant.id_, "owner_joined")
+        self.datalayer.save(stored_case)
+        return Status.SUCCESS
+
+
 class CreateCaseOwnerParticipant(py_trees.composites.Sequence):
     """
     Composed subtree that creates and attaches the case-owner participant.
@@ -593,6 +638,7 @@ class CreateCaseOwnerParticipant(py_trees.composites.Sequence):
                 CreateOwnerParticipantNode(actor_config=actor_config),
                 AttachOwnerParticipantToCaseNode(),
                 PersistOwnerCaseNode(),
+                RecordOwnerJoinedEventNode(),
                 py_trees.composites.Selector(
                     name="AdvanceOwnerRmIfConfigured",
                     memory=False,


### PR DESCRIPTION
- Closes #714

## Summary

This decomposes the remaining in-scope god nodes from #714 into explicit composed BT subtrees while preserving idempotent behavior and existing case-creation call paths.

## Changes

- vultron/core/behaviors/case/nodes/case_setup.py: replaced monolithic CreateCaseActorNode.update() with a composed subtree of named leaves for URL resolution, idempotency reuse, service creation, and participant registration.
- vultron/core/behaviors/case/nodes/participant.py: replaced monolithic CreateCaseOwnerParticipant.update() with a composed subtree and explicit conditional RM-advance branch nodes.
- test/core/behaviors/case/nodes/test_case_setup.py: added subtree-composition assertions for CreateCaseActorNode.
- test/core/behaviors/case/nodes/test_participant.py: added subtree-composition assertions and advance_to_accepted behavior coverage for CreateCaseOwnerParticipant.
- plan/BUILD_LEARNINGS.md: recorded ISSUE-714 decomposition pitfall about preserving alternate context seams.

## Verification

- 3148 passed, 14 skipped, 219 deselected, 5633 subtests passed (uv run pytest --tb=short 2>&1 | tail -5)
- Black, flake8, mypy, and pyright clean
