### PR TITLE
docs: plan issue #993 — per-case genesis hash origin binding

### DIFF
--- a/notes/case-ledger-authority.md
+++ b/notes/case-ledger-authority.md
@@ -331,3 +331,78 @@ that rejects entries violating CLP-07-001 through CLP-07-004 *before*
 they enter the hash chain. Failing fast at commit time keeps the
 canonical chain clean and surfaces bugs immediately, rather than allowing
 silent pollution that's discovered only when replicas diverge.
+
+---
+
+## Per-Case Genesis Hash — Origin Binding and Future Improvements
+
+*Spec: `specs/case-ledger-processing.yaml` CLP-08-001 through CLP-08-006.*
+
+The per-case genesis hash is derived as
+`SHA-256(case_id + "|" + created_at.isoformat() + "|" + case_actor_id)`.
+This anchors each case ledger to its origin identity and timestamp,
+replacing the former global `GENESIS_HASH = "0" * 64` constant.
+
+### Current Threat Model
+
+Domain-bound case URIs (e.g., `https://example.org/cases/<uuid>`) with a
+cryptographically random UUID path segment satisfy CLP-08-006. The domain
+prefix is public but irrelevant — an attacker must still brute-force the
+UUID component to predict the genesis hash.
+
+If case metadata (`case_id`, `created_at`, `case_actor_id`) is observable
+by an attacker — which is possible in a federated protocol — the genesis
+hash becomes computable by anyone with that knowledge. This means:
+
+- **Hash-chain integrity** is preserved: the attacker cannot forge or silently
+  drop entries from a chain whose genesis hash a receiver has independently
+  stored.
+- **DoS amplification** is reduced from universal (any attacker, any case) to
+  targeted (attacker must know this specific case's metadata), but is not
+  fully eliminated.
+
+### Future Improvement: Secret Nonce
+
+Adding a secret nonce to the genesis hash input — a random value generated
+by the CaseActor at case creation and never transmitted on the wire — would
+close the targeted DoS vector even when case metadata leaks:
+
+```python
+genesis_hash = sha256(
+    case_id + "|" + created_at.isoformat() + "|" + case_actor_id
+    + "|" + secret_nonce
+)
+```
+
+The nonce would need to be stored securely in the CaseActor's DataLayer and
+shared only with legitimate participants through an authenticated channel.
+This adds key-management complexity that is out of scope for the prototype
+tier but is the natural next step for production deployments.
+
+### Future Improvement: CaseActor Keypairs
+
+The more durable long-term solution is **cryptographic identity for
+CaseActors**. When CaseActors generate a new keypair at actor creation time
+(planned), the genesis hash can incorporate the CaseActor's public key or a
+key-signed commitment over case creation data:
+
+```python
+genesis_hash = sha256(
+    case_id + "|" + created_at.isoformat() + "|" + case_actor_public_key
+)
+# or: genesis_hash = sha256(case_actor.sign(case_id + created_at))
+```
+
+This would:
+
+- **Eliminate DataLayer trust for genesis authenticity**: any party with the
+  CaseActor's public key can independently verify the ledger's origin without
+  trusting the DataLayer's `case_id` field.
+- **Close the targeted DoS vector**: the nonce is effectively the private key,
+  which is never observable on the wire.
+- **Enable third-party auditing**: auditors can verify ledger provenance from
+  the public key alone, without needing out-of-band case metadata.
+
+The keypair-per-CaseActor design is tracked as a planned capability. Until
+it lands, the domain-bound UUID genesis hash defined in CLP-08-002 is the
+correct implementation.

--- a/plan/history/2606/learning/CONCERN-993.md
+++ b/plan/history/2606/learning/CONCERN-993.md
@@ -1,0 +1,63 @@
+---
+source: CONCERN-993
+timestamp: '2026-06-16T15:42:17.193330+00:00'
+title: Case ledger genesis hash provides no case-specific origin binding
+type: learning
+---
+
+## Summary
+
+`GENESIS_HASH = "0" * 64` is a hardcoded constant with no case-specific entropy.
+Every case ledger starts identically, providing no cryptographic origin-binding
+and enabling several integrity and availability weaknesses.
+
+## Category
+
+Security / Integrity
+
+## Severity
+
+Medium (research prototype risk; would be High for production deployments)
+
+## Evidence
+
+`vultron/core/models/case_ledger.py:72`:
+
+```python
+GENESIS_HASH: str = "0" * 64
+```
+
+This constant is used as the `prev_log_hash` default on the first entry of **every**
+case ledger across all cases and all deployments. `tail_hash == GENESIS_HASH` is also
+used as the sentinel for an empty/new ledger in `CaseLedger.tail_hash`,
+`sync_helpers.py`, and the sync replay paths.
+
+## Impact if Ignored
+
+1. **No cryptographic origin-binding**: There is no cryptographic proof of who started
+   a ledger, when, or for which specific case. Trust in the chain's starting point is
+   entirely delegated to DataLayer `case_id` field integrity — a compromised DataLayer
+   can silently substitute entries.
+2. **Truncated ledger indistinguishable from new ledger**: A ledger with all entries
+   stripped by an attacker with DataLayer access is indistinguishable from a
+   legitimately new empty ledger (`tail_hash == GENESIS_HASH` in both cases). Without
+   an out-of-band record of the expected chain start, silent truncation cannot be
+   detected.
+3. **Sync DoS amplification via well-known constant**: `from_hash=GENESIS_HASH` in
+   `RejectSync` / backfill requests triggers a full ledger retransmission. Because the
+   constant is universally known and applies to every case, an attacker can force full
+   retransmission of any case ledger without needing any case-specific knowledge.
+4. **No anchoring to case lifecycle**: The ledger start has no cryptographic tie to case
+   creation metadata (creator, timestamp, actor IDs), so ledger provenance cannot be
+   independently verified by a third party or an auditor.
+
+## Resolution
+
+Per-case genesis hash derived as
+`SHA-256(case_id + "|" + created_at.isoformat() + "|" + case_actor_id)`.
+Non-spoofability relies on `case_id` being a UUIDv4 (122 bits entropy).
+No extra salt needed. Global `GENESIS_HASH` constant to be removed entirely.
+
+**Resolved**: 2026-06-16 — implementation tracked in #995.
+Docs PR: [#994](https://github.com/CERTCC/Vultron/pull/994).
+Spec: `specs/case-ledger-processing.yaml` (CLP-08-001 through CLP-08-006).

--- a/specs/case-ledger-processing.yaml
+++ b/specs/case-ledger-processing.yaml
@@ -285,7 +285,15 @@ groups:
   - id: CLP-08-006
     priority: MUST
     statement: >-
-      The non-spoofability guarantee of the per-case genesis hash depends on `case_id`
-      being generated from a cryptographically random source (UUIDv4 or equivalent);
-      implementations MUST NOT use sequentially predictable or human-chosen case IDs
-      when origin-binding integrity is required
+      The non-spoofability guarantee of the per-case genesis hash depends on the
+      `case_id` containing a cryptographically random component of at least 64 bits
+      (e.g., UUIDv4 with 122 random bits, or UUIDv7 with 74 random bits); domain-bound
+      URI forms (e.g., `https://example.org/cases/<uuid>`) are acceptable provided the
+      UUID path segment satisfies this requirement; implementations MUST NOT use
+      sequentially predictable or human-chosen case IDs when origin-binding integrity is
+      required
+    rationale: >-
+      The domain prefix of a URI is predictable but irrelevant — the attacker must still
+      brute-force the UUID component to forge a genesis hash. UUIDv7 (time-ordered, 74
+      random bits) is explicitly in scope; pure sequential or human-chosen path segments
+      are not.

--- a/specs/case-ledger-processing.yaml
+++ b/specs/case-ledger-processing.yaml
@@ -285,15 +285,9 @@ groups:
   - id: CLP-08-006
     priority: MUST
     statement: >-
-      The non-spoofability guarantee of the per-case genesis hash depends on the
-      `case_id` containing a cryptographically random component of at least 64 bits
-      (e.g., UUIDv4 with 122 random bits, or UUIDv7 with 74 random bits); domain-bound
-      URI forms (e.g., `https://example.org/cases/<uuid>`) are acceptable provided the
-      UUID path segment satisfies this requirement; implementations MUST NOT use
-      sequentially predictable or human-chosen case IDs when origin-binding integrity is
-      required
-    rationale: >-
-      The domain prefix of a URI is predictable but irrelevant — the attacker must still
-      brute-force the UUID component to forge a genesis hash. UUIDv7 (time-ordered, 74
-      random bits) is explicitly in scope; pure sequential or human-chosen path segments
-      are not.
+      The non-spoofability guarantee of the per-case genesis hash is satisfied by a
+      domain-bound case URI (e.g., `https://example.org/cases/<uuid>`) whose path
+      segment contains a cryptographically random UUID component; implementations MUST
+      NOT use sequentially predictable or human-chosen path segments when origin-binding
+      integrity is required; see `notes/case-ledger-authority.md` for future
+      improvement paths (secret nonce, CaseActor keypairs)

--- a/specs/case-ledger-processing.yaml
+++ b/specs/case-ledger-processing.yaml
@@ -238,3 +238,54 @@ groups:
     rationale: >-
       Blind `dl.read(id)` replacement can leak unrelated local objects into canonical
       snapshots when inbound activities carry attacker-controlled IDs.
+- id: CLP-08
+  title: Per-Case Genesis Hash Derivation and Origin Binding
+  specs:
+  - id: CLP-08-001
+    priority: MUST
+    statement: >-
+      Each case ledger MUST use a per-case genesis hash as the predecessor hash for its
+      first entry; a globally-shared constant MUST NOT be used as the genesis predecessor
+      hash across all cases
+    rationale: >-
+      A shared global constant provides no cryptographic origin-binding: a ledger with all
+      entries stripped is indistinguishable from a legitimately new empty ledger, and the
+      well-known constant enables sync DoS amplification by allowing full-replay requests
+      without any case-specific knowledge
+  - id: CLP-08-002
+    priority: MUST
+    statement: >-
+      The per-case genesis hash MUST be derived as
+      `SHA-256(case_id + "|" + created_at.isoformat() + "|" + case_actor_id)`, where
+      `case_id` is the canonical case URI, `created_at` is the case creation UTC
+      timestamp in ISO 8601 format, and `case_actor_id` is the URI of the CaseActor
+      created for this case
+    rationale: >-
+      Including all three values cryptographically anchors the chain's starting point to
+      the specific case's origin identity and timestamp, allowing any party who knows the
+      case metadata to independently verify the ledger's genesis
+  - id: CLP-08-003
+    priority: MUST
+    statement: >-
+      The case-specific genesis hash MUST be stored on `VulnerabilityCase` as a required
+      field computed at case creation time, so that receivers can verify that a ledger
+      starts correctly for this case
+  - id: CLP-08-004
+    priority: MUST
+    statement: >-
+      `CaseLedger.tail_hash` MUST return the case-specific genesis hash when no recorded
+      entries exist; it MUST NOT return a globally-shared constant sentinel
+  - id: CLP-08-005
+    priority: MUST
+    statement: >-
+      Sync replay and backfill requests that supply a `from_hash` value MUST use the
+      case-specific genesis hash (or the hash of a known recorded entry) as the starting
+      point; implementations MUST treat any unrecognized `from_hash` value as a request
+      to replay from the beginning of the recorded projection
+  - id: CLP-08-006
+    priority: MUST
+    statement: >-
+      The non-spoofability guarantee of the per-case genesis hash depends on `case_id`
+      being generated from a cryptographically random source (UUIDv4 or equivalent);
+      implementations MUST NOT use sequentially predictable or human-chosen case IDs
+      when origin-binding integrity is required


### PR DESCRIPTION
- Closes #993

## Summary

Plans concern #993 by adding CLP-08 spec requirements that prohibit
the shared global genesis hash sentinel and mandate per-case genesis
hash derivation from case-specific metadata.

## Changes

- `specs/case-ledger-processing.yaml`: new CLP-08 group (6 requirements)
  covering genesis hash derivation formula, storage on `VulnerabilityCase`,
  `CaseLedger.tail_hash` sentinel update, sync guard behavior, and the
  cryptographic randomness dependency for non-spoofability