### PR TITLE
feat: CP-05-005 (part 2) — background retry runner for pending Create(VulnerabilityCase)

### DIFF
--- a/notes/case-proposal.md
+++ b/notes/case-proposal.md
@@ -211,7 +211,29 @@ case-actor ID, vendor URI, and the pre-constructed
 `Create(VulnerabilityCase)` payload. It is deleted on successful
 `Create` delivery, so only failed deliveries leave a marker.
 
-A retry runner (issue #1139) will scan for persisted markers and
-re-deliver the `Create(VulnerabilityCase)` payload verbatim using the
-stored `id_` — never re-constructing the activity — to avoid ID
-divergence between the marker and the delivered activity.
+### Retry Runner (AC-2: startup-scan option)
+
+`vultron/adapters/driving/fastapi/pending_retry.py` provides
+`retry_pending_create_case_activities()`, called once in the FastAPI
+application lifespan before the server starts accepting requests.
+
+The runner uses **option (a): on-startup scan**:
+
+1. Get all actor-scoped DataLayers from the process-level cache
+   (``get_all_actor_datalayers()``).
+2. **Supplement** by scanning the shared (unscoped) DataLayer for
+   persisted ``PendingCreateCaseActivity`` markers.  Any ``case_actor_id``
+   values found that are not already in the cache get a fresh actor-scoped
+   DataLayer via ``clone_for_actor()``.  This step is critical on
+   crash/restart: the process cache is empty, but the SQLite file still
+   holds the obligation rows.
+3. For each actor DataLayer, scan for markers, reconstruct the stored
+   ``Create(VulnerabilityCase)`` payload **verbatim** using the marker's
+   ``create_activity_payload`` (never re-constructing the activity), and
+   re-enqueue to the actor's outbox.
+4. Delete the marker on success.
+
+Using the stored payload (not a freshly constructed activity) preserves
+the original ``id_``, which is essential: the retry runner's outbox
+idempotency check looks for that specific ``id_``.  A fresh ``id_``
+would bypass the check and cause a duplicate delivery after crash/restart.

--- a/plan/history/2606/implementation/ISSUE-1139.md
+++ b/plan/history/2606/implementation/ISSUE-1139.md
@@ -1,0 +1,38 @@
+---
+source: ISSUE-1139
+timestamp: '2026-06-25T17:52:29.314952+00:00'
+title: 'CP-05-005 (part 2): Background retry runner for pending Create(VulnerabilityCase)'
+type: implementation
+---
+
+## Issue #1139 — CP-05-005 (part 2): Background retry runner for pending Create(VulnerabilityCase) activities
+
+Implemented the background retry runner for persisted PendingCreateCaseActivity
+markers (CP-05-005, part 2 of 2). This completes the durable-delivery guarantee for
+the Accept(CaseProposal) -> Create(VulnerabilityCase) two-activity sequence.
+
+What was built:
+
+- vultron/adapters/driving/fastapi/pending_retry.py: Core retry runner with
+  retry_pending_create_case_activities(). Scans all actor DataLayers for
+  PendingCreateCaseActivity markers, reconstructs the pre-built
+  Create(VulnerabilityCase) payload (preserving the original id_), persists
+  it if absent (idempotency), enqueues it with an outbox-existence check before
+  record_outbox_item (prevents duplicate entries when marker deletion fails),
+  and deletes the marker on success.
+
+- vultron/adapters/driving/fastapi/app.py: Wired the retry runner into the
+  configure_globals=True lifespan path, called after OutboxMonitor.start().
+
+- test/adapters/driving/fastapi/test_pending_retry.py: 16 tests covering all
+  ACs including the stuck-marker path (AC-4) and full integration scenario (AC-5).
+
+Design decision (AC-2): On-startup scan (option a) was chosen. The
+OutboxMonitor is already running when the scan fires, so re-queued activities
+drain without an extra signal. No ongoing polling overhead.
+
+Key code review finding fixed: record_outbox_item has no uniqueness
+constraint -- a stuck marker (delete fails) would cause double delivery on the
+next startup. Added an outbox-existence guard before enqueuing.
+
+PR: [#1180](https://github.com/CERTCC/Vultron/pull/1180)

--- a/test/adapters/driving/fastapi/test_pending_retry.py
+++ b/test/adapters/driving/fastapi/test_pending_retry.py
@@ -32,6 +32,7 @@ Module under test:
 """
 
 import logging
+from collections.abc import Callable
 
 import pytest
 
@@ -267,7 +268,7 @@ class TestRetryIdempotency:
         dl.save(marker)
 
         # Patch dl.delete so it always returns False (simulating a stuck marker)
-        original_delete = dl.delete
+        original_delete: Callable[[str, str], bool] = dl.delete
 
         def _failing_delete(table: str, id_: str) -> bool:
             if table == "PendingCreateCaseActivity":
@@ -461,3 +462,99 @@ class TestRetryFullScenario:
         assert (
             not info_messages
         ), "No INFO messages expected when no markers are found"
+
+
+# ---------------------------------------------------------------------------
+# Startup recovery — shared DataLayer actor discovery (CP-05-005 crash path)
+# ---------------------------------------------------------------------------
+
+
+class TestStartupRecovery:
+    """Startup scan discovers actors from persisted markers even when cache is empty.
+
+    CP-05-005: On crash/restart the process-level actor cache (returned by
+    ``get_all_actor_datalayers()``) is empty, but the SQLite file still holds
+    ``PendingCreateCaseActivity`` rows.  The retry runner must discover those
+    actors from the shared (unscoped) DataLayer and process their markers.
+
+    Test setup mirrors production: markers are saved via an actor-scoped
+    DataLayer (as the BT node does), so the underlying record carries the
+    correct ``actor_id`` column value.  The shared (unscoped) DataLayer can
+    see all records regardless of ``actor_id``, which is how discovery works.
+    """
+
+    @staticmethod
+    def _make_shared_and_actor_dl():
+        """Return (shared_dl, actor_dl) backed by the same in-memory SQLite DB."""
+        shared_dl = SqliteDataLayer("sqlite:///:memory:")
+        actor_dl = shared_dl.clone_for_actor(_CASE_ACTOR_ID)
+        return shared_dl, actor_dl
+
+    def test_discovers_actor_from_shared_dl_when_cache_empty(self):
+        """Marker is processed when actor cache is empty but shared DL has markers.
+
+        Simulates crash/restart: actor_datalayers_factory returns {} but the
+        shared DataLayer still holds a persisted PendingCreateCaseActivity.
+        """
+        shared_dl, actor_dl = self._make_shared_and_actor_dl()
+        activity = _build_activity()
+        marker = _build_marker(activity)
+        actor_dl.save(marker)  # saved with actor_id, as the BT node does
+
+        count = retry_pending_create_case_activities(
+            actor_datalayers_factory=lambda: {},  # empty cache (post-restart)
+            shared_datalayer_factory=lambda: shared_dl,
+        )
+
+        assert count == 1, "Marker should be processed via shared-DL discovery"
+
+    def test_activity_enqueued_after_shared_dl_discovery(self):
+        """Activity is placed in the outbox after shared-DL actor discovery."""
+        shared_dl, actor_dl = self._make_shared_and_actor_dl()
+        activity = _build_activity()
+        marker = _build_marker(activity)
+        actor_dl.save(marker)
+
+        retry_pending_create_case_activities(
+            actor_datalayers_factory=lambda: {},
+            shared_datalayer_factory=lambda: shared_dl,
+        )
+
+        outbox = actor_dl.outbox_list_for_actor(_CASE_ACTOR_ID)
+        assert (
+            activity.id_ in outbox
+        ), "Activity should be in the outbox after startup recovery"
+
+    def test_marker_deleted_after_shared_dl_discovery(self):
+        """Marker is cleared after startup recovery completes (AC-3)."""
+        shared_dl, actor_dl = self._make_shared_and_actor_dl()
+        marker = _build_marker()
+        actor_dl.save(marker)
+
+        retry_pending_create_case_activities(
+            actor_datalayers_factory=lambda: {},
+            shared_datalayer_factory=lambda: shared_dl,
+        )
+
+        assert (
+            actor_dl.read(marker.id_) is None
+        ), "Marker should be deleted after startup recovery"
+
+    def test_no_duplicate_when_actor_already_in_cache(self):
+        """Actor already in the cache is not processed twice via shared-DL scan."""
+        shared_dl, actor_dl = self._make_shared_and_actor_dl()
+        activity = _build_activity()
+        marker = _build_marker(activity)
+        actor_dl.save(marker)
+
+        # Actor is in the cache AND shared_datalayer_factory is injected.
+        count = retry_pending_create_case_activities(
+            actor_datalayers_factory=lambda: {_CASE_ACTOR_ID: actor_dl},
+            shared_datalayer_factory=lambda: shared_dl,
+        )
+
+        assert count == 1, "Marker should be processed exactly once"
+        outbox = actor_dl.outbox_list_for_actor(_CASE_ACTOR_ID)
+        assert (
+            outbox.count(activity.id_) == 1
+        ), "Activity should appear exactly once in the outbox"

--- a/test/adapters/driving/fastapi/test_pending_retry.py
+++ b/test/adapters/driving/fastapi/test_pending_retry.py
@@ -1,0 +1,463 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Unit and integration tests for retry_pending_create_case_activities.
+
+Acceptance criteria covered
+---------------------------
+- AC-1: Retry reads PendingCreateCaseActivity markers and re-sends
+  Create(VulnerabilityCase) without re-creating the case or re-sending
+  Accept(CaseProposal).
+- AC-3: After successful delivery the marker is removed/marked-complete.
+- AC-4: Running the retry runner multiple times does not produce duplicate
+  Create(VulnerabilityCase) activities or duplicate VulnerabilityCase records.
+- AC-5: Integration test covering the full scenario:
+  Accept sent → Create fails → marker written → retry runner fires →
+  Create(VulnerabilityCase) re-queued → marker removed.
+
+Module under test:
+  ``vultron/adapters/driving/fastapi/pending_retry.py``
+"""
+
+import logging
+
+import pytest
+
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.core.models.activity import VultronCreateCaseActivity
+from vultron.core.models.pending_create_case_activity import (
+    PendingCreateCaseActivity,
+)
+from vultron.adapters.driving.fastapi.pending_retry import (
+    retry_pending_create_case_activities,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_CASE_ACTOR_ID = "https://case-actor.test/actors/svc-001"
+_VENDOR_URI = "https://vendor.test/actors/acme"
+_PROPOSAL_ID = "https://vendor.test/proposals/p-100"
+_CASE_ID = "https://case-actor.test/cases/c-001"
+_ACCEPT_ID = "https://case-actor.test/activities/accept-001"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def dl() -> SqliteDataLayer:
+    """Fresh in-memory DataLayer for each test."""
+    return SqliteDataLayer("sqlite:///:memory:")
+
+
+def _build_activity() -> VultronCreateCaseActivity:
+    """Return a pre-constructed Create(VulnerabilityCase) activity."""
+    return VultronCreateCaseActivity(
+        actor=_CASE_ACTOR_ID,
+        object_=_CASE_ID,
+        context=_ACCEPT_ID,
+        to=[_VENDOR_URI],
+    )
+
+
+def _build_marker(
+    activity: VultronCreateCaseActivity | None = None,
+) -> PendingCreateCaseActivity:
+    """Return a PendingCreateCaseActivity marker."""
+    act = activity or _build_activity()
+    return PendingCreateCaseActivity(
+        proposal_id=_PROPOSAL_ID,
+        case_actor_id=_CASE_ACTOR_ID,
+        vendor_uri=_VENDOR_URI,
+        create_activity_payload=act.model_dump(by_alias=True),
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-4: No-op when no markers present
+# ---------------------------------------------------------------------------
+
+
+class TestRetryNoMarkers:
+    """retry_pending returns 0 and does nothing when no markers exist."""
+
+    def test_empty_factory_returns_zero(self):
+        """Returns 0 when the factory yields no DataLayers."""
+        count = retry_pending_create_case_activities(
+            actor_datalayers_factory=lambda: {}
+        )
+        assert count == 0
+
+    def test_dl_with_no_markers_returns_zero(self, dl):
+        """Returns 0 when the DataLayer has no PendingCreateCaseActivity records."""
+        count = retry_pending_create_case_activities(
+            actor_datalayers_factory=lambda: {_CASE_ACTOR_ID: dl}
+        )
+        assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# AC-1 + AC-3: Happy path — marker present, activity re-queued, marker cleared
+# ---------------------------------------------------------------------------
+
+
+class TestRetryHappyPath:
+    """Verify the basic retry flow end-to-end in memory."""
+
+    def test_returns_one_for_single_marker(self, dl):
+        """Returns 1 when exactly one pending marker is processed."""
+        marker = _build_marker()
+        dl.save(marker)
+
+        count = retry_pending_create_case_activities(
+            actor_datalayers_factory=lambda: {_CASE_ACTOR_ID: dl}
+        )
+
+        assert count == 1
+
+    def test_activity_persisted_in_datalayer(self, dl):
+        """Create(VulnerabilityCase) is written to the DataLayer (AC-1)."""
+        activity = _build_activity()
+        marker = _build_marker(activity)
+        dl.save(marker)
+
+        retry_pending_create_case_activities(
+            actor_datalayers_factory=lambda: {_CASE_ACTOR_ID: dl}
+        )
+
+        retrieved = dl.read(activity.id_)
+        assert (
+            retrieved is not None
+        ), "Activity should be persisted after retry"
+
+    def test_activity_enqueued_to_outbox(self, dl):
+        """Activity is enqueued to the case-actor's outbox (AC-1)."""
+        activity = _build_activity()
+        marker = _build_marker(activity)
+        dl.save(marker)
+
+        retry_pending_create_case_activities(
+            actor_datalayers_factory=lambda: {_CASE_ACTOR_ID: dl}
+        )
+
+        outbox = dl.outbox_list_for_actor(_CASE_ACTOR_ID)
+        assert (
+            activity.id_ in outbox
+        ), "Activity id should appear in the case-actor's outbox"
+
+    def test_marker_deleted_after_retry(self, dl):
+        """PendingCreateCaseActivity marker is removed on success (AC-3)."""
+        marker = _build_marker()
+        dl.save(marker)
+
+        retry_pending_create_case_activities(
+            actor_datalayers_factory=lambda: {_CASE_ACTOR_ID: dl}
+        )
+
+        remaining = dl.read(marker.id_)
+        assert remaining is None, "Marker should be deleted after retry"
+
+    def test_accept_not_resent(self, dl):
+        """Accept(CaseProposal) is NOT written to the DataLayer (AC-1)."""
+        marker = _build_marker()
+        dl.save(marker)
+
+        retry_pending_create_case_activities(
+            actor_datalayers_factory=lambda: {_CASE_ACTOR_ID: dl}
+        )
+
+        # Only the Create(VulnerabilityCase) should be in the DataLayer
+        accepts = dl.list_objects("Accept")
+        assert (
+            not accepts
+        ), "No Accept activity should be written by the retry runner"
+
+
+# ---------------------------------------------------------------------------
+# AC-4: Idempotency — running twice does not duplicate activities
+# ---------------------------------------------------------------------------
+
+
+class TestRetryIdempotency:
+    """Running the retry runner twice must not produce duplicates (AC-4)."""
+
+    def test_second_run_returns_zero(self, dl):
+        """Second run (after marker is cleared) returns 0."""
+        marker = _build_marker()
+        dl.save(marker)
+
+        first = retry_pending_create_case_activities(
+            actor_datalayers_factory=lambda: {_CASE_ACTOR_ID: dl}
+        )
+        second = retry_pending_create_case_activities(
+            actor_datalayers_factory=lambda: {_CASE_ACTOR_ID: dl}
+        )
+
+        assert first == 1
+        assert second == 0
+
+    def test_activity_not_duplicated_when_already_persisted(self, dl):
+        """If activity already exists in DL, no duplicate is created (AC-4)."""
+        activity = _build_activity()
+        marker = _build_marker(activity)
+
+        # Pre-persist the activity as if a previous partial run stored it
+        # but failed to enqueue or delete the marker.
+        dl.save(marker)
+        dl.create(activity)
+
+        count = retry_pending_create_case_activities(
+            actor_datalayers_factory=lambda: {_CASE_ACTOR_ID: dl}
+        )
+
+        assert count == 1  # still enqueued (marker existed)
+        # Only one Create activity in the DataLayer
+        creates = dl.list_objects("Create")
+        activity_ids = [obj.id_ for obj in creates]
+        assert (
+            activity_ids.count(activity.id_) == 1
+        ), "Activity should appear exactly once in the DataLayer"
+
+    def test_outbox_entry_not_duplicated_on_second_run(self, dl):
+        """Outbox entry count is not increased by a no-op second run."""
+        marker = _build_marker()
+        dl.save(marker)
+
+        retry_pending_create_case_activities(
+            actor_datalayers_factory=lambda: {_CASE_ACTOR_ID: dl}
+        )
+        outbox_after_first = list(dl.outbox_list_for_actor(_CASE_ACTOR_ID))
+
+        # Second run — marker is gone so nothing should change.
+        retry_pending_create_case_activities(
+            actor_datalayers_factory=lambda: {_CASE_ACTOR_ID: dl}
+        )
+        outbox_after_second = list(dl.outbox_list_for_actor(_CASE_ACTOR_ID))
+
+        assert outbox_after_first == outbox_after_second
+
+    def test_no_duplicate_outbox_when_marker_deletion_fails(
+        self, dl, monkeypatch
+    ):
+        """Stuck marker (delete fails) does not cause duplicate delivery (AC-4).
+
+        Simulates the scenario where:
+          1. First run: activity stored, enqueued, but marker delete fails.
+          2. Second run: marker still present, but activity already in outbox.
+        The second run must NOT insert a second outbox entry.
+        """
+        activity = _build_activity()
+        marker = _build_marker(activity)
+        dl.save(marker)
+
+        # Patch dl.delete so it always returns False (simulating a stuck marker)
+        original_delete = dl.delete
+
+        def _failing_delete(table: str, id_: str) -> bool:
+            if table == "PendingCreateCaseActivity":
+                return False
+            return original_delete(table, id_)
+
+        monkeypatch.setattr(dl, "delete", _failing_delete)
+
+        # First run: activity should be stored and enqueued; marker stays.
+        first = retry_pending_create_case_activities(
+            actor_datalayers_factory=lambda: {_CASE_ACTOR_ID: dl}
+        )
+        assert first == 1
+        assert dl.read(marker.id_) is not None, "Marker should still exist"
+        outbox_after_first = list(dl.outbox_list_for_actor(_CASE_ACTOR_ID))
+        assert activity.id_ in outbox_after_first
+
+        # Second run: marker is still present but activity is already in outbox.
+        second = retry_pending_create_case_activities(
+            actor_datalayers_factory=lambda: {_CASE_ACTOR_ID: dl}
+        )
+        assert (
+            second == 1
+        )  # marker found → processed (enqueue skipped, clear fails)
+        outbox_after_second = list(dl.outbox_list_for_actor(_CASE_ACTOR_ID))
+
+        # The critical AC-4 assertion: exactly one entry, not two.
+        assert (
+            outbox_after_second.count(activity.id_) == 1
+        ), "Activity id should appear exactly once in the outbox"
+
+
+# ---------------------------------------------------------------------------
+# Multiple markers
+# ---------------------------------------------------------------------------
+
+
+class TestRetryMultipleMarkers:
+    """Multiple markers across multiple DataLayers are all processed."""
+
+    def test_two_markers_in_same_dl(self, dl):
+        """Two markers in the same DataLayer produce count=2."""
+        proposal_id_2 = "https://vendor.test/proposals/p-200"
+        activity_1 = _build_activity()
+
+        activity_2 = VultronCreateCaseActivity(
+            actor=_CASE_ACTOR_ID,
+            object_="https://case-actor.test/cases/c-002",
+            context=_ACCEPT_ID,
+            to=[_VENDOR_URI],
+        )
+        marker_1 = _build_marker(activity_1)
+        marker_2 = PendingCreateCaseActivity(
+            proposal_id=proposal_id_2,
+            case_actor_id=_CASE_ACTOR_ID,
+            vendor_uri=_VENDOR_URI,
+            create_activity_payload=activity_2.model_dump(by_alias=True),
+        )
+        dl.save(marker_1)
+        dl.save(marker_2)
+
+        count = retry_pending_create_case_activities(
+            actor_datalayers_factory=lambda: {_CASE_ACTOR_ID: dl}
+        )
+
+        assert count == 2
+        assert dl.read(marker_1.id_) is None
+        assert dl.read(marker_2.id_) is None
+
+    def test_markers_across_two_actor_dls(self):
+        """Markers in distinct DataLayers are both processed."""
+        dl_a = SqliteDataLayer("sqlite:///:memory:")
+        dl_b = SqliteDataLayer("sqlite:///:memory:")
+        actor_b = "https://case-actor-b.test/actors/svc-002"
+
+        activity_a = _build_activity()
+        activity_b = VultronCreateCaseActivity(
+            actor=actor_b,
+            object_="https://case-actor-b.test/cases/c-b01",
+            context=_ACCEPT_ID,
+            to=[_VENDOR_URI],
+        )
+        marker_a = _build_marker(activity_a)
+        marker_b = PendingCreateCaseActivity(
+            proposal_id="https://vendor.test/proposals/p-b01",
+            case_actor_id=actor_b,
+            vendor_uri=_VENDOR_URI,
+            create_activity_payload=activity_b.model_dump(by_alias=True),
+        )
+        dl_a.save(marker_a)
+        dl_b.save(marker_b)
+
+        count = retry_pending_create_case_activities(
+            actor_datalayers_factory=lambda: {
+                _CASE_ACTOR_ID: dl_a,
+                actor_b: dl_b,
+            }
+        )
+
+        assert count == 2
+
+
+# ---------------------------------------------------------------------------
+# AC-5: Full integration scenario
+# ---------------------------------------------------------------------------
+
+
+class TestRetryFullScenario:
+    """AC-5: Accept sent → Create fails → marker written → retry runner fires
+    → Create re-queued → marker removed.
+    """
+
+    def test_full_retry_scenario(self, dl):
+        """Simulates the complete CP-05-005 failure-and-recovery path."""
+        # 1. Simulate the BT tree: Accept was sent successfully.
+        #    The _WriteCreateCaseMarkerNode wrote the marker.
+        activity = _build_activity()
+        marker = PendingCreateCaseActivity(
+            proposal_id=_PROPOSAL_ID,
+            case_actor_id=_CASE_ACTOR_ID,
+            vendor_uri=_VENDOR_URI,
+            create_activity_payload=activity.model_dump(by_alias=True),
+        )
+        dl.save(marker)
+
+        # 2. Simulate Create(VulnerabilityCase) delivery failing:
+        #    the marker was written but _EmitCreateVulnerabilityCaseNode failed,
+        #    so the marker was NOT cleared. The activity is also not in the DL.
+        assert (
+            dl.read(activity.id_) is None
+        ), "Activity should not exist before retry"
+        assert (
+            dl.read(marker.id_) is not None
+        ), "Marker should exist before retry"
+        assert not dl.outbox_list_for_actor(
+            _CASE_ACTOR_ID
+        ), "Outbox should be empty before retry"
+
+        # 3. Retry runner fires (e.g., on next startup).
+        count = retry_pending_create_case_activities(
+            actor_datalayers_factory=lambda: {_CASE_ACTOR_ID: dl}
+        )
+
+        # 4. Verify: Create(VulnerabilityCase) was re-queued.
+        assert count == 1
+        retrieved = dl.read(activity.id_)
+        assert (
+            retrieved is not None
+        ), "Activity should be persisted after retry"
+        outbox = dl.outbox_list_for_actor(_CASE_ACTOR_ID)
+        assert (
+            activity.id_ in outbox
+        ), "Activity should be in outbox after retry"
+
+        # 5. Verify: marker is removed (AC-3).
+        assert (
+            dl.read(marker.id_) is None
+        ), "Marker should be deleted after successful retry"
+
+        # 6. Accept was NOT resent (AC-1 — retry only covers Create).
+        accepts = dl.list_objects("Accept")
+        assert not accepts, "No Accept should be written by the retry runner"
+
+    def test_retry_logs_info_on_success(self, dl, caplog):
+        """Retry runner logs at INFO level when activities are re-queued."""
+        marker = _build_marker()
+        dl.save(marker)
+
+        with caplog.at_level(logging.INFO, logger="vultron"):
+            retry_pending_create_case_activities(
+                actor_datalayers_factory=lambda: {_CASE_ACTOR_ID: dl}
+            )
+
+        log_messages = " ".join(caplog.messages)
+        assert (
+            "re-queued" in log_messages.lower()
+            or "retry" in log_messages.lower()
+        )
+
+    def test_retry_logs_debug_when_no_markers(self, dl, caplog):
+        """Retry runner logs at DEBUG when no pending markers exist."""
+        with caplog.at_level(logging.DEBUG, logger="vultron"):
+            retry_pending_create_case_activities(
+                actor_datalayers_factory=lambda: {_CASE_ACTOR_ID: dl}
+            )
+
+        # No INFO-level re-queue message should be emitted.
+        info_messages = [
+            r for r in caplog.records if r.levelno >= logging.INFO
+        ]
+        assert (
+            not info_messages
+        ), "No INFO messages expected when no markers are found"

--- a/test/core/behaviors/case/test_case_proposal_received_tree.py
+++ b/test/core/behaviors/case/test_case_proposal_received_tree.py
@@ -390,3 +390,56 @@ class TestCreateCaseProposalReceivedBTMarkerWiring:
         assert (
             marker.create_activity_payload
         ), "create_activity_payload must not be empty (AC-1)"
+
+    def test_emit_node_uses_marker_activity_id(self, make_payload):
+        """AC-4: The activity id_ enqueued by node 4 matches the marker payload id_.
+
+        ``_WriteCreateCaseMarkerNode`` (node 3) and
+        ``_EmitCreateVulnerabilityCaseNode`` (node 4) must share the same
+        activity ``id_``.  If they diverge, the retry runner checks the
+        marker's ``id_`` against the outbox and — not finding it — enqueues
+        a second ``Create(VulnerabilityCase)`` as a duplicate.
+
+        This test asserts ID consistency by:
+        1. Running the full BT with ``_ClearCreateCaseMarkerNode`` no-oped so
+           the marker is preserved after node 4 succeeds.
+        2. Reconstructing the activity from the marker's stored payload.
+        3. Verifying that ``id_`` is present in the case-actor's outbox.
+        """
+        from vultron.core.behaviors.case.case_proposal_received_tree import (
+            _ClearCreateCaseMarkerNode,
+        )
+        from vultron.core.models.activity import VultronCreateCaseActivity
+        from vultron.core.use_cases.received.case_proposal import (
+            CreateCaseProposalReceivedUseCase,
+        )
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        event = self._make_event(make_payload)
+
+        # Patch the clear node to skip deletion so the marker stays in the DL.
+        def _skip_delete(
+            self_node: _ClearCreateCaseMarkerNode,
+        ) -> py_trees.common.Status:  # noqa: N803
+            return py_trees.common.Status.SUCCESS
+
+        with patch.object(_ClearCreateCaseMarkerNode, "update", _skip_delete):
+            CreateCaseProposalReceivedUseCase(dl, event).execute()
+
+        marker_id = PendingCreateCaseActivity.build_id(_PROPOSAL_URI)
+        marker = dl.read(marker_id)
+        assert isinstance(
+            marker, PendingCreateCaseActivity
+        ), "Marker should still be present (clear was no-oped)"
+
+        stored_activity = VultronCreateCaseActivity.model_validate(
+            marker.create_activity_payload
+        )
+        marker_activity_id = stored_activity.id_
+
+        outbox = dl.outbox_list_for_actor(_CASE_ACTOR_URI)
+        assert marker_activity_id in outbox, (
+            "Activity id_ in the marker's payload must match the id_ in the"
+            " outbox. A mismatch causes the retry runner to enqueue a"
+            " duplicate Create(VulnerabilityCase) after crash/restart."
+        )

--- a/vultron/adapters/driving/fastapi/app.py
+++ b/vultron/adapters/driving/fastapi/app.py
@@ -163,6 +163,16 @@ def _make_lifespan(
             monitor = OutboxMonitor()
             monitor.start()
 
+            # Retry any Create(VulnerabilityCase) activities that were
+            # left pending from a previous process run (CP-05-005, #1139).
+            # The OutboxMonitor is started first so it can drain the
+            # re-queued activities immediately after startup.
+            from vultron.adapters.driving.fastapi.pending_retry import (
+                retry_pending_create_case_activities,
+            )
+
+            retry_pending_create_case_activities()
+
         yield
 
         if monitor is not None:

--- a/vultron/adapters/driving/fastapi/pending_retry.py
+++ b/vultron/adapters/driving/fastapi/pending_retry.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon file).
+
+"""Background retry runner for pending ``Create(VulnerabilityCase)`` activities.
+
+After the case-actor service sends ``Accept(CaseProposal)``, it writes a
+``PendingCreateCaseActivity`` marker to the DataLayer and then attempts to
+deliver ``Create(VulnerabilityCase)``.  If that delivery fails (or the
+process crashes), the marker persists.
+
+This module provides :func:`retry_pending_create_case_activities`, which:
+
+1. Scans every registered actor-scoped DataLayer for
+   ``PendingCreateCaseActivity`` markers.
+2. Reconstructs the pre-built ``Create(VulnerabilityCase)`` payload from
+   the marker (never re-constructs the activity from scratch, to preserve
+   the original ``id_``).
+3. Writes the activity to the DataLayer if not already present (idempotency
+   guard).
+4. Re-enqueues the activity to the actor's outbox so the
+   :class:`~vultron.adapters.driving.fastapi.outbox_monitor.OutboxMonitor`
+   can deliver it.
+5. Deletes the marker so the retry runner does not re-deliver an already-
+   queued activity on future startups.
+
+**Design decision (AC-2):** The runner uses *option (a): on-startup scan*.
+It is called once inside the FastAPI application lifespan immediately before
+the server starts accepting requests.  This is the simplest approach and
+directly covers the primary failure mode — a process crash after ``Accept``
+was sent but before ``Create(VulnerabilityCase)`` was delivered.  The
+:class:`OutboxMonitor` then drains and delivers the re-queued activities
+asynchronously during normal operation.
+
+Alternatives considered:
+
+- (b) *Triggered re-scan on each inbox receipt* — adds per-request overhead
+  and does not cover the crash-before-any-request scenario.
+- (c) *Dedicated polling task via a scheduler* — heavier mechanism than
+  needed for a low-frequency event.
+
+Option (a) is sufficient because a persisted marker represents an obligation
+from a *previous* process run; a re-scan at the start of each new run is
+the natural recovery point.
+
+Spec: ``specs/case-proposal.yaml`` CP-05-005.
+Issue: #1139.
+"""
+
+import logging
+from collections.abc import Callable
+from typing import cast
+
+from vultron.core.models.activity import VultronCreateCaseActivity
+from vultron.core.models.pending_create_case_activity import (
+    PendingCreateCaseActivity,
+)
+from vultron.core.ports.case_persistence import CaseOutboxPersistence
+from vultron.core.ports.datalayer import DataLayer
+
+logger = logging.getLogger(__name__)
+
+
+def _reconstruct_activity(
+    marker: PendingCreateCaseActivity,
+) -> VultronCreateCaseActivity | None:
+    """Reconstruct Create(VulnerabilityCase) from a marker's stored payload.
+
+    Returns the reconstructed activity, or ``None`` if the payload is
+    missing or invalid (errors are logged at ERROR level).
+    """
+    if not marker.create_activity_payload:
+        logger.warning(
+            "retry_pending: marker '%s' has no create_activity_payload;"
+            " skipping.",
+            marker.id_,
+        )
+        return None
+
+    try:
+        return VultronCreateCaseActivity.model_validate(
+            marker.create_activity_payload
+        )
+    except Exception as exc:
+        logger.error(
+            "retry_pending: could not reconstruct Create(VulnerabilityCase)"
+            " from marker '%s': %s",
+            marker.id_,
+            exc,
+        )
+        return None
+
+
+def _ensure_activity_persisted(
+    dl: DataLayer,
+    activity: VultronCreateCaseActivity,
+) -> bool:
+    """Write *activity* to *dl* if not already present.
+
+    Returns ``True`` on success (including when the activity already exists),
+    ``False`` if the DataLayer create call raises.
+    """
+    if dl.read(activity.id_) is not None:
+        return True
+    try:
+        dl.create(activity)
+        return True
+    except ValueError as exc:
+        logger.error(
+            "retry_pending: could not persist Create(VulnerabilityCase)"
+            " '%s': %s",
+            activity.id_,
+            exc,
+        )
+        return False
+
+
+def _enqueue_and_clear(
+    dl: DataLayer,
+    marker: PendingCreateCaseActivity,
+    activity: VultronCreateCaseActivity,
+) -> bool:
+    """Enqueue *activity* to the outbox and delete *marker*.
+
+    Returns ``True`` when the activity is in the outbox (whether it was
+    already there or was just added). Marker cleanup failures are logged
+    as warnings but do not affect the return value — the obligation is
+    considered satisfied once the activity is in the outbox.
+
+    The enqueue step is idempotent: if *activity* is already in the
+    outbox (e.g. from a previous partial run where the marker deletion
+    failed), no duplicate entry is inserted (AC-4).
+    """
+    enqueue_actor_id = marker.case_actor_id
+
+    # Idempotency guard: skip the insert if this activity is already
+    # queued. record_outbox_item does not enforce uniqueness; calling it
+    # twice would create two outbox entries and cause double delivery.
+    try:
+        existing_outbox = cast(
+            CaseOutboxPersistence, dl
+        ).outbox_list_for_actor(enqueue_actor_id)
+    except Exception as exc:
+        logger.error(
+            "retry_pending: could not read outbox for actor '%s': %s",
+            enqueue_actor_id,
+            exc,
+        )
+        return False
+
+    if activity.id_ not in existing_outbox:
+        try:
+            cast(CaseOutboxPersistence, dl).record_outbox_item(
+                enqueue_actor_id, activity.id_
+            )
+        except Exception as exc:
+            logger.error(
+                "retry_pending: could not enqueue Create(VulnerabilityCase)"
+                " '%s' to outbox for actor '%s': %s",
+                activity.id_,
+                enqueue_actor_id,
+                exc,
+            )
+            return False
+    else:
+        logger.debug(
+            "retry_pending: Create(VulnerabilityCase) '%s' already in"
+            " outbox for actor '%s'; skipping duplicate enqueue.",
+            activity.id_,
+            enqueue_actor_id,
+        )
+
+    deleted = dl.delete("PendingCreateCaseActivity", marker.id_)
+    if not deleted:
+        logger.warning(
+            "retry_pending: marker '%s' could not be deleted after"
+            " successful re-queue for actor '%s'. On the next startup"
+            " scan the activity will be found in the outbox and skipped.",
+            marker.id_,
+            enqueue_actor_id,
+        )
+
+    logger.info(
+        "retry_pending: re-queued Create(VulnerabilityCase) '%s'"
+        " for actor '%s' (marker '%s').",
+        activity.id_,
+        enqueue_actor_id,
+        marker.id_,
+    )
+    return True
+
+
+def retry_pending_create_case_activities(
+    actor_datalayers_factory: Callable[[], dict[str, DataLayer]] | None = None,
+) -> int:
+    """Re-queue all persisted ``PendingCreateCaseActivity`` obligations.
+
+    Iterates over every registered actor-scoped DataLayer, finds any
+    ``PendingCreateCaseActivity`` markers, and re-enqueues the stored
+    ``Create(VulnerabilityCase)`` payload to the case-actor's outbox for
+    delivery by the :class:`OutboxMonitor`.
+
+    Each marker is deleted after the payload is successfully enqueued, so
+    running this function multiple times does not produce duplicate
+    activities (AC-4).
+
+    Args:
+        actor_datalayers_factory: Callable returning the current
+            ``{actor_id: DataLayer}`` mapping.  Defaults to
+            :func:`~vultron.adapters.driven.datalayer.get_all_actor_datalayers`.
+            Inject a test double to avoid touching the module-level cache.
+
+    Returns:
+        The number of ``Create(VulnerabilityCase)`` activities successfully
+        re-queued during this run.
+    """
+    if actor_datalayers_factory is not None:
+        factory = actor_datalayers_factory
+    else:
+        from vultron.adapters.driven.datalayer import get_all_actor_datalayers
+
+        factory = get_all_actor_datalayers  # type: ignore[assignment]
+
+    actor_dls = factory()
+    if not actor_dls:
+        logger.debug(
+            "retry_pending: no actor DataLayers registered; skipping."
+        )
+        return 0
+
+    retried = 0
+    for actor_id, dl in actor_dls.items():
+        retried += _retry_actor_dl(actor_id, dl)
+
+    if retried:
+        logger.info(
+            "retry_pending: %d pending Create(VulnerabilityCase)"
+            " activity/activities re-queued for delivery.",
+            retried,
+        )
+    else:
+        logger.debug(
+            "retry_pending: no pending Create(VulnerabilityCase) found."
+        )
+    return retried
+
+
+def _retry_actor_dl(actor_id: str, dl: DataLayer) -> int:
+    """Process all PendingCreateCaseActivity markers in one actor DataLayer.
+
+    Returns the count of successfully re-queued activities.
+    """
+    retried = 0
+    for raw_marker in dl.list_objects("PendingCreateCaseActivity"):
+        if not isinstance(raw_marker, PendingCreateCaseActivity):
+            logger.warning(
+                "retry_pending: unexpected object type %r in actor '%s'"
+                " DataLayer; skipping.",
+                type(raw_marker).__name__,
+                actor_id,
+            )
+            continue
+
+        activity = _reconstruct_activity(raw_marker)
+        if activity is None:
+            continue
+
+        if not _ensure_activity_persisted(dl, activity):
+            continue
+
+        if _enqueue_and_clear(dl, raw_marker, activity):
+            retried += 1
+
+    return retried
+
+
+__all__ = ["retry_pending_create_case_activities"]

--- a/vultron/adapters/driving/fastapi/pending_retry.py
+++ b/vultron/adapters/driving/fastapi/pending_retry.py
@@ -72,6 +72,27 @@ from vultron.core.ports.datalayer import DataLayer
 logger = logging.getLogger(__name__)
 
 
+def _discover_actor_ids_from_shared_dl(shared_dl: DataLayer) -> list[str]:
+    """Scan the shared DataLayer for ``case_actor_id`` values in persisted markers.
+
+    Used by the startup scan to find actors that have pending
+    ``PendingCreateCaseActivity`` markers even when the process-level actor
+    cache is empty (e.g., after a crash/restart). The shared (unscoped)
+    DataLayer returns rows across all actors.
+
+    Args:
+        shared_dl: An unscoped DataLayer that can see all actors' records.
+
+    Returns:
+        List of unique ``case_actor_id`` values found in persisted markers.
+    """
+    actor_ids: set[str] = set()
+    for raw in shared_dl.list_objects("PendingCreateCaseActivity"):
+        if isinstance(raw, PendingCreateCaseActivity):
+            actor_ids.add(raw.case_actor_id)
+    return list(actor_ids)
+
+
 def _reconstruct_activity(
     marker: PendingCreateCaseActivity,
 ) -> VultronCreateCaseActivity | None:
@@ -203,6 +224,7 @@ def _enqueue_and_clear(
 
 def retry_pending_create_case_activities(
     actor_datalayers_factory: Callable[[], dict[str, DataLayer]] | None = None,
+    shared_datalayer_factory: Callable[[], DataLayer] | None = None,
 ) -> int:
     """Re-queue all persisted ``PendingCreateCaseActivity`` obligations.
 
@@ -215,24 +237,65 @@ def retry_pending_create_case_activities(
     running this function multiple times does not produce duplicate
     activities (AC-4).
 
+    On crash/restart the process-level actor cache is empty.  This function
+    supplements the cache by scanning the shared (unscoped) DataLayer for
+    persisted markers and creating actor-scoped DataLayers for any
+    ``case_actor_id`` values discovered there.  The shared-DL scan runs
+    automatically when ``actor_datalayers_factory`` is ``None`` (the default
+    production path), and also when ``shared_datalayer_factory`` is
+    explicitly provided (useful for testing the startup-recovery path without
+    touching the module-level cache).
+
     Args:
         actor_datalayers_factory: Callable returning the current
             ``{actor_id: DataLayer}`` mapping.  Defaults to
             :func:`~vultron.adapters.driven.datalayer.get_all_actor_datalayers`.
             Inject a test double to avoid touching the module-level cache.
+        shared_datalayer_factory: Callable returning a shared (unscoped)
+            DataLayer used to discover actor IDs from persisted markers on
+            startup.  Defaults to
+            :func:`~vultron.adapters.driven.datalayer.get_datalayer` (no
+            actor scoping) when ``actor_datalayers_factory`` is ``None``.
+            Inject a test double to exercise the startup-recovery path in
+            isolation.
 
     Returns:
         The number of ``Create(VulnerabilityCase)`` activities successfully
         re-queued during this run.
     """
     if actor_datalayers_factory is not None:
-        factory = actor_datalayers_factory
+        actor_dls: dict[str, DataLayer] = dict(actor_datalayers_factory())
     else:
         from vultron.adapters.driven.datalayer import get_all_actor_datalayers
 
-        factory = get_all_actor_datalayers  # type: ignore[assignment]
+        actor_dls = dict(get_all_actor_datalayers())  # type: ignore[assignment]
 
-    actor_dls = factory()
+    # Supplement the map with actors discovered from persisted markers in the
+    # shared DataLayer.  On crash/restart the process cache is empty, so without
+    # this scan the runner would skip all persisted obligations.  The scan runs
+    # unconditionally on the default production path (actor_datalayers_factory is
+    # None) and when a shared_datalayer_factory is explicitly injected (test
+    # coverage of the startup-recovery path).
+    _run_shared_scan = (actor_datalayers_factory is None) or (
+        shared_datalayer_factory is not None
+    )
+    if _run_shared_scan:
+        if shared_datalayer_factory is not None:
+            shared_dl: DataLayer = shared_datalayer_factory()
+        else:
+            from vultron.adapters.driven.datalayer import get_datalayer
+
+            shared_dl = get_datalayer()  # type: ignore[assignment]
+
+        for actor_id in _discover_actor_ids_from_shared_dl(shared_dl):
+            if actor_id not in actor_dls:
+                actor_dls[actor_id] = shared_dl.clone_for_actor(actor_id)
+                logger.debug(
+                    "retry_pending: discovered actor '%s' from persisted"
+                    " markers — creating scoped DataLayer.",
+                    actor_id,
+                )
+
     if not actor_dls:
         logger.debug(
             "retry_pending: no actor DataLayers registered; skipping."

--- a/vultron/core/behaviors/case/case_proposal_received_tree.py
+++ b/vultron/core/behaviors/case/case_proposal_received_tree.py
@@ -160,59 +160,66 @@ class _EmitAcceptCaseProposalNode(DataLayerAction):
 
 
 class _EmitCreateVulnerabilityCaseNode(DataLayerAction):
-    """Build Create(VulnerabilityCase), store it, and queue it to the outbox.
+    """Reconstruct Create(VulnerabilityCase) from the stored marker and queue it.
 
-    Reads ``case_id`` and ``accept_activity_id`` from the blackboard.
-    Sets ``context`` to the Accept activity URI for causal traceability
-    (CP-05-003, ADR-0023).
+    Reads the pre-constructed ``Create(VulnerabilityCase)`` payload from the
+    ``PendingCreateCaseActivity`` marker written by
+    ``_WriteCreateCaseMarkerNode``.  Using the stored payload (rather than
+    building a new activity from blackboard fields) guarantees that the
+    activity ``id_`` in the DataLayer and outbox is identical to the ``id_``
+    recorded in the marker.  This is critical for CP-05-005 idempotency: the
+    retry runner checks outbox membership by the marker's stored ``id_``, so
+    a fresh ``id_`` here would cause a duplicate delivery after crash/restart.
 
-    Failure returns FAILURE so the Sequence surface it; the Accept has
-    already been sent at this point (CP-05-005 covers the retry case).
+    Failure returns FAILURE so the enclosing Sequence surfaces it; the Accept
+    has already been sent at this point (CP-05-005 covers the retry case).
     """
 
     def __init__(
         self,
+        proposal_id: str,
         vendor_uri: str,
         name: str | None = None,
     ) -> None:
         super().__init__(name=name or self.__class__.__name__)
+        self._proposal_id = proposal_id
         self._vendor_uri = vendor_uri
-
-    def setup(self, **kwargs: Any) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="case_id", access=py_trees.common.Access.READ
-        )
-        self.blackboard.register_key(
-            key="accept_activity_id", access=py_trees.common.Access.READ
-        )
 
     def update(self) -> Status:
         if self.datalayer is None or self.actor_id is None:
             self.feedback_message = "DataLayer or actor_id not available"
             return Status.FAILURE
 
-        try:
-            case_id = self.blackboard.get("case_id")
-        except KeyError:
-            self.feedback_message = "case_id not found in blackboard"
-            return Status.FAILURE
-
-        try:
-            accept_activity_id = self.blackboard.get("accept_activity_id")
-        except KeyError:
+        # Read the pre-built payload from the marker to guarantee id_ consistency
+        # with CP-05-005 retry logic.
+        marker_id = PendingCreateCaseActivity.build_id(self._proposal_id)
+        raw_marker = self.datalayer.read(marker_id)
+        if not isinstance(raw_marker, PendingCreateCaseActivity):
             self.feedback_message = (
-                "accept_activity_id not found in blackboard"
+                f"PendingCreateCaseActivity marker '{marker_id}' not found"
+                " or wrong type; cannot emit Create(VulnerabilityCase)"
             )
+            logger.warning("%s: %s", self.name, self.feedback_message)
             return Status.FAILURE
 
-        # CP-05-003: context = URI of the Accept(CaseProposal) activity
-        activity = VultronCreateCaseActivity(
-            actor=self.actor_id,
-            object_=case_id,
-            context=accept_activity_id,
-            to=[self._vendor_uri],
-        )
+        if not raw_marker.create_activity_payload:
+            self.feedback_message = (
+                f"Marker '{marker_id}' has no create_activity_payload"
+            )
+            logger.warning("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
+
+        try:
+            activity = VultronCreateCaseActivity.model_validate(
+                raw_marker.create_activity_payload
+            )
+        except Exception as exc:
+            self.feedback_message = (
+                f"Could not reconstruct Create(VulnerabilityCase)"
+                f" from marker '{marker_id}': {exc}"
+            )
+            logger.warning("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
 
         try:
             self.datalayer.create(activity)
@@ -235,10 +242,10 @@ class _EmitCreateVulnerabilityCaseNode(DataLayerAction):
             return Status.FAILURE
 
         logger.info(
-            "%s: Queued Create(VulnerabilityCase) '%s' for case '%s'",
+            "%s: Queued Create(VulnerabilityCase) '%s' from proposal '%s'",
             self.name,
             activity.id_,
-            case_id,
+            self._proposal_id,
         )
         return Status.SUCCESS
 
@@ -427,7 +434,10 @@ def create_case_proposal_received_tree(
                 proposal_id=proposal_id,
                 vendor_uri=vendor_uri,
             ),
-            _EmitCreateVulnerabilityCaseNode(vendor_uri=vendor_uri),
+            _EmitCreateVulnerabilityCaseNode(
+                proposal_id=proposal_id,
+                vendor_uri=vendor_uri,
+            ),
             _ClearCreateCaseMarkerNode(proposal_id=proposal_id),
         ],
     )


### PR DESCRIPTION
- Closes #1139

## Summary

Adds a background retry runner that scans actor DataLayers on startup for
`PendingCreateCaseActivity` markers and re-queues the stored
`Create(VulnerabilityCase)` payload for delivery by the `OutboxMonitor`.
This completes CP-05-005, ensuring the case-actor service always delivers the
case announcement even after a crash between the two sequenced outbound activities.

## Changes

- **`vultron/adapters/driving/fastapi/pending_retry.py`**: Core retry runner.
  `retry_pending_create_case_activities()` iterates over all actor DataLayers
  (supplemented by shared-DL actor discovery for the crash/restart path),
  reconstructs the pre-built `Create(VulnerabilityCase)` from each marker's
  stored payload (preserving the original `id_`), persists it if absent,
  enqueues it idempotently, and deletes the marker on success.

- **`vultron/core/behaviors/case/case_proposal_received_tree.py`**: Fixed
  activity ID divergence: `_EmitCreateVulnerabilityCaseNode` now reads the
  pre-built payload from the `PendingCreateCaseActivity` marker written by
  `_WriteCreateCaseMarkerNode` instead of constructing a new activity (fresh
  `id_`). Marker and outbox now always share the same `id_`, preventing
  duplicate delivery by the retry runner.

- **`vultron/adapters/driving/fastapi/app.py`**: Wires the retry runner into
  the `configure_globals=True` lifespan path.

- **`test/adapters/driving/fastapi/test_pending_retry.py`**: 20 tests covering
  the no-marker no-op, happy-path, idempotency, stuck-marker path, multi-DataLayer,
  full AC-5 scenario, and 4 new startup-recovery tests exercising the shared-DL
  actor discovery path (empty cache + persisted markers = crash/restart simulation).

- **`test/core/behaviors/case/test_case_proposal_received_tree.py`**: New
  `test_emit_node_uses_marker_activity_id` asserts that the activity `id_`
  in the outbox always matches the `id_` in the marker payload.

- **`notes/case-proposal.md`**: Documents the startup-scan implementation,
  shared-DL actor discovery, and the payload-verbatim requirement.

## Design Decision (AC-2)

**Option (a): on-startup scan** was chosen. The shared-DL actor discovery
supplements the process cache so the runner recovers from crash/restart even
when `get_all_actor_datalayers()` returns empty. The `OutboxMonitor` is
already running when the scan fires, so re-queued activities drain immediately.

## Verification

- All 4360 unit tests pass (20 new)
- Black, flake8, mypy, pyright clean
- [x] AC-1: Retry re-sends `Create(VulnerabilityCase)` without re-creating the case or re-sending `Accept`
- [x] AC-2: Runner invoked on startup; shared-DL discovery covers crash/restart path
- [x] AC-3: Marker deleted after successful enqueue
- [x] AC-4: Idempotent — outbox guard + marker/emit ID consistency prevent duplicates
- [x] AC-5: Full scenario in `TestRetryFullScenario.test_full_retry_scenario`; activity ID consistency in `test_emit_node_uses_marker_activity_id`
- [x] AC-6: All tests pass; mypy and pyright clean