### PR TITLE
docs: plan issue #1359 — CS-21 collection-typed parameter defaults

### DIFF
--- a/plan/history/2607/learning/CONCERN-1359.md
+++ b/plan/history/2607/learning/CONCERN-1359.md
@@ -1,0 +1,39 @@
+---
+source: CONCERN-1359
+timestamp: '2026-07-13T18:33:01.042481+00:00'
+title: None defaults for collection-typed parameters should be empty collections
+type: learning
+---
+
+## Summary
+
+Several function parameters and dataclass fields use `None` as a default for
+collection-typed values (`dict`, `set`). Every call-site then guards with
+`x or {}` / `x or set()` before use, spreading defensive boilerplate across
+the codebase.
+
+## Affected sites
+
+| Parameter | File | Current default | Call-site guard |
+|---|---|---|---|
+| `payload_snapshot: dict[str, Any] \| None` | `core/models/case_ledger.py:399`, `core/behaviors/sync/nodes/chain.py:353` | `None` | `payload_snapshot or {}` |
+| `excluded_actor_ids: set[str] \| None` | `core/behaviors/case/update_support.py:98`, `core/use_cases/received/case/update.py:58` | `None` | `excluded_actor_ids or set()` |
+
+## Impact
+
+Callers must remember to guard before every use. A missed guard causes a
+`TypeError` at iteration/subscript time rather than at the boundary. The
+`or {}` pattern also silently coerces falsy non-None values.
+
+## Recommended fix
+
+Change parameter defaults to the appropriate empty collection (`{}` /
+`set()`). Remove the `or {}` / `or set()` guards at all call-sites.
+
+Note: `BTExecutionResult.errors`, `VultronActivity.to/cc`, and
+`CaseReference.tags` are intentional `None`-as-sentinel fields and should
+**not** be changed.
+
+**Resolved**: 2026-07-13 — implementation tracked in #1371.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1370>.
+Spec: `specs/code-style.yaml` (CS-21-001).

--- a/specs/code-style.yaml
+++ b/specs/code-style.yaml
@@ -389,3 +389,39 @@ groups:
       member names; replace with `[e.value for e in EnumName]` or equivalent,
       narrowed with an explicit exclusion list where the fixture intentionally
       covers a subset.
+- id: CS-21
+  title: Collection-Typed Parameter Defaults
+  kind: language
+  specs:
+  - id: CS-21-001
+    priority: MUST_NOT
+    statement: >-
+      Function and method parameters whose type is a collection (`dict`, `set`,
+      `list`, or any generic alias thereof) MUST NOT use `None` as their default
+      value when the intent is "empty collection if not provided". Use the
+      appropriate empty-collection literal (`{}` for dicts, `set()` for sets,
+      `[]` for lists) or `Field(default_factory=...)` for Pydantic model fields.
+      `None` is only acceptable as a default when it is an intentional sentinel
+      meaning "absent" (as distinct from "empty"), and that distinction must be
+      observable in the caller's behaviour.
+    rationale: >-
+      Using `None` as the default for a collection-typed parameter forces every
+      call site that reads the value to write a defensive `x or {}` / `x or
+      set()` guard. The `or` idiom silently coerces any falsy non-None value
+      (including an explicitly passed empty collection) and spreads type-unsafe
+      boilerplate across the codebase. Issue #1359 identified four affected sites
+      in `core/models/case_ledger.py`, `core/behaviors/sync/nodes/chain.py`,
+      `core/behaviors/sync/commit_tree.py`, and
+      `core/behaviors/case/update_support.py`.
+    verification: >-
+      Grep `vultron/` for `| None = None` on lines that also contain `dict[`,
+      `set[`, or `list[`; review each hit to determine whether `None` is a
+      genuine sentinel. Any hit where the function body contains an `x or {}`
+      / `x or set()` guard is a violation.
+    exceptions:
+      - >-
+        `None` is permitted when it is a genuine sentinel distinguishing "not
+        provided" from "empty", provided the distinction is observable in
+        caller behaviour (e.g., `BTExecutionResult.errors: list[str] | None`
+        where `None` means "no error list was collected" vs `[]` meaning
+        "errors were collected but none occurred").


### PR DESCRIPTION
- Closes #1359

## Summary

Adds CS-21 spec group to `specs/code-style.yaml` codifying that
collection-typed function/method parameters MUST NOT use `None` as their
default when the intent is "empty collection if not provided". Includes an
explicit exception clause for genuine `None`-as-sentinel fields
(e.g., `BTExecutionResult.errors`).

## Changes

- `specs/code-style.yaml` — add CS-21 (`CS-21-001`) with rationale,
  verification grep pattern, and sentinel-exception clause