### PR TITLE
fix: suppress context and pytest griffe false-positive warnings

### DIFF
--- a/.github/scripts/mkdocs-build-strict.sh
+++ b/.github/scripts/mkdocs-build-strict.sh
@@ -22,7 +22,7 @@ uv run mkdocs build --strict 2>&1 | tee "$TEMP_OUTPUT" || true
 TOTAL=$(grep -c "^WARNING -" "$TEMP_OUTPUT" || echo 0)
 
 # Count false-positive warnings (known decorator/keyword names)
-FALSE=$(grep "^WARNING -  Inline reference to unknown key" "$TEMP_OUTPUT" | grep -cE "(petterogren7535|main|v4|dataclass|prefix|base)" || echo 0)
+FALSE=$(grep "^WARNING -  Inline reference to unknown key" "$TEMP_OUTPUT" | grep -cE "(petterogren7535|main|v4|dataclass|prefix|base|context|pytest)" || echo 0)
 
 # Count print-site warnings (version-specific false positive)
 PRINT=$(grep -c "^WARNING -  \[mkdocs-print-site\]" "$TEMP_OUTPUT" || echo 0)

--- a/plan/history/2607/implementation/ISSUE-1329.md
+++ b/plan/history/2607/implementation/ISSUE-1329.md
@@ -1,0 +1,12 @@
+---
+source: ISSUE-1329
+timestamp: '2026-07-10T20:52:42.316781+00:00'
+title: suppress context and pytest griffe false-positive warnings in mkdocs build
+type: implementation
+---
+
+## Issue #1329 — suppress context and pytest griffe false-positive warnings
+
+Added `context` and `pytest` to the false-positive suppression pattern in `.github/scripts/mkdocs-build-strict.sh`. These keywords were being misinterpreted as bibliography citation keys by `mkdocs_bibtex` when griffe encountered `@context` and `@pytest` in docstrings. The fix reduces real warning count from 5 to 1 (the remaining one being a pre-existing pages-not-in-nav issue).
+
+PR: <https://github.com/CERTCC/Vultron/pull/1355>


### PR DESCRIPTION
- Closes #1329

## Summary

Adds `context` and `pytest` to the false-positive suppression pattern in
`.github/scripts/mkdocs-build-strict.sh`. These two keywords are
misinterpreted as bibliography citation keys by `mkdocs_bibtex` when
griffe encounters `@context` and `@pytest` in docstrings (e.g.,
`context=...` parameter docs, `@pytest.fixture` decorator references).

## Changes

- `.github/scripts/mkdocs-build-strict.sh`: extend `grep -cE` alternation
  to include `context` and `pytest` alongside existing patterns
  (`dataclass`, `prefix`, `base`, etc.)

## Verification

- `bash .github/scripts/mkdocs-build-strict.sh` now exits 0 with
  "Suppressed N false-positive warnings" (previously exited 1 with
  "5 real warning(s)")
- All 4486 unit tests pass (0 new)
- Black, flake8, mypy, pyright clean