### PR TITLE
Add duplicate-delivery idempotency coverage

### DIFF
--- a/plan/history/2606/implementation/ISSUE-903.md
+++ b/plan/history/2606/implementation/ISSUE-903.md
@@ -1,0 +1,14 @@
+---
+source: ISSUE-903
+timestamp: '2026-06-11T20:29:50.792893+00:00'
+title: Duplicate-delivery idempotency coverage
+type: implementation
+---
+
+## Issue #903 — SYNC Integration: duplicate-delivery idempotency for CaseLogEntry
+
+Added a new integration test in `test/demo/test_sync_log_replication.py` that delivers the same `Announce(CaseLogEntry)` twice through isolated FastAPI apps and the shared `_TestASGIRouter`.
+
+The test now proves the idempotency guard by asserting the peer DataLayer saves the `CaseLogEntry` exactly once, instead of relying only on the final replica row count.
+
+PR: [#919](https://github.com/CERTCC/Vultron/pull/919)

--- a/test/demo/test_sync_log_replication.py
+++ b/test/demo/test_sync_log_replication.py
@@ -299,3 +299,93 @@ def test_sync_predecessor_mismatch_reject_and_replay(two_app_setup) -> None:
     assert peer_iso.dl.read(entry1.id_) is not None
     assert peer_iso.dl.read(entry2.id_) is not None
     assert case_actor_iso.dl is not peer_iso.dl
+
+
+@pytest.mark.spec("SYNC-03-003")
+@pytest.mark.spec("SYNC-07-003")
+def test_sync_duplicate_delivery_idempotency(
+    two_app_setup, monkeypatch
+) -> None:
+    """Duplicate delivery of Announce(CaseLogEntry) must produce one replica.
+
+    Delivers the same ``Announce(CaseLogEntry)`` twice to the peer actor
+    and verifies the peer replica contains exactly one copy of the entry
+    (SYNC-03-003: replication MUST be idempotent; repeated delivery MUST NOT
+    produce duplicate entries).
+    """
+    case_actor_iso, peer_iso, case_actor_tc, peer_tc = two_app_setup
+
+    case_actor_base_api = f"{case_actor_iso.base_url}/api/v2"
+    peer_base_api = f"{peer_iso.base_url}/api/v2"
+
+    case_actor_id = _create_actor(
+        case_actor_tc, case_actor_base_api, "case-actor-sync-903", "Service"
+    )
+    peer_actor_id = _create_actor(
+        peer_tc, peer_base_api, "peer-sync-903", "Organization"
+    )
+
+    case = VulnerabilityCase(
+        name="SYNC-903 duplicate delivery integration case"
+    )
+    case_actor_participant = CaseParticipant(
+        attributed_to=case_actor_id,
+        context=case.id_,
+    )
+    peer_participant = CaseParticipant(
+        attributed_to=peer_actor_id,
+        context=case.id_,
+    )
+    case.case_participants.append(case_actor_participant.id_)
+    case.case_participants.append(peer_participant.id_)
+    case.actor_participant_index[case_actor_id] = case_actor_participant.id_
+    case.actor_participant_index[peer_actor_id] = peer_participant.id_
+
+    # Peer needs the case and participants in its DataLayer to process inbound
+    # Announce(CaseLogEntry) as a participant, not as a CaseActor owner.
+    peer_iso.dl.save(case_actor_participant)
+    peer_iso.dl.save(peer_participant)
+    peer_iso.dl.save(case)
+
+    saved_case_log_entry_ids: list[str] = []
+    original_save = peer_iso.dl.save
+
+    def save_spy(obj, *args, **kwargs):
+        if getattr(obj, "type_", None) == "CaseLogEntry":
+            saved_case_log_entry_ids.append(getattr(obj, "id_", ""))
+        return original_save(obj, *args, **kwargs)
+
+    monkeypatch.setattr(peer_iso.dl, "save", save_spy)
+
+    entry = _make_log_entry(case.id_, 0, GENESIS_HASH, "sync_903_dup")
+    wire_entry = WireCaseLogEntry.model_validate(entry.model_dump(mode="json"))
+    announce = announce_log_entry_activity(
+        entry=wire_entry,
+        actor=case_actor_id,
+        to=[peer_actor_id],
+    )
+
+    # Deliver the same Announce(CaseLogEntry) twice.
+    for _ in range(2):
+        handle_inbox_item(
+            actor_id=peer_actor_id,
+            obj=announce,
+            dl=peer_iso.dl,
+            dispatcher=peer_iso.app.state.dispatcher,
+        )
+
+    assert saved_case_log_entry_ids == [entry.id_]
+
+    # Peer replica must contain exactly one copy (idempotent behavior).
+    stored_entries = [
+        e
+        for e in peer_iso.dl.list_objects("CaseLogEntry")
+        if getattr(e, "case_id", None) == case.id_
+    ]
+    assert (
+        len(stored_entries) == 1
+    ), f"Expected exactly 1 CaseLogEntry replica, got {len(stored_entries)}"
+    assert stored_entries[0].id_ == entry.id_
+
+    # AC-4 guard: each actor app must use its own isolated DataLayer.
+    assert case_actor_iso.dl is not peer_iso.dl


### PR DESCRIPTION
- Closes #903

## Summary

Add integration coverage proving duplicate delivery of the same Announce(CaseLogEntry) does not create duplicate replica history.

## Changes

- test/demo/test_sync_log_replication.py: add a new integration test that delivers the same log-entry announcement twice through isolated FastAPI apps and the shared test ASGI router.
- test/demo/test_sync_log_replication.py: assert the peer DataLayer only saves the log entry once, so the test exercises the idempotency guard directly.

## Verification

- uv run black vultron/ test/ && uv run flake8 vultron/ test/
- uv run pytest test/demo/test_sync_log_replication.py -m "" --tb=short 2>&1 | tail -20
- uv run pytest -m "" --tb=short 2>&1 | tail -5
