### PR TITLE
docs: plan issue #1114 — spec quality gaps (6 bugs + 7 vagueness items)

### DIFF
--- a/plan/history/2606/learning/CONCERN-1114.md
+++ b/plan/history/2606/learning/CONCERN-1114.md
@@ -1,0 +1,50 @@
+---
+source: CONCERN-1114
+timestamp: '2026-06-22T20:27:07.566892+00:00'
+title: 'Spec quality gaps from 2026-05-06 review: 6 bugs and 7 incomplete/vague items'
+type: learning
+---
+
+## Summary
+
+A systematic review of all spec files changed since 2026-05-06 found 6 definite errors (priority mismatches, contradictions, truncated content) and 7 instances of vagueness or incomplete coverage.
+
+## Category
+
+Documentation / Specification Quality
+
+## Severity
+
+Medium — most are fixable without design changes; two (CLP-02-006, CP-01-004) could actively mislead an implementer.
+
+## Evidence
+
+### Bugs / Definite Problems
+
+1. **`CLP-02-006` priority mismatch**: Marked `priority: MUST_NOT` but the statement says "MUST include a `log_index` field … MUST NOT be assigned by external parties". The first clause requires MUST; a MUST_NOT priority causes an implementer to skip the field entirely.
+2. **`CP-01-004` contradicts `AKM-03-001`**: Permits a URI reference in `as_CaseProposal.object_`, which directly contradicts `AKM-03-001` ("outbound activities MUST include full inline objects, never bare URIs").
+3. **`SYNC-06-004` truncated statement**: Statement ends mid-sentence with "This is a distinct replication tier from participant replication:" — the continuation has been missing since the original spec migration commit (`2cacc05c`).
+4. **`SYNC-05-002` priority inconsistency**: `priority: MUST` wraps a statement that says "SHOULD be configurable; default values MUST be documented" — conflicting normative levels within a single spec.
+5. **`DEMOMA-06-002` missing M3**: Milestone list jumps M1 → M2 → M4 with M3 absent and no explanation.
+6. **`CLP` description typo**: "local case audit **ledgerging**" — should be "ledgering" or just "ledger".
+
+### Vagueness / Incomplete Specs
+
+1. **`CBT-03-004` undefined vocabulary**: Specifies "send a generic `Question`" but `Question` is not defined in the Vultron AS2 vocabulary — not implementable as written.
+2. **`CBT-03-001/-003` unspecified timeout**: Requires a "short bounded interval" / "bounded pre-bootstrap queue" with no default value, configuration pointer, or cross-reference to a `CFG-*` spec (contrast with `CLP-06-003`, which does).
+3. **`DEMOMA-08-002` dangling requirement**: Introduces `OFFER_CASE_MANAGER_ROLE` and `ACCEPT_CASE_MANAGER_ROLE` `MessageSemantics` values with no corresponding wire vocab, extractor pattern, or use-case specs — a dangling requirement with no downstream specs to implement against.
+4. **`ARCH-13-005` incomplete interface**: Requires `ActorScopedDataLayer` Protocol type but does not specify its method interface or cross-reference the DL spec.
+5. **`CP-05-003` no atomicity/failure spec**: The two-activity response sequence (`Accept(CaseProposal)` then `Create(VulnerabilityCase)`) has no atomicity, failure, or idempotency coverage.
+6. **`PCR-08-009` missing positive counterpart**: Prohibits the case owner from emitting invitee RM state-change activities but never explicitly states who is responsible (the Case Actor) — the positive duty is implied but unspecified.
+7. **`PD-09-004` vague scoping criterion**: "Changes to the canonical CaseLedgerEntry commit path" is too vague to apply consistently — needs specific file/class anchors.
+
+## Resolution
+
+All 13 items resolved in planning session on 2026-06-22.
+
+**Resolved**: 2026-06-22 — spec fixes in docs PR #1124; implementation tracked in #1125, #1126, #1127.
+
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1124>.
+Spec: `specs/multi-actor-demo.yaml`, `specs/case-ledger-processing.yaml`, `specs/case-proposal.yaml`,
+`specs/sync-ledger-replication.yaml`, `specs/case-bootstrap-trust.yaml`, `specs/architecture.yaml`,
+`specs/participant-case-replica.yaml`, `specs/project-documentation.yaml`.

--- a/specs/architecture.yaml
+++ b/specs/architecture.yaml
@@ -396,7 +396,10 @@ groups:
       The `ActorScopedDataLayer` protocol type SHOULD be defined in
       `vultron/core/ports/datalayer.py` as a refinement of `DataLayer` so that
       type-checkers (mypy, pyright) can enforce scope boundaries at
-      function-signature level.
+      function-signature level. It is currently implemented there with methods:
+      `inbox_append(activity_id: str) -> None`, `inbox_list() -> list[str]`,
+      `inbox_pop() -> str | None`, `outbox_append(activity_id: str) -> None`,
+      `outbox_list() -> list[str]`, `outbox_pop() -> str | None`.
     rationale: >
       An explicit Protocol type converts a convention-only rule into a
       compile-time-enforced boundary, making violations visible without running

--- a/specs/case-bootstrap-trust.yaml
+++ b/specs/case-bootstrap-trust.yaml
@@ -139,7 +139,8 @@ groups:
           If a CaseActor-originated case message arrives before the required
           bootstrap trust handoff, the receiving actor SHOULD queue it only for
           a short bounded interval rather than accepting or permanently
-          trusting it immediately.
+          trusting it immediately. The default queue expiry interval is 300 seconds
+          (configurable via `AppConfig.pre_bootstrap_queue_timeout_seconds`).
         relationships:
           - rel_type: refines
             spec_id: PCR-06-002
@@ -155,16 +156,19 @@ groups:
       - id: CBT-03-003
         priority: MUST
         statement: >-
-          When the bounded pre-bootstrap queue expires, the receiver MUST drop
-          the queued message, log a warning, and require a resend after
-          bootstrap.
+          When the bounded pre-bootstrap queue expires (default: 300 seconds,
+          configurable via `AppConfig.pre_bootstrap_queue_timeout_seconds`),
+          the receiver MUST drop the queued message, log a warning, and require
+          a resend after bootstrap.
       - id: CBT-03-004
         priority: SHOULD
         statement: >-
           When bootstrap has not arrived in time, the receiver SHOULD request a
-          replay from the original report receiver / case creator by sending a
-          generic `Question` asking for the bootstrap `Create(VulnerabilityCase)`
-          to be resent.
+          replay from the original report receiver / case creator by sending an
+          `as_Question` activity (`vultron.wire.as2.vocab.base.objects.activities.intransitive.as_Question`)
+          asking for the bootstrap `Create(VulnerabilityCase)` to be resent.
+          The `target` of the `as_Question` SHOULD be set to the `case_actor_id`
+          recorded on the `VultronPendingCaseInbox` entry.
   - id: CBT-04
     title: Late-Joiner Bootstrap
     specs:

--- a/specs/case-ledger-processing.yaml
+++ b/specs/case-ledger-processing.yaml
@@ -1,7 +1,7 @@
 id: CLP
 title: Case Ledger Processing
 description: >-
-  Requirements for participant assertions, CaseActor canonicalization, local case audit ledgerging,
+  Requirements for participant assertions, CaseActor canonicalization, local case audit ledgering,
   recorded-history projection, and replication-facing `CaseLedgerEntry` objects. `notes/activitystreams-semantics.md`,
   `notes/case-state-model.md`, `notes/sync-ledger-replication.md` `specs/sync-ledger-replication.md`,
   `specs/outbox.md`, `specs/message-validation.md`, `specs/idempotency.md` recording. Transport-layer
@@ -63,7 +63,7 @@ groups:
       Rejected `CaseLedgerEntry` objects SHOULD include a machine-readable reason code and MAY
       include human-readable detail
   - id: CLP-02-006
-    priority: MUST_NOT
+    priority: MUST
     statement: >-
       `CaseLedgerEntry` MUST include a `log_index` field corresponding to SYNC-01-002; this field
       MUST be set by the CaseActor's single authoritative write path and MUST NOT be assigned

--- a/specs/case-proposal.yaml
+++ b/specs/case-proposal.yaml
@@ -38,13 +38,14 @@ groups:
       - id: CP-01-004
         priority: MUST
         statement: >-
-          `as_CaseProposal` MUST include an `object_` field containing either
-          an inline `as_VulnerabilityReport` or a URI reference to the report
-          around which the case is to be created.
+          `as_CaseProposal` MUST include an `object_` field containing a fully
+          inline `as_VulnerabilityReport` around which the case is to be created.
+          URI references to the report are NOT permitted (see AKM-03-001).
         rationale: >-
           The case-actor service needs the vulnerability report to initialize
-          the case. An inline or URI-referenced report satisfies this without
-          requiring a separate fetch in the common case.
+          the case. URI references are prohibited because the receiver may not
+          have the referenced object and no dereferencing mechanism is currently
+          specified (AKM-03-001).
       - id: CP-01-005
         priority: MUST
         statement: >-
@@ -168,6 +169,29 @@ groups:
           When rejecting a proposal, the case-actor service MUST send
           `Reject(as_CaseProposal)` with the `as_CaseProposal` embedded inline
           as `object_`.
+      - id: CP-05-005
+        priority: MUST
+        statement: >-
+          If the case-actor service successfully sends `Accept(as_CaseProposal)`
+          but fails to send `Create(VulnerabilityCase)`, it MUST retry
+          `Create(VulnerabilityCase)` independently. The `Accept` is irrevocable
+          once sent and MUST NOT be resent on retry; only `Create(VulnerabilityCase)`
+          requires retry.
+        rationale: >-
+          The two-activity sequence is not atomic at the network level. Resending
+          `Accept` on retry would cause the vendor to see a duplicate acceptance
+          and potentially re-enter the initialization flow.
+      - id: CP-05-006
+        priority: SHOULD
+        statement: >-
+          The case-actor service SHOULD handle duplicate `Create(as_CaseProposal)`
+          idempotently: if a proposal for the same report has already been
+          accepted and a `VulnerabilityCase` created, it SHOULD respond with
+          a new `Accept(as_CaseProposal)` referencing the existing
+          `VulnerabilityCase` rather than creating a second one.
+        rationale: >-
+          Network retries and at-least-once delivery semantics mean the vendor
+          may resend the proposal. Idempotent handling prevents duplicate cases.
   - id: CP-06
     title: Protocol Flow — Receiving (Vendor Side)
     specs:

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -158,10 +158,15 @@ groups:
   - id: DEMOMA-06-002
     priority: MUST
     statement: >-
-      The two-actor demo MUST verify the following milestones, checking both the Vendor and
-      Finder DataLayers at each checkpoint: M1 (case + 3 participants + EM.ACTIVE),
-      M2 (Finder has case replica), M4 (CS.VF on all replicas),
-      M5 (CS.VFD on all replicas), M6 (CS.VFDPxa + EM terminated on all replicas),
+      The two-actor demo MUST verify the following milestones in order, checking both the
+      Vendor and Finder DataLayers at each checkpoint:
+      M1 (case + 3 participants + EM.ACTIVE),
+      M2 (Finder has case replica with matching participant index and active embargo),
+      M3 (notes exchange complete: question note + reply note present in canonical case
+      state on both replicas),
+      M4 (CS.VF on all replicas),
+      M5 (CS.VFD on all replicas),
+      M6 (CS.VFDPxa + EM terminated on all replicas),
       M7 (all participants RM.CLOSED, case closed)
   - id: DEMOMA-06-003
     priority: MUST
@@ -251,8 +256,45 @@ groups:
       The CASE_MANAGER role delegation (Vendor hands operational management to Case Actor)
       MUST be implemented as a distinct protocol mechanism from OFFER_CASE_OWNERSHIP_TRANSFER;
       CASE_MANAGER delegation allows the Vendor to retain CASE_OWNER while delegating
-      operational authority, and requires new MessageSemantics values:
-      OFFER_CASE_MANAGER_ROLE and ACCEPT_CASE_MANAGER_ROLE
+      operational authority.
+      Wire vocab types (`_OfferCaseManagerRoleActivity`, `_AcceptCaseManagerRoleActivity`,
+      `_RejectCaseManagerRoleActivity`), extractor patterns, factory functions,
+      `MessageSemantics` values (`OFFER_CASE_MANAGER_ROLE`, `ACCEPT_CASE_MANAGER_ROLE`,
+      `REJECT_CASE_MANAGER_ROLE`), and received-side use cases are already implemented.
+      The remaining gaps are: (1) these use cases are not registered in the semantic
+      registry (`vultron/semantic_registry/__init__.py`), and
+      (2) trigger-side use cases (`SvcOfferCaseManagerRoleUseCase` and peers) are not yet
+      implemented. See DEMOMA-08-006 through DEMOMA-08-009 for the downstream specs.
+  - id: DEMOMA-08-006
+    priority: MUST
+    statement: >-
+      `OfferCaseManagerRolePattern`, `AcceptCaseManagerRolePattern`, and
+      `RejectCaseManagerRolePattern` MUST be registered in
+      `SEMANTICS_ACTIVITY_PATTERNS` in `vultron/semantic_registry/__init__.py`.
+      `OfferCaseManagerRoleReceivedUseCase`, `AcceptCaseManagerRoleReceivedUseCase`, and
+      `RejectCaseManagerRoleReceivedUseCase` MUST be registered in the `use_case_map`.
+  - id: DEMOMA-08-007
+    priority: MUST
+    statement: >-
+      A trigger-side use case `SvcOfferCaseManagerRoleUseCase` MUST be implemented in
+      `vultron/core/use_cases/triggers/actor.py` (or a new module in that package).
+      It MUST build an `_OfferCaseManagerRoleActivity` addressed to the target Case Actor
+      and enqueue it to the offering Vendor's outbox.
+  - id: DEMOMA-08-008
+    priority: SHOULD
+    statement: >-
+      A trigger-side use case `SvcAcceptCaseManagerRoleUseCase` SHOULD be implemented
+      for the Case Actor to explicitly accept (rather than auto-accepting via the received
+      use case). This allows manual override of the auto-accept behavior for deployments
+      that require explicit operator approval before the Case Actor assumes the role.
+  - id: DEMOMA-08-009
+    priority: MUST
+    statement: >-
+      Unit and integration tests MUST cover the full CASE_MANAGER delegation handshake:
+      (1) Vendor offers role via `_OfferCaseManagerRoleActivity`,
+      (2) Case Actor auto-accepts via `OfferCaseManagerRoleReceivedUseCase`,
+      (3) Vendor receives `_AcceptCaseManagerRoleActivity` and triggers
+      trust bootstrap `Create(VulnerabilityCase)` to Reporter.
   - id: DEMOMA-08-003
     priority: MUST_NOT
     statement: >-

--- a/specs/participant-case-replica.yaml
+++ b/specs/participant-case-replica.yaml
@@ -287,6 +287,22 @@ groups:
       spec_id: PCR-08-002
       note: Using case_addressees() or None as the recipient in a trigger BT is
         the specific violation this requirement prevents
+  - id: PCR-08-012
+    priority: MUST
+    statement: >-
+      The invitee's `Accept(Invite)` activity IS the invitee's RM engagement decision.
+      The Case Actor MUST derive the `RmAcceptInviteToCaseActivity` domain event from
+      this message upon receipt, recording the invitee's RM transition (VALID → ACCEPTED)
+      in its own DataLayer without requiring a separate explicit RM state-change message
+      from the invitee.
+    rationale: >-
+      PCR-08-009 prohibits the case owner from emitting RM state-change activities on
+      behalf of the invitee but did not state who IS responsible. The invitee's
+      `Accept(Invite)` is the authoritative signal; the Case Actor is the sole party
+      authorized to record the resulting RM transition.
+    relationships:
+    - rel_type: refines
+      spec_id: PCR-08-009
 - id: PCR-07
   title: Testing
   specs:

--- a/specs/project-documentation.yaml
+++ b/specs/project-documentation.yaml
@@ -138,7 +138,10 @@ groups:
       (commit call sites, commit authorization/gating, or per-actor ledger content) MUST include a
       closing sub-issue that reviews a fresh multi-actor demo run's per-actor ledger logs before the
       Epic is closed. Passing the aggregate invariant test suite alone is NOT sufficient closure
-      evidence for such an Epic.
+      evidence for such an Epic. Concretely, an Epic is "in scope" for this rule if any change
+      within it touches `CommitCaseLedgerEntryNode`, `create_guarded_commit_case_ledger_entry_tree`,
+      or `create_commit_log_entry_tree` in `vultron/core/behaviors/`, or any call site that invokes
+      these directly.
     rationale: >-
       Epic #788's aggregate invariant suite (`test/ci/test_case_ledger_invariants.py`) passed
       all checks on `main` throughout the epic, yet the originating issue (#923) found 17

--- a/specs/sync-ledger-replication.yaml
+++ b/specs/sync-ledger-replication.yaml
@@ -90,8 +90,11 @@ groups:
     priority: SHOULD
     statement: The replication sender SHOULD implement retry with exponential backoff on delivery failure
   - id: SYNC-05-002
+    priority: SHOULD
+    statement: Retry and backoff parameters SHOULD be configurable
+  - id: SYNC-05-003
     priority: MUST
-    statement: Retry and backoff parameters SHOULD be configurable; default values MUST be documented
+    statement: Default values for retry and backoff parameters MUST be documented
 - id: SYNC-06
   title: Leadership and Ownership
   specs:
@@ -106,9 +109,14 @@ groups:
     statement: The SYNC-1 through SYNC-4 phases implement a **single-node CaseActor configuration** — a degenerate Raft cluster
       of one. A single-node CaseActor is always the leader and always has write authority; no election is needed.
   - id: SYNC-06-004
-    priority: MUST
-    statement: 'A future multi-node CaseActor cluster (Phase 3) provides high-availability write authority via Raft consensus.
-      This is a distinct replication tier from participant replication:'
+    priority: SHOULD
+    statement: >-
+      A future multi-node CaseActor cluster (Phase 3) provides high-availability write authority
+      via Raft consensus. This is a distinct replication tier from participant replication:
+      participant replication (SYNC-2) is pull-based fan-out via `Announce(CaseLedgerEntry)`,
+      whereas the multi-node CaseActor cluster uses Raft consensus to elect a single write
+      authority among the CaseActor nodes. The two tiers operate independently and SHOULD NOT
+      be conflated.
 - id: SYNC-09
   title: Commit Discipline
   specs:


### PR DESCRIPTION
- Closes #1114

## Summary

Addresses all 13 spec quality gaps found in the #1114 review: 6 definite
bugs (priority mismatches, contradictions, truncated content, typo) and 7
vagueness/incomplete items, resolving each through spec fixes or concrete
stub specs for downstream implementation.

## Changes

**Bug fixes:**
- `CLP` description typo: `ledgerging` → `ledgering`
- `CLP-02-006`: fix priority `MUST_NOT` → `MUST` (the statement requires
  `MUST` for the `log_index` field; wrong priority was misleading)
- `CP-01-004`: require inline `as_VulnerabilityReport` only; remove URI
  reference option (resolves contradiction with `AKM-03-001`)
- `SYNC-05-002`: split into `SYNC-05-002` (SHOULD configurable) +
  `SYNC-05-003` (MUST document defaults) to resolve mixed normative levels
- `SYNC-06-004`: complete truncated sentence; lower priority to SHOULD
  (Phase 3 Raft cluster is future work)
- `DEMOMA-06-002`: add missing M3 milestone (notes exchange complete,
  verified on both replicas) in correct order between M2 and M4

**Vagueness/incomplete resolutions:**
- `CBT-03-001`/`-003`: add default timeout value (300 s) and
  `AppConfig.pre_bootstrap_queue_timeout_seconds` cross-reference
- `CBT-03-004`: replace 'generic `Question`' with concrete
  `as_Question` class reference
- `ARCH-13-005`: add `ActorScopedDataLayer` method interface
  cross-reference (already implemented in `vultron/core/ports/datalayer.py`)
- `PCR-08-012` (new): positive counterpart to `PCR-08-009` — the
  invitee's `Accept(Invite)` IS the RM engagement signal
- `PD-09-004`: add concrete file/class anchors for the 'in scope' criterion
- `CP-05-005`/`-006` (new): atomicity, failure, and idempotency spec for
  the Accept + Create two-activity sequence
- `DEMOMA-08-002`: update to reflect wire vocab/extractor/received use cases
  already exist; add `DEMOMA-08-006` through `-009` stub specs covering
  the remaining implementation gap (semantic registry wiring + trigger use cases)

**Implementation issues created separately:**
- Demo phase ordering bug (M2/M3 execution order): #1125
- CASE_MANAGER delegation: semantic registry + received-side wiring: #1126
- CASE_MANAGER delegation: trigger-side use cases + tests: #1127