### PR TITLE
skill: add create-pr; migrate build, plan-issue, bugfix, learn

### DIFF
--- a/.agents/skills/bugfix-handoff/SKILL.md
+++ b/.agents/skills/bugfix-handoff/SKILL.md
@@ -77,7 +77,7 @@ Then confirm to the user:
 ## Constraints
 
 - Do **NOT** attempt further bug resolution after this skill is invoked.
-- Do **NOT** open a PR — the fix is incomplete.
+- Do **NOT** open a PR — the fix is incomplete. Do **NOT** invoke `create-pr`.
 - Do **NOT** run linters or tests unless their output was already
   in-flight and you need to capture it for the handoff notes.
 - Do **NOT** wait for perfect information — document what you have now.

--- a/.agents/skills/bugfix/SKILL.md
+++ b/.agents/skills/bugfix/SKILL.md
@@ -154,29 +154,18 @@ focus hints from Phase 2 (e.g., `"wire layer"`, `"BT integration"`), then:
      `timestamp`, `source`).
    - Compute diff size: ≤50 → `size:S`; 51–300 → `size:M`; 301+ → `size:L`.
      Update the `size:` label.
-   - Push and open PR using the structured body template from
-     `.agents/skills/shared/pr-body-guide.md` (implementation PR shape):
+   - Invoke the `create-pr` skill to push and open the PR:
 
-     ```bash
-     git push -u origin bug/<N>-<slug>
-     gh pr create --repo CERTCC/Vultron \
-       --title "fix: <short title>" \
-       --body "- Fixes #<N>
-
-     ## Summary
-
-     <1–2 sentences: what bug was fixed and how>
-
-     ## Changes
-
-     - \`path/to/file.py\`: <what changed>
-
-     ## Verification
-
-     - All N unit tests pass (M new); regression test added
-     - Black, flake8, mypy, pyright clean" \
-       --label "size:<X>"
+     ```text
+     type:         implementation
+     title:        fix: <short title>
+     body:         <composed per pr-body-guide.md implementation template>
+     labels:       size:<X>
+     issue_number: <N>
      ```
+
+     `create-pr` performs the rebase on `origin/main`, validates, pushes, and
+     returns the PR URL. Use the returned URL in the `archive-history` call.
 
    - Invoke `commit` if any learning files were created in `plan/incoming/learnings/`
      outside the PR branch.

--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -242,37 +242,19 @@ draft commit and use `git diff main...HEAD` normally.
 1. Compute diff size: ≤50 lines → `size:S`; 51–300 → `size:M`; 301+ → `size:L`.
    Update the `size:` label on the Issue.
 
-2. Push and open a PR using the structured body template from
-   `.agents/skills/shared/pr-body-guide.md` (implementation PR shape):
+2. Invoke the `create-pr` skill to push and open the PR:
 
-   ```bash
-   git fetch origin main && git rebase origin/main
-   uv run git push "https://x-access-token:$(gh auth token)@github.com/CERTCC/Vultron.git" \
-     task/<N>-<slug>
-   gh pr create --repo CERTCC/Vultron \
-     --head task/<N>-<slug> \
-     --base main \
-     --title "<short title>" \
-     --body "- Closes #<N>
-
-   ## Summary
-
-   <1–2 sentences: what this PR does and why>
-
-   ## Changes
-
-   - \`path/to/file.py\`: <what changed>
-
-   ## Verification
-
-   - All N unit tests pass (M new)
-   - Black, flake8, mypy, pyright clean" \
-     --label "size:<X>"
+   ```text
+   type:         implementation
+   title:        <short title>
+   body:         <composed per pr-body-guide.md implementation template>
+   labels:       size:<X>
+   issue_number: <N>
    ```
 
-   If the rebase reports conflicts, stop, resolve them, and re-run validation
-   before pushing. This check must happen immediately before the push, not
-   earlier in the workflow.
+   `create-pr` performs the rebase on `origin/main`, validates, pushes, and
+   returns the PR URL. Use the returned URL in the `archive-history` call
+   below.
 
 3. Post `[ADVISORY]` findings as a PR comment (if any).
 
@@ -290,14 +272,6 @@ draft commit and use `git diff main...HEAD` normally.
    `timestamp`, `source`). Do not write completion summaries here.
 
 6. Invoke `commit` if any learning files were created in `plan/incoming/learnings/`.
-
-### Phase 9 — Merge Conflict Recovery (if needed)
-
-```bash
-git fetch origin main && git rebase origin/main
-# Success: git push --force-with-lease
-# Failure: post PR comment, add needs-rebase label, stop.
-```
 
 ## Constraints
 

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: create-pr
+description: >
+  Rebase-safe PR submission. Rebases the current branch on origin/main
+  immediately before pushing, validates (linters for docs PRs; full suite
+  for implementation PRs), resolves minor conflicts automatically, and
+  opens a PR. Called by build, plan-issue, bugfix, and learn. Can also be
+  invoked conversationally ("pr that for me"). Returns the PR URL.
+---
+
+# Skill: Create PR
+
+Centralized PR submission that enforces rebase-before-push on every invocation,
+regardless of how the PR is triggered.
+
+## Interface
+
+All parameters are optional. Supply what you have; the skill derives what's
+missing from `git log origin/main..HEAD` and the current diff.
+
+| Parameter | Description |
+|---|---|
+| `title` | PR title (derived from commits if omitted) |
+| `body` | Full PR body text (derived from diff if omitted) |
+| `type` | `docs` or `implementation` (inferred from changed files if omitted) |
+| `labels` | Space-separated label names (e.g., `"size:M specs-notes"`) |
+| `issue_number` | Issue to close (parsed from branch name if omitted; optional) |
+| `draft` | `true` to open as draft (default: `false`) |
+
+**Returns**: the PR URL as a string. Callers own `archive-history`.
+
+---
+
+## Phase 1 — Pre-flight Checks
+
+### 1a — Uncommitted changes
+
+```bash
+git status --porcelain
+```
+
+- **Called from another skill** (clean tree expected): if any uncommitted
+  changes are detected, hard stop with:
+  > "❌ Uncommitted changes detected. Commit or stash before calling create-pr."
+- **Conversational invocation** (user said "pr that for me"): ask the user
+  what to do:
+  > "There are uncommitted changes. Should I (a) commit them now with an
+  > auto-generated message, (b) stash and discard after the PR, or (c) abort?"
+
+  Wait for the user's answer and act accordingly before continuing.
+
+### 1b — Infer missing parameters
+
+If any required values were not passed by the caller, derive them now:
+
+```bash
+# Commits on this branch not on main
+git log origin/main..HEAD --oneline
+
+# Full diff
+git diff origin/main..HEAD
+
+# Changed files — determines PR type if not provided
+git diff --name-only origin/main..HEAD
+```
+
+**Type inference rule**: if any `.py` file appears in the diff → `implementation`;
+otherwise → `docs`.
+
+**Issue number inference**: if not provided, parse from the branch name
+(e.g., `task/1466-create-pr-skill` → `1466`, `plan/1362-lifecycle-staged` → `1362`).
+If still absent, proceed without a closing reference.
+
+**Title inference** (if not provided): use the most recent commit subject,
+stripping any commit-hash prefix.
+
+**Body inference** (if not provided): compose using the template from
+`.agents/skills/shared/pr-body-guide.md` for the inferred type.
+For `implementation`: Summary + Changes + Verification sections.
+For `docs`: Summary + Changes sections (no Verification).
+
+---
+
+## Phase 2 — Rebase
+
+```bash
+git fetch origin main
+git rebase origin/main
+```
+
+### Conflict handling
+
+If the rebase exits cleanly, proceed to Phase 3.
+
+If the rebase reports conflicts:
+
+1. **Attempt auto-resolution**: read each conflict marker in the affected
+   files. For conflicts that are clearly mechanical (whitespace differences,
+   non-overlapping additions, comment-only changes), resolve them directly
+   and continue the rebase:
+
+   ```bash
+   git add <resolved-file>
+   git rebase --continue
+   ```
+
+2. **If ambiguous conflicts remain** (both sides modified the same logic,
+   semantic collision): abort immediately:
+
+   ```bash
+   git rebase --abort
+   ```
+
+   Then open a draft PR with conflict notes (see Phase 4, draft-with-conflict
+   path below). **Do not push the un-rebased branch.**
+
+---
+
+## Phase 3 — Post-Rebase Validation
+
+Run the appropriate suite based on PR type:
+
+**Docs PR** (`type: docs`):
+
+```bash
+# Linters only — no Python changed
+uv run black --check .
+uv run flake8
+uv run mypy vultron
+uv run pyright
+```
+
+If any linter fails, fix the failure, stage, and amend the relevant commit
+before proceeding. Do not open a PR with lint failures.
+
+**Implementation PR** (`type: implementation`):
+
+Invoke `format-code`, then `run-linters`, then `run-tests`.
+
+If any step fails, fix, re-validate, and continue. Do not open a PR with
+failing tests or lint errors.
+
+---
+
+## Phase 4 — Push and Open PR
+
+### Happy path
+
+```bash
+git push "https://x-access-token:$(gh auth token)@github.com/CERTCC/Vultron.git" \
+  "$(git branch --show-current)"
+
+gh pr create --repo CERTCC/Vultron \
+  --head "$(git branch --show-current)" \
+  --base main \
+  --title "<title>" \
+  --body "<body>" \
+  --label "<labels>"
+```
+
+Capture and return the PR URL emitted by `gh pr create`.
+
+### Draft-with-conflict path (unresolvable rebase)
+
+If Phase 2 aborted with unresolvable conflicts:
+
+1. Push the **un-rebased** branch as-is:
+
+   ```bash
+   git push "https://x-access-token:$(gh auth token)@github.com/CERTCC/Vultron.git" \
+     "$(git branch --show-current)"
+   ```
+
+2. Open a **draft** PR with conflict notes and `needs-rebase` label:
+
+   ```bash
+   gh pr create --repo CERTCC/Vultron \
+     --head "$(git branch --show-current)" \
+     --base main \
+     --title "<title> [NEEDS REBASE]" \
+     --body "<!-- needs-rebase -->
+   > ⚠️ **This PR requires manual conflict resolution before it can be merged.**
+   >
+   > The \`create-pr\` skill attempted an automatic rebase on \`origin/main\`
+   > but encountered conflicts it could not resolve:
+   >
+   > **Conflicting files:**
+   > <list each conflicting file>
+   >
+   > **Nature of each conflict:**
+   > <one line per file: what both sides changed>
+   >
+   > **To resolve:**
+   > \`\`\`bash
+   > git fetch origin main
+   > git rebase origin/main
+   > # resolve conflicts in the files listed above
+   > git rebase --continue
+   > git push --force-with-lease
+   > \`\`\`
+   > Then convert this draft PR to ready for review.
+
+   <original PR body below>
+
+   <body>" \
+     --draft \
+     --label "needs-rebase"
+   ```
+
+3. Tell the user the draft PR URL and what needs resolving.
+4. Return the draft PR URL.
+
+---
+
+## Constraints
+
+- **Never push before rebasing.** The rebase step in Phase 2 is mandatory
+  and must happen immediately before the push in Phase 4.
+- **Never open a non-draft PR with lint failures or failing tests.**
+- **Callers own `archive-history`.** This skill does not call it.
+- If called from another skill, a dirty working tree is a hard stop, not a
+  prompt — callers must arrive with a clean tree.

--- a/.agents/skills/learn/SKILL.md
+++ b/.agents/skills/learn/SKILL.md
@@ -250,8 +250,7 @@ Do **not** reference `plan/incoming/learnings/` from durable docs.
    Fix all errors.
 2. If a requirement conflict cannot be resolved, create a learning file in
    `plan/incoming/learnings/` and **stop before committing**.
-3. Stage, commit, push, and open a docs-only PR (branch was created at the
-   end of Phase 3):
+3. Stage and commit (branch was created at the end of Phase 3):
 
    ```bash
    git add specs/<changed-files> notes/<changed-files> AGENTS.md \
@@ -264,25 +263,24 @@ Do **not** reference `plan/incoming/learnings/` from durable docs.
    - Refresh docs/reference/codebase/ via acquire-codebase-knowledge
 
    Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
-   git push -u origin learn/<YYYYMMDD>-<slug>
-
-   gh pr create --repo CERTCC/Vultron \
-     --title "docs: promote learnings — <topic>" \
-     --body "- Closes #<issue if applicable>
-
-   ## Summary
-
-   <what learnings were promoted and to which docs/specs/notes>
-
-   ## Changes
-
-   - <bullet: what was added or changed>" \
-     --label "specs-notes"
-   ```text
+   ```
 
    Use multiple commits for thematically distinct changes (e.g., spec
-   refinements, notes promoted, AGENTS.md updates). This PR carries the
-   `specs-notes` label for reviewer awareness.
+   refinements, notes promoted, AGENTS.md updates).
+
+   Then invoke the `create-pr` skill:
+
+   ```text
+   type:         docs
+   title:        docs: promote learnings — <topic>
+   body:         <composed per pr-body-guide.md docs template>
+   labels:       specs-notes
+   issue_number: <issue if applicable; omit if none>
+   ```
+
+   `create-pr` performs the rebase on `origin/main`, runs linters, pushes, and
+   returns the PR URL. Use the returned URL when filling in the `Docs PR:`
+   field in the archive bodies (Phase 9).
 
 ### Phase 9 — Archive Entries and Close Issues
 

--- a/.agents/skills/plan-issue/SKILL.md
+++ b/.agents/skills/plan-issue/SKILL.md
@@ -195,25 +195,24 @@ git commit -m "docs: plan issue #${ISSUE_NUMBER} — <short title>
 - <bullet: what was added or changed>
 
 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
-git push -u origin "plan/${ISSUE_NUMBER}-<slug>"
-
-gh pr create --repo CERTCC/Vultron \
-  --title "docs: plan issue #${ISSUE_NUMBER} — <short title>" \
-  --body "- Closes #${ISSUE_NUMBER}
-
-## Summary
-
-<1–2 sentences: what was planned and what docs/specs were produced>
-
-## Changes
-
-- <bullet: what was added or changed>" \
-  --label "specs-notes"
 ```
 
-> For Ideas and Concerns, `Closes #N` in the PR body closes the issue on
-> merge. For Epics, omit `Closes #N` — the Epic must not be closed by the
-> docs PR.
+Then invoke the `create-pr` skill:
+
+```text
+type:         docs
+title:        docs: plan issue #<N> — <short title>
+body:         <composed per pr-body-guide.md docs template>
+labels:       specs-notes
+issue_number: <N>   (omit for Epics — the Epic must not be closed by the docs PR)
+```
+
+`create-pr` performs the rebase on `origin/main`, runs linters, pushes, and
+returns the PR URL. Use the returned URL in the `archive-history` call (Phase 9).
+
+> For Ideas and Concerns, include `issue_number` so the PR body contains
+> `Closes #N`. For Epics, omit `issue_number` — the Epic must not be closed
+> by the docs PR.
 
 ### Phase 8 — Create Implementation Issues
 


### PR DESCRIPTION
- Closes #1466

## Summary

Adds a `create-pr` skill that enforces rebase-on-origin/main immediately before every push, and migrates all PR-opening skills (`build`, `plan-issue`, `bugfix`, `learn`) to call it instead of embedding inline `gh pr create` calls.

## Changes

- **`.agents/skills/create-pr/SKILL.md`**: new skill — pre-flight checks (uncommitted changes detection), parameter inference from git state, mandatory rebase, post-rebase validation (linters for docs; full suite for implementation), push, and PR open; draft-with-conflict path on unresolvable rebase
- **`.agents/skills/build/SKILL.md`**: Phase 8 inline push/create replaced with `create-pr` call; Phase 9 merge-conflict-recovery removed (now owned by `create-pr`)
- **`.agents/skills/plan-issue/SKILL.md`**: Phase 7 inline push/create replaced with `create-pr` call
- **`.agents/skills/bugfix/SKILL.md`**: Phase 3 finalize inline push/create replaced with `create-pr` call
- **`.agents/skills/learn/SKILL.md`**: Phase 8 inline push/create replaced with `create-pr` call
- **`.agents/skills/bugfix-handoff/SKILL.md`**: explicit note added that `create-pr` must not be called there