### PR TITLE
Gate case creation on ActorConfig.auto_create_case (#1272)

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1272.md
+++ b/plan/history/2607/implementation/ISSUE-1272.md
@@ -1,0 +1,30 @@
+---
+source: ISSUE-1272
+timestamp: '2026-07-10T14:28:27.163809+00:00'
+title: auto_create_case policy gate
+type: implementation
+---
+
+## Issue #1272 — Add auto_create_case policy flag to ActorConfig and gate create_receive_report_case_tree on it
+
+Added `ActorConfig.auto_create_case: bool = True` (CM-15-001, ADR-0015
+Option 3/4) and gated case creation on it at two enforcement points:
+
+- `CheckAutoCaseCreationEnabledNode` BT condition node wired at the root of
+  `create_receive_report_case_tree` as `Sequence[gate, Selector[...]]` — the
+  gate sits in a Sequence (not the idempotency Selector) so a genuine
+  case-creation FAILURE still propagates instead of being masked.
+- A routing-level short-circuit in `SubmitReportReceivedUseCase.execute()`
+  (analogous to the existing recipient guards) so a deliberate skip logs at
+  INFO rather than as a case-creation error; report + Offer are still stored.
+
+Reworded CM-15-001 to specify observable behavior (no case, unchanged outbox)
+rather than call path, reconciling a conflict between the issue body (in-tree
+gate) and the original spec text ("MUST NOT invoke the tree").
+
+Scope boundary: no production dispatch path resolves a per-actor `ActorConfig`
+yet, so the flag is currently reachable only via injected config (unit-tested).
+Runtime resolution + vendor seed-config (needed by #1221) tracked in follow-up
+issue 1319.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1322>

--- a/plan/incoming/learnings/20260710-spec-issue-intent-over-letter.md
+++ b/plan/incoming/learnings/20260710-spec-issue-intent-over-letter.md
@@ -1,0 +1,44 @@
+---
+title: Reconcile spec/issue letter vs. intent when they conflict with architecture
+type: learning
+timestamp: 2026-07-10
+source: ISSUE-1272
+---
+
+While implementing #1272 (auto_create_case gate), the issue body and the
+authoritative spec CM-15-001 contradicted each other, and the issue body
+contained a factual error about the codebase.
+
+- Issue §4 claimed the BT "already has access to ActorConfig through the
+  blackboard." False — `actor_config` is threaded as a **constructor arg**
+  through `create_receive_report_case_tree(..., actor_config=...)` to nodes
+  (same pattern as `default_case_roles` / `CreateCaseOwnerParticipant`). The
+  received-report path passed `None` (no per-actor config resolution exists).
+- CM-15-001 (as written) said the use case "MUST NOT invoke
+  `create_receive_report_case_tree`" when False; the issue body wanted an
+  in-tree gate that *does* invoke the tree. Mutually exclusive.
+
+Resolution (endorsed by maintainer): treat the **observable behavior** as the
+real requirement, not the mechanism. Reworded CM-15-001 to specify the outcome
+(no case created, outbox unchanged) and bless either enforcement location.
+Implemented both a BT condition node (canonical, per BT-15-001) AND a
+use-case routing short-circuit (analogous to existing recipient guards).
+
+Guidance for future agents: neither specs nor issue text are meant to
+constrain the *right* solution — they steer away from bad ones. When they
+conflict with the codebase's own architecture principles (here: BT-first,
+thin use-cases) or contain stale/incorrect premises, implement the intent,
+then **capture the correction back into the spec and issue** (edit the spec
+YAML; comment on the issue) rather than silently complying or silently
+diverging. Use AskUserQuestion to surface genuine design forks.
+
+Also: BT gate placement matters. The AGENTS.md-recommended idempotency idiom
+`Selector(Sequence(guard, work), Success)` **masks** flow FAILURE. When a
+downstream FAILURE must still propagate (case creation can genuinely fail),
+use `Sequence[gate, existing_Selector]` instead so the gate fails-safe without
+masking real failures.
+
+Scope boundary captured as follow-up #1319: no production dispatch path
+resolves a per-actor ActorConfig yet, so the flag is reachable only via
+injected config (unit-tested). Runtime resolution + vendor seed-config
+(needed by #1221) tracked there.

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -718,14 +718,25 @@ groups:
     priority: MUST
     statement: >-
       ActorConfig MUST expose an `auto_create_case` boolean field (default: True).
-      When False, SubmitReportReceivedUseCase MUST store the inbound
-      VulnerabilityReport and Offer(Report) activity but MUST NOT invoke
-      create_receive_report_case_tree.
+      When a receiver's auto_create_case is False, processing an inbound
+      Offer(Report) MUST store the VulnerabilityReport and the Offer(Report)
+      activity but MUST NOT create a VulnerabilityCase and MUST leave the
+      receiver's outbox unchanged. The gate MAY be enforced either as a
+      routing-level short-circuit in SubmitReportReceivedUseCase or as an
+      in-tree condition node at the root of create_receive_report_case_tree;
+      the observable outcome (no case, no outbound activities) is what is
+      normative, not the enforcement location.
     rationale: >-
       Receivers that follow the Option 3 protocol path (send Read(Offer(Report))
       before deciding to accept or reject) require the ability to delay case
       creation. The default (True) preserves the original ADR-0015 Option 4
       "always create at RM.RECEIVED" behavior for all existing actors and demos.
+      Case creation is protocol-significant behavior (BT-15-001), so the
+      canonical gate lives in the behavior tree as a condition node; the
+      use-case short-circuit is an equivalent optimization that avoids invoking
+      the BT for a decision already known at dispatch time. Either placement
+      yields the same observable outcome, so the requirement is specified in
+      terms of behavior rather than call path.
     relationships:
     - rel_type: refines
       spec_id: CM-12-001

--- a/test/core/behaviors/case/nodes/test_conditions.py
+++ b/test/core/behaviors/case/nodes/test_conditions.py
@@ -29,9 +29,11 @@ from py_trees.common import Status
 from pydantic import ValidationError
 
 from vultron.core.behaviors.case.nodes.conditions import (
+    CheckAutoCaseCreationEnabledNode,
     CheckCaseAlreadyExists,
     CheckCaseExistsForReport,
 )
+from vultron.core.models.actor_config import ActorConfig
 from vultron.core.models.vultron_types import (
     VultronCase,
     VultronCaseActor,
@@ -224,3 +226,34 @@ class TestVultronCaseIdContract:
     def test_auto_generated_id_is_nonempty(self) -> None:
         case = VultronCase()
         assert case.id_ and case.id_.strip()
+
+
+class TestCheckAutoCaseCreationEnabledNode:
+    """CheckAutoCaseCreationEnabledNode gates case creation on the policy.
+
+    Per specs/case-management.yaml CM-15-001. The node reads the policy from
+    its constructor argument (not the blackboard), so it can be exercised by
+    direct ticking without any DataLayer setup.
+    """
+
+    def test_success_when_auto_create_enabled(self) -> None:
+        node = CheckAutoCaseCreationEnabledNode(
+            actor_config=ActorConfig(auto_create_case=True)
+        )
+        assert node.update() == Status.SUCCESS
+
+    def test_failure_when_auto_create_disabled(self) -> None:
+        node = CheckAutoCaseCreationEnabledNode(
+            actor_config=ActorConfig(auto_create_case=False)
+        )
+        assert node.update() == Status.FAILURE
+
+    def test_defaults_to_success_when_no_config(self) -> None:
+        """No ActorConfig supplied → default enabled (ADR-0015 Option 4)."""
+        node = CheckAutoCaseCreationEnabledNode(actor_config=None)
+        assert node.update() == Status.SUCCESS
+
+    def test_defaults_to_success_with_default_actor_config(self) -> None:
+        """A default ActorConfig has auto_create_case=True."""
+        node = CheckAutoCaseCreationEnabledNode(actor_config=ActorConfig())
+        assert node.update() == Status.SUCCESS

--- a/test/core/behaviors/case/test_receive_report_case_tree.py
+++ b/test/core/behaviors/case/test_receive_report_case_tree.py
@@ -37,6 +37,7 @@ import py_trees
 from py_trees.common import Status
 
 from vultron.core.behaviors.case.nodes import (
+    CheckAutoCaseCreationEnabledNode,
     CheckCaseExistsForReport,
     CreateCaseOwnerParticipant,
     InitializeDefaultEmbargoNode,
@@ -57,10 +58,10 @@ from vultron.core.states.roles import CVDRole
 class TestTreeStructure:
     """Structure assertions: root node type, children count, and node types."""
 
-    def test_create_receive_report_case_tree_returns_selector(
+    def test_create_receive_report_case_tree_returns_sequence(
         self, report, offer, reporter_actor_id
     ):
-        """Tree factory returns a Selector root node."""
+        """Tree factory returns a Sequence root gating on auto_create_case."""
         tree = create_receive_report_case_tree(
             report_id=report.id_,
             offer_id=offer.id_,
@@ -68,31 +69,58 @@ class TestTreeStructure:
         )
         assert tree is not None
         assert tree.name == "ReceiveReportCaseBT"
+        assert isinstance(tree, py_trees.composites.Sequence)
         assert hasattr(tree, "children")
         assert len(tree.children) == 2
 
-    def test_tree_first_child_is_idempotency_check(
+    def test_tree_first_child_is_auto_create_gate(
         self, report, offer, reporter_actor_id
     ):
-        """First child is CheckCaseExistsForReport (idempotency guard)."""
+        """First child is CheckAutoCaseCreationEnabledNode (policy gate)."""
         tree = create_receive_report_case_tree(
             report_id=report.id_,
             offer_id=offer.id_,
             reporter_actor_id=reporter_actor_id,
         )
-        assert isinstance(tree.children[0], CheckCaseExistsForReport)
+        assert isinstance(tree.children[0], CheckAutoCaseCreationEnabledNode)
 
-    def test_tree_second_child_is_sequence(
+    def test_tree_second_child_is_case_creation_selector(
         self, report, offer, reporter_actor_id
     ):
-        """Second child is a Sequence (ReceiveReportCaseFlow)."""
+        """Second child is the idempotency Selector (ReceiveReportCaseSelector)."""
         tree = create_receive_report_case_tree(
             report_id=report.id_,
             offer_id=offer.id_,
             reporter_actor_id=reporter_actor_id,
         )
-        assert isinstance(tree.children[1], py_trees.composites.Sequence)
-        assert tree.children[1].name == "ReceiveReportCaseFlow"
+        selector = tree.children[1]
+        assert isinstance(selector, py_trees.composites.Selector)
+        assert selector.name == "ReceiveReportCaseSelector"
+
+    def test_selector_first_child_is_idempotency_check(
+        self, report, offer, reporter_actor_id
+    ):
+        """Selector's first child is CheckCaseExistsForReport (idempotency guard)."""
+        tree = create_receive_report_case_tree(
+            report_id=report.id_,
+            offer_id=offer.id_,
+            reporter_actor_id=reporter_actor_id,
+        )
+        selector = tree.children[1]
+        assert isinstance(selector.children[0], CheckCaseExistsForReport)
+
+    def test_selector_second_child_is_flow_sequence(
+        self, report, offer, reporter_actor_id
+    ):
+        """Selector's second child is the ReceiveReportCaseFlow Sequence."""
+        tree = create_receive_report_case_tree(
+            report_id=report.id_,
+            offer_id=offer.id_,
+            reporter_actor_id=reporter_actor_id,
+        )
+        flow = tree.children[1].children[1]
+        assert isinstance(flow, py_trees.composites.Sequence)
+        assert flow.name == "ReceiveReportCaseFlow"
 
     def test_tree_flow_has_ten_children(
         self, report, offer, reporter_actor_id
@@ -103,7 +131,7 @@ class TestTreeStructure:
             offer_id=offer.id_,
             reporter_actor_id=reporter_actor_id,
         )
-        flow = tree.children[1]
+        flow = tree.children[1].children[1]
         assert len(flow.children) == 10
 
     def test_propose_case_to_actor_node_is_wired(
@@ -122,7 +150,7 @@ class TestTreeStructure:
             offer_id=offer.id_,
             reporter_actor_id=reporter_actor_id,
         )
-        flow = tree.children[1]
+        flow = tree.children[1].children[1]
         node_types = [type(c) for c in flow.children]
         assert ProposeCaseToActorNode in node_types
         propose_idx = node_types.index(ProposeCaseToActorNode)
@@ -135,6 +163,87 @@ class TestTreeStructure:
             "ProposeCaseToActorNode must appear immediately after "
             "CreateCaseActorNode"
         )
+
+
+# ============================================================================
+# auto_create_case policy gate tests (CM-15-001)
+# ============================================================================
+
+
+class TestAutoCreateCasePolicyGate:
+    """The auto_create_case gate controls whether the tree creates a case."""
+
+    def test_gate_wired_with_actor_config(
+        self, report, offer, reporter_actor_id
+    ):
+        """The root gate receives the supplied ActorConfig (CM-15-001)."""
+        from vultron.core.models.actor_config import ActorConfig
+
+        cfg = ActorConfig(auto_create_case=False)
+        tree = create_receive_report_case_tree(
+            report_id=report.id_,
+            offer_id=offer.id_,
+            reporter_actor_id=reporter_actor_id,
+            actor_config=cfg,
+        )
+        gate = tree.children[0]
+        assert isinstance(gate, CheckAutoCaseCreationEnabledNode)
+        assert gate.actor_config is cfg
+
+    def test_tree_creates_case_when_auto_create_enabled(
+        self,
+        datalayer,
+        actor,
+        reporter_actor,
+        reporter_actor_id,
+        report,
+        offer,
+        bridge,
+        reporter_accepted_status,
+        vendor_received_status,
+    ):
+        """auto_create_case=True (default) still creates the case (AC-1)."""
+        from vultron.core.models.actor_config import ActorConfig
+
+        tree = create_receive_report_case_tree(
+            report_id=report.id_,
+            offer_id=offer.id_,
+            reporter_actor_id=reporter_actor_id,
+            actor_config=ActorConfig(auto_create_case=True),
+        )
+        result = bridge.execute_with_setup(
+            tree=tree, actor_id=actor.id_, activity=offer
+        )
+        assert result.status == Status.SUCCESS
+        assert datalayer.find_case_by_report_id(report.id_) is not None
+
+    def test_tree_skips_case_when_auto_create_disabled(
+        self,
+        datalayer,
+        actor,
+        reporter_actor,
+        reporter_actor_id,
+        report,
+        offer,
+        bridge,
+        reporter_accepted_status,
+        vendor_received_status,
+    ):
+        """auto_create_case=False makes the tree exit without a case (AC-2)."""
+        from vultron.core.models.actor_config import ActorConfig
+
+        tree = create_receive_report_case_tree(
+            report_id=report.id_,
+            offer_id=offer.id_,
+            reporter_actor_id=reporter_actor_id,
+            actor_config=ActorConfig(auto_create_case=False),
+        )
+        result = bridge.execute_with_setup(
+            tree=tree, actor_id=actor.id_, activity=offer
+        )
+        # Outer Sequence fails at the gate before any DataLayer write.
+        assert result.status == Status.FAILURE
+        assert datalayer.find_case_by_report_id(report.id_) is None
 
 
 # ============================================================================
@@ -727,7 +836,7 @@ class TestEmbargoInitialization:
             offer_id=offer.id_,
             reporter_actor_id=reporter_actor_id,
         )
-        flow = tree.children[1]
+        flow = tree.children[1].children[1]
         node_types = [type(child) for child in flow.children]
 
         owner_idx = None

--- a/test/core/models/test_actor_config.py
+++ b/test/core/models/test_actor_config.py
@@ -38,6 +38,25 @@ def test_actor_config_default_roles_empty():
     assert config.default_case_roles == []
 
 
+def test_actor_config_auto_create_case_defaults_true():
+    """ActorConfig.auto_create_case defaults to True (CM-15-001, ADR-0015)."""
+    config = ActorConfig()
+    assert config.auto_create_case is True
+
+
+def test_actor_config_auto_create_case_can_be_disabled():
+    """ActorConfig.auto_create_case can be set to False (CM-15-001)."""
+    config = ActorConfig(auto_create_case=False)
+    assert config.auto_create_case is False
+
+
+def test_actor_config_auto_create_case_roundtrip():
+    """auto_create_case round-trips through model_dump / model_validate."""
+    config = ActorConfig(auto_create_case=False)
+    restored = ActorConfig.model_validate(config.model_dump())
+    assert restored.auto_create_case is False
+
+
 def test_actor_config_accepts_cvd_roles():
     """ActorConfig.default_case_roles accepts CVDRoles enum values."""
     config = ActorConfig(default_case_roles=[CVDRole.VENDOR])

--- a/test/core/use_cases/received/test_submit_report_received.py
+++ b/test/core/use_cases/received/test_submit_report_received.py
@@ -236,6 +236,95 @@ class TestSubmitReportCreatesCase:
         ), "Expected no VulnerabilityCase when receiving actor not in to"
 
 
+class TestSubmitReportAutoCreateCasePolicy:
+    """auto_create_case policy gating of SubmitReportReceivedUseCase (CM-15-001)."""
+
+    VENDOR_ID = "https://example.org/actors/vendor"
+    FINDER_ID = "https://example.org/users/finder"
+    REPORT_ID = "https://example.org/reports/r-policy-1"
+    OFFER_ID = "https://example.org/activities/offer-policy-1"
+
+    def _make_event_and_dl(self):
+        from vultron.core.models.case_actor import VultronCaseActor
+
+        report = VultronReport(id_=self.REPORT_ID)
+        activity = VultronActivity(
+            id_=self.OFFER_ID,
+            type_="Offer",
+            actor=self.FINDER_ID,
+            to=[self.VENDOR_ID],
+        )
+        event = SubmitReportReceivedEvent(
+            semantic_type=MessageSemantics.SUBMIT_REPORT,
+            activity_id=self.OFFER_ID,
+            actor_id=self.FINDER_ID,
+            object_=report,
+            activity=activity,
+            receiving_actor_id=self.VENDOR_ID,
+        )
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        dl.save(VultronCaseActor(id_=self.VENDOR_ID))
+        return event, dl
+
+    def test_auto_create_disabled_stores_report_and_offer_no_case(self):
+        """AC-2: auto_create_case=False stores report + Offer but no case."""
+        from vultron.core.models.actor_config import ActorConfig
+
+        event, dl = self._make_event_and_dl()
+        SubmitReportReceivedUseCase(
+            dl,
+            event,
+            trigger_activity=TriggerActivityAdapter(dl),
+            actor_config=ActorConfig(auto_create_case=False),
+        ).execute()
+
+        # Report and Offer(Report) activity are persisted.
+        assert dl.read(self.REPORT_ID) is not None
+        offer_ids = [row.get("id_") for row in dl.get_all("Offer")]
+        assert self.OFFER_ID in offer_ids
+        # No VulnerabilityCase is created.
+        assert dl.get_all("VulnerabilityCase") == []
+
+    def test_auto_create_disabled_leaves_outbox_empty(self):
+        """AC-2: auto_create_case=False leaves the receiver's outbox empty."""
+        from vultron.core.models.actor_config import ActorConfig
+
+        event, dl = self._make_event_and_dl()
+        SubmitReportReceivedUseCase(
+            dl,
+            event,
+            trigger_activity=TriggerActivityAdapter(dl),
+            actor_config=ActorConfig(auto_create_case=False),
+        ).execute()
+
+        assert dl.outbox_list() == []
+
+    def test_auto_create_enabled_creates_case(self):
+        """AC-1: auto_create_case=True (explicit) still creates the case."""
+        from vultron.core.models.actor_config import ActorConfig
+
+        event, dl = self._make_event_and_dl()
+        dl.save(VultronReport(id_=self.REPORT_ID))
+        SubmitReportReceivedUseCase(
+            dl,
+            event,
+            trigger_activity=TriggerActivityAdapter(dl),
+            actor_config=ActorConfig(auto_create_case=True),
+        ).execute()
+
+        assert len(dl.get_all("VulnerabilityCase")) >= 1
+
+    def test_no_actor_config_creates_case(self):
+        """AC-1: absent ActorConfig preserves always-create behavior."""
+        event, dl = self._make_event_and_dl()
+        dl.save(VultronReport(id_=self.REPORT_ID))
+        SubmitReportReceivedUseCase(
+            dl, event, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
+
+        assert len(dl.get_all("VulnerabilityCase")) >= 1
+
+
 class TestOfferAddressingSemantics:
     """Tests for HP-09-001 / HP-09-002: Offer(Report) to/cc addressing semantics."""
 

--- a/vultron/core/behaviors/case/nodes/__init__.py
+++ b/vultron/core/behaviors/case/nodes/__init__.py
@@ -69,6 +69,7 @@ from vultron.core.behaviors.case.nodes.delegation import (
     ResolveCaseManagerOfferContextNode,
 )
 from vultron.core.behaviors.case.nodes.conditions import (
+    CheckAutoCaseCreationEnabledNode,
     CheckCaseAlreadyExists,
     CheckCaseExistsForReport,
     CheckIsCaseManagerNode,
@@ -105,6 +106,7 @@ __all__ = [
     "EmitAcceptCaseInviteNode",
     "ProposeCaseToActorNode",
     # conditions
+    "CheckAutoCaseCreationEnabledNode",
     "CheckCaseAlreadyExists",
     "CheckCaseExistsForReport",
     "CheckIsCaseManagerNode",

--- a/vultron/core/behaviors/case/nodes/conditions.py
+++ b/vultron/core/behaviors/case/nodes/conditions.py
@@ -27,14 +27,71 @@ constructing the tree would raise ``AttributeError`` before any BT node runs,
 making a runtime validation node unreachable and redundant.
 """
 
+import logging
 from typing import Any
 
 import py_trees
 from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerCondition
+from vultron.core.models.actor_config import ActorConfig
 from vultron.core.models.protocols import is_case_model
 from vultron.core.use_cases._helpers import _resolve_case_manager_id
+
+
+class CheckAutoCaseCreationEnabledNode(py_trees.behaviour.Behaviour):
+    """Gate case creation on the actor's ``auto_create_case`` policy.
+
+    Returns ``SUCCESS`` when the local actor's :class:`ActorConfig` has
+    ``auto_create_case`` set (the ADR-0015 Option 4 default), allowing the
+    downstream case-creation subtree to run.  Returns ``FAILURE`` when
+    ``auto_create_case`` is ``False``, so the enclosing ``Sequence`` exits
+    without creating a ``VulnerabilityCase`` — enabling the pre-case ACK
+    (``Read(Offer(Report))``) protocol path (CM-15-001, ADR-0015 Option 3).
+
+    The policy is supplied as a constructor argument rather than read from
+    the blackboard so it travels with the tree the same way
+    ``default_case_roles`` does (see ``CreateCaseOwnerParticipant``).  When no
+    ``ActorConfig`` is supplied the node defaults to enabled, preserving the
+    historical always-create behavior for callers that predate the flag.
+
+    Per specs/case-management.yaml CM-15-001.
+    """
+
+    # Declare the managed logger type so subclass log calls are type-checked
+    # against the stdlib logging.Logger API (not py_trees.logging.Logger).
+    logger: logging.Logger  # type: ignore[assignment]
+
+    def __init__(
+        self,
+        actor_config: ActorConfig | None = None,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self.logger = logging.getLogger(  # type: ignore[assignment]
+            f"{self.__class__.__module__}.{self.__class__.__name__}"
+        )
+        self.actor_config = actor_config
+
+    def update(self) -> Status:
+        auto_create = (
+            self.actor_config.auto_create_case
+            if self.actor_config is not None
+            else True
+        )
+        if auto_create:
+            self.logger.debug(
+                "%s: auto_create_case enabled — proceeding with case creation",
+                self.name,
+            )
+            return Status.SUCCESS
+
+        self.logger.info(
+            "%s: auto_create_case disabled — deferring case creation "
+            "(pre-case ACK path)",
+            self.name,
+        )
+        return Status.FAILURE
 
 
 class CheckCaseAlreadyExists(DataLayerCondition):

--- a/vultron/core/behaviors/case/receive_report_case_tree.py
+++ b/vultron/core/behaviors/case/receive_report_case_tree.py
@@ -31,19 +31,21 @@ The tree is structurally similar to the ValidationActions subsequence of
 
 Structure (CM-14 canonical order):
 
-    ReceiveReportCaseBT (Selector)
-    ├─ CheckCaseExistsForReport          # Early exit if case already created
-    └─ ReceiveReportCaseFlow (Sequence)
-       ├─ CreateCaseNode                 # Create VulnerabilityCase; write case_id
-       ├─ CreateCaseOwnerParticipant     # Receiver participant (RM.RECEIVED)
-       ├─ InitializeDefaultEmbargoNode   # Create default embargo; seed owner SIGNATORY
-       ├─ CreateCaseActivity             # Queue Create(Case) BEFORE reporter add
-       ├─ UpdateActorOutbox              # Flush Create(Case) to outbox
-       ├─ CreateCaseParticipantNode      # Reporter participant (RM.ACCEPTED); seed SIGNATORY
-       ├─ CreateCaseActorNode            # Spawn Case Actor; write case_actor_id
-       ├─ ProposeCaseToActorNode         # Send Create(as_CaseProposal) to Case Actor
-       ├─ SendOfferCaseManagerRoleNode   # Offer CASE_MANAGER role to Case Actor
-       └─ UpdateActorOutbox (Offer)      # Flush Offer+Proposal to outbox
+    ReceiveReportCaseBT (Sequence)
+    ├─ CheckAutoCaseCreationEnabledNode  # Gate on auto_create_case policy
+    └─ ReceiveReportCaseSelector (Selector)
+       ├─ CheckCaseExistsForReport          # Early exit if case already created
+       └─ ReceiveReportCaseFlow (Sequence)
+          ├─ CreateCaseNode                 # Create VulnerabilityCase; write case_id
+          ├─ CreateCaseOwnerParticipant     # Receiver participant (RM.RECEIVED)
+          ├─ InitializeDefaultEmbargoNode   # Create default embargo; seed owner SIGNATORY
+          ├─ CreateCaseActivity             # Queue Create(Case) BEFORE reporter add
+          ├─ UpdateActorOutbox              # Flush Create(Case) to outbox
+          ├─ CreateCaseParticipantNode      # Reporter participant (RM.ACCEPTED); seed SIGNATORY
+          ├─ CreateCaseActorNode            # Spawn Case Actor; write case_actor_id
+          ├─ ProposeCaseToActorNode         # Send Create(as_CaseProposal) to Case Actor
+          ├─ SendOfferCaseManagerRoleNode   # Offer CASE_MANAGER role to Case Actor
+          └─ UpdateActorOutbox (Offer)      # Flush Offer+Proposal to outbox
 
 Note: No canonical ledger commit happens here.  The vendor actor is not the
 CaseActor and MUST NOT commit canonical case-ledger entries.  The CaseActor
@@ -87,6 +89,7 @@ from vultron.core.behaviors.case.embargo_tree import (
     InitializeDefaultEmbargoNode,
 )
 from vultron.core.behaviors.case.nodes import (
+    CheckAutoCaseCreationEnabledNode,
     CheckCaseExistsForReport,
     ProposeCaseToActorNode,
     UpdateActorOutbox,
@@ -195,12 +198,27 @@ def create_receive_report_case_tree(
         ],
     )
 
-    root = py_trees.composites.Selector(
-        name="ReceiveReportCaseBT",
+    case_creation_selector = py_trees.composites.Selector(
+        name="ReceiveReportCaseSelector",
         memory=False,
         children=[
             CheckCaseExistsForReport(report_id=report_id),
             receive_report_case_flow,
+        ],
+    )
+
+    # Gate the whole case-creation subtree on the actor's auto_create_case
+    # policy (CM-15-001).  The gate is placed in a Sequence (not the idempotency
+    # Selector) so that a genuine case-creation FAILURE still propagates as
+    # FAILURE — a policy-driven skip returns FAILURE at the gate before any
+    # DataLayer write, while the success path leaves the Selector's status
+    # untouched.
+    root = py_trees.composites.Sequence(
+        name="ReceiveReportCaseBT",
+        memory=False,
+        children=[
+            CheckAutoCaseCreationEnabledNode(actor_config=actor_config),
+            case_creation_selector,
         ],
     )
 

--- a/vultron/core/models/actor_config.py
+++ b/vultron/core/models/actor_config.py
@@ -38,9 +38,23 @@ class ActorConfig(BaseModel):
             creates or receives ownership of a ``VulnerabilityCase``.
             Defaults to an empty list; ``CVDRole.CASE_OWNER`` is always
             appended at participant-creation time (BTND-05-002).
+        auto_create_case: When ``True`` (default), create a
+            ``VulnerabilityCase`` immediately on ``Offer(Report)`` receipt
+            per ADR-0015 (Option 4).  When ``False``, defer case creation so
+            the receiver can send a pre-case ACK (``Read(Offer(Report))``)
+            before deciding to accept or reject (ADR-0015 Option 3;
+            CM-15-001, issue #1133).
     """
 
     default_case_roles: list[CVDRole] = Field(default_factory=list)
+    auto_create_case: bool = Field(
+        default=True,
+        description=(
+            "When True (default), create a VulnerabilityCase immediately on "
+            "Offer(Report) receipt per ADR-0015. When False, defer case "
+            "creation to allow a pre-case ACK (Read(Offer(Report))) first."
+        ),
+    )
 
     @field_serializer("default_case_roles")
     def _serialize_default_case_roles(self, value: list[CVDRole]) -> list[str]:

--- a/vultron/core/use_cases/received/report.py
+++ b/vultron/core/use_cases/received/report.py
@@ -18,6 +18,7 @@ from vultron.core.ports.case_persistence import CasePersistence
 from vultron.errors import VultronValidationError
 
 if TYPE_CHECKING:
+    from vultron.core.models.actor_config import ActorConfig
     from vultron.core.ports.sync_activity import SyncActivityPort
     from vultron.core.ports.trigger_activity import TriggerActivityPort
 
@@ -96,6 +97,7 @@ def _run_submit_report_case_creation(
     report_id: str,
     trigger_activity: "TriggerActivityPort | None" = None,
     sync_port: "SyncActivityPort | None" = None,
+    actor_config: "ActorConfig | None" = None,
 ) -> None:
     from py_trees.common import Status
 
@@ -119,6 +121,7 @@ def _run_submit_report_case_creation(
         report_id=report_id,
         offer_id=request.activity_id,
         reporter_actor_id=request.actor_id,
+        actor_config=actor_config,
     )
     result = bridge.execute_with_setup(
         tree,
@@ -189,14 +192,20 @@ class SubmitReportReceivedUseCase:
         request: SubmitReportReceivedEvent,
         trigger_activity: "TriggerActivityPort | None" = None,
         sync_port: "SyncActivityPort | None" = None,
+        actor_config: "ActorConfig | None" = None,
     ) -> None:
         self._dl = dl
         self._request: SubmitReportReceivedEvent = request
         self._trigger_activity = trigger_activity
         self._sync_port = sync_port
+        self._actor_config = actor_config
 
     def execute(self) -> None:
         request = self._request
+        # The report and Offer(Report) activity are stored unconditionally so
+        # that a receiver with auto_create_case=False still retains the data
+        # needed for a subsequent pre-case ACK (Read(Offer(Report))) or an
+        # explicit accept/reject decision (CM-15-001).
         _store_submit_report_dependencies(self._dl, request)
         if not request.report_id:
             return
@@ -215,6 +224,26 @@ class SubmitReportReceivedUseCase:
         ):
             return
 
+        # Routing-level policy short-circuit: when the receiver opts out of
+        # automatic case creation, do not even invoke the case-creation BT.
+        # This is a dispatch decision (like the recipient checks above), so a
+        # deliberate policy skip is logged at INFO rather than surfacing as a
+        # case-creation FAILURE.  The BT also carries an in-tree
+        # CheckAutoCaseCreationEnabledNode gate for any caller that invokes the
+        # tree directly (CM-15-001, ADR-0015 Option 3).
+        if (
+            self._actor_config is not None
+            and not self._actor_config.auto_create_case
+        ):
+            logger.info(
+                "SubmitReportReceivedUseCase: auto_create_case disabled for "
+                "actor '%s' — stored report '%s' and Offer without creating a "
+                "case (pre-case ACK path)",
+                receiving_actor_id,
+                request.report_id,
+            )
+            return
+
         _run_submit_report_case_creation(
             self._dl,
             request,
@@ -222,6 +251,7 @@ class SubmitReportReceivedUseCase:
             request.report_id,
             trigger_activity=self._trigger_activity,
             sync_port=self._sync_port,
+            actor_config=self._actor_config,
         )
 
 


### PR DESCRIPTION
- Closes #1272

## Summary

Adds a configurable `auto_create_case` policy to `ActorConfig` (default `True`)
that gates automatic `VulnerabilityCase` creation on `Offer(Report)` receipt,
enabling the ADR-0015 Option 3 pre-case ACK (`Read(Offer(Report))`) protocol
path (CM-15-001). The default preserves existing always-create behavior.

## Changes

- `vultron/core/models/actor_config.py`: add `auto_create_case: bool = True`.
- `vultron/core/behaviors/case/nodes/conditions.py`: add
  `CheckAutoCaseCreationEnabledNode` (SUCCESS when enabled, FAILURE when
  disabled; defaults to enabled when no config supplied).
- `vultron/core/behaviors/case/nodes/__init__.py`: re-export the new node.
- `vultron/core/behaviors/case/receive_report_case_tree.py`: wrap the root in
  `Sequence[gate, Selector[...]]`. The gate lives in a Sequence (not the
  idempotency Selector) so a genuine case-creation FAILURE still propagates
  instead of being masked; a policy skip fails-safe at the gate before any
  DataLayer write.
- `vultron/core/use_cases/received/report.py`: thread `actor_config` through
  `SubmitReportReceivedUseCase` and `_run_submit_report_case_creation`; add a
  routing-level short-circuit (analogous to the existing recipient guards) so a
  deliberate skip logs at INFO rather than as a case-creation error. Report and
  Offer are still stored unconditionally.
- `specs/case-management.yaml`: reword CM-15-001 to specify observable behavior
  (no case created, outbox unchanged) rather than call path, blessing either
  enforcement location. See design note below.

## Verification

- All 4438 unit tests pass (16 new), 38 skipped, 2 xfailed
- Black, flake8, mypy, pyright clean

## Design notes

- The issue body proposed gating inside the BT and assumed `ActorConfig` was on
  the blackboard; in fact it flows as a constructor arg (like
  `default_case_roles`), and CM-15-001 as originally worded ("MUST NOT invoke
  the tree") conflicted with an in-tree gate. Reconciled in favor of the
  codebase's BT-first architecture by specifying CM-15-001 in terms of
  behavior and implementing both enforcement points (defense-in-depth). See the
  clarifying comment on #1272.
- **Scope boundary → #1319:** no production dispatch path resolves a per-actor
  `ActorConfig` yet, so `auto_create_case=False` is currently reachable only via
  injected config (covered by unit tests). Runtime resolution/wiring and the
  vendor seed-config that #1221 needs are tracked in #1319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)