### PR TITLE
feat: resolve per-actor ActorConfig at dispatch time (issue #1319)

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1319.md
+++ b/plan/history/2607/implementation/ISSUE-1319.md
@@ -1,0 +1,10 @@
+---
+source: ISSUE-1319
+timestamp: '2026-07-10T16:47:59.132200+00:00'
+title: Resolve per-actor ActorConfig at dispatch time
+type: implementation
+---
+
+## Issue #1319 — Resolve per-actor ActorConfig at dispatch time so auto_create_case is honored in production
+
+Added `_resolve_actor_config()` and `_submit_report_port_factory()` to `inbox_port_factories.py`, wired into `make_dispatcher()` via a new `_SUBMIT_REPORT_SEMANTICS` set. `SubmitReportReceivedUseCase` now receives `actor_config` from `SeedConfig` at dispatch time so `auto_create_case=False` is honoured in real deployments. Four new tests including AC-2 end-to-end test through `DirectActivityDispatcher`. PR: <https://github.com/CERTCC/Vultron/pull/1331>

--- a/test/adapters/driving/fastapi/test_inbox_handler.py
+++ b/test/adapters/driving/fastapi/test_inbox_handler.py
@@ -502,6 +502,180 @@ def test_inbox_handler_uses_actor_dl_for_queue_pop_and_shared_dl_for_dispatch(
     ), "dispatch must be called with shared dl, not actor_dl"
 
 
+def test_submit_report_port_factory_injects_actor_config(monkeypatch):
+    """_submit_report_port_factory returns actor_config from SeedConfig.
+
+    When SeedConfig is available, the factory must include an
+    ``actor_config`` key so that ``SubmitReportReceivedUseCase`` can
+    honour the local actor's ``auto_create_case`` policy (CM-15-001,
+    issue #1319).
+    """
+    from vultron.core.models.actor_config import ActorConfig
+    from vultron.demo.seed_config import LocalActorConfig, SeedConfig
+    import vultron.adapters.driving.fastapi.inbox_port_factories as pf
+
+    fake_cfg = SeedConfig(
+        local_actor=LocalActorConfig(
+            name="Vendor",
+            actor_type="Organization",
+            auto_create_case=False,
+        )
+    )
+    monkeypatch.setattr(
+        pf, "_resolve_actor_config", lambda: fake_cfg.local_actor
+    )
+
+    real_dl = SqliteDataLayer("sqlite:///:memory:")
+    kwargs = pf._submit_report_port_factory(real_dl)
+
+    assert "actor_config" in kwargs, "factory must include actor_config"
+    assert isinstance(kwargs["actor_config"], ActorConfig)
+    assert kwargs["actor_config"].auto_create_case is False
+    assert "sync_port" in kwargs
+    assert "trigger_activity" in kwargs
+
+
+def test_submit_report_port_factory_omits_actor_config_when_unavailable(
+    monkeypatch,
+):
+    """_submit_report_port_factory omits actor_config when SeedConfig fails.
+
+    When SeedConfig cannot be loaded (e.g. env vars absent), the factory
+    must still return sync_port + trigger_activity and must NOT include an
+    ``actor_config`` key — so the use case falls back to always-create (CM-15-001).
+    """
+    import vultron.adapters.driving.fastapi.inbox_port_factories as pf
+
+    monkeypatch.setattr(pf, "_resolve_actor_config", lambda: None)
+
+    real_dl = SqliteDataLayer("sqlite:///:memory:")
+    kwargs = pf._submit_report_port_factory(real_dl)
+
+    assert "actor_config" not in kwargs
+    assert "sync_port" in kwargs
+    assert "trigger_activity" in kwargs
+
+
+def test_make_dispatcher_submit_report_uses_actor_config_factory(monkeypatch):
+    """make_dispatcher() must register _submit_report_port_factory for SUBMIT_REPORT.
+
+    SUBMIT_REPORT was moved out of _SYNC_AND_TRIGGER_PORT_SEMANTICS to
+    _SUBMIT_REPORT_SEMANTICS (issue #1319), so it must be wired to the
+    factory that also injects actor_config.
+    """
+    from vultron.adapters.driven.sync_activity_adapter import (
+        SyncActivityAdapter,
+    )
+    from vultron.adapters.driven.trigger_activity_adapter import (
+        TriggerActivityAdapter,
+    )
+    from vultron.core.models.actor_config import ActorConfig
+    from vultron.demo.seed_config import LocalActorConfig
+    import vultron.adapters.driving.fastapi.inbox_port_factories as pf
+
+    captured: dict = {}
+
+    def fake_get_dispatcher(use_case_map, port_factories=None):
+        captured["port_factories"] = port_factories
+        return Mock()
+
+    monkeypatch.setattr(ih, "get_dispatcher", fake_get_dispatcher)
+    monkeypatch.setattr(
+        pf,
+        "_resolve_actor_config",
+        lambda: LocalActorConfig(
+            name="Vendor", actor_type="Organization", auto_create_case=False
+        ),
+    )
+
+    ih.make_dispatcher()
+
+    sem = MessageSemantics.SUBMIT_REPORT
+    assert (
+        sem in captured["port_factories"]
+    ), "SUBMIT_REPORT must have a factory"
+
+    real_dl = SqliteDataLayer("sqlite:///:memory:")
+    kwargs = captured["port_factories"][sem](real_dl)
+
+    assert isinstance(kwargs.get("sync_port"), SyncActivityAdapter)
+    assert isinstance(kwargs.get("trigger_activity"), TriggerActivityAdapter)
+    assert isinstance(kwargs.get("actor_config"), ActorConfig)
+    assert kwargs["actor_config"].auto_create_case is False
+
+
+def test_make_dispatcher_ac2_auto_create_false_no_case_via_dispatcher(
+    monkeypatch,
+):
+    """AC-2: DirectActivityDispatcher honours auto_create_case=False end-to-end.
+
+    With _resolve_actor_config returning auto_create_case=False,
+    dispatching an inbound Offer(Report) via DirectActivityDispatcher must
+    store the report and Offer activity but must NOT create a
+    VulnerabilityCase and must leave the actor's outbox empty (CM-15-001,
+    issue #1319).
+    """
+    from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+    from vultron.core.models.activity import VultronActivity
+    from vultron.core.models.case_actor import VultronCaseActor
+    from vultron.core.models.events.report import SubmitReportReceivedEvent
+    from vultron.core.models.report import VultronReport
+    from vultron.demo.seed_config import LocalActorConfig
+    import vultron.adapters.driving.fastapi.inbox_port_factories as pf
+
+    VENDOR_ID = "https://example.org/actors/vendor-ac2"
+    FINDER_ID = "https://example.org/users/finder-ac2"
+    REPORT_ID = "https://example.org/reports/r-ac2"
+    OFFER_ID = "https://example.org/activities/offer-ac2"
+
+    # Inject auto_create_case=False via the factory that make_dispatcher uses.
+    monkeypatch.setattr(
+        pf,
+        "_resolve_actor_config",
+        lambda: LocalActorConfig(
+            name="Vendor", actor_type="Organization", auto_create_case=False
+        ),
+    )
+
+    # Build a real dispatcher the same way make_dispatcher() does, but
+    # without the full FastAPI lifespan — call make_dispatcher directly.
+    dispatcher = ih.make_dispatcher()
+
+    dl = SqliteDataLayer("sqlite:///:memory:")
+    dl.save(VultronCaseActor(id_=VENDOR_ID))
+
+    report = VultronReport(id_=REPORT_ID)
+    activity = VultronActivity(
+        id_=OFFER_ID,
+        type_="Offer",
+        actor=FINDER_ID,
+        to=[VENDOR_ID],
+    )
+    event = SubmitReportReceivedEvent(
+        semantic_type=MessageSemantics.SUBMIT_REPORT,
+        activity_id=OFFER_ID,
+        actor_id=FINDER_ID,
+        object_=report,
+        activity=activity,
+        receiving_actor_id=VENDOR_ID,
+    )
+
+    dispatcher.dispatch(event, dl)
+
+    # Report and Offer are persisted.
+    assert dl.read(REPORT_ID) is not None, "VulnerabilityReport must be stored"
+    offer_ids = [row.get("id_") for row in dl.get_all("Offer")]
+    assert OFFER_ID in offer_ids, "Offer activity must be stored"
+    # No case created.
+    assert (
+        dl.get_all("VulnerabilityCase") == []
+    ), "No VulnerabilityCase should be created when auto_create_case=False"
+    # Outbox must remain empty.
+    assert (
+        dl.outbox_list_for_actor(VENDOR_ID) == []
+    ), "Outbox must be empty when auto_create_case=False"
+
+
 def test_pending_case_queue_expiry_emits_question(monkeypatch):
     """AC-7: A replay Question is appended to the actor outbox on expiry.
 

--- a/vultron/adapters/driving/fastapi/inbox_handler.py
+++ b/vultron/adapters/driving/fastapi/inbox_handler.py
@@ -50,9 +50,11 @@ from vultron.adapters.driving.fastapi.inbox_port_factories import (  # noqa: F40
     _sync_port_factory,
     _trigger_activity_port_factory,
     _sync_and_trigger_port_factory,
+    _submit_report_port_factory,
     _SYNC_PORT_SEMANTICS,
     _TRIGGER_ACTIVITY_PORT_SEMANTICS,
     _SYNC_AND_TRIGGER_PORT_SEMANTICS,
+    _SUBMIT_REPORT_SEMANTICS,
 )
 
 # Re-export pending-queue helpers so existing callers and tests that
@@ -95,13 +97,14 @@ def make_dispatcher() -> ActivityDispatcher:
     :func:`init_dispatcher` so the global is set for backward-compatible
     callers such as the CLI.
     """
-    # Guard: the three semantics sets must be mutually disjoint.  An overlap
+    # Guard: all semantics sets must be mutually disjoint.  An overlap
     # would cause a silent dict.update() overwrite — exactly the class of bug
     # that #628 introduced — so fail fast with an actionable message.
     _all_sets = (
         _SYNC_PORT_SEMANTICS,
         _TRIGGER_ACTIVITY_PORT_SEMANTICS,
         _SYNC_AND_TRIGGER_PORT_SEMANTICS,
+        _SUBMIT_REPORT_SEMANTICS,
     )
     for i, left in enumerate(_all_sets):
         for right in _all_sets[i + 1 :]:
@@ -109,8 +112,10 @@ def make_dispatcher() -> ActivityDispatcher:
             if overlap:
                 raise AssertionError(
                     f"Port-semantics sets overlap: {overlap!r}. "
-                    "Add the semantic to _SYNC_AND_TRIGGER_PORT_SEMANTICS "
-                    "and remove it from both individual sets."
+                    "Each semantic must appear in exactly one set. "
+                    "For sync+trigger semantics use _SYNC_AND_TRIGGER_PORT_SEMANTICS; "
+                    "for semantics that also need extra ports (e.g. actor_config) "
+                    "create a dedicated set+factory pair like _SUBMIT_REPORT_SEMANTICS."
                 )
 
     port_factories: dict = {
@@ -127,6 +132,9 @@ def make_dispatcher() -> ActivityDispatcher:
             sem: _sync_and_trigger_port_factory
             for sem in _SYNC_AND_TRIGGER_PORT_SEMANTICS
         }
+    )
+    port_factories.update(
+        {sem: _submit_report_port_factory for sem in _SUBMIT_REPORT_SEMANTICS}
     )
     d = get_dispatcher(
         use_case_map=_use_case_map(),

--- a/vultron/adapters/driving/fastapi/inbox_port_factories.py
+++ b/vultron/adapters/driving/fastapi/inbox_port_factories.py
@@ -26,6 +26,7 @@ to inject adapter ports into use cases at dispatch time.
 import logging
 from typing import TYPE_CHECKING, Any, cast
 
+import yaml
 from pydantic import ValidationError
 
 from vultron.core.models.events import MessageSemantics
@@ -49,7 +50,13 @@ def _resolve_actor_config() -> "ActorConfig | None":
     """
     try:
         return SeedConfig.load().local_actor
-    except (FileNotFoundError, KeyError, ValueError, ValidationError):
+    except (
+        FileNotFoundError,
+        KeyError,
+        ValueError,
+        ValidationError,
+        yaml.YAMLError,
+    ):
         logger.debug(
             "_resolve_actor_config: SeedConfig unavailable — "
             "defaulting to auto_create_case=True",

--- a/vultron/adapters/driving/fastapi/inbox_port_factories.py
+++ b/vultron/adapters/driving/fastapi/inbox_port_factories.py
@@ -24,13 +24,38 @@ to inject adapter ports into use cases at dispatch time.
 #  in the U.S. Patent and Trademark Office by Carnegie Mellon University
 
 import logging
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
+
+from pydantic import ValidationError
 
 from vultron.core.models.events import MessageSemantics
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.ports.datalayer import DataLayer
+from vultron.demo.seed_config import SeedConfig
+
+if TYPE_CHECKING:
+    from vultron.core.models.actor_config import ActorConfig
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_actor_config() -> "ActorConfig | None":
+    """Load the local actor's ``ActorConfig`` from ``SeedConfig``.
+
+    Reads ``VULTRON_SEED_CONFIG`` (path) or the individual
+    ``VULTRON_ACTOR_*`` env vars via :func:`~vultron.demo.seed_config.SeedConfig.load`.
+    Returns ``None`` on any load error so callers fall through to the
+    always-create default (CM-15-001).
+    """
+    try:
+        return SeedConfig.load().local_actor
+    except (FileNotFoundError, KeyError, ValueError, ValidationError):
+        logger.debug(
+            "_resolve_actor_config: SeedConfig unavailable — "
+            "defaulting to auto_create_case=True",
+            exc_info=True,
+        )
+        return None
 
 
 def _sync_port_factory(dl: DataLayer) -> dict[str, Any]:
@@ -74,6 +99,22 @@ def _sync_and_trigger_port_factory(dl: DataLayer) -> dict[str, Any]:
     return {**_sync_port_factory(dl), **_trigger_activity_port_factory(dl)}
 
 
+def _submit_report_port_factory(dl: DataLayer) -> dict[str, Any]:
+    """Create sync+trigger ports and resolve the local ``ActorConfig``.
+
+    Used for ``SUBMIT_REPORT`` so that ``SubmitReportReceivedUseCase``
+    receives a populated ``actor_config`` and can honour
+    ``auto_create_case=False`` at runtime (CM-15-001, issue #1319).
+    Falls back to ``actor_config=None`` when ``SeedConfig`` is unavailable,
+    preserving the always-create default.
+    """
+    kwargs: dict[str, Any] = _sync_and_trigger_port_factory(dl)
+    actor_config = _resolve_actor_config()
+    if actor_config is not None:
+        kwargs["actor_config"] = actor_config
+    return kwargs
+
+
 _SYNC_PORT_SEMANTICS = frozenset(
     {
         MessageSemantics.ADD_EMBARGO_EVENT_TO_CASE,
@@ -100,11 +141,12 @@ _TRIGGER_ACTIVITY_PORT_SEMANTICS = frozenset(
 )
 
 # Semantics that require both a sync port and a trigger-activity port.
-# SUBMIT_REPORT, ENGAGE_CASE, DEFER_CASE run BTs that contain
-# CommitCaseLedgerEntryNode, which fans out Announce(CaseLedgerEntry)
-# via sync_port (SYNC-02-002), AND also need trigger_activity for
-# outbound wire-activity construction (e.g. Announce(VulnerabilityCase)
-# broadcast).
+# ENGAGE_CASE, DEFER_CASE run BTs that contain CommitCaseLedgerEntryNode,
+# which fans out Announce(CaseLedgerEntry) via sync_port (SYNC-02-002),
+# AND also need trigger_activity for outbound wire-activity construction
+# (e.g. Announce(VulnerabilityCase) broadcast).
+# NOTE: SUBMIT_REPORT is intentionally absent here — it uses
+# _submit_report_port_factory (below) which also injects actor_config.
 _SYNC_AND_TRIGGER_PORT_SEMANTICS = frozenset(
     {
         MessageSemantics.ACK_REPORT,
@@ -113,6 +155,11 @@ _SYNC_AND_TRIGGER_PORT_SEMANTICS = frozenset(
         MessageSemantics.DEFER_CASE,
         MessageSemantics.ENGAGE_CASE,
         MessageSemantics.OFFER_CASE_MANAGER_ROLE,
-        MessageSemantics.SUBMIT_REPORT,
     }
 )
+
+# SUBMIT_REPORT needs sync + trigger ports AND the local actor's ActorConfig
+# so that SubmitReportReceivedUseCase can honour auto_create_case=False at
+# runtime (CM-15-001, issue #1319).  Kept in a separate set so the disjoint
+# guard in make_dispatcher() does not need special-casing.
+_SUBMIT_REPORT_SEMANTICS = frozenset({MessageSemantics.SUBMIT_REPORT})


### PR DESCRIPTION
- Closes #1319

## Summary

Wires the per-actor `ActorConfig` (specifically `auto_create_case`) into the production `SUBMIT_REPORT` dispatch path so that `SubmitReportReceivedUseCase` honours `auto_create_case=False` in real deployments — not just in unit tests that manually inject the config.

## Changes

- `vultron/adapters/driving/fastapi/inbox_port_factories.py`: add `_resolve_actor_config()` (loads `ActorConfig` from `SeedConfig`; narrows `except` to `FileNotFoundError | KeyError | ValueError | ValidationError`; `SeedConfig` import at module level per project convention); add `_submit_report_port_factory()` which delegates to `_sync_and_trigger_port_factory()` then adds `actor_config`; add `_SUBMIT_REPORT_SEMANTICS`; remove `SUBMIT_REPORT` from `_SYNC_AND_TRIGGER_PORT_SEMANTICS`
- `vultron/adapters/driving/fastapi/inbox_handler.py`: add `_SUBMIT_REPORT_SEMANTICS` to 4-set disjoint guard and `port_factories`; update guard error message to describe the dedicated-set pattern for semantics that need extra ports
- `test/adapters/driving/fastapi/test_inbox_handler.py`: 4 new tests — unit tests for factory injection and fallback, wiring test verifying `SUBMIT_REPORT → _submit_report_port_factory`, and AC-2 end-to-end test through `DirectActivityDispatcher` against a real `SqliteDataLayer`

## Verification

- 4458 unit tests pass (4 new)
- Black, flake8, mypy, pyright clean