### PR TITLE
Add RM terminal-state guard for CLOSED participant updates

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -90,3 +90,12 @@ layout strictly mirrored. The parent `conftest.py` fixtures are automatically
 inherited via pytest's upward conftest search, so only the vocabulary
 registration side-effect import needs copying into each new subdirectory
 conftest.
+
+### 2026-06-15 RM-TERMINAL-GUARD-928 — treat CLOSED as terminal before same-state check
+
+`ValidateRMTransitionNode` must evaluate terminal-state rules before its
+`current == new` short-circuit. If equality is checked first, repeated
+`CLOSED -> CLOSED` updates are treated as successful no-ops at validation time
+but still flow through append/broadcast/log-cascade paths as new status IDs.
+Guarding terminal `RM.CLOSED` first prevents duplicate closure cascades and
+keeps `close_case` retries from creating new canonical ledger entries.

--- a/plan/history/2606/implementation/ISSUE-928.md
+++ b/plan/history/2606/implementation/ISSUE-928.md
@@ -1,0 +1,12 @@
+---
+source: ISSUE-928
+timestamp: '2026-06-15T13:47:02.045331+00:00'
+title: RM terminal-state guard for CLOSED participants
+type: implementation
+---
+
+## Issue #928 — Add RM terminal-state guard: block further RM transitions on a participant once CLOSED
+
+Implemented an RM terminal-state guard in the AddParticipantStatus receive BT path so participants already at RM.CLOSED reject further RM updates, including CLOSED→CLOSED rewrites. Added regression coverage proving terminal rewrites do not append participant statuses and do not commit CaseLedgerEntry cascades, and promoted invariant 7 in the CI case-ledger invariant harness by removing xfail.
+
+PR: <https://github.com/CERTCC/Vultron/pull/947>

--- a/test/ci/test_case_ledger_invariants.py
+++ b/test/ci/test_case_ledger_invariants.py
@@ -116,6 +116,29 @@ def _payload(entry: dict) -> dict:
     return snap if isinstance(snap, dict) else {}
 
 
+def _participant_status_identity_and_rm(
+    snapshot: dict,
+) -> tuple[str | None, str | None]:
+    """Extract participant id + RM state from a status payload snapshot.
+
+    Historical logs may encode ``ParticipantStatus`` directly in
+    ``payloadSnapshot`` or nest it under an ``Add`` activity's ``object``.
+    """
+    p_id = snapshot.get("attributedTo") or snapshot.get("attributed_to")
+    rm_state = snapshot.get("rmState") or snapshot.get("rm_state")
+    if p_id and rm_state:
+        return str(p_id), str(rm_state)
+
+    nested = snapshot.get("object")
+    if isinstance(nested, dict):
+        nested_id = nested.get("attributedTo") or nested.get("attributed_to")
+        nested_rm = nested.get("rmState") or nested.get("rm_state")
+        if nested_id and nested_rm:
+            return str(nested_id), str(nested_rm)
+
+    return None, None
+
+
 # ---------------------------------------------------------------------------
 # Fixture
 # ---------------------------------------------------------------------------
@@ -456,11 +479,9 @@ def test_invariant_7_log_terminates_all_rm_closed(
     for entry in auth:
         if _event_type(entry) != "add_participant_status":
             continue
-        snap = _payload(entry)
-        p_id = snap.get("attributedTo") or snap.get("attributed_to")
-        rm_state = snap.get("rmState") or snap.get("rm_state")
+        p_id, rm_state = _participant_status_identity_and_rm(_payload(entry))
         if p_id and rm_state:
-            latest_rm[str(p_id)] = str(rm_state)
+            latest_rm[p_id] = rm_state
 
     assert (
         latest_rm

--- a/test/ci/test_case_ledger_invariants.py
+++ b/test/ci/test_case_ledger_invariants.py
@@ -442,13 +442,6 @@ def test_invariant_6_no_rm_state_oscillation(
 
 
 @pytest.mark.case_ledger_invariants
-@pytest.mark.xfail(
-    strict=False,
-    reason=(
-        "Log must terminate with all participants in RM=CLOSED; "
-        "requires the RM terminal-state guard (see issue #789)"
-    ),
-)
 def test_invariant_7_log_terminates_all_rm_closed(
     case_ledger_replicas: dict[str, list[dict]],
 ) -> None:

--- a/test/core/behaviors/status/test_add_participant_status_bt.py
+++ b/test/core/behaviors/status/test_add_participant_status_bt.py
@@ -383,6 +383,44 @@ class TestValidateRMTransitionNode:
         )
         assert result.status == Status.FAILURE
 
+    def test_rejects_terminal_closed_rewrite(
+        self, populated_dl, populated_bridge
+    ):
+        """RM.CLOSED is terminal; CLOSED -> CLOSED rewrites are rejected."""
+        p = populated_dl.read(PARTICIPANT_ID)
+        closed_status = ParticipantStatus(
+            id_=f"{STATUS_ID}/closed",
+            context=CASE_ID,
+            rm_state=RM.CLOSED,
+        )
+        p.participant_statuses.append(closed_status)
+        populated_dl.save(p)
+        populated_dl.create(closed_status)
+
+        duplicate_closed_status = ParticipantStatus(
+            id_=f"{STATUS_ID}/closed-dup",
+            context=CASE_ID,
+            rm_state=RM.CLOSED,
+        )
+        populated_dl.create(duplicate_closed_status)
+
+        tree = py_trees.composites.Sequence(
+            name="test-validate-terminal-closed",
+            memory=False,
+            children=[
+                LoadParticipantNode(participant_id=PARTICIPANT_ID),
+                ResolveAndPersistStatusObjectNode(
+                    status_id=duplicate_closed_status.id_,
+                    status_obj_fallback=duplicate_closed_status,
+                ),
+                ValidateRMTransitionNode(participant_id=PARTICIPANT_ID),
+            ],
+        )
+        result = populated_bridge.execute_with_setup(
+            tree=tree, actor_id=ACTOR_ID
+        )
+        assert result.status == Status.FAILURE
+
     def test_accepts_forward_jump(self, populated_dl, populated_bridge):
         """Non-adjacent forward RM jump is accepted (sender authoritative)."""
         p = populated_dl.read(PARTICIPANT_ID)
@@ -536,6 +574,41 @@ class TestAppendParticipantStatusSubtree:
             tree=tree, actor_id=ACTOR_ID
         )
         assert result.status == Status.FAILURE
+
+    def test_terminal_closed_duplicate_is_rejected_and_not_appended(
+        self, populated_dl, populated_bridge, participant
+    ):
+        """Repeated CLOSED updates are rejected and do not append new status."""
+        closed_status = ParticipantStatus(
+            id_=f"{STATUS_ID}/prev",
+            context=CASE_ID,
+            rm_state=RM.CLOSED,
+        )
+        participant.participant_statuses.append(closed_status)
+        populated_dl.save(participant)
+        populated_dl.create(closed_status)
+
+        duplicate_closed = ParticipantStatus(
+            id_=f"{STATUS_ID}/closed-dup",
+            context=CASE_ID,
+            rm_state=RM.CLOSED,
+        )
+        populated_dl.create(duplicate_closed)
+
+        before_count = len(participant.participant_statuses)
+        tree = append_participant_status_tree(
+            status_id=duplicate_closed.id_,
+            participant_id=PARTICIPANT_ID,
+            status_obj_fallback=duplicate_closed,
+        )
+        result = populated_bridge.execute_with_setup(
+            tree=tree, actor_id=ACTOR_ID
+        )
+        assert result.status == Status.FAILURE
+
+        updated_participant = populated_dl.read(PARTICIPANT_ID)
+        assert updated_participant is not None
+        assert len(updated_participant.participant_statuses) == before_count
 
     def test_forward_rm_jump_accepted(
         self, populated_dl, populated_bridge, participant

--- a/test/core/use_cases/received/test_status.py
+++ b/test/core/use_cases/received/test_status.py
@@ -20,6 +20,7 @@ from vultron.core.models.case_actor import VultronCaseActor
 from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
 from vultron.core.models.protocols import is_log_entry_model
 from vultron.core.states.em import EM
+from vultron.core.states.rm import RM
 from vultron.core.use_cases.received.status import (
     AddCaseStatusToCaseReceivedUseCase,
     AddParticipantStatusToParticipantReceivedUseCase,
@@ -395,3 +396,59 @@ class TestParticipantStatusLogEntryCascade:
 
         # But no outbox activities should be queued for fan-out.
         assert dl.outbox_list() == []
+
+    def test_terminal_closed_update_does_not_commit_log_entry(
+        self, make_payload
+    ) -> None:
+        """CLOSED->CLOSED rewrites are rejected before log cascade."""
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+
+        actor_id = "https://example.org/users/vendor"
+        case_id = "https://example.org/cases/st_le3"
+        dl, case_actor_id, participant, _ = self._make_dl(case_id, actor_id)
+        case = cast(VulnerabilityCase, dl.read(case_id))
+        assert case is not None
+
+        closed_status = ParticipantStatus(
+            id_=f"{case_id}/participants/p1/statuses/closed-existing",
+            context=case_id,
+            rm_state=RM.CLOSED,
+        )
+        participant.participant_statuses.append(closed_status)
+        dl.save(participant)
+        dl.create(closed_status)
+
+        duplicate_closed_status = ParticipantStatus(
+            id_=f"{case_id}/participants/p1/statuses/closed-duplicate",
+            context=case_id,
+            rm_state=RM.CLOSED,
+        )
+        dl.create(duplicate_closed_status)
+
+        activity = add_status_to_participant_activity(
+            duplicate_closed_status,
+            target=participant,
+            actor=actor_id,
+            context=case,
+        )
+        event = make_payload(activity, receiving_actor_id=case_actor_id)
+        sync_port = SyncActivityAdapter(dl)
+
+        before_count = len(participant.participant_statuses)
+        AddParticipantStatusToParticipantReceivedUseCase(
+            dl, event, sync_port=sync_port
+        ).execute()
+
+        entries = [
+            obj
+            for obj in dl.list_objects("CaseLedgerEntry")
+            if is_log_entry_model(obj)
+            and cast(VultronCaseLedgerEntry, obj).case_id == case_id
+        ]
+        assert entries == []
+
+        updated_participant = dl.read(participant.id_)
+        assert updated_participant is not None
+        assert len(updated_participant.participant_statuses) == before_count

--- a/vultron/core/behaviors/status/nodes/append.py
+++ b/vultron/core/behaviors/status/nodes/append.py
@@ -32,6 +32,7 @@ from vultron.core.models.protocols import (
     is_participant_model,
 )
 from vultron.core.states.rm import (
+    RM,
     is_monotonic_rm_forward,
     is_valid_rm_transition,
 )
@@ -312,6 +313,18 @@ class ValidateRMTransitionNode(DataLayerCondition):
             return Status.SUCCESS
 
         current_rm = current_status.rm_state
+        if current_rm == RM.CLOSED:
+            self.feedback_message = (
+                "Participant is already in terminal RM.CLOSED state"
+                f" (received {new_rm_state}) for participant"
+                f" '{self.participant_id}'"
+            )
+            self.logger.info(
+                "ValidateRMTransitionNode: %s — rejecting",
+                self.feedback_message,
+            )
+            return Status.FAILURE
+
         if current_rm == new_rm_state:
             self.logger.debug(
                 "ValidateRMTransitionNode: no RM state change (both %s)",


### PR DESCRIPTION
- Closes #928

## Summary

Adds an RM terminal-state guard in the AddParticipantStatus BT path so once a participant reaches RM.CLOSED, further RM updates for that participant are rejected at the CaseActor receive path. This fixes the cascade root cause where repeated close_case calls were treated as successful rewrites (CLOSED -> CLOSED), producing fresh status entries that could re-trigger downstream broadcast/log cascades instead of converging.

## Changes

- vultron/core/behaviors/status/nodes/append.py: added a terminal guard in ValidateRMTransitionNode that fails any incoming RM update when the participant is already at RM.CLOSED (including CLOSED -> CLOSED rewrites).
- test/core/behaviors/status/test_add_participant_status_bt.py: added coverage that terminal CLOSED rewrites are rejected both at node-level validation and at append-subtree integration level (no new participant status append).
- test/core/use_cases/received/test_status.py: added coverage that terminal CLOSED rewrites do not commit a CaseLedgerEntry and do not mutate participant status history.
- test/ci/test_case_ledger_invariants.py: promoted invariant 7 (terminal all-closed end state) by removing xfail.

## Verification

- 3208 passed, 34 skipped, 222 deselected, 2 xfailed (unit suite)
- Black, flake8, mypy, pyright clean