### PR TITLE
test: add regression tests for DataLayer scope (issue #656)

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -219,3 +219,16 @@ header.
   input seams (`case_id` from blackboard and `case_obj`-derived context).
 - If downstream leaves rely on blackboard keys, add explicit fallback reads
   from staged objects/status context to avoid regressing valid call paths.
+
+### 2026-06-11 ISSUE-656 — DataLayer scope regression tests
+
+- Testing get_canonical_actor_dl() directly (as a plain Python function
+  rather than through FastAPI DI) is straightforward: call it with explicit
+  keyword args `actor_id=...` and `dl=...`.
+- The AC-3a failure-mode test is intentionally asymmetric: the short-ID DL
+  must see an empty outbox while the canonical-URI DL sees the entry. This
+  documents the BUG-2026040901 scenario without requiring monkeypatching.
+- Use `call_args.args` (Python 3.8+ attribute) rather than `call_args[0]`
+  when asserting mock positional args — the named attribute fails clearly
+  if the call shifts to kwargs; the index subscript returns an empty tuple
+  silently.

--- a/plan/history/2606/implementation/ISSUE-656.md
+++ b/plan/history/2606/implementation/ISSUE-656.md
@@ -1,0 +1,35 @@
+---
+source: ISSUE-656
+timestamp: '2026-06-11T18:03:46.787156+00:00'
+title: Regression tests for DataLayer scope (get_canonical_actor_dl and inbox dual-DL
+  path)
+type: implementation
+---
+
+## Issue \#656 — Add regression tests for DataLayer scope: get\_canonical\_actor\_dl and inbox\_handler dual-DL path
+
+Added dedicated unit tests covering all five acceptance criteria for issue
+\#656, preventing regression of BUG-2026040901-class bugs where outbound
+activities are silently dropped due to a queue-key mismatch between a short
+UUID and the actor's canonical URI.
+
+**New file** `test/adapters/driving/fastapi/test_deps.py` (5 tests):
+
+- AC-1a: `get_canonical_actor_dl()` actor found via `dl.read()` → DL scoped
+  to canonical URI
+- AC-1b: actor found via `dl.find_actor_by_short_id()` fallback → canonical
+  URI (not short ID)
+- AC-1c: actor not found → falls back to raw path param
+- AC-3a: documents the BUG-2026040901 failure mode — short-ID-scoped DL
+  cannot read entries written by `record_outbox_item` with canonical URI
+- AC-3b: regression test confirming `get_canonical_actor_dl()` prevents the
+  bug
+
+**Modified** `test/adapters/driving/fastapi/test_inbox_handler.py` (1 new test):
+
+- AC-2: `inbox_handler` with `actor_dl ≠ dl` — queue pop uses `actor_dl`;
+  rehydration and dispatch use shared `dl`
+
+All 3153 unit tests pass (6 new). Black, flake8, mypy, pyright clean.
+
+PR: [https://github.com/CERTCC/Vultron/pull/898](https://github.com/CERTCC/Vultron/pull/898)

--- a/test/adapters/driving/fastapi/test_deps.py
+++ b/test/adapters/driving/fastapi/test_deps.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Unit tests for shared FastAPI dependency providers (deps.py).
+
+Covers ARCH-13-003 and ARCH-13-004:
+
+- ``get_canonical_actor_dl()`` resolves short IDs to canonical URIs so that
+  actor-scoped DataLayer instances are keyed by the full canonical URI.
+- The canonical-URI-keyed DL can read outbox entries written by
+  ``record_outbox_item`` (BUG-2026040901 regression).
+"""
+
+import pytest
+
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.adapters.driving.fastapi.deps import get_canonical_actor_dl
+from vultron.core.ports.datalayer import ActorScopedDataLayer
+from vultron.wire.as2.vocab.base.objects.actors import as_Service
+
+CANONICAL_URI = "https://example.org/actors/myactor"
+SHORT_ID = CANONICAL_URI.rsplit("/", 1)[-1]  # "myactor"
+ACTIVITY_ID = "https://example.org/activities/act-001"
+
+
+@pytest.fixture()
+def shared_dl() -> SqliteDataLayer:
+    return SqliteDataLayer("sqlite:///:memory:")
+
+
+# ---------------------------------------------------------------------------
+# AC-1: Unit tests for get_canonical_actor_dl()
+# ---------------------------------------------------------------------------
+
+
+def test_get_canonical_actor_dl_actor_found_via_read(
+    shared_dl: SqliteDataLayer,
+) -> None:
+    """AC-1a: Actor found via dl.read() — DL is scoped to canonical URI.
+
+    When actor_id is already the full canonical URI, ``dl.read()`` returns
+    the actor directly and ``clone_for_actor`` is called with that URI.
+    """
+    actor = as_Service(id_=CANONICAL_URI, name="MyActor")
+    shared_dl.save(actor)
+
+    result: ActorScopedDataLayer = get_canonical_actor_dl(
+        actor_id=CANONICAL_URI, dl=shared_dl
+    )
+
+    assert isinstance(result, SqliteDataLayer)
+    assert result._actor_id == CANONICAL_URI
+
+
+def test_get_canonical_actor_dl_actor_found_via_short_id(
+    shared_dl: SqliteDataLayer,
+) -> None:
+    """AC-1b: Actor found via dl.find_actor_by_short_id() fallback.
+
+    When ``actor_id`` is the short UUID (last path segment of the canonical
+    URI), ``dl.read()`` returns ``None`` but ``dl.find_actor_by_short_id()``
+    resolves the canonical URI.  The returned DL must be keyed by the
+    canonical URI, not the short ID (ARCH-13-003).
+    """
+    actor = as_Service(id_=CANONICAL_URI, name="MyActor")
+    shared_dl.save(actor)
+
+    result: ActorScopedDataLayer = get_canonical_actor_dl(
+        actor_id=SHORT_ID, dl=shared_dl
+    )
+
+    assert isinstance(result, SqliteDataLayer)
+    assert result._actor_id == CANONICAL_URI, (
+        f"Expected canonical URI '{CANONICAL_URI}', "
+        f"got '{result._actor_id}'"
+    )
+
+
+def test_get_canonical_actor_dl_actor_not_found_falls_back_to_raw_param(
+    shared_dl: SqliteDataLayer,
+) -> None:
+    """AC-1c: Actor not found — DL falls back to raw actor_id path param.
+
+    When neither ``dl.read()`` nor ``dl.find_actor_by_short_id()`` can
+    resolve the ID (e.g. an empty store), ``clone_for_actor`` is called with
+    the raw path param so the handler is not blocked.
+    """
+    unknown_id = "https://example.org/actors/unknown"
+
+    result: ActorScopedDataLayer = get_canonical_actor_dl(
+        actor_id=unknown_id, dl=shared_dl
+    )
+
+    assert isinstance(result, SqliteDataLayer)
+    assert result._actor_id == unknown_id
+
+
+# ---------------------------------------------------------------------------
+# AC-3: Regression tests for BUG-2026040901
+# ---------------------------------------------------------------------------
+
+
+def test_short_id_dl_cannot_read_queue_written_by_canonical_uri(
+    shared_dl: SqliteDataLayer,
+) -> None:
+    """AC-3a: Short-ID-scoped DL cannot read outbox written by canonical URI.
+
+    Documents the BUG-2026040901 failure mode: ``record_outbox_item``
+    writes an outbox entry keyed by the canonical URI.  A DL clone scoped
+    to the short UUID (not the canonical URI) reads a different queue bucket
+    and sees no items — the activity is silently dropped.
+
+    This test intentionally demonstrates the problematic behaviour so that
+    AC-3b (the regression test) can confirm ``get_canonical_actor_dl``
+    prevents it.
+    """
+    actor = as_Service(id_=CANONICAL_URI, name="MyActor")
+    shared_dl.save(actor)
+
+    # Use-case writes to the canonical-URI-keyed outbox (normal runtime path)
+    shared_dl.record_outbox_item(
+        actor_id=CANONICAL_URI, activity_id=ACTIVITY_ID
+    )
+
+    # A DL scoped to the short ID reads a *different* queue bucket → empty
+    short_id_dl: ActorScopedDataLayer = shared_dl.clone_for_actor(SHORT_ID)
+    assert short_id_dl.outbox_list() == [], (
+        "Short-ID-scoped DL must NOT see entries written by the canonical-URI "
+        "key (documents the BUG-2026040901 queue-key mismatch scenario)"
+    )
+
+    # A DL scoped to the canonical URI reads the correct bucket
+    canonical_dl: ActorScopedDataLayer = shared_dl.clone_for_actor(
+        CANONICAL_URI
+    )
+    assert ACTIVITY_ID in canonical_dl.outbox_list(), (
+        "Canonical-URI-scoped DL must read the entry written by "
+        "record_outbox_item(actor_id=CANONICAL_URI, ...)"
+    )
+
+
+def test_get_canonical_actor_dl_resolves_canonical_uri_for_queue_reads(
+    shared_dl: SqliteDataLayer,
+) -> None:
+    """AC-3b: get_canonical_actor_dl() returns a DL that can read the outbox.
+
+    Regression for BUG-2026040901 (ARCH-13-003, ARCH-13-004): when the URL
+    path carries a short UUID, ``get_canonical_actor_dl()`` must resolve it
+    to the canonical URI so that subsequent ``outbox_list()`` calls read the
+    same queue bucket that ``record_outbox_item`` wrote to.
+    """
+    actor = as_Service(id_=CANONICAL_URI, name="MyActor")
+    shared_dl.save(actor)
+
+    shared_dl.record_outbox_item(
+        actor_id=CANONICAL_URI, activity_id=ACTIVITY_ID
+    )
+
+    actor_dl: ActorScopedDataLayer = get_canonical_actor_dl(
+        actor_id=SHORT_ID, dl=shared_dl
+    )
+
+    assert ACTIVITY_ID in actor_dl.outbox_list(), (
+        "get_canonical_actor_dl must resolve the short UUID to the canonical "
+        "URI so that outbox reads succeed (BUG-2026040901 regression)"
+    )

--- a/test/adapters/driving/fastapi/test_inbox_handler.py
+++ b/test/adapters/driving/fastapi/test_inbox_handler.py
@@ -427,6 +427,81 @@ def test_pending_case_queue_expires_drops_and_warns(monkeypatch, caplog):
     assert any(activity_id in r.message for r in caplog.records)
 
 
+def test_inbox_handler_uses_actor_dl_for_queue_pop_and_shared_dl_for_dispatch(
+    monkeypatch,
+):
+    """AC-2: inbox_handler pops from actor_dl; rehydration/dispatch use dl.
+
+    When ``actor_dl`` is passed as a separate actor-scoped instance (distinct
+    from the shared ``dl``), queue operations (``inbox_list``, ``inbox_pop``)
+    must use ``actor_dl`` while rehydration and dispatch must receive the
+    shared ``dl`` (ARCH-13-003, ARCH-13-004).
+    """
+    actor_id = "https://example.org/actors/participant"
+    activity_id = "https://example.org/activities/act-dual-dl"
+
+    shared_dl = SqliteDataLayer("sqlite:///:memory:")
+    shared_dl.save(
+        as_Service(id_=actor_id, name="Participant")  # type: ignore[call-arg]
+    )
+    actor_dl = shared_dl.clone_for_actor(actor_id)
+
+    # Item is queued on the actor-scoped DL only
+    actor_dl.inbox_append(activity_id)
+
+    item = as_Activity(
+        id_=activity_id,
+        type_="Create",
+        actor="https://example.org/actors/other",
+        name="dual-dl-test",
+    )
+    rehydrate_dl_args: list = []
+
+    def capture_rehydrate(item_id, dl=None):
+        rehydrate_dl_args.append(dl)
+        return item
+
+    monkeypatch.setattr(ih, "rehydrate", capture_rehydrate)
+
+    fake_event = VultronEvent(
+        semantic_type=MessageSemantics.UNKNOWN,
+        activity_id=activity_id,
+        actor_id="https://example.org/actors/other",
+    )
+    monkeypatch.setattr(
+        ih, "prepare_for_dispatch", lambda activity: fake_event
+    )
+
+    mock_dispatcher = Mock()
+    monkeypatch.setattr(ih, "_DISPATCHER", mock_dispatcher)
+
+    async def fake_outbox_handler(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(ih, "outbox_handler", fake_outbox_handler)
+
+    asyncio.run(ih.inbox_handler(actor_id, shared_dl, actor_dl=actor_dl))
+
+    # Queue pop occurred on actor_dl — its inbox must now be empty
+    assert actor_dl.inbox_list() == [], (
+        "actor_dl inbox must be empty after processing; "
+        "inbox_handler must pop from actor_dl, not shared_dl"
+    )
+
+    # Rehydration must have received the shared dl
+    assert len(rehydrate_dl_args) == 1
+    assert (
+        rehydrate_dl_args[0] is shared_dl
+    ), "rehydrate must be called with shared dl, not actor_dl"
+
+    # Dispatch must have been called with the shared dl
+    mock_dispatcher.dispatch.assert_called_once()
+    _, dispatch_dl = mock_dispatcher.dispatch.call_args.args
+    assert (
+        dispatch_dl is shared_dl
+    ), "dispatch must be called with shared dl, not actor_dl"
+
+
 def test_pending_case_queue_expiry_emits_question(monkeypatch):
     """AC-7: A replay Question is appended to the actor outbox on expiry.
 


### PR DESCRIPTION
- Closes #656

## Summary

Adds dedicated unit tests for `get_canonical_actor_dl()` and the
`inbox_handler` dual-DataLayer path, preventing regression of
BUG-2026040901-class bugs where outbound activities are silently dropped
due to a queue-key mismatch between short UUID and canonical URI.

## Changes

- **`test/adapters/driving/fastapi/test_deps.py`** (new): unit tests for
  `get_canonical_actor_dl()` covering all three resolution paths (actor
  found via `dl.read()`, found via `dl.find_actor_by_short_id()` fallback,
  not found), plus BUG-2026040901 regression tests documenting the
  failure mode (AC-3a) and confirming the fix (AC-3b).
- **`test/adapters/driving/fastapi/test_inbox_handler.py`**: adds
  `test_inbox_handler_uses_actor_dl_for_queue_pop_and_shared_dl_for_dispatch`
  verifying that when `actor_dl ≠ dl`, queue pop uses `actor_dl` and
  rehydration/dispatch use the shared `dl` (AC-2).

## Verification

- All 3153 unit tests pass (6 new)
- Black, flake8, mypy, pyright clean
- [x] AC-1: Unit tests for `get_canonical_actor_dl()` covering actor found via `dl.read()`, found via `dl.find_actor_by_short_id()` fallback, and actor not found
- [x] AC-2: Unit test for `inbox_handler` with `actor_dl ≠ dl`: inbox pop on `actor_dl`; rehydration/dispatch use `dl`
- [x] AC-3: Regression test documenting BUG-2026040901 scenario and verifying `get_canonical_actor_dl` handles it
- [x] AC-4: Tests use `ActorScopedDataLayer` type annotation from #655
- [x] AC-5: All new tests pass under `uv run pytest --tb=short`