### PR TITLE
docs: plan issue #1036 — single-BT-execution invariant for received-side commits

### DIFF
--- a/docs/adr/0022-single-bt-execution-for-received-side-case-actor-routing.md
+++ b/docs/adr/0022-single-bt-execution-for-received-side-case-actor-routing.md
@@ -1,0 +1,232 @@
+---
+status: accepted
+date: 2026-06-18
+deciders: Vultron maintainers
+consulted: >-
+  notes/bt-integration.md, notes/case-communication-model.md,
+  notes/case-ledger-authority.md, specs/case-ledger-processing.yaml,
+  docs/adr/0021-caseactor-inbox-routing-canonical-ledger.md
+---
+
+# Single BT Execution Per Inbox Delivery for Received-Side CaseActor Routing
+
+## Context and Problem Statement
+
+ADR-0021 established that the CaseActor's own inbox delivery is the sole
+path to a canonical ledger commit, and introduced a pre-flight guard
+(CLP-10-002, CLP-10-003): a received-side use case compares
+`receiving_actor_id` to the resolved `case_actor_id` in Python *before*
+deciding whether to execute the guarded-commit BT
+(`create_guarded_commit_case_ledger_entry_tree`).
+
+Issue #1036 found that implementing that guard produced a second
+anti-pattern: every adopting use case now runs **two separate**
+`BTBridge.execute_with_setup()` calls per inbox delivery — one for the
+use case's main operation (often under the message's own actor identity,
+e.g. the invitee or accepting actor), and a second, conditionally
+dispatched call for the guarded commit (under `receiving_actor_id`). The
+condition that decides whether the second call happens at all is plain
+Python control flow (`if receiving_actor_id != case_actor_id: return`),
+not a node inside either tree.
+
+An audit (issue #1036, broadened during planning) found this exact shape
+in **9 use cases across 6 modules**:
+
+- `vultron/core/use_cases/received/embargo.py`:
+  `RemoveEmbargoEventFromCaseReceivedUseCase`,
+  `InviteToEmbargoOnCaseReceivedUseCase`,
+  `AcceptInviteToEmbargoOnCaseReceivedUseCase`
+- `vultron/core/use_cases/received/report.py`:
+  `ValidateReportReceivedUseCase`, `AckReportReceivedUseCase`
+- `vultron/core/use_cases/received/note.py`: `AddNoteToCaseReceivedUseCase`
+- `vultron/core/use_cases/received/status.py`:
+  `AddParticipantStatusReceivedUseCase`
+- `vultron/core/use_cases/received/case/lifecycle.py`:
+  `CloseCaseReceivedUseCase`
+- `vultron/core/use_cases/received/actor/case_manager_role.py`:
+  `OfferCaseManagerRoleReceivedUseCase`
+
+Every one of these imports and calls
+`create_guarded_commit_case_ledger_entry_tree` directly from its own
+`execute()` method, as a second, independently-gated tree execution. The
+last one is structurally similar but slightly worse: its "main operation"
+is plain procedural code (idempotent create + trigger-activity call), not
+a BT at all — a separate, pre-existing BT-06-001 gap that the
+implementation issue for this module should note but is not required to
+fix as part of CLP-10-005.
+
+This is the same class of problem the "Post-BT Procedural Cascade
+Anti-Pattern" (`notes/bt-integration.md`) already names for the
+validate→prioritize cascade: a cascade that is a *child* of the
+triggering operation in the canonical model must be expressed as a BT
+subtree, not as a procedural call (or a second, conditionally-dispatched
+tree execution) sitting outside the tree in `execute()`. The fact that
+the second tree's own internal guard (`CheckIsCaseManagerNode`) is
+correctly role-gated does not fix the problem: the decision of *whether
+to even ask the question* is still made in Python, once per inbox
+delivery, instead of being one branch of one BT run.
+
+A related architectural question raised during planning — whether the
+inbox dispatch pipeline itself needs to be restructured so a use case
+never has to ask "which actor am I running as" — turned out not to apply.
+Investigation found `receiving_actor_id` is already resolved before
+dispatch (`FastAPIDispatchAdapter.dispatch()`, which sets it from the
+canonical actor ID resolved off the inbox URL path) and is already
+present on every received-side event by the time `execute()` runs. The
+dispatcher (`vultron/core/dispatcher.py`) has no CaseActor awareness and
+needs none — it is a pure routing-table lookup keyed on
+`semantic_type`. The gap is entirely at the use-case/BT boundary, not the
+dispatch layer; no change to ADR-0020's proposed `process_payload` seam
+is required by this decision.
+
+## Decision Drivers
+
+- The BT is the domain documentation (`specs/behavior-tree-integration.yaml`
+  BT-06-001); a cascade that is invisible outside the tree structure is
+  invisible to analysis and audit, regardless of whether the gating logic
+  is "correct" in isolation.
+- CLP-09-001 already requires the commit to be reached only through a
+  role-gated *composition* — a Selector/Sequence/Success idiom evaluated
+  inside the tree. A second, externally-gated `execute_with_setup()` call
+  is not that composition; it duplicates the gate in a second place
+  (Python) on top of the one already inside the guarded-commit tree.
+- `receiving_actor_id` is already known before any use case runs (see
+  Context). There is no remaining technical reason for a received-side
+  use case to execute more than one BT per inbox delivery under more than
+  one actor identity.
+- Per-message asserter identities that differ from `receiving_actor_id`
+  (e.g. `invitee_id`, `accepting_actor_id`) are legitimate inputs to leaf
+  nodes — they are not legitimate values for the `actor_id` argument of
+  `execute_with_setup()`, which must always be the identity of the
+  DataLayer actually in scope for this invocation.
+
+## Considered Options
+
+**Option A — Single BT execution per inbox delivery; CASE_MANAGER gating
+is an in-tree branch of the same tree (this ADR's decision).**
+Each received-side use case calls `BTBridge.execute_with_setup()` exactly
+once, with `actor_id=receiving_actor_id`. The use case's tree-factory
+function composes the main operation subtree and the guarded-commit
+subtree (`create_guarded_commit_case_ledger_entry_tree`, or an equivalent
+Selector/Sequence/Success branch) as siblings or a sequence within one
+tree. Any identity referenced by the message other than
+`receiving_actor_id` (invitee, accepting actor, sender) is threaded into
+the tree as leaf-node constructor arguments or blackboard keys — data,
+not a second `actor_id`.
+
+**Option B — Keep the current two-call shape; tighten only the
+pre-flight guard's correctness (status quo, amended).**
+Leave each use case's `execute()` performing two `execute_with_setup()`
+calls, but ensure the second call's `actor_id` is always provably
+`receiving_actor_id` (already true after ADR-0021/CLP-10-003). This
+satisfies CLP-10-002/CLP-10-003 literally but leaves the underlying
+cascade-visibility problem unresolved: the decision to run the commit
+step at all is still Python control flow outside any tree.
+
+**Option C — Move the pre-flight guard into a wrapper BT that always
+runs, with the use case's main tree as a child.**
+Introduce a top-level "received-side dispatch tree" per use case that
+always executes under `receiving_actor_id`, with the existing main tree
+and the guarded-commit tree as two children, but keep them as
+independent tree objects rather than fully merging composition. This is
+a smaller diff than Option A in the short term but reintroduces a
+two-tree-construction split that makes it easy to drift back into the
+Option B shape during future edits, since the "merge point" is itself
+external to either tree's own factory function.
+
+## Decision Outcome
+
+Chosen option: **Option A — single BT execution per inbox delivery, with
+CASE_MANAGER gating as an in-tree branch of the same tree**.
+
+```text
+ReceivedUseCase.execute()
+  └── ONE call: bridge.execute_with_setup(tree, actor_id=receiving_actor_id)
+
+tree = create_<use_case>_received_tree(...)   # single factory function
+  ├── <main operation subtree>                 # may reference invitee_id /
+  │                                             # accepting_actor_id etc. as
+  │                                             # leaf-node data, never as a
+  │                                             # second actor_id
+  └── Selector("GuardedCommitOrSkip")
+        ├── Sequence
+        │     ├── CheckIsCaseManagerNode(case_id=case_id)
+        │     └── CommitCaseLedgerEntryNode(case_id=case_id)
+        └── Success("CommitSkippedNotCaseManager")
+```
+
+`CheckIsCaseManagerNode` resolves the case's `CVDRole.CASE_MANAGER`
+participant and compares it against the actor active for *this*
+invocation (`receiving_actor_id`, since that is now always the BT's
+`actor_id`) — the same role check already required by CLP-09-001, now
+reached through exactly one tree execution instead of two.
+
+This amends ADR-0021's CLP-10-002/CLP-10-003 call-shape (which it leaves
+intact at the routing level — the CaseActor's own inbox delivery is still
+the only path to a commit) by replacing the *external* pre-flight guard
+with an *internal* one. CLP-10-001 (every protocol-significant trigger
+tree emits to `case_manager_id`) is unaffected.
+
+### New Normative Requirement
+
+`specs/case-ledger-processing.yaml` gains CLP-10-005: a received-side use
+case MUST NOT import or call
+`create_guarded_commit_case_ledger_entry_tree` (or any other guarded-commit
+factory) directly from `vultron/core/use_cases/`; it MUST be composed as a
+child of the use case's own tree-factory function in
+`vultron/core/behaviors/`, reached through the single
+`execute_with_setup()` call already used for the use case's main
+operation. A structural test enumerates known violations as a ratchet
+(`test/architecture/test_single_bt_execution_received_side.py`).
+
+### Consequences
+
+- Good, because the cascade from "process this message" to "commit a
+  canonical entry if I'm the CaseActor" becomes visible in tree structure,
+  consistent with every other cascade in the codebase (BT-06-001/006).
+- Good, because it eliminates a structurally duplicated gate (Python
+  check + in-tree `CheckIsCaseManagerNode`) in favor of one gate, in one
+  place, evaluated once.
+- Good, because the fix requires no change to the inbox dispatch pipeline
+  or ADR-0020's proposed seam — `receiving_actor_id` is already available
+  before any use case executes.
+- Neutral, because use cases whose main operation legitimately needs a
+  different actor identity for some leaf nodes (e.g. the Invite/Accept
+  embargo handshake, where `UpdateParticipantEmbargoPecNode` /
+  `RecordParticipantAcceptanceNode` need `invitee_id`/`accepting_actor_id`)
+  must thread that identity through as leaf-node data rather than as
+  `execute_with_setup`'s `actor_id` — a real design change to those trees,
+  not just a call-site edit.
+- Bad, because all 9 known call sites require a tree-factory redesign
+  (not a one-line fix), and discovering the same shape required a
+  full-codebase audit rather than fixing the 3 sites originally named in
+  issue #1036 — the true scope was about 3x the originally reported
+  evidence.
+
+## Validation
+
+- `specs/case-ledger-processing.yaml` CLP-10-005 codifies the requirement
+  from this ADR.
+- `test/architecture/test_single_bt_execution_received_side.py` enumerates
+  the 6 known-violating modules (9 use cases) as a ratchet set (mirroring
+  `test/architecture/test_core_no_adapter_imports.py`): the test fails if
+  a new violation appears, and fails if a known violation is fixed but not
+  removed from the set — forcing each migration to update the test.
+
+## More Information
+
+- Issue #1036 — concern that identified the anti-pattern (3 originally
+  cited call sites) and the planning session that broadened the audit to
+  8.
+- Issue #1038 — folded into this ADR's implementation graph; it had
+  independently proposed the same single-BT shape for the Invite/Accept
+  embargo pair and is superseded by the implementation issue covering
+  `embargo.py`.
+- ADR-0021 — establishes the CaseActor-inbox-is-sole-commit-path routing
+  rule this ADR's call-shape change builds on; not superseded, only
+  amended at the call-shape level.
+- `notes/bt-integration.md` § "Guarded Commit: Role-Gated Canonical
+  Writes" — the existing Selector/Sequence/Success idiom this decision
+  requires to be reached through a single tree execution.
+- `notes/case-communication-model.md` § "Known Implementation Gaps" —
+  tracks the per-module migration status.

--- a/docs/adr/0022-single-bt-execution-for-received-side-case-actor-routing.md
+++ b/docs/adr/0022-single-bt-execution-for-received-side-case-actor-routing.md
@@ -5,7 +5,8 @@ deciders: Vultron maintainers
 consulted: >-
   notes/bt-integration.md, notes/case-communication-model.md,
   notes/case-ledger-authority.md, specs/case-ledger-processing.yaml,
-  docs/adr/0021-caseactor-inbox-routing-canonical-ledger.md
+  docs/adr/0021-caseactor-inbox-routing-canonical-ledger.md,
+  issue #1047
 ---
 
 # Single BT Execution Per Inbox Delivery for Received-Side CaseActor Routing
@@ -29,42 +30,89 @@ condition that decides whether the second call happens at all is plain
 Python control flow (`if receiving_actor_id != case_actor_id: return`),
 not a node inside either tree.
 
-An audit (issue #1036, broadened during planning) found this exact shape
-in **9 use cases across 6 modules**:
+An audit (issue #1036, broadened during planning to also resolve a
+follow-on Concern, issue #1047, which independently named the same
+anti-pattern in `status.py` and asked for it to be codified as a
+spec-level invariant) found the underlying violation in **9 use cases
+across 6 modules**, but
+not all in the same precise shape. There are three distinct ways the
+"execute() does nothing but build one tree, run it once, handle the
+result" intent was violated:
+
+**(1) Genuine actor-identity switching** — a real second
+`execute_with_setup()` call under a different actor than the main
+operation's. This is the literal anti-pattern #1036 and #1047 describe:
 
 - `vultron/core/use_cases/received/embargo.py`:
   `RemoveEmbargoEventFromCaseReceivedUseCase`,
   `InviteToEmbargoOnCaseReceivedUseCase`,
-  `AcceptInviteToEmbargoOnCaseReceivedUseCase`
+  `AcceptInviteToEmbargoOnCaseReceivedUseCase` — main tree runs under
+  `request.actor_id` / `invitee_id` / `accepting_actor_id`; a second,
+  separately constructed `create_guarded_commit_case_ledger_entry_tree`
+  runs under `receiving_actor_id`. **Notably, the main tree (built by
+  `vultron/core/behaviors/embargo/announce_teardown_tree.py`'s factory
+  functions) already composes the identical guarded-commit branch as its
+  own last child** — but because the main tree executes under the
+  invitee's/accepting actor's identity, `CheckIsCaseManagerNode` inside it
+  is a guaranteed no-op (that actor is essentially never the CaseActor).
+  The second, separately-dispatched call is the one that actually fires,
+  on the rare second attempt under the correct identity. The fix is not
+  "add a guarded-commit branch" (it already exists) — it is "stop calling
+  the tree under the wrong actor a second time, and run the one tree that
+  already has the branch under `receiving_actor_id` instead."
 - `vultron/core/use_cases/received/report.py`:
-  `ValidateReportReceivedUseCase`, `AckReportReceivedUseCase`
-- `vultron/core/use_cases/received/note.py`: `AddNoteToCaseReceivedUseCase`
+  `ValidateReportReceivedUseCase` (main operation is a separate
+  `ValidateCaseUseCase` call under `actor_id`, not even a tree of its own),
+  `AckReportReceivedUseCase` (main tree under `request.actor_id`) — both
+  followed by a second, separately-gated guarded-commit call under
+  `receiving_actor_id`/`case_actor_id`.
 - `vultron/core/use_cases/received/status.py`:
-  `AddParticipantStatusReceivedUseCase`
-- `vultron/core/use_cases/received/case/lifecycle.py`:
-  `CloseCaseReceivedUseCase`
+  `AddParticipantStatusToParticipantReceivedUseCase` — main tree
+  (`add_participant_status_tree`) under `request.actor_id`, then a second
+  guarded-commit call under `case_actor_id` via `_commit_log_cascade_bt()`.
+  This is the exact site #1047 cited as its primary evidence.
+
+**(2) Single BT call, but non-BT procedural code precedes it** — only one
+`execute_with_setup()` call exists (the commit), but `execute()` still
+does domain-significant work outside any tree before reaching it, so it
+is not "build one tree, run it, handle the result" either:
+
+- `vultron/core/use_cases/received/note.py`: `AddNoteToCaseReceivedUseCase`
+  — appends to `case.notes`, calls `dl.save()`, and broadcasts to peers, all
+  in plain Python, before the single guarded-commit `execute_with_setup()`
+  call.
 - `vultron/core/use_cases/received/actor/case_manager_role.py`:
-  `OfferCaseManagerRoleReceivedUseCase`
+  `OfferCaseManagerRoleReceivedUseCase` — idempotent-creates the activity
+  and calls a trigger-activity port directly in Python, before the single
+  guarded-commit call. This is a pre-existing BT-06-001 gap (the main
+  operation was never expressed as a BT at all), not actor-switching.
 
-Every one of these imports and calls
-`create_guarded_commit_case_ledger_entry_tree` directly from its own
-`execute()` method, as a second, independently-gated tree execution. The
-last one is structurally similar but slightly worse: its "main operation"
-is plain procedural code (idempotent create + trigger-activity call), not
-a BT at all — a separate, pre-existing BT-06-001 gap that the
-implementation issue for this module should note but is not required to
-fix as part of CLP-10-005.
+**(3) Single BT call under the correct actor, but assembled ad hoc** —
+no actor-switching and no procedural code outside the tree, but the tree
+itself is built inline in `execute()` rather than via a
+`vultron/core/behaviors/` factory function:
 
-This is the same class of problem the "Post-BT Procedural Cascade
-Anti-Pattern" (`notes/bt-integration.md`) already names for the
-validate→prioritize cascade: a cascade that is a *child* of the
-triggering operation in the canonical model must be expressed as a BT
-subtree, not as a procedural call (or a second, conditionally-dispatched
-tree execution) sitting outside the tree in `execute()`. The fact that
-the second tree's own internal guard (`CheckIsCaseManagerNode`) is
-correctly role-gated does not fix the problem: the decision of *whether
-to even ask the question* is still made in Python, once per inbox
-delivery, instead of being one branch of one BT run.
+- `vultron/core/use_cases/received/case/lifecycle.py`:
+  `CloseCaseReceivedUseCase` — constructs a one-off
+  `py_trees.composites.Sequence` directly inside `execute()`, combining
+  `StoreActivityNode` and the guarded-commit subtree, and runs it once
+  under `receiving_actor_id`. This already satisfies the actor-identity
+  requirement; the fix here is purely "move this tree into a named factory
+  function in `behaviors/case/`," not an actor-switching repair.
+
+All nine sites import `create_guarded_commit_case_ledger_entry_tree`
+directly into `vultron/core/use_cases/`, which is what the structural test
+(below) detects — but the underlying defect, and the fix required, differs
+by category. This is the same class of problem the "Post-BT Procedural
+Cascade Anti-Pattern" (`notes/bt-integration.md`) already names for the
+validate→prioritize cascade: a cascade that is a *child* of the triggering
+operation in the canonical model must be expressed as a BT subtree, not as
+a procedural call (or a second, conditionally-dispatched tree execution,
+or any other domain-significant code) sitting outside the tree in
+`execute()`. The fact that the in-tree guard (`CheckIsCaseManagerNode`) is
+itself correctly role-gated does not fix category (1): the decision of
+*whether to even ask the question* is still made in Python, once per
+inbox delivery, instead of being one branch of one BT run.
 
 A related architectural question raised during planning — whether the
 inbox dispatch pipeline itself needs to be restructured so a use case
@@ -170,13 +218,13 @@ tree emits to `case_manager_id`) is unaffected.
 ### New Normative Requirement
 
 `specs/case-ledger-processing.yaml` gains CLP-10-005: a received-side use
-case MUST NOT import or call
-`create_guarded_commit_case_ledger_entry_tree` (or any other guarded-commit
-factory) directly from `vultron/core/use_cases/`; it MUST be composed as a
-child of the use case's own tree-factory function in
-`vultron/core/behaviors/`, reached through the single
-`execute_with_setup()` call already used for the use case's main
-operation. A structural test enumerates known violations as a ratchet
+case's `execute()` method MUST do exactly three things — build one BT via
+a `vultron/core/behaviors/` tree-factory function, call
+`BTBridge.execute_with_setup()` exactly once under
+`actor_id=receiving_actor_id`, and handle the result. No other
+domain-significant code (a second BT execution, direct DataLayer
+mutation, or a direct import of the guarded-commit factory) may appear in
+`execute()`. A structural test enumerates known violations as a ratchet
 (`test/architecture/test_single_bt_execution_received_side.py`).
 
 ### Consequences
@@ -197,11 +245,14 @@ operation. A structural test enumerates known violations as a ratchet
   must thread that identity through as leaf-node data rather than as
   `execute_with_setup`'s `actor_id` — a real design change to those trees,
   not just a call-site edit.
-- Bad, because all 9 known call sites require a tree-factory redesign
-  (not a one-line fix), and discovering the same shape required a
-  full-codebase audit rather than fixing the 3 sites originally named in
-  issue #1036 — the true scope was about 3x the originally reported
-  evidence.
+- Bad, because the 9 known call sites need three different kinds of fix
+  (genuine actor-switching repair for 6 of them; moving procedural code
+  into a new BT for 2 of them; just relocating an already-correct inline
+  tree into a factory function for 1 of them), so the implementation
+  issues cannot treat all 9 as the same mechanical change — and
+  discovering the full set required a full-codebase audit rather than
+  fixing the 3 sites originally named in issue #1036, plus the 1
+  additional site #1047 named independently.
 
 ## Validation
 
@@ -217,7 +268,10 @@ operation. A structural test enumerates known violations as a ratchet
 
 - Issue #1036 — concern that identified the anti-pattern (3 originally
   cited call sites) and the planning session that broadened the audit to
-  8.
+  9.
+- Issue #1047 — independent concern naming the same anti-pattern at
+  `status.py` and requesting it be codified as a spec-level invariant;
+  fully covered by this ADR and CLP-10-005, superseded.
 - Issue #1038 — folded into this ADR's implementation graph; it had
   independently proposed the same single-BT shape for the Invite/Accept
   embargo pair and is superseded by the implementation issue covering

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -76,6 +76,8 @@ General information about architectural decision records is available at <https:
   Log](0019-separate-case-ledger-from-process-log.md)
 - [ADR-0021 CaseActor Inbox Routing as the Sole Path to Canonical Ledger
   Entries](0021-caseactor-inbox-routing-canonical-ledger.md)
+- [ADR-0022 Single BT Execution Per Inbox Delivery for Received-Side
+  CaseActor Routing](0022-single-bt-execution-for-received-side-case-actor-routing.md)
 
 ## Proposed ADRs
 

--- a/notes/bt-integration.md
+++ b/notes/bt-integration.md
@@ -1145,6 +1145,24 @@ re-inlining the Selector at each call site, and migrate all existing bare
 `CommitCaseLedgerEntryNode` call sites to the factory — CLP-09-002 requires
 a test asserting no bare usage remains outside it.
 
+**Call the factory from inside the use case's own tree, not as a second
+tree execution** (ADR-0022, CLP-10-005, issue #1036): a received-side use
+case MUST call `BTBridge.execute_with_setup()` exactly once per inbox
+delivery, with `actor_id=receiving_actor_id`. The guarded-commit factory
+above MUST be composed as a child of that one tree (by the use case's own
+tree-factory function in `vultron/core/behaviors/`), not invoked as a
+second, separately-gated `execute_with_setup()` call from
+`execute()`. Even when the second call's `actor_id` is provably
+`receiving_actor_id` (satisfying CLP-10-002/CLP-10-003 literally), gating
+*whether the second call happens at all* in Python reproduces the
+"Post-BT Procedural Cascade Anti-Pattern" above for the commit step
+specifically — the decision is invisible outside the tree. Nine known
+call sites across six modules (`embargo.py` x3, `report.py` x2, `note.py`,
+`status.py`, `case/lifecycle.py`, `actor/case_manager_role.py`) had this
+exact shape; see ADR-0022 for the full analysis and
+`test/architecture/test_single_bt_execution_received_side.py` for the
+migration ratchet.
+
 ---
 
 ### Fan-out / SYNC Decomposition: Context Handoff Pattern

--- a/notes/bt-integration.md
+++ b/notes/bt-integration.md
@@ -1145,21 +1145,30 @@ re-inlining the Selector at each call site, and migrate all existing bare
 `CommitCaseLedgerEntryNode` call sites to the factory — CLP-09-002 requires
 a test asserting no bare usage remains outside it.
 
-**Call the factory from inside the use case's own tree, not as a second
-tree execution** (ADR-0022, CLP-10-005, issue #1036): a received-side use
-case MUST call `BTBridge.execute_with_setup()` exactly once per inbox
-delivery, with `actor_id=receiving_actor_id`. The guarded-commit factory
-above MUST be composed as a child of that one tree (by the use case's own
-tree-factory function in `vultron/core/behaviors/`), not invoked as a
-second, separately-gated `execute_with_setup()` call from
-`execute()`. Even when the second call's `actor_id` is provably
-`receiving_actor_id` (satisfying CLP-10-002/CLP-10-003 literally), gating
-*whether the second call happens at all* in Python reproduces the
-"Post-BT Procedural Cascade Anti-Pattern" above for the commit step
-specifically — the decision is invisible outside the tree. Nine known
-call sites across six modules (`embargo.py` x3, `report.py` x2, `note.py`,
-`status.py`, `case/lifecycle.py`, `actor/case_manager_role.py`) had this
-exact shape; see ADR-0022 for the full analysis and
+**`execute()` MUST do nothing but build one tree, run it once, and handle
+the result** (ADR-0022, CLP-10-005, issues #1036/#1047): a received-side
+use case's `execute()` method MUST (a) build exactly one BT via a
+tree-factory function in `vultron/core/behaviors/`, (b) call
+`BTBridge.execute_with_setup()` exactly once, with
+`actor_id=receiving_actor_id`, and (c) handle the result (log, extract
+output — see "Procedural Glue Exception" above). The guarded-commit
+factory above MUST be composed as a child of that one tree, not invoked
+separately, and the use case's main operation MUST itself be a BT node —
+not procedural code sitting alongside the one `execute_with_setup()` call.
+
+An audit (issue #1036, broadened to also resolve #1047) found this rule
+violated in 9 use cases across 6 modules, in three different shapes:
+genuine actor-identity switching — a real second `execute_with_setup()`
+call under a different actor (`embargo.py` x3, `report.py` x2,
+`status.py`; this is the literal pattern #1036 and #1047 describe, and in
+`embargo.py`'s case the main tree already contains the identical
+guarded-commit branch as its last child, but it no-ops because that tree
+runs under the wrong actor); a single BT call preceded by non-BT
+procedural code for the main operation (`note.py`, `actor/case_manager_role.py`
+— a BT-06-001 gap, not actor-switching); and a single BT call under the
+correct actor but assembled inline in `execute()` instead of via a
+factory function (`case/lifecycle.py`). See ADR-0022 for the full
+per-site breakdown and
 `test/architecture/test_single_bt_execution_received_side.py` for the
 migration ratchet.
 

--- a/notes/case-communication-model.md
+++ b/notes/case-communication-model.md
@@ -337,7 +337,7 @@ See ADR-0021 for the full decision record.
 
 ---
 
-## Known Implementation Gaps (as of 2026-06-17)
+## Known Implementation Gaps (as of 2026-06-18)
 
 | Gap | Location | Status |
 |---|---|---|
@@ -350,5 +350,7 @@ See ADR-0021 for the full decision record.
 | Embargo triggers send to all participants | `triggers/embargo.py` | Open |
 | Engage/defer-case triggers send to all participants | `triggers/case.py:84,132` | Open |
 | Invite sent from case owner (not Case Actor); Accept routed to owner | `triggers/actor.py`, `received/actor.py` | Open — tracked in #893/#894 |
+| Guarded commit dispatched as a second, separately-gated `execute_with_setup()` call (9 use cases, 6 modules: `embargo.py` x3, `report.py` x2, `note.py`, `status.py`, `case/lifecycle.py`, `actor/case_manager_role.py`) | `received/*.py` | Open — ADR-0022, CLP-10-005, tracked under #1036 impl issues |
 
-See GitHub issues under parent concern #593 and epic #788.
+See GitHub issues under parent concern #593, epic #788, and concern #1036
+(ADR-0022).

--- a/plan/history/2606/learning/CONCERN-1036.md
+++ b/plan/history/2606/learning/CONCERN-1036.md
@@ -1,0 +1,74 @@
+---
+source: CONCERN-1036
+timestamp: '2026-06-18T19:10:32.546350+00:00'
+title: 'Case-actor vs other-actor handling: CASE_MANAGER checks must be BT guards,
+  not precomputed dispatch state'
+type: learning
+---
+
+## Summary
+
+When an activity arrives, the inbox that received it determines the handling
+branch: a case actor's inbox does case-actor things (update case state, add
+case ledger entries, broadcast); any other actor's inbox either receives
+direct messages that don't touch case state, or receives case-ledger entries
+announced by the case actor and updates its local replica. This distinction
+must be visible from the very start of the inbox processor — not derived
+partway through `execute()` by recomputing which actor/role is in play.
+Several `execute()` methods instead started under one actor context and then
+resolved a *different* actor (the case manager) mid-method to perform the
+ledger commit via a second, separately-gated `execute_with_setup()` call —
+the actor-switching anti-pattern this Concern targeted.
+
+The fix is not to split into two BTs per inbox type — same dispatch is fine
+— but role-gated branches (e.g. "CASE_MANAGER role only") must be guard
+nodes evaluated *inside* the BT, not a boolean precomputed in Python that
+gates whether a second tree execution happens at all.
+
+## Evidence (original, 3 sites)
+
+- `vultron/core/use_cases/received/embargo.py`:
+  `RemoveEmbargoEventFromCaseReceivedUseCase.execute`,
+  `InviteToEmbargoOnCaseReceivedUseCase.execute`,
+  `AcceptInviteToEmbargoOnCaseReceivedUseCase.execute` — each started under
+  `request.actor_id`, then resolved a separate `commit_actor_id` (case
+  manager) and ran a second tree under that identity, outside any BT guard.
+- `vultron/core/use_cases/received/report.py`:
+  `ValidateReportReceivedUseCase.execute`, `AckReportReceivedUseCase.execute`
+  — same pattern.
+- `CheckIsCaseManagerNode` (used inside
+  `create_guarded_commit_case_ledger_entry_tree`) already showed the correct
+  shape — an in-tree guard — but was reached only via a second,
+  separately-dispatched tree under a different actor_id.
+
+## Resolved: 2026-06-18
+
+Planning (via `plan-issue`) broadened the audit and found this exact shape in
+**9 use cases across 6 modules** (roughly 3x the originally cited evidence):
+`embargo.py` (3), `report.py` (2), `note.py`, `status.py`,
+`case/lifecycle.py`, and `actor/case_manager_role.py`.
+
+Investigation also resolved an open architectural question: whether the
+inbox dispatch pipeline itself needed restructuring so a use case never has
+to ask "which actor am I running as." It does not —
+`receiving_actor_id` is already resolved before dispatch
+(`FastAPIDispatchAdapter.dispatch()`), and the dispatcher has no CaseActor
+awareness and needs none (pure routing-table lookup). The gap is entirely at
+the use-case/BT boundary.
+
+**ADR-0022** (`docs/adr/0022-single-bt-execution-for-received-side-case-actor-routing.md`)
+amends ADR-0021's call shape: a received-side use case MUST execute exactly
+one BT per inbox delivery (`actor_id=receiving_actor_id`); CASE_MANAGER-gated
+commits must be an in-tree Selector/Sequence/Success branch of that same
+tree. `specs/case-ledger-processing.yaml` CLP-10-005 codifies the rule.
+`notes/bt-integration.md` and `notes/case-communication-model.md` were
+updated with the finding. A ratchet test
+(`test/architecture/test_single_bt_execution_received_side.py`) enumerates
+the 9 known-violating use cases as `KNOWN_VIOLATIONS`.
+
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1049>.
+Spec: `specs/case-ledger-processing.yaml` CLP-10-005.
+Implementation tracked in #1050 (embargo.py — foundation issue, absorbs
+superseded issue #1038), #1051 (report.py, blocked-by #1050), #1052
+(note.py/status.py/case/lifecycle.py/actor/case_manager_role.py,
+blocked-by #1050).

--- a/specs/case-ledger-processing.yaml
+++ b/specs/case-ledger-processing.yaml
@@ -433,3 +433,34 @@ groups:
       `test_invariant_5_expected_event_types_present` (after parameterization)
       does not include `announce_case_ledger_entry` as a required event type for
       the case-actor replica.
+  - id: CLP-10-005
+    priority: MUST_NOT
+    statement: >-
+      A received-side use case MUST NOT import or call
+      `create_guarded_commit_case_ledger_entry_tree` (or any other guarded-commit
+      factory) directly from its own `execute()` method as a second,
+      independently-gated `BTBridge.execute_with_setup()` call; the guarded-commit
+      subtree MUST be composed as a child of the use case's own tree-factory
+      function and reached through the single `execute_with_setup()` call already
+      used for the use case's main operation
+    rationale: >-
+      CLP-10-002/CLP-10-003 (ADR-0021) correctly require a pre-flight guard before
+      committing, and correctly require the guard to compare against
+      `receiving_actor_id`. But satisfying those rules with a Python-level
+      `if receiving_actor_id != case_actor_id: return` that gates whether a SECOND
+      `execute_with_setup()` call happens at all reproduces the "post-BT
+      procedural cascade" anti-pattern (see `notes/bt-integration.md`) for the
+      commit step specifically: the cascade from "process this message" to
+      "commit a canonical entry if I'm the CaseActor" becomes invisible outside
+      the tree structure, even though the in-tree `CheckIsCaseManagerNode` guard
+      inside the commit tree is itself correct. An audit (issue #1036) found this
+      shape in 9 use cases across 6 modules (`embargo.py` x3, `report.py` x2,
+      `note.py`, `status.py`, `case/lifecycle.py`,
+      `actor/case_manager_role.py`). See ADR-0022.
+    verification: >-
+      `test/architecture/test_single_bt_execution_received_side.py` greps every
+      module under `vultron/core/use_cases/` for imports of
+      `create_guarded_commit_case_ledger_entry_tree`; any match outside the
+      guarded-commit factory's own module is a violation. Known violations are
+      tracked as a ratchet set (`KNOWN_VIOLATIONS`) that must shrink to empty as
+      each use case migrates to the single-tree shape.

--- a/specs/case-ledger-processing.yaml
+++ b/specs/case-ledger-processing.yaml
@@ -434,33 +434,52 @@ groups:
       does not include `announce_case_ledger_entry` as a required event type for
       the case-actor replica.
   - id: CLP-10-005
-    priority: MUST_NOT
+    priority: MUST
     statement: >-
-      A received-side use case MUST NOT import or call
-      `create_guarded_commit_case_ledger_entry_tree` (or any other guarded-commit
-      factory) directly from its own `execute()` method as a second,
-      independently-gated `BTBridge.execute_with_setup()` call; the guarded-commit
-      subtree MUST be composed as a child of the use case's own tree-factory
-      function and reached through the single `execute_with_setup()` call already
-      used for the use case's main operation
+      A received-side use case's `execute()` method MUST do exactly three
+      things: build one BT via a tree-factory function in
+      `vultron/core/behaviors/`, call `BTBridge.execute_with_setup()` exactly
+      once with `actor_id=receiving_actor_id` to run it, and handle the
+      result (log/extract output per the existing Procedural Glue Exception).
+      `execute()` MUST NOT perform any other domain-significant work — no
+      direct DataLayer mutation, no second `execute_with_setup()` call, and
+      no direct import or call of `create_guarded_commit_case_ledger_entry_tree`
+      (or any other guarded-commit factory). Any operation that is currently
+      procedural code in `execute()` (including the use case's main
+      operation, if not already a BT) MUST be expressed as a node in the
+      single tree; the guarded-commit subtree MUST be composed as a child
+      of that same tree-factory function, not invoked separately
     rationale: >-
-      CLP-10-002/CLP-10-003 (ADR-0021) correctly require a pre-flight guard before
-      committing, and correctly require the guard to compare against
-      `receiving_actor_id`. But satisfying those rules with a Python-level
-      `if receiving_actor_id != case_actor_id: return` that gates whether a SECOND
-      `execute_with_setup()` call happens at all reproduces the "post-BT
-      procedural cascade" anti-pattern (see `notes/bt-integration.md`) for the
-      commit step specifically: the cascade from "process this message" to
-      "commit a canonical entry if I'm the CaseActor" becomes invisible outside
-      the tree structure, even though the in-tree `CheckIsCaseManagerNode` guard
-      inside the commit tree is itself correct. An audit (issue #1036) found this
-      shape in 9 use cases across 6 modules (`embargo.py` x3, `report.py` x2,
-      `note.py`, `status.py`, `case/lifecycle.py`,
-      `actor/case_manager_role.py`). See ADR-0022.
+      CLP-10-002/CLP-10-003 (ADR-0021) correctly require a pre-flight guard
+      before committing, and correctly require the guard to compare against
+      `receiving_actor_id`. An audit (issue #1036, broadened to also resolve
+      issue #1047) found three distinct ways the single-tree intent was
+      violated, all closed by the same rule: (1) `embargo.py` (3 use cases)
+      and `report.py`/`status.py` (3 use cases) ran a genuine second,
+      independently Python-gated `execute_with_setup()` call under a
+      different actor identity for the commit — literal actor-switching,
+      reproducing the "post-BT procedural cascade" anti-pattern (see
+      `notes/bt-integration.md`) for the commit step specifically; in
+      `embargo.py`'s case the main tree already (uselessly) embeds the same
+      guarded-commit branch under the wrong actor, so the first execution is
+      a guaranteed no-op. (2) `note.py` and `actor/case_manager_role.py`
+      call the commit factory exactly once but precede it with
+      domain-significant procedural code (DataLayer mutation, broadcast,
+      trigger-activity calls) for the main operation, outside any BT —
+      `execute()` is not "build one tree, run it, handle the result" even
+      though only one `execute_with_setup()` call exists. (3)
+      `case/lifecycle.py` already executes a single tree under the correct
+      actor but constructs it ad hoc inside `execute()` instead of via a
+      `behaviors/` factory function. See ADR-0022 for the full per-site
+      breakdown.
     verification: >-
       `test/architecture/test_single_bt_execution_received_side.py` greps every
       module under `vultron/core/use_cases/` for imports of
       `create_guarded_commit_case_ledger_entry_tree`; any match outside the
       guarded-commit factory's own module is a violation. Known violations are
       tracked as a ratchet set (`KNOWN_VIOLATIONS`) that must shrink to empty as
-      each use case migrates to the single-tree shape.
+      each use case migrates to the single-tree shape. The grep is a proxy for
+      the broader "execute() does nothing but build-run-handle one tree" rule;
+      it catches every known violation but a reviewer MUST still confirm no
+      other domain-significant code remains in `execute()` when closing each
+      migration.

--- a/test/architecture/test_single_bt_execution_received_side.py
+++ b/test/architecture/test_single_bt_execution_received_side.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Architecture invariant: one BT execution per inbox delivery (CLP-10-005).
+
+A received-side use case MUST NOT import or call
+``create_guarded_commit_case_ledger_entry_tree`` directly from its own
+``execute()`` method as a second, independently-gated
+``BTBridge.execute_with_setup()`` call. The guarded-commit subtree MUST be
+composed as a child of the use case's own tree-factory function (in
+``vultron/core/behaviors/``) and reached through the single
+``execute_with_setup()`` call already used for the use case's main
+operation.
+
+Spec: CLP-10-005. Decision record: ADR-0022.
+
+Ratchet pattern
+---------------
+``KNOWN_VIOLATIONS`` documents every pre-existing violation awaiting
+migration (see issue #1036 and its implementation issues). The test
+asserts::
+
+    actual_violations == KNOWN_VIOLATIONS
+
+This means:
+
+* **Adding a new violation** causes the test to **fail** immediately.
+* **Fixing a violation** also causes the test to **fail** until the
+  resolved entry is removed from ``KNOWN_VIOLATIONS``.
+
+Remove entries from ``KNOWN_VIOLATIONS`` one by one as each use case
+migrates to the single-tree shape. When the set is empty, CLP-10-005 is
+fully satisfied.
+"""
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parents[2]  # test/architecture/ → test/ → repo root
+
+_GUARDED_COMMIT_FACTORY = "create_guarded_commit_case_ledger_entry_tree"
+
+_USE_CASES_ROOT = REPO_ROOT / "vultron" / "core" / "use_cases"
+
+
+def _imports_guarded_commit_factory(source_path: Path) -> bool:
+    """Return True if *source_path* imports the guarded-commit factory.
+
+    Detects both top-level and deferred (local) ``from ... import`` of
+    ``create_guarded_commit_case_ledger_entry_tree``.
+    """
+    try:
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                if alias.name == _GUARDED_COMMIT_FACTORY:
+                    return True
+    return False
+
+
+def _collect_violations() -> frozenset[str]:
+    """Return repo-relative paths of use-case files importing the factory."""
+    violations: set[str] = set()
+    for py_file in _USE_CASES_ROOT.rglob("*.py"):
+        if "__pycache__" in py_file.parts:
+            continue
+        if _imports_guarded_commit_factory(py_file):
+            violations.add(py_file.relative_to(REPO_ROOT).as_posix())
+    return frozenset(violations)
+
+
+# ---------------------------------------------------------------------------
+# Known pre-existing violations awaiting migration (issue #1036, ADR-0022).
+# Remove entries one by one as each use case migrates to a single
+# `execute_with_setup()` call with the guarded commit composed as a child
+# subtree of the use case's own tree-factory function.
+# ---------------------------------------------------------------------------
+KNOWN_VIOLATIONS: frozenset[str] = frozenset(
+    {
+        "vultron/core/use_cases/received/embargo.py",
+        "vultron/core/use_cases/received/report.py",
+        "vultron/core/use_cases/received/note.py",
+        "vultron/core/use_cases/received/status.py",
+        "vultron/core/use_cases/received/case/lifecycle.py",
+        "vultron/core/use_cases/received/actor/case_manager_role.py",
+    }
+)
+
+
+def test_received_use_cases_do_not_dispatch_guarded_commit_directly():
+    """vultron/core/use_cases/ must not import the guarded-commit factory.
+
+    Spec: CLP-10-005. Decision record: ADR-0022.
+
+    See module docstring for the ratchet strategy.
+    """
+    actual = _collect_violations()
+    new_violations = actual - KNOWN_VIOLATIONS
+    resolved = KNOWN_VIOLATIONS - actual
+
+    diff_lines: list[str] = []
+    if new_violations:
+        diff_lines.append(
+            "NEW violations (use cases must not import the guarded-commit"
+            " factory directly):"
+        )
+        diff_lines.extend(f"  + {v}" for v in sorted(new_violations))
+    if resolved:
+        diff_lines.append(
+            "RESOLVED violations (remove these entries from"
+            " KNOWN_VIOLATIONS):"
+        )
+        diff_lines.extend(f"  - {v}" for v in sorted(resolved))
+
+    assert actual == KNOWN_VIOLATIONS, "\n\n" + "\n".join(diff_lines)

--- a/test/architecture/test_single_bt_execution_received_side.py
+++ b/test/architecture/test_single_bt_execution_received_side.py
@@ -14,22 +14,28 @@
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 """Architecture invariant: one BT execution per inbox delivery (CLP-10-005).
 
-A received-side use case MUST NOT import or call
-``create_guarded_commit_case_ledger_entry_tree`` directly from its own
-``execute()`` method as a second, independently-gated
-``BTBridge.execute_with_setup()`` call. The guarded-commit subtree MUST be
-composed as a child of the use case's own tree-factory function (in
-``vultron/core/behaviors/``) and reached through the single
-``execute_with_setup()`` call already used for the use case's main
-operation.
+A received-side use case's ``execute()`` method MUST do exactly three
+things: build one BT via a tree-factory function in
+``vultron/core/behaviors/``, call ``BTBridge.execute_with_setup()`` exactly
+once under ``actor_id=receiving_actor_id``, and handle the result.
+``execute()`` MUST NOT contain any other domain-significant code — no
+second BT execution, no direct DataLayer mutation, and no direct import of
+``create_guarded_commit_case_ledger_entry_tree`` (or any other
+guarded-commit factory). This grep is a proxy for that broader rule: it
+catches every known violation, but fixing a violation may mean repairing
+genuine actor-identity switching, moving non-BT procedural code into the
+tree, or simply relocating an already-correct inline tree into a factory
+function — see ADR-0022 for the per-site breakdown. A reviewer MUST still
+confirm no other domain-significant code remains in ``execute()`` when
+closing each migration; this test alone does not guarantee that.
 
 Spec: CLP-10-005. Decision record: ADR-0022.
 
 Ratchet pattern
 ---------------
 ``KNOWN_VIOLATIONS`` documents every pre-existing violation awaiting
-migration (see issue #1036 and its implementation issues). The test
-asserts::
+migration (see issues #1036, #1047, and their implementation issues). The
+test asserts::
 
     actual_violations == KNOWN_VIOLATIONS
 


### PR DESCRIPTION
- Closes #1036
- Closes #1047

## Summary

Plans Concern #1036 (case-actor vs. other-actor handling must branch by
receiving inbox, with CASE_MANAGER checks as BT guards, not precomputed
dispatch state). Adds ADR-0022, which amends ADR-0021's call shape: a
received-side use case's `execute()` MUST do exactly three things — build
one BT via a `behaviors/` factory function, call
`BTBridge.execute_with_setup()` exactly once under
`actor_id=receiving_actor_id`, and handle the result — with the
CASE_MANAGER-gated canonical commit composed as an in-tree branch of that
same tree, never a second, separately-gated execution or other
domain-significant code outside the tree.

A codebase audit (broadened during planning) found the underlying
violation in 9 use cases across 6 modules — roughly 3x the 3 sites
originally cited in #1036's evidence — in three distinct shapes, not one
uniform pattern:

1. **Genuine actor-identity switching** (`embargo.py` x3, `report.py` x2,
   `status.py`) — a real second `execute_with_setup()` call under a
   different actor. This is the literal pattern #1036 and the
   independently-filed #1047 both describe (#1047 cited `status.py` as
   its primary evidence — fully covered here, folded in and closed as
   superseded). Notably, `embargo.py`'s main tree already composes the
   identical guarded-commit branch as its own last child, but it no-ops
   because that tree runs under the wrong actor.
2. **Single BT call preceded by non-BT procedural code** (`note.py`,
   `actor/case_manager_role.py`) — a pre-existing BT-06-001 gap, not
   actor-switching.
3. **Single BT call under the correct actor, assembled inline** rather
   than via a factory function (`case/lifecycle.py`).

Also absorbed issue #1038, which had independently proposed the same fix
for the embargo.py Invite/Accept pair (closed as superseded).

## Changes

- `docs/adr/0022-single-bt-execution-for-received-side-case-actor-routing.md` —
  new ADR; amends ADR-0021's call shape (routing conclusion unchanged);
  documents the three violation categories and the per-site breakdown.
- `docs/adr/index.md` — add ADR-0022 to the accepted list.
- `specs/case-ledger-processing.yaml` — add CLP-10-005 codifying the
  "execute() does nothing but build-run-handle one tree" rule.
- `notes/bt-integration.md` — extend "Guarded Commit: Role-Gated Canonical
  Writes" with the single-tree-execution requirement and the three
  violation shapes.
- `notes/case-communication-model.md` — add the gap to "Known
  Implementation Gaps".
- `test/architecture/test_single_bt_execution_received_side.py` — new
  ratchet test (mirrors `test_core_no_adapter_imports.py`) enumerating
  the 9 known-violating use cases as `KNOWN_VIOLATIONS`; fails if a new
  violation appears or a fixed one isn't removed from the set.

## Verification

- [x] `uv run pytest test/architecture/ test/metadata/test_notes_frontmatter.py` — 20 passed, 2 pre-existing xfailed
- [x] `markdownlint-cli2 --fix` — 0 errors
- [x] `black`, `flake8`, `pyright`, `mypy` on the new test file — clean
- [x] `mkdocs build --strict` confirmed to fail identically on `main` before this change (pre-existing, unrelated `vocab_examples.create_case()` participant-index flake) — not introduced by this PR