### PR TITLE
docs: promote learnings — BT, config, wire, testing, tooling (Jul 10–15)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -908,6 +908,81 @@ Short entries are reproduced here; longer ones are referenced below.
   return `Status.FAILURE` (BT nodes) immediately.
   See [notes/domain-validation.md](notes/domain-validation.md) and
   `specs/architecture.yaml` ARCH-15-001 through ARCH-15-004.
+- **`outbox_list()` Requires `clone_for_actor` in Tests** — `SqliteDataLayer.outbox_list()` reads
+  from `dl._actor_id`, which is `""` on a freshly constructed DataLayer.
+  BT nodes write to the named actor's queue via `record_outbox_item(actor_id, ...)`.
+  The two paths share a key only when the DataLayer was obtained via `clone_for_actor(actor_id)`.
+  Use `dl.outbox_list_for_actor(local_actor_id)` or `dl.clone_for_actor(actor_id).outbox_list()` in tests.
+  See [notes/datalayer-design.md](notes/datalayer-design.md) § "`outbox_list()` Requires `clone_for_actor` in Tests".
+- **Happy-Path DL Seed Must Include `origin` Activities for `dl.read()` Calls** — Use cases that call
+  `dl.read(activity_id)` to resolve a related entity (e.g., `recommender_id`) silently fall back to
+  `""` / `None` when the activity is absent from the fixture. Assert `len(outbox) >= N` where N is
+  the *expected* count, not just `>= 1` — a partial emission can pass a weak assertion while hiding
+  a broken notification branch. See [notes/datalayer-design.md](notes/datalayer-design.md)
+  § "Happy-Path DL Seeds Must Include Origin Activities for `dl.read()` Calls".
+- **`UnroutableActivityError` Must Be Caught Inside `_handle`, Not Above It** — A gate/guard called
+  before the `try/except` in `DispatcherBase._handle` escapes to `_process_inbox_item`, which re-queues
+  the item — creating an infinite retry loop. Wrap gate calls in their own `try/except UnroutableActivityError`
+  inside `_handle` and return (drop the event). General rule: when converting a silent `return None`
+  into a `raise`, trace the full call stack to every re-queue/retry handler above the raise site.
+  See [notes/inbox-pipeline.md](notes/inbox-pipeline.md) § "`UnroutableActivityError` Must Be Caught Inside `_handle`".
+- **Blackboard List Write-Back: Only Needed for New Lists** — Mutating a list object retrieved from
+  the blackboard is in-place; the write-back (`blackboard.set(key, value)`) is a no-op unless `key`
+  was absent (KeyError branch) and you just created the list. Do not add write-backs to mutation
+  paths that already hold a reference — they create noise without effect.
+  See [notes/bt-integration.md](notes/bt-integration.md) § "Blackboard List Mutation: Write-Back Is Redundant".
+- **Always Check `BTBridge.execute_with_setup` Return Value** — `execute_with_setup` never raises;
+  it returns the `Status` enum. A FAILURE return left unchecked looks like SUCCESS. Always do:
+  `if bridge.execute_with_setup(...) == Status.FAILURE: raise VultronBTError(...)`.
+  See [notes/bt-integration.md](notes/bt-integration.md) § "Always Check `BTBridge.execute_with_setup` Return Value".
+- **Ledger Commit Must Precede Outbox Write** — When a use case or BT node both commits a ledger
+  entry and writes to the outbox, the commit MUST happen first. Writing to the outbox before
+  the ledger commit produces a state where outbound activities have been sent but the causal record
+  is absent from the ledger. See [notes/bt-integration.md](notes/bt-integration.md)
+  § "Ledger Commit Must Precede Outbox Write".
+- **`disposition="rejected"` for Local-Only Correlation Markers** — A ledger entry that records a
+  *local* correlation or rejection event (not a canonical CaseActor-accepted assertion) MUST use
+  `disposition="rejected"`. Using the default `"accepted"` disposition for non-canonical markers
+  pollutes the authoritative ledger. See [notes/bt-integration.md](notes/bt-integration.md)
+  § "Use `disposition="rejected"` for Local-Only Ledger Correlation Markers".
+- **Semantic Registry Pattern Must Match Inbound Wire Format** — The semantic registry key for
+  an activity type MUST match the inbound wire format (e.g., `SuggestActorToCasePattern`), NOT
+  the outbound factory output (e.g., `OfferActorToCasePattern`). Registering the outbound pattern
+  means the registry never fires for inbound messages of that type. See
+  [notes/activitystreams-semantics.md](notes/activitystreams-semantics.md)
+  § "Semantic Registry Patterns Must Match Inbound Wire Format".
+- **`offer_case_participant_activity`: `event.object_id` Has `#participant` Suffix** —
+  `event.object_id` is the CaseParticipant URI (with `#participant` suffix), not the actor URI.
+  Extract `actor_id` from `event.attributed_to`, not `event.object_id`. See
+  [notes/activitystreams-semantics.md](notes/activitystreams-semantics.md)
+  § "`offer_case_participant_activity`: `event.object_id` Has `#participant` Suffix".
+- **Pre-Build Dedup Sets Before Fallback Loops** — When skipping already-checked IDs inside a loop
+  using membership in `dict.values()`, pre-build `seen = set(d.values())` once before the loop.
+  Each `in d.values()` is O(n); the `set` makes it O(1) per check, reducing O(n×m) to O(n+m).
+- **Consolidated Helper Needs One Test Per Distinct Lookup Path** — When unifying two helpers into
+  one function with N distinct lookup paths (e.g., primary index + fallback scan), each path must
+  have at least one test where it is the sole source of truth (all other paths left empty). Tests
+  that always populate the fallback path leave the primary path untested. See
+  [notes/bt-integration.md](notes/bt-integration.md) § "Dual-Path Consolidation Test Gap".
+- **Domain Sweep Audit: Catalog → Code, Then Factory Injection, Then `register_key`** — For
+  FUZZ-08h-style completeness audits: (1) AST-parse demo/fuzzer classes for a flat inventory,
+  (2) cross-ref catalog `New-arch cross-ref:` lines for gaps, (3) grep `CallOutBackendFactory`
+  in all tree builders, (4) grep `register_key` for naming conflicts. Closed issues referenced by
+  `*(to be implemented — see FUZZ-08x)*` entries must be checked: if the issue is closed but
+  the class is absent, it's a gap. See [notes/bt-fuzzer-nodes-report-management.md](notes/bt-fuzzer-nodes-report-management.md)
+  § "Sentinel Stubs Must Be Synced When the Upstream Issue Closes".
+- **MkDocs `not_in_nav` and `exclude_docs` Are Not the Same** — `exclude_docs` prevents files from
+  appearing in the published build but does NOT satisfy the `validation.nav.omitted_files` guard.
+  Files intentionally excluded from the nav MUST ALSO be listed in `not_in_nav`. Also: when using
+  `INHERIT: mkdocs.yml`, the `not_in_nav` list in the overlay **replaces** (not extends) the base
+  list. The strict local build script `mkdocs-build-strict.sh` is the right gate; CI's
+  `docs-build-check.yml` runs non-strict and does not surface `omitted_files: warn` failures.
+- **Pre-commit Hooks Interfere with `git rebase` in Worktrees** — `git rebase origin/main` in a
+  worktree fails with "local changes would be overwritten" even on a clean tree when pre-commit
+  hooks (black, flake8) modify files during the checkout step. Workaround: use
+  `manage_worktree.sh ensure-synced` (preferred), or abort the rebase and create a fresh branch
+  from `origin/main` directly (`git switch -c <branch> origin/main`). Do NOT run
+  `git rebase` raw in a worktree without confirming pre-commit hooks are hook-only (check-mode).
 
 ## Skill Interaction Rules
 

--- a/docs/codebase/CONVENTIONS.md
+++ b/docs/codebase/CONVENTIONS.md
@@ -1,0 +1,70 @@
+# Coding Conventions
+
+## Core Sections (Required)
+
+### 1) Naming Rules
+
+| Item | Rule | Example | Evidence |
+|------|------|---------|----------|
+| Python modules | `snake_case.py` | `datalayer_sqlite.py`, `bt_node.py` | Any source file in `vultron/` |
+| Classes | `PascalCase` | `VulnerabilityCase`, `SqliteDataLayer` | `vultron/core/models/case.py` |
+| Wire-layer AS2 vocab classes | `as_` prefix + `PascalCase` | `as_VulnerabilityCase`, `as_Activity` | `vultron/wire/as2/vocab/objects/` |
+| Use-case classes | `Svc` prefix + noun + action + `UseCase` | `SvcCloseReportUseCase`, `SvcEngageCaseUseCase` | `vultron/core/use_cases/triggers/` |
+| Use-case trigger request models | noun + `TriggerRequest` suffix | `AcceptCaseInviteTriggerRequest` | `vultron/core/use_cases/triggers/requests.py` |
+| Functions / methods | `snake_case` | `get_config()`, `load_actor_config()` | `vultron/config/app.py` |
+| Constants / env vars | `UPPER_SNAKE_CASE` | `VULTRON_CONFIG`, `VULTRON_DATABASE__DB_URL` | `vultron/config/app.py`, `.env.example` |
+| Domain abbreviation | `vul` (not `vuln`) for vulnerability | `VulnerabilityCase`, `VulnDiscovery` | `AGENTS.md` |
+| CVD sub-protocol abbreviations | `em` (embargo), `rm` (report management), `cs` (case state) | `vultron/bt/embargo_management/`, `vultron/core/states/em.py` | Directory listing |
+| Test files | `test_<module>.py` | `test_config.py`, `test_states_em.py` | `test/` layout |
+| Spec IDs | `<TOPIC>-<NN>-<NNN>` | `ARCH-01-001`, `CFG-07-002` | `specs/*.yaml` |
+
+### 2) Formatting and Linting
+
+- **Formatter**: black, `line-length = 79`, targets Python 3.8–3.13 — config in `pyproject.toml` `[tool.black]`
+- **Linter**: flake8 — config in `.flake8` (ignores E203, E501; max complexity 10; excludes `docs/`, `build/`, `dist/`)
+- **Type checkers**: mypy + pyright (both run in CI, both must pass)
+- **Import ordering**: isort with `profile = "black"` — config in `pyproject.toml` `[tool.isort]`
+- **Markdown**: markdownlint-cli2 via `mdlint.sh`
+- **Most relevant enforced rules**: line length 79, max cyclomatic complexity 10, unused imports allowed only in `__init__.py` (F401), both mypy and pyright must pass
+- **Run commands**:
+
+  ```bash
+  uv run black .          # format
+  uv run flake8 vultron/ test/  # lint
+  uv run mypy             # type-check
+  uv run pyright          # type-check (second pass)
+  ./mdlint.sh             # markdown lint
+  ```
+
+### 3) Import and Module Conventions
+
+- **Import grouping/order**: stdlib → third-party → local; isort enforces black profile
+- **Absolute imports only**: no relative imports; all intra-package references use full `vultron.*` paths
+- **Layer isolation**: `vultron/core/` must not import from `vultron/adapters/` or `vultron/wire/`; `vultron/config/` must not import from `vultron/adapters/` or `vultron/core/`
+- **Backward-compat re-exports**: split modules re-export all public names from their `__init__.py` to avoid breaking callers (e.g., `vultron/adapters/driven/datalayer_sqlite.py`)
+- **`__init__.py` F401 exception**: unused imports in `__init__.py` files are allowed (flake8 per-file-ignore)
+
+### 4) Error and Logging Conventions
+
+- **Error strategy by layer**:
+  - Wire layer: raises `vultron.wire.errors` types on parse/validation failure
+  - Core use cases: raises `vultron.errors.VultronValidationError` or similar domain errors; fail-fast at use-case boundary (ARCH-15)
+  - Adapters: catch and translate errors into HTTP responses or log entries
+- **Logging**: use `logging.getLogger(__name__)` at module level; `logger.debug(...)` for trace detail, `logger.warning(...)` for recoverable issues
+- **Sensitive data**: no specific redaction rules observed; [ASK USER] whether PII from vulnerability reports requires redaction at log points
+
+### 5) Testing Conventions
+
+- **Test file naming/location**: `test/` directory mirrors `vultron/` package layout; files named `test_<module>.py`
+- **Spec marker**: `@pytest.mark.spec("SPEC-ID-NNN")` links tests to spec requirements; validated against `SpecRegistry` at collection time (warns on unknown IDs)
+- **Integration marker**: `@pytest.mark.integration` for tests that exercise the full HTTP stack; excluded from default `pytest` run
+- **Mocking strategy**: real `sqlite:///:memory:` database in all tests (no DB mocking); `conftest.py` forces in-memory DB via env var before any imports
+- **Coverage expectation**: [TODO] — no coverage tool configured in `pyproject.toml`; CI does not report coverage percentage
+
+### 6) Evidence
+
+- `.flake8`
+- `pyproject.toml` `[tool.black]`, `[tool.isort]`, `[tool.pytest.ini_options]`
+- `AGENTS.md` "Coding Rules" section
+- `test/conftest.py`
+- `vultron/wire/as2/AGENTS.md`

--- a/notes/activitystreams-semantics.md
+++ b/notes/activitystreams-semantics.md
@@ -628,3 +628,52 @@ are retained. See also "Base-Typed Activity Serialization Can Drop Inline
 Subtype Fields" in this file.
 
 **Formal requirement**: `specs/case-bootstrap-trust.yaml` CBT-01-007.
+
+---
+
+## Semantic Registry Patterns Must Match Inbound Wire Format
+
+(ISSUE-1298, 2026-07-10)
+
+A semantic registry pattern maps an incoming AS2 activity shape to a
+`MessageSemantics` value. The pattern MUST match the **inbound** wire format
+— the shape that arrives in an actor's inbox from a peer — NOT the outbound
+format that this actor emits.
+
+`OFFER_ACTOR_TO_CASE` was initially mapped to `OfferActorToCasePattern`
+(`Offer(CaseParticipant, Case)`) — the format that CaseActor sends to Case
+Owner — instead of `SuggestActorToCasePattern` (`Offer(Actor, Case)`) — the
+format that Finder sends to CaseActor's inbox.
+
+`OfferActorToCasePattern` is still needed in `_instances.py` as a nested
+template for `AcceptActorRecommendationPattern` and
+`RejectActorRecommendationPattern` (which wrap `Offer(CaseParticipant)`).
+Keep it in `_instances.py` but do NOT register it as a top-level registry
+entry for `OFFER_ACTOR_TO_CASE`.
+
+**Rule**: when adding a new registry entry, trace the message flow and
+ask "who sends this, and what does the recipient's inbox receive?" The
+registry matches the *receiver*'s perspective.
+
+---
+
+## `offer_case_participant_activity`: `event.object_id` Has `#participant` Suffix
+
+(ISSUE-1298, 2026-07-10)
+
+`offer_case_participant_activity(recommended, ...)` builds a `CaseParticipant`
+with `id_=f"{recommended.id_}#participant"`. When extracted via
+`extract_event()`, the event's `object_id` is the `CaseParticipant` URI
+(e.g., `https://example.org/actors/vendor#participant`), not the actor URI.
+
+Use cases that need the actor ID must extract it from the `CaseParticipant`'s
+`attributed_to` field:
+
+```python
+participant_obj = getattr(request.activity, "object_", None)
+raw_actor = getattr(participant_obj, "attributed_to", None)
+actor_id = getattr(raw_actor, "id_", None) or request.object_id
+```
+
+The fallback `request.object_id` retains the `#participant` suffix and should
+only be used as a last resort — log a warning if it is reached.

--- a/notes/behavioral-conformance-specs.md
+++ b/notes/behavioral-conformance-specs.md
@@ -196,6 +196,90 @@ When drafting spec item content, use these sources in priority order:
 Do NOT use `vultron/bt/` (legacy simulator) as a source. Focus exclusively on
 the `vultron/core/behaviors/` py_trees layer.
 
+## Authoring Pitfalls
+
+### `state_entered` Trigger vs. Precondition Mismatch
+
+(ISSUE-1424, 2026-07-15)
+
+When writing `BehavioralSpec` items inside a group whose `trigger` is
+`state_entered: RM.X` (or `EM.X`, `CS.X`), the item's `rm_state`
+precondition MUST list the state that was just *entered* — not the
+predecessor state.
+
+```yaml
+# ✅ CORRECT — state_entered: RM.INVALID means we are now IN RM.INVALID
+- id: RMB-11-002
+  preconditions:
+  - rm_state: [RM.INVALID]   # the state just entered
+
+# ❌ WRONG — RM.RECEIVED is the state *before* the transition
+- id: RMB-11-002
+  preconditions:
+  - rm_state: [RM.RECEIVED]  # impossible: we are no longer in RECEIVED
+```
+
+**Why it matters**: A `state_entered: RM.X` group's trigger fires *after*
+the transition, so any precondition must be satisfiable *in* the new state.
+A precondition requiring a predecessor state is structurally unreachable —
+the behavior can never execute.
+
+**Review checklist**: For every `state_entered: RM.X` group, grep all
+items' `rm_state` preconditions and verify each contains `X`.
+
+---
+
+### START-State Variants Required for Message-Receive Groups
+
+(ISSUE-1424, 2026-07-15)
+
+Per VP-03-010, message-receive groups covering "all states" MUST include
+a START-state variant (e.g., `RMB-07` for `R*` messages must have an item
+with `rm_state: [RM.START]`). Code review on `specs/rm-behavior.yaml`
+found `RMB-07` and `RMB-08` missing their START-state items while
+`RMB-02` through `RMB-06` each had one.
+
+**Pattern**: For any `message_received: R*` group, systematically audit
+whether `RM.START` is covered. The same rule applies to `EP` / `EA` /
+`EV` groups for `EM.NONE` and to `C*` message groups for the initial
+case-state pattern.
+
+---
+
+### Intent Over Letter: When Spec Text and Issue Body Conflict
+
+(ISSUE-1272, 2026-07-10)
+
+When a spec entry and its associated GitHub issue body conflict with each
+other, or when either conflicts with established architectural principles,
+implement the **observable intent** — what the system must *do from the
+outside* — then **correct the spec entry** in the same PR rather than
+silently complying with a stale requirement.
+
+Specifically:
+
+- If the spec mechanism (e.g. "MUST NOT invoke `create_receive_report_case_tree`")
+  contradicts the architectural pattern (BT-first, thin use-cases), reword
+  the spec to describe the outcome, not the mechanism.
+- If the issue body contains a factual error about the codebase (e.g., "the
+  BT already has access to ActorConfig through the blackboard" when it actually
+  threads via constructor arg), note the correction in a PR comment and implement
+  the correct path.
+- Use `AskUserQuestion` to surface genuine design forks — divergences where
+  both interpretations are architecturally valid.
+
+Neither specs nor issue text constrain the *right* solution; they steer
+away from bad ones. The spec is authoritative once corrected; the issue
+text is ephemeral.
+
+Also: **BT gate placement matters.** The idempotency idiom
+`Selector(Sequence(guard, work), Success)` **masks** downstream FAILURE.
+When a downstream FAILURE must still propagate (e.g., case creation can
+genuinely fail), use `Sequence[gate, existing_Selector]` instead so the
+gate fails-safe without swallowing real failures.
+
+---
+
 ## PR Sequence
 
 **PR 1**: Schema changes (`schema.py`) + scaffolding (three empty spec files

--- a/notes/bt-fuzzer-nodes-report-management.md
+++ b/notes/bt-fuzzer-nodes-report-management.md
@@ -2155,3 +2155,33 @@ from within `create_publication_tree`)
 `specs/behavior-tree-integration.yaml`)
 
 ---
+
+## Sentinel Stubs Must Be Synced When the Upstream Issue Closes
+
+(ISSUE-1177, 2026-07-14)
+
+A catalog entry with `New-arch cross-ref: *(to be implemented — see FUZZ-08x)*`
+where the referenced issue is now **closed** is a gap — the stub was never
+promoted.
+
+When FUZZ-08f (Sentinel shape, issue #1175) closed, three catalog entries
+here carried `*(to be implemented — see FUZZ-08f)*`:
+
+- `NewValidationInfoSentinel` — was implemented; cross-ref updated.
+- `NewPrioritizationInfoSentinel` — left unimplemented.
+- `NewDeploymentInfoSentinel` — left unimplemented.
+
+Only the first was added; the other two remained as unimplemented stubs with
+no matching class in `call_out_point.py`.
+
+**Pattern to apply** during domain-sweep audits (FUZZ-08h style):
+
+1. Grep catalog entries for `*(to be implemented — see FUZZ-08x)*`.
+2. Check if the referenced issue is closed.
+3. If closed but the class is absent from `call_out_point.py`, it is a gap —
+   add the class and update the catalog cross-ref line.
+
+The domain-sweep audit is the right checkpoint for this; catching it there
+prevents gaps from persisting across multiple closed issues.
+
+---

--- a/notes/bt-integration.md
+++ b/notes/bt-integration.md
@@ -1572,3 +1572,175 @@ is cheap to implement.
 When auditing for compliance, grep for flat blackboard key registrations in
 tree factories called per-incoming-message and verify each inter-node handoff
 key includes the execution-scoped correlation ID segment.
+
+---
+
+### Blackboard List Mutation: Write-Back Is Redundant (But Needed for New Lists)
+
+(ISSUE-1374, 2026-07-13)
+
+py_trees stores blackboard values by reference. Mutating a list retrieved from
+the blackboard (e.g., `list.pop(0)`, `list.append(x)`) updates the stored value
+in place — any subsequent reader sees the change without a write-back.
+
+```python
+# ❌ REDUNDANT — write-back is a no-op; same object is already updated
+lst = self._bb.my_key
+lst.pop(0)
+self._bb.my_key = lst   # same reference; no effect
+
+# ✅ CORRECT — omit the write-back for mutation of an existing list
+lst = self._bb.my_key
+lst.pop(0)
+```
+
+**Exception**: the write-back IS required when the list was created fresh in
+an `except KeyError` branch. A brand-new `[]` is not yet stored on the
+blackboard; the write-back is the only thing that persists it:
+
+```python
+try:
+    lst = self._bb.my_key
+except KeyError:
+    lst = []
+    self._bb.my_key = lst  # ← required: new list, not yet in blackboard
+lst.pop(0)
+```
+
+---
+
+### Always Check `BTBridge.execute_with_setup` Return Value
+
+(ISSUE-1325, 2026-07-13)
+
+`BTBridge.execute_with_setup` never raises — it catches all exceptions from
+the inner BT tick and returns `BTExecutionResult(status=FAILURE, ...)`. If the
+caller ignores the return value and falls through to `return Status.SUCCESS`,
+the node silently reports success even when the subtree failed.
+
+```python
+# ❌ WRONG — subtree failure is silently swallowed
+BTBridge(...).execute_with_setup(tree=commit_tree, actor_id=self.actor_id)
+return Status.SUCCESS
+
+# ✅ CORRECT — raise on failure so the outer node propagates FAILURE
+result = BTBridge(...).execute_with_setup(
+    tree=commit_tree, actor_id=self.actor_id
+)
+if result.status != Status.SUCCESS:
+    raise RuntimeError(f"subtree failed: {result.feedback_message}")
+```
+
+Raising inside the outer `except Exception` handler in `update()` ensures the
+calling node returns `FAILURE` rather than `SUCCESS`.
+
+---
+
+### Ledger Commit Must Precede Outbox Write
+
+(ISSUE-1325, 2026-07-13)
+
+When a BT subtree both commits a ledger correlation marker and records an
+outbox item, the ledger commit MUST happen first.
+
+If the outbox write happens first and the ledger commit subsequently fails,
+the outbox item is orphaned: an activity queued for delivery with no
+corresponding ledger entry. On the next invocation, the duplicate-detection
+guard finds no pending entry and takes the "fresh" path, triggering a
+duplicate offer or invite.
+
+Correct ordering in a tree or composite node:
+
+1. Build activity via factory (creates the object in the DataLayer)
+2. Commit ledger correlation marker (fail-fast if anything is wrong)
+3. Record outbox item (reached only if ledger commit succeeded)
+
+This invariant is enforced by CLP-10-006 in `specs/case-ledger-processing.yaml`.
+
+---
+
+### Use `disposition="rejected"` for Local-Only Ledger Correlation Markers
+
+(ISSUE-1325, 2026-07-13)
+
+When a BT node needs a local ledger entry that does NOT correspond to a
+canonical AS2 activity (e.g., tracking an outbound
+`offer_case_participant` for duplicate detection), use
+`disposition="rejected"` in `create_commit_log_entry_tree`.
+
+`_validate_canonical_entry` returns early for non-`"recorded"` dispositions,
+bypassing the `_CANONICAL_PAYLOAD_SIGNATURES` allowlist check.  The entry is
+still persisted and `find_protocol_pair` does not filter on disposition, so
+the correlation marker remains visible to duplicate-detection nodes.
+
+The `_find_equivalent_recorded_entry` idempotency check also filters on
+`disposition == "recorded"`, so repeated calls each create a new marker —
+which is fine when the BT guarantees at-most-once execution per receipt (e.g.,
+via `GuardedCommit` in `create_receive_activity_tree`).
+
+---
+
+### suggest-actor Accept Path Does Not Thread Roles Into Invite
+
+(ISSUE-1406, 2026-07-14)
+
+`create_accept_actor_recommendation_received_tree` (CaseActor receives
+`Accept(Offer(CaseParticipant))` from Case Owner) never writes the
+`suggested_roles` blackboard key. `EmitInviteActorToCaseNode` reads this key
+via `_read_suggested_roles()`, gets a `KeyError`, and passes `roles=None` to
+`factory.invite_actor_to_case()`. The resulting `Invite` carries `roles=None`,
+so after `Accept(Invite)` the new `VultronParticipant.case_roles` is `[]`.
+
+This is documented behavior (ADR-0032, BT-HELPER-01: no silent default
+substitution), not a bug.
+
+**Test implication**: Only the `invite_actor_to_case_trigger_bt` path (or a
+tree with `EvaluateDefaultRolesNode`) produces a non-empty `case_roles`. The
+`AcceptOfferCaseParticipant` received-side use case always produces
+`roles=None` in the Invite. Tests that verify roles end up on a participant
+MUST exercise the trigger path, not the received path.
+
+**Blackboard key contrast**:
+
+| Tree factory | Key written | Namespaced? |
+|---|---|---|
+| `create_recommend_actor_to_case_received_tree` | `suggested_roles_{id_segment}` | ✅ |
+| `create_accept_actor_recommendation_received_tree` | *(never written)* | N/A |
+
+---
+
+### BTND-03-004 Audit Scope: All Keys in the Subtree
+
+(ISSUE-1397, 2026-07-14)
+
+When namespacing blackboard keys per BTND-03-004, audit ALL
+`register_key` calls within the affected composite subtree — not just the
+keys named in the issue body. Code review on ISSUE-1397 caught two more
+flat keys (`participant_accepted_status`, `owner_initial_status`) that were
+intra-Sequence only (currently low-risk) but still violate BTND-03-004.
+
+**How to audit**: grep for `register_key` across the affected module, list
+every key, then check whether each one crosses a concurrent-execution
+boundary. Keys that are always cleaned up and rewritten before being read
+within a single `Sequence(memory=False)` are low-risk, but namespacing
+eliminates the risk entirely and is cheap.
+
+---
+
+### Dual-Path Consolidation Test Gap
+
+(ISSUE-1378, 2026-07-14)
+
+When consolidating two helpers with different lookup paths into one unified
+function, the new test suite MUST exercise each distinct path in isolation.
+
+In ISSUE-1378, `_resolve_case_manager_id` was consolidated from two helpers:
+a primary `actor_participant_index` path and a fallback `case_participants`
+path. All 6 initial tests only populated `case_participants`, leaving the
+primary index path entirely untested. Code review caught the gap; a 7th test
+(`test_primary_index_path_returns_actor_id`) was added before the PR merged.
+
+**Pattern**: For a helper with N distinct lookup paths, write at least one
+test per path where that path is the *sole* source of truth — all other paths
+are left empty or unpopulated. "One test exercises both paths" means neither
+path is verified independently.

--- a/notes/configuration.md
+++ b/notes/configuration.md
@@ -364,6 +364,40 @@ also available from the YAML `actor:` section or `VULTRON_ACTOR__*` env vars.
 
 ---
 
+## Key-Presence Check Required Before `model_validate`
+
+(ISSUE-1343, 2026-07-15; see `specs/configuration.yaml` CFG-07-008)
+
+Any YAML sub-block loader MUST check whether the target key is present in the
+raw dict **before** calling `model_validate`:
+
+```python
+# ❌ WRONG — model_validate({}) succeeds silently on an all-defaults model
+raw = yaml.safe_load(fh) or {}
+return ActorConfig.model_validate(raw.get("local_actor", {}))
+
+# ✅ CORRECT — return None when key is absent so caller falls through
+raw = yaml.safe_load(fh) or {}
+if "local_actor" not in raw:
+    return None
+return ActorConfig.model_validate(raw["local_actor"])
+```
+
+**Why `model_validate({})` is wrong**: Pydantic's `model_validate` on a
+model where every field has a default does not distinguish "field absent from
+source" from "field explicitly set to default". A dict with no keys validates
+successfully and returns an all-defaults instance. If the loader returns that
+instance, `load_actor_config()` exits early — silently ignoring
+`VULTRON_ACTOR__*` env vars and violating the YAML → env → defaults
+resolution order.
+
+**Pattern**: Whenever a loader reads a YAML sub-block and is supposed to fall
+back to a secondary source, check for key *presence* (not just type), then
+validate. This applies to all config loaders that have a "key absent means
+skip this source" contract.
+
+---
+
 ## SeedConfig Refactoring
 
 `SeedConfig` in `vultron/demo/seed_config.py` MUST be migrated to

--- a/notes/datalayer-design.md
+++ b/notes/datalayer-design.md
@@ -216,3 +216,57 @@ Files to investigate:
 - `vultron/adapters/driven/datalayer_sqlite.py`
 - `vultron/wire/as2/rehydration.py`
 - `vultron/wire/as2/vocab/registry.py`
+
+---
+
+## `outbox_list()` Requires `clone_for_actor` in Tests
+
+(ISSUE-1298, 2026-07-10)
+
+`SqliteDataLayer.outbox_list()` reads the outbox for `dl._actor_id`, which is
+`""` on a freshly constructed `SqliteDataLayer("sqlite:///:memory:")`. BT nodes
+call `record_outbox_item(actor_id, activity_id)`, writing to the named actor's
+queue. The two paths do not share the same key unless the DataLayer was obtained
+via `clone_for_actor(actor_id)`.
+
+**In tests that verify outbox contents after use-case execution:**
+
+```python
+# ✅ CORRECT — read by explicit actor ID
+outbox = dl.outbox_list_for_actor(local_actor_id)
+
+# ✅ ALSO CORRECT — clone before reading (matches BT pattern)
+actor_dl = dl.clone_for_actor(actor_id)
+outbox = actor_dl.outbox_list()
+
+# ❌ WRONG — returns [] unless dl._actor_id was set
+outbox = dl.outbox_list()
+```
+
+---
+
+## Happy-Path DL Seeds Must Include Origin Activities for `dl.read()` Calls
+
+(ISSUE-1326, 2026-07-10)
+
+When a use case calls `dl.read(some_id)` to resolve a related entity (e.g.,
+`recommender_id` from the original recommendation offer), the happy-path test
+fixture MUST store that entity in the DataLayer, or the use case silently falls
+back to `""` / `None`.
+
+In `AcceptActorRecommendationReceivedUseCase` and
+`RejectActorRecommendationReceivedUseCase`, the `origin` field of the inner
+`Offer(CaseParticipant)` carries the original recommendation activity ID. The
+use case calls `self._dl.read(recommendation_id)` to look up that activity and
+extract `recommender_id`. If the activity is absent, `recommender_id=""` and the
+recommender-notification branch silently no-ops — but other tree nodes still emit
+to the outbox, so `len(outbox) >= 1` can pass while hiding the broken path.
+
+**Fix pattern**: after building the inner offer with
+`origin=<recommendation_id>`, also call
+`dl.create(recommend_actor_activity(..., id_=<recommendation_id>))` in the
+fixture so `dl.read()` resolves correctly.
+
+**Assertion depth**: the Accept happy path emits both an Accept notification
+and an Invite (2 activities). Assert `len(outbox) >= 2`, not `>= 1`, to catch
+the case where only one of the two required activities was emitted.

--- a/notes/inbox-pipeline.md
+++ b/notes/inbox-pipeline.md
@@ -194,6 +194,45 @@ def test_activity_with_unknown_case_is_deferred(test_pipeline):
 
 ---
 
+## `UnroutableActivityError` Must Be Caught Inside `_handle`, Not Above It
+
+(ISSUE-1377, 2026-07-14)
+
+When a gate/guard helper is called *before* the `try/except` that wraps
+use-case execution in `DispatcherBase._handle`, any exception it raises
+escapes `_handle` entirely. The inbox adapter's `_process_inbox_item`
+catches all `Exception` at a higher level and re-queues the item — creating
+an infinite retry loop for any unroutable event.
+
+```python
+# ❌ WRONG — _enforce_join_backfill_gate is called BEFORE the try/except
+def _handle(self, event, dl):
+    self._enforce_join_backfill_gate(event, dl)   # raises UnroutableActivityError
+    try:
+        ...                                        # never reached for unroutable events
+    except SomeOtherError:
+        ...
+
+# ✅ CORRECT — gate call is wrapped independently inside _handle
+def _handle(self, event, dl):
+    try:
+        self._enforce_join_backfill_gate(event, dl)
+    except UnroutableActivityError:
+        logger.error("Unroutable event %s — dropping", event)
+        return                                     # _process_inbox_item sees clean return
+    try:
+        ...
+```
+
+**General rule**: When converting a silent-failure (return `None` / return
+`False`) into a `raise`, trace the full call stack to every exception handler
+above the raise site. If any handler has re-queue / retry semantics, the new
+exception MUST be caught below that handler — at the dispatch level or in a
+dedicated gate wrapper. Letting it propagate restores the silent-failure
+behavior as an infinite retry, which is worse.
+
+---
+
 ## Layer and Import Rules
 
 - `InboxPipeline` is an **adapter-layer** class; it MAY import from

--- a/specs/configuration.yaml
+++ b/specs/configuration.yaml
@@ -9,6 +9,7 @@ description: >-
 version: 1.0.0
 kind: implementation
 scope:
+
 - prototype
 - production
 groups:
@@ -265,3 +266,21 @@ groups:
       startup while policy is read at dispatch time from `AppConfig.actor`.  Decoupling the
       two models reflects this distinct lifecycle and prevents demo scaffolding from leaking
       policy concerns into production paths.
+  - id: CFG-07-008
+    priority: MUST
+    statement: >-
+      A YAML sub-block loader (e.g., `_actor_config_from_seed_yaml()`) MUST check for the
+      presence of the target key in the raw YAML dict before calling `model_validate`.
+      If the key is absent, the loader MUST return `None` so the caller falls through to
+      the next source in the resolution order (env vars, then defaults).
+    rationale: >-
+      `pydantic.model_validate({})` on a model whose every field has a default succeeds
+      silently and returns an all-defaults instance.  This makes it impossible to distinguish
+      "key absent from YAML" from "key explicitly set to defaults", causing `load_actor_config()`
+      to return early and skip `VULTRON_ACTOR__*` env vars — violating the documented
+      YAML → env → defaults resolution order (CFG-03-001).  The fix is a key-presence check
+      before `model_validate`, not a post-validate comparison.
+    relationships:
+    - rel_type: refines
+      spec_id: CFG-03-001
+      note: resolution-order guarantee requires key-presence check, not value comparison


### PR DESCRIPTION
## Summary

Promotes 20 incoming learnings from `plan/incoming/learnings/` (2026-07-10 through
2026-07-15) into durable specs, notes, and agent guidance. No code or test changes.

## Changes

### `specs/configuration.yaml`
- Add **CFG-07-008**: YAML sub-block loaders MUST check key presence before `model_validate`
  (silent all-defaults return breaks YAML→env→defaults resolution order)

### `notes/behavioral-conformance-specs.md`
- Add **Authoring Pitfalls** section with three subsections:
  - `state_entered` trigger vs. precondition mismatch (entered state, not predecessor)
  - START-state variants required for message-receive groups (VP-03-010)
  - Intent over letter: BT gate placement, spec correction in same PR

### `notes/bt-integration.md`
- Blackboard list write-back: only needed for new lists (KeyError branch)
- Always check `BTBridge.execute_with_setup` return value — never raises, must check
- Ledger commit must precede outbox write
- `disposition="rejected"` for local-only ledger correlation markers
- `suggest_actor` accept path does not thread roles into Invite (documented behavior)
- BTND-03-004 audit scope: ALL `register_key` calls in the subtree
- Dual-path consolidation test gap: one test per distinct lookup path

### `notes/configuration.md`
- Key-presence check required before `model_validate` (code examples, why wrong)

### `notes/activitystreams-semantics.md`
- Semantic registry patterns must match inbound wire format (ISSUE-1298)
- `offer_case_participant_activity`: `event.object_id` has `#participant` suffix

### `notes/datalayer-design.md`
- `outbox_list()` requires `clone_for_actor` in tests (actor scope mismatch)
- Happy-path DL seeds must include origin activities for `dl.read()` calls

### `notes/inbox-pipeline.md`
- `UnroutableActivityError` must be caught inside `_handle`, not above it
  (infinite retry loop via `_process_inbox_item` re-queue)

### `notes/bt-fuzzer-nodes-report-management.md`
- Sentinel stubs must be synced when upstream issue closes (ISSUE-1177)

### `AGENTS.md`
- Pointer entries for all new notes sections
- Short inline entries: dedup set before loop; consolidated-path test gap;
  MkDocs `not_in_nav` vs. `exclude_docs`; git worktree rebase hook interference

### `docs/codebase/CONVENTIONS.md`
- Fix MD012 double blank line (markdownlint compliance)

## Notes

- Archive step (append-history --from-file for 20 learning files) runs after PR merges.
- All 6 open `type:Concern` issues are unaffected by these learnings (triaged as no overlap).