### PR TITLE
fix(specs): correct kind designations for 9 entries from #1412

### DIFF
--- a/specs/activity-factories.yaml
+++ b/specs/activity-factories.yaml
@@ -168,7 +168,7 @@ groups:
       and MUST NOT be conflated with factory function migration
 - id: AF-09
   title: Activity Translator Port
-  kind: pattern
+  kind: implementation
   specs:
   - id: AF-09-001
     priority: MUST

--- a/specs/architecture.yaml
+++ b/specs/architecture.yaml
@@ -51,6 +51,7 @@ groups:
           all violations be systematically remediated via driven ports.
   - id: ARCH-01-005
     priority: MUST_NOT
+    kind: implementation
     statement: >-
       Production adapters (HTTP routes, CLI commands, MCP server, background workers)
       MUST NOT import from `vultron/demo/`. Demo-layer modules are not part of the
@@ -512,7 +513,7 @@ groups:
       the code.
 - id: ARCH-16
   title: App State Isolation
-  kind: pattern
+  kind: language
   specs:
   - id: ARCH-16-001
     priority: MUST_NOT
@@ -592,7 +593,7 @@ groups:
       spec_id: ARCH-18-001
 - id: ARCH-19
   title: Outbound Delivery Pipeline
-  kind: domain
+  kind: pattern
   specs:
   - id: ARCH-19-001
     priority: MUST

--- a/specs/behavior-tree-node-design.yaml
+++ b/specs/behavior-tree-node-design.yaml
@@ -504,7 +504,7 @@ groups:
       confirm the `AlwaysSuccess` node's `name` ends with `"Skipped"`.
 - id: BTND-09
   title: BT Error Handling Contract
-  kind: pattern
+  kind: language
   specs:
   - id: BTND-09-001
     priority: MUST

--- a/specs/testability.yaml
+++ b/specs/testability.yaml
@@ -109,6 +109,7 @@ groups:
       A flaky test MUST be fixed or removed; it MUST NOT be left in the suite.
   - id: TB-06-007
     priority: MUST
+    kind: implementation
     statement: >-
       Integration tests that exercise multi-actor message flows MUST give each simulated
       actor its own isolated `DataLayer` instance. Tests that share a single `DataLayer`
@@ -124,6 +125,7 @@ groups:
       spec_id: TB-06-001
   - id: TB-06-008
     priority: MUST
+    kind: language
     statement: >-
       BT factories that have probabilistic defaults (e.g., always-succeed or always-fail
       stubs for nodes backed by configurable policies) MUST expose a module-level
@@ -205,7 +207,7 @@ groups:
         infrastructure correctness
 - id: TB-10
   title: Architecture Boundary Tests
-  kind: pattern
+  kind: dev-process
   specs:
   - id: TB-10-001
     priority: SHOULD
@@ -232,7 +234,7 @@ groups:
       spec_id: ARCH-18-001
 - id: TB-12
   title: BT Test Harness
-  kind: pattern
+  kind: language
   specs:
   - id: TB-12-001
     priority: MUST


### PR DESCRIPTION
- Closes (kind-only follow-up to #1412)

## Summary

PR #1412 backfilled 42 spec entries. On review, 9 entries had incorrect `kind` designations — primarily `pattern` used where the body references Python-specific paths, class names, or framework API methods. This pollutes the language-agnostic spec pool and would mislead a non-Python implementer.

Corrections applied (no content changes — kind field only):

| Entry | Was | Now | Reason |
|---|---|---|---|
| `AF-09` | `pattern` | `implementation` | Names `vultron/core/use_cases/` and `vultron/wire/` Python paths |
| `ARCH-01-005` | inherits `pattern` | `implementation` | Names `vultron/demo/` Python path |
| `ARCH-16` | `pattern` | `language` | App factory principle is Python-ecosystem level (vocabulary registries, DataLayer factories, BT bridges) |
| `ARCH-19` | `domain` | `pattern` | 3-stage emission/transport/acceptance pipeline is a general distributed-systems pattern, not CVD-specific |
| `BTND-09` | `pattern` | `language` | `update()` as sole try/except boundary is py_trees API — not language-agnostic |
| `TB-06-007` | inherits `general` | `implementation` | References `DataLayer`, a Vultron-specific abstraction |
| `TB-06-008` | inherits `general` | `language` | References py_trees BT factories and `_always_succeed_factory` naming convention |
| `TB-10` | `pattern` | `dev-process` | KNOWN_VIOLATIONS ratchet discipline is this project's enforcement process |
| `TB-12` | `pattern` | `language` | `BTTestScenario`, `setup_node_blackboard()`, py_trees `update()`/`execute()` are py_trees API |

## Verification

- `uv run spec-dump` parses all 4 changed files without errors
- Spec registry linter passes (pre-commit hook)
- All 9 corrected entries reflect the new kind in `spec-dump` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)