### PR TITLE
docs: plan issue #1288 — document dual-path roles threading in CM-17-003

### DIFF
--- a/plan/history/2607/learning/CONCERN-1288.md
+++ b/plan/history/2607/learning/CONCERN-1288.md
@@ -1,0 +1,41 @@
+---
+source: CONCERN-1288
+timestamp: '2026-07-14T15:46:37.523583+00:00'
+title: InviteActorToCaseTriggerRequest roles field — dual-path threading
+type: learning
+---
+
+## Concern: InviteActorToCaseTriggerRequest has no roles field — invited participants always get caseRoles=[]
+
+`InviteActorToCaseTriggerRequest` (in `vultron/core/use_cases/triggers/requests.py`) has only an `invitee_id` field — there is no way to pass the intended `CVDRole` values for the new participant via the **direct trigger path**. As a result, every participant created via the `invite-actor-to-case` trigger gets `caseRoles=[]`.
+
+Confirmed in the FVV demo logs (#1265 / PR #1270): Vendor2's participant status entries throughout the run show `roles=[]` despite being invited as a vendor.
+
+> **Scope note (added 2026-07-09):** This issue covers the **direct trigger path** (`invite-actor-to-case` REST trigger → `InviteActorToCaseTriggerRequest`). The **suggest-actor path** (Recommender → CaseActor → `Offer(CaseParticipant)` → Case Owner → Accept → CaseActor → Invite) has its own roles thread, documented in CM-16-003 and tracked by #1300. #1288 must be implemented *after* #1300 so that `EmitInviteActorToCaseNode` already supports reading roles from the blackboard (set by either path) before the trigger-path roles injection is added.
+
+## Root cause
+
+`InviteActorToCaseTriggerRequest`:
+
+```python
+class InviteActorToCaseTriggerRequest(CaseTriggerRequest):
+    invitee_id: NonEmptyString
+    # no roles field
+```
+
+`invite_actor_to_case_trigger_bt` → `EmitInviteActorToCaseNode` constructs the `RmInviteToCaseActivity` without role information. On the received side, `CreateInviteeParticipantAtAcceptedNode` creates the `CaseParticipant` from whatever roles were embedded in the Invite wire object — which is empty.
+
+## Impact
+
+- All directly-triggered invites produce participants with no CVD roles, breaking AC-2 of #1265 ("all three actors have correct CVDRole values")
+- The FVV scenario spec requires Vendor2 to hold `CVDRole.VENDOR`
+- The three-actor demo's `coordinator_invites_actor` works around this by using `three_actor_demo.py`'s own `rm_invite_to_case_activity` factory call directly (not the trigger endpoint), which can embed roles — but the trigger endpoint cannot
+
+## Resolution
+
+**Resolved**: 2026-07-14 — implementation was already complete via PR #1346 (shipped with #1300). The roles field was added to `InviteActorToCaseTriggerRequest`, threaded through `SvcInviteActorToCaseUseCase._extra_execute_kwargs()` → blackboard `suggested_roles` key → `EmitInviteActorToCaseNode` → factory → wire Invite → `CreateInviteeParticipantAtAcceptedNode`. The FVV demo was updated to pass `"roles": ["vendor"]`.
+
+Residual spec gap (dual-path blackboard threading not documented): addressed in Docs PR #1404.
+
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1404>.
+Implementation tracked in #1405 (test coverage — direct trigger path), #1406 (test coverage — suggest-actor received path).

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -899,13 +899,24 @@ groups:
     priority: MUST
     statement: >-
       The `Invite` activity MUST embed the intended `case_roles: list[CVDRole]` for the
-      invitee. These roles come from the Case Owner's Accept response (CM-16-006) or
-      from the CaseActor's default role assignment (CM-16-003) if the Case Owner did not
-      override them.
+      invitee. Roles reach `EmitInviteActorToCaseNode` via the blackboard key
+      ``suggested_roles`` (flat, unnamespaced). There are two distinct source paths:
+      (1) **Direct-trigger path** — the Case Owner explicitly calls
+      `invite-actor-to-case` with a `roles` list; `SvcInviteActorToCaseUseCase`
+      writes that list to ``suggested_roles`` via `_extra_execute_kwargs()` before
+      BT execution. (2) **Suggest-actor received path** — the CaseActor receives
+      `Accept(Offer(CaseParticipant))`; `AcceptOfferCaseParticipantReceivedUseCase`
+      does NOT write ``suggested_roles``; the `Invite` is emitted with `roles=None`
+      and the invitee's `CaseParticipant.case_roles` is populated on
+      `Accept(Invite)` by reading roles from the persisted Invite wire object
+      (CM-17-004). In the suggest-actor path, roles originate from the Case Owner's
+      Accept response (CM-16-006) or the CaseActor's default role assignment
+      (CM-16-003).
     rationale: >-
-      All invited participants getting `caseRoles=[]` is a protocol defect (issue #1288).
-      The participant record created on Accept(Invite) MUST reflect the roles the Case
-      Owner intended.
+      All invited participants getting `caseRoles=[]` is a protocol defect (issue
+      #1288). The participant record created on `Accept(Invite)` MUST reflect the
+      roles the Case Owner intended, whether those roles arrived via a direct trigger
+      request or via the suggest-actor round-trip.
   - id: CM-17-004
     priority: MUST
     statement: >-


### PR DESCRIPTION
## Summary

- Expands CM-17-003 in `specs/case-management.yaml` to explicitly document both source paths for `suggested_roles`: the direct-trigger path (`SvcInviteActorToCaseUseCase._extra_execute_kwargs()` writes to the flat `suggested_roles` blackboard key) and the suggest-actor received path (roles propagate via the persisted Invite wire object on `Accept(Invite)`, not via the blackboard key).

## Changes

- `specs/case-management.yaml` CM-17-003: expanded statement and rationale to document dual-path roles threading and clarify that `AcceptOfferCaseParticipantReceivedUseCase` does not write `suggested_roles` to the blackboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)