### PR TITLE
Implement late-joiner canonical ledger join backfill

### DIFF
--- a/plan/history/2606/implementation/ISSUE-961.md
+++ b/plan/history/2606/implementation/ISSUE-961.md
@@ -1,0 +1,12 @@
+---
+source: ISSUE-961
+timestamp: '2026-06-15T19:41:47.876443+00:00'
+title: Late-joiner canonical case-ledger backfill
+type: implementation
+---
+
+## Issue #961 — Late-joiner canonical case-ledger backfill at participant join time
+
+Implemented join-time canonical `CaseLedgerEntry` backfill for late-joining participants, with resumable progress markers persisted in `VultronReplicationState` (`join_backfill_target_index`, `join_backfill_last_sent_index`, `join_backfill_complete`). Accept-invite processing now replays canonical entries in strict order, resumes interrupted runs without duplicates, and requires `sync_port` so backfill state cannot be skipped. Inbox/dispatcher wiring was updated so `ACCEPT_INVITE_ACTOR_TO_CASE` gets both trigger + sync ports, and dispatch now enforces catch-up gating for selected participant-originated semantics with semantic-safe case-id resolution.
+
+PR: <https://github.com/CERTCC/Vultron/pull/976>

--- a/specs/sync-ledger-replication.yaml
+++ b/specs/sync-ledger-replication.yaml
@@ -173,10 +173,23 @@ groups:
     priority: MUST
     statement: >-
       While catch-up freshness is not established, the actor MUST block or defer new
-      protocol-significant case actions and surface an explicit stale-or-catching-up condition
+      protocol-significant case actions and surface an explicit stale-or-catching-up
+      condition
   - id: SYNC-10-003
     priority: SHOULD
     statement: >-
       Catch-up freshness checks SHOULD use the actor's last acknowledged canonical hash and
       replay mechanisms so that action gating is based on canonical log position, not local
       wall-clock assumptions
+  - id: SYNC-10-004
+    priority: MUST
+    statement: >-
+      The catch-up gate MUST require a contiguous canonical log prefix from genesis through
+      the actor's currently acknowledged tip; any gap in that prefix MUST block
+      protocol-significant case actions
+  - id: SYNC-10-005
+    priority: MUST_NOT
+    statement: >-
+      The catch-up gate MUST NOT require the actor's acknowledged tip to equal the CaseActor's
+      current ledger tip; lagging behind the leader tip is allowed if the actor's own
+      acknowledged prefix is contiguous from genesis

--- a/test/core/use_cases/received/actor/test_invite.py
+++ b/test/core/use_cases/received/actor/test_invite.py
@@ -134,7 +134,9 @@ class TestInviteActorUseCases:
 
         event = make_payload(accept)
 
-        AcceptInviteActorToCaseReceivedUseCase(dl, event).execute()
+        AcceptInviteActorToCaseReceivedUseCase(
+            dl, event, sync_port=MagicMock()
+        ).execute()
 
         case = dl.read(case.id_)
         assert case is not None
@@ -184,7 +186,9 @@ class TestInviteActorUseCases:
 
         event = make_payload(accept)
 
-        AcceptInviteActorToCaseReceivedUseCase(dl, event).execute()
+        AcceptInviteActorToCaseReceivedUseCase(
+            dl, event, sync_port=MagicMock()
+        ).execute()
 
         case = dl.read(case.id_)
         assert case is not None
@@ -240,7 +244,9 @@ class TestInviteActorUseCases:
         event = make_payload(accept)
 
         # No TriggerActivityAdapter needed: RM.ACCEPTED is reached via BT.
-        AcceptInviteActorToCaseReceivedUseCase(dl, event).execute()
+        AcceptInviteActorToCaseReceivedUseCase(
+            dl, event, sync_port=MagicMock()
+        ).execute()
 
         updated_case = cast(Any, dl.read(case.id_))
         participant_id = updated_case.actor_participant_index.get(invitee_id)
@@ -302,7 +308,9 @@ class TestInviteActorUseCases:
         )
         event = make_payload(accept)
 
-        AcceptInviteActorToCaseReceivedUseCase(dl, event).execute()
+        AcceptInviteActorToCaseReceivedUseCase(
+            dl, event, sync_port=MagicMock()
+        ).execute()
 
         # PCR-07-008: no RmEngageCaseActivity (Join) with actor=invitee_id
         # should be queued — the BT records RM.ACCEPTED for the invitee
@@ -364,7 +372,9 @@ class TestInviteActorUseCases:
 
         assert len(case.events) == 0
 
-        AcceptInviteActorToCaseReceivedUseCase(dl, event).execute()
+        AcceptInviteActorToCaseReceivedUseCase(
+            dl, event, sync_port=MagicMock()
+        ).execute()
 
         case = dl.read(case.id_)
         assert case is not None
@@ -372,3 +382,372 @@ class TestInviteActorUseCases:
         assert len(case.events) >= 1
         event_types = [e.event_type for e in case.events]
         assert "participant_joined" in event_types
+
+    def test_accept_invite_backfills_canonical_ledger_from_genesis(
+        self, make_payload
+    ):
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+        from vultron.core.use_cases.triggers.sync import (
+            commit_log_entry_trigger,
+        )
+        from vultron.core.models.replication_state import (
+            VultronReplicationState,
+        )
+        from vultron.wire.as2.vocab.base.objects.actors import (
+            as_Organization,
+            as_Service,
+        )
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        invitee_id = "https://example.org/users/late-joiner"
+        case_actor_id = "https://example.org/actors/case-actor-lj1"
+        invitee = as_Organization(id_=invitee_id)
+        case_actor = as_Service(id_=case_actor_id, context="unused")
+        case = VulnerabilityCase(
+            id_="https://example.org/cases/caseLJ1",
+            name="TEST-LATE-JOIN-BACKFILL",
+        )
+        case_actor.context = case.id_
+        invite = rm_invite_to_case_activity(
+            invitee,
+            target=VulnerabilityCaseStub(id_=case.id_),
+            actor=case_actor_id,
+            id_=f"{case.id_}/invitations/1",
+        )
+        dl.create(invitee)
+        dl.create(case_actor)
+        dl.create(case)
+        dl.create(invite)
+
+        first = commit_log_entry_trigger(
+            case_id=case.id_,
+            object_id=f"{case.id_}/events/0",
+            event_type="submit_report",
+            actor_id=case_actor_id,
+            dl=dl,
+            payload_snapshot={"index": 0},
+        )
+        second = commit_log_entry_trigger(
+            case_id=case.id_,
+            object_id=f"{case.id_}/events/1",
+            event_type="add_participant_status",
+            actor_id=case_actor_id,
+            dl=dl,
+            payload_snapshot={"index": 1},
+        )
+
+        trigger_activity = MagicMock()
+        trigger_activity.announce_vulnerability_case.return_value = (
+            f"{case.id_}/announce/1"
+        )
+        sync_port = MagicMock()
+
+        accept = rm_accept_invite_to_case_activity(invite, actor=invitee_id)
+        event = make_payload(accept)
+        AcceptInviteActorToCaseReceivedUseCase(
+            dl,
+            event,
+            sync_port=sync_port,
+            trigger_activity=trigger_activity,
+        ).execute()
+
+        announced_entries = [
+            kwargs["entry"]
+            for _, kwargs in sync_port.send_announce_log_entry.call_args_list
+        ]
+        assert [entry.log_index for entry in announced_entries] == [0, 1]
+        assert announced_entries[0].entry_hash == first.entry_hash
+        assert announced_entries[1].entry_hash == second.entry_hash
+
+        state_id = VultronReplicationState(
+            case_id=case.id_, peer_id=invitee_id
+        ).id_
+        state = cast(Any, dl.read(state_id))
+        assert state is not None
+        assert state.join_backfill_target_index == 1
+        assert state.join_backfill_last_sent_index == 1
+        assert state.join_backfill_complete is True
+
+    def test_accept_invite_resumes_backfill_without_duplicate_entries(
+        self, make_payload
+    ):
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+        from vultron.core.models.replication_state import (
+            VultronReplicationState,
+        )
+        from vultron.core.use_cases.triggers.sync import (
+            commit_log_entry_trigger,
+        )
+        from vultron.wire.as2.vocab.base.objects.actors import (
+            as_Organization,
+            as_Service,
+        )
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        invitee_id = "https://example.org/users/late-joiner-retry"
+        case_actor_id = "https://example.org/actors/case-actor-lj2"
+        invitee = as_Organization(id_=invitee_id)
+        case_actor = as_Service(id_=case_actor_id, context="unused")
+        case = VulnerabilityCase(
+            id_="https://example.org/cases/caseLJ2",
+            name="TEST-LATE-JOIN-RESUME",
+        )
+        case_actor.context = case.id_
+        invite = rm_invite_to_case_activity(
+            invitee,
+            target=VulnerabilityCaseStub(id_=case.id_),
+            actor=case_actor_id,
+            id_=f"{case.id_}/invitations/1",
+        )
+        dl.create(invitee)
+        dl.create(case_actor)
+        dl.create(case)
+        dl.create(invite)
+
+        first = commit_log_entry_trigger(
+            case_id=case.id_,
+            object_id=f"{case.id_}/events/0",
+            event_type="submit_report",
+            actor_id=case_actor_id,
+            dl=dl,
+            payload_snapshot={"index": 0},
+        )
+        second = commit_log_entry_trigger(
+            case_id=case.id_,
+            object_id=f"{case.id_}/events/1",
+            event_type="add_participant_status",
+            actor_id=case_actor_id,
+            dl=dl,
+            payload_snapshot={"index": 1},
+        )
+
+        # Simulate interrupted run: participant already joined and first entry
+        # already replayed, but join-time backfill not complete.
+        state = VultronReplicationState(
+            case_id=case.id_,
+            peer_id=invitee_id,
+            join_backfill_target_index=1,
+            join_backfill_last_sent_index=0,
+            join_backfill_complete=False,
+        )
+        dl.save(state)
+
+        participant_case = cast(Any, dl.read(case.id_))
+        participant_case.actor_participant_index[invitee_id] = (
+            f"{case.id_}/participants/late-joiner-retry"
+        )
+        participant = cast(
+            Any,
+            dl.read(participant_case.actor_participant_index[invitee_id]),
+        )
+        if participant is None:
+            from vultron.core.models.vultron_types import VultronParticipant
+
+            participant = VultronParticipant(
+                id_=participant_case.actor_participant_index[invitee_id],
+                attributed_to=invitee_id,
+                context=case.id_,
+            )
+            dl.create(participant)
+        participant_case.case_participants.append(participant.id_)
+        dl.save(participant_case)
+
+        trigger_activity = MagicMock()
+        trigger_activity.announce_vulnerability_case.return_value = (
+            f"{case.id_}/announce/1"
+        )
+        sync_port = MagicMock()
+
+        accept = rm_accept_invite_to_case_activity(invite, actor=invitee_id)
+        event = make_payload(accept)
+        AcceptInviteActorToCaseReceivedUseCase(
+            dl,
+            event,
+            sync_port=sync_port,
+            trigger_activity=trigger_activity,
+        ).execute()
+
+        announced_entries = [
+            kwargs["entry"]
+            for _, kwargs in sync_port.send_announce_log_entry.call_args_list
+        ]
+        assert [entry.log_index for entry in announced_entries] == [1]
+        assert announced_entries[0].entry_hash == second.entry_hash
+        assert all(
+            entry.entry_hash != first.entry_hash for entry in announced_entries
+        )
+
+        state_id = VultronReplicationState(
+            case_id=case.id_, peer_id=invitee_id
+        ).id_
+        updated_state = cast(Any, dl.read(state_id))
+        assert updated_state.join_backfill_last_sent_index == 1
+        assert updated_state.join_backfill_complete is True
+
+    def test_accept_invite_resumes_when_participant_exists_without_marker(
+        self, make_payload
+    ):
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+        from vultron.core.models.vultron_types import VultronParticipant
+        from vultron.core.use_cases.triggers.sync import (
+            commit_log_entry_trigger,
+        )
+        from vultron.wire.as2.vocab.base.objects.actors import (
+            as_Organization,
+            as_Service,
+        )
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        invitee_id = "https://example.org/users/late-joiner-nomarker"
+        case_actor_id = "https://example.org/actors/case-actor-lj3"
+        invitee = as_Organization(id_=invitee_id)
+        case_actor = as_Service(id_=case_actor_id, context="unused")
+        case = VulnerabilityCase(
+            id_="https://example.org/cases/caseLJ3",
+            name="TEST-LATE-JOIN-NO-MARKER",
+        )
+        case_actor.context = case.id_
+        participant = VultronParticipant(
+            id_=f"{case.id_}/participants/late-joiner-nomarker",
+            attributed_to=invitee_id,
+            context=case.id_,
+        )
+        case.case_participants = [participant.id_]
+        case.actor_participant_index = {invitee_id: participant.id_}
+        invite = rm_invite_to_case_activity(
+            invitee,
+            target=VulnerabilityCaseStub(id_=case.id_),
+            actor=case_actor_id,
+            id_=f"{case.id_}/invitations/1",
+        )
+        dl.create(invitee)
+        dl.create(case_actor)
+        dl.create(participant)
+        dl.create(case)
+        dl.create(invite)
+
+        commit_log_entry_trigger(
+            case_id=case.id_,
+            object_id=f"{case.id_}/events/0",
+            event_type="submit_report",
+            actor_id=case_actor_id,
+            dl=dl,
+            payload_snapshot={"index": 0},
+        )
+        commit_log_entry_trigger(
+            case_id=case.id_,
+            object_id=f"{case.id_}/events/1",
+            event_type="add_participant_status",
+            actor_id=case_actor_id,
+            dl=dl,
+            payload_snapshot={"index": 1},
+        )
+
+        trigger_activity = MagicMock()
+        trigger_activity.announce_vulnerability_case.return_value = (
+            f"{case.id_}/announce/1"
+        )
+        sync_port = MagicMock()
+
+        accept = rm_accept_invite_to_case_activity(invite, actor=invitee_id)
+        event = make_payload(accept)
+        AcceptInviteActorToCaseReceivedUseCase(
+            dl,
+            event,
+            sync_port=sync_port,
+            trigger_activity=trigger_activity,
+        ).execute()
+
+        announced_entries = [
+            kwargs["entry"]
+            for _, kwargs in sync_port.send_announce_log_entry.call_args_list
+        ]
+        assert [entry.log_index for entry in announced_entries] == [0, 1]
+
+    def test_accept_invite_backfill_runs_when_announce_port_missing(
+        self, make_payload
+    ):
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+        from vultron.core.models.replication_state import (
+            VultronReplicationState,
+        )
+        from vultron.core.use_cases.triggers.sync import (
+            commit_log_entry_trigger,
+        )
+        from vultron.wire.as2.vocab.base.objects.actors import (
+            as_Organization,
+            as_Service,
+        )
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        invitee_id = "https://example.org/users/late-joiner-noannounce"
+        case_actor_id = "https://example.org/actors/case-actor-lj4"
+        invitee = as_Organization(id_=invitee_id)
+        case_actor = as_Service(id_=case_actor_id, context="unused")
+        case = VulnerabilityCase(
+            id_="https://example.org/cases/caseLJ4",
+            name="TEST-LATE-JOIN-NO-ANNOUNCE",
+        )
+        case_actor.context = case.id_
+        invite = rm_invite_to_case_activity(
+            invitee,
+            target=VulnerabilityCaseStub(id_=case.id_),
+            actor=case_actor_id,
+            id_=f"{case.id_}/invitations/1",
+        )
+        dl.create(invitee)
+        dl.create(case_actor)
+        dl.create(case)
+        dl.create(invite)
+
+        commit_log_entry_trigger(
+            case_id=case.id_,
+            object_id=f"{case.id_}/events/0",
+            event_type="submit_report",
+            actor_id=case_actor_id,
+            dl=dl,
+            payload_snapshot={"index": 0},
+        )
+        commit_log_entry_trigger(
+            case_id=case.id_,
+            object_id=f"{case.id_}/events/1",
+            event_type="add_participant_status",
+            actor_id=case_actor_id,
+            dl=dl,
+            payload_snapshot={"index": 1},
+        )
+
+        sync_port = MagicMock()
+        accept = rm_accept_invite_to_case_activity(invite, actor=invitee_id)
+        event = make_payload(accept)
+        AcceptInviteActorToCaseReceivedUseCase(
+            dl,
+            event,
+            sync_port=sync_port,
+            trigger_activity=None,
+        ).execute()
+
+        announced_entries = [
+            kwargs["entry"]
+            for _, kwargs in sync_port.send_announce_log_entry.call_args_list
+        ]
+        assert [entry.log_index for entry in announced_entries] == [0, 1]
+
+        state_id = VultronReplicationState(
+            case_id=case.id_, peer_id=invitee_id
+        ).id_
+        state = cast(Any, dl.read(state_id))
+        assert state is not None
+        assert state.join_backfill_complete is True

--- a/test/demo/test_two_actor_demo.py
+++ b/test/demo/test_two_actor_demo.py
@@ -975,6 +975,7 @@ class TestVerifyM1State:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.timeout(30)
 class TestRunTwoActorDemo:
     """Test the complete two-actor workflow via run_two_actor_demo."""
 

--- a/test/test_behavior_dispatcher.py
+++ b/test/test_behavior_dispatcher.py
@@ -1,13 +1,29 @@
 import logging
 from unittest.mock import MagicMock
 
+import pytest
+
 from vultron.core.dispatcher import DirectActivityDispatcher, get_dispatcher
 from vultron.core.models.activity import VultronActivity
 from vultron.core.models.events import (
+    AddNoteToCaseReceivedEvent,
+    AddParticipantStatusToParticipantReceivedEvent,
     CreateReportReceivedEvent,
     MessageSemantics,
+    RejectInviteToEmbargoOnCaseReceivedEvent,
 )
+from vultron.core.models.participant_status import ParticipantStatus
+from vultron.core.models.replication_state import VultronReplicationState
 from vultron.core.models.report import VultronReport
+from vultron.errors import VultronValidationError
+from vultron.wire.as2.factories import (
+    em_propose_embargo_activity,
+)
+from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    VulnerabilityCase,
+    VulnerabilityCaseStub,
+)
 
 
 def test_get_dispatcher_returns_local_dispatcher():
@@ -44,3 +60,165 @@ def test_local_dispatcher_dispatch_logs_payload(caplog):
 
     assert any("Dispatching" in m for m in info_msgs)
     assert any("act-xyz" in m for m in debug_msgs)
+
+
+def test_dispatcher_blocks_gated_semantic_when_join_backfill_incomplete():
+    mock_dl = MagicMock()
+    use_case_class = MagicMock()
+    dispatcher = DirectActivityDispatcher(
+        use_case_map={MessageSemantics.ADD_NOTE_TO_CASE: use_case_class}
+    )
+
+    actor_id = "https://example.org/users/late-joiner"
+    case = VulnerabilityCase(id_="https://example.org/cases/case-gate")
+    event = AddNoteToCaseReceivedEvent(
+        activity_id="act-gate-1",
+        actor_id=actor_id,
+        target=case,
+        activity=VultronActivity(type_="Add", actor=actor_id),
+    )
+    state_id = VultronReplicationState(
+        case_id=case.id_,
+        peer_id=actor_id,
+    ).id_
+    mock_dl.read.return_value = VultronReplicationState(
+        case_id=case.id_,
+        peer_id=actor_id,
+        join_backfill_target_index=3,
+        join_backfill_last_sent_index=1,
+        join_backfill_complete=False,
+    )
+
+    with pytest.raises(VultronValidationError) as excinfo:
+        dispatcher.dispatch(event, mock_dl)
+    exc = excinfo.value
+    assert "not caught up" in str(exc)
+    mock_dl.read.assert_called_with(state_id)
+    use_case_class.assert_not_called()
+
+
+def test_dispatcher_allows_gated_semantic_when_join_backfill_complete():
+    mock_dl = MagicMock()
+    use_case_instance = MagicMock()
+    use_case_class = MagicMock(return_value=use_case_instance)
+    dispatcher = DirectActivityDispatcher(
+        use_case_map={MessageSemantics.ADD_NOTE_TO_CASE: use_case_class}
+    )
+
+    actor_id = "https://example.org/users/late-joiner"
+    case = VulnerabilityCase(id_="https://example.org/cases/case-gate-ok")
+    event = AddNoteToCaseReceivedEvent(
+        activity_id="act-gate-2",
+        actor_id=actor_id,
+        target=case,
+        activity=VultronActivity(type_="Add", actor=actor_id),
+    )
+    mock_dl.read.return_value = VultronReplicationState(
+        case_id=case.id_,
+        peer_id=actor_id,
+        join_backfill_target_index=2,
+        join_backfill_last_sent_index=2,
+        join_backfill_complete=True,
+    )
+
+    dispatcher.dispatch(event, mock_dl)
+    use_case_class.assert_called_once()
+    use_case_instance.execute.assert_called_once()
+
+
+def test_dispatcher_uses_case_context_for_participant_status_gate():
+    mock_dl = MagicMock()
+    use_case_class = MagicMock()
+    dispatcher = DirectActivityDispatcher(
+        use_case_map={
+            MessageSemantics.ADD_PARTICIPANT_STATUS_TO_PARTICIPANT: use_case_class
+        }
+    )
+
+    actor_id = "https://example.org/users/late-joiner"
+    participant_id = "https://example.org/cases/case-gate-part/participants/p1"
+    case_id = "https://example.org/cases/case-gate-part"
+    event = AddParticipantStatusToParticipantReceivedEvent(
+        activity_id="act-gate-3",
+        actor_id=actor_id,
+        object_=ParticipantStatus(
+            id_=f"{participant_id}/status/1",
+            context=case_id,
+        ),
+        target=VulnerabilityCaseStub(id_=participant_id),
+        activity=VultronActivity(type_="Add", actor=actor_id),
+    )
+    state_id = VultronReplicationState(
+        case_id=case_id,
+        peer_id=actor_id,
+    ).id_
+    mock_dl.read.return_value = VultronReplicationState(
+        case_id=case_id,
+        peer_id=actor_id,
+        join_backfill_target_index=1,
+        join_backfill_last_sent_index=0,
+        join_backfill_complete=False,
+    )
+
+    with pytest.raises(VultronValidationError):
+        dispatcher.dispatch(event, mock_dl)
+
+    mock_dl.read.assert_called_with(state_id)
+    use_case_class.assert_not_called()
+
+
+def test_dispatcher_resolves_case_for_reject_embargo_invite_gate():
+    mock_dl = MagicMock()
+    use_case_class = MagicMock()
+    dispatcher = DirectActivityDispatcher(
+        use_case_map={
+            MessageSemantics.REJECT_INVITE_TO_EMBARGO_ON_CASE: use_case_class
+        }
+    )
+
+    actor_id = "https://example.org/users/late-joiner"
+    case_id = "https://example.org/cases/case-gate-embargo"
+    invite = em_propose_embargo_activity(
+        embargo=EmbargoEvent(
+            id_=f"{case_id}/embargo_events/e1", content="Embargo proposal"
+        ),
+        context=case_id,
+        actor="https://example.org/users/vendor",
+        id_=f"{case_id}/embargo_proposals/1",
+    )
+    event = RejectInviteToEmbargoOnCaseReceivedEvent(
+        activity_id="act-gate-4",
+        actor_id=actor_id,
+        object_=invite,
+        activity=VultronActivity(type_="Reject", actor=actor_id),
+    )
+    state_id = VultronReplicationState(
+        case_id=case_id,
+        peer_id=actor_id,
+    ).id_
+
+    def _read_side_effect(object_id: str):
+        if object_id == invite.id_:
+            return invite
+        if object_id == state_id:
+            return VultronReplicationState(
+                case_id=case_id,
+                peer_id=actor_id,
+                join_backfill_target_index=2,
+                join_backfill_last_sent_index=1,
+                join_backfill_complete=False,
+            )
+        return None
+
+    mock_dl.read.side_effect = _read_side_effect
+
+    with pytest.raises(VultronValidationError):
+        dispatcher.dispatch(event, mock_dl)
+
+    assert any(
+        call.args == (invite.id_,) for call in mock_dl.read.call_args_list
+    )
+    assert any(
+        call.args == (state_id,) for call in mock_dl.read.call_args_list
+    )
+    use_case_class.assert_not_called()

--- a/test/test_behavior_dispatcher.py
+++ b/test/test_behavior_dispatcher.py
@@ -144,6 +144,33 @@ def test_dispatcher_allows_gated_semantic_with_contiguous_prefix_but_tip_lag():
     use_case_instance.execute.assert_called_once()
 
 
+def test_dispatcher_allows_gated_semantic_without_replication_state():
+    mock_dl = MagicMock()
+    use_case_instance = MagicMock()
+    use_case_class = MagicMock(return_value=use_case_instance)
+    dispatcher = DirectActivityDispatcher(
+        use_case_map={MessageSemantics.ADD_NOTE_TO_CASE: use_case_class}
+    )
+
+    actor_id = "https://example.org/users/case-owner"
+    case = VulnerabilityCase(id_="https://example.org/cases/case-gate-owner")
+    event = AddNoteToCaseReceivedEvent(
+        activity_id="act-gate-owner",
+        actor_id=actor_id,
+        target=case,
+        activity=VultronActivity(type_="Add", actor=actor_id),
+    )
+    mock_dl.list_objects.return_value = [
+        _LedgerEntry(case_id=case.id_, log_index=0),
+        _LedgerEntry(case_id=case.id_, log_index=1),
+    ]
+    mock_dl.read.return_value = None
+
+    dispatcher.dispatch(event, mock_dl)
+    use_case_class.assert_called_once()
+    use_case_instance.execute.assert_called_once()
+
+
 def test_dispatcher_blocks_when_case_ledger_prefix_has_gaps():
     mock_dl = MagicMock()
     use_case_class = MagicMock()

--- a/test/test_behavior_dispatcher.py
+++ b/test/test_behavior_dispatcher.py
@@ -1,4 +1,5 @@
 import logging
+from dataclasses import dataclass
 from unittest.mock import MagicMock
 
 import pytest
@@ -24,6 +25,12 @@ from vultron.wire.as2.vocab.objects.vulnerability_case import (
     VulnerabilityCase,
     VulnerabilityCaseStub,
 )
+
+
+@dataclass
+class _LedgerEntry:
+    case_id: str
+    log_index: int
 
 
 def test_get_dispatcher_returns_local_dispatcher():
@@ -62,7 +69,7 @@ def test_local_dispatcher_dispatch_logs_payload(caplog):
     assert any("act-xyz" in m for m in debug_msgs)
 
 
-def test_dispatcher_blocks_gated_semantic_when_join_backfill_incomplete():
+def test_dispatcher_blocks_gated_semantic_without_contiguous_genesis_prefix():
     mock_dl = MagicMock()
     use_case_class = MagicMock()
     dispatcher = DirectActivityDispatcher(
@@ -81,23 +88,28 @@ def test_dispatcher_blocks_gated_semantic_when_join_backfill_incomplete():
         case_id=case.id_,
         peer_id=actor_id,
     ).id_
+    mock_dl.list_objects.return_value = [
+        _LedgerEntry(case_id=case.id_, log_index=0),
+        _LedgerEntry(case_id=case.id_, log_index=1),
+        _LedgerEntry(case_id=case.id_, log_index=2),
+    ]
     mock_dl.read.return_value = VultronReplicationState(
         case_id=case.id_,
         peer_id=actor_id,
         join_backfill_target_index=3,
-        join_backfill_last_sent_index=1,
+        join_backfill_last_sent_index=-1,
         join_backfill_complete=False,
     )
 
     with pytest.raises(VultronValidationError) as excinfo:
         dispatcher.dispatch(event, mock_dl)
     exc = excinfo.value
-    assert "not caught up" in str(exc)
+    assert "no contiguous canonical ledger prefix" in str(exc)
     mock_dl.read.assert_called_with(state_id)
     use_case_class.assert_not_called()
 
 
-def test_dispatcher_allows_gated_semantic_when_join_backfill_complete():
+def test_dispatcher_allows_gated_semantic_with_contiguous_prefix_but_tip_lag():
     mock_dl = MagicMock()
     use_case_instance = MagicMock()
     use_case_class = MagicMock(return_value=use_case_instance)
@@ -113,17 +125,63 @@ def test_dispatcher_allows_gated_semantic_when_join_backfill_complete():
         target=case,
         activity=VultronActivity(type_="Add", actor=actor_id),
     )
+    mock_dl.list_objects.return_value = [
+        _LedgerEntry(case_id=case.id_, log_index=0),
+        _LedgerEntry(case_id=case.id_, log_index=1),
+        _LedgerEntry(case_id=case.id_, log_index=2),
+        _LedgerEntry(case_id=case.id_, log_index=3),
+    ]
     mock_dl.read.return_value = VultronReplicationState(
         case_id=case.id_,
         peer_id=actor_id,
-        join_backfill_target_index=2,
-        join_backfill_last_sent_index=2,
-        join_backfill_complete=True,
+        join_backfill_target_index=3,
+        join_backfill_last_sent_index=1,
+        join_backfill_complete=False,
     )
 
     dispatcher.dispatch(event, mock_dl)
     use_case_class.assert_called_once()
     use_case_instance.execute.assert_called_once()
+
+
+def test_dispatcher_blocks_when_case_ledger_prefix_has_gaps():
+    mock_dl = MagicMock()
+    use_case_class = MagicMock()
+    dispatcher = DirectActivityDispatcher(
+        use_case_map={MessageSemantics.ADD_NOTE_TO_CASE: use_case_class}
+    )
+
+    actor_id = "https://example.org/users/late-joiner-gap"
+    case = VulnerabilityCase(id_="https://example.org/cases/case-gate-gap")
+    event = AddNoteToCaseReceivedEvent(
+        activity_id="act-gate-gap",
+        actor_id=actor_id,
+        target=case,
+        activity=VultronActivity(type_="Add", actor=actor_id),
+    )
+    state_id = VultronReplicationState(
+        case_id=case.id_,
+        peer_id=actor_id,
+    ).id_
+    mock_dl.list_objects.return_value = [
+        _LedgerEntry(case_id=case.id_, log_index=1),
+        _LedgerEntry(case_id=case.id_, log_index=3),
+        _LedgerEntry(case_id=case.id_, log_index=5),
+        _LedgerEntry(case_id=case.id_, log_index=6),
+    ]
+    mock_dl.read.return_value = VultronReplicationState(
+        case_id=case.id_,
+        peer_id=actor_id,
+        join_backfill_target_index=6,
+        join_backfill_last_sent_index=1,
+        join_backfill_complete=False,
+    )
+
+    with pytest.raises(VultronValidationError):
+        dispatcher.dispatch(event, mock_dl)
+
+    mock_dl.read.assert_called_with(state_id)
+    use_case_class.assert_not_called()
 
 
 def test_dispatcher_uses_case_context_for_participant_status_gate():
@@ -152,11 +210,15 @@ def test_dispatcher_uses_case_context_for_participant_status_gate():
         case_id=case_id,
         peer_id=actor_id,
     ).id_
+    mock_dl.list_objects.return_value = [
+        _LedgerEntry(case_id=case_id, log_index=0),
+        _LedgerEntry(case_id=case_id, log_index=1),
+    ]
     mock_dl.read.return_value = VultronReplicationState(
         case_id=case_id,
         peer_id=actor_id,
         join_backfill_target_index=1,
-        join_backfill_last_sent_index=0,
+        join_backfill_last_sent_index=-1,
         join_backfill_complete=False,
     )
 
@@ -205,12 +267,17 @@ def test_dispatcher_resolves_case_for_reject_embargo_invite_gate():
                 case_id=case_id,
                 peer_id=actor_id,
                 join_backfill_target_index=2,
-                join_backfill_last_sent_index=1,
+                join_backfill_last_sent_index=-1,
                 join_backfill_complete=False,
             )
         return None
 
     mock_dl.read.side_effect = _read_side_effect
+    mock_dl.list_objects.return_value = [
+        _LedgerEntry(case_id=case_id, log_index=0),
+        _LedgerEntry(case_id=case_id, log_index=1),
+        _LedgerEntry(case_id=case_id, log_index=2),
+    ]
 
     with pytest.raises(VultronValidationError):
         dispatcher.dispatch(event, mock_dl)

--- a/vultron/adapters/driving/fastapi/inbox_handler.py
+++ b/vultron/adapters/driving/fastapi/inbox_handler.py
@@ -117,7 +117,6 @@ _TRIGGER_ACTIVITY_PORT_SEMANTICS = frozenset(
         MessageSemantics.ACCEPT_CASE_MANAGER_ROLE,
         MessageSemantics.OFFER_CASE_MANAGER_ROLE,
         MessageSemantics.SUGGEST_ACTOR_TO_CASE,
-        MessageSemantics.ACCEPT_INVITE_ACTOR_TO_CASE,
         MessageSemantics.VALIDATE_REPORT,
     }
 )
@@ -131,6 +130,7 @@ _SYNC_AND_TRIGGER_PORT_SEMANTICS = frozenset(
     {
         MessageSemantics.ADD_NOTE_TO_CASE,
         MessageSemantics.ADD_PARTICIPANT_STATUS_TO_PARTICIPANT,
+        MessageSemantics.ACCEPT_INVITE_ACTOR_TO_CASE,
         MessageSemantics.DEFER_CASE,
         MessageSemantics.ENGAGE_CASE,
         MessageSemantics.SUBMIT_REPORT,

--- a/vultron/core/behaviors/case/accept_invite_tree.py
+++ b/vultron/core/behaviors/case/accept_invite_tree.py
@@ -40,9 +40,16 @@ import py_trees
 from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
+from vultron.core.models.protocols import (
+    LogEntryModel,
+    is_log_entry_model,
+    is_participant_model,
+)
+from vultron.core.models.replication_state import VultronReplicationState
 from vultron.core.models.protocols import is_case_model
 from vultron.core.models.vultron_types import VultronParticipant
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
+from vultron.core.ports.sync_activity import SyncActivityPort
 from vultron.core.states.em import EM
 from vultron.core.states.participant_embargo_consent import (
     PEC,
@@ -76,6 +83,10 @@ class CheckInviteeNotAlreadyParticipantNode(DataLayerCondition):
             key="invitee_case",
             access=py_trees.common.Access.WRITE,
         )
+        self.blackboard.register_key(
+            key="invitee_already_participant",
+            access=py_trees.common.Access.WRITE,
+        )
 
     def update(self) -> Status:
         if self.datalayer is None:
@@ -92,22 +103,64 @@ class CheckInviteeNotAlreadyParticipantNode(DataLayerCondition):
             return Status.FAILURE
 
         existing_ids = [_as_id(p) for p in case.case_participants]
-        if (
+        already_participant = (
             self.invitee_id in case.actor_participant_index
             or self.invitee_id in existing_ids
-        ):
-            self.logger.info(
-                "%s: actor '%s' already participant in case '%s'"
-                " — skipping (idempotent)",
-                self.name,
-                self.invitee_id,
-                self.case_id,
-            )
-            return Status.FAILURE
+        )
+        if already_participant:
+            state = self._read_replication_state(case.id_)
+            if state is not None and (
+                state.join_backfill_complete
+                or state.join_backfill_target_index == -1
+            ):
+                self.logger.info(
+                    "%s: actor '%s' already participant in case '%s'"
+                    " — skipping (idempotent)",
+                    self.name,
+                    self.invitee_id,
+                    self.case_id,
+                )
+                self.blackboard.invitee_already_participant = True
+                return Status.FAILURE
+
+            if state is None:
+                self.logger.info(
+                    "%s: actor '%s' already participant in case '%s' with no "
+                    "replication marker; resuming join-time backfill",
+                    self.name,
+                    self.invitee_id,
+                    self.case_id,
+                )
+            else:
+                self.logger.info(
+                    "%s: actor '%s' already participant in case '%s' but"
+                    " backfill is incomplete; resuming join-time backfill",
+                    self.name,
+                    self.invitee_id,
+                    self.case_id,
+                )
+            self.blackboard.invitee_already_participant = True
+            self.blackboard.invitee_case = case
+            return Status.SUCCESS
 
         # Cache the case object for downstream nodes
+        self.blackboard.invitee_already_participant = False
         self.blackboard.invitee_case = case
         return Status.SUCCESS
+
+    def _read_replication_state(
+        self, case_id: str
+    ) -> VultronReplicationState | None:
+        if self.datalayer is None:
+            return None
+        state_id = VultronReplicationState(
+            case_id=case_id,
+            peer_id=self.invitee_id,
+        ).id_
+        state = self.datalayer.read(state_id)
+        if isinstance(state, VultronReplicationState):
+            return state
+        return None
 
 
 class CreateInviteeParticipantAtAcceptedNode(DataLayerAction):
@@ -131,6 +184,10 @@ class CreateInviteeParticipantAtAcceptedNode(DataLayerAction):
     def setup(self, **kwargs) -> None:
         super().setup(**kwargs)
         self.blackboard.register_key(
+            key="invitee_already_participant",
+            access=py_trees.common.Access.READ,
+        )
+        self.blackboard.register_key(
             key="invitee_case",
             access=py_trees.common.Access.READ,
         )
@@ -140,12 +197,44 @@ class CreateInviteeParticipantAtAcceptedNode(DataLayerAction):
         )
 
     def update(self) -> Status:
+        if self.datalayer is None:
+            self.logger.error("%s: DataLayer not available", self.name)
+            return Status.FAILURE
+
         case = self.blackboard.get("invitee_case")
         if not is_case_model(case):
             self.logger.error(
                 "%s: invitee_case not found in blackboard", self.name
             )
             return Status.FAILURE
+
+        if self.blackboard.get("invitee_already_participant"):
+            participant_id = case.actor_participant_index.get(self.invitee_id)
+            if participant_id is None:
+                self.logger.error(
+                    "%s: invitee marked as existing but no participant ID"
+                    " found for actor '%s'",
+                    self.name,
+                    self.invitee_id,
+                )
+                return Status.FAILURE
+            existing = self.datalayer.read(participant_id)
+            if not is_participant_model(existing):
+                self.logger.error(
+                    "%s: expected existing participant '%s'",
+                    self.name,
+                    participant_id,
+                )
+                return Status.FAILURE
+            self.blackboard.new_invite_participant = cast(
+                VultronParticipant, existing
+            )
+            self.logger.info(
+                "%s: reusing existing participant '%s' for backfill resume",
+                self.name,
+                participant_id,
+            )
+            return Status.SUCCESS
 
         participant = VultronParticipant(
             id_=f"{self.case_id}/participants/{self.invitee_id.split('/')[-1]}",
@@ -320,6 +409,10 @@ class PersistInviteeParticipantNode(DataLayerAction):
     def setup(self, **kwargs) -> None:
         super().setup(**kwargs)
         self.blackboard.register_key(
+            key="invitee_already_participant",
+            access=py_trees.common.Access.READ,
+        )
+        self.blackboard.register_key(
             key="new_invite_participant",
             access=py_trees.common.Access.READ,
         )
@@ -336,6 +429,9 @@ class PersistInviteeParticipantNode(DataLayerAction):
         if self.datalayer is None:
             self.logger.error("%s: DataLayer not available", self.name)
             return Status.FAILURE
+
+        if self.blackboard.get("invitee_already_participant"):
+            return Status.SUCCESS
 
         participant = self.blackboard.get("new_invite_participant")
         case = self.blackboard.get("invitee_case")
@@ -367,13 +463,139 @@ class PersistInviteeParticipantNode(DataLayerAction):
         return Status.SUCCESS
 
 
+class BackfillCanonicalLedgerToInviteeNode(DataLayerAction):
+    """Send canonical CaseLedgerEntry history to a joiner in strict order."""
+
+    def __init__(
+        self, case_id: str, invitee_id: str, name: str | None = None
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self.case_id = case_id
+        self.invitee_id = invitee_id
+        self._sync_port: SyncActivityPort | None = None
+
+    def setup(self, **kwargs) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="sync_port", access=py_trees.common.Access.READ
+        )
+
+    def initialise(self) -> None:
+        super().initialise()
+        try:
+            self._sync_port = cast(SyncActivityPort, self.blackboard.sync_port)
+        except (AttributeError, KeyError):
+            self._sync_port = None
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.logger.error("%s: DataLayer not available", self.name)
+            return Status.FAILURE
+        if self.actor_id is None:
+            self.logger.error("%s: actor_id not available", self.name)
+            return Status.FAILURE
+        if self._sync_port is None:
+            self.logger.error(
+                "%s: sync_port not injected; cannot perform join-time backfill",
+                self.name,
+            )
+            return Status.FAILURE
+
+        entries: list[LogEntryModel] = [
+            obj
+            for obj in self.datalayer.list_objects("CaseLedgerEntry")
+            if is_log_entry_model(obj) and obj.case_id == self.case_id
+        ]
+        entries.sort(key=lambda log_entry: log_entry.log_index)
+
+        target_index = entries[-1].log_index if entries else -1
+        state = self._load_or_create_state(target_index)
+
+        if state.join_backfill_complete:
+            self.logger.info(
+                "%s: join-time backfill already complete for '%s' in case '%s'"
+                " at log_index=%d",
+                self.name,
+                self.invitee_id,
+                self.case_id,
+                state.join_backfill_last_sent_index,
+            )
+            return Status.SUCCESS
+
+        if state.join_backfill_last_sent_index >= target_index:
+            state.join_backfill_complete = True
+            self.datalayer.save(state)
+            return Status.SUCCESS
+
+        for entry in entries:
+            if entry.log_index <= state.join_backfill_last_sent_index:
+                continue
+            self._sync_port.send_announce_log_entry(
+                entry=entry,
+                actor_id=self.actor_id,
+                to=[self.invitee_id],
+            )
+            state.join_backfill_last_sent_index = entry.log_index
+            self.datalayer.save(state)
+
+        state.join_backfill_complete = (
+            state.join_backfill_last_sent_index
+            >= state.join_backfill_target_index
+        )
+        self.datalayer.save(state)
+        self.logger.info(
+            "%s: join-time backfill complete for '%s' in case '%s'"
+            " (target_log_index=%d)",
+            self.name,
+            self.invitee_id,
+            self.case_id,
+            state.join_backfill_target_index,
+        )
+        return Status.SUCCESS
+
+    def _load_or_create_state(
+        self, target_index: int
+    ) -> VultronReplicationState:
+        if self.datalayer is None:
+            raise RuntimeError(
+                "_load_or_create_state requires an injected DataLayer"
+            )
+        dl = self.datalayer
+        state_id = VultronReplicationState(
+            case_id=self.case_id, peer_id=self.invitee_id
+        ).id_
+        existing = dl.read(state_id)
+        if isinstance(existing, VultronReplicationState):
+            existing.join_backfill_target_index = max(
+                existing.join_backfill_target_index,
+                target_index,
+            )
+            if (
+                existing.join_backfill_last_sent_index
+                < existing.join_backfill_target_index
+            ):
+                existing.join_backfill_complete = False
+            dl.save(existing)
+            return existing
+        state = VultronReplicationState(
+            case_id=self.case_id,
+            peer_id=self.invitee_id,
+            join_backfill_target_index=target_index,
+            join_backfill_last_sent_index=-1,
+            join_backfill_complete=(target_index == -1),
+        )
+        dl.save(state)
+        return state
+
+
 class EmitAnnounceCaseToInviteeNode(DataLayerAction):
     """Queue Announce(VulnerabilityCase) to the invitee from the CaseActor.
 
     Per MV-10-003/MV-10-005, the CaseActor sends the full case object after
     embargo consent has been resolved (auto-signed above when EM.ACTIVE).
-    FAILURE is returned if the trigger-activity factory is unavailable — the
-    caller should log a warning but is not required to abort.
+    Failures to enqueue Announce are logged but treated as non-fatal so the
+    join-time canonical ledger backfill can still run and establish catch-up
+    markers.
     """
 
     def __init__(
@@ -399,7 +621,7 @@ class EmitAnnounceCaseToInviteeNode(DataLayerAction):
                 self.name,
                 self.case_id,
             )
-            return Status.FAILURE
+            return Status.SUCCESS
 
         try:
             activity_id = factory.announce_vulnerability_case(
@@ -429,7 +651,7 @@ class EmitAnnounceCaseToInviteeNode(DataLayerAction):
                 self.invitee_id,
                 exc,
             )
-            return Status.FAILURE
+            return Status.SUCCESS
 
 
 def create_accept_invite_actor_to_case_tree(
@@ -477,6 +699,9 @@ def create_accept_invite_actor_to_case_tree(
             EmitAnnounceCaseToInviteeNode(
                 case_id=case_id, invitee_id=invitee_id
             ),
+            BackfillCanonicalLedgerToInviteeNode(
+                case_id=case_id, invitee_id=invitee_id
+            ),
         ],
     )
 
@@ -487,5 +712,6 @@ __all__ = [
     "MaybeSignEmbargoConsentNode",
     "PersistInviteeParticipantNode",
     "EmitAnnounceCaseToInviteeNode",
+    "BackfillCanonicalLedgerToInviteeNode",
     "create_accept_invite_actor_to_case_tree",
 ]

--- a/vultron/core/behaviors/sender/nodes/actions.py
+++ b/vultron/core/behaviors/sender/nodes/actions.py
@@ -41,8 +41,8 @@ class ResolveCaseManagerNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
+        if self.datalayer is None or self.actor_id is None:
+            self.feedback_message = "DataLayer or actor_id not available"
             return Status.FAILURE
 
         case = self.datalayer.read(self.case_id)

--- a/vultron/core/dispatcher.py
+++ b/vultron/core/dispatcher.py
@@ -27,15 +27,32 @@ import logging
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Callable
 
+from vultron.core.models.replication_state import VultronReplicationState
 from vultron.core.models.events import MessageSemantics
 from vultron.core.ports.dispatcher import ActivityDispatcher
-from vultron.errors import VultronApiHandlerNotFoundError
+from vultron.errors import (
+    VultronApiHandlerNotFoundError,
+    VultronValidationError,
+)
 
 if TYPE_CHECKING:
     from vultron.core.models.events import VultronEvent
     from vultron.core.ports.datalayer import DataLayer
 
 logger = logging.getLogger(__name__)
+
+_JOIN_BACKFILL_GATED_SEMANTICS = frozenset(
+    {
+        MessageSemantics.ACCEPT_INVITE_TO_EMBARGO_ON_CASE,
+        MessageSemantics.ADD_NOTE_TO_CASE,
+        MessageSemantics.ADD_PARTICIPANT_STATUS_TO_PARTICIPANT,
+        MessageSemantics.DEFER_CASE,
+        MessageSemantics.ENGAGE_CASE,
+        MessageSemantics.INVITE_TO_EMBARGO_ON_CASE,
+        MessageSemantics.REJECT_INVITE_TO_EMBARGO_ON_CASE,
+        MessageSemantics.REMOVE_EMBARGO_EVENT_FROM_CASE,
+    }
+)
 
 
 class DispatcherBase:
@@ -80,6 +97,7 @@ class DispatcherBase:
         self._handle(event, dl)
 
     def _handle(self, event: "VultronEvent", dl: "DataLayer") -> None:
+        self._enforce_join_backfill_gate(event, dl)
         use_case_class = self._get_use_case(event.semantic_type)
         extra_kwargs: dict[str, Any] = {}
         port_factory = self._port_factories.get(event.semantic_type)
@@ -96,6 +114,70 @@ class DispatcherBase:
                 exc_info=True,
             )
             raise
+
+    def _enforce_join_backfill_gate(
+        self, event: "VultronEvent", dl: "DataLayer"
+    ) -> None:
+        if event.semantic_type not in _JOIN_BACKFILL_GATED_SEMANTICS:
+            return
+        sender_id = event.actor_id
+        if not sender_id:
+            return
+        case_id = self._extract_case_id(event, dl)
+        if not case_id:
+            return
+        state_id = VultronReplicationState(
+            case_id=case_id,
+            peer_id=sender_id,
+        ).id_
+        state = dl.read(state_id)
+        if not isinstance(state, VultronReplicationState):
+            return
+        if state.join_backfill_target_index == -1:
+            return
+        if state.join_backfill_complete:
+            return
+        raise VultronValidationError(
+            f"Actor '{sender_id}' is not caught up for case '{case_id}' "
+            "(join-time backfill incomplete)."
+        )
+
+    def _extract_case_id(
+        self, event: "VultronEvent", dl: "DataLayer"
+    ) -> str | None:
+        if (
+            event.semantic_type
+            == MessageSemantics.ADD_PARTICIPANT_STATUS_TO_PARTICIPANT
+        ):
+            status_obj = getattr(event, "object_", None)
+            status_context = getattr(status_obj, "context", None)
+            if isinstance(status_context, str) and status_context:
+                return status_context
+        if (
+            event.semantic_type
+            == MessageSemantics.REJECT_INVITE_TO_EMBARGO_ON_CASE
+        ):
+            invite_id = getattr(event, "invite_id", None)
+            if isinstance(invite_id, str) and invite_id:
+                invite = dl.read(invite_id)
+                invite_context = getattr(invite, "context", None)
+                if isinstance(invite_context, str) and invite_context:
+                    return invite_context
+                invite_context_id = getattr(invite, "context_id", None)
+                if isinstance(invite_context_id, str) and invite_context_id:
+                    return invite_context_id
+        for attr in (
+            "case_id",
+            "inner_context_id",
+            "context_id",
+            "origin_id",
+            "inner_target_id",
+            "target_id",
+        ):
+            value = getattr(event, attr, None)
+            if isinstance(value, str) and value:
+                return value
+        return None
 
     def _get_use_case(self, semantics: MessageSemantics) -> type:
         use_case_class = self._use_case_map.get(semantics)

--- a/vultron/core/dispatcher.py
+++ b/vultron/core/dispatcher.py
@@ -137,11 +137,7 @@ class DispatcherBase:
         ).id_
         state = dl.read(state_id)
         if not isinstance(state, VultronReplicationState):
-            raise VultronValidationError(
-                f"Actor '{sender_id}' has no replication state for case "
-                f"'{case_id}' and cannot prove contiguous ledger coverage "
-                "from genesis."
-            )
+            return
         if state.join_backfill_last_sent_index < 0:
             raise VultronValidationError(
                 f"Actor '{sender_id}' has no contiguous canonical ledger "

--- a/vultron/core/dispatcher.py
+++ b/vultron/core/dispatcher.py
@@ -126,21 +126,52 @@ class DispatcherBase:
         case_id = self._extract_case_id(event, dl)
         if not case_id:
             return
+        highest_contiguous_index, has_case_entries = (
+            self._highest_contiguous_case_log_index(case_id, dl)
+        )
+        if not has_case_entries:
+            return
         state_id = VultronReplicationState(
             case_id=case_id,
             peer_id=sender_id,
         ).id_
         state = dl.read(state_id)
         if not isinstance(state, VultronReplicationState):
-            return
-        if state.join_backfill_target_index == -1:
-            return
-        if state.join_backfill_complete:
-            return
-        raise VultronValidationError(
-            f"Actor '{sender_id}' is not caught up for case '{case_id}' "
-            "(join-time backfill incomplete)."
+            raise VultronValidationError(
+                f"Actor '{sender_id}' has no replication state for case "
+                f"'{case_id}' and cannot prove contiguous ledger coverage "
+                "from genesis."
+            )
+        if state.join_backfill_last_sent_index < 0:
+            raise VultronValidationError(
+                f"Actor '{sender_id}' has no contiguous canonical ledger "
+                f"prefix for case '{case_id}' (genesis backfill not started)."
+            )
+        if state.join_backfill_last_sent_index > highest_contiguous_index:
+            raise VultronValidationError(
+                f"Actor '{sender_id}' reported join backfill index "
+                f"{state.join_backfill_last_sent_index} for case '{case_id}', "
+                "but the canonical ledger prefix is not contiguous to that "
+                "index."
+            )
+
+    def _highest_contiguous_case_log_index(
+        self, case_id: str, dl: "DataLayer"
+    ) -> tuple[int, bool]:
+        case_indices = sorted(
+            int(getattr(obj, "log_index"))
+            for obj in dl.list_objects("CaseLedgerEntry")
+            if getattr(obj, "case_id", None) == case_id
+            and isinstance(getattr(obj, "log_index", None), int)
         )
+        if not case_indices:
+            return -1, False
+        expected = 0
+        for index in case_indices:
+            if index != expected:
+                break
+            expected += 1
+        return expected - 1, True
 
     def _extract_case_id(
         self, event: "VultronEvent", dl: "DataLayer"

--- a/vultron/core/models/replication_state.py
+++ b/vultron/core/models/replication_state.py
@@ -61,10 +61,54 @@ class VultronReplicationState(VultronObject):
         validation_alias="updatedAt",
         serialization_alias="updatedAt",
     )
+    join_backfill_target_index: int = Field(
+        default=-1,
+        description=(
+            "Highest canonical log_index expected for join-time backfill; -1"
+            " means no canonical entries existed when backfill started"
+        ),
+        validation_alias="joinBackfillTargetIndex",
+        serialization_alias="joinBackfillTargetIndex",
+    )
+    join_backfill_last_sent_index: int = Field(
+        default=-1,
+        description=(
+            "Highest canonical log_index sent to this peer during join-time"
+            " backfill; -1 means nothing sent yet"
+        ),
+        validation_alias="joinBackfillLastSentIndex",
+        serialization_alias="joinBackfillLastSentIndex",
+    )
+    join_backfill_complete: bool = Field(
+        default=True,
+        description=(
+            "Whether join-time canonical history backfill is complete for this"
+            " peer"
+        ),
+        validation_alias="joinBackfillComplete",
+        serialization_alias="joinBackfillComplete",
+    )
 
     @model_validator(mode="after")
     def _set_id(self) -> "VultronReplicationState":
         """Compute ``id_`` deterministically from ``case_id`` and ``peer_id``."""
         slug = urllib.parse.quote(self.peer_id, safe="")
         self.id_ = f"{self.case_id}/replication/{slug}"
+        if (
+            self.join_backfill_last_sent_index
+            > self.join_backfill_target_index
+        ):
+            raise ValueError(
+                "join_backfill_last_sent_index cannot exceed "
+                "join_backfill_target_index"
+            )
+        if (
+            self.join_backfill_complete
+            and self.join_backfill_last_sent_index
+            < self.join_backfill_target_index
+        ):
+            raise ValueError(
+                "join_backfill_complete=True requires last_sent_index >= "
+                "target_index"
+            )
         return self

--- a/vultron/core/use_cases/received/actor/invite.py
+++ b/vultron/core/use_cases/received/actor/invite.py
@@ -18,6 +18,7 @@ from vultron.core.ports.case_persistence import (
     CaseOutboxPersistence,
     CasePersistence,
 )
+from vultron.core.ports.sync_activity import SyncActivityPort
 from vultron.core.use_cases._helpers import (
     _find_case_actor_id,
     _idempotent_create,
@@ -74,10 +75,12 @@ class AcceptInviteActorToCaseReceivedUseCase:
         self,
         dl: CaseOutboxPersistence,
         request: AcceptInviteActorToCaseReceivedEvent,
+        sync_port: SyncActivityPort,
         trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: AcceptInviteActorToCaseReceivedEvent = request
+        self._sync_port = sync_port
         self._trigger_activity = trigger_activity
 
     def execute(self) -> None:
@@ -115,6 +118,7 @@ class AcceptInviteActorToCaseReceivedUseCase:
             ),
             actor_id=actor_id,
             activity=request,
+            sync_port=self._sync_port,
         )
 
         if result.status == Status.FAILURE:


### PR DESCRIPTION
- Closes #961

## Summary

Implements join-time canonical CaseLedgerEntry backfill for late joiners and tracks resumable catch-up progress in replication state so participants cannot send gated activities until they are caught up.

## Changes

- `vultron/core/models/replication_state.py`: added join-backfill progress markers (`target_index`, `last_sent_index`, `complete`) with consistency validation.
- `vultron/core/behaviors/case/accept_invite_tree.py`: added resumable backfill node that replays canonical ledger entries in order, persists progress after each send, and supports idempotent resume paths.
- `vultron/core/use_cases/received/actor/invite.py`: made `sync_port` required for accept-invite execution and passed it into BT setup.
- `vultron/adapters/driving/fastapi/inbox_handler.py`: wired `ACCEPT_INVITE_ACTOR_TO_CASE` through sync+trigger port injection.
- `vultron/core/dispatcher.py`: added join-backfill gating for selected participant-originated semantics with semantic-safe case-id resolution.
- `test/core/use_cases/received/actor/test_invite.py`: added regression coverage for genesis backfill, interrupted resume, missing-marker resume, and announce-port-missing continuation.
- `test/test_behavior_dispatcher.py`: added gating tests for blocked/allowed dispatch, participant-status case resolution, and embargo-reject invite resolution.

## Verification

- `uv run pytest --tb=short 2>&1 | tail -5` → `3259 passed, 34 skipped, 225 deselected, 2 xfailed, 5633 subtests passed`
- `uv run pytest test/test_behavior_dispatcher.py test/core/use_cases/received/actor/test_invite.py -v` → `18 passed`
- `uv run flake8 vultron/ test/`
- `uv run mypy`
- `uv run pyright`
