### PR TITLE
docs: plan issue #1071 — direct DataLayer mutations in execute() pitfall

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -551,6 +551,20 @@ Short entries are reproduced here; longer ones are referenced below.
   [notes/bt-integration.md](notes/bt-integration.md)
   § "Trigger/Received Parity" and `specs/behavior-tree-integration.yaml`
   BT-15-001, BT-15-002.
+- **Direct DataLayer Mutations in execute() Are Not Caught by the
+  Import-Based Ratchet** — `test/architecture/test_single_bt_execution_received_side.py`
+  detects direct imports of `create_guarded_commit_case_ledger_entry_tree`
+  and (after #1074) multi-`execute_with_setup` call patterns, but it does
+  **not** detect `self._dl.save()`, `self._dl.create()`, `self._dl.update()`,
+  or `self._dl.delete()` called directly inside `execute()`. These direct
+  mutations bypass the BT audit trail, skip the hash-chained ledger-commit
+  path, and constitute protocol-significant behavior outside the tree — the
+  exact anti-pattern BT-06-001 and BT-15-001 prohibit. A second AST-based
+  ratchet (`test/architecture/test_no_dl_mutations_in_execute.py`) tracks the
+  known violations (issue #1071). Until a file is removed from
+  `KNOWN_VIOLATIONS`, do **not** add new `dl.*()` calls in its `execute()`.
+  Any new `execute()` method MUST delegate all DataLayer mutations to a BT
+  leaf node via `execute_with_setup()`.
 - **Receive-Side BTs Must Record the Triggering Activity Before Applying
   Protocol Effects** — In any receive-side BT tree that contains a
   `GuardedCommitCaseLedgerEntryBT` subtree (via

--- a/plan/history/2606/learning/CONCERN-1071.md
+++ b/plan/history/2606/learning/CONCERN-1071.md
@@ -1,0 +1,39 @@
+---
+source: CONCERN-1071
+timestamp: '2026-06-22T14:46:41.557126+00:00'
+title: 'Single-BT ratchet gap: direct DataLayer mutations in execute()'
+type: learning
+---
+
+## Summary
+
+The single-BT ratchet (CLP-10-005 / ADR-0022) enforces that received-side
+`execute()` methods delegate all domain work to a single BT via
+`execute_with_setup()`. The proxy metric (guarded-commit factory import) is
+clean after #1066. But a broader violation class remains undetected: direct
+DataLayer mutations (`dl.save`, `dl.create`, `dl.update`, `dl.delete`) called
+directly inside `execute()` rather than inside a BT leaf node.
+
+These direct mutations bypass the BT audit trail, skip the hash-chained
+ledger-commit path, and constitute protocol-significant behavior outside the
+tree — the exact anti-pattern BT-06-001 and BT-15-001 prohibit.
+
+## Known violations (post-#1066 baseline)
+
+| File | Method | Mutation |
+|---|---|---|
+| `received/case_participant.py` | `execute()` (×2) | `self._dl.save(case)` |
+| `received/actor/ownership.py` | `execute()` | `self._dl.save(case)` |
+| `received/actor/announce.py` | `execute()` | `self._dl.save(case_obj)` |
+| `received/unknown.py` | `execute()` | `self._dl.save(record)` |
+
+(`received/case/create.py` was clean at audit time — already migrated.)
+
+## References
+
+- Spec: `specs/case-ledger-processing.yaml` CLP-10-005, BT-06-001, BT-15-001
+- ADR: `docs/adr/0022-single-bt-execution-for-received-side-case-actor-routing.md`
+
+**Resolved**: 2026-06-22 — implementation tracked in #1076 (ratchet test)
+and #1077 (migration of 4 files), both blocked by #1069.
+Docs PR: [#1075](https://github.com/CERTCC/Vultron/pull/1075).


### PR DESCRIPTION
- Closes #1071

## Summary

Plans concern #1071: received-side `execute()` methods in 4 files
directly call `self._dl.save()` (and variants) outside any BT execution
context, bypassing the BT audit trail and the hash-chained ledger-commit
path. Adds an AGENTS.md pitfall noting that the existing import-based
ratchet does not catch this violation class.

## Changes

- `AGENTS.md`: Add pitfall 'Direct DataLayer Mutations in execute() Are
  Not Caught by the Import-Based Ratchet', referencing the new ratchet
  test (implementation #1075) and migration issue (#1076)