### PR TITLE
fix: correct shape distribution counts in ISSUE-1150 history entry

### DIFF
--- a/plan/history/2606/implementation/ISSUE-1150.md
+++ b/plan/history/2606/implementation/ISSUE-1150.md
@@ -17,8 +17,8 @@ fuzzer node entries across the four domain catalog files:
 - `notes/bt-fuzzer-nodes-vul-discovery.md` (3 nodes — marked N/A,
   simulation-only BT not ported to new architecture)
 
-Shape distribution: N/A (43), Evaluator (31), Retriever (11), Sentinel (4),
-Composer (4). Shapes assigned per the methodology in
+Shape distribution: N/A (50), Evaluator (28), Retriever (6), Sentinel (4),
+Composer (5). Shapes assigned per the methodology in
 `notes/coordination-agents.md`. Cross-references point to the corresponding
 `vultron.demo.fuzzer.*` classes created in FUZZ-01–07.
 


### PR DESCRIPTION
- Fixes post-merge review comment on #1179

## Summary

Corrects the shape distribution counts in the FUZZ-08a history entry.
The summary did not match the actual catalog entries. Counts verified
by grep across all four `notes/bt-fuzzer-nodes-*.md` files.

## Changes

- `plan/history/2606/implementation/ISSUE-1150.md`: corrected shape
  distribution from `N/A (43), Evaluator (31), Retriever (11), Sentinel
  (4), Composer (4)` to `N/A (50), Evaluator (28), Retriever (6),
  Sentinel (4), Composer (5)`