### PR TITLE
Tighten BTND-07 structure requirements and align guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -345,25 +345,18 @@ Short entries are reproduced here; longer ones are referenced below.
   simple leaf nodes; the tree structure becomes the workflow documentation.
   See [notes/bt-integration.md](notes/bt-integration.md)
   § "DO NOT: God BT nodes with long `update()` methods".
-- **Large `nodes.py` Files Are a Code Smell — Split at 500 Lines** — A
-  `nodes.py` that has grown large is a high-churn, high-blast-radius module.
-  Every change — regardless of which workflow step it touches — modifies the
-  same file, making review shallow and increasing the risk of duplicate method
-  definitions silently shadowing correct logic. The trigger is file size, not
-  class count: any `nodes.py` approaching or exceeding 500 lines
-  (CS-18-002) SHOULD be converted to a `nodes/` subpackage with submodules
-  grouped by semantic concern (e.g., `conditions.py`, `case_setup.py`,
-  `participant.py`, `embargo.py`, `communication.py`, `lifecycle.py`). The
-  `__init__.py` MUST re-export all public names to preserve caller import paths.
-  Mirror the split in the test suite: a `test/…/nodes/` directory with one
-  `test_<submodule>.py` per submodule. More broadly, every process area under
-  `vultron/core/behaviors/` SHOULD use a `nodes/` subpackage even for small
-  modules — the `nodes/` subpackage is the standard structural unit for leaf
-  nodes regardless of current size. See `specs/behavior-tree-node-design.yaml`
-  BTND-07-001, BTND-07-002, and BTND-07-003.
+- **Flat `nodes.py` in BT Areas Is Non-Compliant** — BT-bearing process
+  areas under `vultron/core/behaviors/` MUST use a `nodes/` subpackage for
+  leaf nodes and MUST keep tree composition in root `*_tree.py` modules.
+  A flat `nodes.py` in a BT area is non-compliant regardless of size.
+  Group leaf submodules by semantic concern (e.g., `conditions.py`,
+  `case_setup.py`, `participant.py`, `embargo.py`, `communication.py`,
+  `lifecycle.py`). The `__init__.py` MUST re-export all public names to
+  preserve caller import paths. See
+  `specs/behavior-tree-node-design.yaml` BTND-07-001 and BTND-07-003.
 - **Splits Must Not Produce New God Modules** — When splitting a large
   module into a subpackage, each resulting submodule must itself stay under
-  500 lines (CS-18-002). The split pattern is **recursive**: a submodule
+  500 lines (BTND-07-004, CS-18-002). The split pattern is **recursive**: a submodule
   that re-accumulates size across multiple concerns must be further
   decomposed. For example, splitting `case/nodes.py` into a `nodes/`
   package produced `nodes/participant.py` at 816 lines — that file is itself

--- a/specs/behavior-tree-node-design.yaml
+++ b/specs/behavior-tree-node-design.yaml
@@ -254,16 +254,16 @@ groups:
   kind: pattern
   specs:
   - id: BTND-07-001
-    priority: SHOULD
+    priority: MUST
     statement: >-
-      (**SHOULD**) BT node classes for a given protocol step SHOULD be organized into a
-      `nodes/` subpackage rather than a single flat `nodes.py` module. This applies to
-      all process areas in `vultron/core/behaviors/` regardless of the current number of
-      node classes or total file size — the `nodes/` subpackage is the standard
-      organizational unit for leaf node implementations. Submodules MUST be grouped by
-      semantic concern (e.g., `conditions.py`, `case_setup.py`, `participant.py`,
-      `embargo.py`, `communication.py`, `lifecycle.py`). The package `__init__.py` MUST
-      re-export all public node names to preserve import compatibility with callers.
+      BT node classes for a given protocol step MUST be organized into a `nodes/`
+      subpackage rather than a single flat `nodes.py` module. This applies to all
+      BT-bearing process areas in `vultron/core/behaviors/` regardless of current node
+      count or file size — the `nodes/` subpackage is the standard organizational unit
+      for leaf node implementations. Submodules MUST be grouped by semantic concern
+      (e.g., `conditions.py`, `case_setup.py`, `participant.py`, `embargo.py`,
+      `communication.py`, `lifecycle.py`). The package `__init__.py` MUST re-export all
+      public node names to preserve import compatibility with callers.
     rationale: >-
       A flat `nodes.py` becomes a high-churn, high-blast-radius file where every change
       — regardless of which workflow step it touches — modifies the same module. This
@@ -278,10 +278,10 @@ groups:
     - rel_type: refines
       spec_id: BT-06-004
     verification: >-
-      Every process area directory under `vultron/core/behaviors/` that contains BT
-      node classes SHOULD have a `nodes/` subpackage. Any flat `nodes.py` in a process
-      area directory is a candidate for conversion, with priority given to files
-      exceeding 500 lines (CS-18-002).
+      Every BT-bearing process area under `vultron/core/behaviors/` has a `nodes/`
+      subpackage and does not retain a flat `nodes.py` module at the area root.
+      Helper-only areas that do not define BT tree composition or BT leaf nodes are
+      exempt.
   - id: BTND-07-002
     priority: SHOULD
     statement: >-
@@ -299,13 +299,13 @@ groups:
       For any `nodes/` subpackage, confirm that a matching `test/…/nodes/` directory
       exists with per-submodule test files.
   - id: BTND-07-003
-    priority: SHOULD
+    priority: MUST
     statement: >-
-      (**SHOULD**) Each process area directory under `vultron/core/behaviors/` SHOULD
+      Each BT-bearing process area directory under `vultron/core/behaviors/` MUST
       maintain a clear structural split between tree factory modules and leaf node
       modules. Tree factory modules (files named `*_tree.py` at the area root) define
-      BT composition and structure. Leaf node modules (files in the `nodes/` subpackage)
-      define BT `Behaviour` subclasses. Supporting files (e.g., `policy.py`,
+      BT composition and structure. Leaf node modules (files in the `nodes/`
+      subpackage) define BT `Behaviour` subclasses. Supporting files (e.g., `policy.py`,
       `update_support.py`) MAY exist at the area root alongside tree modules. This
       two-level hierarchy MAY be deepened further: a `nodes/` subpackage MAY itself
       contain sub-subpackages when a semantic concern grows large, following the same
@@ -321,7 +321,22 @@ groups:
     - rel_type: refines
       spec_id: BTND-07-001
     verification: >-
-      For each process area under `vultron/core/behaviors/`, confirm that `*_tree.py`
-      modules do not define `Behaviour` subclasses inline (except trivial one-off
-      composites), and that `nodes/` submodules do not define top-level tree factory
-      functions.
+      For each BT-bearing process area under `vultron/core/behaviors/`, confirm that
+      `*_tree.py` modules do not define `Behaviour` subclasses inline (except trivial
+      one-off composites), and that `nodes/` submodules do not define top-level tree
+      factory functions.
+  - id: BTND-07-004
+    priority: MUST
+    statement: >-
+      BT leaf node modules under `vultron/core/behaviors/**/nodes/` MUST stay under
+      500 lines each. A leaf module that exceeds 500 lines MUST be further decomposed
+      into concern-focused modules or subpackages.
+    rationale: >-
+      Subpackage splits fail when they recreate the same god-module risk in a new file.
+      A hard per-module cap keeps decomposition recursive and auditable.
+    relationships:
+    - rel_type: refines
+      spec_id: CS-18-002
+    verification: >-
+      For each BT-bearing area, scan `nodes/` modules and fail compliance when any leaf
+      module exceeds 500 lines.


### PR DESCRIPTION
## Summary
Tightens BTND-07 so BT module split rules are normative, and aligns project agent guidance with those stricter requirements.

## Changes
- Promoted BTND-07-001 to MUST and clarified it applies to BT-bearing behavior areas with required nodes/ subpackages.
- Promoted BTND-07-003 to MUST and codified the tree/leaf split as root *_tree.py composition plus nodes/ leaf modules.
- Added new MUST requirement BTND-07-004 requiring BT leaf modules under nodes/ to stay under 500 lines.
- Updated root AGENTS.md pitfall guidance to reflect the stricter non-compliance rule for flat nodes.py in BT areas.
- Created and wired migration/enforcement issues under parent #612:
  - #911 (status migration)
  - #912 (embargo migration)
  - #913 (note+sender migration)
  - #914 (pytest CI enforcement), blocked by #911, #912, #913

## Verification
- uv run pytest test/metadata/test_specs_format.py test/metadata/specs/test_real_specs.py -q -> 5 passed
- ./mdlint.sh -> 0 errors
