### PR TITLE
fix: invite_actor_to_case trigger now commits a CaseLedgerEntry

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1293.md
+++ b/plan/history/2607/implementation/ISSUE-1293.md
@@ -1,0 +1,12 @@
+---
+source: ISSUE-1293
+timestamp: '2026-07-09T19:35:49.923460+00:00'
+title: fix invite_actor_to_case trigger commits CaseLedgerEntry
+type: implementation
+---
+
+## Issue #1293 — fix: invite_actor_to_case trigger never commits a CaseLedgerEntry
+
+Fixed all five acceptance criteria. The CaseActor's own URI is now added to `cc:` of the outbound Invite so ASGI self-delivery routes a copy to the CaseActor's inbox. A new `create_invite_actor_to_case_received_tree()` factory handles the received-side BT; `InviteActorToCaseReceivedUseCase` upgraded to use BTBridge on the CaseActor path. OX-08-004 warning suppressed for purposeful self-copies. CI ledger invariants test updated.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1305>

--- a/test/ci/test_case_ledger_invariants.py
+++ b/test/ci/test_case_ledger_invariants.py
@@ -72,6 +72,7 @@ _DEVLOGS_DIR: Path = _REPO_ROOT / "devlogs"
 #:   itself (CLP-10-004); it is excluded from EXPECTED_EVENT_TYPES.
 EXPECTED_EVENT_TYPES: frozenset[str] = frozenset(
     {
+        "invite_actor_to_case",
         "validate_report",
         "add_participant_status_to_participant",
         "close_case",

--- a/vultron/adapters/driven/trigger_activity_adapter/actors.py
+++ b/vultron/adapters/driven/trigger_activity_adapter/actors.py
@@ -64,15 +64,19 @@ class _ActorsMixin:
         case_id: str,
         actor: str,
         to: list[str] | None = None,
+        cc: list[str] | None = None,
         id_: str | None = None,
         attributed_to: str | None = None,
     ) -> tuple[str, dict[str, Any]]:
         """Create and persist an ``Invite(Actor, Case)`` activity.
 
         ``actor`` SHOULD be the Case Actor ID (PCR-08-007); ``attributed_to``
-        MAY carry the case owner's ID for attribution.
+        MAY carry the case owner's ID for attribution.  ``cc`` MAY carry the
+        Case Actor's own ID for self-archival (CLP-10-001).
         """
         extra: dict[str, Any] = {"actor": actor, "to": to}
+        if cc is not None:
+            extra["cc"] = cc
         if id_ is not None:
             extra["id_"] = id_
         if attributed_to is not None:

--- a/vultron/adapters/driving/fastapi/inbox_port_factories.py
+++ b/vultron/adapters/driving/fastapi/inbox_port_factories.py
@@ -81,6 +81,7 @@ _SYNC_PORT_SEMANTICS = frozenset(
         MessageSemantics.ANNOUNCE_CASE_LEDGER_ENTRY,
         MessageSemantics.ADD_NOTE_TO_CASE,
         MessageSemantics.CLOSE_CASE,
+        MessageSemantics.INVITE_ACTOR_TO_CASE,
         MessageSemantics.INVITE_TO_EMBARGO_ON_CASE,
         MessageSemantics.REJECT_CASE_LEDGER_ENTRY,
         MessageSemantics.REJECT_INVITE_TO_EMBARGO_ON_CASE,

--- a/vultron/adapters/driving/fastapi/outbox_delivery.py
+++ b/vultron/adapters/driving/fastapi/outbox_delivery.py
@@ -113,9 +113,15 @@ def _warn_secondary_addressing(
     activity_id: str,
     activity_type: str,
 ) -> None:
+    actor_id = getattr(outbound_activity, "actor", None)
     for addr_field in ("cc", "bto", "bcc"):
         value = getattr(outbound_activity, addr_field, None)
         if value is None or value == []:
+            continue
+        # CLP-10-001: purposeful self-copy — CaseActor adds its own URI to
+        # cc: so ASGI self-delivery routes a copy to its own inbox for ledger
+        # archival.  This is intentional; suppress the OX-08-004 warning.
+        if addr_field == "cc" and actor_id and value == [actor_id]:
             continue
         logger.warning(
             "Outbound %s activity '%s' has `%s:` set."

--- a/vultron/core/behaviors/case/actor_trigger_trees.py
+++ b/vultron/core/behaviors/case/actor_trigger_trees.py
@@ -69,6 +69,7 @@ def suggest_actor_to_case_trigger_bt(
 def invite_actor_to_case_trigger_bt(
     invitee_id: str,
     case_id: str,
+    case_actor_id: str | None = None,
     attributed_to: str | None = None,
     captured: dict | None = None,
 ) -> py_trees.behaviour.Behaviour:
@@ -76,11 +77,15 @@ def invite_actor_to_case_trigger_bt(
 
     Emits Invite(Actor, Case) from the Case Actor's identity directly to
     the invitee (no Case Manager resolution needed — the Case Actor IS the
-    routing endpoint here per PCR-08-007).
+    routing endpoint here per PCR-08-007).  When ``case_actor_id`` is
+    provided it is added to ``cc:`` so ASGI self-delivery routes a copy to
+    the CaseActor's own inbox for canonical ledger archival (CLP-10-001).
 
     Args:
         invitee_id: Actor URI of the participant being invited.
         case_id: ID of the VulnerabilityCase.
+        case_actor_id: Optional Case Actor URI added to ``cc:`` for
+            self-archival (CLP-10-001).
         attributed_to: Optional original requesting actor URI.
         captured: Optional dict; ``captured["activity"]`` is set on success.
 
@@ -94,6 +99,7 @@ def invite_actor_to_case_trigger_bt(
             EmitInviteActorToCaseNode(
                 invitee_id=invitee_id,
                 case_id=case_id,
+                case_actor_id=case_actor_id,
                 attributed_to=attributed_to,
                 captured=captured,
             ),

--- a/vultron/core/behaviors/case/invite_actor_to_case_received_tree.py
+++ b/vultron/core/behaviors/case/invite_actor_to_case_received_tree.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Received-side BT factory for the InviteActorToCase workflow.
+
+See CLP-10-001, CLP-10-006; Issue #1293.
+"""
+
+import logging
+
+import py_trees
+
+from vultron.core.behaviors.case.nodes.lifecycle import (
+    create_receive_activity_tree,
+)
+from vultron.core.behaviors.report.nodes.storage import StoreActivityNode
+
+logger = logging.getLogger(__name__)
+
+
+def create_invite_actor_to_case_received_tree(
+    invite_id: str,
+    invite_obj: object,
+    case_id: str,
+) -> py_trees.composites.Sequence:
+    """Received-side BT for ``Invite(Actor, Case)`` on the CaseActor inbox.
+
+    Commits the canonical ``CaseLedgerEntry`` for the invite when the
+    receiving actor holds ``CVDRole.CASE_MANAGER`` (CLP-10-006), then
+    stores the Invite activity idempotently (CLP-10-001).  The tree is
+    composed by :func:`create_receive_activity_tree` which enforces the
+    ``precondition_guards → GuardedCommitCaseLedgerEntryBT → effect_nodes``
+    ordering (CLP-10-006).
+
+    Args:
+        invite_id: ID of the ``Invite(Actor, Case)`` activity.
+        invite_obj: The wire activity object to persist idempotently.
+        case_id: ID of the VulnerabilityCase referenced by the invite.
+
+    Returns:
+        Root ``InviteActorToCaseReceivedBT`` Sequence node.
+    """
+    return create_receive_activity_tree(
+        name="InviteActorToCaseReceivedBT",
+        case_id=case_id if case_id else None,
+        precondition_guards=[],
+        effect_nodes=[
+            StoreActivityNode(
+                activity_id=invite_id,
+                activity_obj=invite_obj,
+                label="InviteActorToCase",
+            ),
+        ],
+    )

--- a/vultron/core/behaviors/case/nodes/actor.py
+++ b/vultron/core/behaviors/case/nodes/actor.py
@@ -43,16 +43,19 @@ class EmitInviteActorToCaseNode(DataLayerAction):
     """Create Invite(Actor, Case) and queue in the Case Actor's outbox.
 
     Uses ``trigger_activity_factory.invite_actor_to_case()`` with
-    ``actor=self.actor_id`` (expected to be the Case Actor URI) and
-    ``to=[invitee_id]``.  An optional ``attributed_to`` carries the
-    original requesting actor when the invite is sent from the Case
-    Actor identity (PCR-08-007).
+    ``actor=self.actor_id`` (expected to be the Case Actor URI),
+    ``to=[invitee_id]``, and ``cc=[case_actor_id]`` when ``case_actor_id``
+    is provided so ASGI self-delivery routes the Invite to the CaseActor's
+    own inbox for canonical ledger archival (CLP-10-001).  An optional
+    ``attributed_to`` carries the original requesting actor when the invite
+    is sent from the Case Actor identity (PCR-08-007).
     """
 
     def __init__(
         self,
         invitee_id: str,
         case_id: str,
+        case_actor_id: str | None = None,
         attributed_to: str | None = None,
         captured: dict | None = None,
         name: str | None = None,
@@ -60,6 +63,7 @@ class EmitInviteActorToCaseNode(DataLayerAction):
         super().__init__(name=name or self.__class__.__name__)
         self.invitee_id = invitee_id
         self.case_id = case_id
+        self.case_actor_id = case_actor_id
         self.attributed_to = attributed_to
         self._captured = captured
 
@@ -76,12 +80,17 @@ class EmitInviteActorToCaseNode(DataLayerAction):
             self.logger.error(self.feedback_message)
             return Status.FAILURE
 
+        # Add case_actor_id to cc: so ASGI self-delivery routes the Invite
+        # to the CaseActor's inbox for canonical ledger archival (CLP-10-001).
+        cc = [self.case_actor_id] if self.case_actor_id else None
+
         try:
             activity_id, activity_dict = factory.invite_actor_to_case(
                 invitee_id=self.invitee_id,
                 case_id=self.case_id,
                 actor=self.actor_id,
                 to=[self.invitee_id],
+                cc=cc,
                 attributed_to=self.attributed_to,
             )
             cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(

--- a/vultron/core/ports/trigger_activity.py
+++ b/vultron/core/ports/trigger_activity.py
@@ -260,6 +260,7 @@ class TriggerActivityPort(Protocol):
         case_id: str,
         actor: str,
         to: list[str] | None = None,
+        cc: list[str] | None = None,
         id_: str | None = None,
         attributed_to: str | None = None,
     ) -> tuple[str, dict[str, Any]]:
@@ -267,6 +268,7 @@ class TriggerActivityPort(Protocol):
 
         ``actor`` SHOULD be the Case Actor ID (PCR-08-007); ``attributed_to``
         MAY carry the case owner's ID for attribution.
+        ``cc`` MAY carry the Case Actor's own ID for self-archival (CLP-10-001).
         ``id_`` allows callers to supply a deterministic ID for idempotency.
         Returns ``(activity_id, activity_dict)``.
         """

--- a/vultron/core/use_cases/received/actor/invite.py
+++ b/vultron/core/use_cases/received/actor/invite.py
@@ -9,6 +9,9 @@ from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.case.accept_invite_tree import (
     create_accept_invite_actor_to_case_tree,
 )
+from vultron.core.behaviors.case.invite_actor_to_case_received_tree import (
+    create_invite_actor_to_case_received_tree,
+)
 from vultron.core.models.events.actor import (
     AcceptInviteActorToCaseReceivedEvent,
     InviteActorToCaseReceivedEvent,
@@ -31,31 +34,94 @@ logger = logging.getLogger(__name__)
 
 
 class InviteActorToCaseReceivedUseCase:
+    """Handle an incoming Invite(Actor, Case) activity.
+
+    Two delivery paths use this use case (CLP-10-001, ADR-0021):
+
+    1. **Invitee inbox** — ``receiving_actor_id`` is absent (``None``).
+       The invited actor stores the Invite idempotently and logs the case-stub
+       ID per MV-10-004.  No ledger commit occurs; that is reserved for the
+       CaseActor.
+
+    2. **CaseActor inbox** (self-delivered ``cc:`` copy) — ``receiving_actor_id``
+       is set by the inbox adapter to the CaseActor's URI.  The BT runs via
+       BTBridge; ``GuardedCommitCaseLedgerEntryBT`` inside
+       ``InviteActorToCaseReceivedBT`` commits the canonical
+       ``CaseLedgerEntry`` only when the receiving actor holds
+       ``CVDRole.CASE_MANAGER`` (CLP-10-006).  ``StoreActivityNode`` in the
+       BT's effect nodes handles idempotent storage for this path.
+
+    Note: when the trigger had no CaseActor record (``_find_case_actor_id``
+    returned ``None``), the outbound Invite is sent without a ``cc:`` field and
+    no self-delivery occurs.  No ledger entry is committed in that case — this
+    is by design; without a CaseActor there is no canonical ledger (ADR-0021).
+
+    The ``sync_port`` kwarg is injected when ``INVITE_ACTOR_TO_CASE`` is in
+    ``_SYNC_PORT_SEMANTICS`` so ``CommitCaseLedgerEntryNode`` can fan out
+    via ``sync_port`` (SYNC-02-002).
+    """
+
     def __init__(
-        self, dl: CasePersistence, request: InviteActorToCaseReceivedEvent
+        self,
+        dl: CaseOutboxPersistence,
+        request: InviteActorToCaseReceivedEvent,
+        sync_port: SyncActivityPort | None = None,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: InviteActorToCaseReceivedEvent = request
+        self._sync_port = sync_port
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> None:
         request = self._request
-        _idempotent_create(
-            self._dl,
-            request.activity_type,
-            request.activity_id,
-            request.activity,
-            "InviteActorToCase",
-            request.activity_id,
+        receiving_actor_id = request.receiving_actor_id
+
+        if receiving_actor_id is None:
+            # Invitee path: store idempotently and log the case-stub reference.
+            _idempotent_create(
+                self._dl,
+                request.activity_type,
+                request.activity_id,
+                request.activity,
+                "InviteActorToCase",
+                request.activity_id,
+            )
+            # MV-10-004: do NOT create a case from the stub target.  Full case
+            # details arrive later in an AnnounceVulnerabilityCase (MV-10-003).
+            case_stub_id = request.target_id
+            if case_stub_id:
+                logger.info(
+                    "InviteActorToCase: received invite with case stub '%s'."
+                    " Awaiting AnnounceVulnerabilityCase before creating case.",
+                    case_stub_id,
+                )
+            return
+
+        # CaseActor self-delivery path (CLP-10-001): the BT handles idempotent
+        # storage via StoreActivityNode and commits the canonical CaseLedgerEntry
+        # via GuardedCommitCaseLedgerEntryBT (CLP-10-006).
+        case_id = request.target_id or ""
+        tree = create_invite_actor_to_case_received_tree(
+            invite_id=request.activity_id,
+            invite_obj=request.activity,
+            case_id=case_id,
         )
-        # MV-10-004: do NOT create a case from the stub target.  The stub
-        # carries only {id, type} for identification; the full case details
-        # arrive later in an AnnounceVulnerabilityCase activity (MV-10-003).
-        case_stub_id = request.target_id
-        if case_stub_id:
-            logger.info(
-                "InviteActorToCase: received invite with case stub '%s'."
-                " Awaiting AnnounceVulnerabilityCase before creating case.",
-                case_stub_id,
+        result = BTBridge(
+            datalayer=self._dl,
+            trigger_activity=self._trigger_activity,
+        ).execute_with_setup(
+            tree=tree,
+            actor_id=receiving_actor_id,
+            activity=request,
+            sync_port=self._sync_port,
+        )
+        if result.status != Status.SUCCESS:
+            logger.debug(
+                "InviteActorToCaseReceivedUseCase: BT did not fully succeed"
+                " for invite '%s': %s",
+                request.activity_id,
+                BTBridge.get_failure_reason(tree) or result.feedback_message,
             )
 
 

--- a/vultron/core/use_cases/triggers/actor.py
+++ b/vultron/core/use_cases/triggers/actor.py
@@ -116,12 +116,18 @@ class SvcInviteActorToCaseUseCase(SvcBTTriggerBase):
 
         case_actor_id = _find_case_actor_id(self._dl, self._case.id_)
         self._actor_id = case_actor_id if case_actor_id else owner_id
+        # When case_actor_id is None (no dedicated CaseActor), the Invite is
+        # sent without cc: so no self-delivery occurs and no CaseLedgerEntry
+        # is committed — by design (ADR-0021: no CaseActor → no canonical
+        # ledger).
+        self._case_actor_id = case_actor_id
         self._attributed_to = owner_id if case_actor_id else None
 
     def _build_tree(self) -> py_trees.behaviour.Behaviour:
         return invite_actor_to_case_trigger_bt(
             invitee_id=self._invitee_id,
             case_id=self._case.id_,
+            case_actor_id=self._case_actor_id,
             attributed_to=self._attributed_to,
             captured=self._captured,
         )


### PR DESCRIPTION
- Closes #1293

## Summary

The `invite_actor_to_case_trigger_bt` never committed a `CaseLedgerEntry` because the CaseActor was never addressed in the outbound Invite's `to:`/`cc:` fields, so ASGI self-delivery never routed a copy to the CaseActor's inbox. This PR fixes all five acceptance criteria from the issue.

## Changes

- `vultron/core/behaviors/case/nodes/actor.py`: `EmitInviteActorToCaseNode` accepts `case_actor_id`; sets `cc=[case_actor_id]` on the outbound Invite (CLP-10-001).
- `vultron/core/ports/trigger_activity.py`: Add `cc: list[str] | None = None` to `TriggerActivityPort.invite_actor_to_case()` Protocol method.
- `vultron/adapters/driven/trigger_activity_adapter/actors.py`: Thread `cc` through to `rm_invite_to_case_activity()`.
- `vultron/core/behaviors/case/actor_trigger_trees.py`: `invite_actor_to_case_trigger_bt()` accepts and passes `case_actor_id`.
- `vultron/core/use_cases/triggers/actor.py`: `SvcInviteActorToCaseUseCase._prepare()` stores `_case_actor_id` and passes it to the BT factory.
- `vultron/core/behaviors/case/invite_actor_to_case_received_tree.py` (new): `create_invite_actor_to_case_received_tree()` factory using `create_receive_activity_tree` with `StoreActivityNode` effect (CLP-10-006).
- `vultron/core/use_cases/received/actor/invite.py`: `InviteActorToCaseReceivedUseCase` upgraded to use BTBridge on the CaseActor self-delivery path (`receiving_actor_id is not None`); invitee path continues to use `_idempotent_create` only.
- `vultron/adapters/driving/fastapi/inbox_port_factories.py`: Add `INVITE_ACTOR_TO_CASE` to `_SYNC_PORT_SEMANTICS` so `sync_port` is injected for `GuardedCommitCaseLedgerEntryBT` fan-out (SYNC-02-002).
- `vultron/adapters/driving/fastapi/outbox_delivery.py`: Suppress OX-08-004 warning when `cc == [actor]` (purposeful self-copy per CLP-10-001).
- `test/ci/test_case_ledger_invariants.py`: Add `invite_actor_to_case` to `EXPECTED_EVENT_TYPES`.

## Verification

- All 4377 unit tests pass (no new tests required; existing invite use-case tests cover the upgraded code paths)
- Black, flake8, pyright clean
- Pre-PR code review completed; two blocking findings addressed (docstring accuracy and ADR-0021 no-CaseActor design intent documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)