### PR TITLE
fix: replace foreign-actor commit with single-BT pattern in RemoveEmbargoEventFromCaseReceivedUseCase (CLP-10-003)

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -245,3 +245,14 @@ hook (default `{}`) to `SvcBTTriggerBase`; classes whose BTs need extra
 blackboard keys override it. The return type must be `dict[str, Any]` (not
 `dict[str, object]`) to satisfy mypy when the dict is spread into
 `execute_with_setup`'s `**context_data: Any` parameter.
+
+### 2026-06-18 REMOVE-EMBARGO-1033 — single-BT pattern requires receiving_actor_id in all callers
+
+Switching `RemoveEmbargoEventFromCaseReceivedUseCase` from two `execute_with_setup`
+calls to a single call with `actor_id=receiving_actor_id` exposed that several
+existing tests called `make_payload(activity)` without specifying
+`receiving_actor_id`. With the new guard, a `None` `receiving_actor_id` returns
+early and the BT never runs. Pattern: any test for a received-side use case that
+exercises BT operations MUST pass a `receiving_actor_id` in `make_payload`. Tests
+that don't need the guarded commit to fire can use the sender actor as the
+`receiving_actor_id` — `CheckIsCaseManagerNode` will reject it silently.

--- a/plan/history/2606/implementation/ISSUE-1033.md
+++ b/plan/history/2606/implementation/ISSUE-1033.md
@@ -1,0 +1,32 @@
+---
+source: ISSUE-1033
+timestamp: '2026-06-18T14:33:41.323798+00:00'
+title: 'Fix RemoveEmbargoEventFromCaseReceivedUseCase: single-BT pattern (CLP-10-003)'
+type: implementation
+---
+
+## Issue #1033 — Fix RemoveEmbargoEventFromCaseReceivedUseCase: replace foreign-actor commit with pre-flight guard (CLP-10-003)
+
+Replaced the CLP-10-003-violating pattern (resolving CaseActor ID and passing
+it as `actor_id` to a second `execute_with_setup` call) with the correct
+single-BT approach:
+
+- `remove_embargo_from_case_tree` restructured to embed the guarded commit as
+  the final child of the outer Sequence. A new `TeardownIfActive`
+  Selector(Sequence, Success) absorbs the FAILURE from `IsActiveEmbargoNode`
+  when the embargo was only in `proposed_embargoes`, so the commit step is
+  always reached.
+- `RemoveEmbargoEventFromCaseReceivedUseCase.execute()` now makes a single
+  `execute_with_setup` call with `actor_id=receiving_actor_id`. An explicit
+  `None` guard handles missing `receiving_actor_id`. `CheckIsCaseManagerNode`
+  inside the tree provides the role-based gate — no identity comparison in
+  Python.
+- `TestRemoveEmbargoRoutingGuard` (2 new tests) added to
+  `test_embargo_routing_guard.py`.
+- 4 existing `test_embargo.py` tests updated to pass `receiving_actor_id` in
+  `make_payload` calls (previously omitted, which would now skip the BT).
+- Filed #1038 to track the same fix for `InviteToEmbargoOnCaseReceivedUseCase`
+  and `AcceptInviteToEmbargoOnCaseReceivedUseCase` (more complex because those
+  trees need a different `actor_id` for main ops vs. the commit).
+
+PR: [#1037](https://github.com/CERTCC/Vultron/pull/1037)

--- a/test/core/use_cases/received/test_embargo.py
+++ b/test/core/use_cases/received/test_embargo.py
@@ -496,7 +496,9 @@ class TestEmbargoUseCases:
             origin=case,
             actor="https://example.org/users/coord",
         )
-        event = make_payload(activity)
+        event = make_payload(
+            activity, receiving_actor_id="https://example.org/users/coord"
+        )
 
         RemoveEmbargoEventFromCaseReceivedUseCase(dl, event).execute()
 
@@ -540,7 +542,9 @@ class TestEmbargoUseCases:
             origin=case,
             actor="https://example.org/users/coord",
         )
-        event = make_payload(activity)
+        event = make_payload(
+            activity, receiving_actor_id="https://example.org/users/coord"
+        )
 
         RemoveEmbargoEventFromCaseReceivedUseCase(dl, event).execute()
 
@@ -582,7 +586,9 @@ class TestEmbargoUseCases:
             origin=case,
             actor="https://example.org/users/coord",
         )
-        event = make_payload(activity)
+        event = make_payload(
+            activity, receiving_actor_id="https://example.org/users/coord"
+        )
 
         RemoveEmbargoEventFromCaseReceivedUseCase(dl, event).execute()
 
@@ -1116,7 +1122,7 @@ class TestResetEmbargoConsentWithInlineParticipants:
             origin=case,
             actor=actor_id,
         )
-        event = make_payload(activity)
+        event = make_payload(activity, receiving_actor_id=actor_id)
 
         # Must not raise TypeError
         RemoveEmbargoEventFromCaseReceivedUseCase(dl, event).execute()

--- a/test/core/use_cases/received/test_embargo_routing_guard.py
+++ b/test/core/use_cases/received/test_embargo_routing_guard.py
@@ -32,10 +32,12 @@ from vultron.core.states.roles import CVDRole
 from vultron.core.use_cases.received.embargo import (
     AcceptInviteToEmbargoOnCaseReceivedUseCase,
     InviteToEmbargoOnCaseReceivedUseCase,
+    RemoveEmbargoEventFromCaseReceivedUseCase,
 )
 from vultron.wire.as2.factories import (
     em_accept_embargo_activity,
     em_propose_embargo_activity,
+    remove_embargo_from_case_activity,
 )
 from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
 from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
@@ -258,5 +260,96 @@ class TestAcceptInviteToEmbargoRoutingGuard:
         event_types = _ledger_event_types(dl)
         assert "accept_invite_to_embargo_on_case" not in event_types, (
             "Non-CaseActor must NOT write an accept_invite_to_embargo_on_case"
+            f" ledger entry; found: {event_types}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: RemoveEmbargoEventFromCaseReceivedUseCase
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveEmbargoRoutingGuard:
+    """Pre-flight guard for RemoveEmbargoEventFromCaseReceivedUseCase.
+
+    The guarded commit is embedded in ``remove_embargo_from_case_tree`` and
+    runs via the single ``execute_with_setup`` call with
+    ``actor_id=receiving_actor_id``.  ``CheckIsCaseManagerNode`` inside the
+    tree fires only when that actor holds ``CVDRole.CASE_MANAGER``.
+    """
+
+    AUTHOR_ID = "https://example.org/actors/coord-remove"
+    CASE_ID = "https://example.org/cases/c-remove-em"
+    CASE_ACTOR_ID = f"{CASE_ID}/actor"
+    OTHER_ACTOR_ID = "https://example.org/actors/vendor-remove"
+
+    def _setup(
+        self,
+    ) -> tuple[
+        SqliteDataLayer, VultronCaseActor, VulnerabilityCase, EmbargoEvent
+    ]:
+        dl, case_actor, case, embargo = _make_embargo_case(
+            self.CASE_ID, self.AUTHOR_ID, self.CASE_ACTOR_ID
+        )
+        # Add embargo to proposed list so the BT removal step succeeds.
+        read_case = dl.read(case.id_)
+        assert read_case is not None
+        case = cast(VulnerabilityCase, read_case)
+        case.proposed_embargoes.append(embargo.id_)
+        dl.save(case)
+        return dl, case_actor, case, embargo
+
+    def test_caseactor_commits_remove_embargo_ledger_entry(self, make_payload):
+        """Guarded commit fires when receiving_actor_id == case_actor_id.
+
+        Per CLP-10-002: the CaseActor MUST commit a canonical ledger entry.
+        """
+        dl, case_actor, case, embargo = self._setup()
+
+        remove_activity = remove_embargo_from_case_activity(
+            embargo,
+            origin=self.CASE_ID,
+            actor=self.AUTHOR_ID,
+        )
+
+        event = make_payload(
+            remove_activity, receiving_actor_id=self.CASE_ACTOR_ID
+        )
+        RemoveEmbargoEventFromCaseReceivedUseCase(
+            dl, event, sync_port=SyncActivityAdapter(dl)
+        ).execute()
+
+        event_types = _ledger_event_types(dl)
+        assert "remove_embargo_event_from_case" in event_types, (
+            "Expected CaseLedgerEntry with"
+            " event_type='remove_embargo_event_from_case';"
+            f" found: {event_types}"
+        )
+
+    def test_non_caseactor_does_not_commit_remove_embargo_ledger_entry(
+        self, make_payload
+    ):
+        """Guarded commit does NOT fire when receiving_actor_id != case_actor_id.
+
+        Per CLP-10-003: non-CaseActor receiving actors must skip the commit.
+        """
+        dl, case_actor, case, embargo = self._setup()
+
+        remove_activity = remove_embargo_from_case_activity(
+            embargo,
+            origin=self.CASE_ID,
+            actor=self.AUTHOR_ID,
+        )
+
+        event = make_payload(
+            remove_activity, receiving_actor_id=self.OTHER_ACTOR_ID
+        )
+        RemoveEmbargoEventFromCaseReceivedUseCase(
+            dl, event, sync_port=SyncActivityAdapter(dl)
+        ).execute()
+
+        event_types = _ledger_event_types(dl)
+        assert "remove_embargo_event_from_case" not in event_types, (
+            "Non-CaseActor must NOT write a remove_embargo_event_from_case"
             f" ledger entry; found: {event_types}"
         )

--- a/vultron/core/behaviors/embargo/announce_teardown_tree.py
+++ b/vultron/core/behaviors/embargo/announce_teardown_tree.py
@@ -24,8 +24,12 @@ activity (protocol ET message).  Sequence:
     RemoveEmbargoFromCaseBT (Sequence)
     ├─ ValidateCaseExistsNode          # case must exist and pass is_case_model
     ├─ RemoveFromProposedEmbargoesNode # idempotent proposed-list cleanup
-    ├─ IsActiveEmbargoNode             # guard: is this the active embargo?
-    └─ ApplyEmbargoTeardownNode        # ACTIVE/REVISE→EXITED, clear, reset PEC
+    ├─ TeardownIfActive (Selector)     # run teardown if active; skip silently
+    │  ├─ ActiveTeardown (Sequence)
+    │  │  ├─ IsActiveEmbargoNode       # guard: is this the active embargo?
+    │  │  └─ ApplyEmbargoTeardownNode  # ACTIVE/REVISE→EXITED, clear, reset PEC
+    │  └─ Success                      # embargo was only in proposed — not an error
+    └─ GuardedCommitCaseLedgerEntryBT  # commit only when actor is CASE_MANAGER
 
 Per specs/behavior-tree-integration.yaml BT-06-001.
 """
@@ -64,10 +68,16 @@ def remove_embargo_from_case_tree(
     embargo from ``proposed_embargoes`` (idempotent) and, if the embargo is
     the active one, applies the ACTIVE/REVISE → EXITED EM state transition,
     clears ``active_embargo``, and resets participant embargo consent states.
+    Always commits a canonical ledger entry when the executing actor holds
+    the ``CASE_MANAGER`` role (via the guarded commit subtree).
 
-    BT returns SUCCESS when the active embargo is terminated.
-    BT returns FAILURE when the embargo was only in ``proposed_embargoes``
-    (the cleanup still runs — FAILURE is not an error condition here).
+    The inner ``TeardownIfActive`` Selector absorbs the FAILURE that occurs
+    when the embargo was only in ``proposed_embargoes`` (not the active
+    embargo), so the outer Sequence always reaches the guarded commit step.
+
+    BT returns SUCCESS when the outer Sequence completes (including when the
+    embargo was only proposed and no teardown was needed).
+    BT returns FAILURE only when the case is not found.
 
     Args:
         case_id: ID of the VulnerabilityCase to update.
@@ -84,8 +94,24 @@ def remove_embargo_from_case_tree(
             RemoveFromProposedEmbargoesNode(
                 case_id=case_id, embargo_id=embargo_id
             ),
-            IsActiveEmbargoNode(case_id=case_id, embargo_id=embargo_id),
-            ApplyEmbargoTeardownNode(case_id=case_id),
+            py_trees.composites.Selector(
+                name="TeardownIfActive",
+                memory=False,
+                children=[
+                    py_trees.composites.Sequence(
+                        name="ActiveTeardown",
+                        memory=False,
+                        children=[
+                            IsActiveEmbargoNode(
+                                case_id=case_id, embargo_id=embargo_id
+                            ),
+                            ApplyEmbargoTeardownNode(case_id=case_id),
+                        ],
+                    ),
+                    py_trees.behaviours.Success(name="EmbargoWasNotActive"),
+                ],
+            ),
+            create_guarded_commit_case_ledger_entry_tree(case_id=case_id),
         ],
     )
     logger.info(

--- a/vultron/core/use_cases/received/embargo.py
+++ b/vultron/core/use_cases/received/embargo.py
@@ -156,46 +156,36 @@ class RemoveEmbargoEventFromCaseReceivedUseCase:
             )
             return
 
+        receiving_actor_id = request.receiving_actor_id
+        if receiving_actor_id is None:
+            logger.debug(
+                "remove_embargo_from_case: missing receiving_actor_id"
+                " — skipping"
+            )
+            return
+
+        # The tree embeds the guarded commit as its final step (ADR-0021,
+        # CLP-10-002, CLP-10-003).  Running it with actor_id=receiving_actor_id
+        # means CheckIsCaseManagerNode naturally fires only when the receiving
+        # actor holds the CASE_MANAGER role — no identity comparison in Python.
         tree = remove_embargo_from_case_tree(
             case_id=case_id, embargo_id=embargo_id
         )
         bridge = BTBridge(datalayer=self._dl)
         result = bridge.execute_with_setup(
             tree=tree,
-            actor_id=request.actor_id,
+            actor_id=receiving_actor_id,
             activity=request,
             sync_port=self._sync_port,
         )
 
         if result.status != Status.SUCCESS:
             logger.debug(
-                "remove_embargo_from_case: BT did not fully succeed for"
-                " embargo '%s' on case '%s' (msg: '%s') — embargo may have"
-                " been in proposed_embargoes only",
+                "remove_embargo_from_case: BT did not succeed for"
+                " embargo '%s' on case '%s' (msg: '%s')",
                 embargo_id,
                 case_id,
                 result.feedback_message,
-            )
-
-        # Always commit a log entry regardless of BT result.  FAILURE means
-        # the embargo was already cleared or only in proposed_embargoes —
-        # both are non-error outcomes that still require fan-out (PCR-08-003).
-        from vultron.core.behaviors.case.nodes import (
-            create_guarded_commit_case_ledger_entry_tree,
-        )
-        from vultron.core.use_cases.received.actor import _find_case_actor_id
-
-        commit_actor_id = _find_case_actor_id(self._dl, case_id)
-        if commit_actor_id is None:
-            commit_actor_id = request.receiving_actor_id
-        if commit_actor_id is not None:
-            BTBridge(datalayer=self._dl).execute_with_setup(
-                tree=create_guarded_commit_case_ledger_entry_tree(
-                    case_id=case_id
-                ),
-                actor_id=commit_actor_id,
-                activity=request,
-                sync_port=self._sync_port,
             )
 
 


### PR DESCRIPTION
- Closes #1033

## Summary

Fixes the CLP-10-003 violation in `RemoveEmbargoEventFromCaseReceivedUseCase` by embedding the guarded commit inside `remove_embargo_from_case_tree` and using a single `execute_with_setup` call with `actor_id=receiving_actor_id`. `CheckIsCaseManagerNode` inside the tree provides the role-based gate — no foreign-actor identity resolution in Python.

## Changes

- `vultron/core/behaviors/embargo/announce_teardown_tree.py`: restructure `remove_embargo_from_case_tree` — wrap `IsActiveEmbargoNode + ApplyEmbargoTeardownNode` in a `TeardownIfActive` Selector(Sequence, Success) so the outer Sequence always reaches the embedded `create_guarded_commit_case_ledger_entry_tree` even when the embargo was only in `proposed_embargoes`
- `vultron/core/use_cases/received/embargo.py`: single `execute_with_setup` call with `actor_id=receiving_actor_id`; add explicit `None` guard; remove all inline identity-comparison code
- `test/core/use_cases/received/test_embargo_routing_guard.py`: add `TestRemoveEmbargoRoutingGuard` (2 tests: CaseActor commits, non-CaseActor skips)
- `test/core/use_cases/received/test_embargo.py`: update 4 existing tests to pass `receiving_actor_id` in `make_payload` calls

## Verification

- 3505 passed, 38 skipped, 2 xfailed (0 new failures)
- Black, flake8, mypy, pyright clean