### PR TITLE
docs(#1240): amend ADR-0024 — boolean external queries are Retrievers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -789,7 +789,11 @@ Short entries are reproduced here; longer ones are referenced below.
   human-driven. `ProtocolInternal` is reserved exclusively for terminal
   placeholders and structural composites that have **no** external input,
   output, or monitoring seam. See `specs/behavior-tree-integration.yaml`
-  BT-18-005 and `docs/adr/0024-coordination-agent-taxonomy.md`.
+  BT-18-005 and BT-18-006 and `docs/adr/0024-coordination-agent-taxonomy.md`.
+  BT-18-006 resolves the Sentinel vs. Retriever ambiguity for synchronous
+  binary external queries: a node the BT invokes on-demand that queries an
+  external system and returns only SUCCESS/FAILURE is a Retriever, not a
+  Sentinel.
 
 ## Skill Interaction Rules
 

--- a/docs/adr/0024-coordination-agent-taxonomy.md
+++ b/docs/adr/0024-coordination-agent-taxonomy.md
@@ -23,7 +23,7 @@ call-*in* surface where external parties invoke the protocol).
 | --- | --- |
 | **Sentinel** | Monitors a condition; when met, calls a trigger endpoint |
 | **Evaluator** | Receives a situation and options; returns a structured recommendation |
-| **Retriever** | Receives a query; returns structured facts from an external source |
+| **Retriever** | Receives a query; returns structured facts from an external source (including boolean/binary results — see below) |
 | **Composer** | Receives context; generates a new content artifact |
 
 These are a typology, not exactly four singleton agents. A real coordination
@@ -56,7 +56,7 @@ The updated five-shape taxonomy:
 | --- | --- |
 | **Sentinel** | Monitors a condition; when met, calls a trigger endpoint |
 | **Evaluator** | Receives a situation and options; returns a structured recommendation |
-| **Retriever** | Receives a query; returns structured facts from an external source |
+| **Retriever** | Receives a query; returns structured facts from an external source (including boolean/binary results — see below) |
 | **Composer** | Receives context; generates a new content artifact |
 | **Actuator** | Receives a trigger and context; invokes an external system to cause a side effect |
 
@@ -75,6 +75,28 @@ sequences other agents toward a bounded goal) is unresolved. No concrete
 multi-agent sequencing requirement exists yet. The question is tracked in
 GitHub issue #1141 and will be revisited when two or more concrete agent
 instances exist and a workflow clearly needs to sequence them.
+
+### Boolean external queries are Retrievers, not Sentinels
+
+A Retriever returns structured facts from an external source in response to
+an on-demand query. A Sentinel monitors a condition over time and fires a
+trigger endpoint when that condition is met.
+
+A node that queries an external system synchronously and returns only a
+binary (yes/no) result is still a **Retriever**: a boolean is the simplest
+possible structured fact. The defining characteristic is the synchronous
+on-demand query pattern, not the richness of the returned data.
+
+Nodes such as `MitigationDeployed`, `MitigationAvailable`, and `HaveExploit`
+fit the Retriever shape: they receive a query (implicitly, "is X the case?"),
+call an external system to retrieve the current status, and return
+SUCCESS/FAILURE based on that status. They do not monitor continuously or fire
+a trigger — they answer a point-in-time question when the BT reaches them.
+
+A **Sentinel**, by contrast, runs continuously (or is invoked by an external
+event) and calls a *trigger endpoint* when a condition becomes true. The
+flow direction is reversed: Sentinel → trigger endpoint → protocol, not
+protocol → query → external system.
 
 ### "Retriever" over "Data Retriever"
 

--- a/notes/bt-fuzzer-nodes-report-management.md
+++ b/notes/bt-fuzzer-nodes-report-management.md
@@ -249,7 +249,7 @@ to a validated report.
   the main workflow; in production this is a simple metadata check
 - **Automation potential**: **High** — simple query against case metadata or a vulnerability registry; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.assign_vul_id.IdAssigned`
-- **Call-out point shape**: Sentinel — binary status check against case metadata or an external vulnerability registry; returns SUCCESS if an identifier has already been assigned to this vulnerability, FAILURE otherwise, with no output keys.
+- **Call-out point shape**: Retriever — synchronous on-demand query to case metadata or an external vulnerability registry (e.g., CVE database); returns SUCCESS if an identifier has already been assigned to this vulnerability, FAILURE otherwise. A boolean is the simplest structured fact (ADR-0024); the on-demand query pattern makes this a Retriever, not a Sentinel (see BT-18-006).
 
 ### `InScope`
 
@@ -414,7 +414,7 @@ the process of deploying a developed fix or mitigation to affected systems.
   deployment is modeled as the active goal
 - **Automation potential**: **High** — query to patch management system or case-state flag; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.deploy_fix.MitigationDeployed`
-- **Call-out point shape**: Sentinel — binary status query against an asset/patch management system or case-state flag; returns SUCCESS if a mitigation has been deployed, FAILURE otherwise, with no output keys.
+- **Call-out point shape**: Retriever — synchronous on-demand query to an asset/patch management system or case-state flag; returns SUCCESS if a mitigation has been deployed, FAILURE otherwise. A boolean is the simplest structured fact (ADR-0024); the on-demand query pattern makes this a Retriever, not a Sentinel.
 
 ### `MitigationAvailable`
 
@@ -430,7 +430,7 @@ the process of deploying a developed fix or mitigation to affected systems.
   development cycle has progressed
 - **Automation potential**: **High** — patch or advisory feed query; fully automatable once the feed integration is in place.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.deploy_fix.MitigationAvailable`
-- **Call-out point shape**: Sentinel — binary availability query against a patch/advisory feed or internal mitigation catalog; returns SUCCESS if a mitigation is currently available, FAILURE otherwise, with no output keys.
+- **Call-out point shape**: Retriever — synchronous on-demand query to a patch/advisory feed or internal mitigation catalog; returns SUCCESS if a mitigation is currently available, FAILURE otherwise. A boolean is the simplest structured fact (ADR-0024); the on-demand query pattern makes this a Retriever, not a Sentinel.
 
 ### `DeployMitigation`
 
@@ -519,7 +519,7 @@ vulnerability, typically to support impact assessment or testing.
   modeled goal
 - **Automation potential**: **High** — query against an internal exploit repository or threat-intelligence platform; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.acquire_exploit.HaveExploit`
-- **Call-out point shape**: Sentinel — binary query against an internal exploit repository or threat-intelligence platform; returns SUCCESS if a working exploit is already available for this vulnerability, FAILURE otherwise, with no output keys.
+- **Call-out point shape**: Retriever — synchronous on-demand query to an internal exploit repository or threat-intelligence platform; returns SUCCESS if a working exploit is already available for this vulnerability, FAILURE otherwise. A boolean is the simplest structured fact (ADR-0024); the on-demand query pattern makes this a Retriever, not a Sentinel.
 
 ### `ExploitPrioritySet`
 
@@ -660,7 +660,7 @@ exploited in the wild. Threat detection can trigger embargo termination via
   in-the-wild attacks during active coordination
 - **Automation potential**: **High** — SIEM queries, IDS/IPS alert feeds, and threat-intelligence platform APIs can fully automate in-the-wild attack detection.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.monitor_threats.MonitorAttacks`
-- **Call-out point shape**: Sentinel
+- **Call-out point shape**: Retriever — synchronous per-tick query to threat-intelligence feeds or SIEM/IDS telemetry; returns SUCCESS if active attacks are detected, FAILURE otherwise. The BT invokes this node on-demand each tick; it does not run independently or fire a trigger endpoint (see BT-18-006).
 
 ### `MonitorExploits`
 
@@ -678,7 +678,7 @@ exploited in the wild. Threat detection can trigger embargo termination via
   disclosure, not during the coordination phase
 - **Automation potential**: **High** — exploit database feeds, CVE enrichment APIs, and threat-intel platforms can fully automate exploit publication monitoring.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.monitor_threats.MonitorExploits`
-- **Call-out point shape**: Sentinel
+- **Call-out point shape**: Retriever — synchronous per-tick query to exploit database feeds or threat-intelligence platforms; returns SUCCESS if a newly published exploit is found, FAILURE otherwise. The BT invokes this node on-demand each tick; it does not run independently or fire a trigger endpoint (see BT-18-006).
 
 ### `MonitorPublicReports`
 
@@ -696,7 +696,7 @@ exploited in the wild. Threat detection can trigger embargo termination via
   confirmed attacks
 - **Automation potential**: **High** — RSS/news feed monitoring, OSINT tools, and social-media tracking APIs can automate public disclosure detection with high coverage.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.monitor_threats.MonitorPublicReports`
-- **Call-out point shape**: Sentinel
+- **Call-out point shape**: Retriever — synchronous per-tick query to OSINT feeds, news/RSS sources, or social-media tracking APIs; returns SUCCESS if public disclosure evidence is found, FAILURE otherwise. The BT invokes this node on-demand each tick; it does not run independently or fire a trigger endpoint (see BT-18-006).
 
 ### `NoThreatsFound`
 

--- a/notes/bt-fuzzer-nodes.md
+++ b/notes/bt-fuzzer-nodes.md
@@ -68,7 +68,8 @@ Each fuzzer node entry in the sub-files has these fields:
   nodes that are terminal placeholders or structural composites with no
   external input or output seam. See BT-18-005: shape MUST be determined
   by the ADR-0024 seam-structure decision tree, independently of automation
-  potential.
+  potential. See BT-18-006: synchronous binary external queries are
+  Retrievers, not Sentinels.
 - **Factory-fn placement**: The module-qualified `vultron.core.behaviors.*`
   factory function that hosts (or should host) this call-out point node in
   the prototype BT, with ordering hints indicating where in the tree the node
@@ -96,7 +97,9 @@ Each fuzzer node entry in the sub-files has these fields:
 - **Evaluator** — reads situation context; writes a structured
   recommendation; `SUCCESS` = recommendation available
 - **Retriever** — reads a query; writes structured facts from an external
-  source; `SUCCESS` = facts retrieved
+  source; `SUCCESS` = facts retrieved. For binary-result Retrievers (boolean
+  queries), the fact is expressed as `SUCCESS`/`FAILURE` with an empty
+  blackboard output-key set (see BT-18-006)
 - **Composer** — reads composition context; writes a generated artifact;
   `SUCCESS` = artifact ready
 - **ProtocolInternal** — node resolves entirely within the protocol

--- a/plan/history/2607/implementation/ISSUE-1240.md
+++ b/plan/history/2607/implementation/ISSUE-1240.md
@@ -1,0 +1,10 @@
+---
+source: ISSUE-1240
+timestamp: '2026-07-07T20:51:33.044789+00:00'
+title: 'FUZZ-08: Clarify ADR-0024 boolean queries as Retriever'
+type: implementation
+---
+
+## Issue #1240 — FUZZ-08: Clarify ADR-0024 — boolean external queries fit under Retriever
+
+Amended ADR-0024 and added BT-18-006 spec to resolve the Sentinel vs. Retriever ambiguity for synchronous binary external queries. Reclassified 7 nodes: MitigationDeployed, MitigationAvailable, HaveExploit, IdAssigned, MonitorAttacks, MonitorExploits, MonitorPublicReports. PR: <https://github.com/CERTCC/Vultron/pull/1243>

--- a/specs/behavior-tree-integration.yaml
+++ b/specs/behavior-tree-integration.yaml
@@ -630,6 +630,39 @@ groups:
         BT-16-005 defines automation potential categories; BT-18-005 clarifies
         that those categories govern the automation-potential field only and
         have no bearing on call-out point shape assignment.
+  - id: BT-18-006
+    priority: MUST
+    statement: >-
+      A node that queries an external system synchronously and returns only a
+      binary (SUCCESS/FAILURE) result MUST be classified as a Retriever, not
+      a Sentinel. A boolean is the simplest possible structured fact; the
+      defining criterion for Retriever shape is the synchronous on-demand query
+      pattern, not the richness of the returned data. Such a binary-result
+      Retriever has an empty blackboard output-key set: the structured fact is
+      expressed as the BT return value (SUCCESS/FAILURE), not as a blackboard
+      write. BT-18-001 through BT-18-003 apply: the empty output-key set MUST
+      be declared in the node docstring. A Sentinel, by contrast, monitors a
+      condition continuously (or is triggered by an external event) and calls a
+      trigger endpoint when the condition becomes true; the flow direction is
+      Sentinel → trigger endpoint → protocol, not protocol → query →
+      external system.
+    rationale: >-
+      The Sentinel vs. Retriever ambiguity surfaced with nodes such as
+      MitigationDeployed, MitigationAvailable, and HaveExploit (issue #1240).
+      These nodes appear sentinel-like because they return only SUCCESS/FAILURE,
+      but they are invoked synchronously by the BT (on-demand) and query an
+      external system to determine the current status. That is the Retriever
+      pattern. A true Sentinel is not invoked by the BT; it runs independently
+      and calls a trigger endpoint when a condition fires. Clarifying this
+      distinction prevents future misclassification of on-demand binary-query
+      nodes as Sentinels.
+    relationships:
+    - rel_type: refines
+      spec_id: BT-18-005
+      note: >-
+        BT-18-005 establishes that shape is determined by the seam-structure
+        decision tree; BT-18-006 resolves the specific Sentinel vs. Retriever
+        ambiguity for binary-result external queries.
 - id: BT-19
   title: Routing-Gated State Mutation in Lifecycle BT Sequences
   kind: pattern


### PR DESCRIPTION
- Closes #1240

## Summary

Resolves the Sentinel vs. Retriever ambiguity for synchronous binary external
queries. A node the BT invokes on-demand that queries an external system and
returns only SUCCESS/FAILURE is a Retriever (boolean = simplest structured fact),
not a Sentinel (which monitors continuously and fires a trigger endpoint).

## Changes

- `specs/behavior-tree-integration.yaml`: add BT-18-006 (MUST rule) clarifying
  binary-query Retrievers; specifies empty blackboard output-key set (fact
  expressed as BT return value)
- `docs/adr/0024-coordination-agent-taxonomy.md`: add "Boolean external queries
  are Retrievers, not Sentinels" section; update both the four-shape and
  five-shape taxonomy tables to note boolean results qualify as Retriever
- `notes/bt-fuzzer-nodes-report-management.md`: reclassify 7 nodes from
  Sentinel → Retriever: `MitigationDeployed`, `MitigationAvailable`,
  `HaveExploit`, `IdAssigned`, `MonitorAttacks`, `MonitorExploits`,
  `MonitorPublicReports`
- `notes/bt-fuzzer-nodes.md`: update Retriever shape definition to document
  binary-result/empty-output-key variant; add BT-18-006 cross-reference
- `AGENTS.md`: update pitfall entry to reference BT-18-006 for
  Sentinel-vs-Retriever tie-breaker

## Verification

- All 4386 unit tests pass (0 new — docs-only change)
- markdownlint: 0 errors
- spec-dump parses BT-18-006 correctly
- pre-commit hooks: all pass