### PR TITLE
docs: plan #1043 — DEMOMA-07-003 raw re-broadcast superseded by Announce(CaseLedgerEntry)

### DIFF
--- a/plan/history/2606/learning/CONCERN-1043.md
+++ b/plan/history/2606/learning/CONCERN-1043.md
@@ -1,0 +1,53 @@
+---
+source: CONCERN-1043
+timestamp: '2026-06-18T18:57:08.722754+00:00'
+title: DEMOMA-07-003 raw re-broadcast superseded by Announce(CaseLedgerEntry) fan-out
+type: learning
+---
+
+## Summary
+
+DEMOMA-07-003 step 3 requires the Case Actor to directly re-broadcast
+`Add(ParticipantStatus)` to all other participants after processing.
+However, the SYNC layer (`FanOutLogEntryNode` → `Announce(CaseLedgerEntry)`)
+already fans the same update out to all participants after the ledger commit
+in `_commit_log_cascade_bt`. Both paths run today, so every peer receives
+the same status update twice — once as a raw `Add(ParticipantStatus)` and
+once wrapped in `Announce(CaseLedgerEntry)`.
+
+## Category
+
+Specification / Protocol correctness
+
+## Severity
+
+Medium — current code functions, but the direct re-broadcast is a pre-SYNC
+artefact that:
+
+- causes double-processing of status updates on every peer inbox
+- puts non-canonical messages in peer inboxes alongside canonical ledger
+  announcements
+- is the primary reason `BroadcastStatusToPeersNode` and `peer_broadcast_bt`
+  exist
+
+## Key Finding
+
+The `Announce(CaseLedgerEntry)` fan-out (via `FanOutLogEntryNode` in
+`_commit_log_cascade_bt`) covers a **superset** of step 3's recipients —
+including the original sender, which step 3 explicitly excluded. Removing
+step 3 therefore improves coverage, not reduces it.
+
+## Resolution
+
+- Updated DEMOMA-07-003 step 3 wording to specify `Announce(CaseLedgerEntry)`
+  fan-out per ADR-0019/SYNC-02-002 as the canonical propagation mechanism.
+- Added DEMOMA-07-005 (`MUST_NOT`) prohibiting parallel raw
+  `Add(ParticipantStatus)` re-broadcast to peers.
+- A related Concern #1047 was filed for the "single-BT-per-execute()"
+  spec invariant (generalisation of the actor-switching pattern, related
+  to #1036).
+
+**Resolved**: 2026-06-18 — implementation tracked in #1045.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1044>.
+Spec: `specs/multi-actor-demo.yaml` DEMOMA-07-003 (updated), DEMOMA-07-005
+(new).

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -197,15 +197,39 @@ groups:
       The Case Actor received handler for ADD_PARTICIPANT_STATUS_TO_PARTICIPANT MUST:
       (1) verify the activity actor is a known case participant,
       (2) update the participant status record,
-      (3) announce the update to all other case participants,
+      (3) propagate the update to all other case participants via Announce(CaseLedgerEntry)
+      fan-out (per ADR-0019 and SYNC-02-002) — NOT via a direct raw Add(ParticipantStatus)
+      re-broadcast,
       (4) if CS.P is newly set by the Case Owner, trigger embargo teardown automatically,
       (5) if all participants are RM.CLOSED, close the case automatically
+    relationships:
+    - rel_type: refines
+      spec_id: SYNC-02-002
+      note: step 3 propagation must use canonical Announce(CaseLedgerEntry) fan-out
   - id: DEMOMA-07-004
     priority: SHOULD
     statement: >-
       The participant status trigger implementation SHOULD be layered: SvcAddObjectToCaseUseCase
       (generic Add(object, target=Case)) as the base, SvcAddParticipantStatusUseCase (new core
       use case) above it, and demo-specific endpoints in demo_triggers.py at the top
+  - id: DEMOMA-07-005
+    priority: MUST_NOT
+    statement: >-
+      The Case Actor received handler for ADD_PARTICIPANT_STATUS_TO_PARTICIPANT MUST NOT
+      send a raw Add(ParticipantStatus) re-broadcast directly to peer participants after
+      updating the local participant record. Announce(CaseLedgerEntry) fan-out is the sole
+      canonical propagation path for status updates to peers (DEMOMA-07-003 step 3); a
+      parallel raw re-broadcast causes every peer to receive and process the same status
+      update twice — once as a raw Add(ParticipantStatus) and once wrapped in
+      Announce(CaseLedgerEntry) — producing duplicate state transitions and non-canonical
+      messages in peer inboxes. This artefact is superseded by ADR-0019.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-07-003
+      note: prohibits the pre-SYNC raw re-broadcast artefact superseded by ADR-0019
+    - rel_type: refines
+      spec_id: SYNC-02-002
+      note: Announce(CaseLedgerEntry) is the sole canonical propagation path for status updates
 - id: DEMOMA-08
   title: Case Actor Bootstrap and CASE_MANAGER Role
   specs:


### PR DESCRIPTION
- Closes #1043

## Summary

Plans concern #1043: the raw `Add(ParticipantStatus)` re-broadcast in step 3 of
`add_participant_status_tree` is a pre-SYNC artefact superseded by the
`Announce(CaseLedgerEntry)` fan-out that `_commit_log_cascade_bt` already performs.
Updates DEMOMA-07-003 to make step 3's canonical propagation mechanism explicit,
and adds DEMOMA-07-005 to prohibit the duplicate raw re-broadcast pattern.

## Changes

- `specs/multi-actor-demo.yaml`: update DEMOMA-07-003 step 3 wording to specify
  `Announce(CaseLedgerEntry)` fan-out per ADR-0019/SYNC-02-002; add cross-reference
  relationship to SYNC-02-002
- `specs/multi-actor-demo.yaml`: add DEMOMA-07-005 (`MUST_NOT`) prohibiting parallel
  raw `Add(ParticipantStatus)` re-broadcast to peers