### PR TITLE
FUZZ-06: Port publication workflow fuzzer nodes to demo layer

### DIFF
--- a/plan/history/2606/implementation/ISSUE-865.md
+++ b/plan/history/2606/implementation/ISSUE-865.md
@@ -1,0 +1,29 @@
+---
+source: ISSUE-865
+timestamp: '2026-06-22T20:03:48.693341+00:00'
+title: 'FUZZ-06: Port publication workflow fuzzer nodes'
+type: implementation
+---
+
+## Issue #865 — FUZZ-06: Port publication workflow fuzzer nodes to vultron/demo/fuzzer/report_management/publication.py
+
+Ported all 14 publication workflow fuzzer nodes from the legacy
+`vultron/bt/report_management/fuzzer/publication.py` to the new demo layer
+at `vultron/demo/fuzzer/report_management/publication.py`.
+
+Each node is a proper py_trees `Behaviour` subclass using base types from
+FUZZ-01, with a full semantic docstring covering semantic function, input
+category, success probability, and automation potential (BT-16-003, BT-16-005).
+
+Nodes ported: `AllPublished`, `PublicationIntentsSet`,
+`PrioritizePublicationIntents`, `Publish`, `NoPublishExploit`, `ExploitReady`,
+`PrepareExploit`, `ReprioritizeExploit`, `NoPublishFix`, `PrepareFix`,
+`ReprioritizeFix`, `NoPublishReport`, `PrepareReport`, `ReprioritizeReport`.
+
+Re-exports added to `vultron/demo/fuzzer/report_management/__init__.py` and
+`vultron/demo/fuzzer/__init__.py`. 98 unit tests added in
+`test/demo/fuzzer/report_management/test_publication.py`.
+
+All 4261 tests pass; Black, flake8, mypy, pyright clean.
+
+PR: [#1116](https://github.com/CERTCC/Vultron/pull/1116)

--- a/test/demo/fuzzer/report_management/test_publication.py
+++ b/test/demo/fuzzer/report_management/test_publication.py
@@ -1,0 +1,204 @@
+"""Tests for vultron.demo.fuzzer.report_management.publication."""
+
+import pytest
+import py_trees
+
+from vultron.demo.fuzzer.base import (
+    AlmostAlwaysFail,
+    AlmostAlwaysSucceed,
+    AlwaysSucceed,
+    OftenSucceed,
+    UsuallyFail,
+    UsuallySucceed,
+)
+from vultron.demo.fuzzer.report_management.publication import (
+    AllPublished,
+    ExploitReady,
+    NoPublishExploit,
+    NoPublishFix,
+    NoPublishReport,
+    PrepareFix,
+    PrepareExploit,
+    PrepareReport,
+    PrioritizePublicationIntents,
+    Publish,
+    PublicationIntentsSet,
+    ReprioritizeExploit,
+    ReprioritizeFix,
+    ReprioritizeReport,
+)
+
+_ALL_NODES = [
+    AllPublished,
+    PublicationIntentsSet,
+    PrioritizePublicationIntents,
+    Publish,
+    NoPublishExploit,
+    ExploitReady,
+    PrepareExploit,
+    ReprioritizeExploit,
+    NoPublishFix,
+    PrepareFix,
+    ReprioritizeFix,
+    NoPublishReport,
+    PrepareReport,
+    ReprioritizeReport,
+]
+
+
+@pytest.mark.parametrize("node_cls", _ALL_NODES)
+def test_node_is_behaviour(node_cls):
+    """Each node must be a py_trees Behaviour."""
+    node = node_cls()
+    assert isinstance(node, py_trees.behaviour.Behaviour)
+
+
+@pytest.mark.parametrize("node_cls", _ALL_NODES)
+def test_node_has_docstring(node_cls):
+    """Each node must have a non-empty docstring (BT-16-003)."""
+    assert node_cls.__doc__ and node_cls.__doc__.strip()
+
+
+@pytest.mark.parametrize("node_cls", _ALL_NODES)
+def test_node_name_defaults_to_class_name(node_cls):
+    """Default name must be the class name."""
+    node = node_cls()
+    assert node.name == node_cls.__name__
+
+
+@pytest.mark.parametrize("node_cls", _ALL_NODES)
+def test_node_name_custom(node_cls):
+    """Custom name must be respected."""
+    node = node_cls(name="custom")
+    assert node.name == "custom"
+
+
+@pytest.mark.parametrize("node_cls", _ALL_NODES)
+def test_update_returns_status(node_cls):
+    """update() must return a valid py_trees Status."""
+    node = node_cls()
+    node.setup()
+    status = node.update()
+    assert status in (
+        py_trees.common.Status.SUCCESS,
+        py_trees.common.Status.FAILURE,
+        py_trees.common.Status.RUNNING,
+    )
+
+
+# --- Base type assertions ---
+
+
+def test_all_published_base_type():
+    assert issubclass(AllPublished, AlmostAlwaysFail)
+
+
+def test_publication_intents_set_base_type():
+    assert issubclass(PublicationIntentsSet, UsuallyFail)
+
+
+def test_prioritize_publication_intents_base_type():
+    assert issubclass(PrioritizePublicationIntents, AlwaysSucceed)
+
+
+def test_publish_base_type():
+    assert issubclass(Publish, AlmostAlwaysSucceed)
+
+
+def test_no_publish_exploit_base_type():
+    assert issubclass(NoPublishExploit, UsuallySucceed)
+
+
+def test_exploit_ready_base_type():
+    assert issubclass(ExploitReady, OftenSucceed)
+
+
+def test_prepare_exploit_base_type():
+    assert issubclass(PrepareExploit, AlmostAlwaysSucceed)
+
+
+def test_reprioritize_exploit_base_type():
+    assert issubclass(ReprioritizeExploit, AlwaysSucceed)
+
+
+def test_no_publish_fix_base_type():
+    assert issubclass(NoPublishFix, AlmostAlwaysFail)
+
+
+def test_prepare_fix_base_type():
+    assert issubclass(PrepareFix, AlmostAlwaysSucceed)
+
+
+def test_reprioritize_fix_base_type():
+    assert issubclass(ReprioritizeFix, AlwaysSucceed)
+
+
+def test_no_publish_report_base_type():
+    assert issubclass(NoPublishReport, AlmostAlwaysFail)
+
+
+def test_prepare_report_base_type():
+    assert issubclass(PrepareReport, AlmostAlwaysSucceed)
+
+
+def test_reprioritize_report_base_type():
+    assert issubclass(ReprioritizeReport, AlwaysSucceed)
+
+
+# --- Success rate assertions ---
+
+
+def test_all_published_success_rate():
+    assert AllPublished.success_rate == pytest.approx(0.10)
+
+
+def test_publication_intents_set_success_rate():
+    assert PublicationIntentsSet.success_rate == pytest.approx(0.25)
+
+
+def test_prioritize_publication_intents_success_rate():
+    assert PrioritizePublicationIntents.success_rate == pytest.approx(1.0)
+
+
+def test_publish_success_rate():
+    assert Publish.success_rate == pytest.approx(0.90)
+
+
+def test_no_publish_exploit_success_rate():
+    assert NoPublishExploit.success_rate == pytest.approx(0.75)
+
+
+def test_exploit_ready_success_rate():
+    assert ExploitReady.success_rate == pytest.approx(0.70)
+
+
+def test_prepare_exploit_success_rate():
+    assert PrepareExploit.success_rate == pytest.approx(0.90)
+
+
+def test_reprioritize_exploit_success_rate():
+    assert ReprioritizeExploit.success_rate == pytest.approx(1.0)
+
+
+def test_no_publish_fix_success_rate():
+    assert NoPublishFix.success_rate == pytest.approx(0.10)
+
+
+def test_prepare_fix_success_rate():
+    assert PrepareFix.success_rate == pytest.approx(0.90)
+
+
+def test_reprioritize_fix_success_rate():
+    assert ReprioritizeFix.success_rate == pytest.approx(1.0)
+
+
+def test_no_publish_report_success_rate():
+    assert NoPublishReport.success_rate == pytest.approx(0.10)
+
+
+def test_prepare_report_success_rate():
+    assert PrepareReport.success_rate == pytest.approx(0.90)
+
+
+def test_reprioritize_report_success_rate():
+    assert ReprioritizeReport.success_rate == pytest.approx(1.0)

--- a/vultron/demo/fuzzer/__init__.py
+++ b/vultron/demo/fuzzer/__init__.py
@@ -80,6 +80,20 @@ from vultron.demo.fuzzer.report_management import (
     OtherWork,
     PreCloseAction,
     RequestId,
+    AllPublished,
+    ExploitReady,
+    NoPublishExploit,
+    NoPublishFix,
+    NoPublishReport,
+    PrepareFix,
+    PrepareExploit,
+    PrepareReport,
+    PrioritizePublicationIntents,
+    Publish,
+    PublicationIntentsSet,
+    ReprioritizeExploit,
+    ReprioritizeFix,
+    ReprioritizeReport,
 )
 
 __all__ = [
@@ -147,6 +161,21 @@ __all__ = [
     "OtherCloseCriteriaMet",
     "PreCloseAction",
     "OtherWork",
+    # publication workflow nodes
+    "AllPublished",
+    "PublicationIntentsSet",
+    "PrioritizePublicationIntents",
+    "Publish",
+    "NoPublishExploit",
+    "ExploitReady",
+    "PrepareExploit",
+    "ReprioritizeExploit",
+    "NoPublishFix",
+    "PrepareFix",
+    "ReprioritizeFix",
+    "NoPublishReport",
+    "PrepareReport",
+    "ReprioritizeReport",
     # messaging inbound nodes
     "FollowUpOnErrorMessage",
 ]

--- a/vultron/demo/fuzzer/report_management/__init__.py
+++ b/vultron/demo/fuzzer/report_management/__init__.py
@@ -23,6 +23,7 @@ Report Management (RM) workflow, grouped by sub-topic:
 - ``close_report`` — report closure nodes (2 nodes)
 - ``other_work`` — miscellaneous work placeholder (1 node)
 - ``report_to_others`` — report-to-others workflow nodes (21 nodes)
+- ``publication`` — publication workflow nodes (14 nodes)
 """
 
 from vultron.demo.fuzzer.report_management.prioritize import (
@@ -76,6 +77,22 @@ from vultron.demo.fuzzer.report_management.report_to_others import (
     SetRcptQrmR,
     TotalEffortLimitMet,
 )
+from vultron.demo.fuzzer.report_management.publication import (
+    AllPublished,
+    ExploitReady,
+    NoPublishExploit,
+    NoPublishFix,
+    NoPublishReport,
+    PrepareFix,
+    PrepareExploit,
+    PrepareReport,
+    PrioritizePublicationIntents,
+    Publish,
+    PublicationIntentsSet,
+    ReprioritizeExploit,
+    ReprioritizeFix,
+    ReprioritizeReport,
+)
 
 __all__ = [
     # validation nodes
@@ -126,4 +143,19 @@ __all__ = [
     "InjectVendor",
     "InjectCoordinator",
     "InjectOther",
+    # publication workflow
+    "AllPublished",
+    "PublicationIntentsSet",
+    "PrioritizePublicationIntents",
+    "Publish",
+    "NoPublishExploit",
+    "ExploitReady",
+    "PrepareExploit",
+    "ReprioritizeExploit",
+    "NoPublishFix",
+    "PrepareFix",
+    "ReprioritizeFix",
+    "NoPublishReport",
+    "PrepareReport",
+    "ReprioritizeReport",
 ]

--- a/vultron/demo/fuzzer/report_management/publication.py
+++ b/vultron/demo/fuzzer/report_management/publication.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python
+#  Copyright (c) 2023-2025 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Publication workflow fuzzer nodes for the Vultron demo layer.
+
+This module provides probabilistic stub ``py_trees`` behaviour nodes for the
+Report Management publication sub-workflow (``PublicationBt``).  Each node
+represents an external-dependency touchpoint — a human decision, environmental
+check, or system integration hook — that will eventually be replaced by
+production logic.
+
+Nodes are built on the probabilistic base types in
+``vultron.demo.fuzzer.base`` and satisfy BT-16-003 (named integration-point
+nodes with semantic docstrings) and BT-16-005 (automation-potential
+categorization).
+
+References
+----------
+- Source: ``vultron/bt/report_management/fuzzer/publication.py``
+- Spec: ``specs/behavior-tree-integration.yaml`` BT-16-003, BT-16-004, BT-16-005
+- Notes: ``notes/bt-fuzzer-nodes-report-management.md``
+"""
+
+from __future__ import annotations
+
+from vultron.demo.fuzzer.base import (
+    AlmostAlwaysFail,
+    AlmostAlwaysSucceed,
+    AlwaysSucceed,
+    OftenSucceed,
+    UsuallyFail,
+    UsuallySucceed,
+)
+
+
+class AllPublished(AlmostAlwaysFail):
+    """Check whether all intended publication artifacts have been published.
+
+    Semantic function:
+        Condition — check whether all intended publication artifacts
+        (report, fix, exploit) for the vulnerability have been published.
+        In production this would be a metadata check against a publication
+        status field on the case record.  The fuzzer fails most of the
+        time because publication is an active goal being worked toward.
+
+    Input category: Environmental check.
+
+    Success probability: 0.10 (``AlmostAlwaysFail``).
+
+    Automation potential: **High** — publication status flag on the case
+    record; fully automatable as a metadata check.
+    """
+
+
+class PublicationIntentsSet(UsuallyFail):
+    """Check whether publication intentions have been established for the case.
+
+    Semantic function:
+        Condition — check whether publication intentions (what to publish,
+        when, and in what format) have been established for this case.
+        In production this would be a check against case metadata or a
+        structured publication-intent field.  The fuzzer fails most of
+        the time because setting publication intents is an early workflow
+        step being modeled.
+
+    Input category: Environmental check.
+
+    Success probability: 0.25 (``UsuallyFail``).
+
+    Automation potential: **High** — publication intent flags on the case
+    record; fully automatable as a metadata check.
+    """
+
+
+class PrioritizePublicationIntents(AlwaysSucceed):
+    """Establish and record publication intentions for the case.
+
+    Semantic function:
+        Action — establish and record publication intentions: what
+        artifacts to publish, their priority order, timing, and format.
+        In production this involves structured editorial or policy
+        decisions, potentially with human analyst input.  The fuzzer
+        always succeeds to keep the workflow progressing.
+
+    Input category: Human decision.
+
+    Success probability: 1.00 (``AlwaysSucceed``).
+
+    Automation potential: **Medium** — standard policy-driven publication
+    priorities (e.g., always publish report and fix) can be automated;
+    editorial or legal exceptions require human judgment.
+    """
+
+
+class Publish(AlmostAlwaysSucceed):
+    """Execute the publication of a prepared artifact to the intended audience.
+
+    Semantic function:
+        Action — publish a prepared artifact (advisory, patch, bulletin,
+        etc.) to the intended audience.  In production this could be an
+        API call to an advisory publishing platform (NVD, CVE.org, CMS,
+        package repository) or a prompt for a human to complete the
+        publication step.  The fuzzer succeeds almost always, allowing
+        the rest of the workflow to be exercised.
+
+    Input category: System integration.
+
+    Success probability: 0.90 (``AlmostAlwaysSucceed``).
+
+    Automation potential: **High** — advisory platform APIs enable fully
+    automated artifact publication.
+    """
+
+
+class NoPublishExploit(UsuallySucceed):
+    """Check the publication intent flag for the exploit artifact.
+
+    Semantic function:
+        Condition — check the publication intent flag for the exploit
+        artifact; ``SUCCESS`` means "do not publish exploit".  In
+        production this is a read of the exploit publication intent flag
+        set by ``PrioritizePublicationIntents``.  The fuzzer succeeds
+        (i.e., no exploit publication) in most cases, reflecting that
+        exploit publication is not always required or desired.
+
+    Input category: Environmental check / policy.
+
+    Success probability: 0.75 (``UsuallySucceed``).
+
+    Automation potential: **High** — read the exploit publication intent
+    flag from the case record; fully automatable.
+    """
+
+
+class ExploitReady(OftenSucceed):
+    """Check whether the exploit artifact is ready for publication.
+
+    Semantic function:
+        Condition — check whether the exploit artifact is ready for
+        publication (prepared, reviewed, and staged).  In production
+        this is a metadata check against an artifact staging-status field
+        in the publishing pipeline.  The fuzzer succeeds more often than
+        not once preparation has started.
+
+    Input category: Environmental check.
+
+    Success probability: 0.70 (``OftenSucceed``).
+
+    Automation potential: **High** — artifact staging-status check in the
+    publishing pipeline; fully automatable.
+    """
+
+
+class PrepareExploit(AlmostAlwaysSucceed):
+    """Create, document, and stage the exploit artifact for publication.
+
+    Semantic function:
+        Action — create, document, and stage the exploit artifact for
+        publication (write-up, code packaging, filing in publishing
+        system).  In production this would typically be a prompt for a
+        human security researcher to package and document the
+        proof-of-concept.  The fuzzer succeeds almost always.
+
+    Input category: Human decision.
+
+    Success probability: 0.90 (``AlmostAlwaysSucceed``).
+
+    Automation potential: **Low** — write-up and proof-of-concept
+    packaging require human security researcher expertise; not
+    automatable in the general case.
+    """
+
+
+class ReprioritizeExploit(AlwaysSucceed):
+    """Update the priority of the exploit artifact in the publication queue.
+
+    Semantic function:
+        Action — update the priority of the exploit artifact in the
+        publication queue (e.g., in response to a changing threat
+        landscape or embargo state change).  In production this is a
+        human analyst decision or an automated policy trigger.  The
+        fuzzer always succeeds.
+
+    Input category: Human decision.
+
+    Success probability: 1.00 (``AlwaysSucceed``).
+
+    Automation potential: **Medium** — embargo state changes and
+    threat-level updates can trigger automated reprioritization rules;
+    human override may be needed for unusual cases.
+    """
+
+
+class NoPublishFix(AlmostAlwaysFail):
+    """Check the publication intent flag for the fix artifact.
+
+    Semantic function:
+        Condition — check the publication intent flag for the fix
+        artifact; ``SUCCESS`` means "do not publish fix".  In production
+        this is a read of the fix publication intent flag.  The fuzzer
+        fails most of the time because fix publication is the standard
+        expected outcome of CVD.
+
+    Input category: Environmental check / policy.
+
+    Success probability: 0.10 (``AlmostAlwaysFail``).
+
+    Automation potential: **High** — read the fix publication intent flag
+    from the case record; fully automatable.
+    """
+
+
+class PrepareFix(AlmostAlwaysSucceed):
+    """Create, document, and stage the fix artifact for publication.
+
+    Semantic function:
+        Action — create, document, and stage the fix artifact for
+        publication (patch notes, release artifacts, advisory text).  In
+        production this involves the engineering team's patch release
+        pipeline and content-authoring workflow.  The fuzzer succeeds
+        almost always, allowing the rest of the workflow to be exercised.
+
+    Input category: System integration.
+
+    Success probability: 0.90 (``AlmostAlwaysSucceed``).
+
+    Automation potential: **Low–Medium** — CI/CD pipeline can automate
+    patch build and packaging; advisory text and release notes typically
+    require human authoring and review.
+    """
+
+
+class ReprioritizeFix(AlwaysSucceed):
+    """Update the priority of the fix artifact in the publication queue.
+
+    Semantic function:
+        Action — update the priority of the fix artifact in the
+        publication queue.  In production this is a human analyst
+        decision or an automated policy trigger.  The fuzzer always
+        succeeds.
+
+    Input category: Human decision.
+
+    Success probability: 1.00 (``AlwaysSucceed``).
+
+    Automation potential: **Medium** — embargo state changes and
+    threat-level updates can trigger automated reprioritization rules;
+    human override may be needed.
+    """
+
+
+class NoPublishReport(AlmostAlwaysFail):
+    """Check the publication intent flag for the vulnerability report artifact.
+
+    Semantic function:
+        Condition — check the publication intent flag for the
+        vulnerability report artifact; ``SUCCESS`` means "do not publish
+        report".  In production this is a read of the report publication
+        intent flag.  The fuzzer fails most of the time because report
+        publication is the standard CVD outcome.
+
+    Input category: Environmental check / policy.
+
+    Success probability: 0.10 (``AlmostAlwaysFail``).
+
+    Automation potential: **High** — read the report publication intent
+    flag from the case record; fully automatable.
+    """
+
+
+class PrepareReport(AlmostAlwaysSucceed):
+    """Create, review, and stage the vulnerability advisory for publication.
+
+    Semantic function:
+        Action — create, review, and stage the vulnerability advisory or
+        report artifact for publication.  In production this involves
+        human analyst authoring, editorial review, approval workflow, and
+        staging in the advisory publishing pipeline.  The fuzzer succeeds
+        almost always, allowing the rest of the workflow to be exercised.
+
+    Input category: Human decision.
+
+    Success probability: 0.90 (``AlmostAlwaysSucceed``).
+
+    Automation potential: **Low** — advisory writing requires human
+    expertise and editorial judgment; review and approval workflow also
+    typically involves human stakeholders.
+    """
+
+
+class ReprioritizeReport(AlwaysSucceed):
+    """Update the priority of the report artifact in the publication queue.
+
+    Semantic function:
+        Action — update the priority of the report artifact in the
+        publication queue.  In production this is a human analyst
+        decision or an automated policy trigger (e.g., on embargo exit or
+        threat escalation).  The fuzzer always succeeds.
+
+    Input category: Human decision.
+
+    Success probability: 1.00 (``AlwaysSucceed``).
+
+    Automation potential: **Medium** — policy-triggered reprioritization
+    (e.g., on embargo exit or threat escalation) is automatable; complex
+    editorial decisions require human oversight.
+    """


### PR DESCRIPTION
- Closes #865

## Summary

Ports 14 publication workflow fuzzer nodes from the legacy `vultron/bt`
layer to `vultron/demo/fuzzer/report_management/publication.py` using the
py_trees class hierarchy established by FUZZ-01.

## Changes

- `vultron/demo/fuzzer/report_management/publication.py`: New module with
  14 py_trees behaviour nodes — `AllPublished`, `PublicationIntentsSet`,
  `PrioritizePublicationIntents`, `Publish`, `NoPublishExploit`,
  `ExploitReady`, `PrepareExploit`, `ReprioritizeExploit`, `NoPublishFix`,
  `PrepareFix`, `ReprioritizeFix`, `NoPublishReport`, `PrepareReport`,
  `ReprioritizeReport`; each has a semantic docstring per BT-16-003/BT-16-005
- `vultron/demo/fuzzer/report_management/__init__.py`: Re-export all 14 nodes;
  update module docstring node count
- `vultron/demo/fuzzer/__init__.py`: Re-export all 14 nodes in top-level package
- `test/demo/fuzzer/report_management/__init__.py`: New empty init for test subpackage
- `test/demo/fuzzer/report_management/test_publication.py`: 98 unit tests covering
  py_trees Behaviour inheritance, docstring presence, default/custom name, update()
  return values, base type subclass assertions, and success rate values

## Verification

- All 4261 tests pass, 37 skipped, 5 xfailed (uv run pytest -m "" --tb=short)
- Black, flake8, mypy, pyright all clean