### PR TITLE
start.sh: fix git worktree mount, add cleanup trap, add --rebuild flag

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 # Start (or attach to) the Claude Code CLI devcontainer from the Mac terminal.
-# Usage: ./start.sh
+# Usage: ./start.sh [--rebuild]
 set -euo pipefail
+
+REBUILD=false
+for arg in "$@"; do
+    case "$arg" in
+        --rebuild) REBUILD=true ;;
+        *) echo "Unknown option: $arg"; exit 1 ;;
+    esac
+done
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CONTAINER_NAME="$(basename "$SCRIPT_DIR")"
@@ -14,10 +22,21 @@ if [ ! -f "$ENV_FILE" ]; then
     bash "$SCRIPT_DIR/.devcontainer/setup.sh"
 fi
 
+# --rebuild: remove existing container and image so everything is recreated fresh
+if [ "$REBUILD" = true ]; then
+    echo "Rebuilding: removing container '$CONTAINER_NAME' and image '$IMAGE_NAME'..."
+    docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+    docker rmi -f "$IMAGE_NAME" >/dev/null 2>&1 || true
+fi
+
 _exec_shell() {
     docker exec -it -u vscode -w "$WORKSPACE" \
         -e LANG=C.UTF-8 -e LC_ALL=C.UTF-8 -e TERM=xterm-256color \
         "$CONTAINER_NAME" zsh -l
+}
+
+_cleanup() {
+    docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
 }
 
 # Container already running — just attach
@@ -30,6 +49,7 @@ fi
 # Container exists but stopped — restart it
 if docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
     echo "Starting stopped container '$CONTAINER_NAME'..."
+    trap _cleanup EXIT
     docker start "$CONTAINER_NAME"
     docker exec -u vscode -w "$WORKSPACE" "$CONTAINER_NAME" \
         bash -l .devcontainer/poststart.sh
@@ -55,6 +75,17 @@ DOCKER_ARGS=(
     -w "$WORKSPACE"
 )
 
+# If this is a git worktree, the .git file points to a path on the host.
+# Mount the parent .git directory at the same absolute path inside the container
+# so git can resolve the worktree reference.
+if [ -f "$SCRIPT_DIR/.git" ]; then
+    GITDIR_REF=$(grep '^gitdir:' "$SCRIPT_DIR/.git" | sed 's/^gitdir: //')
+    PARENT_GIT=$(echo "$GITDIR_REF" | sed 's|/\.git/worktrees/.*|/.git|')
+    if [ -d "$PARENT_GIT" ]; then
+        DOCKER_ARGS+=(-v "$PARENT_GIT:$PARENT_GIT")
+    fi
+fi
+
 # Forward SSH agent if available (Docker Desktop on Mac)
 if [ -S "/run/host-services/ssh-auth.sock" ]; then
     DOCKER_ARGS+=(
@@ -64,6 +95,7 @@ if [ -S "/run/host-services/ssh-auth.sock" ]; then
 fi
 
 docker run -d "${DOCKER_ARGS[@]}" "$IMAGE_NAME" sleep infinity
+trap _cleanup EXIT
 
 echo ""
 echo "Running post-create setup (first time only)..."


### PR DESCRIPTION
## Summary

- **Git worktree support**: when `.git` is a file (worktree), mounts the parent `.git` directory into the container at its host path so git can resolve the worktree reference inside Docker.
- **Cleanup trap**: registers a `_cleanup` function via `trap EXIT` to remove the container on script exit, both for the restart-stopped and fresh-run paths.
- **`--rebuild` flag**: new CLI option that removes the existing container and image before starting, forcing a clean rebuild without manual `docker rm`/`docker rmi` steps.

## Test plan

- [ ] Run `./start.sh` from a git worktree checkout — verify git works correctly inside the container (`git status`, `git log`)
- [ ] Run `./start.sh --rebuild` — confirm old container/image are removed and a fresh build runs
- [ ] Pass an unknown flag (e.g. `./start.sh --foo`) — confirm it exits with "Unknown option" error
- [ ] Kill the script mid-run (Ctrl-C) — confirm the container is cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)