### PR TITLE
fix(demo): wait for full ledger coverage before log dump in FVV demo

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1363.md
+++ b/plan/history/2607/implementation/ISSUE-1363.md
@@ -1,0 +1,31 @@
+---
+source: ISSUE-1363
+timestamp: '2026-07-14T20:12:13.543406+00:00'
+title: FVV late-joiner backfill miss
+type: implementation
+---
+
+## Issue #1363 — FVV demo intermittent `test_invariant_8_late_joiner_has_full_history` failure
+
+**Symptom**: `_phase_dump_case_ledgers` in the FVV demo occasionally captured a
+gapped case ledger for the Finder replica (e.g. `logIndex=17` missing), causing
+`test_invariant_8_late_joiner_has_full_history` to fail non-deterministically.
+
+**Root cause**: `_phase_case_closure` waited only for the tail entry hash to
+appear in the Finder's DataLayer before dumping logs. `Announce(CaseLedgerEntry)`
+activities are delivered independently per entry; an intermediate entry can
+arrive *after* the tail, so the JSONL dump was captured with a gap.
+
+**Fix**: Added `wait_for_contiguous_ledger_coverage()` to `polling.py`. It polls
+until the replica holds **all** log indices `0…expected_tail_index` before the
+dump proceeds. Replaced both `wait_for_finder_log_entry()` call sites in the FVV
+demo (Phase 2 sync verification and Phase 6 case closure) with this stronger gate.
+
+**Files changed**:
+
+- `vultron/demo/helpers/polling.py` — new helper
+- `vultron/demo/helpers/__init__.py` — re-export
+- `vultron/demo/scenario/fvv_demo.py` — use stronger gate
+- `test/demo/test_fvv_demo.py` — 5 regression tests
+
+PR: <https://github.com/CERTCC/Vultron/pull/1433>

--- a/test/demo/test_fvv_demo.py
+++ b/test/demo/test_fvv_demo.py
@@ -32,6 +32,7 @@ from fastapi.testclient import TestClient
 import vultron.demo.scenario.fvv_demo as demo
 from test.demo._helpers import make_client, make_testclient_call
 from vultron.demo.cli import main
+from vultron.demo.helpers.polling import wait_for_contiguous_ledger_coverage
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -205,3 +206,128 @@ class TestFvvCliCommand:
         runner = CliRunner()
         result = runner.invoke(main, ["fvv", "--help"])
         assert "--vendor2-url" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Regression tests: wait_for_contiguous_ledger_coverage (issue #1363)
+# ---------------------------------------------------------------------------
+
+
+class TestWaitForContiguousLedgerCoverage:
+    """Regression tests for the pre-dump ledger coverage gate (issue #1363).
+
+    The bug: _phase_case_closure waited only for the tail entry hash before
+    dumping logs.  Because Announce(CaseLedgerEntry) activities arrive
+    independently, an intermediate entry (e.g. logIndex=17) could arrive after
+    the tail, leaving the JSONL with a gap.
+
+    wait_for_contiguous_ledger_coverage closes this race by verifying that
+    ALL indices 0…expected_tail_index are present before the dump proceeds.
+    """
+
+    def _make_raw_entries(self, case_id: str, indices: list[int]) -> dict:
+        """Build the dict structure returned by GET /datalayer/CaseLedgerEntrys/."""
+        return {
+            f"entry-{i}": {
+                "case_id": case_id,
+                "log_index": i,
+                "entry_hash": f"hash{i:04d}",
+            }
+            for i in indices
+        }
+
+    def test_returns_when_all_indices_present(self):
+        """Returns immediately when indices 0…N are all present (happy path)."""
+        case_id = "https://example.org/cases/test-coverage-1"
+        client = MagicMock()
+        client.get.return_value = self._make_raw_entries(
+            case_id, list(range(5))
+        )
+
+        wait_for_contiguous_ledger_coverage(
+            client=client,
+            case_id=case_id,
+            expected_tail_index=4,
+            timeout_seconds=1.0,
+        )
+        assert client.get.call_count >= 1
+
+    def test_raises_when_intermediate_index_missing(self):
+        """Raises AssertionError when an intermediate entry (the bug) is absent.
+
+        Simulates the race: indices 0…16, 18…20 are present but index 17 is
+        missing, reproducing the exact failure from issue #1363.
+        """
+        case_id = "https://example.org/cases/test-coverage-2"
+        indices_with_gap = list(range(17)) + list(range(18, 21))
+        client = MagicMock()
+        client.get.return_value = self._make_raw_entries(
+            case_id, indices_with_gap
+        )
+
+        with pytest.raises(AssertionError, match="contiguous ledger coverage"):
+            wait_for_contiguous_ledger_coverage(
+                client=client,
+                case_id=case_id,
+                expected_tail_index=20,
+                timeout_seconds=0.1,
+                poll_interval=0.05,
+            )
+
+    def test_raises_when_tail_present_but_early_entries_missing(self):
+        """Raises when the tail arrived but early entries are absent.
+
+        This is the exact race: tail (logIndex=N) arrives first via
+        Announce, but logIndex=17 (or similar) arrives later.
+        wait_for_finder_log_entry would have returned True here, but
+        wait_for_contiguous_ledger_coverage correctly waits.
+        """
+        case_id = "https://example.org/cases/test-coverage-3"
+        # Present: only the tail entry (index=5), missing 0-4
+        client = MagicMock()
+        client.get.return_value = self._make_raw_entries(case_id, [5])
+
+        with pytest.raises(AssertionError, match="contiguous ledger coverage"):
+            wait_for_contiguous_ledger_coverage(
+                client=client,
+                case_id=case_id,
+                expected_tail_index=5,
+                timeout_seconds=0.1,
+                poll_interval=0.05,
+            )
+
+    def test_ignores_entries_for_other_cases(self):
+        """Does not count entries from other cases toward coverage."""
+        case_id = "https://example.org/cases/target-case"
+        other_case_id = "https://example.org/cases/other-case"
+        client = MagicMock()
+        # Indices 0-3 belong to the target case; 4-9 belong to another case
+        target_entries = self._make_raw_entries(case_id, list(range(4)))
+        other_entries = self._make_raw_entries(
+            other_case_id, list(range(4, 10))
+        )
+        client.get.return_value = {**target_entries, **other_entries}
+
+        with pytest.raises(AssertionError, match="contiguous ledger coverage"):
+            wait_for_contiguous_ledger_coverage(
+                client=client,
+                case_id=case_id,
+                expected_tail_index=5,
+                timeout_seconds=0.1,
+                poll_interval=0.05,
+            )
+
+    def test_raises_when_no_entries_present(self):
+        """Raises when the DataLayer returns no entries at all."""
+        case_id = "https://example.org/cases/test-coverage-4"
+        client = MagicMock()
+        client.get.return_value = {}
+
+        with pytest.raises(AssertionError, match="contiguous ledger coverage"):
+            wait_for_contiguous_ledger_coverage(
+                client=client,
+                case_id=case_id,
+                expected_tail_index=3,
+                timeout_seconds=0.1,
+                poll_interval=0.05,
+            )

--- a/vultron/demo/helpers/__init__.py
+++ b/vultron/demo/helpers/__init__.py
@@ -61,6 +61,7 @@ from vultron.demo.helpers.polling import (  # noqa: F401
     wait_for_case_em_terminated,
     wait_for_case_on_container,
     wait_for_case_participants,
+    wait_for_contiguous_ledger_coverage,
     wait_for_finder_case,
     wait_for_finder_log_entry,
     wait_for_note_in_case,

--- a/vultron/demo/helpers/polling.py
+++ b/vultron/demo/helpers/polling.py
@@ -264,6 +264,81 @@ def wait_for_finder_log_entry(
     )
 
 
+def wait_for_contiguous_ledger_coverage(
+    client: DataLayerClient,
+    case_id: str,
+    expected_tail_index: int,
+    timeout_seconds: float = 15.0,
+    poll_interval: float = 0.5,
+) -> None:
+    """Poll *client*'s DataLayer until it holds all log indices 0…*expected_tail_index*.
+
+    :func:`wait_for_finder_log_entry` only confirms that the tail entry (by
+    hash) has arrived.  Because ``Announce(CaseLedgerEntry)`` activities are
+    delivered independently, an intermediate entry (e.g. logIndex=17) can
+    arrive *after* the tail entry, so the dump may still capture a gapped log.
+
+    This helper closes that race by polling until the replica's local index
+    set is the complete contiguous range ``{0, 1, …, expected_tail_index}``.
+
+    Args:
+        client: DataLayerClient connected to the replica container.
+        case_id: Full URI of the ``VulnerabilityCase``.
+        expected_tail_index: The highest ``log_index`` the replica must hold
+            (inclusive).  Typically obtained from the authoritative actor's
+            ledger dump before calling this function.
+        timeout_seconds: Maximum time to wait before raising.
+        poll_interval: Seconds between DataLayer poll attempts.
+
+    Raises:
+        AssertionError: If the replica does not have full contiguous coverage
+            within *timeout_seconds*.
+
+    Spec: SYNC-02-003 (all entries must be present before log finalisation).
+    """
+    expected_indices = set(range(expected_tail_index + 1))
+
+    def _check() -> bool:
+        raw = client.get("/datalayer/CaseLedgerEntrys/")
+        if not isinstance(raw, dict):
+            return False
+        present = {
+            v["log_index"]
+            for v in raw.values()
+            if isinstance(v, dict)
+            and v.get("case_id") == case_id
+            and isinstance(v.get("log_index"), int)
+        }
+        missing = expected_indices - present
+        if missing:
+            logger.debug(
+                "Ledger coverage check: %d/%d entries present for case %s; "
+                "missing indices: %s",
+                len(present),
+                expected_tail_index + 1,
+                case_id,
+                sorted(missing)[:10],
+            )
+            return False
+        logger.info(
+            "Ledger fully replicated for case %s (%d entries, indices 0…%d)",
+            case_id,
+            expected_tail_index + 1,
+            expected_tail_index,
+        )
+        return True
+
+    _poll_until(
+        _check,
+        timeout_seconds,
+        poll_interval,
+        f"Timed out waiting for contiguous ledger coverage (0…{expected_tail_index}) "
+        f"for case {case_id!r} — one or more intermediate entries may not have "
+        "been delivered",
+        swallow_exceptions=True,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Participant-state polling helpers
 # ---------------------------------------------------------------------------

--- a/vultron/demo/helpers/polling.py
+++ b/vultron/demo/helpers/polling.py
@@ -294,7 +294,7 @@ def wait_for_contiguous_ledger_coverage(
         AssertionError: If the replica does not have full contiguous coverage
             within *timeout_seconds*.
 
-    Spec: SYNC-02-003 (all entries must be present before log finalisation).
+    Spec: SYNC-10-004 (catch-up gate must require a contiguous canonical log prefix).
     """
     expected_indices = set(range(expected_tail_index + 1))
 

--- a/vultron/demo/scenario/fvv_demo.py
+++ b/vultron/demo/scenario/fvv_demo.py
@@ -77,8 +77,8 @@ from vultron.demo.helpers.polling import (
     wait_for_case_em_terminated,
     wait_for_case_on_container,
     wait_for_case_participants,
+    wait_for_contiguous_ledger_coverage,
     wait_for_finder_case,
-    wait_for_finder_log_entry,
     wait_for_participant_vfd_state,
 )
 from vultron.demo.helpers.seeding import (
@@ -297,26 +297,27 @@ def _phase_sync_verification(
     vendor_entries = _get_log_entries_for_case(vendor_client, case.id_)
     if vendor_entries:
         vendor_tail = max(vendor_entries, key=lambda e: e["log_index"])
+        vendor_tail_index: int = vendor_tail["log_index"]
         vendor_tail_hash: str = vendor_tail["entry_hash"]
         logger.info(
             "Waiting for Finder to replicate Vendor1 tail (hash=%s… index=%d)",
             vendor_tail_hash[:16],
-            vendor_tail["log_index"],
+            vendor_tail_index,
         )
-        wait_for_finder_log_entry(
-            finder_client=finder_client,
+        wait_for_contiguous_ledger_coverage(
+            client=finder_client,
             case_id=case.id_,
-            entry_hash=vendor_tail_hash,
+            expected_tail_index=vendor_tail_index,
         )
         logger.info(
             "Waiting for Vendor2 to replicate Vendor1 tail (hash=%s… index=%d)",
             vendor_tail_hash[:16],
-            vendor_tail["log_index"],
+            vendor_tail_index,
         )
-        wait_for_finder_log_entry(
-            finder_client=vendor2_client,
+        wait_for_contiguous_ledger_coverage(
+            client=vendor2_client,
             case_id=case.id_,
-            entry_hash=vendor_tail_hash,
+            expected_tail_index=vendor_tail_index,
         )
 
     wait_for_case_participants(
@@ -612,26 +613,31 @@ def _phase_case_closure(
             case_id=case.id_,
         )
 
-    # Wait for all replicas to receive the canonical close_case ledger entry.
+    # Wait for all replicas to receive every canonical ledger entry including
+    # the close_case tail.  Waiting only for the tail hash is insufficient:
+    # Announce(CaseLedgerEntry) activities are delivered independently and an
+    # intermediate entry can arrive after the tail (issue #1363).  We therefore
+    # verify full contiguous coverage (0…tail_index) before dumping logs.
     vendor_entries = _get_log_entries_for_case(vendor_client, case.id_)
     if vendor_entries:
         vendor_tail = max(vendor_entries, key=lambda e: e["log_index"])
+        vendor_tail_index: int = vendor_tail["log_index"]
         vendor_tail_hash: str = vendor_tail["entry_hash"]
         logger.info(
             "Waiting for replicas to receive vendor1 tail after closure"
             " (hash=%s… index=%d)",
             vendor_tail_hash[:16],
-            vendor_tail["log_index"],
+            vendor_tail_index,
         )
-        wait_for_finder_log_entry(
-            finder_client=finder_client,
+        wait_for_contiguous_ledger_coverage(
+            client=finder_client,
             case_id=case.id_,
-            entry_hash=vendor_tail_hash,
+            expected_tail_index=vendor_tail_index,
         )
-        wait_for_finder_log_entry(
-            finder_client=vendor2_client,
+        wait_for_contiguous_ledger_coverage(
+            client=vendor2_client,
             case_id=case.id_,
-            entry_hash=vendor_tail_hash,
+            expected_tail_index=vendor_tail_index,
         )
 
 

--- a/vultron/demo/scenario/two_actor_demo.py
+++ b/vultron/demo/scenario/two_actor_demo.py
@@ -83,6 +83,7 @@ from vultron.demo.helpers.polling import (  # noqa: F401
     wait_for_case_on_container,
     wait_for_case_participants,
     wait_for_finder_case,
+    wait_for_contiguous_ledger_coverage,
     wait_for_finder_log_entry,
     wait_for_note_in_case,
     wait_for_participant_vfd_state,
@@ -558,23 +559,22 @@ def _phase_sync_verification(
     # in `vultron.demo.helpers.sync` for tests that need to drive a *real*
     # protocol event and wait for its replica; they are intentionally not
     # called here — EXCEPT for the replica-state check below, where we must
-    # wait for finder to receive the vendor's latest canonical entry before
-    # comparing tail hashes.  The vendor's report-acceptance creates canonical
-    # ledger entries whose Announce(CaseLedgerEntry) fan-out is an async
-    # BackgroundTask; without this wait the tail hashes may diverge.
+    # wait for finder to receive all canonical entries before comparing state.
+    # The vendor's report-acceptance creates canonical ledger entries whose
+    # Announce(CaseLedgerEntry) fan-out is an async BackgroundTask; without
+    # this wait intermediate entries may not have arrived yet (issue #1434).
     vendor_entries = _get_log_entries_for_case(vendor_client, case.id_)
     if vendor_entries:
         vendor_tail = max(vendor_entries, key=lambda e: e["log_index"])
-        vendor_tail_hash: str = vendor_tail["entry_hash"]
+        vendor_tail_index: int = vendor_tail["log_index"]
         logger.info(
-            "Waiting for finder to replicate vendor tail entry (hash=%s… index=%d)",
-            vendor_tail_hash[:16],
-            vendor_tail["log_index"],
+            "Waiting for finder to replicate all vendor entries (0…%d)",
+            vendor_tail_index,
         )
-        wait_for_finder_log_entry(
-            finder_client=finder_client,
+        wait_for_contiguous_ledger_coverage(
+            client=finder_client,
             case_id=case.id_,
-            entry_hash=vendor_tail_hash,
+            expected_tail_index=vendor_tail_index,
         )
 
     logger.info(
@@ -752,25 +752,23 @@ def _phase_case_closure(
             case_id=case.id_,
         )
 
-    # Wait for finder to replicate the canonical close_case ledger entry
-    # before _phase_dump_case_ledgers writes the devlog files.
-    # AutoClose commits the entry on case-actor (vendor-1) and fans it out via
-    # Announce(CaseLedgerEntry) as an async BackgroundTask; finder may not have
-    # it yet when verify_case_closed returns.
+    # Wait for finder to receive all canonical ledger entries (including the
+    # close_case tail) before _phase_dump_case_ledgers writes devlog files.
+    # AutoClose fans out Announce(CaseLedgerEntry) as an async BackgroundTask;
+    # intermediate entries may arrive after the tail (issue #1434).
     vendor_entries = _get_log_entries_for_case(vendor_client, case.id_)
     if vendor_entries:
         vendor_tail = max(vendor_entries, key=lambda e: e["log_index"])
-        vendor_tail_hash: str = vendor_tail["entry_hash"]
+        vendor_tail_index: int = vendor_tail["log_index"]
         logger.info(
-            "Waiting for finder to replicate vendor tail after closure"
-            " (hash=%s… index=%d)",
-            vendor_tail_hash[:16],
-            vendor_tail["log_index"],
+            "Waiting for finder to replicate all vendor entries after closure"
+            " (0…%d)",
+            vendor_tail_index,
         )
-        wait_for_finder_log_entry(
-            finder_client=finder_client,
+        wait_for_contiguous_ledger_coverage(
+            client=finder_client,
             case_id=case.id_,
-            entry_hash=vendor_tail_hash,
+            expected_tail_index=vendor_tail_index,
         )
 
 


### PR DESCRIPTION
- Fixes #1363
- Closes #1434

## Summary

`_phase_case_closure` in `fvv_demo.py` waited only for the tail entry
hash before dumping JSONL logs.  `Announce(CaseLedgerEntry)` activities
are delivered independently per-entry; an intermediate entry (e.g.
`logIndex=17`) can arrive *after* the tail, so `_phase_dump_case_ledgers`
captured a gapped log, causing `test_invariant_8_late_joiner_has_full_history`
to fail intermittently.

Adds `wait_for_contiguous_ledger_coverage()` to `polling.py` which polls
until the replica holds **all** log indices `0…expected_tail_index` before
the dump proceeds.  Replaces `wait_for_finder_log_entry()` call sites in
both the FVV demo and the two-actor demo with this stronger gate.

## Changes

- `vultron/demo/helpers/polling.py`: add `wait_for_contiguous_ledger_coverage()`
- `vultron/demo/helpers/__init__.py`: re-export new helper
- `vultron/demo/scenario/fvv_demo.py`: replace tail-hash-only wait with
  contiguous coverage check in `_phase_sync_verification` and `_phase_case_closure`
- `vultron/demo/scenario/two_actor_demo.py`: same fix at both polling sites
  (Phase 2 and Phase 6)
- `test/demo/test_fvv_demo.py`: 5 regression tests in `TestWaitForContiguousLedgerCoverage`

## Verification

- 5 new regression tests — including the exact race (tail present, intermediate entry absent)
- 58 demo tests pass (`uv run pytest test/demo/ -m ""`)
- 4706 unit tests pass (`uv run pytest --tb=short`)
- Black, flake8, mypy, pyright all clean