### PR TITLE
docs: plan issue #977 — inbox BT orchestration with typed process_payload seam

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -610,6 +610,16 @@ Short entries are reproduced here; longer ones are referenced below.
   `get_canonical_actor_dl()` directly with explicit keyword args
   (`actor_id=...`, `dl=...`) rather than through FastAPI DI — it is a plain
   Python function and does not require the full app stack.
+- **Inbox Policy Logic Must Live in the Core BT Module, Not the FastAPI
+  Router** — When adding or modifying inbox processing behavior (parse,
+  rehydrate, defer-check, dispatch), the change belongs in
+  `vultron/core/behaviors/inbox/` — not in the FastAPI router, not in a new
+  adapter-layer pipeline helper. `process_payload` is the sole caller-facing
+  entry point; all policy is internal to the BT. Creating a new
+  adapter-layer helper or adding logic to the router repeats the V-08
+  violation (ADR-0009) and makes the pipeline untestable from non-HTTP entry
+  points. See `specs/inbox-orchestration.yaml` IO-02-003 and IO-03-003, and
+  `notes/inbox-orchestration.md`.
 
 ## Skill Interaction Rules
 

--- a/docs/adr/0020-inbox-bt-orchestration.md
+++ b/docs/adr/0020-inbox-bt-orchestration.md
@@ -1,0 +1,148 @@
+---
+status: proposed
+date: 2026-06-16
+deciders:
+  - vultron maintainers
+consulted:
+  - project stakeholders
+informed:
+  - contributors
+---
+
+# Move Inbox Orchestration into a Core BT Module with a Typed `process_payload` Seam
+
+## Context and Problem Statement
+
+The Vultron inbox pipeline — parse → rehydrate → extract semantics →
+defer-check → dispatch — is currently implemented across two modules in
+`vultron/adapters/driving/fastapi/`: `inbox_handler.py` and
+`inbox_pipeline.py`. Both modules live in the adapter layer, which means:
+
+1. Non-HTTP entry points (CLI, tests, future MCP adapter) cannot reuse the
+   pipeline without importing adapter-layer code, violating ADR-0009 Rule 1.
+2. The ordering of pipeline steps is not enforced; callers can invoke helpers
+   in any order.
+3. Errors surface as exceptions, not typed outcomes, so callers must use
+   exception-driven control flow at the integration boundary.
+4. Tests are patch-heavy and fragile against internal refactors.
+
+A structured, BT-backed orchestration module in `core/` addresses all four
+issues while extending the BT-as-auditable-process-model established in
+ADR-0002.
+
+## Decision Drivers
+
+- **Hexagonal architecture compliance**: Core policy must not live in the
+  adapter layer (ADR-0009 Rule 1).
+- **Reusability**: The same pipeline should be available to FastAPI, CLI, and
+  tests without code duplication.
+- **Auditability**: Fixed BT ordering makes the pipeline inspectable and
+  prevents step misordering.
+- **Typed outcomes**: A `process_payload(...) -> InboxOutcome` seam gives
+  callers a uniform, exception-free way to handle all outcome cases.
+- **Testability**: Interface-level assertions on `InboxOutcome` are resilient
+  to internal refactors.
+
+## Considered Options
+
+1. **Keep pipeline in the adapter layer, improve `InboxPipeline`** — refine
+   the existing `InboxPipeline` class without moving it to `core/`.
+2. **Move pipeline to `core/` as a plain function** — extract a
+   procedural `process_payload` function without BT backing.
+3. **Move pipeline to `core/` as a BT-backed module (chosen)** — implement
+   orchestration as a Behavior Tree in `vultron/core/behaviors/inbox/` with
+   `process_payload(...) -> InboxOutcome` as the sole public entry point.
+
+## Decision Outcome
+
+Chosen option: **Move pipeline to `core/` as a BT-backed module**, because
+it satisfies the hexagonal architecture constraint, enforces fixed pipeline
+ordering through BT Sequence nodes, and aligns with the project's
+BT-as-process-model pattern established in ADR-0002.
+
+### Seam Design
+
+`process_payload` accepts two injected adapters and a pending-queue port:
+
+- **`IngressPayloadAdapter`**: raw input (bytes/dict) → rehydrated
+  `as_Activity`. Owns parse + rehydrate; keeps wire-format knowledge out of
+  the BT nodes.
+- **`DispatchAdapter`**: `VultronEvent` → use-case execution. Wraps the
+  existing `ActivityDispatcher` port.
+- **Pending-queue port** (injected): provides defer/replay queue operations
+  to the `DeferCheckNode` without importing adapter-layer code.
+
+The FastAPI inbox endpoint constructs production adapter implementations and
+calls `process_payload` in a `BackgroundTask`. CLI and test callers supply
+alternative adapters.
+
+### BT Node Ordering
+
+```text
+Sequence
+  ├─ ParsePayloadNode
+  ├─ RehydrateActivityNode
+  ├─ ExtractSemanticsNode
+  ├─ DeferCheckNode
+  ├─ DispatchNode
+  └─ BuildOutcomeNode
+```
+
+### Consequences
+
+- Good, because the pipeline is reusable from any entry point.
+- Good, because BT Sequence ordering is enforced and observable.
+- Good, because `InboxOutcome` gives callers a uniform, typed result.
+- Good, because interface-level tests replace fragile patch-heavy tests.
+- Bad, because the existing `InboxPipeline`/`inbox_handler` must be migrated
+  or shimmed, adding short-term transition overhead.
+- Bad, because a third injected parameter (pending-queue port) increases
+  construction complexity at the adapter layer.
+
+## Validation
+
+- `specs/inbox-orchestration.yaml` IO-01 through IO-04 define testable
+  requirements for this decision.
+- `process_payload` is located in `vultron/core/behaviors/inbox/` with no
+  imports from `vultron/adapters/`.
+- `InboxOutcome.status` covers `processed | deferred | rejected`; no
+  `process_payload` code path raises for protocol-invalid input.
+- Tests assert on `InboxOutcome` fields, not on internal BT node helpers.
+
+## Pros and Cons of the Options
+
+### Keep pipeline in the adapter layer (Option 1)
+
+- Good: no migration cost; existing callers unchanged.
+- Bad: non-HTTP entry points cannot reuse the pipeline without adapter
+  imports — ADR-0009 violation persists.
+- Bad: step ordering remains unenforced; callers can invoke helpers
+  out of order.
+
+### Move to `core/` as a plain function (Option 2)
+
+- Good: satisfies hexagonal architecture constraint.
+- Good: reusable from any entry point.
+- Bad: ordering is still procedural and not intrinsically observable.
+- Bad: errors must be caught and translated at every call site rather than
+  surfaced as typed outcomes automatically.
+
+### Move to `core/` as a BT-backed module (Option 3, chosen)
+
+- Good: satisfies hexagonal architecture (ADR-0009 Rule 1).
+- Good: BT Sequence enforces and documents pipeline order.
+- Good: aligns with ADR-0002 BT-as-process-model.
+- Good: typed `InboxOutcome` gives uniform caller contract.
+- Neutral: BT node granularity adds slight structural overhead vs procedural.
+- Bad: migration of existing adapter-layer callers required.
+
+## More Information
+
+- `notes/inbox-orchestration.md` — design decisions, adapter injection
+  rationale, InboxOutcome contract, and migration path.
+- `specs/inbox-orchestration.yaml` — testable requirements (IO-01–IO-04).
+- `docs/adr/0002-model-processes-with-behavior-trees.md` — BT-as-process-model
+  rationale.
+- `docs/adr/0009-hexagonal-architecture.md` — hexagonal architecture rules
+  this decision extends.
+- GitHub issue #977 — source Idea issue.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -77,13 +77,10 @@ General information about architectural decision records is available at <https:
 
 ## Proposed ADRs
 
-- none
+- [ADR-0020 Move Inbox Orchestration into a Core BT Module with a Typed
+  `process_payload` Seam](0020-inbox-bt-orchestration.md)
 
 ## Rejected ADRs
-
-- none
-
-## Deprecated ADRs
 
 - none
 

--- a/notes/README.md
+++ b/notes/README.md
@@ -113,6 +113,16 @@ standardized `UseCase` protocol, and `SEMANTICS_HANDLERS` migration to core.
 **Load when**: adding a new message type end-to-end, restructuring the
 dispatcher or use-case layer, or deciding whether a use case needs a BT.
 
+**`inbox-orchestration.md`**
+Design decisions for the core BT-backed inbox orchestration module: why
+orchestration belongs in `core/`, two-adapter seam design
+(`IngressPayloadAdapter` + `DispatchAdapter`), BT node ordering invariant,
+`InboxOutcome` contract, pending-queue port injection, and migration path
+from the existing `InboxPipeline`/`inbox_handler`.
+**Load when**: implementing or modifying the inbox pipeline, adding a new
+entry point (CLI, MCP) that processes inbound activities, or debugging
+`process_payload` behavior.
+
 **`vultron/wire/as2/vocab/AGENTS.md`**
 Vocabulary registry design rules: `__init_subclass__` auto-registration,
 flat dict structure, `VocabNamespace` metadata, `Literal type_`

--- a/notes/inbox-orchestration.md
+++ b/notes/inbox-orchestration.md
@@ -1,0 +1,152 @@
+---
+title: Inbox Orchestration — BT Module Design
+status: active
+description: >
+  Design decisions and implementation guidance for the core BT-backed inbox
+  orchestration module: why orchestration belongs in core/, adapter injection
+  rationale, InboxOutcome contract, and pending-queue port design.
+related_specs:
+  - specs/inbox-orchestration.yaml
+related_notes:
+  - notes/architecture-hexagonal.md
+  - notes/bt-integration.md
+  - notes/architecture-adapters.md
+relevant_packages:
+  - vultron/core/behaviors/inbox
+  - vultron/adapters/driving/fastapi
+---
+
+# Inbox Orchestration — BT Module Design
+
+## Why Orchestration Belongs in `core/`
+
+The previous inbox pipeline lived in `vultron/adapters/driving/fastapi/` as
+`InboxPipeline` and `inbox_handler`. This made the orchestration logic
+unavailable to non-HTTP entry points (CLI, tests, future MCP adapter) without
+importing adapter-layer code — a direct ADR-0009 violation.
+
+Moving orchestration to `vultron/core/behaviors/inbox/` restores the
+invariant: core owns the policy; adapters own the translation. The FastAPI
+inbox endpoint becomes thin glue that:
+
+1. Parses the HTTP request body into a raw payload.
+2. Calls `process_payload(payload, ingress_adapter, dispatch_adapter)`.
+3. Returns HTTP 202 immediately and schedules the call via `BackgroundTasks`.
+
+The CLI, tests, and any future inbox entry point do the same but supply
+different adapter implementations.
+
+---
+
+## Two-Adapter Seam Design
+
+`process_payload` accepts exactly two injected adapters:
+
+- **`IngressPayloadAdapter`** — translates raw input (bytes or dict) into a
+  rehydrated `as_Activity`. Owns parse + rehydrate; isolates wire-format
+  knowledge from the orchestration BT.
+- **`DispatchAdapter`** — accepts a `VultronEvent` and executes the
+  appropriate use-case path. Wraps the existing `ActivityDispatcher` port.
+
+This two-adapter design was chosen over:
+
+- **Single adapter** (collapsed ingress + dispatch): rejected because the
+  seam becomes opaque and re-couples wire parsing to dispatch.
+- **Three+ adapters** (separate parse, rehydrate, extract): rejected because
+  each intermediate step becomes an external dependency that callers could
+  invoke out of order, undermining the module's depth invariant.
+
+---
+
+## BT Node Ordering Invariant
+
+The BT implementation enforces a fixed pipeline via Sequence nodes:
+
+```text
+Sequence
+  ├─ ParsePayloadNode       (ingress_adapter → as_Activity)
+  ├─ RehydrateActivityNode  (rehydrate nested objects)
+  ├─ ExtractSemanticsNode   (as_Activity → MessageSemantics)
+  ├─ DeferCheckNode         (case context readiness check)
+  ├─ DispatchNode           (dispatch_adapter → use case)
+  └─ BuildOutcomeNode       (assemble InboxOutcome)
+```
+
+The Sequence guarantees that callers can never invoke steps out of order.
+BT node names are descriptive and observable — the tree structure is the
+workflow documentation.
+
+---
+
+## InboxOutcome Contract
+
+`InboxOutcome` is a Pydantic model returned by every `process_payload` call:
+
+```python
+class InboxOutcome(BaseModel):
+    status: Literal["processed", "deferred", "rejected"]
+    context_id: str | None = None
+    failure_reason: str | None = None
+```
+
+- `processed` — activity was dispatched successfully.
+- `deferred` — activity was queued for replay (case context not yet known).
+- `rejected` — activity could not be processed (parse failure, unknown type,
+  or protocol violation). `failure_reason` is always populated for `rejected`
+  outcomes.
+
+`process_payload` MUST NOT raise for protocol-invalid payloads. All error
+conditions produce a typed `rejected` outcome with an explicit
+`failure_reason`. Callers use the outcome status to decide logging severity
+and response codes.
+
+---
+
+## Pending-Queue Port Injection
+
+The defer-check step (step 4) needs to read and write the pending case
+activity queue. Rather than importing `inbox_pending_queue` directly from
+the adapter layer, the BT module accepts a **pending-queue port** (a
+Protocol interface) as an injected argument.
+
+The concrete implementation (wrapping `_queue_pending_case_activity`,
+`_expire_pending_case_activities`, `_replay_pending_case_activities`) is
+provided by the FastAPI adapter at construction time.
+
+This pattern:
+
+- Keeps `core/` free of adapter imports (ADR-0009 Rule 1).
+- Allows the test suite to supply an in-memory pending-queue stub.
+- Preserves the existing queue semantics without duplication.
+
+---
+
+## Test Surface
+
+Tests MUST target the `process_payload` interface:
+
+```python
+outcome = process_payload(raw_payload, ingress_adapter, dispatch_adapter)
+assert outcome.status == "processed"
+assert outcome.context_id == expected_case_id
+```
+
+Tests MUST NOT monkeypatch internal BT node helpers. Ordering effects and
+deferred-queue behavior are observable through `InboxOutcome.status` and
+the queue port's recorded calls.
+
+Both a production adapter (wrapping the FastAPI/ASGI stack) and an
+in-memory test adapter should implement `IngressPayloadAdapter` so the
+same interface is exercised in both contexts.
+
+---
+
+## Migration Path
+
+The existing `InboxPipeline` class and `inbox_handler` function can be
+kept temporarily as thin wrappers that delegate to `process_payload` with
+production adapters. Once all callers use `process_payload` directly,
+the adapter-layer wrappers can be deleted.
+
+See GitHub issue #977 and implementation issue (wired as blocked-by #977)
+for task tracking.

--- a/plan/history/2606/idea/IDEA-977.md
+++ b/plan/history/2606/idea/IDEA-977.md
@@ -1,0 +1,79 @@
+---
+source: IDEA-977
+timestamp: '2026-06-16T15:49:04.230855+00:00'
+title: Inbox BT orchestration with typed process_payload seam
+type: idea
+---
+
+## Summary
+
+Deepen the Inbox flow into one core module whose interface is a single
+`process_payload` entry point and whose implementation is an auditable
+Behavior Tree. The module should own end-to-end orchestration of inbound
+Activity handling instead of spreading policy across shallow helpers.
+
+## Motivation
+
+The current Inbox flow is shallow: interface knowledge and implementation
+behavior are split across multiple modules (`inbox_handler` and
+`inbox_pipeline`) with duplicated/delegated helper behavior. This reduces
+locality and makes review/debugging depend on cross-file tracing.
+
+This idea captures the agreed direction to increase:
+
+- **locality**: one module owns parse → rehydrate → semantic extraction →
+  defer check → dispatch
+- **leverage**: one interface serves both runtime Inbox adapters and tests
+- **auditability**: explicit BT nodes provide observable ordered behavior
+
+## Rough Approach
+
+### Deep module shape
+
+Create a core Inbox orchestration module with a single caller-facing interface:
+
+- `process_payload(...) -> InboxOutcome`
+
+Where `InboxOutcome` is typed and includes:
+
+- status: `processed | deferred | rejected`
+- `context_id`
+- `failure_reason`
+
+### Enforced internal ordering (inside module implementation)
+
+The module implementation enforces fixed ordering with BT sequence nodes:
+
+1. Parse inbound payload
+2. Rehydrate Activity
+3. Extract `MessageSemantics`
+4. Duplicate / defer eligibility check (Case context readiness)
+5. Dispatch to use-case path
+6. Build typed outcome
+
+### Seam and adapter discipline
+
+Use one explicit seam with exactly two adapters:
+
+1. **Ingress payload adapter**
+2. **Dispatch adapter**
+
+Keep parse/extract orchestration implementation internal to the deep module.
+
+### Error and outcome behavior
+
+- For protocol-invalid payloads, return typed `rejected` outcomes (do not
+  throw).
+- Preserve explicit failure_reason values for observability and triage.
+
+### Placement
+
+- BT orchestration module lives in core.
+- Adapters are injected by adapter-layer construction.
+- The FastAPI Inbox path remains simple caller glue around the deep module
+  interface.
+
+**Processed**: 2026-06-16 — implementation tracked in #997.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/996>.
+Spec: `specs/inbox-orchestration.yaml`.
+Notes: `notes/inbox-orchestration.md`.

--- a/specs/README.md
+++ b/specs/README.md
@@ -71,6 +71,7 @@ Load additional files only when the task touches the relevant area. See the
 | DataLayer adapter | `datalayer.md` |
 | Handler pipeline | `inbox-endpoint.yaml`, `message-validation.yaml`, `semantic-extraction.yaml`, `dispatch-routing.yaml` |
 | Inbox pipeline testability | `inbox-pipeline.yaml` |
+| Inbox orchestration (core BT module + InboxOutcome seam) | `inbox-orchestration.yaml` |
 | Behavior Trees | `behavior-tree-integration.yaml`, `behavior-tree-node-design.yaml`, `bt-composability.yaml`, `triggerable-behaviors.yaml`, `vultron/core/use_cases/triggers/AGENTS.md` |
 | Case / state management | `case-management.yaml`, `state-machine.yaml`, `case-ledger-processing.yaml` |
 | Protocol conformance | `vultron-protocol-spec.yaml`, `vultron-as2-mapping.yaml` |
@@ -144,6 +145,11 @@ Specifications are organized by topic with minimal overlap. Cross-references lin
 - **`inbox-pipeline.yaml`** - `InboxPipeline` class contract and `build_test_pipeline()`
   factory that surface the `inbox_handler → dispatcher` seam as a testable unit;
   routing-safety-net test coverage requirements (IBP-01 through IBP-04)
+
+- **`inbox-orchestration.yaml`** - Core BT-backed inbox orchestration module:
+  `InboxOutcome` model requirements, BT sequence ordering invariants, adapter
+  injection rules, caller interface constraints, and typed error/outcome
+  behavior (IO-01 through IO-04). Derived from GitHub issue #977 and ADR-0020.
 
 **DataLayer Port**:
 
@@ -440,6 +446,7 @@ is reserved for `testability.yaml`).
 | `HP` | `handler-protocol.yaml` |
 | `HTTP` | `http-protocol.yaml` |
 | `IBP` | `inbox-pipeline.yaml` |
+| `IO` | `inbox-orchestration.yaml` |
 | `IE` | `inbox-endpoint.yaml` |
 | `IMPLTS` | `tech-stack.yaml` |
 | `MV` | `message-validation.yaml` |

--- a/specs/inbox-orchestration.yaml
+++ b/specs/inbox-orchestration.yaml
@@ -1,0 +1,189 @@
+id: IO
+title: Inbox Orchestration
+description: >-
+  Testable requirements for the core BT-backed inbox orchestration module:
+  InboxOutcome model, BT sequence invariants, adapter injection rules, caller
+  interface constraints, and error/outcome behavior. Derived from design
+  discussion in GitHub issue #977.
+version: 1.0.0
+kind: pattern
+scope:
+- prototype
+- production
+groups:
+- id: IO-01
+  title: InboxOutcome Model
+  specs:
+  - id: IO-01-001
+    priority: MUST
+    statement: >-
+      The inbox orchestration module MUST define an InboxOutcome Pydantic
+      model as the sole return type of process_payload.
+    rationale: >-
+      A typed return model makes outcome inspection safe and self-documenting
+      for all callers (FastAPI, CLI, tests).
+    tags:
+    - messaging
+    - protocol
+  - id: IO-01-002
+    priority: MUST
+    statement: >-
+      InboxOutcome MUST include a status field whose value is one of:
+      processed, deferred, or rejected.
+    rationale: >-
+      Three distinct statuses cover the full protocol outcome space: a
+      successfully dispatched activity, an activity held for replay, and an
+      activity that cannot be processed.
+    tags:
+    - messaging
+  - id: IO-01-003
+    priority: MUST
+    statement: >-
+      InboxOutcome MUST include a context_id field (nullable string) carrying
+      the case or activity context identifier, when available.
+    rationale: >-
+      Callers need context identity for logging, telemetry, and pending-queue
+      management.
+    tags:
+    - messaging
+  - id: IO-01-004
+    priority: MUST
+    statement: >-
+      InboxOutcome MUST include a failure_reason field (nullable string)
+      carrying a human-readable explanation when status is rejected or
+      deferred.
+    rationale: >-
+      Explicit failure reasons support triage without log scraping.
+    tags:
+    - messaging
+    - observability
+- id: IO-02
+  title: BT Orchestration Module
+  specs:
+  - id: IO-02-001
+    priority: MUST
+    statement: >-
+      The inbox orchestration module MUST live in
+      vultron/core/behaviors/inbox/ and MUST NOT import from
+      vultron/adapters/ or any web framework.
+    rationale: >-
+      Placement in core/ satisfies the hexagonal architecture constraint
+      (ADR-0009 Rule 1) and enables the module to be used by FastAPI, CLI,
+      and test adapters equally.
+    tags:
+    - code-style
+    - code-style
+    references:
+    - docs/adr/0009-hexagonal-architecture.md
+    - docs/adr/0020-inbox-bt-orchestration.md
+  - id: IO-02-002
+    priority: MUST
+    statement: >-
+      The BT implementation MUST enforce the following fixed node ordering
+      via BT Sequence nodes: (1) parse inbound payload, (2) rehydrate
+      Activity, (3) extract MessageSemantics, (4) defer-eligibility check,
+      (5) dispatch to use-case path, (6) build typed outcome.
+    rationale: >-
+      Fixed BT ordering makes the inbound pipeline auditable and prevents
+      callers from accidentally invoking steps out of order.
+    tags:
+    - behavior-tree
+    - protocol
+  - id: IO-02-003
+    priority: MUST
+    statement: >-
+      The process_payload function MUST be the sole caller-facing entry
+      point; intermediate BT nodes MUST NOT be exported as public API.
+    rationale: >-
+      Encapsulating intermediate steps preserves depth and prevents shallow
+      reimplementations of parts of the pipeline.
+    tags:
+    - protocol
+  - id: IO-02-004
+    priority: MUST
+    statement: >-
+      The BT module MUST NOT instantiate or call a use-case class directly
+      inside a BT node update() method.
+    rationale: >-
+      Use cases create BTs; BT nodes are leaves. Calling a use case from a
+      node creates a prohibited BT-UseCase-BT chain (BT-06-006).
+    tags:
+    - behavior-tree
+    - code-style
+- id: IO-03
+  title: Adapter Injection
+  specs:
+  - id: IO-03-001
+    priority: MUST
+    statement: >-
+      process_payload MUST accept exactly two injected adapters: an ingress
+      payload adapter (raw input to as_Activity) and a dispatch adapter
+      (VultronEvent to use-case execution).
+    rationale: >-
+      Two well-named adapters keep the seam explicit and prevent the adapter
+      matrix from growing large enough to make the module shallow again.
+    tags:
+    - tooling
+    - tooling
+    references:
+    - docs/adr/0020-inbox-bt-orchestration.md
+  - id: IO-03-002
+    priority: MUST
+    statement: >-
+      Pending-queue management MUST be provided to the BT module via an
+      injected port dependency and MUST NOT be accessed directly from
+      vultron/adapters/.
+    rationale: >-
+      Injecting the pending-queue port keeps core/ free of adapter
+      dependencies and aligns with hexagonal architecture.
+    tags:
+    - tooling
+    - tooling
+    - code-style
+  - id: IO-03-003
+    priority: MUST
+    statement: >-
+      The FastAPI inbox path MUST supply adapter implementations at
+      construction time and MUST NOT contain any inbox policy logic.
+    rationale: >-
+      Policy logic in the router violates ADR-0009 Rule 1 and makes the
+      orchestration untestable without a running FastAPI app.
+    tags:
+    - tooling
+    - tooling
+- id: IO-04
+  title: Caller Interface
+  specs:
+  - id: IO-04-001
+    priority: MUST
+    statement: >-
+      process_payload MUST always return an InboxOutcome; it MUST NOT raise
+      exceptions for protocol-invalid payloads.
+    rationale: >-
+      Typed outcomes allow callers to handle all cases uniformly without
+      exception-driven control flow at the integration boundary.
+    tags:
+    - protocol
+    - error-handling
+  - id: IO-04-002
+    priority: MUST
+    statement: >-
+      Tests MUST assert on InboxOutcome.status and InboxOutcome.failure_reason;
+      they MUST NOT patch internal BT node helpers to verify pipeline behavior.
+    rationale: >-
+      Interface-level test assertions are resilient to internal refactors and
+      validate the contract rather than the implementation.
+    tags:
+    - testing
+  - id: IO-04-003
+    priority: SHOULD
+    statement: >-
+      Both a production ASGI adapter and an in-memory test adapter SHOULD
+      implement the ingress payload adapter interface, so that the same
+      process_payload seam is used in both runtime and test contexts.
+    rationale: >-
+      Shared interface across runtime and test adapters validates real-world
+      behavior and reduces adapter-specific test scaffolding.
+    tags:
+    - testing
+    - tooling


### PR DESCRIPTION
- Closes #977

## Summary

Plans GitHub issue #977: moves inbox orchestration into a core BT module
with a typed `process_payload(...) -> InboxOutcome` seam. Produces the
spec, design notes, and a proposed ADR documenting the evaluated
alternatives before implementation begins.

## Changes

- **`specs/inbox-orchestration.yaml`** — New spec file (prefix `IO-`,
  14 requirements across IO-01–IO-04): `InboxOutcome` model fields, BT
  sequence ordering invariants, adapter injection rules (two adapters +
  pending-queue port), and caller interface constraints including typed
  outcomes for protocol-invalid payloads.
- **`notes/inbox-orchestration.md`** — Design decisions: why
  orchestration belongs in `core/`, two-adapter seam rationale,
  `InboxOutcome` contract, pending-queue port injection, and migration
  path from existing `InboxPipeline`/`inbox_handler`.
- **`docs/adr/0020-inbox-bt-orchestration.md`** — Proposed ADR for moving
  inbox orchestration to a BT-backed core module; documents evaluated
  alternatives (keep in adapter layer, plain function, BT-backed module).
- **`docs/adr/index.md`** — Adds ADR-0020 to Proposed ADRs.
- **`specs/README.md`** — Adds `inbox-orchestration.yaml` entry and
  `IO` prefix to the prefix table.
- **`notes/README.md`** — Adds `inbox-orchestration.md` to the
  Architecture section.
- **`AGENTS.md`** — New pitfall: *Inbox Policy Logic Must Live in the
  Core BT Module, Not the FastAPI Router*.