### PR TITLE
spec: add HTTP-09 AS2JSONResponse convention; fix HTTP-04-001 content-type

### DIFF
--- a/specs/http-protocol.yaml
+++ b/specs/http-protocol.yaml
@@ -45,7 +45,22 @@ groups:
   specs:
   - id: HTTP-04-001
     priority: MUST
-    statement: 'All JSON responses MUST include `Content-Type: application/json` header'
+    statement: >-
+      Endpoints returning ActivityStreams objects MUST use
+      `Content-Type: application/activity+json`. Endpoints returning non-AS2
+      JSON (e.g., health checks, error bodies) MUST use
+      `Content-Type: application/json`.
+    rationale: >-
+      The ActivityStreams 2.0 specification defines `application/activity+json`
+      as the normative media type for AS2 documents. Using plain
+      `application/json` is ambiguous for federation clients that discover
+      capabilities via Content-Type. The previous requirement
+      (`application/json` for all responses) is superseded by this entry.
+    verification: >-
+      Integration test asserts that `GET /actors/{id}/profile` and
+      `GET /cases/{id}` responses carry
+      `Content-Type: application/activity+json`. Health-check response carries
+      `Content-Type: application/json`.
 - id: HTTP-05
   title: Correlation ID Propagation
   specs:
@@ -111,3 +126,56 @@ groups:
     statement: >-
       API responses MUST include all fields of the actual returned object type, not only fields
       declared on the annotated base class
+- id: HTTP-09
+  title: AS2 Response Class Convention
+  kind: language
+  rationale: >-
+    FastAPI's `response_model=` serves two purposes: OpenAPI schema generation
+    and runtime response filtering. When a route returns a wire AS2 object
+    (e.g., `as_VulnerabilityCase`), using `response_model=` for both purposes
+    risks silently stripping subclass fields (HTTP-08-001 violation). The
+    canonical fix is to separate the two concerns: use `response_model=` for
+    OpenAPI docs only, and return an `AS2JSONResponse` instance for actual
+    serialization (FastAPI skips response_model filtering when a `Response`
+    subclass is returned directly).
+  specs:
+  - id: HTTP-09-001
+    priority: MUST
+    statement: >-
+      Wire vocabulary objects (`as_VulnerabilityCase`, `as_CaseParticipant`,
+      etc.) are the canonical response type for Vultron HTTP endpoints — they
+      define the AS2-formatted JSON shape returned to clients. No separate
+      "response model" layer is needed; the wire model IS the response model.
+    rationale: >-
+      Vultron is an AS2-over-HTTP protocol. Every substantive response body is
+      an ActivityStreams object. The wire vocabulary already defines the correct
+      serialization shape (camelCase aliases, `@context`, `type`).
+  - id: HTTP-09-002
+    priority: MUST
+    statement: >-
+      FastAPI route handlers that return an AS2 object MUST return an
+      `AS2JSONResponse` instance (defined in
+      `vultron/adapters/driving/fastapi/responses.py`). They MUST NOT return a
+      raw dict from `model_dump()`, a plain `JSONResponse`, or the wire model
+      object directly. The `response_model=` decorator argument is used for
+      OpenAPI schema generation only.
+    rationale: >-
+      Returning a `Response` subclass bypasses FastAPI's `response_model`
+      filtering while preserving its use for OpenAPI schema generation (per
+      FastAPI docs). This eliminates the subtype-field-stripping bug
+      (HTTP-08-001) and ensures consistent `Content-Type: application/activity+json`
+      across all AS2 endpoints.
+    verification: >-
+      Architecture test or grep confirms no route in
+      `vultron/adapters/driving/fastapi/routers/` calls `model_dump()` and
+      returns a plain dict instead of `AS2JSONResponse`.
+  - id: HTTP-09-003
+    priority: MUST
+    statement: >-
+      `AS2JSONResponse` MUST serialize using
+      `model_dump(mode="json", by_alias=True, exclude_none=True)` and set
+      `Content-Type: application/activity+json`.
+    verification: >-
+      Unit test confirms `AS2JSONResponse(as_VulnerabilityCase(...)).body`
+      includes camelCase field names and the response headers contain
+      `Content-Type: application/activity+json`.

--- a/vultron/adapters/AGENTS.md
+++ b/vultron/adapters/AGENTS.md
@@ -15,9 +15,25 @@
 - **Layer boundary**: Routers in `vultron/adapters/driving/fastapi/routers/`
   MUST NOT import from `vultron/core/` directly except through the
   dispatcher port. No business logic in routers.
+- **AS2 response pattern** (HTTP-09-002): Endpoints returning AS2 objects
+  MUST use `AS2JSONResponse` from
+  `vultron.adapters.driving.fastapi.responses`. Do NOT return a raw dict
+  from `model_dump()` or the wire model object directly. Use `response_model=`
+  on the decorator for OpenAPI schema only; `AS2JSONResponse` handles
+  serialization and sets `Content-Type: application/activity+json`.
+
+  ```python
+  # Correct pattern
+  @router.get("/cases/{id}", response_model=as_VulnerabilityCase)
+  def get_case(id: str):
+      ...
+      return AS2JSONResponse(wire_case)  # handles model_dump(by_alias=True)
+  ```
+
 - **response\_model filtering**: FastAPI's `response_model=` strips fields
-  not declared on the model. Use a wide-enough model or `response_model=None`
-  when returning subtype objects.
+  not declared on the model when the route returns a non-Response value. The
+  `AS2JSONResponse` pattern above bypasses this filtering entirely (FastAPI
+  docs: returning a `Response` subclass skips response_model filtering).
   See [notes/codebase-structure.md](../../notes/codebase-structure.md)
   § FastAPI response\_model Filtering.
 


### PR DESCRIPTION
## Summary

Establishes the canonical FastAPI response pattern for Vultron AS2 endpoints.

Companion implementation issue: #1061

## Changes

**`specs/http-protocol.yaml`**:

- **Fix HTTP-04-001**: corrects the response `Content-Type` requirement from
  `application/json` to `application/activity+json` for AS2 object responses
  (non-AS2 endpoints like health checks still use `application/json`).
- **New HTTP-09-001**: wire vocabulary objects (`as_VulnerabilityCase`, etc.)
  are the canonical response type for Vultron HTTP endpoints — no separate
  "response model" layer is needed.
- **New HTTP-09-002**: route handlers returning AS2 objects MUST use
  `AS2JSONResponse`; `response_model=` is for OpenAPI schema only.
- **New HTTP-09-003**: `AS2JSONResponse` MUST serialize with
  `model_dump(by_alias=True, exclude_none=True)` and set
  `Content-Type: application/activity+json`.

**`vultron/adapters/AGENTS.md`**:

- Rewrites the FastAPI conventions section with the canonical `AS2JSONResponse`
  pattern and a code example.
- Supersedes the vague "use a wide-enough model or `response_model=None`"
  guidance.

## Verification

- `uv run spec-dump` parses HTTP-09-001/002/003 cleanly.
- `bash mdlint.sh` passes (0 errors).
- Pre-commit hooks pass.
- Implementation of `AS2JSONResponse` and route migration: issue #1061.
