### PR TITLE
test: dedicated execute() unit tests for AcceptActorRecommendationReceivedUseCase and RejectActorRecommendationReceivedUseCase

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1326.md
+++ b/plan/history/2607/implementation/ISSUE-1326.md
@@ -1,0 +1,18 @@
+---
+source: ISSUE-1326
+timestamp: '2026-07-10T18:12:41.304110+00:00'
+title: 'test: AcceptActorRecommendationReceivedUseCase and RejectActorRecommendationReceivedUseCase
+  dedicated execute() unit tests'
+type: implementation
+---
+
+## Issue #1326 — test: AcceptActorRecommendationReceivedUseCase and RejectActorRecommendationReceivedUseCase dedicated execute() unit tests
+
+Added 6 new `execute()`-path unit tests in `test/core/use_cases/received/actor/test_suggest.py`:
+
+- `TestAcceptActorRecommendationReceivedUseCase`: happy path (asserts ≥2 outbox entries — Accept notification + Invite), missing `case_id`, no local actor
+- `TestRejectActorRecommendationReceivedUseCase`: happy path (asserts ≥1 outbox entry — Reject notification), missing `case_id`, no local actor
+
+Key fix during code review: `_build_accept_reject_dl()` initially omitted the original recommendation activity from the DataLayer. Without it, `dl.read(recommendation_id)` returned `None` and `recommender_id` silently fell back to `""`, meaning the recommender-notification tree branch was never exercised. Fixed by storing the recommendation (`recommend_actor_activity(...)`) in the DataLayer and strengthening the Accept happy-path assertion from `>= 1` to `>= 2`.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1340>

--- a/test/core/use_cases/received/actor/test_suggest.py
+++ b/test/core/use_cases/received/actor/test_suggest.py
@@ -22,9 +22,16 @@ from vultron.adapters.driven.trigger_activity_adapter import (
     TriggerActivityAdapter,
 )
 from vultron.core.use_cases.received.actor.suggest import (
+    AcceptActorRecommendationReceivedUseCase,
     OfferActorToCaseReceivedUseCase,
+    RejectActorRecommendationReceivedUseCase,
 )
-from vultron.wire.as2.factories import recommend_actor_activity
+from vultron.wire.as2.factories import (
+    accept_case_participant_offer_activity,
+    offer_case_participant_activity,
+    recommend_actor_activity,
+    reject_case_participant_offer_activity,
+)
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
 
@@ -133,3 +140,211 @@ class TestOfferActorToCaseReceivedUseCase:
             OfferActorToCaseReceivedUseCase(dl, mock_event).execute()
 
         assert any("missing" in r.message.lower() for r in caplog.records)
+
+
+def _build_accept_reject_dl():
+    """Seed a DataLayer with a CaseActor (Service), a VulnerabilityCase, and a stored recommendation.
+
+    The recommendation is stored so that AcceptActorRecommendationReceivedUseCase and
+    RejectActorRecommendationReceivedUseCase can resolve recommender_id via dl.read().
+    """
+    from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+    from vultron.wire.as2.vocab.base.objects.actors import as_Service
+
+    dl = SqliteDataLayer("sqlite:///:memory:")
+    local_actor_id = "https://example.org/actors/case-actor"
+    case_id = "https://example.org/cases/rec-accept-reject-case"
+    owner_id = "https://example.org/actors/owner"
+    recommender_id = "https://example.org/actors/recommender"
+    dl.create(as_Service(id_=local_actor_id))
+    dl.create(
+        VulnerabilityCase(
+            id_=case_id,
+            name="AcceptRejectTest",
+            attributed_to=owner_id,
+        )
+    )
+    # Store the original recommendation so the use cases can resolve recommender_id.
+    recommendation = recommend_actor_activity(
+        as_Actor(id_="https://example.org/actors/vendor-placeholder"),
+        target=case_id,
+        actor=recommender_id,
+        id_="https://example.org/activities/orig-recommendation",
+    )
+    dl.create(recommendation)
+    return dl, local_actor_id, case_id, owner_id, recommender_id
+
+
+class TestAcceptActorRecommendationReceivedUseCase:
+    """execute() unit tests for AcceptActorRecommendationReceivedUseCase (CM-16-006, ADR-0026)."""
+
+    @pytest.fixture(autouse=True)
+    def clear_blackboard(self):
+        py_trees.blackboard.Blackboard.storage.clear()
+        yield
+        py_trees.blackboard.Blackboard.storage.clear()
+
+    def _build_event(self, make_payload, case_id, owner_id, recommended_id):
+        """Build Accept(Offer(CaseParticipant, Case)) and extract the domain event."""
+        from vultron.core.models.events.actor import (
+            AcceptActorRecommendationReceivedEvent,
+        )
+
+        recommended = as_Actor(id_=recommended_id)
+        inner_offer = offer_case_participant_activity(
+            recommended,
+            target=case_id,
+            actor="https://example.org/actors/case-actor",
+            origin="https://example.org/activities/orig-recommendation",
+        )
+        activity = accept_case_participant_offer_activity(
+            inner_offer,
+            target=case_id,
+            actor=owner_id,
+        )
+        event = make_payload(activity)
+        assert isinstance(
+            event, AcceptActorRecommendationReceivedEvent
+        ), f"Expected AcceptActorRecommendationReceivedEvent, got {type(event)}"
+        return event
+
+    def test_happy_path_emits_accept_and_invite(self, make_payload):
+        """Happy path: tree runs and outbox receives Accept notification + Invite."""
+        dl, local_actor_id, case_id, owner_id, _recommender_id = (
+            _build_accept_reject_dl()
+        )
+        recommended_id = "https://example.org/actors/vendor-new"
+        event = self._build_event(
+            make_payload, case_id, owner_id, recommended_id
+        )
+
+        AcceptActorRecommendationReceivedUseCase(
+            dl, event, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
+
+        outbox = dl.outbox_list_for_actor(local_actor_id)
+        assert (
+            len(outbox) >= 2
+        ), f"Expected ≥2 outbox entries (Accept notification + Invite), got {len(outbox)}"
+
+    def test_skips_when_case_id_missing(self, caplog):
+        """Logs a warning and returns early when case_id is absent."""
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        mock_event = MagicMock()
+        mock_event.activity_id = "https://example.org/activities/accept-bad"
+        mock_event.target_id = None
+        mock_event.activity = None
+
+        with caplog.at_level(logging.WARNING):
+            AcceptActorRecommendationReceivedUseCase(dl, mock_event).execute()
+
+        assert any("missing" in r.message.lower() for r in caplog.records)
+
+    def test_skips_when_no_local_actor(self, make_payload, caplog):
+        """Logs a warning and returns early when no local actor exists in DataLayer."""
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case_id = "https://example.org/cases/no-actor-case"
+        owner_id = "https://example.org/actors/owner"
+        recommended_id = "https://example.org/actors/vendor-new"
+        event = self._build_event(
+            make_payload, case_id, owner_id, recommended_id
+        )
+
+        with caplog.at_level(logging.WARNING):
+            AcceptActorRecommendationReceivedUseCase(dl, event).execute()
+
+        assert any(
+            "no local actor" in r.message.lower() for r in caplog.records
+        )
+
+
+class TestRejectActorRecommendationReceivedUseCase:
+    """execute() unit tests for RejectActorRecommendationReceivedUseCase (CM-16-007, ADR-0026)."""
+
+    @pytest.fixture(autouse=True)
+    def clear_blackboard(self):
+        py_trees.blackboard.Blackboard.storage.clear()
+        yield
+        py_trees.blackboard.Blackboard.storage.clear()
+
+    def _build_event(self, make_payload, case_id, owner_id, recommended_id):
+        """Build Reject(Offer(CaseParticipant, Case)) and extract the domain event."""
+        from vultron.core.models.events.actor import (
+            RejectActorRecommendationReceivedEvent,
+        )
+
+        recommended = as_Actor(id_=recommended_id)
+        inner_offer = offer_case_participant_activity(
+            recommended,
+            target=case_id,
+            actor="https://example.org/actors/case-actor",
+            origin="https://example.org/activities/orig-recommendation",
+        )
+        activity = reject_case_participant_offer_activity(
+            inner_offer,
+            target=case_id,
+            actor=owner_id,
+        )
+        event = make_payload(activity)
+        assert isinstance(
+            event, RejectActorRecommendationReceivedEvent
+        ), f"Expected RejectActorRecommendationReceivedEvent, got {type(event)}"
+        return event
+
+    def test_happy_path_emits_reject_notification(self, make_payload):
+        """Happy path: tree runs and outbox receives Reject notification."""
+        dl, local_actor_id, case_id, owner_id, _recommender_id = (
+            _build_accept_reject_dl()
+        )
+        recommended_id = "https://example.org/actors/vendor-rejected"
+        event = self._build_event(
+            make_payload, case_id, owner_id, recommended_id
+        )
+
+        RejectActorRecommendationReceivedUseCase(
+            dl, event, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
+
+        outbox = dl.outbox_list_for_actor(local_actor_id)
+        assert (
+            len(outbox) >= 1
+        ), f"Expected ≥1 outbox entry after reject, got {len(outbox)}"
+
+    def test_skips_when_case_id_missing(self, caplog):
+        """Logs a warning and returns early when case_id is absent."""
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        mock_event = MagicMock()
+        mock_event.activity_id = "https://example.org/activities/reject-bad"
+        mock_event.target_id = None
+        mock_event.activity = None
+        mock_event.object_id = None
+
+        with caplog.at_level(logging.WARNING):
+            RejectActorRecommendationReceivedUseCase(dl, mock_event).execute()
+
+        assert any("missing" in r.message.lower() for r in caplog.records)
+
+    def test_skips_when_no_local_actor(self, make_payload, caplog):
+        """Logs a warning and returns early when no local actor exists in DataLayer."""
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case_id = "https://example.org/cases/no-actor-reject-case"
+        owner_id = "https://example.org/actors/owner"
+        recommended_id = "https://example.org/actors/vendor-new"
+        event = self._build_event(
+            make_payload, case_id, owner_id, recommended_id
+        )
+
+        with caplog.at_level(logging.WARNING):
+            RejectActorRecommendationReceivedUseCase(dl, event).execute()
+
+        assert any(
+            "no local actor" in r.message.lower() for r in caplog.records
+        )


### PR DESCRIPTION
- Closes #1326

## Summary

Adds 6 dedicated `execute()`-path unit tests for the two received-side use cases in the ADR-0026 CaseActor-routed actor suggestion flow (`AcceptActorRecommendationReceivedUseCase` and `RejectActorRecommendationReceivedUseCase`), covering happy path, missing `case_id`, and no-local-actor guard for each. Prior coverage was structural BT tree tests only.

## Changes

- `test/core/use_cases/received/actor/test_suggest.py`: add `TestAcceptActorRecommendationReceivedUseCase` (3 tests) and `TestRejectActorRecommendationReceivedUseCase` (3 tests); add `_build_accept_reject_dl()` helper that seeds a `SqliteDataLayer` with a Service actor, a VulnerabilityCase, and the original recommendation activity so `recommender_id` resolves via `dl.read()` rather than falling back to an empty string

## Verification

- 9 unit tests pass in `test/core/use_cases/received/actor/test_suggest.py` (6 new)
- Full suite: 4474 passed, 38 skipped, 2 xfailed — no regressions
- Black, flake8, mypy, pyright all clean