### PR TITLE
docs: update suggest_actor sequence diagram and vocab examples for ADR-0026

### DIFF
--- a/docs/howto/activitypub/activities/suggest_actor.md
+++ b/docs/howto/activitypub/activities/suggest_actor.md
@@ -44,36 +44,39 @@ is easier to read.
 
 ```mermaid
 ---
-title: Suggesting an Actor for a Case
+title: Suggesting an Actor for a Case (ADR-0026 CaseActor-routed)
 ---
 sequenceDiagram
-    actor A as Participant
-    participant C as Case
+    actor A as Recommender
+    participant CA as CaseActor
     actor B as Case Owner
-    actor D as Actor 
+    actor D as Invitee
     Note over A: Recognize that Actor should be invited
-    A ->> C: Offer(object=Actor, target=Case)
-    activate A
-    C -->+ B: Observe suggestion
+    A ->> CA: Offer(object=Actor, target=Case)
+    activate CA
+    Note over CA: Record in ledger, assign default roles
+    CA ->> B: Offer(object=CaseParticipant{actor,roles}, target=Case, origin=Offer.id)
+    activate B
     alt Accept Suggestion
-        B -->> C: Accept(object=Offer)
-        B ->>+ D: Invite(actor=CaseOwner, object=Actor, target=Case)
+        B ->> CA: Accept(object=Offer(CaseParticipant))
+        CA ->> A: AcceptActorRecommendation
+        CA ->>+ D: Invite(CaseStub + embargo + roles)
+        note over D: Respond to invitation (not shown)
+        deactivate D
     else Reject Suggestion
-        B -->> C: Reject(object=Offer)
+        B ->> CA: Reject(object=Offer(CaseParticipant))
+        CA ->> A: RejectActorRecommendation
     end
     deactivate B
-    C --> A: Observe response
-    deactivate A
-    note over D: Respond to invitation (not shown)
-    deactivate D
+    deactivate CA
 ```
 
 ## Recommend Actor
 
-An actor can recommend that another actor be invited to participate in a case by sending an `Offer` activity
-with the `object` property set to the actor that is being recommended. The `target` property of the `Offer` activity
-is set to the `case` object. Implementations should then prompt the case owner to accept or reject the
-recommendation.
+A participant recommends another actor to the **CaseActor** by sending an `Offer` activity with the
+`object` property set to the actor being recommended and the `target` set to the case.
+The CaseActor records the recommendation in the canonical ledger, assigns default roles, and
+forwards a transformed offer to the Case Owner.
 
 ```python exec="true" idprefix=""
 from vultron.wire.as2.vocab.examples.vocab_examples import recommend_actor, json2md
@@ -81,30 +84,39 @@ from vultron.wire.as2.vocab.examples.vocab_examples import recommend_actor, json
 print(json2md(recommend_actor()))
 ```
 
-## Accept Actor Recommendation
+## CaseActor Forwards Offer to Case Owner
 
-The case owner can accept the recommendation by sending an `Accept` activity.
-We show this as an actor accepting the actor `object` from the recommendation [above](#recommend-actor),
-rather than accepting the `Offer` activity itself. Note the `target` property of the `Accept` activity is set to the
-`case` object.
-
-This should be followed by the case owner [inviting the actor to the case](#invite-to-case).
+The CaseActor transforms the `Offer(Actor, Case)` into `Offer(CaseParticipant{actor, roles}, Case)`
+and sends it to the Case Owner's inbox. The `origin` field carries the ID of the original recommendation
+so the Case Owner can trace the causal chain.
 
 ```python exec="true" idprefix=""
-from vultron.wire.as2.vocab.examples.vocab_examples import accept_actor_recommendation, json2md
+from vultron.wire.as2.vocab.examples.vocab_examples import offer_case_participant, json2md
 
-print(json2md(accept_actor_recommendation()))
+print(json2md(offer_case_participant()))
 ```
 
-## Reject Actor Recommendation
+## Case Owner Accepts Recommendation
 
-The case owner can reject the recommendation by sending a `RejectActorRecommendation` activity.
-The structure of this activity is similar to the `Accept` activity [above](#accept-actor-recommendation).
+The Case Owner accepts the recommendation by sending `Accept(Offer(CaseParticipant))` to the
+**CaseActor** (not directly to the recommender). The CaseActor records the decision, notifies the
+original recommender, and sends an `Invite` to the proposed participant.
 
 ```python exec="true" idprefix=""
-from vultron.wire.as2.vocab.examples.vocab_examples import reject_actor_recommendation, json2md
+from vultron.wire.as2.vocab.examples.vocab_examples import accept_case_participant_offer, json2md
 
-print(json2md(reject_actor_recommendation()))
+print(json2md(accept_case_participant_offer()))
+```
+
+## Case Owner Rejects Recommendation
+
+The Case Owner rejects the recommendation by sending `Reject(Offer(CaseParticipant))` to the
+**CaseActor**. The CaseActor records the decision and notifies the original recommender.
+
+```python exec="true" idprefix=""
+from vultron.wire.as2.vocab.examples.vocab_examples import reject_case_participant_offer, json2md
+
+print(json2md(reject_case_participant_offer()))
 ```
 
 {% include-markdown "./_invite_to_case.md" heading-offset=1 %}

--- a/plan/history/2607/implementation/ISSUE-1301.md
+++ b/plan/history/2607/implementation/ISSUE-1301.md
@@ -1,0 +1,10 @@
+---
+source: ISSUE-1301
+timestamp: '2026-07-13T17:28:14.559500+00:00'
+title: update suggest_actor docs for ADR-0026 CaseActor routing
+type: implementation
+---
+
+## Issue #1301 — docs: update suggest_actor.md sequence diagram and vocab examples for ADR-0026
+
+Updated `docs/howto/activitypub/activities/suggest_actor.md` to reflect the CaseActor-routed suggest-actor protocol per ADR-0026. Added three new vocab example functions (`offer_case_participant`, `accept_case_participant_offer`, `reject_case_participant_offer`) covering the intermediate protocol steps. Fixed a Mermaid diagram bug where the Invitee activation bar rendered unconditionally in the Reject path. PR: <https://github.com/CERTCC/Vultron/pull/1369>

--- a/vultron/wire/as2/vocab/examples/actor.py
+++ b/vultron/wire/as2/vocab/examples/actor.py
@@ -24,8 +24,11 @@ from vultron.wire.as2.vocab.examples._base import (
 )
 from vultron.wire.as2.factories import (
     accept_actor_recommendation_activity,
+    accept_case_participant_offer_activity,
+    offer_case_participant_activity,
     recommend_actor_activity,
     reject_actor_recommendation_activity,
+    reject_case_participant_offer_activity,
 )
 
 
@@ -76,5 +79,64 @@ def reject_actor_recommendation() -> as_Reject:
         target=_case.id_,
         to=_finder.id_,
         content=f"We're declining your recommendation to add {_coordinator.name} to the case. Thanks anyway.",
+    )
+    return _activity
+
+
+def offer_case_participant() -> as_Offer:
+    """CaseActor transforms Offer(Actor) → Offer(CaseParticipant) for Case Owner."""
+    _vendor = vendor()
+    _coordinator = _COORDINATOR
+    _case = case()
+    _recommendation = recommend_actor()
+    _activity = offer_case_participant_activity(
+        _coordinator,
+        target=_case.id_,
+        actor=_vendor.id_,
+        to=[_vendor.id_],
+        context=_case.id_,
+        origin=_recommendation.id_,
+        content=(
+            f"Recommending {_coordinator.name} for case participation "
+            f"(roles: VENDOR). Origin: {_recommendation.id_}"
+        ),
+    )
+    return _activity
+
+
+def accept_case_participant_offer() -> as_Accept:
+    """Case Owner accepts Offer(CaseParticipant) and sends to CaseActor."""
+    _vendor = vendor()
+    _coordinator = _COORDINATOR
+    _case = case()
+    _cp_offer = offer_case_participant()
+    _activity = accept_case_participant_offer_activity(
+        _cp_offer,
+        target=_case.id_,
+        actor=_vendor.id_,
+        to=[_vendor.id_],
+        context=_case.id_,
+        content=(
+            f"Accepting recommendation to add {_coordinator.name} to the case."
+        ),
+    )
+    return _activity
+
+
+def reject_case_participant_offer() -> as_Reject:
+    """Case Owner rejects Offer(CaseParticipant) and sends to CaseActor."""
+    _vendor = vendor()
+    _coordinator = _COORDINATOR
+    _case = case()
+    _cp_offer = offer_case_participant()
+    _activity = reject_case_participant_offer_activity(
+        _cp_offer,
+        target=_case.id_,
+        actor=_vendor.id_,
+        to=[_vendor.id_],
+        context=_case.id_,
+        content=(
+            f"Declining recommendation to add {_coordinator.name} to the case."
+        ),
     )
     return _activity

--- a/vultron/wire/as2/vocab/examples/vocab_examples.py
+++ b/vultron/wire/as2/vocab/examples/vocab_examples.py
@@ -45,8 +45,11 @@ from vultron.wire.as2.vocab.examples._base import (  # noqa: F401
 )
 from vultron.wire.as2.vocab.examples.actor import (  # noqa: F401
     accept_actor_recommendation,
+    accept_case_participant_offer,
+    offer_case_participant,
     recommend_actor,
     reject_actor_recommendation,
+    reject_case_participant_offer,
 )
 from vultron.wire.as2.vocab.examples.case import (  # noqa: F401
     accept_case_ownership_transfer,


### PR DESCRIPTION
- Closes #1301

## Summary

Updates `docs/howto/activitypub/activities/suggest_actor.md` to reflect the
ADR-0026 CaseActor-routed suggest-actor protocol, and adds three new vocab
example functions for the intermediate Offer/Accept/Reject activities.

This PR delivers **AC-6** (the final open criterion) of issue #1301.
**ACs 1–5** (demo routing + end-to-end execution) were implemented in
PR #1320 under issue #1298 (`task/1298-suggest-actor-tree-redesign`,
merged 2026-07-10). The `suggest_actor_demo.py` changes are already on
`main` and do not appear in this diff.

## Changes

- **`docs/howto/activitypub/activities/suggest_actor.md`**: Replaces the
  old direct-to-owner sequence diagram with the ADR-0026 multi-hop flow
  (Recommender → CaseActor → Case Owner → CaseActor). Moves Invitee
  `deactivate D` inside the Accept alt arm so the Reject path renders
  without a spurious activation bar. Renames and rewrites the activity
  sections to describe each protocol step (Recommend Actor, CaseActor
  Forwards Offer, Case Owner Accepts/Rejects).
- **`vultron/wire/as2/vocab/examples/actor.py`**: Adds
  `offer_case_participant()`, `accept_case_participant_offer()`, and
  `reject_case_participant_offer()` example functions using the new
  factories from #1298. All include `context=_case.id_` to match the
  existing `accept_actor_recommendation()` / `reject_actor_recommendation()`
  pattern.
- **`vultron/wire/as2/vocab/examples/vocab_examples.py`**: Adds the three
  new functions to the explicit import/re-export list.

## Verification

- All 4560 unit tests pass (0 new)
- 536 integration tests pass
- Black, flake8, mypy, pyright clean
- [x] AC-6: `docs/howto/activitypub/activities/suggest_actor.md` sequence diagram updated
- ACs 1–5: verified on `main` via PR #1320 (merged 2026-07-10)