### PR TITLE
feat: shared fail-fast peer broadcast BT helper (BT-14-001, BT-14-002)

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -256,3 +256,16 @@ early and the BT never runs. Pattern: any test for a received-side use case that
 exercises BT operations MUST pass a `receiving_actor_id` in `make_payload`. Tests
 that don't need the guarded commit to fire can use the sender actor as the
 `receiving_actor_id` — `CheckIsCaseManagerNode` will reject it silently.
+
+### 2026-06-18 BROADCAST-834-STALE-BLACKBOARD — clear broadcast_activity_id sentinel on no-op path
+
+`py_trees.blackboard.Blackboard.storage` is process-global and
+`execute_with_setup` only cleans `datalayer` and `trigger_activity_factory`
+keys on exit — it does NOT clean domain-specific keys like `broadcast_*`.
+When `CreateBroadcastActivityNode` takes the no-op path (empty recipient
+list), it must write `None` to `broadcast_activity_id` to clear any stale
+value from a prior execution.  `BroadcastQueueToOutboxNode` must treat both
+`KeyError` (first-ever run) and `None` (cleared by prior no-op) as equivalent
+no-op sentinels and skip `record_outbox_item`.  Always add regression tests
+that intentionally do NOT clear the blackboard between two `execute_with_setup`
+calls to catch this class of bug.

--- a/plan/history/2606/implementation/ISSUE-834.md
+++ b/plan/history/2606/implementation/ISSUE-834.md
@@ -1,0 +1,36 @@
+---
+source: ISSUE-834
+timestamp: '2026-06-18T16:19:13.499032+00:00'
+title: Shared fail-fast peer broadcast BT helper
+type: implementation
+---
+
+## Issue #834 — Implement shared fail-fast peer broadcast helper for BT fan-out
+
+Introduced `vultron/core/behaviors/broadcast/` — a new package providing
+reusable, fail-fast BT leaf nodes and a `peer_broadcast_bt()` factory for all
+protocol-visible peer fan-out subtrees (BT-14-001, BT-14-002).
+
+### What was built
+
+- `FindCaseManagerNode`, `FilterPeerRecipientsNode`,
+  `CreateBroadcastActivityNode`, `BroadcastQueueToOutboxNode` leaf nodes
+  with a documented blackboard contract
+- `peer_broadcast_bt()` factory — builds a plain `memory=False` Sequence
+  with no guaranteed-SUCCESS fallback; FAILURE propagates on broadcast
+  preparation or outbox enqueue errors
+- `BroadcastStatusToPeersNode` refactored to delegate to the shared nodes,
+  replacing the old `Selector+Success` anti-pattern
+- `CreateStatusBroadcastActivityNode` fixed with missing empty-list guard
+  (previously called factory with `to=[]` when no peers remained)
+- Stale-blackboard regression fix: `CreateBroadcastActivityNode` now writes
+  `None` sentinel on the no-op path so `BroadcastQueueToOutboxNode` does not
+  re-enqueue a previous execution's activity
+
+### Tests
+
+3 new regression tests added; all 3519 unit tests pass.
+
+### PR
+
+[PR #1040](https://github.com/CERTCC/Vultron/pull/1040)

--- a/test/core/behaviors/broadcast/test_peer_broadcast_bt.py
+++ b/test/core/behaviors/broadcast/test_peer_broadcast_bt.py
@@ -568,6 +568,62 @@ class TestPeerBroadcastBt:
         assert result.status == Status.FAILURE
         builder.assert_not_called()
 
+    def test_no_stale_activity_reenqueued_on_noop_second_run(
+        self, populated_dl
+    ):
+        """Regression: stale broadcast_activity_id must not be re-enqueued.
+
+        If a first run writes broadcast_activity_id to the process-global
+        blackboard, then a second run finds an empty recipient list, the no-op
+        path must clear/sentinel the key so BroadcastQueueToOutboxNode does not
+        re-enqueue the stale activity.  The blackboard is intentionally NOT
+        cleared between the two execute_with_setup calls in this test.
+        """
+        mock_factory = MagicMock()
+        mock_factory.deliver.return_value = "urn:uuid:broadcast-stale"
+
+        def builder(factory, cm_id, recipient_ids):
+            return factory.deliver(actor=cm_id, to=recipient_ids)
+
+        bridge = BTBridge(
+            datalayer=populated_dl, trigger_activity=mock_factory
+        )
+        enqueue_calls: list = []
+        original_record = populated_dl.record_outbox_item
+
+        def _counting_record(*args, **kwargs):
+            enqueue_calls.append(args)
+            return original_record(*args, **kwargs)
+
+        populated_dl.record_outbox_item = _counting_record  # type: ignore[method-assign]
+
+        # First run: peer exists → activity created and enqueued once.
+        tree1 = self._make_bt(builder)
+        result1 = bridge.execute_with_setup(
+            tree=tree1, actor_id=CASE_MANAGER_ID
+        )
+        assert result1.status == Status.SUCCESS
+        assert len(enqueue_calls) == 1, "first run should enqueue exactly once"
+
+        # Remove peer: recipient list becomes empty for the second run.
+        # The blackboard is NOT cleared — broadcast_activity_id retains the
+        # stale value from run 1.
+        case = populated_dl.read(CASE_ID)
+        del case.actor_participant_index[PEER_ID]
+        populated_dl.save(case)
+
+        # Second run: no recipients → no-op → stale activity must NOT be
+        # re-enqueued (BT-14-001 fix for process-global blackboard leakage).
+        tree2 = self._make_bt(builder)
+        result2 = bridge.execute_with_setup(
+            tree=tree2, actor_id=CASE_MANAGER_ID
+        )
+        assert result2.status == Status.SUCCESS
+        assert len(enqueue_calls) == 1, (
+            "stale broadcast_activity_id must not be re-enqueued on "
+            "no-op second run"
+        )
+
     def test_no_guaranteed_success_fallback(self, populated_dl):
         """Verify there is no Selector+Success anti-pattern (BT-14-001).
 

--- a/test/core/behaviors/broadcast/test_peer_broadcast_bt.py
+++ b/test/core/behaviors/broadcast/test_peer_broadcast_bt.py
@@ -1,0 +1,587 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Unit tests for the shared fail-fast peer broadcast helper (BT-14-001, BT-14-002).
+
+Covers:
+- :func:`~vultron.core.behaviors.broadcast.nodes._find_case_manager_id`
+- :class:`~vultron.core.behaviors.broadcast.nodes.FindCaseManagerNode`
+- :class:`~vultron.core.behaviors.broadcast.nodes.FilterPeerRecipientsNode`
+- :class:`~vultron.core.behaviors.broadcast.nodes.CreateBroadcastActivityNode`
+- :class:`~vultron.core.behaviors.broadcast.nodes.BroadcastQueueToOutboxNode`
+- :func:`~vultron.core.behaviors.broadcast.peer_broadcast_tree.peer_broadcast_bt`
+
+Per specs/behavior-tree-integration.yaml BT-14-001, BT-14-002.
+"""
+
+from unittest.mock import MagicMock
+
+import py_trees
+import pytest
+from py_trees.common import Status
+
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.core.behaviors.bridge import BTBridge
+from vultron.core.behaviors.broadcast.nodes import (
+    BroadcastQueueToOutboxNode,
+    CreateBroadcastActivityNode,
+    FilterPeerRecipientsNode,
+    FindCaseManagerNode,
+    _find_case_manager_id,
+)
+from vultron.core.behaviors.broadcast.peer_broadcast_tree import (
+    peer_broadcast_bt,
+)
+from vultron.core.states.roles import CVDRole
+from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+ACTOR_ID = "https://example.org/actors/vendor"
+CASE_MANAGER_ID = "https://example.org/actors/case-actor"
+PEER_ID = "https://example.org/actors/peer"
+SECOND_PEER_ID = "https://example.org/actors/peer2"
+CASE_ID = "https://example.org/cases/case-01"
+PARTICIPANT_ID = "https://example.org/cases/case-01/participants/vendor"
+CM_PARTICIPANT_ID = "https://example.org/cases/case-01/participants/case-actor"
+PEER_PARTICIPANT_ID = "https://example.org/cases/case-01/participants/peer"
+SECOND_PEER_PARTICIPANT_ID = (
+    "https://example.org/cases/case-01/participants/peer2"
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_blackboard():
+    py_trees.blackboard.Blackboard.storage.clear()
+    yield
+    py_trees.blackboard.Blackboard.storage.clear()
+
+
+@pytest.fixture
+def dl():
+    return SqliteDataLayer("sqlite:///:memory:")
+
+
+@pytest.fixture
+def bridge(dl):
+    return BTBridge(datalayer=dl)
+
+
+@pytest.fixture
+def vendor_participant():
+    return CaseParticipant(
+        id_=PARTICIPANT_ID,
+        context=CASE_ID,
+        attributed_to=ACTOR_ID,
+        case_roles=[CVDRole.CASE_OWNER],
+    )
+
+
+@pytest.fixture
+def case_manager_participant():
+    return CaseParticipant(
+        id_=CM_PARTICIPANT_ID,
+        context=CASE_ID,
+        attributed_to=CASE_MANAGER_ID,
+        case_roles=[CVDRole.CASE_MANAGER],
+    )
+
+
+@pytest.fixture
+def peer_participant():
+    return CaseParticipant(
+        id_=PEER_PARTICIPANT_ID,
+        context=CASE_ID,
+        attributed_to=PEER_ID,
+        case_roles=[CVDRole.COORDINATOR],
+    )
+
+
+@pytest.fixture
+def case_with_peers(
+    vendor_participant, case_manager_participant, peer_participant
+):
+    obj = VulnerabilityCase(id_=CASE_ID, name="Test Case")
+    obj.add_participant(vendor_participant)
+    obj.add_participant(case_manager_participant)
+    obj.add_participant(peer_participant)
+    return obj
+
+
+@pytest.fixture
+def populated_dl(
+    dl,
+    case_with_peers,
+    vendor_participant,
+    case_manager_participant,
+    peer_participant,
+):
+    dl.create(case_with_peers)
+    dl.create(vendor_participant)
+    dl.create(case_manager_participant)
+    dl.create(peer_participant)
+    return dl
+
+
+@pytest.fixture
+def populated_bridge(populated_dl):
+    return BTBridge(datalayer=populated_dl)
+
+
+# ---------------------------------------------------------------------------
+# _find_case_manager_id helper
+# ---------------------------------------------------------------------------
+
+
+class TestFindCaseManagerIdHelper:
+    def test_finds_case_manager(self, populated_dl, case_with_peers):
+        result = _find_case_manager_id(populated_dl, case_with_peers)
+        assert result == CASE_MANAGER_ID
+
+    def test_returns_none_when_no_case_manager(self, dl):
+        case = VulnerabilityCase(id_=CASE_ID, name="Test Case")
+        p = CaseParticipant(
+            id_=PARTICIPANT_ID,
+            context=CASE_ID,
+            attributed_to=ACTOR_ID,
+            case_roles=[CVDRole.CASE_OWNER],
+        )
+        case.add_participant(p)
+        dl.create(case)
+        dl.create(p)
+        result = _find_case_manager_id(dl, case)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# FindCaseManagerNode
+# ---------------------------------------------------------------------------
+
+
+class TestFindCaseManagerNode:
+    def test_success_writes_blackboard(self, populated_bridge):
+        node = FindCaseManagerNode(case_id=CASE_ID)
+        result = populated_bridge.execute_with_setup(
+            tree=node, actor_id=ACTOR_ID
+        )
+        assert result.status == Status.SUCCESS
+        assert (
+            py_trees.blackboard.Blackboard.storage[
+                "/broadcast_case_manager_id"
+            ]
+            == CASE_MANAGER_ID
+        )
+
+    def test_none_case_id_fails(self, populated_bridge):
+        node = FindCaseManagerNode(case_id=None)
+        result = populated_bridge.execute_with_setup(
+            tree=node, actor_id=ACTOR_ID
+        )
+        assert result.status == Status.FAILURE
+
+    def test_missing_case_fails(self, bridge):
+        node = FindCaseManagerNode(case_id="https://example.org/cases/missing")
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+        assert result.status == Status.FAILURE
+
+    def test_no_case_manager_participant_fails(self, dl):
+        case = VulnerabilityCase(id_=CASE_ID, name="No CM")
+        p = CaseParticipant(
+            id_=PARTICIPANT_ID,
+            context=CASE_ID,
+            attributed_to=ACTOR_ID,
+            case_roles=[CVDRole.CASE_OWNER],
+        )
+        case.actor_participant_index[ACTOR_ID] = PARTICIPANT_ID
+        dl.create(case)
+        dl.create(p)
+        b = BTBridge(datalayer=dl)
+        node = FindCaseManagerNode(case_id=CASE_ID)
+        result = b.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+        assert result.status == Status.FAILURE
+
+
+# ---------------------------------------------------------------------------
+# FilterPeerRecipientsNode
+# ---------------------------------------------------------------------------
+
+
+class TestFilterPeerRecipientsNode:
+    def _run_find_then_filter(
+        self,
+        dl,
+        actor_id,
+        sender_actor_id=ACTOR_ID,
+        case_id=CASE_ID,
+    ):
+        seq = py_trees.composites.Sequence(
+            name="TestSeq",
+            memory=False,
+            children=[
+                FindCaseManagerNode(case_id=CASE_ID),
+                FilterPeerRecipientsNode(
+                    sender_actor_id=sender_actor_id,
+                    case_id=case_id,
+                ),
+            ],
+        )
+        b = BTBridge(datalayer=dl)
+        return b.execute_with_setup(tree=seq, actor_id=actor_id)
+
+    def test_success_with_eligible_peer(self, populated_dl):
+        result = self._run_find_then_filter(
+            populated_dl,
+            actor_id=CASE_MANAGER_ID,
+            sender_actor_id=ACTOR_ID,
+        )
+        assert result.status == Status.SUCCESS
+        assert py_trees.blackboard.Blackboard.storage[
+            "/broadcast_peer_recipient_ids"
+        ] == [PEER_ID]
+
+    def test_success_with_empty_list_when_no_eligible_recipients(
+        self, populated_dl
+    ):
+        """No peers after filtering → empty list, SUCCESS (no-op, BT-14-001)."""
+        # Remove PEER from the case so only vendor+CM remain
+        case = populated_dl.read(CASE_ID)
+        del case.actor_participant_index[PEER_ID]
+        populated_dl.save(case)
+        result = self._run_find_then_filter(
+            populated_dl,
+            actor_id=CASE_MANAGER_ID,
+            sender_actor_id=ACTOR_ID,
+        )
+        assert result.status == Status.SUCCESS
+        assert (
+            py_trees.blackboard.Blackboard.storage[
+                "/broadcast_peer_recipient_ids"
+            ]
+            == []
+        )
+
+    def test_fails_on_missing_case(self, populated_dl):
+        result = self._run_find_then_filter(
+            populated_dl,
+            actor_id=CASE_MANAGER_ID,
+            case_id="https://example.org/cases/missing",
+        )
+        assert result.status == Status.FAILURE
+
+    def test_excludes_sender(self, populated_dl):
+        """Sender is excluded from recipient list."""
+        result = self._run_find_then_filter(
+            populated_dl,
+            actor_id=CASE_MANAGER_ID,
+            sender_actor_id=PEER_ID,
+        )
+        # ACTOR_ID is not sender, not self (CASE_MANAGER_ID), not CM
+        assert result.status == Status.SUCCESS
+        assert py_trees.blackboard.Blackboard.storage[
+            "/broadcast_peer_recipient_ids"
+        ] == [ACTOR_ID]
+
+    def test_excludes_self(self, populated_dl):
+        """Executing actor is excluded from recipients; empty list → SUCCESS."""
+        result = self._run_find_then_filter(
+            populated_dl,
+            actor_id=PEER_ID,
+            sender_actor_id=ACTOR_ID,
+        )
+        assert result.status == Status.SUCCESS
+        assert (
+            py_trees.blackboard.Blackboard.storage[
+                "/broadcast_peer_recipient_ids"
+            ]
+            == []
+        )
+
+
+# ---------------------------------------------------------------------------
+# CreateBroadcastActivityNode
+# ---------------------------------------------------------------------------
+
+
+class TestCreateBroadcastActivityNode:
+    def _make_seq(self, activity_builder, sender_actor_id=ACTOR_ID):
+        return py_trees.composites.Sequence(
+            name="TestSeq",
+            memory=False,
+            children=[
+                FindCaseManagerNode(case_id=CASE_ID),
+                FilterPeerRecipientsNode(
+                    sender_actor_id=sender_actor_id, case_id=CASE_ID
+                ),
+                CreateBroadcastActivityNode(activity_builder=activity_builder),
+            ],
+        )
+
+    def test_success_calls_builder_with_correct_args(self, populated_dl):
+        mock_factory = MagicMock()
+        mock_factory.some_method.return_value = "urn:uuid:activity-1"
+
+        def builder(factory, cm_id, recipient_ids):
+            return factory.some_method(actor=cm_id, to=recipient_ids)
+
+        bridge = BTBridge(
+            datalayer=populated_dl, trigger_activity=mock_factory
+        )
+        result = bridge.execute_with_setup(
+            tree=self._make_seq(builder), actor_id=CASE_MANAGER_ID
+        )
+        assert result.status == Status.SUCCESS
+        mock_factory.some_method.assert_called_once_with(
+            actor=CASE_MANAGER_ID, to=[PEER_ID]
+        )
+        assert (
+            py_trees.blackboard.Blackboard.storage["/broadcast_activity_id"]
+            == "urn:uuid:activity-1"
+        )
+
+    def test_failure_when_no_factory_and_recipients_exist(
+        self, populated_bridge
+    ):
+        """Recipients exist but no factory → FAILURE (BT-14-001)."""
+        builder = MagicMock()
+
+        result = populated_bridge.execute_with_setup(
+            tree=self._make_seq(builder), actor_id=CASE_MANAGER_ID
+        )
+        assert result.status == Status.FAILURE
+        builder.assert_not_called()
+
+    def test_success_skips_builder_when_empty_recipients(self, populated_dl):
+        """No eligible recipients → SUCCESS without calling builder."""
+        case = populated_dl.read(CASE_ID)
+        del case.actor_participant_index[PEER_ID]
+        populated_dl.save(case)
+
+        builder = MagicMock()
+        bridge = BTBridge(datalayer=populated_dl)
+        result = bridge.execute_with_setup(
+            tree=self._make_seq(builder), actor_id=CASE_MANAGER_ID
+        )
+        assert result.status == Status.SUCCESS
+        builder.assert_not_called()
+
+    def test_failure_on_vultron_error_from_builder(self, populated_dl):
+        from vultron.errors import VultronError
+
+        mock_factory = MagicMock()
+        mock_factory.some_method.side_effect = VultronError("factory failure")
+
+        def builder(factory, cm_id, recipient_ids):
+            return factory.some_method(actor=cm_id, to=recipient_ids)
+
+        bridge = BTBridge(
+            datalayer=populated_dl, trigger_activity=mock_factory
+        )
+        result = bridge.execute_with_setup(
+            tree=self._make_seq(builder), actor_id=CASE_MANAGER_ID
+        )
+        assert result.status == Status.FAILURE
+
+
+# ---------------------------------------------------------------------------
+# BroadcastQueueToOutboxNode
+# ---------------------------------------------------------------------------
+
+
+class TestBroadcastQueueToOutboxNode:
+    def _run_full_seq(self, dl, actor_id, factory=None):
+        mock_factory = factory or MagicMock()
+        if factory is None:
+            mock_factory.some_method.return_value = "urn:uuid:activity-1"
+
+        def builder(f, cm_id, recipient_ids):
+            return f.some_method(actor=cm_id, to=recipient_ids)
+
+        seq = py_trees.composites.Sequence(
+            name="TestSeq",
+            memory=False,
+            children=[
+                FindCaseManagerNode(case_id=CASE_ID),
+                FilterPeerRecipientsNode(
+                    sender_actor_id=ACTOR_ID, case_id=CASE_ID
+                ),
+                CreateBroadcastActivityNode(activity_builder=builder),
+                BroadcastQueueToOutboxNode(),
+            ],
+        )
+        bridge = BTBridge(datalayer=dl, trigger_activity=mock_factory)
+        return bridge.execute_with_setup(tree=seq, actor_id=actor_id)
+
+    def test_full_sequence_success(self, populated_dl):
+        result = self._run_full_seq(populated_dl, actor_id=CASE_MANAGER_ID)
+        assert result.status == Status.SUCCESS
+
+    def test_success_skips_when_no_activity_id(self, populated_dl):
+        """No broadcast_activity_id on blackboard → no-op SUCCESS (BT-14-001)."""
+        node = BroadcastQueueToOutboxNode()
+        # We need broadcast_case_manager_id to be set but no activity_id
+        # Pre-populate only the case_manager key via FindCaseManagerNode
+        seq = py_trees.composites.Sequence(
+            name="TestSeq",
+            memory=False,
+            children=[
+                FindCaseManagerNode(case_id=CASE_ID),
+                node,
+            ],
+        )
+        bridge = BTBridge(datalayer=populated_dl)
+        result = bridge.execute_with_setup(tree=seq, actor_id=CASE_MANAGER_ID)
+        # broadcast_peer_recipient_ids is missing → FAILURE on that key
+        # Actually BroadcastQueueToOutboxNode tries broadcast_activity_id first,
+        # gets KeyError → SUCCESS (no-op).  Then tries recipient_ids → KeyError
+        # but we only test that the no-activity-id path exits SUCCESS.
+        # The actual status depends on whether recipient_ids key exists.
+        # We just confirm the node handles missing broadcast_activity_id.
+        assert result.status == Status.SUCCESS
+
+    def test_failure_when_case_manager_id_missing(self, dl):
+        """No broadcast_case_manager_id in blackboard → FAILURE."""
+        node = BroadcastQueueToOutboxNode()
+        bridge = BTBridge(datalayer=dl)
+        result = bridge.execute_with_setup(tree=node, actor_id=CASE_MANAGER_ID)
+        assert result.status == Status.FAILURE
+
+
+# ---------------------------------------------------------------------------
+# peer_broadcast_bt integration
+# ---------------------------------------------------------------------------
+
+
+class TestPeerBroadcastBt:
+    def _make_bt(
+        self,
+        activity_builder,
+        sender_actor_id: str = ACTOR_ID,
+        case_id: str | None = CASE_ID,
+    ):
+        return peer_broadcast_bt(
+            case_id=case_id,
+            sender_actor_id=sender_actor_id,
+            activity_builder=activity_builder,
+        )
+
+    def test_success_end_to_end(self, populated_dl):
+        """Full happy-path: factory called, activity queued. (BT-14-002)"""
+        mock_factory = MagicMock()
+        mock_factory.deliver.return_value = "urn:uuid:broadcast-1"
+
+        def builder(factory, cm_id, recipient_ids):
+            return factory.deliver(actor=cm_id, to=recipient_ids)
+
+        bridge = BTBridge(
+            datalayer=populated_dl, trigger_activity=mock_factory
+        )
+        tree = self._make_bt(builder)
+        result = bridge.execute_with_setup(tree=tree, actor_id=CASE_MANAGER_ID)
+        assert result.status == Status.SUCCESS
+        mock_factory.deliver.assert_called_once_with(
+            actor=CASE_MANAGER_ID, to=[PEER_ID]
+        )
+
+    def test_failure_when_no_case_manager(self, dl):
+        """No CASE_MANAGER in case → FAILURE (BT-14-001)."""
+        case = VulnerabilityCase(id_=CASE_ID, name="No CM")
+        p = CaseParticipant(
+            id_=PARTICIPANT_ID,
+            context=CASE_ID,
+            attributed_to=ACTOR_ID,
+            case_roles=[CVDRole.CASE_OWNER],
+        )
+        case.actor_participant_index[ACTOR_ID] = PARTICIPANT_ID
+        dl.create(case)
+        dl.create(p)
+        builder = MagicMock()
+        bridge = BTBridge(datalayer=dl)
+        tree = self._make_bt(builder)
+        result = bridge.execute_with_setup(tree=tree, actor_id=ACTOR_ID)
+        assert result.status == Status.FAILURE
+        builder.assert_not_called()
+
+    def test_failure_when_factory_unavailable_and_recipients_exist(
+        self, populated_bridge
+    ):
+        """Recipients exist but no factory → FAILURE (BT-14-001)."""
+        builder = MagicMock()
+        tree = self._make_bt(builder)
+        result = populated_bridge.execute_with_setup(
+            tree=tree, actor_id=CASE_MANAGER_ID
+        )
+        assert result.status == Status.FAILURE
+        builder.assert_not_called()
+
+    def test_failure_when_factory_raises_vultron_error(self, populated_dl):
+        """Factory raises VultronError → FAILURE (BT-14-001)."""
+        from vultron.errors import VultronError
+
+        mock_factory = MagicMock()
+        mock_factory.deliver.side_effect = VultronError("delivery error")
+
+        def builder(factory, cm_id, recipient_ids):
+            return factory.deliver(actor=cm_id, to=recipient_ids)
+
+        bridge = BTBridge(
+            datalayer=populated_dl, trigger_activity=mock_factory
+        )
+        tree = self._make_bt(builder)
+        result = bridge.execute_with_setup(tree=tree, actor_id=CASE_MANAGER_ID)
+        assert result.status == Status.FAILURE
+
+    def test_success_when_no_eligible_recipients(self, populated_dl):
+        """No peers after filtering → empty list → SUCCESS (no-op, BT-14-001)."""
+        case = populated_dl.read(CASE_ID)
+        del case.actor_participant_index[PEER_ID]
+        populated_dl.save(case)
+
+        builder = MagicMock()
+        bridge = BTBridge(datalayer=populated_dl)
+        tree = self._make_bt(builder)
+        result = bridge.execute_with_setup(tree=tree, actor_id=CASE_MANAGER_ID)
+        assert result.status == Status.SUCCESS
+        builder.assert_not_called()
+
+    def test_failure_when_none_case_id(self, populated_bridge):
+        """case_id=None → FindCaseManagerNode FAILURE (BT-14-001)."""
+        builder = MagicMock()
+        tree = self._make_bt(builder, case_id=None)
+        result = populated_bridge.execute_with_setup(
+            tree=tree, actor_id=CASE_MANAGER_ID
+        )
+        assert result.status == Status.FAILURE
+        builder.assert_not_called()
+
+    def test_no_guaranteed_success_fallback(self, populated_dl):
+        """Verify there is no Selector+Success anti-pattern (BT-14-001).
+
+        A plain Sequence must propagate FAILURE; if a Selector-with-Success
+        were present, the tree would return SUCCESS even when the factory is
+        unavailable.  This test confirms the FAILURE is NOT masked.
+        """
+        builder = MagicMock()
+        # populated_dl has a peer, so the factory WILL be called — but we
+        # have no factory → FAILURE must propagate to the root.
+        bridge = BTBridge(datalayer=populated_dl)
+        tree = self._make_bt(builder)
+        result = bridge.execute_with_setup(tree=tree, actor_id=CASE_MANAGER_ID)
+        assert result.status == Status.FAILURE, (
+            "peer_broadcast_bt must NOT have a guaranteed-SUCCESS fallback "
+            "(BT-14-001): got SUCCESS when factory was unavailable"
+        )

--- a/test/core/behaviors/status/nodes/test_broadcast.py
+++ b/test/core/behaviors/status/nodes/test_broadcast.py
@@ -30,6 +30,7 @@ from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.status.nodes.broadcast import (
     BroadcastStatusToPeersNode,
+    CreateStatusBroadcastActivityNode,
     FilterPeerRecipientsNode,
     FindCaseManagerNode,
     _find_case_manager_id,
@@ -231,5 +232,79 @@ class TestBroadcastStatusToPeersNode:
         )
         result = populated_bridge.execute_with_setup(
             tree=node, actor_id=CASE_MANAGER_ID
+        )
+        assert result.status == Status.FAILURE
+
+
+# ---------------------------------------------------------------------------
+# CreateStatusBroadcastActivityNode
+# ---------------------------------------------------------------------------
+
+
+class TestCreateStatusBroadcastActivityNode:
+    def _run_with_prefilled_blackboard(
+        self,
+        dl,
+        actor_id: str,
+        recipient_ids: list,
+        factory=None,
+    ):
+        """Populate blackboard via FindCaseManagerNode+FilterPeerRecipientsNode,
+        then run CreateStatusBroadcastActivityNode."""
+        import py_trees as pt
+
+        node = CreateStatusBroadcastActivityNode(
+            status_id=STATUS_ID,
+            participant_id=PARTICIPANT_REF_ID,
+        )
+        seq = pt.composites.Sequence(
+            name="TestSeq",
+            memory=False,
+            children=[
+                FindCaseManagerNode(case_id=CASE_ID),
+                FilterPeerRecipientsNode(
+                    sender_actor_id=ACTOR_ID, case_id=CASE_ID
+                ),
+                node,
+            ],
+        )
+        bridge = BTBridge(datalayer=dl, trigger_activity=factory)
+        return bridge.execute_with_setup(tree=seq, actor_id=actor_id)
+
+    def test_returns_success_skips_factory_when_no_recipients(
+        self, populated_dl
+    ):
+        """Empty recipient list after filtering → SUCCESS without calling factory.
+
+        Regression for the missing empty-list guard: previously,
+        CreateStatusBroadcastActivityNode would call the factory with to=[].
+        """
+        from unittest.mock import MagicMock
+
+        # Remove the peer so FilterPeerRecipientsNode writes an empty list.
+        case = populated_dl.read(CASE_ID)
+        del case.actor_participant_index[PEER_ID]
+        populated_dl.save(case)
+
+        mock_factory = MagicMock()
+        result = self._run_with_prefilled_blackboard(
+            populated_dl,
+            actor_id=CASE_MANAGER_ID,
+            recipient_ids=[],
+            factory=mock_factory,
+        )
+        assert result.status == Status.SUCCESS
+        # Factory must not be called for an empty recipient list.
+        mock_factory.add_participant_status_to_participant.assert_not_called()
+
+    def test_returns_failure_when_no_factory_and_recipients_exist(
+        self, populated_dl
+    ):
+        """Recipients exist but no factory → FAILURE (BT-14-001)."""
+        result = self._run_with_prefilled_blackboard(
+            populated_dl,
+            actor_id=CASE_MANAGER_ID,
+            recipient_ids=[PEER_ID],
+            factory=None,
         )
         assert result.status == Status.FAILURE

--- a/test/core/behaviors/status/nodes/test_broadcast.py
+++ b/test/core/behaviors/status/nodes/test_broadcast.py
@@ -221,8 +221,8 @@ class TestFilterPeerRecipientsNode:
 
 
 class TestBroadcastStatusToPeersNode:
-    def test_always_succeeds_without_factory(self, populated_bridge):
-        """Broadcast skips gracefully when no trigger_activity_factory."""
+    def test_returns_failure_without_factory(self, populated_bridge):
+        """No trigger_activity_factory → FAILURE (BT-14-001)."""
         node = BroadcastStatusToPeersNode(
             status_id=STATUS_ID,
             participant_id=PARTICIPANT_REF_ID,
@@ -232,4 +232,4 @@ class TestBroadcastStatusToPeersNode:
         result = populated_bridge.execute_with_setup(
             tree=node, actor_id=CASE_MANAGER_ID
         )
-        assert result.status == Status.SUCCESS
+        assert result.status == Status.FAILURE

--- a/test/core/behaviors/status/test_add_participant_status_bt.py
+++ b/test/core/behaviors/status/test_add_participant_status_bt.py
@@ -18,7 +18,8 @@
 Covers all five DEMOMA-07-003 steps:
   1. VerifySenderIsParticipantNode — unknown sender is rejected
   2. AppendParticipantStatusNode  — status appended, RM regression rejected
-  3. BroadcastStatusToPeersNode   — always SUCCESS, skips without trigger_activity
+  3. BroadcastStatusToPeersNode   — fail-fast (BT-14-001): FAILURE when no
+     factory or delivery fails; SUCCESS when no peers to notify (no-op)
   4. PublicDisclosureBranchNode   — always SUCCESS, only triggers teardown on CS.P + CASE_OWNER
   5. AutoCloseBranchNode          — always SUCCESS, logs when all RM.CLOSED
 
@@ -647,8 +648,32 @@ class TestAppendParticipantStatusSubtree:
 
 
 class TestBroadcastStatusToPeersNode:
-    def test_skips_without_trigger_activity(self, populated_bridge):
-        """No trigger_activity → returns SUCCESS silently."""
+    def test_returns_failure_without_trigger_activity(
+        self, populated_dl_with_peer
+    ):
+        """No trigger_activity_factory → FAILURE (BT-14-001).
+
+        Case has a peer recipient, so FilterPeerRecipientsNode returns
+        SUCCESS with a non-empty list.  CreateBroadcastActivityNode then
+        fails because no factory is available.
+        """
+        bridge = BTBridge(datalayer=populated_dl_with_peer)
+        node = BroadcastStatusToPeersNode(
+            status_id=STATUS_ID,
+            participant_id=PARTICIPANT_ID,
+            sender_actor_id=ACTOR_ID,
+            case_id=CASE_ID,
+        )
+        result = bridge.execute_with_setup(tree=node, actor_id=CASE_MANAGER_ID)
+        assert result.status == Status.FAILURE
+
+    def test_returns_success_when_no_peer_recipients(self, populated_bridge):
+        """No peer recipients (only vendor + Case Manager) → SUCCESS (no-op).
+
+        When the recipient list is empty after filtering, broadcast is not
+        needed and the whole subtree returns SUCCESS so downstream steps
+        (PublicDisclosureBranchNode, AutoCloseBranchNode) can still run.
+        """
         node = BroadcastStatusToPeersNode(
             status_id=STATUS_ID,
             participant_id=PARTICIPANT_ID,
@@ -660,8 +685,8 @@ class TestBroadcastStatusToPeersNode:
         )
         assert result.status == Status.SUCCESS
 
-    def test_always_succeeds(self, bridge):
-        """Even with no DataLayer data, BroadcastStatusToPeers succeeds."""
+    def test_returns_failure_without_datalayer_data(self, bridge):
+        """case_id=None → FindCaseManagerNode FAILURE propagates (BT-14-001)."""
         node = BroadcastStatusToPeersNode(
             status_id=STATUS_ID,
             participant_id=PARTICIPANT_ID,
@@ -669,7 +694,7 @@ class TestBroadcastStatusToPeersNode:
             case_id=None,
         )
         result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
-        assert result.status == Status.SUCCESS
+        assert result.status == Status.FAILURE
 
     def test_skips_when_current_actor_is_the_only_peer(self, populated_dl):
         trigger_activity = MagicMock()
@@ -854,14 +879,22 @@ class TestFilterPeerRecipientsNode:
         result = bridge.execute_with_setup(tree=seq, actor_id=CASE_MANAGER_ID)
         assert result.status == Status.FAILURE
 
-    def test_returns_failure_when_no_eligible_recipients(self, populated_dl):
-        """Only vendor and Case Manager in case → no peers after filtering."""
+    def test_returns_success_with_empty_list_when_no_eligible_recipients(
+        self, populated_dl
+    ):
+        """Only vendor and Case Manager in case → empty list, SUCCESS (no-op)."""
         result = self._run_find_then_filter(
             populated_dl,
             actor_id=CASE_MANAGER_ID,
             sender_actor_id=ACTOR_ID,
         )
-        assert result.status == Status.FAILURE
+        assert result.status == Status.SUCCESS
+        assert (
+            py_trees.blackboard.Blackboard.storage[
+                "/broadcast_peer_recipient_ids"
+            ]
+            == []
+        )
 
     def test_returns_success_with_eligible_peer(self, populated_dl_with_peer):
         """Third peer exists and is not sender/self/manager → SUCCESS."""
@@ -889,14 +922,22 @@ class TestFilterPeerRecipientsNode:
             "/broadcast_peer_recipient_ids"
         ] == [ACTOR_ID]
 
-    def test_excludes_self_from_recipients(self, populated_dl_with_peer):
-        """Actor running as the peer → peer excluded from recipient list."""
+    def test_excludes_self_from_recipients_empty_list(
+        self, populated_dl_with_peer
+    ):
+        """Actor running as the peer → peer excluded; empty list → SUCCESS (no-op)."""
         result = self._run_find_then_filter(
             populated_dl_with_peer,
             actor_id=PEER_ACTOR_ID,
             sender_actor_id=ACTOR_ID,
         )
-        assert result.status == Status.FAILURE
+        assert result.status == Status.SUCCESS
+        assert (
+            py_trees.blackboard.Blackboard.storage[
+                "/broadcast_peer_recipient_ids"
+            ]
+            == []
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/test/core/use_cases/received/test_status.py
+++ b/test/core/use_cases/received/test_status.py
@@ -22,6 +22,7 @@ from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
 from vultron.core.models.protocols import is_log_entry_model
 from vultron.core.states.em import EM
 from vultron.core.states.rm import RM
+from vultron.core.states.roles import CVDRole
 from vultron.core.use_cases.received.status import (
     AddCaseStatusToCaseReceivedUseCase,
     AddParticipantStatusToParticipantReceivedUseCase,
@@ -310,6 +311,10 @@ class TestParticipantStatusLogEntryCascade:
         )
         case.case_participants.append(f"{case_id}/participants/p1")
         case.actor_participant_index[actor_id] = f"{case_id}/participants/p1"
+        # Add Case Manager participant so FindCaseManagerNode can succeed.
+        cm_participant_id = f"{case_id}/participants/cm"
+        case.case_participants.append(cm_participant_id)
+        case.actor_participant_index[case_actor_id] = cm_participant_id
         dl.create(case)
 
         case_manager_participant = CaseParticipant(
@@ -326,6 +331,14 @@ class TestParticipantStatusLogEntryCascade:
             attributed_to=actor_id,
         )
         dl.create(participant)
+
+        cm_participant = CaseParticipant(
+            id_=cm_participant_id,
+            context=case_id,
+            attributed_to=case_actor_id,
+            case_roles=[CVDRole.CASE_MANAGER],
+        )
+        dl.create(cm_participant)
 
         pstatus = ParticipantStatus(
             id_=f"{case_id}/participants/p1/statuses/s1",
@@ -558,6 +571,8 @@ class TestParticipantStatusLogEntryCascade:
         self, make_payload
     ) -> None:
         """Stored snapshot keeps asserter actor and announce payload is identical."""
+        from unittest.mock import MagicMock
+
         from vultron.wire.as2.enums import as_TransitiveActivityType
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
             VulnerabilityCase,
@@ -589,8 +604,17 @@ class TestParticipantStatusLogEntryCascade:
             context=case,
         )
         event = make_payload(activity, receiving_actor_id=case_actor_id)
+        # Supply a trigger_activity mock so BroadcastStatusToPeersNode can
+        # succeed (BT-14-001: FAILURE when factory absent and peers exist).
+        mock_trigger = MagicMock()
+        mock_trigger.add_participant_status_to_participant.return_value = (
+            "urn:uuid:broadcast-1"
+        )
         AddParticipantStatusToParticipantReceivedUseCase(
-            dl, event, sync_port=SyncActivityAdapter(dl)
+            dl,
+            event,
+            trigger_activity=mock_trigger,
+            sync_port=SyncActivityAdapter(dl),
         ).execute()
 
         entries = [

--- a/test/core/use_cases/received/test_status.py
+++ b/test/core/use_cases/received/test_status.py
@@ -22,7 +22,6 @@ from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
 from vultron.core.models.protocols import is_log_entry_model
 from vultron.core.states.em import EM
 from vultron.core.states.rm import RM
-from vultron.core.states.roles import CVDRole
 from vultron.core.use_cases.received.status import (
     AddCaseStatusToCaseReceivedUseCase,
     AddParticipantStatusToParticipantReceivedUseCase,

--- a/vultron/core/behaviors/broadcast/__init__.py
+++ b/vultron/core/behaviors/broadcast/__init__.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Shared peer-broadcast BT helper package (BT-14-001, BT-14-002).
+
+Provides reusable leaf nodes and a :func:`peer_broadcast_bt` factory for
+all protocol-visible peer fan-out subtrees.  Callers that used the old
+status-domain ``BroadcastStatusToPeersNode`` directly can continue to do
+so — it now delegates internally to :func:`peer_broadcast_bt`.
+"""
+
+from vultron.core.behaviors.broadcast.nodes import (
+    BroadcastQueueToOutboxNode,
+    CreateBroadcastActivityNode,
+    FilterPeerRecipientsNode,
+    FindCaseManagerNode,
+    _find_case_manager_id,
+)
+from vultron.core.behaviors.broadcast.peer_broadcast_tree import (
+    peer_broadcast_bt,
+)
+
+__all__ = [
+    "_find_case_manager_id",
+    "FindCaseManagerNode",
+    "FilterPeerRecipientsNode",
+    "CreateBroadcastActivityNode",
+    "BroadcastQueueToOutboxNode",
+    "peer_broadcast_bt",
+]

--- a/vultron/core/behaviors/broadcast/nodes/__init__.py
+++ b/vultron/core/behaviors/broadcast/nodes/__init__.py
@@ -296,6 +296,11 @@ class CreateBroadcastActivityNode(DataLayerAction):
             return Status.FAILURE
 
         if not recipient_ids:
+            # Clear any stale value from a previous execution (the blackboard
+            # is process-global; execute_with_setup does not clean broadcast_*
+            # keys between runs).  BroadcastQueueToOutboxNode treats None as
+            # the no-op sentinel, so it will skip outbox enqueue.
+            self.blackboard.broadcast_activity_id = None
             self.logger.debug(
                 "%s: no recipients — skipping activity creation", self.name
             )
@@ -374,6 +379,41 @@ class BroadcastQueueToOutboxNode(DataLayerAction):
             access=py_trees.common.Access.READ,
         )
 
+    def _enqueue_activity(
+        self,
+        case_manager_id: str,
+        activity_id: str,
+        recipient_ids: list[str],
+    ) -> Status:
+        """Enqueue *activity_id* to *case_manager_id*'s outbox."""
+        if self.datalayer is None:
+            self.feedback_message = "DataLayer not available"
+            return Status.FAILURE
+
+        from vultron.core.ports.case_persistence import CaseOutboxPersistence
+        from vultron.errors import VultronError
+
+        try:
+            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
+                case_manager_id, activity_id
+            )
+        except VultronError as exc:
+            self.feedback_message = (
+                f"Failed to queue broadcast to outbox: {exc}"
+            )
+            self.logger.warning("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
+
+        self.logger.info(
+            "%s: Case Manager '%s' queued broadcast activity '%s'"
+            " to %d peer(s) (BT-14-001)",
+            self.name,
+            case_manager_id,
+            activity_id,
+            len(recipient_ids),
+        )
+        return Status.SUCCESS
+
     def update(self) -> Status:
         try:
             case_manager_id: str = self.blackboard.broadcast_case_manager_id
@@ -382,9 +422,16 @@ class BroadcastQueueToOutboxNode(DataLayerAction):
             return Status.FAILURE
 
         # No activity was created (no-op path when recipient list was empty).
+        # CreateBroadcastActivityNode writes None on the no-op path to clear
+        # any stale value from a prior execution (blackboard is process-global).
+        # We accept both KeyError (first-ever run) and None (cleared by prior
+        # no-op) as equivalent no-op sentinels.
         try:
-            activity_id: str = self.blackboard.broadcast_activity_id
+            activity_id: str | None = self.blackboard.broadcast_activity_id
         except KeyError:
+            activity_id = None
+
+        if activity_id is None:
             self.logger.debug(
                 "%s: no broadcast_activity_id — skipping outbox enqueue",
                 self.name,
@@ -399,30 +446,6 @@ class BroadcastQueueToOutboxNode(DataLayerAction):
             self.feedback_message = f"Required blackboard key missing: {exc}"
             return Status.FAILURE
 
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
-
-        from vultron.core.ports.case_persistence import CaseOutboxPersistence
-        from vultron.errors import VultronError
-
-        try:
-            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
-                case_manager_id, activity_id
-            )
-            self.logger.info(
-                "%s: Case Manager '%s' queued broadcast activity '%s'"
-                " to %d peer(s) (BT-14-001)",
-                self.name,
-                case_manager_id,
-                activity_id,
-                len(recipient_ids),
-            )
-        except VultronError as exc:
-            self.feedback_message = (
-                f"Failed to queue broadcast to outbox: {exc}"
-            )
-            self.logger.warning("%s: %s", self.name, self.feedback_message)
-            return Status.FAILURE
-
-        return Status.SUCCESS
+        return self._enqueue_activity(
+            case_manager_id, activity_id, recipient_ids
+        )

--- a/vultron/core/behaviors/broadcast/nodes/__init__.py
+++ b/vultron/core/behaviors/broadcast/nodes/__init__.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Shared peer-broadcast BT leaf nodes (BT-14-001, BT-14-002).
+
+Provides reusable building blocks for all protocol-visible peer fan-out
+subtrees:
+
+- :func:`_find_case_manager_id` — locate the Case Manager actor ID from
+  a case object
+- :class:`FindCaseManagerNode` — resolve CASE_MANAGER actor to the
+  blackboard key ``broadcast_case_manager_id``
+- :class:`FilterPeerRecipientsNode` — filter eligible peer recipients to
+  ``broadcast_peer_recipient_ids`` (returns SUCCESS with an empty list
+  when no recipients remain; broadcast is a no-op, not a failure)
+- :class:`CreateBroadcastActivityNode` — invoke a caller-supplied
+  ``activity_builder`` to create the outbound AS2 activity; short-circuits
+  to SUCCESS when the recipient list is empty; returns FAILURE when
+  construction fails
+- :class:`BroadcastQueueToOutboxNode` — enqueue the activity to the Case
+  Manager's outbox; short-circuits to SUCCESS when no activity was created
+  (no-op path); returns FAILURE on enqueue errors
+
+Blackboard contract (node numbers match the sequence order in
+:func:`~vultron.core.behaviors.broadcast.peer_broadcast_tree.peer_broadcast_bt`):
+
++----------------------------------+--------+---------+
+| Key                              | Reads  | Written |
++==================================+========+=========+
+| ``broadcast_case_manager_id``    | 2, 3, 4| 1       |
++----------------------------------+--------+---------+
+| ``broadcast_peer_recipient_ids`` | 3, 4   | 2       |
++----------------------------------+--------+---------+
+| ``broadcast_activity_id``        | 4      | 3       |
++----------------------------------+--------+---------+
+
+Per specs/behavior-tree-integration.yaml BT-14-001, BT-14-002.
+"""
+
+import logging
+from typing import TYPE_CHECKING, Any, Callable, cast
+
+import py_trees
+from py_trees.common import Status
+
+from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.models.protocols import is_case_model
+from vultron.core.states.roles import CVDRole
+
+if TYPE_CHECKING:
+    from vultron.core.ports.case_persistence import CasePersistence
+    from vultron.core.ports.trigger_activity import TriggerActivityPort
+
+logger = logging.getLogger(__name__)
+
+
+def _find_case_manager_id(dl: "CasePersistence", case: Any) -> str | None:
+    """Return the attributed_to actor ID for the CASE_MANAGER participant."""
+    for p_id in case.actor_participant_index.values():
+        p = dl.read(p_id)
+        if p is None:
+            continue
+        roles = getattr(p, "case_roles", [])
+        if CVDRole.CASE_MANAGER in roles:
+            attr = getattr(p, "attributed_to", None)
+            if attr:
+                return str(attr)
+    return None
+
+
+class FindCaseManagerNode(DataLayerAction):
+    """Resolve the CASE_MANAGER actor ID and write it to the blackboard.
+
+    Reads the :class:`~vultron.wire.as2.vocab.objects.vulnerability_case.VulnerabilityCase`
+    from the DataLayer, iterates its participants, and finds the one holding
+    :attr:`~vultron.core.states.roles.CVDRole.CASE_MANAGER`.  Writes the
+    attributed-to actor ID to ``broadcast_case_manager_id``.
+
+    Returns SUCCESS when a Case Manager is found.
+    Returns FAILURE when:
+
+    - DataLayer or case_id is not available
+    - Case is not found in the DataLayer
+    - No CASE_MANAGER participant exists in the case
+
+    Per BT-14-001, BT-14-002.
+    """
+
+    def __init__(self, case_id: str | None, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self.case_id = case_id
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="broadcast_case_manager_id",
+            access=py_trees.common.Access.WRITE,
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None or not self.case_id:
+            self.feedback_message = "DataLayer or case_id not available"
+            return Status.FAILURE
+
+        case = self.datalayer.read(self.case_id)
+        if not is_case_model(case):
+            self.feedback_message = f"Case '{self.case_id}' not found"
+            return Status.FAILURE
+
+        case_manager_id = _find_case_manager_id(self.datalayer, case)
+        if case_manager_id is None:
+            self.feedback_message = (
+                f"No CASE_MANAGER found in case '{self.case_id}'"
+            )
+            return Status.FAILURE
+
+        self.blackboard.broadcast_case_manager_id = case_manager_id
+        self.logger.debug(
+            "FindCaseManager: resolved CASE_MANAGER actor '%s'"
+            " for case '%s'",
+            case_manager_id,
+            self.case_id,
+        )
+        return Status.SUCCESS
+
+
+class FilterPeerRecipientsNode(DataLayerAction):
+    """Filter broadcast recipients, excluding sender, self, and Case Manager.
+
+    Reads the case from the DataLayer and computes the list of eligible peer
+    recipients by excluding the original sender (``sender_actor_id``), the
+    currently executing actor (``self.actor_id``), and the Case Manager
+    (``broadcast_case_manager_id`` from the blackboard).
+
+    Writes the resulting list — possibly empty — to
+    ``broadcast_peer_recipient_ids`` and returns SUCCESS.  An empty list
+    signals that broadcast is a no-op for this tick; downstream nodes
+    short-circuit gracefully.
+
+    Returns SUCCESS in all non-error cases (including no eligible recipients).
+    Returns FAILURE when:
+
+    - DataLayer or case_id is not available
+    - ``broadcast_case_manager_id`` is not in the blackboard
+    - Case is not found in the DataLayer
+
+    Per BT-14-001, BT-14-002.
+    """
+
+    def __init__(
+        self,
+        sender_actor_id: str,
+        case_id: str | None,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self.sender_actor_id = sender_actor_id
+        self.case_id = case_id
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="broadcast_case_manager_id",
+            access=py_trees.common.Access.READ,
+        )
+        self.blackboard.register_key(
+            key="broadcast_peer_recipient_ids",
+            access=py_trees.common.Access.WRITE,
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None or not self.case_id:
+            self.feedback_message = "DataLayer or case_id not available"
+            return Status.FAILURE
+
+        try:
+            case_manager_id: str = self.blackboard.broadcast_case_manager_id
+        except KeyError:
+            self.feedback_message = (
+                "broadcast_case_manager_id not set in blackboard"
+            )
+            return Status.FAILURE
+
+        case = self.datalayer.read(self.case_id)
+        if not is_case_model(case):
+            self.feedback_message = f"Case '{self.case_id}' not found"
+            return Status.FAILURE
+
+        recipient_ids = [
+            a_id
+            for a_id in case.actor_participant_index.keys()
+            if (
+                a_id != self.sender_actor_id
+                and a_id != self.actor_id
+                and a_id != case_manager_id
+            )
+        ]
+
+        self.blackboard.broadcast_peer_recipient_ids = recipient_ids
+
+        if not recipient_ids:
+            self.logger.debug(
+                "FilterPeerRecipients: no eligible recipients in case '%s'"
+                " — broadcast not needed",
+                self.case_id,
+            )
+        else:
+            self.logger.debug(
+                "FilterPeerRecipients: %d eligible recipient(s)"
+                " for case '%s'",
+                len(recipient_ids),
+                self.case_id,
+            )
+        return Status.SUCCESS
+
+
+class CreateBroadcastActivityNode(DataLayerAction):
+    """Create a broadcast activity via a domain-supplied factory callable.
+
+    Reads ``broadcast_case_manager_id`` and ``broadcast_peer_recipient_ids``
+    from the blackboard.  When the recipient list is empty, skips activity
+    creation and returns SUCCESS without calling the factory (no-op path).
+
+    Otherwise, calls::
+
+        activity_id = activity_builder(factory, case_manager_id, recipient_ids)
+
+    and writes the result to ``broadcast_activity_id``.
+
+    The ``activity_builder`` callable receives:
+
+    - *factory* — the :class:`~vultron.core.ports.trigger_activity.TriggerActivityPort`
+      instance from the blackboard
+    - *case_manager_id* — the Case Manager actor ID string
+    - *recipient_ids* — the filtered list of peer actor ID strings
+
+    It must return the newly created activity ID as a ``str``.
+
+    Returns SUCCESS after creating the activity or when the recipient list is
+    empty.
+    Returns FAILURE when:
+
+    - Required blackboard keys are missing
+    - Recipients exist but ``trigger_activity_factory`` is not available
+    - The ``activity_builder`` raises
+      :class:`~vultron.errors.VultronError`
+
+    Per BT-14-001, BT-14-002.
+    """
+
+    def __init__(
+        self,
+        activity_builder: Callable[
+            ["TriggerActivityPort", str, list[str]], str
+        ],
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._activity_builder = activity_builder
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="broadcast_case_manager_id",
+            access=py_trees.common.Access.READ,
+        )
+        self.blackboard.register_key(
+            key="broadcast_peer_recipient_ids",
+            access=py_trees.common.Access.READ,
+        )
+        self.blackboard.register_key(
+            key="broadcast_activity_id",
+            access=py_trees.common.Access.WRITE,
+        )
+
+    def update(self) -> Status:
+        try:
+            case_manager_id: str = self.blackboard.broadcast_case_manager_id
+            recipient_ids: list[str] = (
+                self.blackboard.broadcast_peer_recipient_ids
+            )
+        except KeyError as exc:
+            self.feedback_message = f"Required blackboard key missing: {exc}"
+            return Status.FAILURE
+
+        if not recipient_ids:
+            self.logger.debug(
+                "%s: no recipients — skipping activity creation", self.name
+            )
+            return Status.SUCCESS
+
+        if self.trigger_activity_factory is None:
+            self.feedback_message = "trigger_activity_factory not available"
+            self.logger.warning(
+                "%s: %s — broadcast FAILURE (BT-14-001)",
+                self.name,
+                self.feedback_message,
+            )
+            return Status.FAILURE
+
+        from vultron.errors import VultronError
+
+        try:
+            activity_id = self._activity_builder(
+                self.trigger_activity_factory,
+                case_manager_id,
+                recipient_ids,
+            )
+        except VultronError as exc:
+            self.feedback_message = (
+                f"Broadcast activity creation failed: {exc}"
+            )
+            self.logger.warning("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
+
+        self.blackboard.broadcast_activity_id = activity_id
+        self.logger.debug(
+            "%s: created broadcast activity '%s' from '%s' to %d peer(s)",
+            self.name,
+            activity_id,
+            case_manager_id,
+            len(recipient_ids),
+        )
+        return Status.SUCCESS
+
+
+class BroadcastQueueToOutboxNode(DataLayerAction):
+    """Queue the broadcast activity to the Case Manager's outbox.
+
+    Reads ``broadcast_case_manager_id``, ``broadcast_activity_id``, and
+    ``broadcast_peer_recipient_ids`` from the blackboard.
+
+    When ``broadcast_activity_id`` is absent (no-op path set by
+    :class:`CreateBroadcastActivityNode` when recipients were empty),
+    returns SUCCESS immediately without touching the outbox.
+
+    Returns SUCCESS after successfully queuing (or when nothing to queue).
+    Returns FAILURE when:
+
+    - ``broadcast_case_manager_id`` is missing from the blackboard
+    - DataLayer is not available (and an activity to queue exists)
+    - An exception is raised while queuing
+
+    Per BT-14-001, BT-14-002.
+    """
+
+    def __init__(self, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="broadcast_case_manager_id",
+            access=py_trees.common.Access.READ,
+        )
+        self.blackboard.register_key(
+            key="broadcast_activity_id",
+            access=py_trees.common.Access.READ,
+        )
+        self.blackboard.register_key(
+            key="broadcast_peer_recipient_ids",
+            access=py_trees.common.Access.READ,
+        )
+
+    def update(self) -> Status:
+        try:
+            case_manager_id: str = self.blackboard.broadcast_case_manager_id
+        except KeyError as exc:
+            self.feedback_message = f"Required blackboard key missing: {exc}"
+            return Status.FAILURE
+
+        # No activity was created (no-op path when recipient list was empty).
+        try:
+            activity_id: str = self.blackboard.broadcast_activity_id
+        except KeyError:
+            self.logger.debug(
+                "%s: no broadcast_activity_id — skipping outbox enqueue",
+                self.name,
+            )
+            return Status.SUCCESS
+
+        try:
+            recipient_ids: list[str] = (
+                self.blackboard.broadcast_peer_recipient_ids
+            )
+        except KeyError as exc:
+            self.feedback_message = f"Required blackboard key missing: {exc}"
+            return Status.FAILURE
+
+        if self.datalayer is None:
+            self.feedback_message = "DataLayer not available"
+            return Status.FAILURE
+
+        from vultron.core.ports.case_persistence import CaseOutboxPersistence
+        from vultron.errors import VultronError
+
+        try:
+            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
+                case_manager_id, activity_id
+            )
+            self.logger.info(
+                "%s: Case Manager '%s' queued broadcast activity '%s'"
+                " to %d peer(s) (BT-14-001)",
+                self.name,
+                case_manager_id,
+                activity_id,
+                len(recipient_ids),
+            )
+        except VultronError as exc:
+            self.feedback_message = (
+                f"Failed to queue broadcast to outbox: {exc}"
+            )
+            self.logger.warning("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
+
+        return Status.SUCCESS

--- a/vultron/core/behaviors/broadcast/peer_broadcast_tree.py
+++ b/vultron/core/behaviors/broadcast/peer_broadcast_tree.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Shared fail-fast peer broadcast BT factory (BT-14-001, BT-14-002).
+
+:func:`peer_broadcast_bt` builds a plain ``memory=False`` Sequence — no
+guaranteed-success fallback — so FAILURE propagates to the caller when any
+broadcast preparation or outbox-enqueueing step fails.
+
+Usage example::
+
+    from vultron.core.behaviors.broadcast import peer_broadcast_bt
+
+    def _build_activity(factory, case_manager_id, recipient_ids):
+        return factory.announce_something(
+            actor=case_manager_id,
+            to=recipient_ids,
+        )
+
+    tree = peer_broadcast_bt(
+        case_id=case_id,
+        sender_actor_id=sender_actor_id,
+        activity_builder=_build_activity,
+    )
+    result = bridge.execute_with_setup(tree=tree, actor_id=actor_id)
+"""
+
+import logging
+from typing import TYPE_CHECKING, Callable
+
+import py_trees
+
+from vultron.core.behaviors.broadcast.nodes import (
+    BroadcastQueueToOutboxNode,
+    CreateBroadcastActivityNode,
+    FilterPeerRecipientsNode,
+    FindCaseManagerNode,
+)
+
+if TYPE_CHECKING:
+    from vultron.core.ports.trigger_activity import TriggerActivityPort
+
+logger = logging.getLogger(__name__)
+
+
+def peer_broadcast_bt(
+    *,
+    case_id: str | None,
+    sender_actor_id: str,
+    activity_builder: Callable[["TriggerActivityPort", str, list[str]], str],
+    name: str | None = None,
+) -> py_trees.behaviour.Behaviour:
+    """Build a fail-fast peer broadcast Sequence (BT-14-001, BT-14-002).
+
+    Composes :class:`~vultron.core.behaviors.broadcast.nodes.FindCaseManagerNode`,
+    :class:`~vultron.core.behaviors.broadcast.nodes.FilterPeerRecipientsNode`,
+    :class:`~vultron.core.behaviors.broadcast.nodes.CreateBroadcastActivityNode`,
+    and :class:`~vultron.core.behaviors.broadcast.nodes.BroadcastQueueToOutboxNode`
+    into a ``memory=False`` Sequence.
+
+    Unlike the old ``Selector``-with-``Success``-fallback pattern, this
+    Sequence propagates FAILURE when broadcast preparation or outbox
+    enqueueing fails, satisfying BT-14-001.  No-op paths (empty recipient
+    list) return SUCCESS to avoid blocking downstream BT steps that do not
+    depend on broadcast completion.
+
+    Blackboard keys shared across all four nodes:
+
+    - ``broadcast_case_manager_id``: Case Manager actor ID
+    - ``broadcast_peer_recipient_ids``: filtered peer actor ID list
+    - ``broadcast_activity_id``: created activity ID (absent when no-op)
+
+    The caller must execute the tree via
+    :meth:`~vultron.core.behaviors.bridge.BTBridge.execute_with_setup` so
+    that ``datalayer``, ``actor_id``, and (when broadcasting)
+    ``trigger_activity_factory`` are present on the blackboard.
+
+    Args:
+        case_id: ID of the
+            :class:`~vultron.wire.as2.vocab.objects.vulnerability_case.VulnerabilityCase`
+            whose CASE_MANAGER should originate the broadcast.
+        sender_actor_id: Actor ID of the entity whose update is being
+            forwarded; excluded from the recipient set.
+        activity_builder: ``(factory, case_manager_id, recipient_ids) ->
+            activity_id`` — called by
+            :class:`~vultron.core.behaviors.broadcast.nodes.CreateBroadcastActivityNode`
+            with the resolved factory instance, Case Manager actor ID, and
+            filtered recipient list.  Must create and persist the outbound
+            AS2 activity and return its ID as a ``str``.
+        name: Optional name override for the root Sequence node.
+
+    Returns:
+        Root node of the fail-fast peer broadcast Sequence.
+    """
+    root = py_trees.composites.Sequence(
+        name=name or "PeerBroadcastBT",
+        memory=False,
+        children=[
+            FindCaseManagerNode(case_id=case_id),
+            FilterPeerRecipientsNode(
+                sender_actor_id=sender_actor_id,
+                case_id=case_id,
+            ),
+            CreateBroadcastActivityNode(activity_builder=activity_builder),
+            BroadcastQueueToOutboxNode(),
+        ],
+    )
+    logger.debug(
+        "Created PeerBroadcastBT for case_id=%s sender=%s",
+        case_id,
+        sender_actor_id,
+    )
+    return root

--- a/vultron/core/behaviors/broadcast/peer_broadcast_tree.py
+++ b/vultron/core/behaviors/broadcast/peer_broadcast_tree.py
@@ -13,11 +13,29 @@
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-"""Shared fail-fast peer broadcast BT factory (BT-14-001, BT-14-002).
+"""Factory for the peer broadcast BT subtree used by all protocol-visible fan-out paths.
 
-:func:`peer_broadcast_bt` builds a plain ``memory=False`` Sequence — no
-guaranteed-success fallback — so FAILURE propagates to the caller when any
-broadcast preparation or outbox-enqueueing step fails.
+In a federated CVD protocol, when a Case Manager receives a state update
+(participant status, embargo proposal, etc.) it must forward that update to
+every other participant so their local views remain consistent.  This
+fan-out is *protocol-visible*: if the Case Manager fails to notify a peer,
+that peer's state silently diverges — a correctness risk that is hard to
+detect or recover from after the fact.
+
+:func:`peer_broadcast_bt` provides the canonical subtree for that fan-out.
+It handles the four steps every broadcast path shares:
+
+1. Resolve which actor is acting as Case Manager for this case.
+2. Compute the eligible recipient set (all participants except the original
+   sender, the current executing actor, and the Case Manager itself).
+3. Construct the domain-specific outbound AS2 activity via a caller-supplied
+   ``activity_builder`` closure.
+4. Enqueue the activity to the Case Manager's outbox for delivery.
+
+Any failure in steps 1–4 propagates as BT ``FAILURE`` so the caller's BT
+can react (retry, escalate, or halt further processing).  An empty recipient
+list is treated as a successful no-op — the broadcast simply isn't needed
+when no eligible peers exist.
 
 Usage example::
 
@@ -35,6 +53,8 @@ Usage example::
         activity_builder=_build_activity,
     )
     result = bridge.execute_with_setup(tree=tree, actor_id=actor_id)
+
+Per ``specs/behavior-tree-integration.yaml`` BT-14-001 and BT-14-002.
 """
 
 import logging
@@ -62,25 +82,27 @@ def peer_broadcast_bt(
     activity_builder: Callable[["TriggerActivityPort", str, list[str]], str],
     name: str | None = None,
 ) -> py_trees.behaviour.Behaviour:
-    """Build a fail-fast peer broadcast Sequence (BT-14-001, BT-14-002).
+    """Assemble the four-step peer broadcast subtree for a single fan-out event.
 
-    Composes :class:`~vultron.core.behaviors.broadcast.nodes.FindCaseManagerNode`,
-    :class:`~vultron.core.behaviors.broadcast.nodes.FilterPeerRecipientsNode`,
-    :class:`~vultron.core.behaviors.broadcast.nodes.CreateBroadcastActivityNode`,
-    and :class:`~vultron.core.behaviors.broadcast.nodes.BroadcastQueueToOutboxNode`
-    into a ``memory=False`` Sequence.
+    The returned tree encodes the protocol requirement that every state change
+    accepted by a Case Manager must be forwarded to all other participants
+    (BT-14-002).  The caller supplies an ``activity_builder`` closure that
+    knows how to construct the domain-specific AS2 activity; this factory
+    handles the surrounding infrastructure: finding the Case Manager, filtering
+    the recipient set, creating the activity, and queuing it for outbox
+    delivery.
 
-    Unlike the old ``Selector``-with-``Success``-fallback pattern, this
-    Sequence propagates FAILURE when broadcast preparation or outbox
-    enqueueing fails, satisfying BT-14-001.  No-op paths (empty recipient
-    list) return SUCCESS to avoid blocking downstream BT steps that do not
-    depend on broadcast completion.
+    The tree returns ``FAILURE`` whenever the Case Manager cannot be resolved,
+    the activity cannot be constructed, or the outbox enqueue fails — giving
+    the caller's BT full control over error handling (BT-14-001).  When no
+    eligible recipients remain after filtering, the tree returns ``SUCCESS``
+    without calling the factory; this is a legitimate no-op, not an error.
 
     Blackboard keys shared across all four nodes:
 
     - ``broadcast_case_manager_id``: Case Manager actor ID
     - ``broadcast_peer_recipient_ids``: filtered peer actor ID list
-    - ``broadcast_activity_id``: created activity ID (absent when no-op)
+    - ``broadcast_activity_id``: created activity ID (``None`` when no-op)
 
     The caller must execute the tree via
     :meth:`~vultron.core.behaviors.bridge.BTBridge.execute_with_setup` so
@@ -92,7 +114,8 @@ def peer_broadcast_bt(
             :class:`~vultron.wire.as2.vocab.objects.vulnerability_case.VulnerabilityCase`
             whose CASE_MANAGER should originate the broadcast.
         sender_actor_id: Actor ID of the entity whose update is being
-            forwarded; excluded from the recipient set.
+            forwarded; excluded from the recipient set so the originating
+            actor does not receive its own update.
         activity_builder: ``(factory, case_manager_id, recipient_ids) ->
             activity_id`` — called by
             :class:`~vultron.core.behaviors.broadcast.nodes.CreateBroadcastActivityNode`
@@ -102,7 +125,7 @@ def peer_broadcast_bt(
         name: Optional name override for the root Sequence node.
 
     Returns:
-        Root node of the fail-fast peer broadcast Sequence.
+        Root node of the peer broadcast Sequence.
     """
     root = py_trees.composites.Sequence(
         name=name or "PeerBroadcastBT",

--- a/vultron/core/behaviors/status/nodes/__init__.py
+++ b/vultron/core/behaviors/status/nodes/__init__.py
@@ -25,7 +25,8 @@ Submodules:
 - ``broadcast``: Peer fan-out helper and nodes (_find_case_manager_id,
   FindCaseManagerNode, FilterPeerRecipientsNode,
   CreateStatusBroadcastActivityNode, BroadcastQueueToOutboxNode,
-  BroadcastStatusToPeersNode)
+  BroadcastStatusToPeersNode); shared nodes are re-exported from
+  :mod:`vultron.core.behaviors.broadcast.nodes` (BT-14-001, BT-14-002)
 - ``append``: Load, validate RM transition, and append action nodes
   (SkipIfIdempotentNode, LoadParticipantNode,
   CheckStatusNotAlreadyAppendedNode, ResolveAndPersistStatusObjectNode,

--- a/vultron/core/behaviors/status/nodes/broadcast.py
+++ b/vultron/core/behaviors/status/nodes/broadcast.py
@@ -13,187 +13,32 @@
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-"""Peer broadcast nodes for the AddParticipantStatus workflow.
+"""Status-domain peer broadcast nodes for the AddParticipantStatus workflow.
 
-Contains the Case Manager resolution, peer recipient filtering, broadcast
-activity creation, and outbox queuing leaf nodes, plus the composite
-:class:`BroadcastStatusToPeersNode` that orchestrates them.
+Re-exports the shared generic nodes from
+:mod:`vultron.core.behaviors.broadcast.nodes` and provides the
+status-specific :class:`CreateStatusBroadcastActivityNode` and the
+updated :class:`BroadcastStatusToPeersNode`.
 
-Per DEMOMA-07-003 step 3.
+Per DEMOMA-07-003 step 3 and specs/behavior-tree-integration.yaml
+BT-14-001, BT-14-002.
 """
 
 import logging
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any
 
 import py_trees
 from py_trees.common import Status
 
+from vultron.core.behaviors.broadcast.nodes import (  # noqa: F401
+    BroadcastQueueToOutboxNode,
+    FilterPeerRecipientsNode,
+    FindCaseManagerNode,
+    _find_case_manager_id,
+)
 from vultron.core.behaviors.helpers import DataLayerAction
-from vultron.core.models.protocols import is_case_model
-from vultron.core.states.roles import CVDRole
-
-if TYPE_CHECKING:
-    from vultron.core.ports.case_persistence import CasePersistence
 
 logger = logging.getLogger(__name__)
-
-
-def _find_case_manager_id(dl: "CasePersistence", case: Any) -> str | None:
-    """Return the attributed_to actor ID for the CASE_MANAGER participant."""
-    for p_id in case.actor_participant_index.values():
-        p = dl.read(p_id)
-        if p is None:
-            continue
-        roles = getattr(p, "case_roles", [])
-        if CVDRole.CASE_MANAGER in roles:
-            attr = getattr(p, "attributed_to", None)
-            if attr:
-                return str(attr)
-    return None
-
-
-class FindCaseManagerNode(DataLayerAction):
-    """Resolve the CASE_MANAGER actor ID and write it to the blackboard.
-
-    Reads the :class:`VulnerabilityCase` from the DataLayer, iterates its
-    participants, and finds the one holding :attr:`CVDRole.CASE_MANAGER`.
-    Writes the attributed-to actor ID to the blackboard under the key
-    ``broadcast_case_manager_id``.
-
-    Designed for use in broadcast subtrees where the Case Manager is the
-    designated broadcast sender.
-
-    Returns SUCCESS when a Case Manager is found.
-    Returns FAILURE when:
-    - DataLayer or case_id is not available
-    - Case is not found in the DataLayer
-    - No CASE_MANAGER participant exists in the case
-    """
-
-    def __init__(self, case_id: str | None, name: str | None = None) -> None:
-        super().__init__(name=name or self.__class__.__name__)
-        self.case_id = case_id
-
-    def setup(self, **kwargs: Any) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="broadcast_case_manager_id",
-            access=py_trees.common.Access.WRITE,
-        )
-
-    def update(self) -> Status:
-        if self.datalayer is None or not self.case_id:
-            self.feedback_message = "DataLayer or case_id not available"
-            return Status.FAILURE
-
-        case = self.datalayer.read(self.case_id)
-        if not is_case_model(case):
-            self.feedback_message = f"Case '{self.case_id}' not found"
-            return Status.FAILURE
-
-        case_manager_id = _find_case_manager_id(self.datalayer, case)
-        if case_manager_id is None:
-            self.feedback_message = (
-                f"No CASE_MANAGER found in case '{self.case_id}'"
-            )
-            return Status.FAILURE
-
-        self.blackboard.broadcast_case_manager_id = case_manager_id
-        self.logger.debug(
-            "FindCaseManager: resolved CASE_MANAGER actor '%s' for case '%s'",
-            case_manager_id,
-            self.case_id,
-        )
-        return Status.SUCCESS
-
-
-class FilterPeerRecipientsNode(DataLayerAction):
-    """Filter broadcast recipients, excluding sender, self, and Case Manager.
-
-    Reads the :class:`VulnerabilityCase` from the DataLayer and computes the
-    list of eligible peer recipients by excluding the original status sender,
-    the currently executing actor (``self.actor_id``), and the Case Manager
-    actor (``broadcast_case_manager_id`` from the blackboard).
-
-    Writes the resulting list to the blackboard under
-    ``broadcast_peer_recipient_ids``.
-
-    Returns SUCCESS when at least one eligible recipient is found.
-    Returns FAILURE when:
-    - DataLayer or case_id is not available
-    - ``broadcast_case_manager_id`` is not in the blackboard
-    - Case is not found
-    - No eligible recipients remain after filtering
-
-    Per DEMOMA-07-003 step 3 filtering rules.
-    """
-
-    def __init__(
-        self,
-        sender_actor_id: str,
-        case_id: str | None,
-        name: str | None = None,
-    ) -> None:
-        super().__init__(name=name or self.__class__.__name__)
-        self.sender_actor_id = sender_actor_id
-        self.case_id = case_id
-
-    def setup(self, **kwargs: Any) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="broadcast_case_manager_id",
-            access=py_trees.common.Access.READ,
-        )
-        self.blackboard.register_key(
-            key="broadcast_peer_recipient_ids",
-            access=py_trees.common.Access.WRITE,
-        )
-
-    def update(self) -> Status:
-        if self.datalayer is None or not self.case_id:
-            self.feedback_message = "DataLayer or case_id not available"
-            return Status.FAILURE
-
-        try:
-            case_manager_id: str = self.blackboard.broadcast_case_manager_id
-        except KeyError:
-            self.feedback_message = (
-                "broadcast_case_manager_id not set in blackboard"
-            )
-            return Status.FAILURE
-
-        case = self.datalayer.read(self.case_id)
-        if not is_case_model(case):
-            self.feedback_message = f"Case '{self.case_id}' not found"
-            return Status.FAILURE
-
-        recipient_ids = [
-            a_id
-            for a_id in case.actor_participant_index.keys()
-            if (
-                a_id != self.sender_actor_id
-                and a_id != self.actor_id
-                and a_id != case_manager_id
-            )
-        ]
-        if not recipient_ids:
-            self.feedback_message = (
-                f"No eligible peer recipients in case '{self.case_id}'"
-            )
-            self.logger.debug(
-                "FilterPeerRecipients: no eligible recipients in case '%s'"
-                " — broadcast not needed",
-                self.case_id,
-            )
-            return Status.FAILURE
-
-        self.blackboard.broadcast_peer_recipient_ids = recipient_ids
-        self.logger.debug(
-            "FilterPeerRecipients: %d eligible recipient(s) for case '%s'",
-            len(recipient_ids),
-            self.case_id,
-        )
-        return Status.SUCCESS
 
 
 class CreateStatusBroadcastActivityNode(DataLayerAction):
@@ -289,114 +134,29 @@ class CreateStatusBroadcastActivityNode(DataLayerAction):
         return Status.SUCCESS
 
 
-class BroadcastQueueToOutboxNode(DataLayerAction):
-    """Queue the broadcast activity to the Case Manager's outbox.
-
-    Reads ``broadcast_case_manager_id``, ``broadcast_activity_id``, and
-    ``broadcast_peer_recipient_ids`` from the blackboard and queues the
-    activity to the Case Manager actor's outbox via
-    :meth:`~vultron.core.ports.case_persistence.CaseOutboxPersistence.record_outbox_item`.
-
-    Returns SUCCESS after successfully queuing.
-    Returns FAILURE when:
-    - DataLayer is not available
-    - Required blackboard keys are missing
-    - An exception is raised while queuing
-
-    Per DEMOMA-07-003 step 3.
-    """
-
-    def __init__(self, name: str | None = None) -> None:
-        super().__init__(name=name or self.__class__.__name__)
-
-    def setup(self, **kwargs: Any) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="broadcast_case_manager_id",
-            access=py_trees.common.Access.READ,
-        )
-        self.blackboard.register_key(
-            key="broadcast_activity_id",
-            access=py_trees.common.Access.READ,
-        )
-        self.blackboard.register_key(
-            key="broadcast_peer_recipient_ids",
-            access=py_trees.common.Access.READ,
-        )
-
-    def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
-
-        try:
-            case_manager_id: str = self.blackboard.broadcast_case_manager_id
-            activity_id: str = self.blackboard.broadcast_activity_id
-            recipient_ids: list[str] = (
-                self.blackboard.broadcast_peer_recipient_ids
-            )
-        except KeyError as exc:
-            self.feedback_message = f"Required blackboard key missing: {exc}"
-            return Status.FAILURE
-
-        from vultron.core.ports.case_persistence import CaseOutboxPersistence
-        from vultron.errors import VultronError
-
-        try:
-            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
-                case_manager_id, activity_id
-            )
-            self.logger.info(
-                "BroadcastQueueToOutbox: Case Manager '%s' queued status"
-                " broadcast activity '%s' to %d peer(s)"
-                " (DEMOMA-07-003 step 3)",
-                case_manager_id,
-                activity_id,
-                len(recipient_ids),
-            )
-        except VultronError as exc:
-            self.feedback_message = (
-                f"Failed to queue broadcast to outbox: {exc}"
-            )
-            self.logger.warning(
-                "BroadcastQueueToOutbox: %s", self.feedback_message
-            )
-            return Status.FAILURE
-
-        return Status.SUCCESS
-
-
-class BroadcastStatusToPeersNode(py_trees.composites.Selector):
-    """Step 3: Broadcast Add(ParticipantStatus, CaseParticipant) to peers.
+class BroadcastStatusToPeersNode(py_trees.composites.Sequence):
+    """Step 3: Fail-fast broadcast of Add(ParticipantStatus) to peers.
 
     The current actor re-sends the status update to all other participants,
-    excluding the original sender, itself, and the Case Manager. Skips
-    silently when no trigger factory is available, when the case or Case
-    Manager is not found, or when there are no eligible recipients.
+    excluding the original sender, itself, and the Case Manager.
 
-    Always returns SUCCESS (failure to broadcast is not fatal).
+    Implemented as a ``py_trees.composites.Sequence`` (memory=False) via
+    :func:`~vultron.core.behaviors.broadcast.peer_broadcast_tree.peer_broadcast_bt`.
+    Returns FAILURE when broadcast preparation or outbox enqueueing fails
+    (BT-14-001).  Returns SUCCESS when the recipient list is empty (no peers
+    to notify — broadcast is a no-op, not a failure).
 
-    Implemented as a ``py_trees.composites.Selector`` (memory=False):
-
-    - Child 1 ``_BroadcastWorkSequence``: inner Sequence of four leaf nodes
-      that resolves the Case Manager, filters eligible peers, creates the
-      broadcast activity, and queues it to the Case Manager's outbox.
-    - Child 2 ``py_trees.behaviours.Success``: non-fatal fallback — only
-      reached when the work sequence returns FAILURE on a known skip path
-      (no recipients, no Case Manager, ``VultronError`` from factory or
-      outbox operations). Non-``VultronError`` exceptions propagate
-      normally and are not swallowed.
-
-    Inner broadcast sequence:
+    Broadcast sequence:
 
     .. code-block:: text
 
         ├── FindCaseManagerNode          # resolve Case Manager → blackboard
         ├── FilterPeerRecipientsNode     # exclude sender/self/manager → blackboard
-        ├── CreateStatusBroadcastActivityNode  # factory call → blackboard
+        ├── CreateBroadcastActivityNode  # factory call → blackboard
         └── BroadcastQueueToOutboxNode   # queue activity to Case Manager outbox
 
-    Per DEMOMA-07-003 step 3.
+    Per DEMOMA-07-003 step 3 and specs/behavior-tree-integration.yaml
+    BT-14-001, BT-14-002.
     """
 
     def __init__(
@@ -408,25 +168,32 @@ class BroadcastStatusToPeersNode(py_trees.composites.Selector):
         name: str | None = None,
     ):
         super().__init__(name=name or self.__class__.__name__, memory=False)
-        inner_sequence = py_trees.composites.Sequence(
-            name="BroadcastWorkSequence",
-            memory=False,
-            children=[
+
+        from vultron.core.behaviors.broadcast.nodes import (
+            CreateBroadcastActivityNode,
+        )
+
+        def _status_activity_builder(
+            factory: Any, case_manager_id: str, recipient_ids: list[str]
+        ) -> str:
+            result: str = factory.add_participant_status_to_participant(
+                status_id=status_id,
+                participant_id=participant_id,
+                actor=case_manager_id,
+                to=recipient_ids,
+            )
+            return result
+
+        self.add_children(
+            [
                 FindCaseManagerNode(case_id=case_id),
                 FilterPeerRecipientsNode(
                     sender_actor_id=sender_actor_id,
                     case_id=case_id,
                 ),
-                CreateStatusBroadcastActivityNode(
-                    status_id=status_id,
-                    participant_id=participant_id,
+                CreateBroadcastActivityNode(
+                    activity_builder=_status_activity_builder
                 ),
                 BroadcastQueueToOutboxNode(),
-            ],
-        )
-        self.add_children(
-            [
-                inner_sequence,
-                py_trees.behaviours.Success(name="BroadcastSkipped"),
             ]
         )

--- a/vultron/core/behaviors/status/nodes/broadcast.py
+++ b/vultron/core/behaviors/status/nodes/broadcast.py
@@ -105,6 +105,13 @@ class CreateStatusBroadcastActivityNode(DataLayerAction):
             self.feedback_message = f"Required blackboard key missing: {exc}"
             return Status.FAILURE
 
+        if not recipient_ids:
+            self.logger.debug(
+                "CreateStatusBroadcastActivity: no recipients — skipping"
+                " (DEMOMA-07-003 step 3)"
+            )
+            return Status.SUCCESS
+
         from vultron.errors import VultronError
 
         try:


### PR DESCRIPTION
- Closes #834

## Summary

Introduces `vultron/core/behaviors/broadcast/` — a shared, fail-fast peer broadcast subtree and leaf nodes for all protocol-visible fan-out paths. Replaces the old `Selector+Success` anti-pattern in status broadcast with a plain `memory=False` Sequence that propagates `FAILURE` when broadcast preparation or outbox enqueue fails (BT-14-001).

## Changes

- **`vultron/core/behaviors/broadcast/__init__.py`**: New package exposing `peer_broadcast_bt()` factory and shared leaf nodes
- **`vultron/core/behaviors/broadcast/nodes/__init__.py`**: `FindCaseManagerNode`, `FilterPeerRecipientsNode`, `CreateBroadcastActivityNode` (with stale-blackboard sentinel fix), `BroadcastQueueToOutboxNode` (with `_enqueue_activity()` helper to stay under CC=10)
- **`vultron/core/behaviors/broadcast/peer_broadcast_tree.py`**: `peer_broadcast_bt()` — builds a fail-fast Sequence; no guaranteed-SUCCESS fallback
- **`vultron/core/behaviors/status/nodes/broadcast.py`**: `BroadcastStatusToPeersNode` now delegates to shared nodes; `CreateStatusBroadcastActivityNode` gains missing empty-list guard (previously called factory with `to=[]`)
- **`test/core/behaviors/broadcast/test_peer_broadcast_bt.py`**: Comprehensive tests for all four nodes and `peer_broadcast_bt()`, including stale-blackboard regression test
- **`test/core/behaviors/status/nodes/test_broadcast.py`**: Added `TestCreateStatusBroadcastActivityNode` class covering empty-list and no-factory failure paths
- **`test/core/use_cases/received/test_status.py`**: Fixed stale top-level CVDRole import (F401/F811)

## Verification

- All 3519 unit tests pass (3 new regression tests)
- Black, flake8 (CC≤10), mypy, pyright clean
- [x] AC-1: Shared broadcast helper/subtree exists for recipient filtering, activity construction, and outbox enqueue
- [x] AC-2: Helper/subtree returns FAILURE when broadcast preparation or enqueue fails (no silent SUCCESS fallback)
- [x] AC-3: Unit tests cover success and failure paths for the shared helper/subtree