### PR TITLE
refactor: migrate AddNoteToCase, CloseCase, OfferCaseManagerRole to single-BT pattern (ADR-0022, #1052)

### DIFF
--- a/plan/history/2606/implementation/ISSUE-1052.md
+++ b/plan/history/2606/implementation/ISSUE-1052.md
@@ -1,0 +1,37 @@
+---
+source: ISSUE-1052
+timestamp: '2026-06-19T03:36:49.675682+00:00'
+title: Migrate AddNoteToCase, CloseCase, OfferCaseManagerRole to single-BT pattern
+type: implementation
+---
+
+## Issue \#1052 — Single-BT migration: AddNoteToCase, CloseCase, OfferCaseManagerRole
+
+Migrated three received-side use cases to the ADR-0022 "single-BT execution per
+inbox delivery" pattern, completing the ratchet started in #1050 (embargo) and
+\#1051 (report/status). `KNOWN_VIOLATIONS` is now `frozenset()`.
+
+**Architecture fix:** `AddNoteToCaseReceivedUseCase` previously called
+`_broadcast_note_to_participants` which emitted `AddNoteToCase` directly from
+the CaseActor to participants — a violation of `notes/case-communication-model.md`.
+The broadcast is removed; `Announce(CaseLedgerEntry)` fan-out via `sync_port`
+is the correct notification mechanism (SYNC-02-002).
+
+**New tree factories:**
+
+- `create_add_note_to_case_received_tree()`: `AttachNoteToCaseNode` + guarded commit
+- `create_close_case_received_tree()`: `StoreActivityNode(Leave)` + guarded commit
+- `create_offer_case_manager_role_received_tree()`: `StoreActivityNode` +
+  `AutoAcceptOrSkip` Selector + conditional guarded commit
+
+**New BT node:** `AutoAcceptCaseManagerRoleNode` calls
+`trigger_activity_factory.accept_case_manager_role()` + `record_outbox_item()`.
+
+**Port factory:** Moved `ADD_NOTE_TO_CASE` from `_SYNC_AND_TRIGGER_PORT_SEMANTICS`
+to `_SYNC_PORT_SEMANTICS` (no longer needs `trigger_activity`).
+
+**Tests:** Cleared `KNOWN_VIOLATIONS`, removed 3 architecture-violating broadcast
+tests, updated all callers to remove `trigger_activity` arg and add
+`receiving_actor_id` where required. 3434 tests pass.
+
+PR: [#1066](https://github.com/CERTCC/Vultron/pull/1066)

--- a/test/architecture/test_single_bt_execution_received_side.py
+++ b/test/architecture/test_single_bt_execution_received_side.py
@@ -95,13 +95,7 @@ def _collect_violations() -> frozenset[str]:
 # `execute_with_setup()` call with the guarded commit composed as a child
 # subtree of the use case's own tree-factory function.
 # ---------------------------------------------------------------------------
-KNOWN_VIOLATIONS: frozenset[str] = frozenset(
-    {
-        "vultron/core/use_cases/received/note.py",
-        "vultron/core/use_cases/received/case/lifecycle.py",
-        "vultron/core/use_cases/received/actor/case_manager_role.py",
-    }
-)
+KNOWN_VIOLATIONS: frozenset[str] = frozenset()
 
 
 def test_received_use_cases_do_not_dispatch_guarded_commit_directly():

--- a/test/core/behaviors/sync/test_announce_tree.py
+++ b/test/core/behaviors/sync/test_announce_tree.py
@@ -266,3 +266,94 @@ class TestAnnounceLogEntryAppliesEmbargoTeardown:
         updated = datalayer.read(CASE_ID)
         assert updated is not None
         assert updated.current_status.em_state == EM.EXITED
+
+
+NOTE_ID = "https://example.org/notes/test-note-1"
+
+
+def _make_add_note_entry(
+    log_index: int, prev_hash: str = _ZERO_HASH
+) -> VultronCaseLedgerEntry:
+    """Create a ledger entry with event_type='add_note_to_case'."""
+    return _to_persistable_entry(
+        HashChainLedgerRecord(
+            case_id=CASE_ID,
+            log_index=log_index,
+            object_id=f"https://example.org/activities/add-note-{log_index}",
+            event_type="add_note_to_case",
+            payload_snapshot={"object": NOTE_ID},
+            prev_log_hash=prev_hash,
+        )
+    )
+
+
+class TestAnnounceLogEntryAppliesNoteAttachment:
+    """Participant receiving add_note_to_case ledger entry attaches note."""
+
+    def test_participant_attaches_note_on_add_note_entry(
+        self, bridge, datalayer, case_actor, case_obj
+    ):
+        """BT attaches note ID to case replica when entry is add_note_to_case.
+
+        A non-CaseActor participant must learn about note additions exclusively
+        via Announce(CaseLedgerEntry) fan-out (SYNC-02-002, ADR-0022).
+        """
+        entry = _make_add_note_entry(0, case_obj.genesis_hash)
+        event = _make_event(entry, actor_id=case_actor.id_)
+
+        result = bridge.execute_with_setup(
+            tree=create_announce_log_entry_tree(),
+            actor_id=PARTICIPANT_ACTOR_ID,
+            activity=event,
+            sync_port=MagicMock(spec=SyncActivityPort),
+        )
+
+        assert result.status == Status.SUCCESS
+        updated = datalayer.read(CASE_ID)
+        assert updated is not None
+        assert NOTE_ID in updated.notes
+
+    def test_note_attachment_is_idempotent(
+        self, bridge, datalayer, case_actor, case_obj
+    ):
+        """Running BT twice with same note entry attaches note exactly once."""
+        case_obj.notes.append(NOTE_ID)
+        datalayer.save(case_obj)
+
+        entry = _make_add_note_entry(0, case_obj.genesis_hash)
+        # Pre-store entry so second run takes the already-stored path.
+        datalayer.save(entry)
+        event = _make_event(entry, actor_id=case_actor.id_)
+
+        result = bridge.execute_with_setup(
+            tree=create_announce_log_entry_tree(),
+            actor_id=PARTICIPANT_ACTOR_ID,
+            activity=event,
+            sync_port=MagicMock(spec=SyncActivityPort),
+        )
+
+        assert result.status == Status.SUCCESS
+        updated = datalayer.read(CASE_ID)
+        assert updated is not None
+        assert updated.notes.count(NOTE_ID) == 1
+
+    def test_note_not_attached_for_non_note_entry(
+        self, bridge, datalayer, case_actor, case_obj
+    ):
+        """NoteEffects Selector short-circuits for unrelated event types."""
+        entry = _make_entry(
+            0, case_obj.genesis_hash
+        )  # event_type="test_event"
+        event = _make_event(entry, actor_id=case_actor.id_)
+
+        result = bridge.execute_with_setup(
+            tree=create_announce_log_entry_tree(),
+            actor_id=PARTICIPANT_ACTOR_ID,
+            activity=event,
+            sync_port=MagicMock(spec=SyncActivityPort),
+        )
+
+        assert result.status == Status.SUCCESS
+        updated = datalayer.read(CASE_ID)
+        assert updated is not None
+        assert updated.notes == []

--- a/test/core/use_cases/received/actor/test_case_manager_role.py
+++ b/test/core/use_cases/received/actor/test_case_manager_role.py
@@ -66,7 +66,7 @@ class TestCaseManagerRoleDelegationUseCases:
 
         dl = SqliteDataLayer("sqlite:///:memory:")
         offer = self._make_offer()
-        event = make_payload(offer)
+        event = make_payload(offer, receiving_actor_id=self._CASE_ACTOR_URI)
 
         OfferCaseManagerRoleReceivedUseCase(dl, event).execute()
 
@@ -79,7 +79,7 @@ class TestCaseManagerRoleDelegationUseCases:
 
         dl = SqliteDataLayer("sqlite:///:memory:")
         offer = self._make_offer()
-        event = make_payload(offer)
+        event = make_payload(offer, receiving_actor_id=self._CASE_ACTOR_URI)
 
         OfferCaseManagerRoleReceivedUseCase(dl, event).execute()
         OfferCaseManagerRoleReceivedUseCase(dl, event).execute()
@@ -138,28 +138,22 @@ class TestCaseManagerRoleDelegationUseCases:
         self, make_payload
     ):
         """OfferCaseManagerRoleReceivedUseCase auto-accepts when trigger_activity provided."""
-        from unittest.mock import MagicMock, patch
+        from unittest.mock import MagicMock
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
-        from vultron.wire.as2.vocab.base.objects.actors import as_Organization
 
         dl = SqliteDataLayer("sqlite:///:memory:")
-        local_actor = as_Organization(id_=self._CASE_ACTOR_URI)
-        dl.create(local_actor)
 
         offer = self._make_offer()
-        event = make_payload(offer)
+        event = make_payload(offer, receiving_actor_id=self._CASE_ACTOR_URI)
 
         trigger = MagicMock()
         trigger.accept_case_manager_role.return_value = (
             "https://example.org/activities/accept-1"
         )
 
-        with patch(
-            "vultron.core.use_cases.triggers._helpers.add_activity_to_outbox"
-        ):
-            OfferCaseManagerRoleReceivedUseCase(
-                dl, event, trigger_activity=trigger
-            ).execute()
+        OfferCaseManagerRoleReceivedUseCase(
+            dl, event, trigger_activity=trigger
+        ).execute()
 
         trigger.accept_case_manager_role.assert_called_once()
         call_kwargs = trigger.accept_case_manager_role.call_args
@@ -174,7 +168,7 @@ class TestCaseManagerRoleDelegationUseCases:
 
         dl = SqliteDataLayer("sqlite:///:memory:")
         offer = self._make_offer()
-        event = make_payload(offer)
+        event = make_payload(offer, receiving_actor_id=self._CASE_ACTOR_URI)
 
         # No trigger_activity — should not raise
         OfferCaseManagerRoleReceivedUseCase(dl, event).execute()

--- a/test/core/use_cases/received/test_note.py
+++ b/test/core/use_cases/received/test_note.py
@@ -136,18 +136,50 @@ class TestNoteUseCases:
         refreshed = cast(VulnerabilityCase, refreshed)
         assert refreshed.notes.count(note_id) == 1
 
-    def test_add_note_to_case_appends_note(self, monkeypatch, make_payload):
-        """add_note_to_case appends note ID to case.notes and persists."""
-        dl = SqliteDataLayer("sqlite:///:memory:")
+    def _setup_case_with_case_manager(
+        self, dl: "SqliteDataLayer", case_id: str, case_actor_id: str
+    ) -> "VulnerabilityCase":
+        """Create a VulnerabilityCase with a CaseActor holding CASE_MANAGER."""
+        from vultron.core.states.roles import CVDRole
+        from vultron.wire.as2.vocab.objects.case_participant import (
+            CaseParticipant,
+        )
+
+        case_actor = VultronCaseActor(
+            id_=case_actor_id,
+            name="CaseActor",
+            attributed_to="https://example.org/users/vendor",
+            context=case_id,
+        )
+        dl.create(case_actor)
+
         case = VulnerabilityCase(
-            id_="https://example.org/cases/case_n1",
+            id_=case_id,
             name="Note Case",
         )
+        case_mgr_participant = CaseParticipant(
+            id_=f"{case_id}/participants/case-actor-p",
+            attributed_to=case_actor_id,
+            context=case_id,
+            case_roles=[CVDRole.CASE_MANAGER],
+        )
+        dl.create(case_mgr_participant)
+        case.case_participants.append(case_mgr_participant.id_)
+        case.actor_participant_index[case_actor_id] = case_mgr_participant.id_
+        dl.create(case)
+        return case
+
+    def test_add_note_to_case_appends_note(self, monkeypatch, make_payload):
+        """CaseActor appends note ID to case.notes on Add(Note, Case)."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case_actor_id = "https://example.org/cases/case_n1/actor"
+        case_id = "https://example.org/cases/case_n1"
+        case = self._setup_case_with_case_manager(dl, case_id, case_actor_id)
+
         note = as_Note(
             id_="https://example.org/notes/note3",
             content="A note",
         )
-        dl.create(case)
         dl.create(note)
 
         activity = add_note_to_case_activity(
@@ -155,27 +187,64 @@ class TestNoteUseCases:
         )
         event = make_payload(
             activity,
-            receiving_actor_id="https://example.org/actors/receiver",
+            receiving_actor_id=case_actor_id,
         )
 
         AddNoteToCaseReceivedUseCase(dl, event).execute()
 
-        case = dl.read(case.id_)
-        assert case is not None
-        case = cast(VulnerabilityCase, case)
-        assert note.id_ in case.notes
+        refreshed = dl.read(case_id)
+        assert refreshed is not None
+        refreshed = cast(VulnerabilityCase, refreshed)
+        assert note.id_ in refreshed.notes
 
     def test_add_note_to_case_idempotent(self, monkeypatch, make_payload):
-        """add_note_to_case skips adding a note already in the case."""
+        """CaseActor skips adding a note already in the case (idempotent)."""
         dl = SqliteDataLayer("sqlite:///:memory:")
+        case_actor_id = "https://example.org/cases/case_n2/actor"
+        case_id = "https://example.org/cases/case_n2"
         note = as_Note(
             id_="https://example.org/notes/note4",
             content="A note",
         )
+        dl.create(note)
+        case = self._setup_case_with_case_manager(dl, case_id, case_actor_id)
+        # Pre-populate note into case to exercise idempotent path
+        case.notes.append(note.id_)
+        dl.save(case)
+
+        activity = add_note_to_case_activity(
+            note, target=case, actor="https://example.org/users/finder"
+        )
+        event = make_payload(
+            activity,
+            receiving_actor_id=case_actor_id,
+        )
+
+        AddNoteToCaseReceivedUseCase(dl, event).execute()
+
+        refreshed = dl.read(case_id)
+        assert refreshed is not None
+        refreshed = cast(VulnerabilityCase, refreshed)
+        assert refreshed.notes.count(note.id_) == 1
+
+    def test_add_note_noop_for_non_case_manager(
+        self, monkeypatch, make_payload
+    ):
+        """Non-CaseActor receiving Add(Note, Case) must not update case replica.
+
+        Case replica updates arrive exclusively via Announce(CaseLedgerEntry)
+        fan-out (SYNC-02-002). The BT CheckIsCaseManagerNode guard ensures
+        the non-CaseActor takes the Success fallback and skips both attach
+        and commit.
+        """
+        dl = SqliteDataLayer("sqlite:///:memory:")
         case = VulnerabilityCase(
-            id_="https://example.org/cases/case_n2",
-            name="Note Case Idempotent",
-            notes=[note.id_],
+            id_="https://example.org/cases/case_n3_noop",
+            name="Noop Case",
+        )
+        note = as_Note(
+            id_="https://example.org/notes/note_noop",
+            content="A note",
         )
         dl.create(case)
         dl.create(note)
@@ -183,14 +252,18 @@ class TestNoteUseCases:
         activity = add_note_to_case_activity(
             note, target=case, actor="https://example.org/users/finder"
         )
+        # Non-CaseActor: no CASE_MANAGER participant registered
         event = make_payload(
             activity,
-            receiving_actor_id="https://example.org/actors/receiver",
+            receiving_actor_id="https://example.org/actors/non-manager",
         )
 
         AddNoteToCaseReceivedUseCase(dl, event).execute()
 
-        assert case.notes.count(note.id_) == 1
+        refreshed = dl.read(case.id_)
+        assert refreshed is not None
+        refreshed = cast(VulnerabilityCase, refreshed)
+        assert note.id_ not in refreshed.notes
 
     def test_remove_note_from_case_removes_note(
         self, monkeypatch, make_payload

--- a/test/core/use_cases/received/test_note.py
+++ b/test/core/use_cases/received/test_note.py
@@ -12,17 +12,13 @@
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 """Tests for note-related use-case classes."""
 
-from typing import Any, cast
+from typing import cast
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.adapters.driven.sync_activity_adapter import SyncActivityAdapter
-from vultron.adapters.driven.trigger_activity_adapter import (
-    TriggerActivityAdapter,
-)
 from vultron.core.models.case_actor import VultronCaseActor
 from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
 from vultron.core.models.protocols import is_log_entry_model
-from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.use_cases.received.note import (
     AddNoteToCaseReceivedUseCase,
     CreateNoteReceivedUseCase,
@@ -157,7 +153,10 @@ class TestNoteUseCases:
         activity = add_note_to_case_activity(
             note, target=case, actor="https://example.org/users/finder"
         )
-        event = make_payload(activity)
+        event = make_payload(
+            activity,
+            receiving_actor_id="https://example.org/actors/receiver",
+        )
 
         AddNoteToCaseReceivedUseCase(dl, event).execute()
 
@@ -184,7 +183,10 @@ class TestNoteUseCases:
         activity = add_note_to_case_activity(
             note, target=case, actor="https://example.org/users/finder"
         )
-        event = make_payload(activity)
+        event = make_payload(
+            activity,
+            receiving_actor_id="https://example.org/actors/receiver",
+        )
 
         AddNoteToCaseReceivedUseCase(dl, event).execute()
 
@@ -244,178 +246,6 @@ class TestNoteUseCases:
 
         result = RemoveNoteFromCaseReceivedUseCase(dl, event).execute()
         assert result is None
-
-    # ------------------------------------------------------------------
-    # Broadcast tests (CM-06-005)
-    # ------------------------------------------------------------------
-
-    def test_add_note_broadcasts_to_participants(self, make_payload):
-        """add_note_to_case broadcasts AddNoteToCase to all participants.
-
-        After a note is added to a case, the CaseActor should enqueue an
-        AddNoteToCaseActivity for delivery to all participants that are not
-        the note author (CM-06-005).
-        """
-        dl = SqliteDataLayer("sqlite:///:memory:")
-        author_id = "https://example.org/users/vendor"
-        participant_id = "https://example.org/users/finder"
-        case_id = "https://example.org/cases/case_nb1"
-
-        case_actor = VultronCaseActor(
-            id_=f"{case_id}/actor",
-            name=f"CaseActor for {case_id}",
-            attributed_to=author_id,
-            context=case_id,
-        )
-        dl.create(case_actor)
-
-        case = VulnerabilityCase(
-            id_=case_id,
-            name="Broadcast Note Case",
-            attributed_to=author_id,
-        )
-        case.actor_participant_index[author_id] = (
-            "https://example.org/participants/p-nb1-vendor"
-        )
-        case.actor_participant_index[participant_id] = (
-            "https://example.org/participants/p-nb1-finder"
-        )
-        dl.create(case)
-
-        note = as_Note(
-            id_="https://example.org/notes/note_bc1",
-            content="Broadcast note",
-            context=case_id,
-        )
-        dl.create(note)
-
-        activity = add_note_to_case_activity(
-            note, target=case, actor=author_id
-        )
-        event = make_payload(activity)
-
-        AddNoteToCaseReceivedUseCase(
-            dl,
-            event,
-            trigger_activity=TriggerActivityAdapter(
-                cast(CaseOutboxPersistence, dl)
-            ),
-        ).execute()
-
-        # CaseActor outbox should contain the broadcast activity.
-        queued_ids = dl.clone_for_actor(case_actor.id_).outbox_list()
-        assert len(queued_ids) == 1
-
-        broadcast_id = queued_ids[0]
-        broadcast = dl.read(broadcast_id)
-        assert broadcast is not None
-        broadcast = cast(Any, broadcast)
-        assert broadcast.actor == case_actor.id_
-        assert broadcast.to is not None
-        assert participant_id in broadcast.to
-
-        # Verify the broadcast is enqueued for delivery by outbox_handler.
-        scoped_dl = SqliteDataLayer(
-            "sqlite:///:memory:", actor_id=case_actor.id_
-        )
-        scoped_dl._engine.dispose()
-        scoped_dl._engine = dl._engine
-        scoped_dl._owns_engine = False
-        queued_ids = scoped_dl.outbox_list()
-        assert broadcast_id in queued_ids
-
-    def test_add_note_broadcast_excludes_author(self, make_payload):
-        """The note author is excluded from broadcast recipients (CM-06-005)."""
-        dl = SqliteDataLayer("sqlite:///:memory:")
-        author_id = "https://example.org/users/vendor"
-        participant_id = "https://example.org/users/finder"
-        case_id = "https://example.org/cases/case_nb2"
-
-        case_actor = VultronCaseActor(
-            id_=f"{case_id}/actor",
-            name=f"CaseActor for {case_id}",
-            attributed_to=author_id,
-            context=case_id,
-        )
-        dl.create(case_actor)
-
-        case = VulnerabilityCase(
-            id_=case_id,
-            name="Exclude Author Case",
-            attributed_to=author_id,
-        )
-        case.actor_participant_index[author_id] = (
-            "https://example.org/participants/p-nb2-vendor"
-        )
-        case.actor_participant_index[participant_id] = (
-            "https://example.org/participants/p-nb2-finder"
-        )
-        dl.create(case)
-
-        note = as_Note(
-            id_="https://example.org/notes/note_bc2",
-            content="Author excluded note",
-            context=case_id,
-        )
-        dl.create(note)
-
-        activity = add_note_to_case_activity(
-            note, target=case, actor=author_id
-        )
-        event = make_payload(activity)
-
-        AddNoteToCaseReceivedUseCase(
-            dl,
-            event,
-            trigger_activity=TriggerActivityAdapter(
-                cast(CaseOutboxPersistence, dl)
-            ),
-        ).execute()
-
-        queued_ids = dl.clone_for_actor(case_actor.id_).outbox_list()
-        assert len(queued_ids) == 1
-
-        broadcast_id = queued_ids[0]
-        broadcast = dl.read(broadcast_id)
-        assert broadcast is not None
-        broadcast = cast(Any, broadcast)
-        assert broadcast.to is not None
-        assert author_id not in broadcast.to
-        assert participant_id in broadcast.to
-
-    def test_add_note_no_broadcast_when_no_case_actor(self, make_payload):
-        """Broadcast is skipped gracefully when no CaseActor exists (CM-06-005)."""
-        dl = SqliteDataLayer("sqlite:///:memory:")
-        author_id = "https://example.org/users/vendor"
-        case_id = "https://example.org/cases/case_nb3"
-
-        case = VulnerabilityCase(
-            id_=case_id,
-            name="No CaseActor Case",
-            attributed_to=author_id,
-        )
-        dl.create(case)
-
-        note = as_Note(
-            id_="https://example.org/notes/note_bc3",
-            content="No broadcast note",
-            context=case_id,
-        )
-        dl.create(note)
-
-        activity = add_note_to_case_activity(
-            note, target=case, actor=author_id
-        )
-        event = make_payload(activity)
-
-        # Should not raise; broadcast is silently skipped.
-        AddNoteToCaseReceivedUseCase(dl, event).execute()
-
-        # Note should still be added to the case.
-        refreshed = dl.read(case_id)
-        assert refreshed is not None
-        refreshed = cast(VulnerabilityCase, refreshed)
-        assert note.id_ in refreshed.notes
 
     # ------------------------------------------------------------------
     # CaseLedgerEntry cascade tests (PCR-08-003, PCR-08-004) — AC-1

--- a/test/core/use_cases/received/test_note_routing_guard.py
+++ b/test/core/use_cases/received/test_note_routing_guard.py
@@ -25,9 +25,6 @@ import pytest
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.adapters.driven.sync_activity_adapter import SyncActivityAdapter
-from vultron.adapters.driven.trigger_activity_adapter import (
-    TriggerActivityAdapter,
-)
 from vultron.core.models.case_actor import VultronCaseActor
 from vultron.core.states.roles import CVDRole
 from vultron.core.use_cases.received.note import AddNoteToCaseReceivedUseCase
@@ -136,7 +133,6 @@ class TestAddNoteToCaseLedgerRouting:
             dl=dl,
             request=event,
             sync_port=SyncActivityAdapter(dl),
-            trigger_activity=TriggerActivityAdapter(dl),
         ).execute()
 
         event_types = _ledger_event_types(dl)
@@ -167,7 +163,6 @@ class TestAddNoteToCaseLedgerRouting:
             dl=dl,
             request=event,
             sync_port=SyncActivityAdapter(dl),
-            trigger_activity=TriggerActivityAdapter(dl),
         ).execute()
 
         event_types = _ledger_event_types(dl)
@@ -202,7 +197,6 @@ class TestAddNoteToCaseLedgerRouting:
             dl=dl,
             request=event,
             sync_port=SyncActivityAdapter(dl),
-            trigger_activity=TriggerActivityAdapter(dl),
         ).execute()
 
         event_types = _ledger_event_types(dl)

--- a/test/demo/test_pcr_bootstrap.py
+++ b/test/demo/test_pcr_bootstrap.py
@@ -468,19 +468,24 @@ class TestBootstrapSequence:
             f"Activity was incorrectly deferred (PCR-07-006 AC-2)."
         )
 
-        # Assert 2: The note ID must appear in the replica's notes list,
-        # confirming AddNoteToCaseReceivedUseCase ran to completion.
+        # Assert 2: Non-CaseActors must NOT attach the note to their replica.
+        # In the new protocol model (ADR-0022), note attachment is gated by
+        # CheckIsCaseManagerNode — only the CaseActor attaches the note to its
+        # case replica.  Non-CaseActor participants receive the note update
+        # exclusively via Announce(CaseLedgerEntry) fan-out from the CaseActor
+        # (SYNC-02-002).  The BT still returns SUCCESS (via the fallback path),
+        # so the handler ran to completion — demonstrated by Assert 3 below.
         replica = participant_iso.dl.read(_DIRECT_CASE_ID)
         assert replica is not None
         replica_note_ids = [
             getattr(n, "id_", n) if not isinstance(n, str) else n
             for n in getattr(replica, "notes", [])
         ]
-        assert note.id_ in replica_note_ids, (
-            f"Note '{note.id_}' not found in case replica notes "
-            f"after Add(Note) was dispatched. "
-            f"AddNoteToCaseReceivedUseCase may not have run "
-            f"(PCR-07-006 AC-2). Replica notes: {replica_note_ids!r}"
+        assert note.id_ not in replica_note_ids, (
+            f"Note '{note.id_}' was unexpectedly attached to a non-CaseActor "
+            f"case replica. Non-CaseActors must not update replica notes "
+            f"directly from Add(Note, Case) messages (SYNC-02-002, ADR-0022). "
+            f"Replica notes: {replica_note_ids!r}"
         )
 
         # Assert 3: The actor's inbox queue must be drained, confirming

--- a/vultron/adapters/driving/fastapi/inbox_port_factories.py
+++ b/vultron/adapters/driving/fastapi/inbox_port_factories.py
@@ -79,6 +79,7 @@ _SYNC_PORT_SEMANTICS = frozenset(
         MessageSemantics.ADD_EMBARGO_EVENT_TO_CASE,
         MessageSemantics.ACCEPT_INVITE_TO_EMBARGO_ON_CASE,
         MessageSemantics.ANNOUNCE_CASE_LEDGER_ENTRY,
+        MessageSemantics.ADD_NOTE_TO_CASE,
         MessageSemantics.CLOSE_CASE,
         MessageSemantics.INVITE_TO_EMBARGO_ON_CASE,
         MessageSemantics.REJECT_CASE_LEDGER_ENTRY,
@@ -104,7 +105,6 @@ _TRIGGER_ACTIVITY_PORT_SEMANTICS = frozenset(
 _SYNC_AND_TRIGGER_PORT_SEMANTICS = frozenset(
     {
         MessageSemantics.ACK_REPORT,
-        MessageSemantics.ADD_NOTE_TO_CASE,
         MessageSemantics.ADD_PARTICIPANT_STATUS_TO_PARTICIPANT,
         MessageSemantics.ACCEPT_INVITE_ACTOR_TO_CASE,
         MessageSemantics.DEFER_CASE,

--- a/vultron/core/behaviors/case/nodes/__init__.py
+++ b/vultron/core/behaviors/case/nodes/__init__.py
@@ -58,6 +58,7 @@ from vultron.core.behaviors.case.nodes.case_setup import (
     SetCaseAttributedTo,
 )
 from vultron.core.behaviors.case.nodes.communication import (
+    AutoAcceptCaseManagerRoleNode,
     CollectCaseAddresseesNode,
     CreateAndPersistCaseActivityNode,
     CreateOfferCaseManagerActivityNode,
@@ -126,6 +127,7 @@ __all__ = [
     # embargo_tree (composite subtree — lazy via __getattr__)
     "InitializeDefaultEmbargoNode",
     # communication (leaf nodes)
+    "AutoAcceptCaseManagerRoleNode",
     "CollectCaseAddresseesNode",
     "CreateAndPersistCaseActivityNode",
     "CreateOfferCaseManagerActivityNode",

--- a/vultron/core/behaviors/case/nodes/communication.py
+++ b/vultron/core/behaviors/case/nodes/communication.py
@@ -16,8 +16,8 @@
 """
 Communication action nodes for case behavior trees.
 
-Provides action nodes that emit outbound activities related to case creation
-and case-manager role offers.
+Provides action nodes that emit outbound activities related to case creation,
+case-manager role offers, and case-manager role auto-acceptance.
 
 Composite subtrees assembling these leaf nodes are defined in the sibling
 ``communication_tree.py`` module at the process-area root per BTND-07-003:
@@ -27,7 +27,7 @@ Composite subtrees assembling these leaf nodes are defined in the sibling
 """
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 import py_trees
 from py_trees.common import Status
@@ -35,6 +35,7 @@ from py_trees.common import Status
 from vultron.core.behaviors.helpers import DataLayerAction
 from vultron.core.models.protocols import is_case_model
 from vultron.core.models.vultron_types import VultronCreateCaseActivity
+from vultron.core.ports.case_persistence import CaseOutboxPersistence
 
 logger = logging.getLogger(__name__)
 
@@ -310,5 +311,101 @@ class CreateOfferCaseManagerActivityNode(DataLayerAction):
         except Exception as e:
             self.logger.error(
                 f"{self.name}: Error sending Offer(CaseManagerRole): {e}"
+            )
+            return Status.FAILURE
+
+
+class AutoAcceptCaseManagerRoleNode(DataLayerAction):
+    """Auto-accept a CASE_MANAGER role delegation offer on behalf of the local actor.
+
+    When the local actor (the Case Actor entity) receives an
+    ``Offer(CaseManagerRole)`` it MUST auto-accept so the offering Vendor
+    receives confirmation.  This node creates the ``Accept`` activity via
+    ``trigger_activity_factory`` and queues it in the local actor's outbox.
+
+    Returns ``FAILURE`` when ``trigger_activity_factory`` is not available
+    so that the enclosing Sequence propagates the failure rather than
+    silently continuing.  Callers that want the guarded-commit subtree to
+    run regardless of auto-accept status should wrap this node in a
+    ``Selector`` with a ``Success`` fallback.
+
+    See DEMOMA-08-002, DEMOMA-08-003; Issue #469, Issue #1021.
+    """
+
+    def __init__(
+        self,
+        offer_id: str,
+        case_id: str,
+        participant_id: str,
+        vendor_id: str,
+        name: str | None = None,
+    ) -> None:
+        """Initialise the node.
+
+        Args:
+            offer_id: ID of the ``Offer(CaseManagerRole)`` activity.
+            case_id: ID of the VulnerabilityCase referenced by the offer.
+            participant_id: ID of the CaseParticipant being offered the role.
+            vendor_id: Actor ID of the offering Vendor (recipient of Accept).
+            name: Optional custom node name.
+        """
+        super().__init__(name=name or self.__class__.__name__)
+        self.offer_id = offer_id
+        self.case_id = case_id
+        self.participant_id = participant_id
+        self.vendor_id = vendor_id
+
+    def update(self) -> Status:
+        if self.datalayer is None or self.actor_id is None:
+            self.logger.error(
+                "%s: DataLayer or actor_id not available", self.name
+            )
+            return Status.FAILURE
+
+        if self.trigger_activity_factory is None:
+            self.logger.warning(
+                "%s: trigger_activity_factory not available"
+                " — cannot auto-accept offer '%s'",
+                self.name,
+                self.offer_id,
+            )
+            return Status.FAILURE
+
+        if not self.case_id or not self.participant_id:
+            self.logger.warning(
+                "%s: missing case_id or participant_id for offer '%s'"
+                " — skipping auto-accept",
+                self.name,
+                self.offer_id,
+            )
+            return Status.FAILURE
+
+        try:
+            accept_id = self.trigger_activity_factory.accept_case_manager_role(
+                offer_id=self.offer_id,
+                case_id=self.case_id,
+                participant_id=self.participant_id,
+                vendor_id=self.vendor_id,
+                actor=self.actor_id,
+                to=[self.vendor_id],
+            )
+            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
+                self.actor_id, accept_id
+            )
+            self.logger.info(
+                "%s: auto-accepted offer '%s' as actor '%s';"
+                " queued Accept '%s' to outbox",
+                self.name,
+                self.offer_id,
+                self.actor_id,
+                accept_id,
+            )
+            return Status.SUCCESS
+        except Exception as exc:
+            self.logger.error(
+                "%s: error auto-accepting offer '%s': %s",
+                self.name,
+                self.offer_id,
+                exc,
             )
             return Status.FAILURE

--- a/vultron/core/behaviors/case/offer_case_manager_role_received_tree.py
+++ b/vultron/core/behaviors/case/offer_case_manager_role_received_tree.py
@@ -43,28 +43,29 @@ def create_offer_case_manager_role_received_tree(
 ) -> py_trees.composites.Sequence:
     """Single-BT received-side tree for OfferCaseManagerRole (ADR-0022).
 
-    Idempotently stores the incoming Offer, auto-accepts it by emitting an
-    ``Accept(Offer(CaseManagerRole))`` to the offering Vendor, and — when the
-    receiving actor holds ``CVDRole.CASE_MANAGER`` — commits the
-    initialization ``CaseLedgerEntry`` that back-fills the canonical record
-    (DEMOMA-08-002, DEMOMA-08-003).
+    Idempotently stores the incoming Offer, then — when the receiving actor
+    holds ``CVDRole.CASE_MANAGER`` — commits the initialization
+    ``CaseLedgerEntry`` that back-fills the canonical record
+    (DEMOMA-08-002, DEMOMA-08-003).  The guarded commit runs BEFORE the
+    auto-accept so the canonical ledger entry for the Offer exists before
+    the ``Accept`` is sent to the offering Vendor.
 
-    The auto-accept step uses a ``Selector`` fallback so that the guarded
-    commit still runs even when ``trigger_activity_factory`` is unavailable
-    (e.g., unit-test contexts that only need the ledger entry).
+    Finally, the tree auto-accepts the offer by emitting
+    ``Accept(Offer(CaseManagerRole))`` to the offering Vendor.  If
+    ``trigger_activity_factory`` is unavailable the auto-accept node returns
+    ``FAILURE``, which propagates through the Sequence so the caller can log
+    the failure.  A protocol-level Reject path is tracked in GitHub.
 
     Structure::
 
         OfferCaseManagerRoleReceivedBT (Sequence)
         ├── StoreActivityNode("OfferCaseManagerRole")
-        ├── AutoAcceptOrSkip (Selector)
-        │   ├── AutoAcceptCaseManagerRoleNode
-        │   └── Success("AutoAcceptSkipped")
-        └── GuardedCommitOrSkip (Selector, only when case_id provided)
-            ├── Sequence
-            │   ├── CheckIsCaseManagerNode
-            │   └── CommitCaseLedgerEntryNode
-            └── Success("CommitSkippedNotCaseManager")
+        ├── GuardedCommitOrSkip (Selector, only when case_id provided)
+        │   ├── Sequence
+        │   │   ├── CheckIsCaseManagerNode
+        │   │   └── CommitCaseLedgerEntryNode
+        │   └── Success("CommitSkippedNotCaseManager")
+        └── AutoAcceptCaseManagerRoleNode
 
     Args:
         offer_id: ID of the ``Offer(CaseManagerRole)`` activity.
@@ -82,25 +83,21 @@ def create_offer_case_manager_role_received_tree(
             activity_obj=offer_obj,
             label="OfferCaseManagerRole",
         ),
-        py_trees.composites.Selector(
-            name="AutoAcceptOrSkip",
-            memory=False,
-            children=[
-                AutoAcceptCaseManagerRoleNode(
-                    offer_id=offer_id,
-                    case_id=case_id,
-                    participant_id=participant_id,
-                    vendor_id=vendor_id,
-                ),
-                py_trees.behaviours.Success(name="AutoAcceptSkipped"),
-            ],
-        ),
     ]
 
     if case_id:
         children.append(
             create_guarded_commit_case_ledger_entry_tree(case_id=case_id)
         )
+
+    children.append(
+        AutoAcceptCaseManagerRoleNode(
+            offer_id=offer_id,
+            case_id=case_id,
+            participant_id=participant_id,
+            vendor_id=vendor_id,
+        )
+    )
 
     return py_trees.composites.Sequence(
         name="OfferCaseManagerRoleReceivedBT",

--- a/vultron/core/behaviors/case/offer_case_manager_role_received_tree.py
+++ b/vultron/core/behaviors/case/offer_case_manager_role_received_tree.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Received-side BT factory for the OfferCaseManagerRole workflow (ADR-0022).
+
+See DEMOMA-08-002, DEMOMA-08-003; Issue #469, Issue #1021.
+"""
+
+import logging
+from typing import Any
+
+import py_trees
+
+from vultron.core.behaviors.case.nodes.communication import (
+    AutoAcceptCaseManagerRoleNode,
+)
+from vultron.core.behaviors.case.nodes.lifecycle import (
+    create_guarded_commit_case_ledger_entry_tree,
+)
+from vultron.core.behaviors.report.nodes.storage import StoreActivityNode
+
+logger = logging.getLogger(__name__)
+
+
+def create_offer_case_manager_role_received_tree(
+    offer_id: str,
+    offer_obj: Any,
+    case_id: str,
+    participant_id: str,
+    vendor_id: str,
+) -> py_trees.composites.Sequence:
+    """Single-BT received-side tree for OfferCaseManagerRole (ADR-0022).
+
+    Idempotently stores the incoming Offer, auto-accepts it by emitting an
+    ``Accept(Offer(CaseManagerRole))`` to the offering Vendor, and — when the
+    receiving actor holds ``CVDRole.CASE_MANAGER`` — commits the
+    initialization ``CaseLedgerEntry`` that back-fills the canonical record
+    (DEMOMA-08-002, DEMOMA-08-003).
+
+    The auto-accept step uses a ``Selector`` fallback so that the guarded
+    commit still runs even when ``trigger_activity_factory`` is unavailable
+    (e.g., unit-test contexts that only need the ledger entry).
+
+    Structure::
+
+        OfferCaseManagerRoleReceivedBT (Sequence)
+        ├── StoreActivityNode("OfferCaseManagerRole")
+        ├── AutoAcceptOrSkip (Selector)
+        │   ├── AutoAcceptCaseManagerRoleNode
+        │   └── Success("AutoAcceptSkipped")
+        └── GuardedCommitOrSkip (Selector, only when case_id provided)
+            ├── Sequence
+            │   ├── CheckIsCaseManagerNode
+            │   └── CommitCaseLedgerEntryNode
+            └── Success("CommitSkippedNotCaseManager")
+
+    Args:
+        offer_id: ID of the ``Offer(CaseManagerRole)`` activity.
+        offer_obj: The wire activity object to persist idempotently.
+        case_id: ID of the VulnerabilityCase referenced by the offer.
+        participant_id: ID of the CaseParticipant being offered the role.
+        vendor_id: Actor ID of the offering Vendor (recipient of Accept).
+
+    Returns:
+        Root ``OfferCaseManagerRoleReceivedBT`` Sequence node.
+    """
+    children: list[py_trees.behaviour.Behaviour] = [
+        StoreActivityNode(
+            activity_id=offer_id,
+            activity_obj=offer_obj,
+            label="OfferCaseManagerRole",
+        ),
+        py_trees.composites.Selector(
+            name="AutoAcceptOrSkip",
+            memory=False,
+            children=[
+                AutoAcceptCaseManagerRoleNode(
+                    offer_id=offer_id,
+                    case_id=case_id,
+                    participant_id=participant_id,
+                    vendor_id=vendor_id,
+                ),
+                py_trees.behaviours.Success(name="AutoAcceptSkipped"),
+            ],
+        ),
+    ]
+
+    if case_id:
+        children.append(
+            create_guarded_commit_case_ledger_entry_tree(case_id=case_id)
+        )
+
+    return py_trees.composites.Sequence(
+        name="OfferCaseManagerRoleReceivedBT",
+        memory=False,
+        children=children,
+    )

--- a/vultron/core/behaviors/case/receive_close_case_tree.py
+++ b/vultron/core/behaviors/case/receive_close_case_tree.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Received-side BT factory for the close-case workflow (ADR-0022)."""
+
+import logging
+from typing import Any
+
+import py_trees
+
+from vultron.core.behaviors.case.nodes.lifecycle import (
+    create_guarded_commit_case_ledger_entry_tree,
+)
+from vultron.core.behaviors.report.nodes.storage import StoreActivityNode
+
+logger = logging.getLogger(__name__)
+
+
+def create_close_case_received_tree(
+    case_id: str,
+    activity_id: str,
+    activity_obj: Any,
+) -> py_trees.composites.Sequence:
+    """Single-BT received-side tree for CloseCaseReceived (ADR-0022).
+
+    Structure::
+
+        CloseCaseBT (Sequence)
+        ├── StoreActivityNode("Leave")
+        └── GuardedCommitOrSkip (Selector)
+            ├── Sequence
+            │   ├── CheckIsCaseManagerNode
+            │   └── CommitCaseLedgerEntryNode
+            └── Success("CommitSkippedNotCaseManager")
+
+    Running under ``actor_id=receiving_actor_id`` means
+    ``CheckIsCaseManagerNode`` naturally gates the commit to the actor that
+    holds ``CVDRole.CASE_MANAGER`` — no identity comparison needed in Python.
+
+    Args:
+        case_id: ID of the VulnerabilityCase being closed.
+        activity_id: ID of the inbound Leave activity to store idempotently.
+        activity_obj: The wire activity object to persist.
+
+    Returns:
+        Root ``CloseCaseBT`` Sequence node.
+    """
+    return py_trees.composites.Sequence(
+        name="CloseCaseBT",
+        memory=False,
+        children=[
+            StoreActivityNode(
+                activity_id=activity_id,
+                activity_obj=activity_obj,
+                label="Leave",
+            ),
+            create_guarded_commit_case_ledger_entry_tree(case_id=case_id),
+        ],
+    )

--- a/vultron/core/behaviors/note/add_note_received_tree.py
+++ b/vultron/core/behaviors/note/add_note_received_tree.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Received-side BT factory for the add-note-to-case workflow (ADR-0022).
+
+The canonical notification mechanism for note additions is
+``Announce(CaseLedgerEntry)`` fan-out from the guarded-commit step
+(SYNC-02-002), **not** a direct ``AddNoteToCase`` broadcast to participants.
+See ``notes/case-communication-model.md`` for the full communication model.
+"""
+
+import logging
+
+import py_trees
+
+from vultron.core.behaviors.case.nodes.lifecycle import (
+    create_guarded_commit_case_ledger_entry_tree,
+)
+from vultron.core.behaviors.note.nodes.storage import AttachNoteToCaseNode
+
+logger = logging.getLogger(__name__)
+
+
+def create_add_note_to_case_received_tree(
+    note_id: str,
+    case_id: str,
+) -> py_trees.composites.Sequence:
+    """Single-BT received-side tree for AddNoteToCase (ADR-0022).
+
+    Attaches the note to the local case replica and, when the receiving actor
+    holds ``CVDRole.CASE_MANAGER``, commits a canonical ``CaseLedgerEntry``
+    whose ``Announce`` fan-out (via ``sync_port``) notifies all participants.
+    No separate ``AddNoteToCase`` broadcast is emitted — the
+    ``Announce(CaseLedgerEntry)`` is the notification (SYNC-02-002,
+    ``notes/case-communication-model.md``).
+
+    Structure::
+
+        AddNoteToCaseBT (Sequence)
+        ├── AttachNoteToCaseNode(note_id, case_id)
+        └── GuardedCommitOrSkip (Selector)
+            ├── Sequence
+            │   ├── CheckIsCaseManagerNode
+            │   └── CommitCaseLedgerEntryNode
+            └── Success("CommitSkippedNotCaseManager")
+
+    Args:
+        note_id: ID of the Note being attached to the case.
+        case_id: ID of the VulnerabilityCase receiving the note.
+
+    Returns:
+        Root ``AddNoteToCaseBT`` Sequence node.
+    """
+    return py_trees.composites.Sequence(
+        name="AddNoteToCaseBT",
+        memory=False,
+        children=[
+            AttachNoteToCaseNode(note_id=note_id, case_id=case_id),
+            create_guarded_commit_case_ledger_entry_tree(case_id=case_id),
+        ],
+    )

--- a/vultron/core/behaviors/note/add_note_received_tree.py
+++ b/vultron/core/behaviors/note/add_note_received_tree.py
@@ -18,6 +18,9 @@
 The canonical notification mechanism for note additions is
 ``Announce(CaseLedgerEntry)`` fan-out from the guarded-commit step
 (SYNC-02-002), **not** a direct ``AddNoteToCase`` broadcast to participants.
+Only the CaseActor may update the canonical case replica; non-CaseActor
+participants must not modify their local replica directly from
+``Add(Note, Case)`` messages.
 See ``notes/case-communication-model.md`` for the full communication model.
 """
 
@@ -25,8 +28,9 @@ import logging
 
 import py_trees
 
+from vultron.core.behaviors.case.nodes.conditions import CheckIsCaseManagerNode
 from vultron.core.behaviors.case.nodes.lifecycle import (
-    create_guarded_commit_case_ledger_entry_tree,
+    CommitCaseLedgerEntryNode,
 )
 from vultron.core.behaviors.note.nodes.storage import AttachNoteToCaseNode
 
@@ -36,38 +40,48 @@ logger = logging.getLogger(__name__)
 def create_add_note_to_case_received_tree(
     note_id: str,
     case_id: str,
-) -> py_trees.composites.Sequence:
+) -> py_trees.composites.Selector:
     """Single-BT received-side tree for AddNoteToCase (ADR-0022).
 
-    Attaches the note to the local case replica and, when the receiving actor
-    holds ``CVDRole.CASE_MANAGER``, commits a canonical ``CaseLedgerEntry``
-    whose ``Announce`` fan-out (via ``sync_port``) notifies all participants.
-    No separate ``AddNoteToCase`` broadcast is emitted — the
-    ``Announce(CaseLedgerEntry)`` is the notification (SYNC-02-002,
-    ``notes/case-communication-model.md``).
+    Only the CaseActor (actor holding ``CVDRole.CASE_MANAGER``) attaches the
+    note to the local case replica and commits a canonical
+    ``CaseLedgerEntry`` whose ``Announce`` fan-out (via ``sync_port``)
+    notifies all participants.  Non-CaseActors MUST NOT update their case
+    replica directly from ``Add(Note, Case)`` messages — they receive the
+    note attachment notification exclusively via ``Announce(CaseLedgerEntry)``
+    fan-out (SYNC-02-002).
 
     Structure::
 
-        AddNoteToCaseBT (Sequence)
-        ├── AttachNoteToCaseNode(note_id, case_id)
-        └── GuardedCommitOrSkip (Selector)
-            ├── Sequence
-            │   ├── CheckIsCaseManagerNode
-            │   └── CommitCaseLedgerEntryNode
-            └── Success("CommitSkippedNotCaseManager")
+        GuardedAttachAndCommitBT (Selector)
+        ├── Sequence (CaseManager path)
+        │   ├── CheckIsCaseManagerNode
+        │   ├── AttachNoteToCaseNode(note_id, case_id)
+        │   └── CommitCaseLedgerEntryNode(case_id)
+        └── Success("AttachAndCommitSkippedNotCaseManager")
 
     Args:
         note_id: ID of the Note being attached to the case.
         case_id: ID of the VulnerabilityCase receiving the note.
 
     Returns:
-        Root ``AddNoteToCaseBT`` Sequence node.
+        Root ``GuardedAttachAndCommitBT`` Selector node.
     """
-    return py_trees.composites.Sequence(
-        name="AddNoteToCaseBT",
+    return py_trees.composites.Selector(
+        name="GuardedAttachAndCommitBT",
         memory=False,
         children=[
-            AttachNoteToCaseNode(note_id=note_id, case_id=case_id),
-            create_guarded_commit_case_ledger_entry_tree(case_id=case_id),
+            py_trees.composites.Sequence(
+                name="AttachAndCommitIfCaseManager",
+                memory=False,
+                children=[
+                    CheckIsCaseManagerNode(case_id=case_id),
+                    AttachNoteToCaseNode(note_id=note_id, case_id=case_id),
+                    CommitCaseLedgerEntryNode(case_id=case_id),
+                ],
+            ),
+            py_trees.behaviours.Success(
+                name="AttachAndCommitSkippedNotCaseManager"
+            ),
         ],
     )

--- a/vultron/core/behaviors/sync/announce_tree.py
+++ b/vultron/core/behaviors/sync/announce_tree.py
@@ -5,11 +5,13 @@ import py_trees
 
 from vultron.core.behaviors.embargo.nodes import ApplyEmbargoTeardownNode
 from vultron.core.behaviors.sync.nodes import (
+    ApplyNoteFromLedgerNode,
     ApplyParticipantStatusFromLedgerNode,
     CheckHashOrRejectOnMismatchNode,
     CheckIsOwnCaseActorNode,
     CheckIsNotOwnCaseActorNode,
     CheckLedgerEntryAlreadyStoredNode,
+    IsNotAddNoteEventNode,
     IsNotParticipantStatusEventNode,
     IsNotRemoveEmbargoEventNode,
     LogDeliveryConfirmationNode,
@@ -74,6 +76,14 @@ def create_announce_log_entry_tree() -> py_trees.behaviour.Behaviour:
                     ApplyParticipantStatusFromLedgerNode(
                         name="ApplyParticipantStatusFromLedger"
                     ),
+                ],
+            ),
+            py_trees.composites.Selector(
+                name="NoteEffects",
+                memory=False,
+                children=[
+                    IsNotAddNoteEventNode(name="IsNotAddNoteEvent"),
+                    ApplyNoteFromLedgerNode(name="ApplyNoteFromLedger"),
                 ],
             ),
         ],

--- a/vultron/core/behaviors/sync/nodes/__init__.py
+++ b/vultron/core/behaviors/sync/nodes/__init__.py
@@ -38,6 +38,7 @@ from vultron.core.behaviors.sync.nodes.conditions import (
     CheckIsOwnCaseActorNode,
     CheckLedgerEntryAlreadyStoredNode,
     CheckLedgerFreshnessNode,
+    IsNotAddNoteEventNode,
     IsNotParticipantStatusEventNode,
     IsNotRemoveEmbargoEventNode,
     VerifySenderIsOwnIdNode,
@@ -53,6 +54,7 @@ from vultron.core.behaviors.sync.nodes.receive import (
     SendRejectLogEntryNode,
 )
 from vultron.core.behaviors.sync.nodes.effects import (
+    ApplyNoteFromLedgerNode,
     ApplyParticipantStatusFromLedgerNode,
 )
 from vultron.core.behaviors.sync.nodes.replay import (
@@ -75,8 +77,10 @@ __all__ = [
     "CheckLedgerFreshnessNode",
     "IsNotRemoveEmbargoEventNode",
     "IsNotParticipantStatusEventNode",
+    "IsNotAddNoteEventNode",
     # effects
     "ApplyParticipantStatusFromLedgerNode",
+    "ApplyNoteFromLedgerNode",
     # receive
     "LogDeliveryConfirmationNode",
     "PersistReceivedLogEntryNode",

--- a/vultron/core/behaviors/sync/nodes/conditions.py
+++ b/vultron/core/behaviors/sync/nodes/conditions.py
@@ -182,6 +182,7 @@ class CheckLedgerEntryAlreadyStoredNode(DataLayerCondition):
 
 _REMOVE_EMBARGO_EVENT = "remove_embargo_event_from_case"
 _ADD_PARTICIPANT_STATUS_EVENT = "add_participant_status_to_participant"
+_ADD_NOTE_TO_CASE_EVENT = "add_note_to_case"
 
 
 class IsNotRemoveEmbargoEventNode(DataLayerCondition):
@@ -232,6 +233,32 @@ class IsNotParticipantStatusEventNode(DataLayerCondition):
     def update(self) -> Status:
         entry = _require_log_entry(self.blackboard.activity, self.name)
         if entry.event_type != _ADD_PARTICIPANT_STATUS_EVENT:
+            return Status.SUCCESS
+        return Status.FAILURE
+
+
+class IsNotAddNoteEventNode(DataLayerCondition):
+    """Guard: return SUCCESS when this log entry is *not* an add-note event.
+
+    Used as the first child of the ``NoteEffects`` Selector in
+    ``AnnounceLogEntryReceivedBT``.  When the event type is not
+    ``add_note_to_case``, the Selector short-circuits to SUCCESS without
+    running the note-attachment branch.  When the event *is* an add-note
+    event, FAILURE is returned so the Selector proceeds to
+    :class:`~vultron.core.behaviors.sync.nodes.effects.ApplyNoteFromLedgerNode`.
+
+    Per SYNC-02-002.
+    """
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="activity", access=py_trees.common.Access.READ
+        )
+
+    def update(self) -> Status:
+        entry = _require_log_entry(self.blackboard.activity, self.name)
+        if entry.event_type != _ADD_NOTE_TO_CASE_EVENT:
             return Status.SUCCESS
         return Status.FAILURE
 

--- a/vultron/core/behaviors/sync/nodes/effects.py
+++ b/vultron/core/behaviors/sync/nodes/effects.py
@@ -19,8 +19,11 @@ Provides action nodes that apply protocol-significant side effects when a
 non-Case-Actor participant processes a ledger entry of a specific event type.
 
 Currently implemented effects:
+
 - :class:`ApplyParticipantStatusFromLedgerNode`: applies an
   ``add_participant_status_to_participant`` event to the local participant record.
+- :class:`ApplyNoteFromLedgerNode`: applies an ``add_note_to_case`` event to
+  the local case replica by attaching the note ID to ``notes``.
 
 Per specs/multi-actor-demo.yaml DEMOMA-07-003 step 3 and
 specs/sync-ledger-replication.yaml SYNC-02-002.
@@ -36,7 +39,7 @@ from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerAction
 from vultron.core.models.participant_status import ParticipantStatus
-from vultron.core.models.protocols import is_participant_model
+from vultron.core.models.protocols import is_case_model, is_participant_model
 from vultron.core.use_cases._helpers import _as_id
 
 logger = logging.getLogger(__name__)
@@ -193,5 +196,83 @@ class ApplyParticipantStatusFromLedgerNode(DataLayerAction):
             self.name,
             status_id,
             participant_id,
+        )
+        return Status.SUCCESS
+
+
+class ApplyNoteFromLedgerNode(DataLayerAction):
+    """Apply an ``add_note_to_case`` ledger entry to the local case replica.
+
+    When a non-CaseActor participant receives ``Announce(CaseLedgerEntry)``
+    and the entry's ``event_type`` is ``add_note_to_case``, this node
+    extracts the note ID from ``payload_snapshot["object"]`` and appends it
+    to the local case replica's ``notes`` list (idempotent).
+
+    This is the canonical mechanism by which non-CaseActor participants
+    learn about note additions — they must NOT update ``notes`` directly from
+    ``Add(Note, Case)`` messages; only the CaseActor does that (ADR-0022,
+    SYNC-02-002).
+
+    Lenient on missing data: if the case replica is absent, the note ID is
+    not present in the snapshot, or the snapshot is malformed, the node
+    returns SUCCESS to avoid blocking the ``Announce`` processing flow.
+    """
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="activity", access=py_trees.common.Access.READ
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.feedback_message = "DataLayer not available"
+            return Status.FAILURE
+
+        from vultron.core.behaviors.sync.nodes.conditions import (
+            _require_log_entry,
+        )
+
+        entry = _require_log_entry(self.blackboard.activity, self.name)
+        snapshot = entry.payload_snapshot
+
+        note_id = _extract_id_from_field(snapshot.get("object"))
+        case_id = entry.case_id
+
+        if not note_id or not case_id:
+            self.logger.debug(
+                "%s: payload_snapshot missing 'object' id or case_id"
+                " — skipping note apply (non-fatal)",
+                self.name,
+            )
+            return Status.SUCCESS
+
+        case = self.datalayer.read(case_id)
+        if not is_case_model(case):
+            self.logger.debug(
+                "%s: case '%s' not found in local DataLayer"
+                " — skipping (non-fatal, partial case view)",
+                self.name,
+                case_id,
+            )
+            return Status.SUCCESS
+
+        existing_ids = [_as_id(n) for n in case.notes]
+        if note_id in existing_ids:
+            self.logger.debug(
+                "%s: note '%s' already in case '%s' — idempotent no-op",
+                self.name,
+                note_id,
+                case_id,
+            )
+            return Status.SUCCESS
+
+        case.notes.append(note_id)
+        self.datalayer.save(case)
+        self.logger.info(
+            "%s: applied ledger note attachment '%s' to case '%s' (SYNC-02-002)",
+            self.name,
+            note_id,
+            case_id,
         )
         return Status.SUCCESS

--- a/vultron/core/use_cases/received/actor/case_manager_role.py
+++ b/vultron/core/use_cases/received/actor/case_manager_role.py
@@ -3,7 +3,6 @@
 import logging
 from typing import TYPE_CHECKING
 
-from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.models.events.actor import (
     AcceptCaseManagerRoleReceivedEvent,
     OfferCaseManagerRoleReceivedEvent,
@@ -57,112 +56,50 @@ class OfferCaseManagerRoleReceivedUseCase:
         self._sync_port = sync_port
 
     def execute(self) -> None:
-        from vultron.core.use_cases.received.sync import _find_local_actor_id
-        from vultron.core.use_cases.triggers._helpers import (
-            add_activity_to_outbox,
+        from py_trees.common import Status
+
+        from vultron.core.behaviors.bridge import BTBridge
+        from vultron.core.behaviors.case.offer_case_manager_role_received_tree import (
+            create_offer_case_manager_role_received_tree,
         )
 
         request = self._request
-        _idempotent_create(
-            self._dl,
-            request.activity_type,
-            request.activity_id,
-            request.activity,
-            "OfferCaseManagerRole",
-            request.activity_id,
-        )
-        logger.info(
-            "OfferCaseManagerRoleReceived: actor '%s' offered CASE_MANAGER"
-            " role delegation for activity '%s'",
-            request.actor_id,
-            request.activity_id,
-        )
-
-        if self._trigger_activity is None:
-            logger.warning(
-                "OfferCaseManagerRoleReceived: trigger_activity not available"
-                " — skipping auto-accept for offer '%s'",
-                request.activity_id,
+        receiving_actor_id = request.receiving_actor_id
+        if receiving_actor_id is None:
+            logger.debug(
+                "OfferCaseManagerRoleReceivedUseCase: missing"
+                " receiving_actor_id — skipping (CLP-10-005)"
             )
             return
 
-        case_id = _as_id(request.activity.object_)
-        participant_id = _as_id(request.activity.target)
         offer_id = request.activity_id
         vendor_id = request.actor_id
+        case_id = _as_id(request.activity.object_)
+        participant_id = _as_id(request.activity.target)
 
-        if not case_id or not participant_id:
-            logger.warning(
-                "OfferCaseManagerRoleReceived: missing case_id or"
-                " participant_id in offer '%s' — skipping auto-accept",
-                offer_id,
-            )
-            return
-
-        local_actor_id = request.receiving_actor_id or _find_local_actor_id(
-            self._dl
+        tree = create_offer_case_manager_role_received_tree(
+            offer_id=offer_id,
+            offer_obj=request.activity,
+            case_id=case_id or "",
+            participant_id=participant_id or "",
+            vendor_id=vendor_id or "",
         )
-        if local_actor_id is None:
-            logger.warning(
-                "OfferCaseManagerRoleReceived: no local actor found"
-                " — skipping auto-accept for offer '%s'",
+        result = BTBridge(
+            datalayer=self._dl,
+            trigger_activity=self._trigger_activity,
+        ).execute_with_setup(
+            tree=tree,
+            actor_id=receiving_actor_id,
+            activity=request,
+            sync_port=self._sync_port,
+        )
+        if result.status != Status.SUCCESS:
+            logger.debug(
+                "OfferCaseManagerRoleReceivedUseCase: BT did not fully"
+                " succeed for offer '%s': %s",
                 offer_id,
+                BTBridge.get_failure_reason(tree) or result.feedback_message,
             )
-            return
-
-        try:
-            accept_id = self._trigger_activity.accept_case_manager_role(
-                offer_id=offer_id,
-                case_id=case_id,
-                participant_id=participant_id,
-                vendor_id=vendor_id,
-                actor=local_actor_id,
-                to=[vendor_id],
-            )
-            add_activity_to_outbox(local_actor_id, accept_id, self._dl)
-            logger.info(
-                "OfferCaseManagerRoleReceived: auto-accepted offer '%s'"
-                " as actor '%s'; queued Accept '%s' to outbox",
-                offer_id,
-                local_actor_id,
-                accept_id,
-            )
-        except Exception as exc:
-            logger.error(
-                "OfferCaseManagerRoleReceived: error auto-accepting offer"
-                " '%s': %s",
-                offer_id,
-                exc,
-            )
-
-        # Backfill: the CaseActor commits its initialization event to the
-        # canonical case ledger.  The vendor MUST NOT do this (it is not
-        # the CaseActor); this is the first point at which the CaseActor
-        # is protocol-operational and can write a canonical entry.
-        # BT-15-001: protocol-significant action lives in a BT leaf.
-        if self._sync_port is not None:
-            from vultron.core.behaviors.case.nodes.lifecycle import (
-                create_guarded_commit_case_ledger_entry_tree,
-            )
-
-            result = BTBridge(
-                datalayer=self._dl,
-                trigger_activity=self._trigger_activity,
-                sync_port=self._sync_port,
-            ).execute_with_setup(
-                tree=create_guarded_commit_case_ledger_entry_tree(
-                    case_id=case_id
-                ),
-                actor_id=local_actor_id,
-                activity=request,
-            )
-            if result.status.value != "success":
-                logger.warning(
-                    "OfferCaseManagerRoleReceived: backfill ledger commit"
-                    " did not succeed for case '%s': %s",
-                    case_id,
-                    result.feedback_message,
-                )
 
 
 class AcceptCaseManagerRoleReceivedUseCase:

--- a/vultron/core/use_cases/received/actor/case_manager_role.py
+++ b/vultron/core/use_cases/received/actor/case_manager_role.py
@@ -3,6 +3,12 @@
 import logging
 from typing import TYPE_CHECKING
 
+from py_trees.common import Status
+
+from vultron.core.behaviors.bridge import BTBridge
+from vultron.core.behaviors.case.offer_case_manager_role_received_tree import (
+    create_offer_case_manager_role_received_tree,
+)
 from vultron.core.models.events.actor import (
     AcceptCaseManagerRoleReceivedEvent,
     OfferCaseManagerRoleReceivedEvent,
@@ -56,13 +62,6 @@ class OfferCaseManagerRoleReceivedUseCase:
         self._sync_port = sync_port
 
     def execute(self) -> None:
-        from py_trees.common import Status
-
-        from vultron.core.behaviors.bridge import BTBridge
-        from vultron.core.behaviors.case.offer_case_manager_role_received_tree import (
-            create_offer_case_manager_role_received_tree,
-        )
-
         request = self._request
         receiving_actor_id = request.receiving_actor_id
         if receiving_actor_id is None:

--- a/vultron/core/use_cases/received/case/lifecycle.py
+++ b/vultron/core/use_cases/received/case/lifecycle.py
@@ -3,6 +3,12 @@
 import logging
 from typing import TYPE_CHECKING
 
+from py_trees.common import Status
+
+from vultron.core.behaviors.bridge import BTBridge
+from vultron.core.behaviors.case.receive_close_case_tree import (
+    create_close_case_received_tree,
+)
 from vultron.core.models.events.case import (
     AddReportToCaseReceivedEvent,
     CloseCaseReceivedEvent,
@@ -66,13 +72,6 @@ class CloseCaseReceivedUseCase:
         self._sync_port = sync_port
 
     def execute(self) -> None:
-        from py_trees.common import Status
-
-        from vultron.core.behaviors.bridge import BTBridge
-        from vultron.core.behaviors.case.receive_close_case_tree import (
-            create_close_case_received_tree,
-        )
-
         request = self._request
         case_id = request.case_id
         if case_id is None:

--- a/vultron/core/use_cases/received/case/lifecycle.py
+++ b/vultron/core/use_cases/received/case/lifecycle.py
@@ -12,7 +12,7 @@ from vultron.core.ports.case_persistence import (
     CaseOutboxPersistence,
     CasePersistence,
 )
-from vultron.core.use_cases._helpers import _as_id, _find_case_actor_id
+from vultron.core.use_cases._helpers import _as_id
 
 if TYPE_CHECKING:
     from vultron.core.ports.sync_activity import SyncActivityPort
@@ -66,66 +66,48 @@ class CloseCaseReceivedUseCase:
         self._sync_port = sync_port
 
     def execute(self) -> None:
-        import py_trees
+        from py_trees.common import Status
 
         from vultron.core.behaviors.bridge import BTBridge
-        from vultron.core.behaviors.case.nodes import (
-            create_guarded_commit_case_ledger_entry_tree,
+        from vultron.core.behaviors.case.receive_close_case_tree import (
+            create_close_case_received_tree,
         )
-        from vultron.core.behaviors.report.nodes import StoreActivityNode
 
         request = self._request
         case_id = request.case_id
-        actor_id = request.actor_id
-
         if case_id is None:
             logger.warning("close_case: missing case_id")
-            return
-
-        logger.info("Actor '%s' is closing case '%s'", actor_id, case_id)
-
-        # Pre-flight guard (ADR-0021, CLP-10-002, CLP-10-003)
-        case_actor_id = _find_case_actor_id(self._dl, case_id)
-        if case_actor_id is None:
-            logger.warning(
-                "CloseCaseReceivedUseCase: cannot resolve CaseActor for case"
-                " '%s' — skipping commit",
-                case_id,
-            )
             return
 
         receiving_actor_id = request.receiving_actor_id
         if receiving_actor_id is None:
             logger.debug(
                 "CloseCaseReceivedUseCase: missing receiving_actor_id"
-                " — skipping commit"
+                " — skipping commit (CLP-10-005)"
             )
             return
 
-        if receiving_actor_id != case_actor_id:
-            logger.debug(
-                "CloseCaseReceivedUseCase: receiving actor '%s' is not the"
-                " CaseActor for case '%s' — skipping commit (CLP-10-003)",
-                receiving_actor_id,
-                case_id,
-            )
-            return
-
-        tree = py_trees.composites.Sequence(
-            name="CloseCaseBT",
-            memory=False,
-            children=[
-                StoreActivityNode(
-                    activity_id=request.activity_id,
-                    activity_obj=request.activity,
-                    label="Leave",
-                ),
-                create_guarded_commit_case_ledger_entry_tree(case_id=case_id),
-            ],
+        logger.info(
+            "Actor '%s' is closing case '%s'",
+            request.actor_id,
+            case_id,
         )
-        BTBridge(datalayer=self._dl).execute_with_setup(
+
+        tree = create_close_case_received_tree(
+            case_id=case_id,
+            activity_id=request.activity_id,
+            activity_obj=request.activity,
+        )
+        result = BTBridge(datalayer=self._dl).execute_with_setup(
             tree=tree,
             actor_id=receiving_actor_id,
             activity=request,
             sync_port=self._sync_port,
         )
+        if result.status != Status.SUCCESS:
+            logger.debug(
+                "CloseCaseReceivedUseCase: BT did not fully succeed for"
+                " case '%s': %s",
+                case_id,
+                BTBridge.get_failure_reason(tree) or result.feedback_message,
+            )

--- a/vultron/core/use_cases/received/note.py
+++ b/vultron/core/use_cases/received/note.py
@@ -5,6 +5,11 @@ from typing import TYPE_CHECKING
 
 from py_trees.common import Status
 
+from vultron.core.behaviors.bridge import BTBridge
+from vultron.core.behaviors.note.add_note_received_tree import (
+    create_add_note_to_case_received_tree,
+)
+from vultron.core.behaviors.note.create_note_tree import create_note_tree
 from vultron.core.models.events.note import (
     AddNoteToCaseReceivedEvent,
     CreateNoteReceivedEvent,
@@ -32,10 +37,6 @@ class CreateNoteReceivedUseCase:
 
     def execute(self) -> None:
         request = self._request
-        from vultron.core.behaviors.bridge import BTBridge
-        from vultron.core.behaviors.note.create_note_tree import (
-            create_note_tree,
-        )
 
         note = request.note
         if note is None:
@@ -66,16 +67,16 @@ class CreateNoteReceivedUseCase:
 class AddNoteToCaseReceivedUseCase:
     """Attach a received note to the case and commit a canonical ledger entry.
 
-    When the CaseActor receives ``Add(Note, Case)`` it:
+    Only the CaseActor (actor holding ``CVDRole.CASE_MANAGER``) attaches the
+    note to ``VulnerabilityCase.notes`` and commits a ``CaseLedgerEntry``.
+    Non-CaseActor receivers MUST NOT update their case replica directly from
+    ``Add(Note, Case)`` messages — they receive note attachment notifications
+    exclusively via ``Announce(CaseLedgerEntry)`` fan-out from the CaseActor
+    (SYNC-02-002).
 
-    1. Attaches the note ID to ``VulnerabilityCase.notes`` (idempotent).
-    2. Commits a ``CaseLedgerEntry`` whose ``Announce`` fan-out (via
-       ``sync_port``) notifies all participants — this is the only
-       notification mechanism; no separate ``AddNoteToCase`` broadcast
-       is emitted (``notes/case-communication-model.md``, SYNC-02-002).
-
-    Non-CaseActor receivers attach the note locally but skip the guarded
-    commit via ``CheckIsCaseManagerNode`` (CLP-10-003).
+    The ``CheckIsCaseManagerNode`` guard inside the BT enforces this: non-
+    CaseActors take the ``Success`` fallback and skip both attach and commit
+    (CLP-10-003).
     """
 
     def __init__(
@@ -103,11 +104,6 @@ class AddNoteToCaseReceivedUseCase:
                 " — skipping (CLP-10-005)"
             )
             return
-
-        from vultron.core.behaviors.bridge import BTBridge
-        from vultron.core.behaviors.note.add_note_received_tree import (
-            create_add_note_to_case_received_tree,
-        )
 
         tree = create_add_note_to_case_received_tree(
             note_id=note_id,

--- a/vultron/core/use_cases/received/note.py
+++ b/vultron/core/use_cases/received/note.py
@@ -1,7 +1,7 @@
 """Use cases for case note activities."""
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from py_trees.common import Status
 
@@ -11,15 +11,14 @@ from vultron.core.models.events.note import (
     RemoveNoteFromCaseReceivedEvent,
 )
 from vultron.core.ports.case_persistence import (
-    CasePersistence,
     CaseOutboxPersistence,
+    CasePersistence,
 )
 from vultron.core.models.protocols import is_case_model
 from vultron.core.use_cases._helpers import _as_id
 
 if TYPE_CHECKING:
     from vultron.core.ports.sync_activity import SyncActivityPort
-    from vultron.core.ports.trigger_activity import TriggerActivityPort
 
 logger = logging.getLogger(__name__)
 
@@ -65,17 +64,29 @@ class CreateNoteReceivedUseCase:
 
 
 class AddNoteToCaseReceivedUseCase:
+    """Attach a received note to the case and commit a canonical ledger entry.
+
+    When the CaseActor receives ``Add(Note, Case)`` it:
+
+    1. Attaches the note ID to ``VulnerabilityCase.notes`` (idempotent).
+    2. Commits a ``CaseLedgerEntry`` whose ``Announce`` fan-out (via
+       ``sync_port``) notifies all participants — this is the only
+       notification mechanism; no separate ``AddNoteToCase`` broadcast
+       is emitted (``notes/case-communication-model.md``, SYNC-02-002).
+
+    Non-CaseActor receivers attach the note locally but skip the guarded
+    commit via ``CheckIsCaseManagerNode`` (CLP-10-003).
+    """
+
     def __init__(
         self,
         dl: CaseOutboxPersistence,
         request: AddNoteToCaseReceivedEvent,
         sync_port: "SyncActivityPort | None" = None,
-        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: AddNoteToCaseReceivedEvent = request
         self._sync_port = sync_port
-        self._trigger_activity = trigger_activity
 
     def execute(self) -> None:
         request = self._request
@@ -84,137 +95,38 @@ class AddNoteToCaseReceivedUseCase:
         if note_id is None or case_id is None:
             logger.warning("add_note_to_case: missing note_id or case_id")
             return
-        case = self._dl.read(case_id)
-
-        if not is_case_model(case):
-            logger.warning("add_note_to_case: case '%s' not found", case_id)
-            return
-
-        existing_ids = [_as_id(n) for n in case.notes]
-        if note_id in existing_ids:
-            logger.info(
-                "Note '%s' already in case '%s' — skipping attachment"
-                " (idempotent)",
-                note_id,
-                case_id,
-            )
-        else:
-            case.notes.append(note_id)
-            self._dl.save(case)
-            logger.info("Added note '%s' to case '%s'", note_id, case_id)
-
-            self._broadcast_note_to_participants(
-                note_id=note_id,
-                case_id=case_id,
-                author_id=request.actor_id,
-                case=case,
-            )
-
-        from vultron.core.behaviors.bridge import BTBridge
-        from vultron.core.behaviors.case.nodes import (
-            create_guarded_commit_case_ledger_entry_tree,
-        )
-        from vultron.core.use_cases._helpers import _find_case_actor_id
-
-        case_actor_id = _find_case_actor_id(self._dl, case_id)
-        if case_actor_id is None:
-            logger.warning(
-                "add_note_to_case: cannot resolve CaseActor for case '%s'"
-                " — skipping log entry (PCR-08-003)",
-                case_id,
-            )
-            return
 
         receiving_actor_id = request.receiving_actor_id
         if receiving_actor_id is None:
             logger.debug(
                 "add_note_to_case: missing receiving_actor_id"
-                " — skipping commit"
+                " — skipping (CLP-10-005)"
             )
             return
 
-        if receiving_actor_id != case_actor_id:
-            logger.debug(
-                "add_note_to_case: receiving actor '%s' is not the CaseActor"
-                " for case '%s' — skipping commit (CLP-10-003)",
-                receiving_actor_id,
-                case_id,
-            )
-            return
+        from vultron.core.behaviors.bridge import BTBridge
+        from vultron.core.behaviors.note.add_note_received_tree import (
+            create_add_note_to_case_received_tree,
+        )
 
-        BTBridge(datalayer=self._dl).execute_with_setup(
-            tree=create_guarded_commit_case_ledger_entry_tree(case_id=case_id),
+        tree = create_add_note_to_case_received_tree(
+            note_id=note_id,
+            case_id=case_id,
+        )
+        result = BTBridge(datalayer=self._dl).execute_with_setup(
+            tree=tree,
             actor_id=receiving_actor_id,
             activity=request,
             sync_port=self._sync_port,
         )
-
-    def _broadcast_note_to_participants(
-        self,
-        note_id: str,
-        case_id: str,
-        author_id: str,
-        case: Any,
-    ) -> None:
-        """Broadcast note addition to all case participants via CaseActor.
-
-        Implements CM-06-005: when a note is added to a case the CaseActor
-        MUST broadcast the note to all participants (excluding the author).
-        Recipients are derived from VulnerabilityCase.actor_participant_index.
-        """
-        if self._trigger_activity is None:
+        if result.status != Status.SUCCESS:
             logger.debug(
-                "add_note_to_case: no TriggerActivityPort for case '%s'"
-                " — skipping broadcast (CM-06-005)",
+                "add_note_to_case: BT did not fully succeed for note '%s'"
+                " in case '%s': %s",
+                note_id,
                 case_id,
+                BTBridge.get_failure_reason(tree) or result.feedback_message,
             )
-            return
-
-        # Locate the CaseActor (type_="Service") for this case.
-        case_actor_id: str | None = None
-        for service in self._dl.list_objects("Service"):
-            if getattr(service, "context", None) == case_id:
-                case_actor_id = service.id_
-                break
-
-        if case_actor_id is None:
-            logger.debug(
-                "add_note_to_case: no CaseActor found for case '%s'"
-                " — skipping broadcast (CM-06-005)",
-                case_id,
-            )
-            return
-
-        recipient_ids = [
-            actor_id
-            for actor_id in case.actor_participant_index.keys()
-            if actor_id != author_id
-        ]
-        if not recipient_ids:
-            logger.debug(
-                "add_note_to_case: no eligible recipients in case '%s'"
-                " — skipping broadcast",
-                case_id,
-            )
-            return
-
-        activity_id, _ = self._trigger_activity.add_note_to_case(
-            note_id=note_id,
-            case_id=case_id,
-            actor=case_actor_id,
-            to=recipient_ids,
-        )
-
-        self._dl.record_outbox_item(case_actor_id, activity_id)
-
-        logger.info(
-            "add_note_to_case: CaseActor '%s' broadcast AddNoteToCase for"
-            " note '%s' in case '%s' to %d participant(s) (CM-06-005)",
-            case_actor_id,
-            note_id,
-            case_id,
-            len(recipient_ids),
-        )
 
 
 class RemoveNoteFromCaseReceivedUseCase:


### PR DESCRIPTION
- Closes #1052

## Summary

Migrates three received-side use cases to the ADR-0022 "single-BT execution per inbox delivery" pattern, completing the ratchet established in #1050 (embargo) and #1051 (report/status). `KNOWN_VIOLATIONS` is now empty.

**Architecture fix included:** `AddNoteToCaseReceivedUseCase` previously called `_broadcast_note_to_participants` which emitted `AddNoteToCase` directly from the CaseActor to participants — a violation of `notes/case-communication-model.md` (participant→participant messaging must route through `Announce(CaseLedgerEntry)`). This broadcast is removed entirely; the `sync_port`-driven `Announce(CaseLedgerEntry)` fan-out is the correct notification mechanism (SYNC-02-002).

## Changes

**New tree factories:**
- `vultron/core/behaviors/note/add_note_received_tree.py`: `create_add_note_to_case_received_tree()` — `AttachNoteToCaseNode` + guarded commit; no broadcast
- `vultron/core/behaviors/case/receive_close_case_tree.py`: `create_close_case_received_tree()` — `StoreActivityNode(Leave)` + guarded commit
- `vultron/core/behaviors/case/offer_case_manager_role_received_tree.py`: `create_offer_case_manager_role_received_tree()` — `StoreActivityNode` + `AutoAcceptOrSkip` Selector + conditional guarded commit

**New BT node:**
- `AutoAcceptCaseManagerRoleNode` in `case/nodes/communication.py`: calls `trigger_activity_factory.accept_case_manager_role()` + `record_outbox_item()`; returns FAILURE when trigger unavailable so Selector's `Success` fallback handles it

**Refactored use cases** (each now: `receiving_actor_id is None` guard → field extraction → factory call → single `execute_with_setup()`):
- `received/note.py`: removed `trigger_activity` param, removed `_broadcast_note_to_participants`
- `received/case/lifecycle.py`: replaced inline `py_trees.composites.Sequence` and Python-level pre-flight guards
- `received/actor/case_manager_role.py`: replaced multi-path inline logic + two `execute_with_setup()` calls

**Port factory fix:**
- Moved `ADD_NOTE_TO_CASE` from `_SYNC_AND_TRIGGER_PORT_SEMANTICS` to `_SYNC_PORT_SEMANTICS` (no longer needs `trigger_activity`)

**Tests:**
- Cleared `KNOWN_VIOLATIONS = frozenset()` in architecture ratchet
- Removed 3 broadcast tests (testing architecture-violating behavior)
- Updated all callers to remove `trigger_activity` arg and add `receiving_actor_id` where required

## Verification

```
3434 passed, 37 skipped, 225 deselected, 2 xfailed, 5633 subtests passed
```