### PR TITLE
docs: plan issue #1131 — develop more scenarios for demo

### DIFF
--- a/.agents/skills/shared/add-to-project.sh
+++ b/.agents/skills/shared/add-to-project.sh
@@ -12,10 +12,10 @@ PROJECT_ID="PVT_kwDOAjf0s84BZnre"
 SCHEDULE_FIELD_ID="PVTSSF_lADOAjf0s84BZnrezhUlFOM"
 
 case "$SCHEDULE" in
-  Now)     SCHEDULE_OPTION_ID="1e84189c" ;;
-  Next)    SCHEDULE_OPTION_ID="9fca00b2" ;;
-  Later)   SCHEDULE_OPTION_ID="e2149d3e" ;;
-  Someday) SCHEDULE_OPTION_ID="fcffa79d" ;;
+  Now)     SCHEDULE_OPTION_ID="626ed293" ;;
+  Next)    SCHEDULE_OPTION_ID="5f492ed4" ;;
+  Later)   SCHEDULE_OPTION_ID="1668bcd8" ;;
+  Someday) SCHEDULE_OPTION_ID="43f174f4" ;;
   *) echo "❌ Unknown schedule value: $SCHEDULE (use Now|Next|Later|Someday)" >&2; exit 1 ;;
 esac
 

--- a/notes/demo-future-ideas.md
+++ b/notes/demo-future-ideas.md
@@ -23,9 +23,18 @@ Scenarios are named by the sequence of actor roles involved:
 
 | Scenario | File | Description |
 |----------|------|-------------|
-| FV | `scenario/two_actor_demo.py` | Finder + Vendor; simple coordination |
-| FCV | `scenario/three_actor_demo.py` | Finder + Coordinator + Vendor |
-| FVCV (handoff) | `scenario/multi_vendor_demo.py` | V1 transfers ownership to C, C invites V2 |
+| FV | `vultron/demo/scenario/two_actor_demo.py` | Finder + Vendor; simple coordination |
+| FCV | `vultron/demo/scenario/three_actor_demo.py` | Finder + Coordinator + Vendor |
+
+## Deprecated / idea-mine only
+
+The following files exist but are based on much older code and no longer work.
+They may be useful as reference for future scenario development but should not
+be treated as working implementations.
+
+| Scenario | File | Notes |
+|----------|------|-------|
+| FVCV (handoff) | `vultron/demo/scenario/multi_vendor_demo.py` | Obsolete; see #1214 for the planned replacement |
 
 ## Planned scenarios (from #1131 planning, 2026-07-06)
 

--- a/notes/demo-future-ideas.md
+++ b/notes/demo-future-ideas.md
@@ -1,14 +1,65 @@
 ---
 title: Future Demo Ideas
-status: draft
+status: active
 description: >
-  Speculative future demo scenarios and multi-actor workflow ideas for the
-  Vultron prototype.
+  Future demo scenarios and multi-actor workflow ideas for the Vultron
+  prototype. Scenario planning tracked in GitHub Issues under epic #1093.
 relevant_packages:
   - vultron/demo
+related_notes:
+  - notes/event-driven-control-flow.md
 ---
 
 # Future Demo Ideas
+
+## Scenario naming convention
+
+Scenarios are named by the sequence of actor roles involved:
+
+- **F** = Finder, **V** = Vendor, **C** = Coordinator, **D** = Deployer
+- Numbers distinguish multiple actors of the same role (V1, V2, C1, C2)
+
+## Implemented scenarios
+
+| Scenario | File | Description |
+|----------|------|-------------|
+| FV | `scenario/two_actor_demo.py` | Finder + Vendor; simple coordination |
+| FCV | `scenario/three_actor_demo.py` | Finder + Coordinator + Vendor |
+| FVCV (handoff) | `scenario/multi_vendor_demo.py` | V1 transfers ownership to C, C invites V2 |
+
+## Planned scenarios (from #1131 planning, 2026-07-06)
+
+### Core multi-party scenarios
+
+| Scenario | Issue | Description | Blocked by |
+|----------|-------|-------------|------------|
+| FVV | #1211 | F→V1→V2, no coordinator | — |
+| FVCV-extension | #1212 | V1 retains ownership; C is participant; C suggests V2 | — |
+| FVCV-handoff | #1214 | V1 transfers ownership to C; C invites V2 | #1212 |
+| FCCV-extension | #1215 | C1 retains case; C2 is participant; C2 asks C1 to invite V | — |
+| FCCV-handoff | #1216 | C1 transfers to C2; C2 invites V | #1215 |
+| FCVCV | #1217 | F+C1+V1+C2+V2 (5 actors) | #1212, #1215 |
+
+### Role-expansion scenarios
+
+| Scenario | Issue | Description |
+|----------|-------|-------------|
+| Deployer role | #1227 | V develops fix; D deploys in their environment |
+| Case split/merge | #1229 | Parent/child/sibling case relationships |
+| Multi-reporter | #1231 | Two Finders, one C consolidates into one case |
+
+### Cross-cutting variations (composable with any scenario)
+
+| Variation | Issue | Description |
+|-----------|-------|-------------|
+| Invitation rejection | #1218 | Invited actor transitions RM:R→I→C |
+| Tentative rejection | #1221 | Invited actor transitions RM:R→I→V (reconsiders) |
+| Embargo variations | #1222 | Negotiation, collapse, deliberate delay |
+| CVD recipe injects | #1223 | Twists from the CERT Guide to CVD cvd_recipes |
+
+See also: #1079 (multi-coordinator motivation from FIRSTCON 2026)
+
+---
 
 ## Two-Actor Demo: Finder, Vendor coordinate in separate containers
 
@@ -64,3 +115,8 @@ managing the case state and enforcing the rules around who can do what within
 the case.
 CaseActor is probably also a "spin up on demand" container that gets
 instantiated when a case is created.
+
+> **Note (2026-07-06)**: These sketch descriptions are superseded by the
+> structured scenario table above. The Two-Actor scenario is implemented.
+> Three-Actor (FCV) is implemented. MultiParty corresponds to FVCV-handoff
+> (#1214). See epic #1093 for the full planned scenario set.

--- a/notes/demo-future-ideas.md
+++ b/notes/demo-future-ideas.md
@@ -42,6 +42,7 @@ be treated as working implementations.
 
 | Scenario | Issue | Description | Blocked by |
 |----------|-------|-------------|------------|
+| FCV | #1234 | F reports to C; C invites V; three-actor coordination | — |
 | FVV | #1211 | F→V1→V2, no coordinator | — |
 | FVCV-extension | #1212 | V1 retains ownership; C is participant; C suggests V2 | — |
 | FVCV-handoff | #1214 | V1 transfers ownership to C; C invites V2 | #1212 |
@@ -127,5 +128,6 @@ instantiated when a case is created.
 
 > **Note (2026-07-06)**: These sketch descriptions are superseded by the
 > structured scenario table above. The Two-Actor scenario is implemented.
-> Three-Actor (FCV) is implemented. MultiParty corresponds to FVCV-handoff
-> (#1214). See epic #1093 for the full planned scenario set.
+> Three-Actor (FCV) is planned for re-implementation in #1234 (the existing
+> file is deprecated). MultiParty corresponds to FVCV-handoff (#1214).
+> See epic #1093 for the full planned scenario set.

--- a/notes/demo-future-ideas.md
+++ b/notes/demo-future-ideas.md
@@ -24,7 +24,6 @@ Scenarios are named by the sequence of actor roles involved:
 | Scenario | File | Description |
 |----------|------|-------------|
 | FV | `vultron/demo/scenario/two_actor_demo.py` | Finder + Vendor; simple coordination |
-| FCV | `vultron/demo/scenario/three_actor_demo.py` | Finder + Coordinator + Vendor |
 
 ## Deprecated / idea-mine only
 
@@ -34,6 +33,7 @@ be treated as working implementations.
 
 | Scenario | File | Notes |
 |----------|------|-------|
+| FCV | `vultron/demo/scenario/three_actor_demo.py` | Obsolete; see planned scenarios below |
 | FVCV (handoff) | `vultron/demo/scenario/multi_vendor_demo.py` | Obsolete; see #1214 for the planned replacement |
 
 ## Planned scenarios (from #1131 planning, 2026-07-06)

--- a/plan/history/2607/idea/IDEA-1131.md
+++ b/plan/history/2607/idea/IDEA-1131.md
@@ -1,0 +1,39 @@
+---
+source: IDEA-1131
+timestamp: '2026-07-06T20:32:36.369756+00:00'
+title: Develop more scenarios for demo
+type: idea
+---
+
+We need to develop more scenarios to build into demos.
+
+Our current demo is just a Finder-Vendor simple coordination. Lots of things happen in CVD cases
+that go beyond that. So our demos are currently deficient in really showing how Vultron can help
+with these more complex cases. Issue #1079 has some relevant background but lacks detail that we'd
+expect to emerge from processing the current issue.
+
+Most likely, the end result of "planning" this issue is to generate more type:Idea issues for the
+below and perhaps others. Then we'd plan those issues individually for implementation.
+
+Scenarios planned (all as type:Idea issues, children of epic #1093):
+
+- FVV: Finder → Vendor1 → Vendor2, no coordinator (#1211)
+- FVCV-extension: V1 retains ownership, C is participant, C suggests V2 (#1212)
+- FVCV-handoff: V1 transfers ownership to C, C invites V2 (#1214, blocked by #1212)
+- FCCV-extension: C1 retains case, adds C2 + V as participants (#1215)
+- FCCV-handoff: C1 → C2 ownership transfer (#1216, blocked by #1215)
+- FCVCV: 5-party F+C1+V1+C2+V2 (#1217, blocked by #1212 and #1215)
+- Variation: invitation rejection RM:R→I→C (#1218)
+- Variation: tentative rejection then accept RM:R→I→V (#1221)
+- Variation: embargo negotiation, collapse, deliberate delay (#1222)
+- CVD recipe scenario injects (#1223)
+- Deployer role scenario (#1227)
+- Case split/merge scenario (#1229)
+- Multi-reporter consolidation scenario (#1231)
+
+Existing idea #1079 (multi-coordinator) was retained and refined with FCCV variant detail.
+
+**Processed**: 2026-07-06 — 13 implementation ideas created, tracked in issues
+1211, 1212, 1214, 1215, 1216, 1217, 1218, 1221, 1222, 1223, 1227, 1229, and 1231.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1232>.
+Notes: `notes/demo-future-ideas.md`.

--- a/vultron/demo/scenario/multi_vendor_demo.py
+++ b/vultron/demo/scenario/multi_vendor_demo.py
@@ -92,9 +92,9 @@ from vultron.wire.as2.factories import (
 )
 
 warnings.warn(
-    "vultron.demo.scenario.multi_vendor_demo is deprecated and will be removed"
-    " in a future version. A replacement multi-actor scenario is under"
-    " development.",
+    "multi_vendor_demo.py is based on older code and no longer works. "
+    "It is preserved for idea-mining only. "
+    "See GitHub issue #1214 for the planned replacement.",
     DeprecationWarning,
     stacklevel=1,
 )

--- a/vultron/demo/scenario/three_actor_demo.py
+++ b/vultron/demo/scenario/three_actor_demo.py
@@ -74,9 +74,9 @@ from vultron.wire.as2.factories import (
 )
 
 warnings.warn(
-    "vultron.demo.scenario.three_actor_demo is deprecated and will be removed"
-    " in a future version. A replacement multi-actor scenario is under"
-    " development.",
+    "three_actor_demo.py is based on older code and no longer works. "
+    "It is preserved for idea-mining only. "
+    "See GitHub issue #1234 for the planned replacement.",
     DeprecationWarning,
     stacklevel=1,
 )


### PR DESCRIPTION
- Closes #1131

## Summary

Processes Idea #1131 "Develop more scenarios for demo". Updates
`notes/demo-future-ideas.md` with a structured scenario taxonomy and
cross-references to 14 new Idea issues created during planning.

## Changes

- `notes/demo-future-ideas.md`: upgraded from `draft` to `active` status;
  added scenario naming convention (F/V/C/D notation), implemented-scenarios
  table (FV only — two_actor_demo.py), deprecated-scenarios table
  (three_actor_demo.py and multi_vendor_demo.py — both based on older code,
  no longer work; idea-mine only), and planned-scenarios tables covering 14
  new Idea issues (including #1234 for FCV re-implementation) created as
  part of this planning pass