### PR TITLE
docs: plan issue #1360 — silent failures and fail-fast domain helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -882,6 +882,15 @@ Short entries are reproduced here; longer ones are referenced below.
   `notes/bt-fuzzer-nodes-report-management.md` for `NewValidationInfoSentinel`,
   `NewPrioritizationInfoSentinel`, and `NewDeploymentInfoSentinel` as worked
   examples. (Established in issue #1199.)
+- **Silent `None` Returns and Fake `SUCCESS` Are the Same Bug** —
+  Returning `None` from a helper when a required ID is absent, or
+  returning `Status.SUCCESS` from a BT node when a required blackboard
+  key is missing, both silently drop protocol behavior (ledger entries,
+  broadcasts, routing decisions). The correct pattern: check at the
+  conversion point and raise `VultronValidationError` (helpers) or
+  return `Status.FAILURE` (BT nodes) immediately.
+  See [notes/domain-validation.md](notes/domain-validation.md) and
+  `specs/architecture.yaml` ARCH-15-001 through ARCH-15-004.
 
 ## Skill Interaction Rules
 

--- a/notes/README.md
+++ b/notes/README.md
@@ -25,6 +25,18 @@ validate-at-edge / promote-to-core rule (ADR-0032).
 **Load when**: orienting to architecture boundaries, reviewing layering
 violations, or validating core/wire separation.
 
+**`domain-validation.md`**
+Strict vs. loose domain object boundary contract: where objects transition from
+loose (wire-deserialized, possibly-None fields) to strict (all required fields
+resolved), fail-fast patterns at use-case, BT node, and helper boundaries,
+canonical helper locations (`use_cases/_helpers.py`), and the named
+silent-failure sites from CONCERN-1360 with before/after behavior.
+Normative requirements: `specs/architecture.yaml` ARCH-15-001 through
+ARCH-15-004.
+**Load when**: implementing or reviewing error handling in use cases or BT nodes,
+auditing helpers that return `None` on failure, or designing new domain helpers
+that require non-None inputs.
+
 **`vultron/core/ports/AGENTS.md`**
 Port-focused architecture guidance for `vultron/core/ports/`: inbound vs
 outbound port taxonomy, dispatch-vs-emit terminology,

--- a/notes/architecture-hexagonal.md
+++ b/notes/architecture-hexagonal.md
@@ -7,6 +7,7 @@ description: >
 related_notes:
   - vultron/core/ports/AGENTS.md
   - notes/architecture-adapters.md
+  - notes/domain-validation.md
 relevant_packages:
   - vultron/core
   - vultron/wire/as2

--- a/notes/domain-validation.md
+++ b/notes/domain-validation.md
@@ -1,0 +1,147 @@
+---
+title: Domain Object Validation — Strict vs. Loose Boundaries
+status: active
+description: >
+  Where in the pipeline domain objects transition from "loose" (possibly
+  None/unresolved fields) to "strict" (all required fields guaranteed),
+  and how helpers must fail fast when strict guarantees are violated.
+related_specs:
+  - specs/architecture.yaml (ARCH-10-001, ARCH-15-001 through ARCH-15-004)
+related_notes:
+  - notes/architecture-hexagonal.md
+  - notes/bt-integration.md
+---
+
+# Domain Object Validation — Strict vs. Loose Boundaries
+
+## The Strict/Loose Distinction
+
+Domain objects in Vultron move through two zones:
+
+- **Loose zone**: Objects freshly deserialized from the wire or DataLayer.
+  Optional fields may be `None`, IDs may be unresolved strings or inline
+  objects, and required-field invariants have not yet been checked in
+  context.
+- **Strict zone**: Objects that have been validated and are ready for
+  domain logic. All fields required for the current operation are
+  non-None and of the expected type.
+
+The boundary is not a single conversion step — it is a series of
+**fail-fast checkpoints** at the entry to each domain operation.
+Pydantic model construction (ARCH-10-001) enforces structural
+invariants. Runtime helpers enforce relational invariants (e.g., "this
+case has a Case Manager participant with a resolvable actor ID").
+
+---
+
+## Conversion Points
+
+Objects transition from loose to strict at:
+
+1. **Use-case `execute()` entry** — required inputs (case ID, actor ID,
+   activity) must be non-None before any DataLayer mutation.
+2. **BT node `update()` entry** — blackboard keys expected to be present
+   must be verified; missing keys return `Status.FAILURE` (not
+   `Status.SUCCESS`) so the BT sequence propagates failure correctly.
+3. **Helper function boundaries** — helpers that require a non-None result
+   from a field access must check and raise immediately. Helpers whose
+   callers may legitimately pass `None` must remain lenient.
+
+---
+
+## Pattern: Fail Fast at the Conversion Point
+
+When a helper or node requires a non-None value, check it explicitly
+and raise or return `FAILURE` immediately:
+
+```python
+# In a helper that requires a valid ID
+case_id = _as_id(case)
+if case_id is None:
+    raise VultronValidationError(
+        f"Cannot process case with no resolvable id (got {case!r})"
+    )
+
+# In a BT node update() that requires a blackboard key
+case_obj = self._read_case_obj()
+if case_obj is None:
+    self.feedback_message = f"{self.name}: 'create_case_obj' not on blackboard"
+    return Status.FAILURE
+```
+
+**Never return `Status.SUCCESS` when a required input is absent.** A
+missing required value means the subtree cannot produce its intended
+effect; returning `SUCCESS` misleads the BT sequence and silently drops
+protocol behavior (ledger entries not written, broadcasts not sent,
+routing never attempted).
+
+---
+
+## Pattern: Lenient Helpers Remain Lenient
+
+`_as_id()` is intentionally lenient — it returns `None` when the input
+is `None` because many callers legitimately probe optional fields (e.g.,
+`case.active_embargo` is `None` when no embargo is active). Do **not**
+make `_as_id()` raise.
+
+The strict guarantee lives in the **caller**, not in the helper:
+
+```python
+# Lenient use — None is a valid outcome
+active_embargo_id = _as_id(case.active_embargo)  # may be None
+
+# Strict use — None means something went wrong
+manager_id = _as_id(participant.attributed_to)
+if manager_id is None:
+    raise VultronValidationError("CASE_MANAGER participant has no attributed_to")
+```
+
+---
+
+## Canonical Helper Locations
+
+Helpers that extract IDs or look up participants belong in
+`vultron/core/use_cases/_helpers.py` — the neutral module importable
+from both `behaviors/` and `use_cases/` layers without circular imports.
+
+Duplicate copies in other modules (e.g., `services/embargo_lifecycle.py`,
+`behaviors/status/nodes/broadcast.py`) MUST import from
+`use_cases/_helpers` and not maintain their own copies.
+
+---
+
+## Routing Failures vs. Validation Failures
+
+Two distinct error types are used for fail-fast signals:
+
+- **`VultronValidationError`** (`vultron/errors.py`) — a domain object
+  or request fails a required invariant (missing field, wrong type).
+- **`UnroutableActivityError`** (`vultron/errors.py`) — an inbound
+  activity cannot be routed to a case because no case ID could be
+  extracted from the event. This is a routing failure, not a data
+  validation failure. The dispatcher caller MUST handle it explicitly
+  rather than silently dropping the activity.
+
+```python
+# Dispatcher site: raise, don't return None
+if case_id is None:
+    raise UnroutableActivityError(
+        activity_id=event.id_,
+        reason="No case_id attribute found on event",
+    )
+```
+
+---
+
+## Summary of Named Silent-Failure Sites (CONCERN-1360)
+
+| Site | Old behavior | New behavior |
+|---|---|---|
+| `_as_id()` in `embargo_lifecycle.py` | Duplicate copy | Removed; callers import from `use_cases._helpers` |
+| `_find_case_manager_*` (3 copies) | 3 independent copies returning `None` | 1 canonical function in `use_cases/_helpers`; others removed |
+| `_extract_case_id()` in dispatcher | Returns `None`; activity silently not indexed | Raises `UnroutableActivityError` |
+| `AppendCaseLedgerEntryNode.update()` | Returns `Status.SUCCESS` on missing `case_id` | Returns `Status.FAILURE` |
+| `_read_case_obj()` in communication.py | Swallows `KeyError`; no diagnostic | Sets `feedback_message`; caller returns `Status.FAILURE` |
+
+See `specs/architecture.yaml` ARCH-15-001 through ARCH-15-004 for
+normative requirements derived from this concern.

--- a/plan/history/2607/learning/CONCERN-1360.md
+++ b/plan/history/2607/learning/CONCERN-1360.md
@@ -1,0 +1,67 @@
+---
+source: CONCERN-1360
+timestamp: '2026-07-13T19:06:32.996145+00:00'
+title: Core domain helpers return None silently instead of raising
+type: learning
+---
+
+## Summary
+
+Several core domain helper functions return `None` on failure rather than
+raising an exception. This creates silent failures: the program continues
+executing with a `None` result, and the error surfaces far from its origin
+— if at all.
+
+## Most significant sites
+
+### `_as_id()` — two copies, both silent
+
+- `core/use_cases/_helpers.py:58-59`
+- `core/services/embargo_lifecycle.py:77` (duplicate; consolidation tracked in #538)
+
+When an AS2 object has no resolvable `id_`, both return `None`. Every
+downstream lookup (`_resolve_case_manager_id`, `resolve_case_participant_id_for_actor`,
+embargo loops) then silently skips or propagates `None` further.
+
+### `_find_case_manager_from_participants()` — three copies, all silent
+
+- `core/use_cases/_helpers.py:361-366`
+- `core/behaviors/status/nodes/broadcast.py:43-49`
+- `core/use_cases/received/case/_helpers.py:50-57`
+
+All return `None` when no case manager is found; callers silently drop
+broadcasts or skip routing.
+
+### `_extract_case_id()` in dispatcher
+
+- `core/dispatcher.py:207`
+
+Returns `None` when an inbound activity cannot be routed to a case; the
+activity is silently never ledger-indexed.
+
+### `AppendCaseLedgerEntryNode` returns `Status.SUCCESS` on missing `case_id`
+
+- `core/behaviors/case/nodes/lifecycle.py:157-161`
+
+When `case_id` resolves to `None` at runtime, the ledger append is silently
+skipped but the node returns `Status.SUCCESS`, misleading the BT sequence.
+
+### `_read_case_obj()` swallows `KeyError` with no log
+
+- `core/behaviors/case/nodes/communication.py:135-138`
+
+Returns `None` on `KeyError` with no `feedback_message` set, leaving the
+BT caller with zero diagnostic information.
+
+## Impact
+
+- Ledger entries silently not written
+- Case-update broadcasts silently dropped
+- Embargo routing silently mis-routed
+- Debug traces point to the point of *use* of `None`, not the point of *failure*
+
+**Resolved**: 2026-07-13 — implementation tracked in #1377 (fail-fast fixes)
+and #1378 (helper consolidation).
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1376>.
+Spec: `specs/architecture.yaml` ARCH-15-001 through ARCH-15-004.
+Notes: `notes/domain-validation.md`.

--- a/specs/architecture.yaml
+++ b/specs/architecture.yaml
@@ -282,6 +282,63 @@ groups:
       required invariants are not satisfied
     rationale: Late validation masks missing data and makes debugging harder; fail-fast ensures errors surface at the point
       of construction
+- id: ARCH-15
+  title: Fail-Fast at Domain Operation Boundaries
+  description: >
+    Extends ARCH-10-001. While ARCH-10 covers structural validation at Pydantic
+    construction time, ARCH-15 governs relational invariants enforced at runtime
+    entry points: use-case execute(), BT node update(), and helper functions that
+    require non-None resolved values. See notes/domain-validation.md for the
+    strict/loose distinction and canonical patterns.
+  specs:
+  - id: ARCH-15-001
+    priority: MUST
+    statement: >
+      A BT node's update() MUST return Status.FAILURE when a required blackboard
+      key is absent or resolves to None. It MUST NOT return Status.SUCCESS in
+      this case, as doing so misleads the enclosing BT sequence and silently
+      drops protocol behavior (e.g., ledger entries not written).
+    rationale: >
+      Status.SUCCESS on a missing required input causes the BT sequence to
+      continue as if the node succeeded, masking the failure and producing
+      ledger gaps, dropped broadcasts, and mis-routed activities.
+      See notes/domain-validation.md.
+  - id: ARCH-15-002
+    priority: MUST
+    statement: >
+      A helper function that requires a non-None ID MUST check the result
+      and raise VultronValidationError (or UnroutableActivityError for routing
+      failures) immediately. The strict guarantee lives in the caller or the
+      helper itself — never deferred silently to downstream code.
+    rationale: >
+      Returning None from a helper that conceptually requires a valid ID moves
+      the error from the point of failure to the point of use, making stack
+      traces and logs point to the wrong location.
+      See notes/domain-validation.md.
+  - id: ARCH-15-003
+    priority: MUST
+    statement: >
+      The dispatcher MUST raise UnroutableActivityError when no case_id can
+      be extracted from an inbound event. It MUST NOT return None and silently
+      drop the activity from ledger indexing.
+    rationale: >
+      A silently dropped activity produces an invisible gap in the canonical
+      case ledger and leaves no audit trail. The dispatcher caller must make
+      an explicit decision about how to handle unroutable activities.
+      See notes/domain-validation.md.
+  - id: ARCH-15-004
+    priority: MUST
+    statement: >
+      Each domain helper function MUST have exactly one canonical copy.
+      Duplicate implementations of the same logic (e.g., multiple copies of
+      _as_id() or case-manager lookup functions) MUST be removed; all callers
+      MUST import from the canonical location in vultron/core/use_cases/_helpers.py.
+    rationale: >
+      Duplicate helper copies diverge silently over time. Two copies of
+      _as_id() in use_cases/_helpers.py and services/embargo_lifecycle.py had
+      already diverged in docstring accuracy. Three copies of the case-manager
+      lookup produced inconsistent None-handling behavior across callers.
+      See notes/domain-validation.md.
 - id: ARCH-11
   title: Port Inbound/Outbound Discrimination
   specs:

--- a/specs/architecture.yaml
+++ b/specs/architecture.yaml
@@ -289,7 +289,9 @@ groups:
     construction time, ARCH-15 governs relational invariants enforced at runtime
     entry points: use-case execute(), BT node update(), and helper functions that
     require non-None resolved values. See notes/domain-validation.md for the
-    strict/loose distinction and canonical patterns.
+    strict/loose distinction and canonical patterns, and ADR-0032
+    (docs/adr/0032-validate-at-edge-promote-to-core.md) for the architectural
+    decision that motivates this group.
   specs:
   - id: ARCH-15-001
     priority: MUST
@@ -302,7 +304,11 @@ groups:
       Status.SUCCESS on a missing required input causes the BT sequence to
       continue as if the node succeeded, masking the failure and producing
       ledger gaps, dropped broadcasts, and mis-routed activities.
-      See notes/domain-validation.md.
+      See notes/domain-validation.md and ADR-0032.
+    relationships:
+      - rel_type: refines
+        spec_id: ARCH-10-001
+        note: Extends construction-time fail-fast to runtime BT node entry points.
   - id: ARCH-15-002
     priority: MUST
     statement: >
@@ -314,7 +320,11 @@ groups:
       Returning None from a helper that conceptually requires a valid ID moves
       the error from the point of failure to the point of use, making stack
       traces and logs point to the wrong location.
-      See notes/domain-validation.md.
+      See notes/domain-validation.md and ADR-0032.
+    relationships:
+      - rel_type: refines
+        spec_id: ARCH-10-001
+        note: Extends construction-time fail-fast to helper function entry points.
   - id: ARCH-15-003
     priority: MUST
     statement: >
@@ -325,7 +335,11 @@ groups:
       A silently dropped activity produces an invisible gap in the canonical
       case ledger and leaves no audit trail. The dispatcher caller must make
       an explicit decision about how to handle unroutable activities.
-      See notes/domain-validation.md.
+      See notes/domain-validation.md and ADR-0032.
+    relationships:
+      - rel_type: refines
+        spec_id: ARCH-10-001
+        note: Extends construction-time fail-fast to dispatcher routing entry points.
   - id: ARCH-15-004
     priority: MUST
     statement: >
@@ -338,7 +352,11 @@ groups:
       _as_id() in use_cases/_helpers.py and services/embargo_lifecycle.py had
       already diverged in docstring accuracy. Three copies of the case-manager
       lookup produced inconsistent None-handling behavior across callers.
-      See notes/domain-validation.md.
+      See notes/domain-validation.md and ADR-0032.
+    relationships:
+      - rel_type: refines
+        spec_id: ARCH-10-001
+        note: Canonical-copy discipline is a prerequisite for consistent fail-fast enforcement.
 - id: ARCH-11
   title: Port Inbound/Outbound Discrimination
   specs:


### PR DESCRIPTION
- Closes #1360

## Summary

Plans CONCERN-1360 (core domain helpers return None silently instead of
raising). Introduces the strict-vs-loose domain object boundary concept,
adds normative ARCH-15 spec requirements, and documents the specific
before/after behavior for all 5 named silent-failure sites.

## Changes

- `notes/domain-validation.md` (new): strict/loose object boundary
  contract, fail-fast patterns at use-case / BT node / helper
  boundaries, canonical helper location (`use_cases/_helpers.py`),
  routing vs validation error distinction, and per-site summary for
  CONCERN-1360
- `specs/architecture.yaml`: ARCH-15-001 through ARCH-15-004 — BT node
  MUST return FAILURE on missing inputs (15-001), helpers MUST check
  and raise on required-but-None results (15-002), dispatcher MUST
  raise `UnroutableActivityError` (15-003), each helper MUST have
  exactly one canonical copy (15-004)
- `notes/README.md`: added `domain-validation.md` entry
- `AGENTS.md`: added Common Pitfalls entry — "Silent None Returns and
  Fake SUCCESS Are the Same Bug"