### PR TITLE
feat: rename start.sh → start-dev.sh; mount wip_notes/wip_outputs in dev containers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
 # The devcontainer image is built from the `dev` stage in docker/Dockerfile.
-# start.sh builds it with:
+# start-dev.sh builds it with:
 #   docker build -f docker/Dockerfile --target dev <repo-root>
 # This file is kept as a placeholder and is not used directly.

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,6 +1,6 @@
 # Dev Container Setup
 
-This project uses a custom Docker-based dev environment driven by `start.sh`.
+This project uses a custom Docker-based dev environment driven by `start-dev.sh`.
 There is no VS Code devcontainer.json — the script handles everything.
 
 ## Prerequisites
@@ -14,7 +14,7 @@ There is no VS Code devcontainer.json — the script handles everything.
 From the repo root, run:
 
 ```sh
-./start.sh <slot>
+./start-dev.sh <slot>
 ```
 
 Replace `<slot>` with any name you like — it's personal to you and not stored in the repo.
@@ -45,19 +45,19 @@ it lives on your filesystem — no hardcoded paths.
 
 ```sh
 # Start (or attach to) a named slot
-./start.sh <slot>
+./start-dev.sh <slot>
 
 # Attach to the main checkout (no worktree)
-./start.sh main
+./start-dev.sh main
 
 # Nuke the slot's worktree and recreate it from main, then start
-./start.sh <slot> --reset
+./start-dev.sh <slot> --reset
 
 # Rebuild the Docker image from scratch, then start
-./start.sh <slot> --rebuild
+./start-dev.sh <slot> --rebuild
 
 # Combine: full clean slate
-./start.sh <slot> --reset --rebuild
+./start-dev.sh <slot> --reset --rebuild
 ```
 
 ## What persists
@@ -70,6 +70,19 @@ container removal. It holds:
 
 Running `--reset` or `--rebuild` removes the container but never the volume.
 Your Claude sessions and shell history survive.
+
+## WIP notes and outputs
+
+Two gitignored directories at the repo root are mounted into every container:
+
+| Dir | Mount in container | Access | Purpose |
+|---|---|---|---|
+| `wip_notes/` | `$WIP_NOTES` (`/workspaces/wip_notes`) | read-only | Drop reference notes and context files here on the host; agents can read them during sessions |
+| `wip_outputs/` | `$WIP_OUTPUTS` (`/workspaces/wip_outputs/<slot>`) | read-write | Agents write ad-hoc reports here; each slot writes to its own subdirectory to avoid conflicts |
+
+`start-dev.sh` creates both directories automatically if they don't exist.
+Files written by the container are owned by uid 1000 (`vscode`) on the host.
+Under Docker Desktop on macOS this is transparent and requires no extra configuration.
 
 ## Skills
 

--- a/.devcontainer/postcreate.sh
+++ b/.devcontainer/postcreate.sh
@@ -70,7 +70,7 @@ set -g default-shell /bin/zsh
 EOF
 
 # --- User-level skills ---
-# Point ~/.claude/skills at the Mac host user skills mounted by start.sh.
+# Point ~/.claude/skills at the Mac host user skills mounted by start-dev.sh.
 # Project skills (.claude/skills/ in the working tree) are auto-discovered by Claude Code separately.
 if [ -d "$HOME/.agents/skills" ]; then
     ln -sfn "$HOME/.agents/skills" "$HOME/.data/claude/skills"

--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,7 @@ mydb.json
 /ontology/*.properties
 catalog-*.xml
 /wip_notes/
+/wip_outputs/
 devlogs
 .codebase-scan.txt
 /demologs/

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Start (or attach to) a slot-based Claude Code devcontainer from the Mac terminal.
-# Usage: ./start.sh <slot> [--rebuild] [--reset]
+# Usage: ./start-dev.sh <slot> [--rebuild] [--reset]
 #   slot       Name for this dev slot (e.g. inky, pinky, main). You pick the name.
 #              "main" is special: attaches to the main checkout with no worktree.
 #   --rebuild  Remove and rebuild the Docker image from scratch.
@@ -26,7 +26,7 @@ for arg in "$@"; do
 done
 
 if [ -z "$SLOT" ]; then
-    echo "Usage: ./start.sh <slot> [--rebuild] [--reset]"
+    echo "Usage: ./start-dev.sh <slot> [--rebuild] [--reset]"
     echo ""
     echo "  slot       Name for this dev slot (e.g. inky, pinky, main)."
     echo "             'main' attaches to the main checkout; all others create a worktree."
@@ -57,6 +57,21 @@ else
     WORKSPACE="/workspaces/${MAIN_NAME}_${SLOT}"
     WORKTREE_PATH="${PARENT_DIR}/${MAIN_NAME}_${SLOT}"
 fi
+
+# Ensure wip_notes/ and wip_outputs/ exist on the host (both gitignored)
+_created_wip=false
+if [ ! -d "$MAIN_DIR/wip_notes" ]; then
+    mkdir -p "$MAIN_DIR/wip_notes"
+    _created_wip=true
+fi
+if [ ! -d "$MAIN_DIR/wip_outputs" ]; then
+    mkdir -p "$MAIN_DIR/wip_outputs"
+    _created_wip=true
+fi
+if [ "$_created_wip" = true ]; then
+    echo "Created wip_notes/ (read-only agent input) and/or wip_outputs/ (agent output files). Both are gitignored."
+fi
+mkdir -p "$MAIN_DIR/wip_outputs/$SLOT"
 
 # --rebuild or --reset: remove existing container first
 if [ "$REBUILD" = true ] || [ "$RESET" = true ]; then
@@ -161,6 +176,14 @@ if [ -S "/run/host-services/ssh-auth.sock" ]; then
         -v /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock
     )
 fi
+
+# Mount wip_notes (read-only) and wip_outputs (read-write, namespaced by slot)
+DOCKER_ARGS+=(
+    -v "$MAIN_DIR/wip_notes:/workspaces/wip_notes:ro"
+    -v "$MAIN_DIR/wip_outputs:/workspaces/wip_outputs"
+    -e WIP_NOTES=/workspaces/wip_notes
+    -e WIP_OUTPUTS=/workspaces/wip_outputs/$SLOT
+)
 
 docker run -d "${DOCKER_ARGS[@]}" "$IMAGE_NAME" sleep infinity
 trap _cleanup EXIT


### PR DESCRIPTION
## Summary

- **Rename `start.sh` → `start-dev.sh`** so the script name signals it is a developer tool, not a generic app runner.
- **Mount `wip_notes/` (read-only) and `wip_outputs/` (read-write) into every dev container** so agents can read context notes and write ad-hoc reports without those files entering the repo.

## Changes

| File | What changed |
|---|---|
| `start.sh` → `start-dev.sh` | Renamed; updated two self-referencing usage strings; added wip dir auto-create logic and mount args |
| `.gitignore` | Added `/wip_outputs/` alongside existing `/wip_notes/` |
| `.devcontainer/Dockerfile` | Updated comment |
| `.devcontainer/README.md` | Updated all `start.sh` refs; added **WIP notes and outputs** section |
| `.devcontainer/postcreate.sh` | Updated comment |

## Behaviour

- `start-dev.sh` creates `wip_notes/` and `wip_outputs/` at the repo root if they don't exist, printing a one-time notice.
- Each slot writes to `wip_outputs/<slot>/` (created automatically) to avoid cross-slot file conflicts.
- Inside every container: `$WIP_NOTES=/workspaces/wip_notes` (read-only), `$WIP_OUTPUTS=/workspaces/wip_outputs/<slot>` (read-write).

## Test plan

- [ ] Run `./start-dev.sh main` with no `wip_notes/` or `wip_outputs/` present → verify one-time notice, both dirs created, `wip_outputs/main/` subdir exists
- [ ] Inside container: `ls $WIP_NOTES` and `ls $WIP_OUTPUTS` both succeed
- [ ] `touch $WIP_OUTPUTS/test.txt` succeeds; file appears on host at `wip_outputs/main/test.txt`
- [ ] `touch $WIP_NOTES/test.txt` fails with "Read-only file system"
- [ ] Slot container (e.g. `./start-dev.sh inky`): `$WIP_OUTPUTS=/workspaces/wip_outputs/inky`
- [ ] `git status` shows nothing new from `wip_outputs/`

Closes #1337

🤖 Generated with [Claude Code](https://claude.com/claude-code)