### PR TITLE
docs: add pr-review skill for project-scoped PR auditing

### DIFF
--- a/.agents/skills/pr-review/REFERENCE.md
+++ b/.agents/skills/pr-review/REFERENCE.md
@@ -1,0 +1,197 @@
+# PR Review — Reference
+
+Detailed criteria for each review phase. Referenced from SKILL.md.
+
+---
+
+## Spec Conformance Criteria
+
+When checking changed code against loaded specs, focus on the spec IDs most
+relevant to the changed file paths:
+
+| Changed path prefix | Primary specs to load |
+|---|---|
+| `vultron/wire/as2/` | `architecture.yaml` (ARCH-14), `code-style.yaml` (CS-08) |
+| `vultron/core/behaviors/` | `behavior-tree-integration.yaml`, `behavior-tree-node-design.yaml` |
+| `vultron/core/use_cases/` | `behavior-tree-integration.yaml` (BT-06, BT-15), `inbox-orchestration.yaml` |
+| `vultron/core/models/` | `architecture.yaml` (ARCH-10, ARCH-12), `code-style.yaml` (CS-20) |
+| `vultron/adapters/` | `outbox.yaml`, `architecture.yaml` (ARCH-14) |
+| `vultron/demo/` | `behavior-tree-integration.yaml` (BT demo patterns) |
+| `docs/`, `notes/`, `specs/` | `project-documentation.yaml` |
+| `plan/history/` | `history-management.yaml` (HM-01–HM-05) |
+
+For each spec ID mentioned in the linked issue or PR body, confirm the
+corresponding requirement is met in the diff.
+
+---
+
+## AGENTS.md Rule Checklist
+
+Check the diff for violations of these non-negotiable rules. Mark **FAIL** for
+confirmed violations; **WARN** for likely violations requiring closer inspection.
+
+### Naming
+
+- [ ] Domain class names use CVD-domain vocabulary, not wire-format parallels
+- [ ] `vul` (not `vuln`) as the abbreviation for vulnerability
+- [ ] Wire layer classes in `vultron/wire/as2/vocab/objects/` use `as_` prefix
+- [ ] Core domain classes do NOT use `as_` prefix
+- [ ] Use-case classes follow Received/Svc/\_trigger naming conventions
+
+### Type Safety and Validation
+
+- [ ] No `Optional[str]` fields that accept empty strings — use `NonEmptyString`
+  or `OptionalNonEmptyString`, or add a validator
+- [ ] No new `Any` usages without justification
+- [ ] Pydantic v2 style (`model_validator`, `field_validator`) throughout
+- [ ] Fail-fast domain objects: required fields not typed as `X | None`
+  in concrete subclasses (ARCH-10-001)
+- [ ] Protocol fields stay in sync with concrete implementations (CS-20-001)
+- [ ] `TypeGuard` discriminators use only Protocol-declared fields (CS-20-002)
+
+### BT Integration (if `behaviors/` or `use_cases/` changed)
+
+- [ ] BT nodes do NOT call use-case classes from `update()` (no BT→UC→BT chain)
+- [ ] BT nodes do NOT import from use-case modules
+- [ ] `update()` stays under ~20–30 lines; large nodes decomposed into subtrees
+- [ ] Protocol-significant behavior lives in BT leaf nodes, not in `execute()`
+- [ ] `execute()` does NOT call `dl.save()` / `dl.create()` / `dl.update()` directly
+- [ ] Received-side BTs commit the triggering activity BEFORE applying protocol effects
+- [ ] Guarded-commit BTs are role-gated (CaseActor identity check before commit)
+- [ ] No new `CommitCaseLedgerEntryNode` calls bypassing `BTBridge`
+
+### ActivityStreams / Wire Layer (if `wire/as2/` changed)
+
+- [ ] `SEMANTICS_ACTIVITY_PATTERNS`: specific patterns ordered before general ones
+- [ ] `rehydrate()` called before pattern matching
+- [ ] Outbound activities use factory functions in `vultron.wire.as2.factories`
+- [ ] `as_VulnerabilityCase` (wire) vs `VulnerabilityCase` (core) — correct prefix in each layer
+
+### Use Cases (if `use_cases/` changed)
+
+- [ ] Received-side use cases do NOT spoof another actor's identity
+- [ ] Trigger-side `execute()` delegates SM transitions to `BTBridge`, not inline
+- [ ] No `case_addressees()` on the participant sender side (PCR-08-001/02)
+
+### Adapters (if `adapters/` changed)
+
+- [ ] Stub adapter files raise `NotImplementedError`, not silent no-op
+- [ ] `create_app()` does NOT mutate module-level singletons
+- [ ] Actor IDs are full URIs
+
+### Module Organization
+
+- [ ] No flat `nodes.py` in BT areas (must use `nodes/` subpackage)
+- [ ] New submodules after a split stay under 500 lines
+- [ ] Subpackage `__init__.py` re-exports all public names (including request models)
+
+---
+
+## ADR Check Criteria
+
+Architectural signals that warrant an ADR (per `notes/specs-vs-adrs.md`
+MS-11-001–MS-11-006):
+
+- Introducing a new layer or cross-layer dependency direction
+- Changing the public API or persistence schema
+- Adding a new adapter type (driving or driven)
+- Changing how BT execution is orchestrated (e.g., concurrency model)
+- Adopting a new protocol pattern with broad reuse implications
+- Reversing or superseding a previous architectural decision
+
+**Check procedure:**
+
+1. `gh pr diff <number> -- docs/adr/` — did the PR add or modify an ADR?
+2. `cat docs/adr/index.md` — does an existing ADR cover the area changed?
+3. If the PR's approach contradicts an existing ADR without a new ADR: **FAIL**.
+4. If the change has architectural signals but no ADR: **WARN** with a
+   suggested title for a follow-up ADR.
+
+---
+
+## Notes and Docs Currency Criteria
+
+### Domain-to-notes mapping (common cases)
+
+| Changed domain | Potentially relevant notes files |
+|---|---|
+| `wire/as2/` | `activitystreams-semantics.md`, `vocabulary-registry.md` |
+| `core/behaviors/` | `bt-integration.md` |
+| `core/use_cases/` | `bt-integration.md`, `event-driven-control-flow.md` |
+| `core/models/case` | `case-state-model.md`, `case-communication-model.md` |
+| `adapters/` | `architecture-adapters.md`, `architecture-hexagonal.md` |
+| `core/ports/` | `architecture-hexagonal.md` |
+| Embargo logic | `participant-embargo-consent.md`, `embargo-lifecycle.md` |
+| Case ledger | `case-ledger-authority.md` |
+| Inbox processing | `inbox-orchestration.md` |
+| Participant routing | `case-communication-model.md` |
+
+### Check procedure
+
+1. Identify relevant notes from the table above.
+2. For each relevant note: was it modified in the PR diff? If not: **WARN**.
+3. For each `notes/*.md` file **modified** in the PR: validate frontmatter.
+4. If any modified note has `status: superseded`, flag that it should have
+   been moved to `archived_notes/` instead of edited.
+5. If `docs/` was modified: confirm `uv run mkdocs build --strict` passed
+   (check CI or run locally).
+
+---
+
+## Report Format
+
+Produce a report with this structure. Use emoji for scanability.
+
+```markdown
+## PR Review: #<number> — <title>
+
+**Linked issues**: #N (<title>), #M (<title>)
+**Changed files**: <count> files, <domains>
+**CI status**: ✅ passing / ❌ failing / ⏳ pending
+
+---
+
+### ✅ Issue Linkage
+Implementation scope matches #N and #M. No scope creep or gaps detected.
+
+### ✅ PR Body Format
+All required sections present. Closing references at top. Verification includes
+real test counts.
+
+### ⚠️ ADR Check
+Changed `vultron/adapters/driven/` in a way that may constitute a new adapter
+pattern. No ADR references found in the PR. Suggest drafting an ADR for
+"HTTP Delivery Adapter Selection" before merge.
+
+### ✅ AGENTS.md Compliance
+No naming violations, no BT anti-patterns detected in the diff.
+
+### ✅ Code Review
+No bugs, logic errors, or security issues found.
+
+### ⚠️ Notes/Docs Currency
+`notes/bt-integration.md` covers BT node design but was not updated. The new
+`update()` pattern in `behaviors/case/nodes/lifecycle.py` may warrant a note.
+
+### ✅ Test Coverage
+New `execute()` paths covered. Integration test suite confirmed via CI.
+
+### ✅ Linter / CI
+All checks passing.
+
+---
+
+**Overall**: ⚠️ WARN — 2 warnings, 0 failures. Recommend addressing before merge.
+```
+
+Severity levels:
+
+- **✅ PASS** — no issues
+- **⚠️ WARN** — should be addressed but not blocking
+- **❌ FAIL** — must be addressed before merge
+
+Overall rating:
+
+- PASS if all phases are PASS
+- WARN if any phase is WARN and none are FAIL
+- FAIL if any phase is FAIL

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: pr-review
+description: >
+  Comprehensive pull request review for the Vultron project. Verifies that
+  a PR addresses its originating GitHub issue(s), conforms to Vultron specs
+  and notes, follows AGENTS.md coding rules and naming conventions, has
+  adequate test coverage, and passes linting requirements. Produces a
+  structured PASS/WARN/FAIL report and optionally posts it as a GitHub PR
+  review comment. Use when the user asks to review a PR, validate a PR
+  before merge, or audit a PR against project standards.
+---
+
+# Skill: PR Review
+
+## Quick Start
+
+```bash
+# Review the current branch's open PR
+/pr-review
+
+# Review a specific PR
+/pr-review 1234
+```
+
+## Workflow
+
+### Phase 1 — Orient
+
+1. Invoke `orient-agent` to load baseline context.
+2. Identify the target PR:
+   - If a PR number was provided, use it.
+   - Otherwise, detect the PR for the current branch:
+     `gh pr view --json number,title,body,headRefName,baseRefName,files`
+3. Fetch PR metadata: title, body, linked issues, changed files, CI status.
+
+### Phase 2 — Issue Linkage
+
+1. Extract closing references (`Closes #N`, `Fixes #N`) from the PR body.
+2. Fetch each linked issue with `gh issue view N --json title,body,labels`.
+3. Verify: does the implementation scope match what the issue describes?
+   Flag scope creep (PR does more than the issue), scope gaps (issue
+   requirements not addressed), and missing issue links.
+
+### Phase 3 — PR Body Format
+
+Check against `.agents/skills/shared/pr-body-guide.md`:
+
+- Closing references at the **top**, one per bullet
+- Required sections present (Summary, Changes, Verification for impl PRs)
+- Test counts in Verification are real numbers, not placeholders
+- Co-authored-by trailer present in all commits
+
+### Phase 4 — Domain Context
+
+1. Identify domains from changed file paths (e.g., `wire/as2/`, `core/behaviors/`,
+   `adapters/`, `demo/`).
+2. Invoke `deepen-context` with hints matching those domains.
+3. Load specs relevant to the changed domains via `load-specs` or `uv run spec-dump`.
+
+### Phase 5 — Spec and Notes Conformance
+
+With specs loaded, check changed code against requirements. See
+[REFERENCE.md](REFERENCE.md) § "Spec Conformance Criteria" for the per-domain
+checklist. Pay particular attention to:
+
+- AGENTS.md Common Pitfalls relevant to the changed code areas
+- Any spec IDs mentioned in the PR body or issue — confirm they are satisfied
+
+### Phase 6 — ADR Check
+
+1. Scan changed files for architectural signals: new layers, new protocols,
+   changes to public APIs, persistence schema changes, new adapters, new BT
+   integration patterns.
+2. For each signal, consult `notes/specs-vs-adrs.md` (MS-11-001–MS-11-006)
+   to determine if an ADR was warranted.
+3. Check `docs/adr/index.md` for a relevant existing ADR:
+   - If the PR *should have* an ADR and none is referenced: **WARN**.
+   - If an existing ADR is contradicted by the change without amendment: **FAIL**.
+   - If a new ADR was added: verify it follows `docs/adr/_adr-template.md`.
+
+### Phase 7 — AGENTS.md Compliance
+
+Check the diff for violations of non-negotiable coding rules. See
+[REFERENCE.md](REFERENCE.md) § "AGENTS.md Rule Checklist".
+
+### Phase 8 — Code Review
+
+Invoke a `code-review` sub-agent (task tool, `agent_type: "code-review"`)
+against the branch diff to surface bugs, logic errors, and security issues.
+
+### Phase 9 — Notes and Docs Currency
+
+1. **Notes currency**: Identify `notes/*.md` files that cover any domain
+   touched by the PR (cross-reference domain hints from Phase 4). If an
+   active note exists for a changed domain and was NOT updated: **WARN** —
+   the note may now contain stale guidance.
+2. **Notes frontmatter**: For any `notes/*.md` file modified in the PR,
+   validate YAML frontmatter per NF-06-001/NF-06-002:
+   - Required fields: `title`, `status`
+   - If `status: superseded`, `superseded_by` must be a non-empty scalar
+   - If status is `superseded`, file should have been moved to `archived_notes/`
+3. **Docs link integrity**: If any `docs/` file was modified, flag the need
+   to run `uv run mkdocs build --strict` (or confirm CI did so).
+4. **Silent contradiction**: If the PR's behavior change conflicts with an
+   `active` note's guidance without updating that note: **FAIL**.
+
+### Phase 10 — Test Coverage
+
+- Are new or changed behaviors covered by tests?
+- If any file under `demo/` or `adapters/` was changed: verify the PR body
+  or CI confirms the integration test suite ran.
+- Flag any public function or use-case `execute()` path with no test.
+
+### Phase 11 — Linter / CI Status
+
+1. Check CI status: `gh pr checks <number>`.
+2. If CI is failing, summarize which checks fail.
+3. If CI is not yet run, note that lint/type verification is pending.
+
+### Phase 12 — Report and (Optional) Post
+
+1. Produce a structured report grouped by phase, with **PASS / WARN / FAIL**
+   for each area. See [REFERENCE.md](REFERENCE.md) § "Report Format".
+2. Ask the user whether to post the report as a GitHub PR review comment:
+   - If yes: `gh pr review <number> --comment --body "<report>"`
+   - If yes + approve: `gh pr review <number> --approve --body "<report>"`
+   - If yes + request changes: `gh pr review <number> --request-changes --body "<report>"`
+
+---
+
+See [REFERENCE.md](REFERENCE.md) for detailed criteria, per-domain checklists,
+and the report format template.


### PR DESCRIPTION
## Summary

Adds a new project skill (`.agents/skills/pr-review/`) that performs
comprehensive, Vultron-specific PR reviews beyond what the generic
`code-review` agent type provides.

## Changes

- **`.agents/skills/pr-review/SKILL.md`**: 12-phase workflow skill covering
  issue linkage, PR body format, domain context loading, spec conformance,
  ADR checks, AGENTS.md compliance, code review (via sub-agent), notes/docs
  currency, test coverage, and CI status — with optional GitHub PR comment posting
- **`.agents/skills/pr-review/REFERENCE.md`**: Detailed criteria: per-domain
  spec mappings, full AGENTS.md rule checklist, ADR signal detection, notes
  currency domain-to-file mapping, and report format template

Docs-only; no Python modified.