### PR TITLE
devcontainer: add ~/.local/bin to zsh PATH for Claude Code

### DIFF
--- a/.devcontainer/postcreate.sh
+++ b/.devcontainer/postcreate.sh
@@ -54,6 +54,11 @@ if [ -f "$HOME/.zshrc" ] && ! grep -q 'HISTFILE=.*\.data' "$HOME/.zshrc" 2>/dev/
     echo 'export HISTFILE="$HOME/.data/shell-history/.zsh_history"' >> "$HOME/.zshrc"
 fi
 
+# Claude Code installs to ~/.local/bin and registers it in .bashrc, but we use zsh
+if ! grep -q 'local/bin' "$HOME/.zshrc" 2>/dev/null; then
+    echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.zshrc"
+fi
+
 # --- tmux configuration ---
 cat > "$HOME/.tmux.conf" <<'EOF'
 set -g default-terminal "tmux-256color"


### PR DESCRIPTION
## Summary

- Claude Code installs to `~/.local/bin` and registers it in `~/.bashrc`
- The container attaches via `zsh -l`, which doesn't source `.bashrc`
- Result: `claude: command not found` on first login in a new container

Adds an idempotent `PATH` export to `~/.zshrc` during `postcreate.sh` so `claude` is found immediately after first create.

## Test plan

- [ ] `docker rm -f pinky && ./start.sh` — fresh container create
- [ ] After attach, run `claude` — should launch without `command not found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)