### PR TITLE
docs: plan #867 — call-out point abstraction layer

### DIFF
--- a/docs/adr/0025-call-out-point-abstraction-layer.md
+++ b/docs/adr/0025-call-out-point-abstraction-layer.md
@@ -82,7 +82,7 @@ The concrete form:
    declared set of input keys (read before the node runs), output keys
    (written to on SUCCESS), and types for each. The contract is documented
    in the node's docstring and — for nodes that produce data — in
-   `specs/behavior-tree-integration.yaml` under BT-17.
+   `specs/behavior-tree-integration.yaml` under BT-18.
 
 2. A call-out point **backend factory** is a callable with a defined
    signature:

--- a/docs/adr/0025-call-out-point-abstraction-layer.md
+++ b/docs/adr/0025-call-out-point-abstraction-layer.md
@@ -1,0 +1,202 @@
+---
+status: proposed
+date: 2026-06-25
+deciders: [adh]
+---
+
+# Call-Out Point Abstraction Layer: Factory-Based Injection with Typed Backends
+
+## Context and Problem Statement
+
+Vultron's Behavior Trees contain **call-out points** — nodes where the
+protocol cannot proceed autonomously and must request input from an external
+party (see ADR-0024 for the taxonomy of agent shapes). After FUZZ-01 through
+FUZZ-07 (#860–#866), each call-out point has a probabilistic fuzzer node as
+its stand-in. The fuzzer is not a permanent implementation: it is an adapter
+that will be replaced over time by real data lookups, policy evaluations, or
+coordination agents.
+
+Before those replacements can happen, the call-out points must be expressed
+as proper injection seams: the BT tree must be built so that the fuzzer is
+the *default* backend, not the *only* option. Without an abstraction layer,
+swapping any call-out point requires finding and editing the concrete node
+class instead of injecting a different factory — and with roughly 93 call-out
+point nodes across all domains, the maintenance burden is unacceptable.
+
+The design question is: **What mechanism makes each call-out point backend
+swappable while remaining consistent with the existing py_trees Behaviour
+pattern, factory-function conventions, and blackboard contract model?**
+
+> **Design status — formed in sand, not concrete**: This ADR captures the
+> forward-looking intent after one planning session. The design will be
+> exercised in #1151 (one exemplar per agent shape) and is expected to
+> converge after two or three concrete implementations across different
+> domain areas. Implementers working on the shape-based follow-on issues
+> (FUZZ-08d through FUZZ-08g) SHOULD refine this ADR if the pattern proves
+> incorrect or incomplete. The ADR status will advance from `proposed` to
+> `accepted` once the exemplars validate the approach.
+
+## Decision Drivers
+
+- Must be consistent with the existing BT factory-function pattern
+  (tree composition functions, not ad-hoc node instantiation)
+- Must allow individual call-out points to be swapped without changing the
+  calling tree structure (incremental replacement)
+- Must maintain the same blackboard contract whether the backend is a fuzzer
+  or a real implementation — downstream nodes must be unaffected by the swap
+- Must keep simulation artifacts (`vultron/demo/fuzzer/`) out of
+  `vultron/core/behaviors/` (BT-16-001)
+- Must be compatible with the four agent shapes from ADR-0024 (Sentinel,
+  Evaluator, Retriever, Composer), each of which has different input/output
+  semantics
+- Must support partial replacement: a scenario can use real implementations
+  for some call-out points and fuzzer backends for others in the same run
+
+## Considered Options
+
+1. **No abstraction** — leave fuzzer nodes as concrete hardcoded classes;
+   require code edits to swap backends
+2. **Node-level strategy injection** — define a
+   `CallOutPointBehaviour(Behaviour)` base class with an injected `backend`
+   callable; require subclassing per call-out point
+3. **Per-tree parameter injection** — each tree-building function has named
+   parameters for its call-out point factories (`eval_validity=make_fuzzer`,
+   `eval_priority=make_fuzzer`, …); swapping is explicit but verbose
+4. **Registry-based injection** — a `CallOutRegistry` maps call-out point
+   names to factory callables; tree builders accept one `registry` argument;
+   mirrors the `USE_CASE_MAP`/`SEMANTIC_REGISTRY` pattern
+5. **Factory-protocol injection** — each call-out point is a typed callable
+   Protocol (`CallOutFactory = Callable[[str], Behaviour]`); individual
+   tree builders accept a mapping or single typed factory per call-out point;
+   swapping is done at construction time
+
+## Decision Outcome
+
+Chosen option: **factory-protocol injection (Option 5)**, refined by
+borrowing the registry-consolidation idea from Option 4 for tree builders
+that have multiple call-out points.
+
+The concrete form:
+
+1. Each call-out point type is defined by its **blackboard contract**: a
+   declared set of input keys (read before the node runs), output keys
+   (written to on SUCCESS), and types for each. The contract is documented
+   in the node's docstring and — for nodes that produce data — in
+   `specs/behavior-tree-integration.yaml` under BT-17.
+
+2. A call-out point **backend factory** is a callable with a defined
+   signature:
+
+   ```python
+   # Minimal form: factory produces a Behaviour with a known blackboard contract
+   CallOutBackendFactory = Callable[[str], py_trees.behaviour.Behaviour]
+   ```
+
+   The factory is responsible for producing a node that honours the
+   call-out point's blackboard contract.
+
+3. The **fuzzer backend factory** is the default for each call-out point.
+   It produces a probabilistic `WeightedBehavior` subclass that writes
+   synthetic data to the required output keys (where applicable), matching
+   the contract that a real backend would satisfy.
+
+4. Tree-building functions that contain call-out points accept the factory
+   (or a mapping of factories) as a parameter with the fuzzer factory as
+   the default. This is the canonical swap mechanism.
+
+5. The four agent shapes (Evaluator, Retriever, Sentinel, Composer from
+   ADR-0024) each define a **lifecycle pattern** — how the node reads
+   input from the blackboard, dispatches to the backend, and writes output
+   back. Concrete call-out point nodes subclass the appropriate shape base
+   class and declare their specific I/O keys and types. The shape base
+   class is NOT reusable generically; it documents the lifecycle pattern and
+   defines the hook points.
+
+### Consequences
+
+- Good, because it is consistent with the existing BT factory pattern and
+  does not require a new base-class hierarchy to be invented from scratch
+- Good, because individual call-out points can be swapped independently;
+  a scenario can mix fuzzer and real backends node by node
+- Good, because fuzzer backends maintain the same blackboard contract as
+  real backends, making swap transparent to downstream nodes
+- Good, because the shape base classes document the lifecycle pattern for
+  each agent shape, making the code self-explanatory
+- Neutral, because tree builders gain new parameters (one per call-out
+  point or a single registry mapping); this is a small API surface increase
+- Bad/uncertain, because the exact factory signature (positional args,
+  configuration struct, or keyword-only) is not yet fully specified — this
+  must be settled during the exemplar implementation in #1151
+- Bad/uncertain, because the blackboard output contract for data-producing
+  nodes (Evaluators, Retrievers, Composers) requires explicit declaration
+  per node — this is documentation work that must be done alongside
+  implementation
+
+## Pros and Cons of the Options
+
+### Option 1: No abstraction
+
+- Bad, because swapping any backend requires editing the concrete class
+- Bad, because fuzzer logic is permanently coupled to the call-out point
+- Bad, because 93 nodes would each need to be touched individually
+
+### Option 2: Node-level strategy injection
+
+- Good, because each node clearly shows its injectable backend
+- Neutral, because subclassing is familiar to py_trees users
+- Bad, because it requires refactoring all 93 existing fuzzer nodes
+- Bad, because the injected callable type varies per node (each has a
+  different I/O contract); a single `Callable` type alias doesn't express this
+
+### Option 3: Per-tree parameter injection
+
+- Good, because explicit parameter names make dependencies visible
+- Bad, because tree builders accumulate many parameters (some BT trees have
+  5–10 call-out points each), making signatures unwieldy
+- Bad, because adding a new call-out point requires changing the tree
+  builder's signature and all call sites
+
+### Option 4: Registry-based injection
+
+- Good, because it mirrors the existing `USE_CASE_MAP` dispatch table pattern
+- Good, because a single `registry` argument keeps tree builder signatures
+  small regardless of the number of call-out points
+- Neutral, because registry lookup introduces a name-coupling risk (typo in
+  the registry key silently uses the wrong backend or raises at runtime)
+- Good, partially adopted: the registry idea is used for tree builders that
+  contain multiple call-out points (keeps signature clean)
+
+### Option 5: Factory-protocol injection (chosen)
+
+- Good, because it is consistent with existing factory-function conventions
+- Good, because typed callable Protocols make the contract explicit
+- Good, because swapping is a construction-time operation, not a runtime
+  configuration dependency
+- Neutral, because the exact factory Protocol signature must be finalized
+  during exemplar implementation — it cannot be fully specified without
+  working through concrete cases
+
+## Validation
+
+- #1151 implements one exemplar per agent shape; each exemplar must
+  demonstrate the factory-based swap (fuzzer default → real backend).
+- Shape-based implementation issues (FUZZ-08d through FUZZ-08g) apply the
+  pattern to all 93 nodes. If the exemplar pattern requires revision for any
+  shape, this ADR must be updated before the corresponding shape issue
+  begins.
+- `specs/behavior-tree-integration.yaml` BT-18 captures the blackboard
+  contract requirements that every call-out point implementation must satisfy.
+
+## More Information
+
+- ADR-0024: Coordination Agent Taxonomy (call-out point concept and the four
+  agent shapes)
+- `notes/coordination-agents.md`: design notes for coordination agents
+  including the two integration surfaces (call-in vs. call-out)
+- `notes/bt-fuzzer-nodes.md` and sub-files: per-node catalog with automation
+  potential ratings and agent-shape classifications (completed by #1150)
+- Implementation chain: #1150 (catalog update) → #1151 (exemplars) →
+  #1152 (demo scenario wiring) → FUZZ-08d–08g (shape rollout)
+
+Generated spec requirements: `specs/behavior-tree-integration.yaml`
+BT-18-001 through BT-18-004.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -86,6 +86,8 @@ General information about architectural decision records is available at <https:
 
 - [ADR-0020 Move Inbox Orchestration into a Core BT Module with a Typed
   `process_payload` Seam](0020-inbox-bt-orchestration.md)
+- [ADR-0025 Call-Out Point Abstraction Layer: Factory-Based Injection with
+  Typed Backends](0025-call-out-point-abstraction-layer.md)
 
 ## Rejected ADRs
 

--- a/notes/coordination-agents.md
+++ b/notes/coordination-agents.md
@@ -201,6 +201,94 @@ the same as an "uber-agent" that manages an entire case.
 
 ---
 
+## Call-Out Point Abstraction Layer
+
+> **Provisional design — formed in sand**: The pattern described here
+> reflects the intent after the #867 planning session. It will be validated
+> by #1151 (one exemplar per agent shape) and may be refined as the
+> shape-based implementation issues (FUZZ-08d through FUZZ-08g) work through
+> the full 93-node inventory. See ADR-0025 for the full decision record.
+
+### Core concept: fuzzer as adapter
+
+Every fuzzer node in `vultron/demo/fuzzer/` is a **call-out point adapter**
+— a probabilistic stand-in for logic that has not yet been implemented. The
+goal of the abstraction layer is to make the adapter *swappable* at tree
+construction time, so that real implementations can replace the fuzzer
+incrementally (node by node, scenario by scenario) without changing the BT
+tree structure.
+
+### Factory-based injection
+
+The mechanism is **factory-based injection**, consistent with how BT trees
+are already constructed elsewhere in the codebase:
+
+- Each call-out point is expressed as a **backend factory**: a callable
+  that produces a `py_trees.behaviour.Behaviour` node honouring the
+  call-out point's blackboard contract.
+- The fuzzer factory is the default for each call-out point.
+- Tree-building functions that contain call-out points accept the factory
+  (or a mapping of factories) as a parameter, with the fuzzer as the
+  default. Swapping is a construction-time operation.
+
+### Blackboard contracts
+
+Every call-out point has a **blackboard contract**:
+
+- **Input keys**: blackboard keys the node reads before dispatching
+- **Output keys + types**: blackboard keys the node writes on `SUCCESS`
+- **Signal**: `SUCCESS` or `FAILURE` to the tree
+
+The fuzzer backend MUST honour the same contract as a real backend: on
+`SUCCESS`, it writes synthetic data to the declared output keys. This ensures
+downstream nodes are unaffected by the fuzzer-vs-real swap.
+
+Blackboard contract requirements are specified in
+`specs/behavior-tree-integration.yaml` BT-17-001 through BT-17-004.
+
+### Shape base classes
+
+Each of the four agent shapes (Evaluator, Retriever, Sentinel, Composer)
+defines a **lifecycle pattern** for how the node reads input, dispatches, and
+writes output. Concrete call-out point nodes subclass the appropriate shape
+base class. The shape base class is NOT a generic reusable class; it
+documents the lifecycle pattern and defines the hook points for subclasses.
+
+- **Sentinel**: binary condition; no output keys; backend monitors a state
+  and returns `SUCCESS`/`FAILURE` only
+- **Evaluator**: reads situation context from the blackboard; writes a
+  structured recommendation to a declared output key; `SUCCESS` = answer
+  available, `FAILURE` = cannot evaluate
+- **Retriever**: reads a query from the blackboard; writes structured facts
+  to a declared output key; `SUCCESS` = facts retrieved, `FAILURE` = not
+  found or unavailable
+- **Composer**: reads composition context from the blackboard; writes a
+  generated artifact to a declared output key; `SUCCESS` = artifact ready,
+  `FAILURE` = generation failed
+
+### Implementation chain
+
+```text
+#1150 — Update catalog: add cross-refs (vultron/bt/ → demo/fuzzer/) +
+         agent-shape classification per node
+
+#1151 — Design exemplar: one call-out point per shape (provisional)
+         + shape base classes + blackboard contract documentation
+
+#1152 — Wire demo BTs: audit BTs for implicit policy nodes; externalize
+         as call-out points with deterministic (AlwaysSucceed/AlwaysFail)
+         backends; add one randomized demo
+
+FUZZ-08d — All Evaluator-shaped call-out points (cross-domain)
+FUZZ-08e — All Retriever-shaped call-out points (cross-domain)
+FUZZ-08f — All Sentinel-shaped call-out points (cross-domain)
+FUZZ-08g — All Composer-shaped call-out points (cross-domain)
+
+Domain sweep audits — verify completeness per domain after shape rollout
+```
+
+---
+
 ## Terminology Note
 
 `notes/bt-fuzzer-nodes.md` and the per-domain fuzzer notes

--- a/notes/coordination-agents.md
+++ b/notes/coordination-agents.md
@@ -244,7 +244,7 @@ The fuzzer backend MUST honour the same contract as a real backend: on
 downstream nodes are unaffected by the fuzzer-vs-real swap.
 
 Blackboard contract requirements are specified in
-`specs/behavior-tree-integration.yaml` BT-17-001 through BT-17-004.
+`specs/behavior-tree-integration.yaml` BT-18-001 through BT-18-004.
 
 ### Shape base classes
 

--- a/plan/history/2606/idea/IDEA-867.md
+++ b/plan/history/2606/idea/IDEA-867.md
@@ -1,0 +1,65 @@
+---
+source: IDEA-867
+timestamp: '2026-06-25T17:01:33.294362+00:00'
+title: 'FUZZ-08: Wire fuzzer nodes into demo scenarios (planning)'
+type: idea
+---
+
+## Original umbrella summary
+
+Umbrella planning issue for wiring the ported `vultron/demo/fuzzer/` nodes into
+demo scenarios as **call-out points** — named integration seams where the BT
+calls out to an external party (initially the fuzzer, later real implementations
+or coordination agents).
+
+FUZZ-01 through FUZZ-07 (#860–#866) are complete. This umbrella tracked the
+follow-on work of exposing those nodes as swappable abstractions and wiring
+them into demo scenarios.
+
+## Planning session outcome (2026-06-25)
+
+Gap analysis and issue review session. #1150, #1151, and #1152 were revised
+with clearer scope. Six new issues were created.
+
+**Docs PR**: #1172 — ADR-0025 (call-out point abstraction layer design),
+BT-18 spec group (blackboard contract requirements), coordination-agents.md
+abstraction section.
+
+**Key design decisions:**
+
+- Call-out point nodes use **factory-based injection** (consistent with
+  existing BT factory pattern): each tree builder accepts the backend factory
+  as a parameter with the fuzzer as the default.
+- Each call-out point has a **blackboard contract**: declared input keys and
+  output keys (with types); fuzzer backends MUST write synthetic
+  type-conformant output to the same keys as real backends.
+- The four agent shapes (Sentinel, Evaluator, Retriever, Composer from
+  ADR-0024) each define a lifecycle pattern for their nodes.
+- Implementation is **shape-based** (not domain-based): one issue per shape
+  covers all nodes of that shape across all domains, ensuring DRY base classes
+  and consistent patterns.
+- The design is **provisional** ("formed in sand"): ADR-0025 status is
+  `proposed` and is expected to be refined during exemplar implementation
+  (#1151) before the shape rollout begins.
+
+**Revised implementation issues:**
+
+- #1150 — Update catalog: add new-arch cross-refs (vultron/bt/ → demo/fuzzer/)
+  - call-out point shape annotations + terminology alignment
+- #1151 — Design: shape base classes + one exemplar per shape + blackboard
+  contract documentation (provisional)
+- #1152 — Demo wiring: audit BTs for implicit policy nodes, externalize as
+  call-out points with deterministic backends, add one randomised demo
+
+**New implementation issues:**
+
+- #1173 (FUZZ-08d): All Evaluator-shaped call-out points (cross-domain)
+- #1174 (FUZZ-08e): All Retriever-shaped call-out points (cross-domain)
+- #1175 (FUZZ-08f): All Sentinel-shaped call-out points (cross-domain)
+- #1176 (FUZZ-08g): All Composer-shaped call-out points (cross-domain)
+- #1177 (FUZZ-08h): Domain sweep audit (breadcrumb — blocked by 08d–08g)
+- #1178: Fully-fuzzed protocol simulation scenario (under #1093 Demo Scenarios)
+
+**Processed**: 2026-06-25 — implementation tracked in #1150, #1151, #1152,
+\#1173, #1174, #1175, #1176, #1177, #1178.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1172>.

--- a/specs/behavior-tree-integration.yaml
+++ b/specs/behavior-tree-integration.yaml
@@ -523,3 +523,72 @@ groups:
       Automation-potential categorization guides future implementers toward the
       correct integration pattern when replacing stubs with production logic,
       supporting the future real-integration roadmap.
+- id: BT-18
+  title: Call-Out Point Abstraction Layer
+  kind: pattern
+  specs:
+  - id: BT-18-001
+    priority: MUST
+    statement: >-
+      Every call-out point node MUST declare its blackboard contract in its
+      class docstring: the set of input keys read before dispatch and the set
+      of output keys (with types) written to the blackboard on SUCCESS.
+    rationale: >-
+      The blackboard contract is the integration seam between the tree and the
+      backend. Without an explicit contract, swapping from a fuzzer backend to
+      a real implementation is a guess — the real backend may omit writing a
+      key that a downstream node expects, causing silent failures.
+    relationships:
+    - rel_type: implements
+      spec_id: BT-16-003
+      note: >-
+        Call-out points are the named integration seam that BT-16-003 requires
+        to be documented; the blackboard contract is the required documentation
+        format for data-producing nodes.
+  - id: BT-18-002
+    priority: MUST
+    statement: >-
+      A call-out point backend — fuzzer or real implementation — MUST write
+      to all declared output keys when it returns SUCCESS. A backend MUST NOT
+      return SUCCESS without writing the declared outputs.
+    rationale: >-
+      Downstream BT nodes rely on declared output keys being present after a
+      call-out point succeeds. A fuzzer that returns SUCCESS without writing
+      synthetic output to those keys produces a contract violation: a
+      downstream node reads a missing key and fails, but the failure is
+      attributed to the downstream node rather than the backend. Both fuzzer
+      and real backends must be contract-conformant to make backend swaps
+      transparent.
+  - id: BT-18-003
+    priority: MUST
+    statement: >-
+      The fuzzer backend for a data-producing call-out point (Evaluator,
+      Retriever, or Composer shape) MUST write synthetic but type-conformant
+      data to the declared output keys. The synthetic data MUST be of the
+      correct type; it does not need to be semantically meaningful.
+    rationale: >-
+      If the fuzzer backend omits output writes that a real backend would
+      perform, the demo/simulation layer cannot serve as a faithful stand-in
+      during development. Maintaining the same output contract ensures that
+      demo scenarios exercise the same downstream code paths as production
+      runs.
+  - id: BT-18-004
+    priority: MUST
+    statement: >-
+      A call-out point node MUST be constructed via a backend factory
+      callable. Tree-building functions that contain call-out points MUST
+      accept the backend factory as a parameter (or as an entry in a factory
+      mapping). The fuzzer factory MUST be the default value.
+    rationale: >-
+      Factory-based injection is the established BT construction pattern in
+      this codebase. Requiring the factory as a parameter (rather than
+      hardcoding the fuzzer import) is what makes each call-out point an
+      actual injection seam rather than a tightly-coupled stub. Without this,
+      replacing any backend requires editing the tree-building function,
+      defeating the abstraction layer's purpose.
+    relationships:
+    - rel_type: implements
+      spec_id: BT-04-001
+      note: >-
+        Factory-based injection for call-out points is an application of the
+        existing factory pattern required for all BT construction.


### PR DESCRIPTION
- Related to #867

## Summary

Planning session for #867 (umbrella already closed). Establishes the design
foundation for the call-out point abstraction layer that makes fuzzer nodes
swappable with real backends.

## Changes

- **ADR-0025** (proposed): Call-out point abstraction layer — factory-based
  injection with typed backends. Provisional; design to be validated by #1151
  exemplars.
- **BT-18 spec group** in `specs/behavior-tree-integration.yaml`: blackboard
  contract requirements (BT-18-001 through BT-18-004) for call-out point nodes.
- **`notes/coordination-agents.md`**: new section documenting the call-out
  point abstraction pattern — factory injection, blackboard contracts, shape
  base classes, and implementation chain.