### PR TITLE
fix(demo): remove synthetic demo_verification commit from canonical case ledger

### DIFF
--- a/vultron/demo/scenario/two_actor_demo.py
+++ b/vultron/demo/scenario/two_actor_demo.py
@@ -529,20 +529,21 @@ def _phase_sync_verification(
     logger.info("Phase 2: Replica synchronization verification")
     logger.info("─" * 80)
 
-    with demo_step("Committing case ledger entry on Vendor (CaseActor)"):
-        entry_hash = trigger_log_commit(
-            client=vendor_client,
-            actor_id=vendor.id_,
-            case_id=case.id_,
-            event_type="demo_verification",
-        )
-
-    with demo_step("Waiting for Finder to receive replicated log entry"):
-        wait_for_finder_log_entry(
-            finder_client=finder_client,
-            case_id=case.id_,
-            entry_hash=entry_hash,
-        )
+    # Synthetic checkpoint entries (demo_verification) are explicitly
+    # excluded from the canonical case ledger per ADR-0019 (CLP-07-004):
+    # only verbatim asserted protocol-significant AS2 activities belong on
+    # the chain. Diagnostic markers belong in Python `logging`. Replication
+    # is verified by comparing replica state directly rather than polling
+    # for a new entry.
+    #
+    # `trigger_log_commit` and `wait_for_finder_log_entry` remain available
+    # in `vultron.demo.helpers.sync` for tests that need to drive a *real*
+    # protocol event and wait for its replica; they are intentionally not
+    # called here.
+    logger.info(
+        "Verifying SYNC-2 replication by comparing vendor ↔ finder replica"
+        " state (ADR-0019: synthetic entries omitted from canonical ledger)"
+    )
 
     with demo_check("Finder replica state matches authoritative Vendor state"):
         verify_finder_replica_state(


### PR DESCRIPTION
- Closes #929

## Summary

Salvaged from the now-closed #944. Removes the synthetic `demo_verification` canonical-ledger commit from the two-actor demo's Phase 2 SYNC verification, per ADR-0019 / CLP-07-001 / CLP-07-004 (canonical entries MUST be verbatim asserted protocol-significant AS2 activities; diagnostic markers belong in Python `logging`).

Replication is verified by comparing replica state directly (`verify_finder_replica_state`) rather than polling for a synthetic entry's hash. `trigger_log_commit` and `wait_for_finder_log_entry` are unchanged and remain in `vultron.demo.helpers.sync` for tests that genuinely need to drive a real protocol event and wait for its replica.

## Changes

- `vultron/demo/scenario/two_actor_demo.py::_phase_sync_verification` — drop the two `demo_step` blocks that called `trigger_log_commit(event_type="demo_verification")` + `wait_for_finder_log_entry(...)`. Replaced with an explanatory comment block and an `INFO` log line.

Net diff: 1 file, +15 / −14.

## Verification

Touched a `vultron/demo/` file, so full suite (integration included) was run:

```
3442 passed, 34 skipped, 5 xfailed, 5633 subtests passed in 60.02s
```

Linters: black, flake8, mypy, pyright all clean.

## Notes

- The `test/demo/test_two_actor_demo.py` smoke test for `verify_finder_replica_state` still calls `trigger_log_commit(event_type="demo_verification")` directly. That use is exercising the helper itself, not the canonical demo flow, and predates ADR-0019; it will be naturally surfaced for cleanup when #930 (commit-boundary runtime guard) lands. Out of scope here.
- Three other findings from concern #923 remain open as sibling issues under epic #788: #926, #927, #930, #931, #932, #933.
