### PR TITLE
docs: plan concern #1334 — neutral ActorConfig loader + config sub-package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,6 +304,13 @@ If instructions are ambiguous:
 Key pitfall write-ups are in the `notes/` files.
 Short entries are reproduced here; longer ones are referenced below.
 
+- **Production Adapters MUST NOT Import from `vultron/demo/` for Config** —
+  `vultron/demo/` is scaffolding; its modules MUST NOT be imported by
+  production adapter code.  Actor policy configuration (`auto_create_case`,
+  `default_case_roles`) belongs in `AppConfig.actor` (loaded via
+  `load_actor_config()` from `vultron/config/`), not in `SeedConfig`.
+  See [notes/configuration.md](notes/configuration.md) § "Target Architecture"
+  and specs CFG-07-005 through CFG-07-007.
 - **Idempotency Responsibility Chain** — see
   [`vultron/core/AGENTS.md`](vultron/core/AGENTS.md)
 - **Bulk Logging-Level Refactors Need a Consistency Grep Pass** — After

--- a/docs/adr/0031-vultron-enums-neutral-layer.md
+++ b/docs/adr/0031-vultron-enums-neutral-layer.md
@@ -1,0 +1,114 @@
+---
+status: accepted
+date: 2026-07-10
+deciders: Allen D. Householder
+---
+
+# Introduce `vultron/enums/` as a Bottom-of-Stack Neutral Layer for Cross-Cutting Enumerations
+
+## Context and Problem Statement
+
+`vultron/config/` must be a neutral module — it must not import from
+`vultron/core/` or `vultron/adapters/`. However, `ActorConfig` (which will
+live in `vultron/config/actor.py`) needs `CVDRole` to type the
+`default_case_roles` field. `CVDRole` currently lives in
+`vultron/core/states/roles.py`, which is inside the core domain layer.
+
+If `vultron/config/` imports `CVDRole` from `vultron/core/`, it violates the
+neutral-module constraint: neutral modules must not import from core. The
+import graph has no valid location for `CVDRole` that satisfies all three
+layers (core, config, adapters) simultaneously — unless a new bottom-of-stack
+layer is introduced that all other layers may import freely.
+
+Concern #1334 and spec CFG-07-006 identified this gap.
+
+## Decision Drivers
+
+- `vultron/config/` must remain neutral (no imports from `vultron/core/` or
+  `vultron/adapters/`).
+- `ActorConfig.default_case_roles` requires `CVDRole` at type-annotation time.
+- `CVDRole` is a pure enumeration with no domain-logic dependencies — it is
+  appropriate as a shared primitive.
+- The fix must not create a circular import.
+- The fix should generalise: other enumerations may need the same treatment.
+
+## Considered Options
+
+1. **Introduce `vultron/enums/` as a new bottom-of-stack neutral package**
+   containing `CVDRole` and related helpers, importable by all layers.
+2. **Move `CVDRole` into `vultron/config/`** directly, making it a config
+   concern rather than a domain concern.
+3. **Keep `CVDRole` in `vultron/core/` and use a `TYPE_CHECKING` guard** in
+   `vultron/config/actor.py` to avoid the runtime import.
+4. **Use `str` / plain string literals** for `default_case_roles`, deferring
+   `CVDRole` validation to a later layer.
+
+## Decision Outcome
+
+Chosen option: **Introduce `vultron/enums/` as a new bottom-of-stack neutral
+package**, because it is the only option that preserves both the neutral-module
+constraint on `vultron/config/` and the domain-model status of `CVDRole` as a
+shared primitive, without `TYPE_CHECKING` hacks or loss of type safety.
+
+### Consequences
+
+- Good, because `vultron/config/`, `vultron/core/`, and `vultron/adapters/`
+  can all import from `vultron/enums/` freely without layering violations.
+- Good, because `CVDRole` retains its identity as a domain primitive rather
+  than being absorbed into config or stringly-typed.
+- Good, because `vultron/enums/` can absorb other cross-cutting enumerations
+  in the future (e.g., `RunMode`) following the same pattern.
+- Bad, because it adds a new top-level package to the module hierarchy;
+  existing imports of `CVDRole` from `vultron/core/states/roles.py` must be
+  updated (tracked in #1342 / #1343).
+- Bad, because `vultron/enums/` must be kept strictly free of imports from
+  `vultron/core/`, `vultron/config/`, or `vultron/adapters/` — a new
+  invariant to enforce.
+
+## Pros and Cons of the Options
+
+### Option 1 — `vultron/enums/` bottom-of-stack package
+
+- Good, because it resolves the import cycle cleanly for all current and
+  future neutral-module consumers.
+- Good, because the constraint is enforceable via import-graph linting.
+- Neutral, because the migration is mechanical (search-and-replace imports).
+
+### Option 2 — Move `CVDRole` into `vultron/config/`
+
+- Bad, because `CVDRole` is used by `vultron/core/` BT nodes; placing it in
+  `vultron/config/` would make core depend on config — a layering violation.
+
+### Option 3 — `TYPE_CHECKING` guard
+
+- Bad, because it breaks runtime isinstance checks and Pydantic validators
+  that need the actual enum class at import time.
+- Bad, because `TYPE_CHECKING` guards are fragile; they hide dependency
+  structure rather than resolving it.
+
+### Option 4 — Plain strings
+
+- Bad, because it removes the type safety that `CVDRole` provides.
+- Bad, because it moves validation responsibility to runtime rather than
+  model-construction time.
+
+## Validation
+
+Import-graph tests in `test/architecture/` (ARCH-01 series) must be extended
+to assert:
+
+- `vultron.enums` does NOT import from `vultron.core`, `vultron.config`, or
+  `vultron.adapters`.
+- `vultron.config` does NOT import from `vultron.core` or `vultron.adapters`.
+
+## More Information
+
+Generated spec requirements: `specs/configuration.yaml` CFG-07-006.
+
+Related:
+
+- Concern #1334 — original bug report (SeedConfig in production adapter)
+- PR #1341 — docs: plan concern #1334 (this ADR drafted as follow-up)
+- Issues #1342 / #1343 — implementation of the config sub-package
+- `notes/configuration.md` § "Target Architecture" — full sub-package layout
+  and import-graph constraints

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -83,6 +83,8 @@ General information about architectural decision records is available at <https:
 - [ADR-0024 Coordination Agent Taxonomy](0024-coordination-agent-taxonomy.md)
 - [ADR-0025 Call-Out Point Abstraction Layer: Factory-Based Injection with
   Typed Backends](0025-call-out-point-abstraction-layer.md)
+- [ADR-0031 Introduce `vultron/enums/` as a Bottom-of-Stack Neutral Layer for
+  Cross-Cutting Enumerations](0031-vultron-enums-neutral-layer.md)
 
 ## Proposed ADRs
 

--- a/notes/configuration.md
+++ b/notes/configuration.md
@@ -310,45 +310,76 @@ def test_env_overrides_yaml(tmp_path, monkeypatch):
 
 ---
 
-## SeedConfig Refactoring Notes
+## Target Architecture: `vultron/config/` Sub-Package
 
-`SeedConfig` in `vultron/demo/seed_config.py` already uses the
-`yaml.safe_load()` + `model_validate()` pattern. The refactor to
-`pydantic-settings` `BaseSettings` makes loading consistent with
-`AppConfig`. Key changes:
+`vultron/config.py` MUST be converted to a `vultron/config/` sub-package
+with the following layout (CFG-07-005, CFG-07-006, issue #1334):
+
+```text
+vultron/
+  enums/
+    __init__.py
+    roles.py     ← CVDRole, serialize_roles, validate_roles
+                   (moved from vultron/core/states/roles.py)
+  config/
+    __init__.py  ← public re-exports: AppConfig, get_config, reload_config,
+                   ActorConfig, load_actor_config
+    app.py       ← AppConfig, ServerConfig, DatabaseConfig, RunMode,
+                   YamlConfigSource, get_config(), reload_config()
+    actor.py     ← ActorConfig (moved from vultron/core/models/actor_config.py),
+                   load_actor_config()
+```
+
+`actor.py` imports `CVDRole` from `vultron.enums.roles` — not from
+`vultron/core/` — preserving the neutral-module constraint.
+
+`load_actor_config()` reads `VULTRON_SEED_CONFIG` YAML first (parsing only
+`auto_create_case` and `default_case_roles` from the `local_actor` block via
+`model_validate(..., strict=False)` with `extra="ignore"`), then falls back to
+`VULTRON_ACTOR_*` env vars. Production adapters call this instead of
+importing `SeedConfig`.
+
+`AppConfig` gains an `actor: ActorConfig` section so that `load_actor_config()`
+becomes a thin wrapper over `get_config().actor`.
+
+---
+
+## SeedConfig Refactoring
+
+`SeedConfig` in `vultron/demo/seed_config.py` MUST be migrated to
+`pydantic-settings` `BaseSettings` (issue #1334). Key changes:
 
 - Subclass `BaseSettings` instead of `BaseModel`
-- Set `model_config = {"env_prefix": "VULTRON_", ...}` with appropriate
-  field aliases matching existing env var names
-- Remove `from_env()` and `from_file()` classmethods; `BaseSettings`
-  handles source merging automatically
-- Keep `load()` as a thin wrapper for the `VULTRON_SEED_CONFIG` path
-  override (or replace with a `YamlConfigSource` on `SeedConfig`)
-- `LocalActorConfig` and `PeerActorConfig` stay as plain `BaseModel`
-  since they are sub-models, not top-level settings
+- Drop `from_env()` and `from_file()` classmethods — `BaseSettings` handles
+  source merging automatically
+- Keep `load()` only if `VULTRON_SEED_CONFIG` path override cannot be
+  expressed as a `YamlConfigSource`; otherwise remove it
+- `LocalActorConfig` MUST become a plain `BaseModel` carrying only bootstrap
+  identity fields (`name`, `actor_type`, `id_`) — it MUST NOT extend
+  `ActorConfig` (CFG-07-007). Actor policy fields (`auto_create_case`,
+  `default_case_roles`) are now owned by `AppConfig.actor`
+- `PeerActorConfig` stays as a plain `BaseModel` sub-model
 
 ---
 
 ## Relation to Existing Code
 
-### What this does NOT change
+### Layer rules
 
-- `SeedConfig`'s YAML format and field names (backward-compatible schema)
-- Docker seed-config YAML files in `docker/seed-configs/`
-- Demo scenario actor URL constants (those live in demo scripts, not
-  AppConfig)
-- The `.env` / `.env.example` files for Docker Compose (those set Docker
-  Compose project name, not Vultron app config)
-
-### Layer rules preserved
-
-`vultron/config.py` is a neutral module. The import graph stays clean:
+`vultron/config/` is a neutral sub-package. The import graph:
 
 ```text
-vultron/adapters/   → vultron/config.py   ✅  (adapters may import neutral modules)
-vultron/core/       → vultron/config.py   ✅  (core may import neutral modules)
-vultron/config.py   → vultron/adapters/   ❌  (MUST NOT — neutral modules don't
-                                               import from adapters)
-vultron/config.py   → vultron/core/       ❌  (MUST NOT — neutral modules don't
-                                               import from domain core)
+vultron/adapters/   → vultron/config/   ✅  (adapters may import neutral modules)
+vultron/core/       → vultron/config/   ✅  (core may import neutral modules)
+vultron/config/     → vultron/adapters/ ❌  (MUST NOT)
+vultron/config/     → vultron/core/     ❌  (MUST NOT — use vultron/enums/ instead)
+vultron/enums/      → vultron/core/     ❌  (MUST NOT — enums are bottom-of-stack)
+vultron/enums/      → vultron/config/   ❌  (MUST NOT)
 ```
+
+### Docker seed-config YAML files
+
+Files in `docker/seed-configs/` use the `local_actor:` block for bootstrap
+identity (`name`, `actor_type`, `id`). Actor policy fields that were previously
+in `local_actor:` (`auto_create_case`, `default_case_roles`) must move to a
+separate `config.yaml` `actor:` section in those deployments.

--- a/plan/history/2607/learning/CONCERN-1334.md
+++ b/plan/history/2607/learning/CONCERN-1334.md
@@ -1,0 +1,39 @@
+---
+source: CONCERN-1334
+timestamp: '2026-07-10T18:20:37.482391+00:00'
+title: SeedConfig imported from vultron/demo/ in production adapter (inbox_port_factories)
+type: learning
+---
+
+## Background
+
+PR #1331 resolved #1319 by wiring `_resolve_actor_config()` into the `SUBMIT_REPORT` dispatch path via `SeedConfig.load()`. This correctly honours `auto_create_case=False` at runtime.
+
+However, the import lives in `vultron/adapters/driving/fastapi/inbox_port_factories.py` (a production adapter module):
+
+```python
+from vultron.demo.seed_config import SeedConfig
+```
+
+`notes/configuration.md` describes `SeedConfig` as a demo/seed-config concern separate from the production `AppConfig`. This import makes `vultron/demo/` a de-facto production dependency.
+
+## What needs to be done
+
+Move the actor configuration loading used by the production dispatch path to a neutral location — either:
+
+- Promote `LocalActorConfig` / the `auto_create_case` field to `vultron/config.py` (or a new `vultron/actor_config.py` neutral module), or
+- Add a thin accessor function in a neutral module that `inbox_port_factories.py` can import without touching `vultron/demo/`.
+
+The resolution must preserve the existing env-var and YAML seed-config loading behaviour for demo deployments.
+
+## References
+
+- PR: <https://github.com/CERTCC/Vultron/pull/1331>
+- Follows: #1319
+- Notes: `notes/configuration.md` § "SeedConfig Refactoring Notes"
+- Spec: `specs/configuration.yaml` CFG-07-*
+
+**Resolved**: 2026-07-10 — implementation tracked in #1342, #1343.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1341>.
+Spec: `specs/configuration.yaml` CFG-07-005 through CFG-07-007.
+Notes: `notes/configuration.md` § "Target Architecture".

--- a/specs/configuration.yaml
+++ b/specs/configuration.yaml
@@ -225,3 +225,43 @@ groups:
     statement: >-
       BT nodes that create a case-owner participant record for the local actor MUST source
       the actor's CVD roles from `ActorConfig.default_case_roles`, not from a hardcoded constant.
+  - id: CFG-07-005
+    priority: MUST
+    statement: >-
+      A `load_actor_config()` function MUST exist in `vultron/config/` (the neutral config
+      sub-package) and MUST return an `ActorConfig` by reading `VULTRON_SEED_CONFIG` YAML
+      (extracting `local_actor` fields with `extra="ignore"` to discard demo-only fields) or
+      falling back to `VULTRON_ACTOR_*` environment variables.  Production adapter modules
+      MUST import this function rather than importing from `vultron/demo/` to obtain actor
+      policy configuration.
+    rationale: >-
+      PR #1331 introduced a direct `SeedConfig` import in
+      `vultron/adapters/driving/fastapi/inbox_port_factories.py`, making `vultron/demo/` a
+      de-facto production dependency (concern #1334).  A neutral `load_actor_config()` in
+      `vultron/config/` severs that dependency without losing YAML seed-file support.
+  - id: CFG-07-006
+    priority: MUST
+    statement: >-
+      `CVDRole` and its associated helpers (`serialize_roles`, `validate_roles`) MUST reside
+      in a top-level neutral enum module (`vultron/enums/roles.py`) rather than inside
+      `vultron/core/`, so that `vultron/config/` and other neutral modules can import them
+      without violating the constraint that neutral modules MUST NOT import from
+      `vultron/core/`.
+    rationale: >-
+      `ActorConfig` in `vultron/config/actor.py` needs `CVDRole`.  If `CVDRole` stays in
+      `vultron/core/states/roles.py`, `vultron/config/` must import from core — a layering
+      violation.  Moving `CVDRole` to the top-level neutral layer resolves this for all
+      layers simultaneously.
+  - id: CFG-07-007
+    priority: MUST
+    statement: >-
+      `LocalActorConfig` in `vultron/demo/seed_config.py` MUST be decoupled from `ActorConfig`:
+      it MUST carry only demo/bootstrap fields (`name`, `actor_type`, `id_`) and MUST NOT
+      extend `ActorConfig`.  Actor policy fields (`auto_create_case`, `default_case_roles`)
+      belong in `AppConfig.actor` and are loaded via `load_actor_config()`.
+    rationale: >-
+      `LocalActorConfig` currently extends `ActorConfig`, mixing bootstrap identity data with
+      runtime policy.  In the target architecture, identity data seeds the DataLayer once at
+      startup while policy is read at dispatch time from `AppConfig.actor`.  Decoupling the
+      two models reflects this distinct lifecycle and prevents demo scaffolding from leaking
+      policy concerns into production paths.


### PR DESCRIPTION
- Closes #1334

## Summary

Plans concern #1334: `SeedConfig` imported from `vultron/demo/` in the
production adapter `inbox_port_factories.py`. Adds specs and design notes
establishing the target architecture (CFG-07-005 through CFG-07-007) and
an AGENTS.md pitfall to prevent recurrence.

## Changes

- `specs/configuration.yaml` — add CFG-07-005 (`load_actor_config()` in neutral
  `vultron/config/`), CFG-07-006 (`CVDRole` to `vultron/enums/roles.py`),
  CFG-07-007 (`LocalActorConfig` decoupled from `ActorConfig`)
- `notes/configuration.md` — target `vultron/config/` sub-package layout,
  `load_actor_config()` design, revised SeedConfig refactor scope, docker YAML
  migration note
- `AGENTS.md` — new pitfall entry: production adapters MUST NOT import from
  `vultron/demo/` for configuration loading