### PR TITLE
docs: teach build and plan-issue to handle undecomposed Epics

### DIFF
--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -69,13 +69,48 @@ Invoke the `orient-agent` skill.
 
 3. Pick the highest-priority candidate.
 
-4. Fail-fast blocker gate on the selected issue (auto-selected or explicit):
+4. **Empty-Epic gate** — applies to both auto-selected and explicit issues:
+
+   Query the selected issue's type and sub-issue count:
+
+   ```bash
+   gh api graphql -f query='{
+     repository(owner:"CERTCC", name:"Vultron") {
+       issue(number: <ISSUE_NUMBER>) {
+         issueType { name }
+         subIssues(first: 1) { totalCount }
+         labels(first: 20) { nodes { name } }
+       }
+     }
+   }'
+   ```
+
+   If `issueType.name == "Epic"` and `subIssues.totalCount == 0`:
+
+   1. Apply `needs-decomposition` label if not already present:
+
+      ```bash
+      gh issue edit <ISSUE_NUMBER> --repo CERTCC/Vultron \
+        --add-label "needs-decomposition"
+      ```
+
+   2. Post an actionable comment on the Epic:
+
+      ```bash
+      gh issue comment <ISSUE_NUMBER> --repo CERTCC/Vultron \
+        --body "No implementable sub-issues found. Run \`/plan-issue <ISSUE_NUMBER>\` to decompose this Epic into Tasks before building."
+      ```
+
+   3. Tell the user: "Epic #N has no sub-issues and cannot be built yet. Run `/plan-issue N` to decompose it into Tasks first."
+   4. **Stop.** Do not claim, branch, or proceed.
+
+5. Fail-fast blocker gate on the selected issue (auto-selected or explicit):
 
    - Query `blockedBy` for the issue and filter to `state=OPEN`.
    - If any OPEN blockers exist, print blocker numbers/titles and stop.
    - Do not claim, branch, or deepen context when blocked.
 
-5. **Claim the Issue**:
+6. **Claim the Issue**:
 
    ```bash
    bash .agents/skills/shared/claim-issue.sh <N> task <slug>
@@ -83,7 +118,7 @@ Invoke the `orient-agent` skill.
 
    Abort immediately if this exits non-zero.
 
-6. Fetch the issue body and comments. Use the content as implementation
+7. Fetch the issue body and comments. Use the content as implementation
    context throughout Phases 3–5.
 
 ### Phase 3 — Deepen Context

--- a/.agents/skills/create-epic/SKILL.md
+++ b/.agents/skills/create-epic/SKILL.md
@@ -99,7 +99,20 @@ gh api graphql -f query="mutation {
 echo "  Added to Project #24 with Schedule=${SCHEDULE}"
 ```
 
-### Step 5 — Return Epic number
+### Step 5 — Apply `needs-decomposition` label
+
+Every newly created Epic starts without sub-issues. Apply the label
+immediately so the project board and `build` can identify it:
+
+```bash
+gh issue edit "${EPIC_NUMBER}" --repo CERTCC/Vultron \
+  --add-label "needs-decomposition"
+```
+
+Skip this step if `LEAF_ISSUES` is non-empty (sub-issues were linked in
+Step 3, so the Epic is not empty).
+
+### Step 6 — Return Epic number
 
 ```bash
 echo "${EPIC_NUMBER}"

--- a/.agents/skills/manage-github-issue/SKILL.md
+++ b/.agents/skills/manage-github-issue/SKILL.md
@@ -70,6 +70,19 @@ Outputs: issue number on **stdout**; progress messages on **stderr**.
   `blockedBy { nodes { number } }` via GraphQL — do not parse issue body text.
 - `--blocks` and `--blocked-by` are inverses: `--blocks 50` on issue 42 is
   equivalent to `--blocked-by 42` on issue 50.
+- **Never pass backtick-containing markdown in a double-quoted `--body` string.**
+  Backticks inside `"..."` are shell-interpreted and render as `\`` on GitHub.
+  Always pass bodies via a single-quoted heredoc:
+
+  ```bash
+  --body "$(cat <<'EOF'
+  Use `code` freely here — no escaping needed.
+  EOF
+  )"
+  ```
+
+  This applies to `--body` on `gh issue comment`, `gh pr create`,
+  `gh issue edit`, and any other CLI command accepting markdown.
 
 ## Reference
 

--- a/.agents/skills/plan-issue/SKILL.md
+++ b/.agents/skills/plan-issue/SKILL.md
@@ -1,20 +1,30 @@
 ---
 name: plan-issue
 description: >
-  Convert a single open GitHub Idea or Concern issue into a concrete
+  Convert a single open GitHub Idea, Concern, or Epic issue into a concrete
   implementation plan. Deepens context from the issue first, then runs a
   grill-me interview to understand scope, creates implementation issues,
-  optionally updates specs/notes, archives the source issue, and closes it.
-  Auto-detects Idea vs Concern from the GitHub issue type. Replaces the
-  former ingest-idea and ingest-concern skills. Use when the user references
-  an Idea or Concern issue number, or says "plan this idea/concern".
+  optionally updates specs/notes, and closes or annotates the source issue
+  appropriately. Auto-detects type from the GitHub issue type. Use when the
+  user references an Idea, Concern, or Epic issue number, or says "plan this
+  idea/concern/epic".
 ---
 
 # Skill: Plan Issue
 
-Convert an open GitHub `type:Idea` or `type:Concern` issue into an
-implementation plan: interview → explore → create impl issues →
-optionally update docs → archive + close the source issue.
+Convert an open GitHub `type:Idea`, `type:Concern`, or `type:Epic` issue into
+an implementation plan: interview → explore → create impl issues →
+optionally update docs → archive/close (Ideas and Concerns) or annotate
+(Epics).
+
+Type-specific interview questions, docs output, and completion steps are in
+the companion files alongside this one:
+
+- `idea.md` — Idea-specific interview and archive/close steps
+- `concern.md` — Concern-specific interview and archive/close steps
+- `epic.md` — Epic validation (Phase A) and decomposition (Phase B) steps
+
+Load only the file matching the detected issue type.
 
 ## Constants
 
@@ -28,14 +38,22 @@ See `.agents/skills/shared/README.md` for project IDs and issue type IDs.
 
 If the user provided a GitHub issue number, skip to Phase 1.
 
-Otherwise, query open Idea and Concern issues and present them as a
-combined multiple-choice list via `ask_user`:
+Otherwise, query open issues of all three types and present as a combined
+multiple-choice list via `ask_user`:
 
 ```bash
+# Ideas and Concerns
 gh issue list --repo CERTCC/Vultron --state open --limit 200 \
   --json number,title,issueType \
   --jq '.[] | select(.issueType.name == "Idea" or .issueType.name == "Concern")
         | "#\(.number) [\(.issueType.name)]: \(.title)"'
+
+# Epics with needs-decomposition label only
+gh issue list --repo CERTCC/Vultron --state open --limit 200 \
+  --label "needs-decomposition" \
+  --json number,title,issueType \
+  --jq '.[] | select(.issueType.name == "Epic")
+        | "#\(.number) [Epic/needs-decomposition]: \(.title)"'
 ```
 
 Include a **"Create a new Idea"** option at the end. Wait for the user's
@@ -65,13 +83,19 @@ if [ "${ISSUE_STATE}" != "OPEN" ]; then
   echo "❌ #${ISSUE_NUMBER} is not open (state=${ISSUE_STATE}). Stopping." >&2
   exit 1
 fi
-if [ "${ISSUE_TYPE}" != "Idea" ] && [ "${ISSUE_TYPE}" != "Concern" ]; then
-  echo "❌ #${ISSUE_NUMBER} is type '${ISSUE_TYPE}', expected Idea or Concern." >&2
+if [ "${ISSUE_TYPE}" != "Idea" ] && \
+   [ "${ISSUE_TYPE}" != "Concern" ] && \
+   [ "${ISSUE_TYPE}" != "Epic" ]; then
+  echo "❌ #${ISSUE_NUMBER} is type '${ISSUE_TYPE}', expected Idea, Concern, or Epic." >&2
   exit 1
 fi
 ```
 
-For both issue types, also query the parent epic (if any):
+**Load the type-specific companion file** matching `${ISSUE_TYPE}`:
+`idea.md`, `concern.md`, or `epic.md`. All type-specific steps below
+reference that file.
+
+For all types, also query the parent epic (if any):
 
 ```bash
 EPIC_NUMBER=$(gh api graphql -f query='{
@@ -92,50 +116,33 @@ Invoke the `orient-agent` skill to load required baseline context.
 Invoke the `deepen-context` skill, using focus hints derived from the issue
 title and body (e.g., "wire layer", "BT integration", "embargo lifecycle").
 This ensures the grill-me interview in Phase 4 starts from an informed
-baseline rather than blank-slate baseline context.
+baseline rather than blank-slate context.
 
 ### Phase 4 — Grill-Me Interview (invoke `grill-me`)
 
 Invoke the `grill-me` skill. Resolve every decision branch one at a time
-via `ask_user`, providing a recommendation for each. Cover:
+via `ask_user`, providing a recommendation for each.
 
-**Both types (shared base):**
+**Shared base questions (all types):**
 
 1. **Scope** — What is in scope? What is explicitly out of scope?
 2. **Acceptance criteria** — How do we verify this is fully addressed?
    Drive one GitHub issue per distinct AC cluster.
 3. **ADR determination** — Apply the `notes/specs-vs-adrs.md` decision tree
-   (MS-11-001 through MS-11-006). Form a recommendation with reasoning
-   (e.g., "This warrants an ADR because alternative X was meaningfully
-   evaluated and rejected"). Present the recommendation to the user for
-   approval or refinement before proceeding.
+   (MS-11-001 through MS-11-006). Form a recommendation with reasoning.
+   Present for approval before proceeding.
 
-**For Idea (additional):**
-
-1. **Spec scope** — What requirements should be captured?
-2. **Design decisions** — What alternatives were considered? Which is recommended?
-3. **Notes scope** — What implementation guidance should be documented?
-
-**For Concern (additional):**
-
-1. **Root cause** — What is actually broken, risky, or missing?
-2. **Impact** — What fails or degrades if left unaddressed?
-3. **Options** — 2–3 ways to address this concern.
-4. **Recommended approach** — Which option and why.
-5. **Spec/notes gaps** — Does this concern reveal missing requirements or
-   design decisions? Which file(s) should be added or changed?
-6. **AGENTS.md gap** — Is there a recurring implementation pitfall to capture?
+**Type-specific questions:** see the loaded companion file.
 
 Do **not** write anything until grill-me is complete.
 
-If the interview surfaces focus areas not covered in Phase 3 (e.g., a
-subsystem or design pattern that only became apparent during grilling),
-invoke `deepen-context` again with those additional hints before proceeding.
+If the interview surfaces focus areas not covered in Phase 3, invoke
+`deepen-context` again with those additional hints before proceeding.
 
 ### Phase 4b — Create Task Branch (if docs changes are expected)
 
 If grill-me established that Phase 5 will produce file writes, create the
-branch **before** writing any files so uncommitted changes are never at risk:
+branch **before** writing any files:
 
 ```bash
 bash .agents/skills/shared/sync-check.sh \
@@ -147,8 +154,8 @@ If no doc gaps were found (Phase 5 will be skipped), skip this step.
 
 ### Phase 5 — Update Docs (conditional)
 
-**For both types** — only if Phase 4 identified a concrete gap (docs changes
-are optional; skip this phase if no gap was found).
+Only if Phase 4 identified a concrete gap. See the loaded companion file for
+which files to update per type.
 
 - **`specs/<topic>.yaml`** — Add or amend requirements. Follow
   `specs/meta-specifications.yaml` conventions (ID scheme `PREFIX-NN-NNN`,
@@ -156,11 +163,10 @@ are optional; skip this phase if no gap was found).
 - **`notes/<topic>.md`** — Add design decisions, pitfalls, or implementation
   guidance. Every `notes/*.md` must have valid YAML frontmatter (`title`,
   `status`). Update `notes/README.md` if adding a new file.
-- **`AGENTS.md`** — Append a new pitfall entry to the
-  **Common Pitfalls** section if Phase 4 identified a recurring agent gap.
-- **ADR** — Draft `docs/adr/NNNN-<slug>.md` alongside the spec if the ADR
-  determination in Phase 4 recommended one (applies to both Ideas and
-  Concerns; see `notes/specs-vs-adrs.md`).
+- **`AGENTS.md`** — Append a new pitfall entry to the **Common Pitfalls**
+  section if Phase 4 identified a recurring agent gap (Concern type only).
+- **ADR** — Draft `docs/adr/NNNN-<slug>.md` if the ADR determination
+  recommended one.
 
 Track created filenames:
 
@@ -201,17 +207,16 @@ gh pr create --repo CERTCC/Vultron \
   --label "specs-notes"
 ```
 
-> For both Idea and Concern, `Closes #N` in the PR body closes the issue
-> on merge. If no docs PR is opened, close the issue directly in Phase 9
-> instead (applies to both types).
+> For Ideas and Concerns, `Closes #N` in the PR body closes the issue on
+> merge. For Epics, omit `Closes #N` — the Epic must not be closed by the
+> docs PR.
 
-### Phase 8 — Create Implementation Issue(s)
+### Phase 8 — Create Implementation Issues
 
-Create one GitHub issue per distinct AC cluster from Phase 3.
-Use `manage-github-issue` for relationship wiring.
+Create one Task sub-issue per distinct AC cluster from Phase 4.
 
-For both types, wire the impl issue as **blocked-by the source issue** and
-as **child of the parent epic** (if `EPIC_NUMBER` is non-empty):
+For Ideas and Concerns, wire the impl issue as **blocked-by the source
+issue** and as **child of the parent epic** (if `EPIC_NUMBER` is non-empty):
 
 ```bash
 PARENT_ARG=""
@@ -234,6 +239,9 @@ $([ -n "${NOTES_FILE}" ] && echo "Notes: \`notes/${NOTES_FILE}\`")" \
   --blocked-by "${ISSUE_NUMBER}")
 ```
 
+For Epics, see the `epic.md` companion file — Tasks are wired as sub-issues
+of the Epic itself, not blocked-by it.
+
 Repeat for each additional impl issue. Set `size:` by AC count:
 1–2 → `size:S`; 3–6 → `size:M`; 7+ → `size:L`.
 
@@ -243,86 +251,44 @@ Add each new issue to Project #24:
 bash .agents/skills/shared/add-to-project.sh "${IMPL_NUMBER}"
 ```
 
-### Phase 9 — Archive and Close
+### Phase 9 — Archive, Close, or Annotate
 
-Invoke the `archive-history` skill (after PR URL is known):
+See the loaded companion file for the type-specific completion step:
 
-**Idea:**
-
-```text
-TYPE    = idea
-TITLE   = <short idea title>
-SOURCE  = IDEA-<ISSUE_NUMBER>
-BODY    = Full original idea text
-          + "**Processed**: YYYY-MM-DD — implementation tracked in #<IMPL_NUMBER>."
-          + "Docs PR: <PR_URL>." (if docs PR was opened)
-          + "Spec: `specs/${SPEC_FILE}`." (if spec was written)
-          + "Notes: `notes/${NOTES_FILE}`." (if notes were written)
-```
-
-**Concern:**
-
-```text
-TYPE    = learning
-TITLE   = <short concern title>
-SOURCE  = CONCERN-<ISSUE_NUMBER>
-BODY    = Full original concern body
-          + "**Resolved**: YYYY-MM-DD — implementation tracked in #<N>
-            [, #<M> ...]."
-          + "Docs PR: <PR_URL>." (if docs PR was opened)
-          + "Spec: `specs/${SPEC_FILE}`." (if spec was written)
-          + "Notes: `notes/${NOTES_FILE}`." (if notes were written)
-```
-
-Then post a resolution comment and close:
-
-```bash
-gh issue comment "${ISSUE_NUMBER}" --repo CERTCC/Vultron \
-  --body "✅ Planned.
-
-$([ -n "${PR_URL}" ] && echo "- Docs PR: ${PR_URL}")
-$(for n in "${IMPL_NUMBERS[@]}"; do echo "- Implementation issue: #${n}"; done)
-$([ -n "${SPEC_FILE}" ] && echo "Spec: \`specs/${SPEC_FILE}\`.")
-$([ -n "${NOTES_FILE}" ] && echo "Notes: \`notes/${NOTES_FILE}\`.")"
-
-# Only close directly when no docs PR was opened (applies to both types).
-# When a PR exists, Closes #N in the PR body closes the issue on merge.
-if [ -z "${PR_URL}" ]; then
-  gh issue close "${ISSUE_NUMBER}" --repo CERTCC/Vultron
-fi
-```
+- **Idea**: invoke `archive-history`, post resolution comment, close issue
+- **Concern**: invoke `archive-history`, post resolution comment, close issue
+- **Epic**: remove `needs-decomposition` label, post summary comment, leave open
 
 ---
 
 ## Checklist
 
 - [ ] Issue identified (user-specified or selected from list)
-- [ ] Issue body fetched; type auto-detected (Idea or Concern); issue is open
+- [ ] Issue body fetched; type auto-detected (Idea, Concern, or Epic); issue is open
+- [ ] Type-specific companion file loaded (`idea.md`, `concern.md`, or `epic.md`)
 - [ ] `orient-agent` invoked
 - [ ] `deepen-context` invoked with focus hints from the issue
-- [ ] All grill-me branches resolved
+- [ ] All grill-me branches resolved (shared + type-specific)
 - [ ] `deepen-context` re-invoked if new focus areas emerged during grilling
 - [ ] Task branch created (`plan/<N>-<slug>`) — if docs changes expected
-- [ ] Docs updated — optional for both types (or consciously skipped with a note)
+- [ ] Docs updated — optional for all types (or consciously skipped with a note)
 - [ ] Markdown lint clean (if docs changed)
 - [ ] Docs-only PR opened with `specs-notes` label — or skipped (no doc changes)
 - [ ] Implementation issue(s) created via `manage-github-issue` + `add-to-project.sh`
-- [ ] Impl issues wired blocked-by source issue + child of epic (if any)
-- [ ] Issue archived via `archive-history` (after PR URL known)
-- [ ] Issue commented with impl issue(s) + optional PR URL; closed appropriately
+- [ ] Impl issues wired per type (blocked-by for Ideas/Concerns; sub-issue for Epics)
+- [ ] Completion step executed per type (archive+close for Ideas/Concerns; annotate for Epics)
 
 ---
 
 ## Conventions
 
 - **Branch name**: `plan/<N>-<slug>` (only created if docs changed)
-- **History source**: `IDEA-<N>` for Ideas; `CONCERN-<N>` for Concerns
-- **History type**: `idea` for Ideas; `learning` for Concerns
+- **History source**: `IDEA-<N>` for Ideas; `CONCERN-<N>` for Concerns (not used for Epics)
+- **History type**: `idea` for Ideas; `learning` for Concerns (not used for Epics)
 - **Spec file names**: lowercase hyphenated `.yaml` in `specs/`
 - **Notes file names**: same base name as spec, `.md` in `notes/`
-- **Close behavior**: `Closes #N` in the PR body closes on merge for both
-  types. If no docs PR is opened, close directly after archive (applies to
-  both types).
+- **Close behavior**: `Closes #N` in the PR body closes on merge for Ideas
+  and Concerns. Epics are never closed by this skill.
 - **Project board**: all new issues added with `Schedule=Someday` via
   `shared/add-to-project.sh`
 
@@ -330,7 +296,9 @@ fi
 
 | Skill | Input | Docs output | Closes issue? |
 |---|---|---|---|
-| `plan-issue` | One Idea or Concern issue | Optional specs+notes for both types | Yes |
+| `plan-issue` (Idea) | One Idea issue | Optional specs+notes | Yes |
+| `plan-issue` (Concern) | One Concern issue | Optional specs+notes | Yes |
+| `plan-issue` (Epic) | One Epic issue | Optional specs+notes | No — annotates only |
 | `learn` | plan/incoming/learnings/ + all Concern issues | specs/notes/AGENTS | Yes (batch) |
 | `new-item` | Freeform text | None | N/A (creates, not resolves) |
 | `process-concerns` | CONCERNS.md file | None | No |

--- a/.agents/skills/plan-issue/concern.md
+++ b/.agents/skills/plan-issue/concern.md
@@ -1,0 +1,60 @@
+# Plan Issue — Concern path
+
+## Grill-Me Interview (additional questions beyond shared base)
+
+After resolving the shared base questions (scope, AC clusters, ADR
+determination), also cover:
+
+1. **Root cause** — What is actually broken, risky, or missing?
+2. **Impact** — What fails or degrades if left unaddressed?
+3. **Options** — 2–3 ways to address this concern.
+4. **Recommended approach** — Which option and why.
+5. **Spec/notes gaps** — Does this concern reveal missing requirements or
+   design decisions? Which file(s) should be added or changed?
+6. **AGENTS.md gap** — Is there a recurring implementation pitfall to capture?
+
+## Docs Output
+
+- `specs/<topic>.yaml` — Add or amend requirements (optional)
+- `notes/<topic>.md` — Add design decisions or implementation guidance (optional)
+- `AGENTS.md` — Append pitfall entry to **Common Pitfalls** section if a
+  recurring agent gap was identified (optional)
+- ADR in `docs/adr/` if ADR determination recommended one
+
+## Archive and Close
+
+After implementation issues are created, archive and close the source Concern issue.
+
+**History entry:**
+
+```text
+TYPE    = learning
+TITLE   = <short concern title>
+SOURCE  = CONCERN-<ISSUE_NUMBER>
+BODY    = Full original concern body
+          + "**Resolved**: YYYY-MM-DD — implementation tracked in #<N>
+            [, #<M> ...]."
+          + "Docs PR: <PR_URL>." (if docs PR was opened)
+          + "Spec: `specs/${SPEC_FILE}`." (if spec was written)
+          + "Notes: `notes/${NOTES_FILE}`." (if notes were written)
+```
+
+Post resolution comment and close:
+
+```bash
+gh issue comment "${ISSUE_NUMBER}" --repo CERTCC/Vultron \
+  --body "✅ Planned.
+
+$([ -n "${PR_URL}" ] && echo "- Docs PR: ${PR_URL}")
+$(for n in "${IMPL_NUMBERS[@]}"; do echo "- Implementation issue: #${n}"; done)
+$([ -n "${SPEC_FILE}" ] && echo "Spec: \`specs/${SPEC_FILE}\`.")
+$([ -n "${NOTES_FILE}" ] && echo "Notes: \`notes/${NOTES_FILE}\`.")"
+
+# Only close directly when no docs PR was opened.
+if [ -z "${PR_URL}" ]; then
+  gh issue close "${ISSUE_NUMBER}" --repo CERTCC/Vultron
+fi
+```
+
+**History source**: `CONCERN-<N>`
+**History type**: `learning`

--- a/.agents/skills/plan-issue/epic.md
+++ b/.agents/skills/plan-issue/epic.md
@@ -1,0 +1,87 @@
+# Plan Issue — Epic path
+
+## Phase A — Validate the Epic
+
+Before decomposing, validate the Epic against current understanding. Cover:
+
+1. **Currency check** — What do we know now that wasn't known when this Epic
+   was written? Has adjacent work (e.g., related Epics, merged PRs, new specs)
+   changed what this Epic should cover or how it should be scoped?
+2. **Codebase audit** — Have any of this Epic's ACs been partially or fully
+   addressed already? Search `vultron/` and `test/` before answering.
+3. **AC refinement** — Should any ACs be dropped, rewritten, or added in light
+   of current understanding?
+4. **Hierarchy check** — Does the Epic still belong under its current parent, or
+   has the project structure shifted?
+5. **Description/title gaps** — Should the Epic title or body be updated to
+   reflect the validated understanding? Draft proposed edits if so.
+
+Apply any agreed Epic title/body edits before proceeding to Phase B:
+
+```bash
+gh issue edit "${ISSUE_NUMBER}" --repo CERTCC/Vultron \
+  --title "<updated title>" \
+  --body "<updated body>"
+```
+
+## Phase B — Decompose into Tasks
+
+After validating the Epic, decompose it. Cover:
+
+1. **Decomposition boundaries** — What is one Task vs. two? Avoid both
+   over-splitting (trivial Tasks) and under-splitting (Tasks too large to
+   implement in a single PR).
+2. **Sequencing constraints** — Which Tasks must precede others? This determines
+   `blocked-by` relationships.
+3. **AC inheritance** — Which of the Epic's ACs map to which Tasks? Every AC
+   must be covered by at least one Task.
+
+## Docs Output (optional)
+
+- `specs/<topic>.yaml` — Add or amend requirements if Phase A revealed gaps
+- `notes/<topic>.md` — Add design decisions or implementation guidance if needed
+- ADR in `docs/adr/` if ADR determination recommended one
+
+Docs updates are optional. Skip if Phase A found no gaps.
+
+## Implementation Issues
+
+Create one Task sub-issue per decomposition cluster from Phase B. Wire each as:
+
+- `--blocked-by <N>` for any sequencing constraints
+- `--issue-type-id IT_kwDOAjf0s84AcFLo` (Task type)
+
+```bash
+TASK_NUMBER=$(.agents/skills/manage-github-issue/manage_github_issue.sh \
+  --title "<task title from Phase B>" \
+  --body "## Summary
+<description>
+
+## Acceptance Criteria
+- [ ] AC-1: <from Phase B>
+
+## Reference
+Epic: #${ISSUE_NUMBER}" \
+  --label "size:<S|M|L>" \
+  --issue-type-id "IT_kwDOAjf0s84AcFLo" \
+  --parent "${ISSUE_NUMBER}" \
+  [--blocked-by "<prerequisite task number>"])
+bash .agents/skills/shared/add-to-project.sh "${TASK_NUMBER}"
+```
+
+## Completion
+
+Remove `needs-decomposition` label and post a summary comment:
+
+```bash
+gh issue edit "${ISSUE_NUMBER}" --repo CERTCC/Vultron \
+  --remove-label "needs-decomposition"
+
+gh issue comment "${ISSUE_NUMBER}" --repo CERTCC/Vultron \
+  --body "✅ Decomposed into Tasks: $(echo "${TASK_NUMBERS[@]}" | sed 's/ /, #/g; s/^/#/').
+
+$([ -n "${PR_URL}" ] && echo "Docs PR: ${PR_URL}")"
+```
+
+**Do NOT archive or close the Epic.** It remains open until all sub-issues
+are complete.

--- a/.agents/skills/plan-issue/idea.md
+++ b/.agents/skills/plan-issue/idea.md
@@ -1,0 +1,54 @@
+# Plan Issue — Idea path
+
+## Grill-Me Interview (additional questions beyond shared base)
+
+After resolving the shared base questions (scope, AC clusters, ADR
+determination), also cover:
+
+1. **Spec scope** — What requirements should be captured in `specs/`?
+2. **Design decisions** — What alternatives were considered? Which is recommended?
+3. **Notes scope** — What implementation guidance should be documented in `notes/`?
+
+## Docs Output
+
+- `specs/<topic>.yaml` — Add or amend requirements (optional)
+- `notes/<topic>.md` — Add design decisions or implementation guidance (optional)
+- ADR in `docs/adr/` if ADR determination recommended one
+
+## Archive and Close
+
+After implementation issues are created, archive and close the source Idea issue.
+
+**History entry:**
+
+```text
+TYPE    = idea
+TITLE   = <short idea title>
+SOURCE  = IDEA-<ISSUE_NUMBER>
+BODY    = Full original idea text
+          + "**Processed**: YYYY-MM-DD — implementation tracked in #<IMPL_NUMBER>."
+          + "Docs PR: <PR_URL>." (if docs PR was opened)
+          + "Spec: `specs/${SPEC_FILE}`." (if spec was written)
+          + "Notes: `notes/${NOTES_FILE}`." (if notes were written)
+```
+
+Post resolution comment and close:
+
+```bash
+gh issue comment "${ISSUE_NUMBER}" --repo CERTCC/Vultron \
+  --body "✅ Planned.
+
+$([ -n "${PR_URL}" ] && echo "- Docs PR: ${PR_URL}")
+$(for n in "${IMPL_NUMBERS[@]}"; do echo "- Implementation issue: #${n}"; done)
+$([ -n "${SPEC_FILE}" ] && echo "Spec: \`specs/${SPEC_FILE}\`.")
+$([ -n "${NOTES_FILE}" ] && echo "Notes: \`notes/${NOTES_FILE}\`.")"
+
+# Only close directly when no docs PR was opened.
+# When a PR exists, Closes #N in the PR body closes the issue on merge.
+if [ -z "${PR_URL}" ]; then
+  gh issue close "${ISSUE_NUMBER}" --repo CERTCC/Vultron
+fi
+```
+
+**History source**: `IDEA-<N>`
+**History type**: `idea`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -939,6 +939,27 @@ or the `createIssue` GraphQL mutation directly (with `issueTypeId`,
 `parentIssueId` inline). Issue type IDs and relationship mutation names are in
 `.agents/skills/manage-github-issue/REFERENCE.md`.
 
+**Never pass backtick-containing markdown in a double-quoted `--body` string.**
+Backticks inside `"..."` are shell-interpreted and appear as `\`` in GitHub.
+Always use a single-quoted heredoc so the shell passes the body verbatim:
+
+```bash
+gh issue comment <N> --repo CERTCC/Vultron --body "$(cat <<'EOF'
+Use `code` freely here — no escaping needed.
+EOF
+)"
+
+gh pr create --body "$(cat <<'EOF'
+- Closes #N
+## Summary
+Run `/plan-issue` to fix `needs-decomposition` Epics.
+EOF
+)"
+```
+
+The same rule applies to `gh issue edit --body`, `gh issue comment`, and any
+other CLI command that accepts a markdown body argument.
+
 ### Triage labels
 
 Default label vocabulary (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.


### PR DESCRIPTION
- Closes #1318

## Summary

Adds handling for Epics that have acceptance criteria but no sub-issues
yet — a legitimate in-between state (like #441) that neither `build` nor
`plan-issue` previously handled gracefully.

## Changes

- `.agents/skills/build/SKILL.md`: empty-Epic gate — any Epic with no
  leaf sub-issues triggers an actionable stop: applies `needs-decomposition`
  label, posts comment on the Epic, tells the user to run `/plan-issue N`
- `.agents/skills/plan-issue/SKILL.md`: refactored as a skeleton that
  accepts Ideas, Concerns, and Epics; Phase 0 auto-select includes Epics
  filtered to `needs-decomposition`; type-specific steps delegated to
  companion files
- `.agents/skills/plan-issue/idea.md`: Idea-specific grill-me questions
  and archive/close steps (extracted from former monolithic SKILL.md)
- `.agents/skills/plan-issue/concern.md`: Concern-specific grill-me
  questions and archive/close steps (extracted from former monolithic
  SKILL.md)
- `.agents/skills/plan-issue/epic.md`: new — Epic two-phase grill-me
  (Phase A: validate against current understanding; Phase B: decompose
  into Tasks); removes `needs-decomposition` on completion; does not
  archive or close
- `.agents/skills/create-epic/SKILL.md`: apply `needs-decomposition` at
  Epic creation when no leaf issues are linked

## Verification

- Markdown lint clean (pre-commit hook passed)
- `needs-decomposition` label created in repo and applied to #441