### PR TITLE
refactor(core): replace getattr case_roles reads with .roles property (PRM-01-003)

### DIFF
--- a/notes/participant-role-management.md
+++ b/notes/participant-role-management.md
@@ -26,6 +26,7 @@ relevant_packages:
 | Should `CaseParticipant` match the `VultronParticipant` interface? | Yes — full parity | Callers should not need to know which class they hold to manage roles |
 | Should wire-layer `model_validator` role inits use `add_role()`? | Yes | Routes all role mutations through the single invariant-check point |
 | Should an architecture test enforce the no-direct-mutation rule? | Yes, with ≤1 s budget | Machine-checkable enforcement; targeted scan stays fast |
+| Should an architecture test enforce the no-direct-read rule (`getattr(*, "case_roles")`)? | Yes — `test_no_getattr_case_roles_read_in_core()` added in PR #1443 | Complements the mutation ratchet; enforces PRM-01-003 |
 
 ---
 

--- a/plan/history/2607/implementation/ISSUE-1388.md
+++ b/plan/history/2607/implementation/ISSUE-1388.md
@@ -1,0 +1,19 @@
+---
+source: ISSUE-1388
+timestamp: '2026-07-15T15:32:34.056156+00:00'
+title: 'refactor: replace getattr case_roles reads with .roles property in core'
+type: implementation
+---
+
+## Issue #1388 — refactor: replace direct case_roles getattr() reads with .roles property in core (PRM-01-003)
+
+Replaced all 8 `getattr(x, "case_roles", [])` call sites in `vultron/core/` with `.roles` property access or `is_participant_model()` guards per PRM-01-003. Added architecture ratchet test `test_no_getattr_case_roles_read_in_core()` to prevent regression.
+
+Key decisions:
+
+- `common.py` uses `getattr(existing, "roles", [])` not `existing.roles` because `existing` is typed `Any` and the `is not None` narrowing causes pyright error at `dl.save(existing)` downstream
+- `case_manager_role.py` extracted `_find_reporter_id` helper to reduce complexity under C901 gate; the helper includes `case_participants` fallback (matching `_resolve_case_manager_id` pattern) so bootstrap trust is not skipped when `actor_participant_index` is unpopulated
+- `status.py`: consistent `is_participant_model()` guard for both `participant_roles` and `raw_consent` extraction
+
+PR: <https://github.com/CERTCC/Vultron/pull/1443>
+4740 unit tests pass; black/flake8/mypy/pyright clean.

--- a/test/architecture/test_participant_case_roles.py
+++ b/test/architecture/test_participant_case_roles.py
@@ -1,11 +1,11 @@
-"""Architecture test: no direct case_roles mutation outside participant.py (PRM-05-004)."""
+"""Architecture tests: case_roles access discipline in core (PRM-05-004, PRM-01-003)."""
 
 import re
 from pathlib import Path
 
 # vultron/core/ root
 _CORE_ROOT = Path(__file__).parents[2] / "vultron" / "core"
-# The modules that are permitted to mutate case_roles directly
+# The modules that are permitted to access case_roles directly
 _ALLOWED_MODULES = frozenset(
     [
         _CORE_ROOT / "models" / "participant.py",
@@ -17,6 +17,10 @@ _ALLOWED_MODULES = frozenset(
 #   .case_roles = ...   (attribute assignment)
 #   .case_roles.append  (in-place list mutation)
 _MUTATION_RE = re.compile(r"\.case_roles\s*=|\.case_roles\s*\.\s*append")
+
+# Pattern that indicates a direct getattr read of case_roles:
+#   getattr(..., "case_roles", ...)  or  getattr(..., 'case_roles', ...)
+_GETATTR_READ_RE = re.compile(r"""getattr\s*\([^)]+,\s*['"]case_roles['"]""")
 
 
 def test_no_direct_case_roles_mutation_in_core():
@@ -37,5 +41,29 @@ def test_no_direct_case_roles_mutation_in_core():
                 )
     assert not violations, (
         "Direct case_roles mutation found in vultron/core/ outside participant.py:\n"
+        + "\n".join(violations)
+    )
+
+
+def test_no_getattr_case_roles_read_in_core():
+    """No core file outside participant.py may read case_roles via getattr() (PRM-01-003).
+
+    Use ``participant.roles`` (property) or ``participant.has_role(role)`` instead.
+    Constructor keyword-argument form (``case_roles=...``) is permitted and is
+    NOT flagged because it lacks the leading ``getattr(`` wrapper.
+    """
+    violations: list[str] = []
+    for py_file in sorted(_CORE_ROOT.rglob("*.py")):
+        if py_file in _ALLOWED_MODULES:
+            continue
+        text = py_file.read_text()
+        for lineno, line in enumerate(text.splitlines(), 1):
+            if _GETATTR_READ_RE.search(line):
+                violations.append(
+                    f"{py_file.relative_to(_CORE_ROOT)}:{lineno}: {line.strip()}"
+                )
+    assert not violations, (
+        "getattr() read of case_roles found in vultron/core/ outside participant.py "
+        "(use .roles or .has_role() instead — PRM-01-003):\n"
         + "\n".join(violations)
     )

--- a/test/core/use_cases/received/actor/test_case_manager_role.py
+++ b/test/core/use_cases/received/actor/test_case_manager_role.py
@@ -229,6 +229,58 @@ class TestCaseManagerRoleDelegationUseCases:
             len(call_kwargs.args) >= 3 and reporter_id in call_kwargs.args
         )
 
+    def test_accept_case_manager_role_bootstrap_via_case_participants_fallback(
+        self, make_payload
+    ):
+        """_find_reporter_id fallback: uses case_participants when index is empty."""
+        from unittest.mock import MagicMock, patch
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+        from vultron.core.models.vultron_types import VultronParticipant
+        from vultron.enums.roles import CVDRole
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            VulnerabilityCase,
+        )
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        reporter_id = "https://example.org/actors/reporter"
+        reporter_participant_id = f"{self._CASE_URI}/participants/reporter"
+        reporter_participant = VultronParticipant(
+            id_=reporter_participant_id,
+            attributed_to=reporter_id,
+            context=self._CASE_URI,
+            name="Reporter",
+            case_roles=[CVDRole.FINDER, CVDRole.REPORTER],
+        )
+        case = VulnerabilityCase(id_=self._CASE_URI, name="FALLBACK-TEST")
+        # Populate only case_participants; leave actor_participant_index empty
+        # (bootstrap path — index not yet populated).
+        case.case_participants.append(reporter_participant_id)  # type: ignore[arg-type]
+        dl.create(reporter_participant)
+        dl.create(case)
+
+        offer = self._make_offer()
+        accept = accept_case_manager_role_activity(
+            offer, actor=self._CASE_ACTOR_URI
+        )
+        event = make_payload(accept, receiving_actor_id=self._VENDOR_URI)
+
+        trigger = MagicMock()
+        trigger.create_case.return_value = (
+            "https://example.org/activities/create-fallback",
+            {},
+        )
+
+        with patch("vultron.core.use_cases._helpers.add_activity_to_outbox"):
+            AcceptCaseManagerRoleReceivedUseCase(
+                dl, event, trigger_activity=trigger
+            ).execute()
+
+        trigger.create_case.assert_called_once()
+        call_kwargs = trigger.create_case.call_args
+        assert call_kwargs.kwargs.get("to") == [reporter_id] or (
+            len(call_kwargs.args) >= 3 and reporter_id in call_kwargs.args
+        )
+
     def test_accept_case_manager_role_no_bootstrap_without_trigger(
         self, make_payload
     ):

--- a/vultron/core/behaviors/case/nodes/participant/common.py
+++ b/vultron/core/behaviors/case/nodes/participant/common.py
@@ -386,7 +386,7 @@ def _upgrade_participant_to_accepted(
         em_consent_state=coerce_em_consent_state(
             getattr(existing, "embargo_consent_state", None)
         ),
-        cvd_role=coerce_cvd_roles(getattr(existing, "case_roles", [])),
+        cvd_role=coerce_cvd_roles(getattr(existing, "roles", [])),
     )
     try:
         dl.create(upgrade_status)

--- a/vultron/core/behaviors/case/nodes/participant/status.py
+++ b/vultron/core/behaviors/case/nodes/participant/status.py
@@ -27,7 +27,7 @@ from vultron.core.models.participant_status import (
     coerce_cvd_roles,
     coerce_em_consent_state,
 )
-from vultron.core.models.protocols import is_case_model
+from vultron.core.models.protocols import is_case_model, is_participant_model
 from vultron.core.states.cs import CS_pxa, CS_vfd
 from vultron.core.states.em import EM
 from vultron.core.states.rm import RM
@@ -102,14 +102,14 @@ class CreateParticipantStatusNode(DataLayerAction):
         )
         participant_obj = dl.read(participant_id)
         participant_roles = (
-            getattr(participant_obj, "case_roles", [])
-            if participant_obj is not None
+            participant_obj.roles
+            if is_participant_model(participant_obj)
             else []
         )
         status_roles = coerce_cvd_roles(participant_roles)
         raw_consent = (
             getattr(participant_obj, "embargo_consent_state", None)
-            if participant_obj is not None
+            if is_participant_model(participant_obj)
             else None
         )
         em_consent_state = coerce_em_consent_state(raw_consent)

--- a/vultron/core/behaviors/status/nodes/lifecycle.py
+++ b/vultron/core/behaviors/status/nodes/lifecycle.py
@@ -29,7 +29,11 @@ from py_trees.common import Status
 from vultron.core.behaviors.embargo.trigger_tree import terminate_embargo_bt
 from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
 from vultron.core.use_cases._helpers import _resolve_case_manager_id
-from vultron.core.models.protocols import PersistableModel, is_case_model
+from vultron.core.models.protocols import (
+    PersistableModel,
+    is_case_model,
+    is_participant_model,
+)
 from vultron.core.states.rm import RM
 from vultron.enums.roles import CVDRole
 from vultron.core.use_cases._helpers import _as_id
@@ -107,7 +111,11 @@ class _PublicDisclosureSkipConditionNode(DataLayerCondition):
             return Status.SUCCESS
 
         sender_participant = self.datalayer.read(sender_participant_id)
-        roles = getattr(sender_participant, "case_roles", [])
+        roles = (
+            sender_participant.roles
+            if is_participant_model(sender_participant)
+            else []
+        )
         if CVDRole.CASE_OWNER not in roles:
             return Status.SUCCESS
 
@@ -205,7 +213,7 @@ class AutoCloseBranchNode(DataLayerAction):
             p = self.datalayer.read(p_id)
             if p is None:
                 return False
-            roles = getattr(p, "case_roles", [])
+            roles = p.roles if is_participant_model(p) else []
             if CVDRole.CASE_MANAGER in roles:
                 continue
             statuses = getattr(p, "participant_statuses", [])

--- a/vultron/core/use_cases/_helpers.py
+++ b/vultron/core/use_cases/_helpers.py
@@ -369,10 +369,9 @@ def _resolve_case_manager_id(
     # Primary path: fast index lookup (normal post-bootstrap operation).
     for p_id in case.actor_participant_index.values():
         p = dl.read(p_id)
-        if p is None:
+        if not is_participant_model(p):
             continue
-        roles = getattr(p, "case_roles", [])
-        if CVDRole.CASE_MANAGER in roles:
+        if CVDRole.CASE_MANAGER in p.roles:
             manager_actor_id = getattr(p, "attributed_to", None)
             return _as_id(manager_actor_id)
 
@@ -382,8 +381,10 @@ def _resolve_case_manager_id(
     for participant_ref in case.case_participants:
         if not isinstance(participant_ref, str):
             # Inline participant object — no DataLayer read needed.
-            roles = getattr(participant_ref, "case_roles", [])
-            if CVDRole.CASE_MANAGER in roles:
+            if (
+                is_participant_model(participant_ref)
+                and CVDRole.CASE_MANAGER in participant_ref.roles
+            ):
                 attributed = getattr(participant_ref, "attributed_to", None)
                 return _as_id(attributed)
             continue
@@ -391,10 +392,9 @@ def _resolve_case_manager_id(
             # Already checked via the index; skip to avoid duplicates.
             continue
         p = dl.read(participant_ref)
-        if p is None:
+        if not is_participant_model(p):
             continue
-        roles = getattr(p, "case_roles", [])
-        if CVDRole.CASE_MANAGER in roles:
+        if CVDRole.CASE_MANAGER in p.roles:
             manager_actor_id = getattr(p, "attributed_to", None)
             return _as_id(manager_actor_id)
     return None

--- a/vultron/core/use_cases/received/actor/case_manager_role.py
+++ b/vultron/core/use_cases/received/actor/case_manager_role.py
@@ -14,7 +14,7 @@ from vultron.core.models.events.actor import (
     OfferCaseManagerRoleReceivedEvent,
     RejectCaseManagerRoleReceivedEvent,
 )
-from vultron.core.models.protocols import is_case_model
+from vultron.core.models.protocols import is_case_model, is_participant_model
 from vultron.core.ports.case_persistence import (
     CaseOutboxPersistence,
     CasePersistence,
@@ -122,6 +122,40 @@ class AcceptCaseManagerRoleReceivedUseCase:
         self._request: AcceptCaseManagerRoleReceivedEvent = request
         self._trigger_activity = trigger_activity
 
+    def _find_reporter_id(self, case: object) -> str | None:
+        """Return the attributed_to actor ID of the first REPORTER or FINDER participant."""
+        # Primary path: fast index lookup.
+        for p_id in getattr(case, "actor_participant_index", {}).values():
+            p = self._dl.read(p_id)
+            if is_participant_model(p) and (
+                CVDRole.REPORTER in p.roles or CVDRole.FINDER in p.roles
+            ):
+                return _as_id(getattr(p, "attributed_to", None))
+
+        # Fallback: case_participants list (bootstrap path — index may not yet
+        # be populated when Accept(OfferCaseManagerRole) arrives).
+        indexed_ids = set(
+            getattr(case, "actor_participant_index", {}).values()
+        )
+        for participant_ref in getattr(case, "case_participants", []):
+            if not isinstance(participant_ref, str):
+                if is_participant_model(participant_ref) and (
+                    CVDRole.REPORTER in participant_ref.roles
+                    or CVDRole.FINDER in participant_ref.roles
+                ):
+                    return _as_id(
+                        getattr(participant_ref, "attributed_to", None)
+                    )
+                continue
+            if participant_ref in indexed_ids:
+                continue
+            p = self._dl.read(participant_ref)
+            if is_participant_model(p) and (
+                CVDRole.REPORTER in p.roles or CVDRole.FINDER in p.roles
+            ):
+                return _as_id(getattr(p, "attributed_to", None))
+        return None
+
     def execute(self) -> None:
         from vultron.core.use_cases.received.sync import _find_local_actor_id
 
@@ -178,15 +212,7 @@ class AcceptCaseManagerRoleReceivedUseCase:
             )
             return
 
-        # Find the Reporter participant to address the Create(Case) to.
-        reporter_id: str | None = None
-        for p_id in case.actor_participant_index.values():
-            p = self._dl.read(p_id)
-            roles = getattr(p, "case_roles", [])
-            if CVDRole.REPORTER in roles or CVDRole.FINDER in roles:
-                reporter_id = _as_id(getattr(p, "attributed_to", None))
-                break
-
+        reporter_id = self._find_reporter_id(case)
         if not reporter_id:
             logger.warning(
                 "AcceptCaseManagerRoleReceived: no Reporter participant found"


### PR DESCRIPTION
- Closes #1388

## Summary

Replaces all 8 `getattr(x, "case_roles", [])` call sites in `vultron/core/` with `x.roles` (property access) or `is_participant_model()` guards, enforcing PRM-01-003. Adds an architecture ratchet test to prevent regression.

## Changes

- `vultron/core/behaviors/status/nodes/lifecycle.py`: two `getattr(…, "case_roles", [])` reads replaced with `is_participant_model()` guard + `.roles`
- `vultron/core/behaviors/case/nodes/participant/status.py`: `participant_roles` and `raw_consent` both now use consistent `is_participant_model()` guard (was: `is not None` for consent, `getattr(case_roles)` for roles)
- `vultron/core/behaviors/case/nodes/participant/common.py`: `getattr(existing, "case_roles", [])` → `getattr(existing, "roles", [])` (existing typed `Any`; avoids pyright narrowing at `dl.save(existing)`)
- `vultron/core/use_cases/_helpers.py`: three `getattr(…, "case_roles", [])` reads in `_resolve_case_manager_id` replaced with `is_participant_model()` guard + `.roles`
- `vultron/core/use_cases/received/actor/case_manager_role.py`: extracted `_find_reporter_id` helper (reduces `execute()` complexity below C901 gate); added `case_participants` fallback matching `_resolve_case_manager_id` pattern so bootstrap trust is not skipped when `actor_participant_index` is unpopulated on early boot
- `test/architecture/test_participant_case_roles.py`: added `test_no_getattr_case_roles_read_in_core()` ratchet — scans all `vultron/core/` files for `getattr(*, "case_roles", *)` patterns and fails on any match outside the two allowed modules

## Verification

- All 4740 unit tests pass (2 new architecture-ratchet assertions)
- Black, flake8 (including CC≤10 gate), mypy, pyright all clean