### PR TITLE
docs: add completeness doctrine and apply across all workflow skills

### DIFF
--- a/.agents/skills/bugfix/SKILL.md
+++ b/.agents/skills/bugfix/SKILL.md
@@ -105,6 +105,9 @@ templates and escalation patterns.
 
 ## Phase 3 — Implement
 
+See `.claude/skills/shared/completeness-doctrine.md` for the project standard
+on what "done" means — loaded by `orient-agent` in Phase 1.
+
 Once shared understanding is confirmed, invoke `deepen-context` with
 focus hints from Phase 2 (e.g., `"wire layer"`, `"BT integration"`), then:
 
@@ -112,10 +115,18 @@ focus hints from Phase 2 (e.g., `"wire layer"`, `"BT integration"`), then:
    bug exists as understood. Do not assume; confirm via code search.
 
 2. **Reproduce with a Failing Test** — Add or modify a test that fails due to
-   the bug. Confirm the test fails before implementing the fix.
+   the bug. Confirm the test fails before implementing the fix. A bug fix
+   without a regression test is not a bug fix.
 
-3. **Implement the Fix** — Modify only the code required to resolve the bug.
-   Follow all project conventions.
+   **Regression test exception**: if test infrastructure cost is genuinely
+   disproportionate (requires long-running infrastructure or complex setup far
+   exceeding the fix's scope), skip the test but create a follow-up GitHub Bug
+   issue explaining the specific reason. Do not silently omit the test.
+
+3. **Fix the Root Cause** — Fix what actually caused the bug, not just the
+   symptom. If the root cause is provably out of scope, fix the symptom anyway
+   but create a Bug issue for the root cause before closing this one. Never
+   ship a symptom-only fix without documenting the underlying cause.
 
 4. **Iterate** — Invoke `format-code`, `run-linters`, `run-tests`; refine
    until all relevant tests pass.

--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -162,11 +162,29 @@ Invoke `deepen-context` with focus hints derived from the issue body
 
 ### Phase 5 — Implement
 
-1. Implement only the selected task.
-2. Follow project conventions; keep the change focused.
-3. Add or update tests for new or changed behavior.
+See `.claude/skills/shared/completeness-doctrine.md` for the project standard
+on what "done" means — loaded by `orient-agent` in Phase 1.
+
+1. Implement the full intent of the selected task, not just the happy path.
+   Edge cases, error handling, and type correctness are part of the task, not
+   optional add-ons.
+2. Follow project conventions. "Keep the change focused" means do not expand
+   into adjacent unscoped work — it does not mean implement less than the task
+   requires.
+3. Add or update tests for every new or changed behavior. A behavior with no
+   test is not done.
 4. Reuse existing helpers and keep the implementation DRY.
 5. Sub-agents may help, but main-agent validation is mandatory.
+
+**Scope expansion judgment:** If implementing this task reveals adjacent work
+that clearly belongs with it, apply the following:
+
+- Would it require a new GitHub issue, a design decision, or an irreversible
+  change? → Ask the user if present. If unattended, make the best-judgment
+  call, record the rationale as a learning file in `plan/incoming/learnings/`,
+  and continue.
+- Trivially additive (clearly-missing test, obvious type annotation fix)?
+  → Just do it.
 
 ### Phase 6 — Validate
 
@@ -199,8 +217,20 @@ Invoke `deepen-context` with focus hints derived from the issue body
 ### Phase 7 — Pre-PR Code Review
 
 Invoke the `code-review` agent against the current branch diff vs `main`.
-Findings are tagged `[BLOCKING]` (fix before continuing) or `[ADVISORY]`
-(log in PR comment after opening).
+
+Findings use the three-category system from
+`.claude/skills/shared/completeness-doctrine.md`:
+
+- **FAIL** — broken, spec violated, changed behavior untested → fix before
+  the PR opens
+- **IMPROVE** — correct but incomplete → fix in this session, document in the
+  PR body
+- **DEFER** — genuinely out of scope → requires creating a follow-up GitHub
+  issue immediately; surface to the user for acknowledgment; do not defer
+  unilaterally
+
+There is no "ADVISORY" category that can be logged and forgotten. Every
+finding is either fixed here or gated via DEFER.
 
 Because this phase runs before the final commit, `git diff main...HEAD` may
 be empty if changes are unstaged. Stage all changed files first (`git add`),

--- a/.agents/skills/learn/SKILL.md
+++ b/.agents/skills/learn/SKILL.md
@@ -114,6 +114,9 @@ that the cost of a full scan is justified on every invocation.
 
 ### Phase 2 — Analyze Gaps
 
+See `.claude/skills/shared/completeness-doctrine.md` for the project standard
+on what constitutes a complete lesson — loaded by `orient-agent` in Phase 1.
+
 Identify what the build process and codebase scan have surfaced that is not
 yet captured in durable docs. Consider both incoming learning files and
 open GitHub Concern issues:
@@ -128,6 +131,12 @@ open GitHub Concern issues:
 6. Recent completed-task insights — when needed, run `uv run show-history
    --month YYMM` to identify which history entries contain architectural
    lessons, then open those entry files.
+
+A lesson is not complete until it has been promoted to `specs/`, `notes/`, or
+`AGENTS.md`. An incoming learning file that is archived without producing a
+durable output is a wasted lesson. If a learning entry clearly warrants a spec
+or notes update but one cannot be written in this session, document why and
+create a Concern issue — do not silently archive the entry without promotion.
 
 ### Phase 3 — Interview with Grill-Me
 

--- a/.agents/skills/orient-agent/SKILL.md
+++ b/.agents/skills/orient-agent/SKILL.md
@@ -3,10 +3,11 @@ name: orient-agent
 description: >
   Load the always-required baseline context before any implementation,
   planning, or documentation work. Reads the glossary, loads all specs,
-  reads AGENTS.md, notes/README.md, and docs/adr/index.md, reads
-  plan/incoming/learnings/, and queries Project #24 for Schedule=Now items.
-  Run this at the start of every workflow skill before selecting or
-  reading a specific issue. Replaces study-project-docs Phase A.
+  reads AGENTS.md, the completeness doctrine, notes/README.md, and
+  docs/adr/index.md, reads plan/incoming/learnings/, and queries Project
+  #24 for Schedule=Now items. Run this at the start of every workflow
+  skill before selecting or reading a specific issue. Replaces
+  study-project-docs Phase A.
 ---
 
 # Skill: Orient Agent
@@ -25,11 +26,13 @@ Read `docs/reference/glossary.md` first to establish domain vocabulary.
 Run `uv run spec-dump 2>&1`. Capture the output. Do **not** read raw
 `specs/*.yaml` files directly.
 
-### Step 3 — Read agent rules, active notes index, and ADR index
+### Step 3 — Read agent rules, completeness doctrine, active notes index, and ADR index
 
 Read in parallel:
 
 - `AGENTS.md` — agent rules, conventions, and pitfalls
+- `.claude/skills/shared/completeness-doctrine.md` — project quality standard;
+  governs what "done" means for every implementation, review, and learning task
 - `notes/README.md` — index of active design notes (do not read individual
   notes files here; use `deepen-context` for task-specific notes)
 - `docs/adr/index.md` — overview of all ADRs (accepted, proposed, rejected,

--- a/.agents/skills/plan-issue/SKILL.md
+++ b/.agents/skills/plan-issue/SKILL.md
@@ -127,7 +127,11 @@ via `ask_user`, providing a recommendation for each.
 
 1. **Scope** — What is in scope? What is explicitly out of scope?
 2. **Acceptance criteria** — How do we verify this is fully addressed?
-   Drive one GitHub issue per distinct AC cluster.
+   Drive one GitHub issue per distinct AC cluster. Be exhaustive: if an
+   acceptance criterion is clearly needed but missing from the issue, add
+   it here. Do not produce a plan that leaves obvious ACs out simply
+   because the issue didn't spell them out. Deferring a clearly-needed AC
+   requires explicit user acknowledgment.
 3. **ADR determination** — Apply the `notes/specs-vs-adrs.md` decision tree
    (MS-11-001 through MS-11-006). Form a recommendation with reasoning.
    Present for approval before proceeding.

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -5,12 +5,32 @@ description: >
   a PR addresses its originating GitHub issue(s), conforms to Vultron specs
   and notes, follows AGENTS.md coding rules and naming conventions, has
   adequate test coverage, and passes linting requirements. Produces a
-  structured PASS/WARN/FAIL report and optionally posts it as a GitHub PR
-  review comment. Use when the user asks to review a PR, validate a PR
-  before merge, or audit a PR against project standards.
+  structured PASS/FAIL/IMPROVE/DEFER report, attempts fixes for FAIL and
+  IMPROVE findings, and posts results as a GitHub PR review comment. Use
+  when the user asks to review a PR, validate a PR before merge, or audit
+  a PR against project standards.
 ---
 
 # Skill: PR Review
+
+## Finding Severity
+
+This skill uses the three-category system from
+`.claude/skills/shared/completeness-doctrine.md` (loaded by `orient-agent`).
+There is no WARN category — every finding is resolved here or explicitly gated.
+
+| Verdict | Meaning | Required action |
+|---|---|---|
+| **FAIL** | Broken: won't work correctly, spec violated, changed behavior untested | Fix before the PR merges |
+| **IMPROVE** | Works but incomplete: missing adjacent test, stale doc, extractable helper, obvious gap in scope | Fix in this session; document in a follow-up commit and PR comment |
+| **DEFER** | Genuinely out of scope | Create a follow-up GitHub issue immediately; surface to user for acknowledgment; do not defer unilaterally |
+
+For FAIL and IMPROVE findings that are within reach: attempt the fix in the
+same session, then commit the changes and note them in a PR comment so the
+history is clear. Do not just flag and stop.
+
+DEFER is a high gate — use it only when fixing would require touching code
+substantially outside the files already changed in this PR.
 
 ## Quick Start
 
@@ -74,7 +94,8 @@ checklist. Pay particular attention to:
 2. For each signal, consult `notes/specs-vs-adrs.md` (MS-11-001–MS-11-006)
    to determine if an ADR was warranted.
 3. Check `docs/adr/index.md` for a relevant existing ADR:
-   - If the PR *should have* an ADR and none is referenced: **WARN**.
+   - If the PR *should have* an ADR and none is referenced: **IMPROVE** — draft
+     the ADR stub or add it to the PR before merging.
    - If an existing ADR is contradicted by the change without amendment: **FAIL**.
    - If a new ADR was added: verify it follows `docs/adr/_adr-template.md`.
 
@@ -92,8 +113,8 @@ against the branch diff to surface bugs, logic errors, and security issues.
 
 1. **Notes currency**: Identify `notes/*.md` files that cover any domain
    touched by the PR (cross-reference domain hints from Phase 4). If an
-   active note exists for a changed domain and was NOT updated: **WARN** —
-   the note may now contain stale guidance.
+   active note exists for a changed domain and was NOT updated: **IMPROVE** —
+   update the note before merging; stale guidance is a real cost.
 2. **Notes frontmatter**: For any `notes/*.md` file modified in the PR,
    validate YAML frontmatter per NF-06-001/NF-06-002:
    - Required fields: `title`, `status`
@@ -117,11 +138,22 @@ against the branch diff to surface bugs, logic errors, and security issues.
 2. If CI is failing, summarize which checks fail.
 3. If CI is not yet run, note that lint/type verification is pending.
 
-### Phase 12 — Report and (Optional) Post
+### Phase 12 — Fix, Report, and Post
 
-1. Produce a structured report grouped by phase, with **PASS / WARN / FAIL**
-   for each area. See [REFERENCE.md](REFERENCE.md) § "Report Format".
-2. Ask the user whether to post the report as a GitHub PR review comment:
+1. For all **FAIL** and **IMPROVE** findings that are within reach: attempt the
+   fix now, before generating the report. Commit the changes. The PR history
+   must show that the review finding was addressed, not just noted.
+
+2. For **DEFER** findings: create the follow-up GitHub issue immediately, then
+   surface each deferred item to the user for acknowledgment before posting the
+   review.
+
+3. Produce a structured report grouped by phase, with **PASS / FAIL / IMPROVE /
+   DEFER** for each area. See [REFERENCE.md](REFERENCE.md) § "Report Format".
+   For any finding that was fixed in step 1, mark it as `FIXED` in the report
+   with the commit reference.
+
+4. Ask the user whether to post the report as a GitHub PR review comment:
    - If yes: `gh pr review <number> --comment --body "<report>"`
    - If yes + approve: `gh pr review <number> --approve --body "<report>"`
    - If yes + request changes: `gh pr review <number> --request-changes --body "<report>"`

--- a/.agents/skills/shared/README.md
+++ b/.agents/skills/shared/README.md
@@ -1,7 +1,15 @@
-# Shared Skill Scripts
+# Shared Skill Resources
 
-Reusable shell scripts referenced by multiple skills. Each script is
-self-contained and executable.
+Shared scripts and reference documents referenced by multiple skills.
+
+## Reference Documents
+
+| File | Purpose | Loaded by |
+|---|---|---|
+| `completeness-doctrine.md` | Project quality standard: what "done" means, finding severity taxonomy (FAIL/IMPROVE/DEFER), scope expansion rules | `orient-agent` Step 3 — in context for every workflow |
+| `pr-body-guide.md` | PR body templates and formatting rules | `build`, `bugfix`, `plan-issue` |
+
+## Scripts
 
 | Script | Purpose | Usage |
 |---|---|---|

--- a/.agents/skills/shared/completeness-doctrine.md
+++ b/.agents/skills/shared/completeness-doctrine.md
@@ -1,0 +1,81 @@
+# Completeness Doctrine
+
+**Boil the lake, not the ocean.**
+
+Complete what is in front of you — thoroughly, with tests, with edge cases
+handled, with documentation current. Do not unilaterally expand into adjacent
+work that was not scoped here. There will be other lakes.
+
+## What "Done" Means
+
+A task is not done until:
+
+- All changed behaviors have tests (unit and/or integration)
+- All edge cases the implementation touches are handled, not deferred
+- Type annotations and docstrings are current with the new behavior
+- Linters pass clean (no `# type: ignore` or `# noqa` added without justification)
+- Specs, notes, and AGENTS.md are consistent with the new behavior
+
+A happy-path-only implementation is not done. A behavior with no test is not
+done. A changed interface with a stale type annotation is not done.
+
+## Depth vs. Scope Expansion
+
+**Depth** (within the current task's scope) is **never optional**. Do not
+offer to "come back to" edge cases, missing tests, or documentation gaps that
+clearly belong to the current task. Do not leave dangling threads when tying
+them off is within reach.
+
+**Scope expansion** (adjacent work that crosses into a different issue,
+domain, or design space) requires a judgment call:
+
+| Signal | Action |
+|---|---|
+| Would require creating a new GitHub issue | Ask the user if present; make best-judgment call if unattended — record rationale as a learning file |
+| Requires a design decision about *how* it should work | Ask the user if present; make best-judgment call if unattended — record rationale as a learning file |
+| Hard to reverse (API change, schema change, spec change) | Ask the user if present; make best-judgment call if unattended — record rationale as a learning file |
+| Trivially additive (clearly-missing test, obvious type fix) | Just do it — no permission needed |
+
+When unattended: choose whatever seems most correct, document the reasoning
+explicitly in a learning file, and let the user review and override.
+
+## Finding Severity (build, pr-review, bugfix)
+
+Both FAIL and IMPROVE require action before the PR merges:
+
+| Category | Meaning | Action |
+|---|---|---|
+| **FAIL** | Broken: won't work correctly, spec violated, changed behavior untested | Fix before the PR opens or merges |
+| **IMPROVE** | Works but incomplete: missing adjacent test, stale doc, extractable helper, obvious gap in scope | Fix in the same session; document in a follow-up commit and PR comment |
+
+One exceptional category for genuinely out-of-scope work:
+
+| Category | Gate |
+|---|---|
+| **DEFER** | 1. Create a follow-up GitHub issue immediately with specific justification. 2. Get explicit user acknowledgment. No unilateral deferral. |
+
+**WARN** (flagged but no required action) does not exist in this project.
+If something is worth noting, it is worth fixing or DEFER-gating.
+
+## The Regression Test Rule (bugfix)
+
+A bug fix without a regression test is not a bug fix. The only exception:
+when test infrastructure cost is genuinely disproportionate (requires
+long-running infrastructure, complex setup far exceeding fix scope). In that
+case, create a follow-up GitHub issue explaining the specific reason. The fix
+may ship — the debt is tracked, not silently discarded.
+
+## Root Cause vs. Symptom (bugfix)
+
+Fix the root cause, not the symptom, unless the root cause is provably out of
+scope. Even then: create an issue. Never ship a symptom-only fix without
+documenting the underlying cause.
+
+## The Cost of Deferral
+
+Every deferral is a bet that future context will be as good as current context.
+That bet is usually wrong. The agent working an issue now has the most context
+it will ever have. A follow-up issue is a lossy description of that context,
+not a reliable handoff.
+
+Defer when you genuinely must. Never defer when you could just finish.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,6 +314,23 @@ If instructions are ambiguous:
 
 ---
 
+## Quality Standard
+
+Every workflow skill reads `.claude/skills/shared/completeness-doctrine.md`
+via `orient-agent`. The full doctrine is there; this is the summary:
+
+- **"Done" requires**: all changed behaviors tested, edge cases handled,
+  types/docs current, linters clean.
+- **Depth within scope is non-negotiable**: happy-path-only is not done; a
+  behavior with no test is not done.
+- **Scope expansion**: ask if user is present; make best-judgment call if not,
+  record rationale as a learning file.
+- **Finding severity**: **FAIL** (broken) → fix before PR opens. **IMPROVE**
+  (correct but incomplete) → fix in this session. **DEFER** (out of scope) →
+  create follow-up issue + get user acknowledgment. No WARN-and-defer.
+
+---
+
 ## Common Pitfalls (Lessons Learned)
 
 Key pitfall write-ups are in the `notes/` files.


### PR DESCRIPTION
## Summary

Establishes a shared quality standard ("completeness doctrine") for all
workflow skills, replacing the informal "keep the change focused" and
WARN-and-defer patterns with explicit rules for what "done" means and a
three-category finding taxonomy.

## Changes

- **`.agents/skills/shared/completeness-doctrine.md`** (new): authoritative
  quality standard — "done" definition, FAIL/IMPROVE/DEFER severity taxonomy,
  scope expansion ask-vs-decide rules, regression test exception, root-cause
  requirement
- **`.agents/skills/orient-agent/SKILL.md`**: reads doctrine in Step 3
  alongside AGENTS.md — loads it for every workflow run automatically
- **`.agents/skills/build/SKILL.md`**: Phase 5 requires full intent (not just
  happy path); Phase 7 replaces BLOCKING/ADVISORY with FAIL/IMPROVE/DEFER;
  ADVISORY no longer exists as a defer-and-forget category
- **`.agents/skills/pr-review/SKILL.md`**: adds finding severity table at
  top; retires WARN; Phase 12 attempts fixes before reporting; DEFER requires
  issue creation + user acknowledgment; WARN usages replaced with IMPROVE
- **`.agents/skills/bugfix/SKILL.md`**: regression test required with
  documented exception path; root-cause rule added
- **`.agents/skills/plan-issue/SKILL.md`**: grill-me Phase 4 requires
  exhaustive AC coverage; deferring a clearly-needed AC needs user
  acknowledgment
- **`.agents/skills/learn/SKILL.md`**: Phase 2 explicitly states that
  archiving a learning without promotion to durable docs is wrong
- **`AGENTS.md`**: new "Quality Standard" section with doctrine summary
  and pointer to the shared file
- **`.agents/skills/shared/README.md`**: adds Reference Documents table
  listing `completeness-doctrine.md` and `pr-body-guide.md`

## Verification

- All 9 modified files pass `markdownlint-cli2 --fix --config .markdownlint-cli2.yaml`
- No Python files changed; no test suite run required