### PR TITLE
specs: audit SpecKind classifications; add dev-process tier

### DIFF
--- a/notes/archived_notes/spec-registry.md
+++ b/notes/archived_notes/spec-registry.md
@@ -100,6 +100,7 @@ class SpecKind(StrEnum):
     DOMAIN         = "domain"          # Vultron / CVD: language-agnostic
     LANGUAGE       = "language"        # Python ecosystem: any Python project
     IMPLEMENTATION = "implementation"  # this specific codebase
+    DEV_PROCESS    = "dev-process"     # this project's development and maintenance process
 
 class Scope(StrEnum):
     PROTOTYPE  = "prototype"
@@ -158,14 +159,16 @@ languages. Each tier answers a different "which specs do I need?" question:
 | `domain` | Vultron / CVD protocol: language-agnostic | embargo lifecycle, AS2 semantics |
 | `language` | Python ecosystem: any Python project | pydantic, py_trees API, pytest |
 | `implementation` | This specific codebase: paths, class names, tooling | `vultron/core/` layout, notes schema |
+| `dev-process` | This project's development and maintenance process | skill workflows, history management, spec conventions |
 
 **Portability use cases:**
 
-- Implementing Vultron in Python → all five tiers
+- Implementing Vultron in Python → `general` + `pattern` + `domain` + `language` + `implementation`
 - Implementing Vultron in another language → `general` + `pattern` + `domain`
 - Different domain, same Python / BT / hexagonal stack → `general` + `pattern` + `language`
 - BT / hexagonal wisdom, any language → `general` + `pattern`
 - Universal wisdom only → `general`
+- Contributing to this project → all six tiers (include `dev-process`)
 
 `kind` is inheritable: required at `SpecFile` level, optional override at
 `SpecGroup` and individual spec level. Effective kind resolves as

--- a/specs/bugfix-workflow.yaml
+++ b/specs/bugfix-workflow.yaml
@@ -5,7 +5,7 @@ description: >-
   of discovered issues, and lifecycle archiving of completed bug fixes. IDEA-26042202 (bug
   archiving)
 version: 1.0.0
-kind: general
+kind: dev-process
 scope:
 - prototype
 - production

--- a/specs/build-workflow.yaml
+++ b/specs/build-workflow.yaml
@@ -13,7 +13,7 @@ description: >-
   queue, what must not go there, file naming and format, how `learn`
   processes and archives entries, and the `learning` history entry type.
 version: 2.0.0
-kind: pattern
+kind: dev-process
 scope:
   - prototype
   - production

--- a/specs/docs-build-workflow.yaml
+++ b/specs/docs-build-workflow.yaml
@@ -8,7 +8,7 @@ description: >
   `.github/workflows/demo-integration.yml` (demo container integration tests,
   specified in `specs/demo-ci.yaml`).
 version: 1.0.0
-kind: general
+kind: implementation
 scope:
   - prototype
   - production

--- a/specs/history-management.yaml
+++ b/specs/history-management.yaml
@@ -6,7 +6,7 @@ description: >-
   pattern with per-entry write-once files organized by month and type under
   `plan/history/`, managed by the `append-history` CLI tool.
 version: 1.2.0
-kind: pattern
+kind: dev-process
 scope:
   - prototype
   - production

--- a/specs/inbox-pipeline.yaml
+++ b/specs/inbox-pipeline.yaml
@@ -9,7 +9,7 @@ description: >-
   global in `inbox_handler.py` is unchanged; `InboxPipeline` is a parallel
   surface for tests and future adapter variants.
 version: 1.0.0
-kind: domain
+kind: implementation
 scope:
 - prototype
 - production

--- a/specs/meta-specifications.yaml
+++ b/specs/meta-specifications.yaml
@@ -3,7 +3,7 @@ title: Meta-Specification Style Guide
 description: Normative rules for authoring specification files in this project. Covers file structure, requirement format,
   IDs, writing rules, cross-references, lifecycle, quality criteria, and the delineation between spec files and ADRs.
 version: 1.0.0
-kind: general
+kind: dev-process
 scope:
 - prototype
 - production

--- a/specs/parallel-development.yaml
+++ b/specs/parallel-development.yaml
@@ -8,7 +8,7 @@ description: >-
   agentic-readiness.yaml (AR), which covers making the Vultron protocol code
   itself integrable with external agentic tools.
 version: 1.0.0
-kind: pattern
+kind: dev-process
 scope:
   - prototype
   - production

--- a/specs/spec-registry.yaml
+++ b/specs/spec-registry.yaml
@@ -84,7 +84,7 @@ groups:
       `refines`, `derives_from`, `verifies`, `part_of`, `constrains`.'
   - id: SR-02-005
     priority: MUST
-    statement: '`SpecKind` MUST include all five portability tiers: `general`, `pattern`, `domain`, `language`, `implementation`.'
+    statement: '`SpecKind` MUST include all six portability tiers: `general`, `pattern`, `domain`, `language`, `implementation`, `dev-process`.'
   - id: SR-02-006
     priority: MUST
     statement: '`Scope` MUST include: `prototype`, `production`.'

--- a/specs/state-machine.yaml
+++ b/specs/state-machine.yaml
@@ -13,7 +13,7 @@ description: >-
   `behavior-tree-integration.md` BT-06 (BT-driven transitions), `handler-protocol.md` HP-00
   (activities as state-change notifications), `vultron-protocol-spec.md` VP-01 through VP-13
 version: 1.0.0
-kind: language
+kind: domain
 scope:
 - prototype
 - production

--- a/specs/structured-logging.yaml
+++ b/specs/structured-logging.yaml
@@ -5,7 +5,7 @@ description: >-
   audit trail. **Consolidates**: `observability.md` (OB-01, OB-03, OB-04, OB-06), `error-handling.md`
   (EH-04, EH-06), `inbox-endpoint.md` (IE-09)
 version: 1.0.0
-kind: pattern
+kind: general
 scope:
 - prototype
 - production

--- a/specs/traceability.yaml
+++ b/specs/traceability.yaml
@@ -4,7 +4,7 @@ description: >-
   Requirements for maintaining the traceability matrix that maps user stories to specification
   requirements. `docs/topics/user_stories/`
 version: 1.0.0
-kind: general
+kind: implementation
 scope:
 - prototype
 - production

--- a/vultron/metadata/specs/schema.py
+++ b/vultron/metadata/specs/schema.py
@@ -52,7 +52,7 @@ class RelationType(StrEnum):
 class SpecKind(StrEnum):
     """Portability tier for a spec requirement (SR-02-005).
 
-    The five tiers form a portability hierarchy.  Use them to filter which
+    The six tiers form a portability hierarchy.  Use them to filter which
     specs apply to your project:
 
     - ``general``        — Universal: any project, any language.
@@ -61,7 +61,7 @@ class SpecKind(StrEnum):
     - ``pattern``        — Architectural / framework approach: language-agnostic
                            and not CVD-specific.
                            Examples: hexagonal architecture, BT composability,
-                           event-driven dispatch, structured logging format.
+                           event-driven dispatch.
     - ``domain``         — Vultron / CVD protocol: language-agnostic.
                            Examples: embargo lifecycle, case management, AS2
                            semantics, MPCVD state machines.
@@ -71,14 +71,18 @@ class SpecKind(StrEnum):
     - ``implementation`` — This specific codebase.
                            Examples: file paths under ``vultron/``, class names
                            in ``vultron/core/``, notes frontmatter schema.
+    - ``dev-process``    — This project's development and maintenance process.
+                           Examples: skill workflows, history management,
+                           spec authoring conventions, parallel agentic dev.
 
     Portability use cases
     ~~~~~~~~~~~~~~~~~~~~~
-    - Implementing Vultron in Python          → all five tiers
+    - Implementing Vultron in Python          → general + pattern + domain + language + implementation
     - Implementing Vultron in another language → general + pattern + domain
     - Different domain, Python/BT/hex stack   → general + pattern + language
     - BT / hexagonal wisdom, any language      → general + pattern
     - Universal wisdom only                    → general
+    - Contributing to this project            → all six tiers (include dev-process)
     """
 
     GENERAL = "general"
@@ -86,6 +90,7 @@ class SpecKind(StrEnum):
     DOMAIN = "domain"
     LANGUAGE = "language"
     IMPLEMENTATION = "implementation"
+    DEV_PROCESS = "dev-process"
 
 
 class Scope(StrEnum):


### PR DESCRIPTION
## Summary

- Adds `dev-process` as a sixth `SpecKind` portability tier, for specs that govern this project's development and maintenance process (skills, workflows, tooling conventions) — distinct from `implementation` (Vultron protocol code) and `pattern` (portable architectural approaches).
- Reclassifies 10 spec files whose `kind` did not accurately reflect their portability tier.
- Updates the enum definition in `vultron/metadata/specs/schema.py`, the requirement in `specs/spec-registry.yaml` (SR-02-005), and the reference table in `notes/archived_notes/spec-registry.md`.

## Reclassifications

| File | From | To | Reason |
|---|---|---|---|
| `state-machine` | `language` | `domain` | CVD protocol state machines, not Python-specific |
| `inbox-pipeline` | `domain` | `implementation` | Names specific module internals; Python testability shim |
| `docs-build-workflow` | `general` | `implementation` | Names repo-specific GHA file paths |
| `traceability` | `general` | `implementation` | Names `notes/user-stories-trace.md` specifically |
| `history-management` | `pattern` | `dev-process` | Describes `plan/history/` and `append-history` tooling |
| `build-workflow` | `pattern` | `dev-process` | Describes `plan/incoming/learnings/` and skill lifecycle |
| `meta-specifications` | `general` | `dev-process` | Normative rules for this project's spec format |
| `bugfix-workflow` | `general` | `dev-process` | Agent skill with `append-history` lifecycle |
| `parallel-development` | `pattern` | `dev-process` | Repo-specific issue/label/skill conventions |
| `structured-logging` | `pattern` | `general` | Universal operational hygiene, not architecture-specific |

## Test plan

- [ ] Pre-commit spec registry linter passes (verified locally — all hooks green)
- [ ] No spec YAML files have `kind` values outside the updated enum

🤖 Generated with [Claude Code](https://claude.com/claude-code)