### PR TITLE
Add SYNC happy-path single-peer replication integration test

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -15,3 +15,12 @@ across sections/files. Adding explicit tests in
 malformed bare-string `object_` integrity checks keeps OX-08/OX-09 validation
 discoverable in the canonical outbox test module and reduces ambiguity during
 future outbox refactors.
+
+### 2026-06-11 SYNC — Isolated two-app replication harness for CaseLogEntry
+
+For SYNC happy-path replication integration coverage (#901), the most stable
+test seam is two isolated FastAPI apps created with `create_isolated_actor_app`
+plus a shared `_TestASGIRouter` wired as each app's emitter fallback and as the
+module-level default emitter. This setup exercises outbox -> ASGI delivery ->
+inbox processing with distinct actor-scoped DataLayers and avoids real HTTP
+retry delays.

--- a/plan/history/2606/implementation/ISSUE-901.md
+++ b/plan/history/2606/implementation/ISSUE-901.md
@@ -1,0 +1,12 @@
+---
+source: ISSUE-901
+timestamp: '2026-06-11T19:33:29.122549+00:00'
+title: SYNC integration single-peer CaseLogEntry replication
+type: implementation
+---
+
+## Issue #901 — SYNC Integration: happy-path single-peer CaseLogEntry replication
+
+Added integration coverage for the SYNC happy path using two isolated FastAPI apps and a shared _TestASGIRouter. The new test verifies CaseActor append -> Announce(CaseLogEntry) delivery -> peer append, and asserts replicated CaseLogEntry content/hash/index plus distinct DataLayer instances per actor.
+
+PR: [#905](https://github.com/CERTCC/Vultron/pull/905)

--- a/test/demo/test_sync_log_replication.py
+++ b/test/demo/test_sync_log_replication.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""SYNC integration tests for single-peer CaseLogEntry replication (#901)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from vultron.adapters.driven.asgi_emitter import ASGIEmitter
+from test.demo.conftest import _TestASGIRouter, create_isolated_actor_app
+from vultron.adapters.driving.fastapi.outbox_handler import (
+    configure_default_emitter,
+    get_default_emitter,
+)
+from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+
+_CASE_ACTOR_BASE = "http://case-actor-sync-901.test"
+_PEER_BASE = "http://peer-sync-901.test"
+
+
+def _actor_slug(actor_id: str) -> str:
+    return actor_id.rstrip("/").rsplit("/", 1)[-1]
+
+
+def _create_actor(client, base_api: str, slug: str, actor_type: str) -> str:
+    actor_id = f"{base_api}/actors/{slug}"
+    response = client.post(
+        "/api/v2/actors/",
+        json={"type": actor_type, "name": slug, "id": actor_id},
+    )
+    assert response.status_code in (
+        200,
+        201,
+    ), f"Actor creation failed ({response.status_code}): {response.text}"
+    return actor_id
+
+
+@pytest.fixture
+def two_app_setup() -> Iterator[tuple]:
+    """Create two isolated actor apps connected by ``_TestASGIRouter``."""
+    router = _TestASGIRouter()
+    case_actor_iso = create_isolated_actor_app(
+        base_url=_CASE_ACTOR_BASE, router=router
+    )
+    peer_iso = create_isolated_actor_app(base_url=_PEER_BASE, router=router)
+
+    previous_emitter = get_default_emitter()
+    configure_default_emitter(router)  # type: ignore[arg-type]
+
+    with case_actor_iso.client as case_actor_tc:
+        with peer_iso.client as peer_tc:
+            for iso in (case_actor_iso, peer_iso):
+                emitter = getattr(iso.app.state, "emitter", None)
+                if isinstance(emitter, ASGIEmitter):
+                    emitter._http_fallback = router  # type: ignore[assignment]
+            yield case_actor_iso, peer_iso, case_actor_tc, peer_tc
+
+    configure_default_emitter(previous_emitter)  # type: ignore[arg-type]
+    case_actor_iso.dl.close()
+    peer_iso.dl.close()
+
+
+@pytest.mark.spec("SYNC-07-002")
+@pytest.mark.spec("SYNC-02-003")
+def test_sync_single_peer_happy_path_replication(two_app_setup) -> None:
+    """CaseActor commit should replicate one CaseLogEntry to a peer replica."""
+    case_actor_iso, peer_iso, case_actor_tc, peer_tc = two_app_setup
+
+    case_actor_base_api = f"{case_actor_iso.base_url}/api/v2"
+    peer_base_api = f"{peer_iso.base_url}/api/v2"
+
+    case_actor_id = _create_actor(
+        case_actor_tc, case_actor_base_api, "case-actor-sync-901", "Service"
+    )
+    peer_actor_id = _create_actor(
+        peer_tc, peer_base_api, "peer-sync-901", "Organization"
+    )
+    # CaseActor must know peer recipient for outbox routing.
+    _create_actor(
+        case_actor_tc, peer_base_api, "peer-sync-901", "Organization"
+    )
+
+    case = VulnerabilityCase(name="SYNC-901 integration case")
+    case_actor_participant = CaseParticipant(
+        attributed_to=case_actor_id,
+        context=case.id_,
+    )
+    peer_participant = CaseParticipant(
+        attributed_to=peer_actor_id,
+        context=case.id_,
+    )
+    case.case_participants.append(case_actor_participant.id_)
+    case.case_participants.append(peer_participant.id_)
+    case.actor_participant_index[case_actor_id] = case_actor_participant.id_
+    case.actor_participant_index[peer_actor_id] = peer_participant.id_
+
+    case_actor_iso.dl.save(case_actor_participant)
+    case_actor_iso.dl.save(peer_participant)
+    case_actor_iso.dl.save(case)
+
+    response = case_actor_tc.post(
+        f"/api/v2/actors/{_actor_slug(case_actor_id)}/demo/sync-log-entry",
+        json={
+            "case_id": case.id_,
+            "object_id": case.id_,
+            "event_type": "sync_901_happy_path",
+        },
+    )
+    assert response.status_code == 202, response.text
+    payload = response.json()
+
+    entry_id = payload["log_entry_id"]
+    peer_entry = peer_iso.dl.read(entry_id)
+    assert (
+        peer_entry is not None
+    ), "Expected peer replica to contain the announced CaseLogEntry."
+    assert peer_entry.case_id == case.id_
+    assert peer_entry.log_index == payload["log_index"]
+    assert peer_entry.entry_hash == payload["entry_hash"]
+    assert peer_entry.log_object_id == case.id_
+    assert peer_entry.event_type == "sync_901_happy_path"
+
+    # AC-4 guard: each actor app uses its own isolated DataLayer.
+    assert case_actor_iso.dl is not peer_iso.dl


### PR DESCRIPTION
- Closes #901

## Summary

Adds an end-to-end integration test for the SYNC happy path where a CaseActor commits a canonical CaseLogEntry, emits Announce(CaseLogEntry), and a peer participant appends the replicated entry.

## Changes

- test/demo/test_sync_log_replication.py: adds a two-app isolated FastAPI integration test using _TestASGIRouter to exercise append to outbox delivery to inbox processing to peer append, including assertions on replicated entry content/hash/index and actor DataLayer isolation.
- plan/BUILD_LEARNINGS.md: records the two-app _TestASGIRouter harness pattern for stable SYNC replication integration coverage.

## Verification

- All 3373 tests pass (including integration suite): uv run pytest -m "" --tb=short 2>&1 | tail -5
- Black, flake8, mypy, and pyright are clean