### PR TITLE
docs: plan issue #1054 — routing-gated state mutation spec (BT-19)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -762,6 +762,21 @@ Short entries are reproduced here; longer ones are referenced below.
   falls through to DEFERRED, and the test may pass for the wrong reason. Any
   test that exercises BT operations in a received-side use case MUST pass a
   `receiving_actor_id`. See `specs/behavior-tree-integration.yaml` BT-17-005.
+- **Routing Prerequisites Must Be Resolved Before State Mutation in Lifecycle BT
+  Sequences** — A BT Sequence that performs a protocol state-machine transition
+  (EM, RM, or CS) and then routes an outbound activity MUST resolve all routing
+  prerequisites (e.g., Case Manager actor ID) in a read-only guard node placed
+  BEFORE the state-mutation node. Committing a transition to the DataLayer before
+  verifying routing is available creates a divergence window: local state reflects
+  the new state (e.g., `EM=EXITED`) while peers still hold the prior state
+  (e.g., `EM=ACTIVE`) because the broadcast was never sent. The Sequence MUST fail
+  at the guard with zero DataLayer state change when routing prerequisites are
+  absent. Duplicated monolithic nodes that inline both mutation and dispatch in a
+  single `update()` MUST be replaced by a shared BT factory function used across
+  all call sites (trigger path and automatic-cascade path) to prevent per-path
+  drift back to the unsafe ordering. See `specs/behavior-tree-integration.yaml`
+  BT-19-001, BT-19-002 and [notes/bt-integration.md](notes/bt-integration.md)
+  § "Routing-Gated State Mutation".
 - **Automation Potential and Call-Out Point Shape Are Orthogonal** — When
   classifying a fuzzer node, the `automation potential` and `call-out point
   shape` fields are **independent**. A node with High automation potential may

--- a/notes/bt-integration.md
+++ b/notes/bt-integration.md
@@ -1352,6 +1352,54 @@ the producer node takes a no-op path.
 
 ---
 
+### Routing-Gated State Mutation
+
+(BT-19, 2026-06-26; see `specs/behavior-tree-integration.yaml` BT-19-001,
+BT-19-002)
+
+A BT Sequence that performs a protocol state-machine transition (EM, RM, or CS)
+and then routes an outbound activity MUST resolve all routing prerequisites
+in a read-only guard node placed **before** the state-mutation node.
+
+**Why ordering matters**: Once the DataLayer accepts a state write (e.g.,
+`EM=EXITED`), the transition is committed. If the subsequent routing step
+then fails (missing Case Manager, missing factory), the outbound notification is
+never sent. Peers retain the prior state; local state has advanced — a
+divergence window that requires ledger-sync catch-up (SYNC-10) to repair.
+Moving the routing guard to the top of the Sequence eliminates the divergence:
+if routing prerequisites are absent, the tree returns `FAILURE` with zero
+DataLayer state change.
+
+**Shared factory requirement**: Duplicated monolithic BT nodes that inline both
+state mutation and dispatch in a single `update()` method drift independently.
+The canonical factory-composed path may correctly order the guard, while the
+automatic-cascade monolith retains the old unsafe ordering, reintroducing the
+divergence bug on that path only. All call sites for the same lifecycle
+transition MUST use a shared BT factory function (BT-19-002).
+
+**Canonical Sequence structure**:
+
+```text
+Sequence
+├── ResolveCaseManagerNode          ← read-only guard; FAILURE = bail, no write
+├── <StateTransitionNode>           ← mutation committed after guard passes
+└── <SendDispatchNode>              ← routing succeeds because guard already verified
+```
+
+**Anti-pattern** (Issue #1054 — `TerminateEmbargoNode`):
+
+```text
+Sequence
+├── TerminateEmbargoLifecycleNode   ← mutation committed first ← ❌
+└── SenderSideBT                    ← routing checked second; fail = divergence
+```
+
+**Fix**: Extract a shared factory (`terminate_embargo_trigger_bt`) that places
+`ResolveCaseManagerNode` before `TerminateEmbargoLifecycleNode`, and replace
+all standalone monolithic nodes with the factory output.
+
+---
+
 ### Demo Devlog Race: Wait for Replica Before Dumping
 
 (DEMO-DEVLOG-RACE, 2026-06-18)

--- a/plan/history/2606/learning/CONCERN-1054.md
+++ b/plan/history/2606/learning/CONCERN-1054.md
@@ -1,0 +1,45 @@
+---
+source: CONCERN-1054
+timestamp: '2026-06-26T20:07:45.486961+00:00'
+title: Terminate embargo BT — routing-gated state mutation (BT-19)
+type: learning
+---
+
+## Code Review — Advisory Finding
+
+**[ADVISORY — Pre-existing, not introduced by this PR]**
+
+The code-review agent flagged a potential issue in
+`vultron/core/behaviors/embargo/nodes/lifecycle.py`
+(`TerminateEmbargoNode.update()`): embargo state is committed to the DataLayer
+*before* `_dispatch_activity` is called, so when dispatch returns `FAILURE`
+(no factory, no Case Manager, etc.) the BT FAILURE propagates up to the use
+case, which then skips `_commit_log_cascade_bt`. This means the
+`Announce(CaseLedgerEntry)` fan-out — the very mechanism this PR and
+\#1043/\#1046 rely on for peer notification — is suppressed on teardown
+dispatch failures.
+
+**Root cause**: `TerminateEmbargoNode` is a monolith that inlines both the EM
+state-machine transition (committing `em_state=EXITED`, `active_embargo=None`,
+and PEC reset to DataLayer) and the outbound activity dispatch in a single
+`update()` method. When dispatch fails — most commonly because no
+`CVDRole.CASE_MANAGER` participant is registered — the local state is already
+committed but peers were never notified, causing silent EM state divergence.
+
+**Dual-implementation concern**: Two independent implementations exist for
+embargo termination. The trigger-side path (`SvcTerminateEmbargoUseCase` via
+`terminate_embargo_trigger_bt`) is factory-composed and uses the
+`EmbargoLifecycle` service. The automatic-cascade path (`PublicDisclosureBranchNode`
+via `TerminateEmbargoNode`) is a monolith using the older inline `EMAdapter` +
+`create_em_machine()` pattern. These drift independently.
+
+**Resolution**: Spec requirements BT-19-001 and BT-19-002 were added to
+`specs/behavior-tree-integration.yaml` to capture (1) the routing-prerequisites-
+before-state-mutation ordering rule and (2) the shared-factory requirement.
+The outbox is the reliability boundary: once the activity is written to the
+outbox, delivery and retry are the outbox's responsibility; residual mid-send
+failures are recoverable via ledger-sync catch-up (SYNC-10).
+
+**Resolved**: 2026-06-26 — implementation tracked in #1204.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1203>.
+Spec: `specs/behavior-tree-integration.yaml` BT-19-001, BT-19-002.

--- a/specs/behavior-tree-integration.yaml
+++ b/specs/behavior-tree-integration.yaml
@@ -626,3 +626,89 @@ groups:
         BT-16-005 defines automation potential categories; BT-18-005 clarifies
         that those categories govern the automation-potential field only and
         have no bearing on call-out point shape assignment.
+- id: BT-19
+  title: Routing-Gated State Mutation in Lifecycle BT Sequences
+  kind: pattern
+  specs:
+  - id: BT-19-001
+    priority: MUST
+    statement: >-
+      A BT Sequence that performs a protocol state-machine transition (EM, RM,
+      or CS) and then routes an outbound activity MUST resolve all routing
+      prerequisites (e.g., Case Manager actor ID, outbox availability) in a
+      read-only guard node placed BEFORE the state-mutation node. The
+      Sequence MUST fail at the guard with no state change when routing
+      prerequisites are absent.
+    rationale: >-
+      Committing a state transition to the DataLayer before verifying that the
+      resulting outbound activity can be constructed and queued creates a
+      divergence window: local state reflects the new state (e.g., EM=EXITED)
+      while peers still hold the prior state (e.g., EM=ACTIVE) because the
+      broadcast was never sent. Moving the routing guard before the mutation
+      eliminates the most common divergence cause (missing Case Manager,
+      missing factory) without requiring full transactional rollback. The
+      outbox is the reliability boundary: once the activity is written to the
+      outbox, delivery and retry are the outbox's responsibility; residual
+      mid-send failures (activity construction or outbox-write errors after
+      state mutation) are recoverable via ledger-sync catch-up (SYNC-10).
+    relationships:
+    - rel_type: refines
+      spec_id: BT-14-001
+      note: >-
+        Routing-gated mutation is the pre-condition counterpart to BT-14-001's
+        fail-fast-on-broadcast-failure rule: guard before mutation addresses
+        the common prerequisite-missing case; BT-14-001 addresses the
+        post-mutation delivery failure case.
+    - rel_type: refines
+      spec_id: BT-06-001
+      note: >-
+        Protocol state transitions are protocol-significant behavior; their
+        ordering relative to routing checks is part of the tree's auditable
+        contract.
+    verification: >-
+      For any embargo lifecycle BT Sequence that includes both a
+      state-mutation node and a send/dispatch node: confirm via code review
+      and test that a simulated missing Case Manager (empty
+      `actor_participant_index`, no `CVDRole.CASE_MANAGER` entry) causes the
+      tree to return FAILURE with zero DataLayer state change.
+  - id: BT-19-002
+    priority: MUST
+    statement: >-
+      A shared BT factory function MUST be used for all paths that trigger the
+      same protocol lifecycle transition (e.g., embargo termination).
+      Duplicate monolithic BT nodes that inline both state mutation and
+      activity dispatch in a single `update()` method MUST NOT exist alongside
+      a canonical factory-composed equivalent.
+    rationale: >-
+      Duplicated implementations drift independently: the canonical trigger-side
+      BT may correctly separate routing guards from state mutation while the
+      automatic-cascade BT retains the old ordering or the old inline EMAdapter
+      pattern, re-introducing the divergence bug in one pathway only. A single
+      shared factory guarantees consistent semantics and the correct guard
+      ordering across all call sites. Issue #1054 observed this exact drift
+      between `TerminateEmbargoNode` (monolith, inline EMAdapter) and
+      `terminate_embargo_trigger_bt` (factory-composed).
+    rationale_detail: >-
+      `TerminateEmbargoNode` (used by `PublicDisclosureBranchNode`) and
+      `TerminateEmbargoLifecycleNode` + `sender_side_bt` (used by
+      `SvcTerminateEmbargoUseCase`) represent the same protocol operation with
+      divergent implementations. Only the factory-composed path applied the
+      correct routing-guard ordering (BT-19-001); the monolith committed state
+      before verifying Case Manager availability.
+    relationships:
+    - rel_type: refines
+      spec_id: BT-14-002
+      note: >-
+        BT-14-002 requires shared helpers for broadcast fan-out; BT-19-002
+        extends this to the full lifecycle-plus-routing sequence.
+    - rel_type: implements
+      spec_id: BT-19-001
+      note: >-
+        Shared factory composition is the mechanism that enforces consistent
+        BT-19-001 guard ordering across all call sites.
+    verification: >-
+      For each protocol lifecycle operation with more than one call site
+      (trigger path and automatic-cascade path), confirm that all call sites
+      use the same BT factory function and that no standalone monolithic node
+      class exists that inlines both state mutation and dispatch in a single
+      `update()` method for the same operation.

--- a/specs/behavior-tree-integration.yaml
+++ b/specs/behavior-tree-integration.yaml
@@ -687,12 +687,11 @@ groups:
       shared factory guarantees consistent semantics and the correct guard
       ordering across all call sites. Issue #1054 observed this exact drift
       between `TerminateEmbargoNode` (monolith, inline EMAdapter) and
-      `terminate_embargo_trigger_bt` (factory-composed).
-    rationale_detail: >-
+      `terminate_embargo_trigger_bt` (factory-composed). Concretely:
       `TerminateEmbargoNode` (used by `PublicDisclosureBranchNode`) and
       `TerminateEmbargoLifecycleNode` + `sender_side_bt` (used by
       `SvcTerminateEmbargoUseCase`) represent the same protocol operation with
-      divergent implementations. Only the factory-composed path applied the
+      divergent implementations — only the factory-composed path applied the
       correct routing-guard ordering (BT-19-001); the monolith committed state
       before verifying Case Manager availability.
     relationships:


### PR DESCRIPTION
- Closes #1054

## Summary

Adds two new spec requirements (BT-19) to `specs/behavior-tree-integration.yaml`
capturing the pattern identified in issue #1054: embargo lifecycle BT
sequences that perform state mutation MUST gate on routing prerequisites
(Case Manager resolution) in a read-only guard node before applying the
state transition, and all call sites for the same lifecycle operation MUST
share a single BT factory function.

## Changes

- `specs/behavior-tree-integration.yaml`: Added BT-19 group with BT-19-001
  (routing-gated state mutation ordering rule) and BT-19-002 (shared BT
  factory requirement for all paths triggering the same lifecycle transition).
  Folded `rationale_detail` content into `rationale` in BT-19-002 (non-schema
  field was silently dropped by Pydantic loader / invisible in spec-dump).
- `plan/history/2606/learning/CONCERN-1054.md`: History entry recording
  the lesson learned from #1054 and referencing implementation PR #1204.
- `AGENTS.md`: Added BT-19-001 Common Pitfall entry — *Routing Prerequisites
  Must Be Resolved Before State Mutation in Lifecycle BT Sequences*.
- `notes/bt-integration.md`: Added § *Routing-Gated State Mutation* covering
  the BT-19 canonical Sequence structure, anti-pattern, and fix guidance.

## Verification

Docs-only PR. All CI checks passing (CodeQL, Markdown lint). Spec linter
passes. `spec-dump` output confirms BT-19-001 and BT-19-002 are present
with no `rationale_detail` field.