### PR TITLE
docs: plan #1188 — automation potential and call-out point shape are orthogonal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -762,6 +762,19 @@ Short entries are reproduced here; longer ones are referenced below.
   falls through to DEFERRED, and the test may pass for the wrong reason. Any
   test that exercises BT operations in a received-side use case MUST pass a
   `receiving_actor_id`. See `specs/behavior-tree-integration.yaml` BT-17-005.
+- **Automation Potential and Call-Out Point Shape Are Orthogonal** — When
+  classifying a fuzzer node, the `automation potential` and `call-out point
+  shape` fields are **independent**. A node with High automation potential may
+  still require a Retriever, Sentinel, Evaluator, or Composer seam — "can be
+  automated" does not mean "no external seam exists." Assign shape using
+  **only** the ADR-0024 seam-structure decision tree: Who/what provides the
+  input? What does the node output? Does it monitor a condition, retrieve
+  facts, evaluate a situation, or compose content? The answers determine the
+  shape regardless of whether the implementation will be automated or
+  human-driven. `ProtocolInternal` is reserved exclusively for terminal
+  placeholders and structural composites that have **no** external input,
+  output, or monitoring seam. See `specs/behavior-tree-integration.yaml`
+  BT-18-005 and `docs/adr/0024-coordination-agent-taxonomy.md`.
 
 ## Skill Interaction Rules
 

--- a/notes/bt-fuzzer-nodes.md
+++ b/notes/bt-fuzzer-nodes.md
@@ -57,13 +57,18 @@ Each fuzzer node entry in the sub-files has these fields:
 - **Semantic function**: What this node represents in the CVD process
 - **Input dependency**: The kind of real-world input needed to replace it
 - **Notes**: Any implementation guidance from the source code comments
-- **Automation potential**: High / Medium / Low / N/A (see below)
+- **Automation potential**: High / Medium / Low / TerminalPlaceholder (see below)
 - **New-arch cross-ref**: The corresponding `vultron.demo.fuzzer.*` class
   in the py_trees-based prototype (added in FUZZ-08a / PR #1179); N/A for
   simulation-only nodes not ported to the new architecture
 - **Call-out point shape**: Evaluator, Retriever, Sentinel, Composer, or
-  N/A — per the agent shape taxonomy in
-  `docs/adr/0024-coordination-agent-taxonomy.md` (added in FUZZ-08a / PR #1179)
+  ProtocolInternal — per the agent shape taxonomy in
+  `docs/adr/0024-coordination-agent-taxonomy.md` (added in FUZZ-08a / PR
+  #1179; reclassified in issue #1188). Use `ProtocolInternal` only for
+  nodes that are terminal placeholders or structural composites with no
+  external input or output seam. See BT-18-005: shape MUST be determined
+  by the ADR-0024 seam-structure decision tree, independently of automation
+  potential.
 - **Factory-fn placement**: The module-qualified `vultron.core.behaviors.*`
   factory function that hosts (or should host) this call-out point node in
   the prototype BT, with ordering hints indicating where in the tree the node
@@ -81,7 +86,25 @@ Each fuzzer node entry in the sub-files has these fields:
   but human oversight or judgment still needed for edge cases
 - **Low** — inherently human-driven; automation limited to notifications
   or task triggers
-- **N/A** — terminal placeholder nodes with no real decision logic
+- **TerminalPlaceholder** — terminal placeholder node with no real decision
+  logic (e.g., `AlwaysSucceed` fallback leaf); no external dependency exists
+
+**Call-out point shape values (per ADR-0024):**
+
+- **Sentinel** — binary condition monitor; no output keys; signals
+  `SUCCESS`/`FAILURE` only
+- **Evaluator** — reads situation context; writes a structured
+  recommendation; `SUCCESS` = recommendation available
+- **Retriever** — reads a query; writes structured facts from an external
+  source; `SUCCESS` = facts retrieved
+- **Composer** — reads composition context; writes a generated artifact;
+  `SUCCESS` = artifact ready
+- **ProtocolInternal** — node resolves entirely within the protocol
+  implementation; no external input, output, or monitoring seam exists.
+  Use this value only for terminal placeholders and structural composites
+  that have no call-out point. Do NOT use `ProtocolInternal` because a
+  node's automation potential is High — those nodes have an external seam
+  and belong to one of the four shapes above (BT-18-005).
 
 ### Fuzzer Base Types (Quick Reference)
 

--- a/plan/history/2606/learning/CONCERN-1188.md
+++ b/plan/history/2606/learning/CONCERN-1188.md
@@ -1,0 +1,80 @@
+---
+source: CONCERN-1188
+timestamp: '2026-06-26T15:05:39.754128+00:00'
+title: 'FUZZ-08a over-applied N/A: automation potential and call-out point shape are
+  orthogonal'
+type: learning
+---
+
+## Summary
+
+PR #1179 (FUZZ-08a) assigned `call-out point shape: N/A` to ~35 nodes that
+have "High automation potential." The implicit reasoning was: if a node can be
+fully automated, it does not need an agent shape. This conflates two
+orthogonal concepts.
+
+## Category
+
+Classification Error / Documentation Gap
+
+## Severity
+
+Medium
+
+## Evidence
+
+Of the 43 N/A nodes across the four catalog files, only ~5 are correctly N/A:
+
+- 2 terminal placeholders (`NoThreatsFound`, `NoVulFound`) — AlwaysSucceed
+  fallback leaves with no real decision logic
+- 3 simulation-only vul-discovery nodes not ported to new architecture
+
+The remaining ~38 nodes were assigned N/A because their `automation potential`
+is High, but they clearly require an external seam:
+
+- Conditions that query metadata flags, registries, or external APIs
+  (`IdAssigned`, `MitigationDeployed`, `AllPublished`, `EmbargoTimerExpired`,
+  `HaveExploit`, and many more) — these are **Retrievers** or **Sentinels**
+- Actions that call external services (`RequestId`, `AssignId`, `Publish`,
+  `InjectParticipant/Vendor/Coordinator/Other`) — **Retrievers** or **Composers**
+- Integration hooks that trigger site-specific side-effects (`OnDefer`,
+  `OnAccept`, `OnEmbargoAccept/Reject/Exit`, `PreCloseAction`) — possibly
+  **Composers**, possibly correctly N/A depending on interpretation
+
+## Root Cause
+
+The ADR-0024 agent shape taxonomy describes **the seam structure** (how input
+enters and output exits the call-out point), not whether that exchange is done
+by a human or an automated system. A Retriever backed by a REST API is still
+a Retriever. The catalog update conflated "automatable" with "no shape needed."
+
+## Impact if Ignored
+
+FUZZ-08a-bis (#1187) will add factory-fn placement data to nodes whose shapes
+are wrong. FUZZ-08b (#1151) and FUZZ-08d-08g will then build the wrong
+abstraction seams — e.g., treating a Retriever as having no blackboard output
+contract, or skipping injection seams for nodes that will need them.
+
+## Suggested Action
+
+Reclassify all N/A nodes in the four catalog files. For each N/A entry, apply
+the ADR-0024 shape decision tree independently of automation potential:
+
+- Binary condition monitoring an external state → Sentinel
+- Reads a query, returns structured facts from external source → Retriever
+- Reads context, produces an artifact or side-effect → Composer
+- Reads situation, writes a recommendation/judgment → Evaluator
+- Truly no call-out point (terminal leaf, structural composite) → ProtocolInternal
+
+This reclassification should be done as part of or before FUZZ-08a-bis (#1187)
+so that factory-fn placement is assigned to nodes with the correct shape.
+
+Additionally, rename the ambiguous "N/A" labels:
+
+- `automation potential: N/A` → `TerminalPlaceholder`
+- `call-out point shape: N/A` → `ProtocolInternal`
+
+**Resolved**: 2026-06-26 — implementation tracked in #1193.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1192>.
+Spec: `specs/behavior-tree-integration.yaml` (BT-16-005, BT-18-005).
+Notes: `notes/bt-fuzzer-nodes.md` (entry format updated).

--- a/specs/behavior-tree-integration.yaml
+++ b/specs/behavior-tree-integration.yaml
@@ -518,11 +518,16 @@ groups:
       automation potential: High (fully automatable via API or policy rule),
       Medium (partially automatable with human oversight required), Low
       (inherently human-driven; automation limited to notifications or task
-      triggers), or N/A (terminal placeholder with no real decision logic).
+      triggers), or TerminalPlaceholder (terminal placeholder node with no real
+      decision logic — an AlwaysSucceed or AlwaysFail fallback leaf with no
+      external dependency).
     rationale: >-
       Automation-potential categorization guides future implementers toward the
       correct integration pattern when replacing stubs with production logic,
-      supporting the future real-integration roadmap.
+      supporting the future real-integration roadmap. The TerminalPlaceholder
+      value replaces the former ambiguous "N/A" label to make the meaning
+      explicit and prevent it from being conflated with "not applicable due to
+      high automation potential."
 - id: BT-18
   title: Call-Out Point Abstraction Layer
   kind: pattern
@@ -592,3 +597,32 @@ groups:
       note: >-
         Factory-based injection for call-out points is an application of the
         existing factory pattern required for all BT construction.
+  - id: BT-18-005
+    priority: MUST
+    statement: >-
+      The call-out point shape of a fuzzer node MUST be determined solely by
+      the ADR-0024 seam-structure decision tree (how external input enters and
+      output exits the call-out point). Automation potential MUST NOT be used
+      as a criterion for assigning shape = ProtocolInternal. A node whose
+      automation potential is High but whose inputs arrive from an external
+      source or whose outputs affect an external system is a Retriever,
+      Sentinel, Evaluator, or Composer — not ProtocolInternal — regardless of
+      how automated the implementation may be.
+    rationale: >-
+      Automation potential and call-out point shape are orthogonal dimensions.
+      Automation potential describes whether the call-out point logic can be
+      executed without human involvement; shape describes the structural pattern
+      of the seam (what flows in, what flows out, and in what direction).
+      A Retriever backed by a REST API is still a Retriever; the automation
+      just means the Retriever implementation does not require human action.
+      Conflating the two dimensions caused the FUZZ-08a misclassification
+      tracked in issue #1188, where ~38 nodes with High automation potential
+      were incorrectly assigned ProtocolInternal shape, causing downstream
+      work (FUZZ-08a-bis, FUZZ-08d through FUZZ-08g) to build wrong seams.
+    relationships:
+    - rel_type: implements
+      spec_id: BT-16-005
+      note: >-
+        BT-16-005 defines automation potential categories; BT-18-005 clarifies
+        that those categories govern the automation-potential field only and
+        have no bearing on call-out point shape assignment.


### PR DESCRIPTION
- Closes #1188

## Summary

Plans issue #1188 (Concern): FUZZ-08a over-applied `call-out point shape: N/A`
to ~38 nodes with High automation potential, conflating two orthogonal concepts.
This PR establishes the correct terminology and spec requirements; the catalog
reclassification work is tracked in a new implementation issue.

## Changes

- **`specs/behavior-tree-integration.yaml`**: Update BT-16-005 to rename
  automation potential `N/A` → `TerminalPlaceholder` with expanded rationale.
  Add BT-18-005: call-out point shape MUST be determined by the ADR-0024
  seam-structure decision tree independently of automation potential.
- **`notes/bt-fuzzer-nodes.md`**: Revise entry format documentation to use
  `TerminalPlaceholder` for automation potential and `ProtocolInternal` for
  call-out point shape (for truly internal nodes), with explicit guidance
  against misapplying `ProtocolInternal` to high-automation-potential nodes.
- **`AGENTS.md`**: Add pitfall entry — "Automation Potential and Call-Out
  Point Shape Are Orthogonal" — referencing BT-18-005 and ADR-0024.