### PR TITLE
docs: plan concern #1445 — message semantics mapping traceability

### DIFF
--- a/notes/behavioral-conformance-specs.md
+++ b/notes/behavioral-conformance-specs.md
@@ -9,7 +9,6 @@ related_specs:
   - specs/vultron-protocol-spec.yaml
   - specs/meta-specifications.yaml
   - specs/spec-registry.yaml
-  - specs/message-semantics-mapping.yaml
 related_notes:
   - notes/specs-vs-adrs.md
   - notes/bt-integration.md
@@ -209,9 +208,10 @@ bridges these shorthands to the implementation:
    domain-layer semantic intent used for dispatch
 3. **VAM spec item ID** (e.g., `VAM-05-005`) — the wire-format mapping
 
-This three-hop chain is now captured normatively in
-`specs/message-semantics-mapping.yaml` (MSM prefix). Each MSM item provides
-one row in the flat table: shorthand → MessageSemantics → VAM ID.
+This three-hop chain will be captured normatively in
+`specs/message-semantics-mapping.yaml` (MSM prefix, tracked in #1449).
+Each MSM item will provide one row in the flat table:
+shorthand → MessageSemantics → VAM ID.
 
 **Authoring rule for behavioral specs**: when writing a `trigger.value` field
 with a protocol shorthand label, always cross-reference the corresponding MSM

--- a/notes/behavioral-conformance-specs.md
+++ b/notes/behavioral-conformance-specs.md
@@ -9,6 +9,7 @@ related_specs:
   - specs/vultron-protocol-spec.yaml
   - specs/meta-specifications.yaml
   - specs/spec-registry.yaml
+  - specs/message-semantics-mapping.yaml
 related_notes:
   - notes/specs-vs-adrs.md
   - notes/bt-integration.md
@@ -208,9 +209,9 @@ bridges these shorthands to the implementation:
    domain-layer semantic intent used for dispatch
 3. **VAM spec item ID** (e.g., `VAM-05-005`) — the wire-format mapping
 
-This three-hop chain will be captured normatively in
-`specs/message-semantics-mapping.yaml` (MSM prefix, tracked in #1449).
-Each MSM item will provide one row in the flat table:
+This three-hop chain is captured normatively in
+`specs/message-semantics-mapping.yaml` (MSM prefix).
+Each MSM item provides one row in the flat table:
 shorthand → MessageSemantics → VAM ID.
 
 **Authoring rule for behavioral specs**: when writing a `trigger.value` field

--- a/notes/behavioral-conformance-specs.md
+++ b/notes/behavioral-conformance-specs.md
@@ -9,6 +9,7 @@ related_specs:
   - specs/vultron-protocol-spec.yaml
   - specs/meta-specifications.yaml
   - specs/spec-registry.yaml
+  - specs/message-semantics-mapping.yaml
 related_notes:
   - notes/specs-vs-adrs.md
   - notes/bt-integration.md
@@ -195,6 +196,29 @@ When drafting spec item content, use these sources in priority order:
 
 Do NOT use `vultron/bt/` (legacy simulator) as a source. Focus exclusively on
 the `vultron/core/behaviors/` py_trees layer.
+
+## Protocol Shorthand → MessageSemantics → VAM Traceability
+
+RMB/EMB/CSB `trigger.value` fields use protocol shorthand labels (RS, EP, EA,
+CV, CP, etc.). An independent implementor needs a normative document that
+bridges these shorthands to the implementation:
+
+1. **Shorthand label** (e.g., `EP`) — used in behavioral spec trigger values
+   and VP spec prose
+2. **`MessageSemantics` enum value** (e.g., `INVITE_TO_EMBARGO_ON_CASE`) — the
+   domain-layer semantic intent used for dispatch
+3. **VAM spec item ID** (e.g., `VAM-05-005`) — the wire-format mapping
+
+This three-hop chain is now captured normatively in
+`specs/message-semantics-mapping.yaml` (MSM prefix). Each MSM item provides
+one row in the flat table: shorthand → MessageSemantics → VAM ID.
+
+**Authoring rule for behavioral specs**: when writing a `trigger.value` field
+with a protocol shorthand label, always cross-reference the corresponding MSM
+spec item in the group or item description. The extractor code
+(`vultron/wire/as2/extractor/_instances.py`) is the authoritative source if
+the shorthand→MessageSemantics mapping differs between the code, legacy
+ontology, and docs.
 
 ## PR Sequence
 

--- a/plan/history/2607/learning/CONCERN-1445.md
+++ b/plan/history/2607/learning/CONCERN-1445.md
@@ -1,0 +1,51 @@
+---
+source: CONCERN-1445
+timestamp: '2026-07-15T17:05:52.819064+00:00'
+title: No spec-level mapping from EM/CS/RM protocol shorthands to AS2 wire types
+type: learning
+---
+
+## Summary
+
+The behavioral conformance specs produced by #1423, #1424, and #1425 (RMB, EMB, CSB)
+reference EM/CS/RM message shorthands (EP, EA, EV, CP, CX, RS, RV, etc.) throughout
+their preconditions, triggers, and steps. The wire mapping spec
+(`specs/vultron-as2-mapping.yaml`, VAM) maps `MessageSemantics` enum values to AS2
+wire patterns. Neither spec layer bridges the two: there is no normative document that
+maps EP → `MessageSemantics.INVITE_TO_EMBARGO_ON_CASE` → `Invite(Event)[context=VulnerabilityCase]`.
+
+## Category
+
+Specification completeness / traceability
+
+## Severity
+
+Medium — the gap does not break the implementation (the mapping exists in code), but it
+makes the spec layer non-self-contained for an independent implementor.
+
+## Evidence
+
+- `specs/rm-behavior.yaml` (RMB), `specs/em-behavior.yaml` (EMB), `specs/cs-behavior.yaml`
+  (CSB) all use protocol shorthand labels (RS, RV, EP, EA, CP, CX…) as trigger `value`
+  fields and in prose.
+- `specs/vultron-as2-mapping.yaml` (VAM) maps `MessageSemantics` enum values to AS2
+  patterns — with no reference to the shorthand labels.
+- The only authoritative shorthand→MessageSemantics mapping lives in
+  `vultron/wire/as2/extractor.py` (`SEMANTICS_ACTIVITY_PATTERNS`) and implicitly in
+  `vultron/core/case_states/patterns/potential_actions.py`.
+- An independent implementor reading EMB-01-001 ("receiving EP MUST...") and
+  VAM-05-005 ("INVITE_TO_EMBARGO_ON_CASE MUST be Invite(Event)...") cannot connect them
+  without reading the code.
+
+## Impact if Ignored
+
+- Independent implementors cannot achieve full L3 behavioral conformance from specs alone —
+  they must reverse-engineer the shorthand mapping from code.
+- Adds friction for any future transport (non-AS2) that needs to produce its own mapping:
+  the intermediate `MessageSemantics` layer is not spec-documented.
+- RMB/EMB/CSB `satisfies` relationships cannot reference VAM items, leaving a gap in the
+  cross-reference graph.
+
+**Resolved**: 2026-07-15 — implementation tracked in #1449, follow-up in #1450.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1448>.
+Notes: `notes/behavioral-conformance-specs.md` § "Protocol Shorthand → MessageSemantics → VAM Traceability".

--- a/specs/README.md
+++ b/specs/README.md
@@ -75,7 +75,7 @@ Load additional files only when the task touches the relevant area. See the
 | Behavior Trees | `behavior-tree-integration.yaml`, `behavior-tree-node-design.yaml`, `bt-composability.yaml`, `triggerable-behaviors.yaml`, `vultron/core/use_cases/triggers/AGENTS.md` |
 | Case / state management | `case-management.yaml`, `state-machine.yaml`, `case-ledger-processing.yaml` |
 | CaseProposal protocol (distributed case actor initialization) | `case-proposal.yaml` |
-| Protocol conformance | `vultron-protocol-spec.yaml`, `vultron-as2-mapping.yaml` |
+| Protocol conformance | `vultron-protocol-spec.yaml`, `vultron-as2-mapping.yaml`, `message-semantics-mapping.yaml` |
 | Wire vocabulary | `vocabulary-model.yaml` |
 | Activity factory functions | `activity-factories.yaml` |
 | Response generation / outbox | `response-format.yaml`, `outbox.yaml` |
@@ -172,11 +172,20 @@ Specifications are organized by topic with minimal overlap. Cross-references lin
 
 **Semantic–Wire Mapping**:
 
+- **`message-semantics-mapping.yaml`** - Normative bridge from protocol message
+  shorthand labels (RS, EP, CV, etc.) used in behavioral conformance specs
+  (RMB, EMB, CSB) to their `MessageSemantics` enum values and corresponding AS2
+  wire-format entries in `vultron-as2-mapping.yaml`. Closes the three-hop traceability
+  chain: shorthand → `MessageSemantics` → VAM spec ID. Also explicitly documents
+  shorthands (RE, EE, EK, CE, CK) that have no AS2 semantic dispatch entry.
+  (MSM-01 through MSM-03)
+
 - **`vultron-as2-mapping.yaml`** - Authoritative mapping from each `MessageSemantics`
   enum value to its ActivityStreams 2.0 wire representation: activity type,
   object type, target/context constraints, and nested-pattern conventions
   (VAM-01 through VAM-09). Foundational for hexagonal-architecture wire
-  replaceability (ARCH-07-001).
+  replaceability (ARCH-07-001). VAM items cross-reference MSM items via
+  `satisfies` relationships where protocol shorthands map to this spec.
 
 **Behavior Tree Integration** (optional for complex workflows):
 
@@ -458,6 +467,7 @@ is reserved for `testability.yaml`).
 | `IO` | `inbox-orchestration.yaml` |
 | `IE` | `inbox-endpoint.yaml` |
 | `IMPLTS` | `tech-stack.yaml` |
+| `MSM` | `message-semantics-mapping.yaml` |
 | `MV` | `message-validation.yaml` |
 | `NF` | `notes-frontmatter.yaml` |
 | `SR` | `spec-registry.yaml` |

--- a/specs/cs-behavior.yaml
+++ b/specs/cs-behavior.yaml
@@ -21,6 +21,9 @@ scope:
 groups:
 - id: CSB-01
   title: Receive CV (Vendor Aware)
+  description: >-
+    Wire-type mapping — see MSM-03-001 (CV → ADD_CASE_STATUS_TO_CASE →
+    Add(CaseStatus)[target=VulnerabilityCase]; CaseStatus payload encodes vendor_aware).
   trigger:
     type: message_received
     value: CV
@@ -33,6 +36,9 @@ groups:
 
 - id: CSB-02
   title: Receive CF (Fix Ready)
+  description: >-
+    Wire-type mapping — see MSM-03-002 (CF → ADD_CASE_STATUS_TO_CASE →
+    Add(CaseStatus)[target=VulnerabilityCase]; CaseStatus payload encodes fix_ready).
   trigger:
     type: message_received
     value: CF
@@ -45,6 +51,9 @@ groups:
 
 - id: CSB-03
   title: Receive CD (Fix Deployed)
+  description: >-
+    Wire-type mapping — see MSM-03-003 (CD → ADD_CASE_STATUS_TO_CASE →
+    Add(CaseStatus)[target=VulnerabilityCase]; CaseStatus payload encodes fix_deployed).
   trigger:
     type: message_received
     value: CD
@@ -57,6 +66,9 @@ groups:
 
 - id: CSB-04
   title: Receive CP (Public Aware)
+  description: >-
+    Wire-type mapping — see MSM-03-004 (CP → ADD_CASE_STATUS_TO_CASE →
+    Add(CaseStatus)[target=VulnerabilityCase]; CaseStatus payload encodes public_aware).
   trigger:
     type: message_received
     value: CP
@@ -69,6 +81,9 @@ groups:
 
 - id: CSB-05
   title: Receive CX (Exploit Public)
+  description: >-
+    Wire-type mapping — see MSM-03-005 (CX → ADD_CASE_STATUS_TO_CASE →
+    Add(CaseStatus)[target=VulnerabilityCase]; CaseStatus payload encodes exploit_published).
   trigger:
     type: message_received
     value: CX
@@ -81,6 +96,9 @@ groups:
 
 - id: CSB-06
   title: Receive CA (Attacks Observed)
+  description: >-
+    Wire-type mapping — see MSM-03-006 (CA → ADD_CASE_STATUS_TO_CASE →
+    Add(CaseStatus)[target=VulnerabilityCase]; CaseStatus payload encodes attacks_observed).
   trigger:
     type: message_received
     value: CA
@@ -93,6 +111,9 @@ groups:
 
 - id: CSB-07
   title: Receive CE (CS Error)
+  description: >-
+    Wire-type mapping — see MSM-03-007 (CE has no dedicated MessageSemantics
+    dispatch value and no AS2 wire representation in the current semantic registry).
   trigger:
     type: message_received
     value: CE
@@ -105,6 +126,9 @@ groups:
 
 - id: CSB-08
   title: Receive CK (CS Acknowledgment)
+  description: >-
+    Wire-type mapping — see MSM-03-008 (CK has no dedicated MessageSemantics
+    dispatch value and no AS2 wire representation in the current semantic registry).
   trigger:
     type: message_received
     value: CK

--- a/specs/em-behavior.yaml
+++ b/specs/em-behavior.yaml
@@ -21,6 +21,9 @@ scope:
 groups:
 - id: EMB-01
   title: Receive EP (Embargo Proposed)
+  description: >-
+    Wire-type mapping — see MSM-02-001 (EP → INVITE_TO_EMBARGO_ON_CASE →
+    Invite(Event)[context=VulnerabilityCase]).
   trigger:
     type: message_received
     value: EP
@@ -33,6 +36,9 @@ groups:
 
 - id: EMB-02
   title: Receive EA (Embargo Accepted)
+  description: >-
+    Wire-type mapping — see MSM-02-002 (EA → ACCEPT_INVITE_TO_EMBARGO_ON_CASE →
+    Accept(Invite(Event)[context=VulnerabilityCase])).
   trigger:
     type: message_received
     value: EA
@@ -45,6 +51,9 @@ groups:
 
 - id: EMB-03
   title: Receive EV (Embargo Revision Proposed)
+  description: >-
+    Wire-type mapping — see MSM-02-003 (EV → INVITE_TO_EMBARGO_ON_CASE →
+    Invite(Event)[context=VulnerabilityCase]; same wire form as EP).
   trigger:
     type: message_received
     value: EV
@@ -57,6 +66,9 @@ groups:
 
 - id: EMB-04
   title: Receive EJ (Embargo Revision Rejected)
+  description: >-
+    Wire-type mapping — see MSM-02-004 (EJ → REJECT_INVITE_TO_EMBARGO_ON_CASE →
+    Reject(Invite(Event)[context=VulnerabilityCase]); same wire form as ER).
   trigger:
     type: message_received
     value: EJ
@@ -69,6 +81,9 @@ groups:
 
 - id: EMB-05
   title: Receive EC (Embargo Revision Accepted)
+  description: >-
+    Wire-type mapping — see MSM-02-005 (EC → ACCEPT_INVITE_TO_EMBARGO_ON_CASE →
+    Accept(Invite(Event)[context=VulnerabilityCase]); same wire form as EA).
   trigger:
     type: message_received
     value: EC
@@ -81,6 +96,9 @@ groups:
 
 - id: EMB-06
   title: Receive ER (Embargo Rejected)
+  description: >-
+    Wire-type mapping — see MSM-02-006 (ER → REJECT_INVITE_TO_EMBARGO_ON_CASE →
+    Reject(Invite(Event)[context=VulnerabilityCase])).
   trigger:
     type: message_received
     value: ER
@@ -93,6 +111,7 @@ groups:
 
 - id: EMB-07
   title: Receive ET (Embargo Terminated)
+  description: Wire-type mapping — see MSM-02-007 (ET → REMOVE_EMBARGO_EVENT_FROM_CASE → Remove(Event)).
   trigger:
     type: message_received
     value: ET
@@ -105,6 +124,9 @@ groups:
 
 - id: EMB-08
   title: Receive EE (Embargo Error)
+  description: >-
+    Wire-type mapping — see MSM-02-008 (EE has no dedicated MessageSemantics
+    dispatch value and no AS2 wire representation in the current semantic registry).
   trigger:
     type: message_received
     value: EE
@@ -117,6 +139,9 @@ groups:
 
 - id: EMB-09
   title: Receive EK (Embargo Acknowledgment)
+  description: >-
+    Wire-type mapping — see MSM-02-009 (EK has no dedicated MessageSemantics
+    dispatch value and no AS2 wire representation in the current semantic registry).
   trigger:
     type: message_received
     value: EK

--- a/specs/message-semantics-mapping.yaml
+++ b/specs/message-semantics-mapping.yaml
@@ -1,0 +1,319 @@
+id: MSM
+title: Protocol Shorthand to MessageSemantics Mapping
+description: >-
+  Authoritative normative bridge from protocol message shorthand labels
+  (RS, EP, CV, etc.) used in behavioral conformance specs (RMB, EMB, CSB) to
+  their `MessageSemantics` enum values and corresponding AS2 wire-format
+  specifications in `specs/vultron-as2-mapping.yaml` (VAM). Each entry
+  provides one row in the three-hop chain: shorthand → `MessageSemantics`
+  enum value → VAM spec ID. Shorthands with no dedicated `MessageSemantics`
+  dispatch value (protocol-layer error and acknowledgment signals) are
+  explicitly documented as such. **Authoritative source**: the extractor
+  pattern constants in `vultron/wire/as2/extractor/_instances.py` and the
+  semantic registry in `vultron/semantic_registry/` define the mapping; this
+  spec makes it normative at the protocol layer.
+version: 0.1.0
+kind: domain
+scope:
+- prototype
+- production
+groups:
+- id: MSM-01
+  title: RM Protocol Message Shorthands
+  description: >-
+    Normative shorthand-to-semantic mappings for Report Management (RM)
+    protocol messages. These shorthands appear as `trigger.value` fields in
+    `specs/rm-behavior.yaml` (RMB). The mapping source is the report and case
+    entries in `vultron/semantic_registry/report.py` and
+    `vultron/semantic_registry/case.py`.
+  specs:
+  - id: MSM-01-001
+    priority: MUST
+    statement: >-
+      Protocol shorthand `RS` (Report Submission) MUST dispatch as
+      `MessageSemantics.SUBMIT_REPORT`; its AS2 wire form is
+      `Offer(VulnerabilityReport)` per VAM-02-002.
+    relationships:
+    - rel_type: derives_from
+      spec_id: VAM-02-002
+  - id: MSM-01-002
+    priority: MUST
+    statement: >-
+      Protocol shorthand `RI` (Report Invalid) MUST dispatch as
+      `MessageSemantics.INVALIDATE_REPORT`; its AS2 wire form is
+      `TentativeReject(Offer(VulnerabilityReport))` per VAM-02-005.
+    relationships:
+    - rel_type: derives_from
+      spec_id: VAM-02-005
+  - id: MSM-01-003
+    priority: MUST
+    statement: >-
+      Protocol shorthand `RV` (Report Valid) MUST dispatch as
+      `MessageSemantics.VALIDATE_REPORT`; its AS2 wire form is
+      `Accept(Offer(VulnerabilityReport))` per VAM-02-004.
+    relationships:
+    - rel_type: derives_from
+      spec_id: VAM-02-004
+  - id: MSM-01-004
+    priority: MUST
+    statement: >-
+      Protocol shorthand `RD` (Report/Case Deferred) MUST dispatch as
+      `MessageSemantics.DEFER_CASE`; its AS2 wire form is
+      `Ignore(VulnerabilityCase)` per VAM-03-004.
+    rationale: >-
+      A deferred report indicates the receiving actor will not engage with the
+      case at this time. The wire representation uses `Ignore(VulnerabilityCase)`
+      rather than a report-level verb because deferral is a case-participation
+      decision, not a report-validity judgment.
+    relationships:
+    - rel_type: derives_from
+      spec_id: VAM-03-004
+  - id: MSM-01-005
+    priority: MUST
+    statement: >-
+      Protocol shorthand `RA` (Report/Case Accepted) MUST dispatch as
+      `MessageSemantics.ENGAGE_CASE`; its AS2 wire form is
+      `Join(VulnerabilityCase)` per VAM-03-003.
+    rationale: >-
+      Accepting a report means the receiving actor commits to engaging with the
+      vulnerability case. The wire verb `Join` captures the case-participation
+      decision, symmetric with `Ignore` for `RD`.
+    relationships:
+    - rel_type: derives_from
+      spec_id: VAM-03-003
+  - id: MSM-01-006
+    priority: MUST
+    statement: >-
+      Protocol shorthand `RC` (Report Closed) MUST dispatch as
+      `MessageSemantics.CLOSE_REPORT`; its AS2 wire form is
+      `Reject(Offer(VulnerabilityReport))` per VAM-02-006.
+    relationships:
+    - rel_type: derives_from
+      spec_id: VAM-02-006
+  - id: MSM-01-007
+    priority: MUST
+    statement: >-
+      Protocol shorthand `RE` (Report Management Error) has no dedicated
+      `MessageSemantics` dispatch value and no entry in
+      `SEMANTICS_ACTIVITY_PATTERNS`; it is a protocol-layer error signal with
+      no AS2 wire representation in the current semantic registry.
+    testable: false
+    rationale: >-
+      `RE` is a protocol-level acknowledgment of an error condition in report
+      management. The AS2-based semantic dispatch pipeline does not currently
+      define a wire pattern or `MessageSemantics` value for error signals;
+      implementations handling `RE` must do so outside the
+      `find_matching_semantics()` dispatch path.
+  - id: MSM-01-008
+    priority: MUST
+    statement: >-
+      Protocol shorthand `RK` (Report Management Acknowledgment) MUST dispatch
+      as `MessageSemantics.ACK_REPORT`; its AS2 wire form is
+      `Read(Offer(VulnerabilityReport))` per VAM-02-003.
+    relationships:
+    - rel_type: derives_from
+      spec_id: VAM-02-003
+
+- id: MSM-02
+  title: EM Protocol Message Shorthands
+  description: >-
+    Normative shorthand-to-semantic mappings for Embargo Management (EM)
+    protocol messages. These shorthands appear as `trigger.value` fields in
+    `specs/em-behavior.yaml` (EMB). The mapping source is
+    `vultron/semantic_registry/embargo.py`. Note: embargo revision shorthands
+    (EV, EJ, EC) share wire formats with their initial-proposal counterparts
+    (EP, ER, EA); the distinction is contextual (active embargo present),
+    not structural at the AS2 wire level.
+  specs:
+  - id: MSM-02-001
+    priority: MUST
+    statement: >-
+      Protocol shorthand `EP` (Embargo Proposed) MUST dispatch as
+      `MessageSemantics.INVITE_TO_EMBARGO_ON_CASE`; its AS2 wire form is
+      `Invite(Event)[context=VulnerabilityCase]` per VAM-05-005.
+    relationships:
+    - rel_type: derives_from
+      spec_id: VAM-05-005
+  - id: MSM-02-002
+    priority: MUST
+    statement: >-
+      Protocol shorthand `EA` (Embargo Accepted) MUST dispatch as
+      `MessageSemantics.ACCEPT_INVITE_TO_EMBARGO_ON_CASE`; its AS2 wire form
+      is `Accept(Invite(Event)[context=VulnerabilityCase])` per VAM-05-006.
+    relationships:
+    - rel_type: derives_from
+      spec_id: VAM-05-006
+  - id: MSM-02-003
+    priority: MUST
+    statement: >-
+      Protocol shorthand `EV` (Embargo Revision Proposed) MUST dispatch as
+      `MessageSemantics.INVITE_TO_EMBARGO_ON_CASE`; its AS2 wire form is
+      `Invite(Event)[context=VulnerabilityCase]` per VAM-05-005 — identical to
+      `EP`. The revision context is inferred from the presence of an active
+      embargo.
+    rationale: >-
+      EV, EJ, and EC are aliases for EP, ER, and EA at the wire layer
+      (`vultron/bt/messaging/states.py`). The distinction between initial
+      proposal and revision proposal is not encoded in the AS2 activity
+      structure; implementations MUST infer it from local EM state.
+    relationships:
+    - rel_type: derives_from
+      spec_id: VAM-05-005
+  - id: MSM-02-004
+    priority: MUST
+    statement: >-
+      Protocol shorthand `EJ` (Embargo Revision Rejected) MUST dispatch as
+      `MessageSemantics.REJECT_INVITE_TO_EMBARGO_ON_CASE`; its AS2 wire form
+      is `Reject(Invite(Event)[context=VulnerabilityCase])` per VAM-05-007 —
+      identical to `ER`.
+    rationale: >-
+      EJ is an alias for ER at the wire layer. See MSM-02-003 rationale.
+    relationships:
+    - rel_type: derives_from
+      spec_id: VAM-05-007
+  - id: MSM-02-005
+    priority: MUST
+    statement: >-
+      Protocol shorthand `EC` (Embargo Revision Accepted) MUST dispatch as
+      `MessageSemantics.ACCEPT_INVITE_TO_EMBARGO_ON_CASE`; its AS2 wire form
+      is `Accept(Invite(Event)[context=VulnerabilityCase])` per VAM-05-006 —
+      identical to `EA`.
+    rationale: >-
+      EC is an alias for EA at the wire layer. See MSM-02-003 rationale.
+    relationships:
+    - rel_type: derives_from
+      spec_id: VAM-05-006
+  - id: MSM-02-006
+    priority: MUST
+    statement: >-
+      Protocol shorthand `ER` (Embargo Rejected) MUST dispatch as
+      `MessageSemantics.REJECT_INVITE_TO_EMBARGO_ON_CASE`; its AS2 wire form
+      is `Reject(Invite(Event)[context=VulnerabilityCase])` per VAM-05-007.
+    relationships:
+    - rel_type: derives_from
+      spec_id: VAM-05-007
+  - id: MSM-02-007
+    priority: MUST
+    statement: >-
+      Protocol shorthand `ET` (Embargo Terminated) MUST dispatch as
+      `MessageSemantics.REMOVE_EMBARGO_EVENT_FROM_CASE`; its AS2 wire form is
+      `Remove(Event)` per VAM-05-003.
+    relationships:
+    - rel_type: derives_from
+      spec_id: VAM-05-003
+  - id: MSM-02-008
+    priority: MUST
+    statement: >-
+      Protocol shorthand `EE` (Embargo Management Error) has no dedicated
+      `MessageSemantics` dispatch value and no entry in
+      `SEMANTICS_ACTIVITY_PATTERNS`; it is a protocol-layer error signal with
+      no AS2 wire representation in the current semantic registry.
+    testable: false
+    rationale: >-
+      Symmetric with MSM-01-007 (`RE`): embargo-layer error signals are
+      not modeled as AS2 semantic dispatch entries.
+  - id: MSM-02-009
+    priority: MUST
+    statement: >-
+      Protocol shorthand `EK` (Embargo Management Acknowledgment) has no
+      dedicated `MessageSemantics` dispatch value and no entry in
+      `SEMANTICS_ACTIVITY_PATTERNS`; it is a protocol-layer acknowledgment
+      signal with no AS2 wire representation in the current semantic registry.
+    testable: false
+    rationale: >-
+      Symmetric with MSM-01-007 (`RE`): embargo-layer acknowledgment signals
+      are not modeled as AS2 semantic dispatch entries.
+
+- id: MSM-03
+  title: CS Protocol Message Shorthands
+  description: >-
+    Normative shorthand-to-semantic mappings for CVD Case State (CS)
+    protocol messages. These shorthands appear as `trigger.value` fields in
+    `specs/cs-behavior.yaml` (CSB). The mapping source is
+    `vultron/semantic_registry/status.py`. CS status shorthands (CV, CF, CD,
+    CP, CX, CA) all share the `ADD_CASE_STATUS_TO_CASE` semantic; the
+    specific state transition is encoded in the `CaseStatus` object payload,
+    not in the activity type.
+  specs:
+  - id: MSM-03-001
+    priority: MUST
+    statement: >-
+      Protocol shorthand `CV` (Vendor Aware) MUST dispatch as
+      `MessageSemantics.ADD_CASE_STATUS_TO_CASE`; its AS2 wire form is
+      `Add(CaseStatus)[target=VulnerabilityCase]` per VAM-08-002. The
+      `CaseStatus` payload encodes the `vendor_aware` state flag.
+    relationships:
+    - rel_type: derives_from
+      spec_id: VAM-08-002
+  - id: MSM-03-002
+    priority: MUST
+    statement: >-
+      Protocol shorthand `CF` (Fix Ready) MUST dispatch as
+      `MessageSemantics.ADD_CASE_STATUS_TO_CASE`; its AS2 wire form is
+      `Add(CaseStatus)[target=VulnerabilityCase]` per VAM-08-002. The
+      `CaseStatus` payload encodes the `fix_ready` state flag.
+    relationships:
+    - rel_type: derives_from
+      spec_id: VAM-08-002
+  - id: MSM-03-003
+    priority: MUST
+    statement: >-
+      Protocol shorthand `CD` (Fix Deployed) MUST dispatch as
+      `MessageSemantics.ADD_CASE_STATUS_TO_CASE`; its AS2 wire form is
+      `Add(CaseStatus)[target=VulnerabilityCase]` per VAM-08-002. The
+      `CaseStatus` payload encodes the `fix_deployed` state flag.
+    relationships:
+    - rel_type: derives_from
+      spec_id: VAM-08-002
+  - id: MSM-03-004
+    priority: MUST
+    statement: >-
+      Protocol shorthand `CP` (Public Aware) MUST dispatch as
+      `MessageSemantics.ADD_CASE_STATUS_TO_CASE`; its AS2 wire form is
+      `Add(CaseStatus)[target=VulnerabilityCase]` per VAM-08-002. The
+      `CaseStatus` payload encodes the `public_aware` state flag.
+    relationships:
+    - rel_type: derives_from
+      spec_id: VAM-08-002
+  - id: MSM-03-005
+    priority: MUST
+    statement: >-
+      Protocol shorthand `CX` (Exploit Published) MUST dispatch as
+      `MessageSemantics.ADD_CASE_STATUS_TO_CASE`; its AS2 wire form is
+      `Add(CaseStatus)[target=VulnerabilityCase]` per VAM-08-002. The
+      `CaseStatus` payload encodes the `exploit_published` state flag.
+    relationships:
+    - rel_type: derives_from
+      spec_id: VAM-08-002
+  - id: MSM-03-006
+    priority: MUST
+    statement: >-
+      Protocol shorthand `CA` (Attacks Observed) MUST dispatch as
+      `MessageSemantics.ADD_CASE_STATUS_TO_CASE`; its AS2 wire form is
+      `Add(CaseStatus)[target=VulnerabilityCase]` per VAM-08-002. The
+      `CaseStatus` payload encodes the `attacks_observed` state flag.
+    relationships:
+    - rel_type: derives_from
+      spec_id: VAM-08-002
+  - id: MSM-03-007
+    priority: MUST
+    statement: >-
+      Protocol shorthand `CE` (Case State Error) has no dedicated
+      `MessageSemantics` dispatch value and no entry in
+      `SEMANTICS_ACTIVITY_PATTERNS`; it is a protocol-layer error signal with
+      no AS2 wire representation in the current semantic registry.
+    testable: false
+    rationale: >-
+      Symmetric with MSM-01-007 (`RE`): case-state-layer error signals are
+      not modeled as AS2 semantic dispatch entries.
+  - id: MSM-03-008
+    priority: MUST
+    statement: >-
+      Protocol shorthand `CK` (Case State Acknowledgment) has no dedicated
+      `MessageSemantics` dispatch value and no entry in
+      `SEMANTICS_ACTIVITY_PATTERNS`; it is a protocol-layer acknowledgment
+      signal with no AS2 wire representation in the current semantic registry.
+    testable: false
+    rationale: >-
+      Symmetric with MSM-01-007 (`RE`): case-state-layer acknowledgment
+      signals are not modeled as AS2 semantic dispatch entries.

--- a/specs/rm-behavior.yaml
+++ b/specs/rm-behavior.yaml
@@ -18,6 +18,7 @@ scope:
 groups:
 - id: RMB-01
   title: Receive RS (Report Submission)
+  description: Wire-type mapping — see MSM-01-001 (RS → SUBMIT_REPORT → Offer(VulnerabilityReport)).
   trigger:
     type: message_received
     value: RS
@@ -190,6 +191,7 @@ groups:
 
 - id: RMB-02
   title: Receive RI (Report Invalid)
+  description: Wire-type mapping — see MSM-01-002 (RI → INVALIDATE_REPORT → TentativeReject(Offer(VulnerabilityReport))).
   trigger:
     type: message_received
     value: RI
@@ -269,6 +271,7 @@ groups:
 
 - id: RMB-03
   title: Receive RV (Report Valid)
+  description: Wire-type mapping — see MSM-01-003 (RV → VALIDATE_REPORT → Accept(Offer(VulnerabilityReport))).
   trigger:
     type: message_received
     value: RV
@@ -347,6 +350,7 @@ groups:
 
 - id: RMB-04
   title: Receive RD (Report Deferred)
+  description: Wire-type mapping — see MSM-01-004 (RD → DEFER_CASE → Ignore(VulnerabilityCase)).
   trigger:
     type: message_received
     value: RD
@@ -424,6 +428,7 @@ groups:
 
 - id: RMB-05
   title: Receive RA (Report Accepted)
+  description: Wire-type mapping — see MSM-01-005 (RA → ENGAGE_CASE → Join(VulnerabilityCase)).
   trigger:
     type: message_received
     value: RA
@@ -503,6 +508,7 @@ groups:
 
 - id: RMB-06
   title: Receive RC (Report Closed)
+  description: Wire-type mapping — see MSM-01-006 (RC → CLOSE_REPORT → Reject(Offer(VulnerabilityReport))).
   trigger:
     type: message_received
     value: RC
@@ -604,6 +610,9 @@ groups:
 
 - id: RMB-07
   title: Receive RE (Report Error)
+  description: >-
+    Wire-type mapping — see MSM-01-007 (RE has no dedicated MessageSemantics
+    dispatch value and no AS2 wire representation in the current semantic registry).
   trigger:
     type: message_received
     value: RE
@@ -681,6 +690,7 @@ groups:
 
 - id: RMB-08
   title: Receive RK (Report Acknowledgment)
+  description: Wire-type mapping — see MSM-01-008 (RK → ACK_REPORT → Read(Offer(VulnerabilityReport))).
   trigger:
     type: message_received
     value: RK

--- a/specs/vultron-as2-mapping.yaml
+++ b/specs/vultron-as2-mapping.yaml
@@ -95,19 +95,39 @@ groups:
   - id: VAM-02-002
     priority: MUST
     statement: '`SUBMIT_REPORT` MUST be represented as `Offer(VulnerabilityReport)`'
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-01-001
+      note: RS shorthand → SUBMIT_REPORT → this wire form
   - id: VAM-02-003
     priority: MUST
     statement: '`ACK_REPORT` MUST be represented as `Read(Offer(VulnerabilityReport))`'
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-01-008
+      note: RK shorthand → ACK_REPORT → this wire form
   - id: VAM-02-004
     priority: MUST
     statement: '`VALIDATE_REPORT` MUST be represented as `Accept(Offer(VulnerabilityReport))`'
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-01-003
+      note: RV shorthand → VALIDATE_REPORT → this wire form
   - id: VAM-02-005
     priority: MUST
     statement: >-
       `INVALIDATE_REPORT` MUST be represented as `TentativeReject(Offer(VulnerabilityReport))`
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-01-002
+      note: RI shorthand → INVALIDATE_REPORT → this wire form
   - id: VAM-02-006
     priority: MUST
     statement: '`CLOSE_REPORT` MUST be represented as `Reject(Offer(VulnerabilityReport))`'
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-01-006
+      note: RC shorthand → CLOSE_REPORT → this wire form
 - id: VAM-03
   title: Case Management Messages
   specs:
@@ -120,9 +140,17 @@ groups:
   - id: VAM-03-003
     priority: MUST
     statement: '`ENGAGE_CASE` MUST be represented as `Join(VulnerabilityCase)`'
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-01-005
+      note: RA shorthand → ENGAGE_CASE → this wire form
   - id: VAM-03-004
     priority: MUST
     statement: '`DEFER_CASE` MUST be represented as `Ignore(VulnerabilityCase)`'
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-01-004
+      note: RD shorthand → DEFER_CASE → this wire form
   - id: VAM-03-005
     priority: MUST
     statement: >-
@@ -182,6 +210,10 @@ groups:
   - id: VAM-05-003
     priority: MUST
     statement: '`REMOVE_EMBARGO_EVENT_FROM_CASE` MUST be represented as `Remove(Event)`'
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-02-007
+      note: ET shorthand → REMOVE_EMBARGO_EVENT_FROM_CASE → this wire form
   - id: VAM-05-004
     priority: MUST
     statement: >-
@@ -190,14 +222,35 @@ groups:
     priority: MUST
     statement: >-
       `INVITE_TO_EMBARGO_ON_CASE` MUST be represented as `Invite(Event)[context=VulnerabilityCase]`
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-02-001
+      note: EP shorthand → INVITE_TO_EMBARGO_ON_CASE → this wire form
+    - rel_type: satisfies
+      spec_id: MSM-02-003
+      note: EV shorthand (revision) → same wire form as EP
   - id: VAM-05-006
     priority: MUST
     statement: >-
       `ACCEPT_INVITE_TO_EMBARGO_ON_CASE` MUST be represented as `Accept(Invite(Event)[context=VulnerabilityCase])`
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-02-002
+      note: EA shorthand → ACCEPT_INVITE_TO_EMBARGO_ON_CASE → this wire form
+    - rel_type: satisfies
+      spec_id: MSM-02-005
+      note: EC shorthand (revision accepted) → same wire form as EA
   - id: VAM-05-007
     priority: MUST
     statement: >-
       `REJECT_INVITE_TO_EMBARGO_ON_CASE` MUST be represented as `Reject(Invite(Event)[context=VulnerabilityCase])`
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-02-006
+      note: ER shorthand → REJECT_INVITE_TO_EMBARGO_ON_CASE → this wire form
+    - rel_type: satisfies
+      spec_id: MSM-02-004
+      note: EJ shorthand (revision rejected) → same wire form as ER
 - id: VAM-06
   title: Case Participant Management Messages
   specs:
@@ -237,6 +290,25 @@ groups:
     priority: MUST
     statement: >-
       `ADD_CASE_STATUS_TO_CASE` MUST be represented as `Add(CaseStatus)[target=VulnerabilityCase]`
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-03-001
+      note: CV shorthand → ADD_CASE_STATUS_TO_CASE → this wire form
+    - rel_type: satisfies
+      spec_id: MSM-03-002
+      note: CF shorthand → ADD_CASE_STATUS_TO_CASE → this wire form
+    - rel_type: satisfies
+      spec_id: MSM-03-003
+      note: CD shorthand → ADD_CASE_STATUS_TO_CASE → this wire form
+    - rel_type: satisfies
+      spec_id: MSM-03-004
+      note: CP shorthand → ADD_CASE_STATUS_TO_CASE → this wire form
+    - rel_type: satisfies
+      spec_id: MSM-03-005
+      note: CX shorthand → ADD_CASE_STATUS_TO_CASE → this wire form
+    - rel_type: satisfies
+      spec_id: MSM-03-006
+      note: CA shorthand → ADD_CASE_STATUS_TO_CASE → this wire form
   - id: VAM-08-003
     priority: MUST
     statement: '`CREATE_PARTICIPANT_STATUS` MUST be represented as `Create(ParticipantStatus)`'


### PR DESCRIPTION
- Closes #1445
- Closes #1449

## Summary

Plans concern #1445 (no spec-level mapping from EM/CS/RM protocol shorthands
to AS2 wire types) and implements #1449 (create the normative mapping spec).

Adds `specs/message-semantics-mapping.yaml` (MSM prefix) — a flat normative
bridge from every protocol message shorthand (RS, EP, CV, etc.) to its
`MessageSemantics` enum value and VAM spec ID. Also adds `satisfies`
back-references from the relevant VAM items to MSM.

## Changes

- `specs/message-semantics-mapping.yaml` (new): 25 StatementSpec items in 3
  groups (MSM-01 RM, MSM-02 EM, MSM-03 CS). Documents all protocol shorthands
  including those with no AS2 dispatch entry (RE, EE, EK, CE, CK). EV/EJ/EC
  aliasing (same wire form as EP/ER/EA) explicitly documented.
- `specs/vultron-as2-mapping.yaml`: add `satisfies` relationships on
  VAM-02-002/003/004/005/006, VAM-03-003/004, VAM-05-003/005/006/007,
  VAM-08-002 pointing back to the corresponding MSM items
- `specs/README.md`: add MSM to prefix registry table; add
  `message-semantics-mapping.yaml` to Semantic–Wire Mapping section and
  Protocol conformance contextual-load row
- `notes/behavioral-conformance-specs.md`: add `specs/message-semantics-mapping.yaml`
  to `related_specs` frontmatter; adds "Protocol Shorthand → MessageSemantics →
  VAM Traceability" section with authoring rule for behavioral spec trigger values