### PR TITLE
refactor: use CasePersistence in AcceptCaseProposalReceivedUseCase and RejectCaseProposalReceivedUseCase

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1385.md
+++ b/plan/history/2607/implementation/ISSUE-1385.md
@@ -1,0 +1,12 @@
+---
+source: ISSUE-1385
+timestamp: '2026-07-15T14:38:59.033004+00:00'
+title: 'refactor: use CasePersistence in AcceptCaseProposalReceivedUseCase and RejectCaseProposalReceivedUseCase'
+type: implementation
+---
+
+## Issue #1385 — refactor: use CasePersistence in AcceptCaseProposalReceivedUseCase and RejectCaseProposalReceivedUseCase
+
+Migrated `AcceptCaseProposalReceivedUseCase` and `RejectCaseProposalReceivedUseCase` in `vultron/core/use_cases/received/case_proposal.py` from the broad `DataLayer` port to the narrow `CasePersistence` port, satisfying DL-03-001/DL-03-002. Removed the unused `DataLayer` import. All 4722 unit tests pass; Black, flake8, mypy, and pyright all clean.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1436>

--- a/vultron/core/use_cases/received/case_proposal.py
+++ b/vultron/core/use_cases/received/case_proposal.py
@@ -49,8 +49,10 @@ from vultron.core.models.events.case_proposal import (
     CreateCaseProposalReceivedEvent,
     RejectCaseProposalReceivedEvent,
 )
-from vultron.core.ports.case_persistence import CaseOutboxPersistence
-from vultron.core.ports.datalayer import DataLayer
+from vultron.core.ports.case_persistence import (
+    CaseOutboxPersistence,
+    CasePersistence,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -167,7 +169,7 @@ class AcceptCaseProposalReceivedUseCase:
 
     def __init__(
         self,
-        dl: DataLayer,
+        dl: CasePersistence,
         request: AcceptCaseProposalReceivedEvent,
     ) -> None:
         self._dl = dl
@@ -228,7 +230,7 @@ class RejectCaseProposalReceivedUseCase:
 
     def __init__(
         self,
-        dl: DataLayer,
+        dl: CasePersistence,
         request: RejectCaseProposalReceivedEvent,
     ) -> None:
         self._dl = dl


### PR DESCRIPTION
- Closes #1385

## Summary

Migrates `AcceptCaseProposalReceivedUseCase` and `RejectCaseProposalReceivedUseCase`
from the broad `DataLayer` port to the narrow `CasePersistence` port, consistent
with DL-03-001/DL-03-002 and all other received-side use cases in the codebase.
Removes the now-unused `DataLayer` import.

## Changes

- `vultron/core/use_cases/received/case_proposal.py`: replace `dl: DataLayer` with
  `dl: CasePersistence` in both `AcceptCaseProposalReceivedUseCase.__init__` and
  `RejectCaseProposalReceivedUseCase.__init__`; remove unused `DataLayer` import;
  consolidate import block for `CaseOutboxPersistence` and `CasePersistence`.

## Verification

- All 4722 unit tests pass (0 new — behavior unchanged, type annotation narrowing only)
- Black, flake8, mypy, pyright all clean