### PR TITLE
docs: plan issue #1362 — lifecycle-staged domain types

### DIFF
--- a/docs/adr/0033-lifecycle-staged-case-types.md
+++ b/docs/adr/0033-lifecycle-staged-case-types.md
@@ -1,0 +1,200 @@
+---
+status: proposed
+date: 2026-07-15
+deciders: Allen D. Householder
+consulted: Claude Code (design session)
+---
+
+# Lifecycle-Staged Domain Types Anchored on Guaranteed-Field Changes
+
+## Context and Problem Statement
+
+`VulnerabilityCase` is the canonical "fat class" named in ADR-0032: one type
+represents a case at every lifecycle stage. Core functions that require a case
+to have reached a particular stage (e.g. "there is an active embargo") cannot
+express that requirement in their type signatures, so they fall back on runtime
+guards (`if case.active_embargo is None: ...`,
+`if case.current_status.em_state == EM.ACTIVE: ...`).
+
+The Idea (#1362) proposed distinct types per lifecycle stage — illustratively
+`IncomingReport`, `TriagedCase`, `ActiveCase` — so a core function accepting a
+stage-specific type would reject earlier-stage data at the type level, with no
+`if x is None` needed. The Idea explicitly deferred deriving the actual stages
+from the protocol until a design was reviewed.
+
+Two protocol facts, verified against the code, shape the answer and make the
+naive "one type per RM state" framing unworkable:
+
+1. **RM state is per-participant, not case-universal.** Each `CaseParticipant`
+   runs its own RM state machine (`ParticipantStatus.rm_state`). There is no
+   such thing as "the case is in RM.VALID" — valid according to *whom*? A case
+   type named `ValidCase`/`TriagedCase` would be ill-defined.
+2. **Only a few facts are genuinely case-universal.** Case existence,
+   structural minimums (≥1 report, reporter + receiver participants), the
+   embargo state (`EM`, one per case), and public state (`pxa`) are the only
+   monotonic facts that hold case-wide.
+
+## Decision Drivers
+
+- Make illegal *shapes* unrepresentable in core logic (ADR-0032 continuation).
+- Do not introduce a type whose fields are identical to its parent's — that is
+  ceremony without a type-checker payoff and invites combinatorial proliferation
+  (2³ for the independent P/X/A dimensions alone).
+- The design must survive DataLayer round-trip: rehydration always yields a
+  valid object, so the design must specify how a rehydrated record acquires its
+  staged type.
+- Reuse the existing precedents: the role-specific `CaseParticipant` subclasses,
+  the `RM_ACTIVE` / `EM_NEGOTIATING` state-group tuples, and the
+  `is_rm_at_least()` predicate family.
+
+## Considered Options
+
+1. **One type per RM/EM/CS state** — rejected: RM is per-participant, so most
+   such types are ill-defined at the case level.
+2. **Staged types on every state-bearing class, keyed on any monotonic
+   milestone** — rejected: proliferates types that add no fields.
+3. **Field-set-anchored staged types** (chosen): a milestone earns a type only
+   when it changes the guaranteed (non-None) field set; everything else is
+   modeled as predicates + preconditions.
+
+For the *mechanism* of the chosen option, two sub-options were weighed and are
+recorded under "Pros and Cons": Pydantic subclasses narrowing fields
+(recommended) vs. a discriminated union of sibling types.
+
+## Decision Outcome
+
+Chosen option: **field-set-anchored staged types**.
+
+### Governing principle
+
+> A lifecycle milestone earns a distinct staged **type** only when it changes
+> the set of guaranteed (required, non-None) fields. A milestone that only
+> changes *which actions are permitted* — without changing which fields are
+> present — belongs in the transition model and precondition specs, not the
+> type hierarchy.
+
+### What this yields
+
+- **`VulnerabilityCase` staged family (the only staged types):**
+  `IncomingReport` → `Case` → `EmbargoedCase`.
+  - `IncomingReport`: report data, no case assignment (pre-case).
+  - `Case`: a case exists — ADR-0015 creates it at report receipt, so it always
+    has ≥1 report, the reporter **and** receiver participants (two parties), and
+    a seeded `case_statuses`.
+  - `EmbargoedCase`: `em_state ∈ {ACTIVE, REVISE}`, so `active_embargo` is
+    **guaranteed non-None**. This is monotonic: EM never returns to
+    `NONE`/`PROPOSED` once `ACTIVE` (see `vultron/core/states/em.py`).
+- **`ParticipantStatus` and `CaseStatus`: no subtypes.** Their per-participant
+  RM/vfd ratchets and case-level EM/pxa ratchets change enum *values*, not the
+  field set. They are modeled as **state-group tuples + predicates**
+  (`RM_VALIDATED`, `is_rm_validated()`, …) extending the existing
+  `RM_ACTIVE`/`EM_NEGOTIATING`/`is_rm_at_least()` helpers.
+- **P/X/A option-gating** (e.g. "no embargo may be proposed once the case is
+  public, exploit is public, or attacks are observed"; "an active embargo must
+  terminate on publication") is modeled as **precondition specs + transition
+  guards**, not a `PublicCase` type.
+
+### Read mechanism (promotion at the edge)
+
+The staged subtype's own `model_validator` *is* the promotion logic. A core
+function that requires a narrowed type calls
+`EmbargoedCase.model_validate(case)` at its entry boundary: on success it holds
+the narrow type and the type checker is satisfied downstream; on invariant
+violation the validation **raises immediately** — a descriptive fail-fast at the
+boundary rather than a silent `None` propagated into core logic. This is
+ADR-0032's "validate at the edge, promote to strict core types" applied at the
+DataLayer read boundary. There is no separate hand-written promotion function;
+the constructor carries the invariant.
+
+### Transition model (write side)
+
+The case *data* is the single source of truth; the staged type is **always
+re-derived, never stored**. Advancing a case is an ordinary field mutation
+(setting `active_embargo` when EM reaches `ACTIVE`), exactly as today's use
+cases and BT nodes already do. No stored "stage" field and no explicit
+`transition()` constructors, which would create a second place transitions can
+happen and risk divergence from the existing write paths.
+
+*(Recorded at ~70% confidence. The alternative — explicit transition
+constructors such as `case.to_embargoed(embargo)` — is documented below and may
+be reopened if the code-migration audit shows the field-mutation path is
+error-prone in practice.)*
+
+### Consequences
+
+- Good: core function signatures express stage requirements; the type checker
+  enforces "this function needs an embargoed case."
+- Good: no combinatorial type explosion — P/X/A stay flags; RM/vfd ratchets stay
+  predicates.
+- Good: consistent single principle across all three state-bearing classes.
+- Good: read-boundary narrowing reuses ADR-0032 and Pydantic `model_validate`.
+- Neutral: staged subtypes share `type_="VulnerabilityCase"`, so the DataLayer
+  stores them in one table and rehydrates the base type; the staged type is a
+  *view* derived on demand (see read mechanism). This is deliberate.
+- Bad: requires incremental migration of existing core call sites (tracked as a
+  follow-up implementation issue).
+
+## Validation
+
+- Full per-stage field inventory written into
+  `specs/lifecycle-staged-types.yaml` confirms each staged type adds a
+  guaranteed field (else it would not earn a type).
+- DataLayer round-trip test: persist an `EmbargoedCase`, `dl.read()` it, and
+  `EmbargoedCase.model_validate()` the result successfully; persist a
+  pre-embargo `Case` and assert the same validate call raises.
+- mypy/pyright clean on the staged-type module.
+
+## Pros and Cons of the Options
+
+### Field-set-anchored staged types (chosen)
+
+- Good, because it introduces types only where they carry a real field
+  guarantee.
+- Good, because it keeps a single, defensible rule for the whole domain model.
+- Neutral, because per-participant/pxa ratchets become predicates rather than
+  types.
+
+### Mechanism sub-option A — Pydantic subclasses narrowing fields (recommended)
+
+- Good, because `model_validate` narrowing works for free (the read mechanism).
+- Good, because it mirrors the `CaseParticipant` role-subclass proof-of-concept
+  and the `CoreObject` `published`/`updated` re-narrowing already in
+  `vultron/core/models/base.py`.
+- Neutral, because subclasses share the parent `type_`, so the staged type is
+  derived on read rather than stored.
+
+### Mechanism sub-option B — discriminated union of sibling types
+
+- Good, because stages are cleanly separated classes.
+- Bad, because it does not reuse the existing subclass-narrowing precedent.
+- Bad, because it complicates DataLayer type resolution and CORE_VOCABULARY
+  registration.
+
+### Transition sub-option — explicit transition constructors (alternative)
+
+- Good, because transitions are centralized and self-documenting.
+- Bad, because it adds a second write path alongside the field mutations that
+  BT nodes and use cases already perform, risking divergence.
+
+## More Information
+
+Related:
+
+- ADR-0032 — Validate at the Edge, Promote to Strict Core Types (this ADR
+  extends it to lifecycle staging and to the read boundary).
+- ADR-0015 — Create VulnerabilityCase at Report Receipt (defines the
+  `IncomingReport → Case` boundary).
+- ADR-0017 — Domain/Wire Object Separation (staged types live on the core
+  branch).
+- #1362 — the source Idea.
+- `notes/lifecycle-staged-types.md` — full design guidance, three-class
+  analysis, and the per-dimension-status **Future direction** trailhead.
+- `notes/domain-model-separation.md`, `notes/domain-validation.md`.
+
+**Future direction (tracked separately, not this decision):** decomposing
+`CaseStatus`/`ParticipantStatus` into per-machine dimension objects (each state
+machine its own small object with its own transition method) would make illegal
+*transitions* unrepresentable and give the scattered EM/RM logic a home. It is
+schema-touching (wire + persistence) and deserves its own ADR.
+
+Generated spec requirements: `lifecycle-staged-types.yaml` LST-01 through LST-05.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -103,6 +103,8 @@ General information about architectural decision records is available at <https:
 - [ADR-0030 Publish Leaf Expansion: Single Actuator →
   Draft-Review-Submit Pipeline](0030-publish-leaf-draft-review-submit-pipeline.md)
   *(provisional)*
+- [ADR-0033 Lifecycle-Staged Domain Types Anchored on Guaranteed-Field
+  Changes](0033-lifecycle-staged-case-types.md)
 
 ## Rejected ADRs
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -244,6 +244,7 @@ nav:
       - Publish Leaf Draft-Review-Submit Pipeline: 'adr/0030-publish-leaf-draft-review-submit-pipeline.md'
       - vultron/enums/ Neutral Layer: 'adr/0031-vultron-enums-neutral-layer.md'
       - Validate at Edge, Promote to Core: 'adr/0032-validate-at-edge-promote-to-core.md'
+      - Lifecycle-Staged Domain Types: 'adr/0033-lifecycle-staged-case-types.md'
   - About:
     - Contributing: 'about/contributing.md'
     - FAQ: 'about/faq.md'

--- a/notes/README.md
+++ b/notes/README.md
@@ -319,6 +319,18 @@ configuration.
 
 ## Case and Data Model
 
+**`lifecycle-staged-types.md`**
+Design guidance for lifecycle-staged domain types (ADR-0033): the field-set
+governing principle (a milestone earns a type only when it changes the
+guaranteed-field set), the three-class analysis (only `VulnerabilityCase` gets
+staged types — `IncomingReport` → `Case` → `EmbargoedCase`; `ParticipantStatus`
+and `CaseStatus` use predicates + state groups), the `model_validate`-at-edge
+read mechanism, the data-as-source-of-truth transition model, the DataLayer
+round-trip constraint, and the per-dimension-status decomposition trailhead.
+**Load when**: designing or reviewing staged domain types, deciding whether a
+lifecycle milestone should be a type vs. a predicate/precondition, or working on
+`specs/lifecycle-staged-types.yaml` (LST) requirements.
+
 **`case-state-model.md`**
 VFD/PXA case state hypercube, potential actions per state, measuring CVD
 quality, participant-specific vs participant-agnostic state, append-only

--- a/notes/lifecycle-staged-types.md
+++ b/notes/lifecycle-staged-types.md
@@ -1,0 +1,159 @@
+---
+title: Lifecycle-Staged Domain Types
+status: active
+description: >
+  Design guidance for lifecycle-staged domain types anchored on guaranteed-field
+  changes: the field-set governing principle, the three-class analysis, the
+  model_validate-at-edge read mechanism, the data-as-source-of-truth transition
+  model, and the DataLayer round-trip constraint.
+related_specs:
+  - specs/lifecycle-staged-types.yaml
+  - specs/architecture.yaml
+related_notes:
+  - notes/domain-model-separation.md
+  - notes/domain-validation.md
+  - notes/case-state-model.md
+relevant_packages:
+  - vultron/core/models
+  - vultron/core/states
+---
+
+# Lifecycle-Staged Domain Types
+
+Design note for ADR-0033. Records *why* the staged-type design is shaped the way
+it is; the normative requirements live in `specs/lifecycle-staged-types.yaml`
+(LST-01 through LST-05), and the decision record is
+`docs/adr/0033-lifecycle-staged-case-types.md`.
+
+## The Problem
+
+`VulnerabilityCase` is the "fat class" named in ADR-0032: one type for a case at
+every lifecycle stage. Core functions that need a case to have reached a stage
+(e.g. "there is an active embargo") cannot say so in their signatures and fall
+back on runtime guards (`if case.active_embargo is None`,
+`case.current_status.em_state == EM.ACTIVE`).
+
+Note that the *current* `VulnerabilityCase` has almost no literal `X | None`
+fields — only `active_embargo`; its collections already default to empty. The
+real problem is not annotation noise but that **one class represents a case at
+every stage**, so functions cannot type-demand a stage.
+
+## The Governing Principle
+
+> A lifecycle milestone earns a distinct staged **type** only when it changes
+> the set of guaranteed (required, non-None) fields. A milestone that only
+> changes *which actions are permitted* — without changing which fields are
+> present — belongs in the transition model and precondition specs, not the
+> type hierarchy.
+
+This single rule resolves every tension below and prevents type proliferation
+(the P/X/A dimensions alone would otherwise imply 2³ combinations).
+
+## Three-Class Analysis
+
+The domain has three state-bearing classes. Applying the principle to each:
+
+### VulnerabilityCase — case-universal facts (earns types)
+
+RM state is **per-participant**, so "the case is valid/accepted" is undefined
+(valid according to whom?). Only these facts are case-universal and monotonic:
+
+| Milestone | Adds a guaranteed field? | Result |
+|---|---|---|
+| Case exists (ADR-0015 create-on-receipt) | Yes — participants, reports, seeded status | **`Case` type** |
+| Embargo active (`em_state ∈ {ACTIVE, REVISE}`) | Yes — `active_embargo` non-None | **`EmbargoedCase` type** |
+| Public / exploit / attacks (P/X/A) | No — `pxa_state` is always present | status flag + precondition |
+
+Plus the pre-case boundary: `IncomingReport` (report data, no case).
+
+So the VulnerabilityCase family is exactly **`IncomingReport` → `Case` →
+`EmbargoedCase`**. A `Case` always has ≥1 report and the reporter + receiver
+participants (two parties, because Vultron creates the case on receipt and both
+sides are present at that moment).
+
+The embargo milestone is monotonic: the EM machine
+(`vultron/core/states/em.py`) never returns to `NONE`/`PROPOSED` once `ACTIVE`.
+
+### ParticipantStatus — per-participant RM/vfd (no types)
+
+`rm_state` and `vfd_state` are always-present enum fields. The RM.VALID ratchet
+is real (once VALID you cannot return to RECEIVED/INVALID; CLOSED only via
+ACCEPTED/DEFERRED) and the vfd path is monotonic (`v→V→F→D`), but neither adds a
+field. Per LST-01-001 they earn **no subtype**. They become state-group tuples
+and predicates — e.g. `RM_VALIDATED`, `is_rm_validated()` — alongside the
+existing `RM_ACTIVE`, `RM_CLOSABLE`, `EM_NEGOTIATING`, and `is_rm_at_least()`
+helpers.
+
+### CaseStatus — case-level EM/pxa (no types)
+
+`em_state` and `pxa_state` are always-present enums; no milestone adds a field.
+Same outcome as `ParticipantStatus`: predicates + state groups, no subtypes.
+
+## P/X/A: Preconditions, Not Types
+
+The public/exploit/attack dimensions change *which actions are permitted* (you
+cannot propose an embargo once any of P/X/A is set; an active embargo must
+terminate on publication) but change no field. They are modeled as **precondition
+specs + transition guards** (LST-01-002, LST-05), never a `PublicCase` type.
+This is deliberately parallel to how RM ratchets are handled — a consistent
+principle across all three classes.
+
+## Read Mechanism: model_validate at the Edge
+
+Staged subtypes share `type_="VulnerabilityCase"` (like the `CaseParticipant`
+role subclasses share `type_="CaseParticipant"`), so the DataLayer stores them
+in one table and rehydrates the **base** type. The staged type is a **view
+derived on demand**, not a stored discriminator.
+
+A core function that needs a narrowed type validates at its entry boundary:
+
+```python
+# dl.read() returns a generic Case; the edge narrows it.
+embargoed = EmbargoedCase.model_validate(case)   # raises if no active embargo
+# ... downstream code holds EmbargoedCase; active_embargo is guaranteed.
+```
+
+The subtype's own `model_validator` **is** the promotion logic — there is no
+separate hand-written promotion function. On invariant violation it raises a
+descriptive error at the boundary (fail-fast), never a silent `None` propagated
+into core. This is ADR-0032 applied at the read boundary.
+
+## Transition Model: Data Is the Source of Truth
+
+The case *data* is the single source of truth; the stage is **always re-derived,
+never stored** (LST-05-002). Advancing a case is an ordinary field mutation
+(setting `active_embargo` when EM reaches `ACTIVE`), exactly as today's BT nodes
+and use cases already do. No stored "stage" field and no explicit
+`transition()` constructors — a second write path would risk divergence from the
+existing mutation paths.
+
+*(Recorded at moderate confidence. The alternative — explicit transition
+constructors like `case.to_embargoed(embargo)` — is documented in ADR-0033 and
+may be reopened if the code-migration audit shows the field-mutation path is
+error-prone.)*
+
+## DataLayer Round-Trip Constraint
+
+Round-trip compatibility is a binding design constraint (LST-05-003): a persisted
+staged object must rehydrate to the base type and re-validate to its staged type
+without loss. Register the base type in `CORE_VOCABULARY` as today; do not add a
+persisted stage discriminator.
+
+## Future Direction: Per-Dimension Status Decomposition
+
+A natural next layer — **not** part of ADR-0033 — is decomposing
+`CaseStatus`/`ParticipantStatus` into per-machine dimension objects (each state
+machine its own small object with its own `transition()`/guard method), e.g.
+`ParticipantStatus` → `{report: RmState, fix: VfdState, consent: PecState}`.
+
+Where it helps: it gives the scattered EM/RM transition logic (see
+`notes/embargo-lifecycle.md`, #538) one home, models the genuinely independent
+dimensions faithfully, and composes with staged types (the `is_rm_validated()`
+predicates become methods on the RM dimension). Staged types make illegal
+*shapes* unrepresentable; dimension objects make illegal *transitions*
+unrepresentable.
+
+Where it gets messier: it is a wire- and persistence-visible schema change
+(rehydration, `CORE_VOCABULARY`, AS2 projection, and the append-only
+history model all interact), so it deserves its **own ADR** and must not be
+folded into the staged-types work. Tracked as a separate Idea issue.

--- a/plan/history/2607/idea/IDEA-1362.md
+++ b/plan/history/2607/idea/IDEA-1362.md
@@ -1,0 +1,44 @@
+---
+source: IDEA-1362
+timestamp: '2026-07-15T17:25:18.658267+00:00'
+title: Lifecycle-staged VulnerabilityCase types
+type: idea
+---
+
+## Idea
+
+`VulnerabilityCase` is a "fat class" — one type representing a case at every
+lifecycle stage, forcing Optional fields and `if x is None` guards throughout
+core logic (the canonical fat-class example named in ADR-0032). The Idea
+proposed distinct types per lifecycle stage (illustratively `IncomingReport`,
+`TriagedCase`, `ActiveCase`) so core functions accept a stage-specific type and
+reject earlier-stage data at the type level. The lifecycle stages were to be
+derived carefully from the RM/EM/CS protocol, not guessed. The role-specific
+`CaseParticipant` subclasses were cited as an in-codebase proof-of-concept.
+
+**Processed**: 2026-07-15 — planned into a reviewed design.
+
+Key design outcomes (see ADR-0033):
+
+- **Governing principle**: a lifecycle milestone earns a distinct staged *type*
+  only when it changes the set of guaranteed (non-None) fields; milestones that
+  only gate permitted actions become predicates + preconditions.
+- RM state is **per-participant**, not case-universal, so case-level RM types
+  (ValidCase/TriagedCase) are ill-defined. The `VulnerabilityCase` staged family
+  is exactly `IncomingReport` → `Case` → `EmbargoedCase`.
+- `ParticipantStatus` and `CaseStatus` get **no subtypes** (their state fields
+  add no columns) — RM/vfd/EM/pxa ratchets become predicates + state-group
+  tuples. P/X/A option-gating becomes precondition guards.
+- Read-boundary promotion via `StagedType.model_validate(case)` (ADR-0032
+  applied at the DataLayer read boundary); data is the single source of truth,
+  stage is always re-derived.
+
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1451>.
+Spec: `specs/lifecycle-staged-types.yaml` (LST-01 through LST-05).
+Notes: `notes/lifecycle-staged-types.md`.
+ADR: `docs/adr/0033-lifecycle-staged-case-types.md`.
+
+Implementation tracked in the following, all blocked-by #1362 and children of
+epic #1394: #1452 (staged types), #1453 (ratchet predicates), #1454 (P/X/A
+precondition guards), and #1455 (migrate core call sites). The
+per-dimension-status decomposition trailhead is tracked as Idea #1456.

--- a/specs/README.md
+++ b/specs/README.md
@@ -74,6 +74,7 @@ Load additional files only when the task touches the relevant area. See the
 | Inbox orchestration (core BT module + InboxOutcome seam) | `inbox-orchestration.yaml` |
 | Behavior Trees | `behavior-tree-integration.yaml`, `behavior-tree-node-design.yaml`, `bt-composability.yaml`, `triggerable-behaviors.yaml`, `vultron/core/use_cases/triggers/AGENTS.md` |
 | Case / state management | `case-management.yaml`, `state-machine.yaml`, `case-ledger-processing.yaml` |
+| Lifecycle-staged domain types | `lifecycle-staged-types.yaml`, `notes/lifecycle-staged-types.md` |
 | CaseProposal protocol (distributed case actor initialization) | `case-proposal.yaml` |
 | Protocol conformance | `vultron-protocol-spec.yaml`, `vultron-as2-mapping.yaml` |
 | Wire vocabulary | `vocabulary-model.yaml` |

--- a/specs/lifecycle-staged-types.yaml
+++ b/specs/lifecycle-staged-types.yaml
@@ -1,0 +1,136 @@
+id: LST
+title: Lifecycle-Staged Domain Types
+description: >-
+  Rules for lifecycle-staged domain types anchored on guaranteed-field changes.
+  A milestone earns a distinct staged type only when it changes the set of
+  required (non-None) fields; milestones that only gate permitted actions are
+  modeled as predicates and preconditions. Derived from ADR-0033 and extends
+  ADR-0032 (validate at the edge). See `notes/lifecycle-staged-types.md` for
+  design rationale and the three-class analysis.
+version: 0.1.0
+kind: domain
+scope:
+- prototype
+- production
+groups:
+- id: LST-01
+  title: Field-Set Governing Principle
+  specs:
+  - id: LST-01-001
+    priority: MUST
+    statement: >-
+      A lifecycle milestone MUST be modeled as a distinct staged type only when
+      it changes the set of guaranteed (required, non-None) fields on the domain
+      object.
+    rationale: >-
+      A subtype whose field set is identical to its parent's adds type ceremony
+      without a type-checker payoff and invites combinatorial proliferation.
+      See ADR-0033.
+  - id: LST-01-002
+    priority: MUST
+    statement: >-
+      A milestone that only changes which actions are permitted, without
+      changing which fields are present, MUST be modeled in the transition model
+      and precondition specs, not as a distinct type.
+    rationale: >-
+      Action-gating is a precondition on transitions, not a change in data
+      shape. See ADR-0033 and LST-05.
+- id: LST-02
+  title: VulnerabilityCase Staged Types
+  specs:
+  - id: LST-02-001
+    priority: MUST
+    statement: >-
+      The VulnerabilityCase staged family MUST consist of exactly three types:
+      `IncomingReport` (report data, no case), `Case` (a case exists), and
+      `EmbargoedCase` (an embargo is active), because only these boundaries
+      change the guaranteed-field set.
+    rationale: >-
+      Case existence and embargo-active each add a guaranteed field; no other
+      case-universal milestone does. See ADR-0033.
+  - id: LST-02-002
+    priority: MUST
+    statement: >-
+      A `Case` MUST guarantee at least one vulnerability report, the reporter
+      and receiver participants (at least two parties), and a seeded
+      `case_statuses` list.
+    rationale: >-
+      ADR-0015 creates the case at report receipt, so these structural minimums
+      always hold for any case that exists.
+    relationships:
+    - rel_type: depends_on
+      spec_id: ARCH-10-001
+  - id: LST-02-003
+    priority: MUST
+    statement: >-
+      An `EmbargoedCase` MUST guarantee `active_embargo` is non-None and
+      `em_state` is in {ACTIVE, REVISE}.
+    rationale: >-
+      The EM machine never returns to NONE/PROPOSED once ACTIVE, so this is a
+      monotonic milestone with a genuine type-level non-None guarantee.
+  - id: LST-02-004
+    priority: MUST_NOT
+    statement: >-
+      Per-participant RM state (valid, accepted, deferred) MUST NOT be modeled
+      as a VulnerabilityCase staged type.
+    rationale: >-
+      RM state is per-participant, not case-universal; a case-level RM type is
+      ill-defined ("valid according to whom?"). See LST-04.
+- id: LST-03
+  title: No Subtypes for Status Objects
+  specs:
+  - id: LST-03-001
+    priority: MUST_NOT
+    statement: >-
+      `ParticipantStatus` and `CaseStatus` MUST NOT be given lifecycle-staged
+      subtypes, because no RM/vfd/EM/pxa milestone adds a field to them.
+    rationale: >-
+      Their state fields are always-present enums; milestones change values, not
+      the field set. Per LST-01-001 they earn no type. See ADR-0033.
+- id: LST-04
+  title: Ratchets as Predicates and State Groups
+  specs:
+  - id: LST-04-001
+    priority: MUST
+    statement: >-
+      Per-participant RM and vfd ratchets, and case-level EM and pxa ratchets,
+      MUST be modeled as state-group tuples and `is_*()` predicates, extending
+      the existing `RM_ACTIVE` / `EM_NEGOTIATING` / `is_rm_at_least()` helpers in
+      `vultron/core/states/`.
+    rationale: >-
+      These milestones are monotonic value transitions without field-set
+      changes; predicates give ergonomic checks without a subtype. See ADR-0033.
+- id: LST-05
+  title: Read-Boundary Promotion and Transition Model
+  specs:
+  - id: LST-05-001
+    priority: MUST
+    statement: >-
+      A core function requiring a narrowed staged type MUST obtain it by
+      validating the generic object at its entry boundary (e.g.
+      `EmbargoedCase.model_validate(case)`), which narrows on success and raises
+      immediately on invariant violation.
+    rationale: >-
+      Applies ADR-0032's validate-at-the-edge pattern at the DataLayer read
+      boundary; the subtype's own validator is the promotion logic.
+    relationships:
+    - rel_type: depends_on
+      spec_id: ARCH-15-002
+  - id: LST-05-002
+    priority: MUST_NOT
+    statement: >-
+      The lifecycle stage MUST NOT be stored as a persisted field; the staged
+      type MUST always be re-derived from the case data, which is the single
+      source of truth.
+    rationale: >-
+      A stored stage can drift from the underlying invariants, creating two
+      sources of truth. See ADR-0033 transition model.
+  - id: LST-05-003
+    priority: MUST
+    statement: >-
+      Staged types MUST remain round-trippable through the DataLayer: a
+      persisted staged object rehydrates to the base type and re-validates to its
+      staged type without loss.
+    rationale: >-
+      Rehydration always yields a valid object; the staged-type guarantee must
+      survive persistence. See ADR-0033.


### PR DESCRIPTION
- Closes #1362

## Summary

Design plan for lifecycle-staged domain types, converting Idea #1362 into a
reviewed design (ADR + specs + notes) plus tracked implementation issues.

The design settles a governing principle: **a lifecycle milestone earns a
distinct staged type only when it changes the set of guaranteed (non-None)
fields; milestones that only gate permitted actions become predicates and
preconditions.** Applied across the three state-bearing classes, this yields a
single staged family on `VulnerabilityCase` (`IncomingReport` → `Case` →
`EmbargoedCase`) and predicates/state-groups everywhere else — resolving the
"valid according to whom?" trap that comes from RM state being per-participant,
not case-universal.

## Changes

- **`docs/adr/0033-lifecycle-staged-case-types.md`** — the decision: field-set
  governing principle; three-class analysis; `model_validate`-at-edge read
  mechanism (ADR-0032 applied at the DataLayer read boundary); data-as-
  source-of-truth transition model (recommended, with explicit-constructor
  alternative recorded); DataLayer round-trip constraint; per-dimension-status
  Future-direction trailhead.
- **`specs/lifecycle-staged-types.yaml`** — LST-01 through LST-05: the
  governing principle, the three `VulnerabilityCase` staged types and their
  field guarantees, no-subtypes-for-status rule, ratchets-as-predicates rule,
  and the read-boundary/transition/round-trip requirements.
- **`notes/lifecycle-staged-types.md`** — design rationale, the three-class
  table, worked read/transition examples, and the Future-direction trailhead.
- Index/nav updates: `specs/README.md`, `notes/README.md`,
  `docs/adr/index.md`, `mkdocs.yml`.

## Notes for reviewers

- Implementation issues are created separately, blocked-by #1362 and childed to
  epic #1394; the trailhead (per-dimension status decomposition) is tracked as a
  separate Idea.
- **Pre-existing, unrelated:** `uv run spec-dump` currently fails on `main`
  because `specs/{rm,em,cs}-behavior.yaml` use `rel_type: satisfies`, which the
  active validator's enum rejects (though `SATISFIES` exists in
  `vultron/metadata/specs/schema.py`). This predates this branch and is not
  touched here; the pre-commit spec-registry linter passes. Flagging for a
  follow-up.
- The `mkdocs --strict` wrapper reports 1 "real" warning from pre-existing
  `context`/`pytest` bib keys (documented in
  `plan/incoming/learnings/20260710-mkdocs-nav-omitted-files-guard.md`); none of
  the warnings reference the files in this PR.