### PR TITLE
feat(demo): port report validate, prioritize, and messaging inbound fuzzer nodes

### DIFF
--- a/plan/history/2606/implementation/ISSUE-862.md
+++ b/plan/history/2606/implementation/ISSUE-862.md
@@ -1,0 +1,30 @@
+---
+source: ISSUE-862
+timestamp: '2026-06-22T19:30:34.475906+00:00'
+title: 'FUZZ-03: Port report validate, prioritize, and messaging inbound fuzzer nodes'
+type: implementation
+---
+
+## Issue #862 — FUZZ-03: Port report validate, prioritize, and messaging inbound fuzzer nodes
+
+Ported 11 fuzzer stub nodes from the legacy `vultron/bt` layer to
+`vultron/demo/fuzzer/` using py_trees class-based patterns consistent with
+FUZZ-01/02 (embargo nodes).
+
+### Modules created
+
+- `vultron/demo/fuzzer/report_management/validate.py`: 5 report validation
+  nodes (`NoNewValidationInfo`, `EvaluateReportCredibility`,
+  `EvaluateReportValidity`, `EnoughValidationInfo`, `GatherValidationInfo`)
+- `vultron/demo/fuzzer/report_management/prioritize.py`: 5 prioritization
+  nodes (`NoNewPrioritizationInfo`, `EnoughPrioritizationInfo`,
+  `GatherPrioritizationInfo`, `OnAccept`, `OnDefer`)
+- `vultron/demo/fuzzer/report_management/__init__.py`: re-exports all 10 nodes
+- `vultron/demo/fuzzer/messaging.py`: `FollowUpOnErrorMessage`
+  (`UniformSucceedFail`, p=0.50)
+- Updated `vultron/demo/fuzzer/__init__.py` to re-export all 11 new nodes
+- `test/demo/fuzzer/`: new test package (26 tests across 3 modules)
+
+All 4027 unit + integration tests passed. All 4 linters clean.
+
+PR: [#1111](https://github.com/CERTCC/Vultron/pull/1111)

--- a/test/demo/fuzzer/test_messaging.py
+++ b/test/demo/fuzzer/test_messaging.py
@@ -1,0 +1,49 @@
+"""Tests for vultron.demo.fuzzer.messaging."""
+
+import pytest
+import py_trees
+
+from vultron.demo.fuzzer.base import UniformSucceedFail
+from vultron.demo.fuzzer.messaging import FollowUpOnErrorMessage
+
+
+class TestFollowUpOnErrorMessage:
+    """Tests for FollowUpOnErrorMessage."""
+
+    def test_is_behaviour(self):
+        """Must be a py_trees Behaviour."""
+        node = FollowUpOnErrorMessage()
+        assert isinstance(node, py_trees.behaviour.Behaviour)
+
+    def test_has_docstring(self):
+        """Must have a non-empty docstring (BT-16-003)."""
+        assert FollowUpOnErrorMessage.__doc__
+        assert FollowUpOnErrorMessage.__doc__.strip()
+
+    def test_name_defaults_to_class_name(self):
+        """Default name must be the class name."""
+        node = FollowUpOnErrorMessage()
+        assert node.name == "FollowUpOnErrorMessage"
+
+    def test_name_custom(self):
+        """Custom name must be respected."""
+        node = FollowUpOnErrorMessage(name="custom")
+        assert node.name == "custom"
+
+    def test_update_returns_status(self):
+        """update() must return a valid py_trees Status."""
+        node = FollowUpOnErrorMessage()
+        node.setup()
+        status = node.update()
+        assert status in (
+            py_trees.common.Status.SUCCESS,
+            py_trees.common.Status.FAILURE,
+        )
+
+    def test_base_type(self):
+        """Must subclass UniformSucceedFail (p=0.50)."""
+        assert issubclass(FollowUpOnErrorMessage, UniformSucceedFail)
+
+    def test_success_rate(self):
+        """Success rate must be 0.50."""
+        assert FollowUpOnErrorMessage.success_rate == pytest.approx(0.5)

--- a/test/demo/fuzzer/test_prioritize.py
+++ b/test/demo/fuzzer/test_prioritize.py
@@ -1,0 +1,110 @@
+"""Tests for vultron.demo.fuzzer.report_management.prioritize."""
+
+import pytest
+import py_trees
+
+from vultron.demo.fuzzer.base import (
+    AlmostAlwaysSucceed,
+    AlwaysSucceed,
+    ProbablySucceed,
+    UsuallySucceed,
+)
+from vultron.demo.fuzzer.report_management.prioritize import (
+    EnoughPrioritizationInfo,
+    GatherPrioritizationInfo,
+    NoNewPrioritizationInfo,
+    OnAccept,
+    OnDefer,
+)
+
+_ALL_NODES = [
+    NoNewPrioritizationInfo,
+    EnoughPrioritizationInfo,
+    GatherPrioritizationInfo,
+    OnAccept,
+    OnDefer,
+]
+
+
+@pytest.mark.parametrize("node_cls", _ALL_NODES)
+def test_node_is_behaviour(node_cls):
+    """Each node must be a py_trees Behaviour."""
+    node = node_cls()
+    assert isinstance(node, py_trees.behaviour.Behaviour)
+
+
+@pytest.mark.parametrize("node_cls", _ALL_NODES)
+def test_node_has_docstring(node_cls):
+    """Each node must have a non-empty docstring (BT-16-003)."""
+    assert node_cls.__doc__ and node_cls.__doc__.strip()
+
+
+@pytest.mark.parametrize("node_cls", _ALL_NODES)
+def test_node_name_defaults_to_class_name(node_cls):
+    """Default name must be the class name."""
+    node = node_cls()
+    assert node.name == node_cls.__name__
+
+
+@pytest.mark.parametrize("node_cls", _ALL_NODES)
+def test_node_name_custom(node_cls):
+    """Custom name must be respected."""
+    node = node_cls(name="custom")
+    assert node.name == "custom"
+
+
+@pytest.mark.parametrize("node_cls", _ALL_NODES)
+def test_update_returns_status(node_cls):
+    """update() must return a valid py_trees Status."""
+    node = node_cls()
+    node.setup()
+    status = node.update()
+    assert status in (
+        py_trees.common.Status.SUCCESS,
+        py_trees.common.Status.FAILURE,
+        py_trees.common.Status.RUNNING,
+    )
+
+
+def test_no_new_prioritization_info_base_type():
+    assert issubclass(NoNewPrioritizationInfo, ProbablySucceed)
+
+
+def test_enough_prioritization_info_base_type():
+    assert issubclass(EnoughPrioritizationInfo, UsuallySucceed)
+
+
+def test_gather_prioritization_info_base_type():
+    assert issubclass(GatherPrioritizationInfo, AlmostAlwaysSucceed)
+
+
+def test_on_accept_base_type():
+    assert issubclass(OnAccept, AlwaysSucceed)
+
+
+def test_on_defer_base_type():
+    assert issubclass(OnDefer, AlwaysSucceed)
+
+
+def test_no_new_prioritization_info_success_rate():
+    assert NoNewPrioritizationInfo.success_rate == pytest.approx(2 / 3)
+
+
+def test_enough_prioritization_info_success_rate():
+    assert EnoughPrioritizationInfo.success_rate == pytest.approx(0.75)
+
+
+def test_gather_prioritization_info_success_rate():
+    assert GatherPrioritizationInfo.success_rate == pytest.approx(0.9)
+
+
+def test_on_accept_always_succeeds():
+    node = OnAccept()
+    node.setup()
+    assert node.update() == py_trees.common.Status.SUCCESS
+
+
+def test_on_defer_always_succeeds():
+    node = OnDefer()
+    node.setup()
+    assert node.update() == py_trees.common.Status.SUCCESS

--- a/test/demo/fuzzer/test_validate.py
+++ b/test/demo/fuzzer/test_validate.py
@@ -1,0 +1,105 @@
+"""Tests for vultron.demo.fuzzer.report_management.validate."""
+
+import pytest
+import py_trees
+
+from vultron.demo.fuzzer.base import (
+    AlmostAlwaysSucceed,
+    ProbablySucceed,
+    UsuallySucceed,
+)
+from vultron.demo.fuzzer.report_management.validate import (
+    EnoughValidationInfo,
+    EvaluateReportCredibility,
+    EvaluateReportValidity,
+    GatherValidationInfo,
+    NoNewValidationInfo,
+)
+
+_ALL_NODES = [
+    NoNewValidationInfo,
+    EvaluateReportCredibility,
+    EvaluateReportValidity,
+    EnoughValidationInfo,
+    GatherValidationInfo,
+]
+
+
+@pytest.mark.parametrize("node_cls", _ALL_NODES)
+def test_node_is_behaviour(node_cls):
+    """Each node must be a py_trees Behaviour."""
+    node = node_cls()
+    assert isinstance(node, py_trees.behaviour.Behaviour)
+
+
+@pytest.mark.parametrize("node_cls", _ALL_NODES)
+def test_node_has_docstring(node_cls):
+    """Each node must have a non-empty docstring (BT-16-003)."""
+    assert node_cls.__doc__ and node_cls.__doc__.strip()
+
+
+@pytest.mark.parametrize("node_cls", _ALL_NODES)
+def test_node_name_defaults_to_class_name(node_cls):
+    """Default name must be the class name."""
+    node = node_cls()
+    assert node.name == node_cls.__name__
+
+
+@pytest.mark.parametrize("node_cls", _ALL_NODES)
+def test_node_name_custom(node_cls):
+    """Custom name must be respected."""
+    node = node_cls(name="custom")
+    assert node.name == "custom"
+
+
+@pytest.mark.parametrize("node_cls", _ALL_NODES)
+def test_update_returns_status(node_cls):
+    """update() must return a valid py_trees Status."""
+    node = node_cls()
+    node.setup()
+    status = node.update()
+    assert status in (
+        py_trees.common.Status.SUCCESS,
+        py_trees.common.Status.FAILURE,
+        py_trees.common.Status.RUNNING,
+    )
+
+
+def test_no_new_validation_info_base_type():
+    assert issubclass(NoNewValidationInfo, ProbablySucceed)
+
+
+def test_evaluate_report_credibility_base_type():
+    assert issubclass(EvaluateReportCredibility, AlmostAlwaysSucceed)
+
+
+def test_evaluate_report_validity_base_type():
+    assert issubclass(EvaluateReportValidity, AlmostAlwaysSucceed)
+
+
+def test_enough_validation_info_base_type():
+    assert issubclass(EnoughValidationInfo, UsuallySucceed)
+
+
+def test_gather_validation_info_base_type():
+    assert issubclass(GatherValidationInfo, AlmostAlwaysSucceed)
+
+
+def test_no_new_validation_info_success_rate():
+    assert NoNewValidationInfo.success_rate == pytest.approx(2 / 3)
+
+
+def test_evaluate_report_credibility_success_rate():
+    assert EvaluateReportCredibility.success_rate == pytest.approx(0.9)
+
+
+def test_evaluate_report_validity_success_rate():
+    assert EvaluateReportValidity.success_rate == pytest.approx(0.9)
+
+
+def test_enough_validation_info_success_rate():
+    assert EnoughValidationInfo.success_rate == pytest.approx(0.75)
+
+
+def test_gather_validation_info_success_rate():
+    assert GatherValidationInfo.success_rate == pytest.approx(0.9)

--- a/vultron/demo/fuzzer/__init__.py
+++ b/vultron/demo/fuzzer/__init__.py
@@ -39,6 +39,19 @@ from vultron.demo.fuzzer.base import (
     UsuallySucceed,
     WeightedBehavior,
 )
+from vultron.demo.fuzzer.messaging import FollowUpOnErrorMessage
+from vultron.demo.fuzzer.report_management import (
+    EnoughPrioritizationInfo,
+    EnoughValidationInfo,
+    EvaluateReportCredibility,
+    EvaluateReportValidity,
+    GatherPrioritizationInfo,
+    GatherValidationInfo,
+    NoNewPrioritizationInfo,
+    NoNewValidationInfo,
+    OnAccept,
+    OnDefer,
+)
 from vultron.demo.fuzzer.embargo import (
     AvoidEmbargoCounterProposal,
     CurrentEmbargoAcceptable,
@@ -99,4 +112,18 @@ __all__ = [
     "OnEmbargoAccept",
     "OnEmbargoReject",
     "CurrentEmbargoAcceptable",
+    # report validation nodes
+    "NoNewValidationInfo",
+    "EvaluateReportCredibility",
+    "EvaluateReportValidity",
+    "EnoughValidationInfo",
+    "GatherValidationInfo",
+    # report prioritization nodes
+    "NoNewPrioritizationInfo",
+    "EnoughPrioritizationInfo",
+    "GatherPrioritizationInfo",
+    "OnAccept",
+    "OnDefer",
+    # messaging inbound nodes
+    "FollowUpOnErrorMessage",
 ]

--- a/vultron/demo/fuzzer/messaging.py
+++ b/vultron/demo/fuzzer/messaging.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+#  Copyright (c) 2023-2025 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Inbound messaging fuzzer nodes for the Vultron demo layer.
+
+This module provides probabilistic stub ``py_trees`` behaviour nodes for the
+inbound message handling workflow (``ReceiveMessagesBt``).  Each node
+represents an external-dependency touchpoint that will eventually be replaced
+by production logic.
+
+Nodes are built on the probabilistic base types in
+``vultron.demo.fuzzer.base`` and satisfy BT-16-003 (named integration-point
+nodes with semantic docstrings) and BT-16-005 (automation-potential
+categorization).
+
+References
+----------
+- Source: ``vultron/bt/messaging/inbound/_behaviors/fuzzer.py``
+- Spec: ``specs/behavior-tree-integration.yaml`` BT-16-003, BT-16-004, BT-16-005
+- Notes: ``notes/bt-fuzzer-nodes-messaging.md``
+"""
+
+from __future__ import annotations
+
+from vultron.demo.fuzzer.base import UniformSucceedFail
+
+
+class FollowUpOnErrorMessage(UniformSucceedFail):
+    """Attempt to send a follow-up inquiry when an error message is received.
+
+    Semantic function:
+        Action — when an unexpected or error message type is received,
+        attempt to send a follow-up inquiry (GI message) to the sender
+        to request clarification.  Implemented in the original source as
+        a fallback containing a 50/50 random success and an
+        ``EmitGI`` action; the net effect is stochastic success at
+        p=0.50.
+
+    Input category: System integration / Human analyst.
+
+    Success probability: 0.50 (``UniformSucceedFail``).
+
+    Automation potential: **High** — deterministic policy-driven GI
+    message dispatch in response to error conditions; can be fully
+    automated once the follow-up policy is defined.
+    """

--- a/vultron/demo/fuzzer/report_management/__init__.py
+++ b/vultron/demo/fuzzer/report_management/__init__.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+#  Copyright (c) 2023-2025 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Report management fuzzer nodes for the Vultron demo layer."""
+
+from vultron.demo.fuzzer.report_management.prioritize import (
+    EnoughPrioritizationInfo,
+    GatherPrioritizationInfo,
+    NoNewPrioritizationInfo,
+    OnAccept,
+    OnDefer,
+)
+from vultron.demo.fuzzer.report_management.validate import (
+    EnoughValidationInfo,
+    EvaluateReportCredibility,
+    EvaluateReportValidity,
+    GatherValidationInfo,
+    NoNewValidationInfo,
+)
+
+__all__ = [
+    # validation nodes
+    "NoNewValidationInfo",
+    "EvaluateReportCredibility",
+    "EvaluateReportValidity",
+    "EnoughValidationInfo",
+    "GatherValidationInfo",
+    # prioritization nodes
+    "NoNewPrioritizationInfo",
+    "EnoughPrioritizationInfo",
+    "GatherPrioritizationInfo",
+    "OnAccept",
+    "OnDefer",
+]

--- a/vultron/demo/fuzzer/report_management/prioritize.py
+++ b/vultron/demo/fuzzer/report_management/prioritize.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+#  Copyright (c) 2023-2025 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Report prioritization fuzzer nodes for the Vultron demo layer.
+
+This module provides probabilistic stub ``py_trees`` behaviour nodes for the
+Report Management prioritization workflow (``RMPrioritizeBt``).  Each node
+represents an external-dependency touchpoint — a human decision,
+environmental check, or system integration hook — that will eventually be
+replaced by production logic.
+
+Nodes are built on the probabilistic base types in
+``vultron.demo.fuzzer.base`` and satisfy BT-16-003 (named integration-point
+nodes with semantic docstrings) and BT-16-005 (automation-potential
+categorization).
+
+References
+----------
+- Source: ``vultron/bt/report_management/fuzzer/prioritize_report.py``
+- Spec: ``specs/behavior-tree-integration.yaml`` BT-16-003, BT-16-004, BT-16-005
+- Notes: ``notes/bt-fuzzer-nodes-report-management.md``
+"""
+
+from __future__ import annotations
+
+from vultron.demo.fuzzer.base import (
+    AlmostAlwaysSucceed,
+    AlwaysSucceed,
+    ProbablySucceed,
+    UsuallySucceed,
+)
+
+
+class NoNewPrioritizationInfo(ProbablySucceed):
+    """Check whether new information has arrived that should trigger
+    re-prioritization of the report.
+
+    Semantic function:
+        Condition — check whether new information has arrived that
+        should trigger re-prioritization of the report.  Succeeds more
+        often than not to avoid redundant re-evaluation cycles.
+
+    Input category: Environmental check / Human decision.
+
+    Success probability: 0.67 (``ProbablySucceed``).
+
+    Automation potential: **High** — metadata timestamp or case-update
+    event check; fully automatable.
+    """
+
+
+class EnoughPrioritizationInfo(UsuallySucceed):
+    """Determine whether sufficient context exists to make an accept/defer
+    decision.
+
+    Semantic function:
+        Condition — determine whether there is enough context to make an
+        accept/defer decision.  Insufficient info triggers a gathering
+        phase.
+
+    Input category: Human decision / Environmental check.
+
+    Success probability: 0.75 (``UsuallySucceed``).
+
+    Automation potential: **Medium** — availability of SSVC decision-point
+    data (e.g., CVSS score, exploitation status) is automatable; the
+    sufficiency judgment for a final accept/defer decision usually
+    involves human analyst review.
+    """
+
+
+class GatherPrioritizationInfo(AlmostAlwaysSucceed):
+    """Collect additional context needed to support a prioritization decision.
+
+    Semantic function:
+        Action — collect additional context needed to support a
+        prioritization decision (e.g., severity scores, asset inventory,
+        threat landscape data).  Succeeds almost always in simulation to
+        keep the workflow progressing.
+
+    Input category: System integration / Human analyst research.
+
+    Success probability: 0.90 (``AlmostAlwaysSucceed``).
+
+    Automation potential: **Medium** — fetching CVSS scores, EPSS
+    scores, NVD data, and asset inventory is fully automatable via APIs;
+    analyst interpretation and gap-filling still requires human
+    involvement.
+    """
+
+
+class OnAccept(AlwaysSucceed):
+    """Execute site-specific tasks when a report is accepted.
+
+    Semantic function:
+        Action integration hook — trigger notifications, initialize the
+        case workflow, assign to a team, and update case status when the
+        report is accepted.  Must be idempotent in production.
+
+    Input category: System integration.
+
+    Success probability: 1.00 (``AlwaysSucceed``).
+
+    Automation potential: **High** — stakeholder notifications, workflow
+    initialization, and state updates are all automatable via
+    integration APIs.
+    """
+
+
+class OnDefer(AlwaysSucceed):
+    """Execute site-specific tasks when a report is deferred.
+
+    Semantic function:
+        Action integration hook — notify stakeholders, schedule a
+        follow-up, and update the case status when the report is
+        deferred.  Must be idempotent in production.
+
+    Input category: System integration.
+
+    Success probability: 1.00 (``AlwaysSucceed``).
+
+    Automation potential: **High** — stakeholder notifications, follow-up
+    scheduling, and state updates are all automatable via integration
+    APIs.
+    """

--- a/vultron/demo/fuzzer/report_management/validate.py
+++ b/vultron/demo/fuzzer/report_management/validate.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+#  Copyright (c) 2023-2025 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Report validation fuzzer nodes for the Vultron demo layer.
+
+This module provides probabilistic stub ``py_trees`` behaviour nodes for the
+Report Management validation workflow (``RMValidateBt``).  Each node
+represents an external-dependency touchpoint — a human decision,
+environmental check, or system integration hook — that will eventually be
+replaced by production logic.
+
+Nodes are built on the probabilistic base types in
+``vultron.demo.fuzzer.base`` and satisfy BT-16-003 (named integration-point
+nodes with semantic docstrings) and BT-16-005 (automation-potential
+categorization).
+
+References
+----------
+- Source: ``vultron/bt/report_management/fuzzer/validate_report.py``
+- Spec: ``specs/behavior-tree-integration.yaml`` BT-16-003, BT-16-004, BT-16-005
+- Notes: ``notes/bt-fuzzer-nodes-report-management.md``
+"""
+
+from __future__ import annotations
+
+from vultron.demo.fuzzer.base import (
+    AlmostAlwaysSucceed,
+    ProbablySucceed,
+    UsuallySucceed,
+)
+
+
+class NoNewValidationInfo(ProbablySucceed):
+    """Check whether any new information has arrived that should trigger
+    re-evaluation of the report's validity.
+
+    Semantic function:
+        Condition — check whether any new information has arrived that
+        should trigger re-evaluation of the report's validity.  In
+        most cases there will be no new information, so this condition
+        succeeds, avoiding redundant re-evaluation loops.
+
+    Input category: Environmental check / Human decision.
+
+    Success probability: 0.67 (``ProbablySucceed``).
+
+    Automation potential: **High** — event subscription on the case
+    record or metadata timestamp comparison; fully automatable.
+    """
+
+
+class EvaluateReportCredibility(AlmostAlwaysSucceed):
+    """Assess whether the report's source and content are credible.
+
+    Semantic function:
+        Condition — assess whether the report's source and content are
+        credible (i.e., likely to describe a real vulnerability).
+        Credibility criteria may include reporter reputation, technical
+        plausibility, and SSVC exploitation status.
+
+    Input category: Human decision.
+
+    Success probability: 0.90 (``AlmostAlwaysSucceed``).
+
+    Automation potential: **Medium** — SSVC exploitation status, reporter
+    reputation scoring, and technical plausibility checks can be
+    partially automated; final credibility determination typically
+    requires human analyst review.
+    """
+
+
+class EvaluateReportValidity(AlmostAlwaysSucceed):
+    """Assess whether the report is valid for this organization's scope.
+
+    Semantic function:
+        Condition — assess whether the report is valid for this
+        organization's scope (credible AND meeting org-specific
+        acceptance criteria).  A report can be credible but out of
+        scope; validity is contextual and role-dependent.
+
+    Input category: Human decision.
+
+    Success probability: 0.90 (``AlmostAlwaysSucceed``).
+
+    Automation potential: **Medium** — scope checks against well-defined
+    CNA/charter rules are automatable; organizational-context validity
+    judgment often requires human review.
+    """
+
+
+class EnoughValidationInfo(UsuallySucceed):
+    """Determine whether sufficient information is available to validate.
+
+    Semantic function:
+        Condition — determine whether sufficient information is available
+        to reach a validation decision.  Sufficient information is the
+        normal case; absence triggers a gathering phase.
+
+    Input category: Human decision / Environmental check.
+
+    Success probability: 0.75 (``UsuallySucceed``).
+
+    Automation potential: **Medium** — completeness check against
+    required fields or evidence criteria can be automated; the
+    sufficiency threshold for a final decision often involves human
+    judgment.
+    """
+
+
+class GatherValidationInfo(AlmostAlwaysSucceed):
+    """Request or collect additional information needed to validate.
+
+    Semantic function:
+        Action — request or collect additional information needed to
+        validate the report (e.g., reproduction steps, affected
+        versions, proof-of-concept).  Succeeds most of the time in
+        simulation to keep the workflow progressing.
+
+    Input category: System integration / Human analyst outreach.
+
+    Success probability: 0.90 (``AlmostAlwaysSucceed``).
+
+    Automation potential: **Low–Medium** — structured intake form
+    follow-ups and automated case-update requests are partially
+    automatable; direct reporter outreach typically requires human
+    involvement.
+    """


### PR DESCRIPTION
- Closes #862

## Summary

Ports 11 fuzzer stub nodes from the legacy `vultron/bt` layer to
`vultron/demo/fuzzer/` using py_trees class-based patterns consistent
with the FUZZ-01/02 work (embargo nodes in `embargo.py`).

## Changes

- `vultron/demo/fuzzer/report_management/validate.py`: 5 report validation
  nodes (`NoNewValidationInfo`, `EvaluateReportCredibility`,
  `EvaluateReportValidity`, `EnoughValidationInfo`, `GatherValidationInfo`)
- `vultron/demo/fuzzer/report_management/prioritize.py`: 5 prioritization
  nodes (`NoNewPrioritizationInfo`, `EnoughPrioritizationInfo`,
  `GatherPrioritizationInfo`, `OnAccept`, `OnDefer`)
- `vultron/demo/fuzzer/report_management/__init__.py`: re-exports all 10
  nodes (AC-2)
- `vultron/demo/fuzzer/messaging.py`: `FollowUpOnErrorMessage`
  (`UniformSucceedFail`, p=0.50) ported from
  `vultron/bt/messaging/inbound/_behaviors/fuzzer.py`
- `vultron/demo/fuzzer/__init__.py`: updated to re-export all 11 new nodes
- `test/demo/fuzzer/`: new test package with `test_validate.py`,
  `test_prioritize.py`, and `test_messaging.py`

## Verification

- All 4027 unit + integration tests pass (0 new failures)
- Black, flake8, mypy, pyright clean
- Pre-commit hooks passed on commit
- 26 new tests across 3 test modules (parametrized: behaviour type,
  docstring, name default/custom, update() status, success_rate)