### PR TITLE
fix: example VulnerabilityCase objects lack genesis_hash (CLP-08-003)

### DIFF
--- a/plan/history/2606/implementation/ISSUE-1055.md
+++ b/plan/history/2606/implementation/ISSUE-1055.md
@@ -1,0 +1,28 @@
+---
+source: ISSUE-1055
+timestamp: '2026-06-18T20:17:45.638404+00:00'
+title: example VulnerabilityCase genesis_hash fix
+type: implementation
+---
+
+## Issue #1055 — fix: example VulnerabilityCase objects lack genesis_hash — violates CLP-08-003
+
+**Symptoms**: Both the module-level `_CASE` object and the `case(random_id=True)`
+path in `vultron/wire/as2/vocab/examples/_base.py` constructed `VulnerabilityCase`
+without `attributed_to`, leaving `genesis_hash=""` in violation of CLP-08-003.
+
+**Root cause**: Example objects predated PR #1048 (the genesis hash feature). The
+model's empty-string default is intentional for rehydration, so no construction-time
+error was raised.
+
+**Fix**: Added `attributed_to=_VENDOR.id_` to both constructions so the
+`_compute_genesis_hash_if_missing` model validator fires and produces a non-empty
+hash. Also expanded the `genesis_hash` field descriptions in both `core/models/case.py`
+and `wire/as2/vocab/objects/vulnerability_case.py` to document that the empty-string
+default is intentional for rehydration paths (addressing acceptance criterion 3).
+
+**Verification**: 2 new tests added (`test_case_has_genesis_hash`,
+`test_case_random_id_has_genesis_hash`); 3486 passed, 2 xfailed in 53 s.
+Black, flake8, mypy, pyright clean.
+
+PR: [#1059](https://github.com/CERTCC/Vultron/pull/1059)

--- a/test/wire/as2/vocab/test_vocab_examples.py
+++ b/test/wire/as2/vocab/test_vocab_examples.py
@@ -223,6 +223,24 @@ class TestVocabExamples(unittest.TestCase):
         json = case.to_json()
         self.assertIsInstance(json, str)
 
+    def test_case_has_genesis_hash(self):
+        # CLP-08-003: example cases must carry a non-empty genesis hash
+        case = examples.case()
+        self.assertIsInstance(case, VulnerabilityCase)
+        self.assertTrue(
+            case.genesis_hash,
+            "examples.case() genesis_hash must be non-empty (CLP-08-003)",
+        )
+
+    def test_case_random_id_has_genesis_hash(self):
+        # CLP-08-003: random-id variant must also carry a non-empty genesis hash
+        case = examples.case(random_id=True)
+        self.assertIsInstance(case, VulnerabilityCase)
+        self.assertTrue(
+            case.genesis_hash,
+            "examples.case(random_id=True) genesis_hash must be non-empty (CLP-08-003)",
+        )
+
     def test_create_case(self):
         # is it an activity?
         create_case = examples.create_case()

--- a/vultron/core/models/case.py
+++ b/vultron/core/models/case.py
@@ -74,7 +74,11 @@ class VulnerabilityCase(CoreObject):
         default="",
         description=(
             "Per-case genesis hash binding this ledger to its origin "
-            "identity and timestamp (CLP-08-003)"
+            "identity and timestamp (CLP-08-003). "
+            "The empty-string default is intentional: rehydration paths "
+            "may deserialise objects that were stored before genesis hashes "
+            "were introduced. The model_validator enforces non-empty when "
+            "attributed_to is present at construction time."
         ),
     )
     # ADR-0017: ID-only cross-refs to avoid graph-cycle issues

--- a/vultron/wire/as2/vocab/examples/_base.py
+++ b/vultron/wire/as2/vocab/examples/_base.py
@@ -62,6 +62,7 @@ _REPORT = VulnerabilityReport(
 )
 _CASE = VulnerabilityCase(
     name=f"{_VENDOR.name} Case #{case_number}",
+    attributed_to=_VENDOR.id_,
 )
 
 
@@ -98,6 +99,7 @@ def case(random_id=False) -> VulnerabilityCase:
         _case = VulnerabilityCase(
             name=f"{_VENDOR.name} Case #{_case_number}",
             id_=_make_id("VulnerabilityCase"),
+            attributed_to=_VENDOR.id_,
         )
         return _case
     return _CASE

--- a/vultron/wire/as2/vocab/objects/vulnerability_case.py
+++ b/vultron/wire/as2/vocab/objects/vulnerability_case.py
@@ -107,7 +107,10 @@ class VulnerabilityCase(VultronAS2Object):
     )
     notes: list[as_NoteRef] = Field(default_factory=list)
 
-    # cryptographic origin binding for the case ledger (CLP-08)
+    # cryptographic origin binding for the case ledger (CLP-08).
+    # The empty-string default is intentional: rehydration paths may
+    # deserialise objects stored before genesis hashes were introduced.
+    # The model_validator enforces non-empty when attributed_to is present.
     genesis_hash: str = ""
 
     # don't excludeIfNone here to make it explicit when there is no embargo


### PR DESCRIPTION
- Fixes #1055

## Summary

Example `VulnerabilityCase` objects in `_base.py` were constructed without
`attributed_to`, leaving `genesis_hash=""` in violation of CLP-08-003. Added
`attributed_to=_VENDOR.id_` to the module-level `_CASE` and the
`case(random_id=True)` path so the model validator computes a non-empty
genesis hash at construction time.

Also clarifies in both model field descriptions that the `default=""` is
intentional for rehydration paths (the 'require when attributed_to present'
policy is spec-compliant).

## Changes

- `vultron/wire/as2/vocab/examples/_base.py`: add `attributed_to=_VENDOR.id_`
  to `_CASE` and `case(random_id=True)`
- `vultron/core/models/case.py`: expand `genesis_hash` field description to
  document the intentional empty-string default for rehydration paths
- `vultron/wire/as2/vocab/objects/vulnerability_case.py`: same clarification
  comment on the wire-layer model
- `test/wire/as2/vocab/test_vocab_examples.py`: add
  `test_case_has_genesis_hash` and `test_case_random_id_has_genesis_hash`

## Verification

- 3486 passed, 37 skipped, 2 xfailed in 53s (2 new tests)
- Black, flake8, mypy, pyright clean