### PR TITLE
Inline nested protocol objects in CaseLedgerEntry payloadSnapshot

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -150,3 +150,13 @@ CaseActor-only, emit nodes must fail fast before queueing when no routable
 CaseActor recipient exists; otherwise outbox enforcement raises
 `VultronOutboxToFieldMissingError` later and masks the true sender-side
 routing defect.
+
+### 2026-06-15 LEDGER-SNAPSHOT-933 — inline nested refs with case-context guard
+
+Inlining nested payloadSnapshot references by blindly resolving `dl.read(id)`
+is unsafe: it can leak unrelated local objects into canonical
+`CaseLedgerEntry` snapshots when inbound activities carry attacker-controlled
+IDs. The inlining path must enforce a case-context match (`resolved.context ==
+payloadSnapshot.context`) before replacing any bare ID with an inline object.
+This keeps CLP-07 self-contained snapshots while preventing cross-case data
+disclosure.

--- a/plan/history/2606/implementation/ISSUE-933.md
+++ b/plan/history/2606/implementation/ISSUE-933.md
@@ -1,0 +1,12 @@
+---
+source: ISSUE-933
+timestamp: '2026-06-15T18:17:57.682848+00:00'
+title: Inline nested protocol objects in canonical CaseLedgerEntry payloadSnapshot
+type: implementation
+---
+
+## Issue #933 — Inline nested protocol objects in canonical CaseLedgerEntry payloadSnapshot (no bare ID-string substitutions)
+
+Implemented deterministic snapshot inlining for known nested reference fields so canonical CaseLedgerEntry payloadSnapshot entries no longer depend on bare ID-string substitutions for protocol-significant nested objects. Added context-bound dereference guards to prevent cross-case object leakage during inlining, and wired the same logic through both received-side log commits and BT lifecycle commit nodes.
+
+PR: <https://github.com/CERTCC/Vultron/pull/963>

--- a/test/core/behaviors/case/nodes/test_lifecycle.py
+++ b/test/core/behaviors/case/nodes/test_lifecycle.py
@@ -26,6 +26,7 @@ from vultron.core.behaviors.bridge import BTBridge, BTExecutionResult
 from vultron.core.behaviors.case.nodes import CommitCaseLedgerEntryNode
 from vultron.core.models.events.base import MessageSemantics
 from vultron.core.models.vultron_types import VultronCaseActor
+from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
 
 _FACTORY_PATH = (
     "vultron.core.behaviors.case.nodes.lifecycle.create_commit_log_entry_tree"
@@ -86,6 +87,16 @@ class _FakeWireActivity:
 
     def model_dump(self, **_: object) -> dict[str, str]:
         return {"id": ACTIVITY_ID, "type": "Create"}
+
+
+class _FakeWireActivityWithPayload:
+    """Minimal stand-in with configurable payload."""
+
+    def __init__(self, payload: dict[str, object]):
+        self._payload = payload
+
+    def model_dump(self, **_: object) -> dict[str, object]:
+        return dict(self._payload)
 
 
 # ---------------------------------------------------------------------------
@@ -232,6 +243,47 @@ def test_activity_payload_is_forwarded_as_payload_snapshot(bridge):
         event_type=MessageSemantics.CREATE_CASE.value,
         payload_snapshot={"id": ACTIVITY_ID, "type": "Create"},
     )
+
+
+def test_activity_payload_inlines_nested_reference_fields(bridge, datalayer):
+    embargo = EmbargoEvent(context=CASE_ID)
+    datalayer.save(embargo)
+    activity = _FakeActivity(
+        activity_id=ACTIVITY_ID,
+        semantic_type=MessageSemantics.CREATE_CASE,
+        activity=_FakeWireActivityWithPayload(
+            {
+                "id": ACTIVITY_ID,
+                "type": "Join",
+                "context": CASE_ID,
+                "object": {
+                    "id": "https://example.org/statuses/status-001",
+                    "type": "ParticipantStatus",
+                    "activeEmbargo": embargo.id_,
+                    "proposedEmbargoes": [embargo.id_],
+                },
+            }
+        ),
+    )
+    node = CommitCaseLedgerEntryNode(case_id=CASE_ID)
+
+    with patch(_FACTORY_PATH) as mock_factory, patch(
+        _INNER_BRIDGE_PATH
+    ) as mock_bridge_cls:
+        mock_bridge_cls.return_value.execute_with_setup.return_value = (
+            BTExecutionResult(status=Status.SUCCESS)
+        )
+        bridge.execute_with_setup(
+            tree=node, actor_id=ACTOR_ID, activity=activity
+        )
+
+    payload_snapshot = mock_factory.call_args.kwargs["payload_snapshot"]
+    status_obj = payload_snapshot["object"]
+    assert payload_snapshot["context"] == CASE_ID
+    assert isinstance(status_obj["activeEmbargo"], dict)
+    assert status_obj["activeEmbargo"]["id"] == embargo.id_
+    assert isinstance(status_obj["proposedEmbargoes"][0], dict)
+    assert status_obj["proposedEmbargoes"][0]["id"] == embargo.id_
 
 
 def test_no_activity_falls_back_to_case_event(bridge):

--- a/test/core/use_cases/triggers/test_sync.py
+++ b/test/core/use_cases/triggers/test_sync.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Unit tests for SYNC trigger helpers."""
+
+from typing import Any, cast
+
+from vultron.core.use_cases.triggers.sync import extract_activity_snapshot
+from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+from vultron.wire.as2.vocab.objects.vulnerability_report import (
+    VulnerabilityReport,
+)
+
+
+class _FakeWireActivity:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def model_dump(self, **_: object) -> dict[str, Any]:
+        return dict(self._payload)
+
+
+class _FakeEvent:
+    def __init__(self, activity: object | None) -> None:
+        self.activity = activity
+
+
+def test_extract_activity_snapshot_returns_empty_without_activity() -> None:
+    event = _FakeEvent(activity=None)
+    assert extract_activity_snapshot(cast(Any, event)) == {}
+
+
+def test_extract_activity_snapshot_inlines_nested_reference_fields(datalayer):
+    embargo = EmbargoEvent(context="https://example.org/cases/case-001")
+    report = VulnerabilityReport(
+        name="TEST-REPORT-001",
+        content="Demo content",
+        context="https://example.org/cases/case-001",
+    )
+    datalayer.save(embargo)
+    datalayer.save(report)
+
+    payload = {
+        "id": "https://example.org/activities/engage-001",
+        "type": "Join",
+        "context": "https://example.org/cases/case-001",
+        "object": {
+            "id": "https://example.org/statuses/status-001",
+            "type": "ParticipantStatus",
+            "activeEmbargo": embargo.id_,
+            "proposedEmbargoes": [embargo.id_],
+            "vulnerabilityReports": [report.id_],
+        },
+    }
+    event = _FakeEvent(activity=_FakeWireActivity(payload))
+
+    snapshot = extract_activity_snapshot(cast(Any, event), dl=datalayer)
+    status_obj = snapshot["object"]
+
+    assert snapshot["context"] == "https://example.org/cases/case-001"
+    assert isinstance(status_obj["activeEmbargo"], dict)
+    assert status_obj["activeEmbargo"]["id"] == embargo.id_
+    assert isinstance(status_obj["proposedEmbargoes"][0], dict)
+    assert status_obj["proposedEmbargoes"][0]["id"] == embargo.id_
+    assert isinstance(status_obj["vulnerabilityReports"][0], dict)
+    assert status_obj["vulnerabilityReports"][0]["id"] == report.id_
+
+
+def test_extract_activity_snapshot_does_not_inline_cross_context_refs(
+    datalayer,
+):
+    embargo = EmbargoEvent(context="https://example.org/cases/other-case")
+    datalayer.save(embargo)
+
+    payload = {
+        "id": "https://example.org/activities/engage-001",
+        "type": "Join",
+        "context": "https://example.org/cases/case-001",
+        "object": {
+            "id": "https://example.org/statuses/status-001",
+            "type": "ParticipantStatus",
+            "activeEmbargo": embargo.id_,
+        },
+    }
+    event = _FakeEvent(activity=_FakeWireActivity(payload))
+
+    snapshot = extract_activity_snapshot(cast(Any, event), dl=datalayer)
+    status_obj = snapshot["object"]
+
+    assert status_obj["activeEmbargo"] == embargo.id_

--- a/vultron/core/behaviors/case/nodes/lifecycle.py
+++ b/vultron/core/behaviors/case/nodes/lifecycle.py
@@ -32,36 +32,28 @@ from vultron.core.behaviors.helpers import DataLayerAction
 from vultron.core.behaviors.sync.commit_tree import (
     create_commit_log_entry_tree,
 )
-from vultron.core.ports.case_persistence import CaseOutboxPersistence
+from vultron.core.ports.case_persistence import (
+    CaseOutboxPersistence,
+    CasePersistence,
+)
+from vultron.core.use_cases._helpers import build_activity_payload_snapshot
 
 logger = logging.getLogger(__name__)
 
 
-def _extract_payload_snapshot(activity: Any) -> dict[str, Any]:
+def _extract_payload_snapshot(
+    activity: Any, dl: CasePersistence | None = None
+) -> dict[str, Any]:
     """Build a normalized payload snapshot for case-ledger commits."""
     event_activity = getattr(activity, "activity", None)
-    if event_activity is not None and hasattr(event_activity, "model_dump"):
+    if event_activity is not None:
         return cast(
             dict[str, Any],
-            event_activity.model_dump(
-                mode="json",
-                by_alias=True,
-                serialize_as_any=True,
-                exclude_none=True,
-            ),
+            build_activity_payload_snapshot(event_activity, dl=dl),
         )
-
-    if hasattr(activity, "model_dump"):
-        return cast(
-            dict[str, Any],
-            activity.model_dump(
-                mode="json",
-                by_alias=True,
-                serialize_as_any=True,
-                exclude_none=True,
-            ),
-        )
-    return {}
+    return cast(
+        dict[str, Any], build_activity_payload_snapshot(activity, dl=dl)
+    )
 
 
 class CommitCaseLedgerEntryNode(DataLayerAction):
@@ -157,7 +149,9 @@ class CommitCaseLedgerEntryNode(DataLayerAction):
             object_id = case_id
             event_type = "case_event"
         payload_snapshot = (
-            _extract_payload_snapshot(activity) if activity is not None else {}
+            _extract_payload_snapshot(activity, dl=self.datalayer)
+            if activity is not None
+            else {}
         )
 
         tree = create_commit_log_entry_tree(

--- a/vultron/core/use_cases/_helpers.py
+++ b/vultron/core/use_cases/_helpers.py
@@ -26,6 +26,24 @@ from vultron.errors import VultronNotFoundError, VultronValidationError
 
 logger = logging.getLogger(__name__)
 
+_SNAPSHOT_REFERENCE_FIELDS = {
+    "object",
+    "object_",
+    "target",
+    "active_embargo",
+    "activeEmbargo",
+    "proposed_embargoes",
+    "proposedEmbargoes",
+    "vulnerability_reports",
+    "vulnerabilityReports",
+    "notes",
+    "case_participants",
+    "caseParticipants",
+    "case_statuses",
+    "caseStatuses",
+}
+_SNAPSHOT_INLINE_DEPTH_LIMIT = 8
+
 
 def _as_id(obj: Any) -> str | None:
     """Return the ActivityStreams id of *obj* as a plain string.
@@ -43,6 +61,116 @@ def _as_id(obj: Any) -> str | None:
     if isinstance(id_, str):
         return id_
     return str(obj)
+
+
+def _inline_snapshot_reference_value(
+    value: Any,
+    dl: CasePersistence | None,
+    *,
+    should_resolve_strings: bool,
+    resolving_ids: set[str],
+    expected_context: str | None,
+    depth: int,
+) -> Any:
+    """Inline nested AS2 object references for canonical payload snapshots."""
+    if depth > _SNAPSHOT_INLINE_DEPTH_LIMIT:
+        return value
+
+    if isinstance(value, dict):
+        inlined: dict[str, Any] = {}
+        for key, child in value.items():
+            inlined[key] = _inline_snapshot_reference_value(
+                child,
+                dl,
+                should_resolve_strings=(key in _SNAPSHOT_REFERENCE_FIELDS),
+                resolving_ids=resolving_ids,
+                expected_context=expected_context,
+                depth=depth + 1,
+            )
+        return inlined
+
+    if isinstance(value, list):
+        return [
+            _inline_snapshot_reference_value(
+                item,
+                dl,
+                should_resolve_strings=should_resolve_strings,
+                resolving_ids=resolving_ids,
+                expected_context=expected_context,
+                depth=depth + 1,
+            )
+            for item in value
+        ]
+
+    if (
+        not should_resolve_strings
+        or dl is None
+        or not isinstance(value, str)
+        or value in resolving_ids
+    ):
+        return value
+
+    resolved = dl.read(value)
+    if resolved is None or not hasattr(resolved, "model_dump"):
+        return value
+    resolved_context = _as_id(getattr(resolved, "context", None))
+    if (
+        expected_context is None
+        or resolved_context is None
+        or resolved_context != expected_context
+    ):
+        return value
+
+    resolving_ids.add(value)
+    try:
+        dumped = resolved.model_dump(
+            mode="json",
+            by_alias=True,
+            serialize_as_any=True,
+            exclude_none=True,
+        )
+        return _inline_snapshot_reference_value(
+            dumped,
+            dl,
+            should_resolve_strings=False,
+            resolving_ids=resolving_ids,
+            expected_context=expected_context,
+            depth=depth + 1,
+        )
+    finally:
+        resolving_ids.remove(value)
+
+
+def build_activity_payload_snapshot(
+    activity: Any, dl: CasePersistence | None = None
+) -> dict[str, Any]:
+    """Return a normalized, self-contained payload snapshot for ledger entries.
+
+    If a DataLayer is provided, known nested object-reference fields are inlined
+    from storage so canonical CaseLedgerEntry snapshots do not carry bare ID
+    strings for protocol-significant nested objects.
+    """
+    if activity is None or not hasattr(activity, "model_dump"):
+        return {}
+
+    snapshot: dict[str, Any] = activity.model_dump(
+        mode="json",
+        by_alias=True,
+        serialize_as_any=True,
+        exclude_none=True,
+    )
+    expected_context = snapshot.get("context")
+    if not isinstance(expected_context, str):
+        expected_context = None
+    inlined = _inline_snapshot_reference_value(
+        snapshot,
+        dl,
+        should_resolve_strings=False,
+        resolving_ids=set(),
+        expected_context=expected_context,
+        depth=0,
+    )
+    return inlined if isinstance(inlined, dict) else {}
 
 
 def _find_case_actor_id(dl: CasePersistence, case_id: str) -> str | None:

--- a/vultron/core/use_cases/received/embargo.py
+++ b/vultron/core/use_cases/received/embargo.py
@@ -52,7 +52,7 @@ def _commit_embargo_log_cascade(
 
     Args:
         payload_snapshot: Optional normalised AS2 activity snapshot.  Pass
-            the result of ``extract_activity_snapshot(request)`` to ensure
+            the result of ``extract_activity_snapshot(request, dl=dl)`` to ensure
             each log entry carries the full inbound AS2 activity payload.
     """
     from vultron.core.use_cases.received.actor import _find_case_actor_id
@@ -181,7 +181,7 @@ class AddEmbargoEventToCaseReceivedUseCase:
         tree = add_embargo_to_case_tree(
             case_id=case_id,
             embargo_id=embargo_id,
-            payload_snapshot=extract_activity_snapshot(request),
+            payload_snapshot=extract_activity_snapshot(request, dl=self._dl),
         )
         bridge = BTBridge(datalayer=self._dl)
         result = bridge.execute_with_setup(
@@ -258,7 +258,7 @@ class RemoveEmbargoEventFromCaseReceivedUseCase:
             dl=self._dl,
             receiving_actor_id=request.receiving_actor_id,
             sync_port=self._sync_port,
-            payload_snapshot=extract_activity_snapshot(request),
+            payload_snapshot=extract_activity_snapshot(request, dl=self._dl),
         )
 
 
@@ -311,7 +311,7 @@ class InviteToEmbargoOnCaseReceivedUseCase:
             case_id=case_id,
             invitee_id=invitee_id,
             invite_id=invite_id,
-            payload_snapshot=extract_activity_snapshot(request),
+            payload_snapshot=extract_activity_snapshot(request, dl=self._dl),
         )
         bridge = BTBridge(datalayer=self._dl)
         result = bridge.execute_with_setup(
@@ -370,7 +370,7 @@ class AcceptInviteToEmbargoOnCaseReceivedUseCase:
             embargo_id=embargo_id,
             accepting_actor_id=accepting_actor_id,
             invite_id=invite_id,
-            payload_snapshot=extract_activity_snapshot(request),
+            payload_snapshot=extract_activity_snapshot(request, dl=self._dl),
         )
         bridge = BTBridge(datalayer=self._dl)
         result = bridge.execute_with_setup(
@@ -438,7 +438,7 @@ class RejectInviteToEmbargoOnCaseReceivedUseCase:
             rejecting_actor_id=rejecting_actor_id,
             invite_id=invite_id or "",
             embargo_id=embargo_id,
-            payload_snapshot=extract_activity_snapshot(request),
+            payload_snapshot=extract_activity_snapshot(request, dl=self._dl),
         )
         bridge = BTBridge(datalayer=self._dl)
         result = bridge.execute_with_setup(

--- a/vultron/core/use_cases/received/status.py
+++ b/vultron/core/use_cases/received/status.py
@@ -253,5 +253,5 @@ class AddParticipantStatusToParticipantReceivedUseCase:
             actor_id=actor_id,
             dl=self._dl,
             sync_port=self._sync_port,
-            payload_snapshot=extract_activity_snapshot(request),
+            payload_snapshot=extract_activity_snapshot(request, dl=self._dl),
         )

--- a/vultron/core/use_cases/triggers/sync.py
+++ b/vultron/core/use_cases/triggers/sync.py
@@ -38,6 +38,7 @@ from vultron.core.ports.case_persistence import (
 )
 from vultron.core.ports.sync_activity import SyncActivityPort
 from vultron.core.use_cases._helpers import case_addressees
+from vultron.core.use_cases._helpers import build_activity_payload_snapshot
 from vultron.core.use_cases.received.sync import _reconstruct_tail_hash
 from vultron.errors import VultronError
 
@@ -47,7 +48,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def extract_activity_snapshot(request: "VultronEvent") -> dict[str, Any]:
+def extract_activity_snapshot(
+    request: "VultronEvent", dl: CaseOutboxPersistence | None = None
+) -> dict[str, Any]:
     """Return a normalised AS2 payload snapshot from a ``VultronEvent``.
 
     When ``request.activity`` is populated (``include_activity=True`` in
@@ -57,23 +60,17 @@ def extract_activity_snapshot(request: "VultronEvent") -> dict[str, Any]:
 
     Args:
         request: The inbound domain event produced by ``extract_intent()``.
+        dl: Optional DataLayer used to inline known nested object-reference
+            fields from storage.
 
     Returns:
         A JSON-serialisable dict suitable for ``payload_snapshot``.
 
     Spec: SYNC-02-002, SYNC-02-003.
     """
-    activity = request.activity
-    if activity is None or not hasattr(activity, "model_dump"):
-        return {}
     return cast(
         dict[str, Any],
-        activity.model_dump(
-            mode="json",
-            by_alias=True,
-            serialize_as_any=True,
-            exclude_none=True,
-        ),
+        build_activity_payload_snapshot(request.activity, dl=dl),
     )
 
 


### PR DESCRIPTION
- Closes #933

## Summary

Case-ledger payload snapshot construction now inlines nested protocol object references for known reference-bearing fields at snapshot time instead of persisting bare ID strings. A context guard ensures only same-case objects are inlined.

## Changes

- vultron/core/use_cases/_helpers.py: added build_activity_payload_snapshot with recursive inlining and context-bound dereference checks.
- vultron/core/use_cases/triggers/sync.py: extract_activity_snapshot now uses the shared snapshot builder and accepts optional DataLayer context.
- vultron/core/use_cases/received/status.py and vultron/core/use_cases/received/embargo.py: pass DataLayer into snapshot extraction before log commits.
- vultron/core/behaviors/case/nodes/lifecycle.py: BT commit node now uses the shared snapshot inlining path.
- test/core/use_cases/triggers/test_sync.py: added regression tests for nested-object inlining and cross-context non-inlining.
- test/core/behaviors/case/nodes/test_lifecycle.py: added BT-level snapshot inlining regression test.

## Verification

- 3240 unit tests passed (34 skipped, 2 xfailed)
- Black, flake8, mypy, and pyright clean