### PR TITLE
test: add ARCH-14 architecture parity and naming-ratchet tests for wire vocab objects

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1057.md
+++ b/plan/history/2607/implementation/ISSUE-1057.md
@@ -1,0 +1,17 @@
+---
+source: ISSUE-1057
+timestamp: '2026-07-06T20:14:42.635763+00:00'
+title: ARCH-14 wire vocab naming-ratchet and parity tests
+type: implementation
+---
+
+## Issue #1057 — test: add architecture parity and naming-ratchet tests for wire vocab objects (ARCH-14)
+
+Added two architecture tests to enforce ARCH-14-001 going forward:
+
+1. `test/architecture/test_wire_vocab_naming.py` — ratchet asserting no wire `vocab/objects/` class shares a bare name with a core model class. Documents 16 known pre-existing collisions in `KNOWN_VIOLATIONS`; new collisions fail immediately.
+2. `test/core/models/test_case.py::TestWireVulnerabilityCaseFieldParity` — asserts wire `VulnerabilityCase` has no fields absent from core (ARCH-09-001 superset invariant).
+
+Code review finding resolved: `assert not core_only` block dropped because ARCH-09-001 requires core >= wire (superset), not strict equality.
+
+PR: [#1220](https://github.com/CERTCC/Vultron/pull/1220)

--- a/test/architecture/test_wire_vocab_naming.py
+++ b/test/architecture/test_wire_vocab_naming.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Architecture ratchet: wire vocab/objects/ classes must not shadow core model names.
+
+All Vultron-specific wire vocabulary classes in
+``vultron/wire/as2/vocab/objects/`` MUST use the ``as_`` prefix so they
+cannot be confused with identically-named core domain models in
+``vultron/core/models/``.  The ``as_`` prefix is already established for
+base ActivityStreams types (``as_Activity``, ``as_Actor``, ``as_Object``) and
+must be extended to every Vultron-specific wire object in that package.
+
+Spec: ARCH-14-001 (``specs/architecture.yaml``).
+
+Ratchet pattern
+---------------
+``KNOWN_VIOLATIONS`` documents every pre-existing name collision awaiting
+the ``as_`` prefix migration (tracked in GitHub issue #1056).  The test
+asserts::
+
+    actual_collisions == KNOWN_VIOLATIONS
+
+This means:
+- A **new** collision (not in ``KNOWN_VIOLATIONS``) fails immediately —
+  preventing any further regression.
+- A **resolved** collision (in ``KNOWN_VIOLATIONS`` but no longer present)
+  also fails — prompting the removal of that entry from ``KNOWN_VIOLATIONS``
+  so the ratchet stays tight.
+"""
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parents[2]  # test/architecture/ → test/ → repo root
+
+_WIRE_OBJECTS = REPO_ROOT / "vultron" / "wire" / "as2" / "vocab" / "objects"
+_CORE_MODELS = REPO_ROOT / "vultron" / "core" / "models"
+
+
+def _class_names(directory: Path) -> dict[str, str]:
+    """Return {class_name: repo-relative file path} for all non-private classes."""
+    result: dict[str, str] = {}
+    for py_file in directory.rglob("*.py"):
+        if "__pycache__" in py_file.parts:
+            continue
+        tree = ast.parse(py_file.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and not node.name.startswith(
+                "_"
+            ):
+                result[node.name] = py_file.relative_to(REPO_ROOT).as_posix()
+    return result
+
+
+def _collect_collisions() -> frozenset[str]:
+    """Return the set of class names that appear in both wire and core."""
+    wire_classes = _class_names(_WIRE_OBJECTS)
+    core_classes = _class_names(_CORE_MODELS)
+    return frozenset(wire_classes.keys() & core_classes.keys())
+
+
+# ---------------------------------------------------------------------------
+# Known pre-existing name collisions awaiting the as_ prefix migration.
+#
+# Each entry is a bare class name that exists in BOTH
+#   vultron/wire/as2/vocab/objects/
+# AND
+#   vultron/core/models/
+#
+# Fix: add the as_ prefix to the wire class (ARCH-14-001).
+# Migration tracked in issue #1056.
+# ---------------------------------------------------------------------------
+KNOWN_VIOLATIONS: frozenset[str] = frozenset(
+    {
+        "CaseActor",
+        "CaseLedgerEntry",
+        "CaseParticipant",
+        "CaseReference",
+        "CaseStatus",
+        "EmbargoEvent",
+        "EmbargoPolicy",
+        "ParticipantStatus",
+        "VulnerabilityCase",
+        "VulnerabilityRecord",
+        "VulnerabilityReport",
+        "VultronApplication",
+        "VultronGroup",
+        "VultronOrganization",
+        "VultronPerson",
+        "VultronService",
+    }
+)
+
+
+def test_wire_vocab_objects_do_not_shadow_core_model_names():
+    """No class in wire/as2/vocab/objects/ may share a name with a core model class.
+
+    Enforces ARCH-14-001.  See module docstring for the ratchet strategy.
+    """
+    actual = _collect_collisions()
+    new_violations = actual - KNOWN_VIOLATIONS
+    resolved = KNOWN_VIOLATIONS - actual
+
+    diff_lines: list[str] = []
+    if new_violations:
+        diff_lines.append(
+            "NEW violations — wire vocab class shadows a core model name "
+            "(ARCH-14-001): add the as_ prefix to the wire class."
+        )
+        diff_lines.extend(f"  + {v}" for v in sorted(new_violations))
+    if resolved:
+        diff_lines.append(
+            "RESOLVED violations — remove these entries from KNOWN_VIOLATIONS "
+            "(as_ prefix migration #1056 complete for these classes):"
+        )
+        diff_lines.extend(f"  - {v}" for v in sorted(resolved))
+
+    assert actual == KNOWN_VIOLATIONS, "\n\n" + "\n".join(diff_lines)

--- a/test/core/models/test_case.py
+++ b/test/core/models/test_case.py
@@ -252,6 +252,29 @@ class TestVulnerabilityCaseRecordActivity:
         assert len(case.case_activity) == 2
 
 
+class TestWireVulnerabilityCaseFieldParity:
+    """Wire VulnerabilityCase must not have fields absent from core VulnerabilityCase.
+
+    Enforces ARCH-14-001 / ARCH-09-001: core domain models MUST be as rich as
+    or richer than wire counterparts (core >= wire).  Wire-only fields are a
+    violation; extra core-only fields are permitted and expected.
+    """
+
+    def test_wire_vulnerability_case_field_names_match_core(self):
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase as WireVC,
+        )
+
+        core_fields = set(VulnerabilityCase.model_fields.keys())
+        wire_fields = set(WireVC.model_fields.keys())
+
+        wire_only = wire_fields - core_fields
+        assert not wire_only, (
+            f"Wire VulnerabilityCase has fields not in core VulnerabilityCase "
+            f"(ARCH-09-001 violation): {sorted(wire_only)}"
+        )
+
+
 class TestVulnerabilityCaseWireRoundTrip:
     """Wire VulnerabilityCase.to_core preserves domain data."""
 


### PR DESCRIPTION
- Closes #1057

## Summary

Adds two architecture tests to prevent wire vocab naming confusion (ARCH-14-001)
from creeping back into the codebase.

## Changes

- `test/architecture/test_wire_vocab_naming.py`: New ratchet test asserting
  that no class in `vultron/wire/as2/vocab/objects/` shares a bare name with
  a class in `vultron/core/models/`. Documents 16 known pre-existing collisions
  in `KNOWN_VIOLATIONS`; any new collision fails immediately. Resolved
  collisions also fail, keeping the ratchet tight.
- `test/core/models/test_case.py`: Adds `TestWireVulnerabilityCaseFieldParity`
  asserting wire `VulnerabilityCase` has no fields absent from core
  `VulnerabilityCase` (ARCH-09-001 superset invariant: core >= wire).

## Verification

- 2 new tests pass (`test_wire_vocab_objects_do_not_shadow_core_model_names`,
  `test_wire_vulnerability_case_field_names_match_core`)
- 4386 unit tests pass, 0 new failures
- Black, flake8, mypy, pyright clean