### PR TITLE
docs: enforce GraphQL-only issue creation in AGENTS.md and process-concerns

### DIFF
--- a/.agents/skills/process-concerns/SKILL.md
+++ b/.agents/skills/process-concerns/SKILL.md
@@ -23,6 +23,7 @@ before creating anything.
 REPO           = CERTCC/Vultron
 REPO_NODE_ID   = R_kgDOIn77fA
 CONCERN_TYPE   = IT_kwDOAjf0s84B_2VT
+TASK_TYPE      = IT_kwDOAjf0s84AcFLo
 ```
 
 ---
@@ -183,15 +184,25 @@ user's response:
   create a `type:Task` issue and add to Project #24 with Schedule=Someday:
 
   ```bash
-  RESULT=$(gh issue create \
-    --repo CERTCC/Vultron \
-    --title "${TITLE}" \
-    --body "${BODY}" \
-    --json number,id)
+  TITLE_JSON=$(printf '%s' "${TITLE}" \
+    | python3 -c "import sys,json; print(json.dumps(sys.stdin.read()))")
+  BODY_JSON=$(printf '%s' "${BODY}" \
+    | python3 -c "import sys,json; print(json.dumps(sys.stdin.read()))")
+  RESULT=$(gh api graphql -f query="
+  mutation {
+    createIssue(input: {
+      repositoryId: \"${REPO_NODE_ID}\"
+      title: ${TITLE_JSON}
+      body: ${BODY_JSON}
+      issueTypeId: \"${TASK_TYPE}\"
+    }) {
+      issue { number id url }
+    }
+  }")
   TASK_NUMBER=$(echo "${RESULT}" | python3 -c \
-    "import json,sys; print(json.load(sys.stdin)['number'])")
+    "import json,sys; print(json.load(sys.stdin)['data']['createIssue']['issue']['number'])")
   TASK_NODE_ID=$(echo "${RESULT}" | python3 -c \
-    "import json,sys; print(json.load(sys.stdin)['id'])")
+    "import json,sys; print(json.load(sys.stdin)['data']['createIssue']['issue']['id'])")
   # Then add to project with Schedule=Someday (same snippet as above)
   ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -902,6 +902,13 @@ completed work.
 
 Issues live in GitHub Issues; external PRs are not a triage surface. See `docs/agents/issue-tracker.md`.
 
+**Never use `gh issue create`** — it cannot set issue types, parent/child
+relationships, or blocker/blocked-by links. Always use the
+`manage-github-issue` helper script (`.agents/skills/manage-github-issue/manage_github_issue.sh`)
+or the `createIssue` GraphQL mutation directly (with `issueTypeId`,
+`parentIssueId` inline). Issue type IDs and relationship mutation names are in
+`.agents/skills/manage-github-issue/REFERENCE.md`.
+
 ### Triage labels
 
 Default label vocabulary (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.


### PR DESCRIPTION
## Summary

- Adds an explicit rule to `AGENTS.md` (under the Issue tracker section): never use `gh issue create`; always use the `manage-github-issue` helper or `createIssue` GraphQL mutation so that issue type, parent, and relationship fields are set correctly.
- Fixes `process-concerns` Phase 4 Task creation: replaces the bare `gh issue create` call with the `createIssue` GraphQL mutation (with `issueTypeId: "${TASK_TYPE}"`), matching the existing Phase 3c Concern pattern.
- Adds `TASK_TYPE = IT_kwDOAjf0s84AcFLo` to the `process-concerns` constants block.

## Test plan

- [ ] Verify `AGENTS.md` contains the new "Never use `gh issue create`" rule under `### Issue tracker`
- [ ] Verify `process-concerns/SKILL.md` Phase 4 Task snippet uses `createIssue` GraphQL with `issueTypeId`
- [ ] Verify `process-concerns/SKILL.md` constants block includes `TASK_TYPE`
- [ ] Run `process-concerns` skill end-to-end on a test concern and confirm created Task issues have the correct type set in GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)