### PR TITLE
docs: plan issue #1068 — receive-side BT commit-before-effects ordering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -551,6 +551,21 @@ Short entries are reproduced here; longer ones are referenced below.
   [notes/bt-integration.md](notes/bt-integration.md)
   § "Trigger/Received Parity" and `specs/behavior-tree-integration.yaml`
   BT-15-001, BT-15-002.
+- **Receive-Side BTs Must Record the Triggering Activity Before Applying
+  Protocol Effects** — In any receive-side BT tree that contains a
+  `GuardedCommitCaseLedgerEntryBT` subtree (via
+  `create_guarded_commit_case_ledger_entry_tree`), the commit subtree MUST
+  appear BEFORE any protocol-effect node (state transitions, outbox enqueues,
+  participant record mutations). Pure precondition-guard nodes (read-only
+  checks that return FAILURE without writing state) MAY precede the commit.
+  The correct ordering is: (1) precondition guards, (2) commit, (3) all
+  protocol effects. Placing effects before the commit inverts causal ordering:
+  the case ledger shows effects without the cause that produced them, breaking
+  forensic auditability and ledger replication. The commit records that the
+  triggering activity was received — this is independent of whether subsequent
+  effects succeed. Audit issue #1068 found this inverted ordering consistently
+  across receive-side BTs; fix tracked in implementation issues blocked by
+  #1052. See `specs/case-ledger-processing.yaml` CLP-10-006.
 - **Received-Side execute() Must Not Call commit_log_entry_trigger() Directly** —
   A received-side `execute()` method that calls `commit_log_entry_trigger()`
   (or any wrapper around it) directly is a BT-06-006 violation.

--- a/plan/history/2606/learning/CONCERN-1068.md
+++ b/plan/history/2606/learning/CONCERN-1068.md
@@ -1,0 +1,68 @@
+---
+source: CONCERN-1068
+timestamp: '2026-06-22T14:27:46.447081+00:00'
+title: Receive-side BT commit-before-effects ordering
+type: learning
+---
+
+## Summary
+
+Across receive-side behavior trees, protocol-significant actions (state
+transitions, outbox enqueues, participant updates, etc.) are taken before
+the triggering received message is committed to the canonical case ledger.
+This inverts cause-before-effect ordering: the case ledger may record effects
+without the cause that produced them.
+
+## Category
+
+- Technical debt
+- Correctness / causal ordering
+
+## Severity
+
+High
+
+## Evidence
+
+The pattern is present in receive-side BTs throughout `vultron/core/behaviors/`
+— `CommitCaseLedgerEntryNode` (if present at all) appears after
+state-transition or outbox nodes rather than as the first node in the
+sequence. This pattern appears to have emerged early in the receive-side BT
+implementation and has been consistently repeated.
+
+Confirmed violations at time of audit (main as of commit df04902f):
+
+- `received/embargo.py`: `InviteToEmbargoOnCaseReceivedUseCase`,
+  `AcceptInviteToEmbargoOnCaseReceivedUseCase` — two `execute_with_setup`
+  calls; effect BT runs first, commit BT second
+- `received/report.py`: `ValidateReportReceivedUseCase`,
+  `AckReportReceivedUseCase` — same two-call pattern
+- `received/status.py`: `AddParticipantStatusToParticipantReceivedUseCase`
+  — same two-call pattern
+- `behaviors/case/accept_invite_tree.py`: commit is last child, after
+  `EmitAnnounceCaseToInviteeNode` and `BackfillCanonicalLedgerToInviteeNode`
+- `behaviors/case/create_tree.py`: commit is last child, after
+  `UpdateActorOutbox`
+- `behaviors/embargo/announce_teardown_tree.py`: commit is last child in
+  each sub-tree, after state-transition nodes
+- `behaviors/report/prioritize_tree.py`: commit is 3rd child, after
+  `TransitionParticipantRMtoAccepted`
+
+## Impact if Ignored
+
+Case ledgers will not accurately reflect the causal order of events.
+Participants replicating the ledger via `Announce(CaseLedgerEntry)` may
+observe effects without the causes that produced them. Forensic and audit
+use of the canonical case ledger becomes unreliable.
+
+## Resolution
+
+Correct ordering: (1) precondition guards (read-only), (2) commit the
+triggering activity, (3) all protocol effects. The commit records that the
+activity was received — this is independent of whether subsequent effects
+succeed.
+
+**Resolved**: 2026-06-22 — implementation tracked in #1072 and #1073
+(both blocked by #1052).
+Docs PR: [#1070](https://github.com/CERTCC/Vultron/pull/1070).
+Spec: `specs/case-ledger-processing.yaml` CLP-10-006.

--- a/specs/case-ledger-processing.yaml
+++ b/specs/case-ledger-processing.yaml
@@ -483,3 +483,39 @@ groups:
       it catches every known violation but a reviewer MUST still confirm no
       other domain-significant code remains in `execute()` when closing each
       migration.
+  - id: CLP-10-006
+    priority: MUST
+    statement: >-
+      In any receive-side BT tree that includes a `GuardedCommitCaseLedgerEntryBT`
+      subtree (composed via `create_guarded_commit_case_ledger_entry_tree`), the
+      commit subtree MUST appear after any pure precondition-guard nodes (nodes
+      that only read state and return FAILURE on mismatch, making no writes) and
+      BEFORE any protocol-effect nodes. A "protocol-effect node" is any node
+      that writes to the DataLayer, mutates actor or participant state, or
+      enqueues an outbox item. The ordering MUST be: (1) precondition
+      guards, (2) commit, (3) all protocol effects. A tree that applies any
+      protocol effect before committing the triggering activity inverts causal
+      ordering and MUST be corrected.
+    rationale: >-
+      The canonical case ledger records the cause (the received activity) and
+      replicates it to all participants. If protocol effects (state transitions,
+      outbox enqueues, participant updates) run before the ledger records the
+      triggering activity, the case ledger may show effects without the causes
+      that produced them. Participants replicating the ledger via
+      `Announce(CaseLedgerEntry)` would observe an effect entry with no prior
+      cause entry — making forensic and audit use of the ledger unreliable.
+      Audit issue #1068 found this inverted ordering consistently across
+      receive-side BTs in `vultron/core/behaviors/` and
+      `vultron/core/use_cases/received/`. The ledger entry records that the
+      activity was received and accepted by the CaseActor — this is independent
+      of whether subsequent effects succeed (a failed effect is an operational
+      concern, not a reason to omit the received-activity record).
+    verification: >-
+      A structural test in `test/architecture/` inspects each receive-side BT
+      tree returned by every tree-factory function in `vultron/core/behaviors/`.
+      For any tree containing `CommitCaseLedgerEntryNode` (or the guarded
+      composite wrapping it), the test asserts that no sibling node appearing
+      before the commit node in the `children` list is a protocol-effect node
+      (i.e., any node whose class name does not match the known
+      precondition-guard allowlist). The test fails if any receive-side tree
+      violates commit-first ordering.


### PR DESCRIPTION
- Closes #1068

## Summary

Plans concern #1068: receive-side BTs apply protocol effects before recording
the triggering activity to the case ledger, inverting causal ordering. Adds a
spec requirement (CLP-10-006) codifying commit-first ordering and an AGENTS.md
pitfall entry to prevent recurrence.

## Changes

- `specs/case-ledger-processing.yaml`: Add CLP-10-006 — in any receive-side
  BT tree, the guarded-commit subtree MUST appear after precondition guards
  and before all protocol-effect nodes (state transitions, outbox enqueues,
  participant mutations)
- `AGENTS.md`: Add pitfall 'Receive-Side BTs Must Record the Triggering
  Activity Before Applying Protocol Effects', referencing CLP-10-006 and
  the implementation issues blocked by #1052