### PR TITLE
docs: add Actuator as fifth call-out point shape (issue #1239)

### DIFF
--- a/docs/adr/0024-coordination-agent-taxonomy.md
+++ b/docs/adr/0024-coordination-agent-taxonomy.md
@@ -30,6 +30,36 @@ These are a typology, not exactly four singleton agents. A real coordination
 agent may embody one shape or combine shapes (e.g., a Participant Discovery
 agent composes Retriever + Evaluator).
 
+### Amendment (2026-07-07): Fifth canonical shape — Actuator
+
+During the FUZZ-08a-ter audit (PR #1195, issue #1239), 11 nodes classified
+as `Composer` were found not to generate content artifacts in the ADR-0024
+sense. They are **side-effect executors** — integration hooks that fire when
+a protocol state transition occurs and invoke external systems (notification
+APIs, timer services, case management writes, queue mutations). The Composer
+lifecycle (reads context → dispatches → writes artifact to blackboard) does
+not map to these nodes: there is no content artifact placed on the blackboard.
+Expanding the Composer definition to cover side-effect invocation was
+considered and rejected — it would obscure the seam and complicate the
+abstraction layer design (ADR-0025 / issue #1151), which needs an invocation
+interface for Actuators, not a content-generation interface.
+
+A fifth shape is added:
+
+| Shape | Role |
+| --- | --- |
+| **Actuator** | Receives a trigger and context; invokes an external system to cause a side effect (notification dispatch, state write, queue mutation, API call); returns SUCCESS when the side effect is confirmed, FAILURE otherwise. Does not produce a content artifact. |
+
+The updated five-shape taxonomy:
+
+| Shape | Role |
+| --- | --- |
+| **Sentinel** | Monitors a condition; when met, calls a trigger endpoint |
+| **Evaluator** | Receives a situation and options; returns a structured recommendation |
+| **Retriever** | Receives a query; returns structured facts from an external source |
+| **Composer** | Receives context; generates a new content artifact |
+| **Actuator** | Receives a trigger and context; invokes an external system to cause a side effect |
+
 ### Message-Driven Responses excluded from the taxonomy
 
 An earlier draft included "message-driven responses" as a fifth category of

--- a/notes/bt-fuzzer-nodes-embargo.md
+++ b/notes/bt-fuzzer-nodes-embargo.md
@@ -133,7 +133,7 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
   must ensure idempotent execution
 - **Automation potential**: **High** — integration hook (notifications, state updates, downstream triggers); can be fully automated via API calls to notification and case-management systems.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.OnEmbargoExit`
-- **Call-out point shape**: Composer — generates and dispatches outbound notifications, state-update calls, and downstream trigger messages when an active embargo exits; the produced artifacts are the emitted notifications and integration-hook invocations.
+- **Call-out point shape**: Actuator — fires integration hooks on embargo exit; invokes notification APIs, case-management state-write calls, and downstream trigger endpoints. There is no content artifact placed on the blackboard; the side effects in external systems are the seam.
 
 ### `StopProposingEmbargo`
 
@@ -248,7 +248,7 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Notes**: Always succeeds in simulation; must be idempotent in production
 - **Automation potential**: **High** — notification dispatch, timer initialization, and state-update actions are all integration-automatable via APIs.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.OnEmbargoAccept`
-- **Call-out point shape**: Composer — generates outbound notifications, initializes embargo timer services, and writes acceptance records to case management when an embargo proposal is accepted; the produced artifacts are the emitted stakeholder notifications and timer-service invocations.
+- **Call-out point shape**: Actuator — fires integration hooks on embargo acceptance; invokes notification APIs, embargo timer-service initialization calls, and case-management state writes. There is no content artifact placed on the blackboard; the side effects in external systems are the seam.
 
 ### `OnEmbargoReject`
 
@@ -264,7 +264,7 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Notes**: Always succeeds in simulation; must be idempotent in production
 - **Automation potential**: **High** — notification dispatch and logging actions are fully automatable via APIs.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.OnEmbargoReject`
-- **Call-out point shape**: Composer — generates outbound notifications and writes rejection-rationale records to case management when an embargo proposal is rejected; the produced artifacts are the emitted stakeholder notifications and case log entries.
+- **Call-out point shape**: Actuator — fires integration hooks on embargo rejection; invokes notification APIs and case-management state writes for the rejection rationale. There is no content artifact placed on the blackboard; the side effects in external systems are the seam.
 
 ### `CurrentEmbargoAcceptable`
 

--- a/notes/bt-fuzzer-nodes-report-management.md
+++ b/notes/bt-fuzzer-nodes-report-management.md
@@ -208,7 +208,7 @@ models the process of deciding whether to accept (engage with) or defer
 - **Notes**: Always succeeds in simulation; must be idempotent in production
 - **Automation potential**: **High** — stakeholder notifications, follow-up scheduling, and state updates are all automatable via integration APIs.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.prioritize.OnDefer`
-- **Call-out point shape**: Composer — integration hook that generates outbound notifications, schedules follow-up tasks, and writes case-status updates when a report is deferred; the produced artifacts are the emitted stakeholder notifications and workflow records.
+- **Call-out point shape**: Actuator — fires integration hooks on report deferral; invokes notification APIs, task-scheduling services, and case-management state writes. There is no content artifact placed on the blackboard; the side effects in external systems are the seam.
 
 ### `OnAccept`
 
@@ -224,7 +224,7 @@ models the process of deciding whether to accept (engage with) or defer
 - **Notes**: Always succeeds in simulation; must be idempotent in production
 - **Automation potential**: **High** — stakeholder notifications, workflow initialization, and state updates are all automatable via integration APIs.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.prioritize.OnAccept`
-- **Call-out point shape**: Composer — integration hook that generates outbound notifications, initializes the case workflow, and writes case-status updates when a report is accepted; the produced artifacts are the emitted stakeholder notifications and workflow-initialization records.
+- **Call-out point shape**: Actuator — fires integration hooks on report acceptance; invokes notification APIs, workflow-initialization services, and case-management state writes. There is no content artifact placed on the blackboard; the side effects in external systems are the seam.
 
 ---
 
@@ -1079,7 +1079,7 @@ coordinated disclosure.
 - **Notes**: Always succeeds in simulation
 - **Automation potential**: **High** — queue management operation; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.RemoveRecipient`
-- **Call-out point shape**: Composer — writes a queue-removal record to the notification queue in the case management system, dequeuing the current recipient after successful notification or after the per-recipient effort limit is exceeded; the produced artifact is the updated queue state.
+- **Call-out point shape**: Actuator — writes a queue-removal state change to the case management system, dequeuing the current recipient; the side effect in the external system is the seam, not a content artifact placed on the blackboard.
 
 ### `RecipientEffortExceeded`
 
@@ -1178,7 +1178,7 @@ coordinated disclosure.
   a state update
 - **Automation potential**: **High** — RM state write on the case participant record; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.SetRcptQrmR`
-- **Call-out point shape**: Composer — writes a recipient RM-state transition (START → RECEIVED) to the case management system, recording that the recipient has been successfully notified; the produced artifact is the updated participant state record.
+- **Call-out point shape**: Actuator — writes a recipient RM-state transition (START → RECEIVED) to the case management system; the side-effect state write is the seam, not a content artifact placed on the blackboard.
 
 ### `MoreVendors`
 
@@ -1238,10 +1238,13 @@ coordinated disclosure.
 - **Input dependency**: Case management system write; triggered after a
   recipient is successfully notified and agrees to participate
 - **Notes**: Always succeeds in simulation; base class for the three
-  role-specific inject nodes below
+  role-specific inject nodes below. In production, these simulator leaf nodes
+  would be replaced by subtrees that invoke the InviteParticipantToCase
+  protocol; the call-out point lives at the boundary with that protocol, not
+  at this leaf.
 - **Automation potential**: **High** — case management system write; fully automatable once participant details are known.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.InjectParticipant`
-- **Call-out point shape**: Composer — writes a new participant record to the case management system, registering the notified party as an active case participant; the produced artifact is the participant entry in the case data store.
+- **Call-out point shape**: Actuator — writes a new participant record to the case management system; the side-effect state write is the seam. Production replacement: InviteParticipantToCase protocol subtree (not yet implemented).
 
 ### `InjectVendor`
 
@@ -1253,10 +1256,11 @@ coordinated disclosure.
   in the coordinated disclosure case
 - **Input dependency**: Case management system write; vendor contact and
   acceptance of participation
-- **Notes**: Specialization of `InjectParticipant` for vendor role
+- **Notes**: Specialization of `InjectParticipant` for vendor role. See
+  `InjectParticipant` for production-replacement note.
 - **Automation potential**: **High** — case management system write for vendor role; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.InjectVendor`
-- **Call-out point shape**: Composer — inherits InjectParticipant; writes a vendor-role participant record to the case management system; the produced artifact is the vendor participant entry in the case data store.
+- **Call-out point shape**: Actuator — inherits InjectParticipant; writes a vendor-role participant record to the case management system; the side-effect state write is the seam. Production replacement: InviteParticipantToCase protocol subtree.
 
 ### `InjectCoordinator`
 
@@ -1268,10 +1272,11 @@ coordinated disclosure.
   participant in the coordinated disclosure case
 - **Input dependency**: Case management system write; coordinator contact
   and acceptance of participation
-- **Notes**: Specialization of `InjectParticipant` for coordinator role
+- **Notes**: Specialization of `InjectParticipant` for coordinator role. See
+  `InjectParticipant` for production-replacement note.
 - **Automation potential**: **High** — case management system write for coordinator role; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.InjectCoordinator`
-- **Call-out point shape**: Composer — inherits InjectParticipant; writes a coordinator-role participant record to the case management system; the produced artifact is the coordinator participant entry in the case data store.
+- **Call-out point shape**: Actuator — inherits InjectParticipant; writes a coordinator-role participant record to the case management system; the side-effect state write is the seam. Production replacement: InviteParticipantToCase protocol subtree.
 
 ### `InjectOther`
 
@@ -1283,10 +1288,11 @@ coordinated disclosure.
   participant in the coordinated disclosure case
 - **Input dependency**: Case management system write; stakeholder contact
   and acceptance of participation
-- **Notes**: Specialization of `InjectParticipant` for other-party role
+- **Notes**: Specialization of `InjectParticipant` for other-party role. See
+  `InjectParticipant` for production-replacement note.
 - **Automation potential**: **High** — case management system write for other-party role; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.InjectOther`
-- **Call-out point shape**: Composer — inherits InjectParticipant; writes an other-party participant record to the case management system; the produced artifact is the other-party participant entry in the case data store.
+- **Call-out point shape**: Actuator — inherits InjectParticipant; writes an other-party participant record to the case management system; the side-effect state write is the seam. Production replacement: InviteParticipantToCase protocol subtree.
 
 ---
 
@@ -1330,7 +1336,7 @@ complete (or otherwise concluded).
   multi-step pre-close workflows
 - **Automation potential**: **Medium** — archiving and standard notification steps can be automated; QA review and final approvals typically require human involvement.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.close_report.PreCloseAction`
-- **Call-out point shape**: Composer — triggers pre-close integration hooks including QA pipeline checks, final stakeholder notifications, and case archiving; the produced artifacts are the archive record, final notifications, and any required sign-off records.
+- **Call-out point shape**: Actuator — fires integration hooks before case closure; invokes QA pipeline checks, final notification APIs, and case-archiving services. There is no content artifact placed on the blackboard; the side effects in external systems are the seam.
 
 ---
 

--- a/plan/history/2607/idea/IDEA-1239.md
+++ b/plan/history/2607/idea/IDEA-1239.md
@@ -1,0 +1,15 @@
+---
+source: IDEA-1239
+timestamp: '2026-07-07T20:38:26.162700+00:00'
+title: Add Actuator as fifth call-out point shape
+type: idea
+---
+
+During the FUZZ-08a-ter audit (PR #1195), 11 nodes classified as Composer were found to be side-effect executors — integration hooks that fire when a protocol state transition occurs and invoke external systems (notification APIs, timer services, case management writes, queue mutations). Neither the Composer shape (content artifact) nor any other existing shape covered them cleanly.
+
+The design question: add a fifth shape or expand Composer?
+
+Decision: fifth shape — **Actuator**. Expanding Composer was rejected because the Composer lifecycle (reads context → dispatches → writes artifact to blackboard) does not match these nodes; there is no content artifact, and the abstraction layer (ADR-0025 / #1151) needs a distinct invocation interface, not a content-generation interface.
+
+**Processed**: 2026-07-07 — implementation tracked in #1242 (FUZZ-08h).
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1241>.

--- a/specs/behavior-tree-integration.yaml
+++ b/specs/behavior-tree-integration.yaml
@@ -606,8 +606,8 @@ groups:
       as a criterion for assigning shape = ProtocolInternal. A node whose
       automation potential is High but whose inputs arrive from an external
       source or whose outputs affect an external system is a Retriever,
-      Sentinel, Evaluator, or Composer — not ProtocolInternal — regardless of
-      how automated the implementation may be.
+      Sentinel, Evaluator, Composer, or Actuator — not ProtocolInternal —
+      regardless of how automated the implementation may be.
     rationale: >-
       Automation potential and call-out point shape are orthogonal dimensions.
       Automation potential describes whether the call-out point logic can be
@@ -619,6 +619,10 @@ groups:
       tracked in issue #1188, where ~38 nodes with High automation potential
       were incorrectly assigned ProtocolInternal shape, causing downstream
       work (FUZZ-08a-bis, FUZZ-08d through FUZZ-08g) to build wrong seams.
+      The five canonical shapes are: Sentinel, Evaluator, Retriever, Composer,
+      and Actuator (added in issue #1239). Nodes that invoke external systems
+      to cause side effects without producing a content artifact MUST be
+      classified as Actuator, not Composer.
     relationships:
     - rel_type: implements
       spec_id: BT-16-005


### PR DESCRIPTION
- Closes #1239

## Summary

Resolves the taxonomy gap identified in #1198/#1239 by adding **Actuator** as
a fifth canonical call-out point shape in ADR-0024. Actuator covers nodes that
invoke external systems to cause side effects (notification dispatch, state
writes, queue mutations, API calls) without producing a content artifact on the
blackboard — a pattern that Composer does not cleanly cover.

## Changes

- **ADR-0024** (`docs/adr/0024-coordination-agent-taxonomy.md`): Amendment
  section added documenting the Actuator shape, the rejected Composer-expansion
  alternative, and the updated five-shape taxonomy table
- **BT-18-005** (`specs/behavior-tree-integration.yaml`): Updated to name all
  five shapes and require Actuator classification for side-effect nodes
- **`notes/bt-fuzzer-nodes-embargo.md`**: `OnEmbargoExit`, `OnEmbargoAccept`,
  `OnEmbargoReject` reclassified Composer → Actuator
- **`notes/bt-fuzzer-nodes-report-management.md`**: `OnDefer`, `OnAccept`,
  `SetRcptQrmR`, `RemoveRecipient`, `PreCloseAction`, `InjectParticipant`,
  `InjectVendor`, `InjectCoordinator`, `InjectOther` reclassified
  Composer → Actuator; InjectParticipant family annotated with
  production-replacement note (InviteParticipantToCase protocol subtree,
  not yet implemented)