### PR TITLE
feat(#1343): add load_actor_config() to vultron/config/; decouple LocalActorConfig from ActorConfig

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1343.md
+++ b/plan/history/2607/implementation/ISSUE-1343.md
@@ -1,0 +1,13 @@
+---
+source: ISSUE-1343
+timestamp: '2026-07-15T15:17:17.232553+00:00'
+title: add load_actor_config() to vultron/config/; decouple LocalActorConfig
+type: implementation
+---
+
+## Issue #1343 — refactor: add load_actor_config() to vultron/config/ and decouple SeedConfig from ActorConfig
+
+Severed the production dependency on `vultron/demo/` introduced in PR #1331. Added `load_actor_config()` to the neutral `vultron/config/` layer, decoupled `LocalActorConfig` from `ActorConfig`, migrated `SeedConfig` to `BaseSettings`, and updated `inbox_port_factories.py` to use `load_actor_config()` instead of importing `SeedConfig`.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1441>
+Defer issue: #1440 (wire load_actor_config through AppConfig.actor)

--- a/plan/incoming/learnings/20260715-empty-yaml-seed-fallback.md
+++ b/plan/incoming/learnings/20260715-empty-yaml-seed-fallback.md
@@ -1,0 +1,23 @@
+---
+title: "YAML seed config with no local_actor key must fall through to env vars"
+type: learning
+timestamp: "2026-07-15"
+source: ISSUE-1343
+---
+
+When `_actor_config_from_seed_yaml()` reads a YAML that has no `local_actor`
+key, returning `{}` as a default and then validating it produces a valid
+`ActorConfig()` (all defaults). This causes `load_actor_config()` to return
+early, silently ignoring `VULTRON_ACTOR__*` env vars — violating the documented
+resolution order (YAML → env → defaults).
+
+Fix: check `"local_actor" in raw` before calling `model_validate`, and return
+`None` when the key is absent.
+
+**Why:** Pydantic's `model_validate({})` on a model where every field has a
+default does not distinguish "field absent from source" from "field explicitly
+set to default". The distinction has to be enforced at the config-reading layer.
+
+**How to apply:** Any loader that reads a YAML sub-block and falls back to a
+secondary source must check for key presence (not just type), not just validate
+the sub-block. Pattern: `if "key" not in raw: return None`.

--- a/test/adapters/driving/fastapi/test_inbox_handler.py
+++ b/test/adapters/driving/fastapi/test_inbox_handler.py
@@ -502,28 +502,72 @@ def test_inbox_handler_uses_actor_dl_for_queue_pop_and_shared_dl_for_dispatch(
     ), "dispatch must be called with shared dl, not actor_dl"
 
 
-def test_submit_report_port_factory_injects_actor_config(monkeypatch):
-    """_submit_report_port_factory returns actor_config from SeedConfig.
+def test_inbox_port_factories_has_no_demo_import():
+    """inbox_port_factories.py must not import from vultron.demo (AC-2, CFG-07-005)."""
+    import ast
+    import pathlib
 
-    When SeedConfig is available, the factory must include an
+    src = (
+        pathlib.Path(__file__).parents[4]
+        / "vultron"
+        / "adapters"
+        / "driving"
+        / "fastapi"
+        / "inbox_port_factories.py"
+    ).read_text()
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            module = ""
+            if isinstance(node, ast.ImportFrom) and node.module:
+                module = node.module
+            elif isinstance(node, ast.Import):
+                module = ",".join(alias.name for alias in node.names)
+            assert "vultron.demo" not in module, (
+                f"inbox_port_factories.py must not import from vultron.demo; "
+                f"found: {module!r}"
+            )
+
+
+def test_resolve_actor_config_delegates_to_load_actor_config(monkeypatch):
+    """_resolve_actor_config() must call load_actor_config() (AC-2, CFG-07-005).
+
+    The production adapter must not import SeedConfig; instead it delegates
+    to load_actor_config() from vultron.config.
+    """
+    from vultron.config.actor import ActorConfig
+    import vultron.adapters.driving.fastapi.inbox_port_factories as pf
+    import vultron.config.actor as actor_mod
+
+    called = []
+
+    def fake_load_actor_config():
+        called.append(True)
+        return ActorConfig(auto_create_case=False)
+
+    monkeypatch.setattr(actor_mod, "load_actor_config", fake_load_actor_config)
+    # Reload pf so it picks up the patched module reference
+    monkeypatch.setattr(pf, "load_actor_config", fake_load_actor_config)
+
+    result = pf._resolve_actor_config()
+    assert called, "load_actor_config must have been called"
+    assert isinstance(result, ActorConfig)
+    assert result.auto_create_case is False
+
+
+def test_submit_report_port_factory_injects_actor_config(monkeypatch):
+    """_submit_report_port_factory returns actor_config from load_actor_config.
+
+    When load_actor_config() is available, the factory must include an
     ``actor_config`` key so that ``SubmitReportReceivedUseCase`` can
     honour the local actor's ``auto_create_case`` policy (CM-15-001,
     issue #1319).
     """
     from vultron.config.actor import ActorConfig
-    from vultron.demo.seed_config import LocalActorConfig, SeedConfig
     import vultron.adapters.driving.fastapi.inbox_port_factories as pf
 
-    fake_cfg = SeedConfig(
-        local_actor=LocalActorConfig(
-            name="Vendor",
-            actor_type="Organization",
-            auto_create_case=False,
-        )
-    )
-    monkeypatch.setattr(
-        pf, "_resolve_actor_config", lambda: fake_cfg.local_actor
-    )
+    fake_actor_config = ActorConfig(auto_create_case=False)
+    monkeypatch.setattr(pf, "_resolve_actor_config", lambda: fake_actor_config)
 
     real_dl = SqliteDataLayer("sqlite:///:memory:")
     kwargs = pf._submit_report_port_factory(real_dl)
@@ -570,7 +614,6 @@ def test_make_dispatcher_submit_report_uses_actor_config_factory(monkeypatch):
         TriggerActivityAdapter,
     )
     from vultron.config.actor import ActorConfig
-    from vultron.demo.seed_config import LocalActorConfig
     import vultron.adapters.driving.fastapi.inbox_port_factories as pf
 
     captured: dict = {}
@@ -583,9 +626,7 @@ def test_make_dispatcher_submit_report_uses_actor_config_factory(monkeypatch):
     monkeypatch.setattr(
         pf,
         "_resolve_actor_config",
-        lambda: LocalActorConfig(
-            name="Vendor", actor_type="Organization", auto_create_case=False
-        ),
+        lambda: ActorConfig(auto_create_case=False),
     )
 
     ih.make_dispatcher()
@@ -616,11 +657,11 @@ def test_make_dispatcher_ac2_auto_create_false_no_case_via_dispatcher(
     issue #1319).
     """
     from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+    from vultron.config.actor import ActorConfig
     from vultron.core.models.activity import VultronActivity
     from vultron.core.models.case_actor import VultronCaseActor
     from vultron.core.models.events.report import SubmitReportReceivedEvent
     from vultron.core.models.report import VultronReport
-    from vultron.demo.seed_config import LocalActorConfig
     import vultron.adapters.driving.fastapi.inbox_port_factories as pf
 
     VENDOR_ID = "https://example.org/actors/vendor-ac2"
@@ -632,9 +673,7 @@ def test_make_dispatcher_ac2_auto_create_false_no_case_via_dispatcher(
     monkeypatch.setattr(
         pf,
         "_resolve_actor_config",
-        lambda: LocalActorConfig(
-            name="Vendor", actor_type="Organization", auto_create_case=False
-        ),
+        lambda: ActorConfig(auto_create_case=False),
     )
 
     # Build a real dispatcher the same way make_dispatcher() does, but

--- a/test/adapters/driving/fastapi/test_inbox_handler.py
+++ b/test/adapters/driving/fastapi/test_inbox_handler.py
@@ -537,7 +537,7 @@ def test_resolve_actor_config_delegates_to_load_actor_config(monkeypatch):
     """
     from vultron.config.actor import ActorConfig
     import vultron.adapters.driving.fastapi.inbox_port_factories as pf
-    import vultron.config.actor as actor_mod
+    import vultron.config.app as app_mod
 
     called = []
 
@@ -545,8 +545,8 @@ def test_resolve_actor_config_delegates_to_load_actor_config(monkeypatch):
         called.append(True)
         return ActorConfig(auto_create_case=False)
 
-    monkeypatch.setattr(actor_mod, "load_actor_config", fake_load_actor_config)
-    # Reload pf so it picks up the patched module reference
+    monkeypatch.setattr(app_mod, "load_actor_config", fake_load_actor_config)
+    # Patch the name in pf's namespace (imported at module load time)
     monkeypatch.setattr(pf, "load_actor_config", fake_load_actor_config)
 
     result = pf._resolve_actor_config()

--- a/test/core/models/test_actor_config.py
+++ b/test/core/models/test_actor_config.py
@@ -14,17 +14,20 @@
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
 """
-Tests for ActorConfig neutral model.
+Tests for ActorConfig neutral model and load_actor_config().
 
 Spec coverage:
 - CFG-07-001: ActorConfig MUST be defined outside the demo layer.
 - CFG-07-002: ActorConfig MUST include a default_case_roles field
               (list[CVDRole], default empty list).
+- CFG-07-005: load_actor_config() must exist in vultron/config/.
+- CFG-07-007: LocalActorConfig must not extend ActorConfig.
 """
 
+import yaml
 import pytest
 
-from vultron.config.actor import ActorConfig
+from vultron.config.actor import ActorConfig, load_actor_config
 from vultron.enums.roles import CVDRole
 
 # ============================================================================
@@ -120,33 +123,162 @@ def test_actor_config_does_not_mutate_between_uses():
 
 
 # ============================================================================
-# LocalActorConfig composition (CFG-07-003)
+# LocalActorConfig decoupling from ActorConfig (CFG-07-007)
 # ============================================================================
 
 
-def test_local_actor_config_inherits_actor_config():
-    """LocalActorConfig MUST inherit from ActorConfig (CFG-07-003)."""
+def test_local_actor_config_is_plain_base_model():
+    """LocalActorConfig MUST be a plain BaseModel, not a subclass of ActorConfig
+    (CFG-07-007).
+    """
+    from pydantic import BaseModel
+
     from vultron.demo.seed_config import LocalActorConfig
 
-    assert issubclass(LocalActorConfig, ActorConfig)
+    assert issubclass(LocalActorConfig, BaseModel)
+    assert not issubclass(LocalActorConfig, ActorConfig)
 
 
-def test_local_actor_config_has_default_case_roles():
-    """LocalActorConfig exposes default_case_roles from ActorConfig."""
+def test_local_actor_config_has_no_policy_fields():
+    """LocalActorConfig must NOT have auto_create_case or default_case_roles
+    (CFG-07-007).
+    """
     from vultron.demo.seed_config import LocalActorConfig
 
     cfg = LocalActorConfig(name="Test Actor")
-    assert hasattr(cfg, "default_case_roles")
-    assert cfg.default_case_roles == []
+    assert not hasattr(cfg, "auto_create_case")
+    assert not hasattr(cfg, "default_case_roles")
 
 
-def test_local_actor_config_with_roles():
-    """LocalActorConfig accepts default_case_roles alongside actor fields."""
+def test_local_actor_config_identity_fields_only():
+    """LocalActorConfig carries only name, actor_type, and id_ (CFG-07-007)."""
     from vultron.demo.seed_config import LocalActorConfig
 
     cfg = LocalActorConfig(
         name="Coordinator",
-        default_case_roles=[CVDRole.COORDINATOR],
+        actor_type="Service",
+        id="http://coordinator:7999/api/v2/actors/coordinator",
     )
-    assert CVDRole.COORDINATOR in cfg.default_case_roles
     assert cfg.name == "Coordinator"
+    assert cfg.actor_type == "Service"
+    assert cfg.id_ == "http://coordinator:7999/api/v2/actors/coordinator"
+
+
+# ============================================================================
+# load_actor_config() (CFG-07-005)
+# ============================================================================
+
+
+def test_load_actor_config_returns_actor_config():
+    """load_actor_config() MUST return an ActorConfig instance (CFG-07-005)."""
+    cfg = load_actor_config()
+    assert isinstance(cfg, ActorConfig)
+
+
+def test_load_actor_config_defaults(monkeypatch):
+    """load_actor_config() returns defaults when no env vars or file set."""
+    monkeypatch.delenv("VULTRON_SEED_CONFIG", raising=False)
+    monkeypatch.delenv("VULTRON_ACTOR__AUTO_CREATE_CASE", raising=False)
+    monkeypatch.delenv("VULTRON_ACTOR__DEFAULT_CASE_ROLES", raising=False)
+    cfg = load_actor_config()
+    assert cfg.auto_create_case is True
+    assert cfg.default_case_roles == []
+
+
+def test_load_actor_config_reads_auto_create_case_from_env(monkeypatch):
+    """load_actor_config() reads VULTRON_ACTOR__AUTO_CREATE_CASE env var."""
+    monkeypatch.delenv("VULTRON_SEED_CONFIG", raising=False)
+    monkeypatch.setenv("VULTRON_ACTOR__AUTO_CREATE_CASE", "false")
+    monkeypatch.delenv("VULTRON_ACTOR__DEFAULT_CASE_ROLES", raising=False)
+    cfg = load_actor_config()
+    assert cfg.auto_create_case is False
+
+
+def test_load_actor_config_reads_default_case_roles_from_env(monkeypatch):
+    """load_actor_config() reads VULTRON_ACTOR__DEFAULT_CASE_ROLES env var."""
+    monkeypatch.delenv("VULTRON_SEED_CONFIG", raising=False)
+    monkeypatch.delenv("VULTRON_ACTOR__AUTO_CREATE_CASE", raising=False)
+    monkeypatch.setenv("VULTRON_ACTOR__DEFAULT_CASE_ROLES", '["coordinator"]')
+    cfg = load_actor_config()
+    assert CVDRole.COORDINATOR in cfg.default_case_roles
+
+
+def test_load_actor_config_reads_policy_from_seed_yaml(tmp_path, monkeypatch):
+    """load_actor_config() extracts policy fields from VULTRON_SEED_CONFIG YAML."""
+    seed_file = tmp_path / "seed.yaml"
+    data = {
+        "local_actor": {
+            "name": "Vendor",
+            "actor_type": "Organization",
+            "id": "http://vendor:7999/api/v2/actors/vendor",
+            "auto_create_case": False,
+            "default_case_roles": ["coordinator"],
+        }
+    }
+    seed_file.write_text(yaml.dump(data))
+    monkeypatch.setenv("VULTRON_SEED_CONFIG", str(seed_file))
+    monkeypatch.delenv("VULTRON_ACTOR__AUTO_CREATE_CASE", raising=False)
+    monkeypatch.delenv("VULTRON_ACTOR__DEFAULT_CASE_ROLES", raising=False)
+    cfg = load_actor_config()
+    assert cfg.auto_create_case is False
+    assert CVDRole.COORDINATOR in cfg.default_case_roles
+
+
+def test_load_actor_config_ignores_bootstrap_fields_from_yaml(
+    tmp_path, monkeypatch
+):
+    """load_actor_config() ignores name/actor_type/id from YAML (extra=ignore)."""
+    seed_file = tmp_path / "seed.yaml"
+    data = {
+        "local_actor": {
+            "name": "Vendor",
+            "actor_type": "Organization",
+            "id": "http://vendor:7999/api/v2/actors/vendor",
+        }
+    }
+    seed_file.write_text(yaml.dump(data))
+    monkeypatch.setenv("VULTRON_SEED_CONFIG", str(seed_file))
+    monkeypatch.delenv("VULTRON_ACTOR__AUTO_CREATE_CASE", raising=False)
+    monkeypatch.delenv("VULTRON_ACTOR__DEFAULT_CASE_ROLES", raising=False)
+    cfg = load_actor_config()
+    # Bootstrap fields are ignored; policy defaults apply
+    assert cfg.auto_create_case is True
+    assert cfg.default_case_roles == []
+    assert not hasattr(cfg, "name")
+
+
+def test_load_actor_config_falls_back_to_env_when_seed_yaml_missing(
+    tmp_path, monkeypatch
+):
+    """load_actor_config() falls back to env vars when VULTRON_SEED_CONFIG file
+    is missing.
+    """
+    monkeypatch.setenv(
+        "VULTRON_SEED_CONFIG", str(tmp_path / "nonexistent.yaml")
+    )
+    monkeypatch.setenv("VULTRON_ACTOR__AUTO_CREATE_CASE", "false")
+    monkeypatch.delenv("VULTRON_ACTOR__DEFAULT_CASE_ROLES", raising=False)
+    cfg = load_actor_config()
+    assert cfg.auto_create_case is False
+
+
+def test_load_actor_config_falls_back_to_env_when_yaml_has_no_local_actor(
+    tmp_path, monkeypatch
+):
+    """load_actor_config() falls back to env vars when VULTRON_SEED_CONFIG YAML
+    exists but contains no local_actor key (CFG-07-005 resolution order).
+    """
+    seed_file = tmp_path / "seed.yaml"
+    seed_file.write_text(yaml.dump({"peers": []}))
+    monkeypatch.setenv("VULTRON_SEED_CONFIG", str(seed_file))
+    monkeypatch.setenv("VULTRON_ACTOR__AUTO_CREATE_CASE", "false")
+    monkeypatch.delenv("VULTRON_ACTOR__DEFAULT_CASE_ROLES", raising=False)
+    cfg = load_actor_config()
+    assert cfg.auto_create_case is False
+
+
+def test_load_actor_config_exported_from_config_package():
+    """load_actor_config MUST be importable from vultron.config (CFG-07-005)."""
+    from vultron.config import load_actor_config as lac
+
+    assert callable(lac)

--- a/test/core/models/test_actor_config.py
+++ b/test/core/models/test_actor_config.py
@@ -27,8 +27,16 @@ Spec coverage:
 import yaml
 import pytest
 
-from vultron.config.actor import ActorConfig, load_actor_config
+from vultron.config.actor import ActorConfig
+from vultron.config.app import load_actor_config, reload_config
 from vultron.enums.roles import CVDRole
+
+
+@pytest.fixture(autouse=True)
+def _reset_config_cache():
+    yield
+    reload_config()
+
 
 # ============================================================================
 # Basic model tests (CFG-07-001, CFG-07-002)
@@ -177,9 +185,10 @@ def test_load_actor_config_returns_actor_config():
 
 def test_load_actor_config_defaults(monkeypatch):
     """load_actor_config() returns defaults when no env vars or file set."""
-    monkeypatch.delenv("VULTRON_SEED_CONFIG", raising=False)
+    monkeypatch.delenv("VULTRON_CONFIG", raising=False)
     monkeypatch.delenv("VULTRON_ACTOR__AUTO_CREATE_CASE", raising=False)
     monkeypatch.delenv("VULTRON_ACTOR__DEFAULT_CASE_ROLES", raising=False)
+    reload_config()
     cfg = load_actor_config()
     assert cfg.auto_create_case is True
     assert cfg.default_case_roles == []
@@ -187,94 +196,43 @@ def test_load_actor_config_defaults(monkeypatch):
 
 def test_load_actor_config_reads_auto_create_case_from_env(monkeypatch):
     """load_actor_config() reads VULTRON_ACTOR__AUTO_CREATE_CASE env var."""
-    monkeypatch.delenv("VULTRON_SEED_CONFIG", raising=False)
+    monkeypatch.delenv("VULTRON_CONFIG", raising=False)
     monkeypatch.setenv("VULTRON_ACTOR__AUTO_CREATE_CASE", "false")
     monkeypatch.delenv("VULTRON_ACTOR__DEFAULT_CASE_ROLES", raising=False)
+    reload_config()
     cfg = load_actor_config()
     assert cfg.auto_create_case is False
 
 
 def test_load_actor_config_reads_default_case_roles_from_env(monkeypatch):
     """load_actor_config() reads VULTRON_ACTOR__DEFAULT_CASE_ROLES env var."""
-    monkeypatch.delenv("VULTRON_SEED_CONFIG", raising=False)
+    monkeypatch.delenv("VULTRON_CONFIG", raising=False)
     monkeypatch.delenv("VULTRON_ACTOR__AUTO_CREATE_CASE", raising=False)
     monkeypatch.setenv("VULTRON_ACTOR__DEFAULT_CASE_ROLES", '["coordinator"]')
+    reload_config()
     cfg = load_actor_config()
     assert CVDRole.COORDINATOR in cfg.default_case_roles
 
 
-def test_load_actor_config_reads_policy_from_seed_yaml(tmp_path, monkeypatch):
-    """load_actor_config() extracts policy fields from VULTRON_SEED_CONFIG YAML."""
-    seed_file = tmp_path / "seed.yaml"
+def test_load_actor_config_reads_policy_from_vultron_config_yaml(
+    tmp_path, monkeypatch
+):
+    """load_actor_config() reads actor policy from the VULTRON_CONFIG YAML."""
+    config_file = tmp_path / "config.yaml"
     data = {
-        "local_actor": {
-            "name": "Vendor",
-            "actor_type": "Organization",
-            "id": "http://vendor:7999/api/v2/actors/vendor",
+        "actor": {
             "auto_create_case": False,
             "default_case_roles": ["coordinator"],
         }
     }
-    seed_file.write_text(yaml.dump(data))
-    monkeypatch.setenv("VULTRON_SEED_CONFIG", str(seed_file))
+    config_file.write_text(yaml.dump(data))
+    monkeypatch.setenv("VULTRON_CONFIG", str(config_file))
     monkeypatch.delenv("VULTRON_ACTOR__AUTO_CREATE_CASE", raising=False)
     monkeypatch.delenv("VULTRON_ACTOR__DEFAULT_CASE_ROLES", raising=False)
+    reload_config()
     cfg = load_actor_config()
     assert cfg.auto_create_case is False
     assert CVDRole.COORDINATOR in cfg.default_case_roles
-
-
-def test_load_actor_config_ignores_bootstrap_fields_from_yaml(
-    tmp_path, monkeypatch
-):
-    """load_actor_config() ignores name/actor_type/id from YAML (extra=ignore)."""
-    seed_file = tmp_path / "seed.yaml"
-    data = {
-        "local_actor": {
-            "name": "Vendor",
-            "actor_type": "Organization",
-            "id": "http://vendor:7999/api/v2/actors/vendor",
-        }
-    }
-    seed_file.write_text(yaml.dump(data))
-    monkeypatch.setenv("VULTRON_SEED_CONFIG", str(seed_file))
-    monkeypatch.delenv("VULTRON_ACTOR__AUTO_CREATE_CASE", raising=False)
-    monkeypatch.delenv("VULTRON_ACTOR__DEFAULT_CASE_ROLES", raising=False)
-    cfg = load_actor_config()
-    # Bootstrap fields are ignored; policy defaults apply
-    assert cfg.auto_create_case is True
-    assert cfg.default_case_roles == []
-    assert not hasattr(cfg, "name")
-
-
-def test_load_actor_config_falls_back_to_env_when_seed_yaml_missing(
-    tmp_path, monkeypatch
-):
-    """load_actor_config() falls back to env vars when VULTRON_SEED_CONFIG file
-    is missing.
-    """
-    monkeypatch.setenv(
-        "VULTRON_SEED_CONFIG", str(tmp_path / "nonexistent.yaml")
-    )
-    monkeypatch.setenv("VULTRON_ACTOR__AUTO_CREATE_CASE", "false")
-    monkeypatch.delenv("VULTRON_ACTOR__DEFAULT_CASE_ROLES", raising=False)
-    cfg = load_actor_config()
-    assert cfg.auto_create_case is False
-
-
-def test_load_actor_config_falls_back_to_env_when_yaml_has_no_local_actor(
-    tmp_path, monkeypatch
-):
-    """load_actor_config() falls back to env vars when VULTRON_SEED_CONFIG YAML
-    exists but contains no local_actor key (CFG-07-005 resolution order).
-    """
-    seed_file = tmp_path / "seed.yaml"
-    seed_file.write_text(yaml.dump({"peers": []}))
-    monkeypatch.setenv("VULTRON_SEED_CONFIG", str(seed_file))
-    monkeypatch.setenv("VULTRON_ACTOR__AUTO_CREATE_CASE", "false")
-    monkeypatch.delenv("VULTRON_ACTOR__DEFAULT_CASE_ROLES", raising=False)
-    cfg = load_actor_config()
-    assert cfg.auto_create_case is False
 
 
 def test_load_actor_config_exported_from_config_package():

--- a/vultron/adapters/driving/fastapi/inbox_port_factories.py
+++ b/vultron/adapters/driving/fastapi/inbox_port_factories.py
@@ -26,7 +26,8 @@ to inject adapter ports into use cases at dispatch time.
 import logging
 from typing import Any, cast
 
-from vultron.config.actor import ActorConfig, load_actor_config
+from vultron.config.actor import ActorConfig
+from vultron.config.app import load_actor_config
 from vultron.core.models.events import MessageSemantics
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.ports.datalayer import DataLayer

--- a/vultron/adapters/driving/fastapi/inbox_port_factories.py
+++ b/vultron/adapters/driving/fastapi/inbox_port_factories.py
@@ -24,41 +24,29 @@ to inject adapter ports into use cases at dispatch time.
 #  in the U.S. Patent and Trademark Office by Carnegie Mellon University
 
 import logging
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 
-import yaml
-from pydantic import ValidationError
-
+from vultron.config.actor import ActorConfig, load_actor_config
 from vultron.core.models.events import MessageSemantics
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.ports.datalayer import DataLayer
-from vultron.demo.seed_config import SeedConfig
-
-if TYPE_CHECKING:
-    from vultron.config.actor import ActorConfig
 
 logger = logging.getLogger(__name__)
 
 
-def _resolve_actor_config() -> "ActorConfig | None":
-    """Load the local actor's ``ActorConfig`` from ``SeedConfig``.
+def _resolve_actor_config() -> ActorConfig | None:
+    """Load the local actor's ``ActorConfig`` via :func:`load_actor_config`.
 
-    Reads ``VULTRON_SEED_CONFIG`` (path) or the individual
-    ``VULTRON_ACTOR_*`` env vars via :func:`~vultron.demo.seed_config.SeedConfig.load`.
-    Returns ``None`` on any load error so callers fall through to the
-    always-create default (CM-15-001).
+    Reads actor policy from ``VULTRON_SEED_CONFIG`` YAML or
+    ``VULTRON_ACTOR__*`` env vars (CFG-07-005).  Returns ``None`` on any
+    load error so callers fall through to the always-create default
+    (CM-15-001).
     """
     try:
-        return SeedConfig.load().local_actor
-    except (
-        FileNotFoundError,
-        KeyError,
-        ValueError,
-        ValidationError,
-        yaml.YAMLError,
-    ):
+        return load_actor_config()
+    except Exception:
         logger.debug(
-            "_resolve_actor_config: SeedConfig unavailable — "
+            "_resolve_actor_config: load_actor_config failed — "
             "defaulting to auto_create_case=True",
             exc_info=True,
         )

--- a/vultron/config/__init__.py
+++ b/vultron/config/__init__.py
@@ -38,7 +38,7 @@ Environment variables
     Override :attr:`AppConfig.mode` (``prototype`` or ``prod``).
 """
 
-from vultron.config.actor import ActorConfig
+from vultron.config.actor import ActorConfig, load_actor_config
 from vultron.config.app import (
     AppConfig,
     DatabaseConfig,
@@ -57,5 +57,6 @@ __all__ = [
     "ServerConfig",
     "YamlConfigSource",
     "get_config",
+    "load_actor_config",
     "reload_config",
 ]

--- a/vultron/config/__init__.py
+++ b/vultron/config/__init__.py
@@ -38,7 +38,7 @@ Environment variables
     Override :attr:`AppConfig.mode` (``prototype`` or ``prod``).
 """
 
-from vultron.config.actor import ActorConfig, load_actor_config
+from vultron.config.actor import ActorConfig
 from vultron.config.app import (
     AppConfig,
     DatabaseConfig,
@@ -46,6 +46,7 @@ from vultron.config.app import (
     ServerConfig,
     YamlConfigSource,
     get_config,
+    load_actor_config,
     reload_config,
 )
 

--- a/vultron/config/actor.py
+++ b/vultron/config/actor.py
@@ -25,9 +25,23 @@ defaults for the local actor without importing from the demo or adapter layers.
 Per ``specs/configuration.yaml`` CFG-07-001, CFG-07-002, CFG-07-005, CFG-07-006.
 """
 
-from pydantic import BaseModel, Field, field_serializer, field_validator
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import (
+    BaseModel,
+    Field,
+    field_serializer,
+    field_validator,
+)
 
 from vultron.enums.roles import CVDRole, serialize_roles, validate_roles
+
+logger = logging.getLogger(__name__)
 
 
 class ActorConfig(BaseModel):
@@ -68,3 +82,85 @@ class ActorConfig(BaseModel):
     @classmethod
     def _validate_default_case_roles(cls, value: object) -> list[CVDRole]:
         return validate_roles(value)
+
+
+def _actor_config_from_seed_yaml(path: str) -> ActorConfig | None:
+    """Extract actor policy fields from a seed YAML file.
+
+    Reads the ``local_actor`` block from the YAML and constructs an
+    :class:`ActorConfig` using only the policy fields it recognises,
+    discarding bootstrap-only fields (``name``, ``actor_type``, ``id``)
+    via ``extra="ignore"`` (CFG-07-005).
+
+    Returns ``None`` if the file is missing or unparseable.
+    """
+    p = Path(path)
+    if not p.exists():
+        logger.debug("_actor_config_from_seed_yaml: file not found: %s", path)
+        return None
+    try:
+        with p.open() as fh:
+            raw: Any = yaml.safe_load(fh) or {}
+        if not isinstance(raw, dict) or "local_actor" not in raw:
+            return None
+        local_actor_data: Any = raw["local_actor"]
+        if not isinstance(local_actor_data, dict):
+            return None
+        return ActorConfig.model_validate(local_actor_data, strict=False)
+    except Exception as exc:
+        logger.debug(
+            "_actor_config_from_seed_yaml: could not parse %s: %s", path, exc
+        )
+        return None
+
+
+def _actor_config_from_env() -> ActorConfig:
+    """Build an :class:`ActorConfig` from ``VULTRON_ACTOR__*`` env vars.
+
+    Reads ``VULTRON_ACTOR__AUTO_CREATE_CASE`` and
+    ``VULTRON_ACTOR__DEFAULT_CASE_ROLES`` with their documented defaults.
+    """
+    raw: dict[str, Any] = {}
+    auto_create = os.environ.get("VULTRON_ACTOR__AUTO_CREATE_CASE")
+    if auto_create is not None:
+        raw["auto_create_case"] = auto_create.lower() not in (
+            "false",
+            "0",
+            "no",
+        )
+    default_roles = os.environ.get("VULTRON_ACTOR__DEFAULT_CASE_ROLES")
+    if default_roles is not None:
+        try:
+            raw["default_case_roles"] = json.loads(default_roles)
+        except json.JSONDecodeError:
+            # Treat as a comma-separated list
+            raw["default_case_roles"] = [
+                r.strip() for r in default_roles.split(",") if r.strip()
+            ]
+    return ActorConfig.model_validate(raw)
+
+
+def load_actor_config() -> ActorConfig:
+    """Load the local actor's policy :class:`ActorConfig`.
+
+    Resolution order (CFG-07-005):
+
+    1. ``VULTRON_SEED_CONFIG`` YAML — reads the ``local_actor`` block,
+       extracting only policy fields and ignoring bootstrap-only fields
+       (``name``, ``actor_type``, ``id``).
+    2. ``VULTRON_ACTOR__*`` environment variables.
+    3. Hard-coded defaults (``auto_create_case=True``,
+       ``default_case_roles=[]``).
+
+    Production adapter modules MUST call this function instead of importing
+    from ``vultron.demo`` to obtain actor policy configuration (CFG-07-005).
+
+    Returns:
+        An :class:`ActorConfig` populated from the available sources.
+    """
+    seed_path = os.environ.get("VULTRON_SEED_CONFIG")
+    if seed_path:
+        cfg = _actor_config_from_seed_yaml(seed_path)
+        if cfg is not None:
+            return cfg
+    return _actor_config_from_env()

--- a/vultron/config/actor.py
+++ b/vultron/config/actor.py
@@ -25,13 +25,6 @@ defaults for the local actor without importing from the demo or adapter layers.
 Per ``specs/configuration.yaml`` CFG-07-001, CFG-07-002, CFG-07-005, CFG-07-006.
 """
 
-import json
-import logging
-import os
-from pathlib import Path
-from typing import Any
-
-import yaml
 from pydantic import (
     BaseModel,
     Field,
@@ -40,8 +33,6 @@ from pydantic import (
 )
 
 from vultron.enums.roles import CVDRole, serialize_roles, validate_roles
-
-logger = logging.getLogger(__name__)
 
 
 class ActorConfig(BaseModel):
@@ -82,85 +73,3 @@ class ActorConfig(BaseModel):
     @classmethod
     def _validate_default_case_roles(cls, value: object) -> list[CVDRole]:
         return validate_roles(value)
-
-
-def _actor_config_from_seed_yaml(path: str) -> ActorConfig | None:
-    """Extract actor policy fields from a seed YAML file.
-
-    Reads the ``local_actor`` block from the YAML and constructs an
-    :class:`ActorConfig` using only the policy fields it recognises,
-    discarding bootstrap-only fields (``name``, ``actor_type``, ``id``)
-    via ``extra="ignore"`` (CFG-07-005).
-
-    Returns ``None`` if the file is missing or unparseable.
-    """
-    p = Path(path)
-    if not p.exists():
-        logger.debug("_actor_config_from_seed_yaml: file not found: %s", path)
-        return None
-    try:
-        with p.open() as fh:
-            raw: Any = yaml.safe_load(fh) or {}
-        if not isinstance(raw, dict) or "local_actor" not in raw:
-            return None
-        local_actor_data: Any = raw["local_actor"]
-        if not isinstance(local_actor_data, dict):
-            return None
-        return ActorConfig.model_validate(local_actor_data, strict=False)
-    except Exception as exc:
-        logger.debug(
-            "_actor_config_from_seed_yaml: could not parse %s: %s", path, exc
-        )
-        return None
-
-
-def _actor_config_from_env() -> ActorConfig:
-    """Build an :class:`ActorConfig` from ``VULTRON_ACTOR__*`` env vars.
-
-    Reads ``VULTRON_ACTOR__AUTO_CREATE_CASE`` and
-    ``VULTRON_ACTOR__DEFAULT_CASE_ROLES`` with their documented defaults.
-    """
-    raw: dict[str, Any] = {}
-    auto_create = os.environ.get("VULTRON_ACTOR__AUTO_CREATE_CASE")
-    if auto_create is not None:
-        raw["auto_create_case"] = auto_create.lower() not in (
-            "false",
-            "0",
-            "no",
-        )
-    default_roles = os.environ.get("VULTRON_ACTOR__DEFAULT_CASE_ROLES")
-    if default_roles is not None:
-        try:
-            raw["default_case_roles"] = json.loads(default_roles)
-        except json.JSONDecodeError:
-            # Treat as a comma-separated list
-            raw["default_case_roles"] = [
-                r.strip() for r in default_roles.split(",") if r.strip()
-            ]
-    return ActorConfig.model_validate(raw)
-
-
-def load_actor_config() -> ActorConfig:
-    """Load the local actor's policy :class:`ActorConfig`.
-
-    Resolution order (CFG-07-005):
-
-    1. ``VULTRON_SEED_CONFIG`` YAML — reads the ``local_actor`` block,
-       extracting only policy fields and ignoring bootstrap-only fields
-       (``name``, ``actor_type``, ``id``).
-    2. ``VULTRON_ACTOR__*`` environment variables.
-    3. Hard-coded defaults (``auto_create_case=True``,
-       ``default_case_roles=[]``).
-
-    Production adapter modules MUST call this function instead of importing
-    from ``vultron.demo`` to obtain actor policy configuration (CFG-07-005).
-
-    Returns:
-        An :class:`ActorConfig` populated from the available sources.
-    """
-    seed_path = os.environ.get("VULTRON_SEED_CONFIG")
-    if seed_path:
-        cfg = _actor_config_from_seed_yaml(seed_path)
-        if cfg is not None:
-            return cfg
-    return _actor_config_from_env()

--- a/vultron/config/app.py
+++ b/vultron/config/app.py
@@ -202,6 +202,28 @@ def get_config() -> AppConfig:
     return _config_cache
 
 
+def load_actor_config() -> ActorConfig:
+    """Return the local actor's policy :class:`~vultron.config.actor.ActorConfig`.
+
+    Delegates to :func:`get_config` so actor policy is read from the same
+    unified config as all other application settings (CFG-07-005).
+
+    Configuration sources, in decreasing priority:
+
+    1. ``VULTRON_ACTOR__AUTO_CREATE_CASE`` / ``VULTRON_ACTOR__DEFAULT_CASE_ROLES``
+       environment variables.
+    2. ``actor:`` section in the YAML file at ``VULTRON_CONFIG``
+       (default: ``config.yaml``).
+    3. Hard-coded defaults (``auto_create_case=True``,
+       ``default_case_roles=[]``).
+
+    Returns:
+        The :class:`~vultron.config.actor.ActorConfig` from the active
+        :class:`AppConfig`.
+    """
+    return get_config().actor
+
+
 def reload_config() -> AppConfig:
     """Clear the cached config and return a freshly loaded :class:`AppConfig`.
 

--- a/vultron/demo/seed_config.py
+++ b/vultron/demo/seed_config.py
@@ -35,12 +35,11 @@ Environment variables
 """
 
 import os
-from typing import Literal, cast
+from typing import Any, Literal
 
 import yaml
 from pydantic import BaseModel, Field
-
-from vultron.config.actor import ActorConfig
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource
 
 #: Valid ActivityStreams actor type strings accepted by the seed command.
 ActorType = Literal[
@@ -48,8 +47,16 @@ ActorType = Literal[
 ]
 
 
-class LocalActorConfig(ActorConfig):
-    """Configuration for the local actor record to create on startup."""
+class LocalActorConfig(BaseModel):
+    """Bootstrap identity configuration for the local actor (CFG-07-007).
+
+    Carries only the fields needed to seed the actor record in the DataLayer:
+    display name, ActivityStreams actor type, and optional actor URI.
+
+    Actor policy fields (``auto_create_case``, ``default_case_roles``) are
+    **not** included here — they belong in ``AppConfig.actor`` and are
+    read via :func:`vultron.config.actor.load_actor_config` (CFG-07-007).
+    """
 
     name: str = Field(description="Display name of the local actor.")
     actor_type: ActorType = Field(
@@ -84,11 +91,35 @@ class PeerActorConfig(BaseModel):
     model_config = {"populate_by_name": True}
 
 
-class SeedConfig(BaseModel):
+class _SeedYamlSource(PydanticBaseSettingsSource):
+    """``pydantic-settings`` source that loads from ``VULTRON_SEED_CONFIG`` YAML."""
+
+    def __call__(self) -> dict[str, Any]:
+        path = os.environ.get("VULTRON_SEED_CONFIG")
+        if not path:
+            return {}
+        try:
+            with open(path) as fh:
+                return yaml.safe_load(fh) or {}
+        except (FileNotFoundError, yaml.YAMLError):
+            return {}
+
+    def get_field_value(
+        self, field: Any, field_name: str
+    ) -> tuple[Any, str, bool]:
+        data = self()
+        return data.get(field_name), field_name, False
+
+
+class SeedConfig(BaseSettings):
     """Complete seed configuration: one local actor plus zero or more peers.
 
-    Can be loaded from a YAML file whose top-level keys are ``local_actor``
-    and ``peers``::
+    Loaded (in decreasing priority) from:
+
+    1. A YAML file at the path given by ``VULTRON_SEED_CONFIG``.
+    2. ``pydantic-settings`` init kwargs (for programmatic construction).
+
+    The YAML schema uses top-level keys ``local_actor`` and ``peers``::
 
         local_actor:
           name: Finder
@@ -98,10 +129,33 @@ class SeedConfig(BaseModel):
           - name: Vendor
             actor_type: Organization
             id: http://vendor:7999/api/v2/actors/vendor-uuid
+
+    .. deprecated::
+        ``from_env()`` and ``from_file()`` class methods are kept for
+        backward compatibility but will be removed in a future release.
+        Construct ``SeedConfig()`` directly (env vars are read automatically)
+        or pass kwargs to the constructor.
     """
 
-    local_actor: LocalActorConfig
+    local_actor: LocalActorConfig = Field(
+        default_factory=lambda: LocalActorConfig(name="Vultron Actor")
+    )
     peers: list[PeerActorConfig] = Field(default_factory=list)
+
+    model_config = {"populate_by_name": True}
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        # Precedence: YAML file < init kwargs.
+        # init_settings wins so that explicit construction args take priority.
+        return (init_settings, _SeedYamlSource(settings_cls))
 
     @classmethod
     def from_env(
@@ -114,6 +168,10 @@ class SeedConfig(BaseModel):
 
         Explicit arguments take precedence over environment variables.
 
+        .. deprecated::
+            Use ``SeedConfig()`` directly. ``pydantic-settings`` reads env
+            vars automatically.
+
         Args:
             actor_name: Local actor display name.  Falls back to
                 ``VULTRON_ACTOR_NAME`` env var (default: ``"Vultron Actor"``).
@@ -122,6 +180,8 @@ class SeedConfig(BaseModel):
             actor_id: Optional full URI for the local actor.  Falls back to
                 ``VULTRON_ACTOR_ID`` env var.
         """
+        from typing import cast
+
         name = actor_name or os.environ.get(
             "VULTRON_ACTOR_NAME", "Vultron Actor"
         )
@@ -140,6 +200,10 @@ class SeedConfig(BaseModel):
     @classmethod
     def from_file(cls, path: str) -> "SeedConfig":
         """Load a SeedConfig from a YAML file.
+
+        .. deprecated::
+            Set ``VULTRON_SEED_CONFIG=<path>`` and use ``SeedConfig()``
+            directly.
 
         Args:
             path: Filesystem path to the YAML seed config file.
@@ -160,11 +224,15 @@ class SeedConfig(BaseModel):
         actor_type: str | None = None,
         actor_id: str | None = None,
     ) -> "SeedConfig":
-        """Load a SeedConfig from a JSON file or environment variables.
+        """Load a SeedConfig from a YAML file or environment variables.
 
         If ``config_path`` is given (or ``VULTRON_SEED_CONFIG`` env var is
         set), the YAML file takes precedence.  Otherwise, configuration is
         assembled from env vars and any explicit keyword arguments.
+
+        .. deprecated::
+            Set ``VULTRON_SEED_CONFIG`` and use ``SeedConfig()`` directly,
+            or pass kwargs to the constructor.
 
         Args:
             config_path: Path to YAML seed config file.


### PR DESCRIPTION
- Closes #1343
- Closes #1440

## Summary

Severs the production dependency on `vultron/demo/` introduced in PR #1331, and completes the architectural fix by wiring `load_actor_config()` through `AppConfig.actor`.

`inbox_port_factories.py` previously imported `SeedConfig` from `vultron.demo` to obtain actor policy — violating hexagonal architecture. This PR routes actor policy through the neutral `vultron/config/` layer via `AppConfig`, making the `actor:` section in `config.yaml` (and `VULTRON_ACTOR__*` env vars) the single source of truth.

## Changes

- `vultron/config/actor.py`: `ActorConfig` model only — standalone helpers removed
- `vultron/config/app.py`: Add `load_actor_config()` as a thin wrapper over `get_config().actor`
- `vultron/config/__init__.py`: Export `load_actor_config` from `app`
- `vultron/demo/seed_config.py`: Decouple `LocalActorConfig` from `ActorConfig` (plain `BaseModel`, identity fields only); migrate `SeedConfig` to `BaseSettings`; keep deprecated `from_env`/`from_file`/`load`
- `vultron/adapters/driving/fastapi/inbox_port_factories.py`: Import `load_actor_config` from `vultron.config.app`; no `vultron.demo` import
- `test/core/models/test_actor_config.py`: CFG-07-007 decoupling tests; `load_actor_config()` tests via `VULTRON_CONFIG` YAML and env vars
- `test/adapters/driving/fastapi/test_inbox_handler.py`: Architecture test asserting no `vultron.demo` import; updated mock targets

## Verification

- 4742 unit tests pass
- Black, flake8, mypy, pyright all clean