### PR TITLE
test: convert hierarchy invariant skips to xfails

### DIFF
--- a/test/architecture/test_hierarchy_invariants.py
+++ b/test/architecture/test_hierarchy_invariants.py
@@ -74,13 +74,14 @@ class TestCoreVocabularyHierarchy:
                 cls, as_Base
             ), f"{name} inherits from as_Base (wire layer)"
 
-    @pytest.mark.skip(
+    @pytest.mark.xfail(
+        strict=False,
         reason="Known pre-existing violation from ADR-0017 migration (issue #800). "
         "CoreObject subclasses VultronPerson, VultronOrganization, VultronService, "
         "VultronApplication, VultronGroup, and CoreActorCollection inherit "
         "alias_generator=to_camel from as_Base (wire layer), but they reside in "
         "the core branch. This test documents the violation and will pass once "
-        "these classes are refactored to remove wire-specific serialization config."
+        "these classes are refactored to remove wire-specific serialization config.",
     )
     def test_no_core_object_has_to_camel_alias_generator(self) -> None:
         """No CoreObject subclass may use alias_generator=to_camel.
@@ -107,12 +108,13 @@ class TestCoreVocabularyHierarchy:
 class TestWireVocabularyHierarchy:
     """Tests for VOCABULARY (wire) hierarchy invariants."""
 
-    @pytest.mark.skip(
+    @pytest.mark.xfail(
+        strict=False,
         reason="Known pre-existing violation from ADR-0017 migration (issue #800). "
         "Core-layer actor classes (CoreActor, VultronPerson, etc.) are registered "
         "in the wire VOCABULARY registry under keys like 'Actor', 'Person', etc. "
         "This test documents the violation and will pass once core-layer actor "
-        "vocabulary is kept separate from wire-layer vocabulary."
+        "vocabulary is kept separate from wire-layer vocabulary.",
     )
     def test_all_vocabulary_are_as_base_subclasses(self) -> None:
         """All VOCABULARY classes must be subclasses of as_Base.


### PR DESCRIPTION
Related to #944

Summary:
Convert two known-violation hierarchy tests from skip to xfail (strict false) so they remain visible as expected failures and can surface an XPASS when resolved.

Changes:
- test/architecture/test_hierarchy_invariants.py
  - test_no_core_object_has_to_camel_alias_generator: skip to xfail
  - test_all_vocabulary_are_as_base_subclasses: skip to xfail