### PR TITLE
fix(specs): add satisfies relationships to all RMB/EMB/CSB message_received items

### DIFF
--- a/specs/cs-behavior.yaml
+++ b/specs/cs-behavior.yaml
@@ -59,6 +59,10 @@ groups:
       expected: CK queued for sender
     postconditions:
     - description: Sender's CS state recorded as Vfd; CK emitted; receiver CS unchanged
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-03-001
+      note: 'CV shorthand wire-type mapping'
 
 - id: CSB-02
   title: Receive CF (Fix Ready)
@@ -99,6 +103,10 @@ groups:
       expected: CK queued for sender
     postconditions:
     - description: Sender's CS state recorded as VFd; CK emitted; receiver CS unchanged
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-03-002
+      note: 'CF shorthand wire-type mapping'
 
 - id: CSB-03
   title: Receive CD (Fix Deployed)
@@ -139,6 +147,10 @@ groups:
       expected: CK queued for sender
     postconditions:
     - description: Sender's CS state recorded as VFD; CK emitted; receiver CS unchanged
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-03-003
+      note: 'CD shorthand wire-type mapping'
 
 - id: CSB-04
   title: Receive CP (Public Aware)
@@ -177,6 +189,10 @@ groups:
       expected: CK queued for sender
     postconditions:
     - description: Receiver CS is public-aware; CK emitted
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-03-004
+      note: 'CP shorthand wire-type mapping'
 
   - id: CSB-04-002
     priority: MUST
@@ -212,6 +228,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-09-001
       note: Embargoes SHALL terminate immediately when information becomes public
+    - rel_type: satisfies
+      spec_id: MSM-03-004
+      note: 'CP shorthand wire-type mapping'
 
   - id: CSB-04-003
     priority: MUST
@@ -261,6 +280,9 @@ groups:
       note: >-
         SHALL initiate embargo termination upon becoming aware of publicly
         available information
+    - rel_type: satisfies
+      spec_id: MSM-03-004
+      note: 'CP shorthand wire-type mapping'
 
   - id: CSB-04-004
     priority: MUST
@@ -281,6 +303,10 @@ groups:
       expected: CK queued for sender; CS and EM states unchanged
     postconditions:
     - description: CK emitted; no state change
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-03-004
+      note: 'CP shorthand wire-type mapping'
 
 - id: CSB-05
   title: Receive CX (Exploit Public)
@@ -320,6 +346,10 @@ groups:
       expected: CK queued for sender
     postconditions:
     - description: Receiver CS is ···PX·; CK emitted
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-03-005
+      note: 'CX shorthand wire-type mapping'
 
   - id: CSB-05-002
     priority: MUST
@@ -355,6 +385,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-09-001
       note: Embargoes SHALL terminate immediately when information becomes public
+    - rel_type: satisfies
+      spec_id: MSM-03-005
+      note: 'CX shorthand wire-type mapping'
 
   - id: CSB-05-003
     priority: MUST
@@ -397,6 +430,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-11-002
       note: SHALL terminate embargo when exploit is public
+    - rel_type: satisfies
+      spec_id: MSM-03-005
+      note: 'CX shorthand wire-type mapping'
 
   - id: CSB-05-004
     priority: MUST
@@ -422,6 +458,10 @@ groups:
       expected: CK queued for sender
     postconditions:
     - description: Receiver CS is ···PX·; CK emitted
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-03-005
+      note: 'CX shorthand wire-type mapping'
 
   - id: CSB-05-005
     priority: MUST
@@ -442,6 +482,10 @@ groups:
       expected: CK queued for sender; CS and EM states unchanged
     postconditions:
     - description: CK emitted; no state change
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-03-005
+      note: 'CX shorthand wire-type mapping'
 
 - id: CSB-06
   title: Receive CA (Attacks Observed)
@@ -481,6 +525,10 @@ groups:
       expected: CK queued for sender
     postconditions:
     - description: Receiver CS is ···P·A; CK emitted
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-03-006
+      note: 'CA shorthand wire-type mapping'
 
   - id: CSB-06-002
     priority: MUST
@@ -517,6 +565,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-09-001
       note: Embargoes SHALL terminate immediately when information becomes public
+    - rel_type: satisfies
+      spec_id: MSM-03-006
+      note: 'CA shorthand wire-type mapping'
 
   - id: CSB-06-003
     priority: MUST
@@ -561,6 +612,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-11-006
       note: SHOULD terminate embargo when attacks are known to have occurred
+    - rel_type: satisfies
+      spec_id: MSM-03-006
+      note: 'CA shorthand wire-type mapping'
 
   - id: CSB-06-004
     priority: MUST
@@ -586,6 +640,10 @@ groups:
       expected: CK queued for sender
     postconditions:
     - description: Receiver CS is ···P·A; CK emitted
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-03-006
+      note: 'CA shorthand wire-type mapping'
 
   - id: CSB-06-005
     priority: MUST
@@ -606,6 +664,10 @@ groups:
       expected: CK queued for sender; CS and EM states unchanged
     postconditions:
     - description: CK emitted; no state change
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-03-006
+      note: 'CA shorthand wire-type mapping'
 
 - id: CSB-07
   title: Receive CE (CS Error)
@@ -645,6 +707,10 @@ groups:
       expected: GI queued for sender
     postconditions:
     - description: CK and GI emitted; CS state unchanged
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-03-007
+      note: 'CE shorthand wire-type mapping'
 
 - id: CSB-08
   title: Receive CK (CS Acknowledgment)
@@ -668,6 +734,10 @@ groups:
     lint_suppress:
     - testable_without_steps
     preconditions: []
+    relationships:
+    - rel_type: satisfies
+      spec_id: MSM-03-008
+      note: 'CK shorthand wire-type mapping'
 
 - id: CSB-09
   title: Enter CS Vendor Aware (V)

--- a/specs/em-behavior.yaml
+++ b/specs/em-behavior.yaml
@@ -58,6 +58,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-11-004
       note: SHOULD send EK in acknowledgment of any E* message except EK itself
+    - rel_type: satisfies
+      spec_id: MSM-02-001
+      note: 'EP shorthand wire-type mapping'
 
   - id: EMB-01-002
     priority: MUST_NOT
@@ -94,6 +97,9 @@ groups:
       note: >-
         SHALL NOT negotiate embargoes where vulnerability or exploit is public
         or attacks occurred
+    - rel_type: satisfies
+      spec_id: MSM-02-001
+      note: 'EP shorthand wire-type mapping'
 
   - id: EMB-01-003
     priority: MUST
@@ -124,6 +130,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-11-004
       note: SHOULD send EK in acknowledgment of any E* message except EK itself
+    - rel_type: satisfies
+      spec_id: MSM-02-001
+      note: 'EP shorthand wire-type mapping'
 
   - id: EMB-01-004
     priority: SHOULD_NOT
@@ -145,6 +154,9 @@ groups:
       spec_id: VP-13-003
       note: >-
         SHOULD NOT begin EM with a proposal from a Participant in RM Invalid
+    - rel_type: satisfies
+      spec_id: MSM-02-001
+      note: 'EP shorthand wire-type mapping'
 
   - id: EMB-01-005
     priority: SHOULD_NOT
@@ -167,6 +179,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-13-002
       note: SHOULD NOT begin EM in an inactive RM state
+    - rel_type: satisfies
+      spec_id: MSM-02-001
+      note: 'EP shorthand wire-type mapping'
 
 - id: EMB-02
   title: Receive EA (Embargo Accepted)
@@ -209,6 +224,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-11-004
       note: SHOULD send EK in acknowledgment of any E* message except EK itself
+    - rel_type: satisfies
+      spec_id: MSM-02-002
+      note: 'EA shorthand wire-type mapping'
 
   - id: EMB-02-002
     priority: MUST_NOT
@@ -240,6 +258,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-11-001
       note: SHALL NOT negotiate embargoes where vulnerability or exploit is public
+    - rel_type: satisfies
+      spec_id: MSM-02-002
+      note: 'EA shorthand wire-type mapping'
 
   - id: EMB-02-003
     priority: SHOULD_NOT
@@ -263,6 +284,9 @@ groups:
       note: >-
         SHOULD NOT proceed from EM Proposed to EM Accepted when RM is Invalid
         or Closed
+    - rel_type: satisfies
+      spec_id: MSM-02-002
+      note: 'EA shorthand wire-type mapping'
 
 - id: EMB-03
   title: Receive EV (Embargo Revision Proposed)
@@ -308,6 +332,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-11-004
       note: SHOULD send EK in acknowledgment of any E* message except EK itself
+    - rel_type: satisfies
+      spec_id: MSM-02-003
+      note: 'EV shorthand wire-type mapping'
 
   - id: EMB-03-002
     priority: MUST
@@ -336,6 +363,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-11-004
       note: SHOULD send EK in acknowledgment of any E* message except EK itself
+    - rel_type: satisfies
+      spec_id: MSM-02-003
+      note: 'EV shorthand wire-type mapping'
 
   - id: EMB-03-003
     priority: MUST
@@ -373,6 +403,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-11-002
       note: SHALL terminate embargo when public/exploit
+    - rel_type: satisfies
+      spec_id: MSM-02-003
+      note: 'EV shorthand wire-type mapping'
 
 - id: EMB-04
   title: Receive EJ (Embargo Revision Rejected)
@@ -413,6 +446,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-11-004
       note: SHOULD send EK in acknowledgment of any E* message except EK itself
+    - rel_type: satisfies
+      spec_id: MSM-02-004
+      note: 'EJ shorthand wire-type mapping'
 
   - id: EMB-04-002
     priority: MUST
@@ -446,6 +482,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-11-002
       note: SHALL terminate embargo when public/exploit
+    - rel_type: satisfies
+      spec_id: MSM-02-004
+      note: 'EJ shorthand wire-type mapping'
 
 - id: EMB-05
   title: Receive EC (Embargo Revision Accepted)
@@ -488,6 +527,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-11-004
       note: SHOULD send EK in acknowledgment of any E* message except EK itself
+    - rel_type: satisfies
+      spec_id: MSM-02-005
+      note: 'EC shorthand wire-type mapping'
 
   - id: EMB-05-002
     priority: MUST
@@ -520,6 +562,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-11-002
       note: SHALL terminate embargo when public/exploit
+    - rel_type: satisfies
+      spec_id: MSM-02-005
+      note: 'EC shorthand wire-type mapping'
 
 - id: EMB-06
   title: Receive ER (Embargo Rejected)
@@ -560,6 +605,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-05-017
       note: Participants MAY reject proposed embargo terms for any reason
+    - rel_type: satisfies
+      spec_id: MSM-02-006
+      note: 'ER shorthand wire-type mapping'
 
 - id: EMB-07
   title: Receive ET (Embargo Terminated)
@@ -596,6 +644,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-11-004
       note: SHOULD send EK in acknowledgment of any E* message except EK itself
+    - rel_type: satisfies
+      spec_id: MSM-02-007
+      note: 'ET shorthand wire-type mapping'
 
   - id: EMB-07-002
     priority: MUST
@@ -625,6 +676,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-11-004
       note: SHOULD send EK in acknowledgment of any E* message except EK itself
+    - rel_type: satisfies
+      spec_id: MSM-02-007
+      note: 'ET shorthand wire-type mapping'
 
   - id: EMB-07-003
     priority: MUST
@@ -649,6 +703,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-11-004
       note: SHOULD send EK in acknowledgment of any E* message except EK itself
+    - rel_type: satisfies
+      spec_id: MSM-02-007
+      note: 'ET shorthand wire-type mapping'
 
 - id: EMB-08
   title: Receive EE (Embargo Error)
@@ -687,6 +744,9 @@ groups:
       note: >-
         SHOULD acknowledge (EK) and inquire (GI) about the nature of any error
         reported by EE
+    - rel_type: satisfies
+      spec_id: MSM-02-008
+      note: 'EE shorthand wire-type mapping'
 
 - id: EMB-09
   title: Receive EK (Embargo Acknowledgment)
@@ -714,6 +774,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-11-004
       note: EK is the acknowledgment; no acknowledgment of acknowledgment required
+    - rel_type: satisfies
+      spec_id: MSM-02-009
+      note: 'EK shorthand wire-type mapping'
 
 - id: EMB-10
   title: Enter EM Proposed

--- a/specs/rm-behavior.yaml
+++ b/specs/rm-behavior.yaml
@@ -50,6 +50,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-03-009
       note: RK acknowledgment of RS
+    - rel_type: satisfies
+      spec_id: MSM-01-001
+      note: 'RS shorthand wire-type mapping'
 
   - id: RMB-01-002
     priority: MUST
@@ -95,6 +98,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-03-009
       note: RK acknowledgment of RS
+    - rel_type: satisfies
+      spec_id: MSM-01-001
+      note: 'RS shorthand wire-type mapping'
 
   - id: RMB-01-003
     priority: SHOULD
@@ -140,6 +146,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-03-009
       note: RK acknowledgment of RS
+    - rel_type: satisfies
+      spec_id: MSM-01-001
+      note: 'RS shorthand wire-type mapping'
 
   - id: RMB-01-004
     priority: SHOULD
@@ -169,6 +178,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-03-009
       note: RK acknowledgment of RS
+    - rel_type: satisfies
+      spec_id: MSM-01-001
+      note: 'RS shorthand wire-type mapping'
 
   - id: RMB-01-005
     priority: MAY
@@ -188,6 +200,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-03-013
       note: Recipients MAY ignore messages received on Closed cases
+    - rel_type: satisfies
+      spec_id: MSM-01-001
+      note: 'RS shorthand wire-type mapping'
 
 - id: RMB-02
   title: Receive RI (Report Invalid)
@@ -234,6 +249,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-02-019
       note: Shared awareness of sender RM state change
+    - rel_type: satisfies
+      spec_id: MSM-01-002
+      note: 'RI shorthand wire-type mapping'
 
   - id: RMB-02-002
     priority: SHOULD
@@ -268,6 +286,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-03-010
       note: RE+GI when R* (other than RS) received while in RM Start
+    - rel_type: satisfies
+      spec_id: MSM-01-002
+      note: 'RI shorthand wire-type mapping'
 
 - id: RMB-03
   title: Receive RV (Report Valid)
@@ -313,6 +334,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-02-019
       note: Shared awareness of sender RM state change
+    - rel_type: satisfies
+      spec_id: MSM-01-003
+      note: 'RV shorthand wire-type mapping'
 
   - id: RMB-03-002
     priority: SHOULD
@@ -347,6 +371,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-03-010
       note: RE+GI when R* (other than RS) received while in RM Start
+    - rel_type: satisfies
+      spec_id: MSM-01-003
+      note: 'RV shorthand wire-type mapping'
 
 - id: RMB-04
   title: Receive RD (Report Deferred)
@@ -392,6 +419,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-02-019
       note: Shared awareness of sender RM state change
+    - rel_type: satisfies
+      spec_id: MSM-01-004
+      note: 'RD shorthand wire-type mapping'
 
   - id: RMB-04-002
     priority: SHOULD
@@ -425,6 +455,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-03-010
       note: RE+GI when R* (other than RS) received while in RM Start
+    - rel_type: satisfies
+      spec_id: MSM-01-004
+      note: 'RD shorthand wire-type mapping'
 
 - id: RMB-05
   title: Receive RA (Report Accepted)
@@ -471,6 +504,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-02-019
       note: Shared awareness of sender RM state change
+    - rel_type: satisfies
+      spec_id: MSM-01-005
+      note: 'RA shorthand wire-type mapping'
 
   - id: RMB-05-002
     priority: SHOULD
@@ -505,6 +541,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-03-010
       note: RE+GI when R* (other than RS) received while in RM Start
+    - rel_type: satisfies
+      spec_id: MSM-01-005
+      note: 'RA shorthand wire-type mapping'
 
 - id: RMB-06
   title: Receive RC (Report Closed)
@@ -551,6 +590,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-02-019
       note: Shared awareness of sender RM state change
+    - rel_type: satisfies
+      spec_id: MSM-01-006
+      note: 'RC shorthand wire-type mapping'
 
   - id: RMB-06-002
     priority: MAY
@@ -574,6 +616,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-02-035
       note: Participants MAY close Accepted, Deferred, or Invalid reports
+    - rel_type: satisfies
+      spec_id: MSM-01-006
+      note: 'RC shorthand wire-type mapping'
 
   - id: RMB-06-003
     priority: SHOULD
@@ -607,6 +652,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-03-010
       note: RE+GI when R* (other than RS) received while in RM Start
+    - rel_type: satisfies
+      spec_id: MSM-01-006
+      note: 'RC shorthand wire-type mapping'
 
 - id: RMB-07
   title: Receive RE (Report Error)
@@ -651,6 +699,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-03-011
       note: Acknowledge RE and inquire about the error with GI
+    - rel_type: satisfies
+      spec_id: MSM-01-007
+      note: 'RE shorthand wire-type mapping'
 
   - id: RMB-07-002
     priority: SHOULD
@@ -687,6 +738,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-03-010
       note: RE+GI when R* (other than RS) received while in RM Start
+    - rel_type: satisfies
+      spec_id: MSM-01-007
+      note: 'RE shorthand wire-type mapping'
 
 - id: RMB-08
   title: Receive RK (Report Acknowledgment)
@@ -719,6 +773,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-03-009
       note: RK itself is never acknowledged with another RK
+    - rel_type: satisfies
+      spec_id: MSM-01-008
+      note: 'RK shorthand wire-type mapping'
 
   - id: RMB-08-002
     priority: SHOULD
@@ -754,6 +811,9 @@ groups:
     - rel_type: satisfies
       spec_id: VP-03-010
       note: RE+GI when R* received while in RM Start
+    - rel_type: satisfies
+      spec_id: MSM-01-008
+      note: 'RK shorthand wire-type mapping'
 
 - id: RMB-09
   title: Enter RM Received


### PR DESCRIPTION
- Closes #1445 (follow-up to #1448 — relationships were missing from behavioral spec items)

## Summary

- Adds `rel_type: satisfies` / `spec_id: MSM-XX-NNN` relationship entries to every `message_received` spec item across the three behavioral conformance spec files
- Completes the traceability graph: behavioral spec items (RMB/EMB/CSB) → MSM shorthand mapping → VAM wire-format specs

## Changes

- `specs/rm-behavior.yaml` — 20 MSM relationships added (RS×5, RI×2, RV×2, RD×2, RA×2, RC×3, RE×2, RK×2)
- `specs/em-behavior.yaml` — 21 MSM relationships added (EP×5, EA×3, EV×3, EJ×2, EC×2, ER×1, ET×3, EE×1, EK×1)
- `specs/cs-behavior.yaml` — 19 MSM relationships added (CV, CF, CD, CP×4, CX×5, CA×5, CE, CK)

Items with existing `relationships:` blocks have the MSM entry appended. Items with no `relationships:` block have a new block added. Registry validates at 67 files / 1972 specs with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)