### PR TITLE
notes: archive stale files and trim completed annotations

### DIFF
--- a/notes/README.md
+++ b/notes/README.md
@@ -267,14 +267,6 @@ manually trigger intermediate steps, designing the boundary between automated
 cascades and external decision nodes, or evaluating where UI or LLM agent
 integration fits in the protocol flow.
 
-**`bt-composability.md`**
-Vultron's fractal composability principle for behavior trees: concrete patterns
-for composing behavioural subtrees, the "trunkless branch" model applied at
-the composability layer, and guidance for building reusable BT building blocks.
-Operationalises `specs/bt-composability.yaml` (BTC-01 through BTC-04).
-**Load when**: designing composable BT subtrees, auditing BT compositions for
-violations, or working on BTC spec requirements.
-
 **`bt-design-patterns.md`**
 Idiomatic BT construction patterns from Colledanchise & Ögren applied to the
 Vultron simulation and prototype implementations: factory methods, node
@@ -397,9 +389,9 @@ startup issues, or optimizing image build times.
 **`encryption.md`**
 Encryption design notes: public-key discovery, decryption placement in the
 inbound pipeline, outgoing encryption strategies, key rotation, and
-implementation guidance.
+implementation guidance. Implementation is tracked in issue #1156.
 **Load when**: implementing message encryption/decryption in the ActivityPub
-inbox/outbox pipeline.
+inbox/outbox pipeline (see issue #1156 and its children).
 
 **`demo-future-ideas.md`**
 Extended multi-actor demo scenario sketches: Two-Actor (Finder + Vendor),
@@ -518,12 +510,14 @@ Pydantic model, loader, pre-commit hook, and migration checklist.
 **Load when**: adding frontmatter to a new notes file, modifying the frontmatter
 schema, or debugging `validate-notes-frontmatter` pre-commit failures.
 
-**`spec-registry.md`**
-Design notes for the spec registry: converting `specs/*.md` files to
-structured YAML governed by Pydantic models in `vultron/metadata/specs/`,
-mirroring the `vultron/metadata/notes/` pattern.
-**Load when**: adding a new spec YAML file, modifying the spec registry schema,
-or debugging `spec-dump` output issues.
+**`spec-registry.md`** *(archived — see `archived_notes/`)*
+Implemented — `specs/*.md` fully migrated to YAML; `vultron/metadata/specs/` is in place.
+
+**`demo-ci.md`** *(archived — see `archived_notes/`)*
+Implemented — `demo-integration.yml` workflow exists in `.github/workflows/`.
+
+**`docs-build-workflow.md`** *(archived — see `archived_notes/`)*
+Implemented — `docs-build-check.yml` workflow exists in `.github/workflows/`.
 
 ---
 

--- a/notes/activitystreams-semantics.md
+++ b/notes/activitystreams-semantics.md
@@ -367,11 +367,10 @@ authenticate that a case update originated from the CaseActor before
 treating it as authoritative (see `specs/case-management.yaml` CM-06-002,
 CM-06-004).
 
-**Current status**: The CaseActor broadcast is implemented in
+The CaseActor broadcast is implemented in
 `vultron/core/use_cases/received/case.py` (`UpdateCaseReceivedUseCase`)
 via `_broadcast_case_update()`, which fans out updates to all case
-participants (see `specs/case-management.yaml` CM-06-001, CM-06-002;
-completed in PRIORITY-200 CA-2, 2026-03-25).
+participants (see `specs/case-management.yaml` CM-06-001, CM-06-002).
 
 **Cross-reference**: `specs/case-management.yaml` CM-02-002, CM-06.
 

--- a/notes/archived_notes/README.md
+++ b/notes/archived_notes/README.md
@@ -1,0 +1,13 @@
+# Archived Notes
+
+Notes files that have been fully superseded or whose implementation is complete.
+These are retained for historical context but are no longer active guidance for
+agents.
+
+---
+
+| File | Archived | Reason |
+|---|---|---|
+| `demo-ci.md` | 2026-07-08 | Implemented — `demo-integration.yml` workflow exists in `.github/workflows/` |
+| `docs-build-workflow.md` | 2026-07-08 | Implemented — `docs-build-check.yml` workflow exists in `.github/workflows/` |
+| `spec-registry.md` | 2026-07-08 | Implemented — `specs/*.md` fully migrated to `.yaml`; `vultron/metadata/specs/` is in place |

--- a/notes/archived_notes/demo-ci.md
+++ b/notes/archived_notes/demo-ci.md
@@ -1,6 +1,6 @@
 ---
 title: Demo CI — GitHub Actions Demo Integration Workflow
-status: active
+status: archived
 ---
 
 # Demo CI — GitHub Actions Demo Integration Workflow

--- a/notes/archived_notes/docs-build-workflow.md
+++ b/notes/archived_notes/docs-build-workflow.md
@@ -1,6 +1,6 @@
 ---
 title: Docs Build and Link Check Workflow
-status: active
+status: archived
 ---
 
 # Docs Build and Link Check Workflow

--- a/notes/archived_notes/spec-registry.md
+++ b/notes/archived_notes/spec-registry.md
@@ -1,6 +1,6 @@
 ---
 title: Spec Registry Design
-status: active
+status: archived
 related_specs:
   - specs/spec-registry.yaml
   - specs/notes-frontmatter.yaml

--- a/notes/case-communication-model.md
+++ b/notes/case-communication-model.md
@@ -337,20 +337,10 @@ See ADR-0021 for the full decision record.
 
 ---
 
-## Known Implementation Gaps (as of 2026-06-18)
+## Known Implementation Gaps
 
 | Gap | Location | Status |
 |---|---|---|
-| `validate_report` trigger tree: no emit to CaseActor | `behaviors/report/validate_tree.py` | Open — tracked in #1026 impl issues |
-| `ack_report` received UC: no guarded commit | `received/report.py` | Open — tracked in #1026 impl issues |
-| `close_case` received UC: no guarded commit | `received/case/lifecycle.py` | Open — tracked in #1026 impl issues |
-| `note.py` guarded commit: uses foreign actor ID | `received/note.py` | Open — tracked in #1026 impl issues |
-| `embargo.py` guarded commit: uses foreign actor ID | `received/embargo.py` | Open — tracked in #1026 impl issues |
 | Notes trigger sends to all participants | `triggers/note.py:102` | Open |
 | Embargo triggers send to all participants | `triggers/embargo.py` | Open |
 | Engage/defer-case triggers send to all participants | `triggers/case.py:84,132` | Open |
-| Invite sent from case owner (not Case Actor); Accept routed to owner | `triggers/actor.py`, `received/actor.py` | Open — tracked in #893/#894 |
-| Guarded commit dispatched as a second, separately-gated `execute_with_setup()` call (9 use cases, 6 modules: `embargo.py` x3, `report.py` x2, `note.py`, `status.py`, `case/lifecycle.py`, `actor/case_manager_role.py`) | `received/*.py` | Open — ADR-0022, CLP-10-005, tracked under #1036 impl issues |
-
-See GitHub issues under parent concern #593, epic #788, and concern #1036
-(ADR-0022).

--- a/notes/encryption.md
+++ b/notes/encryption.md
@@ -8,6 +8,9 @@ description: >
 
 # Encryption implementation notes
 
+> **Tracked by**: issue #1156 and its children. This file is the design seed
+> for that implementation work.
+
 ## Overview
 
 - ActivityPub supports public-key distribution via actor profiles.

--- a/notes/vocabulary-registry.md
+++ b/notes/vocabulary-registry.md
@@ -113,20 +113,6 @@ is never imported, its classes are never defined and never registered.
 Dynamic discovery gives one startup guarantee that all vocab modules are
 loaded without requiring each application path to import them manually.
 
-## Migration Path
-
-1. **VOCAB-REG-1.1** (core mechanics): add `enums.py`, rewrite
-   `registry.py`, add `__init_subclass__` to `as_Base`, override
-   `_vocab_ns` on `VultronObject`, and add unit tests.
-2. **VOCAB-REG-1.2** (migration): remove all `@activitystreams_*`
-   decorators, add dynamic discovery to `__init__.py` files, update
-   `find_in_vocabulary()` callers, and add a registration completeness
-   test.
-
-The refactor is backward-compatible for callers that use only
-`find_in_vocabulary(name)`; the `item_type` parameter is removed because
-no callers use it.
-
 ---
 
 ## Vocabulary Override Preservation


### PR DESCRIPTION
## Summary

- Creates `notes/archived_notes/` directory with README
- Archives 3 notes files whose implementation is now complete:
  - `demo-ci.md` → `demo-integration.yml` is in `.github/workflows/`
  - `docs-build-workflow.md` → `docs-build-check.yml` is in `.github/workflows/`
  - `spec-registry.md` → `specs/` fully migrated to YAML; `vultron/metadata/specs/` in place
- Trims stale completed-task annotations from 3 active files:
  - `activitystreams-semantics.md`: removes "completed in PRIORITY-200 CA-2" status note
  - `case-communication-model.md`: removes 7 rows for closed issues (#593, #788, #893, #894, #1026, #1036) from "Known Implementation Gaps" table
  - `vocabulary-registry.md`: removes "Migration Path" section (`@activitystreams_object` decorator is gone)
- Annotates `notes/encryption.md` with `#1156` callout so agents know it's the design seed for that issue
- Fixes duplicate `bt-composability.md` entry in `notes/README.md`

## Test plan

- [x] `pre-commit run validate-notes-frontmatter --all-files` — passed
- [x] `uv run pytest test/ -k "frontmatter"` — 28 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)