### PR TITLE
refactor: extract fixtures and group tests by phase in test_receive_report_case_tree.py

### DIFF
--- a/plan/history/2606/implementation/ISSUE-1090.md
+++ b/plan/history/2606/implementation/ISSUE-1090.md
@@ -1,0 +1,31 @@
+---
+source: ISSUE-1090
+timestamp: '2026-06-22T18:10:50.000689+00:00'
+title: Refactor test_receive_report_case_tree.py — extract fixtures and group by tree
+  phase
+type: implementation
+---
+
+## Issue #1090 — P9: Refactor test_receive_report_case_tree.py — extract fixtures and group by tree phase
+
+Refactored `test/core/behaviors/case/test_receive_report_case_tree.py`
+(917 lines, 21 flat test functions) by extracting shared fixtures to
+`conftest.py` and grouping the flat test functions into 5 classes by tree
+phase.
+
+**Changes**:
+
+- Moved 10 fixtures (`datalayer`, `actor_id`, `reporter_actor_id`, `actor`,
+  `reporter_actor`, `report`, `reporter_accepted_status`,
+  `vendor_received_status`, `offer`, `bridge`) to
+  `test/core/behaviors/case/conftest.py` for sharing with sibling tree test
+  files
+- Grouped 21 flat test functions into `TestTreeStructure` (4),
+  `TestTreeFlow` (4), `TestTreeIdempotency` (2), `TestParticipantCreation`
+  (4), `TestEmbargoInitialization` (7)
+- Moved module-level imports (`CVDRole`, `EM`, `PEC`, etc.) out of individual
+  test bodies
+
+All 21 tests pass. No logic changes. 3469 unit tests pass overall.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1103>

--- a/test/core/behaviors/case/conftest.py
+++ b/test/core/behaviors/case/conftest.py
@@ -6,9 +6,130 @@ that the global vocabulary registry is populated before any test in this
 directory runs.  Without this import the registry may be empty when tests run
 in isolation, causing TinyDB's record_to_object() to fall back to returning a
 raw Document instead of a deserialized domain object.
+
+Shared fixtures for receive-report case-tree tests are also defined here so
+that multiple tree test files can reuse them without redefinition.
 """
+
+import pytest
 
 # noqa: F401 — imported for vocabulary registration side-effect
 from vultron.wire.as2.vocab.objects.vulnerability_case import (  # noqa: F401
     VulnerabilityCase,
 )
+
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.core.behaviors.bridge import BTBridge
+from vultron.core.models.participant_status import ParticipantStatus
+from vultron.core.models.vultron_types import VultronCaseActor
+from vultron.core.states.rm import RM
+from vultron.core.use_cases._helpers import _report_phase_status_id
+from vultron.wire.as2.factories import rm_submit_report_activity
+from vultron.wire.as2.vocab.objects.vulnerability_report import (
+    VulnerabilityReport,
+)
+
+
+@pytest.fixture
+def datalayer():
+    """In-memory SQLite data layer for testing."""
+    return SqliteDataLayer("sqlite:///:memory:")
+
+
+@pytest.fixture
+def actor_id():
+    """Vendor (receiver) actor ID."""
+    return "https://example.org/actors/vendor"
+
+
+@pytest.fixture
+def reporter_actor_id():
+    """Reporter actor ID."""
+    return "https://example.org/actors/reporter"
+
+
+@pytest.fixture
+def actor(datalayer, actor_id):
+    """Create vendor actor in the DataLayer with an outbox."""
+    obj = VultronCaseActor(id_=actor_id, name="Vendor Co")
+    datalayer.create(obj)
+    return obj
+
+
+@pytest.fixture
+def reporter_actor(datalayer, reporter_actor_id):
+    """Create reporter actor in the DataLayer."""
+    obj = VultronCaseActor(id_=reporter_actor_id, name="Reporter Co")
+    datalayer.create(obj)
+    return obj
+
+
+@pytest.fixture
+def report(datalayer):
+    """Create test VulnerabilityReport."""
+    obj = VulnerabilityReport(
+        id_="https://example.org/reports/CVE-2024-001",
+        name="Test Vulnerability Report",
+        content="Buffer overflow in component X",
+    )
+    datalayer.create(obj)
+    return obj
+
+
+@pytest.fixture
+def reporter_accepted_status(datalayer, reporter_actor_id, report):
+    """Pre-create the reporter's RM.ACCEPTED report-phase status record.
+
+    SubmitReportReceivedUseCase creates this record before the tree runs.
+    """
+    status = ParticipantStatus(
+        id_=_report_phase_status_id(
+            reporter_actor_id, report.id_, RM.ACCEPTED.value
+        ),
+        context=report.id_,
+        attributed_to=reporter_actor_id,
+        rm_state=RM.ACCEPTED,
+    )
+    datalayer.create(status)
+    return status
+
+
+@pytest.fixture
+def vendor_received_status(datalayer, actor_id, report):
+    """Pre-create the vendor's RM.RECEIVED report-phase status record.
+
+    CreateReportReceivedUseCase or AckReportReceivedUseCase creates this
+    record before the tree runs.
+    """
+    status = ParticipantStatus(
+        id_=_report_phase_status_id(actor_id, report.id_, RM.RECEIVED.value),
+        context=report.id_,
+        attributed_to=actor_id,
+        rm_state=RM.RECEIVED,
+    )
+    datalayer.create(status)
+    return status
+
+
+@pytest.fixture
+def offer(datalayer, report, actor_id, reporter_actor_id):
+    """Create test Offer activity (reporter submits report to vendor)."""
+    obj = rm_submit_report_activity(
+        report=report,
+        actor=reporter_actor_id,
+        to=actor_id,
+    )
+    datalayer.create(obj)
+    return obj
+
+
+@pytest.fixture
+def bridge(datalayer):
+    """BT bridge for tree execution (includes TriggerActivityAdapter)."""
+    from vultron.adapters.driven.trigger_activity_adapter import (
+        TriggerActivityAdapter,
+    )
+
+    return BTBridge(
+        datalayer=datalayer, trigger_activity=TriggerActivityAdapter(datalayer)
+    )

--- a/test/core/behaviors/case/test_receive_report_case_tree.py
+++ b/test/core/behaviors/case/test_receive_report_case_tree.py
@@ -22,547 +22,228 @@ the RM.RECEIVED stage (ADR-0015).
 
 Per specs/case-management.yaml CM-12 and specs/behavior-tree-integration.yaml
 BT-06.
+
+Tests are grouped by tree phase:
+- TestTreeStructure  — root node type, child count, and node identity
+- TestTreeFlow       — happy-path execution, case creation, outbox ordering
+- TestTreeIdempotency — idempotency guard and early-exit paths
+- TestParticipantCreation — owner/reporter/vendor participant RM seeding
+- TestEmbargoInitialization — embargo creation, EM state, and signatory seeding
+
+Fixtures are defined in conftest.py and shared with sibling tree test files.
 """
 
-import pytest
+import py_trees
 from py_trees.common import Status
 
-from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
-from vultron.core.behaviors.bridge import BTBridge
+from vultron.core.behaviors.case.nodes import (
+    CheckCaseExistsForReport,
+    CreateCaseOwnerParticipant,
+    InitializeDefaultEmbargoNode,
+)
 from vultron.core.behaviors.case.receive_report_case_tree import (
     create_receive_report_case_tree,
 )
-from vultron.core.models.participant_status import ParticipantStatus
-from vultron.core.models.vultron_types import (
-    VultronCaseActor,
-)
+from vultron.core.states.em import EM
+from vultron.core.states.participant_embargo_consent import PEC
 from vultron.core.states.rm import RM
-from vultron.core.use_cases._helpers import _report_phase_status_id
-from vultron.wire.as2.factories import rm_submit_report_activity
-from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
-)
-
-# ============================================================================
-# Fixtures
-# ============================================================================
-
-
-@pytest.fixture
-def datalayer():
-    """In-memory TinyDB data layer for testing."""
-    return SqliteDataLayer("sqlite:///:memory:")
-
-
-@pytest.fixture
-def actor_id():
-    """Vendor (receiver) actor ID."""
-    return "https://example.org/actors/vendor"
-
-
-@pytest.fixture
-def reporter_actor_id():
-    """Reporter actor ID."""
-    return "https://example.org/actors/reporter"
-
-
-@pytest.fixture
-def actor(datalayer, actor_id):
-    """Create vendor actor in the DataLayer with an outbox."""
-    obj = VultronCaseActor(id_=actor_id, name="Vendor Co")
-    datalayer.create(obj)
-    return obj
-
-
-@pytest.fixture
-def reporter_actor(datalayer, reporter_actor_id):
-    """Create reporter actor in the DataLayer."""
-    obj = VultronCaseActor(id_=reporter_actor_id, name="Reporter Co")
-    datalayer.create(obj)
-    return obj
-
-
-@pytest.fixture
-def report(datalayer):
-    """Create test VulnerabilityReport."""
-    obj = VulnerabilityReport(
-        id_="https://example.org/reports/CVE-2024-001",
-        name="Test Vulnerability Report",
-        content="Buffer overflow in component X",
-    )
-    datalayer.create(obj)
-    return obj
-
-
-@pytest.fixture
-def reporter_accepted_status(datalayer, reporter_actor_id, report):
-    """Pre-create the reporter's RM.ACCEPTED report-phase status record.
-
-    SubmitReportReceivedUseCase creates this record before the tree runs.
-    """
-    status = ParticipantStatus(
-        id_=_report_phase_status_id(
-            reporter_actor_id, report.id_, RM.ACCEPTED.value
-        ),
-        context=report.id_,
-        attributed_to=reporter_actor_id,
-        rm_state=RM.ACCEPTED,
-    )
-    datalayer.create(status)
-    return status
-
-
-@pytest.fixture
-def vendor_received_status(datalayer, actor_id, report):
-    """Pre-create the vendor's RM.RECEIVED report-phase status record.
-
-    CreateReportReceivedUseCase or AckReportReceivedUseCase creates this
-    record before the tree runs.
-    """
-    status = ParticipantStatus(
-        id_=_report_phase_status_id(actor_id, report.id_, RM.RECEIVED.value),
-        context=report.id_,
-        attributed_to=actor_id,
-        rm_state=RM.RECEIVED,
-    )
-    datalayer.create(status)
-    return status
-
-
-@pytest.fixture
-def offer(datalayer, report, actor_id, reporter_actor_id):
-    """Create test Offer activity (reporter submits report to vendor)."""
-    obj = rm_submit_report_activity(
-        report=report,
-        actor=reporter_actor_id,
-        to=actor_id,
-    )
-    datalayer.create(obj)
-    return obj
-
-
-@pytest.fixture
-def bridge(datalayer):
-    """BT bridge for tree execution."""
-    from vultron.adapters.driven.trigger_activity_adapter import (
-        TriggerActivityAdapter,
-    )
-
-    return BTBridge(
-        datalayer=datalayer, trigger_activity=TriggerActivityAdapter(datalayer)
-    )
-
+from vultron.core.states.roles import CVDRole
 
 # ============================================================================
 # Tree structure tests
 # ============================================================================
 
 
-def test_create_receive_report_case_tree_returns_selector(
-    report, offer, reporter_actor_id
-):
-    """Tree factory returns a Selector root node."""
-    tree = create_receive_report_case_tree(
-        report_id=report.id_,
-        offer_id=offer.id_,
-        reporter_actor_id=reporter_actor_id,
-    )
-    assert tree is not None
-    assert tree.name == "ReceiveReportCaseBT"
-    assert hasattr(tree, "children")
-    assert len(tree.children) == 2
+class TestTreeStructure:
+    """Structure assertions: root node type, children count, and node types."""
 
+    def test_create_receive_report_case_tree_returns_selector(
+        self, report, offer, reporter_actor_id
+    ):
+        """Tree factory returns a Selector root node."""
+        tree = create_receive_report_case_tree(
+            report_id=report.id_,
+            offer_id=offer.id_,
+            reporter_actor_id=reporter_actor_id,
+        )
+        assert tree is not None
+        assert tree.name == "ReceiveReportCaseBT"
+        assert hasattr(tree, "children")
+        assert len(tree.children) == 2
 
-def test_tree_first_child_is_idempotency_check(
-    report, offer, reporter_actor_id
-):
-    """First child is CheckCaseExistsForReport (idempotency guard)."""
-    from vultron.core.behaviors.case.nodes import CheckCaseExistsForReport
+    def test_tree_first_child_is_idempotency_check(
+        self, report, offer, reporter_actor_id
+    ):
+        """First child is CheckCaseExistsForReport (idempotency guard)."""
+        tree = create_receive_report_case_tree(
+            report_id=report.id_,
+            offer_id=offer.id_,
+            reporter_actor_id=reporter_actor_id,
+        )
+        assert isinstance(tree.children[0], CheckCaseExistsForReport)
 
-    tree = create_receive_report_case_tree(
-        report_id=report.id_,
-        offer_id=offer.id_,
-        reporter_actor_id=reporter_actor_id,
-    )
-    assert isinstance(tree.children[0], CheckCaseExistsForReport)
+    def test_tree_second_child_is_sequence(
+        self, report, offer, reporter_actor_id
+    ):
+        """Second child is a Sequence (ReceiveReportCaseFlow)."""
+        tree = create_receive_report_case_tree(
+            report_id=report.id_,
+            offer_id=offer.id_,
+            reporter_actor_id=reporter_actor_id,
+        )
+        assert isinstance(tree.children[1], py_trees.composites.Sequence)
+        assert tree.children[1].name == "ReceiveReportCaseFlow"
 
-
-def test_tree_second_child_is_sequence(report, offer, reporter_actor_id):
-    """Second child is a Sequence (ReceiveReportCaseFlow)."""
-    import py_trees
-
-    tree = create_receive_report_case_tree(
-        report_id=report.id_,
-        offer_id=offer.id_,
-        reporter_actor_id=reporter_actor_id,
-    )
-    assert isinstance(tree.children[1], py_trees.composites.Sequence)
-    assert tree.children[1].name == "ReceiveReportCaseFlow"
-
-
-def test_tree_flow_has_ten_children(report, offer, reporter_actor_id):
-    """ReceiveReportCaseFlow sequence has exactly 10 action nodes."""
-    tree = create_receive_report_case_tree(
-        report_id=report.id_,
-        offer_id=offer.id_,
-        reporter_actor_id=reporter_actor_id,
-    )
-    flow = tree.children[1]
-    assert len(flow.children) == 9
+    def test_tree_flow_has_ten_children(
+        self, report, offer, reporter_actor_id
+    ):
+        """ReceiveReportCaseFlow sequence has exactly 9 action nodes."""
+        tree = create_receive_report_case_tree(
+            report_id=report.id_,
+            offer_id=offer.id_,
+            reporter_actor_id=reporter_actor_id,
+        )
+        flow = tree.children[1]
+        assert len(flow.children) == 9
 
 
 # ============================================================================
-# Execution tests
+# Tree flow tests
 # ============================================================================
 
 
-def test_tree_succeeds(
-    datalayer,
-    actor,
-    reporter_actor,
-    reporter_actor_id,
-    report,
-    offer,
-    bridge,
-    reporter_accepted_status,
-    vendor_received_status,
-):
-    """Tree executes successfully and returns Status.SUCCESS."""
-    tree = create_receive_report_case_tree(
-        report_id=report.id_,
-        offer_id=offer.id_,
-        reporter_actor_id=reporter_actor_id,
-    )
-    result = bridge.execute_with_setup(
-        tree=tree, actor_id=actor.id_, activity=offer
-    )
-    assert result.status == Status.SUCCESS
+class TestTreeFlow:
+    """Happy-path execution, case creation, and outbox ordering."""
 
-
-def test_tree_creates_case(
-    datalayer,
-    actor,
-    reporter_actor,
-    reporter_actor_id,
-    report,
-    offer,
-    bridge,
-    reporter_accepted_status,
-    vendor_received_status,
-):
-    """Tree creates a VulnerabilityCase linked to the report."""
-    tree = create_receive_report_case_tree(
-        report_id=report.id_,
-        offer_id=offer.id_,
-        reporter_actor_id=reporter_actor_id,
-    )
-    bridge.execute_with_setup(tree=tree, actor_id=actor.id_, activity=offer)
-
-    case = datalayer.find_case_by_report_id(report.id_)
-    assert case is not None
-    # The case should reference the report
-    reports = getattr(case, "vulnerability_reports", []) or []
-    report_refs = [
-        r if isinstance(r, str) else getattr(r, "id_", str(r)) for r in reports
-    ]
-    assert report.id_ in report_refs
-
-
-def test_tree_creates_case_owner_participant_at_rm_received(
-    datalayer,
-    actor,
-    reporter_actor,
-    reporter_actor_id,
-    report,
-    offer,
-    bridge,
-    reporter_accepted_status,
-    vendor_received_status,
-):
-    """Tree creates a case-owner participant at RM.RECEIVED (BTND-05-002)."""
-    from vultron.core.states.roles import CVDRole
-
-    tree = create_receive_report_case_tree(
-        report_id=report.id_,
-        offer_id=offer.id_,
-        reporter_actor_id=reporter_actor_id,
-    )
-    bridge.execute_with_setup(tree=tree, actor_id=actor.id_, activity=offer)
-
-    case = datalayer.find_case_by_report_id(report.id_)
-    assert case is not None
-
-    found_owner = False
-    for p_ref in case.case_participants:
-        p_id = p_ref if isinstance(p_ref, str) else p_ref.id_
-        participant = datalayer.read(p_id)
-        if participant is None:
-            continue
-        p_actor = participant.attributed_to
-        p_actor_id = (
-            p_actor
-            if isinstance(p_actor, str)
-            else getattr(p_actor, "id_", p_actor)
+    def test_tree_succeeds(
+        self,
+        datalayer,
+        actor,
+        reporter_actor,
+        reporter_actor_id,
+        report,
+        offer,
+        bridge,
+        reporter_accepted_status,
+        vendor_received_status,
+    ):
+        """Tree executes successfully and returns Status.SUCCESS."""
+        tree = create_receive_report_case_tree(
+            report_id=report.id_,
+            offer_id=offer.id_,
+            reporter_actor_id=reporter_actor_id,
         )
-        if p_actor_id != actor.id_:
-            continue
-        roles = participant.case_roles
-        if CVDRole.CASE_OWNER not in roles:
-            continue
-        statuses = participant.participant_statuses
-        assert statuses, "Case-owner participant has no status history"
-        latest = statuses[-1]
-        rm = getattr(latest, "rm_state", None)
-        assert (
-            rm == RM.RECEIVED
-        ), f"Expected case-owner rm_state=RM.RECEIVED, got {rm}"
-        found_owner = True
-
-    assert found_owner, "No case-owner participant found in case"
-
-
-def test_tree_creates_finder_participant_at_rm_accepted(
-    datalayer,
-    actor,
-    reporter_actor,
-    reporter_actor_id,
-    report,
-    offer,
-    bridge,
-    reporter_accepted_status,
-    vendor_received_status,
-):
-    """Tree creates a reporter participant at RM.ACCEPTED."""
-    from vultron.core.states.roles import CVDRole
-
-    tree = create_receive_report_case_tree(
-        report_id=report.id_,
-        offer_id=offer.id_,
-        reporter_actor_id=reporter_actor_id,
-    )
-    bridge.execute_with_setup(tree=tree, actor_id=actor.id_, activity=offer)
-
-    case = datalayer.find_case_by_report_id(report.id_)
-    assert case is not None
-
-    found_finder = False
-    for p_ref in case.case_participants:
-        p_id = p_ref if isinstance(p_ref, str) else p_ref.id_
-        participant = datalayer.read(p_id)
-        if participant is None:
-            continue
-        p_actor = participant.attributed_to
-        p_actor_id = (
-            p_actor
-            if isinstance(p_actor, str)
-            else getattr(p_actor, "id_", p_actor)
+        result = bridge.execute_with_setup(
+            tree=tree, actor_id=actor.id_, activity=offer
         )
-        if p_actor_id != reporter_actor.id_:
-            continue
-        roles = participant.case_roles
-        if CVDRole.FINDER not in roles:
-            continue
-        statuses = participant.participant_statuses
-        assert statuses, "Finder participant has no status history"
-        latest = statuses[-1]
-        rm = getattr(latest, "rm_state", None)
+        assert result.status == Status.SUCCESS
+
+    def test_tree_creates_case(
+        self,
+        datalayer,
+        actor,
+        reporter_actor,
+        reporter_actor_id,
+        report,
+        offer,
+        bridge,
+        reporter_accepted_status,
+        vendor_received_status,
+    ):
+        """Tree creates a VulnerabilityCase linked to the report."""
+        tree = create_receive_report_case_tree(
+            report_id=report.id_,
+            offer_id=offer.id_,
+            reporter_actor_id=reporter_actor_id,
+        )
+        bridge.execute_with_setup(
+            tree=tree, actor_id=actor.id_, activity=offer
+        )
+
+        case = datalayer.find_case_by_report_id(report.id_)
+        assert case is not None
+        # The case should reference the report
+        reports = getattr(case, "vulnerability_reports", []) or []
+        report_refs = [
+            r if isinstance(r, str) else getattr(r, "id_", str(r))
+            for r in reports
+        ]
+        assert report.id_ in report_refs
+
+    def test_tree_queues_create_case_activity(
+        self,
+        datalayer,
+        actor,
+        reporter_actor,
+        reporter_actor_id,
+        report,
+        offer,
+        bridge,
+        reporter_accepted_status,
+        vendor_received_status,
+    ):
+        """Tree queues a Create(Case) activity to the actor's outbox."""
+        tree = create_receive_report_case_tree(
+            report_id=report.id_,
+            offer_id=offer.id_,
+            reporter_actor_id=reporter_actor_id,
+        )
+        bridge.execute_with_setup(
+            tree=tree, actor_id=actor.id_, activity=offer
+        )
+
+        outbox_items = datalayer.clone_for_actor(actor.id_).outbox_list()
+        assert len(outbox_items) > 0
+
+    def test_create_case_precedes_add_participant_in_outbox(
+        self,
+        datalayer,
+        actor,
+        reporter_actor,
+        reporter_actor_id,
+        report,
+        offer,
+        bridge,
+        reporter_accepted_status,
+        vendor_received_status,
+    ):
+        """Create(Case) must be queued before Add(CaseParticipant) (D5-7-MSGORDER-1).
+
+        Ensures the reporter actor receives the case-creation notification before
+        receiving the participant-addition notification, preventing "case not found"
+        warnings on the reporter side.
+        """
+        tree = create_receive_report_case_tree(
+            report_id=report.id_,
+            offer_id=offer.id_,
+            reporter_actor_id=reporter_actor_id,
+        )
+        bridge.execute_with_setup(
+            tree=tree, actor_id=actor.id_, activity=offer
+        )
+
+        items = datalayer.clone_for_actor(actor.id_).outbox_list()
+        assert len(items) >= 2, f"Expected >= 2 outbox items; got {len(items)}"
+
+        # Read the first two activities to check their types
+        first_activity = datalayer.read(items[0])
+        second_activity = datalayer.read(items[1])
         assert (
-            rm == RM.ACCEPTED
-        ), f"Expected reporter rm_state=RM.ACCEPTED, got {rm}"
-        found_finder = True
+            first_activity is not None
+        ), f"Could not read activity '{items[0]}'"
+        assert (
+            second_activity is not None
+        ), f"Could not read activity '{items[1]}'"
 
-    assert found_finder, "No reporter participant found in case"
-
-
-def test_tree_creates_default_embargo(
-    datalayer,
-    actor,
-    reporter_actor,
-    reporter_actor_id,
-    report,
-    offer,
-    bridge,
-    reporter_accepted_status,
-    vendor_received_status,
-):
-    """Tree creates a default embargo and attaches it to the case."""
-    tree = create_receive_report_case_tree(
-        report_id=report.id_,
-        offer_id=offer.id_,
-        reporter_actor_id=reporter_actor_id,
-    )
-    bridge.execute_with_setup(tree=tree, actor_id=actor.id_, activity=offer)
-
-    case = datalayer.find_case_by_report_id(report.id_)
-    assert case is not None
-    assert case.active_embargo is not None
-
-
-def test_tree_sets_em_state_active_after_embargo_init(
-    datalayer,
-    actor,
-    reporter_actor,
-    reporter_actor_id,
-    report,
-    offer,
-    bridge,
-    reporter_accepted_status,
-    vendor_received_status,
-):
-    """After embargo initialization, the case's current EM state MUST be
-    ACTIVE, not NONE or PROPOSED (EP-04-001, EP-04-002,
-    specs/case-management.yaml CM-12-004).
-    """
-    from vultron.core.states.em import EM
-
-    tree = create_receive_report_case_tree(
-        report_id=report.id_,
-        offer_id=offer.id_,
-        reporter_actor_id=reporter_actor_id,
-    )
-    bridge.execute_with_setup(tree=tree, actor_id=actor.id_, activity=offer)
-
-    case = datalayer.find_case_by_report_id(report.id_)
-    assert case is not None
-    assert case.active_embargo is not None
-    assert (
-        case.current_status.em_state != EM.NONE
-    ), f"Expected em_state != NONE after embargo init, got {case.current_status.em_state}"
-    assert case.current_status.em_state == EM.ACTIVE, (
-        f"Expected em_state == ACTIVE after embargo init,"
-        f" got {case.current_status.em_state}"
-    )
-
-
-def test_tree_records_embargo_initialized_event(
-    datalayer,
-    actor,
-    reporter_actor,
-    reporter_actor_id,
-    report,
-    offer,
-    bridge,
-    reporter_accepted_status,
-    vendor_received_status,
-):
-    """After embargo initialization the case MUST have an active embargo
-    (D5-7-EMSTATE-1).
-
-    record_event('embargo_initialized') was removed in #789; the behavioral
-    invariant is now verified by checking case.active_embargo is not None.
-    The canonical ledger commit (CommitCaseLedgerEntryNode) records the
-    submit_report entry that caused the embargo to be initialized.
-    """
-    tree = create_receive_report_case_tree(
-        report_id=report.id_,
-        offer_id=offer.id_,
-        reporter_actor_id=reporter_actor_id,
-    )
-    bridge.execute_with_setup(tree=tree, actor_id=actor.id_, activity=offer)
-
-    case = datalayer.find_case_by_report_id(report.id_)
-    assert case is not None
-    assert (
-        case.active_embargo is not None
-    ), "Expected case.active_embargo to be set after embargo initialization"
-
-
-def test_tree_embargo_initialized_event_references_embargo_id(
-    datalayer,
-    actor,
-    reporter_actor,
-    reporter_actor_id,
-    report,
-    offer,
-    bridge,
-    reporter_accepted_status,
-    vendor_received_status,
-):
-    """The active embargo MUST reference the correct embargo object ID
-    (D5-7-EMSTATE-1).
-
-    record_event('embargo_initialized') was removed in #789; the behavioral
-    invariant is now verified by checking case.active_embargo equals the
-    expected embargo ID.
-    """
-    tree = create_receive_report_case_tree(
-        report_id=report.id_,
-        offer_id=offer.id_,
-        reporter_actor_id=reporter_actor_id,
-    )
-    bridge.execute_with_setup(tree=tree, actor_id=actor.id_, activity=offer)
-
-    case = datalayer.find_case_by_report_id(report.id_)
-    assert case is not None
-    assert case.active_embargo is not None
-    embargo = datalayer.read(case.active_embargo)
-    assert embargo is not None
-
-
-def test_tree_queues_create_case_activity(
-    datalayer,
-    actor,
-    reporter_actor,
-    reporter_actor_id,
-    report,
-    offer,
-    bridge,
-    reporter_accepted_status,
-    vendor_received_status,
-):
-    """Tree queues a Create(Case) activity to the actor's outbox."""
-    tree = create_receive_report_case_tree(
-        report_id=report.id_,
-        offer_id=offer.id_,
-        reporter_actor_id=reporter_actor_id,
-    )
-    bridge.execute_with_setup(tree=tree, actor_id=actor.id_, activity=offer)
-
-    outbox_items = datalayer.clone_for_actor(actor.id_).outbox_list()
-    assert len(outbox_items) > 0
-
-
-def test_create_case_precedes_add_participant_in_outbox(
-    datalayer,
-    actor,
-    reporter_actor,
-    reporter_actor_id,
-    report,
-    offer,
-    bridge,
-    reporter_accepted_status,
-    vendor_received_status,
-):
-    """Create(Case) must be queued before Add(CaseParticipant) (D5-7-MSGORDER-1).
-
-    Ensures the reporter actor receives the case-creation notification before
-    receiving the participant-addition notification, preventing "case not found"
-    warnings on the reporter side.
-    """
-    tree = create_receive_report_case_tree(
-        report_id=report.id_,
-        offer_id=offer.id_,
-        reporter_actor_id=reporter_actor_id,
-    )
-    bridge.execute_with_setup(tree=tree, actor_id=actor.id_, activity=offer)
-
-    items = datalayer.clone_for_actor(actor.id_).outbox_list()
-    assert len(items) >= 2, f"Expected >= 2 outbox items; got {len(items)}"
-
-    # Read the first two activities to check their types
-    first_activity = datalayer.read(items[0])
-    second_activity = datalayer.read(items[1])
-    assert first_activity is not None, f"Could not read activity '{items[0]}'"
-    assert second_activity is not None, f"Could not read activity '{items[1]}'"
-
-    first_type = getattr(first_activity, "type_", None)
-    second_type = getattr(second_activity, "type_", None)
-    assert (
-        first_type == "Create"
-    ), f"First outbox item should be Create(Case), got type_={first_type!r}"
-    assert (
-        second_type == "Add"
-    ), f"Second outbox item should be Add(CaseParticipant), got type_={second_type!r}"
+        first_type = getattr(first_activity, "type_", None)
+        second_type = getattr(second_activity, "type_", None)
+        assert (
+            first_type == "Create"
+        ), f"First outbox item should be Create(Case), got type_={first_type!r}"
+        assert second_type == "Add", (
+            f"Second outbox item should be Add(CaseParticipant),"
+            f" got type_={second_type!r}"
+        )
 
 
 # ============================================================================
@@ -570,348 +251,603 @@ def test_create_case_precedes_add_participant_in_outbox(
 # ============================================================================
 
 
-def test_tree_is_idempotent(
-    datalayer,
-    actor,
-    reporter_actor,
-    reporter_actor_id,
-    report,
-    offer,
-    bridge,
-    reporter_accepted_status,
-    vendor_received_status,
-):
-    """Running the tree twice succeeds and does not duplicate the case."""
-    tree1 = create_receive_report_case_tree(
-        report_id=report.id_,
-        offer_id=offer.id_,
-        reporter_actor_id=reporter_actor_id,
-    )
-    result1 = bridge.execute_with_setup(
-        tree=tree1, actor_id=actor.id_, activity=offer
-    )
-    assert result1.status == Status.SUCCESS
+class TestTreeIdempotency:
+    """Idempotency guard and early-exit paths."""
 
-    tree2 = create_receive_report_case_tree(
-        report_id=report.id_,
-        offer_id=offer.id_,
-        reporter_actor_id=reporter_actor_id,
-    )
-    result2 = bridge.execute_with_setup(
-        tree=tree2, actor_id=actor.id_, activity=offer
-    )
-    assert result2.status == Status.SUCCESS
+    def test_tree_is_idempotent(
+        self,
+        datalayer,
+        actor,
+        reporter_actor,
+        reporter_actor_id,
+        report,
+        offer,
+        bridge,
+        reporter_accepted_status,
+        vendor_received_status,
+    ):
+        """Running the tree twice succeeds and does not duplicate the case."""
+        tree1 = create_receive_report_case_tree(
+            report_id=report.id_,
+            offer_id=offer.id_,
+            reporter_actor_id=reporter_actor_id,
+        )
+        result1 = bridge.execute_with_setup(
+            tree=tree1, actor_id=actor.id_, activity=offer
+        )
+        assert result1.status == Status.SUCCESS
 
-    # Only one case for this report
-    case = datalayer.find_case_by_report_id(report.id_)
-    assert case is not None
+        tree2 = create_receive_report_case_tree(
+            report_id=report.id_,
+            offer_id=offer.id_,
+            reporter_actor_id=reporter_actor_id,
+        )
+        result2 = bridge.execute_with_setup(
+            tree=tree2, actor_id=actor.id_, activity=offer
+        )
+        assert result2.status == Status.SUCCESS
 
+        # Only one case for this report
+        case = datalayer.find_case_by_report_id(report.id_)
+        assert case is not None
 
-def test_tree_early_exits_when_case_already_initialized(
-    datalayer,
-    actor,
-    reporter_actor,
-    reporter_actor_id,
-    report,
-    offer,
-    bridge,
-    reporter_accepted_status,
-    vendor_received_status,
-):
-    """CheckCaseExistsForReport returns SUCCESS when case has participants."""
-    # Run once to initialize case
-    tree1 = create_receive_report_case_tree(
-        report_id=report.id_,
-        offer_id=offer.id_,
-        reporter_actor_id=reporter_actor_id,
-    )
-    bridge.execute_with_setup(tree=tree1, actor_id=actor.id_, activity=offer)
+    def test_tree_early_exits_when_case_already_initialized(
+        self,
+        datalayer,
+        actor,
+        reporter_actor,
+        reporter_actor_id,
+        report,
+        offer,
+        bridge,
+        reporter_accepted_status,
+        vendor_received_status,
+    ):
+        """CheckCaseExistsForReport returns SUCCESS when case has participants."""
+        # Run once to initialize case
+        tree1 = create_receive_report_case_tree(
+            report_id=report.id_,
+            offer_id=offer.id_,
+            reporter_actor_id=reporter_actor_id,
+        )
+        bridge.execute_with_setup(
+            tree=tree1, actor_id=actor.id_, activity=offer
+        )
 
-    # Record outbox length before second run
-    outbox_count_before = len(
-        datalayer.clone_for_actor(actor.id_).outbox_list()
-    )
+        # Record outbox length before second run
+        outbox_count_before = len(
+            datalayer.clone_for_actor(actor.id_).outbox_list()
+        )
 
-    # Second run: CheckCaseExistsForReport should succeed (early exit)
-    tree2 = create_receive_report_case_tree(
-        report_id=report.id_,
-        offer_id=offer.id_,
-        reporter_actor_id=reporter_actor_id,
-    )
-    result2 = bridge.execute_with_setup(
-        tree=tree2, actor_id=actor.id_, activity=offer
-    )
-    assert result2.status == Status.SUCCESS
+        # Second run: CheckCaseExistsForReport should succeed (early exit)
+        tree2 = create_receive_report_case_tree(
+            report_id=report.id_,
+            offer_id=offer.id_,
+            reporter_actor_id=reporter_actor_id,
+        )
+        result2 = bridge.execute_with_setup(
+            tree=tree2, actor_id=actor.id_, activity=offer
+        )
+        assert result2.status == Status.SUCCESS
 
-    # No additional outbox items (early exit skips CreateCaseActivity)
-    assert (
-        len(datalayer.clone_for_actor(actor.id_).outbox_list())
-        == outbox_count_before
-    )
+        # No additional outbox items (early exit skips CreateCaseActivity)
+        assert (
+            len(datalayer.clone_for_actor(actor.id_).outbox_list())
+            == outbox_count_before
+        )
 
 
 # ============================================================================
-# Vendor RM state tests (IDEA-260408-01-2 spec requirement)
+# Participant creation tests
 # ============================================================================
 
 
-def test_vendor_participant_reuses_existing_received_status(
-    datalayer,
-    actor,
-    reporter_actor,
-    reporter_actor_id,
-    report,
-    offer,
-    bridge,
-    reporter_accepted_status,
-    vendor_received_status,
-):
-    """Vendor participant reuses pre-existing RM.RECEIVED status (no duplicate)."""
-    tree = create_receive_report_case_tree(
-        report_id=report.id_,
-        offer_id=offer.id_,
-        reporter_actor_id=reporter_actor_id,
-    )
-    bridge.execute_with_setup(tree=tree, actor_id=actor.id_, activity=offer)
+class TestParticipantCreation:
+    """Owner, reporter, and vendor participant RM state seeding."""
 
-    case = datalayer.find_case_by_report_id(report.id_)
-    assert case is not None
-
-    for p_ref in case.case_participants:
-        p_id = p_ref if isinstance(p_ref, str) else p_ref.id_
-        participant = datalayer.read(p_id)
-        if participant is None:
-            continue
-        p_actor = participant.attributed_to
-        p_actor_id = (
-            p_actor
-            if isinstance(p_actor, str)
-            else getattr(p_actor, "id_", p_actor)
+    def test_tree_creates_case_owner_participant_at_rm_received(
+        self,
+        datalayer,
+        actor,
+        reporter_actor,
+        reporter_actor_id,
+        report,
+        offer,
+        bridge,
+        reporter_accepted_status,
+        vendor_received_status,
+    ):
+        """Tree creates a case-owner participant at RM.RECEIVED (BTND-05-002)."""
+        tree = create_receive_report_case_tree(
+            report_id=report.id_,
+            offer_id=offer.id_,
+            reporter_actor_id=reporter_actor_id,
         )
-        if p_actor_id != actor.id_:
-            continue
-        # Participant should have exactly one status (the pre-existing one)
-        statuses = participant.participant_statuses
-        assert len(statuses) == 1
-        assert statuses[0].id_ == vendor_received_status.id_
-        break
-
-
-def test_case_owner_participant_created_without_pre_existing_status(
-    datalayer,
-    actor,
-    reporter_actor,
-    reporter_actor_id,
-    report,
-    offer,
-    bridge,
-    reporter_accepted_status,
-):
-    """Case-owner participant is created with fresh RM.RECEIVED when no prior status."""
-    # No vendor_received_status fixture — owner has no prior status record
-    tree = create_receive_report_case_tree(
-        report_id=report.id_,
-        offer_id=offer.id_,
-        reporter_actor_id=reporter_actor_id,
-    )
-    result = bridge.execute_with_setup(
-        tree=tree, actor_id=actor.id_, activity=offer
-    )
-    assert result.status == Status.SUCCESS
-
-    case = datalayer.find_case_by_report_id(report.id_)
-    assert case is not None
-
-    from vultron.core.states.roles import CVDRole
-
-    for p_ref in case.case_participants:
-        p_id = p_ref if isinstance(p_ref, str) else p_ref.id_
-        participant = datalayer.read(p_id)
-        if participant is None:
-            continue
-        p_actor = participant.attributed_to
-        p_actor_id = (
-            p_actor
-            if isinstance(p_actor, str)
-            else getattr(p_actor, "id_", p_actor)
+        bridge.execute_with_setup(
+            tree=tree, actor_id=actor.id_, activity=offer
         )
-        if p_actor_id != actor.id_:
-            continue
-        if CVDRole.CASE_OWNER not in participant.case_roles:
-            continue
-        statuses = participant.participant_statuses
-        assert statuses
-        rm = getattr(statuses[-1], "rm_state", None)
-        assert rm == RM.RECEIVED, f"Expected RM.RECEIVED, got {rm}"
-        break
+
+        case = datalayer.find_case_by_report_id(report.id_)
+        assert case is not None
+
+        found_owner = False
+        for p_ref in case.case_participants:
+            p_id = p_ref if isinstance(p_ref, str) else p_ref.id_
+            participant = datalayer.read(p_id)
+            if participant is None:
+                continue
+            p_actor = participant.attributed_to
+            p_actor_id = (
+                p_actor
+                if isinstance(p_actor, str)
+                else getattr(p_actor, "id_", p_actor)
+            )
+            if p_actor_id != actor.id_:
+                continue
+            roles = participant.case_roles
+            if CVDRole.CASE_OWNER not in roles:
+                continue
+            statuses = participant.participant_statuses
+            assert statuses, "Case-owner participant has no status history"
+            latest = statuses[-1]
+            rm = getattr(latest, "rm_state", None)
+            assert (
+                rm == RM.RECEIVED
+            ), f"Expected case-owner rm_state=RM.RECEIVED, got {rm}"
+            found_owner = True
+
+        assert found_owner, "No case-owner participant found in case"
+
+    def test_tree_creates_finder_participant_at_rm_accepted(
+        self,
+        datalayer,
+        actor,
+        reporter_actor,
+        reporter_actor_id,
+        report,
+        offer,
+        bridge,
+        reporter_accepted_status,
+        vendor_received_status,
+    ):
+        """Tree creates a reporter participant at RM.ACCEPTED."""
+        tree = create_receive_report_case_tree(
+            report_id=report.id_,
+            offer_id=offer.id_,
+            reporter_actor_id=reporter_actor_id,
+        )
+        bridge.execute_with_setup(
+            tree=tree, actor_id=actor.id_, activity=offer
+        )
+
+        case = datalayer.find_case_by_report_id(report.id_)
+        assert case is not None
+
+        found_finder = False
+        for p_ref in case.case_participants:
+            p_id = p_ref if isinstance(p_ref, str) else p_ref.id_
+            participant = datalayer.read(p_id)
+            if participant is None:
+                continue
+            p_actor = participant.attributed_to
+            p_actor_id = (
+                p_actor
+                if isinstance(p_actor, str)
+                else getattr(p_actor, "id_", p_actor)
+            )
+            if p_actor_id != reporter_actor.id_:
+                continue
+            roles = participant.case_roles
+            if CVDRole.FINDER not in roles:
+                continue
+            statuses = participant.participant_statuses
+            assert statuses, "Finder participant has no status history"
+            latest = statuses[-1]
+            rm = getattr(latest, "rm_state", None)
+            assert (
+                rm == RM.ACCEPTED
+            ), f"Expected reporter rm_state=RM.ACCEPTED, got {rm}"
+            found_finder = True
+
+        assert found_finder, "No reporter participant found in case"
+
+    def test_vendor_participant_reuses_existing_received_status(
+        self,
+        datalayer,
+        actor,
+        reporter_actor,
+        reporter_actor_id,
+        report,
+        offer,
+        bridge,
+        reporter_accepted_status,
+        vendor_received_status,
+    ):
+        """Vendor participant reuses pre-existing RM.RECEIVED status (no duplicate)."""
+        tree = create_receive_report_case_tree(
+            report_id=report.id_,
+            offer_id=offer.id_,
+            reporter_actor_id=reporter_actor_id,
+        )
+        bridge.execute_with_setup(
+            tree=tree, actor_id=actor.id_, activity=offer
+        )
+
+        case = datalayer.find_case_by_report_id(report.id_)
+        assert case is not None
+
+        for p_ref in case.case_participants:
+            p_id = p_ref if isinstance(p_ref, str) else p_ref.id_
+            participant = datalayer.read(p_id)
+            if participant is None:
+                continue
+            p_actor = participant.attributed_to
+            p_actor_id = (
+                p_actor
+                if isinstance(p_actor, str)
+                else getattr(p_actor, "id_", p_actor)
+            )
+            if p_actor_id != actor.id_:
+                continue
+            # Participant should have exactly one status (the pre-existing one)
+            statuses = participant.participant_statuses
+            assert len(statuses) == 1
+            assert statuses[0].id_ == vendor_received_status.id_
+            break
+
+    def test_case_owner_participant_created_without_pre_existing_status(
+        self,
+        datalayer,
+        actor,
+        reporter_actor,
+        reporter_actor_id,
+        report,
+        offer,
+        bridge,
+        reporter_accepted_status,
+    ):
+        """Case-owner participant is created with fresh RM.RECEIVED when no prior status."""
+        # No vendor_received_status fixture — owner has no prior status record
+        tree = create_receive_report_case_tree(
+            report_id=report.id_,
+            offer_id=offer.id_,
+            reporter_actor_id=reporter_actor_id,
+        )
+        result = bridge.execute_with_setup(
+            tree=tree, actor_id=actor.id_, activity=offer
+        )
+        assert result.status == Status.SUCCESS
+
+        case = datalayer.find_case_by_report_id(report.id_)
+        assert case is not None
+
+        for p_ref in case.case_participants:
+            p_id = p_ref if isinstance(p_ref, str) else p_ref.id_
+            participant = datalayer.read(p_id)
+            if participant is None:
+                continue
+            p_actor = participant.attributed_to
+            p_actor_id = (
+                p_actor
+                if isinstance(p_actor, str)
+                else getattr(p_actor, "id_", p_actor)
+            )
+            if p_actor_id != actor.id_:
+                continue
+            if CVDRole.CASE_OWNER not in participant.case_roles:
+                continue
+            statuses = participant.participant_statuses
+            assert statuses
+            rm = getattr(statuses[-1], "rm_state", None)
+            assert rm == RM.RECEIVED, f"Expected RM.RECEIVED, got {rm}"
+            break
 
 
 # ============================================================================
-# CM-14 ordering and SIGNATORY seeding tests (AC-1, AC-2, AC-3, AC-5)
+# Embargo initialization tests
 # ============================================================================
 
 
-def test_tree_owner_participant_precedes_embargo_in_sequence(
-    report, offer, reporter_actor_id
-):
-    """CreateCaseOwnerParticipant MUST precede InitializeDefaultEmbargoNode
-    in the sequence (CM-14-002, AC-1).
-    """
-    from vultron.core.behaviors.case.nodes import (
-        CreateCaseOwnerParticipant,
-        InitializeDefaultEmbargoNode,
-    )
+class TestEmbargoInitialization:
+    """Embargo creation, EM state, and signatory seeding."""
 
-    tree = create_receive_report_case_tree(
-        report_id=report.id_,
-        offer_id=offer.id_,
-        reporter_actor_id=reporter_actor_id,
-    )
-    flow = tree.children[1]
-    node_types = [type(child) for child in flow.children]
-
-    owner_idx = None
-    embargo_idx = None
-    for i, t in enumerate(node_types):
-        if t is CreateCaseOwnerParticipant:
-            owner_idx = i
-        if t is InitializeDefaultEmbargoNode:
-            embargo_idx = i
-
-    assert (
-        owner_idx is not None
-    ), "CreateCaseOwnerParticipant not found in flow"
-    assert (
-        embargo_idx is not None
-    ), "InitializeDefaultEmbargoNode not found in flow"
-    assert owner_idx < embargo_idx, (
-        f"CreateCaseOwnerParticipant (idx={owner_idx}) must precede"
-        f" InitializeDefaultEmbargoNode (idx={embargo_idx}) — CM-14-002"
-    )
-
-
-def test_owner_seeded_as_signatory_after_embargo_init(
-    datalayer,
-    actor,
-    reporter_actor,
-    reporter_actor_id,
-    report,
-    offer,
-    bridge,
-    reporter_accepted_status,
-    vendor_received_status,
-):
-    """Case-owner participant MUST have embargo_consent_state == SIGNATORY
-    after tree execution when a default embargo is created (CM-14-003, AC-2).
-    """
-    from vultron.core.states.participant_embargo_consent import PEC
-    from vultron.core.states.roles import CVDRole
-
-    tree = create_receive_report_case_tree(
-        report_id=report.id_,
-        offer_id=offer.id_,
-        reporter_actor_id=reporter_actor_id,
-    )
-    bridge.execute_with_setup(tree=tree, actor_id=actor.id_, activity=offer)
-
-    case = datalayer.find_case_by_report_id(report.id_)
-    assert case is not None
-    assert case.active_embargo is not None, "No active embargo — prerequisite"
-
-    found_owner = False
-    for p_ref in case.case_participants:
-        p_id = p_ref if isinstance(p_ref, str) else p_ref.id_
-        participant = datalayer.read(p_id)
-        if participant is None:
-            continue
-        p_actor = participant.attributed_to
-        p_actor_id = (
-            p_actor
-            if isinstance(p_actor, str)
-            else getattr(p_actor, "id_", p_actor)
+    def test_tree_creates_default_embargo(
+        self,
+        datalayer,
+        actor,
+        reporter_actor,
+        reporter_actor_id,
+        report,
+        offer,
+        bridge,
+        reporter_accepted_status,
+        vendor_received_status,
+    ):
+        """Tree creates a default embargo and attaches it to the case."""
+        tree = create_receive_report_case_tree(
+            report_id=report.id_,
+            offer_id=offer.id_,
+            reporter_actor_id=reporter_actor_id,
         )
-        if p_actor_id != actor.id_:
-            continue
-        if CVDRole.CASE_OWNER not in participant.case_roles:
-            continue
-        assert PEC(participant.embargo_consent_state) == PEC.SIGNATORY, (
-            f"Expected owner embargo_consent_state=SIGNATORY,"
-            f" got {participant.embargo_consent_state!r}"
+        bridge.execute_with_setup(
+            tree=tree, actor_id=actor.id_, activity=offer
         )
-        active_embargo_id = (
-            case.active_embargo
-            if isinstance(case.active_embargo, str)
-            else getattr(case.active_embargo, "id_", str(case.active_embargo))
+
+        case = datalayer.find_case_by_report_id(report.id_)
+        assert case is not None
+        assert case.active_embargo is not None
+
+    def test_tree_sets_em_state_active_after_embargo_init(
+        self,
+        datalayer,
+        actor,
+        reporter_actor,
+        reporter_actor_id,
+        report,
+        offer,
+        bridge,
+        reporter_accepted_status,
+        vendor_received_status,
+    ):
+        """After embargo initialization, the case's current EM state MUST be
+        ACTIVE, not NONE or PROPOSED (EP-04-001, EP-04-002,
+        specs/case-management.yaml CM-12-004).
+        """
+        tree = create_receive_report_case_tree(
+            report_id=report.id_,
+            offer_id=offer.id_,
+            reporter_actor_id=reporter_actor_id,
         )
-        assert active_embargo_id in participant.accepted_embargo_ids, (
-            f"Expected active embargo '{active_embargo_id}'"
-            f" in owner accepted_embargo_ids,"
-            f" got {participant.accepted_embargo_ids!r}"
+        bridge.execute_with_setup(
+            tree=tree, actor_id=actor.id_, activity=offer
         )
-        found_owner = True
 
-    assert found_owner, "No case-owner participant found in case"
-
-
-def test_reporter_seeded_as_signatory_when_active_embargo(
-    datalayer,
-    actor,
-    reporter_actor,
-    reporter_actor_id,
-    report,
-    offer,
-    bridge,
-    reporter_accepted_status,
-    vendor_received_status,
-):
-    """Reporter participant MUST have embargo_consent_state == SIGNATORY
-    when an active embargo exists at participant creation time
-    (CM-14-005, AC-3).
-    """
-    from vultron.core.states.participant_embargo_consent import PEC
-    from vultron.core.states.roles import CVDRole
-
-    tree = create_receive_report_case_tree(
-        report_id=report.id_,
-        offer_id=offer.id_,
-        reporter_actor_id=reporter_actor_id,
-    )
-    bridge.execute_with_setup(tree=tree, actor_id=actor.id_, activity=offer)
-
-    case = datalayer.find_case_by_report_id(report.id_)
-    assert case is not None
-    assert case.active_embargo is not None, "No active embargo — prerequisite"
-
-    found_reporter = False
-    for p_ref in case.case_participants:
-        p_id = p_ref if isinstance(p_ref, str) else p_ref.id_
-        participant = datalayer.read(p_id)
-        if participant is None:
-            continue
-        p_actor = participant.attributed_to
-        p_actor_id = (
-            p_actor
-            if isinstance(p_actor, str)
-            else getattr(p_actor, "id_", p_actor)
+        case = datalayer.find_case_by_report_id(report.id_)
+        assert case is not None
+        assert case.active_embargo is not None
+        assert case.current_status.em_state != EM.NONE, (
+            f"Expected em_state != NONE after embargo init,"
+            f" got {case.current_status.em_state}"
         )
-        if p_actor_id != reporter_actor.id_:
-            continue
-        if CVDRole.FINDER not in participant.case_roles:
-            continue
-        assert PEC(participant.embargo_consent_state) == PEC.SIGNATORY, (
-            f"Expected reporter embargo_consent_state=SIGNATORY,"
-            f" got {participant.embargo_consent_state!r}"
+        assert case.current_status.em_state == EM.ACTIVE, (
+            f"Expected em_state == ACTIVE after embargo init,"
+            f" got {case.current_status.em_state}"
         )
-        active_embargo_id = (
-            case.active_embargo
-            if isinstance(case.active_embargo, str)
-            else getattr(case.active_embargo, "id_", str(case.active_embargo))
-        )
-        assert active_embargo_id in participant.accepted_embargo_ids, (
-            f"Expected active embargo '{active_embargo_id}'"
-            f" in reporter accepted_embargo_ids,"
-            f" got {participant.accepted_embargo_ids!r}"
-        )
-        found_reporter = True
 
-    assert found_reporter, "No reporter participant found in case"
+    def test_tree_records_embargo_initialized_event(
+        self,
+        datalayer,
+        actor,
+        reporter_actor,
+        reporter_actor_id,
+        report,
+        offer,
+        bridge,
+        reporter_accepted_status,
+        vendor_received_status,
+    ):
+        """After embargo initialization the case MUST have an active embargo
+        (D5-7-EMSTATE-1).
+
+        record_event('embargo_initialized') was removed in #789; the behavioral
+        invariant is now verified by checking case.active_embargo is not None.
+        The canonical ledger commit (CommitCaseLedgerEntryNode) records the
+        submit_report entry that caused the embargo to be initialized.
+        """
+        tree = create_receive_report_case_tree(
+            report_id=report.id_,
+            offer_id=offer.id_,
+            reporter_actor_id=reporter_actor_id,
+        )
+        bridge.execute_with_setup(
+            tree=tree, actor_id=actor.id_, activity=offer
+        )
+
+        case = datalayer.find_case_by_report_id(report.id_)
+        assert case is not None
+        assert (
+            case.active_embargo is not None
+        ), "Expected case.active_embargo to be set after embargo initialization"
+
+    def test_tree_embargo_initialized_event_references_embargo_id(
+        self,
+        datalayer,
+        actor,
+        reporter_actor,
+        reporter_actor_id,
+        report,
+        offer,
+        bridge,
+        reporter_accepted_status,
+        vendor_received_status,
+    ):
+        """The active embargo MUST reference the correct embargo object ID
+        (D5-7-EMSTATE-1).
+
+        record_event('embargo_initialized') was removed in #789; the behavioral
+        invariant is now verified by checking case.active_embargo equals the
+        expected embargo ID.
+        """
+        tree = create_receive_report_case_tree(
+            report_id=report.id_,
+            offer_id=offer.id_,
+            reporter_actor_id=reporter_actor_id,
+        )
+        bridge.execute_with_setup(
+            tree=tree, actor_id=actor.id_, activity=offer
+        )
+
+        case = datalayer.find_case_by_report_id(report.id_)
+        assert case is not None
+        assert case.active_embargo is not None
+        embargo = datalayer.read(case.active_embargo)
+        assert embargo is not None
+
+    def test_tree_owner_participant_precedes_embargo_in_sequence(
+        self,
+        report,
+        offer,
+        reporter_actor_id,
+    ):
+        """CreateCaseOwnerParticipant MUST precede InitializeDefaultEmbargoNode
+        in the sequence (CM-14-002, AC-1).
+        """
+        tree = create_receive_report_case_tree(
+            report_id=report.id_,
+            offer_id=offer.id_,
+            reporter_actor_id=reporter_actor_id,
+        )
+        flow = tree.children[1]
+        node_types = [type(child) for child in flow.children]
+
+        owner_idx = None
+        embargo_idx = None
+        for i, t in enumerate(node_types):
+            if t is CreateCaseOwnerParticipant:
+                owner_idx = i
+            if t is InitializeDefaultEmbargoNode:
+                embargo_idx = i
+
+        assert (
+            owner_idx is not None
+        ), "CreateCaseOwnerParticipant not found in flow"
+        assert (
+            embargo_idx is not None
+        ), "InitializeDefaultEmbargoNode not found in flow"
+        assert owner_idx < embargo_idx, (
+            f"CreateCaseOwnerParticipant (idx={owner_idx}) must precede"
+            f" InitializeDefaultEmbargoNode (idx={embargo_idx}) — CM-14-002"
+        )
+
+    def test_owner_seeded_as_signatory_after_embargo_init(
+        self,
+        datalayer,
+        actor,
+        reporter_actor,
+        reporter_actor_id,
+        report,
+        offer,
+        bridge,
+        reporter_accepted_status,
+        vendor_received_status,
+    ):
+        """Case-owner participant MUST have embargo_consent_state == SIGNATORY
+        after tree execution when a default embargo is created (CM-14-003, AC-2).
+        """
+        tree = create_receive_report_case_tree(
+            report_id=report.id_,
+            offer_id=offer.id_,
+            reporter_actor_id=reporter_actor_id,
+        )
+        bridge.execute_with_setup(
+            tree=tree, actor_id=actor.id_, activity=offer
+        )
+
+        case = datalayer.find_case_by_report_id(report.id_)
+        assert case is not None
+        assert (
+            case.active_embargo is not None
+        ), "No active embargo — prerequisite"
+
+        found_owner = False
+        for p_ref in case.case_participants:
+            p_id = p_ref if isinstance(p_ref, str) else p_ref.id_
+            participant = datalayer.read(p_id)
+            if participant is None:
+                continue
+            p_actor = participant.attributed_to
+            p_actor_id = (
+                p_actor
+                if isinstance(p_actor, str)
+                else getattr(p_actor, "id_", p_actor)
+            )
+            if p_actor_id != actor.id_:
+                continue
+            if CVDRole.CASE_OWNER not in participant.case_roles:
+                continue
+            assert PEC(participant.embargo_consent_state) == PEC.SIGNATORY, (
+                f"Expected owner embargo_consent_state=SIGNATORY,"
+                f" got {participant.embargo_consent_state!r}"
+            )
+            active_embargo_id = (
+                case.active_embargo
+                if isinstance(case.active_embargo, str)
+                else getattr(
+                    case.active_embargo, "id_", str(case.active_embargo)
+                )
+            )
+            assert active_embargo_id in participant.accepted_embargo_ids, (
+                f"Expected active embargo '{active_embargo_id}'"
+                f" in owner accepted_embargo_ids,"
+                f" got {participant.accepted_embargo_ids!r}"
+            )
+            found_owner = True
+
+        assert found_owner, "No case-owner participant found in case"
+
+    def test_reporter_seeded_as_signatory_when_active_embargo(
+        self,
+        datalayer,
+        actor,
+        reporter_actor,
+        reporter_actor_id,
+        report,
+        offer,
+        bridge,
+        reporter_accepted_status,
+        vendor_received_status,
+    ):
+        """Reporter participant MUST have embargo_consent_state == SIGNATORY
+        when an active embargo exists at participant creation time
+        (CM-14-005, AC-3).
+        """
+        tree = create_receive_report_case_tree(
+            report_id=report.id_,
+            offer_id=offer.id_,
+            reporter_actor_id=reporter_actor_id,
+        )
+        bridge.execute_with_setup(
+            tree=tree, actor_id=actor.id_, activity=offer
+        )
+
+        case = datalayer.find_case_by_report_id(report.id_)
+        assert case is not None
+        assert (
+            case.active_embargo is not None
+        ), "No active embargo — prerequisite"
+
+        found_reporter = False
+        for p_ref in case.case_participants:
+            p_id = p_ref if isinstance(p_ref, str) else p_ref.id_
+            participant = datalayer.read(p_id)
+            if participant is None:
+                continue
+            p_actor = participant.attributed_to
+            p_actor_id = (
+                p_actor
+                if isinstance(p_actor, str)
+                else getattr(p_actor, "id_", p_actor)
+            )
+            if p_actor_id != reporter_actor.id_:
+                continue
+            if CVDRole.FINDER not in participant.case_roles:
+                continue
+            assert PEC(participant.embargo_consent_state) == PEC.SIGNATORY, (
+                f"Expected reporter embargo_consent_state=SIGNATORY,"
+                f" got {participant.embargo_consent_state!r}"
+            )
+            active_embargo_id = (
+                case.active_embargo
+                if isinstance(case.active_embargo, str)
+                else getattr(
+                    case.active_embargo, "id_", str(case.active_embargo)
+                )
+            )
+            assert active_embargo_id in participant.accepted_embargo_ids, (
+                f"Expected active embargo '{active_embargo_id}'"
+                f" in reporter accepted_embargo_ids,"
+                f" got {participant.accepted_embargo_ids!r}"
+            )
+            found_reporter = True
+
+        assert found_reporter, "No reporter participant found in case"


### PR DESCRIPTION
- Closes #1090

## Summary

Refactors `test/core/behaviors/case/test_receive_report_case_tree.py` (917 lines, 21 flat test functions) by extracting fixtures to `conftest.py` and grouping test functions into classes by tree phase. No logic changes.

## Changes

- `test/core/behaviors/case/conftest.py`: Added 10 shared fixtures (`datalayer`, `actor_id`, `reporter_actor_id`, `actor`, `reporter_actor`, `report`, `reporter_accepted_status`, `vendor_received_status`, `offer`, `bridge`) extracted from the test file so sibling tree test files can reuse them
- `test/core/behaviors/case/test_receive_report_case_tree.py`: Removed the 10 local fixtures; grouped 21 flat test functions into 5 classes (`TestTreeStructure`, `TestTreeFlow`, `TestTreeIdempotency`, `TestParticipantCreation`, `TestEmbargoInitialization`); moved module-level imports (`CVDRole`, `EM`, `PEC`, etc.) out of individual test bodies

## Verification

- All 21 tests pass: `uv run pytest test/core/behaviors/case/test_receive_report_case_tree.py --tb=short`
- Full case directory: 137 passed (sibling tests unaffected)
- 3469 unit tests pass (0 failures)
- Black, flake8, mypy, pyright clean