### PR TITLE
Migrate status BT area to BTND-07 structure (#911)

### DIFF
--- a/plan/history/2606/implementation/ISSUE-911.md
+++ b/plan/history/2606/implementation/ISSUE-911.md
@@ -1,0 +1,24 @@
+---
+source: ISSUE-911
+timestamp: '2026-06-15T13:45:27.346903+00:00'
+title: Migrate status BT area to BTND-07 structure
+type: implementation
+---
+
+## Issue #911 — Migrate status BT area to BTND-07 structure
+
+The `status/nodes/` subpackage was already implemented in earlier commits
+(`abeb064d`, `c8b9b9e7`). This task verified all three acceptance criteria
+were met and corrected the only remaining gap: a stale docstring in
+`nodes/__init__.py` that still referenced a `participant_status` submodule
+which had been split into `append.py` + `lifecycle.py`.
+
+Acceptance criteria verified:
+
+- No root `status/nodes.py` remains
+- `status/nodes/` exists with 5 concern-based modules (`conditions`,
+  `broadcast`, `append`, `lifecycle`, `case_status`) and `__init__.py`
+  re-exports all 19 public names
+- All 100 status behavior tests pass; 3205 unit tests pass overall
+
+PR: <https://github.com/CERTCC/Vultron/pull/946>

--- a/vultron/core/behaviors/status/nodes/__init__.py
+++ b/vultron/core/behaviors/status/nodes/__init__.py
@@ -22,11 +22,17 @@ without modification.
 
 Submodules:
 - ``conditions``: Participant verification condition nodes
-- ``broadcast``: Peer fan-out nodes (FindCaseManager, FilterPeerRecipients,
-  CreateStatusBroadcastActivity, BroadcastQueueToOutbox,
-  BroadcastStatusToPeers)
-- ``participant_status``: Load, validate RM transition, append, public
-  disclosure, and auto-close action nodes
+- ``broadcast``: Peer fan-out helper and nodes (_find_case_manager_id,
+  FindCaseManagerNode, FilterPeerRecipientsNode,
+  CreateStatusBroadcastActivityNode, BroadcastQueueToOutboxNode,
+  BroadcastStatusToPeersNode)
+- ``append``: Load, validate RM transition, and append action nodes
+  (SkipIfIdempotentNode, LoadParticipantNode,
+  CheckStatusNotAlreadyAppendedNode, ResolveAndPersistStatusObjectNode,
+  ValidateRMTransitionNode, AppendStatusAndSaveParticipantNode)
+- ``lifecycle``: Public disclosure and auto-close lifecycle nodes
+  (_PublicDisclosureSkipConditionNode, PublicDisclosureBranchNode,
+  AutoCloseBranchNode)
 - ``case_status``: Idempotency guard, EM/PXA transition validation, and
   append nodes for the AddCaseStatusToCase workflow
 """


### PR DESCRIPTION
- Closes #911

## Summary

Formally closes #911: the `status/nodes/` subpackage was already
implemented in earlier commits (`abeb064d`, `c8b9b9e7`). This PR
corrects the only remaining gap — a stale docstring in
`nodes/__init__.py` that still referenced a `participant_status`
submodule which was subsequently split into `append.py` + `lifecycle.py`.

## Changes

- `vultron/core/behaviors/status/nodes/__init__.py`: Replace stale
  `participant_status` submodule description with accurate entries for
  `append` and `lifecycle`; list all exported names including
  `_find_case_manager_id`.

## Verification

- All 3205 unit tests pass (0 new — implementation already on main)
- Black, flake8, mypy, pyright clean
- Acceptance criteria verified:
  - No root `status/nodes.py` remains ✅
  - `status/nodes/` exists with 5 concern-based modules and `__init__.py` re-exports ✅
  - 100 status behavior tests pass ✅