### PR TITLE
Add unit test guard for ProdHttpDeliveryAdapter stub

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -56,3 +56,10 @@ When converting a behavior area from `nodes.py` to `nodes/`, preserve
 re-export list, and move node-level tests into `test/.../nodes/` with
 per-submodule files. Keep tree composition tests in the parent workflow test
 module so node behavior and tree wiring remain independently reviewable.
+
+### 2026-06-11 OX-10-004-STUB-GUARD — keep stub adapters under explicit test
+
+`ProdHttpDeliveryAdapter` is intentionally unimplemented and must fail fast
+with a spec-linked `NotImplementedError`. A dedicated adapter-level unit test
+prevents future placeholder edits from silently downgrading the fail-fast
+signal into a no-op module.

--- a/test/adapters/driven/test_prod_http_delivery.py
+++ b/test/adapters/driven/test_prod_http_delivery.py
@@ -1,0 +1,11 @@
+import pytest
+
+from vultron.adapters.driven.prod_http_delivery import ProdHttpDeliveryAdapter
+
+
+def test_prod_http_delivery_adapter_init_raises_not_implemented() -> None:
+    with pytest.raises(
+        NotImplementedError,
+        match=r"ProdHttpDeliveryAdapter is not implemented yet.*OX-10-004",
+    ):
+        ProdHttpDeliveryAdapter()


### PR DESCRIPTION
- Closes #717

## Summary

Adds explicit test coverage for the unimplemented production HTTP delivery stub so accidental use fails fast with a spec-linked error.

## Changes

- test/adapters/driven/test_prod_http_delivery.py: added a unit test asserting ProdHttpDeliveryAdapter() raises NotImplementedError and includes OX-10-004.
- plan/BUILD_LEARNINGS.md: recorded the fail-fast stub-testing observation for OX-10-004 placeholder adapters.

## Verification

- uv run pytest --tb=short 2>&1 | tail -5 -> 3203 passed, 14 skipped, 221 deselected
- uv run black vultron/ test/ && uv run flake8 vultron/ test/ && uv run mypy && uv run pyright