### PR TITLE
docs: plan issue #1336 — _read_suggested_roles() silent override

### DIFF
--- a/plan/history/2607/learning/CONCERN-1336.md
+++ b/plan/history/2607/learning/CONCERN-1336.md
@@ -1,0 +1,29 @@
+---
+source: CONCERN-1336
+timestamp: '2026-07-13T19:56:13.912484+00:00'
+title: _read_suggested_roles() silently substitutes default for intentional empty
+  role list
+type: learning
+---
+
+`EmitOfferCaseParticipantToOwnerNode._read_suggested_roles()` uses the guard
+`if isinstance(roles, list) and roles:` — treating an empty list as "absent"
+and substituting `[CVDRole.VENDOR]`. This is safe for the current prototype
+where `EvaluateDefaultRolesNode` always writes a non-empty list (CM-16-003
+requires `suggested_roles` to be non-empty), but creates a silent override
+hazard for future Evaluator implementations.
+
+**Risk scenario**: A future Evaluator evaluates that no default role can be
+determined and intentionally writes `suggested_roles = []` to signal "caller
+should prompt the Case Owner for roles rather than pre-populating." The
+substitution fallback would silently override this signal with
+`[CVDRole.VENDOR]`, defeating the intended semantics.
+
+**Resolution**: Option 1 — enforce non-empty at write time in
+`EvaluateDefaultRolesNode` (returns FAILURE if computed list is empty) per
+ADR-0032/BT-HELPER-01. CM-16-003 spec amended to clarify MUST (non-empty
+list), SHOULD (use VENDOR), MAY (use OTHER for unclassifiable actors).
+
+**Resolved**: 2026-07-13 — implementation tracked in #1383.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1382>.
+Spec: `specs/case-management.yaml` CM-16-003.

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -771,13 +771,26 @@ groups:
   - id: CM-16-003
     priority: MUST
     statement: >-
-      After recording the received `Offer(Actor)`, the CaseActor MUST assign default
-      roles for the suggested actor (defaulting to `[CVDRole.VENDOR]`) via an Evaluator
-      BT node that can be overridden by configuration or by the Case Owner at accept time.
+      After recording the received `Offer(Actor)`, the CaseActor MUST assign a
+      non-empty default role list for the suggested actor via an Evaluator BT node
+      (ADR-0024 shape: Evaluator). The Evaluator MUST return FAILURE if it cannot
+      produce a non-empty role list, preventing a silent substitution of an
+      unintended default by the downstream consumer node (see CONCERN-1336).
+      The default role SHOULD be `[CVDRole.VENDOR]` for actors whose type cannot
+      be determined from context. The default MAY be `[CVDRole.OTHER]` when the
+      Evaluator can determine that the actor does not fit any known CVD role but
+      still requires case membership (e.g., a security researcher with no vendor
+      affiliation). The Evaluator output MAY be overridden by configuration or by
+      the Case Owner at accept time.
     note: >-
       The Evaluator node is a call-out point (ADR-0025 abstraction; ADR-0024 shape: Evaluator) that MAY be
-      replaced by a more sophisticated role-inference implementation in future. The
-      default of VENDOR is the most conservative choice for an unknown actor.
+      replaced by a more sophisticated role-inference implementation in future.
+      The non-empty invariant MUST be enforced at write time (ADR-0032 BT-HELPER-01):
+      the Evaluator node returns FAILURE rather than writing an empty list,
+      so the downstream consumer never needs to treat empty as a sentinel.
+      The VENDOR default is the most conservative useful starting point for an
+      unknown actor; OTHER is the correct signal when actor type is genuinely
+      unclassifiable.
   - id: CM-16-004
     priority: MUST
     statement: >-

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -774,23 +774,28 @@ groups:
       After recording the received `Offer(Actor)`, the CaseActor MUST assign a
       non-empty default role list for the suggested actor via an Evaluator BT node
       (ADR-0024 shape: Evaluator). The Evaluator MUST return FAILURE if it cannot
-      produce a non-empty role list, preventing a silent substitution of an
-      unintended default by the downstream consumer node (see CONCERN-1336).
-      The default role SHOULD be `[CVDRole.VENDOR]` for actors whose type cannot
-      be determined from context. The default MAY be `[CVDRole.OTHER]` when the
-      Evaluator can determine that the actor does not fit any known CVD role but
-      still requires case membership (e.g., a security researcher with no vendor
-      affiliation). The Evaluator output MAY be overridden by configuration or by
-      the Case Owner at accept time.
+      produce a non-empty role list; the downstream consumer node MUST NOT silently
+      substitute a default for an empty list written by the Evaluator (ADR-0032
+      BT-HELPER-01).
     note: >-
-      The Evaluator node is a call-out point (ADR-0025 abstraction; ADR-0024 shape: Evaluator) that MAY be
-      replaced by a more sophisticated role-inference implementation in future.
-      The non-empty invariant MUST be enforced at write time (ADR-0032 BT-HELPER-01):
-      the Evaluator node returns FAILURE rather than writing an empty list,
-      so the downstream consumer never needs to treat empty as a sentinel.
-      The VENDOR default is the most conservative useful starting point for an
-      unknown actor; OTHER is the correct signal when actor type is genuinely
-      unclassifiable.
+      The Evaluator node is a call-out point (ADR-0025 abstraction; ADR-0024 shape:
+      Evaluator) that MAY be replaced by a more sophisticated role-inference
+      implementation in future. The non-empty invariant is enforced at write time so
+      the downstream consumer never needs to treat empty as a sentinel.
+  - id: CM-16-011
+    priority: SHOULD
+    statement: >-
+      The default role list SHOULD be `[CVDRole.VENDOR]` for actors whose type cannot
+      be determined from context. VENDOR is the most conservative useful starting point
+      for an unknown actor.
+  - id: CM-16-012
+    priority: MAY
+    statement: >-
+      The default role list MAY be `[CVDRole.OTHER]` when the Evaluator can determine
+      that the suggested actor does not fit any known CVD role but still requires case
+      membership (e.g., a security researcher with no vendor affiliation).
+      The Evaluator output MAY be overridden by configuration or by the Case Owner at
+      accept time.
   - id: CM-16-004
     priority: MUST
     statement: >-

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -805,10 +805,10 @@ groups:
       or by the Case Owner at accept time when the Case Owner selects different
       roles for the suggested participant.
     rationale: >-
-      The Evaluator is a prototype stub (CM-16-003); its output is a starting
-      point, not a binding decision. Configuration-driven overrides allow
-      operators to tune defaults without replacing the Evaluator node. Case Owner
-      overrides preserve human authority over final role assignments.
+      The Case Owner has ultimate authority over who participates in their case
+      and in what role. The Evaluator's output is a suggested starting point to
+      reduce friction, not a binding decision. The Case Owner can always update
+      role assignments to whatever they determine is appropriate.
   - id: CM-16-004
     priority: MUST
     statement: >-

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -781,19 +781,22 @@ groups:
       The Evaluator node is a call-out point (ADR-0025 abstraction; ADR-0024 shape:
       Evaluator) that MAY be replaced by a more sophisticated role-inference
       implementation in future. The non-empty invariant is enforced at write time so
-      the downstream consumer never needs to treat empty as a sentinel.
+      the downstream consumer never needs to treat an empty list as a sentinel.
+      See CM-16-011 and CM-16-012 for the recommended and permitted default values.
   - id: CM-16-011
     priority: SHOULD
     statement: >-
       The default role list SHOULD be `[CVDRole.VENDOR]` for actors whose type cannot
-      be determined from context. VENDOR is the most conservative useful starting point
-      for an unknown actor.
+      be determined from context, because in CVD cases the most likely role for a
+      newly added participant is Vendor.
   - id: CM-16-012
     priority: MAY
     statement: >-
       The default role list MAY be `[CVDRole.OTHER]` when the Evaluator can determine
       that the suggested actor does not fit any known CVD role but still requires case
       membership (e.g., a security researcher with no vendor affiliation).
+      `CVDRole.OTHER` is the most conservative choice because it makes no assumption
+      about the actor's function in the CVD process.
       The Evaluator output MAY be overridden by configuration or by the Case Owner at
       accept time.
   - id: CM-16-004

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -797,8 +797,18 @@ groups:
       membership (e.g., a security researcher with no vendor affiliation).
       `CVDRole.OTHER` is the most conservative choice because it makes no assumption
       about the actor's function in the CVD process.
-      The Evaluator output MAY be overridden by configuration or by the Case Owner at
-      accept time.
+  - id: CM-16-013
+    priority: MAY
+    statement: >-
+      The Evaluator's default role assignment MAY be overridden by actor-level
+      configuration (e.g., a policy that maps known actor URIs to specific roles)
+      or by the Case Owner at accept time when the Case Owner selects different
+      roles for the suggested participant.
+    rationale: >-
+      The Evaluator is a prototype stub (CM-16-003); its output is a starting
+      point, not a binding decision. Configuration-driven overrides allow
+      operators to tune defaults without replacing the Evaluator node. Case Owner
+      overrides preserve human authority over final role assignments.
   - id: CM-16-004
     priority: MUST
     statement: >-


### PR DESCRIPTION
- Closes #1336

## Summary

Plans CONCERN-1336: `EmitOfferCaseParticipantToOwnerNode._read_suggested_roles()`
silently substitutes `[CVDRole.VENDOR]` for an intentional empty role list written
by a future Evaluator implementation.

Splits CM-16-003 into four focused spec rules and adds the non-empty invariant
enforcement requirement (ADR-0032 BT-HELPER-01).

## Changes

- `specs/case-management.yaml`:
  - **CM-16-003** (MUST, amended): Evaluator MUST assign a non-empty role list and
    MUST return FAILURE if it cannot; downstream consumer MUST NOT silently
    substitute a default for an empty list (ADR-0032 BT-HELPER-01)
  - **CM-16-011** (SHOULD, new): default role SHOULD be `[CVDRole.VENDOR]` —
    most likely role for a newly added participant in a CVD case
  - **CM-16-012** (MAY, new): default MAY be `[CVDRole.OTHER]` when the actor
    does not fit any known CVD role — most conservative because it makes no
    assumption about the actor's function
  - **CM-16-013** (MAY, new): Evaluator default MAY be overridden by
    configuration or by the Case Owner — the Case Owner has ultimate authority
    over participation and role assignments