### PR TITLE
feat: add EmitRejectCaseManagerRoleNode as explicit Reject fallback for OfferCaseManagerRole

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/plan/history/2606/implementation/ISSUE-1067.md
+++ b/plan/history/2606/implementation/ISSUE-1067.md
@@ -1,0 +1,32 @@
+---
+source: ISSUE-1067
+timestamp: '2026-06-26T16:02:46.703609+00:00'
+title: Add EmitRejectCaseManagerRoleNode as explicit Reject fallback
+type: implementation
+---
+
+## Issue #1067 — feat: add explicit Reject path for OfferCaseManagerRole when actor cannot accept
+
+Added `EmitRejectCaseManagerRoleNode` as a Selector fallback after
+`AutoAcceptCaseManagerRoleNode` in the `offer_case_manager_role` received BT
+tree. When the Case Actor cannot auto-accept a case manager role offer, it now
+sends an explicit `Reject` activity back to the offering vendor instead of
+staying silent.
+
+### Implementation
+
+- `TriggerActivityPort`: added `reject_case_manager_role` protocol method
+- `TriggerActivityAdapter/_ActorsMixin`: implemented `reject_case_manager_role`
+  (mirrors `accept_case_manager_role`)
+- `nodes/delegation.py` (new): split delegation nodes from `communication.py`
+  to comply with BTND-07-004 500-line limit; contains
+  `ResolveCaseManagerOfferContextNode`, `CreateOfferCaseManagerActivityNode`,
+  `AutoAcceptCaseManagerRoleNode`, `EmitRejectCaseManagerRoleNode`
+- `nodes/communication.py`: trimmed to `CollectCaseAddresseesNode` +
+  `CreateAndPersistCaseActivityNode` (~190 lines)
+- `offer_case_manager_role_received_tree.py`: `AcceptOrReject` Selector wraps
+  AutoAccept + EmitReject as the final effect node
+- Tests: 7 unit tests for `EmitRejectCaseManagerRoleNode` + 2 received
+  use-case tests for the reject-fallback path
+
+PR: [#1194](https://github.com/CERTCC/Vultron/pull/1194)

--- a/test/core/behaviors/case/nodes/test_communication.py
+++ b/test/core/behaviors/case/nodes/test_communication.py
@@ -16,20 +16,25 @@
 """
 Tests for communication behavior tree nodes.
 
-Covers SendOfferCaseManagerRoleNode.
+Covers SendOfferCaseManagerRoleNode and EmitRejectCaseManagerRoleNode.
 
-Per DEMOMA-08-002, DEMOMA-08-003; Issue #469.
+Per DEMOMA-08-002, DEMOMA-08-003; Issue #469, Issue #1067.
 """
+
+import logging
+from unittest.mock import MagicMock
 
 import py_trees
 import pytest
 
 from vultron.core.behaviors.case.nodes import (
+    AutoAcceptCaseManagerRoleNode,
     CollectCaseAddresseesNode,
     CreateAndPersistCaseActivityNode,
     CreateOfferCaseManagerActivityNode,
     CreateCaseActorNode,
     EmitCreateCaseActivity,
+    EmitRejectCaseManagerRoleNode,
     ResolveCaseManagerOfferContextNode,
     SendOfferCaseManagerRoleNode,
 )
@@ -218,3 +223,214 @@ class TestSendOfferCaseManagerRoleNode:
             # case_actor_id intentionally omitted
         )
         assert result.status == py_trees.common.Status.FAILURE
+
+
+# ---------------------------------------------------------------------------
+# TestEmitRejectCaseManagerRoleNode
+# ---------------------------------------------------------------------------
+
+
+class TestEmitRejectCaseManagerRoleNode:
+    """EmitRejectCaseManagerRoleNode sends Reject(Offer(CaseManagerRole))."""
+
+    _OFFER_ID = "https://example.org/activities/offer-cm-001"
+    _CASE_ID = "https://example.org/cases/case-cm-001"
+    _PARTICIPANT_ID = (
+        "https://example.org/participants/urn:uuid:case-actor-cm-001"
+    )
+    _VENDOR_ID = "https://example.org/actors/vendor-cm"
+    _CASE_ACTOR_ID = "https://example.org/actors/case-actor-cm"
+
+    def _make_node(self) -> EmitRejectCaseManagerRoleNode:
+        return EmitRejectCaseManagerRoleNode(
+            offer_id=self._OFFER_ID,
+            case_id=self._CASE_ID,
+            participant_id=self._PARTICIPANT_ID,
+            vendor_id=self._VENDOR_ID,
+        )
+
+    def _seed_dl(self, bt_scenario: BTTestScenario) -> None:
+        """Seed the DataLayer with case and participant objects."""
+        from vultron.wire.as2.vocab.objects.case_participant import (
+            CaseParticipant,
+        )
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+
+        case = VulnerabilityCase(id_=self._CASE_ID, name="CM-TEST")
+        participant = CaseParticipant(
+            id_=self._PARTICIPANT_ID,
+            attributed_to=self._CASE_ACTOR_ID,
+            context=self._CASE_ID,
+        )
+        bt_scenario.dl.create(case)
+        bt_scenario.dl.create(participant)
+
+    def test_succeeds_and_records_outbox_item(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        """Returns SUCCESS and records reject activity ID in actor's outbox."""
+        self._seed_dl(bt_scenario)
+
+        result = bt_scenario.run(
+            self._make_node(),
+            actor_id=self._CASE_ACTOR_ID,
+        )
+        bt_scenario.assert_success(result)
+
+    def test_reject_activity_persisted_to_datalayer(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        """The Reject activity is stored in the DataLayer after SUCCESS."""
+        self._seed_dl(bt_scenario)
+
+        bt_scenario.run(
+            self._make_node(),
+            actor_id=self._CASE_ACTOR_ID,
+        )
+
+        # TriggerActivityAdapter.reject_case_manager_role persists the activity
+        stored_rejects = bt_scenario.dl.list_objects("Reject")
+        assert len(stored_rejects) >= 1
+
+    def test_fails_when_trigger_factory_is_none(self) -> None:
+        """Returns FAILURE when trigger_activity_factory is not available."""
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+        from vultron.core.behaviors.bridge import BTBridge
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        bridge = BTBridge(
+            datalayer=dl,
+            is_leader=lambda: True,
+            trigger_activity=None,
+        )
+        py_trees.blackboard.Blackboard.storage.clear()
+        result = bridge.execute_with_setup(
+            tree=self._make_node(),
+            actor_id=self._CASE_ACTOR_ID,
+        )
+        assert result.status == py_trees.common.Status.FAILURE
+
+    def test_logs_warning_when_trigger_factory_is_none(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Logs a warning at WARNING level when factory is unavailable."""
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+        from vultron.core.behaviors.bridge import BTBridge
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        bridge = BTBridge(
+            datalayer=dl,
+            is_leader=lambda: True,
+            trigger_activity=None,
+        )
+        py_trees.blackboard.Blackboard.storage.clear()
+        with caplog.at_level(logging.WARNING):
+            bridge.execute_with_setup(
+                tree=self._make_node(),
+                actor_id=self._CASE_ACTOR_ID,
+            )
+        assert any(
+            "trigger_activity_factory" in r.message.lower()
+            or "cannot emit reject" in r.message.lower()
+            for r in caplog.records
+        )
+
+    def test_accept_or_reject_selector_in_received_tree(self) -> None:
+        """AcceptOrReject Selector wraps AutoAccept + EmitReject in the tree."""
+        from vultron.core.behaviors.case.offer_case_manager_role_received_tree import (
+            create_offer_case_manager_role_received_tree,
+        )
+
+        tree = create_offer_case_manager_role_received_tree(
+            offer_id=self._OFFER_ID,
+            offer_obj=None,
+            case_id=self._CASE_ID,
+            participant_id=self._PARTICIPANT_ID,
+            vendor_id=self._VENDOR_ID,
+        )
+
+        # The last effect node should be AcceptOrReject Selector
+        # Tree structure: Sequence → [..., StoreActivityNode, AcceptOrReject]
+        last_child = tree.children[-1]
+        assert isinstance(last_child, py_trees.composites.Selector)
+        assert last_child.name == "AcceptOrReject"
+        assert len(last_child.children) == 2
+        assert isinstance(
+            last_child.children[0], AutoAcceptCaseManagerRoleNode
+        )
+        assert isinstance(
+            last_child.children[1], EmitRejectCaseManagerRoleNode
+        )
+
+    def test_reject_emitted_when_accept_fails(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        """When AutoAccept fails, EmitReject fires via AcceptOrReject Selector."""
+        from vultron.core.behaviors.bridge import BTBridge
+        from vultron.core.behaviors.case.offer_case_manager_role_received_tree import (
+            create_offer_case_manager_role_received_tree,
+        )
+        from vultron.wire.as2.factories.case import (
+            offer_case_manager_role_activity,
+        )
+        from vultron.wire.as2.vocab.objects.case_participant import (
+            CaseParticipant,
+        )
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+
+        # Seed DL so EmitReject can reconstruct the offer
+        self._seed_dl(bt_scenario)
+
+        # Build a real offer object so StoreActivityNode can persist it
+        case = VulnerabilityCase(id_=self._CASE_ID, name="CM-TEST")
+        participant = CaseParticipant(
+            id_=self._PARTICIPANT_ID,
+            attributed_to=self._CASE_ACTOR_ID,
+            context=self._CASE_ID,
+        )
+        offer = offer_case_manager_role_activity(
+            case, target=participant, actor=self._VENDOR_ID
+        )
+
+        # Mock factory: accept raises, reject succeeds
+        reject_id = "https://example.org/activities/reject-cm-001"
+        mock_factory = MagicMock()
+        mock_factory.accept_case_manager_role.side_effect = RuntimeError(
+            "accept unavailable"
+        )
+        mock_factory.reject_case_manager_role.return_value = reject_id
+
+        dl = bt_scenario.dl
+        bridge = BTBridge(
+            datalayer=dl,
+            is_leader=lambda: True,
+            trigger_activity=mock_factory,
+        )
+
+        tree = create_offer_case_manager_role_received_tree(
+            offer_id=offer.id_,
+            offer_obj=offer,
+            case_id=self._CASE_ID,
+            participant_id=self._PARTICIPANT_ID,
+            vendor_id=self._VENDOR_ID,
+        )
+        py_trees.blackboard.Blackboard.storage.clear()
+        result = bridge.execute_with_setup(
+            tree=tree,
+            actor_id=self._CASE_ACTOR_ID,
+        )
+
+        # EmitReject took over — Selector succeeded, Sequence succeeded
+        assert result.status == py_trees.common.Status.SUCCESS
+        mock_factory.reject_case_manager_role.assert_called_once_with(
+            offer_id=offer.id_,
+            case_id=self._CASE_ID,
+            participant_id=self._PARTICIPANT_ID,
+            vendor_id=self._VENDOR_ID,
+            actor=self._CASE_ACTOR_ID,
+            to=[self._VENDOR_ID],
+        )

--- a/test/core/use_cases/received/actor/test_case_manager_role.py
+++ b/test/core/use_cases/received/actor/test_case_manager_role.py
@@ -298,6 +298,58 @@ class TestCaseManagerRoleDelegationUseCases:
             to=[self._VENDOR_URI],
         )
 
+    def test_offer_case_manager_role_outbox_failure_does_not_emit_reject(
+        self, make_payload
+    ):
+        """Outbox failure after Accept is persisted must NOT trigger Reject.
+
+        Regression for the broad-exception anti-pattern: when
+        accept_case_manager_role() succeeds (Accept written to DataLayer) but
+        record_outbox_item() then fails, the exception must propagate through
+        py_trees (bypassing the AcceptOrReject Selector fallback) so that
+        BTBridge fails the tree hard without emitting a contradictory Reject.
+        """
+        from unittest.mock import MagicMock, patch
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+        from vultron.wire.as2.vocab.objects.case_participant import (
+            CaseParticipant,
+        )
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case = VulnerabilityCase(id_=self._CASE_URI, name="OUTBOX-FAIL-TEST")
+        participant = CaseParticipant(
+            id_=self._PARTICIPANT_URI,
+            attributed_to=self._CASE_ACTOR_URI,
+            context=self._CASE_URI,
+        )
+        dl.create(case)
+        dl.create(participant)
+
+        offer = self._make_offer()
+        event = make_payload(offer, receiving_actor_id=self._CASE_ACTOR_URI)
+
+        trigger = MagicMock()
+        trigger.accept_case_manager_role.return_value = (
+            "https://example.org/activities/accept-outbox-fail"
+        )
+
+        # Accept creation succeeds, but outbox enqueue fails.
+        with patch.object(
+            dl,
+            "record_outbox_item",
+            side_effect=RuntimeError("outbox unavailable"),
+        ):
+            # BTBridge swallows the exception; execute() must not raise.
+            OfferCaseManagerRoleReceivedUseCase(
+                dl, event, trigger_activity=trigger
+            ).execute()
+
+        # The Reject must NOT have been emitted — Accept was already persisted.
+        trigger.reject_case_manager_role.assert_not_called()
+
     def test_offer_case_manager_role_reject_uses_adapter_when_accept_fails(
         self, make_payload
     ):

--- a/test/core/use_cases/received/actor/test_case_manager_role.py
+++ b/test/core/use_cases/received/actor/test_case_manager_role.py
@@ -249,3 +249,96 @@ class TestCaseManagerRoleDelegationUseCases:
 
         stored = dl.get(accept.type_.value, accept.id_)
         assert stored is not None
+
+    def test_offer_case_manager_role_reject_emitted_when_accept_fails(
+        self, make_payload
+    ):
+        """When auto-accept raises, EmitRejectCaseManagerRoleNode fires instead."""
+        from unittest.mock import MagicMock
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+        from vultron.wire.as2.vocab.objects.case_participant import (
+            CaseParticipant,
+        )
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+
+        # Seed DL so EmitRejectCaseManagerRoleNode can reconstruct the offer
+        case = VulnerabilityCase(id_=self._CASE_URI, name="REJECT-TEST")
+        participant = CaseParticipant(
+            id_=self._PARTICIPANT_URI,
+            attributed_to=self._CASE_ACTOR_URI,
+            context=self._CASE_URI,
+        )
+        dl.create(case)
+        dl.create(participant)
+
+        offer = self._make_offer()
+        event = make_payload(offer, receiving_actor_id=self._CASE_ACTOR_URI)
+
+        reject_id = "https://example.org/activities/reject-cm-fallback"
+        trigger = MagicMock()
+        trigger.accept_case_manager_role.side_effect = RuntimeError(
+            "accept unavailable"
+        )
+        trigger.reject_case_manager_role.return_value = reject_id
+
+        OfferCaseManagerRoleReceivedUseCase(
+            dl, event, trigger_activity=trigger
+        ).execute()
+
+        trigger.reject_case_manager_role.assert_called_once_with(
+            offer_id=offer.id_,
+            case_id=self._CASE_URI,
+            participant_id=self._PARTICIPANT_URI,
+            vendor_id=self._VENDOR_URI,
+            actor=self._CASE_ACTOR_URI,
+            to=[self._VENDOR_URI],
+        )
+
+    def test_offer_case_manager_role_reject_uses_adapter_when_accept_fails(
+        self, make_payload
+    ):
+        """reject_case_manager_role adapter method is called with correct args."""
+        from unittest.mock import MagicMock
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+        from vultron.wire.as2.vocab.objects.case_participant import (
+            CaseParticipant,
+        )
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+        from vultron.adapters.driven.trigger_activity_adapter import (
+            TriggerActivityAdapter,
+        )
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case = VulnerabilityCase(id_=self._CASE_URI, name="ADAPTER-REJECT")
+        participant = CaseParticipant(
+            id_=self._PARTICIPANT_URI,
+            attributed_to=self._CASE_ACTOR_URI,
+            context=self._CASE_URI,
+        )
+        dl.create(case)
+        dl.create(participant)
+
+        offer = self._make_offer()
+        event = make_payload(offer, receiving_actor_id=self._CASE_ACTOR_URI)
+
+        # Use a real adapter wrapped so accept raises but reject succeeds
+        real_adapter = TriggerActivityAdapter(dl)
+        patched = MagicMock(wraps=real_adapter)
+        patched.accept_case_manager_role.side_effect = RuntimeError(
+            "accept unavailable"
+        )
+
+        OfferCaseManagerRoleReceivedUseCase(
+            dl, event, trigger_activity=patched
+        ).execute()
+
+        patched.reject_case_manager_role.assert_called_once()
+        kwargs = patched.reject_case_manager_role.call_args.kwargs
+        assert kwargs["offer_id"] == offer.id_
+        assert kwargs["vendor_id"] == self._VENDOR_URI

--- a/vultron/adapters/driven/trigger_activity_adapter/actors.py
+++ b/vultron/adapters/driven/trigger_activity_adapter/actors.py
@@ -37,6 +37,7 @@ from vultron.wire.as2.factories import (
 from vultron.wire.as2.factories.case import (
     accept_case_manager_role_activity,
     offer_case_manager_role_activity,
+    reject_case_manager_role_activity,
 )
 from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
 from vultron.wire.as2.vocab.objects.case_status import ParticipantStatus
@@ -305,6 +306,42 @@ class _ActorsMixin:
         except ValueError:
             logger.warning(
                 "accept_case_manager_role: activity '%s' already exists"
+                " — skipping",
+                activity.id_,
+            )
+        return activity.id_
+
+    def reject_case_manager_role(
+        self,
+        offer_id: str,
+        case_id: str,
+        participant_id: str,
+        vendor_id: str,
+        actor: str,
+        to: list[str] | None = None,
+    ) -> str:
+        """Create and persist a ``Reject(_OfferCaseManagerRoleActivity)``.
+
+        Ephemerally reconstructs the original Offer from ``offer_id``,
+        ``case_id``, ``participant_id``, and ``vendor_id`` so that
+        ``Reject.object_`` is a typed ``_OfferCaseManagerRoleActivity``.
+        """
+        case = cast(VulnerabilityCase, self._dl.read(case_id))
+        participant = cast(CaseParticipant, self._dl.read(participant_id))
+        offer = offer_case_manager_role_activity(
+            case=case,
+            target=participant,
+            id_=offer_id,
+            actor=vendor_id,
+        )
+        activity = reject_case_manager_role_activity(
+            offer=offer, actor=actor, to=to
+        )
+        try:
+            self._dl.create(activity)
+        except ValueError:
+            logger.warning(
+                "reject_case_manager_role: activity '%s' already exists"
                 " — skipping",
                 activity.id_,
             )

--- a/vultron/core/behaviors/case/communication_tree.py
+++ b/vultron/core/behaviors/case/communication_tree.py
@@ -40,6 +40,8 @@ import py_trees
 from vultron.core.behaviors.case.nodes.communication import (
     CollectCaseAddresseesNode,
     CreateAndPersistCaseActivityNode,
+)
+from vultron.core.behaviors.case.nodes.delegation import (
     CreateOfferCaseManagerActivityNode,
     ResolveCaseManagerOfferContextNode,
 )

--- a/vultron/core/behaviors/case/nodes/__init__.py
+++ b/vultron/core/behaviors/case/nodes/__init__.py
@@ -59,10 +59,13 @@ from vultron.core.behaviors.case.nodes.case_setup import (
     SetCaseAttributedTo,
 )
 from vultron.core.behaviors.case.nodes.communication import (
-    AutoAcceptCaseManagerRoleNode,
     CollectCaseAddresseesNode,
     CreateAndPersistCaseActivityNode,
+)
+from vultron.core.behaviors.case.nodes.delegation import (
+    AutoAcceptCaseManagerRoleNode,
     CreateOfferCaseManagerActivityNode,
+    EmitRejectCaseManagerRoleNode,
     ResolveCaseManagerOfferContextNode,
 )
 from vultron.core.behaviors.case.nodes.conditions import (
@@ -134,6 +137,7 @@ __all__ = [
     "CollectCaseAddresseesNode",
     "CreateAndPersistCaseActivityNode",
     "CreateOfferCaseManagerActivityNode",
+    "EmitRejectCaseManagerRoleNode",
     "ResolveCaseManagerOfferContextNode",
     # communication_tree (composite subtrees — lazy via __getattr__)
     "EmitCreateCaseActivity",

--- a/vultron/core/behaviors/case/nodes/communication.py
+++ b/vultron/core/behaviors/case/nodes/communication.py
@@ -16,18 +16,21 @@
 """
 Communication action nodes for case behavior trees.
 
-Provides action nodes that emit outbound activities related to case creation,
-case-manager role offers, and case-manager role auto-acceptance.
+Provides action nodes that emit outbound activities related to case creation.
 
 Composite subtrees assembling these leaf nodes are defined in the sibling
 ``communication_tree.py`` module at the process-area root per BTND-07-003:
 
 - ``EmitCreateCaseActivity``
-- ``SendOfferCaseManagerRoleNode``
+
+Delegation-related nodes (``ResolveCaseManagerOfferContextNode``,
+``CreateOfferCaseManagerActivityNode``, ``AutoAcceptCaseManagerRoleNode``,
+``EmitRejectCaseManagerRoleNode``) live in the sibling ``delegation.py``
+module.
 """
 
 import logging
-from typing import Any, cast
+from typing import Any
 
 import py_trees
 from py_trees.common import Status
@@ -35,7 +38,6 @@ from py_trees.common import Status
 from vultron.core.behaviors.helpers import DataLayerAction
 from vultron.core.models.protocols import is_case_model
 from vultron.core.models.vultron_types import VultronCreateCaseActivity
-from vultron.core.ports.case_persistence import CaseOutboxPersistence
 
 logger = logging.getLogger(__name__)
 
@@ -184,244 +186,3 @@ class CreateAndPersistCaseActivityNode(DataLayerAction):
 
         self.blackboard.activity_id = activity.id_
         return Status.SUCCESS
-
-
-class ResolveCaseManagerOfferContextNode(DataLayerAction):
-    """Validate blackboard context and stage Offer recipients."""
-
-    def __init__(self, name: str | None = None):
-        super().__init__(name=name or self.__class__.__name__)
-
-    def setup(self, **kwargs: Any) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="case_id", access=py_trees.common.Access.READ
-        )
-        self.blackboard.register_key(
-            key="case_actor_id", access=py_trees.common.Access.READ
-        )
-        self.blackboard.register_key(
-            key="case_actor_participant_id",
-            access=py_trees.common.Access.READ,
-        )
-        self.blackboard.register_key(
-            key="offer_case_manager_to", access=py_trees.common.Access.WRITE
-        )
-
-    def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.logger.error(
-                f"{self.name}: DataLayer or actor_id not available"
-            )
-            return Status.FAILURE
-
-        case_id = self.blackboard.get("case_id")
-        case_actor_id = self.blackboard.get("case_actor_id")
-        participant_id = self.blackboard.get("case_actor_participant_id")
-        if (
-            not isinstance(case_id, str)
-            or not isinstance(case_actor_id, str)
-            or not isinstance(participant_id, str)
-        ):
-            self.logger.error(
-                f"{self.name}: case_id, case_actor_id, or"
-                " case_actor_participant_id missing from blackboard"
-            )
-            return Status.FAILURE
-
-        self.blackboard.offer_case_manager_to = [case_actor_id]
-        return Status.SUCCESS
-
-
-class CreateOfferCaseManagerActivityNode(DataLayerAction):
-    """Create Offer(CaseManagerRole) via trigger_activity_factory."""
-
-    def __init__(
-        self,
-        captured: dict | None = None,
-        name: str | None = None,
-    ) -> None:
-        super().__init__(name=name or self.__class__.__name__)
-        self._captured = captured
-
-    def setup(self, **kwargs: Any) -> None:
-        super().setup(**kwargs)
-        self.blackboard.register_key(
-            key="case_id", access=py_trees.common.Access.READ
-        )
-        self.blackboard.register_key(
-            key="case_actor_id", access=py_trees.common.Access.READ
-        )
-        self.blackboard.register_key(
-            key="case_actor_participant_id",
-            access=py_trees.common.Access.READ,
-        )
-        self.blackboard.register_key(
-            key="offer_case_manager_to", access=py_trees.common.Access.READ
-        )
-        self.blackboard.register_key(
-            key="activity_id", access=py_trees.common.Access.WRITE
-        )
-
-    def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.logger.error(
-                f"{self.name}: DataLayer or actor_id not available"
-            )
-            return Status.FAILURE
-
-        if self.trigger_activity_factory is None:
-            self.logger.error(
-                f"{self.name}: trigger_activity_factory not available"
-            )
-            return Status.FAILURE
-
-        case_id = self.blackboard.get("case_id")
-        case_actor_id = self.blackboard.get("case_actor_id")
-        participant_id = self.blackboard.get("case_actor_participant_id")
-        recipients = self.blackboard.get("offer_case_manager_to")
-
-        if (
-            not isinstance(case_id, str)
-            or not isinstance(case_actor_id, str)
-            or not isinstance(participant_id, str)
-            or not isinstance(recipients, list)
-        ):
-            self.logger.error(
-                f"{self.name}: case_id, case_actor_id, or"
-                " case_actor_participant_id missing from blackboard"
-            )
-            return Status.FAILURE
-
-        try:
-            activity_id = (
-                self.trigger_activity_factory.offer_case_manager_role(
-                    case_id=case_id,
-                    participant_id=participant_id,
-                    actor=case_actor_id,
-                    to=recipients,
-                )
-            )
-            self.blackboard.activity_id = activity_id
-            if self._captured is not None:
-                activity_obj = self.datalayer.read(activity_id)
-                if activity_obj is not None and hasattr(
-                    activity_obj, "model_dump"
-                ):
-                    self._captured["activity"] = activity_obj.model_dump(
-                        mode="json",
-                        by_alias=True,
-                        serialize_as_any=True,
-                        exclude_none=True,
-                    )
-            self.logger.info(
-                "%s: Queued Offer(CaseManagerRole) '%s' to Case Actor '%s'"
-                " for case '%s'",
-                self.name,
-                activity_id,
-                case_actor_id,
-                case_id,
-            )
-            return Status.SUCCESS
-
-        except Exception as e:
-            self.logger.error(
-                f"{self.name}: Error sending Offer(CaseManagerRole): {e}"
-            )
-            return Status.FAILURE
-
-
-class AutoAcceptCaseManagerRoleNode(DataLayerAction):
-    """Auto-accept a CASE_MANAGER role delegation offer on behalf of the local actor.
-
-    When the local actor (the Case Actor entity) receives an
-    ``Offer(CaseManagerRole)`` it MUST auto-accept so the offering Vendor
-    receives confirmation.  This node creates the ``Accept`` activity via
-    ``trigger_activity_factory`` and queues it in the local actor's outbox.
-
-    Returns ``FAILURE`` when ``trigger_activity_factory`` is not available
-    so that the enclosing Sequence propagates the failure rather than
-    silently continuing.  Callers that want the guarded-commit subtree to
-    run regardless of auto-accept status should wrap this node in a
-    ``Selector`` with a ``Success`` fallback.
-
-    See DEMOMA-08-002, DEMOMA-08-003; Issue #469, Issue #1021.
-    """
-
-    def __init__(
-        self,
-        offer_id: str,
-        case_id: str,
-        participant_id: str,
-        vendor_id: str,
-        name: str | None = None,
-    ) -> None:
-        """Initialise the node.
-
-        Args:
-            offer_id: ID of the ``Offer(CaseManagerRole)`` activity.
-            case_id: ID of the VulnerabilityCase referenced by the offer.
-            participant_id: ID of the CaseParticipant being offered the role.
-            vendor_id: Actor ID of the offering Vendor (recipient of Accept).
-            name: Optional custom node name.
-        """
-        super().__init__(name=name or self.__class__.__name__)
-        self.offer_id = offer_id
-        self.case_id = case_id
-        self.participant_id = participant_id
-        self.vendor_id = vendor_id
-
-    def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.logger.error(
-                "%s: DataLayer or actor_id not available", self.name
-            )
-            return Status.FAILURE
-
-        if self.trigger_activity_factory is None:
-            self.logger.warning(
-                "%s: trigger_activity_factory not available"
-                " — cannot auto-accept offer '%s'",
-                self.name,
-                self.offer_id,
-            )
-            return Status.FAILURE
-
-        if not self.case_id or not self.participant_id:
-            self.logger.warning(
-                "%s: missing case_id or participant_id for offer '%s'"
-                " — skipping auto-accept",
-                self.name,
-                self.offer_id,
-            )
-            return Status.FAILURE
-
-        try:
-            accept_id = self.trigger_activity_factory.accept_case_manager_role(
-                offer_id=self.offer_id,
-                case_id=self.case_id,
-                participant_id=self.participant_id,
-                vendor_id=self.vendor_id,
-                actor=self.actor_id,
-                to=[self.vendor_id],
-            )
-            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
-                self.actor_id, accept_id
-            )
-            self.logger.info(
-                "%s: auto-accepted offer '%s' as actor '%s';"
-                " queued Accept '%s' to outbox",
-                self.name,
-                self.offer_id,
-                self.actor_id,
-                accept_id,
-            )
-            return Status.SUCCESS
-        except Exception as exc:
-            self.logger.error(
-                "%s: error auto-accepting offer '%s': %s",
-                self.name,
-                self.offer_id,
-                exc,
-            )
-            return Status.FAILURE

--- a/vultron/core/behaviors/case/nodes/delegation.py
+++ b/vultron/core/behaviors/case/nodes/delegation.py
@@ -249,6 +249,10 @@ class AutoAcceptCaseManagerRoleNode(DataLayerAction):
             )
             return Status.FAILURE
 
+        # Step 1: create and persist the Accept activity.
+        # Nothing has been written yet; any exception here is safe to
+        # convert to FAILURE so the AcceptOrReject Selector can fall back
+        # to EmitRejectCaseManagerRoleNode.
         try:
             accept_id = self.trigger_activity_factory.accept_case_manager_role(
                 offer_id=self.offer_id,
@@ -258,26 +262,35 @@ class AutoAcceptCaseManagerRoleNode(DataLayerAction):
                 actor=self.actor_id,
                 to=[self.vendor_id],
             )
-            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
-                self.actor_id, accept_id
-            )
-            self.logger.info(
-                "%s: auto-accepted offer '%s' as actor '%s';"
-                " queued Accept '%s' to outbox",
-                self.name,
-                self.offer_id,
-                self.actor_id,
-                accept_id,
-            )
-            return Status.SUCCESS
         except Exception as exc:
             self.logger.error(
-                "%s: error auto-accepting offer '%s': %s",
+                "%s: error creating Accept activity for offer '%s': %s",
                 self.name,
                 self.offer_id,
                 exc,
             )
             return Status.FAILURE
+
+        # Step 2: enqueue the Accept activity to the outbox.
+        # The Accept is now persisted in the DataLayer.  If outbox enqueue
+        # fails here, we MUST NOT return FAILURE — the AcceptOrReject
+        # Selector would then fall through to EmitRejectCaseManagerRoleNode,
+        # producing contradictory protocol state (Accept stored, Reject sent).
+        # Let the exception propagate so BTBridge fails the tree hard,
+        # preserving the persisted Accept without triggering a spurious Reject.
+        cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
+            self.actor_id, accept_id
+        )
+
+        self.logger.info(
+            "%s: auto-accepted offer '%s' as actor '%s';"
+            " queued Accept '%s' to outbox",
+            self.name,
+            self.offer_id,
+            self.actor_id,
+            accept_id,
+        )
+        return Status.SUCCESS
 
 
 class EmitRejectCaseManagerRoleNode(DataLayerAction):

--- a/vultron/core/behaviors/case/nodes/delegation.py
+++ b/vultron/core/behaviors/case/nodes/delegation.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""
+CASE_MANAGER delegation action nodes for case behavior trees.
+
+Provides action nodes for the CASE_MANAGER role delegation workflow:
+offering, auto-accepting, and explicitly rejecting the delegation.
+
+Composite subtrees assembling these leaf nodes are defined in the sibling
+``communication_tree.py`` module at the process-area root per BTND-07-003:
+
+- ``SendOfferCaseManagerRoleNode``
+
+See DEMOMA-08-002, DEMOMA-08-003; Issue #469, Issue #1067.
+"""
+
+import logging
+from typing import Any, cast
+
+import py_trees
+from py_trees.common import Status
+
+from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.ports.case_persistence import CaseOutboxPersistence
+
+logger = logging.getLogger(__name__)
+
+
+class ResolveCaseManagerOfferContextNode(DataLayerAction):
+    """Validate blackboard context and stage Offer recipients."""
+
+    def __init__(self, name: str | None = None):
+        super().__init__(name=name or self.__class__.__name__)
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="case_id", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="case_actor_id", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="case_actor_participant_id",
+            access=py_trees.common.Access.READ,
+        )
+        self.blackboard.register_key(
+            key="offer_case_manager_to", access=py_trees.common.Access.WRITE
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None or self.actor_id is None:
+            self.logger.error(
+                f"{self.name}: DataLayer or actor_id not available"
+            )
+            return Status.FAILURE
+
+        case_id = self.blackboard.get("case_id")
+        case_actor_id = self.blackboard.get("case_actor_id")
+        participant_id = self.blackboard.get("case_actor_participant_id")
+        if (
+            not isinstance(case_id, str)
+            or not isinstance(case_actor_id, str)
+            or not isinstance(participant_id, str)
+        ):
+            self.logger.error(
+                f"{self.name}: case_id, case_actor_id, or"
+                " case_actor_participant_id missing from blackboard"
+            )
+            return Status.FAILURE
+
+        self.blackboard.offer_case_manager_to = [case_actor_id]
+        return Status.SUCCESS
+
+
+class CreateOfferCaseManagerActivityNode(DataLayerAction):
+    """Create Offer(CaseManagerRole) via trigger_activity_factory."""
+
+    def __init__(
+        self,
+        captured: dict | None = None,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._captured = captured
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="case_id", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="case_actor_id", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="case_actor_participant_id",
+            access=py_trees.common.Access.READ,
+        )
+        self.blackboard.register_key(
+            key="offer_case_manager_to", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="activity_id", access=py_trees.common.Access.WRITE
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None or self.actor_id is None:
+            self.logger.error(
+                f"{self.name}: DataLayer or actor_id not available"
+            )
+            return Status.FAILURE
+
+        if self.trigger_activity_factory is None:
+            self.logger.error(
+                f"{self.name}: trigger_activity_factory not available"
+            )
+            return Status.FAILURE
+
+        case_id = self.blackboard.get("case_id")
+        case_actor_id = self.blackboard.get("case_actor_id")
+        participant_id = self.blackboard.get("case_actor_participant_id")
+        recipients = self.blackboard.get("offer_case_manager_to")
+
+        if (
+            not isinstance(case_id, str)
+            or not isinstance(case_actor_id, str)
+            or not isinstance(participant_id, str)
+            or not isinstance(recipients, list)
+        ):
+            self.logger.error(
+                f"{self.name}: case_id, case_actor_id, or"
+                " case_actor_participant_id missing from blackboard"
+            )
+            return Status.FAILURE
+
+        try:
+            activity_id = (
+                self.trigger_activity_factory.offer_case_manager_role(
+                    case_id=case_id,
+                    participant_id=participant_id,
+                    actor=case_actor_id,
+                    to=recipients,
+                )
+            )
+            self.blackboard.activity_id = activity_id
+            if self._captured is not None:
+                activity_obj = self.datalayer.read(activity_id)
+                if activity_obj is not None and hasattr(
+                    activity_obj, "model_dump"
+                ):
+                    self._captured["activity"] = activity_obj.model_dump(
+                        mode="json",
+                        by_alias=True,
+                        serialize_as_any=True,
+                        exclude_none=True,
+                    )
+            self.logger.info(
+                "%s: Queued Offer(CaseManagerRole) '%s' to Case Actor '%s'"
+                " for case '%s'",
+                self.name,
+                activity_id,
+                case_actor_id,
+                case_id,
+            )
+            return Status.SUCCESS
+
+        except Exception as e:
+            self.logger.error(
+                f"{self.name}: Error sending Offer(CaseManagerRole): {e}"
+            )
+            return Status.FAILURE
+
+
+class AutoAcceptCaseManagerRoleNode(DataLayerAction):
+    """Auto-accept a CASE_MANAGER role delegation offer on behalf of the local actor.
+
+    When the local actor (the Case Actor entity) receives an
+    ``Offer(CaseManagerRole)`` it MUST auto-accept so the offering Vendor
+    receives confirmation.  This node creates the ``Accept`` activity via
+    ``trigger_activity_factory`` and queues it in the local actor's outbox.
+
+    Returns ``FAILURE`` when ``trigger_activity_factory`` is not available
+    so that the enclosing Sequence propagates the failure rather than
+    silently continuing.  Callers that want the guarded-commit subtree to
+    run regardless of auto-accept status should wrap this node in a
+    ``Selector`` with a ``Success`` fallback.
+
+    See DEMOMA-08-002, DEMOMA-08-003; Issue #469, Issue #1021.
+    """
+
+    def __init__(
+        self,
+        offer_id: str,
+        case_id: str,
+        participant_id: str,
+        vendor_id: str,
+        name: str | None = None,
+    ) -> None:
+        """Initialise the node.
+
+        Args:
+            offer_id: ID of the ``Offer(CaseManagerRole)`` activity.
+            case_id: ID of the VulnerabilityCase referenced by the offer.
+            participant_id: ID of the CaseParticipant being offered the role.
+            vendor_id: Actor ID of the offering Vendor (recipient of Accept).
+            name: Optional custom node name.
+        """
+        super().__init__(name=name or self.__class__.__name__)
+        self.offer_id = offer_id
+        self.case_id = case_id
+        self.participant_id = participant_id
+        self.vendor_id = vendor_id
+
+    def update(self) -> Status:
+        if self.datalayer is None or self.actor_id is None:
+            self.logger.error(
+                "%s: DataLayer or actor_id not available", self.name
+            )
+            return Status.FAILURE
+
+        if self.trigger_activity_factory is None:
+            self.logger.warning(
+                "%s: trigger_activity_factory not available"
+                " — cannot auto-accept offer '%s'",
+                self.name,
+                self.offer_id,
+            )
+            return Status.FAILURE
+
+        if not self.case_id or not self.participant_id:
+            self.logger.warning(
+                "%s: missing case_id or participant_id for offer '%s'"
+                " — skipping auto-accept",
+                self.name,
+                self.offer_id,
+            )
+            return Status.FAILURE
+
+        try:
+            accept_id = self.trigger_activity_factory.accept_case_manager_role(
+                offer_id=self.offer_id,
+                case_id=self.case_id,
+                participant_id=self.participant_id,
+                vendor_id=self.vendor_id,
+                actor=self.actor_id,
+                to=[self.vendor_id],
+            )
+            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
+                self.actor_id, accept_id
+            )
+            self.logger.info(
+                "%s: auto-accepted offer '%s' as actor '%s';"
+                " queued Accept '%s' to outbox",
+                self.name,
+                self.offer_id,
+                self.actor_id,
+                accept_id,
+            )
+            return Status.SUCCESS
+        except Exception as exc:
+            self.logger.error(
+                "%s: error auto-accepting offer '%s': %s",
+                self.name,
+                self.offer_id,
+                exc,
+            )
+            return Status.FAILURE
+
+
+class EmitRejectCaseManagerRoleNode(DataLayerAction):
+    """Emit a Reject(Offer(CaseManagerRole)) to the offering Vendor.
+
+    Used as the fallback branch of the ``AcceptOrReject`` Selector after
+    :class:`AutoAcceptCaseManagerRoleNode`.  When the Case Actor cannot
+    auto-accept the role delegation offer (for example, the accept call fails
+    due to a business constraint), this node sends an explicit ``Reject`` so
+    the offering Vendor is notified rather than receiving silence.
+
+    Returns ``FAILURE`` on any error so callers can observe the failure.
+
+    See DEMOMA-08-002, DEMOMA-08-003; Issue #1067.
+    """
+
+    def __init__(
+        self,
+        offer_id: str,
+        case_id: str,
+        participant_id: str,
+        vendor_id: str,
+        name: str | None = None,
+    ) -> None:
+        """Initialise the node.
+
+        Args:
+            offer_id: ID of the ``Offer(CaseManagerRole)`` activity.
+            case_id: ID of the VulnerabilityCase referenced by the offer.
+            participant_id: ID of the CaseParticipant being offered the role.
+            vendor_id: Actor ID of the offering Vendor (recipient of Reject).
+            name: Optional custom node name.
+        """
+        super().__init__(name=name or self.__class__.__name__)
+        self.offer_id = offer_id
+        self.case_id = case_id
+        self.participant_id = participant_id
+        self.vendor_id = vendor_id
+
+    def update(self) -> Status:
+        if self.datalayer is None or self.actor_id is None:
+            self.logger.error(
+                "%s: DataLayer or actor_id not available", self.name
+            )
+            return Status.FAILURE
+
+        if self.trigger_activity_factory is None:
+            self.logger.warning(
+                "%s: trigger_activity_factory not available"
+                " — cannot emit Reject for offer '%s'",
+                self.name,
+                self.offer_id,
+            )
+            return Status.FAILURE
+
+        if not self.case_id or not self.participant_id:
+            self.logger.warning(
+                "%s: missing case_id or participant_id for offer '%s'"
+                " — cannot emit Reject",
+                self.name,
+                self.offer_id,
+            )
+            return Status.FAILURE
+
+        try:
+            reject_id = self.trigger_activity_factory.reject_case_manager_role(
+                offer_id=self.offer_id,
+                case_id=self.case_id,
+                participant_id=self.participant_id,
+                vendor_id=self.vendor_id,
+                actor=self.actor_id,
+                to=[self.vendor_id],
+            )
+            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
+                self.actor_id, reject_id
+            )
+            self.logger.info(
+                "%s: emitted Reject(Offer(CaseManagerRole)) '%s'"
+                " to vendor '%s' for offer '%s'",
+                self.name,
+                reject_id,
+                self.vendor_id,
+                self.offer_id,
+            )
+            return Status.SUCCESS
+        except Exception as exc:
+            self.logger.error(
+                "%s: error emitting Reject for offer '%s': %s",
+                self.name,
+                self.offer_id,
+                exc,
+            )
+            return Status.FAILURE

--- a/vultron/core/behaviors/case/offer_case_manager_role_received_tree.py
+++ b/vultron/core/behaviors/case/offer_case_manager_role_received_tree.py
@@ -23,8 +23,9 @@ from typing import Any
 
 import py_trees
 
-from vultron.core.behaviors.case.nodes.communication import (
+from vultron.core.behaviors.case.nodes.delegation import (
     AutoAcceptCaseManagerRoleNode,
+    EmitRejectCaseManagerRoleNode,
 )
 from vultron.core.behaviors.case.nodes.lifecycle import (
     create_receive_activity_tree,
@@ -50,11 +51,13 @@ def create_offer_case_manager_role_received_tree(
     auto-accept so the canonical ledger entry for the Offer exists before
     the ``Accept`` is sent to the offering Vendor.
 
-    Finally, the tree auto-accepts the offer by emitting
-    ``Accept(Offer(CaseManagerRole))`` to the offering Vendor.  If
-    ``trigger_activity_factory`` is unavailable the auto-accept node returns
-    ``FAILURE``, which propagates through the Sequence so the caller can log
-    the failure.  A protocol-level Reject path is tracked in GitHub.
+    Finally, the tree attempts to auto-accept the offer by emitting
+    ``Accept(Offer(CaseManagerRole))`` to the offering Vendor.  If the
+    auto-accept node fails (e.g. ``trigger_activity_factory`` unavailable
+    or a business error), the ``AcceptOrReject`` Selector falls back to
+    :class:`~vultron.core.behaviors.case.nodes.communication.EmitRejectCaseManagerRoleNode`
+    which sends an explicit ``Reject`` so the Vendor is informed rather
+    than receiving silence.
 
     Structure::
 
@@ -65,18 +68,38 @@ def create_offer_case_manager_role_received_tree(
         │   │   └── CommitCaseLedgerEntryNode
         │   └── Success("CommitSkippedNotCaseManager")
         ├── StoreActivityNode("OfferCaseManagerRole")
-        └── AutoAcceptCaseManagerRoleNode
+        └── AcceptOrReject (Selector)
+            ├── AutoAcceptCaseManagerRoleNode
+            └── EmitRejectCaseManagerRoleNode
 
     Args:
         offer_id: ID of the ``Offer(CaseManagerRole)`` activity.
         offer_obj: The wire activity object to persist idempotently.
         case_id: ID of the VulnerabilityCase referenced by the offer.
         participant_id: ID of the CaseParticipant being offered the role.
-        vendor_id: Actor ID of the offering Vendor (recipient of Accept).
+        vendor_id: Actor ID of the offering Vendor (recipient of Accept/Reject).
 
     Returns:
         Root ``OfferCaseManagerRoleReceivedBT`` Sequence node.
     """
+    accept_or_reject = py_trees.composites.Selector(
+        name="AcceptOrReject",
+        memory=False,
+        children=[
+            AutoAcceptCaseManagerRoleNode(
+                offer_id=offer_id,
+                case_id=case_id,
+                participant_id=participant_id,
+                vendor_id=vendor_id,
+            ),
+            EmitRejectCaseManagerRoleNode(
+                offer_id=offer_id,
+                case_id=case_id,
+                participant_id=participant_id,
+                vendor_id=vendor_id,
+            ),
+        ],
+    )
     return create_receive_activity_tree(
         name="OfferCaseManagerRoleReceivedBT",
         case_id=case_id if case_id else None,
@@ -87,11 +110,6 @@ def create_offer_case_manager_role_received_tree(
                 activity_obj=offer_obj,
                 label="OfferCaseManagerRole",
             ),
-            AutoAcceptCaseManagerRoleNode(
-                offer_id=offer_id,
-                case_id=case_id,
-                participant_id=participant_id,
-                vendor_id=vendor_id,
-            ),
+            accept_or_reject,
         ],
     )

--- a/vultron/core/behaviors/case/offer_case_manager_role_received_tree.py
+++ b/vultron/core/behaviors/case/offer_case_manager_role_received_tree.py
@@ -53,11 +53,19 @@ def create_offer_case_manager_role_received_tree(
 
     Finally, the tree attempts to auto-accept the offer by emitting
     ``Accept(Offer(CaseManagerRole))`` to the offering Vendor.  If the
-    auto-accept node fails (e.g. ``trigger_activity_factory`` unavailable
-    or a business error), the ``AcceptOrReject`` Selector falls back to
-    :class:`~vultron.core.behaviors.case.nodes.communication.EmitRejectCaseManagerRoleNode`
+    Accept activity *creation* fails (e.g. ``trigger_activity_factory``
+    unavailable or a factory-level error) before any state is written, the
+    ``AcceptOrReject`` Selector falls back to
+    :class:`~vultron.core.behaviors.case.nodes.delegation.EmitRejectCaseManagerRoleNode`
     which sends an explicit ``Reject`` so the Vendor is informed rather
     than receiving silence.
+
+    Outbox-enqueue failures that occur *after* the Accept activity has been
+    persisted are **not** converted to Reject: the exception propagates from
+    the node so BTBridge fails the tree hard, preserving the persisted
+    Accept without emitting a contradictory Reject.  This distinction is
+    enforced by :class:`~vultron.core.behaviors.case.nodes.delegation.AutoAcceptCaseManagerRoleNode`
+    which splits the two operations into separate error paths.
 
     Structure::
 

--- a/vultron/core/ports/trigger_activity.py
+++ b/vultron/core/ports/trigger_activity.py
@@ -385,6 +385,26 @@ class TriggerActivityPort(Protocol):
         """
         ...
 
+    def reject_case_manager_role(
+        self,
+        offer_id: str,
+        case_id: str,
+        participant_id: str,
+        vendor_id: str,
+        actor: str,
+        to: list[str] | None = None,
+    ) -> str:
+        """Create and persist a ``Reject(_OfferCaseManagerRoleActivity)``.
+
+        Ephemerally reconstructs the original Offer (using ``offer_id``,
+        ``case_id``, ``participant_id``, and ``vendor_id``) before building
+        the Reject so that ``Reject.object_`` is a typed
+        ``_OfferCaseManagerRoleActivity``, not a bare string IRI.
+
+        Returns the activity ID.
+        """
+        ...
+
     # -----------------------------------------------------------------------
     # Embargo
     # -----------------------------------------------------------------------


### PR DESCRIPTION
- Closes #1067

## Summary

When the Case Actor cannot auto-accept a case manager role offer (e.g., at capacity or policy-blocked), it previously went silent. This PR adds `EmitRejectCaseManagerRoleNode` as a Selector fallback after `AutoAcceptCaseManagerRoleNode` in the `offer_case_manager_role` received BT tree, ensuring the offering vendor receives an explicit `Reject` activity.

## Changes

### Core protocol layer
- `vultron/core/ports/trigger_activity.py`: Added `reject_case_manager_role` method to `TriggerActivityPort` Protocol
- `vultron/adapters/driven/trigger_activity_adapter/actors.py`: Implemented `reject_case_manager_role` in `_ActorsMixin` (mirrors `accept_case_manager_role`)

### BT nodes
- `vultron/core/behaviors/case/nodes/delegation.py` (new): Split delegation nodes from `communication.py` to comply with BTND-07-004 500-line limit. Contains `ResolveCaseManagerOfferContextNode`, `CreateOfferCaseManagerActivityNode`, `AutoAcceptCaseManagerRoleNode`, `EmitRejectCaseManagerRoleNode`
- `vultron/core/behaviors/case/nodes/communication.py`: Trimmed to `CollectCaseAddresseesNode` + `CreateAndPersistCaseActivityNode` (~190 lines)
- `vultron/core/behaviors/case/nodes/__init__.py`: Updated imports; exports `EmitRejectCaseManagerRoleNode`

### BT tree
- `vultron/core/behaviors/case/offer_case_manager_role_received_tree.py`: Wrapped `AutoAcceptCaseManagerRoleNode` + `EmitRejectCaseManagerRoleNode` in an `AcceptOrReject` Selector as the final effect node in the Sequence

### Tests
- `test/core/behaviors/case/nodes/test_communication.py`: Added `TestEmitRejectCaseManagerRoleNode` (7 tests)
- `test/core/use_cases/received/actor/test_case_manager_role.py`: Added 2 new tests for the reject-fallback path

## Verification

All tests pass:
```
4380 passed, 38 skipped, 403 deselected, 2 xfailed in 69.20s
```

All linters clean: Black, flake8, mypy, pyright