### PR TITLE
feat: single-BT execution for report.py and status.py received use cases (#1051)

### DIFF
--- a/plan/history/2606/implementation/ISSUE-1051.md
+++ b/plan/history/2606/implementation/ISSUE-1051.md
@@ -1,0 +1,45 @@
+---
+source: ISSUE-1051
+timestamp: '2026-06-18T23:32:59.876579+00:00'
+title: Single-BT execution for report.py and status.py received use cases
+type: implementation
+---
+
+## Issue #1051 — Single-BT execution for report.py and status.py received use cases
+
+Migrated three received-side use cases to the ADR-0022 single-BT-execution
+pattern: one `execute_with_setup()` call per inbox delivery under
+`actor_id=receiving_actor_id`, with the guarded-commit subtree embedded in
+the tree factory rather than called as a separate BT execution.
+
+### Use cases migrated
+
+- `ValidateReportReceivedUseCase` — replaced `ValidateCaseUseCase` +
+  separate guarded-commit BT with a single `create_validate_report_received_tree()`
+  call embedding both the validate subtree and the guarded commit. Introduced
+  `sender_actor_id` threading into `CheckRMStateValid`,
+  `CheckRMStateReceivedOrInvalid`, and `TransitionRMtoValid` so the tree runs
+  under `receiving_actor_id` while transitioning the message sender's RM state.
+- `AckReportReceivedUseCase` — replaced two `execute_with_setup()` calls with
+  one call using the updated `create_ack_report_received_tree(case_id=case_id)`.
+- `AddParticipantStatusToParticipantReceivedUseCase` — removed
+  `_commit_log_cascade_bt()` helper method; `add_participant_status_tree()` now
+  accepts `case_id` and appends the guarded-commit subtree as its final child.
+
+### Architecture ratchet updated
+
+Removed `vultron/core/use_cases/received/report.py` and
+`vultron/core/use_cases/received/status.py` from `KNOWN_VIOLATIONS` in
+`test/architecture/test_single_bt_execution_received_side.py`.
+
+### Notable design decisions
+
+- The `ValidationOrShortcut` subtree in `create_validate_report_received_tree()`
+  is wrapped in a `ValidationOrSkip` Selector with a `Success` fallback,
+  preserving the old behavior where the guarded commit runs regardless of
+  whether the validation BT succeeded (e.g., when `EnsureEmbargoExists` blocks
+  due to no active embargo in the CaseActor's DataLayer context).
+- Added `test_sender_rm_state_transitions_to_valid` to verify the
+  `sender_actor_id` threading mechanism correctness end-to-end.
+
+PR: [#1065](https://github.com/CERTCC/Vultron/pull/1065)

--- a/test/architecture/test_single_bt_execution_received_side.py
+++ b/test/architecture/test_single_bt_execution_received_side.py
@@ -97,9 +97,7 @@ def _collect_violations() -> frozenset[str]:
 # ---------------------------------------------------------------------------
 KNOWN_VIOLATIONS: frozenset[str] = frozenset(
     {
-        "vultron/core/use_cases/received/report.py",
         "vultron/core/use_cases/received/note.py",
-        "vultron/core/use_cases/received/status.py",
         "vultron/core/use_cases/received/case/lifecycle.py",
         "vultron/core/use_cases/received/actor/case_manager_role.py",
     }

--- a/test/core/behaviors/report/test_received_report_trees.py
+++ b/test/core/behaviors/report/test_received_report_trees.py
@@ -46,7 +46,7 @@ from vultron.core.behaviors.report.nodes.storage import (
 from vultron.core.behaviors.report.received_report_trees import (
     create_ack_report_received_tree,
     create_close_report_received_tree,
-    create_create_report_received_tree,
+    create_report_received_tree,
     create_invalidate_report_received_tree,
 )
 from vultron.core.models.activity import VultronActivity
@@ -372,6 +372,7 @@ def _make_ack_report_event() -> AckReportReceivedEvent:
         object_=CoreReport(id_=ACTIVITY_ID),
         inner_object=CoreReport(id_=REPORT_ID),
         activity=_make_activity(type_="Read"),
+        receiving_actor_id=ACTOR_ID,
     )
 
 
@@ -406,7 +407,7 @@ class TestCreateReportReceivedTree:
     def test_happy_path_stores_report_and_activity(self, dl):
         """Full BT stores both VulnerabilityReport and CreateReport activity."""
         event = _make_create_report_event()
-        tree = create_create_report_received_tree(event)
+        tree = create_report_received_tree(event)
         bridge = BTBridge(datalayer=dl)
         result = bridge.execute_with_setup(
             tree=tree, actor_id=ACTOR_ID, activity=event
@@ -422,7 +423,7 @@ class TestCreateReportReceivedTree:
         bridge = BTBridge(datalayer=dl)
 
         for _ in range(2):
-            tree = create_create_report_received_tree(event)
+            tree = create_report_received_tree(event)
             result = bridge.execute_with_setup(
                 tree=tree, actor_id=ACTOR_ID, activity=event
             )

--- a/test/core/use_cases/received/case/test_bootstrap_participants.py
+++ b/test/core/use_cases/received/case/test_bootstrap_participants.py
@@ -271,7 +271,7 @@ class TestM4AddParticipantStatusAfterBootstrap:
             target=vendor_p,
             actor=_CASE_ACTOR_ID,
         )
-        event = make_payload(activity)
+        event = make_payload(activity, receiving_actor_id=_CASE_ACTOR_ID)
 
         AddParticipantStatusToParticipantReceivedUseCase(dl, event).execute()
 

--- a/test/core/use_cases/received/test_report.py
+++ b/test/core/use_cases/received/test_report.py
@@ -1028,6 +1028,7 @@ class TestFullReportFlow:
             object_=offer,
             inner_object=report,
             activity=activity,
+            receiving_actor_id=self.VENDOR_ID,
         )
 
     def test_full_flow_case_created_at_received(self):
@@ -1223,14 +1224,15 @@ class TestValidateReportReceivedGuardedCommit:
             "no case found" in r.message.lower() for r in caplog.records
         ), "Expected debug log indicating skip due to missing case"
 
-    def test_skip_commit_when_receiving_actor_not_case_actor(self, caplog):
+    def test_skip_commit_when_receiving_actor_not_case_actor(self):
         """ValidateReportReceivedUseCase skips commit when receiving_actor != CaseActor.
 
-        Per CLP-10-003: the pre-flight guard MUST skip the guarded commit BT when
-        the receiving actor is not the CaseActor.
+        Per CLP-10-003: the guarded commit BT MUST skip the canonical commit
+        when the receiving actor is not the CaseActor.  In the single-BT
+        pattern (ADR-0022) this is enforced in-tree by CheckIsCaseManagerNode
+        rather than via a Python pre-flight guard.  We verify at the data level
+        that no CaseLedgerEntry is written.
         """
-        import logging
-
         from vultron.wire.as2.vocab.objects.report_case_link import (
             VultronReportCaseLink,
         )
@@ -1246,6 +1248,20 @@ class TestValidateReportReceivedGuardedCommit:
             name="Guarded Commit Test Case",
         )
         case.vulnerability_reports.append(self.REPORT_ID)
+        # Register case actor as CASE_MANAGER
+        from vultron.core.states.roles import CVDRole
+        from vultron.wire.as2.vocab.objects.case_participant import (
+            CaseParticipant,
+        )
+
+        cm_participant = CaseParticipant(
+            attributed_to=self.CASE_ACTOR_ID,
+            context=case.id_,
+            case_roles=[CVDRole.CASE_MANAGER],
+        )
+        dl.create(cm_participant)
+        case.case_participants.append(cm_participant.id_)
+        case.actor_participant_index[self.CASE_ACTOR_ID] = cm_participant.id_
         dl.save(case)
 
         # Create a ReportCaseLink to establish the CaseActor mapping
@@ -1261,29 +1277,30 @@ class TestValidateReportReceivedGuardedCommit:
             receiving_actor_id=self.VENDOR_ID  # != case_actor_id
         )
 
-        with caplog.at_level(logging.DEBUG):
-            ValidateReportReceivedUseCase(dl, event).execute()
+        ValidateReportReceivedUseCase(dl, event).execute()
 
-        assert any(
-            "is not the CaseActor" in r.message
-            and "skipping canonical commit" in r.message
-            for r in caplog.records
-        ), "Expected debug log indicating skip due to non-CaseActor receiving actor"
+        entries = list(dl.list_objects("CaseLedgerEntry"))
+        assert not entries, (
+            "Expected no CaseLedgerEntry when receiving actor is not the CaseActor"
+            f" (CLP-10-003); found: {entries}"
+        )
 
     def test_calls_commit_bt_when_receiving_actor_is_case_actor(
         self, monkeypatch
     ):
         """Guarded commit BT runs when receiving_actor_id == case_actor_id (CLP-10-002).
 
-        When all pre-flight guards pass — receiving_actor_id is set, a case is
-        linked to the report, a CaseActor ID is resolvable, and
-        receiving_actor_id == case_actor_id — the guarded commit BT MUST be
-        executed.  Verified by patching ``create_guarded_commit_case_ledger_entry_tree``
-        in the use-case module's namespace; it is called only after all guards
-        succeed.
+        When all pre-flight guards pass — receiving_actor_id is set and a case
+        is linked to the report with the receiving actor holding CASE_MANAGER
+        role — the guarded commit BT MUST execute, resulting in a persisted
+        CaseLedgerEntry.
         """
-        import vultron.core.use_cases.received.report as report_module
+        import vultron.core.behaviors.report.received_report_trees as rrt_module
         from vultron.core.models.report_case_link import VultronReportCaseLink
+        from vultron.core.states.roles import CVDRole
+        from vultron.wire.as2.vocab.objects.case_participant import (
+            CaseParticipant,
+        )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
             VulnerabilityCase,
         )
@@ -1300,10 +1317,18 @@ class TestValidateReportReceivedGuardedCommit:
             name="Guarded Commit Positive Test",
         )
         case.vulnerability_reports.append(self.REPORT_ID)
+        # Register the CASE_ACTOR as CASE_MANAGER so CheckIsCaseManagerNode passes
+        cm_participant = CaseParticipant(
+            attributed_to=self.CASE_ACTOR_ID,
+            context=CASE_ID,
+            case_roles=[CVDRole.CASE_MANAGER],
+        )
+        dl.create(cm_participant)
+        case.case_participants.append(cm_participant.id_)
+        case.actor_participant_index[self.CASE_ACTOR_ID] = cm_participant.id_
         dl.save(case)
 
-        # VultronReportCaseLink establishes the CaseActor mapping checked by
-        # _find_case_actor_id (CBT-01-006).
+        # VultronReportCaseLink establishes the case_id lookup.
         link = VultronReportCaseLink(
             report_id=self.REPORT_ID,
             case_id=CASE_ID,
@@ -1311,16 +1336,15 @@ class TestValidateReportReceivedGuardedCommit:
         )
         dl.save(link)
 
-        # Receiving actor IS the CaseActor — all pre-flight guards must pass.
+        # Receiving actor IS the CaseActor — CheckIsCaseManagerNode must pass.
         event = self._make_validate_event_with_receiving_actor(
             receiving_actor_id=self.CASE_ACTOR_ID
         )
 
-        # Track calls to create_guarded_commit_case_ledger_entry_tree in the
-        # use-case module's namespace.  This function is invoked only when the
-        # pre-flight guard passes (CLP-10-002).
+        # Track calls to create_guarded_commit_case_ledger_entry_tree in
+        # received_report_trees (where it is called in the ADR-0022 pattern).
         original_create = (
-            report_module.create_guarded_commit_case_ledger_entry_tree
+            rrt_module.create_guarded_commit_case_ledger_entry_tree
         )
         commit_tree_calls: list[str | None] = []
 
@@ -1329,7 +1353,7 @@ class TestValidateReportReceivedGuardedCommit:
             return original_create(case_id=case_id)
 
         monkeypatch.setattr(
-            report_module,
+            rrt_module,
             "create_guarded_commit_case_ledger_entry_tree",
             tracking_create,
         )

--- a/test/core/use_cases/received/test_status.py
+++ b/test/core/use_cases/received/test_status.py
@@ -260,7 +260,10 @@ class TestStatusUseCases:
             actor="https://example.org/users/vendor",
             context=case_ps2,
         )
-        event = make_payload(activity)
+        event = make_payload(
+            activity,
+            receiving_actor_id="https://example.org/users/vendor",
+        )
 
         AddParticipantStatusToParticipantReceivedUseCase(dl, event).execute()
 

--- a/test/core/use_cases/test_validate_report_ledger_routing.py
+++ b/test/core/use_cases/test_validate_report_ledger_routing.py
@@ -404,6 +404,7 @@ class TestCaseActorReceivedWritesLedgerEntry:
         # Register VENDOR as a case participant so TransitionRMtoValid can
         # persist the status record.
         case = dl.read(self.CASE_ID)
+        assert isinstance(case, VulnerabilityCase)
         from vultron.core.models.case_actor import VultronCaseActor
 
         vendor_svc = VultronCaseActor(id_=self.VENDOR_ID)

--- a/test/core/use_cases/test_validate_report_ledger_routing.py
+++ b/test/core/use_cases/test_validate_report_ledger_routing.py
@@ -387,10 +387,50 @@ class TestCaseActorReceivedWritesLedgerEntry:
             f"ledger entry; found event_types={event_types}"
         )
 
+    def test_sender_rm_state_transitions_to_valid(self):
+        """Vendor (sender) RM state is set to VALID even when CaseActor is receiver.
 
-# ---------------------------------------------------------------------------
-# Layer 3 — Full two-DataLayer chain
-# ---------------------------------------------------------------------------
+        Verifies the sender_actor_id threading introduced in ADR-0022: nodes
+        CheckRMStateValid, CheckRMStateReceivedOrInvalid, and TransitionRMtoValid
+        receive ``sender_actor_id=VENDOR_ID`` so the RM transition targets the
+        message sender regardless of which actor ``execute_with_setup`` runs
+        under (receiving_actor_id=CASE_ACTOR_ID).
+        """
+        from vultron.core.states.rm import RM
+        from vultron.core.use_cases._helpers import _report_phase_status_id
+
+        dl = self._make_case_actor_dl()
+
+        # Register VENDOR as a case participant so TransitionRMtoValid can
+        # persist the status record.
+        case = dl.read(self.CASE_ID)
+        from vultron.core.models.case_actor import VultronCaseActor
+
+        vendor_svc = VultronCaseActor(id_=self.VENDOR_ID)
+        dl.save(vendor_svc)
+        vendor_p = CaseParticipant(
+            attributed_to=self.VENDOR_ID,
+            context=self.CASE_ID,
+            case_roles=[CVDRole.COORDINATOR],
+        )
+        dl.create(vendor_p)
+        case.case_participants.append(vendor_p.id_)
+        case.actor_participant_index[self.VENDOR_ID] = vendor_p.id_
+        dl.save(case)
+
+        ValidateReportReceivedUseCase(
+            dl,
+            self._make_validate_event(),  # actor_id=VENDOR, receiving=CASE_ACTOR
+        ).execute()
+
+        valid_id = _report_phase_status_id(
+            self.VENDOR_ID, self.REPORT_ID, RM.VALID.value
+        )
+        assert dl.get("ParticipantStatus", valid_id) is not None, (
+            f"Vendor (sender) {self.VENDOR_ID!r} must have RM.VALID persisted "
+            "after validate-report; sender_actor_id threading may be broken "
+            "(ADR-0022 single-BT migration)"
+        )
 
 
 class TestFullValidateReportLedgerChain:

--- a/vultron/core/behaviors/report/nodes/conditions.py
+++ b/vultron/core/behaviors/report/nodes/conditions.py
@@ -36,16 +36,26 @@ class CheckRMStateValid(DataLayerCondition):
     This node implements the early-exit check from the simulation BT.
     """
 
-    def __init__(self, report_id: str, name: str | None = None):
+    def __init__(
+        self,
+        report_id: str,
+        sender_actor_id: str | None = None,
+        name: str | None = None,
+    ):
         """
         Initialize CheckRMStateValid node.
 
         Args:
             report_id: ID of VulnerabilityReport to check
+            sender_actor_id: Explicit actor ID to use instead of the blackboard
+                ``actor_id``.  Thread this in when the tree runs under
+                ``receiving_actor_id`` but the RM check must target the message
+                sender (ADR-0022 single-BT pattern).
             name: Optional custom node name (defaults to class name)
         """
         super().__init__(name=name or self.__class__.__name__)
         self.report_id = report_id
+        self.sender_actor_id = sender_actor_id
 
     def update(self) -> Status:
         """
@@ -57,12 +67,15 @@ class CheckRMStateValid(DataLayerCondition):
         if self.datalayer is None:
             self.logger.error(f"{self.name}: DataLayer not available")
             return Status.FAILURE
-        if self.actor_id is None:
+        actor_id = (
+            self.sender_actor_id if self.sender_actor_id else self.actor_id
+        )
+        if actor_id is None:
             self.logger.error(f"{self.name}: actor_id not available")
             return Status.FAILURE
 
         valid_id = _report_phase_status_id(
-            self.actor_id, self.report_id, RM.VALID.value
+            actor_id, self.report_id, RM.VALID.value
         )
         if self.datalayer.read(valid_id) is not None:
             self.logger.debug(
@@ -85,16 +98,26 @@ class CheckRMStateReceivedOrInvalid(DataLayerCondition):
     This node implements the precondition check from the simulation BT.
     """
 
-    def __init__(self, report_id: str, name: str | None = None):
+    def __init__(
+        self,
+        report_id: str,
+        sender_actor_id: str | None = None,
+        name: str | None = None,
+    ):
         """
         Initialize CheckRMStateReceivedOrInvalid node.
 
         Args:
             report_id: ID of VulnerabilityReport to check
+            sender_actor_id: Explicit actor ID to use instead of the blackboard
+                ``actor_id``.  Thread this in when the tree runs under
+                ``receiving_actor_id`` but the RM check must target the message
+                sender (ADR-0022 single-BT pattern).
             name: Optional custom node name (defaults to class name)
         """
         super().__init__(name=name or self.__class__.__name__)
         self.report_id = report_id
+        self.sender_actor_id = sender_actor_id
 
     def update(self) -> Status:
         """
@@ -106,12 +129,15 @@ class CheckRMStateReceivedOrInvalid(DataLayerCondition):
         if self.datalayer is None:
             self.logger.error(f"{self.name}: DataLayer not available")
             return Status.FAILURE
-        if self.actor_id is None:
+        actor_id = (
+            self.sender_actor_id if self.sender_actor_id else self.actor_id
+        )
+        if actor_id is None:
             self.logger.error(f"{self.name}: actor_id not available")
             return Status.FAILURE
 
         valid_id = _report_phase_status_id(
-            self.actor_id, self.report_id, RM.VALID.value
+            actor_id, self.report_id, RM.VALID.value
         )
         if self.datalayer.read(valid_id) is not None:
             self.logger.debug(

--- a/vultron/core/behaviors/report/nodes/rm_transitions.py
+++ b/vultron/core/behaviors/report/nodes/rm_transitions.py
@@ -105,18 +105,29 @@ class TransitionRMtoValid(DataLayerAction):
     This node implements the core state transition from the validate_report handler.
     """
 
-    def __init__(self, report_id: str, offer_id: str, name: str | None = None):
+    def __init__(
+        self,
+        report_id: str,
+        offer_id: str,
+        sender_actor_id: str | None = None,
+        name: str | None = None,
+    ):
         """
         Initialize TransitionRMtoValid node.
 
         Args:
             report_id: ID of VulnerabilityReport to update
             offer_id: ID of Offer to update
+            sender_actor_id: Explicit actor ID to use instead of the blackboard
+                ``actor_id``.  Thread this in when the tree runs under
+                ``receiving_actor_id`` but the RM transition must target the
+                message sender (ADR-0022 single-BT pattern).
             name: Optional custom node name (defaults to class name)
         """
         super().__init__(name=name or self.__class__.__name__)
         self.report_id = report_id
         self.offer_id = offer_id
+        self.sender_actor_id = sender_actor_id
 
     def update(self) -> Status:
         """
@@ -130,7 +141,15 @@ class TransitionRMtoValid(DataLayerAction):
         Returns:
             SUCCESS if status updated, FAILURE on error
         """
-        if self.datalayer is None or self.actor_id is None:
+        if self.datalayer is None:
+            self.logger.error(
+                f"{self.name}: DataLayer or actor_id not available"
+            )
+            return Status.FAILURE
+        actor_id = (
+            self.sender_actor_id if self.sender_actor_id else self.actor_id
+        )
+        if actor_id is None:
             self.logger.error(
                 f"{self.name}: DataLayer or actor_id not available"
             )
@@ -143,10 +162,10 @@ class TransitionRMtoValid(DataLayerAction):
 
             status = ParticipantStatus(
                 id_=_report_phase_status_id(
-                    self.actor_id, self.report_id, RM.VALID.value
+                    actor_id, self.report_id, RM.VALID.value
                 ),
                 context=context,
-                attributed_to=self.actor_id,
+                attributed_to=actor_id,
                 rm_state=RM.VALID,
                 em_consent_state=PEC.NO_EMBARGO,
                 cvd_role=[CVDRole.REPORTER],
@@ -161,12 +180,12 @@ class TransitionRMtoValid(DataLayerAction):
             self.logger.info(
                 "RM → VALID for report '%s' (actor '%s')",
                 self.report_id,
-                self.actor_id,
+                actor_id,
             )
 
             if is_case_model(case):
                 update_participant_rm_state(
-                    case.id_, self.actor_id, RM.VALID, self.datalayer
+                    case.id_, actor_id, RM.VALID, self.datalayer
                 )
 
             return Status.SUCCESS

--- a/vultron/core/behaviors/report/received_report_trees.py
+++ b/vultron/core/behaviors/report/received_report_trees.py
@@ -40,7 +40,20 @@ from vultron.core.models.events.report import (
     CreateReportReceivedEvent,
     InvalidateReportReceivedEvent,
 )
+from vultron.core.behaviors.case.nodes.lifecycle import (
+    create_guarded_commit_case_ledger_entry_tree,
+)
+from vultron.core.behaviors.report.nodes.conditions import (
+    CheckRMStateReceivedOrInvalid,
+    CheckRMStateValid,
+    EnsureEmbargoExists,
+    EvaluateReportCredibility,
+    EvaluateReportValidity,
+)
 from vultron.core.behaviors.report.nodes.emit import EmitAckReportActivity
+from vultron.core.behaviors.report.nodes.rm_transitions import (
+    TransitionRMtoValid,
+)
 from vultron.core.behaviors.report.nodes.rm_transitions import (
     TransitionCaseParticipantRMtoClosed,
     TransitionCaseParticipantRMtoInvalid,
@@ -53,7 +66,127 @@ from vultron.core.behaviors.report.nodes.storage import (
 logger = logging.getLogger(__name__)
 
 
-def create_create_report_received_tree(
+def create_validate_report_received_tree(
+    report_id: str,
+    offer_id: str,
+    sender_actor_id: str,
+    case_id: str | None = None,
+) -> py_trees.behaviour.Behaviour:
+    """Create the single-BT received-side tree for ValidateReport (ADR-0022).
+
+    Composes the validate-report workflow for a received ``Accept(Offer(Report))``
+    activity.  All nodes that need the message sender's identity receive
+    ``sender_actor_id`` as an explicit constructor arg so the tree can run
+    under ``actor_id=receiving_actor_id`` while still transitioning the
+    *sender's* RM state to VALID.
+
+    When ``case_id`` is provided, the guarded-commit subtree
+    (``create_guarded_commit_case_ledger_entry_tree``) is appended as the
+    final child so ``CheckIsCaseManagerNode`` fires when the receiving actor
+    holds ``CVDRole.CASE_MANAGER``.  When ``case_id`` is ``None`` the tree
+    omits the guarded commit entirely (no ledger entry is written).
+
+    Structure::
+
+        ValidateReportReceivedBT (Sequence)
+        ├── ValidationOrSkip (Selector)
+        │   ├── ValidationOrShortcut (Selector)   # try validation
+        │   │   ├── CheckRMStateValid(sender_actor_id)       # idempotency exit
+        │   │   └── ValidationFlow (Sequence)
+        │   │       ├── CheckRMStateReceivedOrInvalid(sender_actor_id)
+        │   │       ├── EvaluateReportCredibility
+        │   │       ├── EvaluateReportValidity
+        │   │       └── ValidationActions (Sequence)
+        │   │           ├── TransitionRMtoValid(sender_actor_id)
+        │   │           └── EnsureEmbargoExists
+        │   └── Success("ValidationSkipped")        # fallback — commit always runs
+        └── GuardedCommitOrSkip (Selector, only if case_id)
+            ├── Sequence
+            │   ├── CheckIsCaseManagerNode
+            │   └── CommitCaseLedgerEntryNode
+            └── Success("CommitSkippedNotCaseManager")
+
+    Args:
+        report_id: ID of the VulnerabilityReport being validated.
+        offer_id: ID of the Offer activity that carried the report.
+        sender_actor_id: Actor ID of the message sender (the validating actor).
+            Used by validation nodes instead of the blackboard ``actor_id``.
+        case_id: ID of the VulnerabilityCase linked to this report.  Required
+            for the guarded-commit step; pass ``None`` to skip ledger commit.
+
+    Returns:
+        Root node of the ``ValidateReportReceivedBT`` Sequence.
+    """
+    validation_actions = py_trees.composites.Sequence(
+        name="ValidationActions",
+        memory=False,
+        children=[
+            TransitionRMtoValid(
+                report_id=report_id,
+                offer_id=offer_id,
+                sender_actor_id=sender_actor_id,
+            ),
+            EnsureEmbargoExists(report_id=report_id),
+        ],
+    )
+
+    validation_flow = py_trees.composites.Sequence(
+        name="ValidationFlow",
+        memory=False,
+        children=[
+            CheckRMStateReceivedOrInvalid(
+                report_id=report_id, sender_actor_id=sender_actor_id
+            ),
+            EvaluateReportCredibility(report_id=report_id),
+            EvaluateReportValidity(report_id=report_id),
+            validation_actions,
+        ],
+    )
+
+    validation_or_shortcut = py_trees.composites.Selector(
+        name="ValidationOrShortcut",
+        memory=False,
+        children=[
+            CheckRMStateValid(
+                report_id=report_id, sender_actor_id=sender_actor_id
+            ),
+            validation_flow,
+        ],
+    )
+
+    children: list[py_trees.behaviour.Behaviour] = [
+        py_trees.composites.Selector(
+            name="ValidationOrSkip",
+            memory=False,
+            children=[
+                validation_or_shortcut,
+                py_trees.behaviours.Success(name="ValidationSkipped"),
+            ],
+        )
+    ]
+
+    if case_id is not None:
+        children.append(
+            create_guarded_commit_case_ledger_entry_tree(case_id=case_id)
+        )
+
+    root = py_trees.composites.Sequence(
+        name="ValidateReportReceivedBT",
+        memory=False,
+        children=children,
+    )
+    logger.debug(
+        "Created ValidateReportReceivedBT for report=%s offer=%s sender=%s"
+        " case=%s",
+        report_id,
+        offer_id,
+        sender_actor_id,
+        case_id,
+    )
+    return root
+
+
+def create_report_received_tree(
     request: CreateReportReceivedEvent,
 ) -> py_trees.behaviour.Behaviour:
     """Create the BT for the CreateReportReceived workflow.
@@ -98,6 +231,7 @@ def create_create_report_received_tree(
 
 def create_ack_report_received_tree(
     request: AckReportReceivedEvent,
+    case_id: str | None = None,
 ) -> py_trees.behaviour.Behaviour:
     """Create the BT for the AckReportReceived workflow.
 
@@ -106,9 +240,20 @@ def create_ack_report_received_tree(
     Steps (Sequence):
     1. Store AckReport activity idempotently.
     2. Emit AckReport to CaseActor (Selector — graceful no-op if no CaseActor).
+    3. Guarded commit (only when ``case_id`` is provided and the receiving
+       actor holds ``CVDRole.CASE_MANAGER``).
+
+    When running under ``actor_id=receiving_actor_id`` (ADR-0022 single-BT
+    shape), step 2's ``EmitAckReportActivity`` uses the blackboard
+    ``actor_id`` as sender.  On the received side (no TriggerActivityPort),
+    the emit node returns FAILURE and the ``NoEmitFallback`` Success absorbs
+    it — so the emit is a graceful no-op in the typical CaseActor context.
 
     Args:
         request: The parsed inbound domain event.
+        case_id: ID of the VulnerabilityCase linked to this report.  When
+            provided, a guarded-commit subtree is appended so the receiving
+            CaseActor can write a canonical ledger entry.
 
     Returns:
         Root node of the ``AckReportReceivedBT`` Sequence.
@@ -117,31 +262,39 @@ def create_ack_report_received_tree(
     offer_id = request.offer_id or activity_id
     report_id = request.report_id or ""
 
+    children: list[py_trees.behaviour.Behaviour] = [
+        StoreActivityNode(
+            activity_id=activity_id,
+            activity_obj=request.activity,
+            label="AckReport",
+        ),
+        py_trees.composites.Selector(
+            name="MaybeEmitAckToCaseActor",
+            memory=False,
+            children=[
+                EmitAckReportActivity(
+                    offer_id=offer_id,
+                    report_id=report_id,
+                ),
+                py_trees.behaviours.Success(name="NoEmitFallback"),
+            ],
+        ),
+    ]
+
+    if case_id is not None:
+        children.append(
+            create_guarded_commit_case_ledger_entry_tree(case_id=case_id)
+        )
+
     root = py_trees.composites.Sequence(
         name="AckReportReceivedBT",
         memory=False,
-        children=[
-            StoreActivityNode(
-                activity_id=activity_id,
-                activity_obj=request.activity,
-                label="AckReport",
-            ),
-            py_trees.composites.Selector(
-                name="MaybeEmitAckToCaseActor",
-                memory=False,
-                children=[
-                    EmitAckReportActivity(
-                        offer_id=offer_id,
-                        report_id=report_id,
-                    ),
-                    py_trees.behaviours.Success(name="NoEmitFallback"),
-                ],
-            ),
-        ],
+        children=children,
     )
     logger.debug(
-        "Created AckReportReceivedBT for activity=%s",
+        "Created AckReportReceivedBT for activity=%s case=%s",
         activity_id,
+        case_id,
     )
     return root
 

--- a/vultron/core/behaviors/status/add_participant_status_tree.py
+++ b/vultron/core/behaviors/status/add_participant_status_tree.py
@@ -23,11 +23,16 @@ Composes the four-step DEMOMA-07-003 workflow as a Sequence BT
     ├─ VerifySenderIsParticipantNode      # Step 1: sender must be known participant
     ├─ AppendParticipantStatusNode        # Step 2: append status to participant record
     ├─ PublicDisclosureBranchNode         # Step 4: embargo teardown on CS.P + CASE_OWNER
-    └─ AutoCloseIfCaseManager (Selector)  # Step 5: auto-close only when CASE_MANAGER
+    ├─ AutoCloseIfCaseManager (Selector)  # Step 5: auto-close only when CASE_MANAGER
+    │   ├─ Sequence
+    │   │   ├─ CheckIsCaseManagerNode
+    │   │   └─ AutoCloseBranchNode
+    │   └─ Success (skip if not CASE_MANAGER)
+    └─ GuardedCommitOrSkip (Selector, only if case_id)  # ADR-0022 / CLP-10-005
         ├─ Sequence
         │   ├─ CheckIsCaseManagerNode
-        │   └─ AutoCloseBranchNode
-        └─ Success (skip if not CASE_MANAGER)
+        │   └─ CommitCaseLedgerEntryNode
+        └─ Success("CommitSkippedNotCaseManager")
 
 Per specs/multi-actor-demo.yaml DEMOMA-07-003 and DEMOMA-07-005.
 """
@@ -40,6 +45,9 @@ from vultron.core.models.events.status import (
     AddParticipantStatusToParticipantReceivedEvent,
 )
 from vultron.core.behaviors.case.nodes.conditions import CheckIsCaseManagerNode
+from vultron.core.behaviors.case.nodes.lifecycle import (
+    create_guarded_commit_case_ledger_entry_tree,
+)
 from vultron.core.behaviors.status.append_participant_status_tree import (
     append_participant_status_tree,
 )
@@ -54,6 +62,7 @@ logger = logging.getLogger(__name__)
 
 def add_participant_status_tree(
     request: AddParticipantStatusToParticipantReceivedEvent,
+    case_id: str | None = None,
 ) -> py_trees.behaviour.Behaviour:
     """Create the behavior tree for the AddParticipantStatus workflow.
 
@@ -61,16 +70,27 @@ def add_participant_status_tree(
     activity.  Implements the four remaining steps of DEMOMA-07-003 as BT
     nodes in a Sequence (step 3 raw re-broadcast removed per DEMOMA-07-005).
 
-    The *case_id* is derived from the inline ``request.status.context``
-    field.  If it is not available in the inline object, the
-    ``VerifySenderIsParticipantNode`` will perform a DataLayer lookup.
+    When ``case_id`` is provided, a guarded-commit subtree
+    (``create_guarded_commit_case_ledger_entry_tree``) is appended as the
+    final child.  Running the tree with ``actor_id=receiving_actor_id``
+    (ADR-0022 single-BT shape) means ``CheckIsCaseManagerNode`` in that
+    subtree correctly fires only when the receiving actor holds
+    ``CVDRole.CASE_MANAGER``.
 
-    ``PublicDisclosureBranchNode`` uses
-    the ``trigger_activity_factory`` that the caller places on the
-    py_trees blackboard via ``BTBridge(trigger_activity=...)``.
+    The *case_id* for the existing children is derived from the inline
+    ``request.status.context`` field.  If it is not available in the inline
+    object, the ``VerifySenderIsParticipantNode`` will perform a DataLayer
+    lookup.
+
+    ``PublicDisclosureBranchNode`` uses the ``trigger_activity_factory`` that
+    the caller places on the py_trees blackboard via
+    ``BTBridge(trigger_activity=...)``.
 
     Args:
         request: The parsed inbound domain event.
+        case_id: ID of the VulnerabilityCase.  When provided, a guarded-commit
+            subtree is appended so the receiving CaseActor writes a canonical
+            ledger entry (CLP-10-005).  Pass ``None`` to skip the commit.
 
     Returns:
         Root node of the ``AddParticipantStatusBT`` Sequence.
@@ -80,51 +100,58 @@ def add_participant_status_tree(
     actor_id = request.actor_id
     status_obj = request.status
 
-    # Derive case_id from the inline status object when available.
+    # Derive case_id from the inline status object when not supplied explicitly.
     # VerifySenderIsParticipantNode falls back to a DataLayer lookup when None.
-    case_id: str | None = None
-    if status_obj is not None:
+    tree_case_id: str | None = case_id
+    if tree_case_id is None and status_obj is not None:
         context_field = getattr(status_obj, "context", None)
         if context_field:
-            case_id = str(context_field)
+            tree_case_id = str(context_field)
+
+    children: list[py_trees.behaviour.Behaviour] = [
+        VerifySenderIsParticipantNode(
+            status_id=status_id,
+            sender_actor_id=actor_id,
+            case_id=tree_case_id,
+        ),
+        append_participant_status_tree(
+            status_id=status_id,
+            participant_id=participant_id,
+            status_obj_fallback=status_obj,
+        ),
+        PublicDisclosureBranchNode(
+            status_obj=status_obj,
+            sender_actor_id=actor_id,
+            case_id=tree_case_id,
+        ),
+        py_trees.composites.Selector(
+            name="AutoCloseIfCaseManager",
+            memory=False,
+            children=[
+                py_trees.composites.Sequence(
+                    name="CaseManagerAutoClose",
+                    memory=False,
+                    children=[
+                        CheckIsCaseManagerNode(case_id=tree_case_id),
+                        AutoCloseBranchNode(case_id=tree_case_id),
+                    ],
+                ),
+                py_trees.behaviours.Success(
+                    name="AutoCloseSkippedNotCaseManager"
+                ),
+            ],
+        ),
+    ]
+
+    if case_id is not None:
+        children.append(
+            create_guarded_commit_case_ledger_entry_tree(case_id=case_id)
+        )
 
     root = py_trees.composites.Sequence(
         name="AddParticipantStatusBT",
         memory=False,
-        children=[
-            VerifySenderIsParticipantNode(
-                status_id=status_id,
-                sender_actor_id=actor_id,
-                case_id=case_id,
-            ),
-            append_participant_status_tree(
-                status_id=status_id,
-                participant_id=participant_id,
-                status_obj_fallback=status_obj,
-            ),
-            PublicDisclosureBranchNode(
-                status_obj=status_obj,
-                sender_actor_id=actor_id,
-                case_id=case_id,
-            ),
-            py_trees.composites.Selector(
-                name="AutoCloseIfCaseManager",
-                memory=False,
-                children=[
-                    py_trees.composites.Sequence(
-                        name="CaseManagerAutoClose",
-                        memory=False,
-                        children=[
-                            CheckIsCaseManagerNode(case_id=case_id),
-                            AutoCloseBranchNode(case_id=case_id),
-                        ],
-                    ),
-                    py_trees.behaviours.Success(
-                        name="AutoCloseSkippedNotCaseManager"
-                    ),
-                ],
-            ),
-        ],
+        children=children,
     )
     logger.debug(
         "Created AddParticipantStatusBT for status=%s participant=%s"
@@ -132,6 +159,6 @@ def add_participant_status_tree(
         status_id,
         participant_id,
         actor_id,
-        case_id,
+        tree_case_id,
     )
     return root

--- a/vultron/core/use_cases/received/report.py
+++ b/vultron/core/use_cases/received/report.py
@@ -6,9 +6,6 @@ from typing import TYPE_CHECKING
 from py_trees.common import Status
 
 from vultron.core.behaviors.bridge import BTBridge
-from vultron.core.behaviors.case.nodes import (
-    create_guarded_commit_case_ledger_entry_tree,
-)
 from vultron.core.models.events.report import (
     AckReportReceivedEvent,
     CloseReportReceivedEvent,
@@ -18,10 +15,6 @@ from vultron.core.models.events.report import (
     ValidateReportReceivedEvent,
 )
 from vultron.core.ports.case_persistence import CasePersistence
-from vultron.core.use_cases.received.actor import _find_case_actor_id
-from vultron.core.use_cases.received.case import (
-    ValidateCaseUseCase,
-)
 from vultron.errors import VultronValidationError
 
 if TYPE_CHECKING:
@@ -169,11 +162,11 @@ class CreateReportReceivedUseCase:
 
         from vultron.core.behaviors.bridge import BTBridge
         from vultron.core.behaviors.report.received_report_trees import (
-            create_create_report_received_tree,
+            create_report_received_tree,
         )
 
         request = self._request
-        tree = create_create_report_received_tree(request)
+        tree = create_report_received_tree(request)
         bridge = BTBridge(datalayer=self._dl)
         result = bridge.execute_with_setup(
             tree=tree,
@@ -247,7 +240,7 @@ class ValidateReportReceivedUseCase:
 
     def execute(self) -> None:
         request = self._request
-        actor_id = request.actor_id
+        sender_actor_id = request.actor_id
         report_id = request.report_id
         offer_id = request.offer_id
         if report_id is None or offer_id is None:
@@ -255,83 +248,58 @@ class ValidateReportReceivedUseCase:
                 "ValidateReportReceivedEvent requires report_id and offer_id"
             )
 
-        logger.info(
-            "Actor '%s' validates VulnerabilityReport '%s'",
-            actor_id,
-            report_id,
-        )
-
-        ValidateCaseUseCase(
-            dl=self._dl,
-            actor_id=actor_id,
-            report_id=report_id,
-            offer_id=offer_id,
-        ).execute()
-
-        # Per ADR-0021 CLP-10-002, CLP-10-003: guarded commit with pre-flight
-        # guard. Only the CaseActor should commit a canonical ledger entry for
-        # this activity. Non-CaseActors skip the commit entirely.
         receiving_actor_id = request.receiving_actor_id
         if receiving_actor_id is None:
             logger.debug(
                 "ValidateReportReceivedUseCase: receiving_actor_id not set"
-                " — skipping canonical commit (issue #1026)"
+                " — skipping (CLP-10-005)"
             )
             return
 
+        logger.info(
+            "Actor '%s' validates VulnerabilityReport '%s' (receiving='%s')",
+            sender_actor_id,
+            report_id,
+            receiving_actor_id,
+        )
+
+        # Resolve case_id for the guarded-commit subtree (pre-flight lookup,
+        # not domain-significant mutation).
         case = self._dl.find_case_by_report_id(report_id)
-        if case is None:
-            logger.debug(
-                "ValidateReportReceivedUseCase: no case found for report '%s'"
-                " — skipping canonical commit",
-                report_id,
-            )
-            return
-
         case_id = getattr(case, "id_", None)
         if case_id is None:
             logger.debug(
-                "ValidateReportReceivedUseCase: case has no id_"
-                " — skipping canonical commit"
+                "ValidateReportReceivedUseCase: no case found for report '%s'"
+                " — guarded commit will be skipped",
+                report_id,
             )
-            return
 
-        case_actor_id = _find_case_actor_id(self._dl, case_id)
-        if case_actor_id is None:
-            logger.warning(
-                "ValidateReportReceivedUseCase: cannot resolve CaseActor for"
-                " case '%s' — skipping canonical commit",
-                case_id,
-            )
-            return
+        from vultron.core.behaviors.report.received_report_trees import (
+            create_validate_report_received_tree,
+        )
 
-        if receiving_actor_id != case_actor_id:
-            logger.debug(
-                "ValidateReportReceivedUseCase: receiving actor '%s' is not"
-                " the CaseActor for case '%s' — skipping canonical commit"
-                " (CLP-10-003)",
-                receiving_actor_id,
-                case_id,
-            )
-            return
-
+        tree = create_validate_report_received_tree(
+            report_id=report_id,
+            offer_id=offer_id,
+            sender_actor_id=sender_actor_id,
+            case_id=case_id,
+        )
         bridge = BTBridge(
             datalayer=self._dl,
             sync_port=self._sync_port,
         )
-        tree = create_guarded_commit_case_ledger_entry_tree(case_id=case_id)
         result = bridge.execute_with_setup(
             tree=tree,
-            actor_id=case_actor_id,
+            actor_id=receiving_actor_id,
             activity=request,
         )
 
         if result.status != Status.SUCCESS:
             reason = BTBridge.get_failure_reason(tree)
             logger.warning(
-                "ValidateReportReceivedUseCase: guarded commit BT did not"
-                " succeed for case '%s': %s",
-                case_id,
+                "ValidateReportReceivedUseCase: BT did not succeed for"
+                " report '%s': %s",
+                report_id,
                 reason or result.feedback_message or "",
             )
 
@@ -383,26 +351,37 @@ class AckReportReceivedUseCase:
         self._trigger_activity = trigger_activity
 
     def execute(self) -> None:
-        from py_trees.common import Status
+        request = self._request
 
-        from vultron.core.behaviors.bridge import BTBridge
-        from vultron.core.behaviors.case.nodes import (
-            create_guarded_commit_case_ledger_entry_tree,
-        )
+        receiving_actor_id = request.receiving_actor_id
+        if receiving_actor_id is None:
+            logger.debug(
+                "AckReportReceivedUseCase: receiving_actor_id not set"
+                " — skipping (CLP-10-005)"
+            )
+            return
+
+        # Resolve case_id for the guarded-commit subtree.
+        report_id = request.report_id
+        case_id: str | None = None
+        if report_id is not None:
+            case = self._dl.find_case_by_report_id(report_id)
+            case_id = getattr(case, "id_", None)
+
         from vultron.core.behaviors.report.received_report_trees import (
             create_ack_report_received_tree,
         )
 
-        request = self._request
-        tree = create_ack_report_received_tree(request)
+        tree = create_ack_report_received_tree(request, case_id=case_id)
         bridge = BTBridge(
             datalayer=self._dl,
             trigger_activity=self._trigger_activity,
         )
         result = bridge.execute_with_setup(
             tree=tree,
-            actor_id=request.actor_id,
+            actor_id=receiving_actor_id,
             activity=request,
+            sync_port=self._sync_port,
         )
         if result.status != Status.SUCCESS:
             reason = BTBridge.get_failure_reason(tree)
@@ -411,60 +390,6 @@ class AckReportReceivedUseCase:
                 request.activity_id,
                 reason or result.feedback_message or "",
             )
-
-        # Pre-flight guard + guarded commit (ADR-0021, CLP-10-002, CLP-10-003)
-        report_id = request.report_id
-        if report_id is None:
-            logger.debug(
-                "AckReportReceivedUseCase: missing report_id — skipping commit"
-            )
-            return
-
-        case = self._dl.find_case_by_report_id(report_id)
-        if case is None:
-            logger.debug(
-                "AckReportReceivedUseCase: no case found for report '%s'"
-                " — skipping commit",
-                report_id,
-            )
-            return
-
-        case_id = getattr(case, "id_", None)
-        if case_id is None:
-            return
-
-        case_actor_id = _find_case_actor_id(self._dl, case_id)
-        if case_actor_id is None:
-            logger.warning(
-                "AckReportReceivedUseCase: cannot resolve CaseActor for case"
-                " '%s' — skipping commit",
-                case_id,
-            )
-            return
-
-        receiving_actor_id = request.receiving_actor_id
-        if receiving_actor_id is None:
-            logger.debug(
-                "AckReportReceivedUseCase: missing receiving_actor_id"
-                " — skipping commit"
-            )
-            return
-
-        if receiving_actor_id != case_actor_id:
-            logger.debug(
-                "AckReportReceivedUseCase: receiving actor '%s' is not the"
-                " CaseActor for case '%s' — skipping commit (CLP-10-003)",
-                receiving_actor_id,
-                case_id,
-            )
-            return
-
-        BTBridge(datalayer=self._dl).execute_with_setup(
-            tree=create_guarded_commit_case_ledger_entry_tree(case_id=case_id),
-            actor_id=receiving_actor_id,
-            activity=request,
-            sync_port=self._sync_port,
-        )
 
 
 class CloseReportReceivedUseCase:

--- a/vultron/core/use_cases/received/status.py
+++ b/vultron/core/use_cases/received/status.py
@@ -158,29 +158,35 @@ class AddParticipantStatusToParticipantReceivedUseCase:
             )
             return
 
+        receiving_actor_id = request.receiving_actor_id
+        if receiving_actor_id is None:
+            logger.debug(
+                "AddParticipantStatusToParticipantReceivedUseCase:"
+                " receiving_actor_id not set — skipping (CLP-10-005)"
+            )
+            return
+
         from vultron.core.behaviors.bridge import BTBridge
         from vultron.core.behaviors.status.add_participant_status_tree import (
             add_participant_status_tree,
         )
 
+        # Resolve case_id for the guarded-commit subtree (pre-flight lookup).
+        case_id = self._resolve_case_id_for_log_cascade()
+
         tree = add_participant_status_tree(
             request=request,
+            case_id=case_id,
         )
         bridge = BTBridge(
             datalayer=self._dl,
             trigger_activity=self._trigger_activity,
         )
-        # Use receiving_actor_id (the Case Actor) as the blackboard actor_id
-        # so that CheckIsCaseManagerNode in step 5 correctly identifies the
-        # executing actor as CASE_MANAGER.  Sender identity is captured via
-        # constructor args on VerifySenderIsParticipantNode and
-        # PublicDisclosureBranchNode — neither reads actor_id from the
-        # blackboard.
-        bt_actor_id = request.receiving_actor_id or request.actor_id
         result = bridge.execute_with_setup(
             tree=tree,
-            actor_id=bt_actor_id,
+            actor_id=receiving_actor_id,
             activity=request,
+            sync_port=self._sync_port,
         )
 
         if result.status != Status.SUCCESS:
@@ -190,15 +196,6 @@ class AddParticipantStatusToParticipantReceivedUseCase:
                 request.activity_id,
                 reason or result.feedback_message,
             )
-            # Do NOT cascade on BT failure here.  Unlike RemoveEmbargo (where
-            # FAILURE means "already cleared" — an idempotent, non-error
-            # outcome), a status-update BT failure means the update itself was
-            # rejected (e.g., participant not found, invalid state transition).
-            # Broadcasting a log entry for a rejected update would mislead
-            # peers into believing the status was accepted.
-            return
-
-        self._commit_log_cascade_bt()
 
     def _resolve_case_id_for_log_cascade(self) -> str | None:
         request = self._request
@@ -218,63 +215,3 @@ class AddParticipantStatusToParticipantReceivedUseCase:
                 if context:
                     return str(context)
         return None
-
-    def _commit_log_cascade_bt(self) -> None:
-        """Commit a CaseLedgerEntry via the guarded commit subtree.
-
-        Derives ``case_id`` from the inline status object's ``context`` field,
-        resolves the CaseActor ID for that case, and executes the guarded
-        canonical-commit subtree as that actor.
-        """
-        from vultron.core.behaviors.bridge import BTBridge
-        from vultron.core.behaviors.case.nodes import (
-            create_guarded_commit_case_ledger_entry_tree,
-        )
-        from vultron.core.use_cases.received.actor import _find_case_actor_id
-
-        request = self._request
-        case_id = self._resolve_case_id_for_log_cascade()
-        if case_id is None:
-            logger.warning(
-                "add_participant_status: cannot determine case_id"
-                " — skipping log entry cascade (PCR-08-003)"
-            )
-            return
-
-        case_actor_id = _find_case_actor_id(self._dl, case_id)
-        if case_actor_id is None:
-            logger.warning(
-                "add_participant_status: cannot resolve CaseActor for case '%s'"
-                " — skipping log entry cascade (PCR-08-003)",
-                case_id,
-            )
-            return
-
-        # Guard: only the CaseActor receiver may commit a canonical log entry.
-        # This preserves the semantics of the removed _is_case_actor_receiver
-        # check — the in-tree CASE_MANAGER gate alone is insufficient because
-        # actor_id is always case_actor_id here regardless of who received the
-        # message.
-        receiving_actor_id = request.receiving_actor_id
-        if receiving_actor_id is None:
-            logger.warning(
-                "add_participant_status: missing receiving_actor_id for case '%s'"
-                " — skipping canonical commit to avoid non-CaseActor append",
-                case_id,
-            )
-            return
-        if receiving_actor_id != case_actor_id:
-            logger.debug(
-                "add_participant_status: receiving actor '%s' is not the"
-                " CaseActor for case '%s' — skipping canonical commit",
-                receiving_actor_id,
-                case_id,
-            )
-            return
-
-        BTBridge(datalayer=self._dl).execute_with_setup(
-            tree=create_guarded_commit_case_ledger_entry_tree(case_id=case_id),
-            actor_id=case_actor_id,
-            activity=request,
-            sync_port=self._sync_port,
-        )


### PR DESCRIPTION
- Closes #1051

## Summary

Migrates three received-side use cases to the ADR-0022 single-BT-execution
pattern: one `execute_with_setup()` call per inbox delivery under
`actor_id=receiving_actor_id`, with the guarded-commit subtree embedded
in the tree factory. Removes `report.py` and `status.py` from the
architecture-test `KNOWN_VIOLATIONS` ratchet.

## Changes

**Use case layer:**
- `received/report.py` — `ValidateReportReceivedUseCase` and
  `AckReportReceivedUseCase`: removed separate guarded-commit
  `execute_with_setup()` calls, removed `ValidateCaseUseCase` and
  `_find_case_actor_id` imports, removed module-level
  `create_guarded_commit_case_ledger_entry_tree` import.
- `received/status.py` — `AddParticipantStatusToParticipantReceivedUseCase`:
  removed `_commit_log_cascade_bt()` helper, single tree call with
  `case_id` forwarded to the tree factory.

**Behavior tree factories:**
- `received_report_trees.py`: new `create_validate_report_received_tree()`
  with `sender_actor_id` threading; `create_ack_report_received_tree()`
  now accepts `case_id`; `create_create_report_received_tree` renamed to
  `create_report_received_tree`.
- `add_participant_status_tree.py`: added `case_id` param and optional
  guarded-commit child.

**Nodes:**
- `conditions.py`, `rm_transitions.py`: added `sender_actor_id` param to
  allow BT to run under `receiving_actor_id` while transitioning the
  *sender's* RM state (ADR-0022 core mechanism).

**Architecture ratchet:**
- `test_single_bt_execution_received_side.py`: removed `report.py` and
  `status.py` from `KNOWN_VIOLATIONS`.

**Tests:**
- Updated fixtures to pass `receiving_actor_id` (required by new guard).
- Updated `TestValidateReportReceivedGuardedCommit` assertions to match
  in-tree `CheckIsCaseManagerNode` gating (no Python-level guard log).
- Added `test_sender_rm_state_transitions_to_valid` to verify
  `sender_actor_id` threading correctness.

## Verification

```
uv run pytest --tb=short 2>&1 | tail -3
# 3437 passed, 37 skipped, 225 deselected, 2 xfailed, 5633 subtests passed
```
All four linters pass: Black, flake8, mypy, pyright.