### PR TITLE
Normalize ParticipantStatus context to case URI at report→case promotion

### DIFF
--- a/plan/history/2606/implementation/ISSUE-932.md
+++ b/plan/history/2606/implementation/ISSUE-932.md
@@ -1,0 +1,36 @@
+---
+source: ISSUE-932
+timestamp: '2026-06-16T16:24:23.667240+00:00'
+title: Normalize ParticipantStatus context to case URI at report→case promotion
+type: implementation
+---
+
+## Issue #932 — Normalize ParticipantStatus context to case URI at report→case promotion
+
+Implemented CLP-07-007: `ParticipantStatus.context` must use the case URI
+once a case exists. Before this fix, three RM-transition BT nodes and
+`_get_or_create_accepted_status` created status records with
+`context=report_id` even after a case had been promoted, violating the
+canonical ledger context invariant.
+
+**Changes:**
+
+- `rm_transitions.py`: `TransitionRMtoValid/Invalid/Closed` now call
+  `find_case_by_report_id()` before constructing `ParticipantStatus`;
+  use `case.id_` as context when available (fallback: `report_id`).
+- `common.py`: `_get_or_create_accepted_status()` performs the same
+  lookup; adds AC-3 backfill — updates `existing.context` from
+  `report_id` → `case_id` when a case has since been promoted.
+- `protocols.py`: Adds `is_participant_status_model()` TypeGuard helper
+  that checks `type_ == "ParticipantStatus"` structurally so it works
+  for both the core model and the wire-layer type returned by the
+  DataLayer vocabulary registry.
+- `participant_add.py`: Switches `isinstance(…, ParticipantStatus)` guard
+  to `is_participant_status_model()` for the same reason.
+
+**Tests:** 5 new AC-2 tests in `test_rm_transitions.py` (context = case URI
+for each transition + fallback), AC-3 backfill test in `test_participant_add.py`.
+
+**Verification:** 3397 passed, 0 failed (unit suite).
+
+PR: [#1002](https://github.com/CERTCC/Vultron/pull/1002)

--- a/test/core/behaviors/case/nodes/participant/test_participant_add.py
+++ b/test/core/behaviors/case/nodes/participant/test_participant_add.py
@@ -37,7 +37,11 @@ from vultron.core.behaviors.case.nodes.participant import (
 )
 from vultron.core.models.embargo_event import EmbargoEvent
 from vultron.core.models.participant_status import ParticipantStatus
-from vultron.core.models.vultron_types import VultronCase, VultronCaseActor
+from vultron.core.models.vultron_types import (
+    VultronCase,
+    VultronCaseActor,
+    VultronReport,
+)
 from vultron.core.states.participant_embargo_consent import PEC
 from vultron.core.states.rm import RM
 from vultron.core.states.roles import CVDRole
@@ -234,3 +238,50 @@ class TestCreateCaseParticipantNode:
         refreshed = cast(Any, bt_scenario.dl.read(status_id))
         assert refreshed is not None
         assert refreshed.em_consent_state == PEC.SIGNATORY
+
+    def test_backfills_context_to_case_uri_for_existing_status(
+        self,
+        bt_scenario: BTTestScenario,
+        report: VultronReport,
+        case_obj: VultronCase,
+    ) -> None:
+        """AC-3: existing ParticipantStatus with report-URI context is migrated.
+
+        When a pre-fix status was created with context=report_id, a subsequent
+        call to _get_or_create_accepted_status (via ResolveParticipantAcceptedStatusNode)
+        must backfill the context to the case URI (CLP-07-007).
+        """
+        actor_id = "https://example.org/actors/finder"
+        status_id = _report_phase_status_id(
+            actor_id, report.id_, RM.ACCEPTED.value
+        )
+        # Seed a stale status with report-URI context (pre-fix state).
+        stale = ParticipantStatus(
+            id_=status_id,
+            context=report.id_,
+            attributed_to=actor_id,
+            rm_state=RM.ACCEPTED,
+            em_consent_state=PEC.NO_EMBARGO,
+            cvd_role=[CVDRole.FINDER],
+        )
+        bt_scenario.dl.create(stale)
+
+        result = bt_scenario.run(
+            ResolveParticipantAcceptedStatusNode(
+                participant_actor_id=actor_id,
+                roles=[CVDRole.FINDER],
+                report_id=report.id_,
+            ),
+            actor_id=actor_id,
+        )
+        bt_scenario.assert_success(result)
+
+        backfilled = cast(Any, bt_scenario.dl.read(status_id))
+        assert backfilled is not None
+        assert backfilled.context == case_obj.id_, (
+            f"Expected context backfilled to {case_obj.id_!r}, "
+            f"got {backfilled.context!r} (CLP-07-007)"
+        )
+        assert (
+            backfilled.context != report.id_
+        ), "ParticipantStatus.context must not remain the report URI after backfill"

--- a/test/core/behaviors/report/nodes/conftest.py
+++ b/test/core/behaviors/report/nodes/conftest.py
@@ -24,13 +24,14 @@ package runs.
 import pytest
 
 from vultron.core.models.activity import VultronOffer
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_actor import VultronCaseActor
 from vultron.core.models.report import VultronReport
 from test.core.behaviors.bt_harness import BTTestScenario
 
 # noqa: F401 — imported for vocabulary registration side-effect
 from vultron.wire.as2.vocab.objects.vulnerability_case import (  # noqa: F401
-    VulnerabilityCase,
+    VulnerabilityCase as _WireVulnerabilityCase,
 )
 
 
@@ -64,5 +65,21 @@ def offer(
 ) -> VultronOffer:
     """Create a test offer and persist it in the scenario DataLayer."""
     obj = VultronOffer(actor=actor.id_, object_=report.id_)
+    bt_scenario.dl.create(obj)
+    return obj
+
+
+@pytest.fixture
+def case(
+    bt_scenario: BTTestScenario,
+    report: VultronReport,
+    actor: VultronCaseActor,
+) -> VulnerabilityCase:
+    """Create a VulnerabilityCase linked to the test report."""
+    obj = VulnerabilityCase(
+        name="Test Case for TEST-001",
+        vulnerability_reports=[report.id_],
+        attributed_to=actor.id_,
+    )
     bt_scenario.dl.create(obj)
     return obj

--- a/test/core/behaviors/report/nodes/test_rm_transitions.py
+++ b/test/core/behaviors/report/nodes/test_rm_transitions.py
@@ -15,6 +15,7 @@
 
 """Unit tests for report RM transition nodes."""
 
+from typing import Any
 from py_trees.composites import Sequence
 
 from vultron.core.behaviors.helpers import UpdateActorOutbox
@@ -29,13 +30,16 @@ from vultron.core.behaviors.report.nodes.conditions import (
     EvaluateReportValidity,
 )
 from vultron.core.behaviors.report.nodes.rm_transitions import (
+    TransitionRMtoClosed,
     TransitionRMtoInvalid,
     TransitionRMtoValid,
 )
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_actor import VultronCaseActor
 from vultron.core.models.report import VultronReport
 from vultron.core.models.activity import VultronOffer
 from vultron.core.states.rm import RM
+from vultron.core.use_cases._helpers import _report_phase_status_id
 from test.core.behaviors.bt_harness import BTTestScenario
 
 
@@ -123,3 +127,116 @@ def test_full_validation_workflow(
     bt_scenario.assert_success(bt_scenario.run(actions, actor_id=actor.id_))
 
     bt_scenario.assert_rm_state(report.id_, RM.VALID, actor_id=actor.id_)
+
+
+# ---------------------------------------------------------------------------
+# AC-2: ParticipantStatus.context uses case URI when case exists (CLP-07-007)
+# ---------------------------------------------------------------------------
+
+
+def _read_status(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    report: VultronReport,
+    rm_state: RM,
+) -> Any:
+    """Read a report-phase ParticipantStatus and assert it exists."""
+    status_id = _report_phase_status_id(actor.id_, report.id_, rm_state.value)
+    obj = bt_scenario.dl.read(status_id)
+    assert (
+        obj is not None
+    ), f"No ParticipantStatus found at {status_id!r} in DataLayer"
+    # Two ParticipantStatus classes exist (core + wire). Check by type_ string.
+    assert (
+        getattr(obj, "type_", None) == "ParticipantStatus"
+    ), f"Expected ParticipantStatus at {status_id!r}, got {type(obj).__name__}"
+    return obj
+
+
+def test_transition_rm_to_valid_context_is_case_uri(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    report: VultronReport,
+    offer: VultronOffer,
+    case: VulnerabilityCase,
+) -> None:
+    """TransitionRMtoValid sets ParticipantStatus.context to the case URI."""
+    result = bt_scenario.run(
+        TransitionRMtoValid(report_id=report.id_, offer_id=offer.id_),
+        actor_id=actor.id_,
+    )
+    bt_scenario.assert_success(result)
+
+    status = _read_status(bt_scenario, actor, report, RM.VALID)
+    ctx = getattr(status, "context", None)
+    assert ctx == case.id_, (
+        f"Expected context={case.id_!r}, got {ctx!r} "
+        "(report URI must not appear in ParticipantStatus.context, CLP-07-007)"
+    )
+    assert (
+        ctx != report.id_
+    ), "ParticipantStatus.context must not be the report URI (CLP-07-007)"
+
+
+def test_transition_rm_to_invalid_context_is_case_uri(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    report: VultronReport,
+    offer: VultronOffer,
+    case: VulnerabilityCase,
+) -> None:
+    """TransitionRMtoInvalid sets ParticipantStatus.context to the case URI."""
+    result = bt_scenario.run(
+        TransitionRMtoInvalid(report_id=report.id_, offer_id=offer.id_),
+        actor_id=actor.id_,
+    )
+    bt_scenario.assert_success(result)
+
+    status = _read_status(bt_scenario, actor, report, RM.INVALID)
+    ctx = getattr(status, "context", None)
+    assert ctx == case.id_, (
+        f"Expected context={case.id_!r}, got {ctx!r} "
+        "(report URI must not appear in ParticipantStatus.context, CLP-07-007)"
+    )
+
+
+def test_transition_rm_to_closed_context_is_case_uri(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    report: VultronReport,
+    offer: VultronOffer,
+    case: VulnerabilityCase,
+) -> None:
+    """TransitionRMtoClosed sets ParticipantStatus.context to the case URI."""
+    result = bt_scenario.run(
+        TransitionRMtoClosed(report_id=report.id_, offer_id=offer.id_),
+        actor_id=actor.id_,
+    )
+    bt_scenario.assert_success(result)
+
+    status = _read_status(bt_scenario, actor, report, RM.CLOSED)
+    ctx = getattr(status, "context", None)
+    assert ctx == case.id_, (
+        f"Expected context={case.id_!r}, got {ctx!r} "
+        "(report URI must not appear in ParticipantStatus.context, CLP-07-007)"
+    )
+
+
+def test_transition_rm_to_valid_fallback_uses_report_id_when_no_case(
+    bt_scenario: BTTestScenario,
+    actor: VultronCaseActor,
+    report: VultronReport,
+    offer: VultronOffer,
+) -> None:
+    """TransitionRMtoValid falls back to report_id context when no case exists."""
+    result = bt_scenario.run(
+        TransitionRMtoValid(report_id=report.id_, offer_id=offer.id_),
+        actor_id=actor.id_,
+    )
+    bt_scenario.assert_success(result)
+
+    status = _read_status(bt_scenario, actor, report, RM.VALID)
+    ctx = getattr(status, "context", None)
+    assert (
+        ctx == report.id_
+    ), f"Expected fallback context={report.id_!r}, got {ctx!r}"

--- a/vultron/core/behaviors/case/nodes/participant/common.py
+++ b/vultron/core/behaviors/case/nodes/participant/common.py
@@ -20,7 +20,11 @@ from typing import TYPE_CHECKING, cast
 
 from vultron.core.models.enums import VultronObjectType
 from vultron.core.models.participant_status import ParticipantStatus
-from vultron.core.models.protocols import CaseModel, is_case_model
+from vultron.core.models.protocols import (
+    CaseModel,
+    is_case_model,
+    is_participant_status_model,
+)
 from vultron.core.models.vultron_types import VultronParticipant
 from vultron.core.ports.case_persistence import (
     CaseOutboxPersistence,
@@ -103,23 +107,49 @@ def _get_or_create_accepted_status(
     if report_id is None:
         return None
 
+    # CLP-07-007: context must use the case URI once a case exists.
+    case_obj = dl.find_case_by_report_id(report_id)
+    context = case_obj.id_ if is_case_model(case_obj) else report_id
+
     accepted_status_id = _report_phase_status_id(
         actor_id,
         report_id,
         RM.ACCEPTED.value,
     )
     existing = dl.read(accepted_status_id)
-    if isinstance(existing, ParticipantStatus):
+    if is_participant_status_model(existing):
         should_update_role = existing.cvd_role != cvd_role
         should_backfill_consent = (
             existing.em_consent_state is None and em_consent_state is not None
         )
-        if should_update_role or should_backfill_consent:
+        # AC-3: backfill context if it still holds the report URI.
+        should_backfill_context = (
+            existing.context == report_id and context != report_id
+        )
+        if (
+            should_update_role
+            or should_backfill_consent
+            or should_backfill_context
+        ):
             existing.cvd_role = cvd_role
             if should_backfill_consent:
                 existing.em_consent_state = em_consent_state
+            if should_backfill_context:
+                existing.context = context
             dl.save(existing)
-        return existing
+        # Construct a fresh core ParticipantStatus for callers that require
+        # the core type (e.g. CaseParticipant.participant_statuses).  The
+        # DataLayer vocabulary registry may return the wire-layer subclass;
+        # we normalise here so downstream code never sees a wire-layer type.
+        return ParticipantStatus(
+            id_=existing.id_,
+            context=existing.context,
+            rm_state=existing.rm_state,
+            vfd_state=existing.vfd_state,
+            attributed_to=getattr(existing, "attributed_to", actor_id),
+            cvd_role=existing.cvd_role,
+            em_consent_state=existing.em_consent_state,
+        )
 
     node_logger.info(
         "%s: Creating fresh RM.ACCEPTED status for actor '%s' "
@@ -129,7 +159,7 @@ def _get_or_create_accepted_status(
     )
     accepted_status = ParticipantStatus(
         id_=accepted_status_id,
-        context=report_id,
+        context=context,
         rm_state=RM.ACCEPTED,
         attributed_to=actor_id,
         cvd_role=cvd_role,

--- a/vultron/core/behaviors/case/nodes/participant/participant_add.py
+++ b/vultron/core/behaviors/case/nodes/participant/participant_add.py
@@ -22,7 +22,7 @@ The composite subtrees that orchestrate these nodes
 process-area root, per BTND-07-003.
 """
 
-from typing import Any
+from typing import Any, cast
 
 import py_trees
 from py_trees.common import Status
@@ -37,7 +37,11 @@ from vultron.core.models.participant_status import (
     ParticipantStatus,
     coerce_cvd_roles,
 )
-from vultron.core.models.protocols import CaseModel, is_case_model
+from vultron.core.models.protocols import (
+    CaseModel,
+    is_case_model,
+    is_participant_status_model,
+)
 from vultron.core.models.report_case_link import VultronReportCaseLink
 from vultron.core.models.vultron_types import VultronParticipant
 from vultron.core.states.participant_embargo_consent import PEC
@@ -124,8 +128,8 @@ class CreateParticipantNode(DataLayerAction):
             return Status.FAILURE
 
         accepted_status = self.blackboard.get("participant_accepted_status")
-        if accepted_status is not None and not isinstance(
-            accepted_status, ParticipantStatus
+        if accepted_status is not None and not is_participant_status_model(
+            accepted_status
         ):
             self.logger.error(
                 "%s: participant_accepted_status has invalid type",
@@ -138,7 +142,9 @@ class CreateParticipantNode(DataLayerAction):
             context=case_id,
             case_roles=self.roles,
             participant_statuses=(
-                [accepted_status] if accepted_status is not None else []
+                [cast(ParticipantStatus, accepted_status)]
+                if accepted_status is not None
+                else []
             ),
         )
         self.blackboard.new_case_participant = participant

--- a/vultron/core/behaviors/report/nodes/rm_transitions.py
+++ b/vultron/core/behaviors/report/nodes/rm_transitions.py
@@ -137,11 +137,15 @@ class TransitionRMtoValid(DataLayerAction):
             return Status.FAILURE
 
         try:
+            # CLP-07-007: context must use the case URI once a case exists.
+            case = self.datalayer.find_case_by_report_id(self.report_id)
+            context = case.id_ if is_case_model(case) else self.report_id
+
             status = ParticipantStatus(
                 id_=_report_phase_status_id(
                     self.actor_id, self.report_id, RM.VALID.value
                 ),
-                context=self.report_id,
+                context=context,
                 attributed_to=self.actor_id,
                 rm_state=RM.VALID,
                 em_consent_state=PEC.NO_EMBARGO,
@@ -160,7 +164,6 @@ class TransitionRMtoValid(DataLayerAction):
                 self.actor_id,
             )
 
-            case = self.datalayer.find_case_by_report_id(self.report_id)
             if is_case_model(case):
                 update_participant_rm_state(
                     case.id_, self.actor_id, RM.VALID, self.datalayer
@@ -213,11 +216,15 @@ class TransitionRMtoInvalid(DataLayerAction):
             return Status.FAILURE
 
         try:
+            # CLP-07-007: context must use the case URI once a case exists.
+            case = self.datalayer.find_case_by_report_id(self.report_id)
+            context = case.id_ if is_case_model(case) else self.report_id
+
             status = ParticipantStatus(
                 id_=_report_phase_status_id(
                     self.actor_id, self.report_id, RM.INVALID.value
                 ),
-                context=self.report_id,
+                context=context,
                 attributed_to=self.actor_id,
                 rm_state=RM.INVALID,
                 em_consent_state=PEC.NO_EMBARGO,
@@ -283,11 +290,15 @@ class TransitionRMtoClosed(DataLayerAction):
             return Status.FAILURE
 
         try:
+            # CLP-07-007: context must use the case URI once a case exists.
+            case = self.datalayer.find_case_by_report_id(self.report_id)
+            context = case.id_ if is_case_model(case) else self.report_id
+
             status = ParticipantStatus(
                 id_=_report_phase_status_id(
                     self.actor_id, self.report_id, RM.CLOSED.value
                 ),
-                context=self.report_id,
+                context=context,
                 attributed_to=self.actor_id,
                 rm_state=RM.CLOSED,
                 em_consent_state=PEC.NO_EMBARGO,

--- a/vultron/core/models/protocols.py
+++ b/vultron/core/models/protocols.py
@@ -46,9 +46,18 @@ class CaseStatusModel(Protocol):
     pxa_state: CS_pxa
 
 
-class ParticipantStatusModel(Protocol):
+class ParticipantStatusModel(PersistableModel, Protocol):
+    """Duck-type protocol for a persisted ParticipantStatus record.
+
+    Satisfied by both the core :class:`~vultron.core.models.participant_status.ParticipantStatus`
+    and the wire-layer type returned by the DataLayer vocabulary registry.
+    """
+
     rm_state: RM
     vfd_state: CS_vfd
+    context: str
+    cvd_role: list
+    em_consent_state: Any | None
 
 
 class CaseModel(PersistableModel, Protocol):
@@ -113,6 +122,23 @@ def is_participant_model(
         and getattr(obj, "type_", None) == "CaseParticipant"
         and hasattr(obj, "participant_statuses")
         and hasattr(obj, "append_rm_state")
+    )
+
+
+def is_participant_status_model(
+    obj: object | None,
+) -> "TypeGuard[ParticipantStatusModel]":
+    """Return True if *obj* duck-types as a ParticipantStatus record.
+
+    Checks ``type_ == "ParticipantStatus"`` rather than using ``isinstance``
+    so it works for both the core model and the wire-layer type returned by
+    the DataLayer vocabulary registry (CLP-07-007).
+    """
+    return bool(
+        obj is not None
+        and getattr(obj, "type_", None) == "ParticipantStatus"
+        and hasattr(obj, "rm_state")
+        and hasattr(obj, "context")
     )
 
 


### PR DESCRIPTION
- Closes #932

## Summary

Implements CLP-07-007: `ParticipantStatus.context` must use the case URI
once a case exists. Before this fix, all three RM-transition BT nodes
(`TransitionRMtoValid/Invalid/Closed`) and `_get_or_create_accepted_status`
created status records with `context=report_id` even after a case had been
promoted, violating the canonical ledger context invariant.

## Changes

**Production**

- `vultron/core/behaviors/report/nodes/rm_transitions.py`: All three
  transition nodes now call `find_case_by_report_id()` before constructing
  `ParticipantStatus`; use `case.id_` as `context` when available
  (falls back to `report_id` when no case exists yet).
- `vultron/core/behaviors/case/nodes/participant/common.py`:
  `_get_or_create_accepted_status()` performs the same lookup; adds AC-3
  backfill: updates `existing.context` from `report_id` → `case_id` when
  a case has since been promoted.
- `vultron/core/models/protocols.py`: Adds `is_participant_status_model()`
  TypeGuard helper that checks `type_ == "ParticipantStatus"` structurally so
  it works for both the core model and the wire-layer type returned by the
  DataLayer vocabulary registry.
- `vultron/core/behaviors/case/nodes/participant/participant_add.py`: Switches
  `isinstance(…, ParticipantStatus)` guard to `is_participant_status_model()`
  for the same reason.

**Tests**

- `test/core/behaviors/report/nodes/conftest.py`: Adds `case` fixture
  (creates `VulnerabilityCase` linked to the report).
- `test/core/behaviors/report/nodes/test_rm_transitions.py`: Adds 5 new
  AC-2 tests verifying `context == case.id_` for each transition node and
  a fallback test.
- `test/core/behaviors/case/nodes/participant/test_participant_add.py`: Adds
  AC-3 backfill test.

## Verification

```
3397 passed, 34 skipped, 225 deselected, 2 xfailed, 5633 subtests passed in 55.92s
```