### PR TITLE
notes: reclassify EmbargoTimerExpired and MonitorDeployment from Sentinel

### DIFF
--- a/notes/bt-fuzzer-nodes-embargo.md
+++ b/notes/bt-fuzzer-nodes-embargo.md
@@ -128,11 +128,16 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
   production this is a simple timestamp comparison
 - **Automation potential**: **High** — simple system-clock comparison against the recorded embargo expiry timestamp; fully automatable with no human involvement.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.EmbargoTimerExpired`
-- **Call-out point shape**: Sentinel — binary timer-expiry condition; compares current time against the recorded embargo deadline and returns SUCCESS/FAILURE with no output keys; fully resolved by system-clock comparison against case-state data.
+- **Call-out point shape**: Retriever — on-demand synchronous check: reads the embargo expiry
+  timestamp from the case DataLayer, compares it to the current system clock, and returns
+  SUCCESS/FAILURE with no output keys. The BT tick drives this node; it does not run
+  independently or fire a trigger endpoint. A timestamp comparison is the simplest kind of
+  structured fact (ADR-0024 BT-18-006: binary on-demand queries are Retrievers, not Sentinels).
 - **Factory-fn placement**: FUTURE:
   `vultron.core.behaviors.embargo.create_terminate_embargo_on_condition_tree`
-  (issue #1256) — Sentinel condition guard early in the
-  `_SufficientCauseToTerminateActiveEmbargo` Sequence
+  (issue #1256) — Retriever condition guard early in the
+  `_SufficientCauseToTerminateActiveEmbargo` Sequence; reads embargo expiry
+  timestamp from DataLayer and compares to system clock
 
 ### `OnEmbargoExit`
 

--- a/notes/bt-fuzzer-nodes-report-management.md
+++ b/notes/bt-fuzzer-nodes-report-management.md
@@ -689,11 +689,17 @@ the process of deploying a developed fix or mitigation to affected systems.
   deployment coverage metrics
 - **Automation potential**: **High** — integration with deployment verification tools, patch compliance dashboards, or asset management platforms; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.deploy_fix.MonitorDeployment`
-- **Call-out point shape**: Sentinel
+- **Call-out point shape**: Actuator — initiates external deployment-monitoring as a side-effect;
+  invokes patch-compliance dashboard, deployment-verification API, or asset-management platform
+  to start ongoing coverage tracking. There is no content artifact placed on the blackboard;
+  the side effect in the external monitoring system is the seam. This is a fire-and-confirm
+  action node, not a continuous monitor running outside the BT — the BT tick reaches this node
+  once per `MonitoringRequirement` pass and asks the external system to begin tracking.
 - **Factory-fn placement**: FUTURE:
   `vultron.core.behaviors.report.create_deploy_fix_tree` (issue #1248) —
-  Sentinel action node in the monitoring-initiation Sequence, after
-  `MonitoringRequirement` succeeds; monitors deployment coverage metrics
+  Actuator action node in the monitoring-initiation Sequence, after
+  `MonitoringRequirement` succeeds; fires the external monitoring registration
+  call and confirms activation
 
 ### `DeployFix`
 

--- a/plan/history/2607/implementation/ISSUE-1266.md
+++ b/plan/history/2607/implementation/ISSUE-1266.md
@@ -1,0 +1,19 @@
+---
+source: ISSUE-1266
+timestamp: '2026-07-08T19:02:48.278578+00:00'
+title: 'FUZZ-08a-quart: Reclassify remaining Sentinel-labeled fuzzer nodes'
+type: implementation
+---
+
+## Issue #1266 — FUZZ-08a-quart: Reclassify remaining 17 Sentinel-labeled nodes
+
+Completed audit of all 17 nodes listed in #1266. Reclassified the final two nodes that still carried the Sentinel label:
+
+- EmbargoTimerExpired → Retriever (BT-tick-driven synchronous timestamp comparison; BT-18-006)
+- MonitorDeployment → Actuator (fire-and-confirm side-effect executor; no content artifact)
+
+All other 15 nodes (NoNewValidationInfo, NoNewPrioritizationInfo, NoNewDeploymentInfo, ExploitPrioritySet, ExploitDeferred, ExploitDesired, AllPublished, PublicationIntentsSet, ExploitReady, NotificationsComplete, RcptNotInQrmS, MoreVendors, MoreCoordinators, MoreOthers, IsIDAssignmentAuthority) were already reclassified to ProtocolInternal in prior PRs.
+
+With zero Sentinel-labeled BT nodes remaining, issue #1175 (FUZZ-08f — Implement all Sentinel-shaped call-out points) was closed: its scope reached zero.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1273>


### PR DESCRIPTION
- Closes #1266
- closes #1175

## Summary

Reclassifies the last two Sentinel-labeled BT nodes in the fuzzer node
catalogs, completing the FUZZ-08a-quart audit. With this change, zero
Sentinel-labeled BT nodes remain in any catalog file, and issue #1175
(FUZZ-08f) is closed because its scope reached zero.

## Changes

- `notes/bt-fuzzer-nodes-embargo.md`: `EmbargoTimerExpired` Sentinel →
  **Retriever**. A BT-tick-driven synchronous timestamp comparison against
  the case DataLayer is a binary on-demand query — Retriever per
  ADR-0024 BT-18-006.

- `notes/bt-fuzzer-nodes-report-management.md`: `MonitorDeployment` Sentinel
  → **Actuator**. Initiates external deployment-monitoring as a
  fire-and-confirm side effect (no blackboard artifact) — Actuator shape,
  not Sentinel (which would run autonomously and fire a trigger endpoint).

## Verification

- All 4413 unit tests pass (0 new — docs-only change)
- Black, flake8, mypy, pyright clean
- Notes frontmatter and markdownlint pre-commit hooks pass