### PR TITLE
docs: plan #893/#894 — Invite/Accept routing and received-side identity-spoofing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -417,6 +417,25 @@ Short entries are reproduced here; longer ones are referenced below.
   (PCR-08-001, PCR-08-002). `case_addressees()` is correct only on the Case Actor's
   **outbound fan-out** side (broadcasting to all participants). See
   [notes/case-communication-model.md](notes/case-communication-model.md).
+- **Received-Side Use Cases MUST NOT Spoof Another Actor's Identity** — A received-side
+  use case runs in one actor's DataLayer context. It MUST NOT build an ActivityStreams
+  activity with `actor` set to a different actor's ID, and MUST NOT execute a Behavior
+  Tree with `actor_id` set to any actor other than the one whose DataLayer is active.
+  Example violation: `AcceptInviteActorToCaseReceivedUseCase` (running on the Case Actor)
+  calling `PrioritizeBT(actor_id=invitee_id)` — the BT emits `RmEngageCaseActivity` as if
+  from the invitee and transitions their RM state from the wrong DataLayer context. The
+  correct fix is an inline RM state update on the receiving actor's DataLayer; the
+  `Accept(Invite)` message IS the invitee's engage decision (PCR-08-009, PCR-08-010).
+  See [notes/case-communication-model.md](notes/case-communication-model.md)
+  § "Antipattern: Identity Spoofing in Received-Side Use Cases".
+- **Invite/Accept Handshake Must Route Through the Case Actor** — `RmInviteToCaseActivity`
+  MUST be sent with `actor=case_actor_id` (not the case owner) from the Case Actor's
+  outbox. The invitee's `Accept` MUST be addressed to the Case Actor, not the case owner.
+  The "owner triggers, Case Actor executes" pattern applies: `SvcInviteActorToCaseUseCase`
+  resolves the Case Actor ID, builds the Invite with `actor=case_actor_id` (optionally
+  `attributedTo=case_owner_id`), and places it in the Case Actor's outbox (PCR-08-007,
+  PCR-08-008). See [notes/case-communication-model.md](notes/case-communication-model.md)
+  § "Invite/Accept Handshake Routing".
 - **Close Bugs With Evidence, Not Assumption** — see [notes/bt-integration.md](notes/bt-integration.md)
 - **Use `isinstance` for Pyright Attribute Narrowing, Not `# type: ignore`** — see [`vultron/core/AGENTS.md`](vultron/core/AGENTS.md)
 - **Untyped Closures Are Invisible to mypy — Extract to Named Functions** — see [`vultron/core/AGENTS.md`](vultron/core/AGENTS.md)

--- a/notes/case-communication-model.md
+++ b/notes/case-communication-model.md
@@ -67,6 +67,7 @@ of authoritative case history.
 |---|---|
 | **Before case creation** | Finder sends `Offer(Report)` directly to Vendor — no Case Actor exists yet. This direct peer message is the **only** exception. |
 | **Case creation / bootstrap** | Vendor sends `Create(VulnerabilityCase)` to Finder to introduce the Case Actor. This is the trust-bootstrap handshake (one-time exception). |
+| **Inviting a new participant** | See [Invite/Accept Handshake Routing](#inviteaccept-handshake-routing) below. The Case Actor sends `Invite` on the owner's behalf and processes `Accept`. |
 | **After case is active** | ALL subsequent messages from any participant go to the Case Actor only. No direct peer messaging. |
 
 ---
@@ -189,7 +190,87 @@ the recipient when building outbound participant activities.
 
 ---
 
-## Known Implementation Gaps (as of 2026-05-21)
+## Invite/Accept Handshake Routing
+
+Adding a new participant to an active case uses `RmInviteToCaseActivity` /
+`RmAcceptInviteToCaseActivity`. Because the invitee is not yet a participant,
+the standard CaseActor → broadcast model cannot be used to deliver the invite.
+However, the Case Actor MUST still be the authoritative actor in the exchange.
+
+### Correct Flow
+
+```text
+Case Owner triggers SvcInviteActorToCaseUseCase
+  → Case Actor sends Invite(actor=case_actor_id, attributedTo=case_owner_id)
+    → Invitee's inbox
+
+Invitee sends Accept(Invite, actor=invitee_id, to=[case_actor_id])
+  → Case Actor's inbox (NOT the case owner's inbox)
+
+Case Actor's AcceptInviteActorToCaseReceivedUseCase:
+  1. Creates VultronParticipant at RM.VALID
+  2. Records RM VALID→ACCEPTED inline (Accept(Invite) IS the engage signal)
+  3. Emits Announce(VulnerabilityCase) to invitee
+  4. Commits CaseLogEntry → Announce(CaseLogEntry) broadcast
+```
+
+### Key Rules
+
+- `actor` on `RmInviteToCaseActivity` MUST be the **Case Actor's ID**.
+  `attributedTo` MAY carry the case owner's ID (PCR-08-007).
+- The invitee's `Accept` MUST be addressed **to the Case Actor**,
+  not to the case owner (PCR-08-008).
+- The Case Actor (not the case owner) MUST process the Accept and
+  record the invitee's RM transition (PCR-08-009).
+- No `RmEngageCaseActivity` is emitted on behalf of the invitee.
+  `Accept(Invite)` is semantically equivalent to engaging, so the
+  separate engage step is redundant.
+
+### Implementation Pattern: Owner Triggers, Case Actor Executes
+
+`SvcInviteActorToCaseUseCase` resolves the Case Actor ID, constructs the
+Invite with `actor=case_actor_id`, and places it in the **Case Actor's
+outbox** — not the case owner's outbox:
+
+```python
+case_actor_id = _find_case_actor_id(dl, case_id)
+activity_id = trigger_activity.invite_actor_to_case(
+    invitee_id=invitee_id,
+    case_id=case_id,
+    actor=case_actor_id,           # ← Case Actor sends
+    attributed_to=actor_id,        # ← Case Owner attribution
+    to=[invitee_id],
+)
+add_activity_to_outbox(case_actor_id, activity_id, dl)   # ← Case Actor outbox
+```
+
+---
+
+## Antipattern: Identity Spoofing in Received-Side Use Cases
+
+A received-side use case runs in one actor's DataLayer context. It MUST NOT
+construct activities or run BTs with `actor_id` set to a **different** actor.
+
+```python
+# ❌ WRONG — runs invitee's BT from the owner's DataLayer context
+bridge = BTBridge(datalayer=self._dl, ...)         # owner's DL
+tree = create_prioritize_subtree(actor_id=invitee_id)  # invitee's identity
+bridge.execute_with_setup(tree, actor_id=invitee_id)   # spoofed actor
+```
+
+```python
+# ✅ CORRECT — inline transition; no BT, no spoofed emit
+participant.append_rm_state(RM.ACCEPTED, actor=invitee_id, context=case_id)
+dl.save(participant)
+```
+
+The `Accept(Invite)` message is the invitee's engage decision. The Case Actor
+records that decision as a direct RM state update, without emitting a proxy
+`RmEngageCaseActivity` (PCR-08-010).
+
+---
+
+## Known Implementation Gaps (as of 2026-06-10)
 
 | Gap | Location | Status |
 |---|---|---|
@@ -198,5 +279,6 @@ the recipient when building outbound participant activities.
 | Engage/defer-case triggers send to all participants | `triggers/case.py:84,132` | Open |
 | No sender-side BTs | All of the above | Open — BT refactor issue |
 | Auto CaseLogEntry cascade not wired to all received handlers | Multiple | Open |
+| Invite sent from case owner (not Case Actor); Accept routed to owner | `triggers/actor.py`, `received/actor.py` | Open — tracked in #893/#894 |
 
 See GitHub issues under parent concern #593.

--- a/plan/history/2606/learning/CONCERN-893.md
+++ b/plan/history/2606/learning/CONCERN-893.md
@@ -1,0 +1,47 @@
+---
+source: CONCERN-893
+timestamp: '2026-06-10T21:12:10.998787+00:00'
+title: Invite/Accept routing and received-side identity spoofing
+type: learning
+---
+
+## Summary
+
+In `vultron/core/use_cases/received/actor.py`,
+`AcceptInviteActorToCaseReceivedUseCase.execute()` calls
+`create_prioritize_subtree(actor_id=invitee_id)` using the **case
+owner's** DataLayer and `trigger_activity`. This causes two violations:
+
+1. **Identity spoofing**: `EmitEngageCaseActivity` produces an
+   `RmEngageCaseActivity` with `actor=invitee_id` but authored by the
+   owner's factory.
+2. **PCR-model violation**: The invitee's RM state transition
+   (VALID → ACCEPTED) is authored by the owner, not the invitee
+   (PCR-08-001, PCR-08-002).
+
+During planning, a second entangled concern was identified (#894): the
+entire Invite/Accept handshake routes directly through the case owner,
+bypassing the Case Actor as the authoritative intermediary.
+
+## Protocol Design Decision
+
+The correct model is "owner triggers, Case Actor executes":
+
+- `SvcInviteActorToCaseUseCase` resolves the Case Actor ID and builds
+  `RmInviteToCaseActivity` with `actor=case_actor_id` (optionally
+  `attributedTo=case_owner_id`), placed in the Case Actor's outbox.
+- The invitee's `Accept` is addressed to the **Case Actor** inbox.
+- The Case Actor's `AcceptInviteActorToCaseReceivedUseCase` records the
+  invitee's RM VALID→ACCEPTED inline — no `PrioritizeBT`, no spoofed
+  emit. `Accept(Invite)` IS the engage decision.
+
+## Outcome
+
+**Resolved**: 2026-06-10 — implementation tracked in #896 (blocked by
+[#893](https://github.com/CERTCC/Vultron/issues/893) and
+[#894](https://github.com/CERTCC/Vultron/issues/894)).
+Docs PR: [#895](https://github.com/CERTCC/Vultron/pull/895).
+Spec: `specs/participant-case-replica.yaml` (PCR-08-007 through
+PCR-08-010, PCR-07-008).
+Notes: `notes/case-communication-model.md` § Invite/Accept Handshake
+Routing.

--- a/specs/participant-case-replica.yaml
+++ b/specs/participant-case-replica.yaml
@@ -223,6 +223,46 @@ groups:
     statement: >-
       Unit and integration tests MUST verify that a participant's outbound activity is addressed
       only to the Case Actor, and that no direct peer-to-peer delivery is attempted.
+  - id: PCR-08-007
+    priority: MUST
+    statement: >-
+      `RmInviteToCaseActivity` MUST be sent with `actor` set to the Case Actor's ID, not
+      the case owner's ID. The case owner triggers the invite action, but the Case Actor
+      MUST be the ActivityStreams actor performing the send. Optionally, `attributedTo` on
+      the activity MAY carry the case owner's ID to record who initiated the invitation.
+    relationships:
+    - rel_type: refines
+      spec_id: PCR-08-001
+  - id: PCR-08-008
+    priority: MUST
+    statement: >-
+      The invitee's `RmAcceptInviteToCaseActivity` MUST be addressed to the Case Actor
+      (not the case owner). The Case Actor is the authoritative recipient and processor of
+      all case-management handshake messages after case creation.
+    relationships:
+    - rel_type: refines
+      spec_id: PCR-08-001
+  - id: PCR-08-009
+    priority: MUST
+    statement: >-
+      The Case Actor MUST process `RmAcceptInviteToCaseActivity` and record the invitee's
+      RM state transition (VALID → ACCEPTED) in its own DataLayer. The case owner MUST NOT
+      author or emit any RM state-change activity on behalf of the invitee.
+    relationships:
+    - rel_type: refines
+      spec_id: PCR-08-001
+    - rel_type: refines
+      spec_id: PCR-08-003
+  - id: PCR-08-010
+    priority: MUST_NOT
+    statement: >-
+      A received-side use case MUST NOT construct or emit an ActivityStreams activity with
+      `actor` set to a different actor's ID (identity spoofing). It MUST NOT execute a
+      Behavior Tree with `actor_id` set to any actor other than the one whose DataLayer
+      is active for that use case invocation.
+    relationships:
+    - rel_type: refines
+      spec_id: PCR-08-001
 - id: PCR-07
   title: Testing
   specs:
@@ -263,3 +303,19 @@ groups:
       Integration tests MUST verify the late-joiner sequence: `Invite` → `Accept` → CaseActor
       sends `Announce(VulnerabilityCase)` to new participant → new participant creates local
       replica.
+  - id: PCR-07-008
+    priority: MUST
+    statement: >-
+      Integration tests MUST verify that `RmInviteToCaseActivity` carries `actor` set to the
+      Case Actor's ID, and that the invitee's `RmAcceptInviteToCaseActivity` is processed
+      by the Case Actor (not the case owner). Tests MUST assert that no RM state-change
+      activity is emitted with `actor` set to the invitee's ID from the case owner's context.
+    relationships:
+    - rel_type: verifies
+      spec_id: PCR-08-007
+    - rel_type: verifies
+      spec_id: PCR-08-008
+    - rel_type: verifies
+      spec_id: PCR-08-009
+    - rel_type: verifies
+      spec_id: PCR-08-010


### PR DESCRIPTION
- Closes #893
- Closes #894

## Summary

Plans the combined fix for #893 (PrioritizeBT identity-spoofing in
AcceptInviteActorToCaseReceivedUseCase) and #894 (Invite/Accept handshake
bypasses Case Actor). Adds formal spec requirements, design notes, and
AGENTS.md pitfalls covering the correct routing model and the prohibition
on received-side identity spoofing.

## Changes

- `specs/participant-case-replica.yaml`: PCR-08-007 through PCR-08-010
  (Invite routing via Case Actor, Accept routing to Case Actor, Case Actor
  processes Accept, received-side identity-spoofing prohibition) + PCR-07-008
  test requirement
- `notes/case-communication-model.md`: Invite/Accept Handshake Routing
  section (correct flow, key rules, implementation pattern) + identity-spoofing
  antipattern section + updated Known Implementation Gaps
- `AGENTS.md`: two new pitfall entries — received-side identity spoofing and
  Invite/Accept routing through Case Actor