### PR TITLE
feat: per-case genesis hash origin binding for case ledger (CLP-08)

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -294,3 +294,20 @@ value from a prior execution.  `BroadcastQueueToOutboxNode` must treat both
 no-op sentinels and skip `record_outbox_item`.  Always add regression tests
 that intentionally do NOT clear the blackboard between two `execute_with_setup`
 calls to catch this class of bug.
+
+### 2026-06-18 CLP-08-995-WIRE-GENESIS — wire VulnerabilityCase must not fall back to `updated` for genesis hash
+
+The wire `VulnerabilityCase` model validator had `created_at = self.published or self.updated`
+for computing the genesis hash. Using `updated` as a fallback silently produces a hash that
+diverges from the CaseActor's hash (which always uses `published`). The correct fix is to
+skip genesis hash computation entirely when `published` is absent — leave `genesis_hash=""`
+and let callers treat an empty string as "unknown, skip genesis validation". A wrong hash
+is strictly worse than no hash.
+
+### 2026-06-18 CLP-08-995-POSITIVE-TEST — freshness tests need a case in DataLayer for genesis-hash path
+
+`is_ledger_fresh_for_case` skips the genesis-hash check when `effective_genesis == ""`.
+Positive freshness tests that don't save a `VulnerabilityCase` to the DataLayer always
+bypass the genesis-hash validation path — they pass even if `_get_case_genesis_hash` is
+broken. Always add a positive test that stores the case first (via `dl.save(_make_case())`)
+to exercise the active genesis-hash check path (CLP-08-004).

--- a/plan/history/2606/implementation/ISSUE-995.md
+++ b/plan/history/2606/implementation/ISSUE-995.md
@@ -1,0 +1,37 @@
+---
+source: ISSUE-995
+timestamp: '2026-06-18T18:57:53.315794+00:00'
+title: Per-case genesis hash origin binding (CLP-08)
+type: implementation
+---
+
+## Issue #995 — Implement per-case genesis hash origin binding (CLP-08)
+
+Replaced the global `GENESIS_HASH = "0" * 64` sentinel with a per-case genesis
+hash derived from case-specific metadata (SHA-256 of case_id + "|" +
+created_at.isoformat() + "|" + case_actor_id), cryptographically anchoring each
+case ledger to its origin identity and timestamp (CLP-08-001, CLP-08-002).
+
+### What was implemented
+
+- `compute_genesis_hash(case_id, created_at, case_actor_id)` added to
+  `vultron/core/models/case_ledger.py`; global `GENESIS_HASH` constant removed
+- `CaseLedger.__init__` updated to require `genesis_hash: str`; `tail_hash` and
+  `verify_chain` use `self._genesis_hash` (CLP-08-004)
+- `genesis_hash: str` field added to core and wire `VulnerabilityCase` with a
+  `model_validator` that auto-computes at construction from `id_`, `published`,
+  and `attributed_to` (CLP-08-003); wire model uses only `published` (not
+  `updated` fallback) to avoid divergence with the CaseActor's computed hash
+- `_get_case_genesis_hash(case_id, dl)` added to `sync_helpers`; duck-typed via
+  `getattr` to avoid importing wire types from core; `is_ledger_fresh_for_case`
+  updated with optional `genesis_hash` parameter; `_reconstruct_tail_hash` uses
+  per-case genesis when ledger is empty (CLP-08-005)
+- `last_acknowledged_hash`, `last_accepted_hash`, and `prev_log_hash` defaults
+  all updated to `""` (empty string) across models
+- 18 test files updated; positive CLP-08-004 coverage added in
+  `test/core/test_sync_helpers.py::TestContiguousChain::test_per_case_genesis_hash_chain_is_fresh`
+
+### Outcome
+
+All 3705 tests pass (1 new). Black, flake8, mypy, pyright clean.
+PR: [#1048](https://github.com/CERTCC/Vultron/pull/1048)

--- a/test/adapters/driven/test_sqlite_backend.py
+++ b/test/adapters/driven/test_sqlite_backend.py
@@ -37,6 +37,8 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Offer,
 )
 
+_ZERO_HASH: str = "0" * 64  # arbitrary hash for test chains
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -882,7 +884,6 @@ class TestCoerceToSemanticClass:
     def test_announce_log_entry_round_trip_returns_specific_class(self, dl):
         """dl.read returns AnnounceLogEntryActivity with CaseLedgerEntry object_."""
         from vultron.core.models.case_ledger import (
-            GENESIS_HASH,
             HashChainLedgerRecord,
         )
         from vultron.core.behaviors.sync.nodes.chain import (
@@ -898,7 +899,7 @@ class TestCoerceToSemanticClass:
             object_id="https://example.org/activities/logged-1",
             event_type="log_entry_committed",
             payload_snapshot={"status": "ok"},
-            prev_log_hash=GENESIS_HASH,
+            prev_log_hash=_ZERO_HASH,
         )
         entry = _to_persistable_entry(chain_entry)
         announce = announce_log_entry_activity(

--- a/test/adapters/driving/fastapi/test_outbox.py
+++ b/test/adapters/driving/fastapi/test_outbox.py
@@ -47,6 +47,8 @@ from vultron.errors import (
     VultronOutboxToFieldMissingError,
 )
 
+_ZERO_HASH: str = "0" * 64  # arbitrary hash for test chains
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -853,7 +855,6 @@ def test_handle_outbox_item_converts_typed_activity_with_full_target():
 def test_handle_outbox_item_preserves_inline_case_ledger_entry_fields():
     """Announce(CaseLedgerEntry) delivery keeps full inline log-entry fields."""
     from vultron.core.models.case_ledger import (
-        GENESIS_HASH,
         HashChainLedgerRecord,
     )
     from vultron.core.behaviors.sync.nodes.chain import _to_persistable_entry
@@ -869,7 +870,7 @@ def test_handle_outbox_item_preserves_inline_case_ledger_entry_fields():
         object_id="https://example.org/activities/logged-2",
         event_type="log_entry_committed",
         payload_snapshot={"state": "replicated"},
-        prev_log_hash=GENESIS_HASH,
+        prev_log_hash=_ZERO_HASH,
     )
     entry = _to_persistable_entry(chain_entry)
     activity = announce_log_entry_activity(

--- a/test/ci/test_case_ledger_invariants.py
+++ b/test/ci/test_case_ledger_invariants.py
@@ -42,6 +42,7 @@ Spec: CLP-07.
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -54,7 +55,8 @@ from vultron.core.states.roles import CVDRole
 # ---------------------------------------------------------------------------
 
 #: Sentinel hash used for the genesis entry (mirrors vultron.core.models.case_ledger).
-GENESIS_HASH: str = "0" * 64
+#: After per-case genesis hash (CLP-08), genesis prevLogHash is a SHA-256 of case metadata.
+_SHA256_HEX_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 
 _REPO_ROOT: Path = Path(__file__).resolve().parents[2]
 _DEVLOGS_DIR: Path = _REPO_ROOT / "devlogs"
@@ -250,7 +252,8 @@ def test_invariant_1_local_hash_chain_consistent(
 
     - ``entry[N].prevLogHash == entry[N-1].entryHash``
     - If the run starts at ``logIndex=0``, that entry's ``prevLogHash``
-      must equal ``GENESIS_HASH``.
+      must be a valid 64-character hex SHA-256 (the per-case genesis hash,
+      CLP-08).
 
     Cross-fragment boundaries are **not** checked: if logIndex 4 is absent
     the check does not assert that entry 5's prevLogHash equals entry 3's
@@ -269,9 +272,10 @@ def test_invariant_1_local_hash_chain_consistent(
 
         if first_idx == 0:
             actual_prev = _prev_log_hash(first)
-            assert actual_prev == GENESIS_HASH, (
+            assert _SHA256_HEX_PATTERN.match(actual_prev), (
                 f"Actor {actor_name!r}: fragment starting at logIndex=0 "
-                f"prevLogHash={actual_prev!r} != GENESIS_HASH"
+                f"prevLogHash={actual_prev!r} is not a valid 64-char hex "
+                f"SHA-256 (per-case genesis hash, CLP-08)"
             )
 
         for i, entry in enumerate(fragment[1:], start=1):

--- a/test/core/behaviors/case/nodes/test_guarded_commit_tree.py
+++ b/test/core/behaviors/case/nodes/test_guarded_commit_tree.py
@@ -52,6 +52,7 @@ def _seed_case_with_manager(bt_scenario: BTTestScenario) -> None:
     case = VultronCase(
         id_=CASE_ID,
         name="Test Case",
+        attributed_to=MANAGER_ACTOR_ID,
         case_participants=[manager_participant.id_, vendor_participant.id_],
         actor_participant_index={
             MANAGER_ACTOR_ID: manager_participant.id_,

--- a/test/core/behaviors/sync/nodes/conftest.py
+++ b/test/core/behaviors/sync/nodes/conftest.py
@@ -8,6 +8,7 @@ import pytest
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.core.behaviors.bridge import BTBridge
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_actor import VultronCaseActor
 from vultron.core.models.case_ledger import HashChainLedgerRecord
 from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
@@ -22,6 +23,8 @@ from vultron.wire.as2.vocab.objects.case_ledger_entry import (
 OWNER_ACTOR_ID = "https://example.org/actors/vendor"
 PARTICIPANT_ACTOR_ID = "https://example.org/actors/reporter"
 CASE_ID = "https://example.org/cases/case-sync"
+
+_ZERO_HASH: str = "0" * 64  # arbitrary prev_log_hash for test chains
 
 
 @pytest.fixture(autouse=True)
@@ -42,6 +45,13 @@ def bridge(datalayer):
 
 
 @pytest.fixture
+def case_obj(datalayer):
+    case = VulnerabilityCase(id_=CASE_ID, attributed_to=OWNER_ACTOR_ID)
+    datalayer.save(case)
+    return case
+
+
+@pytest.fixture
 def case_actor(datalayer):
     actor = VultronCaseActor(
         name="Case Actor",
@@ -52,7 +62,9 @@ def case_actor(datalayer):
     return actor
 
 
-def _make_entry(log_index: int, prev_hash: str) -> VultronCaseLedgerEntry:
+def _make_entry(
+    log_index: int, prev_hash: str = _ZERO_HASH
+) -> VultronCaseLedgerEntry:
     return _to_persistable_entry(
         HashChainLedgerRecord(
             case_id=CASE_ID,

--- a/test/core/behaviors/sync/nodes/test_chain.py
+++ b/test/core/behaviors/sync/nodes/test_chain.py
@@ -17,11 +17,12 @@ from vultron.core.behaviors.sync.nodes import (
     CreateLogEntryNode,
     PersistLogEntryNode,
 )
-from vultron.core.models.case_ledger import GENESIS_HASH
 from vultron.core.behaviors.sync.nodes.chain import (
     _validate_canonical_entry,
 )
 from vultron.errors import VultronCanonicalEntryError
+
+_ZERO_HASH: str = "0" * 64  # arbitrary hash for test chains
 
 
 def _canonical_note_snapshot(actor_id: str) -> dict[str, object]:
@@ -60,7 +61,7 @@ def test_create_log_entry_node_writes_log_entry_to_blackboard(bridge):
             name="CreateLogEntry",
         ),
         actor_id=OWNER_ACTOR_ID,
-        tail_hash=GENESIS_HASH,
+        tail_hash=_ZERO_HASH,
         tail_index=-1,
     )
 
@@ -149,7 +150,7 @@ def test_create_log_entry_node_rejects_non_canonical_snapshots(
             name="CreateLogEntry",
         ),
         actor_id=OWNER_ACTOR_ID,
-        tail_hash=GENESIS_HASH,
+        tail_hash=_ZERO_HASH,
         tail_index=-1,
     )
 
@@ -167,7 +168,7 @@ def test_create_log_entry_node_allows_case_authored_announce(bridge):
             name="CreateLogEntry",
         ),
         actor_id=OWNER_ACTOR_ID,
-        tail_hash=GENESIS_HASH,
+        tail_hash=_ZERO_HASH,
         tail_index=-1,
     )
 
@@ -260,7 +261,7 @@ class TestPersistLogEntryNodeLogging:
 
     @pytest.fixture()
     def entry(self):
-        return _make_entry(log_index=0, prev_hash=GENESIS_HASH)
+        return _make_entry(log_index=0, prev_hash=_ZERO_HASH)
 
     def test_info_log_emitted_on_persist(
         self, bridge, entry, caplog: pytest.LogCaptureFixture

--- a/test/core/behaviors/sync/nodes/test_conditions.py
+++ b/test/core/behaviors/sync/nodes/test_conditions.py
@@ -13,12 +13,11 @@ from vultron.core.behaviors.sync.nodes import (
     CheckIsOwnCaseActorNode,
     CheckLedgerFreshnessNode,
 )
-from vultron.core.models.case_ledger import GENESIS_HASH
 from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
 
 
 def test_check_is_own_case_actor_succeeds_for_case_owner(bridge, case_actor):
-    entry = _make_entry(0, GENESIS_HASH)
+    entry = _make_entry(0)
     event = _make_event(entry, actor_id=case_actor.id_)
 
     result = bridge.execute_with_setup(
@@ -44,7 +43,7 @@ class TestCheckLedgerFreshnessNodeWithCaseIdArg:
         assert result.status == Status.SUCCESS
 
     def test_contiguous_chain_is_fresh(self, bridge, datalayer):
-        e0 = _make_entry(0, GENESIS_HASH)
+        e0 = _make_entry(0)
         datalayer.save(e0)
         e1 = _make_entry(1, e0.entry_hash)
         datalayer.save(e1)
@@ -59,7 +58,7 @@ class TestCheckLedgerFreshnessNodeWithCaseIdArg:
 
     def test_gap_in_ledger_is_stale(self, bridge, datalayer):
         """SYNC-10-004: any gap blocks the gate."""
-        e0 = _make_entry(0, GENESIS_HASH)
+        e0 = _make_entry(0)
         datalayer.save(e0)
         # Skip index 1; jump to index 2
         e2 = VultronCaseLedgerEntry(
@@ -83,7 +82,7 @@ class TestCheckLedgerFreshnessNodeWithCaseIdArg:
 
     def test_hash_mismatch_is_stale(self, bridge, datalayer):
         """SYNC-10-004: hash mismatch at any link is stale."""
-        e0 = _make_entry(0, GENESIS_HASH)
+        e0 = _make_entry(0)
         datalayer.save(e0)
         bad_e1 = VultronCaseLedgerEntry(
             case_id=CASE_ID,
@@ -109,7 +108,7 @@ class TestCheckLedgerFreshnessNodeWithCaseIdArg:
         import logging
 
         # Create a gap
-        e0 = _make_entry(0, GENESIS_HASH)
+        e0 = _make_entry(0)
         datalayer.save(e0)
         e2 = VultronCaseLedgerEntry(
             case_id=CASE_ID,

--- a/test/core/behaviors/sync/nodes/test_conditions.py
+++ b/test/core/behaviors/sync/nodes/test_conditions.py
@@ -42,8 +42,8 @@ class TestCheckLedgerFreshnessNodeWithCaseIdArg:
         )
         assert result.status == Status.SUCCESS
 
-    def test_contiguous_chain_is_fresh(self, bridge, datalayer):
-        e0 = _make_entry(0)
+    def test_contiguous_chain_is_fresh(self, bridge, datalayer, case_obj):
+        e0 = _make_entry(0, case_obj.genesis_hash)
         datalayer.save(e0)
         e1 = _make_entry(1, e0.entry_hash)
         datalayer.save(e1)

--- a/test/core/behaviors/sync/nodes/test_receive.py
+++ b/test/core/behaviors/sync/nodes/test_receive.py
@@ -15,8 +15,9 @@ from vultron.core.behaviors.sync.nodes import (
     CheckHashOrRejectOnMismatchNode,
     SendRejectLogEntryNode,
 )
-from vultron.core.models.case_ledger import GENESIS_HASH
 from vultron.core.ports.sync_activity import SyncActivityPort
+
+_ZERO_HASH: str = "0" * 64  # arbitrary hash for test chains
 
 
 def test_check_hash_or_reject_on_mismatch_is_selector_with_condition_and_action():
@@ -30,14 +31,14 @@ def test_check_hash_or_reject_on_mismatch_is_selector_with_condition_and_action(
 def test_check_hash_matches_node_succeeds_when_hash_matches(
     bridge, case_actor
 ):
-    entry = _make_entry(0, GENESIS_HASH)
+    entry = _make_entry(0)
     event = _make_event(entry, actor_id=case_actor.id_)
 
     result = bridge.execute_with_setup(
         tree=CheckHashMatchesNode(name="CheckHashMatches"),
         actor_id=PARTICIPANT_ACTOR_ID,
         activity=event,
-        tail_hash=GENESIS_HASH,
+        tail_hash=_ZERO_HASH,
     )
 
     assert result.status == Status.SUCCESS
@@ -52,7 +53,7 @@ def test_send_reject_log_entry_node_sends_reject(bridge, case_actor):
         tree=SendRejectLogEntryNode(name="SendRejectLogEntry"),
         actor_id=PARTICIPANT_ACTOR_ID,
         activity=event,
-        tail_hash=GENESIS_HASH,
+        tail_hash=_ZERO_HASH,
         sync_port=sync_port,
     )
 
@@ -71,7 +72,7 @@ def test_check_hash_or_reject_on_mismatch_sends_reject(bridge, case_actor):
         ),
         actor_id=PARTICIPANT_ACTOR_ID,
         activity=event,
-        tail_hash=GENESIS_HASH,
+        tail_hash=_ZERO_HASH,
         sync_port=sync_port,
     )
 
@@ -82,7 +83,7 @@ def test_check_hash_or_reject_on_mismatch_sends_reject(bridge, case_actor):
 def test_check_hash_or_reject_on_mismatch_short_circuits_on_match(
     bridge, case_actor
 ):
-    entry = _make_entry(0, GENESIS_HASH)
+    entry = _make_entry(0)
     event = _make_event(entry, actor_id=case_actor.id_)
     sync_port = MagicMock(spec=SyncActivityPort)
 
@@ -92,7 +93,7 @@ def test_check_hash_or_reject_on_mismatch_short_circuits_on_match(
         ),
         actor_id=PARTICIPANT_ACTOR_ID,
         activity=event,
-        tail_hash=GENESIS_HASH,
+        tail_hash=_ZERO_HASH,
         sync_port=sync_port,
     )
 

--- a/test/core/behaviors/sync/nodes/test_replay.py
+++ b/test/core/behaviors/sync/nodes/test_replay.py
@@ -23,7 +23,6 @@ from vultron.core.behaviors.sync.nodes import (
     SendMissingEntriesNode,
 )
 from vultron.core.models.case import VultronCase
-from vultron.core.models.case_ledger import GENESIS_HASH
 from vultron.core.models.events.sync import RejectLogEntryReceivedEvent
 from vultron.core.ports.sync_activity import SyncActivityPort
 from vultron.semantic_registry import extract_event
@@ -32,11 +31,13 @@ from vultron.wire.as2.vocab.objects.case_ledger_entry import (
     CaseLedgerEntry as WireCaseLedgerEntry,
 )
 
+_ZERO_HASH: str = "0" * 64  # arbitrary hash for test chains
+
 
 def _make_reject_event(
     *, tail_hash: str, entry_log_index: int = 1
 ) -> RejectLogEntryReceivedEvent:
-    prev_hash = GENESIS_HASH if entry_log_index == 0 else "deadbeef" * 8
+    prev_hash = _ZERO_HASH if entry_log_index == 0 else "deadbeef" * 8
     entry = _make_entry(entry_log_index, prev_hash)
     wire_entry = WireCaseLedgerEntry.model_validate(
         entry.model_dump(mode="json")
@@ -62,7 +63,7 @@ def test_replay_missing_entries_node_is_sequence_with_named_leaf_nodes():
 def test_send_missing_entries_node_replays_entries_after_divergence(
     bridge, case_actor
 ):
-    first_entry = _make_entry(0, GENESIS_HASH)
+    first_entry = _make_entry(0)
     second_entry = _make_entry(1, first_entry.entry_hash)
     sync_port = MagicMock(spec=SyncActivityPort)
 
@@ -86,7 +87,7 @@ def test_send_missing_entries_node_replays_entries_after_divergence(
 
 
 def test_collect_and_find_replay_context_writes_blackboard(bridge, datalayer):
-    first_entry = _make_entry(0, GENESIS_HASH)
+    first_entry = _make_entry(0)
     second_entry = _make_entry(1, first_entry.entry_hash)
     datalayer.save(second_entry)
     datalayer.save(first_entry)
@@ -135,7 +136,7 @@ def test_fanout_log_entry_node_is_sequence_with_named_leaf_nodes():
 def test_replay_missing_entries_node_replays_from_divergence(
     bridge, datalayer, case_actor
 ):
-    first_entry = _make_entry(0, GENESIS_HASH)
+    first_entry = _make_entry(0)
     second_entry = _make_entry(1, first_entry.entry_hash)
     datalayer.save(first_entry)
     datalayer.save(second_entry)
@@ -168,7 +169,7 @@ def test_fanout_log_entry_node_sends_to_case_addressees(bridge, datalayer):
         },
     )
     datalayer.save(case_obj)
-    entry = _make_entry(0, GENESIS_HASH)
+    entry = _make_entry(0)
     sync_port = MagicMock(spec=SyncActivityPort)
 
     result = bridge.execute_with_setup(

--- a/test/core/behaviors/sync/test_announce_tree.py
+++ b/test/core/behaviors/sync/test_announce_tree.py
@@ -14,7 +14,7 @@ from vultron.core.behaviors.sync.announce_tree import (
     create_announce_log_entry_tree,
 )
 from vultron.core.models.case_actor import VultronCaseActor
-from vultron.core.models.case_ledger import GENESIS_HASH, HashChainLedgerRecord
+from vultron.core.models.case_ledger import HashChainLedgerRecord
 from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
 from vultron.core.models.events.sync import AnnounceLogEntryReceivedEvent
 from vultron.core.ports.sync_activity import SyncActivityPort
@@ -33,6 +33,8 @@ _ = VulnerabilityCase
 OWNER_ACTOR_ID = "https://example.org/actors/vendor"
 PARTICIPANT_ACTOR_ID = "https://example.org/actors/reporter"
 CASE_ID = "https://example.org/cases/case-sync"
+
+_ZERO_HASH: str = "0" * 64  # arbitrary prev_log_hash for test chains
 
 
 @pytest.fixture(autouse=True)
@@ -63,7 +65,16 @@ def case_actor(datalayer):
     return actor
 
 
-def _make_entry(log_index: int, prev_hash: str) -> VultronCaseLedgerEntry:
+@pytest.fixture
+def case_obj(datalayer):
+    case = VulnerabilityCase(id_=CASE_ID, attributed_to=OWNER_ACTOR_ID)
+    datalayer.save(case)
+    return case
+
+
+def _make_entry(
+    log_index: int, prev_hash: str = _ZERO_HASH
+) -> VultronCaseLedgerEntry:
     return _to_persistable_entry(
         HashChainLedgerRecord(
             case_id=CASE_ID,
@@ -92,8 +103,10 @@ def test_create_announce_log_entry_tree_returns_selector():
     assert len(tree.children) == 2
 
 
-def test_participant_persists_valid_entry(bridge, datalayer, case_actor):
-    entry = _make_entry(0, GENESIS_HASH)
+def test_participant_persists_valid_entry(
+    bridge, datalayer, case_actor, case_obj
+):
+    entry = _make_entry(0, case_obj.genesis_hash)
     event = _make_event(entry, actor_id=case_actor.id_)
 
     result = bridge.execute_with_setup(
@@ -110,7 +123,7 @@ def test_participant_persists_valid_entry(bridge, datalayer, case_actor):
 def test_case_actor_round_trip_logs_delivery_without_repersisting(
     bridge, datalayer, case_actor
 ):
-    entry = _make_entry(0, GENESIS_HASH)
+    entry = _make_entry(0)
     datalayer.save(entry)
     event = _make_event(entry, actor_id=case_actor.id_)
 
@@ -126,7 +139,7 @@ def test_case_actor_round_trip_logs_delivery_without_repersisting(
 
 
 def test_case_actor_spoofed_sender_fails(bridge, datalayer, case_actor):
-    entry = _make_entry(0, GENESIS_HASH)
+    entry = _make_entry(0)
     event = _make_event(
         entry, actor_id="https://example.org/actors/attacker-service"
     )
@@ -144,7 +157,7 @@ def test_case_actor_spoofed_sender_fails(bridge, datalayer, case_actor):
 def test_hash_mismatch_sends_reject_and_does_not_store(
     bridge, datalayer, case_actor
 ):
-    first_entry = _make_entry(0, GENESIS_HASH)
+    first_entry = _make_entry(0)
     datalayer.save(first_entry)
     bad_entry = _make_entry(1, "badbadbadbadbad0" * 4)
     event = _make_event(bad_entry, actor_id=case_actor.id_)
@@ -163,7 +176,7 @@ def test_hash_mismatch_sends_reject_and_does_not_store(
 
 
 def _make_remove_embargo_entry(
-    log_index: int, prev_hash: str
+    log_index: int, prev_hash: str = _ZERO_HASH
 ) -> VultronCaseLedgerEntry:
     return _to_persistable_entry(
         HashChainLedgerRecord(
@@ -178,7 +191,9 @@ def _make_remove_embargo_entry(
 
 
 def _make_case_with_em_active(datalayer: SqliteDataLayer) -> VulnerabilityCase:
-    case = VulnerabilityCase(id_=CASE_ID, name="Test Case")
+    case = VulnerabilityCase(
+        id_=CASE_ID, name="Test Case", attributed_to=OWNER_ACTOR_ID
+    )
     case.current_status.em_state = EM.ACTIVE
     datalayer.create(case)
     return case
@@ -191,8 +206,8 @@ class TestAnnounceLogEntryAppliesEmbargoTeardown:
         self, bridge, datalayer, case_actor
     ):
         """BT applies EM.EXITED when entry has remove_embargo_event_from_case."""
-        _make_case_with_em_active(datalayer)
-        entry = _make_remove_embargo_entry(0, GENESIS_HASH)
+        case = _make_case_with_em_active(datalayer)
+        entry = _make_remove_embargo_entry(0, case.genesis_hash)
         event = _make_event(entry, actor_id=case_actor.id_)
 
         result = bridge.execute_with_setup(
@@ -212,7 +227,7 @@ class TestAnnounceLogEntryAppliesEmbargoTeardown:
     ):
         """Even if log entry is already stored, EM.EXITED must be applied."""
         _make_case_with_em_active(datalayer)
-        entry = _make_remove_embargo_entry(0, GENESIS_HASH)
+        entry = _make_remove_embargo_entry(0)
         datalayer.save(
             entry
         )  # pre-store to trigger CheckLogEntryAlreadyStored
@@ -232,10 +247,12 @@ class TestAnnounceLogEntryAppliesEmbargoTeardown:
 
     def test_em_exited_is_idempotent(self, bridge, datalayer, case_actor):
         """Running BT when case is already EM.EXITED must succeed silently."""
-        case = VulnerabilityCase(id_=CASE_ID, name="Test Case")
+        case = VulnerabilityCase(
+            id_=CASE_ID, name="Test Case", attributed_to=OWNER_ACTOR_ID
+        )
         case.current_status.em_state = EM.EXITED
         datalayer.create(case)
-        entry = _make_remove_embargo_entry(0, GENESIS_HASH)
+        entry = _make_remove_embargo_entry(0, case.genesis_hash)
         event = _make_event(entry, actor_id=case_actor.id_)
 
         result = bridge.execute_with_setup(

--- a/test/core/behaviors/sync/test_commit_tree.py
+++ b/test/core/behaviors/sync/test_commit_tree.py
@@ -13,9 +13,11 @@ from vultron.core.behaviors.sync.commit_tree import (
     create_commit_log_entry_tree,
 )
 from vultron.core.models.case import VultronCase
-from vultron.core.models.case_ledger import GENESIS_HASH, HashChainLedgerRecord
+from vultron.core.models.case_ledger import HashChainLedgerRecord
 from vultron.core.ports.sync_activity import SyncActivityPort
 from vultron.core.behaviors.sync.nodes.chain import _to_persistable_entry
+
+_ZERO_HASH: str = "0" * 64  # arbitrary hash for test chains
 
 OWNER_ACTOR_ID = "https://example.org/actors/vendor"
 PEER_ID = "https://example.org/actors/reporter"
@@ -110,14 +112,15 @@ def test_commit_tree_persists_entry_and_fans_out(bridge, datalayer, case_obj):
     entries = list(datalayer.list_objects("CaseLedgerEntry"))
     assert len(entries) == 1
     assert entries[0].log_index == 0
-    assert entries[0].prev_log_hash == GENESIS_HASH
+    assert entries[0].prev_log_hash == case_obj.genesis_hash
+    assert len(entries[0].prev_log_hash) == 64
     sync_port.send_announce_log_entry.assert_called_once()
     call_kwargs = sync_port.send_announce_log_entry.call_args.kwargs
     assert call_kwargs["to"] == [PEER_ID]
 
 
 def test_commit_tree_uses_existing_tail_hash(bridge, datalayer, case_obj):
-    first_entry = _make_entry(0, GENESIS_HASH)
+    first_entry = _make_entry(0, case_obj.genesis_hash)
     datalayer.save(first_entry)
     sync_port = MagicMock(spec=SyncActivityPort)
 

--- a/test/core/behaviors/sync/test_reject_tree.py
+++ b/test/core/behaviors/sync/test_reject_tree.py
@@ -14,7 +14,7 @@ from vultron.core.behaviors.sync.reject_tree import (
     create_reject_log_entry_tree,
 )
 from vultron.core.models.case_actor import VultronCaseActor
-from vultron.core.models.case_ledger import GENESIS_HASH, HashChainLedgerRecord
+from vultron.core.models.case_ledger import HashChainLedgerRecord
 from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
 from vultron.core.models.events.sync import RejectLogEntryReceivedEvent
 from vultron.core.models.replication_state import VultronReplicationState
@@ -29,6 +29,8 @@ from vultron.wire.as2.vocab.objects.case_ledger_entry import (
 OWNER_ACTOR_ID = "https://example.org/actors/vendor"
 PEER_ID = "https://example.org/actors/reporter"
 CASE_ID = "https://example.org/cases/case-sync"
+
+_ZERO_HASH: str = "0" * 64  # arbitrary prev_log_hash for test chains
 
 
 @pytest.fixture(autouse=True)
@@ -59,7 +61,9 @@ def case_actor(datalayer):
     return actor
 
 
-def _make_entry(log_index: int, prev_hash: str) -> VultronCaseLedgerEntry:
+def _make_entry(
+    log_index: int, prev_hash: str = _ZERO_HASH
+) -> VultronCaseLedgerEntry:
     return _to_persistable_entry(
         HashChainLedgerRecord(
             case_id=CASE_ID,
@@ -96,7 +100,7 @@ def test_create_reject_log_entry_tree_returns_sequence():
 def test_reject_tree_updates_replication_state_and_replays_entries(
     bridge, datalayer, case_actor
 ):
-    first_entry = _make_entry(0, GENESIS_HASH)
+    first_entry = _make_entry(0)
     second_entry = _make_entry(1, first_entry.entry_hash)
     datalayer.save(first_entry)
     datalayer.save(second_entry)
@@ -129,7 +133,7 @@ def test_reject_tree_updates_replication_state_and_replays_entries(
 def test_reject_tree_replays_all_entries_when_hash_not_found(
     bridge, datalayer, case_actor
 ):
-    first_entry = _make_entry(0, GENESIS_HASH)
+    first_entry = _make_entry(0)
     second_entry = _make_entry(1, first_entry.entry_hash)
     datalayer.save(first_entry)
     datalayer.save(second_entry)

--- a/test/core/models/test_case_ledger.py
+++ b/test/core/models/test_case_ledger.py
@@ -34,6 +34,7 @@ Covers:
 import hashlib
 import json
 import logging
+from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 import py_trees
@@ -41,11 +42,11 @@ import pytest
 
 from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.models.case_ledger import (
-    GENESIS_HASH,
     CaseLedger,
     HashChainLedgerRecord,
     _canonical_bytes,
     _sha256_hex,
+    compute_genesis_hash,
 )
 from vultron.core.models.replication_state import VultronReplicationState
 
@@ -55,11 +56,20 @@ from vultron.core.models.replication_state import VultronReplicationState
 
 CASE_ID = "urn:uuid:case-1234"
 OBJECT_ID = "urn:uuid:report-5678"
+CASE_ACTOR_ID = "https://example.org/actors/case-actor"
+
+# A fixed genesis hash for consistent tests — computed from known inputs
+_FIXED_CREATED_AT = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+CASE_GENESIS_HASH = compute_genesis_hash(
+    CASE_ID, _FIXED_CREATED_AT, CASE_ACTOR_ID
+)
+
+_ZERO_HASH: str = "0" * 64  # arbitrary prev_log_hash for test chains
 
 
 @pytest.fixture()
 def empty_log() -> CaseLedger:
-    return CaseLedger(case_id=CASE_ID)
+    return CaseLedger(case_id=CASE_ID, genesis_hash=CASE_GENESIS_HASH)
 
 
 @pytest.fixture()
@@ -123,16 +133,45 @@ class TestCanonicalHelpers:
 
 
 # ---------------------------------------------------------------------------
-# GENESIS_HASH
+# compute_genesis_hash
 # ---------------------------------------------------------------------------
 
 
-class TestGenesisHash:
-    def test_genesis_hash_is_64_zeros(self):
-        assert GENESIS_HASH == "0" * 64
+class TestComputeGenesisHash:
+    def test_returns_64_char_hex(self):
+        result = compute_genesis_hash(
+            CASE_ID, _FIXED_CREATED_AT, CASE_ACTOR_ID
+        )
+        assert len(result) == 64
+        assert all(c in "0123456789abcdef" for c in result)
 
-    def test_genesis_hash_length(self):
-        assert len(GENESIS_HASH) == 64
+    def test_deterministic_same_inputs(self):
+        h1 = compute_genesis_hash(CASE_ID, _FIXED_CREATED_AT, CASE_ACTOR_ID)
+        h2 = compute_genesis_hash(CASE_ID, _FIXED_CREATED_AT, CASE_ACTOR_ID)
+        assert h1 == h2
+
+    def test_different_case_ids_give_different_hashes(self):
+        h1 = compute_genesis_hash(CASE_ID, _FIXED_CREATED_AT, CASE_ACTOR_ID)
+        h2 = compute_genesis_hash(
+            "urn:uuid:other-case", _FIXED_CREATED_AT, CASE_ACTOR_ID
+        )
+        assert h1 != h2
+
+    def test_different_actor_ids_give_different_hashes(self):
+        h1 = compute_genesis_hash(CASE_ID, _FIXED_CREATED_AT, CASE_ACTOR_ID)
+        h2 = compute_genesis_hash(
+            CASE_ID, _FIXED_CREATED_AT, "https://example.org/actors/other"
+        )
+        assert h1 != h2
+
+    def test_different_timestamps_give_different_hashes(self):
+        h1 = compute_genesis_hash(CASE_ID, _FIXED_CREATED_AT, CASE_ACTOR_ID)
+        h2 = compute_genesis_hash(
+            CASE_ID,
+            datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc),
+            CASE_ACTOR_ID,
+        )
+        assert h1 != h2
 
 
 # ---------------------------------------------------------------------------
@@ -147,13 +186,13 @@ class TestCaseLedgerEntry:
             log_index=0,
             object_id=OBJECT_ID,
             event_type="report_received",
-            prev_log_hash=GENESIS_HASH,
+            prev_log_hash=_ZERO_HASH,
         )
         assert entry.case_id == CASE_ID
         assert entry.log_index == 0
         assert entry.object_id == OBJECT_ID
         assert entry.event_type == "report_received"
-        assert entry.prev_log_hash == GENESIS_HASH
+        assert entry.prev_log_hash == _ZERO_HASH
 
     def test_entry_hash_auto_computed(self):
         entry = HashChainLedgerRecord(
@@ -161,7 +200,7 @@ class TestCaseLedgerEntry:
             log_index=0,
             object_id=OBJECT_ID,
             event_type="report_received",
-            prev_log_hash=GENESIS_HASH,
+            prev_log_hash=_ZERO_HASH,
         )
         assert entry.entry_hash != ""
         assert len(entry.entry_hash) == 64
@@ -172,7 +211,7 @@ class TestCaseLedgerEntry:
             log_index=0,
             object_id=OBJECT_ID,
             event_type="report_received",
-            prev_log_hash=GENESIS_HASH,
+            prev_log_hash=_ZERO_HASH,
         )
         assert entry.verify_hash()
 
@@ -182,7 +221,7 @@ class TestCaseLedgerEntry:
             log_index=0,
             object_id=OBJECT_ID,
             event_type="report_received",
-            prev_log_hash=GENESIS_HASH,
+            prev_log_hash=_ZERO_HASH,
         )
         # Manually tamper with object_id after creation
         object.__setattr__(entry, "object_id", "urn:uuid:tampered")
@@ -194,7 +233,7 @@ class TestCaseLedgerEntry:
             log_index=0,
             object_id=OBJECT_ID,
             event_type="test",
-            prev_log_hash=GENESIS_HASH,
+            prev_log_hash=_ZERO_HASH,
         )
         assert entry.disposition == "recorded"
 
@@ -204,7 +243,7 @@ class TestCaseLedgerEntry:
             log_index=0,
             object_id=OBJECT_ID,
             event_type="test",
-            prev_log_hash=GENESIS_HASH,
+            prev_log_hash=_ZERO_HASH,
             disposition="rejected",
             reason_code="INVALID_STATE",
         )
@@ -217,7 +256,7 @@ class TestCaseLedgerEntry:
             log_index=0,
             object_id=OBJECT_ID,
             event_type="test",
-            prev_log_hash=GENESIS_HASH,
+            prev_log_hash=_ZERO_HASH,
         )
         assert entry.term is None
 
@@ -227,14 +266,14 @@ class TestCaseLedgerEntry:
             log_index=0,
             object_id="urn:uuid:obj1",
             event_type="test",
-            prev_log_hash=GENESIS_HASH,
+            prev_log_hash=_ZERO_HASH,
         )
         e2 = HashChainLedgerRecord(
             case_id=CASE_ID,
             log_index=0,
             object_id="urn:uuid:obj2",
             event_type="test",
-            prev_log_hash=GENESIS_HASH,
+            prev_log_hash=_ZERO_HASH,
         )
         assert e1.entry_hash != e2.entry_hash
 
@@ -245,7 +284,7 @@ class TestCaseLedgerEntry:
             log_index=0,
             object_id=OBJECT_ID,
             event_type="test",
-            prev_log_hash=GENESIS_HASH,
+            prev_log_hash=_ZERO_HASH,
         )
         hashable = entry._hashable_dict()
         assert "entry_hash" not in hashable
@@ -257,7 +296,7 @@ class TestCaseLedgerEntry:
             log_index=0,
             object_id=OBJECT_ID,
             event_type="test",
-            prev_log_hash=GENESIS_HASH,
+            prev_log_hash=_ZERO_HASH,
             payload_snapshot=snap,
         )
         assert entry.payload_snapshot == snap
@@ -268,7 +307,7 @@ class TestCaseLedgerEntry:
             log_index=0,
             object_id=OBJECT_ID,
             event_type="test",
-            prev_log_hash=GENESIS_HASH,
+            prev_log_hash=_ZERO_HASH,
             disposition="rejected",
             reason_code="PRECONDITION_FAILED",
             reason_detail="Case is already closed",
@@ -283,7 +322,7 @@ class TestCaseLedgerEntry:
 
 class TestCaseLedgerAppend:
     def test_empty_log_tail_hash_is_genesis(self, empty_log: CaseLedger):
-        assert empty_log.tail_hash == GENESIS_HASH
+        assert empty_log.tail_hash == CASE_GENESIS_HASH
 
     def test_empty_log_next_index_is_zero(self, empty_log: CaseLedger):
         assert empty_log.next_index == 0
@@ -296,7 +335,7 @@ class TestCaseLedgerAppend:
     def test_first_entry_prev_hash_is_genesis(
         self, log_with_one_entry: CaseLedger
     ):
-        assert log_with_one_entry.entries[0].prev_log_hash == GENESIS_HASH
+        assert log_with_one_entry.entries[0].prev_log_hash == CASE_GENESIS_HASH
 
     def test_tail_hash_updates_after_append(
         self, log_with_one_entry: CaseLedger
@@ -452,7 +491,7 @@ class TestCaseLedgerVerifyChain:
         empty_log.append(object_id="urn:uuid:a", event_type="first")
         e2 = empty_log.append(object_id="urn:uuid:b", event_type="second")
         # Tamper with e2's prev_log_hash to point at something wrong
-        object.__setattr__(e2, "prev_log_hash", GENESIS_HASH)
+        object.__setattr__(e2, "prev_log_hash", _ZERO_HASH)
         # verify_chain should detect the broken link
         assert not empty_log.verify_chain()
 
@@ -579,7 +618,7 @@ class TestReplicationState:
         state = VultronReplicationState(
             case_id=CASE_URI, peer_id="https://example.org/finder"
         )
-        assert state.last_acknowledged_hash == GENESIS_HASH
+        assert state.last_acknowledged_hash == ""
 
     def test_custom_last_acknowledged_hash(self):
         digest = "a" * 64

--- a/test/core/test_sync_helpers.py
+++ b/test/core/test_sync_helpers.py
@@ -94,6 +94,20 @@ class TestContiguousChain:
         fresh, reason = is_ledger_fresh_for_case(CASE_ID, dl)
         assert fresh is True, reason
 
+    def test_per_case_genesis_hash_chain_is_fresh(self, dl):
+        """CLP-08-004: chain anchored to per-case genesis hash is accepted as fresh.
+
+        Positive path: with a VulnerabilityCase in the DataLayer, the genesis
+        hash check is active; a correctly-anchored chain must still return fresh.
+        """
+        case = _make_case()
+        dl.save(case)
+        e0 = _store(dl, _entry(0, case.genesis_hash))
+        e1 = _store(dl, _entry(1, e0.entry_hash))
+        _store(dl, _entry(2, e1.entry_hash))
+        fresh, reason = is_ledger_fresh_for_case(CASE_ID, dl)
+        assert fresh is True, reason
+
     def test_only_checks_entries_for_requested_case(self, dl):
         """Other cases' entries do not affect freshness of the requested case."""
         # Store entries for another case

--- a/test/core/test_sync_helpers.py
+++ b/test/core/test_sync_helpers.py
@@ -19,18 +19,30 @@ Spec: SYNC-10-003, SYNC-10-004, SYNC-10-005.
 import pytest
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
-from vultron.core.models.case_ledger import GENESIS_HASH, HashChainLedgerRecord
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.case_ledger import (
+    HashChainLedgerRecord,
+)
 from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
 from vultron.core.sync_helpers import is_ledger_fresh_for_case
 from vultron.core.behaviors.sync.nodes.chain import _to_persistable_entry
 
 CASE_ID = "https://example.org/cases/catchup-test"
+CASE_ACTOR_ID = "https://example.org/actors/case-actor"
 OTHER_CASE_ID = "https://example.org/cases/other"
+_ZERO_HASH: str = "0" * 64  # arbitrary hash for non-genesis test chains
 
 
 @pytest.fixture
 def dl():
     return SqliteDataLayer("sqlite:///:memory:")
+
+
+def _make_case(
+    case_id: str = CASE_ID, case_actor_id: str = CASE_ACTOR_ID
+) -> VulnerabilityCase:
+    """Create a VulnerabilityCase with computed genesis_hash."""
+    return VulnerabilityCase(id_=case_id, attributed_to=case_actor_id)
 
 
 def _entry(
@@ -65,18 +77,18 @@ class TestEmptyLedger:
 
 class TestContiguousChain:
     def test_single_genesis_entry_is_fresh(self, dl):
-        _store(dl, _entry(0, GENESIS_HASH))
+        _store(dl, _entry(0, _ZERO_HASH))
         fresh, reason = is_ledger_fresh_for_case(CASE_ID, dl)
         assert fresh is True, reason
 
     def test_two_entry_chain_is_fresh(self, dl):
-        e0 = _store(dl, _entry(0, GENESIS_HASH))
+        e0 = _store(dl, _entry(0, _ZERO_HASH))
         _store(dl, _entry(1, e0.entry_hash))
         fresh, reason = is_ledger_fresh_for_case(CASE_ID, dl)
         assert fresh is True, reason
 
     def test_three_entry_chain_is_fresh(self, dl):
-        e0 = _store(dl, _entry(0, GENESIS_HASH))
+        e0 = _store(dl, _entry(0, _ZERO_HASH))
         e1 = _store(dl, _entry(1, e0.entry_hash))
         _store(dl, _entry(2, e1.entry_hash))
         fresh, reason = is_ledger_fresh_for_case(CASE_ID, dl)
@@ -85,7 +97,7 @@ class TestContiguousChain:
     def test_only_checks_entries_for_requested_case(self, dl):
         """Other cases' entries do not affect freshness of the requested case."""
         # Store entries for another case
-        other_e0 = _store(dl, _entry(0, GENESIS_HASH, case_id=OTHER_CASE_ID))
+        other_e0 = _store(dl, _entry(0, _ZERO_HASH, case_id=OTHER_CASE_ID))
         _store(dl, _entry(1, other_e0.entry_hash, case_id=OTHER_CASE_ID))
         # Requested case is empty → fresh
         fresh, reason = is_ledger_fresh_for_case(CASE_ID, dl)
@@ -95,7 +107,7 @@ class TestContiguousChain:
 class TestMissingGenesisEntry:
     def test_missing_genesis_is_stale(self, dl):
         """SYNC-10-004: first entry must be at log_index=0."""
-        e1 = _store(dl, _entry(0, GENESIS_HASH))
+        e1 = _store(dl, _entry(0, _ZERO_HASH))
         # Manually create an entry at index 2 with no index-1 entry
         _store(dl, _entry(2, e1.entry_hash))
         # e1 (index 0) exists but jumps to index 2 → gap
@@ -112,7 +124,7 @@ class TestMissingGenesisEntry:
             log_object_id="https://example.org/activities/orphan",
             event_type="test_event",
             payload_snapshot={"note": "no genesis"},
-            prev_log_hash=GENESIS_HASH,
+            prev_log_hash=_ZERO_HASH,
             entry_hash="0" * 64,
         )
         dl.save(e)
@@ -124,7 +136,7 @@ class TestMissingGenesisEntry:
 class TestHashMismatch:
     def test_wrong_prev_log_hash_is_stale(self, dl):
         """SYNC-10-004: hash mismatch at any link is stale."""
-        _store(dl, _entry(0, GENESIS_HASH))
+        _store(dl, _entry(0, _ZERO_HASH))
         # Build e1 with a deliberately wrong prev_log_hash
         bad_prev = "a" * 64
         bad_e1 = VultronCaseLedgerEntry(
@@ -142,26 +154,28 @@ class TestHashMismatch:
         assert "hash mismatch" in reason
 
     def test_wrong_genesis_prev_hash_is_stale(self, dl):
-        """Genesis entry must have GENESIS_HASH as prev_log_hash."""
+        """Genesis entry prev_log_hash must match the per-case genesis hash."""
+        case = _make_case()
+        dl.save(case)
         bad_genesis = VultronCaseLedgerEntry(
             case_id=CASE_ID,
             log_index=0,
             log_object_id="https://example.org/activities/log-0",
             event_type="test_event",
             payload_snapshot={"log_index": 0},
-            prev_log_hash="c" * 64,  # not GENESIS_HASH
+            prev_log_hash="c" * 64,  # not the per-case genesis hash
             entry_hash="d" * 64,
         )
         dl.save(bad_genesis)
         fresh, reason = is_ledger_fresh_for_case(CASE_ID, dl)
         assert fresh is False
-        assert "prev_log_hash mismatch" in reason or "GENESIS_HASH" in reason
+        assert "prev_log_hash mismatch" in reason or "genesis" in reason
 
 
 class TestIndexGap:
     def test_gap_in_middle_is_stale(self, dl):
         """Entries 0, 1, 3 (missing 2) is a gap → stale."""
-        e0 = _store(dl, _entry(0, GENESIS_HASH))
+        e0 = _store(dl, _entry(0, _ZERO_HASH))
         e1 = _store(dl, _entry(1, e0.entry_hash))
         # Skip index 2; build entry at index 3 referencing e1's hash
         e3 = VultronCaseLedgerEntry(

--- a/test/core/test_sync_helpers.py
+++ b/test/core/test_sync_helpers.py
@@ -11,9 +11,10 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Unit tests for :func:`vultron.core.sync_helpers.is_ledger_fresh_for_case`.
+"""Unit tests for :func:`vultron.core.sync_helpers.is_ledger_fresh_for_case`
+and :func:`vultron.core.sync_helpers._reconstruct_tail_hash`.
 
-Spec: SYNC-10-003, SYNC-10-004, SYNC-10-005.
+Spec: SYNC-10-003, SYNC-10-004, SYNC-10-005, CLP-08-004, CLP-08-005.
 """
 
 import pytest
@@ -24,8 +25,12 @@ from vultron.core.models.case_ledger import (
     HashChainLedgerRecord,
 )
 from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
-from vultron.core.sync_helpers import is_ledger_fresh_for_case
+from vultron.core.sync_helpers import (
+    _reconstruct_tail_hash,
+    is_ledger_fresh_for_case,
+)
 from vultron.core.behaviors.sync.nodes.chain import _to_persistable_entry
+from vultron.errors import VultronValidationError
 
 CASE_ID = "https://example.org/cases/catchup-test"
 CASE_ACTOR_ID = "https://example.org/actors/case-actor"
@@ -75,20 +80,42 @@ class TestEmptyLedger:
         assert reason == ""
 
 
+class TestReconstructTailHash:
+    def test_empty_log_with_case_returns_genesis(self, dl):
+        """CLP-08-005: empty ledger returns per-case genesis hash."""
+        case = _make_case()
+        dl.save(case)
+        tail_hash, tail_index = _reconstruct_tail_hash(CASE_ID, dl)
+        assert tail_hash == case.genesis_hash
+        assert len(tail_hash) == 64
+        assert tail_index == -1
+
+    def test_empty_log_no_case_raises(self, dl):
+        """CLP-08-005 fail-closed: no case in DataLayer raises VultronValidationError."""
+        with pytest.raises(VultronValidationError, match="genesis hash"):
+            _reconstruct_tail_hash(CASE_ID, dl)
+
+
 class TestContiguousChain:
     def test_single_genesis_entry_is_fresh(self, dl):
-        _store(dl, _entry(0, _ZERO_HASH))
+        case = _make_case()
+        dl.save(case)
+        _store(dl, _entry(0, case.genesis_hash))
         fresh, reason = is_ledger_fresh_for_case(CASE_ID, dl)
         assert fresh is True, reason
 
     def test_two_entry_chain_is_fresh(self, dl):
-        e0 = _store(dl, _entry(0, _ZERO_HASH))
+        case = _make_case()
+        dl.save(case)
+        e0 = _store(dl, _entry(0, case.genesis_hash))
         _store(dl, _entry(1, e0.entry_hash))
         fresh, reason = is_ledger_fresh_for_case(CASE_ID, dl)
         assert fresh is True, reason
 
     def test_three_entry_chain_is_fresh(self, dl):
-        e0 = _store(dl, _entry(0, _ZERO_HASH))
+        case = _make_case()
+        dl.save(case)
+        e0 = _store(dl, _entry(0, case.genesis_hash))
         e1 = _store(dl, _entry(1, e0.entry_hash))
         _store(dl, _entry(2, e1.entry_hash))
         fresh, reason = is_ledger_fresh_for_case(CASE_ID, dl)
@@ -121,13 +148,25 @@ class TestContiguousChain:
 class TestMissingGenesisEntry:
     def test_missing_genesis_is_stale(self, dl):
         """SYNC-10-004: first entry must be at log_index=0."""
-        e1 = _store(dl, _entry(0, _ZERO_HASH))
-        # Manually create an entry at index 2 with no index-1 entry
-        _store(dl, _entry(2, e1.entry_hash))
-        # e1 (index 0) exists but jumps to index 2 → gap
+        case = _make_case()
+        dl.save(case)
+        e0 = _store(dl, _entry(0, case.genesis_hash))
+        # Skip index 1; add entry at index 2 referencing e0's hash
+        _store(dl, _entry(2, e0.entry_hash))
         fresh, reason = is_ledger_fresh_for_case(CASE_ID, dl)
         assert fresh is False
         assert "gap" in reason or "jump" in reason
+
+    def test_no_case_in_dl_with_entries_is_stale(self, dl):
+        """Fail-closed: entries present but case not in DataLayer → stale.
+
+        CLP-08-004: genesis hash is unavailable when the case record is
+        absent, so origin binding cannot be verified.
+        """
+        _store(dl, _entry(0, _ZERO_HASH))
+        fresh, reason = is_ledger_fresh_for_case(CASE_ID, dl)
+        assert fresh is False
+        assert "genesis hash unavailable" in reason
 
     def test_non_zero_first_index_is_stale(self, dl):
         """Actor has no genesis entry; its first stored entry has index > 0."""
@@ -150,7 +189,9 @@ class TestMissingGenesisEntry:
 class TestHashMismatch:
     def test_wrong_prev_log_hash_is_stale(self, dl):
         """SYNC-10-004: hash mismatch at any link is stale."""
-        _store(dl, _entry(0, _ZERO_HASH))
+        case = _make_case()
+        dl.save(case)
+        _store(dl, _entry(0, case.genesis_hash))
         # Build e1 with a deliberately wrong prev_log_hash
         bad_prev = "a" * 64
         bad_e1 = VultronCaseLedgerEntry(
@@ -189,7 +230,9 @@ class TestHashMismatch:
 class TestIndexGap:
     def test_gap_in_middle_is_stale(self, dl):
         """Entries 0, 1, 3 (missing 2) is a gap → stale."""
-        e0 = _store(dl, _entry(0, _ZERO_HASH))
+        case = _make_case()
+        dl.save(case)
+        e0 = _store(dl, _entry(0, case.genesis_hash))
         e1 = _store(dl, _entry(1, e0.entry_hash))
         # Skip index 2; build entry at index 3 referencing e1's hash
         e3 = VultronCaseLedgerEntry(

--- a/test/core/use_cases/received/actor/test_invite.py
+++ b/test/core/use_cases/received/actor/test_invite.py
@@ -402,10 +402,12 @@ class TestInviteActorUseCases:
 
         dl = SqliteDataLayer("sqlite:///:memory:")
         invitee_id = "https://example.org/users/coordinator"
+        case_actor_id = "https://example.org/cases/caseIA3/actor"
         invitee = as_Organization(id_=invitee_id)
         case = VulnerabilityCase(
             id_="https://example.org/cases/caseIA3",
             name="TEST-ACCEPT-INVITE-EVENT",
+            attributed_to=case_actor_id,
         )
         invite = rm_invite_to_case_activity(
             invitee,
@@ -421,7 +423,6 @@ class TestInviteActorUseCases:
         )
         from vultron.wire.as2.vocab.base.objects.actors import as_Service
 
-        case_actor_id = f"{case.id_}/actor"
         dl.create(as_Service(id_=case_actor_id, context=case.id_))
         case_manager_participant = CaseParticipant(
             id_=f"{case.id_}/participants/case-actor-p",
@@ -481,6 +482,7 @@ class TestInviteActorUseCases:
         case = VulnerabilityCase(
             id_="https://example.org/cases/caseLJ1",
             name="TEST-LATE-JOIN-BACKFILL",
+            attributed_to=case_actor_id,
         )
         case_actor.context = case.id_
         invite = rm_invite_to_case_activity(
@@ -585,6 +587,7 @@ class TestInviteActorUseCases:
         case = VulnerabilityCase(
             id_="https://example.org/cases/caseLJ2",
             name="TEST-LATE-JOIN-RESUME",
+            attributed_to=case_actor_id,
         )
         case_actor.context = case.id_
         invite = rm_invite_to_case_activity(
@@ -718,6 +721,7 @@ class TestInviteActorUseCases:
         case = VulnerabilityCase(
             id_="https://example.org/cases/caseLJ3",
             name="TEST-LATE-JOIN-NO-MARKER",
+            attributed_to=case_actor_id,
         )
         case_actor.context = case.id_
         participant = VultronParticipant(
@@ -820,6 +824,7 @@ class TestInviteActorUseCases:
         case = VulnerabilityCase(
             id_="https://example.org/cases/caseLJ4",
             name="TEST-LATE-JOIN-NO-ANNOUNCE",
+            attributed_to=case_actor_id,
         )
         case_actor.context = case.id_
         invite = rm_invite_to_case_activity(

--- a/test/core/use_cases/received/test_ack_report_routing.py
+++ b/test/core/use_cases/received/test_ack_report_routing.py
@@ -76,7 +76,9 @@ def _make_case_actor_dl() -> SqliteDataLayer:
     ca_svc = VultronCaseActor(id_=CASE_ACTOR_ID, context=CASE_ID)
     dl.save(ca_svc)
 
-    case = VulnerabilityCase(id_=CASE_ID, name="AckReport Routing Test")
+    case = VulnerabilityCase(
+        id_=CASE_ID, name="AckReport Routing Test", attributed_to=CASE_ACTOR_ID
+    )
     case.vulnerability_reports.append(REPORT_ID)
 
     cm_participant = CaseParticipant(

--- a/test/core/use_cases/received/test_close_case_routing.py
+++ b/test/core/use_cases/received/test_close_case_routing.py
@@ -67,7 +67,11 @@ def _make_case_actor_dl() -> SqliteDataLayer:
     ca_svc = VultronCaseActor(id_=CASE_ACTOR_ID, context=CASE_ID)
     dl.save(ca_svc)
 
-    case = VulnerabilityCase(id_=CASE_ID, name="CloseCase Routing Test")
+    case = VulnerabilityCase(
+        id_=CASE_ID,
+        name="CloseCase Routing Test",
+        attributed_to=CASE_ACTOR_ID,
+    )
 
     cm_participant = CaseParticipant(
         attributed_to=CASE_ACTOR_ID,

--- a/test/core/use_cases/received/test_note_routing_guard.py
+++ b/test/core/use_cases/received/test_note_routing_guard.py
@@ -71,7 +71,9 @@ def _make_case_actor_dl() -> SqliteDataLayer:
     ca_svc = VultronCaseActor(id_=CASE_ACTOR_ID, context=CASE_ID)
     dl.save(ca_svc)
 
-    case = VulnerabilityCase(id_=CASE_ID, name="AddNote Routing Test")
+    case = VulnerabilityCase(
+        id_=CASE_ID, name="AddNote Routing Test", attributed_to=CASE_ACTOR_ID
+    )
 
     cm_participant = CaseParticipant(
         attributed_to=CASE_ACTOR_ID,

--- a/test/core/use_cases/received/test_reject_sync.py
+++ b/test/core/use_cases/received/test_reject_sync.py
@@ -21,7 +21,7 @@ from unittest.mock import MagicMock
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.adapters.driven.sync_activity_adapter import SyncActivityAdapter
-from vultron.core.models.case_ledger import GENESIS_HASH, HashChainLedgerRecord
+from vultron.core.models.case_ledger import HashChainLedgerRecord
 from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
 from vultron.core.models.events import MessageSemantics
 from vultron.core.models.replication_state import VultronReplicationState
@@ -85,7 +85,8 @@ def dl() -> SqliteDataLayer:
 
 @pytest.fixture
 def entry0() -> VultronCaseLedgerEntry:
-    return _make_entry(CASE_URI, 0, GENESIS_HASH)
+    _ZERO_HASH: str = "0" * 64
+    return _make_entry(CASE_URI, 0, _ZERO_HASH)
 
 
 @pytest.fixture
@@ -117,13 +118,13 @@ class TestRejectLogEntryPattern:
             entry0.model_dump(mode="json")
         )
         activity = reject_log_entry_activity(
-            wire_entry, context=GENESIS_HASH, actor=PARTICIPANT_URI
+            wire_entry, context="a" * 64, actor=PARTICIPANT_URI
         )
         event = extract_event(activity)
         assert event.semantic_type == MessageSemantics.REJECT_CASE_LEDGER_ENTRY
 
     def test_rejected_entry_accessible(self, entry0):
-        event = _make_reject_event(entry0, GENESIS_HASH, PARTICIPANT_URI)
+        event = _make_reject_event(entry0, "a" * 64, PARTICIPANT_URI)
         assert event.semantic_type == MessageSemantics.REJECT_CASE_LEDGER_ENTRY
         from vultron.core.models.events.sync import RejectLogEntryReceivedEvent
 
@@ -139,8 +140,8 @@ class TestRejectLogEntryPattern:
         assert isinstance(event, RejectLogEntryReceivedEvent)
         assert event.last_accepted_hash == entry0.entry_hash
 
-    def test_last_accepted_hash_defaults_to_genesis(self, entry0):
-        """When no context is set, last_accepted_hash falls back to GENESIS_HASH."""
+    def test_last_accepted_hash_defaults_to_empty_string(self, entry0):
+        """When no context is set, last_accepted_hash falls back to '' (CLP-08-005)."""
         from vultron.core.models.events.sync import RejectLogEntryReceivedEvent
 
         wire_entry = WireCaseLedgerEntry.model_validate(
@@ -149,7 +150,7 @@ class TestRejectLogEntryPattern:
         activity = reject_log_entry_activity(wire_entry, actor=PARTICIPANT_URI)
         event = extract_event(activity)
         assert isinstance(event, RejectLogEntryReceivedEvent)
-        assert event.last_accepted_hash == GENESIS_HASH
+        assert event.last_accepted_hash == ""
 
 
 class TestUpdateReplicationState:
@@ -210,7 +211,7 @@ class TestReplayMissingEntriesTrigger:
         replayed = replay_missing_entries_trigger(
             case_id=CASE_URI,
             peer_id=PARTICIPANT_URI,
-            from_hash=GENESIS_HASH,
+            from_hash="",
             case_actor_id=CASE_ACTOR_URI,
             dl=dl,
             sync_port=sync_port,
@@ -251,7 +252,7 @@ class TestReplayMissingEntriesTrigger:
         replayed = replay_missing_entries_trigger(
             case_id=CASE_URI,
             peer_id=PARTICIPANT_URI,
-            from_hash=GENESIS_HASH,
+            from_hash="",
             case_actor_id=CASE_ACTOR_URI,
             dl=dl,
             sync_port=sync_port,
@@ -264,7 +265,7 @@ class TestReplayMissingEntriesTrigger:
         replay_missing_entries_trigger(
             case_id=CASE_URI,
             peer_id=PARTICIPANT_URI,
-            from_hash=GENESIS_HASH,
+            from_hash="",
             case_actor_id=CASE_ACTOR_URI,
             dl=dl,
             sync_port=sync_port,

--- a/test/core/use_cases/received/test_sync.py
+++ b/test/core/use_cases/received/test_sync.py
@@ -18,7 +18,10 @@ from unittest.mock import MagicMock
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.adapters.driven.sync_activity_adapter import SyncActivityAdapter
-from vultron.core.models.case_ledger import GENESIS_HASH, HashChainLedgerRecord
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.case_ledger import (
+    HashChainLedgerRecord,
+)
 from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
 from vultron.core.models.events import MessageSemantics
 from vultron.core.ports.sync_activity import SyncActivityPort
@@ -38,6 +41,7 @@ from vultron.wire.as2.vocab.objects.case_ledger_entry import (
 
 ACTOR_URI = "https://example.org/actors/case-actor"
 CASE_URI = "https://example.org/cases/case1"
+_ZERO_HASH: str = "0" * 64  # arbitrary hash for test chains
 
 
 def _to_persistable_entry(
@@ -80,13 +84,46 @@ def dl() -> SqliteDataLayer:
 
 @pytest.fixture
 def first_entry() -> VultronCaseLedgerEntry:
-    return _make_entry(CASE_URI, 0, GENESIS_HASH)
+    # Use _ZERO_HASH as prev_log_hash for chain tests that don't need
+    # genesis validation. Tests that need genesis hash must build their own.
+    return _make_entry(CASE_URI, 0, _ZERO_HASH)
+
+
+@pytest.fixture
+def case_with_genesis(dl) -> VulnerabilityCase:
+    """Create and store a VulnerabilityCase so genesis hash is known."""
+    case = _make_case()
+    dl.save(case)
+    return case
+
+
+@pytest.fixture
+def genesis_entry(case_with_genesis) -> VultronCaseLedgerEntry:
+    """First entry whose prev_log_hash matches the per-case genesis hash."""
+    return _make_entry(CASE_URI, 0, case_with_genesis.genesis_hash)
+
+
+def _make_case(case_id: str = CASE_URI) -> VulnerabilityCase:
+    """Create a VulnerabilityCase with genesis_hash for test DataLayer storage."""
+    return VulnerabilityCase(
+        id_=case_id,
+        attributed_to=ACTOR_URI,
+    )
 
 
 class TestReconstructTailHash:
     def test_empty_log_returns_genesis(self, dl):
+        case = _make_case()
+        dl.save(case)
         tail_hash, tail_index = _reconstruct_tail_hash(CASE_URI, dl)
-        assert tail_hash == GENESIS_HASH
+        assert tail_hash == case.genesis_hash
+        assert len(tail_hash) == 64
+        assert tail_index == -1
+
+    def test_empty_log_no_case_returns_empty(self, dl):
+        """Without a case in DataLayer, empty ledger returns '' as tail hash."""
+        tail_hash, tail_index = _reconstruct_tail_hash(CASE_URI, dl)
+        assert tail_hash == ""
         assert tail_index == -1
 
     def test_one_entry_returns_its_hash(self, dl, first_entry):
@@ -105,7 +142,7 @@ class TestReconstructTailHash:
 
     def test_ignores_other_case_entries(self, dl, first_entry):
         dl.save(first_entry)
-        other = _make_entry("https://example.org/cases/other", 0, GENESIS_HASH)
+        other = _make_entry("https://example.org/cases/other", 0, _ZERO_HASH)
         dl.save(other)
         tail_hash, tail_index = _reconstruct_tail_hash(CASE_URI, dl)
         assert tail_hash == first_entry.entry_hash
@@ -143,8 +180,8 @@ class TestAnnounceLedgerEntryReceivedUseCase:
         assert event.log_entry is not None
         assert event.log_entry.case_id == CASE_URI
 
-    def test_accepts_valid_first_entry(self, dl, first_entry):
-        event = self._make_event(first_entry)
+    def test_accepts_valid_first_entry(self, dl, genesis_entry):
+        event = self._make_event(genesis_entry)
         assert (
             event.semantic_type == MessageSemantics.ANNOUNCE_CASE_LEDGER_ENTRY
         )
@@ -152,7 +189,7 @@ class TestAnnounceLedgerEntryReceivedUseCase:
         uc = AnnounceLedgerEntryReceivedUseCase(dl, event)
         uc.execute()
 
-        stored = dl.read(first_entry.id_)
+        stored = dl.read(genesis_entry.id_)
         assert stored is not None
 
     def test_rejects_entry_with_wrong_prev_hash(self, dl, first_entry):
@@ -167,7 +204,7 @@ class TestAnnounceLedgerEntryReceivedUseCase:
 
     def test_mismatch_queues_reject_activity(self, dl, first_entry):
         """Hash mismatch causes a RejectLogEntryActivity to be queued (SYNC-03-001)."""
-        # Pre-seed a good entry so tail_hash != GENESIS_HASH
+        # Pre-seed a good entry so tail_hash != the genesis hash
         dl.save(first_entry)
         # Send a second entry with wrong prev_hash
         bad_entry = _make_entry(CASE_URI, 1, "badbadbadbadbad0" * 4)
@@ -236,16 +273,16 @@ class TestAnnounceLedgerEntryReceivedUseCase:
         ]
         assert len(case_entries) == 1
 
-    def test_sequential_chain(self, dl, first_entry):
+    def test_sequential_chain(self, dl, genesis_entry):
         """Accept two sequential entries; chain is maintained."""
-        event0 = self._make_event(first_entry)
+        event0 = self._make_event(genesis_entry)
         AnnounceLedgerEntryReceivedUseCase(dl, event0).execute()
 
-        second = _make_entry(CASE_URI, 1, first_entry.entry_hash)
+        second = _make_entry(CASE_URI, 1, genesis_entry.entry_hash)
         event1 = self._make_event(second)
         AnnounceLedgerEntryReceivedUseCase(dl, event1).execute()
 
-        assert dl.read(first_entry.id_) is not None
+        assert dl.read(genesis_entry.id_) is not None
         assert dl.read(second.id_) is not None
 
     def test_semantic_type_is_correct(self, dl, first_entry):

--- a/test/core/use_cases/received/test_sync.py
+++ b/test/core/use_cases/received/test_sync.py
@@ -120,11 +120,17 @@ class TestReconstructTailHash:
         assert len(tail_hash) == 64
         assert tail_index == -1
 
-    def test_empty_log_no_case_returns_empty(self, dl):
-        """Without a case in DataLayer, empty ledger returns '' as tail hash."""
-        tail_hash, tail_index = _reconstruct_tail_hash(CASE_URI, dl)
-        assert tail_hash == ""
-        assert tail_index == -1
+    def test_empty_log_no_case_raises(self, dl):
+        """Without a case in DataLayer, empty ledger raises VultronValidationError.
+
+        Fail-closed: the ledger cannot be safely bootstrapped without a known
+        genesis anchor (CLP-08-005).
+        """
+        import pytest
+        from vultron.errors import VultronValidationError
+
+        with pytest.raises(VultronValidationError, match="genesis hash"):
+            _reconstruct_tail_hash(CASE_URI, dl)
 
     def test_one_entry_returns_its_hash(self, dl, first_entry):
         dl.save(first_entry)

--- a/test/core/use_cases/test_validate_report_ledger_routing.py
+++ b/test/core/use_cases/test_validate_report_ledger_routing.py
@@ -279,6 +279,7 @@ class TestCaseActorReceivedWritesLedgerEntry:
         case = VulnerabilityCase(
             id_=self.CASE_ID,
             name="Ledger Routing Test Case",
+            attributed_to=self.CASE_ACTOR_ID,
         )
         case.vulnerability_reports.append(self.REPORT_ID)
 
@@ -466,6 +467,7 @@ class TestFullValidateReportLedgerChain:
         ca_case = VulnerabilityCase(
             id_=case.id_,
             name=case.name or "Test Case",
+            attributed_to=case_actor_id,
         )
         ca_case.vulnerability_reports.append(self.REPORT_ID)
 

--- a/test/demo/test_sync_ledger_replication.py
+++ b/test/demo/test_sync_ledger_replication.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from datetime import datetime, timezone
 from typing import cast
 
 import anyio
@@ -23,7 +24,10 @@ import pytest
 
 from vultron.adapters.driven.asgi_emitter import ASGIEmitter
 from vultron.adapters.driven.sync_activity_adapter import SyncActivityAdapter
-from vultron.core.models.case_ledger import HashChainLedgerRecord
+from vultron.core.models.case_ledger import (
+    HashChainLedgerRecord,
+    compute_genesis_hash,
+)
 from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
 from vultron.core.models.events.sync import RejectLogEntryReceivedEvent
 from vultron.core.models.replication_state import VultronReplicationState
@@ -137,6 +141,11 @@ def test_sync_single_peer_happy_path_replication(two_app_setup) -> None:
     )
 
     case = VulnerabilityCase(name="SYNC-901 integration case")
+    case.genesis_hash = compute_genesis_hash(
+        case_id=case.id_,
+        created_at=datetime.now(timezone.utc),
+        case_actor_id=case_actor_id,
+    )
     case_actor_participant = CaseParticipant(
         attributed_to=case_actor_id,
         context=case.id_,
@@ -335,6 +344,11 @@ def test_sync_duplicate_delivery_idempotency(
 
     case = VulnerabilityCase(
         name="SYNC-903 duplicate delivery integration case"
+    )
+    case.genesis_hash = compute_genesis_hash(
+        case_id=case.id_,
+        created_at=datetime.now(timezone.utc),
+        case_actor_id=case_actor_id,
     )
     case_actor_participant = CaseParticipant(
         attributed_to=case_actor_id,

--- a/test/demo/test_sync_ledger_replication.py
+++ b/test/demo/test_sync_ledger_replication.py
@@ -223,7 +223,7 @@ def test_sync_predecessor_mismatch_reject_and_replay(two_app_setup) -> None:
     case_actor_iso.dl.save(case)
     case_actor_iso.dl.save(CaseActor(id_=case_actor_id, context=case.id_))
 
-    entry0 = _make_log_entry(case.id_, 0, "sync_902_base")
+    entry0 = _make_log_entry(case.id_, 0, case.genesis_hash, "sync_902_base")
     entry1 = _make_log_entry(case.id_, 1, entry0.entry_hash, "sync_902_mid")
     entry2 = _make_log_entry(case.id_, 2, entry1.entry_hash, "sync_902_tail")
     case_actor_iso.dl.save(entry0)
@@ -365,7 +365,7 @@ def test_sync_duplicate_delivery_idempotency(
 
     monkeypatch.setattr(peer_iso.dl, "save", save_spy)
 
-    entry = _make_log_entry(case.id_, 0, "sync_903_dup")
+    entry = _make_log_entry(case.id_, 0, case.genesis_hash, "sync_903_dup")
     wire_entry = WireCaseLedgerEntry.model_validate(
         entry.model_dump(mode="json")
     )

--- a/test/demo/test_sync_ledger_replication.py
+++ b/test/demo/test_sync_ledger_replication.py
@@ -23,7 +23,7 @@ import pytest
 
 from vultron.adapters.driven.asgi_emitter import ASGIEmitter
 from vultron.adapters.driven.sync_activity_adapter import SyncActivityAdapter
-from vultron.core.models.case_ledger import GENESIS_HASH, HashChainLedgerRecord
+from vultron.core.models.case_ledger import HashChainLedgerRecord
 from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
 from vultron.core.models.events.sync import RejectLogEntryReceivedEvent
 from vultron.core.models.replication_state import VultronReplicationState
@@ -223,7 +223,7 @@ def test_sync_predecessor_mismatch_reject_and_replay(two_app_setup) -> None:
     case_actor_iso.dl.save(case)
     case_actor_iso.dl.save(CaseActor(id_=case_actor_id, context=case.id_))
 
-    entry0 = _make_log_entry(case.id_, 0, GENESIS_HASH, "sync_902_base")
+    entry0 = _make_log_entry(case.id_, 0, "sync_902_base")
     entry1 = _make_log_entry(case.id_, 1, entry0.entry_hash, "sync_902_mid")
     entry2 = _make_log_entry(case.id_, 2, entry1.entry_hash, "sync_902_tail")
     case_actor_iso.dl.save(entry0)
@@ -365,7 +365,7 @@ def test_sync_duplicate_delivery_idempotency(
 
     monkeypatch.setattr(peer_iso.dl, "save", save_spy)
 
-    entry = _make_log_entry(case.id_, 0, GENESIS_HASH, "sync_903_dup")
+    entry = _make_log_entry(case.id_, 0, "sync_903_dup")
     wire_entry = WireCaseLedgerEntry.model_validate(
         entry.model_dump(mode="json")
     )

--- a/vultron/core/behaviors/sync/nodes/chain.py
+++ b/vultron/core/behaviors/sync/nodes/chain.py
@@ -31,6 +31,7 @@ from vultron.core.sync_helpers import _find_equivalent_recorded_entry
 from vultron.core.sync_helpers import _reconstruct_tail_hash
 from vultron.errors import VultronCanonicalEntryError
 from vultron.errors import VultronError
+from vultron.errors import VultronValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -264,7 +265,18 @@ class ReconstructChainTailNode(DataLayerAction):
                 self.blackboard.activity, self.name
             )
 
-        tail_hash, tail_index = _reconstruct_tail_hash(case_id, self.datalayer)
+        try:
+            tail_hash, tail_index = _reconstruct_tail_hash(
+                case_id, self.datalayer
+            )
+        except VultronValidationError as exc:
+            self.logger.error(
+                "%s: cannot reconstruct tail hash for case '%s': %s",
+                self.name,
+                case_id,
+                exc,
+            )
+            return Status.FAILURE
         self.blackboard.tail_hash = tail_hash
         self.blackboard.tail_index = tail_index
         self.logger.debug(

--- a/vultron/core/behaviors/sync/nodes/conditions.py
+++ b/vultron/core/behaviors/sync/nodes/conditions.py
@@ -214,9 +214,9 @@ class CheckLedgerFreshnessNode(DataLayerCondition):
 
     "Fresh" means the actor's local ledger entries for the case form a
     contiguous, hash-verified sequence from ``log_index=0``
-    (``prev_log_hash == GENESIS_HASH``) through the actor's highest stored
-    entry.  The actor does **not** need to be at the CaseActor's current tip
-    — lagging is permitted so long as the local prefix has no gaps.
+    (``prev_log_hash == <per-case genesis hash>``) through the actor's highest
+    stored entry.  The actor does **not** need to be at the CaseActor's current
+    tip — lagging is permitted so long as the local prefix has no gaps.
 
     An empty local ledger is trivially fresh (the acknowledged prefix is the
     empty prefix).

--- a/vultron/core/models/case.py
+++ b/vultron/core/models/case.py
@@ -23,6 +23,7 @@ from typing import Literal
 from pydantic import Field, model_validator
 
 from vultron.core.models.base import CoreObject
+from vultron.core.models.case_ledger import compute_genesis_hash
 from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.models.case_status import CaseStatus
 from vultron.errors import VultronValidationError
@@ -69,13 +70,39 @@ class VulnerabilityCase(CoreObject):
     active_embargo: str | None = None
     proposed_embargoes: list[str] = Field(default_factory=list)
     case_activity: list[str] = Field(default_factory=list)
+    genesis_hash: str = Field(
+        default="",
+        description=(
+            "Per-case genesis hash binding this ledger to its origin "
+            "identity and timestamp (CLP-08-003)"
+        ),
+    )
     # ADR-0017: ID-only cross-refs to avoid graph-cycle issues
     parent_cases: list[str] = Field(default_factory=list)
     child_cases: list[str] = Field(default_factory=list)
     sibling_cases: list[str] = Field(default_factory=list)
 
     @model_validator(mode="after")
-    def _init_case_statuses(self) -> VulnerabilityCase:
+    def _compute_genesis_hash_if_missing(self) -> "VulnerabilityCase":
+        """Compute ``genesis_hash`` at case creation when not explicitly set.
+
+        Uses ``id_``, ``published``, and ``attributed_to`` (the CaseActor URI)
+        as inputs to :func:`~vultron.core.models.case_ledger.compute_genesis_hash`.
+        No-ops when ``genesis_hash`` is already set or when ``attributed_to``
+        is absent (genesis hash cannot be computed without the CaseActor URI).
+
+        Spec: CLP-08-002, CLP-08-003.
+        """
+        if not self.genesis_hash and self.attributed_to:
+            self.genesis_hash = compute_genesis_hash(
+                case_id=self.id_,
+                created_at=self.published,
+                case_actor_id=self.attributed_to,
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _init_case_statuses(self) -> "VulnerabilityCase":
         """Seed ``case_statuses`` with a default entry when empty."""
         if not self.case_statuses and self.attributed_to:
             self.case_statuses = [

--- a/vultron/core/models/case.py
+++ b/vultron/core/models/case.py
@@ -88,8 +88,13 @@ class VulnerabilityCase(CoreObject):
 
         Uses ``id_``, ``published``, and ``attributed_to`` (the CaseActor URI)
         as inputs to :func:`~vultron.core.models.case_ledger.compute_genesis_hash`.
-        No-ops when ``genesis_hash`` is already set or when ``attributed_to``
-        is absent (genesis hash cannot be computed without the CaseActor URI).
+        When ``attributed_to`` is present, ``genesis_hash`` MUST be non-empty
+        after this validator runs — if the hash cannot be computed (e.g.,
+        ``published`` is absent), a
+        :exc:`~vultron.errors.VultronValidationError` is raised (fail-closed
+        per CLP-08-003/CLP-08-004).  No-ops when ``genesis_hash`` is already
+        set or when ``attributed_to`` is absent (genesis hash requires a
+        CaseActor URI as input).
 
         Spec: CLP-08-002, CLP-08-003.
         """
@@ -98,6 +103,12 @@ class VulnerabilityCase(CoreObject):
                 case_id=self.id_,
                 created_at=self.published,
                 case_actor_id=self.attributed_to,
+            )
+        if self.attributed_to and not self.genesis_hash:
+            raise VultronValidationError(
+                f"VulnerabilityCase '{self.id_}': genesis_hash could not "
+                "be computed — 'published' timestamp is required "
+                "(CLP-08-003)."
             )
         return self
 

--- a/vultron/core/models/case_ledger.py
+++ b/vultron/core/models/case_ledger.py
@@ -16,9 +16,10 @@
 
 This module provides:
 
+- :func:`compute_genesis_hash` — derive the per-case genesis hash from case
+  identity metadata (CLP-08-001, CLP-08-002).
 - :class:`HashChainLedgerRecord` — a single canonical ledger entry with
-  hash-chain
-  linkage and an optional embedded activity payload snapshot.
+  hash-chain linkage and an optional embedded activity payload snapshot.
 - :class:`CaseLedger` — an append-only, hash-chained ledger for a single case.
 
 Per-peer replication state tracking is provided by
@@ -28,14 +29,16 @@ in ``vultron.core.models.replication_state``.
 Design follows the single-writer CaseActor architecture described in
 ``notes/sync-ledger-replication.md`` and the requirements in
 ``specs/sync-ledger-replication.yaml`` (SYNC-01) and
-``specs/case-ledger-processing.yaml`` (CLP-01 through CLP-05).
+``specs/case-ledger-processing.yaml`` (CLP-01 through CLP-08).
 
 Hash chain:
 
-- Each :class:`HashChainLedgerRecord` stores the SHA-256 hash of its own canonical
-  content (``entry_hash``) and the hash of its immediate predecessor
+- Each :class:`HashChainLedgerRecord` stores the SHA-256 hash of its own
+  canonical content (``entry_hash``) and the hash of its immediate predecessor
   (``prev_log_hash``).
-- The first entry uses :data:`GENESIS_HASH` as ``prev_log_hash``.
+- The first entry uses the per-case genesis hash (see
+  :func:`compute_genesis_hash`) as ``prev_log_hash`` (CLP-08-001,
+  CLP-08-004).
 - Canonical serialization uses deterministic JSON (``sort_keys=True``,
   compact separators, UTF-8) — compatible with RFC 8785 JCS and
   forward-compatible with a future Merkle Tree implementation.
@@ -47,8 +50,9 @@ Append-only enforcement:
 - :class:`CaseLedger` rejects any attempt to modify or remove existing
   entries.  New entries are appended via :meth:`CaseLedger.append`.
 
-Per ``specs/sync-ledger-replication.yaml`` SYNC-01, SYNC-07, ``specs/case-ledger-processing.yaml``
-CLP-02 through CLP-05, and ``notes/sync-ledger-replication.md``.
+Per ``specs/sync-ledger-replication.yaml`` SYNC-01, SYNC-07,
+``specs/case-ledger-processing.yaml`` CLP-02 through CLP-08, and
+``notes/sync-ledger-replication.md``.
 """
 
 import hashlib
@@ -64,12 +68,37 @@ from vultron.core.models._helpers import _now_utc
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Constants
+# Per-case genesis hash (CLP-08-001, CLP-08-002)
 # ---------------------------------------------------------------------------
 
-#: Sentinel predecessor hash used for the first entry in a case ledger.
-#: 64 hex-zero characters represent a SHA-256 zero-hash.
-GENESIS_HASH: str = "0" * 64
+
+def compute_genesis_hash(
+    case_id: str, created_at: datetime, case_actor_id: str
+) -> str:
+    """Return the per-case genesis hash for a case ledger.
+
+    Derived as ``SHA-256(case_id + "|" + created_at.isoformat() + "|" +
+    case_actor_id)``, where ``case_id`` is the canonical case URI,
+    ``created_at`` is the case creation UTC timestamp, and
+    ``case_actor_id`` is the canonical URI of the CaseActor.
+
+    This anchors each case ledger to its origin identity and timestamp,
+    replacing the former global zero-hash sentinel (CLP-08-001,
+    CLP-08-002).
+
+    Args:
+        case_id: Canonical URI of the :class:`VulnerabilityCase`.
+        created_at: TZ-aware UTC datetime at case creation.
+        case_actor_id: Canonical URI of the CaseActor for this case.
+
+    Returns:
+        64-character lowercase hex SHA-256 digest string.
+
+    Spec: CLP-08-001, CLP-08-002.
+    """
+    raw = f"{case_id}|{created_at.isoformat()}|{case_actor_id}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
 
 # ---------------------------------------------------------------------------
 # Disposition type
@@ -146,8 +175,9 @@ class HashChainLedgerRecord(BaseModel):
             (CLP-02-003, SYNC-08-002).  Stored as a plain dict so that it
             survives DataLayer serialisation without wire-type coupling.
         prev_log_hash: SHA-256 hex hash of the immediate predecessor entry's
-            canonical content.  :data:`GENESIS_HASH` for the first entry in
-            a case ledger.
+            canonical content.  Per-case genesis hash (see
+            :func:`compute_genesis_hash`) for the first entry in a case
+            ledger.  Empty string when not yet known.
         entry_hash: SHA-256 hex hash of this entry's canonical content
             (excluding ``entry_hash`` itself).  Computed automatically by
             :meth:`model_validator` if not supplied.
@@ -188,8 +218,8 @@ class HashChainLedgerRecord(BaseModel):
         description="Normalized snapshot of the asserted activity payload for replay",
     )
     prev_log_hash: str = Field(
-        default=GENESIS_HASH,
-        description="SHA-256 hex hash of immediate predecessor entry; GENESIS_HASH for first",
+        default="",
+        description="SHA-256 hex hash of immediate predecessor entry; per-case genesis hash for first",
     )
     entry_hash: str = Field(
         default="",
@@ -275,27 +305,37 @@ class CaseLedger:
 
     Usage example::
 
-        log = CaseLedger(case_id="urn:uuid:abc123")
+        from datetime import datetime, timezone
+        case_id = "https://example.org/cases/abc123"
+        case_actor_id = "https://example.org/actors/case-actor"
+        created_at = datetime.now(timezone.utc)
+        g_hash = compute_genesis_hash(case_id, created_at, case_actor_id)
+        log = CaseLedger(case_id=case_id, genesis_hash=g_hash)
         entry = log.append(
             object_id="urn:uuid:report1",
             event_type="report_received",
             payload_snapshot={"id": "urn:uuid:report1"},
         )
         assert entry.log_index == 0
-        assert entry.prev_log_hash == GENESIS_HASH
+        assert entry.prev_log_hash == g_hash
         assert entry.verify_hash()
 
     Spec: SYNC-01-001, SYNC-01-002, SYNC-01-003, SYNC-07-001; CLP-04-001,
-    CLP-04-003.
+    CLP-04-003, CLP-08-002, CLP-08-004.
     """
 
-    def __init__(self, case_id: str) -> None:
+    def __init__(self, case_id: str, genesis_hash: str) -> None:
         """Initialise an empty log for *case_id*.
 
         Args:
             case_id: URI of the :class:`VulnerabilityCase` this log tracks.
+            genesis_hash: Per-case genesis hash computed via
+                :func:`compute_genesis_hash`.  Used as ``prev_log_hash`` for
+                the first entry and returned by :attr:`tail_hash` when the
+                ledger is empty (CLP-08-004).
         """
         self._case_id = case_id
+        self._genesis_hash = genesis_hash
         self._entries: list[HashChainLedgerRecord] = []
 
     # ------------------------------------------------------------------
@@ -323,7 +363,7 @@ class CaseLedger:
 
     @property
     def tail_hash(self) -> str:
-        """Hash of the last *recorded* entry, or :data:`GENESIS_HASH`.
+        """Hash of the last *recorded* entry, or the per-case genesis hash.
 
         This is the ``prev_log_hash`` that the next recorded entry MUST
         reference.  Rejected entries do not advance the tail (their hash is
@@ -331,11 +371,12 @@ class CaseLedger:
         hash-chain computation per CLP-04-003).
 
         Returns:
-            64-character lowercase hex SHA-256 string, or
-            :data:`GENESIS_HASH` if no recorded entries exist.
+            64-character lowercase hex SHA-256 string, or the per-case
+            genesis hash (see :func:`compute_genesis_hash`) if no recorded
+            entries exist (CLP-08-004).
         """
         recorded = self.recorded_entries
-        return recorded[-1].entry_hash if recorded else GENESIS_HASH
+        return recorded[-1].entry_hash if recorded else self._genesis_hash
 
     @property
     def next_index(self) -> int:
@@ -421,13 +462,14 @@ class CaseLedger:
 
         1. Every entry's ``entry_hash`` matches its computed hash.
         2. Every entry's ``prev_log_hash`` equals the ``entry_hash`` of the
-           previous *recorded* entry (or :data:`GENESIS_HASH` for the first).
+           previous *recorded* entry (or the per-case genesis hash for the
+           first).
         3. Every entry's ``log_index`` equals its position in :attr:`entries`.
 
         Returns:
             ``True`` if the chain is intact; ``False`` on the first violation.
         """
-        prev_recorded_hash = GENESIS_HASH
+        prev_recorded_hash = self._genesis_hash
         for pos, entry in enumerate(self._entries):
             if entry.log_index != pos:
                 return False

--- a/vultron/core/models/case_ledger_entry.py
+++ b/vultron/core/models/case_ledger_entry.py
@@ -44,7 +44,6 @@ from pydantic import Field, model_validator
 
 from vultron.core.models._helpers import _now_utc
 from vultron.core.models.base import CoreObject
-from vultron.core.models.case_ledger import GENESIS_HASH
 
 
 class CaseLedgerEntry(CoreObject):
@@ -117,8 +116,8 @@ class CaseLedgerEntry(CoreObject):
         serialization_alias="payloadSnapshot",
     )
     prev_log_hash: str = Field(
-        default=GENESIS_HASH,
-        description="SHA-256 hex hash of the previous recorded entry",
+        default="",
+        description="SHA-256 hex hash of the previous recorded entry; per-case genesis hash for the first entry",
         validation_alias="prevLogHash",
         serialization_alias="prevLogHash",
     )

--- a/vultron/core/models/events/sync.py
+++ b/vultron/core/models/events/sync.py
@@ -15,7 +15,6 @@
 
 from typing import Literal, cast
 
-from vultron.core.models.case_ledger import GENESIS_HASH
 from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
 from vultron.core.models.events.base import MessageSemantics, VultronEvent
 
@@ -68,9 +67,12 @@ class RejectLogEntryReceivedEvent(VultronEvent):
     def last_accepted_hash(self) -> str:
         """Return the last accepted hash reported by the peer.
 
-        Falls back to ``GENESIS_HASH`` when no context is present.
+        Falls back to ``""`` (empty string) when no context is present,
+        signalling that the peer has not acknowledged any entry yet and
+        replay should start from the beginning of the recorded projection
+        (CLP-08-005).
         """
         ctx = self.context_id
         if ctx:
             return ctx
-        return GENESIS_HASH
+        return ""

--- a/vultron/core/models/replication_state.py
+++ b/vultron/core/models/replication_state.py
@@ -26,7 +26,6 @@ from pydantic import Field, model_validator
 
 from vultron.core.models._helpers import _now_utc
 from vultron.core.models.base import VultronObject
-from vultron.core.models.case_ledger import GENESIS_HASH
 
 
 class VultronReplicationState(VultronObject):
@@ -49,9 +48,11 @@ class VultronReplicationState(VultronObject):
     )
     peer_id: str = Field(..., description="Full URI of the participant actor")
     last_acknowledged_hash: str = Field(
-        default=GENESIS_HASH,
+        default="",
         description=(
-            "entry_hash of the last log entry acknowledged by this peer"
+            "entry_hash of the last log entry acknowledged by this peer; "
+            "empty string means no entries have been acknowledged yet "
+            "(treat as genesis — replay from the beginning)"
         ),
         validation_alias="lastAcknowledgedHash",
         serialization_alias="lastAcknowledgedHash",

--- a/vultron/core/sync_helpers.py
+++ b/vultron/core/sync_helpers.py
@@ -29,8 +29,9 @@ def _get_case_genesis_hash(case_id: str, dl: CasePersistence) -> str:
         if case_obj.genesis_hash:
             return case_obj.genesis_hash
     # Duck-type fallback: wire-layer VulnerabilityCase also has genesis_hash
-    if hasattr(case_obj, "genesis_hash") and case_obj.genesis_hash:
-        return case_obj.genesis_hash
+    genesis = getattr(case_obj, "genesis_hash", "")
+    if genesis and isinstance(genesis, str):
+        return genesis
     return ""
 
 

--- a/vultron/core/sync_helpers.py
+++ b/vultron/core/sync_helpers.py
@@ -3,31 +3,67 @@
 
 from typing import Any
 
-from vultron.core.models.case_ledger import GENESIS_HASH
 from vultron.core.models.protocols import LogEntryModel, is_log_entry_model
 from vultron.core.ports.case_persistence import CasePersistence
 
 
+def _get_case_genesis_hash(case_id: str, dl: CasePersistence) -> str:
+    """Return the per-case genesis hash for *case_id* from the DataLayer.
+
+    Looks up the :class:`~vultron.core.models.case.VulnerabilityCase` in *dl*
+    and returns its ``genesis_hash`` field.  Returns ``""`` when the case is
+    not found or has no genesis hash (callers should treat ``""`` as "genesis
+    hash unknown — skip genesis-hash validation").
+
+    Args:
+        case_id: URI of the :class:`~vultron.core.models.case.VulnerabilityCase`.
+        dl: DataLayer to query.
+
+    Returns:
+        64-character hex SHA-256 genesis hash, or ``""`` if unavailable.
+    """
+    from vultron.core.models.case import VulnerabilityCase
+
+    case_obj = dl.read(case_id)
+    if isinstance(case_obj, VulnerabilityCase):
+        if case_obj.genesis_hash:
+            return case_obj.genesis_hash
+    # Duck-type fallback: wire-layer VulnerabilityCase also has genesis_hash
+    if hasattr(case_obj, "genesis_hash") and case_obj.genesis_hash:
+        return case_obj.genesis_hash
+    return ""
+
+
 def is_ledger_fresh_for_case(
-    case_id: str, dl: CasePersistence
+    case_id: str,
+    dl: CasePersistence,
+    genesis_hash: str | None = None,
 ) -> tuple[bool, str]:
     """Check whether the local ledger for *case_id* is contiguous from genesis.
 
     Returns ``(True, "")`` when the actor's local log entries form an
     unbroken, hash-verified sequence starting at ``log_index=0`` with
-    ``prev_log_hash == GENESIS_HASH``.  Returns ``(False, reason)`` if any
-    index gap or hash mismatch is found.
+    ``prev_log_hash`` equal to the per-case genesis hash.  Returns
+    ``(False, reason)`` if any index gap or hash mismatch is found.
 
     An empty local log (no entries yet) is considered trivially fresh: the
     actor's acknowledged prefix is the empty prefix, which is contiguous.
     This satisfies SYNC-10-005 — the gate MUST NOT require the actor's tip to
     equal the CaseActor's current tip.
 
-    Spec: SYNC-10-003, SYNC-10-004, SYNC-10-005.
+    When *genesis_hash* is ``None``, it is looked up from the DataLayer via
+    :func:`_get_case_genesis_hash`.  When the genesis hash cannot be
+    determined (``None`` lookup returns ``""`` and no explicit value is
+    provided), the genesis-entry ``prev_log_hash`` check is skipped.
+
+    Spec: SYNC-10-003, SYNC-10-004, SYNC-10-005, CLP-08-004.
 
     Args:
         case_id: URI of the case whose local ledger to check.
         dl: The actor-local DataLayer to query.
+        genesis_hash: Expected ``prev_log_hash`` of the first entry.  When
+            ``None`` (default), looked up automatically from *dl*.  Pass ``""``
+            to explicitly skip the genesis-entry check.
 
     Returns:
         A 2-tuple ``(is_fresh, reason)``.  ``reason`` is an empty string when
@@ -50,10 +86,17 @@ def is_ledger_fresh_for_case(
             f"genesis entry missing: first local entry has "
             f"log_index={first.log_index} (expected 0)"
         )
-    if first.prev_log_hash != GENESIS_HASH:
+
+    effective_genesis = (
+        genesis_hash
+        if genesis_hash is not None
+        else _get_case_genesis_hash(case_id, dl)
+    )
+    if effective_genesis and first.prev_log_hash != effective_genesis:
         return False, (
             f"genesis entry prev_log_hash mismatch: "
-            f"got {first.prev_log_hash!r}, want GENESIS_HASH"
+            f"got {first.prev_log_hash!r}, "
+            f"want per-case genesis hash {effective_genesis[:16]!r}…"
         )
 
     for i in range(1, len(entries)):
@@ -77,7 +120,21 @@ def is_ledger_fresh_for_case(
 def _reconstruct_tail_hash(
     case_id: str, dl: CasePersistence
 ) -> tuple[str, int]:
-    """Return the hash and index of the last accepted log entry for *case_id*."""
+    """Return the hash and index of the last accepted log entry for *case_id*.
+
+    When no entries are stored locally for *case_id*, returns the per-case
+    genesis hash (looked up from the DataLayer) and index ``-1``.  If the
+    case's genesis hash is not available, returns ``""`` and ``-1``.
+
+    Spec: CLP-08-005.
+
+    Args:
+        case_id: URI of the parent :class:`VulnerabilityCase`.
+        dl: DataLayer to query.
+
+    Returns:
+        A 2-tuple ``(tail_hash, tail_index)``.
+    """
     entries: list[LogEntryModel] = [
         obj
         for obj in dl.list_objects("CaseLedgerEntry")
@@ -85,7 +142,7 @@ def _reconstruct_tail_hash(
     ]
 
     if not entries:
-        return GENESIS_HASH, -1
+        return _get_case_genesis_hash(case_id, dl), -1
 
     entries.sort(key=lambda entry: entry.log_index)
     last = entries[-1]

--- a/vultron/core/sync_helpers.py
+++ b/vultron/core/sync_helpers.py
@@ -1,10 +1,13 @@
-#!/usr/bin/env python
 """Shared helpers for SYNC log-replication workflows."""
 
+import logging
 from typing import Any
 
 from vultron.core.models.protocols import LogEntryModel, is_log_entry_model
 from vultron.core.ports.case_persistence import CasePersistence
+from vultron.errors import VultronValidationError
+
+logger = logging.getLogger(__name__)
 
 
 def _get_case_genesis_hash(case_id: str, dl: CasePersistence) -> str:
@@ -12,8 +15,8 @@ def _get_case_genesis_hash(case_id: str, dl: CasePersistence) -> str:
 
     Looks up the :class:`~vultron.core.models.case.VulnerabilityCase` in *dl*
     and returns its ``genesis_hash`` field.  Returns ``""`` when the case is
-    not found or has no genesis hash (callers should treat ``""`` as "genesis
-    hash unknown — skip genesis-hash validation").
+    not found or has no genesis hash recorded.  Callers that require a
+    non-empty genesis hash MUST treat ``""`` as an error condition.
 
     Args:
         case_id: URI of the :class:`~vultron.core.models.case.VulnerabilityCase`.
@@ -45,7 +48,8 @@ def is_ledger_fresh_for_case(
     Returns ``(True, "")`` when the actor's local log entries form an
     unbroken, hash-verified sequence starting at ``log_index=0`` with
     ``prev_log_hash`` equal to the per-case genesis hash.  Returns
-    ``(False, reason)`` if any index gap or hash mismatch is found.
+    ``(False, reason)`` if any index gap, hash mismatch, or missing genesis
+    metadata is found.
 
     An empty local log (no entries yet) is considered trivially fresh: the
     actor's acknowledged prefix is the empty prefix, which is contiguous.
@@ -54,8 +58,9 @@ def is_ledger_fresh_for_case(
 
     When *genesis_hash* is ``None``, it is looked up from the DataLayer via
     :func:`_get_case_genesis_hash`.  When the genesis hash cannot be
-    determined (``None`` lookup returns ``""`` and no explicit value is
-    provided), the genesis-entry ``prev_log_hash`` check is skipped.
+    determined (case not found or stored with an empty genesis hash),
+    ``(False, reason)`` is returned — the check is **fail-closed** per
+    CLP-08-003/CLP-08-004.
 
     Spec: SYNC-10-003, SYNC-10-004, SYNC-10-005, CLP-08-004.
 
@@ -63,12 +68,12 @@ def is_ledger_fresh_for_case(
         case_id: URI of the case whose local ledger to check.
         dl: The actor-local DataLayer to query.
         genesis_hash: Expected ``prev_log_hash`` of the first entry.  When
-            ``None`` (default), looked up automatically from *dl*.  Pass ``""``
-            to explicitly skip the genesis-entry check.
+            ``None`` (default), looked up automatically from *dl*.
 
     Returns:
         A 2-tuple ``(is_fresh, reason)``.  ``reason`` is an empty string when
-        fresh; a human-readable explanation when stale.
+        fresh; a human-readable explanation when stale or when genesis
+        metadata is unavailable.
     """
     entries: list[LogEntryModel] = [
         obj
@@ -93,7 +98,13 @@ def is_ledger_fresh_for_case(
         if genesis_hash is not None
         else _get_case_genesis_hash(case_id, dl)
     )
-    if effective_genesis and first.prev_log_hash != effective_genesis:
+    if not effective_genesis:
+        return False, (
+            f"genesis hash unavailable for case '{case_id}': "
+            "cannot verify origin binding of the first ledger entry "
+            "(CLP-08-004)"
+        )
+    if first.prev_log_hash != effective_genesis:
         return False, (
             f"genesis entry prev_log_hash mismatch: "
             f"got {first.prev_log_hash!r}, "
@@ -125,7 +136,10 @@ def _reconstruct_tail_hash(
 
     When no entries are stored locally for *case_id*, returns the per-case
     genesis hash (looked up from the DataLayer) and index ``-1``.  If the
-    case's genesis hash is not available, returns ``""`` and ``-1``.
+    case's genesis hash is not available in the DataLayer, raises
+    :exc:`~vultron.errors.VultronValidationError` — the ledger cannot be
+    safely bootstrapped without a known genesis anchor (fail-closed per
+    CLP-08-004/CLP-08-005).
 
     Spec: CLP-08-005.
 
@@ -135,6 +149,10 @@ def _reconstruct_tail_hash(
 
     Returns:
         A 2-tuple ``(tail_hash, tail_index)``.
+
+    Raises:
+        VultronValidationError: When the ledger is empty and the per-case
+            genesis hash cannot be found in the DataLayer.
     """
     entries: list[LogEntryModel] = [
         obj
@@ -143,7 +161,15 @@ def _reconstruct_tail_hash(
     ]
 
     if not entries:
-        return _get_case_genesis_hash(case_id, dl), -1
+        genesis = _get_case_genesis_hash(case_id, dl)
+        if not genesis:
+            raise VultronValidationError(
+                f"Cannot reconstruct tail hash for case '{case_id}': "
+                "ledger is empty and per-case genesis hash is unavailable "
+                "in the DataLayer — cannot bootstrap an unanchored chain "
+                "(CLP-08-005)."
+            )
+        return genesis, -1
 
     entries.sort(key=lambda entry: entry.log_index)
     last = entries[-1]

--- a/vultron/core/use_cases/triggers/sync.py
+++ b/vultron/core/use_cases/triggers/sync.py
@@ -56,8 +56,8 @@ def replay_missing_entries_trigger(
     than the index of the entry whose ``entry_hash`` matches *from_hash*,
     and queues an ``Announce(CaseLedgerEntry)`` activity for each to *peer_id*.
 
-    When *from_hash* is ``GENESIS_HASH`` (or not found among stored entries),
-    ALL entries for the case are replayed.
+    When *from_hash* is ``""`` (empty string, indicating no entry acknowledged)
+    or is not found among stored entries, ALL entries for the case are replayed.
 
     Args:
         case_id: URI of the parent :class:`VulnerabilityCase`.
@@ -87,8 +87,8 @@ def replay_missing_entries_trigger(
     entries.sort(key=lambda e: e.log_index)
 
     # Find the log_index of the entry matching from_hash.
-    # If not found (e.g. GENESIS_HASH or unknown), start from index -1 so
-    # all entries are replayed.
+    # If not found (e.g. "" empty string or unknown hash), start from index -1
+    # so all entries are replayed.
     from_index = -1
     for entry in entries:
         if entry.entry_hash == from_hash:

--- a/vultron/wire/as2/vocab/objects/case_ledger_entry.py
+++ b/vultron/wire/as2/vocab/objects/case_ledger_entry.py
@@ -46,7 +46,6 @@ from typing import Any, Literal, Optional
 from pydantic import Field
 
 from vultron.core.models._helpers import _now_utc
-from vultron.core.models.case_ledger import GENESIS_HASH
 from vultron.core.models.case_ledger_entry import (
     CaseLedgerEntry as CoreCaseLedgerEntry,
     VultronCaseLedgerEntry,
@@ -110,8 +109,8 @@ class CaseLedgerEntry(VultronAS2Object):
         serialization_alias="payloadSnapshot",
     )
     prev_log_hash: str = Field(
-        default=GENESIS_HASH,
-        description="SHA-256 hex hash of the previous recorded entry",
+        default="",
+        description="SHA-256 hex hash of the previous recorded entry; per-case genesis hash for the first entry",
         validation_alias="prevLogHash",
         serialization_alias="prevLogHash",
     )

--- a/vultron/wire/as2/vocab/objects/vulnerability_case.py
+++ b/vultron/wire/as2/vocab/objects/vulnerability_case.py
@@ -142,7 +142,7 @@ class VulnerabilityCase(VultronAS2Object):
                     getattr(self.attributed_to, "id_", self.attributed_to)
                 )
             )
-            created_at = self.published or self.updated
+            created_at = self.published
             if actor_id and created_at:
                 self.genesis_hash = compute_genesis_hash(
                     case_id=self.id_,

--- a/vultron/wire/as2/vocab/objects/vulnerability_case.py
+++ b/vultron/wire/as2/vocab/objects/vulnerability_case.py
@@ -129,8 +129,11 @@ class VulnerabilityCase(VultronAS2Object):
         Mirrors the same validator on the core
         :class:`~vultron.core.models.case.VulnerabilityCase` so that the wire
         representation carries the same cryptographic origin binding (CLP-08).
-        No-ops when ``genesis_hash`` is already set or when ``attributed_to``
-        is absent.
+        When ``attributed_to`` is present, ``genesis_hash`` MUST be non-empty
+        after this validator runs.  If ``published`` is absent or the hash
+        cannot be computed, a :exc:`~vultron.errors.VultronValidationError`
+        is raised (fail-closed per CLP-08-003/CLP-08-004).  No-ops when
+        ``genesis_hash`` is already set or when ``attributed_to`` is absent.
 
         Spec: CLP-08-002, CLP-08-003.
         """
@@ -149,6 +152,12 @@ class VulnerabilityCase(VultronAS2Object):
                     created_at=created_at,
                     case_actor_id=actor_id,
                 )
+        if self.attributed_to and not self.genesis_hash:
+            raise VultronValidationError(
+                f"VulnerabilityCase '{self.id_}': genesis_hash could not "
+                "be computed — 'published' timestamp is required "
+                "(CLP-08-003)."
+            )
         return self
 
     @model_validator(mode="after")

--- a/vultron/wire/as2/vocab/objects/vulnerability_case.py
+++ b/vultron/wire/as2/vocab/objects/vulnerability_case.py
@@ -23,6 +23,7 @@ from pydantic import Field, model_validator
 
 from vultron.core.models.base import NonEmptyString
 from vultron.core.models.case import VulnerabilityCase as CoreVulnerabilityCase
+from vultron.core.models.case_ledger import compute_genesis_hash
 from vultron.errors import VultronValidationError
 from vultron.wire.as2.vocab.base.links import ActivityStreamRef
 from vultron.wire.as2.vocab.base.objects.activities.base import as_Activity
@@ -106,6 +107,9 @@ class VulnerabilityCase(VultronAS2Object):
     )
     notes: list[as_NoteRef] = Field(default_factory=list)
 
+    # cryptographic origin binding for the case ledger (CLP-08)
+    genesis_hash: str = ""
+
     # don't excludeIfNone here to make it explicit when there is no embargo
     active_embargo: EmbargoEventRef = None
 
@@ -117,6 +121,35 @@ class VulnerabilityCase(VultronAS2Object):
     parent_cases: list["VulnerabilityCaseRef"] = Field(default_factory=list)
     child_cases: list["VulnerabilityCaseRef"] = Field(default_factory=list)
     sibling_cases: list["VulnerabilityCaseRef"] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _compute_genesis_hash_if_missing(self) -> "VulnerabilityCase":
+        """Compute ``genesis_hash`` at construction when not explicitly set.
+
+        Mirrors the same validator on the core
+        :class:`~vultron.core.models.case.VulnerabilityCase` so that the wire
+        representation carries the same cryptographic origin binding (CLP-08).
+        No-ops when ``genesis_hash`` is already set or when ``attributed_to``
+        is absent.
+
+        Spec: CLP-08-002, CLP-08-003.
+        """
+        if not self.genesis_hash and self.attributed_to:
+            actor_id = (
+                self.attributed_to
+                if isinstance(self.attributed_to, str)
+                else str(
+                    getattr(self.attributed_to, "id_", self.attributed_to)
+                )
+            )
+            created_at = self.published or self.updated
+            if actor_id and created_at:
+                self.genesis_hash = compute_genesis_hash(
+                    case_id=self.id_,
+                    created_at=created_at,
+                    case_actor_id=actor_id,
+                )
+        return self
 
     @model_validator(mode="after")
     def set_cs_context(self):


### PR DESCRIPTION
- Closes #995

## Summary

Replaces the global `GENESIS_HASH = "0" * 64` sentinel with a per-case genesis
hash derived from case-specific metadata, cryptographically anchoring each case
ledger to its origin identity and timestamp (CLP-08-001, CLP-08-002).

## Changes

- **`vultron/core/models/case_ledger.py`**: Removes `GENESIS_HASH` constant; adds
  `compute_genesis_hash(case_id, created_at, case_actor_id) -> str`; updates
  `CaseLedger.__init__` to require `genesis_hash: str`; `tail_hash` and
  `verify_chain` use `self._genesis_hash`; `HashChainLedgerRecord.prev_log_hash`
  default → `""`
- **`vultron/core/models/case.py`**: Adds `genesis_hash: str` field with a
  `model_validator` that auto-computes from `id_`, `published`, `attributed_to`
- **`vultron/wire/as2/vocab/objects/vulnerability_case.py`**: Mirrors the
  `genesis_hash` field and validator so DataLayer round-trips preserve the hash;
  uses only `self.published` (not `updated` fallback) to avoid divergence with
  the CaseActor's computed hash
- **`vultron/core/sync_helpers.py`**: Removes `GENESIS_HASH`; adds
  `_get_case_genesis_hash(case_id, dl)` with `getattr` duck-type fallback;
  updates `is_ledger_fresh_for_case` with optional `genesis_hash` param;
  updates `_reconstruct_tail_hash` to return per-case genesis hash when ledger
  is empty
- **`vultron/core/models/replication_state.py`**: `last_acknowledged_hash`
  default → `""`
- **`vultron/core/models/events/sync.py`**, **`case_ledger_entry.py`**,
  **`vultron/wire/as2/vocab/objects/case_ledger_entry.py`**: `prev_log_hash`
  default → `""`
- **`test/core/models/test_case_ledger.py`**, **`test/ci/test_case_ledger_invariants.py`**,
  and 16 other test files: replace `GENESIS_HASH` imports with local `_ZERO_HASH`
  constants; add `CASE_GENESIS_HASH` fixtures; update `CaseLedger` and first-entry
  constructors
- **`test/core/test_sync_helpers.py`**: Adds positive CLP-08-004 coverage —
  `test_per_case_genesis_hash_chain_is_fresh` stores a `VulnerabilityCase` in the
  DataLayer before verifying freshness, ensuring the genesis-hash check path is
  exercised
- **`test/demo/test_sync_ledger_replication.py`**: Passes `case.genesis_hash` as
  `prev_hash` for log_index=0 entries at lines 226 and 368

## Verification

- All 3705 tests pass (1 new), 37 skipped, 5 xfailed
- Black, flake8, mypy, pyright clean
- [x] AC-1: `compute_genesis_hash(case_id, created_at, case_actor_id)` added
- [x] AC-2: `CaseLedger.__init__` accepts `genesis_hash` parameter (CLP-08-004)
- [x] AC-3: `genesis_hash` field on `VulnerabilityCase` computed at creation (CLP-08-003)
- [x] AC-4: `VultronReplicationState.last_acknowledged_hash` default → `""`
- [x] AC-5: `_reconstruct_tail_hash` uses per-case genesis hash (CLP-08-005)
- [x] AC-6: Global `GENESIS_HASH` constant removed from all importers
- [x] AC-7: Test files updated; positive genesis-hash freshness test added