### PR TITLE
FUZZ-07: Port report-to-others workflow fuzzer nodes to demo layer

### DIFF
--- a/plan/history/2606/implementation/ISSUE-866.md
+++ b/plan/history/2606/implementation/ISSUE-866.md
@@ -1,0 +1,30 @@
+---
+source: ISSUE-866
+timestamp: '2026-06-22T20:02:29.346842+00:00'
+title: 'FUZZ-07: Port report-to-others workflow fuzzer nodes'
+type: implementation
+---
+
+## Issue #866 — FUZZ-07: Port report-to-others workflow fuzzer nodes
+
+Ported all 21 report-to-others workflow fuzzer nodes from the legacy
+`vultron/bt/report_management/fuzzer/report_to_others.py` to
+`vultron/demo/fuzzer/report_management/report_to_others.py` using
+py_trees class inheritance on the probabilistic base types introduced
+in FUZZ-01.
+
+**Nodes ported**: HaveReportToOthersCapability, AllPartiesKnown,
+IdentifyVendors, IdentifyCoordinators, IdentifyOthers,
+NotificationsComplete, ChooseRecipient, RemoveRecipient,
+RecipientEffortExceeded, PolicyCompatible, FindContact, RcptNotInQrmS,
+SetRcptQrmR, TotalEffortLimitMet, MoreVendors, MoreCoordinators,
+MoreOthers, InjectParticipant, InjectVendor, InjectCoordinator,
+InjectOther.
+
+Each node has a semantic docstring with Automation potential per
+BT-16-003. InjectVendor/InjectCoordinator/InjectOther inherit from
+InjectParticipant. IdentifyVendors/IdentifyCoordinators use
+SuccessOrRunning (never FAILURE). 147 unit tests added in
+`test/fuzzer/report_management/test_report_to_others.py`.
+
+PR: [#1115](https://github.com/CERTCC/Vultron/pull/1115)

--- a/test/fuzzer/report_management/test_report_to_others.py
+++ b/test/fuzzer/report_management/test_report_to_others.py
@@ -1,0 +1,290 @@
+"""Tests for vultron.demo.fuzzer.report_management.report_to_others."""
+
+import pytest
+import py_trees
+
+from vultron.demo.fuzzer.base import (
+    AlmostAlwaysFail,
+    AlmostAlwaysSucceed,
+    AlmostCertainlyFail,
+    AlwaysSucceed,
+    ProbablySucceed,
+    SuccessOrRunning,
+    UniformSucceedFail,
+    UsuallyFail,
+    UsuallySucceed,
+)
+from vultron.demo.fuzzer.report_management.report_to_others import (
+    AllPartiesKnown,
+    ChooseRecipient,
+    FindContact,
+    HaveReportToOthersCapability,
+    IdentifyCoordinators,
+    IdentifyOthers,
+    IdentifyVendors,
+    InjectCoordinator,
+    InjectOther,
+    InjectParticipant,
+    InjectVendor,
+    MoreCoordinators,
+    MoreOthers,
+    MoreVendors,
+    NotificationsComplete,
+    PolicyCompatible,
+    RcptNotInQrmS,
+    RecipientEffortExceeded,
+    RemoveRecipient,
+    SetRcptQrmR,
+    TotalEffortLimitMet,
+)
+
+_ALL_NODES = [
+    HaveReportToOthersCapability,
+    AllPartiesKnown,
+    IdentifyVendors,
+    IdentifyCoordinators,
+    IdentifyOthers,
+    NotificationsComplete,
+    ChooseRecipient,
+    RemoveRecipient,
+    RecipientEffortExceeded,
+    PolicyCompatible,
+    FindContact,
+    RcptNotInQrmS,
+    SetRcptQrmR,
+    TotalEffortLimitMet,
+    MoreVendors,
+    MoreCoordinators,
+    MoreOthers,
+    InjectParticipant,
+    InjectVendor,
+    InjectCoordinator,
+    InjectOther,
+]
+
+
+@pytest.mark.parametrize("node_cls", _ALL_NODES)
+def test_node_is_behaviour(node_cls):
+    """Each node must be a py_trees Behaviour."""
+    node = node_cls()
+    assert isinstance(node, py_trees.behaviour.Behaviour)
+
+
+@pytest.mark.parametrize("node_cls", _ALL_NODES)
+def test_node_has_docstring(node_cls):
+    """Each node must have a non-empty docstring (BT-16-003)."""
+    assert node_cls.__doc__ and node_cls.__doc__.strip()
+
+
+@pytest.mark.parametrize("node_cls", _ALL_NODES)
+def test_node_name_defaults_to_class_name(node_cls):
+    """Default name must be the class name."""
+    node = node_cls()
+    assert node.name == node_cls.__name__
+
+
+@pytest.mark.parametrize("node_cls", _ALL_NODES)
+def test_node_name_custom(node_cls):
+    """Custom name must be respected."""
+    node = node_cls(name="custom")
+    assert node.name == "custom"
+
+
+@pytest.mark.parametrize("node_cls", _ALL_NODES)
+def test_update_returns_status(node_cls):
+    """update() must return a valid py_trees Status."""
+    node = node_cls()
+    node.setup()
+    status = node.update()
+    assert status in (
+        py_trees.common.Status.SUCCESS,
+        py_trees.common.Status.FAILURE,
+        py_trees.common.Status.RUNNING,
+    )
+
+
+# --- Base-type tests ---
+
+
+def test_have_report_to_others_capability_base_type():
+    assert issubclass(HaveReportToOthersCapability, UsuallySucceed)
+
+
+def test_all_parties_known_base_type():
+    assert issubclass(AllPartiesKnown, UniformSucceedFail)
+
+
+def test_identify_vendors_base_type():
+    assert issubclass(IdentifyVendors, SuccessOrRunning)
+
+
+def test_identify_coordinators_base_type():
+    assert issubclass(IdentifyCoordinators, SuccessOrRunning)
+
+
+def test_identify_others_base_type():
+    assert issubclass(IdentifyOthers, AlwaysSucceed)
+
+
+def test_notifications_complete_base_type():
+    assert issubclass(NotificationsComplete, UniformSucceedFail)
+
+
+def test_choose_recipient_base_type():
+    assert issubclass(ChooseRecipient, AlwaysSucceed)
+
+
+def test_remove_recipient_base_type():
+    assert issubclass(RemoveRecipient, AlwaysSucceed)
+
+
+def test_recipient_effort_exceeded_base_type():
+    assert issubclass(RecipientEffortExceeded, AlmostCertainlyFail)
+
+
+def test_policy_compatible_base_type():
+    assert issubclass(PolicyCompatible, ProbablySucceed)
+
+
+def test_find_contact_base_type():
+    assert issubclass(FindContact, UsuallySucceed)
+
+
+def test_rcpt_not_in_qrm_s_base_type():
+    assert issubclass(RcptNotInQrmS, AlmostAlwaysSucceed)
+
+
+def test_set_rcpt_qrm_r_base_type():
+    assert issubclass(SetRcptQrmR, AlwaysSucceed)
+
+
+def test_total_effort_limit_met_base_type():
+    assert issubclass(TotalEffortLimitMet, AlmostAlwaysFail)
+
+
+def test_more_vendors_base_type():
+    assert issubclass(MoreVendors, UsuallyFail)
+
+
+def test_more_coordinators_base_type():
+    assert issubclass(MoreCoordinators, AlmostAlwaysFail)
+
+
+def test_more_others_base_type():
+    assert issubclass(MoreOthers, AlmostAlwaysFail)
+
+
+def test_inject_participant_base_type():
+    assert issubclass(InjectParticipant, AlwaysSucceed)
+
+
+def test_inject_vendor_base_type():
+    assert issubclass(InjectVendor, InjectParticipant)
+
+
+def test_inject_coordinator_base_type():
+    assert issubclass(InjectCoordinator, InjectParticipant)
+
+
+def test_inject_other_base_type():
+    assert issubclass(InjectOther, InjectParticipant)
+
+
+# --- Success-rate tests (WeightedBehavior subclasses only) ---
+
+
+def test_have_report_to_others_capability_success_rate():
+    assert HaveReportToOthersCapability.success_rate == pytest.approx(0.75)
+
+
+def test_all_parties_known_success_rate():
+    assert AllPartiesKnown.success_rate == pytest.approx(0.5)
+
+
+def test_identify_others_success_rate():
+    assert IdentifyOthers.success_rate == pytest.approx(1.0)
+
+
+def test_notifications_complete_success_rate():
+    assert NotificationsComplete.success_rate == pytest.approx(0.5)
+
+
+def test_choose_recipient_success_rate():
+    assert ChooseRecipient.success_rate == pytest.approx(1.0)
+
+
+def test_remove_recipient_success_rate():
+    assert RemoveRecipient.success_rate == pytest.approx(1.0)
+
+
+def test_recipient_effort_exceeded_success_rate():
+    assert RecipientEffortExceeded.success_rate == pytest.approx(7 / 100)
+
+
+def test_policy_compatible_success_rate():
+    assert PolicyCompatible.success_rate == pytest.approx(2 / 3)
+
+
+def test_find_contact_success_rate():
+    assert FindContact.success_rate == pytest.approx(0.75)
+
+
+def test_rcpt_not_in_qrm_s_success_rate():
+    assert RcptNotInQrmS.success_rate == pytest.approx(0.9)
+
+
+def test_set_rcpt_qrm_r_success_rate():
+    assert SetRcptQrmR.success_rate == pytest.approx(1.0)
+
+
+def test_total_effort_limit_met_success_rate():
+    assert TotalEffortLimitMet.success_rate == pytest.approx(0.1)
+
+
+def test_more_vendors_success_rate():
+    assert MoreVendors.success_rate == pytest.approx(0.25)
+
+
+def test_more_coordinators_success_rate():
+    assert MoreCoordinators.success_rate == pytest.approx(0.1)
+
+
+def test_more_others_success_rate():
+    assert MoreOthers.success_rate == pytest.approx(0.1)
+
+
+def test_inject_participant_success_rate():
+    assert InjectParticipant.success_rate == pytest.approx(1.0)
+
+
+def test_inject_vendor_success_rate():
+    assert InjectVendor.success_rate == pytest.approx(1.0)
+
+
+def test_inject_coordinator_success_rate():
+    assert InjectCoordinator.success_rate == pytest.approx(1.0)
+
+
+def test_inject_other_success_rate():
+    assert InjectOther.success_rate == pytest.approx(1.0)
+
+
+# --- SuccessOrRunning nodes never return FAILURE ---
+
+
+def test_identify_vendors_never_fails():
+    """IdentifyVendors (SuccessOrRunning) must never return FAILURE."""
+    node = IdentifyVendors()
+    node.setup()
+    for _ in range(50):
+        status = node.update()
+        assert status != py_trees.common.Status.FAILURE
+
+
+def test_identify_coordinators_never_fails():
+    """IdentifyCoordinators (SuccessOrRunning) must never return FAILURE."""
+    node = IdentifyCoordinators()
+    node.setup()
+    for _ in range(50):
+        status = node.update()
+        assert status != py_trees.common.Status.FAILURE

--- a/vultron/demo/fuzzer/report_management/__init__.py
+++ b/vultron/demo/fuzzer/report_management/__init__.py
@@ -22,6 +22,7 @@ Report Management (RM) workflow, grouped by sub-topic:
 - ``develop_fix`` — fix development nodes (1 node)
 - ``close_report`` — report closure nodes (2 nodes)
 - ``other_work`` — miscellaneous work placeholder (1 node)
+- ``report_to_others`` — report-to-others workflow nodes (21 nodes)
 """
 
 from vultron.demo.fuzzer.report_management.prioritize import (
@@ -52,6 +53,29 @@ from vultron.demo.fuzzer.report_management.close_report import (
 )
 from vultron.demo.fuzzer.report_management.develop_fix import CreateFix
 from vultron.demo.fuzzer.report_management.other_work import OtherWork
+from vultron.demo.fuzzer.report_management.report_to_others import (
+    AllPartiesKnown,
+    ChooseRecipient,
+    FindContact,
+    HaveReportToOthersCapability,
+    IdentifyCoordinators,
+    IdentifyOthers,
+    IdentifyVendors,
+    InjectCoordinator,
+    InjectOther,
+    InjectParticipant,
+    InjectVendor,
+    MoreCoordinators,
+    MoreOthers,
+    MoreVendors,
+    NotificationsComplete,
+    PolicyCompatible,
+    RcptNotInQrmS,
+    RecipientEffortExceeded,
+    RemoveRecipient,
+    SetRcptQrmR,
+    TotalEffortLimitMet,
+)
 
 __all__ = [
     # validation nodes
@@ -80,4 +104,26 @@ __all__ = [
     "PreCloseAction",
     # other work
     "OtherWork",
+    # report-to-others workflow
+    "HaveReportToOthersCapability",
+    "AllPartiesKnown",
+    "IdentifyVendors",
+    "IdentifyCoordinators",
+    "IdentifyOthers",
+    "NotificationsComplete",
+    "ChooseRecipient",
+    "RemoveRecipient",
+    "RecipientEffortExceeded",
+    "PolicyCompatible",
+    "FindContact",
+    "RcptNotInQrmS",
+    "SetRcptQrmR",
+    "TotalEffortLimitMet",
+    "MoreVendors",
+    "MoreCoordinators",
+    "MoreOthers",
+    "InjectParticipant",
+    "InjectVendor",
+    "InjectCoordinator",
+    "InjectOther",
 ]

--- a/vultron/demo/fuzzer/report_management/report_to_others.py
+++ b/vultron/demo/fuzzer/report_management/report_to_others.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python
+#  Copyright (c) 2023-2025 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Report-to-others workflow fuzzer nodes for the Vultron demo layer.
+
+This module provides probabilistic stub ``py_trees`` behaviour nodes for the
+Report Management report-to-others workflow (``MaybeReportToOthers``).  Each
+node represents an external-dependency touchpoint — a human decision,
+environmental check, or system integration hook — that will eventually be
+replaced by production logic.
+
+There are 21 nodes covering: party identification, notification tracking,
+recipient selection, effort limits, policy compatibility, contact lookup,
+RM state management, and participant injection.
+
+Nodes are built on the probabilistic base types in
+``vultron.demo.fuzzer.base`` and satisfy BT-16-003 (named integration-point
+nodes with semantic docstrings) and BT-16-005 (automation-potential
+categorization).
+
+References
+----------
+- Source: ``vultron/bt/report_management/fuzzer/report_to_others.py``
+- Spec: ``specs/behavior-tree-integration.yaml`` BT-16-003, BT-16-004,
+  BT-16-005
+- Notes: ``notes/bt-fuzzer-nodes-report-management.md``
+"""
+
+from __future__ import annotations
+
+from vultron.demo.fuzzer.base import (
+    AlmostAlwaysFail,
+    AlmostAlwaysSucceed,
+    AlmostCertainlyFail,
+    AlwaysSucceed,
+    ProbablySucceed,
+    SuccessOrRunning,
+    UniformSucceedFail,
+    UsuallyFail,
+    UsuallySucceed,
+)
+
+
+class HaveReportToOthersCapability(UsuallySucceed):
+    """Check whether this participant has the capability to notify others.
+
+    Semantic function:
+        Condition — check whether this participant has the capability and
+        mandate to notify other parties about the vulnerability.  In
+        production this is typically a static capability check against
+        the participant's CVD role and organizational policy.
+
+    Input category: Environmental check.
+
+    Success probability: 0.75 (``UsuallySucceed``).
+
+    Automation potential: **High** — static capability and role
+    configuration check; fully automatable as a metadata lookup.
+    """
+
+
+class AllPartiesKnown(UniformSucceedFail):
+    """Check whether all relevant parties for notification have been identified.
+
+    Semantic function:
+        Condition — check whether all relevant parties that should receive
+        notification have been identified.  Modeled as a coin flip in
+        simulation because identification completeness is inherently
+        uncertain.
+
+    Input category: Human decision / Environmental check.
+
+    Success probability: 0.50 (``UniformSucceedFail``).
+
+    Automation potential: **Low** — inherently requires human expert
+    judgment about stakeholder completeness in a specific vulnerability
+    context; hard to automate reliably.
+    """
+
+
+class IdentifyVendors(SuccessOrRunning):
+    """Identify the software vendors responsible for the affected product(s).
+
+    Semantic function:
+        Action — identify the software vendors responsible for the
+        affected product(s) so they can be notified.  Uses
+        ``SuccessOrRunning`` to model that vendor identification may be
+        an ongoing (multi-tick) process; never hard-fails.
+
+    Input category: Human decision / System integration.
+
+    Success probability: 0.50 (``SuccessOrRunning``; never returns
+    FAILURE).
+
+    Automation potential: **Medium** — CPE/product database lookups,
+    SBOM analysis, and NVD product data queries are automatable for known
+    products; novel, multi-vendor, or open-source supply-chain cases
+    benefit from human review.
+    """
+
+
+class IdentifyCoordinators(SuccessOrRunning):
+    """Identify coordinator organizations that should be involved.
+
+    Semantic function:
+        Action — identify any coordinator organizations (e.g., CERT/CC,
+        national CSIRTs) that should be involved in the disclosure.  Uses
+        ``SuccessOrRunning`` to model an ongoing identification process;
+        never hard-fails.
+
+    Input category: Human decision / System integration.
+
+    Success probability: 0.50 (``SuccessOrRunning``; never returns
+    FAILURE).
+
+    Automation potential: **Medium** — FIRST member directory and national
+    CSIRT registry lookups are automatable; routing policy (when to involve
+    a coordinator) may require human judgment.
+    """
+
+
+class IdentifyOthers(AlwaysSucceed):
+    """Identify any other parties (beyond vendors and coordinators) to notify.
+
+    Semantic function:
+        Action — identify any other parties (beyond vendors and
+        coordinators) that should be notified.  Always succeeds in
+        simulation as a stub placeholder.
+
+    Input category: Human decision.
+
+    Success probability: 1.00 (``AlwaysSucceed``).
+
+    Automation potential: **Low** — by definition a catch-all for
+    non-vendor, non-coordinator parties; requires human expert assessment
+    of the specific disclosure context.
+    """
+
+
+class NotificationsComplete(UniformSucceedFail):
+    """Check whether all identified parties have been successfully notified.
+
+    Semantic function:
+        Condition — check whether all identified parties have been
+        successfully notified.  Modeled as a coin flip; in production
+        this is a status check against a notification queue.
+
+    Input category: Environmental check.
+
+    Success probability: 0.50 (``UniformSucceedFail``).
+
+    Automation potential: **High** — notification status tracking against
+    the identified-parties queue; fully automatable.
+    """
+
+
+class ChooseRecipient(AlwaysSucceed):
+    """Select the next recipient from the identified-parties list.
+
+    Semantic function:
+        Action — select the next recipient from the identified-parties
+        list for notification.  Could be fully automated; always succeeds
+        in simulation.
+
+    Input category: System integration.
+
+    Success probability: 1.00 (``AlwaysSucceed``).
+
+    Automation potential: **High** — deterministic queue selection from
+    the identified-parties list; fully automatable.
+    """
+
+
+class RemoveRecipient(AlwaysSucceed):
+    """Remove a recipient from the pending notification queue.
+
+    Semantic function:
+        Action — remove a recipient from the pending notification queue
+        (after successful notification or after effort limits are
+        exceeded).  Always succeeds in simulation.
+
+    Input category: System integration.
+
+    Success probability: 1.00 (``AlwaysSucceed``).
+
+    Automation potential: **High** — queue management operation; fully
+    automatable.
+    """
+
+
+class RecipientEffortExceeded(AlmostCertainlyFail):
+    """Check whether notification effort for a recipient has exceeded a limit.
+
+    Semantic function:
+        Condition — check whether the effort spent trying to notify a
+        specific recipient has exceeded an organizational threshold
+        (e.g., 3 contact attempts, 1 hour of effort).  Rarely triggers
+        in simulation; in production enforces reasonable limits on
+        notification attempts.
+
+    Input category: Environmental check / Human decision.
+
+    Success probability: 0.07 (``AlmostCertainlyFail``).
+
+    Automation potential: **High** — effort counter check against a
+    configurable policy threshold; fully automatable once the threshold
+    policy is defined.
+    """
+
+
+class PolicyCompatible(ProbablySucceed):
+    """Check whether the recipient's disclosure policy is compatible with the case.
+
+    Semantic function:
+        Condition — check whether the potential recipient's
+        disclosure/embargo policy is compatible with the case's current
+        embargo expectations before notifying them.  In production may
+        involve structured policy comparison tooling.
+
+    Input category: Environmental check / Human decision.
+
+    Success probability: 0.67 (``ProbablySucceed``).
+
+    Automation potential: **Medium** — comparison between the recipient's
+    published CVD policy and the case embargo terms is automatable for
+    machine-readable policies (e.g., OpenVEX, structured security.txt);
+    human review needed for ambiguous or informal policies.
+    """
+
+
+class FindContact(UsuallySucceed):
+    """Look up contact information for the chosen recipient.
+
+    Semantic function:
+        Action — look up contact information for the chosen recipient
+        (security email, bug bounty platform, disclosure portal).
+        Succeeds most of the time; may fail for lesser-known vendors
+        with no published security contact.
+
+    Input category: System integration.
+
+    Success probability: 0.75 (``UsuallySucceed``).
+
+    Automation potential: **High** — security.txt lookup, PSIRT directory
+    queries, FIRST member database, and NVD contact data are all
+    automatable for well-known organizations; obscure vendors may require
+    manual research.
+    """
+
+
+class RcptNotInQrmS(AlmostAlwaysSucceed):
+    """Verify the recipient has not already been notified (RM state is START).
+
+    Semantic function:
+        Condition — verify that the recipient has not already been
+        notified (i.e., their RM state is still START / not yet
+        RECEIVED).  Succeeds almost always; guards against duplicate
+        notifications.
+
+    Input category: Environmental check.
+
+    Success probability: 0.90 (``AlmostAlwaysSucceed``).
+
+    Automation potential: **High** — RM state query against the case
+    participant record; fully automatable.
+    """
+
+
+class SetRcptQrmR(AlwaysSucceed):
+    """Record notification by transitioning recipient's RM state to RECEIVED.
+
+    Semantic function:
+        Action — record that the recipient has been notified by
+        transitioning their RM state from START to RECEIVED.  Always
+        succeeds in simulation; in production performs a state update.
+
+    Input category: System integration.
+
+    Success probability: 1.00 (``AlwaysSucceed``).
+
+    Automation potential: **High** — RM state write on the case
+    participant record; fully automatable.
+    """
+
+
+class TotalEffortLimitMet(AlmostAlwaysFail):
+    """Check whether the total notification effort ceiling has been reached.
+
+    Semantic function:
+        Condition — check whether the total effort across all notification
+        attempts has exceeded an organizational ceiling (e.g., 20 hours
+        total).  Rarely triggers in simulation; provides a global stop
+        condition to prevent unbounded notification effort.
+
+    Input category: Environmental check / Human decision.
+
+    Success probability: 0.10 (``AlmostAlwaysFail``).
+
+    Automation potential: **High** — aggregate effort counter check
+    against a configurable policy ceiling; fully automatable.
+    """
+
+
+class MoreVendors(UsuallyFail):
+    """Check whether there are more vendors in the notification queue.
+
+    Semantic function:
+        Condition — check whether there are more vendor parties in the
+        identified-but-not-yet-notified queue.  Fails most of the time
+        in simulation because the vendor list is usually short.
+
+    Input category: Environmental check.
+
+    Success probability: 0.25 (``UsuallyFail``).
+
+    Automation potential: **High** — query against the vendor
+    notification queue; fully automatable.
+    """
+
+
+class MoreCoordinators(AlmostAlwaysFail):
+    """Check whether there are more coordinators pending notification.
+
+    Semantic function:
+        Condition — check whether there are more coordinator parties
+        pending notification.  Fails almost always because the coordinator
+        list is typically short (often zero or one).
+
+    Input category: Environmental check.
+
+    Success probability: 0.10 (``AlmostAlwaysFail``).
+
+    Automation potential: **High** — query against the coordinator
+    notification queue; fully automatable.
+    """
+
+
+class MoreOthers(AlmostAlwaysFail):
+    """Check whether there are more "other" parties pending notification.
+
+    Semantic function:
+        Condition — check whether there are more "other" parties pending
+        notification.  Fails almost always; catch-all category is usually
+        empty.
+
+    Input category: Environmental check.
+
+    Success probability: 0.10 (``AlmostAlwaysFail``).
+
+    Automation potential: **High** — query against the other-parties
+    notification queue; fully automatable.
+    """
+
+
+class InjectParticipant(AlwaysSucceed):
+    """Add a new participant to the case (generic form).
+
+    Semantic function:
+        Action — add a new participant to the case.  This is the generic
+        base node; specialized by ``InjectVendor``,
+        ``InjectCoordinator``, and ``InjectOther`` for role-specific
+        injection.  Always succeeds in simulation; in production
+        performs a case management system write.
+
+    Input category: System integration.
+
+    Success probability: 1.00 (``AlwaysSucceed``).
+
+    Automation potential: **High** — case management system write; fully
+    automatable once participant details are known.
+    """
+
+
+class InjectVendor(InjectParticipant):
+    """Add an identified vendor as a participant in the disclosure case.
+
+    Semantic function:
+        Action — add an identified vendor as a participant in the
+        coordinated disclosure case.  Specialization of
+        ``InjectParticipant`` for the vendor role.  Always succeeds in
+        simulation; in production performs a case management system write
+        with vendor role attribution.
+
+    Input category: System integration.
+
+    Success probability: 1.00 (``InjectParticipant`` / ``AlwaysSucceed``).
+
+    Automation potential: **High** — case management system write for
+    vendor role; fully automatable.
+    """
+
+
+class InjectCoordinator(InjectParticipant):
+    """Add an identified coordinator as a participant in the disclosure case.
+
+    Semantic function:
+        Action — add an identified coordinator as a participant in the
+        coordinated disclosure case.  Specialization of
+        ``InjectParticipant`` for the coordinator role.  Always succeeds
+        in simulation; in production performs a case management system
+        write with coordinator role attribution.
+
+    Input category: System integration.
+
+    Success probability: 1.00 (``InjectParticipant`` / ``AlwaysSucceed``).
+
+    Automation potential: **High** — case management system write for
+    coordinator role; fully automatable.
+    """
+
+
+class InjectOther(InjectParticipant):
+    """Add any other identified party as a participant in the disclosure case.
+
+    Semantic function:
+        Action — add any other identified party as a participant in the
+        coordinated disclosure case.  Specialization of
+        ``InjectParticipant`` for the other-party role.  Always succeeds
+        in simulation; in production performs a case management system
+        write with other-party role attribution.
+
+    Input category: System integration.
+
+    Success probability: 1.00 (``InjectParticipant`` / ``AlwaysSucceed``).
+
+    Automation potential: **High** — case management system write for
+    other-party role; fully automatable.
+    """


### PR DESCRIPTION
- Closes #866

## Summary

Ports 21 report-to-others workflow fuzzer nodes from the legacy
`vultron/bt/` layer to `vultron/demo/fuzzer/report_management/report_to_others.py`
using py_trees class inheritance on the probabilistic base types from FUZZ-01.

## Changes

- `vultron/demo/fuzzer/report_management/report_to_others.py`: New module with
  all 21 nodes (HaveReportToOthersCapability, AllPartiesKnown, IdentifyVendors,
  IdentifyCoordinators, IdentifyOthers, NotificationsComplete, ChooseRecipient,
  RemoveRecipient, RecipientEffortExceeded, PolicyCompatible, FindContact,
  RcptNotInQrmS, SetRcptQrmR, TotalEffortLimitMet, MoreVendors, MoreCoordinators,
  MoreOthers, InjectParticipant, InjectVendor, InjectCoordinator, InjectOther).
  InjectVendor/InjectCoordinator/InjectOther inherit from InjectParticipant.
  IdentifyVendors/IdentifyCoordinators use SuccessOrRunning (never FAILURE).
  Each node has a semantic docstring with Automation potential per BT-16-003.
- `vultron/demo/fuzzer/report_management/__init__.py`: Exports all 21 new nodes.
- `test/fuzzer/report_management/test_report_to_others.py`: 147 unit tests
  covering behaviour isinstance checks, docstrings, naming, update() status
  validity, base-type assertions, success-rate assertions, and
  SuccessOrRunning never-FAILURE invariant.

## Verification

- All 4310 unit + integration tests pass (147 new), 37 skipped, 5 xfailed
- Black, flake8, mypy, pyright clean