### PR TITLE
FUZZ-04: Port VUL ID, fix development, report closure, and other-work fuzzer nodes

### DIFF
--- a/plan/history/2606/implementation/ISSUE-863.md
+++ b/plan/history/2606/implementation/ISSUE-863.md
@@ -1,0 +1,36 @@
+---
+source: ISSUE-863
+timestamp: '2026-06-22T19:33:45.236583+00:00'
+title: 'FUZZ-04: Port VUL ID, fix development, report closure, and other-work fuzzer
+  nodes'
+type: implementation
+---
+
+## Issue #863 — FUZZ-04: Port VUL ID assignment, fix development, report closure, and other-work fuzzer nodes
+
+Ported 10 Report Management fuzzer nodes across four new submodules under
+`vultron/demo/fuzzer/report_management/` using py_trees `WeightedBehavior`
+base types from FUZZ-01 (#860).
+
+### Modules created
+
+- `assign_vul_id.py`: 6 nodes — `IdAssigned` (UsuallyFail), `IdAssignable`
+  (ProbablySucceed), `IsIDAssignmentAuthority` (OftenSucceed), `RequestId`
+  (UsuallySucceed), `AssignId` (AlwaysSucceed), `InScope` (UsuallySucceed)
+- `develop_fix.py`: 1 node — `CreateFix` (AlmostAlwaysSucceed)
+- `close_report.py`: 2 nodes — `OtherCloseCriteriaMet` (UsuallyFail),
+  `PreCloseAction` (AlwaysSucceed)
+- `other_work.py`: 1 node — `OtherWork` (AlwaysSucceed)
+
+All nodes satisfy BT-16-003 (semantic docstrings with semantic function,
+input category, success probability, automation potential) and BT-16-004
+(correct submodule placement). The top-level `vultron/demo/fuzzer/__init__.py`
+was updated to export all 10 new nodes.
+
+### Tests
+
+124 new unit tests across `test/fuzzer/report_management/` covering AC-1
+(WeightedBehavior subclass), AC-2 (docstring fields), and AC-3 (success-rate
+distribution). All 3852 unit tests pass. Black, flake8, mypy, and pyright clean.
+
+PR: [#1113](https://github.com/CERTCC/Vultron/pull/1113)

--- a/test/fuzzer/report_management/__init__.py
+++ b/test/fuzzer/report_management/__init__.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+#  Copyright (c) 2023-2025 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University

--- a/test/fuzzer/report_management/test_assign_vul_id.py
+++ b/test/fuzzer/report_management/test_assign_vul_id.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python
+#  Copyright (c) 2023-2025 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Unit tests for vultron/demo/fuzzer/report_management/assign_vul_id.py.
+
+Tests cover:
+  - All 6 nodes are WeightedBehavior subclasses (AC-1)
+  - Each node has a non-empty docstring covering semantic function,
+    input category, success probability, and automation potential (AC-2)
+  - Each node has the correct success_rate attribute (AC-3)
+  - update() returns only valid Status values
+  - AlwaysSucceed-based nodes always succeed
+  - Empirical distribution checks for selected nodes
+"""
+
+import random
+from typing import Type
+
+import py_trees
+import pytest
+from py_trees.common import Status
+
+from vultron.demo.fuzzer.base import WeightedBehavior
+from vultron.demo.fuzzer.report_management.assign_vul_id import (
+    AssignId,
+    IdAssignable,
+    IdAssigned,
+    InScope,
+    IsIDAssignmentAuthority,
+    RequestId,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_TRIALS = 10_000
+_TOLERANCE = 0.03  # ±3 percentage points
+
+# All 6 nodes with their expected success_rates
+_ALL_NODES: list[tuple[Type[WeightedBehavior], float]] = [
+    (IdAssigned, 1.0 / 4.0),
+    (IdAssignable, 2.0 / 3.0),
+    (IsIDAssignmentAuthority, 7.0 / 10.0),
+    (RequestId, 3.0 / 4.0),
+    (AssignId, 1.0),
+    (InScope, 3.0 / 4.0),
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_trials(node_cls: Type[WeightedBehavior], n: int = _TRIALS) -> float:
+    """Return empirical success rate over *n* independent ticks."""
+    node = node_cls()
+    successes = sum(1 for _ in range(n) if node.update() == Status.SUCCESS)
+    return successes / n
+
+
+# ---------------------------------------------------------------------------
+# AC-1: All 6 nodes ported using py_trees base types
+# ---------------------------------------------------------------------------
+
+
+class TestAllNodesAreWeightedBehavior:
+    @pytest.mark.parametrize("cls,_rate", _ALL_NODES)
+    def test_is_weighted_behavior_subclass(
+        self, cls: Type[WeightedBehavior], _rate: float
+    ) -> None:
+        assert issubclass(
+            cls, WeightedBehavior
+        ), f"{cls.__name__} must be a WeightedBehavior subclass"
+
+    @pytest.mark.parametrize("cls,_rate", _ALL_NODES)
+    def test_is_py_trees_behaviour(
+        self, cls: Type[WeightedBehavior], _rate: float
+    ) -> None:
+        node = cls()
+        assert isinstance(node, py_trees.behaviour.Behaviour)
+
+    @pytest.mark.parametrize("cls,_rate", _ALL_NODES)
+    def test_default_name_is_class_name(
+        self, cls: Type[WeightedBehavior], _rate: float
+    ) -> None:
+        node = cls()
+        assert node.name == cls.__name__
+
+    def test_all_6_nodes_present(self) -> None:
+        assert (
+            len(_ALL_NODES) == 6
+        ), f"Expected 6 VUL ID assignment fuzzer nodes, found {len(_ALL_NODES)}"
+
+
+# ---------------------------------------------------------------------------
+# AC-2: Docstrings cover required fields per BT-16-003 / BT-16-005
+# ---------------------------------------------------------------------------
+
+
+class TestDocstrings:
+    @pytest.mark.parametrize("cls,_rate", _ALL_NODES)
+    def test_has_non_empty_docstring(
+        self, cls: Type[WeightedBehavior], _rate: float
+    ) -> None:
+        doc = cls.__doc__ or ""
+        assert len(doc.strip()) > 0, f"{cls.__name__} has an empty docstring"
+
+    @pytest.mark.parametrize("cls,_rate", _ALL_NODES)
+    def test_docstring_mentions_semantic_function(
+        self, cls: Type[WeightedBehavior], _rate: float
+    ) -> None:
+        doc = (cls.__doc__ or "").lower()
+        assert (
+            "semantic function" in doc
+        ), f"{cls.__name__} docstring missing 'Semantic function' section"
+
+    @pytest.mark.parametrize("cls,_rate", _ALL_NODES)
+    def test_docstring_mentions_input_category(
+        self, cls: Type[WeightedBehavior], _rate: float
+    ) -> None:
+        doc = (cls.__doc__ or "").lower()
+        assert (
+            "input category" in doc
+        ), f"{cls.__name__} docstring missing 'Input category' section"
+
+    @pytest.mark.parametrize("cls,_rate", _ALL_NODES)
+    def test_docstring_mentions_success_probability(
+        self, cls: Type[WeightedBehavior], _rate: float
+    ) -> None:
+        doc = (cls.__doc__ or "").lower()
+        assert (
+            "success probability" in doc
+        ), f"{cls.__name__} docstring missing 'Success probability' section"
+
+    @pytest.mark.parametrize("cls,_rate", _ALL_NODES)
+    def test_docstring_mentions_automation_potential(
+        self, cls: Type[WeightedBehavior], _rate: float
+    ) -> None:
+        doc = (cls.__doc__ or "").lower()
+        assert (
+            "automation potential" in doc
+        ), f"{cls.__name__} docstring missing 'Automation potential' section"
+
+
+# ---------------------------------------------------------------------------
+# AC-3: success_rate attributes and status distribution
+# ---------------------------------------------------------------------------
+
+
+class TestSuccessRateAttributes:
+    @pytest.mark.parametrize("cls,expected_rate", _ALL_NODES)
+    def test_success_rate_attribute(
+        self, cls: Type[WeightedBehavior], expected_rate: float
+    ) -> None:
+        assert abs(cls.success_rate - expected_rate) < 1e-9, (
+            f"{cls.__name__}: success_rate={cls.success_rate!r}, "
+            f"expected {expected_rate!r}"
+        )
+
+
+class TestUpdateReturnsValidStatus:
+    @pytest.mark.parametrize("cls,_rate", _ALL_NODES)
+    def test_update_returns_success_or_failure(
+        self, cls: Type[WeightedBehavior], _rate: float
+    ) -> None:
+        node = cls()
+        result = node.update()
+        assert result in (
+            Status.SUCCESS,
+            Status.FAILURE,
+        ), f"{cls.__name__}.update() returned unexpected status: {result}"
+
+    @pytest.mark.parametrize("cls,_rate", _ALL_NODES)
+    def test_update_never_returns_running(
+        self, cls: Type[WeightedBehavior], _rate: float
+    ) -> None:
+        node = cls()
+        results = {node.update() for _ in range(50)}
+        assert (
+            Status.RUNNING not in results
+        ), f"{cls.__name__}.update() returned RUNNING unexpectedly"
+
+
+class TestDeterministicExtremes:
+    def test_assign_id_always_succeeds(self) -> None:
+        node = AssignId()
+        assert all(node.update() == Status.SUCCESS for _ in range(100))
+
+
+class TestEmpiricalDistributions:
+    """Verify that probabilistic nodes produce the expected distribution."""
+
+    @pytest.mark.parametrize(
+        "cls,expected_rate",
+        [
+            (IdAssigned, 1.0 / 4.0),
+            (IdAssignable, 2.0 / 3.0),
+            (IsIDAssignmentAuthority, 7.0 / 10.0),
+            (RequestId, 3.0 / 4.0),
+            (InScope, 3.0 / 4.0),
+        ],
+    )
+    def test_empirical_distribution(
+        self, cls: Type[WeightedBehavior], expected_rate: float
+    ) -> None:
+        rate = _run_trials(cls)
+        assert abs(rate - expected_rate) < _TOLERANCE, (
+            f"{cls.__name__}: empirical={rate:.4f} "
+            f"expected={expected_rate:.4f}"
+        )
+
+    def test_seeded_determinism(self) -> None:
+        """Same seed → same sequence for a representative node."""
+        random.seed(42)
+        node = RequestId()
+        seq_a = [node.update() for _ in range(20)]
+        random.seed(42)
+        seq_b = [node.update() for _ in range(20)]
+        assert seq_a == seq_b

--- a/test/fuzzer/report_management/test_close_report.py
+++ b/test/fuzzer/report_management/test_close_report.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python
+#  Copyright (c) 2023-2025 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Unit tests for vultron/demo/fuzzer/report_management/close_report.py.
+
+Tests cover:
+  - Both nodes are WeightedBehavior subclasses (AC-1)
+  - Each node has a non-empty docstring covering required sections (AC-2)
+  - Correct success_rate attributes and status distribution (AC-3)
+  - AlwaysSucceed-based nodes always succeed
+  - Empirical distribution check for OtherCloseCriteriaMet
+"""
+
+import py_trees
+import pytest
+from py_trees.common import Status
+from typing import Type
+
+from vultron.demo.fuzzer.base import WeightedBehavior
+from vultron.demo.fuzzer.report_management.close_report import (
+    OtherCloseCriteriaMet,
+    PreCloseAction,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_TRIALS = 10_000
+_TOLERANCE = 0.03  # ±3 percentage points
+
+_ALL_NODES: list[tuple[Type[WeightedBehavior], float]] = [
+    (OtherCloseCriteriaMet, 1.0 / 4.0),
+    (PreCloseAction, 1.0),
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_trials(node_cls: Type[WeightedBehavior], n: int = _TRIALS) -> float:
+    """Return empirical success rate over *n* independent ticks."""
+    node = node_cls()
+    successes = sum(1 for _ in range(n) if node.update() == Status.SUCCESS)
+    return successes / n
+
+
+# ---------------------------------------------------------------------------
+# AC-1: All 2 nodes use py_trees base types
+# ---------------------------------------------------------------------------
+
+
+class TestAllNodesAreWeightedBehavior:
+    @pytest.mark.parametrize("cls,_rate", _ALL_NODES)
+    def test_is_weighted_behavior_subclass(
+        self, cls: Type[WeightedBehavior], _rate: float
+    ) -> None:
+        assert issubclass(
+            cls, WeightedBehavior
+        ), f"{cls.__name__} must be a WeightedBehavior subclass"
+
+    @pytest.mark.parametrize("cls,_rate", _ALL_NODES)
+    def test_is_py_trees_behaviour(
+        self, cls: Type[WeightedBehavior], _rate: float
+    ) -> None:
+        assert isinstance(cls(), py_trees.behaviour.Behaviour)
+
+    @pytest.mark.parametrize("cls,_rate", _ALL_NODES)
+    def test_default_name_is_class_name(
+        self, cls: Type[WeightedBehavior], _rate: float
+    ) -> None:
+        assert cls().name == cls.__name__
+
+    def test_all_2_nodes_present(self) -> None:
+        assert (
+            len(_ALL_NODES) == 2
+        ), f"Expected 2 close-report fuzzer nodes, found {len(_ALL_NODES)}"
+
+
+# ---------------------------------------------------------------------------
+# AC-2: Docstrings cover required fields per BT-16-003 / BT-16-005
+# ---------------------------------------------------------------------------
+
+
+class TestDocstrings:
+    @pytest.mark.parametrize("cls,_rate", _ALL_NODES)
+    def test_has_non_empty_docstring(
+        self, cls: Type[WeightedBehavior], _rate: float
+    ) -> None:
+        doc = cls.__doc__ or ""
+        assert len(doc.strip()) > 0, f"{cls.__name__} has an empty docstring"
+
+    @pytest.mark.parametrize(
+        "cls,_rate,section",
+        [
+            (cls, rate, section)
+            for cls, rate in _ALL_NODES
+            for section in [
+                "semantic function",
+                "input category",
+                "success probability",
+                "automation potential",
+            ]
+        ],
+    )
+    def test_docstring_has_required_section(
+        self, cls: Type[WeightedBehavior], _rate: float, section: str
+    ) -> None:
+        doc = (cls.__doc__ or "").lower()
+        assert (
+            section in doc
+        ), f"{cls.__name__} docstring missing '{section}' section"
+
+
+# ---------------------------------------------------------------------------
+# AC-3: success_rate attributes and status distribution
+# ---------------------------------------------------------------------------
+
+
+class TestSuccessRateAttributes:
+    @pytest.mark.parametrize("cls,expected_rate", _ALL_NODES)
+    def test_success_rate_attribute(
+        self, cls: Type[WeightedBehavior], expected_rate: float
+    ) -> None:
+        assert abs(cls.success_rate - expected_rate) < 1e-9, (
+            f"{cls.__name__}: success_rate={cls.success_rate!r}, "
+            f"expected {expected_rate!r}"
+        )
+
+
+class TestUpdateReturnsValidStatus:
+    @pytest.mark.parametrize("cls,_rate", _ALL_NODES)
+    def test_update_returns_success_or_failure(
+        self, cls: Type[WeightedBehavior], _rate: float
+    ) -> None:
+        node = cls()
+        result = node.update()
+        assert result in (Status.SUCCESS, Status.FAILURE)
+
+    @pytest.mark.parametrize("cls,_rate", _ALL_NODES)
+    def test_update_never_returns_running(
+        self, cls: Type[WeightedBehavior], _rate: float
+    ) -> None:
+        node = cls()
+        results = {node.update() for _ in range(50)}
+        assert Status.RUNNING not in results
+
+
+class TestDeterministicExtremes:
+    def test_pre_close_action_always_succeeds(self) -> None:
+        node = PreCloseAction()
+        assert all(node.update() == Status.SUCCESS for _ in range(100))
+
+
+class TestEmpiricalDistributions:
+    def test_other_close_criteria_met_distribution(self) -> None:
+        rate = _run_trials(OtherCloseCriteriaMet)
+        expected = 1.0 / 4.0
+        assert abs(rate - expected) < _TOLERANCE, (
+            f"OtherCloseCriteriaMet: empirical={rate:.4f} "
+            f"expected={expected:.4f}"
+        )

--- a/test/fuzzer/report_management/test_develop_fix.py
+++ b/test/fuzzer/report_management/test_develop_fix.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+#  Copyright (c) 2023-2025 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Unit tests for vultron/demo/fuzzer/report_management/develop_fix.py.
+
+Tests cover:
+  - CreateFix is a WeightedBehavior subclass (AC-1)
+  - Docstring covers required fields (AC-2)
+  - Correct success_rate and status distribution (AC-3)
+"""
+
+import py_trees
+import pytest
+from py_trees.common import Status
+
+from vultron.demo.fuzzer.base import WeightedBehavior
+from vultron.demo.fuzzer.report_management.develop_fix import CreateFix
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_TRIALS = 10_000
+_TOLERANCE = 0.03  # ±3 percentage points
+
+_ALL_NODES = [(CreateFix, 9.0 / 10.0)]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_trials(node_cls: type, n: int = _TRIALS) -> float:
+    """Return empirical success rate over *n* independent ticks."""
+    node = node_cls()
+    successes = sum(1 for _ in range(n) if node.update() == Status.SUCCESS)
+    return successes / n
+
+
+# ---------------------------------------------------------------------------
+# AC-1: Node uses py_trees base type
+# ---------------------------------------------------------------------------
+
+
+class TestCreateFixIsWeightedBehavior:
+    def test_is_weighted_behavior_subclass(self) -> None:
+        assert issubclass(CreateFix, WeightedBehavior)
+
+    def test_is_py_trees_behaviour(self) -> None:
+        assert isinstance(CreateFix(), py_trees.behaviour.Behaviour)
+
+    def test_default_name_is_class_name(self) -> None:
+        assert CreateFix().name == "CreateFix"
+
+    def test_one_node_present(self) -> None:
+        assert len(_ALL_NODES) == 1
+
+
+# ---------------------------------------------------------------------------
+# AC-2: Docstring covers required fields per BT-16-003 / BT-16-005
+# ---------------------------------------------------------------------------
+
+
+class TestDocstring:
+    def test_has_non_empty_docstring(self) -> None:
+        doc = CreateFix.__doc__ or ""
+        assert len(doc.strip()) > 0
+
+    @pytest.mark.parametrize(
+        "section",
+        [
+            "semantic function",
+            "input category",
+            "success probability",
+            "automation potential",
+        ],
+    )
+    def test_docstring_has_required_section(self, section: str) -> None:
+        doc = (CreateFix.__doc__ or "").lower()
+        assert (
+            section in doc
+        ), f"CreateFix docstring missing '{section}' section"
+
+
+# ---------------------------------------------------------------------------
+# AC-3: success_rate attribute and status distribution
+# ---------------------------------------------------------------------------
+
+
+class TestSuccessRate:
+    def test_success_rate_attribute(self) -> None:
+        assert abs(CreateFix.success_rate - 9.0 / 10.0) < 1e-9
+
+    def test_update_returns_success_or_failure(self) -> None:
+        node = CreateFix()
+        result = node.update()
+        assert result in (Status.SUCCESS, Status.FAILURE)
+
+    def test_update_never_returns_running(self) -> None:
+        node = CreateFix()
+        results = {node.update() for _ in range(50)}
+        assert Status.RUNNING not in results
+
+    def test_empirical_distribution(self) -> None:
+        rate = _run_trials(CreateFix)
+        expected = 9.0 / 10.0
+        assert (
+            abs(rate - expected) < _TOLERANCE
+        ), f"CreateFix: empirical={rate:.4f} expected={expected:.4f}"

--- a/test/fuzzer/report_management/test_other_work.py
+++ b/test/fuzzer/report_management/test_other_work.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+#  Copyright (c) 2023-2025 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Unit tests for vultron/demo/fuzzer/report_management/other_work.py.
+
+Tests cover:
+  - OtherWork is a WeightedBehavior subclass (AC-1)
+  - Docstring covers required fields (AC-2)
+  - Correct success_rate and always-success behavior (AC-3)
+"""
+
+import py_trees
+import pytest
+from py_trees.common import Status
+
+from vultron.demo.fuzzer.base import WeightedBehavior
+from vultron.demo.fuzzer.report_management.other_work import OtherWork
+
+_ALL_NODES = [(OtherWork, 1.0)]
+
+
+# ---------------------------------------------------------------------------
+# AC-1: Node uses py_trees base type
+# ---------------------------------------------------------------------------
+
+
+class TestOtherWorkIsWeightedBehavior:
+    def test_is_weighted_behavior_subclass(self) -> None:
+        assert issubclass(OtherWork, WeightedBehavior)
+
+    def test_is_py_trees_behaviour(self) -> None:
+        assert isinstance(OtherWork(), py_trees.behaviour.Behaviour)
+
+    def test_default_name_is_class_name(self) -> None:
+        assert OtherWork().name == "OtherWork"
+
+    def test_one_node_present(self) -> None:
+        assert len(_ALL_NODES) == 1
+
+
+# ---------------------------------------------------------------------------
+# AC-2: Docstring covers required fields per BT-16-003 / BT-16-005
+# ---------------------------------------------------------------------------
+
+
+class TestDocstring:
+    def test_has_non_empty_docstring(self) -> None:
+        doc = OtherWork.__doc__ or ""
+        assert len(doc.strip()) > 0
+
+    @pytest.mark.parametrize(
+        "section",
+        [
+            "semantic function",
+            "input category",
+            "success probability",
+            "automation potential",
+        ],
+    )
+    def test_docstring_has_required_section(self, section: str) -> None:
+        doc = (OtherWork.__doc__ or "").lower()
+        assert (
+            section in doc
+        ), f"OtherWork docstring missing '{section}' section"
+
+
+# ---------------------------------------------------------------------------
+# AC-3: success_rate and deterministic behavior
+# ---------------------------------------------------------------------------
+
+
+class TestSuccessRate:
+    def test_success_rate_attribute(self) -> None:
+        assert abs(OtherWork.success_rate - 1.0) < 1e-9
+
+    def test_always_succeeds(self) -> None:
+        node = OtherWork()
+        assert all(node.update() == Status.SUCCESS for _ in range(100))
+
+    def test_update_never_returns_running(self) -> None:
+        node = OtherWork()
+        results = {node.update() for _ in range(50)}
+        assert Status.RUNNING not in results

--- a/vultron/demo/fuzzer/__init__.py
+++ b/vultron/demo/fuzzer/__init__.py
@@ -69,6 +69,18 @@ from vultron.demo.fuzzer.embargo import (
     WantToProposeEmbargo,
     WillingToCounterEmbargoProposal,
 )
+from vultron.demo.fuzzer.report_management import (
+    AssignId,
+    CreateFix,
+    IdAssignable,
+    IdAssigned,
+    InScope,
+    IsIDAssignmentAuthority,
+    OtherCloseCriteriaMet,
+    OtherWork,
+    PreCloseAction,
+    RequestId,
+)
 
 __all__ = [
     # base types
@@ -124,6 +136,17 @@ __all__ = [
     "GatherPrioritizationInfo",
     "OnAccept",
     "OnDefer",
+    # report management nodes
+    "IdAssigned",
+    "IdAssignable",
+    "IsIDAssignmentAuthority",
+    "RequestId",
+    "AssignId",
+    "InScope",
+    "CreateFix",
+    "OtherCloseCriteriaMet",
+    "PreCloseAction",
+    "OtherWork",
     # messaging inbound nodes
     "FollowUpOnErrorMessage",
 ]

--- a/vultron/demo/fuzzer/report_management/__init__.py
+++ b/vultron/demo/fuzzer/report_management/__init__.py
@@ -11,7 +11,18 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Report management fuzzer nodes for the Vultron demo layer."""
+"""Report management fuzzer nodes for the Vultron demo layer.
+
+This sub-package provides probabilistic py_trees behaviour nodes for the
+Report Management (RM) workflow, grouped by sub-topic:
+
+- ``validate`` — report validation nodes (5 nodes)
+- ``prioritize`` — report prioritization nodes (5 nodes)
+- ``assign_vul_id`` — VUL ID assignment nodes (6 nodes)
+- ``develop_fix`` — fix development nodes (1 node)
+- ``close_report`` — report closure nodes (2 nodes)
+- ``other_work`` — miscellaneous work placeholder (1 node)
+"""
 
 from vultron.demo.fuzzer.report_management.prioritize import (
     EnoughPrioritizationInfo,
@@ -27,6 +38,20 @@ from vultron.demo.fuzzer.report_management.validate import (
     GatherValidationInfo,
     NoNewValidationInfo,
 )
+from vultron.demo.fuzzer.report_management.assign_vul_id import (
+    AssignId,
+    IdAssignable,
+    IdAssigned,
+    InScope,
+    IsIDAssignmentAuthority,
+    RequestId,
+)
+from vultron.demo.fuzzer.report_management.close_report import (
+    OtherCloseCriteriaMet,
+    PreCloseAction,
+)
+from vultron.demo.fuzzer.report_management.develop_fix import CreateFix
+from vultron.demo.fuzzer.report_management.other_work import OtherWork
 
 __all__ = [
     # validation nodes
@@ -41,4 +66,18 @@ __all__ = [
     "GatherPrioritizationInfo",
     "OnAccept",
     "OnDefer",
+    # VUL ID assignment
+    "IdAssigned",
+    "IdAssignable",
+    "IsIDAssignmentAuthority",
+    "RequestId",
+    "AssignId",
+    "InScope",
+    # fix development
+    "CreateFix",
+    # report closure
+    "OtherCloseCriteriaMet",
+    "PreCloseAction",
+    # other work
+    "OtherWork",
 ]

--- a/vultron/demo/fuzzer/report_management/assign_vul_id.py
+++ b/vultron/demo/fuzzer/report_management/assign_vul_id.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+#  Copyright (c) 2023-2025 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""VUL ID assignment fuzzer nodes for the Vultron demo layer.
+
+This module provides probabilistic stub ``py_trees`` behaviour nodes for the
+VUL ID assignment sub-workflow within Report Management.  Each node represents
+an external-dependency touchpoint — a human decision, environmental check, or
+system integration hook — that will eventually be replaced by production logic.
+
+Nodes are built on the probabilistic base types in
+``vultron.demo.fuzzer.base`` and satisfy BT-16-003 (named integration-point
+nodes with semantic docstrings) and BT-16-005 (automation-potential
+categorization).
+
+References
+----------
+- Source: ``vultron/bt/report_management/fuzzer/assign_vul_id.py``
+- Spec: ``specs/behavior-tree-integration.yaml`` BT-16-003, BT-16-004, BT-16-005
+- Notes: ``notes/bt-fuzzer-nodes-report-management.md``
+"""
+
+from __future__ import annotations
+
+from vultron.demo.fuzzer.base import (
+    AlwaysSucceed,
+    OftenSucceed,
+    ProbablySucceed,
+    UsuallyFail,
+    UsuallySucceed,
+)
+
+
+class IdAssigned(UsuallyFail):
+    """Check whether the vulnerability has already been assigned an identity.
+
+    Semantic function:
+        Environmental condition — verify that a vulnerability identifier (such
+        as a CVE ID) has already been assigned to this vulnerability.  In
+        production this is a simple lookup against the case record.  The fuzzer
+        models the common case where the workflow has not yet assigned an ID
+        (i.e., the condition fails most of the time), so that subsequent
+        ID-assignment steps are exercised.
+
+    Input category: Environmental check.
+
+    Success probability: 0.25 (``UsuallyFail``).
+
+    Automation potential: **High** — the ID assignment status is a structured
+    field on the case record; fully automatable via a read from the case
+    DataLayer with no human involvement required.
+    """
+
+
+class IdAssignable(ProbablySucceed):
+    """Check whether the vulnerability qualifies for an ID assignment.
+
+    Semantic function:
+        Environmental condition — evaluate whether the vulnerability meets the
+        eligibility criteria of the relevant ID-assignment authority.  For
+        example, when using CVE ID assignment rules, this checks whether the
+        evaluating party is the authoritative CNA for the affected product and
+        whether the vulnerability is within that CNA's scope.  A vulnerability
+        may be in scope for an ID space yet not assignable by the current
+        party.
+
+    Input category: Environmental check.
+
+    Success probability: 0.6667 (``ProbablySucceed``).
+
+    Automation potential: **Medium** — basic eligibility criteria (product
+    in scope, CNA authority) can often be checked automatically against
+    organizational metadata; edge cases or out-of-scope products may still
+    require human review.
+    """
+
+
+class IsIDAssignmentAuthority(OftenSucceed):
+    """Check whether the organization is itself an ID assignment authority.
+
+    Semantic function:
+        Environmental condition — determine whether the local organization
+        holds an assignment authority role (e.g., is a CVE Numbering Authority)
+        that allows it to directly assign IDs rather than requesting them from
+        an upstream authority.  This is a generic condition and is not specific
+        to CVE ID assignment except as an illustrative example.
+
+    Input category: Environmental check.
+
+    Success probability: 0.70 (``OftenSucceed``).
+
+    Automation potential: **High** — the authority role is a static property
+    of the organization's metadata; fully automatable as a lookup with no
+    human involvement required.
+    """
+
+
+class RequestId(UsuallySucceed):
+    """Request a Vulnerability ID assignment from an external authority.
+
+    Semantic function:
+        Action — submit a request for a VUL ID to the applicable assignment
+        authority.  For CVE IDs this corresponds to submitting a request to the
+        relevant CNA.  In production this step may be automatable via an API
+        call, or may involve prompting a human operator to file the request
+        manually.
+
+    Input category: System integration.
+
+    Success probability: 0.75 (``UsuallySucceed``).
+
+    Automation potential: **High** — CNA APIs (e.g., CVE Services API) support
+    automated CVE ID reservation; a production implementation could submit the
+    request without human intervention in most cases.
+    """
+
+
+class AssignId(AlwaysSucceed):
+    """Assign a Vulnerability ID directly to the vulnerability.
+
+    Semantic function:
+        Action — record the assignment of a VUL ID (e.g., a CVE ID) to the
+        vulnerability.  This node is exercised when the local organization is
+        itself an ID assignment authority.  In production this may be an
+        automated internal allocation from a pre-reserved ID pool or an API
+        call to the local ID management system.
+
+    Input category: System integration.
+
+    Success probability: 1.00 (``AlwaysSucceed``).
+
+    Automation potential: **High** — assignment from a managed ID pool or
+    internal tracking system is fully automatable; no human involvement is
+    required once the allocation decision is made.
+    """
+
+
+class InScope(UsuallySucceed):
+    """Check whether the vulnerability is within scope for an ID assignment.
+
+    Semantic function:
+        Environmental condition / policy — evaluate whether the vulnerability
+        falls within the scope definition governing the relevant ID space.  For
+        CVE ID assignment this means checking the CNA scope rules; other ID
+        spaces may have different scope definitions.  An ID space that allows
+        rapid assignment may have a very broad scope requiring little or no
+        explicit scope checking.
+
+    Input category: Environmental check / policy.
+
+    Success probability: 0.75 (``UsuallySucceed``).
+
+    Automation potential: **Medium** — scope rules for well-defined ID spaces
+    (e.g., CVE scope per product/vendor) can be encoded and checked
+    automatically; novel or ambiguous scope boundaries may still require human
+    judgment.
+    """

--- a/vultron/demo/fuzzer/report_management/close_report.py
+++ b/vultron/demo/fuzzer/report_management/close_report.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+#  Copyright (c) 2023-2025 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Report closure fuzzer nodes for the Vultron demo layer.
+
+This module provides probabilistic stub ``py_trees`` behaviour nodes for the
+report closure sub-workflow within Report Management.  Each node represents an
+external-dependency touchpoint — a human decision, policy check, or system
+integration hook — that will eventually be replaced by production logic.
+
+Nodes are built on the probabilistic base types in
+``vultron.demo.fuzzer.base`` and satisfy BT-16-003 (named integration-point
+nodes with semantic docstrings) and BT-16-005 (automation-potential
+categorization).
+
+References
+----------
+- Source: ``vultron/bt/report_management/fuzzer/close_report.py``
+- Spec: ``specs/behavior-tree-integration.yaml`` BT-16-003, BT-16-004, BT-16-005
+- Notes: ``notes/bt-fuzzer-nodes-report-management.md``
+"""
+
+from __future__ import annotations
+
+from vultron.demo.fuzzer.base import AlwaysSucceed, UsuallyFail
+
+
+class OtherCloseCriteriaMet(UsuallyFail):
+    """Check whether site-specific closure criteria have been satisfied.
+
+    Semantic function:
+        Condition — evaluate whether organizational or case-specific criteria
+        beyond the standard CVD workflow conditions have been met, allowing the
+        report to be closed.  In production this is typically a human decision
+        or a check of case state against a configurable set of site-specific
+        policies (e.g., all stakeholders notified, public advisory published,
+        or internal QA completed).  The fuzzer models the uncommon case where
+        additional criteria are satisfied, reflecting that extra criteria are
+        not routinely met.
+
+    Input category: Human decision / policy.
+
+    Success probability: 0.25 (``UsuallyFail``).
+
+    Automation potential: **Low** — closure criteria are highly
+    organization-specific and often context-dependent; encoding all
+    possible criteria as a general policy rule is impractical, and the
+    final closure decision usually benefits from human confirmation.
+    """
+
+
+class PreCloseAction(AlwaysSucceed):
+    """Perform required actions immediately before closing the report.
+
+    Semantic function:
+        Action integration hook — execute any mandatory pre-closure tasks such
+        as quality-assurance checks, notification dispatches, or bookkeeping
+        updates that must be completed before the report transitions to the
+        Closed state.  Must be idempotent in production to support safe retries.
+
+    Input category: System integration.
+
+    Success probability: 1.00 (``AlwaysSucceed``).
+
+    Automation potential: **High** — standard pre-close actions (e.g., marking
+    tasks complete, archiving related artifacts, sending closure notifications)
+    are fully automatable via API integrations; no human involvement is
+    required once the pre-close checklist is defined.
+    """

--- a/vultron/demo/fuzzer/report_management/develop_fix.py
+++ b/vultron/demo/fuzzer/report_management/develop_fix.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+#  Copyright (c) 2023-2025 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Fix development fuzzer nodes for the Vultron demo layer.
+
+This module provides a probabilistic stub ``py_trees`` behaviour node for the
+fix development sub-workflow within Report Management.  The node represents an
+external-dependency touchpoint — a human decision or system integration hook —
+that will eventually be replaced by production logic.
+
+Nodes are built on the probabilistic base types in
+``vultron.demo.fuzzer.base`` and satisfy BT-16-003 (named integration-point
+nodes with semantic docstrings) and BT-16-005 (automation-potential
+categorization).
+
+References
+----------
+- Source: ``vultron/bt/report_management/fuzzer/develop_fix.py``
+- Spec: ``specs/behavior-tree-integration.yaml`` BT-16-003, BT-16-004, BT-16-005
+- Notes: ``notes/bt-fuzzer-nodes-report-management.md``
+"""
+
+from __future__ import annotations
+
+from vultron.demo.fuzzer.base import AlmostAlwaysSucceed
+
+
+class CreateFix(AlmostAlwaysSucceed):
+    """Initiate the process of creating a fix for the vulnerability.
+
+    Semantic function:
+        Action — trigger the internal fix development process for the
+        vulnerability.  In production this would typically mean opening a bug
+        in an internal tracking system, assigning the issue to an engineering
+        team, or initiating an automated patch-generation workflow.  The fuzzer
+        models the overwhelmingly common case where the fix development
+        handoff succeeds, allowing the rest of the workflow to be exercised.
+
+    Input category: System integration.
+
+    Success probability: 0.90 (``AlmostAlwaysSucceed``).
+
+    Automation potential: **Medium** — creating a ticket in an internal bug
+    tracker or project-management system can be automated via an API
+    integration; however, assigning the right engineering owner and
+    establishing acceptance criteria may require human review for non-trivial
+    vulnerabilities.
+    """

--- a/vultron/demo/fuzzer/report_management/other_work.py
+++ b/vultron/demo/fuzzer/report_management/other_work.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+#  Copyright (c) 2023-2025 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Other-work fuzzer nodes for the Vultron demo layer.
+
+This module provides a probabilistic stub ``py_trees`` behaviour node
+representing miscellaneous work within the Report Management workflow.  The
+node acts as a placeholder that will eventually be replaced by a sub-tree of
+concrete integration nodes.
+
+Nodes are built on the probabilistic base types in
+``vultron.demo.fuzzer.base`` and satisfy BT-16-003 (named integration-point
+nodes with semantic docstrings) and BT-16-005 (automation-potential
+categorization).
+
+References
+----------
+- Source: ``vultron/bt/report_management/fuzzer/other_work.py``
+- Spec: ``specs/behavior-tree-integration.yaml`` BT-16-003, BT-16-004, BT-16-005
+- Notes: ``notes/bt-fuzzer-nodes-report-management.md``
+"""
+
+from __future__ import annotations
+
+from vultron.demo.fuzzer.base import AlwaysSucceed
+
+
+class OtherWork(AlwaysSucceed):
+    """Execute miscellaneous work within the report management workflow.
+
+    Semantic function:
+        Action placeholder — represents any additional work that the
+        ``do_work`` behavior tree may need to perform that is not covered by
+        more specific nodes.  In production this node would be replaced by a
+        sub-tree of concrete integration nodes tailored to the organization's
+        specific workflow requirements.  Because the intent is that other work
+        should always complete successfully when attempted, the stub always
+        returns SUCCESS.
+
+    Input category: System integration.
+
+    Success probability: 1.00 (``AlwaysSucceed``).
+
+    Automation potential: **High** — the specific work represented by this
+    placeholder is organization-defined; once the concrete tasks are
+    identified, most routine workflow actions (status updates, notifications,
+    artifact archiving) are fully automatable via API integrations.
+    """


### PR DESCRIPTION
- Closes #863

## Summary

Ports 10 Report Management fuzzer nodes across four new submodules under
`vultron/demo/fuzzer/report_management/` using py_trees
`WeightedBehavior` base types from FUZZ-01 (#860). All nodes satisfy
BT-16-003 (semantic docstrings) and BT-16-005 (automation-potential
categorization).

## Changes

- `vultron/demo/fuzzer/report_management/__init__.py`: New subpackage
  exporting all 10 ported nodes.
- `vultron/demo/fuzzer/report_management/assign_vul_id.py`: 6 nodes —
  `IdAssigned`, `IdAssignable`, `IsIDAssignmentAuthority`, `RequestId`,
  `AssignId`, `InScope`.
- `vultron/demo/fuzzer/report_management/develop_fix.py`: 1 node —
  `CreateFix`.
- `vultron/demo/fuzzer/report_management/close_report.py`: 2 nodes —
  `OtherCloseCriteriaMet`, `PreCloseAction`.
- `vultron/demo/fuzzer/report_management/other_work.py`: 1 node —
  `OtherWork`.
- `vultron/demo/fuzzer/__init__.py`: Exports all 10 new nodes.
- `test/fuzzer/report_management/`: 4 test modules covering all 3 ACs
  (base type, docstring fields, success-rate distribution).

## Verification

- All 3852 unit tests pass (124 new)
- Black, flake8, mypy, pyright clean