### PR TITLE
feat(#1300): enrich EmitInviteActorToCaseNode — embargo stub and roles in Invite

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1300.md
+++ b/plan/history/2607/implementation/ISSUE-1300.md
@@ -1,0 +1,12 @@
+---
+source: ISSUE-1300
+timestamp: '2026-07-10T20:51:13.456093+00:00'
+title: enrich EmitInviteActorToCaseNode — embargo stub and roles in Invite
+type: implementation
+---
+
+## Issue #1300 — enrich EmitInviteActorToCaseNode — embargo stub and roles in Invite
+
+Implemented CM-16-002 (embed active embargo details in VulnerabilityCaseStub) and CM-16-003 (embed intended CVD roles in Invite activity). CreateInviteeParticipantAtAcceptedNode reads roles from the stored Invite at accept time and sets case_roles via constructor form (PRM-05-004). Fixed a DataLayer coercion regression where semantic-subclass-only fields were lost during the as_Invite → _RmInviteToCaseActivity round-trip.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1354>

--- a/test/adapters/driven/trigger_activity_adapter/test_actors.py
+++ b/test/adapters/driven/trigger_activity_adapter/test_actors.py
@@ -17,8 +17,11 @@ Covers invitations, recommendations, participant management, and
 CASE_MANAGER delegation.
 """
 
+from datetime import datetime, timezone
+
 import pytest
 
+from vultron.core.states.roles import CVDRole
 from vultron.errors import VultronValidationError
 from vultron.wire.as2.factories import rm_invite_to_case_activity
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
@@ -81,6 +84,65 @@ class TestInviteActorToCase:
         )
 
         assert activity_dict.get("attributedTo") == owner
+
+    def test_roles_embedded_in_invite(self, adapter, dl):
+        """roles list is serialised into the Invite activity (CM-16-003)."""
+        roles = [CVDRole.VENDOR, CVDRole.COORDINATOR]
+        dl.create(as_Service(id_=_INVITEE))
+        activity_id, activity_dict = adapter.invite_actor_to_case(
+            invitee_id=_INVITEE,
+            case_id=_CASE_ID,
+            actor=_ACTOR,
+            roles=roles,
+        )
+
+        assert activity_dict.get("roles") == [str(r) for r in roles]
+        persisted = dl.read(activity_id)
+        assert getattr(persisted, "roles", None) == [str(r) for r in roles]
+
+    def test_embargo_stub_embedded_when_active(self, adapter, dl):
+        """When embargo is ACTIVE, VulnerabilityCaseStub carries embargo fields (CM-16-002)."""
+        embargo_id = "https://example.org/embargoes/emb-001"
+        end_time = datetime(2026, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
+        _, activity_dict = adapter.invite_actor_to_case(
+            invitee_id=_INVITEE,
+            case_id=_CASE_ID,
+            actor=_ACTOR,
+            active_embargo_id=embargo_id,
+            em_state="ACTIVE",
+            embargo_end_time=end_time,
+        )
+
+        target = activity_dict.get("target") or {}
+        assert target.get("activeEmbargo") is not None
+        assert target.get("caseStatus") is not None
+
+    def test_no_embargo_stub_when_em_state_not_active(self, adapter):
+        """When em_state is not ACTIVE, case stub has no embargo enrichment."""
+        _, activity_dict = adapter.invite_actor_to_case(
+            invitee_id=_INVITEE,
+            case_id=_CASE_ID,
+            actor=_ACTOR,
+            active_embargo_id="https://example.org/embargoes/emb-001",
+            em_state="NO_EMBARGO",
+        )
+
+        target = activity_dict.get("target") or {}
+        assert target.get("activeEmbargo") is None
+
+    def test_no_embargo_stub_when_end_time_missing(self, adapter):
+        """When embargo_end_time is None, case stub has no embargo enrichment."""
+        _, activity_dict = adapter.invite_actor_to_case(
+            invitee_id=_INVITEE,
+            case_id=_CASE_ID,
+            actor=_ACTOR,
+            active_embargo_id="https://example.org/embargoes/emb-001",
+            em_state="ACTIVE",
+            embargo_end_time=None,
+        )
+
+        target = activity_dict.get("target") or {}
+        assert target.get("activeEmbargo") is None
 
 
 class TestAcceptCaseInvite:

--- a/test/core/use_cases/received/actor/test_invite.py
+++ b/test/core/use_cases/received/actor/test_invite.py
@@ -903,3 +903,56 @@ class TestInviteActorUseCases:
         state = cast(Any, dl.read(state_id))
         assert state is not None
         assert state.join_backfill_complete is True
+
+    def test_accept_invite_sets_roles_from_invite(
+        self, monkeypatch, make_payload
+    ):
+        """CM-16-003: roles embedded in Invite wire object are set on created participant."""
+        from unittest.mock import MagicMock
+
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+        from vultron.core.states.roles import CVDRole
+        from vultron.wire.as2.vocab.base.objects.actors import as_Organization
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        invitee_id = "https://example.org/users/roles-test-coordinator"
+        invitee = as_Organization(id_=invitee_id)
+        case = VulnerabilityCase(
+            id_="https://example.org/cases/caseRoles001",
+            name="TEST-ACCEPT-INVITE-ROLES",
+        )
+        invite = rm_invite_to_case_activity(
+            invitee,
+            target=VulnerabilityCaseStub(id_=case.id_),
+            actor="https://example.org/users/owner",
+            id_="https://example.org/cases/caseRoles001/invitations/1",
+            roles=[str(CVDRole.COORDINATOR), str(CVDRole.FINDER)],
+        )
+        dl.create(invitee)
+        dl.create(case)
+        dl.create(invite)
+
+        accept = rm_accept_invite_to_case_activity(invite, actor=invitee_id)
+        event = make_payload(accept)
+
+        AcceptInviteActorToCaseReceivedUseCase(
+            dl, event, sync_port=MagicMock()
+        ).execute()
+
+        updated_case = cast(Any, dl.read(case.id_))
+        participant_id = updated_case.actor_participant_index.get(invitee_id)
+        assert participant_id is not None
+        participant_obj = cast(Any, dl.get(id_=participant_id))
+        assert participant_obj is not None
+        participant_roles = list(participant_obj.case_roles)
+        assert (
+            CVDRole.COORDINATOR in participant_roles
+            or str(CVDRole.COORDINATOR) in participant_roles
+        )
+        assert (
+            CVDRole.FINDER in participant_roles
+            or str(CVDRole.FINDER) in participant_roles
+        )

--- a/test/core/use_cases/triggers/test_actor_triggers.py
+++ b/test/core/use_cases/triggers/test_actor_triggers.py
@@ -271,6 +271,51 @@ class TestSvcInviteActorToCaseUseCase:
         case_actor_outbox = dl.clone_for_actor(case_actor.id_).outbox_list()
         assert activity_data["id"] in case_actor_outbox
 
+    def test_invite_embeds_roles_from_request(self):
+        """AC-6/CM-16-003: roles from InviteActorToCaseTriggerRequest appear in Invite."""
+        actor, dl = _make_actor_dl("Coordinator")
+        invitee, _ = _make_actor_dl("Finder")
+        dl.create(invitee)
+        case = VulnerabilityCase(
+            attributed_to=actor.id_, name="Test Case", content="Content"
+        )
+        dl.create(case)
+        roles = [CVDRole.FINDER, CVDRole.REPORTER]
+        request = InviteActorToCaseTriggerRequest(
+            actor_id=actor.id_,
+            case_id=case.id_,
+            invitee_id=invitee.id_,
+            roles=roles,
+        )
+        result = SvcInviteActorToCaseUseCase(
+            dl, request, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
+
+        activity_data = result["activity"]
+        assert activity_data.get("roles") == [str(r) for r in roles]
+
+    def test_invite_defaults_to_vendor_role_when_roles_none(self):
+        """When request.roles is None, EvaluateDefaultRolesNode provides VENDOR."""
+        actor, dl = _make_actor_dl("Coordinator")
+        invitee, _ = _make_actor_dl("Vendor")
+        dl.create(invitee)
+        case = VulnerabilityCase(
+            attributed_to=actor.id_, name="Test Case", content="Content"
+        )
+        dl.create(case)
+        request = InviteActorToCaseTriggerRequest(
+            actor_id=actor.id_,
+            case_id=case.id_,
+            invitee_id=invitee.id_,
+            # roles intentionally omitted
+        )
+        result = SvcInviteActorToCaseUseCase(
+            dl, request, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
+
+        activity_data = result["activity"]
+        assert CVDRole.VENDOR in (activity_data.get("roles") or [])
+
 
 class TestSvcSuggestActorToCaseUseCase:
     """Tests for the suggest-actor-to-case trigger use case."""

--- a/vultron/adapters/driven/datalayer_sqlite/datalayer.py
+++ b/vultron/adapters/driven/datalayer_sqlite/datalayer.py
@@ -169,7 +169,7 @@ class SqliteDataLayer:
         if obj is None:
             return None
         obj = self._rehydrate_fields(obj)
-        return self._coerce_to_semantic_class(obj)
+        return self._coerce_to_semantic_class(obj, raw_data=rec.data_)
 
     def _rehydrate_fields(self, obj: PersistableModel) -> PersistableModel:
         """Expand dehydrated object-reference fields back to typed objects.
@@ -257,7 +257,9 @@ class SqliteDataLayer:
         return obj
 
     def _coerce_to_semantic_class(
-        self, obj: PersistableModel
+        self,
+        obj: PersistableModel,
+        raw_data: dict[str, Any] | None = None,
     ) -> PersistableModel:
         """Coerce a base-vocabulary activity to its semantic subtype.
 
@@ -268,6 +270,12 @@ class SqliteDataLayer:
         coerces via ``model_validate``.
         Coercion failures are logged as warnings and the original object is
         returned unchanged.
+
+        ``raw_data`` (if supplied) is the original stored record dict
+        (Python-style field names).  It is overlaid onto the by-alias dump so
+        that fields present in the semantic subclass but absent from the base
+        vocabulary class (e.g. ``roles`` on ``_RmInviteToCaseActivity``) are
+        preserved through coercion.
         """
         if not isinstance(obj, as_Activity):
             return obj
@@ -283,11 +291,18 @@ class SqliteDataLayer:
             return obj
 
         try:
+            coerce_dict = obj.model_dump(by_alias=True, serialize_as_any=True)
+            if raw_data:
+                # raw_data (Python-style keys) supplies semantic-subclass-only
+                # fields absent from the base vocabulary class (e.g. `roles`).
+                # Rehydrated by-alias values must win for any collision so that
+                # typed objects (e.g. a rehydrated VulnerabilityCaseStub for
+                # `target`) are not overwritten by the dehydrated string stored
+                # in raw_data.
+                coerce_dict = {**raw_data, **coerce_dict}
             return cast(
                 PersistableModel,
-                activity_cls.model_validate(
-                    obj.model_dump(by_alias=True, serialize_as_any=True)
-                ),
+                activity_cls.model_validate(coerce_dict),
             )
         except (ValidationError, TypeError) as exc:
             logger.warning(

--- a/vultron/adapters/driven/trigger_activity_adapter/actors.py
+++ b/vultron/adapters/driven/trigger_activity_adapter/actors.py
@@ -20,6 +20,7 @@ Case Actor / CASE_MANAGER delegation activities.
 """
 
 import logging
+from datetime import datetime
 from typing import Any, cast
 
 from vultron.core.models.actor import CoreActor
@@ -41,8 +42,13 @@ from vultron.wire.as2.factories.case import (
     offer_case_manager_role_activity,
     reject_case_manager_role_activity,
 )
+from vultron.core.states.em import EM
 from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.case_status import ParticipantStatus
+from vultron.wire.as2.vocab.objects.case_status import (
+    CaseStatus,
+    ParticipantStatus,
+)
+from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
     VulnerabilityCase,
     VulnerabilityCaseStub,
@@ -69,12 +75,22 @@ class _ActorsMixin:
         cc: list[str] | None = None,
         id_: str | None = None,
         attributed_to: str | None = None,
+        roles: list | None = None,
+        active_embargo_id: str | None = None,
+        em_state: str | None = None,
+        embargo_end_time: datetime | None = None,
     ) -> tuple[str, dict[str, Any]]:
         """Create and persist an ``Invite(Actor, Case)`` activity.
 
         ``actor`` SHOULD be the Case Actor ID (PCR-08-007); ``attributed_to``
         MAY carry the case owner's ID for attribution.  ``cc`` MAY carry the
         Case Actor's own ID for self-archival (CLP-10-001).
+
+        When ``active_embargo_id`` and ``em_state`` are provided and the
+        embargo is active, an enriched ``VulnerabilityCaseStub`` is built
+        with ``active_embargo`` and ``case_status`` so the invitee can check
+        embargo terms before accepting (CM-16-002).  ``roles`` is embedded in
+        the Invite activity (CM-16-003).
         """
         extra: dict[str, Any] = {"actor": actor, "to": to}
         if cc is not None:
@@ -83,9 +99,23 @@ class _ActorsMixin:
             extra["id_"] = id_
         if attributed_to is not None:
             extra["attributed_to"] = attributed_to
+        if roles is not None:
+            extra["roles"] = [str(r) for r in roles]
+
+        stub_kwargs: dict[str, Any] = {}
+        if (
+            active_embargo_id
+            and em_state == "ACTIVE"
+            and embargo_end_time is not None
+        ):
+            stub_kwargs["active_embargo"] = EmbargoEvent(
+                id_=active_embargo_id, end_time=embargo_end_time
+            )
+            stub_kwargs["case_status"] = CaseStatus(em_state=EM.ACTIVE)
+
         activity = rm_invite_to_case_activity(
             invitee=CoreActor(id_=invitee_id),
-            target=VulnerabilityCaseStub(id_=case_id),
+            target=VulnerabilityCaseStub(id_=case_id, **stub_kwargs),
             **extra,
         )
         try:

--- a/vultron/core/behaviors/case/accept_invite_tree.py
+++ b/vultron/core/behaviors/case/accept_invite_tree.py
@@ -260,6 +260,11 @@ class CreateInviteeParticipantAtAcceptedNode(DataLayerAction):
     CaseActor records RM.ACCEPTED directly in its own DataLayer rather
     than running an engage-case BT as the invitee.
 
+    Reads ``roles`` from the original ``Invite`` wire object (stored in the
+    DataLayer) and sets ``participant.case_roles`` when present (CM-16-003).
+    The invite ID is derived from ``event.object_id`` on the blackboard
+    ``activity`` (the ``AcceptInviteActorToCaseReceivedEvent``).
+
     Writes ``new_invite_participant`` to the blackboard.
     """
 
@@ -284,6 +289,29 @@ class CreateInviteeParticipantAtAcceptedNode(DataLayerAction):
             key="new_invite_participant",
             access=py_trees.common.Access.WRITE,
         )
+        self.blackboard.register_key(
+            key="activity", access=py_trees.common.Access.READ
+        )
+
+    def _read_invite_roles(self) -> list:
+        """Read roles from the original Invite wire object via the DataLayer.
+
+        Returns the roles list when the Invite has one, else empty list.
+        """
+        if self.datalayer is None:
+            return []
+        try:
+            event = self.blackboard.get("activity")
+            invite_id = getattr(event, "object_id", None)
+            if not invite_id:
+                return []
+            invite = self.datalayer.read(invite_id)
+            roles = getattr(invite, "roles", None)
+            if isinstance(roles, list) and roles:
+                return roles
+        except (KeyError, AttributeError):
+            pass
+        return []
 
     def update(self) -> Status:
         if self.datalayer is None:
@@ -325,11 +353,14 @@ class CreateInviteeParticipantAtAcceptedNode(DataLayerAction):
             )
             return Status.SUCCESS
 
+        roles = self._read_invite_roles()
         participant = VultronParticipant(
             id_=f"{self.case_id}/participants/{self.invitee_id.split('/')[-1]}",
             attributed_to=self.invitee_id,
             context=self.case_id,
+            case_roles=list(roles) if roles else [],
         )
+
         # PCR-08-010: Accept(Invite) IS the engage signal; record all three
         # RM transitions on behalf of the invitee in the CaseActor's DataLayer.
         participant.append_rm_state(

--- a/vultron/core/behaviors/case/nodes/actor.py
+++ b/vultron/core/behaviors/case/nodes/actor.py
@@ -32,12 +32,14 @@ the process-area root per BTND-07-003:
 """
 
 import logging
+from datetime import datetime
 from typing import Any, cast
 
 import py_trees
 from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.states.em import EM
 from vultron.core.states.roles import CVDRole
 from vultron.core.models.protocols import is_case_model
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
@@ -54,6 +56,15 @@ class EmitInviteActorToCaseNode(DataLayerAction):
     own inbox for canonical ledger archival (CLP-10-001).  An optional
     ``attributed_to`` carries the original requesting actor when the invite
     is sent from the Case Actor identity (PCR-08-007).
+
+    Reads ``suggested_roles`` from the blackboard (written by
+    :class:`EvaluateDefaultRolesNode`) and embeds them in the Invite activity
+    as the intended CVD roles for the invitee (CM-16-003).
+
+    When the case has an active embargo (``em_state == EM.ACTIVE``), embeds
+    ``active_embargo.end_time`` and the embargo state in ``Invite.target``
+    (the ``VulnerabilityCaseStub``) so the invitee can check terms before
+    accepting (CM-16-002).
     """
 
     def __init__(
@@ -72,6 +83,44 @@ class EmitInviteActorToCaseNode(DataLayerAction):
         self.attributed_to = attributed_to
         self._captured = captured
 
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="suggested_roles", access=py_trees.common.Access.READ
+        )
+
+    def _read_suggested_roles(self) -> list[CVDRole]:
+        try:
+            roles = self.blackboard.get("suggested_roles")
+            if isinstance(roles, list) and roles:
+                return roles
+        except KeyError:
+            pass
+        return [CVDRole.VENDOR]
+
+    def _get_embargo_details(
+        self,
+    ) -> tuple[str | None, str | None, datetime | None]:
+        """Return (active_embargo_id, em_state_str, embargo_end_time) for CM-16-002."""
+        assert self.datalayer is not None
+        case = self.datalayer.read(self.case_id)
+        if not is_case_model(case):
+            return None, None, None
+        try:
+            status = case.current_status
+            if status.em_state != EM.ACTIVE:
+                return None, None, None
+            raw_embargo = case.active_embargo
+            embargo_id = _as_id(raw_embargo) if raw_embargo else None
+            end_time = getattr(raw_embargo, "end_time", None)
+            return (
+                embargo_id,
+                "ACTIVE",
+                end_time if isinstance(end_time, datetime) else None,
+            )
+        except (AttributeError, ValueError):
+            return None, None, None
+
     def update(self) -> Status:
         if self.datalayer is None or self.actor_id is None:
             self.feedback_message = "DataLayer or actor_id not available"
@@ -88,6 +137,10 @@ class EmitInviteActorToCaseNode(DataLayerAction):
         # Add case_actor_id to cc: so ASGI self-delivery routes the Invite
         # to the CaseActor's inbox for canonical ledger archival (CLP-10-001).
         cc = [self.case_actor_id] if self.case_actor_id else None
+        roles = self._read_suggested_roles()
+        active_embargo_id, em_state_str, embargo_end_time = (
+            self._get_embargo_details()
+        )
 
         try:
             activity_id, activity_dict = factory.invite_actor_to_case(
@@ -97,6 +150,10 @@ class EmitInviteActorToCaseNode(DataLayerAction):
                 to=[self.invitee_id],
                 cc=cc,
                 attributed_to=self.attributed_to,
+                roles=roles,
+                active_embargo_id=active_embargo_id,
+                em_state=em_state_str,
+                embargo_end_time=embargo_end_time,
             )
             cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
                 self.actor_id, activity_id

--- a/vultron/core/ports/trigger_activity.py
+++ b/vultron/core/ports/trigger_activity.py
@@ -263,6 +263,10 @@ class TriggerActivityPort(Protocol):
         cc: list[str] | None = None,
         id_: str | None = None,
         attributed_to: str | None = None,
+        roles: list | None = None,
+        active_embargo_id: str | None = None,
+        em_state: str | None = None,
+        embargo_end_time: Any | None = None,
     ) -> tuple[str, dict[str, Any]]:
         """Create and persist an ``Invite(Actor, Case)`` activity.
 
@@ -270,6 +274,9 @@ class TriggerActivityPort(Protocol):
         MAY carry the case owner's ID for attribution.
         ``cc`` MAY carry the Case Actor's own ID for self-archival (CLP-10-001).
         ``id_`` allows callers to supply a deterministic ID for idempotency.
+        ``roles`` carries the intended CVD roles for the invitee (CM-16-003).
+        ``active_embargo_id``, ``em_state``, and ``embargo_end_time`` enrich
+        the case stub when an embargo is active (CM-16-002).
         Returns ``(activity_id, activity_dict)``.
         """
         ...

--- a/vultron/core/use_cases/triggers/actor.py
+++ b/vultron/core/use_cases/triggers/actor.py
@@ -100,6 +100,11 @@ class SvcInviteActorToCaseUseCase(SvcBTTriggerBase):
     Emits RmInviteToCaseActivity from the Case Actor's identity
     (PCR-08-007).  ``self._actor_id`` is set to the Case Actor URI in
     ``_prepare()`` so the BT queues the invite in the Case Actor's outbox.
+
+    When ``request.roles`` is provided, it is pre-populated into the
+    ``suggested_roles`` blackboard key so ``EmitInviteActorToCaseNode`` picks
+    it up (CM-16-003).  Otherwise ``EvaluateDefaultRolesNode`` (when present
+    in the tree) writes ``[CVDRole.VENDOR]`` as the default.
     """
 
     def _prepare(self) -> None:
@@ -113,6 +118,7 @@ class SvcInviteActorToCaseUseCase(SvcBTTriggerBase):
             raise VultronNotFoundError("Actor", request.invitee_id)
 
         self._invitee_id = request.invitee_id
+        self._roles = request.roles
 
         case_actor_id = _find_case_actor_id(self._dl, self._case.id_)
         self._actor_id = case_actor_id if case_actor_id else owner_id
@@ -131,6 +137,11 @@ class SvcInviteActorToCaseUseCase(SvcBTTriggerBase):
             attributed_to=self._attributed_to,
             captured=self._captured,
         )
+
+    def _extra_execute_kwargs(self) -> dict:
+        return {
+            "suggested_roles": self._roles if self._roles is not None else None
+        }
 
     def _handle_result(self) -> None:
         logger.info(

--- a/vultron/core/use_cases/triggers/requests.py
+++ b/vultron/core/use_cases/triggers/requests.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel, ConfigDict, field_validator
 from vultron.core.models.base import NonEmptyString, UriString
 from vultron.core.states.cs import CS_vfd, CS_pxa
 from vultron.core.states.rm import RM
+from vultron.core.states.roles import CVDRole
 
 
 class TriggerRequest(BaseModel):
@@ -196,10 +197,13 @@ class InviteActorToCaseTriggerRequest(CaseTriggerRequest):
     """Trigger request for the case owner to directly invite an actor.
 
     Emits an RmInviteToCaseActivity addressed to the invitee, queued in the
-    actor's outbox for delivery.
+    actor's outbox for delivery.  ``roles`` carries the intended CVD roles
+    for the invitee (CM-16-003); when ``None`` the BT falls back to
+    ``[CVDRole.VENDOR]`` via ``EvaluateDefaultRolesNode``.
     """
 
     invitee_id: NonEmptyString
+    roles: list[CVDRole] | None = None
 
 
 class AddParticipantStatusTriggerRequest(CaseTriggerRequest):

--- a/vultron/wire/as2/vocab/activities/case.py
+++ b/vultron/wire/as2/vocab/activities/case.py
@@ -275,12 +275,14 @@ class _RmInviteToCaseActivity(as_Invite):
     See also _RmSubmitReportActivity for the scenario when a case does not exist yet.
     object_: the Actor being invited
     target: VulnerabilityCase
+    roles: intended CVD roles for the invitee (CM-16-003)
     """
 
     object_: CoreActor | as_Actor = Field(
         ..., validation_alias="object", serialization_alias="object"
     )
     target: VulnerabilityCaseStub | str | None = None
+    roles: list[str] | None = None
 
 
 class _RmAcceptInviteToCaseActivity(as_Accept):

--- a/vultron/wire/as2/vocab/objects/vulnerability_case.py
+++ b/vultron/wire/as2/vocab/objects/vulnerability_case.py
@@ -56,11 +56,13 @@ def init_case_status():
 class VulnerabilityCaseStub(VultronAS2Object):
     """Minimal case reference sent in ``Invite.target`` (MV-10-001).
 
-    Carries only ``id`` and ``type`` — and an optional ``summary`` — on the
-    wire so that invitees can identify the case without receiving confidential
-    case details before they have accepted the invitation.
+    Carries ``id`` and ``type`` plus optional ``summary``, ``active_embargo``,
+    and ``case_status`` fields. When the case has an active embargo
+    (``em_state == EM.ACTIVE``), the sender SHOULD populate ``active_embargo``
+    and ``case_status`` so the invitee can check embargo terms before accepting
+    (CM-16-002).
 
-    Serialised with ``exclude_none=True`` this produces::
+    Serialised with ``exclude_none=True`` this produces (minimal)::
 
         {"id": "https://example.org/cases/abc", "type": "VulnerabilityCase"}
     """
@@ -77,6 +79,8 @@ class VulnerabilityCaseStub(VultronAS2Object):
         default=None, json_schema_extra={"format": "date-time"}
     )
     summary: NonEmptyString | None = None
+    active_embargo: EmbargoEventRef | None = None
+    case_status: CaseStatusRef | None = None
 
 
 def _materialized_case_statuses(


### PR DESCRIPTION
- Closes #1300

## Summary

Enriches the Invite(Actor, Case) activity with (1) intended CVD roles for the invitee (CM-16-003) and (2) active embargo details in the case stub so the invitee can check terms before accepting (CM-16-002). `CreateInviteeParticipantAtAcceptedNode` reads roles from the stored Invite and sets them on `VultronParticipant.case_roles` at accept time.

Also fixes a DataLayer regression where semantic-subclass-only fields (e.g. `roles` on `_RmInviteToCaseActivity`) were lost during the `as_Invite → _RmInviteToCaseActivity` coercion round-trip in `_coerce_to_semantic_class`.

## Changes

- `vultron/wire/as2/vocab/activities/case.py`: Add `roles: list[str] | None` to `_RmInviteToCaseActivity` (CM-16-003)
- `vultron/wire/as2/vocab/objects/vulnerability_case.py`: Add `active_embargo` and `case_status` to `VulnerabilityCaseStub` (CM-16-002)
- `vultron/adapters/driven/trigger_activity_adapter/actors.py`: Pass `roles`, `active_embargo_id`, `em_state`, `embargo_end_time` through to `rm_invite_to_case_activity`; move inline imports to module level
- `vultron/core/behaviors/case/nodes/actor.py`: `EmitInviteActorToCaseNode` reads `suggested_roles` blackboard key and calls `_get_embargo_details()` to enrich the factory call
- `vultron/core/behaviors/case/accept_invite_tree.py`: `CreateInviteeParticipantAtAcceptedNode` reads `roles` from the stored Invite and sets `case_roles` via constructor (PRM-05-004)
- `vultron/core/ports/trigger_activity.py`: Update `TriggerActivityPort.invite_actor_to_case` Protocol signature
- `vultron/core/use_cases/triggers/actor.py`: `SvcInviteActorToCaseUseCase._extra_execute_kwargs()` writes `suggested_roles` to blackboard; uses `is not None` check to preserve explicit empty lists
- `vultron/core/use_cases/triggers/requests.py`: Add `roles: list[CVDRole] | None` to `InviteActorToCaseTriggerRequest`
- `vultron/adapters/driven/datalayer_sqlite/datalayer.py`: `_coerce_to_semantic_class` accepts `raw_data`; merges with `{**raw_data, **coerce_dict}` so rehydrated typed objects win but semantic-subclass fields are preserved
- `test/` — 7 new tests covering all acceptance criteria

## Verification

- 4481 unit tests pass (7 new)
- Black, flake8, mypy, pyright clean

## Advisory (pre-existing gap, not introduced by this PR)

The FastAPI `InviteActorToCaseRequest` model and `TriggerService.invite_actor_to_case` do not yet propagate `roles` — the field would need to be added to both to reach the domain layer via the HTTP path. The domain-level `InviteActorToCaseTriggerRequest.roles` field added here is ready; wiring the API surface is deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)