### PR TITLE
docs: plan #1287 — invite ledger cc self-routing

### DIFF
--- a/docs/adr/0021-caseactor-inbox-routing-canonical-ledger.md
+++ b/docs/adr/0021-caseactor-inbox-routing-canonical-ledger.md
@@ -147,9 +147,51 @@ satisfied without corrupting the ledger.
 - A grep-based test (CLP-09-002) asserts that no bare, unguarded commit
   invocation exists outside the guarded-commit factory.
 
+## Clarification: CaseActor-Originated Activities (Issue #1287)
+
+The canonical path above applies symmetrically when the **CaseActor** is
+the originator, not just when it is a relay target. The CaseActor is a
+participant with extra duties; it is not exempt from CLP-10-001.
+
+When the CaseActor originates an activity (e.g., `invite_actor_to_case`),
+the activity is addressed to the external recipient(s) via `to:`. To
+ensure the CaseActor's own inbox receives the activity for archival, the
+CaseActor MUST add its own actor ID to the `cc:` field of the outbound
+activity. ASGI self-delivery then routes the `cc:` copy to the CaseActor's
+received-side use case, where the `GuardedCommitCaseLedgerEntryBT` fires
+under the correct `actor_id = case_actor_id` identity.
+
+**Why `cc:` instead of adding `case_actor_id` to `to:`:**
+The primary recipient of an `Invite(VulnerabilityCase)` is the invitee.
+The CaseActor's copy is an archival side-channel, not a primary delivery.
+Using `to:` for both would misrepresent the CaseActor as a co-primary
+recipient of its own outbound message. `cc:` preserves the correct
+semantic: the invitee is in `to:`, the self-archival copy is in `cc:`.
+OX-08-004 narrows its WARNING scope to exclude this purposeful self-copy
+pattern (the only valid use of `cc:` in the protocol).
+
+**The working precedent** for this pattern is `offer_case_manager_role`:
+its `ResolveCaseManagerOfferContextNode` sets
+`blackboard.offer_case_manager_to = [case_actor_id]` and the Offer is
+addressed to the CaseActor's own ID in `to:` (a special case where the
+CaseActor is genuinely the primary recipient). The `invite_actor_to_case`
+fix follows the same principle but uses `cc:` because the invitee is the
+primary recipient.
+
+**Distinguishing self-delivery from external delivery in received-side
+use cases:** The CaseActor's received-side `InviteActorToCaseReceivedUseCase`
+does not need to special-case "did I send this myself?" — the
+`GuardedCommitCaseLedgerEntryBT`'s `CheckIsCaseManagerNode` role gate is
+the only pre-flight guard needed. If the executing actor is the CaseActor,
+the commit fires; if not, it is skipped. The `cc:` addressing is
+transparent to the received-side use case.
+
 ## More Information
 
-- Issue #1026 — root-cause analysis and fix plan.
+- Issue #1026 — root-cause analysis and fix plan for the broader ADR-0021
+  routing gap.
+- Issue #1287 — `invite_actor_to_case` trigger BT gap: CaseActor-originated
+  activities also need to route through the CaseActor's inbox.
 - ADR-0018 — single-writer canonical ledger established.
 - ADR-0019 — content boundary of the canonical ledger established.
 - `notes/case-communication-model.md` — canonical communication flow,
@@ -158,3 +200,5 @@ satisfied without corrupting the ledger.
   coverage requirements that this ADR extends.
 - `specs/case-ledger-processing.yaml` CLP-10 — normative requirements
   generated from this ADR.
+- `specs/outbox.yaml` OX-08-004 — purposeful self-copy exception to the
+  `cc:`/`bcc:`/`bto:` WARNING.

--- a/notes/outbox.md
+++ b/notes/outbox.md
@@ -31,12 +31,12 @@ Vultron activities are direct messages and MUST have a non-empty `to:` field.
 
 | Question | Decision | Rationale |
 |---|---|---|
-| Which addressing fields are valid? | `to:` only | All Vultron exchanges are DMs; `cc`/`bto`/`bcc` unsupported |
+| Which addressing fields are valid? | `to:` required; one `cc:` exception | All Vultron exchanges are DMs; `cc`/`bto`/`bcc` unsupported except for the CaseActor purposeful self-copy (see OX-08-004) |
 | Where to enforce? | `handle_outbox_item` in `outbox_handler.py` | Already has the full activity; consistent with existing `VultronOutboxObjectIntegrityError` pattern |
 | Exception class? | New `VultronOutboxToFieldMissingError` | Matches project exception naming convention; distinct from object-integrity errors |
 | Scope? | All outbox activities, no exceptions | Every outbound activity must be addressed |
 | What counts as valid `to:`? | Non-empty list (or scalar) of URI strings | Empty list is as bad as `None`; format validation out of scope |
-| `cc`/`bto`/`bcc` presence? | Log WARNING, do not reject | Surfaces bugs without breaking delivery in edge cases |
+| `cc`/`bto`/`bcc` presence? | Log WARNING, except for CaseActor purposeful self-copy | OX-08-004: purposeful `cc:` self-copy (originating actor's own ID only) MUST NOT trigger the WARNING; all other uses SHOULD warn |
 
 ---
 
@@ -86,17 +86,26 @@ if _to_empty:
         activity_type=activity_type,
     )
 
-# Warn if cc/bto/bcc are set (OX-08-004)
+# Warn if cc/bto/bcc are set (OX-08-004), except for purposeful CaseActor
+# self-copy: a cc: list consisting solely of the originating actor's own ID
+# is the only valid non-to: addressing in the protocol (CLP-10-001).
+_actor_id = getattr(outbound_activity, "actor", None)
 for _addr_field in ("cc", "bto", "bcc"):
     _val = getattr(outbound_activity, _addr_field, None)
     if _val is not None and _val != []:
-        logger.warning(
-            "Outbound %s activity '%s' has `%s:` set."
-            " Vultron only uses `to:` for addressing (OX-08-004).",
-            activity_type,
-            activity_id,
-            _addr_field,
+        _is_self_copy = (
+            _addr_field == "cc"
+            and isinstance(_val, list)
+            and _val == [_actor_id]
         )
+        if not _is_self_copy:
+            logger.warning(
+                "Outbound %s activity '%s' has `%s:` set."
+                " Vultron only uses `to:` for addressing (OX-08-004).",
+                activity_type,
+                activity_id,
+                _addr_field,
+            )
 ```
 
 ### 3. Import the new exception
@@ -137,14 +146,25 @@ activity = make_test_activity(to=[])
 activity = make_test_activity(to=None, cc=["https://example.org/alice"])
 ...
 
-# Test: to: present with cc: logs WARNING but delivers
+# Test: to: present with cc: pointing to a *third party* logs WARNING
 activity = make_test_activity(
     to=["https://example.org/alice"],
-    cc=["https://example.org/bob"],
+    cc=["https://example.org/bob"],  # bob ≠ sender → WARNING fires
 )
 with caplog.at_level(logging.WARNING):
     await handle_outbox_item(actor_id, activity.id_, dl, emitter)
 assert any("cc" in r.message for r in caplog.records)
+emitter.emit.assert_called_once()
+
+# Test: purposeful CaseActor self-copy (cc: = own ID) does NOT log WARNING
+activity = make_test_activity(
+    actor=actor_id,
+    to=["https://example.org/invitee"],
+    cc=[actor_id],  # self-copy: actor's own ID only → no WARNING
+)
+with caplog.at_level(logging.WARNING):
+    await handle_outbox_item(actor_id, activity.id_, dl, emitter)
+assert not any("cc" in r.message for r in caplog.records)
 emitter.emit.assert_called_once()
 ```
 
@@ -187,7 +207,8 @@ When modifying `outbox_handler.py`, add or update tests for these scenarios:
 
 3. **Activity Validation** (`handle_outbox_item`)
    - Test: reject missing or empty `to:` field (OX-08-001, OX-08-002)
-   - Test: warn on `cc`/`bto`/`bcc` presence (OX-08-004)
+   - Test: warn on `cc`/`bto`/`bcc` presence for third-party addresses (OX-08-004)
+   - Test: no WARNING for purposeful CaseActor self-copy (`cc:` = own actor ID)
    - Test: enforce `VultronOutboxObjectIntegrityError` for malformed activities
    - Location: `test/adapters/driving/fastapi/test_outbox.py`
 

--- a/plan/history/2607/learning/CONCERN-1287.md
+++ b/plan/history/2607/learning/CONCERN-1287.md
@@ -1,0 +1,50 @@
+---
+source: CONCERN-1287
+timestamp: '2026-07-09T14:23:47.846098+00:00'
+title: invite_actor_to_case trigger never commits a CaseLedgerEntry (trigger-side
+  BT gap)
+type: learning
+---
+
+## Problem
+
+`invite_actor_to_case_trigger_bt` in `vultron/core/behaviors/case/actor_trigger_trees.py`
+emits an `Invite(VulnerabilityCase)` addressed only to `invitee_id` (`to=[invitee_id]`).
+The CaseActor never receives its own Invite activity in its inbox, so
+`InviteActorToCaseReceivedUseCase` never fires for the CaseActor and the canonical
+case ledger has no `invite_actor_to_case` entry. The FVV demo log jumps from
+`validate_report` directly to `accept_invite_actor_to_case` with no Invite entry in
+between — violating `notes/case-ledger-authority.md` which explicitly lists
+`Invite(VulnerabilityCase)` as a required canonical entry type.
+
+## Root Cause
+
+CLP-10-001 (ADR-0021) requires every protocol-significant trigger tree to emit at
+least one outbound activity addressed to `case_manager_id`. This requirement was
+interpreted as applying only to participant-originated triggers, not to
+CaseActor-originated triggers. Since the CaseActor IS a participant with extra
+duties, it is not exempt — but no code enforced this for CaseActor-originated
+activities. The `offer_case_manager_role` trigger works correctly (it uses a
+self-addressed Offer), but `invite_actor_to_case` was never fixed.
+
+## Fix Approach
+
+1. `EmitInviteActorToCaseNode` adds `case_actor_id` to the Invite's `cc:` field
+2. `InviteActorToCaseReceivedUseCase` upgraded to BTBridge + new
+   `create_invite_actor_to_case_received_tree` with `GuardedCommitCaseLedgerEntryBT`
+3. OX-08-004 WARNING suppressed for purposeful CaseActor self-copy (cc: = own ID)
+4. `invite_actor_to_case` added to `EXPECTED_EVENT_TYPES`
+
+## Why cc: not to: for the self-copy
+
+The invitee is the primary recipient; the CaseActor's copy is archival.
+Using `to:` for both would misrepresent the CaseActor as a co-primary recipient of
+its own outbound message. `cc:` preserves the correct semantic. OX-08-004 was
+narrowed to exclude this purposeful self-copy pattern (the only valid `cc:` use
+in the protocol).
+
+**Resolved**: 2026-07-09 — implementation tracked in #1293.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1291>.
+Spec: `specs/case-ledger-processing.yaml` (CLP-10-001).
+Spec: `specs/outbox.yaml` (OX-08-004).
+ADR: `docs/adr/0021-caseactor-inbox-routing-canonical-ledger.md`.

--- a/specs/case-ledger-processing.yaml
+++ b/specs/case-ledger-processing.yaml
@@ -362,7 +362,12 @@ groups:
       Every protocol-significant trigger tree MUST emit at least one outbound
       activity addressed to `case_manager_id` (the CaseActor's actor ID) so that
       the CaseActor's inbox receives the activity and can author a canonical
-      ledger entry
+      ledger entry. This requirement applies to ALL participants — the CaseActor
+      is a participant with extra duties; it is not excluded from CLP-10-001.
+      When the CaseActor itself originates an activity (e.g., `invite_actor_to_case`),
+      it MUST include its own actor ID in the outbound activity's `cc:` field so
+      that ASGI self-delivery triggers the CaseActor's received-side use case and
+      the `GuardedCommitCaseLedgerEntryBT` fires in the correct inbox context.
     rationale: >-
       Before ADR-0021, several trigger trees (e.g., `validate_report`,
       `ack_report`, `close_case`) emitted no activity addressed to the CaseActor.
@@ -371,6 +376,14 @@ groups:
       mechanism already handles routing when the target actor ID is the
       CaseActor sub-actor for the same container; the missing piece was the
       emit node itself.
+      The self-routing requirement also applies when the CaseActor is the
+      originator: `invite_actor_to_case_trigger_bt` emitted an `Invite` addressed
+      only to the invitee — the CaseActor never received its own activity and the
+      canonical ledger had no `invite_actor_to_case` entry. Using `cc:` rather
+      than `to:` for the self-copy preserves the semantics that the invitee is the
+      primary recipient while still routing the activity through the CaseActor's
+      inbox for archival. See OX-08-004 for the updated addressing policy and
+      ADR-0021 for the full end-to-end path.
     verification: >-
       For each entry in `EXPECTED_EVENT_TYPES`, a test verifies that the
       CaseActor's canonical ledger contains at least one entry with that

--- a/specs/outbox.yaml
+++ b/specs/outbox.yaml
@@ -118,8 +118,18 @@ groups:
   - id: OX-08-004
     priority: SHOULD
     statement: >-
-      If an outbound activity carries non-empty `cc:`, `bto:`, or `bcc:` fields, the outbox
+      If an outbound activity carries non-empty `cc:`, `bto:`, or `bcc:` fields
+      AND the `cc:`/`bto:`/`bcc:` list is not solely the originating actor's own
+      ID (i.e., a purposeful self-copy for canonical-ledger archival), the outbox
       handler SHOULD log a WARNING
+    rationale: >-
+      Vultron direct messages use `to:` for primary recipients. The `cc:`/`bto:`/`bcc:`
+      fields are reserved for a single exception: a CaseActor-originated activity
+      that adds the CaseActor's own ID to `cc:` so ASGI self-delivery routes the
+      activity through the CaseActor's received-side use case and the
+      `GuardedCommitCaseLedgerEntryBT` fires in the correct inbox context
+      (CLP-10-001). This purposeful self-copy MUST NOT trigger the WARNING. Any
+      other use of `cc:`/`bto:`/`bcc:` is suspect and SHOULD be logged.
 - id: OX-09
   title: Outbox Monitor Efficiency
   rationale: >-


### PR DESCRIPTION
- Closes #1287

## Summary

Plans the fix for the `invite_actor_to_case` trigger BT gap: the CaseActor
never committed a canonical ledger entry for invites it sent because
`invite_actor_to_case_trigger_bt` only addressed the Invite to the invitee —
not back to the CaseActor's own inbox.

## Changes

- `specs/case-ledger-processing.yaml` **CLP-10-001**: clarified that the
  emit-to-CaseActor requirement applies to all participants including the
  CaseActor itself; documented the `cc:` self-copy pattern for
  CaseActor-originated activities
- `specs/outbox.yaml` **OX-08-004**: narrowed the `cc:`/`bcc:`/`bto:` WARNING
  scope to exclude purposeful CaseActor self-copy (the only valid non-`to:`
  addressing in the protocol); added rationale
- `docs/adr/0021-caseactor-inbox-routing-canonical-ledger.md`: added
  "CaseActor-Originated Activities" clarification section documenting the
  `cc:` vs `to:` decision, the working precedent (`offer_case_manager_role`),
  and why received-side use cases need no special-casing

## Implementation tracked in

Implementation issue to be created as part of this plan.