### PR TITLE
CP-05-005 (part 1): Add PendingCreateCaseActivity durable marker and wire into received BT tree

### DIFF
--- a/notes/case-proposal.md
+++ b/notes/case-proposal.md
@@ -193,3 +193,25 @@ corresponding `MessageSemantics` value.
 
 None — all design decisions were resolved in the planning session.
 See `docs/adr/0023-case-proposal-protocol.md` for the alternatives evaluated.
+
+---
+
+## Durable-Delivery Marker (CP-05-005)
+
+The case-actor's accepted path involves two sequenced outbound activities
+(`Accept(CaseProposal)` then `Create(VulnerabilityCase)`). If the second
+delivery fails after the first succeeds, the vendor receives an Accept with
+no corresponding case announcement.
+
+To recover from this, a `PendingCreateCaseActivity` marker is written to
+the DataLayer **after** `Accept` is sent and **before** `Create` is
+attempted (implemented in `vultron/core/behaviors/case/
+case_proposal_received_tree.py`). The marker captures the proposal ID,
+case-actor ID, vendor URI, and the pre-constructed
+`Create(VulnerabilityCase)` payload. It is deleted on successful
+`Create` delivery, so only failed deliveries leave a marker.
+
+A retry runner (issue #1139) will scan for persisted markers and
+re-deliver the `Create(VulnerabilityCase)` payload verbatim using the
+stored `id_` — never re-constructing the activity — to avoid ID
+divergence between the marker and the delivered activity.

--- a/plan/history/2606/implementation/ISSUE-1136.md
+++ b/plan/history/2606/implementation/ISSUE-1136.md
@@ -1,0 +1,30 @@
+---
+source: ISSUE-1136
+timestamp: '2026-06-24T21:05:41.496673+00:00'
+title: Add PendingCreateCaseActivity durable marker
+type: implementation
+---
+
+## Issue #1136 — CP-05-005 (part 1): Add PendingCreateCaseActivity durable marker and wire into received BT tree
+
+Added a durable `PendingCreateCaseActivity` DataLayer marker and wired it
+into the `CreateCaseProposalReceivedBT` tree to satisfy CP-05-005.
+
+### What was done
+
+- Created `vultron/core/models/pending_create_case_activity.py`: new
+  `VultronObject` subclass with `proposal_id`, `case_actor_id`, `vendor_uri`,
+  and `create_activity_payload` fields; stable `id_` derived from `proposal_id`
+  via `build_id()`.
+- Created `vultron/wire/as2/vocab/objects/pending_create_case_activity.py`:
+  registers `PendingCreateCaseActivity` in the wire `VOCABULARY` so SQLite
+  DataLayer can deserialize it.
+- Extended `case_proposal_received_tree.py` from a 3-node to a 5-node
+  Sequence: `_WriteCreateCaseMarkerNode` (writes marker after Accept, before
+  Create) and `_ClearCreateCaseMarkerNode` (clears on Create success; always
+  returns SUCCESS).
+- Added 13 unit tests in `test/core/behaviors/case/test_case_proposal_received_tree.py`
+  covering model round-trips, marker write/clear, and partial-failure paths.
+- All 4334 unit tests pass; Black, flake8, mypy, pyright clean.
+
+PR: [#1154](https://github.com/CERTCC/Vultron/pull/1154)

--- a/test/core/behaviors/case/test_case_proposal_received_tree.py
+++ b/test/core/behaviors/case/test_case_proposal_received_tree.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Unit tests for CreateCaseProposalReceivedBT marker behaviour (CP-05-005).
+
+AC-4: Verifies that
+  - The ``PendingCreateCaseActivity`` marker is written after Accept succeeds
+    and before Create fires (AC-2).
+  - The marker is removed when Create(VulnerabilityCase) is delivered
+    successfully (AC-3).
+  - The marker remains when Create(VulnerabilityCase) delivery fails (AC-2
+    partial-failure path).
+  - The marker stores at minimum: proposal_id, case_actor_id, vendor_uri,
+    and the pre-constructed Create(VulnerabilityCase) payload (AC-1).
+"""
+
+import logging
+from unittest.mock import patch
+
+import py_trees
+import pytest
+
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.core.behaviors.bridge import BTBridge
+from vultron.core.behaviors.case.case_proposal_received_tree import (
+    _ClearCreateCaseMarkerNode,
+    _WriteCreateCaseMarkerNode,
+)
+from vultron.core.models.pending_create_case_activity import (
+    PendingCreateCaseActivity,
+)
+from vultron.semantic_registry import extract_event
+
+# noqa: F401 — imported for vocabulary registration side-effect
+from vultron.wire.as2.vocab.objects.case_proposal import as_CaseProposal
+from vultron.wire.as2.vocab.objects.vulnerability_case import (  # noqa: F401
+    VulnerabilityCase,
+)
+
+
+@pytest.fixture
+def make_payload():
+    """Return a helper that extracts a VultronEvent from an AS2 activity."""
+
+    def _make_payload(activity, **extra_fields):
+        event = extract_event(activity)
+        if extra_fields:
+            return event.model_copy(update=extra_fields)
+        return event
+
+    return _make_payload
+
+
+_CASE_ACTOR_URI = "https://example.org/case-actors/svc-1"
+_VENDOR_URI = "https://example.org/vendors/acme"
+_PROPOSAL_URI = "https://example.org/proposals/p-001"
+
+
+def _make_proposal() -> as_CaseProposal:
+    return as_CaseProposal(
+        id_=_PROPOSAL_URI,
+        attributed_to=_VENDOR_URI,
+        object_="https://example.org/reports/r-001",
+        target=_CASE_ACTOR_URI,
+    )
+
+
+class TestPendingCreateCaseActivityModel:
+    """AC-1: model stores required fields and produces stable ID."""
+
+    def test_build_id_is_stable(self):
+        """build_id() returns the same value for the same proposal_id."""
+        marker_id = PendingCreateCaseActivity.build_id(_PROPOSAL_URI)
+        assert "pending-create-case/" in marker_id
+        assert PendingCreateCaseActivity.build_id(_PROPOSAL_URI) == marker_id
+
+    def test_id_is_set_from_proposal_id(self):
+        """id_ is computed deterministically from proposal_id."""
+        marker = PendingCreateCaseActivity(
+            proposal_id=_PROPOSAL_URI,
+            case_actor_id=_CASE_ACTOR_URI,
+            vendor_uri=_VENDOR_URI,
+        )
+        assert marker.id_ == PendingCreateCaseActivity.build_id(_PROPOSAL_URI)
+
+    def test_required_fields_present(self):
+        """Model captures all four required fields (AC-1)."""
+        payload = {"type": "Create", "actor": _CASE_ACTOR_URI}
+        marker = PendingCreateCaseActivity(
+            proposal_id=_PROPOSAL_URI,
+            case_actor_id=_CASE_ACTOR_URI,
+            vendor_uri=_VENDOR_URI,
+            create_activity_payload=payload,
+        )
+        assert marker.proposal_id == _PROPOSAL_URI
+        assert marker.case_actor_id == _CASE_ACTOR_URI
+        assert marker.vendor_uri == _VENDOR_URI
+        assert marker.create_activity_payload == payload
+
+    def test_roundtrip_through_datalayer(self):
+        """Marker survives a DataLayer save/read round-trip."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        marker = PendingCreateCaseActivity(
+            proposal_id=_PROPOSAL_URI,
+            case_actor_id=_CASE_ACTOR_URI,
+            vendor_uri=_VENDOR_URI,
+            create_activity_payload={"type": "Create"},
+        )
+        dl.save(marker)
+        retrieved = dl.read(marker.id_)
+        assert isinstance(retrieved, PendingCreateCaseActivity)
+        assert retrieved.proposal_id == _PROPOSAL_URI
+        assert retrieved.case_actor_id == _CASE_ACTOR_URI
+        assert retrieved.vendor_uri == _VENDOR_URI
+
+
+class TestWriteCreateCaseMarkerNode:
+    """Unit tests for _WriteCreateCaseMarkerNode."""
+
+    def _run_node(
+        self, dl: SqliteDataLayer, actor_id: str, case_id: str, accept_id: str
+    ) -> py_trees.common.Status:
+        """Execute _WriteCreateCaseMarkerNode via BTBridge."""
+        node = _WriteCreateCaseMarkerNode(
+            proposal_id=_PROPOSAL_URI, vendor_uri=_VENDOR_URI
+        )
+        # Wrap in a Sequence so BTBridge can set up the blackboard.
+        tree = py_trees.composites.Sequence(
+            name="TestSeq", memory=False, children=[node]
+        )
+        # Pre-populate blackboard keys the node reads.
+        py_trees.blackboard.Blackboard.enable_activity_stream()
+        client = py_trees.blackboard.Client(name="TestSetup")
+        client.register_key(key="case_id", access=py_trees.common.Access.WRITE)
+        client.register_key(
+            key="accept_activity_id", access=py_trees.common.Access.WRITE
+        )
+        client.case_id = case_id
+        client.accept_activity_id = accept_id
+
+        result = BTBridge(datalayer=dl).execute_with_setup(
+            tree=tree, actor_id=actor_id
+        )
+        return result.status
+
+    def test_writes_marker_to_datalayer(self):
+        """Marker is persisted after node executes (AC-2)."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        status = self._run_node(
+            dl,
+            actor_id=_CASE_ACTOR_URI,
+            case_id="https://example.org/cases/c-001",
+            accept_id="https://example.org/activities/a-001",
+        )
+        assert status == py_trees.common.Status.SUCCESS
+        marker_id = PendingCreateCaseActivity.build_id(_PROPOSAL_URI)
+        marker = dl.read(marker_id)
+        assert isinstance(
+            marker, PendingCreateCaseActivity
+        ), "Marker should be stored in DataLayer"
+        assert marker.proposal_id == _PROPOSAL_URI
+        assert marker.case_actor_id == _CASE_ACTOR_URI
+        assert marker.vendor_uri == _VENDOR_URI
+
+    def test_marker_contains_create_payload(self):
+        """Marker create_activity_payload is non-empty and contains actor (AC-1)."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        self._run_node(
+            dl,
+            actor_id=_CASE_ACTOR_URI,
+            case_id="https://example.org/cases/c-001",
+            accept_id="https://example.org/activities/a-001",
+        )
+        marker_id = PendingCreateCaseActivity.build_id(_PROPOSAL_URI)
+        marker = dl.read(marker_id)
+        assert isinstance(marker, PendingCreateCaseActivity)
+        payload = marker.create_activity_payload
+        assert payload, "create_activity_payload must not be empty"
+        assert (
+            payload.get("actor") == _CASE_ACTOR_URI
+            or payload.get("attributedTo") == _CASE_ACTOR_URI
+            or _CASE_ACTOR_URI in str(payload)
+        ), "Payload must reference the case-actor URI"
+
+    def test_fails_when_case_id_missing(self):
+        """FAILURE returned when case_id is absent from blackboard."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        node = _WriteCreateCaseMarkerNode(
+            proposal_id=_PROPOSAL_URI, vendor_uri=_VENDOR_URI
+        )
+        tree = py_trees.composites.Sequence(
+            name="TestSeq", memory=False, children=[node]
+        )
+        # Only set accept_activity_id — omit case_id.
+        client = py_trees.blackboard.Client(name="TestSetup2")
+        client.register_key(
+            key="accept_activity_id", access=py_trees.common.Access.WRITE
+        )
+        client.accept_activity_id = "https://example.org/activities/a-001"
+
+        result = BTBridge(datalayer=dl).execute_with_setup(
+            tree=tree, actor_id=_CASE_ACTOR_URI
+        )
+        assert result.status == py_trees.common.Status.FAILURE
+
+
+class TestClearCreateCaseMarkerNode:
+    """Unit tests for _ClearCreateCaseMarkerNode."""
+
+    def _run_clear_node(
+        self, dl: SqliteDataLayer, actor_id: str
+    ) -> py_trees.common.Status:
+        node = _ClearCreateCaseMarkerNode(proposal_id=_PROPOSAL_URI)
+        tree = py_trees.composites.Sequence(
+            name="TestSeq", memory=False, children=[node]
+        )
+        result = BTBridge(datalayer=dl).execute_with_setup(
+            tree=tree, actor_id=actor_id
+        )
+        return result.status
+
+    def test_removes_existing_marker(self):
+        """Marker is absent after _ClearCreateCaseMarkerNode runs (AC-3)."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        marker = PendingCreateCaseActivity(
+            proposal_id=_PROPOSAL_URI,
+            case_actor_id=_CASE_ACTOR_URI,
+            vendor_uri=_VENDOR_URI,
+        )
+        dl.save(marker)
+        # Confirm it's there before clearing.
+        assert isinstance(dl.read(marker.id_), PendingCreateCaseActivity)
+
+        status = self._run_clear_node(dl, actor_id=_CASE_ACTOR_URI)
+        assert status == py_trees.common.Status.SUCCESS
+        assert (
+            dl.read(marker.id_) is None
+        ), "Marker should be removed after clear node"
+
+    def test_succeeds_when_marker_already_absent(self, caplog):
+        """SUCCESS returned even if the marker was already removed (idempotent)."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        with caplog.at_level(logging.WARNING, logger="vultron"):
+            status = self._run_clear_node(dl, actor_id=_CASE_ACTOR_URI)
+        assert status == py_trees.common.Status.SUCCESS
+
+    def test_always_returns_success(self):
+        """_ClearCreateCaseMarkerNode always returns SUCCESS regardless of delete result."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        # Run without pre-seeding a marker — delete returns False.
+        status = self._run_clear_node(dl, actor_id=_CASE_ACTOR_URI)
+        assert status == py_trees.common.Status.SUCCESS
+
+
+class TestCreateCaseProposalReceivedBTMarkerWiring:
+    """AC-4: end-to-end marker write/clear via the full BT tree."""
+
+    def _make_event(self, make_payload):
+        """Build a CreateCaseProposalReceivedEvent for the full tree."""
+        from vultron.wire.as2.vocab.base.objects.activities.transitive import (
+            as_Create,
+        )
+
+        proposal = _make_proposal()
+        activity = as_Create(
+            actor=_VENDOR_URI,
+            object_=proposal,
+            to=[_CASE_ACTOR_URI],
+        )
+        event = make_payload(activity)
+        return event.model_copy(update={"receiving_actor_id": _CASE_ACTOR_URI})
+
+    def test_marker_absent_after_full_success(self, make_payload):
+        """AC-3: Marker is removed when Create(VulnerabilityCase) succeeds."""
+        from vultron.core.use_cases.received.case_proposal import (
+            CreateCaseProposalReceivedUseCase,
+        )
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        event = self._make_event(make_payload)
+
+        CreateCaseProposalReceivedUseCase(dl, event).execute()
+
+        marker_id = PendingCreateCaseActivity.build_id(_PROPOSAL_URI)
+        assert (
+            dl.read(marker_id) is None
+        ), "Marker must be cleared on full BT success (AC-3)"
+
+    def test_marker_present_when_create_fails(self, make_payload):
+        """AC-2 / AC-4: Marker is written and persists when Create delivery fails."""
+        from vultron.core.behaviors.case.case_proposal_received_tree import (
+            _EmitCreateVulnerabilityCaseNode,
+        )
+        from vultron.core.use_cases.received.case_proposal import (
+            CreateCaseProposalReceivedUseCase,
+        )
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        event = self._make_event(make_payload)
+
+        # Patch the Create-emit node so it fails after Accept and marker write.
+        with patch.object(
+            _EmitCreateVulnerabilityCaseNode,
+            "update",
+            return_value=py_trees.common.Status.FAILURE,
+        ):
+            CreateCaseProposalReceivedUseCase(dl, event).execute()
+
+        marker_id = PendingCreateCaseActivity.build_id(_PROPOSAL_URI)
+        marker = dl.read(marker_id)
+        assert isinstance(
+            marker, PendingCreateCaseActivity
+        ), "Marker must be present when Create delivery fails (AC-2)"
+        assert marker.proposal_id == _PROPOSAL_URI
+        assert marker.vendor_uri == _VENDOR_URI
+        assert marker.case_actor_id == _CASE_ACTOR_URI
+
+    def test_marker_payload_stored_on_partial_failure(self, make_payload):
+        """AC-1 / AC-4: Marker payload is non-empty on partial failure."""
+        from vultron.core.behaviors.case.case_proposal_received_tree import (
+            _EmitCreateVulnerabilityCaseNode,
+        )
+        from vultron.core.use_cases.received.case_proposal import (
+            CreateCaseProposalReceivedUseCase,
+        )
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        event = self._make_event(make_payload)
+
+        with patch.object(
+            _EmitCreateVulnerabilityCaseNode,
+            "update",
+            return_value=py_trees.common.Status.FAILURE,
+        ):
+            CreateCaseProposalReceivedUseCase(dl, event).execute()
+
+        marker_id = PendingCreateCaseActivity.build_id(_PROPOSAL_URI)
+        marker = dl.read(marker_id)
+        assert isinstance(marker, PendingCreateCaseActivity)
+        assert (
+            marker.create_activity_payload
+        ), "create_activity_payload must not be empty (AC-1)"

--- a/test/core/behaviors/case/test_case_proposal_received_tree.py
+++ b/test/core/behaviors/case/test_case_proposal_received_tree.py
@@ -215,6 +215,44 @@ class TestWriteCreateCaseMarkerNode:
         )
         assert result.status == py_trees.common.Status.FAILURE
 
+    def test_fails_when_accept_activity_id_missing(self):
+        """FAILURE returned when accept_activity_id is absent from blackboard."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        node = _WriteCreateCaseMarkerNode(
+            proposal_id=_PROPOSAL_URI, vendor_uri=_VENDOR_URI
+        )
+        tree = py_trees.composites.Sequence(
+            name="TestSeq", memory=False, children=[node]
+        )
+        # Only set case_id — omit accept_activity_id.
+        client = py_trees.blackboard.Client(name="TestSetup3")
+        client.register_key(key="case_id", access=py_trees.common.Access.WRITE)
+        client.case_id = "https://example.org/cases/c-001"
+
+        result = BTBridge(datalayer=dl).execute_with_setup(
+            tree=tree, actor_id=_CASE_ACTOR_URI
+        )
+        assert result.status == py_trees.common.Status.FAILURE
+
+    def test_fails_when_datalayer_save_raises(self):
+        """FAILURE returned when DataLayer.save raises; no subsequent write occurs."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+
+        with patch.object(dl, "save", side_effect=RuntimeError("disk full")):
+            status = self._run_node(
+                dl,
+                actor_id=_CASE_ACTOR_URI,
+                case_id="https://example.org/cases/c-001",
+                accept_id="https://example.org/activities/a-001",
+            )
+
+        assert status == py_trees.common.Status.FAILURE
+        # No marker should have been persisted.
+        marker_id = PendingCreateCaseActivity.build_id(_PROPOSAL_URI)
+        assert (
+            dl.read(marker_id) is None
+        ), "No marker should be stored when save raises"
+
 
 class TestClearCreateCaseMarkerNode:
     """Unit tests for _ClearCreateCaseMarkerNode."""

--- a/vultron/core/behaviors/case/case_proposal_received_tree.py
+++ b/vultron/core/behaviors/case/case_proposal_received_tree.py
@@ -6,7 +6,11 @@ two outbound activities in sequence:
   1. ``Accept(as_CaseProposal)`` — acknowledgement to the vendor
   2. ``Create(VulnerabilityCase)`` — case announcement to the vendor
 
-Spec: ``specs/case-proposal.yaml`` CP-05-001 through CP-05-004.
+A durable ``PendingCreateCaseActivity`` marker is written to the DataLayer
+after step 1 and cleared on successful completion of step 2 so that a retry
+runner (#1139) can recover the obligation if delivery of step 2 fails.
+
+Spec: ``specs/case-proposal.yaml`` CP-05-001 through CP-05-005.
 """
 
 #  Copyright (c) 2026 Carnegie Mellon University and Contributors.
@@ -34,7 +38,11 @@ from vultron.core.models.activity import (
     VultronCreateCaseActivity,
 )
 from vultron.core.models.case import VultronCase
+from vultron.core.models.pending_create_case_activity import (
+    PendingCreateCaseActivity,
+)
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
+from vultron.core.ports.datalayer import DataLayer
 
 logger = logging.getLogger(__name__)
 
@@ -228,6 +236,142 @@ class _EmitCreateVulnerabilityCaseNode(DataLayerAction):
         return Status.SUCCESS
 
 
+class _WriteCreateCaseMarkerNode(DataLayerAction):
+    """Write a ``PendingCreateCaseActivity`` marker to the DataLayer.
+
+    Called after ``Accept(CaseProposal)`` has been sent and before
+    ``Create(VulnerabilityCase)`` is attempted.  The marker records the
+    obligation so that a retry runner (#1139) can complete it if the
+    subsequent ``Create(VulnerabilityCase)`` delivery fails (CP-05-005).
+
+    Reads ``case_id`` and ``accept_activity_id`` from the blackboard to
+    pre-construct the ``Create(VulnerabilityCase)`` payload stored in the
+    marker.  Returns FAILURE if either blackboard key is missing or the
+    DataLayer write fails, so the Sequence halts before attempting delivery.
+    """
+
+    def __init__(
+        self,
+        proposal_id: str,
+        vendor_uri: str,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._proposal_id = proposal_id
+        self._vendor_uri = vendor_uri
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="case_id", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="accept_activity_id", access=py_trees.common.Access.READ
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None or self.actor_id is None:
+            self.feedback_message = "DataLayer or actor_id not available"
+            return Status.FAILURE
+
+        try:
+            case_id = self.blackboard.get("case_id")
+        except KeyError:
+            self.feedback_message = "case_id not found in blackboard"
+            return Status.FAILURE
+
+        try:
+            accept_activity_id = self.blackboard.get("accept_activity_id")
+        except KeyError:
+            self.feedback_message = (
+                "accept_activity_id not found in blackboard"
+            )
+            return Status.FAILURE
+
+        # Pre-construct the payload that will be (re-)sent as
+        # Create(VulnerabilityCase).  Mirrors the logic in
+        # _EmitCreateVulnerabilityCaseNode so the retry runner (#1139)
+        # can reconstruct the exact same activity without re-running the BT.
+        create_activity = VultronCreateCaseActivity(
+            actor=self.actor_id,
+            object_=case_id,
+            context=accept_activity_id,
+            to=[self._vendor_uri],
+        )
+        payload = create_activity.model_dump(by_alias=True)
+
+        marker = PendingCreateCaseActivity(
+            proposal_id=self._proposal_id,
+            case_actor_id=self.actor_id,
+            vendor_uri=self._vendor_uri,
+            create_activity_payload=payload,
+        )
+
+        try:
+            self.datalayer.save(marker)
+        except Exception as exc:  # pragma: no cover
+            self.feedback_message = f"Failed to write marker: {exc}"
+            logger.warning("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
+
+        logger.info(
+            "%s: Wrote PendingCreateCaseActivity marker for proposal '%s'",
+            self.name,
+            self._proposal_id,
+        )
+        return Status.SUCCESS
+
+
+class _ClearCreateCaseMarkerNode(DataLayerAction):
+    """Remove the ``PendingCreateCaseActivity`` marker after successful delivery.
+
+    Called after ``Create(VulnerabilityCase)`` has been queued to the
+    outbox.  Deletes the marker so the retry runner (#1139) does not
+    re-deliver an already-sent activity (CP-05-005, AC-3).
+
+    Always returns SUCCESS: the ``Create(VulnerabilityCase)`` has already
+    been delivered; a cleanup failure must not roll back the delivery or
+    fail the Sequence.  A warning is logged if the delete fails so that
+    stale markers can be detected during retry-runner inspection.
+    """
+
+    def __init__(
+        self,
+        proposal_id: str,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._proposal_id = proposal_id
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            logger.warning(
+                "%s: DataLayer not available — marker '%s' may be stale",
+                self.name,
+                self._proposal_id,
+            )
+            return Status.SUCCESS
+
+        marker_id = PendingCreateCaseActivity.build_id(self._proposal_id)
+        deleted = cast(DataLayer, self.datalayer).delete(
+            "PendingCreateCaseActivity", marker_id
+        )
+        if deleted:
+            logger.info(
+                "%s: Cleared PendingCreateCaseActivity marker for proposal '%s'",
+                self.name,
+                self._proposal_id,
+            )
+        else:
+            logger.warning(
+                "%s: PendingCreateCaseActivity marker for proposal '%s'"
+                " was not found during cleanup — may already be cleared",
+                self.name,
+                self._proposal_id,
+            )
+        return Status.SUCCESS
+
+
 def create_case_proposal_received_tree(
     report_id: str | None,
     proposal_id: str,
@@ -236,13 +380,19 @@ def create_case_proposal_received_tree(
 ) -> py_trees.behaviour.Behaviour:
     """Return the received-side BT for processing a ``Create(as_CaseProposal)``.
 
-    The tree is a Sequence of three leaf nodes:
+    The tree is a Sequence of five leaf nodes:
 
     1. ``_CreateCaseFromProposalNode`` — creates VulnerabilityCase
     2. ``_EmitAcceptCaseProposalNode`` — emits Accept(as_CaseProposal)
-    3. ``_EmitCreateVulnerabilityCaseNode`` — emits Create(VulnerabilityCase)
+    3. ``_WriteCreateCaseMarkerNode`` — writes durable retry marker (CP-05-005)
+    4. ``_EmitCreateVulnerabilityCaseNode`` — emits Create(VulnerabilityCase)
+    5. ``_ClearCreateCaseMarkerNode`` — removes marker on success (CP-05-005)
 
-    Spec: CP-05-001 through CP-05-004.
+    If node 4 fails the marker written in node 3 remains in the DataLayer so
+    that a retry runner (#1139) can complete the ``Create(VulnerabilityCase)``
+    delivery independently.
+
+    Spec: CP-05-001 through CP-05-005.
 
     Args:
         report_id: URI of the VulnerabilityReport embedded in the proposal
@@ -268,6 +418,11 @@ def create_case_proposal_received_tree(
                 vendor_uri=vendor_uri,
                 proposal_dict=proposal_dict,
             ),
+            _WriteCreateCaseMarkerNode(
+                proposal_id=proposal_id,
+                vendor_uri=vendor_uri,
+            ),
             _EmitCreateVulnerabilityCaseNode(vendor_uri=vendor_uri),
+            _ClearCreateCaseMarkerNode(proposal_id=proposal_id),
         ],
     )

--- a/vultron/core/behaviors/case/case_proposal_received_tree.py
+++ b/vultron/core/behaviors/case/case_proposal_received_tree.py
@@ -42,7 +42,6 @@ from vultron.core.models.pending_create_case_activity import (
     PendingCreateCaseActivity,
 )
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
-from vultron.core.ports.datalayer import DataLayer
 
 logger = logging.getLogger(__name__)
 
@@ -224,9 +223,17 @@ class _EmitCreateVulnerabilityCaseNode(DataLayerAction):
             logger.warning("%s: %s", self.name, self.feedback_message)
             return Status.FAILURE
 
-        cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
-            self.actor_id, activity.id_
-        )
+        try:
+            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
+                self.actor_id, activity.id_
+            )
+        except Exception as exc:
+            self.feedback_message = (
+                f"Failed to enqueue Create(VulnerabilityCase) to outbox: {exc}"
+            )
+            logger.warning("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
+
         logger.info(
             "%s: Queued Create(VulnerabilityCase) '%s' for case '%s'",
             self.name,
@@ -309,7 +316,7 @@ class _WriteCreateCaseMarkerNode(DataLayerAction):
 
         try:
             self.datalayer.save(marker)
-        except Exception as exc:  # pragma: no cover
+        except Exception as exc:
             self.feedback_message = f"Failed to write marker: {exc}"
             logger.warning("%s: %s", self.name, self.feedback_message)
             return Status.FAILURE
@@ -353,9 +360,7 @@ class _ClearCreateCaseMarkerNode(DataLayerAction):
             return Status.SUCCESS
 
         marker_id = PendingCreateCaseActivity.build_id(self._proposal_id)
-        deleted = cast(DataLayer, self.datalayer).delete(
-            "PendingCreateCaseActivity", marker_id
-        )
+        deleted = self.datalayer.delete("PendingCreateCaseActivity", marker_id)
         if deleted:
             logger.info(
                 "%s: Cleared PendingCreateCaseActivity marker for proposal '%s'",

--- a/vultron/core/models/pending_create_case_activity.py
+++ b/vultron/core/models/pending_create_case_activity.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Durable marker for a pending ``Create(VulnerabilityCase)`` obligation.
+
+The ``PendingCreateCaseActivity`` record is written to the DataLayer after
+``Accept(CaseProposal)`` has been sent but *before* the
+``Create(VulnerabilityCase)`` delivery is attempted.  If delivery of
+``Create(VulnerabilityCase)`` fails (or the process crashes between the two
+sends), the marker persists so that a retry runner (#1139) can discover the
+unfulfilled obligation and complete it.
+
+Spec: ``specs/case-proposal.yaml`` CP-05-005.
+"""
+
+import urllib.parse
+from typing import Any, Literal
+
+from pydantic import Field, model_validator
+
+from vultron.core.models.base import UriString, VultronObject
+
+
+class PendingCreateCaseActivity(VultronObject):
+    """Durable marker recording a pending ``Create(VulnerabilityCase)`` obligation.
+
+    The marker stores the minimum information needed to reconstruct and
+    re-deliver the ``Create(VulnerabilityCase)`` activity without re-running
+    the full BT tree.
+
+    Attributes:
+        proposal_id: URI of the ``as_CaseProposal`` that was accepted.
+            Used as the stable key component for ``build_id()``.
+        case_actor_id: URI of the case-actor service that issued the
+            ``Accept(CaseProposal)`` and owns the ``Create(VulnerabilityCase)``
+            obligation.
+        vendor_uri: URI of the vendor actor to whom
+            ``Create(VulnerabilityCase)`` must be delivered.
+        create_activity_payload: Pre-constructed
+            ``Create(VulnerabilityCase)`` payload as a plain dict
+            (``model_dump(by_alias=True)``).  The retry runner (#1139)
+            reconstructs the activity from this dict rather than rebuilding
+            it from scratch.
+
+    Spec: CP-05-005.
+    """
+
+    type_: Literal["PendingCreateCaseActivity"] = Field(  # type: ignore[assignment]
+        default="PendingCreateCaseActivity",
+        validation_alias="type",
+        serialization_alias="type",
+    )
+    proposal_id: UriString = Field(
+        ..., description="URI of the CaseProposal that was accepted"
+    )
+    case_actor_id: UriString = Field(
+        ..., description="URI of the case-actor service sending the Create"
+    )
+    vendor_uri: UriString = Field(
+        ...,
+        description="URI of the vendor recipient of Create(VulnerabilityCase)",
+    )
+    create_activity_payload: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Pre-constructed Create(VulnerabilityCase) payload "
+            "(model_dump by_alias=True) for retry use"
+        ),
+    )
+
+    @classmethod
+    def build_id(cls, proposal_id: str) -> str:
+        """Return the stable DataLayer ID for *proposal_id*."""
+        slug = urllib.parse.quote(proposal_id, safe="")
+        return f"pending-create-case/{slug}"
+
+    @model_validator(mode="after")
+    def _set_id(self) -> "PendingCreateCaseActivity":
+        """Compute ``id_`` deterministically from ``proposal_id``."""
+        self.id_ = self.build_id(self.proposal_id)
+        return self
+
+
+__all__ = ["PendingCreateCaseActivity"]

--- a/vultron/core/ports/case_persistence.py
+++ b/vultron/core/ports/case_persistence.py
@@ -75,6 +75,8 @@ class CasePersistence(Protocol):
         self, short_id: str
     ) -> PersistableModel | None: ...
 
+    def delete(self, table: str, id_: str) -> bool: ...
+
 
 class CaseOutboxPersistence(CasePersistence, Protocol):
     """CasePersistence extended for use cases that enqueue outbound activities.

--- a/vultron/wire/as2/vocab/objects/pending_create_case_activity.py
+++ b/vultron/wire/as2/vocab/objects/pending_create_case_activity.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Wire-layer vocabulary registration for :class:`PendingCreateCaseActivity`."""
+
+from vultron.core.models.pending_create_case_activity import (
+    PendingCreateCaseActivity,
+)
+from vultron.wire.as2.vocab.base.registry import VOCABULARY
+
+VOCABULARY["PendingCreateCaseActivity"] = PendingCreateCaseActivity
+
+__all__ = ["PendingCreateCaseActivity"]


### PR DESCRIPTION
- Closes #1136

## Summary

Adds a durable `PendingCreateCaseActivity` DataLayer marker and wires it
into `CreateCaseProposalReceivedBT`, so that a retry runner (#1139) can
recover a partial failure where `Accept(CaseProposal)` was sent but
`Create(VulnerabilityCase)` delivery failed (CP-05-005).

## Changes

- **`vultron/core/models/pending_create_case_activity.py`**: New domain
  model extending `VultronObject`. Stores `proposal_id`,
  `case_actor_id`, `vendor_uri`, and a pre-constructed
  `Create(VulnerabilityCase)` payload dict. ID is derived deterministically
  from `proposal_id` via `build_id()` for stable DataLayer lookups.
- **`vultron/wire/as2/vocab/objects/pending_create_case_activity.py`**:
  Registers `PendingCreateCaseActivity` in the wire `VOCABULARY` so the
  SQLite DataLayer can deserialize it on `read()`.
- **`vultron/core/behaviors/case/case_proposal_received_tree.py`**: Adds
  two new BT leaf nodes and expands the Sequence from 3 to 5 nodes:
  `_WriteCreateCaseMarkerNode` (node 3) writes the marker after Accept
  succeeds; `_ClearCreateCaseMarkerNode` (node 5) removes it after Create
  is queued. The clear node always returns SUCCESS so a cleanup error cannot
  roll back an already-delivered activity. Uses `cast(DataLayer, ...)` to
  call `delete()` since `CasePersistence` does not expose that method.
- **`test/core/behaviors/case/test_case_proposal_received_tree.py`**: 13
  new unit tests covering model round-trips, marker write, clear, partial
  failure (Accept sent / Create fails → marker persists), and full-success
  (marker cleared).

## Verification

- All 4334 unit tests pass (13 new)
- Black, flake8, mypy, pyright clean
- [x] AC-1: `PendingCreateCaseActivity` stores proposal_id, case_actor_id, vendor_uri, payload
- [x] AC-2: Marker written after Accept succeeds, before Create fires
- [x] AC-3: Marker cleared on successful Create delivery
- [x] AC-4: Tests cover partial-failure and full-success marker paths
- [ ] AC-5: Full `pytest -m ""` — deferred to #1139 (no demo files touched)