### PR TITLE
docs: plan issue #923 — case log ledger vs process log

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -483,6 +483,18 @@ Short entries are reproduced here; longer ones are referenced below.
   `id_` and registers in `CORE_VOCABULARY`. Always import by full module path and
   verify which class you need. See `specs/architecture.yaml` ARCH-12-007 and
   issue #806.
+- **Case Log Is a Ledger, Not a Process Log** — The canonical case log
+  (`CaseLogEntry` chain authored by the CaseActor and replicated via
+  `Announce(CaseLogEntry)`) is **exclusively** for CaseActor-accepted
+  protocol-significant assertions. Each entry's `payloadSnapshot` MUST be the
+  verbatim asserted AS2 activity (or a deterministic normalization of it) and
+  MUST NOT be empty for non-rejection entries. Runtime diagnostics, demo
+  checkpoints (e.g., `demo_verification`), troubleshooting markers, and any
+  per-actor observability belong in Python `logging` output governed by
+  `specs/structured-logging.yaml` — **never** in the canonical case log. Do
+  NOT use `record_event()` or any canonical commit path as a generic "log
+  this thing" sink. See ADR-0019, `specs/case-log-processing.yaml` CLP-07,
+  and `notes/case-log-authority.md` § "Canonical Entry Criteria".
 - **Adding a New Pitfall: Check the Routing Policy First** — see
   [notes/agents-md-structure.md](notes/agents-md-structure.md)
 - **Trigger-Side execute() Must Delegate SM Transitions to BTBridge** — A

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -410,7 +410,7 @@ Short entries are reproduced here; longer ones are referenced below.
   case creation, participant-originated activities MUST be addressed only to the Case Actor
   (`CVDRole.CASE_MANAGER` participant's `attributed_to`), not to `case_addressees()`.
   Using `case_addressees()` on the sender side bypasses the CaseActor and violates the
-  `participant → CaseActor → CaseLogEntry → broadcast → participants` model
+  `participant → CaseActor → CaseLedgerEntry → broadcast → participants` model
   (PCR-08-001, PCR-08-002). `case_addressees()` is correct only on the Case Actor's
   **outbound fan-out** side (broadcasting to all participants). See
   [notes/case-communication-model.md](notes/case-communication-model.md).
@@ -469,29 +469,29 @@ Short entries are reproduced here; longer ones are referenced below.
   failure modes). Incidental coverage via `test_trignotify.py` or scenario
   demos is insufficient — when `triggers/case.py` accumulated 26 commits in
   90 days (#652), half its use cases had no dedicated test and regressions
-  in case logic shipped behind embargo fixes. Also avoid bundling
+  in case ledgeric shipped behind embargo fixes. Also avoid bundling
   case-trigger and embargo-trigger changes in the same PR unless the change
   is intrinsically cross-cutting; bundled diffs let reviewers miss
   regressions in the half they aren't focused on. See
   [notes/triggers-test-coverage.md](notes/triggers-test-coverage.md).
-- **Hash-Chain Log Record vs. Domain Model** — Two distinct classes exist for case
-  log entries. `vultron.core.models.case_log.HashChainLogRecord` (`BaseModel`) is
-  the in-memory hash-chain record used by `CaseEventLog` for local SYNC-1 processing
-  — it is **not** persisted or shared over the wire. `vultron.core.models.case_log_entry.CaseLogEntry`
+- **Hash-Chain Ledger Record vs. Domain Model** — Two distinct classes exist for case
+  ledger entries. `vultron.core.models.case_log.HashChainLedgerRecord` (`BaseModel`) is
+  the in-memory hash-chain record used by `CaseLedger` for local SYNC-1 processing
+  — it is **not** persisted or shared over the wire. `vultron.core.models.case_ledger_entry.CaseLedgerEntry`
   (`CoreObject`) is the wire-serialisable domain model used in
-  `Announce(CaseLogEntry)` replication activities — it has an auto-computed
+  `Announce(CaseLedgerEntry)` replication activities — it has an auto-computed
   `id_` and registers in `CORE_VOCABULARY`. Always import by full module path and
   verify which class you need. See `specs/architecture.yaml` ARCH-12-007 and
   issue #806.
-- **Case Log Is a Ledger, Not a Process Log** — The canonical case log
-  (`CaseLogEntry` chain authored by the CaseActor and replicated via
-  `Announce(CaseLogEntry)`) is **exclusively** for CaseActor-accepted
+- **Case Ledger Is Not a Process Log** — The canonical case ledger
+  (`CaseLedgerEntry` chain authored by the CaseActor and replicated via
+  `Announce(CaseLedgerEntry)`) is **exclusively** for CaseActor-accepted
   protocol-significant assertions. Each entry's `payloadSnapshot` MUST be the
   verbatim asserted AS2 activity (or a deterministic normalization of it) and
   MUST NOT be empty for non-rejection entries. Runtime diagnostics, demo
   checkpoints (e.g., `demo_verification`), troubleshooting markers, and any
   per-actor observability belong in Python `logging` output governed by
-  `specs/structured-logging.yaml` — **never** in the canonical case log. Do
+  `specs/structured-logging.yaml` — **never** in the canonical case ledger. Do
   NOT use `record_event()` or any canonical commit path as a generic "log
   this thing" sink. See ADR-0019, `specs/case-log-processing.yaml` CLP-07,
   and `notes/case-log-authority.md` § "Canonical Entry Criteria".

--- a/docs/adr/0019-case-log-is-canonical-ledger-not-process-log.md
+++ b/docs/adr/0019-case-log-is-canonical-ledger-not-process-log.md
@@ -1,0 +1,117 @@
+---
+status: accepted
+date: 2026-06-12
+deciders: Vultron maintainers
+consulted: notes/case-log-authority.md, notes/sync-log-replication.md, specs/case-log-processing.yaml
+---
+
+# Case Log Is a Canonical Protocol Ledger, Not a Process Log
+
+## Context and Problem Statement
+
+The canonical case log (`CaseLogEntry` chain authored by the CaseActor) and
+the per-actor runtime process log (Python `logging` output) serve fundamentally
+different purposes, but the distinction has not been carved deeply enough to
+prevent agents and code from conflating them.
+
+Evidence: A two-actor demo run (case
+`urn:uuid:0f69d289-734f-47af-afd2-37091895371a`, 2026-06-12) revealed
+synthetic checkpoint events such as `demo_verification` being committed to
+the canonical case log with empty `payloadSnapshot` fields, alongside the
+absence of the actual protocol-significant activities (`validate_report`,
+`accept_report`, `propose_embargo`, `accept_embargo`, `notify_*`,
+`close_case`, `add_note`) that *should* be in the log.
+
+This concern (#923) and its parent epic (#788) make clear that the project
+needs an explicit, ADR-level decision separating the two logs so future
+agents and contributors stop using `record_event()` as a generic "log this
+thing" sink.
+
+## Decision Drivers
+
+- The canonical case log is replicated to all participants and forms the
+  authoritative shared history of the case; its contents are protocol-visible.
+- The process log is per-actor, ephemeral, and intended for operators and
+  developers; it must never be replicated or relied on for protocol semantics.
+- Conflation has demonstrably caused real bugs (empty `payloadSnapshot`
+  entries, missing protocol activities, hash-chain divergence).
+- A spec entry alone has not been sufficient to prevent this conflation;
+  an ADR carries the "do not re-litigate" weight needed to make the
+  separation durable.
+
+## Considered Options
+
+- A. **Single log, multiple severity levels** — record everything in the
+  canonical case log, with a severity field distinguishing protocol events
+  from diagnostics.
+- B. **Two distinct logs with strict separation** — the canonical case log is
+  exclusively for CaseActor-authored records of protocol-significant
+  assertions; runtime diagnostics, demo checkpoints, and any other
+  per-actor observability go to Python `logging` (the process log) and
+  are never replicated.
+- C. **Status quo (implicit separation)** — rely on convention and
+  scattered spec/notes guidance to keep the two apart.
+
+## Decision Outcome
+
+Chosen option: **B — two distinct logs with strict separation**.
+
+The canonical case log MUST contain only CaseActor-authored
+`CaseLogEntry` records whose `payloadSnapshot` is the verbatim AS2
+activity (or a normalized, deterministic snapshot) that was accepted as
+a protocol-significant assertion. Runtime diagnostics, demo
+checkpoints, troubleshooting markers, and any other per-actor
+observability MUST use the per-actor process log (Python `logging`) at
+the level prescribed in `specs/structured-logging.yaml`. Process-log
+content MUST NOT enter the canonical case log under any circumstance.
+
+The commit boundary of the canonical case log is therefore an enforcement
+point: a runtime guard at the CaseActor's commit path SHOULD reject
+entries that do not meet canonical entry criteria, so violations fail
+fast instead of silently polluting replicated history.
+
+### Consequences
+
+- Good, because participant replicas can be reconstructed deterministically
+  from the canonical log alone, without filtering out diagnostic noise.
+- Good, because the canonical log's hash chain only depends on
+  protocol-significant content, so unrelated runtime events cannot perturb
+  it.
+- Good, because operators can use the process log freely without affecting
+  protocol correctness or replica convergence.
+- Good, because the ADR creates an unambiguous reference future agents can
+  cite when reviewing code that calls `record_event()` or appends to the
+  canonical log.
+- Bad, because existing call sites that currently emit synthetic events
+  into the case log must be migrated to the process log or removed.
+- Bad, because adding a commit-boundary guard introduces a new runtime
+  check that must be carefully placed to avoid blocking legitimate
+  CaseActor writes.
+
+## Validation
+
+- `specs/case-log-processing.yaml` `CLP-07` codifies the normative
+  separation as MUST-level requirements.
+- A new runtime guard at the CaseActor commit boundary rejects
+  non-canonical entries (tracked in a follow-on implementation issue).
+- The CI two-actor demo invariant assertion job (tracked in a follow-on
+  implementation issue) includes a `non-empty payloadSnapshot` check
+  that fails the build when synthetic entries are committed.
+
+## More Information
+
+- ADR-0018 — Canonical Case History Convergence on `CaseLogEntry` —
+  established the single-writer convergence; this ADR sharpens the
+  *content* boundary of that single writer's log.
+- Concern #923 — Two-actor demo case log: hash-chain fork, oscillation
+  loop, and 17 protocol correctness findings — the empirical evidence
+  motivating this ADR.
+- Epic #788 — Converge CaseEvent flow onto canonical CaseLogEntry.
+- `notes/case-log-authority.md` — design rationale for the canonical
+  entry model.
+- `notes/sync-log-replication.md` — replication invariants that depend on
+  canonical-log purity.
+- `specs/structured-logging.yaml` — process-log conventions and levels.
+
+Generated spec requirements: `case-log-processing.yaml` CLP-07-001
+through CLP-07-005.

--- a/docs/adr/0019-separate-case-ledger-from-process-log.md
+++ b/docs/adr/0019-separate-case-ledger-from-process-log.md
@@ -5,11 +5,11 @@ deciders: Vultron maintainers
 consulted: notes/case-log-authority.md, notes/sync-log-replication.md, specs/case-log-processing.yaml
 ---
 
-# Case Log Is a Canonical Protocol Ledger, Not a Process Log
+# Separate the Case Ledger from the Per-Actor Process Log
 
 ## Context and Problem Statement
 
-The canonical case log (`CaseLogEntry` chain authored by the CaseActor) and
+The canonical case ledger (`CaseLedgerEntry` chain authored by the CaseActor) and
 the per-actor runtime process log (Python `logging` output) serve fundamentally
 different purposes, but the distinction has not been carved deeply enough to
 prevent agents and code from conflating them.
@@ -17,7 +17,7 @@ prevent agents and code from conflating them.
 Evidence: A two-actor demo run (case
 `urn:uuid:0f69d289-734f-47af-afd2-37091895371a`, 2026-06-12) revealed
 synthetic checkpoint events such as `demo_verification` being committed to
-the canonical case log with empty `payloadSnapshot` fields, alongside the
+the canonical case ledger with empty `payloadSnapshot` fields, alongside the
 absence of the actual protocol-significant activities (`validate_report`,
 `accept_report`, `propose_embargo`, `accept_embargo`, `notify_*`,
 `close_case`, `add_note`) that *should* be in the log.
@@ -29,7 +29,7 @@ thing" sink.
 
 ## Decision Drivers
 
-- The canonical case log is replicated to all participants and forms the
+- The canonical case ledger is replicated to all participants and forms the
   authoritative shared history of the case; its contents are protocol-visible.
 - The process log is per-actor, ephemeral, and intended for operators and
   developers; it must never be replicated or relied on for protocol semantics.
@@ -42,9 +42,9 @@ thing" sink.
 ## Considered Options
 
 - A. **Single log, multiple severity levels** — record everything in the
-  canonical case log, with a severity field distinguishing protocol events
+  canonical case ledger, with a severity field distinguishing protocol events
   from diagnostics.
-- B. **Two distinct logs with strict separation** — the canonical case log is
+- B. **Two distinct logs with strict separation** — the canonical case ledger is
   exclusively for CaseActor-authored records of protocol-significant
   assertions; runtime diagnostics, demo checkpoints, and any other
   per-actor observability go to Python `logging` (the process log) and
@@ -56,16 +56,16 @@ thing" sink.
 
 Chosen option: **B — two distinct logs with strict separation**.
 
-The canonical case log MUST contain only CaseActor-authored
-`CaseLogEntry` records whose `payloadSnapshot` is the verbatim AS2
+The canonical case ledger MUST contain only CaseActor-authored
+`CaseLedgerEntry` records whose `payloadSnapshot` is the verbatim AS2
 activity (or a normalized, deterministic snapshot) that was accepted as
 a protocol-significant assertion. Runtime diagnostics, demo
 checkpoints, troubleshooting markers, and any other per-actor
 observability MUST use the per-actor process log (Python `logging`) at
 the level prescribed in `specs/structured-logging.yaml`. Process-log
-content MUST NOT enter the canonical case log under any circumstance.
+content MUST NOT enter the canonical case ledger under any circumstance.
 
-The commit boundary of the canonical case log is therefore an enforcement
+The commit boundary of the canonical case ledger is therefore an enforcement
 point: a runtime guard at the CaseActor's commit path SHOULD reject
 entries that do not meet canonical entry criteria, so violations fail
 fast instead of silently polluting replicated history.
@@ -83,7 +83,7 @@ fast instead of silently polluting replicated history.
   cite when reviewing code that calls `record_event()` or appends to the
   canonical log.
 - Bad, because existing call sites that currently emit synthetic events
-  into the case log must be migrated to the process log or removed.
+  into the case ledger must be migrated to the process log or removed.
 - Bad, because adding a commit-boundary guard introduces a new runtime
   check that must be carefully placed to avoid blocking legitimate
   CaseActor writes.
@@ -98,15 +98,63 @@ fast instead of silently polluting replicated history.
   implementation issue) includes a `non-empty payloadSnapshot` check
   that fails the build when synthetic entries are committed.
 
+## Terminology
+
+This ADR also formalizes a terminology rename motivated by the same
+conflation problem it addresses. The historical name "case log" was
+ambiguous: it sat too close to Python `logging` and invited use as a
+generic event sink. Going forward, the project uses **ledger** vocabulary
+for the canonical, append-only, hash-chained, replicated record of
+protocol-significant case events:
+
+| Old name | New name |
+|---|---|
+| Case Log | **Case Ledger** |
+| `CaseLogEntry` | **`CaseLedgerEntry`** |
+| `CaseEventLog` | **`CaseLedger`** |
+| `HashChainLogRecord` | **`HashChainLedgerRecord`** |
+| `case_log_entry` module | **`case_ledger_entry`** module |
+| `case_event_log` module | **`case_ledger`** module |
+| `Announce(CaseLogEntry)` wire envelope | **`Announce(CaseLedgerEntry)`** |
+| case audit log | **case audit ledger** |
+| (new method) | **`commit_ledger_entry()`** for the canonical append API |
+
+`record_event()` is **not** renamed — it is the legacy `CaseEvent` path,
+which is scheduled for removal in #792. The new canonical append API
+on the CaseActor side is named `commit_ledger_entry()` to align with the
+commit-discipline vocabulary in `notes/sync-log-replication.md` and to
+make it self-evident that the method appends to the authoritative
+ledger, not to a generic log sink.
+
+The "process log" remains the standard term for per-actor Python
+`logging` output, governed by `specs/structured-logging.yaml`. It is
+ephemeral, per-actor, never replicated, and never part of any hash
+chain.
+
+**Rationale.** "Ledger" carries the exact semantic properties the
+canonical record must have: append-only, authoritative, immutable,
+audit-grade, and amenable to hash-chained / Merkle-tree representation.
+It maps cleanly onto distributed-systems precedent (blockchain ledgers,
+event-sourcing ledgers, Raft log entries reframed as ledger
+appends) and removes the naming collision with Python `logging`.
+
+**Migration.** The terminology decision is captured here at ADR level so
+it cannot be re-litigated quietly. The mechanical bulk rename of source
+code, remaining specs/notes, file paths (`specs/case-log-processing.yaml`,
+`notes/case-log-authority.md`, `vultron/core/models/case_log.py`,
+`vultron/core/models/case_log_entry.py`, etc.), and wire-format type
+identifiers is tracked as a dedicated implementation issue under epic #788, scheduled to land before the bulk of CLP-07 enforcement work so
+that follow-on PRs are written in the new vocabulary from the start.
+
 ## More Information
 
 - ADR-0018 — Canonical Case History Convergence on `CaseLogEntry` —
   established the single-writer convergence; this ADR sharpens the
   *content* boundary of that single writer's log.
-- Concern #923 — Two-actor demo case log: hash-chain fork, oscillation
+- Concern #923 — Two-actor demo case ledger: hash-chain fork, oscillation
   loop, and 17 protocol correctness findings — the empirical evidence
   motivating this ADR.
-- Epic #788 — Converge CaseEvent flow onto canonical CaseLogEntry.
+- Epic #788 — Converge CaseEvent flow onto canonical CaseLedgerEntry.
 - `notes/case-log-authority.md` — design rationale for the canonical
   entry model.
 - `notes/sync-log-replication.md` — replication invariants that depend on

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -72,6 +72,8 @@ General information about architectural decision records is available at <https:
   Hierarchy](0017-domain-wire-object-separation.md)
 - [ADR-0018 Canonical Case History Convergence on
   `CaseLogEntry`](0018-canonical-case-history-convergence.md)
+- [ADR-0019 Case Log Is a Canonical Protocol Ledger, Not a Process
+  Log](0019-case-log-is-canonical-ledger-not-process-log.md)
 
 ## Proposed ADRs
 

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -72,8 +72,8 @@ General information about architectural decision records is available at <https:
   Hierarchy](0017-domain-wire-object-separation.md)
 - [ADR-0018 Canonical Case History Convergence on
   `CaseLogEntry`](0018-canonical-case-history-convergence.md)
-- [ADR-0019 Case Log Is a Canonical Protocol Ledger, Not a Process
-  Log](0019-case-log-is-canonical-ledger-not-process-log.md)
+- [ADR-0019 Separate the Case Ledger from the Per-Actor Process
+  Log](0019-separate-case-ledger-from-process-log.md)
 
 ## Proposed ADRs
 

--- a/notes/case-log-authority.md
+++ b/notes/case-log-authority.md
@@ -1,5 +1,5 @@
 ---
-title: Case Log Authority and Assertion Recording
+title: Case Ledger Authority and Assertion Recording
 status: active
 description: "Authority model for the case activity log: trusted timestamps, assertion recording, and authority chain."
 related_specs:
@@ -15,7 +15,7 @@ relevant_packages:
   - vultron/core/models
 ---
 
-# Case Log Authority and Assertion Recording
+# Case Ledger Authority and Assertion Recording
 
 **Relates to**: `specs/case-log-processing.yaml`,
 `specs/case-management.yaml`, `specs/sync-log-replication.yaml`,
@@ -36,7 +36,7 @@ sender's side. The important distinction is instead:
 
 - **participant assertion**: an inbound case- or proto-case-scoped activity
   that claims a protocol-relevant change occurred
-- **canonical case log entry**: a CaseActor-authored record that says the
+- **canonical case ledger entry**: a CaseActor-authored record that says the
   assertion was processed and either accepted into canonical history or
   rejected at the case layer
 
@@ -96,9 +96,9 @@ publishing the canonical statement:
 
 ---
 
-## `CaseLogEntry` Is the Canonical Content Object
+## `CaseLedgerEntry` Is the Canonical Content Object
 
-The canonical object should be a neutral **`CaseLogEntry`**, not a renamed copy
+The canonical object should be a neutral **`CaseLedgerEntry`**, not a renamed copy
 of the original activity and not the transport envelope itself.
 
 Why a neutral object type:
@@ -107,7 +107,7 @@ Why a neutral object type:
 - it separates canonical log content from transport concerns
 - it gives the CaseActor a stable object to hash, replicate, replay, and audit
 
-A `CaseLogEntry` should carry at least:
+A `CaseLedgerEntry` should carry at least:
 
 - the asserted activity payload, or a normalized immutable snapshot sufficient
   for deterministic replay
@@ -117,7 +117,7 @@ A `CaseLogEntry` should carry at least:
   human-readable detail
 
 `Announce` remains the **transport wrapper** for replication. The thing being
-announced is the `CaseLogEntry`, not the other way around.
+announced is the `CaseLedgerEntry`, not the other way around.
 
 ---
 
@@ -161,11 +161,11 @@ of the canonical replicated history.
 
 ## Rejections Stay Local Except for Sender Feedback
 
-Not every inbound failure belongs in the case audit log.
+Not every inbound failure belongs in the case audit ledger.
 
 - If a message cannot be tied to a report/case (including proto-cases in
   RM.RECEIVED/INVALID stages), it belongs in transport- or actor-level
-  diagnostics, not the case log.
+  diagnostics, not the case ledger.
 - If the CaseActor can resolve the message to a case context but rejects it
   during case-layer validation, the rejection belongs in the local case audit
   log.
@@ -181,7 +181,7 @@ canonical recorded history, not the full stream of invalid assertion attempts.
 This model sharpens the replication boundary:
 
 - participant assertions are **inputs** to CaseActor processing
-- `CaseLogEntry(recorded)` objects are the **canonical replicated facts**
+- `CaseLedgerEntry(recorded)` objects are the **canonical replicated facts**
 - participant replicas derive state only from the canonical recorded entries
 
 To support replay and stale-position detection, participant assertions should
@@ -201,7 +201,7 @@ because replicas need the actual asserted content to reconstruct state.
 
 Issue #787 intentionally kept `CaseEvent` as a lightweight inline value object.
 That merged decision remains valid as a short-term compatibility step while the
-project converges on canonical `CaseLogEntry` history.
+project converges on canonical `CaseLedgerEntry` history.
 
 Follow-on plan (Epic #788):
 
@@ -215,7 +215,7 @@ Follow-on plan (Epic #788):
   protocol-significant history.
 
 `pending_assertions` is temporary local memory for decision suppression, not a
-second source of truth. Canonical `CaseLogEntry` remains authoritative.
+second source of truth. Canonical `CaseLedgerEntry` remains authoritative.
 
 Initial policy decisions for pending assertions:
 
@@ -223,7 +223,7 @@ Initial policy decisions for pending assertions:
 - timeout marks the assertion as `timed_out` and logs an error
 - timeout does not auto-retry; future behavior may decide to re-emit if still
   needed
-- entries clear when matching canonical `CaseLogEntry(recorded|rejected)`
+- entries clear when matching canonical `CaseLedgerEntry(recorded|rejected)`
   arrives
 
 ---
@@ -237,7 +237,7 @@ This framing has several practical consequences:
   CaseActor disposition.
 - The current `CaseEvent` / `record_event()` path is a useful foundation, but
   the long-term canonical content model needs to grow into a richer
-  `CaseLogEntry`.
+  `CaseLedgerEntry`.
 - Specs and implementations dealing with replication must distinguish between
   the broader local audit trail and the narrower canonical recorded chain.
 - Proto-case history must remain continuous across the
@@ -250,14 +250,14 @@ requirements belong in `specs/case-log-processing.yaml`.
 
 ## Canonical Entry Criteria: What Belongs in the Log
 
-The canonical case log is a **protocol ledger**, not a process log. It records
+The canonical case ledger is a **protocol ledger**, not a process log. It records
 exactly one entry per CaseActor-accepted protocol-significant assertion. Each
 entry's `payloadSnapshot` is the verbatim AS2 activity that was asserted (or a
 deterministic canonical normalization of it).
 
 Concretely:
 
-**Belongs in the canonical case log (allowed `payloadSnapshot` types):**
+**Belongs in the canonical case ledger (allowed `payloadSnapshot` types):**
 
 - `Offer(VulnerabilityReport)` — finder asserts report submission
 - `Add(Note)` — participant asserts a note exchange
@@ -270,7 +270,7 @@ Concretely:
 - Any other protocol-significant AS2 activity that mutates protocol-visible
   state
 
-**Does NOT belong in the canonical case log:**
+**Does NOT belong in the canonical case ledger:**
 
 - Synthetic checkpoint markers (e.g., `demo_verification`)
 - Per-actor runtime diagnostics, troubleshooting traces, or "I made it to
@@ -281,11 +281,11 @@ Concretely:
 
 Anything in the "does NOT belong" category is **process-log content** and
 belongs in Python `logging` output governed by `specs/structured-logging.yaml`,
-not in the canonical case log.
+not in the canonical case ledger.
 
 ### Why the Separation Matters
 
-The canonical case log is replicated to every participant and contributes
+The canonical case ledger is replicated to every participant and contributes
 to the hash chain that participants use to verify their replicas agree
 with the CaseActor's authoritative copy. If diagnostic or synthetic
 content enters the chain:
@@ -298,7 +298,7 @@ content enters the chain:
   detail without risking protocol-level effects.
 
 The decision is captured at the ADR level in
-**ADR-0019 — Case Log Is a Canonical Protocol Ledger, Not a Process Log**.
+**ADR-0019 — Case Ledger Is a Canonical Protocol Ledger, Not a Process Log**.
 
 ### `Announce` Envelope vs. `payloadSnapshot` Actor
 
@@ -306,19 +306,19 @@ A subtle but important distinction:
 
 ```text
 Vendor sends:  Add(ParticipantStatus, actor=vendor) → CaseActor
-CaseActor commits: CaseLogEntry(
+CaseActor commits: CaseLedgerEntry(
   log_index=N,
   recording_actor=case_actor,
   payloadSnapshot=Add(ParticipantStatus, actor=vendor),  ← verbatim assertion
 )
 CaseActor broadcasts: Announce(
   actor=case_actor,                                       ← envelope actor
-  object=CaseLogEntry(...),
+  object=CaseLedgerEntry(...),
 ) → all participants
 ```
 
 The `Announce` envelope's `actor` field is always the CaseActor. The
-`payloadSnapshot.actor` inside the `CaseLogEntry` preserves the original
+`payloadSnapshot.actor` inside the `CaseLedgerEntry` preserves the original
 asserter (`vendor` in the example). Replicas receiving the broadcast
 update their state based on the snapshot's asserter, not the envelope's
 actor. Rewriting `payloadSnapshot.actor` to the CaseActor would erase

--- a/notes/case-log-authority.md
+++ b/notes/case-log-authority.md
@@ -245,3 +245,89 @@ This framing has several practical consequences:
 
 This note should be treated as the durable design explanation. Normative
 requirements belong in `specs/case-log-processing.yaml`.
+
+---
+
+## Canonical Entry Criteria: What Belongs in the Log
+
+The canonical case log is a **protocol ledger**, not a process log. It records
+exactly one entry per CaseActor-accepted protocol-significant assertion. Each
+entry's `payloadSnapshot` is the verbatim AS2 activity that was asserted (or a
+deterministic canonical normalization of it).
+
+Concretely:
+
+**Belongs in the canonical case log (allowed `payloadSnapshot` types):**
+
+- `Offer(VulnerabilityReport)` — finder asserts report submission
+- `Add(Note)` — participant asserts a note exchange
+- `Add(ParticipantStatus)` — participant asserts an RM/CS/EM transition
+- `Offer(EmbargoEvent)`, `Accept(EmbargoEvent)`, `Reject(EmbargoEvent)` —
+  embargo proposal/response
+- `Invite(VulnerabilityCase)`, `Accept(Invite)`, `Reject(Invite)` — case
+  membership handshake (note: routed through the CaseActor per PCR-08)
+- `Announce(VulnerabilityCase)` — case bootstrap broadcast
+- Any other protocol-significant AS2 activity that mutates protocol-visible
+  state
+
+**Does NOT belong in the canonical case log:**
+
+- Synthetic checkpoint markers (e.g., `demo_verification`)
+- Per-actor runtime diagnostics, troubleshooting traces, or "I made it to
+  step N" markers
+- Internal cascade triggers, sentinels, or scheduling events
+- Any event whose `payloadSnapshot` would be empty or whose `logObjectId`
+  points at the case itself rather than a specific protocol activity
+
+Anything in the "does NOT belong" category is **process-log content** and
+belongs in Python `logging` output governed by `specs/structured-logging.yaml`,
+not in the canonical case log.
+
+### Why the Separation Matters
+
+The canonical case log is replicated to every participant and contributes
+to the hash chain that participants use to verify their replicas agree
+with the CaseActor's authoritative copy. If diagnostic or synthetic
+content enters the chain:
+
+- Participants cannot deterministically reconstruct case state from the
+  log alone — they'd have to filter out non-protocol entries.
+- The hash chain becomes sensitive to runtime details that have nothing
+  to do with protocol semantics (e.g., timing of demo checkpoints).
+- Operators using process logs for troubleshooting cannot freely add
+  detail without risking protocol-level effects.
+
+The decision is captured at the ADR level in
+**ADR-0019 — Case Log Is a Canonical Protocol Ledger, Not a Process Log**.
+
+### `Announce` Envelope vs. `payloadSnapshot` Actor
+
+A subtle but important distinction:
+
+```text
+Vendor sends:  Add(ParticipantStatus, actor=vendor) → CaseActor
+CaseActor commits: CaseLogEntry(
+  log_index=N,
+  recording_actor=case_actor,
+  payloadSnapshot=Add(ParticipantStatus, actor=vendor),  ← verbatim assertion
+)
+CaseActor broadcasts: Announce(
+  actor=case_actor,                                       ← envelope actor
+  object=CaseLogEntry(...),
+) → all participants
+```
+
+The `Announce` envelope's `actor` field is always the CaseActor. The
+`payloadSnapshot.actor` inside the `CaseLogEntry` preserves the original
+asserter (`vendor` in the example). Replicas receiving the broadcast
+update their state based on the snapshot's asserter, not the envelope's
+actor. Rewriting `payloadSnapshot.actor` to the CaseActor would erase
+the assertion's provenance and is forbidden by CLP-07-003.
+
+### Commit-Boundary Enforcement
+
+CLP-07-005 recommends a runtime guard at the CaseActor commit boundary
+that rejects entries violating CLP-07-001 through CLP-07-004 *before*
+they enter the hash chain. Failing fast at commit time keeps the
+canonical chain clean and surfaces bugs immediately, rather than allowing
+silent pollution that's discovered only when replicas diverge.

--- a/plan/history/2606/learning/CONCERN-923.md
+++ b/plan/history/2606/learning/CONCERN-923.md
@@ -1,0 +1,106 @@
+---
+source: CONCERN-923
+timestamp: '2026-06-12T15:52:23.115413+00:00'
+title: 'Two-actor demo case log: hash-chain fork, oscillation loop, and 17 protocol
+  correctness findings'
+type: learning
+---
+
+## Summary
+
+A review of case log replicas from a two-actor demo run (2026-06-12, case
+`urn:uuid:0f69d289-734f-47af-afd2-37091895371a`) surfaced 17 findings across
+all three actors (case-actor, vendor, finder), including two critical-severity
+bugs: a permanent hash-chain fork starting at logIndex=3 (50% cross-replica
+mismatch rate) and an infinite RM ACCEPTED↔CLOSED oscillation loop on the
+finder participant with no convergence.
+
+The findings together pointed to a deeper structural gap: the canonical case
+log was being used as a generic event sink, with synthetic checkpoint events
+(`demo_verification`) committed alongside missing protocol-significant
+activities (`validate_report`, `accept_report`, `propose_embargo`,
+`accept_embargo`, `notify_*`, `close_case`, `add_note`). The conceptual model
+"the case log is a CaseActor-authored ledger of protocol-significant
+assertions, NOT a per-actor process log" was implicit but not enforced.
+
+## Findings (abbreviated)
+
+- 🔴 Finding 1: Hash-chain fork at logIndex=3 — duplicate `Add(ParticipantStatus)`
+  emitted by both vendor and case-actor for the same RM/CS transition; replicas
+  receive inconsistent bytes.
+- 🔴 Finding 2: Case-actor oscillation between ACCEPTED and CLOSED for finder,
+  13 consecutive entries, log ends mid-oscillation.
+- 🟠 Findings 3–6: pre-join history absent for late joiners; empty
+  `payloadSnapshot` for synthetic `demo_verification`; payload content
+  divergence; no terminal all-CLOSED state.
+- 🟡 Findings 7–11: missing protocol event log entries (validate_report,
+  accept_report, propose_embargo, accept_embargo, notify_*, close_case,
+  add_note, announce_case_log_entry).
+- 🟡 Findings 12–13: `emConsentState` and `cvdRole` absent from
+  `ParticipantStatus` snapshots.
+- 🟡 Findings 14–15: report-URI context discontinuity; nested embargo objects
+  stored as bare ID strings.
+- 🟡 Findings 16–17: duplicate Add for same transition; tail missing from
+  finder/vendor (demo terminated mid-oscillation).
+
+## Resolution
+
+**Resolved**: 2026-06-12 — Planned via `plan-issue` skill under epic #788
+(Converge CaseEvent flow onto canonical CaseLogEntry).
+
+**Docs PR**: <https://github.com/CERTCC/Vultron/pull/924>
+
+Docs PR adds:
+
+- **ADR-0019** — "Case Log Is a Canonical Protocol Ledger, Not a Process Log"
+  (carves into stone the separation between canonical case log and per-actor
+  process log; rejects the conflated-log alternative).
+- **`specs/case-log-processing.yaml`** — new **CLP-07** group (CLP-07-001
+  through CLP-07-007): one entry per accepted assertion, verbatim
+  `payloadSnapshot`, asserter-identity preservation, exclusion of
+  diagnostics, commit-boundary guard, inline nested objects, case-URI
+  context.
+- **`notes/case-log-authority.md`** — extended with canonical entry criteria,
+  allowed vs. disallowed entry-type examples, the `Announce` envelope vs.
+  `payloadSnapshot.actor` distinction (with worked example), and
+  commit-boundary enforcement guidance.
+- **`AGENTS.md`** — pitfall: "Case Log Is a Ledger, Not a Process Log".
+
+**Implementation tracked in:**
+
+- #925 — CI case-log invariant assertion harness (xfail ratchet) — lands first
+- #926 — CaseActor commit-path uniqueness (Findings 1, 16)
+- #927 — Sender-side trigger audit sweep (PCR-08 enforcement)
+- #928 — RM terminal-state guard (Finding 2)
+- #929 — Remove synthetic checkpoint events (Finding 4)
+- #930 — Commit-boundary runtime guard (CLP-07-005)
+- #931 — ParticipantStatus schema completeness: emConsentState + cvdRole
+  (Findings 12, 13)
+- #932 — Snapshot context normalization at report→case promotion (Finding 14)
+- #933 — Inline nested protocol objects in canonical snapshots (Finding 15)
+
+**Refinements to existing issues:**
+
+- #789 — added explicit ACs for Findings 7–11 (missing protocol event entries)
+- #791 — added join-time backfill AC (Finding 3)
+
+All new issues are children of epic #788, blocked by #923 (this concern) and
+by #925 (the harness scaffolding lands first). Each implementation PR is
+required to flip its named xfail invariant in the harness to passing, giving
+the dependency chain progressive deep-test coverage rather than one big
+final test imposition.
+
+## Key conceptual outcomes
+
+- **Two distinct logs** (now ADR-level): canonical case log = protocol ledger,
+  CaseActor-authored, replicated, hash-chained; per-actor process log =
+  Python logging, ephemeral, never replicated. They MUST NOT be conflated.
+- **CaseLogEntry payloadSnapshot is the verbatim asserted AS2 activity** —
+  `payloadSnapshot.actor` is the original asserter; `Announce.actor` is the
+  CaseActor (envelope). These MUST NOT be swapped.
+- **One canonical entry per logical state change**, broadcast byte-identically
+  to every participant.
+- **Commit-boundary enforcement**: runtime guard at the CaseActor's commit
+  path rejects non-canonical entries before they enter the hash chain.
+- **Progressive test ratcheting**: invariant assertions land up front as
+  xfail; each fix PR flips one xfail to passing.

--- a/specs/case-log-processing.yaml
+++ b/specs/case-log-processing.yaml
@@ -1,8 +1,8 @@
 id: CLP
-title: Case Log Processing
+title: Case Ledger Processing
 description: >-
-  Requirements for participant assertions, CaseActor canonicalization, local case audit logging,
-  recorded-history projection, and replication-facing `CaseLogEntry` objects. `notes/activitystreams-semantics.md`,
+  Requirements for participant assertions, CaseActor canonicalization, local case audit ledgerging,
+  recorded-history projection, and replication-facing `CaseLedgerEntry` objects. `notes/activitystreams-semantics.md`,
   `notes/case-state-model.md`, `notes/sync-log-replication.md` `specs/sync-log-replication.md`,
   `specs/outbox.md`, `specs/message-validation.md`, `specs/idempotency.md` recording. Transport-layer
   handling for malformed or unrouteable traffic that cannot be attached to a report or case
@@ -36,42 +36,42 @@ groups:
     statement: >-
       Participant replicas MUST NOT project shared case state directly from peer assertions
 - id: CLP-02
-  title: Canonical `CaseLogEntry`
+  title: Canonical `CaseLedgerEntry`
   specs:
   - id: CLP-02-001
     priority: MUST
     statement: >-
       For each case-resolvable assertion processed at the case layer, the CaseActor MUST append
-      a canonical `CaseLogEntry`
+      a canonical `CaseLedgerEntry`
   - id: CLP-02-002
     priority: MUST
     statement: >-
-      `CaseLogEntry` MUST be a canonical content object distinct from any transport envelope
+      `CaseLedgerEntry` MUST be a canonical content object distinct from any transport envelope
       used to replicate it
   - id: CLP-02-003
     priority: MUST
     statement: >-
-      `CaseLogEntry` MUST include the asserted activity payload, or a normalized immutable
+      `CaseLedgerEntry` MUST include the asserted activity payload, or a normalized immutable
       snapshot of it, sufficient for deterministic replay
   - id: CLP-02-004
     priority: MUST
     statement: >-
-      `CaseLogEntry` MUST include a disposition field with at least `recorded` and `rejected`
+      `CaseLedgerEntry` MUST include a disposition field with at least `recorded` and `rejected`
   - id: CLP-02-005
     priority: SHOULD
     statement: >-
-      Rejected `CaseLogEntry` objects SHOULD include a machine-readable reason code and MAY
+      Rejected `CaseLedgerEntry` objects SHOULD include a machine-readable reason code and MAY
       include human-readable detail
   - id: CLP-02-006
     priority: MUST_NOT
     statement: >-
-      `CaseLogEntry` MUST include a `log_index` field corresponding to SYNC-01-002; this field
+      `CaseLedgerEntry` MUST include a `log_index` field corresponding to SYNC-01-002; this field
       MUST be set by the CaseActor's single authoritative write path and MUST NOT be assigned
       by external parties
   - id: CLP-02-007
     priority: MUST
     statement: >-
-      `CaseLogEntry` MAY include an optional `term` field reserved for Raft cluster use; in
+      `CaseLedgerEntry` MAY include an optional `term` field reserved for Raft cluster use; in
       single-node deployments this field SHOULD be omitted or set to `null`; in multi-node
       CaseActor cluster deployments this field MUST be populated with the current Raft term
       at time of append
@@ -82,25 +82,25 @@ groups:
     priority: MUST
     statement: >-
       Only assertions that can be resolved to a specific report, proto-case, or case MUST
-      be appended to the case audit log
+      be appended to the case audit ledger
   - id: CLP-03-002
     priority: MUST
     statement: >-
       Malformed, unauthenticated, or otherwise unrouteable inbound messages that cannot be
-      attached to a report or case MUST be handled outside the case audit log
+      attached to a report or case MUST be handled outside the case audit ledger
   - id: CLP-03-003
     priority: MUST
     statement: >-
       The assertion-recording model MUST support continuity from report receipt through the
       case lifecycle so that all history — including the proto-case stage (RM.RECEIVED / RM.INVALID)
-      — is captured in the case audit log
+      — is captured in the case audit ledger
 - id: CLP-04
   title: Recorded Projection and Replication
   specs:
   - id: CLP-04-001
     priority: MUST
     statement: >-
-      The authoritative recorded history of a case MUST be a filtered projection of `CaseLogEntry`
+      The authoritative recorded history of a case MUST be a filtered projection of `CaseLedgerEntry`
       objects whose disposition is `recorded`
   - id: CLP-04-002
     priority: MUST
@@ -111,11 +111,11 @@ groups:
     priority: MUST
     statement: >-
       Replicated hash chains, Merkle proofs, and replay state MUST be computed over recorded
-      `CaseLogEntry` objects only
+      `CaseLedgerEntry` objects only
   - id: CLP-04-004
     priority: MUST
     statement: >-
-      CaseActor fan-out replication MUST deliver the canonical `CaseLogEntry` content, wrapped
+      CaseActor fan-out replication MUST deliver the canonical `CaseLedgerEntry` content, wrapped
       in an ActivityStreams transport envelope such as `Announce`
   - id: CLP-04-005
     priority: SHOULD
@@ -138,7 +138,7 @@ groups:
   - id: CLP-05-002
     priority: MUST_NOT
     statement: >-
-      Normal case-update fan-out MUST NOT replicate rejected `CaseLogEntry` objects to all
+      Normal case-update fan-out MUST NOT replicate rejected `CaseLedgerEntry` objects to all
       case participants
   - id: CLP-05-003
     priority: SHOULD
@@ -153,7 +153,7 @@ groups:
     priority: SHOULD
     statement: >-
       Participant actors SHOULD maintain actor-local pending assertion state for recently
-      emitted case-scoped assertions that are awaiting canonical `CaseLogEntry` confirmation
+      emitted case-scoped assertions that are awaiting canonical `CaseLedgerEntry` confirmation
   - id: CLP-06-002
     priority: MUST_NOT
     statement: >-
@@ -178,34 +178,34 @@ groups:
     priority: MUST
     statement: >-
       A pending assertion entry MUST be cleared when a matching canonical
-      `CaseLogEntry(recorded|rejected)` is observed
+      `CaseLedgerEntry(recorded|rejected)` is observed
 - id: CLP-07
   title: Canonical Entry Criteria and Ledger/Process-Log Separation
   specs:
   - id: CLP-07-001
     priority: MUST
     statement: >-
-      A `CaseLogEntry` committed to the canonical case log MUST correspond to exactly
+      A `CaseLedgerEntry` committed to the canonical case ledger MUST correspond to exactly
       one CaseActor-accepted protocol-significant assertion; the entry's `payloadSnapshot`
       MUST be the verbatim AS2 activity that was asserted, or a deterministic canonical
       normalization of it, and MUST NOT be empty for non-rejection entries
   - id: CLP-07-002
     priority: MUST
     statement: >-
-      Each logical state change MUST produce at most one canonical `CaseLogEntry`; the
+      Each logical state change MUST produce at most one canonical `CaseLedgerEntry`; the
       CaseActor MUST NOT commit both an accepted-participant-assertion entry and a
       separately-synthesized CaseActor entry for the same state change
   - id: CLP-07-003
     priority: MUST
     statement: >-
-      The `payloadSnapshot.actor` field of a `CaseLogEntry(recorded)` MUST preserve the
+      The `payloadSnapshot.actor` field of a `CaseLedgerEntry(recorded)` MUST preserve the
       original asserting actor's identity; the CaseActor's own identity appears only on
-      the `Announce(CaseLogEntry)` transport envelope and in CaseLogEntry recording
+      the `Announce(CaseLedgerEntry)` transport envelope and in CaseLedgerEntry recording
       metadata, never as a substitute for the asserter
   - id: CLP-07-004
     priority: MUST_NOT
     statement: >-
-      The canonical case log MUST NOT contain runtime diagnostics, demo checkpoints,
+      The canonical case ledger MUST NOT contain runtime diagnostics, demo checkpoints,
       synthetic verification markers, troubleshooting events, or any per-actor
       observability content; such content belongs in the per-actor process log governed
       by `specs/structured-logging.yaml`

--- a/specs/case-log-processing.yaml
+++ b/specs/case-log-processing.yaml
@@ -179,3 +179,52 @@ groups:
     statement: >-
       A pending assertion entry MUST be cleared when a matching canonical
       `CaseLogEntry(recorded|rejected)` is observed
+- id: CLP-07
+  title: Canonical Entry Criteria and Ledger/Process-Log Separation
+  specs:
+  - id: CLP-07-001
+    priority: MUST
+    statement: >-
+      A `CaseLogEntry` committed to the canonical case log MUST correspond to exactly
+      one CaseActor-accepted protocol-significant assertion; the entry's `payloadSnapshot`
+      MUST be the verbatim AS2 activity that was asserted, or a deterministic canonical
+      normalization of it, and MUST NOT be empty for non-rejection entries
+  - id: CLP-07-002
+    priority: MUST
+    statement: >-
+      Each logical state change MUST produce at most one canonical `CaseLogEntry`; the
+      CaseActor MUST NOT commit both an accepted-participant-assertion entry and a
+      separately-synthesized CaseActor entry for the same state change
+  - id: CLP-07-003
+    priority: MUST
+    statement: >-
+      The `payloadSnapshot.actor` field of a `CaseLogEntry(recorded)` MUST preserve the
+      original asserting actor's identity; the CaseActor's own identity appears only on
+      the `Announce(CaseLogEntry)` transport envelope and in CaseLogEntry recording
+      metadata, never as a substitute for the asserter
+  - id: CLP-07-004
+    priority: MUST_NOT
+    statement: >-
+      The canonical case log MUST NOT contain runtime diagnostics, demo checkpoints,
+      synthetic verification markers, troubleshooting events, or any per-actor
+      observability content; such content belongs in the per-actor process log governed
+      by `specs/structured-logging.yaml`
+  - id: CLP-07-005
+    priority: SHOULD
+    statement: >-
+      The CaseActor commit boundary SHOULD enforce CLP-07-001 through CLP-07-004 with a
+      runtime guard that rejects non-canonical entries before they enter the hash chain,
+      failing fast rather than silently polluting replicated history
+  - id: CLP-07-006
+    priority: MUST
+    statement: >-
+      Nested protocol objects referenced from a `payloadSnapshot` (e.g., `EmbargoEvent`,
+      `VulnerabilityReport`, `Note`, `ParticipantStatus`) MUST be embedded inline as full
+      objects in the snapshot; ID-string substitutions that require an out-of-band
+      DataLayer lookup to resolve MUST NOT be used in canonical snapshots
+  - id: CLP-07-007
+    priority: MUST
+    statement: >-
+      `payloadSnapshot` context values MUST use the case URI once a case exists;
+      report URIs MUST NOT appear as the context for ParticipantStatus or other
+      case-scoped snapshots after the report→case promotion has occurred


### PR DESCRIPTION
- Closes #923

## Summary

Captures the durable design clarification motivated by concern #923 (two-actor demo case-log replication review): the canonical case log is a CaseActor-authored protocol ledger; runtime diagnostics belong in the per-actor Python process log. Adds ADR-0019, a new CLP-07 spec group, an extension to `notes/case-log-authority.md`, and an `AGENTS.md` pitfall.

## Changes

- **ADR-0019** — `docs/adr/0019-case-log-is-canonical-ledger-not-process-log.md`. Records the decision to maintain two strictly separate logs (canonical case log vs. per-actor process log), the alternatives considered, and consequences.
- **`specs/case-log-processing.yaml`** — adds CLP-07 group (CLP-07-001 through CLP-07-007):
  - exactly one canonical entry per accepted assertion, verbatim `payloadSnapshot`
  - one entry per logical state change (no duplicate emit)
  - `payloadSnapshot.actor` preserves the original asserter
  - canonical log MUST NOT contain diagnostics/synthetic markers
  - commit-boundary runtime guard SHOULD enforce CLP-07-001..004
  - nested objects MUST be inlined (no ID-string substitutions)
  - context MUST use case URI after report→case promotion
- **`notes/case-log-authority.md`** — extends with canonical entry criteria, allowed vs. disallowed entry-type examples, the `Announce` envelope vs. `payloadSnapshot.actor` distinction (with worked example), and commit-boundary enforcement guidance.
- **`AGENTS.md`** — adds "Case Log Is a Ledger, Not a Process Log" pitfall under Common Pitfalls.
- **`docs/adr/index.md`** — lists ADR-0019 under Accepted ADRs.

Implementation issues that cite this docs work will be created next under epic #788.