### PR TITLE
docs(#1187): add factory-fn placement field to all fuzzer node catalog entries

### DIFF
--- a/docs/adr/0024-coordination-agent-taxonomy.md
+++ b/docs/adr/0024-coordination-agent-taxonomy.md
@@ -2,9 +2,10 @@
 
 Vultron's Behavior Trees contain **call-out points** — locations where the
 protocol cannot determine the correct next action autonomously and must request
-input from an external party. We established a canonical taxonomy of four agent
+input from an external party. We established a canonical taxonomy of agent
 shapes that answer those call-out points, and chose "call-out point" as the
-term for those locations.
+term for those locations. The taxonomy began with four shapes and was extended
+to five by the Actuator amendment (2026-07-07).
 
 ## Decisions
 
@@ -17,7 +18,7 @@ explicit (protocol → external party → protocol), implies the workflow pauses
 and waits for a response, and cleanly contrasts with *trigger endpoint* (the
 call-*in* surface where external parties invoke the protocol).
 
-### Four canonical agent shapes
+### Canonical agent shapes
 
 | Shape | Role |
 | --- | --- |
@@ -26,7 +27,7 @@ call-*in* surface where external parties invoke the protocol).
 | **Retriever** | Receives a query; returns structured facts from an external source (including boolean/binary results — see below) |
 | **Composer** | Receives context; generates a new content artifact |
 
-These are a typology, not exactly four singleton agents. A real coordination
+These are a typology, not exactly singleton agents. A real coordination
 agent may embody one shape or combine shapes (e.g., a Participant Discovery
 agent composes Retriever + Evaluator).
 
@@ -62,7 +63,7 @@ The updated five-shape taxonomy:
 
 ### Message-Driven Responses excluded from the taxonomy
 
-An earlier draft included "message-driven responses" as a fifth category of
+An earlier draft included "message-driven responses" as an additional category of
 agent touchpoint. This was rejected: receiving a protocol message is handled
 by the protocol's inbox BT, not by a coordination agent. The relevant
 call-out point — if any — is the evaluation or decision node that fires
@@ -70,7 +71,7 @@ call-out point — if any — is the evaluation or decision node that fires
 
 ### Orchestrator deferred
 
-Whether **Orchestrator** constitutes a fifth agent shape (an agent that
+Whether **Orchestrator** constitutes an additional agent shape (an agent that
 sequences other agents toward a bounded goal) is unresolved. No concrete
 multi-agent sequencing requirement exists yet. The question is tracked in
 GitHub issue #1141 and will be revisited when two or more concrete agent

--- a/notes/bt-fuzzer-nodes-embargo.md
+++ b/notes/bt-fuzzer-nodes-embargo.md
@@ -68,6 +68,10 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Automation potential**: **Medium** — deployment status check is automatable via patch-management or case-state APIs; the *decision* to exit still requires policy-rule evaluation or human confirmation.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.ExitEmbargoWhenDeployed`
 - **Call-out point shape**: Evaluator
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.embargo.create_terminate_embargo_on_condition_tree`
+  (issue #1256) — condition guard in the TerminateEmbargo Selector, checked
+  before delegating to `terminate_embargo_trigger_bt`
 
 ### `ExitEmbargoWhenFixReady`
 
@@ -84,6 +88,10 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Automation potential**: **Medium** — fix-readiness flag is queryable automatically; the exit decision depends on configurable organizational policy that may require human override.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.ExitEmbargoWhenFixReady`
 - **Call-out point shape**: Evaluator
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.embargo.create_terminate_embargo_on_condition_tree`
+  (issue #1256) — condition guard in the TerminateEmbargo Selector, checked
+  before delegating to `terminate_embargo_trigger_bt`
 
 ### `ExitEmbargoForOtherReason`
 
@@ -100,6 +108,10 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Automation potential**: **Low** — rare edge case representing extraordinary circumstances; fundamentally requires human judgment that cannot be anticipated by a general policy rule.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.ExitEmbargoForOtherReason`
 - **Call-out point shape**: Evaluator
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.embargo.create_terminate_embargo_on_condition_tree`
+  (issue #1256) — rare fallback condition guard in the TerminateEmbargo
+  Selector for extraordinary circumstances
 
 ### `EmbargoTimerExpired`
 
@@ -117,6 +129,10 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Automation potential**: **High** — simple system-clock comparison against the recorded embargo expiry timestamp; fully automatable with no human involvement.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.EmbargoTimerExpired`
 - **Call-out point shape**: Sentinel — binary timer-expiry condition; compares current time against the recorded embargo deadline and returns SUCCESS/FAILURE with no output keys; fully resolved by system-clock comparison against case-state data.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.embargo.create_terminate_embargo_on_condition_tree`
+  (issue #1256) — Sentinel condition guard early in the
+  `_SufficientCauseToTerminateActiveEmbargo` Sequence
 
 ### `OnEmbargoExit`
 
@@ -134,6 +150,11 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Automation potential**: **High** — integration hook (notifications, state updates, downstream triggers); can be fully automated via API calls to notification and case-management systems.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.OnEmbargoExit`
 - **Call-out point shape**: Actuator — fires integration hooks on embargo exit; invokes notification APIs, case-management state-write calls, and downstream trigger endpoints. There is no content artifact placed on the blackboard; the side effects in external systems are the seam.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.embargo.create_terminate_embargo_on_condition_tree`
+  (issue #1256) — Actuator effect node in
+  `_ConsiderTerminatingActiveEmbargo` Sequence, after the condition Selector
+  succeeds and before `terminate_embargo_trigger_bt`
 
 ### `StopProposingEmbargo`
 
@@ -150,6 +171,10 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Automation potential**: **Low** — fundamentally a negotiation-fatigue judgment; depends on relationship context and subjective assessment of negotiation prospects; requires human decision.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.StopProposingEmbargo`
 - **Call-out point shape**: Evaluator
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.embargo.create_propose_embargo_decision_tree`
+  (issue #1257) — Evaluator condition guard in
+  `_ConsiderAbandoningProposedEmbargo` Selector
 
 ### `SelectEmbargoOfferTerms`
 
@@ -167,6 +192,10 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Automation potential**: **Medium** — standard terms (duration, conditions) can be drawn from organizational policy templates automatically; atypical situations may need human review.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.SelectEmbargoOfferTerms`
 - **Call-out point shape**: Evaluator
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.embargo.create_propose_embargo_decision_tree`
+  (issue #1257) — Evaluator action node in `_ProposeNewEmbargo` and
+  `_ProposeEmbargoRevision` Sequences, before the proposal trigger BT
 
 ### `WantToProposeEmbargo`
 
@@ -183,6 +212,10 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Automation potential**: **Medium** — default policy (always propose) can be automated; exceptions (e.g., already-public vulnerability, no vendor identified) could be rule-encoded, but edge cases may need human override.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.WantToProposeEmbargo`
 - **Call-out point shape**: Evaluator
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.embargo.create_propose_embargo_decision_tree`
+  (issue #1257) — Evaluator condition guard in `_ConsiderProposingEmbargo`
+  Sequence (within `_EmNone` Selector)
 
 ### `WillingToCounterEmbargoProposal`
 
@@ -200,6 +233,11 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Automation potential**: **Low** — nuanced negotiation judgment about whether countering is strategically preferable to accepting and revising; best left to human discretion.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.WillingToCounterEmbargoProposal`
 - **Call-out point shape**: Evaluator
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.embargo.create_propose_embargo_decision_tree`
+  (issue #1257) — Evaluator condition guard in `_AvoidCounterProposal`
+  Selector; determines whether a counter-proposal is sent instead of
+  accept/reject
 
 ### `ReasonToProposeEmbargoWhenDeployed`
 
@@ -216,6 +254,10 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Automation potential**: **Low** — highly exceptional circumstance; no general rule can anticipate valid reasons, so human judgment is required.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.ReasonToProposeEmbargoWhenDeployed`
 - **Call-out point shape**: Evaluator
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.embargo.create_propose_embargo_decision_tree`
+  (issue #1257) — Evaluator condition guard in
+  `_AvoidNewEmbargoesInCsDeployedUnlessReason` Selector
 
 ### `EvaluateEmbargoProposal`
 
@@ -233,6 +275,11 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Automation potential**: **Medium** — basic compatibility check (is proposed duration within policy bounds?) is automatable; final accept/reject for out-of-range proposals typically needs human review.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.EvaluateEmbargoProposal`
 - **Call-out point shape**: Evaluator
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.embargo.create_propose_embargo_decision_tree`
+  (issue #1257) — Evaluator condition guard in
+  `_EvaluateAndAcceptProposedEmbargo` Sequence; precedes
+  `accept_embargo_trigger_bt`
 
 ### `OnEmbargoAccept`
 
@@ -249,6 +296,11 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Automation potential**: **High** — notification dispatch, timer initialization, and state-update actions are all integration-automatable via APIs.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.OnEmbargoAccept`
 - **Call-out point shape**: Actuator — fires integration hooks on embargo acceptance; invokes notification APIs, embargo timer-service initialization calls, and case-management state writes. There is no content artifact placed on the blackboard; the side effects in external systems are the seam.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.embargo.create_propose_embargo_decision_tree`
+  (issue #1257) — Actuator effect node in
+  `_EvaluateAndAcceptProposedEmbargo` Sequence, after the Evaluator and
+  `accept_embargo_trigger_bt`
 
 ### `OnEmbargoReject`
 
@@ -265,6 +317,11 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Automation potential**: **High** — notification dispatch and logging actions are fully automatable via APIs.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.OnEmbargoReject`
 - **Call-out point shape**: Actuator — fires integration hooks on embargo rejection; invokes notification APIs and case-management state writes for the rejection rationale. There is no content artifact placed on the blackboard; the side effects in external systems are the seam.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.embargo.create_propose_embargo_decision_tree`
+  (issue #1257) — Actuator effect node in `_RejectProposedEmbargo`
+  Sequence (within `_ChooseEmProposedResponse`), after
+  `reject_embargo_trigger_bt`
 
 ### `CurrentEmbargoAcceptable`
 
@@ -281,5 +338,10 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Automation potential**: **Medium** — automated comparison of current terms against policy preferences is feasible; edge cases and dynamic negotiation contexts may still require human judgment.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.CurrentEmbargoAcceptable`
 - **Call-out point shape**: Evaluator
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.embargo.create_propose_embargo_decision_tree`
+  (issue #1257) — Evaluator condition guard in `_ChooseEmActiveResponse`
+  Selector; SUCCESS = no revision needed, FAILURE = revision proposal path
+  taken
 
 ---

--- a/notes/bt-fuzzer-nodes-messaging.md
+++ b/notes/bt-fuzzer-nodes-messaging.md
@@ -72,6 +72,10 @@ from unexpected or malformed inbound protocol messages.
 - **Automation potential**: **High** — deterministic policy-driven GI message dispatch in response to error conditions; can be fully automated once the follow-up policy is defined.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.messaging.FollowUpOnErrorMessage`
 - **Call-out point shape**: Composer — generates and dispatches a follow-up GI inquiry message to the sender of an unexpected or error protocol message; the produced artifact is the outbound GI protocol message.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.inbox.create_inbound_error_followup_tree`
+  (issue #1254) — Composer effect node in the error-handling Fallback
+  within `ReceiveMessagesBt`, after the unrecognized-message check fails
 
 ---
 

--- a/notes/bt-fuzzer-nodes-report-management.md
+++ b/notes/bt-fuzzer-nodes-report-management.md
@@ -70,6 +70,11 @@ credible and valid for the receiving organization.
 - **Automation potential**: **High** — event subscription on the case record or metadata timestamp comparison; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.validate.NoNewValidationInfo`
 - **Call-out point shape**: Sentinel — binary change-detection condition; monitors the case record for new validation-relevant events via a metadata timestamp or event subscription; returns SUCCESS/FAILURE with no output keys.
+- **Factory-fn placement**:
+  `vultron.core.behaviors.report.validate_tree.create_validate_report_tree` —
+  early-exit Sentinel guard at the top of `ValidationOrShortcut` Selector;
+  currently stubbed as `CheckRMStateValid` but the change-detection variant
+  belongs here when the full retry loop is implemented (Phase 2)
 
 ### `EvaluateReportCredibility`
 
@@ -87,6 +92,11 @@ credible and valid for the receiving organization.
 - **Automation potential**: **Medium** — SSVC exploitation status, reporter reputation scoring, and technical plausibility checks can be partially automated; final credibility determination typically requires human analyst review.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.validate.EvaluateReportCredibility`
 - **Call-out point shape**: Evaluator
+- **Factory-fn placement**:
+  `vultron.core.behaviors.report.validate_tree.create_validate_report_tree` —
+  Evaluator condition guard in `ValidationFlow` Sequence (second child, before
+  `EvaluateReportValidity`); currently a stub `EvaluateReportCredibility` node
+  that always returns SUCCESS
 
 ### `EvaluateReportValidity`
 
@@ -104,6 +114,11 @@ credible and valid for the receiving organization.
 - **Automation potential**: **Medium** — scope checks against well-defined CNA/charter rules are automatable; organizational-context validity judgment often requires human review.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.validate.EvaluateReportValidity`
 - **Call-out point shape**: Evaluator
+- **Factory-fn placement**:
+  `vultron.core.behaviors.report.validate_tree.create_validate_report_tree` —
+  Evaluator condition guard in `ValidationFlow` Sequence (third child, before
+  `ValidationActions`); currently a stub `EvaluateReportValidity` node that
+  always returns SUCCESS
 
 ### `EnoughValidationInfo`
 
@@ -120,6 +135,10 @@ credible and valid for the receiving organization.
 - **Automation potential**: **Medium** — completeness check against required fields or evidence criteria can be automated; the sufficiency threshold for final decision often involves human judgment.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.validate.EnoughValidationInfo`
 - **Call-out point shape**: Evaluator
+- **Factory-fn placement**:
+  `vultron.core.behaviors.report.validate_tree.create_validate_report_tree` —
+  Evaluator condition guard in `ValidationFlow` Sequence (Phase 2); gate
+  before the info-gathering loop that `GatherValidationInfo` populates
 
 ### `GatherValidationInfo`
 
@@ -137,6 +156,10 @@ credible and valid for the receiving organization.
 - **Automation potential**: **Low–Medium** — structured intake form follow-ups and automated case-update requests are partially automatable; direct reporter outreach typically requires human involvement.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.validate.GatherValidationInfo`
 - **Call-out point shape**: Retriever
+- **Factory-fn placement**:
+  `vultron.core.behaviors.report.validate_tree.create_validate_report_tree` —
+  Retriever action node in the info-gathering Sequence (Phase 2), triggered
+  when `EnoughValidationInfo` returns FAILURE
 
 ---
 
@@ -161,6 +184,11 @@ models the process of deciding whether to accept (engage with) or defer
 - **Automation potential**: **High** — metadata timestamp or case-update event check; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.prioritize.NoNewPrioritizationInfo`
 - **Call-out point shape**: Sentinel — binary change-detection condition; monitors the case record for new prioritization-relevant events via a metadata timestamp or event subscription; returns SUCCESS/FAILURE with no output keys.
+- **Factory-fn placement**:
+  `vultron.core.behaviors.report.prioritize_tree.create_prioritize_subtree` —
+  early-exit Sentinel guard at the top of `PrioritizeBT` Selector; the retry
+  skip-if-no-new-info check belongs here when the full re-prioritization
+  loop is implemented (Phase 2)
 
 ### `EnoughPrioritizationInfo`
 
@@ -176,6 +204,10 @@ models the process of deciding whether to accept (engage with) or defer
 - **Automation potential**: **Medium** — availability of SSVC decision-point data (e.g., CVSS score, exploitation status) is automatable; the sufficiency judgment for a final accept/defer decision usually involves human analyst review.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.prioritize.EnoughPrioritizationInfo`
 - **Call-out point shape**: Evaluator
+- **Factory-fn placement**:
+  `vultron.core.behaviors.report.prioritize_tree.create_prioritize_subtree` —
+  Evaluator condition guard in the `PrioritizeBT` Sequence (Phase 2); gate
+  before the info-gathering loop that `GatherPrioritizationInfo` populates
 
 ### `GatherPrioritizationInfo`
 
@@ -193,6 +225,10 @@ models the process of deciding whether to accept (engage with) or defer
 - **Automation potential**: **Medium** — fetching CVSS scores, EPSS scores, NVD data, and asset inventory is fully automatable via APIs; analyst interpretation and gap-filling still requires human involvement.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.prioritize.GatherPrioritizationInfo`
 - **Call-out point shape**: Retriever
+- **Factory-fn placement**:
+  `vultron.core.behaviors.report.prioritize_tree.create_prioritize_subtree` —
+  Retriever action node in the info-gathering Sequence (Phase 2), triggered
+  when `EnoughPrioritizationInfo` returns FAILURE
 
 ### `OnDefer`
 
@@ -209,6 +245,11 @@ models the process of deciding whether to accept (engage with) or defer
 - **Automation potential**: **High** — stakeholder notifications, follow-up scheduling, and state updates are all automatable via integration APIs.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.prioritize.OnDefer`
 - **Call-out point shape**: Actuator — fires integration hooks on report deferral; invokes notification APIs, task-scheduling services, and case-management state writes. There is no content artifact placed on the blackboard; the side effects in external systems are the seam.
+- **Factory-fn placement**:
+  `vultron.core.behaviors.report.prioritize_tree.create_prioritize_subtree` —
+  Actuator effect node appended to `DeferCaseTriggerBT` Sequence (in
+  `create_defer_case_tree`), after `TransitionParticipantRMtoDeferred` and
+  the sender-side subtree
 
 ### `OnAccept`
 
@@ -225,6 +266,11 @@ models the process of deciding whether to accept (engage with) or defer
 - **Automation potential**: **High** — stakeholder notifications, workflow initialization, and state updates are all automatable via integration APIs.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.prioritize.OnAccept`
 - **Call-out point shape**: Actuator — fires integration hooks on report acceptance; invokes notification APIs, workflow-initialization services, and case-management state writes. There is no content artifact placed on the blackboard; the side effects in external systems are the seam.
+- **Factory-fn placement**:
+  `vultron.core.behaviors.report.prioritize_tree.create_prioritize_subtree` —
+  Actuator effect node appended to `EngageCaseTriggerBT` Sequence (in
+  `create_engage_case_tree`), after `TransitionParticipantRMtoAccepted` and
+  the sender-side subtree
 
 ---
 
@@ -250,6 +296,10 @@ to a validated report.
 - **Automation potential**: **High** — simple query against case metadata or a vulnerability registry; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.assign_vul_id.IdAssigned`
 - **Call-out point shape**: Retriever — synchronous on-demand query to case metadata or an external vulnerability registry (e.g., CVE database); returns SUCCESS if an identifier has already been assigned to this vulnerability, FAILURE otherwise. A boolean is the simplest structured fact (ADR-0024); the on-demand query pattern makes this a Retriever, not a Sentinel (see BT-18-006).
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_assign_vul_id_tree` (issue #1246) —
+  early-exit Retriever guard at the top of `AssignVulID` Fallback Selector;
+  returns SUCCESS if an ID is already assigned, short-circuiting assignment work
 
 ### `InScope`
 
@@ -266,6 +316,10 @@ to a validated report.
 - **Automation potential**: **High** — scope rules for well-defined ID spaces (e.g., CVE CNA rules) can be encoded as a policy check and automated; may require human review for ambiguous cases.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.assign_vul_id.InScope`
 - **Call-out point shape**: Evaluator — evaluates whether the vulnerability falls within the applicable ID namespace by comparing vulnerability attributes against CNA scope rules or a product/component registry; returns a policy judgment (in-scope or out-of-scope), not a binary monitor.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_assign_vul_id_tree` (issue #1246) —
+  Evaluator condition guard early in `AssignVulID` Sequence, before the
+  authority-check nodes
 
 ### `IsIDAssignmentAuthority`
 
@@ -288,6 +342,10 @@ to a validated report.
 - **Automation potential**: **High** — static organizational configuration; can be fully automated as a capability metadata lookup.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.assign_vul_id.IsIDAssignmentAuthority`
 - **Call-out point shape**: Retriever — synchronous on-demand query to the participant's static role metadata; returns SUCCESS if this participant holds `CVDRole.CVE_NUMBERING_AUTHORITY` in their `case_roles`, FAILURE otherwise. A boolean is the simplest structured fact (ADR-0024); the on-demand query pattern makes this a Retriever, not a Sentinel (see BT-18-006).
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_assign_vul_id_tree` (issue #1246) —
+  Retriever condition guard in `AssignVulID` Sequence; queries participant
+  role metadata before `IdAssignable` and `AssignId`
 
 ### `IdAssignable`
 
@@ -315,6 +373,10 @@ to a validated report.
   authority for this specific vulnerability by matching vulnerability
   attributes against CNA scope rules and product-to-CNA mappings;
   a scope-matching evaluation, not a binary condition monitor.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_assign_vul_id_tree` (issue #1246) —
+  Evaluator condition guard in the assign-direct path Sequence, after
+  `IsIDAssignmentAuthority` succeeds
 
 ### `RequestId`
 
@@ -331,6 +393,10 @@ to a validated report.
 - **Automation potential**: **High** — can be fully automated as an API call to the CVE Services endpoint or equivalent ID-request interface.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.assign_vul_id.RequestId`
 - **Call-out point shape**: Retriever — queries an external ID assignment authority (e.g., CVE Services API) with a reservation/assignment request and writes the resulting assigned ID to the case record; SUCCESS = ID retrieved and recorded.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_assign_vul_id_tree` (issue #1246) —
+  Retriever action node in the request-external-id Sequence, used when
+  `IsIDAssignmentAuthority` fails (non-CNA path)
 
 ### `AssignId`
 
@@ -347,6 +413,10 @@ to a validated report.
 - **Automation potential**: **High** — can be fully automated as an API call (reserve/assign) to the ID assignment authority or an internal ID pool management system.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.assign_vul_id.AssignId`
 - **Call-out point shape**: Composer — generates a new vulnerability identifier from this participant's own ID pool via the ID management system or CVE Services reserve/assign endpoint; the produced artifact is the newly assigned ID recorded in the case.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_assign_vul_id_tree` (issue #1246) —
+  Composer action node in the direct-assign Sequence, used when
+  `IdAssignable` succeeds (CNA-direct path)
 
 ---
 
@@ -372,6 +442,9 @@ vulnerability.
 - **Automation potential**: **Low** — engineering work is human-initiated; automation is limited to triggering a bug-tracker ticket or sending a development task notification.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.develop_fix.CreateFix`
 - **Call-out point shape**: Composer
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_develop_fix_tree` (issue #1247) —
+  Composer action node in the `DevelopFix` Sequence; the primary work node
 
 ---
 
@@ -397,6 +470,9 @@ the process of deploying a developed fix or mitigation to affected systems.
 - **Automation potential**: **High** — metadata timestamp or deployment-event subscription check; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.deploy_fix.NoNewDeploymentInfo`
 - **Call-out point shape**: Sentinel — binary change-detection condition; monitors the case/deployment record for new deployment-relevant events via a metadata timestamp or event subscription; returns SUCCESS/FAILURE with no output keys.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_deploy_fix_tree` (issue #1248) —
+  early-exit Sentinel guard at the top of `Deployment` Fallback Selector
 
 ### `PrioritizeDeployment`
 
@@ -414,6 +490,10 @@ the process of deploying a developed fix or mitigation to affected systems.
 - **Automation potential**: **Medium** — CVSS environmental scores, EPSS, and asset criticality data are automatable inputs; final prioritization decision may require human approval, especially for production systems.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.deploy_fix.PrioritizeDeployment`
 - **Call-out point shape**: Evaluator
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_deploy_fix_tree` (issue #1248) —
+  Evaluator action node in the `Deployment` Sequence, setting deployment
+  priority before the mitigation/fix-deploy paths
 
 ### `MitigationDeployed`
 
@@ -430,6 +510,10 @@ the process of deploying a developed fix or mitigation to affected systems.
 - **Automation potential**: **High** — query to patch management system or case-state flag; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.deploy_fix.MitigationDeployed`
 - **Call-out point shape**: Retriever — synchronous on-demand query to an asset/patch management system or case-state flag; returns SUCCESS if a mitigation has been deployed, FAILURE otherwise. A boolean is the simplest structured fact (ADR-0024); the on-demand query pattern makes this a Retriever, not a Sentinel.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_deploy_fix_tree` (issue #1248) —
+  early-exit Retriever guard in `Deployment` Selector; short-circuits when
+  mitigation is already deployed
 
 ### `MitigationAvailable`
 
@@ -446,6 +530,10 @@ the process of deploying a developed fix or mitigation to affected systems.
 - **Automation potential**: **High** — patch or advisory feed query; fully automatable once the feed integration is in place.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.deploy_fix.MitigationAvailable`
 - **Call-out point shape**: Retriever — synchronous on-demand query to a patch/advisory feed or internal mitigation catalog; returns SUCCESS if a mitigation is currently available, FAILURE otherwise. A boolean is the simplest structured fact (ADR-0024); the on-demand query pattern makes this a Retriever, not a Sentinel.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_deploy_fix_tree` (issue #1248) —
+  Retriever condition guard in the mitigation-deploy Sequence, before
+  `DeployMitigation`; queries availability before attempting deployment
 
 ### `DeployMitigation`
 
@@ -462,6 +550,10 @@ the process of deploying a developed fix or mitigation to affected systems.
 - **Automation potential**: **Medium** — automated deployment is feasible for some environments (configuration management, cloud); human approval is typically required for production system changes.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.deploy_fix.DeployMitigation`
 - **Call-out point shape**: Evaluator
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_deploy_fix_tree` (issue #1248) —
+  Evaluator action node in the mitigation-deploy Sequence, after
+  `MitigationAvailable` succeeds
 
 ### `MonitoringRequirement`
 
@@ -478,6 +570,10 @@ the process of deploying a developed fix or mitigation to affected systems.
 - **Automation potential**: **High** — policy rule evaluation against case context (severity, asset class, environment); fully automatable as a policy engine check.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.deploy_fix.MonitoringRequirement`
 - **Call-out point shape**: Evaluator — evaluates whether organizational policy requires post-deployment monitoring for this case by applying policy rules against case context (severity, asset class, environment); a policy judgment call, not a binary condition monitor.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_deploy_fix_tree` (issue #1248) —
+  Evaluator condition guard in the monitoring-initiation Sequence; SUCCESS
+  proceeds to `MonitorDeployment`
 
 ### `MonitorDeployment`
 
@@ -494,6 +590,10 @@ the process of deploying a developed fix or mitigation to affected systems.
 - **Automation potential**: **High** — integration with deployment verification tools, patch compliance dashboards, or asset management platforms; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.deploy_fix.MonitorDeployment`
 - **Call-out point shape**: Sentinel
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_deploy_fix_tree` (issue #1248) —
+  Sentinel action node in the monitoring-initiation Sequence, after
+  `MonitoringRequirement` succeeds; monitors deployment coverage metrics
 
 ### `DeployFix`
 
@@ -510,6 +610,10 @@ the process of deploying a developed fix or mitigation to affected systems.
 - **Automation potential**: **Medium** — release pipeline and patch distribution can be automated (CI/CD, package repositories); human approval gate is commonly required for production releases.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.deploy_fix.DeployFix`
 - **Call-out point shape**: Evaluator
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_deploy_fix_tree` (issue #1248) —
+  Evaluator action node in the full-fix-deploy Sequence; the primary patch
+  deployment step (distinct from mitigation deployment)
 
 ---
 
@@ -535,6 +639,11 @@ vulnerability, typically to support impact assessment or testing.
 - **Automation potential**: **High** — query against an internal exploit repository or threat-intelligence platform; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.acquire_exploit.HaveExploit`
 - **Call-out point shape**: Retriever — synchronous on-demand query to an internal exploit repository or threat-intelligence platform; returns SUCCESS if a working exploit is already available for this vulnerability, FAILURE otherwise. A boolean is the simplest structured fact (ADR-0024); the on-demand query pattern makes this a Retriever, not a Sentinel.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_acquire_exploit_strategy_tree`
+  (issue #1249) — early-exit Retriever guard at the top of
+  `AcquireExploit` Selector; may collapse into `EvaluateExploitStrategy`
+  input context per production redesign (#1200)
 
 ### `ExploitPrioritySet`
 
@@ -551,6 +660,10 @@ vulnerability, typically to support impact assessment or testing.
 - **Automation potential**: **High** — metadata flag check on the case record; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.acquire_exploit.ExploitPrioritySet`
 - **Call-out point shape**: Sentinel — binary case-metadata flag check; returns SUCCESS if a priority decision for exploit acquisition has already been recorded for this case, FAILURE otherwise, with no output keys.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_acquire_exploit_strategy_tree`
+  (issue #1249) — early-exit Sentinel after `HaveExploit`; collapses the
+  loop if the priority decision is already on record for this cycle
 
 ### `EvaluateExploitPriority`
 
@@ -567,6 +680,11 @@ vulnerability, typically to support impact assessment or testing.
 - **Automation potential**: **Medium** — SSVC/CVSS scoring inputs are automatable; the final exploit-acquisition priority decision often requires human analyst judgment given organizational and legal context.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.acquire_exploit.EvaluateExploitPriority`
 - **Call-out point shape**: Evaluator
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_acquire_exploit_strategy_tree`
+  (issue #1249) — Evaluator action node in the priority-decision Sequence;
+  writes the `exploit_priority` decision to the blackboard for downstream
+  Sentinel nodes
 
 ### `ExploitDeferred`
 
@@ -583,6 +701,10 @@ vulnerability, typically to support impact assessment or testing.
 - **Automation potential**: **High** — read the outcome of the priority evaluation from case metadata; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.acquire_exploit.ExploitDeferred`
 - **Call-out point shape**: Sentinel — binary case-metadata flag check against the outcome written by EvaluateExploitPriority; returns SUCCESS if the decision was to defer exploit acquisition, FAILURE otherwise, with no output keys.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_acquire_exploit_strategy_tree`
+  (issue #1249) — Sentinel branch guard after `EvaluateExploitPriority`;
+  early-exits the acquire-exploit Selector when deferral is recorded
 
 ### `ExploitDesired`
 
@@ -598,6 +720,10 @@ vulnerability, typically to support impact assessment or testing.
 - **Automation potential**: **High** — read the outcome of the priority evaluation from case metadata; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.acquire_exploit.ExploitDesired`
 - **Call-out point shape**: Sentinel — binary case-metadata flag check against the outcome written by EvaluateExploitPriority; returns SUCCESS if the decision was to acquire an exploit, FAILURE otherwise, with no output keys.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_acquire_exploit_strategy_tree`
+  (issue #1249) — Sentinel precondition guard before the acquisition
+  Fallback (`FindExploit → DevelopExploit → PurchaseExploit`)
 
 ### `FindExploit`
 
@@ -616,6 +742,10 @@ vulnerability, typically to support impact assessment or testing.
 - **Automation potential**: **High** — automated search of exploit databases (ExploitDB, Metasploit module index, NVD exploit references, threat-intel APIs) is fully feasible.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.acquire_exploit.FindExploit`
 - **Call-out point shape**: Retriever
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_acquire_exploit_strategy_tree`
+  (issue #1249) — first Retriever child in the acquisition Fallback;
+  searched before `DevelopExploit` and `PurchaseExploit`
 
 ### `DevelopExploit`
 
@@ -632,6 +762,10 @@ vulnerability, typically to support impact assessment or testing.
 - **Automation potential**: **Low** — security research requiring human expertise; cannot be meaningfully automated in the general case.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.acquire_exploit.DevelopExploit`
 - **Call-out point shape**: Composer
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_acquire_exploit_strategy_tree`
+  (issue #1249) — second Composer child in the acquisition Fallback;
+  tried after `FindExploit` fails, before `PurchaseExploit`
 
 ### `PurchaseExploit`
 
@@ -648,6 +782,10 @@ vulnerability, typically to support impact assessment or testing.
 - **Automation potential**: **Low** — procurement and legal authorization require human decision-making; cannot be automated.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.acquire_exploit.PurchaseExploit`
 - **Call-out point shape**: Evaluator
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_acquire_exploit_strategy_tree`
+  (issue #1249) — third (last-resort) Evaluator child in the acquisition
+  Fallback; tried only after `FindExploit` and `DevelopExploit` both fail
 
 ---
 
@@ -676,6 +814,10 @@ exploited in the wild. Threat detection can trigger embargo termination via
 - **Automation potential**: **High** — SIEM queries, IDS/IPS alert feeds, and threat-intelligence platform APIs can fully automate in-the-wild attack detection.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.monitor_threats.MonitorAttacks`
 - **Call-out point shape**: Retriever — synchronous per-tick query to threat-intelligence feeds or SIEM/IDS telemetry; returns SUCCESS if active attacks are detected, FAILURE otherwise. The BT invokes this node on-demand each tick; it does not run independently or fire a trigger endpoint (see BT-18-006).
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_monitor_threats_tree`
+  (issue #1250) — first Retriever child in the `MonitorThreats` Fallback;
+  queries SIEM/IDS feeds for evidence of active in-the-wild attacks
 
 ### `MonitorExploits`
 
@@ -694,6 +836,11 @@ exploited in the wild. Threat detection can trigger embargo termination via
 - **Automation potential**: **High** — exploit database feeds, CVE enrichment APIs, and threat-intel platforms can fully automate exploit publication monitoring.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.monitor_threats.MonitorExploits`
 - **Call-out point shape**: Retriever — synchronous per-tick query to exploit database feeds or threat-intelligence platforms; returns SUCCESS if a newly published exploit is found, FAILURE otherwise. The BT invokes this node on-demand each tick; it does not run independently or fire a trigger endpoint (see BT-18-006).
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_monitor_threats_tree`
+  (issue #1250) — second Retriever child in the `MonitorThreats` Fallback;
+  queries exploit-database feeds and CVE enrichment APIs for newly
+  published exploit code
 
 ### `MonitorPublicReports`
 
@@ -712,6 +859,10 @@ exploited in the wild. Threat detection can trigger embargo termination via
 - **Automation potential**: **High** — RSS/news feed monitoring, OSINT tools, and social-media tracking APIs can automate public disclosure detection with high coverage.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.monitor_threats.MonitorPublicReports`
 - **Call-out point shape**: Retriever — synchronous per-tick query to OSINT feeds, news/RSS sources, or social-media tracking APIs; returns SUCCESS if public disclosure evidence is found, FAILURE otherwise. The BT invokes this node on-demand each tick; it does not run independently or fire a trigger endpoint (see BT-18-006).
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_monitor_threats_tree`
+  (issue #1250) — third Retriever child in the `MonitorThreats` Fallback;
+  queries OSINT/news feeds for public disclosure of the vulnerability
 
 ### `NoThreatsFound`
 
@@ -728,6 +879,9 @@ exploited in the wild. Threat detection can trigger embargo termination via
 - **Automation potential**: **TerminalPlaceholder** — terminal success placeholder; no real decision logic required.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.monitor_threats.NoThreatsFound`
 - **Call-out point shape**: ProtocolInternal — terminal success placeholder; AlwaysSucceed fallback leaf that prevents MonitorThreats from failing when no active threats are detected in this monitoring cycle; no external input, output, or monitoring seam.
+- **Factory-fn placement**: N/A — ProtocolInternal terminal success leaf;
+  `create_monitor_threats_tree` (issue #1250) will provide this node
+  internally as a hardcoded AlwaysSucceed fallback, not a call-out point
 
 ---
 
@@ -753,6 +907,11 @@ preparing them, and executing publication.
 - **Automation potential**: **High** — publication status flag on the case record; fully automatable as a metadata check.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.publication.AllPublished`
 - **Call-out point shape**: Sentinel — binary publication-status check against a case-record flag; returns SUCCESS if all intended publication artifacts have been published, FAILURE otherwise, with no output keys.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_publication_tree`
+  (issue #1251) — top-level early-exit Sentinel guard at the root
+  of the `Publication` Selector; short-circuits the entire subtree once
+  all artifacts are published
 
 ### `PublicationIntentsSet`
 
@@ -770,6 +929,10 @@ preparing them, and executing publication.
 - **Automation potential**: **High** — publication intent flags on the case record; fully automatable as a metadata check.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.publication.PublicationIntentsSet`
 - **Call-out point shape**: Sentinel — binary case-metadata flag check; returns SUCCESS if publication intentions have already been established for this case, FAILURE otherwise, with no output keys.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_publication_tree`
+  (issue #1251) — Sentinel guard before `PrioritizePublicationIntents`;
+  skips intent-setting if a publication plan is already on record
 
 ### `PrioritizePublicationIntents`
 
@@ -788,6 +951,11 @@ preparing them, and executing publication.
 - **Automation potential**: **Medium** — standard policy-driven publication priorities (e.g., always publish report and fix) can be automated; editorial or legal exceptions require human judgment.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.publication.PrioritizePublicationIntents`
 - **Call-out point shape**: Evaluator
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_publication_tree`
+  (issue #1251) — Evaluator action node that runs when
+  `PublicationIntentsSet` fails; writes the publication plan (artifacts,
+  priority order, timing) to case metadata
 
 ### `Publish`
 
@@ -803,7 +971,12 @@ preparing them, and executing publication.
   API calls to advisory publishing platforms
 - **Automation potential**: **High** — advisory platform APIs (NVD, CVE.org, CMS, package repository) enable fully automated artifact publication.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.publication.Publish`
-- **Call-out point shape**: Composer — submits a prepared publication artifact to an external advisory platform (NVD, CVE.org, CMS, package repository, or equivalent); the produced artifact is the externally visible published entry at the target platform.
+- **Call-out point shape**: Actuator — submits an already-prepared artifact to an external advisory platform (NVD, CVE.org, CMS, package repository, or equivalent) via an API call; the side effect is the externally visible published entry at the target platform. There is no new content artifact placed on the blackboard; the preceding Prepare* nodes produce the content.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_publication_tree`
+  (issue #1251) — terminal Actuator action node at the end of each
+  per-artifact Sequence (`ExploitReady → Publish`, `PrepareFix → Publish`,
+  `PrepareReport → Publish`)
 
 ### `NoPublishExploit`
 
@@ -820,6 +993,9 @@ preparing them, and executing publication.
 - **Automation potential**: **TerminalPlaceholder** — BT bypass fallback leaf; no decision logic required.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.publication.NoPublishExploit`
 - **Call-out point shape**: ProtocolInternal — bypass fallback leaf that succeeds when the exploit is not intended for publication; exists purely so the BT succeeds gracefully on the no-op path; no external input, output, or monitoring seam. Analogous to `NoThreatsFound`.
+- **Factory-fn placement**: N/A — ProtocolInternal bypass leaf; the
+  `create_publication_tree` (issue #1251) exploit-arm Selector will
+  provide this as a hardcoded AlwaysSucceed no-op, not a call-out point
 
 ### `ExploitReady`
 
@@ -834,6 +1010,11 @@ preparing them, and executing publication.
 - **Automation potential**: **High** — artifact staging-status check in the publishing pipeline; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.publication.ExploitReady`
 - **Call-out point shape**: Sentinel — binary artifact-staging status check against the publishing pipeline; returns SUCCESS if the exploit artifact is staged and ready for publication, FAILURE otherwise, with no output keys.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_publication_tree`
+  (issue #1251) — Sentinel guard before `Publish` in the exploit-arm
+  Sequence; succeeds when the exploit artifact is already staged, avoiding
+  redundant `PrepareExploit` work
 
 ### `PrepareExploit`
 
@@ -850,6 +1031,10 @@ preparing them, and executing publication.
 - **Automation potential**: **Low** — write-up and proof-of-concept packaging require human security researcher expertise; not automatable in the general case.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.publication.PrepareExploit`
 - **Call-out point shape**: Composer
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_publication_tree`
+  (issue #1251) — Composer action node in the exploit-arm Sequence;
+  creates and stages the exploit artifact when `ExploitReady` fails
 
 ### `ReprioritizeExploit`
 
@@ -866,6 +1051,11 @@ preparing them, and executing publication.
 - **Automation potential**: **Medium** — embargo state changes and threat-level updates can trigger automated reprioritization rules; human override may be needed for unusual cases.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.publication.ReprioritizeExploit`
 - **Call-out point shape**: Evaluator
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_publication_tree`
+  (issue #1251) — Evaluator action node in the exploit-arm fallback;
+  updates the exploit-publication priority in response to a changing threat
+  landscape or embargo state change
 
 ### `NoPublishFix`
 
@@ -881,6 +1071,9 @@ preparing them, and executing publication.
 - **Automation potential**: **TerminalPlaceholder** — BT bypass fallback leaf; no decision logic required.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.publication.NoPublishFix`
 - **Call-out point shape**: ProtocolInternal — bypass fallback leaf that succeeds when the fix is not intended for publication; exists purely so the BT succeeds gracefully on the no-op path; no external input, output, or monitoring seam. Analogous to `NoThreatsFound`.
+- **Factory-fn placement**: N/A — ProtocolInternal bypass leaf; the
+  `create_publication_tree` (issue #1251) fix-arm Selector will
+  provide this as a hardcoded AlwaysSucceed no-op, not a call-out point
 
 ### `PrepareFix`
 
@@ -896,6 +1089,10 @@ preparing them, and executing publication.
 - **Automation potential**: **Low–Medium** — CI/CD pipeline can automate patch build and packaging; advisory text and release notes typically require human authoring and review.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.publication.PrepareFix`
 - **Call-out point shape**: Composer
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_publication_tree`
+  (issue #1251) — Composer action node in the fix-arm Sequence; creates
+  and stages the patch/advisory artifact when the fix is not yet ready
 
 ### `ReprioritizeFix`
 
@@ -911,6 +1108,11 @@ preparing them, and executing publication.
 - **Automation potential**: **Medium** — embargo state changes and threat-level updates can trigger automated reprioritization rules; human override may be needed.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.publication.ReprioritizeFix`
 - **Call-out point shape**: Evaluator
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_publication_tree`
+  (issue #1251) — Evaluator action node in the fix-arm fallback; updates
+  the fix-publication priority in response to embargo state changes or
+  threat escalation
 
 ### `NoPublishReport`
 
@@ -927,6 +1129,9 @@ preparing them, and executing publication.
 - **Automation potential**: **TerminalPlaceholder** — BT bypass fallback leaf; no decision logic required.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.publication.NoPublishReport`
 - **Call-out point shape**: ProtocolInternal — bypass fallback leaf that succeeds when the vulnerability report is not intended for publication; exists purely so the BT succeeds gracefully on the no-op path; no external input, output, or monitoring seam. Analogous to `NoThreatsFound`.
+- **Factory-fn placement**: N/A — ProtocolInternal bypass leaf; the
+  `create_publication_tree` (issue #1251) report-arm Selector will
+  provide this as a hardcoded AlwaysSucceed no-op, not a call-out point
 
 ### `PrepareReport`
 
@@ -942,6 +1147,10 @@ preparing them, and executing publication.
 - **Automation potential**: **Low** — advisory writing requires human expertise and editorial judgment; review and approval workflow also typically involves human stakeholders.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.publication.PrepareReport`
 - **Call-out point shape**: Composer
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_publication_tree`
+  (issue #1251) — Composer action node in the report-arm Sequence; authors
+  and stages the vulnerability advisory artifact for external publication
 
 ### `ReprioritizeReport`
 
@@ -957,6 +1166,11 @@ preparing them, and executing publication.
 - **Automation potential**: **Medium** — policy-triggered reprioritization (e.g., on embargo exit or threat escalation) is automatable; complex editorial decisions require human oversight.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.publication.ReprioritizeReport`
 - **Call-out point shape**: Evaluator
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_publication_tree`
+  (issue #1251) — Evaluator action node in the report-arm fallback; updates
+  the advisory publication priority in response to embargo exit or threat
+  escalation
 
 ---
 
@@ -983,6 +1197,11 @@ coordinated disclosure.
 - **Automation potential**: **High** — static capability and role configuration check; fully automatable as a metadata lookup.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.HaveReportToOthersCapability`
 - **Call-out point shape**: TBD — role/eligibility check: "does this participant have the capability and mandate to notify other parties?" In the evolving architecture this may devolve to a `CVDRole.CASE_MANAGER` membership check (internal BT condition check, not a call-out point), or remain an Evaluator if notification-obligation reasoning beyond role membership is required. Revisit after the invite-participant-to-case protocol is finalized (see #1199, #1200).
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_report_to_others_tree`
+  (issue #1252) — top-level guard at the root of `MaybeReportToOthers`;
+  exact shape (Evaluator vs. internal condition check) depends on
+  invite-participant-to-case protocol design (#1199, #1200)
 
 ### `AllPartiesKnown`
 
@@ -999,6 +1218,10 @@ coordinated disclosure.
 - **Automation potential**: **Low** — inherently requires human expert judgment about stakeholder completeness in a specific vulnerability context; hard to automate reliably.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.AllPartiesKnown`
 - **Call-out point shape**: Evaluator
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_report_to_others_tree`
+  (issue #1252) — Evaluator Sentinel after `HaveReportToOthersCapability`;
+  exits the outer party-identification loop once all parties are known
 
 ### `IdentifyVendors`
 
@@ -1016,6 +1239,11 @@ coordinated disclosure.
 - **Automation potential**: **Medium** — CPE/product database lookups, SBOM analysis, and NVD product data queries are automatable for known products; novel, multi-vendor, or open-source supply-chain cases benefit from human review.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.IdentifyVendors`
 - **Call-out point shape**: Retriever
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_report_to_others_tree`
+  (issue #1252) — Retriever node in the party-identification Sequence;
+  populates the vendor portion of the identified-parties queue using
+  CPE/product database lookups, SBOM analysis, and NVD product data
 
 ### `IdentifyCoordinators`
 
@@ -1034,6 +1262,11 @@ coordinated disclosure.
 - **Automation potential**: **Medium** — FIRST member directory and national CSIRT registry lookups are automatable; routing policy (when to involve a coordinator) may require human judgment.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.IdentifyCoordinators`
 - **Call-out point shape**: Retriever
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_report_to_others_tree`
+  (issue #1252) — Retriever node in the party-identification Sequence;
+  populates the coordinator portion of the identified-parties queue using
+  FIRST member directory and national CSIRT registry lookups
 
 ### `IdentifyOthers`
 
@@ -1049,6 +1282,11 @@ coordinated disclosure.
 - **Automation potential**: **Low** — by definition a catch-all for non-vendor, non-coordinator parties; requires human expert assessment of the specific disclosure context.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.IdentifyOthers`
 - **Call-out point shape**: Evaluator
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_report_to_others_tree`
+  (issue #1252) — Evaluator node in the party-identification Sequence;
+  catch-all for non-vendor, non-coordinator stakeholders requiring
+  case-specific human expert assessment
 
 ### `NotificationsComplete`
 
@@ -1065,6 +1303,11 @@ coordinated disclosure.
 - **Automation potential**: **High** — notification status tracking against the identified-parties queue; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.NotificationsComplete`
 - **Call-out point shape**: Sentinel — binary status check against notification tracking metadata; returns SUCCESS if all identified parties have been successfully notified, FAILURE otherwise, with no output keys.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_report_to_others_tree`
+  (issue #1252) — Sentinel guard at the top of the per-recipient
+  notification loop; exits the loop once the full notification queue
+  is drained
 
 ### `ChooseRecipient`
 
@@ -1080,6 +1323,11 @@ coordinated disclosure.
 - **Automation potential**: **High** — deterministic queue selection from the identified-parties list; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.ChooseRecipient`
 - **Call-out point shape**: Retriever — reads the next recipient entry from the identified-parties queue according to the priority ordering and writes the selected recipient details to the blackboard for downstream nodes (FindContact, SetRcptQrmR, etc.); SUCCESS = next recipient selected and written.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_report_to_others_tree`
+  (issue #1252) — Retriever node at the top of the per-recipient loop
+  body; pops the next candidate from the queue and writes it to the
+  blackboard
 
 ### `RemoveRecipient`
 
@@ -1095,6 +1343,11 @@ coordinated disclosure.
 - **Automation potential**: **High** — queue management operation; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.RemoveRecipient`
 - **Call-out point shape**: Actuator — writes a queue-removal state change to the case management system, dequeuing the current recipient; the side effect in the external system is the seam, not a content artifact placed on the blackboard.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_report_to_others_tree`
+  (issue #1252) — Actuator node appended at the end of the per-recipient
+  notification Sequence (after `SetRcptQrmR`); removes the processed
+  recipient from the pending queue
 
 ### `RecipientEffortExceeded`
 
@@ -1112,6 +1365,11 @@ coordinated disclosure.
 - **Automation potential**: **High** — effort counter check against a configurable policy threshold; fully automatable once the threshold policy is defined.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.RecipientEffortExceeded`
 - **Call-out point shape**: Evaluator — evaluates whether the notification-attempt budget for this recipient has been exhausted by comparing the per-recipient attempt counter against a configurable policy threshold; a process-gate judgment about whether continued effort is warranted.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_report_to_others_tree`
+  (issue #1252) — Evaluator guard in the per-recipient effort-limit
+  Sequence; triggers `RemoveRecipient` when the per-recipient attempt
+  budget is exhausted
 
 ### `TotalEffortLimitMet`
 
@@ -1128,6 +1386,11 @@ coordinated disclosure.
 - **Automation potential**: **High** — aggregate effort counter check against a configurable policy ceiling; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.TotalEffortLimitMet`
 - **Call-out point shape**: Evaluator — evaluates whether the global notification budget has been exhausted by comparing the total effort counter against a configurable policy ceiling; a process-gate judgment about whether any further notification attempts are warranted across all recipients.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_report_to_others_tree`
+  (issue #1252) — Evaluator guard checked at the outer loop level;
+  terminates all further notification attempts when the global effort
+  ceiling is reached
 
 ### `PolicyCompatible`
 
@@ -1145,6 +1408,11 @@ coordinated disclosure.
 - **Automation potential**: **Medium** — comparison between the recipient's published CVD policy and the case embargo terms is automatable for machine-readable policies (e.g., OpenVEX, structured security.txt); human review needed for ambiguous or informal policies.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.PolicyCompatible`
 - **Call-out point shape**: Evaluator
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_report_to_others_tree`
+  (issue #1252) — Evaluator precondition guard before `FindContact` and
+  `RcptNotInQrmS`; gates notification on policy compatibility check
+  against the recipient's published CVD/embargo policy
 
 ### `FindContact`
 
@@ -1162,6 +1430,11 @@ coordinated disclosure.
 - **Automation potential**: **High** — security.txt lookup, PSIRT directory queries, FIRST member database, and NVD contact data are all automatable for well-known organizations; obscure vendors may require manual research.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.FindContact`
 - **Call-out point shape**: Retriever
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_report_to_others_tree`
+  (issue #1252) — Retriever node after `PolicyCompatible`; resolves contact
+  details for the current recipient and writes them to the blackboard
+  for downstream use by `SetRcptQrmR` and outbound message nodes
 
 ### `RcptNotInQrmS`
 
@@ -1178,6 +1451,10 @@ coordinated disclosure.
 - **Automation potential**: **High** — RM state query against the case participant record; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.RcptNotInQrmS`
 - **Call-out point shape**: Sentinel — binary RM-state check against the recipient's participant record in the case; returns SUCCESS if the recipient's RM state is still START (not yet notified), FAILURE otherwise, with no output keys.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_report_to_others_tree`
+  (issue #1252) — Sentinel idempotency guard after `FindContact`; skips
+  re-notification if the recipient's RM state is already past START
 
 ### `SetRcptQrmR`
 
@@ -1194,6 +1471,11 @@ coordinated disclosure.
 - **Automation potential**: **High** — RM state write on the case participant record; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.SetRcptQrmR`
 - **Call-out point shape**: Actuator — writes a recipient RM-state transition (START → RECEIVED) to the case management system; the side-effect state write is the seam, not a content artifact placed on the blackboard.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_report_to_others_tree`
+  (issue #1252) — Actuator node after `RcptNotInQrmS` in the notification
+  Sequence; records the state transition confirming the recipient was
+  notified, before `RemoveRecipient` dequeues them
 
 ### `MoreVendors`
 
@@ -1210,6 +1492,10 @@ coordinated disclosure.
 - **Automation potential**: **High** — query against the vendor notification queue; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.MoreVendors`
 - **Call-out point shape**: Sentinel — binary queue-status check against the vendor notification queue; returns SUCCESS if additional vendors are pending notification, FAILURE otherwise, with no output keys.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_report_to_others_tree`
+  (issue #1252) — Sentinel guard at the head of the vendor sub-loop;
+  drives the vendor-notification iteration until the vendor queue is empty
 
 ### `MoreCoordinators`
 
@@ -1226,6 +1512,11 @@ coordinated disclosure.
 - **Automation potential**: **High** — query against the coordinator notification queue; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.MoreCoordinators`
 - **Call-out point shape**: Sentinel — binary queue-status check against the coordinator notification queue; returns SUCCESS if additional coordinators are pending notification, FAILURE otherwise, with no output keys.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_report_to_others_tree`
+  (issue #1252) — Sentinel guard at the head of the coordinator sub-loop;
+  drives coordinator-notification iteration until the coordinator queue is
+  empty
 
 ### `MoreOthers`
 
@@ -1241,6 +1532,11 @@ coordinated disclosure.
 - **Automation potential**: **High** — query against the other-parties notification queue; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.MoreOthers`
 - **Call-out point shape**: Sentinel — binary queue-status check against the other-parties notification queue; returns SUCCESS if additional other parties are pending notification, FAILURE otherwise, with no output keys.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_report_to_others_tree`
+  (issue #1252) — Sentinel guard at the head of the other-parties sub-loop;
+  drives other-party notification iteration until the other-parties queue
+  is empty
 
 ### `InjectParticipant`
 
@@ -1260,6 +1556,11 @@ coordinated disclosure.
 - **Automation potential**: **High** — case management system write; fully automatable once participant details are known.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.InjectParticipant`
 - **Call-out point shape**: Actuator — writes a new participant record to the case management system; the side-effect state write is the seam. Production replacement: InviteParticipantToCase protocol subtree (not yet implemented).
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_report_to_others_tree`
+  (issue #1252) — base Actuator node; production replacement is the
+  InviteParticipantToCase protocol subtree (#1199); the call-out point
+  seam lives here at the case-management write boundary
 
 ### `InjectVendor`
 
@@ -1276,6 +1577,11 @@ coordinated disclosure.
 - **Automation potential**: **High** — case management system write for vendor role; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.InjectVendor`
 - **Call-out point shape**: Actuator — inherits InjectParticipant; writes a vendor-role participant record to the case management system; the side-effect state write is the seam. Production replacement: InviteParticipantToCase protocol subtree.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_report_to_others_tree`
+  (issue #1252) — Actuator node in the vendor sub-loop, after `MoreVendors`
+  succeeds and the notification Sequence completes; invokes vendor-role
+  InviteParticipantToCase protocol subtree (#1199) once ready
 
 ### `InjectCoordinator`
 
@@ -1292,6 +1598,11 @@ coordinated disclosure.
 - **Automation potential**: **High** — case management system write for coordinator role; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.InjectCoordinator`
 - **Call-out point shape**: Actuator — inherits InjectParticipant; writes a coordinator-role participant record to the case management system; the side-effect state write is the seam. Production replacement: InviteParticipantToCase protocol subtree.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_report_to_others_tree`
+  (issue #1252) — Actuator node in the coordinator sub-loop, after
+  `MoreCoordinators` succeeds and the notification Sequence completes;
+  invokes coordinator-role InviteParticipantToCase protocol subtree (#1199)
 
 ### `InjectOther`
 
@@ -1308,6 +1619,11 @@ coordinated disclosure.
 - **Automation potential**: **High** — case management system write for other-party role; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.InjectOther`
 - **Call-out point shape**: Actuator — inherits InjectParticipant; writes an other-party participant record to the case management system; the side-effect state write is the seam. Production replacement: InviteParticipantToCase protocol subtree.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_report_to_others_tree`
+  (issue #1252) — Actuator node in the other-parties sub-loop, after
+  `MoreOthers` succeeds and the notification Sequence completes; invokes
+  other-party-role InviteParticipantToCase protocol subtree (#1199)
 
 ---
 
@@ -1335,6 +1651,11 @@ complete (or otherwise concluded).
 - **Automation potential**: **Low** — site-specific; closure criteria vary widely by organization and case context; typically requires human policy evaluation or explicit sign-off.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.close_report.OtherCloseCriteriaMet`
 - **Call-out point shape**: Evaluator
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_close_report_tree`
+  (issue #1253) — Evaluator precondition guard in the `RMCloseBt` Sequence;
+  evaluated before `PreCloseAction`; blocks closure until site-specific
+  criteria are satisfied
 
 ### `PreCloseAction`
 
@@ -1352,6 +1673,10 @@ complete (or otherwise concluded).
 - **Automation potential**: **Medium** — archiving and standard notification steps can be automated; QA review and final approvals typically require human involvement.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.close_report.PreCloseAction`
 - **Call-out point shape**: Actuator — fires integration hooks before case closure; invokes QA pipeline checks, final notification APIs, and case-archiving services. There is no content artifact placed on the blackboard; the side effects in external systems are the seam.
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_close_report_tree`
+  (issue #1253) — Actuator effect node after `OtherCloseCriteriaMet`;
+  last node before the RM → CLOSED state transition fires
 
 ---
 
@@ -1379,5 +1704,10 @@ accepted vulnerability report outside of the more specific sub-trees.
 - **Automation potential**: **Low** — intentional extensibility stub for unmodeled work; automation potential is entirely site-specific and cannot be assessed generically.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.other_work.OtherWork`
 - **Call-out point shape**: Evaluator
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_do_work_tree`
+  (issue #1255) — primary Evaluator leaf of `RMDoWorkBt`; the main
+  extensibility seam for organization-specific in-flight case work
+  not covered by more specific sub-trees
 
 ---

--- a/notes/bt-fuzzer-nodes-vul-discovery.md
+++ b/notes/bt-fuzzer-nodes-vul-discovery.md
@@ -70,6 +70,8 @@ is essentially the "output" of the discovery process.
 - **Automation potential**: **High** — static role/capability configuration check; can be fully automated as a lookup against the participant's role metadata or organizational task queue.
 - **New-arch cross-ref**: N/A — simulation-only BT not ported to new architecture
 - **Call-out point shape**: N/A
+- **Factory-fn placement**: N/A — simulation-only; `DiscoverVulnerabilityBt` is not
+  ported to the prototype architecture
 
 ### `DiscoverVulnerability`
 
@@ -86,6 +88,8 @@ is essentially the "output" of the discovery process.
 - **Automation potential**: **Low** — inherently a human or tool-driven research activity (fuzzing, code audit, pentesting); results must be fed in from an external research pipeline.
 - **New-arch cross-ref**: N/A — simulation-only BT not ported to new architecture
 - **Call-out point shape**: N/A
+- **Factory-fn placement**: N/A — simulation-only; `DiscoverVulnerabilityBt` is not
+  ported to the prototype architecture
 
 ### `NoVulFound`
 
@@ -102,5 +106,7 @@ is essentially the "output" of the discovery process.
 - **Automation potential**: **TerminalPlaceholder** — terminal success placeholder; no real decision logic required.
 - **New-arch cross-ref**: N/A — simulation-only BT not ported to new architecture
 - **Call-out point shape**: N/A
+- **Factory-fn placement**: N/A — simulation-only; `DiscoverVulnerabilityBt` is not
+  ported to the prototype architecture
 
 ---

--- a/notes/bt-fuzzer-nodes.md
+++ b/notes/bt-fuzzer-nodes.md
@@ -102,12 +102,16 @@ Each fuzzer node entry in the sub-files has these fields:
   blackboard output-key set (see BT-18-006)
 - **Composer** — reads composition context; writes a generated artifact;
   `SUCCESS` = artifact ready
+- **Actuator** — receives a trigger and context; invokes an external system
+  to cause a side effect (notification dispatch, state write, queue mutation,
+  API call); returns `SUCCESS` when the side effect is confirmed, `FAILURE`
+  otherwise. Does not produce a content artifact on the blackboard.
 - **ProtocolInternal** — node resolves entirely within the protocol
   implementation; no external input, output, or monitoring seam exists.
   Use this value only for terminal placeholders and structural composites
   that have no call-out point. Do NOT use `ProtocolInternal` because a
   node's automation potential is High — those nodes have an external seam
-  and belong to one of the four shapes above (BT-18-005).
+  and belong to one of the five shapes above (BT-18-005).
 
 ### Fuzzer Base Types (Quick Reference)
 

--- a/plan/history/2607/implementation/ISSUE-1187.md
+++ b/plan/history/2607/implementation/ISSUE-1187.md
@@ -1,0 +1,23 @@
+---
+source: ISSUE-1187
+timestamp: '2026-07-08T15:38:58.546786+00:00'
+title: 'FUZZ-08a-bis: Add factory-fn placement field to all fuzzer node catalog entries'
+type: implementation
+---
+
+## Issue #1187 — FUZZ-08a-bis: Add factory-fn placement field to all fuzzer node catalog entries
+
+Added the `factory-fn placement` field to every non-ProtocolInternal catalog entry across all four fuzzer node domain files (75 nodes in report-management alone, plus 14 in embargo, 1 in messaging, 3 N/A in vul-discovery).
+
+Key decisions:
+
+- Nodes with existing factory functions in `vultron/core/behaviors/` map directly with ordering hints (create_validate_report_tree, create_prioritize_subtree)
+- Nodes without existing factory functions use `FUTURE: vultron.core.behaviors.<module>.create_<name>_tree` with tracking issue references (#1246–#1255)
+- ProtocolInternal nodes (terminal success placeholders) get `N/A`
+- Simulation-only nodes (DiscoverVulnerabilityBt) get `N/A`
+- Reclassified 11+ Composer→Actuator nodes per ADR-0024 Actuator amendment
+- Fixed stale "four shapes" count references in ADR-0024 and bt-fuzzer-nodes.md
+
+Resolved merge conflict caused by PR #1243 (issue #1240) reclassifying 9 Sentinel→Retriever nodes; updated factory-fn descriptions to match.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1261>


### PR DESCRIPTION
- Closes #1187

## Summary

Adds the `factory-fn placement` field to every non-ProtocolInternal catalog entry across all four fuzzer node domain files, completing FUZZ-08a-bis. Each field maps the fuzzer node to the module-qualified `vultron.core.behaviors.*` factory function that hosts (or will host) it in the prototype BT, with ordering hints. Nodes whose target factory function does not yet exist use the `FUTURE:` convention with a reference to a tracking issue.

## Changes

- `notes/bt-fuzzer-nodes-vul-discovery.md`: 3 nodes → `N/A` (simulation-only; `DiscoverVulnerabilityBt` not ported to prototype architecture)
- `notes/bt-fuzzer-nodes-messaging.md`: 1 node → `FUTURE: vultron.core.behaviors.inbox.create_inbound_error_followup_tree` (issue #1254)
- `notes/bt-fuzzer-nodes-embargo.md`: 14 nodes → `FUTURE` refs to #1256/#1257; also reclassify `OnEmbargoExit`, `OnEmbargoAccept`, `OnEmbargoReject` from Composer → Actuator per ADR-0024 Actuator amendment
- `notes/bt-fuzzer-nodes-report-management.md`: 75 nodes → existing factory functions (`create_validate_report_tree`, `create_prioritize_subtree`) or `FUTURE` refs to tracking issues #1246–#1255; reclassify `Publish`, `OnDefer`, `OnAccept`, `RemoveRecipient`, `SetRcptQrmR`, `InjectParticipant`/`Vendor`/`Coordinator`/`Other`, `PreCloseAction` from Composer → Actuator; 3 ProtocolInternal bypass leaves (`NoPublishExploit`, `NoPublishFix`, `NoPublishReport`) → `N/A`
- `notes/bt-fuzzer-nodes.md`: Add Actuator shape to the call-out point shape enumeration; update "four shapes" → "five shapes"
- `docs/adr/0024-coordination-agent-taxonomy.md`: Fix stale "four agent shapes" count references in intro and section headings post-Actuator amendment; fix "fifth" references in deferred-addition sections

## Verification

- All 4386 unit tests pass
- Black, flake8, mypy, pyright clean
- markdownlint clean
- Notes frontmatter validation passes