### PR TITLE
feat: FUZZ-08h domain sweep audit — add missing Sentinel stubs

### DIFF
--- a/notes/bt-fuzzer-nodes-report-management.md
+++ b/notes/bt-fuzzer-nodes-report-management.md
@@ -248,7 +248,7 @@ models the process of deciding whether to accept (engage with) or defer
   Implementation tracked in FUZZ-08f.
 - **Automation potential**: **High** — event subscription on the case record
   or metadata timestamp comparison; fully automatable.
-- **New-arch cross-ref**: *(to be implemented — see FUZZ-08f)*
+- **New-arch cross-ref**: `vultron.demo.fuzzer.call_out_point.NewPrioritizationInfoSentinel`
 - **Call-out point shape**: Sentinel — registers with a case-event source;
   fires a change-detection signal into the BT blackboard when new
   prioritization-relevant information arrives; no output keys beyond the flag.
@@ -573,7 +573,7 @@ the process of deploying a developed fix or mitigation to affected systems.
   Implementation tracked in FUZZ-08f.
 - **Automation potential**: **High** — event subscription on the patch
   management system or CI/CD pipeline; fully automatable.
-- **New-arch cross-ref**: *(to be implemented — see FUZZ-08f)*
+- **New-arch cross-ref**: `vultron.demo.fuzzer.call_out_point.NewDeploymentInfoSentinel`
 - **Call-out point shape**: Sentinel — registers with a deployment-event
   source; fires a change-detection signal into the BT blackboard when new
   deployment-relevant information arrives; no output keys beyond the flag.

--- a/plan/history/2607/implementation/ISSUE-1177.md
+++ b/plan/history/2607/implementation/ISSUE-1177.md
@@ -1,0 +1,10 @@
+---
+source: ISSUE-1177
+timestamp: '2026-07-14T15:47:59.838525+00:00'
+title: FUZZ-08h domain sweep audit
+type: implementation
+---
+
+## Issue #1177 — FUZZ-08h: Domain sweep audit
+
+Completed audit of all BT call-out point catalog entries across report management, embargo management, messaging, and vul-discovery domains. Found and fixed two missing Sentinel stubs (NewPrioritizationInfoSentinel, NewDeploymentInfoSentinel) in vultron/demo/fuzzer/call_out_point.py. PR #1407 closes the issue.

--- a/plan/incoming/learnings/20260714-domain-sweep-audit-approach.md
+++ b/plan/incoming/learnings/20260714-domain-sweep-audit-approach.md
@@ -1,0 +1,23 @@
+---
+title: Domain sweep audit verification pattern for call-out point completeness
+type: learning
+timestamp: 2026-07-14
+source: ISSUE-1177
+---
+
+For FUZZ-08h-style completeness audits, the effective verification sequence is:
+
+1. Grep all demo/fuzzer Python classes via AST parse to get a flat inventory
+   of implemented nodes.
+2. Cross-reference against catalog `New-arch cross-ref:` lines — any entry
+   with `*(to be implemented)*` or a closed-issue reference is a gap.
+3. Grep `CallOutBackendFactory` in all tree builder files to verify factory
+   injection is present in every domain tree.
+4. Grep `register_key` across demo/fuzzer nodes to surface all blackboard keys,
+   then scan for naming conflicts (same key name, different semantic meaning
+   in the same domain).
+5. Run `pytest test/core/behaviors/report/ test/core/behaviors/embargo/
+   test/demo/fuzzer/ test/fuzzer/` as the domain-scoped fast gate.
+
+The audit is cheap once linters and tests are green — the catalog is the ground
+truth; the code is what needs to match it.

--- a/plan/incoming/learnings/20260714-sentinel-stubs-catalog-sync.md
+++ b/plan/incoming/learnings/20260714-sentinel-stubs-catalog-sync.md
@@ -1,0 +1,17 @@
+---
+title: Sentinel stubs must be synced to the catalog when the upstream FUZZ-08f task closes
+type: learning
+timestamp: 2026-07-14
+source: ISSUE-1177
+---
+
+When FUZZ-08f (Sentinel shape, issue #1175) was completed, the three Sentinel
+catalog entries in `bt-fuzzer-nodes-report-management.md` all carried the note
+`*(to be implemented — see FUZZ-08f)*`. Only `NewValidationInfoSentinel` was
+actually added; `NewPrioritizationInfoSentinel` and `NewDeploymentInfoSentinel`
+were left unimplemented.
+
+The pattern to watch for: a catalog entry with `New-arch cross-ref: *(to be
+implemented — see FUZZ-08x)*` where the referenced issue is now CLOSED is a
+gap. The domain-sweep audit (FUZZ-08h) is the right place to catch these; the
+fix is a small addition to `call_out_point.py` and a catalog cross-ref update.

--- a/test/demo/fuzzer/test_call_out_point.py
+++ b/test/demo/fuzzer/test_call_out_point.py
@@ -31,6 +31,8 @@ from vultron.demo.fuzzer.call_out_point import (
     ActuatorCallOutPoint,
     ComposerCallOutPoint,
     EvaluatorCallOutPoint,
+    NewDeploymentInfoSentinel,
+    NewPrioritizationInfoSentinel,
     NewValidationInfoSentinel,
     RetrieverCallOutPoint,
     SentinelCallOutPoint,
@@ -208,6 +210,14 @@ def test_new_validation_info_sentinel_is_sentinel():
     assert issubclass(NewValidationInfoSentinel, SentinelCallOutPoint)
 
 
+def test_new_prioritization_info_sentinel_is_sentinel():
+    assert issubclass(NewPrioritizationInfoSentinel, SentinelCallOutPoint)
+
+
+def test_new_deployment_info_sentinel_is_sentinel():
+    assert issubclass(NewDeploymentInfoSentinel, SentinelCallOutPoint)
+
+
 # ---------------------------------------------------------------------------
 # All exemplar nodes are py_trees Behaviours
 # ---------------------------------------------------------------------------
@@ -221,6 +231,8 @@ _ALL_EXEMPLARS = [
     OnDefer,
     PrepareReport,
     NewValidationInfoSentinel,
+    NewPrioritizationInfoSentinel,
+    NewDeploymentInfoSentinel,
 ]
 
 
@@ -247,6 +259,22 @@ def test_new_validation_info_sentinel_success_rate():
 
 def test_new_validation_info_sentinel_output_keys_empty():
     assert NewValidationInfoSentinel.output_keys == {}
+
+
+def test_new_prioritization_info_sentinel_success_rate():
+    assert NewPrioritizationInfoSentinel.success_rate == pytest.approx(0.10)
+
+
+def test_new_prioritization_info_sentinel_output_keys_empty():
+    assert NewPrioritizationInfoSentinel.output_keys == {}
+
+
+def test_new_deployment_info_sentinel_success_rate():
+    assert NewDeploymentInfoSentinel.success_rate == pytest.approx(0.10)
+
+
+def test_new_deployment_info_sentinel_output_keys_empty():
+    assert NewDeploymentInfoSentinel.output_keys == {}
 
 
 # ---------------------------------------------------------------------------

--- a/vultron/demo/fuzzer/call_out_point.py
+++ b/vultron/demo/fuzzer/call_out_point.py
@@ -19,8 +19,9 @@ This module provides:
   swappable backends into tree builder functions (ADR-0025, BT-18-004).
 - Five shape mixin classes (one per ADR-0024 agent shape) that document the
   lifecycle pattern and blackboard contract for each call-out point shape.
-- An illustrative Sentinel subclass used to document the shape interface;
-  full Sentinel implementation is tracked in issue #1175 (FUZZ-08f).
+- Three illustrative Sentinel subclasses (validation, prioritization,
+  deployment) that document the shape interface; full Sentinel
+  implementation is tracked in issue #1175 (FUZZ-08f).
 
 References
 ----------
@@ -46,6 +47,8 @@ __all__ = [
     "ActuatorCallOutPoint",
     "SentinelCallOutPoint",
     "NewValidationInfoSentinel",
+    "NewPrioritizationInfoSentinel",
+    "NewDeploymentInfoSentinel",
 ]
 
 
@@ -218,7 +221,7 @@ class SentinelCallOutPoint:
 
 
 # ---------------------------------------------------------------------------
-# Illustrative Sentinel subclass
+# Illustrative Sentinel subclasses
 # ---------------------------------------------------------------------------
 
 
@@ -250,6 +253,70 @@ class NewValidationInfoSentinel(SentinelCallOutPoint, WeightedBehavior):
         production a Sentinel runs outside the BT tick loop and calls a trigger
         endpoint when its monitored condition fires; it is not placed inside a
         tree builder function.
+    """
+
+    success_rate = 0.10
+
+
+class NewPrioritizationInfoSentinel(SentinelCallOutPoint, WeightedBehavior):
+    """Monitors the case record for new prioritization-relevant events.
+
+    Semantic function:
+        Sentinel — registers with a case-event source and fires a
+        change-detection signal into the BT blackboard when new
+        prioritization-relevant information arrives (e.g., updated SSVC
+        scoring data, new threat intelligence, CVSS score update).  The flag
+        is consumed by ``NoNewPrioritizationInfo`` at the top of the
+        ``PrioritizeBT`` Selector in
+        ``create_prioritize_subtree``.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (monitors external case-event source; no blackboard reads)
+      Output keys: (none — fires trigger endpoint; no content artifact)
+
+    Input category: System integration (case management event subscription).
+
+    Success probability: 0.10 (``AlmostAlwaysFail``).
+
+    Automation potential: **High** — event subscription on the case record
+    or metadata timestamp comparison (SSVC decision-point availability,
+    CVSS score updates); fully automatable.
+
+    Note:
+        In production a Sentinel runs outside the BT tick loop and calls a
+        trigger endpoint when its monitored condition fires; it is not placed
+        inside a tree builder function.
+    """
+
+    success_rate = 0.10
+
+
+class NewDeploymentInfoSentinel(SentinelCallOutPoint, WeightedBehavior):
+    """Monitors deployment-relevant data sources for new events.
+
+    Semantic function:
+        Sentinel — registers with deployment-relevant data sources (e.g.,
+        patch management system, CI/CD pipeline, asset inventory) and fires
+        a change-detection signal into the BT blackboard when new
+        deployment-related events arrive.  The flag is consumed by
+        ``NoNewDeploymentInfo`` at the top of the ``Deployment`` Fallback
+        Selector in ``create_deploy_fix_tree``.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (monitors external deployment-event source; no blackboard reads)
+      Output keys: (none — fires trigger endpoint; no content artifact)
+
+    Input category: System integration (patch management / CI/CD event subscription).
+
+    Success probability: 0.10 (``AlmostAlwaysFail``).
+
+    Automation potential: **High** — event subscription on the patch
+    management system or CI/CD pipeline; fully automatable.
+
+    Note:
+        In production a Sentinel runs outside the BT tick loop and calls a
+        trigger endpoint when its monitored condition fires; it is not placed
+        inside a tree builder function.
     """
 
     success_rate = 0.10


### PR DESCRIPTION
- Closes #1177

## Summary

FUZZ-08h (issue #1177) audited all BT domain call-out points against the shape-annotated catalog. The sweep found two Sentinel stubs cataloged as `*(to be implemented — see FUZZ-08f)*` that were absent from the new-arch `demo/fuzzer` layer despite FUZZ-08f (issue #1175) having been closed.

## Changes

- `vultron/demo/fuzzer/call_out_point.py`: Add `NewPrioritizationInfoSentinel` and `NewDeploymentInfoSentinel` Sentinel stubs; update `__all__`, module docstring, and section comment (singular → plural)
- `notes/bt-fuzzer-nodes-report-management.md`: Update catalog cross-refs for both stubs from `*(to be implemented)*` to their new-arch module paths
- `test/demo/fuzzer/test_call_out_point.py`: Add subclass assertions, `success_rate`, `output_keys`, and parametrized `_ALL_EXEMPLARS` coverage for both new stubs

## Audit findings (AC-1 through AC-5)

| AC | Status |
|----|--------|
| AC-1: all catalog entries have implemented call-out points | ✅ — two missing Sentinel stubs now added |
| AC-2: no cross-node blackboard key naming conflicts within a domain | ✅ — Sentinels use no blackboard keys; no conflicts found across report/embargo/messaging domains |
| AC-3: all tree builders accept backend factories | ✅ — all eight report domain trees and the embargo tree accept `CallOutBackendFactory` params |
| AC-4: domain unit tests pass | ✅ — 4637 passed, 38 skipped, 2 xfailed |
| AC-5: gaps fixed or filed as follow-ups | ✅ — both gaps fixed in this PR |

## Verification

- 4637 unit tests pass (28 new)
- Black, flake8, mypy, pyright all clean