### PR TITLE
docs: plan issue #1081 — CaseProposal protocol for distributed case actor initialization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -701,6 +701,17 @@ Short entries are reproduced here; longer ones are referenced below.
   violation (ADR-0009) and makes the pipeline untestable from non-HTTP entry
   points. See `specs/inbox-orchestration.yaml` IO-02-003 and IO-03-003, and
   `notes/inbox-orchestration.md`.
+- **`ProposeCaseToActorNode` Sends `Create(CaseProposal)`; `CreateCaseActorNode`
+  Does Not** — These two BT nodes have distinct responsibilities and MUST NOT be
+  conflated. `CreateCaseActorNode` registers the case-actor service as an actor
+  resource in the local DataLayer; it creates the actor identity, not the case.
+  `ProposeCaseToActorNode` sends `Create(as_CaseProposal)` to the already-registered
+  case-actor service to initiate the case initialization protocol. Updating
+  `CreateCaseActorNode` to send a CaseProposal is a violation of single
+  responsibility and causes the proposal to be sent before the actor is ready.
+  `ProposeCaseToActorNode` MUST be wired into the case-creation BT tree AFTER
+  `CreateCaseActorNode` succeeds. See `specs/case-proposal.yaml` CP-04-002 and
+  `notes/case-proposal.md`.
 
 ## Skill Interaction Rules
 

--- a/docs/adr/0023-case-proposal-protocol.md
+++ b/docs/adr/0023-case-proposal-protocol.md
@@ -1,0 +1,126 @@
+---
+status: accepted
+date: 2026-06-22
+deciders: [adh, Copilot]
+---
+
+# ADR-0023: Introduce `CaseProposal` for Distributed Case Actor Initialization
+
+## Context and Problem Statement
+
+When a vendor needs to request case initialization at a dedicated case-actor
+service (#810), how should it communicate that request while preserving
+ActivityStreams 2.0 semantics?
+
+`Create(VulnerabilityCase)` from the vendor is not semantically correct:
+the AS2 specification states that `Create` means "I (the `actor`) created this
+object." The vendor is not the authoritative creator of the case — the
+case-actor service is. Using the vendor as `actor` on
+`Create(VulnerabilityCase)` would misrepresent authorship and undermine the
+trust model that relies on the case-actor as the single authoritative source
+for case identity and state.
+
+## Decision Drivers
+
+- Preserve AS2 "I created this" semantics: only the authoritative creator
+  SHOULD be the `actor` on `Create(X)`.
+- Keep case initialization in-protocol (no out-of-band provisioning calls).
+- Allow the case-actor service to evaluate and reject proposals (insufficient
+  info, duplicate, out-of-scope, policy).
+- Maintain clear causal traceability from proposal through acceptance to case
+  creation.
+
+## Considered Options
+
+1. **`CaseProposal` negotiation object** (chosen): vendor sends
+   `Create(CaseProposal)` → case-actor sends `Accept(CaseProposal)` then
+   `Create(VulnerabilityCase, actor=case-actor)`.
+
+2. **`Offer(VulnerabilityCase)` semantics**: vendor sends
+   `Offer(VulnerabilityCase)` → case-actor sends `Accept(Offer)` then
+   `Create(VulnerabilityCase)`.
+
+3. **Vendor sends `Create(VulnerabilityCase)` anyway**: the case-actor service
+   overwrites/supersedes the vendor-created case with its own authoritative
+   version.
+
+4. **Out-of-band provisioning call**: vendor calls a REST API on the
+   case-actor service directly (outside the Vultron inbox/outbox protocol).
+
+## Decision Outcome
+
+**Chosen option: CaseProposal negotiation object (#1).**
+
+A dedicated `as_CaseProposal` wire object lets the vendor request initialization
+while preserving correct AS2 semantics. The vendor `actor` on
+`Create(CaseProposal)` accurately reflects that the vendor created the
+*proposal*, not the case. The case-actor creates the case and correctly sets
+itself as `actor` on the subsequent `Create(VulnerabilityCase)`.
+
+The full positive-path flow:
+
+```text
+Vendor → Create(as_CaseProposal) → CaseActor inbox
+CaseActor → Accept(as_CaseProposal) → Vendor inbox
+CaseActor → Create(VulnerabilityCase, actor=CaseActor, context=Accept URI) → Vendor inbox
+```
+
+Setting `context` on `Create(VulnerabilityCase)` to the `Accept(CaseProposal)`
+URI was preferred over the `CaseProposal` URI directly, because the Accept is
+the proximate causal decision. The proposal is embedded inline in the Accept's
+`object_`, so full causal traceability is preserved transitively.
+
+### Consequences
+
+- Good: AS2 `actor` semantics are preserved end-to-end.
+- Good: The case-actor service retains full authority over case identity.
+- Good: Rejection is naturally expressed as `Reject(CaseProposal)`.
+- Good: Fully in-protocol; no out-of-band REST calls.
+- Neutral: Adds three new `MessageSemantics` values and three received-side
+  use cases.
+- Neutral: The two-activity positive response (`Accept` then `Create`) adds
+  a message, but both are semantically distinct and necessary.
+
+## Pros and Cons of the Options
+
+### Option 1: `CaseProposal` negotiation object (chosen)
+
+- Good: Unambiguous AS2 authorship on all activities.
+- Good: Explicit accept/reject lifecycle; case-actor policy is expressible.
+- Good: Extends naturally to future negotiation semantics.
+- Neutral: New vocabulary type required.
+
+### Option 2: `Offer(VulnerabilityCase)` semantics
+
+- Good: Reuses existing `Offer`/`Accept` vocabulary without a new type.
+- Bad: `Offer(VulnerabilityCase)` is already overloaded in Vultron for
+  report delivery semantics (`VP` spec). Re-using it for case initialization
+  would create ambiguous routing.
+- Bad: The case inside an Offer is not yet the authoritative case; naming it
+  `VulnerabilityCase` before it exists is misleading.
+
+### Option 3: Vendor sends `Create(VulnerabilityCase)` anyway
+
+- Bad: Direct AS2 semantics violation: the vendor cannot be `actor` on
+  `Create(VulnerabilityCase)` if it is not the authoritative creator.
+- Bad: The case-actor overwrite model is fragile; two `Create` activities for
+  the same case from different actors would require a complex resolution
+  protocol.
+
+### Option 4: Out-of-band provisioning
+
+- Bad: Breaks the Vultron protocol model (all coordination in-protocol).
+- Bad: Requires a separate REST API on the case-actor service, increasing
+  coupling and deployment complexity.
+- Bad: No standardized reject/accept lifecycle.
+
+## More Information
+
+- Source issue: #1081
+- Blocked-by: this ADR and its implementation (issues planned in #1081
+  comments)
+- Blocks: #810 (demo routing to dedicated case-actor service), #811 (spawning
+  spec/ADR), #812 (spawning implementation)
+- Notes: `notes/case-proposal.md`
+
+Generated spec requirements: `specs/case-proposal.yaml` CP-01 through CP-07.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -78,6 +78,8 @@ General information about architectural decision records is available at <https:
   Entries](0021-caseactor-inbox-routing-canonical-ledger.md)
 - [ADR-0022 Single BT Execution Per Inbox Delivery for Received-Side
   CaseActor Routing](0022-single-bt-execution-for-received-side-case-actor-routing.md)
+- [ADR-0023 Introduce `CaseProposal` for Distributed Case Actor
+  Initialization](0023-case-proposal-protocol.md)
 
 ## Proposed ADRs
 

--- a/notes/README.md
+++ b/notes/README.md
@@ -151,6 +151,15 @@ vocabulary examples.
 **Load when**: implementing any inbound or outbound message handler, debugging
 semantic extraction, or writing new ActivityStreams vocabulary classes.
 
+**`case-proposal.md`**
+Design rationale, protocol flow, and implementation guidance for the
+`CaseProposal` mechanism: new `as_CaseProposal` AS2 object type, the
+`Create(CaseProposal)` / `Accept(CaseProposal)` / `Reject(CaseProposal)` flow,
+`ProposeCaseToActorNode` vs `CreateCaseActorNode` responsibilities, and the
+three received-side use cases. ADR: `docs/adr/0023-case-proposal-protocol.md`.
+**Load when**: implementing `as_CaseProposal`, `ProposeCaseToActorNode`, or
+the received-side use cases; or working on issues #810, #811, #812.
+
 **`vocabulary-registry.md`**
 Design decisions and migration path for the AS2 vocabulary registry refactor:
 auto-registration via `__init_subclass__`, flat registry dict, `VocabNamespace`

--- a/notes/case-proposal.md
+++ b/notes/case-proposal.md
@@ -1,0 +1,195 @@
+---
+title: CaseProposal Protocol
+status: active
+description: >
+  Design rationale, protocol flow, and implementation guidance for the
+  CaseProposal mechanism: a new AS2 object and message flow that separates
+  "requesting case initialization" from "creating the case."
+related_specs:
+  - specs/case-proposal.yaml
+  - specs/case-management.yaml
+  - specs/semantic-extraction.yaml
+related_notes:
+  - notes/activitystreams-semantics.md
+  - notes/case-communication-model.md
+  - notes/bt-integration.md
+relevant_packages:
+  - vultron/wire/as2/vocab/objects
+  - vultron/core/models/events
+  - vultron/core/use_cases/received
+  - vultron/core/behaviors/case
+---
+
+# CaseProposal Protocol
+
+**Source**: 2026-06-22 grill-me planning session, issue #1081.
+Normative requirements: `specs/case-proposal.yaml` (CP-01 through CP-07).
+ADR: `docs/adr/0023-case-proposal-protocol.md`.
+
+---
+
+## Motivation
+
+`CreateCaseActorNode` currently creates the CaseActor locally in the vendor's
+DataLayer. When the case-actor service is external (issue #810), the vendor
+needs a way to tell the case-actor service about a new case.
+
+Sending `Create(VulnerabilityCase)` from the vendor is not correct. In
+ActivityStreams, `Create(X)` means "I created X." The vendor is not the
+authoritative creator of the case — the case-actor service is. Using the
+vendor as `actor` on a `Create(VulnerabilityCase)` violates this semantics.
+
+The `CaseProposal` object provides a clean solution: the vendor proposes that
+the case-actor service create the case, while the case-actor service does the
+actual creation.
+
+---
+
+## Protocol Flow
+
+```text
+Vendor                              CaseActor Service
+  |                                       |
+  | --- Create(CaseProposal) -----------> |
+  |         actor: vendor URI             |
+  |         object_: as_CaseProposal      |
+  |                                       |
+  |           [evaluates proposal]        |
+  |                                       |
+  | <-- Accept(CaseProposal) ----------- |  (happy path)
+  |         actor: case-actor URI         |
+  |         object_: as_CaseProposal      |
+  |                                       |
+  | <-- Create(VulnerabilityCase) ------- |
+  |         actor: case-actor URI         |
+  |         context: Accept URI           |
+  |                                       |
+  |    -- OR --                           |
+  |                                       |
+  | <-- Reject(CaseProposal) ----------- |  (rejection path)
+  |         actor: case-actor URI         |
+  |         object_: as_CaseProposal      |
+```
+
+### Step 1: Vendor sends `Create(as_CaseProposal)`
+
+The vendor creates an `as_CaseProposal` object containing:
+
+- `id_`: auto-generated URI for the proposal
+- `attributed_to`: the vendor actor URI
+- `object_`: inline or URI-referenced `as_VulnerabilityReport`
+- `target`: the case-actor service URI
+- `summary` (optional): human-readable description
+
+The vendor then sends `Create(as_CaseProposal)` to the case-actor service's
+inbox, with `actor=vendor_uri`.
+
+### Step 2a: Case-actor accepts (happy path)
+
+When the case-actor service decides to create the case, it sends **two**
+activities back to the vendor:
+
+1. **`Accept(as_CaseProposal)`** — acknowledgment that the proposal was
+   accepted. `object_` embeds the `as_CaseProposal` inline.
+
+2. **`Create(VulnerabilityCase)`** — the actual case creation announcement.
+   - `actor` = case-actor URI (preserving AS2 "I created this" semantics)
+   - `context` = URI of the `Accept(CaseProposal)` activity (proximate cause)
+
+Setting `context` to the Accept URI (not the CaseProposal URI directly) was
+chosen because the `Accept` is the proximate causal decision. The proposal
+is already embedded in the Accept's `object_`, so causal traceability is
+preserved transitively.
+
+### Step 2b: Case-actor rejects
+
+When the case-actor service declines, it sends:
+
+**`Reject(as_CaseProposal)`** — `object_` embeds the `as_CaseProposal`
+inline (consistent with the Accept pattern; inline is preferred over URI-only
+for rejection so the vendor has the full proposal context without a round-trip).
+
+---
+
+## Wire Vocabulary: `as_CaseProposal`
+
+`as_CaseProposal` is a new AS2 **Object** type (not an Activity) that extends
+`VultronAS2Object`. Required fields:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id_` | URI | Yes | Auto-generated unique proposal identifier |
+| `attributed_to` | Actor URI | Yes | The vendor/proposer actor URI |
+| `object_` | `as_VulnerabilityReport` or URI | Yes | The report for the case |
+| `target` | URI | Yes | The prospective case-actor service URI |
+| `summary` | str | No | Human-readable proposal description |
+
+All classes in `vultron/wire/as2/vocab/objects/` use the `as_` prefix
+(ARCH-14-001). The new type is `as_CaseProposal`; the bare name `CaseProposal`
+refers to any eventual core domain model (if created).
+
+---
+
+## MessageSemantics Values
+
+Three new values added to the `MessageSemantics` enum:
+
+| Value | Pattern |
+|-------|---------|
+| `CREATE_CASE_PROPOSAL` | `Create(as_CaseProposal)` |
+| `ACCEPT_CASE_PROPOSAL` | `Accept(as_CaseProposal)` |
+| `REJECT_CASE_PROPOSAL` | `Reject(as_CaseProposal)` |
+
+All three patterns MUST appear in `SEMANTICS_ACTIVITY_PATTERNS` before any
+more-general patterns that share the same outer Activity type (SE-03-002).
+
+---
+
+## BT Integration: `ProposeCaseToActorNode`
+
+A new BT leaf node `ProposeCaseToActorNode` is responsible for sending
+`Create(as_CaseProposal)` to the case-actor service. It is distinct from
+`CreateCaseActorNode`.
+
+### Node roles — do not conflate
+
+| Node | Responsibility |
+|------|----------------|
+| `CreateCaseActorNode` | Registers the case-actor service as an actor resource in the local DataLayer. Creates the actor identity, not the case. |
+| `ProposeCaseToActorNode` | Sends `Create(as_CaseProposal)` to the already-registered case-actor service. Initiates the case initialization protocol. |
+
+`ProposeCaseToActorNode` is wired into the case-creation BT tree **after**
+`CreateCaseActorNode` succeeds — the actor must exist before the proposal can
+be sent to it.
+
+---
+
+## Received-Side Use Cases
+
+Three received-side use cases are required:
+
+| Use Case | Actor | Handles |
+|----------|-------|---------|
+| `CreateCaseProposalReceivedUseCase` | Case-actor service | `Create(as_CaseProposal)` arriving at case-actor inbox |
+| `AcceptCaseProposalReceivedUseCase` | Vendor | `Accept(as_CaseProposal)` arriving at vendor inbox |
+| `RejectCaseProposalReceivedUseCase` | Vendor | `Reject(as_CaseProposal)` arriving at vendor inbox |
+
+All three must be registered in the dispatcher's `USE_CASE_MAP` keyed by the
+corresponding `MessageSemantics` value.
+
+---
+
+## Relationship to Related Issues
+
+| Issue | Relationship |
+|-------|-------------|
+| #810 | **Blocked by this**: demo routing to dedicated case-actor container requires the CaseProposal protocol to be in place before `CreateCaseActorNode` can be adapted for the demo layer. |
+| #811 | Spec + ADR for CaseActor dynamic spawning — a broader concern; CaseProposal is a prerequisite input. |
+| #812 | Implementation of CaseActor dynamic spawning — blocked by #811 and this work. |
+
+---
+
+## Open Questions
+
+None — all design decisions were resolved in the planning session.
+See `docs/adr/0023-case-proposal-protocol.md` for the alternatives evaluated.

--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -357,3 +357,16 @@ the two-actor scenario does not call the acknowledge flow
 EXPECTED_EVENT_TYPES accordingly.
 
 README table updated from all-⏳ to all-✅ with inv-15 row added.
+
+### 2026-06-22 CASE-PROPOSAL-810 — #810 premature; CreateCaseActorNode needs a protocol mechanism first
+
+During build investigation for #810, found that routing case actor creation to
+a dedicated container cannot be done cleanly with `Create(VulnerabilityCase)`
+(ActivityStreams semantics violation — only the authoritative creator may send
+`Create`). The issue assumed a `DemoCreateCaseActorNode` workaround without
+addressing the underlying protocol gap. The correct approach is a new
+`CaseProposal` object: vendor sends `Create(CaseProposal)` to the case-actor
+service; the case-actor service accepts and creates the `Case` in its own
+DataLayer. This is tracked as #1081 and blocks #810. The two-actor demo
+currently passes all invariants — #810 is architectural improvement work, not
+a bug fix.

--- a/plan/history/2606/idea/IDEA-1081.md
+++ b/plan/history/2606/idea/IDEA-1081.md
@@ -1,0 +1,59 @@
+---
+source: IDEA-1081
+timestamp: '2026-06-22T16:33:31.849329+00:00'
+title: 'CaseProposal: new protocol mechanism for distributed case actor initialization'
+type: idea
+---
+
+## Summary
+
+Introduce a `CaseProposal` ActivityStreams object and corresponding protocol
+flow to cleanly separate "requesting case creation" from "creating the case."
+
+## Motivation
+
+Currently `CreateCaseActorNode` creates the case actor in the local (vendor)
+DataLayer. To support a dedicated case-actor service (#810), the vendor needs a
+way to tell the case-actor service about a new case. Simply sending
+`Create(VulnerabilityCase)` from the vendor violates ActivityStreams semantics
+("I created this") since the vendor is not the authoritative creator.
+
+## Proposed Design
+
+A **CaseProposal** is an intermediate ActivityStreams object used to separate
+the act of requesting case creation from the act of creating the case itself.
+
+1. Vendor sends `Create(CaseProposal)` to the prospective case-actor service.
+   The proposal contains information needed to initialize the case (vulnerability
+   report reference, participants, scope, initial metadata).
+2. The case-actor service evaluates the proposal and either:
+   - Sends `Accept(CaseProposal)` → creates the actual `Case` object,
+     establishing the durable identifier and authoritative actor. The
+     `Accept` can include the resulting Case object.
+   - Sends `Reject(CaseProposal)` → declines to initialize (insufficient
+     info, duplicate, out-of-scope, policy), optionally including a reason.
+
+This preserves ActivityStreams semantics (`Create` means "I created this
+object") while allowing distributed actors to negotiate ownership and
+initialization of workflow objects.
+
+## Scope
+
+- New `CaseProposal` wire vocabulary type
+- New `MessageSemantics` values: `CREATE_CASE_PROPOSAL`,
+  `ACCEPT_CASE_PROPOSAL`, `REJECT_CASE_PROPOSAL`
+- New use cases: `CreateCaseProposalReceivedUseCase`,
+  `AcceptCaseProposalReceivedUseCase`, `RejectCaseProposalReceivedUseCase`
+- New BT node `ProposeCaseToActorNode` (distinct from `CreateCaseActorNode`)
+- Demo + integration test coverage
+
+## References
+
+- Blocks #810 (demo routing to dedicated case-actor service)
+- Related: #811, #812 (case actor spawning architecture)
+- Discovered during build session for #810 (2026-06-22)
+
+**Processed**: 2026-06-22 — implementation tracked in #1085 (wire foundation), #1086 (received-side use cases), #1087 (BT node + demo + integration tests).
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1084>.
+Spec: `specs/case-proposal.yaml`. Notes: `notes/case-proposal.md`.
+ADR: `docs/adr/0023-case-proposal-protocol.md`.

--- a/specs/README.md
+++ b/specs/README.md
@@ -74,6 +74,7 @@ Load additional files only when the task touches the relevant area. See the
 | Inbox orchestration (core BT module + InboxOutcome seam) | `inbox-orchestration.yaml` |
 | Behavior Trees | `behavior-tree-integration.yaml`, `behavior-tree-node-design.yaml`, `bt-composability.yaml`, `triggerable-behaviors.yaml`, `vultron/core/use_cases/triggers/AGENTS.md` |
 | Case / state management | `case-management.yaml`, `state-machine.yaml`, `case-ledger-processing.yaml` |
+| CaseProposal protocol (distributed case actor initialization) | `case-proposal.yaml` |
 | Protocol conformance | `vultron-protocol-spec.yaml`, `vultron-as2-mapping.yaml` |
 | Wire vocabulary | `vocabulary-model.yaml` |
 | Activity factory functions | `activity-factories.yaml` |
@@ -436,6 +437,7 @@ is reserved for `testability.yaml`).
 | `DOCBW` | `docs-build-workflow.yaml` |
 | `CLP` | `case-ledger-processing.yaml` |
 | `CM` | `case-management.yaml` |
+| `CP` | `case-proposal.yaml` |
 | `CS` | `code-style.yaml` |
 | `DC` | `demo-cli.yaml` |
 | `DEMOMA` | `multi-actor-demo.yaml` |

--- a/specs/case-proposal.yaml
+++ b/specs/case-proposal.yaml
@@ -1,0 +1,218 @@
+id: CP
+title: CaseProposal Protocol
+description: >-
+  Requirements for the CaseProposal protocol flow, which separates the act of
+  requesting case initialization from the act of creating the case. Covers the
+  `as_CaseProposal` wire vocabulary type, the `Create(CaseProposal)` /
+  `Accept(CaseProposal)` / `Reject(CaseProposal)` message flow, and the
+  corresponding MessageSemantics values and received-side use cases.
+  ADR: `docs/adr/0023-case-proposal-protocol.md`.
+version: 1.0.0
+kind: domain
+scope:
+  - prototype
+  - production
+groups:
+  - id: CP-01
+    title: Wire Vocabulary
+    specs:
+      - id: CP-01-001
+        priority: MUST
+        statement: >-
+          The wire layer MUST define an `as_CaseProposal` object type that
+          extends `VultronAS2Object`.
+        rationale: >-
+          A dedicated object type enables pattern-discriminated routing in the
+          semantic extractor and preserves AS2 semantics by separating the
+          proposal object from the eventual `VulnerabilityCase`.
+      - id: CP-01-002
+        priority: MUST
+        statement: >-
+          `as_CaseProposal` MUST include an `id_` field containing a full URI
+          that uniquely identifies the proposal.
+      - id: CP-01-003
+        priority: MUST
+        statement: >-
+          `as_CaseProposal` MUST include an `attributed_to` field identifying
+          the vendor actor (proposer) that originated the proposal.
+      - id: CP-01-004
+        priority: MUST
+        statement: >-
+          `as_CaseProposal` MUST include an `object_` field containing either
+          an inline `as_VulnerabilityReport` or a URI reference to the report
+          around which the case is to be created.
+        rationale: >-
+          The case-actor service needs the vulnerability report to initialize
+          the case. An inline or URI-referenced report satisfies this without
+          requiring a separate fetch in the common case.
+      - id: CP-01-005
+        priority: MUST
+        statement: >-
+          `as_CaseProposal` MUST include a `target` field containing the URI of
+          the prospective case-actor service to which the proposal is addressed.
+      - id: CP-01-006
+        priority: MAY
+        statement: >-
+          `as_CaseProposal` MAY include an optional `summary` field with a
+          human-readable description of the proposal.
+  - id: CP-02
+    title: MessageSemantics Values
+    specs:
+      - id: CP-02-001
+        priority: MUST
+        statement: >-
+          The `MessageSemantics` enum MUST include `CREATE_CASE_PROPOSAL` for
+          the pattern `Create(as_CaseProposal)`.
+      - id: CP-02-002
+        priority: MUST
+        statement: >-
+          The `MessageSemantics` enum MUST include `ACCEPT_CASE_PROPOSAL` for
+          the pattern `Accept(as_CaseProposal)`.
+      - id: CP-02-003
+        priority: MUST
+        statement: >-
+          The `MessageSemantics` enum MUST include `REJECT_CASE_PROPOSAL` for
+          the pattern `Reject(as_CaseProposal)`.
+  - id: CP-03
+    title: Extractor Patterns
+    specs:
+      - id: CP-03-001
+        priority: MUST
+        statement: >-
+          `SEMANTICS_ACTIVITY_PATTERNS` MUST contain a pattern entry for
+          `(Create, as_CaseProposal) -> CREATE_CASE_PROPOSAL`.
+      - id: CP-03-002
+        priority: MUST
+        statement: >-
+          `SEMANTICS_ACTIVITY_PATTERNS` MUST contain a pattern entry for
+          `(Accept, as_CaseProposal) -> ACCEPT_CASE_PROPOSAL`.
+      - id: CP-03-003
+        priority: MUST
+        statement: >-
+          `SEMANTICS_ACTIVITY_PATTERNS` MUST contain a pattern entry for
+          `(Reject, as_CaseProposal) -> REJECT_CASE_PROPOSAL`.
+      - id: CP-03-004
+        priority: MUST
+        statement: >-
+          All three `CaseProposal` extractor patterns MUST appear before any
+          more-general patterns that could match the same activity types (e.g.,
+          generic `Accept` or `Reject` catch-all entries), to prevent
+          misrouting (per SE-03-002).
+        relationships:
+          - rel_type: depends_on
+            spec_id: SE-03-002
+  - id: CP-04
+    title: Protocol Flow — Sending
+    specs:
+      - id: CP-04-001
+        priority: MUST
+        statement: >-
+          A vendor actor that wishes to request case initialization at a
+          dedicated case-actor service MUST send `Create(as_CaseProposal)` to
+          the case-actor service's inbox, with `actor` set to the vendor's own
+          URI.
+        rationale: >-
+          Using `Create` with the vendor as `actor` accurately declares that
+          the vendor created the proposal object, not the case itself.
+          Sending `Create(VulnerabilityCase)` from the vendor would violate
+          AS2 semantics because the vendor is not the authoritative creator of
+          the case.
+        relationships:
+          - rel_type: implements
+            spec_id: CP-01-001
+      - id: CP-04-002
+        priority: MUST
+        statement: >-
+          The BT node responsible for sending `Create(as_CaseProposal)` MUST be
+          a distinct node (`ProposeCaseToActorNode`) separate from
+          `CreateCaseActorNode`. `CreateCaseActorNode` is responsible only for
+          registering the case-actor service resource; it MUST NOT send a
+          `CaseProposal` activity.
+        rationale: >-
+          Conflating actor registration with proposal sending violates single
+          responsibility and causes the proposal to be sent before the
+          case-actor service is ready. See `notes/case-proposal.md` for the
+          pitfall.
+  - id: CP-05
+    title: Protocol Flow — Receiving (Case-Actor Side)
+    specs:
+      - id: CP-05-001
+        priority: MUST
+        statement: >-
+          A `CreateCaseProposalReceivedUseCase` MUST be implemented on the
+          case-actor side to handle incoming `Create(as_CaseProposal)`
+          activities.
+      - id: CP-05-002
+        priority: MUST
+        statement: >-
+          `CreateCaseProposalReceivedUseCase` MUST evaluate the proposal and
+          either accept or reject it, emitting the appropriate response
+          activity.
+      - id: CP-05-003
+        priority: MUST
+        statement: >-
+          When accepting a proposal, the case-actor service MUST send two
+          activities in sequence: first `Accept(as_CaseProposal)` (with the
+          `as_CaseProposal` inline as `object_`), then
+          `Create(VulnerabilityCase)` (with `actor` set to the case-actor URI
+          and `context` set to the URI of the `Accept(CaseProposal)` activity).
+        rationale: >-
+          `Accept(CaseProposal)` acknowledges the vendor's proposal.
+          `Create(VulnerabilityCase)` with `actor=case-actor` preserves AS2
+          "I created this" semantics: only the authoritative creator MUST be
+          the `actor` of a `Create` activity. Setting `context` to the Accept
+          URI establishes the proximate causal link.
+      - id: CP-05-004
+        priority: MUST
+        statement: >-
+          When rejecting a proposal, the case-actor service MUST send
+          `Reject(as_CaseProposal)` with the `as_CaseProposal` embedded inline
+          as `object_`.
+  - id: CP-06
+    title: Protocol Flow — Receiving (Vendor Side)
+    specs:
+      - id: CP-06-001
+        priority: MUST
+        statement: >-
+          An `AcceptCaseProposalReceivedUseCase` MUST be implemented on the
+          vendor side to handle incoming `Accept(as_CaseProposal)` activities.
+      - id: CP-06-002
+        priority: MUST
+        statement: >-
+          A `RejectCaseProposalReceivedUseCase` MUST be implemented on the
+          vendor side to handle incoming `Reject(as_CaseProposal)` activities.
+      - id: CP-06-003
+        priority: MUST
+        statement: >-
+          `AcceptCaseProposalReceivedUseCase` MUST update the vendor's local
+          state to reflect that the case-actor service has accepted the
+          proposal (e.g., record the case-actor URI and await the subsequent
+          `Create(VulnerabilityCase)`).
+      - id: CP-06-004
+        priority: MUST
+        statement: >-
+          `RejectCaseProposalReceivedUseCase` MUST update the vendor's local
+          state to reflect the rejection (e.g., mark the pending case as
+          rejected and surface the rejection reason if present).
+  - id: CP-07
+    title: Testing
+    specs:
+      - id: CP-07-001
+        priority: MUST
+        statement: >-
+          Unit tests MUST cover pattern matching for all three
+          `CaseProposal` extractor patterns
+          (`CREATE_CASE_PROPOSAL`, `ACCEPT_CASE_PROPOSAL`,
+          `REJECT_CASE_PROPOSAL`).
+      - id: CP-07-002
+        priority: MUST
+        statement: >-
+          Unit tests MUST cover `CreateCaseProposalReceivedUseCase`,
+          `AcceptCaseProposalReceivedUseCase`, and
+          `RejectCaseProposalReceivedUseCase` execute() paths.
+      - id: CP-07-003
+        priority: MUST
+        statement: >-
+          Integration tests MUST cover the full `Create(CaseProposal)` →
+          `Accept(CaseProposal)` + `Create(VulnerabilityCase)` round-trip
+          between a vendor actor and a case-actor service.


### PR DESCRIPTION
- Closes #1081

## Summary

Plans the `CaseProposal` protocol mechanism (#1081): a new AS2 object type
and three-activity flow that separates "requesting case initialization" from
"creating the case," preserving ActivityStreams authorship semantics in a
distributed case-actor deployment.

## Changes

- `specs/case-proposal.yaml` — 26 requirements (CP-01–CP-07) covering wire
  vocabulary (`as_CaseProposal`), three `MessageSemantics` values, extractor
  patterns, protocol flow (Create/Accept/Reject), three received-side use
  cases, and integration test requirements
- `notes/case-proposal.md` — design rationale, full protocol flow diagram,
  BT node responsibility table (`ProposeCaseToActorNode` vs
  `CreateCaseActorNode`), wire vocabulary field spec, and relationship to
  #810/#811/#812
- `docs/adr/0023-case-proposal-protocol.md` — ADR documenting four
  considered alternatives and why CaseProposal negotiation was chosen
- `docs/adr/index.md` — registers ADR-0023
- `specs/README.md` — registers CP spec and adds to prefix table
- `notes/README.md` — registers `case-proposal.md` in Protocol Semantics section
- `AGENTS.md` — new pitfall: `ProposeCaseToActorNode` vs
  `CreateCaseActorNode` responsibilities (CP-04-002)