### PR TITLE
docs: plan issue #1011 — received-side commit_log_entry_trigger BT-06-006 pitfall

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -512,6 +512,19 @@ Short entries are reproduced here; longer ones are referenced below.
   [notes/bt-integration.md](notes/bt-integration.md)
   § "Trigger/Received Parity" and `specs/behavior-tree-integration.yaml`
   BT-15-001, BT-15-002.
+- **Received-Side execute() Must Not Call commit_log_entry_trigger() Directly** —
+  A received-side `execute()` method that calls `commit_log_entry_trigger()`
+  (or any wrapper around it) directly is a BT-06-006 violation.
+  `Announce(CaseLedgerEntry)` fan-out is protocol-visible (SYNC-02-002) and
+  MUST be delegated to `CommitCaseLedgerEntryNode` inside a BT tree executed
+  via `BTBridge.execute_with_setup()`. The three historical violators were
+  `received/embargo.py`, `received/note.py`, and `received/status.py`. Do
+  **not** introduce a parallel BT node (e.g., a node that calls
+  `commit_log_entry_trigger()` directly in `update()`) as a workaround — all
+  hash-chained ledger commits MUST flow through `CommitCaseLedgerEntryNode`,
+  which itself composes `create_commit_log_entry_tree()` via
+  `BTBridge.execute_with_setup()`. See `specs/behavior-tree-integration.yaml`
+  BT-06-006, BT-15-001, and `specs/sync-ledger-replication.yaml` SYNC-02-002.
 - **BTBridge Global Blackboard Is Not Thread-Safe Under FastAPI
   BackgroundTasks** — FastAPI runs synchronous `BackgroundTask` callables
   via `anyio.to_thread.run_sync`, placing them on a thread pool. Two BT

--- a/plan/history/2606/learning/CONCERN-1011.md
+++ b/plan/history/2606/learning/CONCERN-1011.md
@@ -1,0 +1,44 @@
+---
+source: CONCERN-1011
+timestamp: '2026-06-16T19:26:10.332308+00:00'
+title: Fix BT-06-006 ledger-commit violations in received use cases
+type: learning
+---
+
+## Problem
+
+Case-ledger commits (persist + `Announce(CaseLedgerEntry)` fan-out) are not
+consistently routed through BT nodes.
+
+### 1. BT-06-006 violations: received use cases calling `commit_log_entry_trigger()` directly from `execute()`
+
+Three received-side use cases call `commit_log_entry_trigger()` procedurally,
+bypassing BT entirely:
+
+- `vultron/core/use_cases/received/embargo.py` — `_cascade_embargo_log_entry()` called from `execute()`
+- `vultron/core/use_cases/received/note.py::AddNoteToCaseReceivedUseCase._commit_log_entry()` — called from `execute()`
+- `vultron/core/use_cases/received/status.py::AddParticipantStatusReceivedUseCase._cascade_log_entry()` — called from `execute()`
+
+The `Announce(CaseLedgerEntry)` fan-out is protocol-visible behavior (SYNC-02-002,
+BT-15-001). It MUST live in a BT leaf node, not in procedural `execute()` code.
+
+### 2. Two BT node implementations for the same job
+
+- `CommitCaseLedgerEntryNode` (`behaviors/case/nodes/lifecycle.py`) — reads from blackboard,
+  sub-composes `create_commit_log_entry_tree()` via `BTBridge.execute_with_setup()`. Used in
+  case create / accept_invite / receive_report / prioritize trees.
+- `CommitLogCascadeNode` (`behaviors/embargo/nodes/cascade.py`) — takes `case_id/object_id/event_type`
+  as constructor params, calls `commit_log_entry_trigger()` directly inside `update()`. Used in
+  embargo teardown trees.
+
+### 3. Demo-era `commit_log_entry` trigger endpoint
+
+`TriggerActivityService.commit_log_entry()` in `triggers/service.py` is surfaced as
+`POST /{actor_id}/demo/commit-log-entry` in `demo_triggers.py`. Only caller is the demo
+router — no production or BT path calls it.
+
+## Resolution
+
+**Resolved**: 2026-06-16 — implementation tracked in #1013.
+
+Docs PR: [#1012](https://github.com/CERTCC/Vultron/pull/1012).


### PR DESCRIPTION
- Closes #1011

## Summary

Plans #1011 by adding an AGENTS.md pitfall capturing the rule that
received-side `execute()` methods must never call
`commit_log_entry_trigger()` directly and that all hash-chained ledger
commits must flow through `CommitCaseLedgerEntryNode` via
`BTBridge.execute_with_setup()`.

## Changes

- `AGENTS.md`: added pitfall **Received-Side execute() Must Not Call
  commit_log_entry_trigger() Directly** with references to BT-06-006,
  BT-15-001, and SYNC-02-002