### PR TITLE
docs: plan #1133 — auto_create_case policy, ADR-0015 refinement, CM-15-001

### DIFF
--- a/docs/adr/0015-create-case-at-report-receipt.md
+++ b/docs/adr/0015-create-case-at-report-receipt.md
@@ -151,12 +151,33 @@ This decision is validated by:
 - Bad, because cases for subsequently-invalidated reports persist in
   storage (acceptable; they are in a terminal state)
 
+## Post-Decision Refinement (issue #1133, 2026-07-08)
+
+The Option 4 "always create case" behavior is now **configurable** via
+`ActorConfig.auto_create_case: bool` (default: `True`).
+
+When `auto_create_case=False`, `SubmitReportReceivedUseCase` stores the
+inbound `VulnerabilityReport` and `Offer(Report)` activity as before, but
+the `create_receive_report_case_tree` BT exits early without creating a
+`VulnerabilityCase`. This enables the **Option 3** path that was evaluated
+and rejected in the original decision: the receiver can send a pre-case
+`Read(Offer(Report))` acknowledgment (via `AckReportReceivedUseCase`) before
+explicitly deciding to accept or reject the report.
+
+The default preserves the original Option 4 behavior for all existing actors
+and scenarios. The `auto_create_case=False` path is intended for scenarios
+that model deliberate pre-case evaluation workflows (see issue #1221 —
+tentative rejection → acceptance — as the first demo to use this flag).
+
+Spec requirement: `specs/case-management.yaml` CM-15-001.
+
 ## More Information
 
 - **Supersedes**: FINDER-PART-1 task in `plan/IMPLEMENTATION_PLAN.md`
 - **Refines**: `notes/case-state-model.md` (proto-case / caterpillar–butterfly
   metaphor)
-- **Updates**: `specs/case-management.yaml` (new CM-12 requirements)
+- **Updates**: `specs/case-management.yaml` (new CM-12 requirements, CM-15-001)
 - **Updates**: `specs/duration.yaml` (DUR-07-002 timing, new DUR-07-004)
 - **Updates**: `notes/protocol-event-cascades.md` (cascade list)
 - **Source idea**: IDEA-260408-01 in `plan/IDEAS.md`
+- **Post-decision refinement**: issue #1133

--- a/notes/demo-future-ideas.md
+++ b/notes/demo-future-ideas.md
@@ -67,6 +67,26 @@ be treated as working implementations.
 | Embargo variations | #1222 | Negotiation, collapse, deliberate delay |
 | CVD recipe injects | #1223 | Twists from the CERT Guide to CVD cvd_recipes |
 
+### Pre-case ACK flow (`auto_create_case=False`)
+
+Issue #1133 introduced `ActorConfig.auto_create_case` (default: `True`). When
+`False`, the receiver stores the inbound report but does **not** auto-create a
+`VulnerabilityCase`, enabling the receiver to send a pre-case
+`Read(Offer(Report))` acknowledgment (`AckReportReceivedUseCase`) before
+deciding to accept or reject.
+
+The **tentative rejection → acceptance** scenario (#1221) is the first planned
+demo to exercise this path:
+
+1. Finder submits report.
+2. Vendor (with `auto_create_case=False`) sends pre-case ACK via trigger.
+3. Vendor invalidates report (RM:R→I) — "tentative rejection".
+4. Vendor later validates (RM:I→V) and engages — "reconsideration".
+
+Once #1221 is implemented, `ack_report` should be wired into
+`EXPECTED_EVENT_TYPES` in `test/ci/test_case_ledger_invariants.py` (currently
+excluded; see the comment at line 413 citing #1133).
+
 See also: #1079 (multi-coordinator motivation from FIRSTCON 2026)
 
 ---

--- a/plan/history/2607/idea/IDEA-1133.md
+++ b/plan/history/2607/idea/IDEA-1133.md
@@ -1,0 +1,64 @@
+---
+source: IDEA-1133
+timestamp: '2026-07-08T18:45:43.561529+00:00'
+title: Add pre-case ACK demo scenario and manual-create case policy option
+type: idea
+---
+
+## Background
+
+When a reporter submits a report (`Offer(VulnerabilityReport)`) to a receiver, the receiver
+may want to send an immediate acknowledgment (`Read(Offer(Report))`) before deciding whether
+to create a case. This pre-case ACK is a direct actor-to-actor message that says "I have
+received and read your report, I am evaluating it" — without committing to Accept or Reject.
+
+Currently, the two-actor demo follows an **always-create-case-on-receipt** policy, where
+the receiver creates a case immediately when the Offer arrives. In that flow, a separate
+`ack-report` step is protocol noise: the reporter already learns the report was received
+when they are added as a participant to the newly-created case.
+
+However, this is not the only valid receiver policy. A receiver may want to:
+
+1. Acknowledge receipt immediately (pre-case ACK)
+2. Review the report internally
+3. Only then decide to Accept (create a case) or Reject
+
+The `RmReadReportActivity` (`as:Read`) mechanism already exists in the codebase for this
+purpose (see `vultron/demo/exchange/acknowledge_demo.py`), but there is no demo scenario
+that exercises the full pre-case-creation ACK workflow.
+
+## What needs to be done
+
+This is NOT merely demoing existing features — it also requires adding a policy option
+to the BT:
+
+1. **Add a policy check to the report-receipt BT** — the `SubmitReportReceivedUseCase`
+   currently always runs case creation. A configurable policy flag (e.g.
+   `auto_create_case: bool`) should gate whether case creation runs automatically
+   on report receipt, or whether the receiver must explicitly trigger it later.
+
+2. **Add a new demo scenario** (e.g. `vultron/demo/scenario/pre_case_ack_demo.py`)
+   that exercises the "manual-create" policy path:
+   - Reporter submits report
+   - Receiver sends pre-case ACK (`Read(Offer(Report))`) directly to reporter
+   - Receiver later explicitly creates the case (or rejects)
+
+3. **Wire `ack_report` into `EXPECTED_EVENT_TYPES`** once the scenario that
+   produces a canonical `ack_report` ledger entry exists.
+
+## Protocol note
+
+In the pre-case context, actors communicate directly (reporter ↔ receiver).
+Once a case exists, all communication goes through the CaseActor fan-out model.
+The pre-case ACK is the only scenario where a direct actor-to-actor `Read`
+makes protocol sense for this message type.
+
+## Traceability
+
+- Identified during scope reduction of #1039 (ack_report in two-actor demo)
+- See also: `vultron/demo/exchange/acknowledge_demo.py` (existing single-actor ACK demo)
+- `AckReportReceivedUseCase`, `EmitAckReportActivity` already implemented
+
+**Processed**: 2026-07-08 — implementation tracked in #1272.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1271>.
+Spec: `specs/case-management.yaml` CM-15-001.

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -705,3 +705,25 @@ groups:
     relationships:
     - rel_type: depends_on
       spec_id: CM-14-001
+- id: CM-15
+  title: Case Creation Policy
+  description: >-
+    Requirements for the configurable auto_create_case policy on ActorConfig.
+    Enables pre-case-ACK protocol flows (ADR-0015 post-decision refinement,
+    issue #1133).
+  specs:
+  - id: CM-15-001
+    priority: MUST
+    statement: >-
+      ActorConfig MUST expose an `auto_create_case` boolean field (default: True).
+      When False, SubmitReportReceivedUseCase MUST store the inbound
+      VulnerabilityReport and Offer(Report) activity but MUST NOT invoke
+      create_receive_report_case_tree.
+    rationale: >-
+      Receivers that follow the Option 3 protocol path (send Read(Offer(Report))
+      before deciding to accept or reject) require the ability to delay case
+      creation. The default (True) preserves the original ADR-0015 Option 4
+      "always create at RM.RECEIVED" behavior for all existing actors and demos.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-12-001


### PR DESCRIPTION
- Closes #1133

## Summary

Plans issue #1133 (pre-case ACK demo scenario and manual-create case policy
option) by documenting the design decisions and requirements that unblock
implementation.

## Changes

- **`docs/adr/0015-create-case-at-report-receipt.md`** — Post-decision
  refinement section documenting that `ActorConfig.auto_create_case` makes
  Option 4 configurable; `False` enables the Option 3 pre-case ACK path.
  Cross-references #1221 as the first scenario to use this flag.
- **`specs/case-management.yaml`** — New `CM-15` group with `CM-15-001`
  requiring `ActorConfig.auto_create_case: bool = True` and specifying
  behavior when `False`.
- **`notes/demo-future-ideas.md`** — Pre-case ACK flow section explaining
  the `auto_create_case=False` mechanism, its relationship to #1221, and
  the forward pointer to wiring `ack_report` into `EXPECTED_EVENT_TYPES`.