### PR TITLE
Remove events field and record_event() from wire-layer VulnerabilityCase

### DIFF
--- a/plan/history/2606/implementation/ISSUE-888.md
+++ b/plan/history/2606/implementation/ISSUE-888.md
@@ -1,0 +1,31 @@
+---
+source: ISSUE-888
+timestamp: '2026-06-12T13:06:57.153342+00:00'
+title: Remove events field and record_event() from wire-layer VulnerabilityCase
+type: implementation
+---
+
+## Issue #888 — Remove events field and record_event() from wire-layer VulnerabilityCase
+
+Removed the duplicate `events: list[CaseEvent]` field and `record_event()` method
+from the wire-layer `VulnerabilityCase` class. These were a layer-boundary violation:
+wire-layer objects were accumulating domain state that belongs only in the core model.
+
+**Changes:**
+
+- Removed `CaseEvent` import, `events` field, and `record_event()` from
+  `vultron/wire/as2/vocab/objects/vulnerability_case.py`
+- Removed `events` and `record_event()` from `CaseModel` Protocol in `protocols.py`
+- Removed `hasattr(obj, 'record_event')` from `is_case_model()` TypeGuard
+- Removed `record_event()` calls from 7 BT/use-case call sites across
+  embargo, case setup, participant, and received-actor modules
+- Simplified `verification.py`: participant presence already validated via
+  `actor_participant_index`
+- Updated tests to use behavioral assertions (participant index, active_embargo,
+  tree success) instead of the removed `case.events` field
+
+**Outcome:** 3412 passed, 14 skipped, 3 xfailed in 57s. All 4 linters pass.
+Core `VulnerabilityCase` retains `events`/`record_event()` (issue #792 handles
+core removal). Wire-layer `from_core()` unaffected via Pydantic `extra='ignore'`.
+
+PR: [#922](https://github.com/CERTCC/Vultron/pull/922)

--- a/test/core/behaviors/case/nodes/participant/test_owner.py
+++ b/test/core/behaviors/case/nodes/participant/test_owner.py
@@ -185,7 +185,7 @@ class TestCreateCaseOwnerParticipant:
         case_obj: VultronCase,
         actor_id: str,
     ) -> None:
-        """CreateCaseOwnerParticipant records 'owner_joined' on the case."""
+        """CreateCaseOwnerParticipant attaches the owner participant to the case."""
         result = bt_scenario.run(
             CreateCaseOwnerParticipant(),
             actor_id=actor_id,
@@ -194,8 +194,8 @@ class TestCreateCaseOwnerParticipant:
         bt_scenario.assert_success(result)
 
         stored_case = cast(Any, bt_scenario.dl.read(case_obj.id_))
-        event_types = [e.event_type for e in stored_case.events]
-        assert "owner_joined" in event_types
+        # Owner participant must be present in the case index
+        assert actor_id in stored_case.actor_participant_index
 
     def test_advances_owner_rm_to_accepted_when_configured(
         self,

--- a/test/core/behaviors/case/nodes/participant/test_participant_add.py
+++ b/test/core/behaviors/case/nodes/participant/test_participant_add.py
@@ -79,7 +79,7 @@ class TestCreateCaseParticipantNode:
         actor_id: str,
         finder_actor_id: str,
     ) -> None:
-        """CreateCaseParticipantNode records 'participant_added' on the case."""
+        """CreateCaseParticipantNode adds the participant to the case."""
         bt_scenario.run(
             CreateCaseParticipantNode(
                 actor_id=finder_actor_id, roles=[CVDRole.FINDER]
@@ -89,8 +89,8 @@ class TestCreateCaseParticipantNode:
         )
 
         stored_case = cast(Any, bt_scenario.dl.read(case_obj.id_))
-        event_types = [e.event_type for e in stored_case.events]
-        assert "participant_added" in event_types
+        # Participant must be present in the case index
+        assert finder_actor_id in stored_case.actor_participant_index
 
     def test_is_composed_subtree_of_named_leaf_nodes(self) -> None:
         node = CreateCaseParticipantNode(
@@ -184,7 +184,7 @@ class TestCreateCaseParticipantNode:
         case_obj: VultronCase,
         actor_id: str,
     ) -> None:
-        """CreateCaseOwnerParticipant does NOT record 'participant_added'."""
+        """CreateCaseOwnerParticipant adds the owner; no extra participants."""
         bt_scenario.run(
             CreateCaseOwnerParticipant(),
             actor_id=actor_id,
@@ -192,5 +192,5 @@ class TestCreateCaseParticipantNode:
         )
 
         stored_case = cast(Any, bt_scenario.dl.read(case_obj.id_))
-        event_types = [e.event_type for e in stored_case.events]
-        assert "participant_added" not in event_types
+        # Only the owner (actor_id) should be in the participant index
+        assert list(stored_case.actor_participant_index.keys()) == [actor_id]

--- a/test/core/behaviors/case/nodes/test_case_setup.py
+++ b/test/core/behaviors/case/nodes/test_case_setup.py
@@ -26,7 +26,6 @@ and GitHub issue #401.
 """
 
 import hashlib
-from typing import Any, cast
 from unittest.mock import MagicMock
 
 import py_trees
@@ -171,9 +170,8 @@ class TestRecordCaseCreationEvents:
             case_for_creation_events=case_obj,
         )
         bt_scenario.assert_success(result)
-        stored_case = cast(Any, bt_scenario.dl.read(case_obj.id_))
-        event_types = [e.event_type for e in stored_case.events]
-        assert "case_created" in event_types
+        stored_case = bt_scenario.dl.read(case_obj.id_)
+        assert stored_case is not None
 
     def test_record_offer_received_leaf_fails_without_case_id(
         self,
@@ -231,17 +229,15 @@ class TestRecordCaseCreationEvents:
         case_obj: VultronCase,
         actor_id: str,
     ) -> None:
-        """Without activity on blackboard, case_created event is recorded."""
+        """Without activity on blackboard, tree runs to SUCCESS."""
         result = bt_scenario.run(
             RecordCaseCreationEvents(case_obj=case_obj),
             actor_id=actor_id,
             case_id=case_obj.id_,
         )
         bt_scenario.assert_success(result)
-
-        stored_case = cast(Any, bt_scenario.dl.read(case_obj.id_))
-        event_types = [e.event_type for e in stored_case.events]
-        assert "case_created" in event_types
+        stored_case = bt_scenario.dl.read(case_obj.id_)
+        assert stored_case is not None
 
     def test_records_offer_received_event_when_activity_has_in_reply_to(
         self,
@@ -251,7 +247,7 @@ class TestRecordCaseCreationEvents:
         report: VultronReport,
         actor_id: str,
     ) -> None:
-        """With activity.in_reply_to set, offer_received event is backfilled."""
+        """With activity.in_reply_to set, tree runs to SUCCESS."""
         offer_mock = MagicMock()
         offer_mock.id_ = "https://example.org/activities/offer-001"
         activity_mock = MagicMock()
@@ -264,11 +260,8 @@ class TestRecordCaseCreationEvents:
             activity=activity_mock,
         )
         bt_scenario.assert_success(result)
-
-        stored_case = cast(Any, bt_scenario.dl.read(case_obj.id_))
-        event_types = [e.event_type for e in stored_case.events]
-        assert "offer_received" in event_types
-        assert "case_created" in event_types
+        stored_case = bt_scenario.dl.read(case_obj.id_)
+        assert stored_case is not None
 
     def test_no_offer_received_when_activity_lacks_in_reply_to(
         self,
@@ -277,7 +270,7 @@ class TestRecordCaseCreationEvents:
         case_obj: VultronCase,
         actor_id: str,
     ) -> None:
-        """Activity without in_reply_to produces only case_created event."""
+        """Activity without in_reply_to still runs to SUCCESS."""
         activity_mock = MagicMock()
         activity_mock.in_reply_to = None
 
@@ -288,11 +281,8 @@ class TestRecordCaseCreationEvents:
             activity=activity_mock,
         )
         bt_scenario.assert_success(result)
-
-        stored_case = cast(Any, bt_scenario.dl.read(case_obj.id_))
-        event_types = [e.event_type for e in stored_case.events]
-        assert "offer_received" not in event_types
-        assert "case_created" in event_types
+        stored_case = bt_scenario.dl.read(case_obj.id_)
+        assert stored_case is not None
 
 
 # ---------------------------------------------------------------------------

--- a/test/core/behaviors/case/test_create_tree.py
+++ b/test/core/behaviors/case/test_create_tree.py
@@ -308,36 +308,30 @@ def test_create_case_tree_vendor_participant_seeded_with_rm_valid(
 def test_create_case_tree_records_case_created_event(
     datalayer, actor, case_obj, bridge
 ):
-    """A case_created event MUST be recorded in the case event log (CM-02-009)."""
+    """create_case_tree runs to SUCCESS and persists the case (CM-02-009)."""
     tree = create_create_case_tree(case_obj=case_obj, actor_id=actor.id_)
     bridge.execute_with_setup(tree=tree, actor_id=actor.id_, activity=None)
 
     stored = datalayer.read(case_obj.id_)
     assert stored is not None
-    event_types = [e.event_type for e in stored.events]
-    assert "case_created" in event_types
 
 
 def test_create_case_tree_case_created_event_uses_case_id(
     datalayer, actor, case_obj, bridge
 ):
-    """The case_created event MUST reference the case ID as object_id (CM-02-009)."""
+    """create_case_tree persists the case under the expected ID."""
     tree = create_create_case_tree(case_obj=case_obj, actor_id=actor.id_)
     bridge.execute_with_setup(tree=tree, actor_id=actor.id_, activity=None)
 
     stored = datalayer.read(case_obj.id_)
     assert stored is not None
-    created_events = [
-        e for e in stored.events if e.event_type == "case_created"
-    ]
-    assert len(created_events) == 1
-    assert created_events[0].object_id == case_obj.id_
+    assert getattr(stored, "id_", None) == case_obj.id_
 
 
 def test_create_case_tree_records_offer_received_event_when_present(
     datalayer, actor, actor_id, case_obj, bridge
 ):
-    """If the triggering activity has in_reply_to, an offer_received event MUST be recorded (CM-02-009)."""
+    """create_case_tree runs to SUCCESS when triggering activity has in_reply_to."""
     from vultron.core.models.vultron_types import VultronOffer
 
     offer_id = "https://example.org/activities/offer-001"
@@ -352,33 +346,23 @@ def test_create_case_tree_records_offer_received_event_when_present(
 
     stored = datalayer.read(case_obj.id_)
     assert stored is not None
-    event_types = [e.event_type for e in stored.events]
-    assert "offer_received" in event_types
-
-    offer_events = [
-        e for e in stored.events if e.event_type == "offer_received"
-    ]
-    assert len(offer_events) == 1
-    assert offer_events[0].object_id == offer_id
 
 
 def test_create_case_tree_no_offer_received_event_without_in_reply_to(
     datalayer, actor, case_obj, bridge
 ):
-    """If the triggering activity has no in_reply_to, no offer_received event is recorded."""
+    """create_case_tree runs to SUCCESS when no in_reply_to is present."""
     tree = create_create_case_tree(case_obj=case_obj, actor_id=actor.id_)
     bridge.execute_with_setup(tree=tree, actor_id=actor.id_, activity=None)
 
     stored = datalayer.read(case_obj.id_)
     assert stored is not None
-    event_types = [e.event_type for e in stored.events]
-    assert "offer_received" not in event_types
 
 
 def test_create_case_tree_offer_received_before_case_created(
     datalayer, actor, actor_id, case_obj, bridge
 ):
-    """offer_received event MUST appear before case_created in the event log."""
+    """create_case_tree runs to SUCCESS with an in_reply_to activity."""
     from vultron.core.models.vultron_types import VultronOffer
 
     offer_id = "https://example.org/activities/offer-002"
@@ -393,28 +377,17 @@ def test_create_case_tree_offer_received_before_case_created(
 
     stored = datalayer.read(case_obj.id_)
     assert stored is not None
-    event_types = [e.event_type for e in stored.events]
-    assert event_types.index("offer_received") < event_types.index(
-        "case_created"
-    )
 
 
 def test_create_case_tree_events_have_trusted_timestamps(
     datalayer, actor, case_obj, bridge
 ):
-    """Case event timestamps MUST be server-generated (CM-02-009)."""
-    from datetime import timezone
-
+    """create_case_tree runs to SUCCESS and persists the case."""
     tree = create_create_case_tree(case_obj=case_obj, actor_id=actor.id_)
     bridge.execute_with_setup(tree=tree, actor_id=actor.id_, activity=None)
 
     stored = datalayer.read(case_obj.id_)
     assert stored is not None
-    assert len(stored.events) >= 1
-    for evt in stored.events:
-        assert evt.received_at is not None
-        assert evt.received_at.tzinfo is not None
-        assert evt.received_at.tzinfo == timezone.utc
 
 
 # ============================================================================

--- a/test/core/behaviors/case/test_receive_report_case_tree.py
+++ b/test/core/behaviors/case/test_receive_report_case_tree.py
@@ -442,8 +442,8 @@ def test_tree_records_embargo_initialized_event(
     reporter_accepted_status,
     vendor_received_status,
 ):
-    """After embargo initialization, an 'embargo_initialized' event MUST be
-    recorded in the case event log (D5-7-EMSTATE-1, CM-02-009).
+    """After embargo initialization, the case MUST have an active embargo set
+    (D5-7-EMSTATE-1, CM-02-009).
     """
     tree = create_receive_report_case_tree(
         report_id=report.id_,
@@ -454,10 +454,7 @@ def test_tree_records_embargo_initialized_event(
 
     case = datalayer.find_case_by_report_id(report.id_)
     assert case is not None
-    event_types = [e.event_type for e in case.events]
-    assert (
-        "embargo_initialized" in event_types
-    ), f"Expected 'embargo_initialized' in case events, got {event_types}"
+    assert case.active_embargo is not None
 
 
 def test_tree_embargo_initialized_event_references_embargo_id(
@@ -471,8 +468,8 @@ def test_tree_embargo_initialized_event_references_embargo_id(
     reporter_accepted_status,
     vendor_received_status,
 ):
-    """The 'embargo_initialized' event MUST reference the embargo's ID as
-    object_id (D5-7-EMSTATE-1, CM-02-009).
+    """The active_embargo on the case MUST reference the embargo's ID
+    (D5-7-EMSTATE-1, CM-02-009).
     """
     tree = create_receive_report_case_tree(
         report_id=report.id_,
@@ -484,11 +481,6 @@ def test_tree_embargo_initialized_event_references_embargo_id(
     case = datalayer.find_case_by_report_id(report.id_)
     assert case is not None
     assert case.active_embargo is not None
-    embargo_events = [
-        e for e in case.events if e.event_type == "embargo_initialized"
-    ]
-    assert len(embargo_events) == 1
-    assert embargo_events[0].object_id == case.active_embargo
 
 
 def test_tree_queues_create_case_activity(

--- a/test/core/models/test_case.py
+++ b/test/core/models/test_case.py
@@ -326,20 +326,3 @@ class TestVulnerabilityCaseWireRoundTrip:
         wire_case = WireVC.from_core(core_case)
         restored = wire_case.to_core()
         assert restored.active_embargo == "urn:uuid:embargo-1"
-
-    def test_to_core_events_field_preserved(self):
-        from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase as WireVC,
-        )
-
-        wire_case = WireVC(
-            id_="urn:uuid:vc-events",
-            attributed_to="https://example.org/actor",
-        )
-        wire_case.record_event("urn:uuid:obj", "test_event")
-        core_case = wire_case.to_core()
-        assert isinstance(core_case, VulnerabilityCase)
-        # events are preserved as embedded CaseEvent objects
-        assert len(core_case.events) == 1
-        assert isinstance(core_case.events[0], CaseEvent)
-        assert core_case.events[0].event_type == "test_event"

--- a/test/core/use_cases/received/test_actor.py
+++ b/test/core/use_cases/received/test_actor.py
@@ -388,16 +388,13 @@ class TestInviteActorUseCases:
 
         event = make_payload(accept)
 
-        assert len(case.events) == 0
-
         AcceptInviteActorToCaseReceivedUseCase(dl, event).execute()
 
         case = dl.read(case.id_)
         assert case is not None
         case = cast(VulnerabilityCase, case)
-        assert len(case.events) >= 1
-        event_types = [e.event_type for e in case.events]
-        assert "participant_joined" in event_types
+        # Verify participant was added to the case
+        assert invitee_id in case.actor_participant_index
 
 
 class TestSuggestActorUseCases:

--- a/test/core/use_cases/received/test_embargo.py
+++ b/test/core/use_cases/received/test_embargo.py
@@ -386,54 +386,9 @@ class TestEmbargoUseCases:
         updated_participant = cast(Any, updated_participant)
         assert embargo.id_ in updated_participant.accepted_embargo_ids
 
-    def test_accept_invite_to_embargo_records_case_event(
-        self, monkeypatch, make_payload
-    ):
-        """accept_invite_to_embargo_on_case appends a trusted-timestamp event to case.events (CM-02-009)."""
-        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
-        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
-        from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
-        )
-
-        dl = SqliteDataLayer("sqlite:///:memory:")
-        coordinator_id = "https://example.org/users/coordinator"
-        case = VulnerabilityCase(
-            id_="https://example.org/cases/case_em6",
-            name="EM Accept Event Test",
-            attributed_to=coordinator_id,
-        )
-        embargo = EmbargoEvent(
-            id_="https://example.org/cases/case_em6/embargo_events/e6",
-            content="Embargo",
-        )
-        proposal = em_propose_embargo_activity(
-            embargo,
-            context=case,
-            actor="https://example.org/users/vendor",
-            id_="https://example.org/cases/case_em6/embargo_proposals/1",
-        )
-        dl.create(case)
-        dl.create(embargo)
-        dl.create(proposal)
-
-        accept = em_accept_embargo_activity(
-            proposal,
-            context=case,
-            actor=coordinator_id,
-        )
-        event = make_payload(accept)
-
-        assert len(case.events) == 0
-
-        AcceptInviteToEmbargoOnCaseReceivedUseCase(dl, event).execute()
-
-        case = dl.read(case.id_)
-        assert case is not None
-        case = cast(VulnerabilityCase, case)
-        assert len(case.events) >= 1
-        event_types = [e.event_type for e in case.events]
-        assert "embargo_accepted" in event_types
+    # test_accept_invite_to_embargo_records_case_event was removed in issue #888.
+    # The wire-layer VulnerabilityCase no longer has a case.events field.
+    # EM state activation is covered by test_accept_invite_to_embargo_on_case_activates_embargo.
 
     def test_reject_invite_to_embargo_on_case_logs_rejection(
         self, make_payload

--- a/test/wire/as2/vocab/test_case_event.py
+++ b/test/wire/as2/vocab/test_case_event.py
@@ -1,5 +1,5 @@
 """
-Tests for CaseEvent model and VulnerabilityCase.events field (SC-PRE-1).
+Tests for CaseEvent model (SC-PRE-1).
 
 References: specs/case-management.yaml CM-02-009, CM-10-002.
 """
@@ -19,15 +19,11 @@ References: specs/case-management.yaml CM-02-009, CM-10-002.
 
 import unittest
 from datetime import datetime, timezone
-from typing import cast
 
 import pytest
 from pydantic import ValidationError
 
-from vultron.adapters.driven.db_record import object_to_record
-from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.wire.as2.vocab.objects.case_event import CaseEvent
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
 
 OBJ_ID = "https://example.org/reports/abc123"
 EVENT_TYPE = "embargo_accepted"
@@ -133,80 +129,6 @@ class TestCaseEventSerialization(unittest.TestCase):
             datetime(2026, 3, 6, 20, 0, 0, tzinfo=timezone.utc),
             evt.received_at,
         )
-
-
-class TestVulnerabilityCaseEventsField(unittest.TestCase):
-    """Test VulnerabilityCase.events field (SC-PRE-1)."""
-
-    def test_events_defaults_to_empty_list(self):
-        case = VulnerabilityCase()
-        self.assertEqual([], case.events)
-
-    def test_record_event_appends_to_events(self):
-        case = VulnerabilityCase()
-        evt = case.record_event(OBJ_ID, EVENT_TYPE)
-        self.assertEqual(1, len(case.events))
-        self.assertIs(evt, case.events[0])
-
-    def test_record_event_returns_case_event_with_correct_fields(self):
-        case = VulnerabilityCase()
-        evt = case.record_event(OBJ_ID, EVENT_TYPE)
-        self.assertEqual(OBJ_ID, evt.object_id)
-        self.assertEqual(EVENT_TYPE, evt.event_type)
-        self.assertIsNotNone(evt.received_at)
-        self.assertIsNotNone(evt.received_at.tzinfo)
-
-    def test_record_event_is_append_only(self):
-        case = VulnerabilityCase()
-        case.record_event(OBJ_ID, "participant_joined")
-        case.record_event(OBJ_ID, "embargo_accepted")
-        self.assertEqual(2, len(case.events))
-        self.assertEqual("participant_joined", case.events[0].event_type)
-        self.assertEqual("embargo_accepted", case.events[1].event_type)
-
-    def test_events_round_trip_via_object_to_record(self):
-        case = VulnerabilityCase()
-        case.record_event(OBJ_ID, EVENT_TYPE)
-        record = object_to_record(case)
-        data = record.data_
-        self.assertIn("events", data)
-        self.assertEqual(1, len(data["events"]))
-        evt_data = data["events"][0]
-        self.assertEqual(OBJ_ID, evt_data["object_id"])
-        self.assertEqual(EVENT_TYPE, evt_data["event_type"])
-        self.assertIn("received_at", evt_data)
-
-    def test_events_round_trip_via_datalayer(self):
-        dl = SqliteDataLayer("sqlite:///:memory:")
-        case = VulnerabilityCase()
-        ts = datetime(2026, 3, 6, 20, 0, 0, tzinfo=timezone.utc)
-        case.events.append(
-            CaseEvent(object_id=OBJ_ID, event_type=EVENT_TYPE, received_at=ts)
-        )
-        dl.create(case)
-        stored = cast(VulnerabilityCase, dl.read(case.id_))
-        self.assertIsNotNone(stored)
-        self.assertIsInstance(stored, VulnerabilityCase)
-        self.assertEqual(1, len(stored.events))
-        evt = stored.events[0]
-        self.assertEqual(OBJ_ID, evt.object_id)
-        self.assertEqual(EVENT_TYPE, evt.event_type)
-        self.assertEqual(ts, evt.received_at)
-
-    def test_events_preserved_on_model_validate(self):
-        ts = datetime(2026, 3, 6, 20, 0, 0, tzinfo=timezone.utc)
-        original = VulnerabilityCase()
-        original.events.append(
-            CaseEvent(object_id=OBJ_ID, event_type=EVENT_TYPE, received_at=ts)
-        )
-        data = original.model_dump(mode="json")
-        restored = VulnerabilityCase.model_validate(data)
-        self.assertEqual(1, len(restored.events))
-        evt = restored.events[0]
-        self.assertIsInstance(evt, CaseEvent)
-        self.assertEqual(OBJ_ID, evt.object_id)
-        self.assertEqual(EVENT_TYPE, evt.event_type)
-        self.assertEqual(ts, evt.received_at)
 
 
 if __name__ == "__main__":

--- a/vultron/core/behaviors/case/nodes/case_setup.py
+++ b/vultron/core/behaviors/case/nodes/case_setup.py
@@ -187,9 +187,8 @@ class RecordOfferReceivedEventNode(DataLayerAction):
             offer_id = (
                 offer_ref.id_ if hasattr(offer_ref, "id_") else str(offer_ref)
             )
-            case.record_event(offer_id, "offer_received")
             self.logger.info(
-                f"{self.name}: Recorded offer_received event"
+                f"{self.name}: Observed offer_received"
                 f" for {offer_id} on case {case_id}"
             )
 
@@ -240,9 +239,8 @@ class RecordCaseCreatedEventNode(DataLayerAction):
             )
             return Status.FAILURE
 
-        case.record_event(case_id, "case_created")
         self.logger.info(
-            f"{self.name}: Recorded case_created event on case {case_id}"
+            f"{self.name}: Observed case_created event on case {case_id}"
         )
         self.datalayer.save(case)
         return Status.SUCCESS

--- a/vultron/core/behaviors/case/nodes/embargo.py
+++ b/vultron/core/behaviors/case/nodes/embargo.py
@@ -292,7 +292,6 @@ class AttachEmbargoToCaseNode(DataLayerAction):
         if active_embargo_id is None:
             stored_case.active_embargo = embargo_id
             stored_case.current_status.em_state = EM.ACTIVE
-            stored_case.record_event(embargo_id, "embargo_initialized")
             self.datalayer.save(stored_case)
             self.logger.info(
                 "Attached embargo '%s' to case '%s' as active_embargo",

--- a/vultron/core/behaviors/case/nodes/participant/owner.py
+++ b/vultron/core/behaviors/case/nodes/participant/owner.py
@@ -379,7 +379,6 @@ class RecordOwnerJoinedEventNode(DataLayerAction):
             )
             return Status.FAILURE
 
-        stored_case.record_event(participant.id_, "owner_joined")
         self.datalayer.save(stored_case)
         return Status.SUCCESS
 

--- a/vultron/core/behaviors/case/nodes/participant/participant_add.py
+++ b/vultron/core/behaviors/case/nodes/participant/participant_add.py
@@ -221,7 +221,6 @@ class RecordParticipantAddedEventNode(DataLayerAction):
             )
             return Status.FAILURE
 
-        stored_case.record_event(participant_id, "participant_added")
         self.datalayer.save(stored_case)
         return Status.SUCCESS
 

--- a/vultron/core/behaviors/embargo/nodes/proposal.py
+++ b/vultron/core/behaviors/embargo/nodes/proposal.py
@@ -205,7 +205,6 @@ class RecordParticipantAcceptanceNode(DataLayerAction):
         if result.case_changed or result.case_embargo_changed:
             updated_case = self.datalayer.read(self.case_id)
             if is_case_model(updated_case):
-                updated_case.record_event(self.embargo_id, "embargo_accepted")
                 self.datalayer.save(updated_case)
 
         self.feedback_message = (

--- a/vultron/core/models/protocols.py
+++ b/vultron/core/models/protocols.py
@@ -56,7 +56,6 @@ class CaseModel(PersistableModel, Protocol):
     vulnerability_reports: list
     active_embargo: object
     actor_participant_index: dict[str, str]
-    events: list
     attributed_to: object
     notes: list
     case_statuses: list
@@ -66,7 +65,6 @@ class CaseModel(PersistableModel, Protocol):
     def set_embargo(self, embargo_id: str) -> None: ...
     def add_participant(self, participant: object) -> None: ...
     def remove_participant(self, participant_id: str) -> None: ...
-    def record_event(self, obj_id: str, event_type: str) -> None: ...
 
     @property
     def current_status(self) -> CaseStatusModel: ...
@@ -101,7 +99,6 @@ def is_case_model(obj: PersistableModel | None) -> TypeGuard[CaseModel]:
         obj is not None
         and getattr(obj, "type_", None) == "VulnerabilityCase"
         and hasattr(obj, "case_participants")
-        and hasattr(obj, "record_event")
     )
 
 

--- a/vultron/core/use_cases/received/actor.py
+++ b/vultron/core/use_cases/received/actor.py
@@ -599,9 +599,6 @@ class AcceptInviteActorToCaseReceivedUseCase:
         self._dl.create(participant)
 
         case.add_participant(participant)
-        case.record_event(invitee_id, "participant_joined")
-        if active_embargo_id and em_state == EM.ACTIVE:
-            case.record_event(active_embargo_id, "embargo_accepted")
         self._dl.save(case)
 
         # MV-10-003/MV-10-005: emit full case details to the invitee now that

--- a/vultron/core/use_cases/received/case_participant.py
+++ b/vultron/core/use_cases/received/case_participant.py
@@ -69,7 +69,6 @@ class AddCaseParticipantToCaseReceivedUseCase:
             return
 
         case.add_participant(participant)
-        case.record_event(participant_id, "participant_added")
         self._dl.save(case)
         logger.info(
             "Added participant '%s' to case '%s'", participant_id, case_id

--- a/vultron/demo/helpers/verification.py
+++ b/vultron/demo/helpers/verification.py
@@ -365,13 +365,6 @@ def verify_coordinator_case_state(
         coordinator_client, coordinator_participant_id
     )
 
-    event_types = [event.event_type for event in final_case.events]
-    if "participant_added" not in event_types:
-        raise AssertionError(
-            "Expected participant_added event after reporter was added to the"
-            " case"
-        )
-
     _assert_vendor_case_status(final_case)
     _assert_case_notes(final_case, question_note_id, reply_note_id)
     return final_case

--- a/vultron/wire/as2/vocab/objects/vulnerability_case.py
+++ b/vultron/wire/as2/vocab/objects/vulnerability_case.py
@@ -33,7 +33,6 @@ from vultron.wire.as2.vocab.objects.base import (
     _scalar_ref_id_or_value,
     _strip_core_context,
 )
-from vultron.wire.as2.vocab.objects.case_event import CaseEvent
 from vultron.wire.as2.vocab.objects.case_participant import (
     CaseParticipant,
     CaseParticipantRef,
@@ -113,8 +112,6 @@ class VulnerabilityCase(VultronAS2Object):
     proposed_embargoes: list[EmbargoEventRef] = Field(default_factory=list)
 
     case_activity: list[as_Activity] = Field(default_factory=list)
-
-    events: list[CaseEvent] = Field(default_factory=list)
 
     # case relationships
     parent_cases: list["VulnerabilityCaseRef"] = Field(default_factory=list)
@@ -235,29 +232,6 @@ class VulnerabilityCase(VultronAS2Object):
         ids = set([a.id_ for a in self.case_activity])
         if activity.id_ not in ids:
             self.case_activity.append(activity)
-
-    def record_event(
-        self,
-        object_id: str,
-        event_type: str,
-    ) -> CaseEvent:
-        """Append a trusted-timestamp event to the case event log.
-
-        The ``received_at`` timestamp is set to the current UTC time at the
-        moment this method is called.  Callers MUST NOT supply a
-        ``received_at`` value sourced from an incoming activity payload.
-
-        Args:
-            object_id: Full URI of the object being acted upon.
-            event_type: Short descriptor of the event kind
-                (e.g. ``"embargo_accepted"``).
-
-        Returns:
-            The newly-created CaseEvent.
-        """
-        event = CaseEvent(object_id=object_id, event_type=event_type)
-        self.events.append(event)
-        return event
 
     @classmethod
     def from_core(cls, core_obj: CoreVulnerabilityCase) -> "VulnerabilityCase":


### PR DESCRIPTION
- Closes #888

## Summary

Removes the duplicate `events: list[CaseEvent]` field and `record_event()`
method from the wire-layer `VulnerabilityCase` class
(`vultron/wire/as2/vocab/objects/vulnerability_case.py`). These were a
layer-boundary violation: wire-layer objects were accumulating domain state that
belongs only in the core model.

## Changes

**Wire layer**
- Removed `CaseEvent` import, `events: list[CaseEvent]` field, and
  `record_event()` from wire-layer `VulnerabilityCase`
- `from_core()` is unaffected — Pydantic v2 `extra='ignore'` silently drops
  the `events` key from core dumps

**Core protocols**
- Removed `events: list` and `record_event()` from `CaseModel` Protocol
- Removed `hasattr(obj, 'record_event')` from `is_case_model()` TypeGuard

**BT behaviors / use cases (7 call sites)**
- Removed `record_event()` calls from: `embargo/nodes/proposal.py`,
  `case/nodes/participant/owner.py`, `case/nodes/participant/participant_add.py`,
  `case/nodes/embargo.py`, `case/nodes/case_setup.py`,
  `use_cases/received/actor.py`, `use_cases/received/case_participant.py`

**Demo**
- `verification.py`: removed the `CaseLogEntry` event-type check (participant
  presence is already validated via `actor_participant_index` earlier in the
  function)

**Tests**
- Replaced `case.events` assertions with behavioral checks (participant index
  membership, `active_embargo` presence, tree-succeeded-and-case-persisted)
- Removed `TestVulnerabilityCaseEventsField` and
  `test_to_core_events_field_preserved` (tested the removed field)
- Removed `test_accept_invite_to_embargo_records_case_event` (tested the
  removed field; EM activation is covered by
  `test_accept_invite_to_embargo_on_case_activates_embargo`)

**Not in scope**: Core `VulnerabilityCase` retains `events`/`record_event()`;
the `case_event.py` compat shim is retained. Issue #792 will handle core removal.

## Verification

All linters pass (Black, flake8, mypy, pyright). Full test suite:

```
3412 passed, 14 skipped, 3 xfailed, 5633 subtests passed in 57.03s
```