### PR TITLE
feat: replace BUILD_LEARNINGS.md with plan/incoming/learnings/ queue

### DIFF
--- a/.agents/skills/archive-history/SKILL.md
+++ b/.agents/skills/archive-history/SKILL.md
@@ -108,18 +108,14 @@ BODY    = Full original concern body + "**Resolved**: YYYY-MM-DD — ..."
           + "Docs PR: <PR_URL>. Implementation tracked in #<IMPL_ISSUE>."
 ```
 
-### learn
+### learn (incoming learning file)
 
-```text
-TYPE    = learning
-TITLE   = <short observation title>
-SOURCE  = <label from the BUILD_LEARNINGS header, e.g. TRIGGER-ACTIVITY-PORT>
-BODY    = Full original BUILD_LEARNINGS entry text
-          + "**Promoted**: YYYY-MM-DD — captured in <destination files>."
-          + "Docs PR: <PR_URL>."
-```text
+```bash
+# After adding the promotion note to the file body, run:
+uv run append-history --from-file plan/incoming/learnings/<YYYYMMDD-SLUG>.md
+```
 
-Call once per archived entry in a loop.
+This moves the file to `plan/history/YYMM/learning/` and deletes the source.
 
 ### build
 

--- a/.agents/skills/bugfix/SKILL.md
+++ b/.agents/skills/bugfix/SKILL.md
@@ -138,7 +138,9 @@ focus hints from Phase 2 (e.g., `"wire layer"`, `"BT integration"`), then:
      BODY    = issue number, symptoms, root cause, fix summary, PR link
      ```
 
-   - Record observations in `plan/BUILD_LEARNINGS.md`.
+   - Record observations as individual learning files in `plan/incoming/learnings/`
+     (filename: `YYYYMMDD-SLUG.md`; frontmatter: `title`, `type: learning`,
+     `timestamp`, `source`).
    - Compute diff size: ≤50 → `size:S`; 51–300 → `size:M`; 301+ → `size:L`.
      Update the `size:` label.
    - Push and open PR using the structured body template from
@@ -165,7 +167,8 @@ focus hints from Phase 2 (e.g., `"wire layer"`, `"BT integration"`), then:
        --label "size:<X>"
      ```
 
-   - Invoke `commit` if `BUILD_LEARNINGS.md` was updated outside the PR branch.
+   - Invoke `commit` if any learning files were created in `plan/incoming/learnings/`
+     outside the PR branch.
 
 ## Constraints
 

--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -106,10 +106,10 @@ Invoke `deepen-context` with focus hints derived from the issue body
    bash .agents/skills/shared/add-to-project.sh "${NEW_ISSUE}"
    ```
 
-   Record the dependency in `plan/BUILD_LEARNINGS.md` and stop.
+   Record the dependency as a learning file in `plan/incoming/learnings/` and stop.
 
 4. If more than one prerequisite is required, or the work is non-trivial,
-   record details in `plan/BUILD_LEARNINGS.md` and stop.
+   create a learning file in `plan/incoming/learnings/` and stop.
 
 ### Phase 5 — Implement
 
@@ -142,8 +142,8 @@ Invoke `deepen-context` with focus hints derived from the issue body
      blockers, not body-text markers).
    - Add a handoff comment on that Bug issue with pickup context for the next
      agent.
-   - Record the Bug link and blocked/unblocked decision in
-     `plan/BUILD_LEARNINGS.md`.
+   - Record the Bug link and blocked/unblocked decision as a learning file in
+     `plan/incoming/learnings/`.
 6. If clean-base proof cannot be obtained in-session, do **not** classify the
    failure as unrelated; continue treating it as branch-owned.
 
@@ -198,11 +198,11 @@ Findings are tagged `[BLOCKING]` (fix before continuing) or `[ADVISORY]`
    BODY    = "## Issue #<N> — <title>\n\n<completion summary, PR link>"
    ```
 
-5. Record observations in `plan/BUILD_LEARNINGS.md`
-   (`### YYYY-MM-DD LABEL — description`). Do not write completion summaries
-   here.
+5. Record observations as individual learning files in `plan/incoming/learnings/`
+   (filename: `YYYYMMDD-SLUG.md`; frontmatter: `title`, `type: learning`,
+   `timestamp`, `source`). Do not write completion summaries here.
 
-6. Invoke `commit` if `BUILD_LEARNINGS.md` was updated.
+6. Invoke `commit` if any learning files were created in `plan/incoming/learnings/`.
 
 ### Phase 9 — Merge Conflict Recovery (if needed)
 

--- a/.agents/skills/dev-status/REFERENCE.md
+++ b/.agents/skills/dev-status/REFERENCE.md
@@ -171,14 +171,14 @@ comments. When all PRs are green and approved, the count is still shown but
 the row skill column should list `pr-comprehensive-fix` (it handles review
 preparation too).
 
-## Query: BUILD_LEARNINGS Entry Count
+## Query: Incoming Learnings File Count
 
 ```bash
-grep -c '^### ' plan/BUILD_LEARNINGS.md 2>/dev/null || echo 0
+find plan/incoming/learnings -name '*.md' 2>/dev/null | wc -l | tr -d ' '
 ```
 
-Returns the number of dated entry headers. Zero means the file contains only
-the preamble — no actionable entries.
+Returns the number of incoming learning files. Zero means the queue is
+empty (only `.gitkeep` present or directory missing).
 
 ## Report Template
 
@@ -187,7 +187,7 @@ the preamble — no actionable entries.
 
 | Queue                 | Count | Skill                |
 |-----------------------|-------|----------------------|
-| BUILD_LEARNINGS       |  {n}  | learn                |
+| Incoming Learnings    |  {n}  | learn                |
 | Ideas (open)          |  {n}  | plan-issue           |
 | Bugs (open)           |  {n}  | bugfix               |
 | Concerns (open)       |  {n}  | process-concerns     |
@@ -201,8 +201,8 @@ Now: {epic_titles}
 ```
 
 `{epic_titles}` lists the titles of all open `Schedule=Now` Epics on Project #24.
-When all counts are zero and BUILD_LEARNINGS is empty, replace the "Next up"
-line with:
+When all counts are zero and plan/incoming/learnings/ is empty, replace the
+"Next up" line with:
 
 ```text
 **All queues clear.** Nothing actionable at this time.

--- a/.agents/skills/dev-status/SKILL.md
+++ b/.agents/skills/dev-status/SKILL.md
@@ -33,7 +33,7 @@ Read these in parallel:
 
 | Source | What to check |
 |---|---|
-| `plan/BUILD_LEARNINGS.md` | Non-empty beyond the header? |
+| `plan/incoming/learnings/` | Count of `.md` files (excluding `.gitkeep`)? |
 | GitHub Issues — type: Idea | Count of open issues |
 | GitHub Issues — type: Bug | Count of open issues |
 | GitHub Issues — type: Concern | Count of open issues — **this is the only concern source; do not read `docs/reference/codebase/CONCERNS.md`** |
@@ -52,7 +52,7 @@ Print a single table followed by a "Next up" callout:
 
 | Queue                  | Count | Skill                |
 |------------------------|-------|----------------------|
-| BUILD_LEARNINGS        |   2   | learn                |
+| Incoming Learnings     |   2   | learn                |
 | Ideas (open)           |   1   | plan-issue           |
 | Bugs (open)            |   3   | bugfix               |
 | Concerns (open)        |   0   | —                    |
@@ -62,11 +62,11 @@ Print a single table followed by a "Next up" callout:
 
 Now: #691 Migrate project tracking | #476 Bug Fixes and Demo Polish
 
-**Next up**: learn — BUILD_LEARNINGS.md has unprocessed entries.
+**Next up**: learn — plan/incoming/learnings/ has unprocessed files.
 ```
 
-- **BUILD_LEARNINGS count**: number of `###` entry headers in the file
-  (zero if only the preamble is present)
+- **Incoming Learnings count**: number of `.md` files in `plan/incoming/learnings/`
+  (zero if the directory is empty or contains only `.gitkeep`)
 - **Ready to build**: open leaf issues in a Now-scheduled Epic that have no
   open blockers — determined entirely from the GitHub API
 - **Triage**: issues in Project #24 with `Schedule=Someday` and no Epic parent
@@ -77,7 +77,7 @@ Now: #691 Migrate project tracking | #476 Bug Fixes and Demo Polish
 Ranked priority (first matching condition wins for the primary recommendation;
 list all non-zero conditions as `ask_user` choices):
 
-1. `learn` — BUILD_LEARNINGS has entries
+1. `learn` — plan/incoming/learnings/ has files
 2. `process-concerns` — open Concern issues
 3. `plan-issue` — open Idea or Concern issues
 4. `bugfix` — open Bug issues

--- a/.agents/skills/learn/SKILL.md
+++ b/.agents/skills/learn/SKILL.md
@@ -3,7 +3,7 @@ name: learn
 description: >
   Promote lessons learned from the build process into durable specifications
   and design notes. First refreshes docs/reference/codebase/ via
-  acquire-codebase-knowledge, then reads BUILD_LEARNINGS.md and queries
+  acquire-codebase-knowledge, then reads plan/incoming/learnings/ and queries
   GitHub for open type:Concern issues (both as input queues), analyzes
   gaps, interviews the user with grill-me to align on scope, then writes
   to specs/, notes/, and AGENTS.md, opens a docs-only PR with the
@@ -17,14 +17,14 @@ description: >
 
 Integrate lessons learned from build execution into the project's durable
 specification and design documentation. The inputs are what the build process
-has discovered (`BUILD_LEARNINGS.md`) and open GitHub `type:Concern` issues
-tracked in the repository; the output is refined `specs/`, `notes/`, and
-`AGENTS.md`.
+has discovered (`plan/incoming/learnings/` — individual per-entry files) and
+open GitHub `type:Concern` issues tracked in the repository; the output is
+refined `specs/`, `notes/`, and `AGENTS.md`.
 
 **Constraint**: Modify **documentation files only**, including Markdown files
 and YAML spec files in `specs/`. Do not modify code or tests.
 
-**Trigger**: Use this skill when `plan/BUILD_LEARNINGS.md` has unprocessed
+**Trigger**: Use this skill when `plan/incoming/learnings/` has unprocessed
 entries that should be promoted into durable docs.
 
 > For new external ideas (GitHub Idea-type issues), use `plan-issue` instead.
@@ -34,8 +34,8 @@ entries that should be promoted into durable docs.
 1. **Ensure synced** (before any writes): `manage_worktree.sh ensure-synced`
 2. Invoke `acquire-codebase-knowledge` — full scan, refreshes all 7 docs
    in `docs/reference/codebase/`.
-3. Read `plan/BUILD_LEARNINGS.md` and query GitHub for open `type:Concern`
-   issues (both are input queues).
+3. Read all files in `plan/incoming/learnings/` and query GitHub for open
+   `type:Concern` issues (both are input queues).
 4. Invoke `orient-agent` then `deepen-context` for full context (specs,
    notes, code) — it now reads the freshly updated codebase docs.
 5. Analyze what the build process has learned vs. what specs and notes capture.
@@ -45,10 +45,11 @@ entries that should be promoted into durable docs.
 7. **Create the task branch**: `git switch -c learn/<YYYYMMDD>-<slug>`
    (worktree was already synced in step 1; branch here after slug is known)
 8. Write to `specs/`, `notes/`, and `AGENTS.md`.
-9. Archive each processed BUILD_LEARNINGS entry and each resolved Concern issue
-   via `uv run append-history learning`; delete BUILD_LEARNINGS entries from
-   their source file and close each resolved GitHub Concern issue with a
-   resolution comment.
+9. Archive each processed incoming learning file via
+   `uv run append-history --from-file <path>` (which moves the file to
+   `plan/history/YYMM/learning/` and deletes the source).
+   Archive each resolved Concern issue via `uv run append-history learning`
+   and close the issue with a resolution comment.
 10. Invoke `format-markdown`.
 11. Commit (including updated `docs/reference/codebase/` files), push, and
     open a docs-only PR with `specs-notes` label.
@@ -85,9 +86,9 @@ that the cost of a full scan is justified on every invocation.
 
 ### Phase 1 — Load Internal Sources and Context
 
-1. Read `plan/BUILD_LEARNINGS.md` — open questions, observations, and
-   constraints from recent build/bugfix runs (ephemeral queue; entries are
-   deleted after archiving).
+1. Read all files in `plan/incoming/learnings/` — open questions, observations,
+   and constraints from recent build/bugfix runs (ephemeral queue; files are
+   moved to `plan/history/YYMM/learning/` after archiving).
 2. Query GitHub for all open `type:Concern` issues — these are the tracked
    technical concerns, risks, and debt items surfaced by prior codebase scans
    and the `process-concerns` skill (second input queue; resolved issues are
@@ -106,20 +107,21 @@ that the cost of a full scan is justified on every invocation.
    Phase 0 has already refreshed the codebase docs, `orient-agent`/`deepen-context`
    will read up-to-date architecture and structure information.
 
-> `BUILD_LEARNINGS.md` is an ephemeral queue. Entries are deleted after
-> archiving. Any critical insight in an entry **must be promoted** to
-> `specs/` or `notes/` before being archived.
+> `plan/incoming/learnings/` is an ephemeral queue. Files are moved to
+> `plan/history/YYMM/learning/` after archiving. Any critical insight
+> in an entry **must be promoted** to `specs/` or `notes/` before being
+> archived.
 
 ### Phase 2 — Analyze Gaps
 
 Identify what the build process and codebase scan have surfaced that is not
-yet captured in durable docs. Consider both BUILD_LEARNINGS entries and
+yet captured in durable docs. Consider both incoming learning files and
 open GitHub Concern issues:
 
 1. Missing requirements — behavior exists in code but has no spec.
 2. Ambiguous or untestable requirements — reality diverges from what's written.
 3. Redundant or contradictory requirements across spec files.
-4. Agent guidance patterns that keep recurring in `BUILD_LEARNINGS.md`
+4. Agent guidance patterns that keep recurring in `plan/incoming/learnings/`
    but are not yet in `AGENTS.md`.
 5. Open GitHub `type:Concern` issues that reveal missing spec requirements or
    durable design notes.
@@ -132,7 +134,7 @@ open GitHub Concern issues:
 Invoke the `grill-me` skill. Resolve one question at a time (using `ask_user`)
 with a recommended answer before writing anything:
 
-- Which insights from `BUILD_LEARNINGS.md` are most important to promote?
+- Which insights from `plan/incoming/learnings/` are most important to promote?
 - Which open GitHub `type:Concern` issues are addressed by this session's
   insights, outdated, or should be promoted to specs/notes? (Resolved
   concerns go to `specs/` if they reveal missing requirements, `notes/`
@@ -184,32 +186,39 @@ generated spec IDs in the ADR's "More Information" section (MS-11-004).
 ### Phase 6 — Update Agent Guidance (`AGENTS.md`)
 
 Promote recurring implementation patterns and conventions from
-`BUILD_LEARNINGS.md` into `AGENTS.md`. Keep entries precise, actionable,
+`plan/incoming/learnings/` into `AGENTS.md`. Keep entries precise, actionable,
 and minimal.
 
 ### Phase 7 — Prepare Archive Content and Close Processed Entries
 
-For each BUILD_LEARNINGS entry and each resolved GitHub Concern issue that
+For each incoming learning file and each resolved GitHub Concern issue that
 has been fully promoted to `specs/`, `notes/`, or `AGENTS.md`:
 
-1. Draft the archive body for each item (store in memory — the actual
-   `archive-history` invocations happen in Phase 9 after the PR URL is known):
+1. **For incoming learning files**: run `uv run append-history --from-file
+   <path>` — this moves the file from `plan/incoming/learnings/` to
+   `plan/history/YYMM/learning/`, deletes the source, and regenerates the
+   monthly README. Add a promotion note to the end of the body **before**
+   calling `append-history --from-file` (edit the file in-place):
 
    ```text
+   **Promoted**: YYYY-MM-DD — captured in <destination file(s)>.
+   Docs PR: <PR_URL>.   ← filled in after PR is opened
+   ```
 
+1. **For resolved GitHub Concern issues**: draft the archive body
+   (store in memory — the actual `archive-history` invocations happen in
+   Phase 9 after the PR URL is known):
+
+   ```text
    TYPE    = learning
-   TITLE   = <short observation title>
-   SOURCE  = <label from the entry header, e.g. LABEL>
-   BODY    = <full original BUILD_LEARNINGS entry or Concern body>
-             + "**Promoted**: YYYY-MM-DD — captured in <destination file(s)>."
+   TITLE   = <short concern title>
+   SOURCE  = CONCERN-<ISSUE_NUMBER>
+   BODY    = Full original concern body
+             + "**Resolved**: YYYY-MM-DD — captured in <destination file(s)>."
              + "Docs PR: <PR_URL>."  ← filled in after PR is opened
+   ```
 
-   ```text
-
-2. **For BUILD_LEARNINGS entries**: delete the entry from
-   `plan/BUILD_LEARNINGS.md` entirely — no strike-through, no tombstone.
-
-3. **For resolved GitHub Concern issues**: close the issue and add a
+2. **For resolved GitHub Concern issues**: close the issue and add a
    resolution comment after the PR is open (step in Phase 9):
 
    ```bash
@@ -224,24 +233,24 @@ has been fully promoted to `specs/`, `notes/`, or `AGENTS.md`:
    gh issue close "${ISSUE_NUMBER}" --repo CERTCC/Vultron
    ```text
 
-Do **not** reference `plan/BUILD_LEARNINGS.md` from durable docs.
+Do **not** reference `plan/incoming/learnings/` from durable docs.
 
 ### Phase 8 — Lint, Commit, and Open PR
 
 1. Invoke the `format-markdown` skill on all new/modified markdown files.
    Fix all errors.
-2. If a requirement conflict cannot be resolved, add a note to
-   `plan/BUILD_LEARNINGS.md` and **stop before committing**.
+2. If a requirement conflict cannot be resolved, create a learning file in
+   `plan/incoming/learnings/` and **stop before committing**.
 3. Stage, commit, push, and open a docs-only PR (branch was created at the
    end of Phase 3):
 
    ```bash
    git add specs/<changed-files> notes/<changed-files> AGENTS.md \
-       plan/BUILD_LEARNINGS.md docs/reference/codebase/
-   git commit -m "docs: promote BUILD_LEARNINGS — <topic>
+       plan/incoming/learnings/ docs/reference/codebase/
+   git commit -m "docs: promote learnings — <topic>
 
    - <bullet: what was promoted and where>
-   - Archive <N> entr[y/ies] via archive-history (after PR)
+   - Archive <N> entr[y/ies] via append-history --from-file (after PR)
    - Close <N> resolved GitHub Concern issue(s) with resolution comments
    - Refresh docs/reference/codebase/ via acquire-codebase-knowledge
 
@@ -249,12 +258,12 @@ Do **not** reference `plan/BUILD_LEARNINGS.md` from durable docs.
    git push -u origin learn/<YYYYMMDD>-<slug>
 
    gh pr create --repo CERTCC/Vultron \
-     --title "docs: promote BUILD_LEARNINGS — <topic>" \
+     --title "docs: promote learnings — <topic>" \
      --body "- Closes #<issue if applicable>
 
    ## Summary
 
-   <what build learnings were promoted and to which docs/specs/notes>
+   <what learnings were promoted and to which docs/specs/notes>
 
    ## Changes
 
@@ -268,20 +277,29 @@ Do **not** reference `plan/BUILD_LEARNINGS.md` from durable docs.
 
 ### Phase 9 — Archive Entries and Close Issues
 
-Now that the PR URL is known, archive each item by invoking the
-`archive-history` skill once per entry. For each item, pass:
+Now that the PR URL is known:
+
+1. **For each incoming learning file**: edit it in-place to add the final
+   PR URL to the promotion note (appended in Phase 7), then run:
+
+   ```bash
+   uv run append-history --from-file plan/incoming/learnings/<YYYYMMDD-SLUG>.md
+   ```
+
+   This moves the file to `plan/history/YYMM/learning/` and deletes the
+   source. Stage `plan/history/` and commit.
+
+2. **For each resolved GitHub Concern issue**: invoke the `archive-history`
+   skill once per entry:
 
 ```text
 TYPE    = learning
-TITLE   = <short observation title>
-SOURCE  = <label from the BUILD_LEARNINGS header>
-BODY    = <full original entry text>
-          + "**Promoted**: YYYY-MM-DD — captured in <destination file(s)>."
+TITLE   = <short concern title>
+SOURCE  = CONCERN-<ISSUE_NUMBER>
+BODY    = <full original concern body>
+          + "**Resolved**: YYYY-MM-DD — captured in <destination file(s)>."
           + "Docs PR: <PR_URL>."
-```text
-
-The `archive-history` skill runs `uv run append-history`, lints the new
-files, stages `plan/history/`, commits, and pushes — once per entry.
+```
 
 For resolved GitHub Concern issues, post the resolution comment and close
 the issue (see Phase 7 step 3 for the comment template).
@@ -291,9 +309,10 @@ the issue (see Phase 7 step 3 for the comment template).
 - Do not modify code or tests.
 - Do not process GitHub Idea-type issues — use `plan-issue` for those.
 - Do not skip the grill-me phase — it must complete before any writing.
-- Do not reference `plan/BUILD_LEARNINGS.md` from durable docs.
-- Archive processed entries via the `archive-history` skill; do not
-  call `uv run append-history` directly or leave entries in the file
-  after promoting.
+- Do not reference `plan/incoming/learnings/` from durable docs.
+- Archive processed incoming learning files via
+  `uv run append-history --from-file <path>`; do not leave files in
+  `plan/incoming/learnings/` after promoting.
+- Archive Concern issues via the `archive-history` skill.
 - Verify assumptions against the codebase; do not assert absence without
   evidence.

--- a/.agents/skills/orient-agent/SKILL.md
+++ b/.agents/skills/orient-agent/SKILL.md
@@ -37,8 +37,8 @@ Read in parallel:
 
 ### Step 4 — Read build observations
 
-Read `plan/BUILD_LEARNINGS.md` for ephemeral build/bugfix observations
-queued for the `learn` skill.
+Read all files in `plan/incoming/learnings/` for ephemeral build/bugfix
+observations queued for the `learn` skill.
 
 > **`plan/history/` is excluded.** Read it only when investigating
 > completed work (e.g., during the `learn` skill).

--- a/.agents/skills/plan-issue/SKILL.md
+++ b/.agents/skills/plan-issue/SKILL.md
@@ -331,6 +331,6 @@ fi
 | Skill | Input | Docs output | Closes issue? |
 |---|---|---|---|
 | `plan-issue` | One Idea or Concern issue | Optional specs+notes for both types | Yes |
-| `learn` | BUILD_LEARNINGS + all Concern issues | specs/notes/AGENTS | Yes (batch) |
+| `learn` | plan/incoming/learnings/ + all Concern issues | specs/notes/AGENTS | Yes (batch) |
 | `new-item` | Freeform text | None | N/A (creates, not resolves) |
 | `process-concerns` | CONCERNS.md file | None | No |

--- a/.agents/skills/update-plan/SKILL.md
+++ b/.agents/skills/update-plan/SKILL.md
@@ -15,8 +15,8 @@ the actual codebase, then create GitHub Issues for any untracked gaps.
 **Constraint**: Do not write new tasks to the plan — all new work items MUST be
 GitHub Issues. Do not change
 code, tests, `specs/`, or `notes/` (except when writing gap-analysis
-observations). Do **not** write to `plan/BUILD_LEARNINGS.md` — that file is
-reserved for `build` and `bugfix`.
+observations). Do **not** write to `plan/incoming/learnings/` — that directory
+is reserved for `build` and `bugfix`.
 
 **Trigger**: Use after `learn` or `plan-issue` has updated specs or notes,
 to translate those changes into concrete GitHub Issues. Also run periodically
@@ -30,7 +30,7 @@ to keep open Issues aligned with the codebase.
 3. For each gap, create a GitHub Issue (added to Project #24 with
    Schedule=Someday) rather than a plan entry.
 4. Write any significant observations or open questions directly to the
-   appropriate `notes/*.md` file (not to `BUILD_LEARNINGS.md`).
+   appropriate `notes/*.md` file (not to `plan/incoming/learnings/`).
 5. Invoke `commit`.
 
 ## Workflow
@@ -159,8 +159,8 @@ grouping. Independent gaps MUST remain flat leaf Issues.
 - Any gap-analysis observations, open questions, clarified assumptions, or
   architectural risks discovered during gap analysis SHOULD be written
   directly to the appropriate `notes/*.md` file.
-- Do **not** write these observations to `plan/BUILD_LEARNINGS.md`.
-  That file is reserved for `build` and `bugfix` outputs.
+- Do **not** write these observations to `plan/incoming/learnings/`.
+  That directory is reserved for `build` and `bugfix` outputs.
 
 ### Phase 5 — Commit
 
@@ -171,7 +171,7 @@ specific message (e.g.,
 ## Constraints
 
 - Do not modify code or tests.
-- Do not write to `plan/BUILD_LEARNINGS.md`.
+- Do not write to `plan/incoming/learnings/`.
 - Do not speculate about missing functionality; verify with code search first.
 - Do not implement anything — that is `build`'s domain.
 - Use `uv run append-history implementation` only via `build` — never from

--- a/notes/agentic-workflow.md
+++ b/notes/agentic-workflow.md
@@ -54,11 +54,11 @@ specifications, design notes, and agent guidance.
 
 | | |
 |---|---|
-| **Trigger** | `plan/BUILD_LEARNINGS.md` has unprocessed insights |
-| **Input** | `plan/BUILD_LEARNINGS.md` |
+| **Trigger** | `plan/incoming/learnings/` has unprocessed files |
+| **Input** | `plan/incoming/learnings/` (individual per-entry files) |
 | **Process** | Load context → analyze gaps → grill-me interview → write |
 | **Output** | `specs/` (refined), `notes/` (promoted), `AGENTS.md` (updated) |
-| **Side effects** | Processed entries archived via `uv run append-history learning`, then deleted from `BUILD_LEARNINGS.md` |
+| **Side effects** | Processed files moved to `plan/history/YYMM/learning/` via `uv run append-history --from-file` |
 
 `learn` is the **second-priority** skill. Build execution produces insights
 that should be reflected in specs before the plan is updated. Running
@@ -100,10 +100,10 @@ already-completed work.
 | **Input** | Top-priority open GitHub Issue, `specs/`, `notes/` |
 | **Process** | Select task → claim branch → implement → validate → open PR |
 | **Output** | `vultron/` (code), `test/` (tests), GitHub PR |
-| **Side effects** | Summary archived via `uv run append-history implementation`; observations and open questions appended to `plan/BUILD_LEARNINGS.md` (triggering `learn` on the next loop) |
+| **Side effects** | Summary archived via `uv run append-history implementation`; observations recorded as individual files in `plan/incoming/learnings/` (triggering `learn` on the next loop) |
 
 `build` is the **lowest-priority** skill — it only runs when no higher-level
-skill is triggered. Its side effects (new `plan/BUILD_LEARNINGS.md` entries)
+skill is triggered. Its side effects (new files in `plan/incoming/learnings/`)
 naturally trigger `learn` on the next loop iteration.
 
 ---
@@ -122,9 +122,9 @@ flowchart TD
     CHK_IDEAS -->|Yes| INGEST["🌱 ingest-idea\nGitHub idea → specs/ + notes/"]
     INGEST --> START
 
-    CHK_IDEAS -->|No| CHK_NOTES{BUILD_LEARNINGS.md\nhas unprocessed\ninsights?}
+    CHK_IDEAS -->|No| CHK_NOTES{plan/incoming/learnings/\nhas unprocessed\nfiles?}
 
-    CHK_NOTES -->|Yes| LEARN["🧠 learn\nBUILD_LEARNINGS.md → specs/ + notes/ + AGENTS.md"]
+    CHK_NOTES -->|Yes| LEARN["🧠 learn\nplan/incoming/learnings/ → specs/ + notes/ + AGENTS.md"]
     LEARN --> START
 
     CHK_NOTES -->|No| CHK_SPECS{specs/ or notes/\nchanged since last\nplan update?}
@@ -153,15 +153,20 @@ flowchart TD
 | `AGENTS.md` | Agent conventions and patterns | Permanent |
 | GitHub Project #24 | Authoritative priority scheduling (Now/Next/Later/Someday) | Live — updated via API |
 | GitHub Task/Subtask Issues | Pending + in-progress tasks | Yes — closed when PR merges |
-| `plan/BUILD_LEARNINGS.md` | Ephemeral build/bugfix observations | Yes — processed and archived by `learn` |
+| `plan/incoming/learnings/` | Ephemeral build/bugfix observations (individual files) | Yes — files moved to history by `learn` |
 | `vultron/`, `test/` | Implementation | Permanent |
 
 ---
 
-## BUILD_LEARNINGS.md Content Policy
+## Incoming Learnings Queue Content Policy
 
-`plan/BUILD_LEARNINGS.md` is the **exclusive upstream channel** from
+`plan/incoming/learnings/` is the **exclusive upstream channel** from
 code-executing skills (`build`, `bugfix`) to the `learn` skill.
+
+Each observation is recorded as an individual file (`YYYYMMDD-SLUG.md`) with
+YAML frontmatter matching the history entry format. Using individual files
+instead of a shared flat file eliminates merge conflicts when multiple PRs
+each have an observation to record.
 
 ### What belongs here
 
@@ -179,23 +184,36 @@ code-executing skills (`build`, `bugfix`) to the `learn` skill.
 - Documentation of finished work → use `append-history` or `notes/`
 - `update-plan` gap-analysis observations → write directly to `notes/*.md`
 
+### File format
+
+```yaml
+---
+title: "Short observation title"
+type: learning
+timestamp: 'YYYY-MM-DDTHH:MM:SS+00:00'
+source: YYYYMMDD-SLUG
+---
+
+Observation body text.
+```
+
 ### Lifecycle
 
 ```text
 build/bugfix run
-  → observations appended to plan/BUILD_LEARNINGS.md
+  → creates plan/incoming/learnings/YYYYMMDD-SLUG.md (committed in the PR)
 
 learn run
-  → each entry promoted to specs/*.yaml, notes/*.md, or AGENTS.md
-  → each entry archived: uv run append-history learning
-  → each entry deleted from plan/BUILD_LEARNINGS.md
+  → each file promoted to specs/*.yaml, notes/*.md, or AGENTS.md
+  → promotion note appended to file body
+  → uv run append-history --from-file <path>  ← moves file to history, deletes source
 
 After learn completes:
-  plan/BUILD_LEARNINGS.md contains only unprocessed entries (ideally empty)
+  plan/incoming/learnings/ contains only .gitkeep (ideally empty)
   plan/history/YYMM/learning/*.md contains the archived originals
 ```
 
-See `specs/build-workflow.yaml` (BW-01 through BW-04) for the normative
+See `specs/build-workflow.yaml` (BW-01 through BW-06) for the normative
 requirements.
 
 ---
@@ -204,12 +222,12 @@ requirements.
 
 The pipeline has two natural feedback loops:
 
-1. **Build → Learn**: `build` and `bugfix` write observations to
-   `BUILD_LEARNINGS.md`. On the next loop, `learn` promotes those observations
-   to specs, notes, and `AGENTS.md`, archives each entry via
-   `uv run append-history learning`, then deletes the entry from
-   `BUILD_LEARNINGS.md`. This ensures what the codebase teaches us is
-   captured durably before the plan is next updated.
+1. **Build → Learn**: `build` and `bugfix` create individual learning files in
+   `plan/incoming/learnings/`. On the next loop, `learn` promotes each file's
+   observations to specs, notes, and `AGENTS.md`, archives each entry via
+   `uv run append-history --from-file`, and the file moves to history.
+   This ensures what the codebase teaches us is captured durably before the
+   plan is next updated.
 
 2. **Learn/Ingest → Update-plan**: After `learn` or `ingest-idea` refines
    specs and notes, `update-plan` picks up the changes and translates them

--- a/specs/README.md
+++ b/specs/README.md
@@ -338,11 +338,11 @@ Specifications are organized by topic with minimal overlap. Cross-references lin
 
 ### Project and Agent Guidance
 
-- **`build-workflow.yaml`** - Content policy for `plan/BUILD_LEARNINGS.md`:
-  what belongs in the file, what must not, how the `learn` skill archives
-  processed entries via `uv run append-history learning`, the `learning`
-  history entry type, and skill documentation update requirements
-  (BW-01 through BW-04)
+- **`build-workflow.yaml`** - Content policy for `plan/incoming/learnings/`:
+  individual per-entry files replacing the legacy shared `BUILD_LEARNINGS.md`,
+  file naming and format requirements, how the `learn` skill archives entries
+  via `uv run append-history --from-file`, the `--from-file` CLI flag
+  behaviour, and skill documentation update requirements (BW-01 through BW-06)
 - **`parallel-development.yaml`** - Multi-agent coordination via GitHub Issues:
   issue hierarchy (Epic/Task/Subtask), label taxonomy (`group:`, `size:`,
   `stale-claim`, `needs-rebase`, `specs-notes`), task claiming protocol (branch

--- a/specs/build-workflow.yaml
+++ b/specs/build-workflow.yaml
@@ -1,32 +1,37 @@
 id: BW
 title: Build Workflow Learnings Policy
 description: >-
-  Defines the content policy for `plan/BUILD_LEARNINGS.md` — the ephemeral
-  queue used by the `build` and `bugfix` skills to pass implementation
-  observations upstream to the `learn` skill. Covers what belongs in the
-  file, what must not go there, how `learn` processes and archives entries,
-  and the `learning` history entry type that enables this flow.
-  Supersedes the informal usage of `plan/IMPLEMENTATION_NOTES.md`.
-version: 1.0.0
+  Defines the content policy for `plan/incoming/learnings/` — the
+  per-entry incoming queue used by the `build` and `bugfix` skills to
+  pass implementation observations upstream to the `learn` skill. Each
+  observation is a separate file with YAML frontmatter matching the
+  history entry format. This eliminates merge conflicts that occurred
+  with the legacy `plan/BUILD_LEARNINGS.md` shared flat file and gives
+  each entry a clear lifecycle: created in the PR that surfaces the
+  learning, promoted by `learn`, then moved to `plan/history/YYMM/learning/`
+  via `uv run append-history --from-file`. Covers what belongs in the
+  queue, what must not go there, file naming and format, how `learn`
+  processes and archives entries, and the `learning` history entry type.
+version: 2.0.0
 kind: pattern
 scope:
   - prototype
   - production
 groups:
   - id: BW-01
-    title: BUILD_LEARNINGS.md Content Policy
+    title: Incoming Learnings Queue Content Policy
     kind: general
     specs:
       - id: BW-01-001
         priority: MUST
         statement: >-
-          `plan/BUILD_LEARNINGS.md` MUST contain only implementation
+          `plan/incoming/learnings/` MUST contain only implementation
           observations, open questions, constraints, and insights discovered
           during `build` or `bugfix` execution that are relevant to future
           implementation work. Completion summaries, "what was done"
-          narratives, and status updates MUST NOT appear in this file.
+          narratives, and status updates MUST NOT appear here.
         rationale: >-
-          The file is a focused upstream communication channel from executing
+          The queue is a focused upstream communication channel from executing
           skills to the `learn` skill. Mixing status updates with actionable
           insights dilutes the signal and creates noise for `learn` to filter.
         relationships:
@@ -34,119 +39,179 @@ groups:
             spec_id: HM-03-001
             note: >-
               Completion summaries belong in `append-history implementation`,
-              not in BUILD_LEARNINGS.md.
+              not in the incoming learnings queue.
       - id: BW-01-002
         priority: MUST_NOT
         statement: >-
           The `build` and `bugfix` skills MUST NOT write completion summaries
-          or task-status narratives to `plan/BUILD_LEARNINGS.md`.
+          or task-status narratives to `plan/incoming/learnings/`.
           Completion summaries MUST be archived exclusively via
           `uv run append-history implementation`.
         relationships:
           - rel_type: depends_on
             spec_id: HM-05-001
       - id: BW-01-003
-        priority: SHOULD
+        priority: MUST
         statement: >-
-          Each entry in `plan/BUILD_LEARNINGS.md` SHOULD include a dated
-          header (e.g., `### 2026-04-28 LABEL — Short description`) to make
-          individual entries identifiable for archiving and review.
+          Each incoming learning file MUST be named `YYYYMMDD-SLUG.md`
+          where `YYYYMMDD` is the creation date and `SLUG` is a short
+          uppercase identifier matching the `source` frontmatter field
+          (e.g., `20260622-AST-RATCHET-LAMBDA.md`). The file MUST be
+          committed as part of the originating PR so the learning is
+          permanently linked to the work that produced it.
+        rationale: >-
+          Using individual files instead of a shared flat file eliminates
+          merge conflicts when multiple PRs each have an observation to
+          record. The date prefix provides filesystem sort order.
       - id: BW-01-004
         priority: MUST_NOT
         statement: >-
-          Skills other than `build` and `bugfix` MUST NOT write to
-          `plan/BUILD_LEARNINGS.md`. The `update-plan` skill MUST write
+          Skills other than `build` and `bugfix` MUST NOT create files in
+          `plan/incoming/learnings/`. The `update-plan` skill MUST write
           observations and open questions directly to appropriate
-          `notes/*.md` files. It MUST NOT use `BUILD_LEARNINGS.md` as an
-          intermediate staging area.
+          `notes/*.md` files. It MUST NOT use the incoming learnings queue
+          as an intermediate staging area.
         rationale: >-
-          `BUILD_LEARNINGS.md` is specifically a channel for code-execution
-          insights flowing from build/bugfix to learn. Gap-analysis
-          observations from `update-plan` are a different signal and belong
-          in notes directly.
+          `plan/incoming/learnings/` is specifically a channel for
+          code-execution insights flowing from build/bugfix to learn.
+          Gap-analysis observations from `update-plan` are a different
+          signal and belong in notes directly.
   - id: BW-02
-    title: learn Skill Processing
-    kind: pattern
+    title: Incoming Learnings File Format
+    kind: domain
     specs:
       - id: BW-02-001
         priority: MUST
         statement: >-
-          When the `learn` skill processes `plan/BUILD_LEARNINGS.md`, each
-          entry MUST be promoted to the appropriate durable destination
-          (`specs/*.yaml`, `notes/*.md`, or `AGENTS.md`) before being
-          archived via `uv run append-history learning`.
+          Every file in `plan/incoming/learnings/` MUST use the same YAML
+          frontmatter format as history entry files: required fields
+          `title`, `type` (value `learning`), `timestamp` (tz-aware ISO
+          8601 UTC), and `source` (matching the filename stem without
+          `.md`).
+        rationale: >-
+          Using identical format means archiving is a `git mv` equivalent
+          via `uv run append-history --from-file` — no content
+          transformation needed.
         relationships:
           - rel_type: depends_on
-            spec_id: HM-02-002
+            spec_id: HM-02-001
       - id: BW-02-002
         priority: MUST
         statement: >-
-          After archiving an entry, the `learn` skill MUST delete that entry
-          from `plan/BUILD_LEARNINGS.md`. Entries MUST NOT be left in the
-          file after archiving — no strike-through, no tombstone.
-        rationale: >-
-          `BUILD_LEARNINGS.md` is a queue of unprocessed items. The same
-          lifecycle pattern applies here as for GitHub Idea-type issues
-          processed by `ingest-idea`: once processed, an entry is removed
-          from the queue and its content lives in the archive and in durable
-          docs.
-      - id: BW-02-003
-        priority: SHOULD
-        statement: >-
-          After a complete `learn` cycle, `plan/BUILD_LEARNINGS.md` SHOULD
-          contain only entries that have not yet been processed. The file
-          SHOULD be empty after every learning that fully drains the queue.
+          The `source` field MUST match the filename stem
+          (`YYYYMMDD-SLUG`). The `timestamp` field MUST reflect the
+          actual creation time of the observation (not today's date if
+          the entry was written for a historical run).
+        relationships:
+          - rel_type: depends_on
+            spec_id: HM-02-001
   - id: BW-03
-    title: learning History Entry Type
-    kind: implementation
+    title: learn Skill Processing
+    kind: pattern
     specs:
       - id: BW-03-001
         priority: MUST
         statement: >-
-          A `learning` entry type MUST be added to `HistoryEntryType` in
-          `vultron/metadata/history/types.py`. The `learn` skill MUST use
-          `uv run append-history learning` to archive each processed entry
-          from `plan/BUILD_LEARNINGS.md`.
+          When the `learn` skill processes `plan/incoming/learnings/`, each
+          file MUST be promoted to the appropriate durable destination
+          (`specs/*.yaml`, `notes/*.md`, or `AGENTS.md`) before being
+          archived via `uv run append-history --from-file <path>`.
         relationships:
-          - rel_type: refines
+          - rel_type: depends_on
             spec_id: HM-02-002
       - id: BW-03-002
         priority: MUST
         statement: >-
-          History entries of type `learning` MUST follow the same frontmatter
-          and body format as all other `append-history` entry types,
-          including required fields `title`, `type`, `date`, and `source`.
+          `uv run append-history --from-file <path>` MUST be used to
+          archive each processed incoming learning file. This command
+          moves the file from `plan/incoming/learnings/` to
+          `plan/history/YYMM/learning/` and deletes the source. Files
+          MUST NOT be moved manually or remain in `plan/incoming/learnings/`
+          after archiving.
+        rationale: >-
+          Using the CLI tool preserves the audit trail, regenerates the
+          monthly history README, and enforces write-once semantics.
         relationships:
           - rel_type: depends_on
-            spec_id: HM-02-001
+            spec_id: HM-01-002
+      - id: BW-03-003
+        priority: SHOULD
+        statement: >-
+          After a complete `learn` cycle, `plan/incoming/learnings/` SHOULD
+          contain only a `.gitkeep` file. The queue SHOULD be empty after
+          every learning session that fully drains it.
   - id: BW-04
-    title: Skill Documentation Updates
-    kind: general
+    title: learning History Entry Type
+    kind: implementation
     specs:
       - id: BW-04-001
         priority: MUST
         statement: >-
-          The `build` skill documentation MUST distinguish between learnings
-          (observations, open questions, constraints to `plan/BUILD_LEARNINGS.md`)
-          and completion summaries (what was done via `uv run append-history
-          implementation`). Both outputs are required; neither may be omitted
-          or combined into a single destination.
+          The `learning` entry type MUST exist in `HistoryEntryType` in
+          `vultron/metadata/history/types.py`.  The `learn` skill MUST
+          use `uv run append-history --from-file` to archive each
+          processed incoming learning file.
+        relationships:
+          - rel_type: refines
+            spec_id: HM-02-002
       - id: BW-04-002
         priority: MUST
         statement: >-
+          History entries of type `learning` MUST follow the same
+          frontmatter and body format as all other `append-history` entry
+          types, including required fields `title`, `type`, `timestamp`,
+          and `source`.
+        relationships:
+          - rel_type: depends_on
+            spec_id: HM-02-001
+  - id: BW-05
+    title: append-history --from-file Behaviour
+    kind: implementation
+    specs:
+      - id: BW-05-001
+        priority: MUST
+        statement: >-
+          `uv run append-history --from-file <path>` MUST read the
+          complete file content (frontmatter + body), parse the
+          frontmatter to derive `type`, `title`, `source`, and
+          `timestamp`, then call the normal write path to create the
+          history entry at `plan/history/YYMM/<type>/<source>.md`.
+          It MUST delete the source file after a successful write.
+      - id: BW-05-002
+        priority: MUST
+        statement: >-
+          `uv run append-history --from-file` MUST be mutually exclusive
+          with the positional `type` argument, `--title`, `--source`,
+          `--file`, and `--timestamp` flags. Any combination MUST exit
+          non-zero with an error message listing the conflicting flags.
+      - id: BW-05-003
+        priority: MUST
+        statement: >-
+          `uv run append-history --from-file` MUST reject files whose
+          frontmatter `timestamp` is more than 60 seconds in the future
+          (HM-06-004). It MUST reject files with missing or invalid
+          frontmatter fields (HM-02-001).
+  - id: BW-06
+    title: Skill Documentation Updates
+    kind: general
+    specs:
+      - id: BW-06-001
+        priority: MUST
+        statement: >-
+          The `build` skill documentation MUST distinguish between
+          learnings (observations and constraints recorded as individual
+          files in `plan/incoming/learnings/`) and completion summaries
+          (archived via `uv run append-history implementation`). Both
+          outputs are required; neither may be omitted or combined.
+      - id: BW-06-002
+        priority: MUST
+        statement: >-
           The `learn` skill documentation MUST reference
-          `plan/BUILD_LEARNINGS.md` (not `IMPLEMENTATION_NOTES.md`) as its
-          primary input source, and MUST describe the delete-after-archive
-          lifecycle (not strike-through).
-      - id: BW-04-003
+          `plan/incoming/learnings/` as its primary input source and MUST
+          describe the `append-history --from-file` archiving lifecycle.
+      - id: BW-06-003
         priority: MUST_NOT
         statement: >-
           The `update-plan` skill MUST NOT instruct agents to write to
-          `plan/BUILD_LEARNINGS.md`. Any tidying step in `update-plan` that
-          previously wrote to `IMPLEMENTATION_NOTES.md` MUST instead direct
-          content to appropriate `notes/*.md` files.
-      - id: BW-04-004
-        priority: MUST
-        statement: >-
-          The `study-project-docs` skill MUST list `plan/BUILD_LEARNINGS.md`
-          (not `IMPLEMENTATION_NOTES.md`) in its Step 2 plan-context reads.
+          `plan/incoming/learnings/`. Observations discovered during gap
+          analysis MUST be written directly to `notes/*.md` files.

--- a/specs/traceability.yaml
+++ b/specs/traceability.yaml
@@ -39,5 +39,6 @@ groups:
   - id: TRACE-02-002
     priority: SHOULD
     statement: >-
-      Stories with insufficient spec coverage SHOULD be documented in `plan/BUILD_LEARNINGS.md`
-      with specific technical details describing the gap and concrete steps toward remediation
+      Stories with insufficient spec coverage SHOULD be documented as incoming
+      learning files in `plan/incoming/learnings/` with specific technical
+      details describing the gap and concrete steps toward remediation

--- a/test/metadata/test_append_history.py
+++ b/test/metadata/test_append_history.py
@@ -479,6 +479,169 @@ class TestReadmeGenValidation:
         assert not new_file.exists(), "new entry file should be rolled back"
 
 
+_LEARNING_SOURCE = "20260622-AST-RATCHET-LAMBDA"
+_LEARNING_TITLE = "AST ratchet lambda guard"
+_LEARNING_CONTENT = (
+    "---\n"
+    f"title: '{_LEARNING_TITLE}'\n"
+    "type: learning\n"
+    "timestamp: '2026-06-22T10:00:00+00:00'\n"
+    f"source: {_LEARNING_SOURCE}\n"
+    "---\n"
+    "\n"
+    "Guard ast.Lambda in the scope walker.\n"
+)
+
+
+def _make_incoming_file(
+    tmp_path: Path,
+    content: str = _LEARNING_CONTENT,
+    filename: str = f"{_LEARNING_SOURCE}.md",
+) -> Path:
+    """Write *content* to *tmp_path*/<filename> and return the path."""
+    f = tmp_path / filename
+    f.write_text(content)
+    return f
+
+
+def _run_from_file(
+    source_path: Path,
+    extra_args: list[str] | None = None,
+) -> _RunResult:
+    """Run ``append-history --from-file <source_path>``."""
+    cmd = ["append-history", "--from-file", str(source_path)]
+    if extra_args:
+        cmd.extend(extra_args)
+    return _run_with_cmd(cmd, body="")
+
+
+class TestFromFileMode:
+    """append-history --from-file: move a pre-formatted incoming learning file."""
+
+    def test_archives_file_to_history(
+        self, fake_repo: Path, tmp_path: Path
+    ) -> None:
+        """Valid file is moved to plan/history/YYMM/learning/ (BW-01-004)."""
+        src = _make_incoming_file(tmp_path)
+        result = _run_from_file(src)
+        assert result.returncode == 0
+        dest = Path(result.stdout.strip())
+        assert dest.exists()
+        assert dest.parent.name == "learning"
+        assert dest.stem == _LEARNING_SOURCE
+
+    def test_source_file_deleted_after_archive(
+        self, fake_repo: Path, tmp_path: Path
+    ) -> None:
+        """Source file is removed from plan/incoming/ on success (BW-01-004)."""
+        src = _make_incoming_file(tmp_path)
+        result = _run_from_file(src)
+        assert result.returncode == 0
+        assert not src.exists()
+
+    def test_body_content_preserved(
+        self, fake_repo: Path, tmp_path: Path
+    ) -> None:
+        src = _make_incoming_file(tmp_path)
+        result = _run_from_file(src)
+        assert result.returncode == 0
+        assert "Guard ast.Lambda" in Path(result.stdout.strip()).read_text()
+
+    def test_timestamp_determines_yymm_directory(
+        self, fake_repo: Path, tmp_path: Path
+    ) -> None:
+        """Frontmatter timestamp controls which YYMM directory is used."""
+        src = _make_incoming_file(tmp_path)
+        result = _run_from_file(src)
+        assert result.returncode == 0
+        dest = Path(result.stdout.strip())
+        assert dest.parent.parent.name == "2606"
+
+    def test_missing_source_file_exits_nonzero(self, fake_repo: Path) -> None:
+        result = _run_from_file(Path("/nonexistent/20260622-SLUG.md"))
+        assert result.returncode != 0
+        assert "not found" in result.stderr.lower()
+
+    def test_file_without_frontmatter_exits_nonzero(
+        self, fake_repo: Path, tmp_path: Path
+    ) -> None:
+        src = _make_incoming_file(tmp_path, content="No frontmatter here.\n")
+        result = _run_from_file(src)
+        assert result.returncode != 0
+
+    def test_file_with_missing_required_fields_exits_nonzero(
+        self, fake_repo: Path, tmp_path: Path
+    ) -> None:
+        content = "---\ntitle: Only title\n---\nBody.\n"
+        src = _make_incoming_file(tmp_path, content=content)
+        result = _run_from_file(src)
+        assert result.returncode != 0
+
+    def test_future_timestamp_rejected(
+        self, fake_repo: Path, tmp_path: Path
+    ) -> None:
+        future = (
+            datetime.datetime.now(_UTC) + datetime.timedelta(hours=1)
+        ).isoformat()
+        content = (
+            "---\n"
+            "title: Future entry\n"
+            "type: learning\n"
+            f"timestamp: '{future}'\n"
+            "source: 20260622-FUTURE\n"
+            "---\n"
+            "Body.\n"
+        )
+        src = _make_incoming_file(
+            tmp_path, content=content, filename="20260622-FUTURE.md"
+        )
+        result = _run_from_file(src)
+        assert result.returncode != 0
+        assert "future" in result.stderr.lower()
+
+    def test_duplicate_destination_exits_nonzero(
+        self, fake_repo: Path, tmp_path: Path
+    ) -> None:
+        src1 = _make_incoming_file(tmp_path, filename=f"{_LEARNING_SOURCE}.md")
+        _run_from_file(src1)
+        # Recreate the source so the second run has something to read.
+        src2 = _make_incoming_file(
+            tmp_path, filename=f"{_LEARNING_SOURCE}-copy.md"
+        )
+        content_dup = _LEARNING_CONTENT.replace(
+            _LEARNING_SOURCE, _LEARNING_SOURCE
+        )
+        src2.write_text(content_dup)
+        result = _run_from_file(src2)
+        assert result.returncode != 0
+        assert "already exists" in result.stderr.lower()
+
+    def test_incompatible_with_title_flag(
+        self, fake_repo: Path, tmp_path: Path
+    ) -> None:
+        src = _make_incoming_file(tmp_path)
+        result = _run_from_file(src, extra_args=["--title", "override"])
+        assert result.returncode != 0
+        assert "--title" in result.stderr
+
+    def test_incompatible_with_source_flag(
+        self, fake_repo: Path, tmp_path: Path
+    ) -> None:
+        src = _make_incoming_file(tmp_path)
+        result = _run_from_file(src, extra_args=["--source", "OTHER"])
+        assert result.returncode != 0
+        assert "--source" in result.stderr
+
+    def test_incompatible_with_positional_type(
+        self, fake_repo: Path, tmp_path: Path
+    ) -> None:
+        src = _make_incoming_file(tmp_path)
+        cmd = ["append-history", "learning", "--from-file", str(src)]
+        result = _run_with_cmd(cmd, body="")
+        assert result.returncode != 0
+        assert "positional type argument" in result.stderr
+
+
 def _run_with_cmd(
     cmd: list[str],
     body: str = _IDEA_BODY,

--- a/vultron/metadata/history/cli.py
+++ b/vultron/metadata/history/cli.py
@@ -4,11 +4,12 @@ Usage::
 
     uv run append-history <type> --title "..." --source "..."
     uv run append-history <type> --title "..." --source "..." --file /path/to/body.md
+    uv run append-history --from-file plan/incoming/learnings/20260622-SLUG.md
 
 ``<type>`` must be one of the ``HistoryEntryType`` values
 (``idea``, ``implementation``, ``learning``, ``priority``).
 
-The tool:
+Normal mode (``<type>`` required):
 
 1. Parses ``<type>`` against ``HistoryEntryType``; exits 1 on unknown type.
 2. Reads body text from stdin or ``--file <path>``.
@@ -22,7 +23,21 @@ The tool:
 7. Regenerates ``plan/history/YYMM/README.md``.
 8. Prints the written file path to stdout.
 
+``--from-file`` mode (for ``plan/incoming/learnings/`` processing):
+
+1. Reads the source file as complete content (frontmatter + body).
+2. Parses and validates the frontmatter to obtain type, title, source,
+   and timestamp (HM-02-001).
+3. Moves the entry to ``plan/history/YYMM/<type>/`` using the frontmatter
+   timestamp to determine the ``YYMM`` directory.
+4. Deletes the source file from ``plan/incoming/``.
+5. Prints the written file path to stdout.
+
+``--from-file`` is mutually exclusive with ``<type>``, ``--title``,
+``--source``, ``--file``, and ``--timestamp``.
+
 See ``specs/history-management.yaml`` HM-03, HM-06, HM-07.
+See ``specs/build-workflow.yaml`` BW-01 for the incoming-learnings queue.
 """
 
 from __future__ import annotations
@@ -173,31 +188,54 @@ def _build_parser() -> argparse.ArgumentParser:
         prog="append-history",
         description=(
             "Append a write-once entry to the project history archive under "
-            "plan/history/. Body text is read from stdin by default."
+            "plan/history/. Body text is read from stdin by default. "
+            "Use --from-file to move a pre-formatted incoming learning file."
         ),
     )
     parser.add_argument(
         "entry_type",
         metavar="type",
-        help=f"History entry type. One of: {valid_types}",
+        nargs="?",
+        default=None,
+        help=(
+            f"History entry type. One of: {valid_types}. "
+            "Required unless --from-file is provided."
+        ),
     )
     parser.add_argument(
         "--title",
-        required=True,
+        default=None,
         metavar="TEXT",
-        help="Human-readable summary for the entry frontmatter.",
+        help=(
+            "Human-readable summary for the entry frontmatter. "
+            "Required unless --from-file is provided."
+        ),
     )
     parser.add_argument(
         "--source",
-        required=True,
+        default=None,
         metavar="ID",
-        help="Originating identifier (e.g. IDEA-26043001, TASK-FOO).",
+        help=(
+            "Originating identifier (e.g. IDEA-26043001, TASK-FOO). "
+            "Required unless --from-file is provided."
+        ),
     )
     parser.add_argument(
         "--file",
         metavar="PATH",
         default=None,
-        help="Read body text from FILE instead of stdin.",
+        help="Read body text from FILE instead of stdin. Incompatible with --from-file.",
+    )
+    parser.add_argument(
+        "--from-file",
+        metavar="PATH",
+        default=None,
+        dest="from_file",
+        help=(
+            "Move a pre-formatted incoming learning file (with YAML frontmatter) "
+            "to plan/history/YYMM/<type>/ and delete the source. "
+            "Incompatible with type, --title, --source, --file, --timestamp."
+        ),
     )
     parser.add_argument(
         "--timestamp",
@@ -320,10 +358,89 @@ def _parse_timestamp(value: str | None) -> datetime.datetime | None:
         _fail(str(exc))
 
 
+def _check_from_file_conflicts(args: argparse.Namespace) -> None:
+    """Fail if --from-file is combined with incompatible normal-mode flags."""
+    conflicts = []
+    if args.entry_type is not None:
+        conflicts.append("positional type argument")
+    if args.title is not None:
+        conflicts.append("--title")
+    if args.source is not None:
+        conflicts.append("--source")
+    if args.file is not None:
+        conflicts.append("--file")
+    if args.timestamp is not None:
+        conflicts.append("--timestamp")
+    if conflicts:
+        _fail(
+            f"--from-file is incompatible with: {', '.join(conflicts)}. "
+            "Provide only --from-file when moving a pre-formatted incoming file."
+        )
+
+
+def _handle_from_file_mode(source_path: Path) -> None:
+    """Archive a pre-formatted incoming learning file into plan/history/.
+
+    Reads the file's YAML frontmatter to determine the entry type, source
+    identifier, and timestamp, then delegates to :func:`append_history_entry`.
+    The source file is deleted after a successful write.
+
+    Args:
+        source_path: Path to the incoming learning file with YAML frontmatter.
+
+    Raises:
+        SystemExit: On any validation or write error (via :func:`_fail`).
+    """
+    if not source_path.exists():
+        _fail(f"file not found: {source_path}")
+
+    content = source_path.read_text(encoding="utf-8")
+
+    try:
+        fm = _validate_frontmatter(content)
+    except ValueError as exc:
+        _fail(str(exc))
+
+    try:
+        _check_timestamp_not_future(fm.timestamp)
+    except ValueError as exc:
+        _fail(str(exc))
+    target_date = fm.timestamp.date()
+
+    try:
+        entry_file = append_history_entry(
+            fm.type,
+            content,
+            target_date=target_date,
+        )
+    except (FileExistsError, FileNotFoundError, ValueError) as exc:
+        _fail(str(exc))
+
+    source_path.unlink()
+    print(str(entry_file))
+
+
 def main() -> None:
     """Entry point for ``uv run append-history``."""
     parser = _build_parser()
     args = parser.parse_args()
+
+    if args.from_file is not None:
+        _check_from_file_conflicts(args)
+        _handle_from_file_mode(Path(args.from_file))
+        return
+
+    # Normal mode — require entry_type, --title, --source.
+    if not args.entry_type:
+        _fail(
+            "entry type is required when --from-file is not provided. "
+            f"Valid values: {', '.join(t.value for t in HistoryEntryType)}"
+        )
+    if not args.title:
+        _fail("--title is required when --from-file is not provided")
+    if not args.source:
+        _fail("--source is required when --from-file is not provided")
+
     entry_type = _parse_entry_type(args.entry_type)
     body = _read_body(args.file)
     timestamp = _parse_timestamp(args.timestamp)


### PR DESCRIPTION
- Closes #1107 (once BUILD_LEARNINGS.md is drained — see issue for final cleanup step)

## Summary

Replaces the shared flat-file `plan/BUILD_LEARNINGS.md` with individual
per-entry files under `plan/incoming/learnings/`. The root cause was
that multiple PRs appending to the same file caused ~1.5 merge conflicts
per day at current merge velocity.

Key design decisions:
- Each learning file uses the **same frontmatter format** as
  `plan/history/YYMM/learning/` entries, so archiving is
  `uv run append-history --from-file <path>` (no content transformation)
- Files are committed **in the originating PR** — no shared file, no conflicts
- `plan/BUILD_LEARNINGS.md` is NOT deleted in this PR; issue #1107 tracks
  that once the concurrent `learn` run drains it

## Changes

### CLI (`append-history`)
- `vultron/metadata/history/cli.py`: new `--from-file <path>` flag reads
  a pre-formatted file with YAML frontmatter, moves it to
  `plan/history/YYMM/learning/`, and deletes the source. Mutually exclusive
  with positional type, `--title`, `--source`, `--file`, `--timestamp`.
- `test/metadata/test_append_history.py`: add `TestFromFileMode` (13 tests)

### Directory
- `plan/incoming/learnings/.gitkeep`: establish the new queue directory

### Specs
- `specs/build-workflow.yaml`: full rewrite v2.0.0 — new content policy,
  file format (BW-02), `--from-file` behaviour (BW-05), skill docs (BW-06)
- `specs/traceability.yaml`, `specs/README.md`: update references

### Notes
- `notes/agentic-workflow.md`: update all references, rewrite content
  policy section, update lifecycle diagram

### Skills (9 files updated)
- `build`, `bugfix`: create file instead of appending
- `learn`: read directory; archive via `--from-file`; updated Phases 7–9
- `orient-agent`: read from directory
- `dev-status` (SKILL.md + REFERENCE.md): count files in directory
- `archive-history`: update learn example
- `plan-issue`, `update-plan`: update references

## Verification

- 54 unit tests pass (13 new `TestFromFileMode` tests)
- Black, flake8, mypy, pyright clean
- All pre-commit hooks pass (markdownlint, spec-registry, notes-frontmatter)