### PR TITLE
feat: FUZZ-02 — port 15 embargo management fuzzer nodes to vultron/demo/fuzzer/embargo.py

### DIFF
--- a/plan/history/2606/implementation/ISSUE-861.md
+++ b/plan/history/2606/implementation/ISSUE-861.md
@@ -1,0 +1,31 @@
+---
+source: ISSUE-861
+timestamp: '2026-06-22T18:52:20.228922+00:00'
+title: 'FUZZ-02: Port embargo management fuzzer nodes'
+type: implementation
+---
+
+## Issue #861 — FUZZ-02: Port embargo management fuzzer nodes to vultron/demo/fuzzer/embargo.py
+
+Ported all 15 embargo management fuzzer nodes from
+`vultron/bt/embargo_management/fuzzer.py` to the new
+`vultron/demo/fuzzer/embargo.py` module using the py_trees probabilistic
+base types from FUZZ-01 (#860).
+
+Each node subclasses the appropriate `WeightedBehavior` subclass
+(`ProbablyFail`, `UsuallyFail`, `AlwaysSucceed`, etc.) and carries a
+docstring covering semantic function, input category, success
+probability, and automation potential per BT-16-003 and BT-16-005.
+
+`AvoidEmbargoCounterProposal` is implemented as `UsuallySucceed`
+(p=0.75), the logical complement of `WillingToCounterEmbargoProposal`
+(p=0.25).
+
+Added 179 unit tests in `test/fuzzer/test_embargo.py` (placed under
+`test/fuzzer/` rather than `test/demo/fuzzer/` to avoid the
+auto-integration marker from `test/demo/conftest.py`). All 15 nodes are
+re-exported from `vultron/demo/fuzzer/__init__.py`.
+
+Full suite: 3950 passed, 37 skipped, 5 xfailed. All linters clean.
+
+PR: [#1106](https://github.com/CERTCC/Vultron/pull/1106)

--- a/test/fuzzer/test_embargo.py
+++ b/test/fuzzer/test_embargo.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python
+#  Copyright (c) 2023-2025 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Unit tests for vultron/demo/fuzzer/embargo.py.
+
+Tests cover:
+  - All 15 nodes are WeightedBehavior subclasses
+  - Each node has the correct success_rate attribute (AC-1, AC-3)
+  - Each node has a non-empty docstring covering semantic function,
+    input category, success probability, and automation potential (AC-2)
+  - update() returns only valid Status values
+  - AlwaysSucceed-based nodes always succeed
+  - AlwaysFail-based nodes never succeed
+  - Empirical distribution checks for selected nodes
+"""
+
+import random
+from typing import Type
+
+import py_trees
+import pytest
+from py_trees.common import Status
+
+from vultron.demo.fuzzer.base import WeightedBehavior
+from vultron.demo.fuzzer.embargo import (
+    AvoidEmbargoCounterProposal,
+    CurrentEmbargoAcceptable,
+    EmbargoTimerExpired,
+    EvaluateEmbargoProposal,
+    ExitEmbargoForOtherReason,
+    ExitEmbargoWhenDeployed,
+    ExitEmbargoWhenFixReady,
+    OnEmbargoAccept,
+    OnEmbargoExit,
+    OnEmbargoReject,
+    ReasonToProposeEmbargoWhenDeployed,
+    SelectEmbargoOfferTerms,
+    StopProposingEmbargo,
+    WantToProposeEmbargo,
+    WillingToCounterEmbargoProposal,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_TRIALS = 10_000
+_TOLERANCE = 0.03  # ±3 percentage points
+
+# All 15 nodes with their expected success_rates
+_ALL_NODES: list[tuple[Type[WeightedBehavior], float]] = [
+    (ExitEmbargoWhenDeployed, 1.0 / 3.0),
+    (ExitEmbargoWhenFixReady, 1.0 / 4.0),
+    (ExitEmbargoForOtherReason, 1.0 / 200.0),
+    (EmbargoTimerExpired, 1.0 / 100.0),
+    (OnEmbargoExit, 1.0),
+    (StopProposingEmbargo, 1.0 / 4.0),
+    (SelectEmbargoOfferTerms, 1.0),
+    (WantToProposeEmbargo, 1.0 / 2.0),
+    (WillingToCounterEmbargoProposal, 1.0 / 4.0),
+    (AvoidEmbargoCounterProposal, 3.0 / 4.0),
+    (ReasonToProposeEmbargoWhenDeployed, 7.0 / 100.0),
+    (EvaluateEmbargoProposal, 3.0 / 4.0),
+    (OnEmbargoAccept, 1.0),
+    (OnEmbargoReject, 1.0),
+    (CurrentEmbargoAcceptable, 9.0 / 10.0),
+]
+
+_NODE_NAMES = [cls.__name__ for cls, _ in _ALL_NODES]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_trials(node_cls: Type[WeightedBehavior], n: int = _TRIALS) -> float:
+    """Return empirical success rate over *n* independent ticks."""
+    node = node_cls()
+    successes = sum(1 for _ in range(n) if node.update() == Status.SUCCESS)
+    return successes / n
+
+
+# ---------------------------------------------------------------------------
+# AC-1: All 15 nodes ported using py_trees base types
+# ---------------------------------------------------------------------------
+
+
+class TestAllNodesAreWeightedBehavior:
+    @pytest.mark.parametrize("cls,_rate", _ALL_NODES)
+    def test_is_weighted_behavior_subclass(
+        self, cls: Type[WeightedBehavior], _rate: float
+    ) -> None:
+        assert issubclass(
+            cls, WeightedBehavior
+        ), f"{cls.__name__} must be a WeightedBehavior subclass"
+
+    @pytest.mark.parametrize("cls,_rate", _ALL_NODES)
+    def test_is_py_trees_behaviour(
+        self, cls: Type[WeightedBehavior], _rate: float
+    ) -> None:
+        node = cls()
+        assert isinstance(node, py_trees.behaviour.Behaviour)
+
+    @pytest.mark.parametrize("cls,_rate", _ALL_NODES)
+    def test_default_name_is_class_name(
+        self, cls: Type[WeightedBehavior], _rate: float
+    ) -> None:
+        node = cls()
+        assert node.name == cls.__name__
+
+    def test_all_15_nodes_present(self) -> None:
+        assert (
+            len(_ALL_NODES) == 15
+        ), f"Expected 15 embargo fuzzer nodes, found {len(_ALL_NODES)}"
+
+
+# ---------------------------------------------------------------------------
+# AC-2: Docstrings cover required fields per BT-16-003 / BT-16-005
+# ---------------------------------------------------------------------------
+
+
+class TestDocstrings:
+    @pytest.mark.parametrize("cls,_rate", _ALL_NODES)
+    def test_has_non_empty_docstring(
+        self, cls: Type[WeightedBehavior], _rate: float
+    ) -> None:
+        doc = cls.__doc__ or ""
+        assert len(doc.strip()) > 0, f"{cls.__name__} has an empty docstring"
+
+    @pytest.mark.parametrize("cls,_rate", _ALL_NODES)
+    def test_docstring_mentions_semantic_function(
+        self, cls: Type[WeightedBehavior], _rate: float
+    ) -> None:
+        doc = (cls.__doc__ or "").lower()
+        assert (
+            "semantic function" in doc
+        ), f"{cls.__name__} docstring missing 'Semantic function' section"
+
+    @pytest.mark.parametrize("cls,_rate", _ALL_NODES)
+    def test_docstring_mentions_input_category(
+        self, cls: Type[WeightedBehavior], _rate: float
+    ) -> None:
+        doc = (cls.__doc__ or "").lower()
+        assert (
+            "input category" in doc
+        ), f"{cls.__name__} docstring missing 'Input category' section"
+
+    @pytest.mark.parametrize("cls,_rate", _ALL_NODES)
+    def test_docstring_mentions_success_probability(
+        self, cls: Type[WeightedBehavior], _rate: float
+    ) -> None:
+        doc = (cls.__doc__ or "").lower()
+        assert (
+            "success probability" in doc
+        ), f"{cls.__name__} docstring missing 'Success probability' section"
+
+    @pytest.mark.parametrize("cls,_rate", _ALL_NODES)
+    def test_docstring_mentions_automation_potential(
+        self, cls: Type[WeightedBehavior], _rate: float
+    ) -> None:
+        doc = (cls.__doc__ or "").lower()
+        assert (
+            "automation potential" in doc
+        ), f"{cls.__name__} docstring missing 'Automation potential' section"
+
+
+# ---------------------------------------------------------------------------
+# AC-3: Unit tests verify correct status distribution
+# ---------------------------------------------------------------------------
+
+
+class TestSuccessRateAttributes:
+    @pytest.mark.parametrize("cls,expected_rate", _ALL_NODES)
+    def test_success_rate_attribute(
+        self, cls: Type[WeightedBehavior], expected_rate: float
+    ) -> None:
+        assert abs(cls.success_rate - expected_rate) < 1e-9, (
+            f"{cls.__name__}: success_rate={cls.success_rate!r}, "
+            f"expected {expected_rate!r}"
+        )
+
+
+class TestUpdateReturnsValidStatus:
+    @pytest.mark.parametrize("cls,_rate", _ALL_NODES)
+    def test_update_returns_success_or_failure(
+        self, cls: Type[WeightedBehavior], _rate: float
+    ) -> None:
+        node = cls()
+        result = node.update()
+        assert result in (
+            Status.SUCCESS,
+            Status.FAILURE,
+        ), f"{cls.__name__}.update() returned unexpected status: {result}"
+
+    @pytest.mark.parametrize("cls,_rate", _ALL_NODES)
+    def test_update_never_returns_running(
+        self, cls: Type[WeightedBehavior], _rate: float
+    ) -> None:
+        node = cls()
+        results = {node.update() for _ in range(50)}
+        assert (
+            Status.RUNNING not in results
+        ), f"{cls.__name__}.update() returned RUNNING unexpectedly"
+
+
+class TestDeterministicExtremes:
+    def test_on_embargo_exit_always_succeeds(self) -> None:
+        node = OnEmbargoExit()
+        assert all(node.update() == Status.SUCCESS for _ in range(100))
+
+    def test_select_embargo_offer_terms_always_succeeds(self) -> None:
+        node = SelectEmbargoOfferTerms()
+        assert all(node.update() == Status.SUCCESS for _ in range(100))
+
+    def test_on_embargo_accept_always_succeeds(self) -> None:
+        node = OnEmbargoAccept()
+        assert all(node.update() == Status.SUCCESS for _ in range(100))
+
+    def test_on_embargo_reject_always_succeeds(self) -> None:
+        node = OnEmbargoReject()
+        assert all(node.update() == Status.SUCCESS for _ in range(100))
+
+
+class TestEmpiricalDistributions:
+    """Verify that probabilistic nodes produce the expected distribution."""
+
+    @pytest.mark.parametrize(
+        "cls,expected_rate",
+        [
+            (ExitEmbargoWhenDeployed, 1.0 / 3.0),
+            (ExitEmbargoWhenFixReady, 1.0 / 4.0),
+            (WantToProposeEmbargo, 0.50),
+            (AvoidEmbargoCounterProposal, 0.75),
+            (EvaluateEmbargoProposal, 0.75),
+            (CurrentEmbargoAcceptable, 0.90),
+        ],
+    )
+    def test_empirical_distribution(
+        self, cls: Type[WeightedBehavior], expected_rate: float
+    ) -> None:
+        rate = _run_trials(cls)
+        assert (
+            abs(rate - expected_rate) < _TOLERANCE
+        ), f"{cls.__name__}: empirical={rate:.4f} expected={expected_rate:.4f}"
+
+    def test_seeded_determinism(self) -> None:
+        """Same seed → same sequence for a representative node."""
+        random.seed(42)
+        node = EvaluateEmbargoProposal()
+        seq_a = [node.update() for _ in range(20)]
+        random.seed(42)
+        seq_b = [node.update() for _ in range(20)]
+        assert seq_a == seq_b
+
+
+# ---------------------------------------------------------------------------
+# Invariant: AvoidEmbargoCounterProposal is complement of WillingToCounter
+# ---------------------------------------------------------------------------
+
+
+class TestAvoidCounterIsComplementOfWillingToCounter:
+    def test_success_rates_sum_to_one(self) -> None:
+        assert (
+            abs(
+                WillingToCounterEmbargoProposal.success_rate
+                + AvoidEmbargoCounterProposal.success_rate
+                - 1.0
+            )
+            < 1e-9
+        )
+
+    def test_empirical_rates_are_complementary(self) -> None:
+        willing_rate = _run_trials(WillingToCounterEmbargoProposal)
+        avoid_rate = _run_trials(AvoidEmbargoCounterProposal)
+        assert abs(willing_rate + avoid_rate - 1.0) < (2 * _TOLERANCE)

--- a/vultron/demo/fuzzer/__init__.py
+++ b/vultron/demo/fuzzer/__init__.py
@@ -39,8 +39,26 @@ from vultron.demo.fuzzer.base import (
     UsuallySucceed,
     WeightedBehavior,
 )
+from vultron.demo.fuzzer.embargo import (
+    AvoidEmbargoCounterProposal,
+    CurrentEmbargoAcceptable,
+    EmbargoTimerExpired,
+    EvaluateEmbargoProposal,
+    ExitEmbargoForOtherReason,
+    ExitEmbargoWhenDeployed,
+    ExitEmbargoWhenFixReady,
+    OnEmbargoAccept,
+    OnEmbargoExit,
+    OnEmbargoReject,
+    ReasonToProposeEmbargoWhenDeployed,
+    SelectEmbargoOfferTerms,
+    StopProposingEmbargo,
+    WantToProposeEmbargo,
+    WillingToCounterEmbargoProposal,
+)
 
 __all__ = [
+    # base types
     "WeightedBehavior",
     "SuccessOrRunning",
     "AlwaysSucceed",
@@ -65,4 +83,20 @@ __all__ = [
     "LikelyFail",
     "RandomConditionNode",
     "RandomActionNode",
+    # embargo management nodes
+    "ExitEmbargoWhenDeployed",
+    "ExitEmbargoWhenFixReady",
+    "ExitEmbargoForOtherReason",
+    "EmbargoTimerExpired",
+    "OnEmbargoExit",
+    "StopProposingEmbargo",
+    "SelectEmbargoOfferTerms",
+    "WantToProposeEmbargo",
+    "WillingToCounterEmbargoProposal",
+    "AvoidEmbargoCounterProposal",
+    "ReasonToProposeEmbargoWhenDeployed",
+    "EvaluateEmbargoProposal",
+    "OnEmbargoAccept",
+    "OnEmbargoReject",
+    "CurrentEmbargoAcceptable",
 ]

--- a/vultron/demo/fuzzer/embargo.py
+++ b/vultron/demo/fuzzer/embargo.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python
+#  Copyright (c) 2023-2025 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Embargo management fuzzer nodes for the Vultron demo layer.
+
+This module provides probabilistic stub ``py_trees`` behaviour nodes for the
+Embargo Management (EM) workflow.  Each node represents an external-dependency
+touchpoint — a human decision, environmental check, or system integration
+hook — that will eventually be replaced by production logic.
+
+Nodes are built on the probabilistic base types in
+``vultron.demo.fuzzer.base`` and satisfy BT-16-003 (named integration-point
+nodes with semantic docstrings) and BT-16-005 (automation-potential
+categorization).
+
+References
+----------
+- Source: ``vultron/bt/embargo_management/fuzzer.py``
+- Spec: ``specs/behavior-tree-integration.yaml`` BT-16-003, BT-16-004, BT-16-005
+- Notes: ``notes/bt-fuzzer-nodes-embargo.md``
+"""
+
+from __future__ import annotations
+
+from vultron.demo.fuzzer.base import (
+    AlmostAlwaysSucceed,
+    AlmostCertainlyFail,
+    AlwaysSucceed,
+    OneInOneHundred,
+    OneInTwoHundred,
+    ProbablyFail,
+    RandomSucceedFail,
+    UsuallyFail,
+    UsuallySucceed,
+)
+
+# ---------------------------------------------------------------------------
+# Embargo termination nodes
+# ---------------------------------------------------------------------------
+
+
+class ExitEmbargoWhenDeployed(ProbablyFail):
+    """Decide whether to exit an active embargo when the fix is deployed.
+
+    Semantic function:
+        Condition/action — evaluate whether deployment of the fix is
+        sufficient reason to exit the active embargo.  Models the common
+        case where deployment alone is *not* a sufficient trigger (e.g.,
+        partial rollout, emergency deployment, or pending coordinated
+        announcement).
+
+    Input category: Human decision / policy judgment.
+
+    Success probability: 0.33 (``ProbablyFail``).
+
+    Automation potential: **Medium** — deployment status is queryable via
+    patch-management or case-state APIs; the *decision* to exit still
+    requires policy-rule evaluation or human confirmation.
+    """
+
+
+class ExitEmbargoWhenFixReady(UsuallyFail):
+    """Decide whether to exit an active embargo when the fix is ready.
+
+    Semantic function:
+        Condition/action — evaluate whether fix availability (without
+        deployment) is sufficient reason to terminate the embargo.
+        Vendors may prefer to coordinate simultaneous deployment across
+        the affected population before ending the embargo.
+
+    Input category: Human decision / policy judgment.
+
+    Success probability: 0.25 (``UsuallyFail``).
+
+    Automation potential: **Medium** — fix-readiness flag is queryable
+    automatically; the exit decision depends on configurable organizational
+    policy that may require human override.
+    """
+
+
+class ExitEmbargoForOtherReason(OneInTwoHundred):
+    """Decide whether to exit an embargo for an uncommon or exceptional reason.
+
+    Semantic function:
+        Condition — catch-all for exiting an embargo for reasons other than
+        fix readiness, deployment, timer expiry, public awareness, known
+        exploits, or observed attacks.  Represents extraordinary
+        circumstances that are rare in practice.
+
+    Input category: Human decision.
+
+    Success probability: 0.005 (``OneInTwoHundred``).
+
+    Automation potential: **Low** — rare edge case representing
+    extraordinary circumstances; fundamentally requires human judgment that
+    cannot be anticipated by a general policy rule.
+    """
+
+
+class EmbargoTimerExpired(OneInOneHundred):
+    """Check whether the embargo's agreed-upon deadline has passed.
+
+    Semantic function:
+        Environmental condition — compare the current system clock against
+        the embargo expiry timestamp recorded in the case.  In simulation
+        this fires rarely; in production it is a simple timestamp
+        comparison.
+
+    Input category: Environmental check.
+
+    Success probability: 0.01 (``OneInOneHundred``).
+
+    Automation potential: **High** — simple system-clock comparison against
+    the recorded embargo expiry timestamp; fully automatable with no human
+    involvement.
+    """
+
+
+class OnEmbargoExit(AlwaysSucceed):
+    """Execute site-specific tasks when leaving an active embargo.
+
+    Semantic function:
+        Action integration hook — trigger notifications, logging, and
+        downstream system updates required when the embargo exits.  Must
+        be idempotent in production.
+
+    Input category: System integration.
+
+    Success probability: 1.00 (``AlwaysSucceed``).
+
+    Automation potential: **High** — notification dispatch, state updates,
+    and downstream triggers are fully automatable via APIs.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Embargo negotiation / proposal nodes
+# ---------------------------------------------------------------------------
+
+
+class StopProposingEmbargo(UsuallyFail):
+    """Decide whether to abandon an ongoing embargo negotiation.
+
+    Semantic function:
+        Condition — human or policy decision to give up on negotiating an
+        embargo (e.g., too many counter-proposals, time pressure).
+        Modeled as uncommon; parties are usually willing to keep
+        negotiating.
+
+    Input category: Human decision.
+
+    Success probability: 0.25 (``UsuallyFail``).
+
+    Automation potential: **Low** — negotiation-fatigue judgment depends on
+    relationship context and subjective assessment of negotiation
+    prospects; requires human decision.
+    """
+
+
+class SelectEmbargoOfferTerms(AlwaysSucceed):
+    """Select the specific terms to include in an embargo proposal.
+
+    Semantic function:
+        Action — choose duration, conditions, and other terms for a new
+        embargo proposal or counter-proposal.  In production may involve
+        negotiation-support tooling or organizational policy lookup.
+
+    Input category: Human decision.
+
+    Success probability: 1.00 (``AlwaysSucceed``).
+
+    Automation potential: **Medium** — standard terms can be drawn from
+    organizational policy templates automatically; atypical situations may
+    need human review.
+    """
+
+
+class WantToProposeEmbargo(RandomSucceedFail):
+    """Decide whether to initiate an embargo negotiation.
+
+    Semantic function:
+        Condition — does the participant currently wish to propose an
+        embargo?  Depends on case context, role, and organizational
+        policy.  The fuzzer exercises both paths equally; in production
+        the recommended default is to propose an embargo.
+
+    Input category: Human decision.
+
+    Success probability: 0.50 (``RandomSucceedFail``).
+
+    Automation potential: **Medium** — default policy (always propose) can
+    be automated; exceptions (already-public vulnerability, no vendor
+    identified) could be rule-encoded, but edge cases may need human
+    override.
+    """
+
+
+class WillingToCounterEmbargoProposal(UsuallyFail):
+    """Decide whether to counter an incoming embargo proposal.
+
+    Semantic function:
+        Condition — is the participant willing to respond to an incoming
+        proposal with a counter-proposal rather than accepting or
+        rejecting outright?  The recommended behavior is to accept the
+        current proposal and negotiate revisions separately; countering is
+        intentionally modeled as uncommon.
+
+    Input category: Human decision.
+
+    Success probability: 0.25 (``UsuallyFail``).
+
+    Automation potential: **Low** — nuanced negotiation judgment about
+    whether countering is strategically preferable to accepting and
+    revising; best left to human discretion.
+    """
+
+
+class AvoidEmbargoCounterProposal(UsuallySucceed):
+    """Prefer accepting an embargo proposal over issuing a counter-proposal.
+
+    Semantic function:
+        Condition — convenience complement of
+        ``WillingToCounterEmbargoProposal``.  Returns ``SUCCESS`` when
+        the participant should *not* counter (i.e., accept or reject
+        directly), and ``FAILURE`` when a counter-proposal is warranted.
+        Derived as the logical inversion of
+        ``WillingToCounterEmbargoProposal`` (p=0.25 → p=0.75).
+
+    Input category: Human decision (derived).
+
+    Success probability: 0.75 (complement of ``WillingToCounterEmbargoProposal``).
+
+    Automation potential: **Low** — mirrors the inverted decision from
+    ``WillingToCounterEmbargoProposal``; same human-discretion constraints
+    apply.
+    """
+
+
+class ReasonToProposeEmbargoWhenDeployed(AlmostCertainlyFail):
+    """Decide whether to start a new embargo after the fix is already deployed.
+
+    Semantic function:
+        Condition — is there an unusual reason to propose an embargo even
+        though the fix has already been deployed?  Post-deployment embargo
+        proposals are exceptional and very rare.
+
+    Input category: Human decision.
+
+    Success probability: 0.07 (``AlmostCertainlyFail``).
+
+    Automation potential: **Low** — highly exceptional circumstance; no
+    general rule can anticipate valid reasons, so human judgment is
+    required.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Embargo proposal evaluation nodes
+# ---------------------------------------------------------------------------
+
+
+class EvaluateEmbargoProposal(UsuallySucceed):
+    """Assess an incoming embargo proposal and decide whether to accept it.
+
+    Semantic function:
+        Condition/action — review the proposed terms and determine whether
+        they are acceptable.  In production may involve automated policy
+        compatibility checks or structured human analyst review.  Modeled
+        as usually succeeding (acceptance is the common outcome).
+
+    Input category: Human decision.
+
+    Success probability: 0.75 (``UsuallySucceed``).
+
+    Automation potential: **Medium** — basic compatibility check (is the
+    proposed duration within policy bounds?) is automatable; final
+    accept/reject for out-of-range proposals typically needs human review.
+    """
+
+
+class OnEmbargoAccept(AlwaysSucceed):
+    """Execute site-specific tasks when an embargo proposal is accepted.
+
+    Semantic function:
+        Action integration hook — notify stakeholders, record the
+        agreement, and start the embargo timer when the proposal is
+        accepted.  Must be idempotent in production.
+
+    Input category: System integration.
+
+    Success probability: 1.00 (``AlwaysSucceed``).
+
+    Automation potential: **High** — notification dispatch, timer
+    initialization, and state-update actions are fully automatable via
+    APIs.
+    """
+
+
+class OnEmbargoReject(AlwaysSucceed):
+    """Execute site-specific tasks when an embargo proposal is rejected.
+
+    Semantic function:
+        Action integration hook — notify stakeholders and log the
+        rejection rationale when the proposal is not accepted.  Must be
+        idempotent in production.
+
+    Input category: System integration.
+
+    Success probability: 1.00 (``AlwaysSucceed``).
+
+    Automation potential: **High** — notification dispatch and logging
+    actions are fully automatable via APIs.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Active embargo evaluation nodes
+# ---------------------------------------------------------------------------
+
+
+class CurrentEmbargoAcceptable(AlmostAlwaysSucceed):
+    """Decide whether the current active embargo terms remain acceptable.
+
+    Semantic function:
+        Condition — is the participant satisfied with the current active
+        embargo, or do they wish to propose a revision?  Modeled as
+        usually acceptable; revision proposals are relatively uncommon.
+
+    Input category: Human decision.
+
+    Success probability: 0.90 (``AlmostAlwaysSucceed``).
+
+    Automation potential: **Medium** — automated comparison of current
+    terms against policy preferences is feasible; edge cases and dynamic
+    negotiation contexts may still require human judgment.
+    """


### PR DESCRIPTION
- Closes #861

## Summary

Ports all 15 embargo management fuzzer nodes from the legacy
`vultron/bt/embargo_management/fuzzer.py` module to the new
`vultron/demo/fuzzer/embargo.py` module using the probabilistic
py_trees base types introduced in FUZZ-01 (#860). Each node subclasses
the appropriate `WeightedBehavior` subclass, carries a full docstring
per BT-16-003/BT-16-005, and is re-exported from the package
`__init__.py`.

## Changes

- `vultron/demo/fuzzer/embargo.py`: new module with all 15 embargo fuzzer
  nodes as py_trees `WeightedBehavior` subclasses; each node has a docstring
  covering semantic function, input category, success probability, and
  automation potential
- `vultron/demo/fuzzer/__init__.py`: updated to re-export all 15 new embargo
  nodes alongside the existing base-type exports
- `test/fuzzer/test_embargo.py`: 179 new unit tests placed under
  `test/fuzzer/` (not `test/demo/fuzzer/`) so they run in the default suite
  rather than being auto-marked as integration tests; covers all 15 nodes,
  docstring completeness, `success_rate` attributes, status distribution,
  and the complement invariant between `AvoidEmbargoCounterProposal` and
  `WillingToCounterEmbargoProposal`

## Verification

- All 3950 unit tests pass (179 new)
- Full suite (unit + integration) clean: 3950 passed, 37 skipped, 5 xfailed
- Black, flake8, mypy, pyright all clean