### PR TITLE
impl: add EvaluateDefaultRolesNode (CM-15-003 Evaluator call-out point)

### DIFF
--- a/notes/coordination-agents.md
+++ b/notes/coordination-agents.md
@@ -345,6 +345,12 @@ FUZZ-08a-quart (#1266) — Reclassify remaining 17 Sentinel-labeled nodes
                            (likely all become Retriever or ProtocolInternal)
 
 FUZZ-08d — All Evaluator-shaped call-out points (cross-domain)
+         Prototype instance landed in #1330 (issue #1299):
+           EvaluateDefaultRolesNode (Evaluator, CM-16-003) —
+             vultron/core/behaviors/case/nodes/actor.py
+             Writes suggested_roles=[CVDRole.VENDOR] to blackboard;
+             call-out point for actor role assignment in the
+             Offer(Actor, Case) received-side BT.
 FUZZ-08e — All Retriever-shaped call-out points (cross-domain)
 FUZZ-08f (#1175) — All Sentinel-shaped call-out points (cross-domain)
                    [scope likely zero after FUZZ-08a-quart]

--- a/plan/history/2607/implementation/ISSUE-1299.md
+++ b/plan/history/2607/implementation/ISSUE-1299.md
@@ -1,0 +1,10 @@
+---
+source: ISSUE-1299
+timestamp: '2026-07-10T16:31:57.522615+00:00'
+title: Add EvaluateDefaultRolesNode — Evaluator BT call-out point for actor role assignment
+type: implementation
+---
+
+## Issue #1299 — impl: add EvaluateDefaultRolesNode
+
+Added EvaluateDefaultRolesNode (ADR-0024 Evaluator shape) to the CaseActor inbox BT for Offer(Actor, Case) processing. Prototype writes [CVDRole.VENDOR] to blackboard (CM-15-003). Wired before EmitOfferCaseParticipantToOwnerNode in create_recommend_actor_to_case_received_tree. PR: <https://github.com/CERTCC/Vultron/pull/1330>

--- a/test/core/behaviors/case/test_suggest_actor_tree.py
+++ b/test/core/behaviors/case/test_suggest_actor_tree.py
@@ -19,7 +19,7 @@ Covers:
 - create_recommend_actor_to_case_received_tree
 - create_accept_actor_recommendation_received_tree
 - create_reject_actor_recommendation_received_tree
-- EvaluateDefaultRolesNode (AC-1 through AC-3, CM-15-003)
+- EvaluateDefaultRolesNode (AC-1 through AC-3, CM-16-003)
 
 Per specs/behavior-tree-integration.yaml BT-15-001, BTND-02-001 (memory=False),
 ADR-0026/CM-16.
@@ -49,7 +49,7 @@ _CASE_ID = "https://example.org/cases/case-1"
 
 
 class TestEvaluateDefaultRolesNode:
-    """Unit tests for EvaluateDefaultRolesNode (AC-1, AC-2, AC-3, CM-15-003)."""
+    """Unit tests for EvaluateDefaultRolesNode (AC-1, AC-2, AC-3, CM-16-003)."""
 
     def setup_method(self):
         py_trees.blackboard.Blackboard.enable_activity_stream()

--- a/test/core/behaviors/case/test_suggest_actor_tree.py
+++ b/test/core/behaviors/case/test_suggest_actor_tree.py
@@ -19,12 +19,14 @@ Covers:
 - create_recommend_actor_to_case_received_tree
 - create_accept_actor_recommendation_received_tree
 - create_reject_actor_recommendation_received_tree
+- EvaluateDefaultRolesNode (AC-1 through AC-3, CM-15-003)
 
 Per specs/behavior-tree-integration.yaml BT-15-001, BTND-02-001 (memory=False),
 ADR-0026/CM-16.
 """
 
 import py_trees
+from py_trees.common import Status
 
 from vultron.core.behaviors.case.suggest_actor_tree import (
     EmitAcceptActorRecommendationNode,
@@ -34,12 +36,66 @@ from vultron.core.behaviors.case.suggest_actor_tree import (
     create_recommend_actor_to_case_received_tree,
     create_reject_actor_recommendation_received_tree,
 )
-from vultron.core.behaviors.case.nodes.actor import EmitInviteActorToCaseNode
+from vultron.core.behaviors.case.nodes.actor import (
+    EmitInviteActorToCaseNode,
+    EvaluateDefaultRolesNode,
+)
+from vultron.core.states.roles import CVDRole
 
 _REC_ID = "https://example.org/recommendations/rec-1"
 _RECOMMENDER = "https://example.org/actors/recommender"
 _RECOMMENDED = "https://example.org/actors/recommended"
 _CASE_ID = "https://example.org/cases/case-1"
+
+
+class TestEvaluateDefaultRolesNode:
+    """Unit tests for EvaluateDefaultRolesNode (AC-1, AC-2, AC-3, CM-15-003)."""
+
+    def setup_method(self):
+        py_trees.blackboard.Blackboard.enable_activity_stream()
+        self.node = EvaluateDefaultRolesNode(
+            suggested_actor_id=_RECOMMENDED,
+            case_id=_CASE_ID,
+        )
+        self.node.setup()
+        self.node.initialise()
+
+    def teardown_method(self):
+        py_trees.blackboard.Blackboard.disable_activity_stream()
+
+    def test_node_exists(self):
+        """AC-1: EvaluateDefaultRolesNode exists in the BT node library."""
+        assert self.node is not None
+
+    def test_node_name_defaults_to_class_name(self):
+        assert self.node.name == "EvaluateDefaultRolesNode"
+
+    def test_node_stores_suggested_actor_id(self):
+        assert self.node.suggested_actor_id == _RECOMMENDED
+
+    def test_node_stores_case_id(self):
+        assert self.node.case_id == _CASE_ID
+
+    def test_returns_success_unconditionally(self):
+        """AC-3: returns SUCCESS unconditionally in the prototype."""
+        result = self.node.update()
+        assert result == Status.SUCCESS
+
+    def test_writes_vendor_role_to_blackboard(self):
+        """AC-2: writes suggested_roles = [CVDRole.VENDOR] to blackboard."""
+        self.node.update()
+        raw = py_trees.blackboard.Blackboard.storage.get("/suggested_roles")
+        assert raw == [
+            CVDRole.VENDOR
+        ], f"Expected [CVDRole.VENDOR] in suggested_roles, got {raw!r}"
+
+    def test_custom_name_accepted(self):
+        node = EvaluateDefaultRolesNode(
+            suggested_actor_id=_RECOMMENDED,
+            case_id=_CASE_ID,
+            name="MyCustomName",
+        )
+        assert node.name == "MyCustomName"
 
 
 class TestRecommendActorToCaseReceivedTree:
@@ -65,25 +121,69 @@ class TestRecommendActorToCaseReceivedTree:
             "(BTND-02-001 stateless-ticking invariant)"
         )
 
+    def _flatten_tree_types(self):
+        """Collect all node types via depth-first walk."""
+        types = []
+        for node in self.tree.iterate():
+            types.append(type(node))
+        return types
+
+    def test_has_evaluate_default_roles_node(self):
+        """AC-4 (tree wiring): EvaluateDefaultRolesNode appears in the tree."""
+        all_types = self._flatten_tree_types()
+        assert (
+            EvaluateDefaultRolesNode in all_types
+        ), "RecommendActorToCaseBT must contain EvaluateDefaultRolesNode"
+
+    def test_evaluate_roles_node_before_emit_node(self):
+        """EvaluateDefaultRolesNode must precede EmitOfferCaseParticipantToOwnerNode."""
+        nodes = list(self.tree.iterate())
+        types = [type(n) for n in nodes]
+        eval_idx = next(
+            (i for i, t in enumerate(types) if t is EvaluateDefaultRolesNode),
+            None,
+        )
+        emit_idx = next(
+            (
+                i
+                for i, t in enumerate(types)
+                if t is EmitOfferCaseParticipantToOwnerNode
+            ),
+            None,
+        )
+        assert eval_idx is not None, "EvaluateDefaultRolesNode not found"
+        assert (
+            emit_idx is not None
+        ), "EmitOfferCaseParticipantToOwnerNode not found"
+        assert eval_idx < emit_idx, (
+            "EvaluateDefaultRolesNode must appear before "
+            "EmitOfferCaseParticipantToOwnerNode in tree ordering"
+        )
+
+    def test_evaluate_node_carries_recommended_id(self):
+        nodes = [
+            n
+            for n in self.tree.iterate()
+            if isinstance(n, EvaluateDefaultRolesNode)
+        ]
+        assert nodes, "Expected EvaluateDefaultRolesNode in tree"
+        node = nodes[0]
+        assert node.suggested_actor_id == _RECOMMENDED
+        assert node.case_id == _CASE_ID
+
     def test_has_emit_offer_case_participant_node(self):
         """Effect nodes must include EmitOfferCaseParticipantToOwnerNode."""
-        flat_types = []
-        for child in self.tree.children:
-            if isinstance(child, py_trees.composites.Sequence):
-                flat_types.extend(type(gc) for gc in child.children)
-            else:
-                flat_types.append(type(child))
-        assert EmitOfferCaseParticipantToOwnerNode in flat_types or any(
-            isinstance(c, EmitOfferCaseParticipantToOwnerNode)
-            for c in self.tree.children
+        all_types = self._flatten_tree_types()
+        assert (
+            EmitOfferCaseParticipantToOwnerNode in all_types
         ), "RecommendActorToCaseBT must contain EmitOfferCaseParticipantToOwnerNode"
 
     def test_emit_node_carries_recommendation_id(self):
         """The emit node must carry the original recommendation ID as origin."""
         emit_nodes = [
-            c
-            for c in self.tree.children
-            if isinstance(c, EmitOfferCaseParticipantToOwnerNode)
+            n
+            for n in self.tree.iterate()
+            if isinstance(n, EmitOfferCaseParticipantToOwnerNode)
         ]
         assert (
             emit_nodes

--- a/vultron/adapters/driven/trigger_activity_adapter/actors.py
+++ b/vultron/adapters/driven/trigger_activity_adapter/actors.py
@@ -174,7 +174,7 @@ class _ActorsMixin:
 
         Transforms the original Offer(Actor, Case) from a recommending
         participant into an Offer(CaseParticipant) addressed to the Case Owner.
-        ``roles`` defaults to ``[CVDRole.VENDOR]`` when ``None`` (CM-15-003).
+        ``roles`` defaults to ``[CVDRole.VENDOR]`` when ``None`` (CM-16-003).
         ``origin`` carries the original Offer ID for causal traceability
         (CM-16-004).
         """

--- a/vultron/adapters/driven/trigger_activity_adapter/actors.py
+++ b/vultron/adapters/driven/trigger_activity_adapter/actors.py
@@ -168,11 +168,13 @@ class _ActorsMixin:
         origin: str | None = None,
         to: list[str] | None = None,
         id_: str | None = None,
+        roles: list | None = None,
     ) -> tuple[str, dict[str, Any]]:
         """Create and persist an Offer(CaseParticipant{actor, roles}, Case).
 
         Transforms the original Offer(Actor, Case) from a recommending
         participant into an Offer(CaseParticipant) addressed to the Case Owner.
+        ``roles`` defaults to ``[CVDRole.VENDOR]`` when ``None`` (CM-15-003).
         ``origin`` carries the original Offer ID for causal traceability
         (CM-16-004).
         """
@@ -184,6 +186,7 @@ class _ActorsMixin:
         activity = offer_case_participant_activity(
             recommended=CoreActor(id_=recommended_id),
             target=case_id,
+            roles=roles,
             **extra,
         )
         try:

--- a/vultron/core/behaviors/case/nodes/__init__.py
+++ b/vultron/core/behaviors/case/nodes/__init__.py
@@ -50,6 +50,7 @@ from typing import TYPE_CHECKING
 from vultron.core.behaviors.case.nodes.actor import (
     EmitAcceptCaseInviteNode,
     EmitInviteActorToCaseNode,
+    EvaluateDefaultRolesNode,
     ProposeCaseToActorNode,
 )
 from vultron.core.behaviors.case.nodes.case_setup import (
@@ -104,6 +105,7 @@ __all__ = [
     # actor (leaf nodes)
     "EmitInviteActorToCaseNode",
     "EmitAcceptCaseInviteNode",
+    "EvaluateDefaultRolesNode",
     "ProposeCaseToActorNode",
     # conditions
     "CheckAutoCaseCreationEnabledNode",

--- a/vultron/core/behaviors/case/nodes/actor.py
+++ b/vultron/core/behaviors/case/nodes/actor.py
@@ -20,7 +20,7 @@ invitation and invite-acceptance workflows, and for applying received
 ownership-transfer decisions to the case record.
 
 Also provides :class:`EvaluateDefaultRolesNode`, the ADR-0024 Evaluator
-call-out point that assigns default roles for a suggested actor (CM-15-003).
+call-out point that assigns default roles for a suggested actor (CM-16-003).
 
 Composite subtrees assembling these leaf nodes are defined in the sibling
 ``actor_trigger_trees.py`` and ``ownership_transfer_tree.py`` modules at
@@ -372,7 +372,7 @@ class ProposeCaseToActorNode(DataLayerAction):
 
 
 class EvaluateDefaultRolesNode(py_trees.behaviour.Behaviour):
-    """Assign default CVD roles for a suggested actor (CM-15-003).
+    """Assign default CVD roles for a suggested actor (CM-16-003).
 
     **ADR-0024 shape: Evaluator** — receives a bounded input (actor + case
     context via constructor) and writes a bounded recommendation

--- a/vultron/core/behaviors/case/nodes/actor.py
+++ b/vultron/core/behaviors/case/nodes/actor.py
@@ -19,6 +19,9 @@ Provides leaf action nodes that emit outbound activities for actor
 invitation and invite-acceptance workflows, and for applying received
 ownership-transfer decisions to the case record.
 
+Also provides :class:`EvaluateDefaultRolesNode`, the ADR-0024 Evaluator
+call-out point that assigns default roles for a suggested actor (CM-15-003).
+
 Composite subtrees assembling these leaf nodes are defined in the sibling
 ``actor_trigger_trees.py`` and ``ownership_transfer_tree.py`` modules at
 the process-area root per BTND-07-003:
@@ -28,12 +31,14 @@ the process-area root per BTND-07-003:
 - ``create_accept_ownership_transfer_tree``
 """
 
+import logging
 from typing import Any, cast
 
 import py_trees
 from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.states.roles import CVDRole
 from vultron.core.models.protocols import is_case_model
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.use_cases._helpers import _as_id
@@ -362,5 +367,61 @@ class ProposeCaseToActorNode(DataLayerAction):
             activity_id,
             case_actor_id,
             case_id,
+        )
+        return Status.SUCCESS
+
+
+class EvaluateDefaultRolesNode(py_trees.behaviour.Behaviour):
+    """Assign default CVD roles for a suggested actor (CM-15-003).
+
+    **ADR-0024 shape: Evaluator** — receives a bounded input (actor + case
+    context via constructor) and writes a bounded recommendation
+    (``suggested_roles``) to the blackboard.
+
+    Prototype behaviour: always writes ``[CVDRole.VENDOR]`` and returns
+    ``SUCCESS``.  Future implementations can inspect actor metadata, prior
+    case history, or external configuration to choose more specific roles.
+
+    Args:
+        suggested_actor_id: The actor URI being suggested to the case.
+        case_id: The case URI, provided as context for future policy logic.
+        name: Optional display name for the node.
+
+    Blackboard outputs (WRITE):
+        - ``suggested_roles`` (list[CVDRole]): always non-empty; defaults to
+          ``[CVDRole.VENDOR]``.
+
+    Returns ``SUCCESS`` unconditionally in the prototype implementation.
+    """
+
+    logger: logging.Logger  # type: ignore[assignment]
+
+    def __init__(
+        self,
+        suggested_actor_id: str,
+        case_id: str,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self.suggested_actor_id = suggested_actor_id
+        self.case_id = case_id
+        self.logger = logging.getLogger(  # type: ignore[assignment]
+            f"{self.__class__.__module__}.{self.__class__.__name__}"
+        )
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard = self.attach_blackboard_client(name=self.name)
+        self.blackboard.register_key(
+            key="suggested_roles", access=py_trees.common.Access.WRITE
+        )
+
+    def update(self) -> Status:
+        self.blackboard.suggested_roles = [CVDRole.VENDOR]
+        self.logger.debug(
+            "%s: assigned default roles [VENDOR] for actor '%s' in case '%s'",
+            self.name,
+            self.suggested_actor_id,
+            self.case_id,
         )
         return Status.SUCCESS

--- a/vultron/core/behaviors/case/suggest_actor_tree.py
+++ b/vultron/core/behaviors/case/suggest_actor_tree.py
@@ -282,7 +282,7 @@ def create_recommend_actor_to_case_received_tree(
 
     Commits a canonical ``CaseLedgerEntry`` for the received Offer
     (CM-16-002), evaluates default roles for the suggested actor
-    (CM-15-003), then transforms the offer to
+    (CM-16-003), then transforms the offer to
     ``Offer(CaseParticipant{actor, roles}, Case)`` with
     ``origin=recommendation_id`` and DMs it to the Case Owner
     (CM-16-003, CM-16-004).
@@ -291,7 +291,7 @@ def create_recommend_actor_to_case_received_tree(
 
         RecommendActorToCaseBT (Sequence, memory=False)
         ├── GuardedCommitCaseLedgerEntryBT   — record receipt (CLP-10-006)
-        ├── EvaluateDefaultRolesNode          — assign roles (CM-15-003)
+        ├── EvaluateDefaultRolesNode          — assign roles (CM-16-003)
         └── EmitOfferCaseParticipantToOwnerNode — transform + DM owner
 
     Args:

--- a/vultron/core/behaviors/case/suggest_actor_tree.py
+++ b/vultron/core/behaviors/case/suggest_actor_tree.py
@@ -36,12 +36,16 @@ from typing import cast
 import py_trees
 from py_trees.common import Status
 
-from vultron.core.behaviors.case.nodes.actor import EmitInviteActorToCaseNode
+from vultron.core.behaviors.case.nodes.actor import (
+    EmitInviteActorToCaseNode,
+    EvaluateDefaultRolesNode,
+)
 from vultron.core.behaviors.case.nodes.lifecycle import (
     create_receive_activity_tree,
 )
 from vultron.core.behaviors.helpers import DataLayerAction
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
+from vultron.core.states.roles import CVDRole
 
 logger = logging.getLogger(__name__)
 
@@ -55,9 +59,14 @@ class EmitOfferCaseParticipantToOwnerNode(DataLayerAction):
     """Transform Offer(Actor, Case) → Offer(CaseParticipant) and DM Case Owner.
 
     Uses ``trigger_activity_factory.offer_actor_to_case()`` with the
-    recommender_id, recommended_id, default roles, case_id, and case owner id.
+    recommender_id, recommended_id, roles from the blackboard (written by
+    :class:`~vultron.core.behaviors.case.nodes.actor.EvaluateDefaultRolesNode`),
+    case_id, and case owner id.
     The original offer ID is carried in the ``origin`` field so the Case Owner
     can trace the causal chain (CM-16-004).
+
+    Reads ``suggested_roles`` from the blackboard; falls back to
+    ``[CVDRole.VENDOR]`` when the key is absent.
 
     Returns SUCCESS on success, FAILURE if any required dependency is missing.
     """
@@ -76,6 +85,21 @@ class EmitOfferCaseParticipantToOwnerNode(DataLayerAction):
         self.recommended_id = recommended_id
         self.case_id = case_id
 
+    def setup(self, **kwargs) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="suggested_roles", access=py_trees.common.Access.READ
+        )
+
+    def _read_suggested_roles(self) -> list[CVDRole]:
+        try:
+            roles = self.blackboard.get("suggested_roles")
+            if isinstance(roles, list) and roles:
+                return roles
+        except KeyError:
+            pass
+        return [CVDRole.VENDOR]
+
     def update(self) -> Status:
         if self.datalayer is None or self.actor_id is None:
             self.feedback_message = "DataLayer or actor_id not available"
@@ -89,6 +113,7 @@ class EmitOfferCaseParticipantToOwnerNode(DataLayerAction):
             self.logger.error(self.feedback_message)
             return Status.FAILURE
 
+        roles = self._read_suggested_roles()
         try:
             case_obj = self.datalayer.read(self.case_id)
             raw_owner = getattr(case_obj, "attributed_to", None)
@@ -100,6 +125,7 @@ class EmitOfferCaseParticipantToOwnerNode(DataLayerAction):
                 actor=self.actor_id,
                 origin=self.recommendation_id,
                 to=[owner_id],
+                roles=roles,
             )
             cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
                 self.actor_id, activity_id
@@ -255,9 +281,18 @@ def create_recommend_actor_to_case_received_tree(
     """Received-side BT for Offer(Actor, Case) on the CaseActor inbox.
 
     Commits a canonical ``CaseLedgerEntry`` for the received Offer
-    (CM-16-002), then transforms it to ``Offer(CaseParticipant{actor,
-    roles=[VENDOR]}, Case)`` with ``origin=recommendation_id`` and DMs
-    it to the Case Owner (CM-16-003, CM-16-004).
+    (CM-16-002), evaluates default roles for the suggested actor
+    (CM-15-003), then transforms the offer to
+    ``Offer(CaseParticipant{actor, roles}, Case)`` with
+    ``origin=recommendation_id`` and DMs it to the Case Owner
+    (CM-16-003, CM-16-004).
+
+    Tree structure::
+
+        RecommendActorToCaseBT (Sequence, memory=False)
+        ├── GuardedCommitCaseLedgerEntryBT   — record receipt (CLP-10-006)
+        ├── EvaluateDefaultRolesNode          — assign roles (CM-15-003)
+        └── EmitOfferCaseParticipantToOwnerNode — transform + DM owner
 
     Args:
         recommendation_id: ID of the incoming ``Offer(Actor, Case)`` activity.
@@ -273,6 +308,10 @@ def create_recommend_actor_to_case_received_tree(
         case_id=case_id,
         precondition_guards=[],
         effect_nodes=[
+            EvaluateDefaultRolesNode(
+                suggested_actor_id=recommended_id,
+                case_id=case_id,
+            ),
             EmitOfferCaseParticipantToOwnerNode(
                 recommendation_id=recommendation_id,
                 recommender_id=recommender_id,

--- a/vultron/core/ports/trigger_activity.py
+++ b/vultron/core/ports/trigger_activity.py
@@ -316,7 +316,7 @@ class TriggerActivityPort(Protocol):
         Transforms the original ``Offer(Actor, Case)`` into an
         ``Offer(CaseParticipant{actor, roles}, Case)`` addressed to the
         Case Owner.  ``roles`` defaults to ``[CVDRole.VENDOR]`` when
-        ``None`` (CM-15-003).  ``origin`` carries the original recommender
+        ``None`` (CM-16-003).  ``origin`` carries the original recommender
         Offer ID so the Case Owner can trace the causal chain (CM-16-004).
         Returns ``(activity_id, activity_dict)``.
         """

--- a/vultron/core/ports/trigger_activity.py
+++ b/vultron/core/ports/trigger_activity.py
@@ -309,13 +309,15 @@ class TriggerActivityPort(Protocol):
         origin: str | None = None,
         to: list[str] | None = None,
         id_: str | None = None,
+        roles: list[Any] | None = None,
     ) -> tuple[str, dict[str, Any]]:
         """Create and persist an ``Offer(CaseParticipant, Case)`` activity.
 
         Transforms the original ``Offer(Actor, Case)`` into an
-        ``Offer(CaseParticipant{actor, roles=[VENDOR]}, Case)`` addressed to
-        the Case Owner.  ``origin`` carries the original recommender Offer ID
-        so the Case Owner can trace the causal chain (CM-16-004).
+        ``Offer(CaseParticipant{actor, roles}, Case)`` addressed to the
+        Case Owner.  ``roles`` defaults to ``[CVDRole.VENDOR]`` when
+        ``None`` (CM-15-003).  ``origin`` carries the original recommender
+        Offer ID so the Case Owner can trace the causal chain (CM-16-004).
         Returns ``(activity_id, activity_dict)``.
         """
         ...


### PR DESCRIPTION
- Closes #1299

## Summary

Adds `EvaluateDefaultRolesNode` — the ADR-0024 Evaluator shape BT node that assigns default CVD roles for a suggested actor when the CaseActor receives `Offer(Actor, Case)`. Prototype writes `[CVDRole.VENDOR]` to the blackboard; the node is a named call-out point replaceable by future policy-driven implementations (CM-15-003).

## Changes

- `vultron/core/behaviors/case/nodes/actor.py`: new `EvaluateDefaultRolesNode` — writes `suggested_roles=[CVDRole.VENDOR]` to blackboard, returns `SUCCESS` unconditionally; `setup()` registers WRITE key and calls `super().setup()`
- `vultron/core/behaviors/case/suggest_actor_tree.py`: `create_recommend_actor_to_case_received_tree` now includes `EvaluateDefaultRolesNode` before `EmitOfferCaseParticipantToOwnerNode` in `effect_nodes`; `EmitOfferCaseParticipantToOwnerNode` reads `suggested_roles` from blackboard via `_read_suggested_roles()`, falls back to `[CVDRole.VENDOR]`
- `vultron/core/ports/trigger_activity.py`: `offer_actor_to_case()` gains `roles: list[Any] | None = None`
- `vultron/adapters/driven/trigger_activity_adapter/actors.py`: `offer_actor_to_case()` threads `roles` to `offer_case_participant_activity()`
- `vultron/core/behaviors/case/nodes/__init__.py`: exports `EvaluateDefaultRolesNode`
- `test/core/behaviors/case/test_suggest_actor_tree.py`: 7 new unit tests (AC-1–AC-4); updated `TestRecommendActorToCaseReceivedTree` to use `tree.iterate()` depth-first walk

## Verification

- 24 unit tests pass (`test_suggest_actor_tree.py`)
- Full suite: 4464 passed, 38 skipped, 2 xfailed
- Black, flake8, mypy, pyright all clean