### PR TITLE
CP-06-004: RejectCaseProposalReceivedUseCase updates vendor local state

### DIFF
--- a/plan/history/2606/implementation/ISSUE-1135.md
+++ b/plan/history/2606/implementation/ISSUE-1135.md
@@ -1,0 +1,31 @@
+---
+source: ISSUE-1135
+timestamp: '2026-06-24T20:57:58.088821+00:00'
+title: 'CP-06-004: RejectCaseProposalReceivedUseCase updates vendor local state'
+type: implementation
+---
+
+## Issue #1135 — CP-06-004: RejectCaseProposalReceivedUseCase must update vendor local state
+
+Implemented CP-06-004: `RejectCaseProposalReceivedUseCase` now updates the
+vendor's `VultronReportCaseLink` with rejection state via a BT tree, instead
+of only emitting a WARNING log.
+
+**Changes:**
+
+- Added `proposal_rejected: bool` and `rejection_reason: NonEmptyString | None`
+  fields to `VultronReportCaseLink` (CP-06-004, CS-08-002).
+- Created `reject_case_proposal_received_tree.py` with
+  `_RecordCaseProposalRejectionNode` BT leaf and factory function
+  (BT-15-001 compliant).
+- Updated `RejectCaseProposalReceivedUseCase` to extract `report_id` and
+  `rejection_reason`, then delegate to BT tree via `BTBridge.execute_with_setup()`.
+- Fixed `_build_activity_snapshot` in the extractor to propagate the outer
+  AS2 activity's `summary` field into the `VultronActivity` snapshot
+  (normalised with `or None` to guard empty strings per CS-08-002).
+- Added 4 new unit tests (rejection state, rejection reason, missing-link
+  tolerance, log message).
+
+All 4323 unit tests pass. Black, flake8, mypy, pyright clean.
+
+PR: [#1153](https://github.com/CERTCC/Vultron/pull/1153)

--- a/test/core/use_cases/received/test_case_proposal.py
+++ b/test/core/use_cases/received/test_case_proposal.py
@@ -269,6 +269,87 @@ class TestAcceptCaseProposalReceivedUseCase:
 class TestRejectCaseProposalReceivedUseCase:
     """Tests for RejectCaseProposalReceivedUseCase (CP-06-002, CP-06-004)."""
 
+    def test_execute_marks_link_as_rejected(self, make_payload):
+        """Rejection sets proposal_rejected=True on VultronReportCaseLink (CP-06-004)."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        proposal = _make_proposal()
+        assert isinstance(proposal.object_, VulnerabilityReport)
+        report_id = proposal.object_.id_
+
+        # Seed a VultronReportCaseLink so the use case can find it
+        link = VultronReportCaseLink(
+            report_id=report_id,
+            trusted_case_creator_id=_CASE_ACTOR_URI,
+        )
+        dl.create(link)
+
+        activity = as_Reject(
+            actor=_CASE_ACTOR_URI,
+            object_=proposal,
+            to=[_VENDOR_URI],
+        )
+        event = make_payload(activity)
+        event = event.model_copy(update={"receiving_actor_id": _VENDOR_URI})
+
+        RejectCaseProposalReceivedUseCase(dl, event).execute()
+
+        stored_link = dl.read(VultronReportCaseLink.build_id(report_id))
+        assert isinstance(stored_link, VultronReportCaseLink)
+        assert (
+            stored_link.proposal_rejected is True
+        ), "proposal_rejected should be True after rejection"
+        assert (
+            stored_link.rejection_reason is None
+        ), "rejection_reason should be None when not provided"
+
+    def test_execute_records_rejection_reason(self, make_payload):
+        """When Reject activity carries a summary, it is stored as rejection_reason (CP-06-004)."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        proposal = _make_proposal()
+        assert isinstance(proposal.object_, VulnerabilityReport)
+        report_id = proposal.object_.id_
+
+        link = VultronReportCaseLink(
+            report_id=report_id,
+            trusted_case_creator_id=_CASE_ACTOR_URI,
+        )
+        dl.create(link)
+
+        rejection_summary = "Duplicate report; case already exists."
+        activity = as_Reject(
+            actor=_CASE_ACTOR_URI,
+            object_=proposal,
+            to=[_VENDOR_URI],
+            summary=rejection_summary,
+        )
+        event = make_payload(activity)
+        event = event.model_copy(update={"receiving_actor_id": _VENDOR_URI})
+
+        RejectCaseProposalReceivedUseCase(dl, event).execute()
+
+        stored_link = dl.read(VultronReportCaseLink.build_id(report_id))
+        assert isinstance(stored_link, VultronReportCaseLink)
+        assert stored_link.proposal_rejected is True
+        assert (
+            stored_link.rejection_reason == rejection_summary
+        ), "rejection_reason should match the Reject activity summary"
+
+    def test_execute_no_link_is_non_fatal(self, make_payload):
+        """Missing VultronReportCaseLink causes a warning but not an error (CP-06-004)."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        proposal = _make_proposal()
+
+        activity = as_Reject(
+            actor=_CASE_ACTOR_URI,
+            object_=proposal,
+            to=[_VENDOR_URI],
+        )
+        event = make_payload(activity)
+        event = event.model_copy(update={"receiving_actor_id": _VENDOR_URI})
+
+        # Should not raise even when no VultronReportCaseLink exists
+        RejectCaseProposalReceivedUseCase(dl, event).execute()
+
     def test_execute_logs_rejection(self, make_payload, caplog):
         """Rejection is surfaced via a warning-level log message (CP-06-004)."""
         dl = SqliteDataLayer("sqlite:///:memory:")
@@ -287,6 +368,3 @@ class TestRejectCaseProposalReceivedUseCase:
         assert any(
             "reject" in record.message.lower() for record in caplog.records
         ), "Expected a rejection log message"
-        # TODO(#1088): CP-06-004 MUST — update vendor local state to reflect
-        # rejection (e.g., mark VultronReportCaseLink as rejected). Tracked
-        # in https://github.com/CERTCC/Vultron/issues/1088.

--- a/vultron/core/behaviors/case/reject_case_proposal_received_tree.py
+++ b/vultron/core/behaviors/case/reject_case_proposal_received_tree.py
@@ -1,0 +1,117 @@
+"""BT tree for the RejectCaseProposal received-side use case.
+
+Vendor side: handles an inbound ``Reject(as_CaseProposal)`` by recording
+the rejection state in the vendor's ``VultronReportCaseLink``.
+
+Spec: ``specs/case-proposal.yaml`` CP-06-002, CP-06-004.
+"""
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+import logging
+from typing import Any
+
+import py_trees
+from py_trees.common import Status
+
+from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.models.report_case_link import VultronReportCaseLink
+
+logger = logging.getLogger(__name__)
+
+
+class _RecordCaseProposalRejectionNode(DataLayerAction):
+    """Mark the vendor's VultronReportCaseLink as rejected.
+
+    When the case-actor service rejects the proposal, the vendor records
+    ``proposal_rejected=True`` and, when provided, the ``rejection_reason``
+    so it can be surfaced to the operator (CP-06-004).
+
+    Returns SUCCESS even when no matching link is found, because the vendor
+    may not always have submitted a report offer before the proposal flow
+    (e.g. relay scenarios).  Missing-link situations are logged at WARNING.
+    """
+
+    def __init__(
+        self,
+        report_id: str,
+        rejection_reason: str | None = None,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._report_id = report_id
+        self._rejection_reason = rejection_reason
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.feedback_message = "DataLayer not available"
+            return Status.FAILURE
+
+        link_id = VultronReportCaseLink.build_id(self._report_id)
+        link = self.datalayer.read(link_id)
+
+        if not isinstance(link, VultronReportCaseLink):
+            logger.warning(
+                "%s: No VultronReportCaseLink found for report '%s'"
+                " — cannot record rejection state (CP-06-004)",
+                self.name,
+                self._report_id,
+            )
+            return Status.SUCCESS
+
+        link.proposal_rejected = True
+        link.rejection_reason = self._rejection_reason or None
+        self.datalayer.save(link)
+        logger.info(
+            "%s: Recorded proposal rejection for report '%s'"
+            " (reason: %r) (CP-06-004)",
+            self.name,
+            self._report_id,
+            self._rejection_reason,
+        )
+        return Status.SUCCESS
+
+
+def create_reject_case_proposal_received_tree(
+    report_id: str,
+    rejection_reason: str | None = None,
+) -> py_trees.behaviour.Behaviour:
+    """Return the received-side BT for processing ``Reject(as_CaseProposal)``.
+
+    Marks the vendor's ``VultronReportCaseLink`` as rejected and records
+    the rejection reason when present, allowing the vendor to surface the
+    rejection to the operator (CP-06-002, CP-06-004).
+
+    Args:
+        report_id: URI of the VulnerabilityReport linked to the proposal.
+        rejection_reason: Human-readable reason from the case-actor service,
+            taken from the Reject activity's ``summary`` field.  ``None``
+            when not provided.
+
+    Returns:
+        A py_trees Sequence behaviour ready for ``BTBridge.execute_with_setup``.
+    """
+    return py_trees.composites.Sequence(
+        name="RejectCaseProposalReceivedBT",
+        memory=False,
+        children=[
+            _RecordCaseProposalRejectionNode(
+                report_id=report_id,
+                rejection_reason=rejection_reason,
+            ),
+        ],
+    )

--- a/vultron/core/models/report_case_link.py
+++ b/vultron/core/models/report_case_link.py
@@ -21,7 +21,7 @@ from typing import Literal
 
 from pydantic import Field, model_validator
 
-from vultron.core.models.base import UriString, VultronObject
+from vultron.core.models.base import NonEmptyString, UriString, VultronObject
 
 
 class VultronReportCaseLink(VultronObject):
@@ -52,6 +52,21 @@ class VultronReportCaseLink(VultronObject):
             "validation.  Extracted from the CASE_MANAGER participant in the "
             "bootstrap snapshot; used to validate subsequent "
             "Announce(VulnerabilityCase) senders (CBT-01-006)."
+        ),
+    )
+    proposal_rejected: bool = Field(
+        default=False,
+        description=(
+            "True when the case-actor service rejected the CaseProposal "
+            "for this report (CP-06-004)."
+        ),
+    )
+    rejection_reason: NonEmptyString | None = Field(
+        default=None,
+        description=(
+            "Human-readable reason provided by the case-actor service when "
+            "rejecting the CaseProposal (CP-06-004).  None when not provided "
+            "or when the proposal was accepted."
         ),
     )
 

--- a/vultron/core/use_cases/received/case_proposal.py
+++ b/vultron/core/use_cases/received/case_proposal.py
@@ -270,7 +270,7 @@ class RejectCaseProposalReceivedUseCase:
                 BTBridge.get_failure_reason(tree) or result.feedback_message,
             )
         else:
-            logger.warning(
+            logger.info(
                 "reject_case_proposal_received: case-actor '%s' rejected"
                 " proposal for report '%s' (reason: %r) (CP-06-004)",
                 request.actor_id,

--- a/vultron/core/use_cases/received/case_proposal.py
+++ b/vultron/core/use_cases/received/case_proposal.py
@@ -41,6 +41,9 @@ from vultron.core.behaviors.case.accept_case_proposal_received_tree import (
 from vultron.core.behaviors.case.case_proposal_received_tree import (
     create_case_proposal_received_tree,
 )
+from vultron.core.behaviors.case.reject_case_proposal_received_tree import (
+    create_reject_case_proposal_received_tree,
+)
 from vultron.core.models.events.case_proposal import (
     AcceptCaseProposalReceivedEvent,
     CreateCaseProposalReceivedEvent,
@@ -214,13 +217,11 @@ class AcceptCaseProposalReceivedUseCase:
 class RejectCaseProposalReceivedUseCase:
     """Handle an inbound ``Reject(as_CaseProposal)`` on the vendor actor.
 
-    Logs the rejection so the vendor can surface it and take corrective
-    action (CP-06-002, CP-06-004).
+    Updates the vendor's ``VultronReportCaseLink`` to reflect the rejection,
+    setting ``proposal_rejected=True`` and recording any ``rejection_reason``
+    present in the activity's ``summary`` field (CP-06-002, CP-06-004).
 
-    TODO(#1088): CP-06-004 MUST — update vendor local state to reflect
-    rejection (e.g., mark VultronReportCaseLink as rejected with rejection
-    reason when present). A BT tree delegating via BTBridge is required once
-    this state field exists.
+    BT-15-001 audit: the DataLayer mutation is delegated to a BT leaf node.
 
     Spec: CP-06-002, CP-06-004.
     """
@@ -235,9 +236,44 @@ class RejectCaseProposalReceivedUseCase:
 
     def execute(self) -> None:
         request = self._request
-        logger.warning(
-            "reject_case_proposal_received: case-actor '%s' rejected"
-            " proposal '%s' (CP-06-004)",
-            request.actor_id,
-            request.proposal_id,
+
+        # The inner object is the VulnerabilityReport embedded in the proposal.
+        report_id = request.inner_object_id
+        if report_id is None:
+            logger.warning(
+                "reject_case_proposal_received: no report_id available"
+                " — cannot update VultronReportCaseLink (CP-06-004)"
+            )
+            return
+
+        # The rejection reason comes from the Reject activity's summary field.
+        rejection_reason: str | None = None
+        if request.activity is not None:
+            rejection_reason = request.activity.summary
+
+        receiving_actor_id = request.receiving_actor_id or request.actor_id
+
+        tree = create_reject_case_proposal_received_tree(
+            report_id=report_id,
+            rejection_reason=rejection_reason,
         )
+        result = BTBridge(datalayer=self._dl).execute_with_setup(
+            tree=tree,
+            actor_id=receiving_actor_id,
+            activity=request,
+        )
+        if result.status != Status.SUCCESS:
+            logger.warning(
+                "reject_case_proposal_received: BT did not succeed"
+                " for report '%s': %s",
+                report_id,
+                BTBridge.get_failure_reason(tree) or result.feedback_message,
+            )
+        else:
+            logger.warning(
+                "reject_case_proposal_received: case-actor '%s' rejected"
+                " proposal for report '%s' (reason: %r) (CP-06-004)",
+                request.actor_id,
+                report_id,
+                rejection_reason,
+            )

--- a/vultron/wire/as2/extractor/_builders.py
+++ b/vultron/wire/as2/extractor/_builders.py
@@ -101,6 +101,7 @@ def _build_activity_snapshot(
         in_reply_to=_get_id(getattr(activity, "in_reply_to", None)),
         to=_get_id_list(getattr(activity, "to", None)),
         cc=_get_id_list(getattr(activity, "cc", None)),
+        summary=getattr(activity, "summary", None) or None,
     )
 
 


### PR DESCRIPTION
- Closes #1135

## Summary

Implements CP-06-004: `RejectCaseProposalReceivedUseCase` now updates the
vendor's `VultronReportCaseLink` with rejection state instead of only
emitting a WARNING log. A new BT tree delegates the DataLayer mutation via
`BTBridge.execute_with_setup()` (BT-15-001). Also fixes
`_build_activity_snapshot` to propagate the outer activity's `summary`
field into the `VultronActivity` snapshot so rejection reasons (and other
activity-level summaries) are accessible to use cases.

## Changes

- `vultron/core/models/report_case_link.py`: Add `proposal_rejected: bool` and `rejection_reason: NonEmptyString | None` fields (CP-06-004, CS-08-002)
- `vultron/core/behaviors/case/reject_case_proposal_received_tree.py`: New BT module with `_RecordCaseProposalRejectionNode` leaf and `create_reject_case_proposal_received_tree()` factory (BT-15-001)
- `vultron/core/use_cases/received/case_proposal.py`: Update `RejectCaseProposalReceivedUseCase` to extract `report_id` and `rejection_reason`, then delegate to BT tree
- `vultron/wire/as2/extractor/_builders.py`: Propagate `summary` from outer AS2 activity into `VultronActivity` snapshot (normalised with `or None` to guard against empty strings)
- `test/core/use_cases/received/test_case_proposal.py`: 4 new tests covering rejection state, rejection reason, missing-link tolerance, and log message

## Verification

- All 4323 unit tests pass (4 new)
- Black, flake8, mypy, pyright clean