### PR TITLE
feat: wire CallOutBackendFactory injection into new-arch BT tree builders (FUZZ-08e)

### DIFF
--- a/notes/bt-fuzzer-nodes-embargo.md
+++ b/notes/bt-fuzzer-nodes-embargo.md
@@ -68,7 +68,9 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Automation potential**: **Medium** — deployment status check is automatable via patch-management or case-state APIs; the *decision* to exit still requires policy-rule evaluation or human confirmation.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.ExitEmbargoWhenDeployed`
 - **Call-out point shape**: Evaluator
-- **Factory-fn placement**: FUTURE:
+- **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
+  `vultron.core.behaviors.embargo.manage_embargo_tree.create_manage_embargo_tree`
+  (`exit_embargo_when_deployed_factory` param). FUTURE full placement:
   `vultron.core.behaviors.embargo.create_terminate_embargo_on_condition_tree`
   (issue #1256) — condition guard in the TerminateEmbargo Selector, checked
   before delegating to `terminate_embargo_trigger_bt`
@@ -88,7 +90,9 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Automation potential**: **Medium** — fix-readiness flag is queryable automatically; the exit decision depends on configurable organizational policy that may require human override.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.ExitEmbargoWhenFixReady`
 - **Call-out point shape**: Evaluator
-- **Factory-fn placement**: FUTURE:
+- **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
+  `vultron.core.behaviors.embargo.manage_embargo_tree.create_manage_embargo_tree`
+  (`exit_embargo_when_fix_ready_factory` param). FUTURE full placement:
   `vultron.core.behaviors.embargo.create_terminate_embargo_on_condition_tree`
   (issue #1256) — condition guard in the TerminateEmbargo Selector, checked
   before delegating to `terminate_embargo_trigger_bt`
@@ -108,7 +112,9 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Automation potential**: **Low** — rare edge case representing extraordinary circumstances; fundamentally requires human judgment that cannot be anticipated by a general policy rule.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.ExitEmbargoForOtherReason`
 - **Call-out point shape**: Evaluator
-- **Factory-fn placement**: FUTURE:
+- **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
+  `vultron.core.behaviors.embargo.manage_embargo_tree.create_manage_embargo_tree`
+  (`exit_embargo_for_other_reason_factory` param). FUTURE full placement:
   `vultron.core.behaviors.embargo.create_terminate_embargo_on_condition_tree`
   (issue #1256) — rare fallback condition guard in the TerminateEmbargo
   Selector for extraordinary circumstances
@@ -176,7 +182,9 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Automation potential**: **Low** — fundamentally a negotiation-fatigue judgment; depends on relationship context and subjective assessment of negotiation prospects; requires human decision.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.StopProposingEmbargo`
 - **Call-out point shape**: Evaluator
-- **Factory-fn placement**: FUTURE:
+- **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
+  `vultron.core.behaviors.embargo.manage_embargo_tree.create_manage_embargo_tree`
+  (`stop_proposing_embargo_factory` param). FUTURE full placement:
   `vultron.core.behaviors.embargo.create_propose_embargo_decision_tree`
   (issue #1257) — Evaluator condition guard in
   `_ConsiderAbandoningProposedEmbargo` Selector
@@ -197,7 +205,9 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Automation potential**: **Medium** — standard terms (duration, conditions) can be drawn from organizational policy templates automatically; atypical situations may need human review.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.SelectEmbargoOfferTerms`
 - **Call-out point shape**: Evaluator
-- **Factory-fn placement**: FUTURE:
+- **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
+  `vultron.core.behaviors.embargo.manage_embargo_tree.create_manage_embargo_tree`
+  (`select_embargo_offer_terms_factory` param). FUTURE full placement:
   `vultron.core.behaviors.embargo.create_propose_embargo_decision_tree`
   (issue #1257) — Evaluator action node in `_ProposeNewEmbargo` and
   `_ProposeEmbargoRevision` Sequences, before the proposal trigger BT
@@ -217,7 +227,9 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Automation potential**: **Medium** — default policy (always propose) can be automated; exceptions (e.g., already-public vulnerability, no vendor identified) could be rule-encoded, but edge cases may need human override.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.WantToProposeEmbargo`
 - **Call-out point shape**: Evaluator
-- **Factory-fn placement**: FUTURE:
+- **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
+  `vultron.core.behaviors.embargo.manage_embargo_tree.create_manage_embargo_tree`
+  (`want_to_propose_embargo_factory` param). FUTURE full placement:
   `vultron.core.behaviors.embargo.create_propose_embargo_decision_tree`
   (issue #1257) — Evaluator condition guard in `_ConsiderProposingEmbargo`
   Sequence (within `_EmNone` Selector)
@@ -238,7 +250,9 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Automation potential**: **Low** — nuanced negotiation judgment about whether countering is strategically preferable to accepting and revising; best left to human discretion.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.WillingToCounterEmbargoProposal`
 - **Call-out point shape**: Evaluator
-- **Factory-fn placement**: FUTURE:
+- **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
+  `vultron.core.behaviors.embargo.manage_embargo_tree.create_manage_embargo_tree`
+  (`willing_to_counter_factory` param). FUTURE full placement:
   `vultron.core.behaviors.embargo.create_propose_embargo_decision_tree`
   (issue #1257) — Evaluator condition guard in `_AvoidCounterProposal`
   Selector; determines whether a counter-proposal is sent instead of
@@ -259,7 +273,9 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Automation potential**: **Low** — highly exceptional circumstance; no general rule can anticipate valid reasons, so human judgment is required.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.ReasonToProposeEmbargoWhenDeployed`
 - **Call-out point shape**: Evaluator
-- **Factory-fn placement**: FUTURE:
+- **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
+  `vultron.core.behaviors.embargo.manage_embargo_tree.create_manage_embargo_tree`
+  (`reason_to_propose_when_deployed_factory` param). FUTURE full placement:
   `vultron.core.behaviors.embargo.create_propose_embargo_decision_tree`
   (issue #1257) — Evaluator condition guard in
   `_AvoidNewEmbargoesInCsDeployedUnlessReason` Selector
@@ -280,7 +296,9 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Automation potential**: **Medium** — basic compatibility check (is proposed duration within policy bounds?) is automatable; final accept/reject for out-of-range proposals typically needs human review.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.EvaluateEmbargoProposal`
 - **Call-out point shape**: Evaluator
-- **Factory-fn placement**: FUTURE:
+- **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
+  `vultron.core.behaviors.embargo.manage_embargo_tree.create_manage_embargo_tree`
+  (`evaluate_embargo_proposal_factory` param). FUTURE full placement:
   `vultron.core.behaviors.embargo.create_propose_embargo_decision_tree`
   (issue #1257) — Evaluator condition guard in
   `_EvaluateAndAcceptProposedEmbargo` Sequence; precedes
@@ -343,7 +361,9 @@ evaluation, and lifecycle management of coordinated disclosure embargoes.
 - **Automation potential**: **Medium** — automated comparison of current terms against policy preferences is feasible; edge cases and dynamic negotiation contexts may still require human judgment.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.embargo.CurrentEmbargoAcceptable`
 - **Call-out point shape**: Evaluator
-- **Factory-fn placement**: FUTURE:
+- **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
+  `vultron.core.behaviors.embargo.manage_embargo_tree.create_manage_embargo_tree`
+  (`current_embargo_acceptable_factory` param). FUTURE full placement:
   `vultron.core.behaviors.embargo.create_propose_embargo_decision_tree`
   (issue #1257) — Evaluator condition guard in `_ChooseEmActiveResponse`
   Selector; SUCCESS = no revision needed, FAILURE = revision proposal path

--- a/notes/bt-fuzzer-nodes-report-management.md
+++ b/notes/bt-fuzzer-nodes-report-management.md
@@ -384,7 +384,9 @@ to a validated report.
 - **Automation potential**: **High** — scope rules for well-defined ID spaces (e.g., CVE CNA rules) can be encoded as a policy check and automated; may require human review for ambiguous cases.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.assign_vul_id.InScope`
 - **Call-out point shape**: Evaluator — evaluates whether the vulnerability falls within the applicable ID namespace by comparing vulnerability attributes against CNA scope rules or a product/component registry; returns a policy judgment (in-scope or out-of-scope), not a binary monitor.
-- **Factory-fn placement**: FUTURE:
+- **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
+  `vultron.core.behaviors.report.assign_vul_id_tree.create_assign_vul_id_tree`
+  (`in_scope_factory` param). FUTURE full placement:
   `vultron.core.behaviors.report.create_assign_vul_id_tree` (issue #1246) —
   Evaluator condition guard early in `AssignVulID` Sequence, before the
   authority-check nodes
@@ -442,7 +444,9 @@ to a validated report.
   authority for this specific vulnerability by matching vulnerability
   attributes against CNA scope rules and product-to-CNA mappings;
   a scope-matching evaluation, not a binary condition monitor.
-- **Factory-fn placement**: FUTURE:
+- **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
+  `vultron.core.behaviors.report.assign_vul_id_tree.create_assign_vul_id_tree`
+  (`id_assignable_factory` param). FUTURE full placement:
   `vultron.core.behaviors.report.create_assign_vul_id_tree` (issue #1246) —
   Evaluator condition guard in the assign-direct path Sequence, after
   `IsIDAssignmentAuthority` succeeds
@@ -542,9 +546,12 @@ the process of deploying a developed fix or mitigation to affected systems.
   `NewDeploymentInfoSentinel` agent (see stub entry below). The external agent seam is at the
   Sentinel (event subscription or polling hook), not at this BT condition check.
   (Category 2 per issue #1199 triage — consumes a flag written by an upstream Sentinel.)
-- **Factory-fn placement**: FUTURE:
+- **Factory-fn placement**: FUTURE (not wired in Phase 1 stub):
   `vultron.core.behaviors.report.create_deploy_fix_tree` (issue #1248) —
-  ProtocolInternal condition check at the top of `Deployment` Fallback Selector
+  ProtocolInternal condition check at the top of `Deployment` Fallback Selector.
+  Note: Phase 1 stub exists as of PR #1357 in
+  `vultron.core.behaviors.report.deploy_fix_tree.create_deploy_fix_tree`
+  but this ProtocolInternal node is not among the 4 factory params exposed.
 
 ### `NewDeploymentInfoSentinel` *(upstream Sentinel stub)*
 
@@ -592,7 +599,9 @@ the process of deploying a developed fix or mitigation to affected systems.
 - **Automation potential**: **Medium** — CVSS environmental scores, EPSS, and asset criticality data are automatable inputs; final prioritization decision may require human approval, especially for production systems.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.deploy_fix.PrioritizeDeployment`
 - **Call-out point shape**: Evaluator
-- **Factory-fn placement**: FUTURE:
+- **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
+  `vultron.core.behaviors.report.deploy_fix_tree.create_deploy_fix_tree`
+  (`prioritize_deployment_factory` param). FUTURE full placement:
   `vultron.core.behaviors.report.create_deploy_fix_tree` (issue #1248) —
   Evaluator action node in the `Deployment` Sequence, setting deployment
   priority before the mitigation/fix-deploy paths
@@ -612,10 +621,12 @@ the process of deploying a developed fix or mitigation to affected systems.
 - **Automation potential**: **High** — query to patch management system or case-state flag; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.deploy_fix.MitigationDeployed`
 - **Call-out point shape**: Retriever — synchronous on-demand query to an asset/patch management system or case-state flag; returns SUCCESS if a mitigation has been deployed, FAILURE otherwise. A boolean is the simplest structured fact (ADR-0024); the on-demand query pattern makes this a Retriever, not a Sentinel.
-- **Factory-fn placement**: FUTURE:
+- **Factory-fn placement**: FUTURE (not wired in Phase 1 stub):
   `vultron.core.behaviors.report.create_deploy_fix_tree` (issue #1248) —
   early-exit Retriever guard in `Deployment` Selector; short-circuits when
-  mitigation is already deployed
+  mitigation is already deployed.
+  Note: Phase 1 stub exists as of PR #1357 but this Retriever is not
+  among the 4 factory params exposed.
 
 ### `MitigationAvailable`
 
@@ -632,10 +643,12 @@ the process of deploying a developed fix or mitigation to affected systems.
 - **Automation potential**: **High** — patch or advisory feed query; fully automatable once the feed integration is in place.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.deploy_fix.MitigationAvailable`
 - **Call-out point shape**: Retriever — synchronous on-demand query to a patch/advisory feed or internal mitigation catalog; returns SUCCESS if a mitigation is currently available, FAILURE otherwise. A boolean is the simplest structured fact (ADR-0024); the on-demand query pattern makes this a Retriever, not a Sentinel.
-- **Factory-fn placement**: FUTURE:
+- **Factory-fn placement**: FUTURE (not wired in Phase 1 stub):
   `vultron.core.behaviors.report.create_deploy_fix_tree` (issue #1248) —
   Retriever condition guard in the mitigation-deploy Sequence, before
-  `DeployMitigation`; queries availability before attempting deployment
+  `DeployMitigation`; queries availability before attempting deployment.
+  Note: Phase 1 stub exists as of PR #1357 but this Retriever is not
+  among the 4 factory params exposed.
 
 ### `DeployMitigation`
 
@@ -652,7 +665,9 @@ the process of deploying a developed fix or mitigation to affected systems.
 - **Automation potential**: **Medium** — automated deployment is feasible for some environments (configuration management, cloud); human approval is typically required for production system changes.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.deploy_fix.DeployMitigation`
 - **Call-out point shape**: Evaluator
-- **Factory-fn placement**: FUTURE:
+- **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
+  `vultron.core.behaviors.report.deploy_fix_tree.create_deploy_fix_tree`
+  (`deploy_mitigation_factory` param). FUTURE full placement:
   `vultron.core.behaviors.report.create_deploy_fix_tree` (issue #1248) —
   Evaluator action node in the mitigation-deploy Sequence, after
   `MitigationAvailable` succeeds
@@ -672,7 +687,9 @@ the process of deploying a developed fix or mitigation to affected systems.
 - **Automation potential**: **High** — policy rule evaluation against case context (severity, asset class, environment); fully automatable as a policy engine check.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.deploy_fix.MonitoringRequirement`
 - **Call-out point shape**: Evaluator — evaluates whether organizational policy requires post-deployment monitoring for this case by applying policy rules against case context (severity, asset class, environment); a policy judgment call, not a binary condition monitor.
-- **Factory-fn placement**: FUTURE:
+- **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
+  `vultron.core.behaviors.report.deploy_fix_tree.create_deploy_fix_tree`
+  (`monitoring_requirement_factory` param). FUTURE full placement:
   `vultron.core.behaviors.report.create_deploy_fix_tree` (issue #1248) —
   Evaluator condition guard in the monitoring-initiation Sequence; SUCCESS
   proceeds to `MonitorDeployment`
@@ -697,11 +714,13 @@ the process of deploying a developed fix or mitigation to affected systems.
   the side effect in the external monitoring system is the seam. This is a fire-and-confirm
   action node, not a continuous monitor running outside the BT — the BT tick reaches this node
   once per `MonitoringRequirement` pass and asks the external system to begin tracking.
-- **Factory-fn placement**: FUTURE:
+- **Factory-fn placement**: FUTURE (not wired in Phase 1 stub):
   `vultron.core.behaviors.report.create_deploy_fix_tree` (issue #1248) —
   Actuator action node in the monitoring-initiation Sequence, after
   `MonitoringRequirement` succeeds; fires the external monitoring registration
-  call and confirms activation
+  call and confirms activation.
+  Note: Phase 1 stub exists as of PR #1357 but this Actuator is not
+  among the 4 factory params exposed.
 
 ### `DeployFix`
 
@@ -718,7 +737,9 @@ the process of deploying a developed fix or mitigation to affected systems.
 - **Automation potential**: **Medium** — release pipeline and patch distribution can be automated (CI/CD, package repositories); human approval gate is commonly required for production releases.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.deploy_fix.DeployFix`
 - **Call-out point shape**: Evaluator
-- **Factory-fn placement**: FUTURE:
+- **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
+  `vultron.core.behaviors.report.deploy_fix_tree.create_deploy_fix_tree`
+  (`deploy_fix_factory` param). FUTURE full placement:
   `vultron.core.behaviors.report.create_deploy_fix_tree` (issue #1248) —
   Evaluator action node in the full-fix-deploy Sequence; the primary patch
   deployment step (distinct from mitigation deployment)
@@ -792,7 +813,9 @@ vulnerability, typically to support impact assessment or testing.
 - **Automation potential**: **Medium** — SSVC/CVSS scoring inputs are automatable; the final exploit-acquisition priority decision often requires human analyst judgment given organizational and legal context.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.acquire_exploit.EvaluateExploitPriority`
 - **Call-out point shape**: Evaluator
-- **Factory-fn placement**: FUTURE:
+- **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
+  `vultron.core.behaviors.report.acquire_exploit_tree.create_acquire_exploit_tree`
+  (`evaluate_exploit_priority_factory` param). FUTURE full placement:
   `vultron.core.behaviors.report.create_acquire_exploit_strategy_tree`
   (issue #1249) — Evaluator action node in the priority-decision Sequence;
   writes the `exploit_priority` decision to the blackboard for downstream
@@ -903,7 +926,9 @@ vulnerability, typically to support impact assessment or testing.
 - **Automation potential**: **Low** — procurement and legal authorization require human decision-making; cannot be automated.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.acquire_exploit.PurchaseExploit`
 - **Call-out point shape**: Evaluator
-- **Factory-fn placement**: FUTURE:
+- **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
+  `vultron.core.behaviors.report.acquire_exploit_tree.create_acquire_exploit_tree`
+  (`purchase_exploit_factory` param). FUTURE full placement:
   `vultron.core.behaviors.report.create_acquire_exploit_strategy_tree`
   (issue #1249) — third (last-resort) Evaluator child in the acquisition
   Fallback; tried only after `FindExploit` and `DevelopExploit` both fail
@@ -1352,7 +1377,9 @@ coordinated disclosure.
 - **Automation potential**: **Low** — inherently requires human expert judgment about stakeholder completeness in a specific vulnerability context; hard to automate reliably.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.AllPartiesKnown`
 - **Call-out point shape**: Evaluator
-- **Factory-fn placement**: FUTURE:
+- **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
+  `vultron.core.behaviors.report.report_to_others_tree.create_report_to_others_tree`
+  (`all_parties_known_factory` param). FUTURE full placement:
   `vultron.core.behaviors.report.create_report_to_others_tree`
   (issue #1252) — Evaluator Sentinel after `HaveReportToOthersCapability`;
   exits the outer party-identification loop once all parties are known
@@ -1502,7 +1529,9 @@ coordinated disclosure.
 - **Automation potential**: **High** — effort counter check against a configurable policy threshold; fully automatable once the threshold policy is defined.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.RecipientEffortExceeded`
 - **Call-out point shape**: Evaluator — evaluates whether the notification-attempt budget for this recipient has been exhausted by comparing the per-recipient attempt counter against a configurable policy threshold; a process-gate judgment about whether continued effort is warranted.
-- **Factory-fn placement**: FUTURE:
+- **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
+  `vultron.core.behaviors.report.report_to_others_tree.create_report_to_others_tree`
+  (`recipient_effort_exceeded_factory` param). FUTURE full placement:
   `vultron.core.behaviors.report.create_report_to_others_tree`
   (issue #1252) — Evaluator guard in the per-recipient effort-limit
   Sequence; triggers `RemoveRecipient` when the per-recipient attempt
@@ -1523,7 +1552,9 @@ coordinated disclosure.
 - **Automation potential**: **High** — aggregate effort counter check against a configurable policy ceiling; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.TotalEffortLimitMet`
 - **Call-out point shape**: Evaluator — evaluates whether the global notification budget has been exhausted by comparing the total effort counter against a configurable policy ceiling; a process-gate judgment about whether any further notification attempts are warranted across all recipients.
-- **Factory-fn placement**: FUTURE:
+- **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
+  `vultron.core.behaviors.report.report_to_others_tree.create_report_to_others_tree`
+  (`total_effort_limit_factory` param). FUTURE full placement:
   `vultron.core.behaviors.report.create_report_to_others_tree`
   (issue #1252) — Evaluator guard checked at the outer loop level;
   terminates all further notification attempts when the global effort
@@ -1545,7 +1576,9 @@ coordinated disclosure.
 - **Automation potential**: **Medium** — comparison between the recipient's published CVD policy and the case embargo terms is automatable for machine-readable policies (e.g., OpenVEX, structured security.txt); human review needed for ambiguous or informal policies.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.report_to_others.PolicyCompatible`
 - **Call-out point shape**: Evaluator
-- **Factory-fn placement**: FUTURE:
+- **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
+  `vultron.core.behaviors.report.report_to_others_tree.create_report_to_others_tree`
+  (`policy_compatible_factory` param). FUTURE full placement:
   `vultron.core.behaviors.report.create_report_to_others_tree`
   (issue #1252) — Evaluator precondition guard before `FindContact` and
   `RcptNotInQrmS`; gates notification on policy compatibility check
@@ -1802,7 +1835,9 @@ complete (or otherwise concluded).
 - **Automation potential**: **Low** — site-specific; closure criteria vary widely by organization and case context; typically requires human policy evaluation or explicit sign-off.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.close_report.OtherCloseCriteriaMet`
 - **Call-out point shape**: Evaluator
-- **Factory-fn placement**: FUTURE:
+- **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
+  `vultron.core.behaviors.report.close_report_tree.create_close_report_tree`
+  (`other_close_criteria_factory` param). FUTURE full placement:
   `vultron.core.behaviors.report.create_close_report_tree`
   (issue #1253) — Evaluator precondition guard in the `RMCloseBt` Sequence;
   evaluated before `PreCloseAction`; blocks closure until site-specific

--- a/test/core/behaviors/embargo/test_manage_embargo_tree.py
+++ b/test/core/behaviors/embargo/test_manage_embargo_tree.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Tests for the manage-embargo behavior tree (Phase 1 stub).
+
+Verifies BT-18-004: all ten factory params are accepted and wired; defaults
+are the correct fuzzer classes.
+"""
+
+import pytest
+import py_trees
+
+from vultron.core.behaviors.embargo.manage_embargo_tree import (
+    create_manage_embargo_tree,
+)
+from vultron.demo.fuzzer.embargo import (
+    CurrentEmbargoAcceptable,
+    EvaluateEmbargoProposal,
+    ExitEmbargoForOtherReason,
+    ExitEmbargoWhenDeployed,
+    ExitEmbargoWhenFixReady,
+    ReasonToProposeEmbargoWhenDeployed,
+    SelectEmbargoOfferTerms,
+    StopProposingEmbargo,
+    WantToProposeEmbargo,
+    WillingToCounterEmbargoProposal,
+)
+
+CASE_ID = "https://example.org/cases/test-001"
+
+_EXPECTED_DEFAULTS = [
+    ExitEmbargoWhenDeployed,
+    ExitEmbargoWhenFixReady,
+    ExitEmbargoForOtherReason,
+    StopProposingEmbargo,
+    SelectEmbargoOfferTerms,
+    WantToProposeEmbargo,
+    WillingToCounterEmbargoProposal,
+    ReasonToProposeEmbargoWhenDeployed,
+    EvaluateEmbargoProposal,
+    CurrentEmbargoAcceptable,
+]
+
+_FACTORY_PARAMS = [
+    "exit_embargo_when_deployed_factory",
+    "exit_embargo_when_fix_ready_factory",
+    "exit_embargo_for_other_reason_factory",
+    "stop_proposing_embargo_factory",
+    "select_embargo_offer_terms_factory",
+    "want_to_propose_embargo_factory",
+    "willing_to_counter_factory",
+    "reason_to_propose_when_deployed_factory",
+    "evaluate_embargo_proposal_factory",
+    "current_embargo_acceptable_factory",
+]
+
+
+def _marker_factory(label):
+    def factory(name):
+        class _Marker(py_trees.behaviour.Behaviour):
+            def update(self):
+                return py_trees.common.Status.SUCCESS
+
+        return _Marker(name=label)
+
+    return factory
+
+
+def test_create_manage_embargo_tree_returns_behaviour():
+    tree = create_manage_embargo_tree(case_id=CASE_ID)
+    assert isinstance(tree, py_trees.behaviour.Behaviour)
+
+
+def test_root_name():
+    tree = create_manage_embargo_tree(case_id=CASE_ID)
+    assert tree.name == "ManageEmbargoBT"
+
+
+def test_default_children_count():
+    tree = create_manage_embargo_tree(case_id=CASE_ID)
+    assert len(tree.children) == 10
+
+
+@pytest.mark.parametrize("index,cls", list(enumerate(_EXPECTED_DEFAULTS)))
+def test_default_child_is_correct_fuzzer_node(index, cls):
+    """Each child defaults to the expected fuzzer class (BT-18-004)."""
+    tree = create_manage_embargo_tree(case_id=CASE_ID)
+    assert isinstance(tree.children[index], cls)
+
+
+@pytest.mark.parametrize("param,index", list(zip(_FACTORY_PARAMS, range(10))))
+def test_each_factory_is_wired(param, index):
+    """Each factory parameter is individually wired into the corresponding child."""
+    label = f"Custom_{index}"
+    sentinel = {"called": False}
+
+    def custom_factory(name):
+        sentinel["called"] = True
+
+        class _Marker(py_trees.behaviour.Behaviour):
+            def update(self):
+                return py_trees.common.Status.SUCCESS
+
+        return _Marker(name=label)
+
+    tree = create_manage_embargo_tree(
+        case_id=CASE_ID, **{param: custom_factory}
+    )
+    assert sentinel["called"]
+    assert tree.children[index].name == label
+
+
+def test_all_factories_replaceable():
+    """All factory params can be replaced simultaneously."""
+    kwargs = {
+        param: _marker_factory(f"M{i}")
+        for i, param in enumerate(_FACTORY_PARAMS)
+    }
+    tree = create_manage_embargo_tree(case_id=CASE_ID, **kwargs)
+    tree_str = py_trees.display.ascii_tree(tree)
+    for i in range(10):
+        assert f"M{i}" in tree_str

--- a/test/core/behaviors/report/test_acquire_exploit_tree.py
+++ b/test/core/behaviors/report/test_acquire_exploit_tree.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Tests for the acquire-exploit behavior tree (Phase 1 stub).
+
+Verifies BT-18-004: factory params are accepted and used; defaults are the
+correct fuzzer classes.
+"""
+
+import py_trees
+
+from vultron.core.behaviors.report.acquire_exploit_tree import (
+    create_acquire_exploit_tree,
+)
+from vultron.demo.fuzzer.report_management.acquire_exploit import (
+    EvaluateExploitPriority,
+    PurchaseExploit,
+)
+
+CASE_ID = "https://example.org/cases/test-001"
+
+
+def _marker_factory(label):
+    def factory(name):
+        class _Marker(py_trees.behaviour.Behaviour):
+            def update(self):
+                return py_trees.common.Status.SUCCESS
+
+        return _Marker(name=label)
+
+    return factory
+
+
+def test_create_acquire_exploit_tree_returns_behaviour():
+    tree = create_acquire_exploit_tree(case_id=CASE_ID)
+    assert isinstance(tree, py_trees.behaviour.Behaviour)
+
+
+def test_create_acquire_exploit_tree_root_name():
+    tree = create_acquire_exploit_tree(case_id=CASE_ID)
+    assert tree.name == "AcquireExploitBT"
+
+
+def test_default_children_are_fuzzer_nodes():
+    """Default factory produces the correct fuzzer-class nodes."""
+    tree = create_acquire_exploit_tree(case_id=CASE_ID)
+    assert len(tree.children) == 2
+    assert isinstance(tree.children[0], EvaluateExploitPriority)
+    assert isinstance(tree.children[1], PurchaseExploit)
+
+
+def test_evaluate_exploit_priority_factory_used():
+    """Custom evaluate_exploit_priority_factory is wired into the tree."""
+    sentinel = {"called": False}
+
+    def custom_factory(name):
+        sentinel["called"] = True
+
+        class _Marker(py_trees.behaviour.Behaviour):
+            def update(self):
+                return py_trees.common.Status.SUCCESS
+
+        return _Marker(name="CustomEvaluateExploitPriority")
+
+    tree = create_acquire_exploit_tree(
+        case_id=CASE_ID,
+        evaluate_exploit_priority_factory=custom_factory,
+    )
+    assert sentinel["called"]
+    tree_str = py_trees.display.ascii_tree(tree)
+    assert "CustomEvaluateExploitPriority" in tree_str
+
+
+def test_purchase_exploit_factory_used():
+    """Custom purchase_exploit_factory is wired into the tree."""
+    sentinel = {"called": False}
+
+    def custom_factory(name):
+        sentinel["called"] = True
+
+        class _Marker(py_trees.behaviour.Behaviour):
+            def update(self):
+                return py_trees.common.Status.SUCCESS
+
+        return _Marker(name="CustomPurchaseExploit")
+
+    tree = create_acquire_exploit_tree(
+        case_id=CASE_ID,
+        purchase_exploit_factory=custom_factory,
+    )
+    assert sentinel["called"]
+    tree_str = py_trees.display.ascii_tree(tree)
+    assert "CustomPurchaseExploit" in tree_str
+
+
+def test_both_factories_replaceable():
+    """Both factory params can be replaced simultaneously."""
+    tree = create_acquire_exploit_tree(
+        case_id=CASE_ID,
+        evaluate_exploit_priority_factory=_marker_factory("EEP"),
+        purchase_exploit_factory=_marker_factory("PE"),
+    )
+    tree_str = py_trees.display.ascii_tree(tree)
+    assert "EEP" in tree_str
+    assert "PE" in tree_str
+    assert not isinstance(tree.children[0], EvaluateExploitPriority)
+    assert not isinstance(tree.children[1], PurchaseExploit)

--- a/test/core/behaviors/report/test_assign_vul_id_tree.py
+++ b/test/core/behaviors/report/test_assign_vul_id_tree.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Tests for the assign-VUL-ID behavior tree (Phase 1 stub).
+
+Verifies BT-18-004: factory params are accepted and used; defaults are the
+correct fuzzer classes.
+"""
+
+import py_trees
+
+from vultron.core.behaviors.report.assign_vul_id_tree import (
+    create_assign_vul_id_tree,
+)
+from vultron.demo.fuzzer.report_management.assign_vul_id import (
+    IdAssignable,
+    InScope,
+)
+
+CASE_ID = "https://example.org/cases/test-001"
+
+
+def _marker_factory(label):
+    def factory(name):
+        class _Marker(py_trees.behaviour.Behaviour):
+            def update(self):
+                return py_trees.common.Status.SUCCESS
+
+        return _Marker(name=label)
+
+    return factory
+
+
+def test_create_assign_vul_id_tree_returns_behaviour():
+    tree = create_assign_vul_id_tree(case_id=CASE_ID)
+    assert isinstance(tree, py_trees.behaviour.Behaviour)
+
+
+def test_create_assign_vul_id_tree_root_name():
+    tree = create_assign_vul_id_tree(case_id=CASE_ID)
+    assert tree.name == "AssignVulIDBT"
+
+
+def test_default_children_are_fuzzer_nodes():
+    tree = create_assign_vul_id_tree(case_id=CASE_ID)
+    assert len(tree.children) == 2
+    assert isinstance(tree.children[0], InScope)
+    assert isinstance(tree.children[1], IdAssignable)
+
+
+def test_id_assignable_factory_used():
+    sentinel = {"called": False}
+
+    def custom_factory(name):
+        sentinel["called"] = True
+
+        class _Marker(py_trees.behaviour.Behaviour):
+            def update(self):
+                return py_trees.common.Status.SUCCESS
+
+        return _Marker(name="CustomIdAssignable")
+
+    tree = create_assign_vul_id_tree(
+        case_id=CASE_ID,
+        id_assignable_factory=custom_factory,
+    )
+    assert sentinel["called"]
+    assert "CustomIdAssignable" in py_trees.display.ascii_tree(tree)
+
+
+def test_in_scope_factory_used():
+    sentinel = {"called": False}
+
+    def custom_factory(name):
+        sentinel["called"] = True
+
+        class _Marker(py_trees.behaviour.Behaviour):
+            def update(self):
+                return py_trees.common.Status.SUCCESS
+
+        return _Marker(name="CustomInScope")
+
+    tree = create_assign_vul_id_tree(
+        case_id=CASE_ID,
+        in_scope_factory=custom_factory,
+    )
+    assert sentinel["called"]
+    assert "CustomInScope" in py_trees.display.ascii_tree(tree)
+
+
+def test_both_factories_replaceable():
+    tree = create_assign_vul_id_tree(
+        case_id=CASE_ID,
+        id_assignable_factory=_marker_factory("IA"),
+        in_scope_factory=_marker_factory("IS"),
+    )
+    tree_str = py_trees.display.ascii_tree(tree)
+    assert "IA" in tree_str
+    assert "IS" in tree_str

--- a/test/core/behaviors/report/test_close_report_tree.py
+++ b/test/core/behaviors/report/test_close_report_tree.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Tests for the close-report behavior tree (Phase 1 stub).
+
+Verifies BT-18-004: factory param is accepted and used; default is the
+correct fuzzer class.
+"""
+
+import py_trees
+
+from vultron.core.behaviors.report.close_report_tree import (
+    create_close_report_tree,
+)
+from vultron.demo.fuzzer.report_management.close_report import (
+    OtherCloseCriteriaMet,
+)
+
+CASE_ID = "https://example.org/cases/test-001"
+
+
+def test_create_close_report_tree_returns_behaviour():
+    tree = create_close_report_tree(case_id=CASE_ID)
+    assert isinstance(tree, py_trees.behaviour.Behaviour)
+
+
+def test_default_is_other_close_criteria_met():
+    tree = create_close_report_tree(case_id=CASE_ID)
+    assert isinstance(tree, OtherCloseCriteriaMet)
+
+
+def test_default_node_name():
+    tree = create_close_report_tree(case_id=CASE_ID)
+    assert tree.name == "OtherCloseCriteriaMet"
+
+
+def test_custom_factory_used():
+    sentinel = {"called": False}
+
+    def custom_factory(name):
+        sentinel["called"] = True
+
+        class _Marker(py_trees.behaviour.Behaviour):
+            def update(self):
+                return py_trees.common.Status.SUCCESS
+
+        return _Marker(name="CustomOtherClose")
+
+    tree = create_close_report_tree(
+        case_id=CASE_ID,
+        other_close_criteria_factory=custom_factory,
+    )
+    assert sentinel["called"]
+    assert tree.name == "CustomOtherClose"
+    assert not isinstance(tree, OtherCloseCriteriaMet)

--- a/test/core/behaviors/report/test_deploy_fix_tree.py
+++ b/test/core/behaviors/report/test_deploy_fix_tree.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Tests for the deploy-fix behavior tree (Phase 1 stub).
+
+Verifies BT-18-004: factory params are accepted and used; defaults are the
+correct fuzzer classes.
+"""
+
+import pytest
+import py_trees
+
+from vultron.core.behaviors.report.deploy_fix_tree import (
+    create_deploy_fix_tree,
+)
+from vultron.demo.fuzzer.report_management.deploy_fix import (
+    DeployFix,
+    DeployMitigation,
+    MonitoringRequirement,
+    PrioritizeDeployment,
+)
+
+CASE_ID = "https://example.org/cases/test-001"
+
+
+def _marker_factory(label):
+    def factory(name):
+        class _Marker(py_trees.behaviour.Behaviour):
+            def update(self):
+                return py_trees.common.Status.SUCCESS
+
+        return _Marker(name=label)
+
+    return factory
+
+
+def test_create_deploy_fix_tree_returns_behaviour():
+    tree = create_deploy_fix_tree(case_id=CASE_ID)
+    assert isinstance(tree, py_trees.behaviour.Behaviour)
+
+
+def test_create_deploy_fix_tree_root_name():
+    tree = create_deploy_fix_tree(case_id=CASE_ID)
+    assert tree.name == "DeployFixBT"
+
+
+def test_default_children_are_fuzzer_nodes():
+    tree = create_deploy_fix_tree(case_id=CASE_ID)
+    assert len(tree.children) == 4
+    assert isinstance(tree.children[0], PrioritizeDeployment)
+    assert isinstance(tree.children[1], DeployMitigation)
+    assert isinstance(tree.children[2], MonitoringRequirement)
+    assert isinstance(tree.children[3], DeployFix)
+
+
+@pytest.mark.parametrize(
+    "param,label,index",
+    [
+        ("prioritize_deployment_factory", "PD", 0),
+        ("deploy_mitigation_factory", "DM", 1),
+        ("monitoring_requirement_factory", "MR", 2),
+        ("deploy_fix_factory", "DF", 3),
+    ],
+)
+def test_each_factory_is_wired(param, label, index):
+    """Each factory parameter is individually wired into the tree."""
+    sentinel = {"called": False}
+
+    def custom_factory(name):
+        sentinel["called"] = True
+
+        class _Marker(py_trees.behaviour.Behaviour):
+            def update(self):
+                return py_trees.common.Status.SUCCESS
+
+        return _Marker(name=label)
+
+    tree = create_deploy_fix_tree(case_id=CASE_ID, **{param: custom_factory})
+    assert sentinel["called"]
+    assert tree.children[index].name == label
+
+
+def test_all_factories_replaceable():
+    tree = create_deploy_fix_tree(
+        case_id=CASE_ID,
+        prioritize_deployment_factory=_marker_factory("PD"),
+        deploy_mitigation_factory=_marker_factory("DM"),
+        monitoring_requirement_factory=_marker_factory("MR"),
+        deploy_fix_factory=_marker_factory("DF"),
+    )
+    tree_str = py_trees.display.ascii_tree(tree)
+    for label in ("PD", "DM", "MR", "DF"):
+        assert label in tree_str

--- a/test/core/behaviors/report/test_prioritize_tree_factory_injection.py
+++ b/test/core/behaviors/report/test_prioritize_tree_factory_injection.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Factory injection tests for create_prioritize_subtree (BT-18-004).
+
+Verifies the two Phase 2 reserved factory parameters (enough_info_factory,
+gather_info_factory) are accepted without error.  The two wired params
+(on_accept_factory, on_defer_factory) are covered by the existing
+test_prioritize_tree.py tests.
+"""
+
+import py_trees
+
+from vultron.core.behaviors.report.prioritize_tree import (
+    create_prioritize_subtree,
+)
+
+CASE_ID = "https://example.org/cases/test-001"
+ACTOR_ID = "https://example.org/actors/vendor"
+
+
+def _marker_factory(label):
+    def factory(name):
+        class _Marker(py_trees.behaviour.Behaviour):
+            def update(self):
+                return py_trees.common.Status.SUCCESS
+
+        return _Marker(name=label)
+
+    return factory
+
+
+def test_enough_info_factory_accepted():
+    """enough_info_factory is accepted (Phase 2 reserved)."""
+    tree = create_prioritize_subtree(
+        case_id=CASE_ID,
+        actor_id=ACTOR_ID,
+        enough_info_factory=_marker_factory("EnoughInfo"),
+    )
+    assert tree is not None
+
+
+def test_gather_info_factory_accepted():
+    """gather_info_factory is accepted (Phase 2 reserved)."""
+    tree = create_prioritize_subtree(
+        case_id=CASE_ID,
+        actor_id=ACTOR_ID,
+        gather_info_factory=_marker_factory("GatherInfo"),
+    )
+    assert tree is not None
+
+
+def test_both_phase2_factories_accepted_together():
+    """Both Phase 2 reserved factories are accepted together."""
+    tree = create_prioritize_subtree(
+        case_id=CASE_ID,
+        actor_id=ACTOR_ID,
+        enough_info_factory=_marker_factory("EnoughInfo"),
+        gather_info_factory=_marker_factory("GatherInfo"),
+    )
+    assert tree is not None

--- a/test/core/behaviors/report/test_publication_tree_factory_injection.py
+++ b/test/core/behaviors/report/test_publication_tree_factory_injection.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Factory injection tests for create_publication_tree (BT-18-004).
+
+Verifies the four Phase 2 reserved factory parameters are accepted without
+error and that the wired prepare_report_factory is used correctly.
+"""
+
+import py_trees
+
+from vultron.core.behaviors.report.publication_tree import (
+    create_publication_tree,
+)
+
+CASE_ID = "https://example.org/cases/test-001"
+
+
+def _marker_factory(label):
+    """Return a factory that produces a distinctly-named Behaviour."""
+
+    def factory(name):
+        class _Marker(py_trees.behaviour.Behaviour):
+            def update(self):
+                return py_trees.common.Status.SUCCESS
+
+        return _Marker(name=label)
+
+    return factory
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 reserved params: accepted without error
+# ---------------------------------------------------------------------------
+
+
+def test_prioritize_publication_intents_factory_accepted():
+    """prioritize_publication_intents_factory is accepted (Phase 2 reserved)."""
+    tree = create_publication_tree(
+        case_id=CASE_ID,
+        prioritize_publication_intents_factory=_marker_factory("PPI"),
+    )
+    assert tree is not None
+
+
+def test_reprioritize_exploit_factory_accepted():
+    """reprioritize_exploit_factory is accepted (Phase 2 reserved)."""
+    tree = create_publication_tree(
+        case_id=CASE_ID,
+        reprioritize_exploit_factory=_marker_factory("RE"),
+    )
+    assert tree is not None
+
+
+def test_reprioritize_fix_factory_accepted():
+    """reprioritize_fix_factory is accepted (Phase 2 reserved)."""
+    tree = create_publication_tree(
+        case_id=CASE_ID,
+        reprioritize_fix_factory=_marker_factory("RF"),
+    )
+    assert tree is not None
+
+
+def test_reprioritize_report_factory_accepted():
+    """reprioritize_report_factory is accepted (Phase 2 reserved)."""
+    tree = create_publication_tree(
+        case_id=CASE_ID,
+        reprioritize_report_factory=_marker_factory("RR"),
+    )
+    assert tree is not None
+
+
+def test_all_phase2_factories_accepted_together():
+    """All four Phase 2 reserved factories are accepted together."""
+    tree = create_publication_tree(
+        case_id=CASE_ID,
+        prioritize_publication_intents_factory=_marker_factory("PPI"),
+        reprioritize_exploit_factory=_marker_factory("RE"),
+        reprioritize_fix_factory=_marker_factory("RF"),
+        reprioritize_report_factory=_marker_factory("RR"),
+    )
+    assert tree is not None

--- a/test/core/behaviors/report/test_report_to_others_tree.py
+++ b/test/core/behaviors/report/test_report_to_others_tree.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Tests for the report-to-others behavior tree (Phase 1 stub).
+
+Verifies BT-18-004: factory params are accepted and used; defaults are the
+correct fuzzer classes.
+"""
+
+import pytest
+import py_trees
+
+from vultron.core.behaviors.report.report_to_others_tree import (
+    create_report_to_others_tree,
+)
+from vultron.demo.fuzzer.report_management.report_to_others import (
+    AllPartiesKnown,
+    PolicyCompatible,
+    RecipientEffortExceeded,
+    TotalEffortLimitMet,
+)
+
+CASE_ID = "https://example.org/cases/test-001"
+
+
+def _marker_factory(label):
+    def factory(name):
+        class _Marker(py_trees.behaviour.Behaviour):
+            def update(self):
+                return py_trees.common.Status.SUCCESS
+
+        return _Marker(name=label)
+
+    return factory
+
+
+def test_create_report_to_others_tree_returns_behaviour():
+    tree = create_report_to_others_tree(case_id=CASE_ID)
+    assert isinstance(tree, py_trees.behaviour.Behaviour)
+
+
+def test_create_report_to_others_tree_root_name():
+    tree = create_report_to_others_tree(case_id=CASE_ID)
+    assert tree.name == "ReportToOthersBT"
+
+
+def test_default_children_are_fuzzer_nodes():
+    tree = create_report_to_others_tree(case_id=CASE_ID)
+    assert len(tree.children) == 4
+    assert isinstance(tree.children[0], AllPartiesKnown)
+    assert isinstance(tree.children[1], RecipientEffortExceeded)
+    assert isinstance(tree.children[2], PolicyCompatible)
+    assert isinstance(tree.children[3], TotalEffortLimitMet)
+
+
+@pytest.mark.parametrize(
+    "param,label,index",
+    [
+        ("all_parties_known_factory", "APK", 0),
+        ("recipient_effort_exceeded_factory", "REE", 1),
+        ("policy_compatible_factory", "PC", 2),
+        ("total_effort_limit_factory", "TEL", 3),
+    ],
+)
+def test_each_factory_is_wired(param, label, index):
+    """Each factory parameter is individually wired into the tree."""
+    sentinel = {"called": False}
+
+    def custom_factory(name):
+        sentinel["called"] = True
+
+        class _Marker(py_trees.behaviour.Behaviour):
+            def update(self):
+                return py_trees.common.Status.SUCCESS
+
+        return _Marker(name=label)
+
+    tree = create_report_to_others_tree(
+        case_id=CASE_ID, **{param: custom_factory}
+    )
+    assert sentinel["called"]
+    assert tree.children[index].name == label
+
+
+def test_all_factories_replaceable():
+    tree = create_report_to_others_tree(
+        case_id=CASE_ID,
+        all_parties_known_factory=_marker_factory("APK"),
+        recipient_effort_exceeded_factory=_marker_factory("REE"),
+        policy_compatible_factory=_marker_factory("PC"),
+        total_effort_limit_factory=_marker_factory("TEL"),
+    )
+    tree_str = py_trees.display.ascii_tree(tree)
+    for label in ("APK", "REE", "PC", "TEL"):
+        assert label in tree_str

--- a/vultron/core/behaviors/embargo/manage_embargo_tree.py
+++ b/vultron/core/behaviors/embargo/manage_embargo_tree.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Embargo management behavior tree composition (Phase 1 stub).
+
+This module provides :func:`create_manage_embargo_tree`, which hosts the ten
+embargo management call-out points wired per ADR-0025 / BT-18-004:
+
+Termination nodes:
+- ``ExitEmbargoWhenDeployed``
+- ``ExitEmbargoWhenFixReady``
+- ``ExitEmbargoForOtherReason``
+
+Negotiation / proposal nodes:
+- ``StopProposingEmbargo``
+- ``SelectEmbargoOfferTerms``
+- ``WantToProposeEmbargo``
+- ``WillingToCounterEmbargoProposal``
+- ``ReasonToProposeEmbargoWhenDeployed``
+
+Proposal evaluation node:
+- ``EvaluateEmbargoProposal``
+
+Active embargo evaluation node:
+- ``CurrentEmbargoAcceptable``
+
+Phase 1 contains only the injectable call-out points in a stub Sequence.
+The full embargo management lifecycle (termination arm, proposal arm,
+counter-proposal arm, active-embargo review loop) is deferred to a future
+issue.
+
+References
+----------
+- ADR-0025: ``docs/adr/0025-call-out-point-abstraction-layer.md``
+- Spec: ``specs/behavior-tree-integration.yaml`` BT-18-004
+"""
+
+import logging
+
+import py_trees
+
+from vultron.core.behaviors.call_out_point import CallOutBackendFactory
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Termination default factories
+# ---------------------------------------------------------------------------
+
+
+def _default_exit_embargo_when_deployed_factory(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.embargo import ExitEmbargoWhenDeployed
+
+    return ExitEmbargoWhenDeployed(name)
+
+
+def _default_exit_embargo_when_fix_ready_factory(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.embargo import ExitEmbargoWhenFixReady
+
+    return ExitEmbargoWhenFixReady(name)
+
+
+def _default_exit_embargo_for_other_reason_factory(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.embargo import ExitEmbargoForOtherReason
+
+    return ExitEmbargoForOtherReason(name)
+
+
+# ---------------------------------------------------------------------------
+# Negotiation / proposal default factories
+# ---------------------------------------------------------------------------
+
+
+def _default_stop_proposing_embargo_factory(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.embargo import StopProposingEmbargo
+
+    return StopProposingEmbargo(name)
+
+
+def _default_select_embargo_offer_terms_factory(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.embargo import SelectEmbargoOfferTerms
+
+    return SelectEmbargoOfferTerms(name)
+
+
+def _default_want_to_propose_embargo_factory(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.embargo import WantToProposeEmbargo
+
+    return WantToProposeEmbargo(name)
+
+
+def _default_willing_to_counter_factory(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.embargo import WillingToCounterEmbargoProposal
+
+    return WillingToCounterEmbargoProposal(name)
+
+
+def _default_reason_to_propose_when_deployed_factory(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.embargo import ReasonToProposeEmbargoWhenDeployed
+
+    return ReasonToProposeEmbargoWhenDeployed(name)
+
+
+# ---------------------------------------------------------------------------
+# Proposal evaluation default factory
+# ---------------------------------------------------------------------------
+
+
+def _default_evaluate_embargo_proposal_factory(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.embargo import EvaluateEmbargoProposal
+
+    return EvaluateEmbargoProposal(name)
+
+
+# ---------------------------------------------------------------------------
+# Active embargo evaluation default factory
+# ---------------------------------------------------------------------------
+
+
+def _default_current_embargo_acceptable_factory(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.embargo import CurrentEmbargoAcceptable
+
+    return CurrentEmbargoAcceptable(name)
+
+
+# ---------------------------------------------------------------------------
+# Tree builder
+# ---------------------------------------------------------------------------
+
+
+def create_manage_embargo_tree(
+    case_id: str,
+    exit_embargo_when_deployed_factory: CallOutBackendFactory = _default_exit_embargo_when_deployed_factory,
+    exit_embargo_when_fix_ready_factory: CallOutBackendFactory = _default_exit_embargo_when_fix_ready_factory,
+    exit_embargo_for_other_reason_factory: CallOutBackendFactory = _default_exit_embargo_for_other_reason_factory,
+    stop_proposing_embargo_factory: CallOutBackendFactory = _default_stop_proposing_embargo_factory,
+    select_embargo_offer_terms_factory: CallOutBackendFactory = _default_select_embargo_offer_terms_factory,
+    want_to_propose_embargo_factory: CallOutBackendFactory = _default_want_to_propose_embargo_factory,
+    willing_to_counter_factory: CallOutBackendFactory = _default_willing_to_counter_factory,
+    reason_to_propose_when_deployed_factory: CallOutBackendFactory = _default_reason_to_propose_when_deployed_factory,
+    evaluate_embargo_proposal_factory: CallOutBackendFactory = _default_evaluate_embargo_proposal_factory,
+    current_embargo_acceptable_factory: CallOutBackendFactory = _default_current_embargo_acceptable_factory,
+) -> py_trees.behaviour.Behaviour:
+    """Create behavior tree for the embargo management workflow (Phase 1 stub).
+
+    Phase 1 exposes all ten Evaluator call-out points as a stub Sequence.
+    The full embargo management lifecycle (termination arm, proposal arm,
+    counter-proposal arm, active-embargo review loop) is deferred to a
+    future issue.
+
+    Args:
+        case_id: ID of VulnerabilityCase whose embargo is being managed.
+        exit_embargo_when_deployed_factory: Factory for the Evaluator that
+            decides whether fix deployment is sufficient to end the embargo.
+            Defaults to the fuzzer backend (BT-18-004).
+        exit_embargo_when_fix_ready_factory: Factory for the Evaluator that
+            decides whether fix availability alone ends the embargo.  Defaults
+            to the fuzzer backend (BT-18-004).
+        exit_embargo_for_other_reason_factory: Factory for the Evaluator that
+            handles exceptional embargo exit triggers.  Defaults to the fuzzer
+            backend (BT-18-004).
+        stop_proposing_embargo_factory: Factory for the Evaluator that decides
+            whether to abandon ongoing embargo negotiations.  Defaults to the
+            fuzzer backend (BT-18-004).
+        select_embargo_offer_terms_factory: Factory for the Evaluator that
+            selects terms for a new embargo proposal.  Defaults to the fuzzer
+            backend (BT-18-004).
+        want_to_propose_embargo_factory: Factory for the Evaluator that decides
+            whether to initiate an embargo proposal.  Defaults to the fuzzer
+            backend (BT-18-004).
+        willing_to_counter_factory: Factory for the Evaluator that decides
+            whether to respond to an incoming proposal with a counter-proposal.
+            Defaults to the fuzzer backend (BT-18-004).
+        reason_to_propose_when_deployed_factory: Factory for the Evaluator
+            that handles the rare case of proposing an embargo post-deployment.
+            Defaults to the fuzzer backend (BT-18-004).
+        evaluate_embargo_proposal_factory: Factory for the Evaluator that
+            assesses an incoming embargo proposal.  Defaults to the fuzzer
+            backend (BT-18-004).
+        current_embargo_acceptable_factory: Factory for the Evaluator that
+            decides whether the active embargo terms remain acceptable.
+            Defaults to the fuzzer backend (BT-18-004).
+
+    Returns:
+        Root node of the manage-embargo behavior tree (Phase 1 stub Sequence).
+    """
+    root = py_trees.composites.Sequence(
+        name="ManageEmbargoBT",
+        memory=False,
+        children=[
+            exit_embargo_when_deployed_factory("ExitEmbargoWhenDeployed"),
+            exit_embargo_when_fix_ready_factory("ExitEmbargoWhenFixReady"),
+            exit_embargo_for_other_reason_factory("ExitEmbargoForOtherReason"),
+            stop_proposing_embargo_factory("StopProposingEmbargo"),
+            select_embargo_offer_terms_factory("SelectEmbargoOfferTerms"),
+            want_to_propose_embargo_factory("WantToProposeEmbargo"),
+            willing_to_counter_factory("WillingToCounterEmbargoProposal"),
+            reason_to_propose_when_deployed_factory(
+                "ReasonToProposeEmbargoWhenDeployed"
+            ),
+            evaluate_embargo_proposal_factory("EvaluateEmbargoProposal"),
+            current_embargo_acceptable_factory("CurrentEmbargoAcceptable"),
+        ],
+    )
+    logger.info(f"Created ManageEmbargoBT (Phase 1 stub) for case={case_id}")
+    return root

--- a/vultron/core/behaviors/report/acquire_exploit_tree.py
+++ b/vultron/core/behaviors/report/acquire_exploit_tree.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Exploit acquisition behavior tree composition (Phase 1 stub).
+
+This module provides :func:`create_acquire_exploit_tree`, which hosts the
+``EvaluateExploitPriority`` and ``PurchaseExploit`` call-out points wired
+per ADR-0025 / BT-18-004.
+
+Phase 1 contains only the two injectable call-out points as a stub tree.
+The full exploit-acquisition workflow (priority evaluation loop, find/develop/
+purchase arms) is deferred to a future issue.
+
+References
+----------
+- ADR-0025: ``docs/adr/0025-call-out-point-abstraction-layer.md``
+- Spec: ``specs/behavior-tree-integration.yaml`` BT-18-004
+"""
+
+import logging
+
+import py_trees
+
+from vultron.core.behaviors.call_out_point import CallOutBackendFactory
+
+logger = logging.getLogger(__name__)
+
+
+def _default_evaluate_exploit_priority_factory(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.acquire_exploit import (
+        EvaluateExploitPriority,
+    )
+
+    return EvaluateExploitPriority(name)
+
+
+def _default_purchase_exploit_factory(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.acquire_exploit import (
+        PurchaseExploit,
+    )
+
+    return PurchaseExploit(name)
+
+
+def create_acquire_exploit_tree(
+    case_id: str,
+    evaluate_exploit_priority_factory: CallOutBackendFactory = _default_evaluate_exploit_priority_factory,
+    purchase_exploit_factory: CallOutBackendFactory = _default_purchase_exploit_factory,
+) -> py_trees.behaviour.Behaviour:
+    """Create behavior tree for the exploit acquisition workflow (Phase 1 stub).
+
+    Phase 1 exposes the two Evaluator call-out points as a stub Sequence.
+    The full workflow (priority evaluation loop, find/develop/purchase arms,
+    exploit deferred/desired branching) is deferred to a future issue.
+
+    Args:
+        case_id: ID of VulnerabilityCase being processed.
+        evaluate_exploit_priority_factory: Factory for the Evaluator call-out
+            point that assesses priority for acquiring an exploit.  Defaults
+            to the fuzzer backend (BT-18-004).
+        purchase_exploit_factory: Factory for the Evaluator call-out point that
+            drives exploit procurement from an external vendor or broker.
+            Defaults to the fuzzer backend (BT-18-004).
+
+    Returns:
+        Root node of the acquire-exploit behavior tree (Phase 1 stub Sequence).
+    """
+    root = py_trees.composites.Sequence(
+        name="AcquireExploitBT",
+        memory=False,
+        children=[
+            evaluate_exploit_priority_factory("EvaluateExploitPriority"),
+            purchase_exploit_factory("PurchaseExploit"),
+        ],
+    )
+    logger.info(f"Created AcquireExploitBT (Phase 1 stub) for case={case_id}")
+    return root

--- a/vultron/core/behaviors/report/assign_vul_id_tree.py
+++ b/vultron/core/behaviors/report/assign_vul_id_tree.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""VUL ID assignment behavior tree composition (Phase 1 stub).
+
+This module provides :func:`create_assign_vul_id_tree`, which hosts the
+``IdAssignable`` and ``InScope`` call-out points wired per ADR-0025 / BT-18-004.
+
+Phase 1 contains only the two injectable call-out points as a stub tree.
+The full VUL ID assignment workflow (authority check, request/assign branching)
+is deferred to a future issue.
+
+References
+----------
+- ADR-0025: ``docs/adr/0025-call-out-point-abstraction-layer.md``
+- Spec: ``specs/behavior-tree-integration.yaml`` BT-18-004
+"""
+
+import logging
+
+import py_trees
+
+from vultron.core.behaviors.call_out_point import CallOutBackendFactory
+
+logger = logging.getLogger(__name__)
+
+
+def _default_id_assignable_factory(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.assign_vul_id import (
+        IdAssignable,
+    )
+
+    return IdAssignable(name)
+
+
+def _default_in_scope_factory(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.assign_vul_id import InScope
+
+    return InScope(name)
+
+
+def create_assign_vul_id_tree(
+    case_id: str,
+    id_assignable_factory: CallOutBackendFactory = _default_id_assignable_factory,
+    in_scope_factory: CallOutBackendFactory = _default_in_scope_factory,
+) -> py_trees.behaviour.Behaviour:
+    """Create behavior tree for the VUL ID assignment workflow (Phase 1 stub).
+
+    Phase 1 exposes the two Evaluator call-out points as a stub Sequence.
+    The full workflow (authority check, request/assign branching, ID-already-
+    assigned early exit) is deferred to a future issue.
+
+    Args:
+        case_id: ID of VulnerabilityCase being processed.
+        id_assignable_factory: Factory for the Evaluator call-out point that
+            checks whether the vulnerability qualifies for ID assignment.
+            Defaults to the fuzzer backend (BT-18-004).
+        in_scope_factory: Factory for the Evaluator call-out point that checks
+            whether the vulnerability is within the applicable ID space scope.
+            Defaults to the fuzzer backend (BT-18-004).
+
+    Returns:
+        Root node of the assign-VUL-ID behavior tree (Phase 1 stub Sequence).
+    """
+    root = py_trees.composites.Sequence(
+        name="AssignVulIDBT",
+        memory=False,
+        children=[
+            in_scope_factory("InScope"),
+            id_assignable_factory("IdAssignable"),
+        ],
+    )
+    logger.info(f"Created AssignVulIDBT (Phase 1 stub) for case={case_id}")
+    return root

--- a/vultron/core/behaviors/report/close_report_tree.py
+++ b/vultron/core/behaviors/report/close_report_tree.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Report closure behavior tree composition (Phase 1 stub).
+
+This module provides :func:`create_close_report_tree`, which hosts the
+``OtherCloseCriteriaMet`` call-out point wired per ADR-0025 / BT-18-004.
+
+Phase 1 contains only the injectable call-out point as a stub tree.
+The full close-report workflow (deployed/deferred/invalid short-circuit
+arms, pre-close actions) is deferred to a future issue.
+
+References
+----------
+- ADR-0025: ``docs/adr/0025-call-out-point-abstraction-layer.md``
+- Spec: ``specs/behavior-tree-integration.yaml`` BT-18-004
+"""
+
+import logging
+
+import py_trees
+
+from vultron.core.behaviors.call_out_point import CallOutBackendFactory
+
+logger = logging.getLogger(__name__)
+
+
+def _default_other_close_criteria_factory(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.close_report import (
+        OtherCloseCriteriaMet,
+    )
+
+    return OtherCloseCriteriaMet(name)
+
+
+def create_close_report_tree(
+    case_id: str,
+    other_close_criteria_factory: CallOutBackendFactory = _default_other_close_criteria_factory,
+) -> py_trees.behaviour.Behaviour:
+    """Create behavior tree for the report closure workflow (Phase 1 stub).
+
+    Phase 1 exposes the ``OtherCloseCriteriaMet`` Evaluator call-out point
+    as a stub root node.  The full workflow (deployed/deferred/invalid
+    short-circuit arms, pre-close actions, RM state transition) is deferred
+    to a future issue.
+
+    Args:
+        case_id: ID of VulnerabilityCase being processed.
+        other_close_criteria_factory: Factory for the Evaluator call-out point
+            that checks whether site-specific closure criteria have been met.
+            Defaults to the fuzzer backend (BT-18-004).
+
+    Returns:
+        Root node of the close-report behavior tree (Phase 1 stub).
+    """
+    root = other_close_criteria_factory("OtherCloseCriteriaMet")
+    logger.info(f"Created CloseReportBT (Phase 1 stub) for case={case_id}")
+    return root

--- a/vultron/core/behaviors/report/deploy_fix_tree.py
+++ b/vultron/core/behaviors/report/deploy_fix_tree.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Fix deployment behavior tree composition (Phase 1 stub).
+
+This module provides :func:`create_deploy_fix_tree`, which hosts the four
+fix-deployment call-out points (``PrioritizeDeployment``, ``DeployMitigation``,
+``MonitoringRequirement``, ``DeployFix``) wired per ADR-0025 / BT-18-004.
+
+Phase 1 contains only the injectable call-out points as a stub Sequence.
+The full deployment workflow (no-new-info early exit, mitigation arm,
+monitoring arm, fix deployment arm) is deferred to a future issue.
+
+References
+----------
+- ADR-0025: ``docs/adr/0025-call-out-point-abstraction-layer.md``
+- Spec: ``specs/behavior-tree-integration.yaml`` BT-18-004
+"""
+
+import logging
+
+import py_trees
+
+from vultron.core.behaviors.call_out_point import CallOutBackendFactory
+
+logger = logging.getLogger(__name__)
+
+
+def _default_prioritize_deployment_factory(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.deploy_fix import (
+        PrioritizeDeployment,
+    )
+
+    return PrioritizeDeployment(name)
+
+
+def _default_deploy_mitigation_factory(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.deploy_fix import (
+        DeployMitigation,
+    )
+
+    return DeployMitigation(name)
+
+
+def _default_monitoring_requirement_factory(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.deploy_fix import (
+        MonitoringRequirement,
+    )
+
+    return MonitoringRequirement(name)
+
+
+def _default_deploy_fix_factory(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.deploy_fix import DeployFix
+
+    return DeployFix(name)
+
+
+def create_deploy_fix_tree(
+    case_id: str,
+    prioritize_deployment_factory: CallOutBackendFactory = _default_prioritize_deployment_factory,
+    deploy_mitigation_factory: CallOutBackendFactory = _default_deploy_mitigation_factory,
+    monitoring_requirement_factory: CallOutBackendFactory = _default_monitoring_requirement_factory,
+    deploy_fix_factory: CallOutBackendFactory = _default_deploy_fix_factory,
+) -> py_trees.behaviour.Behaviour:
+    """Create behavior tree for the fix deployment workflow (Phase 1 stub).
+
+    Phase 1 exposes the four Evaluator call-out points as a stub Sequence.
+    The full workflow (no-new-info early exit, mitigation arm, monitoring
+    arm, fix deployment arm) is deferred to a future issue.
+
+    Args:
+        case_id: ID of VulnerabilityCase being processed.
+        prioritize_deployment_factory: Factory for the Evaluator call-out point
+            that assigns deployment priority.  Defaults to the fuzzer backend
+            (BT-18-004).
+        deploy_mitigation_factory: Factory for the Evaluator call-out point
+            that deploys an interim mitigation.  Defaults to the fuzzer backend
+            (BT-18-004).
+        monitoring_requirement_factory: Factory for the Evaluator call-out
+            point that checks whether deployment monitoring is required by
+            policy.  Defaults to the fuzzer backend (BT-18-004).
+        deploy_fix_factory: Factory for the Evaluator call-out point that
+            applies the vendor-provided fix.  Defaults to the fuzzer backend
+            (BT-18-004).
+
+    Returns:
+        Root node of the deploy-fix behavior tree (Phase 1 stub Sequence).
+    """
+    root = py_trees.composites.Sequence(
+        name="DeployFixBT",
+        memory=False,
+        children=[
+            prioritize_deployment_factory("PrioritizeDeployment"),
+            deploy_mitigation_factory("DeployMitigation"),
+            monitoring_requirement_factory("MonitoringRequirement"),
+            deploy_fix_factory("DeployFix"),
+        ],
+    )
+    logger.info(f"Created DeployFixBT (Phase 1 stub) for case={case_id}")
+    return root

--- a/vultron/core/behaviors/report/prioritize_tree.py
+++ b/vultron/core/behaviors/report/prioritize_tree.py
@@ -86,6 +86,22 @@ def _default_on_defer_factory(name: str) -> py_trees.behaviour.Behaviour:
     return OnDefer(name)
 
 
+def _default_enough_info_factory(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.prioritize import (
+        EnoughPrioritizationInfo,
+    )
+
+    return EnoughPrioritizationInfo(name)
+
+
+def _default_gather_info_factory(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.prioritize import (
+        GatherPrioritizationInfo,
+    )
+
+    return GatherPrioritizationInfo(name)
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -170,6 +186,8 @@ def create_prioritize_subtree(
     trigger_activity: "TriggerActivityPort | None" = None,
     on_accept_factory: CallOutBackendFactory = _default_on_accept_factory,
     on_defer_factory: CallOutBackendFactory = _default_on_defer_factory,
+    enough_info_factory: CallOutBackendFactory = _default_enough_info_factory,
+    gather_info_factory: CallOutBackendFactory = _default_gather_info_factory,
 ) -> py_trees.behaviour.Behaviour:
     """
     Create behavior tree subtree for case prioritization (engage or defer).
@@ -220,10 +238,21 @@ def create_prioritize_subtree(
         on_defer_factory: Factory for the Actuator call-out point that
             fires integration hooks when the report is deferred.  Defaults
             to the fuzzer backend (BT-18-004).
+        enough_info_factory: Factory for the Evaluator call-out point that
+            checks whether sufficient prioritization information is available.
+            Reserved for Phase 2 info-gathering loop; accepted but not yet
+            wired into the Phase 1 tree body (BT-18-004).
+        gather_info_factory: Factory for the Retriever call-out point that
+            collects additional prioritization information.  Reserved for
+            Phase 2 info-gathering loop; accepted but not yet wired into
+            the Phase 1 tree body (BT-18-004).
 
     Returns:
         Root node of the prioritize behavior tree (Selector)
     """
+    # Phase 2: enough_info_factory and gather_info_factory are reserved for
+    # the prioritization info-gathering loop and are not wired into the Phase 1
+    # tree body.  Accepting them here satisfies BT-18-004 without breaking callers.
     factory = trigger_activity
 
     def _build_engage(case_manager_id: str) -> list[str]:

--- a/vultron/core/behaviors/report/publication_tree.py
+++ b/vultron/core/behaviors/report/publication_tree.py
@@ -43,9 +43,53 @@ def _default_prepare_report_factory(name: str) -> py_trees.behaviour.Behaviour:
     return PrepareReport(name)
 
 
+def _default_prioritize_publication_intents_factory(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.publication import (
+        PrioritizePublicationIntents,
+    )
+
+    return PrioritizePublicationIntents(name)
+
+
+def _default_reprioritize_exploit_factory(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.publication import (
+        ReprioritizeExploit,
+    )
+
+    return ReprioritizeExploit(name)
+
+
+def _default_reprioritize_fix_factory(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.publication import (
+        ReprioritizeFix,
+    )
+
+    return ReprioritizeFix(name)
+
+
+def _default_reprioritize_report_factory(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.publication import (
+        ReprioritizeReport,
+    )
+
+    return ReprioritizeReport(name)
+
+
 def create_publication_tree(
     case_id: str,
     prepare_report_factory: CallOutBackendFactory = _default_prepare_report_factory,
+    prioritize_publication_intents_factory: CallOutBackendFactory = _default_prioritize_publication_intents_factory,
+    reprioritize_exploit_factory: CallOutBackendFactory = _default_reprioritize_exploit_factory,
+    reprioritize_fix_factory: CallOutBackendFactory = _default_reprioritize_fix_factory,
+    reprioritize_report_factory: CallOutBackendFactory = _default_reprioritize_report_factory,
 ) -> py_trees.behaviour.Behaviour:
     """Create behavior tree for the publication workflow (Phase 1 stub).
 
@@ -59,10 +103,26 @@ def create_publication_tree(
         prepare_report_factory: Factory for the Composer call-out point that
             authors and stages the vulnerability advisory artifact.  Defaults
             to the fuzzer backend (BT-18-004).
+        prioritize_publication_intents_factory: Factory for the Evaluator
+            call-out point that ranks publication intents.  Reserved for Phase
+            2; accepted but not yet wired into the Phase 1 tree body (BT-18-004).
+        reprioritize_exploit_factory: Factory for the Evaluator call-out point
+            that re-scores exploit publication priority.  Reserved for Phase 2;
+            not wired in Phase 1 (BT-18-004).
+        reprioritize_fix_factory: Factory for the Evaluator call-out point that
+            re-scores fix publication priority.  Reserved for Phase 2; not wired
+            in Phase 1 (BT-18-004).
+        reprioritize_report_factory: Factory for the Evaluator call-out point
+            that re-scores report publication priority.  Reserved for Phase 2;
+            not wired in Phase 1 (BT-18-004).
 
     Returns:
         Root node of the publication behavior tree.
     """
+    # Phase 2: prioritize_publication_intents_factory, reprioritize_exploit_factory,
+    # reprioritize_fix_factory, and reprioritize_report_factory are reserved for the
+    # full multi-arm publication workflow tracked in issue #1251.  Accepting them
+    # here satisfies BT-18-004 without breaking callers.
     root = prepare_report_factory("PrepareReport")
     logger.info(f"Created PublicationBT (Phase 1 stub) for case={case_id}")
     return root

--- a/vultron/core/behaviors/report/report_to_others_tree.py
+++ b/vultron/core/behaviors/report/report_to_others_tree.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Report-to-others behavior tree composition (Phase 1 stub).
+
+This module provides :func:`create_report_to_others_tree`, which hosts the
+four injectable call-out points from the report-to-others workflow
+(``AllPartiesKnown``, ``RecipientEffortExceeded``, ``PolicyCompatible``,
+``TotalEffortLimitMet``) wired per ADR-0025 / BT-18-004.
+
+Phase 1 contains only the injectable call-out points as a stub Sequence.
+The full notification workflow (party identification loop, recipient
+selection, effort-limit checks, RM state management, participant injection)
+is deferred to a future issue.
+
+References
+----------
+- ADR-0025: ``docs/adr/0025-call-out-point-abstraction-layer.md``
+- Spec: ``specs/behavior-tree-integration.yaml`` BT-18-004
+"""
+
+import logging
+
+import py_trees
+
+from vultron.core.behaviors.call_out_point import CallOutBackendFactory
+
+logger = logging.getLogger(__name__)
+
+
+def _default_all_parties_known_factory(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.report_to_others import (
+        AllPartiesKnown,
+    )
+
+    return AllPartiesKnown(name)
+
+
+def _default_recipient_effort_exceeded_factory(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.report_to_others import (
+        RecipientEffortExceeded,
+    )
+
+    return RecipientEffortExceeded(name)
+
+
+def _default_policy_compatible_factory(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.report_to_others import (
+        PolicyCompatible,
+    )
+
+    return PolicyCompatible(name)
+
+
+def _default_total_effort_limit_factory(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.report_to_others import (
+        TotalEffortLimitMet,
+    )
+
+    return TotalEffortLimitMet(name)
+
+
+def create_report_to_others_tree(
+    case_id: str,
+    all_parties_known_factory: CallOutBackendFactory = _default_all_parties_known_factory,
+    recipient_effort_exceeded_factory: CallOutBackendFactory = _default_recipient_effort_exceeded_factory,
+    policy_compatible_factory: CallOutBackendFactory = _default_policy_compatible_factory,
+    total_effort_limit_factory: CallOutBackendFactory = _default_total_effort_limit_factory,
+) -> py_trees.behaviour.Behaviour:
+    """Create behavior tree for the report-to-others workflow (Phase 1 stub).
+
+    Phase 1 exposes the four Evaluator call-out points as a stub Sequence.
+    The full notification workflow (party identification loop, recipient
+    selection and pruning, effort-limit guards, RM state transitions, and
+    participant injection) is deferred to a future issue.
+
+    Args:
+        case_id: ID of VulnerabilityCase being processed.
+        all_parties_known_factory: Factory for the Evaluator call-out point
+            that checks whether all relevant notification parties have been
+            identified.  Defaults to the fuzzer backend (BT-18-004).
+        recipient_effort_exceeded_factory: Factory for the Evaluator call-out
+            point that checks whether per-recipient notification effort has
+            exceeded the policy threshold.  Defaults to the fuzzer backend
+            (BT-18-004).
+        policy_compatible_factory: Factory for the Evaluator call-out point
+            that checks whether a recipient's disclosure policy is compatible
+            with the case embargo.  Defaults to the fuzzer backend (BT-18-004).
+        total_effort_limit_factory: Factory for the Evaluator call-out point
+            that checks whether total notification effort has reached the
+            organizational ceiling.  Defaults to the fuzzer backend (BT-18-004).
+
+    Returns:
+        Root node of the report-to-others behavior tree (Phase 1 stub Sequence).
+    """
+    root = py_trees.composites.Sequence(
+        name="ReportToOthersBT",
+        memory=False,
+        children=[
+            all_parties_known_factory("AllPartiesKnown"),
+            recipient_effort_exceeded_factory("RecipientEffortExceeded"),
+            policy_compatible_factory("PolicyCompatible"),
+            total_effort_limit_factory("TotalEffortLimitMet"),
+        ],
+    )
+    logger.info(f"Created ReportToOthersBT (Phase 1 stub) for case={case_id}")
+    return root


### PR DESCRIPTION
- Closes #1353

## Summary

Wires `CallOutBackendFactory` injection (ADR-0025 BT-18-004) into the
`vultron/core/behaviors/` py_trees tree builders — the correct target for
FUZZ-08e. Supersedes #1356, which mistakenly applied changes to
`vultron/bt/` (the legacy custom-engine simulator).

## Changes

**Modified existing tree builders** (adding missing factory params):
- `vultron/core/behaviors/report/prioritize_tree.py` — adds Phase 2 reserved `enough_info_factory`, `gather_info_factory` to `create_prioritize_subtree()`
- `vultron/core/behaviors/report/publication_tree.py` — adds Phase 2 reserved `prioritize_publication_intents_factory`, `reprioritize_exploit_factory`, `reprioritize_fix_factory`, `reprioritize_report_factory` to `create_publication_tree()`

**New Phase 1 stub tree builders** (covering workflows with no prior new-arch equivalent):
- `vultron/core/behaviors/report/acquire_exploit_tree.py` — 2 factory params
- `vultron/core/behaviors/report/assign_vul_id_tree.py` — 2 factory params
- `vultron/core/behaviors/report/close_report_tree.py` — 1 factory param
- `vultron/core/behaviors/report/deploy_fix_tree.py` — 4 factory params
- `vultron/core/behaviors/report/report_to_others_tree.py` — 4 factory params
- `vultron/core/behaviors/embargo/manage_embargo_tree.py` — 10 factory params

All default factories use lazy imports per BT-16-001 (no demo imports from core at module load time). Phase 2 reserved params are accepted by the function signature but not yet wired into the Phase 1 tree body, following the established pattern from `validate_tree.py:gather_info_factory`.

## Verification

- 64 new tests pass (factory acceptance + node wiring per BT-18-004)
- Full suite: 4553 passed, 0 failures
- Black, flake8 clean
- No `vultron/bt/` files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)