### PR TITLE
docs: plan issue #1199 — reclassify internal BT condition checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -795,6 +795,23 @@ Short entries are reproduced here; longer ones are referenced below.
   external system and returns only SUCCESS/FAILURE is a Retriever, not a
   Sentinel.
 
+- **`NoNew*` flags imply an upstream Sentinel seam.** When a BT condition
+  node of the form `NoNew<X>Info` (or any node whose description says "check
+  whether new information has arrived") reads a change-detection flag, that
+  flag must have been written by someone. If the flag is written by the
+  **protocol's own BT execution** (e.g., a prior BT tick or an Actuator in
+  the same tree), the consuming node is `ProtocolInternal`. But if the flag
+  is written by an **external event monitor** — an agent that watches an
+  outside data source and fires into the blackboard when something changes —
+  then there is an upstream **Sentinel** agent whose call-out point must be
+  documented separately in the catalog. The consuming `NoNew*` node itself
+  is `ProtocolInternal` (it reads a local flag), but failing to document the
+  upstream Sentinel leaves the real external seam invisible. Always trace
+  the flag back to its writer and record a Sentinel stub entry for it. See
+  `notes/bt-fuzzer-nodes-report-management.md` for `NewValidationInfoSentinel`,
+  `NewPrioritizationInfoSentinel`, and `NewDeploymentInfoSentinel` as worked
+  examples. (Established in issue #1199.)
+
 ## Skill Interaction Rules
 
 When a skill requires user input or asks the user a question:

--- a/notes/bt-fuzzer-nodes-report-management.md
+++ b/notes/bt-fuzzer-nodes-report-management.md
@@ -69,7 +69,35 @@ credible and valid for the receiving organization.
   re-evaluation loops
 - **Automation potential**: **High** — event subscription on the case record or metadata timestamp comparison; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.validate.NoNewValidationInfo`
-- **Call-out point shape**: Sentinel — binary change-detection condition; monitors the case record for new validation-relevant events via a metadata timestamp or event subscription; returns SUCCESS/FAILURE with no output keys.
+- **Call-out point shape**: ProtocolInternal — reads a change-detection flag written by the upstream
+  `NewValidationInfoSentinel` agent (see stub entry below). The external agent seam is at the
+  Sentinel (event subscription or polling hook), not at this BT condition check. In production this
+  node reads from the BT blackboard or case metadata written by the upstream Sentinel.
+  (Category 2 per issue #1199 triage — consumes a flag written by an upstream Sentinel.)
+
+### `NewValidationInfoSentinel` *(upstream Sentinel stub)*
+
+- **Node name**: `NewValidationInfoSentinel`
+- **btz type**: *(not a BT node — upstream agent seam)*
+- **Source file**: *(to be determined)*
+- **Parent tree**: *(runs independently, outside the BT tick loop)*
+- **Semantic function**: Sentinel — monitors the case record for new
+  validation-relevant events (e.g., reporter follow-up, credibility update,
+  new threat intelligence) and writes a change-detection flag that
+  `NoNewValidationInfo` consumes.
+- **Input dependency**: Case management system event stream; metadata
+  timestamp comparison or event subscription on validation-relevant case
+  fields.
+- **Notes**: This is the real call-out point implied by `NoNewValidationInfo`.
+  The upstream Sentinel registers with an external event source and writes
+  a flag to the BT blackboard / local DataLayer; `NoNewValidationInfo` then
+  reads that flag each BT tick. Implementation tracked in FUZZ-08f.
+- **Automation potential**: **High** — event subscription on the case record
+  or metadata timestamp comparison; fully automatable.
+- **New-arch cross-ref**: *(to be implemented — see FUZZ-08f)*
+- **Call-out point shape**: Sentinel — registers with a case-event source;
+  fires a change-detection signal into the BT blackboard when new
+  validation-relevant information arrives; no output keys beyond the flag.
 
 ### `EvaluateReportCredibility`
 
@@ -160,7 +188,35 @@ models the process of deciding whether to accept (engage with) or defer
 - **Notes**: Succeeds more often than not to avoid redundant re-evaluation
 - **Automation potential**: **High** — metadata timestamp or case-update event check; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.prioritize.NoNewPrioritizationInfo`
-- **Call-out point shape**: Sentinel — binary change-detection condition; monitors the case record for new prioritization-relevant events via a metadata timestamp or event subscription; returns SUCCESS/FAILURE with no output keys.
+- **Call-out point shape**: ProtocolInternal — reads a change-detection flag written by the upstream
+  `NewPrioritizationInfoSentinel` agent (see stub entry below). The external agent seam is at the
+  Sentinel (event subscription or polling hook), not at this BT condition check.
+  (Category 2 per issue #1199 triage — consumes a flag written by an upstream Sentinel.)
+
+### `NewPrioritizationInfoSentinel` *(upstream Sentinel stub)*
+
+- **Node name**: `NewPrioritizationInfoSentinel`
+- **btz type**: *(not a BT node — upstream agent seam)*
+- **Source file**: *(to be determined)*
+- **Parent tree**: *(runs independently, outside the BT tick loop)*
+- **Semantic function**: Sentinel — monitors the case record for new
+  prioritization-relevant events (e.g., updated SSVC scoring data, new
+  threat intelligence, CVSS score update) and writes a change-detection
+  flag that `NoNewPrioritizationInfo` consumes.
+- **Input dependency**: Case management system event stream; metadata
+  timestamp comparison or event subscription on prioritization-relevant
+  case fields (e.g., SSVC decision points, CVSS scores).
+- **Notes**: This is the real call-out point implied by
+  `NoNewPrioritizationInfo`. The upstream Sentinel registers with an
+  external event source and writes a flag to the BT blackboard / local
+  DataLayer; `NoNewPrioritizationInfo` reads that flag each BT tick.
+  Implementation tracked in FUZZ-08f.
+- **Automation potential**: **High** — event subscription on the case record
+  or metadata timestamp comparison; fully automatable.
+- **New-arch cross-ref**: *(to be implemented — see FUZZ-08f)*
+- **Call-out point shape**: Sentinel — registers with a case-event source;
+  fires a change-detection signal into the BT blackboard when new
+  prioritization-relevant information arrives; no output keys beyond the flag.
 
 ### `EnoughPrioritizationInfo`
 
@@ -287,7 +343,8 @@ to a validated report.
   their own BT context.
 - **Automation potential**: **High** — static organizational configuration; can be fully automated as a capability metadata lookup.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.assign_vul_id.IsIDAssignmentAuthority`
-- **Call-out point shape**: Retriever — synchronous on-demand query to the participant's static role metadata; returns SUCCESS if this participant holds `CVDRole.CVE_NUMBERING_AUTHORITY` in their `case_roles`, FAILURE otherwise. A boolean is the simplest structured fact (ADR-0024); the on-demand query pattern makes this a Retriever, not a Sentinel (see BT-18-006).
+- **Call-out point shape**: ProtocolInternal — reads a deployment-time configuration constant (`CVDRole.CVE_NUMBERING_AUTHORITY` on this participant's `case_roles`); the value is set at participant registration, not queried from an external system at runtime. There is no agent seam here: the check resolves entirely within the protocol's own DataLayer.
+  (Category 2 per issue #1199 triage — reads a flag written by the protocol's own deployment-time setup.)
 
 ### `IdAssignable`
 
@@ -396,7 +453,35 @@ the process of deploying a developed fix or mitigation to affected systems.
   without update
 - **Automation potential**: **High** — metadata timestamp or deployment-event subscription check; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.deploy_fix.NoNewDeploymentInfo`
-- **Call-out point shape**: Sentinel — binary change-detection condition; monitors the case/deployment record for new deployment-relevant events via a metadata timestamp or event subscription; returns SUCCESS/FAILURE with no output keys.
+- **Call-out point shape**: ProtocolInternal — reads a change-detection flag written by the upstream
+  `NewDeploymentInfoSentinel` agent (see stub entry below). The external agent seam is at the
+  Sentinel (event subscription or polling hook), not at this BT condition check.
+  (Category 2 per issue #1199 triage — consumes a flag written by an upstream Sentinel.)
+
+### `NewDeploymentInfoSentinel` *(upstream Sentinel stub)*
+
+- **Node name**: `NewDeploymentInfoSentinel`
+- **btz type**: *(not a BT node — upstream agent seam)*
+- **Source file**: *(to be determined)*
+- **Parent tree**: *(runs independently, outside the BT tick loop)*
+- **Semantic function**: Sentinel — monitors deployment-relevant data sources
+  (e.g., patch management system, CI/CD pipeline, asset inventory) for new
+  deployment-related events and writes a change-detection flag that
+  `NoNewDeploymentInfo` consumes.
+- **Input dependency**: Patch management system event stream, CI/CD pipeline
+  notifications, or asset-inventory change feed; metadata timestamp
+  comparison or event subscription on deployment-relevant case fields.
+- **Notes**: This is the real call-out point implied by
+  `NoNewDeploymentInfo`. The upstream Sentinel registers with an external
+  event source and writes a flag to the BT blackboard / local DataLayer;
+  `NoNewDeploymentInfo` reads that flag each BT tick.
+  Implementation tracked in FUZZ-08f.
+- **Automation potential**: **High** — event subscription on the patch
+  management system or CI/CD pipeline; fully automatable.
+- **New-arch cross-ref**: *(to be implemented — see FUZZ-08f)*
+- **Call-out point shape**: Sentinel — registers with a deployment-event
+  source; fires a change-detection signal into the BT blackboard when new
+  deployment-relevant information arrives; no output keys beyond the flag.
 
 ### `PrioritizeDeployment`
 
@@ -550,7 +635,10 @@ vulnerability, typically to support impact assessment or testing.
   prerequisite step that runs early
 - **Automation potential**: **High** — metadata flag check on the case record; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.acquire_exploit.ExploitPrioritySet`
-- **Call-out point shape**: Sentinel — binary case-metadata flag check; returns SUCCESS if a priority decision for exploit acquisition has already been recorded for this case, FAILURE otherwise, with no output keys.
+- **Call-out point shape**: ProtocolInternal — reads a flag written by `EvaluateExploitPriority`
+  during the same BT execution cycle; the flag lives on the BT blackboard (per-actor in-process).
+  No external agent seam — the flag never crosses an actor boundary.
+  (Category 3 per issue #1199 triage — reads a flag written by the protocol's own BT execution.)
 
 ### `EvaluateExploitPriority`
 
@@ -582,7 +670,10 @@ vulnerability, typically to support impact assessment or testing.
   exploit acquisition is not always the highest priority
 - **Automation potential**: **High** — read the outcome of the priority evaluation from case metadata; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.acquire_exploit.ExploitDeferred`
-- **Call-out point shape**: Sentinel — binary case-metadata flag check against the outcome written by EvaluateExploitPriority; returns SUCCESS if the decision was to defer exploit acquisition, FAILURE otherwise, with no output keys.
+- **Call-out point shape**: ProtocolInternal — reads a flag written by `EvaluateExploitPriority`
+  during the same BT execution cycle; the flag lives on the BT blackboard (per-actor in-process).
+  No external agent seam — the flag never crosses an actor boundary.
+  (Category 3 per issue #1199 triage — reads a flag written by the protocol's own BT execution.)
 
 ### `ExploitDesired`
 
@@ -597,7 +688,10 @@ vulnerability, typically to support impact assessment or testing.
 - **Notes**: Complements `ExploitDeferred`; fails more often than it succeeds
 - **Automation potential**: **High** — read the outcome of the priority evaluation from case metadata; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.acquire_exploit.ExploitDesired`
-- **Call-out point shape**: Sentinel — binary case-metadata flag check against the outcome written by EvaluateExploitPriority; returns SUCCESS if the decision was to acquire an exploit, FAILURE otherwise, with no output keys.
+- **Call-out point shape**: ProtocolInternal — reads a flag written by `EvaluateExploitPriority`
+  during the same BT execution cycle; the flag lives on the BT blackboard (per-actor in-process).
+  No external agent seam — the flag never crosses an actor boundary.
+  (Category 3 per issue #1199 triage — reads a flag written by the protocol's own BT execution.)
 
 ### `FindExploit`
 
@@ -752,7 +846,10 @@ preparing them, and executing publication.
   is an active goal being worked toward
 - **Automation potential**: **High** — publication status flag on the case record; fully automatable as a metadata check.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.publication.AllPublished`
-- **Call-out point shape**: Sentinel — binary publication-status check against a case-record flag; returns SUCCESS if all intended publication artifacts have been published, FAILURE otherwise, with no output keys.
+- **Call-out point shape**: ProtocolInternal — reads a publication-completion flag maintained in the
+  local DataLayer / BT blackboard by the protocol's own BT execution (written by `Publish` nodes).
+  No external agent seam — the flag is local and actor-scoped.
+  (Category 3 per issue #1199 triage — reads a flag written by the protocol's own BT execution.)
 
 ### `PublicationIntentsSet`
 
@@ -769,7 +866,10 @@ preparing them, and executing publication.
   is an early workflow step being modeled
 - **Automation potential**: **High** — publication intent flags on the case record; fully automatable as a metadata check.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.publication.PublicationIntentsSet`
-- **Call-out point shape**: Sentinel — binary case-metadata flag check; returns SUCCESS if publication intentions have already been established for this case, FAILURE otherwise, with no output keys.
+- **Call-out point shape**: ProtocolInternal — reads a flag written by `PrioritizePublicationIntents`
+  during the same BT execution cycle; the flag lives on the local DataLayer / BT blackboard.
+  No external agent seam — the flag is local and actor-scoped.
+  (Category 3 per issue #1199 triage — reads a flag written by the protocol's own BT execution.)
 
 ### `PrioritizePublicationIntents`
 
@@ -833,7 +933,10 @@ preparing them, and executing publication.
 - **Notes**: Ready more often than not once preparation has started
 - **Automation potential**: **High** — artifact staging-status check in the publishing pipeline; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.publication.ExploitReady`
-- **Call-out point shape**: Sentinel — binary artifact-staging status check against the publishing pipeline; returns SUCCESS if the exploit artifact is staged and ready for publication, FAILURE otherwise, with no output keys.
+- **Call-out point shape**: ProtocolInternal — reads a staging-readiness flag written by
+  `PrepareExploit` during the same BT execution cycle; the flag lives on the local DataLayer /
+  BT blackboard. No external agent seam — the flag is local and actor-scoped.
+  (Category 3 per issue #1199 triage — reads a flag written by the protocol's own BT execution.)
 
 ### `PrepareExploit`
 
@@ -1064,7 +1167,10 @@ coordinated disclosure.
   against a notification queue
 - **Automation potential**: **High** — notification status tracking against the identified-parties queue; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.NotificationsComplete`
-- **Call-out point shape**: Sentinel — binary status check against notification tracking metadata; returns SUCCESS if all identified parties have been successfully notified, FAILURE otherwise, with no output keys.
+- **Call-out point shape**: ProtocolInternal — reads notification-completion flags maintained in the
+  local DataLayer / BT blackboard by the protocol's own `SetRcptQrmR` Actuator nodes (per-actor
+  in-process). No external agent seam — the flag is local and actor-scoped.
+  (Category 3 per issue #1199 triage — reads a flag written by the protocol's own BT execution.)
 
 ### `ChooseRecipient`
 
@@ -1177,7 +1283,10 @@ coordinated disclosure.
 - **Notes**: Succeeds almost always; guards against duplicate notifications
 - **Automation potential**: **High** — RM state query against the case participant record; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.RcptNotInQrmS`
-- **Call-out point shape**: Sentinel — binary RM-state check against the recipient's participant record in the case; returns SUCCESS if the recipient's RM state is still START (not yet notified), FAILURE otherwise, with no output keys.
+- **Call-out point shape**: ProtocolInternal — reads a per-recipient RM-state flag maintained in the
+  local DataLayer / BT blackboard; the flag is written by `SetRcptQrmR` (protocol-internal Actuator)
+  after each notification. No external agent seam — the flag is local and actor-scoped.
+  (Category 3 per issue #1199 triage — reads a flag written by the protocol's own BT execution.)
 
 ### `SetRcptQrmR`
 
@@ -1209,7 +1318,10 @@ coordinated disclosure.
   is usually short
 - **Automation potential**: **High** — query against the vendor notification queue; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.MoreVendors`
-- **Call-out point shape**: Sentinel — binary queue-status check against the vendor notification queue; returns SUCCESS if additional vendors are pending notification, FAILURE otherwise, with no output keys.
+- **Call-out point shape**: ProtocolInternal — checks the local `bb.case.potential_participants`
+  vendor sub-list (BT blackboard, per-actor in-process); this is a BT for-loop iteration guard,
+  not an external query. No external agent seam — the list is local and actor-scoped.
+  (Category 3 per issue #1199 triage — reads from the protocol's own BT blackboard.)
 
 ### `MoreCoordinators`
 
@@ -1225,7 +1337,10 @@ coordinated disclosure.
   short (often zero or one)
 - **Automation potential**: **High** — query against the coordinator notification queue; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.MoreCoordinators`
-- **Call-out point shape**: Sentinel — binary queue-status check against the coordinator notification queue; returns SUCCESS if additional coordinators are pending notification, FAILURE otherwise, with no output keys.
+- **Call-out point shape**: ProtocolInternal — checks the local `bb.case.potential_participants`
+  coordinator sub-list (BT blackboard, per-actor in-process); this is a BT for-loop iteration guard,
+  not an external query. No external agent seam — the list is local and actor-scoped.
+  (Category 3 per issue #1199 triage — reads from the protocol's own BT blackboard.)
 
 ### `MoreOthers`
 
@@ -1240,7 +1355,10 @@ coordinated disclosure.
 - **Notes**: Fails almost always; catch-all category is usually empty
 - **Automation potential**: **High** — query against the other-parties notification queue; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.MoreOthers`
-- **Call-out point shape**: Sentinel — binary queue-status check against the other-parties notification queue; returns SUCCESS if additional other parties are pending notification, FAILURE otherwise, with no output keys.
+- **Call-out point shape**: ProtocolInternal — checks the local `bb.case.potential_participants`
+  other-parties sub-list (BT blackboard, per-actor in-process); this is a BT for-loop iteration guard,
+  not an external query. No external agent seam — the list is local and actor-scoped.
+  (Category 3 per issue #1199 triage — reads from the protocol's own BT blackboard.)
 
 ### `InjectParticipant`
 

--- a/notes/bt-fuzzer-nodes-report-management.md
+++ b/notes/bt-fuzzer-nodes-report-management.md
@@ -74,6 +74,11 @@ credible and valid for the receiving organization.
   Sentinel (event subscription or polling hook), not at this BT condition check. In production this
   node reads from the BT blackboard or case metadata written by the upstream Sentinel.
   (Category 2 per issue #1199 triage — consumes a flag written by an upstream Sentinel.)
+- **Factory-fn placement**:
+  `vultron.core.behaviors.report.validate_tree.create_validate_report_tree` —
+  ProtocolInternal condition check at the top of `ValidationOrShortcut` Selector;
+  currently stubbed as `CheckRMStateValid` but the change-detection variant
+  belongs here when the full retry loop is implemented (Phase 2)
 
 ### `NewValidationInfoSentinel` *(upstream Sentinel stub)*
 
@@ -98,11 +103,11 @@ credible and valid for the receiving organization.
 - **Call-out point shape**: Sentinel — registers with a case-event source;
   fires a change-detection signal into the BT blackboard when new
   validation-relevant information arrives; no output keys beyond the flag.
-- **Factory-fn placement**:
-  `vultron.core.behaviors.report.validate_tree.create_validate_report_tree` —
-  early-exit Sentinel guard at the top of `ValidationOrShortcut` Selector;
-  currently stubbed as `CheckRMStateValid` but the change-detection variant
-  belongs here when the full retry loop is implemented (Phase 2)
+- **Factory-fn placement**: FUZZ-08f (planned) — upstream agent seam, not
+  placed inside the BT tree; writes a change-detection flag to the blackboard
+  key read by `NoNewValidationInfo` at the top of the
+  `ValidationOrShortcut` Selector in
+  `vultron.core.behaviors.report.validate_tree.create_validate_report_tree`
 
 ### `EvaluateReportCredibility`
 
@@ -215,6 +220,11 @@ models the process of deciding whether to accept (engage with) or defer
   `NewPrioritizationInfoSentinel` agent (see stub entry below). The external agent seam is at the
   Sentinel (event subscription or polling hook), not at this BT condition check.
   (Category 2 per issue #1199 triage — consumes a flag written by an upstream Sentinel.)
+- **Factory-fn placement**:
+  `vultron.core.behaviors.report.prioritize_tree.create_prioritize_subtree` —
+  ProtocolInternal condition check at the top of `PrioritizeBT` Selector; the retry
+  skip-if-no-new-info check belongs here when the full re-prioritization
+  loop is implemented (Phase 2)
 
 ### `NewPrioritizationInfoSentinel` *(upstream Sentinel stub)*
 
@@ -240,11 +250,11 @@ models the process of deciding whether to accept (engage with) or defer
 - **Call-out point shape**: Sentinel — registers with a case-event source;
   fires a change-detection signal into the BT blackboard when new
   prioritization-relevant information arrives; no output keys beyond the flag.
-- **Factory-fn placement**:
-  `vultron.core.behaviors.report.prioritize_tree.create_prioritize_subtree` —
-  early-exit Sentinel guard at the top of `PrioritizeBT` Selector; the retry
-  skip-if-no-new-info check belongs here when the full re-prioritization
-  loop is implemented (Phase 2)
+- **Factory-fn placement**: FUZZ-08f (planned) — upstream agent seam, not
+  placed inside the BT tree; writes a change-detection flag to the blackboard
+  key read by `NoNewPrioritizationInfo` at the top of the
+  `PrioritizeBT` Selector in
+  `vultron.core.behaviors.report.prioritize_tree.create_prioritize_subtree`
 
 ### `EnoughPrioritizationInfo`
 
@@ -401,8 +411,8 @@ to a validated report.
   (Category 2 per issue #1199 triage — reads a flag written by the protocol's own deployment-time setup.)
 - **Factory-fn placement**: FUTURE:
   `vultron.core.behaviors.report.create_assign_vul_id_tree` (issue #1246) —
-  Retriever condition guard in `AssignVulID` Sequence; queries participant
-  role metadata before `IdAssignable` and `AssignId`
+  ProtocolInternal condition check in `AssignVulID` Sequence; evaluates
+  participant role metadata before `IdAssignable` and `AssignId`
 
 ### `IdAssignable`
 
@@ -530,6 +540,9 @@ the process of deploying a developed fix or mitigation to affected systems.
   `NewDeploymentInfoSentinel` agent (see stub entry below). The external agent seam is at the
   Sentinel (event subscription or polling hook), not at this BT condition check.
   (Category 2 per issue #1199 triage — consumes a flag written by an upstream Sentinel.)
+- **Factory-fn placement**: FUTURE:
+  `vultron.core.behaviors.report.create_deploy_fix_tree` (issue #1248) —
+  ProtocolInternal condition check at the top of `Deployment` Fallback Selector
 
 ### `NewDeploymentInfoSentinel` *(upstream Sentinel stub)*
 
@@ -555,9 +568,11 @@ the process of deploying a developed fix or mitigation to affected systems.
 - **Call-out point shape**: Sentinel — registers with a deployment-event
   source; fires a change-detection signal into the BT blackboard when new
   deployment-relevant information arrives; no output keys beyond the flag.
-- **Factory-fn placement**: FUTURE:
-  `vultron.core.behaviors.report.create_deploy_fix_tree` (issue #1248) —
-  early-exit Sentinel guard at the top of `Deployment` Fallback Selector
+- **Factory-fn placement**: FUZZ-08f (planned) — upstream agent seam, not
+  placed inside the BT tree; writes a change-detection flag to the blackboard
+  key read by `NoNewDeploymentInfo` at the top of the `Deployment` Fallback
+  Selector in
+  `vultron.core.behaviors.report.create_deploy_fix_tree` (issue #1248)
 
 ### `PrioritizeDeployment`
 
@@ -750,8 +765,8 @@ vulnerability, typically to support impact assessment or testing.
   (Category 3 per issue #1199 triage — reads a flag written by the protocol's own BT execution.)
 - **Factory-fn placement**: FUTURE:
   `vultron.core.behaviors.report.create_acquire_exploit_strategy_tree`
-  (issue #1249) — early-exit Sentinel after `HaveExploit`; collapses the
-  loop if the priority decision is already on record for this cycle
+  (issue #1249) — ProtocolInternal condition check after `HaveExploit`;
+  collapses the loop if the priority decision is already on record for this cycle
 
 ### `EvaluateExploitPriority`
 
@@ -772,7 +787,7 @@ vulnerability, typically to support impact assessment or testing.
   `vultron.core.behaviors.report.create_acquire_exploit_strategy_tree`
   (issue #1249) — Evaluator action node in the priority-decision Sequence;
   writes the `exploit_priority` decision to the blackboard for downstream
-  Sentinel nodes
+  ProtocolInternal condition nodes (`ExploitDeferred`, `ExploitDesired`)
 
 ### `ExploitDeferred`
 
@@ -794,7 +809,7 @@ vulnerability, typically to support impact assessment or testing.
   (Category 3 per issue #1199 triage — reads a flag written by the protocol's own BT execution.)
 - **Factory-fn placement**: FUTURE:
   `vultron.core.behaviors.report.create_acquire_exploit_strategy_tree`
-  (issue #1249) — Sentinel branch guard after `EvaluateExploitPriority`;
+  (issue #1249) — ProtocolInternal condition check after `EvaluateExploitPriority`;
   early-exits the acquire-exploit Selector when deferral is recorded
 
 ### `ExploitDesired`
@@ -816,7 +831,7 @@ vulnerability, typically to support impact assessment or testing.
   (Category 3 per issue #1199 triage — reads a flag written by the protocol's own BT execution.)
 - **Factory-fn placement**: FUTURE:
   `vultron.core.behaviors.report.create_acquire_exploit_strategy_tree`
-  (issue #1249) — Sentinel precondition guard before the acquisition
+  (issue #1249) — ProtocolInternal condition check before the acquisition
   Fallback (`FindExploit → DevelopExploit → PurchaseExploit`)
 
 ### `FindExploit`
@@ -1006,7 +1021,7 @@ preparing them, and executing publication.
   (Category 3 per issue #1199 triage — reads a flag written by the protocol's own BT execution.)
 - **Factory-fn placement**: FUTURE:
   `vultron.core.behaviors.report.create_publication_tree`
-  (issue #1251) — top-level early-exit Sentinel guard at the root
+  (issue #1251) — top-level early-exit ProtocolInternal condition check at the root
   of the `Publication` Selector; short-circuits the entire subtree once
   all artifacts are published
 
@@ -1031,7 +1046,7 @@ preparing them, and executing publication.
   (Category 3 per issue #1199 triage — reads a flag written by the protocol's own BT execution.)
 - **Factory-fn placement**: FUTURE:
   `vultron.core.behaviors.report.create_publication_tree`
-  (issue #1251) — Sentinel guard before `PrioritizePublicationIntents`;
+  (issue #1251) — ProtocolInternal condition check before `PrioritizePublicationIntents`;
   skips intent-setting if a publication plan is already on record
 
 ### `PrioritizePublicationIntents`
@@ -1115,7 +1130,7 @@ preparing them, and executing publication.
   (Category 3 per issue #1199 triage — reads a flag written by the protocol's own BT execution.)
 - **Factory-fn placement**: FUTURE:
   `vultron.core.behaviors.report.create_publication_tree`
-  (issue #1251) — Sentinel guard before `Publish` in the exploit-arm
+  (issue #1251) — ProtocolInternal condition check before `Publish` in the exploit-arm
   Sequence; succeeds when the exploit artifact is already staged, avoiding
   redundant `PrepareExploit` work
 
@@ -1411,7 +1426,7 @@ coordinated disclosure.
   (Category 3 per issue #1199 triage — reads a flag written by the protocol's own BT execution.)
 - **Factory-fn placement**: FUTURE:
   `vultron.core.behaviors.report.create_report_to_others_tree`
-  (issue #1252) — Sentinel guard at the top of the per-recipient
+  (issue #1252) — ProtocolInternal condition check at the top of the per-recipient
   notification loop; exits the loop once the full notification queue
   is drained
 
@@ -1562,7 +1577,7 @@ coordinated disclosure.
   (Category 3 per issue #1199 triage — reads a flag written by the protocol's own BT execution.)
 - **Factory-fn placement**: FUTURE:
   `vultron.core.behaviors.report.create_report_to_others_tree`
-  (issue #1252) — Sentinel idempotency guard after `FindContact`; skips
+  (issue #1252) — ProtocolInternal idempotency check after `FindContact`; skips
   re-notification if the recipient's RM state is already past START
 
 ### `SetRcptQrmR`
@@ -1606,7 +1621,7 @@ coordinated disclosure.
   (Category 3 per issue #1199 triage — reads from the protocol's own BT blackboard.)
 - **Factory-fn placement**: FUTURE:
   `vultron.core.behaviors.report.create_report_to_others_tree`
-  (issue #1252) — Sentinel guard at the head of the vendor sub-loop;
+  (issue #1252) — ProtocolInternal iteration guard at the head of the vendor sub-loop;
   drives the vendor-notification iteration until the vendor queue is empty
 
 ### `MoreCoordinators`
@@ -1629,7 +1644,7 @@ coordinated disclosure.
   (Category 3 per issue #1199 triage — reads from the protocol's own BT blackboard.)
 - **Factory-fn placement**: FUTURE:
   `vultron.core.behaviors.report.create_report_to_others_tree`
-  (issue #1252) — Sentinel guard at the head of the coordinator sub-loop;
+  (issue #1252) — ProtocolInternal iteration guard at the head of the coordinator sub-loop;
   drives coordinator-notification iteration until the coordinator queue is
   empty
 
@@ -1652,7 +1667,7 @@ coordinated disclosure.
   (Category 3 per issue #1199 triage — reads from the protocol's own BT blackboard.)
 - **Factory-fn placement**: FUTURE:
   `vultron.core.behaviors.report.create_report_to_others_tree`
-  (issue #1252) — Sentinel guard at the head of the other-parties sub-loop;
+  (issue #1252) — ProtocolInternal iteration guard at the head of the other-parties sub-loop;
   drives other-party notification iteration until the other-parties queue
   is empty
 

--- a/plan/history/2607/idea/IDEA-1199.md
+++ b/plan/history/2607/idea/IDEA-1199.md
@@ -1,0 +1,11 @@
+---
+source: IDEA-1199
+timestamp: '2026-07-08T15:48:15.725016+00:00'
+title: Reclassify internal BT condition checks
+type: idea
+---
+
+Many nodes in the call-out point catalog (`notes/bt-fuzzer-nodes-report-management.md`) were assigned Sentinel shape but do not meet the Sentinel seam criteria — they read flags written either by the protocol's own BT execution (Category 3) or by an upstream Sentinel agent that was not yet documented (Category 2). The catalog needed to reflect ProtocolInternal shape for the consuming nodes, with explicit upstream Sentinel stub entries for the NoNew* pattern.
+
+**Processed**: 2026-07-08 — docs-only resolution; no implementation issues created. Replacement of ProtocolInternal fuzzer stubs with deterministic Condition nodes tracked in #1152 (FUZZ-08c, already blocked-by this issue). Upstream Sentinel stub implementation tracked in FUZZ-08f.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1262>.


### PR DESCRIPTION
- Closes #1199

## Summary

Reclassifies 15 call-out point catalog nodes in
`notes/bt-fuzzer-nodes-report-management.md` from `Sentinel` (or `Retriever`)
to `ProtocolInternal`, per the triage analysis in issue #1199.
Adds 3 upstream Sentinel stub entries for the `NoNew*` pattern and a new
`AGENTS.md` Common Pitfalls entry documenting the implication.

## Changes

- **`notes/bt-fuzzer-nodes-report-management.md`**:
  - Reclassify 3 Category-2 nodes (`NoNewValidationInfo`,
    `NoNewPrioritizationInfo`, `NoNewDeploymentInfo`) from Sentinel →
    ProtocolInternal; each reads a flag written by an upstream Sentinel agent.
  - Reclassify 12 Category-3 nodes (`IsIDAssignmentAuthority`,
    `ExploitPrioritySet`, `ExploitDeferred`, `ExploitDesired`,
    `AllPublished`, `PublicationIntentsSet`, `ExploitReady`,
    `NotificationsComplete`, `RcptNotInQrmS`, `MoreVendors`,
    `MoreCoordinators`, `MoreOthers`) from Sentinel/Retriever →
    ProtocolInternal; each reads from the BT blackboard or local DataLayer
    with no external agent seam.
  - Add 3 upstream Sentinel stub entries (`NewValidationInfoSentinel`,
    `NewPrioritizationInfoSentinel`, `NewDeploymentInfoSentinel`), each
    cross-referencing its ProtocolInternal consuming node and noting
    implementation in FUZZ-08f.
- **`AGENTS.md`**: Add Common Pitfalls entry — "`NoNew*` flags imply an
  upstream Sentinel seam": trace every change-detection flag back to its
  writer; document a Sentinel stub entry if the writer is an external event
  monitor.

## Background

`IsIDAssignmentAuthority` was reclassified Retriever by PR #1243 based on
ADR-0024/BT-18-006. This PR overrides that to ProtocolInternal per the
grill-me interview for #1199: the value is a deployment-time configuration
constant on the participant's `case_roles`, not a runtime external query —
the check resolves entirely within the protocol's own DataLayer.

Replacement of all ProtocolInternal fuzzer stubs with deterministic
`py_trees.behaviour.Behaviour` Condition nodes is tracked in #1152 (FUZZ-08c,
already blocked-by #1199).