### PR TITLE
test: verify roles-threading end-to-end (Issue-1405)

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1405.md
+++ b/plan/history/2607/implementation/ISSUE-1405.md
@@ -1,0 +1,15 @@
+---
+source: ISSUE-1405
+timestamp: '2026-07-14T18:31:03.598582+00:00'
+title: 'Verify roles-threading end-to-end: InviteActorToCaseTriggerRequest → CaseParticipant.case_roles'
+type: implementation
+---
+
+## Issue #1405 — Verify roles-threading end-to-end: InviteActorToCaseTriggerRequest → CaseParticipant.case_roles
+
+Added three acceptance-criteria tests for the roles-threading path:
+
+- AC-1/AC-2: integration round-trip in TestRolesThreadingIntegration (test_actor_triggers.py)
+- AC-3: unit test for EmitInviteActorToCaseNode._read_suggested_roles() KeyError path (test_actor_and_announce_nodes.py)
+
+PR: <https://github.com/CERTCC/Vultron/pull/1420>

--- a/test/core/behaviors/case/nodes/test_actor_and_announce_nodes.py
+++ b/test/core/behaviors/case/nodes/test_actor_and_announce_nodes.py
@@ -13,10 +13,12 @@
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-"""Tests for AcceptCaseOwnershipTransferNode and SeedAnnouncedCaseNode."""
+"""Tests for AcceptCaseOwnershipTransferNode, SeedAnnouncedCaseNode,
+and EmitInviteActorToCaseNode._read_suggested_roles."""
 
 from typing import Any, cast
 
+import py_trees
 import pytest
 from py_trees.common import Status
 
@@ -24,6 +26,7 @@ from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.case.nodes.actor import (
     AcceptCaseOwnershipTransferNode,
+    EmitInviteActorToCaseNode,
 )
 from vultron.core.behaviors.case.nodes.announce import SeedAnnouncedCaseNode
 from vultron.core.models.events import MessageSemantics
@@ -155,3 +158,34 @@ class TestSeedAnnouncedCaseNode:
         )
         assert result.status == Status.SUCCESS
         assert dl.read(CASE_ID2) is not None
+
+
+# ---------------------------------------------------------------------------
+# EmitInviteActorToCaseNode._read_suggested_roles (AC-3, Issue-1405)
+# ---------------------------------------------------------------------------
+
+INVITEE_ID = "https://example.org/actors/invitee-ac3"
+AC3_CASE_ID = "https://example.org/cases/ac3-case"
+
+
+class TestEmitInviteActorToCaseNodeReadSuggestedRoles:
+    """AC-3: _read_suggested_roles() returns None when suggested_roles absent."""
+
+    def setup_method(self):
+        py_trees.blackboard.Blackboard.enable_activity_stream()
+        self.node = EmitInviteActorToCaseNode(
+            invitee_id=INVITEE_ID,
+            case_id=AC3_CASE_ID,
+        )
+        self.node.setup()
+
+    def teardown_method(self):
+        py_trees.blackboard.Blackboard.disable_activity_stream()
+        py_trees.blackboard.Blackboard.clear()
+
+    def test_returns_none_when_key_absent(self):
+        """AC-3: _read_suggested_roles() returns None on KeyError (key not set)."""
+        result = self.node._read_suggested_roles()
+        assert (
+            result is None
+        ), f"AC-3: expected None when suggested_roles absent, got {result!r}"

--- a/test/core/use_cases/triggers/test_actor_triggers.py
+++ b/test/core/use_cases/triggers/test_actor_triggers.py
@@ -426,6 +426,128 @@ class TestInviteRolesAndEmbargoEnrichment:
         ), "caseStatus must not be present when em_state != ACTIVE"
 
 
+class TestRolesThreadingIntegration:
+    """AC-1 / AC-2: full roles-threading round-trip end-to-end (Issue-1405).
+
+    InviteActorToCaseTriggerRequest.roles flows through the BT blackboard
+    (suggested_roles) → Invite wire object → Accept(Invite) BT →
+    VultronParticipant.case_roles.
+    """
+
+    def setup_method(self):
+        import py_trees
+
+        py_trees.blackboard.Blackboard.enable_activity_stream()
+
+    def teardown_method(self):
+        import py_trees
+
+        py_trees.blackboard.Blackboard.clear()
+        py_trees.blackboard.Blackboard.disable_activity_stream()
+
+    def _run_round_trip(self, roles, make_payload):
+        """Trigger Invite then Accept(Invite); return the new VultronParticipant."""
+        from typing import Any, cast
+        from unittest.mock import MagicMock
+
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+        from vultron.core.use_cases.received.actor.invite import (
+            AcceptInviteActorToCaseReceivedUseCase,
+        )
+        from vultron.wire.as2.factories import (
+            rm_accept_invite_to_case_activity,
+        )
+        from vultron.wire.as2.vocab.base.objects.activities.transitive import (
+            as_Invite,
+        )
+        from vultron.wire.as2.vocab.base.objects.actors import (
+            as_Organization,
+            as_Service,
+        )
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+
+        # Shared DataLayer: both trigger and receive sides use it so the
+        # persisted Invite is visible when Accept is processed.
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        _CREATED_DLS.append(dl)
+
+        owner = as_Service(name="CaseOwner")
+        dl.create(owner)
+        invitee_id = "https://example.org/actors/invitee-roundtrip"
+        invitee = as_Organization(id_=invitee_id)
+        dl.create(invitee)
+        case = VulnerabilityCase(
+            attributed_to=owner.id_, name="Roles Round-Trip Test"
+        )
+        dl.create(case)
+
+        from vultron.adapters.driven.datalayer_sqlite import reset_datalayer
+
+        reset_datalayer(owner.id_)
+        owner_dl = SqliteDataLayer("sqlite:///:memory:", actor_id=owner.id_)
+        _CREATED_DLS.append(owner_dl)
+        owner_dl.create(owner)
+        owner_dl.create(invitee)
+        owner_dl.create(case)
+
+        request = InviteActorToCaseTriggerRequest(
+            actor_id=owner.id_,
+            case_id=case.id_,
+            invitee_id=invitee_id,
+            roles=roles,
+        )
+        result = SvcInviteActorToCaseUseCase(
+            owner_dl,
+            request,
+            trigger_activity=TriggerActivityAdapter(owner_dl),
+        ).execute()
+
+        invite_id = result["activity"]["id"]
+        invite_obj = owner_dl.read(invite_id)
+        assert isinstance(invite_obj, as_Invite)
+        dl.create(invite_obj)
+
+        accept = rm_accept_invite_to_case_activity(
+            invite_obj, actor=invitee_id
+        )
+        event = make_payload(accept)
+
+        AcceptInviteActorToCaseReceivedUseCase(
+            dl, event, sync_port=MagicMock()
+        ).execute()
+
+        updated_case = cast(Any, dl.read(case.id_))
+        participant_id = updated_case.actor_participant_index.get(invitee_id)
+        assert (
+            participant_id is not None
+        ), "invitee must be registered after Accept"
+        return cast(Any, dl.get(id_=participant_id))
+
+    def test_ac1_roles_vendor_reaches_participant_case_roles(
+        self, make_payload
+    ):
+        """AC-1 (CM-17-003/004): roles=[CVDRole.VENDOR] in request results in
+        VultronParticipant.case_roles=[CVDRole.VENDOR] after Accept(Invite)."""
+        participant = self._run_round_trip(
+            roles=[CVDRole.VENDOR], make_payload=make_payload
+        )
+        assert (
+            CVDRole.VENDOR in participant.case_roles
+        ), f"AC-1: expected CVDRole.VENDOR in case_roles, got {participant.case_roles!r}"
+
+    def test_ac2_none_roles_gives_empty_case_roles(self, make_payload):
+        """AC-2 (CM-17-003/004): roles=None in request results in
+        VultronParticipant.case_roles=[] after Accept(Invite)."""
+        participant = self._run_round_trip(
+            roles=None, make_payload=make_payload
+        )
+        assert (
+            participant.case_roles == []
+        ), f"AC-2: expected empty case_roles, got {participant.case_roles!r}"
+
+
 class TestSvcSuggestActorToCaseUseCase:
     """Tests for the suggest-actor-to-case trigger use case."""
 

--- a/test/core/use_cases/triggers/test_actor_triggers.py
+++ b/test/core/use_cases/triggers/test_actor_triggers.py
@@ -523,7 +523,11 @@ class TestRolesThreadingIntegration:
         assert (
             participant_id is not None
         ), "invitee must be registered after Accept"
-        return cast(Any, dl.get(id_=participant_id))
+        participant = cast(Any, dl.read(participant_id))
+        assert (
+            participant is not None
+        ), "participant object not found in DataLayer"
+        return participant
 
     def test_ac1_roles_vendor_reaches_participant_case_roles(
         self, make_payload


### PR DESCRIPTION
- Closes #1405

## Summary

Adds three acceptance-criteria tests verifying the full roles-threading path: `InviteActorToCaseTriggerRequest.roles` → BT blackboard (`suggested_roles`) → Invite wire object → `Accept(Invite)` BT → `VultronParticipant.case_roles`.

## Changes

- `test/core/use_cases/triggers/test_actor_triggers.py`: adds `TestRolesThreadingIntegration` with two integration round-trip tests (AC-1: `roles=[CVDRole.VENDOR]` → `case_roles=[CVDRole.VENDOR]`; AC-2: `roles=None` → `case_roles=[]`)
- `test/core/behaviors/case/nodes/test_actor_and_announce_nodes.py`: adds `TestEmitInviteActorToCaseNodeReadSuggestedRoles` with AC-3 unit test that `_read_suggested_roles()` returns `None` when `suggested_roles` is absent from the blackboard (KeyError path)

## Verification

- All 3 new tests pass; full suite: 4688 passed, 38 skipped, 2 xfailed
- Black, flake8, mypy, pyright all clean
- Pre-PR code review: one FAIL fixed (AC-3 teardown used `Blackboard.storage.clear()` instead of `Blackboard.clear()`, leaving stale client registrations — corrected to `Blackboard.clear()`); one dead-code line removed (`dl.save(case)` before `execute()`)