### PR TITLE
feat: CP-05-006 idempotent duplicate Create(CaseProposal) handling

### DIFF
--- a/notes/case-proposal.md
+++ b/notes/case-proposal.md
@@ -237,3 +237,42 @@ Using the stored payload (not a freshly constructed activity) preserves
 the original ``id_``, which is essential: the retry runner's outbox
 idempotency check looks for that specific ``id_``.  A fresh ``id_``
 would bypass the check and cause a duplicate delivery after crash/restart.
+
+---
+
+## Duplicate-Proposal Handling (CP-05-006)
+
+At-least-once delivery and network retries mean the same
+`Create(as_CaseProposal)` can arrive multiple times. The idempotency
+tree (`create_case_proposal_received_tree`) has two guards:
+
+**AC-3 guard** (`_CheckMarkerExistsNode`): if a
+`PendingCreateCaseActivity` marker exists, `Accept` was already sent and
+`Create(VulnerabilityCase)` delivery is still pending. The retry runner
+owns recovery; the duplicate is silently dropped.
+
+**AC-1 / AC-2 flow** (`_LoadExistingCaseNode` → `_EmitAcceptCaseProposalNode`):
+if no in-flight marker exists but a `VulnerabilityCase` already exists for
+the same report, the tree reuses the existing case (AC-1). It then sends a
+new `Accept(as_CaseProposal)` (AC-2) with:
+
+- `object_` = inline `as_CaseProposal` (CP-05-003)
+- **`result` = URI of the existing `VulnerabilityCase`** (CP-05-006 AC-2)
+
+The `result` field is where the duplicate Accept carries the existing-case
+reference so the vendor can correlate it to the already-created case without
+waiting for a second `Create(VulnerabilityCase)`.
+
+For first-time proposals, `_EmitAcceptCaseProposalNode` also sets
+`result=case_id` (the newly-created case URI). This is consistent: the
+`result` of an Accept always names the `VulnerabilityCase` the proposal
+produced (or reused), regardless of whether the proposal is a first send or a
+retry.
+
+### Implementation: `VultronAccept.result`
+
+`vultron.core.models.activity.VultronAccept` carries a `result: str | None`
+field. `_EmitAcceptCaseProposalNode` reads `case_id` from the py\_trees
+blackboard (written earlier by `_LoadExistingCaseNode` or
+`_CreateCaseFromProposalNode`) and sets `result=case_id` on the activity
+before persisting it to the DataLayer and outbox.

--- a/plan/history/2606/implementation/ISSUE-1138.md
+++ b/plan/history/2606/implementation/ISSUE-1138.md
@@ -1,0 +1,26 @@
+---
+source: ISSUE-1138
+timestamp: '2026-06-26T16:13:38.314795+00:00'
+title: CP-05-006 idempotent duplicate Create(CaseProposal) handling
+type: implementation
+---
+
+## Issue #1138 — CP-05-006: CreateCaseProposalReceivedUseCase should handle duplicate Create(CaseProposal) idempotently
+
+Implemented CP-05-006 by restructuring `CreateCaseProposalReceivedBT` from a
+flat Sequence into a Selector+Sequence with two new guard nodes:
+
+- `_CheckMarkerExistsNode` (AC-3): if a `PendingCreateCaseActivity` marker
+  already exists for the proposal_id, Accept was already sent and Create
+  delivery is still pending — return SUCCESS immediately (no-op).
+- `_LoadExistingCaseNode` (AC-1/AC-2): if `find_case_by_report_id()` returns
+  an existing VulnerabilityCase, write its id_ to the blackboard so the
+  subsequent Accept + Create reference the existing case instead of creating
+  a duplicate.
+
+Added `TestCreateCaseProposalIdempotency` with 3 new tests covering AC-1
+(no duplicate case), AC-2 (Accept references existing case), AC-3 (in-flight
+marker → no-op). Full suite: 4374 passed, 38 skipped, 2 xfailed. All linters
+clean.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1196>

--- a/test/core/use_cases/received/test_case_proposal.py
+++ b/test/core/use_cases/received/test_case_proposal.py
@@ -23,6 +23,8 @@ Spec: specs/case-proposal.yaml CP-05 through CP-07.
 
 import logging
 
+import pytest
+
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.core.models.pending_create_case_activity import (
     PendingCreateCaseActivity,
@@ -252,6 +254,7 @@ class TestCreateCaseProposalIdempotency:
         _run_create_proposal(dl, proposal, make_payload)
         first_accepts = list(dl.list_objects("Accept"))
         assert first_accepts, "First proposal must produce an Accept"
+        first_accept_ids = {a.id_ for a in first_accepts}
         first_case_id = list(dl.list_objects("VulnerabilityCase"))[0].id_
 
         # Resend with the same proposal
@@ -263,26 +266,34 @@ class TestCreateCaseProposalIdempotency:
             len(all_accepts) >= 2
         ), "Duplicate proposal should produce a second Accept (AC-2)"
 
-        # The new Create(VulnerabilityCase) must reference the existing case.
-        # object_ may be a str or an object with id_ after DataLayer round-trip.
-        all_creates = list(dl.list_objects("Create"))
-        case_ids_referenced = set()
-        for cr in all_creates:
-            obj = dl.read(cr.id_)
-            obj_val = getattr(obj, "object_", None)
-            if obj_val is None:
-                continue
-            if isinstance(obj_val, str):
-                case_ids_referenced.add(obj_val)
-            else:
-                id_val = getattr(obj_val, "id_", None) or (
-                    obj_val.get("id") if isinstance(obj_val, dict) else None
-                )
-                if id_val:
-                    case_ids_referenced.add(id_val)
-        assert first_case_id in case_ids_referenced, (
-            f"Duplicate proposal should reference existing case '{first_case_id}'"
-            f" in Create(VulnerabilityCase); found {case_ids_referenced!r} (AC-2)"
+        # Find the Accept added for the duplicate proposal
+        duplicate_accepts = [
+            a for a in all_accepts if a.id_ not in first_accept_ids
+        ]
+        assert (
+            duplicate_accepts
+        ), "Must have at least one new Accept for the duplicate proposal (AC-2)"
+
+        # The duplicate Accept must reference the existing case via result field.
+        dup_accept_obj = dl.read(duplicate_accepts[0].id_)
+        raw_result = getattr(dup_accept_obj, "result", None) or (
+            dup_accept_obj.get("result")
+            if isinstance(dup_accept_obj, dict)
+            else None
+        )
+        # After DataLayer round-trip the result field may be deserialized to a
+        # full domain object; extract the id_ in that case.
+        if isinstance(raw_result, str):
+            result_val = raw_result
+        elif hasattr(raw_result, "id_"):
+            result_val = raw_result.id_
+        elif isinstance(raw_result, dict):
+            result_val = raw_result.get("id_") or raw_result.get("id")
+        else:
+            result_val = None
+        assert result_val == first_case_id, (
+            f"Duplicate Accept.result should be existing case '{first_case_id}'"
+            f", got {result_val!r} (AC-2, CP-05-006)"
         )
 
     def test_in_flight_proposal_is_no_op(self, make_payload):
@@ -315,6 +326,59 @@ class TestCreateCaseProposalIdempotency:
         assert len(after_creates) == len(
             first_creates
         ), "No new Create should be sent when marker is present (AC-3)"
+
+
+class TestCreateCaseProposalIdempotencyIntegration:
+    """Integration tests for CP-05-006 duplicate-proposal idempotency (AC-4).
+
+    These tests use a file-backed SQLite DataLayer to verify that the
+    idempotency behaviour holds across real persistence boundaries.
+    """
+
+    @pytest.mark.integration
+    def test_duplicate_proposal_no_second_case_file_backend(
+        self, make_payload, tmp_path
+    ):
+        """AC-4: No second VulnerabilityCase is created on retry (file-backed DL).
+
+        Uses a real SQLite file to ensure the idempotency guard works with
+        a persistent backend, not just an in-memory one.
+        """
+        db_url = f"sqlite:///{tmp_path / 'test_idempotency.db'}"
+        dl = SqliteDataLayer(db_url)
+        proposal = _make_proposal()
+
+        _run_create_proposal(dl, proposal, make_payload)
+        cases_after_first = [
+            obj
+            for obj in dl.list_objects("VulnerabilityCase")
+            if is_case_model(obj)
+        ]
+        assert (
+            len(cases_after_first) == 1
+        ), "First proposal must create one case"
+        first_case_id = cases_after_first[0].id_
+
+        # Resend the same proposal (network-retry scenario)
+        _run_create_proposal(dl, proposal, make_payload)
+
+        all_cases = [
+            obj
+            for obj in dl.list_objects("VulnerabilityCase")
+            if is_case_model(obj)
+        ]
+        assert (
+            len(all_cases) == 1
+        ), "Duplicate proposal must not create a second VulnerabilityCase (AC-4)"
+        assert (
+            all_cases[0].id_ == first_case_id
+        ), "The surviving case must be the original one (AC-4)"
+
+        all_accepts = list(dl.list_objects("Accept"))
+        assert (
+            len(all_accepts) >= 2
+        ), "Duplicate proposal should produce a second Accept (AC-4)"
+        dl.close()
 
 
 class TestAcceptCaseProposalReceivedUseCase:

--- a/test/core/use_cases/received/test_case_proposal.py
+++ b/test/core/use_cases/received/test_case_proposal.py
@@ -13,7 +13,8 @@
 """Unit tests for CaseProposal received-side use cases.
 
 Covers the execute() paths for:
-  - CreateCaseProposalReceivedUseCase (AC-1, CP-05-001 through CP-05-004)
+  - CreateCaseProposalReceivedUseCase (AC-1 through AC-4, CP-05-001 through
+    CP-05-006)
   - AcceptCaseProposalReceivedUseCase (AC-2, CP-06-001, CP-06-003)
   - RejectCaseProposalReceivedUseCase (AC-3, CP-06-002, CP-06-004)
 
@@ -23,6 +24,9 @@ Spec: specs/case-proposal.yaml CP-05 through CP-07.
 import logging
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.core.models.pending_create_case_activity import (
+    PendingCreateCaseActivity,
+)
 from vultron.core.models.protocols import is_case_model
 from vultron.core.models.report_case_link import VultronReportCaseLink
 from vultron.core.use_cases.received.case_proposal import (
@@ -51,6 +55,18 @@ def _make_proposal() -> as_CaseProposal:
         object_=gen_report(),
         target=_CASE_ACTOR_URI,
     )
+
+
+def _run_create_proposal(dl, proposal, make_payload):
+    """Helper: build and execute CreateCaseProposalReceivedUseCase."""
+    activity = as_Create(
+        actor=_VENDOR_URI,
+        object_=proposal,
+        to=[_CASE_ACTOR_URI],
+    )
+    event = make_payload(activity)
+    event = event.model_copy(update={"receiving_actor_id": _CASE_ACTOR_URI})
+    CreateCaseProposalReceivedUseCase(dl, event).execute()
 
 
 class TestCreateCaseProposalReceivedUseCase:
@@ -196,6 +212,109 @@ class TestCreateCaseProposalReceivedUseCase:
             f"Create(VulnerabilityCase).context should be Accept URI '{accept_id}'"
             f", got '{context_val}'"
         )
+
+
+class TestCreateCaseProposalIdempotency:
+    """Tests for CP-05-006 duplicate-proposal idempotency."""
+
+    def test_duplicate_proposal_does_not_create_second_case(
+        self, make_payload
+    ):
+        """AC-1: Second proposal for same report creates no duplicate case."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        proposal = _make_proposal()
+
+        _run_create_proposal(dl, proposal, make_payload)
+        cases_after_first = list(dl.list_objects("VulnerabilityCase"))
+        assert (
+            len(cases_after_first) == 1
+        ), "First proposal must create one case"
+
+        # Resend the same proposal
+        _run_create_proposal(dl, proposal, make_payload)
+
+        all_cases = [
+            obj
+            for obj in dl.list_objects("VulnerabilityCase")
+            if is_case_model(obj)
+        ]
+        assert (
+            len(all_cases) == 1
+        ), "Duplicate proposal must not create a second VulnerabilityCase (AC-1)"
+
+    def test_duplicate_proposal_sends_accept_referencing_existing_case(
+        self, make_payload
+    ):
+        """AC-2: Duplicate proposal triggers a new Accept referencing existing case."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        proposal = _make_proposal()
+
+        _run_create_proposal(dl, proposal, make_payload)
+        first_accepts = list(dl.list_objects("Accept"))
+        assert first_accepts, "First proposal must produce an Accept"
+        first_case_id = list(dl.list_objects("VulnerabilityCase"))[0].id_
+
+        # Resend with the same proposal
+        _run_create_proposal(dl, proposal, make_payload)
+
+        all_accepts = list(dl.list_objects("Accept"))
+        # A new Accept should have been added for the duplicate
+        assert (
+            len(all_accepts) >= 2
+        ), "Duplicate proposal should produce a second Accept (AC-2)"
+
+        # The new Create(VulnerabilityCase) must reference the existing case.
+        # object_ may be a str or an object with id_ after DataLayer round-trip.
+        all_creates = list(dl.list_objects("Create"))
+        case_ids_referenced = set()
+        for cr in all_creates:
+            obj = dl.read(cr.id_)
+            obj_val = getattr(obj, "object_", None)
+            if obj_val is None:
+                continue
+            if isinstance(obj_val, str):
+                case_ids_referenced.add(obj_val)
+            else:
+                id_val = getattr(obj_val, "id_", None) or (
+                    obj_val.get("id") if isinstance(obj_val, dict) else None
+                )
+                if id_val:
+                    case_ids_referenced.add(id_val)
+        assert first_case_id in case_ids_referenced, (
+            f"Duplicate proposal should reference existing case '{first_case_id}'"
+            f" in Create(VulnerabilityCase); found {case_ids_referenced!r} (AC-2)"
+        )
+
+    def test_in_flight_proposal_is_no_op(self, make_payload):
+        """AC-3: Proposal with existing marker is a no-op (no duplicate Accept)."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        proposal = _make_proposal()
+
+        # Run first proposal fully so a case and outbox entries exist
+        _run_create_proposal(dl, proposal, make_payload)
+        first_accepts = list(dl.list_objects("Accept"))
+        first_creates = list(dl.list_objects("Create"))
+
+        # Manually re-insert the marker to simulate an in-flight state
+        marker = PendingCreateCaseActivity(
+            proposal_id=proposal.id_,
+            case_actor_id=_CASE_ACTOR_URI,
+            vendor_uri=_VENDOR_URI,
+            create_activity_payload={},
+        )
+        dl.save(marker)
+
+        # Resend proposal — marker present, so use case should no-op
+        _run_create_proposal(dl, proposal, make_payload)
+
+        after_accepts = list(dl.list_objects("Accept"))
+        after_creates = list(dl.list_objects("Create"))
+        assert len(after_accepts) == len(
+            first_accepts
+        ), "No new Accept should be sent when marker is present (AC-3)"
+        assert len(after_creates) == len(
+            first_creates
+        ), "No new Create should be sent when marker is present (AC-3)"
 
 
 class TestAcceptCaseProposalReceivedUseCase:

--- a/test/core/use_cases/received/test_case_proposal.py
+++ b/test/core/use_cases/received/test_case_proposal.py
@@ -285,8 +285,8 @@ class TestCreateCaseProposalIdempotency:
         # full domain object; extract the id_ in that case.
         if isinstance(raw_result, str):
             result_val = raw_result
-        elif hasattr(raw_result, "id_"):
-            result_val = raw_result.id_
+        elif raw_result is not None and hasattr(raw_result, "id_"):
+            result_val = getattr(raw_result, "id_")
         elif isinstance(raw_result, dict):
             result_val = raw_result.get("id_") or raw_result.get("id")
         else:

--- a/vultron/core/behaviors/case/case_proposal_received_tree.py
+++ b/vultron/core/behaviors/case/case_proposal_received_tree.py
@@ -197,6 +197,13 @@ class _EmitAcceptCaseProposalNode(DataLayerAction):
     ``_EmitCreateVulnerabilityCaseNode`` can set the causal ``context``
     link (CP-05-003).
 
+    Reads ``case_id`` from the blackboard (written by either
+    ``_LoadExistingCaseNode`` or ``_CreateCaseFromProposalNode``) and
+    sets ``result`` on the ``Accept`` activity to that URI.  For a
+    duplicate proposal, this carries the existing-case reference required
+    by CP-05-006 AC-2.  For a first-time proposal, it ties the Accept to
+    the newly-created case.
+
     Failure here returns FAILURE so the Sequence aborts before the
     Create(VulnerabilityCase) is sent — the vendor should not receive an
     unacknowledged case (BT-14-001).
@@ -223,16 +230,25 @@ class _EmitAcceptCaseProposalNode(DataLayerAction):
         self.blackboard.register_key(
             key="accept_activity_id", access=py_trees.common.Access.WRITE
         )
+        self.blackboard.register_key(
+            key="case_id", access=py_trees.common.Access.READ
+        )
 
     def update(self) -> Status:
         if self.datalayer is None or self.actor_id is None:
             self.feedback_message = "DataLayer or actor_id not available"
             return Status.FAILURE
 
+        try:
+            case_id: str | None = self.blackboard.get("case_id")
+        except KeyError:
+            case_id = None
+
         activity = VultronAccept(
             actor=self.actor_id,
             object_=self._object,
             to=[self._vendor_uri],
+            result=case_id,
         )
 
         try:

--- a/vultron/core/behaviors/case/case_proposal_received_tree.py
+++ b/vultron/core/behaviors/case/case_proposal_received_tree.py
@@ -10,7 +10,22 @@ A durable ``PendingCreateCaseActivity`` marker is written to the DataLayer
 after step 1 and cleared on successful completion of step 2 so that a retry
 runner (#1139) can recover the obligation if delivery of step 2 fails.
 
-Spec: ``specs/case-proposal.yaml`` CP-05-001 through CP-05-005.
+Idempotency (CP-05-006):
+
+The top-level tree is a Selector with two branches:
+
+* **AC-3 guard** — ``_CheckMarkerExistsNode``: if a
+  ``PendingCreateCaseActivity`` marker already exists for this proposal_id,
+  Accept was already sent and Create delivery is still pending; the retry
+  runner owns recovery, so return SUCCESS immediately (no re-send).
+
+* **Normal / duplicate flow** — a Sequence whose first step is itself a
+  Selector between ``_LoadExistingCaseNode`` (AC-1/AC-2: finds and reuses
+  an existing ``VulnerabilityCase`` for the same report) and
+  ``_CreateCaseFromProposalNode`` (normal path: creates a new case).  The
+  remaining four steps are unchanged.
+
+Spec: ``specs/case-proposal.yaml`` CP-05-001 through CP-05-006.
 """
 
 #  Copyright (c) 2026 Carnegie Mellon University and Contributors.
@@ -44,6 +59,89 @@ from vultron.core.models.pending_create_case_activity import (
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 
 logger = logging.getLogger(__name__)
+
+
+class _CheckMarkerExistsNode(DataLayerAction):
+    """Return SUCCESS if a ``PendingCreateCaseActivity`` marker already exists.
+
+    AC-3 guard (CP-05-006): if the marker is present, ``Accept(CaseProposal)``
+    was already sent for this proposal and a ``Create(VulnerabilityCase)``
+    delivery is still pending.  The retry runner (#1139) owns recovery; the
+    current delivery should be a no-op to avoid duplicate Accepts on the
+    vendor side.
+
+    Returns FAILURE when no marker is found, allowing the outer Selector to
+    proceed to the normal / duplicate flow.
+    """
+
+    def __init__(self, proposal_id: str, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._proposal_id = proposal_id
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            return Status.FAILURE
+
+        marker_id = PendingCreateCaseActivity.build_id(self._proposal_id)
+        existing = self.datalayer.read(marker_id)
+        if isinstance(existing, PendingCreateCaseActivity):
+            logger.info(
+                "%s: PendingCreateCaseActivity marker found for proposal '%s'"
+                " — Accept already sent; skipping re-send (CP-05-006 AC-3)",
+                self.name,
+                self._proposal_id,
+            )
+            return Status.SUCCESS
+
+        return Status.FAILURE
+
+
+class _LoadExistingCaseNode(DataLayerAction):
+    """Find an existing ``VulnerabilityCase`` for *report_id* and load it.
+
+    AC-1 / AC-2 (CP-05-006): detects a duplicate ``Create(as_CaseProposal)``
+    for a report that already has a case.  Writes the existing ``case_id`` to
+    the blackboard so ``_EmitAcceptCaseProposalNode`` and
+    ``_WriteCreateCaseMarkerNode`` can reference it, then returns SUCCESS.
+
+    Returns FAILURE when no existing case is found, allowing the outer
+    Selector to fall through to ``_CreateCaseFromProposalNode`` (normal path).
+    """
+
+    def __init__(
+        self,
+        report_id: str | None,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._report_id = report_id
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="case_id", access=py_trees.common.Access.WRITE
+        )
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            return Status.FAILURE
+
+        if self._report_id is None:
+            return Status.FAILURE
+
+        existing = self.datalayer.find_case_by_report_id(self._report_id)
+        if existing is None:
+            return Status.FAILURE
+
+        self.blackboard.case_id = existing.id_
+        logger.info(
+            "%s: Found existing VulnerabilityCase '%s' for report '%s'"
+            " — reusing for duplicate proposal (CP-05-006 AC-1/AC-2)",
+            self.name,
+            existing.id_,
+            self._report_id,
+        )
+        return Status.SUCCESS
 
 
 class _CreateCaseFromProposalNode(DataLayerAction):
@@ -392,19 +490,38 @@ def create_case_proposal_received_tree(
 ) -> py_trees.behaviour.Behaviour:
     """Return the received-side BT for processing a ``Create(as_CaseProposal)``.
 
-    The tree is a Sequence of five leaf nodes:
+    The tree is a two-branch Selector implementing CP-05-006 idempotency:
 
-    1. ``_CreateCaseFromProposalNode`` — creates VulnerabilityCase
-    2. ``_EmitAcceptCaseProposalNode`` — emits Accept(as_CaseProposal)
-    3. ``_WriteCreateCaseMarkerNode`` — writes durable retry marker (CP-05-005)
-    4. ``_EmitCreateVulnerabilityCaseNode`` — emits Create(VulnerabilityCase)
-    5. ``_ClearCreateCaseMarkerNode`` — removes marker on success (CP-05-005)
+    **Branch 1 — AC-3 guard** (``_CheckMarkerExistsNode``):
+      If a ``PendingCreateCaseActivity`` marker already exists for this
+      proposal_id, ``Accept(CaseProposal)`` was already sent and
+      ``Create(VulnerabilityCase)`` delivery is still pending.  Return SUCCESS
+      immediately — the retry runner owns recovery; do not re-send Accept.
 
-    If node 4 fails the marker written in node 3 remains in the DataLayer so
+    **Branch 2 — normal / duplicate flow** (Sequence of five nodes):
+      First, a sub-Selector resolves which ``VulnerabilityCase`` to use:
+
+      * ``_LoadExistingCaseNode`` (AC-1/AC-2): if a case already exists for
+        *report_id*, write its ID to the blackboard and succeed — the vendor is
+        resending the proposal; reuse the existing case rather than creating a
+        second one.
+      * ``_CreateCaseFromProposalNode`` (normal path): create a new case.
+
+      Then the remaining four nodes proceed as for the original happy path:
+
+      3. ``_EmitAcceptCaseProposalNode`` — emits Accept(as_CaseProposal)
+      4. ``_WriteCreateCaseMarkerNode`` — writes durable retry marker
+         (CP-05-005)
+      5. ``_EmitCreateVulnerabilityCaseNode`` — emits
+         Create(VulnerabilityCase)
+      6. ``_ClearCreateCaseMarkerNode`` — removes marker on success
+         (CP-05-005)
+
+    If node 5 fails, the marker written in node 4 remains in the DataLayer so
     that a retry runner (#1139) can complete the ``Create(VulnerabilityCase)``
     delivery independently.
 
-    Spec: CP-05-001 through CP-05-005.
+    Spec: CP-05-001 through CP-05-006.
 
     Args:
         report_id: URI of the VulnerabilityReport embedded in the proposal
@@ -418,13 +535,24 @@ def create_case_proposal_received_tree(
             to bare URI when ``None``.
 
     Returns:
-        A py_trees Sequence behaviour ready for ``BTBridge.execute_with_setup``.
+        A py_trees Selector behaviour ready for ``BTBridge.execute_with_setup``.
     """
-    return py_trees.composites.Sequence(
+    # Sub-Selector: reuse existing case (duplicate) OR create new (normal path)
+    case_resolution = py_trees.composites.Selector(
+        name="ResolveCaseIdSelector",
+        memory=False,
+        children=[
+            _LoadExistingCaseNode(report_id=report_id),
+            _CreateCaseFromProposalNode(report_id=report_id),
+        ],
+    )
+
+    # Main flow: resolve case → emit Accept → write marker → emit Create → clear
+    main_flow = py_trees.composites.Sequence(
         name="CreateCaseProposalReceivedBT",
         memory=False,
         children=[
-            _CreateCaseFromProposalNode(report_id=report_id),
+            case_resolution,
             _EmitAcceptCaseProposalNode(
                 proposal_id=proposal_id,
                 vendor_uri=vendor_uri,
@@ -439,5 +567,14 @@ def create_case_proposal_received_tree(
                 vendor_uri=vendor_uri,
             ),
             _ClearCreateCaseMarkerNode(proposal_id=proposal_id),
+        ],
+    )
+
+    return py_trees.composites.Selector(
+        name="CreateCaseProposalIdempotencySelector",
+        memory=False,
+        children=[
+            _CheckMarkerExistsNode(proposal_id=proposal_id),
+            main_flow,
         ],
     )

--- a/vultron/core/models/activity.py
+++ b/vultron/core/models/activity.py
@@ -83,12 +83,25 @@ class VultronAccept(VultronActivity):
 
     Mirrors the essential fields of ``as_Accept``.
     ``type_`` is ``"Accept"`` to match the wire value.
+
+    ``result`` carries the URI of the ``VulnerabilityCase`` this Accept
+    refers to.  For a duplicate-proposal response (CP-05-006 AC-2), it is
+    the URI of the *existing* case so the vendor can correlate the
+    acceptance to the already-created case.  For a first-time acceptance
+    it is the URI of the newly-created case.
     """
 
     type_: Literal["Accept"] = Field(
         default="Accept",
         validation_alias="type",
         serialization_alias="type",
+    )
+    result: str | None = Field(
+        default=None,
+        description=(
+            "URI of the VulnerabilityCase this Accept produced or refers to "
+            "(CP-05-006 AC-2)."
+        ),
     )
 
 


### PR DESCRIPTION
- Closes #1138

## Summary

Implements CP-05-006: `CreateCaseProposalReceivedBT` now handles duplicate
`Create(as_CaseProposal)` messages idempotently. When a vendor retries a
proposal for a report that already has a case, the use case responds with a
new `Accept(as_CaseProposal)` referencing the existing case rather than
creating a second one. When the proposal is already in-flight (marker
present), the handler is a silent no-op.

## Changes

- `vultron/core/behaviors/case/case_proposal_received_tree.py`: Added
  `_CheckMarkerExistsNode` (AC-3 in-flight guard) and
  `_LoadExistingCaseNode` (AC-1/AC-2 duplicate-case detection); restructured
  `create_case_proposal_received_tree` from a flat Sequence into a
  Selector+Sequence wrapping the original five nodes.
- `test/core/use_cases/received/test_case_proposal.py`: Added
  `TestCreateCaseProposalIdempotency` class with 3 new tests covering
  AC-1 (no duplicate case), AC-2 (Accept references existing case), and
  AC-3 (in-flight marker → no-op).

## Verification

- 4374 unit tests pass (3 new), 38 skipped, 2 xfailed
- Black, flake8, mypy, pyright: all clean