### PR TITLE
feat: apply EvaluatorCallOutPoint mixin to all Evaluator-shaped fuzzer nodes (FUZZ-08d)

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1173.md
+++ b/plan/history/2607/implementation/ISSUE-1173.md
@@ -1,0 +1,16 @@
+---
+source: ISSUE-1173
+timestamp: '2026-07-10T20:08:10.729359+00:00'
+title: 'FUZZ-08d: Apply EvaluatorCallOutPoint to all Evaluator-shaped fuzzer nodes'
+type: implementation
+---
+
+## Issue #1173 — FUZZ-08d: Implement all Evaluator-shaped call-out points (cross-domain)
+
+Applied EvaluatorCallOutPoint (and RetrieverCallOutPoint where appropriate) to 25 Evaluator-shaped fuzzer nodes across all domains: embargo (10 nodes), prioritize (1 Evaluator + 1 Retriever), assign_vul_id (2), deploy_fix (4), acquire_exploit (2), report_to_others (4), close_report (1), publication (4).
+
+Each node: EvaluatorCallOutPoint as first parent (MRO), output_keys dict with_verdict-suffixed key, blackboard contract docstring (BT-18-001).
+
+Test fixes: added node.setup() before node.update() in 5 legacy test files (test/fuzzer/) since the mixin now requires setup() to register the blackboard client.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1351>

--- a/plan/incoming/learnings/20260710-happy-path-dl-seed-must-include-stored-origin-activities.md
+++ b/plan/incoming/learnings/20260710-happy-path-dl-seed-must-include-stored-origin-activities.md
@@ -1,0 +1,28 @@
+---
+title: "Happy-path DataLayer seeds must include origin activities for use cases that call dl.read()"
+type: learning
+timestamp: "2026-07-10"
+source: ISSUE-1326
+---
+
+When a use case calls `dl.read(some_id)` to resolve a related entity (e.g.
+`recommender_id` from the original recommendation offer), the happy-path test
+fixture must store that entity in the DataLayer or the use case silently falls
+back to `""` / `None`.
+
+In `AcceptActorRecommendationReceivedUseCase` and
+`RejectActorRecommendationReceivedUseCase`, the `origin` field of the inner
+`Offer(CaseParticipant)` carries the original recommendation activity ID.
+The use case calls `self._dl.read(recommendation_id)` to look up that activity
+and extract `recommender_id`. If the activity is absent, `recommender_id=""`
+and the recommender-notification branch of the BT tree silently no-ops —
+but `len(outbox) >= 1` passes anyway because other tree nodes emit to the
+outbox. This hides the broken path.
+
+**Fix pattern**: after building the inner offer with `origin=<recommendation_id>`,
+call `dl.create(recommend_actor_activity(..., id_=<recommendation_id>))` in
+the fixture so `dl.read()` resolves correctly.
+
+**Assertion depth**: the Accept happy path emits both an Accept notification
+and an Invite (2 activities). Assert `len(outbox) >= 2` — not `>= 1` — to
+catch the case where only one of the two required activities was emitted.

--- a/test/demo/fuzzer/test_call_out_point.py
+++ b/test/demo/fuzzer/test_call_out_point.py
@@ -37,6 +37,51 @@ from vultron.demo.fuzzer.call_out_point import (
 )
 from vultron.demo.fuzzer.report_management.prioritize import OnAccept, OnDefer
 from vultron.demo.fuzzer.report_management.publication import PrepareReport
+from vultron.demo.fuzzer.embargo import (
+    CurrentEmbargoAcceptable,
+    EvaluateEmbargoProposal,
+    ExitEmbargoForOtherReason,
+    ExitEmbargoWhenDeployed,
+    ExitEmbargoWhenFixReady,
+    ReasonToProposeEmbargoWhenDeployed,
+    SelectEmbargoOfferTerms,
+    StopProposingEmbargo,
+    WantToProposeEmbargo,
+    WillingToCounterEmbargoProposal,
+)
+from vultron.demo.fuzzer.report_management.acquire_exploit import (
+    EvaluateExploitPriority,
+    PurchaseExploit,
+)
+from vultron.demo.fuzzer.report_management.assign_vul_id import (
+    IdAssignable,
+    InScope,
+)
+from vultron.demo.fuzzer.report_management.close_report import (
+    OtherCloseCriteriaMet,
+)
+from vultron.demo.fuzzer.report_management.deploy_fix import (
+    DeployFix,
+    DeployMitigation,
+    MonitoringRequirement,
+    PrioritizeDeployment,
+)
+from vultron.demo.fuzzer.report_management.prioritize import (
+    EnoughPrioritizationInfo,
+    GatherPrioritizationInfo,
+)
+from vultron.demo.fuzzer.report_management.publication import (
+    PrioritizePublicationIntents,
+    ReprioritizeExploit,
+    ReprioritizeFix,
+    ReprioritizeReport,
+)
+from vultron.demo.fuzzer.report_management.report_to_others import (
+    AllPartiesKnown,
+    PolicyCompatible,
+    RecipientEffortExceeded,
+    TotalEffortLimitMet,
+)
 from vultron.demo.fuzzer.report_management.validate import (
     EvaluateReportCredibility,
     EvaluateReportValidity,
@@ -275,3 +320,96 @@ def test_prepare_report_writes_blackboard_on_success():
     )
     val = py_trees.blackboard.Blackboard.storage["/prepared_report_artifact"]
     assert isinstance(val, str)
+
+
+# ---------------------------------------------------------------------------
+# AC5 — Blackboard contract for all 29 FUZZ-08d call-out-point nodes
+# (BT-18-001): each subclasses the correct shape mixin and declares its
+# output key with the right type annotation.
+# ---------------------------------------------------------------------------
+
+_EMBARGO_EVALUATOR_NODES = [
+    (ExitEmbargoWhenDeployed, "exit_embargo_when_deployed_verdict"),
+    (ExitEmbargoWhenFixReady, "exit_embargo_when_fix_ready_verdict"),
+    (ExitEmbargoForOtherReason, "exit_embargo_other_reason_verdict"),
+    (StopProposingEmbargo, "stop_proposing_embargo_verdict"),
+    (SelectEmbargoOfferTerms, "selected_embargo_terms_verdict"),
+    (WantToProposeEmbargo, "want_to_propose_embargo_verdict"),
+    (WillingToCounterEmbargoProposal, "willing_to_counter_verdict"),
+    (
+        ReasonToProposeEmbargoWhenDeployed,
+        "reason_to_propose_when_deployed_verdict",
+    ),
+    (EvaluateEmbargoProposal, "evaluate_embargo_proposal_verdict"),
+    (CurrentEmbargoAcceptable, "current_embargo_acceptable_verdict"),
+]
+
+_RM_EVALUATOR_NODES = [
+    (EnoughPrioritizationInfo, "enough_prioritization_info_verdict"),
+    (EvaluateExploitPriority, "exploit_priority_verdict"),
+    (PurchaseExploit, "purchase_exploit_verdict"),
+    (IdAssignable, "id_assignable_verdict"),
+    (InScope, "in_scope_verdict"),
+    (OtherCloseCriteriaMet, "other_close_criteria_met_verdict"),
+    (PrioritizeDeployment, "deployment_priority_verdict"),
+    (DeployMitigation, "deploy_mitigation_verdict"),
+    (MonitoringRequirement, "monitoring_requirement_verdict"),
+    (DeployFix, "deploy_fix_verdict"),
+    (PrioritizePublicationIntents, "publication_intents_verdict"),
+    (ReprioritizeExploit, "reprioritize_exploit_verdict"),
+    (ReprioritizeFix, "reprioritize_fix_verdict"),
+    (ReprioritizeReport, "reprioritize_report_verdict"),
+    (AllPartiesKnown, "all_parties_known_verdict"),
+    (RecipientEffortExceeded, "recipient_effort_exceeded_verdict"),
+    (PolicyCompatible, "policy_compatible_verdict"),
+    (TotalEffortLimitMet, "total_effort_limit_met_verdict"),
+]
+
+_RM_RETRIEVER_NODES = [
+    (GatherPrioritizationInfo, "prioritization_info_gathered"),
+]
+
+
+@pytest.mark.parametrize("node_cls, output_key", _EMBARGO_EVALUATOR_NODES)
+def test_embargo_node_subclasses_evaluator(node_cls, output_key):
+    assert issubclass(node_cls, EvaluatorCallOutPoint)
+
+
+@pytest.mark.parametrize("node_cls, output_key", _EMBARGO_EVALUATOR_NODES)
+def test_embargo_node_output_key_declared(node_cls, output_key):
+    assert output_key in node_cls.output_keys
+
+
+@pytest.mark.parametrize("node_cls, output_key", _EMBARGO_EVALUATOR_NODES)
+def test_embargo_node_output_key_type_is_str(node_cls, output_key):
+    assert node_cls.output_keys[output_key] is str
+
+
+@pytest.mark.parametrize("node_cls, output_key", _RM_EVALUATOR_NODES)
+def test_rm_evaluator_node_subclasses_evaluator(node_cls, output_key):
+    assert issubclass(node_cls, EvaluatorCallOutPoint)
+
+
+@pytest.mark.parametrize("node_cls, output_key", _RM_EVALUATOR_NODES)
+def test_rm_evaluator_node_output_key_declared(node_cls, output_key):
+    assert output_key in node_cls.output_keys
+
+
+@pytest.mark.parametrize("node_cls, output_key", _RM_EVALUATOR_NODES)
+def test_rm_evaluator_node_output_key_type_is_str(node_cls, output_key):
+    assert node_cls.output_keys[output_key] is str
+
+
+@pytest.mark.parametrize("node_cls, output_key", _RM_RETRIEVER_NODES)
+def test_rm_retriever_node_subclasses_retriever(node_cls, output_key):
+    assert issubclass(node_cls, RetrieverCallOutPoint)
+
+
+@pytest.mark.parametrize("node_cls, output_key", _RM_RETRIEVER_NODES)
+def test_rm_retriever_node_output_key_declared(node_cls, output_key):
+    assert output_key in node_cls.output_keys
+
+
+@pytest.mark.parametrize("node_cls, output_key", _RM_RETRIEVER_NODES)
+def test_rm_retriever_node_output_key_type_is_str(node_cls, output_key):
+    assert node_cls.output_keys[output_key] is str

--- a/test/fuzzer/report_management/test_acquire_exploit.py
+++ b/test/fuzzer/report_management/test_acquire_exploit.py
@@ -76,6 +76,7 @@ _ALL_NODES = [spec[0] for spec in _NODE_SPECS]
 def _run_trials(node_cls: "Type[WeightedBehavior]", n: int = _TRIALS) -> float:
     """Return empirical success rate over *n* independent ticks."""
     node = node_cls()
+    node.setup()
     successes = sum(1 for _ in range(n) if node.update() == Status.SUCCESS)
     return successes / n
 
@@ -171,6 +172,7 @@ class TestSuccessRates:
         self, node_cls: Type[WeightedBehavior]
     ) -> None:
         node = node_cls()
+        node.setup()
         result = node.update()
         assert result in (Status.SUCCESS, Status.FAILURE)
 
@@ -179,6 +181,7 @@ class TestSuccessRates:
         self, node_cls: Type[WeightedBehavior]
     ) -> None:
         node = node_cls()
+        node.setup()
         results = {node.update() for _ in range(50)}
         assert Status.RUNNING not in results
 
@@ -191,7 +194,9 @@ class TestSuccessRates:
     ) -> None:
         # AlwaysSucceed is deterministic — verify directly instead of statistically
         if expected_rate == 1.0:
-            assert node_cls().update() == Status.SUCCESS
+            node = node_cls()
+            node.setup()
+            assert node.update() == Status.SUCCESS
             return
         rate = _run_trials(node_cls)
         assert (

--- a/test/fuzzer/report_management/test_assign_vul_id.py
+++ b/test/fuzzer/report_management/test_assign_vul_id.py
@@ -66,6 +66,7 @@ _ALL_NODES: list[tuple[Type[WeightedBehavior], float]] = [
 def _run_trials(node_cls: Type[WeightedBehavior], n: int = _TRIALS) -> float:
     """Return empirical success rate over *n* independent ticks."""
     node = node_cls()
+    node.setup()
     successes = sum(1 for _ in range(n) if node.update() == Status.SUCCESS)
     return successes / n
 
@@ -176,6 +177,7 @@ class TestUpdateReturnsValidStatus:
         self, cls: Type[WeightedBehavior], _rate: float
     ) -> None:
         node = cls()
+        node.setup()
         result = node.update()
         assert result in (
             Status.SUCCESS,
@@ -187,6 +189,7 @@ class TestUpdateReturnsValidStatus:
         self, cls: Type[WeightedBehavior], _rate: float
     ) -> None:
         node = cls()
+        node.setup()
         results = {node.update() for _ in range(50)}
         assert (
             Status.RUNNING not in results
@@ -196,6 +199,7 @@ class TestUpdateReturnsValidStatus:
 class TestDeterministicExtremes:
     def test_assign_id_always_succeeds(self) -> None:
         node = AssignId()
+        node.setup()
         assert all(node.update() == Status.SUCCESS for _ in range(100))
 
 

--- a/test/fuzzer/report_management/test_close_report.py
+++ b/test/fuzzer/report_management/test_close_report.py
@@ -53,6 +53,7 @@ _ALL_NODES: list[tuple[Type[WeightedBehavior], float]] = [
 def _run_trials(node_cls: Type[WeightedBehavior], n: int = _TRIALS) -> float:
     """Return empirical success rate over *n* independent ticks."""
     node = node_cls()
+    node.setup()
     successes = sum(1 for _ in range(n) if node.update() == Status.SUCCESS)
     return successes / n
 
@@ -146,6 +147,7 @@ class TestUpdateReturnsValidStatus:
         self, cls: Type[WeightedBehavior], _rate: float
     ) -> None:
         node = cls()
+        node.setup()
         result = node.update()
         assert result in (Status.SUCCESS, Status.FAILURE)
 
@@ -154,6 +156,7 @@ class TestUpdateReturnsValidStatus:
         self, cls: Type[WeightedBehavior], _rate: float
     ) -> None:
         node = cls()
+        node.setup()
         results = {node.update() for _ in range(50)}
         assert Status.RUNNING not in results
 
@@ -161,6 +164,7 @@ class TestUpdateReturnsValidStatus:
 class TestDeterministicExtremes:
     def test_pre_close_action_always_succeeds(self) -> None:
         node = PreCloseAction()
+        node.setup()
         assert all(node.update() == Status.SUCCESS for _ in range(100))
 
 

--- a/test/fuzzer/report_management/test_deploy_fix.py
+++ b/test/fuzzer/report_management/test_deploy_fix.py
@@ -75,6 +75,7 @@ _ALL_NODES = [spec[0] for spec in _NODE_SPECS]
 def _run_trials(node_cls: "Type[WeightedBehavior]", n: int = _TRIALS) -> float:
     """Return empirical success rate over *n* independent ticks."""
     node = node_cls()
+    node.setup()
     successes = sum(1 for _ in range(n) if node.update() == Status.SUCCESS)
     return successes / n
 
@@ -170,6 +171,7 @@ class TestSuccessRates:
         self, node_cls: Type[WeightedBehavior]
     ) -> None:
         node = node_cls()
+        node.setup()
         result = node.update()
         assert result in (Status.SUCCESS, Status.FAILURE)
 
@@ -178,6 +180,7 @@ class TestSuccessRates:
         self, node_cls: Type[WeightedBehavior]
     ) -> None:
         node = node_cls()
+        node.setup()
         results = {node.update() for _ in range(50)}
         assert Status.RUNNING not in results
 
@@ -191,6 +194,7 @@ class TestSuccessRates:
         # AlwaysSucceed and AlwaysFail are deterministic — skip statistical check
         if expected_rate in (0.0, 1.0):
             node = node_cls()
+            node.setup()
             expected_status = (
                 Status.SUCCESS if expected_rate == 1.0 else Status.FAILURE
             )

--- a/test/fuzzer/test_embargo.py
+++ b/test/fuzzer/test_embargo.py
@@ -87,6 +87,7 @@ _NODE_NAMES = [cls.__name__ for cls, _ in _ALL_NODES]
 def _run_trials(node_cls: Type[WeightedBehavior], n: int = _TRIALS) -> float:
     """Return empirical success rate over *n* independent ticks."""
     node = node_cls()
+    node.setup()
     successes = sum(1 for _ in range(n) if node.update() == Status.SUCCESS)
     return successes / n
 
@@ -197,6 +198,7 @@ class TestUpdateReturnsValidStatus:
         self, cls: Type[WeightedBehavior], _rate: float
     ) -> None:
         node = cls()
+        node.setup()
         result = node.update()
         assert result in (
             Status.SUCCESS,
@@ -208,6 +210,7 @@ class TestUpdateReturnsValidStatus:
         self, cls: Type[WeightedBehavior], _rate: float
     ) -> None:
         node = cls()
+        node.setup()
         results = {node.update() for _ in range(50)}
         assert (
             Status.RUNNING not in results
@@ -217,18 +220,22 @@ class TestUpdateReturnsValidStatus:
 class TestDeterministicExtremes:
     def test_on_embargo_exit_always_succeeds(self) -> None:
         node = OnEmbargoExit()
+        node.setup()
         assert all(node.update() == Status.SUCCESS for _ in range(100))
 
     def test_select_embargo_offer_terms_always_succeeds(self) -> None:
         node = SelectEmbargoOfferTerms()
+        node.setup()
         assert all(node.update() == Status.SUCCESS for _ in range(100))
 
     def test_on_embargo_accept_always_succeeds(self) -> None:
         node = OnEmbargoAccept()
+        node.setup()
         assert all(node.update() == Status.SUCCESS for _ in range(100))
 
     def test_on_embargo_reject_always_succeeds(self) -> None:
         node = OnEmbargoReject()
+        node.setup()
         assert all(node.update() == Status.SUCCESS for _ in range(100))
 
 
@@ -258,6 +265,7 @@ class TestEmpiricalDistributions:
         """Same seed → same sequence for a representative node."""
         random.seed(42)
         node = EvaluateEmbargoProposal()
+        node.setup()
         seq_a = [node.update() for _ in range(20)]
         random.seed(42)
         seq_b = [node.update() for _ in range(20)]

--- a/vultron/demo/fuzzer/embargo.py
+++ b/vultron/demo/fuzzer/embargo.py
@@ -43,13 +43,14 @@ from vultron.demo.fuzzer.base import (
     UsuallyFail,
     UsuallySucceed,
 )
+from vultron.demo.fuzzer.call_out_point import EvaluatorCallOutPoint
 
 # ---------------------------------------------------------------------------
 # Embargo termination nodes
 # ---------------------------------------------------------------------------
 
 
-class ExitEmbargoWhenDeployed(ProbablyFail):
+class ExitEmbargoWhenDeployed(EvaluatorCallOutPoint, ProbablyFail):
     """Decide whether to exit an active embargo when the fix is deployed.
 
     Semantic function:
@@ -58,6 +59,10 @@ class ExitEmbargoWhenDeployed(ProbablyFail):
         case where deployment alone is *not* a sufficient trigger (e.g.,
         partial rollout, emergency deployment, or pending coordinated
         announcement).
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — evaluates deployment state from caller's DataLayer)
+      Output keys: exit_embargo_when_deployed_verdict: str  (SUCCESS only)
 
     Input category: Human decision / policy judgment.
 
@@ -68,8 +73,10 @@ class ExitEmbargoWhenDeployed(ProbablyFail):
     requires policy-rule evaluation or human confirmation.
     """
 
+    output_keys = {"exit_embargo_when_deployed_verdict": str}
 
-class ExitEmbargoWhenFixReady(UsuallyFail):
+
+class ExitEmbargoWhenFixReady(EvaluatorCallOutPoint, UsuallyFail):
     """Decide whether to exit an active embargo when the fix is ready.
 
     Semantic function:
@@ -77,6 +84,10 @@ class ExitEmbargoWhenFixReady(UsuallyFail):
         deployment) is sufficient reason to terminate the embargo.
         Vendors may prefer to coordinate simultaneous deployment across
         the affected population before ending the embargo.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — evaluates fix-readiness state from caller's DataLayer)
+      Output keys: exit_embargo_when_fix_ready_verdict: str  (SUCCESS only)
 
     Input category: Human decision / policy judgment.
 
@@ -87,8 +98,10 @@ class ExitEmbargoWhenFixReady(UsuallyFail):
     policy that may require human override.
     """
 
+    output_keys = {"exit_embargo_when_fix_ready_verdict": str}
 
-class ExitEmbargoForOtherReason(OneInTwoHundred):
+
+class ExitEmbargoForOtherReason(EvaluatorCallOutPoint, OneInTwoHundred):
     """Decide whether to exit an embargo for an uncommon or exceptional reason.
 
     Semantic function:
@@ -96,6 +109,10 @@ class ExitEmbargoForOtherReason(OneInTwoHundred):
         fix readiness, deployment, timer expiry, public awareness, known
         exploits, or observed attacks.  Represents extraordinary
         circumstances that are rare in practice.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — evaluates case context from caller's DataLayer)
+      Output keys: exit_embargo_other_reason_verdict: str  (SUCCESS only)
 
     Input category: Human decision.
 
@@ -105,6 +122,8 @@ class ExitEmbargoForOtherReason(OneInTwoHundred):
     extraordinary circumstances; fundamentally requires human judgment that
     cannot be anticipated by a general policy rule.
     """
+
+    output_keys = {"exit_embargo_other_reason_verdict": str}
 
 
 class EmbargoTimerExpired(OneInOneHundred):
@@ -148,7 +167,7 @@ class OnEmbargoExit(AlwaysSucceed):
 # ---------------------------------------------------------------------------
 
 
-class StopProposingEmbargo(UsuallyFail):
+class StopProposingEmbargo(EvaluatorCallOutPoint, UsuallyFail):
     """Decide whether to abandon an ongoing embargo negotiation.
 
     Semantic function:
@@ -156,6 +175,10 @@ class StopProposingEmbargo(UsuallyFail):
         embargo (e.g., too many counter-proposals, time pressure).
         Modeled as uncommon; parties are usually willing to keep
         negotiating.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — evaluates negotiation context from caller's DataLayer)
+      Output keys: stop_proposing_embargo_verdict: str  (SUCCESS only)
 
     Input category: Human decision.
 
@@ -166,14 +189,20 @@ class StopProposingEmbargo(UsuallyFail):
     prospects; requires human decision.
     """
 
+    output_keys = {"stop_proposing_embargo_verdict": str}
 
-class SelectEmbargoOfferTerms(AlwaysSucceed):
+
+class SelectEmbargoOfferTerms(EvaluatorCallOutPoint, AlwaysSucceed):
     """Select the specific terms to include in an embargo proposal.
 
     Semantic function:
         Action — choose duration, conditions, and other terms for a new
         embargo proposal or counter-proposal.  In production may involve
         negotiation-support tooling or organizational policy lookup.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — selects terms based on case context from DataLayer)
+      Output keys: selected_embargo_terms_verdict: str  (SUCCESS only)
 
     Input category: Human decision.
 
@@ -184,8 +213,10 @@ class SelectEmbargoOfferTerms(AlwaysSucceed):
     need human review.
     """
 
+    output_keys = {"selected_embargo_terms_verdict": str}
 
-class WantToProposeEmbargo(RandomSucceedFail):
+
+class WantToProposeEmbargo(EvaluatorCallOutPoint, RandomSucceedFail):
     """Decide whether to initiate an embargo negotiation.
 
     Semantic function:
@@ -193,6 +224,10 @@ class WantToProposeEmbargo(RandomSucceedFail):
         embargo?  Depends on case context, role, and organizational
         policy.  The fuzzer exercises both paths equally; in production
         the recommended default is to propose an embargo.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — evaluates case and role context from caller's DataLayer)
+      Output keys: want_to_propose_embargo_verdict: str  (SUCCESS only)
 
     Input category: Human decision.
 
@@ -204,8 +239,10 @@ class WantToProposeEmbargo(RandomSucceedFail):
     override.
     """
 
+    output_keys = {"want_to_propose_embargo_verdict": str}
 
-class WillingToCounterEmbargoProposal(UsuallyFail):
+
+class WillingToCounterEmbargoProposal(EvaluatorCallOutPoint, UsuallyFail):
     """Decide whether to counter an incoming embargo proposal.
 
     Semantic function:
@@ -215,6 +252,10 @@ class WillingToCounterEmbargoProposal(UsuallyFail):
         current proposal and negotiate revisions separately; countering is
         intentionally modeled as uncommon.
 
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — evaluates proposal context from caller's DataLayer)
+      Output keys: willing_to_counter_verdict: str  (SUCCESS only)
+
     Input category: Human decision.
 
     Success probability: 0.25 (``UsuallyFail``).
@@ -223,6 +264,8 @@ class WillingToCounterEmbargoProposal(UsuallyFail):
     whether countering is strategically preferable to accepting and
     revising; best left to human discretion.
     """
+
+    output_keys = {"willing_to_counter_verdict": str}
 
 
 class AvoidEmbargoCounterProposal(UsuallySucceed):
@@ -246,13 +289,19 @@ class AvoidEmbargoCounterProposal(UsuallySucceed):
     """
 
 
-class ReasonToProposeEmbargoWhenDeployed(AlmostCertainlyFail):
+class ReasonToProposeEmbargoWhenDeployed(
+    EvaluatorCallOutPoint, AlmostCertainlyFail
+):
     """Decide whether to start a new embargo after the fix is already deployed.
 
     Semantic function:
         Condition — is there an unusual reason to propose an embargo even
         though the fix has already been deployed?  Post-deployment embargo
         proposals are exceptional and very rare.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — evaluates case context from caller's DataLayer)
+      Output keys: reason_to_propose_when_deployed_verdict: str  (SUCCESS only)
 
     Input category: Human decision.
 
@@ -263,13 +312,15 @@ class ReasonToProposeEmbargoWhenDeployed(AlmostCertainlyFail):
     required.
     """
 
+    output_keys = {"reason_to_propose_when_deployed_verdict": str}
+
 
 # ---------------------------------------------------------------------------
 # Embargo proposal evaluation nodes
 # ---------------------------------------------------------------------------
 
 
-class EvaluateEmbargoProposal(UsuallySucceed):
+class EvaluateEmbargoProposal(EvaluatorCallOutPoint, UsuallySucceed):
     """Assess an incoming embargo proposal and decide whether to accept it.
 
     Semantic function:
@@ -277,6 +328,10 @@ class EvaluateEmbargoProposal(UsuallySucceed):
         they are acceptable.  In production may involve automated policy
         compatibility checks or structured human analyst review.  Modeled
         as usually succeeding (acceptance is the common outcome).
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — evaluates incoming proposal from caller's DataLayer)
+      Output keys: evaluate_embargo_proposal_verdict: str  (SUCCESS only)
 
     Input category: Human decision.
 
@@ -286,6 +341,8 @@ class EvaluateEmbargoProposal(UsuallySucceed):
     proposed duration within policy bounds?) is automatable; final
     accept/reject for out-of-range proposals typically needs human review.
     """
+
+    output_keys = {"evaluate_embargo_proposal_verdict": str}
 
 
 class OnEmbargoAccept(AlwaysSucceed):
@@ -328,13 +385,17 @@ class OnEmbargoReject(AlwaysSucceed):
 # ---------------------------------------------------------------------------
 
 
-class CurrentEmbargoAcceptable(AlmostAlwaysSucceed):
+class CurrentEmbargoAcceptable(EvaluatorCallOutPoint, AlmostAlwaysSucceed):
     """Decide whether the current active embargo terms remain acceptable.
 
     Semantic function:
         Condition — is the participant satisfied with the current active
         embargo, or do they wish to propose a revision?  Modeled as
         usually acceptable; revision proposals are relatively uncommon.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — evaluates active embargo terms from caller's DataLayer)
+      Output keys: current_embargo_acceptable_verdict: str  (SUCCESS only)
 
     Input category: Human decision.
 
@@ -344,3 +405,5 @@ class CurrentEmbargoAcceptable(AlmostAlwaysSucceed):
     terms against policy preferences is feasible; edge cases and dynamic
     negotiation contexts may still require human judgment.
     """
+
+    output_keys = {"current_embargo_acceptable_verdict": str}

--- a/vultron/demo/fuzzer/report_management/acquire_exploit.py
+++ b/vultron/demo/fuzzer/report_management/acquire_exploit.py
@@ -42,6 +42,7 @@ from vultron.demo.fuzzer.base import (
     RarelySucceed,
     UsuallyFail,
 )
+from vultron.demo.fuzzer.call_out_point import EvaluatorCallOutPoint
 
 
 class HaveExploit(UsuallyFail):
@@ -102,7 +103,7 @@ class ExploitPrioritySet(AlmostAlwaysSucceed):
     """
 
 
-class EvaluateExploitPriority(AlwaysSucceed):
+class EvaluateExploitPriority(EvaluatorCallOutPoint, AlwaysSucceed):
     """Evaluate the priority of acquiring an exploit for this vulnerability.
 
     Semantic function:
@@ -111,6 +112,10 @@ class EvaluateExploitPriority(AlwaysSucceed):
         as SSVC exploitation status, asset criticality, and organizational
         policy.  Always succeeds in simulation to ensure the priority
         decision is always recorded, keeping the workflow progressing.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — evaluates case context from caller's DataLayer)
+      Output keys: exploit_priority_verdict: str  (SUCCESS only)
 
     Input category: Human decision.
 
@@ -121,6 +126,8 @@ class EvaluateExploitPriority(AlwaysSucceed):
     to pursue exploit acquisition typically requires human authorization,
     especially for high-risk or regulated environments.
     """
+
+    output_keys = {"exploit_priority_verdict": str}
 
 
 class ExploitDesired(OftenFail):
@@ -186,7 +193,7 @@ class DevelopExploit(OftenSucceed):
     """
 
 
-class PurchaseExploit(RarelySucceed):
+class PurchaseExploit(EvaluatorCallOutPoint, RarelySucceed):
     """Pursue purchase of an exploit from an external vendor or broker.
 
     Semantic function:
@@ -196,6 +203,10 @@ class PurchaseExploit(RarelySucceed):
         and often logistically complex path, reserved for high-priority
         cases where internal development has failed.
 
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — evaluates procurement context from caller's DataLayer)
+      Output keys: purchase_exploit_verdict: str  (SUCCESS only)
+
     Input category: Human decision.
 
     Success probability: 0.10 (``RarelySucceed``).
@@ -204,3 +215,5 @@ class PurchaseExploit(RarelySucceed):
     compliance, and budget approvals as well as vendor negotiation; these
     steps are inherently manual and cannot be automated.
     """
+
+    output_keys = {"purchase_exploit_verdict": str}

--- a/vultron/demo/fuzzer/report_management/assign_vul_id.py
+++ b/vultron/demo/fuzzer/report_management/assign_vul_id.py
@@ -39,6 +39,7 @@ from vultron.demo.fuzzer.base import (
     UsuallyFail,
     UsuallySucceed,
 )
+from vultron.demo.fuzzer.call_out_point import EvaluatorCallOutPoint
 
 
 class IdAssigned(UsuallyFail):
@@ -62,7 +63,7 @@ class IdAssigned(UsuallyFail):
     """
 
 
-class IdAssignable(ProbablySucceed):
+class IdAssignable(EvaluatorCallOutPoint, ProbablySucceed):
     """Check whether the vulnerability qualifies for an ID assignment.
 
     Semantic function:
@@ -74,6 +75,10 @@ class IdAssignable(ProbablySucceed):
         may be in scope for an ID space yet not assignable by the current
         party.
 
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — evaluates vulnerability attributes from caller's DataLayer)
+      Output keys: id_assignable_verdict: str  (SUCCESS only)
+
     Input category: Environmental check.
 
     Success probability: 0.6667 (``ProbablySucceed``).
@@ -83,6 +88,8 @@ class IdAssignable(ProbablySucceed):
     organizational metadata; edge cases or out-of-scope products may still
     require human review.
     """
+
+    output_keys = {"id_assignable_verdict": str}
 
 
 class IsIDAssignmentAuthority(OftenSucceed):
@@ -145,7 +152,7 @@ class AssignId(AlwaysSucceed):
     """
 
 
-class InScope(UsuallySucceed):
+class InScope(EvaluatorCallOutPoint, UsuallySucceed):
     """Check whether the vulnerability is within scope for an ID assignment.
 
     Semantic function:
@@ -156,6 +163,10 @@ class InScope(UsuallySucceed):
         rapid assignment may have a very broad scope requiring little or no
         explicit scope checking.
 
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — evaluates vulnerability attributes from caller's DataLayer)
+      Output keys: in_scope_verdict: str  (SUCCESS only)
+
     Input category: Environmental check / policy.
 
     Success probability: 0.75 (``UsuallySucceed``).
@@ -165,3 +176,5 @@ class InScope(UsuallySucceed):
     automatically; novel or ambiguous scope boundaries may still require human
     judgment.
     """
+
+    output_keys = {"in_scope_verdict": str}

--- a/vultron/demo/fuzzer/report_management/close_report.py
+++ b/vultron/demo/fuzzer/report_management/close_report.py
@@ -33,9 +33,10 @@ References
 from __future__ import annotations
 
 from vultron.demo.fuzzer.base import AlwaysSucceed, UsuallyFail
+from vultron.demo.fuzzer.call_out_point import EvaluatorCallOutPoint
 
 
-class OtherCloseCriteriaMet(UsuallyFail):
+class OtherCloseCriteriaMet(EvaluatorCallOutPoint, UsuallyFail):
     """Check whether site-specific closure criteria have been satisfied.
 
     Semantic function:
@@ -48,6 +49,10 @@ class OtherCloseCriteriaMet(UsuallyFail):
         additional criteria are satisfied, reflecting that extra criteria are
         not routinely met.
 
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — evaluates case-specific criteria from caller's DataLayer)
+      Output keys: other_close_criteria_met_verdict: str  (SUCCESS only)
+
     Input category: Human decision / policy.
 
     Success probability: 0.25 (``UsuallyFail``).
@@ -57,6 +62,8 @@ class OtherCloseCriteriaMet(UsuallyFail):
     possible criteria as a general policy rule is impractical, and the
     final closure decision usually benefits from human confirmation.
     """
+
+    output_keys = {"other_close_criteria_met_verdict": str}
 
 
 class PreCloseAction(AlwaysSucceed):

--- a/vultron/demo/fuzzer/report_management/deploy_fix.py
+++ b/vultron/demo/fuzzer/report_management/deploy_fix.py
@@ -41,6 +41,7 @@ from vultron.demo.fuzzer.base import (
     UsuallyFail,
     UsuallySucceed,
 )
+from vultron.demo.fuzzer.call_out_point import EvaluatorCallOutPoint
 
 
 class NoNewDeploymentInfo(UsuallySucceed):
@@ -64,7 +65,7 @@ class NoNewDeploymentInfo(UsuallySucceed):
     """
 
 
-class PrioritizeDeployment(AlmostAlwaysSucceed):
+class PrioritizeDeployment(EvaluatorCallOutPoint, AlmostAlwaysSucceed):
     """Assign priority to deploying the available fix or mitigation.
 
     Semantic function:
@@ -74,6 +75,10 @@ class PrioritizeDeployment(AlmostAlwaysSucceed):
         or SSVC-based prioritization workflow.  The fuzzer models the
         overwhelmingly common case where prioritization succeeds.
 
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — evaluates case context from caller's DataLayer)
+      Output keys: deployment_priority_verdict: str  (SUCCESS only)
+
     Input category: Human decision.
 
     Success probability: 0.90 (``AlmostAlwaysSucceed``).
@@ -82,6 +87,8 @@ class PrioritizeDeployment(AlmostAlwaysSucceed):
     environmental scoring can drive an automated priority recommendation;
     final approval for high-impact changes typically requires human sign-off.
     """
+
+    output_keys = {"deployment_priority_verdict": str}
 
 
 class MitigationDeployed(UsuallyFail):
@@ -124,7 +131,7 @@ class MitigationAvailable(OftenSucceed):
     """
 
 
-class DeployMitigation(UsuallySucceed):
+class DeployMitigation(EvaluatorCallOutPoint, UsuallySucceed):
     """Deploy the available mitigation for the vulnerability.
 
     Semantic function:
@@ -134,6 +141,10 @@ class DeployMitigation(UsuallySucceed):
         (e.g., applying a firewall rule via an API).  Succeeds most of
         the time to model the common case where mitigation deployment
         proceeds without issues.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — evaluates mitigation context from caller's DataLayer)
+      Output keys: deploy_mitigation_verdict: str  (SUCCESS only)
 
     Input category: System integration / Human decision.
 
@@ -145,8 +156,10 @@ class DeployMitigation(UsuallySucceed):
         mitigations typically require human coordination.
     """
 
+    output_keys = {"deploy_mitigation_verdict": str}
 
-class MonitoringRequirement(OftenSucceed):
+
+class MonitoringRequirement(EvaluatorCallOutPoint, OftenSucceed):
     """Determine whether deployment monitoring is required by policy.
 
     Semantic function:
@@ -156,6 +169,10 @@ class MonitoringRequirement(OftenSucceed):
         configuration check.  Succeeds about 70 % of the time to reflect
         that monitoring is commonly required but not universal.
 
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — evaluates case and policy context from caller's DataLayer)
+      Output keys: monitoring_requirement_verdict: str  (SUCCESS only)
+
     Input category: Environmental check / Policy.
 
     Success probability: 0.70 (``OftenSucceed``).
@@ -164,6 +181,8 @@ class MonitoringRequirement(OftenSucceed):
     all critical-severity deployments") are fully automatable; rule-based
     policy engines can evaluate this condition without human input.
     """
+
+    output_keys = {"monitoring_requirement_verdict": str}
 
 
 class MonitorDeployment(AlwaysSucceed):
@@ -187,7 +206,7 @@ class MonitorDeployment(AlwaysSucceed):
     """
 
 
-class DeployFix(AlmostAlwaysFail):
+class DeployFix(EvaluatorCallOutPoint, AlmostAlwaysFail):
     """Deploy the vendor fix to the affected environment.
 
     Semantic function:
@@ -198,6 +217,10 @@ class DeployFix(AlmostAlwaysFail):
         mitigation or monitoring paths.  Infrequent successes allow the
         rest of the post-deployment workflow to be exercised.
 
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — evaluates deployment context from caller's DataLayer)
+      Output keys: deploy_fix_verdict: str  (SUCCESS only)
+
     Input category: System integration / Human decision.
 
     Success probability: 0.10 (``AlmostAlwaysFail``).
@@ -207,3 +230,5 @@ class DeployFix(AlmostAlwaysFail):
     types; complex or high-risk changes in regulated environments typically
     require human approval and change-management controls.
     """
+
+    output_keys = {"deploy_fix_verdict": str}

--- a/vultron/demo/fuzzer/report_management/prioritize.py
+++ b/vultron/demo/fuzzer/report_management/prioritize.py
@@ -39,7 +39,11 @@ from vultron.demo.fuzzer.base import (
     ProbablySucceed,
     UsuallySucceed,
 )
-from vultron.demo.fuzzer.call_out_point import ActuatorCallOutPoint
+from vultron.demo.fuzzer.call_out_point import (
+    ActuatorCallOutPoint,
+    EvaluatorCallOutPoint,
+    RetrieverCallOutPoint,
+)
 
 
 class NoNewPrioritizationInfo(ProbablySucceed):
@@ -60,7 +64,7 @@ class NoNewPrioritizationInfo(ProbablySucceed):
     """
 
 
-class EnoughPrioritizationInfo(UsuallySucceed):
+class EnoughPrioritizationInfo(EvaluatorCallOutPoint, UsuallySucceed):
     """Determine whether sufficient context exists to make an accept/defer
     decision.
 
@@ -68,6 +72,10 @@ class EnoughPrioritizationInfo(UsuallySucceed):
         Condition — determine whether there is enough context to make an
         accept/defer decision.  Insufficient info triggers a gathering
         phase.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — evaluates available context from caller's DataLayer)
+      Output keys: enough_prioritization_info_verdict: str  (SUCCESS only)
 
     Input category: Human decision / Environmental check.
 
@@ -79,8 +87,10 @@ class EnoughPrioritizationInfo(UsuallySucceed):
     involves human analyst review.
     """
 
+    output_keys = {"enough_prioritization_info_verdict": str}
 
-class GatherPrioritizationInfo(AlmostAlwaysSucceed):
+
+class GatherPrioritizationInfo(RetrieverCallOutPoint, AlmostAlwaysSucceed):
     """Collect additional context needed to support a prioritization decision.
 
     Semantic function:
@@ -88,6 +98,10 @@ class GatherPrioritizationInfo(AlmostAlwaysSucceed):
         prioritization decision (e.g., severity scores, asset inventory,
         threat landscape data).  Succeeds almost always in simulation to
         keep the workflow progressing.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — queries external sources directly)
+      Output keys: prioritization_info_gathered: str  (SUCCESS only)
 
     Input category: System integration / Human analyst research.
 
@@ -98,6 +112,8 @@ class GatherPrioritizationInfo(AlmostAlwaysSucceed):
     analyst interpretation and gap-filling still requires human
     involvement.
     """
+
+    output_keys = {"prioritization_info_gathered": str}
 
 
 class OnAccept(ActuatorCallOutPoint, AlwaysSucceed):

--- a/vultron/demo/fuzzer/report_management/publication.py
+++ b/vultron/demo/fuzzer/report_management/publication.py
@@ -41,7 +41,10 @@ from vultron.demo.fuzzer.base import (
     UsuallyFail,
     UsuallySucceed,
 )
-from vultron.demo.fuzzer.call_out_point import ComposerCallOutPoint
+from vultron.demo.fuzzer.call_out_point import (
+    ComposerCallOutPoint,
+    EvaluatorCallOutPoint,
+)
 
 
 class AllPublished(AlmostAlwaysFail):
@@ -83,7 +86,7 @@ class PublicationIntentsSet(UsuallyFail):
     """
 
 
-class PrioritizePublicationIntents(AlwaysSucceed):
+class PrioritizePublicationIntents(EvaluatorCallOutPoint, AlwaysSucceed):
     """Establish and record publication intentions for the case.
 
     Semantic function:
@@ -93,6 +96,10 @@ class PrioritizePublicationIntents(AlwaysSucceed):
         decisions, potentially with human analyst input.  The fuzzer
         always succeeds to keep the workflow progressing.
 
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — evaluates case context from caller's DataLayer)
+      Output keys: publication_intents_verdict: str  (SUCCESS only)
+
     Input category: Human decision.
 
     Success probability: 1.00 (``AlwaysSucceed``).
@@ -101,6 +108,8 @@ class PrioritizePublicationIntents(AlwaysSucceed):
     priorities (e.g., always publish report and fix) can be automated;
     editorial or legal exceptions require human judgment.
     """
+
+    output_keys = {"publication_intents_verdict": str}
 
 
 class Publish(AlmostAlwaysSucceed):
@@ -182,7 +191,7 @@ class PrepareExploit(AlmostAlwaysSucceed):
     """
 
 
-class ReprioritizeExploit(AlwaysSucceed):
+class ReprioritizeExploit(EvaluatorCallOutPoint, AlwaysSucceed):
     """Update the priority of the exploit artifact in the publication queue.
 
     Semantic function:
@@ -192,6 +201,10 @@ class ReprioritizeExploit(AlwaysSucceed):
         human analyst decision or an automated policy trigger.  The
         fuzzer always succeeds.
 
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — evaluates exploit publication context from caller's DataLayer)
+      Output keys: reprioritize_exploit_verdict: str  (SUCCESS only)
+
     Input category: Human decision.
 
     Success probability: 1.00 (``AlwaysSucceed``).
@@ -200,6 +213,8 @@ class ReprioritizeExploit(AlwaysSucceed):
     threat-level updates can trigger automated reprioritization rules;
     human override may be needed for unusual cases.
     """
+
+    output_keys = {"reprioritize_exploit_verdict": str}
 
 
 class NoPublishFix(AlmostAlwaysFail):
@@ -241,7 +256,7 @@ class PrepareFix(AlmostAlwaysSucceed):
     """
 
 
-class ReprioritizeFix(AlwaysSucceed):
+class ReprioritizeFix(EvaluatorCallOutPoint, AlwaysSucceed):
     """Update the priority of the fix artifact in the publication queue.
 
     Semantic function:
@@ -249,6 +264,10 @@ class ReprioritizeFix(AlwaysSucceed):
         publication queue.  In production this is a human analyst
         decision or an automated policy trigger.  The fuzzer always
         succeeds.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — evaluates fix publication context from caller's DataLayer)
+      Output keys: reprioritize_fix_verdict: str  (SUCCESS only)
 
     Input category: Human decision.
 
@@ -258,6 +277,8 @@ class ReprioritizeFix(AlwaysSucceed):
     threat-level updates can trigger automated reprioritization rules;
     human override may be needed.
     """
+
+    output_keys = {"reprioritize_fix_verdict": str}
 
 
 class NoPublishReport(AlmostAlwaysFail):
@@ -305,7 +326,7 @@ class PrepareReport(ComposerCallOutPoint, AlmostAlwaysSucceed):
     output_keys = {"prepared_report_artifact": str}
 
 
-class ReprioritizeReport(AlwaysSucceed):
+class ReprioritizeReport(EvaluatorCallOutPoint, AlwaysSucceed):
     """Update the priority of the report artifact in the publication queue.
 
     Semantic function:
@@ -313,6 +334,10 @@ class ReprioritizeReport(AlwaysSucceed):
         publication queue.  In production this is a human analyst
         decision or an automated policy trigger (e.g., on embargo exit or
         threat escalation).  The fuzzer always succeeds.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — evaluates report publication context from caller's DataLayer)
+      Output keys: reprioritize_report_verdict: str  (SUCCESS only)
 
     Input category: Human decision.
 
@@ -322,3 +347,5 @@ class ReprioritizeReport(AlwaysSucceed):
     (e.g., on embargo exit or threat escalation) is automatable; complex
     editorial decisions require human oversight.
     """
+
+    output_keys = {"reprioritize_report_verdict": str}

--- a/vultron/demo/fuzzer/report_management/report_to_others.py
+++ b/vultron/demo/fuzzer/report_management/report_to_others.py
@@ -49,6 +49,7 @@ from vultron.demo.fuzzer.base import (
     UsuallyFail,
     UsuallySucceed,
 )
+from vultron.demo.fuzzer.call_out_point import EvaluatorCallOutPoint
 
 
 class HaveReportToOthersCapability(UsuallySucceed):
@@ -69,7 +70,7 @@ class HaveReportToOthersCapability(UsuallySucceed):
     """
 
 
-class AllPartiesKnown(UniformSucceedFail):
+class AllPartiesKnown(EvaluatorCallOutPoint, UniformSucceedFail):
     """Check whether all relevant parties for notification have been identified.
 
     Semantic function:
@@ -77,6 +78,10 @@ class AllPartiesKnown(UniformSucceedFail):
         notification have been identified.  Modeled as a coin flip in
         simulation because identification completeness is inherently
         uncertain.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — evaluates party-identification state from caller's DataLayer)
+      Output keys: all_parties_known_verdict: str  (SUCCESS only)
 
     Input category: Human decision / Environmental check.
 
@@ -86,6 +91,8 @@ class AllPartiesKnown(UniformSucceedFail):
     judgment about stakeholder completeness in a specific vulnerability
     context; hard to automate reliably.
     """
+
+    output_keys = {"all_parties_known_verdict": str}
 
 
 class IdentifyVendors(SuccessOrRunning):
@@ -198,7 +205,7 @@ class RemoveRecipient(AlwaysSucceed):
     """
 
 
-class RecipientEffortExceeded(AlmostCertainlyFail):
+class RecipientEffortExceeded(EvaluatorCallOutPoint, AlmostCertainlyFail):
     """Check whether notification effort for a recipient has exceeded a limit.
 
     Semantic function:
@@ -207,6 +214,10 @@ class RecipientEffortExceeded(AlmostCertainlyFail):
         (e.g., 3 contact attempts, 1 hour of effort).  Rarely triggers
         in simulation; in production enforces reasonable limits on
         notification attempts.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — evaluates per-recipient effort counter from caller's DataLayer)
+      Output keys: recipient_effort_exceeded_verdict: str  (SUCCESS only)
 
     Input category: Environmental check / Human decision.
 
@@ -217,8 +228,10 @@ class RecipientEffortExceeded(AlmostCertainlyFail):
     policy is defined.
     """
 
+    output_keys = {"recipient_effort_exceeded_verdict": str}
 
-class PolicyCompatible(ProbablySucceed):
+
+class PolicyCompatible(EvaluatorCallOutPoint, ProbablySucceed):
     """Check whether the recipient's disclosure policy is compatible with the case.
 
     Semantic function:
@@ -226,6 +239,10 @@ class PolicyCompatible(ProbablySucceed):
         disclosure/embargo policy is compatible with the case's current
         embargo expectations before notifying them.  In production may
         involve structured policy comparison tooling.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — evaluates recipient and case policy from caller's DataLayer)
+      Output keys: policy_compatible_verdict: str  (SUCCESS only)
 
     Input category: Environmental check / Human decision.
 
@@ -236,6 +253,8 @@ class PolicyCompatible(ProbablySucceed):
     machine-readable policies (e.g., OpenVEX, structured security.txt);
     human review needed for ambiguous or informal policies.
     """
+
+    output_keys = {"policy_compatible_verdict": str}
 
 
 class FindContact(UsuallySucceed):
@@ -293,7 +312,7 @@ class SetRcptQrmR(AlwaysSucceed):
     """
 
 
-class TotalEffortLimitMet(AlmostAlwaysFail):
+class TotalEffortLimitMet(EvaluatorCallOutPoint, AlmostAlwaysFail):
     """Check whether the total notification effort ceiling has been reached.
 
     Semantic function:
@@ -302,6 +321,10 @@ class TotalEffortLimitMet(AlmostAlwaysFail):
         total).  Rarely triggers in simulation; provides a global stop
         condition to prevent unbounded notification effort.
 
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — evaluates total effort counter from caller's DataLayer)
+      Output keys: total_effort_limit_met_verdict: str  (SUCCESS only)
+
     Input category: Environmental check / Human decision.
 
     Success probability: 0.10 (``AlmostAlwaysFail``).
@@ -309,6 +332,8 @@ class TotalEffortLimitMet(AlmostAlwaysFail):
     Automation potential: **High** — aggregate effort counter check
     against a configurable policy ceiling; fully automatable.
     """
+
+    output_keys = {"total_effort_limit_met_verdict": str}
 
 
 class MoreVendors(UsuallyFail):


### PR DESCRIPTION
- Closes #1173

## Summary

Applies `EvaluatorCallOutPoint` (and `RetrieverCallOutPoint` where appropriate) to every Evaluator-shaped fuzzer node across all domains (embargo, report management: prioritize, assign\_vul\_id, deploy\_fix, acquire\_exploit, report\_to\_others, close\_report, publication). Each node now declares `output_keys` with a `_verdict`-suffixed key, has a documented blackboard contract in its docstring (BT-18-001), and uses the mixin as first parent for correct MRO.

## Changes

- `vultron/demo/fuzzer/embargo.py`: 10 nodes updated (`ExitEmbargoWhenDeployed`, `ExitEmbargoWhenFixReady`, `ExitEmbargoForOtherReason`, `StopProposingEmbargo`, `SelectEmbargoOfferTerms`, `WantToProposeEmbargo`, `WillingToCounterEmbargoProposal`, `ReasonToProposeEmbargoWhenDeployed`, `EvaluateEmbargoProposal`, `CurrentEmbargoAcceptable`)
- `vultron/demo/fuzzer/report_management/prioritize.py`: `EnoughPrioritizationInfo` (Evaluator), `GatherPrioritizationInfo` (Retriever)
- `vultron/demo/fuzzer/report_management/assign_vul_id.py`: `IdAssignable`, `InScope`
- `vultron/demo/fuzzer/report_management/deploy_fix.py`: `PrioritizeDeployment`, `DeployMitigation`, `MonitoringRequirement`, `DeployFix`
- `vultron/demo/fuzzer/report_management/acquire_exploit.py`: `EvaluateExploitPriority`, `PurchaseExploit`
- `vultron/demo/fuzzer/report_management/report_to_others.py`: `AllPartiesKnown`, `RecipientEffortExceeded`, `PolicyCompatible`, `TotalEffortLimitMet`
- `vultron/demo/fuzzer/report_management/close_report.py`: `OtherCloseCriteriaMet`
- `vultron/demo/fuzzer/report_management/publication.py`: `PrioritizePublicationIntents`, `ReprioritizeExploit`, `ReprioritizeFix`, `ReprioritizeReport`
- `test/fuzzer/` (5 files): add `node.setup()` before `node.update()` in all legacy test helpers and test methods — required because the mixin now registers the blackboard client in `setup()`

## Verification

- 806 fuzzer unit tests pass (0 new failures)
- 4474 total tests pass, 0 failures
- Black, flake8 clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)