### PR TITLE
docs: add CONTEXT.md, agent skills config, and ADR-0024 coordination agent taxonomy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -837,3 +837,19 @@ History entries live under `plan/history/YYMM/<type>/<entry-id>.md`. Use the
 `notes/history-management.md` for the format and usage. During `orient-agent`,
 read only `plan/*.md` — access `plan/history/` only for investigating
 completed work.
+
+---
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in GitHub Issues; external PRs are not a triage surface. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default label vocabulary (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context repo: one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,104 @@
+# Vultron
+
+A federated, decentralized protocol for Coordinated Vulnerability Disclosure (CVD). Vultron
+models multi-party CVD (MPCVD) as a set of interacting state machines — Report Management
+(RM), Embargo Management (EM), and Case State (CS) — executed as Behavior Trees.
+
+## Language
+
+**Vulnerability (vul)**:
+A flaw in a product or system that an attacker could exploit. Abbreviated *vul*, not *vuln*.
+*Avoid*: vuln, bug (when the security-relevant sense is intended)
+
+**Coordinated Vulnerability Disclosure (CVD)**:
+A process in which a vulnerability is reported to the affected vendor(s), a fix is developed,
+and public disclosure is timed to minimize harm.
+*Avoid*: responsible disclosure, full disclosure (these have distinct meanings)
+
+**Multi-Party CVD (MPCVD)**:
+CVD involving more than two parties — typically a finder/reporter, a coordinator, and multiple
+affected vendors.
+*Avoid*: coordinated disclosure (too generic when multiple vendors are involved)
+
+**Case**:
+The unit of coordination in Vultron. A case captures all state and history for one MPCVD
+engagement: participants, embargo status, report management state, and the canonical ledger.
+*Avoid*: ticket, report (a report is what initiates a case, not the case itself)
+
+**Actor**:
+A participant in the Vultron protocol — a person, organization, or automated service that sends
+and receives protocol messages. Actors have persistent identities (URIs) and maintain their own
+DataLayer.
+*Avoid*: user, agent (in the protocol-participant sense; see Coordination Agent below)
+
+**Case Actor**:
+A special-purpose service actor that owns the canonical ledger for a case, coordinates
+participant invitations, and fans out protocol messages to all participants. Not a human.
+*Avoid*: coordinator (the Case Actor is a protocol role, not an organizational role)
+
+**Embargo**:
+A time-limited agreement among case participants to withhold public disclosure of a
+vulnerability until a specified date or condition.
+*Avoid*: NDA, hold
+
+---
+
+## Coordination Agents
+
+Vultron's Behavior Trees include **call-out points** — locations where the protocol cannot
+proceed automatically and must request input from an external party. Coordination agents are
+the capabilities that answer those call-out points.
+
+**Call-out point**:
+A location in a Vultron workflow where the protocol cannot determine the correct next action
+on its own and must request input — a fact, a decision, or content — from an external party
+(a human, an agent, or an external system) before it can continue.
+*Avoid*: decision point (reserved for SSVC scoring trees), touchpoint, integration point
+
+**Coordination agent**:
+An external capability — a skill, a set of skills with light orchestration, or a human — that
+answers a call-out point. A coordination agent has a narrow responsibility, explicit inputs,
+and explicit outputs. No single coordination agent is responsible for managing an entire case.
+*Avoid*: agent (alone; too broad), uber-agent
+
+The four canonical shapes a coordination agent can take:
+
+**Sentinel**:
+A coordination agent that monitors a condition and, when the condition is met, calls a Vultron
+trigger endpoint to initiate a protocol action. Sentinels are proactive — they loop or watch;
+they are not called by the protocol.
+*Avoid*: watcher, monitor (as standalone agent names)
+
+**Evaluator**:
+A coordination agent that is called by the protocol (or by an orchestrator) with a described
+situation and a set of options, and returns a structured recommendation or decision. The output
+shapes what the Behavior Tree does next.
+*Avoid*: advisor, scorer (these are valid sub-types but not the canonical type name)
+
+**Retriever**:
+A coordination agent that is called with a query and returns structured facts from an external
+source — vendor records, CPE entries, EPSS scores, threat intel, asset inventory, or similar.
+The Retriever fetches what already exists; it does not generate new content.
+*Avoid*: lookup, fetcher
+
+**Composer**:
+A coordination agent that is called with context (case state, participants, prior decisions)
+and generates a new content artifact — a notification draft, an advisory, a case summary, a
+participant invitation. The Composer produces something that did not exist before.
+*Avoid*: drafter, writer
+
+---
+
+## SSVC
+
+**SSVC (Stakeholder-Specific Vulnerability Categorization)**:
+A decision-support framework for vulnerability prioritization. SSVC defines decision points,
+enumerated answer sets, and decision tables that reduce multiple inputs to a prioritization
+outcome. Vultron reuses SSVC decision-point structures to represent process decisions at
+call-out points.
+*Avoid*: CVSS (a scoring system, not a decision framework)
+
+**Decision point** (SSVC sense):
+Within an SSVC tree, a specific question with an enumerated answer set that contributes to a
+prioritization outcome. Do not use this term for Vultron workflow call-out points more broadly.
+*Avoid*: (using this term outside the SSVC context)

--- a/docs/adr/0024-coordination-agent-taxonomy.md
+++ b/docs/adr/0024-coordination-agent-taxonomy.md
@@ -1,0 +1,54 @@
+# Coordination Agent Taxonomy
+
+Vultron's Behavior Trees contain **call-out points** — locations where the
+protocol cannot determine the correct next action autonomously and must request
+input from an external party. We established a canonical taxonomy of four agent
+shapes that answer those call-out points, and chose "call-out point" as the
+term for those locations.
+
+## Decisions
+
+### "Call-out point" as the canonical term
+
+We evaluated six alternatives: *touchpoint*, *integration point*, *hold point*,
+*extension point*, *deferral point*, and *decision point* (already reserved by
+SSVC). "Call-out point" was chosen because it makes the direction of flow
+explicit (protocol → external party → protocol), implies the workflow pauses
+and waits for a response, and cleanly contrasts with *trigger endpoint* (the
+call-*in* surface where external parties invoke the protocol).
+
+### Four canonical agent shapes
+
+| Shape | Role |
+| --- | --- |
+| **Sentinel** | Monitors a condition; when met, calls a trigger endpoint |
+| **Evaluator** | Receives a situation and options; returns a structured recommendation |
+| **Retriever** | Receives a query; returns structured facts from an external source |
+| **Composer** | Receives context; generates a new content artifact |
+
+These are a typology, not exactly four singleton agents. A real coordination
+agent may embody one shape or combine shapes (e.g., a Participant Discovery
+agent composes Retriever + Evaluator).
+
+### Message-Driven Responses excluded from the taxonomy
+
+An earlier draft included "message-driven responses" as a fifth category of
+agent touchpoint. This was rejected: receiving a protocol message is handled
+by the protocol's inbox BT, not by a coordination agent. The relevant
+call-out point — if any — is the evaluation or decision node that fires
+*after* message receipt, which already falls under Evaluator or Retriever.
+
+### Orchestrator deferred
+
+Whether **Orchestrator** constitutes a fifth agent shape (an agent that
+sequences other agents toward a bounded goal) is unresolved. No concrete
+multi-agent sequencing requirement exists yet. The question is tracked in
+GitHub issue #1141 and will be revisited when two or more concrete agent
+instances exist and a workflow clearly needs to sequence them.
+
+### "Retriever" over "Data Retriever"
+
+The qualifier "Data" was dropped to achieve parallel naming with the other
+single-word role nouns (Sentinel, Evaluator, Composer). The definition in
+`CONTEXT.md` makes clear that a Retriever returns structured external facts,
+not generated content — the qualifier is redundant.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -80,6 +80,7 @@ General information about architectural decision records is available at <https:
   CaseActor Routing](0022-single-bt-execution-for-received-side-case-actor-routing.md)
 - [ADR-0023 Introduce `CaseProposal` for Distributed Case Actor
   Initialization](0023-case-proposal-protocol.md)
+- [ADR-0024 Coordination Agent Taxonomy](0024-coordination-agent-taxonomy.md)
 
 ## Proposed ADRs
 

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,35 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo:
+
+```text
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-record-architecture-decisions.md
+│   └── 0002-model-processes-with-behavior-trees.md
+└── src/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> *Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…*

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,34 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.**
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## Summary

Establishes canonical vocabulary and documentation for Vultron coordination agents following a domain-modeling session on the fuzzer/call-out point taxonomy.

## Changes

- **`CONTEXT.md`** (new) — project glossary: core CVD/MPCVD terms, the four coordination agent types (Sentinel, Evaluator, Retriever, Composer), *call-out point* definition, SSVC vocabulary
- **`docs/agents/`** (new) — agent skills configuration:
  - `issue-tracker.md` — GitHub Issues as the tracker
  - `triage-labels.md` — default triage label mapping
  - `domain.md` — single-context doc layout
- **`AGENTS.md`** — appended `## Agent skills` section linking to `docs/agents/`
- **`docs/adr/0024-coordination-agent-taxonomy.md`** (new) — records decisions: *call-out point* term (rejected 6 alternatives), four canonical agent types, exclusion of message-driven responses, Orchestrator deferral, Retriever vs Data Retriever naming
- **`docs/adr/index.md`** — added ADR-0024 entry

## Verification

All pre-commit checks pass (markdownlint, flake8).

## Related issues

- #1143 Sentinel agent type
- #1144 Evaluator agent type
- #1145 Retriever agent type
- #1146 Composer agent type
- #1147 Coordination Agents Epic (groups #1141 #1142 #1143 #1144 #1145 #1146)