### PR TITLE
Fix Invite/Accept routing: Case Actor as sender/recipient; remove identity spoofing

### DIFF
--- a/plan/history/2606/implementation/ISSUE-896.md
+++ b/plan/history/2606/implementation/ISSUE-896.md
@@ -1,0 +1,36 @@
+---
+source: ISSUE-896
+timestamp: '2026-06-11T18:12:59.093135+00:00'
+title: 'Fix Invite/Accept routing: Case Actor as sender/recipient; remove identity
+  spoofing'
+type: implementation
+---
+
+## Issue #896 — Fix Invite/Accept routing: Case Actor as sender/recipient; remove identity spoofing
+
+Fixed two PCR-08 spec violations in the Invite/Accept handshake.
+
+**PCR-08-007**: `SvcInviteActorToCaseUseCase` now resolves the Case Actor ID
+and builds the Invite with `actor=case_actor_id` (falling back to owner when
+no Case Actor Service exists yet), placing it in the **Case Actor's outbox**.
+
+**PCR-08-009/010**: `AcceptInviteActorToCaseReceivedUseCase` no longer
+identity-spoofs. The `PrioritizeBT(actor_id=invitee_id)` call executed from
+the Case Actor's DataLayer context was removed. `RM.ACCEPTED` is now
+pre-seeded inline before participant creation, eliminating the spurious
+`RmEngageCaseActivity` (Join) emission from a foreign DataLayer context.
+
+**Supporting changes**:
+
+- `_find_case_actor_id` moved to `vultron/core/use_cases/_helpers.py` (shared)
+- `TriggerActivityPort.invite_actor_to_case` gains `attributed_to` param
+- `TriggerActivityAdapter` passes `attributed_to` when set
+- Demo `invite_actor_demo.py` routes Accept to Case Actor inbox
+
+**Integration test fix**: `test_pcr_late_joiner.py` fixture now patches
+`VULTRON_SERVER__BASE_URL` to `{_OWNER_BASE}/api/v2` (same pattern as
+`test_pcr_engage_case.py`) so Case Actor IDs are routable. Explicit
+`_drain_case_actor_outbox` call added after invite trigger since the Invite
+is now in the Case Actor's outbox, not the owner's.
+
+PR: <https://github.com/CERTCC/Vultron/pull/899>

--- a/test/core/use_cases/received/test_actor.py
+++ b/test/core/use_cases/received/test_actor.py
@@ -225,11 +225,60 @@ class TestInviteActorUseCases:
     def test_accept_invite_participant_can_reach_rm_accepted(
         self, make_payload
     ):
-        """Accepted invite auto-engages the participant to RM.ACCEPTED.
+        """Accepted invite advances the participant to RM.ACCEPTED inline.
 
-        CM-11-001 requires invitation acceptance to advance the invitee to
-        RM.ACCEPTED without a separate engage-case trigger. The use case still
-        pre-seeds RECEIVED and VALID before invoking the engage-case logic.
+        PCR-08-010: Accept(Invite) IS the engage decision.  The use case
+        records VALID→ACCEPTED directly on the participant without a separate
+        engage-case BT or emitting a proxy RmEngageCaseActivity.
+        """
+        from typing import Any, cast
+
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+        from vultron.wire.as2.vocab.base.objects.actors import as_Organization
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+        from vultron.core.states.rm import RM
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        invitee_id = "https://example.org/users/coordinator_rm1"
+        invitee = as_Organization(id_=invitee_id)
+        owner_id = "https://example.org/users/owner"
+        case = VulnerabilityCase(
+            id_="https://example.org/cases/caseRM001",
+            name="TEST-RM-LIFECYCLE",
+        )
+        invite = rm_invite_to_case_activity(
+            invitee,
+            target=VulnerabilityCaseStub(id_=case.id_),
+            actor=owner_id,
+            id_="https://example.org/cases/caseRM001/invitations/1",
+        )
+        dl.create(invitee)
+        dl.create(case)
+        dl.create(invite)
+
+        accept = rm_accept_invite_to_case_activity(
+            invite,
+            actor=invitee_id,
+        )
+        event = make_payload(accept)
+
+        # No TriggerActivityAdapter needed: RM.ACCEPTED is set inline.
+        AcceptInviteActorToCaseReceivedUseCase(dl, event).execute()
+
+        updated_case = cast(Any, dl.read(case.id_))
+        participant_id = updated_case.actor_participant_index.get(invitee_id)
+        participant_obj = cast(Any, dl.get(id_=participant_id))
+        latest_status = participant_obj.participant_statuses[-1]
+        assert latest_status.rm_state == RM.ACCEPTED
+
+    def test_accept_invite_no_identity_spoofing(self, make_payload):
+        """PCR-07-008: AcceptInviteActorToCaseReceivedUseCase MUST NOT emit
+        RmEngageCaseActivity (Join) with actor=invitee_id from the Case Actor
+        context.  The Accept(Invite) IS the engage decision; the participant
+        reaches RM.ACCEPTED via an inline state transition, not a spoofed BT
+        call.
         """
         from typing import Any, cast
 
@@ -240,75 +289,6 @@ class TestInviteActorUseCases:
         )
         from vultron.core.models.vultron_types import VultronParticipant
         from vultron.core.states.rm import RM
-        from vultron.core.states.roles import CVDRole
-
-        dl = SqliteDataLayer("sqlite:///:memory:")
-        invitee_id = "https://example.org/users/coordinator_rm1"
-        invitee = as_Organization(id_=invitee_id)
-        owner_id = "https://example.org/users/owner"
-        case_manager_participant_id = (
-            "https://example.org/cases/caseRM001/participants/case-manager"
-        )
-        case_manager_participant = VultronParticipant(
-            id_=case_manager_participant_id,
-            attributed_to=owner_id,
-            context="https://example.org/cases/caseRM001",
-            name="CaseManager",
-            case_roles=[CVDRole.CASE_MANAGER],
-        )
-        case = VulnerabilityCase(
-            id_="https://example.org/cases/caseRM001",
-            name="TEST-RM-LIFECYCLE",
-            case_participants=[case_manager_participant_id],
-            actor_participant_index={owner_id: case_manager_participant_id},
-        )
-        invite = rm_invite_to_case_activity(
-            invitee,
-            target=VulnerabilityCaseStub(id_=case.id_),
-            actor=owner_id,
-            id_="https://example.org/cases/caseRM001/invitations/1",
-        )
-        dl.create(invitee)
-        dl.create(case_manager_participant)
-        dl.create(case)
-        dl.create(invite)
-
-        accept = rm_accept_invite_to_case_activity(
-            invite,
-            actor=invitee_id,
-        )
-        event = make_payload(accept)
-        from vultron.adapters.driven.trigger_activity_adapter import (
-            TriggerActivityAdapter,
-        )
-        from vultron.core.ports.case_persistence import CaseOutboxPersistence
-
-        AcceptInviteActorToCaseReceivedUseCase(
-            dl,
-            event,
-            trigger_activity=TriggerActivityAdapter(
-                cast(CaseOutboxPersistence, dl)
-            ),
-        ).execute()
-
-        updated_case = cast(Any, dl.read(case.id_))
-        participant_id = updated_case.actor_participant_index.get(invitee_id)
-        participant_obj = cast(Any, dl.get(id_=participant_id))
-        latest_status = participant_obj.participant_statuses[-1]
-        assert latest_status.rm_state == RM.ACCEPTED
-
-    def test_accept_invite_actor_to_case_emits_engage_activity(
-        self, make_payload
-    ):
-        """AcceptInviteActorToCaseReceivedUseCase queues an RmEngageCaseActivity."""
-        from typing import Any, cast
-
-        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
-        from vultron.wire.as2.vocab.base.objects.actors import as_Organization
-        from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
-        )
-        from vultron.core.models.vultron_types import VultronParticipant
         from vultron.core.states.roles import CVDRole
 
         dl = SqliteDataLayer("sqlite:///:memory:")
@@ -347,35 +327,32 @@ class TestInviteActorUseCases:
             actor=invitee_id,
         )
         event = make_payload(accept)
-        from vultron.adapters.driven.trigger_activity_adapter import (
-            TriggerActivityAdapter,
-        )
-        from vultron.core.ports.case_persistence import CaseOutboxPersistence
 
-        AcceptInviteActorToCaseReceivedUseCase(
-            dl,
-            event,
-            trigger_activity=TriggerActivityAdapter(
-                cast(CaseOutboxPersistence, dl)
-            ),
-        ).execute()
+        AcceptInviteActorToCaseReceivedUseCase(dl, event).execute()
 
+        # PCR-07-008: no RmEngageCaseActivity (Join) with actor=invitee_id
+        # should be queued in the invitee's outbox — the RM.ACCEPTED state is
+        # set inline; no BT proxy emit is permitted.
         outbox_items = dl.clone_for_actor(invitee_id).outbox_list()
-        # At least the engage (Join) activity must be present.  An Announce
-        # activity may also be queued by _emit_announce_case so we allow ≥ 1.
-        assert len(outbox_items) >= 1
-
-        engage_activity = None
         for item_id in outbox_items:
             candidate = cast(Any, dl.read(item_id))
             if candidate is not None and str(candidate.type_) == "Join":
-                engage_activity = candidate
-                break
-        assert (
-            engage_activity is not None
-        ), "No Join/engage activity found in outbox"
-        assert engage_activity.actor == invitee_id
-        assert engage_activity.object_.id_ == case.id_
+                assert False, (
+                    f"PCR-07-008 violation: RmEngageCaseActivity (Join) with "
+                    f"actor={invitee_id!r} found in outbox — identity spoofing"
+                )
+
+        # The participant should already be at RM.ACCEPTED (inline transition).
+        updated_case = cast(Any, dl.read(case.id_))
+        participant_id = updated_case.actor_participant_index.get(invitee_id)
+        assert participant_id is not None
+        participant_obj = cast(Any, dl.get(id_=participant_id))
+        assert participant_obj is not None
+        latest_status = participant_obj.participant_statuses[-1]
+        assert latest_status.rm_state == RM.ACCEPTED, (
+            f"Expected RM.ACCEPTED after inline transition, "
+            f"got {latest_status.rm_state}"
+        )
 
     def test_accept_invite_actor_to_case_records_case_event(
         self, monkeypatch, make_payload

--- a/test/core/use_cases/triggers/test_actor_triggers.py
+++ b/test/core/use_cases/triggers/test_actor_triggers.py
@@ -187,6 +187,48 @@ class TestSvcInviteActorToCaseUseCase:
         # Activity actor field must be the full canonical URI, not the short UUID
         assert result["activity"]["actor"] == _HTTP_ACTOR_ID
 
+    def test_invite_uses_case_actor_when_present(self):
+        """PCR-08-007: when a Case Actor Service exists the invite actor must
+        be the Case Actor ID, not the case-owner actor ID.  The case owner's
+        ID is carried in ``attributedTo`` instead.
+        """
+        from vultron.wire.as2.vocab.base.objects.actors import as_Service
+
+        actor, dl = _make_actor_dl("Vendor")
+        invitee, _ = _make_actor_dl("Coordinator")
+        dl.create(invitee)
+        case = VulnerabilityCase(
+            attributed_to=actor.id_, name="PCR Test Case", content="Content"
+        )
+        dl.create(case)
+
+        # Register a Case Actor Service with context = case.id_
+        case_actor = as_Service(
+            id_=f"{actor.id_}/case-actor",
+            context=case.id_,
+            name="CaseActorService",
+        )
+        dl.create(case_actor)
+
+        request = InviteActorToCaseTriggerRequest(
+            actor_id=actor.id_,
+            case_id=case.id_,
+            invitee_id=invitee.id_,
+        )
+        result = SvcInviteActorToCaseUseCase(
+            dl, request, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
+
+        activity_data = result["activity"]
+        assert activity_data["type"] == "Invite"
+        # Invite actor MUST be the Case Actor Service ID (PCR-08-007)
+        assert activity_data["actor"] == case_actor.id_
+        # Case owner attribution is preserved
+        assert activity_data.get("attributedTo") == actor.id_
+        # The activity must be in the Case Actor's outbox, not the owner's
+        case_actor_outbox = dl.clone_for_actor(case_actor.id_).outbox_list()
+        assert activity_data["id"] in case_actor_outbox
+
 
 class TestSvcSuggestActorToCaseUseCase:
     """Tests for the suggest-actor-to-case trigger use case."""

--- a/test/demo/test_pcr_late_joiner.py
+++ b/test/demo/test_pcr_late_joiner.py
@@ -34,8 +34,8 @@ Both test methods in ``TestLateJoinerSequence`` run the complete
    triggers ``create_validate_report_tree`` and causes the CaseActor to
    emit ``Create(VulnerabilityCase)`` to the reporter via the outbox.
 3. The owner triggers ``invite-actor-to-case`` for the late-joiner actor.
-   The outbox is drained synchronously by the TestClient background task,
-   delivering the ``Invite`` to the late-joiner's inbox.
+   Per PCR-08-007, the ``Invite`` is placed in the **CaseActor's** outbox
+   and drained explicitly here, delivering it to the late-joiner's inbox.
 4. The late-joiner triggers ``accept-case-invite``.  The outbox drain
    delivers the ``Accept`` to the owner's inbox; the owner processes it via
    ``AcceptInviteActorToCaseReceivedUseCase``, adds the late-joiner as a
@@ -80,7 +80,7 @@ _LATE_JOINER_BASE = "http://late-joiner.test"
 
 
 @pytest.fixture
-def three_app_setup():
+def three_app_setup(monkeypatch):
     """Owner app + reporter app + late-joiner app wired for end-to-end delivery.
 
     Uses three isolated FastAPI app instances each with their own in-memory
@@ -89,17 +89,23 @@ def three_app_setup():
     outbox → inbox → inbox-handler chain is exercised without real HTTP.
 
     Lifecycle:
-      1. Enters all three TestClient contexts (triggers lifespan startup).
-      2. Replaces each app's ``ASGIEmitter._http_fallback`` with the shared
+      1. Patches ``VULTRON_SERVER__BASE_URL`` to ``{_OWNER_BASE}/api/v2`` so
+         that ``CreateCaseActorNode`` generates a routable CaseActor ID (e.g.
+         ``http://owner-late-joiner.test/api/v2/actors/case-actor-…``).
+         Without this the default ``http://localhost:7999`` is used, which
+         lacks the ``/api/v2/`` prefix and gets a 404 from the owner's ASGI
+         app (its routes are at ``/api/v2/actors/…``).
+      2. Enters all three TestClient contexts (triggers lifespan startup).
+      3. Replaces each app's ``ASGIEmitter._http_fallback`` with the shared
          router so cross-app deliveries use ASGI transport.
-      3. Configures the module-level ``_default_emitter`` to the shared
+      4. Configures the module-level ``_default_emitter`` to the shared
          router so trigger-endpoint ``outbox_handler`` calls route through
          ASGI instead of making real HTTP requests.
-      4. Registers the config-default ``base_url`` with the router pointing
-         to the owner's app so that deliveries to the CaseActor (whose ID
-         uses the config base_url) are routed correctly.
-      5. Yields the three ``IsolatedActorApp`` instances and their clients.
-      6. On teardown restores the previous default emitter and closes DLs.
+      5. Registers the patched ``base_url`` with the router pointing to the
+         owner's app so that CaseActor deliveries are routed correctly.
+      6. Yields the three ``IsolatedActorApp`` instances and their clients.
+      7. On teardown restores the previous default emitter, closes DLs, and
+         reloads config to remove the patched env var.
 
     Yields:
         Tuple of (owner_iso, reporter_iso, late_joiner_iso,
@@ -109,7 +115,15 @@ def three_app_setup():
         configure_default_emitter,
         get_default_emitter,
     )
-    from vultron.config import get_config
+    from vultron.config import get_config, reload_config
+
+    # Patch the server base URL so the CaseActor is created with the owner's
+    # routable base URL.  Without this, CreateCaseActorNode reads the default
+    # http://localhost:7999 which produces IDs like
+    # http://localhost:7999/actors/case-actor-... and the owner's app returns
+    # 404 for /actors/ paths (it expects /api/v2/actors/).
+    monkeypatch.setenv("VULTRON_SERVER__BASE_URL", f"{_OWNER_BASE}/api/v2")
+    reload_config()
 
     router = _TestASGIRouter()
     owner_iso = create_isolated_actor_app(base_url=_OWNER_BASE, router=router)
@@ -120,9 +134,9 @@ def three_app_setup():
         base_url=_LATE_JOINER_BASE, router=router
     )
 
-    # Register the config-default base_url (e.g. http://localhost:7999) with
-    # the router so that deliveries to CaseActor IDs (which use this URL)
-    # are routed to the owner's app via ASGI.
+    # Register the patched base_url with the router so CaseActor deliveries
+    # (whose IDs now use http://owner-late-joiner.test/api/v2) route to
+    # the owner's ASGI app.
     config_base_url = get_config().server.base_url.rstrip("/")
     router.register(config_base_url, owner_iso.app)
 
@@ -153,6 +167,7 @@ def three_app_setup():
     owner_iso.dl.close()
     reporter_iso.dl.close()
     late_joiner_iso.dl.close()
+    reload_config()
 
 
 # ---------------------------------------------------------------------------
@@ -386,6 +401,18 @@ def _run_late_joiner_sequence(
         f"{resp.text}"
     )
 
+    # PCR-08-007: SvcInviteActorToCaseUseCase now places the Invite in the
+    # CaseActor's outbox (not the owner's), so drain it explicitly here.
+    # The background task triggered by the invite endpoint only drains the
+    # owner's outbox; the CaseActor's outbox must be processed separately.
+    case_actor_id = _find_case_actor_id_in_dl(owner_iso.dl, case_id)
+    assert case_actor_id is not None, (
+        f"Could not find CaseActor for case '{case_id}' in owner's "
+        f"DataLayer.  CreateCaseActorNode may not have run during "
+        f"create_receive_report_case_tree."
+    )
+    _drain_case_actor_outbox(owner_iso, case_actor_id)
+
     # Step 4: retrieve invite_id from late-joiner's DataLayer
     invites = late_joiner_iso.dl.list_objects("Invite")
     assert len(invites) >= 1, (
@@ -408,12 +435,6 @@ def _run_late_joiner_sequence(
     # Step 6: drain CaseActor's outbox via real outbox_handler
     # Announce(VulnerabilityCase) is routed to late-joiner via the
     # configured default emitter (_TestASGIRouter).
-    case_actor_id = _find_case_actor_id_in_dl(owner_iso.dl, case_id)
-    assert case_actor_id is not None, (
-        f"Could not find CaseActor for case '{case_id}' in owner's "
-        f"DataLayer.  CreateCaseActorNode may not have run during "
-        f"create_receive_report_case_tree."
-    )
     _drain_case_actor_outbox(owner_iso, case_actor_id)
 
     return case_id, lj_actor_id

--- a/vultron/adapters/driven/trigger_activity_adapter.py
+++ b/vultron/adapters/driven/trigger_activity_adapter.py
@@ -317,11 +317,18 @@ class TriggerActivityAdapter:
         actor: str,
         to: list[str] | None = None,
         id_: str | None = None,
+        attributed_to: str | None = None,
     ) -> tuple[str, dict[str, Any]]:
-        """Create and persist an ``Invite(Actor, Case)`` activity."""
+        """Create and persist an ``Invite(Actor, Case)`` activity.
+
+        ``actor`` SHOULD be the Case Actor ID (PCR-08-007); ``attributed_to``
+        MAY carry the case owner's ID for attribution.
+        """
         extra: dict[str, Any] = {"actor": actor, "to": to}
         if id_ is not None:
             extra["id_"] = id_
+        if attributed_to is not None:
+            extra["attributed_to"] = attributed_to
         activity = rm_invite_to_case_activity(
             invitee=CoreActor(id_=invitee_id),
             target=VulnerabilityCaseStub(id_=case_id),

--- a/vultron/core/ports/trigger_activity.py
+++ b/vultron/core/ports/trigger_activity.py
@@ -199,9 +199,12 @@ class TriggerActivityPort(Protocol):
         actor: str,
         to: list[str] | None = None,
         id_: str | None = None,
+        attributed_to: str | None = None,
     ) -> tuple[str, dict[str, Any]]:
         """Create and persist an ``Invite(Actor, Case)`` activity.
 
+        ``actor`` SHOULD be the Case Actor ID (PCR-08-007); ``attributed_to``
+        MAY carry the case owner's ID for attribution.
         ``id_`` allows callers to supply a deterministic ID for idempotency.
         Returns ``(activity_id, activity_dict)``.
         """

--- a/vultron/core/use_cases/_helpers.py
+++ b/vultron/core/use_cases/_helpers.py
@@ -13,6 +13,7 @@ from vultron.core.models.protocols import (
     is_case_model,
     is_participant_model,
 )
+from vultron.core.models.report_case_link import VultronReportCaseLink
 from vultron.core.ports.case_persistence import CasePersistence
 from vultron.core.states.participant_embargo_consent import (
     PEC,
@@ -42,6 +43,28 @@ def _as_id(obj: Any) -> str | None:
     if isinstance(id_, str):
         return id_
     return str(obj)
+
+
+def _find_case_actor_id(dl: CasePersistence, case_id: str) -> str | None:
+    """Return the CaseActor Service ID for *case_id*, if present in the DataLayer.
+
+    First checks for a ``VultronReportCaseLink`` whose ``trusted_case_actor_id``
+    was established during bootstrap (CBT-01-006).  Falls back to the legacy
+    Service-object scan for backward compatibility.
+
+    Returns ``None`` when no CaseActor Service can be found for *case_id*.
+    This is the authoritative resolver for PCR-08-007 (invite sender) and
+    PCR-08-008 (accept recipient).
+    """
+    for link in dl.list_objects("ReportCaseLink"):
+        if isinstance(link, VultronReportCaseLink):
+            if link.case_id == case_id and link.trusted_case_actor_id:
+                return str(link.trusted_case_actor_id)
+
+    for service in dl.list_objects("Service"):
+        if getattr(service, "context", None) == case_id:
+            return service.id_
+    return None
 
 
 def _idempotent_create(

--- a/vultron/core/use_cases/received/actor.py
+++ b/vultron/core/use_cases/received/actor.py
@@ -34,32 +34,16 @@ from vultron.core.states.participant_embargo_consent import (
 from vultron.core.states.rm import RM
 from vultron.core.states.roles import CVDRole
 from vultron.core.use_cases.received.case import _store_embedded_participants
-from vultron.core.use_cases._helpers import _as_id, _idempotent_create
+from vultron.core.use_cases._helpers import (
+    _as_id,
+    _find_case_actor_id,
+    _idempotent_create,
+)
 
 if TYPE_CHECKING:
     from vultron.core.ports.trigger_activity import TriggerActivityPort
 
 logger = logging.getLogger(__name__)
-
-
-def _find_case_actor_id(dl: CasePersistence, case_id: str) -> str | None:
-    """Return the CaseActor ID for *case_id*, if present in the DataLayer.
-
-    First checks for a ``VultronReportCaseLink`` whose ``trusted_case_actor_id``
-    was established during bootstrap (CBT-01-006).  Falls back to the legacy
-    Service-object scan for backward compatibility.
-    """
-    # Bootstrap-trust path: check ReportCaseLink first
-    for link in dl.list_objects("ReportCaseLink"):
-        if isinstance(link, VultronReportCaseLink):
-            if link.case_id == case_id and link.trusted_case_actor_id:
-                return str(link.trusted_case_actor_id)
-
-    # Legacy path: scan for a VultronCaseActor Service with context=case_id
-    for service in dl.list_objects("Service"):
-        if getattr(service, "context", None) == case_id:
-            return service.id_
-    return None
 
 
 def _link_report_case_links(dl: CasePersistence, case) -> None:
@@ -592,14 +576,17 @@ class AcceptInviteActorToCaseReceivedUseCase:
             attributed_to=invitee_id,
             context=case_id,
         )
-        # An accepted invite implies the invitee has received and validated the
-        # case. Pre-seeding RECEIVED→VALID ensures the engage-case trigger
-        # (VALID→ACCEPTED) is a valid RM transition.
+        # Accept(Invite) IS the engage signal (PCR-08-010): pre-seed all three
+        # RM states inline so the participant reaches ACCEPTED immediately
+        # without a separate engage-case trigger or identity-spoofing BT call.
         participant.append_rm_state(
             RM.RECEIVED, actor=invitee_id, context=case_id
         )
         participant.append_rm_state(
             RM.VALID, actor=invitee_id, context=case_id
+        )
+        participant.append_rm_state(
+            RM.ACCEPTED, actor=invitee_id, context=case_id
         )
         # Only auto-sign embargo consent when the embargo is fully ACTIVE.
         # In REVISE state the terms are under negotiation; auto-signing would
@@ -619,27 +606,13 @@ class AcceptInviteActorToCaseReceivedUseCase:
 
         # MV-10-003/MV-10-005: emit full case details to the invitee now that
         # embargo consent has been resolved (auto-signed above when ACTIVE).
-        # The case owner (receiving_actor_id) sends Announce(VulnerabilityCase)
-        # so the invitee can seed their local DataLayer.
+        # The Case Actor sends Announce(VulnerabilityCase) so the invitee can
+        # seed their local DataLayer.
         self._emit_announce_case(case_id, invitee_id, case)
 
-        from vultron.core.behaviors.bridge import BTBridge
-        from vultron.core.behaviors.report.prioritize_tree import (
-            create_prioritize_subtree,
-        )
-
-        bridge = BTBridge(
-            datalayer=self._dl, trigger_activity=self._trigger_activity
-        )
-        prioritize_tree = create_prioritize_subtree(
-            case_id=case_id,
-            actor_id=invitee_id,
-            trigger_activity=self._trigger_activity,
-        )
-        bridge.execute_with_setup(prioritize_tree, actor_id=invitee_id)
-
         logger.info(
-            "Added participant '%s' to case '%s' via accepted invite and auto-engaged via BT",
+            "Added participant '%s' to case '%s' via accepted invite"
+            " (RM.ACCEPTED inline, PCR-08-010)",
             invitee_id,
             case_id,
         )

--- a/vultron/core/use_cases/triggers/actor.py
+++ b/vultron/core/use_cases/triggers/actor.py
@@ -23,6 +23,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
+from vultron.core.use_cases._helpers import _find_case_actor_id
 from vultron.core.use_cases.triggers._helpers import (
     add_activity_to_outbox,
     resolve_actor,
@@ -129,22 +130,34 @@ class SvcInviteActorToCaseUseCase:
                 "SvcInviteActorToCaseUseCase requires a TriggerActivityPort"
             )
 
+        # PCR-08-007: the invite MUST be sent from the Case Actor's identity.
+        # Fall back to the case owner (actor_id) only when no Case Actor has
+        # been established yet (early-lifecycle cases without a Service record).
+        case_actor_id = _find_case_actor_id(self._dl, case.id_)
+        invite_actor_id = case_actor_id if case_actor_id else actor_id
+        attributed_to = actor_id if case_actor_id else None
+
         activity_id, activity_dict = (
             self._trigger_activity.invite_actor_to_case(
                 invitee_id=self._request.invitee_id,
                 case_id=case.id_,
-                actor=actor_id,
+                actor=invite_actor_id,
                 to=[self._request.invitee_id],
+                attributed_to=attributed_to,
             )
         )
 
-        add_activity_to_outbox(actor_id, activity_id, self._dl)
+        # PCR-08-007: queue in the Case Actor's outbox so it appears to come
+        # from the Case Actor.  Fall back to the owner's outbox when no Case
+        # Actor is registered.
+        add_activity_to_outbox(invite_actor_id, activity_id, self._dl)
 
         logger.info(
-            "Actor '%s' invited actor '%s' to case '%s'",
+            "Actor '%s' invited actor '%s' to case '%s' (via Case Actor '%s')",
             actor_id,
             self._request.invitee_id,
             case.id_,
+            invite_actor_id,
         )
 
         return {"activity": activity_dict}

--- a/vultron/core/use_cases/triggers/actor.py
+++ b/vultron/core/use_cases/triggers/actor.py
@@ -153,11 +153,10 @@ class SvcInviteActorToCaseUseCase:
         add_activity_to_outbox(invite_actor_id, activity_id, self._dl)
 
         logger.info(
-            "Actor '%s' invited actor '%s' to case '%s' (via Case Actor '%s')",
+            "Actor '%s' invited actor '%s' to case '%s'",
             actor_id,
             self._request.invitee_id,
             case.id_,
-            invite_actor_id,
         )
 
         return {"activity": activity_dict}

--- a/vultron/demo/exchange/invite_actor_demo.py
+++ b/vultron/demo/exchange/invite_actor_demo.py
@@ -87,6 +87,21 @@ from vultron.wire.as2.factories import (
 logger = logging.getLogger(__name__)
 
 
+def _get_case_actor_id(client: DataLayerClient, case_id: str) -> str | None:
+    """Return the Case Actor Service ID for *case_id* by querying the actor list.
+
+    The Case Actor Service is stored in the DataLayer with ``context`` equal to
+    the case ID.  Returns ``None`` when no matching Service is found.
+    """
+    actors = client.get("/actors/")
+    if not isinstance(actors, list):
+        return None
+    for actor in actors:
+        if actor.get("type") == "Service" and actor.get("context") == case_id:
+            return actor.get("id")
+    return None
+
+
 def _setup_initialized_case(
     client: DataLayerClient,
     finder: as_Actor,
@@ -179,28 +194,35 @@ def demo_invite_actor_accept(
 
     case = _setup_initialized_case(client, finder, vendor)
 
+    # PCR-08-007: the invite MUST be sent from the Case Actor's identity.
+    # The Case Actor is registered as a Service in the DataLayer after case creation.
+    case_actor_id = _get_case_actor_id(client, case.id_)
+    invite_actor_id = case_actor_id if case_actor_id else vendor.id_
+
     with demo_step("Step 2: Vendor invites coordinator to case"):
         invite = rm_invite_to_case_activity(
             coordinator,
-            actor=vendor.id_,
+            actor=invite_actor_id,
             target=case.id_,
             to=[coordinator.id_],
+            attributed_to=vendor.id_ if case_actor_id else None,
             content=f"We're inviting you to participate in {case.name}.",
         )
         logger.info(f"Sending invite: {logfmt(invite)}")
         post_to_inbox_and_wait(client, coordinator.id_, invite)
 
     with demo_step("Step 3: Coordinator accepts invitation"):
-        # reference invite by ID so the handler can rehydrate it from the
-        # datalayer with all fields intact
+        # PCR-08-008: Accept must be addressed to the Case Actor inbox.
+        # The invite's actor field carries the Case Actor ID.
+        accept_recipient = invite_actor_id
         accept = rm_accept_invite_to_case_activity(
             invite,
             actor=coordinator.id_,
-            to=[vendor.id_],
+            to=[accept_recipient],
             content=f"Accepting invitation to participate in {case.name}.",
         )
         logger.info(f"Sending accept: {logfmt(accept)}")
-        post_to_inbox_and_wait(client, vendor.id_, accept)
+        post_to_inbox_and_wait(client, accept_recipient, accept)
 
     with demo_step("Step 4: Verify coordinator added as case participant"):
         with demo_check("Coordinator present in case participant list"):
@@ -255,28 +277,33 @@ def demo_invite_actor_reject(
     initial_case = log_case_state(client, case.id_, "initial")
     initial_count = len(initial_case.case_participants) if initial_case else 0
 
+    # PCR-08-007: the invite MUST be sent from the Case Actor's identity.
+    case_actor_id = _get_case_actor_id(client, case.id_)
+    invite_actor_id = case_actor_id if case_actor_id else vendor.id_
+
     with demo_step("Step 2: Vendor invites coordinator to case"):
         invite = rm_invite_to_case_activity(
             coordinator,
-            actor=vendor.id_,
+            actor=invite_actor_id,
             target=case.id_,
             to=[coordinator.id_],
+            attributed_to=vendor.id_ if case_actor_id else None,
             content=f"We're inviting you to participate in {case.name}.",
         )
         logger.info(f"Sending invite: {logfmt(invite)}")
         post_to_inbox_and_wait(client, coordinator.id_, invite)
 
     with demo_step("Step 3: Coordinator rejects invitation"):
-        # reference invite by ID so the handler can rehydrate it from the
-        # datalayer with all fields intact
+        # PCR-08-008: Reject must also be addressed to the Case Actor inbox.
+        reject_recipient = invite_actor_id
         reject = rm_reject_invite_to_case_activity(
             invite,
             actor=coordinator.id_,
-            to=[vendor.id_],
+            to=[reject_recipient],
             content=f"Declining the invitation to participate in {case.name}.",
         )
         logger.info(f"Sending reject: {logfmt(reject)}")
-        post_to_inbox_and_wait(client, vendor.id_, reject)
+        post_to_inbox_and_wait(client, reject_recipient, reject)
 
     with demo_step("Step 4: Verify coordinator not added as participant"):
         with demo_check("Participant count unchanged after reject"):


### PR DESCRIPTION
- Closes #896

## Summary

Fixes two PCR-08 spec violations in the Invite/Accept handshake:

1. **PCR-08-007** — `SvcInviteActorToCaseUseCase` now builds the Invite with `actor=case_actor_id` (falling back to owner when no Case Actor exists yet) and queues it in the **Case Actor's outbox**, not the owner's.

2. **PCR-08-009/010** — `AcceptInviteActorToCaseReceivedUseCase` no longer identity-spoofs: the `PrioritizeBT(actor_id=invitee_id)` call executed from the Case Actor's DataLayer context is removed. `RM.ACCEPTED` is pre-seeded inline before participant creation instead, eliminating the spurious `RmEngageCaseActivity` (Join) emission.

## Changes

- `vultron/core/use_cases/_helpers.py`: `_find_case_actor_id` moved here from `received/actor.py` (shared helper)
- `vultron/core/use_cases/triggers/actor.py`: `SvcInviteActorToCaseUseCase.execute()` rewritten for PCR-08-007
- `vultron/core/use_cases/received/actor.py`: identity-spoofing BT block removed; inline `RM.ACCEPTED` pre-seed
- `vultron/core/ports/trigger_activity.py`: `invite_actor_to_case` gains `attributed_to` param
- `vultron/adapters/driven/trigger_activity_adapter.py`: passes `attributed_to` when set
- `vultron/demo/exchange/invite_actor_demo.py`: Accept routed to Case Actor inbox
- `test/core/use_cases/received/test_actor.py`: tests updated for new behavior
- `test/core/use_cases/triggers/test_actor_triggers.py`: `test_invite_uses_case_actor_when_present` added
- `test/demo/test_pcr_late_joiner.py`: fixture patches server base URL (same pattern as `test_pcr_engage_case.py`); explicit Case Actor outbox drain added after invite trigger

## Verification

```
3364 passed, 14 skipped, 3 xfailed in 56.20s
```
All 4 linters pass (Black, flake8, mypy, pyright).