### PR TITLE
docs: rename nav sections to diataxis terms; add persona entry points

### DIFF
--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -1,4 +1,4 @@
-# Implementing Vultron
+# How-to Guides
 
 {% include-markdown "../includes/not_normative.md" %}
 
@@ -14,13 +14,13 @@ suggestions for potential implementers.
 
 !!! tip inline end "Prerequisites"
 
-    The [Implementing Vultron](index.md) section assumes that you have:
+    The [How-to Guides](index.md) section assumes that you have:
     
     - an interest in implementing the Vultron Protocol
     - basic familiarity with the Vultron Protocol
     - familiarity with the CVD process in general
 
-    If you are unfamiliar with the Vultron Protocol, we recommend that you start with [Understanding Vultron](../topics/index.md).
+    If you are unfamiliar with the Vultron Protocol, we recommend that you start with [Explanation](../topics/index.md).
     For technical reference, see [Reference](../reference/index.md).
     If you're just trying to understand the CVD process, we recommend that you start with the [CERT Guide to Coordinated Vulnerability Disclosure](https://certcc.github.io/CERT-Guide-to-CVD){:target="_blank"}.
 

--- a/docs/includes/do_not_start_here.md
+++ b/docs/includes/do_not_start_here.md
@@ -1,5 +1,5 @@
 !!! warning "Do Not Start Here"
 
-    If this is your first time reading about the Vultron Protocol, we recommend that you start with [Understanding Vultron](../topics/background/index.md).
+    If this is your first time reading about the Vultron Protocol, we recommend that you start with [Explanation](../topics/background/index.md).
     This section is heavy on formalism and is intended for readers who are already familiar with the Vultron Protocol
     concepts and design principles.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,9 +15,9 @@ anyone seeking interoperability in the CVD ecosystem.
     We are currently working on the documentation of the Vultron CVD Protocol.
     Our focus so far is on
 
-    - [Understanding Vultron](topics/background/index.md), which describes the
+    - [Explanation](topics/index.md), which describes the
       protocol in detail
-    - [Implementing Vultron](howto/index.md), which provides guidance for
+    - [How-to Guides](howto/index.md), which provides guidance for
       potential implementations of Vultron
     - [Reference](reference/formal_protocol/index.md), which provides the formal
       protocol specification
@@ -85,51 +85,80 @@ We are using the [Diátaxis Framework](https://diataxis.fr/){:target="_blank"} t
 organize our documentation into four main categories, oriented around the different
 ways that people might need to learn about and use the Vultron Protocol.
 
-Our current focus is on the [Understanding Vultron](topics/background/index.md)
+Our current focus is on the [Explanation](topics/index.md)
 section, which describes the protocol in detail.
 
 <div class="grid cards" markdown>
 
-- :material-school:{ .lg .middle } **Learning About Vultron**
+- :material-school:{ .lg .middle } **Tutorials**
 
     ---
 
-    The [Learning Vultron](tutorials/index.md) section is intended to eventually include tutorials and other
-    information about the Vultron Protocol that is oriented towards novice users and getting started with the protocol.
-    However, because we are still in the early stages of the project, this section is just a placeholder for now.
+    Step-by-step guided lessons for getting started with Vultron. Run the
+    demos and see the protocol in action.
 
-    [:octicons-arrow-right-24: Learning Vultron](tutorials/index.md)
+    [:octicons-arrow-right-24: Tutorials](tutorials/index.md)
 
-- :fontawesome-solid-book-open:{ .lg .middle } **Understanding Vultron**
-
-    ---
-
-    The [Understanding Vultron](topics/background/index.md) section includes background information about Vultron,
-    including the motivation for the project, the problem space that we are trying to address, and the design principles
-    that we are using to guide our work. It also includes a detailed description of the Vultron Protocol, including
-    the state machines and behavior logic that we use to model the behavior of the protocol.
-
-    [:octicons-arrow-right-24: Understanding Vultron](topics/background/index.md)
-
-- :fontawesome-solid-code:{ .lg .middle } **Implementing Vultron**
+- :fontawesome-solid-book-open:{ .lg .middle } **Explanation**
 
     ---
 
-    The [Implementing Vultron](howto/index.md) section includes guidance for potential implementations of Vultron.
-    In the future, we plan to include how-to guides to help you use Vultron, but for now it is focused on guidance for
-    potential implementers of Vultron.
+    Background, concepts, process models, and formal protocol description.
+    Builds understanding of how and why Vultron works.
 
-    [:octicons-arrow-right-24: Implementing Vultron](howto/index.md)
+    [:octicons-arrow-right-24: Explanation](topics/index.md)
+
+- :fontawesome-solid-wrench:{ .lg .middle } **How-to Guides**
+
+    ---
+
+    Goal-oriented guidance for implementers. Data models, ActivityPub
+    integration, and protocol implementation advice.
+
+    [:octicons-arrow-right-24: How-to Guides](howto/index.md)
 
 - :material-bookshelf:{ .lg .middle } **Reference**
 
     ---
 
-    The [Reference](reference/index.md) section includes the formal Vultron Protocol specification, crosswalks the
-    protocol with other related standards and protocols, etc.
-    In the future, we plan to include other reference information about Vultron, including code documentation.
+    Formal protocol specification, case state listings, code documentation,
+    ontologies, and ISO crosswalks.
 
     [:octicons-arrow-right-24: Reference](reference/index.md)
+
+</div>
+
+## Who is this documentation for?
+
+<div class="grid cards" markdown>
+
+- :material-shield-search:{ .lg .middle } **CVD Practitioner**
+
+    ---
+
+    You coordinate vulnerability disclosures, work at a CERT/CSIRT, or manage
+    vulnerability response for your organization. You want to understand how
+    Vultron models the CVD process and whether it fits your workflow.
+
+    [:octicons-arrow-right-24: Start with Explanation](topics/index.md)
+
+- :fontawesome-solid-code:{ .lg .middle } **Software Developer**
+
+    ---
+
+    You are building a vulnerability tracking system, CVD tool, or
+    interoperability layer and want to implement the Vultron Protocol.
+
+    [:octicons-arrow-right-24: Start with How-to Guides](howto/index.md)
+
+- :material-source-pull:{ .lg .middle } **Vultron Contributor**
+
+    ---
+
+    You are working on the Vultron reference implementation and want to
+    understand the codebase, run the demos, or contribute to the project.
+
+    [:octicons-arrow-right-24: Start with Tutorials](tutorials/index.md)
 
 </div>
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -5,11 +5,11 @@
     The [Reference](index.md) section assumes that you have
 
     - specific questions about or a desire for a detailed understanding of the Vultron Protocol
-    - familiarity with the [Understanding Vultron](../topics/index.md) section
+    - familiarity with the [Explanation](../topics/index.md) section
     - familiarity with the CVD process in general
      
-    If you are unfamiliar with the Vultron Protocol, we recommend that you start with [Understanding Vultron](../topics/index.md).
-    If you are familiar enough with the Vultron Protocol that you're interested in implementing it, see [Implementing Vultron](../howto/index.md).
+    If you are unfamiliar with the Vultron Protocol, we recommend that you start with [Explanation](../topics/index.md).
+    If you are familiar enough with the Vultron Protocol that you're interested in implementing it, see [How-to Guides](../howto/index.md).
     And finally, if you're just trying to understand the CVD process, we recommend that you start with the [CERT Guide to Coordinated Vulnerability Disclosure](https://certcc.github.io/CERT-Guide-to-CVD){:target="_blank"}.
 
 The Vultron Protocol Reference includes the formal Vultron Protocol specification, and crosswalks the

--- a/docs/topics/background/index.md
+++ b/docs/topics/background/index.md
@@ -2,13 +2,13 @@
 
 !!! tip inline end "Prerequisites"
 
-    The [Understanding Vultron](index.md) section assumes that you have:
+    The [Explanation](../index.md) section assumes that you have:
     
     - an interest in learning about the Vultron Protocol
     - familiarity with the CVD process in general
 
     If you are already familiar with the Vultron Protocol, and are looking for implementation advice, 
-    see [Implementing Vultron](../../howto/index.md).
+    see [How-to Guides](../../howto/index.md).
     For technical reference, see [Reference](../../reference/index.md).
     If you're just trying to understand the CVD process, we recommend that you start with the [CERT Guide to Coordinated Vulnerability Disclosure](https://certcc.github.io/CERT-Guide-to-CVD){:target="_blank"}.
 

--- a/docs/topics/index.md
+++ b/docs/topics/index.md
@@ -1,14 +1,14 @@
-# Understanding the Vultron Protocol
+# Explanation
 
 !!! tip inline end "Prerequisites"
 
-    The [Understanding Vultron](index.md) section assumes that you have:
+    The [Explanation](index.md) section assumes that you have:
     
     - an interest in learning about the Vultron Protocol
     - familiarity with the CVD process in general
 
     If you are already familiar with the Vultron Protocol, and are looking for implementation advice, 
-    see [Implementing Vultron](../howto/index.md).
+    see [How-to Guides](../howto/index.md).
     For technical reference, see [Reference](../reference/index.md).
     If you're just trying to understand the CVD process, we recommend that you start with the [CERT Guide to Coordinated Vulnerability Disclosure](https://certcc.github.io/CERT-Guide-to-CVD){:target="_blank"}.
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -19,9 +19,9 @@
 ## Further reading
 
 - If you are unfamiliar with the Vultron Protocol, we recommend that you
-  start with [Understanding Vultron](../topics/index.md).
+  start with [Explanation](../topics/index.md).
 - If you are familiar enough with the Vultron Protocol that you're
-  interested in implementing it, see [Implementing Vultron](../howto/index.md).
+  interested in implementing it, see [How-to Guides](../howto/index.md).
 - For technical reference material, see [Reference](../reference/index.md).
 - And finally, if you're just trying to understand the CVD process, we
   recommend that you start with the

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,13 +5,13 @@ site_author: 'CERT Coordination Center'
 nav:
   - Home: 'https://certcc.github.io/'
   - Vultron: 'index.md'
-  - Learning Vultron:
+  - Tutorials:
     - 'tutorials/index.md'
     - Run the Receive-Report Demo: 'tutorials/receive_report_demo.md'
     - Running the Other Demos: 'tutorials/other_demos.md'
     - Running the Multi-Actor Container Demos: 'tutorials/container_demos.md'
     - Run the Two-Actor Demo: 'tutorials/two-actor-demo.md'
-  - Understanding Vultron:
+  - Explanation:
     - 'topics/index.md'
     - Background:
         - 'topics/background/index.md'
@@ -104,7 +104,7 @@ nav:
         - Reward Functions: 'topics/future_work/reward_functions.md'
         - Ontology: 'topics/future_work/ontology.md'
         - Modeling and Simulation: 'topics/future_work/mod_sim.md'
-  - Implementing Vultron:
+  - How-to Guides:
       - 'howto/index.md'
       - A Case Object: 'howto/case_object.md'
       - Process Implementation: 'howto/process_implementation.md'

--- a/plan/history/2607/implementation/ISSUE-598.md
+++ b/plan/history/2607/implementation/ISSUE-598.md
@@ -1,0 +1,19 @@
+---
+source: ISSUE-598
+timestamp: '2026-07-10T18:02:11.137261+00:00'
+title: docs homepage nav renamed to diataxis terms with persona cards
+type: implementation
+---
+
+## Issue #598 — [Docs] Homepage: add audience entry points and fix nav section names
+
+Renamed the four top-level mkdocs nav sections to canonical Diátaxis terminology
+(Tutorials, Explanation, How-to Guides, Reference) and added audience-persona
+entry-point cards to the homepage for CVD Practitioners, Software Developers,
+and Vultron Contributors.
+
+Updated cross-links across tutorials, reference, topics/background, howto, and
+includes to use the new section names. Fixed H1 of docs/topics/index.md to match
+nav label. Fixed Explanation links to point to section root (topics/index.md).
+
+PR: <https://github.com/CERTCC/Vultron/pull/1339>


### PR DESCRIPTION
- Closes #598

## Summary

Renames the four top-level mkdocs nav sections to their canonical Diátaxis
names and adds audience-persona entry-point cards to the homepage.

## Changes

- `mkdocs.yml`: `Learning Vultron` → `Tutorials`, `Understanding Vultron` →
  `Explanation`, `Implementing Vultron` → `How-to Guides`
- `docs/topics/index.md`: update H1 to `Explanation` to match nav label
- `docs/howto/index.md`: update H1 and prerequisites box to new names
- `docs/index.md`: replace single grid-card block with two sections —
  "How this documentation is organized" (four Diátaxis cards) and
  "Who is this documentation for?" (three audience-persona cards:
  CVD Practitioner → Explanation; Software Developer → How-to Guides;
  Vultron Contributor → Tutorials); fix all links to use section-root
  targets (`topics/index.md`, not `topics/background/index.md`)
- `docs/tutorials/index.md`, `docs/reference/index.md`,
  `docs/topics/background/index.md`, `docs/includes/do_not_start_here.md`:
  update cross-links to use new section names

## Verification

- `npx markdownlint-cli2` passes on all changed files (0 errors)
- `mkdocs-build-strict.sh` exits with same 8 pre-existing warnings as
  `main` (reference/codebase/ nav omissions, markdown_exec errors,
  context/pytest bib keys) — no new warnings introduced