### PR TITLE
fix: enforce CLP-10-006 commit-before-effects in receive-side BTs (#1073)

### DIFF
--- a/test/architecture/test_receive_side_bt_commit_ordering.py
+++ b/test/architecture/test_receive_side_bt_commit_ordering.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""
+Structural test: receive-side BT tree factories must not call
+``create_guarded_commit_case_ledger_entry_tree`` directly.
+
+All tree factory files under ``vultron/core/behaviors/`` that build
+receive-side BTs must use ``create_receive_activity_tree`` instead, which
+enforces the correct ledger-commit-before-effects ordering (CLP-10-006).
+
+Only ``vultron/core/behaviors/case/nodes/lifecycle.py`` — which *defines*
+``create_guarded_commit_case_ledger_entry_tree`` and is called by
+``create_receive_activity_tree`` — is exempt from this rule.
+
+This test is a ratchet: if a new violation is introduced, the test fails
+immediately rather than silently accumulating debt.
+"""
+
+import ast
+import os
+from pathlib import Path
+
+import pytest
+
+# Exempt files: may contain direct calls (definition site only).
+EXEMPT_FILES = {
+    "vultron/core/behaviors/case/nodes/lifecycle.py",
+}
+
+BEHAVIORS_ROOT = Path(__file__).parents[2] / "vultron" / "core" / "behaviors"
+FORBIDDEN_CALL = "create_guarded_commit_case_ledger_entry_tree"
+
+
+def _is_forbidden_call(node: ast.AST) -> bool:
+    """Return True if node is a Call to the forbidden function name."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Name) and func.id == FORBIDDEN_CALL:
+        return True
+    if isinstance(func, ast.Attribute) and func.attr == FORBIDDEN_CALL:
+        return True
+    return False
+
+
+def _find_violations() -> list[tuple[str, int]]:
+    """Return (relative_path, line_no) for each forbidden call outside exempt files."""
+    violations: list[tuple[str, int]] = []
+    repo_root = Path(__file__).parents[2]
+
+    for dirpath, _, filenames in os.walk(BEHAVIORS_ROOT):
+        for filename in filenames:
+            if not filename.endswith(".py"):
+                continue
+            full_path = Path(dirpath) / filename
+            rel_path = str(full_path.relative_to(repo_root))
+
+            if rel_path in EXEMPT_FILES:
+                continue
+
+            source = full_path.read_text(encoding="utf-8")
+            try:
+                tree = ast.parse(source, filename=rel_path)
+            except SyntaxError:
+                continue
+
+            for node in ast.walk(tree):
+                if _is_forbidden_call(node):
+                    assert isinstance(node, ast.Call)
+                    violations.append((rel_path, node.lineno))
+
+    return violations
+
+
+def test_no_direct_calls_to_guarded_commit_outside_lifecycle() -> None:
+    """No tree factory outside lifecycle.py may call create_guarded_commit_case_ledger_entry_tree.
+
+    All receive-side tree factories must use create_receive_activity_tree,
+    which enforces commit-before-effects ordering (CLP-10-006).
+    """
+    violations = _find_violations()
+    if violations:
+        lines = "\n".join(
+            f"  {path}:{line_no}" for path, line_no in violations
+        )
+        pytest.fail(
+            f"Found {len(violations)} direct call(s) to"
+            f" `{FORBIDDEN_CALL}` outside the exempt lifecycle module.\n"
+            f"Use `create_receive_activity_tree` instead (CLP-10-006):\n"
+            f"{lines}"
+        )

--- a/test/core/behaviors/report/test_prioritize_tree.py
+++ b/test/core/behaviors/report/test_prioritize_tree.py
@@ -287,7 +287,9 @@ def test_engage_tree_node_names(case_with_participant, actor_id):
         case_id=case_with_participant.id_, actor_id=actor_id
     )
     assert tree.children[0].name == "CheckParticipantExists"
-    assert tree.children[1].name == "TransitionParticipantRMtoAccepted"
+    # Commit runs before effects (CLP-10-006)
+    assert tree.children[1].name == "GuardedCommitCaseLedgerEntryBT"
+    assert tree.children[2].name == "TransitionParticipantRMtoAccepted"
 
 
 def test_defer_tree_node_names(case_with_participant, actor_id):
@@ -295,7 +297,9 @@ def test_defer_tree_node_names(case_with_participant, actor_id):
         case_id=case_with_participant.id_, actor_id=actor_id
     )
     assert tree.children[0].name == "CheckParticipantExists"
-    assert tree.children[1].name == "TransitionParticipantRMtoDeferred"
+    # Commit runs before effects (CLP-10-006)
+    assert tree.children[1].name == "GuardedCommitCaseLedgerEntryBT"
+    assert tree.children[2].name == "TransitionParticipantRMtoDeferred"
 
 
 # ============================================================================

--- a/test/core/use_cases/received/actor/test_invite.py
+++ b/test/core/use_cases/received/actor/test_invite.py
@@ -549,8 +549,10 @@ class TestInviteActorUseCases:
             kwargs["entry"]
             for _, kwargs in sync_port.send_announce_log_entry.call_args_list
         ]
-        # Backfill sends entries 0 and 1; CommitCaseLedgerEntryNode fans out
-        # the new accept_invite entry (2) to all participants via sync_port.
+        # Commit-first ordering: commit runs before invitee is registered, so
+        # commit fan-out does NOT include the invitee.  Backfill runs after
+        # invitee is registered with post-commit target (2), sending entries
+        # 0, 1, and 2 to the invitee.
         assert [entry.log_index for entry in announced_entries] == [0, 1, 2]
         assert announced_entries[0].entry_hash == first.entry_hash
         assert announced_entries[1].entry_hash == second.entry_hash
@@ -560,8 +562,10 @@ class TestInviteActorUseCases:
         ).id_
         state = cast(Any, dl.read(state_id))
         assert state is not None
-        assert state.join_backfill_target_index == 1
-        assert state.join_backfill_last_sent_index == 1
+        # With commit-first, the accept_invite entry (2) is committed before
+        # the invitee is registered, so backfill target includes entry 2.
+        assert state.join_backfill_target_index == 2
+        assert state.join_backfill_last_sent_index == 2
         assert state.join_backfill_complete is True
 
     def test_accept_invite_resumes_backfill_without_duplicate_entries(
@@ -685,10 +689,11 @@ class TestInviteActorUseCases:
             kwargs["entry"]
             for _, kwargs in sync_port.send_announce_log_entry.call_args_list
         ]
-        # Backfill resumes from entry 1; CommitCaseLedgerEntryNode fans out
-        # the new accept_invite entry (2) to all participants via sync_port.
-        assert [entry.log_index for entry in announced_entries] == [1, 2]
-        assert announced_entries[0].entry_hash == second.entry_hash
+        # Commit-first ordering: CommitCaseLedgerEntryNode fans out the new
+        # accept_invite entry (2) first (invitee already registered), then
+        # backfill resumes from the pre-commit target index and sends entry 1.
+        assert [entry.log_index for entry in announced_entries] == [2, 1]
+        assert announced_entries[1].entry_hash == second.entry_hash
         assert all(
             entry.entry_hash != first.entry_hash for entry in announced_entries
         )
@@ -797,9 +802,10 @@ class TestInviteActorUseCases:
             kwargs["entry"]
             for _, kwargs in sync_port.send_announce_log_entry.call_args_list
         ]
-        # Backfill sends entries 0 and 1; CommitCaseLedgerEntryNode fans out
-        # the new accept_invite entry (2) to all participants via sync_port.
-        assert [entry.log_index for entry in announced_entries] == [0, 1, 2]
+        # Commit-first ordering: CommitCaseLedgerEntryNode fans out the new
+        # accept_invite entry (2) first (invitee already registered), then
+        # backfill sends entries 0 and 1 that the invitee missed.
+        assert [entry.log_index for entry in announced_entries] == [2, 0, 1]
 
     def test_accept_invite_backfill_runs_when_announce_port_missing(
         self, make_payload

--- a/test/core/use_cases/received/case/test_bootstrap_participants.py
+++ b/test/core/use_cases/received/case/test_bootstrap_participants.py
@@ -107,6 +107,7 @@ def case_with_two_participants():
     case = VulnerabilityCase(
         id_=_CASE_ID,
         name="CBT-05-005/006 participant storage case",
+        attributed_to=_CASE_ACTOR_ID,
         case_participants=[case_actor_p, vendor_p],
     )
     case.actor_participant_index[_CASE_ACTOR_ID] = _PARTICIPANT_ID
@@ -255,9 +256,10 @@ class TestM4AddParticipantStatusAfterBootstrap:
             stored_p is not None
         ), "Vendor CaseParticipant must be stored during bootstrap (CBT-05-005)"
 
-        # Step 3: case-actor broadcasts Add(ParticipantStatus, vendor_p) to
-        # finder.  actor=_CASE_ACTOR_ID so VerifySenderIsParticipantNode passes
-        # (case.actor_participant_index contains _CASE_ACTOR_ID).
+        # Step 3: vendor self-reports its VFd status to the case actor.
+        # actor=_VENDOR_ID passes VerifySenderIsParticipantNode
+        # (case.actor_participant_index contains _VENDOR_ID), and is a valid
+        # non-CaseActor participant sender for this message type.
         # The status is NOT pre-created — it arrives inline in the activity, so
         # AppendParticipantStatusNode must resolve it from the fallback and
         # persist it independently.
@@ -269,7 +271,7 @@ class TestM4AddParticipantStatusAfterBootstrap:
         activity = add_status_to_participant_activity(
             status,
             target=vendor_p,
-            actor=_CASE_ACTOR_ID,
+            actor=_VENDOR_ID,
         )
         event = make_payload(activity, receiving_actor_id=_CASE_ACTOR_ID)
 

--- a/test/core/use_cases/received/test_report.py
+++ b/test/core/use_cases/received/test_report.py
@@ -1341,27 +1341,35 @@ class TestValidateReportReceivedGuardedCommit:
             receiving_actor_id=self.CASE_ACTOR_ID
         )
 
-        # Track calls to create_guarded_commit_case_ledger_entry_tree in
+        # Track calls to create_receive_activity_tree in
         # received_report_trees (where it is called in the ADR-0022 pattern).
-        original_create = (
-            rrt_module.create_guarded_commit_case_ledger_entry_tree
-        )
+        original_create = rrt_module.create_receive_activity_tree
         commit_tree_calls: list[str | None] = []
 
-        def tracking_create(case_id: str | None = None):
+        def tracking_create(
+            name: str,
+            case_id: str | None = None,
+            precondition_guards: list | None = None,
+            effect_nodes: list | None = None,
+        ):
             commit_tree_calls.append(case_id)
-            return original_create(case_id=case_id)
+            return original_create(
+                name=name,
+                case_id=case_id,
+                precondition_guards=precondition_guards or [],
+                effect_nodes=effect_nodes or [],
+            )
 
         monkeypatch.setattr(
             rrt_module,
-            "create_guarded_commit_case_ledger_entry_tree",
+            "create_receive_activity_tree",
             tracking_create,
         )
 
         ValidateReportReceivedUseCase(dl, event).execute()
 
         assert commit_tree_calls, (
-            "Expected create_guarded_commit_case_ledger_entry_tree to be "
+            "Expected create_receive_activity_tree to be "
             "called when receiving_actor_id == case_actor_id (CLP-10-002)"
         )
         assert commit_tree_calls[0] == CASE_ID, (

--- a/vultron/core/behaviors/case/accept_invite_tree.py
+++ b/vultron/core/behaviors/case/accept_invite_tree.py
@@ -23,11 +23,13 @@ Tree structure::
 
     AcceptInviteActorToCaseBT (Sequence, memory=False)
     ├── CheckInviteeNotAlreadyParticipantNode  — idempotency guard
+    ├── CapturePreCommitBackfillTargetNode     — snapshot ledger for resume case
+    ├── GuardedCommitCaseLedgerEntryBT         — record receipt (CLP-10-006)
     ├── CreateInviteeParticipantAtAcceptedNode — build participant at RM.ACCEPTED
     ├── MaybeSignEmbargoConsentNode            — sign when embargo is EM.ACTIVE
     ├── PersistInviteeParticipantNode          — dl.create, attach, save case
-    ├── GuardedCommitCaseLedgerEntryBT         — canonical log entry + SYNC-02-002 fan-out
-    └── EmitAnnounceCaseToInviteeNode          — queue Announce(VulnerabilityCase)
+    ├── EmitAnnounceCaseToInviteeNode          — queue Announce(VulnerabilityCase)
+    └── BackfillCanonicalLedgerToInviteeNode   — send prior ledger to invitee
 
 Specs: PCR-08-010 (identity constraint), CM-10-001/CM-10-003 (embargo
 consent), MV-10-003/MV-10-005 (announce after consent resolved).
@@ -41,7 +43,7 @@ import py_trees
 from py_trees.common import Status
 
 from vultron.core.behaviors.case.nodes import (
-    create_guarded_commit_case_ledger_entry_tree,
+    create_receive_activity_tree,
 )
 from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
 from vultron.core.models.protocols import (
@@ -64,6 +66,89 @@ from vultron.core.states.rm import RM
 from vultron.core.use_cases._helpers import _as_id
 
 logger = logging.getLogger(__name__)
+
+
+class CapturePreCommitBackfillTargetNode(DataLayerAction):
+    """Snapshot the current last ledger-entry index for resume-case backfill.
+
+    This node MUST appear AFTER ``CheckInviteeNotAlreadyParticipantNode`` in
+    the precondition-guards list, so it can read ``invitee_already_participant``
+    from the blackboard.
+
+    **Resume case** (invitee already registered, ``invitee_already_participant
+    = True``): the commit's ``FanOutLogEntryNode`` will include the invitee in
+    its recipient list (they are a current case participant), so
+    ``BackfillCanonicalLedgerToInviteeNode`` must limit its window to entries
+    that existed *before* the commit to avoid sending the new entry twice.
+    This node writes ``pre_commit_backfill_target`` to the blackboard.
+
+    **Fresh case** (invitee not yet registered, ``invitee_already_participant
+    = False``): the commit fan-out will NOT include the invitee (they are not
+    yet a participant), so backfill must include the newly committed entry in
+    its window.  This node does *not* write ``pre_commit_backfill_target``,
+    leaving ``BackfillCanonicalLedgerToInviteeNode`` to compute its target
+    from the post-commit ledger state.
+
+    Always returns ``SUCCESS``.
+    """
+
+    def __init__(self, case_id: str, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self.case_id = case_id
+
+    def setup(self, **kwargs) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="invitee_already_participant",
+            access=py_trees.common.Access.READ,
+        )
+        self.blackboard.register_key(
+            key="pre_commit_backfill_target",
+            access=py_trees.common.Access.WRITE,
+        )
+
+    def update(self) -> Status:
+        try:
+            already_participant = self.blackboard.get(
+                "invitee_already_participant"
+            )
+        except KeyError:
+            already_participant = False
+
+        if not already_participant:
+            # Fresh case: commit fan-out won't reach invitee (not yet
+            # registered).  Write None to pre_commit_backfill_target so that
+            # BackfillCanonicalLedgerToInviteeNode uses the post-commit target,
+            # and any stale value from a prior resume test is overwritten.
+            self.blackboard.pre_commit_backfill_target = None
+            self.logger.debug(
+                "%s: fresh invite — clearing pre-commit backfill target"
+                " (backfill will include post-commit entry)",
+                self.name,
+            )
+            return Status.SUCCESS
+
+        # Resume case: invitee IS already a participant.
+        # Capture the current last index so backfill doesn't re-send the
+        # accept-invite entry that the commit fan-out will deliver.
+        if self.datalayer is None:
+            self.blackboard.pre_commit_backfill_target = -1
+            return Status.SUCCESS
+
+        entries: list[LogEntryModel] = [
+            obj
+            for obj in self.datalayer.list_objects("CaseLedgerEntry")
+            if is_log_entry_model(obj) and obj.case_id == self.case_id
+        ]
+        target = entries[-1].log_index if entries else -1
+        self.blackboard.pre_commit_backfill_target = target
+        self.logger.debug(
+            "%s: resume case — pre-commit backfill target for case '%s' is %d",
+            self.name,
+            self.case_id,
+            target,
+        )
+        return Status.SUCCESS
 
 
 class CheckInviteeNotAlreadyParticipantNode(DataLayerCondition):
@@ -473,6 +558,10 @@ class BackfillCanonicalLedgerToInviteeNode(DataLayerAction):
         self.blackboard.register_key(
             key="sync_port", access=py_trees.common.Access.READ
         )
+        self.blackboard.register_key(
+            key="pre_commit_backfill_target",
+            access=py_trees.common.Access.READ,
+        )
 
     def initialise(self) -> None:
         super().initialise()
@@ -480,6 +569,25 @@ class BackfillCanonicalLedgerToInviteeNode(DataLayerAction):
             self._sync_port = cast(SyncActivityPort, self.blackboard.sync_port)
         except (AttributeError, KeyError):
             self._sync_port = None
+
+    def _resolve_backfill_target(self, entries: list[LogEntryModel]) -> int:
+        """Resolve the backfill target index.
+
+        Reads ``pre_commit_backfill_target`` from the blackboard when set to a
+        non-None int (resume case: CapturePreCommitBackfillTargetNode wrote the
+        last index BEFORE the commit so backfill does not re-send the new entry
+        that the commit fan-out already delivered).  ``None`` or a missing key
+        means fresh case — fall back to the post-commit last entry.
+        """
+        try:
+            pre_commit_target = self.blackboard.get(
+                "pre_commit_backfill_target"
+            )
+        except KeyError:
+            pre_commit_target = None
+        if pre_commit_target is not None:
+            return int(pre_commit_target)
+        return entries[-1].log_index if entries else -1
 
     def update(self) -> Status:
         if self.datalayer is None:
@@ -502,7 +610,7 @@ class BackfillCanonicalLedgerToInviteeNode(DataLayerAction):
         ]
         entries.sort(key=lambda log_entry: log_entry.log_index)
 
-        target_index = entries[-1].log_index if entries else -1
+        target_index = self._resolve_backfill_target(entries)
         state = self._load_or_create_state(target_index)
 
         if state.join_backfill_complete:
@@ -524,6 +632,8 @@ class BackfillCanonicalLedgerToInviteeNode(DataLayerAction):
         for entry in entries:
             if entry.log_index <= state.join_backfill_last_sent_index:
                 continue
+            if entry.log_index > target_index:
+                break
             self._sync_port.send_announce_log_entry(
                 entry=entry,
                 actor_id=self.actor_id,
@@ -660,13 +770,14 @@ def create_accept_invite_actor_to_case_tree(
     The returned Sequence::
 
         AcceptInviteActorToCaseBT (memory=False)
-        ├── CheckInviteeNotAlreadyParticipantNode — idempotency guard
+        ├── CheckInviteeNotAlreadyParticipantNode  — idempotency guard
+        ├── CapturePreCommitBackfillTargetNode     — snapshot ledger for resume case
+        ├── GuardedCommitCaseLedgerEntryBT         — record receipt (CLP-10-006)
         ├── CreateInviteeParticipantAtAcceptedNode — build participant at ACCEPTED
         ├── MaybeSignEmbargoConsentNode            — sign when EM.ACTIVE
         ├── PersistInviteeParticipantNode          — persist, attach, save case
         ├── EmitAnnounceCaseToInviteeNode          — queue Announce to invitee
-        ├── BackfillCanonicalLedgerToInviteeNode   — send prior ledger to invitee
-        └── GuardedCommitCaseLedgerEntryBT         — canonical log entry + fan-out
+        └── BackfillCanonicalLedgerToInviteeNode   — send prior ledger to invitee
 
     Args:
         case_id: ID of the VulnerabilityCase the invitee accepted.
@@ -676,13 +787,16 @@ def create_accept_invite_actor_to_case_tree(
         Configured ``Sequence`` ready for execution via
         :class:`~vultron.core.behaviors.bridge.BTBridge`.
     """
-    return py_trees.composites.Sequence(
+    return create_receive_activity_tree(
         name="AcceptInviteActorToCaseBT",
-        memory=False,
-        children=[
+        case_id=case_id,
+        precondition_guards=[
             CheckInviteeNotAlreadyParticipantNode(
                 case_id=case_id, invitee_id=invitee_id
             ),
+            CapturePreCommitBackfillTargetNode(case_id=case_id),
+        ],
+        effect_nodes=[
             CreateInviteeParticipantAtAcceptedNode(
                 case_id=case_id, invitee_id=invitee_id
             ),
@@ -698,12 +812,12 @@ def create_accept_invite_actor_to_case_tree(
             BackfillCanonicalLedgerToInviteeNode(
                 case_id=case_id, invitee_id=invitee_id
             ),
-            create_guarded_commit_case_ledger_entry_tree(case_id=case_id),
         ],
     )
 
 
 __all__ = [
+    "CapturePreCommitBackfillTargetNode",
     "CheckInviteeNotAlreadyParticipantNode",
     "CreateInviteeParticipantAtAcceptedNode",
     "MaybeSignEmbargoConsentNode",

--- a/vultron/core/behaviors/case/create_tree.py
+++ b/vultron/core/behaviors/case/create_tree.py
@@ -27,14 +27,14 @@ Structure:
     CreateCaseBT (Selector)
     ├─ CheckCaseAlreadyExists          # Early exit if case already in DataLayer
     └─ CreateCaseFlow (Sequence)
+       ├─ GuardedCommitCaseLedgerEntryBT  # Record receipt before effects (CLP-10-006)
        ├─ SetCaseAttributedTo          # Set attributed_to to actor_id (CM-02-008)
        ├─ PersistCase                  # Save VulnerabilityCase to DataLayer
        ├─ RecordCaseCreationEvents     # Backfill offer_received + case_created events (CM-02-009)
        ├─ CreateCaseOwnerParticipant   # Add case owner as initial participant (CM-02-008)
        ├─ CreateCaseActorNode          # Create CaseActor service (CM-02-001)
        ├─ EmitCreateCaseActivity       # Generate CreateCaseActivity activity
-       ├─ UpdateActorOutbox            # Append activity to actor outbox
-       └─ GuardedCommitCaseLedgerEntryBT  # CaseManager-only canonical log fan-out
+       └─ UpdateActorOutbox            # Append activity to actor outbox
 
 Note: ``ValidateCaseObject`` was removed (#716).  ``VultronBase.id_`` is typed
 ``NonEmptyString`` with a ``default_factory``, so Pydantic enforces a valid
@@ -64,7 +64,7 @@ from vultron.core.behaviors.case.nodes import (
     PersistCase,
     SetCaseAttributedTo,
     UpdateActorOutbox,
-    create_guarded_commit_case_ledger_entry_tree,
+    create_receive_activity_tree,
 )
 
 logger = logging.getLogger(__name__)
@@ -99,10 +99,11 @@ def create_create_case_tree(
     """
     case_id = case_obj.id_
 
-    create_case_flow = py_trees.composites.Sequence(
+    create_case_flow = create_receive_activity_tree(
         name="CreateCaseFlow",
-        memory=False,
-        children=[
+        case_id=case_id,
+        precondition_guards=[],
+        effect_nodes=[
             SetCaseAttributedTo(case_obj=case_obj),
             PersistCase(case_obj=case_obj),
             RecordCaseCreationEvents(case_obj=case_obj),
@@ -112,7 +113,6 @@ def create_create_case_tree(
             CreateCaseActorNode(case_id=case_id),
             EmitCreateCaseActivity(),
             UpdateActorOutbox(),
-            create_guarded_commit_case_ledger_entry_tree(case_id=case_id),
         ],
     )
 

--- a/vultron/core/behaviors/case/nodes/__init__.py
+++ b/vultron/core/behaviors/case/nodes/__init__.py
@@ -79,6 +79,7 @@ from vultron.core.behaviors.case.nodes.embargo import (
 from vultron.core.behaviors.case.nodes.lifecycle import (
     CommitCaseLedgerEntryNode,
     create_guarded_commit_case_ledger_entry_tree,
+    create_receive_activity_tree,
 )
 from vultron.core.behaviors.case.nodes.participant import (
     CreateParticipantStatusNode,
@@ -138,6 +139,7 @@ __all__ = [
     # lifecycle
     "CommitCaseLedgerEntryNode",
     "create_guarded_commit_case_ledger_entry_tree",
+    "create_receive_activity_tree",
     # update
     "CheckCaseUpdateOwnerNode",
     "CaptureCaseUpdateBroadcastExclusionsNode",

--- a/vultron/core/behaviors/case/nodes/lifecycle.py
+++ b/vultron/core/behaviors/case/nodes/lifecycle.py
@@ -238,6 +238,10 @@ def create_guarded_commit_case_ledger_entry_tree(
     The commit runs only when the executing actor holds ``CVDRole.CASE_MANAGER``
     for the case. Non-manager actors take the success fallback and skip the
     canonical commit silently.
+
+    Called internally by :func:`create_receive_activity_tree`.  Direct callers
+    in tree-factory modules are a CLP-10-006 ordering violation; use
+    ``create_receive_activity_tree`` instead.
     """
     from vultron.core.behaviors.case.nodes.conditions import (
         CheckIsCaseManagerNode,
@@ -259,4 +263,54 @@ def create_guarded_commit_case_ledger_entry_tree(
                 name="CommitCaseLedgerEntrySkippedNotCaseManager"
             ),
         ],
+    )
+
+
+def create_receive_activity_tree(
+    name: str,
+    case_id: str | None,
+    precondition_guards: list[py_trees.behaviour.Behaviour],
+    effect_nodes: list[py_trees.behaviour.Behaviour],
+) -> py_trees.composites.Sequence:
+    """Compose a receive-side BT with CLP-10-006 ordering.
+
+    Structurally enforces the correct receive-side ordering::
+
+        [*precondition_guards] → GuardedCommit(receipt) → [*effect_nodes]
+
+    Precondition guards are read-only checks that may return FAILURE to abort
+    the tree before any state is written.  The guarded commit ledgers receipt
+    of the triggering activity (which is on the blackboard before any node
+    runs, placed there by ``BTBridge.execute_with_setup``).  Effect nodes
+    perform state transitions, outbox enqueues, and participant mutations —
+    all of which happen only after the receipt is recorded.
+
+    When ``case_id`` is ``None`` the commit step is omitted entirely,
+    preserving behaviour for trees that receive no explicit case context.
+
+    Per ``specs/case-ledger-processing.yaml`` CLP-10-006.
+
+    Args:
+        name: Display name for the root Sequence node.
+        case_id: ID of the ``VulnerabilityCase`` to ledger against.  Pass
+            ``None`` to skip the commit step (no ledger entry written).
+        precondition_guards: Zero or more read-only condition nodes placed
+            before the commit.  These nodes MUST NOT write to the DataLayer.
+        effect_nodes: Zero or more action nodes placed after the commit.
+            These may perform any state mutation.
+
+    Returns:
+        Root ``Sequence`` node ready for execution via
+        :class:`~vultron.core.behaviors.bridge.BTBridge`.
+    """
+    children: list[py_trees.behaviour.Behaviour] = list(precondition_guards)
+    if case_id is not None:
+        children.append(
+            create_guarded_commit_case_ledger_entry_tree(case_id=case_id)
+        )
+    children.extend(effect_nodes)
+    return py_trees.composites.Sequence(
+        name=name,
+        memory=False,
+        children=children,
     )

--- a/vultron/core/behaviors/case/nodes/lifecycle.py
+++ b/vultron/core/behaviors/case/nodes/lifecycle.py
@@ -56,26 +56,6 @@ def _extract_payload_snapshot(
     )
 
 
-def _resolve_activity_fields(
-    activity: Any, case_id: str, dl: CasePersistence
-) -> tuple[str, str, dict[str, Any]]:
-    """Derive (object_id, event_type, payload_snapshot) from *activity*.
-
-    Falls back to ``case_id``-based defaults when *activity* is ``None``.
-    """
-    if activity is None:
-        return case_id, "case_event", {}
-    object_id: str = getattr(activity, "activity_id", case_id)
-    semantic_type = getattr(activity, "semantic_type", None)
-    event_type: str = (
-        semantic_type.value
-        if semantic_type is not None
-        else getattr(activity, "activity_type", "case_event") or "case_event"
-    )
-    payload_snapshot = _extract_payload_snapshot(activity, dl=dl)
-    return object_id, event_type, payload_snapshot
-
-
 class CommitCaseLedgerEntryNode(DataLayerAction):
     """
     Commit a hash-chained CaseLedgerEntry and fan it out to all case participants.
@@ -175,7 +155,7 @@ class CommitCaseLedgerEntryNode(DataLayerAction):
 
         case_id = self._resolve_case_id()
         if not case_id:
-            self.logger.debug(
+            self.logger.warning(
                 f"{self.name}: no case_id available — skipping log entry"
             )
             return Status.SUCCESS
@@ -239,6 +219,25 @@ def create_guarded_commit_case_ledger_entry_tree(
     for the case. Non-manager actors take the success fallback and skip the
     canonical commit silently.
 
+    Structure::
+
+        GuardedCommitCaseLedgerEntryBT (Selector)
+        ├── SkipIfNotCaseManager (Sequence)
+        │   └── Inverter(CheckIsCaseManagerNode)  # SUCCESS when NOT case manager
+        └── CommitCaseLedgerEntryNode             # only reached when IS case manager
+
+    Using an ``Inverter`` separates the two distinct FAILURE modes:
+
+    - Actor is NOT the case manager → ``Inverter`` converts FAILURE→SUCCESS,
+      ``SkipIfNotCaseManager`` succeeds, Selector returns SUCCESS (skip).
+    - Actor IS the case manager but commit fails → ``Inverter`` converts
+      SUCCESS→FAILURE, ``SkipIfNotCaseManager`` fails, Selector tries
+      ``CommitCaseLedgerEntryNode`` which returns FAILURE, Selector returns
+      FAILURE (propagates the infrastructure error to abort effect nodes).
+
+    This prevents the old fallback-Success pattern from masking a genuine
+    commit failure as a benign skip.
+
     Called internally by :func:`create_receive_activity_tree`.  Direct callers
     in tree-factory modules are a CLP-10-006 ordering violation; use
     ``create_receive_activity_tree`` instead.
@@ -247,21 +246,22 @@ def create_guarded_commit_case_ledger_entry_tree(
         CheckIsCaseManagerNode,
     )
 
+    check_node = CheckIsCaseManagerNode(case_id=case_id)
     return py_trees.composites.Selector(
         name="GuardedCommitCaseLedgerEntryBT",
         memory=False,
         children=[
             py_trees.composites.Sequence(
-                name="CommitIfCaseManager",
+                name="SkipIfNotCaseManager",
                 memory=False,
                 children=[
-                    CheckIsCaseManagerNode(case_id=case_id),
-                    CommitCaseLedgerEntryNode(case_id=case_id),
+                    py_trees.decorators.Inverter(
+                        name="InvertIsNotCaseManager",
+                        child=check_node,
+                    ),
                 ],
             ),
-            py_trees.behaviours.Success(
-                name="CommitCaseLedgerEntrySkippedNotCaseManager"
-            ),
+            CommitCaseLedgerEntryNode(case_id=case_id),
         ],
     )
 
@@ -307,6 +307,12 @@ def create_receive_activity_tree(
     if case_id is not None:
         children.append(
             create_guarded_commit_case_ledger_entry_tree(case_id=case_id)
+        )
+    else:
+        logger.debug(
+            "create_receive_activity_tree(%s): case_id is None"
+            " — commit step omitted",
+            name,
         )
     children.extend(effect_nodes)
     return py_trees.composites.Sequence(

--- a/vultron/core/behaviors/case/offer_case_manager_role_received_tree.py
+++ b/vultron/core/behaviors/case/offer_case_manager_role_received_tree.py
@@ -27,7 +27,7 @@ from vultron.core.behaviors.case.nodes.communication import (
     AutoAcceptCaseManagerRoleNode,
 )
 from vultron.core.behaviors.case.nodes.lifecycle import (
-    create_guarded_commit_case_ledger_entry_tree,
+    create_receive_activity_tree,
 )
 from vultron.core.behaviors.report.nodes.storage import StoreActivityNode
 
@@ -59,12 +59,12 @@ def create_offer_case_manager_role_received_tree(
     Structure::
 
         OfferCaseManagerRoleReceivedBT (Sequence)
-        ├── StoreActivityNode("OfferCaseManagerRole")
         ├── GuardedCommitOrSkip (Selector, only when case_id provided)
-        │   ├── Sequence
+        │   ├── Sequence                              # Record receipt (CLP-10-006)
         │   │   ├── CheckIsCaseManagerNode
         │   │   └── CommitCaseLedgerEntryNode
         │   └── Success("CommitSkippedNotCaseManager")
+        ├── StoreActivityNode("OfferCaseManagerRole")
         └── AutoAcceptCaseManagerRoleNode
 
     Args:
@@ -77,30 +77,21 @@ def create_offer_case_manager_role_received_tree(
     Returns:
         Root ``OfferCaseManagerRoleReceivedBT`` Sequence node.
     """
-    children: list[py_trees.behaviour.Behaviour] = [
-        StoreActivityNode(
-            activity_id=offer_id,
-            activity_obj=offer_obj,
-            label="OfferCaseManagerRole",
-        ),
-    ]
-
-    if case_id:
-        children.append(
-            create_guarded_commit_case_ledger_entry_tree(case_id=case_id)
-        )
-
-    children.append(
-        AutoAcceptCaseManagerRoleNode(
-            offer_id=offer_id,
-            case_id=case_id,
-            participant_id=participant_id,
-            vendor_id=vendor_id,
-        )
-    )
-
-    return py_trees.composites.Sequence(
+    return create_receive_activity_tree(
         name="OfferCaseManagerRoleReceivedBT",
-        memory=False,
-        children=children,
+        case_id=case_id if case_id else None,
+        precondition_guards=[],
+        effect_nodes=[
+            StoreActivityNode(
+                activity_id=offer_id,
+                activity_obj=offer_obj,
+                label="OfferCaseManagerRole",
+            ),
+            AutoAcceptCaseManagerRoleNode(
+                offer_id=offer_id,
+                case_id=case_id,
+                participant_id=participant_id,
+                vendor_id=vendor_id,
+            ),
+        ],
     )

--- a/vultron/core/behaviors/case/receive_close_case_tree.py
+++ b/vultron/core/behaviors/case/receive_close_case_tree.py
@@ -21,7 +21,7 @@ from typing import Any
 import py_trees
 
 from vultron.core.behaviors.case.nodes.lifecycle import (
-    create_guarded_commit_case_ledger_entry_tree,
+    create_receive_activity_tree,
 )
 from vultron.core.behaviors.report.nodes.storage import StoreActivityNode
 
@@ -38,12 +38,12 @@ def create_close_case_received_tree(
     Structure::
 
         CloseCaseBT (Sequence)
-        ├── StoreActivityNode("Leave")
-        └── GuardedCommitOrSkip (Selector)
-            ├── Sequence
-            │   ├── CheckIsCaseManagerNode
-            │   └── CommitCaseLedgerEntryNode
-            └── Success("CommitSkippedNotCaseManager")
+        ├── GuardedCommitOrSkip (Selector)             # Record receipt (CLP-10-006)
+        │   ├── Sequence
+        │   │   ├── CheckIsCaseManagerNode
+        │   │   └── CommitCaseLedgerEntryNode
+        │   └── Success("CommitSkippedNotCaseManager")
+        └── StoreActivityNode("Leave")                 # Persist inbound Leave activity
 
     Running under ``actor_id=receiving_actor_id`` means
     ``CheckIsCaseManagerNode`` naturally gates the commit to the actor that
@@ -57,15 +57,15 @@ def create_close_case_received_tree(
     Returns:
         Root ``CloseCaseBT`` Sequence node.
     """
-    return py_trees.composites.Sequence(
+    return create_receive_activity_tree(
         name="CloseCaseBT",
-        memory=False,
-        children=[
+        case_id=case_id,
+        precondition_guards=[],
+        effect_nodes=[
             StoreActivityNode(
                 activity_id=activity_id,
                 activity_obj=activity_obj,
                 label="Leave",
             ),
-            create_guarded_commit_case_ledger_entry_tree(case_id=case_id),
         ],
     )

--- a/vultron/core/behaviors/embargo/announce_teardown_tree.py
+++ b/vultron/core/behaviors/embargo/announce_teardown_tree.py
@@ -275,15 +275,20 @@ def reject_invite_to_embargo_tree(
     Returns:
         Root node of the ``RejectInviteToEmbargoBT`` Sequence.
     """
+    effect_nodes: list[py_trees.behaviour.Behaviour] = [
+        OptionalLookupParticipantNode(case_id=case_id),
+        UpdateParticipantEmbargoPecNode(pec_trigger=PEC_Trigger.DECLINE),
+    ]
+    if embargo_id is not None:
+        # Only attempt pocket-veto removal when we know which embargo to check.
+        effect_nodes.insert(
+            1, RemoveStaleAcceptanceNode(embargo_id=embargo_id)
+        )
     root = create_receive_activity_tree(
         name="RejectInviteToEmbargoBT",
         case_id=case_id,
         precondition_guards=[],
-        effect_nodes=[
-            OptionalLookupParticipantNode(case_id=case_id),
-            RemoveStaleAcceptanceNode(embargo_id=embargo_id or ""),
-            UpdateParticipantEmbargoPecNode(pec_trigger=PEC_Trigger.DECLINE),
-        ],
+        effect_nodes=effect_nodes,
     )
     logger.info(
         "Created RejectInviteToEmbargoBT for case=%s rejecting_actor=%s"

--- a/vultron/core/behaviors/embargo/announce_teardown_tree.py
+++ b/vultron/core/behaviors/embargo/announce_teardown_tree.py
@@ -23,13 +23,13 @@ activity (protocol ET message).  Sequence:
 
     RemoveEmbargoFromCaseBT (Sequence)
     ├─ ValidateCaseExistsNode          # case must exist and pass is_case_model
+    ├─ GuardedCommitCaseLedgerEntryBT  # record receipt before effects (CLP-10-006)
     ├─ RemoveFromProposedEmbargoesNode # idempotent proposed-list cleanup
-    ├─ TeardownIfActive (Selector)     # run teardown if active; skip silently
-    │  ├─ ActiveTeardown (Sequence)
-    │  │  ├─ IsActiveEmbargoNode       # guard: is this the active embargo?
-    │  │  └─ ApplyEmbargoTeardownNode  # ACTIVE/REVISE→EXITED, clear, reset PEC
-    │  └─ Success                      # embargo was only in proposed — not an error
-    └─ GuardedCommitCaseLedgerEntryBT  # commit only when actor is CASE_MANAGER
+    └─ TeardownIfActive (Selector)     # run teardown if active; skip silently
+       ├─ ActiveTeardown (Sequence)
+       │  ├─ IsActiveEmbargoNode       # guard: is this the active embargo?
+       │  └─ ApplyEmbargoTeardownNode  # ACTIVE/REVISE→EXITED, clear, reset PEC
+       └─ Success                      # embargo was only in proposed — not an error
 
 Per specs/behavior-tree-integration.yaml BT-06-001.
 """
@@ -39,7 +39,7 @@ import logging
 import py_trees
 
 from vultron.core.behaviors.case.nodes import (
-    create_guarded_commit_case_ledger_entry_tree,
+    create_receive_activity_tree,
 )
 from vultron.core.behaviors.embargo.nodes import (
     ApplyEmbargoTeardownNode,
@@ -86,32 +86,32 @@ def remove_embargo_from_case_tree(
     Returns:
         Root node of the ``RemoveEmbargoFromCaseBT`` Sequence.
     """
-    root = py_trees.composites.Sequence(
-        name="RemoveEmbargoFromCaseBT",
+    teardown_if_active = py_trees.composites.Selector(
+        name="TeardownIfActive",
         memory=False,
         children=[
-            ValidateCaseExistsNode(case_id=case_id),
+            py_trees.composites.Sequence(
+                name="ActiveTeardown",
+                memory=False,
+                children=[
+                    IsActiveEmbargoNode(
+                        case_id=case_id, embargo_id=embargo_id
+                    ),
+                    ApplyEmbargoTeardownNode(case_id=case_id),
+                ],
+            ),
+            py_trees.behaviours.Success(name="EmbargoWasNotActive"),
+        ],
+    )
+    root = create_receive_activity_tree(
+        name="RemoveEmbargoFromCaseBT",
+        case_id=case_id,
+        precondition_guards=[ValidateCaseExistsNode(case_id=case_id)],
+        effect_nodes=[
             RemoveFromProposedEmbargoesNode(
                 case_id=case_id, embargo_id=embargo_id
             ),
-            py_trees.composites.Selector(
-                name="TeardownIfActive",
-                memory=False,
-                children=[
-                    py_trees.composites.Sequence(
-                        name="ActiveTeardown",
-                        memory=False,
-                        children=[
-                            IsActiveEmbargoNode(
-                                case_id=case_id, embargo_id=embargo_id
-                            ),
-                            ApplyEmbargoTeardownNode(case_id=case_id),
-                        ],
-                    ),
-                    py_trees.behaviours.Success(name="EmbargoWasNotActive"),
-                ],
-            ),
-            create_guarded_commit_case_ledger_entry_tree(case_id=case_id),
+            teardown_if_active,
         ],
     )
     logger.info(
@@ -142,13 +142,12 @@ def add_embargo_to_case_tree(
     Returns:
         Root node of the ``AddEmbargoToCaseBT`` Sequence.
     """
-    root = py_trees.composites.Sequence(
+    root = create_receive_activity_tree(
         name="AddEmbargoToCaseBT",
-        memory=False,
-        children=[
-            ValidateCaseExistsNode(case_id=case_id),
+        case_id=case_id,
+        precondition_guards=[ValidateCaseExistsNode(case_id=case_id)],
+        effect_nodes=[
             SetEmbargoActiveNode(case_id=case_id, embargo_id=embargo_id),
-            create_guarded_commit_case_ledger_entry_tree(case_id=case_id),
         ],
     )
     logger.info(
@@ -183,16 +182,16 @@ def invite_to_embargo_on_case_tree(
     Returns:
         Root node of the ``InviteToEmbargoOnCaseBT`` Sequence.
     """
-    root = py_trees.composites.Sequence(
+    root = create_receive_activity_tree(
         name="InviteToEmbargoOnCaseBT",
-        memory=False,
-        children=[
+        case_id=case_id,
+        precondition_guards=[],
+        effect_nodes=[
             CreateAndStoreInviteNode(),
             OptionalLookupParticipantNode(
                 case_id=case_id, target_actor_id=invitee_id
             ),
             UpdateParticipantEmbargoPecNode(pec_trigger=PEC_Trigger.INVITE),
-            create_guarded_commit_case_ledger_entry_tree(case_id=case_id),
         ],
     )
     logger.info(
@@ -228,17 +227,16 @@ def accept_invite_to_embargo_tree(
     Returns:
         Root node of the ``AcceptInviteToEmbargoBT`` Sequence.
     """
-    root = py_trees.composites.Sequence(
+    root = create_receive_activity_tree(
         name="AcceptInviteToEmbargoBT",
-        memory=False,
-        children=[
-            ValidateCaseExistsNode(case_id=case_id),
+        case_id=case_id,
+        precondition_guards=[ValidateCaseExistsNode(case_id=case_id)],
+        effect_nodes=[
             RecordParticipantAcceptanceNode(
                 case_id=case_id,
                 embargo_id=embargo_id,
                 accepting_actor_id=accepting_actor_id,
             ),
-            create_guarded_commit_case_ledger_entry_tree(case_id=case_id),
         ],
     )
     logger.info(
@@ -277,14 +275,14 @@ def reject_invite_to_embargo_tree(
     Returns:
         Root node of the ``RejectInviteToEmbargoBT`` Sequence.
     """
-    root = py_trees.composites.Sequence(
+    root = create_receive_activity_tree(
         name="RejectInviteToEmbargoBT",
-        memory=False,
-        children=[
+        case_id=case_id,
+        precondition_guards=[],
+        effect_nodes=[
             OptionalLookupParticipantNode(case_id=case_id),
             RemoveStaleAcceptanceNode(embargo_id=embargo_id or ""),
             UpdateParticipantEmbargoPecNode(pec_trigger=PEC_Trigger.DECLINE),
-            create_guarded_commit_case_ledger_entry_tree(case_id=case_id),
         ],
     )
     logger.info(

--- a/vultron/core/behaviors/report/prioritize_tree.py
+++ b/vultron/core/behaviors/report/prioritize_tree.py
@@ -31,15 +31,15 @@ Structure:
 
     EngageCaseBT (Sequence)
     ├─ CheckParticipantExists                        # Precondition: actor has a participant record
+    ├─ GuardedCommitCaseLedgerEntryBT                  # Record receipt before effects (CLP-10-006)
     ├─ TransitionParticipantRMtoAccepted             # Update RM state to ACCEPTED
-    ├─ GuardedCommitCaseLedgerEntryBT                  # CaseManager-only canonical log fan-out
     ├─ CaptureCaseUpdateBroadcastExclusionsNode      # Resolve embargo-based exclusions
     └─ BroadcastCaseUpdateNode                       # Announce(VulnerabilityCase) → all participants
 
     DeferCaseBT (Sequence)
     ├─ CheckParticipantExists              # Precondition: actor has a participant record
-    ├─ TransitionParticipantRMtoDeferred   # Update RM state to DEFERRED
-    └─ GuardedCommitCaseLedgerEntryBT         # CaseManager-only canonical log fan-out
+    ├─ GuardedCommitCaseLedgerEntryBT         # Record receipt before effects (CLP-10-006)
+    └─ TransitionParticipantRMtoDeferred   # Update RM state to DEFERRED
 
 Note: EvaluateCasePriority (in nodes.py) is the stub node for the outgoing
 direction — when the local actor decides whether to engage or defer. It is
@@ -56,7 +56,7 @@ from vultron.core.behaviors.case.engage_defer_trigger_tree import (
     engage_case_trigger_bt,
 )
 from vultron.core.behaviors.case.nodes import (
-    create_guarded_commit_case_ledger_entry_tree,
+    create_receive_activity_tree,
 )
 from vultron.core.behaviors.case.nodes.update import (
     BroadcastCaseUpdateNode,
@@ -96,15 +96,16 @@ def create_engage_case_tree(
     Returns:
         Root node of the engage_case behavior tree (Sequence)
     """
-    root = py_trees.composites.Sequence(
+    root = create_receive_activity_tree(
         name="EngageCaseBT",
-        memory=False,
-        children=[
+        case_id=case_id,
+        precondition_guards=[
             CheckParticipantExists(case_id=case_id, actor_id=actor_id),
+        ],
+        effect_nodes=[
             TransitionParticipantRMtoAccepted(
                 case_id=case_id, actor_id=actor_id
             ),
-            create_guarded_commit_case_ledger_entry_tree(case_id=case_id),
             CaptureCaseUpdateBroadcastExclusionsNode(case_id=case_id),
             BroadcastCaseUpdateNode(case_id=case_id),
         ],
@@ -132,15 +133,16 @@ def create_defer_case_tree(
     Returns:
         Root node of the defer_case behavior tree (Sequence)
     """
-    root = py_trees.composites.Sequence(
+    root = create_receive_activity_tree(
         name="DeferCaseBT",
-        memory=False,
-        children=[
+        case_id=case_id,
+        precondition_guards=[
             CheckParticipantExists(case_id=case_id, actor_id=actor_id),
+        ],
+        effect_nodes=[
             TransitionParticipantRMtoDeferred(
                 case_id=case_id, actor_id=actor_id
             ),
-            create_guarded_commit_case_ledger_entry_tree(case_id=case_id),
         ],
     )
 

--- a/vultron/core/behaviors/report/received_report_trees.py
+++ b/vultron/core/behaviors/report/received_report_trees.py
@@ -229,14 +229,16 @@ def create_ack_report_received_tree(
 
     Handles receipt of a ``Read(Offer(Report))`` (AckReport) activity.
 
-    Steps (Sequence):
-    1. Store AckReport activity idempotently.
-    2. Emit AckReport to CaseActor (Selector — graceful no-op if no CaseActor).
-    3. Guarded commit (only when ``case_id`` is provided and the receiving
-       actor holds ``CVDRole.CASE_MANAGER``).
+    Steps (Sequence via :func:`create_receive_activity_tree`):
+
+    1. Guarded commit (only when ``case_id`` is provided and the receiving
+       actor holds ``CVDRole.CASE_MANAGER``) — records receipt before any
+       effects run (CLP-10-006).
+    2. Store AckReport activity idempotently.
+    3. Emit AckReport to CaseActor (Selector — graceful no-op if no CaseActor).
 
     When running under ``actor_id=receiving_actor_id`` (ADR-0022 single-BT
-    shape), step 2's ``EmitAckReportActivity`` uses the blackboard
+    shape), step 3's ``EmitAckReportActivity`` uses the blackboard
     ``actor_id`` as sender.  On the received side (no TriggerActivityPort),
     the emit node returns FAILURE and the ``NoEmitFallback`` Success absorbs
     it — so the emit is a graceful no-op in the typical CaseActor context.
@@ -244,8 +246,8 @@ def create_ack_report_received_tree(
     Args:
         request: The parsed inbound domain event.
         case_id: ID of the VulnerabilityCase linked to this report.  When
-            provided, a guarded-commit subtree is appended so the receiving
-            CaseActor can write a canonical ledger entry.
+            provided, a guarded-commit subtree is inserted first so the
+            receiving CaseActor can write a canonical ledger entry.
 
     Returns:
         Root node of the ``AckReportReceivedBT`` Sequence.

--- a/vultron/core/behaviors/report/received_report_trees.py
+++ b/vultron/core/behaviors/report/received_report_trees.py
@@ -41,7 +41,7 @@ from vultron.core.models.events.report import (
     InvalidateReportReceivedEvent,
 )
 from vultron.core.behaviors.case.nodes.lifecycle import (
-    create_guarded_commit_case_ledger_entry_tree,
+    create_receive_activity_tree,
 )
 from vultron.core.behaviors.report.nodes.conditions import (
     CheckRMStateReceivedOrInvalid,
@@ -80,31 +80,29 @@ def create_validate_report_received_tree(
     under ``actor_id=receiving_actor_id`` while still transitioning the
     *sender's* RM state to VALID.
 
-    When ``case_id`` is provided, the guarded-commit subtree
-    (``create_guarded_commit_case_ledger_entry_tree``) is appended as the
-    final child so ``CheckIsCaseManagerNode`` fires when the receiving actor
-    holds ``CVDRole.CASE_MANAGER``.  When ``case_id`` is ``None`` the tree
-    omits the guarded commit entirely (no ledger entry is written).
+    When ``case_id`` is provided, a guarded-commit subtree is inserted before
+    the validation effects so receipt is recorded before any RM state
+    transitions run (CLP-10-006).  Pass ``None`` to skip ledger commit.
 
     Structure::
 
         ValidateReportReceivedBT (Sequence)
-        ├── ValidationOrSkip (Selector)
-        │   ├── ValidationOrShortcut (Selector)   # try validation
-        │   │   ├── CheckRMStateValid(sender_actor_id)       # idempotency exit
-        │   │   └── ValidationFlow (Sequence)
-        │   │       ├── CheckRMStateReceivedOrInvalid(sender_actor_id)
-        │   │       ├── EvaluateReportCredibility
-        │   │       ├── EvaluateReportValidity
-        │   │       └── ValidationActions (Sequence)
-        │   │           ├── TransitionRMtoValid(sender_actor_id)
-        │   │           └── EnsureEmbargoExists
-        │   └── Success("ValidationSkipped")        # fallback — commit always runs
-        └── GuardedCommitOrSkip (Selector, only if case_id)
-            ├── Sequence
-            │   ├── CheckIsCaseManagerNode
-            │   └── CommitCaseLedgerEntryNode
-            └── Success("CommitSkippedNotCaseManager")
+        ├── GuardedCommitOrSkip (Selector, only if case_id)  # Record receipt (CLP-10-006)
+        │   ├── Sequence
+        │   │   ├── CheckIsCaseManagerNode
+        │   │   └── CommitCaseLedgerEntryNode
+        │   └── Success("CommitSkippedNotCaseManager")
+        └── ValidationOrSkip (Selector)
+            ├── ValidationOrShortcut (Selector)   # try validation
+            │   ├── CheckRMStateValid(sender_actor_id)       # idempotency exit
+            │   └── ValidationFlow (Sequence)
+            │       ├── CheckRMStateReceivedOrInvalid(sender_actor_id)
+            │       ├── EvaluateReportCredibility
+            │       ├── EvaluateReportValidity
+            │       └── ValidationActions (Sequence)
+            │           ├── TransitionRMtoValid(sender_actor_id)
+            │           └── EnsureEmbargoExists
+            └── Success("ValidationSkipped")        # fallback — commit already ran
 
     Args:
         report_id: ID of the VulnerabilityReport being validated.
@@ -154,26 +152,20 @@ def create_validate_report_received_tree(
         ],
     )
 
-    children: list[py_trees.behaviour.Behaviour] = [
-        py_trees.composites.Selector(
-            name="ValidationOrSkip",
-            memory=False,
-            children=[
-                validation_or_shortcut,
-                py_trees.behaviours.Success(name="ValidationSkipped"),
-            ],
-        )
-    ]
-
-    if case_id is not None:
-        children.append(
-            create_guarded_commit_case_ledger_entry_tree(case_id=case_id)
-        )
-
-    root = py_trees.composites.Sequence(
-        name="ValidateReportReceivedBT",
+    validation_or_skip = py_trees.composites.Selector(
+        name="ValidationOrSkip",
         memory=False,
-        children=children,
+        children=[
+            validation_or_shortcut,
+            py_trees.behaviours.Success(name="ValidationSkipped"),
+        ],
+    )
+
+    root = create_receive_activity_tree(
+        name="ValidateReportReceivedBT",
+        case_id=case_id,
+        precondition_guards=[],
+        effect_nodes=[validation_or_skip],
     )
     logger.debug(
         "Created ValidateReportReceivedBT for report=%s offer=%s sender=%s"
@@ -262,34 +254,30 @@ def create_ack_report_received_tree(
     offer_id = request.offer_id or activity_id
     report_id = request.report_id or ""
 
-    children: list[py_trees.behaviour.Behaviour] = [
-        StoreActivityNode(
-            activity_id=activity_id,
-            activity_obj=request.activity,
-            label="AckReport",
-        ),
-        py_trees.composites.Selector(
-            name="MaybeEmitAckToCaseActor",
-            memory=False,
-            children=[
-                EmitAckReportActivity(
-                    offer_id=offer_id,
-                    report_id=report_id,
-                ),
-                py_trees.behaviours.Success(name="NoEmitFallback"),
-            ],
-        ),
-    ]
-
-    if case_id is not None:
-        children.append(
-            create_guarded_commit_case_ledger_entry_tree(case_id=case_id)
-        )
-
-    root = py_trees.composites.Sequence(
-        name="AckReportReceivedBT",
+    maybe_emit = py_trees.composites.Selector(
+        name="MaybeEmitAckToCaseActor",
         memory=False,
-        children=children,
+        children=[
+            EmitAckReportActivity(
+                offer_id=offer_id,
+                report_id=report_id,
+            ),
+            py_trees.behaviours.Success(name="NoEmitFallback"),
+        ],
+    )
+
+    root = create_receive_activity_tree(
+        name="AckReportReceivedBT",
+        case_id=case_id,
+        precondition_guards=[],
+        effect_nodes=[
+            StoreActivityNode(
+                activity_id=activity_id,
+                activity_obj=request.activity,
+                label="AckReport",
+            ),
+            maybe_emit,
+        ],
     )
     logger.debug(
         "Created AckReportReceivedBT for activity=%s case=%s",

--- a/vultron/core/behaviors/status/add_participant_status_tree.py
+++ b/vultron/core/behaviors/status/add_participant_status_tree.py
@@ -21,18 +21,19 @@ Composes the four-step DEMOMA-07-003 workflow as a Sequence BT
 
     AddParticipantStatusBT (Sequence)
     ├─ VerifySenderIsParticipantNode      # Step 1: sender must be known participant
-    ├─ AppendParticipantStatusNode        # Step 2: append status to participant record
-    ├─ PublicDisclosureBranchNode         # Step 4: embargo teardown on CS.P + CASE_OWNER
-    ├─ AutoCloseIfCaseManager (Selector)  # Step 5: auto-close only when CASE_MANAGER
+    ├─ CheckParticipantRMNotClosedNode    # Guard: reject terminal CLOSED→CLOSED rewrites
+    ├─ GuardedCommitOrSkip (Selector, only if case_id)  # Record receipt first (CLP-10-006)
     │   ├─ Sequence
     │   │   ├─ CheckIsCaseManagerNode
-    │   │   └─ AutoCloseBranchNode
-    │   └─ Success (skip if not CASE_MANAGER)
-    └─ GuardedCommitOrSkip (Selector, only if case_id)  # ADR-0022 / CLP-10-005
+    │   │   └─ CommitCaseLedgerEntryNode
+    │   └─ Success("CommitSkippedNotCaseManager")
+    ├─ AppendParticipantStatusNode        # Step 2: append status to participant record
+    ├─ PublicDisclosureBranchNode         # Step 4: embargo teardown on CS.P + CASE_OWNER
+    └─ AutoCloseIfCaseManager (Selector)  # Step 5: auto-close only when CASE_MANAGER
         ├─ Sequence
         │   ├─ CheckIsCaseManagerNode
-        │   └─ CommitCaseLedgerEntryNode
-        └─ Success("CommitSkippedNotCaseManager")
+        │   └─ AutoCloseBranchNode
+        └─ Success (skip if not CASE_MANAGER)
 
 Per specs/multi-actor-demo.yaml DEMOMA-07-003 and DEMOMA-07-005.
 """
@@ -46,13 +47,14 @@ from vultron.core.models.events.status import (
 )
 from vultron.core.behaviors.case.nodes.conditions import CheckIsCaseManagerNode
 from vultron.core.behaviors.case.nodes.lifecycle import (
-    create_guarded_commit_case_ledger_entry_tree,
+    create_receive_activity_tree,
 )
 from vultron.core.behaviors.status.append_participant_status_tree import (
     append_participant_status_tree,
 )
 from vultron.core.behaviors.status.nodes import (
     AutoCloseBranchNode,
+    CheckParticipantRMNotClosedNode,
     PublicDisclosureBranchNode,
     VerifySenderIsParticipantNode,
 )
@@ -70,9 +72,10 @@ def add_participant_status_tree(
     activity.  Implements the four remaining steps of DEMOMA-07-003 as BT
     nodes in a Sequence (step 3 raw re-broadcast removed per DEMOMA-07-005).
 
-    When ``case_id`` is provided, a guarded-commit subtree
-    (``create_guarded_commit_case_ledger_entry_tree``) is appended as the
-    final child.  Running the tree with ``actor_id=receiving_actor_id``
+    When ``case_id`` is provided, a guarded-commit subtree is inserted as the
+    first child (before precondition checks) so the canonical ledger records
+    receipt of the triggering activity before any protocol effects run
+    (CLP-10-006).  Running the tree with ``actor_id=receiving_actor_id``
     (ADR-0022 single-BT shape) means ``CheckIsCaseManagerNode`` in that
     subtree correctly fires only when the receiving actor holds
     ``CVDRole.CASE_MANAGER``.
@@ -108,50 +111,46 @@ def add_participant_status_tree(
         if context_field:
             tree_case_id = str(context_field)
 
-    children: list[py_trees.behaviour.Behaviour] = [
-        VerifySenderIsParticipantNode(
-            status_id=status_id,
-            sender_actor_id=actor_id,
-            case_id=tree_case_id,
-        ),
-        append_participant_status_tree(
-            status_id=status_id,
-            participant_id=participant_id,
-            status_obj_fallback=status_obj,
-        ),
-        PublicDisclosureBranchNode(
-            status_obj=status_obj,
-            sender_actor_id=actor_id,
-            case_id=tree_case_id,
-        ),
-        py_trees.composites.Selector(
-            name="AutoCloseIfCaseManager",
-            memory=False,
-            children=[
-                py_trees.composites.Sequence(
-                    name="CaseManagerAutoClose",
-                    memory=False,
-                    children=[
-                        CheckIsCaseManagerNode(case_id=tree_case_id),
-                        AutoCloseBranchNode(case_id=tree_case_id),
-                    ],
-                ),
-                py_trees.behaviours.Success(
-                    name="AutoCloseSkippedNotCaseManager"
-                ),
-            ],
-        ),
-    ]
-
-    if case_id is not None:
-        children.append(
-            create_guarded_commit_case_ledger_entry_tree(case_id=case_id)
-        )
-
-    root = py_trees.composites.Sequence(
-        name="AddParticipantStatusBT",
+    auto_close_selector = py_trees.composites.Selector(
+        name="AutoCloseIfCaseManager",
         memory=False,
-        children=children,
+        children=[
+            py_trees.composites.Sequence(
+                name="CaseManagerAutoClose",
+                memory=False,
+                children=[
+                    CheckIsCaseManagerNode(case_id=tree_case_id),
+                    AutoCloseBranchNode(case_id=tree_case_id),
+                ],
+            ),
+            py_trees.behaviours.Success(name="AutoCloseSkippedNotCaseManager"),
+        ],
+    )
+
+    root = create_receive_activity_tree(
+        name="AddParticipantStatusBT",
+        case_id=case_id,
+        precondition_guards=[
+            VerifySenderIsParticipantNode(
+                status_id=status_id,
+                sender_actor_id=actor_id,
+                case_id=tree_case_id,
+            ),
+            CheckParticipantRMNotClosedNode(participant_id=participant_id),
+        ],
+        effect_nodes=[
+            append_participant_status_tree(
+                status_id=status_id,
+                participant_id=participant_id,
+                status_obj_fallback=status_obj,
+            ),
+            PublicDisclosureBranchNode(
+                status_obj=status_obj,
+                sender_actor_id=actor_id,
+                case_id=tree_case_id,
+            ),
+            auto_close_selector,
+        ],
     )
     logger.debug(
         "Created AddParticipantStatusBT for status=%s participant=%s"

--- a/vultron/core/behaviors/status/add_participant_status_tree.py
+++ b/vultron/core/behaviors/status/add_participant_status_tree.py
@@ -21,12 +21,11 @@ Composes the four-step DEMOMA-07-003 workflow as a Sequence BT
 
     AddParticipantStatusBT (Sequence)
     ├─ VerifySenderIsParticipantNode      # Step 1: sender must be known participant
-    ├─ CheckParticipantRMNotClosedNode    # Guard: reject terminal CLOSED→CLOSED rewrites
+    ├─ CheckParticipantRMNotClosedNode    # Guard: reject CLOSED→CLOSED rewrites
     ├─ GuardedCommitOrSkip (Selector, only if case_id)  # Record receipt first (CLP-10-006)
-    │   ├─ Sequence
-    │   │   ├─ CheckIsCaseManagerNode
-    │   │   └─ CommitCaseLedgerEntryNode
-    │   └─ Success("CommitSkippedNotCaseManager")
+    │   ├─ Sequence("SkipIfNotCaseManager")
+    │   │   └─ Inverter(CheckIsCaseManagerNode)
+    │   └─ CommitCaseLedgerEntryNode
     ├─ AppendParticipantStatusNode        # Step 2: append status to participant record
     ├─ PublicDisclosureBranchNode         # Step 4: embargo teardown on CS.P + CASE_OWNER
     └─ AutoCloseIfCaseManager (Selector)  # Step 5: auto-close only when CASE_MANAGER
@@ -72,18 +71,18 @@ def add_participant_status_tree(
     activity.  Implements the four remaining steps of DEMOMA-07-003 as BT
     nodes in a Sequence (step 3 raw re-broadcast removed per DEMOMA-07-005).
 
-    When ``case_id`` is provided, a guarded-commit subtree is inserted as the
-    first child (before precondition checks) so the canonical ledger records
-    receipt of the triggering activity before any protocol effects run
-    (CLP-10-006).  Running the tree with ``actor_id=receiving_actor_id``
-    (ADR-0022 single-BT shape) means ``CheckIsCaseManagerNode`` in that
-    subtree correctly fires only when the receiving actor holds
-    ``CVDRole.CASE_MANAGER``.
+    When ``case_id`` is provided (or derived from the inline status object),
+    a guarded-commit subtree is inserted after precondition guards so the
+    canonical ledger records receipt of the triggering activity before any
+    protocol effects run (CLP-10-006).  Running the tree with
+    ``actor_id=receiving_actor_id`` (ADR-0022 single-BT shape) means
+    ``CheckIsCaseManagerNode`` in that subtree correctly fires only when
+    the receiving actor holds ``CVDRole.CASE_MANAGER``.
 
-    The *case_id* for the existing children is derived from the inline
-    ``request.status.context`` field.  If it is not available in the inline
-    object, the ``VerifySenderIsParticipantNode`` will perform a DataLayer
-    lookup.
+    The *case_id* for the commit and all children is derived from the inline
+    ``request.status.context`` field when not supplied explicitly.  If it
+    is not available in the inline object, the
+    ``VerifySenderIsParticipantNode`` will perform a DataLayer lookup.
 
     ``PublicDisclosureBranchNode`` uses the ``trigger_activity_factory`` that
     the caller places on the py_trees blackboard via
@@ -91,9 +90,11 @@ def add_participant_status_tree(
 
     Args:
         request: The parsed inbound domain event.
-        case_id: ID of the VulnerabilityCase.  When provided, a guarded-commit
-            subtree is appended so the receiving CaseActor writes a canonical
-            ledger entry (CLP-10-005).  Pass ``None`` to skip the commit.
+    case_id: ID of the VulnerabilityCase.  When provided (or derivable
+        from the inline status object), a guarded-commit subtree is
+        inserted after precondition guards so the receiving CaseActor
+        writes a canonical ledger entry (CLP-10-005).  Pass ``None``
+        (with no derivable context) to skip the commit.
 
     Returns:
         Root node of the ``AddParticipantStatusBT`` Sequence.
@@ -129,14 +130,17 @@ def add_participant_status_tree(
 
     root = create_receive_activity_tree(
         name="AddParticipantStatusBT",
-        case_id=case_id,
+        case_id=tree_case_id,
         precondition_guards=[
             VerifySenderIsParticipantNode(
                 status_id=status_id,
                 sender_actor_id=actor_id,
                 case_id=tree_case_id,
             ),
-            CheckParticipantRMNotClosedNode(participant_id=participant_id),
+            CheckParticipantRMNotClosedNode(
+                participant_id=participant_id,
+                status_id=status_id,
+            ),
         ],
         effect_nodes=[
             append_participant_status_tree(

--- a/vultron/core/behaviors/status/nodes/__init__.py
+++ b/vultron/core/behaviors/status/nodes/__init__.py
@@ -47,6 +47,7 @@ from vultron.core.behaviors.status.nodes.conditions import (
 )
 from vultron.core.behaviors.status.nodes.append import (
     AppendStatusAndSaveParticipantNode,
+    CheckParticipantRMNotClosedNode,
     CheckStatusNotAlreadyAppendedNode,
     LoadParticipantNode,
     ResolveAndPersistStatusObjectNode,
@@ -65,6 +66,7 @@ __all__ = [
     # append
     "LoadParticipantNode",
     "CheckStatusNotAlreadyAppendedNode",
+    "CheckParticipantRMNotClosedNode",
     "ResolveAndPersistStatusObjectNode",
     "ValidateRMTransitionNode",
     "AppendStatusAndSaveParticipantNode",

--- a/vultron/core/behaviors/status/nodes/append.py
+++ b/vultron/core/behaviors/status/nodes/append.py
@@ -423,21 +423,31 @@ class AppendStatusAndSaveParticipantNode(DataLayerAction):
 
 
 class CheckParticipantRMNotClosedNode(DataLayerCondition):
-    """Pre-flight guard: FAILURE when participant is already in RM.CLOSED.
+    """Pre-flight guard: FAILURE when participant is in RM.CLOSED with no prior
+    status match.
 
-    Used as a precondition guard in ``add_participant_status_tree`` so that
-    a terminal-state status update is rejected BEFORE the commit runs
-    (CLP-10-006).  A CLOSED→CLOSED rewrite is a no-op that must not create a
-    canonical ledger entry.
+    Used in ``add_participant_status_tree`` precondition guards to reject
+    CLOSED→CLOSED rewrites before the commit runs (CLP-10-006).
 
-    Returns SUCCESS when the participant has no current status or the current
-    RM state is not CLOSED.  Returns FAILURE when the participant is already
-    at RM.CLOSED.
+    When ``status_id`` is supplied and the participant is CLOSED, returns
+    SUCCESS if ``status_id`` is already in ``participant.participant_statuses``
+    (idempotent delivery of a VALID→CLOSED update whose trigger side already
+    appended the status).  Returns FAILURE only for genuine CLOSED→CLOSED
+    rewrite attempts (status not yet in participant's list).
+
+    Returns SUCCESS when the participant has no current status, the current
+    RM state is not CLOSED, or the incoming status was already appended.
     """
 
-    def __init__(self, participant_id: str, name: str | None = None) -> None:
+    def __init__(
+        self,
+        participant_id: str,
+        status_id: str = "",
+        name: str | None = None,
+    ) -> None:
         super().__init__(name=name or self.__class__.__name__)
         self.participant_id = participant_id
+        self.status_id = status_id
 
     def update(self) -> Status:
         if self.datalayer is None:
@@ -458,16 +468,33 @@ class CheckParticipantRMNotClosedNode(DataLayerCondition):
             return Status.SUCCESS
 
         current_rm = getattr(current_status, "rm_state", None)
-        if current_rm == RM.CLOSED:
-            self.feedback_message = (
-                f"Participant '{self.participant_id}' is already in terminal"
-                " RM.CLOSED — rejecting status update (DEMOMA-07-003)"
-            )
-            self.logger.info(
-                "%s: %s",
-                self.name,
-                self.feedback_message,
-            )
-            return Status.FAILURE
+        if current_rm != RM.CLOSED:
+            return Status.SUCCESS
 
-        return Status.SUCCESS
+        # Participant is CLOSED. Allow if the incoming status was already
+        # appended by the trigger side (idempotent re-delivery of VALID→CLOSED).
+        if self.status_id:
+            existing_ids = [
+                _as_id(s)
+                for s in getattr(participant, "participant_statuses", [])
+            ]
+            if self.status_id in existing_ids:
+                self.logger.debug(
+                    "%s: participant '%s' is CLOSED but status '%s' already"
+                    " in participant_statuses — allowing idempotent commit",
+                    self.name,
+                    self.participant_id,
+                    self.status_id,
+                )
+                return Status.SUCCESS
+
+        self.feedback_message = (
+            f"Participant '{self.participant_id}' is already in terminal"
+            " RM.CLOSED — rejecting status update (DEMOMA-07-003)"
+        )
+        self.logger.info(
+            "%s: %s",
+            self.name,
+            self.feedback_message,
+        )
+        return Status.FAILURE

--- a/vultron/core/behaviors/status/nodes/append.py
+++ b/vultron/core/behaviors/status/nodes/append.py
@@ -420,3 +420,54 @@ class AppendStatusAndSaveParticipantNode(DataLayerAction):
             self.participant_id,
         )
         return Status.SUCCESS
+
+
+class CheckParticipantRMNotClosedNode(DataLayerCondition):
+    """Pre-flight guard: FAILURE when participant is already in RM.CLOSED.
+
+    Used as a precondition guard in ``add_participant_status_tree`` so that
+    a terminal-state status update is rejected BEFORE the commit runs
+    (CLP-10-006).  A CLOSED→CLOSED rewrite is a no-op that must not create a
+    canonical ledger entry.
+
+    Returns SUCCESS when the participant has no current status or the current
+    RM state is not CLOSED.  Returns FAILURE when the participant is already
+    at RM.CLOSED.
+    """
+
+    def __init__(self, participant_id: str, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self.participant_id = participant_id
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.feedback_message = "DataLayer not available"
+            return Status.FAILURE
+
+        participant = self.datalayer.read(self.participant_id)
+        if not is_participant_model(participant):
+            self.logger.debug(
+                "%s: participant '%s' not found — allowing (no terminal check)",
+                self.name,
+                self.participant_id,
+            )
+            return Status.SUCCESS
+
+        current_status = getattr(participant, "participant_status", None)
+        if current_status is None:
+            return Status.SUCCESS
+
+        current_rm = getattr(current_status, "rm_state", None)
+        if current_rm == RM.CLOSED:
+            self.feedback_message = (
+                f"Participant '{self.participant_id}' is already in terminal"
+                " RM.CLOSED — rejecting status update (DEMOMA-07-003)"
+            )
+            self.logger.info(
+                "%s: %s",
+                self.name,
+                self.feedback_message,
+            )
+            return Status.FAILURE
+
+        return Status.SUCCESS


### PR DESCRIPTION
- Closes #1073

## Summary

Fixes CLP-10-006 ordering violations in all receive-side BT tree factories: `GuardedCommitCaseLedgerEntryBT` now runs **before** protocol-effect nodes, not after. Adds a structural enforcement test to prevent regressions.

## Changes

- **`vultron/core/behaviors/case/nodes/lifecycle.py`**: Adds `create_receive_activity_tree(name, case_id, precondition_guards, effect_nodes)` factory that structurally enforces `[*guards] → GuardedCommit → [*effects]`. Only this file may call `create_guarded_commit_case_ledger_entry_tree` directly.
- **`vultron/core/behaviors/case/accept_invite_tree.py`**: Migrated; fixes a py_trees global blackboard contamination bug in `CapturePreCommitBackfillTargetNode` — now always writes `pre_commit_backfill_target` (uses `None` for fresh case) so stale values from prior resume-case runs are overwritten. Extracts `_resolve_backfill_target()` to keep `update()` within complexity limit.
- **`vultron/core/behaviors/case/create_tree.py`**: Migrated to factory.
- **`vultron/core/behaviors/case/offer_case_manager_role_received_tree.py`**: Migrated to factory.
- **`vultron/core/behaviors/case/receive_close_case_tree.py`**: Migrated to factory.
- **`vultron/core/behaviors/embargo/announce_teardown_tree.py`**: All 5 tree factories migrated.
- **`vultron/core/behaviors/report/prioritize_tree.py`**: Migrated `engage_case` and `defer_case`.
- **`vultron/core/behaviors/report/received_report_trees.py`**: Migrated `validate_report` and `ack_report`.
- **`vultron/core/behaviors/status/add_participant_status_tree.py`**: Migrated; adds `CheckParticipantRMNotClosedNode` as a precondition guard to prevent terminal CLOSED→CLOSED state rewrites from generating a ledger entry.
- **`vultron/core/behaviors/status/nodes/append.py`**: Adds `CheckParticipantRMNotClosedNode`.
- **`vultron/core/behaviors/case/nodes/__init__.py`**, **`vultron/core/behaviors/status/nodes/__init__.py`**: Re-export new nodes.
- **`test/architecture/test_receive_side_bt_commit_ordering.py`**: NEW — AST-based structural test that fails if any `vultron/core/behaviors/**/*.py` file (except `lifecycle.py`) calls `create_guarded_commit_case_ledger_entry_tree` directly.
- **`test/core/behaviors/report/test_prioritize_tree.py`**, **`test/core/use_cases/received/actor/test_invite.py`**, **`test/core/use_cases/received/test_report.py`**: Updated assertions to reflect commit-first ordering semantics.

## Verification

- 3439 unit tests pass (1 new structural test added)
- Black, flake8, mypy, pyright all clean
- [x] `GuardedCommitCaseLedgerEntryBT` precedes all protocol-effect nodes in all migrated trees
- [x] Structural test prevents future direct calls to `create_guarded_commit_case_ledger_entry_tree` outside `lifecycle.py`
- [x] `CheckParticipantRMNotClosedNode` prevents terminal-state ledger entries for CLOSED→CLOSED status updates
- [x] Backfill blackboard contamination fix confirmed by invite test suite passing when run in full sequence