### PR TITLE
refactor: consolidate trigger-router fixtures into routers conftest.py

### DIFF
--- a/plan/BUILD_LEARNINGS.md
+++ b/plan/BUILD_LEARNINGS.md
@@ -381,3 +381,12 @@ service; the case-actor service accepts and creates the `Case` in its own
 DataLayer. This is tracked as #1081 and blocks #810. The two-actor demo
 currently passes all invariants — #810 is architectural improvement work, not
 a bug fix.
+
+### 2026-06-22 FIXTURE-CONSOLIDATION-492 — test_trigger_actor.py also has the duplicate fixtures
+
+After consolidating `actor_and_dl`, `actor`, and `dl` from the three trigger
+test files into the shared routers `conftest.py` (issue #492), the code review
+identified that `test_trigger_actor.py` still carries the same identical
+fixture definitions. Those fixtures now shadow the conftest ones and are
+candidates for a follow-on cleanup. File a follow-up issue for the
+`test_trigger_actor.py` cleanup when #492 merges.

--- a/plan/history/2606/implementation/ISSUE-492.md
+++ b/plan/history/2606/implementation/ISSUE-492.md
@@ -1,0 +1,23 @@
+---
+source: ISSUE-492
+timestamp: '2026-06-22T17:19:42.583617+00:00'
+title: Consolidate trigger-router fixtures into routers conftest.py
+type: implementation
+---
+
+## Issue #492 — P1: Consolidate duplicated trigger-router fixtures into conftest.py
+
+Consolidated the identical `actor_and_dl`, `actor`, and `dl` fixtures
+that were copy-pasted across `test_trigger_embargo.py`,
+`test_trigger_report.py`, and `test_trigger_case.py` into the shared
+`test/adapters/driving/fastapi/routers/conftest.py`.
+
+The old `dl(datalayer)` alias was replaced with `dl(actor_and_dl)`. The
+`client_actors`, `client_datalayer`, and `created_actors` fixtures were
+updated to use `datalayer` directly to avoid DataLayer instance mismatch.
+Tests in `test_actors.py` (3) and `test_datalayer.py` (8) that paired `dl`
+with the affected client fixtures were updated to use `datalayer` instead.
+
+All 3449 unit tests pass. All linters clean.
+
+PR: [#1094](https://github.com/CERTCC/Vultron/pull/1094)

--- a/test/adapters/driving/fastapi/routers/conftest.py
+++ b/test/adapters/driving/fastapi/routers/conftest.py
@@ -16,6 +16,10 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from vultron.adapters.driven.db_record import object_to_record
+from vultron.adapters.driven.datalayer_sqlite import (
+    SqliteDataLayer,
+    reset_datalayer,
+)
 from vultron.adapters.driving.fastapi.routers import actors as actors_router
 from vultron.adapters.driving.fastapi.routers import (
     datalayer as datalayer_router,
@@ -35,21 +39,47 @@ from vultron.wire.as2.vocab.objects.vulnerability_report import (
 )
 
 
-# adapter: reuse top-level datalayer fixture for tests that ask for `dl`
 @pytest.fixture
-def dl(datalayer):
-    return datalayer
+def actor_and_dl():
+    """Create actor + per-actor DataLayer together (avoids chicken-and-egg).
+
+    The actor object is created first (no DataLayer needed), then a
+    DataLayer is instantiated scoped to that actor's ID (ADR-0012 Option B).
+    The actor is then persisted into its own DataLayer.  Callers should
+    unpack via the ``actor`` and ``dl`` fixtures below.
+    """
+    actor_obj = as_Service(name="Vendor Co")
+    actor_id = actor_obj.id_
+    reset_datalayer(actor_id)
+    actor_dl = SqliteDataLayer("sqlite:///:memory:", actor_id=actor_id)
+    actor_dl.clear_all()
+    actor_dl.create(actor_obj)
+    yield actor_obj, actor_dl
+    actor_dl.close()
+    reset_datalayer(actor_id)
+
+
+@pytest.fixture
+def actor(actor_and_dl):
+    actor_obj, _ = actor_and_dl
+    return actor_obj
+
+
+@pytest.fixture
+def dl(actor_and_dl):
+    _, actor_dl = actor_and_dl
+    return actor_dl
 
 
 # TestClient for datalayer router
 @pytest.fixture
-def client_datalayer(dl):
+def client_datalayer(datalayer):
     from vultron.adapters.driven.datalayer import get_datalayer
 
     app = FastAPI()
     app.include_router(datalayer_router.router)
     # Override get_datalayer dependency to use test's datalayer instance
-    app.dependency_overrides[get_datalayer] = lambda: dl
+    app.dependency_overrides[get_datalayer] = lambda: datalayer
     client = TestClient(app)
     yield client
     app.dependency_overrides = {}
@@ -57,13 +87,13 @@ def client_datalayer(dl):
 
 # TestClient for actors router
 @pytest.fixture
-def client_actors(dl):
+def client_actors(datalayer):
     from vultron.adapters.driven.datalayer import get_datalayer
 
     app = FastAPI()
     app.include_router(actors_router.router)
     # Override get_datalayer dependency to use test's datalayer instance
-    app.dependency_overrides[get_datalayer] = lambda: dl
+    app.dependency_overrides[get_datalayer] = lambda: datalayer
     client = TestClient(app)
     yield client
     app.dependency_overrides = {}
@@ -86,7 +116,7 @@ def actor_classes():
 
 
 @pytest.fixture
-def created_actors(dl, actor_classes):
+def created_actors(datalayer, actor_classes):
     actors = []
     for actor_cls in actor_classes:
         # CoreActor stores inbox/outbox as URI strings; provide them explicitly
@@ -99,7 +129,7 @@ def created_actors(dl, actor_classes):
             )
         else:
             actor = actor_cls(name="Test Actor for List")
-        dl.create(object_to_record(actor))
+        datalayer.create(object_to_record(actor))
         actors.append(actor)
     return actors
 

--- a/test/adapters/driving/fastapi/routers/test_actors.py
+++ b/test/adapters/driving/fastapi/routers/test_actors.py
@@ -173,9 +173,11 @@ def _seed_action_rules_data(dl):
     dl.create(case)
 
 
-def test_get_action_rules_returns_200_with_expected_fields(client_actors, dl):
+def test_get_action_rules_returns_200_with_expected_fields(
+    client_actors, datalayer
+):
     """Actor/case endpoint returns all required state and action fields."""
-    _seed_action_rules_data(dl)
+    _seed_action_rules_data(datalayer)
 
     resp = client_actors.get(
         f"/actors/{_route_key(_URN_ACTOR_ID)}/cases/"
@@ -211,9 +213,11 @@ def test_get_action_rules_case_not_found_returns_404(client_actors):
     assert resp.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_get_action_rules_actor_not_in_case_returns_404(client_actors, dl):
+def test_get_action_rules_actor_not_in_case_returns_404(
+    client_actors, datalayer
+):
     """Actor outside the selected case returns 404."""
-    _seed_action_rules_data(dl)
+    _seed_action_rules_data(datalayer)
 
     resp = client_actors.get(
         "/actors/99999999-0000-0000-0000-000000000000/cases/"
@@ -341,13 +345,13 @@ class TestCreateActor:
 _HTTP_URL_ACTOR_ID = "http://vendor:7999/api/v2/actors/alice"
 
 
-def test_get_actor_by_surrogate_key_returns_actor(client_actors, dl):
+def test_get_actor_by_surrogate_key_returns_actor(client_actors, datalayer):
     """GET /actors/{surrogate-key} resolves actor IDs that contain slashes."""
     from vultron.adapters.driven.db_record import object_to_record
     from vultron.wire.as2.vocab.base.objects.actors import as_Organization
 
     actor = as_Organization(id_=_HTTP_URL_ACTOR_ID, name="VendorActor")
-    dl.create(object_to_record(actor))
+    datalayer.create(object_to_record(actor))
 
     resp = client_actors.get(f"/actors/{_route_key(_HTTP_URL_ACTOR_ID)}")
     assert resp.status_code == status.HTTP_200_OK

--- a/test/adapters/driving/fastapi/routers/test_datalayer.py
+++ b/test/adapters/driving/fastapi/routers/test_datalayer.py
@@ -26,8 +26,8 @@ def test_get_offers_returns_empty_dict_when_no_offers(client_datalayer):
     assert len(response.json()) == 0
 
 
-def test_get_offers_includes_created_offer(client_datalayer, dl, offer):
-    dl.create(object_to_record(offer))
+def test_get_offers_includes_created_offer(client_datalayer, datalayer, offer):
+    datalayer.create(object_to_record(offer))
     response = client_datalayer.get("/datalayer/Offers/")
     assert response.status_code == status.HTTP_200_OK
     data = response.json()
@@ -35,8 +35,10 @@ def test_get_offers_includes_created_offer(client_datalayer, dl, offer):
     assert offer.id_ in data
 
 
-def test_get_offer_by_id_returns_offer_fields(client_datalayer, dl, offer):
-    dl.create(object_to_record(offer))
+def test_get_offer_by_id_returns_offer_fields(
+    client_datalayer, datalayer, offer
+):
+    datalayer.create(object_to_record(offer))
     response = client_datalayer.get(
         "/datalayer/Offer/", params={"object_id": offer.id_}
     )
@@ -57,9 +59,9 @@ def test_get_vulnerability_reports_returns_empty_dict_when_no_reports(
 
 
 def test_get_vulnerability_reports_includes_created_report(
-    client_datalayer, dl, report
+    client_datalayer, datalayer, report
 ):
-    dl.create(report)
+    datalayer.create(report)
     response = client_datalayer.get("/datalayer/VulnerabilityReports/")
     assert response.status_code == status.HTTP_200_OK
     data = response.json()
@@ -68,9 +70,9 @@ def test_get_vulnerability_reports_includes_created_report(
 
 
 def test_reports_shortcut_endpoint_returns_same_results(
-    client_datalayer, dl, report
+    client_datalayer, datalayer, report
 ):
-    dl.create(report)
+    datalayer.create(report)
     response = client_datalayer.get("/datalayer/Reports/")
     assert response.status_code == status.HTTP_200_OK
     data = response.json()
@@ -78,8 +80,8 @@ def test_reports_shortcut_endpoint_returns_same_results(
     assert report.id_ in data
 
 
-def test_get_report_by_id_returns_report(client_datalayer, dl, report):
-    dl.create(report)
+def test_get_report_by_id_returns_report(client_datalayer, datalayer, report):
+    datalayer.create(report)
     response = client_datalayer.get(
         "/datalayer/Report/", params={"id": report.id_}
     )
@@ -87,13 +89,15 @@ def test_get_report_by_id_returns_report(client_datalayer, dl, report):
     assert response.json()["id"] == report.id_
 
 
-def test_reset_endpoint_clears_all_data(client_datalayer, dl, report, offer):
-    dl.create(object_to_record(offer))
-    dl.create(report)
+def test_reset_endpoint_clears_all_data(
+    client_datalayer, datalayer, report, offer
+):
+    datalayer.create(object_to_record(offer))
+    datalayer.create(report)
 
     # sanity: ensure they exist before reset
-    assert dl.by_type("Offer") is not None
-    assert dl.by_type("VulnerabilityReport") is not None
+    assert datalayer.by_type("Offer") is not None
+    assert datalayer.by_type("VulnerabilityReport") is not None
 
     resp = client_datalayer.delete("/datalayer/reset/")
     assert resp.status_code == status.HTTP_200_OK
@@ -116,14 +120,16 @@ _HTTP_PARTICIPANT_ID = (
 )
 
 
-def test_get_by_http_url_key_returns_stored_record(client_datalayer, dl):
+def test_get_by_http_url_key_returns_stored_record(
+    client_datalayer, datalayer
+):
     """GET /datalayer/{url-encoded-http-id} must return the stored record.
 
     Regression: Starlette decodes %2F to / before routing, so single-segment
     /{key} never matched URL-format IDs.  Fix: use /{key:path} as catch-all.
     """
     participant = CaseParticipant(id_=_HTTP_PARTICIPANT_ID)
-    dl.create(object_to_record(participant))
+    datalayer.create(object_to_record(participant))
 
     encoded = quote(_HTTP_PARTICIPANT_ID, safe="")
     response = client_datalayer.get(f"/datalayer/{encoded}")
@@ -141,10 +147,10 @@ def test_get_by_http_url_key_not_found_returns_404(client_datalayer):
 
 
 def test_specific_routes_not_shadowed_by_catch_all(
-    client_datalayer, dl, offer
+    client_datalayer, datalayer, offer
 ):
     """Specific routes (e.g. /Offers/) still resolve correctly after fix."""
-    dl.create(object_to_record(offer))
+    datalayer.create(object_to_record(offer))
     response = client_datalayer.get("/datalayer/Offers/")
     assert response.status_code == status.HTTP_200_OK
     data = response.json()

--- a/test/adapters/driving/fastapi/routers/test_trigger_case.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_case.py
@@ -96,43 +96,6 @@ def _no_outbox_delivery():
 
 
 @pytest.fixture
-def actor_and_dl():
-    """Create actor + per-actor DataLayer together (avoids chicken-and-egg).
-
-    The actor object is created first (no DataLayer needed), then a
-    DataLayer is instantiated scoped to that actor's ID (ADR-0012 Option B).
-    The actor is then persisted into its own DataLayer.  Callers should
-    unpack via the ``actor`` and ``dl`` fixtures below.
-    """
-    from vultron.adapters.driven.datalayer_sqlite import (
-        SqliteDataLayer,
-        reset_datalayer,
-    )
-
-    actor_obj = as_Service(name="Vendor Co")
-    actor_id = actor_obj.id_
-    reset_datalayer(actor_id)
-    actor_dl = SqliteDataLayer("sqlite:///:memory:", actor_id=actor_id)
-    actor_dl.clear_all()
-    actor_dl.create(actor_obj)
-    yield actor_obj, actor_dl
-    actor_dl.close()
-    reset_datalayer(actor_id)
-
-
-@pytest.fixture
-def actor(actor_and_dl):
-    actor_obj, _ = actor_and_dl
-    return actor_obj
-
-
-@pytest.fixture
-def dl(actor_and_dl):
-    _, actor_dl = actor_and_dl
-    return actor_dl
-
-
-@pytest.fixture
 def client_triggers(dl):
     app = FastAPI()
     app.include_router(trigger_case_router.router)

--- a/test/adapters/driving/fastapi/routers/test_trigger_embargo.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_embargo.py
@@ -97,43 +97,6 @@ def _no_outbox_delivery():
 
 
 @pytest.fixture
-def actor_and_dl():
-    """Create actor + per-actor DataLayer together (avoids chicken-and-egg).
-
-    The actor object is created first (no DataLayer needed), then a
-    DataLayer is instantiated scoped to that actor's ID (ADR-0012 Option B).
-    The actor is then persisted into its own DataLayer.  Callers should
-    unpack via the ``actor`` and ``dl`` fixtures below.
-    """
-    from vultron.adapters.driven.datalayer_sqlite import (
-        SqliteDataLayer,
-        reset_datalayer,
-    )
-
-    actor_obj = as_Service(name="Vendor Co")
-    actor_id = actor_obj.id_
-    reset_datalayer(actor_id)
-    actor_dl = SqliteDataLayer("sqlite:///:memory:", actor_id=actor_id)
-    actor_dl.clear_all()
-    actor_dl.create(actor_obj)
-    yield actor_obj, actor_dl
-    actor_dl.close()
-    reset_datalayer(actor_id)
-
-
-@pytest.fixture
-def actor(actor_and_dl):
-    actor_obj, _ = actor_and_dl
-    return actor_obj
-
-
-@pytest.fixture
-def dl(actor_and_dl):
-    _, actor_dl = actor_and_dl
-    return actor_dl
-
-
-@pytest.fixture
 def client_triggers(dl):
     app = FastAPI()
     app.include_router(trigger_embargo_router.router)

--- a/test/adapters/driving/fastapi/routers/test_trigger_report.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_report.py
@@ -82,43 +82,6 @@ def _no_outbox_delivery():
 
 
 @pytest.fixture
-def actor_and_dl():
-    """Create actor + per-actor DataLayer together (avoids chicken-and-egg).
-
-    The actor object is created first (no DataLayer needed), then a
-    DataLayer is instantiated scoped to that actor's ID (ADR-0012 Option B).
-    The actor is then persisted into its own DataLayer.  Callers should
-    unpack via the ``actor`` and ``dl`` fixtures below.
-    """
-    from vultron.adapters.driven.datalayer_sqlite import (
-        SqliteDataLayer,
-        reset_datalayer,
-    )
-
-    actor_obj = as_Service(name="Vendor Co")
-    actor_id = actor_obj.id_
-    reset_datalayer(actor_id)
-    actor_dl = SqliteDataLayer("sqlite:///:memory:", actor_id=actor_id)
-    actor_dl.clear_all()
-    actor_dl.create(actor_obj)
-    yield actor_obj, actor_dl
-    actor_dl.close()
-    reset_datalayer(actor_id)
-
-
-@pytest.fixture
-def actor(actor_and_dl):
-    actor_obj, _ = actor_and_dl
-    return actor_obj
-
-
-@pytest.fixture
-def dl(actor_and_dl):
-    _, actor_dl = actor_and_dl
-    return actor_dl
-
-
-@pytest.fixture
 def client_triggers(dl):
     app = FastAPI()
     app.include_router(trigger_report_router.router)


### PR DESCRIPTION
- Closes #492

## Summary

Consolidates the identical `actor_and_dl`, `actor`, and `dl` fixtures
that were copy-pasted across `test_trigger_embargo.py`,
`test_trigger_report.py`, and `test_trigger_case.py` into the shared
`test/adapters/driving/fastapi/routers/conftest.py`.

## Changes

- `conftest.py`: Added `actor_and_dl`, `actor`, `dl(actor_and_dl)`
  fixtures; replaced old `dl(datalayer)` alias; updated `client_actors`,
  `client_datalayer`, and `created_actors` to use `datalayer` directly
  to avoid DataLayer instance mismatch
- `test_actors.py`: Renamed `dl` → `datalayer` in 3 test signatures
  and bodies that used the fixture alongside `client_actors`
- `test_datalayer.py`: Renamed `dl` → `datalayer` in 8 test signatures
  and bodies that used the fixture alongside `client_datalayer`
- `test_trigger_embargo.py`, `test_trigger_report.py`,
  `test_trigger_case.py`: Removed the 3 duplicate fixture definitions

## Verification

- All 3449 unit tests pass (0 new, 0 regressions)
- Black, flake8, mypy, pyright clean