### PR TITLE
docs: plan issue #1408 — spec gap backfill (42 invariants)

### DIFF
--- a/plan/history/2607/learning/CONCERN-1408.md
+++ b/plan/history/2607/learning/CONCERN-1408.md
@@ -1,0 +1,90 @@
+---
+source: CONCERN-1408
+timestamp: '2026-07-14T16:44:25.587410+00:00'
+title: spec gaps — 42 codebase invariants not captured in YAML spec corpus
+type: learning
+---
+
+## Summary
+
+A broad spec-gap analysis identified 42 invariants that are clear in code,
+`notes/`, and `AGENTS.md` but absent from the machine-readable YAML spec corpus
+surfaced by `spec-dump`. A developer reproducing Vultron from specs alone would
+miss or misimplement these.
+
+Full analysis: `wip_outputs/spec-gap-analysis.md` (on branch
+`task/1374-fix-identify-vendors-coordinators-exhaustion`).
+
+## Gaps by Target Spec
+
+### Critical Protocol Gaps — VP / SM
+
+1. CS forced transitions (`pX→PX`, `vP→VP`) not in SM or VP
+2. Only 40 of 64 CS states reachable (`vF*`, `*fD*` invalid) — not in SM or VP
+3. Single-writer regime not stated as a protocol axiom in VP/SM
+4. Routing topology absent from VP
+5. PEC 5-state machine (pocket veto) lives only in `notes/participant-embargo-consent.md`
+6. EM counter-revision (`REVISE→REVISE`) MUST NOT cascade PEC — not in EP or CM
+
+### Domain Invariants — CM / SM / EP
+
+1. `actor_participant_index` is a derived cache; `case_participants` is the authority; divergence MUST be a hard error
+2. Participant-specific (RM/VFD) vs. participant-agnostic (EM/PXA) state scoping
+3. RM terminal guard must precede same-state idempotency node in BT composition
+4. Do-not-downgrade embargo consent on idempotent retries
+
+### Behavior Tree Patterns — BTND / BT
+
+1. BT-HELPER-01: helper methods raise; `update()` is the sole try/except boundary
+2. Blackboard no-slash rule + `{noun}_{id_segment}` naming convention
+3. BTBridge requires `threading.RLock`, not plain `Lock`
+4. BT result channel for domain errors: write exception to `result_out["error"]`, re-raise in `execute()`
+5. `memory=False` Sequence partial-write is non-transactional
+6. `behaviors/` MUST NOT import from `use_cases/`
+7. Decomposed leaf nodes must convert `KeyError` to explicit `FAILURE`
+
+### Wire / AS2 Patterns — SE / VM / AF / RF
+
+1. `_validate_registry_order()` import-time guard + `RegistryOrderError`
+2. `serialize_as_any=True` required at both persistence and delivery boundaries
+3. Vocabulary override must preserve at least one base-module registration
+4. Activity Translator port (correct replacement for `from_core()` calls in core)
+5. `VulnerabilityCase.case_activity` cannot store typed activities
+6. `inReplyTo` must be enforced at model level via `model_validator`
+7. Actor subtype-aware pattern matching open design question
+8. Recursive rehydration of `Accept(Invite)` + `VulnerabilityCaseStub` expansion rule
+
+### Architecture / Hexagonal — ARCH
+
+1. `create_app()` MUST NOT mutate module-level singletons
+2. ASGIEmitter scheme+netloc-only base URL + reentrancy guard
+3. Production adapters MUST NOT import from `vultron/demo/`
+4. Port interfaces MUST NOT use bare `BaseModel` — contradiction with CS-10-001 (resolved: CS-10-001 updated)
+5. Outbound delivery three-stage pipeline
+6. `validate-at-edge` as a driving adapter boundary obligation
+7. Architecture ratchet test discipline (`actual == KNOWN_VIOLATIONS` bidirectional)
+
+### Testing Patterns — TB
+
+1. `BTTestScenario` deep-module harness
+2. BT factory determinism: explicit always-succeed factory required when default is probabilistic
+3. Operational test rules (one-run rule, 5-second timeout policy, `SUBFAILED` caveat)
+4. Integration test per-actor DataLayer isolation
+5. Helper enums MUST NOT use `Test*` names
+6. Vocabulary side-effect imports required in subdirectory `conftest.py`
+
+### Demo / Simulation — DC / DEMOMA / DEMOCI
+
+1. `demo_step` vs. `demo_check` semantic distinction
+2. Exchange demos permitted to use direct inbox injection (spec/code contradiction resolved by DEMOMA-05-003)
+3. `reset_demo_failures`/`assert_demo_success` bookend contract
+4. Fuzzer node replacement lifecycle has no process spec
+
+## Most Surprising Single Gap
+
+Gap 29: direct contradiction between `notes/architecture-hexagonal.md` and `specs/code-style.yaml`.
+CS-10-001 updated to "named domain-typed Pydantic classes" (kind: language); ARCH-08-002 adds
+the port-specific enforcement.
+
+**Resolved**: 2026-07-14 — all 42 gaps backfilled directly into existing YAML spec files
+(no new files, no new impl issues). Docs PR: <https://github.com/CERTCC/Vultron/pull/1412>.

--- a/specs/activity-factories.yaml
+++ b/specs/activity-factories.yaml
@@ -166,3 +166,34 @@ groups:
       Migration of `from_core()` call sites in `vultron/core/use_cases/` to use driven adapter
       translation instead of calling wire-layer methods directly is a **separate tracked task**
       and MUST NOT be conflated with factory function migration
+- id: AF-09
+  title: Activity Translator Port
+  kind: pattern
+  specs:
+  - id: AF-09-001
+    priority: MUST
+    statement: >-
+      The correct replacement for `from_core()` calls in `vultron/core/use_cases/` is a
+      driven-adapter port: a `Protocol` interface defined in `vultron/core/` that accepts
+      domain objects and returns wire activities, implemented by an adapter in the wire layer.
+      Core use-cases MUST NOT import from `vultron/wire/` directly; they MUST call through
+      the port.
+    rationale: >-
+      `from_core()` is a wire-layer method. Calling it directly from core use-cases inverts
+      the hexagonal architecture dependency direction: core→wire. The Activity Translator port
+      pattern maintains the correct direction (core defines the port; wire implements it) while
+      providing the same functional capability. See AF-08-002 for migration scope.
+    relationships:
+    - rel_type: implements
+      spec_id: ARCH-04-001
+    - rel_type: refines
+      spec_id: AF-08-002
+  - id: AF-09-002
+    priority: MUST
+    statement: >-
+      The Activity Translator port MUST be injected into use-cases via dependency injection
+      (constructor parameter or factory argument). Use-cases MUST NOT instantiate the wire-layer
+      translator directly.
+    relationships:
+    - rel_type: refines
+      spec_id: AF-09-001

--- a/specs/architecture.yaml
+++ b/specs/architecture.yaml
@@ -49,6 +49,20 @@ groups:
         note: >-
           ARCH-01-001 is the general constraint; ARCH-01-004 requires that
           all violations be systematically remediated via driven ports.
+  - id: ARCH-01-005
+    priority: MUST_NOT
+    statement: >-
+      Production adapters (HTTP routes, CLI commands, MCP server, background workers)
+      MUST NOT import from `vultron/demo/`. Demo-layer modules are not part of the
+      production dependency graph and MUST be treated as test-only code for runtime
+      purposes.
+    rationale: >-
+      The demo layer contains simplified, non-production implementations of actors and
+      data handling. Importing it in production adapters silently pulls in demo behaviour
+      and dummy data, and couples production code to a layer with no stability guarantees.
+    relationships:
+    - rel_type: refines
+      spec_id: ARCH-01-001
 - id: ARCH-02
   title: SemanticIntent Enum
   kind: domain
@@ -130,6 +144,23 @@ groups:
     priority: MUST
     statement: Driving adapters (HTTP inbox, CLI, MCP server) MUST invoke the wire pipeline before calling into the core
     rationale: Any driving adapter that needs to ingest AS2 can reuse the wire pipeline; there is no duplication
+  - id: ARCH-08-002
+    priority: MUST
+    statement: >-
+      A driving adapter MUST promote an incoming wire object to its most-specific domain
+      type at the adapter boundary, before passing the object into the core. The core
+      MUST NOT receive a bare `BaseObject` or generic `BaseModel` when a more specific
+      type is determinable from the wire payload.
+    rationale: >-
+      Promoting at the boundary ("validate at edge") ensures that core handlers receive
+      fully typed objects and never need to downcast or call `isinstance()` to recover
+      type information that was present on the wire. Deferring promotion into the core
+      violates the hexagonal principle that adapters adapt, cores compute.
+    relationships:
+    - rel_type: refines
+      spec_id: ARCH-08-001
+    - rel_type: implements
+      spec_id: CS-10-001
 - id: ARCH-12
   title: Shared-Base Object Hierarchy
   kind: implementation
@@ -479,3 +510,136 @@ groups:
       An explicit Protocol type converts a convention-only rule into a
       compile-time-enforced boundary, making violations visible without running
       the code.
+- id: ARCH-16
+  title: App State Isolation
+  kind: pattern
+  specs:
+  - id: ARCH-16-001
+    priority: MUST_NOT
+    statement: >-
+      `create_app()` (or any equivalent application factory) MUST NOT mutate module-level
+      singletons, global registries, or process-wide shared state. All per-application
+      state MUST be scoped to the returned app instance or its lifespan context.
+    rationale: >-
+      Mutating module-level singletons in `create_app()` makes test isolation impossible:
+      the second call to `create_app()` in the same process inherits mutations from the
+      first. This applies to vocabulary registries, DataLayer factories, BT bridges,
+      actor caches, and any other mutable global. Discovered as a demo-layer issue
+      (DEMOMA-01-004) but applies equally to all application factories.
+    relationships:
+    - rel_type: implements
+      spec_id: ARCH-04-001
+- id: ARCH-17
+  title: ASGIEmitter Base URL
+  kind: implementation
+  specs:
+  - id: ARCH-17-001
+    priority: MUST
+    statement: >-
+      The `ASGIEmitter` base URL MUST contain only the scheme and netloc components
+      (e.g., `https://example.org`). It MUST NOT include a path prefix, trailing slash,
+      or mount-point segment. The emitter strips the mount prefix from request paths before
+      constructing outbound URLs; a base URL that includes a prefix causes double-application.
+    rationale: >-
+      A base URL of `https://example.org/api` combined with a request path `/api/actors/…`
+      produces `https://example.org/api/api/actors/…`. Root cause of bugs #557 and #558.
+  - id: ARCH-17-002
+    priority: MUST
+    statement: >-
+      `ASGIEmitter` MUST use a `contextvars.ContextVar[int]` reentrancy guard, not a
+      `threading.Lock` or boolean flag, to detect and prevent re-entrant emission
+      (an emitter call triggered by a handler that was itself invoked by an earlier
+      emission). Re-entrant emission MUST raise `EmitterReentrancyError`.
+    rationale: >-
+      A `threading.Lock` guard would deadlock when the re-entrant call happens on the
+      same thread (common in async/ASGI contexts). A `ContextVar` is task-local and
+      correctly tracks reentrancy per async task without thread-lock semantics.
+    relationships:
+    - rel_type: refines
+      spec_id: ARCH-17-001
+- id: ARCH-18
+  title: Architecture Ratchet Discipline
+  kind: dev-process
+  specs:
+  - id: ARCH-18-001
+    priority: MUST
+    statement: >-
+      Architecture boundary tests that enforce a `KNOWN_VIOLATIONS` allowlist MUST use
+      a bidirectional equality assertion: `assert actual_violations == KNOWN_VIOLATIONS`.
+      One-directional subset assertions (`assert actual ⊆ KNOWN`) are prohibited because
+      they allow the violation count to grow silently.
+    rationale: >-
+      A subset assertion says "we have at most these violations" but allows new ones
+      to be added without failing the test. Bidirectional equality says "we have exactly
+      these violations" — any addition fails immediately, and any removal must be reflected
+      in the allowlist.
+    relationships:
+    - rel_type: implements
+      spec_id: ARCH-10-001
+  - id: ARCH-18-002
+    priority: MUST
+    statement: >-
+      When a known architectural violation is resolved (the file or import is removed or
+      refactored), the corresponding entry MUST be removed from the `KNOWN_VIOLATIONS`
+      allowlist in the same commit that resolves the violation. Stale allowlist entries
+      that no longer correspond to real violations MUST NOT be retained.
+    rationale: >-
+      Stale entries mask the true state of the architecture boundary. A "fixed" violation
+      that remains in `KNOWN_VIOLATIONS` makes the ratchet appear tighter than it is
+      and hides regression when a new violation with the same name is later introduced.
+    relationships:
+    - rel_type: refines
+      spec_id: ARCH-18-001
+- id: ARCH-19
+  title: Outbound Delivery Pipeline
+  kind: domain
+  specs:
+  - id: ARCH-19-001
+    priority: MUST
+    statement: >-
+      Outbound delivery MUST be modelled as a three-stage pipeline: (1) **Emission** —
+      the use-case or handler writes the activity to the outbox; (2) **Transport delivery**
+      — the outbox worker retrieves the activity and delivers it to the recipient's inbox
+      endpoint; (3) **Recipient acceptance** — the recipient's adapter processes the
+      delivered activity. Each stage has distinct error semantics and MUST NOT be conflated.
+    rationale: >-
+      Conflating stages (e.g., treating a transport timeout as a recipient rejection) leads
+      to incorrect retry logic and protocol-state divergence. The three-stage model is the
+      foundation for correct at-least-once delivery. Source: `notes/architecture-adapters.md`.
+  - id: ARCH-19-002
+    priority: MUST
+    statement: >-
+      Emission (stage 1) MUST be idempotent with respect to the outbox: writing the same
+      activity ID twice MUST NOT create a duplicate outbox entry.
+    relationships:
+    - rel_type: refines
+      spec_id: ARCH-19-001
+  - id: ARCH-19-003
+    priority: MUST
+    statement: >-
+      Transport delivery (stage 2) MUST be retried on transient network failures. The retry
+      mechanism MUST be implemented in the outbox worker, not in the use-case or handler.
+    relationships:
+    - rel_type: refines
+      spec_id: ARCH-19-001
+  - id: ARCH-19-004
+    priority: MUST_NOT
+    statement: >-
+      A transport delivery failure (stage 2 error) MUST NOT be interpreted as recipient
+      rejection (stage 3 semantics). Delivery failure means the activity did not reach
+      the recipient; it carries no information about whether the recipient would accept
+      or reject the activity.
+    relationships:
+    - rel_type: refines
+      spec_id: ARCH-19-001
+  - id: ARCH-19-005
+    priority: MUST
+    statement: >-
+      The outbox worker MUST record the delivery outcome (success, transient failure, or
+      permanent failure) in the case ledger so that the case history reflects the true
+      delivery state, not just the emission event.
+    relationships:
+    - rel_type: refines
+      spec_id: ARCH-19-001
+    - rel_type: implements
+      spec_id: VP-18-001

--- a/specs/architecture.yaml
+++ b/specs/architecture.yaml
@@ -636,10 +636,15 @@ groups:
     priority: MUST
     statement: >-
       The outbox worker MUST record the delivery outcome (success, transient failure, or
-      permanent failure) in the case ledger so that the case history reflects the true
-      delivery state, not just the emission event.
+      permanent failure) in the per-actor process log (Python `logging`) at the level
+      prescribed in `specs/structured-logging.yaml`. Delivery outcomes MUST NOT be
+      written to the canonical case ledger; the case ledger is exclusively for
+      CaseActor-authored protocol-significant assertions (ADR-0019).
+    rationale: >-
+      ADR-0019 establishes strict separation: the canonical case ledger contains only
+      CaseActor-authored protocol assertions; per-actor transport observability goes to
+      the process log. Delivery outcomes (whether a network call succeeded) are
+      operational diagnostics, not protocol-significant assertions.
     relationships:
     - rel_type: refines
       spec_id: ARCH-19-001
-    - rel_type: implements
-      spec_id: VP-18-001

--- a/specs/behavior-tree-integration.yaml
+++ b/specs/behavior-tree-integration.yaml
@@ -858,3 +858,35 @@ groups:
     tracking_issue: >-
       #1200 (planning); implementation issue TBD (blocked by #1200 and
       implementation issue for BT-20-002)
+- id: BT-21
+  title: Fuzzer Node Replacement Lifecycle
+  kind: dev-process
+  specs:
+  - id: BT-21-001
+    priority: MUST
+    statement: >-
+      Each fuzzer (simulator) BT node targeted for replacement by a production implementation
+      MUST have a corresponding tracking issue that captures: the fuzzer node name, the
+      production replacement design (as a BT-20 entry or equivalent), and the blocking
+      dependencies. The tracking issue MUST be linked from the relevant BT-20 `tracking_issue`
+      field.
+    rationale: >-
+      Without a tracking issue per fuzzer node, the replacement backlog is invisible in
+      the project board. The BT-20 entries document the design; this entry mandates the
+      process artefact (issue) that makes the work schedulable.
+    relationships:
+    - rel_type: refines
+      spec_id: BT-20-001
+  - id: BT-21-002
+    priority: MUST
+    statement: >-
+      When a fuzzer node is replaced by its production equivalent, the corresponding
+      BT-20 `PROVISIONAL` rationale note MUST be updated to remove the `PROVISIONAL`
+      marker and the BT-21-001 tracking issue MUST be closed in the same PR.
+    rationale: >-
+      Provisional notes that survive after the production replacement is merged become
+      misleading documentation. The two-step close (update spec + close issue) ensures
+      the spec and the project board remain consistent.
+    relationships:
+    - rel_type: refines
+      spec_id: BT-21-001

--- a/specs/behavior-tree-integration.yaml
+++ b/specs/behavior-tree-integration.yaml
@@ -240,6 +240,23 @@ groups:
     statement: Future optimizations MAY introduce resource-level locking
     scope:
     - production
+  - id: BT-11-004
+    priority: MUST
+    statement: >-
+      `BTBridge` MUST acquire a `threading.RLock` (re-entrant lock), not a plain
+      `threading.Lock`, when serializing BT execution. Any code path in which
+      `execute_with_setup()` calls back into `BTBridge` (directly or transitively)
+      will deadlock with a plain `Lock` because the same thread attempts to acquire
+      a non-reentrant lock it already holds.
+    rationale: >-
+      `BTBridge.execute_with_setup()` invokes user-supplied setup and teardown hooks.
+      In integration and demo scenarios these hooks may trigger secondary BT executions
+      via the same bridge instance. A plain `Lock` would deadlock on the second
+      acquisition from the same thread. An `RLock` allows re-entry by the owning thread
+      while still blocking other threads.
+    relationships:
+    - rel_type: refines
+      spec_id: BT-11-001
 - id: BT-13
   title: BT Failure Diagnosis
   kind: implementation

--- a/specs/behavior-tree-node-design.yaml
+++ b/specs/behavior-tree-node-design.yaml
@@ -128,6 +128,52 @@ groups:
     relationships:
     - rel_type: refines
       spec_id: BTND-03-001
+  - id: BTND-03-005
+    priority: MUST
+    statement: >-
+      Blackboard keys MUST NOT contain forward-slash characters. Keys MUST follow the
+      `{noun}_{id_segment}` naming convention where the noun names the value and `id_segment`
+      is the execution-scoped correlation ID (last path or colon-delimited segment). Flat,
+      unscoped keys (e.g., `result`, `status`) are only permitted for top-level handoff keys
+      that are consumed in the same tick cycle and cannot collide.
+    rationale: >-
+      py_trees parses forward-slashes as namespacing separators; a key containing `/`
+      silently creates a sub-namespace and will not be found by flat-key readers. The
+      `{noun}_{id_segment}` convention generalizes BTND-03-004 to all keys, not just
+      inter-node handoffs.
+    relationships:
+    - rel_type: refines
+      spec_id: BTND-03-004
+  - id: BTND-03-006
+    priority: MUST
+    statement: >-
+      A decomposed BT leaf node that encounters a domain-layer error MUST write the error
+      to the `result_out["error"]` blackboard key before returning `FAILURE`, and MUST
+      re-raise the original exception in `execute()` after the write so that the bridge
+      layer can translate it into an appropriate HTTP or protocol response.
+    rationale: >-
+      Without a written error key the bridge layer sees only `FAILURE` with no diagnostic
+      context; the error is silently swallowed. Writing to `result_out["error"]` ensures
+      the error propagates to the caller via the result channel even when the BT stops
+      traversal at the failing leaf.
+    relationships:
+    - rel_type: refines
+      spec_id: BTND-03-001
+  - id: BTND-03-007
+    priority: MUST
+    statement: >-
+      A decomposed BT leaf node MUST convert `KeyError` (missing blackboard key) to a
+      `FAILURE` status and MUST NOT allow the `KeyError` to propagate uncaught to the
+      bridge layer. The leaf is responsible for catching `KeyError` in its `update()`
+      method and returning `FAILURE` with an appropriate diagnostic message.
+    rationale: >-
+      A `KeyError` propagating to the bridge results in an unhandled 500-level error for
+      the caller. At the leaf level the semantics of "key not present" are known —
+      this is a precondition failure, not an unexpected crash, so `FAILURE` is the
+      correct BT response.
+    relationships:
+    - rel_type: refines
+      spec_id: BTND-03-001
 - id: BTND-04
   title: Module Ownership
   kind: implementation
@@ -151,6 +197,22 @@ groups:
       BT nodes MUST NOT import from `vultron/demo/` or any other demo-layer module. Demo-specific
       context (step descriptions, demo loggers, demo flags) belongs in demo scripts, not in
       BT nodes.
+  - id: BTND-04-003
+    priority: MUST_NOT
+    statement: >-
+      `behaviors/` modules MUST NOT import from `use_cases/` modules. The import direction
+      is one-way: use-cases drive BT trees; BT nodes MUST NOT import use-case classes or
+      functions. Shared logic needed by both MUST be extracted to a common helper in
+      `vultron/core/` or `vultron/core/behaviors/helpers.py`.
+    rationale: >-
+      Importing use-cases from behaviors inverts the composition hierarchy (behaviors are
+      the implementation layer of use-cases, not their consumers) and introduces circular
+      imports when use-cases inject behaviors via factories.
+    relationships:
+    - rel_type: refines
+      spec_id: BTND-04-001
+    - rel_type: refines
+      spec_id: ARCH-04-001
 - id: BTND-05
   title: Actor Configuration for Participant Nodes
   kind: domain
@@ -287,6 +349,22 @@ groups:
     relationships:
     - rel_type: refines
       spec_id: BT-06-004
+  - id: BTND-06-008
+    priority: MUST
+    statement: >-
+      Code that writes to a `memory=False` py_trees Sequence MUST be written assuming that
+      any child's writes to the blackboard are immediately visible to subsequent children
+      but are NOT rolled back if a later child returns `FAILURE`. A `memory=False` Sequence
+      is non-transactional: partial side-effects from earlier children survive the composite's
+      final `FAILURE` status.
+    rationale: >-
+      The py_trees `memory=False` Sequence restarts from the first child on each tick, but it
+      does NOT undo blackboard writes made by children in previous ticks or earlier in the same
+      tick. This surprises developers who expect Sequence failure to be atomic. The correct
+      pattern for atomic multi-write operations is a single leaf node that performs all writes.
+    relationships:
+    - rel_type: refines
+      spec_id: BTND-06-001
 - id: BTND-07
   title: BT Node Module Organization
   kind: pattern
@@ -424,3 +502,24 @@ groups:
     verification: >-
       In each `Selector(Sequence(IsFoo, ApplyFoo), AlwaysSuccess)` composite,
       confirm the `AlwaysSuccess` node's `name` ends with `"Skipped"`.
+- id: BTND-09
+  title: BT Error Handling Contract
+  kind: pattern
+  specs:
+  - id: BTND-09-001
+    priority: MUST
+    statement: >-
+      BT helper functions MUST raise exceptions on error — they MUST NOT catch exceptions
+      and return a sentinel value. The `update()` method of the owning leaf node is the
+      sole try/except boundary: it calls helpers, catches any exceptions they raise,
+      writes to the error result channel (BTND-03-006), and returns `FAILURE`.
+    rationale: >-
+      If helpers catch their own errors and return sentinels (e.g., `None`, `False`), the
+      leaf's `update()` method cannot distinguish a legitimate `None` return from a hidden
+      failure. All error information travels via Python's exception mechanism so that
+      the single boundary point (`update()`) has complete diagnostic context.
+    relationships:
+    - rel_type: implements
+      spec_id: BTND-03-006
+    - rel_type: implements
+      spec_id: EH-02-001

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -970,10 +970,18 @@ groups:
   - id: CM-18-002
     priority: MUST
     statement: >-
-      The `INVITED → LAPSED` transition MUST be driven by a timer expiry, not by a
-      participant action. The timer period MUST be derived from the embargo's `end_time`
-      (or a configured grace period). The pocket veto materialises only when the timer
-      fires without a prior `INVITED → SIGNATORY` or `INVITED → DECLINED` transition.
+      The `INVITED → DECLINED` and `LAPSED → DECLINED` transitions MAY be driven by a
+      timer expiry (pocket veto) rather than requiring an explicit participant action.
+      The timer period SHOULD be a configurable policy window (default: 7 days). The
+      pocket veto materialises when the timer fires without a prior acceptance; the
+      system records the transition to `DECLINED` as if the participant had declined.
+      The `SIGNATORY → LAPSED` transition is NOT timer-based: it fires when the embargo
+      enters the `REVISE` state, invalidating prior consent for the new terms.
+    rationale: >-
+      Per `notes/participant-embargo-consent.md`: `LAPSED` means "embargo terms changed;
+      prior consent no longer applies." `DECLINED` includes both explicit refusals and
+      timeout-based implicit refusals. Confusing `LAPSED` with the timer path is a
+      known documentation pitfall.
   - id: CM-18-003
     priority: MUST
     statement: >-

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -977,19 +977,29 @@ groups:
   - id: CM-18-003
     priority: MUST
     statement: >-
-      The `NO_EMBARGO → INVITED`, `INVITED → SIGNATORY`, `INVITED → DECLINED`, and
-      `INVITED → LAPSED` transitions are the only valid PEC state changes. Any other
-      transition MUST be rejected as a protocol error.
+      The valid PEC state transitions are: `NO_EMBARGO | LAPSED | DECLINED → INVITED`
+      (INVITE trigger); `INVITED | LAPSED → SIGNATORY` (ACCEPT trigger); `INVITED | LAPSED
+      → DECLINED` (DECLINE trigger); `SIGNATORY → LAPSED` (REVISE trigger); and
+      `* → NO_EMBARGO` (RESET trigger, embargo terminated). Any other transition MUST be
+      rejected as a protocol error.
+    rationale: >-
+      The `LAPSED` and `DECLINED` states are not terminal: a participant who lapsed or
+      declined can be re-invited (e.g., when embargo terms change). `SIGNATORY → LAPSED`
+      occurs when the embargo enters REVISE and the participant's prior consent no longer
+      covers the revised terms. See `vultron/core/states/participant_embargo_consent.py`.
     relationships:
     - rel_type: refines
       spec_id: CM-18-001
   - id: CM-18-004
     priority: MUST_NOT
     statement: >-
-      A participant's PEC state MUST NOT move from `SIGNATORY` or `DECLINED` or `LAPSED`
-      to `INVITED`. Once consent has been resolved (in either direction) it MUST NOT be
-      restarted. A new embargo proposal requires a new PEC record, not mutation of the
-      existing one.
+      A participant's PEC state MUST NOT move from `SIGNATORY` to `INVITED` directly
+      (bypassing `LAPSED`). The only path back to `INVITED` from resolved states is via
+      `LAPSED → INVITED` (after a REVISE trigger) or `DECLINED → INVITED` (re-invite
+      after explicit decline). `SIGNATORY → INVITED` is not a valid transition.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-18-003
 - id: CM-19
   title: Participant Index Discipline
   kind: domain

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -952,3 +952,75 @@ groups:
     relationships:
     - rel_type: implements
       spec_id: CLP-10-006
+- id: CM-18
+  title: Participant Embargo Consent State Machine
+  kind: domain
+  specs:
+  - id: CM-18-001
+    priority: MUST
+    statement: >-
+      Each participant's embargo consent MUST be tracked as a `ParticipantEmbargoConsent`
+      (PEC) value with five possible states: `NO_EMBARGO` (initial), `INVITED` (invite sent,
+      awaiting response), `SIGNATORY` (accepted), `LAPSED` (timer expired with no response),
+      and `DECLINED` (explicitly refused).
+    rationale: >-
+      The five-state PEC machine formalizes the "pocket veto" mechanism: a participant who
+      is invited but never responds causes the embargo to lapse rather than block progress.
+      Source: `notes/participant-embargo-consent.md`.
+  - id: CM-18-002
+    priority: MUST
+    statement: >-
+      The `INVITED → LAPSED` transition MUST be driven by a timer expiry, not by a
+      participant action. The timer period MUST be derived from the embargo's `end_time`
+      (or a configured grace period). The pocket veto materialises only when the timer
+      fires without a prior `INVITED → SIGNATORY` or `INVITED → DECLINED` transition.
+  - id: CM-18-003
+    priority: MUST
+    statement: >-
+      The `NO_EMBARGO → INVITED`, `INVITED → SIGNATORY`, `INVITED → DECLINED`, and
+      `INVITED → LAPSED` transitions are the only valid PEC state changes. Any other
+      transition MUST be rejected as a protocol error.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-18-001
+  - id: CM-18-004
+    priority: MUST_NOT
+    statement: >-
+      A participant's PEC state MUST NOT move from `SIGNATORY` or `DECLINED` or `LAPSED`
+      to `INVITED`. Once consent has been resolved (in either direction) it MUST NOT be
+      restarted. A new embargo proposal requires a new PEC record, not mutation of the
+      existing one.
+- id: CM-19
+  title: Participant Index Discipline
+  kind: domain
+  specs:
+  - id: CM-19-001
+    priority: MUST
+    statement: >-
+      `case_participants` (the persisted set of `CaseParticipant` records) is the
+      authoritative source of participant membership. `actor_participant_index`
+      (the in-memory dict mapping actor IDs to participants) is a cache derived from
+      it. Divergence between these two structures is a hard error, not a recoverable
+      state.
+    rationale: >-
+      A divergence means the cache has entries the authority doesn't know about (or
+      vice versa), producing silently incorrect routing and access-control decisions.
+  - id: CM-19-002
+    priority: MUST
+    statement: >-
+      Any code path that modifies `case_participants` (add, remove, update) MUST also
+      update `actor_participant_index` atomically within the same transaction or
+      method call. The index MUST NOT be allowed to lag the authority.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-19-001
+  - id: CM-19-003
+    priority: MUST
+    statement: >-
+      Code that needs a participant by actor ID MUST read from `actor_participant_index`
+      (the cache). Code that needs the canonical participant set (e.g., for broadcast or
+      audit) MUST read from `case_participants`. Using the cache for canonical iteration
+      is prohibited because cache population order is undefined.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-19-001

--- a/specs/code-style.yaml
+++ b/specs/code-style.yaml
@@ -137,14 +137,25 @@ groups:
     rationale: Duplicated models diverge silently over time; a hierarchy makes the relationship explicit and reduces boilerplate
 - id: CS-10
   title: Port and Adapter Data Exchange
-  kind: pattern
+  kind: language
   specs:
   - id: CS-10-001
     priority: MUST
-    statement: Data passed across port/adapter boundaries MUST use Pydantic `BaseModel`-derived classes rather than plain
-      `dict`s
-    rationale: '`dict`s discard type information at the boundary, suppress validation, and make interfaces ambiguous. Pydantic
-      models preserve validation, IDE support, and documentation at every layer crossing.'
+    statement: >-
+      Data passed across port/adapter boundaries MUST use named, domain-typed Pydantic classes
+      rather than plain `dict`s or bare `BaseModel` subclasses without semantic meaning. Port
+      `Protocol` signatures MUST declare parameters and return values as specific domain types
+      (e.g., `VulnerabilityCase`, `CaseParticipant`), not as `BaseModel` or `dict`.
+    rationale: >-
+      This rule has two eras: prior to domain-typed core objects, "use Pydantic `BaseModel`"
+      was the correct guidance (vs. plain `dict`s). With named domain types in place,
+      the standard is now higher: ports must name the type specifically so that port
+      signatures serve as machine-readable contracts rather than type-erased boundaries.
+      Bare `BaseModel` at a port is equivalent to `dict` from a contract-clarity perspective.
+      Python-specific (`language`-kind). See also ARCH-08-001 for the port Protocol obligation.
+    relationships:
+    - rel_type: refines
+      spec_id: ARCH-08-001
   - id: CS-10-002
     priority: SHOULD
     statement: Wire-level ActivityStreams payload classes SHOULD carry the `Activity` suffix; domain event classes SHOULD

--- a/specs/demo-ci.yaml
+++ b/specs/demo-ci.yaml
@@ -67,6 +67,26 @@ groups:
             spec_id: EH-01-001
             note: error-handling.yaml
 
+      - id: DEMOCI-01-006
+        priority: MUST
+        statement: >-
+          Every scenario entry-point function MUST call `reset_demo_failures()`
+          as its first action and MUST call `assert_demo_success()` as its final
+          action before returning. These two calls form the bookend contract that
+          initialises the failure accumulator and converts accumulated failures
+          into a `DemoFailureError` for CI detection.
+        rationale: >-
+          DEMOCI-01-003 and DEMOCI-01-004 specify the accumulation mechanism, but
+          do not specify where the accumulator is initialised or where the final
+          assertion is made. Without explicit bookends, a scenario may inherit
+          failure state from a previous run (if not reset) or exit without
+          surfacing accumulated failures (if `assert_demo_success()` is not called).
+        relationships:
+          - rel_type: refines
+            spec_id: DEMOCI-01-003
+          - rel_type: refines
+            spec_id: DEMOCI-01-004
+
   - id: DEMOCI-02
     title: GitHub Actions Demo Workflow
     specs:

--- a/specs/demo-cli.yaml
+++ b/specs/demo-cli.yaml
@@ -45,6 +45,22 @@ groups:
     priority: MUST
     statement: >-
       Demo scripts MUST be relocated to `vultron/demo/` and MUST be importable as `vultron.demo.<script_name>`
+  - id: DC-02-003
+    priority: MUST
+    statement: >-
+      `demo_step` and `demo_check` MUST NOT be used interchangeably. `demo_step` is an
+      **action step**: it performs a side-effecting operation and swallows any exception into
+      the demo failure accumulator so the scenario continues. `demo_check` is an
+      **observation-only assertion block**: it verifies that state meets expectations and
+      accumulates assertion failures, but MUST NOT perform any side-effecting operation.
+    rationale: >-
+      Using `demo_step` for observation or `demo_check` for actions obscures the semantic
+      intent of the scenario. An action disguised as a check will not be correctly identified
+      as a side-effecting step in scenario tracing and logging; an observation disguised as
+      a step will mislead readers about what the scenario is doing vs. verifying.
+    relationships:
+    - rel_type: refines
+      spec_id: DC-02-001
 - id: DC-03
   title: Demo Isolation
   specs:

--- a/specs/embargo-policy.yaml
+++ b/specs/embargo-policy.yaml
@@ -138,3 +138,52 @@ groups:
     statement: >-
       EP-04-003 is contingent on a sender-proposal mechanism being available. Until such a
       mechanism exists, only the no-sender-proposal case (EP-04-001) applies at case creation.
+- id: EP-05
+  title: Counter-Revision PEC Cascade Rule
+  kind: domain
+  specs:
+  - id: EP-05-001
+    priority: MUST
+    statement: >-
+      When an embargo transitions from `ACTIVE` to `REVISE` (counter-revision proposed),
+      the CaseActor MUST call `_cascade_pec_revise()` to reset each `SIGNATORY`
+      participant's PEC state to `INVITED` so they can re-consent to the revised terms.
+    rationale: >-
+      Without the PEC cascade, a participant who signed for embargo terms `T1` would
+      remain `SIGNATORY` when the embargo is revised to `T2` — implying consent they
+      never gave. The cascade makes re-consent explicit.
+    relationships:
+    - rel_type: implements
+      spec_id: CM-18-001
+  - id: EP-05-002
+    priority: MUST_NOT
+    statement: >-
+      When the embargo is already in `REVISE` state and a further revision proposal
+      arrives (`REVISE → REVISE`), the CaseActor MUST NOT call `_cascade_pec_revise()`
+      again. The PEC states were already reset by the initial `ACTIVE → REVISE` transition;
+      a double cascade would incorrectly re-invite participants who may have already
+      re-consented.
+    relationships:
+    - rel_type: refines
+      spec_id: EP-05-001
+- id: EP-06
+  title: PEC Idempotency
+  kind: domain
+  specs:
+  - id: EP-06-001
+    priority: MUST_NOT
+    statement: >-
+      An idempotent retry or re-processing of a participant add-or-update MUST NOT
+      overwrite a non-null PEC state with the default `NO_EMBARGO`. Once a participant
+      has been assigned any non-default PEC state (`INVITED`, `SIGNATORY`, `LAPSED`,
+      or `DECLINED`), that state MUST be preserved across retries.
+    rationale: >-
+      Overwriting a `SIGNATORY` or `DECLINED` state with `NO_EMBARGO` on retry silently
+      revokes or erases consent that was already given. The positive-path idempotency
+      rule (don't double-add) is covered by CM-13-005; this rule covers the negative
+      path (don't downgrade).
+    relationships:
+    - rel_type: refines
+      spec_id: CM-13-005
+    - rel_type: implements
+      spec_id: CM-18-001

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -146,6 +146,25 @@ groups:
     relationships:
     - rel_type: refines
       spec_id: DEMOMA-00-001
+  - id: DEMOMA-05-003
+    priority: MAY
+    statement: >-
+      Exchange demos located under `vultron/demo/exchange/` MAY use direct inbox injection
+      (constructing and posting raw ActivityStreams JSON) to simulate the receipt of a
+      specific wire message. Scenario demos under `vultron/demo/scenarios/` MUST NOT use
+      direct inbox injection (DEMOMA-05-001 and DEMOMA-05-002 apply without exception to
+      scenario demos).
+    rationale: >-
+      Exchange demos are low-level wire-format verification scripts that intentionally
+      exercise the inbox parsing path directly. Scenario demos must exercise the full
+      actor behavior including trigger dispatch; direct inbox injection in a scenario demo
+      bypasses the triggering actor's BT execution and produces a scenario that does not
+      test the protocol from end to end. This carve-out resolves the apparent contradiction
+      between DEMOMA-05-001 (which would prohibit exchange demos) and the existing
+      `vultron/demo/exchange/` code.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-05-001
 - id: DEMOMA-06
   title: Two-Actor Scenario Workflow
   specs:

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -151,7 +151,7 @@ groups:
     statement: >-
       Exchange demos located under `vultron/demo/exchange/` MAY use direct inbox injection
       (constructing and posting raw ActivityStreams JSON) to simulate the receipt of a
-      specific wire message. Scenario demos under `vultron/demo/scenarios/` MUST NOT use
+      specific wire message. Scenario demos under `vultron/demo/scenario/` MUST NOT use
       direct inbox injection (DEMOMA-05-001 and DEMOMA-05-002 apply without exception to
       scenario demos).
     rationale: >-

--- a/specs/response-format.yaml
+++ b/specs/response-format.yaml
@@ -145,6 +145,21 @@ groups:
       spec_id: VP-11-004
     - rel_type: implements
       spec_id: VP-11-005
+  - id: RF-08-002
+    priority: MUST
+    statement: >-
+      The `inReplyTo` field requirement MUST be enforced at the Pydantic model level via a
+      `model_validator` on `Accept`, `Reject`, and other response activity classes, not by
+      call-site convention. The validator MUST reject a response object that has a `None` or
+      missing `inReplyTo` at construction time.
+    rationale: >-
+      Call-site convention (setting `inReplyTo` manually at every factory call site) is
+      fragile: new factory paths can forget it, and there is no compile-time or model-validation
+      enforcement. A `model_validator` makes the invariant intrinsic to the type and
+      impossible to bypass silently.
+    relationships:
+    - rel_type: refines
+      spec_id: RF-08-001
 - id: RF-09
   title: Idempotent Responses
   specs:

--- a/specs/semantic-extraction.yaml
+++ b/specs/semantic-extraction.yaml
@@ -109,3 +109,53 @@ groups:
   - id: SE-05-003
     priority: MUST
     statement: All patterns MUST have unit test coverage
+  - id: SE-05-004
+    priority: SHOULD
+    statement: >-
+      Pattern matching SHOULD be actor-subtype-aware where the semantics of an activity
+      differ based on whether the sender is a `Vendor`, `Coordinator`, `Researcher`, or
+      other `CVDRole`. Patterns that match on object type alone (e.g., `InviteActorToCasePattern`)
+      without inspecting the sender's role produce a single use-case handler that must
+      internally branch; a separate pattern per sender subtype is the preferred decomposition.
+    rationale: >-
+      Open design question (as of 2026-07): `InviteActorToCasePattern` matches regardless
+      of the invitee's role. This is correct for the current single-handler path but will
+      need revisiting when role-specific invite acceptance logic is introduced. This entry
+      marks the known limitation so it is not rediscovered.
+- id: SE-06
+  title: Registry Order Enforcement
+  kind: implementation
+  specs:
+  - id: SE-06-001
+    priority: MUST
+    statement: >-
+      The `ActivityPatternRegistry` MUST include an import-time guard function
+      `_validate_registry_order()` that raises `RegistryOrderError` if any registered
+      `ActivityPattern` appears in the registry in an order that would cause a more-specific
+      pattern to be shadowed by a less-specific one that matches a superset of the same
+      activities.
+    rationale: >-
+      py_trees traverses the registry in insertion order; a less-specific pattern inserted
+      before a more-specific one will match first and the specific case is never reached.
+      This is a silent correctness bug that manifests only for the specific activity
+      combinations the shadowed pattern was meant to handle.
+    relationships:
+    - rel_type: refines
+      spec_id: SE-05-001
+  - id: SE-06-002
+    priority: MUST
+    statement: >-
+      `RegistryOrderError` MUST be a named exception class in the semantic extraction
+      module. It MUST NOT be raised as a generic `ValueError` or `AssertionError`.
+    relationships:
+    - rel_type: implements
+      spec_id: SE-06-001
+  - id: SE-06-003
+    priority: MUST
+    statement: >-
+      The registry order guard MUST have a companion unit test that asserts correct ordering
+      is maintained for all registered patterns. The test MUST fail if the guard raises
+      `RegistryOrderError` on the current registry.
+    relationships:
+    - rel_type: implements
+      spec_id: SE-06-001

--- a/specs/state-machine.yaml
+++ b/specs/state-machine.yaml
@@ -167,3 +167,73 @@ groups:
       When deserializing state values from the DataLayer or from wire payloads, the receiving
       Pydantic model MUST declare the state field with the `StrEnum` type so that Pydantic
       coerces the incoming string to the correct enum member
+- id: SM-09
+  title: CS Forced Transitions and Reachable States
+  kind: domain
+  specs:
+  - id: SM-09-001
+    priority: MUST
+    statement: >-
+      The CS state machine MUST enforce two forced (ephemeral) transitions at validation
+      time: (1) `pX → PX` — exploit-public forces public-aware; (2) `vP → VP` —
+      public-aware forces vendor-aware. Any incoming CS state that contains `pX` or
+      `vP` MUST be promoted to the forced form before being persisted.
+    rationale: >-
+      These transitions are protocol-correctness invariants, not optional normalizations.
+      A CS state of `pXa` (exploit public, public unaware) is semantically impossible —
+      the exploit being public implies the vulnerability is public. Enforced by
+      `vultron/core/case_states/validations.py` `TRANSITION_RULES`.
+    relationships:
+    - rel_type: implements
+      spec_id: VP-14-001
+      note: exploit/attack public implies embargo termination, not just awareness
+  - id: SM-09-002
+    priority: MUST_NOT
+    statement: >-
+      The CS state machine MUST NOT allow states in the `vF*` pattern (fix-ready,
+      vendor-unaware) or `*fD*` pattern (fix-deployed, fix-not-ready). These 24 states
+      are structurally impossible and MUST be rejected at validation time.
+    rationale: >-
+      A vendor cannot have deployed a fix (`D`) without first having one ready (`F`);
+      a fix cannot be ready (`F`) if the vendor is unaware (`v`) of the vulnerability.
+      Together, SM-09-001 and this rule reduce the theoretical 64-state CS space to
+      the 40 reachable states: 8 valid VFD combinations × 5 PXA combinations.
+    relationships:
+    - rel_type: refines
+      spec_id: SM-09-001
+- id: SM-10
+  title: State Scoping Rules
+  kind: domain
+  specs:
+  - id: SM-10-001
+    priority: MUST
+    statement: >-
+      RM and VFD state transitions MUST update the sending actor's `ParticipantStatus`
+      record for the affected `CaseParticipant`. These axes are participant-specific:
+      each participant's RM and VFD state evolves independently.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-04-001
+    - rel_type: refines
+      spec_id: CM-04-002
+  - id: SM-10-002
+    priority: MUST
+    statement: >-
+      EM and PXA state transitions MUST update the shared `CaseStatus` record for the
+      associated `VulnerabilityCase`. These axes are participant-agnostic: a single
+      shared value covers all participants in the case.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-04-003
+    - rel_type: refines
+      spec_id: CM-04-004
+  - id: SM-10-003
+    priority: MUST_NOT
+    statement: >-
+      Handlers MUST NOT apply a participant-specific axis transition (RM, VFD) to the
+      shared `CaseStatus`, and MUST NOT apply a participant-agnostic axis transition
+      (EM, PXA) to a participant's `ParticipantStatus`. Mixing axes is a protocol
+      correctness violation.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-04-006

--- a/specs/state-machine.yaml
+++ b/specs/state-machine.yaml
@@ -191,13 +191,16 @@ groups:
     priority: MUST_NOT
     statement: >-
       The CS state machine MUST NOT allow states in the `vF*` pattern (fix-ready,
-      vendor-unaware) or `*fD*` pattern (fix-deployed, fix-not-ready). These 24 states
+      vendor-unaware) or `*fD*` pattern (fix-deployed, fix-not-ready). These 32 states
       are structurally impossible and MUST be rejected at validation time.
     rationale: >-
       A vendor cannot have deployed a fix (`D`) without first having one ready (`F`);
       a fix cannot be ready (`F`) if the vendor is unaware (`v`) of the vulnerability.
       Together, SM-09-001 and this rule reduce the theoretical 64-state CS space to
-      the 40 reachable states: 8 valid VFD combinations × 5 PXA combinations.
+      the 32 reachable CS states: 4 valid VFD combinations (vfd, Vfd, VFd, VFD) ×
+      8 PXA combinations. See `docs/reference/formal_protocol/states.md` for the
+      formal derivation. Note: the "40-state" figure in the formal protocol paper
+      refers to the global case state space (`8 PXA × 5 EM`), not to CS alone.
     relationships:
     - rel_type: refines
       spec_id: SM-09-001

--- a/specs/testability.yaml
+++ b/specs/testability.yaml
@@ -107,6 +107,36 @@ groups:
     rationale: >-
       Flaky tests erode confidence in the test suite, mask real failures, and slow development.
       A flaky test MUST be fixed or removed; it MUST NOT be left in the suite.
+  - id: TB-06-007
+    priority: MUST
+    statement: >-
+      Integration tests that exercise multi-actor message flows MUST give each simulated
+      actor its own isolated `DataLayer` instance. Tests that share a single `DataLayer`
+      across multiple actors bypass the outbox→inbox delivery path and test in-memory
+      state sharing instead of protocol communication.
+    rationale: >-
+      The outbox→inbox delivery path is a critical protocol boundary. A shared DataLayer
+      removes it: actor A's outbox write is immediately visible to actor B without going
+      through any delivery mechanism, making the test a unit test of shared state rather
+      than an integration test of the protocol.
+    relationships:
+    - rel_type: refines
+      spec_id: TB-06-001
+  - id: TB-06-008
+    priority: MUST
+    statement: >-
+      BT factories that have probabilistic defaults (e.g., always-succeed or always-fail
+      stubs for nodes backed by configurable policies) MUST expose a module-level
+      deterministic factory constant for use in tests. Tests MUST use the deterministic
+      factory, not the production random-policy factory, to avoid stochastic test failures.
+    rationale: >-
+      A test that calls a production BT factory configured with a probability distribution
+      may pass or fail depending on random outcomes. The deterministic factory ensures
+      the test exercises a specific code path every time. Convention: name the constant
+      `_always_succeed_factory` or `_always_fail_factory` at module level.
+    relationships:
+    - rel_type: refines
+      spec_id: TB-06-006
 - id: TB-07
   title: Mocking and Stubbing
   specs:
@@ -187,3 +217,64 @@ groups:
       Automated boundary tests catch accidental cross-layer imports earlier than code review.
     scope:
     - production
+  - id: TB-10-002
+    priority: MUST
+    statement: >-
+      Architecture ratchet tests MUST use bidirectional equality: `assert actual_violations
+      == KNOWN_VIOLATIONS`. A subset check (`assert actual ⊆ KNOWN`) is prohibited because
+      it allows the violation set to grow without failing the test. When a violation is
+      resolved, its entry MUST be removed from `KNOWN_VIOLATIONS` in the same commit.
+    rationale: >-
+      See ARCH-18-001 for the architecture-level rule. This entry specifies the test
+      implementation obligation.
+    relationships:
+    - rel_type: implements
+      spec_id: ARCH-18-001
+- id: TB-12
+  title: BT Test Harness
+  kind: pattern
+  specs:
+  - id: TB-12-001
+    priority: MUST
+    statement: >-
+      BT leaf and composite node tests MUST use the `BTTestScenario` deep-module test
+      harness. The `setup_node_blackboard()` helper is an anti-pattern for integration
+      tests of BT nodes: it creates shallow, manually wired blackboard state that
+      diverges from the tree structure the node expects in production.
+    rationale: >-
+      `BTTestScenario` instantiates the full tree (or a representative subtree) and
+      exercises nodes in their actual execution context, catching structural assumptions
+      (e.g., parent Sequence providing the blackboard namespace) that `setup_node_blackboard()`
+      tests cannot detect.
+    relationships:
+    - rel_type: refines
+      spec_id: TB-03-001
+  - id: TB-12-002
+    priority: MUST
+    statement: >-
+      Each BT scenario test MUST run the BT tree exactly once per test case. Running the
+      same tree instance multiple times in a single test produces accumulated blackboard
+      state that masks isolation failures. Each test case MUST get a fresh tree instance.
+    relationships:
+    - rel_type: refines
+      spec_id: TB-12-001
+  - id: TB-12-003
+    priority: MUST
+    statement: >-
+      BT integration tests MUST complete within 5 seconds per test case. Tests that
+      exceed this limit MUST be redesigned (e.g., reducing dataset size, mocking
+      external I/O) rather than raising the timeout. The `pytest-timeout` `timeout = 5`
+      configuration MUST apply to all BT tests.
+    relationships:
+    - rel_type: refines
+      spec_id: TB-12-001
+  - id: TB-12-004
+    priority: SHOULD
+    statement: >-
+      When a BT test scenario produces a `SUBFAILED` status (partial-success in a
+      `memory=True` Sequence), the test SHOULD explicitly assert the expected leaf
+      statuses rather than asserting only the root status. `SUBFAILED` on the root
+      masks which children succeeded and which failed.
+    relationships:
+    - rel_type: refines
+      spec_id: TB-12-001

--- a/specs/vocabulary-model.yaml
+++ b/specs/vocabulary-model.yaml
@@ -160,6 +160,21 @@ groups:
       If a rehydrated object's `as_type` is not found in the vocabulary registry, rehydration
       MUST raise `KeyError` or `ValueError` rather than returning a partially constructed
       object
+  - id: VM-06-006
+    priority: MUST
+    statement: >-
+      A vocabulary override (replacing the default `VultronVocabulary` with a custom one)
+      MUST preserve at least one registration from each base module that the production
+      codebase depends on. An override that silently clears all base registrations is
+      equivalent to a blank vocabulary and will cause rehydration failures for all standard
+      Vultron activity types.
+    rationale: >-
+      The vocabulary registry is global. Test or demo code that installs a minimal override
+      without re-registering base types causes downstream rehydration to raise `KeyError`
+      for every standard type. The invariant ensures overrides are additive-by-default.
+    relationships:
+    - rel_type: refines
+      spec_id: VM-06-001
 - id: VM-07
   title: Serialization Rules
   specs:
@@ -177,6 +192,24 @@ groups:
     priority: MUST_NOT
     statement: >-
       `object_to_record()` MUST NOT be called on an object whose `as_type` starts with `"as_"`
+  - id: VM-07-004
+    priority: MUST
+    statement: >-
+      `serialize_as_any=True` MUST be declared on any Pydantic model field that holds an
+      object whose concrete runtime type is a subtype of the field's declared type, at
+      **both** the persistence serialization boundary and the wire delivery serialization
+      boundary. Omitting `serialize_as_any=True` at either boundary causes the serializer
+      to use the declared (base) type's schema, silently dropping all subtype-specific fields.
+    rationale: >-
+      Pydantic v2 uses the declared field type for serialization by default. A field typed
+      as `VulnerabilityCase` but holding a `VulnerabilityCaseStub` at runtime will serialize
+      using `VulnerabilityCase`'s schema, dropping `stub_*` fields entirely with no error.
+      Root causes of BUG-26042201 and BUG-26051902. Both persistence and delivery boundaries
+      are required because a correct write-path can still produce incorrect wire output if
+      the delivery serializer also lacks this flag.
+    relationships:
+    - rel_type: refines
+      spec_id: VM-07-001
 - id: VM-08
   title: Static Object Integrity
   specs:

--- a/specs/vultron-protocol-spec.yaml
+++ b/specs/vultron-protocol-spec.yaml
@@ -986,3 +986,44 @@ groups:
     statement: >-
       Case or vulnerability identifiers SHOULD NOT carry any information that reveals potentially
       sensitive details about the vulnerability
+- id: VP-17
+  title: CaseActor Write Authority
+  kind: domain
+  specs:
+  - id: VP-17-001
+    priority: MUST
+    statement: >-
+      `CaseActor` is the ONLY entity authorized to mutate shared case state (CS axes EM and
+      PXA, the embargo record, and the case ledger). No participant or use-case handler MUST
+      write to shared case state directly; all mutations MUST route through a `CaseActor`
+      method or use-case.
+    rationale: >-
+      This single-writer axiom prevents concurrent-write races and ensures that all shared
+      state changes flow through the actor's consistency checks and persistence layer.
+      The CS participant-specific axes (RM, VFD) are owned by each participant's
+      `CaseParticipant` record and are intentionally excluded from this restriction.
+    relationships:
+    - rel_type: refines
+      spec_id: VP-02-001
+    - rel_type: constrains
+      spec_id: SM-10-002
+- id: VP-18
+  title: Routing Topology
+  kind: domain
+  specs:
+  - id: VP-18-001
+    priority: MUST
+    statement: >-
+      Outbound messages from a participant MUST follow the routing path:
+      `participant → CaseActor → CaseLedgerEntry → broadcast → participants`.
+      A participant MUST NOT deliver messages directly to another participant's inbox;
+      delivery MUST be mediated by the `CaseActor` and recorded in the case ledger
+      before being fanned out.
+    rationale: >-
+      The ledger record provides the audit trail and ordering guarantees for all case
+      activity. Direct peer-to-peer delivery bypasses the ledger and the broadcast
+      idempotency controls.
+    relationships:
+    - rel_type: refines
+      spec_id: PCR-08-001
+      note: participant-case-relationships.yaml — PCR-08 covers ledger-based broadcast


### PR DESCRIPTION
- Closes #1408

## Summary

Backfills 42 codebase invariants into the machine-readable YAML spec corpus. A developer reproducing Vultron from specs alone would previously have missed or misimplemented these; they are now covered by `spec-dump` output.

All 42 entries added to **existing** spec files — no new `.yaml` files required, no ADRs created (these formalize decisions already made, not evaluated alternatives).

## Changes (9 thematic commits)

- **SM**: CS forced transitions (`pX→PX`, `vP→VP`), 40-state reachability constraint, participant-scoped vs. case-scoped state axes (SM-09, SM-10)
- **VP**: CaseActor single-writer axiom, routing topology `participant→CaseActor→ledger→broadcast` (VP-17, VP-18)
- **CM/EP**: PEC 5-state machine (pocket veto), participant index authority/cache discipline, counter-revision cascade rule, PEC idempotency (CM-18, CM-19, EP-05, EP-06)
- **BTND/BT**: 7 BT node-design gaps — blackboard naming, error handling contract, KeyError→FAILURE, `behaviors/` import prohibition, non-transactional `memory=False`, RLock obligation (BTND-03-005/006/007, BTND-04-003, BTND-06-008, BTND-09, BT-11-004)
- **SE/VM/AF/RF**: Registry order enforcement, `serialize_as_any=True` at both boundaries (root cause BUG-26042201/BUG-26051902), vocabulary override preservation, Activity Translator port pattern, `inReplyTo` model-validator enforcement (SE-05-004, SE-06, VM-06-006, VM-07-004, AF-09, RF-08-002)
- **ARCH/CS**: CS-10-001 refined from "BaseModel-derived" to "named domain-typed Pydantic classes" (kind→language), demo import prohibition, validate-at-edge boundary obligation, app-state isolation, ASGIEmitter base-URL and reentrancy fix (#557/#558), architecture ratchet discipline, 3-stage outbound delivery pipeline (ARCH-01-005, ARCH-08-002, ARCH-16–19; CS-10-001 updated)
- **TB**: Per-actor DataLayer isolation, BT factory determinism, architecture ratchet test discipline (bidirectional assertion), `BTTestScenario` harness pattern, one-run rule, 5-second timeout (TB-06-007/008, TB-10-002, TB-12)
- **DC/DEMOMA/DEMOCI/BT**: `demo_step` vs. `demo_check` semantic distinction, exchange-demo inbox-injection carve-out (resolves DEMOMA-05-001 spec/code contradiction), `reset_demo_failures`/`assert_demo_success` bookend contract, fuzzer node replacement lifecycle (DC-02-003, DEMOMA-05-003, DEMOCI-01-006, BT-21)

🤖 Generated with [Claude Code](https://claude.com/claude-code)