### PR TITLE
feat: add INFO/DEBUG logging for case-ledger commit events

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -100,6 +100,16 @@ but still flow through append/broadcast/log-cascade paths as new status IDs.
 Guarding terminal `RM.CLOSED` first prevents duplicate closure cascades and
 keeps `close_case` retries from creating new canonical ledger entries.
 
+### 2026-06-15 LEDGER-LOGGING-949 — PersistLogEntryNode tests require log_entry in blackboard
+
+When testing `PersistLogEntryNode` logging via `bridge.execute_with_setup()`,
+pass the `VultronCaseLedgerEntry` as `log_entry=entry` in kwargs — the bridge
+writes it to the blackboard before executing the node. The conftest `_make_entry()`
+helper builds a ready-to-use entry from a `HashChainLedgerRecord`. Use
+`caplog.at_level(logging.INFO, logger="vultron.core.behaviors.sync.nodes.chain")`
+to scope capture to just the chain node logger; without scoping, other node
+loggers at DEBUG can fill caplog with unrelated records.
+
 ### 2026-06-15 LEDGER-INVARIANTS-950 — demo_get_case_ledger ignores actor_id; in-process tests see unified log
 
 `demo_triggers.demo_get_case_ledger` ignores the `actor_id` path parameter

--- a/plan/history/2606/implementation/ISSUE-949.md
+++ b/plan/history/2606/implementation/ISSUE-949.md
@@ -1,0 +1,31 @@
+---
+source: ISSUE-949
+timestamp: '2026-06-15T16:08:02.335839+00:00'
+title: Add INFO/DEBUG logging for case-ledger commit events
+type: implementation
+---
+
+## Issue #949 — Track B: Add INFO-level logging for case-ledger commit events
+
+Added structured INFO and DEBUG logging at the two ledger-commit points to
+fill the missing layer-3 diagnostic gap ("was it committed to the ledger?")
+for Demo Integration CI failures.
+
+### Changes
+
+- `vultron/core/models/case_ledger.py`: added module logger; `CaseLedger.append()`
+  now emits `logger.info()` (case_id, event_type, log_index, disposition) and
+  `logger.debug()` (entry_hash prefix, payload_snapshot) after each hash-chain commit
+- `vultron/core/behaviors/sync/nodes/chain.py`: enhanced `PersistLogEntryNode.update()`
+  INFO log to include case_id, event_type, log_index, actor_id; added DEBUG log with
+  entry_hash prefix and payload_snapshot
+- `test/core/models/test_case_ledger.py`: added `TestCaseLedgerAppendLogging` (7 tests)
+  covering INFO and DEBUG emission from `CaseLedger.append()`
+- `test/core/behaviors/sync/nodes/test_chain.py`: added `TestPersistLogEntryNodeLogging`
+  (5 tests) verifying INFO fields (event_type, log_index, actor_id) and DEBUG
+  entry_hash prefix in `PersistLogEntryNode`
+
+### Outcome
+
+All 3220 unit tests pass (12 new).
+PR: [#953](https://github.com/CERTCC/Vultron/pull/953)

--- a/test/core/behaviors/sync/nodes/test_chain.py
+++ b/test/core/behaviors/sync/nodes/test_chain.py
@@ -1,11 +1,20 @@
 #!/usr/bin/env python
 """Unit tests for sync chain nodes."""
 
+import logging
+
 import py_trees
+import pytest
 from py_trees.common import Status
 
-from test.core.behaviors.sync.nodes.conftest import OWNER_ACTOR_ID
-from vultron.core.behaviors.sync.nodes import CreateLogEntryNode
+from test.core.behaviors.sync.nodes.conftest import (
+    OWNER_ACTOR_ID,
+    _make_entry,
+)
+from vultron.core.behaviors.sync.nodes import (
+    CreateLogEntryNode,
+    PersistLogEntryNode,
+)
 from vultron.core.models.case_ledger import GENESIS_HASH
 
 
@@ -30,3 +39,90 @@ def test_create_log_entry_node_writes_log_entry_to_blackboard(bridge):
     )
     assert blackboard.log_entry.case_id == case_id
     assert blackboard.log_entry.log_index == 0
+
+
+# ---------------------------------------------------------------------------
+# PersistLogEntryNode — logging (SL-03-001, SL-04-001)
+# ---------------------------------------------------------------------------
+
+
+class TestPersistLogEntryNodeLogging:
+    """Verify INFO and DEBUG log emission from PersistLogEntryNode."""
+
+    @pytest.fixture()
+    def entry(self):
+        return _make_entry(log_index=0, prev_hash=GENESIS_HASH)
+
+    def test_info_log_emitted_on_persist(
+        self, bridge, entry, caplog: pytest.LogCaptureFixture
+    ):
+        node_logger = "vultron.core.behaviors.sync.nodes.chain"
+        with caplog.at_level(logging.INFO, logger=node_logger):
+            result = bridge.execute_with_setup(
+                tree=PersistLogEntryNode(name="PersistLogEntry"),
+                actor_id=OWNER_ACTOR_ID,
+                log_entry=entry,
+            )
+        assert result.status == Status.SUCCESS
+        assert any(r.levelno == logging.INFO for r in caplog.records)
+
+    def test_info_log_contains_event_type(
+        self, bridge, entry, caplog: pytest.LogCaptureFixture
+    ):
+        node_logger = "vultron.core.behaviors.sync.nodes.chain"
+        with caplog.at_level(logging.INFO, logger=node_logger):
+            bridge.execute_with_setup(
+                tree=PersistLogEntryNode(name="PersistLogEntry"),
+                actor_id=OWNER_ACTOR_ID,
+                log_entry=entry,
+            )
+        assert any(
+            r.levelno == logging.INFO and "test_event" in r.message
+            for r in caplog.records
+        )
+
+    def test_info_log_contains_log_index(
+        self, bridge, entry, caplog: pytest.LogCaptureFixture
+    ):
+        node_logger = "vultron.core.behaviors.sync.nodes.chain"
+        with caplog.at_level(logging.INFO, logger=node_logger):
+            bridge.execute_with_setup(
+                tree=PersistLogEntryNode(name="PersistLogEntry"),
+                actor_id=OWNER_ACTOR_ID,
+                log_entry=entry,
+            )
+        assert any(
+            r.levelno == logging.INFO and "log_index=0" in r.message
+            for r in caplog.records
+        )
+
+    def test_info_log_contains_actor_id(
+        self, bridge, entry, caplog: pytest.LogCaptureFixture
+    ):
+        node_logger = "vultron.core.behaviors.sync.nodes.chain"
+        with caplog.at_level(logging.INFO, logger=node_logger):
+            bridge.execute_with_setup(
+                tree=PersistLogEntryNode(name="PersistLogEntry"),
+                actor_id=OWNER_ACTOR_ID,
+                log_entry=entry,
+            )
+        assert any(
+            r.levelno == logging.INFO and OWNER_ACTOR_ID in r.message
+            for r in caplog.records
+        )
+
+    def test_debug_log_contains_entry_hash_prefix(
+        self, bridge, entry, caplog: pytest.LogCaptureFixture
+    ):
+        node_logger = "vultron.core.behaviors.sync.nodes.chain"
+        with caplog.at_level(logging.DEBUG, logger=node_logger):
+            bridge.execute_with_setup(
+                tree=PersistLogEntryNode(name="PersistLogEntry"),
+                actor_id=OWNER_ACTOR_ID,
+                log_entry=entry,
+            )
+        expected_prefix = entry.entry_hash[:16]
+        assert any(
+            r.levelno == logging.DEBUG and expected_prefix in r.message
+            for r in caplog.records
+        )

--- a/test/core/models/test_case_ledger.py
+++ b/test/core/models/test_case_ledger.py
@@ -23,6 +23,8 @@ Covers:
   ``tail_hash``, ``recorded_entries`` projection, and ``verify_chain``
   (SYNC-01-001, SYNC-01-002, SYNC-01-003, SYNC-07-001,
   CLP-04-001, CLP-04-003).
+- ``CaseLedger.append()`` logging at INFO and DEBUG levels (SL-03-001,
+  SL-04-001).
 - ``VultronReplicationState`` construction and DataLayer serialisation
   (SYNC-04-001, SYNC-04-002).
 - ``BTBridge`` leadership guard port — default always-True behaviour and
@@ -31,6 +33,7 @@ Covers:
 
 import hashlib
 import json
+import logging
 from unittest.mock import MagicMock
 
 import py_trees
@@ -456,6 +459,107 @@ class TestCaseLedgerVerifyChain:
     def test_all_entry_hashes_unique(self, log_with_three_entries: CaseLedger):
         hashes = [e.entry_hash for e in log_with_three_entries.entries]
         assert len(set(hashes)) == len(hashes)
+
+
+# ---------------------------------------------------------------------------
+# CaseLedger — append logging (SL-03-001, SL-04-001)
+# ---------------------------------------------------------------------------
+
+
+class TestCaseLedgerAppendLogging:
+    """Verify INFO and DEBUG log emission from CaseLedger.append()."""
+
+    def test_info_log_emitted_on_recorded_append(
+        self, empty_log: CaseLedger, caplog: pytest.LogCaptureFixture
+    ):
+        with caplog.at_level(
+            logging.INFO, logger="vultron.core.models.case_ledger"
+        ):
+            empty_log.append(object_id=OBJECT_ID, event_type="report_received")
+        assert any(
+            r.levelno == logging.INFO and "report_received" in r.message
+            for r in caplog.records
+        )
+
+    def test_info_log_contains_event_type(
+        self, empty_log: CaseLedger, caplog: pytest.LogCaptureFixture
+    ):
+        with caplog.at_level(
+            logging.INFO, logger="vultron.core.models.case_ledger"
+        ):
+            empty_log.append(
+                object_id=OBJECT_ID, event_type="participant_added"
+            )
+        assert any("participant_added" in r.message for r in caplog.records)
+
+    def test_info_log_contains_log_index(
+        self, empty_log: CaseLedger, caplog: pytest.LogCaptureFixture
+    ):
+        with caplog.at_level(
+            logging.INFO, logger="vultron.core.models.case_ledger"
+        ):
+            empty_log.append(object_id=OBJECT_ID, event_type="test_event")
+        assert any("log_index=0" in r.message for r in caplog.records)
+
+    def test_info_log_contains_disposition(
+        self, empty_log: CaseLedger, caplog: pytest.LogCaptureFixture
+    ):
+        with caplog.at_level(
+            logging.INFO, logger="vultron.core.models.case_ledger"
+        ):
+            empty_log.append(
+                object_id=OBJECT_ID,
+                event_type="test_event",
+                disposition="recorded",
+            )
+        assert any("recorded" in r.message for r in caplog.records)
+
+    def test_info_log_rejected_disposition(
+        self, empty_log: CaseLedger, caplog: pytest.LogCaptureFixture
+    ):
+        with caplog.at_level(
+            logging.INFO, logger="vultron.core.models.case_ledger"
+        ):
+            empty_log.append(
+                object_id=OBJECT_ID,
+                event_type="test_event",
+                disposition="rejected",
+                reason_code="PRECONDITION_FAILED",
+            )
+        assert any("rejected" in r.message for r in caplog.records)
+
+    def test_debug_log_contains_entry_hash(
+        self, empty_log: CaseLedger, caplog: pytest.LogCaptureFixture
+    ):
+        with caplog.at_level(
+            logging.DEBUG, logger="vultron.core.models.case_ledger"
+        ):
+            entry = empty_log.append(
+                object_id=OBJECT_ID, event_type="test_event"
+            )
+        expected_prefix = entry.entry_hash[:16]
+        assert any(
+            expected_prefix in r.message
+            for r in caplog.records
+            if r.levelno == logging.DEBUG
+        )
+
+    def test_debug_log_emitted_with_payload(
+        self, empty_log: CaseLedger, caplog: pytest.LogCaptureFixture
+    ):
+        snap = {"id": OBJECT_ID, "type": "Create"}
+        with caplog.at_level(
+            logging.DEBUG, logger="vultron.core.models.case_ledger"
+        ):
+            empty_log.append(
+                object_id=OBJECT_ID,
+                event_type="test_event",
+                payload_snapshot=snap,
+            )
+        assert any(
+            r.levelno == logging.DEBUG and "Create" in r.message
+            for r in caplog.records
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/vultron/core/behaviors/sync/nodes/chain.py
+++ b/vultron/core/behaviors/sync/nodes/chain.py
@@ -248,9 +248,17 @@ class PersistLogEntryNode(DataLayerAction):
         entry = cast(VultronCaseLedgerEntry, self.blackboard.log_entry)
         self.datalayer.save(entry)
         self.logger.info(
-            "%s: committed log entry '%s' for case '%s'",
+            "%s: committed log entry case_id=%s event_type=%s log_index=%d actor_id=%s",
             self.name,
-            entry.id_,
             entry.case_id,
+            entry.event_type,
+            entry.log_index,
+            self.actor_id,
+        )
+        self.logger.debug(
+            "%s: entry_hash=%.16s… payload_snapshot=%s",
+            self.name,
+            entry.entry_hash,
+            entry.payload_snapshot,
         )
         return Status.SUCCESS

--- a/vultron/core/models/case_ledger.py
+++ b/vultron/core/models/case_ledger.py
@@ -53,12 +53,15 @@ CLP-02 through CLP-05, and ``notes/sync-ledger-replication.md``.
 
 import hashlib
 import json
+import logging
 from datetime import datetime
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
 from vultron.core.models._helpers import _now_utc
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -397,6 +400,18 @@ class CaseLedger:
             reason_detail=reason_detail,
         )
         self._entries.append(entry)
+        logger.info(
+            "Committed ledger entry: case_id=%s event_type=%s log_index=%d disposition=%s",
+            self._case_id,
+            event_type,
+            entry.log_index,
+            disposition,
+        )
+        logger.debug(
+            "Ledger entry detail: entry_hash=%.16s… payload_snapshot=%s",
+            entry.entry_hash,
+            payload_snapshot or {},
+        )
         return entry
 
     def verify_chain(self) -> bool:


### PR DESCRIPTION
- Closes #949

## Summary

Adds structured INFO and DEBUG logging at the two ledger-commit points —
`CaseLedger.append()` and `PersistLogEntryNode` — filling the missing
layer-3 diagnostic gap ("was it committed to the ledger?") for Demo
Integration CI failures.

## Changes

- `vultron/core/models/case_ledger.py`: add `import logging` + module
  logger; emit `logger.info()` (case_id, event_type, log_index,
  disposition) and `logger.debug()` (entry_hash prefix, payload_snapshot)
  in `CaseLedger.append()` after each hash-chain commit
- `vultron/core/behaviors/sync/nodes/chain.py`: enhance
  `PersistLogEntryNode.update()` INFO log to include case_id, event_type,
  log_index, actor_id; add DEBUG log with entry_hash prefix and
  payload_snapshot
- `test/core/models/test_case_ledger.py`: add `TestCaseLedgerAppendLogging`
  (7 tests) covering INFO and DEBUG emission from `CaseLedger.append()`
- `test/core/behaviors/sync/nodes/test_chain.py`: add
  `TestPersistLogEntryNodeLogging` (5 tests) verifying INFO fields
  (event_type, log_index, actor_id) and DEBUG entry_hash prefix in
  `PersistLogEntryNode`

## Verification

- All 3220 unit tests pass (12 new)
- Black, flake8, mypy, pyright clean