### PR TITLE
test: verify suggest-actor roles threading (ISSUE-1406)

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1406.md
+++ b/plan/history/2607/implementation/ISSUE-1406.md
@@ -1,0 +1,15 @@
+---
+source: ISSUE-1406
+timestamp: '2026-07-14T19:31:25.529920+00:00'
+title: verify suggest-actor roles threading
+type: implementation
+---
+
+## Issue #1406 — Verify/document suggest-actor received path roles threading
+
+Added integration and unit tests to document and verify that roles from `Accept(Offer(CaseParticipant))` are NOT propagated into the Invite in the `create_accept_actor_recommendation_received_tree` path (because `suggested_roles` is absent from the blackboard), and that `VultronParticipant.case_roles` is therefore `[]`.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1427>
+
+AC-1: `TestAcceptOfferCaseParticipantRolesThreading.test_participant_case_roles_empty_after_full_round_trip` — full round-trip integration test
+AC-2: `TestEmitInviteActorToCaseNodePassesRolesNoneToFactory.test_invite_actor_to_case_called_with_roles_none` + `TestAcceptOfferCaseParticipantRolesThreading.test_invite_roles_none_when_no_blackboard_key` — factory receives roles=None when suggested_roles absent (ADR-0032, BT-HELPER-01)

--- a/plan/incoming/learnings/20260714-suggest-actor-roles-threading-not-propagated.md
+++ b/plan/incoming/learnings/20260714-suggest-actor-roles-threading-not-propagated.md
@@ -1,0 +1,28 @@
+---
+title: suggest-actor Accept path does not thread CaseParticipant roles into Invite
+type: learning
+timestamp: 2026-07-14
+source: ISSUE-1406
+---
+
+In the `create_accept_actor_recommendation_received_tree` path (CaseActor
+receives `Accept(Offer(CaseParticipant))` from Case Owner), the
+`suggested_roles` blackboard key is **never written**. `EmitInviteActorToCaseNode`
+reads this key via `_read_suggested_roles()`, gets a `KeyError`, and returns
+`None` — passing `roles=None` to `factory.invite_actor_to_case()`.
+
+The resulting `Invite` has `roles=None`, so after `Accept(Invite)` the new
+`VultronParticipant.case_roles` is `[]`. This is documented behavior, not a
+bug (ADR-0032, BT-HELPER-01: no silent default substitution).
+
+Contrast with `create_recommend_actor_to_case_received_tree` (fresh path):
+that tree writes `suggested_roles_{id_segment}` (namespaced, per BTND-03-004)
+via `EvaluateDefaultRolesNode`, then reads it in `EmitOfferCaseParticipantToOwnerNode`.
+The key used by `EmitInviteActorToCaseNode` is the flat `suggested_roles` key,
+which the Accept path never populates.
+
+**Takeaway**: When writing tests for the suggest-actor path that verify roles
+end up on a participant, check which sub-tree is under test. Only the
+`invite_actor_to_case_trigger_bt` path (or a manually-constructed tree with
+`EvaluateDefaultRolesNode`) will produce a non-empty `case_roles`. The
+`AcceptOfferCaseParticipant` use case always produces `roles=None` in the Invite.

--- a/test/core/behaviors/case/nodes/test_actor_and_announce_nodes.py
+++ b/test/core/behaviors/case/nodes/test_actor_and_announce_nodes.py
@@ -189,3 +189,64 @@ class TestEmitInviteActorToCaseNodeReadSuggestedRoles:
         assert (
             result is None
         ), f"AC-3: expected None when suggested_roles absent, got {result!r}"
+
+
+class TestEmitInviteActorToCaseNodePassesRolesNoneToFactory:
+    """AC-2 (ISSUE-1406): factory.invite_actor_to_case() called with roles=None.
+
+    When ``suggested_roles`` is absent from the blackboard (as in the
+    ``create_accept_actor_recommendation_received_tree`` path), the node
+    must pass ``roles=None`` to the factory — no silent default substitution
+    (ADR-0032, BT-HELPER-01).
+    """
+
+    @pytest.fixture(autouse=True)
+    def clear_blackboard(self):
+        py_trees.blackboard.Blackboard.storage.clear()
+        yield
+        py_trees.blackboard.Blackboard.storage.clear()
+
+    def test_invite_actor_to_case_called_with_roles_none(self, dl):
+        """AC-2: roles=None passed to factory when suggested_roles absent."""
+        from unittest.mock import MagicMock
+
+        from vultron.adapters.driven.trigger_activity_adapter import (
+            TriggerActivityAdapter,
+        )
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+
+        # attributed_to triggers genesis_hash computation so the internal
+        # commit_log_entry_tree inside EmitInviteActorToCaseNode can bootstrap.
+        case = VulnerabilityCase(
+            id_=AC3_CASE_ID,
+            name="AC2 test case",
+            attributed_to=ACTOR_ID,
+        )
+        dl.create(case)
+
+        mock_factory = MagicMock(spec=TriggerActivityAdapter)
+        mock_factory.invite_actor_to_case.return_value = (
+            "urn:uuid:ac2-invite-001",
+            {"id_": "urn:uuid:ac2-invite-001"},
+        )
+
+        bridge = BTBridge(datalayer=dl, trigger_activity=mock_factory)
+        node = EmitInviteActorToCaseNode(
+            invitee_id=INVITEE_ID,
+            case_id=AC3_CASE_ID,
+        )
+        result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
+
+        assert result.status == Status.SUCCESS
+        mock_factory.invite_actor_to_case.assert_called_once()
+        call_kwargs = mock_factory.invite_actor_to_case.call_args
+        actual_roles = call_kwargs.kwargs.get(
+            "roles",
+            call_kwargs.args[3] if len(call_kwargs.args) > 3 else "MISSING",
+        )
+        assert actual_roles is None, (
+            f"AC-2: invite_actor_to_case must be called with roles=None "
+            f"when suggested_roles is absent, got {actual_roles!r}"
+        )

--- a/test/core/use_cases/received/actor/test_offer_case_participant.py
+++ b/test/core/use_cases/received/actor/test_offer_case_participant.py
@@ -17,14 +17,14 @@ Covers:
 - OfferCaseParticipantReceivedUseCase (Case Owner inbox)
 - AcceptOfferCaseParticipantReceivedUseCase (CaseActor inbox)
 - RejectOfferCaseParticipantReceivedUseCase (CaseActor inbox)
+- TestAcceptOfferCaseParticipantRolesThreading (AC-1/AC-2, ISSUE-1406)
 """
 
 import logging
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import py_trees
-from typing import cast
-
 import pytest
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
@@ -46,6 +46,7 @@ from vultron.wire.as2.factories import (
     accept_case_participant_offer_activity,
     offer_case_participant_activity,
     reject_case_participant_offer_activity,
+    rm_accept_invite_to_case_activity,
 )
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor, as_Service
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
@@ -270,3 +271,175 @@ class TestRejectOfferCaseParticipantReceivedUseCase:
         with caplog.at_level(logging.WARNING):
             RejectOfferCaseParticipantReceivedUseCase(dl, mock_event).execute()
         assert any("missing" in r.message.lower() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# AC-1/AC-2: suggest-actor roles threading (ISSUE-1406)
+# ---------------------------------------------------------------------------
+
+AC1_CASE_ID = "https://example.org/cases/ac1-roles-threading"
+AC1_CASE_ACTOR_ID = "https://example.org/actors/ac1-case-actor"
+AC1_CASE_OWNER_ID = "https://example.org/actors/ac1-case-owner"
+AC1_INVITEE_ID = "https://example.org/actors/ac1-vendor"
+
+
+def _seed_dl_for_ac1() -> SqliteDataLayer:
+    """DataLayer seeded for the full suggest-actor roles-threading round-trip.
+
+    The CaseActor Service has ``context=AC1_CASE_ID`` so that
+    ``_find_case_actor_id()`` resolves correctly when
+    ``AcceptInviteActorToCaseReceivedUseCase`` runs.
+    """
+    from vultron.wire.as2.vocab.base.objects.actors import as_Organization
+
+    dl = SqliteDataLayer("sqlite:///:memory:")
+    case_actor = as_Service(id_=AC1_CASE_ACTOR_ID, context=AC1_CASE_ID)
+    case = VulnerabilityCase(
+        id_=AC1_CASE_ID,
+        name="AC1RolesThreading",
+        attributed_to=AC1_CASE_OWNER_ID,
+    )
+    invitee = as_Organization(id_=AC1_INVITEE_ID)
+    dl.create(case_actor)
+    dl.create(case)
+    dl.create(invitee)
+    return dl
+
+
+class TestAcceptOfferCaseParticipantRolesThreading:
+    """AC-1/AC-2 (ISSUE-1406): roles threading through suggest-actor received path.
+
+    AC-1: Full round-trip — Accept(Offer(CaseParticipant[roles])) →
+          EmitInviteActorToCaseNode (roles=None, no blackboard key) →
+          Invite(roles=None) stored → Accept(Invite) →
+          VultronParticipant.case_roles == [].
+
+    AC-2: Confirm that EmitInviteActorToCaseNode with no ``suggested_roles``
+          blackboard key passes roles=None to invite_actor_to_case(), verifying
+          no silent default substitution (ADR-0032 BT-HELPER-01).
+    """
+
+    @pytest.fixture(autouse=True)
+    def clear_blackboard(self):
+        py_trees.blackboard.Blackboard.storage.clear()
+        yield
+        py_trees.blackboard.Blackboard.storage.clear()
+
+    def _build_accept_offer_event(
+        self,
+    ) -> AcceptOfferCaseParticipantReceivedEvent:
+        from vultron.core.states.roles import CVDRole
+
+        recommended = as_Actor(id_=AC1_INVITEE_ID)
+        offer = offer_case_participant_activity(
+            recommended,
+            target=AC1_CASE_ID,
+            actor=AC1_CASE_ACTOR_ID,
+            to=[AC1_CASE_OWNER_ID],
+            roles=[CVDRole.VENDOR],
+        )
+        accept = accept_case_participant_offer_activity(
+            offer,
+            target=AC1_CASE_ID,
+            actor=AC1_CASE_OWNER_ID,
+            to=[AC1_CASE_ACTOR_ID],
+        )
+        return cast(
+            AcceptOfferCaseParticipantReceivedEvent, extract_event(accept)
+        )
+
+    def test_invite_roles_none_when_no_blackboard_key(self):
+        """AC-2: EmitInviteActorToCaseNode passes roles=None to factory.
+
+        When Accept(Offer(CaseParticipant)) arrives, ``suggested_roles`` is
+        absent from the blackboard (``create_accept_actor_recommendation_received_tree``
+        does not write it).  ``EmitInviteActorToCaseNode._read_suggested_roles()``
+        returns None, and the stored Invite has roles=None — no silent default
+        substitution (ADR-0032, BT-HELPER-01).
+        """
+        dl = _seed_dl_for_ac1()
+        event = self._build_accept_offer_event()
+        AcceptOfferCaseParticipantReceivedUseCase(
+            dl, event, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
+
+        outbox = dl.outbox_list_for_actor(AC1_CASE_ACTOR_ID)
+        invite_obj = None
+        for act_id in outbox:
+            obj = dl.read(act_id)
+            if obj is not None and str(getattr(obj, "type_", "")) == "Invite":
+                invite_obj = obj
+                break
+
+        assert (
+            invite_obj is not None
+        ), "Invite must be stored in CaseActor outbox"
+        assert getattr(invite_obj, "roles", "sentinel") is None, (
+            "AC-2: EmitInviteActorToCaseNode must pass roles=None when "
+            "suggested_roles is absent from blackboard (no default substitution)"
+        )
+
+    def test_participant_case_roles_empty_after_full_round_trip(self):
+        """AC-1: Full suggest-actor round-trip ends with participant.case_roles==[].
+
+        Roles from Accept(Offer(CaseParticipant[VENDOR])) are NOT threaded into
+        the Invite when ``suggested_roles`` is absent from the blackboard.
+        The resulting participant is created with an empty case_roles list.
+        """
+        from vultron.core.use_cases.received.actor.invite import (
+            AcceptInviteActorToCaseReceivedUseCase,
+        )
+
+        dl = _seed_dl_for_ac1()
+        event = self._build_accept_offer_event()
+
+        # Step 1: CaseActor receives Accept(Offer(CaseParticipant)) → emits Invite
+        AcceptOfferCaseParticipantReceivedUseCase(
+            dl, event, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
+
+        # Step 2: find the stored Invite
+        outbox = dl.outbox_list_for_actor(AC1_CASE_ACTOR_ID)
+        invite_obj = None
+        for act_id in outbox:
+            obj = dl.read(act_id)
+            if obj is not None and str(getattr(obj, "type_", "")) == "Invite":
+                invite_obj = obj
+                break
+        assert (
+            invite_obj is not None
+        ), "Invite must be present in CaseActor outbox"
+
+        # Step 3: invitee sends Accept(Invite) — BT creates VultronParticipant
+        py_trees.blackboard.Blackboard.storage.clear()
+        from vultron.core.models.events.actor import (
+            AcceptInviteActorToCaseReceivedEvent,
+        )
+        from vultron.wire.as2.vocab.base.objects.activities.transitive import (
+            as_Invite,
+        )
+
+        accept_invite = rm_accept_invite_to_case_activity(
+            cast(as_Invite, invite_obj), actor=AC1_INVITEE_ID
+        )
+        accept_invite_event = cast(
+            AcceptInviteActorToCaseReceivedEvent, extract_event(accept_invite)
+        )
+        AcceptInviteActorToCaseReceivedUseCase(
+            dl, accept_invite_event, sync_port=MagicMock()
+        ).execute()
+
+        # Step 4: assert participant.case_roles == []
+        reloaded_case = cast(Any, dl.read(AC1_CASE_ID))
+        participant_id = reloaded_case.actor_participant_index.get(
+            AC1_INVITEE_ID
+        )
+        assert (
+            participant_id is not None
+        ), "Invitee must be registered as participant"
+        participant = cast(Any, dl.get(id_=participant_id))
+        assert participant is not None
+        assert participant.case_roles == [], (
+            "AC-1: participant.case_roles must be [] when roles were not "
+            "threaded from CaseParticipant offer (suggested_roles absent)"
+        )


### PR DESCRIPTION
- Closes #1406

## Summary

Adds integration and unit tests that document and verify the roles-threading behavior in the suggest-actor received path: roles from `Accept(Offer(CaseParticipant[roles]))` are **not** propagated into the Invite (because `suggested_roles` is absent from the blackboard in `create_accept_actor_recommendation_received_tree`), so `VultronParticipant.case_roles` ends up as `[]`. No silent default substitution occurs (ADR-0032, BT-HELPER-01).

## Changes

- `test/core/behaviors/case/nodes/test_actor_and_announce_nodes.py`: adds `TestEmitInviteActorToCaseNodePassesRolesNoneToFactory` — unit test confirming `factory.invite_actor_to_case()` is called with `roles=None` when `suggested_roles` is absent (AC-2)
- `test/core/use_cases/received/actor/test_offer_case_participant.py`: adds `TestAcceptOfferCaseParticipantRolesThreading` with two tests:
  - `test_invite_roles_none_when_no_blackboard_key` — verifies stored Invite has `roles=None` (AC-2 integration confirmation)
  - `test_participant_case_roles_empty_after_full_round_trip` — full round-trip from `Accept(Offer(CaseParticipant[VENDOR]))` through `Accept(Invite)` to `VultronParticipant.case_roles==[]` (AC-1)

## Verification

- All 4709 unit tests pass (3 new)
- Black, flake8, mypy, pyright clean