### PR TITLE
Apply SvcBTTriggerBase to case trigger use cases

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -168,3 +168,15 @@ call sites inside the abstract methods. Initialising them at the top of
 avoids "possibly unbound" errors without introducing unnecessary sentinel
 values into `__init__`. Use `cast()` in `_prepare()` to restore specific
 request type narrowing lost by widening to `object` in the base `__init__`.
+
+### 2026-06-16 BASE-HOOK-1005 — SvcBTTriggerBase needs _extra_execute_kwargs() for trees that read case_id from blackboard
+
+`UpdateActorOutbox` reads `case_id` from the blackboard (registered via
+`execute_with_setup` kwargs). The original `_execute_add_object_trigger_bt`
+standalone function passed `case_id=case_id` explicitly. When converting to
+`SvcBTTriggerBase`, the base `execute()` only passes `actor_id` to
+`execute_with_setup`. Fix: add a `_extra_execute_kwargs() -> dict[str, Any]`
+hook (default `{}`) to `SvcBTTriggerBase`; classes whose BTs need extra
+blackboard keys override it. The return type must be `dict[str, Any]` (not
+`dict[str, object]`) to satisfy mypy when the dict is spread into
+`execute_with_setup`'s `**context_data: Any` parameter.

--- a/plan/history/2606/implementation/ISSUE-1005.md
+++ b/plan/history/2606/implementation/ISSUE-1005.md
@@ -1,0 +1,27 @@
+---
+source: ISSUE-1005
+timestamp: '2026-06-16T18:37:41.433757+00:00'
+title: Apply SvcBTTriggerBase to case trigger use cases
+type: implementation
+---
+
+## Issue #1005 — Apply SvcBTTriggerBase to case trigger use cases
+
+Applied the `SvcBTTriggerBase` ABC to all six case trigger use case classes
+under `vultron/core/use_cases/triggers/case/`, removing duplicated `__init__`,
+`BTBridge` construction, and failure guards from each class.
+
+Key implementation decisions:
+
+- Added `_extra_execute_kwargs()` hook to `SvcBTTriggerBase` (returns
+  `dict[str, Any]`, default `{}`) so `SvcAddObjectToCaseUseCase` and
+  `SvcAddReportToCaseUseCase` can pass `case_id` to the blackboard for
+  `UpdateActorOutbox`.
+- Removed the standalone `_execute_add_object_trigger_bt()` private function
+  from `add_object.py`; both add-object classes now implement the BT hooks
+  directly.
+- `SvcAddParticipantStatusUseCase` overrides `execute()` to return
+  `{activity_id, status_id}` (different shape from base class default).
+- All 3422 existing tests pass unchanged.
+
+PR: [#1009](https://github.com/CERTCC/Vultron/pull/1009)

--- a/vultron/core/use_cases/triggers/_base.py
+++ b/vultron/core/use_cases/triggers/_base.py
@@ -30,6 +30,7 @@ Two-level hierarchy:
 
 import logging
 from abc import ABC, abstractmethod
+from typing import Any
 
 import py_trees.behaviour
 from py_trees.common import Status
@@ -91,7 +92,11 @@ class SvcBTTriggerBase(ABC):
             trigger_activity=self._factory,
         )
         tree = self._build_tree()
-        result = bridge.execute_with_setup(tree, actor_id=self._actor_id)
+        result = bridge.execute_with_setup(
+            tree,
+            actor_id=self._actor_id,
+            **self._extra_execute_kwargs(),
+        )
 
         if result.status != Status.SUCCESS:
             error = self._result_out.get("error")
@@ -131,6 +136,15 @@ class SvcBTTriggerBase(ABC):
 
         Called only when the BT succeeded.
         """
+
+    def _extra_execute_kwargs(self) -> dict[str, Any]:
+        """Additional kwargs passed to ``bridge.execute_with_setup``.
+
+        Override to inject extra blackboard context required by specific BT
+        trees (e.g. ``{"case_id": self._case_id}`` for trees whose nodes
+        read ``case_id`` from the blackboard).
+        """
+        return {}
 
 
 class SvcEmbargoTriggerBase(SvcBTTriggerBase):

--- a/vultron/core/use_cases/triggers/case/add_object.py
+++ b/vultron/core/use_cases/triggers/case/add_object.py
@@ -14,15 +14,14 @@
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import Any, cast
 
-from py_trees.common import Status
+import py_trees.behaviour
 
-from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.case.add_object_trigger_tree import (
     add_object_trigger_bt,
 )
-from vultron.core.ports.case_persistence import CaseOutboxPersistence
+from vultron.core.use_cases.triggers._base import SvcBTTriggerBase
 from vultron.core.use_cases.triggers._helpers import (
     resolve_actor,
     resolve_case,
@@ -30,15 +29,12 @@ from vultron.core.use_cases.triggers._helpers import (
 from vultron.core.use_cases.triggers.requests import (
     AddObjectToCaseTriggerRequest,
 )
-from vultron.errors import VultronNotFoundError, VultronValidationError
-
-if TYPE_CHECKING:
-    from vultron.core.ports.trigger_activity import TriggerActivityPort
+from vultron.errors import VultronNotFoundError
 
 logger = logging.getLogger(__name__)
 
 
-class SvcAddObjectToCaseUseCase:
+class SvcAddObjectToCaseUseCase(SvcBTTriggerBase):
     """Add any existing AS2 object to a case (general-purpose).
 
     Reads the object by ``object_id`` from the datalayer, creates a generic
@@ -54,80 +50,36 @@ class SvcAddObjectToCaseUseCase:
     queueing are delegated to a trigger-side BT.
     """
 
-    def __init__(
-        self,
-        dl: CaseOutboxPersistence,
-        request: AddObjectToCaseTriggerRequest,
-        trigger_activity: "TriggerActivityPort | None" = None,
-    ) -> None:
-        self._dl = dl
-        self._request = request
-        self._trigger_activity = trigger_activity
+    def _prepare(self) -> None:
+        request = cast(AddObjectToCaseTriggerRequest, self._request)
+        actor = resolve_actor(request.actor_id, self._dl)
+        self._actor_id = actor.id_
+        self._case_id = resolve_case(request.case_id, self._dl).id_
+        self._object_id: str = request.object_id
+        if self._dl.read(self._object_id) is None:
+            raise VultronNotFoundError("AS2Object", self._object_id)
 
-    def execute(self) -> dict[str, Any]:
-        actor_id = self._request.actor_id
-        case_id = self._request.case_id
-        object_id = self._request.object_id
-        dl = self._dl
-
-        actor = resolve_actor(actor_id, dl)
-        actor_id = actor.id_
-
-        resolve_case(case_id, dl)
-
-        raw = dl.read(object_id)
-        if raw is None:
-            raise VultronNotFoundError("AS2Object", object_id)
-
-        if self._trigger_activity is None:
-            raise RuntimeError(
-                "SvcAddObjectToCaseUseCase requires a TriggerActivityPort"
+    def _build_tree(self) -> py_trees.behaviour.Behaviour:
+        def _build_activity() -> tuple[str, dict[str, Any]]:
+            return self._factory.add_object_to_case(
+                actor=self._actor_id,
+                object_id=self._object_id,
+                case_id=self._case_id,
             )
 
-        return _execute_add_object_trigger_bt(
-            dl=dl,
-            actor_id=actor_id,
-            case_id=case_id,
-            object_id=object_id,
-            trigger_activity=self._trigger_activity,
+        return add_object_trigger_bt(
+            result_out=self._result_out,
+            activity_builder=_build_activity,
         )
 
+    def _extra_execute_kwargs(self) -> dict[str, Any]:
+        return {"case_id": self._case_id}
 
-def _execute_add_object_trigger_bt(
-    *,
-    dl: CaseOutboxPersistence,
-    actor_id: str,
-    case_id: str,
-    object_id: str,
-    trigger_activity: "TriggerActivityPort",
-) -> dict[str, Any]:
-    """Emit Add(object,target=case) and queue it via BTBridge."""
-    result_data: dict[str, Any] = {}
-
-    def _build_activity() -> tuple[str, dict[str, Any]]:
-        return trigger_activity.add_object_to_case(
-            actor=actor_id,
-            object_id=object_id,
-            case_id=case_id,
+    def _handle_result(self) -> None:
+        self._captured["activity"] = self._result_out.get("activity")
+        logger.info(
+            "Actor '%s' added object '%s' to case '%s'",
+            self._actor_id,
+            self._object_id,
+            self._case_id,
         )
-
-    bridge = BTBridge(datalayer=dl, trigger_activity=trigger_activity)
-    tree = add_object_trigger_bt(
-        result_out=result_data,
-        activity_builder=_build_activity,
-    )
-    result = bridge.execute_with_setup(
-        tree, actor_id=actor_id, case_id=case_id
-    )
-    if result.status != Status.SUCCESS:
-        raise VultronValidationError(
-            f"AddObjectToCase failed: {BTBridge.get_failure_reason(tree)}"
-        )
-
-    logger.info(
-        "Actor '%s' added object '%s' to case '%s'",
-        actor_id,
-        object_id,
-        case_id,
-    )
-    return {"activity": result_data.get("activity")}

--- a/vultron/core/use_cases/triggers/case/add_participant_status.py
+++ b/vultron/core/use_cases/triggers/case/add_participant_status.py
@@ -14,17 +14,17 @@
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import Any, cast
 
-from py_trees.common import Status
+import py_trees.behaviour
 
-from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.case.add_participant_status_trigger_tree import (
     add_participant_status_trigger_bt,
 )
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.states.cs import CS_vfd
 from vultron.core.states.rm import RM
+from vultron.core.use_cases.triggers._base import SvcBTTriggerBase
 from vultron.core.use_cases.triggers._helpers import (
     resolve_actor,
     resolve_case,
@@ -32,15 +32,11 @@ from vultron.core.use_cases.triggers._helpers import (
 from vultron.core.use_cases.triggers.requests import (
     AddParticipantStatusTriggerRequest,
 )
-from vultron.errors import VultronValidationError
-
-if TYPE_CHECKING:
-    from vultron.core.ports.trigger_activity import TriggerActivityPort
 
 logger = logging.getLogger(__name__)
 
 
-class SvcAddParticipantStatusUseCase:
+class SvcAddParticipantStatusUseCase(SvcBTTriggerBase):
     """Self-report actor RM/VFD/PXA state to the Case Manager.
 
     Delegates ParticipantStatus record creation to
@@ -57,15 +53,58 @@ class SvcAddParticipantStatusUseCase:
     performed here.
     """
 
-    def __init__(
-        self,
-        dl: CaseOutboxPersistence,
-        request: AddParticipantStatusTriggerRequest,
-        trigger_activity: "TriggerActivityPort | None" = None,
-    ) -> None:
-        self._dl = dl
-        self._request = request
-        self._trigger_activity = trigger_activity
+    def _prepare(self) -> None:
+        request = cast(AddParticipantStatusTriggerRequest, self._request)
+        actor = resolve_actor(request.actor_id, self._dl)
+        self._actor_id = actor.id_
+        self._case_id = resolve_case(request.case_id, self._dl).id_
+        self._rm_state = request.rm_state
+        self._vfd_state = request.vfd_state
+        self._pxa_state = request.pxa_state
+
+    def _build_tree(self) -> py_trees.behaviour.Behaviour:
+        def _build_activities(case_manager_id: str) -> list[str]:
+            status_id = self._result_out.get("status_id")
+            participant_id = self._result_out.get("participant_id")
+            if not isinstance(status_id, str) or not isinstance(
+                participant_id, str
+            ):
+                raise RuntimeError(
+                    "CreateParticipantStatusNode did not populate result_out"
+                    " before activity_builder was called"
+                )
+            activity_id = self._factory.add_participant_status_to_participant(
+                status_id=status_id,
+                participant_id=participant_id,
+                actor=self._actor_id,
+                to=[case_manager_id],
+            )
+            self._result_out["activity_id"] = activity_id
+            return [activity_id]
+
+        return add_participant_status_trigger_bt(
+            case_id=self._case_id,
+            actor_id=self._actor_id,
+            rm_state=self._rm_state,
+            vfd_state=self._vfd_state,
+            pxa_state=self._pxa_state,
+            result_out=self._result_out,
+            activity_builder=_build_activities,
+        )
+
+    def _handle_result(self) -> None:
+        logger.info(
+            "Actor '%s' reported status in case '%s'",
+            self._actor_id,
+            self._case_id,
+        )
+
+    def execute(self) -> dict[str, Any]:
+        super().execute()
+        return {
+            "activity_id": self._result_out.get("activity_id"),
+            "status_id": self._result_out.get("status_id"),
+        }
 
     def _resolve_current_participant_state(
         self,
@@ -78,79 +117,15 @@ class SvcAddParticipantStatusUseCase:
         :func:`~vultron.core.behaviors.case.nodes.participant\
 .resolve_participant_state_from_dl`.
         """
+        from typing import cast as typing_cast
+
         from vultron.core.behaviors.case.nodes.participant import (
             resolve_participant_state_from_dl,
         )
-        from typing import cast
-        from vultron.core.ports.case_persistence import CasePersistence
+        from vultron.core.ports.case_persistence import (
+            CasePersistence,
+        )
 
         return resolve_participant_state_from_dl(
-            cast(CasePersistence, dl), participant_id
+            typing_cast(CasePersistence, dl), participant_id
         )
-
-    def execute(self) -> dict[str, Any]:
-        request = self._request
-        actor_id = request.actor_id
-        case_id = request.case_id
-        dl = self._dl
-
-        actor = resolve_actor(actor_id, dl)
-        actor_id = actor.id_
-
-        resolve_case(case_id, dl)
-
-        if self._trigger_activity is None:
-            raise RuntimeError(
-                "SvcAddParticipantStatusUseCase requires a TriggerActivityPort"
-            )
-
-        factory = self._trigger_activity
-        result_data: dict = {}
-
-        def _build_activities(case_manager_id: str) -> list[str]:
-            status_id = result_data.get("status_id")
-            participant_id = result_data.get("participant_id")
-            if not isinstance(status_id, str) or not isinstance(
-                participant_id, str
-            ):
-                raise RuntimeError(
-                    "CreateParticipantStatusNode did not populate result_data"
-                    " before activity_builder was called"
-                )
-            activity_id = factory.add_participant_status_to_participant(
-                status_id=status_id,
-                participant_id=participant_id,
-                actor=actor_id,
-                to=[case_manager_id],
-            )
-            result_data["activity_id"] = activity_id
-            return [activity_id]
-
-        bridge = BTBridge(datalayer=dl, trigger_activity=factory)
-        tree = add_participant_status_trigger_bt(
-            case_id=case_id,
-            actor_id=actor_id,
-            rm_state=request.rm_state,
-            vfd_state=request.vfd_state,
-            pxa_state=request.pxa_state,
-            result_out=result_data,
-            activity_builder=_build_activities,
-        )
-        result = bridge.execute_with_setup(tree, actor_id=actor_id)
-
-        if result.status != Status.SUCCESS:
-            raise VultronValidationError(
-                f"AddParticipantStatus failed:"
-                f" {BTBridge.get_failure_reason(tree)}"
-            )
-
-        logger.info(
-            "Actor '%s' reported status in case '%s'",
-            actor_id,
-            case_id,
-        )
-
-        return {
-            "activity_id": result_data.get("activity_id"),
-            "status_id": result_data.get("status_id"),
-        }

--- a/vultron/core/use_cases/triggers/case/add_report.py
+++ b/vultron/core/use_cases/triggers/case/add_report.py
@@ -13,9 +13,15 @@
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-from typing import TYPE_CHECKING, Any
+import logging
+from typing import Any, cast
 
-from vultron.core.ports.case_persistence import CaseOutboxPersistence
+import py_trees.behaviour
+
+from vultron.core.behaviors.case.add_object_trigger_tree import (
+    add_object_trigger_bt,
+)
+from vultron.core.use_cases.triggers._base import SvcBTTriggerBase
 from vultron.core.use_cases.triggers._helpers import (
     resolve_actor,
     resolve_case,
@@ -25,62 +31,57 @@ from vultron.core.use_cases.triggers.requests import (
 )
 from vultron.errors import VultronNotFoundError, VultronValidationError
 
-from .add_object import _execute_add_object_trigger_bt
-
-if TYPE_CHECKING:
-    from vultron.core.ports.trigger_activity import TriggerActivityPort
+logger = logging.getLogger(__name__)
 
 
-class SvcAddReportToCaseUseCase:
+class SvcAddReportToCaseUseCase(SvcBTTriggerBase):
     """Link a VulnerabilityReport to an existing case.
 
     Validates that the referenced object is a ``VulnerabilityReport``, then
-    delegates to :class:`SvcAddObjectToCaseUseCase` (TRIG-10-002).
+    delegates to the same Add-object BT as ``SvcAddObjectToCaseUseCase``
+    (TRIG-10-002).
     Emits an ``Add(VulnerabilityReport, target=VulnerabilityCase)`` activity
     queued in the actor's outbox.
 
     BT-15-001 audit: outbound Add(Report,target=case) emission and outbox
-    queueing are delegated to the same trigger-side BT used by
-    ``SvcAddObjectToCaseUseCase``.
+    queueing are delegated to a trigger-side BT.
     """
 
-    def __init__(
-        self,
-        dl: CaseOutboxPersistence,
-        request: AddReportToCaseTriggerRequest,
-        trigger_activity: "TriggerActivityPort | None" = None,
-    ) -> None:
-        self._dl = dl
-        self._request = request
-        self._trigger_activity = trigger_activity
-
-    def execute(self) -> dict[str, Any]:
-        actor_id = self._request.actor_id
-        dl = self._dl
-
-        actor = resolve_actor(actor_id, dl)
-        actor_id = actor.id_
-        resolve_case(self._request.case_id, dl)
-
-        raw = dl.read(self._request.report_id)
+    def _prepare(self) -> None:
+        request = cast(AddReportToCaseTriggerRequest, self._request)
+        actor = resolve_actor(request.actor_id, self._dl)
+        self._actor_id = actor.id_
+        self._case_id = resolve_case(request.case_id, self._dl).id_
+        self._object_id: str = request.report_id
+        raw = self._dl.read(self._object_id)
         if raw is None:
-            raise VultronNotFoundError(
-                "VulnerabilityReport", self._request.report_id
-            )
+            raise VultronNotFoundError("VulnerabilityReport", self._object_id)
         if getattr(raw, "type_", "") != "VulnerabilityReport":
             raise VultronValidationError(
-                f"'{self._request.report_id}' is not a VulnerabilityReport"
+                f"'{self._object_id}' is not a VulnerabilityReport"
             )
 
-        if self._trigger_activity is None:
-            raise RuntimeError(
-                "SvcAddReportToCaseUseCase requires a TriggerActivityPort"
+    def _build_tree(self) -> py_trees.behaviour.Behaviour:
+        def _build_activity() -> tuple[str, dict[str, Any]]:
+            return self._factory.add_object_to_case(
+                actor=self._actor_id,
+                object_id=self._object_id,
+                case_id=self._case_id,
             )
 
-        return _execute_add_object_trigger_bt(
-            dl=dl,
-            actor_id=actor_id,
-            case_id=self._request.case_id,
-            object_id=self._request.report_id,
-            trigger_activity=self._trigger_activity,
+        return add_object_trigger_bt(
+            result_out=self._result_out,
+            activity_builder=_build_activity,
+        )
+
+    def _extra_execute_kwargs(self) -> dict[str, Any]:
+        return {"case_id": self._case_id}
+
+    def _handle_result(self) -> None:
+        self._captured["activity"] = self._result_out.get("activity")
+        logger.info(
+            "Actor '%s' added object '%s' to case '%s'",
+            self._actor_id,
+            self._object_id,
+            self._case_id,
         )

--- a/vultron/core/use_cases/triggers/case/create.py
+++ b/vultron/core/use_cases/triggers/case/create.py
@@ -14,30 +14,22 @@
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import Any, cast
 
-from py_trees.common import Status
+import py_trees.behaviour
 
-from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.case.create_case_trigger_tree import (
     create_case_trigger_bt,
 )
-from vultron.core.ports.case_persistence import CaseOutboxPersistence
-from vultron.core.use_cases.triggers._helpers import (
-    resolve_actor,
-)
-from vultron.core.use_cases.triggers.requests import (
-    CreateCaseTriggerRequest,
-)
+from vultron.core.use_cases.triggers._base import SvcBTTriggerBase
+from vultron.core.use_cases.triggers._helpers import resolve_actor
+from vultron.core.use_cases.triggers.requests import CreateCaseTriggerRequest
 from vultron.errors import VultronNotFoundError, VultronValidationError
-
-if TYPE_CHECKING:
-    from vultron.core.ports.trigger_activity import TriggerActivityPort
 
 logger = logging.getLogger(__name__)
 
 
-class SvcCreateCaseUseCase:
+class SvcCreateCaseUseCase(SvcBTTriggerBase):
     """Create a new VulnerabilityCase and emit a CreateCaseActivity.
 
     The actor creates a local case and queues the activity for delivery to
@@ -48,22 +40,14 @@ class SvcCreateCaseUseCase:
     emission are delegated to a trigger-side BT.
     """
 
-    def __init__(
-        self,
-        dl: CaseOutboxPersistence,
-        request: CreateCaseTriggerRequest,
-        trigger_activity: "TriggerActivityPort | None" = None,
-    ) -> None:
-        self._dl = dl
-        self._request = request
-        self._trigger_activity = trigger_activity
+    def _prepare(self) -> None:
+        request = cast(CreateCaseTriggerRequest, self._request)
+        actor = resolve_actor(request.actor_id, self._dl)
+        self._actor_id = actor.id_
+        self._case_name: str = request.name
+        self._case_content: str = request.content
 
-    def execute(self) -> dict[str, Any]:
-        actor_id = self._request.actor_id
-        actor = resolve_actor(actor_id, self._dl)
-        actor_id = actor.id_
-        report_id = self._request.report_id
-
+        report_id = request.report_id
         if report_id is not None:
             raw = self._dl.read(report_id)
             if raw is None:
@@ -73,40 +57,28 @@ class SvcCreateCaseUseCase:
                     f"'{report_id}' is not a VulnerabilityReport"
                 )
             report_id = getattr(raw, "id_", None) or report_id
+        self._report_id: str | None = report_id
 
-        if self._trigger_activity is None:
-            raise RuntimeError(
-                "SvcCreateCaseUseCase requires a TriggerActivityPort"
+    def _build_tree(self) -> py_trees.behaviour.Behaviour:
+        def _build_activity(case_id: str) -> tuple[str, dict[str, Any]]:
+            return self._factory.create_case(
+                case_id=case_id, actor=self._actor_id
             )
 
-        factory = self._trigger_activity
-        result_data: dict[str, Any] = {}
-
-        def _build_activity(case_id: str) -> tuple[str, dict[str, Any]]:
-            return factory.create_case(case_id=case_id, actor=actor_id)
-
-        bridge = BTBridge(datalayer=self._dl, trigger_activity=factory)
-        tree = create_case_trigger_bt(
-            case_name=self._request.name,
-            case_content=self._request.content,
-            report_id=report_id,
-            result_out=result_data,
+        return create_case_trigger_bt(
+            case_name=self._case_name,
+            case_content=self._case_content,
+            report_id=self._report_id,
+            result_out=self._result_out,
             activity_builder=_build_activity,
         )
-        result = bridge.execute_with_setup(tree, actor_id=actor_id)
-        if result.status != Status.SUCCESS:
-            raise VultronValidationError(
-                f"CreateCase failed: {BTBridge.get_failure_reason(tree)}"
-            )
 
-        case_id = result_data.get("case_id")
-        activity = result_data.get("activity")
-
+    def _handle_result(self) -> None:
+        self._captured["activity"] = self._result_out.get("activity")
+        activity = self._captured.get("activity")
         logger.info(
             "Actor '%s' created case '%s' (CreateCaseActivity '%s')",
-            actor_id,
-            case_id,
+            self._actor_id,
+            self._result_out.get("case_id"),
             activity.get("id") if isinstance(activity, dict) else None,
         )
-
-        return {"activity": activity}

--- a/vultron/core/use_cases/triggers/case/defer.py
+++ b/vultron/core/use_cases/triggers/case/defer.py
@@ -14,92 +14,55 @@
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
 import logging
-from typing import TYPE_CHECKING
+from typing import cast
 
-from py_trees.common import Status
+import py_trees.behaviour
 
-from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.case.engage_defer_trigger_tree import (
     defer_case_trigger_bt,
 )
-from vultron.core.ports.case_persistence import CaseOutboxPersistence
+from vultron.core.use_cases.triggers._base import SvcBTTriggerBase
 from vultron.core.use_cases.triggers._helpers import (
     resolve_actor,
     resolve_case,
 )
-from vultron.core.use_cases.triggers.requests import (
-    DeferCaseTriggerRequest,
-)
-from vultron.errors import VultronValidationError
-
-if TYPE_CHECKING:
-    from vultron.core.ports.trigger_activity import TriggerActivityPort
+from vultron.core.use_cases.triggers.requests import DeferCaseTriggerRequest
 
 logger = logging.getLogger(__name__)
 
 
-class SvcDeferCaseUseCase:
+class SvcDeferCaseUseCase(SvcBTTriggerBase):
     """Defer a case (RM → DEFERRED).
 
     Updates the actor's RM state to DEFERRED and sends a Defer(Case)
     activity to the Case Actor via SenderSideBT (PCR-08-001).
     """
 
-    def __init__(
-        self,
-        dl: CaseOutboxPersistence,
-        request: DeferCaseTriggerRequest,
-        trigger_activity: "TriggerActivityPort | None" = None,
-    ) -> None:
-        self._dl = dl
-        self._request: DeferCaseTriggerRequest = request
-        self._trigger_activity = trigger_activity
+    def _prepare(self) -> None:
+        request = cast(DeferCaseTriggerRequest, self._request)
+        actor = resolve_actor(request.actor_id, self._dl)
+        self._actor_id = actor.id_
+        self._case_id = resolve_case(request.case_id, self._dl).id_
 
-    def execute(self) -> dict:
-        request = self._request
-        actor_id = request.actor_id
-        case_id = request.case_id
-        dl = self._dl
-
-        actor = resolve_actor(actor_id, dl)
-        actor_id = actor.id_
-
-        resolve_case(case_id, dl)
-
-        if self._trigger_activity is None:
-            raise RuntimeError(
-                "SvcDeferCaseUseCase requires a TriggerActivityPort"
-            )
-
-        factory = self._trigger_activity
-        captured: dict = {}
-
+    def _build_tree(self) -> py_trees.behaviour.Behaviour:
         def _build_activities(case_manager_id: str) -> list[str]:
-            activity_id, activity_dict = factory.defer_case(
-                case_id=case_id,
-                actor=actor_id,
+            activity_id, activity_dict = self._factory.defer_case(
+                case_id=self._case_id,
+                actor=self._actor_id,
                 to=[case_manager_id],
             )
-            captured["activity"] = activity_dict
+            self._captured["activity"] = activity_dict
             return [activity_id]
 
-        bridge = BTBridge(datalayer=dl, trigger_activity=factory)
-        tree = defer_case_trigger_bt(
-            case_id=case_id,
-            actor_id=actor_id,
+        return defer_case_trigger_bt(
+            case_id=self._case_id,
+            actor_id=self._actor_id,
             activity_builder=_build_activities,
         )
-        result = bridge.execute_with_setup(tree, actor_id=actor_id)
 
-        if result.status != Status.SUCCESS:
-            raise VultronValidationError(
-                f"DeferCase failed: {BTBridge.get_failure_reason(tree)}"
-            )
-
+    def _handle_result(self) -> None:
         logger.info(
             "Actor '%s' deferred case '%s' (RM → DEFERRED)",
-            actor_id,
-            case_id,
+            self._actor_id,
+            self._case_id,
         )
-
-        return {"activity": captured.get("activity")}

--- a/vultron/core/use_cases/triggers/case/engage.py
+++ b/vultron/core/use_cases/triggers/case/engage.py
@@ -14,92 +14,55 @@
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
 import logging
-from typing import TYPE_CHECKING
+from typing import cast
 
-from py_trees.common import Status
+import py_trees.behaviour
 
-from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.case.engage_defer_trigger_tree import (
     engage_case_trigger_bt,
 )
-from vultron.core.ports.case_persistence import CaseOutboxPersistence
+from vultron.core.use_cases.triggers._base import SvcBTTriggerBase
 from vultron.core.use_cases.triggers._helpers import (
     resolve_actor,
     resolve_case,
 )
-from vultron.core.use_cases.triggers.requests import (
-    EngageCaseTriggerRequest,
-)
-from vultron.errors import VultronValidationError
-
-if TYPE_CHECKING:
-    from vultron.core.ports.trigger_activity import TriggerActivityPort
+from vultron.core.use_cases.triggers.requests import EngageCaseTriggerRequest
 
 logger = logging.getLogger(__name__)
 
 
-class SvcEngageCaseUseCase:
+class SvcEngageCaseUseCase(SvcBTTriggerBase):
     """Engage a case (RM → ACCEPTED).
 
     Updates the actor's RM state to ACCEPTED and sends an Engage(Case)
     activity to the Case Actor via SenderSideBT (PCR-08-001).
     """
 
-    def __init__(
-        self,
-        dl: CaseOutboxPersistence,
-        request: EngageCaseTriggerRequest,
-        trigger_activity: "TriggerActivityPort | None" = None,
-    ) -> None:
-        self._dl = dl
-        self._request: EngageCaseTriggerRequest = request
-        self._trigger_activity = trigger_activity
+    def _prepare(self) -> None:
+        request = cast(EngageCaseTriggerRequest, self._request)
+        actor = resolve_actor(request.actor_id, self._dl)
+        self._actor_id = actor.id_
+        self._case_id = resolve_case(request.case_id, self._dl).id_
 
-    def execute(self) -> dict:
-        request = self._request
-        actor_id = request.actor_id
-        case_id = request.case_id
-        dl = self._dl
-
-        actor = resolve_actor(actor_id, dl)
-        actor_id = actor.id_
-
-        resolve_case(case_id, dl)
-
-        if self._trigger_activity is None:
-            raise RuntimeError(
-                "SvcEngageCaseUseCase requires a TriggerActivityPort"
-            )
-
-        factory = self._trigger_activity
-        captured: dict = {}
-
+    def _build_tree(self) -> py_trees.behaviour.Behaviour:
         def _build_activities(case_manager_id: str) -> list[str]:
-            activity_id, activity_dict = factory.engage_case(
-                case_id=case_id,
-                actor=actor_id,
+            activity_id, activity_dict = self._factory.engage_case(
+                case_id=self._case_id,
+                actor=self._actor_id,
                 to=[case_manager_id],
             )
-            captured["activity"] = activity_dict
+            self._captured["activity"] = activity_dict
             return [activity_id]
 
-        bridge = BTBridge(datalayer=dl, trigger_activity=factory)
-        tree = engage_case_trigger_bt(
-            case_id=case_id,
-            actor_id=actor_id,
+        return engage_case_trigger_bt(
+            case_id=self._case_id,
+            actor_id=self._actor_id,
             activity_builder=_build_activities,
         )
-        result = bridge.execute_with_setup(tree, actor_id=actor_id)
 
-        if result.status != Status.SUCCESS:
-            raise VultronValidationError(
-                f"EngageCase failed: {BTBridge.get_failure_reason(tree)}"
-            )
-
+    def _handle_result(self) -> None:
         logger.info(
             "Actor '%s' engaged case '%s' (RM → ACCEPTED)",
-            actor_id,
-            case_id,
+            self._actor_id,
+            self._case_id,
         )
-
-        return {"activity": captured.get("activity")}


### PR DESCRIPTION
- Closes #1005

## Summary

Applies the `SvcBTTriggerBase` ABC (from #1004) to all six case trigger use case classes under `vultron/core/use_cases/triggers/case/`, removing duplicated `__init__`, `BTBridge` construction, and failure guards from each.

## Changes

- `_base.py`: adds `_extra_execute_kwargs()` hook (`dict[str, Any]`, default `{}`) so subclasses can inject extra blackboard context; adds `typing.Any` import
- `case/engage.py`: extends `SvcBTTriggerBase`; activity captured via closure in `_build_tree()`
- `case/defer.py`: same pattern as engage
- `case/add_object.py`: removes standalone `_execute_add_object_trigger_bt()`; overrides `_extra_execute_kwargs()` to pass `case_id` to blackboard (required by `UpdateActorOutbox`)
- `case/add_report.py`: same BT path as `add_object`; imports `add_object_trigger_bt` directly; overrides `_extra_execute_kwargs()`
- `case/add_participant_status.py`: overrides `execute()` to return `{activity_id, status_id}`; preserves `_resolve_current_participant_state` for backward compatibility
- `case/create.py`: `_handle_result()` copies activity from `_result_out` to `_captured`; no `execute()` override needed

## Verification

- All 3422 unit tests pass (0 new — existing tests cover all paths unchanged)
- Black, flake8, mypy, pyright clean