### PR TITLE
fix: add CaseActor roster entry and correct to= fields in suggest-actor vocab examples

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1372.md
+++ b/plan/history/2607/implementation/ISSUE-1372.md
@@ -1,0 +1,10 @@
+---
+source: ISSUE-1372
+timestamp: '2026-07-14T16:39:04.211022+00:00'
+title: fix CaseActor roster entry and correct suggest-actor vocab to= fields
+type: implementation
+---
+
+## Issue #1372 — fix: add CaseActor roster entry and correct to= fields in suggest-actor vocab examples
+
+Added `_CASE_ACTOR` (as_Service) to the vocab examples roster in `_base.py`, corrected `actor=` and `to=` fields in `offer_case_participant()`, `accept_case_participant_offer()`, and `reject_case_participant_offer()` to reflect ADR-0026 actor boundaries. Added 4 new unit tests. PR: <https://github.com/CERTCC/Vultron/pull/1411>

--- a/test/wire/as2/vocab/test_vocab_participant_examples.py
+++ b/test/wire/as2/vocab/test_vocab_participant_examples.py
@@ -25,6 +25,7 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Reject,
     as_Remove,
 )
+from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.base.objects.base import as_Object
 from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
 from vultron.wire.as2.vocab.objects.case_status import (
@@ -231,6 +232,74 @@ class TestVocabParticipantExamples(unittest.TestCase):
         self.assertIsInstance(activity.object_, _RecommendActorActivity)
         self.assertEqual(activity.target, case.id_)
         self.assertEqual(activity.to, finder.id_)
+
+    def test_case_actor(self):
+        ca = examples.case_actor()
+        self.assertIsInstance(ca, as_Service)
+        self.assertIsNotNone(ca.id_)
+        self.assertIsNotNone(ca.name)
+
+    def test_offer_case_participant(self):
+        activity = examples.offer_case_participant()
+        self.assertIsInstance(activity, as_Activity)
+        ca = examples.case_actor()
+        v = examples.vendor()
+        coordinator = examples.coordinator()
+        c = examples.case()
+
+        self.assertIsInstance(activity, as_Offer)
+        self.assertEqual(activity.type_, "Offer")
+
+        # CaseActor sends the transformed offer to the Case Owner
+        self.assertEqual(activity.actor, ca.id_)
+        self.assertEqual(activity.to, [v.id_])
+
+        participant = cast(CaseParticipant, activity.object_)
+        self.assertIsInstance(participant, CaseParticipant)
+        attr = participant.attributed_to
+        attr_id = getattr(attr, "id_", None) or attr
+        self.assertEqual(attr_id, coordinator.id_)
+        self.assertEqual(activity.target, c.id_)
+        self.assertEqual(activity.context, c.id_)
+        self.assertIsNotNone(activity.origin)
+
+    def test_accept_case_participant_offer(self):
+        activity = examples.accept_case_participant_offer()
+        self.assertIsInstance(activity, as_Activity)
+        ca = examples.case_actor()
+        v = examples.vendor()
+        c = examples.case()
+
+        self.assertIsInstance(activity, as_Accept)
+        self.assertEqual(activity.type_, "Accept")
+
+        # Case Owner accepts and sends back to CaseActor
+        self.assertEqual(activity.actor, v.id_)
+        self.assertEqual(activity.to, [ca.id_])
+        self.assertEqual(activity.target, c.id_)
+        self.assertEqual(activity.context, c.id_)
+
+        offer = cast(as_Offer, activity.object_)
+        self.assertIsInstance(offer, as_Offer)
+
+    def test_reject_case_participant_offer(self):
+        activity = examples.reject_case_participant_offer()
+        self.assertIsInstance(activity, as_Activity)
+        ca = examples.case_actor()
+        v = examples.vendor()
+        c = examples.case()
+
+        self.assertIsInstance(activity, as_Reject)
+        self.assertEqual(activity.type_, "Reject")
+
+        # Case Owner rejects and sends back to CaseActor
+        self.assertEqual(activity.actor, v.id_)
+        self.assertEqual(activity.to, [ca.id_])
+        self.assertEqual(activity.target, c.id_)
+        self.assertEqual(activity.context, c.id_)
+
+        offer = cast(as_Offer, activity.object_)
+        self.assertIsInstance(offer, as_Offer)
 
     def test_remove_participant_from_case(self):
         activity = examples.remove_participant_from_case()

--- a/vultron/wire/as2/vocab/examples/_base.py
+++ b/vultron/wire/as2/vocab/examples/_base.py
@@ -22,6 +22,7 @@ from vultron.wire.as2.vocab.base.base import as_Base
 from vultron.wire.as2.vocab.base.objects.actors import (
     as_Organization,
     as_Person,
+    as_Service,
 )
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
@@ -50,6 +51,12 @@ _VENDOR = as_Organization(
 )
 _COORDINATOR = as_Organization(
     name="Coordinator LLC", id_=f"{organization_base_url}/coordinator"
+)
+
+case_actor_base_url = f"{base_url}/case-actors"
+_CASE_ACTOR = as_Service(
+    name="VendorCo Case Actor",
+    id_=f"{case_actor_base_url}/vendorco-case-actor",
 )
 
 _REPORT = VulnerabilityReport(
@@ -93,6 +100,15 @@ def coordinator() -> as_Organization:
     return _COORDINATOR
 
 
+def case_actor() -> as_Service:
+    """
+    Create a CaseActor (Service) object representing the automated case-management service actor.
+    Returns:
+        an as_Service object
+    """
+    return _CASE_ACTOR
+
+
 def case(random_id=False) -> VulnerabilityCase:
     if random_id:
         _case_number = random.randint(10000000, 99999999)
@@ -115,7 +131,7 @@ def gen_report() -> VulnerabilityReport:
 
 
 def initialize_examples(datalayer: DataLayer) -> None:
-    for obj in [_FINDER, _VENDOR, _COORDINATOR, _REPORT]:
+    for obj in [_FINDER, _VENDOR, _COORDINATOR, _CASE_ACTOR, _REPORT]:
         if obj.type_ is None:
             raise ValueError(f"Example object missing type_: {obj}")
         datalayer.create(object_to_record(cast(PersistableModel, obj)))
@@ -179,4 +195,4 @@ def print_obj(obj: as_Base) -> None:
     print(obj.to_json(indent=2))
 
 
-ACTOR_FUNCS = [finder, vendor, coordinator]
+ACTOR_FUNCS = [finder, vendor, coordinator, case_actor]

--- a/vultron/wire/as2/vocab/examples/actor.py
+++ b/vultron/wire/as2/vocab/examples/actor.py
@@ -17,6 +17,7 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Reject,
 )
 from vultron.wire.as2.vocab.examples._base import (
+    _CASE_ACTOR,
     _COORDINATOR,
     case,
     finder,
@@ -92,7 +93,7 @@ def offer_case_participant() -> as_Offer:
     _activity = offer_case_participant_activity(
         _coordinator,
         target=_case.id_,
-        actor=_vendor.id_,
+        actor=_CASE_ACTOR.id_,
         to=[_vendor.id_],
         context=_case.id_,
         origin=_recommendation.id_,
@@ -114,7 +115,7 @@ def accept_case_participant_offer() -> as_Accept:
         _cp_offer,
         target=_case.id_,
         actor=_vendor.id_,
-        to=[_vendor.id_],
+        to=[_CASE_ACTOR.id_],
         context=_case.id_,
         content=(
             f"Accepting recommendation to add {_coordinator.name} to the case."
@@ -133,7 +134,7 @@ def reject_case_participant_offer() -> as_Reject:
         _cp_offer,
         target=_case.id_,
         actor=_vendor.id_,
-        to=[_vendor.id_],
+        to=[_CASE_ACTOR.id_],
         context=_case.id_,
         content=(
             f"Declining recommendation to add {_coordinator.name} to the case."

--- a/vultron/wire/as2/vocab/examples/vocab_examples.py
+++ b/vultron/wire/as2/vocab/examples/vocab_examples.py
@@ -35,8 +35,10 @@ from vultron.wire.as2.vocab.examples.status import *  # noqa: F401, F403
 
 from vultron.wire.as2.vocab.examples._base import (  # noqa: F401
     ACTOR_FUNCS,
+    _CASE_ACTOR,
     _COORDINATOR,
     case,
+    case_actor,
     coordinator,
     finder,
     gen_report,


### PR DESCRIPTION
- Closes #1372

## Summary

Adds a `_CASE_ACTOR` (`as_Service`) object to the vocab examples roster and
corrects the `actor=` / `to=` fields in the three suggest-actor example functions
to reflect ADR-0026 actor boundaries: the CaseActor sends
`Offer(CaseParticipant)` to the Case Owner, and the Case Owner sends
`Accept` / `Reject` back to the CaseActor.

## Changes

- `vultron/wire/as2/vocab/examples/_base.py`: add `as_Service` import,
  `case_actor_base_url`, `_CASE_ACTOR` singleton, `case_actor()` accessor;
  add `_CASE_ACTOR` to `initialize_examples()` and `ACTOR_FUNCS`
- `vultron/wire/as2/vocab/examples/actor.py`: import `_CASE_ACTOR`;
  fix `offer_case_participant()` to use `actor=_CASE_ACTOR.id_`;
  fix `accept_case_participant_offer()` and `reject_case_participant_offer()`
  to use `to=[_CASE_ACTOR.id_]`
- `vultron/wire/as2/vocab/examples/vocab_examples.py`: re-export `_CASE_ACTOR`
  and `case_actor`
- `test/wire/as2/vocab/test_vocab_participant_examples.py`: add tests for
  `case_actor()`, `offer_case_participant()`, `accept_case_participant_offer()`,
  `reject_case_participant_offer()` asserting correct ADR-0026 actor boundaries

## Verification

- 4641 unit tests pass (4 new)
- Black, flake8, mypy, pyright clean

[ADVISORY] Two pre-existing cleanup items confirmed by review:
1. `ACTOR_FUNCS` list is never consumed by any production code — adding
   `case_actor` to it is inert. Pre-existing issue, not introduced by this PR.
2. `_CASE_ACTOR` is explicitly re-exported in `vocab_examples.py` (mirroring
   the pre-existing `_COORDINATOR` re-export), while `_FINDER` / `_VENDOR`
   are not. Pre-existing asymmetry, not introduced by this PR.