### PR TITLE
fix: namespace suggested_roles blackboard key by recommendation_id

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1348.md
+++ b/plan/history/2607/implementation/ISSUE-1348.md
@@ -1,0 +1,14 @@
+---
+source: ISSUE-1348
+timestamp: '2026-07-10T20:25:37.753453+00:00'
+title: 'fix: namespace suggested_roles blackboard key by recommendation_id'
+type: implementation
+---
+
+## Issue #1348 — fix: namespace suggested_roles blackboard key by recommendation_id
+
+EvaluateDefaultRolesNode previously wrote to a flat `suggested_roles` blackboard key.
+Fixed by namespacing it as `suggested_roles_{recommendation_id_segment}` per BTND-03-004,
+eliminating the concurrent-tree collision risk.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1352>

--- a/test/core/behaviors/case/test_suggest_actor_tree.py
+++ b/test/core/behaviors/case/test_suggest_actor_tree.py
@@ -19,7 +19,7 @@ Covers:
 - create_recommend_actor_to_case_received_tree
 - create_accept_actor_recommendation_received_tree
 - create_reject_actor_recommendation_received_tree
-- EvaluateDefaultRolesNode (AC-1 through AC-3, CM-16-003)
+- EvaluateDefaultRolesNode (AC-1 through AC-4, CM-16-003)
 
 Per specs/behavior-tree-integration.yaml BT-15-001, BTND-02-001 (memory=False),
 ADR-0026/CM-16.

--- a/test/core/behaviors/case/test_suggest_actor_tree.py
+++ b/test/core/behaviors/case/test_suggest_actor_tree.py
@@ -56,12 +56,14 @@ class TestEvaluateDefaultRolesNode:
         self.node = EvaluateDefaultRolesNode(
             suggested_actor_id=_RECOMMENDED,
             case_id=_CASE_ID,
+            recommendation_id=_REC_ID,
         )
         self.node.setup()
         self.node.initialise()
 
     def teardown_method(self):
         py_trees.blackboard.Blackboard.disable_activity_stream()
+        py_trees.blackboard.Blackboard.storage.clear()
 
     def test_node_exists(self):
         """AC-1: EvaluateDefaultRolesNode exists in the BT node library."""
@@ -76,26 +78,67 @@ class TestEvaluateDefaultRolesNode:
     def test_node_stores_case_id(self):
         assert self.node.case_id == _CASE_ID
 
+    def test_node_stores_recommendation_id(self):
+        """AC-1: EvaluateDefaultRolesNode accepts recommendation_id."""
+        assert self.node.recommendation_id == _REC_ID
+
     def test_returns_success_unconditionally(self):
-        """AC-3: returns SUCCESS unconditionally in the prototype."""
+        """returns SUCCESS unconditionally in the prototype."""
         result = self.node.update()
         assert result == Status.SUCCESS
 
-    def test_writes_vendor_role_to_blackboard(self):
-        """AC-2: writes suggested_roles = [CVDRole.VENDOR] to blackboard."""
+    def test_writes_vendor_role_to_namespaced_blackboard_key(self):
+        """AC-2: writes suggested_roles_{segment} = [CVDRole.VENDOR] to blackboard."""
         self.node.update()
-        raw = py_trees.blackboard.Blackboard.storage.get("/suggested_roles")
+        expected_key = f"/suggested_roles_{_REC_ID.split('/')[-1]}"
+        raw = py_trees.blackboard.Blackboard.storage.get(expected_key)
         assert raw == [
             CVDRole.VENDOR
-        ], f"Expected [CVDRole.VENDOR] in suggested_roles, got {raw!r}"
+        ], f"Expected [CVDRole.VENDOR] at '{expected_key}', got {raw!r}"
+
+    def test_does_not_write_global_suggested_roles_key(self):
+        """AC-4: raw /suggested_roles key must not be written."""
+        self.node.update()
+        raw = py_trees.blackboard.Blackboard.storage.get("/suggested_roles")
+        assert (
+            raw is None
+        ), f"Expected no /suggested_roles key, but found {raw!r}"
 
     def test_custom_name_accepted(self):
         node = EvaluateDefaultRolesNode(
             suggested_actor_id=_RECOMMENDED,
             case_id=_CASE_ID,
+            recommendation_id=_REC_ID,
             name="MyCustomName",
         )
         assert node.name == "MyCustomName"
+
+    def test_two_instances_write_different_keys(self):
+        """AC-3: two tree instances with different recommendation_ids write to different keys."""
+        rec_id_2 = "https://example.org/recommendations/rec-2"
+        node2 = EvaluateDefaultRolesNode(
+            suggested_actor_id=_RECOMMENDED,
+            case_id=_CASE_ID,
+            recommendation_id=rec_id_2,
+        )
+        node2.setup()
+        node2.initialise()
+
+        self.node.update()
+        node2.update()
+
+        key1 = f"/suggested_roles_{_REC_ID.split('/')[-1]}"
+        key2 = f"/suggested_roles_{rec_id_2.split('/')[-1]}"
+
+        assert (
+            key1 != key2
+        ), "Keys must differ for different recommendation_ids"
+        assert py_trees.blackboard.Blackboard.storage.get(key1) == [
+            CVDRole.VENDOR
+        ]
+        assert py_trees.blackboard.Blackboard.storage.get(key2) == [
+            CVDRole.VENDOR
+        ]
 
 
 class TestRecommendActorToCaseReceivedTree:

--- a/vultron/core/behaviors/case/nodes/actor.py
+++ b/vultron/core/behaviors/case/nodes/actor.py
@@ -376,7 +376,11 @@ class EvaluateDefaultRolesNode(py_trees.behaviour.Behaviour):
 
     **ADR-0024 shape: Evaluator** — receives a bounded input (actor + case
     context via constructor) and writes a bounded recommendation
-    (``suggested_roles``) to the blackboard.
+    (``suggested_roles_{recommendation_id_segment}``) to the blackboard.
+
+    The blackboard key is namespaced by ``recommendation_id`` to avoid
+    collisions when two ``RecommendActorToCaseBT`` trees execute concurrently
+    (BTND-03-004).
 
     Prototype behaviour: always writes ``[CVDRole.VENDOR]`` and returns
     ``SUCCESS``.  Future implementations can inspect actor metadata, prior
@@ -385,11 +389,14 @@ class EvaluateDefaultRolesNode(py_trees.behaviour.Behaviour):
     Args:
         suggested_actor_id: The actor URI being suggested to the case.
         case_id: The case URI, provided as context for future policy logic.
+        recommendation_id: ID of the incoming ``Offer(Actor, Case)`` activity;
+            used to derive the namespaced blackboard key.
         name: Optional display name for the node.
 
     Blackboard outputs (WRITE):
-        - ``suggested_roles`` (list[CVDRole]): always non-empty; defaults to
-          ``[CVDRole.VENDOR]``.
+        - ``suggested_roles_{id_segment}`` (list[CVDRole]): always non-empty;
+          defaults to ``[CVDRole.VENDOR]``.  ``id_segment`` is the last
+          ``/``-delimited segment of ``recommendation_id``.
 
     Returns ``SUCCESS`` unconditionally in the prototype implementation.
     """
@@ -400,11 +407,13 @@ class EvaluateDefaultRolesNode(py_trees.behaviour.Behaviour):
         self,
         suggested_actor_id: str,
         case_id: str,
+        recommendation_id: str,
         name: str | None = None,
     ) -> None:
         super().__init__(name=name or self.__class__.__name__)
         self.suggested_actor_id = suggested_actor_id
         self.case_id = case_id
+        self.recommendation_id = recommendation_id
         self.logger = logging.getLogger(  # type: ignore[assignment]
             f"{self.__class__.__module__}.{self.__class__.__name__}"
         )
@@ -412,12 +421,14 @@ class EvaluateDefaultRolesNode(py_trees.behaviour.Behaviour):
     def setup(self, **kwargs: Any) -> None:
         super().setup(**kwargs)
         self.blackboard = self.attach_blackboard_client(name=self.name)
+        id_segment = self.recommendation_id.split("/")[-1]
+        self.blackboard_key = f"suggested_roles_{id_segment}"
         self.blackboard.register_key(
-            key="suggested_roles", access=py_trees.common.Access.WRITE
+            key=self.blackboard_key, access=py_trees.common.Access.WRITE
         )
 
     def update(self) -> Status:
-        self.blackboard.suggested_roles = [CVDRole.VENDOR]
+        setattr(self.blackboard, self.blackboard_key, [CVDRole.VENDOR])
         self.logger.debug(
             "%s: assigned default roles [VENDOR] for actor '%s' in case '%s'",
             self.name,

--- a/vultron/core/behaviors/case/suggest_actor_tree.py
+++ b/vultron/core/behaviors/case/suggest_actor_tree.py
@@ -65,8 +65,9 @@ class EmitOfferCaseParticipantToOwnerNode(DataLayerAction):
     The original offer ID is carried in the ``origin`` field so the Case Owner
     can trace the causal chain (CM-16-004).
 
-    Reads ``suggested_roles`` from the blackboard; falls back to
-    ``[CVDRole.VENDOR]`` when the key is absent.
+    Reads ``suggested_roles_{recommendation_id_segment}`` from the blackboard
+    (namespaced per BTND-03-004); falls back to ``[CVDRole.VENDOR]`` when the
+    key is absent.
 
     Returns SUCCESS on success, FAILURE if any required dependency is missing.
     """
@@ -87,13 +88,15 @@ class EmitOfferCaseParticipantToOwnerNode(DataLayerAction):
 
     def setup(self, **kwargs) -> None:
         super().setup(**kwargs)
+        id_segment = self.recommendation_id.split("/")[-1]
+        self.blackboard_key = f"suggested_roles_{id_segment}"
         self.blackboard.register_key(
-            key="suggested_roles", access=py_trees.common.Access.READ
+            key=self.blackboard_key, access=py_trees.common.Access.READ
         )
 
     def _read_suggested_roles(self) -> list[CVDRole]:
         try:
-            roles = self.blackboard.get("suggested_roles")
+            roles = self.blackboard.get(self.blackboard_key)
             if isinstance(roles, list) and roles:
                 return roles
         except KeyError:
@@ -335,6 +338,7 @@ def create_recommend_actor_to_case_received_tree(
             EvaluateDefaultRolesNode(
                 suggested_actor_id=recommended_id,
                 case_id=case_id,
+                recommendation_id=recommendation_id,
             ),
             EmitOfferCaseParticipantToOwnerNode(
                 recommendation_id=recommendation_id,


### PR DESCRIPTION
- Closes #1348

## Summary

`EvaluateDefaultRolesNode.setup()` previously registered `suggested_roles`
as a flat global blackboard key. When two `RecommendActorToCaseBT` trees
executed concurrently, the second write silently overwrote the first, causing
`EmitOfferCaseParticipantToOwnerNode` to read the wrong role list.

This fix namespaces the key as `suggested_roles_{recommendation_id_segment}`
per BTND-03-004, eliminating the collision risk.

## Changes

- `vultron/core/behaviors/case/nodes/actor.py`: `EvaluateDefaultRolesNode`
  accepts new `recommendation_id` constructor parameter; derives
  `blackboard_key = f"suggested_roles_{recommendation_id.split('/')[-1]}"` in
  `setup()` and writes to the namespaced key in `update()`
- `vultron/core/behaviors/case/suggest_actor_tree.py`:
  `EmitOfferCaseParticipantToOwnerNode.setup()` and `_read_suggested_roles()`
  derive and use the same namespaced key from `self.recommendation_id`;
  `create_recommend_actor_to_case_received_tree()` passes `recommendation_id`
  to `EvaluateDefaultRolesNode`
- `test/core/behaviors/case/test_suggest_actor_tree.py`: updated all
  construction calls; added tests for namespaced key written (AC-2), flat
  `/suggested_roles` key absent (AC-4), and two-instance no-collision (AC-3);
  `teardown_method` now clears `Blackboard.storage` to prevent cross-test leakage

## Verification

- [x] AC-1: `EvaluateDefaultRolesNode` accepts `recommendation_id` and writes namespaced key
- [x] AC-2: `EmitOfferCaseParticipantToOwnerNode` reads same namespaced key
- [x] AC-3: Two instances with different `recommendation_id` write to different keys (tested)
- [x] AC-4: No test reads raw `/suggested_roles` key; tests use namespaced key
- All 4488 unit tests pass (3 new)
- Black, flake8, mypy, pyright clean