### PR TITLE
docs: plan #1275 — positive-precondition announce tree refactor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -523,6 +523,13 @@ Short entries are reproduced here; longer ones are referenced below.
   NOT use `record_event()` or any canonical commit path as a generic "log
   this thing" sink. See ADR-0019, `specs/case-ledger-processing.yaml` CLP-07,
   and `notes/case-ledger-authority.md` § "Canonical Entry Criteria".
+- **Negative-Guard Condition Nodes Are a Readability Anti-Pattern** — Do NOT
+  create condition nodes named `IsNotFoo` that return SUCCESS to *skip* an
+  effect and FAILURE to *trigger* it.  The backwards semantics force readers to
+  mentally invert the condition.  Use positive-precondition Sequences instead:
+  `Selector(Sequence(IsFooLedgerEntryNode, ApplyFooNode), Success("FooSkipped"))`.
+  See `specs/behavior-tree-node-design.yaml` BTND-08-001, BTND-08-002 and
+  `notes/bt-design-patterns.md` § "Idiom Family Selection Guide".
 - **Adding a New Pitfall: Check the Routing Policy First** — see
   [notes/agents-md-structure.md](notes/agents-md-structure.md)
 - **`as_VulnerabilityCase` (wire) vs `VulnerabilityCase` (core) — Always Check
@@ -801,6 +808,17 @@ Short entries are reproduced here; longer ones are referenced below.
   binary external queries: a node the BT invokes on-demand that queries an
   external system and returns only SUCCESS/FAILURE is a Retriever, not a
   Sentinel.
+
+- **BT Integration Tests Must Use Deterministic Factories When the Default Is
+  Probabilistic** — When a tree builder's default `CallOutBackendFactory` wraps
+  a `WeightedBehavior` or `AlmostAlwaysSucceed` fuzzer node, integration tests
+  that assert `Status.SUCCESS` on the full tree become flaky. Pass an explicit
+  deterministic factory (e.g., a module-level `_always_succeed_factory` helper)
+  to every success-path integration test. Structure tests and `FAILURE`-path
+  tests are unaffected. See `test/AGENTS.md` § "BT Factory Determinism" and
+  [notes/bt-integration.md](notes/bt-integration.md)
+  § "Integration Tests Must Use Deterministic Factories When BT Default Is
+  Probabilistic".
 
 - **`NoNew*` flags imply an upstream Sentinel seam.** When a BT condition
   node of the form `NoNew<X>Info` (or any node whose description says "check

--- a/notes/bt-design-patterns.md
+++ b/notes/bt-design-patterns.md
@@ -484,3 +484,53 @@ Fallback                             ← Pattern 1 (goal-first)
        ├─ PreconditionCheck          ← PPA precondition
        └─ Action                     ← PPA action
 ```
+
+---
+
+## Idiom Family Selection Guide
+
+Two distinct idiom families apply at different levels of the BT hierarchy.
+Choose by asking: **Is this tree routing a message to the right effect, or
+ensuring that a goal state is achieved?**
+
+### Handler / Routing BTs: Precondition-Sequence
+
+Use when dispatching an incoming ledger entry or activity to the appropriate
+effect handler based on its type.  The effect should fire if and only if the
+type matches; a non-match is a silent no-op.
+
+```text
+Selector                            ← effect slot (one per event type)
+  ├─ Sequence
+  │    ├─ IsFooLedgerEntryNode      ← SUCCESS iff entry IS this type
+  │    └─ ApplyFooEffectNode        ← fires only when IsFoo succeeded
+  └─ AlwaysSuccess("FooSkipped")    ← no-op path; name ends with "Skipped"
+```
+
+**Condition naming rule (BTND-08-001)**: Condition nodes in this idiom MUST
+use positive names (`IsFoo`, not `IsNotFoo`).  A negative-guard node that
+returns SUCCESS to *skip* an effect inverts the intent and is a
+readability anti-pattern — see BTND-08-001, BTND-08-002.
+
+### Goal-Ensuring / Action BTs: Postcondition-Fallback (PPA)
+
+Use when the tree must achieve a protocol state (see Patterns 1–3 above).
+The effect should fire only when the goal is not yet met.
+
+```text
+Fallback                            ← PPA root
+  ├─ GoalAlreadyAchievedNode        ← SUCCESS iff already done → short-circuit
+  └─ Sequence
+       ├─ PreconditionNode          ← guard: required before acting
+       └─ ActionNode                ← achieves the goal
+```
+
+**Selection heuristic**: If you are writing a dispatch table (one effect
+per message/entry type), reach for Precondition-Sequence.  If you are
+writing a stateful protocol step (reach state X if not already there),
+reach for Postcondition-Fallback.
+
+The distinction maps to the canonical protocol BT structure documented in
+`docs/topics/behavior_logic/`: ReceiveMessages subtrees use
+Precondition-Sequence routing; ReportManagement / EmbargoManagement subtrees
+use Postcondition-Fallback goal-ensuring patterns.

--- a/plan/history/2607/idea/IDEA-1133.md
+++ b/plan/history/2607/idea/IDEA-1133.md
@@ -1,0 +1,64 @@
+---
+source: IDEA-1133
+timestamp: '2026-07-08T18:45:43.561529+00:00'
+title: Add pre-case ACK demo scenario and manual-create case policy option
+type: idea
+---
+
+## Background
+
+When a reporter submits a report (`Offer(VulnerabilityReport)`) to a receiver, the receiver
+may want to send an immediate acknowledgment (`Read(Offer(Report))`) before deciding whether
+to create a case. This pre-case ACK is a direct actor-to-actor message that says "I have
+received and read your report, I am evaluating it" — without committing to Accept or Reject.
+
+Currently, the two-actor demo follows an **always-create-case-on-receipt** policy, where
+the receiver creates a case immediately when the Offer arrives. In that flow, a separate
+`ack-report` step is protocol noise: the reporter already learns the report was received
+when they are added as a participant to the newly-created case.
+
+However, this is not the only valid receiver policy. A receiver may want to:
+
+1. Acknowledge receipt immediately (pre-case ACK)
+2. Review the report internally
+3. Only then decide to Accept (create a case) or Reject
+
+The `RmReadReportActivity` (`as:Read`) mechanism already exists in the codebase for this
+purpose (see `vultron/demo/exchange/acknowledge_demo.py`), but there is no demo scenario
+that exercises the full pre-case-creation ACK workflow.
+
+## What needs to be done
+
+This is NOT merely demoing existing features — it also requires adding a policy option
+to the BT:
+
+1. **Add a policy check to the report-receipt BT** — the `SubmitReportReceivedUseCase`
+   currently always runs case creation. A configurable policy flag (e.g.
+   `auto_create_case: bool`) should gate whether case creation runs automatically
+   on report receipt, or whether the receiver must explicitly trigger it later.
+
+2. **Add a new demo scenario** (e.g. `vultron/demo/scenario/pre_case_ack_demo.py`)
+   that exercises the "manual-create" policy path:
+   - Reporter submits report
+   - Receiver sends pre-case ACK (`Read(Offer(Report))`) directly to reporter
+   - Receiver later explicitly creates the case (or rejects)
+
+3. **Wire `ack_report` into `EXPECTED_EVENT_TYPES`** once the scenario that
+   produces a canonical `ack_report` ledger entry exists.
+
+## Protocol note
+
+In the pre-case context, actors communicate directly (reporter ↔ receiver).
+Once a case exists, all communication goes through the CaseActor fan-out model.
+The pre-case ACK is the only scenario where a direct actor-to-actor `Read`
+makes protocol sense for this message type.
+
+## Traceability
+
+- Identified during scope reduction of #1039 (ack_report in two-actor demo)
+- See also: `vultron/demo/exchange/acknowledge_demo.py` (existing single-actor ACK demo)
+- `AckReportReceivedUseCase`, `EmitAckReportActivity` already implemented
+
+**Processed**: 2026-07-08 — implementation tracked in #1272.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1271>.
+Spec: `specs/case-management.yaml` CM-15-001.

--- a/plan/history/2607/implementation/ISSUE-1151.md
+++ b/plan/history/2607/implementation/ISSUE-1151.md
@@ -1,0 +1,20 @@
+---
+source: ISSUE-1151
+timestamp: '2026-07-08T17:35:13.879423+00:00'
+title: 'FUZZ-08b: Call-out point abstraction layer (ADR-0025)'
+type: implementation
+---
+
+## Issue #1151 — FUZZ-08b: Call-out point abstraction layer
+
+Implemented the full call-out point abstraction layer (ADR-0025):
+
+- `CallOutBackendFactory` type alias in `vultron/core/behaviors/call_out_point.py`
+- Five shape mixin classes in `vultron/demo/fuzzer/call_out_point.py` (Evaluator, Retriever, Composer, Actuator, Sentinel)
+- Illustrative `NewValidationInfoSentinel` subclass (full impl: #1175)
+- Factory injection into `create_validate_report_tree`, `create_prioritize_subtree`, and new `create_publication_tree`
+- BT-18-001 blackboard contract docstrings on all exemplar nodes
+- ADR-0025 advanced from proposed to accepted
+- 44 new tests; 20 integration tests made deterministic with `_always_succeed_factory`
+
+PR: <https://github.com/CERTCC/Vultron/pull/1267>

--- a/plan/history/2607/implementation/ISSUE-1266.md
+++ b/plan/history/2607/implementation/ISSUE-1266.md
@@ -1,0 +1,19 @@
+---
+source: ISSUE-1266
+timestamp: '2026-07-08T19:02:48.278578+00:00'
+title: 'FUZZ-08a-quart: Reclassify remaining Sentinel-labeled fuzzer nodes'
+type: implementation
+---
+
+## Issue #1266 — FUZZ-08a-quart: Reclassify remaining 17 Sentinel-labeled nodes
+
+Completed audit of all 17 nodes listed in #1266. Reclassified the final two nodes that still carried the Sentinel label:
+
+- EmbargoTimerExpired → Retriever (BT-tick-driven synchronous timestamp comparison; BT-18-006)
+- MonitorDeployment → Actuator (fire-and-confirm side-effect executor; no content artifact)
+
+All other 15 nodes (NoNewValidationInfo, NoNewPrioritizationInfo, NoNewDeploymentInfo, ExploitPrioritySet, ExploitDeferred, ExploitDesired, AllPublished, PublicationIntentsSet, ExploitReady, NotificationsComplete, RcptNotInQrmS, MoreVendors, MoreCoordinators, MoreOthers, IsIDAssignmentAuthority) were already reclassified to ProtocolInternal in prior PRs.
+
+With zero Sentinel-labeled BT nodes remaining, issue #1175 (FUZZ-08f — Implement all Sentinel-shaped call-out points) was closed: its scope reached zero.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1273>

--- a/plan/history/2607/learning/CONCERN-1275.md
+++ b/plan/history/2607/learning/CONCERN-1275.md
@@ -1,0 +1,36 @@
+---
+source: CONCERN-1275
+timestamp: '2026-07-09T18:26:12.840363+00:00'
+title: 'Refactor log_entry_event_effects: replace IsNot*/Selector pattern with positive-precondition
+  Sequence'
+type: learning
+---
+
+## Original Concern
+
+The `log_entry_event_effects` Sequence in `create_announce_log_entry_tree()`
+(`vultron/core/behaviors/sync/announce_tree.py`) currently uses a
+**negative-guard Selector** pattern for each conditional effect:
+
+```text
+Selector(IsNotXxxEventNode, ApplyXxxFromLedgerNode)
+```
+
+This pattern is hard to follow because:
+
+- Readers must mentally invert the condition to understand when the effect runs.
+- `IsNotFoo` naming implies a guard against `Foo`, but the *intent* is to *apply* `Foo`.
+- The Selector-short-circuit mechanic is non-obvious unless you know BT semantics cold.
+
+## Resolution
+
+**Processed**: 2026-07-09 — implementation tracked in #1303.
+**Docs PR**: <https://github.com/CERTCC/Vultron/pull/1302>
+**Spec**: `specs/behavior-tree-node-design.yaml` BTND-08-001, BTND-08-002.
+**Notes**: `notes/bt-design-patterns.md` § "Idiom Family Selection Guide".
+
+Decided approach: Option A — replace each `Selector(IsNotFoo, Apply)` with
+`Selector(Sequence(IsFooLedgerEntryNode, Apply), AlwaysSuccess("FooSkipped"))`.
+Delete old `IsNot*` classes. Add positive `IsXxxLedgerEntryNode` classes.
+Add unit tests for the new conditions. No ADR needed; a BTND-08 spec group
+captures the positive-precondition idiom rule for future code.

--- a/plan/history/2607/learning/CONCERN-1287.md
+++ b/plan/history/2607/learning/CONCERN-1287.md
@@ -1,0 +1,50 @@
+---
+source: CONCERN-1287
+timestamp: '2026-07-09T14:23:47.846098+00:00'
+title: invite_actor_to_case trigger never commits a CaseLedgerEntry (trigger-side
+  BT gap)
+type: learning
+---
+
+## Problem
+
+`invite_actor_to_case_trigger_bt` in `vultron/core/behaviors/case/actor_trigger_trees.py`
+emits an `Invite(VulnerabilityCase)` addressed only to `invitee_id` (`to=[invitee_id]`).
+The CaseActor never receives its own Invite activity in its inbox, so
+`InviteActorToCaseReceivedUseCase` never fires for the CaseActor and the canonical
+case ledger has no `invite_actor_to_case` entry. The FVV demo log jumps from
+`validate_report` directly to `accept_invite_actor_to_case` with no Invite entry in
+between — violating `notes/case-ledger-authority.md` which explicitly lists
+`Invite(VulnerabilityCase)` as a required canonical entry type.
+
+## Root Cause
+
+CLP-10-001 (ADR-0021) requires every protocol-significant trigger tree to emit at
+least one outbound activity addressed to `case_manager_id`. This requirement was
+interpreted as applying only to participant-originated triggers, not to
+CaseActor-originated triggers. Since the CaseActor IS a participant with extra
+duties, it is not exempt — but no code enforced this for CaseActor-originated
+activities. The `offer_case_manager_role` trigger works correctly (it uses a
+self-addressed Offer), but `invite_actor_to_case` was never fixed.
+
+## Fix Approach
+
+1. `EmitInviteActorToCaseNode` adds `case_actor_id` to the Invite's `cc:` field
+2. `InviteActorToCaseReceivedUseCase` upgraded to BTBridge + new
+   `create_invite_actor_to_case_received_tree` with `GuardedCommitCaseLedgerEntryBT`
+3. OX-08-004 WARNING suppressed for purposeful CaseActor self-copy (cc: = own ID)
+4. `invite_actor_to_case` added to `EXPECTED_EVENT_TYPES`
+
+## Why cc: not to: for the self-copy
+
+The invitee is the primary recipient; the CaseActor's copy is archival.
+Using `to:` for both would misrepresent the CaseActor as a co-primary recipient of
+its own outbound message. `cc:` preserves the correct semantic. OX-08-004 was
+narrowed to exclude this purposeful self-copy pattern (the only valid `cc:` use
+in the protocol).
+
+**Resolved**: 2026-07-09 — implementation tracked in #1293.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1291>.
+Spec: `specs/case-ledger-processing.yaml` (CLP-10-001).
+Spec: `specs/outbox.yaml` (OX-08-004).
+ADR: `docs/adr/0021-caseactor-inbox-routing-canonical-ledger.md`.

--- a/plan/history/2607/learning/ISSUE-1061.md
+++ b/plan/history/2607/learning/ISSUE-1061.md
@@ -1,0 +1,35 @@
+---
+title: "SKIP=black needed when rebasing in any vultron_* worktree"
+type: learning
+timestamp: 2026-07-08T00:00:00+00:00
+source: ISSUE-1061
+---
+
+When rebasing in any `vultron_*` git worktree, the pre-commit hook runs
+`black` in-place during cherry-pick. Black reformats files after git applies
+the patch but before the cherry-pick completes, leaving a dirty working tree
+that blocks the merge step with "Your local changes to the following files
+would be overwritten."
+
+**Fix**: `SKIP=black git rebase origin/main`
+
+This skips only the black hook for that rebase; black is already enforced at
+commit time and CI, so nothing is bypassed.
+
+**Why it happens**: The `.git/hooks/pre-commit` points to a Python
+interpreter in a sibling worktree's `.venv`, which runs `pre-commit` against
+the current working tree. During rebase cherry-pick, git applies changes then
+runs hooks — if black reformats any of those files, git sees them as newly
+modified and refuses to continue.
+
+**Scope**: Only affected rebases that touched Python files that black would
+reformat (import ordering, line length, etc.).
+
+**Resolved**: Fixed in #1260 by adding `--check` to the `black` hook and
+removing `--fix` from the `markdownlint-cli2` hook in `.pre-commit-config.yaml`.
+Hooks are now fail-only; auto-fix is done by the `format-code`/`run-linters`
+skills before committing. The `SKIP=black` workaround is no longer needed.
+
+**Promoted**: 2026-07-08 — resolved/superseded; already captured in
+`AGENTS.md` § "Pre-commit Hooks Are Fail-Only". No new doc changes needed.
+Docs PR: [#1274](https://github.com/CERTCC/Vultron/pull/1274)

--- a/plan/history/2607/learning/ISSUE-1151.md
+++ b/plan/history/2607/learning/ISSUE-1151.md
@@ -1,0 +1,41 @@
+---
+title: "Integration tests must use deterministic factories when BT default is probabilistic"
+type: learning
+timestamp: 2026-07-08T00:00:00+00:00
+source: ISSUE-1151
+---
+
+When a tree builder's default factory produces a `WeightedBehavior` node
+(e.g., `AlmostAlwaysSucceed` at 90% success rate), integration tests that
+assert `result.status == Status.SUCCESS` become flaky.  Two such nodes in
+series give ~81% tree success — a failure probability that surfaces within
+a few test runs.
+
+**Pattern that caused this**: Adding factory injection to
+`create_validate_report_tree` where the fuzzer defaults (`EvaluateReportCredibility`,
+`EvaluateReportValidity`) are `AlmostAlwaysSucceed` nodes.  Existing integration
+tests called the tree builder with no factory args and asserted SUCCESS.
+
+**Fix**: Add a module-level `_always_succeed_factory` helper to the test
+file and pass it explicitly to all integration tests that require SUCCESS.
+Tree-structure tests (node names, child counts) and FAILURE-path tests
+(missing DataLayer, missing report) don't need it.
+
+```python
+def _always_succeed_factory(name: str) -> py_trees.behaviour.Behaviour:
+    class _AlwaysSucceed(py_trees.behaviour.Behaviour):
+        def update(self):
+            return py_trees.common.Status.SUCCESS
+    return _AlwaysSucceed(name)
+```
+
+**Rule**: Any time a tree builder's default factory wraps a probabilistic
+fuzzer node, update all integration tests that assert SUCCESS to pass an
+explicit deterministic factory.  Tests that check tree structure (names,
+children) or FAILURE paths are unaffected.
+
+**Promoted**: 2026-07-08 — captured in `notes/bt-integration.md`
+§ "Integration Tests Must Use Deterministic Factories When BT Default Is
+Probabilistic", `test/AGENTS.md` § "BT Factory Determinism", and root
+`AGENTS.md` pitfall entry.
+Docs PR: [#1274](https://github.com/CERTCC/Vultron/pull/1274)

--- a/specs/behavior-tree-node-design.yaml
+++ b/specs/behavior-tree-node-design.yaml
@@ -357,3 +357,49 @@ groups:
     verification: >-
       For each BT-bearing area, scan `nodes/` modules and fail compliance when any leaf
       module exceeds 500 lines.
+- id: BTND-08
+  title: Positive-Precondition Condition Node Naming
+  kind: pattern
+  specs:
+  - id: BTND-08-001
+    priority: SHOULD
+    statement: >-
+      Condition nodes used as type-dispatch guards in a
+      `Selector(Sequence(Condition, Action), AlwaysSuccess)` composite MUST use
+      positive names (e.g., `IsFooEventNode`) that return SUCCESS when the
+      condition IS true and FAILURE otherwise.  Negative-guard names
+      (e.g., `IsNotFooEventNode`) that return SUCCESS to *skip* an effect and
+      FAILURE to *trigger* it are a readability anti-pattern and MUST NOT be
+      introduced in new code.
+    rationale: >-
+      The `Selector(IsNotFoo, ApplyFoo)` pattern requires readers to mentally
+      invert the condition to understand when the effect fires, and the
+      `IsNotFoo` naming implies a guard against `Foo` when the intent is to
+      *apply* `Foo`.  Positive-precondition Sequences make intent immediately
+      readable: "if this IS a remove-embargo entry, apply embargo teardown;
+      otherwise skip".
+    relationships:
+    - rel_type: refines
+      spec_id: BT-06-004
+    verification: >-
+      Search `vultron/core/behaviors/` for `IsNot*Node` class definitions used
+      as the first child of a `Selector` composite; flag any found.
+  - id: BTND-08-002
+    priority: SHOULD
+    statement: >-
+      The `AlwaysSuccess` fallback in a `Selector(Sequence(IsFoo, ApplyFoo),
+      AlwaysSuccess)` composite MUST be given a descriptive `name` of the form
+      `"<Effect>Skipped"` (e.g., `"EmbargoEffectsSkipped"`) so the no-op path
+      is identifiable in BT visualizations and logs.
+    rationale: >-
+      An unnamed or generically-named `AlwaysSuccess` node is invisible in tree
+      dumps and log output, making it harder to trace which effect was skipped
+      and why.  A descriptive `<Effect>Skipped` name makes the no-op path
+      explicit and consistent with the existing codebase convention
+      (e.g., `"AutoCloseSkippedNotCaseManager"`, `"ValidationSkipped"`).
+    relationships:
+    - rel_type: refines
+      spec_id: BTND-08-001
+    verification: >-
+      In each `Selector(Sequence(IsFoo, ApplyFoo), AlwaysSuccess)` composite,
+      confirm the `AlwaysSuccess` node's `name` ends with `"Skipped"`.


### PR DESCRIPTION
- Closes #1275

## Summary

Plans the refactor of `log_entry_event_effects` in `announce_tree.py` to
replace the backwards `IsNot*/Selector` pattern with positive-precondition
`Selector(Sequence(IsFoo, Apply), AlwaysSuccess("FooSkipped"))` composites.
Documents the idiom-family selection rule distinguishing Handler/Routing BTs
(precondition-Sequence) from Goal-Ensuring BTs (postcondition-Fallback/PPA).

## Changes

- `specs/behavior-tree-node-design.yaml`: new BTND-08 group (BTND-08-001:
  positive condition naming; BTND-08-002: AlwaysSuccess skip naming)
- `notes/bt-design-patterns.md`: new "Idiom Family Selection Guide" section
- `AGENTS.md`: new pitfall entry against IsNot*/negative-guard Selector
  anti-pattern