### PR TITLE
Add missing outbox delivery-path unit tests

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -6,3 +6,12 @@ insights, issues, and learnings during the implementation process.
 
 Append new items below any existing ones, marking them with the date and a
 header.
+
+### 2026-06-11 OUTBOX-873-TEST-COVERAGE — make acceptance criteria explicit in one file
+
+Issue #873 found that most delivery-path coverage already existed but was split
+across sections/files. Adding explicit tests in
+`test/adapters/driving/fastapi/test_outbox.py` for direct `to` extraction and
+malformed bare-string `object_` integrity checks keeps OX-08/OX-09 validation
+discoverable in the canonical outbox test module and reduces ambiguity during
+future outbox refactors.

--- a/plan/history/2606/implementation/ISSUE-873.md
+++ b/plan/history/2606/implementation/ISSUE-873.md
@@ -1,0 +1,12 @@
+---
+source: ISSUE-873
+timestamp: '2026-06-11T19:22:57.238867+00:00'
+title: Outbox delivery-path unit tests
+type: implementation
+---
+
+## Issue #873 — Add unit tests for outbox delivery-path scenarios
+
+Added explicit unit tests in test_outbox.py to cover direct to-field recipient extraction and malformed bare-string object integrity handling in handle_outbox_item, completing the remaining delivery-path scenarios tracked by this issue.
+
+PR: [#904](https://github.com/CERTCC/Vultron/pull/904)

--- a/test/adapters/driving/fastapi/test_outbox.py
+++ b/test/adapters/driving/fastapi/test_outbox.py
@@ -309,6 +309,22 @@ def test_extract_recipients_deduplicates():
     assert recipients == [alice]
 
 
+def test_extract_recipients_reads_to_field():
+    """_extract_recipients reads recipients directly from `to`."""
+    alice = "https://example.org/actors/alice"
+    bob = "https://example.org/actors/bob"
+    activity = SimpleNamespace(
+        to=[alice, bob],
+        cc=None,
+        bto=None,
+        bcc=None,
+    )
+
+    recipients = oh._extract_recipients(activity)
+
+    assert recipients == [alice, bob]
+
+
 def test_extract_recipients_handles_embedded_object():
     """_extract_recipients extracts id_ from embedded actor objects."""
     alice_id = "https://example.org/actors/alice"
@@ -859,6 +875,34 @@ def test_handle_outbox_item_no_warning_when_only_to_set(caplog):
     assert not any(
         any(f in msg for f in ("cc", "bto", "bcc")) for msg in warning_texts
     )
+
+
+def test_handle_outbox_item_raises_integrity_error_for_bare_object():
+    """Malformed bare-string object_ must raise integrity error (OX-09/MV-09)."""
+    activity = _make_vultron_activity(
+        to=["https://example.org/actors/alice"],
+        activity_type="Create",
+    )
+    activity.object_ = "urn:uuid:bare-object"  # type: ignore[assignment]
+    mock_dl = MagicMock()
+    mock_dl.read.side_effect = lambda id_: (
+        activity if id_ == activity.id_ else None
+    )
+    mock_emitter = AsyncMock()
+
+    with pytest.raises(VultronOutboxObjectIntegrityError) as exc_info:
+        asyncio.run(
+            oh.handle_outbox_item(
+                "actor-abc",
+                activity.id_,
+                mock_dl,
+                mock_emitter,
+            )
+        )
+
+    assert exc_info.value.activity_id == activity.id_
+    assert exc_info.value.activity_type == "Create"
+    mock_emitter.emit.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- Closes #873

## Summary

Adds explicit unit tests in test_outbox.py for remaining delivery-path scenarios required by #873, tightening recipient extraction and malformed-activity validation coverage.

## Changes

- test/adapters/driving/fastapi/test_outbox.py: added a direct to-field recipient extraction test.
- test/adapters/driving/fastapi/test_outbox.py: added a malformed bare-string object_ integrity-error test for handle_outbox_item.

## Verification

- 3156 passed, 14 skipped, 219 deselected, 5633 subtests passed (uv run pytest --tb=short 2>&1 | tail -5)
- Black, flake8, mypy, pyright clean