### PR TITLE
docs: plan issue #1200 — FUZZ-08 production BT collapse designs

### DIFF
--- a/docs/adr/0027-exploit-strategy-bt-collapse.md
+++ b/docs/adr/0027-exploit-strategy-bt-collapse.md
@@ -1,0 +1,68 @@
+---
+status: proposed
+date: 2026-07-09
+deciders: [adh]
+---
+
+# Exploit-Strategy Subtree Collapse: Five Simulator Nodes → EvaluateExploitStrategy
+
+> **PROVISIONAL** — formed at planning time (issue #1200). Subject to revision
+> when the implementation issue for this collapse candidate is worked.
+> Implementation tracked by the issue blocked by #1200.
+
+## Context and Problem Statement
+
+The simulator BT for exploit acquisition (`AcquireExploit`) encodes a single
+policy-driven question — "should we acquire an exploit for this vulnerability?"
+— as a sequence of five granular nodes: `HaveExploit` (Retriever), `ExploitPrioritySet`
+(ProtocolInternal flag check), `EvaluateExploitPriority` (Evaluator), `ExploitDeferred`
+(ProtocolInternal), `ExploitDesired` (ProtocolInternal). In production this granularity
+is unnecessary: the BT needs a structured decision, not a flag-by-flag reconstruction
+of what would have been one deliberate evaluation.
+
+How should the five simulator nodes collapse in the production BT?
+
+## Decision Drivers
+
+- Minimize the number of external call-out point seams for what is conceptually
+  a single evaluation
+- Keep individual seams independently swappable (Retriever-feeds-Evaluator pattern)
+- Produce a typed, structured output that downstream BT nodes can read directly
+
+## Considered Options
+
+1. Single `EvaluateExploitStrategy` Evaluator (queries exploit repo internally)
+2. `HaveExploit` Retriever feeds `EvaluateExploitStrategy` Evaluator (two seams)
+3. Keep all five nodes (no collapse)
+
+## Decision Outcome
+
+Chosen option: **Option 2 (lean)** — `HaveExploit` Retriever feeds `EvaluateExploitStrategy`
+Evaluator. The provisional decision is to keep the exploit-repo query as a separate
+Retriever seam (independently swappable) while collapsing the three ProtocolInternal flag
+nodes into the Evaluator's output record.
+
+> **Note**: The choice between options 1 and 2 is **deferred** to the implementation issue.
+> The lean is Option 2 because it preserves independent swapability of the exploit-repo
+> query seam. The implementation issue should finalize this decision before coding.
+
+### Consequences
+
+- Good, because the three ProtocolInternal flag nodes (`ExploitPrioritySet`, `ExploitDeferred`,
+  `ExploitDesired`) disappear as separate BT leaves — they become internal decision reads on
+  the Evaluator's output record
+- Good, because `EvaluateExploitStrategy` has a clean typed output contract
+- Neutral, because retaining `HaveExploit` as a Retriever means two call-out points remain
+  instead of one; this is acceptable given the independent swapability benefit
+
+## More Information
+
+- Planning issue: #1200
+- Simulator nodes: `HaveExploit`, `ExploitPrioritySet`, `EvaluateExploitPriority`,
+  `ExploitDeferred`, `ExploitDesired` (see `notes/bt-fuzzer-nodes-report-management.md`
+  § "Exploit Acquisition" and "Production Collapse 1")
+- Implementation blocked by: #1200; also see issue #1249 (target factory function)
+- Provisional output schema: `ExploitStrategyDecision(have_exploit, acquire, rationale)`
+  as a Pydantic BaseModel (lean)
+
+Generated spec requirements: `behavior-tree-integration.yaml` BT-20-001 (provisional)

--- a/docs/adr/0028-publication-intent-bt-collapse.md
+++ b/docs/adr/0028-publication-intent-bt-collapse.md
@@ -1,0 +1,71 @@
+---
+status: proposed
+date: 2026-07-09
+deciders: [adh]
+---
+
+# Publication-Intent Subtree Collapse: Bypass Leaves → Intent-Record-Driven Arms
+
+> **PROVISIONAL** — formed at planning time (issue #1200). Subject to revision
+> when the implementation issue for this collapse candidate is worked.
+> Implementation tracked by the issue blocked by #1200.
+
+## Context and Problem Statement
+
+The simulator `Publication` BT encodes publication intent as a combination of
+a `PublicationIntentsSet` flag check, a `PrioritizePublicationIntents` Evaluator,
+and per-artifact bypass leaves (`NoPublishExploit`, `NoPublishFix`, `NoPublishReport`)
+that allow the BT to short-circuit each artifact arm. In production, these bypass
+leaves and the flag check are structural artifacts of the simulator representation
+and do not represent real call-out points.
+
+How should the publication-intent subtree be structured in production?
+
+## Decision Drivers
+
+- Eliminate structural artifacts (bypass leaves, flag checks) that add BT
+  complexity without adding real call-out point seams
+- Preserve `PrioritizePublicationIntents` as the primary Evaluator — it is already
+  the correct shape and should survive
+- Keep per-artifact arms independently executable (exploit, fix, report)
+
+## Considered Options
+
+1. Intent-record-driven arms — Evaluator output gates which arms execute;
+   bypass leaves disappear; three named arms (exploit, fix, report) remain
+2. Unified loop over artifact list — Evaluator returns an ordered list; BT
+   iterates it; no named arms
+3. Keep all simulator nodes (no collapse)
+
+## Decision Outcome
+
+Chosen option: **Option 1 (lean)** — intent-record-driven named arms.
+`PrioritizePublicationIntents` returns `{publish_exploit, publish_fix,
+publish_report}`; the BT uses these booleans to gate which of the three named
+arms execute. The `PublicationIntentsSet` flag check and `NoPublish*` bypass
+leaves disappear.
+
+> **Note**: The choice between options 1 and 2 is **deferred** to the
+> implementation issue. The lean is Option 1 because it preserves readable
+> BT structure with named arms.
+
+### Consequences
+
+- Good, because `NoPublish*` bypass leaves and `PublicationIntentsSet` flag check
+  are eliminated — they were ProtocolInternal no-ops masquerading as structural nodes
+- Good, because three named per-artifact arms are easier to understand and debug
+  than a generic loop
+- Neutral, because the intent record must be designed as a typed Pydantic BaseModel
+  to support the boolean-gate pattern
+
+## More Information
+
+- Planning issue: #1200
+- Simulator nodes: `PublicationIntentsSet`, `PrioritizePublicationIntents`,
+  `NoPublishExploit`, `NoPublishFix`, `NoPublishReport` and the Reprioritize*
+  nodes (see `notes/bt-fuzzer-nodes-report-management.md` § "Publication" and
+  "Production Collapse 2")
+- Implementation blocked by: #1200; also see issue #1251 (target factory function)
+- Per-artifact Publish leaf is handled separately in ADR-0029
+
+Generated spec requirements: `behavior-tree-integration.yaml` BT-20-002 (provisional)

--- a/docs/adr/0029-notification-loop-suggest-actor.md
+++ b/docs/adr/0029-notification-loop-suggest-actor.md
@@ -1,0 +1,81 @@
+---
+status: proposed
+date: 2026-07-09
+deciders: [adh]
+---
+
+# Notification Loop Collapse: InjectParticipant → suggest-actor-to-case Protocol
+
+> **PROVISIONAL** — formed at planning time (issue #1200). Subject to revision
+> when the implementation issue for this collapse candidate is worked.
+> Implementation tracked by the issue blocked by #1200 and #1298.
+
+## Context and Problem Statement
+
+The simulator `MaybeReportToOthers` BT models the notification loop with
+`InjectParticipant`/`InjectVendor`/`InjectCoordinator`/`InjectOther` nodes
+that write participant records directly to the case management system. In the
+production architecture, participant invitation is handled by the
+`suggest-actor-to-case` protocol (Offer → Invite → Accept → Record cascade).
+The `InjectParticipant` family bypasses this protocol entirely.
+
+How should the notification loop interact with the production invitation protocol?
+
+## Decision Drivers
+
+- The `InjectParticipant` family must not bypass the `suggest-actor-to-case`
+  invite/accept handshake that the production protocol requires
+- The outer loop structure ("should we notify additional parties?") represents
+  real CVD process logic and should survive
+- Party identification Retrievers and effort-gate Evaluators are valid call-out
+  points and should survive unchanged
+- Vendor/Coordinator/Other role distinction must be preserved when calling
+  `suggest-actor-to-case`
+
+## Considered Options
+
+1. Outer loop survives; `InjectParticipant` family replaced by `suggest-actor-to-case`
+   trigger with explicit role parameter
+2. Entire `MaybeReportToOthers` BT replaced by a standalone orchestrator that
+   calls `suggest-actor-to-case` externally
+3. Keep `InjectParticipant` family (no collapse; defer to later)
+
+## Decision Outcome
+
+Chosen option: **Option 1** — the outer loop structure survives. The
+`InjectParticipant`/`InjectVendor`/`InjectCoordinator`/`InjectOther` Actuator
+nodes are replaced by calls to the `suggest-actor-to-case` trigger (or
+equivalently, emitting `Offer(Actor)` to the CaseActor). The full
+`RecommendActor → Invite → Accept → Record` cascade follows automatically.
+
+### Key constraint
+
+`suggest-actor-to-case` currently assumes `CVDRole.VENDOR` for all suggested
+actors. The implementation issue for this collapse candidate **MUST** extend
+`suggest-actor-to-case` to accept an explicit `roles` parameter so that
+`CVDRole.COORDINATOR` and `CVDRole.OTHER` can be passed from the coordinator
+and other-parties sub-loops respectively.
+
+### Consequences
+
+- Good, because the `InjectParticipant` family no longer bypasses the protocol
+  handshake — participant records are now created only after proper invite/accept
+- Good, because party identification, effort gating, and typed sub-loops survive
+  unchanged — minimal structural change to the outer BT
+- Bad/risk, because `suggest-actor-to-case` must be generalized for role;
+  this is a concrete pre-condition for the implementation issue (see #1298)
+
+## More Information
+
+- Planning issue: #1200
+- Simulator nodes: full `MaybeReportToOthers` subtree (see
+  `notes/bt-fuzzer-nodes-report-management.md` § "Reporting to Other Parties"
+  and "Production Collapse 3")
+- Blocked by: #1200 (this planning issue) and #1298 (suggest_actor_tree
+  redesign — CaseActor-routed suggestion, role parameter)
+- Related: ADR-0026 (CaseActor-routed actor suggestion), #1252 (target
+  factory function)
+- Note: `SetRcptQrmR` RM-state write is handled by the `AcceptInviteToCase`
+  cascade; no standalone Actuator is needed at the outer loop layer
+
+Generated spec requirements: `behavior-tree-integration.yaml` BT-20-003 (provisional)

--- a/docs/adr/0030-publish-leaf-draft-review-submit-pipeline.md
+++ b/docs/adr/0030-publish-leaf-draft-review-submit-pipeline.md
@@ -1,0 +1,79 @@
+---
+status: proposed
+date: 2026-07-09
+deciders: [adh]
+---
+
+# Publish Leaf Expansion: Single Actuator → Draft-Review-Submit Pipeline
+
+> **PROVISIONAL** — formed at planning time (issue #1200). Subject to revision
+> when the implementation issue for this collapse candidate is worked.
+> Implementation tracked by the issue blocked by #1200 and the implementation
+> issue for ADR-0028 (publication intents).
+
+## Context and Problem Statement
+
+The simulator `Publish` node is a single Actuator leaf that stands in for the
+entire advisory publication workflow. In production, publishing a vulnerability
+advisory involves at minimum: drafting the artifact, reviewing/approving it,
+and submitting it to the external advisory platform. These are distinct operations
+with distinct external seams that should be separately swappable.
+
+How should the single `Publish` simulator leaf expand in the production BT?
+
+## Decision Drivers
+
+- Draft, review, and submit are distinct operations with distinct call-out point
+  shapes (Composer, Evaluator, Actuator)
+- The Actuator shape for external platform submission is confirmed by ADR-0024
+  (Actuator amendment, 2026-07-07)
+- The review phase may involve a broadcast-for-participant-comment step — this is
+  an open design question
+- The pipeline is invoked per-artifact (once each for exploit, fix, and report
+  artifacts as decided by `PrioritizePublicationIntents`)
+
+## Considered Options
+
+1. Three-step pipeline: Composer → Evaluator → Actuator
+2. Four-step pipeline: Composer → Evaluator → optional Composer (revision) → Actuator
+3. Extended pipeline with participant-comment broadcast: Composer → Evaluator
+   (parallel with broadcast-for-comment) → optional Composer → Actuator
+4. Keep single `Publish` Actuator (defer expansion)
+
+## Decision Outcome
+
+Chosen option: **Option 2 (lean)** — four-step pipeline with an optional revision
+Composer. The core shape is Composer (draft) → Evaluator (review/approve) →
+optional Composer (revise based on feedback) → Actuator (submit to advisory
+platform).
+
+> **Note**: Whether the review phase should include a broadcast-for-participant-comment
+> step (Option 3) is an **open design question** deferred to the implementation issue.
+> The broadcast step would involve emitting an outbound Activity (a protocol-visible
+> action that may trigger an `Accept/Reject` response pattern). The implementation
+> issue MUST design the review-phase protocol before wiring the BT.
+
+### Consequences
+
+- Good, because draft and submit become independently swappable call-out points
+- Good, because the Evaluator review step has a default implementation (auto-approve)
+  that allows the pipeline to function before a real review agent is available
+- Neutral, because the optional revision Composer adds complexity; implementations
+  may start with the three-step variant and add revision later
+- Uncertain, because the participant-comment broadcast question may expand scope
+  significantly — this must be resolved at implementation time
+
+## More Information
+
+- Planning issue: #1200
+- Simulator node: `Publish` (see `notes/bt-fuzzer-nodes-report-management.md`
+  § "Publication" and "Production Collapse 4")
+- Blocked by: #1200 (this planning issue) and the implementation issue for
+  ADR-0028 (publication intents — the intent record must be in place before the
+  pipeline is wired)
+- Related: ADR-0024 (Actuator shape), ADR-0028 (publication-intent arm structure),
+  issue #1251 (publication tree factory function)
+- Each per-artifact arm in `create_publication_tree` (exploit arm, fix arm, report arm)
+  uses this pipeline for its Publish step
+
+Generated spec requirements: `behavior-tree-integration.yaml` BT-20-004 (provisional)

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -90,6 +90,15 @@ General information about architectural decision records is available at <https:
   `process_payload` Seam](0020-inbox-bt-orchestration.md)
 - [ADR-0026 CaseActor-Routed Actor Suggestion and Invitation
   Flow](0026-caseactor-routed-actor-suggestion.md)
+- [ADR-0027 Exploit-Strategy Subtree Collapse: Five Simulator Nodes →
+  EvaluateExploitStrategy](0027-exploit-strategy-bt-collapse.md) *(provisional)*
+- [ADR-0028 Publication-Intent Subtree Collapse: Bypass Leaves →
+  Intent-Record-Driven Arms](0028-publication-intent-bt-collapse.md) *(provisional)*
+- [ADR-0029 Notification Loop Collapse: InjectParticipant →
+  suggest-actor-to-case Protocol](0029-notification-loop-suggest-actor.md) *(provisional)*
+- [ADR-0030 Publish Leaf Expansion: Single Actuator →
+  Draft-Review-Submit Pipeline](0030-publish-leaf-draft-review-submit-pipeline.md)
+  *(provisional)*
 
 ## Rejected ADRs
 

--- a/notes/bt-fuzzer-nodes-report-management.md
+++ b/notes/bt-fuzzer-nodes-report-management.md
@@ -5,12 +5,14 @@ description: >
   Catalog of fuzzer (stub) BT nodes for Report Management workflows in
   the Vultron BT simulation, covering validation, prioritization, ID assignment,
   fix development and deployment, exploit/threat tracking, publication,
-  reporting to other parties, and report closure.
+  reporting to other parties, and report closure. Includes provisional
+  production-collapse designs for four simulator subtree groups (issue #1200).
 related_specs:
   - specs/behavior-tree-integration.yaml
 related_notes:
   - notes/bt-integration.md
   - notes/bt-fuzzer-nodes.md
+  - notes/coordination-agents.md
 relevant_packages:
   - vultron/bt/report_management
 ---
@@ -749,7 +751,7 @@ vulnerability, typically to support impact assessment or testing.
   `vultron.core.behaviors.report.create_acquire_exploit_strategy_tree`
   (issue #1249) — early-exit Retriever guard at the top of
   `AcquireExploit` Selector; may collapse into `EvaluateExploitStrategy`
-  input context per production redesign (#1200)
+  input context per production redesign (see Production Collapse 1 below)
 
 ### `ExploitPrioritySet`
 
@@ -772,7 +774,8 @@ vulnerability, typically to support impact assessment or testing.
 - **Factory-fn placement**: FUTURE:
   `vultron.core.behaviors.report.create_acquire_exploit_strategy_tree`
   (issue #1249) — ProtocolInternal condition check after `HaveExploit`;
-  collapses the loop if the priority decision is already on record for this cycle
+  collapses the loop if the priority decision is already on record for this cycle.
+  See Production Collapse 1 below.
 
 ### `EvaluateExploitPriority`
 
@@ -793,7 +796,8 @@ vulnerability, typically to support impact assessment or testing.
   `vultron.core.behaviors.report.create_acquire_exploit_strategy_tree`
   (issue #1249) — Evaluator action node in the priority-decision Sequence;
   writes the `exploit_priority` decision to the blackboard for downstream
-  ProtocolInternal condition nodes (`ExploitDeferred`, `ExploitDesired`)
+  ProtocolInternal condition nodes (`ExploitDeferred`, `ExploitDesired`).
+  See Production Collapse 1 below — this is the core Evaluator that survives.
 
 ### `ExploitDeferred`
 
@@ -816,7 +820,8 @@ vulnerability, typically to support impact assessment or testing.
 - **Factory-fn placement**: FUTURE:
   `vultron.core.behaviors.report.create_acquire_exploit_strategy_tree`
   (issue #1249) — ProtocolInternal condition check after `EvaluateExploitPriority`;
-  early-exits the acquire-exploit Selector when deferral is recorded
+  early-exits the acquire-exploit Selector when deferral is recorded.
+  See Production Collapse 1 below.
 
 ### `ExploitDesired`
 
@@ -838,7 +843,8 @@ vulnerability, typically to support impact assessment or testing.
 - **Factory-fn placement**: FUTURE:
   `vultron.core.behaviors.report.create_acquire_exploit_strategy_tree`
   (issue #1249) — ProtocolInternal condition check before the acquisition
-  Fallback (`FindExploit → DevelopExploit → PurchaseExploit`)
+  Fallback (`FindExploit → DevelopExploit → PurchaseExploit`).
+  See Production Collapse 1 below.
 
 ### `FindExploit`
 
@@ -1053,7 +1059,8 @@ preparing them, and executing publication.
 - **Factory-fn placement**: FUTURE:
   `vultron.core.behaviors.report.create_publication_tree`
   (issue #1251) — ProtocolInternal condition check before `PrioritizePublicationIntents`;
-  skips intent-setting if a publication plan is already on record
+  skips intent-setting if a publication plan is already on record.
+  See Production Collapse 2 below — this flag check disappears in production.
 
 ### `PrioritizePublicationIntents`
 
@@ -1076,7 +1083,8 @@ preparing them, and executing publication.
   `vultron.core.behaviors.report.create_publication_tree`
   (issue #1251) — Evaluator action node that runs when
   `PublicationIntentsSet` fails; writes the publication plan (artifacts,
-  priority order, timing) to case metadata
+  priority order, timing) to case metadata.
+  See Production Collapse 2 below — this is the core Evaluator that survives.
 
 ### `Publish`
 
@@ -1097,7 +1105,9 @@ preparing them, and executing publication.
   `vultron.core.behaviors.report.create_publication_tree`
   (issue #1251) — terminal Actuator action node at the end of each
   per-artifact Sequence (`ExploitReady → Publish`, `PrepareFix → Publish`,
-  `PrepareReport → Publish`)
+  `PrepareReport → Publish`).
+  See Production Collapse 4 below — this single leaf expands into a
+  draft-review-submit pipeline in production.
 
 ### `NoPublishExploit`
 
@@ -1698,8 +1708,8 @@ coordinated disclosure.
 - **Factory-fn placement**: FUTURE:
   `vultron.core.behaviors.report.create_report_to_others_tree`
   (issue #1252) — base Actuator node; production replacement is the
-  InviteParticipantToCase protocol subtree (#1199); the call-out point
-  seam lives here at the case-management write boundary
+  `suggest-actor-to-case` trigger (see Production Collapse 3 below);
+  the call-out point seam lives here at the case-management write boundary
 
 ### `InjectVendor`
 
@@ -1719,8 +1729,8 @@ coordinated disclosure.
 - **Factory-fn placement**: FUTURE:
   `vultron.core.behaviors.report.create_report_to_others_tree`
   (issue #1252) — Actuator node in the vendor sub-loop, after `MoreVendors`
-  succeeds and the notification Sequence completes; invokes vendor-role
-  InviteParticipantToCase protocol subtree (#1199) once ready
+  succeeds and the notification Sequence completes; replaced by
+  `suggest-actor-to-case` with `CVDRole.VENDOR` (see Production Collapse 3)
 
 ### `InjectCoordinator`
 
@@ -1741,7 +1751,8 @@ coordinated disclosure.
   `vultron.core.behaviors.report.create_report_to_others_tree`
   (issue #1252) — Actuator node in the coordinator sub-loop, after
   `MoreCoordinators` succeeds and the notification Sequence completes;
-  invokes coordinator-role InviteParticipantToCase protocol subtree (#1199)
+  replaced by `suggest-actor-to-case` with `CVDRole.COORDINATOR`
+  (see Production Collapse 3)
 
 ### `InjectOther`
 
@@ -1761,8 +1772,9 @@ coordinated disclosure.
 - **Factory-fn placement**: FUTURE:
   `vultron.core.behaviors.report.create_report_to_others_tree`
   (issue #1252) — Actuator node in the other-parties sub-loop, after
-  `MoreOthers` succeeds and the notification Sequence completes; invokes
-  other-party-role InviteParticipantToCase protocol subtree (#1199)
+  `MoreOthers` succeeds and the notification Sequence completes;
+  replaced by `suggest-actor-to-case` with `CVDRole.OTHER`
+  (see Production Collapse 3)
 
 ---
 
@@ -1848,5 +1860,226 @@ accepted vulnerability report outside of the more specific sub-trees.
   (issue #1255) — primary Evaluator leaf of `RMDoWorkBt`; the main
   extensibility seam for organization-specific in-flight case work
   not covered by more specific sub-trees
+
+---
+
+## Production Collapse Designs
+
+The sections below document how groups of simulator fuzzer nodes are expected
+to **collapse** in the production BT architecture. Each group of simulator
+leaves maps to a smaller set of production call-out points. These designs are
+**provisional** — they represent the best understanding at planning time
+(issue #1200) and are subject to revision when the corresponding
+implementation issues are worked.
+
+Cross-references: each affected simulator-node entry above has a
+"see Production Collapse" note pointing here. The implementation issues listed
+in each section are what to work when it is time to build the production
+subtrees.
+
+---
+
+### Production Collapse 1: Exploit-strategy subtree → EvaluateExploitStrategy
+
+**Simulator nodes involved**: `HaveExploit`, `ExploitPrioritySet`,
+`EvaluateExploitPriority`, `ExploitDeferred`, `ExploitDesired`
+(see Exploit Acquisition section above)
+
+**Tracked by**: implementation issue for collapse candidate 1 (blocked by #1200)
+
+#### Production shape
+
+A single **Evaluator** call-out point — `EvaluateExploitStrategy` — replaces
+the five-node simulator sequence. The Evaluator receives case context
+(vulnerability state, org policy, threat landscape, and optionally the result
+of a prior `HaveExploit` Retriever query) and returns a structured decision
+record.
+
+The five simulator nodes collapse to:
+
+1. One Evaluator call-out point: `EvaluateExploitStrategy`
+2. ProtocolInternal BT condition checks reading its structured output (no
+   external seam — these are internal decision reads, not new call-out points)
+
+**Open design question**: Does `HaveExploit` survive as a separate Retriever
+node that feeds context into the Evaluator (lean: yes), or does the Evaluator
+query the exploit repo internally as part of its evaluation? Both approaches
+are valid; the Retriever-feeds-Evaluator pattern is preferred because it keeps
+the exploit-repo query seam independently swappable.
+
+**Provisional output schema** (subject to revision — lean: Pydantic BaseModel):
+
+```python
+class ExploitStrategyDecision(BaseModel):
+    have_exploit: bool       # whether a working exploit is already available
+    acquire: bool            # decision: pursue exploit acquisition
+    rationale: str           # reasoning for the decision
+```
+
+**Target factory function**:
+`vultron.core.behaviors.report.create_acquire_exploit_strategy_tree`
+
+**Spec requirements**: BT-20-001 (provisional — see
+`specs/behavior-tree-integration.yaml`)
+
+---
+
+### Production Collapse 2: Publication-intent subtree → Evaluator + per-artifact arms
+
+**Simulator nodes involved**: `PublicationIntentsSet`, `PrioritizePublicationIntents`,
+`NoPublishExploit`, `ExploitReady`, `PrepareExploit`, `ReprioritizeExploit`,
+`NoPublishFix`, `PrepareFix`, `ReprioritizeFix`, `NoPublishReport`,
+`PrepareReport`, `ReprioritizeReport`
+(see Publication section above)
+
+**Tracked by**: implementation issue for collapse candidate 2 (blocked by #1200)
+
+#### Production shape
+
+The `PublicationIntentsSet` flag check and `NoPublish*` bypass leaves are
+**ProtocolInternal structural artifacts** of the simulator representation —
+they do not survive as call-out points. In production:
+
+1. **`PrioritizePublicationIntents`** (already an Evaluator) returns a
+   structured intent record: `{publish_exploit: bool, publish_fix: bool,
+   publish_report: bool}`. The `PublicationIntentsSet` flag check disappears —
+   the BT queries the intent record directly.
+
+2. For each intended artifact: one **Composer** subtree
+   (`PrepareExploit` / `PrepareFix` / `PrepareReport`) drafts and stages the
+   artifact.
+
+3. For each prepared artifact: one **Actuator** (`Publish`) submits to the
+   external advisory platform.
+
+The `NoPublish*` bypass leaves and `ReprioritizeX` Evaluators become
+ProtocolInternal no-ops or disappear — the intent record from step 1 drives
+which arms execute.
+
+**BT structure** (lean: three named arms — exploit arm, fix arm, report arm —
+rather than a unified loop; subject to revision at implementation time):
+
+```text
+PublicationBT (Sequence)
+├── PrioritizePublicationIntents (Evaluator)       — sets intent record
+├── ExploitPublicationArm (Selector, if intended)  — PrepareExploit → Publish
+├── FixPublicationArm (Selector, if intended)      — PrepareFix → Publish
+└── ReportPublicationArm (Selector, if intended)   — PrepareReport → Publish
+```
+
+**Target factory function**:
+`vultron.core.behaviors.report.create_publication_tree` (issue #1251)
+
+**Spec requirements**: BT-20-002 (provisional — see
+`specs/behavior-tree-integration.yaml`)
+
+---
+
+### Production Collapse 3: Notification loop → InviteParticipantToCase protocol
+
+**Simulator nodes involved**: `HaveReportToOthersCapability`, `AllPartiesKnown`,
+`IdentifyVendors`, `IdentifyCoordinators`, `IdentifyOthers`,
+`NotificationsComplete`, `ChooseRecipient`, `RemoveRecipient`,
+`RecipientEffortExceeded`, `TotalEffortLimitMet`, `PolicyCompatible`,
+`FindContact`, `RcptNotInQrmS`, `SetRcptQrmR`, `MoreVendors`,
+`MoreCoordinators`, `MoreOthers`, `InjectParticipant`, `InjectVendor`,
+`InjectCoordinator`, `InjectOther`
+(see Reporting to Other Parties section above)
+
+**Tracked by**: implementation issue for collapse candidate 3 (blocked by #1200 and #1298 suggest-actor redesign)
+
+#### Production shape
+
+The **outer loop structure survives** — `MaybeReportToOthers` remains a BT
+subtree that asks "should we notify additional parties?" and iterates through
+identified parties. What changes is **what happens at the end of each
+iteration**: instead of `InjectParticipant` (a direct case-management write),
+the BT calls the `suggest-actor-to-case` trigger, which initiates the full
+`RecommendActor → Invite → Accept → Record` cascade automatically.
+
+**Nodes that survive** (as call-out points or ProtocolInternal guards):
+
+- `HaveReportToOthersCapability` — TBD shape; likely resolves to a
+  `CVDRole.CASE_MANAGER` membership check (ProtocolInternal) once the
+  invite-participant-to-case protocol is finalized
+- `AllPartiesKnown` — Evaluator (unchanged)
+- `IdentifyVendors`, `IdentifyCoordinators`, `IdentifyOthers` — Retrievers
+  (unchanged)
+- `NotificationsComplete` — ProtocolInternal (unchanged)
+- `ChooseRecipient`, `FindContact` — Retrievers (unchanged; feed context into
+  the suggest-actor call)
+- `RecipientEffortExceeded`, `TotalEffortLimitMet` — Evaluators (unchanged)
+- `PolicyCompatible` — Evaluator (unchanged)
+- `RcptNotInQrmS` — ProtocolInternal idempotency check (unchanged)
+- `MoreVendors`, `MoreCoordinators`, `MoreOthers` — ProtocolInternal
+  iteration guards (unchanged; three typed sub-loops survive)
+
+**Nodes that collapse**:
+
+- `SetRcptQrmR` — the RM-state write is now handled by the `AcceptInviteToCase`
+  cascade; no standalone Actuator needed at this layer
+- `InjectParticipant`, `InjectVendor`, `InjectCoordinator`, `InjectOther` —
+  replaced by a call to the `suggest-actor-to-case` trigger endpoint (or
+  equivalently, emitting an `Offer(Actor)` to the CaseActor). The full
+  `RecommendActor → Invite → Accept → Record` cascade follows automatically.
+
+**Key design note**: `suggest-actor-to-case` currently assumes
+`CVDRole.VENDOR` for the invited party. Collapse candidate 3 implementation
+**MUST** extend `suggest-actor-to-case` to accept an explicit role parameter
+(VENDOR / COORDINATOR / OTHER), since the three typed sub-loops each map to
+a different CVD role.
+
+**Target factory function**:
+`vultron.core.behaviors.report.create_report_to_others_tree` (issue #1252)
+
+**Spec requirements**: BT-20-003 (provisional — see
+`specs/behavior-tree-integration.yaml`)
+
+---
+
+### Production Collapse 4: Publish leaf → draft-review-submit pipeline
+
+**Simulator nodes involved**: `Publish`
+(see Publication section above; also see Production Collapse 2 for the
+per-artifact preparation context)
+
+**Tracked by**: implementation issue for collapse candidate 4 (blocked by #1200 and collapse candidate 2 impl issue)
+
+#### Production shape
+
+The single `Publish` simulator leaf expands into a **multi-step pipeline**
+with its own call-out points. This acknowledges that advisory publication in
+production involves drafting, review/approval, and submission — not a single
+atomic action.
+
+**Core pipeline** (lean: Composer → Evaluator → Actuator):
+
+```text
+PublishArtifactBT (Sequence)
+├── DraftAdvisoryArtifact (Composer)    — draft CSAF/CVE JSON/advisory from case data
+├── ReviewAdvisoryDraft (Evaluator)     — review/approve the draft (human or automated QA)
+├── [optional] ReviseAdvisoryDraft (Composer) — revise based on review feedback
+└── SubmitAdvisoryArtifact (Actuator)   — submit finalized artifact to advisory platform
+```
+
+**Open design question**: Should the review phase include a
+"broadcast draft to case participants for comment" step before the Evaluator
+runs? This would involve emitting an outbound Activity (a protocol-visible
+action) and optionally waiting for participant responses — resembling the
+`Accept/Reject` question pattern used elsewhere in the protocol. This is
+captured here as an open question; the implementation issue should design
+the review-phase protocol before wiring the BT.
+
+**Impact on existing `Publish` Actuator nodes**: Each per-artifact arm in
+Production Collapse 2 (`ExploitReady → Publish`, `PrepareFix → Publish`,
+`PrepareReport → Publish`) has its own `Publish` Actuator. In production,
+those Actuators are each replaced by this full `PublishArtifactBT` subtree.
+
+**Target factory function**:
+`vultron.core.behaviors.report.create_publish_artifact_tree` (new; called
+from within `create_publication_tree`)
+
+**Spec requirements**: BT-20-004 (provisional — see
+`specs/behavior-tree-integration.yaml`)
 
 ---

--- a/plan/history/2607/idea/IDEA-1200.md
+++ b/plan/history/2607/idea/IDEA-1200.md
@@ -1,0 +1,18 @@
+---
+source: IDEA-1200
+timestamp: '2026-07-09T20:56:19.383142+00:00'
+title: 'FUZZ-08: Production BT redesign — catalog subtrees that collapse in production
+  design'
+type: idea
+---
+
+## Summary
+
+Catalog of BT fuzzer simulator subtrees that will look substantially different in the production design. Four collapse candidates identified:
+
+1. Five exploit-strategy nodes (`HaveExploit`, `ExploitPrioritySet`, `EvaluateExploitPriority`, `ExploitDeferred`, `ExploitDesired`) → `HaveExploit` Retriever + `EvaluateExploitStrategy` Evaluator
+2. Publication-intent simulator nodes with bypass leaves → `PrioritizePublicationIntents` Evaluator driving three named per-artifact arms; bypass leaves and flag check disappear
+3. Full notification loop with `InjectParticipant` family → outer loop survives; `InjectParticipant` family replaced by `suggest-actor-to-case` trigger with explicit role parameter
+4. Single `Publish` Actuator leaf → Composer → Evaluator → optional Composer → Actuator draft-review-submit pipeline
+
+**Processed**: 2026-07-09 — implementation tracked in #1309, #1310, #1311, #1312. Docs PR: <https://github.com/CERTCC/Vultron/pull/1308>. Spec: `specs/behavior-tree-integration.yaml` BT-20. Notes: `notes/bt-fuzzer-nodes-report-management.md`.

--- a/specs/behavior-tree-integration.yaml
+++ b/specs/behavior-tree-integration.yaml
@@ -748,3 +748,96 @@ groups:
       use the same BT factory function and that no standalone monolithic node
       class exists that inlines both state mutation and dispatch in a single
       `update()` method for the same operation.
+
+- id: BT-20
+  title: Production BT Collapse Patterns
+  kind: pattern
+  description: >-
+    PROVISIONAL (subject to revision at implementation time — see issue #1200
+    and per-requirement tracking issues). Requirements for production BT subtrees
+    that replace groups of simulator fuzzer nodes. Each collapse candidate
+    reduces multiple granular simulator leaves to a smaller set of production
+    call-out points with cleaner seam structure.
+  specs:
+  - id: BT-20-001
+    priority: SHOULD
+    statement: >-
+      The production `create_acquire_exploit_strategy_tree` factory SHOULD
+      provide a single `EvaluateExploitStrategy` Evaluator call-out point in
+      place of the five simulator nodes (`HaveExploit`, `ExploitPrioritySet`,
+      `EvaluateExploitPriority`, `ExploitDeferred`, `ExploitDesired`). The
+      Evaluator SHOULD receive case context (vulnerability state, org policy,
+      threat landscape) and return a structured decision record containing at
+      minimum the acquire decision and rationale. Whether a separate
+      `HaveExploit` Retriever feeds into the Evaluator's context is an open
+      design question (lean: yes — keep as a separate seam for independent
+      swapability).
+    rationale: >-
+      PROVISIONAL. The five-node simulator sequence encodes a single
+      policy-driven decision ("should we acquire an exploit?") in granular
+      boolean flags that are unnecessary in production. Collapsing to one
+      Evaluator reduces the number of external seams and makes the decision
+      boundary explicit. See `notes/bt-fuzzer-nodes-report-management.md`
+      § "Production Collapse 1: Exploit-strategy subtree" and ADR-0026.
+    tracking_issue: "#1200 (planning); implementation issue TBD (blocked by #1200)"
+  - id: BT-20-002
+    priority: SHOULD
+    statement: >-
+      The production `create_publication_tree` factory SHOULD use
+      `PrioritizePublicationIntents` (Evaluator) output to gate per-artifact
+      arms directly, without separate `NoPublish*` bypass leaves or a
+      `PublicationIntentsSet` flag check. The intent record SHOULD drive which
+      of three named arms (exploit, fix, report) execute. Each arm SHOULD
+      consist of a Composer (prepare artifact) followed by a Publish pipeline
+      (see BT-20-004).
+    rationale: >-
+      PROVISIONAL. The `NoPublish*` bypass leaves and `PublicationIntentsSet`
+      flag check are structural artifacts of the simulator BT representation;
+      they do not represent real call-out points. In production the
+      `PrioritizePublicationIntents` Evaluator output drives arm execution
+      directly. See `notes/bt-fuzzer-nodes-report-management.md`
+      § "Production Collapse 2: Publication-intent subtree" and ADR-0027.
+    tracking_issue: "#1200 (planning); implementation issue TBD (blocked by #1200)"
+  - id: BT-20-003
+    priority: SHOULD
+    statement: >-
+      The production `create_report_to_others_tree` factory SHOULD retain the
+      outer loop structure (party identification Retrievers, effort-gate
+      Evaluators, typed vendor/coordinator/other sub-loops), and SHOULD invoke
+      the `suggest-actor-to-case` trigger in place of `InjectParticipant`
+      family nodes. The `suggest-actor-to-case` trigger MUST be called with
+      an explicit role parameter (`CVDRole.VENDOR`, `CVDRole.COORDINATOR`, or
+      `CVDRole.OTHER`) matching the sub-loop type; the current assumption that
+      all suggestions use `CVDRole.VENDOR` MUST be generalized.
+    rationale: >-
+      PROVISIONAL. The `InjectParticipant` family is a direct case-management
+      write that bypasses the protocol's invite/accept handshake. In production
+      the `suggest-actor-to-case` protocol (Offer → Invite → Accept → Record
+      cascade) replaces it. The outer loop remains because the BT must still
+      ask "should we notify additional parties?" and iterate through identified
+      candidates. See `notes/bt-fuzzer-nodes-report-management.md`
+      § "Production Collapse 3: Notification loop" and ADR-0028.
+    tracking_issue: >-
+      #1200 (planning); implementation issue TBD (blocked by #1200 and #1298
+      suggest-actor redesign)
+  - id: BT-20-004
+    priority: SHOULD
+    statement: >-
+      The production `create_publish_artifact_tree` factory SHOULD implement
+      a multi-step pipeline replacing the single `Publish` Actuator leaf: at
+      minimum (1) a Composer node drafts the advisory artifact from case data,
+      (2) an Evaluator node reviews and approves the draft, and (3) an Actuator
+      node submits the finalized artifact to the external advisory platform.
+      An optional revision Composer MAY be included between the Evaluator and
+      Actuator. Whether the review phase includes a broadcast-for-participant-comment
+      step is an open design question to be resolved at implementation time.
+    rationale: >-
+      PROVISIONAL. The single `Publish` simulator leaf stands in for a full
+      advisory publication workflow. In production, drafting, review, and
+      submission are distinct operations with separate external seams. The
+      Actuator shape for submission is confirmed by ADR-0024 (Actuator
+      amendment, 2026-07-07). See `notes/bt-fuzzer-nodes-report-management.md`
+      § "Production Collapse 4: Publish leaf" and ADR-0029.
+    tracking_issue: >-
+      #1200 (planning); implementation issue TBD (blocked by #1200 and
+      implementation issue for BT-20-002)

--- a/specs/behavior-tree-integration.yaml
+++ b/specs/behavior-tree-integration.yaml
@@ -778,7 +778,7 @@ groups:
       boolean flags that are unnecessary in production. Collapsing to one
       Evaluator reduces the number of external seams and makes the decision
       boundary explicit. See `notes/bt-fuzzer-nodes-report-management.md`
-      § "Production Collapse 1: Exploit-strategy subtree" and ADR-0026.
+      § "Production Collapse 1: Exploit-strategy subtree" and ADR-0027.
     tracking_issue: "#1200 (planning); implementation issue TBD (blocked by #1200)"
   - id: BT-20-002
     priority: SHOULD
@@ -796,7 +796,7 @@ groups:
       they do not represent real call-out points. In production the
       `PrioritizePublicationIntents` Evaluator output drives arm execution
       directly. See `notes/bt-fuzzer-nodes-report-management.md`
-      § "Production Collapse 2: Publication-intent subtree" and ADR-0027.
+      § "Production Collapse 2: Publication-intent subtree" and ADR-0028.
     tracking_issue: "#1200 (planning); implementation issue TBD (blocked by #1200)"
   - id: BT-20-003
     priority: SHOULD
@@ -816,7 +816,7 @@ groups:
       cascade) replaces it. The outer loop remains because the BT must still
       ask "should we notify additional parties?" and iterate through identified
       candidates. See `notes/bt-fuzzer-nodes-report-management.md`
-      § "Production Collapse 3: Notification loop" and ADR-0028.
+      § "Production Collapse 3: Notification loop" and ADR-0029.
     tracking_issue: >-
       #1200 (planning); implementation issue TBD (blocked by #1200 and #1298
       suggest-actor redesign)
@@ -837,7 +837,7 @@ groups:
       submission are distinct operations with separate external seams. The
       Actuator shape for submission is confirmed by ADR-0024 (Actuator
       amendment, 2026-07-07). See `notes/bt-fuzzer-nodes-report-management.md`
-      § "Production Collapse 4: Publish leaf" and ADR-0029.
+      § "Production Collapse 4: Publish leaf" and ADR-0030.
     tracking_issue: >-
       #1200 (planning); implementation issue TBD (blocked by #1200 and
       implementation issue for BT-20-002)


### PR DESCRIPTION
- Closes #1200

## Summary

Plans the four production BT collapse candidates from FUZZ-08: exploit-strategy
subtree, publication-intent subtree, notification loop, and publish leaf pipeline.
Produces four provisional ADRs, four provisional spec entries (BT-20), and
cross-referenced notes.

## Changes

- `docs/adr/0027-exploit-strategy-bt-collapse.md` — provisional ADR: five
  simulator nodes → `HaveExploit` Retriever + `EvaluateExploitStrategy`
  Evaluator (lean Option 2); `ExploitStrategyDecision` Pydantic output schema
- `docs/adr/0028-publication-intent-bt-collapse.md` — provisional ADR:
  `PublicationIntentsSet` flag check + `NoPublish*` bypass leaves disappear;
  `PrioritizePublicationIntents` Evaluator drives three named per-artifact arms
  (lean Option 1)
- `docs/adr/0029-notification-loop-suggest-actor.md` — provisional ADR: outer
  loop survives; `InjectParticipant` family replaced by `suggest-actor-to-case`
  trigger with explicit `roles` parameter; blocked by #1298
- `docs/adr/0030-publish-leaf-draft-review-submit-pipeline.md` — provisional
  ADR: single `Publish` leaf expands to Composer → Evaluator → optional
  Composer → Actuator (lean Option 2); participant-comment broadcast is an open
  design question deferred to the implementation issue
- `docs/adr/index.md` — registers ADR-0027 through ADR-0030 as Proposed
  (provisional)
- `specs/behavior-tree-integration.yaml` — appends BT-20 group with
  BT-20-001 through BT-20-004 (all provisional, tracking issues TBD)
- `notes/bt-fuzzer-nodes-report-management.md` — adds cross-references on
  affected simulator node entries; appends four `## Production Collapse Designs`
  sections with simulator nodes involved, production shape, surviving/collapsed
  nodes, open design questions, and spec references