### PR TITLE
docs: plan issue #1349 — namespace participant-add blackboard keys

### DIFF
--- a/notes/bt-integration.md
+++ b/notes/bt-integration.md
@@ -1559,7 +1559,13 @@ cleaned up and rewritten before being read (e.g., within a single Sequence with
 `memory=False`) are safe, but namespacing eliminates the risk entirely and
 is cheap to implement.
 
-**First concrete instance**: `suggested_roles` in
-`create_recommend_actor_to_case_received_tree` — discovered in CONCERN-1335.
-Renamed to `suggested_roles_{recommendation_id_segment}` in issue #1335's
-implementation task.
+**Known instances** (catalogue for conformance audits):
+
+| Key(s) | Tree factory | Correlation ID | Discovered |
+|---|---|---|---|
+| `suggested_roles` | `create_recommend_actor_to_case_received_tree` | `recommendation_id` | CONCERN-1335 |
+| `new_case_participant`, `participant_case`, `new_participant_id` | `create_receive_report_case_tree` / `create_case_tree` | `report_id` | CONCERN-1349 |
+
+When auditing for compliance, grep for flat blackboard key registrations in
+tree factories called per-incoming-message and verify each inter-node handoff
+key includes the execution-scoped correlation ID segment.

--- a/notes/bt-integration.md
+++ b/notes/bt-integration.md
@@ -1564,7 +1564,7 @@ is cheap to implement.
 | Key(s) | Tree factory | Correlation ID | Discovered |
 |---|---|---|---|
 | `suggested_roles` | `create_recommend_actor_to_case_received_tree` | `recommendation_id` | CONCERN-1335 |
-| `new_case_participant`, `participant_case`, `new_participant_id` | `create_receive_report_case_tree` / `create_case_tree` | `report_id` | CONCERN-1349 |
+| `new_case_participant`, `participant_case`, `new_participant_id` | `create_receive_report_case_tree` | `report_id` | CONCERN-1349 |
 
 When auditing for compliance, grep for flat blackboard key registrations in
 tree factories called per-incoming-message and verify each inter-node handoff

--- a/plan/history/2607/learning/CONCERN-1349.md
+++ b/plan/history/2607/learning/CONCERN-1349.md
@@ -1,0 +1,37 @@
+---
+source: CONCERN-1349
+timestamp: '2026-07-13T20:23:40.599054+00:00'
+title: 'concern: new_case_participant / participant_case / new_participant_id blackboard
+  keys are un-namespaced in participant_add/owner nodes'
+type: learning
+---
+
+## Summary
+
+`vultron/core/behaviors/case/nodes/participant/participant_add.py` and
+`owner.py` use flat blackboard keys `new_case_participant`, `participant_case`,
+and `new_participant_id` as inter-node handoffs within the participant-add
+subtree. These keys are not namespaced by an execution-scoped ID.
+
+Like `suggested_roles` (CONCERN-1335), these keys would collide if two
+`create_receive_report_case_tree` executions ran concurrently — e.g., if two
+`Offer(VulnerabilityReport)` messages arrived simultaneously. This tree fires
+on every incoming report submission, making the collision frequency higher
+than for the suggest-actor workflow.
+
+## Current status
+
+Latent today — the BTBridge `RLock` serializes all BT executions within a
+single process. Becomes a live data-corruption hazard if:
+
+- Actor-level parallelism or async delivery is introduced
+- Multiple parallel report submissions are processed concurrently
+
+## Proposed resolution
+
+Namespace the three keys by `report_id` segment (already available in the
+blackboard and as a constructor arg for most nodes in this subtree).
+
+**Resolved**: 2026-07-13 — implementation tracked in #1397.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1396>.
+Notes: `notes/bt-integration.md` § "Namespaced Inter-Node Handoff Keys".


### PR DESCRIPTION
- Closes #1349

## Summary

Plans CONCERN-1349 by extending `notes/bt-integration.md` with a known-instances
catalogue for the "Namespaced Inter-Node Handoff Keys" pattern. The three
un-namespaced blackboard keys (`new_case_participant`, `participant_case`,
`new_participant_id`) in the participant-add subtree are catalogued alongside
the existing `suggested_roles` entry from CONCERN-1335.

## Changes

- `notes/bt-integration.md`: replaced single "first concrete instance" sentence
  with a two-row table listing both known inter-node handoff key sites and a
  conformance audit guidance paragraph