### PR TITLE
chore(#1108): remove shadowing fixture definitions from test_trigger_actor.py

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1108.md
+++ b/plan/history/2607/implementation/ISSUE-1108.md
@@ -1,0 +1,16 @@
+---
+source: ISSUE-1108
+timestamp: '2026-07-08T15:13:53.594193+00:00'
+title: Remove shadowing fixture definitions from test_trigger_actor.py
+type: implementation
+---
+
+## Issue #1108 — Chore: Remove shadowing fixture definitions from test_trigger_actor.py
+
+Removed duplicate `actor_and_dl`, `actor`, and `dl` fixture definitions from
+`test/adapters/driving/fastapi/routers/test_trigger_actor.py`. These three
+fixtures were identical to the ones consolidated into the shared routers
+`conftest.py` in PR #492. The test file was inheriting them via shadowing
+rather than from conftest. After removal, all 21 tests pass unchanged.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1259>

--- a/test/adapters/driving/fastapi/routers/test_trigger_actor.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_actor.py
@@ -51,43 +51,6 @@ from vultron.wire.as2.vocab.objects.vulnerability_case import (
 
 
 @pytest.fixture
-def actor_and_dl():
-    """Create actor + per-actor DataLayer together (avoids chicken-and-egg).
-
-    The actor object is created first (no DataLayer needed), then a
-    DataLayer is instantiated scoped to that actor's ID (ADR-0012 Option B).
-    The actor is then persisted into its own DataLayer.  Callers should
-    unpack via the ``actor`` and ``dl`` fixtures below.
-    """
-    from vultron.adapters.driven.datalayer_sqlite import (
-        SqliteDataLayer,
-        reset_datalayer,
-    )
-
-    actor_obj = as_Service(name="Vendor Co")
-    actor_id = actor_obj.id_
-    reset_datalayer(actor_id)
-    actor_dl = SqliteDataLayer("sqlite:///:memory:", actor_id=actor_id)
-    actor_dl.clear_all()
-    actor_dl.create(actor_obj)
-    yield actor_obj, actor_dl
-    actor_dl.close()
-    reset_datalayer(actor_id)
-
-
-@pytest.fixture
-def actor(actor_and_dl):
-    actor_obj, _ = actor_and_dl
-    return actor_obj
-
-
-@pytest.fixture
-def dl(actor_and_dl):
-    _, actor_dl = actor_and_dl
-    return actor_dl
-
-
-@pytest.fixture
 def client_triggers(dl):
     app = FastAPI()
     app.include_router(trigger_actor_router.router)


### PR DESCRIPTION
- Closes #1108

## Summary

Remove duplicate `actor_and_dl`, `actor`, and `dl` fixture definitions from
`test/adapters/driving/fastapi/routers/test_trigger_actor.py` that were
shadowing identical fixtures in the shared `conftest.py` (consolidated in #492).
Tests now inherit these fixtures from conftest automatically.

## Changes

- `test/adapters/driving/fastapi/routers/test_trigger_actor.py`: remove
  37 lines of duplicate fixture code (`actor_and_dl`, `actor`, `dl`)

## Verification

- All 21 unit tests pass unchanged after removal
- Black, flake8, mypy, pyright clean