### PR TITLE
CaseActor commit-path uniqueness

### DIFF
--- a/plan/history/2606/implementation/ISSUE-926.md
+++ b/plan/history/2606/implementation/ISSUE-926.md
@@ -1,0 +1,12 @@
+---
+source: ISSUE-926
+timestamp: '2026-06-15T18:03:15.717816+00:00'
+title: CaseActor commit-path uniqueness
+type: implementation
+---
+
+## Issue #926 — CaseActor commit-path uniqueness
+
+Implemented an idempotent CaseActor commit path so a logical assertion only produces one canonical CaseLedgerEntry, while preserved payload snapshots and fan-out payloads stay identical across recipients.
+
+PR: [#962](https://github.com/CERTCC/Vultron/pull/962)

--- a/test/core/behaviors/sync/test_commit_tree.py
+++ b/test/core/behaviors/sync/test_commit_tree.py
@@ -123,3 +123,38 @@ def test_commit_tree_uses_existing_tail_hash(bridge, datalayer, case_obj):
     assert len(entries) == 2
     assert entries[1].log_index == 1
     assert entries[1].prev_log_hash == first_entry.entry_hash
+
+
+def test_commit_tree_reuses_equivalent_entry(bridge, datalayer, case_obj):
+    sync_port = MagicMock(spec=SyncActivityPort)
+    tree = create_commit_log_entry_tree(
+        case_id=CASE_ID,
+        object_id="https://example.org/activities/act-3",
+        event_type="case_updated",
+        payload_snapshot={"k": "v"},
+    )
+
+    first = bridge.execute_with_setup(
+        tree=tree,
+        actor_id=OWNER_ACTOR_ID,
+        sync_port=sync_port,
+    )
+    second = bridge.execute_with_setup(
+        tree=create_commit_log_entry_tree(
+            case_id=CASE_ID,
+            object_id="https://example.org/activities/act-3",
+            event_type="case_updated",
+            payload_snapshot={"k": "v"},
+        ),
+        actor_id=OWNER_ACTOR_ID,
+        sync_port=sync_port,
+    )
+
+    assert first.status == Status.SUCCESS
+    assert second.status == Status.SUCCESS
+    entries = [
+        entry
+        for entry in datalayer.list_objects("CaseLedgerEntry")
+        if entry.case_id == CASE_ID
+    ]
+    assert len(entries) == 1

--- a/test/core/use_cases/received/test_status.py
+++ b/test/core/use_cases/received/test_status.py
@@ -12,6 +12,7 @@
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 """Tests for status-related use-case classes."""
 
+import json
 from typing import cast
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
@@ -452,3 +453,172 @@ class TestParticipantStatusLogEntryCascade:
         updated_participant = dl.read(participant.id_)
         assert updated_participant is not None
         assert len(updated_participant.participant_statuses) == before_count
+
+    def test_duplicate_assertion_reuses_existing_log_entry(
+        self, make_payload
+    ) -> None:
+        """Two equivalent assertions append only one canonical log entry."""
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+
+        actor_id = "https://example.org/users/vendor"
+        case_id = "https://example.org/cases/st_le4"
+        dl, case_actor_id, participant, pstatus = self._make_dl(
+            case_id, actor_id
+        )
+        case = cast(VulnerabilityCase, dl.read(case_id))
+        assert case is not None
+
+        activity = add_status_to_participant_activity(
+            pstatus,
+            target=participant,
+            actor=actor_id,
+            context=case,
+        )
+        event = make_payload(activity, receiving_actor_id=case_actor_id)
+        sync_port = SyncActivityAdapter(dl)
+        uc = AddParticipantStatusToParticipantReceivedUseCase(
+            dl, event, sync_port=sync_port
+        )
+
+        uc.execute()
+        uc.execute()
+
+        entries = [
+            obj
+            for obj in dl.list_objects("CaseLedgerEntry")
+            if is_log_entry_model(obj)
+            and cast(VultronCaseLedgerEntry, obj).case_id == case_id
+        ]
+        assert len(entries) == 1
+
+    def test_non_case_actor_receiver_does_not_commit_log_entry(
+        self, make_payload
+    ) -> None:
+        """Peer-side replay of broadcast status must not append canonical entries."""
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+
+        actor_id = "https://example.org/users/vendor"
+        non_case_actor_id = "https://example.org/users/finder"
+        case_id = "https://example.org/cases/st_le5"
+        dl, case_actor_id, participant, pstatus = self._make_dl(
+            case_id, actor_id
+        )
+        case = cast(VulnerabilityCase, dl.read(case_id))
+        assert case is not None
+
+        peer = CaseParticipant(
+            id_=f"{case_id}/participants/p2",
+            context=case_id,
+            attributed_to=non_case_actor_id,
+        )
+        dl.create(peer)
+        case.case_participants.append(peer.id_)
+        case.actor_participant_index[non_case_actor_id] = peer.id_
+        dl.save(case)
+
+        activity = add_status_to_participant_activity(
+            pstatus,
+            target=participant,
+            actor=case_actor_id,
+            context=case,
+        )
+        event = make_payload(activity, receiving_actor_id=non_case_actor_id)
+        AddParticipantStatusToParticipantReceivedUseCase(
+            dl, event, sync_port=SyncActivityAdapter(dl)
+        ).execute()
+
+        entries = [
+            obj
+            for obj in dl.list_objects("CaseLedgerEntry")
+            if is_log_entry_model(obj)
+            and cast(VultronCaseLedgerEntry, obj).case_id == case_id
+        ]
+        assert entries == []
+
+    def test_commit_path_preserves_snapshot_actor_and_fanout_payload_identity(
+        self, make_payload
+    ) -> None:
+        """Stored snapshot keeps asserter actor and announce payload is identical."""
+        from vultron.wire.as2.enums import as_TransitiveActivityType
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+
+        reporter_actor_id = "https://example.org/users/vendor"
+        finder_actor_id = "https://example.org/users/finder"
+        case_id = "https://example.org/cases/st_le6"
+        dl, case_actor_id, participant, pstatus = self._make_dl(
+            case_id, reporter_actor_id
+        )
+        case = cast(VulnerabilityCase, dl.read(case_id))
+        assert case is not None
+
+        finder_participant = CaseParticipant(
+            id_=f"{case_id}/participants/finder",
+            context=case_id,
+            attributed_to=finder_actor_id,
+        )
+        dl.create(finder_participant)
+        case.case_participants.append(finder_participant.id_)
+        case.actor_participant_index[finder_actor_id] = finder_participant.id_
+        dl.save(case)
+
+        activity = add_status_to_participant_activity(
+            pstatus,
+            target=participant,
+            actor=reporter_actor_id,
+            context=case,
+        )
+        event = make_payload(activity, receiving_actor_id=case_actor_id)
+        AddParticipantStatusToParticipantReceivedUseCase(
+            dl, event, sync_port=SyncActivityAdapter(dl)
+        ).execute()
+
+        entries = [
+            cast(VultronCaseLedgerEntry, obj)
+            for obj in dl.list_objects("CaseLedgerEntry")
+            if is_log_entry_model(obj)
+            and cast(VultronCaseLedgerEntry, obj).case_id == case_id
+        ]
+        assert len(entries) == 1
+        assert entries[0].payload_snapshot.get("actor") == reporter_actor_id
+
+        announce_ids = []
+        announce_payloads = []
+        announce_actors = []
+        for activity_id in dl.outbox_list_for_actor(case_actor_id):
+            queued = dl.read(activity_id)
+            if (
+                queued is None
+                or getattr(queued, "type_", None)
+                != as_TransitiveActivityType.ANNOUNCE
+            ):
+                continue
+            queued_object = getattr(queued, "object_", None)
+            if (
+                queued_object is None
+                or getattr(queued_object, "type_", None) != "CaseLedgerEntry"
+            ):
+                continue
+            announce_ids.append(activity_id)
+            announce_actors.append(getattr(queued, "actor", None))
+            announce_payloads.append(
+                json.dumps(
+                    queued_object.model_dump(
+                        mode="json",
+                        by_alias=True,
+                        exclude_none=True,
+                        serialize_as_any=True,
+                    ),
+                    sort_keys=True,
+                    separators=(",", ":"),
+                )
+            )
+
+        assert len(announce_ids) == 2
+        assert all(actor == case_actor_id for actor in announce_actors)
+        assert len(set(announce_payloads)) == 1

--- a/test/demo/test_pcr_bootstrap.py
+++ b/test/demo/test_pcr_bootstrap.py
@@ -348,11 +348,14 @@ class TestBootstrapSequence:
             f"{_PARTICIPANT_BASE}/api/v2/actors/participant-pcr-006-ac1"
         )
         actor_dl = participant_iso.dl.clone_for_actor(participant_actor_id)
-        assert actor_dl.inbox_list() == [], (
-            "Participant actor's inbox queue was not drained after "
-            "processing Announce(VulnerabilityCase).  The inbox handler "
-            "may not have run (PCR-07-006 AC-1)."
-        )
+        try:
+            assert actor_dl.inbox_list() == [], (
+                "Participant actor's inbox queue was not drained after "
+                "processing Announce(VulnerabilityCase).  The inbox handler "
+                "may not have run (PCR-07-006 AC-1)."
+            )
+        finally:
+            actor_dl.close()
 
         replica = participant_iso.dl.read(case_id)
         assert replica is not None, (
@@ -483,8 +486,11 @@ class TestBootstrapSequence:
         # Assert 3: The actor's inbox queue must be drained, confirming
         # inbox_handler ran and dispatched the Add(Note) activity.
         actor_dl = participant_iso.dl.clone_for_actor(actor_id)
-        assert actor_dl.inbox_list() == [], (
-            f"Actor '{actor_id}' inbox queue was not drained after "
-            f"Add(Note) was processed. The inbox handler may not have "
-            f"run or may have re-queued the activity (PCR-07-006 AC-2)."
-        )
+        try:
+            assert actor_dl.inbox_list() == [], (
+                f"Actor '{actor_id}' inbox queue was not drained after "
+                f"Add(Note) was processed. The inbox handler may not have "
+                f"run or may have re-queued the activity (PCR-07-006 AC-2)."
+            )
+        finally:
+            actor_dl.close()

--- a/test/demo/test_pcr_engage_case.py
+++ b/test/demo/test_pcr_engage_case.py
@@ -175,7 +175,7 @@ def _drain_case_actor_outbox(owner_iso, case_actor_id: str) -> None:
     try:
         asyncio.run(outbox_handler(case_actor_id, case_actor_dl, owner_iso.dl))
     finally:
-        del case_actor_dl
+        case_actor_dl.close()
 
 
 def _find_case_actor_id(dl, case_id: str) -> str | None:
@@ -384,8 +384,10 @@ class TestEngageCaseParticipantExpansion:
         reporter_actor_id = str(reporter_actors[0].id_)
         reporter_actor_dl = reporter_iso.dl.clone_for_actor(reporter_actor_id)
 
-        pending = reporter_actor_dl.inbox_list()
-        del reporter_actor_dl
+        try:
+            pending = reporter_actor_dl.inbox_list()
+        finally:
+            reporter_actor_dl.close()
         assert pending == [], (
             f"Reporter actor inbox queue is not empty after "
             f"Join(VulnerabilityCase) processing.  "

--- a/test/demo/test_pcr_engage_case.py
+++ b/test/demo/test_pcr_engage_case.py
@@ -172,7 +172,10 @@ def _drain_case_actor_outbox(owner_iso, case_actor_id: str) -> None:
         case_actor_id: Full ID of the CaseActor.
     """
     case_actor_dl = owner_iso.dl.clone_for_actor(case_actor_id)
-    asyncio.run(outbox_handler(case_actor_id, case_actor_dl, owner_iso.dl))
+    try:
+        asyncio.run(outbox_handler(case_actor_id, case_actor_dl, owner_iso.dl))
+    finally:
+        del case_actor_dl
 
 
 def _find_case_actor_id(dl, case_id: str) -> str | None:
@@ -382,6 +385,7 @@ class TestEngageCaseParticipantExpansion:
         reporter_actor_dl = reporter_iso.dl.clone_for_actor(reporter_actor_id)
 
         pending = reporter_actor_dl.inbox_list()
+        del reporter_actor_dl
         assert pending == [], (
             f"Reporter actor inbox queue is not empty after "
             f"Join(VulnerabilityCase) processing.  "

--- a/test/demo/test_pcr_late_joiner.py
+++ b/test/demo/test_pcr_late_joiner.py
@@ -328,7 +328,10 @@ def _drain_case_actor_outbox(owner_iso, case_actor_id: str) -> None:
         case_actor_id: Full ID of the CaseActor.
     """
     case_actor_dl = owner_iso.dl.clone_for_actor(case_actor_id)
-    asyncio.run(outbox_handler(case_actor_id, case_actor_dl, owner_iso.dl))
+    try:
+        asyncio.run(outbox_handler(case_actor_id, case_actor_dl, owner_iso.dl))
+    finally:
+        case_actor_dl.close()
 
 
 def _run_late_joiner_sequence(
@@ -499,11 +502,14 @@ class TestLateJoinerSequence:
         # The late-joiner actor's inbox queue must be empty: the inbox handler
         # ran and processed the Announce (dispatch chain completed).
         lj_actor_dl = late_joiner_iso.dl.clone_for_actor(lj_actor_id)
-        assert lj_actor_dl.inbox_list() == [], (
-            "Late-joiner actor's inbox queue was not drained after "
-            "processing Announce(VulnerabilityCase).  The inbox handler "
-            "may not have run (PCR-07-007 AC-1)."
-        )
+        try:
+            assert lj_actor_dl.inbox_list() == [], (
+                "Late-joiner actor's inbox queue was not drained after "
+                "processing Announce(VulnerabilityCase).  The inbox handler "
+                "may not have run (PCR-07-007 AC-1)."
+            )
+        finally:
+            lj_actor_dl.close()
 
         replica = late_joiner_iso.dl.read(case_id)
         assert replica is not None, (

--- a/test/demo/test_sync_ledger_replication.py
+++ b/test/demo/test_sync_ledger_replication.py
@@ -241,55 +241,61 @@ def test_sync_predecessor_mismatch_reject_and_replay(two_app_setup) -> None:
     )
     peer_actor_dl = peer_iso.dl.clone_for_actor(peer_actor_id)
     case_actor_dl = case_actor_iso.dl.clone_for_actor(case_actor_id)
-    handle_inbox_item(
-        actor_id=peer_actor_id,
-        obj=out_of_chain_announce,
-        dl=peer_iso.dl,
-        dispatcher=peer_iso.app.state.dispatcher,
-    )
-    peer_reject_events = [
-        cast(RejectLogEntryReceivedEvent, extract_event(activity))
-        for activity in peer_iso.dl.list_objects("Reject")
-    ]
-    assert peer_reject_events, "Expected peer to emit Reject(CaseLedgerEntry)."
-    emitted_reject_event = peer_reject_events[-1]
-    assert emitted_reject_event.actor_id == peer_actor_id
-    assert emitted_reject_event.last_accepted_hash == entry0.entry_hash
-    assert peer_iso.dl.read(entry2.id_) is None
+    try:
+        handle_inbox_item(
+            actor_id=peer_actor_id,
+            obj=out_of_chain_announce,
+            dl=peer_iso.dl,
+            dispatcher=peer_iso.app.state.dispatcher,
+        )
+        peer_reject_events = [
+            cast(RejectLogEntryReceivedEvent, extract_event(activity))
+            for activity in peer_iso.dl.list_objects("Reject")
+        ]
+        assert (
+            peer_reject_events
+        ), "Expected peer to emit Reject(CaseLedgerEntry)."
+        emitted_reject_event = peer_reject_events[-1]
+        assert emitted_reject_event.actor_id == peer_actor_id
+        assert emitted_reject_event.last_accepted_hash == entry0.entry_hash
+        assert peer_iso.dl.read(entry2.id_) is None
 
-    reject_for_case_actor = cast(
-        RejectLogEntryReceivedEvent,
-        extract_event(
-            reject_log_entry_activity(
-                entry=wire_entry2,
-                context=entry0.entry_hash,
-                actor=peer_actor_id,
-                to=[case_actor_id],
-            )
-        ),
-    )
+        reject_for_case_actor = cast(
+            RejectLogEntryReceivedEvent,
+            extract_event(
+                reject_log_entry_activity(
+                    entry=wire_entry2,
+                    context=entry0.entry_hash,
+                    actor=peer_actor_id,
+                    to=[case_actor_id],
+                )
+            ),
+        )
 
-    RejectLedgerEntryReceivedUseCase(
-        case_actor_iso.dl,
-        reject_for_case_actor,
-        sync_port=SyncActivityAdapter(case_actor_iso.dl),
-    ).execute()
+        RejectLedgerEntryReceivedUseCase(
+            case_actor_iso.dl,
+            reject_for_case_actor,
+            sync_port=SyncActivityAdapter(case_actor_iso.dl),
+        ).execute()
 
-    anyio.run(
-        outbox_handler,
-        case_actor_id,
-        case_actor_dl,
-        case_actor_iso.dl,
-        case_actor_iso.app.state.emitter,
-    )
-    anyio.run(
-        inbox_handler,
-        peer_actor_id,
-        peer_iso.dl,
-        peer_actor_dl,
-        peer_iso.app.state.emitter,
-        peer_iso.app.state.dispatcher,
-    )
+        anyio.run(
+            outbox_handler,
+            case_actor_id,
+            case_actor_dl,
+            case_actor_iso.dl,
+            case_actor_iso.app.state.emitter,
+        )
+        anyio.run(
+            inbox_handler,
+            peer_actor_id,
+            peer_iso.dl,
+            peer_actor_dl,
+            peer_iso.app.state.emitter,
+            peer_iso.app.state.dispatcher,
+        )
+    finally:
+        case_actor_dl.close()
+        peer_actor_dl.close()
 
     state_id = VultronReplicationState(
         case_id=case.id_, peer_id=peer_actor_id

--- a/vultron/core/behaviors/sync/nodes/chain.py
+++ b/vultron/core/behaviors/sync/nodes/chain.py
@@ -27,6 +27,7 @@ from vultron.core.models._helpers import _now_utc
 from vultron.core.models.case_ledger import HashChainLedgerRecord
 from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
 from vultron.core.models.protocols import is_log_entry_model
+from vultron.core.sync_helpers import _find_equivalent_recorded_entry
 from vultron.core.sync_helpers import _reconstruct_tail_hash
 from vultron.errors import VultronError
 
@@ -213,8 +214,41 @@ class CreateLogEntryNode(DataLayerAction):
         self.blackboard.register_key(
             key="log_entry", access=py_trees.common.Access.WRITE
         )
+        self.blackboard.register_key(
+            key="log_entry_preexisting", access=py_trees.common.Access.WRITE
+        )
 
     def update(self) -> Status:
+        if self.datalayer is None:
+            self.logger.error("%s: DataLayer not available", self.name)
+            return Status.FAILURE
+
+        existing = _find_equivalent_recorded_entry(
+            case_id=self.case_id,
+            object_id=self.object_id,
+            event_type=self.event_type,
+            payload_snapshot=self.payload_snapshot,
+            dl=self.datalayer,
+        )
+        if existing is not None:
+            if isinstance(existing, VultronCaseLedgerEntry):
+                entry = existing
+            else:
+                entry = VultronCaseLedgerEntry.model_validate(
+                    existing.model_dump(mode="json")
+                )
+            self.blackboard.log_entry = entry
+            self.blackboard.log_entry_preexisting = True
+            self.logger.info(
+                "%s: reusing existing log entry case_id=%s event_type=%s "
+                "log_index=%d",
+                self.name,
+                entry.case_id,
+                entry.event_type,
+                entry.log_index,
+            )
+            return Status.SUCCESS
+
         tail_hash = self.blackboard.tail_hash
         tail_index = self.blackboard.tail_index
         chain_entry = HashChainLedgerRecord(
@@ -230,6 +264,7 @@ class CreateLogEntryNode(DataLayerAction):
             reason_detail=self.reason_detail,
         )
         self.blackboard.log_entry = _to_persistable_entry(chain_entry)
+        self.blackboard.log_entry_preexisting = False
         return Status.SUCCESS
 
 
@@ -239,6 +274,9 @@ class PersistLogEntryNode(DataLayerAction):
         self.blackboard.register_key(
             key="log_entry", access=py_trees.common.Access.READ
         )
+        self.blackboard.register_key(
+            key="log_entry_preexisting", access=py_trees.common.Access.READ
+        )
 
     def update(self) -> Status:
         if self.datalayer is None:
@@ -246,6 +284,22 @@ class PersistLogEntryNode(DataLayerAction):
             return Status.FAILURE
 
         entry = cast(VultronCaseLedgerEntry, self.blackboard.log_entry)
+        try:
+            preexisting = bool(self.blackboard.log_entry_preexisting)
+        except KeyError:
+            preexisting = False
+        if preexisting:
+            self.logger.info(
+                "%s: log entry already exists for case_id=%s event_type=%s "
+                "log_index=%d actor_id=%s",
+                self.name,
+                entry.case_id,
+                entry.event_type,
+                entry.log_index,
+                self.actor_id,
+            )
+            return Status.SUCCESS
+
         self.datalayer.save(entry)
         self.logger.info(
             "%s: committed log entry case_id=%s event_type=%s log_index=%d actor_id=%s",

--- a/vultron/core/sync_helpers.py
+++ b/vultron/core/sync_helpers.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 """Shared helpers for SYNC log-replication workflows."""
 
+from typing import Any
+
 from vultron.core.models.case_ledger import GENESIS_HASH
 from vultron.core.models.protocols import LogEntryModel, is_log_entry_model
 from vultron.core.ports.case_persistence import CasePersistence
@@ -22,3 +24,34 @@ def _reconstruct_tail_hash(
     entries.sort(key=lambda entry: entry.log_index)
     last = entries[-1]
     return last.entry_hash, last.log_index
+
+
+def _find_equivalent_recorded_entry(
+    *,
+    case_id: str,
+    object_id: str,
+    event_type: str,
+    payload_snapshot: dict[str, Any],
+    dl: CasePersistence,
+) -> LogEntryModel | None:
+    """Return an already-recorded canonical entry with equivalent semantics.
+
+    "Equivalent" means same case, object, event type, and payload snapshot.
+    This supports idempotent handling of participant retries without appending
+    duplicate canonical entries for the same logical assertion.
+    """
+    matches: list[LogEntryModel] = [
+        entry
+        for obj in dl.list_objects("CaseLedgerEntry")
+        if is_log_entry_model(obj)
+        for entry in [obj]
+        if entry.case_id == case_id
+        and entry.disposition == "recorded"
+        and entry.log_object_id == object_id
+        and entry.event_type == event_type
+        and entry.payload_snapshot == payload_snapshot
+    ]
+    if not matches:
+        return None
+    matches.sort(key=lambda entry: entry.log_index)
+    return matches[-1]

--- a/vultron/core/use_cases/received/status.py
+++ b/vultron/core/use_cases/received/status.py
@@ -221,10 +221,8 @@ class AddParticipantStatusToParticipantReceivedUseCase:
             return False
         if receiving_actor_id != case_actor_id:
             logger.debug(
-                "add_participant_status: actor '%s' is not CaseActor '%s' for"
+                "add_participant_status: receiving actor is not the CaseActor for"
                 " case '%s' — skipping canonical commit",
-                receiving_actor_id,
-                case_actor_id,
                 case_id,
             )
             return False

--- a/vultron/core/use_cases/received/status.py
+++ b/vultron/core/use_cases/received/status.py
@@ -189,6 +189,47 @@ class AddParticipantStatusToParticipantReceivedUseCase:
 
         self._commit_log_cascade()
 
+    def _resolve_case_id_for_log_cascade(self) -> str | None:
+        request = self._request
+
+        if request.status is not None:
+            context = getattr(request.status, "context", None)
+            if context:
+                return str(context)
+
+        if request.context_id is not None:
+            return request.context_id
+
+        if request.status_id:
+            stored_status = self._dl.read(request.status_id)
+            if stored_status is not None:
+                context = getattr(stored_status, "context", None)
+                if context:
+                    return str(context)
+        return None
+
+    def _is_case_actor_receiver(
+        self, *, case_id: str, case_actor_id: str
+    ) -> bool:
+        receiving_actor_id = self._request.receiving_actor_id
+        if receiving_actor_id is None:
+            logger.warning(
+                "add_participant_status: missing receiving_actor_id for case '%s'"
+                " — skipping canonical commit to avoid non-CaseActor append",
+                case_id,
+            )
+            return False
+        if receiving_actor_id != case_actor_id:
+            logger.debug(
+                "add_participant_status: actor '%s' is not CaseActor '%s' for"
+                " case '%s' — skipping canonical commit",
+                receiving_actor_id,
+                case_actor_id,
+                case_id,
+            )
+            return False
+        return True
+
     def _commit_log_cascade(self) -> None:
         """Commit a CaseLedgerEntry and fan it out to all participants (PCR-08-003).
 
@@ -204,30 +245,7 @@ class AddParticipantStatusToParticipantReceivedUseCase:
         )
 
         request = self._request
-
-        # Derive case_id from the inline status object (same approach as BT).
-        case_id: str | None = None
-        if request.status is not None:
-            context = getattr(request.status, "context", None)
-            if context:
-                case_id = str(context)
-
-        # Fallback 1: activity-level context (populated when activity.context
-        # is set to the case object by the caller, e.g. add_status_to_participant
-        # sets context=case).
-        if case_id is None:
-            case_id = request.context_id
-
-        # Fallback 2: read the stored ParticipantStatus and check its context.
-        # Handles cases where the inline object was omitted and the BT resolved
-        # it via a DataLayer lookup (VerifySenderIsParticipantNode._resolve_case_id).
-        if case_id is None and request.status_id:
-            stored_status = self._dl.read(request.status_id)
-            if stored_status is not None:
-                ctx = getattr(stored_status, "context", None)
-                if ctx:
-                    case_id = str(ctx)
-
+        case_id = self._resolve_case_id_for_log_cascade()
         if case_id is None:
             logger.warning(
                 "add_participant_status: cannot determine case_id"
@@ -235,22 +253,24 @@ class AddParticipantStatusToParticipantReceivedUseCase:
             )
             return
 
-        actor_id = request.receiving_actor_id
-        if actor_id is None:
-            actor_id = _find_case_actor_id(self._dl, case_id)
-        if actor_id is None:
+        case_actor_id = _find_case_actor_id(self._dl, case_id)
+        if case_actor_id is None:
             logger.warning(
                 "add_participant_status: cannot resolve CaseActor for case '%s'"
                 " — skipping log entry cascade (PCR-08-003)",
                 case_id,
             )
             return
+        if not self._is_case_actor_receiver(
+            case_id=case_id, case_actor_id=case_actor_id
+        ):
+            return
 
         commit_log_entry_trigger(
             case_id=case_id,
             object_id=request.status_id or request.activity_id,
             event_type="add_participant_status",
-            actor_id=actor_id,
+            actor_id=case_actor_id,
             dl=self._dl,
             sync_port=self._sync_port,
             payload_snapshot=extract_activity_snapshot(request, dl=self._dl),

--- a/vultron/core/use_cases/triggers/sync.py
+++ b/vultron/core/use_cases/triggers/sync.py
@@ -37,9 +37,12 @@ from vultron.core.ports.case_persistence import (
     CaseOutboxPersistence,
 )
 from vultron.core.ports.sync_activity import SyncActivityPort
+from vultron.core.sync_helpers import (
+    _find_equivalent_recorded_entry,
+    _reconstruct_tail_hash,
+)
 from vultron.core.use_cases._helpers import case_addressees
 from vultron.core.use_cases._helpers import build_activity_payload_snapshot
-from vultron.core.use_cases.received.sync import _reconstruct_tail_hash
 from vultron.errors import VultronError
 
 if TYPE_CHECKING:
@@ -94,6 +97,12 @@ def _to_persistable_entry(
         reason_code=chain_entry.reason_code,
         reason_detail=chain_entry.reason_detail,
     )
+
+
+def _as_persistable_log_entry(entry: LogEntryModel) -> VultronCaseLedgerEntry:
+    if isinstance(entry, VultronCaseLedgerEntry):
+        return entry
+    return VultronCaseLedgerEntry.model_validate(entry.model_dump(mode="json"))
 
 
 def _fan_out_log_entry(
@@ -190,6 +199,29 @@ def commit_log_entry_trigger(
 
     Spec: SYNC-02-002, SYNC-02-003, SYNC-03-001.
     """
+    normalized_snapshot = payload_snapshot or {}
+    existing = _find_equivalent_recorded_entry(
+        case_id=case_id,
+        object_id=object_id,
+        event_type=event_type,
+        payload_snapshot=normalized_snapshot,
+        dl=dl,
+    )
+    if existing is not None:
+        existing_entry = _as_persistable_log_entry(existing)
+        logger.info(
+            "sync: idempotent commit hit for case '%s' event_type=%s "
+            "object_id='%s' (reusing log_index=%d)",
+            case_id,
+            event_type,
+            object_id,
+            existing_entry.log_index,
+        )
+        _fan_out_log_entry(
+            case_id, existing_entry, actor_id, dl, sync_port=sync_port
+        )
+        return existing_entry
+
     tail_hash, tail_index = _reconstruct_tail_hash(case_id, dl)
 
     # Create the new entry directly using HashChainLedgerRecord so the entry_hash is
@@ -202,7 +234,7 @@ def commit_log_entry_trigger(
         object_id=object_id,
         event_type=event_type,
         disposition=disposition,  # type: ignore[arg-type]
-        payload_snapshot=payload_snapshot or {},
+        payload_snapshot=normalized_snapshot,
         prev_log_hash=tail_hash,
         term=term,
         reason_code=reason_code,


### PR DESCRIPTION
- Closes #926

## Summary

Ensures the CaseActor commit path records at most one canonical CaseLedgerEntry per logical assertion and preserves identical broadcast payloads across recipients.

## Changes

- `vultron/core/sync_helpers.py`: added equivalent-entry lookup for idempotent commit suppression.
- `vultron/core/use_cases/triggers/sync.py`: short-circuits duplicate canonical commits before appending a new ledger entry.
- `vultron/core/behaviors/sync/nodes/chain.py`: reuses preexisting canonical entries and avoids duplicate persistence/fan-out.
- `vultron/core/use_cases/received/status.py`: only the CaseActor receiver can advance the canonical commit cascade.
- `test/core/use_cases/received/test_status.py` and `test/core/behaviors/sync/test_commit_tree.py`: regression coverage for duplicate suppression, actor preservation, and identical fan-out payloads.

## Verification

- 3239 passed, 34 skipped, 225 deselected, 2 xfailed, 5633 subtests passed
- black, flake8, mypy, pyright all passed
