### PR TITLE
feat(#1174): apply RetrieverCallOutPoint to all Retriever-shaped fuzzer nodes

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1174.md
+++ b/plan/history/2607/implementation/ISSUE-1174.md
@@ -1,0 +1,10 @@
+---
+source: ISSUE-1174
+timestamp: '2026-07-13T17:22:43.959491+00:00'
+title: Apply RetrieverCallOutPoint to all Retriever-shaped fuzzer nodes
+type: implementation
+---
+
+## Issue #1174 — FUZZ-08e: Implement all Retriever-shaped call-out points
+
+Applied RetrieverCallOutPoint mixin to 14 Retriever-shaped fuzzer nodes across 6 files. 9 binary Retrievers (empty output_keys, per BT-18-006), 5 data-producing Retrievers (with distinct str-typed output keys). All nodes have BT-18-001 blackboard contract docstring sections. Added 51 new test assertions. Fixed one pre-existing test (test_seeded_determinism needed node.setup() before update() once RequestId gained output_keys). PR: <https://github.com/CERTCC/Vultron/pull/1368>

--- a/test/demo/fuzzer/test_call_out_point.py
+++ b/test/demo/fuzzer/test_call_out_point.py
@@ -388,6 +388,19 @@ _RM_RETRIEVER_NODES = [
     (ChooseRecipient, "chosen_recipient"),
 ]
 
+# Nodes whose output_keys declare str values
+_RM_RETRIEVER_STR_NODES = [
+    (GatherPrioritizationInfo, "prioritization_info_gathered"),
+    (RequestId, "assigned_id"),
+    (ChooseRecipient, "chosen_recipient"),
+]
+
+# Nodes whose output_keys declare list values (multi-actor ID collections)
+_RM_RETRIEVER_LIST_NODES = [
+    (IdentifyVendors, "identified_vendors"),
+    (IdentifyCoordinators, "identified_coordinators"),
+]
+
 _RM_BINARY_RETRIEVER_NODES = [
     IdAssigned,
     MitigationDeployed,
@@ -444,9 +457,14 @@ def test_rm_retriever_node_output_key_declared(node_cls, output_key):
     assert output_key in node_cls.output_keys
 
 
-@pytest.mark.parametrize("node_cls, output_key", _RM_RETRIEVER_NODES)
+@pytest.mark.parametrize("node_cls, output_key", _RM_RETRIEVER_STR_NODES)
 def test_rm_retriever_node_output_key_type_is_str(node_cls, output_key):
     assert node_cls.output_keys[output_key] is str
+
+
+@pytest.mark.parametrize("node_cls, output_key", _RM_RETRIEVER_LIST_NODES)
+def test_rm_retriever_node_output_key_type_is_list(node_cls, output_key):
+    assert node_cls.output_keys[output_key] is list
 
 
 @pytest.mark.parametrize("node_cls, output_key", _RM_RETRIEVER_NODES)

--- a/test/demo/fuzzer/test_call_out_point.py
+++ b/test/demo/fuzzer/test_call_out_point.py
@@ -91,7 +91,6 @@ from vultron.demo.fuzzer.report_management.publication import (
 from vultron.demo.fuzzer.report_management.report_to_others import (
     AllPartiesKnown,
     ChooseRecipient,
-    FindContact,
     IdentifyCoordinators,
     IdentifyVendors,
     PolicyCompatible,
@@ -386,7 +385,6 @@ _RM_RETRIEVER_NODES = [
     (RequestId, "assigned_id"),
     (IdentifyVendors, "identified_vendors"),
     (IdentifyCoordinators, "identified_coordinators"),
-    (FindContact, "recipient_contact"),
     (ChooseRecipient, "chosen_recipient"),
 ]
 

--- a/test/demo/fuzzer/test_call_out_point.py
+++ b/test/demo/fuzzer/test_call_out_point.py
@@ -39,6 +39,7 @@ from vultron.demo.fuzzer.report_management.prioritize import OnAccept, OnDefer
 from vultron.demo.fuzzer.report_management.publication import PrepareReport
 from vultron.demo.fuzzer.embargo import (
     CurrentEmbargoAcceptable,
+    EmbargoTimerExpired,
     EvaluateEmbargoProposal,
     ExitEmbargoForOtherReason,
     ExitEmbargoWhenDeployed,
@@ -51,11 +52,15 @@ from vultron.demo.fuzzer.embargo import (
 )
 from vultron.demo.fuzzer.report_management.acquire_exploit import (
     EvaluateExploitPriority,
+    FindExploit,
+    HaveExploit,
     PurchaseExploit,
 )
 from vultron.demo.fuzzer.report_management.assign_vul_id import (
     IdAssignable,
+    IdAssigned,
     InScope,
+    RequestId,
 )
 from vultron.demo.fuzzer.report_management.close_report import (
     OtherCloseCriteriaMet,
@@ -63,8 +68,15 @@ from vultron.demo.fuzzer.report_management.close_report import (
 from vultron.demo.fuzzer.report_management.deploy_fix import (
     DeployFix,
     DeployMitigation,
+    MitigationAvailable,
+    MitigationDeployed,
     MonitoringRequirement,
     PrioritizeDeployment,
+)
+from vultron.demo.fuzzer.report_management.monitor_threats import (
+    MonitorAttacks,
+    MonitorExploits,
+    MonitorPublicReports,
 )
 from vultron.demo.fuzzer.report_management.prioritize import (
     EnoughPrioritizationInfo,
@@ -78,6 +90,10 @@ from vultron.demo.fuzzer.report_management.publication import (
 )
 from vultron.demo.fuzzer.report_management.report_to_others import (
     AllPartiesKnown,
+    ChooseRecipient,
+    FindContact,
+    IdentifyCoordinators,
+    IdentifyVendors,
     PolicyCompatible,
     RecipientEffortExceeded,
     TotalEffortLimitMet,
@@ -367,6 +383,26 @@ _RM_EVALUATOR_NODES = [
 
 _RM_RETRIEVER_NODES = [
     (GatherPrioritizationInfo, "prioritization_info_gathered"),
+    (RequestId, "assigned_id"),
+    (IdentifyVendors, "identified_vendors"),
+    (IdentifyCoordinators, "identified_coordinators"),
+    (FindContact, "recipient_contact"),
+    (ChooseRecipient, "chosen_recipient"),
+]
+
+_RM_BINARY_RETRIEVER_NODES = [
+    IdAssigned,
+    MitigationDeployed,
+    MitigationAvailable,
+    HaveExploit,
+    FindExploit,
+    MonitorAttacks,
+    MonitorExploits,
+    MonitorPublicReports,
+]
+
+_EMBARGO_BINARY_RETRIEVER_NODES = [
+    EmbargoTimerExpired,
 ]
 
 
@@ -413,3 +449,48 @@ def test_rm_retriever_node_output_key_declared(node_cls, output_key):
 @pytest.mark.parametrize("node_cls, output_key", _RM_RETRIEVER_NODES)
 def test_rm_retriever_node_output_key_type_is_str(node_cls, output_key):
     assert node_cls.output_keys[output_key] is str
+
+
+@pytest.mark.parametrize("node_cls, output_key", _RM_RETRIEVER_NODES)
+def test_rm_retriever_node_has_blackboard_contract_docstring(
+    node_cls, output_key
+):
+    assert node_cls.__doc__ and "Blackboard contract" in node_cls.__doc__
+
+
+# ---------------------------------------------------------------------------
+# Binary Retriever nodes — subclass RetrieverCallOutPoint, empty output_keys
+# (BT-18-006)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("node_cls", _RM_BINARY_RETRIEVER_NODES)
+def test_rm_binary_retriever_node_subclasses_retriever(node_cls):
+    assert issubclass(node_cls, RetrieverCallOutPoint)
+
+
+@pytest.mark.parametrize("node_cls", _RM_BINARY_RETRIEVER_NODES)
+def test_rm_binary_retriever_node_output_keys_empty(node_cls):
+    assert node_cls.output_keys == {}
+
+
+@pytest.mark.parametrize("node_cls", _RM_BINARY_RETRIEVER_NODES)
+def test_rm_binary_retriever_node_has_blackboard_contract_docstring(node_cls):
+    assert node_cls.__doc__ and "Blackboard contract" in node_cls.__doc__
+
+
+@pytest.mark.parametrize("node_cls", _EMBARGO_BINARY_RETRIEVER_NODES)
+def test_embargo_binary_retriever_node_subclasses_retriever(node_cls):
+    assert issubclass(node_cls, RetrieverCallOutPoint)
+
+
+@pytest.mark.parametrize("node_cls", _EMBARGO_BINARY_RETRIEVER_NODES)
+def test_embargo_binary_retriever_node_output_keys_empty(node_cls):
+    assert node_cls.output_keys == {}
+
+
+@pytest.mark.parametrize("node_cls", _EMBARGO_BINARY_RETRIEVER_NODES)
+def test_embargo_binary_retriever_node_has_blackboard_contract_docstring(
+    node_cls,
+):
+    assert node_cls.__doc__ and "Blackboard contract" in node_cls.__doc__

--- a/test/fuzzer/report_management/test_assign_vul_id.py
+++ b/test/fuzzer/report_management/test_assign_vul_id.py
@@ -229,6 +229,7 @@ class TestEmpiricalDistributions:
         """Same seed → same sequence for a representative node."""
         random.seed(42)
         node = RequestId()
+        node.setup()
         seq_a = [node.update() for _ in range(20)]
         random.seed(42)
         seq_b = [node.update() for _ in range(20)]

--- a/test/fuzzer/report_management/test_report_to_others.py
+++ b/test/fuzzer/report_management/test_report_to_others.py
@@ -17,7 +17,6 @@ from vultron.demo.fuzzer.base import (
 from vultron.demo.fuzzer.report_management.report_to_others import (
     AllPartiesKnown,
     ChooseRecipient,
-    FindContact,
     HaveReportToOthersCapability,
     IdentifyCoordinators,
     IdentifyOthers,
@@ -49,7 +48,6 @@ _ALL_NODES = [
     RemoveRecipient,
     RecipientEffortExceeded,
     PolicyCompatible,
-    FindContact,
     RcptNotInQrmS,
     SetRcptQrmR,
     TotalEffortLimitMet,
@@ -146,10 +144,6 @@ def test_policy_compatible_base_type():
     assert issubclass(PolicyCompatible, ProbablySucceed)
 
 
-def test_find_contact_base_type():
-    assert issubclass(FindContact, UsuallySucceed)
-
-
 def test_rcpt_not_in_qrm_s_base_type():
     assert issubclass(RcptNotInQrmS, AlmostAlwaysSucceed)
 
@@ -223,10 +217,6 @@ def test_recipient_effort_exceeded_success_rate():
 
 def test_policy_compatible_success_rate():
     assert PolicyCompatible.success_rate == pytest.approx(2 / 3)
-
-
-def test_find_contact_success_rate():
-    assert FindContact.success_rate == pytest.approx(0.75)
 
 
 def test_rcpt_not_in_qrm_s_success_rate():

--- a/vultron/bt/report_management/_behaviors/report_to_others.py
+++ b/vultron/bt/report_management/_behaviors/report_to_others.py
@@ -34,7 +34,6 @@ from vultron.bt.messaging.states import MessageTypes
 from vultron.bt.report_management.fuzzer.report_to_others import (
     AllPartiesKnown,
     ChooseRecipient,
-    FindContact,
     HaveReportToOthersCapability,
     InjectCoordinator,
     InjectOther,
@@ -244,9 +243,8 @@ _EngageParticipant = sequence_node(
 #  will also need to sync case pxa and embargo status with new participant
 _NotifyRecipient = sequence_node(
     "_NotifyRecipient",
-    "Checks if it is ok to notify a recipient, finds their contact info, then notifies them",
+    "Checks if it is ok to notify a recipient, then notifies them",
     _EnsureOkToNotify,
-    FindContact,
     _EngageParticipant,
 )
 

--- a/vultron/demo/fuzzer/embargo.py
+++ b/vultron/demo/fuzzer/embargo.py
@@ -43,7 +43,10 @@ from vultron.demo.fuzzer.base import (
     UsuallyFail,
     UsuallySucceed,
 )
-from vultron.demo.fuzzer.call_out_point import EvaluatorCallOutPoint
+from vultron.demo.fuzzer.call_out_point import (
+    EvaluatorCallOutPoint,
+    RetrieverCallOutPoint,
+)
 
 # ---------------------------------------------------------------------------
 # Embargo termination nodes
@@ -126,7 +129,7 @@ class ExitEmbargoForOtherReason(EvaluatorCallOutPoint, OneInTwoHundred):
     output_keys = {"exit_embargo_other_reason_verdict": str}
 
 
-class EmbargoTimerExpired(OneInOneHundred):
+class EmbargoTimerExpired(RetrieverCallOutPoint, OneInOneHundred):
     """Check whether the embargo's agreed-upon deadline has passed.
 
     Semantic function:
@@ -134,6 +137,10 @@ class EmbargoTimerExpired(OneInOneHundred):
         the embargo expiry timestamp recorded in the case.  In simulation
         this fires rarely; in production it is a simple timestamp
         comparison.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — queries embargo expiry timestamp from case record)
+      Output keys: (none — binary result only, per BT-18-006)
 
     Input category: Environmental check.
 

--- a/vultron/demo/fuzzer/report_management/__init__.py
+++ b/vultron/demo/fuzzer/report_management/__init__.py
@@ -86,7 +86,6 @@ from vultron.demo.fuzzer.report_management.other_work import OtherWork
 from vultron.demo.fuzzer.report_management.report_to_others import (
     AllPartiesKnown,
     ChooseRecipient,
-    FindContact,
     HaveReportToOthersCapability,
     IdentifyCoordinators,
     IdentifyOthers,
@@ -184,7 +183,6 @@ __all__ = [
     "RemoveRecipient",
     "RecipientEffortExceeded",
     "PolicyCompatible",
-    "FindContact",
     "RcptNotInQrmS",
     "SetRcptQrmR",
     "TotalEffortLimitMet",

--- a/vultron/demo/fuzzer/report_management/acquire_exploit.py
+++ b/vultron/demo/fuzzer/report_management/acquire_exploit.py
@@ -42,10 +42,13 @@ from vultron.demo.fuzzer.base import (
     RarelySucceed,
     UsuallyFail,
 )
-from vultron.demo.fuzzer.call_out_point import EvaluatorCallOutPoint
+from vultron.demo.fuzzer.call_out_point import (
+    EvaluatorCallOutPoint,
+    RetrieverCallOutPoint,
+)
 
 
-class HaveExploit(UsuallyFail):
+class HaveExploit(RetrieverCallOutPoint, UsuallyFail):
     """Check whether the organization already possesses an exploit.
 
     Semantic function:
@@ -53,6 +56,10 @@ class HaveExploit(UsuallyFail):
         exploit for the vulnerability in its internal exploit repository
         or threat-intelligence database.  Fails most of the time to reflect
         the typical case where an exploit must be acquired or developed.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — queries internal exploit repository or TI database)
+      Output keys: (none — binary result only, per BT-18-006)
 
     Input category: Environmental check.
 
@@ -150,7 +157,7 @@ class ExploitDesired(OftenFail):
     """
 
 
-class FindExploit(AlmostAlwaysFail):
+class FindExploit(RetrieverCallOutPoint, AlmostAlwaysFail):
     """Search external sources for an existing exploit.
 
     Semantic function:
@@ -160,6 +167,10 @@ class FindExploit(AlmostAlwaysFail):
         the realistic assumption that ready-made exploits are rarely
         available, while infrequent successes allow downstream workflow
         paths to be exercised.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — queries external exploit databases and TI feeds)
+      Output keys: (none — binary result only, per BT-18-006)
 
     Input category: System integration / Human decision.
 

--- a/vultron/demo/fuzzer/report_management/assign_vul_id.py
+++ b/vultron/demo/fuzzer/report_management/assign_vul_id.py
@@ -39,10 +39,13 @@ from vultron.demo.fuzzer.base import (
     UsuallyFail,
     UsuallySucceed,
 )
-from vultron.demo.fuzzer.call_out_point import EvaluatorCallOutPoint
+from vultron.demo.fuzzer.call_out_point import (
+    EvaluatorCallOutPoint,
+    RetrieverCallOutPoint,
+)
 
 
-class IdAssigned(UsuallyFail):
+class IdAssigned(RetrieverCallOutPoint, UsuallyFail):
     """Check whether the vulnerability has already been assigned an identity.
 
     Semantic function:
@@ -52,6 +55,10 @@ class IdAssigned(UsuallyFail):
         models the common case where the workflow has not yet assigned an ID
         (i.e., the condition fails most of the time), so that subsequent
         ID-assignment steps are exercised.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — queries case record or external ID registry)
+      Output keys: (none — binary result only, per BT-18-006)
 
     Input category: Environmental check.
 
@@ -112,7 +119,7 @@ class IsIDAssignmentAuthority(OftenSucceed):
     """
 
 
-class RequestId(UsuallySucceed):
+class RequestId(RetrieverCallOutPoint, UsuallySucceed):
     """Request a Vulnerability ID assignment from an external authority.
 
     Semantic function:
@@ -122,6 +129,10 @@ class RequestId(UsuallySucceed):
         call, or may involve prompting a human operator to file the request
         manually.
 
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — submits request to external ID authority)
+      Output keys: assigned_id: str  (SUCCESS only)
+
     Input category: System integration.
 
     Success probability: 0.75 (``UsuallySucceed``).
@@ -130,6 +141,8 @@ class RequestId(UsuallySucceed):
     automated CVE ID reservation; a production implementation could submit the
     request without human intervention in most cases.
     """
+
+    output_keys = {"assigned_id": str}
 
 
 class AssignId(AlwaysSucceed):

--- a/vultron/demo/fuzzer/report_management/deploy_fix.py
+++ b/vultron/demo/fuzzer/report_management/deploy_fix.py
@@ -41,7 +41,10 @@ from vultron.demo.fuzzer.base import (
     UsuallyFail,
     UsuallySucceed,
 )
-from vultron.demo.fuzzer.call_out_point import EvaluatorCallOutPoint
+from vultron.demo.fuzzer.call_out_point import (
+    EvaluatorCallOutPoint,
+    RetrieverCallOutPoint,
+)
 
 
 class NoNewDeploymentInfo(UsuallySucceed):
@@ -91,7 +94,7 @@ class PrioritizeDeployment(EvaluatorCallOutPoint, AlmostAlwaysSucceed):
     output_keys = {"deployment_priority_verdict": str}
 
 
-class MitigationDeployed(UsuallyFail):
+class MitigationDeployed(RetrieverCallOutPoint, UsuallyFail):
     """Check whether a mitigation has already been deployed.
 
     Semantic function:
@@ -101,6 +104,10 @@ class MitigationDeployed(UsuallyFail):
         the case record or a configuration-management database.  Fails most
         of the time to reflect that mitigations are not yet deployed in the
         typical workflow step.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — queries case record or CMDB for mitigation status)
+      Output keys: (none — binary result only, per BT-18-006)
 
     Input category: Environmental check.
 
@@ -112,7 +119,7 @@ class MitigationDeployed(UsuallyFail):
     """
 
 
-class MitigationAvailable(OftenSucceed):
+class MitigationAvailable(RetrieverCallOutPoint, OftenSucceed):
     """Check whether a mitigation option is available to deploy.
 
     Semantic function:
@@ -120,6 +127,10 @@ class MitigationAvailable(OftenSucceed):
         firewall rule, or configuration change) has been identified and is
         ready to be applied.  Succeeds more often than not to reflect that
         mitigations are typically available when this node is reached.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — queries case record or mitigation catalogue)
+      Output keys: (none — binary result only, per BT-18-006)
 
     Input category: Environmental check.
 

--- a/vultron/demo/fuzzer/report_management/monitor_threats.py
+++ b/vultron/demo/fuzzer/report_management/monitor_threats.py
@@ -38,9 +38,10 @@ from vultron.demo.fuzzer.base import (
     AlwaysSucceed,
     UsuallyFail,
 )
+from vultron.demo.fuzzer.call_out_point import RetrieverCallOutPoint
 
 
-class MonitorAttacks(AlmostAlwaysFail):
+class MonitorAttacks(RetrieverCallOutPoint, AlmostAlwaysFail):
     """Monitor threat-intelligence feeds for active attacks on the vulnerability.
 
     Semantic function:
@@ -49,6 +50,10 @@ class MonitorAttacks(AlmostAlwaysFail):
         has been observed in the wild.  Fails almost always to reflect the
         realistic low prior probability that an attack against a specific
         vulnerability will be detected during a routine coordination cycle.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — queries TI feeds and SIEM for attack signals)
+      Output keys: (none — binary result only, per BT-18-006)
 
     Input category: System integration.
 
@@ -61,7 +66,7 @@ class MonitorAttacks(AlmostAlwaysFail):
     """
 
 
-class MonitorExploits(AlmostAlwaysFail):
+class MonitorExploits(RetrieverCallOutPoint, AlmostAlwaysFail):
     """Monitor threat-intelligence feeds for public exploits of the vulnerability.
 
     Semantic function:
@@ -70,6 +75,10 @@ class MonitorExploits(AlmostAlwaysFail):
         the vulnerability has been published or is circulating.  Fails almost
         always to reflect the realistic low prior probability that a public
         exploit will be detected during a routine coordination cycle.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — queries exploit databases and TI platforms)
+      Output keys: (none — binary result only, per BT-18-006)
 
     Input category: System integration.
 
@@ -81,7 +90,7 @@ class MonitorExploits(AlmostAlwaysFail):
     """
 
 
-class MonitorPublicReports(UsuallyFail):
+class MonitorPublicReports(RetrieverCallOutPoint, UsuallyFail):
     """Monitor public sources for disclosure of the vulnerability.
 
     Semantic function:
@@ -90,6 +99,10 @@ class MonitorPublicReports(UsuallyFail):
         disclosed or publicly discussed before the coordinated embargo
         expires.  Fails most of the time to reflect that premature public
         disclosure is the uncommon case during active coordination.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — scans public news feeds, mailing lists, social media)
+      Output keys: (none — binary result only, per BT-18-006)
 
     Input category: System integration.
 

--- a/vultron/demo/fuzzer/report_management/report_to_others.py
+++ b/vultron/demo/fuzzer/report_management/report_to_others.py
@@ -109,7 +109,7 @@ class IdentifyVendors(RetrieverCallOutPoint, SuccessOrRunning):
 
     Blackboard contract (BT-18-001):
       Input keys:  (none — queries CPE/product databases and SBOM data)
-      Output keys: identified_vendors: str  (SUCCESS only)
+      Output keys: identified_vendors: list  (SUCCESS only)
 
     Input category: Human decision / System integration.
 
@@ -122,7 +122,7 @@ class IdentifyVendors(RetrieverCallOutPoint, SuccessOrRunning):
     benefit from human review.
     """
 
-    output_keys = {"identified_vendors": str}
+    output_keys = {"identified_vendors": list}
 
 
 class IdentifyCoordinators(RetrieverCallOutPoint, SuccessOrRunning):
@@ -136,7 +136,7 @@ class IdentifyCoordinators(RetrieverCallOutPoint, SuccessOrRunning):
 
     Blackboard contract (BT-18-001):
       Input keys:  (none — queries FIRST member directory and CSIRT registries)
-      Output keys: identified_coordinators: str  (SUCCESS only)
+      Output keys: identified_coordinators: list  (SUCCESS only)
 
     Input category: Human decision / System integration.
 
@@ -148,7 +148,7 @@ class IdentifyCoordinators(RetrieverCallOutPoint, SuccessOrRunning):
     a coordinator) may require human judgment.
     """
 
-    output_keys = {"identified_coordinators": str}
+    output_keys = {"identified_coordinators": list}
 
 
 class IdentifyOthers(AlwaysSucceed):
@@ -276,32 +276,6 @@ class PolicyCompatible(EvaluatorCallOutPoint, ProbablySucceed):
     """
 
     output_keys = {"policy_compatible_verdict": str}
-
-
-class FindContact(RetrieverCallOutPoint, UsuallySucceed):
-    """Look up contact information for the chosen recipient.
-
-    Semantic function:
-        Action — look up contact information for the chosen recipient
-        (security email, bug bounty platform, disclosure portal).
-        Succeeds most of the time; may fail for lesser-known vendors
-        with no published security contact.
-
-    Blackboard contract (BT-18-001):
-      Input keys:  (none — queries security.txt, PSIRT directory, FIRST DB)
-      Output keys: recipient_contact: str  (SUCCESS only)
-
-    Input category: System integration.
-
-    Success probability: 0.75 (``UsuallySucceed``).
-
-    Automation potential: **High** — security.txt lookup, PSIRT directory
-    queries, FIRST member database, and NVD contact data are all
-    automatable for well-known organizations; obscure vendors may require
-    manual research.
-    """
-
-    output_keys = {"recipient_contact": str}
 
 
 class RcptNotInQrmS(AlmostAlwaysSucceed):

--- a/vultron/demo/fuzzer/report_management/report_to_others.py
+++ b/vultron/demo/fuzzer/report_management/report_to_others.py
@@ -49,7 +49,10 @@ from vultron.demo.fuzzer.base import (
     UsuallyFail,
     UsuallySucceed,
 )
-from vultron.demo.fuzzer.call_out_point import EvaluatorCallOutPoint
+from vultron.demo.fuzzer.call_out_point import (
+    EvaluatorCallOutPoint,
+    RetrieverCallOutPoint,
+)
 
 
 class HaveReportToOthersCapability(UsuallySucceed):
@@ -95,7 +98,7 @@ class AllPartiesKnown(EvaluatorCallOutPoint, UniformSucceedFail):
     output_keys = {"all_parties_known_verdict": str}
 
 
-class IdentifyVendors(SuccessOrRunning):
+class IdentifyVendors(RetrieverCallOutPoint, SuccessOrRunning):
     """Identify the software vendors responsible for the affected product(s).
 
     Semantic function:
@@ -103,6 +106,10 @@ class IdentifyVendors(SuccessOrRunning):
         affected product(s) so they can be notified.  Uses
         ``SuccessOrRunning`` to model that vendor identification may be
         an ongoing (multi-tick) process; never hard-fails.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — queries CPE/product databases and SBOM data)
+      Output keys: identified_vendors: str  (SUCCESS only)
 
     Input category: Human decision / System integration.
 
@@ -115,8 +122,10 @@ class IdentifyVendors(SuccessOrRunning):
     benefit from human review.
     """
 
+    output_keys = {"identified_vendors": str}
 
-class IdentifyCoordinators(SuccessOrRunning):
+
+class IdentifyCoordinators(RetrieverCallOutPoint, SuccessOrRunning):
     """Identify coordinator organizations that should be involved.
 
     Semantic function:
@@ -124,6 +133,10 @@ class IdentifyCoordinators(SuccessOrRunning):
         national CSIRTs) that should be involved in the disclosure.  Uses
         ``SuccessOrRunning`` to model an ongoing identification process;
         never hard-fails.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — queries FIRST member directory and CSIRT registries)
+      Output keys: identified_coordinators: str  (SUCCESS only)
 
     Input category: Human decision / System integration.
 
@@ -134,6 +147,8 @@ class IdentifyCoordinators(SuccessOrRunning):
     CSIRT registry lookups are automatable; routing policy (when to involve
     a coordinator) may require human judgment.
     """
+
+    output_keys = {"identified_coordinators": str}
 
 
 class IdentifyOthers(AlwaysSucceed):
@@ -171,13 +186,17 @@ class NotificationsComplete(UniformSucceedFail):
     """
 
 
-class ChooseRecipient(AlwaysSucceed):
+class ChooseRecipient(RetrieverCallOutPoint, AlwaysSucceed):
     """Select the next recipient from the identified-parties list.
 
     Semantic function:
         Action — select the next recipient from the identified-parties
         list for notification.  Could be fully automated; always succeeds
         in simulation.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — reads pending notification queue from DataLayer)
+      Output keys: chosen_recipient: str  (SUCCESS only)
 
     Input category: System integration.
 
@@ -186,6 +205,8 @@ class ChooseRecipient(AlwaysSucceed):
     Automation potential: **High** — deterministic queue selection from
     the identified-parties list; fully automatable.
     """
+
+    output_keys = {"chosen_recipient": str}
 
 
 class RemoveRecipient(AlwaysSucceed):
@@ -257,7 +278,7 @@ class PolicyCompatible(EvaluatorCallOutPoint, ProbablySucceed):
     output_keys = {"policy_compatible_verdict": str}
 
 
-class FindContact(UsuallySucceed):
+class FindContact(RetrieverCallOutPoint, UsuallySucceed):
     """Look up contact information for the chosen recipient.
 
     Semantic function:
@@ -265,6 +286,10 @@ class FindContact(UsuallySucceed):
         (security email, bug bounty platform, disclosure portal).
         Succeeds most of the time; may fail for lesser-known vendors
         with no published security contact.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — queries security.txt, PSIRT directory, FIRST DB)
+      Output keys: recipient_contact: str  (SUCCESS only)
 
     Input category: System integration.
 
@@ -275,6 +300,8 @@ class FindContact(UsuallySucceed):
     automatable for well-known organizations; obscure vendors may require
     manual research.
     """
+
+    output_keys = {"recipient_contact": str}
 
 
 class RcptNotInQrmS(AlmostAlwaysSucceed):


### PR DESCRIPTION
- Closes #1174

## Summary

Applies the `RetrieverCallOutPoint` mixin base class to all 14 Retriever-shaped fuzzer nodes identified in the FUZZ-08 catalog, completing the call-out point abstraction layer (ADR-0025) for the Retriever agent shape (ADR-0024).

## Changes

- `vultron/demo/fuzzer/report_management/assign_vul_id.py`: `IdAssigned` (binary), `RequestId` (data → `assigned_id: str`)
- `vultron/demo/fuzzer/report_management/deploy_fix.py`: `MitigationDeployed`, `MitigationAvailable` (both binary)
- `vultron/demo/fuzzer/report_management/acquire_exploit.py`: `HaveExploit`, `FindExploit` (both binary)
- `vultron/demo/fuzzer/report_management/monitor_threats.py`: `MonitorAttacks`, `MonitorExploits`, `MonitorPublicReports` (all binary)
- `vultron/demo/fuzzer/report_management/report_to_others.py`: `IdentifyVendors`, `IdentifyCoordinators`, `FindContact`, `ChooseRecipient` (all data-producing with distinct output keys)
- `vultron/demo/fuzzer/embargo.py`: `EmbargoTimerExpired` (binary)
- `test/demo/fuzzer/test_call_out_point.py`: added 5 data-producing entries to `_RM_RETRIEVER_NODES`; new `_RM_BINARY_RETRIEVER_NODES` (8 nodes) and `_EMBARGO_BINARY_RETRIEVER_NODES` (1 node) with subclass / empty-keys / docstring assertions
- `test/fuzzer/report_management/test_assign_vul_id.py`: added `node.setup()` before `update()` in `test_seeded_determinism` (required now that `RequestId` declares `output_keys`)

Each node:
- Subclasses `RetrieverCallOutPoint` as first base class (MRO)
- Has a BT-18-001 blackboard contract section in its docstring
- Binary nodes rely on inherited `output_keys = {}` per BT-18-006
- Data-producing nodes declare `output_keys` with `str` value types

## Verification

- All 4560 non-integration tests pass (174 integration tests pass under `-m integration`)
- 51 new test assertions across the new parametrized test lists
- Black, flake8 clean