### PR TITLE
docs: plan #1026 — CaseActor inbox routing as sole canonical ledger path (ADR-0021)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -425,6 +425,17 @@ Short entries are reproduced here; longer ones are referenced below.
   `Accept(Invite)` message IS the invitee's engage decision (PCR-08-009, PCR-08-010).
   See [notes/case-communication-model.md](notes/case-communication-model.md)
   § "Antipattern: Identity Spoofing in Received-Side Use Cases".
+- **Received-Side Guarded Commit MUST NOT Resolve a Foreign CaseActor ID** — Resolving
+  `case_actor_id` from the DataLayer and passing it as `actor_id` to
+  `BTBridge.execute_with_setup` from a non-CaseActor inbox context is an identity-spoofing
+  violation (CLP-10-003). The canonical pattern (see `status.py::_commit_log_cascade_bt`)
+  requires a strict pre-flight guard: `if receiving_actor_id != case_actor_id: return`.
+  The guarded commit BT must only run when the receiving actor IS the CaseActor — at which
+  point `actor_id=receiving_actor_id` is correct and no identity spoofing occurs. For the
+  CaseActor to receive the activity in the first place, the trigger tree MUST emit an
+  outbound activity addressed to `case_manager_id` (CLP-10-001). See ADR-0021 and
+  [notes/case-communication-model.md](notes/case-communication-model.md)
+  § "Antipattern: Received-Side Guarded Commit with Foreign CaseActor ID".
 - **Invite/Accept Handshake Must Route Through the Case Actor** — `RmInviteToCaseActivity`
   MUST be sent with `actor=case_actor_id` (not the case owner) from the Case Actor's
   outbox. The invitee's `Accept` MUST be addressed to the Case Actor, not the case owner.

--- a/docs/adr/0021-caseactor-inbox-routing-canonical-ledger.md
+++ b/docs/adr/0021-caseactor-inbox-routing-canonical-ledger.md
@@ -1,0 +1,160 @@
+---
+status: accepted
+date: 2026-06-17
+deciders: Vultron maintainers
+consulted: >-
+  notes/case-communication-model.md, notes/case-ledger-authority.md,
+  specs/case-ledger-processing.yaml, specs/participant-case-replica.yaml
+---
+
+# CaseActor Inbox Routing as the Sole Path to Canonical Ledger Entries
+
+## Context and Problem Statement
+
+The two-actor demo CI invariant test
+(`test_invariant_5_expected_event_types_present`) failed after PR #1024
+introduced the CASE_MANAGER role gate on `CommitCaseLedgerEntryNode`.
+Investigation (issue #1026) revealed that most vendor-side trigger and
+received-side use cases never send an activity to the CaseActor's inbox.
+Consequently the CaseActor's canonical ledger was missing entries for
+`validate_report`, `ack_report`, `add_note_to_case`,
+`invite_to_embargo_on_case`, `accept_invite_to_embargo_on_case`, and
+`close_case`.
+
+Deeper inspection found that some received-side use cases (`note.py`,
+`embargo.py`) worked around this by resolving the CaseActor's ID from the
+DataLayer and then executing `create_guarded_commit_case_ledger_entry_tree`
+with `actor_id=case_actor_id` — even when the use case was running inside
+the **vendor actor's** inbox, not the CaseActor's. This violates the
+identity contract documented in ADR-0018 and the identity-spoofing pitfall
+in `AGENTS.md`: a received-side use case MUST NOT execute a BT with an
+`actor_id` different from the actor whose DataLayer is active. The guarded
+commit BT emits `Announce(CaseLedgerEntry)` activities as if authored by
+the CaseActor while running in the wrong actor's outbox context, which is
+either silently dropped or produces hash-chain divergence.
+
+The project has stated this rule in scattered form across `AGENTS.md`,
+`notes/case-communication-model.md`, and `specs/case-ledger-processing.yaml`,
+but the explicit, ADR-level statement of the **only correct end-to-end path**
+has been missing. As a result, agents and contributors keep re-discovering
+the shortcut (resolve CaseActor ID, run BT) and believing it is a valid
+"delegation" pattern.
+
+## Decision Drivers
+
+- `notes/case-communication-model.md` establishes that all post-creation
+  participant messages route through the Case Actor exclusively.
+- ADR-0018 established a single-writer canonical ledger authored by the
+  CaseActor. ADR-0019 sharpened the content boundary of that ledger.
+- The guarded-commit BT (`create_guarded_commit_case_ledger_entry_tree`)
+  already enforces the CASE_MANAGER role gate. The problem is that the
+  activity must **arrive at the CaseActor's inbox** before that gate can
+  fire; there is no inbox delivery mechanism for events that skip it.
+- A received-side use case that resolves a foreign actor ID and runs a BT
+  under that ID is the same class of identity-spoofing bug documented for
+  the `PrioritizeBT(actor_id=invitee_id)` anti-pattern (PCR-08-009,
+  PCR-08-010).
+
+## Considered Options
+
+**Option A — Explicit trigger-tree emit + received-UC pre-flight guard
+(this ADR's decision).**
+Every protocol-significant trigger tree emits an outbound activity addressed
+to `case_manager_id`. ASGI delivers it to the CaseActor's inbox. The
+CaseActor's received use case checks `receiving_actor_id == case_actor_id`
+before executing the guarded commit — and only executes it when the check
+passes. Non-CaseActor received use cases do nothing at the commit step; they
+rely on the fact that the CaseActor's inbox will separately receive the same
+activity.
+
+**Option B — "Delegation" via foreign actor_id resolution.**
+Received-side use cases resolve `case_actor_id` from the DataLayer and
+execute the guarded-commit BT with `actor_id=case_actor_id`, regardless of
+which actor is actually running the use case. This is the pattern found in
+`note.py` and `embargo.py` before this fix.
+
+**Option C — Shared commit helper called directly (no BT).**
+Received-side use cases call `commit_ledger_entry()` directly after resolving
+the CaseActor ID, bypassing the BT and the role gate.
+
+## Decision Outcome
+
+Chosen option: **Option A — Explicit trigger-tree emit + received-UC
+pre-flight guard**.
+
+The canonical ledger entry path is:
+
+```text
+Trigger tree
+  → emits outbound activity addressed to case_manager_id
+  → ASGI delivers to CaseActor inbox
+  → CaseActor's received use case runs with actor_id = case_actor_id
+  → pre-flight guard: receiving_actor_id == case_actor_id  [PASS]
+  → guarded commit BT executes with actor_id = case_actor_id
+  → CommitCaseLedgerEntryNode authors and broadcasts CaseLedgerEntry
+```
+
+When the activity is received by a **non-CaseActor** actor:
+
+```text
+Non-CaseActor received use case runs with actor_id ≠ case_actor_id
+  → pre-flight guard: receiving_actor_id == case_actor_id  [FAIL]
+  → commit step skipped entirely — no delegation, no BT, no spoofing
+```
+
+The pre-flight guard MUST use `receiving_actor_id` (the actor whose inbox is
+active), not a separately resolved CaseActor ID. This is the pattern already
+implemented correctly in `status.py`'s `_commit_log_cascade_bt()` and MUST
+be applied to every received-side use case that participates in ledger entry
+authorship.
+
+**Why `announce_case_ledger_entry` is excluded from `EXPECTED_EVENT_TYPES`:**
+`Announce(CaseLedgerEntry)` is the replication envelope: the mechanism by
+which the CaseActor broadcasts its canonical entries to participants. It
+cannot appear as the `payloadSnapshot` of a canonical entry because the
+snapshot is the protocol activity that *triggered* the entry, not the
+replication envelope that *delivers* it. Including it in `EXPECTED_EVENT_TYPES`
+for the case-actor log creates a circular requirement that can never be
+satisfied without corrupting the ledger.
+
+### Consequences
+
+- Good, because the delivery mechanism (ASGI self-delivery) is the same
+  trusted path already proven to work for case creation and status events.
+  No new infrastructure is needed.
+- Good, because the pre-flight guard keeps received-side use cases honest:
+  a use case that runs in a non-CaseActor inbox simply skips the commit step
+  instead of spoofing the CaseActor's identity.
+- Good, because the rule is symmetric with the existing "actor MUST NOT
+  spoof another actor's identity" pitfall and can be enforced structurally
+  (the BT's CASE_MANAGER role gate fires naturally once the activity arrives
+  at the right inbox).
+- Bad, because every trigger tree that currently omits an emit node needs
+  one added — this is a mechanical but non-trivial change spread across
+  multiple trees.
+- Bad, because received-side use cases that currently use the Option B
+  shortcut must have their shortcut removed and replaced with a strict
+  pre-flight guard, which is a semantics-changing fix that requires new
+  tests.
+
+## Validation
+
+- `specs/case-ledger-processing.yaml` CLP-10 codifies the requirements
+  from this ADR as MUST-level rules.
+- CI test `test_invariant_5_expected_event_types_present` (parameterized
+  per event type after issue #1026 implementation) is promoted from `xfail`
+  to a hard assertion for each event type as its routing gap is closed.
+- A grep-based test (CLP-09-002) asserts that no bare, unguarded commit
+  invocation exists outside the guarded-commit factory.
+
+## More Information
+
+- Issue #1026 — root-cause analysis and fix plan.
+- ADR-0018 — single-writer canonical ledger established.
+- ADR-0019 — content boundary of the canonical ledger established.
+- `notes/case-communication-model.md` — canonical communication flow,
+  including antipattern sections.
+- `specs/case-ledger-processing.yaml` CLP-09 — commit authorization and
+  coverage requirements that this ADR extends.
+- `specs/case-ledger-processing.yaml` CLP-10 — normative requirements
+  generated from this ADR.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -74,6 +74,8 @@ General information about architectural decision records is available at <https:
   `CaseLogEntry`](0018-canonical-case-history-convergence.md)
 - [ADR-0019 Separate the Case Ledger from the Per-Actor Process
   Log](0019-separate-case-ledger-from-process-log.md)
+- [ADR-0021 CaseActor Inbox Routing as the Sole Path to Canonical Ledger
+  Entries](0021-caseactor-inbox-routing-canonical-ledger.md)
 
 ## Proposed ADRs
 

--- a/notes/case-communication-model.md
+++ b/notes/case-communication-model.md
@@ -270,15 +270,85 @@ records that decision as a direct RM state update, without emitting a proxy
 
 ---
 
-## Known Implementation Gaps (as of 2026-06-10)
+## Antipattern: Received-Side Guarded Commit with Foreign CaseActor ID
+
+A subtler form of identity spoofing appears when a received-side use case
+resolves the CaseActor's ID from the DataLayer and then executes the
+guarded-commit BT under that foreign ID — even though the active DataLayer
+belongs to a different actor (e.g., the vendor actor). This was the pattern
+in `note.py` and `embargo.py` before ADR-0021 was established.
+
+```python
+# ❌ WRONG — resolves a foreign actor ID and runs BT under that identity
+case_actor_id = _find_case_actor_id(self._dl, case_id)   # foreign ID
+BTBridge(datalayer=self._dl).execute_with_setup(         # vendor's DL
+    tree=create_guarded_commit_case_ledger_entry_tree(case_id),
+    actor_id=case_actor_id,   # ← spoofed: vendor's DL, CaseActor's identity
+    ...
+)
+```
+
+The problem: `self._dl` is the **vendor actor's** DataLayer (since the use case
+is running in the vendor's inbox), but `actor_id=case_actor_id` causes the BT
+to emit `Announce(CaseLedgerEntry)` as if authored by the CaseActor. The
+outbox entry is queued under the wrong actor, and the CaseActor's canonical
+ledger never receives it.
+
+The correct pattern (from `status.py`'s `_commit_log_cascade_bt`) is a strict
+pre-flight guard that only proceeds when the receiving actor IS the CaseActor:
+
+```python
+# ✅ CORRECT — pre-flight guard; only commits when receiving actor IS CaseActor
+receiving_actor_id = request.receiving_actor_id
+case_actor_id = _find_case_actor_id(self._dl, case_id)
+
+if receiving_actor_id != case_actor_id:
+    return   # not the CaseActor — skip commit entirely
+
+# Now safe: receiving_actor_id == case_actor_id, so DL matches identity
+BTBridge(datalayer=self._dl).execute_with_setup(
+    tree=create_guarded_commit_case_ledger_entry_tree(case_id),
+    actor_id=receiving_actor_id,   # ← correct: same as active DL
+    ...
+)
+```
+
+The pre-flight guard is what makes the identity correct. When a non-CaseActor
+receives the same activity (relay copy to finder, vendor's own inbox), the
+guard fires and the commit is skipped. The CaseActor's own inbox delivery —
+which arrives because the trigger tree emitted to `case_manager_id`
+(CLP-10-001) — is the only path to a canonical write.
+
+### Why the `Announce(CaseLedgerEntry)` envelope is not a payload
+
+`Announce(CaseLedgerEntry)` is the replication wire envelope the CaseActor
+uses to broadcast canonical entries to participants (SYNC-02-002). It cannot
+appear as the `payloadSnapshot` of a canonical entry because the snapshot
+captures the protocol activity that *triggered* the entry, not the transport
+mechanism that *delivered* it. Think of it as a postcard (the protocol
+activity) placed inside a binder envelope (the `CaseLedgerEntry`) that is
+then mailed to all recipients (the `Announce` broadcast). The envelope is
+never its own contents.
+
+This is why `announce_case_ledger_entry` MUST NOT appear in
+`EXPECTED_EVENT_TYPES` for the canonical case-actor log (CLP-10-004).
+
+See ADR-0021 for the full decision record.
+
+---
+
+## Known Implementation Gaps (as of 2026-06-17)
 
 | Gap | Location | Status |
 |---|---|---|
-| Notes trigger sends to all participants | `triggers/note.py:102` | Open — tracked in impl issues |
-| Embargo triggers send to all participants | `triggers/embargo.py:399,472,589,657,773` | Open |
+| `validate_report` trigger tree: no emit to CaseActor | `behaviors/report/validate_tree.py` | Open — tracked in #1026 impl issues |
+| `ack_report` received UC: no guarded commit | `received/report.py` | Open — tracked in #1026 impl issues |
+| `close_case` received UC: no guarded commit | `received/case/lifecycle.py` | Open — tracked in #1026 impl issues |
+| `note.py` guarded commit: uses foreign actor ID | `received/note.py` | Open — tracked in #1026 impl issues |
+| `embargo.py` guarded commit: uses foreign actor ID | `received/embargo.py` | Open — tracked in #1026 impl issues |
+| Notes trigger sends to all participants | `triggers/note.py:102` | Open |
+| Embargo triggers send to all participants | `triggers/embargo.py` | Open |
 | Engage/defer-case triggers send to all participants | `triggers/case.py:84,132` | Open |
-| No sender-side BTs | All of the above | Open — BT refactor issue |
-| Auto CaseLedgerEntry cascade not wired to all received handlers | Multiple | Open |
 | Invite sent from case owner (not Case Actor); Accept routed to owner | `triggers/actor.py`, `received/actor.py` | Open — tracked in #893/#894 |
 
-See GitHub issues under parent concern #593.
+See GitHub issues under parent concern #593 and epic #788.

--- a/plan/history/2606/learning/CONCERN-1026.md
+++ b/plan/history/2606/learning/CONCERN-1026.md
@@ -1,0 +1,56 @@
+---
+source: CONCERN-1026
+timestamp: '2026-06-17T19:40:49.456633+00:00'
+title: CaseActor inbox routing as sole canonical ledger path
+type: learning
+---
+
+## Summary
+
+Most vendor-side trigger use cases and received use cases do not emit an
+outbound activity addressed to the CaseActor, so the CaseActor's canonical
+ledger never receives those events. The CASE_MANAGER gate added in #1021
+(PR #1024) correctly enforces single-writer authority — but this exposed that
+the delivery mechanism was never wired for most event types.
+
+## Root Cause
+
+The two-actor demo uses ASGI self-delivery: when the vendor creates a
+per-case `VultronCaseActor` sub-actor, activities addressed to that CaseActor
+ID are delivered via ASGI to the same vendor container's inbox, where they are
+dispatched with `actor_id = case_actor_id`. This mechanism works correctly —
+but only when vendor code explicitly emits an outbound activity addressed to
+`case_manager_id`.
+
+Before PR #1021, vendor code called `CommitCaseLedgerEntryNode` without a
+gate. It broadcast `Announce(CaseLedgerEntry)` to all participants including
+the CaseActor sub-actor. The CaseActor's local replica stored those received
+entries and the devlog appeared complete. The test was passing for the wrong
+reason. PR #1021's gate correctly blocked vendor commits — which correctly
+revealed that most events never actually reach the CaseActor's inbox at all.
+
+A subtler violation was found in `note.py` and `embargo.py`: both resolved
+`case_actor_id` from the DataLayer and passed it as `actor_id` to
+`BTBridge.execute_with_setup` even when the active DataLayer belonged to the
+vendor actor. This is identity spoofing — executing the guarded-commit BT
+with a foreign identity from the wrong DataLayer context.
+
+## Resolution
+
+ADR-0021 establishes that the CaseActor's inbox is the **only** correct path
+to a canonical ledger entry. The end-to-end routing contract is: trigger tree
+emits to `case_manager_id` → ASGI delivers to CaseActor inbox → received use
+case checks `receiving_actor_id == case_actor_id` pre-flight guard → guarded
+commit BT executes as the CaseActor. Received-side use cases that run in a
+non-CaseActor inbox skip the commit entirely.
+
+`announce_case_ledger_entry` is removed from `EXPECTED_EVENT_TYPES` because
+it is the replication envelope, not a canonical entry type — it cannot be its
+own payload.
+
+**Resolved**: 2026-06-17 — implementation tracked in #1029 (pilot: validate_report
+end-to-end + test parameterization) and #1030 (remaining event types + flip all
+xfails). #1030 blocked by #1029.
+Docs PR: [PR #1028](https://github.com/CERTCC/Vultron/pull/1028).
+Spec: `specs/case-ledger-processing.yaml` CLP-10-001 through CLP-10-004.
+Notes: `notes/case-communication-model.md` § "Antipattern: Received-Side Guarded Commit with Foreign CaseActor ID".

--- a/specs/case-ledger-processing.yaml
+++ b/specs/case-ledger-processing.yaml
@@ -349,3 +349,87 @@ groups:
       of bug that produced the original hash-chain fork in issue #923, and it
       recurs at every new dual-invocation call site unless authorization is
       re-evaluated per invocation rather than per use-case class.
+- id: CLP-10
+  title: CaseActor Inbox Routing for Canonical Ledger Entry Authorship
+  description: >-
+    Requirements for the end-to-end routing path that delivers protocol-significant
+    activities to the CaseActor's inbox so the CaseActor can author canonical ledger
+    entries. Normative requirements generated from ADR-0021.
+  specs:
+  - id: CLP-10-001
+    priority: MUST
+    statement: >-
+      Every protocol-significant trigger tree MUST emit at least one outbound
+      activity addressed to `case_manager_id` (the CaseActor's actor ID) so that
+      the CaseActor's inbox receives the activity and can author a canonical
+      ledger entry
+    rationale: >-
+      Before ADR-0021, several trigger trees (e.g., `validate_report`,
+      `ack_report`, `close_case`) emitted no activity addressed to the CaseActor.
+      The CaseActor therefore had no protocol event to commit, and the canonical
+      ledger was missing those event types entirely. The ASGI self-delivery
+      mechanism already handles routing when the target actor ID is the
+      CaseActor sub-actor for the same container; the missing piece was the
+      emit node itself.
+    verification: >-
+      For each entry in `EXPECTED_EVENT_TYPES`, a test verifies that the
+      CaseActor's canonical ledger contains at least one entry with that
+      `eventType` after a full two-actor demo run.
+  - id: CLP-10-002
+    priority: MUST
+    statement: >-
+      A received-side use case MUST include a pre-flight guard that compares
+      `receiving_actor_id` to `case_actor_id` before executing any canonical
+      ledger commit operation; if `receiving_actor_id != case_actor_id`, the
+      commit step MUST be skipped entirely
+    rationale: >-
+      The correct pattern (established in `status.py`'s `_commit_log_cascade_bt`)
+      is to commit only when the actor running the use case IS the CaseActor.
+      When a non-CaseActor inbox receives the same activity (e.g., a relay copy
+      to a finder), the use case runs but skips the commit. The CaseActor's own
+      inbox delivery (via CLP-10-001) is responsible for the canonical write.
+    verification: >-
+      Unit tests for each received-side use case that participates in ledger
+      authorship assert that `create_guarded_commit_case_ledger_entry_tree` (or
+      the BT bridge) is NOT called when `receiving_actor_id` differs from the
+      resolved `case_actor_id`.
+  - id: CLP-10-003
+    priority: MUST_NOT
+    statement: >-
+      A received-side use case MUST NOT execute a BT or call the canonical commit
+      operation with `actor_id` set to any actor other than `receiving_actor_id`;
+      resolving a foreign `case_actor_id` and passing it to
+      `BTBridge.execute_with_setup` from the wrong DataLayer context is an
+      identity-spoofing violation and MUST NOT occur
+    rationale: >-
+      `note.py` and `embargo.py` contained this exact violation before ADR-0021:
+      they resolved the CaseActor ID from the DataLayer and ran the guarded-commit
+      BT with `actor_id=case_actor_id` even when the active DataLayer belonged to
+      the vendor actor. This produced outbox entries attributed to the wrong actor
+      and caused hash-chain divergence. See AGENTS.md § "Received-Side Use Cases
+      MUST NOT Spoof Another Actor's Identity" for the general rule; CLP-10-003
+      is the specific application to the canonical ledger commit path.
+    verification: >-
+      A static grep check (or dedicated test) asserts that no received-side use
+      case module passes a separately resolved actor ID to
+      `BTBridge.execute_with_setup` — only `receiving_actor_id` (or a name
+      that is provably equal to it) may appear as the `actor_id` argument.
+  - id: CLP-10-004
+    priority: MUST_NOT
+    statement: >-
+      The `announce_case_ledger_entry` event type MUST NOT appear in
+      `EXPECTED_EVENT_TYPES` for the case-actor canonical log; `Announce(CaseLedgerEntry)`
+      is the replication envelope that carries canonical entries to participants
+      and cannot itself be a `payloadSnapshot` inside a canonical entry
+    rationale: >-
+      Including `announce_case_ledger_entry` in `EXPECTED_EVENT_TYPES` creates a
+      circular requirement: the CaseActor would need to commit a ledger entry
+      whose payload is the `Announce` activity used to broadcast ledger entries,
+      which is self-referential and unachievable without corrupting the hash chain.
+      The `Announce(CaseLedgerEntry)` wire envelope is a transport artifact, not a
+      protocol-significant domain event; it belongs to the SYNC replication layer
+      (SYNC-02-002), not the canonical ledger content layer.
+    verification: >-
+      `test_invariant_5_expected_event_types_present` (after parameterization)
+      does not include `announce_case_ledger_entry` as a required event type for
+      the case-actor replica.


### PR DESCRIPTION
- Closes #1026

## Summary

Establishes ADR-0021 formalizing that the CaseActor's inbox is the **only**
correct path to a canonical ledger entry. Adds CLP-10 spec requirements,
a new antipattern section in `notes/case-communication-model.md`,
and an AGENTS.md pitfall entry.

## Changes

- `docs/adr/0021-caseactor-inbox-routing-canonical-ledger.md` — new ADR
  documenting the routing contract, three options considered, and the
  reasons Option B (foreign actor ID delegation) is a violation
- `docs/adr/index.md` — ADR-0021 registered as accepted
- `specs/case-ledger-processing.yaml` — CLP-10 group (4 new requirements):
  CLP-10-001 (trigger trees MUST emit to CaseActor inbox),
  CLP-10-002 (received UCs MUST use pre-flight guard),
  CLP-10-003 (MUST NOT pass foreign actor_id to BTBridge),
  CLP-10-004 (announce_case_ledger_entry MUST NOT be in EXPECTED_EVENT_TYPES)
- `notes/case-communication-model.md` — new antipattern section for
  guarded commit with foreign CaseActor ID; updated Known Implementation
  Gaps table (dated 2026-06-17)
- `AGENTS.md` — new pitfall entry: Received-Side Guarded Commit MUST NOT
  Resolve a Foreign CaseActor ID (references ADR-0021, CLP-10-003)