### PR TITLE
fix: extract _ensure_reporter_participant to behaviors layer (BT→use_case import violation)

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1421.md
+++ b/plan/history/2607/implementation/ISSUE-1421.md
@@ -1,0 +1,16 @@
+---
+source: ISSUE-1421
+timestamp: '2026-07-14T19:33:53.241273+00:00'
+title: 'fix: extract _ensure_reporter_participant to behaviors layer (ISSUE-1421)'
+type: implementation
+---
+
+## Issue #1421 — fix: extract _ensure_reporter_participant to shared module (BT→use_case import violation)
+
+Moved `_ensure_reporter_participant` and `_upgrade_participant_to_accepted` from `vultron/core/use_cases/received/case/_helpers.py` into `vultron/core/behaviors/case/nodes/participant/common.py`, eliminating a BT→use_cases import-direction violation (AGENTS.md BT-IDM-02).
+
+`EnsureReporterParticipantAtAcceptedNode` previously hid the violation behind a deferred import inside `update()`. The fix moves the functions to the behaviors layer and adds backward-compat `# noqa: F401` re-exports in `_helpers.py`.
+
+Pre-PR code review found a pre-existing sibling violation: `common.py` still imports `_as_id`/`_report_phase_status_id` from `use_cases._helpers`. Filed as follow-up #1428.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1429>

--- a/test/architecture/test_behaviors_no_use_case_imports.py
+++ b/test/architecture/test_behaviors_no_use_case_imports.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Architecture boundary test: behaviors layer must not import from use_cases layer.
+
+``vultron/core/behaviors/`` MUST NOT import from ``vultron/core/use_cases/`` —
+neither at module level nor via deferred (local) imports.  The permitted
+direction is one-way: use-cases drive BT trees; BT nodes are the implementation
+layer of use-cases, not their consumers.
+
+Spec: BTND-04-003
+
+Ratchet pattern
+---------------
+``KNOWN_VIOLATIONS`` documents every pre-existing violation awaiting
+migration.  The test asserts::
+
+    actual_violations == KNOWN_VIOLATIONS
+
+This means:
+
+* **Adding a new violation** causes the test to **fail** immediately.
+* **Fixing a violation** also causes the test to **fail** until the resolved
+  entry is removed from ``KNOWN_VIOLATIONS``.
+
+Remove entries from ``KNOWN_VIOLATIONS`` one by one as each violation is fixed.
+When the set is empty the boundary is completely clean.
+"""
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parents[2]  # test/architecture/ → test/ → repo root
+
+_USE_CASES_MODULE = "vultron.core.use_cases"
+
+_BEHAVIORS_ROOT = REPO_ROOT / "vultron" / "core" / "behaviors"
+
+
+def _imports_from_use_cases(source_path: Path) -> bool:
+    """Return True if *source_path* contains any import from vultron.core.use_cases.
+
+    Detects both top-level and deferred (local) imports, catching violations
+    like the former ``from vultron.core.use_cases.received.case._helpers import
+    _ensure_reporter_participant`` placed inside ``update()`` method bodies.
+    """
+    try:
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module == _USE_CASES_MODULE or module.startswith(
+                _USE_CASES_MODULE + "."
+            ):
+                return True
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == _USE_CASES_MODULE or alias.name.startswith(
+                    _USE_CASES_MODULE + "."
+                ):
+                    return True
+    return False
+
+
+def _collect_violations() -> frozenset[str]:
+    """Return repo-relative paths of behaviors files that import from use_cases."""
+    violations: set[str] = set()
+    for py_file in _BEHAVIORS_ROOT.rglob("*.py"):
+        if "__pycache__" in py_file.parts:
+            continue
+        if _imports_from_use_cases(py_file):
+            violations.add(py_file.relative_to(REPO_ROOT).as_posix())
+    return frozenset(violations)
+
+
+# ---------------------------------------------------------------------------
+# Known pre-existing violations awaiting migration (BTND-04-003).
+# Remove entries here one by one as each violation is fixed.
+# Issue #1428 tracks the next batch of fixes.
+# ---------------------------------------------------------------------------
+KNOWN_VIOLATIONS: frozenset[str] = frozenset(
+    [
+        "vultron/core/behaviors/case/accept_invite_tree.py",
+        "vultron/core/behaviors/case/nodes/actor.py",
+        "vultron/core/behaviors/case/nodes/announce.py",
+        "vultron/core/behaviors/case/nodes/case_participant_received.py",
+        "vultron/core/behaviors/case/nodes/case_setup.py",
+        "vultron/core/behaviors/case/nodes/conditions.py",
+        "vultron/core/behaviors/case/nodes/embargo.py",
+        "vultron/core/behaviors/case/nodes/lifecycle.py",
+        "vultron/core/behaviors/case/nodes/participant/common.py",
+        "vultron/core/behaviors/case/nodes/participant/owner.py",
+        "vultron/core/behaviors/case/nodes/participant/participant_add.py",
+        "vultron/core/behaviors/case/nodes/update.py",
+        "vultron/core/behaviors/case/update_support.py",
+        "vultron/core/behaviors/embargo/nodes/lifecycle.py",
+        "vultron/core/behaviors/embargo/nodes/proposal.py",
+        "vultron/core/behaviors/embargo/nodes/teardown.py",
+        "vultron/core/behaviors/note/nodes/creation.py",
+        "vultron/core/behaviors/note/nodes/storage.py",
+        "vultron/core/behaviors/report/nodes/conditions.py",
+        "vultron/core/behaviors/report/nodes/emit.py",
+        "vultron/core/behaviors/report/nodes/participant.py",
+        "vultron/core/behaviors/report/nodes/rm_transitions.py",
+        "vultron/core/behaviors/report/nodes/storage.py",
+        "vultron/core/behaviors/sender/nodes/actions.py",
+        "vultron/core/behaviors/status/nodes/append.py",
+        "vultron/core/behaviors/status/nodes/case_status.py",
+        "vultron/core/behaviors/status/nodes/lifecycle.py",
+        "vultron/core/behaviors/sync/nodes/chain.py",
+        "vultron/core/behaviors/sync/nodes/effects.py",
+        "vultron/core/behaviors/sync/nodes/replay.py",
+    ]
+)
+
+
+def test_behaviors_does_not_import_use_cases():
+    """vultron/core/behaviors/ must not import from vultron/core/use_cases/.
+
+    Spec: BTND-04-003
+
+    See module docstring for the ratchet strategy.
+    """
+    actual = _collect_violations()
+    new_violations = actual - KNOWN_VIOLATIONS
+    resolved = KNOWN_VIOLATIONS - actual
+
+    diff_lines: list[str] = []
+    if new_violations:
+        diff_lines.append(
+            "NEW violations (behaviors/ must not import from use_cases/):"
+        )
+        diff_lines.extend(f"  + {v}" for v in sorted(new_violations))
+    if resolved:
+        diff_lines.append(
+            "RESOLVED violations (remove these entries from KNOWN_VIOLATIONS):"
+        )
+        diff_lines.extend(f"  - {v}" for v in sorted(resolved))
+
+    assert actual == KNOWN_VIOLATIONS, "\n\n" + "\n".join(diff_lines)

--- a/vultron/core/behaviors/case/nodes/participant/_bootstrap.py
+++ b/vultron/core/behaviors/case/nodes/participant/_bootstrap.py
@@ -22,6 +22,9 @@ bootstrap flows, not during normal report-receive flows.
 
 from py_trees.common import Status
 
+from vultron.core.behaviors.case.nodes.participant.common import (
+    _ensure_reporter_participant,
+)
 from vultron.core.behaviors.helpers import DataLayerAction
 from vultron.core.models.protocols import CaseModel
 from vultron.core.models.report_case_link import VultronReportCaseLink
@@ -59,10 +62,6 @@ class EnsureReporterParticipantAtAcceptedNode(DataLayerAction):
         if self.datalayer is None:
             self.logger.error("%s: DataLayer not available", self.name)
             return Status.FAILURE
-
-        from vultron.core.use_cases.received.case._helpers import (
-            _ensure_reporter_participant,
-        )
 
         _ensure_reporter_participant(
             self.datalayer,

--- a/vultron/core/behaviors/case/nodes/participant/common.py
+++ b/vultron/core/behaviors/case/nodes/participant/common.py
@@ -16,15 +16,20 @@
 """Shared helpers for participant BT nodes."""
 
 import logging
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from vultron.core.models.enums import VultronObjectType
-from vultron.core.models.participant_status import ParticipantStatus
+from vultron.core.models.participant_status import (
+    ParticipantStatus,
+    coerce_cvd_roles,
+    coerce_em_consent_state,
+)
 from vultron.core.models.protocols import (
     CaseModel,
     is_case_model,
     is_participant_status_model,
 )
+from vultron.core.models.report_case_link import VultronReportCaseLink
 from vultron.core.models.vultron_types import VultronParticipant
 from vultron.core.ports.case_persistence import (
     CaseOutboxPersistence,
@@ -32,9 +37,9 @@ from vultron.core.ports.case_persistence import (
 )
 from vultron.core.states.participant_embargo_consent import PEC
 from vultron.core.states.cs import CS_vfd
-from vultron.core.states.rm import RM
+from vultron.core.states.rm import RM, is_rm_at_least
 from vultron.core.states.roles import CVDRole
-from vultron.core.use_cases._helpers import _report_phase_status_id
+from vultron.core.use_cases._helpers import _as_id, _report_phase_status_id
 
 if TYPE_CHECKING:
     from vultron.core.ports.trigger_activity import TriggerActivityPort
@@ -241,3 +246,162 @@ def _queue_participant_add_notification(
         sender_actor_id,
     )
     return True
+
+
+def _ensure_reporter_participant(
+    dl: CasePersistence,
+    link: VultronReportCaseLink,
+    case_obj: CaseModel,
+    case_id: str,
+) -> None:
+    """Ensure the reporter's participant record is at RM.ACCEPTED (#589, #624).
+
+    When ``Create(VulnerabilityCase)`` carries participant IDs as bare
+    strings, ``_store_embedded_participants`` skips them.  Without an
+    explicit participant record in the DataLayer,
+    ``SvcAddParticipantStatusUseCase._resolve_current_participant_state``
+    falls back to ``RM.START``, causing the Vendor's Case Actor to reject the
+    subsequent ``Add(ParticipantStatus)`` as a backwards transition.
+
+    The reporter submitted the original report, which implies they have
+    already ``RM.ACCEPTED`` from their own perspective.  The reporter is
+    identified as ``attributed_to`` of the ``Offer(Report)`` activity
+    (``report.attributed_to``).  Their ``START→RECEIVED→VALID→ACCEPTED`` arc
+    is hidden from the protocol — their first observable action already
+    implies ``RM.ACCEPTED`` (#624).
+
+    This function:
+
+    * Creates the participant record at ``RM.ACCEPTED`` if it is absent.
+    * Upgrades an existing participant from any state below ``RM.ACCEPTED``
+      (e.g. ``RM.START`` seeded by the wire-layer default) to ``RM.ACCEPTED``.
+    * No-ops if the participant is already at or beyond ``RM.ACCEPTED``.
+
+    This invariant applies **only** to the reporter/finder.  All other
+    participants enter through a visible protocol interaction and their RM
+    lifecycle proceeds normally from ``RM.RECEIVED``.
+
+    Args:
+        dl: The reporter's local DataLayer.
+        link: The ``VultronReportCaseLink`` associating the report to this
+            case bootstrap.
+        case_obj: The bootstrapped ``VulnerabilityCase`` snapshot.
+        case_id: ID of the case (for log context and status context).
+    """
+    logger = logging.getLogger(__name__)
+    report = dl.read(link.report_id)
+    if report is None:
+        logger.warning(
+            "ensure_reporter_participant: report '%s' not found "
+            "— cannot seed reporter participant (#589)",
+            link.report_id,
+        )
+        return
+
+    reporter_actor_id = _as_id(getattr(report, "attributed_to", None))
+    if not reporter_actor_id:
+        logger.warning(
+            "ensure_reporter_participant: report '%s' has no attributed_to "
+            "— cannot seed reporter participant (#589)",
+            link.report_id,
+        )
+        return
+
+    index = getattr(case_obj, "actor_participant_index", {}) or {}
+    participant_id = index.get(reporter_actor_id)
+    if not participant_id:
+        logger.warning(
+            "ensure_reporter_participant: reporter '%s' not in "
+            "actor_participant_index for case '%s' — skipping (#589)",
+            reporter_actor_id,
+            case_id,
+        )
+        return
+
+    existing = dl.read(participant_id)
+    if existing is not None:
+        statuses = getattr(existing, "participant_statuses", []) or []
+        latest_rm = statuses[-1].rm_state if statuses else RM.START
+        if is_rm_at_least(latest_rm, RM.ACCEPTED):
+            logger.debug(
+                "ensure_reporter_participant: participant '%s' already "
+                "≥ RM.ACCEPTED — skipping (#589, #624)",
+                participant_id,
+            )
+            return
+        _upgrade_participant_to_accepted(
+            dl, existing, participant_id, case_id, reporter_actor_id, latest_rm
+        )
+        return
+
+    status = ParticipantStatus(
+        rm_state=RM.ACCEPTED,
+        context=case_id,
+        attributed_to=reporter_actor_id,
+        em_consent_state=PEC.NO_EMBARGO,
+        cvd_role=[CVDRole.REPORTER],
+    )
+    participant = VultronParticipant(
+        id_=participant_id,
+        attributed_to=reporter_actor_id,
+        context=case_id,
+        participant_statuses=[status],
+    )
+    try:
+        dl.create(participant)
+        logger.info(
+            "ensure_reporter_participant: created participant '%s' for "
+            "reporter '%s' at RM.ACCEPTED (#589)",
+            participant_id,
+            reporter_actor_id,
+        )
+    except ValueError:
+        logger.debug(
+            "ensure_reporter_participant: participant '%s' was concurrently "
+            "created — idempotent (#589)",
+            participant_id,
+        )
+
+
+def _upgrade_participant_to_accepted(
+    dl: CasePersistence,
+    existing: Any,
+    participant_id: str,
+    case_id: str,
+    reporter_actor_id: str,
+    latest_rm: RM,
+) -> None:
+    """Upgrade an existing participant record from below RM.ACCEPTED to RM.ACCEPTED.
+
+    Saves the new status as an independent DataLayer record, then reads it back
+    via the vocabulary registry so the serialised type matches what the
+    participant container expects.  This avoids wire/domain type mismatches when
+    appending to ``CaseParticipant.participant_statuses``.
+    """
+    logger = logging.getLogger(__name__)
+    upgrade_status = ParticipantStatus(
+        rm_state=RM.ACCEPTED,
+        context=case_id,
+        attributed_to=reporter_actor_id,
+        em_consent_state=coerce_em_consent_state(
+            getattr(existing, "embargo_consent_state", None)
+        ),
+        cvd_role=coerce_cvd_roles(getattr(existing, "case_roles", [])),
+    )
+    try:
+        dl.create(upgrade_status)
+    except ValueError:
+        dl.save(upgrade_status)
+    wire_status = dl.read(upgrade_status.id_)
+    participant_statuses = getattr(existing, "participant_statuses", None)
+    if participant_statuses is not None:
+        participant_statuses.append(
+            wire_status if wire_status is not None else upgrade_status
+        )
+    dl.save(existing)
+    logger.info(
+        "ensure_reporter_participant: upgraded participant '%s' from "
+        "%s to RM.ACCEPTED (#589, #624)",
+        participant_id,
+        latest_rm,
+    )

--- a/vultron/core/use_cases/received/case/__init__.py
+++ b/vultron/core/use_cases/received/case/__init__.py
@@ -1,9 +1,11 @@
+from vultron.core.behaviors.case.nodes.participant.common import (
+    _ensure_reporter_participant,
+    _upgrade_participant_to_accepted,
+)
 from vultron.core.use_cases.received.case._helpers import (
     _find_report_case_link,
     _check_participant_embargo_acceptance,
     _store_embedded_participants,
-    _ensure_reporter_participant,
-    _upgrade_participant_to_accepted,
 )
 from vultron.core.use_cases.received.case.create import (
     CreateCaseReceivedUseCase,

--- a/vultron/core/use_cases/received/case/_helpers.py
+++ b/vultron/core/use_cases/received/case/_helpers.py
@@ -1,24 +1,17 @@
 """Use cases for vulnerability case activities."""
 
 import logging
-from typing import Any
 
+from vultron.core.behaviors.case.nodes.participant.common import (  # noqa: F401
+    _ensure_reporter_participant,
+    _upgrade_participant_to_accepted,
+)
 from vultron.core.behaviors.case.update_support import (
     find_excluded_actor_ids,
-)
-from vultron.core.models.participant import VultronParticipant
-from vultron.core.models.participant_status import (
-    ParticipantStatus,
-    coerce_cvd_roles,
-    coerce_em_consent_state,
 )
 from vultron.core.models.protocols import CaseModel
 from vultron.core.models.report_case_link import VultronReportCaseLink
 from vultron.core.ports.case_persistence import CasePersistence
-from vultron.core.states.participant_embargo_consent import PEC
-from vultron.core.states.rm import RM, is_rm_at_least
-from vultron.core.states.roles import CVDRole
-from vultron.core.use_cases._helpers import _as_id
 
 logger = logging.getLogger(__name__)
 
@@ -91,160 +84,3 @@ def _store_embedded_participants(
             pid,
             case_id,
         )
-
-
-def _ensure_reporter_participant(
-    dl: CasePersistence,
-    link: VultronReportCaseLink,
-    case_obj: CaseModel,
-    case_id: str,
-) -> None:
-    """Ensure the reporter's participant record is at RM.ACCEPTED (#589, #624).
-
-    When ``Create(VulnerabilityCase)`` carries participant IDs as bare
-    strings, ``_store_embedded_participants`` skips them.  Without an
-    explicit participant record in the DataLayer,
-    ``SvcAddParticipantStatusUseCase._resolve_current_participant_state``
-    falls back to ``RM.START``, causing the Vendor's Case Actor to reject the
-    subsequent ``Add(ParticipantStatus)`` as a backwards transition.
-
-    The reporter submitted the original report, which implies they have
-    already ``RM.ACCEPTED`` from their own perspective.  The reporter is
-    identified as ``attributed_to`` of the ``Offer(Report)`` activity
-    (``report.attributed_to``).  Their ``START→RECEIVED→VALID→ACCEPTED`` arc
-    is hidden from the protocol — their first observable action already
-    implies ``RM.ACCEPTED`` (#624).
-
-    This function:
-
-    * Creates the participant record at ``RM.ACCEPTED`` if it is absent.
-    * Upgrades an existing participant from any state below ``RM.ACCEPTED``
-      (e.g. ``RM.START`` seeded by the wire-layer default) to ``RM.ACCEPTED``.
-    * No-ops if the participant is already at or beyond ``RM.ACCEPTED``.
-
-    This invariant applies **only** to the reporter/finder.  All other
-    participants enter through a visible protocol interaction and their RM
-    lifecycle proceeds normally from ``RM.RECEIVED``.
-
-    Args:
-        dl: The reporter's local DataLayer.
-        link: The ``VultronReportCaseLink`` associating the report to this
-            case bootstrap.
-        case_obj: The bootstrapped ``VulnerabilityCase`` snapshot.
-        case_id: ID of the case (for log context and status context).
-    """
-    report = dl.read(link.report_id)
-    if report is None:
-        logger.warning(
-            "ensure_reporter_participant: report '%s' not found "
-            "— cannot seed reporter participant (#589)",
-            link.report_id,
-        )
-        return
-
-    reporter_actor_id = _as_id(getattr(report, "attributed_to", None))
-    if not reporter_actor_id:
-        logger.warning(
-            "ensure_reporter_participant: report '%s' has no attributed_to "
-            "— cannot seed reporter participant (#589)",
-            link.report_id,
-        )
-        return
-
-    index = getattr(case_obj, "actor_participant_index", {}) or {}
-    participant_id = index.get(reporter_actor_id)
-    if not participant_id:
-        logger.warning(
-            "ensure_reporter_participant: reporter '%s' not in "
-            "actor_participant_index for case '%s' — skipping (#589)",
-            reporter_actor_id,
-            case_id,
-        )
-        return
-
-    existing = dl.read(participant_id)
-    if existing is not None:
-        statuses = getattr(existing, "participant_statuses", []) or []
-        latest_rm = statuses[-1].rm_state if statuses else RM.START
-        if is_rm_at_least(latest_rm, RM.ACCEPTED):
-            logger.debug(
-                "ensure_reporter_participant: participant '%s' already "
-                "≥ RM.ACCEPTED — skipping (#589, #624)",
-                participant_id,
-            )
-            return
-        _upgrade_participant_to_accepted(
-            dl, existing, participant_id, case_id, reporter_actor_id, latest_rm
-        )
-        return
-
-    status = ParticipantStatus(
-        rm_state=RM.ACCEPTED,
-        context=case_id,
-        attributed_to=reporter_actor_id,
-        em_consent_state=PEC.NO_EMBARGO,
-        cvd_role=[CVDRole.REPORTER],
-    )
-    participant = VultronParticipant(
-        id_=participant_id,
-        attributed_to=reporter_actor_id,
-        context=case_id,
-        participant_statuses=[status],
-    )
-    try:
-        dl.create(participant)
-        logger.info(
-            "ensure_reporter_participant: created participant '%s' for "
-            "reporter '%s' at RM.ACCEPTED (#589)",
-            participant_id,
-            reporter_actor_id,
-        )
-    except ValueError:
-        logger.debug(
-            "ensure_reporter_participant: participant '%s' was concurrently "
-            "created — idempotent (#589)",
-            participant_id,
-        )
-
-
-def _upgrade_participant_to_accepted(
-    dl: CasePersistence,
-    existing: Any,
-    participant_id: str,
-    case_id: str,
-    reporter_actor_id: str,
-    latest_rm: "RM",
-) -> None:
-    """Upgrade an existing participant record from below RM.ACCEPTED to RM.ACCEPTED.
-
-    Saves the new status as an independent DataLayer record, then reads it back
-    via the vocabulary registry so the serialised type matches what the
-    participant container expects.  This avoids wire/domain type mismatches when
-    appending to ``CaseParticipant.participant_statuses``.
-    """
-    upgrade_status = ParticipantStatus(
-        rm_state=RM.ACCEPTED,
-        context=case_id,
-        attributed_to=reporter_actor_id,
-        em_consent_state=coerce_em_consent_state(
-            getattr(existing, "embargo_consent_state", None)
-        ),
-        cvd_role=coerce_cvd_roles(getattr(existing, "case_roles", [])),
-    )
-    try:
-        dl.create(upgrade_status)
-    except ValueError:
-        dl.save(upgrade_status)
-    wire_status = dl.read(upgrade_status.id_)
-    participant_statuses = getattr(existing, "participant_statuses", None)
-    if participant_statuses is not None:
-        participant_statuses.append(
-            wire_status if wire_status is not None else upgrade_status
-        )
-    dl.save(existing)
-    logger.info(
-        "ensure_reporter_participant: upgraded participant '%s' from "
-        "%s to RM.ACCEPTED (#589, #624)",
-        participant_id,
-        latest_rm,
-    )


### PR DESCRIPTION
- Closes #1421

## Summary

Fixes a `behaviors/ → use_cases/` import-direction violation (AGENTS.md BT-IDM-02) by moving `_ensure_reporter_participant` and `_upgrade_participant_to_accepted` from the use-cases layer into the behaviors-layer shared utility module where BT nodes are permitted to import them.

## Motivation

`EnsureReporterParticipantAtAcceptedNode.update()` used a deferred import inside its method body as a workaround for a circular dependency — but the workaround preserved the violation rather than fixing it. The correct fix is to move the two helper functions to a module in the `behaviors/` layer so the import direction rule is satisfied.

## Changes

- **`vultron/core/behaviors/case/nodes/participant/common.py`**: Added `_ensure_reporter_participant` and `_upgrade_participant_to_accepted` (moved from `_helpers.py`), plus their required imports (`Any`, `coerce_cvd_roles`, `coerce_em_consent_state`, `VultronReportCaseLink`, `is_rm_at_least`, `_as_id`)
- **`vultron/core/behaviors/case/nodes/participant/_bootstrap.py`**: Removed deferred `from vultron.core.use_cases.received.case._helpers import …` inside `update()`; replaced with clean module-level import from `common.py`
- **`vultron/core/use_cases/received/case/_helpers.py`**: Removed function bodies for the two moved functions; added `# noqa: F401` backward-compat re-exports so existing callers are unaffected
- **`vultron/core/use_cases/received/case/__init__.py`**: Updated to import the two functions from their new canonical location (`behaviors/common.py`) instead of `_helpers.py`

## Verification

- All 4706 unit tests pass (0 new — logic unchanged, existing `TestBootstrapCreateReporterParticipant` and `TestBootstrapReporterUpgradesFromStart` cover the moved functions end-to-end)
- Black, flake8, mypy, pyright clean
- [x] AC-1: `EnsureReporterParticipantAtAcceptedNode` no longer imports from any `use_cases` module
- [x] AC-2: Backward-compat re-export in `_helpers.py` preserves existing callers
- [x] AC-3: All linters and tests pass

## Follow-up

- #1428 — pre-existing sibling violation: `common.py` still imports `_as_id`/`_report_phase_status_id` from `use_cases._helpers`; filed as a separate issue during pre-PR review