### PR TITLE
feat(#1366): define BtNodePreconditionError exception class

### DIFF
--- a/docs/adr/0032-validate-at-edge-promote-to-core.md
+++ b/docs/adr/0032-validate-at-edge-promote-to-core.md
@@ -114,8 +114,8 @@ no `self.feedback_message` set.
 - Good: eliminates `x or []` / `x or {}` boilerplate at call-sites.
 - Good: aligns BT node helpers with the `dl.read()` precedent.
 - Bad: requires migration of existing code; tracked in #1359 and #1360.
-- Bad: BT node helpers need a custom exception class (`BtNodePreconditionError`
-  or similar) before they can adopt the raise pattern.
+- Good: `BtNodePreconditionError` is now defined in `vultron/errors.py` and
+  importable as `from vultron.errors import BtNodePreconditionError`.
 
 ## Validation
 

--- a/notes/bt-integration.md
+++ b/notes/bt-integration.md
@@ -1061,6 +1061,9 @@ complete successfully or raise a domain exception (e.g.
 `update()` is the single `try/except` handler:
 
 ```python
+from vultron.errors import BtNodePreconditionError
+
+
 def _read_case_obj(self, case_id: str) -> VulnerabilityCase:
     try:
         obj = self.blackboard[case_id]

--- a/plan/history/2607/implementation/ISSUE-1366.md
+++ b/plan/history/2607/implementation/ISSUE-1366.md
@@ -1,0 +1,12 @@
+---
+source: ISSUE-1366
+timestamp: '2026-07-15T15:03:24.086748+00:00'
+title: define BtNodePreconditionError exception class
+type: implementation
+---
+
+## Issue #1366 — feat: define BtNodePreconditionError exception class
+
+Added `BtNodePreconditionError(VultronError)` to `vultron/errors.py` as required by ADR-0032 and `notes/bt-integration.md` BT-HELPER-01. This is the prerequisite exception class for BT node helpers to raise instead of returning `None` on precondition failure (#1360 consumer). Updated ADR-0032 Consequences to mark the class as available. Added 7 tests in `test/test_errors.py` covering inheritance, message preservation, exception chaining, catchability, and the canonical update()-catches-helper BT-HELPER-01 stub pattern.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1438>

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""
+Unit tests for vultron.errors — BtNodePreconditionError.
+
+Spec coverage:
+- ADR-0032 / BT-HELPER-01: BT node helpers raise BtNodePreconditionError
+  instead of returning None; update() is the single try/except handler.
+"""
+
+import pytest
+
+from vultron.errors import BtNodePreconditionError, VultronError
+
+
+def test_bt_node_precondition_error_is_vultron_error():
+    """BtNodePreconditionError must inherit from VultronError (ADR-0032)."""
+    assert issubclass(BtNodePreconditionError, VultronError)
+
+
+def test_bt_node_precondition_error_is_exception():
+    """BtNodePreconditionError must be a standard Exception subclass."""
+    assert issubclass(BtNodePreconditionError, Exception)
+
+
+def test_bt_node_precondition_error_can_be_raised_with_message():
+    """BtNodePreconditionError carries the message string (BT-HELPER-01)."""
+    import re
+
+    msg = "case 'abc' not in blackboard"
+    with pytest.raises(BtNodePreconditionError, match=re.escape(msg)):
+        raise BtNodePreconditionError(msg)
+
+
+def test_bt_node_precondition_error_message_preserved():
+    """str(exc) returns the original message."""
+    msg = "blackboard entry 'x' is not a VulnerabilityCase"
+    try:
+        raise BtNodePreconditionError(msg)
+    except BtNodePreconditionError as exc:
+        assert str(exc) == msg
+
+
+def test_bt_node_precondition_error_is_catchable_as_vultron_error():
+    """BtNodePreconditionError is catchable as VultronError (ADR-0032)."""
+    with pytest.raises(VultronError):
+        raise BtNodePreconditionError("precondition failed")
+
+
+def test_bt_node_precondition_error_supports_chained_cause():
+    """BtNodePreconditionError supports exception chaining via __cause__."""
+    original = KeyError("missing_key")
+    try:
+        raise BtNodePreconditionError("key missing") from original
+    except BtNodePreconditionError as exc:
+        assert exc.__cause__ is original
+
+
+def test_update_catches_bt_node_precondition_error():
+    """update() pattern: helper raises, update() sets feedback_message and returns FAILURE.
+
+    This is the canonical BT-HELPER-01 usage pattern from ADR-0032.
+    The test uses a stub class with a ``feedback_message`` attribute to verify
+    that the catch site assigns ``self.feedback_message = str(e)``, which is
+    the mechanism BT infrastructure uses to surface failure reasons.
+    """
+    from py_trees.common import Status
+
+    class _StubNode:
+        feedback_message: str = ""
+
+        def _helper_that_raises(self) -> str:
+            raise BtNodePreconditionError("case not on blackboard")
+
+        def update(self) -> Status:
+            try:
+                self._helper_that_raises()
+                return Status.SUCCESS
+            except BtNodePreconditionError as e:
+                self.feedback_message = str(e)
+                return Status.FAILURE
+
+    node = _StubNode()
+    status = node.update()
+    assert status == Status.FAILURE
+    assert node.feedback_message == "case not on blackboard"

--- a/vultron/errors.py
+++ b/vultron/errors.py
@@ -169,6 +169,17 @@ class UnroutableActivityError(VultronError):
         super().__init__(f"Activity '{activity_id}' is unroutable: {reason}")
 
 
+class BtNodePreconditionError(VultronError):
+    """Raised by a BT node helper when a required precondition is unmet.
+
+    BT node helper methods (private methods called from ``update()``) MUST
+    raise this exception instead of returning ``None`` when a precondition
+    fails.  ``update()`` is the single ``try/except`` handler that converts
+    the exception to ``Status.FAILURE`` and sets ``self.feedback_message``.
+    See ADR-0032 and ``notes/bt-integration.md`` BT-HELPER-01.
+    """
+
+
 class DemoFailureError(VultronError):
     """Raised when a demo scenario completes with one or more step failures.
 


### PR DESCRIPTION
- Closes #1366

## Summary

Defines `BtNodePreconditionError` in `vultron/errors.py` as required by
ADR-0032 and `notes/bt-integration.md` BT-HELPER-01. This exception is the
prerequisite for BT node helpers to raise instead of returning `None` on
precondition failure (the pattern adopted by #1360).

## Changes

- `vultron/errors.py`: add `BtNodePreconditionError(VultronError)` with docstring
  referencing ADR-0032 and BT-HELPER-01
- `docs/adr/0032-validate-at-edge-promote-to-core.md`: update Consequences bullet
  from "Bad: exception class not yet defined" to "Good: available at
  `vultron.errors.BtNodePreconditionError`"
- `test/test_errors.py`: 7 new tests covering inheritance, message preservation,
  exception chaining, catchability as `VultronError`, and the canonical
  BT-HELPER-01 `update()`-catches-helper pattern via a stub class that asserts
  `self.feedback_message` is set

## Verification

- All 4746 unit tests pass (7 new)
- Black, flake8, mypy, pyright clean