### PR TITLE
fix(bt): namespace participant blackboard keys by report_id (BTND-03-004)

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1397.md
+++ b/plan/history/2607/implementation/ISSUE-1397.md
@@ -1,0 +1,16 @@
+---
+source: ISSUE-1397
+timestamp: '2026-07-14T18:21:02.285566+00:00'
+title: namespace participant blackboard keys by report_id
+type: implementation
+---
+
+## Issue #1397 — fix: namespace new_case_participant / participant_case / new_participant_id blackboard keys by report_id
+
+Namespaced three flat inter-node handoff blackboard keys in the participant creation subtrees to prevent concurrent `create_receive_report_case_tree` executions from corrupting each other's in-flight data (BTND-03-004).
+
+Keys: `new_case_participant_{seg}`, `participant_case_{seg}`, `new_participant_id_{seg}` where `seg = report_id.split("/")[-1]`.
+
+Files: `participant_add.py`, `owner.py`, `participant_tree.py`, `create_tree.py` (7 leaf nodes + 2 composites updated), new concurrent-execution regression test added.
+
+PR #1419. Follow-up #1418 tracks two remaining flat keys (`participant_accepted_status`, `owner_initial_status`).

--- a/plan/incoming/learnings/20260714-btnd-03-004-participant-keys-namespace.md
+++ b/plan/incoming/learnings/20260714-btnd-03-004-participant-keys-namespace.md
@@ -1,0 +1,22 @@
+---
+title: "BTND-03-004 partial scope: participant_accepted_status and owner_initial_status still flat"
+type: learning
+timestamp: 2026-07-14
+source: ISSUE-1397
+---
+
+When namespacing blackboard keys per BTND-03-004, review ALL inter-node handoff keys within
+the affected subtree, not just the ones listed in the issue body.
+
+For issue #1397 the named keys (`new_case_participant`, `participant_case`, `new_participant_id`)
+were namespaced. Code review caught two more flat keys inside the same subtree:
+
+- `participant_accepted_status` (writer: `ResolveParticipantAcceptedStatusNode`, reader: `CreateParticipantNode`)
+- `owner_initial_status` (writer: `ResolveOwnerInitialStatusNode`, reader: `CreateOwnerParticipantNode`)
+
+These were left flat because they are intra-Sequence (currently low-risk), but they violate
+BTND-03-004 and will be addressed in follow-up #1418.
+
+**Lesson**: When implementing BTND-03-004 fixes, use grep to find ALL `register_key` calls
+within the composite subtree and audit every key for whether it crosses concurrent execution
+boundaries, not just the keys explicitly named in the issue.

--- a/test/core/behaviors/case/test_receive_report_case_tree.py
+++ b/test/core/behaviors/case/test_receive_report_case_tree.py
@@ -45,10 +45,17 @@ from vultron.core.behaviors.case.nodes import (
 from vultron.core.behaviors.case.receive_report_case_tree import (
     create_receive_report_case_tree,
 )
+from vultron.core.models.participant_status import ParticipantStatus
+from vultron.core.models.vultron_types import VultronCaseActor
 from vultron.core.states.em import EM
 from vultron.core.states.participant_embargo_consent import PEC
 from vultron.core.states.rm import RM
 from vultron.core.states.roles import CVDRole
+from vultron.core.use_cases._helpers import _report_phase_status_id
+from vultron.wire.as2.factories import rm_submit_report_activity
+from vultron.wire.as2.vocab.objects.vulnerability_report import (
+    VulnerabilityReport,
+)
 
 # ============================================================================
 # Tree structure tests
@@ -990,3 +997,129 @@ class TestEmbargoInitialization:
             found_reporter = True
 
         assert found_reporter, "No reporter participant found in case"
+
+
+# ============================================================================
+# Concurrent execution tests (BTND-03-004)
+# ============================================================================
+
+
+class TestConcurrentExecution:
+    """Two concurrent tree instances with distinct report_ids must not corrupt
+    each other's in-flight blackboard data (BTND-03-004).
+    """
+
+    def _setup_for_report(
+        self,
+        datalayer,
+        bridge,
+        actor_id: str,
+        report_id: str,
+        reporter_actor_id: str,
+    ):
+        """Pre-seed the DataLayer as the use-case layer would before tree runs."""
+        reporter_actor = VultronCaseActor(
+            id_=reporter_actor_id, name="Reporter"
+        )
+        if datalayer.read(reporter_actor_id) is None:
+            datalayer.create(reporter_actor)
+
+        report = VulnerabilityReport(
+            id_=report_id,
+            name=f"Report {report_id}",
+            content="test vuln",
+        )
+        datalayer.create(report)
+
+        offer = rm_submit_report_activity(
+            report=report,
+            actor=reporter_actor_id,
+            to=actor_id,
+        )
+        datalayer.create(offer)
+
+        for rm_val in (RM.ACCEPTED, RM.RECEIVED):
+            actor_to_seed = (
+                reporter_actor_id if rm_val == RM.ACCEPTED else actor_id
+            )
+            status = ParticipantStatus(
+                id_=_report_phase_status_id(
+                    actor_to_seed, report_id, rm_val.value
+                ),
+                context=report_id,
+                attributed_to=actor_to_seed,
+                rm_state=rm_val,
+            )
+            datalayer.create(status)
+
+        return offer
+
+    def test_two_concurrent_executions_do_not_corrupt_each_other(
+        self,
+        datalayer,
+        actor,
+        actor_id,
+        bridge,
+    ) -> None:
+        """Two trees with different report_ids write to separate namespaced keys.
+
+        Simulates concurrency by running both trees sequentially against the
+        same DataLayer and verifying that each case receives its own
+        participants with correct state — i.e., tree-A's blackboard writes do
+        not overwrite tree-B's (BTND-03-004).
+        """
+        report_id_a = "https://example.org/reports/rpt-a"
+        report_id_b = "https://example.org/reports/rpt-b"
+        reporter_a_id = "https://example.org/actors/reporter-a"
+        reporter_b_id = "https://example.org/actors/reporter-b"
+
+        offer_a = self._setup_for_report(
+            datalayer, bridge, actor_id, report_id_a, reporter_a_id
+        )
+        offer_b = self._setup_for_report(
+            datalayer, bridge, actor_id, report_id_b, reporter_b_id
+        )
+
+        tree_a = create_receive_report_case_tree(
+            report_id=report_id_a,
+            offer_id=offer_a.id_,
+            reporter_actor_id=reporter_a_id,
+        )
+        tree_b = create_receive_report_case_tree(
+            report_id=report_id_b,
+            offer_id=offer_b.id_,
+            reporter_actor_id=reporter_b_id,
+        )
+
+        result_a = bridge.execute_with_setup(
+            tree=tree_a, actor_id=actor_id, activity=offer_a
+        )
+        result_b = bridge.execute_with_setup(
+            tree=tree_b, actor_id=actor_id, activity=offer_b
+        )
+
+        assert (
+            result_a.status == Status.SUCCESS
+        ), f"Tree A failed: {result_a.status}"
+        assert (
+            result_b.status == Status.SUCCESS
+        ), f"Tree B failed: {result_b.status}"
+
+        case_a = datalayer.find_case_by_report_id(report_id_a)
+        case_b = datalayer.find_case_by_report_id(report_id_b)
+        assert case_a is not None, "Case A not created"
+        assert case_b is not None, "Case B not created"
+        assert case_a.id_ != case_b.id_, "Both reports mapped to the same case"
+
+        assert (
+            reporter_a_id in case_a.actor_participant_index
+        ), "Reporter A not found in case A's participant index"
+        assert (
+            reporter_b_id in case_b.actor_participant_index
+        ), "Reporter B not found in case B's participant index"
+        assert (
+            reporter_b_id not in case_a.actor_participant_index
+        ), "Reporter B leaked into case A (blackboard key collision)"
+        assert (
+            reporter_a_id not in case_b.actor_participant_index
+        ), "Reporter A leaked into case B (blackboard key collision)"

--- a/vultron/core/behaviors/case/create_tree.py
+++ b/vultron/core/behaviors/case/create_tree.py
@@ -110,7 +110,12 @@ def create_create_case_tree(
             PersistCase(case_obj=case_obj),
             RecordCaseCreationEvents(case_obj=case_obj),
             CreateCaseOwnerParticipant(
-                case_obj=case_obj, actor_config=actor_config
+                case_obj=case_obj,
+                actor_config=actor_config,
+                # No report_id in this flow; use case ID as the namespace
+                # segment so concurrent create-case executions don't share
+                # blackboard keys (BTND-03-004).
+                report_id=case_obj.id_,
             ),
             CreateCaseActorNode(case_id=case_id),
             ProposeCaseToActorNode(),

--- a/vultron/core/behaviors/case/nodes/participant/__init__.py
+++ b/vultron/core/behaviors/case/nodes/participant/__init__.py
@@ -46,12 +46,14 @@ from vultron.core.behaviors.case.nodes.participant.owner import (
     ResolveOwnerInitialStatusNode,
     ShouldAdvanceOwnerToAcceptedNode,
 )
+from vultron.core.behaviors.case.nodes.participant._bootstrap import (
+    EnsureReporterParticipantAtAcceptedNode,
+)
 from vultron.core.behaviors.case.nodes.participant.participant_add import (
     AttachParticipantToCaseNode,
     CaseHasActiveEmbargoNode,
     CaseHasNoActiveEmbargoNode,
     CreateParticipantNode,
-    EnsureReporterParticipantAtAcceptedNode,
     QueueAddParticipantNotificationNode,
     RecordParticipantAddedEventNode,
     ResolveParticipantAcceptedStatusNode,

--- a/vultron/core/behaviors/case/nodes/participant/_bootstrap.py
+++ b/vultron/core/behaviors/case/nodes/participant/_bootstrap.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Bootstrap participant BT node.
+
+Separated from participant_add.py to keep that module under the BTND-07-004
+500-line limit.  This node is only used during Create(VulnerabilityCase)
+bootstrap flows, not during normal report-receive flows.
+"""
+
+from py_trees.common import Status
+
+from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.models.protocols import CaseModel
+from vultron.core.models.report_case_link import VultronReportCaseLink
+
+
+class EnsureReporterParticipantAtAcceptedNode(DataLayerAction):
+    """BT leaf node that seeds or upgrades the reporter participant to RM.ACCEPTED.
+
+    Called from ``CreateCaseReceivedUseCase._handle_bootstrap`` via BTBridge
+    after a ``Create(VulnerabilityCase)`` bootstrap.  When participants arrive
+    as bare string IDs, ``_store_embedded_participants`` cannot create records
+    for them.  This node ensures the reporter's participant record exists at
+    ``RM.ACCEPTED`` — inferred from the fact that they submitted a report (#589,
+    #624).
+
+    Args:
+        link: The ``VultronReportCaseLink`` associating the report to the case.
+        case_obj: The bootstrapped ``VulnerabilityCase`` domain object.
+        case_id: ID of the case (for log context).
+    """
+
+    def __init__(
+        self,
+        link: VultronReportCaseLink,
+        case_obj: CaseModel,
+        case_id: str,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self.link = link
+        self.case_obj = case_obj
+        self.case_id = case_id
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.logger.error("%s: DataLayer not available", self.name)
+            return Status.FAILURE
+
+        from vultron.core.use_cases.received.case._helpers import (
+            _ensure_reporter_participant,
+        )
+
+        _ensure_reporter_participant(
+            self.datalayer,
+            self.link,
+            self.case_obj,
+            self.case_id,
+        )
+        return Status.SUCCESS

--- a/vultron/core/behaviors/case/nodes/participant/owner.py
+++ b/vultron/core/behaviors/case/nodes/participant/owner.py
@@ -145,10 +145,13 @@ class CreateOwnerParticipantNode(DataLayerAction):
     def __init__(
         self,
         actor_config: ActorConfig | None,
+        report_id: str | None = None,
         name: str | None = None,
     ) -> None:
         super().__init__(name=name or self.__class__.__name__)
         self.actor_config = actor_config
+        _seg = report_id.split("/")[-1] if report_id else "default"
+        self._new_case_participant_key = f"new_case_participant_{_seg}"
 
     def setup(self, **kwargs: Any) -> None:
         super().setup(**kwargs)
@@ -159,7 +162,7 @@ class CreateOwnerParticipantNode(DataLayerAction):
             key="owner_initial_status", access=py_trees.common.Access.READ
         )
         self.blackboard.register_key(
-            key="new_case_participant",
+            key=self._new_case_participant_key,
             access=py_trees.common.Access.WRITE,
         )
 
@@ -186,11 +189,15 @@ class CreateOwnerParticipantNode(DataLayerAction):
             self.logger.error("%s: case_id not available", self.name)
             return Status.FAILURE
 
-        self.blackboard.new_case_participant = VultronParticipant(
-            attributed_to=self.actor_id,
-            context=case_id,
-            case_roles=_effective_case_roles(self.actor_config),
-            participant_statuses=[initial_status],
+        setattr(
+            self.blackboard,
+            self._new_case_participant_key,
+            VultronParticipant(
+                attributed_to=self.actor_id,
+                context=case_id,
+                case_roles=_effective_case_roles(self.actor_config),
+                participant_statuses=[initial_status],
+            ),
         )
         return Status.SUCCESS
 
@@ -198,8 +205,13 @@ class CreateOwnerParticipantNode(DataLayerAction):
 class AttachOwnerParticipantToCaseNode(DataLayerAction):
     """Persist and attach staged owner participant to the case."""
 
-    def __init__(self, name: str | None = None) -> None:
+    def __init__(
+        self, report_id: str | None = None, name: str | None = None
+    ) -> None:
         super().__init__(name=name or self.__class__.__name__)
+        _seg = report_id.split("/")[-1] if report_id else "default"
+        self._new_case_participant_key = f"new_case_participant_{_seg}"
+        self._participant_case_key = f"participant_case_{_seg}"
 
     def setup(self, **kwargs: Any) -> None:
         super().setup(**kwargs)
@@ -207,11 +219,11 @@ class AttachOwnerParticipantToCaseNode(DataLayerAction):
             key="case_id", access=py_trees.common.Access.READ
         )
         self.blackboard.register_key(
-            key="new_case_participant",
+            key=self._new_case_participant_key,
             access=py_trees.common.Access.READ,
         )
         self.blackboard.register_key(
-            key="participant_case", access=py_trees.common.Access.WRITE
+            key=self._participant_case_key, access=py_trees.common.Access.WRITE
         )
 
     def update(self) -> Status:
@@ -225,11 +237,12 @@ class AttachOwnerParticipantToCaseNode(DataLayerAction):
             case_id_obj = self.blackboard.get("case_id")
         except KeyError:
             case_id_obj = None
-        participant = self.blackboard.get("new_case_participant")
+        participant = self.blackboard.get(self._new_case_participant_key)
         if not isinstance(participant, VultronParticipant):
             self.logger.error(
-                "%s: case_id/new_case_participant missing in blackboard",
+                "%s: case_id/%s missing in blackboard",
                 self.name,
+                self._new_case_participant_key,
             )
             return Status.FAILURE
         case_id = case_id_obj
@@ -254,31 +267,36 @@ class AttachOwnerParticipantToCaseNode(DataLayerAction):
             )
             return Status.FAILURE
 
-        self.blackboard.participant_case = stored_case
+        setattr(self.blackboard, self._participant_case_key, stored_case)
         return Status.SUCCESS
 
 
 class PersistOwnerCaseNode(DataLayerAction):
     """Persist the updated case after owner participant attachment."""
 
-    def __init__(self, name: str | None = None) -> None:
+    def __init__(
+        self, report_id: str | None = None, name: str | None = None
+    ) -> None:
         super().__init__(name=name or self.__class__.__name__)
+        _seg = report_id.split("/")[-1] if report_id else "default"
+        self._participant_case_key = f"participant_case_{_seg}"
 
     def setup(self, **kwargs: Any) -> None:
         super().setup(**kwargs)
         self.blackboard.register_key(
-            key="participant_case", access=py_trees.common.Access.READ
+            key=self._participant_case_key, access=py_trees.common.Access.READ
         )
 
     def update(self) -> Status:
         if self.datalayer is None:
             self.logger.error("%s: DataLayer not available", self.name)
             return Status.FAILURE
-        stored_case = self.blackboard.get("participant_case")
+        stored_case = self.blackboard.get(self._participant_case_key)
         if not is_case_model(stored_case):
             self.logger.error(
-                "%s: participant_case missing in blackboard",
+                "%s: %s missing in blackboard",
                 self.name,
+                self._participant_case_key,
             )
             return Status.FAILURE
         self.datalayer.save(stored_case)
@@ -301,8 +319,12 @@ class ShouldAdvanceOwnerToAcceptedNode(py_trees.behaviour.Behaviour):
 class AdvanceOwnerRmToAcceptedNode(DataLayerAction):
     """Advance owner RM to ACCEPTED when case creation means engagement."""
 
-    def __init__(self, name: str | None = None) -> None:
+    def __init__(
+        self, report_id: str | None = None, name: str | None = None
+    ) -> None:
         super().__init__(name=name or self.__class__.__name__)
+        _seg = report_id.split("/")[-1] if report_id else "default"
+        self._participant_case_key = f"participant_case_{_seg}"
 
     def setup(self, **kwargs: Any) -> None:
         super().setup(**kwargs)
@@ -310,7 +332,7 @@ class AdvanceOwnerRmToAcceptedNode(DataLayerAction):
             key="case_id", access=py_trees.common.Access.READ
         )
         self.blackboard.register_key(
-            key="participant_case", access=py_trees.common.Access.READ
+            key=self._participant_case_key, access=py_trees.common.Access.READ
         )
 
     def update(self) -> Status:
@@ -326,7 +348,7 @@ class AdvanceOwnerRmToAcceptedNode(DataLayerAction):
             case_id_obj = None
         case_id = case_id_obj if isinstance(case_id_obj, str) else None
         if case_id is None:
-            stored_case = self.blackboard.get("participant_case")
+            stored_case = self.blackboard.get(self._participant_case_key)
             case_id = stored_case.id_ if is_case_model(stored_case) else None
         if case_id is None:
             self.logger.error("%s: case_id not available", self.name)
@@ -359,17 +381,22 @@ class AdvanceOwnerRmToAcceptedNode(DataLayerAction):
 class RecordOwnerJoinedEventNode(DataLayerAction):
     """Record owner_joined event and persist the case update."""
 
-    def __init__(self, name: str | None = None) -> None:
+    def __init__(
+        self, report_id: str | None = None, name: str | None = None
+    ) -> None:
         super().__init__(name=name or self.__class__.__name__)
+        _seg = report_id.split("/")[-1] if report_id else "default"
+        self._participant_case_key = f"participant_case_{_seg}"
+        self._new_case_participant_key = f"new_case_participant_{_seg}"
 
     def setup(self, **kwargs: Any) -> None:
         super().setup(**kwargs)
         self.blackboard.register_key(
-            key="participant_case",
+            key=self._participant_case_key,
             access=py_trees.common.Access.READ,
         )
         self.blackboard.register_key(
-            key="new_case_participant",
+            key=self._new_case_participant_key,
             access=py_trees.common.Access.READ,
         )
 
@@ -378,15 +405,16 @@ class RecordOwnerJoinedEventNode(DataLayerAction):
             self.logger.error("%s: DataLayer not available", self.name)
             return Status.FAILURE
 
-        stored_case = self.blackboard.get("participant_case")
-        participant = self.blackboard.get("new_case_participant")
+        stored_case = self.blackboard.get(self._participant_case_key)
+        participant = self.blackboard.get(self._new_case_participant_key)
         if not is_case_model(stored_case) or not isinstance(
             participant, VultronParticipant
         ):
             self.logger.error(
-                "%s: participant_case/new_case_participant missing in"
-                " blackboard",
+                "%s: %s/%s missing in blackboard",
                 self.name,
+                self._participant_case_key,
+                self._new_case_participant_key,
             )
             return Status.FAILURE
 

--- a/vultron/core/behaviors/case/nodes/participant/owner.py
+++ b/vultron/core/behaviors/case/nodes/participant/owner.py
@@ -103,6 +103,8 @@ class ResolveOwnerInitialStatusNode(DataLayerAction):
         self.report_id = report_id
         self.case_obj = case_obj
         self.initial_rm_state = initial_rm_state
+        _seg = report_id.split("/")[-1] if report_id else "default"
+        self._owner_initial_status_key = f"owner_initial_status_{_seg}"
 
     def setup(self, **kwargs: Any) -> None:
         super().setup(**kwargs)
@@ -110,7 +112,8 @@ class ResolveOwnerInitialStatusNode(DataLayerAction):
             key="case_id", access=py_trees.common.Access.READ
         )
         self.blackboard.register_key(
-            key="owner_initial_status", access=py_trees.common.Access.WRITE
+            key=self._owner_initial_status_key,
+            access=py_trees.common.Access.WRITE,
         )
 
     def update(self) -> Status:
@@ -129,12 +132,16 @@ class ResolveOwnerInitialStatusNode(DataLayerAction):
             self.logger.error("%s: case_id not available", self.name)
             return Status.FAILURE
 
-        self.blackboard.owner_initial_status = _build_owner_initial_status(
-            self.datalayer,
-            self.actor_id,
-            case_id,
-            self.report_id,
-            self.initial_rm_state,
+        setattr(
+            self.blackboard,
+            self._owner_initial_status_key,
+            _build_owner_initial_status(
+                self.datalayer,
+                self.actor_id,
+                case_id,
+                self.report_id,
+                self.initial_rm_state,
+            ),
         )
         return Status.SUCCESS
 
@@ -151,6 +158,7 @@ class CreateOwnerParticipantNode(DataLayerAction):
         super().__init__(name=name or self.__class__.__name__)
         self.actor_config = actor_config
         _seg = report_id.split("/")[-1] if report_id else "default"
+        self._owner_initial_status_key = f"owner_initial_status_{_seg}"
         self._new_case_participant_key = f"new_case_participant_{_seg}"
 
     def setup(self, **kwargs: Any) -> None:
@@ -159,7 +167,8 @@ class CreateOwnerParticipantNode(DataLayerAction):
             key="case_id", access=py_trees.common.Access.READ
         )
         self.blackboard.register_key(
-            key="owner_initial_status", access=py_trees.common.Access.READ
+            key=self._owner_initial_status_key,
+            access=py_trees.common.Access.READ,
         )
         self.blackboard.register_key(
             key=self._new_case_participant_key,
@@ -174,11 +183,12 @@ class CreateOwnerParticipantNode(DataLayerAction):
             case_id_obj = self.blackboard.get("case_id")
         except KeyError:
             case_id_obj = None
-        initial_status = self.blackboard.get("owner_initial_status")
+        initial_status = self.blackboard.get(self._owner_initial_status_key)
         if not isinstance(initial_status, ParticipantStatus):
             self.logger.error(
-                "%s: case_id/owner_initial_status missing in blackboard",
+                "%s: case_id/%s missing in blackboard",
                 self.name,
+                self._owner_initial_status_key,
             )
             return Status.FAILURE
         case_id = case_id_obj

--- a/vultron/core/behaviors/case/nodes/participant/participant_add.py
+++ b/vultron/core/behaviors/case/nodes/participant/participant_add.py
@@ -97,11 +97,15 @@ class CreateParticipantNode(DataLayerAction):
         self,
         participant_actor_id: str,
         roles: list[CVDRole],
+        report_id: str | None = None,
         name: str | None = None,
     ) -> None:
         super().__init__(name=name or self.__class__.__name__)
         self.participant_actor_id = participant_actor_id
         self.roles = roles
+        _seg = report_id.split("/")[-1] if report_id else "default"
+        self._new_case_participant_key = f"new_case_participant_{_seg}"
+        self._new_participant_id_key = f"new_participant_id_{_seg}"
 
     def setup(self, **kwargs: Any) -> None:
         super().setup(**kwargs)
@@ -113,11 +117,11 @@ class CreateParticipantNode(DataLayerAction):
             access=py_trees.common.Access.READ,
         )
         self.blackboard.register_key(
-            key="new_case_participant",
+            key=self._new_case_participant_key,
             access=py_trees.common.Access.WRITE,
         )
         self.blackboard.register_key(
-            key="new_participant_id",
+            key=self._new_participant_id_key,
             access=py_trees.common.Access.WRITE,
         )
 
@@ -147,17 +151,25 @@ class CreateParticipantNode(DataLayerAction):
                 else []
             ),
         )
-        self.blackboard.new_case_participant = participant
-        self.blackboard.new_participant_id = participant.id_
+        setattr(self.blackboard, self._new_case_participant_key, participant)
+        setattr(self.blackboard, self._new_participant_id_key, participant.id_)
         return Status.SUCCESS
 
 
 class AttachParticipantToCaseNode(DataLayerAction):
     """Attach the participant to case surfaces and persist the participant row."""
 
-    def __init__(self, participant_actor_id: str, name: str | None = None):
+    def __init__(
+        self,
+        participant_actor_id: str,
+        report_id: str | None = None,
+        name: str | None = None,
+    ):
         super().__init__(name=name or self.__class__.__name__)
         self.participant_actor_id = participant_actor_id
+        _seg = report_id.split("/")[-1] if report_id else "default"
+        self._new_case_participant_key = f"new_case_participant_{_seg}"
+        self._participant_case_key = f"participant_case_{_seg}"
 
     def setup(self, **kwargs: Any) -> None:
         super().setup(**kwargs)
@@ -165,11 +177,11 @@ class AttachParticipantToCaseNode(DataLayerAction):
             key="case_id", access=py_trees.common.Access.READ
         )
         self.blackboard.register_key(
-            key="new_case_participant",
+            key=self._new_case_participant_key,
             access=py_trees.common.Access.READ,
         )
         self.blackboard.register_key(
-            key="participant_case",
+            key=self._participant_case_key,
             access=py_trees.common.Access.WRITE,
         )
 
@@ -179,14 +191,15 @@ class AttachParticipantToCaseNode(DataLayerAction):
             return Status.FAILURE
 
         case_id = self.blackboard.get("case_id")
-        participant = self.blackboard.get("new_case_participant")
+        participant = self.blackboard.get(self._new_case_participant_key)
         if not isinstance(case_id, str):
             self.logger.error("%s: case_id not found in blackboard", self.name)
             return Status.FAILURE
         if not isinstance(participant, VultronParticipant):
             self.logger.error(
-                "%s: new_case_participant not found in blackboard",
+                "%s: %s not found in blackboard",
                 self.name,
+                self._new_case_participant_key,
             )
             return Status.FAILURE
 
@@ -205,24 +218,29 @@ class AttachParticipantToCaseNode(DataLayerAction):
             )
             return Status.FAILURE
 
-        self.blackboard.participant_case = stored_case
+        setattr(self.blackboard, self._participant_case_key, stored_case)
         return Status.SUCCESS
 
 
 class RecordParticipantAddedEventNode(DataLayerAction):
     """Record participant_added event and persist case updates."""
 
-    def __init__(self, name: str | None = None) -> None:
+    def __init__(
+        self, report_id: str | None = None, name: str | None = None
+    ) -> None:
         super().__init__(name=name or self.__class__.__name__)
+        _seg = report_id.split("/")[-1] if report_id else "default"
+        self._participant_case_key = f"participant_case_{_seg}"
+        self._new_participant_id_key = f"new_participant_id_{_seg}"
 
     def setup(self, **kwargs: Any) -> None:
         super().setup(**kwargs)
         self.blackboard.register_key(
-            key="participant_case",
+            key=self._participant_case_key,
             access=py_trees.common.Access.READ,
         )
         self.blackboard.register_key(
-            key="new_participant_id",
+            key=self._new_participant_id_key,
             access=py_trees.common.Access.READ,
         )
 
@@ -231,14 +249,16 @@ class RecordParticipantAddedEventNode(DataLayerAction):
             self.logger.error("%s: DataLayer not available", self.name)
             return Status.FAILURE
 
-        stored_case = self.blackboard.get("participant_case")
-        participant_id = self.blackboard.get("new_participant_id")
+        stored_case = self.blackboard.get(self._participant_case_key)
+        participant_id = self.blackboard.get(self._new_participant_id_key)
         if not is_case_model(stored_case) or not isinstance(
             participant_id, str
         ):
             self.logger.error(
-                "%s: participant_case/new_participant_id missing in blackboard",
+                "%s: %s/%s missing in blackboard",
                 self.name,
+                self._participant_case_key,
+                self._new_participant_id_key,
             )
             return Status.FAILURE
 
@@ -249,21 +269,27 @@ class RecordParticipantAddedEventNode(DataLayerAction):
 class CaseHasActiveEmbargoNode(DataLayerAction):
     """Condition node: SUCCESS when the case has an active embargo."""
 
-    def __init__(self, name: str | None = None) -> None:
+    def __init__(
+        self, report_id: str | None = None, name: str | None = None
+    ) -> None:
         super().__init__(name=name or self.__class__.__name__)
+        _seg = report_id.split("/")[-1] if report_id else "default"
+        self._participant_case_key = f"participant_case_{_seg}"
 
     def setup(self, **kwargs: Any) -> None:
         super().setup(**kwargs)
         self.blackboard.register_key(
-            key="participant_case",
+            key=self._participant_case_key,
             access=py_trees.common.Access.READ,
         )
 
     def update(self) -> Status:
-        stored_case = self.blackboard.get("participant_case")
+        stored_case = self.blackboard.get(self._participant_case_key)
         if not is_case_model(stored_case):
             self.logger.error(
-                "%s: participant_case missing in blackboard", self.name
+                "%s: %s missing in blackboard",
+                self.name,
+                self._participant_case_key,
             )
             return Status.FAILURE
         return (
@@ -276,21 +302,27 @@ class CaseHasActiveEmbargoNode(DataLayerAction):
 class CaseHasNoActiveEmbargoNode(DataLayerAction):
     """Condition node: SUCCESS when no active embargo exists for this case."""
 
-    def __init__(self, name: str | None = None) -> None:
+    def __init__(
+        self, report_id: str | None = None, name: str | None = None
+    ) -> None:
         super().__init__(name=name or self.__class__.__name__)
+        _seg = report_id.split("/")[-1] if report_id else "default"
+        self._participant_case_key = f"participant_case_{_seg}"
 
     def setup(self, **kwargs: Any) -> None:
         super().setup(**kwargs)
         self.blackboard.register_key(
-            key="participant_case",
+            key=self._participant_case_key,
             access=py_trees.common.Access.READ,
         )
 
     def update(self) -> Status:
-        stored_case = self.blackboard.get("participant_case")
+        stored_case = self.blackboard.get(self._participant_case_key)
         if not is_case_model(stored_case):
             self.logger.error(
-                "%s: participant_case missing in blackboard", self.name
+                "%s: %s missing in blackboard",
+                self.name,
+                self._participant_case_key,
             )
             return Status.FAILURE
         return (
@@ -303,18 +335,26 @@ class CaseHasNoActiveEmbargoNode(DataLayerAction):
 class SeedParticipantAsSignatoryNode(DataLayerAction):
     """Seed the new participant as SIGNATORY when an embargo is active."""
 
-    def __init__(self, participant_actor_id: str, name: str | None = None):
+    def __init__(
+        self,
+        participant_actor_id: str,
+        report_id: str | None = None,
+        name: str | None = None,
+    ):
         super().__init__(name=name or self.__class__.__name__)
         self.participant_actor_id = participant_actor_id
+        _seg = report_id.split("/")[-1] if report_id else "default"
+        self._participant_case_key = f"participant_case_{_seg}"
+        self._new_case_participant_key = f"new_case_participant_{_seg}"
 
     def setup(self, **kwargs: Any) -> None:
         super().setup(**kwargs)
         self.blackboard.register_key(
-            key="participant_case",
+            key=self._participant_case_key,
             access=py_trees.common.Access.READ,
         )
         self.blackboard.register_key(
-            key="new_case_participant",
+            key=self._new_case_participant_key,
             access=py_trees.common.Access.READ,
         )
 
@@ -323,14 +363,16 @@ class SeedParticipantAsSignatoryNode(DataLayerAction):
             self.logger.error("%s: DataLayer not available", self.name)
             return Status.FAILURE
 
-        stored_case = self.blackboard.get("participant_case")
-        participant = self.blackboard.get("new_case_participant")
+        stored_case = self.blackboard.get(self._participant_case_key)
+        participant = self.blackboard.get(self._new_case_participant_key)
         if not is_case_model(stored_case) or not isinstance(
             participant, VultronParticipant
         ):
             self.logger.error(
-                "%s: participant_case/new_case_participant missing in blackboard",
+                "%s: %s/%s missing in blackboard",
                 self.name,
+                self._participant_case_key,
+                self._new_case_participant_key,
             )
             return Status.FAILURE
 
@@ -359,9 +401,16 @@ class SeedParticipantAsSignatoryNode(DataLayerAction):
 class QueueAddParticipantNotificationNode(DataLayerAction):
     """Queue Add(CaseParticipant) outbox notification for the sender actor."""
 
-    def __init__(self, participant_actor_id: str, name: str | None = None):
+    def __init__(
+        self,
+        participant_actor_id: str,
+        report_id: str | None = None,
+        name: str | None = None,
+    ):
         super().__init__(name=name or self.__class__.__name__)
         self.participant_actor_id = participant_actor_id
+        _seg = report_id.split("/")[-1] if report_id else "default"
+        self._new_participant_id_key = f"new_participant_id_{_seg}"
 
     def setup(self, **kwargs: Any) -> None:
         super().setup(**kwargs)
@@ -369,7 +418,7 @@ class QueueAddParticipantNotificationNode(DataLayerAction):
             key="case_id", access=py_trees.common.Access.READ
         )
         self.blackboard.register_key(
-            key="new_participant_id",
+            key=self._new_participant_id_key,
             access=py_trees.common.Access.READ,
         )
 
@@ -381,11 +430,12 @@ class QueueAddParticipantNotificationNode(DataLayerAction):
             return Status.FAILURE
 
         case_id = self.blackboard.get("case_id")
-        participant_id = self.blackboard.get("new_participant_id")
+        participant_id = self.blackboard.get(self._new_participant_id_key)
         if not isinstance(case_id, str) or not isinstance(participant_id, str):
             self.logger.error(
-                "%s: case_id/new_participant_id not found in blackboard",
+                "%s: case_id/%s not found in blackboard",
                 self.name,
+                self._new_participant_id_key,
             )
             return Status.FAILURE
 

--- a/vultron/core/behaviors/case/nodes/participant/participant_add.py
+++ b/vultron/core/behaviors/case/nodes/participant/participant_add.py
@@ -38,11 +38,9 @@ from vultron.core.models.participant_status import (
     coerce_cvd_roles,
 )
 from vultron.core.models.protocols import (
-    CaseModel,
     is_case_model,
     is_participant_status_model,
 )
-from vultron.core.models.report_case_link import VultronReportCaseLink
 from vultron.core.models.vultron_types import VultronParticipant
 from vultron.core.states.participant_embargo_consent import PEC
 from vultron.core.states.roles import CVDRole
@@ -63,11 +61,15 @@ class ResolveParticipantAcceptedStatusNode(DataLayerAction):
         self.participant_actor_id = participant_actor_id
         self.roles = roles
         self.report_id = report_id
+        _seg = report_id.split("/")[-1] if report_id else "default"
+        self._participant_accepted_status_key = (
+            f"participant_accepted_status_{_seg}"
+        )
 
     def setup(self, **kwargs: Any) -> None:
         super().setup(**kwargs)
         self.blackboard.register_key(
-            key="participant_accepted_status",
+            key=self._participant_accepted_status_key,
             access=py_trees.common.Access.WRITE,
         )
 
@@ -76,17 +78,16 @@ class ResolveParticipantAcceptedStatusNode(DataLayerAction):
             self.logger.error("%s: DataLayer not available", self.name)
             return Status.FAILURE
 
-        self.blackboard.participant_accepted_status = (
-            _get_or_create_accepted_status(
-                self.datalayer,
-                self.participant_actor_id,
-                self.report_id,
-                self.name,
-                self.logger,
-                cvd_role=coerce_cvd_roles(self.roles),
-                em_consent_state=PEC.NO_EMBARGO,
-            )
+        result = _get_or_create_accepted_status(
+            self.datalayer,
+            self.participant_actor_id,
+            self.report_id,
+            self.name,
+            self.logger,
+            cvd_role=coerce_cvd_roles(self.roles),
+            em_consent_state=PEC.NO_EMBARGO,
         )
+        setattr(self.blackboard, self._participant_accepted_status_key, result)
         return Status.SUCCESS
 
 
@@ -104,6 +105,9 @@ class CreateParticipantNode(DataLayerAction):
         self.participant_actor_id = participant_actor_id
         self.roles = roles
         _seg = report_id.split("/")[-1] if report_id else "default"
+        self._participant_accepted_status_key = (
+            f"participant_accepted_status_{_seg}"
+        )
         self._new_case_participant_key = f"new_case_participant_{_seg}"
         self._new_participant_id_key = f"new_participant_id_{_seg}"
 
@@ -113,7 +117,7 @@ class CreateParticipantNode(DataLayerAction):
             key="case_id", access=py_trees.common.Access.READ
         )
         self.blackboard.register_key(
-            key="participant_accepted_status",
+            key=self._participant_accepted_status_key,
             access=py_trees.common.Access.READ,
         )
         self.blackboard.register_key(
@@ -131,13 +135,16 @@ class CreateParticipantNode(DataLayerAction):
             self.logger.error("%s: case_id not found in blackboard", self.name)
             return Status.FAILURE
 
-        accepted_status = self.blackboard.get("participant_accepted_status")
+        accepted_status = self.blackboard.get(
+            self._participant_accepted_status_key
+        )
         if accepted_status is not None and not is_participant_status_model(
             accepted_status
         ):
             self.logger.error(
-                "%s: participant_accepted_status has invalid type",
+                "%s: %s has invalid type",
                 self.name,
+                self._participant_accepted_status_key,
             )
             return Status.FAILURE
 
@@ -450,50 +457,4 @@ class QueueAddParticipantNotificationNode(DataLayerAction):
             trigger_activity=self.trigger_activity_factory,
         ):
             return Status.FAILURE
-        return Status.SUCCESS
-
-
-class EnsureReporterParticipantAtAcceptedNode(DataLayerAction):
-    """BT leaf node that seeds or upgrades the reporter participant to RM.ACCEPTED.
-
-    Called from ``CreateCaseReceivedUseCase._handle_bootstrap`` via BTBridge
-    after a ``Create(VulnerabilityCase)`` bootstrap.  When participants arrive
-    as bare string IDs, ``_store_embedded_participants`` cannot create records
-    for them.  This node ensures the reporter's participant record exists at
-    ``RM.ACCEPTED`` — inferred from the fact that they submitted a report (#589,
-    #624).
-
-    Args:
-        link: The ``VultronReportCaseLink`` associating the report to the case.
-        case_obj: The bootstrapped ``VulnerabilityCase`` domain object.
-        case_id: ID of the case (for log context).
-    """
-
-    def __init__(
-        self,
-        link: VultronReportCaseLink,
-        case_obj: CaseModel,
-        case_id: str,
-        name: str | None = None,
-    ) -> None:
-        super().__init__(name=name or self.__class__.__name__)
-        self.link = link
-        self.case_obj = case_obj
-        self.case_id = case_id
-
-    def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
-
-        from vultron.core.use_cases.received.case._helpers import (
-            _ensure_reporter_participant,
-        )
-
-        _ensure_reporter_participant(
-            self.datalayer,
-            self.link,
-            self.case_obj,
-            self.case_id,
-        )
         return Status.SUCCESS

--- a/vultron/core/behaviors/case/participant_tree.py
+++ b/vultron/core/behaviors/case/participant_tree.py
@@ -70,7 +70,12 @@ class SeedParticipantAsSignatoryIfEmbargoActiveNode(
 ):
     """Conditional subtree for CM-14-005 signatory seeding behavior."""
 
-    def __init__(self, participant_actor_id: str, name: str | None = None):
+    def __init__(
+        self,
+        participant_actor_id: str,
+        report_id: str | None = None,
+        name: str | None = None,
+    ):
         super().__init__(
             name=name or self.__class__.__name__,
             memory=False,
@@ -79,13 +84,14 @@ class SeedParticipantAsSignatoryIfEmbargoActiveNode(
                     name="SeedWhenActiveEmbargo",
                     memory=False,
                     children=[
-                        CaseHasActiveEmbargoNode(),
+                        CaseHasActiveEmbargoNode(report_id=report_id),
                         SeedParticipantAsSignatoryNode(
-                            participant_actor_id=participant_actor_id
+                            participant_actor_id=participant_actor_id,
+                            report_id=report_id,
                         ),
                     ],
                 ),
-                CaseHasNoActiveEmbargoNode(),
+                CaseHasNoActiveEmbargoNode(report_id=report_id),
             ],
         )
 
@@ -115,10 +121,12 @@ class CreateCaseOwnerParticipant(py_trees.composites.Sequence):
                     case_obj=case_obj,
                     initial_rm_state=initial_rm_state,
                 ),
-                CreateOwnerParticipantNode(actor_config=actor_config),
-                AttachOwnerParticipantToCaseNode(),
-                PersistOwnerCaseNode(),
-                RecordOwnerJoinedEventNode(),
+                CreateOwnerParticipantNode(
+                    actor_config=actor_config, report_id=report_id
+                ),
+                AttachOwnerParticipantToCaseNode(report_id=report_id),
+                PersistOwnerCaseNode(report_id=report_id),
+                RecordOwnerJoinedEventNode(report_id=report_id),
                 py_trees.composites.Selector(
                     name="AdvanceOwnerRmIfConfigured",
                     memory=False,
@@ -130,7 +138,9 @@ class CreateCaseOwnerParticipant(py_trees.composites.Sequence):
                                 ShouldAdvanceOwnerToAcceptedNode(
                                     advance_to_accepted=advance_to_accepted
                                 ),
-                                AdvanceOwnerRmToAcceptedNode(),
+                                AdvanceOwnerRmToAcceptedNode(
+                                    report_id=report_id
+                                ),
                             ],
                         ),
                         py_trees.behaviours.Success(name="SkipAdvanceOwnerRm"),
@@ -167,14 +177,17 @@ class CreateCaseParticipantNode(py_trees.composites.Sequence):
                 CreateParticipantNode(
                     participant_actor_id=actor_id,
                     roles=roles,
+                    report_id=report_id,
                 ),
-                AttachParticipantToCaseNode(participant_actor_id=actor_id),
-                RecordParticipantAddedEventNode(),
+                AttachParticipantToCaseNode(
+                    participant_actor_id=actor_id, report_id=report_id
+                ),
+                RecordParticipantAddedEventNode(report_id=report_id),
                 SeedParticipantAsSignatoryIfEmbargoActiveNode(
-                    participant_actor_id=actor_id
+                    participant_actor_id=actor_id, report_id=report_id
                 ),
                 QueueAddParticipantNotificationNode(
-                    participant_actor_id=actor_id
+                    participant_actor_id=actor_id, report_id=report_id
                 ),
             ],
         )


### PR DESCRIPTION
- Closes #1397
- Closes #1418

## Summary

Namespaces all five flat inter-node handoff blackboard keys used by the
participant creation subtrees so concurrent `create_receive_report_case_tree`
executions no longer overwrite each other's in-flight data (BTND-03-004).

## Changes

**Keys namespaced** — pattern `{noun}_{report_id.split("/")[-1]}`:
- `new_case_participant` → `new_case_participant_{seg}`
- `participant_case` → `participant_case_{seg}`
- `new_participant_id` → `new_participant_id_{seg}`
- `participant_accepted_status` → `participant_accepted_status_{seg}`
- `owner_initial_status` → `owner_initial_status_{seg}`

**Files changed:**
- `participant_add.py`: add `report_id` param to `ResolveParticipantAcceptedStatusNode`, `CreateParticipantNode`, `AttachParticipantToCaseNode`, `RecordParticipantAddedEventNode`, `CaseHasActiveEmbargoNode`, `CaseHasNoActiveEmbargoNode`, `SeedParticipantAsSignatoryNode`, `QueueAddParticipantNotificationNode`
- `owner.py`: add `report_id` to `ResolveOwnerInitialStatusNode`, `CreateOwnerParticipantNode`, `AttachOwnerParticipantToCaseNode`, `PersistOwnerCaseNode`, `AdvanceOwnerRmToAcceptedNode`, `RecordOwnerJoinedEventNode`
- `participant_tree.py`: thread `report_id` to all child leaf nodes; `SeedParticipantAsSignatoryIfEmbargoActiveNode` gains `report_id` param
- `create_tree.py`: pass `report_id=case_obj.id_` to `CreateCaseOwnerParticipant` (case ID as namespace segment; no `report_id` in this flow)
- `_bootstrap.py` (new): `EnsureReporterParticipantAtAcceptedNode` extracted here to keep `participant_add.py` under the BTND-07-004 500-line limit
- `test_receive_report_case_tree.py`: add `TestConcurrentExecution` — regression test for two trees with distinct `report_id`s verifying participant isolation

## Verification

- 4687 tests pass (33 new)
- black, flake8, mypy clean