### PR TITLE
fix: fail-fast at silent-failure sites in core domain helpers

### DIFF
--- a/notes/domain-validation.md
+++ b/notes/domain-validation.md
@@ -141,7 +141,7 @@ if case_id is None:
 | `_as_id()` in `embargo_lifecycle.py` | Duplicate copy | Removed; callers import from `use_cases._helpers` |
 | `_find_case_manager_*` (3 copies) | 3 independent copies returning `None` | 1 canonical function in `use_cases/_helpers`; others removed |
 | `_extract_case_id()` in dispatcher | Returns `None`; activity silently not indexed | Raises `UnroutableActivityError` |
-| `AppendCaseLedgerEntryNode.update()` | Returns `Status.SUCCESS` on missing `case_id` | Returns `Status.FAILURE` |
+| `CommitCaseLedgerEntryNode.update()` | Returns `Status.SUCCESS` on missing `case_id` | Returns `Status.FAILURE` |
 | `_read_case_obj()` in communication.py | Swallows `KeyError`; no diagnostic | Sets `feedback_message`; caller returns `Status.FAILURE` |
 
 See `specs/architecture.yaml` ARCH-15-001 through ARCH-15-004 for

--- a/plan/history/2607/implementation/ISSUE-1377.md
+++ b/plan/history/2607/implementation/ISSUE-1377.md
@@ -1,0 +1,23 @@
+---
+source: ISSUE-1377
+timestamp: '2026-07-14T18:54:43.276424+00:00'
+title: fix fail-fast at silent-failure sites in core domain helpers
+type: implementation
+---
+
+## Issue #1377 — fix: fail-fast at silent-failure sites in core domain helpers
+
+Applied fail-fast behaviour at all 5 named silent-failure sites from CONCERN-1360.
+
+**Changes made:**
+
+- `vultron/errors.py`: added `UnroutableActivityError` with `activity_id` and `reason` fields
+- `vultron/core/behaviors/case/nodes/lifecycle.py`: `CommitCaseLedgerEntryNode` returns FAILURE (not SUCCESS) when `case_id` unresolvable
+- `vultron/core/behaviors/case/nodes/communication.py`: `_read_case_obj()` sets `feedback_message` + logs ERROR on KeyError; `update()` returns FAILURE when `case_obj` is None
+- `vultron/core/dispatcher.py`: `_extract_case_id()` raises `UnroutableActivityError` instead of returning None; `_handle()` catches and drops unroutable events (prevents infinite retry loop)
+- `test/core/behaviors/case/nodes/test_lifecycle.py`: updated SUCCESS→FAILURE assertion
+- `test/core/test_fail_fast_silent_sites.py`: 11 new dedicated tests
+
+**Code review finding fixed:** `UnroutableActivityError` caught in `_handle` before reaching `_process_inbox_item`'s re-queue loop.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1422>

--- a/plan/incoming/learnings/20260714-unroutable-error-catch-placement.md
+++ b/plan/incoming/learnings/20260714-unroutable-error-catch-placement.md
@@ -1,0 +1,27 @@
+---
+title: Catch UnroutableActivityError in _handle, not at call site
+type: learning
+timestamp: '2026-07-14T00:00:00+00:00'
+source: ISSUE-1377
+---
+
+When raising a domain exception from a gate/guard helper called early in a dispatch
+method (before the main `try/except` block), the exception must be caught and handled
+by the dispatch method itself — not left to propagate to the caller.
+
+In `DispatcherBase._handle`, `_enforce_join_backfill_gate` is called at line 101
+*before* the `try` block that wraps use-case execution at line 107. When
+`_extract_case_id` was changed to raise `UnroutableActivityError` instead of
+returning `None`, the exception escaped `_handle` entirely. The inbox adapter's
+`_process_inbox_item` catches all `Exception` at line 326 and re-queues the item —
+creating an infinite retry loop for any unroutable event.
+
+**Fix**: wrap the gate call in its own `try/except UnroutableActivityError` inside
+`_handle`, log at ERROR, and return (drop the event). The infinite loop cannot occur
+because `dispatch()` completes normally, `_process_inbox_item` sees a clean return, and
+the item is not re-queued.
+
+**General rule**: When converting a silent-failure (return None / return False) into a
+raise, trace the full call stack to every exception handler above the raise site. If any
+handler has re-queue / retry semantics, the new exception must be caught below that
+handler — either at the dispatch level or in a dedicated gate wrapper.

--- a/test/core/behaviors/case/nodes/test_lifecycle.py
+++ b/test/core/behaviors/case/nodes/test_lifecycle.py
@@ -124,8 +124,8 @@ def test_node_instantiates_without_case_id():
 # ---------------------------------------------------------------------------
 
 
-def test_no_case_id_returns_success_without_building_inner_tree(bridge):
-    """Node returns SUCCESS silently when no case_id is available (no-op)."""
+def test_no_case_id_returns_failure_without_building_inner_tree(bridge):
+    """Node returns FAILURE when no case_id is available (ARCH-15-001)."""
     node = CommitCaseLedgerEntryNode()
     with patch(_FACTORY_PATH) as mock_factory, patch(
         _INNER_BRIDGE_PATH
@@ -133,7 +133,7 @@ def test_no_case_id_returns_success_without_building_inner_tree(bridge):
         result = bridge.execute_with_setup(
             tree=node, actor_id=ACTOR_ID, activity=None
         )
-    assert result.status == Status.SUCCESS
+    assert result.status == Status.FAILURE
     mock_factory.assert_not_called()
     mock_bridge.assert_not_called()
 

--- a/test/core/test_fail_fast_silent_sites.py
+++ b/test/core/test_fail_fast_silent_sites.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute
+#    to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype
+#  is licensed under a MIT (SEI)-style license, please see LICENSE.md
+#  distributed with this Software or contact permission@sei.cmu.edu for full
+#  terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Dedicated unit tests for the 5 named silent-failure sites (CONCERN-1360).
+
+Each test demonstrates that the site now fails fast instead of silently
+returning None or Status.SUCCESS when a required value is absent.
+
+Reference: specs/architecture.yaml ARCH-15-001 through ARCH-15-003,
+           notes/domain-validation.md, GitHub issue #1377.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import py_trees
+import pytest
+from py_trees.common import Status
+
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.core.behaviors.bridge import BTBridge
+from vultron.core.behaviors.case.nodes import CommitCaseLedgerEntryNode
+from vultron.core.behaviors.case.nodes.communication import (
+    CreateAndPersistCaseActivityNode,
+)
+from vultron.core.dispatcher import DirectActivityDispatcher
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.events import (
+    AddNoteToCaseReceivedEvent,
+    MessageSemantics,
+)
+from vultron.core.models.vultron_types import VultronCaseActor, VultronCase
+from vultron.errors import UnroutableActivityError
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    VulnerabilityCase as as_VulnerabilityCase,
+)
+
+_FACTORY_PATH = (
+    "vultron.core.behaviors.case.nodes.lifecycle.create_commit_log_entry_tree"
+)
+_INNER_BRIDGE_PATH = "vultron.core.behaviors.case.nodes.lifecycle.BTBridge"
+
+ACTOR_ID = "https://example.org/actors/vendor"
+CASE_ID = "https://example.org/cases/case-001"
+ACTIVITY_ID = "https://example.org/activities/act-001"
+CM_ACTOR_ID = "https://example.org/actors/case-manager-001"
+CM_CASE_ID = "https://example.org/cases/cm-case-001"
+CM_PARTICIPANT_ID = f"{CM_CASE_ID}/participants/case-manager-001"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def clear_blackboard():
+    from vultron.core.models.pending_assertion import _reset_stores
+
+    py_trees.blackboard.Blackboard.storage.clear()
+    _reset_stores()
+    yield
+    py_trees.blackboard.Blackboard.storage.clear()
+    _reset_stores()
+
+
+@pytest.fixture()
+def datalayer():
+    dl = SqliteDataLayer("sqlite:///:memory:")
+    actor = VultronCaseActor(id_=ACTOR_ID, name="Vendor Co")
+    dl.create(actor)
+    return dl
+
+
+@pytest.fixture()
+def bridge(datalayer):
+    return BTBridge(datalayer=datalayer)
+
+
+# ---------------------------------------------------------------------------
+# AC-1a: CommitCaseLedgerEntryNode returns FAILURE when case_id unresolvable
+# ---------------------------------------------------------------------------
+
+
+class TestCommitCaseLedgerEntryNodeFailFast:
+    """ARCH-15-001: update() returns FAILURE when case_id is unresolvable."""
+
+    def test_no_case_id_on_blackboard_returns_failure(self, bridge):
+        """No case_id in blackboard → FAILURE, inner tree never built."""
+        node = CommitCaseLedgerEntryNode()
+        with patch(_FACTORY_PATH) as mock_factory, patch(
+            _INNER_BRIDGE_PATH
+        ) as mock_bridge:
+            result = bridge.execute_with_setup(
+                tree=node, actor_id=ACTOR_ID, activity=None
+            )
+        assert result.status == Status.FAILURE
+        mock_factory.assert_not_called()
+        mock_bridge.assert_not_called()
+
+    def test_none_case_id_returns_failure(self, bridge):
+        """case_id resolves to None → FAILURE (not SUCCESS no-op)."""
+        node = CommitCaseLedgerEntryNode(case_id=None)
+        with patch(_FACTORY_PATH) as mock_factory:
+            result = bridge.execute_with_setup(
+                tree=node, actor_id=ACTOR_ID, activity=None
+            )
+        assert result.status == Status.FAILURE
+        mock_factory.assert_not_called()
+
+    def test_empty_string_case_id_returns_failure(self, bridge):
+        """Empty string case_id → FAILURE (falsy value treated as absent)."""
+        node = CommitCaseLedgerEntryNode(case_id="")
+        with patch(_FACTORY_PATH) as mock_factory:
+            result = bridge.execute_with_setup(
+                tree=node, actor_id=ACTOR_ID, activity=None
+            )
+        assert result.status == Status.FAILURE
+        mock_factory.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# AC-1b: _read_case_obj sets feedback_message; update returns FAILURE on None
+# ---------------------------------------------------------------------------
+
+
+class TestCreateAndPersistCaseActivityNodeFailFast:
+    """ARCH-15-001: update() returns FAILURE when create_case_obj absent."""
+
+    def test_missing_case_obj_returns_failure(self, bridge):
+        """create_case_obj absent from blackboard → FAILURE."""
+        node = CreateAndPersistCaseActivityNode()
+        case_obj = VultronCase(id_=CASE_ID, name="Test Case")
+        bridge.datalayer.create(case_obj)
+        result = bridge.execute_with_setup(
+            tree=node,
+            actor_id=ACTOR_ID,
+            case_id=CASE_ID,
+            # create_case_obj intentionally omitted
+            create_case_addressees=[],
+        )
+        assert result.status == Status.FAILURE
+
+    def test_missing_case_obj_sets_feedback_message(self, bridge, datalayer):
+        """_read_case_obj KeyError sets feedback_message on the node."""
+        node = CreateAndPersistCaseActivityNode()
+        case_obj = VultronCase(id_=CASE_ID, name="Test Case")
+        datalayer.create(case_obj)
+
+        result = bridge.execute_with_setup(
+            tree=node,
+            actor_id=ACTOR_ID,
+            case_id=CASE_ID,
+            # create_case_obj intentionally omitted
+            create_case_addressees=[],
+        )
+        assert result.status == Status.FAILURE
+        # feedback_message should mention the missing key
+        failure_reason = BTBridge.get_failure_reason(node)
+        assert "create_case_obj" in failure_reason
+
+
+# ---------------------------------------------------------------------------
+# AC-1c: _extract_case_id raises UnroutableActivityError instead of None
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCaseIdRaisesUnroutableActivityError:
+    """ARCH-15-003: unroutable events are dropped, not silently swallowed."""
+
+    def test_unroutable_event_is_dropped_not_retried(self):
+        """Gated event with no case_id is dropped; use case is not invoked.
+
+        An ADD_NOTE_TO_CASE event whose target.id_ is empty has no extractable
+        case_id.  _extract_case_id raises UnroutableActivityError; _handle
+        catches it, logs at ERROR, and returns without calling the use case.
+        dispatch() completes normally (no exception propagates to the caller),
+        which prevents the inbox re-queue loop (ARCH-15-003).
+        """
+        mock_dl = MagicMock()
+        use_case_class = MagicMock()
+        dispatcher = DirectActivityDispatcher(
+            use_case_map={MessageSemantics.ADD_NOTE_TO_CASE: use_case_class}
+        )
+
+        # target.id_ = "" → target_id property = "" (falsy) → no extractable
+        # case_id in case_id / context_id / origin_id / target_id attributes.
+        event = AddNoteToCaseReceivedEvent(
+            activity_id=ACTIVITY_ID,
+            actor_id=ACTOR_ID,
+            target=as_VulnerabilityCase(id_=""),
+        )
+
+        # dispatch() must not raise — unroutable events are dropped at _handle
+        dispatcher.dispatch(event, mock_dl)
+        use_case_class.assert_not_called()
+
+    def test_extract_case_id_raises_unroutable_directly(self):
+        """_extract_case_id raises UnroutableActivityError (not returns None).
+
+        Test the internal method directly so the raise behaviour is explicit
+        even if the caller (_handle) catches it.
+        """
+        mock_dl = MagicMock()
+        dispatcher = DirectActivityDispatcher(use_case_map={})
+        event = AddNoteToCaseReceivedEvent(
+            activity_id=ACTIVITY_ID,
+            actor_id=ACTOR_ID,
+            target=as_VulnerabilityCase(id_=""),
+        )
+
+        with pytest.raises(UnroutableActivityError) as exc_info:
+            dispatcher._extract_case_id(event, mock_dl)
+
+        exc = exc_info.value
+        assert exc.activity_id == ACTIVITY_ID
+        assert "No case_id" in exc.reason
+
+    def test_unroutable_error_has_activity_id_and_reason_fields(self):
+        """UnroutableActivityError carries activity_id and reason attributes."""
+        err = UnroutableActivityError(
+            activity_id="act-xyz",
+            reason="No case_id attribute found on event",
+        )
+        assert err.activity_id == "act-xyz"
+        assert err.reason == "No case_id attribute found on event"
+        assert "act-xyz" in str(err)
+        assert "No case_id" in str(err)
+
+    def test_unroutable_error_is_vultron_error_subclass(self):
+        """UnroutableActivityError is a VultronError subclass."""
+        from vultron.errors import VultronError
+
+        err = UnroutableActivityError(activity_id="x", reason="test")
+        assert isinstance(err, VultronError)
+
+
+# ---------------------------------------------------------------------------
+# AC-1d: _resolve_case_manager_id callers return FAILURE when required
+# ---------------------------------------------------------------------------
+
+
+class TestResolveCaseManagerIdCallers:
+    """ARCH-15-002: callers return FAILURE when _resolve_case_manager_id is None."""
+
+    def test_sender_node_returns_failure_when_no_case_manager(self):
+        """ResolveCaseManagerNode returns FAILURE when no CASE_MANAGER exists."""
+        from test.core.behaviors.bt_harness import BTTestScenario
+        from vultron.core.behaviors.sender.nodes.actions import (
+            ResolveCaseManagerNode,
+        )
+
+        scenario = BTTestScenario(actor_id=ACTOR_ID)
+        # Seed case with no participants (empty actor_participant_index)
+        case = VulnerabilityCase(id_=CASE_ID, name="No CM")
+        scenario.dl.create(case)
+
+        node = ResolveCaseManagerNode(case_id=CASE_ID)
+        result = scenario.run(node, actor_id=ACTOR_ID)
+        scenario.assert_failure(result)
+
+    def test_check_is_case_manager_returns_failure_when_no_case_manager(self):
+        """CheckIsCaseManagerNode returns FAILURE when no CASE_MANAGER found."""
+        from test.core.behaviors.bt_harness import BTTestScenario
+        from vultron.core.behaviors.case.nodes.conditions import (
+            CheckIsCaseManagerNode,
+        )
+
+        scenario = BTTestScenario(actor_id=ACTOR_ID)
+        case = VulnerabilityCase(id_=CASE_ID, name="No CM")
+        scenario.dl.create(case)
+
+        node = CheckIsCaseManagerNode()
+        result = scenario.run(node, actor_id=ACTOR_ID, case_id=CASE_ID)
+        scenario.assert_failure(result)

--- a/vultron/core/behaviors/case/nodes/communication.py
+++ b/vultron/core/behaviors/case/nodes/communication.py
@@ -136,6 +136,10 @@ class CreateAndPersistCaseActivityNode(DataLayerAction):
         try:
             return self.blackboard.get("create_case_obj")
         except KeyError:
+            self.feedback_message = (
+                f"{self.name}: 'create_case_obj' not on blackboard"
+            )
+            self.logger.error(self.feedback_message)
             return None
 
     def _read_addressees(self) -> list[str] | None:
@@ -162,13 +166,16 @@ class CreateAndPersistCaseActivityNode(DataLayerAction):
             return Status.FAILURE
 
         case_obj = self._read_case_obj()
+        if case_obj is None:
+            return Status.FAILURE
+
         addressees = self._read_addressees()
         if addressees is None:
             return Status.FAILURE
 
         activity = VultronCreateCaseActivity(
             actor=self.actor_id,
-            object_=case_obj if case_obj is not None else case_id,
+            object_=case_obj,
             context=case_id,
             to=addressees if addressees else None,
         )

--- a/vultron/core/behaviors/case/nodes/lifecycle.py
+++ b/vultron/core/behaviors/case/nodes/lifecycle.py
@@ -71,8 +71,8 @@ class CommitCaseLedgerEntryNode(DataLayerAction):
     2. ``case_id`` key in the py_trees blackboard (written by a prior node
        such as :class:`CreateCaseNode` or :class:`PersistCase`).
 
-    If ``case_id`` cannot be resolved, the node returns ``SUCCESS`` silently
-    (no-op for trees that run in a non-case context).
+    If ``case_id`` cannot be resolved, the node returns ``FAILURE`` so the
+    enclosing BT sequence propagates the error (ARCH-15-001).
 
     ``event_type`` and ``object_id`` are derived from the ``activity``
     blackboard key (the inbound :class:`~vultron.core.models.events.base.VultronEvent`
@@ -155,10 +155,11 @@ class CommitCaseLedgerEntryNode(DataLayerAction):
 
         case_id = self._resolve_case_id()
         if not case_id:
-            self.logger.warning(
-                f"{self.name}: no case_id available — skipping log entry"
+            self.logger.error(
+                f"{self.name}: no case_id available — cannot commit ledger"
+                " entry"
             )
-            return Status.SUCCESS
+            return Status.FAILURE
 
         activity = self._resolve_activity()
         if activity is None:

--- a/vultron/core/dispatcher.py
+++ b/vultron/core/dispatcher.py
@@ -31,6 +31,7 @@ from vultron.core.models.replication_state import VultronReplicationState
 from vultron.core.models.events import MessageSemantics
 from vultron.core.ports.dispatcher import ActivityDispatcher
 from vultron.errors import (
+    UnroutableActivityError,
     VultronApiHandlerNotFoundError,
     VultronValidationError,
 )
@@ -97,7 +98,17 @@ class DispatcherBase:
         self._handle(event, dl)
 
     def _handle(self, event: "VultronEvent", dl: "DataLayer") -> None:
-        self._enforce_join_backfill_gate(event, dl)
+        try:
+            self._enforce_join_backfill_gate(event, dl)
+        except UnroutableActivityError:
+            logger.error(
+                "Activity '%s' is unroutable and will be dropped"
+                " (semantics=%s actor_id=%s): no case_id extractable",
+                event.activity_id,
+                event.semantic_type,
+                event.actor_id,
+            )
+            return
         use_case_class = self._get_use_case(event.semantic_type)
         extra_kwargs: dict[str, Any] = {}
         port_factory = self._port_factories.get(event.semantic_type)
@@ -124,8 +135,6 @@ class DispatcherBase:
         if not sender_id:
             return
         case_id = self._extract_case_id(event, dl)
-        if not case_id:
-            return
         highest_contiguous_index, has_case_entries = (
             self._highest_contiguous_case_log_index(case_id, dl)
         )
@@ -169,9 +178,7 @@ class DispatcherBase:
             expected += 1
         return expected - 1, True
 
-    def _extract_case_id(
-        self, event: "VultronEvent", dl: "DataLayer"
-    ) -> str | None:
+    def _extract_case_id(self, event: "VultronEvent", dl: "DataLayer") -> str:
         if (
             event.semantic_type
             == MessageSemantics.ADD_PARTICIPANT_STATUS_TO_PARTICIPANT
@@ -204,7 +211,10 @@ class DispatcherBase:
             value = getattr(event, attr, None)
             if isinstance(value, str) and value:
                 return value
-        return None
+        raise UnroutableActivityError(
+            activity_id=getattr(event, "activity_id", "") or "",
+            reason="No case_id attribute found on event",
+        )
 
     def _get_use_case(self, semantics: MessageSemantics) -> type:
         use_case_class = self._use_case_map.get(semantics)

--- a/vultron/errors.py
+++ b/vultron/errors.py
@@ -153,6 +153,22 @@ class RegistryOrderError(VultronError):
     """
 
 
+class UnroutableActivityError(VultronError):
+    """Raised when an inbound activity cannot be routed to a case.
+
+    Raised by the dispatcher when no ``case_id`` can be extracted from an
+    inbound event whose semantic type requires case-scoped join-backfill
+    gating.  The caller MUST handle this exception explicitly rather than
+    silently dropping the activity.  See ``specs/architecture.yaml``
+    ARCH-15-003 and ``notes/domain-validation.md``.
+    """
+
+    def __init__(self, activity_id: str, reason: str):
+        self.activity_id = activity_id
+        self.reason = reason
+        super().__init__(f"Activity '{activity_id}' is unroutable: {reason}")
+
+
 class DemoFailureError(VultronError):
     """Raised when a demo scenario completes with one or more step failures.
 


### PR DESCRIPTION
- Closes #1377

## Summary

Applies fail-fast behaviour at the 5 named silent-failure sites from
CONCERN-1360. Domain helpers that previously returned `None` or
`Status.SUCCESS` when required values were absent now return
`Status.FAILURE` or raise a typed exception, making failures explicit
and observable.

## Changes

- `vultron/errors.py`: add `UnroutableActivityError(activity_id, reason)` class
- `vultron/core/behaviors/case/nodes/lifecycle.py`: `CommitCaseLedgerEntryNode.update()` returns `Status.FAILURE` (not SUCCESS) when `case_id` unresolvable (ARCH-15-001)
- `vultron/core/behaviors/case/nodes/communication.py`: `_read_case_obj()` sets `feedback_message` and logs at ERROR on KeyError; `update()` returns FAILURE immediately when `case_obj is None` (ARCH-15-001)
- `vultron/core/dispatcher.py`: `_extract_case_id()` raises `UnroutableActivityError` instead of returning None (ARCH-15-003); `_handle()` catches it, logs at ERROR, and returns without re-raising — preventing the inbox re-queue infinite-retry loop
- `test/core/behaviors/case/nodes/test_lifecycle.py`: update existing test assertion SUCCESS → FAILURE
- `test/core/test_fail_fast_silent_sites.py`: 11 dedicated tests covering all 4 sites (AC-1a through AC-1d)

## Verification

- 4658 unit tests pass (11 new)
- Black, flake8, mypy, pyright clean
- Code review finding fixed: `UnroutableActivityError` caught in `_handle` before reaching `_process_inbox_item`'s re-queue path