### PR TITLE
feat(fuzz-05): port fix-deployment, threat-monitoring, and exploit-acquisition fuzzer nodes

### DIFF
--- a/plan/history/2606/implementation/ISSUE-864.md
+++ b/plan/history/2606/implementation/ISSUE-864.md
@@ -1,0 +1,30 @@
+---
+source: ISSUE-864
+timestamp: '2026-06-22T20:09:26.792663+00:00'
+title: 'FUZZ-05: Port fix-deployment, threat-monitoring, exploit-acquisition fuzzer
+  nodes'
+type: implementation
+---
+
+## Issue #864 — FUZZ-05: Port fix deployment, threat monitoring, and exploit acquisition fuzzer nodes
+
+Ported 20 probabilistic stub py_trees nodes across three new modules for
+the Report Management fuzzer demo layer (Epic #427):
+
+- `vultron/demo/fuzzer/report_management/deploy_fix.py` — 8 nodes
+  (`NoNewDeploymentInfo`, `PrioritizeDeployment`, `MitigationDeployed`,
+  `MitigationAvailable`, `DeployMitigation`, `MonitoringRequirement`,
+  `MonitorDeployment`, `DeployFix`)
+- `vultron/demo/fuzzer/report_management/monitor_threats.py` — 4 nodes
+  (`MonitorAttacks`, `MonitorExploits`, `MonitorPublicReports`, `NoThreatsFound`)
+- `vultron/demo/fuzzer/report_management/acquire_exploit.py` — 8 nodes
+  (`HaveExploit`, `ExploitDeferred`, `ExploitPrioritySet`,
+  `EvaluateExploitPriority`, `ExploitDesired`, `FindExploit`,
+  `DevelopExploit`, `PurchaseExploit`)
+
+Each node subclasses a `WeightedBehavior` base type and carries a
+BT-16-003/BT-16-005-compliant docstring. 283 new parametric tests verify
+inheritance, docstring completeness, and empirical success-rate distribution.
+All 4446 tests pass; all linters clean.
+
+PR: [#1117](https://github.com/CERTCC/Vultron/pull/1117)

--- a/test/fuzzer/report_management/test_acquire_exploit.py
+++ b/test/fuzzer/report_management/test_acquire_exploit.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python
+#  Copyright (c) 2023-2025 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Unit tests for vultron/demo/fuzzer/report_management/acquire_exploit.py.
+
+Tests cover:
+  - AC-1: All nodes use correct py_trees WeightedBehavior base types (BT-16-004)
+  - AC-2: All nodes have docstrings with required sections (BT-16-003)
+  - AC-3: Unit tests cover each node's success_rate and status distribution
+"""
+
+from typing import Type
+
+import py_trees
+import pytest
+from py_trees.common import Status
+
+from vultron.demo.fuzzer.base import (
+    AlmostAlwaysFail,
+    AlmostAlwaysSucceed,
+    AlwaysSucceed,
+    OftenFail,
+    OftenSucceed,
+    RarelySucceed,
+    UsuallyFail,
+    WeightedBehavior,
+)
+from vultron.demo.fuzzer.report_management.acquire_exploit import (
+    DevelopExploit,
+    EvaluateExploitPriority,
+    ExploitDeferred,
+    ExploitDesired,
+    ExploitPrioritySet,
+    FindExploit,
+    HaveExploit,
+    PurchaseExploit,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_TRIALS = 10_000
+_TOLERANCE = 0.03  # ±3 percentage points
+
+# (node_class, expected_base_type, expected_success_rate)
+_NODE_SPECS = [
+    (HaveExploit, UsuallyFail, 1.0 / 4.0),
+    (ExploitDeferred, OftenSucceed, 7.0 / 10.0),
+    (ExploitPrioritySet, AlmostAlwaysSucceed, 9.0 / 10.0),
+    (EvaluateExploitPriority, AlwaysSucceed, 1.0),
+    (ExploitDesired, OftenFail, 3.0 / 10.0),
+    (FindExploit, AlmostAlwaysFail, 1.0 / 10.0),
+    (DevelopExploit, OftenSucceed, 7.0 / 10.0),
+    (PurchaseExploit, RarelySucceed, 1.0 / 10.0),
+]
+
+_ALL_NODES = [spec[0] for spec in _NODE_SPECS]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_trials(node_cls: "Type[WeightedBehavior]", n: int = _TRIALS) -> float:
+    """Return empirical success rate over *n* independent ticks."""
+    node = node_cls()
+    successes = sum(1 for _ in range(n) if node.update() == Status.SUCCESS)
+    return successes / n
+
+
+# ---------------------------------------------------------------------------
+# AC-1: Node inheritance and py_trees compliance
+# ---------------------------------------------------------------------------
+
+
+class TestNodeIsWeightedBehavior:
+    @pytest.mark.parametrize("node_cls", _ALL_NODES)
+    def test_is_weighted_behavior_subclass(
+        self, node_cls: Type[WeightedBehavior]
+    ) -> None:
+        assert issubclass(node_cls, WeightedBehavior)
+
+    @pytest.mark.parametrize("node_cls", _ALL_NODES)
+    def test_is_py_trees_behaviour(
+        self, node_cls: Type[WeightedBehavior]
+    ) -> None:
+        assert isinstance(node_cls(), py_trees.behaviour.Behaviour)
+
+    @pytest.mark.parametrize("node_cls", _ALL_NODES)
+    def test_default_name_is_class_name(
+        self, node_cls: Type[WeightedBehavior]
+    ) -> None:
+        assert node_cls().name == node_cls.__name__
+
+    @pytest.mark.parametrize("node_cls", _ALL_NODES)
+    def test_custom_name_respected(
+        self, node_cls: Type[WeightedBehavior]
+    ) -> None:
+        assert node_cls(name="custom").name == "custom"
+
+    def test_node_count(self) -> None:
+        assert len(_ALL_NODES) == 8
+
+    @pytest.mark.parametrize("node_cls, expected_base, _", _NODE_SPECS)
+    def test_base_type(
+        self, node_cls: Type[WeightedBehavior], expected_base: type, _: float
+    ) -> None:
+        assert issubclass(node_cls, expected_base)
+
+
+# ---------------------------------------------------------------------------
+# AC-2: Docstring completeness (BT-16-003, BT-16-005)
+# ---------------------------------------------------------------------------
+
+_REQUIRED_SECTIONS = [
+    "semantic function",
+    "input category",
+    "success probability",
+    "automation potential",
+]
+
+
+class TestDocstrings:
+    @pytest.mark.parametrize("node_cls", _ALL_NODES)
+    def test_has_non_empty_docstring(
+        self, node_cls: Type[WeightedBehavior]
+    ) -> None:
+        doc = node_cls.__doc__ or ""
+        assert len(doc.strip()) > 0
+
+    @pytest.mark.parametrize("node_cls", _ALL_NODES)
+    @pytest.mark.parametrize("section", _REQUIRED_SECTIONS)
+    def test_docstring_has_required_section(
+        self, node_cls: Type[WeightedBehavior], section: str
+    ) -> None:
+        doc = (node_cls.__doc__ or "").lower()
+        assert (
+            section in doc
+        ), f"{node_cls.__name__} docstring missing '{section}' section"
+
+
+# ---------------------------------------------------------------------------
+# AC-3: success_rate attribute and status distribution
+# ---------------------------------------------------------------------------
+
+
+class TestSuccessRates:
+    @pytest.mark.parametrize("node_cls, _, expected_rate", _NODE_SPECS)
+    def test_success_rate_attribute(
+        self,
+        node_cls: Type[WeightedBehavior],
+        _: Type[WeightedBehavior],
+        expected_rate: float,
+    ) -> None:
+        assert abs(node_cls.success_rate - expected_rate) < 1e-9
+
+    @pytest.mark.parametrize("node_cls", _ALL_NODES)
+    def test_update_returns_valid_status(
+        self, node_cls: Type[WeightedBehavior]
+    ) -> None:
+        node = node_cls()
+        result = node.update()
+        assert result in (Status.SUCCESS, Status.FAILURE)
+
+    @pytest.mark.parametrize("node_cls", _ALL_NODES)
+    def test_update_never_returns_running(
+        self, node_cls: Type[WeightedBehavior]
+    ) -> None:
+        node = node_cls()
+        results = {node.update() for _ in range(50)}
+        assert Status.RUNNING not in results
+
+    @pytest.mark.parametrize("node_cls, _, expected_rate", _NODE_SPECS)
+    def test_empirical_distribution(
+        self,
+        node_cls: Type[WeightedBehavior],
+        _: Type[WeightedBehavior],
+        expected_rate: float,
+    ) -> None:
+        # AlwaysSucceed is deterministic — verify directly instead of statistically
+        if expected_rate == 1.0:
+            assert node_cls().update() == Status.SUCCESS
+            return
+        rate = _run_trials(node_cls)
+        assert (
+            abs(rate - expected_rate) < _TOLERANCE
+        ), f"{node_cls.__name__}: empirical={rate:.4f} expected={expected_rate:.4f}"

--- a/test/fuzzer/report_management/test_deploy_fix.py
+++ b/test/fuzzer/report_management/test_deploy_fix.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python
+#  Copyright (c) 2023-2025 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Unit tests for vultron/demo/fuzzer/report_management/deploy_fix.py.
+
+Tests cover:
+  - AC-1: All nodes use correct py_trees WeightedBehavior base types (BT-16-004)
+  - AC-2: All nodes have docstrings with required sections (BT-16-003)
+  - AC-3: Unit tests cover each node's success_rate and status distribution
+"""
+
+from typing import Type
+
+import py_trees
+import pytest
+from py_trees.common import Status
+
+from vultron.demo.fuzzer.base import (
+    AlmostAlwaysFail,
+    AlmostAlwaysSucceed,
+    AlwaysSucceed,
+    OftenSucceed,
+    UsuallyFail,
+    UsuallySucceed,
+    WeightedBehavior,
+)
+from vultron.demo.fuzzer.report_management.deploy_fix import (
+    DeployFix,
+    DeployMitigation,
+    MitigationAvailable,
+    MitigationDeployed,
+    MonitorDeployment,
+    MonitoringRequirement,
+    NoNewDeploymentInfo,
+    PrioritizeDeployment,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_TRIALS = 10_000
+_TOLERANCE = 0.03  # ±3 percentage points
+
+# (node_class, expected_base_type, expected_success_rate)
+_NODE_SPECS = [
+    (NoNewDeploymentInfo, UsuallySucceed, 3.0 / 4.0),
+    (PrioritizeDeployment, AlmostAlwaysSucceed, 9.0 / 10.0),
+    (MitigationDeployed, UsuallyFail, 1.0 / 4.0),
+    (MitigationAvailable, OftenSucceed, 7.0 / 10.0),
+    (DeployMitigation, UsuallySucceed, 3.0 / 4.0),
+    (MonitoringRequirement, OftenSucceed, 7.0 / 10.0),
+    (MonitorDeployment, AlwaysSucceed, 1.0),
+    (DeployFix, AlmostAlwaysFail, 1.0 / 10.0),
+]
+
+_ALL_NODES = [spec[0] for spec in _NODE_SPECS]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_trials(node_cls: "Type[WeightedBehavior]", n: int = _TRIALS) -> float:
+    """Return empirical success rate over *n* independent ticks."""
+    node = node_cls()
+    successes = sum(1 for _ in range(n) if node.update() == Status.SUCCESS)
+    return successes / n
+
+
+# ---------------------------------------------------------------------------
+# AC-1: Node inheritance and py_trees compliance
+# ---------------------------------------------------------------------------
+
+
+class TestNodeIsWeightedBehavior:
+    @pytest.mark.parametrize("node_cls", _ALL_NODES)
+    def test_is_weighted_behavior_subclass(
+        self, node_cls: Type[WeightedBehavior]
+    ) -> None:
+        assert issubclass(node_cls, WeightedBehavior)
+
+    @pytest.mark.parametrize("node_cls", _ALL_NODES)
+    def test_is_py_trees_behaviour(
+        self, node_cls: Type[WeightedBehavior]
+    ) -> None:
+        assert isinstance(node_cls(), py_trees.behaviour.Behaviour)
+
+    @pytest.mark.parametrize("node_cls", _ALL_NODES)
+    def test_default_name_is_class_name(
+        self, node_cls: Type[WeightedBehavior]
+    ) -> None:
+        assert node_cls().name == node_cls.__name__
+
+    @pytest.mark.parametrize("node_cls", _ALL_NODES)
+    def test_custom_name_respected(
+        self, node_cls: Type[WeightedBehavior]
+    ) -> None:
+        assert node_cls(name="custom").name == "custom"
+
+    def test_node_count(self) -> None:
+        assert len(_ALL_NODES) == 8
+
+    @pytest.mark.parametrize("node_cls, expected_base, _", _NODE_SPECS)
+    def test_base_type(
+        self, node_cls: Type[WeightedBehavior], expected_base: type, _: float
+    ) -> None:
+        assert issubclass(node_cls, expected_base)
+
+
+# ---------------------------------------------------------------------------
+# AC-2: Docstring completeness (BT-16-003, BT-16-005)
+# ---------------------------------------------------------------------------
+
+_REQUIRED_SECTIONS = [
+    "semantic function",
+    "input category",
+    "success probability",
+    "automation potential",
+]
+
+
+class TestDocstrings:
+    @pytest.mark.parametrize("node_cls", _ALL_NODES)
+    def test_has_non_empty_docstring(
+        self, node_cls: Type[WeightedBehavior]
+    ) -> None:
+        doc = node_cls.__doc__ or ""
+        assert len(doc.strip()) > 0
+
+    @pytest.mark.parametrize("node_cls", _ALL_NODES)
+    @pytest.mark.parametrize("section", _REQUIRED_SECTIONS)
+    def test_docstring_has_required_section(
+        self, node_cls: Type[WeightedBehavior], section: str
+    ) -> None:
+        doc = (node_cls.__doc__ or "").lower()
+        assert (
+            section in doc
+        ), f"{node_cls.__name__} docstring missing '{section}' section"
+
+
+# ---------------------------------------------------------------------------
+# AC-3: success_rate attribute and status distribution
+# ---------------------------------------------------------------------------
+
+
+class TestSuccessRates:
+    @pytest.mark.parametrize("node_cls, _, expected_rate", _NODE_SPECS)
+    def test_success_rate_attribute(
+        self,
+        node_cls: Type[WeightedBehavior],
+        _: Type[WeightedBehavior],
+        expected_rate: float,
+    ) -> None:
+        assert abs(node_cls.success_rate - expected_rate) < 1e-9
+
+    @pytest.mark.parametrize("node_cls", _ALL_NODES)
+    def test_update_returns_valid_status(
+        self, node_cls: Type[WeightedBehavior]
+    ) -> None:
+        node = node_cls()
+        result = node.update()
+        assert result in (Status.SUCCESS, Status.FAILURE)
+
+    @pytest.mark.parametrize("node_cls", _ALL_NODES)
+    def test_update_never_returns_running(
+        self, node_cls: Type[WeightedBehavior]
+    ) -> None:
+        node = node_cls()
+        results = {node.update() for _ in range(50)}
+        assert Status.RUNNING not in results
+
+    @pytest.mark.parametrize("node_cls, _, expected_rate", _NODE_SPECS)
+    def test_empirical_distribution(
+        self,
+        node_cls: Type[WeightedBehavior],
+        _: Type[WeightedBehavior],
+        expected_rate: float,
+    ) -> None:
+        # AlwaysSucceed and AlwaysFail are deterministic — skip statistical check
+        if expected_rate in (0.0, 1.0):
+            node = node_cls()
+            expected_status = (
+                Status.SUCCESS if expected_rate == 1.0 else Status.FAILURE
+            )
+            assert node.update() == expected_status
+            return
+        rate = _run_trials(node_cls)
+        assert (
+            abs(rate - expected_rate) < _TOLERANCE
+        ), f"{node_cls.__name__}: empirical={rate:.4f} expected={expected_rate:.4f}"

--- a/test/fuzzer/report_management/test_monitor_threats.py
+++ b/test/fuzzer/report_management/test_monitor_threats.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python
+#  Copyright (c) 2023-2025 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Unit tests for vultron/demo/fuzzer/report_management/monitor_threats.py.
+
+Tests cover:
+  - AC-1: All nodes use correct py_trees WeightedBehavior base types (BT-16-004)
+  - AC-2: All nodes have docstrings with required sections (BT-16-003)
+  - AC-3: Unit tests cover each node's success_rate and status distribution
+"""
+
+from typing import Type
+
+import py_trees
+import pytest
+from py_trees.common import Status
+
+from vultron.demo.fuzzer.base import (
+    AlmostAlwaysFail,
+    AlwaysSucceed,
+    UsuallyFail,
+    WeightedBehavior,
+)
+from vultron.demo.fuzzer.report_management.monitor_threats import (
+    MonitorAttacks,
+    MonitorExploits,
+    MonitorPublicReports,
+    NoThreatsFound,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_TRIALS = 10_000
+_TOLERANCE = 0.03  # ±3 percentage points
+
+# (node_class, expected_base_type, expected_success_rate)
+_NODE_SPECS = [
+    (MonitorAttacks, AlmostAlwaysFail, 1.0 / 10.0),
+    (MonitorExploits, AlmostAlwaysFail, 1.0 / 10.0),
+    (MonitorPublicReports, UsuallyFail, 1.0 / 4.0),
+    (NoThreatsFound, AlwaysSucceed, 1.0),
+]
+
+_ALL_NODES = [spec[0] for spec in _NODE_SPECS]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_trials(node_cls: "Type[WeightedBehavior]", n: int = _TRIALS) -> float:
+    """Return empirical success rate over *n* independent ticks."""
+    node = node_cls()
+    successes = sum(1 for _ in range(n) if node.update() == Status.SUCCESS)
+    return successes / n
+
+
+# ---------------------------------------------------------------------------
+# AC-1: Node inheritance and py_trees compliance
+# ---------------------------------------------------------------------------
+
+
+class TestNodeIsWeightedBehavior:
+    @pytest.mark.parametrize("node_cls", _ALL_NODES)
+    def test_is_weighted_behavior_subclass(
+        self, node_cls: Type[WeightedBehavior]
+    ) -> None:
+        assert issubclass(node_cls, WeightedBehavior)
+
+    @pytest.mark.parametrize("node_cls", _ALL_NODES)
+    def test_is_py_trees_behaviour(
+        self, node_cls: Type[WeightedBehavior]
+    ) -> None:
+        assert isinstance(node_cls(), py_trees.behaviour.Behaviour)
+
+    @pytest.mark.parametrize("node_cls", _ALL_NODES)
+    def test_default_name_is_class_name(
+        self, node_cls: Type[WeightedBehavior]
+    ) -> None:
+        assert node_cls().name == node_cls.__name__
+
+    @pytest.mark.parametrize("node_cls", _ALL_NODES)
+    def test_custom_name_respected(
+        self, node_cls: Type[WeightedBehavior]
+    ) -> None:
+        assert node_cls(name="custom").name == "custom"
+
+    def test_node_count(self) -> None:
+        assert len(_ALL_NODES) == 4
+
+    @pytest.mark.parametrize("node_cls, expected_base, _", _NODE_SPECS)
+    def test_base_type(
+        self, node_cls: Type[WeightedBehavior], expected_base: type, _: float
+    ) -> None:
+        assert issubclass(node_cls, expected_base)
+
+
+# ---------------------------------------------------------------------------
+# AC-2: Docstring completeness (BT-16-003, BT-16-005)
+# ---------------------------------------------------------------------------
+
+_REQUIRED_SECTIONS = [
+    "semantic function",
+    "input category",
+    "success probability",
+    "automation potential",
+]
+
+
+class TestDocstrings:
+    @pytest.mark.parametrize("node_cls", _ALL_NODES)
+    def test_has_non_empty_docstring(
+        self, node_cls: Type[WeightedBehavior]
+    ) -> None:
+        doc = node_cls.__doc__ or ""
+        assert len(doc.strip()) > 0
+
+    @pytest.mark.parametrize("node_cls", _ALL_NODES)
+    @pytest.mark.parametrize("section", _REQUIRED_SECTIONS)
+    def test_docstring_has_required_section(
+        self, node_cls: Type[WeightedBehavior], section: str
+    ) -> None:
+        doc = (node_cls.__doc__ or "").lower()
+        assert (
+            section in doc
+        ), f"{node_cls.__name__} docstring missing '{section}' section"
+
+
+# ---------------------------------------------------------------------------
+# AC-3: success_rate attribute and status distribution
+# ---------------------------------------------------------------------------
+
+
+class TestSuccessRates:
+    @pytest.mark.parametrize("node_cls, _, expected_rate", _NODE_SPECS)
+    def test_success_rate_attribute(
+        self,
+        node_cls: Type[WeightedBehavior],
+        _: Type[WeightedBehavior],
+        expected_rate: float,
+    ) -> None:
+        assert abs(node_cls.success_rate - expected_rate) < 1e-9
+
+    @pytest.mark.parametrize("node_cls", _ALL_NODES)
+    def test_update_returns_valid_status(
+        self, node_cls: Type[WeightedBehavior]
+    ) -> None:
+        node = node_cls()
+        result = node.update()
+        assert result in (Status.SUCCESS, Status.FAILURE)
+
+    @pytest.mark.parametrize("node_cls", _ALL_NODES)
+    def test_update_never_returns_running(
+        self, node_cls: Type[WeightedBehavior]
+    ) -> None:
+        node = node_cls()
+        results = {node.update() for _ in range(50)}
+        assert Status.RUNNING not in results
+
+    @pytest.mark.parametrize("node_cls, _, expected_rate", _NODE_SPECS)
+    def test_empirical_distribution(
+        self,
+        node_cls: Type[WeightedBehavior],
+        _: Type[WeightedBehavior],
+        expected_rate: float,
+    ) -> None:
+        # AlwaysSucceed is deterministic — verify directly instead of statistically
+        if expected_rate == 1.0:
+            assert node_cls().update() == Status.SUCCESS
+            return
+        rate = _run_trials(node_cls)
+        assert (
+            abs(rate - expected_rate) < _TOLERANCE
+        ), f"{node_cls.__name__}: empirical={rate:.4f} expected={expected_rate:.4f}"

--- a/vultron/demo/fuzzer/report_management/__init__.py
+++ b/vultron/demo/fuzzer/report_management/__init__.py
@@ -20,6 +20,9 @@ Report Management (RM) workflow, grouped by sub-topic:
 - ``prioritize`` — report prioritization nodes (5 nodes)
 - ``assign_vul_id`` — VUL ID assignment nodes (6 nodes)
 - ``develop_fix`` — fix development nodes (1 node)
+- ``deploy_fix`` — fix deployment nodes (8 nodes)
+- ``monitor_threats`` — threat monitoring nodes (4 nodes)
+- ``acquire_exploit`` — exploit acquisition nodes (8 nodes)
 - ``close_report`` — report closure nodes (2 nodes)
 - ``other_work`` — miscellaneous work placeholder (1 node)
 - ``report_to_others`` — report-to-others workflow nodes (21 nodes)
@@ -52,6 +55,32 @@ from vultron.demo.fuzzer.report_management.close_report import (
     PreCloseAction,
 )
 from vultron.demo.fuzzer.report_management.develop_fix import CreateFix
+from vultron.demo.fuzzer.report_management.deploy_fix import (
+    DeployFix,
+    DeployMitigation,
+    MitigationAvailable,
+    MitigationDeployed,
+    MonitorDeployment,
+    MonitoringRequirement,
+    NoNewDeploymentInfo,
+    PrioritizeDeployment,
+)
+from vultron.demo.fuzzer.report_management.monitor_threats import (
+    MonitorAttacks,
+    MonitorExploits,
+    MonitorPublicReports,
+    NoThreatsFound,
+)
+from vultron.demo.fuzzer.report_management.acquire_exploit import (
+    DevelopExploit,
+    EvaluateExploitPriority,
+    ExploitDeferred,
+    ExploitDesired,
+    ExploitPrioritySet,
+    FindExploit,
+    HaveExploit,
+    PurchaseExploit,
+)
 from vultron.demo.fuzzer.report_management.other_work import OtherWork
 from vultron.demo.fuzzer.report_management.report_to_others import (
     AllPartiesKnown,
@@ -99,6 +128,29 @@ __all__ = [
     "InScope",
     # fix development
     "CreateFix",
+    # fix deployment
+    "NoNewDeploymentInfo",
+    "PrioritizeDeployment",
+    "MitigationDeployed",
+    "MitigationAvailable",
+    "DeployMitigation",
+    "MonitoringRequirement",
+    "MonitorDeployment",
+    "DeployFix",
+    # threat monitoring
+    "MonitorAttacks",
+    "MonitorExploits",
+    "MonitorPublicReports",
+    "NoThreatsFound",
+    # exploit acquisition
+    "HaveExploit",
+    "ExploitDeferred",
+    "ExploitPrioritySet",
+    "EvaluateExploitPriority",
+    "ExploitDesired",
+    "FindExploit",
+    "DevelopExploit",
+    "PurchaseExploit",
     # report closure
     "OtherCloseCriteriaMet",
     "PreCloseAction",

--- a/vultron/demo/fuzzer/report_management/acquire_exploit.py
+++ b/vultron/demo/fuzzer/report_management/acquire_exploit.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python
+#  Copyright (c) 2023-2025 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Exploit acquisition fuzzer nodes for the Vultron demo layer.
+
+This module provides probabilistic stub ``py_trees`` behaviour nodes for the
+exploit acquisition sub-workflow within Report Management
+(``AcquireExploitBt``).  Each node represents an external-dependency
+touchpoint — a human decision or system integration hook — that will
+eventually be replaced by production logic.
+
+Nodes are built on the probabilistic base types in
+``vultron.demo.fuzzer.base`` and satisfy BT-16-003 (named integration-point
+nodes with semantic docstrings) and BT-16-005 (automation-potential
+categorization).
+
+References
+----------
+- Source: ``vultron/bt/report_management/fuzzer/acquire_exploit.py``
+- Spec: ``specs/behavior-tree-integration.yaml`` BT-16-003, BT-16-004, BT-16-005
+- Notes: ``notes/bt-fuzzer-nodes-report-management.md``
+"""
+
+from __future__ import annotations
+
+from vultron.demo.fuzzer.base import (
+    AlmostAlwaysFail,
+    AlmostAlwaysSucceed,
+    AlwaysSucceed,
+    OftenFail,
+    OftenSucceed,
+    RarelySucceed,
+    UsuallyFail,
+)
+
+
+class HaveExploit(UsuallyFail):
+    """Check whether the organization already possesses an exploit.
+
+    Semantic function:
+        Condition — check whether the organization already has a working
+        exploit for the vulnerability in its internal exploit repository
+        or threat-intelligence database.  Fails most of the time to reflect
+        the typical case where an exploit must be acquired or developed.
+
+    Input category: Environmental check.
+
+    Success probability: 0.25 (``UsuallyFail``).
+
+    Automation potential: **High** — internal exploit-database queries and
+    threat-intelligence platform lookups are fully automatable; no human
+    involvement is required for a simple existence check.
+    """
+
+
+class ExploitDeferred(OftenSucceed):
+    """Check whether exploit acquisition has been deferred.
+
+    Semantic function:
+        Condition — check whether the organization has decided to defer
+        exploit acquisition, for example because the vulnerability has low
+        priority, a public exploit already exists, or resources are
+        constrained.  Succeeds more often than not to reflect that
+        deferral is the common outcome of the priority-evaluation step.
+
+    Input category: Environmental check / Human decision.
+
+    Success probability: 0.70 (``OftenSucceed``).
+
+    Automation potential: **Medium** — deferral status can be stored as
+    case metadata and queried automatically; the initial deferral decision
+    typically requires human judgment or a policy-driven evaluation.
+    """
+
+
+class ExploitPrioritySet(AlmostAlwaysSucceed):
+    """Check whether a priority has been assigned for exploit acquisition.
+
+    Semantic function:
+        Condition — check whether the organization has already made an
+        explicit priority decision regarding exploit acquisition for this
+        vulnerability.  Succeeds almost always to reflect that most cases
+        reach this node after a priority decision has been recorded.
+
+    Input category: Environmental check.
+
+    Success probability: 0.90 (``AlmostAlwaysSucceed``).
+
+    Automation potential: **High** — priority metadata is stored in the
+    case record and can be queried without human involvement; the
+    upstream priority-setting step may involve human judgment.
+    """
+
+
+class EvaluateExploitPriority(AlwaysSucceed):
+    """Evaluate the priority of acquiring an exploit for this vulnerability.
+
+    Semantic function:
+        Action — perform a structured assessment of whether acquiring an
+        exploit is warranted for this vulnerability, based on factors such
+        as SSVC exploitation status, asset criticality, and organizational
+        policy.  Always succeeds in simulation to ensure the priority
+        decision is always recorded, keeping the workflow progressing.
+
+    Input category: Human decision.
+
+    Success probability: 1.00 (``AlwaysSucceed``).
+
+    Automation potential: **Medium** — SSVC-based scoring and policy-rule
+    evaluation can automate a priority recommendation; the final decision
+    to pursue exploit acquisition typically requires human authorization,
+    especially for high-risk or regulated environments.
+    """
+
+
+class ExploitDesired(OftenFail):
+    """Check whether the organization has decided to acquire an exploit.
+
+    Semantic function:
+        Condition — check the outcome of the priority evaluation to
+        determine whether the organization has decided that exploit
+        acquisition is desirable.  Fails more often than not to reflect
+        that most vulnerability cases do not warrant active exploit
+        acquisition — deferral is the common outcome.
+
+    Input category: Environmental check / Human decision.
+
+    Success probability: 0.30 (``OftenFail``).
+
+    Automation potential: **Medium** — the exploit-desired flag can be
+    read directly from case metadata once set; the upstream decision
+    step that sets the flag typically requires human review.
+    """
+
+
+class FindExploit(AlmostAlwaysFail):
+    """Search external sources for an existing exploit.
+
+    Semantic function:
+        Action — search public exploit databases, threat-intelligence
+        platforms, or other external sources to locate a pre-existing
+        exploit for the vulnerability.  Fails almost always to reflect
+        the realistic assumption that ready-made exploits are rarely
+        available, while infrequent successes allow downstream workflow
+        paths to be exercised.
+
+    Input category: System integration / Human decision.
+
+    Success probability: 0.10 (``AlmostAlwaysFail``).
+
+    Automation potential: **High** — exploit database APIs (e.g., ExploitDB,
+    Metasploit, commercial threat-intel feeds) provide fully automatable
+    search capabilities; a human analyst may be needed to evaluate
+    applicability and quality of retrieved exploits.
+    """
+
+
+class DevelopExploit(OftenSucceed):
+    """Develop an exploit for the vulnerability internally.
+
+    Semantic function:
+        Action — prompt a security researcher or red-team member to
+        develop a proof-of-concept or working exploit for the
+        vulnerability.  Succeeds more often than not to model the
+        common case where a skilled researcher can produce an exploit
+        once development is initiated.
+
+    Input category: Human decision.
+
+    Success probability: 0.70 (``OftenSucceed``).
+
+    Automation potential: **Low** — exploit development requires deep
+    technical expertise and creativity; while automated fuzzing and
+    symbolic-execution tools can assist, the development of a reliable
+    exploit is largely a manual research activity.
+    """
+
+
+class PurchaseExploit(RarelySucceed):
+    """Pursue purchase of an exploit from an external vendor or broker.
+
+    Semantic function:
+        Action — initiate the process of purchasing a working exploit from
+        an exploit broker or commercial vulnerability-intelligence vendor.
+        Rarely succeeds to reflect that exploit purchasing is an uncommon
+        and often logistically complex path, reserved for high-priority
+        cases where internal development has failed.
+
+    Input category: Human decision.
+
+    Success probability: 0.10 (``RarelySucceed``).
+
+    Automation potential: **Low** — exploit procurement involves legal,
+    compliance, and budget approvals as well as vendor negotiation; these
+    steps are inherently manual and cannot be automated.
+    """

--- a/vultron/demo/fuzzer/report_management/deploy_fix.py
+++ b/vultron/demo/fuzzer/report_management/deploy_fix.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python
+#  Copyright (c) 2023-2025 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Fix deployment fuzzer nodes for the Vultron demo layer.
+
+This module provides probabilistic stub ``py_trees`` behaviour nodes for the
+fix deployment sub-workflow within Report Management (``DeployFixBt``).  Each
+node represents an external-dependency touchpoint — a human decision,
+environmental check, or system integration hook — that will eventually be
+replaced by production logic.
+
+Nodes are built on the probabilistic base types in
+``vultron.demo.fuzzer.base`` and satisfy BT-16-003 (named integration-point
+nodes with semantic docstrings) and BT-16-005 (automation-potential
+categorization).
+
+References
+----------
+- Source: ``vultron/bt/report_management/fuzzer/deploy_fix.py``
+- Spec: ``specs/behavior-tree-integration.yaml`` BT-16-003, BT-16-004, BT-16-005
+- Notes: ``notes/bt-fuzzer-nodes-report-management.md``
+"""
+
+from __future__ import annotations
+
+from vultron.demo.fuzzer.base import (
+    AlmostAlwaysFail,
+    AlmostAlwaysSucceed,
+    AlwaysSucceed,
+    OftenSucceed,
+    UsuallyFail,
+    UsuallySucceed,
+)
+
+
+class NoNewDeploymentInfo(UsuallySucceed):
+    """Check whether any new deployment information has arrived.
+
+    Semantic function:
+        Condition — check whether any new information about the deployment
+        state of a fix or mitigation has arrived since the last evaluation.
+        In most cases there will be no new information, so this condition
+        succeeds, avoiding unnecessary re-evaluation.  In production this
+        could be implemented as an event subscription or a case-metadata
+        timestamp comparison.
+
+    Input category: Environmental check / Human decision.
+
+    Success probability: 0.75 (``UsuallySucceed``).
+
+    Automation potential: **High** — event subscription on the case record
+    or metadata timestamp comparison; fully automatable without human
+    involvement.
+    """
+
+
+class PrioritizeDeployment(AlmostAlwaysSucceed):
+    """Assign priority to deploying the available fix or mitigation.
+
+    Semantic function:
+        Action — prompt a human or invoke a policy engine to assign a
+        deployment priority for the available fix or mitigation.  In
+        production this would typically involve a change-management system
+        or SSVC-based prioritization workflow.  The fuzzer models the
+        overwhelmingly common case where prioritization succeeds.
+
+    Input category: Human decision.
+
+    Success probability: 0.90 (``AlmostAlwaysSucceed``).
+
+    Automation potential: **Medium** — SSVC deployment status and
+    environmental scoring can drive an automated priority recommendation;
+    final approval for high-impact changes typically requires human sign-off.
+    """
+
+
+class MitigationDeployed(UsuallyFail):
+    """Check whether a mitigation has already been deployed.
+
+    Semantic function:
+        Condition — check whether an interim mitigation (workaround, network
+        control, configuration change) is currently active for the
+        vulnerability.  In production this is typically a status query against
+        the case record or a configuration-management database.  Fails most
+        of the time to reflect that mitigations are not yet deployed in the
+        typical workflow step.
+
+    Input category: Environmental check.
+
+    Success probability: 0.25 (``UsuallyFail``).
+
+    Automation potential: **High** — configuration-management database (CMDB)
+    or asset-inventory API queries can confirm mitigation status without
+    human involvement.
+    """
+
+
+class MitigationAvailable(OftenSucceed):
+    """Check whether a mitigation option is available to deploy.
+
+    Semantic function:
+        Condition — check whether an interim mitigation (e.g., a workaround,
+        firewall rule, or configuration change) has been identified and is
+        ready to be applied.  Succeeds more often than not to reflect that
+        mitigations are typically available when this node is reached.
+
+    Input category: Environmental check.
+
+    Success probability: 0.70 (``OftenSucceed``).
+
+    Automation potential: **Medium** — known workarounds and mitigations can
+    be catalogued in the case record and queried automatically; evaluating
+    applicability to a specific environment may require human judgment.
+    """
+
+
+class DeployMitigation(UsuallySucceed):
+    """Deploy the available mitigation for the vulnerability.
+
+    Semantic function:
+        Action — apply the identified mitigation to the affected system or
+        environment.  In production this would typically be a prompt for
+        a system administrator or an automated remediation workflow
+        (e.g., applying a firewall rule via an API).  Succeeds most of
+        the time to model the common case where mitigation deployment
+        proceeds without issues.
+
+    Input category: System integration / Human decision.
+
+    Success probability: 0.75 (``UsuallySucceed``).
+
+    Automation potential: **Medium** — standard mitigations with
+        well-defined procedures (e.g., network-level controls) can be
+        automated via infrastructure APIs; complex environment-specific
+        mitigations typically require human coordination.
+    """
+
+
+class MonitoringRequirement(OftenSucceed):
+    """Determine whether deployment monitoring is required by policy.
+
+    Semantic function:
+        Condition — evaluate whether it is necessary to actively monitor
+        the deployment of the fix or mitigation according to organizational
+        policy.  In production this is typically a policy lookup or a
+        configuration check.  Succeeds about 70 % of the time to reflect
+        that monitoring is commonly required but not universal.
+
+    Input category: Environmental check / Policy.
+
+    Success probability: 0.70 (``OftenSucceed``).
+
+    Automation potential: **High** — policy-driven checks (e.g., "monitor
+    all critical-severity deployments") are fully automatable; rule-based
+    policy engines can evaluate this condition without human input.
+    """
+
+
+class MonitorDeployment(AlwaysSucceed):
+    """Monitor the ongoing deployment of the fix or mitigation.
+
+    Semantic function:
+        Action — perform active monitoring of the deployment process to
+        ensure the fix or mitigation is being applied correctly and
+        completely.  In production this would typically be a prompt for a
+        human operator or an automated monitoring hook (e.g., a deployment
+        pipeline status poll).  Always succeeds in simulation to model the
+        assumption that monitoring itself does not fail.
+
+    Input category: System integration.
+
+    Success probability: 1.00 (``AlwaysSucceed``).
+
+    Automation potential: **High** — deployment-pipeline APIs and
+    configuration-management tools provide fully automatable monitoring
+    hooks; human involvement is only required when anomalies are detected.
+    """
+
+
+class DeployFix(AlmostAlwaysFail):
+    """Deploy the vendor fix to the affected environment.
+
+    Semantic function:
+        Action — apply the vendor-provided fix (patch, updated package, or
+        firmware) to the affected system.  Fails almost always to model the
+        realistic scenario where a definitive fix is not yet deployed at
+        the point this node is evaluated — the workflow must fall back to
+        mitigation or monitoring paths.  Infrequent successes allow the
+        rest of the post-deployment workflow to be exercised.
+
+    Input category: System integration / Human decision.
+
+    Success probability: 0.10 (``AlmostAlwaysFail``).
+
+    Automation potential: **Medium** — patch-management systems and software
+    distribution platforms can automate fix deployment for many asset
+    types; complex or high-risk changes in regulated environments typically
+    require human approval and change-management controls.
+    """

--- a/vultron/demo/fuzzer/report_management/monitor_threats.py
+++ b/vultron/demo/fuzzer/report_management/monitor_threats.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+#  Copyright (c) 2023-2025 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Threat monitoring fuzzer nodes for the Vultron demo layer.
+
+This module provides probabilistic stub ``py_trees`` behaviour nodes for the
+threat monitoring sub-workflow within Report Management
+(``MonitorThreatsBt``).  Each node represents an external-dependency
+touchpoint — typically a threat-intelligence system integration — that will
+eventually be replaced by production logic.
+
+Nodes are built on the probabilistic base types in
+``vultron.demo.fuzzer.base`` and satisfy BT-16-003 (named integration-point
+nodes with semantic docstrings) and BT-16-005 (automation-potential
+categorization).
+
+References
+----------
+- Source: ``vultron/bt/report_management/fuzzer/monitor_threats.py``
+- Spec: ``specs/behavior-tree-integration.yaml`` BT-16-003, BT-16-004, BT-16-005
+- Notes: ``notes/bt-fuzzer-nodes-report-management.md``
+"""
+
+from __future__ import annotations
+
+from vultron.demo.fuzzer.base import (
+    AlmostAlwaysFail,
+    AlwaysSucceed,
+    UsuallyFail,
+)
+
+
+class MonitorAttacks(AlmostAlwaysFail):
+    """Monitor threat-intelligence feeds for active attacks on the vulnerability.
+
+    Semantic function:
+        Action — query threat-intelligence feeds, SIEM systems, or other
+        sources to detect whether active exploitation of the vulnerability
+        has been observed in the wild.  Fails almost always to reflect the
+        realistic low prior probability that an attack against a specific
+        vulnerability will be detected during a routine coordination cycle.
+
+    Input category: System integration.
+
+    Success probability: 0.10 (``AlmostAlwaysFail``).
+
+    Automation potential: **High** — threat-intelligence feed APIs,
+    SIEM alert integrations, and CVE-tagged IOC repositories provide fully
+    automatable attack-detection signals; human analyst triage is only
+    required when a potential match is identified.
+    """
+
+
+class MonitorExploits(AlmostAlwaysFail):
+    """Monitor threat-intelligence feeds for public exploits of the vulnerability.
+
+    Semantic function:
+        Action — query exploit databases, threat-intelligence platforms, or
+        dark-web monitoring services to detect whether a working exploit for
+        the vulnerability has been published or is circulating.  Fails almost
+        always to reflect the realistic low prior probability that a public
+        exploit will be detected during a routine coordination cycle.
+
+    Input category: System integration.
+
+    Success probability: 0.10 (``AlmostAlwaysFail``).
+
+    Automation potential: **High** — exploit-database APIs (e.g., ExploitDB,
+    Metasploit feed, NVD), commercial threat-intelligence platforms, and
+    OSINT aggregators provide fully automatable exploit-detection signals.
+    """
+
+
+class MonitorPublicReports(UsuallyFail):
+    """Monitor public sources for disclosure of the vulnerability.
+
+    Semantic function:
+        Action — scan news feeds, security mailing lists, social media, and
+        other public channels for signs that the vulnerability has been
+        disclosed or publicly discussed before the coordinated embargo
+        expires.  Fails most of the time to reflect that premature public
+        disclosure is the uncommon case during active coordination.
+
+    Input category: System integration.
+
+    Success probability: 0.25 (``UsuallyFail``).
+
+    Automation potential: **Medium** — keyword-based monitoring tools and
+    RSS/social-media aggregators can provide partial automation; reviewing
+    ambiguous signals and determining whether they constitute a true
+    disclosure typically requires human analyst judgment.
+    """
+
+
+class NoThreatsFound(AlwaysSucceed):
+    """Confirm that no active threats were detected during this monitoring pass.
+
+    Semantic function:
+        Condition — serve as a guaranteed-success fallback at the end of
+        the threat-monitoring selector, ensuring the ``MonitorThreatsBt``
+        subtree always returns SUCCESS even when none of the upstream
+        monitoring nodes (attacks, exploits, public reports) reported a
+        finding.  This keeps the overall workflow progressing in the
+        absence of threats.
+
+    Input category: Environmental check.
+
+    Success probability: 1.00 (``AlwaysSucceed``).
+
+    Automation potential: **High** — this is a structural no-op node whose
+    success is guaranteed by design; no external input is required.
+    """


### PR DESCRIPTION
- Closes #864

## Summary

Ports 20 probabilistic stub py_trees nodes across three new modules for the
Report Management fuzzer demo layer (Epic #427). Each node subclasses a
`WeightedBehavior` base type and carries a BT-16-003/BT-16-005-compliant
docstring with semantic function, input category, success probability, and
automation potential.

## Changes

- `vultron/demo/fuzzer/report_management/deploy_fix.py`: 8 nodes —
  `NoNewDeploymentInfo`, `PrioritizeDeployment`, `MitigationDeployed`,
  `MitigationAvailable`, `DeployMitigation`, `MonitoringRequirement`,
  `MonitorDeployment`, `DeployFix`
- `vultron/demo/fuzzer/report_management/monitor_threats.py`: 4 nodes —
  `MonitorAttacks`, `MonitorExploits`, `MonitorPublicReports`, `NoThreatsFound`
- `vultron/demo/fuzzer/report_management/acquire_exploit.py`: 8 nodes —
  `HaveExploit`, `ExploitDeferred`, `ExploitPrioritySet`,
  `EvaluateExploitPriority`, `ExploitDesired`, `FindExploit`,
  `DevelopExploit`, `PurchaseExploit`
- `vultron/demo/fuzzer/report_management/__init__.py`: updated module docstring,
  imports, and `__all__` to include all 20 new nodes
- `test/fuzzer/report_management/test_deploy_fix.py`: parametric tests for all
  8 deploy-fix nodes (AC-1, AC-2, AC-3)
- `test/fuzzer/report_management/test_monitor_threats.py`: parametric tests for
  all 4 threat-monitoring nodes
- `test/fuzzer/report_management/test_acquire_exploit.py`: parametric tests for
  all 8 exploit-acquisition nodes

## Verification

- All 4446 unit + integration tests pass (283 new), 37 skipped, 5 xfailed (pre-existing)
- Black, flake8, mypy, pyright all clean