### PR TITLE
docs: ADR-0026 + CM-15/CM-16 spec additions for CaseActor-routed actor suggestion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,6 +266,18 @@ the GitHub Issue-based coordination model and
 - Treat anything under `/security`, `/auth`, or equivalent paths as sensitive
 - Do not generate secrets, credentials, or real tokens
 - Flag ambiguous requirements instead of guessing
+- **NEVER run `git worktree prune` (or `git gc` / any pruning command) in this
+  repo.** The `.git` common directory is **shared across multiple environments**
+  (host macOS checkouts *and* dev-container checkouts) via mounts. `prune` deletes
+  the admin metadata (`gitdir`/`commondir`/`HEAD`/`index`) for every worktree
+  whose checkout path is not resolvable *from the current environment* — which
+  silently destroys live worktrees belonging to other containers/the host, not
+  just stale ones. A worktree registered under a path the current environment
+  can't see always looks "prunable" but usually is not. If `git worktree list`
+  shows `prunable` entries, **leave them**; verify with the human before removing
+  any worktree. Recovery after an erroneous prune is possible (refs/objects
+  survive) but requires hand-rebuilding each admin dir — see
+  [`notes/parallel-development.md`](notes/parallel-development.md).
 
 ---
 

--- a/docs/adr/0026-caseactor-routed-actor-suggestion.md
+++ b/docs/adr/0026-caseactor-routed-actor-suggestion.md
@@ -1,0 +1,157 @@
+---
+status: proposed
+date: 2026-07-09
+deciders: [adh, Copilot]
+---
+
+# ADR-0026: CaseActor-Routed Actor Suggestion and Invitation Flow
+
+## Context and Problem Statement
+
+When a case participant wants to suggest that another actor be invited to the case,
+how should the suggestion be communicated so that (1) the CaseActor can record the event
+in the canonical ledger, (2) the Case Owner receives the suggestion and can approve or
+reject it, and (3) the approved invitation follows the existing invite/accept/bootstrap
+chain?
+
+The current prototype implementation (`suggest_actor_tree.py`,
+`suggest_actor_demo.py`) routes the suggestion `Offer(Actor, Case)` directly to the
+Case Owner's inbox. This predates the CaseActor routing model established in
+ADR-0021 and PCR-08: all case-scoped protocol activity MUST route through the
+CaseActor's inbox so it can record the event in the canonical ledger before
+broadcasting to participants.
+
+## Decision Drivers
+
+- All case-scoped messages MUST route through the CaseActor inbox (ADR-0021,
+  PCR-08-001, PCR-08-002).
+- The Case Owner is the sole decision-maker for case participant membership; no
+  participant can invite directly without Case Owner approval (CM-02-001).
+- The CaseActor MUST commit a ledger entry for every received and every sent
+  protocol activity (CLP-07, CLP-10-006 ordering rule).
+- The invited actor MUST have enough information to give informed consent to the
+  active embargo before accepting the invitation (issue #1289, MV-10-006).
+- Invited participants MUST carry the roles the Case Owner intends for them
+  (issue #1288).
+
+## Considered Options
+
+### Option A: Direct-to-owner routing (current prototype behavior)
+
+The recommending participant sends `Offer(Actor, Case)` directly to the Case
+Owner's inbox. The Case Owner's BT checks `case.attributed_to == actor_id` and
+either emits an `AcceptActorRecommendation + RmInviteToCase` or a
+`RejectActorRecommendation`.
+
+- Good: simple, fewer protocol hops.
+- Bad: bypasses the CaseActor; recommendation is never recorded in the canonical
+  ledger.
+- Bad: the Case Owner's BT must self-identify as the owner, coupling the handler
+  to the authorization model in a way that other received-side use cases do not.
+- Bad: there is no mechanism for the CaseActor to broadcast the recommendation
+  to other participants so they have consistent ledger state.
+- Bad: roles for the new participant must come from the recommender or be invented
+  at accept time; neither path is specified.
+
+### Option B: CaseActor-routed with transform (chosen)
+
+The recommending participant sends `Offer(Actor X, Case)` to the CaseActor's
+inbox. The CaseActor:
+
+1. Records the received Offer in the ledger.
+2. Broadcasts the ledger entry to all participants.
+3. Runs an Evaluator BT node to assign default roles (`[VENDOR]`).
+4. Transforms the Offer into `Offer(CaseParticipant{actor=X, roles=[VENDOR]},
+   Case)` addressed to the Case Owner, with `origin = original-offer-id`.
+
+The Case Owner responds with `Accept(Offer)` or `Reject(Offer)` to the CaseActor.
+The CaseActor records the response, fans it out, and either sends
+`Invite(CaseStub+embargo)` to Actor X or sends `RejectActorRecommendation` to
+the original recommender (with `in_reply_to = original-offer-id`).
+
+- Good: all protocol events pass through the CaseActor and are recorded in the
+  ledger.
+- Good: the Case Owner can override default roles in their Accept response.
+- Good: the recommender's original offer and the Case Owner's decision are both
+  auditable.
+- Good: the `origin` field on the CaseActor's Offer to the Case Owner preserves
+  the causal chain without requiring a separate lookup table.
+- Neutral: adds two extra protocol hops (recommender→CaseActor,
+  CaseActor→CaseOwner) compared to Option A.
+
+### Option C: Any-participant-can-invite
+
+Any existing participant can directly invite another actor without Case Owner
+approval.
+
+- Good: simpler for cases with low-trust or egalitarian coordination styles.
+- Bad: removes the ownership gate; violates CM-02-001 (Case Owner administers
+  the case).
+- Bad: in multi-vendor or multi-coordinator scenarios, uncontrolled invites
+  create race conditions on participant list state.
+- Rejected.
+
+## Decision Outcome
+
+Chosen option: **Option B — CaseActor-routed with transform**, because it is the
+only option that satisfies all routing invariants (ADR-0021, PCR-08) and the
+ledger recording requirement (CLP-07) while preserving the Case Owner as sole
+decision-maker for participant membership.
+
+### Consequences
+
+- Good: the suggest-actor flow becomes consistent with all other case-scoped
+  protocol messages.
+- Good: all three roles in the flow — recommender, CaseActor, Case Owner — have
+  a clearly defined inbox and single responsibility.
+- Good: the `origin` field canonicalizes how AS2 activities carry causal chain
+  context without a side-channel data store.
+- Bad: the existing `suggest_actor_tree.py` BT and `suggest_actor_demo.py`
+  must be redesigned; they cannot be incrementally adapted.
+- Bad: the Case Owner now receives a transformed Offer (CaseParticipant) rather
+  than the recommender's original Offer; implementations must handle the
+  indirection.
+
+### Ledger Commit Ordering
+
+Per the invariant established in this design session: a ledger entry MUST be
+committed only for events that have already occurred — receipt of an inbound
+message or emission of an outbound message. Pre-committing a decision before
+communicating it is not permitted. The sequence for every step in this flow is:
+(1) send/receive the protocol message, (2) record it in the ledger, (3) fan-out
+the ledger entry to all participants.
+
+### Duplicate Recommendation Handling
+
+Three distinct states must be distinguished when a second `Offer(Actor X)` arrives:
+
+| State | CaseActor behavior |
+|---|---|
+| Pending decision (first Offer not yet resolved) | Record in ledger, fan-out, send Note to Case Owner noting the reinforcing demand signal |
+| Invite issued to Actor X (awaiting Accept/Reject) | Record in ledger, fan-out, auto-send `AcceptActorRecommendation` to second recommender, no duplicate Invite |
+| Actor X is already a participant | Record in ledger, fan-out, auto-send `AcceptActorRecommendation` to second recommender |
+
+## Validation
+
+- `suggest_actor_tree.py` and its test coverage must be rewritten to exercise
+  the new CaseActor-side BT (receive `Offer(Actor)`, transform,
+  forward `Offer(CaseParticipant)` to Case Owner).
+- `suggest_actor_demo.py` must be updated to route the recommendation to the
+  CaseActor inbox rather than the Case Owner inbox.
+- A new received-side BT must handle `Accept(Offer(CaseParticipant))` from the
+  Case Owner at the CaseActor and trigger `Invite(CaseStub+embargo)` to the
+  invitee.
+- Spec requirements CM-15 and CM-16 (in `specs/case-management.yaml`) capture
+  the normative requirements derived from this decision.
+
+## More Information
+
+- ADR-0021: CaseActor Inbox Routing as the Sole Path to Canonical Ledger Entries
+- ADR-0022: Single BT Execution Per Inbox Delivery for Received-Side CaseActor Routing
+- `notes/case-communication-model.md` — canonical PCR-08 routing rules
+- `notes/case-bootstrap-trust.md` — late-joiner trust establishment
+- `specs/participant-case-replica.yaml` PCR-08 — invite/accept/bootstrap chain
+- Issue #1292 — invite/embargo consent completeness epic
+- Issue #1295 — tracking issue for this ADR + spec additions PR
+
+Generated spec requirements: `case-management.yaml` CM-15, CM-16.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -88,6 +88,8 @@ General information about architectural decision records is available at <https:
   `process_payload` Seam](0020-inbox-bt-orchestration.md)
 - [ADR-0025 Call-Out Point Abstraction Layer: Factory-Based Injection with
   Typed Backends](0025-call-out-point-abstraction-layer.md)
+- [ADR-0026 CaseActor-Routed Actor Suggestion and Invitation
+  Flow](0026-caseactor-routed-actor-suggestion.md)
 
 ## Rejected ADRs
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -232,6 +232,7 @@ nav:
       - Use Factory Pattern for BT nodes: 'adr/0004-use-factory-methods-for-common-bt-node-types.md'
       - Use ActivityStreams Vocabulary as Message Format: 'adr/0005-activitystreams-vocabulary-as-vultron-message-format.md'
       - Use CalVer for Versioning: 'adr/0006-use-calver-for-project-versioning.md'
+      - CaseActor-Routed Actor Suggestion: 'adr/0026-caseactor-routed-actor-suggestion.md'
   - About:
     - Contributing: 'about/contributing.md'
     - FAQ: 'about/faq.md'

--- a/notes/parallel-development.md
+++ b/notes/parallel-development.md
@@ -147,6 +147,51 @@ PR-time detection is sufficient.
 
 ---
 
+## Shared `.git` and Worktree Pruning (Danger)
+
+In this setup the `.git` **common directory is shared across multiple
+environments** — host macOS checkouts and one or more dev-container checkouts
+mount the same `.git`. Each worktree checkout may live at a path that only
+*one* of those environments can resolve (e.g. `/workspaces/vultron_clyde`
+exists only inside a container; `/Users/adh/dev/vultron_blinky` exists only on
+the host).
+
+**Never run `git worktree prune`, `git gc`, or any pruning command.** `prune`
+walks `.git/worktrees/*` and deletes the admin metadata for any worktree whose
+checkout path is not resolvable *from the current environment*. Because sibling
+environments' paths never resolve locally, prune silently destroys the admin
+dirs (`gitdir`, `commondir`, `HEAD`, `index`) of **live** worktrees owned by
+other containers or the host — not just genuinely stale ones. From the host,
+container worktrees always appear `prunable`; from a container, host worktrees
+always appear `prunable`. **`prunable` here means "path not visible from here,"
+not "safe to delete."** Leave such entries alone and confirm with the human
+before removing any worktree.
+
+### Recovery after an erroneous prune
+
+Refs and objects are never touched by prune, so no commits are lost — only the
+per-worktree admin metadata. `git worktree repair` **cannot** recreate a fully
+deleted admin dir; rebuild each one by hand, run **from the environment that
+can see that checkout**:
+
+```bash
+# For each affected worktree <path> that was on branch <branch>:
+#   (find the authoritative admin path from the worktree's own .git file)
+admin=$(sed -n 's/^gitdir: //p' "<path>/.git")   # e.g. .../.git/worktrees/<id>
+mkdir -p "$admin"
+printf '%s/.git\n' "<path>"              > "$admin/gitdir"
+printf '../..\n'                         > "$admin/commondir"
+printf 'ref: refs/heads/%s\n' "<branch>" > "$admin/HEAD"   # or a 40-char SHA if detached
+git -C "<path>" reset --mixed            # rebuilds the index only; leaves working-tree edits intact
+```
+
+Then `git worktree repair` (now that admin dirs exist) and `git worktree list`
+to confirm. Recover the branch mapping from `git worktree list` output captured
+*before* the prune, or from open PRs; if a worktree had moved branches,
+`git -C <path> checkout <correct-branch>` afterward — no data is lost either way.
+
+---
+
 ## Skill Updates Summary
 
 | Skill | Change |

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -6,6 +6,8 @@ description: >-
   between participant-specific and participant-agnostic state. `notes/bt-integration.md`,
   ActivityPub specification `handler-protocol.md` (HP-00-001, HP-00-002), `actor-knowledge-model.md`
   (AKM-01-001, AKM-01-002). CM-14 (case initialization sequence) sourced from IDEA-26050501.
+  CM-15 (actor suggestion routing) and CM-16 (invitation flow) sourced from ADR-0026
+  design session 2026-07-09.
 version: 1.0.0
 kind: domain
 scope:
@@ -705,3 +707,173 @@ groups:
     relationships:
     - rel_type: depends_on
       spec_id: CM-14-001
+- id: CM-15
+  title: Actor Suggestion Routing (Recommend-Actor Flow)
+  specs:
+  - id: CM-15-001
+    priority: MUST
+    statement: >-
+      A participant wishing to suggest that another actor be invited to the case MUST
+      send `Offer(object=Actor, target=Case)` to the CaseActor's inbox, not directly
+      to the Case Owner's inbox.
+    rationale: >-
+      All case-scoped protocol messages MUST route through the CaseActor so the event
+      can be recorded in the canonical case ledger before any downstream action is taken
+      (ADR-0021, PCR-08-001).
+    relationships:
+    - rel_type: implements
+      spec_id: PCR-08-001
+  - id: CM-15-002
+    priority: MUST
+    statement: >-
+      When the CaseActor receives `Offer(object=Actor, target=Case)`, it MUST commit a
+      `CaseLedgerEntry` for the received Offer and fan out the entry to all participants
+      BEFORE taking any downstream action.
+    rationale: >-
+      Ledger entries record events that have already occurred; pre-committing a
+      decision before communicating it is not permitted (CLP-10-006 commit ordering).
+    relationships:
+    - rel_type: implements
+      spec_id: CLP-10-006
+  - id: CM-15-003
+    priority: MUST
+    statement: >-
+      After recording the received `Offer(Actor)`, the CaseActor MUST assign default
+      roles for the suggested actor (defaulting to `[CVDRole.VENDOR]`) via an Evaluator
+      BT node that can be overridden by configuration or by the Case Owner at accept time.
+    note: >-
+      The Evaluator node is a call-out point (ADR-0024 shape: Evaluator) that MAY be
+      replaced by a more sophisticated role-inference implementation in future. The
+      default of VENDOR is the most conservative choice for an unknown actor.
+  - id: CM-15-004
+    priority: MUST
+    statement: >-
+      The CaseActor MUST transform the received `Offer(Actor)` into
+      `Offer(object=CaseParticipant{attributed_to=actor, case_roles=roles}, target=Case)`
+      and send it to the Case Owner's inbox, with `origin` set to the ID of the original
+      recommender's Offer activity.
+    rationale: >-
+      The Case Owner makes a membership decision about a CaseParticipant (actor + roles),
+      not about a bare Actor identity. The `origin` field preserves the causal chain
+      without a side-channel data store.
+  - id: CM-15-005
+    priority: MAY
+    statement: >-
+      The recommender's `Offer(Actor)` MAY include a `content` or `summary` field
+      explaining why the actor is being suggested. The CaseActor SHOULD forward this
+      text as the `content` of the transformed `Offer(CaseParticipant)` it sends to
+      the Case Owner.
+  - id: CM-15-006
+    priority: MUST
+    statement: >-
+      After receiving `Accept(Offer(CaseParticipant))` from the Case Owner, the CaseActor
+      MUST (1) commit a ledger entry for the Accept, (2) fan out the ledger entry, (3) send
+      `AcceptActorRecommendation` to the original recommender with `in_reply_to` set to
+      the ID of the original recommender's `Offer` activity, and (4) send
+      `Invite(CaseStub[+embargo])` to the suggested actor per CM-16.
+    relationships:
+    - rel_type: implements
+      spec_id: CM-16-001
+  - id: CM-15-007
+    priority: MUST
+    statement: >-
+      After receiving `Reject(Offer(CaseParticipant))` from the Case Owner, the CaseActor
+      MUST (1) commit a ledger entry for the Reject, (2) fan out the ledger entry, and
+      (3) send `RejectActorRecommendation` to the original recommender with `in_reply_to`
+      set to the ID of the original recommender's `Offer` activity.
+  - id: CM-15-008
+    priority: MUST
+    statement: >-
+      When a second `Offer(Actor X, Case)` arrives while a pending decision for Actor X
+      is still outstanding (no Accept or Reject yet received from the Case Owner), the
+      CaseActor MUST record the duplicate recommendation in the ledger and MUST send a
+      `Note` to the Case Owner's inbox indicating that a reinforcing suggestion was
+      received, including the second recommender's identity and any `content` from the
+      Offer. The CaseActor MUST NOT send a second transformed Offer to the Case Owner.
+  - id: CM-15-009
+    priority: MUST
+    statement: >-
+      When a second `Offer(Actor X, Case)` arrives after an Invite has already been sent
+      to Actor X (i.e., the invite is in-flight or the actor is already a participant),
+      the CaseActor MUST record the recommendation in the ledger, fan out the entry, and
+      auto-send `AcceptActorRecommendation` (with `in_reply_to` = original recommender's
+      Offer ID) back to the second recommender. The CaseActor MUST NOT send a duplicate
+      Invite to Actor X.
+  - id: CM-15-010
+    priority: MUST
+    statement: >-
+      In every step of the actor suggestion flow, the CaseActor MUST commit the ledger
+      entry for a protocol event AFTER the corresponding message has been sent or received,
+      never before.
+    rationale: >-
+      Pre-announcing a decision in the ledger before communicating the decision creates
+      a window where the ledger shows an effect without its cause.
+- id: CM-16
+  title: Invitation Flow — Enrichment and Roles
+  specs:
+  - id: CM-16-001
+    priority: MUST
+    statement: >-
+      The `Invite` activity sent by the CaseActor to a new actor MUST include a case
+      stub as the `object`, with the case stub containing at minimum the case ID and
+      type. This requirement is extended by CM-16-002 and CM-16-003.
+  - id: CM-16-002
+    priority: MUST
+    statement: >-
+      When `CaseStatus.em_state == ACTIVE` at the time the Invite is sent, the case stub
+      MUST include at minimum the `activeEmbargo` reference (ID + `end_time`) and the
+      embedded `CaseStatus.em_state` field so the invitee can give informed consent before
+      accepting.
+    rationale: >-
+      The invite-accept cycle is the only consent signal for late-joining participants
+      when an active embargo already exists. Accepting without seeing embargo terms is
+      not meaningfully informed consent (issue #1289, MV-10-006).
+    relationships:
+    - rel_type: implements
+      spec_id: MV-10-006
+  - id: CM-16-003
+    priority: MUST
+    statement: >-
+      The `Invite` activity MUST embed the intended `case_roles: list[CVDRole]` for the
+      invitee. These roles come from the Case Owner's Accept response (CM-15-006) or
+      from the CaseActor's default role assignment (CM-15-003) if the Case Owner did not
+      override them.
+    rationale: >-
+      All invited participants getting `caseRoles=[]` is a protocol defect (issue #1288).
+      The participant record created on Accept(Invite) MUST reflect the roles the Case
+      Owner intended.
+  - id: CM-16-004
+    priority: MUST
+    statement: >-
+      When the CaseActor receives `Accept(Invite)` from the invitee, it MUST (1) commit a
+      ledger entry for the Accept, (2) fan out the ledger entry to ALL existing participants,
+      (3) create a `CaseParticipant` record for the invitee at `RM.ACCEPTED` with the roles
+      from the Invite, (4) sign embargo consent if `em_state == EM.ACTIVE` (CM-10-001),
+      (5) send `Announce(VulnerabilityCase)` with the current full case snapshot to the
+      invitee, and (6) backfill all prior `CaseLedgerEntry` records to the invitee in
+      log-index order.
+    relationships:
+    - rel_type: implements
+      spec_id: CM-11-001
+    - rel_type: implements
+      spec_id: CM-10-001
+    - rel_type: implements
+      spec_id: PCR-08-010
+  - id: CM-16-005
+    priority: MUST_NOT
+    statement: >-
+      The invitee MUST NOT appear in the case participant list until their `Accept(Invite)`
+      has been received and processed by the CaseActor. A pending invitation (Invite sent,
+      no response yet) is tracked only as a ledger entry, not as a participant record.
+    rationale: >-
+      A participant record implies RM.ACCEPTED state and associated permissions. Creating
+      one before the invitee has consented would grant protocol access prematurely.
+  - id: CM-16-006
+    priority: MUST
+    statement: >-
+      The CaseActor MUST commit a `CaseLedgerEntry` for the emitted `Invite` activity
+      (recording the fact of its emission) AFTER the Invite has been queued for delivery
+      to the invitee. The commit MUST NOT precede the emission.
+    relationships:
+    - rel_type: implements
+      spec_id: CLP-10-006

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -742,7 +742,7 @@ groups:
       roles for the suggested actor (defaulting to `[CVDRole.VENDOR]`) via an Evaluator
       BT node that can be overridden by configuration or by the Case Owner at accept time.
     note: >-
-      The Evaluator node is a call-out point (ADR-0024 shape: Evaluator) that MAY be
+      The Evaluator node is a call-out point (ADR-0025 abstraction; ADR-0024 shape: Evaluator) that MAY be
       replaced by a more sophisticated role-inference implementation in future. The
       default of VENDOR is the most conservative choice for an unknown actor.
   - id: CM-15-004


### PR DESCRIPTION
- Closes #1295

## Summary

- Adds **ADR-0026** (proposed): documents the decision to route all actor
  recommendations through the CaseActor inbox rather than directly to the
  Case Owner. Captures alternatives considered, consequences, and the
  validation path.
- Adds **CM-15** (10 requirements) to `specs/case-management.yaml`:
  normalizes the full suggest-actor flow from recommender to CaseActor to
  Case Owner, including the `Offer(CaseParticipant)` transform, `origin`
  field linkage, duplicate handling (3 scenarios), and commit ordering invariant.
- Adds **CM-16** (6 requirements): formalizes the invitation enrichment
  requirements — embargo stub in `Invite(CaseStub)` when `EM.ACTIVE` (#1289),
  roles threading through invite to participant record (#1288), and the
  `Accept(Invite)` → snapshot + ledger backfill cascade.
- Updates `docs/adr/index.md` to list ADR-0026 under Proposed ADRs.

## Changes

- `docs/adr/0026-caseactor-routed-actor-suggestion.md` — new ADR
- `docs/adr/index.md` — add ADR-0026 to Proposed list
- `specs/case-management.yaml` — add CM-15 and CM-16 groups (172 lines)

### Review follow-ups (post-review commits)

- `mkdocs.yml` — add ADR-0026 to the Decision Records nav (it was added to
  `docs/adr/index.md` only; the nav omission surfaces as INFO, so `--strict`
  did not catch it).
- `specs/case-management.yaml` CM-15-003 — cite ADR-0025 (call-out-point
  abstraction) alongside ADR-0024 (Evaluator shape).
- `AGENTS.md` + `notes/parallel-development.md` — **out-of-original-scope
  guardrail**, added at maintainer request after a `git worktree prune`
  incident: the `.git` common dir is shared across host + dev-container
  checkouts, so pruning silently destroyed live sibling worktrees. Documents a
  hard "never prune" rule and a validated admin-dir recovery procedure. Flagged
  here so the scope expansion is explicit.

## Verification

- `uv run spec-dump` parses CM-15 and CM-16 correctly (verified locally)
- `markdownlint-cli2` passes on the new ADR, updated `AGENTS.md`, and
  `notes/parallel-development.md` (0 errors)
- Spec registry linter passes on the updated YAML
- `mkdocs build` no longer reports ADR-0026 as absent from nav
- Notes frontmatter validation passes
- No production code changes; docs/specs/agent-guidance only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
