### PR TITLE
test(arch): add hard invariant for single execute_with_setup per execute() (CLP-10-005)

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -94,6 +94,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          fetch-depth: 0
           fetch-tags: true
       - name: Set up Python and uv
         uses: ./.github/actions/setup-python-uv

--- a/plan/history/2606/implementation/ISSUE-1074.md
+++ b/plan/history/2606/implementation/ISSUE-1074.md
@@ -1,0 +1,29 @@
+---
+source: ISSUE-1074
+timestamp: '2026-06-22T15:07:37.042102+00:00'
+title: 'Add hard invariant: no execute() calls execute_with_setup() more than once'
+type: implementation
+---
+
+## Issue #1074 — Add AST-based invariant test: assert no execute() method calls execute_with_setup() more than once (CLP-10-005)
+
+Added two new tests to `test/architecture/test_single_bt_execution_received_side.py`:
+
+- `test_no_execute_method_calls_execute_with_setup_more_than_once`: walks all
+  `.py` files under `vultron/core/use_cases/` with `ast`, counts
+  `execute_with_setup` call sites inside each `execute()` method (own scope
+  only, not nested helpers via `_walk_own_scope`), and asserts the count is
+  ≤ 1. Hard invariant — no `KNOWN_VIOLATIONS` escape hatch.
+
+- `test_detector_catches_synthetic_multi_execute_with_setup_violation`:
+  confirms the detector flags two direct calls in one `execute()` body (AC-3),
+  and confirms it does NOT false-positive on a single call inside a nested
+  helper function defined inside `execute()`.
+
+Also added `_is_execute_with_setup_call` and `_walk_own_scope` helpers, and
+updated the module docstring to document both the proxy ratchet and the hard
+invariant.
+
+All 3440 unit tests pass (2 new). Black, flake8, mypy, pyright clean.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1078>

--- a/test/architecture/test_single_bt_execution_received_side.py
+++ b/test/architecture/test_single_bt_execution_received_side.py
@@ -12,42 +12,34 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Architecture invariant: one BT execution per inbox delivery (CLP-10-005).
+"""Architecture invariants: one BT execution per inbox delivery (CLP-10-005).
+
+Two complementary tests enforce the single-BT-execution contract for all
+``execute()`` methods under ``vultron/core/use_cases/``.
+
+**Proxy ratchet** (``test_received_use_cases_do_not_dispatch_guarded_commit_directly``)
+  Detects direct imports of ``create_guarded_commit_case_ledger_entry_tree``
+  in use-case files — a structural proxy for the "double BT execution"
+  anti-pattern. Uses a ``KNOWN_VIOLATIONS`` escape hatch to track pre-existing
+  sites awaiting migration. A reviewer MUST still confirm no other
+  domain-significant code remains in ``execute()`` when closing each migration;
+  this test alone does not guarantee that. See ADR-0022 for the per-site
+  breakdown.
+
+**Hard invariant** (``test_no_execute_method_calls_execute_with_setup_more_than_once``)
+  Uses ``ast.walk`` to count ``execute_with_setup`` call sites directly inside
+  each ``execute()`` method body. Asserts that the count is **≤ 1** for every
+  method. Unlike the ratchet above, this test has **no** ``KNOWN_VIOLATIONS``
+  escape hatch — it is an unconditional upper bound. The baseline is already
+  clean (zero violations after #1052 / #1066), so the assertion ships
+  unconditional.
 
 A received-side use case's ``execute()`` method MUST do exactly three
 things: build one BT via a tree-factory function in
 ``vultron/core/behaviors/``, call ``BTBridge.execute_with_setup()`` exactly
 once under ``actor_id=receiving_actor_id``, and handle the result.
-``execute()`` MUST NOT contain any other domain-significant code — no
-second BT execution, no direct DataLayer mutation, and no direct import of
-``create_guarded_commit_case_ledger_entry_tree`` (or any other
-guarded-commit factory). This grep is a proxy for that broader rule: it
-catches every known violation, but fixing a violation may mean repairing
-genuine actor-identity switching, moving non-BT procedural code into the
-tree, or simply relocating an already-correct inline tree into a factory
-function — see ADR-0022 for the per-site breakdown. A reviewer MUST still
-confirm no other domain-significant code remains in ``execute()`` when
-closing each migration; this test alone does not guarantee that.
 
 Spec: CLP-10-005. Decision record: ADR-0022.
-
-Ratchet pattern
----------------
-``KNOWN_VIOLATIONS`` documents every pre-existing violation awaiting
-migration (see issues #1036, #1047, and their implementation issues). The
-test asserts::
-
-    actual_violations == KNOWN_VIOLATIONS
-
-This means:
-
-* **Adding a new violation** causes the test to **fail** immediately.
-* **Fixing a violation** also causes the test to **fail** until the
-  resolved entry is removed from ``KNOWN_VIOLATIONS``.
-
-Remove entries from ``KNOWN_VIOLATIONS`` one by one as each use case
-migrates to the single-tree shape. When the set is empty, CLP-10-005 is
-fully satisfied.
 """
 
 import ast
@@ -124,3 +116,140 @@ def test_received_use_cases_do_not_dispatch_guarded_commit_directly():
         diff_lines.extend(f"  - {v}" for v in sorted(resolved))
 
     assert actual == KNOWN_VIOLATIONS, "\n\n" + "\n".join(diff_lines)
+
+
+# ---------------------------------------------------------------------------
+# Hard invariant: no execute() method may call execute_with_setup() more
+# than once.  No KNOWN_VIOLATIONS escape hatch — this is unconditional.
+# Spec: CLP-10-005. Decision record: ADR-0022.
+# ---------------------------------------------------------------------------
+
+
+def _is_execute_with_setup_call(node: ast.AST) -> bool:
+    """Return True if *node* is a call expression targeting execute_with_setup."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    return (
+        isinstance(func, ast.Attribute) and func.attr == "execute_with_setup"
+    ) or (isinstance(func, ast.Name) and func.id == "execute_with_setup")
+
+
+def _walk_own_scope(node: ast.AST):
+    """Yield all descendants of *node* without crossing nested function scopes.
+
+    Unlike ``ast.walk``, this generator stops descending when it encounters a
+    ``FunctionDef`` or ``AsyncFunctionDef`` that is not the root *node* itself.
+    This prevents calls inside inner helper functions defined inside
+    ``execute()`` from being counted as direct calls of ``execute()``.
+    """
+    yield node
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            # Stop here: inner function bodies are a separate scope.
+            continue
+        yield from _walk_own_scope(child)
+
+
+def _count_multi_execute_violations(source_path: Path) -> dict[str, int]:
+    """Return ``'file:lineno' → call_count`` for every execute() method that
+    calls execute_with_setup() more than once in its own scope.
+
+    Only direct calls inside the ``execute()`` body are counted; calls inside
+    nested helper functions defined within ``execute()`` are excluded.
+
+    Returns an empty dict when no violations are found or on SyntaxError.
+    """
+    try:
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return {}
+
+    results: dict[str, int] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if node.name != "execute":
+            continue
+        count = sum(
+            1
+            for child in _walk_own_scope(node)
+            if _is_execute_with_setup_call(child)
+        )
+        if count > 1:
+            try:
+                label = source_path.relative_to(REPO_ROOT).as_posix()
+            except ValueError:
+                label = str(source_path)
+            results[f"{label}:{node.lineno}"] = count
+
+    return results
+
+
+def test_no_execute_method_calls_execute_with_setup_more_than_once():
+    """No execute() method in use_cases/ calls execute_with_setup() more than once.
+
+    This is a hard invariant (CLP-10-005) with no KNOWN_VIOLATIONS escape hatch.
+    The baseline is already clean after #1052 / #1066; any new violation causes
+    an immediate failure.
+
+    Spec: CLP-10-005. Decision record: ADR-0022.
+    """
+    violations: dict[str, int] = {}
+    for py_file in _USE_CASES_ROOT.rglob("*.py"):
+        if "__pycache__" in py_file.parts:
+            continue
+        violations.update(_count_multi_execute_violations(py_file))
+
+    assert not violations, (
+        "execute() methods calling execute_with_setup() more than once"
+        " (CLP-10-005 hard invariant):\n"
+        + "\n".join(
+            f"  {path}: {count} call(s)"
+            for path, count in sorted(violations.items())
+        )
+    )
+
+
+def test_detector_catches_synthetic_multi_execute_with_setup_violation(
+    tmp_path: Path,
+) -> None:
+    """Confirm the AST scanner flags a synthetic double execute_with_setup call.
+
+    AC-3: verifies that a future regression would be caught immediately, and
+    that a single call in an inner helper function does NOT produce a false
+    positive.
+    """
+    # Two direct calls in one execute() — should be flagged.
+    violation_file = tmp_path / "synthetic_violation.py"
+    violation_file.write_text(
+        "class FakeUseCase:\n"
+        "    def execute(self):\n"
+        "        self.bridge.execute_with_setup(actor_id='a', bt=None)\n"
+        "        self.bridge.execute_with_setup(actor_id='b', bt=None)\n",
+        encoding="utf-8",
+    )
+    violations = _count_multi_execute_violations(violation_file)
+    assert (
+        violations
+    ), "Detector did not flag the synthetic double execute_with_setup call"
+    counts = list(violations.values())
+    assert counts == [
+        2
+    ], f"Expected exactly 2 calls detected; got: {violations}"
+
+    # One direct call plus one call inside a nested helper — must NOT be flagged.
+    nested_ok_file = tmp_path / "synthetic_nested_ok.py"
+    nested_ok_file.write_text(
+        "class FakeUseCase:\n"
+        "    def execute(self):\n"
+        "        def _retry():\n"
+        "            self.bridge.execute_with_setup(actor_id='retry', bt=None)\n"
+        "        return self.bridge.execute_with_setup(actor_id='a', bt=None)\n",
+        encoding="utf-8",
+    )
+    non_violations = _count_multi_execute_violations(nested_ok_file)
+    assert not non_violations, (
+        "Detector produced a false positive for a nested helper function: "
+        f"{non_violations}"
+    )


### PR DESCRIPTION
- Closes #1074

## Summary

Adds a hard AST-based invariant test to `test/architecture/test_single_bt_execution_received_side.py` that asserts no `execute()` method in `vultron/core/use_cases/` calls `execute_with_setup()` more than once. Unlike the existing proxy ratchet, this test has no `KNOWN_VIOLATIONS` escape hatch — it is an unconditional upper bound.

## Changes

- `test/architecture/test_single_bt_execution_received_side.py`: adds `_is_execute_with_setup_call`, `_walk_own_scope` helpers and two new tests:
  - `test_no_execute_method_calls_execute_with_setup_more_than_once` — hard invariant (AC-1, AC-2)
  - `test_detector_catches_synthetic_multi_execute_with_setup_violation` — confirms detector catches a real violation and does not false-positive on a single call inside a nested helper function (AC-3)
- Updates module docstring to document both the proxy ratchet and the new hard invariant.

## Verification

- All 3440 unit tests pass (2 new)
- Black, flake8, mypy, pyright clean