### PR TITLE
spec: add ARCH-14 wire vocab naming convention (as_ prefix for vocab/objects/)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,11 @@ Do NOT introduce alternative frameworks or package managers without approval.
   (e.g., `CaseTransferOffer` not `VultronOffer`). See CS-12-001.
 - **Vulnerability**: Abbreviated as `vul` (not `vuln`)
 - Wire-layer naming (as\_ prefix, trailing underscore, pattern objects) →
-  see [`vultron/wire/as2/AGENTS.md`](vultron/wire/as2/AGENTS.md)
+  see [`vultron/wire/as2/AGENTS.md`](vultron/wire/as2/AGENTS.md).
+  **Critical**: ALL classes in `vultron/wire/as2/vocab/objects/` use the
+  `as_` prefix (`as_VulnerabilityCase`, `as_CaseParticipant`, etc.). The
+  bare name `VulnerabilityCase` (no prefix) always refers to the **core**
+  domain model. See ARCH-14-001.
 - Use-case / handler naming (Received suffix, Svc prefix, \_trigger suffix)
   → see [`vultron/core/AGENTS.md`](vultron/core/AGENTS.md)
 
@@ -519,6 +523,19 @@ Short entries are reproduced here; longer ones are referenced below.
   and `notes/case-ledger-authority.md` § "Canonical Entry Criteria".
 - **Adding a New Pitfall: Check the Routing Policy First** — see
   [notes/agents-md-structure.md](notes/agents-md-structure.md)
+- **`as_VulnerabilityCase` (wire) vs `VulnerabilityCase` (core) — Always Check
+  Your Prefix** — The core domain model is `VulnerabilityCase` in
+  `vultron.core.models.case`. The wire AS2 projection is `as_VulnerabilityCase`
+  in `vultron.wire.as2.vocab.objects.vulnerability_case`. This `as_` prefix
+  convention applies to **all** classes in `vultron/wire/as2/vocab/objects/`:
+  `as_CaseParticipant`, `as_CaseStatus`, `as_VulnerabilityReport`, etc. If you
+  see a bare `VulnerabilityCase` import from the wire layer, that is a naming
+  violation (ARCH-14-001) — the migration to `as_` prefixes is tracked in GitHub.
+  In BT nodes, use cases, and core code: always import the bare-name core type.
+  In wire/extractor/factory code: always import the `as_`-prefixed wire type.
+  The two objects have identical field names; they differ only in field types
+  (core uses `str` IDs, wire uses `ActivityStreamRef[T]` unions). See
+  `specs/architecture.yaml` ARCH-14-001.
 - **Trigger-Side execute() Must Delegate SM Transitions to BTBridge** — A
   trigger-side `execute()` method that calls `EmbargoLifecycle`, `EMAdapter`,
   or creates `ParticipantStatus` records with a specific `rm_state`/`em_state`

--- a/specs/architecture.yaml
+++ b/specs/architecture.yaml
@@ -288,6 +288,65 @@ groups:
   - id: ARCH-11-001
     priority: SHOULD
     statement: Core ports SHOULD be organized into inbound (driving) and outbound (driven) categories
+- id: ARCH-14
+  title: Wire Vocabulary Object Naming Convention
+  rationale: >-
+    Wire vocabulary objects in `vultron/wire/as2/vocab/objects/` historically
+    used bare domain names (e.g., `VulnerabilityCase`, `CaseParticipant`) that
+    shadow identically-named core domain models. This causes persistent
+    confusion: agents and developers grab the wrong class, reason about the
+    wrong object, or inadvertently introduce wire-layer imports into core code.
+    The `as_` prefix — already established for base ActivityStreams types
+    (`as_Activity`, `as_Actor`, `as_Object`) — MUST be extended to all
+    Vultron-specific wire vocabulary objects to make the layer boundary
+    unambiguous at a glance.
+  specs:
+  - id: ARCH-14-001
+    priority: MUST
+    statement: >-
+      All Vultron-specific wire vocabulary classes defined in
+      `vultron/wire/as2/vocab/objects/` MUST use the `as_` prefix
+      (e.g., `as_VulnerabilityCase`, `as_CaseParticipant`, `as_CaseStatus`).
+      This extends the existing `as_` naming convention — already applied to
+      base ActivityStreams types (`as_Activity`, `as_Actor`, `as_Object`) —
+      to all Vultron-specific wire objects in that package.
+    rationale: >-
+      Without the `as_` prefix, wire objects shadow identically-named core
+      domain models, making it ambiguous which `VulnerabilityCase` a developer
+      or agent is working with. The `as_` prefix makes the layer boundary
+      unambiguous at a glance and enables automated detection of violations.
+    verification: >-
+      Architecture test in `test/architecture/` asserts that no class in
+      `vultron/wire/as2/vocab/objects/` shares a name with any class in
+      `vultron/core/models/`.
+  - id: ARCH-14-002
+    priority: MUST
+    statement: >-
+      The wire-layer base class for all Vultron-specific AS2 objects (currently
+      `VultronAS2Object`) MUST be renamed `as_VultronObject`. This eliminates
+      the redundant "AS2" qualifier (the `as_` prefix already connotes the
+      wire layer) and aligns the base class name with ARCH-14-001.
+    rationale: >-
+      `VultronAS2Object` does not follow the `as_` prefix convention. The
+      "AS2" suffix is redundant when the `as_` prefix already signals the
+      wire layer. Renaming to `as_VultronObject` makes the base class
+      consistent with all subclasses.
+    verification: >-
+      `vultron/wire/as2/vocab/objects/base.py` exports `as_VultronObject`;
+      no class named `VultronAS2Object` exists anywhere in the codebase.
+  - id: ARCH-14-003
+    priority: MUST
+    statement: >-
+      `TypeAlias` companion types (wire-layer reference unions, e.g.,
+      `VulnerabilityCaseRef`) MUST also use the `as_` prefix
+      (e.g., `as_VulnerabilityCaseRef`, `as_CaseParticipantRef`).
+    rationale: >-
+      Companion aliases that do not follow the `as_` naming convention
+      undermine the goal of ARCH-14-001: an import of `VulnerabilityCaseRef`
+      is just as ambiguous as importing `VulnerabilityCase` from the wire layer.
+    verification: >-
+      No `TypeAlias` variable in `vultron/wire/as2/vocab/objects/` uses a
+      name that matches a core model name without the `as_` prefix.
 - id: ARCH-13
   title: DataLayer Scope Contract
   specs:

--- a/vultron/wire/as2/AGENTS.md
+++ b/vultron/wire/as2/AGENTS.md
@@ -9,14 +9,26 @@
 
 ## Naming Conventions (wire layer)
 
-- **ActivityStreams class names**: Use `as_` prefix (e.g.,
-  `as_Activity`, `as_Actor`) — in this layer (`vultron/wire/as2/`)
-  **only**. Do NOT use `as_`-prefixed field names anywhere.
+- **All wire vocabulary class names** (base AS2 types AND Vultron-specific
+  objects in `vultron/wire/as2/vocab/objects/`) MUST use the `as_` prefix.
+  Examples: `as_Activity`, `as_Actor`, `as_VulnerabilityCase`,
+  `as_CaseParticipant`, `as_CaseStatus`. See ARCH-14-001.
+  - The wire base class is `as_VultronObject` (in `vocab/objects/base.py`).
+    Do NOT use `VultronAS2Object` — that name is retired. See ARCH-14-002.
+  - `TypeAlias` companion types also use the `as_` prefix:
+    `as_VulnerabilityCaseRef`, `as_CaseParticipantRef`, etc. See ARCH-14-003.
+  - **IMPORTANT**: Core domain models (`vultron/core/models/`) do NOT use the
+    `as_` prefix. `VulnerabilityCase` (no prefix) is always the core type;
+    `as_VulnerabilityCase` is always the wire type. If you find yourself
+    importing `VulnerabilityCase` from `vultron.wire.as2.vocab.objects.*`,
+    that is a bug — switch to `as_VulnerabilityCase`.
 - **Wire-layer field names**: Use trailing underscore for fields whose
   plain name collides with a Python builtin or reserved word (e.g.,
   `id_`, `type_`, `object_`, `context_`) with a Pydantic alias for the
   JSON key (e.g., `id_: str = Field(alias="id")`). See CS-07-002,
   CS-07-003.
+- **Do NOT use `as_`-prefixed field names** anywhere (the prefix is for
+  class names only, not field or variable names).
 - **Pattern objects**: Descriptive CamelCase with `Pattern` suffix
   (e.g., `CreateReportPattern`, `AcceptInviteToEmbargoOnCasePattern`)
 


### PR DESCRIPTION
- Closes #1056 (unblocks the rename work)

## Summary

Establishes the formal spec requirement and agent guidance for the wire
vocabulary object naming convention that eliminates the
`VulnerabilityCase`-vs-`VulnerabilityCase` ambiguity between the wire and
core layers.

## Changes

**`specs/architecture.yaml`** — new ARCH-14 group:

- **ARCH-14-001**: All classes in `vultron/wire/as2/vocab/objects/` MUST use
  the `as_` prefix (`as_VulnerabilityCase`, `as_CaseParticipant`, etc.).
  Extends the existing convention already applied to `as_Activity`, `as_Actor`.
- **ARCH-14-002**: Base class `VultronAS2Object` MUST be renamed
  `as_VultronObject` (drops redundant "AS2").
- **ARCH-14-003**: `TypeAlias` companion types (`*Ref`) MUST also use the
  `as_` prefix.

**`vultron/wire/as2/AGENTS.md`** — naming section rewritten:

- Clarifies that `as_` applies to ALL wire vocab objects, not just base AS2 types.
- Adds explicit import guidance: if you find yourself importing
  `VulnerabilityCase` from `vultron.wire.as2.vocab.objects.*`, that is a bug.

**`AGENTS.md`** (root) — two additions:

- Wire naming summary with ARCH-14-001 reference in the Naming Conventions section.
- New pitfall entry: `as_VulnerabilityCase` (wire) vs `VulnerabilityCase` (core)
  explaining the core-wire field symmetry and the correct import source per layer.

## Verification

- `uv run spec-dump` parses ARCH-14-001/002/003 cleanly.
- `bash mdlint.sh` passes (0 errors).
- Pre-commit hooks pass.
- The actual rename is tracked in issue #1056 (unblocked by this PR).
- The field-parity and naming-ratchet tests are tracked in issue #1057
  (blocked by #1056).
