### PR TITLE
Refactor outbox_handler helpers to cut complexity

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -15,3 +15,12 @@ across sections/files. Adding explicit tests in
 malformed bare-string `object_` integrity checks keeps OX-08/OX-09 validation
 discoverable in the canonical outbox test module and reduces ambiguity during
 future outbox refactors.
+
+### 2026-06-11 OUTBOX-874-HELPER-EXTRACTION — split protocol invariants from flow wiring
+
+The outbox handler became easier to reason about after extracting nested
+protocol checks into explicit helper functions (`_coerce_reference_value`,
+`_prepare_activity_object_for_delivery`, `_recover_typed_inline_object_from_dict`,
+etc.). Keeping the main delivery function focused on sequence-level orchestration
+reduces churn risk when adding future outbox requirements while preserving
+existing OX/MV invariants.

--- a/plan/history/2606/implementation/ISSUE-874.md
+++ b/plan/history/2606/implementation/ISSUE-874.md
@@ -1,0 +1,12 @@
+---
+source: ISSUE-874
+timestamp: '2026-06-11T19:35:17.013831+00:00'
+title: Outbox handler maintainability refactor
+type: implementation
+---
+
+## Issue #874 — Refactor outbox_handler.py to reduce complexity and improve maintainability
+
+Refactored outbox_handler.py by extracting focused helper functions for reference dehydration, recipient-id extraction, inline object recovery, and hydration preparation. This reduced branching in handle_outbox_item and clarified intent without changing delivery behavior.
+
+PR: [#906](https://github.com/CERTCC/Vultron/pull/906)

--- a/test/adapters/driving/fastapi/test_outbox.py
+++ b/test/adapters/driving/fastapi/test_outbox.py
@@ -644,6 +644,158 @@ def test_dehydrate_references_leaves_none_fields_unchanged():
     assert result["target"] is None
 
 
+def test_is_stub_object_dict_true_for_minimal_case_stub():
+    """_is_stub_object_dict identifies the selective-disclosure case stub."""
+    stub: dict[object, object] = {
+        "id": "https://example.org/cases/case-001",
+        "type": "VulnerabilityCase",
+    }
+    assert oh._is_stub_object_dict(stub) is True
+
+
+def test_coerce_reference_value_preserves_case_stub_dict():
+    """_coerce_reference_value keeps intentional case stubs inline."""
+    stub = {
+        "id": "https://example.org/cases/case-001",
+        "type": "VulnerabilityCase",
+    }
+    assert oh._coerce_reference_value(stub) == stub
+
+
+def test_coerce_reference_value_collapses_href_then_id():
+    """_coerce_reference_value prefers href over id for dict references."""
+    assert (
+        oh._coerce_reference_value(
+            {"id": "urn:uuid:obj-001", "href": "https://example.org/obj/1"}
+        )
+        == "https://example.org/obj/1"
+    )
+    assert (
+        oh._coerce_reference_value({"id": "https://example.org/obj/2"})
+        == "https://example.org/obj/2"
+    )
+
+
+def test_recover_typed_inline_object_from_dict_rehydrates_model():
+    """_recover_typed_inline_object_from_dict rebuilds configured model types."""
+    from vultron.wire.as2.vocab.objects.vulnerability_case import (
+        VulnerabilityCase,
+    )
+
+    activity = _make_vultron_activity(
+        to=["https://example.org/actors/alice"],
+        activity_type="Create",
+    )
+    object_dict = {
+        "id": "https://example.org/cases/case-123",
+        "type": "VulnerabilityCase",
+        "name": "Case 123",
+    }
+
+    recovered = oh._recover_typed_inline_object_from_dict(
+        object_dict,
+        "Create",
+        activity.id_,
+        activity,
+    )
+
+    assert isinstance(recovered, VulnerabilityCase)
+    assert activity.object_ is recovered
+
+
+def test_recover_typed_inline_object_from_dict_returns_input_on_validation_error(
+    monkeypatch,
+):
+    """_recover_typed_inline_object_from_dict leaves dict unchanged on failure."""
+
+    class BrokenModel:
+        @classmethod
+        def model_validate(cls, payload):
+            raise ValueError("broken")
+
+    monkeypatch.setitem(oh._STUB_OBJECT_MODEL_MAP, "BrokenType", BrokenModel)
+    activity = _make_vultron_activity(
+        to=["https://example.org/actors/alice"],
+        activity_type="Create",
+    )
+    object_dict = {
+        "id": "urn:uuid:broken-1",
+        "type": "BrokenType",
+        "name": "Broken",
+    }
+
+    recovered = oh._recover_typed_inline_object_from_dict(
+        object_dict,
+        "Create",
+        activity.id_,
+        activity,
+    )
+
+    assert recovered == object_dict
+    assert activity.object_ is None
+
+
+def test_hydrate_inline_object_if_persistable_hydrates_basemodel():
+    """_hydrate_inline_object_if_persistable calls dl.hydrate for BaseModel."""
+    from pydantic import BaseModel
+
+    class DummyModel(BaseModel):
+        id_: str
+
+    activity = _make_vultron_activity(
+        to=["https://example.org/actors/alice"],
+        activity_type="Create",
+    )
+    model = DummyModel(id_="urn:uuid:dummy-1")
+    hydrated_model = DummyModel(id_="urn:uuid:dummy-2")
+    mock_dl = MagicMock()
+    mock_dl.hydrate.return_value = hydrated_model
+
+    result = oh._hydrate_inline_object_if_persistable(model, activity, mock_dl)
+
+    mock_dl.hydrate.assert_called_once_with(model)
+    assert result is hydrated_model
+    assert activity.object_ is hydrated_model
+
+
+def test_prepare_activity_object_for_delivery_calls_helper_pipeline(
+    monkeypatch,
+):
+    """_prepare_activity_object_for_delivery uses expansion/validate/recovery/hydration."""
+    activity = _make_vultron_activity(
+        to=["https://example.org/actors/alice"],
+        activity_type="Create",
+    )
+    activity.object_ = {"id": "urn:uuid:obj", "type": "VulnerabilityCase"}
+    mock_dl = MagicMock()
+
+    expanded_obj = {"id": "urn:uuid:expanded", "type": "VulnerabilityCase"}
+    recovered_obj = SimpleNamespace(id_="urn:uuid:recovered")
+    hydrated_obj = SimpleNamespace(id_="urn:uuid:hydrated")
+
+    expand = MagicMock(return_value=expanded_obj)
+    validate = MagicMock()
+    recover = MagicMock(return_value=recovered_obj)
+    hydrate = MagicMock(return_value=hydrated_obj)
+
+    monkeypatch.setattr(oh, "_expand_inline_object", expand)
+    monkeypatch.setattr(oh, "_validate_inline_object", validate)
+    monkeypatch.setattr(oh, "_recover_typed_inline_object_from_dict", recover)
+    monkeypatch.setattr(oh, "_hydrate_inline_object_if_persistable", hydrate)
+
+    result = oh._prepare_activity_object_for_delivery(
+        activity, activity.id_, "Create", mock_dl
+    )
+
+    expand.assert_called_once()
+    validate.assert_called_once_with(activity.id_, "Create", expanded_obj)
+    recover.assert_called_once_with(
+        expanded_obj, "Create", activity.id_, activity
+    )
+    hydrate.assert_called_once_with(recovered_obj, activity, mock_dl)
+    assert result is hydrated_obj
+
+
 def test_handle_outbox_item_converts_typed_activity_with_full_target():
     """handle_outbox_item delivers when activity.target is a full domain object.
 

--- a/vultron/adapters/driving/fastapi/outbox_handler.py
+++ b/vultron/adapters/driving/fastapi/outbox_handler.py
@@ -109,6 +109,24 @@ _INLINE_OBJECT_ACTIVITY_TYPES: frozenset[str] = frozenset(
 )
 
 
+def _is_stub_object_dict(value: dict[object, object]) -> bool:
+    """Return True when ``value`` is an intentional selective-disclosure stub."""
+    return (
+        value.get("type") in _STUB_OBJECT_TYPES and value.keys() <= _STUB_KEYS
+    )
+
+
+def _coerce_reference_value(value: object) -> object:
+    """Collapse reference dicts to URI strings unless they are stubs."""
+    if not isinstance(value, dict):
+        return value
+    if _is_stub_object_dict(value):
+        return value
+    # Prefer href (AS2 Link) then id (any AS2 object)
+    uri = value.get("href") or value.get("id")
+    return uri if uri is not None else value
+
+
 def _dehydrate_references(activity_dict: dict) -> dict:
     """Collapse domain-object dicts in reference fields to URI strings.
 
@@ -132,30 +150,15 @@ def _dehydrate_references(activity_dict: dict) -> dict:
         possible.
     """
 
-    def _coerce(value: object) -> object:
-        if not isinstance(value, dict):
-            return value
-        # Preserve minimal stub dicts that carry {id, type} for selective
-        # disclosure (MV-10-001).  Only VulnerabilityCase stubs are preserved;
-        # all other object dicts (e.g. actors) are collapsed to a bare URI.
-        if (
-            value.get("type") in _STUB_OBJECT_TYPES
-            and value.keys() <= _STUB_KEYS
-        ):
-            return value
-        # Prefer href (AS2 Link) then id (any AS2 object)
-        uri = value.get("href") or value.get("id")
-        return uri if uri is not None else value
-
     result = dict(activity_dict)
     for field in _DEHYDRATION_FIELDS:
         value = result.get(field)
         if value is None:
             continue
         if isinstance(value, list):
-            result[field] = [_coerce(item) for item in value]
+            result[field] = [_coerce_reference_value(item) for item in value]
         else:
-            result[field] = _coerce(value)
+            result[field] = _coerce_reference_value(value)
     return result
 
 
@@ -196,6 +199,16 @@ def _extract_recipients(activity) -> list[str]:
     Returns:
         Deduplicated list of recipient actor ID strings.
     """
+
+    def _item_actor_id(item: object) -> str | None:
+        if isinstance(item, str):
+            return item
+        if hasattr(item, "id_"):
+            actor_id = getattr(item, "id_", None)
+            if isinstance(actor_id, str):
+                return actor_id
+        return None
+
     seen: set[str] = set()
     recipients: list[str] = []
     for field in ("to", "cc", "bto", "bcc"):
@@ -204,11 +217,8 @@ def _extract_recipients(activity) -> list[str]:
             continue
         items = val if isinstance(val, list) else [val]
         for item in items:
-            if isinstance(item, str):
-                actor_id = item
-            elif hasattr(item, "id_"):
-                actor_id = item.id_
-            else:
+            actor_id = _item_actor_id(item)
+            if actor_id is None:
                 continue
             if actor_id not in seen:
                 seen.add(actor_id)
@@ -332,6 +342,92 @@ def _validate_inline_object(
         )
 
 
+def _recover_typed_inline_object_from_dict(
+    activity_object: object,
+    activity_type: str,
+    activity_id: str,
+    outbound_activity: VultronActivity,
+) -> object:
+    """Reconstruct a typed object from ``dict`` payloads when possible.
+
+    This preserves the queued outbound object payload while enabling the
+    downstream ``dl.hydrate()`` path for persistable domain models.
+    """
+    if not isinstance(activity_object, dict) or isinstance(
+        activity_object, BaseModel
+    ):
+        return activity_object
+
+    obj_type = activity_object.get("type", "")
+    if activity_object.keys() <= _STUB_KEYS:
+        return activity_object
+
+    model_class = _STUB_OBJECT_MODEL_MAP.get(obj_type)
+    if model_class is None:
+        return activity_object
+
+    try:
+        full_obj = model_class.model_validate(activity_object)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Failed to reconstruct %s model for %s activity '%s';"
+            " hydration will be skipped.",
+            obj_type,
+            activity_type,
+            activity_id,
+        )
+        return activity_object
+
+    outbound_activity.object_ = full_obj
+    logger.debug(
+        "Recovered typed %s from dict for %s activity '%s'.",
+        model_class.__name__,
+        activity_type,
+        activity_id,
+    )
+    return full_obj
+
+
+def _hydrate_inline_object_if_persistable(
+    activity_object: object,
+    outbound_activity: VultronActivity,
+    dl: DataLayer,
+) -> object:
+    """Hydrate persistable inline objects through the configured ``DataLayer``."""
+    if not isinstance(activity_object, BaseModel):
+        return activity_object
+    hydrated_object = dl.hydrate(cast(PersistableModel, activity_object))
+    outbound_activity.object_ = hydrated_object
+    return hydrated_object
+
+
+def _prepare_activity_object_for_delivery(
+    outbound_activity: VultronActivity,
+    activity_id: str,
+    activity_type: str,
+    dl: DataLayer,
+) -> object:
+    """Normalize and validate ``object_`` before recipient delivery."""
+    activity_object = getattr(outbound_activity, "object_", None)
+    activity_object = _expand_inline_object(
+        outbound_activity,
+        activity_id,
+        activity_type,
+        activity_object,
+        dl,
+    )
+    _validate_inline_object(activity_id, activity_type, activity_object)
+    activity_object = _recover_typed_inline_object_from_dict(
+        activity_object,
+        activity_type,
+        activity_id,
+        outbound_activity,
+    )
+    return _hydrate_inline_object_if_persistable(
+        activity_object, outbound_activity, dl
+    )
+
+
 async def handle_outbox_item(
     actor_id: str,
     activity_id: str,
@@ -365,62 +461,11 @@ async def handle_outbox_item(
     activity_type = (
         raw_activity_type if isinstance(raw_activity_type, str) else "Activity"
     )
-    activity_object = getattr(outbound_activity, "object_", None)
     _validate_to_field(outbound_activity, activity_id, activity_type)
     _warn_secondary_addressing(outbound_activity, activity_id, activity_type)
-    activity_object = _expand_inline_object(
-        outbound_activity,
-        activity_id,
-        activity_type,
-        activity_object,
-        dl,
+    activity_object = _prepare_activity_object_for_delivery(
+        outbound_activity, activity_id, activity_type, dl
     )
-    _validate_inline_object(activity_id, activity_type, activity_object)
-
-    # Recover typed model when object_ is a raw dict.
-    #
-    # _load_outbound_activity round-trips through model_dump() →
-    # VultronActivity.model_validate(), which stores the nested object
-    # as a plain dict (VultronActivity.object_ is Any | None).
-    # Without this recovery step, isinstance(…, BaseModel) is False and
-    # dl.hydrate() is never called — participant expansion is skipped
-    # (see #585).
-    #
-    # Reconstruct the typed model from the dict itself (not from dl.read())
-    # so the emitted object reflects exactly what was queued, not a
-    # potentially-updated DB snapshot.
-    #
-    # Skip intentional stubs (keys ⊆ _STUB_KEYS) and non-recoverable types
-    # (e.g. CaseLogEntry) — these are passed through as dicts.
-    if isinstance(activity_object, dict) and not isinstance(
-        activity_object, BaseModel
-    ):
-        obj_type = activity_object.get("type", "")
-        is_stub = activity_object.keys() <= _STUB_KEYS
-        model_class = _STUB_OBJECT_MODEL_MAP.get(obj_type)
-        if not is_stub and model_class is not None:
-            try:
-                full_obj = model_class.model_validate(activity_object)
-                activity_object = full_obj
-                outbound_activity.object_ = activity_object
-                logger.debug(
-                    "Recovered typed %s from dict for %s activity '%s'.",
-                    model_class.__name__,
-                    activity_type,
-                    activity_id,
-                )
-            except Exception:
-                logger.warning(
-                    "Failed to reconstruct %s model for %s activity '%s';"
-                    " hydration will be skipped.",
-                    obj_type,
-                    activity_type,
-                    activity_id,
-                )
-
-    if isinstance(activity_object, BaseModel):
-        activity_object = dl.hydrate(cast(PersistableModel, activity_object))
-        outbound_activity.object_ = activity_object
 
     recipients = _extract_recipients(outbound_activity)
     if not recipients:


### PR DESCRIPTION
- Closes #874

## Summary

Refactors outbox delivery internals in outbox_handler.py to split object normalization and reference dehydration into focused helper functions, reducing function complexity while preserving behavior.

## Changes

- vultron/adapters/driving/fastapi/outbox_handler.py: extracted dedicated helpers for stub/reference coercion, inline object recovery, hydration, and delivery preparation.
- vultron/adapters/driving/fastapi/outbox_handler.py: simplified recipient extraction with typed actor-id normalization and reduced branch nesting.
- vultron/adapters/driving/fastapi/outbox_handler.py: narrowed model-recovery exception handling to validation/type failures and kept logging semantics intact.

## Verification

- 3156 passed, 14 skipped, 219 deselected, 5633 subtests passed (uv run pytest --tb=short 2>&1 | tail -5)
- Black, flake8, mypy, pyright clean