### PR TITLE
test: add per-function unit tests for all six actor vocab example functions

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1373.md
+++ b/plan/history/2607/implementation/ISSUE-1373.md
@@ -1,0 +1,18 @@
+---
+source: ISSUE-1373
+timestamp: '2026-07-14T17:44:55.844705+00:00'
+title: add per-function unit tests for all six actor vocab example functions
+type: implementation
+---
+
+## Issue #1373 — test: add per-function unit tests for all six actor vocab example functions
+
+Added `test/wire/as2/vocab/test_vocab_actor_examples.py` with 32 unit tests
+covering all six actor vocab example functions: `recommend_actor`,
+`accept_actor_recommendation`, `reject_actor_recommendation`,
+`offer_case_participant`, `accept_case_participant_offer`, and
+`reject_case_participant_offer`. Each test class asserts return type, `actor`
+field, `to` field, and `object_` reference. All 4679 unit tests pass;
+Black/flake8/mypy/pyright clean.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1417>

--- a/test/wire/as2/vocab/test_vocab_actor_examples.py
+++ b/test/wire/as2/vocab/test_vocab_actor_examples.py
@@ -1,0 +1,202 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""
+Per-function unit tests for the six actor vocab example functions in
+``vultron.wire.as2.vocab.examples.actor``.
+
+Each test asserts:
+- Return type matches the declared return annotation.
+- ``actor`` field is set to the expected actor ID.
+- ``to`` field is set to the expected recipient(s).
+- ``object_`` references the expected actor or CaseParticipant.
+"""
+
+import unittest
+from typing import cast
+
+from vultron.wire.as2.vocab.activities.actor import _RecommendActorActivity
+from vultron.wire.as2.vocab.base.objects.activities.transitive import (
+    as_Accept,
+    as_Offer,
+    as_Reject,
+)
+from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+from vultron.wire.as2.vocab.examples._base import (
+    _CASE_ACTOR,
+    _COORDINATOR,
+    case,
+    finder,
+    vendor,
+)
+from vultron.wire.as2.vocab.examples.actor import (
+    accept_actor_recommendation,
+    accept_case_participant_offer,
+    offer_case_participant,
+    recommend_actor,
+    reject_actor_recommendation,
+    reject_case_participant_offer,
+)
+
+
+class TestRecommendActor(unittest.TestCase):
+    def setUp(self):
+        self.activity = recommend_actor()
+        self.finder = finder()
+        self.vendor = vendor()
+        self.coordinator = _COORDINATOR
+        self.case = case()
+
+    def test_return_type(self):
+        self.assertIsInstance(self.activity, as_Offer)
+
+    def test_actor_is_finder(self):
+        self.assertEqual(self.activity.actor, self.finder.id_)
+
+    def test_to_is_vendor(self):
+        self.assertEqual(self.activity.to, self.vendor.id_)
+
+    def test_object_is_recommended_actor(self):
+        self.assertEqual(self.activity.object_, self.coordinator)
+
+    def test_target_is_case(self):
+        self.assertEqual(self.activity.target, self.case.id_)
+
+
+class TestAcceptActorRecommendation(unittest.TestCase):
+    def setUp(self):
+        self.activity = accept_actor_recommendation()
+        self.vendor = vendor()
+        self.finder = finder()
+        self.case = case()
+
+    def test_return_type(self):
+        self.assertIsInstance(self.activity, as_Accept)
+
+    def test_actor_is_vendor(self):
+        self.assertEqual(self.activity.actor, self.vendor.id_)
+
+    def test_to_is_finder(self):
+        self.assertEqual(self.activity.to, self.finder.id_)
+
+    def test_object_is_recommendation_offer(self):
+        self.assertIsInstance(self.activity.object_, _RecommendActorActivity)
+
+    def test_target_is_case(self):
+        self.assertEqual(self.activity.target, self.case.id_)
+
+
+class TestRejectActorRecommendation(unittest.TestCase):
+    def setUp(self):
+        self.activity = reject_actor_recommendation()
+        self.vendor = vendor()
+        self.finder = finder()
+        self.case = case()
+
+    def test_return_type(self):
+        self.assertIsInstance(self.activity, as_Reject)
+
+    def test_actor_is_vendor(self):
+        self.assertEqual(self.activity.actor, self.vendor.id_)
+
+    def test_to_is_finder(self):
+        self.assertEqual(self.activity.to, self.finder.id_)
+
+    def test_object_is_recommendation_offer(self):
+        self.assertIsInstance(self.activity.object_, _RecommendActorActivity)
+
+    def test_target_is_case(self):
+        self.assertEqual(self.activity.target, self.case.id_)
+
+
+class TestOfferCaseParticipant(unittest.TestCase):
+    def setUp(self):
+        self.activity = offer_case_participant()
+        self.case_actor = _CASE_ACTOR
+        self.vendor = vendor()
+        self.coordinator = _COORDINATOR
+        self.case = case()
+
+    def test_return_type(self):
+        self.assertIsInstance(self.activity, as_Offer)
+
+    def test_actor_is_case_actor(self):
+        self.assertEqual(self.activity.actor, self.case_actor.id_)
+
+    def test_to_is_vendor(self):
+        self.assertEqual(self.activity.to, [self.vendor.id_])
+
+    def test_object_is_case_participant(self):
+        participant = cast(CaseParticipant, self.activity.object_)
+        self.assertIsInstance(participant, CaseParticipant)
+
+    def test_participant_attributed_to_coordinator(self):
+        participant = cast(CaseParticipant, self.activity.object_)
+        attr = participant.attributed_to
+        attr_id = getattr(attr, "id_", None) or attr
+        self.assertEqual(attr_id, self.coordinator.id_)
+
+    def test_target_is_case(self):
+        self.assertEqual(self.activity.target, self.case.id_)
+
+    def test_origin_is_set(self):
+        self.assertIsNotNone(self.activity.origin)
+
+
+class TestAcceptCaseParticipantOffer(unittest.TestCase):
+    def setUp(self):
+        self.activity = accept_case_participant_offer()
+        self.vendor = vendor()
+        self.case_actor = _CASE_ACTOR
+        self.case = case()
+
+    def test_return_type(self):
+        self.assertIsInstance(self.activity, as_Accept)
+
+    def test_actor_is_vendor(self):
+        self.assertEqual(self.activity.actor, self.vendor.id_)
+
+    def test_to_is_case_actor(self):
+        self.assertEqual(self.activity.to, [self.case_actor.id_])
+
+    def test_object_is_offer(self):
+        self.assertIsInstance(self.activity.object_, as_Offer)
+
+    def test_target_is_case(self):
+        self.assertEqual(self.activity.target, self.case.id_)
+
+
+class TestRejectCaseParticipantOffer(unittest.TestCase):
+    def setUp(self):
+        self.activity = reject_case_participant_offer()
+        self.vendor = vendor()
+        self.case_actor = _CASE_ACTOR
+        self.case = case()
+
+    def test_return_type(self):
+        self.assertIsInstance(self.activity, as_Reject)
+
+    def test_actor_is_vendor(self):
+        self.assertEqual(self.activity.actor, self.vendor.id_)
+
+    def test_to_is_case_actor(self):
+        self.assertEqual(self.activity.to, [self.case_actor.id_])
+
+    def test_object_is_offer(self):
+        self.assertIsInstance(self.activity.object_, as_Offer)
+
+    def test_target_is_case(self):
+        self.assertEqual(self.activity.target, self.case.id_)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/wire/as2/vocab/test_vocab_actor_examples.py
+++ b/test/wire/as2/vocab/test_vocab_actor_examples.py
@@ -24,7 +24,10 @@ Each test asserts:
 import unittest
 from typing import cast
 
-from vultron.wire.as2.vocab.activities.actor import _RecommendActorActivity
+from vultron.wire.as2.vocab.activities.actor import (
+    _OfferCaseParticipantActivity,
+    _RecommendActorActivity,
+)
 from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Accept,
     as_Offer,
@@ -168,8 +171,10 @@ class TestAcceptCaseParticipantOffer(unittest.TestCase):
     def test_to_is_case_actor(self):
         self.assertEqual(self.activity.to, [self.case_actor.id_])
 
-    def test_object_is_offer(self):
-        self.assertIsInstance(self.activity.object_, as_Offer)
+    def test_object_is_case_participant_offer(self):
+        self.assertIsInstance(
+            self.activity.object_, _OfferCaseParticipantActivity
+        )
 
     def test_target_is_case(self):
         self.assertEqual(self.activity.target, self.case.id_)
@@ -191,8 +196,10 @@ class TestRejectCaseParticipantOffer(unittest.TestCase):
     def test_to_is_case_actor(self):
         self.assertEqual(self.activity.to, [self.case_actor.id_])
 
-    def test_object_is_offer(self):
-        self.assertIsInstance(self.activity.object_, as_Offer)
+    def test_object_is_case_participant_offer(self):
+        self.assertIsInstance(
+            self.activity.object_, _OfferCaseParticipantActivity
+        )
 
     def test_target_is_case(self):
         self.assertEqual(self.activity.target, self.case.id_)


### PR DESCRIPTION
- Closes #1373

## Summary

Adds 32 per-function unit tests covering the six actor vocab example functions
in `vultron/wire/as2/vocab/examples/actor.py`, satisfying the issue acceptance
criteria that all six functions have at least one assertion-based test covering
return type, `actor` field, `to` field, and `object_` reference.

## Changes

- `test/wire/as2/vocab/test_vocab_actor_examples.py`: new test file with six
  test classes (`TestRecommendActor`, `TestAcceptActorRecommendation`,
  `TestRejectActorRecommendation`, `TestOfferCaseParticipant`,
  `TestAcceptCaseParticipantOffer`, `TestRejectCaseParticipantOffer`),
  importing directly from `vultron.wire.as2.vocab.examples.actor` for
  per-module coverage.

## Verification

- All 32 new tests pass
- 4679 unit tests pass total (38 skipped, 2 xfailed)
- Black, flake8, mypy, pyright all clean