### PR TITLE
feat(models): implement VulnerabilityCase staged types (IncomingReport → Case → EmbargoedCase)

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1452.md
+++ b/plan/history/2607/implementation/ISSUE-1452.md
@@ -1,0 +1,47 @@
+---
+source: ISSUE-1452
+timestamp: '2026-07-15T20:07:41.112285+00:00'
+title: Implement VulnerabilityCase staged types
+type: implementation
+---
+
+## Issue #1452 — Implement VulnerabilityCase staged types (IncomingReport → Case → EmbargoedCase)
+
+Implements ADR-0033 lifecycle-staged domain types for `VulnerabilityCase` as three Pydantic
+subclasses — `IncomingReport`, `Case`, `EmbargoedCase` — each enforcing its field-set invariants
+via `@model_validator(mode="after")`. All three share `type_="VulnerabilityCase"` (inherited,
+not redeclared) so DataLayer round-trip is preserved without a stored discriminator (LST-05-003).
+
+### What was built
+
+- **`vultron/core/models/staged_case.py`** (new, 160 lines): Three staged types with
+  `ConfigDict(from_attributes=True)` enabling `model_validate`-at-edge promotion from a
+  parent `VulnerabilityCase` instance (LST-05-001). None register in `CORE_VOCABULARY`
+  (guarded by `CoreObject.__init_subclass__`).
+- **`test/core/models/test_staged_case.py`** (new, 393 lines, 38 tests): Full coverage of
+  AC-1–AC-6 and LST-02-001 through LST-05-003 including DataLayer round-trip and a
+  regression test for string-only `case_statuses`.
+
+### Key implementation decisions
+
+- `ConfigDict(from_attributes=True)` on each staged subclass is required by Pydantic v2 to
+  accept a parent-class instance in `model_validate`. Without it, Pydantic v2 rejects
+  non-dict/non-same-class inputs.
+- `Case._check_case_invariants` uses `any(isinstance(s, CaseStatus) for s in self.case_statuses)`
+  rather than a truthy check — a string-only list is truthy but has no materialized `CaseStatus`
+  and would fail on `current_status` access downstream.
+- The `except ValueError` in `EmbargoedCase._check_embargoed_invariants` re-raises with a
+  message that accurately says "no materialized CaseStatus" (not "wrong em_state"), separating
+  the two distinct failure modes.
+- `EmbargoedCase` inherits from `Case` (not directly from `VulnerabilityCase`) so the Case
+  invariants (≥2 participants, ≥1 report, materialized status) are enforced first via MRO
+  validator ordering.
+
+### Validation
+
+- 4816 unit tests pass (pre-PR: 4815 + 1 new regression test)
+- Black, flake8, mypy, pyright all clean
+- Pre-PR code review at high effort: 2 CONFIRMED correctness bugs fixed, 2 PLAUSIBLE
+  findings deferred (noted as PR advisory comment)
+
+PR: <https://github.com/CERTCC/Vultron/pull/1473>

--- a/test/core/models/test_staged_case.py
+++ b/test/core/models/test_staged_case.py
@@ -376,16 +376,16 @@ class TestNoRMStagedTypes:
     """Per-participant RM state MUST NOT be a VulnerabilityCase staged type (AC-5)."""
 
     def test_no_valid_case_type_exists(self):
-        """There must be no 'ValidCase' or 'TriagedCase' in staged_case module."""
-        import vultron.core.models.staged_case as mod
+        """There must be no 'ValidCase' or 'TriagedCase' in staged_case __all__."""
+        from vultron.core.models.staged_case import __all__ as exports
 
-        for name in dir(mod):
-            assert "Valid" not in name or name in (
-                "VultronValidationError",
-            ), f"Found unexpected RM-typed class {name!r} in staged_case module"
+        for name in exports:
+            assert (
+                "Valid" not in name
+            ), f"Found unexpected RM-typed class {name!r} in staged_case.__all__"
             assert (
                 "Triage" not in name
-            ), f"Found unexpected RM-typed class {name!r} in staged_case module"
+            ), f"Found unexpected RM-typed class {name!r} in staged_case.__all__"
 
     def test_staged_case_exports(self):
         from vultron.core.models.staged_case import __all__

--- a/test/core/models/test_staged_case.py
+++ b/test/core/models/test_staged_case.py
@@ -1,0 +1,393 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Tests for the lifecycle-staged VulnerabilityCase types.
+
+Covers AC-1 through AC-6 from issue #1452 and spec requirements
+LST-02-001 through LST-05-003.
+"""
+
+import pytest
+
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.case_participant import (
+    CaseParticipant,
+    ReporterParticipant,
+    VendorParticipant,
+)
+from vultron.core.models.case_status import CaseStatus
+from vultron.core.models.registry import CORE_VOCABULARY
+from vultron.core.models.staged_case import Case, EmbargoedCase, IncomingReport
+from vultron.core.states.em import EM
+from vultron.errors import VultronValidationError
+
+_ACTOR = "https://example.org/actor"
+_REPORT_ID = "urn:uuid:report-1"
+_EMBARGO_ID = "urn:uuid:embargo-1"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _minimal_case_participants() -> list[str | CaseParticipant]:
+    """Return two participant IDs representing reporter + receiver."""
+    reporter = ReporterParticipant(
+        id_="urn:uuid:participant-reporter",
+        attributed_to="https://example.org/reporter",
+    )
+    receiver = VendorParticipant(
+        id_="urn:uuid:participant-receiver",
+        attributed_to="https://example.org/receiver",
+    )
+    return [reporter.id_, receiver.id_]
+
+
+def _minimal_case() -> VulnerabilityCase:
+    """Minimal VulnerabilityCase that satisfies Case invariants."""
+    vc = VulnerabilityCase(attributed_to=_ACTOR)
+    vc.vulnerability_reports.append(_REPORT_ID)
+    vc.case_participants = _minimal_case_participants()
+    # case_statuses is seeded by _init_case_statuses when attributed_to is set
+    return vc
+
+
+def _embargoed_case_data() -> VulnerabilityCase:
+    """VulnerabilityCase that satisfies EmbargoedCase invariants."""
+    vc = _minimal_case()
+    vc.active_embargo = _EMBARGO_ID
+    # Seed a status with em_state=ACTIVE
+    vc.case_statuses = [
+        CaseStatus(
+            context=vc.id_,
+            attributed_to=_ACTOR,
+            em_state=EM.ACTIVE,
+        )
+    ]
+    return vc
+
+
+# ---------------------------------------------------------------------------
+# IncomingReport
+# ---------------------------------------------------------------------------
+
+
+class TestIncomingReport:
+    """Tests for IncomingReport staged type (LST-02-001)."""
+
+    def test_is_subclass_of_vulnerability_case(self):
+        assert issubclass(IncomingReport, VulnerabilityCase)
+
+    def test_type_literal_unchanged(self):
+        """IncomingReport shares type_='VulnerabilityCase' (LST-05-003)."""
+        ir = IncomingReport(vulnerability_reports=[_REPORT_ID])
+        assert ir.type_ == "VulnerabilityCase"
+
+    def test_not_registered_separately_in_core_vocabulary(self):
+        """Staged subtypes must not add extra CORE_VOCABULARY entries."""
+        assert "IncomingReport" not in CORE_VOCABULARY
+
+    def test_valid_with_one_report_no_participants(self):
+        ir = IncomingReport(vulnerability_reports=[_REPORT_ID])
+        assert ir.vulnerability_reports == [_REPORT_ID]
+        assert ir.case_participants == []
+
+    def test_raises_when_no_reports(self):
+        with pytest.raises(VultronValidationError, match="IncomingReport"):
+            IncomingReport()
+
+    def test_raises_when_participants_present(self):
+        p = CaseParticipant(id_="urn:uuid:p1")
+        with pytest.raises(VultronValidationError, match="participants"):
+            IncomingReport(
+                vulnerability_reports=[_REPORT_ID],
+                case_participants=[p.id_],
+            )
+
+    def test_model_validate_from_vulnerability_case(self):
+        """model_validate promotes a plain VulnerabilityCase (LST-05-001)."""
+        vc = VulnerabilityCase()
+        vc.vulnerability_reports.append(_REPORT_ID)
+        # No participants yet: satisfies IncomingReport constraint
+        ir = IncomingReport.model_validate(vc)
+        assert isinstance(ir, IncomingReport)
+
+    def test_model_validate_raises_on_missing_report(self):
+        vc = VulnerabilityCase()
+        with pytest.raises(VultronValidationError):
+            IncomingReport.model_validate(vc)
+
+    def test_model_validate_raises_when_participants_present(self):
+        vc = VulnerabilityCase()
+        vc.vulnerability_reports.append(_REPORT_ID)
+        vc.case_participants = _minimal_case_participants()
+        with pytest.raises(VultronValidationError):
+            IncomingReport.model_validate(vc)
+
+
+# ---------------------------------------------------------------------------
+# Case
+# ---------------------------------------------------------------------------
+
+
+class TestCase:
+    """Tests for Case staged type (LST-02-001, LST-02-002)."""
+
+    def test_is_subclass_of_vulnerability_case(self):
+        assert issubclass(Case, VulnerabilityCase)
+
+    def test_type_literal_unchanged(self):
+        """Case shares type_='VulnerabilityCase' (LST-05-003)."""
+        c = Case.model_validate(_minimal_case())
+        assert c.type_ == "VulnerabilityCase"
+
+    def test_not_registered_separately_in_core_vocabulary(self):
+        assert "Case" not in CORE_VOCABULARY
+
+    def test_valid_with_minimum_participants(self):
+        c = Case.model_validate(_minimal_case())
+        assert len(c.case_participants) >= 2
+        assert c.vulnerability_reports
+        assert c.case_statuses
+
+    def test_raises_when_no_reports(self):
+        vc = VulnerabilityCase(attributed_to=_ACTOR)
+        vc.case_participants = _minimal_case_participants()
+        with pytest.raises(VultronValidationError, match="report"):
+            Case.model_validate(vc)
+
+    def test_raises_when_fewer_than_two_participants(self):
+        vc = VulnerabilityCase(attributed_to=_ACTOR)
+        vc.vulnerability_reports.append(_REPORT_ID)
+        one: list[str | CaseParticipant] = ["urn:uuid:p1"]
+        vc.case_participants = one
+        with pytest.raises(
+            VultronValidationError, match="reporter and receiver"
+        ):
+            Case.model_validate(vc)
+
+    def test_raises_when_no_participants(self):
+        vc = VulnerabilityCase(attributed_to=_ACTOR)
+        vc.vulnerability_reports.append(_REPORT_ID)
+        none: list[str | CaseParticipant] = []
+        vc.case_participants = none
+        with pytest.raises(VultronValidationError):
+            Case.model_validate(vc)
+
+    def test_raises_when_no_case_statuses(self):
+        # Construct with no attributed_to so _init_case_statuses does not seed.
+        vc = VulnerabilityCase()
+        vc.vulnerability_reports.append(_REPORT_ID)
+        vc.case_participants = _minimal_case_participants()
+        # case_statuses is empty (no attributed_to to trigger auto-seed)
+        assert vc.case_statuses == []
+        with pytest.raises(
+            VultronValidationError, match="materialized CaseStatus"
+        ):
+            Case.model_validate(vc)
+
+    def test_raises_when_case_statuses_contains_only_string_ids(self):
+        """String-only case_statuses must not pass the Case invariant (LST-02-002)."""
+        vc = VulnerabilityCase()
+        vc.vulnerability_reports.append(_REPORT_ID)
+        vc.case_participants = _minimal_case_participants()
+        vc.case_statuses = ["urn:uuid:status-string-id"]
+        with pytest.raises(
+            VultronValidationError, match="materialized CaseStatus"
+        ):
+            Case.model_validate(vc)
+
+    def test_model_validate_promotes_vulnerability_case(self):
+        """model_validate promotes a qualifying VulnerabilityCase (LST-05-001)."""
+        vc = _minimal_case()
+        c = Case.model_validate(vc)
+        assert isinstance(c, Case)
+
+    def test_pre_embargo_case_is_valid_case(self):
+        """A Case without an active embargo is still a valid Case."""
+        vc = _minimal_case()
+        assert vc.active_embargo is None
+        c = Case.model_validate(vc)
+        assert c.active_embargo is None
+
+
+# ---------------------------------------------------------------------------
+# EmbargoedCase
+# ---------------------------------------------------------------------------
+
+
+class TestEmbargoedCase:
+    """Tests for EmbargoedCase staged type (LST-02-001, LST-02-003)."""
+
+    def test_is_subclass_of_case(self):
+        assert issubclass(EmbargoedCase, Case)
+
+    def test_is_subclass_of_vulnerability_case(self):
+        assert issubclass(EmbargoedCase, VulnerabilityCase)
+
+    def test_type_literal_unchanged(self):
+        """EmbargoedCase shares type_='VulnerabilityCase' (LST-05-003)."""
+        ec = EmbargoedCase.model_validate(_embargoed_case_data())
+        assert ec.type_ == "VulnerabilityCase"
+
+    def test_not_registered_separately_in_core_vocabulary(self):
+        assert "EmbargoedCase" not in CORE_VOCABULARY
+
+    def test_valid_with_active_embargo_and_active_em_state(self):
+        ec = EmbargoedCase.model_validate(_embargoed_case_data())
+        assert ec.active_embargo == _EMBARGO_ID
+        assert ec.current_status.em_state == EM.ACTIVE
+
+    def test_valid_with_revise_em_state(self):
+        vc = _embargoed_case_data()
+        vc.case_statuses = [
+            CaseStatus(
+                context=vc.id_,
+                attributed_to=_ACTOR,
+                em_state=EM.REVISE,
+            )
+        ]
+        ec = EmbargoedCase.model_validate(vc)
+        assert ec.current_status.em_state == EM.REVISE
+
+    def test_raises_when_active_embargo_is_none(self):
+        vc = _minimal_case()
+        assert vc.active_embargo is None
+        with pytest.raises(VultronValidationError, match="active_embargo"):
+            EmbargoedCase.model_validate(vc)
+
+    def test_raises_when_em_state_is_no_embargo(self):
+        vc = _embargoed_case_data()
+        vc.case_statuses = [
+            CaseStatus(
+                context=vc.id_,
+                attributed_to=_ACTOR,
+                em_state=EM.NO_EMBARGO,
+            )
+        ]
+        with pytest.raises(VultronValidationError, match="em_state"):
+            EmbargoedCase.model_validate(vc)
+
+    def test_raises_when_em_state_is_proposed(self):
+        vc = _embargoed_case_data()
+        vc.case_statuses = [
+            CaseStatus(
+                context=vc.id_,
+                attributed_to=_ACTOR,
+                em_state=EM.PROPOSED,
+            )
+        ]
+        with pytest.raises(VultronValidationError, match="em_state"):
+            EmbargoedCase.model_validate(vc)
+
+    def test_raises_when_em_state_is_exited(self):
+        vc = _embargoed_case_data()
+        vc.case_statuses = [
+            CaseStatus(
+                context=vc.id_,
+                attributed_to=_ACTOR,
+                em_state=EM.EXITED,
+            )
+        ]
+        with pytest.raises(VultronValidationError, match="em_state"):
+            EmbargoedCase.model_validate(vc)
+
+    def test_inherits_case_invariants(self):
+        """EmbargoedCase is a Case: it also enforces Case invariants."""
+        vc = VulnerabilityCase(attributed_to=_ACTOR)
+        vc.active_embargo = _EMBARGO_ID
+        # No reports: should fail the Case check first
+        with pytest.raises(VultronValidationError):
+            EmbargoedCase.model_validate(vc)
+
+    def test_model_validate_promotes_qualified_vulnerability_case(self):
+        """model_validate promotes a qualifying VulnerabilityCase (LST-05-001)."""
+        vc = _embargoed_case_data()
+        ec = EmbargoedCase.model_validate(vc)
+        assert isinstance(ec, EmbargoedCase)
+
+    def test_pre_embargo_case_fails_embargoed_validate(self):
+        """A pre-embargo Case fails EmbargoedCase.model_validate (LST-05-003)."""
+        vc = _minimal_case()
+        with pytest.raises(VultronValidationError):
+            EmbargoedCase.model_validate(vc)
+
+
+# ---------------------------------------------------------------------------
+# DataLayer round-trip (AC-4, LST-05-003)
+# ---------------------------------------------------------------------------
+
+
+class TestDataLayerRoundTrip:
+    """Persisted staged objects rehydrate to base type and re-validate."""
+
+    def test_embargoed_case_round_trips_via_model_dump(self):
+        """Dump EmbargoedCase → reload as VulnerabilityCase → re-validate (LST-05-003)."""
+        ec = EmbargoedCase.model_validate(_embargoed_case_data())
+        dumped = ec.model_dump(by_alias=True)
+
+        # Rehydration always yields the base type
+        vc = VulnerabilityCase.model_validate(dumped)
+        assert isinstance(vc, VulnerabilityCase)
+        assert vc.type_ == "VulnerabilityCase"
+        assert vc.active_embargo == _EMBARGO_ID
+
+        # Re-narrowing succeeds
+        ec2 = EmbargoedCase.model_validate(vc)
+        assert isinstance(ec2, EmbargoedCase)
+
+    def test_case_round_trips_via_model_dump(self):
+        """Dump Case → reload as VulnerabilityCase → re-validate (LST-05-003)."""
+        c = Case.model_validate(_minimal_case())
+        dumped = c.model_dump(by_alias=True)
+
+        vc = VulnerabilityCase.model_validate(dumped)
+        assert isinstance(vc, VulnerabilityCase)
+
+        c2 = Case.model_validate(vc)
+        assert isinstance(c2, Case)
+
+    def test_pre_embargo_case_fails_embargoed_revalidation(self):
+        """A persisted pre-embargo Case fails EmbargoedCase re-validation (AC-4)."""
+        c = Case.model_validate(_minimal_case())
+        dumped = c.model_dump(by_alias=True)
+        vc = VulnerabilityCase.model_validate(dumped)
+        with pytest.raises(VultronValidationError):
+            EmbargoedCase.model_validate(vc)
+
+
+# ---------------------------------------------------------------------------
+# Spec compliance: no RM staged type (AC-5, LST-02-004)
+# ---------------------------------------------------------------------------
+
+
+class TestNoRMStagedTypes:
+    """Per-participant RM state MUST NOT be a VulnerabilityCase staged type (AC-5)."""
+
+    def test_no_valid_case_type_exists(self):
+        """There must be no 'ValidCase' or 'TriagedCase' in staged_case module."""
+        import vultron.core.models.staged_case as mod
+
+        for name in dir(mod):
+            assert "Valid" not in name or name in (
+                "VultronValidationError",
+            ), f"Found unexpected RM-typed class {name!r} in staged_case module"
+            assert (
+                "Triage" not in name
+            ), f"Found unexpected RM-typed class {name!r} in staged_case module"
+
+    def test_staged_case_exports(self):
+        from vultron.core.models.staged_case import __all__
+
+        assert set(__all__) == {"IncomingReport", "Case", "EmbargoedCase"}

--- a/vultron/core/behaviors/sync/nodes/chain.py
+++ b/vultron/core/behaviors/sync/nodes/chain.py
@@ -39,15 +39,10 @@ _CANONICAL_PAYLOAD_SIGNATURES: tuple[tuple[str, str], ...] = (
     ("Create", "VulnerabilityCase"),
     ("Offer", "VulnerabilityReport"),
     ("Offer", "VulnerabilityCase"),
-    # Accept(Offer(VulnerabilityReport)) — validate_report (RV message).
-    # The payload object is the Offer wrapping the VulnerabilityReport.
-    ("Accept", "Offer"),
-    # TentativeReject(Offer(VulnerabilityReport)) — invalidate_report (RI).
-    ("TentativeReject", "Offer"),
-    # Reject(Offer(VulnerabilityReport)) — close_report (RC).
-    ("Reject", "Offer"),
-    # Read(Offer(VulnerabilityReport)) — ack_report (RK message, ADR-0021).
-    ("Read", "Offer"),
+    ("Accept", "Offer"),  # validate_report (RV) — object_ is the Offer
+    ("TentativeReject", "Offer"),  # invalidate_report (RI)
+    ("Reject", "Offer"),  # close_report (RC)
+    ("Read", "Offer"),  # ack_report (RK, ADR-0021)
     ("Add", "Note"),
     ("Add", "ParticipantStatus"),
     ("Add", "EmbargoEvent"),
@@ -137,16 +132,27 @@ def _snapshot_type(snapshot: dict[str, Any]) -> str | None:
     )
 
 
+_ACTOR_TYPES: frozenset[str] = frozenset(
+    {"Actor", "Application", "Group", "Organization", "Person", "Service"}
+)
+
+
 def _snapshot_object_type(snapshot: dict[str, Any]) -> str | None:
-    snapshot_object = snapshot.get("object")
-    if not isinstance(snapshot_object, dict):
-        snapshot_object = snapshot.get("object_")
-    if not isinstance(snapshot_object, dict):
+    # Invite(Actor, target=Case): object_ is the actor; use target.type so the
+    # signature resolves to ('Invite','VulnerabilityCase') not ('Invite','Org').
+    obj = snapshot.get("object") or snapshot.get("object_")
+    if not isinstance(obj, dict):
         return None
-    object_type = snapshot_object.get("type") or snapshot_object.get("type_")
-    return (
-        object_type if isinstance(object_type, str) and object_type else None
-    )
+    object_type = obj.get("type") or obj.get("type_")
+    if not isinstance(object_type, str) or not object_type:
+        return None
+    if object_type in _ACTOR_TYPES:
+        target = snapshot.get("target")
+        if isinstance(target, dict):
+            target_type = target.get("type") or target.get("type_")
+            if isinstance(target_type, str) and target_type:
+                return target_type
+    return object_type
 
 
 def _bare_inline_object_path(

--- a/vultron/core/models/staged_case.py
+++ b/vultron/core/models/staged_case.py
@@ -133,8 +133,6 @@ class EmbargoedCase(Case):
     Spec: LST-02-001, LST-02-003.
     """
 
-    model_config = ConfigDict(from_attributes=True)
-
     @model_validator(mode="after")
     def _check_embargoed_invariants(self) -> "EmbargoedCase":
         if self.active_embargo is None:

--- a/vultron/core/models/staged_case.py
+++ b/vultron/core/models/staged_case.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Lifecycle-staged VulnerabilityCase domain types.
+
+Implements ADR-0033: field-set-anchored staged types for VulnerabilityCase.
+Each staged type adds ``model_validator`` logic that enforces its lifecycle
+invariants.  All three types share ``type_="VulnerabilityCase"`` (inherited from
+the base class and not redeclared here) so they:
+
+- Round-trip through the DataLayer as the base type (LST-05-003).
+- Do **not** register separately in ``CORE_VOCABULARY`` — only the base class
+  is registered (per the ``__init_subclass__`` guard in
+  :class:`~vultron.core.models.base.CoreObject`).
+
+The canonical usage pattern is read-boundary promotion (ADR-0032, LST-05-001):
+
+.. code-block:: python
+
+    vc = dl.read(case_id)                           # returns VulnerabilityCase
+    embargoed = EmbargoedCase.model_validate(vc)    # raises if no active embargo
+
+Spec: ``specs/lifecycle-staged-types.yaml`` LST-02, LST-05.
+ADR: ``docs/adr/0033-lifecycle-staged-case-types.md``.
+Notes: ``notes/lifecycle-staged-types.md``.
+"""
+
+from __future__ import annotations
+
+from pydantic import ConfigDict, model_validator
+
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.case_status import CaseStatus
+from vultron.core.states.em import EM
+from vultron.errors import VultronValidationError
+
+
+class IncomingReport(VulnerabilityCase):
+    """Pre-case stage: report data present, no case participants assigned yet.
+
+    Guarantees:
+
+    - At least one entry in ``vulnerability_reports``.
+    - ``case_participants`` is empty (no case bootstrap has run).
+
+    Shared ``type_="VulnerabilityCase"`` (inherited, not redeclared) ensures
+    DataLayer round-trip compatibility.
+
+    Spec: LST-02-001.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    @model_validator(mode="after")
+    def _check_incoming_report_invariants(self) -> "IncomingReport":
+        if not self.vulnerability_reports:
+            raise VultronValidationError(
+                "IncomingReport requires at least one vulnerability report "
+                "(LST-02-001)."
+            )
+        if self.case_participants:
+            raise VultronValidationError(
+                "IncomingReport must not have case participants — "
+                "no case assignment yet (LST-02-001)."
+            )
+        return self
+
+
+class Case(VulnerabilityCase):
+    """Bootstrapped case stage: case exists with participants and status history.
+
+    Guarantees:
+
+    - At least one entry in ``vulnerability_reports``.
+    - At least two ``case_participants`` (reporter and receiver).
+    - ``case_statuses`` is non-empty (seeded at bootstrap).
+
+    Shared ``type_="VulnerabilityCase"`` (inherited, not redeclared) ensures
+    DataLayer round-trip compatibility.
+
+    Spec: LST-02-001, LST-02-002.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    @model_validator(mode="after")
+    def _check_case_invariants(self) -> "Case":
+        if not self.vulnerability_reports:
+            raise VultronValidationError(
+                "Case requires at least one vulnerability report (LST-02-002)."
+            )
+        n = len(self.case_participants)
+        if n < 2:
+            raise VultronValidationError(
+                f"Case requires reporter and receiver participants "
+                f"(≥2 parties); found {n} (LST-02-002)."
+            )
+        if not any(isinstance(s, CaseStatus) for s in self.case_statuses):
+            raise VultronValidationError(
+                "Case requires at least one materialized CaseStatus entry "
+                "(LST-02-002)."
+            )
+        return self
+
+
+class EmbargoedCase(Case):
+    """Active-embargo stage: Case with a non-None active embargo.
+
+    Guarantees all :class:`Case` invariants plus:
+
+    - ``active_embargo`` is non-None.
+    - The most recent :class:`~vultron.core.models.case_status.CaseStatus`
+      has ``em_state ∈ {ACTIVE, REVISE}``.
+
+    The EM machine never returns to ``NONE``/``PROPOSED`` once ``ACTIVE``,
+    so this milestone is monotonic (LST-02-003).
+
+    Shared ``type_="VulnerabilityCase"`` (inherited, not redeclared) ensures
+    DataLayer round-trip compatibility.
+
+    Spec: LST-02-001, LST-02-003.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    @model_validator(mode="after")
+    def _check_embargoed_invariants(self) -> "EmbargoedCase":
+        if self.active_embargo is None:
+            raise VultronValidationError(
+                "EmbargoedCase requires active_embargo to be non-None "
+                "(LST-02-003)."
+            )
+        try:
+            em_state = self.current_status.em_state
+        except ValueError as exc:
+            raise VultronValidationError(
+                "EmbargoedCase requires at least one materialized CaseStatus; "
+                "found none (LST-02-003)."
+            ) from exc
+        if em_state not in (EM.ACTIVE, EM.REVISE):
+            raise VultronValidationError(
+                f"EmbargoedCase requires em_state ∈ {{ACTIVE, REVISE}}, "
+                f"got {em_state!r} (LST-02-003)."
+            )
+        return self
+
+
+__all__ = ["Case", "EmbargoedCase", "IncomingReport"]


### PR DESCRIPTION
- Closes #1452

## Summary

Implements ADR-0033 lifecycle-staged domain types for `VulnerabilityCase` as three Pydantic subclasses — `IncomingReport`, `Case`, `EmbargoedCase` — each enforcing its field-set invariants via `@model_validator(mode="after")`. All three share `type_="VulnerabilityCase"` (inherited, not redeclared) so DataLayer round-trip is preserved without a separate discriminator.

## Changes

- `vultron/core/models/staged_case.py` (new): `IncomingReport`, `Case`, `EmbargoedCase` with `ConfigDict(from_attributes=True)` for `model_validate`-at-edge promotion (LST-05-001); none register in `CORE_VOCABULARY` (LST-05-003).
- `test/core/models/test_staged_case.py` (new): 38 tests covering AC-1–AC-6, LST-02-001–LST-05-003, including DataLayer round-trip tests and a regression test for string-only `case_statuses`.

## Verification

- 4816 unit tests pass (1 new vs. pre-PR baseline)
- Black, flake8, mypy, pyright all clean
- Code review found and fixed 2 CONFIRMED correctness bugs before this PR opened:
  - `Case._check_case_invariants` (line 110): truthy `case_statuses` check replaced with `any(isinstance(s, CaseStatus) for s in ...)` — a string-only list was truthy but breaks `current_status`; regression test added
  - `EmbargoedCase._check_embargoed_invariants` (line 147): `except ValueError` re-raise message split to accurately diagnose "no materialized CaseStatus" vs. "wrong em_state"