### PR TITLE
feat: add CVE_NUMBERING_AUTHORITY to CVDRole enum

### DIFF
--- a/notes/bt-fuzzer-nodes-report-management.md
+++ b/notes/bt-fuzzer-nodes-report-management.md
@@ -277,12 +277,17 @@ to a validated report.
   itself an ID assignment authority (e.g., a CVE CNA) able to assign
   IDs directly
 - **Input dependency**: Organizational metadata / role configuration;
-  fully automatable as a static capability check
+  fully automatable as a static capability check.  Driven by
+  `CVDRole.CVE_NUMBERING_AUTHORITY` on the participant's `case_roles`
+  list — if the participant holds this role, the check succeeds.
 - **Notes**: In production this is a static configuration check, not a
-  runtime decision
+  runtime decision.  Multiple participants in the same case may
+  independently hold `CVDRole.CVE_NUMBERING_AUTHORITY` (e.g., a vendor
+  CNA and a coordinator CNA); each evaluates this node independently in
+  their own BT context.
 - **Automation potential**: **High** — static organizational configuration; can be fully automated as a capability metadata lookup.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.assign_vul_id.IsIDAssignmentAuthority`
-- **Call-out point shape**: Sentinel — binary organizational capability check against static participant metadata; returns SUCCESS if this participant holds ID-assignment authority, FAILURE otherwise, with no output keys.
+- **Call-out point shape**: Retriever — synchronous on-demand query to the participant's static role metadata; returns SUCCESS if this participant holds `CVDRole.CVE_NUMBERING_AUTHORITY` in their `case_roles`, FAILURE otherwise. A boolean is the simplest structured fact (ADR-0024); the on-demand query pattern makes this a Retriever, not a Sentinel (see BT-18-006).
 
 ### `IdAssignable`
 
@@ -294,12 +299,22 @@ to a validated report.
   authority to assign an ID to this specific vulnerability (e.g., is the
   authoritative CNA for the affected product)
 - **Input dependency**: CNA rules lookup, product-to-CNA mapping, or
-  human analyst determination
-- **Notes**: A participant may be an ID authority generally but not the
-  authoritative CNA for this specific product
+  human analyst determination.  Requires that the participant holds
+  `CVDRole.CVE_NUMBERING_AUTHORITY` (necessary precondition, evaluated
+  by `IsIDAssignmentAuthority`); this node then evaluates the CNA's
+  scope rules against the specific vulnerability's affected product/
+  component to determine whether assignment authority applies here.
+- **Notes**: A participant may be an ID authority generally (holds
+  `CVDRole.CVE_NUMBERING_AUTHORITY`) but not the authoritative CNA for
+  this specific product.  The two checks are separate and sequential:
+  `IsIDAssignmentAuthority` first, `IdAssignable` second.
 - **Automation potential**: **High** — CNA-scope and product-to-CNA mapping checks are automatable via the CVE Services API or a local policy registry.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.assign_vul_id.IdAssignable`
-- **Call-out point shape**: Evaluator — evaluates whether this CNA has assignment authority for this specific vulnerability by matching vulnerability attributes against CNA scope rules and product-to-CNA mappings; a scope-matching evaluation, not a binary condition monitor.
+- **Call-out point shape**: Evaluator — evaluates whether this CNA
+  (`CVDRole.CVE_NUMBERING_AUTHORITY` participant) has assignment
+  authority for this specific vulnerability by matching vulnerability
+  attributes against CNA scope rules and product-to-CNA mappings;
+  a scope-matching evaluation, not a binary condition monitor.
 
 ### `RequestId`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ target-version = ['py38', 'py39', 'py310', 'py311', 'py312', 'py313' ]
 
 [tool.pytest.ini_options]
 minversion = "6.0"
+pythonpath = ["."]
 # Default run excludes integration tests (demo suite) so the fast unit-test
 # suite stays under ~1 minute.  To run integration tests use one of:
 #

--- a/specs/behavior-tree-node-design.yaml
+++ b/specs/behavior-tree-node-design.yaml
@@ -165,6 +165,23 @@ groups:
     rationale: >-
       Alias names carry the old "finder-specific" framing and mislead readers about the node's
       actual generality.
+  - id: BTND-05-004
+    priority: MUST
+    statement: >-
+      The `CVDRole` enum MUST include a `CVE_NUMBERING_AUTHORITY` value representing a
+      participant that holds CVE Numbering Authority (CNA) status.
+    rationale: >-
+      Multiple participants in an MPCVD case may independently be CNAs (e.g., a vendor CNA and
+      a coordinator CNA). The `IsIDAssignmentAuthority` BT node checks whether a participant
+      holds this role as a static capability check; `IdAssignable` evaluates whether the CNA's
+      scope rules cover the specific vulnerability. Without a `CVE_NUMBERING_AUTHORITY` role in
+      `CVDRole`, the protocol has no way to represent CNA status, route ID-assignment decision
+      nodes to the correct participant(s), or distinguish CNA participants from non-CNA
+      participants in case actor lists. `CVE_NUMBERING_AUTHORITY` is orthogonal to all other
+      CVD roles — a VENDOR, COORDINATOR, or any participant may independently hold it.
+    relationships:
+    - rel_type: refines
+      spec_id: BTND-05-001
 - id: BTND-06
   title: Idiomatic BT Construction Patterns
   kind: language

--- a/test/core/models/test_case_participant.py
+++ b/test/core/models/test_case_participant.py
@@ -16,7 +16,7 @@ from vultron.core.models.case_participant import (
 )
 from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.states.rm import RM
-from vultron.core.states.roles import CVDRole
+from vultron.core.states.roles import CVDRole, validate_roles
 
 _ACTOR = "https://example.org/actors/alice"
 _CONTEXT = "https://example.org/cases/case-001"
@@ -271,3 +271,60 @@ class TestAcceptedStatusOnReporterSubclasses:
         p = cls(attributed_to=_ACTOR, context=_CONTEXT)
         assert p.participant_status is not None
         assert p.participant_status.rm_state == RM.START
+
+
+# ---------------------------------------------------------------------------
+# CVE_NUMBERING_AUTHORITY role on participants
+# ---------------------------------------------------------------------------
+
+
+class TestCNARoleOnParticipant:
+    """CVE_NUMBERING_AUTHORITY is recognised in participant role lookups."""
+
+    def test_cna_role_recognized_via_add_role(self):
+        """add_role(CVE_NUMBERING_AUTHORITY) stores the role correctly."""
+        p = _make()
+        p.add_role(CVDRole.CVE_NUMBERING_AUTHORITY)
+        assert CVDRole.CVE_NUMBERING_AUTHORITY in p.case_roles
+
+    def test_has_role_returns_true_for_cna(self):
+        """has_role() returns True when CVE_NUMBERING_AUTHORITY is held."""
+        p = _make(case_roles=[CVDRole.CVE_NUMBERING_AUTHORITY])
+        assert p.has_role(CVDRole.CVE_NUMBERING_AUTHORITY)
+
+    def test_has_role_returns_false_without_cna(self):
+        """has_role() returns False when CVE_NUMBERING_AUTHORITY is not held."""
+        p = _make(case_roles=[CVDRole.VENDOR])
+        assert not p.has_role(CVDRole.CVE_NUMBERING_AUTHORITY)
+
+    def test_cna_role_orthogonal_to_vendor(self):
+        """A participant may hold both CVE_NUMBERING_AUTHORITY and VENDOR."""
+        p = _make(case_roles=[CVDRole.VENDOR, CVDRole.CVE_NUMBERING_AUTHORITY])
+        assert p.has_role(CVDRole.VENDOR)
+        assert p.has_role(CVDRole.CVE_NUMBERING_AUTHORITY)
+
+    def test_cna_role_orthogonal_to_coordinator(self):
+        """A participant may hold both CVE_NUMBERING_AUTHORITY and COORDINATOR."""
+        p = _make(
+            case_roles=[CVDRole.COORDINATOR, CVDRole.CVE_NUMBERING_AUTHORITY]
+        )
+        assert p.has_role(CVDRole.COORDINATOR)
+        assert p.has_role(CVDRole.CVE_NUMBERING_AUTHORITY)
+
+    def test_cna_role_roundtrips_via_serialization(self):
+        """CVE_NUMBERING_AUTHORITY survives a serialize_roles → validate_roles roundtrip."""
+        from vultron.core.states.roles import serialize_roles
+
+        roles = [CVDRole.VENDOR, CVDRole.CVE_NUMBERING_AUTHORITY]
+        serialized = serialize_roles(roles)
+        assert "cve_numbering_authority" in serialized
+        restored = validate_roles(serialized)
+        assert CVDRole.CVE_NUMBERING_AUTHORITY in restored
+
+    def test_cna_role_persists_in_participant_status(self):
+        """CVE_NUMBERING_AUTHORITY assigned to participant is stored in its status.cvd_role."""
+        p = _make(case_roles=[CVDRole.CVE_NUMBERING_AUTHORITY])
+        p.participant_statuses[0].cvd_role = p.case_roles
+        status = p.participant_status
+        assert status is not None
+        assert CVDRole.CVE_NUMBERING_AUTHORITY in status.cvd_role

--- a/test/core/states/test_cvd_roles.py
+++ b/test/core/states/test_cvd_roles.py
@@ -42,6 +42,7 @@ def test_atomic_roles_exist():
         "OTHER",
         "CASE_OWNER",
         "CASE_MANAGER",
+        "CVE_NUMBERING_AUTHORITY",
     }
     actual = {m.name for m in CVDRole}
     assert expected == actual
@@ -51,6 +52,41 @@ def test_case_owner_exists():
     """CVDRole.CASE_OWNER must exist (BTND-05-001)."""
     assert hasattr(CVDRole, "CASE_OWNER")
     assert CVDRole.CASE_OWNER in CVDRole
+
+
+def test_cve_numbering_authority_exists():
+    """CVDRole.CVE_NUMBERING_AUTHORITY must exist."""
+    assert hasattr(CVDRole, "CVE_NUMBERING_AUTHORITY")
+    assert CVDRole.CVE_NUMBERING_AUTHORITY in CVDRole
+
+
+def test_cve_numbering_authority_value():
+    """CVE_NUMBERING_AUTHORITY value is the expected lowercase string."""
+    assert CVDRole.CVE_NUMBERING_AUTHORITY == "cve_numbering_authority"
+
+
+def test_cve_numbering_authority_lookup():
+    """CVE_NUMBERING_AUTHORITY can be looked up by value and name."""
+    assert (
+        CVDRole("cve_numbering_authority") is CVDRole.CVE_NUMBERING_AUTHORITY
+    )
+    assert (
+        CVDRole["CVE_NUMBERING_AUTHORITY"] is CVDRole.CVE_NUMBERING_AUTHORITY
+    )
+
+
+def test_cna_role_is_orthogonal_to_vendor():
+    """A participant may hold both CVE_NUMBERING_AUTHORITY and VENDOR simultaneously."""
+    roles = [CVDRole.VENDOR, CVDRole.CVE_NUMBERING_AUTHORITY]
+    assert CVDRole.VENDOR in roles
+    assert CVDRole.CVE_NUMBERING_AUTHORITY in roles
+
+
+def test_cna_role_is_orthogonal_to_coordinator():
+    """A participant may hold both CVE_NUMBERING_AUTHORITY and COORDINATOR simultaneously."""
+    roles = [CVDRole.COORDINATOR, CVDRole.CVE_NUMBERING_AUTHORITY]
+    assert CVDRole.COORDINATOR in roles
+    assert CVDRole.CVE_NUMBERING_AUTHORITY in roles
 
 
 def test_values_are_lowercase():

--- a/vultron/core/states/roles.py
+++ b/vultron/core/states/roles.py
@@ -38,6 +38,13 @@ class CVDRole(StrEnum):
             owner.  A CaseManager participant always also holds the COORDINATOR
             role (CBT-01-003).  While the demo uses a Service actor type, any
             Actor type (e.g. Person) may hold this role.
+        CVE_NUMBERING_AUTHORITY: Participant that holds CVE Numbering Authority
+            (CNA) status, granting authority to assign CVE IDs.  A CNA is
+            orthogonal to other CVD roles — a VENDOR, COORDINATOR, or any other
+            participant may independently hold this role.  Used by
+            ``IsIDAssignmentAuthority`` (static capability check) and
+            ``IdAssignable`` (scope-match evaluation) BT nodes to route ID
+            assignment decisions to the correct participant(s).
     """
 
     FINDER = auto()
@@ -48,6 +55,7 @@ class CVDRole(StrEnum):
     OTHER = auto()
     CASE_OWNER = auto()
     CASE_MANAGER = auto()
+    CVE_NUMBERING_AUTHORITY = auto()
 
 
 def serialize_roles(roles: list[CVDRole]) -> list[str]:


### PR DESCRIPTION
- Closes #1201

## Summary

Adds `CVDRole.CVE_NUMBERING_AUTHORITY` as a 9th atomic role representing a participant that holds CVE Numbering Authority (CNA) status. The role is orthogonal to all other CVD roles — a VENDOR, COORDINATOR, or any participant may independently hold it. This enables `IsIDAssignmentAuthority` and `IdAssignable` BT nodes to route ID-assignment decisions to the correct participant(s).

**Shape fix**: `IsIDAssignmentAuthority` call-out shape reclassified Sentinel → Retriever per BT-18-006 (landed in #1243 after this branch was cut): a synchronous on-demand binary query to static role metadata is a Retriever, not a Sentinel.

## Changes

- `vultron/core/states/roles.py`: adds `CVE_NUMBERING_AUTHORITY = auto()` with docstring documenting the role's orthogonality and its relationship to the ID-assignment BT nodes
- `specs/behavior-tree-node-design.yaml`: adds BTND-05-004 (MUST) formalising the new role requirement with rationale and relationship to BTND-05-001
- `notes/bt-fuzzer-nodes-report-management.md`: updates `IsIDAssignmentAuthority` (Sentinel → Retriever per BT-18-006) and `IdAssignable` catalog entries to reference `CVDRole.CVE_NUMBERING_AUTHORITY`
- `test/core/states/test_cvd_roles.py`: 6 new tests — existence, value, lookup by value/name, and orthogonality
- `test/core/models/test_case_participant.py`: `TestCNARoleOnParticipant` (7 tests) — `add_role`, `has_role`, serialize/validate roundtrip, and `status.cvd_role` persistence
- `pyproject.toml`: adds `pythonpath = ["."]` to pytest ini options so the workspace package takes precedence over any stale `/app` install in the devcontainer

## Verification

- 4398 unit tests pass (13 new), 0 failures
- Black, flake8, mypy, pyright all clean
- Pre-commit hooks pass (black, markdownlint-cli2, flake8, spec-lint)