### PR TITLE
docs: plan concern #1335 — namespace suggested_roles BT blackboard key

### DIFF
--- a/notes/bt-integration.md
+++ b/notes/bt-integration.md
@@ -1461,3 +1461,66 @@ are not affected.
 **Rule**: Any time a tree builder's default factory wraps a probabilistic fuzzer
 node, update all integration tests that assert `SUCCESS` to pass an explicit
 deterministic factory. See `test/AGENTS.md` § "BT Factory Determinism".
+
+---
+
+### Namespaced Inter-Node Handoff Keys
+
+(CONCERN-1335, 2026-07-10; see `specs/behavior-tree-node-design.yaml` BTND-03-004)
+
+The py_trees blackboard is **process-global**. When a tree factory function is
+called for two concurrent incoming messages of the same type (e.g., two
+simultaneous `Offer(Actor, Case)` deliveries), both tree instances write to the
+same flat blackboard namespace. A node in instance A that writes `suggested_roles`
+will have that value overwritten by instance B before instance A's downstream
+consumer reads it — causing silent data corruption.
+
+**Pattern**: Any BT node that writes an inter-node handoff key (a value written
+by one node and consumed by a downstream sibling in the same tree) MUST include
+the execution-scoped correlation ID in the key name:
+
+```python
+# ❌ WRONG — flat key, collides across concurrent tree instances
+self.blackboard.register_key("suggested_roles", access=Access.WRITE)
+self.blackboard.suggested_roles = [CVDRole.VENDOR]
+
+# ✅ CORRECT — namespaced by execution-scoped ID
+id_segment = self.recommendation_id.split("/")[-1]
+self.blackboard_key = f"suggested_roles_{id_segment}"
+self.blackboard.register_key(self.blackboard_key, access=Access.WRITE)
+setattr(self.blackboard, self.blackboard_key, [CVDRole.VENDOR])
+```
+
+The consumer node derives the same key from the same correlation ID:
+
+```python
+# In setup():
+id_segment = self.recommendation_id.split("/")[-1]
+self.blackboard_key = f"suggested_roles_{id_segment}"
+self.blackboard.register_key(self.blackboard_key, access=Access.READ)
+
+# In update():
+try:
+    roles = self.blackboard.get(self.blackboard_key)
+except KeyError:
+    roles = [CVDRole.VENDOR]  # safe default if key not set
+```
+
+**Key derivation convention**: `{noun}_{id_segment}` where `id_segment` is
+`correlation_id.split("/")[-1]` for HTTP URIs (same as `helpers.py` line 352),
+or the last colon-delimited segment for URN IDs. This matches the existing
+`object_{id_segment}` pattern used by `WriteObjectToBBNode` /
+`ReadObjectFromBBNode` in `helpers.py`.
+
+**When this applies**: Any inter-node handoff key in a tree factory that may
+realistically be called with multiple concurrent executions — i.e., where the
+factory is called per-incoming-message for a message type that can arrive in
+bursts (offer/accept/reject workflows in particular). Keys that are always
+cleaned up and rewritten before being read (e.g., within a single Sequence with
+`memory=False`) are safe, but namespacing eliminates the risk entirely and
+is cheap to implement.
+
+**First concrete instance**: `suggested_roles` in
+`create_recommend_actor_to_case_received_tree` — discovered in CONCERN-1335.
+Renamed to `suggested_roles_{recommendation_id_segment}` in issue #1335's
+implementation task.

--- a/plan/history/2607/learning/CONCERN-1335.md
+++ b/plan/history/2607/learning/CONCERN-1335.md
@@ -1,0 +1,27 @@
+---
+source: CONCERN-1335
+timestamp: '2026-07-10T19:57:34.629377+00:00'
+title: 'concern: EvaluateDefaultRolesNode uses global blackboard namespace — key collision
+  under concurrent BT execution'
+type: learning
+---
+
+`EvaluateDefaultRolesNode.setup()` registers `suggested_roles` in the global
+py_trees blackboard namespace (no `namespace=` argument). If two
+`RecommendActorToCaseBT` trees are instantiated and ticked in the same
+py_trees session simultaneously — e.g., two concurrent
+`Offer(Actor, Case)` inbox messages — the second write to `suggested_roles`
+silently overwrites the first, causing the first tree's
+`EmitOfferCaseParticipantToOwnerNode` to read the wrong role list.
+
+Latent today — inbox processing is sequential per-actor, so two simultaneous
+`RecommendActorToCaseBT` executions cannot race under the current delivery
+model. Becomes a live data-corruption hazard if concurrent BT execution is
+introduced (e.g., async inbox with parallel delivery) or a future Evaluator
+replacement (e.g., #1142) is wired without fixing the namespace first.
+
+**Resolved**: 2026-07-10 — implementation tracked in #1348. Follow-up concern
+for participant_add/owner cluster filed in #1349.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1347>.
+Spec: `specs/behavior-tree-node-design.yaml` BTND-03-004.
+Notes: `notes/bt-integration.md` § "Namespaced Inter-Node Handoff Keys".

--- a/specs/behavior-tree-node-design.yaml
+++ b/specs/behavior-tree-node-design.yaml
@@ -107,6 +107,27 @@ groups:
     statement: >-
       A BT node's docstring SHOULD document all blackboard keys it reads and writes, including
       the expected type and the node that produces the value for each READ key.
+  - id: BTND-03-004
+    priority: MUST
+    statement: >-
+      A BT node that writes an inter-node handoff key (a blackboard key written by one node
+      and consumed by a downstream sibling within the same tree) MUST namespace the key by
+      the execution-scoped correlation ID of the tree instance, using the `{noun}_{id_segment}`
+      convention (`id_segment` = `recommendation_id.split('/')[-1]` for HTTP URIs, or the
+      last colon-delimited segment for URN IDs). The same namespaced key MUST be used
+      consistently by all nodes in the tree that read or write that value.
+    rationale: >-
+      The py_trees blackboard is process-global. When a tree factory is called concurrently
+      (e.g., two `Offer(Actor, Case)` messages arriving in parallel futures), two tree
+      instances share the same blackboard namespace. A flat key like `suggested_roles` written
+      by the first instance is silently overwritten by the second before the first instance
+      reads it — causing the wrong role list to be emitted to the Case Owner. Namespacing by
+      the execution-scoped ID (e.g., `suggested_roles_abc123`) guarantees collision-free
+      per-execution storage. See `notes/bt-integration.md` §
+      "Namespaced Inter-Node Handoff Keys". Discovered in CONCERN-1335.
+    relationships:
+    - rel_type: refines
+      spec_id: BTND-03-001
 - id: BTND-04
   title: Module Ownership
   kind: implementation


### PR DESCRIPTION
- Closes #1335

## Summary

Plans concern #1335: `EvaluateDefaultRolesNode` uses a flat global blackboard
key `suggested_roles` that would collide if two `RecommendActorToCaseBT` trees
ran concurrently (e.g., two simultaneous `Offer(Actor, Case)` inbox messages).

## Changes

- `specs/behavior-tree-node-design.yaml` — adds BTND-03-004: inter-node
  handoff keys in BT trees that may be instantiated concurrently MUST be
  namespaced by the execution-scoped correlation ID using the
  `{noun}_{id_segment}` convention.
- `notes/bt-integration.md` — adds "Namespaced Inter-Node Handoff Keys"
  section with pattern, code examples, and derivation convention.