### PR TITLE
docs: promote two-week learning gaps into durable guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -588,6 +588,19 @@ Short entries are reproduced here; longer ones are referenced below.
   `ACTIVE → REVISE` transition; a counter-revision must leave PEC states
   unchanged. Tests that only cover `ACTIVE → REVISE` do not verify this
   invariant.
+- **RM Terminal Guard Must Run Before Same-State Shortcut** —
+  `ValidateRMTransitionNode` (and equivalent validators) must evaluate
+  terminal `RM.CLOSED` rules before `current == new` no-op checks. Otherwise
+  repeated `CLOSED -> CLOSED` retries can flow into append/broadcast paths and
+  produce duplicate canonical ledger entries.
+- **Do Not Downgrade Existing Consent on Idempotent Retries** —
+  when reusing a report-phase `ParticipantStatus` during embargo
+  accept/reject retries, preserve any non-null existing consent value; never
+  overwrite it with default `NO_EMBARGO` during "upsert" paths.
+- **Case-Ledger Demo Endpoint Returns Combined View in Single-DL Tests** —
+  `demo_get_case_ledger` currently ignores `actor_id` in single-DataLayer
+  test setups and returns a combined case log. Use replica JSONL artifacts for
+  per-actor assertions and name helpers accordingly (`_fetch_case_log`).
 - **DataLayer Scope Tests: Use `call_args.args`, Not `call_args[0]`** —
   When asserting mock positional arguments in DataLayer scope tests (e.g.,
   for `get_canonical_actor_dl()`), use `mock.call_args.args` (Python 3.8+)

--- a/notes/demo-ci-diagnostics.md
+++ b/notes/demo-ci-diagnostics.md
@@ -146,6 +146,23 @@ identified which layer broke.
 
 ---
 
+## Single-DataLayer Case-Ledger Endpoint Caveat
+
+In the in-process test harness, `demo_get_case_ledger` currently ignores the
+`actor_id` path parameter and returns the case's combined ledger view from the
+shared DataLayer.
+
+Implications for diagnostics:
+
+- Treat this endpoint as a **combined case log** view, not a per-replica view.
+- Name test helpers accordingly (for example, `_fetch_case_log`, not
+  `_fetch_case_actor_log`).
+- When you need per-replica assertions, use replica JSONL artifacts under
+  `devlogs/two-actor/<actor>/<case>-case-ledger.jsonl` instead of the demo
+  endpoint.
+
+---
+
 ## Local Docker Run Workflow
 
 Use this to reproduce a CI failure locally before investigating logs.

--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -91,15 +91,6 @@ inherited via pytest's upward conftest search, so only the vocabulary
 registration side-effect import needs copying into each new subdirectory
 conftest.
 
-### 2026-06-15 RM-TERMINAL-GUARD-928 — treat CLOSED as terminal before same-state check
-
-`ValidateRMTransitionNode` must evaluate terminal-state rules before its
-`current == new` short-circuit. If equality is checked first, repeated
-`CLOSED -> CLOSED` updates are treated as successful no-ops at validation time
-but still flow through append/broadcast/log-cascade paths as new status IDs.
-Guarding terminal `RM.CLOSED` first prevents duplicate closure cascades and
-keeps `close_case` retries from creating new canonical ledger entries.
-
 ### 2026-06-15 LEDGER-LOGGING-949 — PersistLogEntryNode tests require log_entry in blackboard
 
 When testing `PersistLogEntryNode` logging via `bridge.execute_with_setup()`,
@@ -109,17 +100,6 @@ helper builds a ready-to-use entry from a `HashChainLedgerRecord`. Use
 `caplog.at_level(logging.INFO, logger="vultron.core.behaviors.sync.nodes.chain")`
 to scope capture to just the chain node logger; without scoping, other node
 loggers at DEBUG can fill caplog with unrelated records.
-
-### 2026-06-15 LEDGER-INVARIANTS-950 — demo_get_case_ledger ignores actor_id; in-process tests see unified log
-
-`demo_triggers.demo_get_case_ledger` ignores the `actor_id` path parameter
-(`# noqa: ARG001`) and returns all `CaseLedgerEntry` objects for the case from
-the shared DataLayer.  In the single-DataLayer test environment the "case-actor
-log" is therefore the union of all actors' entries.  Test helpers should be
-named `_fetch_case_log` (not `_fetch_case_actor_log`) and docstrings must say
-"combined case log" to avoid implying per-replica isolation.  The event types
-currently recorded in this unified log are `add_participant_status` and
-`submit_report` — not the full CI invariant 5 set (pending #789).
 
 ### 2026-06-15 DEMO-CI-DIAGNOSTICS-951 — inbox logger is uvicorn.error, not module path
 
@@ -132,14 +112,6 @@ uses a class-qualified logger name:
 `vultron.core.behaviors.sync.nodes.chain.PersistLogEntryNode` (not the
 bare module path). Always verify logger names from source before writing
 diagnostic docs or log-filter commands.
-
-### 2026-06-15 STATUS-SCHEMA-931 — preserve accepted-status consent on retries
-
-When reusing an existing report-phase `ParticipantStatus` at `RM.ACCEPTED`,
-do not overwrite a non-null `em_consent_state` with default `NO_EMBARGO`.
-Update `cvd_role` as needed, but only backfill consent when it is missing.
-This keeps retries/idempotent paths from silently downgrading consent
-snapshots.
 
 ### 2026-06-15 TRIGGER-927-CASEACTOR-ROUTING — report trigger fallback must fail fast on missing CaseActor
 
@@ -159,13 +131,3 @@ steps (`CreateNoteNode`, `AttachNoteFromResultNode`) have already succeeded
 and committed local state. The note IS attached to the case locally even
 though the overall tree returns FAILURE. Tests should assert on this partial-
 write behavior explicitly so readers do not assume FAILURE → no writes.
-
-### 2026-06-15 LEDGER-SNAPSHOT-933 — inline nested refs with case-context guard
-
-Inlining nested payloadSnapshot references by blindly resolving `dl.read(id)`
-is unsafe: it can leak unrelated local objects into canonical
-`CaseLedgerEntry` snapshots when inbound activities carry attacker-controlled
-IDs. The inlining path must enforce a case-context match (`resolved.context ==
-payloadSnapshot.context`) before replacing any bare ID with an inline object.
-This keeps CLP-07 self-contained snapshots while preventing cross-case data
-disclosure.

--- a/plan/history/2606/learning/LEDGER-INVARIANTS-950.md
+++ b/plan/history/2606/learning/LEDGER-INVARIANTS-950.md
@@ -1,0 +1,11 @@
+---
+source: LEDGER-INVARIANTS-950
+timestamp: '2026-06-15T20:16:37.077324+00:00'
+title: Single-DataLayer demo case-ledger endpoint semantics
+type: learning
+---
+
+`demo_triggers.demo_get_case_ledger` ignores the `actor_id` path parameter (`# noqa: ARG001`) and returns all `CaseLedgerEntry` objects for the case from the shared DataLayer. In the single-DataLayer test environment the "case-actor log" is therefore the union of all actors' entries. Test helpers should be named `_fetch_case_log` (not `_fetch_case_actor_log`) and docstrings must say "combined case log" to avoid implying per-replica isolation. The event types currently recorded in this unified log are `add_participant_status` and `submit_report` — not the full CI invariant 5 set (pending #789).
+
+**Promoted**: 2026-06-15 — captured in `notes/demo-ci-diagnostics.md` and `AGENTS.md`.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/978>.

--- a/plan/history/2606/learning/LEDGER-SNAPSHOT-933.md
+++ b/plan/history/2606/learning/LEDGER-SNAPSHOT-933.md
@@ -1,0 +1,11 @@
+---
+source: LEDGER-SNAPSHOT-933
+timestamp: '2026-06-15T20:17:11.303528+00:00'
+title: Guard nested payloadSnapshot inlining with case-context match
+type: learning
+---
+
+Inlining nested payloadSnapshot references by blindly resolving `dl.read(id)` is unsafe: it can leak unrelated local objects into canonical `CaseLedgerEntry` snapshots when inbound activities carry attacker-controlled IDs. The inlining path must enforce a case-context match (`resolved.context == payloadSnapshot.context`) before replacing any bare ID with an inline object. This keeps CLP-07 self-contained snapshots while preventing cross-case data disclosure.
+
+**Promoted**: 2026-06-15 — captured in `specs/case-ledger-processing.yaml` (CLP-07-008) and `AGENTS.md`.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/978>.

--- a/plan/history/2606/learning/RM-TERMINAL-GUARD-928.md
+++ b/plan/history/2606/learning/RM-TERMINAL-GUARD-928.md
@@ -1,0 +1,11 @@
+---
+source: RM-TERMINAL-GUARD-928
+timestamp: '2026-06-15T20:16:01.555928+00:00'
+title: RM terminal guard ordering
+type: learning
+---
+
+`ValidateRMTransitionNode` must evaluate terminal-state rules before its `current == new` short-circuit. If equality is checked first, repeated `CLOSED -> CLOSED` updates are treated as successful no-ops at validation time but still flow through append/broadcast/log-cascade paths as new status IDs. Guarding terminal `RM.CLOSED` first prevents duplicate closure cascades and keeps `close_case` retries from creating new canonical ledger entries.
+
+**Promoted**: 2026-06-15 — captured in `specs/case-management.yaml` (CM-04-007) and `AGENTS.md`.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/978>.

--- a/plan/history/2606/learning/STATUS-SCHEMA-931.md
+++ b/plan/history/2606/learning/STATUS-SCHEMA-931.md
@@ -1,0 +1,11 @@
+---
+source: STATUS-SCHEMA-931
+timestamp: '2026-06-15T20:16:53.888074+00:00'
+title: Preserve accepted-status consent snapshots on retries
+type: learning
+---
+
+When reusing an existing report-phase `ParticipantStatus` at `RM.ACCEPTED`, do not overwrite a non-null `em_consent_state` with default `NO_EMBARGO`. Update `cvd_role` as needed, but only backfill consent when it is missing. This keeps retries/idempotent paths from silently downgrading consent snapshots.
+
+**Promoted**: 2026-06-15 — captured in `specs/case-management.yaml` (CM-13-008) and `AGENTS.md`.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/978>.

--- a/specs/case-ledger-processing.yaml
+++ b/specs/case-ledger-processing.yaml
@@ -228,3 +228,13 @@ groups:
       `payloadSnapshot` context values MUST use the case URI once a case exists;
       report URIs MUST NOT appear as the context for ParticipantStatus or other
       case-scoped snapshots after the report→case promotion has occurred
+  - id: CLP-07-008
+    priority: MUST
+    statement: >-
+      If a canonicalization path resolves an ID-string nested reference for
+      `payloadSnapshot` inlining, it MUST verify that the resolved object's context
+      matches the parent snapshot context before replacement. On context mismatch, the
+      entry MUST be rejected rather than inlining cross-case data.
+    rationale: >-
+      Blind `dl.read(id)` replacement can leak unrelated local objects into canonical
+      snapshots when inbound activities carry attacker-controlled IDs.

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -220,6 +220,16 @@ groups:
       spec_id: VP-13-009
     - rel_type: depends_on
       spec_id: CM-03-008
+  - id: CM-04-007
+    priority: MUST
+    statement: >-
+      RM transition validation MUST treat `RM.CLOSED` as terminal before applying any
+      same-state no-op shortcut. A repeated `CLOSED -> CLOSED` update MUST be treated
+      as a terminal no-op that does not append new participant status records, trigger
+      broadcast, or create new case-ledger entries.
+    rationale: >-
+      Checking equality first can let duplicate close retries flow into downstream
+      append/broadcast paths as fresh state changes.
 - id: CM-05
   title: Object Model Relationships
   specs:
@@ -566,6 +576,15 @@ groups:
     rationale: >-
       A note may be stored in the DataLayer by one path and never attached to `case.notes`
       by another path. Checking DataLayer existence produces false idempotency.
+  - id: CM-13-008
+    priority: MUST
+    statement: >-
+      When reusing an existing report-phase `ParticipantStatus` record on embargo
+      accept/reject retries, handlers MUST preserve a non-null existing consent value and
+      MUST NOT overwrite it with the default `NO_EMBARGO` value.
+    rationale: >-
+      Retry/idempotent paths must not silently downgrade previously established consent
+      snapshots.
 - id: CM-14
   title: Case Initialization Sequence
   description: >-


### PR DESCRIPTION
## Summary
Promote recurring lessons from the last two weeks of closed work into durable documentation so future implementation retries preserve protocol invariants.

## Changes
- Add CM-04-007 (RM terminal guard ordering) and CM-13-008 (preserve non-null consent on retry reuse)
- Add CLP-07-008 requiring case-context match before nested payloadSnapshot ID inlining
- Extend notes/demo-ci-diagnostics.md with single-DataLayer case-ledger endpoint caveat (actor_id ignored, combined view)
- Add corresponding AGENTS pitfalls and remove promoted entries from plan/BUILD_LEARNINGS.md
