### PR TITLE
fix(specs): add satisfies relationships to RMB/EMB/CSB message_received items

### DIFF
--- a/specs/cs-behavior.yaml
+++ b/specs/cs-behavior.yaml
@@ -34,6 +34,10 @@ groups:
       Placeholder — content to be filled in PR for issue #1425.
     testable: true
 
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-03-001
+      note: 'CV shorthand wire-type mapping'
 - id: CSB-02
   title: Receive CF (Fix Ready)
   description: >-
@@ -49,6 +53,10 @@ groups:
       Placeholder — content to be filled in PR for issue #1425.
     testable: true
 
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-03-002
+      note: 'CF shorthand wire-type mapping'
 - id: CSB-03
   title: Receive CD (Fix Deployed)
   description: >-
@@ -64,6 +72,10 @@ groups:
       Placeholder — content to be filled in PR for issue #1425.
     testable: true
 
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-03-003
+      note: 'CD shorthand wire-type mapping'
 - id: CSB-04
   title: Receive CP (Public Aware)
   description: >-
@@ -79,6 +91,10 @@ groups:
       Placeholder — content to be filled in PR for issue #1425.
     testable: true
 
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-03-004
+      note: 'CP shorthand wire-type mapping'
 - id: CSB-05
   title: Receive CX (Exploit Public)
   description: >-
@@ -94,6 +110,10 @@ groups:
       Placeholder — content to be filled in PR for issue #1425.
     testable: true
 
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-03-005
+      note: 'CX shorthand wire-type mapping'
 - id: CSB-06
   title: Receive CA (Attacks Observed)
   description: >-
@@ -109,6 +129,10 @@ groups:
       Placeholder — content to be filled in PR for issue #1425.
     testable: true
 
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-03-006
+      note: 'CA shorthand wire-type mapping'
 - id: CSB-07
   title: Receive CE (CS Error)
   description: >-
@@ -124,6 +148,10 @@ groups:
       Placeholder — content to be filled in PR for issue #1425.
     testable: true
 
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-03-007
+      note: 'CE shorthand wire-type mapping'
 - id: CSB-08
   title: Receive CK (CS Acknowledgment)
   description: >-
@@ -139,6 +167,10 @@ groups:
       Placeholder — content to be filled in PR for issue #1425.
     testable: true
 
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-03-008
+      note: 'CK shorthand wire-type mapping'
 - id: CSB-09
   title: Enter CS Vendor Aware (V)
   trigger:

--- a/specs/em-behavior.yaml
+++ b/specs/em-behavior.yaml
@@ -34,6 +34,10 @@ groups:
       Placeholder — content to be filled in PR for issue #1425.
     testable: true
 
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-02-001
+      note: 'EP shorthand wire-type mapping'
 - id: EMB-02
   title: Receive EA (Embargo Accepted)
   description: >-
@@ -49,6 +53,10 @@ groups:
       Placeholder — content to be filled in PR for issue #1425.
     testable: true
 
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-02-002
+      note: 'EA shorthand wire-type mapping'
 - id: EMB-03
   title: Receive EV (Embargo Revision Proposed)
   description: >-
@@ -64,6 +72,10 @@ groups:
       Placeholder — content to be filled in PR for issue #1425.
     testable: true
 
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-02-003
+      note: 'EV shorthand wire-type mapping'
 - id: EMB-04
   title: Receive EJ (Embargo Revision Rejected)
   description: >-
@@ -79,6 +91,10 @@ groups:
       Placeholder — content to be filled in PR for issue #1425.
     testable: true
 
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-02-004
+      note: 'EJ shorthand wire-type mapping'
 - id: EMB-05
   title: Receive EC (Embargo Revision Accepted)
   description: >-
@@ -94,6 +110,10 @@ groups:
       Placeholder — content to be filled in PR for issue #1425.
     testable: true
 
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-02-005
+      note: 'EC shorthand wire-type mapping'
 - id: EMB-06
   title: Receive ER (Embargo Rejected)
   description: >-
@@ -109,6 +129,10 @@ groups:
       Placeholder — content to be filled in PR for issue #1425.
     testable: true
 
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-02-006
+      note: 'ER shorthand wire-type mapping'
 - id: EMB-07
   title: Receive ET (Embargo Terminated)
   description: Wire-type mapping — see MSM-02-007 (ET → REMOVE_EMBARGO_EVENT_FROM_CASE → Remove(Event)).
@@ -122,6 +146,10 @@ groups:
       Placeholder — content to be filled in PR for issue #1425.
     testable: true
 
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-02-007
+      note: 'ET shorthand wire-type mapping'
 - id: EMB-08
   title: Receive EE (Embargo Error)
   description: >-
@@ -137,6 +165,10 @@ groups:
       Placeholder — content to be filled in PR for issue #1425.
     testable: true
 
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-02-008
+      note: 'EE shorthand wire-type mapping'
 - id: EMB-09
   title: Receive EK (Embargo Acknowledgment)
   description: >-
@@ -152,6 +184,10 @@ groups:
       Placeholder — content to be filled in PR for issue #1425.
     testable: true
 
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-02-009
+      note: 'EK shorthand wire-type mapping'
 - id: EMB-10
   title: Enter EM Proposed
   trigger:

--- a/specs/rm-behavior.yaml
+++ b/specs/rm-behavior.yaml
@@ -50,6 +50,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-03-009
       note: RK acknowledgment of RS
+    - rel_type: satisfies
+      spec_id: MSM-01-001
+      note: 'RS shorthand wire-type mapping'
 
   - id: RMB-01-002
     priority: MUST
@@ -95,6 +98,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-03-009
       note: RK acknowledgment of RS
+    - rel_type: satisfies
+      spec_id: MSM-01-001
+      note: 'RS shorthand wire-type mapping'
 
   - id: RMB-01-003
     priority: SHOULD
@@ -140,6 +146,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-03-009
       note: RK acknowledgment of RS
+    - rel_type: satisfies
+      spec_id: MSM-01-001
+      note: 'RS shorthand wire-type mapping'
 
   - id: RMB-01-004
     priority: SHOULD
@@ -169,6 +178,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-03-009
       note: RK acknowledgment of RS
+    - rel_type: satisfies
+      spec_id: MSM-01-001
+      note: 'RS shorthand wire-type mapping'
 
   - id: RMB-01-005
     priority: MAY
@@ -188,6 +200,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-03-013
       note: Recipients MAY ignore messages received on Closed cases
+    - rel_type: satisfies
+      spec_id: MSM-01-001
+      note: 'RS shorthand wire-type mapping'
 
 - id: RMB-02
   title: Receive RI (Report Invalid)
@@ -234,6 +249,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-02-019
       note: Shared awareness of sender RM state change
+    - rel_type: satisfies
+      spec_id: MSM-01-002
+      note: 'RI shorthand wire-type mapping'
 
   - id: RMB-02-002
     priority: SHOULD
@@ -268,6 +286,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-03-010
       note: RE+GI when R* (other than RS) received while in RM Start
+    - rel_type: satisfies
+      spec_id: MSM-01-002
+      note: 'RI shorthand wire-type mapping'
 
 - id: RMB-03
   title: Receive RV (Report Valid)
@@ -313,6 +334,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-02-019
       note: Shared awareness of sender RM state change
+    - rel_type: satisfies
+      spec_id: MSM-01-003
+      note: 'RV shorthand wire-type mapping'
 
   - id: RMB-03-002
     priority: SHOULD
@@ -347,6 +371,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-03-010
       note: RE+GI when R* (other than RS) received while in RM Start
+    - rel_type: satisfies
+      spec_id: MSM-01-003
+      note: 'RV shorthand wire-type mapping'
 
 - id: RMB-04
   title: Receive RD (Report Deferred)
@@ -392,6 +419,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-02-019
       note: Shared awareness of sender RM state change
+    - rel_type: satisfies
+      spec_id: MSM-01-004
+      note: 'RD shorthand wire-type mapping'
 
   - id: RMB-04-002
     priority: SHOULD
@@ -425,6 +455,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-03-010
       note: RE+GI when R* (other than RS) received while in RM Start
+    - rel_type: satisfies
+      spec_id: MSM-01-004
+      note: 'RD shorthand wire-type mapping'
 
 - id: RMB-05
   title: Receive RA (Report Accepted)
@@ -471,6 +504,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-02-019
       note: Shared awareness of sender RM state change
+    - rel_type: satisfies
+      spec_id: MSM-01-005
+      note: 'RA shorthand wire-type mapping'
 
   - id: RMB-05-002
     priority: SHOULD
@@ -505,6 +541,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-03-010
       note: RE+GI when R* (other than RS) received while in RM Start
+    - rel_type: satisfies
+      spec_id: MSM-01-005
+      note: 'RA shorthand wire-type mapping'
 
 - id: RMB-06
   title: Receive RC (Report Closed)
@@ -551,6 +590,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-02-019
       note: Shared awareness of sender RM state change
+    - rel_type: satisfies
+      spec_id: MSM-01-006
+      note: 'RC shorthand wire-type mapping'
 
   - id: RMB-06-002
     priority: MAY
@@ -574,6 +616,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-02-035
       note: Participants MAY close Accepted, Deferred, or Invalid reports
+    - rel_type: satisfies
+      spec_id: MSM-01-006
+      note: 'RC shorthand wire-type mapping'
 
   - id: RMB-06-003
     priority: SHOULD
@@ -607,6 +652,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-03-010
       note: RE+GI when R* (other than RS) received while in RM Start
+    - rel_type: satisfies
+      spec_id: MSM-01-006
+      note: 'RC shorthand wire-type mapping'
 
 - id: RMB-07
   title: Receive RE (Report Error)
@@ -651,6 +699,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-03-011
       note: Acknowledge RE and inquire about the error with GI
+    - rel_type: satisfies
+      spec_id: MSM-01-007
+      note: 'RE shorthand wire-type mapping'
 
   - id: RMB-07-002
     priority: SHOULD
@@ -687,6 +738,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-03-010
       note: RE+GI when R* (other than RS) received while in RM Start
+    - rel_type: satisfies
+      spec_id: MSM-01-007
+      note: 'RE shorthand wire-type mapping'
 
 - id: RMB-08
   title: Receive RK (Report Acknowledgment)
@@ -719,6 +773,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-03-009
       note: RK itself is never acknowledged with another RK
+    - rel_type: satisfies
+      spec_id: MSM-01-008
+      note: 'RK shorthand wire-type mapping'
 
   - id: RMB-08-002
     priority: SHOULD
@@ -754,6 +811,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-03-010
       note: RE+GI when R* received while in RM Start
+    - rel_type: satisfies
+      spec_id: MSM-01-008
+      note: 'RK shorthand wire-type mapping'
 
 - id: RMB-09
   title: Enter RM Received


### PR DESCRIPTION
- Closes #1445 (follow-up fix — relationships omitted from #1448)

## Summary

- Adds machine-readable `rel_type: satisfies` relationship entries to all `message_received` spec items in `rm-behavior.yaml` (20 items), `em-behavior.yaml` (9 items), and `cs-behavior.yaml` (8 items)
- Each entry points to the corresponding MSM spec item (`MSM-01-NNN` for RM, `MSM-02-NNN` for EM, `MSM-03-NNN` for CS)
- Completes the traceability graph: RMB/EMB/CSB items → MSM items → VAM wire-format items

## Changes

- `specs/rm-behavior.yaml` — 20 new relationship entries across RMB-01 through RMB-08 groups
- `specs/em-behavior.yaml` — 9 new relationship entries across EMB-01 through EMB-09 groups
- `specs/cs-behavior.yaml` — 8 new relationship entries across CSB-01 through CSB-08 groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)