### PR TITLE
refactor: move CVDRole to vultron/enums/; config.py → config/ sub-package (#1342)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -339,9 +339,9 @@ Short entries are reproduced here; longer ones are referenced below.
 - **Production Adapters MUST NOT Import from `vultron/demo/` for Config** —
   `vultron/demo/` is scaffolding; its modules MUST NOT be imported by
   production adapter code.  Actor policy configuration (`auto_create_case`,
-  `default_case_roles`) belongs in `AppConfig.actor` (loaded via
-  `load_actor_config()` from `vultron/config/`), not in `SeedConfig`.
-  See [notes/configuration.md](notes/configuration.md) § "Target Architecture"
+  `default_case_roles`) belongs in `AppConfig.actor` (read via
+  `get_config().actor` from `vultron/config/`), not in `SeedConfig`.
+  See [notes/configuration.md](notes/configuration.md) § "Current Architecture"
   and specs CFG-07-005 through CFG-07-007.
 - **Idempotency Responsibility Chain** — see
   [`vultron/core/AGENTS.md`](vultron/core/AGENTS.md)

--- a/notes/bt-composability.md
+++ b/notes/bt-composability.md
@@ -533,10 +533,9 @@ bb.set("https://example.org/cases/abc123", case_obj)
 The local actor's default CVD roles MUST be sourced from `ActorConfig`
 rather than hardcoded in BT nodes.
 
-`ActorConfig` is a neutral Pydantic model in `vultron/core/models/` (or
-`vultron/config.py`) — **not** inside `vultron/demo/`. This ensures BT
-nodes can import it without violating the no-demo-layer-imports rule
-(BTND-04-002, CFG-07-001).
+`ActorConfig` is a neutral Pydantic model in `vultron/config/actor.py` —
+**not** inside `vultron/demo/`. This ensures BT nodes can import it without
+violating the no-demo-layer-imports rule (BTND-04-002, CFG-07-001).
 
 See also: `specs/behavior-tree-node-design.yaml` BTND-05-001 through
 BTND-05-003, `specs/configuration.yaml` CFG-07-001 through CFG-07-004.

--- a/notes/case-communication-model.md
+++ b/notes/case-communication-model.md
@@ -124,7 +124,7 @@ The Case Actor is the participant with `CVDRole.CASE_MANAGER`. To resolve
 its actor ID from a known case:
 
 ```python
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 
 def _resolve_case_manager_id(case, dl) -> str | None:
     for p_id in case.actor_participant_index.values():

--- a/notes/codebase-structure.md
+++ b/notes/codebase-structure.md
@@ -46,7 +46,9 @@ Enums are currently organized across multiple locations in the codebase:
 - `vultron/core/models/events.py` — `MessageSemantics` (domain enum)
 - `vultron/wire/as2/enums.py` — AS2 structural enums (`as_ObjectType`,
   `as_TransitiveActivityType`, etc.)
-- `vultron/enums.py` — backward-compat re-exports only
+- `vultron/enums/` — bottom-of-stack neutral enumeration layer (`CVDRole`,
+  `serialize_roles`, `validate_roles`; MUST NOT import from `vultron/core/`
+  or `vultron/config/`); see `docs/adr/0031-vultron-enums-neutral-layer.md`
 - `vultron/case_states/enums/` — case state enums, split into submodules:
   - `cvss_31.py`
   - `embargo.py`

--- a/notes/configuration.md
+++ b/notes/configuration.md
@@ -20,8 +20,10 @@ relevant_packages:
 IDEA-260402-01 (design session 2026-04-23) established that Vultron config
 files MUST use YAML for readability and MUST be loaded into Pydantic-backed
 structured objects for type safety. This note captures the design decisions
-and implementation guidance for `vultron/config.py` and the aligned
-`SeedConfig` refactor.
+and implementation guidance for the `vultron/config/` sub-package and the
+aligned `SeedConfig` refactor. The `vultron/config.py` flat module shown in
+the historical sections below was replaced by the sub-package in issue #1342;
+see § "Current Architecture" for the live layout.
 
 See `specs/configuration.yaml` for the formal requirements (CFG-01 through
 CFG-06).
@@ -45,7 +47,11 @@ CFG-06).
 
 ---
 
-## Module Structure
+## Module Structure (historical — superseded by issue #1342)
+
+> **Note**: The layout below was the pre-migration design. The flat
+> `vultron/config.py` no longer exists. See § "Current Architecture" below
+> for the live sub-package layout.
 
 ```text
 vultron/
@@ -55,9 +61,10 @@ vultron/
     seed_config.py   ← SeedConfig (separate; refactored to BaseSettings)
 ```
 
-`vultron/config.py` is a **neutral module** — it MUST NOT import from
-`vultron/adapters/` or `vultron/wire/` or FastAPI. It sits alongside
-`vultron/errors.py` and `vultron/enums.py` as a shared-access layer.
+`vultron/config.py` was a **neutral module** — it MUST NOT import from
+`vultron/adapters/` or `vultron/wire/` or FastAPI. It sat alongside
+`vultron/errors.py` as a shared-access layer. This constraint still applies
+to the `vultron/config/` sub-package.
 
 ---
 

--- a/notes/configuration.md
+++ b/notes/configuration.md
@@ -186,7 +186,23 @@ server:
 
 database:
   db_url: "sqlite:///vultron.db"
+
+actor:
+  auto_create_case: true
+  default_case_roles: []
 ```
+
+The `actor:` section maps to `AppConfig.actor` (`ActorConfig`). It controls
+actor-policy defaults used by BT nodes and the production adapter:
+
+- `auto_create_case`: when `true` (default), create a `VulnerabilityCase`
+  immediately on `Offer(Report)` receipt (ADR-0015 Option 4).  Set to
+  `false` to defer case creation so a pre-case ACK can be sent first
+  (CM-15-001, issue #1133).
+- `default_case_roles`: list of CVD role strings (e.g. `["coordinator"]`)
+  assigned to the local actor when it creates or takes ownership of a case.
+  `CVDRole.CASE_OWNER` is always appended at participant-creation time
+  (BTND-05-002) and does not need to be listed here.
 
 ---
 
@@ -198,6 +214,8 @@ database:
 | `VULTRON_SERVER__BASE_URL` | `server.base_url` | `http://localhost:7999` |
 | `VULTRON_SERVER__LOG_LEVEL` | `server.log_level` | `INFO` |
 | `VULTRON_DATABASE__DB_URL` | `database.db_url` | `sqlite:///vultron.db` |
+| `VULTRON_ACTOR__AUTO_CREATE_CASE` | `actor.auto_create_case` | `true` |
+| `VULTRON_ACTOR__DEFAULT_CASE_ROLES` | `actor.default_case_roles` | `[]` |
 
 ### Legacy env var migration
 
@@ -263,7 +281,7 @@ async def info(config: AppConfig = Depends(get_config)):
 ```python
 # test/test_config.py
 import pytest
-import vultron.config as _cfg_module
+import vultron.config.app as _cfg_module  # _config_cache lives in app.py, not __init__
 from vultron.config import get_config, reload_config
 
 
@@ -310,37 +328,32 @@ def test_env_overrides_yaml(tmp_path, monkeypatch):
 
 ---
 
-## Target Architecture: `vultron/config/` Sub-Package
+## Current Architecture: `vultron/config/` Sub-Package
 
-`vultron/config.py` MUST be converted to a `vultron/config/` sub-package
-with the following layout (CFG-07-005, CFG-07-006, issue #1334):
+`vultron/config.py` was converted to a `vultron/config/` sub-package in
+issue #1342 (CFG-07-005, CFG-07-006). The current layout:
 
 ```text
 vultron/
   enums/
-    __init__.py
+    __init__.py  ← re-exports CVDRole, serialize_roles, validate_roles
     roles.py     ← CVDRole, serialize_roles, validate_roles
                    (moved from vultron/core/states/roles.py)
   config/
-    __init__.py  ← public re-exports: AppConfig, get_config, reload_config,
-                   ActorConfig, load_actor_config
+    __init__.py  ← public re-exports: AppConfig, ActorConfig, get_config,
+                   reload_config, RunMode, ServerConfig, DatabaseConfig,
+                   YamlConfigSource
     app.py       ← AppConfig, ServerConfig, DatabaseConfig, RunMode,
                    YamlConfigSource, get_config(), reload_config()
-    actor.py     ← ActorConfig (moved from vultron/core/models/actor_config.py),
-                   load_actor_config()
+    actor.py     ← ActorConfig (moved from vultron/core/models/actor_config.py)
 ```
 
 `actor.py` imports `CVDRole` from `vultron.enums.roles` — not from
-`vultron/core/` — preserving the neutral-module constraint.
+`vultron/core/` — satisfying the neutral-module constraint.
 
-`load_actor_config()` reads `VULTRON_SEED_CONFIG` YAML first (parsing only
-`auto_create_case` and `default_case_roles` from the `local_actor` block via
-`model_validate(..., strict=False)` with `extra="ignore"`), then falls back to
-`VULTRON_ACTOR_*` env vars. Production adapters call this instead of
-importing `SeedConfig`.
-
-`AppConfig` gains an `actor: ActorConfig` section so that `load_actor_config()`
-becomes a thin wrapper over `get_config().actor`.
+`AppConfig` has an `actor: ActorConfig` field (default: `ActorConfig()`) so
+production code reads actor policy via `get_config().actor`.  Actor config is
+also available from the YAML `actor:` section or `VULTRON_ACTOR__*` env vars.
 
 ---
 

--- a/notes/two-actor-demo.md
+++ b/notes/two-actor-demo.md
@@ -68,7 +68,7 @@ inbox). The **role** it holds within the case is `CASE_MANAGER` (a
 `CVDRole` enum value). This disambiguates entity from role. `CASE_ACTOR` as a
 role name is retired.
 
-See `vultron/core/states/roles.py` (`CVDRole.CASE_MANAGER`) and
+See `vultron/enums/roles.py` (`CVDRole.CASE_MANAGER`) and
 `notes/participant-role-management.md`.
 
 ---

--- a/plan/history/2607/implementation/ISSUE-1342.md
+++ b/plan/history/2607/implementation/ISSUE-1342.md
@@ -1,0 +1,14 @@
+---
+source: ISSUE-1342
+timestamp: '2026-07-14T20:08:32.770970+00:00'
+title: move CVDRole to vultron/enums/; config.py → config/ sub-package
+type: implementation
+---
+
+## Issue #1342 — refactor: move CVDRole to vultron/enums/; config.py → config/ sub-package
+
+Moved `CVDRole`, `serialize_roles`, `validate_roles` from `vultron/core/states/roles.py` to the new bottom-of-stack `vultron/enums/` package. Converted `vultron/config.py` into a `vultron/config/` sub-package with `app.py` (AppConfig etc.) and `actor.py` (ActorConfig). AppConfig gains `actor: ActorConfig` field. All ~99 CVDRole import sites and ~15 ActorConfig import sites updated. Deleted source files with no shims.
+
+Code review found and fixed: stale `load_actor_config()` reference in AGENTS.md, stale testing-pattern snippet in notes/configuration.md, stale CVDRole import path in notes/case-communication-model.md, missing VULTRON_ACTOR__* env var clearance in test_config.py fixture, zero AppConfig.actor test coverage, silent-swallow bug in validate_roles (now raises for non-None non-list), dead helpers in test_enums_import_graph.py refactored to shared helper.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1432>

--- a/test/adapters/driven/test_get_datalayer.py
+++ b/test/adapters/driven/test_get_datalayer.py
@@ -27,7 +27,7 @@ from vultron.adapters.driven.datalayer_sqlite import (
 @pytest.fixture(autouse=True)
 def reset_singleton():
     """Ensure the datalayer singletons and config cache are reset each test."""
-    import vultron.config as _cfg_module
+    import vultron.config.app as _cfg_module
 
     reset_datalayer()
     yield

--- a/test/adapters/driven/test_sqlite_rehydration.py
+++ b/test/adapters/driven/test_sqlite_rehydration.py
@@ -174,7 +174,7 @@ def test_rehydration_does_not_mutate_stored_record(dl):
 
 def test_hydrate_expands_list_ref_field(dl):
     """hydrate() resolves case_participants string IDs to stored objects."""
-    from vultron.core.states.roles import CVDRole
+    from vultron.enums.roles import CVDRole
     from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
     from vultron.wire.as2.vocab.objects.vulnerability_case import (
         VulnerabilityCase,
@@ -207,7 +207,7 @@ def test_hydrate_expands_list_ref_field(dl):
 
 def test_hydrate_leaves_already_expanded_participants_unchanged(dl):
     """hydrate() leaves non-string participants unchanged."""
-    from vultron.core.states.roles import CVDRole
+    from vultron.enums.roles import CVDRole
     from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
     from vultron.wire.as2.vocab.objects.vulnerability_case import (
         VulnerabilityCase,

--- a/test/adapters/driving/fastapi/routers/conftest.py
+++ b/test/adapters/driving/fastapi/routers/conftest.py
@@ -37,7 +37,7 @@ from vultron.adapters.driving.fastapi.routers import (
 )
 from vultron.core.models.actor import CoreActor
 from vultron.core.states.em import EM
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.core.use_cases.triggers.service import TriggerService
 from vultron.adapters.utils import make_id
 from vultron.wire.as2.factories import em_propose_embargo_activity

--- a/test/adapters/driving/fastapi/routers/test_actors.py
+++ b/test/adapters/driving/fastapi/routers/test_actors.py
@@ -19,7 +19,7 @@ from vultron.adapters.utils import strip_id_prefix
 from vultron.core.states.cs import CS_pxa, CS_vfd
 from vultron.core.states.em import EM
 from vultron.core.states.rm import RM
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Create
 from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
 from vultron.wire.as2.vocab.objects.case_status import (

--- a/test/adapters/driving/fastapi/routers/test_demo_triggers.py
+++ b/test/adapters/driving/fastapi/routers/test_demo_triggers.py
@@ -41,7 +41,7 @@ from vultron.core.use_cases.triggers.service import TriggerService
 from vultron.adapters.driven.trigger_activity_adapter import (
     TriggerActivityAdapter,
 )
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase

--- a/test/adapters/driving/fastapi/routers/test_trigger_actor.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_actor.py
@@ -32,7 +32,7 @@ from vultron.adapters.driving.fastapi.deps import (
     get_trigger_dl,
     get_trigger_service,
 )
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.core.use_cases.triggers.service import TriggerService
 from vultron.adapters.driven.trigger_activity_adapter import (
     TriggerActivityAdapter,

--- a/test/adapters/driving/fastapi/routers/test_trigger_case.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_case.py
@@ -39,7 +39,7 @@ from vultron.adapters.driven.trigger_activity_adapter import (
 )
 from vultron.adapters.utils import parse_id
 from vultron.core.states.rm import RM
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase

--- a/test/adapters/driving/fastapi/routers/test_trigger_report.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_report.py
@@ -48,7 +48,7 @@ from vultron.wire.as2.vocab.objects.vulnerability_report import (
     VulnerabilityReport,
 )
 from vultron.core.states.rm import RM
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 
 # ---------------------------------------------------------------------------
 # Module-level outbox suppression

--- a/test/adapters/driving/fastapi/test_inbox_handler.py
+++ b/test/adapters/driving/fastapi/test_inbox_handler.py
@@ -510,7 +510,7 @@ def test_submit_report_port_factory_injects_actor_config(monkeypatch):
     honour the local actor's ``auto_create_case`` policy (CM-15-001,
     issue #1319).
     """
-    from vultron.core.models.actor_config import ActorConfig
+    from vultron.config.actor import ActorConfig
     from vultron.demo.seed_config import LocalActorConfig, SeedConfig
     import vultron.adapters.driving.fastapi.inbox_port_factories as pf
 
@@ -569,7 +569,7 @@ def test_make_dispatcher_submit_report_uses_actor_config_factory(monkeypatch):
     from vultron.adapters.driven.trigger_activity_adapter import (
         TriggerActivityAdapter,
     )
-    from vultron.core.models.actor_config import ActorConfig
+    from vultron.config.actor import ActorConfig
     from vultron.demo.seed_config import LocalActorConfig
     import vultron.adapters.driving.fastapi.inbox_port_factories as pf
 

--- a/test/architecture/test_enums_import_graph.py
+++ b/test/architecture/test_enums_import_graph.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Import-graph invariant tests for the ``vultron.enums`` and ``vultron.config``
+neutral layers.
+
+Enforces the bottom-of-stack constraints from
+``docs/adr/0031-vultron-enums-neutral-layer.md`` and
+``specs/configuration.yaml`` CFG-07-006:
+
+- ``vultron.enums`` MUST NOT import from ``vultron.core``, ``vultron.config``,
+  or ``vultron.adapters``.
+- ``vultron.config`` MUST NOT import from ``vultron.core`` or
+  ``vultron.adapters``.
+"""
+
+import ast
+import pathlib
+
+import pytest
+
+_REPO_ROOT = pathlib.Path(__file__).parents[2]
+
+
+def _assert_no_forbidden_imports(
+    source_dir: pathlib.Path, layer: str, forbidden_prefix: str
+) -> None:
+    """Raise AssertionError if any .py file under *source_dir* imports from *forbidden_prefix*."""
+    violations: list[str] = []
+    for py_file in source_dir.rglob("*.py"):
+        tree = ast.parse(py_file.read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                module = (
+                    node.module if isinstance(node, ast.ImportFrom) else None
+                )
+                if module and module.startswith(forbidden_prefix):
+                    violations.append(
+                        f"{py_file.relative_to(source_dir.parent)}: "
+                        f"imports from {module}"
+                    )
+                if isinstance(node, ast.Import):
+                    for alias in node.names:
+                        if alias.name.startswith(forbidden_prefix):
+                            violations.append(
+                                f"{py_file.relative_to(source_dir.parent)}: "
+                                f"imports {alias.name}"
+                            )
+    assert (
+        not violations
+    ), f"{layer} MUST NOT import from {forbidden_prefix}:\n" + "\n".join(
+        violations
+    )
+
+
+class TestEnumsLayerImportGraph:
+    """``vultron.enums`` must be the bottom of the import stack."""
+
+    @pytest.fixture(autouse=True)
+    def _import_enums(self) -> None:
+        import vultron.enums  # noqa: F401 — side-effect: populates sys.modules
+        import vultron.enums.roles  # noqa: F401
+
+    def test_enums_does_not_import_vultron_core(self) -> None:
+        """``vultron.enums`` MUST NOT import from ``vultron.core``."""
+        _assert_no_forbidden_imports(
+            _REPO_ROOT / "vultron" / "enums", "vultron.enums", "vultron.core"
+        )
+
+    def test_enums_does_not_import_vultron_config(self) -> None:
+        """``vultron.enums`` MUST NOT import from ``vultron.config``."""
+        _assert_no_forbidden_imports(
+            _REPO_ROOT / "vultron" / "enums",
+            "vultron.enums",
+            "vultron.config",
+        )
+
+    def test_enums_does_not_import_vultron_adapters(self) -> None:
+        """``vultron.enums`` MUST NOT import from ``vultron.adapters``."""
+        _assert_no_forbidden_imports(
+            _REPO_ROOT / "vultron" / "enums",
+            "vultron.enums",
+            "vultron.adapters",
+        )
+
+
+class TestConfigLayerImportGraph:
+    """``vultron.config`` must not import from core or adapters."""
+
+    def test_config_does_not_import_vultron_core(self) -> None:
+        """``vultron.config`` MUST NOT import from ``vultron.core``."""
+        _assert_no_forbidden_imports(
+            _REPO_ROOT / "vultron" / "config",
+            "vultron.config",
+            "vultron.core",
+        )
+
+    def test_config_does_not_import_vultron_adapters(self) -> None:
+        """``vultron.config`` MUST NOT import from ``vultron.adapters``."""
+        _assert_no_forbidden_imports(
+            _REPO_ROOT / "vultron" / "config",
+            "vultron.config",
+            "vultron.adapters",
+        )

--- a/test/bt/test_vultrabot.py
+++ b/test/bt/test_vultrabot.py
@@ -22,20 +22,27 @@ class MyTestCase(unittest.TestCase):
     # capture stdout
     @patch("sys.stdout", new_callable=StringIO)
     def test_main(self, stdout):
-        for i in range(10):
+        any_closed = False
+        for _ in range(10):
             # capture the output
-            vultrabot._run_simulation()
+            closed = vultrabot._run_simulation()
+            any_closed = any_closed or closed
             vultrabot._print_sim_result()
-            # test the output
-            self.assertIsNotNone(stdout)
-            output = stdout.getvalue()
 
-            # things that are consistently in the output
-            look_for = "q_rm q_em q_cs RS START NONE vfdpxa FINDER_REPORTER_VENDOR_DEPLOYER_COORDINATOR CLOSED".split()
+        # test the output
+        self.assertIsNotNone(stdout)
+        output = stdout.getvalue()
 
-            for item in look_for:
-                with self.subTest():
-                    self.assertIn(item, output)
+        # things that are consistently in the output
+        always_present = "q_rm q_em q_cs RS START NONE vfdpxa FINDER_REPORTER_VENDOR_DEPLOYER_COORDINATOR".split()
+        for item in always_present:
+            with self.subTest(item=item):
+                self.assertIn(item, output)
+
+        # CLOSED only appears when at least one simulation reached closure
+        if any_closed:
+            with self.subTest(item="CLOSED"):
+                self.assertIn("CLOSED", output)
 
 
 if __name__ == "__main__":

--- a/test/ci/test_case_ledger_invariants.py
+++ b/test/ci/test_case_ledger_invariants.py
@@ -48,7 +48,7 @@ from pathlib import Path
 import pytest
 
 from vultron.core.states.participant_embargo_consent import PEC
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 
 # ---------------------------------------------------------------------------
 # Constants

--- a/test/core/behaviors/case/nodes/participant/test_helpers.py
+++ b/test/core/behaviors/case/nodes/participant/test_helpers.py
@@ -20,7 +20,7 @@ from typing import Any, cast
 
 from vultron.core.behaviors.case.nodes import _create_and_attach_participant
 from vultron.core.models.vultron_types import VultronCase, VultronParticipant
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from test.core.behaviors.bt_harness import BTTestScenario
 
 

--- a/test/core/behaviors/case/nodes/participant/test_owner.py
+++ b/test/core/behaviors/case/nodes/participant/test_owner.py
@@ -30,10 +30,10 @@ from vultron.core.behaviors.case.nodes.participant import (
     ResolveOwnerInitialStatusNode,
     ShouldAdvanceOwnerToAcceptedNode,
 )
-from vultron.core.models.actor_config import ActorConfig
+from vultron.config.actor import ActorConfig
 from vultron.core.models.vultron_types import VultronCase, VultronCaseActor
 from vultron.core.states.rm import RM
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from test.core.behaviors.bt_harness import BTTestScenario
 
 

--- a/test/core/behaviors/case/nodes/participant/test_participant_add.py
+++ b/test/core/behaviors/case/nodes/participant/test_participant_add.py
@@ -43,7 +43,7 @@ from vultron.core.models.vultron_types import (
 )
 from vultron.core.states.participant_embargo_consent import PEC
 from vultron.core.states.rm import RM
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Add
 from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
 from vultron.core.use_cases._helpers import _report_phase_status_id

--- a/test/core/behaviors/case/nodes/test_check_is_case_manager.py
+++ b/test/core/behaviors/case/nodes/test_check_is_case_manager.py
@@ -22,7 +22,7 @@ from vultron.core.behaviors.case.nodes.conditions import (
     CheckIsCaseManagerNode,
 )
 from vultron.core.models.vultron_types import VultronCase, VultronParticipant
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from test.core.behaviors.bt_harness import BTTestScenario
 
 CASE_ID = "https://example.org/cases/case-001"

--- a/test/core/behaviors/case/nodes/test_conditions.py
+++ b/test/core/behaviors/case/nodes/test_conditions.py
@@ -33,14 +33,14 @@ from vultron.core.behaviors.case.nodes.conditions import (
     CheckCaseAlreadyExists,
     CheckCaseExistsForReport,
 )
-from vultron.core.models.actor_config import ActorConfig
+from vultron.config.actor import ActorConfig
 from vultron.core.models.vultron_types import (
     VultronCase,
     VultronCaseActor,
     VultronParticipant,
     VultronReport,
 )
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from test.core.behaviors.bt_harness import BTTestScenario
 
 # ---------------------------------------------------------------------------

--- a/test/core/behaviors/case/nodes/test_guarded_commit_tree.py
+++ b/test/core/behaviors/case/nodes/test_guarded_commit_tree.py
@@ -27,7 +27,7 @@ from vultron.core.behaviors.case.nodes.lifecycle import (
 )
 from vultron.core.models.events.base import MessageSemantics
 from vultron.core.models.vultron_types import VultronCase, VultronParticipant
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from test.core.behaviors.bt_harness import BTTestScenario
 
 CASE_ID = "https://example.org/cases/case-001"

--- a/test/core/behaviors/case/test_create_tree.py
+++ b/test/core/behaviors/case/test_create_tree.py
@@ -264,7 +264,7 @@ def test_create_case_tree_creates_case_owner_participant(
     datalayer, actor, case_obj, create_case_activity, bridge
 ):
     """A case-owner participant SHOULD be created and added to case_participants (CM-02-008)."""
-    from vultron.core.states.roles import CVDRole
+    from vultron.enums.roles import CVDRole
 
     tree = create_create_case_tree(case_obj=case_obj, actor_id=actor.id_)
     bridge.execute_with_setup(
@@ -301,8 +301,8 @@ def test_create_case_tree_case_owner_participant_includes_config_roles(
     datalayer, actor, case_obj, create_case_activity, bridge
 ):
     """CreateCaseOwnerParticipant includes config roles + CASE_OWNER (CFG-07-004)."""
-    from vultron.core.models.actor_config import ActorConfig
-    from vultron.core.states.roles import CVDRole
+    from vultron.config.actor import ActorConfig
+    from vultron.enums.roles import CVDRole
 
     config = ActorConfig(default_case_roles=[CVDRole.COORDINATOR])
     tree = create_create_case_tree(

--- a/test/core/behaviors/case/test_receive_report_case_tree.py
+++ b/test/core/behaviors/case/test_receive_report_case_tree.py
@@ -50,7 +50,7 @@ from vultron.core.models.vultron_types import VultronCaseActor
 from vultron.core.states.em import EM
 from vultron.core.states.participant_embargo_consent import PEC
 from vultron.core.states.rm import RM
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.core.use_cases._helpers import _report_phase_status_id
 from vultron.wire.as2.factories import rm_submit_report_activity
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
@@ -184,7 +184,7 @@ class TestAutoCreateCasePolicyGate:
         self, report, offer, reporter_actor_id
     ):
         """The root gate receives the supplied ActorConfig (CM-15-001)."""
-        from vultron.core.models.actor_config import ActorConfig
+        from vultron.config.actor import ActorConfig
 
         cfg = ActorConfig(auto_create_case=False)
         tree = create_receive_report_case_tree(
@@ -210,7 +210,7 @@ class TestAutoCreateCasePolicyGate:
         vendor_received_status,
     ):
         """auto_create_case=True (default) still creates the case (AC-1)."""
-        from vultron.core.models.actor_config import ActorConfig
+        from vultron.config.actor import ActorConfig
 
         tree = create_receive_report_case_tree(
             report_id=report.id_,
@@ -237,7 +237,7 @@ class TestAutoCreateCasePolicyGate:
         vendor_received_status,
     ):
         """auto_create_case=False makes the tree exit without a case (AC-2)."""
-        from vultron.core.models.actor_config import ActorConfig
+        from vultron.config.actor import ActorConfig
 
         tree = create_receive_report_case_tree(
             report_id=report.id_,

--- a/test/core/behaviors/case/test_suggest_actor_tree.py
+++ b/test/core/behaviors/case/test_suggest_actor_tree.py
@@ -51,7 +51,7 @@ from vultron.core.models.protocol_pair import (
     OFFER_CASE_PARTICIPANT_REPLY_TYPES,
     ProtocolPair,
 )
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 
 _REC_ID = "https://example.org/recommendations/rec-1"
 _RECOMMENDER = "https://example.org/actors/recommender"

--- a/test/core/behaviors/embargo/nodes/test_lifecycle.py
+++ b/test/core/behaviors/embargo/nodes/test_lifecycle.py
@@ -29,7 +29,7 @@ from vultron.core.behaviors.embargo.nodes.lifecycle import (
 from vultron.core.behaviors.embargo.trigger_tree import terminate_embargo_bt
 from vultron.core.states.em import EM
 from vultron.core.states.participant_embargo_consent import PEC
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
 

--- a/test/core/behaviors/note/test_add_note_trigger_tree.py
+++ b/test/core/behaviors/note/test_add_note_trigger_tree.py
@@ -31,7 +31,7 @@ from vultron.core.behaviors.note.nodes import (
     AttachNoteFromResultNode,
     CreateNoteNode,
 )
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.objects.case_participant import (
     FinderParticipant,

--- a/test/core/behaviors/report/test_prioritize_tree.py
+++ b/test/core/behaviors/report/test_prioritize_tree.py
@@ -46,7 +46,7 @@ from vultron.core.behaviors.report.prioritize_tree import (
     create_prioritize_subtree,
 )
 from vultron.core.states.rm import RM
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 
 
 def _make_participant_in_valid_state(

--- a/test/core/behaviors/sender/nodes/test_actions.py
+++ b/test/core/behaviors/sender/nodes/test_actions.py
@@ -29,7 +29,7 @@ from vultron.core.behaviors.sender.nodes.actions import (
     QueueToOutboxNode,
     ResolveCaseManagerNode,
 )
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.objects.case_participant import (
     FinderParticipant,

--- a/test/core/behaviors/sender/test_sender_side_bt.py
+++ b/test/core/behaviors/sender/test_sender_side_bt.py
@@ -30,7 +30,7 @@ from vultron.core.behaviors.sender.nodes import (
     ResolveCaseManagerNode,
 )
 from vultron.core.behaviors.sender.send_tree import sender_side_bt
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.objects.case_participant import (
     FinderParticipant,

--- a/test/core/behaviors/status/nodes/test_append.py
+++ b/test/core/behaviors/status/nodes/test_append.py
@@ -37,7 +37,7 @@ from vultron.core.behaviors.status.nodes.append import (
     SkipIfIdempotentNode,
     ValidateRMTransitionNode,
 )
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
 from vultron.wire.as2.vocab.objects.case_status import ParticipantStatus
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase

--- a/test/core/behaviors/status/nodes/test_conditions.py
+++ b/test/core/behaviors/status/nodes/test_conditions.py
@@ -28,7 +28,7 @@ from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.status.nodes.conditions import (
     VerifySenderIsParticipantNode,
 )
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
 from vultron.wire.as2.vocab.objects.case_status import ParticipantStatus
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase

--- a/test/core/behaviors/status/nodes/test_lifecycle.py
+++ b/test/core/behaviors/status/nodes/test_lifecycle.py
@@ -31,7 +31,7 @@ from vultron.core.behaviors.status.nodes.lifecycle import (
     AutoCloseBranchNode,
     PublicDisclosureBranchNode,
 )
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
 from vultron.wire.as2.vocab.objects.case_status import ParticipantStatus
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase

--- a/test/core/behaviors/status/test_add_participant_status_bt.py
+++ b/test/core/behaviors/status/test_add_participant_status_bt.py
@@ -48,7 +48,7 @@ from vultron.core.behaviors.status.nodes import (
     VerifySenderIsParticipantNode,
 )
 from vultron.core.states.rm import RM
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.wire.as2.factories import add_status_to_participant_activity
 from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
 from vultron.wire.as2.vocab.objects.case_status import ParticipantStatus

--- a/test/core/models/test_actor_config.py
+++ b/test/core/models/test_actor_config.py
@@ -24,8 +24,8 @@ Spec coverage:
 
 import pytest
 
-from vultron.core.models.actor_config import ActorConfig
-from vultron.core.states.roles import CVDRole
+from vultron.config.actor import ActorConfig
+from vultron.enums.roles import CVDRole
 
 # ============================================================================
 # Basic model tests (CFG-07-001, CFG-07-002)
@@ -85,6 +85,12 @@ def test_actor_config_rejects_invalid_role_name():
     """ActorConfig raises ValueError for unknown role names."""
     with pytest.raises((ValueError, KeyError)):
         ActorConfig.model_validate({"default_case_roles": ["NOT_A_ROLE"]})
+
+
+def test_actor_config_rejects_scalar_default_case_roles():
+    """ActorConfig raises ValueError when default_case_roles is a scalar string."""
+    with pytest.raises((ValueError, KeyError)):
+        ActorConfig.model_validate({"default_case_roles": "coordinator"})
 
 
 def test_actor_config_serializes_roles_as_names():

--- a/test/core/models/test_case_participant.py
+++ b/test/core/models/test_case_participant.py
@@ -16,7 +16,7 @@ from vultron.core.models.case_participant import (
 )
 from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.states.rm import RM
-from vultron.core.states.roles import CVDRole, validate_roles
+from vultron.enums.roles import CVDRole, validate_roles
 
 _ACTOR = "https://example.org/actors/alice"
 _CONTEXT = "https://example.org/cases/case-001"
@@ -313,7 +313,7 @@ class TestCNARoleOnParticipant:
 
     def test_cna_role_roundtrips_via_serialization(self):
         """CVE_NUMBERING_AUTHORITY survives a serialize_roles → validate_roles roundtrip."""
-        from vultron.core.states.roles import serialize_roles
+        from vultron.enums.roles import serialize_roles
 
         roles = [CVDRole.VENDOR, CVDRole.CVE_NUMBERING_AUTHORITY]
         serialized = serialize_roles(roles)

--- a/test/core/models/test_participant.py
+++ b/test/core/models/test_participant.py
@@ -5,7 +5,7 @@ import logging
 import pytest
 
 from vultron.core.models.participant import VultronParticipant
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/test/core/services/test_embargo_lifecycle.py
+++ b/test/core/services/test_embargo_lifecycle.py
@@ -32,7 +32,7 @@ from vultron.core.services.embargo_lifecycle import (
 )
 from vultron.core.states.em import EM
 from vultron.core.states.participant_embargo_consent import PEC, PEC_Trigger
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.errors import VultronInvalidStateTransitionError
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.core.use_cases._helpers import _as_id

--- a/test/core/states/test_cvd_roles.py
+++ b/test/core/states/test_cvd_roles.py
@@ -23,7 +23,7 @@ from enum import StrEnum
 
 import pytest
 
-from vultron.core.states.roles import CVDRole, serialize_roles, validate_roles
+from vultron.enums.roles import CVDRole, serialize_roles, validate_roles
 
 
 def test_cvdrole_is_str_enum():
@@ -183,10 +183,15 @@ def test_validate_roles_empty():
     assert validate_roles([]) == []
 
 
-def test_validate_roles_non_list():
-    """validate_roles returns [] for non-list input."""
+def test_validate_roles_none_returns_empty():
+    """validate_roles returns [] for None (field omitted)."""
     assert validate_roles(None) == []  # type: ignore[arg-type]
-    assert validate_roles("finder") == []  # type: ignore[arg-type]
+
+
+def test_validate_roles_non_list_raises():
+    """validate_roles raises ValueError for non-list, non-None input."""
+    with pytest.raises(ValueError, match="must be a list"):
+        validate_roles("finder")  # type: ignore[arg-type]
 
 
 def test_validate_roles_invalid_value():

--- a/test/core/use_cases/query/test_action_rules.py
+++ b/test/core/use_cases/query/test_action_rules.py
@@ -23,7 +23,7 @@ from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.core.states.em import EM
 from vultron.core.states.rm import RM
 from vultron.core.states.cs import CS_pxa, CS_vfd
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.core.use_cases.query.action_rules import (
     ActionRulesRequest,
     GetActionRulesUseCase,

--- a/test/core/use_cases/received/actor/test_announce.py
+++ b/test/core/use_cases/received/actor/test_announce.py
@@ -24,7 +24,7 @@ from vultron.core.use_cases.received.actor.announce import (
 from vultron.wire.as2.factories import announce_vulnerability_case_activity
 from vultron.wire.as2.vocab.objects.case_actor import CaseActor
 from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
 
 _OWNER_ID = "https://example.org/actors/owner"

--- a/test/core/use_cases/received/actor/test_case_manager_role.py
+++ b/test/core/use_cases/received/actor/test_case_manager_role.py
@@ -184,7 +184,7 @@ class TestCaseManagerRoleDelegationUseCases:
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
         from vultron.wire.as2.vocab.base.objects.actors import as_Organization
         from vultron.core.models.vultron_types import VultronParticipant
-        from vultron.core.states.roles import CVDRole
+        from vultron.enums.roles import CVDRole
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
             VulnerabilityCase,
         )

--- a/test/core/use_cases/received/actor/test_invite.py
+++ b/test/core/use_cases/received/actor/test_invite.py
@@ -313,7 +313,7 @@ class TestInviteActorUseCases:
         )
         from vultron.core.models.vultron_types import VultronParticipant
         from vultron.core.states.rm import RM
-        from vultron.core.states.roles import CVDRole
+        from vultron.enums.roles import CVDRole
 
         dl = SqliteDataLayer("sqlite:///:memory:")
         invitee_id = "https://example.org/users/coordinator_rm2"
@@ -417,7 +417,7 @@ class TestInviteActorUseCases:
         )
         dl.create(invitee)
         dl.create(case)
-        from vultron.core.states.roles import CVDRole
+        from vultron.enums.roles import CVDRole
         from vultron.wire.as2.vocab.objects.case_participant import (
             CaseParticipant,
         )
@@ -494,7 +494,7 @@ class TestInviteActorUseCases:
         dl.create(invitee)
         dl.create(case_actor)
         dl.create(case)
-        from vultron.core.states.roles import CVDRole
+        from vultron.enums.roles import CVDRole
         from vultron.wire.as2.vocab.objects.case_participant import (
             CaseParticipant,
         )
@@ -603,7 +603,7 @@ class TestInviteActorUseCases:
         dl.create(invitee)
         dl.create(case_actor)
         dl.create(case)
-        from vultron.core.states.roles import CVDRole
+        from vultron.enums.roles import CVDRole
         from vultron.wire.as2.vocab.objects.case_participant import (
             CaseParticipant,
         )
@@ -734,7 +734,7 @@ class TestInviteActorUseCases:
             attributed_to=invitee_id,
             context=case.id_,
         )
-        from vultron.core.states.roles import CVDRole
+        from vultron.enums.roles import CVDRole
         from vultron.wire.as2.vocab.objects.case_participant import (
             CaseParticipant,
         )
@@ -842,7 +842,7 @@ class TestInviteActorUseCases:
         dl.create(invitee)
         dl.create(case_actor)
         dl.create(case)
-        from vultron.core.states.roles import CVDRole
+        from vultron.enums.roles import CVDRole
         from vultron.wire.as2.vocab.objects.case_participant import (
             CaseParticipant,
         )
@@ -911,7 +911,7 @@ class TestAcceptInviteRolesAC4:
     def test_roles_from_invite_set_on_participant(self, make_payload):
         """AC-4: Accept(Invite) causes new participant to inherit roles from Invite."""
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
-        from vultron.core.states.roles import CVDRole
+        from vultron.enums.roles import CVDRole
         from vultron.wire.as2.vocab.base.objects.actors import as_Organization
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
             VulnerabilityCase,

--- a/test/core/use_cases/received/case/test_bootstrap_participants.py
+++ b/test/core/use_cases/received/case/test_bootstrap_participants.py
@@ -29,7 +29,7 @@ import pytest
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.core.models.report_case_link import VultronReportCaseLink
 from vultron.core.states.cs import CS_vfd
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.core.use_cases.received.case.create import (
     CreateCaseReceivedUseCase,
 )

--- a/test/core/use_cases/received/case/test_create.py
+++ b/test/core/use_cases/received/case/test_create.py
@@ -32,7 +32,7 @@ import pytest
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.core.models.report_case_link import VultronReportCaseLink
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.core.use_cases.received.actor import _find_case_actor_id
 from vultron.core.use_cases.received.actor.announce import (
     AnnounceVulnerabilityCaseReceivedUseCase,

--- a/test/core/use_cases/received/case/test_helpers.py
+++ b/test/core/use_cases/received/case/test_helpers.py
@@ -34,7 +34,7 @@ from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models.report import VultronReport
 from vultron.core.models.report_case_link import VultronReportCaseLink
 from vultron.core.states.rm import RM
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.core.use_cases.received.case.create import (
     CreateCaseReceivedUseCase,
 )

--- a/test/core/use_cases/received/test_ack_report_routing.py
+++ b/test/core/use_cases/received/test_ack_report_routing.py
@@ -30,7 +30,7 @@ from vultron.core.models.case_actor import VultronCaseActor
 from vultron.core.models.events.base import MessageSemantics
 from vultron.core.models.events.report import AckReportReceivedEvent
 from vultron.core.models.report import VultronReport
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.core.use_cases.received.report import AckReportReceivedUseCase
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
 from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant

--- a/test/core/use_cases/received/test_ack_validate_report_received.py
+++ b/test/core/use_cases/received/test_ack_validate_report_received.py
@@ -365,7 +365,7 @@ class TestValidateReportReceivedGuardedCommit:
         )
         case.vulnerability_reports.append(self.REPORT_ID)
         # Register case actor as CASE_MANAGER
-        from vultron.core.states.roles import CVDRole
+        from vultron.enums.roles import CVDRole
         from vultron.wire.as2.vocab.objects.case_participant import (
             CaseParticipant,
         )
@@ -413,7 +413,7 @@ class TestValidateReportReceivedGuardedCommit:
         """
         import vultron.core.behaviors.report.received_report_trees as rrt_module
         from vultron.core.models.report_case_link import VultronReportCaseLink
-        from vultron.core.states.roles import CVDRole
+        from vultron.enums.roles import CVDRole
         from vultron.wire.as2.vocab.objects.case_participant import (
             CaseParticipant,
         )

--- a/test/core/use_cases/received/test_close_case_routing.py
+++ b/test/core/use_cases/received/test_close_case_routing.py
@@ -26,7 +26,7 @@ from vultron.core.models.activity import VultronActivity
 from vultron.core.models.case_actor import VultronCaseActor
 from vultron.core.models.events.base import MessageSemantics
 from vultron.core.models.events.case import CloseCaseReceivedEvent
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.core.use_cases.received.case.lifecycle import (
     CloseCaseReceivedUseCase,
 )

--- a/test/core/use_cases/received/test_embargo_ledger_cascade.py
+++ b/test/core/use_cases/received/test_embargo_ledger_cascade.py
@@ -49,7 +49,7 @@ def _make_embargo_case_with_actor(
     Also creates ``CaseParticipant`` objects so actor → participant lookups
     in the embargo handlers succeed.
     """
-    from vultron.core.states.roles import CVDRole
+    from vultron.enums.roles import CVDRole
     from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
 
     dl = SqliteDataLayer("sqlite:///:memory:")

--- a/test/core/use_cases/received/test_embargo_propose_accept_reject.py
+++ b/test/core/use_cases/received/test_embargo_propose_accept_reject.py
@@ -422,7 +422,7 @@ class TestEmbargoProposalLifecycle:
 
         # Add a Case Manager participant so routing proceeds to the
         # EM-state validation check (the test's actual assertion target).
-        from vultron.core.states.roles import CVDRole
+        from vultron.enums.roles import CVDRole
         from vultron.wire.as2.vocab.objects.case_participant import (
             CaseParticipant as CP,
         )

--- a/test/core/use_cases/received/test_embargo_routing_guard.py
+++ b/test/core/use_cases/received/test_embargo_routing_guard.py
@@ -28,7 +28,7 @@ from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.adapters.driven.sync_activity_adapter import SyncActivityAdapter
 from vultron.core.models.case_actor import VultronCaseActor
 from vultron.core.states.em import EM
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.core.use_cases.received.embargo import (
     AcceptInviteToEmbargoOnCaseReceivedUseCase,
     InviteToEmbargoOnCaseReceivedUseCase,

--- a/test/core/use_cases/received/test_note.py
+++ b/test/core/use_cases/received/test_note.py
@@ -140,7 +140,7 @@ class TestNoteUseCases:
         self, dl: "SqliteDataLayer", case_id: str, case_actor_id: str
     ) -> "VulnerabilityCase":
         """Create a VulnerabilityCase with a CaseActor holding CASE_MANAGER."""
-        from vultron.core.states.roles import CVDRole
+        from vultron.enums.roles import CVDRole
         from vultron.wire.as2.vocab.objects.case_participant import (
             CaseParticipant,
         )
@@ -359,7 +359,7 @@ class TestNoteUseCases:
             "https://example.org/participants/p-le1-finder"
         )
         dl.create(case)
-        from vultron.core.states.roles import CVDRole
+        from vultron.enums.roles import CVDRole
         from vultron.wire.as2.vocab.objects.case_participant import (
             CaseParticipant,
         )
@@ -436,7 +436,7 @@ class TestNoteUseCases:
             "https://example.org/participants/p-le2-finder"
         )
         dl.create(case)
-        from vultron.core.states.roles import CVDRole
+        from vultron.enums.roles import CVDRole
         from vultron.wire.as2.vocab.objects.case_participant import (
             CaseParticipant,
         )

--- a/test/core/use_cases/received/test_note_routing_guard.py
+++ b/test/core/use_cases/received/test_note_routing_guard.py
@@ -26,7 +26,7 @@ import pytest
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.adapters.driven.sync_activity_adapter import SyncActivityAdapter
 from vultron.core.models.case_actor import VultronCaseActor
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.core.use_cases.received.note import AddNoteToCaseReceivedUseCase
 from vultron.wire.as2.factories import add_note_to_case_activity
 from vultron.wire.as2.vocab.base.objects.object_types import as_Note

--- a/test/core/use_cases/received/test_status.py
+++ b/test/core/use_cases/received/test_status.py
@@ -285,7 +285,7 @@ class TestParticipantStatusLogEntryCascade:
     """CaseLedgerEntry cascade for AddParticipantStatusToParticipantReceivedUseCase."""
 
     def _make_dl(self, case_id: str, actor_id: str) -> tuple:
-        from vultron.core.states.roles import CVDRole
+        from vultron.enums.roles import CVDRole
 
         dl = SqliteDataLayer("sqlite:///:memory:")
         case_actor_id = f"{case_id}/actor"

--- a/test/core/use_cases/received/test_submit_report_received.py
+++ b/test/core/use_cases/received/test_submit_report_received.py
@@ -268,7 +268,7 @@ class TestSubmitReportAutoCreateCasePolicy:
 
     def test_auto_create_disabled_stores_report_and_offer_no_case(self):
         """AC-2: auto_create_case=False stores report + Offer but no case."""
-        from vultron.core.models.actor_config import ActorConfig
+        from vultron.config.actor import ActorConfig
 
         event, dl = self._make_event_and_dl()
         SubmitReportReceivedUseCase(
@@ -287,7 +287,7 @@ class TestSubmitReportAutoCreateCasePolicy:
 
     def test_auto_create_disabled_leaves_outbox_empty(self):
         """AC-2: auto_create_case=False leaves the receiver's outbox empty."""
-        from vultron.core.models.actor_config import ActorConfig
+        from vultron.config.actor import ActorConfig
 
         event, dl = self._make_event_and_dl()
         SubmitReportReceivedUseCase(
@@ -301,7 +301,7 @@ class TestSubmitReportAutoCreateCasePolicy:
 
     def test_auto_create_enabled_creates_case(self):
         """AC-1: auto_create_case=True (explicit) still creates the case."""
-        from vultron.core.models.actor_config import ActorConfig
+        from vultron.config.actor import ActorConfig
 
         event, dl = self._make_event_and_dl()
         dl.save(VultronReport(id_=self.REPORT_ID))

--- a/test/core/use_cases/test_helpers.py
+++ b/test/core/use_cases/test_helpers.py
@@ -44,7 +44,7 @@ from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.models.protocols import CaseModel, is_case_model
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.core.use_cases._helpers import (
     _resolve_case_manager_id,
     resolve_case_participant_id_for_actor,

--- a/test/core/use_cases/test_validate_report_ledger_routing.py
+++ b/test/core/use_cases/test_validate_report_ledger_routing.py
@@ -47,7 +47,7 @@ from vultron.core.models.activity import VultronActivity
 from vultron.core.models.events.base import MessageSemantics
 from vultron.core.models.events.report import ValidateReportReceivedEvent
 from vultron.core.models.report import VultronReport
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.core.use_cases._helpers import _find_case_actor_id
 from vultron.core.use_cases.received.report import (
     ValidateReportReceivedUseCase,

--- a/test/core/use_cases/triggers/case/test_add_participant_status.py
+++ b/test/core/use_cases/triggers/case/test_add_participant_status.py
@@ -218,7 +218,7 @@ class TestSvcAddParticipantStatusExecuteUpdatesSenderRecord:
         from vultron.adapters.driven.trigger_activity_adapter import (
             TriggerActivityAdapter,
         )
-        from vultron.core.states.roles import CVDRole
+        from vultron.enums.roles import CVDRole
         from vultron.wire.as2.vocab.base.objects.actors import as_Service
         from vultron.wire.as2.vocab.objects.case_participant import (
             CaseParticipant,
@@ -378,7 +378,7 @@ class TestCreateParticipantStatusNode:
             TriggerActivityAdapter,
         )
         from vultron.core.behaviors.bridge import BTBridge
-        from vultron.core.states.roles import CVDRole
+        from vultron.enums.roles import CVDRole
         from vultron.wire.as2.vocab.base.objects.actors import as_Service
         from vultron.wire.as2.vocab.objects.case_participant import (
             CaseParticipant,

--- a/test/core/use_cases/triggers/case/test_defer.py
+++ b/test/core/use_cases/triggers/case/test_defer.py
@@ -11,7 +11,7 @@ from vultron.adapters.driven.trigger_activity_adapter import (
     TriggerActivityAdapter,
 )
 from vultron.core.states.rm import RM
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.core.use_cases.triggers.case import (
     DeferCaseTriggerRequest,
     SvcDeferCaseUseCase,

--- a/test/core/use_cases/triggers/case/test_engage.py
+++ b/test/core/use_cases/triggers/case/test_engage.py
@@ -10,7 +10,7 @@ from vultron.adapters.driven.trigger_activity_adapter import (
     TriggerActivityAdapter,
 )
 from vultron.core.states.rm import RM
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.core.use_cases.triggers.case import (
     EngageCaseTriggerRequest,
     SvcEngageCaseUseCase,

--- a/test/core/use_cases/triggers/embargo/conftest.py
+++ b/test/core/use_cases/triggers/embargo/conftest.py
@@ -10,7 +10,7 @@ from vultron.adapters.driven.datalayer_sqlite import (
 )
 from vultron.core.states.em import EM
 from vultron.core.states.participant_embargo_consent import PEC
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.wire.as2.factories import em_propose_embargo_activity
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Invite
 from vultron.wire.as2.vocab.base.objects.actors import as_Service

--- a/test/core/use_cases/triggers/test_actor_triggers.py
+++ b/test/core/use_cases/triggers/test_actor_triggers.py
@@ -27,7 +27,7 @@ from vultron.adapters.driven.datalayer_sqlite import (
     SqliteDataLayer,
     reset_datalayer,
 )
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.core.use_cases.triggers.actor import (
     SvcAcceptCaseInviteUseCase,
     SvcInviteActorToCaseUseCase,

--- a/test/core/use_cases/triggers/test_case_engage_defer.py
+++ b/test/core/use_cases/triggers/test_case_engage_defer.py
@@ -36,7 +36,7 @@ from vultron.adapters.driven.trigger_activity_adapter import (
     TriggerActivityAdapter,
 )
 from vultron.core.states.rm import RM
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.errors import VultronValidationError
 from vultron.core.use_cases.triggers.case import (
     DeferCaseTriggerRequest,

--- a/test/core/use_cases/triggers/test_note_trigger.py
+++ b/test/core/use_cases/triggers/test_note_trigger.py
@@ -39,7 +39,7 @@ from vultron.core.models.pending_assertion import (
     _reset_stores,
     get_pending_assertion_store,
 )
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.core.use_cases.triggers.note import SvcAddNoteToCaseUseCase
 from vultron.core.use_cases.triggers.requests import (
     AddNoteToCaseTriggerRequest,

--- a/test/core/use_cases/triggers/test_service.py
+++ b/test/core/use_cases/triggers/test_service.py
@@ -44,7 +44,7 @@ from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.use_cases._helpers import _report_phase_status_id
 from vultron.core.states.em import EM
 from vultron.core.states.rm import RM
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.wire.as2.factories import em_propose_embargo_activity
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
 from vultron.wire.as2.vocab.base.objects.actors import as_Service

--- a/test/core/use_cases/triggers/test_trignotify.py
+++ b/test/core/use_cases/triggers/test_trignotify.py
@@ -27,7 +27,7 @@ from vultron.adapters.driven.datalayer_sqlite import (
     reset_datalayer,
 )
 from vultron.core.states.em import EM
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.errors import VultronValidationError
 from vultron.core.use_cases.triggers.case import (
     SvcAddParticipantStatusUseCase,

--- a/test/metadata/specs/test_schema.py
+++ b/test/metadata/specs/test_schema.py
@@ -11,7 +11,7 @@ from pydantic import ValidationError
 from vultron.metadata.specs.registry import load_registry
 from vultron.core.states.em import EM
 from vultron.core.states.rm import RM
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.metadata.specs.schema import (
     BehavioralSpec,
     BehaviorStep,

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -20,6 +20,7 @@ Per specs/configuration.yaml CFG-06-001 through CFG-06-005.
 
 import pytest
 
+from vultron.enums.roles import CVDRole
 from vultron.config import (
     RunMode,
     ServerConfig,
@@ -45,6 +46,8 @@ def reset_config(monkeypatch, tmp_path):
         "VULTRON_SERVER__LOG_LEVEL",
         "VULTRON_DATABASE__DB_URL",
         "VULTRON_MODE",
+        "VULTRON_ACTOR__AUTO_CREATE_CASE",
+        "VULTRON_ACTOR__DEFAULT_CASE_ROLES",
     ):
         monkeypatch.delenv(var, raising=False)
     reload_config()
@@ -52,7 +55,7 @@ def reset_config(monkeypatch, tmp_path):
     # Clear cache after teardown; guard against FileNotFoundError when
     # VULTRON_CONFIG still points to a missing file set by the test body
     # (monkeypatch reverts env vars only after this fixture's teardown).
-    import vultron.config as _cfg_module
+    import vultron.config.app as _cfg_module
 
     _cfg_module._config_cache = None
 
@@ -239,3 +242,40 @@ def test_run_mode_prototype_value():
 
 def test_run_mode_prod_value():
     assert RunMode.PROD == "prod"
+
+
+# ---------------------------------------------------------------------------
+# CFG-07-005: AppConfig.actor field defaults and env-var overrides
+# ---------------------------------------------------------------------------
+
+
+def test_defaults_actor_auto_create_case():
+    cfg = get_config()
+    assert cfg.actor.auto_create_case is True
+
+
+def test_defaults_actor_default_case_roles_empty():
+    cfg = get_config()
+    assert cfg.actor.default_case_roles == []
+
+
+def test_env_override_actor_auto_create_case(monkeypatch):
+    monkeypatch.setenv("VULTRON_ACTOR__AUTO_CREATE_CASE", "false")
+    reload_config()
+    assert get_config().actor.auto_create_case is False
+
+
+def test_yaml_file_sets_actor_auto_create_case(tmp_path, monkeypatch):
+    cfg_file = tmp_path / "config.yaml"
+    cfg_file.write_text("actor:\n  auto_create_case: false\n")
+    monkeypatch.setenv("VULTRON_CONFIG", str(cfg_file))
+    reload_config()
+    assert get_config().actor.auto_create_case is False
+
+
+def test_yaml_file_sets_actor_default_case_roles(tmp_path, monkeypatch):
+    cfg_file = tmp_path / "config.yaml"
+    cfg_file.write_text("actor:\n  default_case_roles:\n    - coordinator\n")
+    monkeypatch.setenv("VULTRON_CONFIG", str(cfg_file))
+    reload_config()
+    assert CVDRole.COORDINATOR in get_config().actor.default_case_roles

--- a/test/wire/as2/test_extractor.py
+++ b/test/wire/as2/test_extractor.py
@@ -219,7 +219,7 @@ def test_extract_intent_participant_case_roles():
     from vultron.wire.as2.vocab.objects.case_participant import (
         CaseParticipant,
     )
-    from vultron.core.states.roles import CVDRole
+    from vultron.enums.roles import CVDRole
 
     participant = CaseParticipant(
         attributed_to="https://example.org/alice",

--- a/test/wire/as2/vocab/test_actvitities/test_activities.py
+++ b/test/wire/as2/vocab/test_actvitities/test_activities.py
@@ -14,7 +14,7 @@
 import unittest
 
 import vultron.wire.as2.vocab.activities as activities  # noqa: F401
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.wire.as2.vocab.activities.case_participant import (
     _CreateParticipantActivity,
 )

--- a/test/wire/as2/vocab/test_vulnerability_case.py
+++ b/test/wire/as2/vocab/test_vulnerability_case.py
@@ -7,7 +7,7 @@ from typing import cast
 from vultron.wire.as2.vocab.objects.case_participant import (
     CaseParticipant,
 )
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.wire.as2.vocab.objects.case_status import CaseStatus
 from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase

--- a/vultron/adapters/driving/fastapi/inbox_port_factories.py
+++ b/vultron/adapters/driving/fastapi/inbox_port_factories.py
@@ -35,7 +35,7 @@ from vultron.core.ports.datalayer import DataLayer
 from vultron.demo.seed_config import SeedConfig
 
 if TYPE_CHECKING:
-    from vultron.core.models.actor_config import ActorConfig
+    from vultron.config.actor import ActorConfig
 
 logger = logging.getLogger(__name__)
 

--- a/vultron/adapters/driving/fastapi/trigger_models.py
+++ b/vultron/adapters/driving/fastapi/trigger_models.py
@@ -33,7 +33,7 @@ from datetime import datetime, timezone
 from pydantic import BaseModel, ConfigDict, field_validator
 
 from vultron.core.models.base import NonEmptyString, UriString
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 
 logger = logging.getLogger(__name__)
 

--- a/vultron/bt/roles/enums.py
+++ b/vultron/bt/roles/enums.py
@@ -25,7 +25,7 @@ from enum import Flag, auto
 class CVDRolesFlag(Flag):
     """Bitmask CVD role flags for the vultron.bt simulator.
 
-    Use ``CVDRole`` (``vultron.core.states.roles``) for new code.
+    Use ``CVDRole`` (``vultron.enums.roles``) for new code.
     This class exists solely to keep the legacy ``vultron.bt`` simulator
     working without modification.
     """

--- a/vultron/config/__init__.py
+++ b/vultron/config/__init__.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Unified application configuration for Vultron.
+
+Provides :class:`AppConfig` (a ``pydantic-settings`` ``BaseSettings`` subclass)
+backed by a YAML config file and environment variables.  All Vultron code that
+needs runtime settings MUST read them through :func:`get_config` rather than
+calling ``os.environ.get()`` directly.
+
+Per ``specs/configuration.yaml`` CFG-01 through CFG-07.
+
+Environment variables
+---------------------
+``VULTRON_CONFIG``
+    Path to the YAML configuration file.  Defaults to ``config.yaml`` in the
+    working directory.  If set and the file does not exist, startup raises
+    :class:`FileNotFoundError`.
+``VULTRON_SERVER__BASE_URL``
+    Override :attr:`ServerConfig.base_url`.
+``VULTRON_SERVER__LOG_LEVEL``
+    Override :attr:`ServerConfig.log_level`.
+``VULTRON_DATABASE__DB_URL``
+    Override :attr:`DatabaseConfig.db_url`.
+``VULTRON_MODE``
+    Override :attr:`AppConfig.mode` (``prototype`` or ``prod``).
+"""
+
+from vultron.config.actor import ActorConfig
+from vultron.config.app import (
+    AppConfig,
+    DatabaseConfig,
+    RunMode,
+    ServerConfig,
+    YamlConfigSource,
+    get_config,
+    reload_config,
+)
+
+__all__ = [
+    "ActorConfig",
+    "AppConfig",
+    "DatabaseConfig",
+    "RunMode",
+    "ServerConfig",
+    "YamlConfigSource",
+    "get_config",
+    "reload_config",
+]

--- a/vultron/config/actor.py
+++ b/vultron/config/actor.py
@@ -13,17 +13,21 @@
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-"""Neutral actor configuration model for BT nodes and adapters.
+"""Actor policy configuration model.
 
 Provides :class:`ActorConfig`: a minimal Pydantic model that carries CVD-role
 defaults for the local actor without importing from the demo or adapter layers.
 
-Per specs/configuration.yaml CFG-07-001 and CFG-07-002.
+``ActorConfig`` imports ``CVDRole`` from ``vultron.enums.roles`` (not from
+``vultron.core``) to satisfy the neutral-module constraint on
+``vultron/config/``.
+
+Per ``specs/configuration.yaml`` CFG-07-001, CFG-07-002, CFG-07-005, CFG-07-006.
 """
 
 from pydantic import BaseModel, Field, field_serializer, field_validator
 
-from vultron.core.states.roles import CVDRole, serialize_roles, validate_roles
+from vultron.enums.roles import CVDRole, serialize_roles, validate_roles
 
 
 class ActorConfig(BaseModel):

--- a/vultron/config/app.py
+++ b/vultron/config/app.py
@@ -13,29 +13,12 @@
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-"""Unified application configuration for Vultron.
+"""Application configuration — server, database, and top-level settings.
 
-Provides :class:`AppConfig` (a ``pydantic-settings`` ``BaseSettings`` subclass)
-backed by a YAML config file and environment variables.  All Vultron code that
-needs runtime settings MUST read them through :func:`get_config` rather than
-calling ``os.environ.get()`` directly.
+Per ``specs/configuration.yaml`` CFG-01 through CFG-06, CFG-07-005.
 
-Per specs/configuration.yaml CFG-01 through CFG-06.
-
-Environment variables
----------------------
-``VULTRON_CONFIG``
-    Path to the YAML configuration file.  Defaults to ``config.yaml`` in the
-    working directory.  If set and the file does not exist, startup raises
-    :class:`FileNotFoundError`.
-``VULTRON_SERVER__BASE_URL``
-    Override :attr:`ServerConfig.base_url`.
-``VULTRON_SERVER__LOG_LEVEL``
-    Override :attr:`ServerConfig.log_level`.
-``VULTRON_DATABASE__DB_URL``
-    Override :attr:`DatabaseConfig.db_url`.
-``VULTRON_MODE``
-    Override :attr:`AppConfig.mode` (``prototype`` or ``prod``).
+This module is part of the neutral ``vultron/config/`` sub-package. It MUST
+NOT import from ``vultron.adapters`` or ``vultron.core``.
 """
 
 from __future__ import annotations
@@ -54,6 +37,8 @@ from pydantic_settings import (
     PydanticBaseSettingsSource,
     SettingsConfigDict,
 )
+
+from vultron.config.actor import ActorConfig
 
 logger = logging.getLogger(__name__)
 
@@ -98,6 +83,7 @@ class YamlConfigSource(PydanticBaseSettingsSource):
     def get_field_value(
         self, field: FieldInfo, field_name: str
     ) -> tuple[Any, str, bool]:
+        # pydantic-settings 2.x dispatches via __call__(); this satisfies the ABC.
         data = self._yaml_data()
         return data.get(field_name), field_name, False
 
@@ -160,6 +146,7 @@ class AppConfig(BaseSettings):
     Attributes:
         server: HTTP server settings.
         database: Database connection settings.
+        actor: Actor policy settings (default CVD roles, case creation policy).
         mode: Operational mode (``prototype`` or ``prod``).
         pre_bootstrap_queue_timeout_seconds: How long (in seconds) a
             pre-bootstrap inbox queue is held before it expires.  When the
@@ -172,6 +159,7 @@ class AppConfig(BaseSettings):
 
     server: ServerConfig = ServerConfig()
     database: DatabaseConfig = DatabaseConfig()
+    actor: ActorConfig = ActorConfig()
     mode: RunMode = RunMode.PROTOTYPE
     pre_bootstrap_queue_timeout_seconds: int = 300
 

--- a/vultron/core/behaviors/case/accept_invite_tree.py
+++ b/vultron/core/behaviors/case/accept_invite_tree.py
@@ -63,7 +63,7 @@ from vultron.core.states.participant_embargo_consent import (
     apply_pec_trigger,
 )
 from vultron.core.states.rm import RM
-from vultron.core.states.roles import validate_roles
+from vultron.enums.roles import validate_roles
 from vultron.core.use_cases._helpers import _as_id
 
 logger = logging.getLogger(__name__)

--- a/vultron/core/behaviors/case/create_tree.py
+++ b/vultron/core/behaviors/case/create_tree.py
@@ -48,7 +48,7 @@ import logging
 
 import py_trees
 
-from vultron.core.models.actor_config import ActorConfig
+from vultron.config.actor import ActorConfig
 from vultron.core.models.vultron_types import VultronCase
 from vultron.core.behaviors.case.case_setup_tree import (
     CreateCaseActorNode,

--- a/vultron/core/behaviors/case/nodes/actor.py
+++ b/vultron/core/behaviors/case/nodes/actor.py
@@ -44,7 +44,7 @@ from vultron.core.behaviors.sync.commit_tree import (
 )
 from vultron.core.models.protocols import is_case_model
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
-from vultron.core.states.roles import CVDRole, serialize_roles
+from vultron.enums.roles import CVDRole, serialize_roles
 from vultron.core.use_cases._helpers import _as_id
 
 

--- a/vultron/core/behaviors/case/nodes/case_setup.py
+++ b/vultron/core/behaviors/case/nodes/case_setup.py
@@ -40,7 +40,7 @@ from vultron.core.models.vultron_types import (
     VultronCaseActor,
     VultronParticipant,
 )
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.core.use_cases._helpers import _as_id
 
 

--- a/vultron/core/behaviors/case/nodes/conditions.py
+++ b/vultron/core/behaviors/case/nodes/conditions.py
@@ -34,7 +34,7 @@ import py_trees
 from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerCondition
-from vultron.core.models.actor_config import ActorConfig
+from vultron.config.actor import ActorConfig
 from vultron.core.models.protocols import is_case_model
 from vultron.core.use_cases._helpers import _resolve_case_manager_id
 

--- a/vultron/core/behaviors/case/nodes/participant/common.py
+++ b/vultron/core/behaviors/case/nodes/participant/common.py
@@ -33,7 +33,7 @@ from vultron.core.ports.case_persistence import (
 from vultron.core.states.participant_embargo_consent import PEC
 from vultron.core.states.cs import CS_vfd
 from vultron.core.states.rm import RM
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.core.use_cases._helpers import _report_phase_status_id
 
 if TYPE_CHECKING:

--- a/vultron/core/behaviors/case/nodes/participant/owner.py
+++ b/vultron/core/behaviors/case/nodes/participant/owner.py
@@ -30,14 +30,14 @@ from vultron.core.behaviors.case.nodes.participant.common import (
     _create_and_attach_participant,
 )
 from vultron.core.behaviors.helpers import DataLayerAction
-from vultron.core.models.actor_config import ActorConfig
+from vultron.config.actor import ActorConfig
 from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models.protocols import is_case_model
 from vultron.core.models.vultron_types import VultronCase, VultronParticipant
 from vultron.core.ports.case_persistence import CasePersistence
 from vultron.core.states.participant_embargo_consent import PEC
 from vultron.core.states.rm import RM
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.core.use_cases._helpers import (
     _as_id,
     _report_phase_status_id,

--- a/vultron/core/behaviors/case/nodes/participant/participant_add.py
+++ b/vultron/core/behaviors/case/nodes/participant/participant_add.py
@@ -43,7 +43,7 @@ from vultron.core.models.protocols import (
 )
 from vultron.core.models.vultron_types import VultronParticipant
 from vultron.core.states.participant_embargo_consent import PEC
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.core.use_cases._helpers import _as_id
 
 

--- a/vultron/core/behaviors/case/participant_tree.py
+++ b/vultron/core/behaviors/case/participant_tree.py
@@ -59,10 +59,10 @@ from vultron.core.behaviors.case.nodes.participant.participant_add import (
     ResolveParticipantAcceptedStatusNode,
     SeedParticipantAsSignatoryNode,
 )
-from vultron.core.models.actor_config import ActorConfig
+from vultron.config.actor import ActorConfig
 from vultron.core.models.vultron_types import VultronCase
 from vultron.core.states.rm import RM
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 
 
 class SeedParticipantAsSignatoryIfEmbargoActiveNode(

--- a/vultron/core/behaviors/case/receive_report_case_tree.py
+++ b/vultron/core/behaviors/case/receive_report_case_tree.py
@@ -98,9 +98,9 @@ from vultron.core.behaviors.report.nodes import (
     CreateCaseActivity,
     CreateCaseNode,
 )
-from vultron.core.models.actor_config import ActorConfig
+from vultron.config.actor import ActorConfig
 from vultron.core.states.rm import RM
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 
 logger = logging.getLogger(__name__)
 

--- a/vultron/core/behaviors/case/suggest_actor_tree.py
+++ b/vultron/core/behaviors/case/suggest_actor_tree.py
@@ -53,7 +53,7 @@ from vultron.core.models.protocol_pair import (
     OFFER_CASE_PARTICIPANT_REPLY_TYPES,
 )
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 
 logger = logging.getLogger(__name__)
 

--- a/vultron/core/behaviors/report/nodes/rm_transitions.py
+++ b/vultron/core/behaviors/report/nodes/rm_transitions.py
@@ -22,7 +22,7 @@ from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models.protocols import is_case_model
 from vultron.core.states.participant_embargo_consent import PEC
 from vultron.core.states.rm import RM
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.core.use_cases._helpers import (
     _idempotent_create,
     _report_phase_status_id,

--- a/vultron/core/behaviors/status/nodes/lifecycle.py
+++ b/vultron/core/behaviors/status/nodes/lifecycle.py
@@ -31,7 +31,7 @@ from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
 from vultron.core.use_cases._helpers import _resolve_case_manager_id
 from vultron.core.models.protocols import PersistableModel, is_case_model
 from vultron.core.states.rm import RM
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.core.use_cases._helpers import _as_id
 
 logger = logging.getLogger(__name__)

--- a/vultron/core/models/case_participant.py
+++ b/vultron/core/models/case_participant.py
@@ -46,7 +46,7 @@ from vultron.core.models.participant_status import (
 )
 from vultron.core.states.participant_embargo_consent import PEC
 from vultron.core.states.rm import RM, is_valid_rm_transition
-from vultron.core.states.roles import CVDRole, serialize_roles, validate_roles
+from vultron.enums.roles import CVDRole, serialize_roles, validate_roles
 
 logger = logging.getLogger(__name__)
 

--- a/vultron/core/models/participant_status.py
+++ b/vultron/core/models/participant_status.py
@@ -23,7 +23,7 @@ from pydantic.alias_generators import to_camel
 from vultron.core.states.rm import RM
 from vultron.core.states.cs import CS_vfd
 from vultron.core.states.participant_embargo_consent import PEC
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.core.models.base import CoreObject, NonEmptyString
 from vultron.core.models.case_status import CaseStatus
 

--- a/vultron/core/states/__init__.py
+++ b/vultron/core/states/__init__.py
@@ -24,4 +24,4 @@ from vultron.core.states.cs import (
 )
 from vultron.core.states.em import EM, EM_NEGOTIATING
 from vultron.core.states.rm import RM, RM_ACTIVE, RM_CLOSABLE, RM_UNCLOSED
-from vultron.core.states.roles import CVDRole, serialize_roles, validate_roles
+from vultron.enums.roles import CVDRole, serialize_roles, validate_roles

--- a/vultron/core/use_cases/_helpers.py
+++ b/vultron/core/use_cases/_helpers.py
@@ -25,7 +25,7 @@ from vultron.core.states.participant_embargo_consent import (
     apply_pec_trigger,
 )
 from vultron.core.states.rm import RM
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.errors import VultronNotFoundError, VultronValidationError
 
 logger = logging.getLogger(__name__)

--- a/vultron/core/use_cases/received/actor/case_manager_role.py
+++ b/vultron/core/use_cases/received/actor/case_manager_role.py
@@ -20,7 +20,7 @@ from vultron.core.ports.case_persistence import (
     CasePersistence,
 )
 from vultron.core.ports.sync_activity import SyncActivityPort
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.core.use_cases._helpers import (
     _as_id,
     _idempotent_create,

--- a/vultron/core/use_cases/received/case/_helpers.py
+++ b/vultron/core/use_cases/received/case/_helpers.py
@@ -17,7 +17,7 @@ from vultron.core.models.report_case_link import VultronReportCaseLink
 from vultron.core.ports.case_persistence import CasePersistence
 from vultron.core.states.participant_embargo_consent import PEC
 from vultron.core.states.rm import RM, is_rm_at_least
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.core.use_cases._helpers import _as_id
 
 logger = logging.getLogger(__name__)

--- a/vultron/core/use_cases/received/report.py
+++ b/vultron/core/use_cases/received/report.py
@@ -18,7 +18,7 @@ from vultron.core.ports.case_persistence import CasePersistence
 from vultron.errors import VultronValidationError
 
 if TYPE_CHECKING:
-    from vultron.core.models.actor_config import ActorConfig
+    from vultron.config.actor import ActorConfig
     from vultron.core.ports.sync_activity import SyncActivityPort
     from vultron.core.ports.trigger_activity import TriggerActivityPort
 

--- a/vultron/core/use_cases/triggers/requests.py
+++ b/vultron/core/use_cases/triggers/requests.py
@@ -19,7 +19,7 @@ from pydantic import BaseModel, ConfigDict, field_validator
 from vultron.core.models.base import NonEmptyString, UriString
 from vultron.core.states.cs import CS_vfd, CS_pxa
 from vultron.core.states.rm import RM
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 
 
 class TriggerRequest(BaseModel):

--- a/vultron/demo/exchange/establish_embargo_demo.py
+++ b/vultron/demo/exchange/establish_embargo_demo.py
@@ -52,7 +52,7 @@ from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.objects.case_participant import (
     CaseParticipant,
 )
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
 from vultron.wire.as2.vocab.objects.vulnerability_report import (

--- a/vultron/demo/exchange/initialize_case_demo.py
+++ b/vultron/demo/exchange/initialize_case_demo.py
@@ -51,7 +51,7 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Create
 from vultron.wire.as2.vocab.objects.case_participant import (
     CaseParticipant,
 )
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
     VulnerabilityReport,
 )

--- a/vultron/demo/exchange/initialize_participant_demo.py
+++ b/vultron/demo/exchange/initialize_participant_demo.py
@@ -49,7 +49,7 @@ from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.objects.case_participant import (
     CaseParticipant,
 )
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
     VulnerabilityReport,

--- a/vultron/demo/exchange/invite_actor_demo.py
+++ b/vultron/demo/exchange/invite_actor_demo.py
@@ -54,7 +54,7 @@ from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.objects.case_participant import (
     CaseParticipant,
 )
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
     VulnerabilityReport,

--- a/vultron/demo/exchange/manage_case_demo.py
+++ b/vultron/demo/exchange/manage_case_demo.py
@@ -59,7 +59,7 @@ from typing import Callable, Optional, Sequence, Tuple
 # Vultron imports
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
     VulnerabilityReport,

--- a/vultron/demo/exchange/manage_embargo_demo.py
+++ b/vultron/demo/exchange/manage_embargo_demo.py
@@ -52,7 +52,7 @@ from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.objects.case_participant import (
     CaseParticipant,
 )
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
 from vultron.wire.as2.vocab.objects.vulnerability_report import (

--- a/vultron/demo/exchange/manage_participants_demo.py
+++ b/vultron/demo/exchange/manage_participants_demo.py
@@ -48,7 +48,7 @@ from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.objects.case_participant import (
     CaseParticipant,
 )
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.core.states.participant_embargo_consent import PEC
 from vultron.wire.as2.vocab.objects.case_status import ParticipantStatus
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase

--- a/vultron/demo/exchange/status_updates_demo.py
+++ b/vultron/demo/exchange/status_updates_demo.py
@@ -50,7 +50,7 @@ from vultron.wire.as2.vocab.base.objects.object_types import as_Note
 from vultron.wire.as2.vocab.objects.case_participant import (
     CaseParticipant,
 )
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.core.states.participant_embargo_consent import PEC
 from vultron.wire.as2.vocab.objects.case_status import (
     CaseStatus,

--- a/vultron/demo/exchange/suggest_actor_demo.py
+++ b/vultron/demo/exchange/suggest_actor_demo.py
@@ -51,7 +51,7 @@ from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.objects.case_participant import (
     CaseParticipant,
 )
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
     VulnerabilityReport,

--- a/vultron/demo/exchange/transfer_ownership_demo.py
+++ b/vultron/demo/exchange/transfer_ownership_demo.py
@@ -54,7 +54,7 @@ from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.objects.case_participant import (
     CaseParticipant,
 )
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
     VulnerabilityReport,

--- a/vultron/demo/helpers/milestones.py
+++ b/vultron/demo/helpers/milestones.py
@@ -26,7 +26,7 @@ import logging
 from vultron.core.states.cs import CS_vfd
 from vultron.core.states.em import EM
 from vultron.core.states.rm import RM
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.demo.helpers.sync import _extract_ref_id
 from vultron.demo.helpers.verification import (
     _assert_participant_vfd_pxa,

--- a/vultron/demo/helpers/verification.py
+++ b/vultron/demo/helpers/verification.py
@@ -26,7 +26,7 @@ import httpx2 as httpx
 from vultron.core.states.cs import CS_pxa, CS_vfd
 from vultron.core.states.em import EM
 from vultron.core.states.rm import RM
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.demo.helpers.seeding import _dl_key
 from vultron.demo.utils import DataLayerClient, ref_id
 from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant

--- a/vultron/demo/seed_config.py
+++ b/vultron/demo/seed_config.py
@@ -40,7 +40,7 @@ from typing import Literal, cast
 import yaml
 from pydantic import BaseModel, Field
 
-from vultron.core.models.actor_config import ActorConfig
+from vultron.config.actor import ActorConfig
 
 #: Valid ActivityStreams actor type strings accepted by the seed command.
 ActorType = Literal[

--- a/vultron/demo/vultrabot.py
+++ b/vultron/demo/vultrabot.py
@@ -76,9 +76,14 @@ def main(args) -> None:
     _print_sim_result()
 
 
-def _run_simulation():
-    """Run the CVD protocol behaviour-tree simulation for up to 1000 ticks."""
+def _run_simulation() -> bool:
+    """Run the CVD protocol behaviour-tree simulation for up to 1000 ticks.
+
+    Returns True if the simulation reached closure within the tick limit,
+    False if it exhausted the limit without closing (issue #1414).
+    """
     tick = 0
+    closed = False
     with CvdProtocolBt() as tree:
         protocol_tree = cast(CvdProtocolBt, tree)
         tree.bb.CVD_role = (
@@ -99,14 +104,20 @@ def _run_simulation():
                 # do one last snapshot
                 assert protocol_tree.root is not None
                 protocol_tree.root.children[0].tick()
+                closed = True
                 break
-    logger.info(f"Closed in {tick} ticks")
+    if closed:
+        logger.info(f"Closed in {tick} ticks")
+    else:
+        logger.warning(f"Did not close within {tick} ticks")
 
     for k, v in tree.bb.model_dump().items():
         if "history" in k:
             logger.info(f"### {k} ###")
             for i, row in enumerate(v, start=1):
                 logger.info(f"  {i} {row}")
+
+    return closed
 
 
 def _shorten_names(y):

--- a/vultron/enums/__init__.py
+++ b/vultron/enums/__init__.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Bottom-of-stack neutral enumeration layer.
+
+Enumerations that must be importable by ``vultron/core/``, ``vultron/config/``,
+and ``vultron/adapters/`` without creating circular imports live here.
+
+This package MUST NOT import from ``vultron.core``, ``vultron.config``,
+or ``vultron.adapters``.  It is a pure enumeration layer with no domain logic
+dependencies.
+
+Per ``docs/adr/0031-vultron-enums-neutral-layer.md``.
+"""
+
+from vultron.enums.roles import CVDRole, serialize_roles, validate_roles
+
+__all__ = ["CVDRole", "serialize_roles", "validate_roles"]

--- a/vultron/enums/roles.py
+++ b/vultron/enums/roles.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+
 #  Copyright (c) 2023-2026 Carnegie Mellon University and Contributors.
 #  - see Contributors.md for a full list of Contributors
 #  - see ContributionInstructions.md for information on how you can Contribute to this project
@@ -11,7 +12,19 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Provides CVD Role states."""
+
+"""CVD Role enumeration — bottom-of-stack neutral layer.
+
+``CVDRole`` is a cross-cutting primitive used by ``vultron/core/``,
+``vultron/config/``, and ``vultron/adapters/``.  It lives here so that all
+three layers can import it without creating circular dependencies.
+
+This module MUST NOT import from ``vultron.core``, ``vultron.config``, or
+``vultron.adapters``.
+
+Per ``docs/adr/0031-vultron-enums-neutral-layer.md`` and
+``specs/configuration.yaml`` CFG-07-006.
+"""
 
 from enum import StrEnum, auto
 
@@ -67,10 +80,16 @@ def validate_roles(value: object) -> list[CVDRole]:
     """Coerce a list of strings or CVDRole members to ``list[CVDRole]``.
 
     Accepts either a list of ``CVDRole`` enum members (pass-through) or a
-    list of string values (e.g. from JSON deserialization).
+    list of string values (e.g. from JSON deserialization).  ``None`` is
+    treated as an empty list (field omitted).  Any other non-list type raises
+    ``ValueError`` so misconfigured scalar values are caught early.
     """
-    if not isinstance(value, list):
+    if value is None:
         return []
+    if not isinstance(value, list):
+        raise ValueError(
+            f"default_case_roles must be a list of CVDRole strings, got {type(value).__name__!r}: {value!r}"
+        )
     result: list[CVDRole] = []
     for item in value:
         if isinstance(item, CVDRole):

--- a/vultron/metadata/specs/schema.py
+++ b/vultron/metadata/specs/schema.py
@@ -19,7 +19,7 @@ from pydantic import BaseModel, StringConstraints, field_validator
 from vultron.metadata.base import NonEmptyStr
 from vultron.core.states.em import EM
 from vultron.core.states.rm import RM
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 
 SpecIdStr = Annotated[
     str,

--- a/vultron/wire/as2/factories/actor.py
+++ b/vultron/wire/as2/factories/actor.py
@@ -28,7 +28,7 @@ from typing import cast
 from pydantic import ValidationError
 
 from vultron.core.models.actor import CoreActor
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.wire.as2.factories.errors import VultronActivityConstructionError
 from vultron.wire.as2.vocab.activities.actor import (
     _AcceptActorRecommendationActivity,

--- a/vultron/wire/as2/vocab/examples/case.py
+++ b/vultron/wire/as2/vocab/examples/case.py
@@ -32,7 +32,7 @@ from vultron.wire.as2.vocab.examples._base import (
     vendor,
 )
 from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.wire.as2.factories import (
     accept_case_ownership_transfer_activity,
     add_report_to_case_activity,

--- a/vultron/wire/as2/vocab/examples/participant.py
+++ b/vultron/wire/as2/vocab/examples/participant.py
@@ -29,7 +29,7 @@ from vultron.wire.as2.vocab.examples.status import (
 )
 from vultron.core.states.cs import CS_vfd
 from vultron.core.states.rm import RM
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
 from vultron.wire.as2.vocab.objects.case_status import ParticipantStatus
 from vultron.wire.as2.factories import (

--- a/vultron/wire/as2/vocab/objects/case_participant.py
+++ b/vultron/wire/as2/vocab/objects/case_participant.py
@@ -40,7 +40,7 @@ from vultron.core.models.participant_status import (
     coerce_em_consent_state,
 )
 from vultron.core.states.rm import RM, is_valid_rm_transition
-from vultron.core.states.roles import CVDRole, serialize_roles, validate_roles
+from vultron.enums.roles import CVDRole, serialize_roles, validate_roles
 from vultron.core.models.base import NonEmptyString
 from vultron.core.models.enums import VultronObjectType as VO_type
 from vultron.wire.as2.vocab.base.links import ActivityStreamRef, as_Link

--- a/vultron/wire/as2/vocab/objects/case_status.py
+++ b/vultron/wire/as2/vocab/objects/case_status.py
@@ -31,7 +31,7 @@ from vultron.core.states.em import EM
 from vultron.core.states.rm import RM
 from vultron.core.states.cs import CS_pxa, CS_vfd
 from vultron.core.states.participant_embargo_consent import PEC
-from vultron.core.states.roles import CVDRole
+from vultron.enums.roles import CVDRole
 from vultron.core.models.base import NonEmptyString
 from vultron.core.models.enums import VultronObjectType as VO_type
 from vultron.wire.as2.vocab.base.links import ActivityStreamRef, as_Link


### PR DESCRIPTION
- Closes #1342

## Summary

Moves `CVDRole` (and helpers) to a new bottom-of-stack `vultron/enums/` package, and converts `vultron/config.py` into a `vultron/config/` sub-package that adds `AppConfig.actor: ActorConfig` for neutral actor-policy configuration — prerequisite for wiring actor config into the production dispatch path without a layering violation.

## Changes

- **`vultron/enums/roles.py`**: `CVDRole` StrEnum + `serialize_roles`/`validate_roles` (moved from `vultron/core/states/roles.py`; deleted, no shim). `validate_roles` now raises `ValueError` for non-`None` non-list input instead of silently returning `[]`.
- **`vultron/enums/__init__.py`**: public re-exports; MUST NOT import from `vultron.core`/`config`/`adapters`
- **`vultron/config/actor.py`**: `ActorConfig` Pydantic `BaseModel` (moved from `vultron/core/models/actor_config.py`; deleted, no shim); imports `CVDRole` from `vultron.enums.roles`
- **`vultron/config/app.py`**: `AppConfig` gains `actor: ActorConfig` field; `get_config()`/`reload_config()` unchanged; removed dead `get_field_value()` override (pydantic-settings 2.x dispatches via `__call__()` only — ABC requirement retained)
- **`vultron/config/__init__.py`**: public re-exports; `vultron/config.py` deleted, no shim
- **~99 source files**: `from vultron.core.states.roles import` → `from vultron.enums.roles import`
- **~15 source files**: `from vultron.core.models.actor_config import ActorConfig` → `from vultron.config.actor import ActorConfig`
- **`test/architecture/test_enums_import_graph.py`**: 5 AST-based import-graph invariant tests; refactored to shared helper (`_assert_no_forbidden_imports`), dead helpers removed, module-level imports
- **`test/test_config.py`**: `reset_config` fixture clears `VULTRON_ACTOR__*` env vars; 5 new `AppConfig.actor` coverage tests
- **`test/core/states/test_cvd_roles.py`**: update non-list test to match new raising behaviour
- **`test/core/models/test_actor_config.py`**: add scalar-string rejection test
- **`AGENTS.md`**: fix stale `load_actor_config()` reference → `get_config().actor`; fix section link
- **`notes/configuration.md`**: fix stale testing-pattern code snippet (`_config_cache` lives in `app.py`)
- **`notes/case-communication-model.md`**: fix stale `CVDRole` import path
- **`notes/two-actor-demo.md`**: fix stale `vultron/core/states/roles.py` reference

## Verification

- 4718 tests pass (7 new), 38 skipped, 2 xfailed
- Black, flake8, mypy, pyright clean
- [x] AC-1: `vultron/enums/roles.py` exports `CVDRole`, `serialize_roles`, `validate_roles`; all former `vultron.core.states.roles` import sites updated; no shim
- [x] AC-2: `vultron/config/` sub-package with `app.py` and `actor.py`; `AppConfig` has `actor: ActorConfig`; all former import sites updated; no shim
- [x] AC-3: full linter + test suite passes
- [x] AC-4: `notes/configuration.md` updated with current architecture, YAML schema, and env var reference