### PR TITLE
docs: promote learnings — BT factory test determinism

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -802,6 +802,17 @@ Short entries are reproduced here; longer ones are referenced below.
   external system and returns only SUCCESS/FAILURE is a Retriever, not a
   Sentinel.
 
+- **BT Integration Tests Must Use Deterministic Factories When the Default Is
+  Probabilistic** — When a tree builder's default `CallOutBackendFactory` wraps
+  a `WeightedBehavior` or `AlmostAlwaysSucceed` fuzzer node, integration tests
+  that assert `Status.SUCCESS` on the full tree become flaky. Pass an explicit
+  deterministic factory (e.g., a module-level `_always_succeed_factory` helper)
+  to every success-path integration test. Structure tests and `FAILURE`-path
+  tests are unaffected. See `test/AGENTS.md` § "BT Factory Determinism" and
+  [notes/bt-integration.md](notes/bt-integration.md)
+  § "Integration Tests Must Use Deterministic Factories When BT Default Is
+  Probabilistic".
+
 - **`NoNew*` flags imply an upstream Sentinel seam.** When a BT condition
   node of the form `NoNew<X>Info` (or any node whose description says "check
   whether new information has arrived") reads a change-detection flag, that

--- a/docs/reference/codebase/ARCHITECTURE.md
+++ b/docs/reference/codebase/ARCHITECTURE.md
@@ -60,6 +60,7 @@ Evidence-backed flow:
 | Background outbox monitor | `vultron/adapters/driving/fastapi/outbox_monitor.py` | Drain actor outboxes outside request handlers |
 | Local-first delivery fallback | `vultron/adapters/driven/asgi_emitter.py` | Use in-process ASGI for co-located actors and HTTP fallback for remote ones |
 | Domain→wire translation adapters | `vultron/adapters/driven/sync_activity_adapter.py`, `vultron/adapters/driven/trigger_activity_adapter/__init__.py` | Keep wire factory imports out of `core/` |
+| Call-out point abstraction layer | `vultron/core/behaviors/call_out_point.py` (type alias), `vultron/demo/fuzzer/call_out_point.py` (shape mixins) | Decouple BT tree builders from fuzzer/demo implementations; tree builders accept `CallOutBackendFactory` callables (ADR-0025, BT-18-004) |
 
 ### 5) Known Architectural Risks
 
@@ -83,3 +84,6 @@ Evidence-backed flow:
 - `vultron/wire/as2/extractor/_extract.py`
 - `vultron/adapters/driven/asgi_emitter.py`
 - `vultron/adapters/driving/fastapi/outbox_monitor.py`
+- `vultron/core/behaviors/call_out_point.py`
+- `vultron/demo/fuzzer/call_out_point.py`
+- `docs/adr/0025-call-out-point-abstraction-layer.md`

--- a/docs/reference/codebase/CONVENTIONS.md
+++ b/docs/reference/codebase/CONVENTIONS.md
@@ -18,6 +18,9 @@
 - Formatter: `black` with `line-length = 79` in `pyproject.toml`
 - Linter: `flake8` via `.flake8`; static analysis also uses `mypy` and
   `pyright`; markdown is checked by `markdownlint-cli2`
+- Pre-commit hooks are **fail-only** (no auto-fix during commit): `black` runs
+  with `--check`, `markdownlint-cli2` does not apply fixes. Auto-format before
+  committing via the `format-code` and `run-linters` skills or `make black`.
 - Most relevant enforced rules: flake8 ignores `E203` and `E501`,
   `__init__.py` may ignore `F401`, mypy checks packages `vultron` and `test`,
   and markdownlint disables `MD013`, `MD033`, `MD041`, `MD046`, `MD051`, and

--- a/docs/reference/codebase/STACK.md
+++ b/docs/reference/codebase/STACK.md
@@ -35,7 +35,7 @@
 
 | Tool | Purpose | Evidence |
 |------|---------|----------|
-| `black` | Python formatting | `pyproject.toml`, `.pre-commit-config.yaml` |
+| `black` | Python formatting (pre-commit hook runs `--check` only; auto-fix via `make black` or `format-code` skill) | `pyproject.toml`, `.pre-commit-config.yaml` |
 | `flake8` | Python linting | `pyproject.toml`, `.flake8`, `.github/workflows/python-app.yml` |
 | `mypy` | Static type checking | `pyproject.toml`, `.mypy.ini`, `.github/workflows/python-app.yml` |
 | `pyright` | Static type checking | `pyproject.toml`, `pyrightconfig.json`, `.github/workflows/python-app.yml` |

--- a/docs/reference/codebase/STRUCTURE.md
+++ b/docs/reference/codebase/STRUCTURE.md
@@ -43,6 +43,7 @@
 | `vultron/metadata/` | Spec, notes, and history tooling | Runtime protocol orchestration |
 | `vultron/demo/` | Demo orchestration, seeding, verification helpers | Authoritative domain interfaces |
 | `vultron/bt/` | Legacy/experimental BT package retained alongside core behaviors | New adapter wiring or primary runtime entrypoints |
+| `vultron/demo/fuzzer/` | Fuzzer/simulation call-out point implementations and shape mixin classes; depends on `vultron/core/behaviors/call_out_point.py` for `CallOutBackendFactory` type | Core domain logic; tree builders default to fuzzer factories but must not import `vultron.demo` (BT-16-001) |
 | `test/` | Mirrored tests and fixtures | Production runtime code |
 
 ### 4) Naming and Organization Rules

--- a/docs/reference/codebase/TESTING.md
+++ b/docs/reference/codebase/TESTING.md
@@ -45,6 +45,11 @@ suite with `-m ""`.
   isolated per-app state
 - Common failure mode in tests: shared/actor-scoped `DataLayer` seams and
   py_trees global state can leak behavior if fixtures do not isolate them
+- BT tree builder tests: when a tree builder's default `CallOutBackendFactory`
+  wraps a probabilistic fuzzer node (`AlmostAlwaysSucceed`, `WeightedBehavior`),
+  integration tests that assert `Status.SUCCESS` must pass an explicit
+  deterministic factory; structure tests and FAILURE-path tests are unaffected
+  (learning: `20260708-integration-test-determinism-with-probabilistic-defaults.md`)
 
 ### 5) Coverage and Quality Signals
 

--- a/notes/bt-integration.md
+++ b/notes/bt-integration.md
@@ -1424,3 +1424,40 @@ Apply this poll-until-hash pattern after every phase that introduces a new
 ledger tail before a devlog dump. This is the same pattern used in
 `_phase_sync_verification` and ensures dump artifacts are always consistent
 with the replica's committed state.
+
+---
+
+### Integration Tests Must Use Deterministic Factories When BT Default Is Probabilistic
+
+(BT-FACTORY-DETERMINISM, 2026-07-08; learning `ISSUE-1151`)
+
+When a tree builder's default `CallOutBackendFactory` wraps a probabilistic
+fuzzer node (e.g., `AlmostAlwaysSucceed` at 90% success), integration tests
+that assert `result.status == Status.SUCCESS` become flaky. Two such nodes in
+series give ~81% tree success — a failure probability that surfaces within a
+few test runs.
+
+**Pattern that caused this**: Adding factory injection to a tree builder (e.g.,
+`create_validate_report_tree`) where the fuzzer defaults (`EvaluateReportCredibility`,
+`EvaluateReportValidity`) are `AlmostAlwaysSucceed` nodes. Existing integration
+tests called the builder with no factory args and asserted `SUCCESS`.
+
+**Fix**: Add a module-level `_always_succeed_factory` helper to the test file
+and pass it explicitly to all integration tests that require `SUCCESS`:
+
+```python
+def _always_succeed_factory(name: str) -> py_trees.behaviour.Behaviour:
+    class _AlwaysSucceed(py_trees.behaviour.Behaviour):
+        def update(self):
+            return py_trees.common.Status.SUCCESS
+    return _AlwaysSucceed(name)
+```
+
+**Scope**: This applies only to integration tests (those that assert
+`Status.SUCCESS` on the full tree execution). Tree-structure tests (node names,
+child counts) and `FAILURE`-path tests (missing `DataLayer`, missing report)
+are not affected.
+
+**Rule**: Any time a tree builder's default factory wraps a probabilistic fuzzer
+node, update all integration tests that assert `SUCCESS` to pass an explicit
+deterministic factory. See `test/AGENTS.md` § "BT Factory Determinism".

--- a/plan/history/2607/learning/ISSUE-1061.md
+++ b/plan/history/2607/learning/ISSUE-1061.md
@@ -1,7 +1,7 @@
 ---
 title: "SKIP=black needed when rebasing in any vultron_* worktree"
 type: learning
-timestamp: 2026-07-08
+timestamp: 2026-07-08T00:00:00+00:00
 source: ISSUE-1061
 ---
 
@@ -32,4 +32,4 @@ skills before committing. The `SKIP=black` workaround is no longer needed.
 
 **Promoted**: 2026-07-08 — resolved/superseded; already captured in
 `AGENTS.md` § "Pre-commit Hooks Are Fail-Only". No new doc changes needed.
-Docs PR: (TBD — filled in after PR is opened)
+Docs PR: [#1274](https://github.com/CERTCC/Vultron/pull/1274)

--- a/plan/history/2607/learning/ISSUE-1151.md
+++ b/plan/history/2607/learning/ISSUE-1151.md
@@ -1,7 +1,7 @@
 ---
 title: "Integration tests must use deterministic factories when BT default is probabilistic"
 type: learning
-timestamp: 2026-07-08
+timestamp: 2026-07-08T00:00:00+00:00
 source: ISSUE-1151
 ---
 
@@ -38,4 +38,4 @@ children) or FAILURE paths are unaffected.
 § "Integration Tests Must Use Deterministic Factories When BT Default Is
 Probabilistic", `test/AGENTS.md` § "BT Factory Determinism", and root
 `AGENTS.md` pitfall entry.
-Docs PR: (TBD — filled in after PR is opened)
+Docs PR: [#1274](https://github.com/CERTCC/Vultron/pull/1274)

--- a/plan/incoming/learnings/20260708-integration-test-determinism-with-probabilistic-defaults.md
+++ b/plan/incoming/learnings/20260708-integration-test-determinism-with-probabilistic-defaults.md
@@ -33,3 +33,9 @@ def _always_succeed_factory(name: str) -> py_trees.behaviour.Behaviour:
 fuzzer node, update all integration tests that assert SUCCESS to pass an
 explicit deterministic factory.  Tests that check tree structure (names,
 children) or FAILURE paths are unaffected.
+
+**Promoted**: 2026-07-08 — captured in `notes/bt-integration.md`
+§ "Integration Tests Must Use Deterministic Factories When BT Default Is
+Probabilistic", `test/AGENTS.md` § "BT Factory Determinism", and root
+`AGENTS.md` pitfall entry.
+Docs PR: (TBD — filled in after PR is opened)

--- a/plan/incoming/learnings/20260708-rebase-black-hook-workaround.md
+++ b/plan/incoming/learnings/20260708-rebase-black-hook-workaround.md
@@ -29,3 +29,7 @@ reformat (import ordering, line length, etc.).
 removing `--fix` from the `markdownlint-cli2` hook in `.pre-commit-config.yaml`.
 Hooks are now fail-only; auto-fix is done by the `format-code`/`run-linters`
 skills before committing. The `SKIP=black` workaround is no longer needed.
+
+**Promoted**: 2026-07-08 — resolved/superseded; already captured in
+`AGENTS.md` § "Pre-commit Hooks Are Fail-Only". No new doc changes needed.
+Docs PR: (TBD — filled in after PR is opened)

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -391,6 +391,49 @@ uv run pytest -m "new_mark_name" --collect-only 2>&1 | tail -5
 
 ---
 
+## BT Factory Determinism: Integration Tests Must Use Explicit Factories
+
+(BT-FACTORY-DETERMINISM, 2026-07-08)
+
+When a BT tree builder accepts a `CallOutBackendFactory` parameter whose
+**default** is a probabilistic fuzzer node (`AlmostAlwaysSucceed`, `WeightedBehavior`,
+etc.), integration tests that assert `Status.SUCCESS` on the full tree MUST
+pass an explicit deterministic factory.
+
+A default factory at 90% success + two nodes in series = ~81% tree success
+rate — a failure probability that appears within a few test runs.
+
+**Structure tests** (node names, child counts) and **`FAILURE`-path tests**
+(missing `DataLayer`, missing report) are unaffected and do NOT need the
+deterministic factory.
+
+**Pattern**:
+
+```python
+# Module-level helper in the test file
+def _always_succeed_factory(name: str) -> py_trees.behaviour.Behaviour:
+    class _AlwaysSucceed(py_trees.behaviour.Behaviour):
+        def update(self):
+            return py_trees.common.Status.SUCCESS
+    return _AlwaysSucceed(name)
+
+
+# Passed explicitly to every SUCCESS-asserting integration test
+def test_validate_report_succeeds(dl, report):
+    tree = create_validate_report_tree(
+        report_id=report.id_,
+        credibility_factory=_always_succeed_factory,
+        validity_factory=_always_succeed_factory,
+    )
+    ...
+    assert result.status == Status.SUCCESS
+```
+
+See `notes/bt-integration.md` § "Integration Tests Must Use Deterministic
+Factories When BT Default Is Probabilistic" for full context.
+
+---
+
 ## Genesis-Hash Path Must Be Tested with a Stored Case
 
 (CLP-08-995, 2026-06-18)


### PR DESCRIPTION
## Summary

- Promotes learning `ISSUE-1151`: BT tree builders with probabilistic fuzzer
  defaults require explicit deterministic factories in integration tests
- Refreshes `docs/reference/codebase/` reference files from latest scan
  (call-out point abstraction layer, fail-only pre-commit hooks, test note)
- Archives 2 incoming learnings (pending `append-history --from-file` after merge)
- Updated TODO count in concern issue #505 (12, was 15)

## Changes

- `notes/bt-integration.md` — new pitfall § "Integration Tests Must Use
  Deterministic Factories When BT Default Is Probabilistic"
- `test/AGENTS.md` — new § "BT Factory Determinism" with pattern and cross-ref
- `AGENTS.md` — new cross-reference pitfall entry
- `docs/reference/codebase/ARCHITECTURE.md` — add call-out point abstraction
  layer pattern (ADR-0025, BT-18-004)
- `docs/reference/codebase/STRUCTURE.md` — add `vultron/demo/fuzzer/` boundary
- `docs/reference/codebase/CONVENTIONS.md` — note fail-only pre-commit hooks
- `docs/reference/codebase/STACK.md` — note `black` hook is `--check` only
- `docs/reference/codebase/TESTING.md` — note deterministic factory requirement
- `docs/reference/codebase/.codebase-scan.txt` — refreshed from current repo scan
- `plan/incoming/learnings/*.md` — promotion notes added (PR URL TBD)