### PR TITLE
fix: run _phase_sync_verification (M2) before _phase_notes_exchange (M3)

### DIFF
--- a/plan/history/2606/implementation/ISSUE-1125.md
+++ b/plan/history/2606/implementation/ISSUE-1125.md
@@ -1,0 +1,23 @@
+---
+source: ISSUE-1125
+timestamp: '2026-06-23T13:28:32.082140+00:00'
+title: 'Fix demo scenario phase execution order: M2 before M3'
+type: implementation
+---
+
+## Issue #1125 — Fix demo scenario phase execution order: M2 (sync verification) must run before M3 (notes exchange)
+
+The two-actor demo in `vultron/demo/scenario/two_actor_demo.py` was executing
+phases in the wrong order: `_phase_notes_exchange` (M3) ran before
+`_phase_sync_verification` (M2). Per the CVD lifecycle and DEMOMA-06-002, the
+Finder must have the case replica (M2) before the notes exchange occurs (M3).
+
+**Fix**: Swapped `_phase_sync_verification` and `_phase_notes_exchange` call
+order in `run_two_actor_demo()`. Also updated a stale comment in
+`_phase_sync_verification` that referenced "After _phase_notes_exchange" — no
+longer accurate once sync verification runs before notes exchange.
+
+**Verification**: 4691 unit + integration tests pass; Black, flake8, mypy,
+pyright all clean.
+
+PR: [#1130](https://github.com/CERTCC/Vultron/pull/1130)

--- a/vultron/demo/scenario/two_actor_demo.py
+++ b/vultron/demo/scenario/two_actor_demo.py
@@ -540,12 +540,11 @@ def _phase_sync_verification(
     # `trigger_log_commit` and `wait_for_finder_log_entry` remain available
     # in `vultron.demo.helpers.sync` for tests that need to drive a *real*
     # protocol event and wait for its replica; they are intentionally not
-    # called here — EXCEPT for the final replica-state check below, where
-    # we must wait for finder to receive the vendor's latest canonical entry
-    # before comparing tail hashes.  After _phase_notes_exchange, the vendor's
-    # note reply creates a new canonical ledger entry (entry 3) whose
-    # Announce(CaseLedgerEntry) fan-out is an async BackgroundTask.
-    # Without this wait the tail hashes diverge (finder = entry 2, vendor = entry 3).
+    # called here — EXCEPT for the replica-state check below, where we must
+    # wait for finder to receive the vendor's latest canonical entry before
+    # comparing tail hashes.  The vendor's report-acceptance creates canonical
+    # ledger entries whose Announce(CaseLedgerEntry) fan-out is an async
+    # BackgroundTask; without this wait the tail hashes may diverge.
     vendor_entries = _get_log_entries_for_case(vendor_client, case.id_)
     if vendor_entries:
         vendor_tail = max(vendor_entries, key=lambda e: e["log_index"])
@@ -903,6 +902,14 @@ def run_two_actor_demo(
             vendor_id,
         )
     )
+    _phase_sync_verification(
+        finder_client,
+        vendor_client,
+        vendor,
+        finder,
+        case,
+        case_actor_client,
+    )
     _, _, _, finder_in_finder = _phase_notes_exchange(
         finder_client,
         vendor_client,
@@ -911,14 +918,6 @@ def run_two_actor_demo(
         vendor_in_vendor,
         case,
         report,
-    )
-    _phase_sync_verification(
-        finder_client,
-        vendor_client,
-        vendor,
-        finder,
-        case,
-        case_actor_client,
     )
     _phase_fix_lifecycle(
         finder_client,


### PR DESCRIPTION
- Closes #1125

## Summary

The two-actor demo was executing phases in the wrong order: notes exchange
(M3) ran before sync verification (M2). Per the CVD lifecycle and
DEMOMA-06-002, the Finder must have the case replica (M2) before the notes
exchange occurs (M3).

## Changes

- `vultron/demo/scenario/two_actor_demo.py`: swapped `_phase_sync_verification`
  and `_phase_notes_exchange` call order in `run_two_actor_demo()`; updated
  stale comment in `_phase_sync_verification` that referenced
  "After _phase_notes_exchange"

## Verification

- 4691 unit + integration tests pass (0 new, 37 skipped, 5 xfailed)
- Black, flake8, mypy, pyright clean