### PR TITLE
test(#824): participant lookup regression tests and consistent fixture setup

### DIFF
--- a/plan/history/2606/implementation/ISSUE-824.md
+++ b/plan/history/2606/implementation/ISSUE-824.md
@@ -1,0 +1,24 @@
+---
+source: ISSUE-824
+timestamp: '2026-06-22T18:15:24.171265+00:00'
+title: participant lookup regression tests and consistent fixture setup
+type: implementation
+---
+
+## Issue #824 — Update participant lookup tests for canonical case surfaces
+
+Added 7 regression tests for `resolve_case_participant_id_for_actor` in
+`test/core/use_cases/test_helpers.py` covering all divergence-detection
+scenarios: happy path, cache miss, inline participant object, actor not
+found, stale index, index divergence, and duplicate actor in canonical
+list. Tests use the `is_case_model()` + DL round-trip pattern matching
+production call sites.
+
+Fixed `_make_two_actor_case()` in `test/core/use_cases/triggers/test_trignotify.py`
+to populate both `case_participants` and `actor_participant_index` consistently
+via `add_participant()` and store participant objects in the DataLayer. The
+old fixture left `case_participants` empty.
+
+All 3476 unit tests pass (7 new). Black, flake8, mypy, pyright clean.
+
+PR: [#1104](https://github.com/CERTCC/Vultron/pull/1104)

--- a/test/core/use_cases/test_helpers.py
+++ b/test/core/use_cases/test_helpers.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute
+#    to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype
+#  is licensed under a MIT (SEI)-style license, please see LICENSE.md
+#  distributed with this Software or contact permission@sei.cmu.edu for full
+#  terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Regression tests for ``resolve_case_participant_id_for_actor``.
+
+Covers the divergence-detection contract between ``case_participants``
+(canonical source) and ``actor_participant_index`` (derived cache):
+
+- Happy path: both surfaces consistent → canonical ID returned.
+- Cache miss: participant in ``case_participants`` but absent from index
+  → canonical ID returned (cache-miss is not an error).
+- Inline participant object in ``case_participants`` → canonical ID returned.
+- Actor absent from both surfaces → None returned.
+- Stale index: actor in ``actor_participant_index`` but no matching entry
+  in ``case_participants`` → VultronValidationError raised.
+- Index divergence: ``case_participants`` and ``actor_participant_index``
+  disagree on the participant ID → VultronValidationError raised.
+- Duplicate actor in ``case_participants``: two distinct participants share
+  the same ``attributed_to`` actor → VultronValidationError raised.
+
+Reference: AGENTS.md § "Case Participant Lookup Must Fail Fast on Surface
+Divergence", issue #822, issue #825.
+"""
+
+import pytest
+
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.case_participant import CaseParticipant
+from vultron.core.models.protocols import CaseModel, is_case_model
+from vultron.core.states.roles import CVDRole
+from vultron.core.use_cases._helpers import (
+    resolve_case_participant_id_for_actor,
+)
+from vultron.errors import VultronValidationError
+
+_ACTOR_ID = "https://example.org/actors/vendor-001"
+_CASE_ID = "https://example.org/cases/case-001"
+_PARTICIPANT_ID = f"{_CASE_ID}/participants/vendor-001"
+_ALT_PARTICIPANT_ID = f"{_CASE_ID}/participants/vendor-alt"
+
+
+@pytest.fixture()
+def dl() -> SqliteDataLayer:
+    return SqliteDataLayer("sqlite:///:memory:")
+
+
+@pytest.fixture()
+def participant() -> CaseParticipant:
+    return CaseParticipant(
+        id_=_PARTICIPANT_ID,
+        attributed_to=_ACTOR_ID,
+        context=_CASE_ID,
+        case_roles=[CVDRole.VENDOR],
+    )
+
+
+@pytest.fixture()
+def seeded_case(
+    dl: SqliteDataLayer, participant: CaseParticipant
+) -> CaseModel:
+    """Case with participant stored in DL and registered on both surfaces."""
+    dl.create(participant)
+    case = VulnerabilityCase(id_=_CASE_ID, name="Test Case")
+    case.add_participant(participant)
+    dl.create(case)
+    stored = dl.read(_CASE_ID)
+    assert is_case_model(stored), "seeded_case: DL did not return a CaseModel"
+    return stored
+
+
+class TestResolveCaseParticipantIdForActor:
+    """Contract tests for resolve_case_participant_id_for_actor."""
+
+    def test_happy_path_returns_canonical_id(
+        self, seeded_case: CaseModel, dl: SqliteDataLayer
+    ) -> None:
+        """Both surfaces consistent: canonical participant ID is returned."""
+        result = resolve_case_participant_id_for_actor(
+            seeded_case, _ACTOR_ID, dl
+        )
+        assert result == _PARTICIPANT_ID
+
+    def test_cache_miss_returns_canonical_id(
+        self, dl: SqliteDataLayer, participant: CaseParticipant
+    ) -> None:
+        """Participant in case_participants but absent from index → no error.
+
+        A missing index entry (cache miss) is not a divergence — the canonical
+        list has the correct entry so the ID should be resolved without error.
+        """
+        dl.create(participant)
+        case = VulnerabilityCase(id_=_CASE_ID, name="Test Case")
+        # Populate only case_participants; omit actor_participant_index entry.
+        case.case_participants.append(_PARTICIPANT_ID)
+        dl.create(case)
+
+        stored = dl.read(_CASE_ID)
+        assert is_case_model(stored)
+        result = resolve_case_participant_id_for_actor(stored, _ACTOR_ID, dl)
+        assert result == _PARTICIPANT_ID
+
+    def test_inline_participant_object_resolved(
+        self, dl: SqliteDataLayer, participant: CaseParticipant
+    ) -> None:
+        """Inline CaseParticipant object in case_participants is resolved."""
+        case = VulnerabilityCase(id_=_CASE_ID, name="Test Case")
+        # Store participant inline (not as a string ID) — simulates wire-layer
+        # round-trips where objects arrive embedded rather than referenced.
+        case.case_participants.append(participant)  # type: ignore[arg-type]
+        case.actor_participant_index[_ACTOR_ID] = _PARTICIPANT_ID
+        dl.create(participant)
+        dl.create(case)
+
+        # Re-read from DL: the DL normalises inline objects to typed records.
+        # The case must still resolve via the inline-then-rehydrated path.
+        stored = dl.read(_CASE_ID)
+        assert is_case_model(stored)
+        result = resolve_case_participant_id_for_actor(stored, _ACTOR_ID, dl)
+        assert result == _PARTICIPANT_ID
+
+    def test_not_found_returns_none(
+        self, seeded_case: CaseModel, dl: SqliteDataLayer
+    ) -> None:
+        """Actor not in case at all → None returned without error."""
+        unknown_id = "https://example.org/actors/unknown"
+        result = resolve_case_participant_id_for_actor(
+            seeded_case, unknown_id, dl
+        )
+        assert result is None
+
+    def test_stale_index_raises(self, dl: SqliteDataLayer) -> None:
+        """Actor in actor_participant_index but not in case_participants raises.
+
+        This is the canonical stale-cache divergence: the index claims an entry
+        exists but the authoritative list has no matching participant.  Any code
+        that only populates the index (without case_participants) is in error.
+        """
+        case = VulnerabilityCase(id_=_CASE_ID, name="Test Case")
+        # Stale index: actor mapped to a participant ID, but case_participants
+        # is empty so there is no canonical entry to validate against.
+        case.actor_participant_index[_ACTOR_ID] = _PARTICIPANT_ID
+        dl.create(case)
+
+        stored = dl.read(_CASE_ID)
+        assert is_case_model(stored)
+        with pytest.raises(
+            VultronValidationError, match="actor_participant_index"
+        ):
+            resolve_case_participant_id_for_actor(stored, _ACTOR_ID, dl)
+
+    def test_index_divergence_raises(
+        self, dl: SqliteDataLayer, participant: CaseParticipant
+    ) -> None:
+        """Index maps actor to a different ID than case_participants → raises.
+
+        This is the strict divergence case: both surfaces have an entry for the
+        same actor, but they disagree on which participant ID is authoritative.
+        """
+        dl.create(participant)
+        case = VulnerabilityCase(id_=_CASE_ID, name="Test Case")
+        # Canonical list has the correct participant.
+        case.case_participants.append(_PARTICIPANT_ID)
+        # Index deliberately maps to a *different* ID.
+        case.actor_participant_index[_ACTOR_ID] = _ALT_PARTICIPANT_ID
+        dl.create(case)
+
+        stored = dl.read(_CASE_ID)
+        assert is_case_model(stored)
+        with pytest.raises(VultronValidationError, match="divergence"):
+            resolve_case_participant_id_for_actor(stored, _ACTOR_ID, dl)
+
+    def test_duplicate_actor_in_canonical_list_raises(
+        self, dl: SqliteDataLayer
+    ) -> None:
+        """Two distinct participants with the same attributed_to actor → raises.
+
+        The canonical list must be unique per actor; duplicates indicate a
+        write-path bug that must surface immediately rather than silently
+        choosing one entry.
+        """
+        p1 = CaseParticipant(
+            id_=_PARTICIPANT_ID,
+            attributed_to=_ACTOR_ID,
+            context=_CASE_ID,
+            case_roles=[CVDRole.VENDOR],
+        )
+        p2 = CaseParticipant(
+            id_=_ALT_PARTICIPANT_ID,
+            attributed_to=_ACTOR_ID,
+            context=_CASE_ID,
+            case_roles=[CVDRole.VENDOR],
+        )
+        dl.create(p1)
+        dl.create(p2)
+        case = VulnerabilityCase(id_=_CASE_ID, name="Test Case")
+        case.case_participants.append(_PARTICIPANT_ID)
+        case.case_participants.append(_ALT_PARTICIPANT_ID)
+        dl.create(case)
+
+        stored = dl.read(_CASE_ID)
+        assert is_case_model(stored)
+        with pytest.raises(
+            VultronValidationError, match="multiple participants"
+        ):
+            resolve_case_participant_id_for_actor(stored, _ACTOR_ID, dl)

--- a/test/core/use_cases/triggers/test_trignotify.py
+++ b/test/core/use_cases/triggers/test_trignotify.py
@@ -160,14 +160,33 @@ def _make_case_with_case_manager(
 def _make_two_actor_case(
     dl, vendor_id: str, finder_id: str
 ) -> VulnerabilityCase:
-    """Create a VulnerabilityCase with vendor and finder in actor_participant_index.
+    """Create a VulnerabilityCase with vendor and finder — no CASE_MANAGER.
 
-    Note: no CASE_MANAGER participant — use _make_case_with_case_manager for
-    tests that verify PCR-08-001 routing.
+    Both ``case_participants`` and ``actor_participant_index`` are kept in
+    sync via ``add_participant()``.  Participant objects are stored in the
+    DataLayer so ``resolve_case_participant_id_for_actor`` can resolve them
+    from the canonical list without hitting divergence errors.
+
+    Use ``_make_case_with_case_manager`` for tests that need PCR-08-001
+    routing or an ``EngageCaseTriggerRequest``/``AddParticipantStatusTriggerRequest``.
     """
     case = VulnerabilityCase(name="Test Case")
-    case.actor_participant_index[vendor_id] = f"{case.id_}/participants/vendor"
-    case.actor_participant_index[finder_id] = f"{case.id_}/participants/finder"
+    vendor_participant = CaseParticipant(
+        id_=f"{case.id_}/participants/vendor",
+        attributed_to=vendor_id,
+        context=case.id_,
+        case_roles=[CVDRole.VENDOR],
+    )
+    finder_participant = CaseParticipant(
+        id_=f"{case.id_}/participants/finder",
+        attributed_to=finder_id,
+        context=case.id_,
+        case_roles=[CVDRole.FINDER],
+    )
+    case.add_participant(vendor_participant)
+    case.add_participant(finder_participant)
+    dl.create(vendor_participant)
+    dl.create(finder_participant)
     dl.create(case)
     return case
 


### PR DESCRIPTION
- Closes #824

## Summary

Adds 7 regression tests for `resolve_case_participant_id_for_actor` covering
all divergence-detection scenarios, and fixes `_make_two_actor_case` to
keep `case_participants` and `actor_participant_index` consistent through
`add_participant()`.

## Changes

- **`test/core/use_cases/test_helpers.py`** (new): Regression tests for
  `resolve_case_participant_id_for_actor` — happy path, cache miss, inline
  participant, actor not found, stale index, index divergence, and duplicate
  actor in canonical list. Uses `is_case_model()` + DL round-trip pattern
  matching production call sites.
- **`test/core/use_cases/triggers/test_trignotify.py`**: Update
  `_make_two_actor_case` to create real `CaseParticipant` objects in the
  DataLayer and register them on both `case_participants` and
  `actor_participant_index` via `add_participant()`. Replaces the old
  index-only fixture that left `case_participants` empty.

## Verification

- All 3476 unit tests pass (7 new)
- Black, flake8, mypy, pyright clean
- [x] AC-1: Existing tests updated to keep both surfaces consistent via shared helpers
- [x] AC-2: Regression coverage added for lookup divergence scenarios