### PR TITLE
feat(CM-16-008): forward Offer content to duplicate-recommendation Note

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1401.md
+++ b/plan/history/2607/implementation/ISSUE-1401.md
@@ -1,0 +1,15 @@
+---
+source: ISSUE-1401
+timestamp: '2026-07-15T19:08:47.753503+00:00'
+title: Forward Offer content to duplicate-recommendation Note (CM-16-008)
+type: implementation
+---
+
+## Issue #1401 — Forward Offer.content to duplicate-recommendation Note
+
+Implemented CM-16-008: wire extractor now populates VultronActivity.content;
+use case validates and passes offer_content to tree factory;
+EmitNoteDuplicateRecommendationToOwnerNode appends it to the Note body.
+6 new unit tests added.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1471>

--- a/test/core/behaviors/case/test_suggest_actor_tree.py
+++ b/test/core/behaviors/case/test_suggest_actor_tree.py
@@ -851,3 +851,100 @@ class TestProtocolPairIsPending:
             object_id=_RECOMMENDED,
         )
         assert pair.request_found is False
+
+
+class TestEmitNoteDuplicateRecommendationToOwnerNodeContent:
+    """Unit tests for offer_content forwarding (CM-16-008)."""
+
+    _OWNER_ID = "https://example.org/actors/owner"
+
+    def _node_with_factory(self, offer_content=None):
+        """Build a wired node with a mock DataLayer and factory."""
+        dl = MagicMock()
+        case_obj = MagicMock()
+        case_obj.attributed_to = self._OWNER_ID
+        dl.read.return_value = case_obj
+        factory = MagicMock()
+        factory.create_note.return_value = ("note-id-1", MagicMock())
+        factory.add_note_to_case.return_value = ("activity-id-1", MagicMock())
+        node = EmitNoteDuplicateRecommendationToOwnerNode(
+            recommendation_id=_REC_ID,
+            recommender_id=_RECOMMENDER,
+            recommended_id=_RECOMMENDED,
+            case_id=_CASE_ID,
+            offer_content=offer_content,
+        )
+        writer = py_trees.blackboard.Client(name="test-emit-note-dup-writer")
+        writer.register_key(
+            key="datalayer", access=py_trees.common.Access.WRITE
+        )
+        writer.register_key(
+            key="actor_id", access=py_trees.common.Access.WRITE
+        )
+        writer.register_key(
+            key="trigger_activity_factory",
+            access=py_trees.common.Access.WRITE,
+        )
+        writer.datalayer = dl
+        writer.actor_id = _ACTOR_ID
+        writer.trigger_activity_factory = factory
+        node.setup()
+        node.initialise()
+        return node, factory
+
+    def setup_method(self):
+        py_trees.blackboard.Blackboard.enable_activity_stream()
+
+    def teardown_method(self):
+        py_trees.blackboard.Blackboard.disable_activity_stream()
+        py_trees.blackboard.Blackboard.storage.clear()
+
+    def test_returns_success_without_offer_content(self):
+        """AC-6: node succeeds and sends Note when offer_content is None."""
+        node, factory = self._node_with_factory(offer_content=None)
+        result = node.update()
+        assert result == Status.SUCCESS
+        factory.create_note.assert_called_once()
+
+    def test_note_body_excludes_content_when_absent(self):
+        """Note body must not contain 'Recommender note:' when offer_content is None."""
+        node, factory = self._node_with_factory(offer_content=None)
+        node.update()
+        call_kwargs = factory.create_note.call_args
+        content_arg = call_kwargs.kwargs["content"]
+        assert "Recommender note:" not in content_arg
+
+    def test_returns_success_with_offer_content(self):
+        """AC-6 + CM-16-008: node succeeds and sends Note when offer_content is set."""
+        node, factory = self._node_with_factory(
+            offer_content="Please add this vendor urgently."
+        )
+        result = node.update()
+        assert result == Status.SUCCESS
+        factory.create_note.assert_called_once()
+
+    def test_note_body_includes_offer_content(self):
+        """CM-16-008: Note body must include offer_content when provided."""
+        offer_text = "Please add this vendor urgently."
+        node, factory = self._node_with_factory(offer_content=offer_text)
+        node.update()
+        call_kwargs = factory.create_note.call_args
+        content_arg = call_kwargs.kwargs["content"]
+        assert "Recommender note:" in content_arg
+        assert offer_text in content_arg
+
+    def test_offer_content_stored_on_node(self):
+        """offer_content is stored as an attribute for introspection."""
+        offer_text = "Some notes."
+        node, _ = self._node_with_factory(offer_content=offer_text)
+        assert node.offer_content == offer_text
+
+    def test_offer_content_none_by_default(self):
+        """offer_content defaults to None (backward-compatible constructor)."""
+        node = EmitNoteDuplicateRecommendationToOwnerNode(
+            recommendation_id=_REC_ID,
+            recommender_id=_RECOMMENDER,
+            recommended_id=_RECOMMENDED,
+            case_id=_CASE_ID,
+        )
+        assert node.offer_content is None

--- a/test/core/behaviors/case/test_suggest_actor_tree.py
+++ b/test/core/behaviors/case/test_suggest_actor_tree.py
@@ -948,3 +948,22 @@ class TestEmitNoteDuplicateRecommendationToOwnerNodeContent:
             case_id=_CASE_ID,
         )
         assert node.offer_content is None
+
+    def test_whitespace_only_offer_content_normalized_to_none(self):
+        """Whitespace-only offer_content is normalized to None at construction."""
+        node = EmitNoteDuplicateRecommendationToOwnerNode(
+            recommendation_id=_REC_ID,
+            recommender_id=_RECOMMENDER,
+            recommended_id=_RECOMMENDED,
+            case_id=_CASE_ID,
+            offer_content="   ",
+        )
+        assert node.offer_content is None
+
+    def test_note_body_excludes_content_for_whitespace_only_input(self):
+        """Note body must not contain 'Recommender note:' for whitespace-only offer_content."""
+        node, factory = self._node_with_factory(offer_content="   ")
+        node.update()
+        call_kwargs = factory.create_note.call_args
+        content_arg = call_kwargs.kwargs["content"]
+        assert "Recommender note:" not in content_arg

--- a/vultron/core/behaviors/case/suggest_actor_tree.py
+++ b/vultron/core/behaviors/case/suggest_actor_tree.py
@@ -472,7 +472,9 @@ class EmitNoteDuplicateRecommendationToOwnerNode(DataLayerAction):
         self.recommender_id = recommender_id
         self.recommended_id = recommended_id
         self.case_id = case_id
-        self.offer_content = offer_content
+        self.offer_content = (
+            (offer_content.strip() or None) if offer_content else None
+        )
 
     def update(self) -> Status:
         if self.datalayer is None or self.actor_id is None:

--- a/vultron/core/behaviors/case/suggest_actor_tree.py
+++ b/vultron/core/behaviors/case/suggest_actor_tree.py
@@ -452,6 +452,10 @@ class EmitNoteDuplicateRecommendationToOwnerNode(DataLayerAction):
     Accept/Reject decision (AC-6, CM-16-008).  Sends a
     ``Create(Note)`` + ``Add(Note, Case)`` to the Case Owner without
     issuing a second ``Offer(CaseParticipant)``.
+
+    When ``offer_content`` is provided (non-None, non-empty), it is appended
+    to the Note body per CM-16-008's requirement to forward the incoming
+    Offer's ``content`` field to the Case Owner.
     """
 
     def __init__(
@@ -460,6 +464,7 @@ class EmitNoteDuplicateRecommendationToOwnerNode(DataLayerAction):
         recommender_id: str,
         recommended_id: str,
         case_id: str,
+        offer_content: str | None = None,
         name: str | None = None,
     ) -> None:
         super().__init__(name=name or self.__class__.__name__)
@@ -467,6 +472,7 @@ class EmitNoteDuplicateRecommendationToOwnerNode(DataLayerAction):
         self.recommender_id = recommender_id
         self.recommended_id = recommended_id
         self.case_id = case_id
+        self.offer_content = offer_content
 
     def update(self) -> Status:
         if self.datalayer is None or self.actor_id is None:
@@ -500,6 +506,10 @@ class EmitNoteDuplicateRecommendationToOwnerNode(DataLayerAction):
                 f"'{self.case_id}'.  An Offer(CaseParticipant) is already "
                 f"pending your decision (no second offer sent)."
             )
+            if self.offer_content:
+                content = (
+                    f"{content}\n\nRecommender note: {self.offer_content}"
+                )
             note_id, _ = factory.create_note(
                 name=f"Duplicate recommendation — {actor_segment}",
                 content=content,
@@ -566,6 +576,7 @@ def create_recommend_actor_to_case_received_tree(
     recommender_id: str,
     recommended_id: str,
     case_id: str,
+    offer_content: str | None = None,
 ) -> py_trees.composites.Sequence:
     """Received-side BT for Offer(Actor, Case) on the CaseActor inbox.
 
@@ -598,6 +609,9 @@ def create_recommend_actor_to_case_received_tree(
         recommender_id: Actor ID of the recommending participant.
         recommended_id: Actor ID of the suggested new participant.
         case_id: ID of the VulnerabilityCase.
+        offer_content: Optional ``content`` field from the inbound Offer
+            activity; forwarded to the duplicate-recommendation Note per
+            CM-16-008.
 
     Returns:
         Root ``RecommendActorToCaseBT`` Sequence node.
@@ -649,6 +663,7 @@ def create_recommend_actor_to_case_received_tree(
                 recommender_id=recommender_id,
                 recommended_id=recommended_id,
                 case_id=case_id,
+                offer_content=offer_content,
             ),
         ],
     )

--- a/vultron/core/use_cases/received/actor/suggest.py
+++ b/vultron/core/use_cases/received/actor/suggest.py
@@ -62,11 +62,16 @@ class OfferActorToCaseReceivedUseCase:
             )
             return
 
+        offer_content = getattr(request.activity, "content", None)
+        if not isinstance(offer_content, str) or not offer_content.strip():
+            offer_content = None
+
         tree = create_recommend_actor_to_case_received_tree(
             recommendation_id=activity_id,
             recommender_id=recommender_id,
             recommended_id=recommended_id,
             case_id=case_id,
+            offer_content=offer_content,
         )
         bridge = BTBridge(
             datalayer=self._dl, trigger_activity=self._trigger_activity

--- a/vultron/core/use_cases/received/actor/suggest.py
+++ b/vultron/core/use_cases/received/actor/suggest.py
@@ -63,7 +63,15 @@ class OfferActorToCaseReceivedUseCase:
             return
 
         offer_content = getattr(request.activity, "content", None)
-        if not isinstance(offer_content, str) or not offer_content.strip():
+        if offer_content is not None and not isinstance(offer_content, str):
+            logger.warning(
+                "OfferActorToCaseReceived: activity '%s' has non-string content"
+                " type %s — ignoring",
+                activity_id,
+                type(offer_content).__name__,
+            )
+            offer_content = None
+        elif not isinstance(offer_content, str) or not offer_content.strip():
             offer_content = None
 
         tree = create_recommend_actor_to_case_received_tree(

--- a/vultron/wire/as2/extractor/_builders.py
+++ b/vultron/wire/as2/extractor/_builders.py
@@ -102,6 +102,7 @@ def _build_activity_snapshot(
         to=_get_id_list(getattr(activity, "to", None)),
         cc=_get_id_list(getattr(activity, "cc", None)),
         summary=getattr(activity, "summary", None) or None,
+        content=getattr(activity, "content", None) or None,
     )
 
 


### PR DESCRIPTION
- Closes #1401

## Summary

Satisfies spec requirement CM-16-008: when a duplicate `Offer(Actor, Case)` arrives while an `Offer(CaseParticipant)` is already pending, the CaseActor now forwards the incoming Offer's `content` field to the Note sent to the Case Owner.

## Changes

- `vultron/wire/as2/extractor/_builders.py`: `_build_activity_snapshot` now extracts `content` (with `or None` normalisation) so `VultronActivity.content` is populated from the wire layer
- `vultron/core/behaviors/case/suggest_actor_tree.py`: `EmitNoteDuplicateRecommendationToOwnerNode` gains `offer_content: str | None = None`; appends `\n\nRecommender note: <text>` to the Note body when set; `create_recommend_actor_to_case_received_tree` threads the param to the AC-6 arm
- `vultron/core/use_cases/received/actor/suggest.py`: extracts and validates `offer_content` at the use-case boundary (type check + `strip()` guard for whitespace-only strings) before passing to the tree factory
- `test/core/behaviors/case/test_suggest_actor_tree.py`: 6 new tests in `TestEmitNoteDuplicateRecommendationToOwnerNodeContent` covering content-absent, content-present, whitespace-safe, attribute storage, and backward-compatible default constructor

## Verification

- 70 unit tests in `test_suggest_actor_tree.py` pass (6 new)
- Full unit suite: 4779 passed, 0 failures
- Black, flake8, mypy, pyright all clean