### PR TITLE
Define SvcBTTriggerBase + SvcEmbargoTriggerBase and apply to embargo trigger use cases

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -201,7 +201,10 @@ class CreateReportReceivedUseCase:
 - Use factory methods (not direct subclassing) for BT nodes
 - BT blackboard keys use `{noun}_{last_url_segment}` (no slashes in keys)
 - Clear `py_trees.blackboard.Blackboard.storage` in test fixtures to prevent state leakage
-- Not every handler needs a BT: use BTs for complex branching/state transitions; use procedural code for simple CRUD
+- All trigger and received use cases MUST delegate protocol-significant behavior
+  to a BT via `BTBridge`. Procedural code in `execute()` is limited to
+  infrastructure glue (instantiate BT, set up blackboard, call bridge, check
+  status, extract output).
 
 ### Error Handling
 

--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -157,3 +157,14 @@ entries for a case is treated as trivially fresh (acknowledged prefix is the
 empty prefix, which is contiguous). This aligns with SYNC-10-005: the gate
 MUST NOT require the actor's tip to equal the CaseActor's tip. Test fixtures
 for the gate can safely start with a clean DataLayer and expect SUCCESS.
+
+### 2026-06-16 ABC-HIERARCHY-TEMPLATE — transient instance attributes require care in abstract template methods
+
+When a template method sets transient per-call attributes (e.g.,
+`self._captured`, `self._actor_id`, `self._factory`) in `execute()` before
+calling abstract hooks, pyright does not always infer they are set at the
+call sites inside the abstract methods. Initialising them at the top of
+`execute()` (rather than in `__init__`) keeps them visible to pyright and
+avoids "possibly unbound" errors without introducing unnecessary sentinel
+values into `__init__`. Use `cast()` in `_prepare()` to restore specific
+request type narrowing lost by widening to `object` in the base `__init__`.

--- a/plan/history/2606/implementation/ISSUE-1004.md
+++ b/plan/history/2606/implementation/ISSUE-1004.md
@@ -1,0 +1,37 @@
+---
+source: ISSUE-1004
+timestamp: '2026-06-16T17:19:34.416179+00:00'
+title: Define SvcBTTriggerBase + SvcEmbargoTriggerBase for embargo trigger use cases
+type: implementation
+---
+
+## Issue #1004 — Define SvcBTTriggerBase + SvcEmbargoTriggerBase and apply to embargo trigger use cases
+
+Introduced a two-level ABC hierarchy in
+`vultron/core/use_cases/triggers/_base.py`:
+
+- `SvcBTTriggerBase`: template method `execute()` that owns the common
+  workflow — init transient state, call `_prepare()`, validate the
+  `TriggerActivityPort`, construct `BTBridge`, call `_build_tree()`, run
+  the BT, raise on failure, call `_handle_result()`, return activity dict.
+- `SvcEmbargoTriggerBase`: extends `SvcBTTriggerBase` with a concrete
+  `_handle_result()` that validates and stores the `lifecycle_result` from
+  BT output, then delegates to the per-operation `_log_lifecycle_result()` hook.
+
+All 5 embargo trigger use cases (`SvcProposeEmbargoUseCase`,
+`SvcAcceptEmbargoUseCase`, `SvcRejectEmbargoUseCase`,
+`SvcTerminateEmbargoUseCase`, `SvcProposeEmbargoRevisionUseCase`) were
+refactored to extend `SvcEmbargoTriggerBase`, eliminating the duplicated
+`__init__`, BTBridge construction, `captured`/`result_out` setup, and
+`lifecycle_result` type-guard that previously appeared verbatim in every class.
+
+Also replaced the stale 'Not every handler needs a BT: use BTs for complex
+branching/state transitions; use procedural code for simple CRUD' guidance in
+`.github/copilot-instructions.md` with the spec-aligned BT-15-001/BT-15-002
+rule: all trigger and received use cases MUST delegate protocol-significant
+behavior to a BT via `BTBridge`.
+
+7 new hook contract tests added in `test/core/use_cases/triggers/test_base.py`.
+All 3422 unit tests pass. Black, flake8, mypy, pyright clean.
+
+PR: [#1007](https://github.com/CERTCC/Vultron/pull/1007)

--- a/test/core/use_cases/triggers/test_base.py
+++ b/test/core/use_cases/triggers/test_base.py
@@ -1,0 +1,169 @@
+"""Tests for SvcBTTriggerBase and SvcEmbargoTriggerBase hook contracts."""
+
+from unittest.mock import MagicMock
+
+import py_trees.behaviour
+import pytest
+
+from vultron.core.use_cases.triggers._base import (
+    SvcBTTriggerBase,
+    SvcEmbargoTriggerBase,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal concrete subclasses for testing base-class hooks
+# ---------------------------------------------------------------------------
+
+
+class _MinimalTrigger(SvcBTTriggerBase):
+    """Simplest concrete subclass: records hook calls and raises nothing."""
+
+    def __init__(self, dl, request, trigger_activity=None):
+        super().__init__(dl, request, trigger_activity)
+        self.prepare_called = False
+        self.build_tree_called = False
+        self.handle_result_called = False
+
+    def _prepare(self) -> None:
+        self.prepare_called = True
+        self._actor_id = "https://example.org/actor"
+
+    def _build_tree(self) -> py_trees.behaviour.Behaviour:
+        self.build_tree_called = True
+        from py_trees.behaviours import Success
+
+        return Success(name="test-tree")
+
+    def _handle_result(self) -> None:
+        self.handle_result_called = True
+
+
+class _EmbargoTrigger(SvcEmbargoTriggerBase):
+    """Minimal concrete embargo subclass for testing."""
+
+    def __init__(self, dl, request, trigger_activity=None):
+        super().__init__(dl, request, trigger_activity)
+        self.log_called = False
+
+    def _prepare(self) -> None:
+        self._actor_id = "https://example.org/actor"
+
+    def _build_tree(self) -> py_trees.behaviour.Behaviour:
+        from py_trees.behaviours import Success
+
+        return Success(name="embargo-test-tree")
+
+    def _log_lifecycle_result(self) -> None:
+        self.log_called = True
+
+
+# ---------------------------------------------------------------------------
+# SvcBTTriggerBase: missing TriggerActivityPort raises RuntimeError
+# ---------------------------------------------------------------------------
+
+
+def test_missing_trigger_activity_raises():
+    """execute() raises RuntimeError when trigger_activity is None."""
+    uc = _MinimalTrigger(
+        dl=MagicMock(), request=object(), trigger_activity=None
+    )
+    with pytest.raises(RuntimeError, match="requires a TriggerActivityPort"):
+        uc.execute()
+
+
+def test_missing_trigger_activity_calls_prepare_first():
+    """_prepare() is called before the TriggerActivityPort guard."""
+    uc = _MinimalTrigger(
+        dl=MagicMock(), request=object(), trigger_activity=None
+    )
+    with pytest.raises(RuntimeError):
+        uc.execute()
+    assert uc.prepare_called, "_prepare() must run before the port guard"
+
+
+# ---------------------------------------------------------------------------
+# SvcBTTriggerBase: hook ordering with a mock trigger port
+# ---------------------------------------------------------------------------
+
+
+def test_hooks_called_in_order():
+    """Template method calls hooks in the correct sequence."""
+    uc = _MinimalTrigger(
+        dl=MagicMock(), request=object(), trigger_activity=MagicMock()
+    )
+    result = uc.execute()
+
+    assert uc.prepare_called
+    assert uc.build_tree_called
+    assert uc.handle_result_called
+    assert result == {"activity": None}
+
+
+def test_execute_returns_captured_activity():
+    """execute() returns the activity captured by _build_tree's closure."""
+
+    class _CapturingTrigger(_MinimalTrigger):
+        def _build_tree(self) -> py_trees.behaviour.Behaviour:
+            self.build_tree_called = True
+            self._captured["activity"] = {"type": "TestActivity"}
+            from py_trees.behaviours import Success
+
+            return Success(name="capturing-tree")
+
+    uc = _CapturingTrigger(
+        dl=MagicMock(), request=object(), trigger_activity=MagicMock()
+    )
+    result = uc.execute()
+    assert result == {"activity": {"type": "TestActivity"}}
+
+
+# ---------------------------------------------------------------------------
+# SvcEmbargoTriggerBase: _handle_result validates lifecycle_result
+# ---------------------------------------------------------------------------
+
+
+def test_embargo_handle_result_raises_when_lifecycle_result_missing():
+    """_handle_result raises RuntimeError when lifecycle_result is absent."""
+    uc = _EmbargoTrigger(
+        dl=MagicMock(),
+        request=object(),
+        trigger_activity=MagicMock(),
+    )
+    uc._result_out = {}
+    with pytest.raises(RuntimeError, match="did not capture lifecycle result"):
+        uc._handle_result()
+
+
+def test_embargo_handle_result_raises_for_wrong_type():
+    """_handle_result raises RuntimeError for a non-EmbargoLifecycleResult."""
+    uc = _EmbargoTrigger(
+        dl=MagicMock(),
+        request=object(),
+        trigger_activity=MagicMock(),
+    )
+    uc._result_out = {"lifecycle_result": "not-the-right-type"}
+    with pytest.raises(RuntimeError, match="did not capture lifecycle result"):
+        uc._handle_result()
+
+
+def test_embargo_handle_result_stores_lifecycle_result_and_delegates():
+    """_handle_result stores lifecycle_result and calls _log_lifecycle_result."""
+    from vultron.core.services.embargo_lifecycle import EmbargoLifecycleResult
+    from vultron.core.states.em import EM
+
+    lr = EmbargoLifecycleResult(
+        em_before=EM.NONE,
+        em_after=EM.PROPOSED,
+        case_changed=True,
+        case_embargo_changed=False,
+        pec_reset=False,
+    )
+    uc = _EmbargoTrigger(
+        dl=MagicMock(),
+        request=object(),
+        trigger_activity=MagicMock(),
+    )
+    uc._result_out = {"lifecycle_result": lr}
+    uc._handle_result()
+    assert uc._lifecycle_result is lr
+    assert uc.log_called

--- a/vultron/core/use_cases/triggers/_base.py
+++ b/vultron/core/use_cases/triggers/_base.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Abstract base classes for BT-backed trigger use cases.
+
+Two-level hierarchy:
+
+- :class:`SvcBTTriggerBase` — top-level template method that owns the
+  ``__init__``, the TriggerActivityPort guard, BTBridge construction, BT
+  execution, and the failure guard.  Subclasses implement ``_prepare()``,
+  ``_build_tree()``, and ``_handle_result()``.
+
+- :class:`SvcEmbargoTriggerBase` — extends ``SvcBTTriggerBase`` with a
+  concrete ``_handle_result()`` that validates and stores the
+  ``lifecycle_result`` from the BT output, then delegates to the
+  per-operation ``_log_lifecycle_result()`` hook.
+"""
+
+import logging
+from abc import ABC, abstractmethod
+
+import py_trees.behaviour
+from py_trees.common import Status
+
+from vultron.core.behaviors.bridge import BTBridge
+from vultron.core.ports.case_persistence import CaseOutboxPersistence
+from vultron.core.ports.trigger_activity import TriggerActivityPort
+from vultron.core.services.embargo_lifecycle import EmbargoLifecycleResult
+from vultron.errors import VultronValidationError
+
+logger = logging.getLogger(__name__)
+
+
+class SvcBTTriggerBase(ABC):
+    """Abstract base for all BT-backed trigger use cases.
+
+    The :meth:`execute` template method orchestrates the common workflow:
+
+    1. Initialise transient state (``_captured``, ``_result_out``,
+       ``_actor_id``).
+    2. Call :meth:`_prepare` (abstract) — subclass resolves domain objects and
+       sets ``self._actor_id``.
+    3. Validate that a ``TriggerActivityPort`` was supplied and store it as
+       ``self._factory``.
+    4. Construct a :class:`~vultron.core.behaviors.bridge.BTBridge`.
+    5. Call :meth:`_build_tree` (abstract) — subclass returns the BT.
+    6. Execute the BT via ``bridge.execute_with_setup``.
+    7. Raise on failure.
+    8. Call :meth:`_handle_result` (abstract) — subclass logs/extracts output.
+    9. Return ``{"activity": self._captured.get("activity")}``.
+    """
+
+    def __init__(
+        self,
+        dl: CaseOutboxPersistence,
+        request: object,
+        trigger_activity: TriggerActivityPort | None = None,
+    ) -> None:
+        self._dl = dl
+        self._request = request
+        self._trigger_activity = trigger_activity
+
+    def execute(self) -> dict:
+        """Template method: prepare → gate → run BT → handle result."""
+        self._captured: dict = {}
+        self._result_out: dict[str, object] = {}
+        self._actor_id: str = ""
+
+        self._prepare()
+
+        if self._trigger_activity is None:
+            raise RuntimeError(
+                f"{type(self).__name__} requires a TriggerActivityPort"
+            )
+        self._factory: TriggerActivityPort = self._trigger_activity
+
+        bridge = BTBridge(
+            datalayer=self._dl,
+            trigger_activity=self._factory,
+        )
+        tree = self._build_tree()
+        result = bridge.execute_with_setup(tree, actor_id=self._actor_id)
+
+        if result.status != Status.SUCCESS:
+            error = self._result_out.get("error")
+            if isinstance(error, Exception):
+                raise error
+            raise VultronValidationError(
+                f"{type(self).__name__} failed:"
+                f" {BTBridge.get_failure_reason(tree)}"
+            )
+
+        self._handle_result()
+
+        return {"activity": self._captured.get("activity")}
+
+    @abstractmethod
+    def _prepare(self) -> None:
+        """Pre-BT validation and setup.
+
+        Implementations MUST set ``self._actor_id`` to the resolved full actor
+        URI and may set additional operation-specific attributes (e.g.
+        ``self._case``, ``self._embargo``).  Raise domain exceptions on invalid
+        input.
+        """
+
+    @abstractmethod
+    def _build_tree(self) -> py_trees.behaviour.Behaviour:
+        """Construct and return the operation-specific BT.
+
+        Called after ``_prepare()`` and after ``self._factory`` is set.
+        Implementations may close over ``self._captured`` and
+        ``self._result_out`` for BT I/O.
+        """
+
+    @abstractmethod
+    def _handle_result(self) -> None:
+        """Post-BT logging or result extraction.
+
+        Called only when the BT succeeded.
+        """
+
+
+class SvcEmbargoTriggerBase(SvcBTTriggerBase):
+    """Abstract base for embargo trigger use cases.
+
+    Provides a concrete :meth:`_handle_result` that:
+
+    1. Extracts ``lifecycle_result`` from ``self._result_out``.
+    2. Raises ``RuntimeError`` if the value is absent or the wrong type.
+    3. Stores the validated result as ``self._lifecycle_result``.
+    4. Delegates to the per-operation :meth:`_log_lifecycle_result` hook.
+    """
+
+    def _handle_result(self) -> None:
+        lifecycle_result = self._result_out.get("lifecycle_result")
+        if not isinstance(lifecycle_result, EmbargoLifecycleResult):
+            raise RuntimeError(
+                f"{type(self).__name__} did not capture lifecycle result"
+                " in BT output"
+            )
+        self._lifecycle_result: EmbargoLifecycleResult = lifecycle_result
+        self._log_lifecycle_result()
+
+    @abstractmethod
+    def _log_lifecycle_result(self) -> None:
+        """Log the per-operation lifecycle result after BT execution."""

--- a/vultron/core/use_cases/triggers/embargo/__init__.py
+++ b/vultron/core/use_cases/triggers/embargo/__init__.py
@@ -21,6 +21,10 @@ one-module-per-use-case while preserving existing imports such as:
 ``from vultron.core.use_cases.triggers.embargo import SvcProposeEmbargoUseCase``.
 """
 
+from vultron.core.use_cases.triggers._base import (
+    SvcBTTriggerBase,
+    SvcEmbargoTriggerBase,
+)
 from vultron.core.use_cases.triggers._helpers import _is_case_owner
 from vultron.core.use_cases.triggers.requests import (
     AcceptEmbargoTriggerRequest,
@@ -42,11 +46,13 @@ __all__ = [
     "ProposeEmbargoRevisionTriggerRequest",
     "ProposeEmbargoTriggerRequest",
     "RejectEmbargoTriggerRequest",
-    "TerminateEmbargoTriggerRequest",
     "SvcAcceptEmbargoUseCase",
+    "SvcBTTriggerBase",
+    "SvcEmbargoTriggerBase",
     "SvcEvaluateEmbargoUseCase",
     "SvcProposeEmbargoRevisionUseCase",
     "SvcProposeEmbargoUseCase",
     "SvcRejectEmbargoUseCase",
     "SvcTerminateEmbargoUseCase",
+    "TerminateEmbargoTriggerRequest",
 ]

--- a/vultron/core/use_cases/triggers/embargo/accept.py
+++ b/vultron/core/use_cases/triggers/embargo/accept.py
@@ -16,16 +16,14 @@
 """Embargo accept trigger use case."""
 
 import logging
+from typing import cast
 
-from py_trees.common import Status
+import py_trees.behaviour
 
-from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.embargo.trigger_tree import (
     accept_embargo_trigger_bt,
 )
-from vultron.core.ports.case_persistence import CaseOutboxPersistence
-from vultron.core.ports.trigger_activity import TriggerActivityPort
-from vultron.core.services.embargo_lifecycle import EmbargoLifecycleResult
+from vultron.core.use_cases.triggers._base import SvcEmbargoTriggerBase
 from vultron.core.use_cases.triggers._helpers import (
     _is_case_owner,
     _resolve_embargo_id_from_proposal,
@@ -41,100 +39,70 @@ from vultron.errors import VultronValidationError
 logger = logging.getLogger(__name__)
 
 
-class SvcAcceptEmbargoUseCase:
-    def __init__(
-        self,
-        dl: CaseOutboxPersistence,
-        request: AcceptEmbargoTriggerRequest,
-        trigger_activity: TriggerActivityPort | None = None,
-    ) -> None:
-        self._dl = dl
-        self._request: AcceptEmbargoTriggerRequest = request
-        self._trigger_activity = trigger_activity
-
-    def execute(self) -> dict:
-        request = self._request
+class SvcAcceptEmbargoUseCase(SvcEmbargoTriggerBase):
+    def _prepare(self) -> None:
+        request = cast(AcceptEmbargoTriggerRequest, self._request)
         dl = self._dl
 
         actor = resolve_actor(request.actor_id, dl)
-        actor_id = actor.id_
-        case = resolve_case(request.case_id, dl)
-        proposal = _resolve_embargo_proposal(case, request.proposal_id, dl)
-        embargo_id = _resolve_embargo_id_from_proposal(proposal)
+        self._actor_id = actor.id_
+        self._case = resolve_case(request.case_id, dl)
+        self._proposal = _resolve_embargo_proposal(
+            self._case, request.proposal_id, dl
+        )
+        self._embargo_id = _resolve_embargo_id_from_proposal(self._proposal)
 
-        embargo = dl.read(embargo_id)
+        embargo = dl.read(self._embargo_id)
         if embargo is None:
             raise VultronValidationError(
-                f"Could not resolve EmbargoEvent '{embargo_id}'."
+                f"Could not resolve EmbargoEvent '{self._embargo_id}'."
             )
 
-        if self._trigger_activity is None:
-            raise RuntimeError(
-                "SvcAcceptEmbargoUseCase requires a TriggerActivityPort"
-            )
-
-        factory = self._trigger_activity
-        captured: dict = {}
-        result_out: dict[str, object] = {}
-
+    def _build_tree(self) -> py_trees.behaviour.Behaviour:
         def _build_activities(case_manager_id: str) -> list[str]:
-            accept_id, accept_dict = factory.accept_embargo(
-                proposal_id=proposal.id_,
-                case_id=case.id_,
-                actor=actor_id,
+            accept_id, accept_dict = self._factory.accept_embargo(
+                proposal_id=self._proposal.id_,
+                case_id=self._case.id_,
+                actor=self._actor_id,
                 to=[case_manager_id],
             )
-            captured["activity"] = accept_dict
+            self._captured["activity"] = accept_dict
             return [accept_id]
 
-        bridge = BTBridge(datalayer=dl, trigger_activity=factory)
-        tree = accept_embargo_trigger_bt(
-            case_id=case.id_,
-            embargo_id=embargo_id,
-            result_out=result_out,
+        return accept_embargo_trigger_bt(
+            case_id=self._case.id_,
+            embargo_id=self._embargo_id,
+            result_out=self._result_out,
             activity_builder=_build_activities,
         )
-        result = bridge.execute_with_setup(tree, actor_id=actor_id)
-        if result.status != Status.SUCCESS:
-            error = result_out.get("error")
-            if isinstance(error, Exception):
-                raise error
-            raise VultronValidationError(
-                f"AcceptEmbargo failed: {BTBridge.get_failure_reason(tree)}"
-            )
-        lifecycle_result = result_out.get("lifecycle_result")
-        if not isinstance(lifecycle_result, EmbargoLifecycleResult):
-            raise RuntimeError(
-                "AcceptEmbargo did not capture lifecycle result in BT output"
-            )
 
+    def _log_lifecycle_result(self) -> None:
+        lr = self._lifecycle_result
         if (
-            _is_case_owner(case, actor_id)
-            and lifecycle_result.em_after != lifecycle_result.em_before
+            _is_case_owner(self._case, self._actor_id)
+            and lr.em_after != lr.em_before
         ):
             logger.info(
                 "Actor '%s' accepted embargo proposal '%s'; activated embargo"
                 " '%s' on case '%s' (EM %s → %s)",
-                actor_id,
-                proposal.id_,
-                embargo_id,
-                case.id_,
-                lifecycle_result.em_before,
-                lifecycle_result.em_after,
+                self._actor_id,
+                self._proposal.id_,
+                self._embargo_id,
+                self._case.id_,
+                lr.em_before,
+                lr.em_after,
             )
         else:
             logger.info(
                 "Actor '%s' accepted embargo proposal '%s'; recorded"
                 " participant consent for embargo '%s' on case '%s'"
                 " (EM unchanged at %s)",
-                actor_id,
-                proposal.id_,
-                embargo_id,
-                case.id_,
-                lifecycle_result.em_after,
+                self._actor_id,
+                self._proposal.id_,
+                self._embargo_id,
+                self._case.id_,
+                lr.em_after,
             )
-
-        return {"activity": captured.get("activity")}
 
 
 SvcEvaluateEmbargoUseCase = SvcAcceptEmbargoUseCase

--- a/vultron/core/use_cases/triggers/embargo/propose.py
+++ b/vultron/core/use_cases/triggers/embargo/propose.py
@@ -16,17 +16,15 @@
 """Embargo proposal trigger use case."""
 
 import logging
+from typing import cast
 
-from py_trees.common import Status
+import py_trees.behaviour
 
-from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.embargo.trigger_tree import (
     propose_embargo_trigger_bt,
 )
 from vultron.core.models.embargo_event import EmbargoEvent
-from vultron.core.ports.case_persistence import CaseOutboxPersistence
-from vultron.core.ports.trigger_activity import TriggerActivityPort
-from vultron.core.services.embargo_lifecycle import EmbargoLifecycleResult
+from vultron.core.use_cases.triggers._base import SvcEmbargoTriggerBase
 from vultron.core.use_cases.triggers._helpers import (
     resolve_actor,
     resolve_case,
@@ -34,97 +32,57 @@ from vultron.core.use_cases.triggers._helpers import (
 from vultron.core.use_cases.triggers.requests import (
     ProposeEmbargoTriggerRequest,
 )
-from vultron.errors import VultronValidationError
 
 logger = logging.getLogger(__name__)
 
 
-class SvcProposeEmbargoUseCase:
-    def __init__(
-        self,
-        dl: CaseOutboxPersistence,
-        request: ProposeEmbargoTriggerRequest,
-        trigger_activity: TriggerActivityPort | None = None,
-    ) -> None:
-        self._dl = dl
-        self._request: ProposeEmbargoTriggerRequest = request
-        self._trigger_activity = trigger_activity
+class SvcProposeEmbargoUseCase(SvcEmbargoTriggerBase):
+    def _prepare(self) -> None:
+        request = cast(ProposeEmbargoTriggerRequest, self._request)
+        actor = resolve_actor(request.actor_id, self._dl)
+        self._actor_id = actor.id_
+        self._case = resolve_case(request.case_id, self._dl)
 
-    def execute(self) -> dict:
-        request = self._request
-        actor_id = request.actor_id
-        case_id = request.case_id
-        end_time = request.end_time
-        dl = self._dl
+        embargo_kwargs: dict = {"context": self._case.id_}
+        if request.end_time is not None:
+            embargo_kwargs["end_time"] = request.end_time
+        self._embargo = EmbargoEvent(**embargo_kwargs)
 
-        actor = resolve_actor(actor_id, dl)
-        actor_id = actor.id_
-
-        case = resolve_case(case_id, dl)
-
-        embargo_kwargs: dict = {"context": case.id_}
-        if end_time is not None:
-            embargo_kwargs["end_time"] = end_time
-
-        embargo = EmbargoEvent(**embargo_kwargs)
-
-        if self._trigger_activity is None:
-            raise RuntimeError(
-                "SvcProposeEmbargoUseCase requires a TriggerActivityPort"
-            )
-
-        factory = self._trigger_activity
-        captured: dict = {}
-        result_out: dict[str, object] = {}
-
+    def _build_tree(self) -> py_trees.behaviour.Behaviour:
         def _build_activities(case_manager_id: str) -> list[str]:
-            proposal_id, proposal_dict = factory.propose_embargo(
-                embargo_id=embargo.id_,
-                case_id=case.id_,
-                actor=actor_id,
+            proposal_id, proposal_dict = self._factory.propose_embargo(
+                embargo_id=self._embargo.id_,
+                case_id=self._case.id_,
+                actor=self._actor_id,
                 to=[case_manager_id],
             )
-            captured["activity"] = proposal_dict
+            self._captured["activity"] = proposal_dict
             return [proposal_id]
 
-        bridge = BTBridge(datalayer=dl, trigger_activity=factory)
-        tree = propose_embargo_trigger_bt(
-            case_id=case.id_,
-            embargo=embargo,
-            result_out=result_out,
+        return propose_embargo_trigger_bt(
+            case_id=self._case.id_,
+            embargo=self._embargo,
+            result_out=self._result_out,
             activity_builder=_build_activities,
         )
-        result = bridge.execute_with_setup(tree, actor_id=actor_id)
-        if result.status != Status.SUCCESS:
-            error = result_out.get("error")
-            if isinstance(error, Exception):
-                raise error
-            raise VultronValidationError(
-                f"ProposeEmbargo failed: {BTBridge.get_failure_reason(tree)}"
-            )
-        lifecycle_result = result_out.get("lifecycle_result")
-        if not isinstance(lifecycle_result, EmbargoLifecycleResult):
-            raise RuntimeError(
-                "ProposeEmbargo did not capture lifecycle result in BT output"
-            )
 
-        if lifecycle_result.em_after != lifecycle_result.em_before:
+    def _log_lifecycle_result(self) -> None:
+        lr = self._lifecycle_result
+        if lr.em_after != lr.em_before:
             logger.info(
                 "Actor '%s' proposed embargo '%s' on case '%s' (EM %s → %s)",
-                actor_id,
-                embargo.id_,
-                case.id_,
-                lifecycle_result.em_before,
-                lifecycle_result.em_after,
+                self._actor_id,
+                self._embargo.id_,
+                self._case.id_,
+                lr.em_before,
+                lr.em_after,
             )
         else:
             logger.info(
                 "Actor '%s' counter-proposed embargo '%s' on case '%s'"
                 " (EM %s, no state change)",
-                actor_id,
-                embargo.id_,
-                case.id_,
-                lifecycle_result.em_before,
+                self._actor_id,
+                self._embargo.id_,
+                self._case.id_,
+                lr.em_before,
             )
-
-        return {"activity": captured.get("activity")}

--- a/vultron/core/use_cases/triggers/embargo/reject.py
+++ b/vultron/core/use_cases/triggers/embargo/reject.py
@@ -16,16 +16,14 @@
 """Embargo rejection trigger use case."""
 
 import logging
+from typing import cast
 
-from py_trees.common import Status
+import py_trees.behaviour
 
-from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.embargo.trigger_tree import (
     reject_embargo_trigger_bt,
 )
-from vultron.core.ports.case_persistence import CaseOutboxPersistence
-from vultron.core.ports.trigger_activity import TriggerActivityPort
-from vultron.core.services.embargo_lifecycle import EmbargoLifecycleResult
+from vultron.core.use_cases.triggers._base import SvcEmbargoTriggerBase
 from vultron.core.use_cases.triggers._helpers import (
     _is_case_owner,
     _resolve_embargo_id_from_proposal,
@@ -36,95 +34,64 @@ from vultron.core.use_cases.triggers._helpers import (
 from vultron.core.use_cases.triggers.requests import (
     RejectEmbargoTriggerRequest,
 )
-from vultron.errors import VultronValidationError
 
 logger = logging.getLogger(__name__)
 
 
-class SvcRejectEmbargoUseCase:
-    def __init__(
-        self,
-        dl: CaseOutboxPersistence,
-        request: RejectEmbargoTriggerRequest,
-        trigger_activity: TriggerActivityPort | None = None,
-    ) -> None:
-        self._dl = dl
-        self._request: RejectEmbargoTriggerRequest = request
-        self._trigger_activity = trigger_activity
-
-    def execute(self) -> dict:
-        request = self._request
+class SvcRejectEmbargoUseCase(SvcEmbargoTriggerBase):
+    def _prepare(self) -> None:
+        request = cast(RejectEmbargoTriggerRequest, self._request)
         dl = self._dl
 
         actor = resolve_actor(request.actor_id, dl)
-        actor_id = actor.id_
-        case = resolve_case(request.case_id, dl)
-        proposal = _resolve_embargo_proposal(case, request.proposal_id, dl)
-        embargo_id = _resolve_embargo_id_from_proposal(proposal)
+        self._actor_id = actor.id_
+        self._case = resolve_case(request.case_id, dl)
+        self._proposal = _resolve_embargo_proposal(
+            self._case, request.proposal_id, dl
+        )
+        self._embargo_id = _resolve_embargo_id_from_proposal(self._proposal)
 
-        if self._trigger_activity is None:
-            raise RuntimeError(
-                "SvcRejectEmbargoUseCase requires a TriggerActivityPort"
-            )
-
-        factory = self._trigger_activity
-        captured: dict = {}
-        result_out: dict[str, object] = {}
-
+    def _build_tree(self) -> py_trees.behaviour.Behaviour:
         def _build_activities(case_manager_id: str) -> list[str]:
-            reject_id, reject_dict = factory.reject_embargo(
-                proposal_id=proposal.id_,
-                case_id=case.id_,
-                actor=actor_id,
+            reject_id, reject_dict = self._factory.reject_embargo(
+                proposal_id=self._proposal.id_,
+                case_id=self._case.id_,
+                actor=self._actor_id,
                 to=[case_manager_id],
             )
-            captured["activity"] = reject_dict
+            self._captured["activity"] = reject_dict
             return [reject_id]
 
-        bridge = BTBridge(datalayer=dl, trigger_activity=factory)
-        tree = reject_embargo_trigger_bt(
-            case_id=case.id_,
-            embargo_id=embargo_id,
-            result_out=result_out,
+        return reject_embargo_trigger_bt(
+            case_id=self._case.id_,
+            embargo_id=self._embargo_id,
+            result_out=self._result_out,
             activity_builder=_build_activities,
         )
-        result = bridge.execute_with_setup(tree, actor_id=actor_id)
-        if result.status != Status.SUCCESS:
-            error = result_out.get("error")
-            if isinstance(error, Exception):
-                raise error
-            raise VultronValidationError(
-                f"RejectEmbargo failed: {BTBridge.get_failure_reason(tree)}"
-            )
-        lifecycle_result = result_out.get("lifecycle_result")
-        if not isinstance(lifecycle_result, EmbargoLifecycleResult):
-            raise RuntimeError(
-                "RejectEmbargo did not capture lifecycle result in BT output"
-            )
 
+    def _log_lifecycle_result(self) -> None:
+        lr = self._lifecycle_result
         if (
-            _is_case_owner(case, actor_id)
-            and lifecycle_result.em_after != lifecycle_result.em_before
+            _is_case_owner(self._case, self._actor_id)
+            and lr.em_after != lr.em_before
         ):
             logger.info(
                 "Actor '%s' rejected embargo proposal '%s' on case '%s'"
                 " (EM %s → %s)",
-                actor_id,
-                proposal.id_,
-                case.id_,
-                lifecycle_result.em_before,
-                lifecycle_result.em_after,
+                self._actor_id,
+                self._proposal.id_,
+                self._case.id_,
+                lr.em_before,
+                lr.em_after,
             )
         else:
             logger.info(
                 "Actor '%s' rejected embargo proposal '%s'; recorded"
                 " participant consent for embargo '%s' on case '%s'"
                 " (EM unchanged at %s)",
-                actor_id,
-                proposal.id_,
-                embargo_id,
-                case.id_,
-                lifecycle_result.em_after,
+                self._actor_id,
+                self._proposal.id_,
+                self._embargo_id,
+                self._case.id_,
+                lr.em_after,
             )
-
-        return {"activity": captured.get("activity")}

--- a/vultron/core/use_cases/triggers/embargo/revise.py
+++ b/vultron/core/use_cases/triggers/embargo/revise.py
@@ -16,17 +16,15 @@
 """Embargo revision proposal trigger use case."""
 
 import logging
+from typing import cast
 
-from py_trees.common import Status
+import py_trees.behaviour
 
-from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.embargo.trigger_tree import (
     propose_embargo_revision_trigger_bt,
 )
 from vultron.core.models.embargo_event import EmbargoEvent
-from vultron.core.ports.case_persistence import CaseOutboxPersistence
-from vultron.core.ports.trigger_activity import TriggerActivityPort
-from vultron.core.services.embargo_lifecycle import EmbargoLifecycleResult
+from vultron.core.use_cases.triggers._base import SvcEmbargoTriggerBase
 from vultron.core.use_cases.triggers._helpers import (
     resolve_actor,
     resolve_case,
@@ -34,91 +32,50 @@ from vultron.core.use_cases.triggers._helpers import (
 from vultron.core.use_cases.triggers.requests import (
     ProposeEmbargoRevisionTriggerRequest,
 )
-from vultron.errors import VultronValidationError
 
 logger = logging.getLogger(__name__)
 
 
-class SvcProposeEmbargoRevisionUseCase:
-    def __init__(
-        self,
-        dl: CaseOutboxPersistence,
-        request: ProposeEmbargoRevisionTriggerRequest,
-        trigger_activity: TriggerActivityPort | None = None,
-    ) -> None:
-        self._dl = dl
-        self._request: ProposeEmbargoRevisionTriggerRequest = request
-        self._trigger_activity = trigger_activity
-
-    def execute(self) -> dict:
-        request = self._request
-        actor_id = request.actor_id
-        case_id = request.case_id
-        end_time = request.end_time
+class SvcProposeEmbargoRevisionUseCase(SvcEmbargoTriggerBase):
+    def _prepare(self) -> None:
+        request = cast(ProposeEmbargoRevisionTriggerRequest, self._request)
         dl = self._dl
 
-        actor = resolve_actor(actor_id, dl)
-        actor_id = actor.id_
+        actor = resolve_actor(request.actor_id, dl)
+        self._actor_id = actor.id_
+        self._case = resolve_case(request.case_id, dl)
 
-        case = resolve_case(case_id, dl)
+        embargo_kwargs: dict = {"context": self._case.id_}
+        if request.end_time is not None:
+            embargo_kwargs["end_time"] = request.end_time
+        self._embargo = EmbargoEvent(**embargo_kwargs)
 
-        embargo_kwargs: dict = {"context": case.id_}
-        if end_time is not None:
-            embargo_kwargs["end_time"] = end_time
-
-        embargo = EmbargoEvent(**embargo_kwargs)
-
-        if self._trigger_activity is None:
-            raise RuntimeError(
-                "SvcProposeEmbargoRevisionUseCase requires a"
-                " TriggerActivityPort"
-            )
-
-        factory = self._trigger_activity
-        captured: dict = {}
-        result_out: dict[str, object] = {}
-
+    def _build_tree(self) -> py_trees.behaviour.Behaviour:
         def _build_activities(case_manager_id: str) -> list[str]:
-            proposal_id, proposal_dict = factory.propose_embargo(
-                embargo_id=embargo.id_,
-                case_id=case.id_,
-                actor=actor_id,
+            proposal_id, proposal_dict = self._factory.propose_embargo(
+                embargo_id=self._embargo.id_,
+                case_id=self._case.id_,
+                actor=self._actor_id,
                 to=[case_manager_id],
             )
-            captured["activity"] = proposal_dict
+            self._captured["activity"] = proposal_dict
             return [proposal_id]
 
-        bridge = BTBridge(datalayer=dl, trigger_activity=factory)
-        tree = propose_embargo_revision_trigger_bt(
-            case_id=case.id_,
-            embargo=embargo,
-            result_out=result_out,
+        return propose_embargo_revision_trigger_bt(
+            case_id=self._case.id_,
+            embargo=self._embargo,
+            result_out=self._result_out,
             activity_builder=_build_activities,
         )
-        result = bridge.execute_with_setup(tree, actor_id=actor_id)
-        if result.status != Status.SUCCESS:
-            error = result_out.get("error")
-            if isinstance(error, Exception):
-                raise error
-            raise VultronValidationError(
-                f"ProposeEmbargoRevision failed:"
-                f" {BTBridge.get_failure_reason(tree)}"
-            )
-        lifecycle_result = result_out.get("lifecycle_result")
-        if not isinstance(lifecycle_result, EmbargoLifecycleResult):
-            raise RuntimeError(
-                "ProposeEmbargoRevision did not capture lifecycle result"
-                " in BT output"
-            )
 
+    def _log_lifecycle_result(self) -> None:
+        lr = self._lifecycle_result
         logger.info(
             "Actor '%s' proposed embargo revision '%s' on case '%s'"
             " (EM %s → %s)",
-            actor_id,
-            embargo.id_,
-            case.id_,
-            lifecycle_result.em_before,
-            lifecycle_result.em_after,
+            self._actor_id,
+            self._embargo.id_,
+            self._case.id_,
+            lr.em_before,
+            lr.em_after,
         )
-
-        return {"activity": captured.get("activity")}

--- a/vultron/core/use_cases/triggers/embargo/terminate.py
+++ b/vultron/core/use_cases/triggers/embargo/terminate.py
@@ -16,16 +16,14 @@
 """Embargo termination trigger use case."""
 
 import logging
+from typing import cast
 
-from py_trees.common import Status
+import py_trees.behaviour
 
-from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.embargo.trigger_tree import (
     terminate_embargo_trigger_bt,
 )
-from vultron.core.ports.case_persistence import CaseOutboxPersistence
-from vultron.core.ports.trigger_activity import TriggerActivityPort
-from vultron.core.services.embargo_lifecycle import EmbargoLifecycleResult
+from vultron.core.use_cases.triggers._base import SvcEmbargoTriggerBase
 from vultron.core.use_cases.triggers._helpers import (
     _coerce_embargo_event,
     resolve_actor,
@@ -42,97 +40,63 @@ from vultron.errors import (
 logger = logging.getLogger(__name__)
 
 
-class SvcTerminateEmbargoUseCase:
-    def __init__(
-        self,
-        dl: CaseOutboxPersistence,
-        request: TerminateEmbargoTriggerRequest,
-        trigger_activity: TriggerActivityPort | None = None,
-    ) -> None:
-        self._dl = dl
-        self._request: TerminateEmbargoTriggerRequest = request
-        self._trigger_activity = trigger_activity
-
-    def execute(self) -> dict:
-        request = self._request
-        actor_id = request.actor_id
-        case_id = request.case_id
+class SvcTerminateEmbargoUseCase(SvcEmbargoTriggerBase):
+    def _prepare(self) -> None:
+        request = cast(TerminateEmbargoTriggerRequest, self._request)
         dl = self._dl
 
-        actor = resolve_actor(actor_id, dl)
-        actor_id = actor.id_
+        actor = resolve_actor(request.actor_id, dl)
+        self._actor_id = actor.id_
+        self._case = resolve_case(request.case_id, dl)
 
-        case = resolve_case(case_id, dl)
-
-        if case.active_embargo is None:
+        if self._case.active_embargo is None:
             logger.warning(
                 "Invalid EM state transition: actor '%s' cannot TERMINATE:"
                 " case '%s' has no active embargo.",
-                actor_id,
-                case.id_,
+                self._actor_id,
+                self._case.id_,
             )
             raise VultronInvalidStateTransitionError(
-                f"Case '{case.id_}' has no active embargo to terminate."
+                f"Case '{self._case.id_}' has no active embargo to terminate."
             )
 
         embargo_id = (
-            case.active_embargo
-            if isinstance(case.active_embargo, str)
-            else getattr(case.active_embargo, "id_", None)
+            self._case.active_embargo
+            if isinstance(self._case.active_embargo, str)
+            else getattr(self._case.active_embargo, "id_", None)
         )
         if embargo_id is None:
             raise VultronValidationError(
-                f"Active embargo on case '{case.id_}' is missing an ID."
+                f"Active embargo on case '{self._case.id_}' is missing an ID."
             )
 
         _coerce_embargo_event(dl.read(embargo_id), embargo_id)
+        self._embargo_id = embargo_id
 
-        if self._trigger_activity is None:
-            raise RuntimeError(
-                "SvcTerminateEmbargoUseCase requires a TriggerActivityPort"
-            )
-
-        factory = self._trigger_activity
-        captured: dict = {}
-        result_out: dict[str, object] = {}
-
+    def _build_tree(self) -> py_trees.behaviour.Behaviour:
         def _build_activities(case_manager_id: str) -> list[str]:
-            announce_id, announce_dict = factory.terminate_embargo(
-                embargo_id=embargo_id,
-                case_id=case.id_,
-                actor=actor_id,
+            announce_id, announce_dict = self._factory.terminate_embargo(
+                embargo_id=self._embargo_id,
+                case_id=self._case.id_,
+                actor=self._actor_id,
                 to=[case_manager_id],
             )
-            captured["activity"] = announce_dict
+            self._captured["activity"] = announce_dict
             return [announce_id]
 
-        bridge = BTBridge(datalayer=dl, trigger_activity=factory)
-        tree = terminate_embargo_trigger_bt(
-            case_id=case.id_,
-            result_out=result_out,
+        return terminate_embargo_trigger_bt(
+            case_id=self._case.id_,
+            result_out=self._result_out,
             activity_builder=_build_activities,
         )
-        result = bridge.execute_with_setup(tree, actor_id=actor_id)
-        if result.status != Status.SUCCESS:
-            error = result_out.get("error")
-            if isinstance(error, Exception):
-                raise error
-            raise VultronValidationError(
-                f"TerminateEmbargo failed: {BTBridge.get_failure_reason(tree)}"
-            )
-        lifecycle_result = result_out.get("lifecycle_result")
-        if not isinstance(lifecycle_result, EmbargoLifecycleResult):
-            raise RuntimeError(
-                "TerminateEmbargo did not capture lifecycle result in BT output"
-            )
 
+    def _log_lifecycle_result(self) -> None:
+        lr = self._lifecycle_result
         logger.info(
             "Actor '%s' terminated embargo '%s' on case '%s' (EM %s → %s)",
-            actor_id,
-            embargo_id,
-            case.id_,
-            lifecycle_result.em_before,
-            lifecycle_result.em_after,
+            self._actor_id,
+            self._embargo_id,
+            self._case.id_,
+            lr.em_before,
+            lr.em_after,
         )
-
-        return {"activity": captured.get("activity")}


### PR DESCRIPTION
- Closes #1004

## Summary

Introduces a two-level ABC hierarchy for BT-backed trigger use cases.
`SvcBTTriggerBase` owns the `execute()` template method (prepare →
TriggerActivityPort guard → BTBridge → BT execution → failure guard →
handle result). `SvcEmbargoTriggerBase` adds a concrete
`_handle_result()` that validates and stores the `lifecycle_result`
from BT output before delegating to a per-operation
`_log_lifecycle_result()` hook. All 5 embargo trigger use cases are
refactored to extend `SvcEmbargoTriggerBase`, eliminating the
previously duplicated boilerplate across every `execute()`.

## Changes

- `vultron/core/use_cases/triggers/_base.py`: new file — `SvcBTTriggerBase`
  and `SvcEmbargoTriggerBase` ABCs
- `vultron/core/use_cases/triggers/embargo/{propose,accept,reject,terminate,revise}.py`:
  refactored to extend `SvcEmbargoTriggerBase`; removed duplicated
  `__init__`, BTBridge construction, and `lifecycle_result` guard
- `vultron/core/use_cases/triggers/embargo/__init__.py`: exports both
  base classes
- `test/core/use_cases/triggers/test_base.py`: 7 new hook contract tests
- `.github/copilot-instructions.md`: replace stale
  'Not every handler needs a BT' guidance with spec-aligned BT-15-001/BT-15-002
  rule

## Verification

- All 3422 unit tests pass (7 new)
- Black, flake8, mypy, pyright all clean