### PR TITLE
feat(inbox): implement core BT inbox orchestration module (#997)

### DIFF
--- a/plan/history/2606/implementation/ISSUE-997.md
+++ b/plan/history/2606/implementation/ISSUE-997.md
@@ -1,0 +1,51 @@
+---
+source: ISSUE-997
+timestamp: '2026-06-16T21:21:55.145369+00:00'
+title: Core BT inbox orchestration module
+type: implementation
+---
+
+## Issue #997 — Implement core BT inbox orchestration module with process_payload -> InboxOutcome seam
+
+Implemented the `process_payload() -> InboxOutcome` seam specified in ADR-0020
+and `specs/inbox-orchestration.yaml` IO-01 through IO-04.
+
+### What was done
+
+- Added `vultron/core/behaviors/inbox/` package with:
+  - `models.py` — `InboxOutcome` Pydantic model + 3 `@runtime_checkable`
+    Protocol interfaces (`IngressPayloadAdapter`, `DispatchAdapter`,
+    `PendingCaseQueuePort`); no wire imports per ARCH-01-001
+  - `nodes/pipeline.py` — 6 BT leaf nodes enforcing fixed pipeline ordering:
+    `ParsePayloadNode → RehydrateActivityNode → ExtractSemanticsNode →
+    DeferCheckNode → DispatchNode → BuildOutcomeNode`
+  - `inbox_tree.py` — `create_inbox_bt()` factory
+  - `_process_payload.py` — `process_payload()` with extracted helpers;
+    acquires `_BT_GLOBAL_LOCK` (RLock shared with BTBridge) and saves/restores
+    blackboard state
+- Added `vultron/adapters/driving/fastapi/inbox_orchestration.py` with
+  `FastAPIIngressAdapter`, `StoredActivityIngressAdapter`,
+  `FastAPIDispatchAdapter`, `FastAPIQueuePort`, `run_inbox_pipeline()`
+- Updated `routers/actors/_routes.py` `post_actor_inbox` to call
+  `run_inbox_pipeline`; restored `_record_inbox_receipt` (dedup fix) and
+  threaded raw body dict through to adapter (nested object re-parsing fix)
+- Added 14 tests in `test/core/behaviors/inbox/test_process_payload.py`
+  asserting on `InboxOutcome` fields only (no internal BT node patching per
+  IO-04-002)
+
+### Key design notes
+
+- `ExtractSemanticsNode` extracts `context_id` from `event.object_.id_` for
+  bootstrap (`ANNOUNCE_VULNERABILITY_CASE`) activities where `context_` is not
+  set on the activity
+- `DeferCheckNode` skips defer for bootstrap and when `queue_port is None`
+- `DispatchNode` triggers `queue.replay()` after successful bootstrap dispatch
+- Pre-existing bug fixed: `_activity_context_id` used `getattr(activity,
+  "context", None)` (wrong attribute name); corrected to `context_` with
+  AS2 default namespace filtered out
+
+### Outcome
+
+All linters pass. 3492 unit tests pass, 34 skipped, 2 xfailed.
+
+PR: [#1019](https://github.com/CERTCC/Vultron/pull/1019)

--- a/test/core/behaviors/inbox/__init__.py
+++ b/test/core/behaviors/inbox/__init__.py
@@ -1,0 +1,1 @@
+#!/usr/bin/env python

--- a/test/core/behaviors/inbox/test_process_payload.py
+++ b/test/core/behaviors/inbox/test_process_payload.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python
+"""Tests for the core BT inbox orchestration module.
+
+Asserts on :class:`InboxOutcome` fields only — no patching of internal
+BT node helpers (IO-04-002).
+"""
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+from typing import Any
+
+import pytest
+
+from vultron.core.behaviors.inbox import (
+    InboxOutcome,
+    process_payload,
+)
+from vultron.core.models.events import VultronEvent
+from vultron.wire.as2.factories import (
+    add_note_to_case_activity,
+    announce_vulnerability_case_activity,
+    rm_create_report_activity,
+)
+from vultron.wire.as2.vocab.base.objects.object_types import as_Note
+from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_report import (
+    VulnerabilityReport,
+)
+
+SENDER_ID = "https://example.org/actors/sender"
+RECEIVER_ID = "https://example.org/actors/receiver"
+CASE_ID = "https://example.org/cases/case-io-test"
+UNKNOWN_CASE_ID = "https://example.org/cases/case-unknown"
+
+
+# ---------------------------------------------------------------------------
+# Stub implementations
+# ---------------------------------------------------------------------------
+
+
+class _StubIngressAdapter:
+    """IngressPayloadAdapter stub for unit tests."""
+
+    def __init__(
+        self,
+        activity: Any = None,
+        rehydrated: Any = None,
+        fail_parse: bool = False,
+    ) -> None:
+        self._activity = activity
+        self._rehydrated = rehydrated or activity
+        self._fail_parse = fail_parse
+
+    def parse(self, payload: Any) -> Any:
+        if self._fail_parse:
+            return None
+        return self._activity
+
+    def rehydrate(self, activity: Any) -> Any:
+        return self._rehydrated or activity
+
+
+class _StubDispatchAdapter:
+    """DispatchAdapter stub that records dispatched events."""
+
+    def __init__(self, should_fail: bool = False) -> None:
+        self.dispatched: list[VultronEvent] = []
+        self._should_fail = should_fail
+
+    def dispatch(self, event: VultronEvent) -> None:
+        if self._should_fail:
+            raise RuntimeError("Dispatch error (stub)")
+        self.dispatched.append(event)
+
+
+class _StubQueuePort:
+    """PendingCaseQueuePort stub for testing defer/replay logic."""
+
+    def __init__(
+        self,
+        case_known: bool = True,
+        queue_expired: bool = False,
+    ) -> None:
+        self._case_known = case_known
+        self._queue_expired = queue_expired
+        self.queued: list[tuple[str, str, str | None]] = []
+        self.replayed: list[str] = []
+
+    def is_case_known(self, case_id: str) -> bool:
+        return self._case_known
+
+    def queue(
+        self,
+        activity_id: str,
+        case_id: str,
+        case_actor_id: str | None = None,
+    ) -> None:
+        self.queued.append((activity_id, case_id, case_actor_id))
+
+    def check_and_expire(self, case_id: str) -> bool:
+        return self._queue_expired
+
+    def replay(self, case_id: str) -> None:
+        self.replayed.append(case_id)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def report_activity():
+    report = VulnerabilityReport(
+        id_="https://example.org/reports/r-io-1",
+        content="test report",
+    )
+    return rm_create_report_activity(report, actor=SENDER_ID, to=[RECEIVER_ID])
+
+
+@pytest.fixture()
+def case_activity():
+    case = VulnerabilityCase(
+        id_=CASE_ID,
+        name="CASE-IO",
+    )
+    return announce_vulnerability_case_activity(
+        case, actor=SENDER_ID, to=[RECEIVER_ID]
+    )
+
+
+@pytest.fixture()
+def note_activity_unknown_case():
+    note = as_Note(id_="https://example.org/notes/n-io-1", content="note")
+    return add_note_to_case_activity(
+        note,
+        target=UNKNOWN_CASE_ID,
+        context=UNKNOWN_CASE_ID,
+        actor=SENDER_ID,
+        to=[RECEIVER_ID],
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-2: InboxOutcome model
+# ---------------------------------------------------------------------------
+
+
+class TestInboxOutcomeModel:
+    def test_processed_status(self):
+        o = InboxOutcome(status="processed")
+        assert o.status == "processed"
+        assert o.context_id is None
+        assert o.failure_reason is None
+
+    def test_deferred_status_with_fields(self):
+        o = InboxOutcome(
+            status="deferred",
+            context_id=CASE_ID,
+            failure_reason="case not yet known",
+        )
+        assert o.status == "deferred"
+        assert o.context_id == CASE_ID
+        assert o.failure_reason == "case not yet known"
+
+    def test_rejected_status_with_reason(self):
+        o = InboxOutcome(status="rejected", failure_reason="parse failed")
+        assert o.status == "rejected"
+        assert o.failure_reason == "parse failed"
+
+
+# ---------------------------------------------------------------------------
+# AC-6: rejected InboxOutcome for invalid payloads — no exception raised
+# ---------------------------------------------------------------------------
+
+
+class TestProcessPayloadRejectsInvalidInput:
+    def test_none_parse_result_returns_rejected(self, report_activity):
+        """When IngressAdapter.parse returns None, outcome is rejected."""
+        ingress = _StubIngressAdapter(activity=None, fail_parse=True)
+        dispatch = _StubDispatchAdapter()
+
+        outcome = process_payload({}, ingress, dispatch)
+
+        assert isinstance(outcome, InboxOutcome)
+        assert outcome.status == "rejected"
+        assert outcome.failure_reason is not None
+
+    def test_dispatch_failure_returns_rejected(self, report_activity):
+        """When dispatch raises, outcome is rejected; no exception propagates."""
+        ingress = _StubIngressAdapter(activity=report_activity)
+        dispatch = _StubDispatchAdapter(should_fail=True)
+
+        outcome = process_payload({}, ingress, dispatch)
+
+        assert isinstance(outcome, InboxOutcome)
+        assert outcome.status == "rejected"
+        assert outcome.failure_reason is not None
+
+
+# ---------------------------------------------------------------------------
+# AC-3 / AC-5: happy path returns processed
+# ---------------------------------------------------------------------------
+
+
+class TestProcessPayloadHappyPath:
+    def test_processed_for_report_activity(self, report_activity):
+        """Non-case-scoped activity is dispatched and returns processed."""
+        ingress = _StubIngressAdapter(activity=report_activity)
+        dispatch = _StubDispatchAdapter()
+
+        outcome = process_payload({}, ingress, dispatch)
+
+        assert outcome.status == "processed"
+        assert outcome.failure_reason is None
+        assert len(dispatch.dispatched) == 1
+
+    def test_context_id_none_for_non_case_scoped(self, report_activity):
+        ingress = _StubIngressAdapter(activity=report_activity)
+        dispatch = _StubDispatchAdapter()
+
+        outcome = process_payload({}, ingress, dispatch)
+
+        assert outcome.status == "processed"
+        # Reports are not case-scoped
+        assert outcome.context_id is None
+
+
+# ---------------------------------------------------------------------------
+# AC-7: deferred outcome when case context unknown
+# ---------------------------------------------------------------------------
+
+
+class TestProcessPayloadDeferral:
+    def test_deferred_for_unknown_case(self, note_activity_unknown_case):
+        """Activity for unknown case returns deferred outcome."""
+        ingress = _StubIngressAdapter(activity=note_activity_unknown_case)
+        dispatch = _StubDispatchAdapter()
+        queue = _StubQueuePort(case_known=False)
+
+        outcome = process_payload({}, ingress, dispatch, queue)
+
+        assert outcome.status == "deferred"
+        assert outcome.failure_reason is not None
+        assert len(queue.queued) == 1
+        assert len(dispatch.dispatched) == 0
+
+    def test_deferred_carries_context_id(self, note_activity_unknown_case):
+        ingress = _StubIngressAdapter(activity=note_activity_unknown_case)
+        dispatch = _StubDispatchAdapter()
+        queue = _StubQueuePort(case_known=False)
+
+        outcome = process_payload({}, ingress, dispatch, queue)
+
+        assert outcome.status == "deferred"
+        assert outcome.context_id == UNKNOWN_CASE_ID
+
+    def test_rejected_when_queue_expired(self, note_activity_unknown_case):
+        """Expired pending queue returns rejected, not deferred."""
+        ingress = _StubIngressAdapter(activity=note_activity_unknown_case)
+        dispatch = _StubDispatchAdapter()
+        queue = _StubQueuePort(case_known=False, queue_expired=True)
+
+        outcome = process_payload({}, ingress, dispatch, queue)
+
+        assert outcome.status == "rejected"
+        assert outcome.failure_reason is not None
+        assert len(queue.queued) == 0
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap replay trigger
+# ---------------------------------------------------------------------------
+
+
+class TestProcessPayloadBootstrap:
+    def test_bootstrap_triggers_replay(self, case_activity):
+        """ANNOUNCE_VULNERABILITY_CASE dispatch triggers queue.replay."""
+        ingress = _StubIngressAdapter(activity=case_activity)
+        dispatch = _StubDispatchAdapter()
+        queue = _StubQueuePort(case_known=True)
+
+        outcome = process_payload({}, ingress, dispatch, queue)
+
+        assert outcome.status == "processed"
+        assert CASE_ID in queue.replayed
+
+    def test_bootstrap_skips_defer_check(self, case_activity):
+        """Bootstrap activity is never deferred even when case unknown."""
+        ingress = _StubIngressAdapter(activity=case_activity)
+        dispatch = _StubDispatchAdapter()
+        # case_known=False would defer non-bootstrap, but bootstrap skips
+        queue = _StubQueuePort(case_known=False)
+
+        outcome = process_payload({}, ingress, dispatch, queue)
+
+        assert outcome.status == "processed"
+        assert len(queue.queued) == 0
+
+
+# ---------------------------------------------------------------------------
+# No queue_port — skip defer check, allow dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestProcessPayloadNoQueuePort:
+    def test_no_queue_port_skips_defer(self, note_activity_unknown_case):
+        """Without a queue port, activities proceed to dispatch."""
+        ingress = _StubIngressAdapter(activity=note_activity_unknown_case)
+        dispatch = _StubDispatchAdapter()
+
+        outcome = process_payload({}, ingress, dispatch, queue_port=None)
+
+        assert outcome.status == "processed"
+        assert len(dispatch.dispatched) == 1
+
+
+# ---------------------------------------------------------------------------
+# Thread safety: concurrent calls do not corrupt each other's outcomes
+# ---------------------------------------------------------------------------
+
+
+class TestProcessPayloadThreadSafety:
+    def test_concurrent_calls_independent_outcomes(self, report_activity):
+        """Multiple calls from different threads get independent outcomes."""
+        import threading
+
+        results: list[InboxOutcome] = []
+        errors: list[Exception] = []
+
+        def _run() -> None:
+            try:
+                ingress = _StubIngressAdapter(activity=report_activity)
+                dispatch = _StubDispatchAdapter()
+                outcome = process_payload({}, ingress, dispatch)
+                results.append(outcome)
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=_run) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        assert all(o.status == "processed" for o in results)
+        assert len(results) == 4

--- a/vultron/adapters/driving/fastapi/inbox_orchestration.py
+++ b/vultron/adapters/driving/fastapi/inbox_orchestration.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python
+"""FastAPI adapter implementations for inbox orchestration.
+
+Provides concrete adapter classes that implement the
+:mod:`vultron.core.behaviors.inbox` protocols using the FastAPI
+DataLayer and dispatcher infrastructure:
+
+- :class:`FastAPIIngressAdapter` — parse (wire) + rehydrate (DataLayer)
+- :class:`StoredActivityIngressAdapter` — rehydrate only (stored by ID)
+- :class:`FastAPIDispatchAdapter` — wraps the dispatcher port
+- :class:`FastAPIQueuePort` — wraps pending-case queue helpers
+
+These adapters are constructed in the inbox background task and passed to
+:func:`~vultron.core.behaviors.inbox.process_payload` (IO-03-001,
+IO-03-003).
+"""
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+import logging
+from typing import Any, cast
+
+from vultron.adapters.driving.fastapi.inbox_handler import dispatch
+from vultron.adapters.driving.fastapi.inbox_pending_queue import (
+    _expire_pending_case_activities,
+    _queue_pending_case_activity,
+    _replay_pending_case_activities,
+)
+from vultron.adapters.driving.fastapi.routers.actors._inbox import (
+    _store_inbox_activity,
+    _store_nested_inbox_object,
+)
+from vultron.core.models.events import VultronEvent
+from vultron.core.models.protocols import is_case_model
+from vultron.core.ports.datalayer import ActorScopedDataLayer, DataLayer
+from vultron.core.ports.dispatcher import ActivityDispatcher
+from vultron.wire.as2.errors import VultronParseError
+from vultron.wire.as2.parser import parse_activity as _parse_activity
+from vultron.wire.as2.rehydration import rehydrate
+from vultron.wire.as2.vocab.base.objects.activities.base import as_Activity
+
+logger = logging.getLogger(__name__)
+
+
+class FastAPIIngressAdapter:
+    """Ingress adapter for the FastAPI driving adapter.
+
+    ``parse`` parses a raw JSON request-body dict into a typed
+    ``as_Activity`` and stores the activity (and any inline nested
+    object) in the shared DataLayer so later rehydration can resolve
+    references.  ``rehydrate`` resolves the stored activity's nested
+    references via the DataLayer.
+
+    Args:
+        dl: Shared DataLayer (for storing activities and rehydration).
+        body: Raw request-body dict, used to re-parse inline nested
+            objects with their specific vocabulary classes.
+    """
+
+    def __init__(
+        self, dl: DataLayer, body: dict[str, Any] | None = None
+    ) -> None:
+        self._dl = dl
+        self._body = body or {}
+
+    def parse(
+        self,
+        payload: dict[str, Any] | bytes | str | Any,
+    ) -> as_Activity | None:
+        """Parse *payload* as an AS2 activity and store to DataLayer.
+
+        Returns ``None`` on parse failure; never raises.
+        """
+        if isinstance(payload, as_Activity):
+            # Already parsed (e.g., passed directly from the router DI).
+            _store_nested_inbox_object(self._dl, payload, self._body)
+            _store_inbox_activity(self._dl, payload)
+            return payload
+
+        if not isinstance(payload, dict):
+            logger.warning(
+                "FastAPIIngressAdapter.parse: unsupported payload type %s",
+                type(payload).__name__,
+            )
+            return None
+
+        try:
+            activity = _parse_activity(payload)
+        except VultronParseError as exc:
+            logger.warning(
+                "FastAPIIngressAdapter.parse: parse failed — %s", exc
+            )
+            return None
+
+        _store_nested_inbox_object(self._dl, activity, payload)
+        _store_inbox_activity(self._dl, activity)
+        return activity
+
+    def rehydrate(self, activity: as_Activity) -> as_Activity:
+        """Resolve nested object references via the DataLayer."""
+        result = rehydrate(activity.id_, dl=self._dl)
+        if isinstance(result, as_Activity):
+            return result
+        return activity
+
+
+class StoredActivityIngressAdapter:
+    """Ingress adapter for replay of already-stored activities.
+
+    Used when the payload is an activity-ID string (e.g., when
+    replaying activities that were deferred pending case bootstrap).
+
+    ``parse`` reads and rehydrates the stored activity by ID.
+    ``rehydrate`` is a no-op (parse already returns the rehydrated form).
+
+    Args:
+        dl: Shared DataLayer for activity lookup and rehydration.
+    """
+
+    def __init__(self, dl: DataLayer) -> None:
+        self._dl = dl
+
+    def parse(
+        self,
+        payload: dict[str, Any] | bytes | str | Any,
+    ) -> as_Activity | None:
+        """Read and rehydrate a stored activity by ID.
+
+        Returns ``None`` when the ID does not resolve to an Activity.
+        """
+        if isinstance(payload, as_Activity):
+            return payload
+
+        activity_id = str(payload) if payload is not None else None
+        if not activity_id:
+            logger.warning("StoredActivityIngressAdapter.parse: empty payload")
+            return None
+
+        result = rehydrate(activity_id, dl=self._dl)
+        if isinstance(result, as_Activity):
+            return result
+
+        logger.warning(
+            "StoredActivityIngressAdapter.parse: rehydrate('%s') returned %s",
+            activity_id,
+            type(result).__name__,
+        )
+        return None
+
+    def rehydrate(self, activity: as_Activity) -> as_Activity:
+        """No-op: parse already returns the rehydrated activity."""
+        return activity
+
+
+class FastAPIDispatchAdapter:
+    """Dispatch adapter wrapping the inbox dispatcher port.
+
+    Args:
+        dl: Shared DataLayer for use-case dispatch.
+        actor_id: Canonical URI of the receiving actor; injected into
+            the domain event before dispatch.
+        dispatcher: Optional per-app dispatcher.  Falls back to the
+            module-level dispatcher when ``None``.
+    """
+
+    def __init__(
+        self,
+        dl: DataLayer,
+        actor_id: str,
+        dispatcher: ActivityDispatcher | None = None,
+    ) -> None:
+        self._dl = dl
+        self._actor_id = actor_id
+        self._dispatcher = dispatcher
+
+    def dispatch(self, event: VultronEvent) -> None:
+        """Inject receiving actor ID and dispatch the event."""
+        scoped_event = event.model_copy(
+            update={"receiving_actor_id": self._actor_id}
+        )
+        dispatch(
+            event=scoped_event,
+            dl=self._dl,
+            dispatcher=self._dispatcher,
+        )
+
+
+class FastAPIQueuePort:
+    """Pending-case queue port wrapping the adapter-layer helpers.
+
+    Args:
+        dl: Shared DataLayer (for case reads and Question persistence).
+        actor_dl: Actor-scoped DataLayer for queue management.
+        actor_id: Canonical URI of the receiving actor; used when
+            building a replay Question on expiry.
+    """
+
+    def __init__(
+        self,
+        dl: DataLayer,
+        actor_dl: ActorScopedDataLayer,
+        actor_id: str,
+    ) -> None:
+        self._dl = dl
+        self._actor_dl = cast(ActorScopedDataLayer, actor_dl)
+        self._actor_id = actor_id
+
+    def is_case_known(self, case_id: str) -> bool:
+        """Return ``True`` if the case replica is locally available."""
+        return is_case_model(self._dl.read(case_id))
+
+    def queue(
+        self,
+        activity_id: str,
+        case_id: str,
+        case_actor_id: str | None = None,
+    ) -> None:
+        """Persist *activity_id* in the deferred queue for *case_id*."""
+        _queue_pending_case_activity(
+            queue_dl=self._actor_dl,
+            case_id=case_id,
+            activity_id=activity_id,
+            case_actor_id=case_actor_id,
+        )
+
+    def check_and_expire(self, case_id: str) -> bool:
+        """Check expiry; drop queue and return ``True`` when expired."""
+        return _expire_pending_case_activities(
+            case_id=case_id,
+            actor_id=self._actor_id,
+            dl=self._dl,
+            queue_dl=self._actor_dl,
+        )
+
+    def replay(self, case_id: str) -> None:
+        """Move deferred activities for *case_id* back to the live inbox."""
+        _replay_pending_case_activities(
+            case_id=case_id,
+            dl=self._dl,
+            queue_dl=self._actor_dl,
+            actor_id=self._actor_id,
+        )
+
+
+async def run_inbox_pipeline(
+    payload: dict[str, Any] | bytes | str | Any,
+    body: dict[str, Any] | None,
+    dl: DataLayer,
+    actor_dl: ActorScopedDataLayer,
+    actor_id: str,
+    dispatcher: ActivityDispatcher | None,
+    emitter: Any,
+) -> None:
+    """Adapter-layer background task: construct adapters and run pipeline.
+
+    Calls :func:`~vultron.core.behaviors.inbox.process_payload` for the
+    immediate payload, then processes any replayed activities that were
+    pushed back to the inbox queue (e.g., after bootstrap dispatch), and
+    finally drains the outbox.
+
+    This function is the background task scheduled by ``post_actor_inbox``.
+    It is the ONLY place that constructs the adapter instances, satisfying
+    IO-03-003.
+
+    Args:
+        payload: Raw inbox payload (JSON body dict or as_Activity).
+        body: Raw JSON request body dict, forwarded from the endpoint for
+            nested-object re-parsing (preserves domain-specific fields).
+        dl: Shared DataLayer.
+        actor_dl: Actor-scoped DataLayer for inbox/outbox queues.
+        actor_id: Canonical URI of the receiving actor.
+        dispatcher: Optional per-app dispatcher.
+        emitter: Optional per-app ActivityEmitter.
+    """
+    from vultron.adapters.driving.fastapi.outbox_handler import outbox_handler
+    from vultron.core.behaviors.inbox import process_payload
+
+    ingress = FastAPIIngressAdapter(dl=dl, body=body)
+    dispatch_adp = FastAPIDispatchAdapter(
+        dl=dl, actor_id=actor_id, dispatcher=dispatcher
+    )
+    queue = FastAPIQueuePort(
+        dl=dl,
+        actor_dl=cast(ActorScopedDataLayer, actor_dl),
+        actor_id=actor_id,
+    )
+
+    outcome = process_payload(payload, ingress, dispatch_adp, queue)
+    logger.info(
+        "run_inbox_pipeline: status=%s context_id=%s",
+        outcome.status,
+        outcome.context_id,
+    )
+
+    # Process any replayed activities (pushed back to the queue by
+    # DeferCheckNode/DispatchNode replay after bootstrap).
+    stored_ingress = StoredActivityIngressAdapter(dl=dl)
+    while actor_dl.inbox_list():
+        item_id = actor_dl.inbox_pop()
+        if item_id is None:
+            break
+        replay_outcome = process_payload(
+            item_id, stored_ingress, dispatch_adp, queue
+        )
+        logger.info(
+            "run_inbox_pipeline: replayed status=%s context_id=%s",
+            replay_outcome.status,
+            replay_outcome.context_id,
+        )
+
+    await outbox_handler(actor_id, actor_dl, shared_dl=dl, emitter=emitter)

--- a/vultron/adapters/driving/fastapi/routers/actors/_routes.py
+++ b/vultron/adapters/driving/fastapi/routers/actors/_routes.py
@@ -37,7 +37,9 @@ from pydantic import BaseModel, Field
 
 from vultron.adapters.driven.db_record import object_to_record
 from vultron.adapters.driven.datalayer import get_shared_dl
-from vultron.adapters.driving.fastapi.inbox_handler import inbox_handler
+from vultron.adapters.driving.fastapi.inbox_orchestration import (
+    run_inbox_pipeline,
+)
 from vultron.adapters.driving.fastapi.outbox_handler import outbox_handler
 from vultron.adapters.utils import make_id, strip_id_prefix
 from vultron.core.models.actor import (
@@ -62,8 +64,6 @@ from vultron.adapters.driving.fastapi.routers.actors._inbox import (
     _activity_already_received,
     _get_body,
     _record_inbox_receipt,
-    _store_inbox_activity,
-    _store_nested_inbox_object,
     parse_activity,
 )
 from vultron.adapters.driving.fastapi.routers.actors._lookup import (
@@ -330,20 +330,24 @@ def post_actor_inbox(
     request: Request,
     background_tasks: BackgroundTasks,
     activity: as_Activity = Depends(parse_activity),
-    dl: DataLayer = Depends(get_shared_dl),
     body: dict[str, Any] = Depends(_get_body),
+    dl: DataLayer = Depends(get_shared_dl),
 ) -> None:
     """Adds an item to the Actor's Inbox.
     The 202 Accepted status code indicates that the request has been accepted for
     processing, but the processing has not been completed. This is appropriate here
     because the inbox processing is handled asynchronously in the background.
+
+    Policy logic lives in ``process_payload`` (core BT module); this
+    endpoint is thin glue that supplies adapter implementations and
+    schedules the background task (IO-03-003).
+
     Args:
         actor_id: The ID of the Actor whose Inbox to add the item to.
-        request: The FastAPI Request (used to resolve the per-app emitter).
-        activity: The Activity item to add to the Inbox.
+        request: The FastAPI Request (used to resolve the per-app emitter/dispatcher).
+        activity: The Activity item (parsed by the ``parse_activity`` dependency).
+        body: Raw JSON request body dict (needed for nested object re-parsing).
         background_tasks: FastAPI BackgroundTasks instance to schedule background tasks.
-        body: Raw JSON request body dict, used to re-parse inline nested
-            objects with their specific vocabulary classes.
     Returns:
         None
     Raises:
@@ -360,20 +364,23 @@ def post_actor_inbox(
         )
         return None
 
-    _store_nested_inbox_object(dl, activity, body)
-    _store_inbox_activity(dl, activity)
-
-    logger.debug(
-        f"Posting activity to actor {canonical_actor_id} inbox: {activity}"
-    )
+    # Record receipt synchronously so the dedup guard on the next delivery
+    # of the same activity_id sees the updated actor inbox record.
     _record_inbox_receipt(dl, actor, activity.id_, canonical_actor_id)
 
-    actor_dl = dl.clone_for_actor(canonical_actor_id)
-    actor_dl.inbox_append(activity.id_)
     emitter = getattr(request.app.state, "emitter", None)
     dispatcher = getattr(request.app.state, "dispatcher", None)
+
+    actor_dl = dl.clone_for_actor(canonical_actor_id)
     background_tasks.add_task(
-        inbox_handler, canonical_actor_id, dl, actor_dl, emitter, dispatcher
+        run_inbox_pipeline,
+        activity,
+        body,
+        dl,
+        actor_dl,
+        canonical_actor_id,
+        dispatcher,
+        emitter,
     )
     return None
 

--- a/vultron/core/behaviors/inbox/__init__.py
+++ b/vultron/core/behaviors/inbox/__init__.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+"""Core BT inbox orchestration package.
+
+Public API (IO-02-003: only process_payload and the model/protocol
+types are exported; intermediate BT nodes are not public API):
+
+    process_payload(payload, ingress_adapter, dispatch_adapter,
+                    queue_port=None) -> InboxOutcome
+
+    InboxOutcome          — typed pipeline result
+    IngressPayloadAdapter — Protocol: raw input → as_Activity
+    DispatchAdapter       — Protocol: VultronEvent → dispatch
+    PendingCaseQueuePort  — Protocol: pending-case queue operations
+"""
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+from vultron.core.behaviors.inbox._process_payload import (  # noqa: F401
+    process_payload,
+)
+from vultron.core.behaviors.inbox.models import (  # noqa: F401
+    DispatchAdapter,
+    InboxOutcome,
+    IngressPayloadAdapter,
+    PendingCaseQueuePort,
+)

--- a/vultron/core/behaviors/inbox/_process_payload.py
+++ b/vultron/core/behaviors/inbox/_process_payload.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python
+"""Core BT inbox orchestration module.
+
+Provides :func:`process_payload` as the sole caller-facing entry point
+for inbox processing.  Callers supply adapter implementations for
+ingress parsing, dispatch, and pending-queue management; the BT Sequence
+enforces fixed pipeline ordering and returns a typed
+:class:`InboxOutcome`.
+
+Per specs/inbox-orchestration.yaml IO-02-001 through IO-02-003.
+"""
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import py_trees
+from py_trees.common import Status
+
+from vultron.core.behaviors.inbox.inbox_tree import create_inbox_bt
+from vultron.core.behaviors.inbox.models import (
+    DispatchAdapter,
+    InboxOutcome,
+    IngressPayloadAdapter,
+    PendingCaseQueuePort,
+)
+from vultron.core.behaviors.inbox.nodes import (
+    ALL_INBOX_KEYS,
+    KEY_CONTEXT_ID,
+    KEY_DISPATCH,
+    KEY_FAILURE_REASON,
+    KEY_INGRESS,
+    KEY_OUTCOME_STATUS,
+    KEY_PAYLOAD,
+    KEY_QUEUE,
+)
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+# Maximum BT ticks before giving up (safety limit — all pipeline nodes
+# return SUCCESS/FAILURE synchronously, so one tick should suffice).
+_MAX_TICKS = 10
+
+
+def _save_inbox_keys(
+    storage: dict[str, Any],
+) -> dict[str, tuple[bool, Any]]:
+    """Snapshot the current values of all inbox blackboard keys."""
+    saved: dict[str, tuple[bool, Any]] = {}
+    for key in ALL_INBOX_KEYS:
+        for variant in (key, f"/{key}"):
+            saved[variant] = (variant in storage, storage.get(variant))
+    return saved
+
+
+def _write_inbox_inputs(
+    payload: Any,
+    ingress_adapter: IngressPayloadAdapter,
+    dispatch_adapter: DispatchAdapter,
+    queue_port: PendingCaseQueuePort | None,
+) -> None:
+    """Write pipeline inputs to the BT blackboard."""
+    setup_bb = py_trees.blackboard.Client(name="InboxOrchestrator-setup")
+    setup_bb.register_key(KEY_PAYLOAD, access=py_trees.common.Access.WRITE)
+    setup_bb.register_key(KEY_INGRESS, access=py_trees.common.Access.WRITE)
+    setup_bb.register_key(KEY_DISPATCH, access=py_trees.common.Access.WRITE)
+    setup_bb.register_key(KEY_QUEUE, access=py_trees.common.Access.WRITE)
+    setup_bb.inbox_payload = payload
+    setup_bb.inbox_ingress = ingress_adapter
+    setup_bb.inbox_dispatch = dispatch_adapter
+    setup_bb.inbox_queue = queue_port
+
+
+def _run_bt_pipeline() -> Status:
+    """Instantiate the inbox BT, tick to completion, and return the status."""
+    tree = create_inbox_bt()
+    bt = py_trees.trees.BehaviourTree(root=tree)
+    bt.setup()
+
+    tick_count = 0
+    final_status = Status.INVALID
+    try:
+        while tick_count < _MAX_TICKS:
+            tick_count += 1
+            bt.tick()
+            final_status = bt.root.status
+            if final_status in (Status.SUCCESS, Status.FAILURE):
+                break
+    except Exception as exc:
+        logger.exception("process_payload: BT tick raised exception: %s", exc)
+        final_status = Status.FAILURE
+    finally:
+        bt.shutdown()
+
+    logger.debug(
+        "process_payload: BT completed status=%s ticks=%d",
+        final_status,
+        tick_count,
+    )
+    return final_status
+
+
+def _read_inbox_outcome() -> InboxOutcome:
+    """Read the outcome fields written by BT nodes and build an InboxOutcome."""
+    result_bb = py_trees.blackboard.Client(name="InboxOrchestrator-result")
+    result_bb.register_key(
+        KEY_OUTCOME_STATUS, access=py_trees.common.Access.READ
+    )
+    result_bb.register_key(KEY_CONTEXT_ID, access=py_trees.common.Access.READ)
+    result_bb.register_key(
+        KEY_FAILURE_REASON, access=py_trees.common.Access.READ
+    )
+
+    try:
+        status_str: str = result_bb.inbox_outcome_status
+    except KeyError:
+        status_str = "rejected"
+
+    try:
+        context_id: str | None = result_bb.inbox_context_id
+    except KeyError:
+        context_id = None
+
+    try:
+        failure_reason: str | None = result_bb.inbox_failure_reason
+    except KeyError:
+        failure_reason = None
+
+    return InboxOutcome(
+        status=status_str,  # type: ignore[arg-type]
+        context_id=context_id,
+        failure_reason=failure_reason,
+    )
+
+
+def _restore_inbox_keys(
+    storage: dict[str, Any],
+    saved: dict[str, tuple[bool, Any]],
+) -> None:
+    """Restore inbox blackboard keys to their pre-execution state."""
+    for key, (had_value, value) in saved.items():
+        if had_value:
+            storage[key] = value
+        else:
+            storage.pop(key, None)
+
+
+def process_payload(
+    payload: dict[str, Any] | bytes | str | Any,
+    ingress_adapter: IngressPayloadAdapter,
+    dispatch_adapter: DispatchAdapter,
+    queue_port: PendingCaseQueuePort | None = None,
+) -> InboxOutcome:
+    """Process one inbox payload through the BT pipeline.
+
+    Always returns an :class:`InboxOutcome`; never raises for
+    protocol-invalid payloads (IO-04-001).
+
+    Args:
+        payload: Raw inbox payload.  For the FastAPI driving adapter this
+            is the JSON request body dict (or an already-parsed
+            ``as_Activity``).  For replay paths it is a stored
+            activity-ID string.
+        ingress_adapter: Translates *payload* into a rehydrated
+            ``as_Activity``.  Owns parse and rehydrate (IO-03-001).
+        dispatch_adapter: Executes the use-case path for a
+            ``VultronEvent`` (IO-03-001).
+        queue_port: Optional pending-case queue port.  When provided,
+            activities whose case context is not yet locally available
+            are queued for later replay instead of being rejected
+            (IO-03-002).
+
+    Returns:
+        :class:`InboxOutcome` with ``status`` set to one of
+        ``"processed"``, ``"deferred"``, or ``"rejected"``.
+    """
+    # Import the shared BT global lock to serialise BT blackboard access
+    # across concurrent FastAPI BackgroundTasks.  The RLock supports
+    # re-entrant acquisition so replay paths calling process_payload
+    # recursively do not deadlock.
+    from vultron.core.behaviors.bridge import _BT_GLOBAL_LOCK
+
+    with _BT_GLOBAL_LOCK:
+        storage = py_trees.blackboard.Blackboard.storage
+        saved = _save_inbox_keys(storage)
+
+        try:
+            _write_inbox_inputs(
+                payload, ingress_adapter, dispatch_adapter, queue_port
+            )
+            _run_bt_pipeline()
+            outcome = _read_inbox_outcome()
+        finally:
+            _restore_inbox_keys(storage, saved)
+
+    logger.info(
+        "process_payload: outcome status=%s context_id=%s",
+        outcome.status,
+        outcome.context_id,
+    )
+    return outcome

--- a/vultron/core/behaviors/inbox/inbox_tree.py
+++ b/vultron/core/behaviors/inbox/inbox_tree.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+"""Behavior tree factory for the inbox orchestration pipeline.
+
+Creates the BT Sequence that enforces fixed pipeline ordering:
+parse → rehydrate → extract → defer-check → dispatch → outcome.
+
+Per specs/inbox-orchestration.yaml IO-02-002.
+"""
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+import py_trees
+
+from vultron.core.behaviors.inbox.nodes import (
+    BuildOutcomeNode,
+    DeferCheckNode,
+    DispatchNode,
+    ExtractSemanticsNode,
+    ParsePayloadNode,
+    RehydrateActivityNode,
+)
+
+
+def create_inbox_bt() -> py_trees.behaviour.Behaviour:
+    """Return a fresh BT Sequence for one inbox pipeline execution.
+
+    The Sequence enforces that each step succeeds before the next runs.
+    On any failure the remaining steps are skipped and the failure step
+    records the outcome status on the blackboard for
+    :func:`~vultron.core.behaviors.inbox.process_payload` to read.
+
+    Tree structure (IO-02-002):
+
+    .. code-block:: text
+
+        Sequence
+          ├─ ParsePayloadNode
+          ├─ RehydrateActivityNode
+          ├─ ExtractSemanticsNode
+          ├─ DeferCheckNode
+          ├─ DispatchNode
+          └─ BuildOutcomeNode
+    """
+    return py_trees.composites.Sequence(
+        name="InboxPipelineBT",
+        memory=False,
+        children=[
+            ParsePayloadNode(name="ParsePayload"),
+            RehydrateActivityNode(name="RehydrateActivity"),
+            ExtractSemanticsNode(name="ExtractSemantics"),
+            DeferCheckNode(name="DeferCheck"),
+            DispatchNode(name="Dispatch"),
+            BuildOutcomeNode(name="BuildOutcome"),
+        ],
+    )

--- a/vultron/core/behaviors/inbox/models.py
+++ b/vultron/core/behaviors/inbox/models.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+"""InboxOutcome model and adapter/port protocol interfaces.
+
+Defines the typed return model and Protocol interfaces used by
+:func:`~vultron.core.behaviors.inbox.process_payload`.
+
+Per specs/inbox-orchestration.yaml:
+- IO-01-001 through IO-01-004: InboxOutcome model
+- IO-03-001: IngressPayloadAdapter and DispatchAdapter protocols
+- IO-03-002: PendingCaseQueuePort protocol
+"""
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+from __future__ import annotations
+
+from typing import Any, Literal, Protocol, runtime_checkable
+
+from pydantic import BaseModel
+
+from vultron.core.models.events import VultronEvent
+
+
+class InboxOutcome(BaseModel):
+    """Result returned by every :func:`process_payload` call.
+
+    Per specs/inbox-orchestration.yaml IO-01-001 through IO-01-004.
+    """
+
+    status: Literal["processed", "deferred", "rejected"]
+    context_id: str | None = None
+    failure_reason: str | None = None
+
+
+@runtime_checkable
+class IngressPayloadAdapter(Protocol):
+    """Adapter: raw input → rehydrated as_Activity.
+
+    Owns parse and rehydrate; isolates wire-format knowledge from the
+    orchestration BT.  Per IO-03-001.
+    """
+
+    def parse(
+        self,
+        payload: dict[str, Any] | bytes | str | Any,
+    ) -> Any | None:
+        """Parse raw payload into a typed Activity.
+
+        Returns ``None`` on parse failure; MUST NOT raise.
+        """
+        ...  # pragma: no cover
+
+    def rehydrate(self, activity: Any) -> Any:
+        """Resolve nested object references to their full representations."""
+        ...  # pragma: no cover
+
+
+@runtime_checkable
+class DispatchAdapter(Protocol):
+    """Adapter: VultronEvent → use-case execution.
+
+    Wraps the existing ActivityDispatcher port.  Per IO-03-001.
+    """
+
+    def dispatch(self, event: VultronEvent) -> None:
+        """Dispatch a domain event to the appropriate use case."""
+        ...  # pragma: no cover
+
+
+@runtime_checkable
+class PendingCaseQueuePort(Protocol):
+    """Port: pending-case inbox queue management.
+
+    Provides defer and replay queue operations to :class:`DeferCheckNode`
+    without requiring adapter-layer imports in core.  Per IO-03-002.
+    """
+
+    def is_case_known(self, case_id: str) -> bool:
+        """Return ``True`` if the case replica is locally available."""
+        ...  # pragma: no cover
+
+    def queue(
+        self,
+        activity_id: str,
+        case_id: str,
+        case_actor_id: str | None = None,
+    ) -> None:
+        """Persist *activity_id* in the deferred queue for *case_id*."""
+        ...  # pragma: no cover
+
+    def check_and_expire(self, case_id: str) -> bool:
+        """Check expiry; drop queue and return ``True`` when expired."""
+        ...  # pragma: no cover
+
+    def replay(self, case_id: str) -> None:
+        """Move deferred activities for *case_id* back to the live inbox."""
+        ...  # pragma: no cover

--- a/vultron/core/behaviors/inbox/nodes/__init__.py
+++ b/vultron/core/behaviors/inbox/nodes/__init__.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+"""Public re-exports for inbox pipeline BT nodes.
+
+Per specs/behavior-tree-node-design.yaml BTND-07-001: leaf nodes live in
+this ``nodes/`` subpackage; this ``__init__.py`` re-exports all public
+names to preserve caller import paths.
+
+Note: nodes are implementation details of the inbox BT module.  They are
+re-exported here for use by ``inbox_tree.py`` and tests; they MUST NOT be
+exposed as the public API of the ``vultron.core.behaviors.inbox`` package
+(IO-02-003).
+"""
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+from vultron.core.behaviors.inbox.nodes.pipeline import (  # noqa: F401
+    ALL_INBOX_KEYS,
+    KEY_ACTIVITY,
+    KEY_CONTEXT_ID,
+    KEY_DISPATCH,
+    KEY_EVENT,
+    KEY_FAILURE_REASON,
+    KEY_INGRESS,
+    KEY_OUTCOME_STATUS,
+    KEY_PAYLOAD,
+    KEY_QUEUE,
+    BuildOutcomeNode,
+    DeferCheckNode,
+    DispatchNode,
+    ExtractSemanticsNode,
+    ParsePayloadNode,
+    RehydrateActivityNode,
+)

--- a/vultron/core/behaviors/inbox/nodes/pipeline.py
+++ b/vultron/core/behaviors/inbox/nodes/pipeline.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python
+"""BT pipeline leaf nodes for inbox orchestration.
+
+Each node is responsible for exactly one pipeline step.  Intermediate
+state is communicated via the py_trees blackboard using the
+``inbox_*`` key namespace.
+
+Blackboard keys (all prefixed ``inbox_``):
+
+Input keys (written by :func:`~...process_payload` before BT execution):
+    inbox_payload       — raw payload passed to process_payload
+    inbox_ingress       — IngressPayloadAdapter instance
+    inbox_dispatch      — DispatchAdapter instance
+    inbox_queue         — PendingCaseQueuePort instance or None
+
+Intermediate keys (written by pipeline nodes during execution):
+    inbox_activity      — parsed as_Activity
+    inbox_event         — VultronEvent with extracted semantics
+    inbox_context_id    — case context ID string or None
+
+Output keys (written by pipeline nodes on completion or failure):
+    inbox_outcome_status   — one of "processed", "deferred", "rejected"
+    inbox_failure_reason   — human-readable reason when not processed
+
+Per specs/inbox-orchestration.yaml IO-02-002.
+"""
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import py_trees
+from py_trees.common import Access, Status
+
+from vultron.core.models.events import MessageSemantics
+from vultron.semantic_registry import extract_event
+
+# Blackboard key constants — single source of truth used by both nodes
+# and process_payload setup/cleanup.
+KEY_PAYLOAD = "inbox_payload"
+KEY_INGRESS = "inbox_ingress"
+KEY_DISPATCH = "inbox_dispatch"
+KEY_QUEUE = "inbox_queue"
+KEY_ACTIVITY = "inbox_activity"
+KEY_EVENT = "inbox_event"
+KEY_CONTEXT_ID = "inbox_context_id"
+KEY_OUTCOME_STATUS = "inbox_outcome_status"
+KEY_FAILURE_REASON = "inbox_failure_reason"
+
+# All keys managed by the inbox pipeline (for setup and cleanup).
+ALL_INBOX_KEYS = (
+    KEY_PAYLOAD,
+    KEY_INGRESS,
+    KEY_DISPATCH,
+    KEY_QUEUE,
+    KEY_ACTIVITY,
+    KEY_EVENT,
+    KEY_CONTEXT_ID,
+    KEY_OUTCOME_STATUS,
+    KEY_FAILURE_REASON,
+)
+
+
+class _InboxNode(py_trees.behaviour.Behaviour):
+    """Base class for inbox pipeline nodes.
+
+    Provides a properly-wired logger and helper methods for writing
+    failure outcomes to the blackboard.
+    """
+
+    logger: logging.Logger  # type: ignore[assignment]
+    blackboard: py_trees.blackboard.Client
+
+    def __init__(self, name: str) -> None:
+        super().__init__(name=name)
+        # Replace py_trees' parentless logger with a hierarchy-wired one.
+        self.logger = logging.getLogger(  # type: ignore[assignment]
+            f"{self.__class__.__module__}.{self.__class__.__name__}"
+        )
+
+    def _reject(self, reason: str) -> Status:
+        """Write rejected outcome to blackboard and return FAILURE."""
+        self.feedback_message = reason
+        try:
+            self.blackboard.inbox_outcome_status = "rejected"
+            self.blackboard.inbox_failure_reason = reason
+        except Exception:
+            pass
+        self.logger.warning("%s: rejected — %s", self.name, reason)
+        return Status.FAILURE
+
+
+class ParsePayloadNode(_InboxNode):
+    """Step 1: parse raw payload into a typed Activity.
+
+    Reads ``inbox_payload`` and ``inbox_ingress``; writes
+    ``inbox_activity``.  Returns FAILURE with status ``rejected`` when
+    parsing fails.
+    """
+
+    def setup(self, **kwargs: Any) -> None:
+        self.blackboard = self.attach_blackboard_client(name=self.name)
+        self.blackboard.register_key(KEY_PAYLOAD, access=Access.READ)
+        self.blackboard.register_key(KEY_INGRESS, access=Access.READ)
+        self.blackboard.register_key(KEY_ACTIVITY, access=Access.WRITE)
+        self.blackboard.register_key(KEY_OUTCOME_STATUS, access=Access.WRITE)
+        self.blackboard.register_key(KEY_FAILURE_REASON, access=Access.WRITE)
+
+    def update(self) -> Status:
+        try:
+            payload = self.blackboard.inbox_payload
+            ingress = self.blackboard.inbox_ingress
+        except KeyError as exc:
+            return self._reject(f"Missing blackboard key: {exc}")
+
+        try:
+            activity = ingress.parse(payload)
+        except Exception as exc:
+            return self._reject(f"Parse raised exception: {exc}")
+
+        if activity is None:
+            return self._reject("Ingress adapter returned None from parse()")
+
+        self.blackboard.inbox_activity = activity
+        self.logger.debug(
+            "%s: parsed activity type=%s id=%s",
+            self.name,
+            getattr(activity, "type_", "?"),
+            getattr(activity, "id_", "?"),
+        )
+        return Status.SUCCESS
+
+
+class RehydrateActivityNode(_InboxNode):
+    """Step 2: resolve nested object references in the parsed Activity.
+
+    Reads ``inbox_activity`` and ``inbox_ingress``; overwrites
+    ``inbox_activity`` with the rehydrated result.
+    """
+
+    def setup(self, **kwargs: Any) -> None:
+        self.blackboard = self.attach_blackboard_client(name=self.name)
+        self.blackboard.register_key(KEY_ACTIVITY, access=Access.WRITE)
+        self.blackboard.register_key(KEY_INGRESS, access=Access.READ)
+        self.blackboard.register_key(KEY_OUTCOME_STATUS, access=Access.WRITE)
+        self.blackboard.register_key(KEY_FAILURE_REASON, access=Access.WRITE)
+
+    def update(self) -> Status:
+        try:
+            activity = self.blackboard.inbox_activity
+            ingress = self.blackboard.inbox_ingress
+        except KeyError as exc:
+            return self._reject(f"Missing blackboard key: {exc}")
+
+        try:
+            rehydrated = ingress.rehydrate(activity)
+        except Exception as exc:
+            return self._reject(f"Rehydrate raised exception: {exc}")
+
+        self.blackboard.inbox_activity = rehydrated
+        self.logger.debug(
+            "%s: rehydrated activity id=%s",
+            self.name,
+            getattr(rehydrated, "id_", "?"),
+        )
+        return Status.SUCCESS
+
+
+class ExtractSemanticsNode(_InboxNode):
+    """Step 3: extract MessageSemantics from the rehydrated Activity.
+
+    Reads ``inbox_activity``; writes ``inbox_event`` and
+    ``inbox_context_id``.
+    """
+
+    def setup(self, **kwargs: Any) -> None:
+        self.blackboard = self.attach_blackboard_client(name=self.name)
+        self.blackboard.register_key(KEY_ACTIVITY, access=Access.READ)
+        self.blackboard.register_key(KEY_EVENT, access=Access.WRITE)
+        self.blackboard.register_key(KEY_CONTEXT_ID, access=Access.WRITE)
+        self.blackboard.register_key(KEY_OUTCOME_STATUS, access=Access.WRITE)
+        self.blackboard.register_key(KEY_FAILURE_REASON, access=Access.WRITE)
+
+    def update(self) -> Status:
+        try:
+            activity: Any = self.blackboard.inbox_activity
+        except KeyError as exc:
+            return self._reject(f"Missing blackboard key: {exc}")
+
+        try:
+            event = extract_event(activity)
+        except Exception as exc:
+            return self._reject(f"extract_event raised exception: {exc}")
+
+        self.blackboard.inbox_event = event
+
+        # Resolve context_id: prefer event.context_id, fall back to
+        # activity.context_ (the AS2 context field — but only when it is
+        # a non-default, case-scoped URI), and finally to event.object_.id_
+        # for bootstrap (ANNOUNCE_VULNERABILITY_CASE) activities where the
+        # case ID is carried in the announce object rather than the context.
+        context_id: str | None = event.context_id
+        if context_id is None:
+            context = getattr(activity, "context_", None)
+            # Skip the default AS2 namespace URI — it is not a case ID.
+            if (
+                isinstance(context, str)
+                and context
+                and not context.startswith("https://www.w3.org/ns/")
+            ):
+                context_id = context
+            elif context is not None and not isinstance(context, str):
+                context_id = getattr(context, "id_", None)
+        if (
+            context_id is None
+            and event.semantic_type
+            == MessageSemantics.ANNOUNCE_VULNERABILITY_CASE
+            and event.object_ is not None
+        ):
+            # Bootstrap case: case ID is in the announced VulnerabilityCase.
+            candidate = getattr(event.object_, "id_", None)
+            if isinstance(candidate, str) and candidate:
+                context_id = candidate
+        self.blackboard.inbox_context_id = context_id
+
+        self.logger.debug(
+            "%s: extracted semantics=%s context_id=%s",
+            self.name,
+            event.semantic_type,
+            context_id,
+        )
+        return Status.SUCCESS
+
+
+class DeferCheckNode(_InboxNode):
+    """Step 4: defer activity when its case context is not yet known.
+
+    If a case context ID is present, the activity semantic is not the
+    bootstrap ``ANNOUNCE_VULNERABILITY_CASE``, and the case is not yet
+    locally available, the activity is either queued for later replay
+    (``deferred`` outcome) or dropped when the queue has expired
+    (``rejected`` outcome).
+
+    Passes through to SUCCESS when no deferral is needed.
+    """
+
+    def setup(self, **kwargs: Any) -> None:
+        self.blackboard = self.attach_blackboard_client(name=self.name)
+        self.blackboard.register_key(KEY_EVENT, access=Access.READ)
+        self.blackboard.register_key(KEY_CONTEXT_ID, access=Access.READ)
+        self.blackboard.register_key(KEY_QUEUE, access=Access.READ)
+        self.blackboard.register_key(KEY_OUTCOME_STATUS, access=Access.WRITE)
+        self.blackboard.register_key(KEY_FAILURE_REASON, access=Access.WRITE)
+
+    def update(self) -> Status:
+        try:
+            event = self.blackboard.inbox_event
+            context_id: str | None = self.blackboard.inbox_context_id
+        except KeyError as exc:
+            return self._reject(f"Missing blackboard key: {exc}")
+
+        try:
+            queue = self.blackboard.inbox_queue
+        except KeyError:
+            queue = None
+
+        # No deferral needed when there is no case context, when
+        # processing the bootstrap itself, or when no queue port is
+        # available.
+        is_bootstrap = (
+            event.semantic_type == MessageSemantics.ANNOUNCE_VULNERABILITY_CASE
+        )
+        if context_id is None or is_bootstrap or queue is None:
+            return Status.SUCCESS
+
+        if queue.is_case_known(context_id):
+            return Status.SUCCESS
+
+        # Case is not yet known — check if the pending queue has expired.
+        if queue.check_and_expire(context_id):
+            reason = (
+                f"Pre-bootstrap queue for case '{context_id}' expired; "
+                "resend required after new bootstrap"
+            )
+            self.feedback_message = reason
+            self.blackboard.inbox_outcome_status = "rejected"
+            self.blackboard.inbox_failure_reason = reason
+            self.logger.warning("%s: %s", self.name, reason)
+            return Status.FAILURE
+
+        # Queue for replay when bootstrap arrives.
+        queue.queue(
+            activity_id=event.activity_id,
+            case_id=context_id,
+            case_actor_id=event.actor_id,
+        )
+        reason = f"Deferred: case '{context_id}' not yet known locally"
+        self.feedback_message = reason
+        self.blackboard.inbox_outcome_status = "deferred"
+        self.blackboard.inbox_failure_reason = reason
+        self.logger.info("%s: %s", self.name, reason)
+        return Status.FAILURE
+
+
+class DispatchNode(_InboxNode):
+    """Step 5: dispatch the domain event to the appropriate use case.
+
+    After a successful bootstrap dispatch, triggers replay of any
+    activities that were deferred pending this case's local replica.
+    """
+
+    def setup(self, **kwargs: Any) -> None:
+        self.blackboard = self.attach_blackboard_client(name=self.name)
+        self.blackboard.register_key(KEY_EVENT, access=Access.READ)
+        self.blackboard.register_key(KEY_DISPATCH, access=Access.READ)
+        self.blackboard.register_key(KEY_CONTEXT_ID, access=Access.READ)
+        self.blackboard.register_key(KEY_QUEUE, access=Access.READ)
+        self.blackboard.register_key(KEY_OUTCOME_STATUS, access=Access.WRITE)
+        self.blackboard.register_key(KEY_FAILURE_REASON, access=Access.WRITE)
+
+    def update(self) -> Status:
+        try:
+            event = self.blackboard.inbox_event
+            dispatch = self.blackboard.inbox_dispatch
+        except KeyError as exc:
+            return self._reject(f"Missing blackboard key: {exc}")
+
+        try:
+            dispatch.dispatch(event)
+        except Exception as exc:
+            return self._reject(f"Dispatch raised exception: {exc}")
+
+        self.logger.info(
+            "%s: dispatched %s activity_id=%s",
+            self.name,
+            event.semantic_type,
+            event.activity_id,
+        )
+
+        # After bootstrap, replay any activities that were held pending
+        # this case's local replica becoming available.
+        is_bootstrap = (
+            event.semantic_type == MessageSemantics.ANNOUNCE_VULNERABILITY_CASE
+        )
+        try:
+            context_id: str | None = self.blackboard.inbox_context_id
+            queue = self.blackboard.inbox_queue
+        except KeyError:
+            context_id = None
+            queue = None
+
+        if is_bootstrap and context_id is not None and queue is not None:
+            queue.replay(context_id)
+            self.logger.info(
+                "%s: triggered replay for case '%s'", self.name, context_id
+            )
+
+        return Status.SUCCESS
+
+
+class BuildOutcomeNode(_InboxNode):
+    """Step 6: record the processed outcome on the blackboard.
+
+    Runs only when all preceding Sequence nodes succeeded.  Writes
+    ``inbox_outcome_status = "processed"`` so that :func:`process_payload`
+    can assemble the final :class:`InboxOutcome`.
+    """
+
+    def setup(self, **kwargs: Any) -> None:
+        self.blackboard = self.attach_blackboard_client(name=self.name)
+        self.blackboard.register_key(KEY_OUTCOME_STATUS, access=Access.WRITE)
+
+    def update(self) -> Status:
+        self.blackboard.inbox_outcome_status = "processed"
+        self.logger.debug("%s: outcome = processed", self.name)
+        return Status.SUCCESS


### PR DESCRIPTION
- Closes #997

## Summary

Implements the `process_payload() -> InboxOutcome` seam specified in ADR-0020 and `specs/inbox-orchestration.yaml` (IO-01 through IO-04). All inbox processing policy moves from the FastAPI adapter layer into `vultron/core/behaviors/inbox/` as a 6-node BT Sequence. The FastAPI endpoint becomes thin glue that supplies adapter implementations and schedules a background task.

## Changes

**Core module** (`vultron/core/behaviors/inbox/`):
- `models.py` — `InboxOutcome` Pydantic model + 3 `@runtime_checkable` Protocol interfaces (`IngressPayloadAdapter`, `DispatchAdapter`, `PendingCaseQueuePort`); no wire imports (ARCH-01-001)
- `nodes/pipeline.py` — 6 BT leaf nodes: `ParsePayloadNode`, `RehydrateActivityNode`, `ExtractSemanticsNode`, `DeferCheckNode`, `DispatchNode`, `BuildOutcomeNode`
- `inbox_tree.py` — `create_inbox_bt()` factory composing the 6-node Sequence
- `_process_payload.py` — `process_payload()` with extracted helpers; acquires `_BT_GLOBAL_LOCK` (RLock, shared with BTBridge) and saves/restores blackboard state
- `__init__.py` / `nodes/__init__.py` — re-exports preserving public API

**Adapter layer** (`vultron/adapters/driving/fastapi/`):
- `inbox_orchestration.py` — `FastAPIIngressAdapter`, `StoredActivityIngressAdapter`, `FastAPIDispatchAdapter`, `FastAPIQueuePort`, `run_inbox_pipeline()` async background function
- `routers/actors/_routes.py` — updated `post_actor_inbox`: restores `_record_inbox_receipt` (dedup fix), threads raw `body` dict through to adapter (nested object re-parsing fix), calls `run_inbox_pipeline`

**Tests** (`test/core/behaviors/inbox/test_process_payload.py`):
- 14 tests asserting on `InboxOutcome.status` and `failure_reason` only — no internal BT node patching (IO-04-002)
- Covers: happy path, parse failure, dispatch failure, defer/expire/replay, bootstrap triggers replay, no-queue-port passthrough, thread safety

## Verification

All linters pass (black, flake8 CC≤10, mypy, pyright):
```
Success: no issues found in 879 source files
0 errors, 0 warnings, 0 informations
```

Unit test suite:
```
3492 passed, 34 skipped, 225 deselected, 2 xfailed, 5633 subtests passed in 59.15s
```