### PR TITLE
docs: add factory-fn placement field to fuzzer node catalog entry format (#1182)

### DIFF
--- a/notes/bt-fuzzer-nodes.md
+++ b/notes/bt-fuzzer-nodes.md
@@ -58,6 +58,20 @@ Each fuzzer node entry in the sub-files has these fields:
 - **Input dependency**: The kind of real-world input needed to replace it
 - **Notes**: Any implementation guidance from the source code comments
 - **Automation potential**: High / Medium / Low / N/A (see below)
+- **New-arch cross-ref**: The corresponding `vultron.demo.fuzzer.*` class
+  in the py_trees-based prototype (added in FUZZ-08a / PR #1179); N/A for
+  simulation-only nodes not ported to the new architecture
+- **Call-out point shape**: Evaluator, Retriever, Sentinel, Composer, or
+  N/A — per the agent shape taxonomy in
+  `docs/adr/0024-coordination-agent-taxonomy.md` (added in FUZZ-08a / PR #1179)
+- **Factory-fn placement**: The module-qualified `vultron.core.behaviors.*`
+  factory function that hosts (or should host) this call-out point node in
+  the prototype BT, with ordering hints indicating where in the tree the node
+  is inserted (e.g., guard vs effect, and which composite it belongs to).
+  Use `FUTURE: vultron.core.behaviors.<module>.create_<name>_tree` (with
+  a reference to the tracking issue) for nodes whose target factory function
+  does not yet exist. N/A for nodes that map to no prototype factory
+  function (e.g., simulation-only nodes).
 
 **Automation potential categories:**
 

--- a/plan/history/2606/learning/CONCERN-1182.md
+++ b/plan/history/2606/learning/CONCERN-1182.md
@@ -1,0 +1,51 @@
+---
+source: CONCERN-1182
+timestamp: '2026-06-25T20:15:41.108835+00:00'
+title: FUZZ-08a missed factory-fn placement mapping step
+type: learning
+---
+
+## Summary
+
+The FUZZ-08a implementation (PR #1179, based on #1150) cataloged fuzzer nodes
+and mapped them from old `vultron/bt/` classes to new py_trees node classes —
+but it stopped there. The missing step is mapping *where in the current
+use-case BT factory functions* each fuzzer node should be inserted to achieve
+simulator parity. Without this placement map, the call-out point abstraction
+work in #1151 lacks the information it needs to design the correct seams.
+
+## Category
+
+Implementation Gap
+
+## Severity
+
+Medium
+
+## Evidence
+
+PR #1179 updated fuzzer node cross-references and class mappings but no
+factory functions in `vultron/core/behaviors/` were modified. The old BT
+simulator placed fuzzer nodes at specific positions in BT subtrees; those
+positions need to be traced to their equivalents in the current (more complex)
+factory functions. The use cases have evolved into more complex behavior trees
+than the simulator had, but their overall structure remains approximately the
+same.
+
+## Impact if Ignored
+
+Fuzzer parity (epic #427) and the call-out abstraction (#1151) will proceed
+without a validated placement map, risking incorrect or incomplete seam
+locations that require rework. #1151 cannot be properly designed without
+knowing where the seams belong.
+
+## Suggested Action
+
+For each fuzzer node cataloged in FUZZ-08a, trace its original position in the
+old BT simulator and identify the corresponding location(s) in the current
+factory functions. Likely requires a mix of agent review and human judgment for
+ambiguous cases. Produce a placement map before or alongside #1151 work.
+
+**Resolved**: 2026-06-25 — implementation tracked in #1187.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1186>.
+Spec: n/a. Notes: `notes/bt-fuzzer-nodes.md` (updated).


### PR DESCRIPTION
- Closes #1182

## Summary

Documents the new `factory-fn placement` field in the Entry Format section
of `notes/bt-fuzzer-nodes.md`, unblocking FUZZ-08a-bis (add placement data
to all 93 catalog entries) and by extension FUZZ-08b (#1151, call-out point
abstraction layer design).

## Changes

- `notes/bt-fuzzer-nodes.md`: adds `factory-fn placement` field to the
  Entry Format section with format guidance (`FUTURE:` convention for
  missing factory functions, N/A for simulation-only nodes)
- Also backfills the two fields added in FUZZ-08a / PR #1179 (`new-arch
  cross-ref` and `call-out point shape`) into the documented format, since
  they were added to individual catalog entries but never added to the format
  description in the index file