### PR TITLE
fix: clear VIRTUAL_ENV in dev Docker stage to suppress uv warning

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,6 +48,10 @@ ENTRYPOINT ["/app/demo-entrypoint.sh"]
 
 FROM dependencies AS dev
 
+# Clear VIRTUAL_ENV so uv resolves the project venv from the workspace path,
+# not /app/.venv (which is valid for app stages but wrong for devcontainer use).
+ENV VIRTUAL_ENV=
+
 # Install dev tooling (git and curl already present from base stage)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     zsh tmux jq unzip sudo ca-certificates \


### PR DESCRIPTION
## Summary

- The `base` stage in `docker/Dockerfile` sets `VIRTUAL_ENV=/app/.venv` for production containers
- The `dev` stage inherits this env var, but devcontainers run from `/workspaces/` where `uv` expects the project venv
- The mismatch causes a noisy (but harmless) warning on every `uv` invocation in dev containers

## Change

Adds `ENV VIRTUAL_ENV=` at the top of the `dev` stage to clear the inherited value. `uv` then resolves the project venv from the workspace path without interference.

## Test plan

- [ ] Rebuild a dev container with `--rebuild` and confirm `uv run black ...` no longer emits the `VIRTUAL_ENV` mismatch warning
- [ ] Confirm existing `uv run` commands (black, flake8, mypy, pytest) still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)