### PR TITLE
refactor: migrate embargo.py received use cases to single-BT shape (ADR-0022 / CLP-10-005)

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -271,7 +271,23 @@ blackboard keys override it. The return type must be `dict[str, Any]` (not
 `dict[str, object]`) to satisfy mypy when the dict is spread into
 `execute_with_setup`'s `**context_data: Any` parameter.
 
-### 2026-06-18 REMOVE-EMBARGO-1033 — single-BT pattern requires receiving_actor_id in all callers
+### 2026-06-18 SINGLE-BT-1050 — test_accept_invite_to_embargo_commits_log_entry used VultronCaseActor ID not CASE_MANAGER ID
+
+When migrating `AcceptInviteToEmbargoOnCaseReceivedUseCase` to the
+single-BT pattern, `test_accept_invite_to_embargo_commits_log_entry`
+used `receiving_actor_id=case_actor.id_` (the VultronCaseActor service
+entity ID) and expected a commit to fire. The old Python guard
+(`receiving_actor_id == case_actor_id`) happened to pass because it
+compared the service actor ID; the new `CheckIsCaseManagerNode` gate
+compares against the actor holding `CVDRole.CASE_MANAGER` in
+`actor_participant_index`. With `case_manager_actor_id=coordinator_id`
+in the fixture, the case_actor was NOT the CASE_MANAGER, so the commit
+never fired. Fix: use `receiving_actor_id=coordinator_id` (the actual
+CASE_MANAGER) when expecting a guarded commit to fire.
+
+Rule: when writing tests for the single-BT guarded-commit pattern, the
+`receiving_actor_id` must be the actor that holds `CVDRole.CASE_MANAGER`
+via `actor_participant_index`, not the VultronCaseActor service entity.
 
 Switching `RemoveEmbargoEventFromCaseReceivedUseCase` from two `execute_with_setup`
 calls to a single call with `actor_id=receiving_actor_id` exposed that several

--- a/plan/history/2606/implementation/ISSUE-1050.md
+++ b/plan/history/2606/implementation/ISSUE-1050.md
@@ -1,0 +1,32 @@
+---
+source: ISSUE-1050
+timestamp: '2026-06-18T22:29:03.308215+00:00'
+title: Migrate embargo.py received use cases to single-BT shape (ADR-0022)
+type: implementation
+---
+
+## Issue #1050 — Single-BT execution for embargo.py received use cases (Remove/Invite/Accept)
+
+Migrated `InviteToEmbargoOnCaseReceivedUseCase` and
+`AcceptInviteToEmbargoOnCaseReceivedUseCase` in
+`vultron/core/use_cases/received/embargo.py` to the single-BT execution
+shape required by ADR-0022 / CLP-10-005. Each `execute()` now builds one
+tree via a `behaviors/` factory function, calls `execute_with_setup()`
+exactly once under `actor_id=receiving_actor_id`, and handles the result.
+
+To support the pattern, two BT node classes gained optional identity
+override constructor args: `OptionalLookupParticipantNode` gains
+`target_actor_id` and `RecordParticipantAcceptanceNode` gains
+`accepting_actor_id`. These allow PEC lookups and acceptance recording to
+target the correct subject actor even when the tree executes under the
+receiving actor's identity.
+
+`embargo.py` removed from `KNOWN_VIOLATIONS` in the architecture ratchet
+test (`test_single_bt_execution_received_side.py`). Six existing tests
+updated to pass `receiving_actor_id` per the single-BT requirement.
+Side-effect fix: `AcceptInviteToEmbargoOnCaseReceivedUseCase` now correctly
+passes `sync_port` to the single BT execution.
+
+All 3486 unit tests pass. Black, flake8, mypy, pyright clean.
+
+PR: [#1063](https://github.com/CERTCC/Vultron/pull/1063)

--- a/test/architecture/test_single_bt_execution_received_side.py
+++ b/test/architecture/test_single_bt_execution_received_side.py
@@ -97,7 +97,6 @@ def _collect_violations() -> frozenset[str]:
 # ---------------------------------------------------------------------------
 KNOWN_VIOLATIONS: frozenset[str] = frozenset(
     {
-        "vultron/core/use_cases/received/embargo.py",
         "vultron/core/use_cases/received/report.py",
         "vultron/core/use_cases/received/note.py",
         "vultron/core/use_cases/received/status.py",

--- a/test/core/use_cases/received/test_embargo.py
+++ b/test/core/use_cases/received/test_embargo.py
@@ -227,7 +227,9 @@ class TestEmbargoUseCases:
             id_="https://example.org/cases/case_em2/embargo_proposals/1",
         )
 
-        event = make_payload(proposal)
+        event = make_payload(
+            proposal, receiving_actor_id="https://example.org/users/vendor"
+        )
 
         InviteToEmbargoOnCaseReceivedUseCase(dl, event).execute()
 
@@ -273,7 +275,7 @@ class TestEmbargoUseCases:
             context=case,
             actor=coordinator_id,
         )
-        event = make_payload(accept)
+        event = make_payload(accept, receiving_actor_id=coordinator_id)
 
         AcceptInviteToEmbargoOnCaseReceivedUseCase(dl, event).execute()
 
@@ -321,7 +323,7 @@ class TestEmbargoUseCases:
             context=case,
             actor=coordinator_id,
         )
-        event = make_payload(accept)
+        event = make_payload(accept, receiving_actor_id=coordinator_id)
 
         with caplog.at_level(logging.WARNING):
             AcceptInviteToEmbargoOnCaseReceivedUseCase(dl, event).execute()
@@ -377,7 +379,7 @@ class TestEmbargoUseCases:
             context=case,
             actor=coordinator_id,
         )
-        event = make_payload(accept)
+        event = make_payload(accept, receiving_actor_id=coordinator_id)
 
         AcceptInviteToEmbargoOnCaseReceivedUseCase(dl, event).execute()
 
@@ -428,7 +430,7 @@ class TestEmbargoUseCases:
             context=case,
             actor=coordinator_id,
         )
-        event = make_payload(accept)
+        event = make_payload(accept, receiving_actor_id=coordinator_id)
 
         AcceptInviteToEmbargoOnCaseReceivedUseCase(dl, event).execute()
 
@@ -992,7 +994,10 @@ class TestEmbargoLogEntryCascade:
             context=case,
             actor=coordinator_id,
         )
-        event = make_payload(accept, receiving_actor_id=case_actor.id_)
+        # Per ADR-0022 / CLP-10-005: the guarded commit fires when
+        # receiving_actor_id holds CVDRole.CASE_MANAGER.  coordinator_id is
+        # the CASE_MANAGER in this fixture (case_manager_actor_id=coordinator_id).
+        event = make_payload(accept, receiving_actor_id=coordinator_id)
         sync_port = SyncActivityAdapter(dl)
         AcceptInviteToEmbargoOnCaseReceivedUseCase(
             dl, event, sync_port=sync_port

--- a/vultron/core/behaviors/embargo/announce_teardown_tree.py
+++ b/vultron/core/behaviors/embargo/announce_teardown_tree.py
@@ -188,7 +188,9 @@ def invite_to_embargo_on_case_tree(
         memory=False,
         children=[
             CreateAndStoreInviteNode(),
-            OptionalLookupParticipantNode(case_id=case_id),
+            OptionalLookupParticipantNode(
+                case_id=case_id, target_actor_id=invitee_id
+            ),
             UpdateParticipantEmbargoPecNode(pec_trigger=PEC_Trigger.INVITE),
             create_guarded_commit_case_ledger_entry_tree(case_id=case_id),
         ],
@@ -232,7 +234,9 @@ def accept_invite_to_embargo_tree(
         children=[
             ValidateCaseExistsNode(case_id=case_id),
             RecordParticipantAcceptanceNode(
-                case_id=case_id, embargo_id=embargo_id
+                case_id=case_id,
+                embargo_id=embargo_id,
+                accepting_actor_id=accepting_actor_id,
             ),
             create_guarded_commit_case_ledger_entry_tree(case_id=case_id),
         ],

--- a/vultron/core/behaviors/embargo/nodes/conditions.py
+++ b/vultron/core/behaviors/embargo/nodes/conditions.py
@@ -173,15 +173,23 @@ class OptionalLookupParticipantNode(DataLayerCondition):
 
     Used in received-side BT workflows where participant may legitimately not
     exist locally yet.
+
+    When ``target_actor_id`` is provided it is used for the participant lookup
+    instead of the BT-execution ``actor_id`` (which is the receiving actor).
+    This is the ADR-0022 single-BT pattern: the tree executes under
+    ``actor_id=receiving_actor_id`` for guarded-commit gating, while the PEC
+    lookup targets the message's actual invitee/subject.
     """
 
     def __init__(
         self,
         case_id: str,
+        target_actor_id: str | None = None,
         name: str | None = None,
     ):
         super().__init__(name=name or self.__class__.__name__)
         self.case_id = case_id
+        self.target_actor_id = target_actor_id
 
     def setup(self, **kwargs: object) -> None:
         super().setup(**kwargs)
@@ -199,7 +207,12 @@ class OptionalLookupParticipantNode(DataLayerCondition):
             self.logger.debug("%s: %s", self.name, self.feedback_message)
             return Status.SUCCESS
 
-        actor_id = self.actor_id
+        # Use target_actor_id when provided (ADR-0022 single-BT pattern:
+        # tree executes under receiving_actor_id but PEC lookup targets the
+        # actual invitee/subject). Fall back to the BT execution actor_id.
+        actor_id = (
+            self.target_actor_id if self.target_actor_id else self.actor_id
+        )
         if actor_id is None:
             self.feedback_message = "actor_id not found in blackboard — skipping participant lookup"
             self.logger.debug("%s: %s", self.name, self.feedback_message)

--- a/vultron/core/behaviors/embargo/nodes/proposal.py
+++ b/vultron/core/behaviors/embargo/nodes/proposal.py
@@ -158,17 +158,25 @@ class RecordParticipantAcceptanceNode(DataLayerAction):
 
     Uses EmbargoLifecycle.accept_embargo_invite(OBSERVED) to record the
     acceptance and apply any state transitions.
+
+    When ``accepting_actor_id`` is provided it is used instead of the BT
+    execution ``actor_id`` (which is the receiving actor).  This is the
+    ADR-0022 single-BT pattern: the tree executes under
+    ``actor_id=receiving_actor_id`` for guarded-commit gating, while the
+    acceptance is recorded for the message's actual accepting actor.
     """
 
     def __init__(
         self,
         case_id: str,
         embargo_id: str,
+        accepting_actor_id: str | None = None,
         name: str | None = None,
     ):
         super().__init__(name=name or self.__class__.__name__)
         self.case_id = case_id
         self.embargo_id = embargo_id
+        self.accepting_actor_id = accepting_actor_id
 
     def update(self) -> Status:
         from vultron.core.states.em import EM
@@ -177,7 +185,15 @@ class RecordParticipantAcceptanceNode(DataLayerAction):
             self.feedback_message = "DataLayer not available"
             return Status.FAILURE
 
-        if self.actor_id is None:
+        # Use accepting_actor_id when provided (ADR-0022 single-BT pattern:
+        # tree executes under receiving_actor_id but acceptance is recorded
+        # for the actual accepting actor). Fall back to BT execution actor_id.
+        actor_id = (
+            self.accepting_actor_id
+            if self.accepting_actor_id
+            else self.actor_id
+        )
+        if actor_id is None:
             self.feedback_message = "actor_id not available"
             return Status.FAILURE
 
@@ -185,7 +201,7 @@ class RecordParticipantAcceptanceNode(DataLayerAction):
         result = service.accept_embargo_invite(
             case_id=self.case_id,
             embargo_id=self.embargo_id,
-            actor_id=self.actor_id,
+            actor_id=actor_id,
             transition_mode=TransitionMode.OBSERVED,
         )
 

--- a/vultron/core/use_cases/received/embargo.py
+++ b/vultron/core/use_cases/received/embargo.py
@@ -234,6 +234,20 @@ class InviteToEmbargoOnCaseReceivedUseCase:
             logger.warning("invite_to_embargo_on_case: missing activity_id")
             return
 
+        receiving_actor_id = request.receiving_actor_id
+        if receiving_actor_id is None:
+            logger.debug(
+                "invite_to_embargo_on_case: missing receiving_actor_id"
+                " — skipping"
+            )
+            return
+
+        # Single BT execution under receiving_actor_id (ADR-0022 / CLP-10-005).
+        # invitee_id is threaded into the tree as a node constructor arg so
+        # OptionalLookupParticipantNode looks up the correct participant even
+        # when receiving_actor_id != invitee_id (e.g. CaseActor processing
+        # the invite).  The embedded guarded-commit branch fires naturally
+        # when the receiving actor holds CVDRole.CASE_MANAGER.
         tree = invite_to_embargo_on_case_tree(
             case_id=case_id,
             invitee_id=invitee_id,
@@ -242,7 +256,7 @@ class InviteToEmbargoOnCaseReceivedUseCase:
         bridge = BTBridge(datalayer=self._dl)
         result = bridge.execute_with_setup(
             tree=tree,
-            actor_id=invitee_id,
+            actor_id=receiving_actor_id,
             activity=request,
             sync_port=self._sync_port,
         )
@@ -254,51 +268,6 @@ class InviteToEmbargoOnCaseReceivedUseCase:
                 invite_id,
                 result.feedback_message,
             )
-
-        # Pre-flight guard + guarded commit (ADR-0021, CLP-10-002, CLP-10-003)
-        from vultron.core.behaviors.case.nodes import (
-            create_guarded_commit_case_ledger_entry_tree,
-        )
-        from vultron.core.use_cases._helpers import _find_case_actor_id
-
-        if not case_id:
-            logger.debug(
-                "invite_to_embargo_on_case: missing case_id — skipping commit"
-            )
-            return
-
-        case_actor_id = _find_case_actor_id(self._dl, case_id)
-        if case_actor_id is None:
-            logger.warning(
-                "invite_to_embargo_on_case: cannot resolve CaseActor for"
-                " case '%s' — skipping commit",
-                case_id,
-            )
-            return
-
-        receiving_actor_id = request.receiving_actor_id
-        if receiving_actor_id is None:
-            logger.debug(
-                "invite_to_embargo_on_case: missing receiving_actor_id"
-                " — skipping commit"
-            )
-            return
-
-        if receiving_actor_id != case_actor_id:
-            logger.debug(
-                "invite_to_embargo_on_case: receiving actor '%s' is not the"
-                " CaseActor for case '%s' — skipping commit (CLP-10-003)",
-                receiving_actor_id,
-                case_id,
-            )
-            return
-
-        BTBridge(datalayer=self._dl).execute_with_setup(
-            tree=create_guarded_commit_case_ledger_entry_tree(case_id=case_id),
-            actor_id=receiving_actor_id,
-            activity=request,
-            sync_port=self._sync_port,
-        )
 
 
 class AcceptInviteToEmbargoOnCaseReceivedUseCase:
@@ -328,6 +297,14 @@ class AcceptInviteToEmbargoOnCaseReceivedUseCase:
             )
             return
 
+        receiving_actor_id = request.receiving_actor_id
+        if receiving_actor_id is None:
+            logger.debug(
+                "accept_invite_to_embargo_on_case: missing receiving_actor_id"
+                " — skipping"
+            )
+            return
+
         _case = _resolve_case_for_embargo_acceptance(self._dl, request)
         if not is_case_model(_case):
             logger.error("accept_invite_to_embargo_on_case: case not found")
@@ -337,6 +314,13 @@ class AcceptInviteToEmbargoOnCaseReceivedUseCase:
         accepting_actor_id = request.actor_id
         invite_id = request.invite_id or ""
 
+        # Single BT execution under receiving_actor_id (ADR-0022 / CLP-10-005).
+        # accepting_actor_id is threaded into the tree as a node constructor arg
+        # so RecordParticipantAcceptanceNode records acceptance for the correct
+        # actor even when receiving_actor_id != accepting_actor_id (e.g. the
+        # CaseActor processing an Accept sent by the invitee).  The embedded
+        # guarded-commit branch fires naturally when the receiving actor holds
+        # CVDRole.CASE_MANAGER.
         tree = accept_invite_to_embargo_tree(
             case_id=case_id,
             embargo_id=embargo_id,
@@ -346,8 +330,9 @@ class AcceptInviteToEmbargoOnCaseReceivedUseCase:
         bridge = BTBridge(datalayer=self._dl)
         result = bridge.execute_with_setup(
             tree=tree,
-            actor_id=request.actor_id,
+            actor_id=receiving_actor_id,
             activity=request,
+            sync_port=self._sync_port,
         )
 
         if result.status != Status.SUCCESS:
@@ -358,46 +343,6 @@ class AcceptInviteToEmbargoOnCaseReceivedUseCase:
                 case_id,
                 result.feedback_message,
             )
-
-        # Pre-flight guard + guarded commit (ADR-0021, CLP-10-002, CLP-10-003)
-        from vultron.core.behaviors.case.nodes import (
-            create_guarded_commit_case_ledger_entry_tree,
-        )
-        from vultron.core.use_cases._helpers import _find_case_actor_id
-
-        case_actor_id = _find_case_actor_id(self._dl, case_id)
-        if case_actor_id is None:
-            logger.warning(
-                "accept_invite_to_embargo_on_case: cannot resolve CaseActor"
-                " for case '%s' — skipping commit",
-                case_id,
-            )
-            return
-
-        receiving_actor_id = request.receiving_actor_id
-        if receiving_actor_id is None:
-            logger.debug(
-                "accept_invite_to_embargo_on_case: missing receiving_actor_id"
-                " — skipping commit"
-            )
-            return
-
-        if receiving_actor_id != case_actor_id:
-            logger.debug(
-                "accept_invite_to_embargo_on_case: receiving actor '%s' is"
-                " not the CaseActor for case '%s' — skipping commit"
-                " (CLP-10-003)",
-                receiving_actor_id,
-                case_id,
-            )
-            return
-
-        BTBridge(datalayer=self._dl).execute_with_setup(
-            tree=create_guarded_commit_case_ledger_entry_tree(case_id=case_id),
-            actor_id=receiving_actor_id,
-            activity=request,
-            sync_port=self._sync_port,
-        )
 
 
 class RejectInviteToEmbargoOnCaseReceivedUseCase:


### PR DESCRIPTION
- Closes #1050

## Summary

Migrates `InviteToEmbargoOnCaseReceivedUseCase` and
`AcceptInviteToEmbargoOnCaseReceivedUseCase` in
`vultron/core/use_cases/received/embargo.py` from the two-call
actor-identity-switching pattern to the single-BT execution shape required
by ADR-0022 / CLP-10-005. Removes `embargo.py` from the architecture
ratchet test's `KNOWN_VIOLATIONS` set.

## Changes

- `vultron/core/use_cases/received/embargo.py`: each of the two
  violating `execute()` methods now builds one tree, calls
  `execute_with_setup()` exactly once under
  `actor_id=receiving_actor_id`, and handles the result. The embedded
  guarded-commit branch fires naturally via `CheckIsCaseManagerNode`.
  The second `execute_with_setup` call and all Python identity-comparison
  guard code are removed. Side-effect fix: `AcceptInviteToEmbargoOnCase`
  now correctly passes `sync_port` to the single BT execution (it was
  omitted from the old first call).
- `vultron/core/behaviors/embargo/nodes/conditions.py`:
  `OptionalLookupParticipantNode` gains an optional
  `target_actor_id` constructor arg so the PEC participant lookup can
  target the actual invitee when the tree runs under
  `receiving_actor_id`.
- `vultron/core/behaviors/embargo/nodes/proposal.py`:
  `RecordParticipantAcceptanceNode` gains an optional
  `accepting_actor_id` constructor arg so acceptance is recorded for
  the message sender (the accepting actor), not the receiving actor.
- `vultron/core/behaviors/embargo/announce_teardown_tree.py`: factory
  functions thread the new args into the respective nodes.
- `test/architecture/test_single_bt_execution_received_side.py`:
  `embargo.py` removed from `KNOWN_VIOLATIONS`.
- `test/core/use_cases/received/test_embargo.py`: six tests updated
  to pass `receiving_actor_id` per the single-BT requirement (ADR-0022;
  cf. BUILD_LEARNINGS 2026-06-18 REMOVE-EMBARGO-1033).

## Verification

- 3486 unit tests pass (0 new failures)
- Black, flake8, mypy, pyright all clean
- Architecture ratchet test (`test_received_use_cases_do_not_dispatch_guarded_commit_directly`) passes with embargo.py removed from KNOWN_VIOLATIONS
- All 6 embargo routing/guard tests pass