### PR TITLE
docs: plan issue #1286 — demo scenario report tool spec

### DIFF
--- a/plan/history/2607/idea/IDEA-1286.md
+++ b/plan/history/2607/idea/IDEA-1286.md
@@ -1,0 +1,47 @@
+---
+source: IDEA-1286
+timestamp: '2026-07-09T20:05:16.356132+00:00'
+title: CLI tool to parse demo scenario JSONL logs into readable reports
+type: idea
+---
+
+## Original Idea
+
+Add a CLI tool that parses JSONL log files produced by demo scenario runs and
+outputs a selective, human-readable report summarizing who did what to whom,
+with what activity, in what order.
+
+Demo scenario runs produce verbose JSONL case-ledger files (written per actor
+per case under `DEVLOGS_DIR`) that are hard to scan manually. A focused report
+showing the key protocol events in sequence would make it much easier to
+understand and validate scenario behavior. Converting logs to a markdown table
+or similar structured format — filtering to only the fields that matter — would
+aid both debugging and demonstration.
+
+References: `vultron/demo/scenario/two_actor_demo.py`
+(`_phase_dump_case_ledgers` writes
+`{DEVLOGS_DIR}/{demo_name}/{actor_name}/{case_id_slug}-case-ledger.jsonl`);
+`integration_tests/demo/colorize_compose_logs.py` (log post-processing
+precedent). Parent epic: #1083.
+
+## Processed
+
+**Processed**: 2026-07-09 — implementation tracked in #1307.
+
+Planning resolved the design via grill-me:
+
+- Standalone `vultron/demo/report.py` module (importable, own `__main__`).
+- First-class distilled `CaseTimelineEvent` Pydantic model consumed by both
+  renderers; input discovery by globbing `**/*-case-ledger.jsonl`; merge +
+  dedup by `entry_hash`; camelCase/snake_case tolerance.
+- Fields: actor / event type / target / timestamp, RM·EM·CS transitions,
+  per-actor replica-presence matrix, log_index + short entry_hash.
+- Friendly (non-URI) naming in summaries ("Finder submitted report").
+- Markdown table AND self-contained static HTML (auto-open, `--no-open`).
+  Client-side-JS rendering was considered and rejected (keep parsing in
+  Python, deterministic + testable).
+- No ADR (read-only utility over an existing artifact format); testable
+  requirements captured in `specs/demo-report.yaml` (DRPT-01 through DRPT-05).
+
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1306>.
+Spec: `specs/demo-report.yaml`.

--- a/specs/README.md
+++ b/specs/README.md
@@ -87,6 +87,7 @@ Load additional files only when the task touches the relevant area. See the
 | Embargo default semantics | `embargo-policy.yaml`, `notes/embargo-default-semantics.md` |
 | Configuration | `configuration.yaml` |
 | Demo / CLI | `demo-cli.yaml`, `multi-actor-demo.yaml` |
+| Demo scenario report tool | `demo-report.yaml` |
 | Event-driven control flow / cascade model | `event-driven-control-flow.yaml`, `notes/event-driven-control-flow.md` |
 | Observability | `observability.yaml` |
 | Security / CI | `ci-security.yaml`, `encryption.yaml` |
@@ -291,6 +292,11 @@ Specifications are organized by topic with minimal overlap. Cross-references lin
   workflow trigger and path-filter rules, Dependabot skip condition, Docker layer caching,
   log artifact on failure, extensibility pattern for future scenarios
   (DEMOCI-01 through DEMOCI-03)
+- **`demo-report.yaml`** - Read-only tool that parses demo-run JSONL case-ledger
+  files into a human-readable report: input discovery, the distilled
+  `CaseTimelineEvent` model, markdown and self-contained HTML rendering, the
+  per-actor replica-presence matrix, friendly (non-URI) naming, and test
+  requirements (DRPT-01 through DRPT-05)
 
 ### Actor Profiles and Policies
 
@@ -441,6 +447,7 @@ is reserved for `testability.yaml`).
 | `CS` | `code-style.yaml` |
 | `DC` | `demo-cli.yaml` |
 | `DEMOMA` | `multi-actor-demo.yaml` |
+| `DRPT` | `demo-report.yaml` |
 | `DF` | `diataxis-requirements.yaml` |
 | `DL` | `datalayer.md` |
 | `EH` | `error-handling.yaml` |

--- a/specs/demo-report.yaml
+++ b/specs/demo-report.yaml
@@ -1,0 +1,181 @@
+id: DRPT
+title: Demo Scenario Report Tool
+description: >-
+  Requirements for a read-only command-line tool that parses the JSONL
+  case-ledger replica files produced by demo scenario runs and renders a
+  selective, human-readable report — "who did what to whom, with what activity,
+  in what order." Covers input discovery, the distilled intermediate data model,
+  markdown and self-contained HTML rendering, the per-actor replica-presence
+  matrix, friendly (non-URI) naming, and test requirements. Sourced from
+  IDEA-1286. Related: `demo-cli.yaml` (DC), `multi-actor-demo.yaml` (DEMOMA),
+  `sync-ledger-replication.yaml` (SYNC), `case-ledger-processing.yaml` (CLP).
+version: 1.0.0
+kind: implementation
+scope:
+- prototype
+groups:
+- id: DRPT-01
+  title: Tool Structure and Invocation
+  specs:
+  - id: DRPT-01-001
+    priority: MUST
+    statement: >-
+      The report tool MUST be implemented as a standalone module at
+      `vultron/demo/report.py`, importable as `vultron.demo.report`, and MUST
+      provide an `if __name__ == "__main__"` entry point so it is directly
+      invokable (`python -m vultron.demo.report ...`).
+    rationale: >-
+      A standalone module keeps the read-only reporting utility decoupled from
+      the demo-run CLI (DC-01) while remaining colocated with the demo code that
+      produces the ledger files.
+  - id: DRPT-01-002
+    priority: MUST
+    statement: >-
+      The tool MUST accept a directory path (defaulting to the `DEVLOGS_DIR`
+      environment variable, or `devlogs/` relative to the repository root when
+      unset) and MUST discover input files by recursively globbing
+      `**/*-case-ledger.jsonl` beneath it.
+    rationale: >-
+      This mirrors the layout written by `two_actor_demo._phase_dump_case_ledgers`
+      (`{DEVLOGS_DIR}/{demo_name}/{actor_name}/{case_id_slug}-case-ledger.jsonl`)
+      and read by `test/ci/test_case_ledger_invariants.py`.
+  - id: DRPT-01-003
+    priority: MUST
+    statement: >-
+      The tool MUST derive each entry's actor name from the name of the
+      directory that contains its JSONL file (e.g. `finder`, `vendor`,
+      `case-actor`).
+  - id: DRPT-01-004
+    priority: MUST
+    statement: >-
+      The tool MUST exit with status code 0 on success and a non-zero status
+      code when the input directory is missing, contains no matching JSONL
+      files, or a file cannot be parsed.
+- id: DRPT-02
+  title: Distilled Timeline Model
+  specs:
+  - id: DRPT-02-001
+    priority: MUST
+    statement: >-
+      The tool MUST define a first-class `pydantic.BaseModel` (v2) distilled
+      event type (e.g. `CaseTimelineEvent`) that represents one canonical
+      timeline event in friendly-readable form. Both the markdown and HTML
+      renderers MUST consume this model rather than raw JSONL dicts.
+    rationale: >-
+      A typed intermediate model is the reusable, testable "friendly data" layer
+      described in IDEA-1286; it isolates JSONL parsing quirks from rendering.
+  - id: DRPT-02-002
+    priority: MUST
+    statement: >-
+      Each distilled event MUST surface, where available in the source entries:
+      the acting actor, the event type (or extracted message semantics), the
+      target object reference, the timestamp (`receivedAt`), the resulting
+      RM/EM/CS state transition(s) from the payload snapshot, the `log_index`,
+      and a short (truncated) `entry_hash` for chain traceability.
+  - id: DRPT-02-003
+    priority: MUST
+    statement: >-
+      The parser MUST tolerate both camelCase and snake_case field spellings in
+      source entries (e.g. `logIndex`/`log_index`, `entryHash`/`entry_hash`,
+      `payloadSnapshot`/`payload_snapshot`), consistent with the tolerance
+      already present in `test/ci/test_case_ledger_invariants.py`.
+  - id: DRPT-02-004
+    priority: MUST
+    statement: >-
+      The tool MUST merge entries from all discovered actors into a single
+      canonical timeline, de-duplicating replicated entries by `entry_hash`, and
+      MUST order the timeline by `log_index` ascending.
+    rationale: >-
+      Replicas hold copies of the same canonical entries; de-duplication yields
+      the single case story rather than N near-identical per-actor logs.
+  - id: DRPT-02-005
+    priority: MUST
+    statement: >-
+      For each canonical timeline event, the tool MUST compute a per-actor
+      replica-presence indicator recording which discovered actors' replicas
+      contain that entry (by `entry_hash`), so replica convergence and
+      divergence are visible at a glance.
+- id: DRPT-03
+  title: Friendly Naming
+  specs:
+  - id: DRPT-03-001
+    priority: MUST
+    statement: >-
+      Human-readable output MUST render actors and target objects by short,
+      friendly names (e.g. "Finder", "report", "note"), MUST NOT use bare URIs
+      or opaque UUID identifiers as the primary noun in event summaries, and
+      SHOULD derive actor labels from the actor directory name. Full identifiers
+      MAY be retained as secondary detail (e.g. a tooltip, title attribute, or
+      trailing reference column).
+    rationale: >-
+      Per IDEA-1286: prefer "Finder submitted report" over
+      "https://…/actors/finder submitted urn:uuid:…".
+  - id: DRPT-03-002
+    priority: SHOULD
+    statement: >-
+      Event summaries SHOULD map the event type / message semantics to a concise
+      active-voice phrase (subject verb object). Where a protocol vocabulary of
+      semantics already exists in the codebase, the mapping SHOULD reuse it to
+      stay in sync; otherwise a tool-local mapping table is acceptable with a
+      sensible fallback that renders the raw event type.
+- id: DRPT-04
+  title: Rendering
+  specs:
+  - id: DRPT-04-001
+    priority: MUST
+    statement: >-
+      The tool MUST render a markdown table report (one row per canonical
+      timeline event) covering the distilled fields, including a per-actor
+      replica-presence matrix column group.
+  - id: DRPT-04-002
+    priority: MUST
+    statement: >-
+      The tool MUST render a self-contained static HTML report file with all
+      styling inlined (no external CSS, JS, fonts, or network assets), so the
+      artifact renders identically offline and can be archived or shared as a
+      single file.
+    rationale: >-
+      Client-side-JS parsing was considered and rejected to keep parsing logic
+      in one place (Python), keep output deterministic and testable, and avoid a
+      JS toolchain.
+  - id: DRPT-04-003
+    priority: MUST
+    statement: >-
+      In the HTML report, the per-actor replica-presence matrix MUST be rendered
+      as a per-actor checkbox/emoji cell per event, showing a present/absent
+      indicator for each actor column (e.g. an event present in three of four
+      actors' replicas shows three checks across four columns).
+  - id: DRPT-04-004
+    priority: MUST
+    statement: >-
+      The output format MUST be selectable (e.g. `--format markdown|html`), and
+      the tool MUST write the report to a file (path configurable).
+  - id: DRPT-04-005
+    priority: SHOULD
+    statement: >-
+      After writing an HTML report, the tool SHOULD open it in the default
+      browser via `webbrowser.open()`, and MUST provide a flag (e.g.
+      `--no-open`) that suppresses the browser launch (required for
+      non-interactive and CI use).
+- id: DRPT-05
+  title: Testing
+  specs:
+  - id: DRPT-05-001
+    priority: MUST
+    statement: >-
+      Unit tests MUST cover JSONL-to-distilled-model parsing against fixtures
+      that include both camelCase and snake_case field spellings, and MUST
+      assert field extraction, merge/de-duplication by `entry_hash`, and the
+      per-actor replica-presence computation.
+  - id: DRPT-05-002
+    priority: MUST
+    statement: >-
+      Unit tests MUST cover both renderers: given a fixed list of distilled
+      events, assert the markdown table structure and assert that the HTML
+      output is well-formed and self-contained (references no external assets).
+  - id: DRPT-05-003
+    priority: MUST
+    statement: >-
+      A CLI smoke test MUST invoke the entry point against a tiny fixture
+      directory, assert exit code 0, assert an output file is written, and
+      assert that `--no-open` suppresses any browser launch.


### PR DESCRIPTION
- Closes #1286

## Summary

Plans IDEA-1286 (a CLI tool to parse demo scenario JSONL case-ledger logs
into readable reports) by capturing testable requirements as a new spec.
No ADR: this is a read-only reporting utility over an existing artifact
format, with no meaningfully-rejected architectural alternative.

## Changes

- Add `specs/demo-report.yaml` (prefix `DRPT`, groups DRPT-01–DRPT-05):
  - Standalone `vultron/demo/report.py` module with a `__main__` entry point
  - Input discovery: glob `**/*-case-ledger.jsonl` under `DEVLOGS_DIR`/`devlogs/`,
    actor name from parent directory
  - First-class distilled `CaseTimelineEvent` Pydantic model consumed by both
    renderers; camelCase/snake_case tolerance; merge + dedup by `entry_hash`
  - Fields: actor / event type / target / timestamp, RM·EM·CS transitions,
    per-actor replica-presence matrix, log_index + short entry_hash
  - Friendly (non-URI) naming in summaries ("Finder submitted report")
  - Markdown table + self-contained static HTML (auto-open, `--no-open` flag)
  - Unit tests (parse→model, both renderers) + CLI smoke test
- Register `DRPT` in `specs/README.md` (index and prefix tables)