### PR TITLE
spec(schema): enforce Precondition.description required + fix all BehavioralSpec YAML items

### DIFF
--- a/notes/behavioral-conformance-specs.md
+++ b/notes/behavioral-conformance-specs.md
@@ -112,8 +112,28 @@ class Precondition(BaseModel):
     em_state: list[EMState] | None = None      # e.g. [EM.ACTIVE]
     cs_pattern: str | None = None              # 6-char vfdpxa regex, e.g. "...pxa"
     role: list[CVDRole] | None = None          # e.g. [CVDRole.VENDOR]
-    description: str | None = None            # prose for anything unstructured
+    description: str                           # required: prose summary of all typed fields
 ```
+
+`description` is **required** (not `Optional[str]`). It MUST be a non-empty
+prose summary of the complete precondition, derived from all typed fields
+present.  Use a consistent "mad lib" pattern synthesised from each typed
+field that is set:
+
+- `rm_state: [X]` → `"Participant is in RM X"`
+- `rm_state: [R,I,V,D,A]` → `"Participant is in an active RM state (Received/Invalid/Valid/Deferred/Accepted)"`
+- `em_state: [X]` → `"EM state is X"`
+- `em_state: [X, Y]` → `"EM state is X or Y"`
+- `role: [X]` → `"Participant holds the X role"`
+- `cs_pattern: "abc..."` → `"CS matches pattern abc..."`
+
+Combine multiple clauses with `"; "` separator, in field order:
+`rm_state` → `em_state` → `role` → `cs_pattern`.
+
+> **Field order in `Precondition`**: the class declares fields in the order
+> `rm_state`, `em_state`, `role`, `cs_pattern`, `description`. The prose
+> clauses MUST follow the same order so machine-generated and hand-authored
+> descriptions are consistent.
 
 The RM/EM/CS enums are stable (unchanged for several years); coupling
 `Precondition` to them is safe. `cs_pattern` uses the same 6-char regex

--- a/plan/history/2607/implementation/ISSUE-1450.md
+++ b/plan/history/2607/implementation/ISSUE-1450.md
@@ -1,0 +1,29 @@
+---
+source: ISSUE-1450
+timestamp: '2026-07-15T18:54:39.928700+00:00'
+title: 'spec(schema): enforce Precondition.description required + fix all BehavioralSpec
+  YAML items'
+type: implementation
+---
+
+## Issue #1450 — enforce Precondition.description required + fix all BehavioralSpec YAML items
+
+All four acceptance criteria met:
+
+- AC-1: `Precondition.description` changed from `Optional[str]` to `NonEmptyStr` (required); `Postcondition.description` also upgraded to `NonEmptyStr`; `Precondition` field order updated to `rm_state` → `em_state` → `role` → `cs_pattern` → `description` (matches mad-lib clause order)
+- AC-2: 116 description fields added to all precondition blocks across rm-behavior.yaml (39), em-behavior.yaml (43), cs-behavior.yaml (34) using a consistent mad-lib pattern: clauses joined by `"; "` in field declaration order
+- AC-3: `uv run spec-dump` exits 0 with no validation errors
+- AC-4: `notes/behavioral-conformance-specs.md` updated with description requirement, mad-lib clause templates and separator rule, field declaration order callout
+
+Mad-lib clause templates:
+
+- `rm_state: [X]` → `"Participant is in RM X"`
+- `em_state: [X, Y]` → `"EM state is X or Y"`
+- `role: [X]` → `"Participant holds the X role"`
+- `cs_pattern: "abc..."` → `"CS matches pattern abc..."`
+
+Tests: added `test_precondition_description_required` and `test_precondition_description_only_typed_fields_optional`; updated round-trip test with description field.
+
+DEFER: #1469 created for pre-existing `render.py export_yaml` bug (drops all typed Precondition fields).
+
+PR: <https://github.com/CERTCC/Vultron/pull/1470>

--- a/plan/history/2607/implementation/ISSUE-1469.md
+++ b/plan/history/2607/implementation/ISSUE-1469.md
@@ -1,0 +1,26 @@
+---
+source: ISSUE-1469
+timestamp: '2026-07-15T19:03:43.802571+00:00'
+title: 'fix(render): export_yaml preserves all typed Precondition and SpecGroup.trigger
+  fields'
+type: implementation
+---
+
+## Issue #1469 — fix(render): export_yaml silently drops typed Precondition fields
+
+**Root cause**: `_add_behavioral_spec_fields` in `vultron/metadata/specs/render.py` serialized `Precondition` objects as `{"description": item.description}` only, silently dropping `rm_state`, `em_state`, `role`, `cs_pattern`. Separately, `_group_to_dict` never serialized `SpecGroup.trigger`.
+
+**Fix**:
+
+- Added `_precondition_dict()` helper that emits all typed fields (in field declaration order) before `description`
+- Updated `_group_to_dict()` to emit `trigger: {type, value}` when present
+
+**Regression tests added** (3):
+
+- `test_export_yaml_precondition_typed_fields_preserved` — confirms typed fields survive export
+- `test_export_yaml_group_trigger_preserved` — confirms trigger survives export
+- `test_export_yaml_round_trips_through_schema` — full YAML round-trip reloads cleanly through Pydantic
+
+Fixed in the same commit as #1450 (same branch/PR).
+
+PR: <https://github.com/CERTCC/Vultron/pull/1470>

--- a/specs/cs-behavior.yaml
+++ b/specs/cs-behavior.yaml
@@ -46,6 +46,7 @@ groups:
         - VALID
         - DEFERRED
         - ACCEPTED
+      description: Participant is in an active RM state (Received/Invalid/Valid/Deferred/Accepted)
     steps:
     - order: 1
       actor: receiver
@@ -90,6 +91,7 @@ groups:
         - VALID
         - DEFERRED
         - ACCEPTED
+      description: Participant is in an active RM state (Received/Invalid/Valid/Deferred/Accepted)
     steps:
     - order: 1
       actor: receiver
@@ -134,6 +136,7 @@ groups:
         - VALID
         - DEFERRED
         - ACCEPTED
+      description: Participant is in an active RM state (Received/Invalid/Valid/Deferred/Accepted)
     steps:
     - order: 1
       actor: receiver
@@ -178,6 +181,7 @@ groups:
       em_state:
         - NONE
         - EXITED
+      description: EM state is None or Exited; CS matches pattern ...p..
     steps:
     - order: 1
       actor: receiver
@@ -209,6 +213,7 @@ groups:
     - cs_pattern: "...p.."
       em_state:
         - PROPOSED
+      description: EM state is Proposed; CS matches pattern ...p..
     steps:
     - order: 1
       actor: receiver
@@ -250,6 +255,7 @@ groups:
       em_state:
         - ACTIVE
         - REVISE
+      description: EM state is Active or Revise; CS matches pattern ...p..
     steps:
     - order: 1
       actor: receiver
@@ -296,6 +302,7 @@ groups:
     testable: true
     preconditions:
     - cs_pattern: "...P.."
+      description: CS matches pattern ...P..
     steps:
     - order: 1
       actor: receiver
@@ -335,6 +342,7 @@ groups:
       em_state:
         - NONE
         - EXITED
+      description: EM state is None or Exited; CS matches pattern ...px.
     steps:
     - order: 1
       actor: receiver
@@ -366,6 +374,7 @@ groups:
     - cs_pattern: "...px."
       em_state:
         - PROPOSED
+      description: EM state is Proposed; CS matches pattern ...px.
     steps:
     - order: 1
       actor: receiver
@@ -408,6 +417,7 @@ groups:
       em_state:
         - ACTIVE
         - REVISE
+      description: EM state is Active or Revise; CS matches pattern ...px.
     steps:
     - order: 1
       actor: receiver
@@ -447,6 +457,7 @@ groups:
     testable: true
     preconditions:
     - cs_pattern: "...Px."
+      description: CS matches pattern ...Px.
     steps:
     - order: 1
       actor: receiver
@@ -475,6 +486,7 @@ groups:
     testable: true
     preconditions:
     - cs_pattern: "...PX."
+      description: CS matches pattern ...PX.
     steps:
     - order: 1
       actor: receiver
@@ -513,6 +525,7 @@ groups:
       em_state:
         - NONE
         - EXITED
+      description: EM state is None or Exited; CS matches pattern ...p.a
     steps:
     - order: 1
       actor: receiver
@@ -545,6 +558,7 @@ groups:
     - cs_pattern: "...p.a"
       em_state:
         - PROPOSED
+      description: EM state is Proposed; CS matches pattern ...p.a
     steps:
     - order: 1
       actor: receiver
@@ -588,6 +602,7 @@ groups:
       em_state:
         - ACTIVE
         - REVISE
+      description: EM state is Active or Revise; CS matches pattern ...p.a
     steps:
     - order: 1
       actor: receiver
@@ -629,6 +644,7 @@ groups:
     testable: true
     preconditions:
     - cs_pattern: "...P.a"
+      description: CS matches pattern ...P.a
     steps:
     - order: 1
       actor: receiver
@@ -657,6 +673,7 @@ groups:
     testable: true
     preconditions:
     - cs_pattern: "...P.A"
+      description: CS matches pattern ...P.A
     steps:
     - order: 1
       actor: receiver
@@ -696,6 +713,7 @@ groups:
         - VALID
         - DEFERRED
         - ACCEPTED
+      description: Participant is in an active RM state (Received/Invalid/Valid/Deferred/Accepted)
     steps:
     - order: 1
       actor: receiver
@@ -761,6 +779,7 @@ groups:
         - NONE
       role:
         - vendor
+      description: EM state is None; Participant holds the Vendor role; CS matches pattern Vfd...
     lint_suppress:
     - testable_without_steps
     relationships:
@@ -782,6 +801,7 @@ groups:
     testable: true
     preconditions:
     - cs_pattern: "Vfd..."
+      description: CS matches pattern Vfd...
     steps:
     - order: 1
       actor: participant
@@ -815,6 +835,7 @@ groups:
     testable: false
     preconditions:
     - cs_pattern: "VFd..."
+      description: CS matches pattern VFd...
     lint_suppress:
     - testable_without_steps
     relationships:
@@ -836,6 +857,7 @@ groups:
     testable: true
     preconditions:
     - cs_pattern: "VFd..."
+      description: CS matches pattern VFd...
     steps:
     - order: 1
       actor: participant
@@ -865,6 +887,7 @@ groups:
       em_state:
         - ACTIVE
         - REVISE
+      description: EM state is Active or Revise; CS matches pattern VFD...
     steps:
     - order: 1
       actor: participant
@@ -891,6 +914,7 @@ groups:
     testable: true
     preconditions:
     - cs_pattern: "VFD..."
+      description: CS matches pattern VFD...
     steps:
     - order: 1
       actor: participant
@@ -924,6 +948,7 @@ groups:
       em_state:
         - ACTIVE
         - REVISE
+      description: EM state is Active or Revise; CS matches pattern ...P..
     steps:
     - order: 1
       actor: participant
@@ -956,6 +981,7 @@ groups:
     testable: false
     preconditions:
     - cs_pattern: "...P.."
+      description: CS matches pattern ...P..
     lint_suppress:
     - testable_without_steps
     relationships:
@@ -978,6 +1004,7 @@ groups:
     testable: true
     preconditions:
     - cs_pattern: "...P.."
+      description: CS matches pattern ...P..
     steps:
     - order: 1
       actor: participant
@@ -1009,6 +1036,7 @@ groups:
     testable: true
     preconditions:
     - cs_pattern: "...pX."
+      description: CS matches pattern ...pX.
     steps:
     - order: 1
       actor: participant
@@ -1044,6 +1072,7 @@ groups:
       em_state:
         - ACTIVE
         - REVISE
+      description: EM state is Active or Revise; CS matches pattern ...PX.
     steps:
     - order: 1
       actor: participant
@@ -1077,6 +1106,7 @@ groups:
     testable: false
     preconditions:
     - cs_pattern: "....X."
+      description: CS matches pattern ....X.
     lint_suppress:
     - testable_without_steps
     relationships:
@@ -1107,6 +1137,7 @@ groups:
       em_state:
         - ACTIVE
         - REVISE
+      description: EM state is Active or Revise; CS matches pattern .....A
     steps:
     - order: 1
       actor: participant
@@ -1145,6 +1176,7 @@ groups:
     testable: true
     preconditions:
     - cs_pattern: "...p.A"
+      description: CS matches pattern ...p.A
     steps:
     - order: 1
       actor: participant
@@ -1171,6 +1203,7 @@ groups:
     testable: false
     preconditions:
     - cs_pattern: ".....A"
+      description: CS matches pattern .....A
     lint_suppress:
     - testable_without_steps
     relationships:
@@ -1191,6 +1224,7 @@ groups:
     testable: true
     preconditions:
     - cs_pattern: ".....A"
+      description: CS matches pattern .....A
     steps:
     - order: 1
       actor: participant

--- a/specs/em-behavior.yaml
+++ b/specs/em-behavior.yaml
@@ -43,6 +43,7 @@ groups:
     - em_state:
         - NONE
       cs_pattern: "...pxa"
+      description: EM state is None; CS matches pattern ...pxa
     steps:
     - order: 1
       actor: receiver
@@ -77,8 +78,11 @@ groups:
     testable: true
     preconditions:
     - cs_pattern: "...P.."
+      description: CS matches pattern ...P..
     - cs_pattern: "....X."
+      description: CS matches pattern ....X.
     - cs_pattern: ".....A"
+      description: CS matches pattern .....A
     steps:
     - order: 1
       actor: receiver
@@ -117,6 +121,7 @@ groups:
     - em_state:
         - PROPOSED
       cs_pattern: "...pxa"
+      description: EM state is Proposed; CS matches pattern ...pxa
     steps:
     - order: 1
       actor: receiver
@@ -147,6 +152,7 @@ groups:
     preconditions:
     - rm_state:
         - INVALID
+      description: Participant is in RM Invalid
     lint_suppress:
     - testable_without_steps
     relationships:
@@ -173,6 +179,7 @@ groups:
     - rm_state:
         - DEFERRED
         - CLOSED
+      description: Participant is in RM Deferred/Closed
     lint_suppress:
     - testable_without_steps
     relationships:
@@ -206,6 +213,7 @@ groups:
     - em_state:
         - PROPOSED
       cs_pattern: "...pxa"
+      description: EM state is Proposed; CS matches pattern ...pxa
     steps:
     - order: 1
       actor: receiver
@@ -242,8 +250,11 @@ groups:
     testable: true
     preconditions:
     - cs_pattern: "...P.."
+      description: CS matches pattern ...P..
     - cs_pattern: "....X."
+      description: CS matches pattern ....X.
     - cs_pattern: ".....A"
+      description: CS matches pattern .....A
     steps:
     - order: 1
       actor: receiver
@@ -276,6 +287,7 @@ groups:
     - rm_state:
         - INVALID
         - CLOSED
+      description: Participant is in RM Invalid/Closed
     lint_suppress:
     - testable_without_steps
     relationships:
@@ -312,6 +324,7 @@ groups:
     - em_state:
         - ACTIVE
       cs_pattern: "...pxa"
+      description: EM state is Active; CS matches pattern ...pxa
     steps:
     - order: 1
       actor: receiver
@@ -352,6 +365,7 @@ groups:
     - em_state:
         - REVISE
       cs_pattern: "...pxa"
+      description: EM state is Revise; CS matches pattern ...pxa
     steps:
     - order: 1
       actor: receiver
@@ -384,14 +398,17 @@ groups:
         - ACTIVE
         - REVISE
       cs_pattern: "...P.."
+      description: EM state is Active or Revise; CS matches pattern ...P..
     - em_state:
         - ACTIVE
         - REVISE
       cs_pattern: "....X."
+      description: EM state is Active or Revise; CS matches pattern ....X.
     - em_state:
         - ACTIVE
         - REVISE
       cs_pattern: ".....A"
+      description: EM state is Active or Revise; CS matches pattern .....A
     steps:
     - order: 1
       actor: receiver
@@ -431,6 +448,7 @@ groups:
     - em_state:
         - REVISE
       cs_pattern: "...pxa"
+      description: EM state is Revise; CS matches pattern ...pxa
     steps:
     - order: 1
       actor: receiver
@@ -465,12 +483,15 @@ groups:
     - em_state:
         - REVISE
       cs_pattern: "...P.."
+      description: EM state is Revise; CS matches pattern ...P..
     - em_state:
         - REVISE
       cs_pattern: "....X."
+      description: EM state is Revise; CS matches pattern ....X.
     - em_state:
         - REVISE
       cs_pattern: ".....A"
+      description: EM state is Revise; CS matches pattern .....A
     steps:
     - order: 1
       actor: receiver
@@ -509,6 +530,7 @@ groups:
     - em_state:
         - REVISE
       cs_pattern: "...pxa"
+      description: EM state is Revise; CS matches pattern ...pxa
     steps:
     - order: 1
       actor: receiver
@@ -545,12 +567,15 @@ groups:
     - em_state:
         - REVISE
       cs_pattern: "...P.."
+      description: EM state is Revise; CS matches pattern ...P..
     - em_state:
         - REVISE
       cs_pattern: "....X."
+      description: EM state is Revise; CS matches pattern ....X.
     - em_state:
         - REVISE
       cs_pattern: ".....A"
+      description: EM state is Revise; CS matches pattern .....A
     steps:
     - order: 1
       actor: receiver
@@ -587,6 +612,7 @@ groups:
     preconditions:
     - em_state:
         - PROPOSED
+      description: EM state is Proposed
     steps:
     - order: 1
       actor: receiver
@@ -629,6 +655,7 @@ groups:
     preconditions:
     - em_state:
         - ACTIVE
+      description: EM state is Active
     steps:
     - order: 1
       actor: receiver
@@ -660,6 +687,7 @@ groups:
     preconditions:
     - em_state:
         - REVISE
+      description: EM state is Revise
     steps:
     - order: 1
       actor: receiver
@@ -692,6 +720,7 @@ groups:
     preconditions:
     - em_state:
         - EXITED
+      description: EM state is Exited
     steps:
     - order: 1
       actor: receiver
@@ -799,6 +828,7 @@ groups:
     preconditions:
     - em_state:
         - PROPOSED
+      description: EM state is Proposed
     relationships:
     - rel_type: satisfies
       spec_id: VP-04-004
@@ -826,6 +856,7 @@ groups:
         - INVALID
         - DEFERRED
         - CLOSED
+      description: Participant is in RM Invalid/Deferred/Closed
     lint_suppress:
     - testable_without_steps
     relationships:
@@ -856,6 +887,7 @@ groups:
     preconditions:
     - em_state:
         - ACTIVE
+      description: EM state is Active
     lint_suppress:
     - testable_without_steps
     relationships:
@@ -881,6 +913,7 @@ groups:
     preconditions:
     - em_state:
         - ACTIVE
+      description: EM state is Active
     relationships:
     - rel_type: satisfies
       spec_id: VP-05-014
@@ -904,6 +937,7 @@ groups:
       rm_state:
         - CLOSED
         - DEFERRED
+      description: Participant is in RM Closed/Deferred; EM state is Active
     lint_suppress:
     - testable_without_steps
     relationships:
@@ -931,6 +965,7 @@ groups:
       rm_state:
         - DEFERRED
         - INVALID
+      description: Participant is in RM Deferred/Invalid; EM state is Active or Revise
     lint_suppress:
     - testable_without_steps
     relationships:
@@ -953,6 +988,7 @@ groups:
     preconditions:
     - em_state:
         - ACTIVE
+      description: EM state is Active
     relationships:
     - rel_type: satisfies
       spec_id: VP-13-008
@@ -980,6 +1016,7 @@ groups:
     preconditions:
     - em_state:
         - REVISE
+      description: EM state is Revise
     relationships:
     - rel_type: satisfies
       spec_id: VP-04-005
@@ -1002,6 +1039,7 @@ groups:
       rm_state:
         - CLOSED
         - DEFERRED
+      description: Participant is in RM Closed/Deferred; EM state is Revise
     lint_suppress:
     - testable_without_steps
     relationships:
@@ -1026,6 +1064,7 @@ groups:
     preconditions:
     - em_state:
         - REVISE
+      description: EM state is Revise
     relationships:
     - rel_type: satisfies
       spec_id: VP-13-008
@@ -1050,6 +1089,7 @@ groups:
     preconditions:
     - em_state:
         - EXITED
+      description: EM state is Exited
     steps:
     - order: 1
       actor: participant
@@ -1080,12 +1120,15 @@ groups:
     - em_state:
         - EXITED
       cs_pattern: "...P.."
+      description: EM state is Exited; CS matches pattern ...P..
     - em_state:
         - EXITED
       cs_pattern: "....X."
+      description: EM state is Exited; CS matches pattern ....X.
     - em_state:
         - EXITED
       cs_pattern: ".....A"
+      description: EM state is Exited; CS matches pattern .....A
     lint_suppress:
     - testable_without_steps
     relationships:

--- a/specs/rm-behavior.yaml
+++ b/specs/rm-behavior.yaml
@@ -35,6 +35,7 @@ groups:
     preconditions:
     - rm_state:
         - START
+      description: Participant is in RM Start
     steps:
     - order: 1
       actor: receiver
@@ -72,6 +73,7 @@ groups:
       role:
         - vendor
       cs_pattern: vfd...
+      description: Participant is in RM Start; Participant holds the Vendor role; CS matches pattern vfd...
     steps:
     - order: 1
       actor: receiver
@@ -124,6 +126,7 @@ groups:
       role:
         - vendor
       cs_pattern: vfd...
+      description: Participant is in an active RM state (Received/Invalid/Valid/Deferred/Accepted); Participant holds the Vendor role; CS matches pattern vfd...
     steps:
     - order: 1
       actor: receiver
@@ -167,6 +170,7 @@ groups:
         - VALID
         - DEFERRED
         - ACCEPTED
+      description: Participant is in an active RM state (Received/Invalid/Valid/Deferred/Accepted)
     steps:
     - order: 1
       actor: receiver
@@ -196,6 +200,7 @@ groups:
     preconditions:
     - rm_state:
         - CLOSED
+      description: Participant is in RM Closed
     relationships:
     - rel_type: satisfies
       spec_id: VP-03-013
@@ -229,6 +234,7 @@ groups:
         - VALID
         - DEFERRED
         - ACCEPTED
+      description: Participant is in an active RM state (Received/Invalid/Valid/Deferred/Accepted)
     steps:
     - order: 1
       actor: receiver
@@ -267,6 +273,7 @@ groups:
     preconditions:
     - rm_state:
         - START
+      description: Participant is in RM Start
     steps:
     - order: 1
       actor: receiver
@@ -314,6 +321,7 @@ groups:
         - VALID
         - DEFERRED
         - ACCEPTED
+      description: Participant is in an active RM state (Received/Invalid/Valid/Deferred/Accepted)
     steps:
     - order: 1
       actor: receiver
@@ -352,6 +360,7 @@ groups:
     preconditions:
     - rm_state:
         - START
+      description: Participant is in RM Start
     steps:
     - order: 1
       actor: receiver
@@ -399,6 +408,7 @@ groups:
         - VALID
         - DEFERRED
         - ACCEPTED
+      description: Participant is in an active RM state (Received/Invalid/Valid/Deferred/Accepted)
     steps:
     - order: 1
       actor: receiver
@@ -436,6 +446,7 @@ groups:
     preconditions:
     - rm_state:
         - START
+      description: Participant is in RM Start
     steps:
     - order: 1
       actor: receiver
@@ -484,6 +495,7 @@ groups:
         - VALID
         - DEFERRED
         - ACCEPTED
+      description: Participant is in an active RM state (Received/Invalid/Valid/Deferred/Accepted)
     steps:
     - order: 1
       actor: receiver
@@ -522,6 +534,7 @@ groups:
     preconditions:
     - rm_state:
         - START
+      description: Participant is in RM Start
     steps:
     - order: 1
       actor: receiver
@@ -570,6 +583,7 @@ groups:
         - VALID
         - DEFERRED
         - ACCEPTED
+      description: Participant is in an active RM state (Received/Invalid/Valid/Deferred/Accepted)
     steps:
     - order: 1
       actor: receiver
@@ -612,6 +626,7 @@ groups:
         - INVALID
         - DEFERRED
         - ACCEPTED
+      description: Participant is in RM Received/Invalid/Deferred/Accepted
     relationships:
     - rel_type: satisfies
       spec_id: VP-02-035
@@ -633,6 +648,7 @@ groups:
     preconditions:
     - rm_state:
         - START
+      description: Participant is in RM Start
     steps:
     - order: 1
       actor: receiver
@@ -684,6 +700,7 @@ groups:
         - VALID
         - DEFERRED
         - ACCEPTED
+      description: Participant is in an active RM state (Received/Invalid/Valid/Deferred/Accepted)
     steps:
     - order: 1
       actor: receiver
@@ -719,6 +736,7 @@ groups:
     preconditions:
     - rm_state:
         - START
+      description: Participant is in RM Start
     steps:
     - order: 1
       actor: receiver
@@ -769,6 +787,7 @@ groups:
         - VALID
         - DEFERRED
         - ACCEPTED
+      description: Participant is in an active RM state (Received/Invalid/Valid/Deferred/Accepted)
     relationships:
     - rel_type: satisfies
       spec_id: VP-03-009
@@ -792,6 +811,7 @@ groups:
     preconditions:
     - rm_state:
         - START
+      description: Participant is in RM Start
     steps:
     - order: 1
       actor: receiver
@@ -834,6 +854,7 @@ groups:
     preconditions:
     - rm_state:
         - RECEIVED
+      description: Participant is in RM Received
     steps:
     - order: 1
       actor: participant
@@ -872,6 +893,7 @@ groups:
     preconditions:
     - rm_state:
         - RECEIVED
+      description: Participant is in RM Received
     relationships:
     - rel_type: satisfies
       spec_id: VP-02-012
@@ -899,6 +921,7 @@ groups:
     preconditions:
     - rm_state:
         - VALID
+      description: Participant is in RM Valid
     steps:
     - order: 1
       actor: participant
@@ -928,6 +951,7 @@ groups:
     preconditions:
     - rm_state:
         - VALID
+      description: Participant is in RM Valid
     lint_suppress:
     - testable_without_steps
     relationships:
@@ -948,6 +972,7 @@ groups:
     preconditions:
     - rm_state:
         - VALID
+      description: Participant is in RM Valid
     steps:
     - order: 1
       actor: participant
@@ -976,6 +1001,7 @@ groups:
     preconditions:
     - rm_state:
         - VALID
+      description: Participant is in RM Valid
     lint_suppress:
     - testable_without_steps
     relationships:
@@ -1005,6 +1031,7 @@ groups:
     preconditions:
     - rm_state:
         - INVALID
+      description: Participant is in RM Invalid
     steps:
     - order: 1
       actor: participant
@@ -1032,6 +1059,7 @@ groups:
     preconditions:
     - rm_state:
         - INVALID
+      description: Participant is in RM Invalid
     lint_suppress:
     - testable_without_steps
     relationships:
@@ -1058,6 +1086,7 @@ groups:
     preconditions:
     - rm_state:
         - INVALID
+      description: Participant is in RM Invalid
     relationships:
     - rel_type: satisfies
       spec_id: VP-02-033
@@ -1080,6 +1109,7 @@ groups:
     preconditions:
     - rm_state:
         - INVALID
+      description: Participant is in RM Invalid
     relationships:
     - rel_type: satisfies
       spec_id: VP-02-035
@@ -1107,6 +1137,7 @@ groups:
     preconditions:
     - rm_state:
         - DEFERRED
+      description: Participant is in RM Deferred
     steps:
     - order: 1
       actor: participant
@@ -1138,6 +1169,7 @@ groups:
     preconditions:
     - rm_state:
         - DEFERRED
+      description: Participant is in RM Deferred
     lint_suppress:
     - testable_without_steps
     relationships:
@@ -1160,6 +1192,7 @@ groups:
     preconditions:
     - rm_state:
         - DEFERRED
+      description: Participant is in RM Deferred
     relationships:
     - rel_type: satisfies
       spec_id: VP-02-031
@@ -1185,6 +1218,7 @@ groups:
     preconditions:
     - rm_state:
         - ACCEPTED
+      description: Participant is in RM Accepted
     lint_suppress:
     - testable_without_steps
     relationships:
@@ -1208,6 +1242,7 @@ groups:
     preconditions:
     - rm_state:
         - ACCEPTED
+      description: Participant is in RM Accepted
     steps:
     - order: 1
       actor: participant
@@ -1240,6 +1275,7 @@ groups:
     preconditions:
     - rm_state:
         - ACCEPTED
+      description: Participant is in RM Accepted
     lint_suppress:
     - testable_without_steps
     relationships:
@@ -1266,6 +1302,7 @@ groups:
     preconditions:
     - rm_state:
         - CLOSED
+      description: Participant is in RM Closed
     steps:
     - order: 1
       actor: participant
@@ -1295,6 +1332,7 @@ groups:
     preconditions:
     - rm_state:
         - CLOSED
+      description: Participant is in RM Closed
     relationships:
     - rel_type: satisfies
       spec_id: VP-03-013
@@ -1319,6 +1357,7 @@ groups:
       em_state:
         - ACTIVE
         - REVISE
+      description: Participant is in RM Invalid/Deferred/Accepted; EM state is Active or Revise
     lint_suppress:
     - testable_without_steps
     relationships:

--- a/test/metadata/specs/test_render.py
+++ b/test/metadata/specs/test_render.py
@@ -1,17 +1,74 @@
 """Tests for vultron.metadata.specs.render (SR.5.3).
 
 Covers: render_markdown output structure, export_json validity and filtering,
-render_registry_markdown multi-file concatenation.
+render_registry_markdown multi-file concatenation, export_yaml round-trip
+fidelity.
 """
 
 import json
 
+import yaml
+import pytest
+
 from vultron.metadata.specs.registry import load_registry
 from vultron.metadata.specs.render import (
     export_json,
+    export_yaml,
     render_markdown,
     render_registry_markdown,
 )
+
+# ---------------------------------------------------------------------------
+# Fixtures for behavioral specs with typed preconditions
+# ---------------------------------------------------------------------------
+
+BEHAVIORAL_YAML = {
+    "id": "BEH",
+    "title": "Behavioral Test Specs",
+    "description": "Spec file for testing export_yaml fidelity",
+    "version": "0.1",
+    "kind": "domain",
+    "scope": ["production"],
+    "groups": [
+        {
+            "id": "BEH-01",
+            "title": "BEH Group One",
+            "trigger": {"type": "message_received", "value": "EP"},
+            "specs": [
+                {
+                    "id": "BEH-01-001",
+                    "priority": "MUST",
+                    "statement": "BEH-01-001 MUST behave correctly",
+                    "preconditions": [
+                        {
+                            "rm_state": ["START"],
+                            "em_state": ["NONE"],
+                            "role": ["vendor"],
+                            "cs_pattern": "vfd...",
+                            "description": "Participant is in RM Start; EM state is None; Participant holds the Vendor role; CS matches pattern vfd...",
+                        }
+                    ],
+                    "postconditions": [
+                        {"description": "State has been updated"}
+                    ],
+                }
+            ],
+        }
+    ],
+}
+
+
+@pytest.fixture
+def behavioral_spec_dir(tmp_path):
+    """Spec directory with a BehavioralSpec that has typed precondition fields."""
+    (tmp_path / "beh_specs.yaml").write_text(yaml.dump(BEHAVIORAL_YAML))
+    return tmp_path
+
+
+@pytest.fixture
+def behavioral_registry(behavioral_spec_dir):
+    return load_registry(behavioral_spec_dir)
+
 
 # ---------------------------------------------------------------------------
 # render_markdown
@@ -108,3 +165,59 @@ def test_render_registry_markdown_multi_file(multi_spec_dir):
     assert "TST-01-001" in md
     assert "MOR-01-001" in md
     assert "---" in md  # files separated by "---"
+
+
+# ---------------------------------------------------------------------------
+# export_yaml — round-trip fidelity (#1469)
+# ---------------------------------------------------------------------------
+
+
+def test_export_yaml_precondition_typed_fields_preserved(behavioral_registry):
+    """export_yaml must not drop typed Precondition fields (fix for #1469)."""
+    yaml_str = export_yaml(behavioral_registry.files[0])
+    data = yaml.safe_load(yaml_str)
+    pc = data["groups"][0]["specs"][0]["preconditions"][0]
+    assert pc["rm_state"] == ["START"]
+    assert pc["em_state"] == ["NONE"]
+    assert pc["role"] == ["vendor"]
+    assert pc["cs_pattern"] == "vfd..."
+    assert "description" in pc
+
+
+def test_export_yaml_group_trigger_preserved(behavioral_registry):
+    """export_yaml must not drop SpecGroup.trigger (fix for #1469)."""
+    yaml_str = export_yaml(behavioral_registry.files[0])
+    data = yaml.safe_load(yaml_str)
+    trigger = data["groups"][0].get("trigger")
+    assert trigger is not None
+    assert trigger["type"] == "message_received"
+    assert trigger["value"] == "EP"
+
+
+def test_export_yaml_round_trips_through_schema(behavioral_registry):
+    """YAML produced by export_yaml must reload without validation errors."""
+    from pathlib import Path
+    from vultron.metadata.specs.registry import load_registry
+
+    yaml_str = export_yaml(behavioral_registry.files[0])
+    tmp = Path(behavioral_registry.files[0].id)  # just for naming
+    _ = tmp  # unused; we load from a tmp directory below
+
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / "beh.yaml"
+        p.write_text(yaml_str)
+        reloaded = load_registry(Path(d))
+
+    from vultron.metadata.specs.schema import BehavioralSpec
+
+    spec = reloaded.all_specs["BEH-01-001"]
+    assert isinstance(spec, BehavioralSpec)
+    assert spec.preconditions is not None
+    pc = spec.preconditions[0]
+    assert pc.rm_state is not None
+    assert len(pc.rm_state) == 1
+    assert pc.em_state is not None
+    assert pc.role is not None
+    assert pc.cs_pattern == "vfd..."

--- a/test/metadata/specs/test_schema.py
+++ b/test/metadata/specs/test_schema.py
@@ -637,13 +637,20 @@ def test_precondition_all_typed_fields():
     assert p.description == "Vendor in RM Valid/Accepted, no embargo"
 
 
-def test_precondition_all_none():
-    p = Precondition()
+def test_precondition_description_required():
+    """Precondition requires description; omitting it raises ValidationError."""
+    with pytest.raises(ValidationError):
+        Precondition()  # pyright: ignore[reportCallIssue]
+
+
+def test_precondition_description_only_typed_fields_optional():
+    """All typed fields are optional; only description is required."""
+    p = Precondition(description="No additional constraints")
     assert p.rm_state is None
     assert p.em_state is None
     assert p.cs_pattern is None
     assert p.role is None
-    assert p.description is None
+    assert p.description == "No additional constraints"
 
 
 def test_precondition_description_only():
@@ -765,6 +772,7 @@ def test_behavioral_spec_round_trips_through_yaml(tmp_path):
                             {
                                 "em_state": ["NONE"],
                                 "cs_pattern": "...pxa",
+                                "description": "EM state is None; CS matches pattern ...pxa",
                             }
                         ],
                         "steps": [

--- a/vultron/metadata/specs/render.py
+++ b/vultron/metadata/specs/render.py
@@ -114,11 +114,24 @@ def render_markdown(spec_file: SpecFile) -> str:
     return "\n".join(lines)
 
 
+def _precondition_dict(pc: object) -> dict:
+    d: dict = {}
+    if pc.rm_state is not None:  # type: ignore[attr-defined]
+        d["rm_state"] = [s.value for s in pc.rm_state]  # type: ignore[attr-defined]
+    if pc.em_state is not None:  # type: ignore[attr-defined]
+        d["em_state"] = [s.value for s in pc.em_state]  # type: ignore[attr-defined]
+    if pc.role is not None:  # type: ignore[attr-defined]
+        d["role"] = [r.value for r in pc.role]  # type: ignore[attr-defined]
+    if pc.cs_pattern is not None:  # type: ignore[attr-defined]
+        d["cs_pattern"] = pc.cs_pattern  # type: ignore[attr-defined]
+    d["description"] = pc.description  # type: ignore[attr-defined]
+    return d
+
+
 def _add_behavioral_spec_fields(d: dict, spec: BehavioralSpec) -> None:
     authored_sequences = {
         "preconditions": [
-            {"description": item.description}
-            for item in spec.preconditions or []
+            _precondition_dict(item) for item in spec.preconditions or []
         ],
         "steps": [_step_dict(item) for item in spec.steps or []],
         "postconditions": [
@@ -199,6 +212,11 @@ def _group_to_dict(group: SpecGroup, file: SpecFile) -> dict:
         d["kind"] = group.kind.value
     if group.scope is not None:
         d["scope"] = [s.value for s in group.scope]
+    if group.trigger is not None:
+        d["trigger"] = {
+            "type": group.trigger.type.value,
+            "value": group.trigger.value,
+        }
     d["specs"] = [_spec_to_dict(s, group, file) for s in group.specs]
     return d
 

--- a/vultron/metadata/specs/schema.py
+++ b/vultron/metadata/specs/schema.py
@@ -215,15 +215,17 @@ class Precondition(BaseModel):
 
     Typed fields reference the stable protocol state-machine enums directly so
     conformance tooling can evaluate preconditions without parsing prose.
-    At least one field must be provided; ``description`` is a prose fallback
-    for conditions that don't map cleanly to the typed fields.
+    ``description`` is required and provides a human-readable prose summary of
+    the full precondition, synthesised from all typed fields present.  Typed
+    fields that don't map to ``rm_state``, ``em_state``, ``cs_pattern``, or
+    ``role`` MUST be described here as a prose fallback.
     """
 
     rm_state: list[RM] | None = None
     em_state: list[EM] | None = None
-    cs_pattern: str | None = None
     role: list[CVDRole] | None = None
-    description: str | None = None
+    cs_pattern: str | None = None
+    description: NonEmptyStr
 
 
 class BehaviorStep(BaseModel):
@@ -238,7 +240,7 @@ class BehaviorStep(BaseModel):
 class Postcondition(BaseModel):
     """A postcondition for a behavioral spec."""
 
-    description: str
+    description: NonEmptyStr
 
 
 class BehavioralSpec(StatementSpec):


### PR DESCRIPTION
- Closes #1450
- Fixes #1469

## Summary

Makes `Precondition.description` a required `NonEmptyStr` field (was `Optional[str]`), adds consistent prose descriptions to all 116 precondition items across the three behavioral spec YAML files, and fixes `export_yaml` to preserve all typed `Precondition` fields and `SpecGroup.trigger` during round-trips.

## Changes

### #1450 — enforce Precondition.description required
- `vultron/metadata/specs/schema.py`: `Precondition.description` → `NonEmptyStr` (required); `Postcondition.description` → `NonEmptyStr`; field order updated to `rm_state` → `em_state` → `role` → `cs_pattern` → `description`
- `specs/rm-behavior.yaml`: added `description:` to all 39 precondition blocks
- `specs/em-behavior.yaml`: added `description:` to all 43 precondition blocks
- `specs/cs-behavior.yaml`: added `description:` to all 34 precondition blocks
- `notes/behavioral-conformance-specs.md`: documented `description` as required, mad-lib clause templates, field declaration order callout

### #1469 — fix export_yaml lossiness
- `vultron/metadata/specs/render.py`: new `_precondition_dict()` helper serializes `rm_state`, `em_state`, `role`, `cs_pattern` (enum values as strings) + `description`; `_group_to_dict()` now emits `trigger: {type, value}` when present

## Mad-lib pattern (for #1450)

Descriptions synthesised from typed fields in declaration order, joined by `"; "`:
- `rm_state: [X]` → `"Participant is in RM X"`
- `em_state: [X, Y]` → `"EM state is X or Y"`
- `role: [X]` → `"Participant holds the X role"`
- `cs_pattern: "abc..."` → `"CS matches pattern abc..."`

## Verification

- All 4777 unit tests pass (5 new: 2 for #1450, 3 for #1469)
- `uv run spec-dump` exits 0 with no validation errors (AC-3)
- Black, flake8, mypy, pyright all clean