### PR TITLE
feat: migrate status and embargo BT broadcast paths to fail-fast semantics (#835)

### DIFF
--- a/plan/history/2606/implementation/ISSUE-835.md
+++ b/plan/history/2606/implementation/ISSUE-835.md
@@ -1,0 +1,30 @@
+---
+source: ISSUE-835
+timestamp: '2026-06-18T18:56:48.219939+00:00'
+title: Migrate status and embargo BT broadcast paths to fail-fast semantics
+type: implementation
+---
+
+## Issue #835 — Migrate status and embargo BT broadcast paths to fail-fast semantics
+
+Migrated the status and embargo behavior tree broadcast paths to fail-fast
+semantics per spec BT-14-001: protocol-visible peer broadcast fan-out nodes
+now return `FAILURE` on delivery errors instead of silently swallowing them.
+
+**Embargo path** (`TerminateEmbargoNode`): `_dispatch_activity()` return type
+changed from `None` to `Status`; returns `FAILURE` when factory unavailable,
+`case_manager_id` missing, or dispatch raises; returns `SUCCESS` on successful
+enqueue. `update()` now propagates the result rather than always returning
+`SUCCESS`.
+
+**Status path** (`BroadcastStatusToPeersNode`): already migrated by #834 to
+use the shared fail-fast `peer_broadcast_bt` helper. Removed dead
+`CreateStatusBroadcastActivityNode` class and all associated test classes.
+
+**Test updates**: embargo lifecycle tests updated from `SUCCESS→FAILURE` for
+no-factory cases; new `test_returns_failure_when_factory_raises` added; status
+test files cleaned of dead class; `test_add_participant_status_bt.py` updated
+to use `CreateBroadcastActivityNode` and added `SUCCESS` path test with mock
+factory.
+
+PR: [#1046](https://github.com/CERTCC/Vultron/pull/1046)

--- a/test/core/behaviors/embargo/nodes/test_lifecycle.py
+++ b/test/core/behaviors/embargo/nodes/test_lifecycle.py
@@ -42,7 +42,11 @@ class TestTerminateEmbargoNode:
     """Tests for TerminateEmbargoNode (trigger-side embargo teardown)."""
 
     def test_terminates_active_embargo(self):
-        """Node transitions ACTIVE → EXITED, clears active_embargo, returns SUCCESS."""
+        """Node transitions ACTIVE → EXITED, clears active_embargo, returns FAILURE.
+
+        The state transition and persistence succeed, but dispatch fails because
+        no trigger_activity_factory is set (BT-14-001).
+        """
         dl = SqliteDataLayer("sqlite:///:memory:")
         case, embargo = make_case_and_embargo("ten1", em_state=EM.ACTIVE)
         dl.create(case)
@@ -53,13 +57,14 @@ class TestTerminateEmbargoNode:
         bt.setup()
         bt.tick()
 
-        assert node.status == py_trees.common.Status.SUCCESS
+        # State transition succeeded even though dispatch returns FAILURE.
+        assert node.status == py_trees.common.Status.FAILURE
         updated = cast(VulnerabilityCase, dl.read(case.id_))
         assert updated.current_status.em_state == EM.EXITED
         assert updated.active_embargo is None
 
     def test_terminates_revise_embargo(self):
-        """Node transitions REVISE → EXITED, returns SUCCESS."""
+        """Node transitions REVISE → EXITED, returns FAILURE (no factory)."""
         dl = SqliteDataLayer("sqlite:///:memory:")
         case, embargo = make_case_and_embargo("ten2", em_state=EM.REVISE)
         dl.create(case)
@@ -70,7 +75,7 @@ class TestTerminateEmbargoNode:
         bt.setup()
         bt.tick()
 
-        assert node.status == py_trees.common.Status.SUCCESS
+        assert node.status == py_trees.common.Status.FAILURE
         updated = cast(VulnerabilityCase, dl.read(case.id_))
         assert updated.current_status.em_state == EM.EXITED
         assert updated.active_embargo is None
@@ -139,7 +144,7 @@ class TestTerminateEmbargoNode:
         assert node.status == py_trees.common.Status.SUCCESS
 
     def test_resets_participant_pec_state(self):
-        """Node resets participant embargo_consent_state to NO_EMBARGO."""
+        """Node resets participant embargo_consent_state to NO_EMBARGO, returns FAILURE (no factory)."""
         dl = SqliteDataLayer("sqlite:///:memory:")
         case, _ = make_case_and_embargo("ten6", em_state=EM.ACTIVE)
         participant = CaseParticipant(
@@ -157,7 +162,8 @@ class TestTerminateEmbargoNode:
         bt.setup()
         bt.tick()
 
-        assert node.status == py_trees.common.Status.SUCCESS
+        # Dispatch fails (no factory), but PEC reset was applied before dispatch.
+        assert node.status == py_trees.common.Status.FAILURE
         updated_p = cast(CaseParticipant, dl.read(participant.id_))
         assert updated_p.embargo_consent_state == PEC.NO_EMBARGO.value
 
@@ -199,6 +205,48 @@ class TestTerminateEmbargoNode:
 
         assert node.status == py_trees.common.Status.SUCCESS
         factory.terminate_embargo.assert_called_once()
+
+    def test_returns_failure_when_factory_raises(self):
+        """FAILURE when factory.terminate_embargo raises (BT-14-001)."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = make_case_and_embargo("ten8", em_state=EM.ACTIVE)
+
+        case_manager_participant = CaseParticipant(
+            id_=f"{case.id_}/participants/cm",
+            attributed_to="https://example.org/actors/case-manager",
+            case_roles=[CVDRole.CASE_MANAGER],
+        )
+        case.case_participants.append(case_manager_participant.id_)
+        case.actor_participant_index[
+            "https://example.org/actors/case-manager"
+        ] = case_manager_participant.id_
+        dl.create(case)
+        dl.create(case_manager_participant)
+
+        py_trees.blackboard.Blackboard.enable_activity_stream()
+        py_trees.blackboard.Blackboard.storage.clear()
+        blackboard = py_trees.blackboard.Client(name="test-setup-ten8")
+        for key in ("datalayer", "actor_id", "trigger_activity_factory"):
+            blackboard.register_key(
+                key=key, access=py_trees.common.Access.WRITE
+            )
+        blackboard.datalayer = dl
+        blackboard.actor_id = "https://example.org/actors/case-manager"
+
+        factory = MagicMock()
+        factory.terminate_embargo.side_effect = RuntimeError("dispatch error")
+        blackboard.trigger_activity_factory = factory
+
+        node = TerminateEmbargoNode(case_id=case.id_)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.FAILURE
+        factory.terminate_embargo.assert_called_once()
+        # State transition was still applied before dispatch failed.
+        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        assert updated.current_status.em_state == EM.EXITED
 
 
 class TestValidateEmbargoRevisionStateNode:

--- a/test/core/behaviors/status/nodes/test_broadcast.py
+++ b/test/core/behaviors/status/nodes/test_broadcast.py
@@ -30,7 +30,6 @@ from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.status.nodes.broadcast import (
     BroadcastStatusToPeersNode,
-    CreateStatusBroadcastActivityNode,
     FilterPeerRecipientsNode,
     FindCaseManagerNode,
     _find_case_manager_id,
@@ -232,79 +231,5 @@ class TestBroadcastStatusToPeersNode:
         )
         result = populated_bridge.execute_with_setup(
             tree=node, actor_id=CASE_MANAGER_ID
-        )
-        assert result.status == Status.FAILURE
-
-
-# ---------------------------------------------------------------------------
-# CreateStatusBroadcastActivityNode
-# ---------------------------------------------------------------------------
-
-
-class TestCreateStatusBroadcastActivityNode:
-    def _run_with_prefilled_blackboard(
-        self,
-        dl,
-        actor_id: str,
-        recipient_ids: list,
-        factory=None,
-    ):
-        """Populate blackboard via FindCaseManagerNode+FilterPeerRecipientsNode,
-        then run CreateStatusBroadcastActivityNode."""
-        import py_trees as pt
-
-        node = CreateStatusBroadcastActivityNode(
-            status_id=STATUS_ID,
-            participant_id=PARTICIPANT_REF_ID,
-        )
-        seq = pt.composites.Sequence(
-            name="TestSeq",
-            memory=False,
-            children=[
-                FindCaseManagerNode(case_id=CASE_ID),
-                FilterPeerRecipientsNode(
-                    sender_actor_id=ACTOR_ID, case_id=CASE_ID
-                ),
-                node,
-            ],
-        )
-        bridge = BTBridge(datalayer=dl, trigger_activity=factory)
-        return bridge.execute_with_setup(tree=seq, actor_id=actor_id)
-
-    def test_returns_success_skips_factory_when_no_recipients(
-        self, populated_dl
-    ):
-        """Empty recipient list after filtering → SUCCESS without calling factory.
-
-        Regression for the missing empty-list guard: previously,
-        CreateStatusBroadcastActivityNode would call the factory with to=[].
-        """
-        from unittest.mock import MagicMock
-
-        # Remove the peer so FilterPeerRecipientsNode writes an empty list.
-        case = populated_dl.read(CASE_ID)
-        del case.actor_participant_index[PEER_ID]
-        populated_dl.save(case)
-
-        mock_factory = MagicMock()
-        result = self._run_with_prefilled_blackboard(
-            populated_dl,
-            actor_id=CASE_MANAGER_ID,
-            recipient_ids=[],
-            factory=mock_factory,
-        )
-        assert result.status == Status.SUCCESS
-        # Factory must not be called for an empty recipient list.
-        mock_factory.add_participant_status_to_participant.assert_not_called()
-
-    def test_returns_failure_when_no_factory_and_recipients_exist(
-        self, populated_dl
-    ):
-        """Recipients exist but no factory → FAILURE (BT-14-001)."""
-        result = self._run_with_prefilled_blackboard(
-            populated_dl,
-            actor_id=CASE_MANAGER_ID,
-            recipient_ids=[PEER_ID],
-            factory=None,
         )
         assert result.status == Status.FAILURE

--- a/test/core/behaviors/status/test_add_participant_status_bt.py
+++ b/test/core/behaviors/status/test_add_participant_status_bt.py
@@ -20,7 +20,8 @@ Covers all five DEMOMA-07-003 steps:
   2. AppendParticipantStatusNode  — status appended, RM regression rejected
   3. BroadcastStatusToPeersNode   — fail-fast (BT-14-001): FAILURE when no
      factory or delivery fails; SUCCESS when no peers to notify (no-op)
-  4. PublicDisclosureBranchNode   — always SUCCESS, only triggers teardown on CS.P + CASE_OWNER
+  4. PublicDisclosureBranchNode   — SUCCESS when skip conditions met; FAILURE
+     when teardown needed but dispatch fails (BT-14-001)
   5. AutoCloseBranchNode          — always SUCCESS, logs when all RM.CLOSED
 
 Per specs/multi-actor-demo.yaml DEMOMA-07-003.
@@ -40,13 +41,13 @@ from vultron.core.behaviors.status.add_participant_status_tree import (
 from vultron.core.behaviors.status.append_participant_status_tree import (
     append_participant_status_tree,
 )
+from vultron.core.behaviors.broadcast.nodes import CreateBroadcastActivityNode
 from vultron.core.behaviors.status.nodes import (
     AppendStatusAndSaveParticipantNode,
     AutoCloseBranchNode,
     BroadcastQueueToOutboxNode,
     BroadcastStatusToPeersNode,
     CheckStatusNotAlreadyAppendedNode,
-    CreateStatusBroadcastActivityNode,
     FilterPeerRecipientsNode,
     FindCaseManagerNode,
     LoadParticipantNode,
@@ -941,75 +942,6 @@ class TestFilterPeerRecipientsNode:
 
 
 # ---------------------------------------------------------------------------
-# Step 3 leaf nodes: CreateStatusBroadcastActivityNode
-# ---------------------------------------------------------------------------
-
-
-class TestCreateStatusBroadcastActivityNode:
-    def _run_to_create(self, dl, actor_id, trigger_activity=None):
-        """Run the three-node prefix ending at CreateStatusBroadcastActivityNode."""
-        seq = py_trees.composites.Sequence(
-            name="TestSeq",
-            memory=False,
-            children=[
-                FindCaseManagerNode(case_id=CASE_ID),
-                FilterPeerRecipientsNode(
-                    sender_actor_id=ACTOR_ID, case_id=CASE_ID
-                ),
-                CreateStatusBroadcastActivityNode(
-                    status_id=STATUS_ID,
-                    participant_id=PARTICIPANT_ID,
-                ),
-            ],
-        )
-        bridge = BTBridge(datalayer=dl, trigger_activity=trigger_activity)
-        return bridge.execute_with_setup(tree=seq, actor_id=actor_id)
-
-    def test_returns_failure_without_trigger_activity_factory(
-        self, populated_dl_with_peer
-    ):
-        """No trigger_activity → CreateStatusBroadcastActivityNode FAILURE."""
-        result = self._run_to_create(
-            populated_dl_with_peer, actor_id=CASE_MANAGER_ID
-        )
-        assert result.status == Status.FAILURE
-
-    def test_calls_factory_with_correct_args(self, populated_dl_with_peer):
-        """Calls factory with case_manager as actor and peer as recipient."""
-        trigger_activity = MagicMock()
-        trigger_activity.add_participant_status_to_participant.return_value = (
-            "urn:uuid:activity-1"
-        )
-        result = self._run_to_create(
-            populated_dl_with_peer,
-            actor_id=CASE_MANAGER_ID,
-            trigger_activity=trigger_activity,
-        )
-        assert result.status == Status.SUCCESS
-        trigger_activity.add_participant_status_to_participant.assert_called_once_with(
-            status_id=STATUS_ID,
-            participant_id=PARTICIPANT_ID,
-            actor=CASE_MANAGER_ID,
-            to=[PEER_ACTOR_ID],
-        )
-
-    def test_returns_failure_on_vultron_error(self, populated_dl_with_peer):
-        """VultronError from factory → FAILURE (non-fatal for caller)."""
-        from vultron.errors import VultronError
-
-        trigger_activity = MagicMock()
-        trigger_activity.add_participant_status_to_participant.side_effect = (
-            VultronError("factory error")
-        )
-        result = self._run_to_create(
-            populated_dl_with_peer,
-            actor_id=CASE_MANAGER_ID,
-            trigger_activity=trigger_activity,
-        )
-        assert result.status == Status.FAILURE
-
-
-# ---------------------------------------------------------------------------
 # Step 3 leaf nodes: BroadcastQueueToOutboxNode
 # ---------------------------------------------------------------------------
 
@@ -1027,9 +959,13 @@ class TestBroadcastQueueToOutboxNode:
                 FilterPeerRecipientsNode(
                     sender_actor_id=ACTOR_ID, case_id=CASE_ID
                 ),
-                CreateStatusBroadcastActivityNode(
-                    status_id=STATUS_ID,
-                    participant_id=PARTICIPANT_ID,
+                CreateBroadcastActivityNode(
+                    activity_builder=lambda factory, cm_id, recipients: factory.add_participant_status_to_participant(
+                        status_id=STATUS_ID,
+                        participant_id=PARTICIPANT_ID,
+                        actor=cm_id,
+                        to=recipients,
+                    )
                 ),
                 BroadcastQueueToOutboxNode(),
             ],
@@ -1115,7 +1051,12 @@ class TestPublicDisclosureBranchNode:
     def test_triggers_teardown_on_public_aware_case_owner(
         self, populated_dl, populated_bridge, case, status_obj
     ):
-        """CS.P + CASE_OWNER sender → embargo terminated, EM=EXITED, PEC reset."""
+        """CS.P + CASE_OWNER sender → embargo terminated (EM=EXITED), but
+        FAILURE when no broadcast factory (BT-14-001).
+
+        State transitions are committed before broadcast; the FAILURE propagates
+        from the missing factory so callers can handle delivery errors.
+        """
         from vultron.core.states.cs import CS_pxa
         from vultron.core.states.em import EM
         from vultron.wire.as2.vocab.objects.case_status import CaseStatus
@@ -1141,15 +1082,67 @@ class TestPublicDisclosureBranchNode:
             sender_actor_id=ACTOR_ID,
             case_id=CASE_ID,
         )
+        # No factory → broadcast fails → FAILURE (BT-14-001)
         result = populated_bridge.execute_with_setup(
             tree=node, actor_id=CASE_MANAGER_ID
         )
-        assert result.status == Status.SUCCESS
+        assert result.status == Status.FAILURE
+
+        from typing import cast as c
 
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
             VulnerabilityCase,
         )
+
+        # State was still applied before the broadcast attempt
+        updated = c(VulnerabilityCase, populated_dl.read(CASE_ID))
+        assert updated.current_status.em_state == EM.EXITED
+        assert updated.active_embargo is None
+
+    def test_triggers_teardown_succeeds_with_factory(
+        self, populated_dl, case, status_obj
+    ):
+        """CS.P + CASE_OWNER sender + factory → SUCCESS and EM=EXITED."""
+        from unittest.mock import MagicMock
         from typing import cast as c
+
+        from vultron.core.states.cs import CS_pxa
+        from vultron.core.states.em import EM
+        from vultron.wire.as2.vocab.objects.case_status import CaseStatus
+        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+
+        embargo = EmbargoEvent(
+            id_=f"{CASE_ID}/embargo_events/e1", context=CASE_ID
+        )
+        case.active_embargo = embargo.id_
+        case.current_status.em_state = EM.ACTIVE
+        populated_dl.create(embargo)
+        populated_dl.save(case)
+
+        cs = CaseStatus()
+        cs.pxa_state = CS_pxa.Pxa
+        status_obj.case_status = cs
+        populated_dl.save(status_obj)
+
+        mock_factory = MagicMock()
+        mock_factory.terminate_embargo.return_value = (
+            "urn:uuid:terminate-1",
+            "urn:uuid:terminate-event-1",
+        )
+        bridge = BTBridge(
+            datalayer=populated_dl, trigger_activity=mock_factory
+        )
+
+        node = PublicDisclosureBranchNode(
+            status_obj=status_obj,
+            sender_actor_id=ACTOR_ID,
+            case_id=CASE_ID,
+        )
+        result = bridge.execute_with_setup(tree=node, actor_id=CASE_MANAGER_ID)
+        assert result.status == Status.SUCCESS
 
         updated = c(VulnerabilityCase, populated_dl.read(CASE_ID))
         assert updated.current_status.em_state == EM.EXITED

--- a/vultron/core/behaviors/embargo/nodes/lifecycle.py
+++ b/vultron/core/behaviors/embargo/nodes/lifecycle.py
@@ -226,12 +226,23 @@ class TerminateEmbargoNode(DataLayerAction):
 
     Applies the ACTIVE/REVISE → EXITED EM state transition via the state
     machine, clears ``active_embargo``, resets all participant embargo
-    consent states, and queues a ``Terminate(EmbargoEvent)`` activity when a
-    ``trigger_activity_factory`` is available.
+    consent states, and queues a ``Terminate(EmbargoEvent)`` activity via
+    ``trigger_activity_factory``.
 
-    Always returns SUCCESS.  Failures (no active embargo, invalid EM
-    transition, activity dispatch errors) are logged as WARNING and are
-    treated as non-fatal.
+    Returns SUCCESS when teardown completes and the broadcast activity is
+    queued successfully.
+
+    Returns SUCCESS (no-op) when:
+
+    - ``case_id`` is ``None`` or ``datalayer`` is unavailable
+    - The case is not found in the DataLayer
+    - There is no active embargo on the case
+    - The EM state machine rejects the ``terminate`` transition
+
+    Returns FAILURE (BT-14-001) when the embargo state transition succeeds
+    but the outbound ``Terminate(EmbargoEvent)`` activity cannot be created
+    or queued (missing factory, unresolvable Case Manager, or dispatch
+    exception).
     """
 
     def __init__(self, case_id: str | None, name: str | None = None):
@@ -292,33 +303,36 @@ class TerminateEmbargoNode(DataLayerAction):
             adapter.state,
         )
 
-        self._dispatch_activity(embargo_id, case_manager_id)
-        return Status.SUCCESS
+        return self._dispatch_activity(embargo_id, case_manager_id)
 
     def _dispatch_activity(
         self, embargo_id: str | None, case_manager_id: str | None
-    ) -> None:
+    ) -> Status:
         """Queue a Terminate(EmbargoEvent) activity to the case manager's outbox.
 
-        No-ops when ``trigger_activity_factory`` is unavailable, ``embargo_id``
-        is missing, or the case manager cannot be resolved.  Activity dispatch
-        failures are logged as WARNING and do not affect the BT return value.
+        Returns FAILURE (BT-14-001) when the factory is unavailable, the
+        Case Manager cannot be resolved, or dispatch raises an exception.
+        Returns SUCCESS when the activity is created and queued.
         """
-        if (
-            self.trigger_activity_factory is None
-            or embargo_id is None
-            or self.datalayer is None
-        ):
-            return
+        if self.trigger_activity_factory is None:
+            self.feedback_message = (
+                "trigger_activity_factory not available"
+                " — broadcast FAILURE (BT-14-001)"
+            )
+            self.logger.warning("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
+
+        if embargo_id is None or self.datalayer is None:
+            self.feedback_message = "embargo_id or datalayer not available"
+            return Status.FAILURE
 
         if case_manager_id is None:
-            self.logger.warning(
-                "%s: no CASE_MANAGER found for case '%s'"
-                " — activity dispatch skipped",
-                self.name,
-                self.case_id,
+            self.feedback_message = (
+                f"no CASE_MANAGER found for case '{self.case_id}'"
+                " — activity dispatch skipped (BT-14-001)"
             )
-            return
+            self.logger.warning("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
 
         try:
             case_id: str = self.case_id  # type: ignore[assignment]  # guarded above
@@ -334,12 +348,13 @@ class TerminateEmbargoNode(DataLayerAction):
                 cast(CaseOutboxPersistence, self.datalayer),
             )
         except Exception as exc:
-            self.logger.warning(
-                "%s: activity dispatch failed for case '%s': %s",
-                self.name,
-                self.case_id,
-                exc,
+            self.feedback_message = (
+                f"activity dispatch failed for case '{self.case_id}': {exc}"
             )
+            self.logger.warning("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
+
+        return Status.SUCCESS
 
 
 class SetEmbargoActiveNode(DataLayerAction):

--- a/vultron/core/behaviors/status/nodes/__init__.py
+++ b/vultron/core/behaviors/status/nodes/__init__.py
@@ -21,12 +21,13 @@ submodules so that existing import paths
 without modification.
 
 Submodules:
+
 - ``conditions``: Participant verification condition nodes
 - ``broadcast``: Peer fan-out helper and nodes (_find_case_manager_id,
   FindCaseManagerNode, FilterPeerRecipientsNode,
-  CreateStatusBroadcastActivityNode, BroadcastQueueToOutboxNode,
-  BroadcastStatusToPeersNode); shared nodes are re-exported from
-  :mod:`vultron.core.behaviors.broadcast.nodes` (BT-14-001, BT-14-002)
+  BroadcastQueueToOutboxNode, BroadcastStatusToPeersNode); shared nodes
+  are re-exported from :mod:`vultron.core.behaviors.broadcast.nodes`
+  (BT-14-001, BT-14-002)
 - ``append``: Load, validate RM transition, and append action nodes
   (SkipIfIdempotentNode, LoadParticipantNode,
   CheckStatusNotAlreadyAppendedNode, ResolveAndPersistStatusObjectNode,
@@ -41,7 +42,6 @@ Submodules:
 from vultron.core.behaviors.status.nodes.broadcast import (
     BroadcastQueueToOutboxNode,
     BroadcastStatusToPeersNode,
-    CreateStatusBroadcastActivityNode,
     FilterPeerRecipientsNode,
     FindCaseManagerNode,
     _find_case_manager_id,
@@ -76,7 +76,6 @@ __all__ = [
     "_find_case_manager_id",
     "FindCaseManagerNode",
     "FilterPeerRecipientsNode",
-    "CreateStatusBroadcastActivityNode",
     "BroadcastQueueToOutboxNode",
     "BroadcastStatusToPeersNode",
     # append

--- a/vultron/core/behaviors/status/nodes/broadcast.py
+++ b/vultron/core/behaviors/status/nodes/broadcast.py
@@ -17,8 +17,7 @@
 
 Re-exports the shared generic nodes from
 :mod:`vultron.core.behaviors.broadcast.nodes` and provides the
-status-specific :class:`CreateStatusBroadcastActivityNode` and the
-updated :class:`BroadcastStatusToPeersNode`.
+status-specific :class:`BroadcastStatusToPeersNode`.
 
 Per DEMOMA-07-003 step 3 and specs/behavior-tree-integration.yaml
 BT-14-001, BT-14-002.
@@ -28,117 +27,16 @@ import logging
 from typing import Any
 
 import py_trees
-from py_trees.common import Status
 
 from vultron.core.behaviors.broadcast.nodes import (  # noqa: F401
     BroadcastQueueToOutboxNode,
+    CreateBroadcastActivityNode,
     FilterPeerRecipientsNode,
     FindCaseManagerNode,
     _find_case_manager_id,
 )
-from vultron.core.behaviors.helpers import DataLayerAction
 
 logger = logging.getLogger(__name__)
-
-
-class CreateStatusBroadcastActivityNode(DataLayerAction):
-    """Create the broadcast Add(ParticipantStatus, CaseParticipant) activity.
-
-    Reads ``broadcast_case_manager_id`` and ``broadcast_peer_recipient_ids``
-    from the blackboard (written by :class:`FindCaseManagerNode` and
-    :class:`FilterPeerRecipientsNode`) and calls ``trigger_activity_factory``
-    to construct the broadcast activity addressed from the Case Manager to all
-    peer recipients.
-
-    Writes the resulting activity ID to the blackboard under
-    ``broadcast_activity_id``.
-
-    Returns SUCCESS on successful activity creation.
-    Returns FAILURE when:
-    - ``trigger_activity_factory`` is not available
-    - Required blackboard keys are missing
-    - The factory raises :class:`~vultron.errors.VultronError`
-
-    Per DEMOMA-07-003 step 3.
-    """
-
-    def __init__(
-        self,
-        status_id: str,
-        participant_id: str,
-        name: str | None = None,
-    ) -> None:
-        super().__init__(name=name or self.__class__.__name__)
-        self.status_id = status_id
-        self.participant_id = participant_id
-
-    def setup(self, **kwargs: Any) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="broadcast_case_manager_id",
-            access=py_trees.common.Access.READ,
-        )
-        self.blackboard.register_key(
-            key="broadcast_peer_recipient_ids",
-            access=py_trees.common.Access.READ,
-        )
-        self.blackboard.register_key(
-            key="broadcast_activity_id",
-            access=py_trees.common.Access.WRITE,
-        )
-
-    def update(self) -> Status:
-        if self.trigger_activity_factory is None:
-            self.feedback_message = "trigger_activity_factory not available"
-            self.logger.debug(
-                "CreateStatusBroadcastActivity: no trigger_activity_factory"
-                " — skipping (DEMOMA-07-003 step 3)"
-            )
-            return Status.FAILURE
-
-        try:
-            case_manager_id: str = self.blackboard.broadcast_case_manager_id
-            recipient_ids: list[str] = (
-                self.blackboard.broadcast_peer_recipient_ids
-            )
-        except KeyError as exc:
-            self.feedback_message = f"Required blackboard key missing: {exc}"
-            return Status.FAILURE
-
-        if not recipient_ids:
-            self.logger.debug(
-                "CreateStatusBroadcastActivity: no recipients — skipping"
-                " (DEMOMA-07-003 step 3)"
-            )
-            return Status.SUCCESS
-
-        from vultron.errors import VultronError
-
-        try:
-            activity_id = self.trigger_activity_factory.add_participant_status_to_participant(
-                status_id=self.status_id,
-                participant_id=self.participant_id,
-                actor=case_manager_id,
-                to=recipient_ids,
-            )
-        except VultronError as exc:
-            self.feedback_message = (
-                f"Broadcast activity creation failed: {exc}"
-            )
-            self.logger.warning(
-                "CreateStatusBroadcastActivity: %s", self.feedback_message
-            )
-            return Status.FAILURE
-
-        self.blackboard.broadcast_activity_id = activity_id
-        self.logger.debug(
-            "CreateStatusBroadcastActivity: created broadcast activity '%s'"
-            " from '%s' to %d peer(s)",
-            activity_id,
-            case_manager_id,
-            len(recipient_ids),
-        )
-        return Status.SUCCESS
 
 
 class BroadcastStatusToPeersNode(py_trees.composites.Sequence):
@@ -175,10 +73,6 @@ class BroadcastStatusToPeersNode(py_trees.composites.Sequence):
         name: str | None = None,
     ):
         super().__init__(name=name or self.__class__.__name__, memory=False)
-
-        from vultron.core.behaviors.broadcast.nodes import (
-            CreateBroadcastActivityNode,
-        )
 
         def _status_activity_builder(
             factory: Any, case_manager_id: str, recipient_ids: list[str]

--- a/vultron/core/behaviors/status/nodes/lifecycle.py
+++ b/vultron/core/behaviors/status/nodes/lifecycle.py
@@ -121,15 +121,19 @@ class PublicDisclosureBranchNode(py_trees.composites.Selector):
     the sender holds the CASE_OWNER role.
 
     When the condition is met, delegates to :class:`TerminateEmbargoNode`.
-    Skips silently if conditions are not met or trigger_activity_factory
-    is unavailable.
+    Skips silently if conditions are not met.
 
-    Always returns SUCCESS (failure to initiate teardown is not fatal to
-    the parent sequence).
+    Returns SUCCESS when teardown conditions are not met (skip path) or
+    when teardown completes and the broadcast activity is queued.
+    Returns FAILURE when teardown is needed but the outbound
+    ``Terminate(EmbargoEvent)`` activity cannot be dispatched (BT-14-001).
 
     Implemented as a ``py_trees.composites.Selector`` (memory=False):
-    - Child 1 ``_PublicDisclosureSkipConditionNode``: SUCCESS → skip teardown.
-    - Child 2 ``TerminateEmbargoNode``: always SUCCESS → teardown attempted.
+
+    - Child 1 ``_PublicDisclosureSkipConditionNode``: SUCCESS → skip
+      teardown.
+    - Child 2 ``TerminateEmbargoNode``: SUCCESS on success; FAILURE when
+      dispatch fails (BT-14-001).
 
     Per DEMOMA-07-003 step 4.
     """


### PR DESCRIPTION
- Closes #835

## Summary

Migrates the status and embargo BT broadcast paths to fail-fast semantics per
spec BT-14-001: protocol-visible peer broadcast fan-out nodes now return
`FAILURE` on delivery errors instead of silently swallowing them.

## Changes

**`vultron/core/behaviors/embargo/nodes/lifecycle.py`**
- `TerminateEmbargoNode._dispatch_activity()`: return type `None → Status`;
  returns `FAILURE` when factory unavailable, `case_manager_id` missing, or
  dispatch raises; returns `SUCCESS` on successful enqueue
- `TerminateEmbargoNode.update()`: propagates `_dispatch_activity()` result
  instead of always returning `SUCCESS`

**`vultron/core/behaviors/status/nodes/broadcast.py`**
- Removed dead `CreateStatusBroadcastActivityNode` class (superseded by #834)
- `BroadcastStatusToPeersNode` already uses fail-fast shared nodes

**`vultron/core/behaviors/status/nodes/{__init__,lifecycle}.py`**
- Removed `CreateStatusBroadcastActivityNode` export; updated docstrings

**Tests**
- `test_lifecycle.py` (embargo): 3 tests updated `SUCCESS→FAILURE` (no factory
  present); added `test_returns_failure_when_factory_raises`
- `test_broadcast.py` (status): removed `TestCreateStatusBroadcastActivityNode`
- `test_add_participant_status_bt.py`: removed dead test class; updated
  `_run_full_broadcast_sequence` to use `CreateBroadcastActivityNode`; updated
  `test_triggers_teardown_on_public_aware_case_owner` to assert `FAILURE` (no
  factory) while verifying EM state still committed; added
  `test_triggers_teardown_succeeds_with_factory` for `SUCCESS` path

## Verification

```
3475 passed, 37 skipped, 225 deselected, 2 xfailed, 5633 subtests passed in 57.66s
```

All four linters (Black, flake8, mypy, pyright) pass cleanly.
