### PR TITLE
Capture Epic #788 retrospective gaps as specs and notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -444,6 +444,17 @@ Short entries are reproduced here; longer ones are referenced below.
 - **Use `isinstance` for Pyright Attribute Narrowing, Not `# type: ignore`** — see [`vultron/core/AGENTS.md`](vultron/core/AGENTS.md)
 - **Untyped Closures Are Invisible to mypy — Extract to Named Functions** — see [`vultron/core/AGENTS.md`](vultron/core/AGENTS.md)
 - **CI Runs All Tests; Default Local Run Omits Integration** — see `test/AGENTS.md` § Integration Tests
+- **Canonical Ledger Commits Must Be Role-Gated and Coverage-Checked, Not
+  Conventionally Trusted** — A canonical-write node
+  (`CommitCaseLedgerEntryNode`) reachable from more than one call site or
+  more than one actor context MUST be wrapped in a role-gated
+  Selector/Sequence/Success composite (see
+  `notes/bt-integration.md` § "Guarded Commit: Role-Gated Canonical
+  Writes"), and every protocol-significant use case MUST be covered by a
+  test asserting it reaches a commit — do not rely on manual audit to find
+  missing or unguarded commits after the fact. See
+  `specs/case-ledger-processing.yaml` CLP-09 and
+  `notes/case-ledger-authority.md` § "Commit Authorization and Coverage".
 - **Superseded `notes/*.md` Files Must Move to `archived_notes/`, Not Stay in `notes/`** — A file
   with `status: superseded` in its frontmatter MUST be moved to `archived_notes/` using `git mv`.
   Leaving it in `notes/` causes agents to load outdated guidance as active context and pollutes

--- a/notes/bt-integration.md
+++ b/notes/bt-integration.md
@@ -1096,6 +1096,57 @@ overall flow readable from the tree structure alone.
 
 ---
 
+### Guarded Commit: Role-Gated Canonical Writes
+
+(ISSUE-1021, 2026-06-17; see `specs/case-ledger-processing.yaml` CLP-09 and
+`notes/case-ledger-authority.md` § "Commit Authorization and Coverage")
+
+Any canonical-write node (e.g., `CommitCaseLedgerEntryNode`) that may be
+reached from more than one actor context MUST be wrapped in a role-gated
+`Selector`, never invoked bare:
+
+```python
+Selector(
+    name="GuardedCommitCaseLedgerEntry",
+    memory=False,
+    children=[
+        Sequence(
+            children=[
+                CheckIsCaseManagerNode(case_id=case_id),
+                CommitCaseLedgerEntryNode(case_id=case_id),
+            ]
+        ),
+        py_trees.behaviours.Success(
+            name="CommitCaseLedgerEntrySkippedNotCaseManager"
+        ),
+    ],
+)
+```
+
+This is the same Selector/Sequence/Success idiom as the section above; the
+difference is what the condition checks. `CheckIsCaseManagerNode` resolves
+the case's `CVDRole.CASE_MANAGER` participant and compares it against the
+*actor active for this invocation* — never against the use-case class's
+identity, and never assumed from a previous invocation having passed.
+
+This matters specifically for use cases that can be invoked more than once
+for the same logical activity with different receiving actors (e.g.,
+`ack_report`'s case-actor invocation vs. its finder-relay invocation in the
+demo). Gating per invocation, inside the tree, is what makes it safe to wire
+the same shared subtree into both the trigger-side and received-side paths
+of such a use case — see CLP-09-004. Do not introduce `py_trees.decorators`
+for this; this codebase uses the Selector/Sequence/Success composite idiom
+exclusively (see also "Conditional BT Branches as Selector Composites"
+above).
+
+Wrap the pattern once as a reusable factory (e.g.
+`create_guarded_commit_case_ledger_entry_tree(case_id=None)`) rather than
+re-inlining the Selector at each call site, and migrate all existing bare
+`CommitCaseLedgerEntryNode` call sites to the factory — CLP-09-002 requires
+a test asserting no bare usage remains outside it.
+
+---
+
 ### Fan-out / SYNC Decomposition: Context Handoff Pattern
 
 (ISSUE-755, 2026-06-10)

--- a/notes/case-ledger-authority.md
+++ b/notes/case-ledger-authority.md
@@ -334,6 +334,69 @@ silent pollution that's discovered only when replicas diverge.
 
 ---
 
+## Commit Authorization and Coverage (CLP-09, Epic #788 retrospective)
+
+Two gaps surfaced late in Epic #788 that CLP-09 now makes explicit, because
+the prior framing (BT-10-004's single line, "CaseActor MUST enforce
+case-level authorization") was not specific enough to prevent them from
+accumulating call site by call site.
+
+### Gap 1: Authorization Was a Convention, Not a Gate
+
+`CommitCaseLedgerEntryNode` (the canonical commit mechanism established by
+PR #1017 / BT-06-006) had no built-in authorization check. An audit found
+that only one of roughly ten call sites guarded the commit, and it did so
+with an ad hoc Python-level identity check (`_is_case_actor_receiver`)
+*outside* the BT, not a role check inside it. The other call sites
+committed unconditionally.
+
+The fix is a reusable guarded-commit composition, following the same
+Selector/Sequence/Success idiom already used elsewhere in this codebase
+(see `notes/bt-integration.md` § "Conditional BT Branches as Selector
+Composites" and § "Guarded Commit: Role-Gated Canonical Writes"):
+
+```text
+Selector
+├─ Sequence
+│  ├─ CheckIsCaseManagerNode   # role check, not identity comparison
+│  └─ CommitCaseLedgerEntryNode
+└─ Success("CommitCaseLedgerEntrySkippedNotCaseManager")
+```
+
+CLP-09-001 requires every commit call site to reach the commit only through
+this kind of guarded composition. CLP-09-002 requires a test that fails if
+any call site bypasses it.
+
+### Gap 2: Commit Coverage Had No Structural Check
+
+`validate_report`, `ack_report`, and `close_case` produced **no** canonical
+ledger entry at all on `main` for an unknown span of time (issue #998).
+Dispatch completeness already has a structural guarantee — DR-02-002 and
+UCORG-02-002 require every `MessageSemantics` value to resolve to a callable
+use case, enforced by a coverage test. Commit completeness had no
+equivalent: a use case could be fully wired for dispatch and still never
+touch the ledger, and nothing would fail until someone manually re-audited
+the tree-by-tree commit sites (which is how #998/#1022 found the gap).
+CLP-09-003 closes this by requiring the same kind of enumerated coverage
+test for commits that already exists for dispatch.
+
+### Gap 3: Dual-Invocation Use Cases Need Per-Invocation Authorization
+
+Some use-case classes are invoked more than once for the same logical
+activity, with different receiving actors. The clearest example is
+`ack_report` in the two/three-actor demo: the same `AckReportReceivedUseCase`
+runs once with the vendor (case actor) as receiver, and once with the finder
+as a relay target. Only the case-actor invocation should commit.
+
+This is structurally the same bug shape that produced the original
+hash-chain fork in issue #923 — a use case authored or committing on behalf
+of the wrong actor. CLP-09-004 makes the general rule explicit: authorization
+for a commit must be evaluated **per invocation**, against the actor that is
+actually active for that invocation, never assumed from the use-case class
+itself or from a prior invocation having been authorized.
+
+---
+
 ## Per-Case Genesis Hash — Origin Binding and Future Improvements
 
 *Spec: `specs/case-ledger-processing.yaml` CLP-08-001 through CLP-08-006.*

--- a/specs/behavior-tree-integration.yaml
+++ b/specs/behavior-tree-integration.yaml
@@ -194,6 +194,13 @@ groups:
     statement: CaseActor MUST enforce case-level authorization
     scope:
     - production
+    relationships:
+    - rel_type: refines
+      spec_id: CLP-09-001
+    - rel_type: refines
+      spec_id: CLP-09-003
+    - rel_type: refines
+      spec_id: CLP-09-004
   - id: BT-10-005
     priority: SHOULD
     statement: >-

--- a/specs/case-ledger-processing.yaml
+++ b/specs/case-ledger-processing.yaml
@@ -291,3 +291,61 @@ groups:
       NOT use sequentially predictable or human-chosen path segments when origin-binding
       integrity is required; see `notes/case-ledger-authority.md` for future
       improvement paths (secret nonce, CaseActor keypairs)
+- id: CLP-09
+  title: Commit Authorization and Coverage
+  specs:
+  - id: CLP-09-001
+    priority: MUST
+    statement: >-
+      Every call site that invokes the canonical commit operation MUST reach it only
+      through a role-gated composition that verifies, at the time of invocation, that
+      the active actor holds `CVDRole.CASE_MANAGER` for the case; this MUST be a
+      role-based check, not an identity comparison, even where the CaseActor and the
+      role holder happen to coincide today
+    rationale: >-
+      An audit of `CommitCaseLedgerEntryNode` call sites (Epic #788, issue #1021)
+      found that only one of roughly ten call sites guarded the commit, and it did
+      so with an ad hoc Python-level identity check outside the BT rather than a
+      role check inside it. The other call sites committed unconditionally. Stating
+      this as one vague authorization line (see BT-10-004) was not specific enough
+      to prevent the gap from accumulating call site by call site.
+  - id: CLP-09-002
+    priority: MUST_NOT
+    statement: >-
+      The canonical commit operation MUST NOT be invoked directly (bare, unguarded)
+      from any production call site outside the guarded-commit composition itself;
+      a registry- or grep-based test MUST assert that no such bare usage exists
+    verification: >-
+      A dedicated test enumerates known commit call sites (or greps for the
+      unguarded commit node's class name) and fails if any usage outside the
+      guarded-commit factory's own implementation is found.
+  - id: CLP-09-003
+    priority: MUST
+    statement: >-
+      Every protocol-significant use case or BT subtree (per BT-06-001) MUST
+      produce exactly one canonical commit; a coverage test MUST enumerate
+      protocol-significant entries (e.g., everything reachable from
+      `USE_CASE_MAP`) and assert each one reaches a commit, rather than relying
+      on manual audit to discover missing commits
+    rationale: >-
+      `validate_report`, `ack_report`, and `close_case` produced no canonical
+      ledger entry at all on `main` for an unknown span of time (issue #998/#1022).
+      Dispatch completeness is already enforced structurally for `USE_CASE_MAP`
+      (DR-02-002, UCORG-02-002); commit completeness had no equivalent structural
+      check and was found only by a manual re-audit.
+  - id: CLP-09-004
+    priority: MUST
+    statement: >-
+      When the same use-case class may be invoked with more than one receiving-actor
+      identity for a single logical activity (e.g., a relayed copy delivered to a
+      second participant), authorization for the commit MUST be evaluated per
+      invocation against the active actor's role, and MUST NOT be assumed from the
+      use-case class's identity or from the fact that earlier invocations were
+      authorized
+    rationale: >-
+      The `ack_report` flow in the two/three-actor demo invokes the same use case
+      once with the case actor as receiver and once with the finder as a relay
+      target; only the case-actor invocation may commit. This is the same shape
+      of bug that produced the original hash-chain fork in issue #923, and it
+      recurs at every new dual-invocation call site unless authorization is
+      re-evaluated per invocation rather than per use-case class.

--- a/specs/code-style.yaml
+++ b/specs/code-style.yaml
@@ -315,3 +315,27 @@ groups:
     relationships:
     - rel_type: refines
       spec_id: BTND-07-002
+- id: CS-19
+  title: Test Fixtures Mirroring Production Enums
+  kind: general
+  specs:
+  - id: CS-19-001
+    priority: MUST
+    statement: >-
+      A test fixture or constant that enumerates the same value set as a production
+      enum (e.g., a list of expected event-type strings mirroring `MessageSemantics`)
+      MUST derive its values from the enum at import/collection time rather than
+      duplicating them as separately-maintained literals.
+    rationale: >-
+      `EXPECTED_EVENT_TYPES` in `test/ci/test_case_ledger_invariants.py` hardcoded
+      values that silently diverged from `MessageSemantics` (issue #998/#1020):
+      five of ten values used legacy names that no longer matched the enum. The
+      mismatch produced no failure on its own — it only surfaced when the invariant
+      using it was audited by hand. Deriving the fixture from the enum makes the
+      two sets impossible to drift apart; a rename in the enum either propagates
+      automatically or fails loudly at collection time.
+    verification: >-
+      Grep test fixtures for literal string lists that parallel a production enum's
+      member names; replace with `[e.value for e in EnumName]` or equivalent,
+      narrowed with an explicit exclusion list where the fixture intentionally
+      covers a subset.

--- a/specs/project-documentation.yaml
+++ b/specs/project-documentation.yaml
@@ -131,3 +131,36 @@ groups:
       visible to collaborators.
     tags:
     - documentation
+  - id: PD-09-004
+    priority: MUST
+    statement: >-
+      An Epic whose scope includes changes to the canonical CaseLedgerEntry commit path
+      (commit call sites, commit authorization/gating, or per-actor ledger content) MUST include a
+      closing sub-issue that reviews a fresh multi-actor demo run's per-actor ledger logs before the
+      Epic is closed. Passing the aggregate invariant test suite alone is NOT sufficient closure
+      evidence for such an Epic.
+    rationale: >-
+      Epic #788's aggregate invariant suite (`test/ci/test_case_ledger_invariants.py`) passed
+      all checks on `main` throughout the epic, yet the originating issue (#923) found 17
+      protocol-correctness findings, including two critical-severity bugs (a hash-chain fork and an
+      RM oscillation loop), that were visible only from a direct side-by-side review of each actor's
+      JSONL log, not from any single structural invariant. Without a standing rule requiring this
+      review at closure, later commit-path changes in the same Epic (e.g., a new authorization gate
+      touching ~10 call sites) could reintroduce the same class of bug undetected.
+    tags:
+    - documentation
+  - id: PD-09-005
+    priority: SHOULD
+    statement: >-
+      Before scheduling an Epic whose goal is to deprecate or remove an existing artifact
+      (a field, a class, a write path), an exhaustive inventory of read and write call sites for that
+      artifact, across all layers, including any wire-layer or adapter-layer duplicates, SHOULD be
+      attached to the Epic issue at creation time.
+    rationale: >-
+      Epic #788's wire-layer `VulnerabilityCase.events`/`record_event()` duplicate (issue
+      #888) was discovered mid-epic rather than scoped at the start, and ended up as a late-arriving
+      prerequisite blocking the epic's final removal step (#792). An upfront inventory would have
+      surfaced this dependency before work began rather than after most of the epic was already
+      complete.
+    tags:
+    - documentation


### PR DESCRIPTION
## Summary

Following a review of Epic #788's history (Converge CaseEvent flow onto
canonical CaseLogEntry) and its remaining open descendants, this PR captures
six gaps that surfaced only through ad hoc audits during the epic, and
generalizes them into standing specs/notes so the same class of issue
doesn't have to be rediscovered next time:

- No structural requirement that canonical ledger commits be
  authorization-gated — only audited late (#1021), after ~9 of ~10 call
  sites had shipped unguarded.
- No coverage requirement linking protocol-significant use cases to ledger
  commits — `validate_report`/`ack_report`/`close_case` produced zero
  entries until a manual audit found the gap (#998/#1022).
- No invariant against test-fixture/enum drift — `EXPECTED_EVENT_TYPES`
  silently diverged from `MessageSemantics` (#1020).
- No epic-closure rule requiring a fresh multi-actor log review for
  ledger-commit-path changes — the very type of review that originally
  found #923's critical bugs.
- No upfront dependency-inventory requirement for deprecation epics — the
  wire-layer `CaseEvent` duplicate (#888) was discovered mid-epic, blocking
  #792 late.
- No named pattern for per-invocation authorization on dual-invocation use
  cases (e.g., `ack_report`'s case-actor vs. finder-relay paths) — the same
  bug shape that caused #923's original hash-chain fork.

## Changes

- `specs/case-ledger-processing.yaml`: new **CLP-09** group (Commit
  Authorization and Coverage), 4 requirements.
- `specs/behavior-tree-integration.yaml`: link `BT-10-004` to the new
  CLP-09 requirements via `relationships`.
- `specs/code-style.yaml`: new **CS-19** group (Test Fixtures Mirroring
  Production Enums), 1 requirement.
- `specs/project-documentation.yaml`: **PD-09-004/005** — epic-closure and
  deprecation-epic dependency-inventory rules.
- `notes/case-ledger-authority.md`: new section explaining the CLP-09 gaps
  and their #788 history.
- `notes/bt-integration.md`: new section documenting the guarded-commit
  Selector/Sequence/Success pattern (the standard idiom for role-gating a
  canonical write).
- `AGENTS.md`: short pitfall entry pointing to the above.

## Verification

- [x] `uv run spec-dump` loads all new requirement IDs cleanly
      (CLP-09-001..004, CS-19-001, PD-09-004, PD-09-005).
- [x] `./mdlint.sh` — 0 errors on changed files.
- [x] `uv run pytest test/metadata/test_notes_frontmatter.py
      test/metadata/test_specs_format.py
      test/metadata/specs/test_spec_marker.py` — all passed.
- [x] Pre-commit hooks (black, markdownlint, frontmatter validator, flake8,
      spec registry linter) passed on commit.

This is a docs/specs-only change; no production code is affected.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>