### PR TITLE
docs: add ADRs 0007-0030 to mkdocs nav and guard un-navved pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -221,7 +221,30 @@ nav:
       - Use Factory Pattern for BT nodes: 'adr/0004-use-factory-methods-for-common-bt-node-types.md'
       - Use ActivityStreams Vocabulary as Message Format: 'adr/0005-activitystreams-vocabulary-as-vultron-message-format.md'
       - Use CalVer for Versioning: 'adr/0006-use-calver-for-project-versioning.md'
+      - Introduce a Behavior Dispatcher: 'adr/0007-use-behavior-dispatcher.md'
+      - Use py_trees for Handler BTs: 'adr/0008-use-py-trees-for-handler-bt-integration.md'
+      - Hexagonal Architecture: 'adr/0009-hexagonal-architecture.md'
+      - Standardize Object IDs: 'adr/0010-standardize-object-ids.md'
+      - Remove API v1: 'adr/0011-remove-api-v1.md'
+      - Per-Actor DataLayer Isolation: 'adr/0012-per-actor-datalayer-isolation.md'
+      - Unify RM State Tracking: 'adr/0013-unify-rm-state-tracking.md'
+      - Pin GitHub Actions to SHAs: 'adr/0014-sha-pin-github-actions.md'
+      - Create Case at Report Receipt: 'adr/0015-create-case-at-report-receipt.md'
+      - SQLModel/SQLite DataLayer: 'adr/0016-sqlmodel-sqlite-datalayer.md'
+      - Domain/Wire Object Separation: 'adr/0017-domain-wire-object-separation.md'
+      - Canonical Case History Convergence: 'adr/0018-canonical-case-history-convergence.md'
+      - Separate Case Ledger from Process Log: 'adr/0019-separate-case-ledger-from-process-log.md'
+      - Inbox BT Orchestration: 'adr/0020-inbox-bt-orchestration.md'
+      - CaseActor Inbox Routing: 'adr/0021-caseactor-inbox-routing-canonical-ledger.md'
+      - Single BT Execution Per Inbox Delivery: 'adr/0022-single-bt-execution-for-received-side-case-actor-routing.md'
+      - CaseProposal Protocol: 'adr/0023-case-proposal-protocol.md'
+      - Coordination Agent Taxonomy: 'adr/0024-coordination-agent-taxonomy.md'
+      - Call-Out Point Abstraction Layer: 'adr/0025-call-out-point-abstraction-layer.md'
       - CaseActor-Routed Actor Suggestion: 'adr/0026-caseactor-routed-actor-suggestion.md'
+      - Exploit-Strategy Subtree Collapse: 'adr/0027-exploit-strategy-bt-collapse.md'
+      - Publication-Intent Subtree Collapse: 'adr/0028-publication-intent-bt-collapse.md'
+      - Notification Loop Collapse: 'adr/0029-notification-loop-suggest-actor.md'
+      - Publish Leaf Draft-Review-Submit Pipeline: 'adr/0030-publish-leaf-draft-review-submit-pipeline.md'
   - About:
     - Contributing: 'about/contributing.md'
     - FAQ: 'about/faq.md'
@@ -235,6 +258,17 @@ not_in_nav: |
   *diagram*.md
   *table*.md
   *.ttl
+  # Maintainer/agent-facing pages intentionally excluded from the published nav
+  agents/*.md
+  developer/**/*.md
+  reference/inbox_handler.md
+  reference/code/hexagonal_architecture.md
+validation:
+  nav:
+    # Emit a warning when a page exists but is missing from the nav and is not
+    # declared in not_in_nav above. Surfaces future un-navved pages (e.g. new
+    # ADRs) and fails any --strict build (see mkdocs-build-strict.sh). #1304.
+    omitted_files: warn
 exclude_docs: |
   # Maintainer-focused docs are available in local/dev builds via mkdocs.dev.yml
   docs/developer/

--- a/plan/history/2607/implementation/ISSUE-1304.md
+++ b/plan/history/2607/implementation/ISSUE-1304.md
@@ -1,0 +1,17 @@
+---
+source: ISSUE-1304
+timestamp: '2026-07-10T17:13:18.577159+00:00'
+title: mkdocs nav ADRs 0007-0030
+type: implementation
+---
+
+## Issue #1304 — docs: mkdocs nav is missing ADRs 0007–0025
+
+Added ADRs 0007–0030 to the mkdocs Decision Records nav in numeric order and
+added a `validation.nav.omitted_files: warn` guard (with `not_in_nav`
+declarations for intentional maintainer/agent omissions: `agents/*.md`,
+`developer/**/*.md`, `reference/inbox_handler.md`,
+`reference/code/hexagonal_architecture.md`) to prevent future un-navved pages.
+All 31 ADR files (0000–0030) now appear in the nav with no orphans. Docs-only.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1333>

--- a/plan/incoming/learnings/20260710-mkdocs-nav-omitted-files-guard.md
+++ b/plan/incoming/learnings/20260710-mkdocs-nav-omitted-files-guard.md
@@ -1,0 +1,32 @@
+---
+title: Enabling mkdocs nav.omitted_files requires declaring intentional omissions first
+type: learning
+timestamp: 2026-07-10
+source: ISSUE-1304
+---
+
+While adding a `validation.nav.omitted_files: warn` regression guard to catch
+un-navved docs pages (#1304), two non-obvious facts surfaced:
+
+- **`exclude_docs` does NOT satisfy the nav-omission validator.** Pages under
+  `docs/developer/` are excluded from the published build via `exclude_docs`,
+  but the nav validator still flagged them as "not included in the nav." They
+  had to *also* be listed in `not_in_nav` (`developer/**/*.md`) for the guard
+  not to flood. Same for `agents/*.md`, `reference/inbox_handler.md`, and
+  `reference/code/hexagonal_architecture.md` — all intentional omissions must
+  be enumerated in `not_in_nav` before turning the guard on.
+- **`mkdocs.dev.yml` REPLACES `not_in_nav`, it does not merge.** The dev
+  overlay (`INHERIT: mkdocs.yml`) sets its own `not_in_nav: | developer/**`,
+  which fully overrides the base list rather than extending it. MkDocs cannot
+  append to list-based nav config via inheritance. CI runs the dev config
+  non-strict, so the inherited `validation` block only warns there — but be
+  aware the two configs have divergent omission lists.
+
+Also: CI's `docs-build-check.yml` runs plain `uv run mkdocs build` (non-strict)
+for both configs, so `omitted_files: warn` never *fails* CI — it fails only the
+local `mkdocs-build-strict.sh` wrapper. The wrapper itself counts known
+false-positive warnings (griffe decorator/bib misreads: `dataclass`, `prefix`,
+`base`, print-site) and exits 0 if only those remain; genuine pre-existing
+warnings (`markdown_exec` code-block execution errors, `context`/`pytest` bib
+keys) make it exit non-zero even on clean `main`, so don't treat a red strict
+wrapper as a regression without a clean-base comparison.


### PR DESCRIPTION
- Closes #1304

## Summary

`docs/adr/index.md` listed all ADRs but the `mkdocs.yml` nav only enumerated
0000–0006 plus 0026, leaving 0007–0025 (and the provisional 0027–0030) present
as pages but absent from site navigation. This adds them and installs a
regression guard so future un-navved pages are caught.

## Changes

- `mkdocs.yml`:
  - Added ADRs 0007–0030 to `nav → Decision Records` in numeric order, using
    short human-readable titles consistent with the existing entries. All 31
    ADR nav entries resolve to real files; no ADR pages remain orphaned from
    the nav.
  - Added `validation.nav.omitted_files: warn` so a page that exists but is
    missing from the nav emits a warning and fails any `--strict` build
    (`mkdocs-build-strict.sh`).
  - Declared the intentionally-excluded maintainer/agent pages (`agents/*.md`,
    `developer/**/*.md`, `reference/inbox_handler.md`,
    `reference/code/hexagonal_architecture.md`) in `not_in_nav` so the guard
    does not flood on known-intentional omissions.

## Verification

- `mkdocs build` (both `mkdocs.yml` and `mkdocs.dev.yml`, matching CI's
  `docs-build-check`) exits 0 with no "pages not included in the nav" warning.
- Confirmed all 31 ADR files (0000–0030) appear in the nav and every nav path
  resolves to an existing file.
- The remaining `--strict` warnings (`markdown_exec`, `context`/`pytest` bib
  keys) are pre-existing on clean `main` and unrelated to this change.

Docs-only; no Python changed, so linters/tests are N/A.