### PR TITLE
fix(demo): rename coordinator_* helpers to receiver_* and update two-actor demo

### DIFF
--- a/test/ci/test_case_ledger_invariants.py
+++ b/test/ci/test_case_ledger_invariants.py
@@ -409,8 +409,13 @@ def test_invariant_5_expected_event_types_present(
     Checked against the ``case-actor`` replica (authoritative log).
     Falls back to any available replica when no ``case-actor`` key exists.
 
-    AC-3: Promoted to hard pass for validate_report (#1029);
-    other types remain xfail pending #1026 follow-on fixes.
+    AC-3: Promoted to hard pass for validate_report (#1029).
+    Note: ``ack_report`` is intentionally excluded from this parametrize list.
+    The two-actor demo follows an "always create case on receipt" policy, so
+    the receiver learns the report was received via case creation itself —
+    a separate pre-case ``Read(Offer(Report))`` would be protocol noise in
+    this scenario.  A dedicated scenario that models the pre-case ACK flow
+    (with an explicit "manual-create" policy option) is tracked in #1133.
     """
     auth = _auth_entries(case_ledger_replicas)
     found = {_event_type(e) for e in auth}

--- a/vultron/demo/helpers/__init__.py
+++ b/vultron/demo/helpers/__init__.py
@@ -27,10 +27,11 @@ Sub-modules
 - :mod:`~vultron.demo.helpers.sync` — SYNC-2 ``trigger_log_commit`` and
   ``verify_replica_state``.
 - :mod:`~vultron.demo.helpers.verification` — lower-level participant and
-  case-state assertion primitives, plus ``verify_coordinator_case_state``
+  case-state assertion primitives, plus ``verify_receiver_case_state``
   and ``verify_case_actor_unused``.
 - :mod:`~vultron.demo.helpers.workflow` — ``reporter_submits_report``,
-  ``coordinator_validates_report``, and ``find_case_for_offer``.
+  ``receiver_validates_report``, ``receiver_engages_case``, and
+  ``find_case_for_offer``.
 - :mod:`~vultron.demo.helpers.notes` — ``participant_adds_note_to_case``.
 - :mod:`~vultron.demo.helpers.milestones` — lifecycle milestone verifiers
   (``verify_case_active``, ``verify_fix_ready``, ``verify_fix_deployed``,
@@ -89,12 +90,13 @@ from vultron.demo.helpers.verification import (  # noqa: F401
     _fetch_participant_data,
     _require_case_participant_id,
     verify_case_actor_unused,
-    verify_coordinator_case_state,
+    verify_receiver_case_state,
 )
 from vultron.demo.helpers.workflow import (  # noqa: F401
     _load_case_from_datalayer,
     _report_id_from_offer_data,
-    coordinator_validates_report,
     find_case_for_offer,
+    receiver_engages_case,
+    receiver_validates_report,
     reporter_submits_report,
 )

--- a/vultron/demo/helpers/milestones.py
+++ b/vultron/demo/helpers/milestones.py
@@ -42,10 +42,10 @@ logger = logging.getLogger(__name__)
 
 
 def verify_case_active(
-    coordinator_client: DataLayerClient,
+    receiver_client: DataLayerClient,
     reporter_client: DataLayerClient,
     case_id: str,
-    coordinator_actor_id: str,
+    receiver_actor_id: str,
     reporter_actor_id: str,
 ) -> None:
     """Verify that the case is active with required participants and EM.ACTIVE.
@@ -57,23 +57,23 @@ def verify_case_active(
     Spec: DEMOMA-06-002, DEMOMA-06-003.
 
     Args:
-        coordinator_client: Client connected to the coordinator container.
+        receiver_client: Client connected to the receiver container.
         reporter_client: Client connected to the reporter container.
         case_id: Full URI of the ``VulnerabilityCase``.
-        coordinator_actor_id: Full URI of the coordinator actor.
+        receiver_actor_id: Full URI of the receiver actor.
         reporter_actor_id: Full URI of the reporter actor.
 
     Raises:
         AssertionError: If any invariant is violated.
     """
     # Coordinator side
-    case_data = coordinator_client.get(f"/datalayer/{case_id}")
+    case_data = receiver_client.get(f"/datalayer/{case_id}")
     assert (
         case_data
-    ), f"verify_case_active: coordinator case {case_id!r} not found"
+    ), f"verify_case_active: receiver case {case_id!r} not found"
     case = VulnerabilityCase.model_validate(case_data)
 
-    required = {coordinator_actor_id, reporter_actor_id}
+    required = {receiver_actor_id, reporter_actor_id}
     missing = required - set(case.actor_participant_index.keys())
     if missing:
         raise AssertionError(
@@ -84,19 +84,19 @@ def verify_case_active(
     if not other_actors:
         raise AssertionError(
             "verify_case_active: expected a Case Actor participant in addition"
-            " to coordinator and reporter"
+            " to receiver and reporter"
         )
     if case.current_status.em_state != EM.ACTIVE:
         raise AssertionError(
-            f"verify_case_active coordinator: expected EM.ACTIVE, found"
+            f"verify_case_active receiver: expected EM.ACTIVE, found"
             f" {case.current_status.em_state}"
         )
     if case.active_embargo is None:
         raise AssertionError(
-            "verify_case_active coordinator: case has no active_embargo"
+            "verify_case_active receiver: case has no active_embargo"
         )
     logger.info(
-        "✓ case active (coordinator): required participants (coordinator,"
+        "✓ case active (receiver): required participants (receiver,"
         " reporter) + case-actor present, EM.ACTIVE, embargo present"
     )
 
@@ -109,15 +109,15 @@ def verify_case_active(
         )
     reporter_case = VulnerabilityCase.model_validate(reporter_case_data)
 
-    coordinator_embargo_id = _extract_ref_id(case.active_embargo)
+    receiver_embargo_id = _extract_ref_id(case.active_embargo)
     reporter_embargo_id = _extract_ref_id(reporter_case.active_embargo)
     if (
-        coordinator_embargo_id is not None
-        and coordinator_embargo_id != reporter_embargo_id
+        receiver_embargo_id is not None
+        and receiver_embargo_id != reporter_embargo_id
     ):
         raise AssertionError(
             f"verify_case_active: reporter active_embargo {reporter_embargo_id!r}"
-            f" != coordinator active_embargo {coordinator_embargo_id!r}"
+            f" != coordinator active_embargo {receiver_embargo_id!r}"
         )
     logger.info(
         "✓ case active (reporter): case replica present, matching participant"
@@ -126,20 +126,20 @@ def verify_case_active(
 
 
 def verify_fix_ready(
-    coordinator_client: DataLayerClient,
+    receiver_client: DataLayerClient,
     reporter_client: DataLayerClient,
     case_id: str,
-    coordinator_actor_id: str,
+    receiver_actor_id: str,
 ) -> None:
     """Verify that both replicas show CS includes F (fix ready).
 
     Spec: DEMOMA-06-002.
 
     Args:
-        coordinator_client: Client connected to the coordinator container.
+        receiver_client: Client connected to the receiver container.
         reporter_client: Client connected to the reporter container.
         case_id: Full URI of the ``VulnerabilityCase``.
-        coordinator_actor_id: Full URI of the coordinator actor whose
+        receiver_actor_id: Full URI of the receiver actor whose
             participant vfd_state to check.
 
     Raises:
@@ -147,16 +147,16 @@ def verify_fix_ready(
     """
     fix_ready_states = {CS_vfd.VFd, CS_vfd.VFD}
     _check_participant_vfd_state_in(
-        coordinator_client,
+        receiver_client,
         case_id,
-        coordinator_actor_id,
+        receiver_actor_id,
         fix_ready_states,
         "verify_fix_ready coordinator",
     )
     _check_participant_vfd_state_in(
         reporter_client,
         case_id,
-        coordinator_actor_id,
+        receiver_actor_id,
         fix_ready_states,
         "verify_fix_ready reporter replica",
     )
@@ -164,20 +164,20 @@ def verify_fix_ready(
 
 
 def verify_fix_deployed(
-    coordinator_client: DataLayerClient,
+    receiver_client: DataLayerClient,
     reporter_client: DataLayerClient,
     case_id: str,
-    coordinator_actor_id: str,
+    receiver_actor_id: str,
 ) -> None:
     """Verify that both replicas show CS includes D (fix deployed).
 
     Spec: DEMOMA-06-002.
 
     Args:
-        coordinator_client: Client connected to the coordinator container.
+        receiver_client: Client connected to the receiver container.
         reporter_client: Client connected to the reporter container.
         case_id: Full URI of the ``VulnerabilityCase``.
-        coordinator_actor_id: Full URI of the coordinator actor whose
+        receiver_actor_id: Full URI of the receiver actor whose
             participant vfd_state to check.
 
     Raises:
@@ -185,16 +185,16 @@ def verify_fix_deployed(
     """
     deployed_state = {CS_vfd.VFD}
     _check_participant_vfd_state_in(
-        coordinator_client,
+        receiver_client,
         case_id,
-        coordinator_actor_id,
+        receiver_actor_id,
         deployed_state,
         "verify_fix_deployed coordinator",
     )
     _check_participant_vfd_state_in(
         reporter_client,
         case_id,
-        coordinator_actor_id,
+        receiver_actor_id,
         deployed_state,
         "verify_fix_deployed reporter replica",
     )
@@ -204,10 +204,10 @@ def verify_fix_deployed(
 
 
 def verify_publicly_disclosed(
-    coordinator_client: DataLayerClient,
+    receiver_client: DataLayerClient,
     reporter_client: DataLayerClient,
     case_id: str,
-    coordinator_actor_id: str,
+    receiver_actor_id: str,
 ) -> None:
     """Verify that both replicas reflect CS.VFDPxa and EM has terminated.
 
@@ -219,16 +219,16 @@ def verify_publicly_disclosed(
     Spec: DEMOMA-06-002.
 
     Args:
-        coordinator_client: Client connected to the coordinator container.
+        receiver_client: Client connected to the receiver container.
         reporter_client: Client connected to the reporter container.
         case_id: Full URI of the ``VulnerabilityCase``.
-        coordinator_actor_id: Full URI of the coordinator actor.
+        receiver_actor_id: Full URI of the receiver actor.
 
     Raises:
         AssertionError: If any disclosure invariant is violated.
     """
     for label, client in [
-        ("coordinator", coordinator_client),
+        ("receiver", receiver_client),
         ("reporter", reporter_client),
     ]:
         case_data = client.get(f"/datalayer/{case_id}")
@@ -243,24 +243,24 @@ def verify_publicly_disclosed(
             )
         logger.info("✓ publicly disclosed %s: EM.EXITED", label)
 
-    # Verify coordinator participant's latest status is VFD + public-aware pxa
+    # Verify receiver participant's latest status is VFD + public-aware pxa
     # on both the coordinator's and reporter's DataLayer replicas.
     for label, c in [
-        ("coordinator", coordinator_client),
+        ("receiver", receiver_client),
         ("reporter", reporter_client),
     ]:
-        p = _fetch_participant(c, case_id, coordinator_actor_id)
+        p = _fetch_participant(c, case_id, receiver_actor_id)
         if p is None:
             raise AssertionError(
-                f"verify_publicly_disclosed {label}: coordinator participant"
-                f" {coordinator_actor_id!r} not found"
+                f"verify_publicly_disclosed {label}: receiver participant"
+                f" {receiver_actor_id!r} not found"
             )
-        _assert_participant_vfd_pxa(p, label, coordinator_actor_id)
+        _assert_participant_vfd_pxa(p, label, receiver_actor_id)
     logger.info("✓ publicly disclosed: both replicas CS.VFDPxa and EM.EXITED")
 
 
 def verify_case_closed(
-    coordinator_client: DataLayerClient,
+    receiver_client: DataLayerClient,
     reporter_client: DataLayerClient,
     case_id: str,
 ) -> None:
@@ -273,16 +273,16 @@ def verify_case_closed(
     Spec: DEMOMA-06-002.
 
     Args:
-        coordinator_client: Client connected to the coordinator container.
+        receiver_client: Client connected to the receiver container.
         reporter_client: Client connected to the reporter container.
         case_id: Full URI of the ``VulnerabilityCase``.
 
     Raises:
-        AssertionError: If any non-coordinator participant is not RM.CLOSED
+        AssertionError: If any non-receiver participant is not RM.CLOSED
             on either replica.
     """
     for label, client in [
-        ("coordinator", coordinator_client),
+        ("receiver", receiver_client),
         ("reporter", reporter_client),
     ]:
         case_data = client.get(f"/datalayer/{case_id}")

--- a/vultron/demo/helpers/verification.py
+++ b/vultron/demo/helpers/verification.py
@@ -272,7 +272,7 @@ def _all_fetchable_participants_rm_closed(
         case: The ``VulnerabilityCase`` whose participant index to walk.
 
     Returns:
-        ``True`` if all locally-fetchable non-coordinator participants are
+        ``True`` if all locally-fetchable non-receiver participants are
         ``RM.CLOSED``; ``False`` otherwise.
     """
     for p_id in case.actor_participant_index.values():
@@ -292,28 +292,28 @@ def _all_fetchable_participants_rm_closed(
     return True
 
 
-def verify_coordinator_case_state(
-    coordinator_client: DataLayerClient,
+def verify_receiver_case_state(
+    receiver_client: DataLayerClient,
     case_id: str,
     report_id: str,
-    coordinator_actor_id: str,
+    receiver_actor_id: str,
     reporter_actor_id: str,
     question_note_id: Optional[str] = None,
     reply_note_id: Optional[str] = None,
 ) -> VulnerabilityCase:
-    """Assert the final authoritative case state on the coordinator container.
+    """Assert the final authoritative case state on the receiver container.
 
     Verifies that the case references the submitted report, that all required
-    participants are present (coordinator, reporter, plus at least one Case
-    Actor), and that the coordinator participant has reached ``RM.ACCEPTED``
+    participants are present (receiver, reporter, plus at least one Case
+    Actor), and that the receiver participant has reached ``RM.ACCEPTED``
     with ``EM.ACTIVE`` and ``pxa == CS_pxa.pxa``.  Optionally checks that
     *question_note_id* and *reply_note_id* appear in the case notes.
 
     Args:
-        coordinator_client: Client connected to the coordinator container.
+        receiver_client: Client connected to the receiver container.
         case_id: Full URI of the ``VulnerabilityCase`` to verify.
         report_id: Full URI of the submitted vulnerability report.
-        coordinator_actor_id: Full URI of the coordinator actor.
+        receiver_actor_id: Full URI of the receiver actor.
         reporter_actor_id: Full URI of the reporter actor.
         question_note_id: Optional URI of the question note to assert present.
         reply_note_id: Optional URI of the reply note to assert present.
@@ -325,25 +325,25 @@ def verify_coordinator_case_state(
         AssertionError: If any invariant is violated.
     """
     final_case = VulnerabilityCase(
-        **coordinator_client.get(f"/datalayer/{case_id}")
+        **receiver_client.get(f"/datalayer/{case_id}")
     )
 
     # Verify required participants are present by ID rather than a raw count,
     # so future changes to the participant set don't silently break CI.
-    required_ids = {coordinator_actor_id, reporter_actor_id}
+    required_ids = {receiver_actor_id, reporter_actor_id}
     missing = required_ids - set(final_case.actor_participant_index.keys())
     if missing:
         raise AssertionError(
             f"Required participants missing from case: {missing}"
         )
-    # At least one Case Actor must be present beyond coordinator and reporter.
+    # At least one Case Actor must be present beyond receiver and reporter.
     other_actors = (
         set(final_case.actor_participant_index.keys()) - required_ids
     )
     if not other_actors:
         raise AssertionError(
             "Expected at least one Case Actor participant in addition to"
-            " coordinator and reporter"
+            " receiver and reporter"
         )
 
     report_ids = [
@@ -355,15 +355,13 @@ def verify_coordinator_case_state(
             "Final case does not reference the submitted report"
         )
 
-    coordinator_participant_id = _require_case_participant_id(
+    receiver_participant_id = _require_case_participant_id(
         final_case,
-        coordinator_actor_id,
+        receiver_actor_id,
         "Coordinator",
     )
     _require_case_participant_id(final_case, reporter_actor_id, "Reporter")
-    _assert_vendor_participant_state(
-        coordinator_client, coordinator_participant_id
-    )
+    _assert_vendor_participant_state(receiver_client, receiver_participant_id)
 
     _assert_vendor_case_status(final_case)
     _assert_case_notes(final_case, question_note_id, reply_note_id)
@@ -377,7 +375,7 @@ def verify_case_actor_unused(
     """Verify the dedicated CaseActor container remains unused in D5-2.
 
     Per D5-1-G3, the per-case ``VultronCaseActor`` co-locates in the
-    coordinator container for D5-2.  The standalone ``case-actor`` service
+    receiver container for D5-2.  The standalone ``case-actor`` service
     participates in the Docker topology but should not hold the created
     ``VulnerabilityCase``.
 

--- a/vultron/demo/helpers/workflow.py
+++ b/vultron/demo/helpers/workflow.py
@@ -48,27 +48,27 @@ logger = logging.getLogger(__name__)
 
 
 def reporter_submits_report(
-    coordinator_client: DataLayerClient,
+    receiver_client: DataLayerClient,
     reporter: as_Actor,
-    coordinator: as_Actor,
+    receiver: as_Actor,
     reporter_client: Optional[DataLayerClient] = None,
 ) -> Tuple[VulnerabilityReport, as_Offer]:
-    """Reporter creates a vulnerability report and submits it to the coordinator.
+    """Reporter creates a vulnerability report and submits it to the receiver.
 
     When ``reporter_client`` is provided (e.g. in a multi-container Docker
     demo), the report and offer are created via the reporter container's
     ``submit-report`` trigger endpoint so that the reporter container logs tell
     the full process-flow story (D5-6a).  The resulting offer is then delivered
-    to the coordinator container's inbox.
+    to the receiver container's inbox.
 
     When ``reporter_client`` is ``None`` (e.g. single-container integration
     tests), the report and offer are constructed in memory and posted directly
-    to the coordinator container (backward-compatible path).
+    to the receiver container (backward-compatible path).
 
     Args:
-        coordinator_client: Client connected to the coordinator container.
+        receiver_client: Client connected to the receiver's container.
         reporter: Reporter ``as_Actor``.
-        coordinator: Coordinator ``as_Actor``.
+        receiver: Receiver ``as_Actor``.
         reporter_client: Optional client connected to the reporter container.
             When provided, the submit-report trigger is called on the reporter
             container; when absent the legacy in-memory path is used.
@@ -84,7 +84,7 @@ def reporter_submits_report(
             "issue to execute arbitrary code with elevated privileges."
         )
         with demo_step(
-            "Reporter submits vulnerability report to coordinator's inbox"
+            "Reporter submits vulnerability report to receiver's inbox"
         ):
             result = post_to_trigger(
                 client=reporter_client,
@@ -93,18 +93,18 @@ def reporter_submits_report(
                 body={
                     "report_name": report_name,
                     "report_content": report_content,
-                    "recipient_id": coordinator.id_,
+                    "recipient_id": receiver.id_,
                 },
             )
         offer_dict = result.get("offer", {})
         report, offer = parse_submit_report_offer(offer_dict)
-        # Deliver the offer from the reporter to the coordinator's inbox.
+        # Deliver the offer from the reporter to the receiver's inbox.
         # Per ADR-0012 (per-actor DataLayer isolation) the trigger stores the
-        # offer only in the reporter's namespace; the coordinator must receive
+        # offer only in the reporter's namespace; the receiver must receive
         # it explicitly via inbox delivery so SubmitReportReceivedUseCase runs
         # and creates the case at RM.RECEIVED (ADR-0015).
-        with demo_step("Deliver reporter's offer to coordinator's inbox"):
-            post_to_inbox_and_wait(coordinator_client, coordinator.id_, offer)
+        with demo_step("Deliver reporter's offer to receiver's inbox"):
+            post_to_inbox_and_wait(receiver_client, receiver.id_, offer)
     else:
         report = VulnerabilityReport(
             attributed_to=reporter.id_,
@@ -118,83 +118,81 @@ def reporter_submits_report(
         offer = rm_submit_report_activity(
             report,
             actor=reporter.id_,
-            target=coordinator.id_,
-            to=coordinator.id_,
+            target=receiver.id_,
+            to=receiver.id_,
         )
         with demo_step(
-            "Reporter submits vulnerability report to coordinator's inbox"
+            "Reporter submits vulnerability report to receiver's inbox"
         ):
-            post_to_inbox_and_wait(coordinator_client, coordinator.id_, offer)
-    with demo_check("Report stored in coordinator's DataLayer"):
-        verify_object_stored(coordinator_client, report.id_)
-    with demo_check("Offer stored in coordinator's DataLayer"):
-        verify_object_stored(coordinator_client, offer.id_)
+            post_to_inbox_and_wait(receiver_client, receiver.id_, offer)
+    with demo_check("Report stored in receiver's DataLayer"):
+        verify_object_stored(receiver_client, report.id_)
+    with demo_check("Offer stored in receiver's DataLayer"):
+        verify_object_stored(receiver_client, offer.id_)
     logger.info("Report submitted: %s", ref_id(report))
     return report, offer
 
 
-def coordinator_validates_report(
-    coordinator_client: DataLayerClient,
-    coordinator: as_Actor,
+def receiver_validates_report(
+    receiver_client: DataLayerClient,
+    receiver: as_Actor,
     offer_id: str,
 ) -> dict:
-    """Coordinator validates the submitted report via the trigger endpoint.
+    """Receiver validates the submitted report via the trigger endpoint.
 
     Advances RM state to VALID only.  To transition RM to ACCEPTED the
-    coordinator must subsequently call ``coordinator_engages_case``.
+    receiver must subsequently call ``receiver_engages_case``.
 
     Args:
-        coordinator_client: Client connected to the coordinator container.
-        coordinator: Coordinator ``as_Actor``.
+        receiver_client: Client connected to the receiver's container.
+        receiver: Receiver ``as_Actor``.
         offer_id: Full URI of the submit-report ``as_Offer`` to validate.
 
     Returns:
         Response dict from the trigger endpoint (contains the validate
         activity).
     """
-    coordinator_obj_id = parse_id(coordinator.id_)["object_id"]
-    with demo_step("Coordinator validates the vulnerability report"):
+    receiver_obj_id = parse_id(receiver.id_)["object_id"]
+    with demo_step("Receiver validates the vulnerability report"):
         result = post_to_trigger(
-            client=coordinator_client,
-            actor_id=coordinator.id_,
+            client=receiver_client,
+            actor_id=receiver.id_,
             behavior="validate-report",
             body={"offer_id": offer_id},
         )
-    logger.info(
-        "Validate-report trigger result for actor %s", coordinator_obj_id
-    )
+    logger.info("Validate-report trigger result for actor %s", receiver_obj_id)
     return result
 
 
-def coordinator_engages_case(
-    coordinator_client: DataLayerClient,
-    coordinator: as_Actor,
+def receiver_engages_case(
+    receiver_client: DataLayerClient,
+    receiver: as_Actor,
     case_id: str,
 ) -> dict:
-    """Coordinator engages the case via the trigger endpoint (RM → ACCEPTED).
+    """Receiver engages the case via the trigger endpoint (RM → ACCEPTED).
 
-    This is a separate, explicit step from ``coordinator_validates_report``.
+    This is a separate, explicit step from ``receiver_validates_report``.
     Validation advances RM to VALID; engagement advances RM to ACCEPTED.
-    A coordinator may validly stop at VALID and defer further work.
+    A receiver may validly stop at VALID and defer further work.
 
     Args:
-        coordinator_client: Client connected to the coordinator container.
-        coordinator: Coordinator ``as_Actor``.
+        receiver_client: Client connected to the receiver's container.
+        receiver: Receiver ``as_Actor``.
         case_id: Full URI of the ``VulnerabilityCase`` to engage.
 
     Returns:
         Response dict from the trigger endpoint (contains the engage
         activity).
     """
-    coordinator_obj_id = parse_id(coordinator.id_)["object_id"]
-    with demo_step("Coordinator engages the vulnerability case"):
+    receiver_obj_id = parse_id(receiver.id_)["object_id"]
+    with demo_step("Receiver engages the vulnerability case"):
         result = post_to_trigger(
-            client=coordinator_client,
-            actor_id=coordinator.id_,
+            client=receiver_client,
+            actor_id=receiver.id_,
             behavior="engage-case",
             body={"case_id": case_id},
         )
-    logger.info("Engage-case trigger result for actor %s", coordinator_obj_id)
+    logger.info("Engage-case trigger result for actor %s", receiver_obj_id)
     return result
 
 

--- a/vultron/demo/scenario/two_actor_demo.py
+++ b/vultron/demo/scenario/two_actor_demo.py
@@ -111,14 +111,14 @@ from vultron.demo.helpers.verification import (  # noqa: F401
     _fetch_participant_data,
     _require_case_participant_id,
     verify_case_actor_unused,
-    verify_coordinator_case_state,
+    verify_receiver_case_state,
 )
 from vultron.demo.helpers.workflow import (  # noqa: F401
     _load_case_from_datalayer,
     _report_id_from_offer_data,
-    coordinator_engages_case,
-    coordinator_validates_report,
     find_case_for_offer,
+    receiver_engages_case,
+    receiver_validates_report,
     reporter_submits_report,
 )
 
@@ -183,9 +183,9 @@ def finder_submits_report(
     in new scenarios.
     """
     return reporter_submits_report(
-        coordinator_client=vendor_client,
+        receiver_client=vendor_client,
         reporter=finder,
-        coordinator=vendor,
+        receiver=vendor,
         reporter_client=finder_client,
     )
 
@@ -195,15 +195,32 @@ def vendor_validates_report(
     vendor: as_Actor,
     offer_id: str,
 ) -> dict:
-    """Scenario alias for :func:`~vultron.demo.helpers.workflow.coordinator_validates_report`.
+    """Vendor validates the submitted report via the trigger endpoint.
 
-    Maintained for backward compatibility; prefer
-    ``coordinator_validates_report`` in new scenarios.
+    Thin scenario wrapper around
+    :func:`~vultron.demo.helpers.workflow.receiver_validates_report`.
     """
-    return coordinator_validates_report(
-        coordinator_client=vendor_client,
-        coordinator=vendor,
+    return receiver_validates_report(
+        receiver_client=vendor_client,
+        receiver=vendor,
         offer_id=offer_id,
+    )
+
+
+def vendor_engages_case(
+    vendor_client: DataLayerClient,
+    vendor: as_Actor,
+    case_id: str,
+) -> dict:
+    """Vendor engages the case via the trigger endpoint (RM → ACCEPTED).
+
+    Thin scenario wrapper around
+    :func:`~vultron.demo.helpers.workflow.receiver_engages_case`.
+    """
+    return receiver_engages_case(
+        receiver_client=vendor_client,
+        receiver=vendor,
+        case_id=case_id,
     )
 
 
@@ -271,16 +288,16 @@ def verify_vendor_case_state(
     question_note_id: Optional[str] = None,
     reply_note_id: Optional[str] = None,
 ) -> VulnerabilityCase:
-    """Scenario alias for :func:`~vultron.demo.helpers.verification.verify_coordinator_case_state`.
+    """Scenario alias for :func:`~vultron.demo.helpers.verification.verify_receiver_case_state`.
 
     Maintained for backward compatibility; prefer
-    ``verify_coordinator_case_state`` in new scenarios.
+    ``verify_receiver_case_state`` in new scenarios.
     """
-    return verify_coordinator_case_state(
-        coordinator_client=vendor_client,
+    return verify_receiver_case_state(
+        receiver_client=vendor_client,
         case_id=case_id,
         report_id=report_id,
-        coordinator_actor_id=vendor_actor_id,
+        receiver_actor_id=vendor_actor_id,
         reporter_actor_id=reporter_actor_id,
         question_note_id=question_note_id,
         reply_note_id=reply_note_id,
@@ -300,10 +317,10 @@ def verify_m1_state(
     new scenarios.
     """
     return verify_case_active(
-        coordinator_client=vendor_client,
+        receiver_client=vendor_client,
         reporter_client=finder_client,
         case_id=case_id,
-        coordinator_actor_id=vendor_actor_id,
+        receiver_actor_id=vendor_actor_id,
         reporter_actor_id=reporter_actor_id,
     )
 
@@ -316,10 +333,10 @@ def verify_m4_state(
 ) -> None:
     """Scenario alias for :func:`~vultron.demo.helpers.milestones.verify_fix_ready`."""
     return verify_fix_ready(
-        coordinator_client=vendor_client,
+        receiver_client=vendor_client,
         reporter_client=finder_client,
         case_id=case_id,
-        coordinator_actor_id=vendor_actor_id,
+        receiver_actor_id=vendor_actor_id,
     )
 
 
@@ -331,10 +348,10 @@ def verify_m5_state(
 ) -> None:
     """Scenario alias for :func:`~vultron.demo.helpers.milestones.verify_fix_deployed`."""
     return verify_fix_deployed(
-        coordinator_client=vendor_client,
+        receiver_client=vendor_client,
         reporter_client=finder_client,
         case_id=case_id,
-        coordinator_actor_id=vendor_actor_id,
+        receiver_actor_id=vendor_actor_id,
     )
 
 
@@ -346,10 +363,10 @@ def verify_m6_state(
 ) -> None:
     """Scenario alias for :func:`~vultron.demo.helpers.milestones.verify_publicly_disclosed`."""
     return verify_publicly_disclosed(
-        coordinator_client=vendor_client,
+        receiver_client=vendor_client,
         reporter_client=finder_client,
         case_id=case_id,
-        coordinator_actor_id=vendor_actor_id,
+        receiver_actor_id=vendor_actor_id,
     )
 
 
@@ -360,7 +377,7 @@ def verify_m7_state(
 ) -> None:
     """Scenario alias for :func:`~vultron.demo.helpers.milestones.verify_case_closed`."""
     return verify_case_closed(
-        coordinator_client=vendor_client,
+        receiver_client=vendor_client,
         reporter_client=finder_client,
         case_id=case_id,
     )
@@ -406,14 +423,14 @@ def _phase_report_submission(
 
     vendor_in_vendor = get_actor_by_id(vendor_client, vendor.id_)
     report, offer = reporter_submits_report(
-        coordinator_client=vendor_client,
+        receiver_client=vendor_client,
         reporter=finder,
-        coordinator=vendor_in_vendor,
+        receiver=vendor_in_vendor,
         reporter_client=finder_client,
     )
-    coordinator_validates_report(
-        coordinator_client=vendor_client,
-        coordinator=vendor_in_vendor,
+    vendor_validates_report(
+        vendor_client=vendor_client,
+        vendor=vendor_in_vendor,
         offer_id=offer.id_,
     )
 
@@ -427,9 +444,9 @@ def _phase_report_submission(
 
     # validate-report advances RM to VALID only; engage-case is a separate
     # explicit step that advances RM to ACCEPTED (RM state machine protocol).
-    coordinator_engages_case(
-        coordinator_client=vendor_client,
-        coordinator=vendor_in_vendor,
+    vendor_engages_case(
+        vendor_client=vendor_client,
+        vendor=vendor_in_vendor,
         case_id=case.id_,
     )
 
@@ -456,10 +473,10 @@ def _phase_report_submission(
         "EM.ACTIVE, finder has case replica"
     ):
         verify_case_active(
-            coordinator_client=vendor_client,
+            receiver_client=vendor_client,
             reporter_client=finder_client,
             case_id=case.id_,
-            coordinator_actor_id=vendor.id_,
+            receiver_actor_id=vendor.id_,
             reporter_actor_id=finder.id_,
         )
 
@@ -503,11 +520,11 @@ def _phase_notes_exchange(
     with demo_check(
         "M3: Vendor container holds the authoritative final case state"
     ):
-        final_case = verify_coordinator_case_state(
-            coordinator_client=vendor_client,
+        final_case = verify_receiver_case_state(
+            receiver_client=vendor_client,
             case_id=case.id_,
             report_id=report.id_,
-            coordinator_actor_id=vendor.id_,
+            receiver_actor_id=vendor.id_,
             reporter_actor_id=finder.id_,
             question_note_id=question_note.id_,
             reply_note_id=reply_note.id_,
@@ -616,10 +633,10 @@ def _phase_fix_lifecycle(
             expected_states={CS_vfd.VFd, CS_vfd.VFD},
         )
         verify_fix_ready(
-            coordinator_client=vendor_client,
+            receiver_client=vendor_client,
             reporter_client=finder_client,
             case_id=case.id_,
-            coordinator_actor_id=vendor.id_,
+            receiver_actor_id=vendor.id_,
         )
 
     actor_notifies_fix_deployed(
@@ -636,10 +653,10 @@ def _phase_fix_lifecycle(
             expected_states={CS_vfd.VFD},
         )
         verify_fix_deployed(
-            coordinator_client=vendor_client,
+            receiver_client=vendor_client,
             reporter_client=finder_client,
             case_id=case.id_,
-            coordinator_actor_id=vendor.id_,
+            receiver_actor_id=vendor.id_,
         )
 
 
@@ -688,10 +705,10 @@ def _phase_publication(
             case_id=case.id_,
         )
         verify_publicly_disclosed(
-            coordinator_client=vendor_client,
+            receiver_client=vendor_client,
             reporter_client=finder_client,
             case_id=case.id_,
-            coordinator_actor_id=vendor.id_,
+            receiver_actor_id=vendor.id_,
         )
 
 
@@ -730,7 +747,7 @@ def _phase_case_closure(
             case_id=case.id_,
         )
         verify_case_closed(
-            coordinator_client=vendor_client,
+            receiver_client=vendor_client,
             reporter_client=finder_client,
             case_id=case.id_,
         )


### PR DESCRIPTION
- Closes #1039

## Summary

After a design discussion, the scope of #1039 was reduced. Adding `ack-report`
to the two-actor demo was found to be protocol noise under the "always create
case on receipt" policy — the reporter already learns the report was received
when they're added as a case participant. The pre-case ACK scenario (with a
manual-create policy option) is tracked in #1133.

This PR delivers the remaining AC items from #1039: fix the misleadingly-named
`coordinator_*` methods and update the stale test comment.

## Changes

**Renames across demo helpers:**
- `coordinator_validates_report` → `receiver_validates_report`
- `coordinator_engages_case` → `receiver_engages_case`
- `reporter_submits_report` params: `coordinator_client`/`coordinator` → `receiver_client`/`receiver`
- `verify_coordinator_case_state` → `verify_receiver_case_state`
- All `coordinator_client` / `coordinator_actor_id` params in `milestones.py` and `verification.py` → `receiver_client` / `receiver_actor_id`

**`two_actor_demo.py`:**
- Added `vendor_engages_case` wrapper (mirrors existing `vendor_validates_report`)
- Fixed `vendor_validates_report` docstring (was backwards — said "prefer coordinator_validates_report")
- Main demo sequence now calls `vendor_validates_report` / `vendor_engages_case`
- No more `coordinator_*` imports

**`test_case_ledger_invariants.py`:**
- Removed stale `#1026` reference from test docstring
- Added explanation of why `ack_report` is excluded; references #1133

## Verification

```
4294 passed, 37 skipped, 400 deselected, 2 xfailed, 5633 subtests passed in 58.02s
```