### PR TITLE
ci: warm GHA buildx cache on main for demo-integration images

### DIFF
--- a/.github/actions/build-demo-images/action.yml
+++ b/.github/actions/build-demo-images/action.yml
@@ -1,0 +1,57 @@
+name: Build demo images
+description: >
+  Builds the demo-integration Docker images via `docker buildx bake` using
+  the GHA cache backend. Shared by demo-integration.yml (PR builds, which
+  also load the images for `docker compose up`) and
+  demo-image-cache-warm.yml (main-branch cache warming, which only needs to
+  populate the cache) so the bake invocation doesn't drift out of sync
+  between the two workflows.
+
+inputs:
+  cache-scope:
+    description: >
+      GHA cache scope to read from and write to. cache-to always writes
+      this scope with mode=max.
+    required: true
+  cache-from-extra-scope:
+    description: >
+      Optional additional GHA cache scope to read from as a fallback (never
+      written to). Used by PR builds to fall back to the cache warmed on
+      main when the PR branch has no cache of its own yet.
+    required: false
+    default: ""
+  load:
+    description: >
+      Whether to pass --load so built images are available to the Docker
+      daemon for a subsequent `docker compose up`. Set to "false" for
+      cache-warming-only builds.
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+    - name: Build Docker images
+      working-directory: docker
+      shell: bash
+      env:
+        CACHE_SCOPE: ${{ inputs.cache-scope }}
+        CACHE_FROM_EXTRA_SCOPE: ${{ inputs.cache-from-extra-scope }}
+        LOAD: ${{ inputs.load }}
+      run: |
+        args=(
+          --allow=fs.read=..
+          -f docker-compose-multi-actor.yml
+          --set "*.cache-from=type=gha,scope=${CACHE_SCOPE}"
+          --set "*.cache-to=type=gha,scope=${CACHE_SCOPE},mode=max"
+        )
+        if [[ -n "$CACHE_FROM_EXTRA_SCOPE" ]]; then
+          args+=(--set "*.cache-from=type=gha,scope=${CACHE_FROM_EXTRA_SCOPE}")
+        fi
+        if [[ "$LOAD" == "true" ]]; then
+          args+=(--load)
+        fi
+        docker buildx bake "${args[@]}"

--- a/.github/actions/setup-python-uv/action.yml
+++ b/.github/actions/setup-python-uv/action.yml
@@ -1,0 +1,35 @@
+name: Set up Python and uv
+description: >
+  Installs the pinned Python version, upgrades pip, installs uv, and runs
+  `uv sync`. Shared by every workflow that needs a Python + uv environment
+  (tests, linters, package build, docs build, GitHub Pages deploy, demo
+  invariant harness) so the setup steps don't drift out of sync across
+  workflow files.
+
+inputs:
+  python-version:
+    description: Python version to install.
+    required: false
+    default: "3.13"
+  uv-sync-args:
+    description: >
+      Arguments passed to `uv sync` (e.g. "--dev --frozen", "--dev",
+      "--no-dev").
+    required: false
+    default: "--dev --frozen"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install dependencies
+      shell: bash
+      env:
+        UV_SYNC_ARGS: ${{ inputs.uv-sync-args }}
+      run: |
+        python -m pip install --upgrade pip uv
+        uv sync $UV_SYNC_ARGS

--- a/.github/workflows/demo-image-cache-warm.yml
+++ b/.github/workflows/demo-image-cache-warm.yml
@@ -36,14 +36,8 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
-
       - name: Build and cache Docker images
-        working-directory: docker
-        run: |
-          docker buildx bake \
-            --allow=fs.read=.. \
-            -f docker-compose-multi-actor.yml \
-            --set "*.cache-from=type=gha,scope=demo-integration-main" \
-            --set "*.cache-to=type=gha,scope=demo-integration-main,mode=max"
+        uses: ./.github/actions/build-demo-images
+        with:
+          cache-scope: demo-integration-main
+          load: "false"

--- a/.github/workflows/demo-image-cache-warm.yml
+++ b/.github/workflows/demo-image-cache-warm.yml
@@ -1,0 +1,49 @@
+# Warms the GHA Buildx cache for the demo-integration Docker images on main.
+#
+# demo-integration.yml only runs on pull_request, so a cache it writes is
+# only visible to that same PR branch (GitHub Actions cache visibility
+# rules). Without a build on the default branch, every new PR branch starts
+# with a fully cold cache. This workflow builds the same bake targets on
+# push to main and exports their layers to the "demo-integration-main" GHA
+# cache scope, which demo-integration.yml reads as a fallback cache-from so
+# new PR branches get a warm start.
+#
+# This workflow never runs the demo or uploads images anywhere — it only
+# populates the cache.
+
+name: Demo Image Cache Warm
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "vultron/**"
+      - "docker/**"
+      - "pyproject.toml"
+      - "uv.lock"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: write  # needed for docker buildx bake cache-to: type=gha
+
+jobs:
+  warm-cache:
+    name: Warm Demo Image Cache
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+
+      - name: Build and cache Docker images
+        working-directory: docker
+        run: |
+          docker buildx bake \
+            --allow=fs.read=.. \
+            -f docker-compose-multi-actor.yml \
+            --set "*.cache-from=type=gha,scope=demo-integration-main" \
+            --set "*.cache-to=type=gha,scope=demo-integration-main,mode=max"

--- a/.github/workflows/demo-integration.yml
+++ b/.github/workflows/demo-integration.yml
@@ -37,35 +37,18 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      # DEMOCI-02-007: Docker layer caching to avoid rebuilding unchanged layers.
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
-
       # DEMOCI-02-007: Docker layer caching via Buildx GHA cache.
-      # docker buildx bake understands the compose file format and passes
-      # cache-from/cache-to through to BuildKit, which writes/reads the GHA
-      # cache natively.  --load ensures all built images are available to the
-      # docker daemon for the subsequent docker compose up step.
-      # Run from the docker/ directory so that context: .. resolves to the
-      # repo root and ../docker/Dockerfile resolves to docker/Dockerfile.
-      #
       # This workflow only triggers on pull_request, so a cache it writes
       # (scope=demo-integration) is only visible to that same PR branch —
       # GitHub Actions cache entries from a branch aren't visible to other
-      # branches. The second cache-from (scope=demo-integration-main) reads
-      # the cache written by demo-image-cache-warm.yml on pushes to main, so
-      # a brand-new PR branch still gets a warm cache instead of starting
-      # fully cold.
+      # branches. cache-from-extra-scope reads the cache written by
+      # demo-image-cache-warm.yml on pushes to main, so a brand-new PR
+      # branch still gets a warm cache instead of starting fully cold.
       - name: Build Docker images
-        working-directory: docker
-        run: |
-          docker buildx bake \
-            --allow=fs.read=.. \
-            -f docker-compose-multi-actor.yml \
-            --set "*.cache-from=type=gha,scope=demo-integration" \
-            --set "*.cache-from=type=gha,scope=demo-integration-main" \
-            --set "*.cache-to=type=gha,scope=demo-integration,mode=max" \
-            --load
+        uses: ./.github/actions/build-demo-images
+        with:
+          cache-scope: demo-integration
+          cache-from-extra-scope: demo-integration-main
 
       # DEMOCI-02-005, DEMOCI-02-006: run two-actor demo; detect failure via
       # exit code of the demo-runner container.
@@ -93,20 +76,13 @@ jobs:
       # Invariants not yet passing are marked xfail so the build stays green;
       # unexpected passes appear as XPASS (visible but not failing).
       # See test/ci/README-case-log-ratchet.md for the ratchet workflow.
-      - name: Set up Python for invariant harness
+      - name: Set up Python and uv for invariant harness
         if: always()
-        id: setup-python-invariants
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.13"
-
-      - name: Install dependencies for invariant harness
-        if: always() && steps.setup-python-invariants.outcome == 'success'
-        id: install-invariant-deps
-        run: python -m pip install --upgrade pip uv && uv sync --dev --frozen
+        id: setup-invariant-harness
+        uses: ./.github/actions/setup-python-uv
 
       - name: Run case-ledger invariant harness
-        if: always() && steps.install-invariant-deps.outcome == 'success'
+        if: always() && steps.setup-invariant-harness.outcome == 'success'
         run: uv run pytest -m case_ledger_invariants -v --tb=short
 
       # DEMOCI-02-008: collect combined stream and per-service logs on failure.

--- a/.github/workflows/demo-integration.yml
+++ b/.github/workflows/demo-integration.yml
@@ -48,14 +48,23 @@ jobs:
       # docker daemon for the subsequent docker compose up step.
       # Run from the docker/ directory so that context: .. resolves to the
       # repo root and ../docker/Dockerfile resolves to docker/Dockerfile.
+      #
+      # This workflow only triggers on pull_request, so a cache it writes
+      # (scope=demo-integration) is only visible to that same PR branch —
+      # GitHub Actions cache entries from a branch aren't visible to other
+      # branches. The second cache-from (scope=demo-integration-main) reads
+      # the cache written by demo-image-cache-warm.yml on pushes to main, so
+      # a brand-new PR branch still gets a warm cache instead of starting
+      # fully cold.
       - name: Build Docker images
         working-directory: docker
         run: |
           docker buildx bake \
             --allow=fs.read=.. \
             -f docker-compose-multi-actor.yml \
-            --set "*.cache-from=type=gha" \
-            --set "*.cache-to=type=gha,mode=max" \
+            --set "*.cache-from=type=gha,scope=demo-integration" \
+            --set "*.cache-from=type=gha,scope=demo-integration-main" \
+            --set "*.cache-to=type=gha,scope=demo-integration,mode=max" \
             --load
 
       # DEMOCI-02-005, DEMOCI-02-006: run two-actor demo; detect failure via

--- a/.github/workflows/deploy_site.yml
+++ b/.github/workflows/deploy_site.yml
@@ -35,15 +35,10 @@ jobs:
           fetch-depth: 50
           fetch-tags: true
 
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - name: Set up Python and uv
+        uses: ./.github/actions/setup-python-uv
         with:
-          python-version: '3.13'
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip uv
-          uv sync --no-dev
+          uv-sync-args: "--no-dev"
 
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0

--- a/.github/workflows/docs-build-check.yml
+++ b/.github/workflows/docs-build-check.yml
@@ -42,15 +42,10 @@ jobs:
             echo "docs_changed=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - name: Set up Python and uv
+        uses: ./.github/actions/setup-python-uv
         with:
-          python-version: '3.13'
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip uv
-          uv sync --dev
+          uv-sync-args: "--dev"
 
       - name: Build Site
         run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -39,14 +39,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-tags: true
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.13"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip uv
-          uv sync --dev --frozen
+      - name: Set up Python and uv
+        uses: ./.github/actions/setup-python-uv
       - name: Run full pytest suite
         run: uv run pytest -m "" --tb=short
 
@@ -57,14 +51,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.13"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip uv
-          uv sync --dev --frozen
+      - name: Set up Python and uv
+        uses: ./.github/actions/setup-python-uv
       - name: Check formatting with black
         run: uv run black --check vultron/ test/
 
@@ -73,14 +61,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.13"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip uv
-          uv sync --dev --frozen
+      - name: Set up Python and uv
+        uses: ./.github/actions/setup-python-uv
       - name: Lint with flake8
         run: uv run flake8 vultron/ test/
 
@@ -89,14 +71,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.13"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip uv
-          uv sync --dev --frozen
+      - name: Set up Python and uv
+        uses: ./.github/actions/setup-python-uv
       - name: Type-check with mypy
         run: uv run mypy
 
@@ -105,14 +81,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.13"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip uv
-          uv sync --dev --frozen
+      - name: Set up Python and uv
+        uses: ./.github/actions/setup-python-uv
       - name: Type-check with pyright
         run: uv run pyright
 
@@ -125,14 +95,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-tags: true
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.13"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip uv
-          uv sync --dev --frozen
+      - name: Set up Python and uv
+        uses: ./.github/actions/setup-python-uv
       - name: Build package
         run: uv build
       - name: Upload Artifacts

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,14 +14,16 @@ FROM base AS dependencies
 # application source does not bust the dependency-install cache.
 # Only a change to pyproject.toml or uv.lock triggers a re-install.
 COPY pyproject.toml uv.lock /app/
-RUN uv sync --frozen --no-install-project
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-install-project
 
 # Copy the full application source and install the project package
 # (including console-script entry points such as vultron-demo).
 # Code-only changes only bust this layer, not the dependency layer above.
 COPY . /app/
 ENV PYTHONPATH=/app
-RUN uv sync --frozen
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen
 
 FROM dependencies AS test
 # Install pytest and dev dependencies

--- a/specs/ci-security.yaml
+++ b/specs/ci-security.yaml
@@ -12,8 +12,10 @@ groups:
   specs:
   - id: CISEC-01-001
     priority: MUST
-    statement: All `uses:` references in `.github/workflows/*.yml` MUST be pinned to a specific commit SHA rather than a version
-      tag or branch name
+    statement: All `uses:` references to third-party or external actions in `.github/workflows/*.yml` MUST be pinned to a
+      specific commit SHA rather than a version tag or branch name. Local path references to actions within this repository
+      (e.g. `./.github/actions/<name>`) are exempt — they are already pinned to the commit being checked out and have no
+      separate tag/release lifecycle to pin against
   - id: CISEC-01-002
     priority: MUST
     statement: Each SHA-pinned `uses:` reference MUST carry an inline comment identifying the corresponding human-readable

--- a/test/ci/test_workflow_sha_pinning.py
+++ b/test/ci/test_workflow_sha_pinning.py
@@ -1,10 +1,15 @@
 """CI security tests — verify GitHub Actions SHA pinning.
 
 Implements CISEC-01-001 and CISEC-01-002 from specs/ci-security.yaml:
-- Every `uses:` line in .github/workflows/*.yml MUST reference a full
-  40-character commit SHA (not a mutable tag or branch name).
+- Every `uses:` line in .github/workflows/*.yml referencing a third-party or
+  external action MUST reference a full 40-character commit SHA (not a
+  mutable tag or branch name).
 - Every SHA-pinned line MUST carry an inline human-readable version comment
   (e.g., ``# v4.1.0``).
+
+Local actions (``uses: ./.github/actions/<name>``) are exempt: they are
+already pinned to the commit being checked out and have no separate
+tag/release lifecycle to pin against.
 """
 
 import re
@@ -23,13 +28,21 @@ _VERSION_COMMENT_RE = re.compile(r"#\s*\S+")
 
 
 def _uses_lines(workflow_path: Path) -> list[tuple[int, str]]:
-    """Return (line_number, stripped_line) pairs for every ``uses:`` line."""
+    """Return (line_number, stripped_line) pairs for every ``uses:`` line.
+
+    Local action references (``uses: ./...``) are excluded — they're pinned
+    to the checked-out commit by definition and have no separate tag/release
+    lifecycle for CISEC-01-001/002 to apply to.
+    """
     lines = []
     for lineno, raw in enumerate(
         workflow_path.read_text().splitlines(), start=1
     ):
         stripped = raw.strip()
         if stripped.startswith("uses:") or re.match(r"^-\s+uses:", stripped):
+            uses_match = re.search(r"uses:\s*(\S+)", stripped)
+            if uses_match and uses_match.group(1).startswith("./"):
+                continue
             lines.append((lineno, stripped))
     return lines
 


### PR DESCRIPTION
- closes #1035

## Summary
- `demo-integration.yml` only triggers on `pull_request`, so its GHA buildx cache is only visible to the branch that wrote it (GitHub Actions cache entries aren't shared across branches except via the default branch). With nothing ever building on `main`, every new PR branch started fully cold — likely the main reason "Build Docker images" consistently took ~2 minutes per push.
- Added `demo-image-cache-warm.yml`, which builds the same images on push to `main` and exports their layers to a `demo-integration-main` GHA cache scope.
- `demo-integration.yml`'s build step now reads both its own branch scope and the new `demo-integration-main` fallback scope, so fresh PR branches get a warm start.
- Added `--mount=type=cache,target=/root/.cache/uv` to the two `uv sync` steps in `docker/Dockerfile` so dependency installs stay fast even when the Docker layer cache itself misses (e.g. on `uv.lock` changes).
- Extracted two patterns duplicated across workflow files into composite actions, since `demo-image-cache-warm.yml` would otherwise have introduced a third copy of the Docker bake step:
  - `.github/actions/setup-python-uv` — the "set up Python, install uv, run `uv sync`" sequence that was repeated 8 times across `python-app.yml` (6 jobs), `docs-build-check.yml`, `deploy_site.yml`, and `demo-integration.yml`'s invariant harness, differing only in `uv sync` flags (now a `uv-sync-args` input).
  - `.github/actions/build-demo-images` — the `docker buildx bake` build step shared by `demo-integration.yml` and `demo-image-cache-warm.yml`, differing only in cache scope and whether `--load` is needed (now `cache-scope`, `cache-from-extra-scope`, and `load` inputs).
- Fixed `test_workflow_sha_pinning.py` (CISEC-01-001/002), which failed CI on the new `uses: ./.github/actions/...` lines. SHA-pinning exists to guard against third-party action tampering; it doesn't apply to local same-repo actions, which are already pinned to the checked-out commit. Excluded `./`-prefixed `uses:` references from the check and clarified the spec statement's scope in `specs/ci-security.yaml`.

## Test plan
- [x] Validated all workflow and composite action YAML files parse correctly
- [x] Dry-ran `docker buildx bake --print` for both the PR-side and cache-warm bake commands to confirm cache-from/cache-to scopes apply to all targets as expected
- [x] Built the `api-dev` target locally with the updated Dockerfile to confirm the cache-mount changes don't break the build
- [x] `uv run pytest test/ci/test_workflow_sha_pinning.py` passes (39/39) after exempting local action references
- [ ] After merge: confirm `Demo Image Cache Warm` runs on the push to main and populates the `demo-integration-main` scope
- [ ] Open a fresh PR touching `vultron/**` afterward and confirm the "Build Docker images" step is faster than the ~2 minute baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)