### PR TITLE
Apply SvcBTTriggerBase to all remaining trigger use cases (#1006)

### DIFF
--- a/plan/history/2606/implementation/ISSUE-1006.md
+++ b/plan/history/2606/implementation/ISSUE-1006.md
@@ -1,0 +1,42 @@
+---
+source: ISSUE-1006
+timestamp: '2026-06-16T18:31:53.203668+00:00'
+title: Apply SvcBTTriggerBase to all remaining trigger use cases
+type: implementation
+---
+
+## Issue #1006 — Apply SvcBTTriggerBase to all remaining trigger use cases
+
+Completed full migration of all trigger use cases to the `SvcBTTriggerBase`
+ABC introduced in #1004. Built missing BT implementations where needed so
+no use case was excluded.
+
+### Changes
+
+- `_base.py` — Added `_requires_trigger_activity: bool = True` class
+  variable; use cases that run BT-only workflows set it to `False` to
+  bypass the `TriggerActivityPort` guard while still executing via
+  `BTBridge`.
+- `report/nodes/emit.py` — Added `EmitSubmitReportActivity` BT node.
+- `report/trigger_report_trees.py` — Added `submit_report_trigger_bt`.
+- `case/actor_trigger_trees.py` (new) — Added
+  `EmitInviteActorToCaseNode`, `EmitAcceptCaseInviteNode`,
+  `invite_actor_to_case_trigger_bt`, `accept_case_invite_trigger_bt`,
+  `suggest_actor_to_case_trigger_bt`.
+- `report.py` — Migrated `SvcValidateReportUseCase`
+  (`_requires_trigger_activity = False`) and `SvcSubmitReportUseCase`
+  (overrides `execute()` to return `{"offer": ...}`).
+- `actor.py` — Fully migrated all three use cases:
+  `SvcSuggestActorToCaseUseCase` (sender_side_bt / PCR-08-001),
+  `SvcInviteActorToCaseUseCase` (Case Actor identity routing per
+  PCR-08-007), `SvcAcceptCaseInviteUseCase` (validates invite type
+  before running BT).
+- `note.py` — Already migrated (no new changes).
+- `sync.py` — Module-level comment added; standalone functions have no
+  class migration needed.
+
+### Outcome
+
+3422 tests passed; mypy and pyright both clean (0 errors).
+
+PR: [#1008](https://github.com/CERTCC/Vultron/pull/1008)

--- a/test/adapters/driving/fastapi/routers/test_trigger_report.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_report.py
@@ -867,7 +867,7 @@ class TestTriggerReportOutboxScheduling:
         )
 
     def test_validate_report_schedules_outbox_handler(
-        self, client_triggers, dl, actor, offer
+        self, client_triggers, dl, actor, offer, received_report
     ):
         """validate-report schedules outbox delivery after execution."""
         with self._make_patches() as mock_outbox:

--- a/vultron/core/behaviors/case/actor_trigger_trees.py
+++ b/vultron/core/behaviors/case/actor_trigger_trees.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Trigger-side behavior trees for actor-participation workflows.
+
+Three trigger trees are provided:
+
+- ``suggest_actor_to_case_trigger_bt`` — SenderSideBT wrapper for
+  Offer(Actor, Case) routed through the Case Manager (PCR-08-001).
+- ``invite_actor_to_case_trigger_bt`` — direct-route Sequence for
+  Invite(Actor, Case) sent from the Case Actor identity.
+- ``accept_case_invite_trigger_bt`` — Sequence for Accept(Invite)
+  sent by the invitee.
+
+Per specs/behavior-tree-integration.yaml BT-15-001, BT-15-002.
+"""
+
+import logging
+from typing import Callable, cast
+
+import py_trees
+from py_trees.common import Status
+
+from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.sender.send_tree import sender_side_bt
+from vultron.core.ports.case_persistence import CaseOutboxPersistence
+
+logger = logging.getLogger(__name__)
+
+
+class EmitInviteActorToCaseNode(DataLayerAction):
+    """Create Invite(Actor, Case) and queue in the Case Actor's outbox.
+
+    Uses ``trigger_activity_factory.invite_actor_to_case()`` with
+    ``actor=self.actor_id`` (expected to be the Case Actor URI) and
+    ``to=[invitee_id]``.  An optional ``attributed_to`` carries the
+    original requesting actor when the invite is sent from the Case
+    Actor identity (PCR-08-007).
+    """
+
+    def __init__(
+        self,
+        invitee_id: str,
+        case_id: str,
+        attributed_to: str | None = None,
+        captured: dict | None = None,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self.invitee_id = invitee_id
+        self.case_id = case_id
+        self.attributed_to = attributed_to
+        self._captured = captured
+
+    def update(self) -> Status:
+        if self.datalayer is None or self.actor_id is None:
+            self.feedback_message = "DataLayer or actor_id not available"
+            return Status.FAILURE
+
+        factory = self.trigger_activity_factory
+        if factory is None:
+            self.feedback_message = (
+                "trigger_activity_factory not in blackboard"
+            )
+            self.logger.error(self.feedback_message)
+            return Status.FAILURE
+
+        try:
+            activity_id, activity_dict = factory.invite_actor_to_case(
+                invitee_id=self.invitee_id,
+                case_id=self.case_id,
+                actor=self.actor_id,
+                to=[self.invitee_id],
+                attributed_to=self.attributed_to,
+            )
+            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
+                self.actor_id, activity_id
+            )
+            if self._captured is not None:
+                self._captured["activity"] = activity_dict
+            self.logger.info(
+                "Actor '%s' emitted Invite(Actor, Case) to '%s' for case '%s'",
+                self.actor_id,
+                self.invitee_id,
+                self.case_id,
+            )
+            return Status.SUCCESS
+
+        except Exception as e:
+            self.feedback_message = f"EmitInviteActorToCase failed: {e}"
+            self.logger.error(self.feedback_message)
+            return Status.FAILURE
+
+
+class EmitAcceptCaseInviteNode(DataLayerAction):
+    """Create Accept(Invite) and queue in the invitee's outbox.
+
+    Uses ``trigger_activity_factory.accept_case_invite()`` — the factory
+    derives the recipient from the persisted invite object.
+    """
+
+    def __init__(
+        self,
+        invite_id: str,
+        captured: dict | None = None,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self.invite_id = invite_id
+        self._captured = captured
+
+    def update(self) -> Status:
+        if self.datalayer is None or self.actor_id is None:
+            self.feedback_message = "DataLayer or actor_id not available"
+            return Status.FAILURE
+
+        factory = self.trigger_activity_factory
+        if factory is None:
+            self.feedback_message = (
+                "trigger_activity_factory not in blackboard"
+            )
+            self.logger.error(self.feedback_message)
+            return Status.FAILURE
+
+        try:
+            activity_id, activity_dict = factory.accept_case_invite(
+                invite_id=self.invite_id,
+                actor=self.actor_id,
+            )
+            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
+                self.actor_id, activity_id
+            )
+            if self._captured is not None:
+                self._captured["activity"] = activity_dict
+            self.logger.info(
+                "Actor '%s' accepted case invite '%s'",
+                self.actor_id,
+                self.invite_id,
+            )
+            return Status.SUCCESS
+
+        except Exception as e:
+            self.feedback_message = f"EmitAcceptCaseInvite failed: {e}"
+            self.logger.error(self.feedback_message)
+            return Status.FAILURE
+
+
+def suggest_actor_to_case_trigger_bt(
+    case_id: str,
+    activity_builder: Callable[[str], list[str]],
+) -> py_trees.behaviour.Behaviour:
+    """Return the trigger-side BT for the suggest-actor workflow.
+
+    Routes Offer(Actor, Case) through the Case Manager via
+    :func:`~vultron.core.behaviors.sender.send_tree.sender_side_bt`
+    (PCR-08-001).
+
+    Args:
+        case_id: ID of the VulnerabilityCase.
+        activity_builder: Closure called with the resolved Case Manager ID;
+            returns the list of outbound activity IDs.
+
+    Returns:
+        SenderSideBT Sequence.
+    """
+    return sender_side_bt(case_id=case_id, activity_builder=activity_builder)
+
+
+def invite_actor_to_case_trigger_bt(
+    invitee_id: str,
+    case_id: str,
+    attributed_to: str | None = None,
+    captured: dict | None = None,
+) -> py_trees.behaviour.Behaviour:
+    """Return the trigger-side BT for the invite-actor workflow.
+
+    Emits Invite(Actor, Case) from the Case Actor's identity directly to
+    the invitee (no Case Manager resolution needed — the Case Actor IS the
+    routing endpoint here per PCR-08-007).
+
+    Args:
+        invitee_id: Actor URI of the participant being invited.
+        case_id: ID of the VulnerabilityCase.
+        attributed_to: Optional original requesting actor URI.
+        captured: Optional dict; ``captured["activity"]`` is set on success.
+
+    Returns:
+        Sequence containing a single EmitInviteActorToCaseNode.
+    """
+    root = py_trees.composites.Sequence(
+        name="InviteActorToCaseTriggerBT",
+        memory=False,
+        children=[
+            EmitInviteActorToCaseNode(
+                invitee_id=invitee_id,
+                case_id=case_id,
+                attributed_to=attributed_to,
+                captured=captured,
+            ),
+        ],
+    )
+    logger.debug(
+        "Created InviteActorToCaseTriggerBT for invitee=%s case=%s",
+        invitee_id,
+        case_id,
+    )
+    return root
+
+
+def accept_case_invite_trigger_bt(
+    invite_id: str,
+    captured: dict | None = None,
+) -> py_trees.behaviour.Behaviour:
+    """Return the trigger-side BT for the accept-case-invite workflow.
+
+    Emits Accept(Invite) from the invitee's identity; the factory derives
+    the recipient from the persisted invite object.
+
+    Args:
+        invite_id: ID of the RmInviteToCaseActivity being accepted.
+        captured: Optional dict; ``captured["activity"]`` is set on success.
+
+    Returns:
+        Sequence containing a single EmitAcceptCaseInviteNode.
+    """
+    root = py_trees.composites.Sequence(
+        name="AcceptCaseInviteTriggerBT",
+        memory=False,
+        children=[
+            EmitAcceptCaseInviteNode(
+                invite_id=invite_id,
+                captured=captured,
+            ),
+        ],
+    )
+    logger.debug("Created AcceptCaseInviteTriggerBT for invite=%s", invite_id)
+    return root

--- a/vultron/core/behaviors/case/actor_trigger_trees.py
+++ b/vultron/core/behaviors/case/actor_trigger_trees.py
@@ -28,133 +28,17 @@ Per specs/behavior-tree-integration.yaml BT-15-001, BT-15-002.
 """
 
 import logging
-from typing import Callable, cast
+from typing import Callable
 
 import py_trees
-from py_trees.common import Status
 
-from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.case.nodes.actor import (
+    EmitAcceptCaseInviteNode,
+    EmitInviteActorToCaseNode,
+)
 from vultron.core.behaviors.sender.send_tree import sender_side_bt
-from vultron.core.ports.case_persistence import CaseOutboxPersistence
 
 logger = logging.getLogger(__name__)
-
-
-class EmitInviteActorToCaseNode(DataLayerAction):
-    """Create Invite(Actor, Case) and queue in the Case Actor's outbox.
-
-    Uses ``trigger_activity_factory.invite_actor_to_case()`` with
-    ``actor=self.actor_id`` (expected to be the Case Actor URI) and
-    ``to=[invitee_id]``.  An optional ``attributed_to`` carries the
-    original requesting actor when the invite is sent from the Case
-    Actor identity (PCR-08-007).
-    """
-
-    def __init__(
-        self,
-        invitee_id: str,
-        case_id: str,
-        attributed_to: str | None = None,
-        captured: dict | None = None,
-        name: str | None = None,
-    ) -> None:
-        super().__init__(name=name or self.__class__.__name__)
-        self.invitee_id = invitee_id
-        self.case_id = case_id
-        self.attributed_to = attributed_to
-        self._captured = captured
-
-    def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.feedback_message = "DataLayer or actor_id not available"
-            return Status.FAILURE
-
-        factory = self.trigger_activity_factory
-        if factory is None:
-            self.feedback_message = (
-                "trigger_activity_factory not in blackboard"
-            )
-            self.logger.error(self.feedback_message)
-            return Status.FAILURE
-
-        try:
-            activity_id, activity_dict = factory.invite_actor_to_case(
-                invitee_id=self.invitee_id,
-                case_id=self.case_id,
-                actor=self.actor_id,
-                to=[self.invitee_id],
-                attributed_to=self.attributed_to,
-            )
-            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
-                self.actor_id, activity_id
-            )
-            if self._captured is not None:
-                self._captured["activity"] = activity_dict
-            self.logger.info(
-                "Actor '%s' emitted Invite(Actor, Case) to '%s' for case '%s'",
-                self.actor_id,
-                self.invitee_id,
-                self.case_id,
-            )
-            return Status.SUCCESS
-
-        except Exception as e:
-            self.feedback_message = f"EmitInviteActorToCase failed: {e}"
-            self.logger.error(self.feedback_message)
-            return Status.FAILURE
-
-
-class EmitAcceptCaseInviteNode(DataLayerAction):
-    """Create Accept(Invite) and queue in the invitee's outbox.
-
-    Uses ``trigger_activity_factory.accept_case_invite()`` — the factory
-    derives the recipient from the persisted invite object.
-    """
-
-    def __init__(
-        self,
-        invite_id: str,
-        captured: dict | None = None,
-        name: str | None = None,
-    ) -> None:
-        super().__init__(name=name or self.__class__.__name__)
-        self.invite_id = invite_id
-        self._captured = captured
-
-    def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.feedback_message = "DataLayer or actor_id not available"
-            return Status.FAILURE
-
-        factory = self.trigger_activity_factory
-        if factory is None:
-            self.feedback_message = (
-                "trigger_activity_factory not in blackboard"
-            )
-            self.logger.error(self.feedback_message)
-            return Status.FAILURE
-
-        try:
-            activity_id, activity_dict = factory.accept_case_invite(
-                invite_id=self.invite_id,
-                actor=self.actor_id,
-            )
-            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
-                self.actor_id, activity_id
-            )
-            if self._captured is not None:
-                self._captured["activity"] = activity_dict
-            self.logger.info(
-                "Actor '%s' accepted case invite '%s'",
-                self.actor_id,
-                self.invite_id,
-            )
-            return Status.SUCCESS
-
-        except Exception as e:
-            self.feedback_message = f"EmitAcceptCaseInvite failed: {e}"
-            self.logger.error(self.feedback_message)
-            return Status.FAILURE
 
 
 def suggest_actor_to_case_trigger_bt(

--- a/vultron/core/behaviors/case/nodes/__init__.py
+++ b/vultron/core/behaviors/case/nodes/__init__.py
@@ -21,6 +21,7 @@ existing import paths (``from vultron.core.behaviors.case.nodes import ...``)
 continue to work without modification.
 
 Submodules:
+- ``actor``: Actor-participation invite/accept emit nodes
 - ``conditions``: Idempotency guard condition nodes
 - ``case_setup``: Case persistence and actor setup leaf action nodes
 - ``participant``: Participant creation and attachment leaf action nodes
@@ -46,6 +47,10 @@ They are re-exported here for backward compatibility via module
 import importlib
 from typing import TYPE_CHECKING
 
+from vultron.core.behaviors.case.nodes.actor import (
+    EmitAcceptCaseInviteNode,
+    EmitInviteActorToCaseNode,
+)
 from vultron.core.behaviors.case.nodes.case_setup import (
     PersistCase,
     RecordCaseCreatedEventNode,
@@ -87,6 +92,9 @@ from vultron.core.behaviors.case.nodes.update import (
 from vultron.core.behaviors.helpers import UpdateActorOutbox  # noqa: F401
 
 __all__ = [
+    # actor (leaf nodes)
+    "EmitInviteActorToCaseNode",
+    "EmitAcceptCaseInviteNode",
     # conditions
     "CheckCaseAlreadyExists",
     "CheckCaseExistsForReport",

--- a/vultron/core/behaviors/case/nodes/actor.py
+++ b/vultron/core/behaviors/case/nodes/actor.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Actor-participation emit nodes for case behavior trees.
+
+Provides leaf action nodes that emit outbound activities for actor
+invitation and invite-acceptance workflows.
+
+Composite subtrees assembling these leaf nodes are defined in the sibling
+``actor_trigger_trees.py`` module at the process-area root per BTND-07-003:
+
+- ``invite_actor_to_case_trigger_bt``
+- ``accept_case_invite_trigger_bt``
+"""
+
+from typing import cast
+
+from py_trees.common import Status
+
+from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.ports.case_persistence import CaseOutboxPersistence
+
+
+class EmitInviteActorToCaseNode(DataLayerAction):
+    """Create Invite(Actor, Case) and queue in the Case Actor's outbox.
+
+    Uses ``trigger_activity_factory.invite_actor_to_case()`` with
+    ``actor=self.actor_id`` (expected to be the Case Actor URI) and
+    ``to=[invitee_id]``.  An optional ``attributed_to`` carries the
+    original requesting actor when the invite is sent from the Case
+    Actor identity (PCR-08-007).
+    """
+
+    def __init__(
+        self,
+        invitee_id: str,
+        case_id: str,
+        attributed_to: str | None = None,
+        captured: dict | None = None,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self.invitee_id = invitee_id
+        self.case_id = case_id
+        self.attributed_to = attributed_to
+        self._captured = captured
+
+    def update(self) -> Status:
+        if self.datalayer is None or self.actor_id is None:
+            self.feedback_message = "DataLayer or actor_id not available"
+            return Status.FAILURE
+
+        factory = self.trigger_activity_factory
+        if factory is None:
+            self.feedback_message = (
+                "trigger_activity_factory not in blackboard"
+            )
+            self.logger.error(self.feedback_message)
+            return Status.FAILURE
+
+        try:
+            activity_id, activity_dict = factory.invite_actor_to_case(
+                invitee_id=self.invitee_id,
+                case_id=self.case_id,
+                actor=self.actor_id,
+                to=[self.invitee_id],
+                attributed_to=self.attributed_to,
+            )
+            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
+                self.actor_id, activity_id
+            )
+            if self._captured is not None:
+                self._captured["activity"] = activity_dict
+            self.logger.info(
+                "Actor '%s' emitted Invite(Actor, Case) to '%s' for case '%s'",
+                self.actor_id,
+                self.invitee_id,
+                self.case_id,
+            )
+            return Status.SUCCESS
+
+        except Exception as e:
+            self.feedback_message = f"EmitInviteActorToCase failed: {e}"
+            self.logger.error(self.feedback_message)
+            return Status.FAILURE
+
+
+class EmitAcceptCaseInviteNode(DataLayerAction):
+    """Create Accept(Invite) and queue in the invitee's outbox.
+
+    Uses ``trigger_activity_factory.accept_case_invite()`` — the factory
+    derives the recipient from the persisted invite object.
+    """
+
+    def __init__(
+        self,
+        invite_id: str,
+        captured: dict | None = None,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self.invite_id = invite_id
+        self._captured = captured
+
+    def update(self) -> Status:
+        if self.datalayer is None or self.actor_id is None:
+            self.feedback_message = "DataLayer or actor_id not available"
+            return Status.FAILURE
+
+        factory = self.trigger_activity_factory
+        if factory is None:
+            self.feedback_message = (
+                "trigger_activity_factory not in blackboard"
+            )
+            self.logger.error(self.feedback_message)
+            return Status.FAILURE
+
+        try:
+            activity_id, activity_dict = factory.accept_case_invite(
+                invite_id=self.invite_id,
+                actor=self.actor_id,
+            )
+            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
+                self.actor_id, activity_id
+            )
+            if self._captured is not None:
+                self._captured["activity"] = activity_dict
+            self.logger.info(
+                "Actor '%s' accepted case invite '%s'",
+                self.actor_id,
+                self.invite_id,
+            )
+            return Status.SUCCESS
+
+        except Exception as e:
+            self.feedback_message = f"EmitAcceptCaseInvite failed: {e}"
+            self.logger.error(self.feedback_message)
+            return Status.FAILURE

--- a/vultron/core/behaviors/report/nodes/emit.py
+++ b/vultron/core/behaviors/report/nodes/emit.py
@@ -238,3 +238,67 @@ class EmitCloseReportActivity(DataLayerAction):
                 "%s: Error emitting close-report activity: %s", self.name, e
             )
             return Status.FAILURE
+
+
+class EmitSubmitReportActivity(DataLayerAction):
+    """Create Offer(VulnerabilityReport) and queue in actor outbox.
+
+    Calls ``trigger_activity_factory.submit_report()`` and queues the
+    offer ID via ``record_outbox_item``.  Stores the offer dict in
+    ``captured["offer"]`` if *captured* is provided.
+
+    Per BT-15-001: outbound activity construction and queueing must be
+    BT leaf nodes.
+    """
+
+    def __init__(
+        self,
+        report_id: str,
+        recipient_id: str,
+        captured: dict | None = None,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self.report_id = report_id
+        self.recipient_id = recipient_id
+        self._captured = captured
+
+    def update(self) -> Status:
+        if self.datalayer is None or self.actor_id is None:
+            self.logger.error(
+                "%s: DataLayer or actor_id not available", self.name
+            )
+            return Status.FAILURE
+
+        if self.trigger_activity_factory is None:
+            self.logger.warning(
+                "%s: no TriggerActivityPort — cannot emit SubmitReport offer",
+                self.name,
+            )
+            return Status.FAILURE
+
+        try:
+            offer_id, offer_dict = self.trigger_activity_factory.submit_report(
+                report_id=self.report_id,
+                actor=self.actor_id,
+                to=self.recipient_id,
+                target=self.recipient_id,
+            )
+            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
+                self.actor_id, offer_id
+            )
+            if self._captured is not None:
+                self._captured["offer"] = offer_dict
+            self.logger.info(
+                "Actor '%s' emitted Offer(VulnerabilityReport) '%s' to '%s'",
+                self.actor_id,
+                offer_id,
+                self.recipient_id,
+            )
+            return Status.SUCCESS
+
+        except Exception as e:
+            self.logger.error(
+                "%s: Error emitting submit-report offer: %s", self.name, e
+            )
+            return Status.FAILURE

--- a/vultron/core/behaviors/report/trigger_report_trees.py
+++ b/vultron/core/behaviors/report/trigger_report_trees.py
@@ -13,11 +13,10 @@
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-"""
-Behavior tree factories for report-lifecycle trigger use cases.
+"""Behavior tree factories for report-lifecycle trigger use cases.
 
 Each factory produces a ``py_trees.composites.Sequence`` that implements the
-outbound protocol handling for one of the three report-lifecycle trigger
+outbound protocol handling for one of the report-lifecycle trigger
 operations:
 
 - ``InvalidateReport`` — emit TentativeReject activity + transition RM → INVALID
@@ -39,6 +38,7 @@ from vultron.core.behaviors.report.nodes.conditions import CheckReportNotClosed
 from vultron.core.behaviors.report.nodes.emit import (
     EmitCloseReportActivity,
     EmitInvalidateReportActivity,
+    EmitSubmitReportActivity,
 )
 from vultron.core.behaviors.report.nodes.rm_transitions import (
     TransitionRMtoClosed,
@@ -195,5 +195,48 @@ def create_close_report_trigger_tree(
         "Created CloseReportTriggerBT for offer=%s report=%s",
         offer_id,
         report_id,
+    )
+    return root
+
+
+def submit_report_trigger_bt(
+    report_id: str,
+    recipient_id: str,
+    captured: dict | None = None,
+) -> py_trees.behaviour.Behaviour:
+    """Create the BT for the submit-report trigger workflow.
+
+    Emits ``Offer(VulnerabilityReport)`` addressed to *recipient_id* and
+    queues the offer ID in the actor's outbox.
+
+    Structure::
+
+        SubmitReportTriggerBT (Sequence)
+        └─ EmitSubmitReportActivity  # emit offer + queue in outbox
+
+    Args:
+        report_id: ID of the already-persisted VulnerabilityReport.
+        recipient_id: Actor URI to send the offer to.
+        captured: Optional dict; ``captured["offer"]`` is set to the
+            serialised offer dict on success.
+
+    Returns:
+        Root node of the ``SubmitReportTriggerBT`` Sequence.
+    """
+    root = py_trees.composites.Sequence(
+        name="SubmitReportTriggerBT",
+        memory=False,
+        children=[
+            EmitSubmitReportActivity(
+                report_id=report_id,
+                recipient_id=recipient_id,
+                captured=captured,
+            ),
+        ],
+    )
+    logger.debug(
+        "Created SubmitReportTriggerBT for report=%s recipient=%s",
+        report_id,
+        recipient_id,
     )
     return root

--- a/vultron/core/use_cases/triggers/_base.py
+++ b/vultron/core/use_cases/triggers/_base.py
@@ -62,6 +62,8 @@ class SvcBTTriggerBase(ABC):
     9. Return ``{"activity": self._captured.get("activity")}``.
     """
 
+    _requires_trigger_activity: bool = True
+
     def __init__(
         self,
         dl: CaseOutboxPersistence,
@@ -80,15 +82,16 @@ class SvcBTTriggerBase(ABC):
 
         self._prepare()
 
-        if self._trigger_activity is None:
+        if self._requires_trigger_activity and self._trigger_activity is None:
             raise RuntimeError(
                 f"{type(self).__name__} requires a TriggerActivityPort"
             )
-        self._factory: TriggerActivityPort = self._trigger_activity
+        if self._trigger_activity is not None:
+            self._factory: TriggerActivityPort = self._trigger_activity
 
         bridge = BTBridge(
             datalayer=self._dl,
-            trigger_activity=self._factory,
+            trigger_activity=self._trigger_activity,
         )
         tree = self._build_tree()
         result = bridge.execute_with_setup(tree, actor_id=self._actor_id)

--- a/vultron/core/use_cases/triggers/actor.py
+++ b/vultron/core/use_cases/triggers/actor.py
@@ -20,15 +20,18 @@ No HTTP framework imports permitted here.
 """
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import cast
 
-from vultron.core.ports.case_persistence import CaseOutboxPersistence
-from vultron.core.use_cases._helpers import (
-    _find_case_actor_id,
-    _resolve_case_manager_id,
+import py_trees.behaviour
+
+from vultron.core.behaviors.case.actor_trigger_trees import (
+    accept_case_invite_trigger_bt,
+    invite_actor_to_case_trigger_bt,
+    suggest_actor_to_case_trigger_bt,
 )
+from vultron.core.use_cases._helpers import _find_case_actor_id
+from vultron.core.use_cases.triggers._base import SvcBTTriggerBase
 from vultron.core.use_cases.triggers._helpers import (
-    add_activity_to_outbox,
     resolve_actor,
     resolve_case,
 )
@@ -37,194 +40,134 @@ from vultron.core.use_cases.triggers.requests import (
     InviteActorToCaseTriggerRequest,
     SuggestActorToCaseTriggerRequest,
 )
-from vultron.errors import VultronNotFoundError, VultronValidationError
-
-if TYPE_CHECKING:
-    from vultron.core.ports.trigger_activity import TriggerActivityPort
+from vultron.errors import (
+    VultronNotFoundError,
+    VultronValidationError,
+)
 
 logger = logging.getLogger(__name__)
 
 
-class SvcSuggestActorToCaseUseCase:
+class SvcSuggestActorToCaseUseCase(SvcBTTriggerBase):
     """Recommend another actor for participation in an existing case.
 
-    Emits a RecommendActorActivity addressed only to the CaseActor, which then
-    autonomously invites the suggested actor.
-    The originating actor is the ``actor`` field; ``object_`` is the actor
-    being suggested; ``target`` is the case.
+    Emits a RecommendActorActivity routed through the Case Manager
+    (SenderSideBT / PCR-08-001).
     """
 
-    def __init__(
-        self,
-        dl: CaseOutboxPersistence,
-        request: SuggestActorToCaseTriggerRequest,
-        trigger_activity: "TriggerActivityPort | None" = None,
-    ) -> None:
-        self._dl = dl
-        self._request = request
-        self._trigger_activity = trigger_activity
+    def _prepare(self) -> None:
+        request = cast(SuggestActorToCaseTriggerRequest, self._request)
+        actor = resolve_actor(request.actor_id, self._dl)
+        self._actor_id = actor.id_
+        self._case = resolve_case(request.case_id, self._dl)
 
-    def execute(self) -> dict[str, Any]:
-        actor_id = self._request.actor_id
-        actor = resolve_actor(actor_id, self._dl)
-        actor_id = actor.id_
-        case = resolve_case(self._request.case_id, self._dl)
-
-        suggested_raw = self._dl.read(self._request.suggested_actor_id)
+        suggested_raw = self._dl.read(request.suggested_actor_id)
         if suggested_raw is None:
-            raise VultronNotFoundError(
-                "Actor", self._request.suggested_actor_id
-            )
+            raise VultronNotFoundError("Actor", request.suggested_actor_id)
 
-        if self._trigger_activity is None:
-            raise RuntimeError(
-                "SvcSuggestActorToCaseUseCase requires a TriggerActivityPort"
-            )
+        self._suggested_actor_id = request.suggested_actor_id
 
-        case_manager_id = _resolve_case_manager_id(case, self._dl)
-        if not case_manager_id:
-            raise VultronValidationError(
-                "SvcSuggestActorToCaseUseCase requires a CASE_MANAGER"
-                " participant with a routable actor ID."
-            )
-
-        activity_id, activity_dict = (
-            self._trigger_activity.suggest_actor_to_case(
-                recommended_id=self._request.suggested_actor_id,
-                case_id=case.id_,
-                actor=actor_id,
+    def _build_tree(self) -> py_trees.behaviour.Behaviour:
+        def _build_activities(case_manager_id: str) -> list[str]:
+            activity_id, activity_dict = self._factory.suggest_actor_to_case(
+                recommended_id=self._suggested_actor_id,
+                case_id=self._case.id_,
+                actor=self._actor_id,
                 to=[case_manager_id],
             )
+            self._captured["activity"] = activity_dict
+            return [activity_id]
+
+        return suggest_actor_to_case_trigger_bt(
+            case_id=self._case.id_,
+            activity_builder=_build_activities,
         )
 
-        add_activity_to_outbox(actor_id, activity_id, self._dl)
-
+    def _handle_result(self) -> None:
         logger.info(
             "Actor '%s' suggested actor '%s' for case '%s'",
-            actor_id,
-            self._request.suggested_actor_id,
-            case.id_,
+            self._actor_id,
+            self._suggested_actor_id,
+            self._case.id_,
         )
 
-        return {"activity": activity_dict}
 
-
-class SvcInviteActorToCaseUseCase:
+class SvcInviteActorToCaseUseCase(SvcBTTriggerBase):
     """Directly invite an actor to a case (case-owner action).
 
-    Emits an RmInviteToCaseActivity addressed to the invitee, queued in the
-    actor's outbox for delivery.
+    Emits RmInviteToCaseActivity from the Case Actor's identity
+    (PCR-08-007).  ``self._actor_id`` is set to the Case Actor URI in
+    ``_prepare()`` so the BT queues the invite in the Case Actor's outbox.
     """
 
-    def __init__(
-        self,
-        dl: CaseOutboxPersistence,
-        request: InviteActorToCaseTriggerRequest,
-        trigger_activity: "TriggerActivityPort | None" = None,
-    ) -> None:
-        self._dl = dl
-        self._request = request
-        self._trigger_activity = trigger_activity
+    def _prepare(self) -> None:
+        request = cast(InviteActorToCaseTriggerRequest, self._request)
+        actor = resolve_actor(request.actor_id, self._dl)
+        owner_id = actor.id_
+        self._case = resolve_case(request.case_id, self._dl)
 
-    def execute(self) -> dict[str, Any]:
-        actor_id = self._request.actor_id
-        actor = resolve_actor(actor_id, self._dl)
-        actor_id = actor.id_
-        case = resolve_case(self._request.case_id, self._dl)
-
-        invitee_raw = self._dl.read(self._request.invitee_id)
+        invitee_raw = self._dl.read(request.invitee_id)
         if invitee_raw is None:
-            raise VultronNotFoundError("Actor", self._request.invitee_id)
+            raise VultronNotFoundError("Actor", request.invitee_id)
 
-        if self._trigger_activity is None:
-            raise RuntimeError(
-                "SvcInviteActorToCaseUseCase requires a TriggerActivityPort"
-            )
+        self._invitee_id = request.invitee_id
 
-        # PCR-08-007: the invite MUST be sent from the Case Actor's identity.
-        # Fall back to the case owner (actor_id) only when no Case Actor has
-        # been established yet (early-lifecycle cases without a Service record).
-        case_actor_id = _find_case_actor_id(self._dl, case.id_)
-        invite_actor_id = case_actor_id if case_actor_id else actor_id
-        attributed_to = actor_id if case_actor_id else None
+        case_actor_id = _find_case_actor_id(self._dl, self._case.id_)
+        self._actor_id = case_actor_id if case_actor_id else owner_id
+        self._attributed_to = owner_id if case_actor_id else None
 
-        activity_id, activity_dict = (
-            self._trigger_activity.invite_actor_to_case(
-                invitee_id=self._request.invitee_id,
-                case_id=case.id_,
-                actor=invite_actor_id,
-                to=[self._request.invitee_id],
-                attributed_to=attributed_to,
-            )
+    def _build_tree(self) -> py_trees.behaviour.Behaviour:
+        return invite_actor_to_case_trigger_bt(
+            invitee_id=self._invitee_id,
+            case_id=self._case.id_,
+            attributed_to=self._attributed_to,
+            captured=self._captured,
         )
 
-        # PCR-08-007: queue in the Case Actor's outbox so it appears to come
-        # from the Case Actor.  Fall back to the owner's outbox when no Case
-        # Actor is registered.
-        add_activity_to_outbox(invite_actor_id, activity_id, self._dl)
-
+    def _handle_result(self) -> None:
         logger.info(
             "Actor '%s' invited actor '%s' to case '%s'",
-            actor_id,
-            self._request.invitee_id,
-            case.id_,
+            self._actor_id,
+            self._invitee_id,
+            self._case.id_,
         )
 
-        return {"activity": activity_dict}
 
-
-class SvcAcceptCaseInviteUseCase:
+class SvcAcceptCaseInviteUseCase(SvcBTTriggerBase):
     """Accept a case invitation by emitting RmAcceptInviteToCaseActivity.
 
-    The invitee actor reads the invite from the DataLayer, coerces it to
-    the expected typed class if needed, and queues the accept activity in
-    their outbox for delivery to the case owner.
+    The invitee actor reads the invite from the DataLayer and queues the
+    Accept activity for delivery to the Case Actor.
     """
 
-    def __init__(
-        self,
-        dl: CaseOutboxPersistence,
-        request: AcceptCaseInviteTriggerRequest,
-        trigger_activity: "TriggerActivityPort | None" = None,
-    ) -> None:
-        self._dl = dl
-        self._request = request
-        self._trigger_activity = trigger_activity
+    def _prepare(self) -> None:
+        request = cast(AcceptCaseInviteTriggerRequest, self._request)
+        actor = resolve_actor(request.actor_id, self._dl)
+        self._actor_id = actor.id_
 
-    def execute(self) -> dict[str, Any]:
-        actor_id = self._request.actor_id
-        actor = resolve_actor(actor_id, self._dl)
-        actor_id = actor.id_
-
-        raw_invite = self._dl.read(self._request.invite_id)
+        raw_invite = self._dl.read(request.invite_id)
         if raw_invite is None:
             raise VultronNotFoundError(
-                "RmInviteToCaseActivity", self._request.invite_id
+                "RmInviteToCaseActivity", request.invite_id
             )
 
         invite_type = getattr(raw_invite, "type_", "")
         if invite_type != "Invite":
             raise VultronValidationError(
-                f"'{self._request.invite_id}' is not an"
-                " RmInviteToCaseActivity"
+                f"'{request.invite_id}' is not an RmInviteToCaseActivity"
             )
 
-        if self._trigger_activity is None:
-            raise RuntimeError(
-                "SvcAcceptCaseInviteUseCase requires a TriggerActivityPort"
-            )
+        self._invite_id = request.invite_id
 
-        activity_id, activity_dict = self._trigger_activity.accept_case_invite(
-            invite_id=self._request.invite_id,
-            actor=actor_id,
+    def _build_tree(self) -> py_trees.behaviour.Behaviour:
+        return accept_case_invite_trigger_bt(
+            invite_id=self._invite_id,
+            captured=self._captured,
         )
 
-        add_activity_to_outbox(actor_id, activity_id, self._dl)
-
+    def _handle_result(self) -> None:
         logger.info(
             "Actor '%s' accepted case invite '%s'",
-            actor_id,
-            self._request.invite_id,
+            self._actor_id,
+            self._invite_id,
         )
-
-        return {"activity": activity_dict}

--- a/vultron/core/use_cases/triggers/note.py
+++ b/vultron/core/use_cases/triggers/note.py
@@ -20,18 +20,16 @@ No HTTP framework imports permitted here.
 """
 
 import logging
-from typing import TYPE_CHECKING
+from typing import cast
 
-from py_trees.common import Status
+import py_trees.behaviour
 
-from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.note.add_note_trigger_tree import (
     add_note_to_case_trigger_bt,
 )
 from vultron.core.models.events.base import MessageSemantics
 from vultron.core.models.pending_assertion import get_pending_assertion_store
-from vultron.core.ports.case_persistence import CaseOutboxPersistence
-from vultron.errors import VultronValidationError
+from vultron.core.use_cases.triggers._base import SvcBTTriggerBase
 from vultron.core.use_cases.triggers._helpers import (
     resolve_actor,
     resolve_case,
@@ -40,13 +38,10 @@ from vultron.core.use_cases.triggers.requests import (
     AddNoteToCaseTriggerRequest,
 )
 
-if TYPE_CHECKING:
-    from vultron.core.ports.trigger_activity import TriggerActivityPort
-
 logger = logging.getLogger(__name__)
 
 
-class SvcAddNoteToCaseUseCase:
+class SvcAddNoteToCaseUseCase(SvcBTTriggerBase):
     """Add a note to a case (actor-initiated).
 
     Creates the note in the actor's datalayer, adds it to the actor's local
@@ -60,93 +55,67 @@ class SvcAddNoteToCaseUseCase:
     in the actor's pending-assertion store so that duplicate near-term
     re-emits are suppressed until the matching Announce(CaseLedgerEntry)
     arrives (SYNC-11-002).
+
+    The return value extends the base-class ``{"activity": ...}`` dict with
+    a ``"note"`` key for the created Note object.
     """
 
-    def __init__(
-        self,
-        dl: CaseOutboxPersistence,
-        request: AddNoteToCaseTriggerRequest,
-        trigger_activity: "TriggerActivityPort | None" = None,
-    ) -> None:
-        self._dl = dl
-        self._request = request
-        self._trigger_activity = trigger_activity
+    def _prepare(self) -> None:
+        request = cast(AddNoteToCaseTriggerRequest, self._request)
+        actor = resolve_actor(request.actor_id, self._dl)
+        self._actor_id = actor.id_
+        self._case_id = request.case_id
+        resolve_case(request.case_id, self._dl)
 
-    def execute(self) -> dict:
-        request = self._request
-        actor_id = request.actor_id
-        case_id = request.case_id
-        dl = self._dl
-
-        actor = resolve_actor(actor_id, dl)
-        actor_id = actor.id_
-
-        resolve_case(case_id, dl)
-
-        if self._trigger_activity is None:
-            raise RuntimeError(
-                "SvcAddNoteToCaseUseCase requires a TriggerActivityPort"
-            )
-        factory = self._trigger_activity
-
-        # result_out is written by CreateNoteNode and AttachNoteFromResultNode
-        # inside the BT; the closure and the return statement read from it.
-        result_out: dict = {}
+    def _build_tree(self) -> py_trees.behaviour.Behaviour:
+        request = cast(AddNoteToCaseTriggerRequest, self._request)
 
         def _build_activities(case_manager_id: str) -> list[str]:
-            note_id = result_out["note_id"]
-            create_id = factory.create_note_activity(
-                actor=actor_id,
+            note_id = str(self._result_out["note_id"])
+            create_id = self._factory.create_note_activity(
+                actor=self._actor_id,
                 note_id=note_id,
                 to=[case_manager_id],
             )
-            add_id, add_dict = factory.add_note_to_case(
+            add_id, add_dict = self._factory.add_note_to_case(
                 note_id=note_id,
-                case_id=case_id,
-                actor=actor_id,
+                case_id=self._case_id,
+                actor=self._actor_id,
                 to=[case_manager_id],
             )
-            result_out["activity"] = add_dict
-            result_out["add_activity_id"] = add_id
+            self._captured["activity"] = add_dict
+            self._result_out["add_activity_id"] = add_id
             return [create_id, add_id]
 
-        bridge = BTBridge(datalayer=dl, trigger_activity=factory)
-        tree = add_note_to_case_trigger_bt(
-            case_id=case_id,
+        return add_note_to_case_trigger_bt(
+            case_id=self._case_id,
             note_name=request.note_name,
             note_content=request.note_content,
             in_reply_to=request.in_reply_to,
-            result_out=result_out,
+            result_out=self._result_out,
             activity_builder=_build_activities,
         )
-        result_status = bridge.execute_with_setup(tree, actor_id=actor_id)
 
-        if result_status.status != Status.SUCCESS:
-            raise VultronValidationError(
-                f"AddNoteToCase failed: {BTBridge.get_failure_reason(tree)}"
-            )
-
-        note_id = result_out.get("note_id", "")
+    def _handle_result(self) -> None:
+        self._captured["note"] = self._result_out.get("note_dict")
+        note_id = self._result_out.get("note_id", "")
         logger.info(
             "Actor '%s' added note '%s' to case '%s'",
-            actor_id,
+            self._actor_id,
             note_id,
-            case_id,
+            self._case_id,
         )
-
-        # Record the Add(Note,Case) activity in the pending-assertion store so
-        # that duplicate near-term re-emits are suppressed until the matching
-        # Announce(CaseLedgerEntry) confirms the round-trip (SYNC-11-002).
-        add_activity_id = result_out.get("add_activity_id", "")
+        add_activity_id = str(self._result_out.get("add_activity_id", ""))
         if add_activity_id:
-            store = get_pending_assertion_store(actor_id)
+            store = get_pending_assertion_store(self._actor_id)
             store.add(
-                case_id,
+                self._case_id,
                 MessageSemantics.ADD_NOTE_TO_CASE.value,
                 add_activity_id,
             )
 
-        return {
-            "note": result_out.get("note_dict"),
-            "activity": result_out.get("activity"),
-        }
+    def execute(self) -> dict:
+        """Execute and return ``{"note": ..., "activity": ...}``."""
+        result = super().execute()
+        result["note"] = self._captured.get("note")
+        return result

--- a/vultron/core/use_cases/triggers/report.py
+++ b/vultron/core/use_cases/triggers/report.py
@@ -25,24 +25,24 @@ No HTTP framework imports (FastAPI, Starlette) are permitted here.
 """
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import Any, cast
 
-from py_trees.common import Status
+import py_trees.behaviour
 
-from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.report.trigger_report_trees import (
     create_close_report_trigger_tree,
     create_invalidate_report_trigger_tree,
     create_reject_report_trigger_tree,
+    submit_report_trigger_bt,
 )
 from vultron.core.behaviors.report.validate_tree import (
     create_validate_report_tree,
 )
-from vultron.core.models.report_case_link import VultronReportCaseLink
 from vultron.core.models.report import VultronReport
+from vultron.core.models.report_case_link import VultronReportCaseLink
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
+from vultron.core.use_cases.triggers._base import SvcBTTriggerBase
 from vultron.core.use_cases.triggers._helpers import (
-    add_activity_to_outbox,
     outbox_ids,
     resolve_actor,
 )
@@ -53,13 +53,7 @@ from vultron.core.use_cases.triggers.requests import (
     SubmitReportTriggerRequest,
     ValidateReportTriggerRequest,
 )
-from vultron.errors import (
-    VultronNotFoundError,
-    VultronValidationError,
-)
-
-if TYPE_CHECKING:
-    from vultron.core.ports.trigger_activity import TriggerActivityPort
+from vultron.errors import VultronNotFoundError, VultronValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -91,296 +85,178 @@ def _resolve_offer_and_report(
     return offer, report
 
 
-class SvcValidateReportUseCase:
-    """Validate a report offer using the ValidateReportBT behavior tree."""
+class SvcValidateReportUseCase(SvcBTTriggerBase):
+    """Validate a report offer using the ValidateReportBT behavior tree.
 
-    def __init__(
-        self, dl: CaseOutboxPersistence, request: ValidateReportTriggerRequest
-    ) -> None:
-        self._dl = dl
-        self._request: ValidateReportTriggerRequest = request
+    Does not require a TriggerActivityPort — the validate BT performs only
+    state transitions without constructing outbound activities.
+    """
 
-    def execute(self) -> dict:
-        request = self._request
-        actor_id = request.actor_id
-        offer_id = request.offer_id
-        note = request.note
-        dl = self._dl
+    _requires_trigger_activity = False
 
-        actor = resolve_actor(actor_id, dl)
-        actor_id = actor.id_
+    def _prepare(self) -> None:
+        request = cast(ValidateReportTriggerRequest, self._request)
+        actor = resolve_actor(request.actor_id, self._dl)
+        self._actor_id = actor.id_
+        self._offer, self._report = _resolve_offer_and_report(
+            request.offer_id, self._dl
+        )
+        self._before = outbox_ids(self._actor_id, self._dl)
 
-        offer, report = _resolve_offer_and_report(offer_id, dl)
-        report_id = report.id_
-        offer_id = offer.id_
-
-        before = outbox_ids(actor_id, dl)
-
-        bridge = BTBridge(datalayer=dl)
-        tree = create_validate_report_tree(
-            report_id=report_id,
-            offer_id=offer_id,
+    def _build_tree(self) -> py_trees.behaviour.Behaviour:
+        return create_validate_report_tree(
+            report_id=self._report.id_,
+            offer_id=self._offer.id_,
         )
 
-        context: dict[str, Any] = {}
-        if note:
-            context["note"] = note
-
-        bridge.execute_with_setup(tree, actor_id=actor_id, **context)
-
-        activity = None
-        actor_after = dl.read(actor_id)
-        if actor_after is not None:
-            after = outbox_ids(actor_id, dl)
-            new_items = after - before
-            if new_items:
-                activity_id = next(iter(new_items))
-                activity_obj = dl.read(activity_id)
-                if activity_obj is not None:
-                    activity = activity_obj.model_dump(
-                        by_alias=True, exclude_none=True
-                    )
-
-        return {"activity": activity}
+    def _handle_result(self) -> None:
+        after = outbox_ids(self._actor_id, self._dl)
+        new_items = after - self._before
+        if new_items:
+            activity_id = next(iter(new_items))
+            activity_obj = self._dl.read(activity_id)
+            if activity_obj is not None:
+                self._captured["activity"] = activity_obj.model_dump(
+                    by_alias=True, exclude_none=True
+                )
 
 
-class SvcInvalidateReportUseCase:
+class SvcInvalidateReportUseCase(SvcBTTriggerBase):
     """Emit RmInvalidateReportActivity (TentativeReject) for the given offer."""
 
-    def __init__(
-        self,
-        dl: CaseOutboxPersistence,
-        request: InvalidateReportTriggerRequest,
-        trigger_activity: "TriggerActivityPort | None" = None,
-    ) -> None:
-        self._dl = dl
-        self._request: InvalidateReportTriggerRequest = request
-        self._trigger_activity = trigger_activity
-
-    def execute(self) -> dict:
-        request = self._request
-        actor_id = request.actor_id
-        offer_id = request.offer_id
-        dl = self._dl
-
-        actor = resolve_actor(actor_id, dl)
-        actor_id = actor.id_
-
-        offer, report = _resolve_offer_and_report(offer_id, dl)
-
-        if self._trigger_activity is None:
-            raise RuntimeError(
-                "SvcInvalidateReportUseCase requires a TriggerActivityPort"
-            )
-
-        before = outbox_ids(actor_id, dl)
-
-        bridge = BTBridge(
-            datalayer=dl, trigger_activity=self._trigger_activity
+    def _prepare(self) -> None:
+        request = cast(InvalidateReportTriggerRequest, self._request)
+        actor = resolve_actor(request.actor_id, self._dl)
+        self._actor_id = actor.id_
+        self._offer, self._report = _resolve_offer_and_report(
+            request.offer_id, self._dl
         )
-        tree = create_invalidate_report_trigger_tree(
-            offer_id=offer.id_,
-            report_id=report.id_,
-        )
-        result = bridge.execute_with_setup(tree, actor_id=actor_id)
-        if result.status != Status.SUCCESS:
-            raise VultronValidationError(
-                f"InvalidateReport failed: {BTBridge.get_failure_reason(tree)}"
-            )
+        self._before = outbox_ids(self._actor_id, self._dl)
 
-        activity = None
-        after = outbox_ids(actor_id, dl)
-        new_items = after - before
+    def _build_tree(self) -> py_trees.behaviour.Behaviour:
+        return create_invalidate_report_trigger_tree(
+            offer_id=self._offer.id_,
+            report_id=self._report.id_,
+        )
+
+    def _handle_result(self) -> None:
+        after = outbox_ids(self._actor_id, self._dl)
+        new_items = after - self._before
         if new_items:
             activity_id = next(iter(new_items))
-            activity_obj = dl.read(activity_id)
+            activity_obj = self._dl.read(activity_id)
             if activity_obj is not None:
-                activity = activity_obj.model_dump(
+                self._captured["activity"] = activity_obj.model_dump(
                     by_alias=True, exclude_none=True
                 )
-
         logger.info(
             "Actor '%s' invalidated offer '%s' (report '%s')",
-            actor_id,
-            offer.id_,
-            report.id_,
+            self._actor_id,
+            self._offer.id_,
+            self._report.id_,
         )
 
-        return {"activity": activity}
 
-
-class SvcRejectReportUseCase:
+class SvcRejectReportUseCase(SvcBTTriggerBase):
     """Hard-close a report offer by emitting RmCloseReportActivity (Reject)."""
 
-    def __init__(
-        self,
-        dl: CaseOutboxPersistence,
-        request: RejectReportTriggerRequest,
-        trigger_activity: "TriggerActivityPort | None" = None,
-    ) -> None:
-        self._dl = dl
-        self._request: RejectReportTriggerRequest = request
-        self._trigger_activity = trigger_activity
-
-    def execute(self) -> dict:
-        request = self._request
-        actor_id = request.actor_id
-        offer_id = request.offer_id
-        note = request.note
-        dl = self._dl
-
-        actor = resolve_actor(actor_id, dl)
-        actor_id = actor.id_
-
-        offer, report = _resolve_offer_and_report(offer_id, dl)
-
-        if self._trigger_activity is None:
-            raise RuntimeError(
-                "SvcRejectReportUseCase requires a TriggerActivityPort"
-            )
-
-        before = outbox_ids(actor_id, dl)
-
-        bridge = BTBridge(
-            datalayer=dl, trigger_activity=self._trigger_activity
+    def _prepare(self) -> None:
+        request = cast(RejectReportTriggerRequest, self._request)
+        actor = resolve_actor(request.actor_id, self._dl)
+        self._actor_id = actor.id_
+        self._offer, self._report = _resolve_offer_and_report(
+            request.offer_id, self._dl
         )
-        tree = create_reject_report_trigger_tree(
-            offer_id=offer.id_,
-            report_id=report.id_,
-        )
-        result = bridge.execute_with_setup(tree, actor_id=actor_id)
-        if result.status != Status.SUCCESS:
-            raise VultronValidationError(
-                f"RejectReport failed: {BTBridge.get_failure_reason(tree)}"
-            )
+        self._before = outbox_ids(self._actor_id, self._dl)
 
-        activity = None
-        after = outbox_ids(actor_id, dl)
-        new_items = after - before
+    def _build_tree(self) -> py_trees.behaviour.Behaviour:
+        return create_reject_report_trigger_tree(
+            offer_id=self._offer.id_,
+            report_id=self._report.id_,
+        )
+
+    def _handle_result(self) -> None:
+        after = outbox_ids(self._actor_id, self._dl)
+        new_items = after - self._before
         if new_items:
             activity_id = next(iter(new_items))
-            activity_obj = dl.read(activity_id)
+            activity_obj = self._dl.read(activity_id)
             if activity_obj is not None:
-                activity = activity_obj.model_dump(
+                self._captured["activity"] = activity_obj.model_dump(
                     by_alias=True, exclude_none=True
                 )
-
+        request = cast(RejectReportTriggerRequest, self._request)
         logger.info(
             "Actor '%s' hard-closed offer '%s' (report '%s'); note: %s",
-            actor_id,
-            offer.id_,
-            report.id_,
-            note,
+            self._actor_id,
+            self._offer.id_,
+            self._report.id_,
+            request.note,
         )
 
-        return {"activity": activity}
 
-
-class SvcCloseReportUseCase:
+class SvcCloseReportUseCase(SvcBTTriggerBase):
     """Close a report via the RM lifecycle (RM → C transition)."""
 
-    def __init__(
-        self,
-        dl: CaseOutboxPersistence,
-        request: CloseReportTriggerRequest,
-        trigger_activity: "TriggerActivityPort | None" = None,
-    ) -> None:
-        self._dl = dl
-        self._request: CloseReportTriggerRequest = request
-        self._trigger_activity = trigger_activity
-
-    def execute(self) -> dict:
-        request = self._request
-        actor_id = request.actor_id
-        offer_id = request.offer_id
-        note = request.note
-        dl = self._dl
-
-        actor = resolve_actor(actor_id, dl)
-        actor_id = actor.id_
-
-        offer, report = _resolve_offer_and_report(offer_id, dl)
-
-        if self._trigger_activity is None:
-            raise RuntimeError(
-                "SvcCloseReportUseCase requires a TriggerActivityPort"
-            )
-
-        before = outbox_ids(actor_id, dl)
-        result_out: dict[str, object] = {}
-
-        bridge = BTBridge(
-            datalayer=dl, trigger_activity=self._trigger_activity
+    def _prepare(self) -> None:
+        request = cast(CloseReportTriggerRequest, self._request)
+        actor = resolve_actor(request.actor_id, self._dl)
+        self._actor_id = actor.id_
+        self._offer, self._report = _resolve_offer_and_report(
+            request.offer_id, self._dl
         )
-        tree = create_close_report_trigger_tree(
-            offer_id=offer.id_,
-            report_id=report.id_,
-            result_out=result_out,
-        )
-        result = bridge.execute_with_setup(tree, actor_id=actor_id)
-        if result.status != Status.SUCCESS:
-            error = result_out.get("error")
-            if isinstance(error, Exception):
-                raise error
-            raise VultronValidationError(
-                f"CloseReport failed: {BTBridge.get_failure_reason(tree)}"
-            )
+        self._before = outbox_ids(self._actor_id, self._dl)
 
-        activity = None
-        after = outbox_ids(actor_id, dl)
-        new_items = after - before
+    def _build_tree(self) -> py_trees.behaviour.Behaviour:
+        return create_close_report_trigger_tree(
+            offer_id=self._offer.id_,
+            report_id=self._report.id_,
+            result_out=self._result_out,
+        )
+
+    def _handle_result(self) -> None:
+        after = outbox_ids(self._actor_id, self._dl)
+        new_items = after - self._before
         if new_items:
             activity_id = next(iter(new_items))
-            activity_obj = dl.read(activity_id)
+            activity_obj = self._dl.read(activity_id)
             if activity_obj is not None:
-                activity = activity_obj.model_dump(
+                self._captured["activity"] = activity_obj.model_dump(
                     by_alias=True, exclude_none=True
                 )
-
+        request = cast(CloseReportTriggerRequest, self._request)
         logger.info(
             "Actor '%s' closed offer '%s' (report '%s') via RM lifecycle;"
             " note: %s",
-            actor_id,
-            offer.id_,
-            report.id_,
-            note,
+            self._actor_id,
+            self._offer.id_,
+            self._report.id_,
+            request.note,
         )
 
-        return {"activity": activity}
 
-
-class SvcSubmitReportUseCase:
+class SvcSubmitReportUseCase(SvcBTTriggerBase):
     """Create a VulnerabilityReport and offer it to a recipient.
 
-    Stores the report and an RmSubmitReportActivity in the actor's DataLayer,
-    queues the offer in the actor's outbox, and returns the serialised offer so
-    the caller can deliver it (e.g. POST to the recipient's inbox).
+    Stores the report and a VultronReportCaseLink in the actor's DataLayer
+    during ``_prepare()``, then runs ``SubmitReportTriggerBT`` to build
+    and queue the Offer activity.  Returns ``{"offer": <offer_dict>}``
+    rather than the base-class ``{"activity": ...}`` shape to preserve
+    the existing API contract.
     """
 
-    def __init__(
-        self,
-        dl: CaseOutboxPersistence,
-        request: SubmitReportTriggerRequest,
-        trigger_activity: "TriggerActivityPort | None" = None,
-    ) -> None:
-        self._dl = dl
-        self._request = request
-        self._trigger_activity = trigger_activity
-
-    def execute(self) -> dict:
-        request = self._request
-        dl = self._dl
-
-        actor = resolve_actor(request.actor_id, dl)
-        actor_id = actor.id_
+    def _prepare(self) -> None:
+        request = cast(SubmitReportTriggerRequest, self._request)
+        actor = resolve_actor(request.actor_id, self._dl)
+        self._actor_id = actor.id_
 
         report = VultronReport(
             name=request.report_name,
             content=request.report_content,
-            attributed_to=actor_id,
+            attributed_to=self._actor_id,
         )
         try:
-            dl.create(report)
+            self._dl.create(report)
         except ValueError:
             logger.warning(
                 "VulnerabilityReport '%s' already exists", report.id_
@@ -391,8 +267,9 @@ class SvcSubmitReportUseCase:
             request.report_name,
             report.id_,
         )
+
         try:
-            dl.create(
+            self._dl.create(
                 VultronReportCaseLink(
                     report_id=report.id_,
                     trusted_case_creator_id=request.recipient_id,
@@ -405,25 +282,24 @@ class SvcSubmitReportUseCase:
                 report.id_,
             )
 
-        if self._trigger_activity is None:
-            raise RuntimeError(
-                "SvcSubmitReportUseCase requires a TriggerActivityPort"
-            )
+        self._report_id = report.id_
+        self._recipient_id = request.recipient_id
 
-        offer_id, offer_dict = self._trigger_activity.submit_report(
-            report_id=report.id_,
-            actor=actor_id,
-            to=request.recipient_id,
-            target=request.recipient_id,
+    def _build_tree(self) -> py_trees.behaviour.Behaviour:
+        return submit_report_trigger_bt(
+            report_id=self._report_id,
+            recipient_id=self._recipient_id,
+            captured=self._captured,
         )
 
+    def _handle_result(self) -> None:
         logger.info(
-            "Offering report '%s' to '%s' (offer: '%s')",
-            report.id_,
-            request.recipient_id,
-            offer_id,
+            "Offering report '%s' to '%s'",
+            self._report_id,
+            self._recipient_id,
         )
 
-        add_activity_to_outbox(actor_id, offer_id, dl)
-
-        return {"offer": offer_dict}
+    def execute(self) -> dict:
+        """Execute and return ``{"offer": <offer_dict>}``."""
+        super().execute()
+        return {"offer": self._captured.get("offer")}

--- a/vultron/core/use_cases/triggers/sync.py
+++ b/vultron/core/use_cases/triggers/sync.py
@@ -18,6 +18,10 @@ Public entry points:
 - :func:`commit_log_entry_trigger`
 - :func:`replay_missing_entries_trigger`
 
+Note: This module contains standalone trigger functions, not class-based use
+cases.  There are no classes to migrate to SvcBTTriggerBase, and neither
+function uses BTBridge.
+
 Spec: SYNC-02-002, SYNC-02-003, SYNC-03-001, SYNC-03-002.
 """
 


### PR DESCRIPTION
- Closes #1006

## Summary

Extends the `SvcBTTriggerBase` ABC (introduced in #1004) to every
trigger use case in `report.py`, `note.py`, `sync.py`, and
`actor.py`, building the missing BT implementations needed for full
coverage.

## Changes

**`_base.py`** — Added `_requires_trigger_activity: bool = True`
class variable. Use cases that run BT-only workflows (no outbound
activity) set it to `False` to bypass the `TriggerActivityPort`
guard while still executing via `BTBridge`.

**New BT nodes / trees**
- `report/nodes/emit.py` — `EmitSubmitReportActivity`
- `report/trigger_report_trees.py` — `submit_report_trigger_bt`
- `case/actor_trigger_trees.py` (new) — `EmitInviteActorToCaseNode`,
  `EmitAcceptCaseInviteNode`, `invite_actor_to_case_trigger_bt`,
  `accept_case_invite_trigger_bt`, `suggest_actor_to_case_trigger_bt`

**`report.py`** — migrated remaining two use cases:
- `SvcValidateReportUseCase` (`_requires_trigger_activity = False`;
  captures activity from outbox diff)
- `SvcSubmitReportUseCase` (overrides `execute()` to return
  `{"offer": ...}` to preserve existing API contract)

**`actor.py`** — fully migrated all three use cases:
- `SvcSuggestActorToCaseUseCase` — `sender_side_bt` for Case-Manager
  routing (PCR-08-001)
- `SvcInviteActorToCaseUseCase` — sets `self._actor_id` to the Case
  Actor URI in `_prepare()` per PCR-08-007
- `SvcAcceptCaseInviteUseCase` — validates invite type before running BT

**`note.py`** — already migrated (no new changes).

**`sync.py`** — module-level comment added; standalone functions have
no class migration needed.

## Verification

```
3422 passed, 34 skipped, 225 deselected, 2 xfailed, 5633 subtests passed
mypy: Success — no issues found in 854 source files
pyright: 0 errors, 0 warnings, 0 informations
```