### PR TITLE
feat: add AS2JSONResponse for AS2 endpoints (HTTP-09-002, HTTP-09-003)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: black
         language_version: py313
-        args: ["."]
+        args: ["--check", "."]
 
   - repo: local
     hooks:
@@ -13,7 +13,7 @@ repos:
         entry: markdownlint-cli2
         # Use the system language so pre-commit resolves the executable via PATH
         language: system
-        args: ["--fix", "--config", ".markdownlint-cli2.yaml", "**/*.md"]
+        args: ["--config", ".markdownlint-cli2.yaml", "**/*.md"]
         files: \.(md|markdown)$
 
       - id: validate-notes-frontmatter

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -777,6 +777,11 @@ Short entries are reproduced here; longer ones are referenced below.
   drift back to the unsafe ordering. See `specs/behavior-tree-integration.yaml`
   BT-19-001, BT-19-002 and [notes/bt-integration.md](notes/bt-integration.md)
   § "Routing-Gated State Mutation".
+- **`SKIP=black` Required When Rebasing in Any `vultron_*` Worktree** — The
+  pre-commit hook runs `black` in-place during cherry-pick, leaving a dirty
+  working tree that blocks `git rebase origin/main` with "Your local changes
+  would be overwritten." Fix: `SKIP=black git rebase origin/main`. Black is
+  still enforced at commit time and CI — nothing is bypassed.
 - **Automation Potential and Call-Out Point Shape Are Orthogonal** — When
   classifying a fuzzer node, the `automation potential` and `call-out point
   shape` fields are **independent**. A node with High automation potential may

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,8 +236,10 @@ creates a new entry file under `plan/history/YYMM/<type>/` — stage it with
 **gitignored**; do **not** stage it. Omitting the entry file is the most
 common cause of history files being left out of PRs.
 
-See each skill's SKILL.md for the exact commands. If the pre-commit hook
-reformats files: `git add -A && git commit -m "Same message"`.
+See each skill's SKILL.md for the exact commands. Pre-commit hooks are
+fail-only (no auto-fix); if a hook fails, run the relevant skill
+(`format-code` for black/markdown, `run-linters` for flake8) to fix and
+re-stage before committing.
 
 **After a PR merges**, if working in a named worktree slot, reset the slot
 so it is ready for the next task:
@@ -777,11 +779,11 @@ Short entries are reproduced here; longer ones are referenced below.
   drift back to the unsafe ordering. See `specs/behavior-tree-integration.yaml`
   BT-19-001, BT-19-002 and [notes/bt-integration.md](notes/bt-integration.md)
   § "Routing-Gated State Mutation".
-- **`SKIP=black` Required When Rebasing in Any `vultron_*` Worktree** — The
-  pre-commit hook runs `black` in-place during cherry-pick, leaving a dirty
-  working tree that blocks `git rebase origin/main` with "Your local changes
-  would be overwritten." Fix: `SKIP=black git rebase origin/main`. Black is
-  still enforced at commit time and CI — nothing is bypassed.
+- **Pre-commit Hooks Are Fail-Only — Run Skills Before Committing** — The
+  `black` and `markdownlint-cli2` hooks use `--check` (no auto-fix). If a
+  hook fails at commit time, run `format-code` to auto-fix, re-stage, then
+  commit. Hooks that auto-modify files break `git rebase` by leaving a dirty
+  working tree mid-cherry-pick.
 - **Automation Potential and Call-Out Point Shape Are Orthogonal** — When
   classifying a fuzzer node, the `automation potential` and `call-out point
   shape` fields are **independent**. A node with High automation potential may

--- a/notes/codebase-structure.md
+++ b/notes/codebase-structure.md
@@ -525,13 +525,23 @@ def get_object_by_key():  # or use Union types for specific subclasses
 add more. FastAPI's `response_model` filtering excludes fields not in the base
 class model.
 
-**Solution**: Remove return type annotations from endpoints that return multiple
-types, or use explicit `Union[Type1, Type2, ...]` if types are known.
+**Solution**:
+
+- *For AS2 endpoints*: Return `AS2JSONResponse(obj)` instead of a plain model
+  instance. `AS2JSONResponse` calls `model_dump(mode="json", by_alias=True,
+  exclude_none=True)` and sets `Content-Type: application/activity+json`,
+  bypassing FastAPI's `response_model` filtering entirely. This is the canonical
+  fix for AS2-typed routes (see `specs/http-protocol.yaml` HTTP-09-002,
+  HTTP-09-003).
+- *For non-AS2 endpoints*: Remove return type annotations from endpoints that
+  return multiple types, or use explicit `Union[Type1, Type2, ...]` if types are
+  known. Do **not** apply `AS2JSONResponse` to generic/non-AS2 routes.
 
 **Verification**: Test API serialization completeness, not just database
 storage. Check that all expected fields appear in JSON responses.
 
-See `specs/http-protocol.yaml` HTTP-08-001 for guidance.
+See `specs/http-protocol.yaml` HTTP-08-001 (root cause) and HTTP-09-002,
+HTTP-09-003 (AS2 endpoint fix).
 
 ### Health Check Readiness Gap
 

--- a/plan/history/2607/implementation/ISSUE-1061.md
+++ b/plan/history/2607/implementation/ISSUE-1061.md
@@ -1,0 +1,33 @@
+---
+source: ISSUE-1061
+timestamp: '2026-07-08T15:07:37.648921+00:00'
+title: Add AS2JSONResponse for AS2 endpoints
+type: implementation
+---
+
+## Issue #1061 — Add AS2JSONResponse for AS2 endpoints
+
+Implemented `AS2JSONResponse`, a canonical FastAPI `JSONResponse` subclass that
+sets `Content-Type: application/activity+json` and serializes `as_Base` instances
+with `model_dump(mode="json", by_alias=True, exclude_none=True)`.
+
+### Changes
+
+- Added `vultron/adapters/driving/fastapi/responses.py` with `AS2JSONResponse`
+  and `AS2_CONTENT_TYPE` constant (HTTP-09-002, HTTP-09-003).
+- Migrated `actors/_routes.py` (`get_actors`, `create_actor`, `get_actor_profile`,
+  `get_actor`) to return `AS2JSONResponse`. Fixed missing `mode="json"` in
+  `get_actor_profile` that would have crashed on datetime fields.
+- Migrated `datalayer.py` (`get_datalayer_contents`, `get_actors`) to return
+  `AS2JSONResponse`. Fixed missing `mode="json"` in `get_datalayer_contents`.
+- Migrated all 22 routes in `examples.py` to return `AS2JSONResponse`;
+  removed `response_model_exclude_none=True` (now handled inside the class).
+- Added 7 unit tests: content-type, camelCase serialization, subclass field
+  retention (HTTP-08-001 regression), exclude_none, non-AS2 passthrough,
+  default and override status codes.
+
+### Outcome
+
+4393 unit tests pass (7 new). Black, flake8, mypy, pyright clean.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1258>

--- a/plan/incoming/learnings/20260708-rebase-black-hook-workaround.md
+++ b/plan/incoming/learnings/20260708-rebase-black-hook-workaround.md
@@ -1,0 +1,28 @@
+---
+title: "SKIP=black needed when rebasing in any vultron_* worktree"
+type: learning
+timestamp: 2026-07-08
+source: ISSUE-1061
+---
+
+When rebasing in any `vultron_*` git worktree, the pre-commit hook runs
+`black` in-place during cherry-pick. Black reformats files after git applies
+the patch but before the cherry-pick completes, leaving a dirty working tree
+that blocks the merge step with "Your local changes to the following files
+would be overwritten."
+
+**Fix**: `SKIP=black git rebase origin/main`
+
+This skips only the black hook for that rebase; black is already enforced at
+commit time and CI, so nothing is bypassed.
+
+**Why it happens**: The `.git/hooks/pre-commit` points to a Python
+interpreter in a sibling worktree's `.venv`, which runs `pre-commit` against
+the current working tree. During rebase cherry-pick, git applies changes then
+runs hooks — if black reformats any of those files, git sees them as newly
+modified and refuses to continue.
+
+**Scope**: Only affects rebases that touch Python files that black would
+reformat (import ordering, line length, etc.). Workaround needed on every
+such rebase in any `vultron_*` worktree until the hook is fixed to use
+`--no-modify` or equivalent.

--- a/plan/incoming/learnings/20260708-rebase-black-hook-workaround.md
+++ b/plan/incoming/learnings/20260708-rebase-black-hook-workaround.md
@@ -22,7 +22,10 @@ the current working tree. During rebase cherry-pick, git applies changes then
 runs hooks — if black reformats any of those files, git sees them as newly
 modified and refuses to continue.
 
-**Scope**: Only affects rebases that touch Python files that black would
-reformat (import ordering, line length, etc.). Workaround needed on every
-such rebase in any `vultron_*` worktree until the hook is fixed to use
-`--no-modify` or equivalent.
+**Scope**: Only affected rebases that touched Python files that black would
+reformat (import ordering, line length, etc.).
+
+**Resolved**: Fixed in #1260 by adding `--check` to the `black` hook and
+removing `--fix` from the `markdownlint-cli2` hook in `.pre-commit-config.yaml`.
+Hooks are now fail-only; auto-fix is done by the `format-code`/`run-linters`
+skills before committing. The `SKIP=black` workaround is no longer needed.

--- a/test/adapters/driving/fastapi/test_responses.py
+++ b/test/adapters/driving/fastapi/test_responses.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+"""
+Unit tests for AS2JSONResponse.
+
+HTTP-09-002: Route handlers returning AS2 objects MUST use AS2JSONResponse.
+HTTP-09-003: Correct Content-Type and serialization behaviour.
+HTTP-08-001: Subclass fields must NOT be stripped (regression test).
+"""
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+import json
+
+from vultron.adapters.driving.fastapi.responses import (
+    AS2_CONTENT_TYPE,
+    AS2JSONResponse,
+)
+from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_report import (
+    VulnerabilityReport,
+)
+
+
+def test_content_type_is_as2():
+    """AS2JSONResponse must set Content-Type: application/activity+json."""
+    report = VulnerabilityReport(name="test")
+    response = AS2JSONResponse(report)
+    assert response.media_type == AS2_CONTENT_TYPE
+    assert AS2_CONTENT_TYPE in response.headers["content-type"]
+
+
+def test_camelcase_keys():
+    """AS2JSONResponse must serialize with by_alias=True (camelCase keys)."""
+    case = VulnerabilityCase(
+        name="Test Case",
+        attributed_to="https://example.org/actor",
+        vulnerability_reports=[],
+    )
+    response = AS2JSONResponse(case)
+    body = json.loads(bytes(response.body))
+
+    # vulnerability_reports → vulnerabilityReports (camelCase)
+    assert (
+        "vulnerabilityReports" in body
+    ), f"Expected 'vulnerabilityReports' in body keys: {list(body.keys())}"
+    # snake_case key must NOT appear
+    assert "vulnerability_reports" not in body
+
+
+def test_subclass_fields_not_stripped():
+    """Subclass-specific fields must be present — HTTP-08-001 regression test.
+
+    FastAPI's response_model filtering strips fields not declared on the base
+    class. AS2JSONResponse bypasses that filtering entirely.
+    """
+    report = VulnerabilityReport(
+        name="Test Report",
+        content="Test vulnerability content",
+        attributed_to="https://example.org/finder",
+    )
+    case = VulnerabilityCase(
+        name="Test Case",
+        attributed_to="https://example.org/actor",
+        vulnerability_reports=[report],
+        case_participants=[],
+        proposed_embargoes=[],
+        case_activity=[],
+    )
+    response = AS2JSONResponse(case)
+    body = json.loads(bytes(response.body))
+
+    case_specific_fields = [
+        "vulnerabilityReports",
+        "caseParticipants",
+        "proposedEmbargoes",
+        "caseActivity",
+    ]
+    for field in case_specific_fields:
+        assert field in body, (
+            f"Subclass field '{field}' missing from response. "
+            f"Keys present: {list(body.keys())}"
+        )
+
+
+def test_exclude_none_true():
+    """None-valued fields must be omitted from the serialized body."""
+    report = VulnerabilityReport(name="Minimal Report")
+    response = AS2JSONResponse(report)
+    body = json.loads(bytes(response.body))
+
+    # Fields that are None should be absent, not null
+    for key, value in body.items():
+        assert (
+            value is not None
+        ), f"Field '{key}' is null — exclude_none=True should have dropped it"
+
+
+def test_non_as2_content_passthrough():
+    """Non-as_Base content is passed through unchanged (dict/list fallback)."""
+    data = {"key": "value", "number": 42}
+    response = AS2JSONResponse(data)
+    body = json.loads(bytes(response.body))
+
+    assert body == data
+    assert response.media_type == AS2_CONTENT_TYPE
+
+
+def test_status_code_default():
+    """Default status code is 200."""
+    report = VulnerabilityReport(name="Test")
+    response = AS2JSONResponse(report)
+    assert response.status_code == 200
+
+
+def test_status_code_override():
+    """Custom status codes are forwarded correctly."""
+    report = VulnerabilityReport(name="Created")
+    response = AS2JSONResponse(report, status_code=201)
+    assert response.status_code == 201

--- a/vultron/adapters/driving/fastapi/responses.py
+++ b/vultron/adapters/driving/fastapi/responses.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+"""
+Canonical FastAPI response class for Vultron AS2 endpoints.
+
+HTTP-09-002: Route handlers returning AS2 objects MUST use AS2JSONResponse.
+HTTP-09-003: Serializes with model_dump(mode="json", by_alias=True,
+             exclude_none=True) and sets Content-Type: application/activity+json.
+"""
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+from typing import Any
+
+from fastapi.responses import JSONResponse
+
+from vultron.wire.as2.vocab.base.base import as_Base
+
+AS2_CONTENT_TYPE = "application/activity+json"
+
+
+class AS2JSONResponse(JSONResponse):
+    """FastAPI response for ActivityStreams 2.0 objects.
+
+    Serializes an ``as_Base`` subclass instance with ``by_alias=True`` and
+    ``exclude_none=True`` to produce compact camelCase AS2 JSON, and sets the
+    ``Content-Type`` header to ``application/activity+json``.
+
+    Usage::
+
+        return AS2JSONResponse(wire_obj)
+
+    Keep ``response_model=`` on the route decorator for OpenAPI schema
+    generation — ``AS2JSONResponse`` bypasses FastAPI's response-model
+    filtering so subclass fields are never stripped (HTTP-08-001 fix).
+    """
+
+    media_type = AS2_CONTENT_TYPE
+
+    def __init__(self, content: "as_Base | Any", **kwargs: Any) -> None:
+        if isinstance(content, as_Base):
+            body = content.model_dump(
+                mode="json", by_alias=True, exclude_none=True
+            )
+        else:
+            body = content
+        super().__init__(content=body, **kwargs)

--- a/vultron/adapters/driving/fastapi/routers/actors/_routes.py
+++ b/vultron/adapters/driving/fastapi/routers/actors/_routes.py
@@ -83,7 +83,6 @@ router = APIRouter(prefix="/actors", tags=["Actors"])
 
 @router.get(
     "/",
-    response_model_exclude_none=True,
     description="Returns a list of Actor examples.",
     operation_id="actors_list",
 )
@@ -140,7 +139,6 @@ class ActorCreateRequest(BaseModel):
 
 @router.post(
     "/",
-    response_model_exclude_none=True,
     status_code=status.HTTP_201_CREATED,
     summary="Create Actor",
     description=(
@@ -181,7 +179,6 @@ def create_actor(
 
 @router.get(
     "/{actor_id:path}/profile",
-    response_model_exclude_none=True,
     summary="Get Actor Profile",
     description=(
         "Returns an ActivityStreams actor profile including inbox and outbox "
@@ -462,7 +459,6 @@ def post_actor_outbox(
 
 @router.get(
     "/{actor_id:path}",
-    response_model_exclude_none=True,
     description="Returns an Actor by surrogate key or canonical ID.",
     operation_id="actors_get",
 )

--- a/vultron/adapters/driving/fastapi/routers/actors/_routes.py
+++ b/vultron/adapters/driving/fastapi/routers/actors/_routes.py
@@ -41,6 +41,7 @@ from vultron.adapters.driving.fastapi.inbox_orchestration import (
     run_inbox_pipeline,
 )
 from vultron.adapters.driving.fastapi.outbox_handler import outbox_handler
+from vultron.adapters.driving.fastapi.responses import AS2JSONResponse
 from vultron.adapters.utils import make_id, strip_id_prefix
 from vultron.core.models.actor import (
     CoreActor,
@@ -103,10 +104,12 @@ def get_actors(
         obj = cls.model_validate(rec.get("data_", {}))
         objects.append(obj)
 
-    return [
-        o.model_dump(mode="json", by_alias=True, exclude_none=True)
-        for o in objects
-    ]
+    return AS2JSONResponse(
+        [
+            o.model_dump(mode="json", by_alias=True, exclude_none=True)
+            for o in objects
+        ]
+    )
 
 
 class ActorCreateRequest(BaseModel):
@@ -162,15 +165,21 @@ def create_actor(
         response.status_code = status.HTTP_200_OK
         cls = _actor_class_for_record(existing)
         data = existing.get("data_", {})
-        return cls.model_validate(data).model_dump(
-            mode="json", by_alias=True, exclude_none=True
+        return AS2JSONResponse(
+            cls.model_validate(data).model_dump(
+                mode="json", by_alias=True, exclude_none=True
+            ),
+            status_code=status.HTTP_200_OK,
         )
 
     actor_cls = _ACTOR_TYPE_MAP.get(request.actor_type, VultronOrganization)
     actor = actor_cls(id_=actor_id, name=request.name)
     datalayer.create(object_to_record(cast(PersistableModel, actor)))
     logger.info("Created actor %s (type=%s)", actor_id, request.actor_type)
-    return actor.model_dump(mode="json", by_alias=True, exclude_none=True)
+    return AS2JSONResponse(
+        actor.model_dump(mode="json", by_alias=True, exclude_none=True),
+        status_code=status.HTTP_201_CREATED,
+    )
 
 
 @router.get(
@@ -204,7 +213,9 @@ def get_actor_profile(
     as_actor = cast(
         Any, actor_cls.model_validate(actor_record.get("data_", {}))
     )
-    profile = as_actor.model_dump(by_alias=True, exclude_none=True)
+    profile = as_actor.model_dump(
+        mode="json", by_alias=True, exclude_none=True
+    )
     inbox = getattr(as_actor, "inbox", None)
     outbox = getattr(as_actor, "outbox", None)
     profile["inbox"] = (
@@ -225,7 +236,7 @@ def get_actor_profile(
             else getattr(outbox, "id_", None)
         )
     )
-    return profile
+    return AS2JSONResponse(profile)
 
 
 @router.get(
@@ -472,6 +483,8 @@ def get_actor(actor_id: str, datalayer: DataLayer = Depends(get_shared_dl)):
 
     cls = _actor_class_for_record(actor)
     data = actor.get("data_", {})
-    return cls.model_validate(data).model_dump(
-        mode="json", by_alias=True, exclude_none=True
+    return AS2JSONResponse(
+        cls.model_validate(data).model_dump(
+            mode="json", by_alias=True, exclude_none=True
+        )
     )

--- a/vultron/adapters/driving/fastapi/routers/actors/_routes.py
+++ b/vultron/adapters/driving/fastapi/routers/actors/_routes.py
@@ -30,7 +30,6 @@ from fastapi import (
     Depends,
     HTTPException,
     Request,
-    Response,
     status,
 )
 from pydantic import BaseModel, Field
@@ -153,7 +152,6 @@ class ActorCreateRequest(BaseModel):
 )
 def create_actor(
     request: ActorCreateRequest,
-    response: Response,
     datalayer: DataLayer = Depends(get_shared_dl),
 ):
     """Create (or return existing) actor record."""
@@ -162,7 +160,6 @@ def create_actor(
     # Idempotency: return existing record unchanged.
     existing = _find_actor_record(datalayer, actor_id)
     if existing is not None:
-        response.status_code = status.HTTP_200_OK
         cls = _actor_class_for_record(existing)
         data = existing.get("data_", {})
         return AS2JSONResponse(
@@ -295,14 +292,13 @@ def get_action_rules(
 @router.get(
     "/{actor_id:path}/inbox",
     response_model=as_OrderedCollection,
-    response_model_exclude_none=True,
     summary="Get Actor Inbox",
     description="Returns the Actor's Inbox. (stub implementation).",
     operation_id="actors_get_inbox",
 )
 def get_actor_inbox(
     actor_id: str, datalayer: DataLayer = Depends(get_shared_dl)
-) -> as_OrderedCollection:
+) -> AS2JSONResponse:
     """Returns the Actor's Inbox."""
 
     actor_record = datalayer.read(actor_id)
@@ -324,7 +320,7 @@ def get_actor_inbox(
         list[as_Object | as_Link | str | _CoreObject | None],
         list(actor_dl.inbox_list()),
     )
-    return as_OrderedCollection(items=items)
+    return AS2JSONResponse(as_OrderedCollection(items=items))
 
 
 @router.post(

--- a/vultron/adapters/driving/fastapi/routers/datalayer.py
+++ b/vultron/adapters/driving/fastapi/routers/datalayer.py
@@ -63,24 +63,32 @@ def get_object(
     return obj
 
 
-@router.get("/Offer/", operation_id="datalayer_get_offer")
+@router.get(
+    "/Offer/",
+    response_model=as_Offer,
+    operation_id="datalayer_get_offer",
+)
 def get_offer(
     object_id: str, datalayer: DataLayer = Depends(get_shared_dl)
-) -> as_Offer:
+) -> AS2JSONResponse:
     obj = datalayer.read(object_id)
     if not obj:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
-    return as_Offer.model_validate(obj)
+    return AS2JSONResponse(as_Offer.model_validate(obj))
 
 
-@router.get("/Report/", operation_id="datalayer_get_report")
+@router.get(
+    "/Report/",
+    response_model=VulnerabilityReport,
+    operation_id="datalayer_get_report",
+)
 def get_report(
     id: str, datalayer: DataLayer = Depends(get_shared_dl)
-) -> VulnerabilityReport:
+) -> AS2JSONResponse:
     obj = datalayer.read(id)
     if not obj:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
-    return VulnerabilityReport.model_validate(obj)
+    return AS2JSONResponse(VulnerabilityReport.model_validate(obj))
 
 
 @router.get(
@@ -105,12 +113,13 @@ def get_datalayer_contents(
 
 @router.get(
     "/Actors/{actor_id}/Offers/{offer_id}",
+    response_model=as_Offer,
     description="Returns a specific object by actor id and offer id.",
     operation_id="datalayer_get_actor_offer",
 )
 def get_actor_offer(
     actor_id: str, offer_id: str, datalayer: DataLayer = Depends(get_shared_dl)
-) -> as_Offer:
+) -> AS2JSONResponse:
     obj = datalayer.read(offer_id)
 
     if not obj:
@@ -128,7 +137,7 @@ def get_actor_offer(
     if not found:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
 
-    return offer
+    return AS2JSONResponse(offer)
 
 
 @router.get(
@@ -138,26 +147,37 @@ def get_actor_offer(
 )
 def get_offers(
     datalayer: DataLayer = Depends(get_shared_dl),
-) -> dict[str, as_Offer]:
+) -> AS2JSONResponse:
     results = datalayer.by_type("Offer")
 
-    return {k: as_Offer.model_validate(v) for k, v in results.items()}
+    return AS2JSONResponse(
+        {
+            k: as_Offer.model_validate(v).model_dump(
+                mode="json", by_alias=True, exclude_none=True
+            )
+            for k, v in results.items()
+        }
+    )
 
 
 @router.get(
     "/Reports/",
     description="Returns all VulnerabilityReport objects.",
-    response_model=dict[str, VulnerabilityReport],
     operation_id="datalayer_list_reports",
 )
 def get_reports(
     datalayer: DataLayer = Depends(get_shared_dl),
-) -> dict[str, VulnerabilityReport]:
+) -> AS2JSONResponse:
     results = datalayer.by_type("VulnerabilityReport")
 
-    return {
-        k: VulnerabilityReport.model_validate(v) for k, v in results.items()
-    }
+    return AS2JSONResponse(
+        {
+            k: VulnerabilityReport.model_validate(v).model_dump(
+                mode="json", by_alias=True, exclude_none=True
+            )
+            for k, v in results.items()
+        }
+    )
 
 
 _DATALAYER_ACTOR_TYPE_MAP: dict[str, type[as_Actor]] = {
@@ -206,7 +226,7 @@ def get_actors(
 )
 def get_actor_outbox(
     actor_id: str, datalayer: DataLayer = Depends(get_shared_dl)
-) -> as_OrderedCollection:
+) -> AS2JSONResponse:
     actor_obj = datalayer.read(actor_id)
 
     if not actor_obj:
@@ -226,7 +246,7 @@ def get_actor_outbox(
         if isinstance(item, str) or isinstance(item, as_Object)
     ]
 
-    return outbox
+    return AS2JSONResponse(outbox)
 
 
 @router.get(

--- a/vultron/adapters/driving/fastapi/routers/datalayer.py
+++ b/vultron/adapters/driving/fastapi/routers/datalayer.py
@@ -19,22 +19,24 @@ Provides a backend API router for basic Vultron data layer operations.
 from copy import deepcopy
 from typing import Any
 
-from fastapi import APIRouter, Depends, status, HTTPException
-from vultron.wire.as2.rehydration import rehydrate
-from vultron.core.ports.datalayer import DataLayer
-from vultron.wire.as2.vocab.base.objects.base import as_Object
+from fastapi import APIRouter, Depends, HTTPException, status
+
 from vultron.adapters.driven.datalayer import get_shared_dl
+from vultron.adapters.driving.fastapi.responses import AS2JSONResponse
+from vultron.core.ports.datalayer import DataLayer
+from vultron.wire.as2.rehydration import rehydrate
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
+from vultron.wire.as2.vocab.base.objects.base import as_Object
+from vultron.wire.as2.vocab.base.objects.collections import (
+    as_OrderedCollection,
+)
 from vultron.wire.as2.vocab.objects.vultron_actor import (
     VultronApplication,
     VultronGroup,
     VultronOrganization,
     VultronPerson,
     VultronService,
-)
-from vultron.wire.as2.vocab.base.objects.collections import (
-    as_OrderedCollection,
 )
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
     VulnerabilityReport,
@@ -88,15 +90,17 @@ def get_report(
 )
 def get_datalayer_contents(
     datalayer: DataLayer = Depends(get_shared_dl),
-) -> dict[str, dict]:
+) -> AS2JSONResponse:
     data = datalayer.all()
     if not isinstance(data, dict):
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-    return {
-        k: v.model_dump(exclude_none=True, by_alias=True)
-        for k, v in data.items()
-    }
+    return AS2JSONResponse(
+        {
+            k: v.model_dump(mode="json", exclude_none=True, by_alias=True)
+            for k, v in data.items()
+        }
+    )
 
 
 @router.get(
@@ -184,12 +188,14 @@ def get_actors(
 ):
     results = datalayer.by_type("Actor")
 
-    return {
-        k: _actor_class_for_payload(v)
-        .model_validate(v)
-        .model_dump(mode="json", by_alias=True, exclude_none=True)
-        for k, v in results.items()
-    }
+    return AS2JSONResponse(
+        {
+            k: _actor_class_for_payload(v)
+            .model_validate(v)
+            .model_dump(mode="json", by_alias=True, exclude_none=True)
+            for k, v in results.items()
+        }
+    )
 
 
 @router.get(

--- a/vultron/adapters/driving/fastapi/routers/examples.py
+++ b/vultron/adapters/driving/fastapi/routers/examples.py
@@ -11,7 +11,7 @@ Vultron API Object Examples
 #  Created, in part, with funding and support from the United States Government
 #  (see Acknowledgments file). This program may include and/or can make use of
 #  certain third party source code, object code, documentation and other files
-#  (“Third Party Software”). See LICENSE.md for more details.
+#  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
@@ -20,6 +20,7 @@ from datetime import timedelta
 
 from fastapi import APIRouter
 
+from vultron.adapters.driving.fastapi.responses import AS2JSONResponse
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.base.objects.object_types import as_Note
 from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
@@ -64,11 +65,10 @@ router = APIRouter(
 @router.get(
     "/actors",
     response_model=as_Actor,
-    response_model_exclude_none=True,
     description="Get an example Actor object.",
     operation_id="examples_get_actor",
 )
-def get_example_actor() -> as_Actor:
+def get_example_actor() -> AS2JSONResponse:
     """
     Get an example Actor object
     """
@@ -79,7 +79,7 @@ def get_example_actor() -> as_Actor:
     ]
     func = random.choice(options)
 
-    return func()
+    return AS2JSONResponse(func())
 
 
 @router.post(
@@ -88,268 +88,259 @@ def get_example_actor() -> as_Actor:
     description="Validate an Actor object.",
     operation_id="examples_validate_actor",
 )
-def validate_actor(actor: as_Actor) -> as_Actor:
+def validate_actor(actor: as_Actor) -> AS2JSONResponse:
     """Validates an Actor object."""
-    return actor
+    return AS2JSONResponse(actor)
 
 
 @router.get(
     "/actors/person",
     response_model=VultronPerson,
-    response_model_exclude_none=True,
     description="Get an example VultronPerson actor object.",
     operation_id="examples_get_actor_person",
 )
-def get_example_actor_person() -> VultronPerson:
+def get_example_actor_person() -> AS2JSONResponse:
     """Returns an example VultronPerson actor with an inline EmbargoPolicy."""
     actor_id = f"{_ACTORS_BASE}/alice"
-    return VultronPerson(
-        id_=actor_id,
-        name="Alice (Example Person)",
-        embargo_policy=_embargo_policy(actor_id),
+    return AS2JSONResponse(
+        VultronPerson(
+            id_=actor_id,
+            name="Alice (Example Person)",
+            embargo_policy=_embargo_policy(actor_id),
+        )
     )
 
 
 @router.get(
     "/actors/organization",
     response_model=VultronOrganization,
-    response_model_exclude_none=True,
     description="Get an example VultronOrganization actor object.",
     operation_id="examples_get_actor_organization",
 )
-def get_example_actor_organization() -> VultronOrganization:
+def get_example_actor_organization() -> AS2JSONResponse:
     """Returns an example VultronOrganization actor with an inline EmbargoPolicy."""
     actor_id = f"{_ACTORS_BASE}/acme-inc"
-    return VultronOrganization(
-        id_=actor_id,
-        name="ACME Inc. (Example Organization)",
-        embargo_policy=_embargo_policy(actor_id),
+    return AS2JSONResponse(
+        VultronOrganization(
+            id_=actor_id,
+            name="ACME Inc. (Example Organization)",
+            embargo_policy=_embargo_policy(actor_id),
+        )
     )
 
 
 @router.get(
     "/actors/service",
     response_model=VultronService,
-    response_model_exclude_none=True,
     description="Get an example VultronService actor object.",
     operation_id="examples_get_actor_service",
 )
-def get_example_actor_service() -> VultronService:
+def get_example_actor_service() -> AS2JSONResponse:
     """Returns an example VultronService actor with an inline EmbargoPolicy."""
     actor_id = f"{_ACTORS_BASE}/vultron-bot"
-    return VultronService(
-        id_=actor_id,
-        name="Vultron Bot (Example Service)",
-        embargo_policy=_embargo_policy(actor_id),
+    return AS2JSONResponse(
+        VultronService(
+            id_=actor_id,
+            name="Vultron Bot (Example Service)",
+            embargo_policy=_embargo_policy(actor_id),
+        )
     )
 
 
 @router.get(
     "/actors/application",
     response_model=VultronApplication,
-    response_model_exclude_none=True,
     description="Get an example VultronApplication actor object.",
     operation_id="examples_get_actor_application",
 )
-def get_example_actor_application() -> VultronApplication:
+def get_example_actor_application() -> AS2JSONResponse:
     """Returns an example VultronApplication actor with an inline EmbargoPolicy."""
     actor_id = f"{_ACTORS_BASE}/vultron-app"
-    return VultronApplication(
-        id_=actor_id,
-        name="Vultron App (Example Application)",
-        embargo_policy=_embargo_policy(actor_id),
+    return AS2JSONResponse(
+        VultronApplication(
+            id_=actor_id,
+            name="Vultron App (Example Application)",
+            embargo_policy=_embargo_policy(actor_id),
+        )
     )
 
 
 @router.get(
     "/actors/group",
     response_model=VultronGroup,
-    response_model_exclude_none=True,
     description="Get an example VultronGroup actor object.",
     operation_id="examples_get_actor_group",
 )
-def get_example_actor_group() -> VultronGroup:
+def get_example_actor_group() -> AS2JSONResponse:
     """Returns an example VultronGroup actor with an inline EmbargoPolicy."""
     actor_id = f"{_ACTORS_BASE}/security-team"
-    return VultronGroup(
-        id_=actor_id,
-        name="Security Team (Example Group)",
-        embargo_policy=_embargo_policy(actor_id),
+    return AS2JSONResponse(
+        VultronGroup(
+            id_=actor_id,
+            name="Security Team (Example Group)",
+            embargo_policy=_embargo_policy(actor_id),
+        )
     )
 
 
 @router.get(
     "/reports",
     response_model=VulnerabilityReport,
-    response_model_exclude_none=True,
     description="Get an example Vulnerability Report object.",
     operation_id="examples_get_report",
 )
-def get_example_report() -> VulnerabilityReport:
+def get_example_report() -> AS2JSONResponse:
     """Returns an example VulnerabilityReport object."""
-    return vocab_examples.gen_report()
+    return AS2JSONResponse(vocab_examples.gen_report())
 
 
 @router.post(
     "/reports",
     response_model=VulnerabilityReport,
-    response_model_exclude_none=True,
     summary="Validate Report object format",
     description="Validates a Vulnerability Report object.",
     operation_id="examples_validate_report",
 )
-def validate_report(report: VulnerabilityReport) -> VulnerabilityReport:
+def validate_report(report: VulnerabilityReport) -> AS2JSONResponse:
     """Validates a VulnerabilityReport object."""
-    return report
+    return AS2JSONResponse(report)
 
 
 @router.get(
     "/cases",
     response_model=VulnerabilityCase,
-    response_model_exclude_none=True,
     description="Get an example Vulnerability Case object.",
     operation_id="examples_get_case",
 )
-def get_example_case() -> VulnerabilityCase:
+def get_example_case() -> AS2JSONResponse:
     """Returns an example VulnerabilityCase object."""
-    return vocab_examples.case()
+    return AS2JSONResponse(vocab_examples.case())
 
 
 @router.post(
     "/cases",
     response_model=VulnerabilityCase,
-    response_model_exclude_none=True,
     summary="Validate Case object format",
     description="Validates a Vulnerability Case object.",
     operation_id="examples_validate_case",
 )
-def validate_case(case: VulnerabilityCase) -> VulnerabilityCase:
+def validate_case(case: VulnerabilityCase) -> AS2JSONResponse:
     """Validates a VulnerabilityCase object."""
-    return case
+    return AS2JSONResponse(case)
 
 
 @router.get(
     "/cases/statuses",
     response_model=CaseStatus,
-    response_model_exclude_none=True,
     description="Get an example Case Status object.",
     operation_id="examples_get_case_status",
 )
-def get_example_case_status() -> CaseStatus:
+def get_example_case_status() -> AS2JSONResponse:
     """Returns an example CaseStatus object."""
-    return vocab_examples.case_status()
+    return AS2JSONResponse(vocab_examples.case_status())
 
 
 @router.post(
     "/cases/statuses",
     response_model=CaseStatus,
-    response_model_exclude_none=True,
     description="Validates a CaseStatus object.",
     operation_id="examples_validate_case_status",
 )
-def validate_case_status(case_status: CaseStatus) -> CaseStatus:
+def validate_case_status(case_status: CaseStatus) -> AS2JSONResponse:
     """Validates a CaseStatus object."""
-    return case_status
+    return AS2JSONResponse(case_status)
 
 
 @router.get(
     "/cases/participants",
     response_model=CaseParticipant,
-    response_model_exclude_none=True,
     description="Get an example Case Participant object.",
     operation_id="examples_get_participant",
 )
-def get_example_participant() -> CaseParticipant:
+def get_example_participant() -> AS2JSONResponse:
     """Returns an example CaseParticipant object."""
-    return vocab_examples.case_participant()
+    return AS2JSONResponse(vocab_examples.case_participant())
 
 
 @router.post(
     "/cases/participants",
     response_model=CaseParticipant,
-    response_model_exclude_none=True,
     summary="Validate Case Participant object format",
     description="Validates a Case Participant object.",
     operation_id="examples_validate_participant",
 )
-def validate_participant(participant: CaseParticipant) -> CaseParticipant:
+def validate_participant(participant: CaseParticipant) -> AS2JSONResponse:
     """Validates a CaseParticipant object."""
-    return participant
+    return AS2JSONResponse(participant)
 
 
 @router.get(
     "/cases/participants/statuses",
     response_model=ParticipantStatus,
-    response_model_exclude_none=True,
     description="Get an example Participant Status object.",
     operation_id="examples_get_participant_status",
 )
-def get_example_participant_status() -> ParticipantStatus:
+def get_example_participant_status() -> AS2JSONResponse:
     """Returns an example ParticipantStatus object."""
-    return vocab_examples.participant_status()
+    return AS2JSONResponse(vocab_examples.participant_status())
 
 
 @router.post(
     "/cases/participants/statuses",
     response_model=ParticipantStatus,
-    response_model_exclude_none=True,
     description="Validates a ParticipantStatus object.",
     operation_id="examples_validate_participant_status",
 )
 def validate_participant_status(
     status: ParticipantStatus,
-) -> ParticipantStatus:
+) -> AS2JSONResponse:
     """Validates a ParticipantStatus object."""
-    return status
+    return AS2JSONResponse(status)
 
 
 @router.get(
     "/cases/embargoes",
     response_model=EmbargoEvent,
-    response_model_exclude_none=True,
     description="Get an example Embargo Event object.",
     operation_id="examples_get_embargo",
 )
-def get_example_embargo() -> EmbargoEvent:
+def get_example_embargo() -> AS2JSONResponse:
     """Returns an example EmbargoEvent object."""
-    return vocab_examples.embargo_event()
+    return AS2JSONResponse(vocab_examples.embargo_event())
 
 
 @router.post(
     "/cases/embargoes",
     response_model=EmbargoEvent,
-    response_model_exclude_none=True,
     summary="Validate Embargo Event object format",
     description="Validates an EmbargoEvent object.",
     operation_id="examples_validate_embargo",
 )
-def validate_embargo(embargo: EmbargoEvent) -> EmbargoEvent:
+def validate_embargo(embargo: EmbargoEvent) -> AS2JSONResponse:
     """Validates an EmbargoEvent object."""
-    return embargo
+    return AS2JSONResponse(embargo)
 
 
 @router.get(
     "/notes",
     response_model=as_Note,
-    response_model_exclude_none=True,
     description="Get an example Note object.",
     operation_id="examples_get_note",
 )
-def get_example_note() -> as_Note:
+def get_example_note() -> AS2JSONResponse:
     """
     Get an example Note object
     """
-    return vocab_examples.note()
+    return AS2JSONResponse(vocab_examples.note())
 
 
 @router.post(
     "/notes",
     response_model=as_Note,
-    response_model_exclude_none=True,
     summary="Validate Note object format",
     description="Validates a Note object.",
     operation_id="examples_validate_note",
 )
-def validate_note(note: as_Note) -> as_Note:
+def validate_note(note: as_Note) -> AS2JSONResponse:
     """Validates a Note object."""
-    return note
+    return AS2JSONResponse(note)


### PR DESCRIPTION
- Closes #1061
- Closes #1260

## Summary

Adds `AS2JSONResponse`, a canonical FastAPI `JSONResponse` subclass that sets
`Content-Type: application/activity+json` and serializes `as_Base` instances
with `model_dump(mode="json", by_alias=True, exclude_none=True)`. Migrates all
AS2-typed route handlers across `actors/_routes.py`, `datalayer.py`, and
`examples.py` to use it, fixing subclass field stripping (HTTP-08-001 regression)
and ensuring consistent `Content-Type` across all AS2 endpoints.

Also fixes pre-commit hooks to be fail-only (`--check`) so they no longer
auto-modify files during `git rebase`.

## Changes

- `vultron/adapters/driving/fastapi/responses.py` (new): `AS2JSONResponse` class
  with `AS2_CONTENT_TYPE` constant.
- `actors/_routes.py`: All five AS2-returning handlers migrated (`get_actors`,
  `create_actor`, `get_actor_profile`, `get_actor`, `get_actor_inbox`). Fixed
  missing `mode="json"` in `get_actor_profile`. Removed dead `response.status_code`
  assignment and unused `Response` parameter from `create_actor`.
- `datalayer.py`: All AS2-typed handlers migrated (`get_datalayer_contents`,
  `get_actors`, `get_actor_outbox`, `get_offer`, `get_report`, `get_actor_offer`,
  `get_offers`, `get_reports`). Fixed missing `mode="json"` in
  `get_datalayer_contents`. Import ordering fixed. Generic passthrough endpoints
  (`get_object`, `get_objects`, `get_object_by_key`) excluded — untyped content.
- `examples.py`: All 22 routes migrated. `response_model_exclude_none=True`
  removed; `response_model=` retained for OpenAPI schema.
- `test/adapters/driving/fastapi/test_responses.py` (new): 7 unit tests.
- `.pre-commit-config.yaml`: Add `--check` to `black` hook; remove `--fix` from
  `markdownlint-cli2` hook. Hooks are now fail-only.
- `AGENTS.md`: Update pre-commit guidance to reflect fail-only hooks.

## Verification

- All 4393 unit tests pass (7 new)
- Black, flake8, mypy, pyright clean
- [x] HTTP-09-002: All AS2-typed route handlers use `AS2JSONResponse`
- [x] HTTP-09-003: `Content-Type: application/activity+json` and correct serialization
- [x] HTTP-08-001: Subclass fields not stripped (regression test included)