### PR TITLE
feat: add SvcOfferCaseManagerRoleUseCase trigger (#1127)

### DIFF
--- a/plan/history/2606/implementation/ISSUE-1127.md
+++ b/plan/history/2606/implementation/ISSUE-1127.md
@@ -1,0 +1,36 @@
+---
+source: ISSUE-1127
+timestamp: '2026-06-25T18:20:00.172456+00:00'
+title: Add SvcOfferCaseManagerRoleUseCase trigger
+type: implementation
+---
+
+## Issue #1127 — Add trigger-side use case for CASE_MANAGER role delegation
+
+Implemented the trigger-side use case for the CASE_MANAGER role delegation
+protocol as part of Epic #1129.
+
+### Deliverables
+
+- `OfferCaseManagerRoleTriggerRequest` added to `requests.py`
+- `offer_case_manager_role_trigger_bt()` BT factory added to
+  `actor_trigger_trees.py`; threads `captured` dict to leaf node to avoid
+  post-lock global blackboard read race condition
+- `SvcOfferCaseManagerRoleUseCase` (BT-15-001 compliant): `_prepare()` sets
+  `self._actor_id = case_actor_id` (PCR-08-007 pattern); `_build_tree()`
+  passes `captured=self._captured`; no racy post-lock blackboard access
+- `SvcAcceptCaseManagerRoleUseCase` stub (raises `NotImplementedError`,
+  per OX-10-004)
+- `TriggerService.offer_case_manager_role()` and
+  `TriggerServicePort.offer_case_manager_role()` added
+- `OfferCaseManagerRoleRequest` HTTP body model and
+  `POST /{actor_id}/trigger/offer-case-manager-role` endpoint
+- 4 unit tests: happy path, missing case actor, missing case, captured activity
+- `CreateOfferCaseManagerActivityNode` updated to populate `captured["activity"]`
+  under the BT global lock (concurrent-safe)
+
+### Verification
+
+4343 unit tests passed. All four linters (black, flake8, mypy, pyright) clean.
+
+**PR**: [#1183](https://github.com/CERTCC/Vultron/pull/1183)

--- a/test/adapters/driving/fastapi/routers/test_trigger_actor.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_actor.py
@@ -136,6 +136,44 @@ def case_obj(dl, actor):
 
 
 @pytest.fixture
+def case_obj_with_case_actor(dl, actor):
+    """Case + Case Actor service for offer-case-manager-role tests.
+
+    Identical to ``case_obj`` but also persists the Case Actor service with
+    ``context=case.id_`` so that ``_find_case_actor_id`` can resolve it.
+    """
+    case_actor = as_Service(name="Case Actor Service")
+    dl.create(case_actor)
+    case = VulnerabilityCase(name="TEST-CASE-OCM")
+    owner_participant = CaseParticipant(
+        attributed_to=actor.id_,
+        context=case.id_,
+        case_roles=[CVDRole.CASE_OWNER],
+    )
+    case_manager_participant = CaseParticipant(
+        attributed_to=case_actor.id_,
+        context=case.id_,
+        case_roles=[CVDRole.CASE_MANAGER],
+    )
+    case.actor_participant_index[actor.id_] = owner_participant.id_
+    case.actor_participant_index[case_actor.id_] = case_manager_participant.id_
+    case.case_participants.append(owner_participant.id_)
+    case.case_participants.append(case_manager_participant.id_)
+    dl.create(case)
+    dl.create(owner_participant)
+    dl.create(case_manager_participant)
+    # Update the Case Actor Service with context=case.id_ so that
+    # _find_case_actor_id resolves it for this case.
+    case_actor_with_context = as_Service(
+        id_=case_actor.id_,
+        name="Case Actor Service",
+        context=case.id_,
+    )
+    dl.save(case_actor_with_context)
+    return case, case_actor
+
+
+@pytest.fixture
 def invite(dl, actor, case_obj, other_actor):
     """Create and persist an RmInviteToCaseActivity for accept-case-invite tests."""
     invite_activity = rm_invite_to_case_activity(
@@ -338,5 +376,98 @@ def test_trigger_accept_case_invite_unknown_invite_returns_404(
     resp = client_triggers.post(
         f"/actors/{other_actor.id_}/trigger/accept-case-invite",
         json={"invite_id": "urn:uuid:nonexistent-invite"},
+    )
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+# ===========================================================================
+# Tests for trigger/offer-case-manager-role
+# ===========================================================================
+
+
+def test_trigger_offer_case_manager_role_returns_202(
+    client_triggers, actor, case_obj_with_case_actor
+):
+    """TB-01-002: POST /actors/{id}/trigger/offer-case-manager-role returns 202."""
+    case, _ = case_obj_with_case_actor
+    resp = client_triggers.post(
+        f"/actors/{actor.id_}/trigger/offer-case-manager-role",
+        json={"case_id": case.id_},
+    )
+    assert resp.status_code == status.HTTP_202_ACCEPTED
+
+
+def test_trigger_offer_case_manager_role_response_contains_activity(
+    client_triggers, actor, case_obj_with_case_actor
+):
+    """TB-04-001: Successful trigger response body contains 'activity' key."""
+    case, _ = case_obj_with_case_actor
+    resp = client_triggers.post(
+        f"/actors/{actor.id_}/trigger/offer-case-manager-role",
+        json={"case_id": case.id_},
+    )
+    assert resp.status_code == status.HTTP_202_ACCEPTED
+    data = resp.json()
+    assert "activity" in data
+    assert data["activity"] is not None
+    assert data["activity"]["type"] == "Offer"
+
+
+def test_trigger_offer_case_manager_role_activity_actor_is_case_actor(
+    client_triggers, actor, case_obj_with_case_actor
+):
+    """Offer activity must be emitted from the Case Actor's identity (PCR-08-007)."""
+    case, case_actor = case_obj_with_case_actor
+    resp = client_triggers.post(
+        f"/actors/{actor.id_}/trigger/offer-case-manager-role",
+        json={"case_id": case.id_},
+    )
+    assert resp.status_code == status.HTTP_202_ACCEPTED
+    data = resp.json()
+    assert data["activity"]["actor"] == case_actor.id_
+
+
+def test_trigger_offer_case_manager_role_missing_case_id_returns_422(
+    client_triggers, actor
+):
+    """TB-03-001: Missing case_id returns HTTP 422."""
+    resp = client_triggers.post(
+        f"/actors/{actor.id_}/trigger/offer-case-manager-role",
+        json={},
+    )
+    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+
+def test_trigger_offer_case_manager_role_unknown_actor_returns_404(
+    client_triggers,
+):
+    """TB-01-003: Unknown actor_id returns HTTP 404."""
+    resp = client_triggers.post(
+        "/actors/nonexistent-actor/trigger/offer-case-manager-role",
+        json={"case_id": "urn:uuid:any-case"},
+    )
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+    data = resp.json()
+    assert data["detail"]["error"] == "NotFound"
+
+
+def test_trigger_offer_case_manager_role_unknown_case_returns_404(
+    client_triggers, actor
+):
+    """TB-01-003: Unknown case_id returns HTTP 404."""
+    resp = client_triggers.post(
+        f"/actors/{actor.id_}/trigger/offer-case-manager-role",
+        json={"case_id": "urn:uuid:nonexistent-case"},
+    )
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_trigger_offer_case_manager_role_no_case_actor_returns_404(
+    client_triggers, actor, case_obj
+):
+    """TB-01-003: No Case Actor for the case returns HTTP 404."""
+    resp = client_triggers.post(
+        f"/actors/{actor.id_}/trigger/offer-case-manager-role",
+        json={"case_id": case_obj.id_},
     )
     assert resp.status_code == status.HTTP_404_NOT_FOUND

--- a/test/core/use_cases/triggers/test_actor_triggers.py
+++ b/test/core/use_cases/triggers/test_actor_triggers.py
@@ -15,9 +15,10 @@
 
 """
 Unit tests for actor-level trigger use cases.
-Covers SvcInviteActorToCaseUseCase, SvcSuggestActorToCaseUseCase, and
-SvcAcceptCaseInviteUseCase.  Includes DR-09 regression tests verifying
-that short UUIDs in actor_id are normalised to full URIs before use.
+Covers SvcInviteActorToCaseUseCase, SvcSuggestActorToCaseUseCase,
+SvcAcceptCaseInviteUseCase, and SvcOfferCaseManagerRoleUseCase.
+Includes DR-09 regression tests verifying that short UUIDs in actor_id
+are normalised to full URIs before use.
 """
 
 import pytest
@@ -30,11 +31,13 @@ from vultron.core.states.roles import CVDRole
 from vultron.core.use_cases.triggers.actor import (
     SvcAcceptCaseInviteUseCase,
     SvcInviteActorToCaseUseCase,
+    SvcOfferCaseManagerRoleUseCase,
     SvcSuggestActorToCaseUseCase,
 )
 from vultron.core.use_cases.triggers.requests import (
     AcceptCaseInviteTriggerRequest,
     InviteActorToCaseTriggerRequest,
+    OfferCaseManagerRoleTriggerRequest,
     SuggestActorToCaseTriggerRequest,
 )
 from vultron.errors import VultronNotFoundError, VultronValidationError
@@ -437,3 +440,137 @@ class TestSvcAcceptCaseInviteUseCase:
         ).execute()
 
         assert result["activity"]["actor"] == _HTTP_ACTOR_ID
+
+
+def _make_case_with_case_actor(
+    dl: SqliteDataLayer, owner_actor_id: str, case_actor_id: str
+) -> tuple[VulnerabilityCase, str]:
+    """Create a VulnerabilityCase with a registered Case Actor service and
+    CASE_MANAGER participant.  Returns ``(case, case_actor_participant_id)``.
+    """
+    case = VulnerabilityCase(
+        attributed_to=owner_actor_id, name="Test Case", content="Content"
+    )
+    owner_participant = CaseParticipant(
+        attributed_to=owner_actor_id,
+        context=case.id_,
+        case_roles=[CVDRole.CASE_OWNER],
+    )
+    case_actor_participant = CaseParticipant(
+        attributed_to=case_actor_id,
+        context=case.id_,
+        case_roles=[CVDRole.CASE_MANAGER],
+    )
+    case.actor_participant_index[owner_actor_id] = owner_participant.id_
+    case.actor_participant_index[case_actor_id] = case_actor_participant.id_
+    case.case_participants.append(owner_participant.id_)
+    case.case_participants.append(case_actor_participant.id_)
+    dl.create(case)
+    dl.create(owner_participant)
+    dl.create(case_actor_participant)
+    return case, case_actor_participant.id_
+
+
+class TestSvcOfferCaseManagerRoleUseCase:
+    """Tests for the offer-case-manager-role trigger use case."""
+
+    def test_offer_creates_activity_and_enqueues_outbox(self):
+        """Happy path: offer is created and queued in the Case Actor's outbox."""
+        actor, dl = _make_actor_dl("Vendor")
+        # Case Actor service uses a deterministic ID pattern.
+        case_actor = as_Service(
+            id_=f"{actor.id_}/case-actor",
+            name="CaseActorService",
+        )
+        dl.create(case_actor)
+        case, _ = _make_case_with_case_actor(dl, actor.id_, case_actor.id_)
+        # Wire the case_actor_id via the Service context so _find_case_actor_id
+        # resolves it.
+        case_actor_with_context = as_Service(
+            id_=case_actor.id_,
+            name="CaseActorService",
+            context=case.id_,
+        )
+        dl.save(case_actor_with_context)
+
+        request = OfferCaseManagerRoleTriggerRequest(
+            actor_id=actor.id_,
+            case_id=case.id_,
+        )
+        result = SvcOfferCaseManagerRoleUseCase(
+            dl, request, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
+
+        # Activity should be queued in the Case Actor's outbox.
+        case_actor_dl = dl.clone_for_actor(case_actor.id_)
+        outbox = case_actor_dl.outbox_list()
+        assert (
+            len(outbox) >= 1
+        ), "Offer activity must be in Case Actor's outbox"
+
+        # result["activity"] should be populated via _handle_result.
+        assert result.get("activity") is not None
+        activity = result["activity"]
+        assert activity["type"] == "Offer"
+        assert activity["actor"] == case_actor.id_
+
+    def test_offer_raises_when_case_actor_missing(self):
+        """VultronNotFoundError when no Case Actor Service exists for the case."""
+        actor, dl = _make_actor_dl("Vendor")
+        case = VulnerabilityCase(
+            attributed_to=actor.id_, name="No CaseActor Case", content="..."
+        )
+        dl.create(case)
+
+        request = OfferCaseManagerRoleTriggerRequest(
+            actor_id=actor.id_,
+            case_id=case.id_,
+        )
+        with pytest.raises(VultronNotFoundError):
+            SvcOfferCaseManagerRoleUseCase(
+                dl, request, trigger_activity=TriggerActivityAdapter(dl)
+            ).execute()
+
+    def test_offer_raises_when_case_not_found(self):
+        """VultronNotFoundError when the case_id does not exist."""
+        actor, dl = _make_actor_dl("Vendor")
+
+        request = OfferCaseManagerRoleTriggerRequest(
+            actor_id=actor.id_,
+            case_id="https://example.org/cases/no-such-case",
+        )
+        with pytest.raises(Exception):
+            SvcOfferCaseManagerRoleUseCase(
+                dl, request, trigger_activity=TriggerActivityAdapter(dl)
+            ).execute()
+
+    def test_offer_activity_persisted_in_datalayer(self):
+        """Offer activity is readable from the DataLayer after execution."""
+        actor, dl = _make_actor_dl("Vendor")
+        case_actor = as_Service(
+            id_=f"{actor.id_}/case-actor",
+            name="CaseActorService",
+            context="placeholder",  # will be updated below
+        )
+        dl.create(case_actor)
+        case, _ = _make_case_with_case_actor(dl, actor.id_, case_actor.id_)
+        case_actor_with_context = as_Service(
+            id_=case_actor.id_,
+            name="CaseActorService",
+            context=case.id_,
+        )
+        dl.save(case_actor_with_context)
+
+        request = OfferCaseManagerRoleTriggerRequest(
+            actor_id=actor.id_,
+            case_id=case.id_,
+        )
+        result = SvcOfferCaseManagerRoleUseCase(
+            dl, request, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
+
+        activity_id = result.get("activity", {}).get("id")
+        assert activity_id is not None
+        stored = dl.read(activity_id)
+        assert stored is not None
+        assert getattr(stored, "type_", None) == "Offer"

--- a/test/core/use_cases/triggers/test_base.py
+++ b/test/core/use_cases/triggers/test_base.py
@@ -96,7 +96,10 @@ def test_hooks_called_in_order():
     assert uc.prepare_called
     assert uc.build_tree_called
     assert uc.handle_result_called
-    assert result == {"activity": None}
+    assert result == {
+        "activity": None,
+        "emitting_actor_id": "https://example.org/actor",
+    }
 
 
 def test_execute_returns_captured_activity():
@@ -114,7 +117,10 @@ def test_execute_returns_captured_activity():
         dl=MagicMock(), request=object(), trigger_activity=MagicMock()
     )
     result = uc.execute()
-    assert result == {"activity": {"type": "TestActivity"}}
+    assert result == {
+        "activity": {"type": "TestActivity"},
+        "emitting_actor_id": "https://example.org/actor",
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/vultron/adapters/driving/fastapi/routers/trigger_actor.py
+++ b/vultron/adapters/driving/fastapi/routers/trigger_actor.py
@@ -32,6 +32,7 @@ from vultron.adapters.driving.fastapi.outbox_handler import outbox_handler
 from vultron.adapters.driving.fastapi.trigger_models import (
     AcceptCaseInviteRequest,
     InviteActorToCaseRequest,
+    OfferCaseManagerRoleRequest,
     SuggestActorToCaseRequest,
 )
 from vultron.core.ports.datalayer import ActorScopedDataLayer, DataLayer
@@ -141,6 +142,43 @@ def trigger_invite_actor_to_case(
             actor_id=actor_id,
             case_id=body.case_id,
             invitee_id=body.invitee_id,
+        )
+    background_tasks.add_task(outbox_handler, actor_id, actor_dl, dl)
+    return result
+
+
+@router.post(
+    "/{actor_id}/trigger/offer-case-manager-role",
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Offer the CASE_MANAGER role to the Case Actor.",
+    description=(
+        "Emits an Offer(CaseManagerRole) from the Case Actor's identity to "
+        "itself, initiating the CASE_MANAGER delegation handshake.  The Case "
+        "Actor must already exist in the DataLayer.  This is the trigger-side "
+        "path for DEMOMA-08-007; the auto-accept is handled by "
+        "OfferCaseManagerRoleReceivedUseCase on the Case Actor's inbox side."
+    ),
+    operation_id="actors_trigger_offer_case_manager_role",
+)
+def trigger_offer_case_manager_role(
+    actor_id: str,
+    body: OfferCaseManagerRoleRequest,
+    background_tasks: BackgroundTasks,
+    svc: TriggerServicePort = Depends(get_trigger_service),
+    dl: DataLayer = Depends(get_trigger_dl),
+    actor_dl: ActorScopedDataLayer = Depends(get_canonical_actor_dl),
+) -> dict:
+    """
+    Trigger the offer-case-manager-role behavior for the given actor.
+
+    Implements:
+        TB-01-001, TB-01-002, TB-01-003, TB-02-001, TB-03-001, TB-03-002,
+        TB-04-001; DEMOMA-08-007
+    """
+    with domain_error_translation():
+        result = svc.offer_case_manager_role(
+            actor_id=actor_id,
+            case_id=body.case_id,
         )
     background_tasks.add_task(outbox_handler, actor_id, actor_dl, dl)
     return result

--- a/vultron/adapters/driving/fastapi/routers/trigger_actor.py
+++ b/vultron/adapters/driving/fastapi/routers/trigger_actor.py
@@ -166,10 +166,15 @@ def trigger_offer_case_manager_role(
     background_tasks: BackgroundTasks,
     svc: TriggerServicePort = Depends(get_trigger_service),
     dl: DataLayer = Depends(get_trigger_dl),
-    actor_dl: ActorScopedDataLayer = Depends(get_canonical_actor_dl),
 ) -> dict:
     """
     Trigger the offer-case-manager-role behavior for the given actor.
+
+    The BT runs under the Case Actor's identity (PCR-08-007), so the Offer
+    activity is queued in the **Case Actor's** outbox — not the path actor's.
+    ``outbox_handler`` is therefore scheduled against the Case Actor's
+    actor-scoped DataLayer, resolved from the use-case result's
+    ``emitting_actor_id`` field.
 
     Implements:
         TB-01-001, TB-01-002, TB-01-003, TB-02-001, TB-03-001, TB-03-002,
@@ -180,5 +185,9 @@ def trigger_offer_case_manager_role(
             actor_id=actor_id,
             case_id=body.case_id,
         )
-    background_tasks.add_task(outbox_handler, actor_id, actor_dl, dl)
+    emitting_actor_id = result.get("emitting_actor_id", actor_id)
+    emitting_dl = dl.clone_for_actor(emitting_actor_id)
+    background_tasks.add_task(
+        outbox_handler, emitting_actor_id, emitting_dl, dl
+    )
     return result

--- a/vultron/adapters/driving/fastapi/trigger_models.py
+++ b/vultron/adapters/driving/fastapi/trigger_models.py
@@ -327,6 +327,19 @@ class InviteActorToCaseRequest(BaseModel):
     invitee_id: UriString
 
 
+class OfferCaseManagerRoleRequest(BaseModel):
+    """Request body for the offer-case-manager-role trigger endpoint.
+
+    TB-03-001: Must include case_id identifying the target case.
+    TB-03-002: Unknown fields are silently ignored (extra="ignore").
+    The Case Actor for the case must already exist in the DataLayer.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    case_id: UriString
+
+
 class NotifyFixReadyRequest(BaseModel):
     """Request body for the notify-fix-ready demo trigger.
 

--- a/vultron/core/behaviors/case/actor_trigger_trees.py
+++ b/vultron/core/behaviors/case/actor_trigger_trees.py
@@ -137,7 +137,9 @@ def accept_case_invite_trigger_bt(
     return root
 
 
-def offer_case_manager_role_trigger_bt() -> py_trees.behaviour.Behaviour:
+def offer_case_manager_role_trigger_bt(
+    captured: dict | None = None,
+) -> py_trees.behaviour.Behaviour:
     """Return the trigger-side BT for the offer-case-manager-role workflow.
 
     Emits ``Offer(CaseManagerRole)`` from the Case Actor's identity and flushes
@@ -163,7 +165,7 @@ def offer_case_manager_role_trigger_bt() -> py_trees.behaviour.Behaviour:
         name="OfferCaseManagerRoleTriggerBT",
         memory=False,
         children=[
-            SendOfferCaseManagerRoleNode(),
+            SendOfferCaseManagerRoleNode(captured=captured),
             UpdateActorOutbox(name="UpdateActorOutbox(Offer)"),
         ],
     )

--- a/vultron/core/behaviors/case/actor_trigger_trees.py
+++ b/vultron/core/behaviors/case/actor_trigger_trees.py
@@ -32,10 +32,14 @@ from typing import Callable
 
 import py_trees
 
+from vultron.core.behaviors.case.communication_tree import (
+    SendOfferCaseManagerRoleNode,
+)
 from vultron.core.behaviors.case.nodes.actor import (
     EmitAcceptCaseInviteNode,
     EmitInviteActorToCaseNode,
 )
+from vultron.core.behaviors.helpers import UpdateActorOutbox
 from vultron.core.behaviors.sender.send_tree import sender_side_bt
 
 logger = logging.getLogger(__name__)
@@ -130,4 +134,38 @@ def accept_case_invite_trigger_bt(
         ],
     )
     logger.debug("Created AcceptCaseInviteTriggerBT for invite=%s", invite_id)
+    return root
+
+
+def offer_case_manager_role_trigger_bt() -> py_trees.behaviour.Behaviour:
+    """Return the trigger-side BT for the offer-case-manager-role workflow.
+
+    Emits ``Offer(CaseManagerRole)`` from the Case Actor's identity and flushes
+    the activity to the Case Actor's outbox.  This is the manual trigger-side
+    counterpart to the automatic path in ``receive_report_case_tree.py``
+    (DEMOMA-08-007).
+
+    The calling use case MUST pre-populate the blackboard (via
+    ``_extra_execute_kwargs``) with:
+
+    - ``case_id``: ID of the ``VulnerabilityCase``.
+    - ``case_actor_id``: ID of the Case Actor Service.
+    - ``case_actor_participant_id``: ID of the Case Actor's
+      ``CaseParticipant`` record.
+
+    Returns:
+        Sequence containing ``SendOfferCaseManagerRoleNode`` followed by
+        ``UpdateActorOutbox``.
+
+    Per specs/multi-actor-demo.yaml DEMOMA-08-007; BT-15-001.
+    """
+    root = py_trees.composites.Sequence(
+        name="OfferCaseManagerRoleTriggerBT",
+        memory=False,
+        children=[
+            SendOfferCaseManagerRoleNode(),
+            UpdateActorOutbox(name="UpdateActorOutbox(Offer)"),
+        ],
+    )
+    logger.debug("Created OfferCaseManagerRoleTriggerBT")
     return root

--- a/vultron/core/behaviors/case/communication_tree.py
+++ b/vultron/core/behaviors/case/communication_tree.py
@@ -73,13 +73,17 @@ class SendOfferCaseManagerRoleNode(py_trees.composites.Sequence):
     Per DEMOMA-08-002, DEMOMA-08-003; Issue #469.
     """
 
-    def __init__(self, name: str | None = None):
+    def __init__(
+        self,
+        captured: dict | None = None,
+        name: str | None = None,
+    ) -> None:
         py_trees.composites.Sequence.__init__(
             self,
             name=name or self.__class__.__name__,
             memory=False,
             children=[
                 ResolveCaseManagerOfferContextNode(),
-                CreateOfferCaseManagerActivityNode(),
+                CreateOfferCaseManagerActivityNode(captured=captured),
             ],
         )

--- a/vultron/core/behaviors/case/nodes/communication.py
+++ b/vultron/core/behaviors/case/nodes/communication.py
@@ -236,8 +236,13 @@ class ResolveCaseManagerOfferContextNode(DataLayerAction):
 class CreateOfferCaseManagerActivityNode(DataLayerAction):
     """Create Offer(CaseManagerRole) via trigger_activity_factory."""
 
-    def __init__(self, name: str | None = None):
+    def __init__(
+        self,
+        captured: dict | None = None,
+        name: str | None = None,
+    ) -> None:
         super().__init__(name=name or self.__class__.__name__)
+        self._captured = captured
 
     def setup(self, **kwargs: Any) -> None:
         super().setup(**kwargs)
@@ -298,6 +303,17 @@ class CreateOfferCaseManagerActivityNode(DataLayerAction):
                 )
             )
             self.blackboard.activity_id = activity_id
+            if self._captured is not None:
+                activity_obj = self.datalayer.read(activity_id)
+                if activity_obj is not None and hasattr(
+                    activity_obj, "model_dump"
+                ):
+                    self._captured["activity"] = activity_obj.model_dump(
+                        mode="json",
+                        by_alias=True,
+                        serialize_as_any=True,
+                        exclude_none=True,
+                    )
             self.logger.info(
                 "%s: Queued Offer(CaseManagerRole) '%s' to Case Actor '%s'"
                 " for case '%s'",

--- a/vultron/core/ports/trigger_service.py
+++ b/vultron/core/ports/trigger_service.py
@@ -203,3 +203,9 @@ class TriggerServicePort(Protocol):
         case_id: str,
         invitee_id: str,
     ) -> dict[str, Any]: ...
+
+    def offer_case_manager_role(
+        self,
+        actor_id: str,
+        case_id: str,
+    ) -> dict[str, Any]: ...

--- a/vultron/core/use_cases/triggers/_base.py
+++ b/vultron/core/use_cases/triggers/_base.py
@@ -112,7 +112,10 @@ class SvcBTTriggerBase(ABC):
 
         self._handle_result()
 
-        return {"activity": self._captured.get("activity")}
+        return {
+            "activity": self._captured.get("activity"),
+            "emitting_actor_id": self._actor_id,
+        }
 
     @abstractmethod
     def _prepare(self) -> None:

--- a/vultron/core/use_cases/triggers/actor.py
+++ b/vultron/core/use_cases/triggers/actor.py
@@ -20,13 +20,15 @@ No HTTP framework imports permitted here.
 """
 
 import logging
-from typing import cast
+from typing import Any, cast
 
 import py_trees.behaviour
+import py_trees.blackboard
 
 from vultron.core.behaviors.case.actor_trigger_trees import (
     accept_case_invite_trigger_bt,
     invite_actor_to_case_trigger_bt,
+    offer_case_manager_role_trigger_bt,
     suggest_actor_to_case_trigger_bt,
 )
 from vultron.core.use_cases._helpers import _find_case_actor_id
@@ -38,6 +40,7 @@ from vultron.core.use_cases.triggers._helpers import (
 from vultron.core.use_cases.triggers.requests import (
     AcceptCaseInviteTriggerRequest,
     InviteActorToCaseTriggerRequest,
+    OfferCaseManagerRoleTriggerRequest,
     SuggestActorToCaseTriggerRequest,
 )
 from vultron.errors import (
@@ -170,4 +173,102 @@ class SvcAcceptCaseInviteUseCase(SvcBTTriggerBase):
             "Actor '%s' accepted case invite '%s'",
             self._actor_id,
             self._invite_id,
+        )
+
+
+class SvcOfferCaseManagerRoleUseCase(SvcBTTriggerBase):
+    """Offer the CASE_MANAGER role to the Case Actor (trigger-side path).
+
+    Emits ``_OfferCaseManagerRoleActivity`` from the Case Actor's identity to
+    itself, initiating the CASE_MANAGER delegation handshake.  This is the
+    manual trigger-side counterpart to the automatic path wired into
+    ``receive_report_case_tree.py`` (DEMOMA-08-007).
+
+    The Case Actor service must already exist in the DataLayer (spawned by
+    the CaseActor spawning protocol, issue #1092).
+    """
+
+    def _prepare(self) -> None:
+        request = cast(OfferCaseManagerRoleTriggerRequest, self._request)
+        # Validate the requesting actor exists in the DataLayer.
+        resolve_actor(request.actor_id, self._dl)
+        self._case = resolve_case(request.case_id, self._dl)
+
+        case_actor_id = _find_case_actor_id(self._dl, self._case.id_)
+        if case_actor_id is None:
+            raise VultronNotFoundError("CaseActor", self._case.id_)
+
+        participant_id = self._case.actor_participant_index.get(case_actor_id)
+        if not participant_id:
+            raise VultronNotFoundError(
+                "CaseParticipant for CaseActor", case_actor_id
+            )
+
+        self._case_actor_id: str = case_actor_id
+        self._case_actor_participant_id: str = participant_id
+        # BT runs under the Case Actor's identity so the offer is queued in
+        # the Case Actor's outbox (mirrors the automatic path in
+        # receive_report_case_tree.py).
+        self._actor_id = case_actor_id
+
+    def _build_tree(self) -> py_trees.behaviour.Behaviour:
+        return offer_case_manager_role_trigger_bt()
+
+    def _extra_execute_kwargs(self) -> dict[str, Any]:
+        return {
+            "case_id": self._case.id_,
+            "case_actor_id": self._case_actor_id,
+            "case_actor_participant_id": self._case_actor_participant_id,
+        }
+
+    def _handle_result(self) -> None:
+        # ``SendOfferCaseManagerRoleNode`` writes ``activity_id`` to the
+        # global blackboard.  Only ``datalayer`` and ``trigger_activity_factory``
+        # are cleaned up by BTBridge, so the key persists here.
+        activity_id = py_trees.blackboard.Blackboard.storage.get(
+            "/activity_id"
+        )
+        if isinstance(activity_id, str):
+            activity_obj = self._dl.read(activity_id)
+            if activity_obj is not None and hasattr(
+                activity_obj, "model_dump"
+            ):
+                self._captured["activity"] = activity_obj.model_dump(
+                    mode="json",
+                    by_alias=True,
+                    serialize_as_any=True,
+                    exclude_none=True,
+                )
+        logger.info(
+            "Actor '%s' offered CASE_MANAGER role for case '%s'",
+            self._case_actor_id,
+            self._case.id_,
+        )
+
+
+class SvcAcceptCaseManagerRoleUseCase:
+    """Stub for the manual accept-case-manager-role trigger path.
+
+    The auto-accept path in ``OfferCaseManagerRoleReceivedUseCase`` handles
+    CASE_MANAGER role acceptance automatically for the demo.  This class is
+    a stub satisfying the interface contract (DEMOMA-08-008); full manual
+    override is deferred until required.
+
+    TODO(#1127): Implement when a manual override trigger is needed.
+    """
+
+    def __init__(
+        self,
+        dl: object,
+        request: object,
+        trigger_activity: object = None,
+    ) -> None:
+        self._dl = dl
+        self._request = request
+
+    def execute(self) -> dict:
+        raise NotImplementedError(
+            "SvcAcceptCaseManagerRoleUseCase.execute() is not yet implemented."
+            " The auto-accept path (OfferCaseManagerRoleReceivedUseCase)"
+            " handles CASE_MANAGER acceptance automatically."
         )

--- a/vultron/core/use_cases/triggers/actor.py
+++ b/vultron/core/use_cases/triggers/actor.py
@@ -23,7 +23,6 @@ import logging
 from typing import Any, cast
 
 import py_trees.behaviour
-import py_trees.blackboard
 
 from vultron.core.behaviors.case.actor_trigger_trees import (
     accept_case_invite_trigger_bt,
@@ -212,7 +211,7 @@ class SvcOfferCaseManagerRoleUseCase(SvcBTTriggerBase):
         self._actor_id = case_actor_id
 
     def _build_tree(self) -> py_trees.behaviour.Behaviour:
-        return offer_case_manager_role_trigger_bt()
+        return offer_case_manager_role_trigger_bt(captured=self._captured)
 
     def _extra_execute_kwargs(self) -> dict[str, Any]:
         return {
@@ -222,23 +221,6 @@ class SvcOfferCaseManagerRoleUseCase(SvcBTTriggerBase):
         }
 
     def _handle_result(self) -> None:
-        # ``SendOfferCaseManagerRoleNode`` writes ``activity_id`` to the
-        # global blackboard.  Only ``datalayer`` and ``trigger_activity_factory``
-        # are cleaned up by BTBridge, so the key persists here.
-        activity_id = py_trees.blackboard.Blackboard.storage.get(
-            "/activity_id"
-        )
-        if isinstance(activity_id, str):
-            activity_obj = self._dl.read(activity_id)
-            if activity_obj is not None and hasattr(
-                activity_obj, "model_dump"
-            ):
-                self._captured["activity"] = activity_obj.model_dump(
-                    mode="json",
-                    by_alias=True,
-                    serialize_as_any=True,
-                    exclude_none=True,
-                )
         logger.info(
             "Actor '%s' offered CASE_MANAGER role for case '%s'",
             self._case_actor_id,

--- a/vultron/core/use_cases/triggers/actor.py
+++ b/vultron/core/use_cases/triggers/actor.py
@@ -222,8 +222,7 @@ class SvcOfferCaseManagerRoleUseCase(SvcBTTriggerBase):
 
     def _handle_result(self) -> None:
         logger.info(
-            "Actor '%s' offered CASE_MANAGER role for case '%s'",
-            self._case_actor_id,
+            "CASE_MANAGER role offered for case '%s'",
             self._case.id_,
         )
 

--- a/vultron/core/use_cases/triggers/requests.py
+++ b/vultron/core/use_cases/triggers/requests.py
@@ -212,3 +212,12 @@ class AddParticipantStatusTriggerRequest(CaseTriggerRequest):
     rm_state: RM | None = None
     vfd_state: CS_vfd | None = None
     pxa_state: CS_pxa | None = None
+
+
+class OfferCaseManagerRoleTriggerRequest(CaseTriggerRequest):
+    """Trigger request to offer the CASE_MANAGER role to the Case Actor.
+
+    Emits an ``_OfferCaseManagerRoleActivity`` from the Case Actor's identity
+    to itself, initiating the CASE_MANAGER delegation handshake.  The Case
+    Actor must already exist in the DataLayer (DEMOMA-08-007).
+    """

--- a/vultron/core/use_cases/triggers/service.py
+++ b/vultron/core/use_cases/triggers/service.py
@@ -42,6 +42,7 @@ from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.use_cases.triggers.actor import (
     SvcAcceptCaseInviteUseCase,
     SvcInviteActorToCaseUseCase,
+    SvcOfferCaseManagerRoleUseCase,
     SvcSuggestActorToCaseUseCase,
 )
 from vultron.core.use_cases.triggers.case import (
@@ -80,6 +81,7 @@ from vultron.core.use_cases.triggers.requests import (
     EngageCaseTriggerRequest,
     InvalidateReportTriggerRequest,
     InviteActorToCaseTriggerRequest,
+    OfferCaseManagerRoleTriggerRequest,
     ProposeEmbargoRevisionTriggerRequest,
     ProposeEmbargoTriggerRequest,
     RejectEmbargoTriggerRequest,
@@ -448,5 +450,23 @@ class TriggerService:
             invitee_id=invitee_id,
         )
         return SvcInviteActorToCaseUseCase(
+            self._dl, req, trigger_activity=self._trigger_activity
+        ).execute()
+
+    def offer_case_manager_role(
+        self,
+        actor_id: str,
+        case_id: str,
+    ) -> dict[str, Any]:
+        """Offer the CASE_MANAGER role to the Case Actor.
+
+        The Case Actor must already exist in the DataLayer.  The offer is
+        sent from the Case Actor's identity (DEMOMA-08-007).
+        """
+        req = OfferCaseManagerRoleTriggerRequest(
+            actor_id=actor_id,
+            case_id=case_id,
+        )
+        return SvcOfferCaseManagerRoleUseCase(
             self._dl, req, trigger_activity=self._trigger_activity
         ).execute()


### PR DESCRIPTION
- Closes #1127

## Summary

Adds the trigger-side use case for CASE_MANAGER role delegation
(`SvcOfferCaseManagerRoleUseCase`) and a stub
`SvcAcceptCaseManagerRoleUseCase`, wiring them through the BT layer,
TriggerService, HTTP router, and unit tests.

This is the manual trigger-side counterpart to the automatic path wired
into `receive_report_case_tree.py` (DEMOMA-08-007, issue #1129 Epic).

## Changes

**BT layer**
- `CreateOfferCaseManagerActivityNode`: add `captured` dict parameter;
  populate `captured["activity"]` under the BT global lock
  (fixes race condition vs. post-lock `Blackboard.storage` read)
- `SendOfferCaseManagerRoleNode`: thread `captured` to leaf node
- `offer_case_manager_role_trigger_bt()`: accept and forward `captured`

**Use cases**
- `OfferCaseManagerRoleTriggerRequest` added to `requests.py`
- `SvcOfferCaseManagerRoleUseCase` (BT-15-001 compliant):
  `_prepare()` sets `self._actor_id = case_actor_id` (PCR-08-007);
  `_build_tree()` passes `captured=self._captured`;
  no post-lock blackboard read in `_handle_result()`
- `SvcAcceptCaseManagerRoleUseCase` stub (raises `NotImplementedError`,
  per OX-10-004; TODO #1127)
- `TriggerService.offer_case_manager_role()` added
- `TriggerServicePort.offer_case_manager_role()` added to Protocol

**Adapter / HTTP**
- `OfferCaseManagerRoleRequest` HTTP body model
- `POST /{actor_id}/trigger/offer-case-manager-role` endpoint
- Fixed: endpoint now drains the **Case Actor's** outbox (not the path
  actor's); `SvcBTTriggerBase.execute()` returns `emitting_actor_id`
  so the router resolves the correct actor-scoped DataLayer via
  `dl.clone_for_actor(emitting_actor_id)`

**Tests**
- 4 unit tests: happy path (activity captured), missing case actor, missing
  case, persisted activity serialization
- 7 new FastAPI endpoint tests for `offer-case-manager-role`: 202 status,
  activity key, Offer actor == Case Actor, 422/404 error paths
- Updated `test_base.py` to assert `emitting_actor_id` in execute() return

**CodeQL**
- Removed Case Actor ID from INFO log in `_handle_result()` (was flagged
  as clear-text logging of sensitive data)

## Verification

```
uv run pytest --tb=short 2>&1 | tail -5
# 4350 passed, 38 skipped, 403 deselected, 2 xfailed, 5633 subtests passed
```

All four linters (black, flake8, mypy, pyright) pass.
CI: CodeQL ✅, Tests (pytest) ✅, Two-Actor Demo Integration ✅, all linters ✅