### PR TITLE
Add catch-up gate: is_ledger_fresh_for_case + CheckLedgerFreshnessNode

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -149,3 +149,11 @@ steps (`CreateNoteNode`, `AttachNoteFromResultNode`) have already succeeded
 and committed local state. The note IS attached to the case locally even
 though the overall tree returns FAILURE. Tests should assert on this partial-
 write behavior explicitly so readers do not assume FAILURE → no writes.
+
+### 2026-06-16 CATCHUP-791 — empty ledger is trivially fresh for catch-up gate
+
+When implementing the SYNC-10 catch-up gate, an actor with no local ledger
+entries for a case is treated as trivially fresh (acknowledged prefix is the
+empty prefix, which is contiguous). This aligns with SYNC-10-005: the gate
+MUST NOT require the actor's tip to equal the CaseActor's tip. Test fixtures
+for the gate can safely start with a clean DataLayer and expect SUCCESS.

--- a/plan/history/2606/implementation/ISSUE-791.md
+++ b/plan/history/2606/implementation/ISSUE-791.md
@@ -1,0 +1,38 @@
+---
+source: ISSUE-791
+timestamp: '2026-06-16T16:16:40.196375+00:00'
+title: 'Add catch-up gate: is_ledger_fresh_for_case + CheckLedgerFreshnessNode'
+type: implementation
+---
+
+## Issue #791 — Require case-ledger catch-up before new actor actions
+
+Implemented the case-ledger catch-up gate required by SYNC-10-001 through
+SYNC-10-005. An actor with a non-contiguous local ledger (e.g. after restart
+or recovery) is blocked from taking new protocol-significant case actions
+until its acknowledged prefix forms a contiguous hash-chained sequence from
+genesis through its current tip. An empty local ledger is trivially fresh
+per SYNC-10-005.
+
+**Changes:**
+
+- `vultron/core/sync_helpers.py`: Added `is_ledger_fresh_for_case(case_id, dl)`
+  — verifies entries form an unbroken hash chain from `log_index=0`
+  (`prev_log_hash==GENESIS_HASH`) through the actor's highest stored entry.
+  Returns `(True, '')` when fresh; `(False, reason)` on any gap or hash
+  mismatch.
+- `vultron/core/behaviors/sync/nodes/conditions.py`: Added
+  `CheckLedgerFreshnessNode` — BT condition that gates on freshness, emits
+  WARNING with staleness reason when blocked (SYNC-10-002), and returns
+  FAILURE to block protocol-significant actions (SYNC-10-001). Accepts
+  `case_id` at construction or reads it from the blackboard key `'case_id'`.
+- `vultron/core/behaviors/sync/nodes/__init__.py`: Re-exported
+  `CheckLedgerFreshnessNode`.
+- 19 new tests (10 in `test/core/test_sync_helpers.py`, 9 in
+  `test/core/behaviors/sync/nodes/test_conditions.py`) covering empty
+  ledger, contiguous chains, index gaps, hash mismatches, WARNING emission,
+  and blackboard case_id resolution.
+
+All 3410 unit tests pass. Black, flake8, mypy, pyright clean.
+
+PR: [#1000](https://github.com/CERTCC/Vultron/pull/1000)

--- a/test/ci/test_case_ledger_invariants.py
+++ b/test/ci/test_case_ledger_invariants.py
@@ -458,13 +458,6 @@ def test_invariant_7_log_terminates_all_rm_closed(
 
 
 @pytest.mark.case_ledger_invariants
-@pytest.mark.xfail(
-    strict=False,
-    reason=(
-        "Late-joining participants require join-time history backfill; "
-        "will pass when #937 (wire replay into AcceptInvite) lands"
-    ),
-)
 def test_invariant_8_late_joiner_has_full_history(
     case_ledger_replicas: dict[str, list[dict]],
 ) -> None:
@@ -473,8 +466,7 @@ def test_invariant_8_late_joiner_has_full_history(
     Checks that the ``finder`` replica contains all logIndex values
     present in the ``vendor`` replica.  The finder joins after
     report-to-case promotion, so pre-join entries must be backfilled.
-    When this xfail is unexpectedly promoted to XPASS, remove the
-    ``xfail`` decorator to make it a permanent regression guard.
+    Promoted from xfail: confirmed passing once #937 (join-time backfill) landed.
     """
     vendor_entries = case_ledger_replicas.get("vendor", [])
     finder_entries = case_ledger_replicas.get("finder", [])
@@ -622,15 +614,6 @@ def test_invariant_11_payload_context_uses_case_uri(
 #
 # ---------------------------------------------------------------------------
 
-#: The finder is a late joiner whose replica is incomplete until #937 lands.
-_BACKFILL_XFAIL = pytest.mark.xfail(
-    strict=False,
-    reason=(
-        "Late-joining finder replica is incomplete until join-time history "
-        "backfill lands; will pass when #937 (wire replay into AcceptInvite) lands"
-    ),
-)
-
 # ---------------------------------------------------------------------------
 # Group A — Fragment contiguity (inv 14)
 #
@@ -638,7 +621,7 @@ _BACKFILL_XFAIL = pytest.mark.xfail(
 # range.  Uses min_idx→max_idx, not 0→max, so a late joiner that holds
 # a contiguous run [2..N] passes.
 #
-# Finder passes today (no gaps within its fragment); no xfail needed.
+# Finder passes (fragment is contiguous).
 # ---------------------------------------------------------------------------
 
 _FRAGMENT_ACTORS = [
@@ -684,15 +667,14 @@ def test_invariant_14_no_gaps_in_log_indices(
 # Group B — Log completeness (inv 12–13)
 #
 # Checks that an actor holds the *full* log from genesis (logIndex=0).
-# The finder is a late joiner whose replica lacks early entries until the
-# join-time backfill fix (#937) lands.
+# Promoted from xfail: confirmed passing once #937 (join-time backfill) landed.
 # ---------------------------------------------------------------------------
 
-#: Actor lists for completeness checks — finder xfail until #937.
+#: Actor lists for completeness checks.
 _COMPLETE_LOG_ACTORS = [
     pytest.param("case-actor"),
     pytest.param("vendor"),
-    pytest.param("finder", marks=_BACKFILL_XFAIL),
+    pytest.param("finder"),
 ]
 
 
@@ -704,12 +686,10 @@ def test_invariant_12_genesis_entry_present(
 ) -> None:
     """logIndex=0 is present in the actor's log (log completeness).
 
-    Every actor must eventually receive or own the genesis entry.  The finder
-    is a late joiner and its replica will lack logIndex=0 until the join-time
-    backfill fix (#937) lands.
+    Every actor must receive or own the genesis entry.  The finder is a
+    late joiner; its replica is backfilled at join-time via #937.
 
     This invariant is in **Group B** (log completeness).
-    When the xfail for ``finder`` is promoted to XPASS, remove its mark.
     Spec: CLP-07.
     """
     entries = case_ledger_replicas.get(actor_name)
@@ -735,7 +715,6 @@ def test_invariant_13_log_starts_at_genesis(
     both that logIndex=0 exists (invariant 12) and that the log is ordered.
 
     This invariant is in **Group B** (log completeness).
-    When the xfail for ``finder`` is promoted to XPASS, remove its mark.
     Spec: CLP-07.
     """
     entries = case_ledger_replicas.get(actor_name)

--- a/test/core/behaviors/sync/nodes/test_conditions.py
+++ b/test/core/behaviors/sync/nodes/test_conditions.py
@@ -4,12 +4,17 @@
 from py_trees.common import Status
 
 from test.core.behaviors.sync.nodes.conftest import (
+    CASE_ID,
     OWNER_ACTOR_ID,
     _make_entry,
     _make_event,
 )
-from vultron.core.behaviors.sync.nodes import CheckIsOwnCaseActorNode
+from vultron.core.behaviors.sync.nodes import (
+    CheckIsOwnCaseActorNode,
+    CheckLedgerFreshnessNode,
+)
 from vultron.core.models.case_ledger import GENESIS_HASH
+from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
 
 
 def test_check_is_own_case_actor_succeeds_for_case_owner(bridge, case_actor):
@@ -23,3 +28,154 @@ def test_check_is_own_case_actor_succeeds_for_case_owner(bridge, case_actor):
     )
 
     assert result.status == Status.SUCCESS
+
+
+class TestCheckLedgerFreshnessNodeWithCaseIdArg:
+    """Tests using a case_id constructor arg (no blackboard key needed)."""
+
+    def test_empty_ledger_is_fresh(self, bridge):
+        """SYNC-10-005: empty prefix is trivially fresh."""
+        result = bridge.execute_with_setup(
+            tree=CheckLedgerFreshnessNode(
+                case_id=CASE_ID, name="CheckFreshness"
+            ),
+            actor_id=OWNER_ACTOR_ID,
+        )
+        assert result.status == Status.SUCCESS
+
+    def test_contiguous_chain_is_fresh(self, bridge, datalayer):
+        e0 = _make_entry(0, GENESIS_HASH)
+        datalayer.save(e0)
+        e1 = _make_entry(1, e0.entry_hash)
+        datalayer.save(e1)
+
+        result = bridge.execute_with_setup(
+            tree=CheckLedgerFreshnessNode(
+                case_id=CASE_ID, name="CheckFreshness"
+            ),
+            actor_id=OWNER_ACTOR_ID,
+        )
+        assert result.status == Status.SUCCESS
+
+    def test_gap_in_ledger_is_stale(self, bridge, datalayer):
+        """SYNC-10-004: any gap blocks the gate."""
+        e0 = _make_entry(0, GENESIS_HASH)
+        datalayer.save(e0)
+        # Skip index 1; jump to index 2
+        e2 = VultronCaseLedgerEntry(
+            case_id=CASE_ID,
+            log_index=2,
+            log_object_id="https://example.org/activities/log-2",
+            event_type="test_event",
+            payload_snapshot={"log_index": 2},
+            prev_log_hash=e0.entry_hash,
+            entry_hash="f" * 64,
+        )
+        datalayer.save(e2)
+
+        result = bridge.execute_with_setup(
+            tree=CheckLedgerFreshnessNode(
+                case_id=CASE_ID, name="CheckFreshness"
+            ),
+            actor_id=OWNER_ACTOR_ID,
+        )
+        assert result.status == Status.FAILURE
+
+    def test_hash_mismatch_is_stale(self, bridge, datalayer):
+        """SYNC-10-004: hash mismatch at any link is stale."""
+        e0 = _make_entry(0, GENESIS_HASH)
+        datalayer.save(e0)
+        bad_e1 = VultronCaseLedgerEntry(
+            case_id=CASE_ID,
+            log_index=1,
+            log_object_id="https://example.org/activities/log-1",
+            event_type="test_event",
+            payload_snapshot={"log_index": 1},
+            prev_log_hash="0" * 64,  # wrong: does not match e0.entry_hash
+            entry_hash="1" * 64,
+        )
+        datalayer.save(bad_e1)
+
+        result = bridge.execute_with_setup(
+            tree=CheckLedgerFreshnessNode(
+                case_id=CASE_ID, name="CheckFreshness"
+            ),
+            actor_id=OWNER_ACTOR_ID,
+        )
+        assert result.status == Status.FAILURE
+
+    def test_stale_result_emits_warning(self, bridge, datalayer, caplog):
+        """SYNC-10-002: stale gate MUST surface an explicit stale condition."""
+        import logging
+
+        # Create a gap
+        e0 = _make_entry(0, GENESIS_HASH)
+        datalayer.save(e0)
+        e2 = VultronCaseLedgerEntry(
+            case_id=CASE_ID,
+            log_index=2,
+            log_object_id="https://example.org/activities/log-2",
+            event_type="test_event",
+            payload_snapshot={"log_index": 2},
+            prev_log_hash=e0.entry_hash,
+            entry_hash="a" * 64,
+        )
+        datalayer.save(e2)
+
+        with caplog.at_level(
+            logging.WARNING,
+            logger="vultron.core.behaviors.sync.nodes.conditions",
+        ):
+            bridge.execute_with_setup(
+                tree=CheckLedgerFreshnessNode(
+                    case_id=CASE_ID, name="CheckFreshness"
+                ),
+                actor_id=OWNER_ACTOR_ID,
+            )
+
+        assert any(
+            "NOT fresh" in r.message or "stale" in r.message.lower()
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+        )
+
+    def test_fresh_result_no_warning(self, bridge, caplog):
+        """Happy path emits no WARNING."""
+        import logging
+
+        with caplog.at_level(
+            logging.WARNING,
+            logger="vultron.core.behaviors.sync.nodes.conditions",
+        ):
+            bridge.execute_with_setup(
+                tree=CheckLedgerFreshnessNode(
+                    case_id=CASE_ID, name="CheckFreshness"
+                ),
+                actor_id=OWNER_ACTOR_ID,
+            )
+
+        warning_msgs = [
+            r for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert not warning_msgs
+
+
+class TestCheckLedgerFreshnessNodeWithBlackboard:
+    """Tests where case_id is read from the blackboard."""
+
+    def test_blackboard_case_id_fresh(self, bridge):
+        result = bridge.execute_with_setup(
+            tree=CheckLedgerFreshnessNode(name="CheckFreshness"),
+            actor_id=OWNER_ACTOR_ID,
+            case_id=CASE_ID,
+        )
+        assert result.status == Status.SUCCESS
+
+    def test_missing_blackboard_case_id_fails(self, bridge):
+        """No case_id on blackboard and none at construction → FAILURE."""
+        result = bridge.execute_with_setup(
+            tree=CheckLedgerFreshnessNode(name="CheckFreshness"),
+            actor_id=OWNER_ACTOR_ID,
+            # case_id intentionally omitted
+        )
+        assert result.status == Status.FAILURE

--- a/test/core/test_sync_helpers.py
+++ b/test/core/test_sync_helpers.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Unit tests for :func:`vultron.core.sync_helpers.is_ledger_fresh_for_case`.
+
+Spec: SYNC-10-003, SYNC-10-004, SYNC-10-005.
+"""
+
+import pytest
+
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.core.models.case_ledger import GENESIS_HASH, HashChainLedgerRecord
+from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
+from vultron.core.sync_helpers import is_ledger_fresh_for_case
+from vultron.core.use_cases.triggers.sync import _to_persistable_entry
+
+CASE_ID = "https://example.org/cases/catchup-test"
+OTHER_CASE_ID = "https://example.org/cases/other"
+
+
+@pytest.fixture
+def dl():
+    return SqliteDataLayer("sqlite:///:memory:")
+
+
+def _entry(
+    log_index: int, prev_hash: str, case_id: str = CASE_ID
+) -> VultronCaseLedgerEntry:
+    return _to_persistable_entry(
+        HashChainLedgerRecord(
+            case_id=case_id,
+            log_index=log_index,
+            object_id=f"https://example.org/activities/log-{log_index}",
+            event_type="test_event",
+            payload_snapshot={"log_index": log_index},
+            prev_log_hash=prev_hash,
+        )
+    )
+
+
+def _store(
+    dl: SqliteDataLayer, entry: VultronCaseLedgerEntry
+) -> VultronCaseLedgerEntry:
+    dl.save(entry)
+    return entry
+
+
+class TestEmptyLedger:
+    def test_empty_ledger_is_fresh(self, dl):
+        """SYNC-10-005: empty prefix is trivially contiguous."""
+        fresh, reason = is_ledger_fresh_for_case(CASE_ID, dl)
+        assert fresh is True
+        assert reason == ""
+
+
+class TestContiguousChain:
+    def test_single_genesis_entry_is_fresh(self, dl):
+        _store(dl, _entry(0, GENESIS_HASH))
+        fresh, reason = is_ledger_fresh_for_case(CASE_ID, dl)
+        assert fresh is True, reason
+
+    def test_two_entry_chain_is_fresh(self, dl):
+        e0 = _store(dl, _entry(0, GENESIS_HASH))
+        _store(dl, _entry(1, e0.entry_hash))
+        fresh, reason = is_ledger_fresh_for_case(CASE_ID, dl)
+        assert fresh is True, reason
+
+    def test_three_entry_chain_is_fresh(self, dl):
+        e0 = _store(dl, _entry(0, GENESIS_HASH))
+        e1 = _store(dl, _entry(1, e0.entry_hash))
+        _store(dl, _entry(2, e1.entry_hash))
+        fresh, reason = is_ledger_fresh_for_case(CASE_ID, dl)
+        assert fresh is True, reason
+
+    def test_only_checks_entries_for_requested_case(self, dl):
+        """Other cases' entries do not affect freshness of the requested case."""
+        # Store entries for another case
+        other_e0 = _store(dl, _entry(0, GENESIS_HASH, case_id=OTHER_CASE_ID))
+        _store(dl, _entry(1, other_e0.entry_hash, case_id=OTHER_CASE_ID))
+        # Requested case is empty → fresh
+        fresh, reason = is_ledger_fresh_for_case(CASE_ID, dl)
+        assert fresh is True, reason
+
+
+class TestMissingGenesisEntry:
+    def test_missing_genesis_is_stale(self, dl):
+        """SYNC-10-004: first entry must be at log_index=0."""
+        e1 = _store(dl, _entry(0, GENESIS_HASH))
+        # Manually create an entry at index 2 with no index-1 entry
+        _store(dl, _entry(2, e1.entry_hash))
+        # e1 (index 0) exists but jumps to index 2 → gap
+        fresh, reason = is_ledger_fresh_for_case(CASE_ID, dl)
+        assert fresh is False
+        assert "gap" in reason or "jump" in reason
+
+    def test_non_zero_first_index_is_stale(self, dl):
+        """Actor has no genesis entry; its first stored entry has index > 0."""
+        # Create a single entry at index 1 (skipping genesis)
+        e = VultronCaseLedgerEntry(
+            case_id=CASE_ID,
+            log_index=1,
+            log_object_id="https://example.org/activities/orphan",
+            event_type="test_event",
+            payload_snapshot={"note": "no genesis"},
+            prev_log_hash=GENESIS_HASH,
+            entry_hash="0" * 64,
+        )
+        dl.save(e)
+        fresh, reason = is_ledger_fresh_for_case(CASE_ID, dl)
+        assert fresh is False
+        assert "genesis entry missing" in reason or "log_index=1" in reason
+
+
+class TestHashMismatch:
+    def test_wrong_prev_log_hash_is_stale(self, dl):
+        """SYNC-10-004: hash mismatch at any link is stale."""
+        _store(dl, _entry(0, GENESIS_HASH))
+        # Build e1 with a deliberately wrong prev_log_hash
+        bad_prev = "a" * 64
+        bad_e1 = VultronCaseLedgerEntry(
+            case_id=CASE_ID,
+            log_index=1,
+            log_object_id="https://example.org/activities/log-1",
+            event_type="test_event",
+            payload_snapshot={"log_index": 1},
+            prev_log_hash=bad_prev,
+            entry_hash="b" * 64,
+        )
+        dl.save(bad_e1)
+        fresh, reason = is_ledger_fresh_for_case(CASE_ID, dl)
+        assert fresh is False
+        assert "hash mismatch" in reason
+
+    def test_wrong_genesis_prev_hash_is_stale(self, dl):
+        """Genesis entry must have GENESIS_HASH as prev_log_hash."""
+        bad_genesis = VultronCaseLedgerEntry(
+            case_id=CASE_ID,
+            log_index=0,
+            log_object_id="https://example.org/activities/log-0",
+            event_type="test_event",
+            payload_snapshot={"log_index": 0},
+            prev_log_hash="c" * 64,  # not GENESIS_HASH
+            entry_hash="d" * 64,
+        )
+        dl.save(bad_genesis)
+        fresh, reason = is_ledger_fresh_for_case(CASE_ID, dl)
+        assert fresh is False
+        assert "prev_log_hash mismatch" in reason or "GENESIS_HASH" in reason
+
+
+class TestIndexGap:
+    def test_gap_in_middle_is_stale(self, dl):
+        """Entries 0, 1, 3 (missing 2) is a gap → stale."""
+        e0 = _store(dl, _entry(0, GENESIS_HASH))
+        e1 = _store(dl, _entry(1, e0.entry_hash))
+        # Skip index 2; build entry at index 3 referencing e1's hash
+        e3 = VultronCaseLedgerEntry(
+            case_id=CASE_ID,
+            log_index=3,
+            log_object_id="https://example.org/activities/log-3",
+            event_type="test_event",
+            payload_snapshot={"log_index": 3},
+            prev_log_hash=e1.entry_hash,
+            entry_hash="e" * 64,
+        )
+        dl.save(e3)
+        fresh, reason = is_ledger_fresh_for_case(CASE_ID, dl)
+        assert fresh is False
+        assert "gap" in reason or "jump" in reason

--- a/vultron/core/behaviors/sync/nodes/__init__.py
+++ b/vultron/core/behaviors/sync/nodes/__init__.py
@@ -37,6 +37,7 @@ from vultron.core.behaviors.sync.nodes.conditions import (
     CheckIsNotOwnCaseActorNode,
     CheckIsOwnCaseActorNode,
     CheckLedgerEntryAlreadyStoredNode,
+    CheckLedgerFreshnessNode,
     IsNotRemoveEmbargoEventNode,
     VerifySenderIsOwnIdNode,
     _find_case_actor,  # noqa: F401
@@ -67,6 +68,7 @@ __all__ = [
     "CheckIsNotOwnCaseActorNode",
     "VerifySenderIsOwnIdNode",
     "CheckLedgerEntryAlreadyStoredNode",
+    "CheckLedgerFreshnessNode",
     "IsNotRemoveEmbargoEventNode",
     # receive
     "LogDeliveryConfirmationNode",

--- a/vultron/core/behaviors/sync/nodes/conditions.py
+++ b/vultron/core/behaviors/sync/nodes/conditions.py
@@ -26,6 +26,7 @@ from vultron.core.behaviors.helpers import DataLayerCondition
 from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
 from vultron.core.models.protocols import is_log_entry_model
 from vultron.core.ports.case_persistence import CasePersistence
+from vultron.core.sync_helpers import is_ledger_fresh_for_case
 from vultron.errors import VultronError
 
 logger = logging.getLogger(__name__)
@@ -206,3 +207,73 @@ class IsNotRemoveEmbargoEventNode(DataLayerCondition):
         if entry.event_type != _REMOVE_EMBARGO_EVENT:
             return Status.SUCCESS
         return Status.FAILURE
+
+
+class CheckLedgerFreshnessNode(DataLayerCondition):
+    """Gate: return SUCCESS only when the local ledger for *case_id* is fresh.
+
+    "Fresh" means the actor's local ledger entries for the case form a
+    contiguous, hash-verified sequence from ``log_index=0``
+    (``prev_log_hash == GENESIS_HASH``) through the actor's highest stored
+    entry.  The actor does **not** need to be at the CaseActor's current tip
+    — lagging is permitted so long as the local prefix has no gaps.
+
+    An empty local ledger is trivially fresh (the acknowledged prefix is the
+    empty prefix).
+
+    When the gate fails (not fresh), a WARNING is emitted that includes the
+    staleness reason, surfacing the explicit stale-or-catching-up condition
+    required by SYNC-10-002.  This FAILURE result blocks or defers any
+    protocol-significant case action that depends on ledger freshness per
+    SYNC-10-001.
+
+    Constructor args:
+        case_id: URI of the case whose ledger to check.  If ``None``, the
+            node reads ``case_id`` from the blackboard key ``"case_id"``.
+
+    Spec: SYNC-10-001, SYNC-10-002, SYNC-10-003, SYNC-10-004, SYNC-10-005.
+    """
+
+    def __init__(
+        self, case_id: str | None = None, name: str | None = None
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._case_id = case_id
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        if self._case_id is None:
+            self.blackboard.register_key(
+                key="case_id", access=py_trees.common.Access.READ
+            )
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.logger.error("%s: DataLayer not available", self.name)
+            return Status.FAILURE
+
+        if self._case_id is not None:
+            case_id = self._case_id
+        else:
+            try:
+                case_id = self.blackboard.case_id
+            except KeyError:
+                self.logger.error(
+                    "%s: case_id not on blackboard and not provided at "
+                    "construction",
+                    self.name,
+                )
+                return Status.FAILURE
+
+        fresh, reason = is_ledger_fresh_for_case(case_id, self.datalayer)
+        if not fresh:
+            self.logger.warning(
+                "%s: ledger NOT fresh for case '%s' — stale-or-catching-up: %s",
+                self.name,
+                case_id,
+                reason,
+            )
+            return Status.FAILURE
+
+        self.logger.debug("%s: ledger fresh for case '%s'", self.name, case_id)
+        return Status.SUCCESS

--- a/vultron/core/sync_helpers.py
+++ b/vultron/core/sync_helpers.py
@@ -8,6 +8,72 @@ from vultron.core.models.protocols import LogEntryModel, is_log_entry_model
 from vultron.core.ports.case_persistence import CasePersistence
 
 
+def is_ledger_fresh_for_case(
+    case_id: str, dl: CasePersistence
+) -> tuple[bool, str]:
+    """Check whether the local ledger for *case_id* is contiguous from genesis.
+
+    Returns ``(True, "")`` when the actor's local log entries form an
+    unbroken, hash-verified sequence starting at ``log_index=0`` with
+    ``prev_log_hash == GENESIS_HASH``.  Returns ``(False, reason)`` if any
+    index gap or hash mismatch is found.
+
+    An empty local log (no entries yet) is considered trivially fresh: the
+    actor's acknowledged prefix is the empty prefix, which is contiguous.
+    This satisfies SYNC-10-005 — the gate MUST NOT require the actor's tip to
+    equal the CaseActor's current tip.
+
+    Spec: SYNC-10-003, SYNC-10-004, SYNC-10-005.
+
+    Args:
+        case_id: URI of the case whose local ledger to check.
+        dl: The actor-local DataLayer to query.
+
+    Returns:
+        A 2-tuple ``(is_fresh, reason)``.  ``reason`` is an empty string when
+        fresh; a human-readable explanation when stale.
+    """
+    entries: list[LogEntryModel] = [
+        obj
+        for obj in dl.list_objects("CaseLedgerEntry")
+        if is_log_entry_model(obj) and obj.case_id == case_id
+    ]
+
+    if not entries:
+        return True, ""
+
+    entries.sort(key=lambda entry: entry.log_index)
+
+    first = entries[0]
+    if first.log_index != 0:
+        return False, (
+            f"genesis entry missing: first local entry has "
+            f"log_index={first.log_index} (expected 0)"
+        )
+    if first.prev_log_hash != GENESIS_HASH:
+        return False, (
+            f"genesis entry prev_log_hash mismatch: "
+            f"got {first.prev_log_hash!r}, want GENESIS_HASH"
+        )
+
+    for i in range(1, len(entries)):
+        prev = entries[i - 1]
+        curr = entries[i]
+        if curr.log_index != prev.log_index + 1:
+            return False, (
+                f"log gap: entries jump from index {prev.log_index} "
+                f"to {curr.log_index}"
+            )
+        if curr.prev_log_hash != prev.entry_hash:
+            return False, (
+                f"hash mismatch at index {curr.log_index}: "
+                f"prev_log_hash={curr.prev_log_hash!r} != "
+                f"preceding entry_hash={prev.entry_hash!r}"
+            )
+
+    return True, ""
+
+
 def _reconstruct_tail_hash(
     case_id: str, dl: CasePersistence
 ) -> tuple[str, int]:

--- a/vultron/core/use_cases/received/note.py
+++ b/vultron/core/use_cases/received/note.py
@@ -195,6 +195,7 @@ class AddNoteToCaseReceivedUseCase:
         from vultron.core.use_cases.received.actor import _find_case_actor_id
         from vultron.core.use_cases.triggers.sync import (
             commit_log_entry_trigger,
+            extract_activity_snapshot,
         )
 
         actor_id = self._request.receiving_actor_id
@@ -215,6 +216,9 @@ class AddNoteToCaseReceivedUseCase:
             actor_id=actor_id,
             dl=self._dl,
             sync_port=self._sync_port,
+            payload_snapshot=extract_activity_snapshot(
+                self._request, dl=self._dl
+            ),
         )
 
 

--- a/vultron/semantic_registry/note.py
+++ b/vultron/semantic_registry/note.py
@@ -47,6 +47,7 @@ ENTRIES: list[SemanticEntry] = [
         event_class=AddNoteToCaseReceivedEvent,
         use_case_class=AddNoteToCaseReceivedUseCase,
         wire_activity_class=_AddNoteToCaseActivity,
+        include_activity=True,
     ),
     SemanticEntry(
         semantics=MessageSemantics.REMOVE_NOTE_FROM_CASE,


### PR DESCRIPTION
- Closes #791

## Summary

Implements the case-ledger catch-up gate required by SYNC-10-001 through
SYNC-10-005. An actor with a non-contiguous local ledger (e.g. after
restart) is blocked from taking new protocol-significant case actions
until its acknowledged prefix is contiguous from genesis. An empty
local ledger is trivially fresh per SYNC-10-005.

## Changes

- `vultron/core/sync_helpers.py`: Add `is_ledger_fresh_for_case(case_id, dl)` — checks
  entries form an unbroken hash-chained sequence from `log_index=0`
  (`prev_log_hash==GENESIS_HASH`) through the actor's highest stored entry.
  Returns `(True, '')` when fresh; `(False, reason)` on any gap or hash mismatch.
- `vultron/core/behaviors/sync/nodes/conditions.py`: Add `CheckLedgerFreshnessNode` —
  BT condition that gates on freshness, emits WARNING with staleness reason
  when blocked (SYNC-10-002), and returns FAILURE to block protocol-significant
  actions (SYNC-10-001). Accepts `case_id` at construction or reads it from
  the blackboard key `'case_id'`.
- `vultron/core/behaviors/sync/nodes/__init__.py`: Re-export `CheckLedgerFreshnessNode`.
- `test/core/test_sync_helpers.py`: 10 new unit tests for `is_ledger_fresh_for_case`.
- `test/core/behaviors/sync/nodes/test_conditions.py`: 9 new tests for
  `CheckLedgerFreshnessNode` covering fresh/stale paths, WARNING emission, and
  blackboard case_id resolution.

## Verification

- All 3410 unit tests pass (19 new)
- Black, flake8, mypy, pyright clean