### PR TITLE
Audit sender-side trigger routing to CaseActor

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -132,3 +132,13 @@ uses a class-qualified logger name:
 `vultron.core.behaviors.sync.nodes.chain.PersistLogEntryNode` (not the
 bare module path). Always verify logger names from source before writing
 diagnostic docs or log-filter commands.
+
+### 2026-06-15 TRIGGER-927-CASEACTOR-ROUTING — report trigger fallback must fail fast on missing CaseActor
+
+Switching sender-side case-scoped report trigger routing from
+`case_addressees()` to CaseActor-only routing exposed hidden fixtures and
+legacy trigger paths that emitted `to=None`. Once case-scoped routing is
+CaseActor-only, emit nodes must fail fast before queueing when no routable
+CaseActor recipient exists; otherwise outbox enforcement raises
+`VultronOutboxToFieldMissingError` later and masks the true sender-side
+routing defect.

--- a/plan/history/2606/implementation/ISSUE-927.md
+++ b/plan/history/2606/implementation/ISSUE-927.md
@@ -1,0 +1,12 @@
+---
+source: ISSUE-927
+timestamp: '2026-06-15T17:22:12.234826+00:00'
+title: Sender-side trigger CaseActor routing audit
+type: implementation
+---
+
+## Issue #927 — Audit sender-side trigger use cases: all participant-originated case-scoped activities must route through CaseActor
+
+Implemented a sender-side routing audit/fix sweep so case-scoped participant-originated trigger activities route only to the CaseActor. Updated report trigger emit routing, suggest-actor trigger routing, trigger activity adapter/port contract, and trigger/router/service coverage to assert single-recipient CaseActor `to` fields across sender-side paths.
+
+PR: <https://github.com/CERTCC/Vultron/pull/958>

--- a/test/adapters/driving/fastapi/routers/test_trigger_actor.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_actor.py
@@ -32,12 +32,14 @@ from vultron.adapters.driving.fastapi.deps import (
     get_trigger_dl,
     get_trigger_service,
 )
+from vultron.core.states.roles import CVDRole
 from vultron.core.use_cases.triggers.service import TriggerService
 from vultron.adapters.driven.trigger_activity_adapter import (
     TriggerActivityAdapter,
 )
 from vultron.wire.as2.factories import rm_invite_to_case_activity
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
+from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
     VulnerabilityCase,
     VulnerabilityCaseStub,
@@ -109,9 +111,27 @@ def other_actor(dl):
 
 @pytest.fixture
 def case_obj(dl, actor):
-    """Create and persist a VulnerabilityCase for tests."""
+    """Create and persist a VulnerabilityCase with a CASE_MANAGER participant."""
+    case_actor = as_Service(name="Case Actor")
+    dl.create(case_actor)
     case = VulnerabilityCase(name="TEST-CASE-001")
+    owner_participant = CaseParticipant(
+        attributed_to=actor.id_,
+        context=case.id_,
+        case_roles=[CVDRole.CASE_OWNER],
+    )
+    case_manager_participant = CaseParticipant(
+        attributed_to=case_actor.id_,
+        context=case.id_,
+        case_roles=[CVDRole.CASE_MANAGER],
+    )
+    case.actor_participant_index[actor.id_] = owner_participant.id_
+    case.actor_participant_index[case_actor.id_] = case_manager_participant.id_
+    case.case_participants.append(owner_participant.id_)
+    case.case_participants.append(case_manager_participant.id_)
     dl.create(case)
+    dl.create(owner_participant)
+    dl.create(case_manager_participant)
     return case
 
 

--- a/test/adapters/driving/fastapi/routers/test_trigger_report.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_report.py
@@ -42,10 +42,13 @@ from vultron.adapters.driven.trigger_activity_adapter import (
 )
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
+from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
     VulnerabilityReport,
 )
 from vultron.core.states.rm import RM
+from vultron.core.states.roles import CVDRole
 
 # ---------------------------------------------------------------------------
 # Module-level outbox suppression
@@ -140,9 +143,16 @@ def report(dl, actor):
 
 
 @pytest.fixture
-def offer(dl, report, actor):
+def reporter(dl):
+    reporter_obj = as_Service(name="Finder Co")
+    dl.create(reporter_obj)
+    return reporter_obj
+
+
+@pytest.fixture
+def offer(dl, report, actor, reporter):
     offer_obj = as_Offer(
-        actor=actor.id_,
+        actor=reporter.id_,
         object_=report.id_,
         target=actor.id_,
     )
@@ -151,7 +161,7 @@ def offer(dl, report, actor):
 
 
 @pytest.fixture
-def received_report(dl, actor, report, offer):
+def received_report(dl, actor, reporter, report, offer):
     """Pre-create a VulnerabilityCase for the report at RM.RECEIVED.
 
     Per ADR-0015, the case is created at report receipt.  The validate_report
@@ -166,9 +176,24 @@ def received_report(dl, actor, report, offer):
     tree = create_receive_report_case_tree(
         report_id=report.id_,
         offer_id=offer.id_,
-        reporter_actor_id=actor.id_,
+        reporter_actor_id=reporter.id_,
     )
     bridge.execute_with_setup(tree, actor_id=actor.id_)
+    case_obj = dl.find_case_by_report_id(report.id_)
+    assert isinstance(case_obj, VulnerabilityCase)
+    case_actor = as_Service(name=f"Case Actor for {case_obj.name}")
+    dl.create(case_actor)
+    case_manager_participant = CaseParticipant(
+        attributed_to=case_actor.id_,
+        context=case_obj.id_,
+        case_roles=[CVDRole.CASE_MANAGER],
+    )
+    dl.create(case_manager_participant)
+    case_obj.actor_participant_index[case_actor.id_] = (
+        case_manager_participant.id_
+    )
+    case_obj.case_participants.append(case_manager_participant.id_)
+    dl.save(case_obj)
     return report
 
 

--- a/test/core/use_cases/received/test_report.py
+++ b/test/core/use_cases/received/test_report.py
@@ -15,6 +15,8 @@
 from typing import cast
 from unittest.mock import MagicMock
 
+import pytest
+
 from vultron.adapters.driven.trigger_activity_adapter import (
     TriggerActivityAdapter,
 )
@@ -52,6 +54,22 @@ from vultron.wire.as2.vocab.objects.vulnerability_report import (
     VulnerabilityReport,
 )
 from vultron.core.models.participant import VultronParticipant
+
+
+@pytest.fixture(autouse=True)
+def _close_sqlite_datalayers(monkeypatch):
+    """Close all SqliteDataLayer instances created during each test."""
+    created: list[SqliteDataLayer] = []
+    original_init = SqliteDataLayer.__init__
+
+    def _tracking_init(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+        created.append(self)
+
+    monkeypatch.setattr(SqliteDataLayer, "__init__", _tracking_init)
+    yield
+    while created:
+        created.pop().close()
 
 
 class TestUseCaseExecution:

--- a/test/core/use_cases/triggers/test_actor_triggers.py
+++ b/test/core/use_cases/triggers/test_actor_triggers.py
@@ -53,6 +53,7 @@ from vultron.adapters.driven.trigger_activity_adapter import (
 _BASE = "http://coordinator:7999/api/v2/actors"
 _UUID = "24d63c7d-6b1e-4f61-a5e1-180d27192d0b"
 _HTTP_ACTOR_ID = f"{_BASE}/{_UUID}"
+_CREATED_DLS: list[SqliteDataLayer] = []
 
 
 def _make_actor_dl(actor_name: str):
@@ -63,6 +64,7 @@ def _make_actor_dl(actor_name: str):
     dl = SqliteDataLayer("sqlite:///:memory:", actor_id=actor_id)
     dl.clear_all()
     dl.create(actor)
+    _CREATED_DLS.append(dl)
     return actor, dl
 
 
@@ -73,7 +75,16 @@ def _make_actor_dl_with_http_id(actor_name: str, actor_id: str):
     dl = SqliteDataLayer("sqlite:///:memory:", actor_id=actor_id)
     dl.clear_all()
     dl.create(actor)
+    _CREATED_DLS.append(dl)
     return actor, dl
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_created_dls():
+    """Close any helper-created DataLayers to avoid unraisable sqlite warnings."""
+    yield
+    while _CREATED_DLS:
+        _CREATED_DLS.pop().close()
 
 
 def _make_case_with_case_manager(

--- a/test/core/use_cases/triggers/test_actor_triggers.py
+++ b/test/core/use_cases/triggers/test_actor_triggers.py
@@ -26,6 +26,7 @@ from vultron.adapters.driven.datalayer_sqlite import (
     SqliteDataLayer,
     reset_datalayer,
 )
+from vultron.core.states.roles import CVDRole
 from vultron.core.use_cases.triggers.actor import (
     SvcAcceptCaseInviteUseCase,
     SvcInviteActorToCaseUseCase,
@@ -36,10 +37,11 @@ from vultron.core.use_cases.triggers.requests import (
     InviteActorToCaseTriggerRequest,
     SuggestActorToCaseTriggerRequest,
 )
-from vultron.errors import VultronNotFoundError
+from vultron.errors import VultronNotFoundError, VultronValidationError
 from vultron.wire.as2.factories import rm_invite_to_case_activity
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Invite
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
+from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
     VulnerabilityCase,
     VulnerabilityCaseStub,
@@ -72,6 +74,32 @@ def _make_actor_dl_with_http_id(actor_name: str, actor_id: str):
     dl.clear_all()
     dl.create(actor)
     return actor, dl
+
+
+def _make_case_with_case_manager(
+    dl: SqliteDataLayer, owner_actor_id: str, case_actor_id: str
+) -> VulnerabilityCase:
+    case = VulnerabilityCase(
+        attributed_to=owner_actor_id, name="Test Case", content="Content"
+    )
+    owner_participant = CaseParticipant(
+        attributed_to=owner_actor_id,
+        context=case.id_,
+        case_roles=[CVDRole.CASE_OWNER],
+    )
+    case_manager_participant = CaseParticipant(
+        attributed_to=case_actor_id,
+        context=case.id_,
+        case_roles=[CVDRole.CASE_MANAGER],
+    )
+    case.actor_participant_index[owner_actor_id] = owner_participant.id_
+    case.actor_participant_index[case_actor_id] = case_manager_participant.id_
+    case.case_participants.append(owner_participant.id_)
+    case.case_participants.append(case_manager_participant.id_)
+    dl.create(case)
+    dl.create(owner_participant)
+    dl.create(case_manager_participant)
+    return case
 
 
 class TestSvcInviteActorToCaseUseCase:
@@ -235,12 +263,11 @@ class TestSvcSuggestActorToCaseUseCase:
 
     def test_suggest_creates_activity(self):
         actor, dl = _make_actor_dl("Coordinator")
+        case_actor, _ = _make_actor_dl("Case Actor")
         suggested, _ = _make_actor_dl("Vendor")
+        dl.create(case_actor)
         dl.create(suggested)
-        case = VulnerabilityCase(
-            attributed_to=actor.id_, name="Test Case", content="Content"
-        )
-        dl.create(case)
+        case = _make_case_with_case_manager(dl, actor.id_, case_actor.id_)
 
         request = SuggestActorToCaseTriggerRequest(
             actor_id=actor.id_,
@@ -253,13 +280,13 @@ class TestSvcSuggestActorToCaseUseCase:
 
         assert "activity" in result
         assert result["activity"]["actor"] == actor.id_
+        assert result["activity"].get("to") == [case_actor.id_]
 
     def test_suggest_raises_when_suggested_actor_missing(self):
         actor, dl = _make_actor_dl("Coordinator")
-        case = VulnerabilityCase(
-            attributed_to=actor.id_, name="Test Case", content="Content"
-        )
-        dl.create(case)
+        case_actor, _ = _make_actor_dl("Case Actor")
+        dl.create(case_actor)
+        case = _make_case_with_case_manager(dl, actor.id_, case_actor.id_)
 
         request = SuggestActorToCaseTriggerRequest(
             actor_id=actor.id_,
@@ -274,12 +301,13 @@ class TestSvcSuggestActorToCaseUseCase:
     def test_suggest_normalises_short_uuid_actor_id(self):
         """DR-09: short UUID in actor_id is resolved to full URI."""
         actor, dl = _make_actor_dl_with_http_id("Coordinator", _HTTP_ACTOR_ID)
+        case_actor, _ = _make_actor_dl("Case Actor")
         suggested, _ = _make_actor_dl("Vendor")
+        dl.create(case_actor)
         dl.create(suggested)
-        case = VulnerabilityCase(
-            attributed_to=_HTTP_ACTOR_ID, name="Test Case", content="Content"
+        case = _make_case_with_case_manager(
+            dl, owner_actor_id=_HTTP_ACTOR_ID, case_actor_id=case_actor.id_
         )
-        dl.create(case)
 
         request = SuggestActorToCaseTriggerRequest(
             actor_id=_UUID,
@@ -291,6 +319,25 @@ class TestSvcSuggestActorToCaseUseCase:
         ).execute()
 
         assert result["activity"]["actor"] == _HTTP_ACTOR_ID
+        assert result["activity"].get("to") == [case_actor.id_]
+
+    def test_suggest_raises_when_no_case_manager(self):
+        actor, dl = _make_actor_dl("Coordinator")
+        suggested, _ = _make_actor_dl("Vendor")
+        dl.create(suggested)
+        case = VulnerabilityCase(
+            attributed_to=actor.id_, name="Test Case", content="Content"
+        )
+        dl.create(case)
+        request = SuggestActorToCaseTriggerRequest(
+            actor_id=actor.id_,
+            case_id=case.id_,
+            suggested_actor_id=suggested.id_,
+        )
+        with pytest.raises(VultronValidationError):
+            SvcSuggestActorToCaseUseCase(
+                dl, request, trigger_activity=TriggerActivityAdapter(dl)
+            ).execute()
 
 
 class TestSvcAcceptCaseInviteUseCase:
@@ -328,6 +375,7 @@ class TestSvcAcceptCaseInviteUseCase:
         assert "activity" in result
         assert result["activity"]["actor"] == invitee.id_
         assert result["activity"]["inReplyTo"] == invite.id_
+        assert result["activity"].get("to") == [inviter.id_]
 
     def test_accept_raises_when_invite_missing(self):
         _, dl = _make_actor_dl("Finder")

--- a/test/core/use_cases/triggers/test_service.py
+++ b/test/core/use_cases/triggers/test_service.py
@@ -111,6 +111,13 @@ def actor(dl):
 
 
 @pytest.fixture
+def reporter(dl):
+    reporter_obj = as_Service(name="Finder Co")
+    dl.create(reporter_obj)
+    return reporter_obj
+
+
+@pytest.fixture
 def report(dl):
     report_obj = VulnerabilityReport(
         name="Test Vulnerability",
@@ -121,9 +128,9 @@ def report(dl):
 
 
 @pytest.fixture
-def offer(dl, report, actor):
+def offer(dl, report, actor, reporter):
     offer_obj = as_Offer(
-        actor=actor.id_,
+        actor=reporter.id_,
         object_=report.id_,
         target=actor.id_,
     )
@@ -132,7 +139,7 @@ def offer(dl, report, actor):
 
 
 @pytest.fixture
-def received_report(dl, actor, report, offer):
+def received_report(dl, actor, reporter, report, offer):
     """Pre-create a VulnerabilityCase for the report at RM.RECEIVED.
 
     Per ADR-0015, the case is created at report receipt.  The validate_report
@@ -147,9 +154,12 @@ def received_report(dl, actor, report, offer):
     tree = create_receive_report_case_tree(
         report_id=report.id_,
         offer_id=offer.id_,
-        reporter_actor_id=actor.id_,
+        reporter_actor_id=reporter.id_,
     )
     bridge.execute_with_setup(tree, actor_id=actor.id_)
+    case_obj = dl.find_case_by_report_id(report.id_)
+    assert case_obj is not None
+    _add_case_manager(case_obj, dl)
     return report
 
 

--- a/test/core/use_cases/triggers/test_trignotify.py
+++ b/test/core/use_cases/triggers/test_trignotify.py
@@ -30,12 +30,15 @@ from vultron.core.states.em import EM
 from vultron.core.states.roles import CVDRole
 from vultron.errors import VultronValidationError
 from vultron.core.use_cases.triggers.case import (
+    SvcAddParticipantStatusUseCase,
     SvcDeferCaseUseCase,
     SvcEngageCaseUseCase,
 )
 from vultron.core.use_cases.triggers.embargo import (
     SvcAcceptEmbargoUseCase,
     SvcProposeEmbargoUseCase,
+    SvcProposeEmbargoRevisionUseCase,
+    SvcRejectEmbargoUseCase,
     SvcTerminateEmbargoUseCase,
 )
 from vultron.core.use_cases.triggers.report import (
@@ -46,8 +49,11 @@ from vultron.core.use_cases.triggers.report import (
 from vultron.core.use_cases.triggers.requests import (
     DeferCaseTriggerRequest,
     EngageCaseTriggerRequest,
+    AddParticipantStatusTriggerRequest,
     AcceptEmbargoTriggerRequest,
     ProposeEmbargoTriggerRequest,
+    ProposeEmbargoRevisionTriggerRequest,
+    RejectEmbargoTriggerRequest,
     TerminateEmbargoTriggerRequest,
     CloseReportTriggerRequest,
     InvalidateReportTriggerRequest,
@@ -269,6 +275,27 @@ class TestCaseTriggerToField:
         assert self.finder.id_ not in recipients
         assert self.vendor.id_ not in recipients
 
+    def test_add_participant_status_to_field_addresses_case_actor_only(self):
+        """SvcAddParticipantStatusUseCase queues activity to only Case Actor."""
+        request = AddParticipantStatusTriggerRequest(
+            actor_id=self.vendor.id_,
+            case_id=self.case.id_,
+        )
+        result = SvcAddParticipantStatusUseCase(
+            self.dl, request, trigger_activity=TriggerActivityAdapter(self.dl)
+        ).execute()
+
+        act_obj = self.dl.read(result["activity_id"])
+        recipients = _to_field(act_obj)
+
+        assert recipients is not None
+        assert (
+            len(recipients) == 1
+        ), f"Expected exactly 1 recipient, got {len(recipients)}: {recipients}"
+        assert recipients[0] == self.case_actor.id_
+        assert self.finder.id_ not in recipients
+        assert self.vendor.id_ not in recipients
+
     def test_engage_case_raises_when_no_case_manager(self):
         """SvcEngageCaseUseCase raises VultronValidationError when no CASE_MANAGER."""
         case_solo = VulnerabilityCase(name="Solo Case")
@@ -395,6 +422,65 @@ class TestEmbargoTriggerToField:
         assert self.finder.id_ not in recipients
         assert self.vendor.id_ not in recipients
 
+    def test_reject_embargo_to_field_addresses_case_actor_only(self):
+        """SvcRejectEmbargoUseCase queues activity addressed only to Case Actor."""
+        embargo = EmbargoEvent(context=self.case.id_)
+        self.dl.create(embargo)
+        proposal = em_propose_embargo_activity(
+            embargo, context=self.case.id_, actor=self.finder.id_
+        )
+        self.dl.create(proposal)
+        self.case.current_status.em_state = EM.PROPOSED
+        self.case.proposed_embargoes.append(embargo.id_)
+        self.dl.save(self.case)
+
+        request = RejectEmbargoTriggerRequest(
+            actor_id=self.vendor.id_,
+            case_id=self.case.id_,
+            proposal_id=proposal.id_,
+        )
+        result = SvcRejectEmbargoUseCase(
+            self.dl, request, trigger_activity=TriggerActivityAdapter(self.dl)
+        ).execute()
+        _, act_obj = _new_outbox_activity(self.vendor, self.dl, result)
+        recipients = _to_field(act_obj)
+
+        assert recipients is not None
+        assert (
+            len(recipients) == 1
+        ), f"Expected exactly 1 recipient, got {len(recipients)}: {recipients}"
+        assert recipients[0] == self.case_actor.id_
+        assert self.finder.id_ not in recipients
+        assert self.vendor.id_ not in recipients
+
+    def test_propose_embargo_revision_to_field_addresses_case_actor_only(self):
+        """SvcProposeEmbargoRevisionUseCase queues activity to only Case Actor."""
+        embargo = EmbargoEvent(context=self.case.id_)
+        self.dl.create(embargo)
+        self.case.set_embargo(embargo.id_)
+        self.case.current_status.em_state = EM.ACTIVE
+        self.dl.save(self.case)
+
+        request = ProposeEmbargoRevisionTriggerRequest(
+            actor_id=self.vendor.id_,
+            case_id=self.case.id_,
+            end_time=FUTURE_END_DATETIME,
+        )
+        result = SvcProposeEmbargoRevisionUseCase(
+            self.dl, request, trigger_activity=TriggerActivityAdapter(self.dl)
+        ).execute()
+
+        _, act_obj = _new_outbox_activity(self.vendor, self.dl, result)
+        recipients = _to_field(act_obj)
+
+        assert recipients is not None
+        assert (
+            len(recipients) == 1
+        ), f"Expected exactly 1 recipient, got {len(recipients)}: {recipients}"
+        assert recipients[0] == self.case_actor.id_
+        assert self.finder.id_ not in recipients
+        assert self.vendor.id_ not in recipients
+
 
 # ---------------------------------------------------------------------------
 # Report trigger use cases
@@ -403,13 +489,14 @@ class TestEmbargoTriggerToField:
 
 class TestReportTriggerToField:
     """SvcCloseReportUseCase, SvcInvalidateReportUseCase, and
-    SvcRejectReportUseCase populate ``to`` with either case participants
+    SvcRejectReportUseCase populate ``to`` with either the Case Actor
     (when a linked case exists) or the offer submitter."""
 
     @pytest.fixture(autouse=True)
     def setup(self):
         self.vendor, self.dl = _make_actor_dl("Vendor Co")
         self.finder, _ = _make_actor_dl("Finder Co")
+        self.case_actor, _ = _make_actor_dl("Case Actor")
 
         self.report = VulnerabilityReport(
             name="CVE-TEST",
@@ -428,6 +515,7 @@ class TestReportTriggerToField:
         self.dl.clear_all()
         reset_datalayer(self.vendor.id_)
         reset_datalayer(self.finder.id_)
+        reset_datalayer(self.case_actor.id_)
 
     def test_close_report_to_field_falls_back_to_offer_actor(self):
         """SvcCloseReportUseCase uses offer actor as to when no case exists."""
@@ -480,11 +568,16 @@ class TestReportTriggerToField:
         assert self.finder.id_ in recipients
         assert self.vendor.id_ not in recipients
 
-    def test_close_report_to_field_uses_case_participants_when_case_exists(
+    def test_close_report_to_field_uses_case_actor_when_case_exists(
         self,
     ):
-        """SvcCloseReportUseCase uses case participants when linked case exists."""
-        case = _make_two_actor_case(self.dl, self.vendor.id_, self.finder.id_)
+        """SvcCloseReportUseCase routes case-scoped close to the Case Actor."""
+        case = _make_case_with_case_manager(
+            self.dl,
+            self.vendor.id_,
+            self.finder.id_,
+            self.case_actor.id_,
+        )
         case.vulnerability_reports.append(self.report.id_)
         self.dl.save(case)
 
@@ -500,5 +593,78 @@ class TestReportTriggerToField:
         recipients = _to_field(act_obj)
 
         assert recipients is not None
-        assert self.finder.id_ in recipients
+        assert len(recipients) == 1
+        assert recipients[0] == self.case_actor.id_
+        assert self.finder.id_ not in recipients
         assert self.vendor.id_ not in recipients
+
+    def test_invalidate_report_to_field_uses_case_actor_when_case_exists(self):
+        """SvcInvalidateReportUseCase routes case-scoped invalidation to Case Actor."""
+        case = _make_case_with_case_manager(
+            self.dl,
+            self.vendor.id_,
+            self.finder.id_,
+            self.case_actor.id_,
+        )
+        case.vulnerability_reports.append(self.report.id_)
+        self.dl.save(case)
+
+        request = InvalidateReportTriggerRequest(
+            actor_id=self.vendor.id_,
+            offer_id=self.offer.id_,
+        )
+        result = SvcInvalidateReportUseCase(
+            self.dl, request, trigger_activity=TriggerActivityAdapter(self.dl)
+        ).execute()
+        _, act_obj = _new_outbox_activity(self.vendor, self.dl, result)
+        recipients = _to_field(act_obj)
+
+        assert recipients is not None
+        assert len(recipients) == 1
+        assert recipients[0] == self.case_actor.id_
+        assert self.finder.id_ not in recipients
+        assert self.vendor.id_ not in recipients
+
+    def test_reject_report_to_field_uses_case_actor_when_case_exists(self):
+        """SvcRejectReportUseCase routes case-scoped reject to the Case Actor."""
+        case = _make_case_with_case_manager(
+            self.dl,
+            self.vendor.id_,
+            self.finder.id_,
+            self.case_actor.id_,
+        )
+        case.vulnerability_reports.append(self.report.id_)
+        self.dl.save(case)
+
+        request = RejectReportTriggerRequest(
+            actor_id=self.vendor.id_,
+            offer_id=self.offer.id_,
+        )
+        result = SvcRejectReportUseCase(
+            self.dl, request, trigger_activity=TriggerActivityAdapter(self.dl)
+        ).execute()
+        _, act_obj = _new_outbox_activity(self.vendor, self.dl, result)
+        recipients = _to_field(act_obj)
+
+        assert recipients is not None
+        assert len(recipients) == 1
+        assert recipients[0] == self.case_actor.id_
+        assert self.finder.id_ not in recipients
+        assert self.vendor.id_ not in recipients
+
+    def test_close_report_raises_when_case_exists_without_case_manager(self):
+        """Case-scoped close fails fast when no CASE_MANAGER is resolvable."""
+        case = _make_two_actor_case(self.dl, self.vendor.id_, self.finder.id_)
+        case.vulnerability_reports.append(self.report.id_)
+        self.dl.save(case)
+
+        request = CloseReportTriggerRequest(
+            actor_id=self.vendor.id_,
+            offer_id=self.offer.id_,
+        )
+        with pytest.raises(VultronValidationError):
+            SvcCloseReportUseCase(
+                self.dl,
+                request,
+                trigger_activity=TriggerActivityAdapter(self.dl),
+            ).execute()

--- a/test/core/use_cases/triggers/test_trignotify.py
+++ b/test/core/use_cases/triggers/test_trignotify.py
@@ -217,8 +217,10 @@ class TestCaseTriggerToField:
     @pytest.fixture(autouse=True)
     def setup(self):
         self.vendor, self.dl = _make_actor_dl("Vendor Co")
-        self.finder, _ = _make_actor_dl("Finder Co")
-        self.case_actor, _ = _make_actor_dl("Case Actor")
+        self.finder = as_Service(name="Finder Co")
+        self.case_actor = as_Service(name="Case Actor")
+        self.dl.create(self.finder)
+        self.dl.create(self.case_actor)
         self.case = _make_case_with_case_manager(
             self.dl,
             self.vendor.id_,
@@ -227,9 +229,8 @@ class TestCaseTriggerToField:
         )
         yield
         self.dl.clear_all()
+        self.dl.close()
         reset_datalayer(self.vendor.id_)
-        reset_datalayer(self.finder.id_)
-        reset_datalayer(self.case_actor.id_)
 
     def test_engage_case_to_field_addresses_case_actor_only(self):
         """SvcEngageCaseUseCase queues activity addressed only to Case Actor
@@ -327,8 +328,10 @@ class TestEmbargoTriggerToField:
     @pytest.fixture(autouse=True)
     def setup(self):
         self.vendor, self.dl = _make_actor_dl("Vendor Co")
-        self.finder, _ = _make_actor_dl("Finder Co")
-        self.case_actor, _ = _make_actor_dl("Case Actor")
+        self.finder = as_Service(name="Finder Co")
+        self.case_actor = as_Service(name="Case Actor")
+        self.dl.create(self.finder)
+        self.dl.create(self.case_actor)
         self.case = _make_case_with_case_manager(
             self.dl,
             self.vendor.id_,
@@ -337,9 +340,8 @@ class TestEmbargoTriggerToField:
         )
         yield
         self.dl.clear_all()
+        self.dl.close()
         reset_datalayer(self.vendor.id_)
-        reset_datalayer(self.finder.id_)
-        reset_datalayer(self.case_actor.id_)
 
     def test_propose_embargo_to_field_addresses_case_actor_only(self):
         """SvcProposeEmbargoUseCase queues activity addressed only to Case Actor."""
@@ -495,8 +497,10 @@ class TestReportTriggerToField:
     @pytest.fixture(autouse=True)
     def setup(self):
         self.vendor, self.dl = _make_actor_dl("Vendor Co")
-        self.finder, _ = _make_actor_dl("Finder Co")
-        self.case_actor, _ = _make_actor_dl("Case Actor")
+        self.finder = as_Service(name="Finder Co")
+        self.case_actor = as_Service(name="Case Actor")
+        self.dl.create(self.finder)
+        self.dl.create(self.case_actor)
 
         self.report = VulnerabilityReport(
             name="CVE-TEST",
@@ -513,9 +517,8 @@ class TestReportTriggerToField:
         self.dl.create(self.offer)
         yield
         self.dl.clear_all()
+        self.dl.close()
         reset_datalayer(self.vendor.id_)
-        reset_datalayer(self.finder.id_)
-        reset_datalayer(self.case_actor.id_)
 
     def test_close_report_to_field_falls_back_to_offer_actor(self):
         """SvcCloseReportUseCase uses offer actor as to when no case exists."""

--- a/vultron/adapters/driven/datalayer_sqlite/queries.py
+++ b/vultron/adapters/driven/datalayer_sqlite/queries.py
@@ -315,17 +315,16 @@ def find_case_by_report_id(
             if is_case_model(linked_case):
                 return linked_case
 
-    for row in (
-        Session(dl._engine)
-        .exec(
+    with Session(dl._engine) as session:
+        rows = session.exec(
             dl._scoped(
                 select(VultronObjectRecord).where(
                     VultronObjectRecord.type_.in_(list(_CASE_TYPES))  # type: ignore[attr-defined]
                 )
             )
-        )
-        .all()
-    ):
+        ).all()
+
+    for row in rows:
         reports = row.data.get("vulnerability_reports", [])
         for entry in reports:
             if entry == report_id:

--- a/vultron/adapters/driven/trigger_activity_adapter.py
+++ b/vultron/adapters/driven/trigger_activity_adapter.py
@@ -381,10 +381,11 @@ class TriggerActivityAdapter:
         recommended_id: str,
         case_id: str,
         actor: str,
+        to: list[str] | None = None,
         id_: str | None = None,
     ) -> tuple[str, dict[str, Any]]:
         """Create and persist a ``Offer(Actor, Case)`` recommendation activity."""
-        extra: dict[str, Any] = {"actor": actor}
+        extra: dict[str, Any] = {"actor": actor, "to": to}
         if id_ is not None:
             extra["id_"] = id_
         # The factory accepts a string for target (case ID).

--- a/vultron/core/behaviors/report/nodes/emit.py
+++ b/vultron/core/behaviors/report/nodes/emit.py
@@ -22,7 +22,7 @@ from py_trees.common import Status
 from vultron.core.behaviors.helpers import DataLayerAction
 from vultron.core.models.protocols import is_case_model
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
-from vultron.core.use_cases._helpers import case_addressees
+from vultron.core.use_cases._helpers import _resolve_case_manager_id
 
 
 def _compute_report_addressees(
@@ -33,8 +33,8 @@ def _compute_report_addressees(
 ) -> list[str] | None:
     """Compute outbound recipient list for a report-phase trigger activity.
 
-    Tries case participants first; falls back to the offer submitter when no
-    case is found.
+    For case-scoped report activities, route only to the Case Actor. Falls back
+    to the offer submitter when no case is found (no case-scoped routing).
 
     Args:
         report_id: VulnerabilityReport ID used to locate the linked case.
@@ -47,9 +47,10 @@ def _compute_report_addressees(
     """
     case = dl.find_case_by_report_id(report_id)
     if is_case_model(case):
-        recipients = case_addressees(case, actor_id)
-        if recipients:
-            return recipients
+        case_manager_id = _resolve_case_manager_id(case, dl)
+        if case_manager_id and case_manager_id != actor_id:
+            return [case_manager_id]
+        return None
 
     offer_actor = getattr(offer, "actor", None)
     if offer_actor is None:
@@ -115,6 +116,16 @@ class EmitInvalidateReportActivity(DataLayerAction):
                 offer,
                 cast(CaseOutboxPersistence, self.datalayer),
             )
+            if not addressees:
+                self.logger.error(
+                    "%s: no routable recipients for report activity"
+                    " (offer_id=%s, report_id=%s, actor_id=%s)",
+                    self.name,
+                    self.offer_id,
+                    self.report_id,
+                    self.actor_id,
+                )
+                return Status.FAILURE
 
             activity_id, _ = self.trigger_activity_factory.invalidate_report(
                 offer_id=self.offer_id,
@@ -194,6 +205,16 @@ class EmitCloseReportActivity(DataLayerAction):
                 offer,
                 cast(CaseOutboxPersistence, self.datalayer),
             )
+            if not addressees:
+                self.logger.error(
+                    "%s: no routable recipients for report activity"
+                    " (offer_id=%s, report_id=%s, actor_id=%s)",
+                    self.name,
+                    self.offer_id,
+                    self.report_id,
+                    self.actor_id,
+                )
+                return Status.FAILURE
 
             activity_id, _ = self.trigger_activity_factory.close_report(
                 offer_id=self.offer_id,

--- a/vultron/core/ports/trigger_activity.py
+++ b/vultron/core/ports/trigger_activity.py
@@ -226,6 +226,7 @@ class TriggerActivityPort(Protocol):
         recommended_id: str,
         case_id: str,
         actor: str,
+        to: list[str] | None = None,
         id_: str | None = None,
     ) -> tuple[str, dict[str, Any]]:
         """Create and persist a ``Offer(Actor, Case)`` recommendation activity.

--- a/vultron/core/use_cases/triggers/actor.py
+++ b/vultron/core/use_cases/triggers/actor.py
@@ -23,7 +23,10 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
-from vultron.core.use_cases._helpers import _find_case_actor_id
+from vultron.core.use_cases._helpers import (
+    _find_case_actor_id,
+    _resolve_case_manager_id,
+)
 from vultron.core.use_cases.triggers._helpers import (
     add_activity_to_outbox,
     resolve_actor,
@@ -45,8 +48,8 @@ logger = logging.getLogger(__name__)
 class SvcSuggestActorToCaseUseCase:
     """Recommend another actor for participation in an existing case.
 
-    Emits a RecommendActorActivity addressed to the case owner (typically
-    the CaseActor), which then autonomously invites the suggested actor.
+    Emits a RecommendActorActivity addressed only to the CaseActor, which then
+    autonomously invites the suggested actor.
     The originating actor is the ``actor`` field; ``object_`` is the actor
     being suggested; ``target`` is the case.
     """
@@ -78,11 +81,19 @@ class SvcSuggestActorToCaseUseCase:
                 "SvcSuggestActorToCaseUseCase requires a TriggerActivityPort"
             )
 
+        case_manager_id = _resolve_case_manager_id(case, self._dl)
+        if not case_manager_id:
+            raise VultronValidationError(
+                "SvcSuggestActorToCaseUseCase requires a CASE_MANAGER"
+                " participant with a routable actor ID."
+            )
+
         activity_id, activity_dict = (
             self._trigger_activity.suggest_actor_to_case(
                 recommended_id=self._request.suggested_actor_id,
                 case_id=case.id_,
                 actor=actor_id,
+                to=[case_manager_id],
             )
         )
 

--- a/vultron/core/use_cases/triggers/requests.py
+++ b/vultron/core/use_cases/triggers/requests.py
@@ -175,8 +175,8 @@ class AddReportToCaseTriggerRequest(CaseTriggerRequest):
 class SuggestActorToCaseTriggerRequest(CaseTriggerRequest):
     """Trigger request for an actor to recommend another actor to a case.
 
-    Emits a RecommendActorActivity addressed to the case owner (typically
-    the CaseActor), which then autonomously invites the suggested actor.
+    Emits a RecommendActorActivity addressed to the Case Actor, which then
+    autonomously invites the suggested actor.
     """
 
     suggested_actor_id: NonEmptyString
@@ -186,7 +186,7 @@ class AcceptCaseInviteTriggerRequest(TriggerRequest):
     """Trigger request for an invitee to accept a case invitation.
 
     Emits an RmAcceptInviteToCaseActivity queued in the actor's outbox for
-    delivery to the case owner.
+    delivery to the Case Actor that issued the invitation.
     """
 
     invite_id: NonEmptyString


### PR DESCRIPTION
- Closes #927

## Summary

Sender-side case-scoped trigger flows now route outbound activities only to the CaseActor, including report trigger BT emit paths and actor recommendation triggers. The trigger test sweep was expanded so sender-side use cases assert a single CaseActor recipient in to.

## Changes

- vultron/core/behaviors/report/nodes/emit.py: replaced sender-side case participant fan-out with CaseActor-only recipient resolution and fail-fast handling when no routable CaseActor recipient exists.
- vultron/core/use_cases/triggers/actor.py: updated SvcSuggestActorToCaseUseCase to resolve CaseActor and address only that actor.
- vultron/core/ports/trigger_activity.py, vultron/adapters/driven/trigger_activity_adapter.py, vultron/core/use_cases/triggers/requests.py: added to support for suggest-actor activity construction and aligned trigger request docs with CaseActor routing semantics.
- test/core/use_cases/triggers/test_trignotify.py, test/core/use_cases/triggers/test_actor_triggers.py, test/core/use_cases/triggers/test_service.py, test/adapters/driving/fastapi/routers/test_trigger_actor.py, test/adapters/driving/fastapi/routers/test_trigger_report.py: expanded and updated assertions and fixtures so sender-side trigger paths validate CaseActor-only routing and case-manager prerequisites.

## Verification

- uv run black vultron/ test/ && uv run flake8 vultron/ test/ && uv run mypy && uv run pyright
- uv run pytest --tb=short 2>&1 | tail -5