### PR TITLE
DRY up logging setup across all demo scripts

### DIFF
--- a/plan/history/2606/implementation/ISSUE-990.md
+++ b/plan/history/2606/implementation/ISSUE-990.md
@@ -1,0 +1,22 @@
+---
+source: ISSUE-990
+timestamp: '2026-06-16T15:09:33.901486+00:00'
+title: DRY up logging setup across demo scripts
+type: implementation
+---
+
+## Issue #990 — DRY up logging setup in `vultron/demo`
+
+Extracted the repeated `_setup_logging()` function from all 16 demo scripts
+into a single canonical `setup_demo_logging()` in `vultron/demo/utils.py`.
+
+All 16 files under `vultron/demo/exchange/` (13 files) and
+`vultron/demo/scenario/` (3 files) defined identical or near-identical
+private functions that silenced `httpx2` and configured a root
+`StreamHandler(sys.stdout)`. The refactor removes ~200 lines of duplication
+and ensures any future logging changes apply in one place.
+
+Also removed inline `import logging as _logging` statements that Black had
+left inside 7 function bodies, and added `import sys` to `utils.py`.
+
+PR: [#992](https://github.com/CERTCC/Vultron/pull/992)

--- a/vultron/demo/exchange/acknowledge_demo.py
+++ b/vultron/demo/exchange/acknowledge_demo.py
@@ -63,6 +63,7 @@ from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monk
     logfmt,
     post_to_inbox_and_wait,
     verify_object_stored,
+    setup_demo_logging,
 )
 from vultron.wire.as2.factories import (
     rm_invalidate_report_activity,
@@ -420,17 +421,6 @@ def main(
         logger.info("")
 
 
-def _setup_logging():
-    """Configure console logging for standalone script execution."""
-    logging.getLogger("httpx2").setLevel(logging.WARNING)
-    _logger = logging.getLogger()
-    hdlr = logging.StreamHandler(sys.stdout)
-    formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
-    hdlr.setFormatter(formatter)
-    _logger.addHandler(hdlr)
-    _logger.setLevel(logging.DEBUG)
-
-
 if __name__ == "__main__":
-    _setup_logging()
+    setup_demo_logging()
     main()

--- a/vultron/demo/exchange/establish_embargo_demo.py
+++ b/vultron/demo/exchange/establish_embargo_demo.py
@@ -70,6 +70,7 @@ from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monk
     demo_environment,
     post_to_inbox_and_wait,
     verify_object_stored,
+    setup_demo_logging,
 )
 from vultron.wire.as2.factories import (
     activate_embargo_activity,
@@ -454,19 +455,6 @@ def main(
         logger.info("")
 
 
-def _setup_logging():
-    """Configure console logging for standalone script execution."""
-    logging.getLogger("httpx2").setLevel(logging.WARNING)
-    logger_ = logging.getLogger()
-    hdlr = logging.StreamHandler(sys.stdout)
-    import logging as _logging
-
-    formatter = _logging.Formatter("%(asctime)s %(levelname)s %(message)s")
-    hdlr.setFormatter(formatter)
-    logger_.addHandler(hdlr)
-    logger_.setLevel(logging.DEBUG)
-
-
 if __name__ == "__main__":
-    _setup_logging()
+    setup_demo_logging()
     main()

--- a/vultron/demo/exchange/initialize_case_demo.py
+++ b/vultron/demo/exchange/initialize_case_demo.py
@@ -70,6 +70,7 @@ from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monk
     post_to_inbox_and_wait,
     ref_id,
     verify_object_stored,
+    setup_demo_logging,
 )
 from vultron.wire.as2.factories import (
     add_participant_to_case_activity,
@@ -309,17 +310,6 @@ def main(
         logger.info("")
 
 
-def _setup_logging():
-    """Configure console logging for standalone script execution."""
-    logging.getLogger("httpx2").setLevel(logging.WARNING)
-    logger_ = logging.getLogger()
-    hdlr = logging.StreamHandler(sys.stdout)
-    formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
-    hdlr.setFormatter(formatter)
-    logger_.addHandler(hdlr)
-    logger_.setLevel(logging.DEBUG)
-
-
 if __name__ == "__main__":
-    _setup_logging()
+    setup_demo_logging()
     main()

--- a/vultron/demo/exchange/initialize_participant_demo.py
+++ b/vultron/demo/exchange/initialize_participant_demo.py
@@ -67,6 +67,7 @@ from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monk
     post_to_inbox_and_wait,
     ref_id,
     verify_object_stored,
+    setup_demo_logging,
 )
 from vultron.wire.as2.factories import (
     add_participant_to_case_activity,
@@ -338,17 +339,6 @@ def main(
         logger.info("")
 
 
-def _setup_logging():
-    """Configure console logging for standalone script execution."""
-    logging.getLogger("httpx2").setLevel(logging.WARNING)
-    logger_ = logging.getLogger()
-    hdlr = logging.StreamHandler(sys.stdout)
-    formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
-    hdlr.setFormatter(formatter)
-    logger_.addHandler(hdlr)
-    logger_.setLevel(logging.DEBUG)
-
-
 if __name__ == "__main__":
-    _setup_logging()
+    setup_demo_logging()
     main()

--- a/vultron/demo/exchange/invite_actor_demo.py
+++ b/vultron/demo/exchange/invite_actor_demo.py
@@ -72,6 +72,7 @@ from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monk
     post_to_inbox_and_wait,
     ref_id,
     verify_object_stored,
+    setup_demo_logging,
 )
 from vultron.wire.as2.factories import (
     add_participant_to_case_activity,
@@ -392,19 +393,6 @@ def main(
         logger.info("")
 
 
-def _setup_logging():
-    """Configure console logging for standalone script execution."""
-    logging.getLogger("httpx2").setLevel(logging.WARNING)
-    logger_ = logging.getLogger()
-    hdlr = logging.StreamHandler(sys.stdout)
-    import logging as _logging
-
-    formatter = _logging.Formatter("%(asctime)s %(levelname)s %(message)s")
-    hdlr.setFormatter(formatter)
-    logger_.addHandler(hdlr)
-    logger_.setLevel(logging.DEBUG)
-
-
 if __name__ == "__main__":
-    _setup_logging()
+    setup_demo_logging()
     main()

--- a/vultron/demo/exchange/manage_case_demo.py
+++ b/vultron/demo/exchange/manage_case_demo.py
@@ -77,6 +77,7 @@ from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monk
     post_to_inbox_and_wait,
     ref_id,
     verify_object_stored,
+    setup_demo_logging,
 )
 from vultron.wire.as2.factories import (
     add_participant_to_case_activity,
@@ -433,17 +434,6 @@ def main(
         logger.info("")
 
 
-def _setup_logging():
-    """Configure console logging for standalone script execution."""
-    logging.getLogger("httpx2").setLevel(logging.WARNING)
-    _logger = logging.getLogger()
-    hdlr = logging.StreamHandler(sys.stdout)
-    formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
-    hdlr.setFormatter(formatter)
-    _logger.addHandler(hdlr)
-    _logger.setLevel(logging.DEBUG)
-
-
 if __name__ == "__main__":
-    _setup_logging()
+    setup_demo_logging()
     main()

--- a/vultron/demo/exchange/manage_embargo_demo.py
+++ b/vultron/demo/exchange/manage_embargo_demo.py
@@ -70,6 +70,7 @@ from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monk
     demo_environment,
     post_to_inbox_and_wait,
     verify_object_stored,
+    setup_demo_logging,
 )
 from vultron.wire.as2.factories import (
     activate_embargo_activity,
@@ -555,19 +556,6 @@ def main(
         logger.info("")
 
 
-def _setup_logging():
-    """Configure console logging for standalone script execution."""
-    logging.getLogger("httpx2").setLevel(logging.WARNING)
-    logger_ = logging.getLogger()
-    hdlr = logging.StreamHandler(sys.stdout)
-    import logging as _logging
-
-    formatter = _logging.Formatter("%(asctime)s %(levelname)s %(message)s")
-    hdlr.setFormatter(formatter)
-    logger_.addHandler(hdlr)
-    logger_.setLevel(logging.DEBUG)
-
-
 if __name__ == "__main__":
-    _setup_logging()
+    setup_demo_logging()
     main()

--- a/vultron/demo/exchange/manage_participants_demo.py
+++ b/vultron/demo/exchange/manage_participants_demo.py
@@ -70,6 +70,7 @@ from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monk
     post_to_inbox_and_wait,
     ref_id,
     verify_object_stored,
+    setup_demo_logging,
 )
 from vultron.wire.as2.factories import (
     add_participant_to_case_activity,
@@ -453,19 +454,6 @@ def main(
         logger.info("")
 
 
-def _setup_logging():
-    """Configure console logging for standalone script execution."""
-    logging.getLogger("httpx2").setLevel(logging.WARNING)
-    logger_ = logging.getLogger()
-    hdlr = logging.StreamHandler(sys.stdout)
-    import logging as _logging
-
-    formatter = _logging.Formatter("%(asctime)s %(levelname)s %(message)s")
-    hdlr.setFormatter(formatter)
-    logger_.addHandler(hdlr)
-    logger_.setLevel(logging.DEBUG)
-
-
 if __name__ == "__main__":
-    _setup_logging()
+    setup_demo_logging()
     main()

--- a/vultron/demo/exchange/receive_report_demo.py
+++ b/vultron/demo/exchange/receive_report_demo.py
@@ -75,6 +75,7 @@ from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monk
     demo_environment,
     postfmt,
     verify_object_stored,
+    setup_demo_logging,
 )
 from vultron.wire.as2.factories import (
     create_case_activity,
@@ -594,19 +595,6 @@ def main(
         logger.info("")
 
 
-def _setup_logging():
-    """Configure console logging for standalone script execution."""
-    # turn down httpx logging
-    logging.getLogger("httpx2").setLevel(logging.WARNING)
-
-    logger = logging.getLogger()
-    hdlr = logging.StreamHandler(sys.stdout)
-    formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
-    hdlr.setFormatter(formatter)
-    logger.addHandler(hdlr)
-    logger.setLevel(logging.DEBUG)
-
-
 if __name__ == "__main__":
-    _setup_logging()
+    setup_demo_logging()
     main()

--- a/vultron/demo/exchange/status_updates_demo.py
+++ b/vultron/demo/exchange/status_updates_demo.py
@@ -75,6 +75,7 @@ from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monk
     post_to_inbox_and_wait,
     ref_id,
     verify_object_stored,
+    setup_demo_logging,
 )
 from vultron.wire.as2.factories import (
     add_note_to_case_activity,
@@ -398,19 +399,6 @@ def main(
         logger.info("")
 
 
-def _setup_logging():
-    """Configure console logging for standalone script execution."""
-    logging.getLogger("httpx2").setLevel(logging.WARNING)
-    logger_ = logging.getLogger()
-    hdlr = logging.StreamHandler(sys.stdout)
-    import logging as _logging
-
-    formatter = _logging.Formatter("%(asctime)s %(levelname)s %(message)s")
-    hdlr.setFormatter(formatter)
-    logger_.addHandler(hdlr)
-    logger_.setLevel(logging.DEBUG)
-
-
 if __name__ == "__main__":
-    _setup_logging()
+    setup_demo_logging()
     main()

--- a/vultron/demo/exchange/suggest_actor_demo.py
+++ b/vultron/demo/exchange/suggest_actor_demo.py
@@ -71,6 +71,7 @@ from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monk
     demo_environment,
     post_to_inbox_and_wait,
     verify_object_stored,
+    setup_demo_logging,
 )
 from vultron.wire.as2.factories import (
     accept_actor_recommendation_activity,
@@ -363,19 +364,6 @@ def main(
         logger.info("")
 
 
-def _setup_logging():
-    """Configure console logging for standalone script execution."""
-    logging.getLogger("httpx2").setLevel(logging.WARNING)
-    logger_ = logging.getLogger()
-    hdlr = logging.StreamHandler(sys.stdout)
-    import logging as _logging
-
-    formatter = _logging.Formatter("%(asctime)s %(levelname)s %(message)s")
-    hdlr.setFormatter(formatter)
-    logger_.addHandler(hdlr)
-    logger_.setLevel(logging.DEBUG)
-
-
 if __name__ == "__main__":
-    _setup_logging()
+    setup_demo_logging()
     main()

--- a/vultron/demo/exchange/transfer_ownership_demo.py
+++ b/vultron/demo/exchange/transfer_ownership_demo.py
@@ -70,6 +70,7 @@ from vultron.demo.utils import (
     logfmt,
     post_to_inbox_and_wait,
     verify_object_stored,
+    setup_demo_logging,
 )
 from vultron.wire.as2.factories import (
     accept_case_ownership_transfer_activity,
@@ -368,19 +369,6 @@ def main(
         logger.info("")
 
 
-def _setup_logging():
-    """Configure console logging for standalone script execution."""
-    logging.getLogger("httpx2").setLevel(logging.WARNING)
-    logger_ = logging.getLogger()
-    hdlr = logging.StreamHandler(sys.stdout)
-    import logging as _logging
-
-    formatter = _logging.Formatter("%(asctime)s %(levelname)s %(message)s")
-    hdlr.setFormatter(formatter)
-    logger_.addHandler(hdlr)
-    logger_.setLevel(logging.DEBUG)
-
-
 if __name__ == "__main__":
-    _setup_logging()
+    setup_demo_logging()
     main()

--- a/vultron/demo/exchange/trigger_demo.py
+++ b/vultron/demo/exchange/trigger_demo.py
@@ -58,6 +58,7 @@ from vultron.demo.utils import (
     post_to_inbox_and_wait,
     post_to_trigger,
     verify_object_stored,
+    setup_demo_logging,
 )
 from vultron.wire.as2.factories import (
     rm_submit_report_activity,
@@ -360,18 +361,6 @@ def main(
         logger.info("")
 
 
-def _setup_logging() -> None:
-    """Configure console logging for standalone script execution."""
-    logging.getLogger("httpx2").setLevel(logging.WARNING)
-    _logger = logging.getLogger()
-    hdlr = logging.StreamHandler(sys.stdout)
-    hdlr.setFormatter(
-        logging.Formatter("%(asctime)s %(levelname)s %(message)s")
-    )
-    _logger.addHandler(hdlr)
-    _logger.setLevel(logging.DEBUG)
-
-
 if __name__ == "__main__":
-    _setup_logging()
+    setup_demo_logging()
     main()

--- a/vultron/demo/scenario/multi_vendor_demo.py
+++ b/vultron/demo/scenario/multi_vendor_demo.py
@@ -84,6 +84,7 @@ from vultron.demo.utils import (
     reset_datalayer,
     seed_actor,
     verify_object_stored,
+    setup_demo_logging,
 )
 from vultron.wire.as2.factories import (
     accept_case_ownership_transfer_activity,
@@ -772,18 +773,6 @@ def main(
         sys.exit(1)
 
 
-def _setup_logging() -> None:
-    """Configure console logging for standalone execution."""
-    logging.getLogger("httpx2").setLevel(logging.WARNING)
-    root = logging.getLogger()
-    handler = logging.StreamHandler(sys.stdout)
-    handler.setFormatter(
-        logging.Formatter("%(asctime)s %(levelname)s %(message)s")
-    )
-    root.addHandler(handler)
-    root.setLevel(logging.DEBUG)
-
-
 if __name__ == "__main__":
-    _setup_logging()
+    setup_demo_logging()
     main()

--- a/vultron/demo/scenario/three_actor_demo.py
+++ b/vultron/demo/scenario/three_actor_demo.py
@@ -54,6 +54,7 @@ from vultron.demo.utils import (
     reset_datalayer,
     seed_actor,
     verify_object_stored,
+    setup_demo_logging,
 )
 from vultron.wire.as2.vocab.base.objects.activities.base import as_Activity
 from vultron.wire.as2.vocab.base.objects.activities.transitive import (
@@ -748,18 +749,6 @@ def main(
         sys.exit(1)
 
 
-def _setup_logging() -> None:
-    """Configure console logging for standalone execution."""
-    logging.getLogger("httpx2").setLevel(logging.WARNING)
-    root = logging.getLogger()
-    handler = logging.StreamHandler(sys.stdout)
-    handler.setFormatter(
-        logging.Formatter("%(asctime)s %(levelname)s %(message)s")
-    )
-    root.addHandler(handler)
-    root.setLevel(logging.DEBUG)
-
-
 if __name__ == "__main__":
-    _setup_logging()
+    setup_demo_logging()
     main()

--- a/vultron/demo/scenario/two_actor_demo.py
+++ b/vultron/demo/scenario/two_actor_demo.py
@@ -55,6 +55,7 @@ from vultron.demo.utils import (  # noqa: F401 — re-exported for test monkeypa
     reset_demo_failures,
     seed_actor,
     verify_object_stored,
+    setup_demo_logging,
 )
 
 # Re-export shared helpers so that existing imports via this module continue to
@@ -982,18 +983,6 @@ def main(
         assert_demo_success()
 
 
-def _setup_logging() -> None:
-    """Configure console logging for standalone script execution."""
-    logging.getLogger("httpx2").setLevel(logging.WARNING)
-    _logger = logging.getLogger()
-    hdlr = logging.StreamHandler(sys.stdout)
-    hdlr.setFormatter(
-        logging.Formatter("%(asctime)s %(levelname)s %(message)s")
-    )
-    _logger.addHandler(hdlr)
-    _logger.setLevel(logging.DEBUG)
-
-
 if __name__ == "__main__":
-    _setup_logging()
+    setup_demo_logging()
     main()

--- a/vultron/demo/utils.py
+++ b/vultron/demo/utils.py
@@ -24,6 +24,7 @@ functions used across all demo scripts (DC-02-001).
 import json
 import logging
 import os
+import sys
 import time
 from contextlib import contextmanager
 from http import HTTPMethod
@@ -529,3 +530,15 @@ def check_server_availability(
         if attempt < max_retries - 1:
             time.sleep(retry_delay)
     return False
+
+
+def setup_demo_logging() -> None:
+    """Configure console logging for standalone demo script execution."""
+    logging.getLogger("httpx2").setLevel(logging.WARNING)
+    _logger = logging.getLogger()
+    hdlr = logging.StreamHandler(sys.stdout)
+    hdlr.setFormatter(
+        logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+    )
+    _logger.addHandler(hdlr)
+    _logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
- Closes #990

## Summary

Extract the repeated `_setup_logging()` function from all 16 demo scripts
into a single canonical `setup_demo_logging()` in `vultron/demo/utils.py`.
All 16 files had identical (or near-identical) private functions; the new
helper eliminates ~200 lines of duplication.

## Changes

- `vultron/demo/utils.py`: add `import sys`; add `setup_demo_logging() -> None`
- `vultron/demo/exchange/` (13 files): remove local `_setup_logging()`, add `setup_demo_logging` to `vultron.demo.utils` import block, update call site
- `vultron/demo/scenario/` (3 files): same as above
- Inline `import logging as _logging` statements (Black artifact in 7 files) removed as part of function body deletion

## Verification

- All 3584 unit + integration tests pass (full suite: `uv run pytest -m "" --tb=short`)
- Black, flake8, mypy, pyright all clean