### PR TITLE
refactor: clear ARCH-14-001 KNOWN_VIOLATIONS — apply as_ prefix to 16 wire vocab objects

### DIFF
--- a/test/adapters/driven/datalayer_sqlite/test_find_protocol_pair.py
+++ b/test/adapters/driven/datalayer_sqlite/test_find_protocol_pair.py
@@ -28,7 +28,9 @@ from vultron.core.models.protocol_pair import (
     OFFER_CASE_PARTICIPANT_REPLY_TYPES,
     ProtocolPair,
 )
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 # ---------------------------------------------------------------------------
 # Shared constants
@@ -88,7 +90,7 @@ def reset_counter():
 @pytest.fixture
 def dl():
     layer = SqliteDataLayer("sqlite:///:memory:")
-    case = VulnerabilityCase(id_=CASE_ID, name="CLP11Test")
+    case = as_VulnerabilityCase(id_=CASE_ID, name="CLP11Test")
     layer.create(case)
     return layer
 

--- a/test/adapters/driven/test_db_record.py
+++ b/test/adapters/driven/test_db_record.py
@@ -189,10 +189,10 @@ def test_dehydrate_data_dehydrates_all_object_ref_fields():
 def test_object_to_record_stores_nested_object_as_id_reference():
     """An activity with a nested object stores only the nested object's ID."""
     from vultron.wire.as2.vocab.objects.vulnerability_report import (
-        VulnerabilityReport,
+        as_VulnerabilityReport,
     )
 
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         name="Test CVE",
         content="Details of the vulnerability",
         attributed_to="https://example.org/finder",
@@ -214,10 +214,10 @@ def test_object_to_record_stores_nested_object_as_id_reference():
 def test_object_to_record_nested_report_not_duplicated_in_offer_data():
     """The stored offer data must not contain a full copy of the nested report."""
     from vultron.wire.as2.vocab.objects.vulnerability_report import (
-        VulnerabilityReport,
+        as_VulnerabilityReport,
     )
 
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         name="Another CVE",
         content="More vulnerability details",
         attributed_to="https://example.org/finder",

--- a/test/adapters/driven/test_sqlite_coercion.py
+++ b/test/adapters/driven/test_sqlite_coercion.py
@@ -43,12 +43,14 @@ class TestRehydrateFields:
     """_rehydrate_fields expands dehydrated string IDs back to typed objects."""
 
     def test_offer_object_field_expanded_to_vulnerability_report(self, dl):
-        """_RmSubmitReportActivity.object_ is a VulnerabilityReport after read."""
+        """_RmSubmitReportActivity.object_ is a as_VulnerabilityReport after read."""
         from vultron.wire.as2.vocab.objects.vulnerability_report import (
-            VulnerabilityReport,
+            as_VulnerabilityReport,
         )
 
-        report = VulnerabilityReport(name="CVE-TEST-001", content="Test body")
+        report = as_VulnerabilityReport(
+            name="CVE-TEST-001", content="Test body"
+        )
         offer = rm_submit_report_activity(
             report,
             "https://alice.example.org",
@@ -60,16 +62,16 @@ class TestRehydrateFields:
         result = dl.read(offer.id_)
 
         assert isinstance(result, as_Offer)
-        assert isinstance(result.object_, VulnerabilityReport)  # type: ignore[union-attr]
+        assert isinstance(result.object_, as_VulnerabilityReport)  # type: ignore[union-attr]
         assert result.object_.name == "CVE-TEST-001"  # type: ignore[union-attr]
 
     def test_missing_nested_object_keeps_string(self, dl):
         """When a referenced object is not in the DB, the string ID is kept."""
         from vultron.wire.as2.vocab.objects.vulnerability_report import (
-            VulnerabilityReport,
+            as_VulnerabilityReport,
         )
 
-        report = VulnerabilityReport(name="CVE-MISSING", content="Body")
+        report = as_VulnerabilityReport(name="CVE-MISSING", content="Body")
         offer = rm_submit_report_activity(
             report,
             "https://alice.example.org",
@@ -96,10 +98,10 @@ class TestCoerceToSemanticClass:
     def test_rm_submit_report_round_trip_returns_specific_class(self, dl):
         """dl.read returns _RmSubmitReportActivity, not generic as_Offer."""
         from vultron.wire.as2.vocab.objects.vulnerability_report import (
-            VulnerabilityReport,
+            as_VulnerabilityReport,
         )
 
-        report = VulnerabilityReport(name="CVE-ROUND-TRIP", content="Body")
+        report = as_VulnerabilityReport(name="CVE-ROUND-TRIP", content="Body")
         offer = rm_submit_report_activity(
             report,
             "https://alice.example.org",
@@ -113,14 +115,16 @@ class TestCoerceToSemanticClass:
         assert type(result).__name__ == "_RmSubmitReportActivity"
 
     def test_em_propose_embargo_round_trip_returns_specific_class(self, dl):
-        """dl.read returns _EmProposeEmbargoActivity with EmbargoEvent object_."""
-        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+        """dl.read returns _EmProposeEmbargoActivity with as_EmbargoEvent object_."""
+        from vultron.wire.as2.vocab.objects.embargo_event import (
+            as_EmbargoEvent,
+        )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
-        case = VulnerabilityCase()
-        embargo = EmbargoEvent(context=case.id_)
+        case = as_VulnerabilityCase()
+        embargo = as_EmbargoEvent(context=case.id_)
         proposal = em_propose_embargo_activity(
             embargo,
             context=case.id_,
@@ -133,7 +137,7 @@ class TestCoerceToSemanticClass:
         result = dl.read(proposal.id_)
 
         assert type(result).__name__ == "_EmProposeEmbargoActivity"
-        assert isinstance(result.object_, EmbargoEvent)  # type: ignore[union-attr]
+        assert isinstance(result.object_, as_EmbargoEvent)  # type: ignore[union-attr]
 
     def test_accept_invite_round_trip_returns_specific_class_from_generic_parse(
         self, dl
@@ -190,7 +194,7 @@ class TestCoerceToSemanticClass:
         assert result.in_reply_to == "urn:uuid:invite-roundtrip-1"
 
     def test_announce_log_entry_round_trip_returns_specific_class(self, dl):
-        """dl.read returns AnnounceLogEntryActivity with CaseLedgerEntry object_."""
+        """dl.read returns AnnounceLogEntryActivity with as_CaseLedgerEntry object_."""
         from vultron.core.behaviors.sync.nodes.chain import (
             _to_persistable_entry,
         )
@@ -198,7 +202,7 @@ class TestCoerceToSemanticClass:
             HashChainLedgerRecord,
         )
         from vultron.wire.as2.vocab.objects.case_ledger_entry import (
-            CaseLedgerEntry as WireCaseLedgerEntry,
+            as_CaseLedgerEntry as WireCaseLedgerEntry,
         )
 
         chain_entry = HashChainLedgerRecord(
@@ -225,14 +229,14 @@ class TestCoerceToSemanticClass:
         assert result.object_.log_object_id == entry.log_object_id  # type: ignore[union-attr]
 
     def test_non_activity_object_not_coerced(self, dl):
-        """Non-activity objects (e.g. VulnerabilityReport) are returned as-is."""
+        """Non-activity objects (e.g. as_VulnerabilityReport) are returned as-is."""
         from vultron.wire.as2.vocab.objects.vulnerability_report import (
-            VulnerabilityReport,
+            as_VulnerabilityReport,
         )
 
-        report = VulnerabilityReport(name="CVE-PLAIN", content="Body")
+        report = as_VulnerabilityReport(name="CVE-PLAIN", content="Body")
         dl.save(report)
 
         result = dl.read(report.id_)
 
-        assert isinstance(result, VulnerabilityReport)
+        assert isinstance(result, as_VulnerabilityReport)

--- a/test/adapters/driven/test_sqlite_find_case.py
+++ b/test/adapters/driven/test_sqlite_find_case.py
@@ -25,41 +25,47 @@ Fixtures (dl) come from conftest.
 
 def test_find_case_by_short_id_with_http_url_case_id(dl):
     from vultron.wire.as2.vocab.objects.vulnerability_case import (
-        VulnerabilityCase,
+        as_VulnerabilityCase,
     )
 
-    case = VulnerabilityCase(id_="https://example.org/api/v2/cases/demo-123")
+    case = as_VulnerabilityCase(
+        id_="https://example.org/api/v2/cases/demo-123"
+    )
     dl.save(case)
 
     result = dl.find_case_by_short_id("demo-123")
     assert result is not None
-    assert isinstance(result, VulnerabilityCase)
+    assert isinstance(result, as_VulnerabilityCase)
     assert result.id_ == case.id_
 
 
 def test_find_case_by_short_id_with_urn_case_id(dl):
     from vultron.wire.as2.vocab.objects.vulnerability_case import (
-        VulnerabilityCase,
+        as_VulnerabilityCase,
     )
 
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         id_="urn:uuid:11111111-2222-3333-4444-555555555555"
     )
     dl.save(case)
 
     result = dl.find_case_by_short_id("11111111-2222-3333-4444-555555555555")
     assert result is not None
-    assert isinstance(result, VulnerabilityCase)
+    assert isinstance(result, as_VulnerabilityCase)
     assert result.id_ == case.id_
 
 
 def test_find_case_by_short_id_returns_none_when_ambiguous(dl):
     from vultron.wire.as2.vocab.objects.vulnerability_case import (
-        VulnerabilityCase,
+        as_VulnerabilityCase,
     )
 
-    case1 = VulnerabilityCase(id_="https://org1.example/api/v2/cases/shared")
-    case2 = VulnerabilityCase(id_="https://org2.example/api/v2/cases/shared")
+    case1 = as_VulnerabilityCase(
+        id_="https://org1.example/api/v2/cases/shared"
+    )
+    case2 = as_VulnerabilityCase(
+        id_="https://org2.example/api/v2/cases/shared"
+    )
     dl.save(case1)
     dl.save(case2)
 
@@ -73,18 +79,18 @@ def test_find_case_by_short_id_returns_none_when_ambiguous(dl):
 
 def test_find_case_by_report_id_returns_case_when_report_stored_as_string(dl):
     from vultron.wire.as2.vocab.objects.vulnerability_case import (
-        VulnerabilityCase,
+        as_VulnerabilityCase,
     )
     from vultron.wire.as2.vocab.objects.vulnerability_report import (
-        VulnerabilityReport,
+        as_VulnerabilityReport,
     )
 
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         name="CVE-2025-001",
         content="Test vulnerability",
         attributed_to="https://example.org/finder",
     )
-    case = VulnerabilityCase()
+    case = as_VulnerabilityCase()
     case.vulnerability_reports.append(report.id_)
 
     dl.create(report)
@@ -92,24 +98,24 @@ def test_find_case_by_report_id_returns_case_when_report_stored_as_string(dl):
 
     result = dl.find_case_by_report_id(report.id_)
     assert result is not None
-    assert isinstance(result, VulnerabilityCase)
+    assert isinstance(result, as_VulnerabilityCase)
     assert result.id_ == case.id_
 
 
 def test_find_case_by_report_id_returns_case_when_report_stored_as_object(dl):
     from vultron.wire.as2.vocab.objects.vulnerability_case import (
-        VulnerabilityCase,
+        as_VulnerabilityCase,
     )
     from vultron.wire.as2.vocab.objects.vulnerability_report import (
-        VulnerabilityReport,
+        as_VulnerabilityReport,
     )
 
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         name="CVE-2025-002",
         content="Another vulnerability",
         attributed_to="https://example.org/finder",
     )
-    case = VulnerabilityCase()
+    case = as_VulnerabilityCase()
     case.vulnerability_reports.append(report)
 
     dl.create(report)
@@ -117,24 +123,24 @@ def test_find_case_by_report_id_returns_case_when_report_stored_as_object(dl):
 
     result = dl.find_case_by_report_id(report.id_)
     assert result is not None
-    assert isinstance(result, VulnerabilityCase)
+    assert isinstance(result, as_VulnerabilityCase)
     assert result.id_ == case.id_
 
 
 def test_find_case_by_report_id_returns_none_when_not_found(dl):
     from vultron.wire.as2.vocab.objects.vulnerability_case import (
-        VulnerabilityCase,
+        as_VulnerabilityCase,
     )
     from vultron.wire.as2.vocab.objects.vulnerability_report import (
-        VulnerabilityReport,
+        as_VulnerabilityReport,
     )
 
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         name="CVE-2025-003",
         content="Unlinked vulnerability",
         attributed_to="https://example.org/finder",
     )
-    case = VulnerabilityCase()
+    case = as_VulnerabilityCase()
 
     dl.create(report)
     dl.save(case)
@@ -150,23 +156,23 @@ def test_find_case_by_report_id_returns_none_when_no_cases(dl):
 
 def test_find_case_by_report_id_returns_none_for_unknown_id(dl):
     from vultron.wire.as2.vocab.objects.vulnerability_case import (
-        VulnerabilityCase,
+        as_VulnerabilityCase,
     )
     from vultron.wire.as2.vocab.objects.vulnerability_report import (
-        VulnerabilityReport,
+        as_VulnerabilityReport,
     )
 
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         name="CVE-2025-004",
         content="Linked vulnerability",
         attributed_to="https://example.org/finder",
     )
-    other_report = VulnerabilityReport(
+    other_report = as_VulnerabilityReport(
         name="CVE-2025-005",
         content="Unlinked vulnerability",
         attributed_to="https://example.org/finder",
     )
-    case = VulnerabilityCase()
+    case = as_VulnerabilityCase()
     case.vulnerability_reports.append(report.id_)
 
     dl.create(report)
@@ -180,18 +186,18 @@ def test_find_case_by_report_id_returns_none_for_unknown_id(dl):
 def test_find_case_by_report_id_returns_case_via_report_case_link(dl):
     from vultron.core.models.report_case_link import VultronReportCaseLink
     from vultron.wire.as2.vocab.objects.vulnerability_case import (
-        VulnerabilityCase,
+        as_VulnerabilityCase,
     )
     from vultron.wire.as2.vocab.objects.vulnerability_report import (
-        VulnerabilityReport,
+        as_VulnerabilityReport,
     )
 
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         name="CVE-2025-006",
         content="Linked through ReportCaseLink",
         attributed_to="https://example.org/finder",
     )
-    case = VulnerabilityCase()
+    case = as_VulnerabilityCase()
 
     dl.create(report)
     dl.save(case)
@@ -200,5 +206,5 @@ def test_find_case_by_report_id_returns_case_via_report_case_link(dl):
     result = dl.find_case_by_report_id(report.id_)
 
     assert result is not None
-    assert isinstance(result, VulnerabilityCase)
+    assert isinstance(result, as_VulnerabilityCase)
     assert result.id_ == case.id_

--- a/test/adapters/driven/test_sqlite_list.py
+++ b/test/adapters/driven/test_sqlite_list.py
@@ -37,11 +37,11 @@ class TestListMethod:
     def test_list_returns_saved_objects(self, dl):
         """list() returns all objects of the requested type."""
         from vultron.wire.as2.vocab.objects.vulnerability_report import (
-            VulnerabilityReport,
+            as_VulnerabilityReport,
         )
 
-        r1 = VulnerabilityReport(name="CVE-1", content="Body 1")
-        r2 = VulnerabilityReport(name="CVE-2", content="Body 2")
+        r1 = as_VulnerabilityReport(name="CVE-1", content="Body 1")
+        r2 = as_VulnerabilityReport(name="CVE-2", content="Body 2")
         dl.save(r1)
         dl.save(r2)
 
@@ -56,10 +56,10 @@ class TestListMethod:
         """list() only returns objects of the requested type, not others."""
         from vultron.wire.as2.vocab.base.objects.object_types import as_Note
         from vultron.wire.as2.vocab.objects.vulnerability_report import (
-            VulnerabilityReport,
+            as_VulnerabilityReport,
         )
 
-        report = VulnerabilityReport(name="CVE-FILTER", content="Body")
+        report = as_VulnerabilityReport(name="CVE-FILTER", content="Body")
         note = as_Note(content="Unrelated note")
         dl.save(report)
         dl.save(note)
@@ -75,16 +75,16 @@ class TestListMethod:
     def test_list_returns_typed_objects_not_dicts(self, dl):
         """list() returns domain model instances, not raw dict records."""
         from vultron.wire.as2.vocab.objects.vulnerability_report import (
-            VulnerabilityReport,
+            as_VulnerabilityReport,
         )
 
-        report = VulnerabilityReport(name="CVE-TYPED", content="Body")
+        report = as_VulnerabilityReport(name="CVE-TYPED", content="Body")
         dl.save(report)
 
         results = dl.list_objects("VulnerabilityReport")
 
         assert len(results) == 1
-        assert isinstance(results[0], VulnerabilityReport)
+        assert isinstance(results[0], as_VulnerabilityReport)
 
     def test_list_returns_semantic_class_for_activities(self, dl):
         """list() applies semantic coercion so activities get their subtype."""

--- a/test/adapters/driven/test_sqlite_rehydration.py
+++ b/test/adapters/driven/test_sqlite_rehydration.py
@@ -28,10 +28,10 @@ from vultron.wire.as2.factories import rm_submit_report_activity
 def test_activity_with_nested_object_stores_id_reference_not_inline_copy(dl):
     """Storing an activity with a nested object writes only the nested ID."""
     from vultron.wire.as2.vocab.objects.vulnerability_report import (
-        VulnerabilityReport,
+        as_VulnerabilityReport,
     )
 
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         name="Test CVE",
         content="A critical vulnerability",
         attributed_to="https://example.org/finder",
@@ -56,10 +56,10 @@ def test_activity_with_nested_object_stores_id_reference_not_inline_copy(dl):
 
 def test_activity_nested_object_retrievable_separately_after_dehydration(dl):
     from vultron.wire.as2.vocab.objects.vulnerability_report import (
-        VulnerabilityReport,
+        as_VulnerabilityReport,
     )
 
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         name="Test CVE 2",
         content="Another vulnerability",
         attributed_to="https://example.org/finder",
@@ -85,10 +85,10 @@ def test_reading_activity_back_yields_expanded_nested_object(dl):
     field; after the rehydration pipeline the full typed object is returned.
     """
     from vultron.wire.as2.vocab.objects.vulnerability_report import (
-        VulnerabilityReport,
+        as_VulnerabilityReport,
     )
 
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         name="Test CVE 3",
         content="Yet another vulnerability",
         attributed_to="https://example.org/finder",
@@ -104,17 +104,17 @@ def test_reading_activity_back_yields_expanded_nested_object(dl):
 
     retrieved_offer = dl.read(offer.id_)
     assert retrieved_offer is not None
-    assert isinstance(retrieved_offer.object_, VulnerabilityReport)  # type: ignore[union-attr]
+    assert isinstance(retrieved_offer.object_, as_VulnerabilityReport)  # type: ignore[union-attr]
     assert retrieved_offer.object_.id_ == report.id_  # type: ignore[union-attr]
 
 
 def test_rehydration_restores_nested_object_from_datalayer(dl):
     from vultron.wire.as2.rehydration import rehydrate
     from vultron.wire.as2.vocab.objects.vulnerability_report import (
-        VulnerabilityReport,
+        as_VulnerabilityReport,
     )
 
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         name="Test CVE 4",
         content="One more vulnerability",
         attributed_to="https://example.org/finder",
@@ -139,10 +139,10 @@ def test_rehydration_restores_nested_object_from_datalayer(dl):
 def test_rehydration_does_not_mutate_stored_record(dl):
     from vultron.wire.as2.rehydration import rehydrate
     from vultron.wire.as2.vocab.objects.vulnerability_report import (
-        VulnerabilityReport,
+        as_VulnerabilityReport,
     )
 
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         name="Test CVE 5",
         content="Final vulnerability",
         attributed_to="https://example.org/finder",
@@ -175,15 +175,17 @@ def test_rehydration_does_not_mutate_stored_record(dl):
 def test_hydrate_expands_list_ref_field(dl):
     """hydrate() resolves case_participants string IDs to stored objects."""
     from vultron.enums.roles import CVDRole
-    from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+    from vultron.wire.as2.vocab.objects.case_participant import (
+        as_CaseParticipant,
+    )
     from vultron.wire.as2.vocab.objects.vulnerability_case import (
-        VulnerabilityCase,
+        as_VulnerabilityCase,
     )
 
     case_actor_id = "https://example.org/actors/case-actor-hydrate"
-    case = VulnerabilityCase()
+    case = as_VulnerabilityCase()
 
-    participant = CaseParticipant(
+    participant = as_CaseParticipant(
         case_roles=[CVDRole.CASE_MANAGER],
         attributed_to=case_actor_id,
         context=case.id_,
@@ -201,21 +203,23 @@ def test_hydrate_expands_list_ref_field(dl):
     hydrated = dl.hydrate(stored_case)
     assert hydrated is not stored_case
     assert len(hydrated.case_participants) == 1
-    assert isinstance(hydrated.case_participants[0], CaseParticipant)
+    assert isinstance(hydrated.case_participants[0], as_CaseParticipant)
     assert hydrated.case_participants[0].id_ == participant.id_
 
 
 def test_hydrate_leaves_already_expanded_participants_unchanged(dl):
     """hydrate() leaves non-string participants unchanged."""
     from vultron.enums.roles import CVDRole
-    from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+    from vultron.wire.as2.vocab.objects.case_participant import (
+        as_CaseParticipant,
+    )
     from vultron.wire.as2.vocab.objects.vulnerability_case import (
-        VulnerabilityCase,
+        as_VulnerabilityCase,
     )
 
     case_actor_id = "https://example.org/actors/case-actor-noop"
-    case = VulnerabilityCase()
-    participant = CaseParticipant(
+    case = as_VulnerabilityCase()
+    participant = as_CaseParticipant(
         case_roles=[CVDRole.CASE_MANAGER],
         attributed_to=case_actor_id,
         context=case.id_,
@@ -233,11 +237,11 @@ def test_hydrate_leaves_already_expanded_participants_unchanged(dl):
 def test_hydrate_keeps_unresolvable_string_ids(dl):
     """hydrate() keeps participant IDs that don't exist in the DataLayer."""
     from vultron.wire.as2.vocab.objects.vulnerability_case import (
-        VulnerabilityCase,
+        as_VulnerabilityCase,
     )
 
     missing_id = "urn:uuid:00000000-0000-0000-0000-000000000000"
-    case = VulnerabilityCase()
+    case = as_VulnerabilityCase()
     case.case_participants = [missing_id]
     dl.save(case)
 
@@ -251,11 +255,11 @@ def test_hydrate_warns_for_unresolvable_string_ids(dl, caplog):
     import logging
 
     from vultron.wire.as2.vocab.objects.vulnerability_case import (
-        VulnerabilityCase,
+        as_VulnerabilityCase,
     )
 
     missing_id = "urn:uuid:00000000-0000-0000-0000-000000000001"
-    case = VulnerabilityCase()
+    case = as_VulnerabilityCase()
     case.case_participants = [missing_id]
     dl.save(case)
 

--- a/test/adapters/driven/trigger_activity_adapter/test_actors.py
+++ b/test/adapters/driven/trigger_activity_adapter/test_actors.py
@@ -22,9 +22,9 @@ import pytest
 from vultron.errors import VultronValidationError
 from vultron.wire.as2.factories import rm_invite_to_case_activity
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
-    VulnerabilityCase,
+    as_VulnerabilityCase,
     VulnerabilityCaseStub,
 )
 
@@ -33,14 +33,14 @@ _INVITEE = "https://example.org/actors/vendor"
 _CASE_ID = "https://example.org/cases/case-001"
 
 
-def _make_case(dl) -> VulnerabilityCase:
-    case = VulnerabilityCase(name="CVE-2025-001")
+def _make_case(dl) -> as_VulnerabilityCase:
+    case = as_VulnerabilityCase(name="CVE-2025-001")
     dl.create(case)
     return case
 
 
-def _make_participant(dl, case_id: str) -> CaseParticipant:
-    participant = CaseParticipant(
+def _make_participant(dl, case_id: str) -> as_CaseParticipant:
+    participant = as_CaseParticipant(
         context=case_id,
         attributed_to=_INVITEE,
     )

--- a/test/adapters/driven/trigger_activity_adapter/test_cases.py
+++ b/test/adapters/driven/trigger_activity_adapter/test_cases.py
@@ -14,15 +14,17 @@
 """Unit tests for TriggerActivityAdapter case-domain methods."""
 
 from vultron.wire.as2.vocab.base.objects.object_types import as_Note
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 _ACTOR = "https://example.org/actors/coordinator"
 _PEER = "https://example.org/actors/vendor"
 _CONTEXT_ID = "https://example.org/contexts/ctx-001"
 
 
-def _make_case(dl) -> VulnerabilityCase:
-    case = VulnerabilityCase(name="CVE-2025-001")
+def _make_case(dl) -> as_VulnerabilityCase:
+    case = as_VulnerabilityCase(name="CVE-2025-001")
     dl.create(case)
     return case
 

--- a/test/adapters/driven/trigger_activity_adapter/test_embargo.py
+++ b/test/adapters/driven/trigger_activity_adapter/test_embargo.py
@@ -13,15 +13,15 @@
 
 """Unit tests for TriggerActivityAdapter embargo-domain methods."""
 
-from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
 
 _ACTOR = "https://example.org/actors/coordinator"
 _PEER = "https://example.org/actors/vendor"
 _CASE_ID = "https://example.org/cases/case-001"
 
 
-def _make_embargo(dl) -> EmbargoEvent:
-    embargo = EmbargoEvent()
+def _make_embargo(dl) -> as_EmbargoEvent:
+    embargo = as_EmbargoEvent()
     dl.create(embargo)
     return embargo
 

--- a/test/adapters/driven/trigger_activity_adapter/test_reports.py
+++ b/test/adapters/driven/trigger_activity_adapter/test_reports.py
@@ -14,7 +14,7 @@
 """Unit tests for TriggerActivityAdapter report-domain methods."""
 
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 _ACTOR = "https://example.org/actors/reporter"
@@ -22,8 +22,8 @@ _COORDINATOR = "https://example.org/actors/coordinator"
 _CASE_ID = "https://example.org/cases/case-001"
 
 
-def _make_report(dl) -> VulnerabilityReport:
-    report = VulnerabilityReport(name="CVE-2025-001", content="PoC details")
+def _make_report(dl) -> as_VulnerabilityReport:
+    report = as_VulnerabilityReport(name="CVE-2025-001", content="PoC details")
     dl.create(report)
     return report
 

--- a/test/adapters/driving/fastapi/routers/actors/test_inbox.py
+++ b/test/adapters/driving/fastapi/routers/actors/test_inbox.py
@@ -39,7 +39,9 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Create,
 )
 from vultron.wire.as2.vocab.base.objects.object_types import as_Note
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 _ACTOR_URI = "https://example.org/actors/alice"
 _ACTIVITY_URI = "https://example.org/activities/create-001"
@@ -120,7 +122,7 @@ def test_activity_already_received_returns_false_when_inbox_is_none():
 def test_reparse_as_specific_type_returns_specific_class_for_known_type():
     from vultron.wire.as2.vocab.base.objects.base import as_Object
 
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         id_="urn:uuid:test-case-001",
         name="Test CVD Case",
     )
@@ -128,7 +130,7 @@ def test_reparse_as_specific_type_returns_specific_class_for_known_type():
     # Pass as base as_Object to simulate what the wire parser produces
     nested = as_Object.model_validate(raw_obj)
     result = _reparse_as_specific_type(nested, raw_obj)
-    assert isinstance(result, VulnerabilityCase)
+    assert isinstance(result, as_VulnerabilityCase)
 
 
 def test_reparse_as_specific_type_returns_base_when_type_is_none():
@@ -141,7 +143,7 @@ def test_reparse_as_specific_type_returns_base_when_type_is_none():
 
 def test_reparse_as_specific_type_returns_same_object_when_already_specific_class():
     """Guard branch: nested is already the specific class → return unchanged."""
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         id_="urn:uuid:test-case-already-specific",
         name="Already Specific",
     )
@@ -177,7 +179,7 @@ def test_store_inbox_activity_is_idempotent(datalayer):
 
 
 def test_store_nested_inbox_object_stores_inline_case(datalayer):
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         id_="urn:uuid:case-nest-001",
         name="Nested Case",
     )
@@ -207,7 +209,7 @@ def test_store_nested_inbox_object_skips_string_object(datalayer):
 
 
 def test_store_nested_inbox_object_skips_when_no_body(datalayer):
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         id_="urn:uuid:case-nobody-001",
         name="No Body Case",
     )

--- a/test/adapters/driving/fastapi/routers/conftest.py
+++ b/test/adapters/driving/fastapi/routers/conftest.py
@@ -49,11 +49,13 @@ from vultron.wire.as2.vocab.base.objects.actors import (
     as_Application,
     as_Group,
 )
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 
@@ -152,10 +154,10 @@ def created_actors(datalayer, actor_classes):
     return actors
 
 
-# Lightweight VulnerabilityReport fixture
+# Lightweight as_VulnerabilityReport fixture
 @pytest.fixture
 def report():
-    return VulnerabilityReport()
+    return as_VulnerabilityReport()
 
 
 # Lightweight Offer fixture tied to the report
@@ -170,11 +172,11 @@ def offer(report):
 # ---------------------------------------------------------------------------
 
 
-def _add_case_manager(case: VulnerabilityCase, dl) -> as_Service:
+def _add_case_manager(case: as_VulnerabilityCase, dl) -> as_Service:
     """Add a CASE_MANAGER participant to *case* and return the case actor."""
     case_actor = as_Service(name=f"Case Actor for {case.name}")
     dl.create(case_actor)
-    cm_participant = CaseParticipant(
+    cm_participant = as_CaseParticipant(
         attributed_to=case_actor.id_,
         context=case.id_,
         case_roles=[CVDRole.CASE_MANAGER],
@@ -202,8 +204,8 @@ def client_triggers(dl):
 
 @pytest.fixture
 def case_without_participant(dl):
-    """A VulnerabilityCase with a Case Manager but no participant for the actor."""
-    case_obj = VulnerabilityCase(name="TEST-CASE-NO-PARTICIPANT")
+    """A as_VulnerabilityCase with a Case Manager but no participant for the actor."""
+    case_obj = as_VulnerabilityCase(name="TEST-CASE-NO-PARTICIPANT")
     dl.create(case_obj)
     _add_case_manager(case_obj, dl)
     return case_obj
@@ -211,9 +213,9 @@ def case_without_participant(dl):
 
 @pytest.fixture
 def case_with_embargo(dl, actor):
-    """A VulnerabilityCase with an active EmbargoEvent."""
-    case_obj = VulnerabilityCase(name="EMBARGO-CASE-001")
-    embargo = EmbargoEvent(context=case_obj.id_)
+    """A as_VulnerabilityCase with an active as_EmbargoEvent."""
+    case_obj = as_VulnerabilityCase(name="EMBARGO-CASE-001")
+    embargo = as_EmbargoEvent(context=case_obj.id_)
     dl.create(embargo)
     case_obj.set_embargo(embargo.id_)
     case_obj.current_status.em_state = EM.ACTIVE
@@ -224,12 +226,12 @@ def case_with_embargo(dl, actor):
 
 @pytest.fixture
 def case_with_proposal(dl, actor):
-    """A VulnerabilityCase with a pending EmProposeEmbargoActivity in EM.PROPOSED state."""
-    case_obj = VulnerabilityCase(
+    """A as_VulnerabilityCase with a pending EmProposeEmbargoActivity in EM.PROPOSED state."""
+    case_obj = as_VulnerabilityCase(
         name="PROPOSAL-CASE-001",
         attributed_to=actor.id_,
     )
-    embargo = EmbargoEvent(context=case_obj.id_)
+    embargo = as_EmbargoEvent(context=case_obj.id_)
     dl.create(embargo)
     proposal = em_propose_embargo_activity(
         embargo, context=case_obj.id_, actor=actor.id_

--- a/test/adapters/driving/fastapi/routers/test_actors.py
+++ b/test/adapters/driving/fastapi/routers/test_actors.py
@@ -21,13 +21,15 @@ from vultron.core.states.em import EM
 from vultron.core.states.rm import RM
 from vultron.enums.roles import CVDRole
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Create
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
 from vultron.wire.as2.vocab.objects.case_status import (
-    CaseStatus,
-    ParticipantStatus,
+    as_CaseStatus,
+    as_ParticipantStatus,
 )
 from vultron.wire.as2.vocab.base.objects.object_types import as_Note
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 _ACTOR_ID = "https://example.org/actors/alice"
 
@@ -148,14 +150,14 @@ def test_get_actors_does_not_log_raw_records_at_info_level(
 
 
 def _seed_action_rules_data(dl):
-    """Insert a minimal valid VulnerabilityCase / CaseParticipant pair."""
-    participant = CaseParticipant(
+    """Insert a minimal valid as_VulnerabilityCase / as_CaseParticipant pair."""
+    participant = as_CaseParticipant(
         id_=_URN_PARTICIPANT_ID,
         attributed_to=_URN_ACTOR_ID,
         context=_URN_CASE_ID,
         case_roles=[CVDRole.VENDOR],
         participant_statuses=[
-            ParticipantStatus(
+            as_ParticipantStatus(
                 context=_URN_CASE_ID,
                 rm_state=RM.ACCEPTED,
                 vfd_state=CS_vfd.VFd,
@@ -164,10 +166,12 @@ def _seed_action_rules_data(dl):
     )
     dl.create(participant)
 
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         id_=_URN_CASE_ID,
         name="Test Case",
-        case_statuses=[CaseStatus(em_state=EM.ACTIVE, pxa_state=CS_pxa.Pxa)],
+        case_statuses=[
+            as_CaseStatus(em_state=EM.ACTIVE, pxa_state=CS_pxa.Pxa)
+        ],
     )
     case.add_participant(participant)
     dl.create(case)

--- a/test/adapters/driving/fastapi/routers/test_actors_serialization.py
+++ b/test/adapters/driving/fastapi/routers/test_actors_serialization.py
@@ -30,13 +30,13 @@ from vultron.adapters.driving.fastapi.routers import actors as actors_router
 from vultron.adapters.driving.fastapi.routers import (
     datalayer as datalayer_router,
 )
-from vultron.wire.as2.vocab.objects.embargo_policy import EmbargoPolicy
+from vultron.wire.as2.vocab.objects.embargo_policy import as_EmbargoPolicy
 from vultron.wire.as2.vocab.objects.vultron_actor import (
-    VultronApplication,
-    VultronGroup,
-    VultronOrganization,
-    VultronPerson,
-    VultronService,
+    as_VultronApplication,
+    as_VultronGroup,
+    as_VultronOrganization,
+    as_VultronPerson,
+    as_VultronService,
 )
 
 
@@ -72,7 +72,7 @@ def client_datalayer(datalayer):
 def embargo_policy():
     from datetime import timedelta
 
-    return EmbargoPolicy(
+    return as_EmbargoPolicy(
         actor_id="https://example.org/actors/alice",
         inbox="https://example.org/actors/alice/inbox",
         preferred_duration=timedelta(days=90),
@@ -81,7 +81,7 @@ def embargo_policy():
 
 @pytest.fixture
 def vultron_person(embargo_policy):
-    return VultronPerson(
+    return as_VultronPerson(
         name="Alice",
         id_="https://example.org/actors/alice",
         embargo_policy=embargo_policy,
@@ -90,7 +90,7 @@ def vultron_person(embargo_policy):
 
 @pytest.fixture
 def vultron_organization(embargo_policy):
-    return VultronOrganization(
+    return as_VultronOrganization(
         name="ACME Corp",
         id_="https://example.org/actors/acme",
         embargo_policy=embargo_policy,
@@ -99,7 +99,7 @@ def vultron_organization(embargo_policy):
 
 @pytest.fixture
 def vultron_service(embargo_policy):
-    return VultronService(
+    return as_VultronService(
         name="VulnBot",
         id_="https://example.org/actors/vulnbot",
         embargo_policy=embargo_policy,
@@ -108,7 +108,7 @@ def vultron_service(embargo_policy):
 
 @pytest.fixture
 def vultron_application(embargo_policy):
-    return VultronApplication(
+    return as_VultronApplication(
         name="VulnApp",
         id_="https://example.org/actors/vulnapp",
         embargo_policy=embargo_policy,
@@ -117,7 +117,7 @@ def vultron_application(embargo_policy):
 
 @pytest.fixture
 def vultron_group(embargo_policy):
-    return VultronGroup(
+    return as_VultronGroup(
         name="VulnGroup",
         id_="https://example.org/actors/vulngroup",
         embargo_policy=embargo_policy,

--- a/test/adapters/driving/fastapi/routers/test_datalayer.py
+++ b/test/adapters/driving/fastapi/routers/test_datalayer.py
@@ -16,7 +16,7 @@ from urllib.parse import quote
 from fastapi import status
 
 from vultron.adapters.driven.db_record import object_to_record
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
 
 
 def test_get_offers_returns_empty_dict_when_no_offers(client_datalayer):
@@ -128,7 +128,7 @@ def test_get_by_http_url_key_returns_stored_record(
     Regression: Starlette decodes %2F to / before routing, so single-segment
     /{key} never matched URL-format IDs.  Fix: use /{key:path} as catch-all.
     """
-    participant = CaseParticipant(id_=_HTTP_PARTICIPANT_ID)
+    participant = as_CaseParticipant(id_=_HTTP_PARTICIPANT_ID)
     datalayer.create(object_to_record(participant))
 
     encoded = quote(_HTTP_PARTICIPANT_ID, safe="")

--- a/test/adapters/driving/fastapi/routers/test_datalayer_serialization.py
+++ b/test/adapters/driving/fastapi/routers/test_datalayer_serialization.py
@@ -27,9 +27,11 @@ from vultron.adapters.driven.datalayer_sqlite import (
     reset_datalayer as _reset_datalayer,
 )
 from vultron.adapters.driving.fastapi.main import app
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 
@@ -63,12 +65,12 @@ def test_get_vulnerability_case_includes_vulnerability_reports_field(
     excluded subclass-specific fields.
     """
     # Create a report
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         name="Test Report", content="Test vulnerability content"
     )
 
     # Create a case with the report
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         name=f"Case for Report {report.id_}",
         vulnerability_reports=[report],
         attributed_to="https://example.org/actor",
@@ -97,12 +99,12 @@ def test_get_vulnerability_case_includes_vulnerability_reports_field(
 
 def test_get_vulnerability_case_includes_all_fields(client, datalayer):
     """
-    Test that GET /datalayer/{key} includes all VulnerabilityCase fields.
+    Test that GET /datalayer/{key} includes all as_VulnerabilityCase fields.
 
     Ensures subclass-specific fields are not filtered by response_model.
     """
     # Create a case with various fields populated
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         name="Comprehensive Test Case",
         attributed_to="https://example.org/actor",
         case_participants=[],  # Empty but should be included
@@ -120,7 +122,7 @@ def test_get_vulnerability_case_includes_all_fields(client, datalayer):
     assert response.status_code == 200
     data = response.json()
 
-    # Verify VulnerabilityCase-specific fields are present
+    # Verify as_VulnerabilityCase-specific fields are present
     expected_fields = [
         "caseParticipants",
         "vulnerabilityReports",
@@ -140,11 +142,11 @@ def test_get_vulnerability_case_includes_all_fields(client, datalayer):
 
 def test_get_vulnerability_report_includes_all_fields(client, datalayer):
     """
-    Test that GET /datalayer/{key} includes all VulnerabilityReport fields.
+    Test that GET /datalayer/{key} includes all as_VulnerabilityReport fields.
 
     Verifies the fix works for other subclasses too.
     """
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         name="Test Report",
         content="Test vulnerability content",
         attributed_to="https://example.org/finder",
@@ -159,7 +161,7 @@ def test_get_vulnerability_report_includes_all_fields(client, datalayer):
     assert response.status_code == 200
     data = response.json()
 
-    # Verify VulnerabilityReport has content field (not in as_Base)
+    # Verify as_VulnerabilityReport has content field (not in as_Base)
     assert (
         "content" in data
     ), f"Response missing 'content' field. Keys: {list(data.keys())}"

--- a/test/adapters/driving/fastapi/routers/test_demo_triggers.py
+++ b/test/adapters/driving/fastapi/routers/test_demo_triggers.py
@@ -43,19 +43,21 @@ from vultron.adapters.driven.trigger_activity_adapter import (
 )
 from vultron.enums.roles import CVDRole
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 
 def _route_key(object_id: str) -> str:
     return strip_id_prefix(object_id)
 
 
-def _add_case_manager(case: VulnerabilityCase, dl) -> as_Service:
+def _add_case_manager(case: as_VulnerabilityCase, dl) -> as_Service:
     """Add a CASE_MANAGER participant to *case* and return the case actor."""
     case_actor = as_Service(name=f"Case Actor for {case.name}")
     dl.create(case_actor)
-    cm_participant = CaseParticipant(
+    cm_participant = as_CaseParticipant(
         attributed_to=case_actor.id_,
         context=case.id_,
         case_roles=[CVDRole.CASE_MANAGER],
@@ -151,9 +153,9 @@ def client_trigger_only(dl):
 
 @pytest.fixture
 def case_with_actor(dl, actor):
-    """Create a VulnerabilityCase listing the actor as a participant."""
-    case_obj = VulnerabilityCase(name="TEST-DEMO-CASE-001")
-    participant = CaseParticipant(
+    """Create a as_VulnerabilityCase listing the actor as a participant."""
+    case_obj = as_VulnerabilityCase(name="TEST-DEMO-CASE-001")
+    participant = as_CaseParticipant(
         attributed_to=actor.id_,
         context=case_obj.id_,
     )
@@ -331,10 +333,10 @@ class TestDemoGetCaseLedger:
     ):
         """Entries from other cases are not included in the response."""
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
-        other_case = VulnerabilityCase(name="OTHER-CASE")
+        other_case = as_VulnerabilityCase(name="OTHER-CASE")
         dl.create(other_case)
         _make_log_entry(dl, case_with_actor.id_, log_index=0)
         _make_log_entry(dl, other_case.id_, log_index=0)
@@ -396,7 +398,7 @@ class TestDemoGetCaseLedger:
     ):
         """Resolves HTTP URL case IDs through their surrogate key."""
         http_case_id = "https://example.org/cases/demo/123"
-        case = VulnerabilityCase(id_=http_case_id, name="HTTP Case")
+        case = as_VulnerabilityCase(id_=http_case_id, name="HTTP Case")
         dl.create(case)
         _make_log_entry(dl, http_case_id, log_index=0)
         _make_log_entry(dl, http_case_id, log_index=1)
@@ -461,7 +463,7 @@ class TestDemoGetCaseLedgerEntry:
     ):
         """Resolves HTTP URL case IDs through their surrogate key."""
         http_case_id = "https://example.org/cases/demo/456"
-        case = VulnerabilityCase(id_=http_case_id, name="HTTP Case")
+        case = as_VulnerabilityCase(id_=http_case_id, name="HTTP Case")
         dl.create(case)
         _make_log_entry(dl, http_case_id, log_index=0)
 

--- a/test/adapters/driving/fastapi/routers/test_trigger_actor.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_actor.py
@@ -39,9 +39,9 @@ from vultron.adapters.driven.trigger_activity_adapter import (
 )
 from vultron.wire.as2.factories import rm_invite_to_case_activity
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
-    VulnerabilityCase,
+    as_VulnerabilityCase,
     VulnerabilityCaseStub,
 )
 
@@ -74,16 +74,16 @@ def other_actor(dl):
 
 @pytest.fixture
 def case_obj(dl, actor):
-    """Create and persist a VulnerabilityCase with a CASE_MANAGER participant."""
+    """Create and persist a as_VulnerabilityCase with a CASE_MANAGER participant."""
     case_actor = as_Service(name="Case Actor")
     dl.create(case_actor)
-    case = VulnerabilityCase(name="TEST-CASE-001")
-    owner_participant = CaseParticipant(
+    case = as_VulnerabilityCase(name="TEST-CASE-001")
+    owner_participant = as_CaseParticipant(
         attributed_to=actor.id_,
         context=case.id_,
         case_roles=[CVDRole.CASE_OWNER],
     )
-    case_manager_participant = CaseParticipant(
+    case_manager_participant = as_CaseParticipant(
         attributed_to=case_actor.id_,
         context=case.id_,
         case_roles=[CVDRole.CASE_MANAGER],
@@ -107,13 +107,13 @@ def case_obj_with_case_actor(dl, actor):
     """
     case_actor = as_Service(name="Case Actor Service")
     dl.create(case_actor)
-    case = VulnerabilityCase(name="TEST-CASE-OCM")
-    owner_participant = CaseParticipant(
+    case = as_VulnerabilityCase(name="TEST-CASE-OCM")
+    owner_participant = as_CaseParticipant(
         attributed_to=actor.id_,
         context=case.id_,
         case_roles=[CVDRole.CASE_OWNER],
     )
-    case_manager_participant = CaseParticipant(
+    case_manager_participant = as_CaseParticipant(
         attributed_to=case_actor.id_,
         context=case.id_,
         case_roles=[CVDRole.CASE_MANAGER],

--- a/test/adapters/driving/fastapi/routers/test_trigger_case.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_case.py
@@ -41,19 +41,21 @@ from vultron.adapters.utils import parse_id
 from vultron.core.states.rm import RM
 from vultron.enums.roles import CVDRole
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 
-def _add_case_manager(case: VulnerabilityCase, dl) -> as_Service:
+def _add_case_manager(case: as_VulnerabilityCase, dl) -> as_Service:
     """Add a CASE_MANAGER participant to *case* and return the case actor."""
     case_actor = as_Service(name=f"Case Actor for {case.name}")
     dl.create(case_actor)
-    cm_participant = CaseParticipant(
+    cm_participant = as_CaseParticipant(
         attributed_to=case_actor.id_,
         context=case.id_,
         case_roles=[CVDRole.CASE_MANAGER],
@@ -111,13 +113,13 @@ def client_triggers(dl):
 
 @pytest.fixture
 def case_with_participant(dl, actor):
-    """Create a VulnerabilityCase with the actor as a CaseParticipant.
+    """Create a as_VulnerabilityCase with the actor as a as_CaseParticipant.
 
     The participant is pre-seeded to RM.VALID so that engage/defer triggers
     can apply valid VALID → ACCEPTED / VALID → DEFERRED transitions.
     """
-    case_obj = VulnerabilityCase(name="TEST-CASE-001")
-    participant = CaseParticipant(
+    case_obj = as_VulnerabilityCase(name="TEST-CASE-001")
+    participant = as_CaseParticipant(
         attributed_to=actor.id_,
         context=case_obj.id_,
     )
@@ -136,8 +138,8 @@ def case_with_participant(dl, actor):
 
 @pytest.fixture
 def case_without_participant(dl):
-    """Create a VulnerabilityCase with a Case Manager but no participant for the actor."""
-    case_obj = VulnerabilityCase(name="TEST-CASE-NO-PARTICIPANT")
+    """Create a as_VulnerabilityCase with a Case Manager but no participant for the actor."""
+    case_obj = as_VulnerabilityCase(name="TEST-CASE-NO-PARTICIPANT")
     dl.create(case_obj)
     _add_case_manager(case_obj, dl)
     return case_obj
@@ -248,7 +250,7 @@ def test_trigger_engage_case_adds_activity_to_outbox(
 def test_trigger_engage_case_updates_participant_rm_state(
     client_triggers, dl, actor, case_with_participant
 ):
-    """engage-case transitions actor's CaseParticipant RM state to ACCEPTED."""
+    """engage-case transitions actor's as_CaseParticipant RM state to ACCEPTED."""
     resp = client_triggers.post(
         f"/actors/{actor.id_}/trigger/engage-case",
         json={"case_id": case_with_participant.id_},
@@ -401,7 +403,7 @@ def test_trigger_defer_case_adds_activity_to_outbox(
 def test_trigger_defer_case_updates_participant_rm_state(
     client_triggers, dl, actor, case_with_participant
 ):
-    """defer-case transitions actor's CaseParticipant RM state to DEFERRED."""
+    """defer-case transitions actor's as_CaseParticipant RM state to DEFERRED."""
     resp = client_triggers.post(
         f"/actors/{actor.id_}/trigger/defer-case",
         json={"case_id": case_with_participant.id_},
@@ -561,12 +563,12 @@ class TestTriggerCaseOutboxCanonicalId:
 
 @pytest.fixture
 def report(dl):
-    """Create a persisted VulnerabilityReport for use in tests."""
+    """Create a persisted as_VulnerabilityReport for use in tests."""
     from vultron.wire.as2.vocab.objects.vulnerability_report import (
-        VulnerabilityReport,
+        as_VulnerabilityReport,
     )
 
-    report_obj = VulnerabilityReport(
+    report_obj = as_VulnerabilityReport(
         name="TEST-REPORT-001",
         content="Vulnerability description",
     )

--- a/test/adapters/driving/fastapi/routers/test_trigger_report.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_report.py
@@ -42,10 +42,12 @@ from vultron.adapters.driven.trigger_activity_adapter import (
 )
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 from vultron.core.states.rm import RM
 from vultron.enums.roles import CVDRole
@@ -97,7 +99,7 @@ def client_triggers(dl):
 
 @pytest.fixture
 def report(dl, actor):
-    report_obj = VulnerabilityReport(
+    report_obj = as_VulnerabilityReport(
         name="Test Vulnerability",
         content="Test content",
     )
@@ -125,7 +127,7 @@ def offer(dl, report, actor, reporter):
 
 @pytest.fixture
 def received_report(dl, actor, reporter, report, offer):
-    """Pre-create a VulnerabilityCase for the report at RM.RECEIVED.
+    """Pre-create a as_VulnerabilityCase for the report at RM.RECEIVED.
 
     Per ADR-0015, the case is created at report receipt.  The validate_report
     BT's EnsureEmbargoExists node requires a case to exist.
@@ -143,10 +145,10 @@ def received_report(dl, actor, reporter, report, offer):
     )
     bridge.execute_with_setup(tree, actor_id=actor.id_)
     case_obj = dl.find_case_by_report_id(report.id_)
-    assert isinstance(case_obj, VulnerabilityCase)
+    assert isinstance(case_obj, as_VulnerabilityCase)
     case_actor = as_Service(name=f"Case Actor for {case_obj.name}")
     dl.create(case_actor)
-    case_manager_participant = CaseParticipant(
+    case_manager_participant = as_CaseParticipant(
         attributed_to=case_actor.id_,
         context=case_obj.id_,
         case_roles=[CVDRole.CASE_MANAGER],
@@ -187,10 +189,10 @@ def closed_report(dl, report, actor):
 
 @pytest.fixture
 def non_report_object(dl):
-    """An EmbargoEvent stored in the datalayer — not an Offer."""
-    from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+    """An as_EmbargoEvent stored in the datalayer — not an Offer."""
+    from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
 
-    obj = EmbargoEvent(context="urn:uuid:some-case")
+    obj = as_EmbargoEvent(context="urn:uuid:some-case")
     dl.create(obj)
     return obj
 
@@ -741,7 +743,7 @@ def test_trigger_submit_report_returns_202(client_triggers, actor):
 def test_trigger_submit_report_creates_report_in_datalayer(
     client_triggers, actor, dl
 ):
-    """submit-report trigger persists a VulnerabilityReport in the DataLayer."""
+    """submit-report trigger persists a as_VulnerabilityReport in the DataLayer."""
     resp = client_triggers.post(
         f"/actors/{actor.id_}/trigger/submit-report",
         json={

--- a/test/adapters/driving/fastapi/test_inbox_handler.py
+++ b/test/adapters/driving/fastapi/test_inbox_handler.py
@@ -11,7 +11,9 @@ from vultron.core.models.pending_case_inbox import VultronPendingCaseInbox
 from vultron.core.models.events import MessageSemantics, VultronEvent
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.base.objects.activities.base import as_Activity
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 
 def test_prepare_for_dispatch_returns_vultron_event(monkeypatch):
@@ -316,7 +318,7 @@ def test_inbox_handler_replays_deferred_items_after_case_announce(monkeypatch):
     def fake_dispatch(event: VultronEvent, dl: SqliteDataLayer) -> None:
         dispatched.append(event.activity_id)
         if event.semantic_type == MessageSemantics.ANNOUNCE_VULNERABILITY_CASE:
-            dl.save(VulnerabilityCase(id_=case_id, name="Replica"))
+            dl.save(as_VulnerabilityCase(id_=case_id, name="Replica"))
 
     async def fake_outbox_handler(*_args: object, **_kwargs: object) -> None:
         return None
@@ -653,7 +655,7 @@ def test_make_dispatcher_ac2_auto_create_false_no_case_via_dispatcher(
     With _resolve_actor_config returning auto_create_case=False,
     dispatching an inbound Offer(Report) via DirectActivityDispatcher must
     store the report and Offer activity but must NOT create a
-    VulnerabilityCase and must leave the actor's outbox empty (CM-15-001,
+    as_VulnerabilityCase and must leave the actor's outbox empty (CM-15-001,
     issue #1319).
     """
     from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
@@ -708,7 +710,7 @@ def test_make_dispatcher_ac2_auto_create_false_no_case_via_dispatcher(
     # No case created.
     assert (
         dl.get_all("VulnerabilityCase") == []
-    ), "No VulnerabilityCase should be created when auto_create_case=False"
+    ), "No as_VulnerabilityCase should be created when auto_create_case=False"
     # Outbox must remain empty.
     assert (
         dl.outbox_list_for_actor(VENDOR_ID) == []

--- a/test/adapters/driving/fastapi/test_inbox_pipeline.py
+++ b/test/adapters/driving/fastapi/test_inbox_pipeline.py
@@ -31,14 +31,14 @@ from vultron.wire.as2.factories import (
     rm_create_report_activity,
 )
 from vultron.wire.as2.vocab.base.objects.object_types import as_Note
-from vultron.wire.as2.vocab.objects.case_ledger_entry import CaseLedgerEntry
-from vultron.wire.as2.vocab.objects.case_status import CaseStatus
-from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+from vultron.wire.as2.vocab.objects.case_ledger_entry import as_CaseLedgerEntry
+from vultron.wire.as2.vocab.objects.case_status import as_CaseStatus
+from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
-    VulnerabilityCase,
+    as_VulnerabilityCase,
 )
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 PipelineFixture: TypeAlias = tuple[InboxPipeline, SqliteDataLayer]
@@ -58,8 +58,8 @@ def _patch_execute_with_marker(
     monkeypatch.setattr(use_case_class, "execute", _execute)
 
 
-def _base_case(case_id: str = CASE_ID) -> VulnerabilityCase:
-    return VulnerabilityCase(id_=case_id, name="CASE-IBP")
+def _base_case(case_id: str = CASE_ID) -> as_VulnerabilityCase:
+    return as_VulnerabilityCase(id_=case_id, name="CASE-IBP")
 
 
 def _save_and_process(
@@ -80,7 +80,7 @@ def test_routing_safety_net_report_domain(test_pipeline, monkeypatch):
     _patch_execute_with_marker(
         monkeypatch, CreateReportReceivedUseCase, marker_id
     )
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         id_="https://example.org/reports/r-ibp-1",
         content="report content",
     )
@@ -120,7 +120,7 @@ def test_routing_safety_net_embargo_domain(test_pipeline, monkeypatch):
         monkeypatch, InviteToEmbargoOnCaseReceivedUseCase, marker_id
     )
     case = _base_case()
-    embargo = EmbargoEvent(
+    embargo = as_EmbargoEvent(
         id_="https://example.org/embargoes/e-ibp-1",
         context=case,
     )
@@ -188,7 +188,7 @@ def test_routing_safety_net_status_domain(test_pipeline, monkeypatch):
         monkeypatch, AddCaseStatusToCaseReceivedUseCase, marker_id
     )
     case = _base_case()
-    status = CaseStatus(
+    status = as_CaseStatus(
         id_="https://example.org/status/cs-ibp-1", context=case.id_
     )
     activity = add_status_to_case_activity(
@@ -213,7 +213,7 @@ def test_routing_safety_net_sync_domain(test_pipeline, monkeypatch):
     _patch_execute_with_marker(
         monkeypatch, AnnounceLedgerEntryReceivedUseCase, marker_id
     )
-    entry = CaseLedgerEntry(
+    entry = as_CaseLedgerEntry(
         id_="https://example.org/log/entry-ibp-1",
         case_id=CASE_ID,
         log_index=0,

--- a/test/adapters/driving/fastapi/test_outbox_handle_item_delivery.py
+++ b/test/adapters/driving/fastapi/test_outbox_handle_item_delivery.py
@@ -17,7 +17,7 @@
 Unit tests for handle_outbox_item — delivery, logging, and regression cases.
 
 Covers: basic delivery flow, skip conditions, log content requirements,
-DR-01 typed-target dehydration regression, and Announce(CaseLedgerEntry)
+DR-01 typed-target dehydration regression, and Announce(as_CaseLedgerEntry)
 inline field preservation.
 
 Module under test: ``vultron/adapters/driving/fastapi/outbox_handler.py``
@@ -276,17 +276,17 @@ def test_handle_outbox_item_converts_typed_activity_with_full_target():
 
 
 # ---------------------------------------------------------------------------
-# handle_outbox_item — Announce(CaseLedgerEntry) inline field preservation
+# handle_outbox_item — Announce(as_CaseLedgerEntry) inline field preservation
 # ---------------------------------------------------------------------------
 
 
 def test_handle_outbox_item_preserves_inline_case_ledger_entry_fields():
-    """Announce(CaseLedgerEntry) delivery keeps full inline log-entry fields."""
+    """Announce(as_CaseLedgerEntry) delivery keeps full inline log-entry fields."""
     from vultron.core.behaviors.sync.nodes.chain import _to_persistable_entry
     from vultron.core.models.case_ledger import HashChainLedgerRecord
     from vultron.wire.as2.factories import announce_log_entry_activity
     from vultron.wire.as2.vocab.objects.case_ledger_entry import (
-        CaseLedgerEntry as WireCaseLedgerEntry,
+        as_CaseLedgerEntry as WireCaseLedgerEntry,
     )
 
     recipient = "https://example.org/actors/participant"

--- a/test/adapters/driving/fastapi/test_outbox_object_pipeline.py
+++ b/test/adapters/driving/fastapi/test_outbox_object_pipeline.py
@@ -60,7 +60,7 @@ def _make_vultron_activity(
 def test_recover_typed_inline_object_from_dict_rehydrates_model():
     """_recover_typed_inline_object_from_dict rebuilds configured model types."""
     from vultron.wire.as2.vocab.objects.vulnerability_case import (
-        VulnerabilityCase,
+        as_VulnerabilityCase,
     )
 
     activity = _make_vultron_activity(
@@ -80,7 +80,7 @@ def test_recover_typed_inline_object_from_dict_rehydrates_model():
         activity,
     )
 
-    assert isinstance(recovered, VulnerabilityCase)
+    assert isinstance(recovered, as_VulnerabilityCase)
     assert activity.object_ is recovered
 
 
@@ -239,17 +239,17 @@ def test_handle_outbox_item_delivers_hydrated_participants():
     the outbound object_, not the pre-hydration object.
     """
     from vultron.wire.as2.vocab.objects.vulnerability_case import (
-        VulnerabilityCase,
+        as_VulnerabilityCase,
     )
 
     participant_id = "urn:uuid:participant-572-001"
-    case_obj = VulnerabilityCase(
+    case_obj = as_VulnerabilityCase(
         id_="urn:uuid:case-572-001",
         case_participants=[participant_id],  # bare string before hydration
     )
     # dl.hydrate() is responsible for replacing bare strings with objects;
     # simulate it returning a case with participants already expanded.
-    hydrated_case = VulnerabilityCase(
+    hydrated_case = as_VulnerabilityCase(
         id_="urn:uuid:case-572-001",
         case_participants=[],  # hydrate() would fill this with full objects
     )

--- a/test/adapters/driving/fastapi/test_responses.py
+++ b/test/adapters/driving/fastapi/test_responses.py
@@ -26,15 +26,17 @@ from vultron.adapters.driving.fastapi.responses import (
     AS2_CONTENT_TYPE,
     AS2JSONResponse,
 )
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 
 def test_content_type_is_as2():
     """AS2JSONResponse must set Content-Type: application/activity+json."""
-    report = VulnerabilityReport(name="test")
+    report = as_VulnerabilityReport(name="test")
     response = AS2JSONResponse(report)
     assert response.media_type == AS2_CONTENT_TYPE
     assert AS2_CONTENT_TYPE in response.headers["content-type"]
@@ -42,7 +44,7 @@ def test_content_type_is_as2():
 
 def test_camelcase_keys():
     """AS2JSONResponse must serialize with by_alias=True (camelCase keys)."""
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         name="Test Case",
         attributed_to="https://example.org/actor",
         vulnerability_reports=[],
@@ -64,12 +66,12 @@ def test_subclass_fields_not_stripped():
     FastAPI's response_model filtering strips fields not declared on the base
     class. AS2JSONResponse bypasses that filtering entirely.
     """
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         name="Test Report",
         content="Test vulnerability content",
         attributed_to="https://example.org/finder",
     )
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         name="Test Case",
         attributed_to="https://example.org/actor",
         vulnerability_reports=[report],
@@ -95,7 +97,7 @@ def test_subclass_fields_not_stripped():
 
 def test_exclude_none_true():
     """None-valued fields must be omitted from the serialized body."""
-    report = VulnerabilityReport(name="Minimal Report")
+    report = as_VulnerabilityReport(name="Minimal Report")
     response = AS2JSONResponse(report)
     body = json.loads(bytes(response.body))
 
@@ -118,13 +120,13 @@ def test_non_as2_content_passthrough():
 
 def test_status_code_default():
     """Default status code is 200."""
-    report = VulnerabilityReport(name="Test")
+    report = as_VulnerabilityReport(name="Test")
     response = AS2JSONResponse(report)
     assert response.status_code == 200
 
 
 def test_status_code_override():
     """Custom status codes are forwarded correctly."""
-    report = VulnerabilityReport(name="Created")
+    report = as_VulnerabilityReport(name="Created")
     response = AS2JSONResponse(report, status_code=201)
     assert response.status_code == 201

--- a/test/architecture/test_wire_vocab_naming.py
+++ b/test/architecture/test_wire_vocab_naming.py
@@ -81,26 +81,7 @@ def _collect_collisions() -> frozenset[str]:
 # Fix: add the as_ prefix to the wire class (ARCH-14-001).
 # Migration tracked in issue #1056.
 # ---------------------------------------------------------------------------
-KNOWN_VIOLATIONS: frozenset[str] = frozenset(
-    {
-        "CaseActor",
-        "CaseLedgerEntry",
-        "CaseParticipant",
-        "CaseReference",
-        "CaseStatus",
-        "EmbargoEvent",
-        "EmbargoPolicy",
-        "ParticipantStatus",
-        "VulnerabilityCase",
-        "VulnerabilityRecord",
-        "VulnerabilityReport",
-        "VultronApplication",
-        "VultronGroup",
-        "VultronOrganization",
-        "VultronPerson",
-        "VultronService",
-    }
-)
+KNOWN_VIOLATIONS: frozenset[str] = frozenset()
 
 
 def test_wire_vocab_objects_do_not_shadow_core_model_names():

--- a/test/core/behaviors/case/conftest.py
+++ b/test/core/behaviors/case/conftest.py
@@ -1,7 +1,7 @@
 """
 Fixtures for test/core/behaviors/case tests.
 
-Imports VulnerabilityCase (and related wire-layer types) as a side effect so
+Imports as_VulnerabilityCase (and related wire-layer types) as a side effect so
 that the global vocabulary registry is populated before any test in this
 directory runs.  Without this import the registry may be empty when tests run
 in isolation, causing TinyDB's record_to_object() to fall back to returning a
@@ -15,7 +15,7 @@ import pytest
 
 # noqa: F401 — imported for vocabulary registration side-effect
 from vultron.wire.as2.vocab.objects.vulnerability_case import (  # noqa: F401
-    VulnerabilityCase,
+    as_VulnerabilityCase,
 )
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
@@ -26,7 +26,7 @@ from vultron.core.states.rm import RM
 from vultron.core.use_cases._helpers import _report_phase_status_id
 from vultron.wire.as2.factories import rm_submit_report_activity
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 
@@ -66,8 +66,8 @@ def reporter_actor(datalayer, reporter_actor_id):
 
 @pytest.fixture
 def report(datalayer):
-    """Create test VulnerabilityReport."""
-    obj = VulnerabilityReport(
+    """Create test as_VulnerabilityReport."""
+    obj = as_VulnerabilityReport(
         id_="https://example.org/reports/CVE-2024-001",
         name="Test Vulnerability Report",
         content="Buffer overflow in component X",

--- a/test/core/behaviors/case/nodes/participant/test_participant_add.py
+++ b/test/core/behaviors/case/nodes/participant/test_participant_add.py
@@ -45,7 +45,7 @@ from vultron.core.states.participant_embargo_consent import PEC
 from vultron.core.states.rm import RM
 from vultron.enums.roles import CVDRole
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Add
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
 from vultron.core.use_cases._helpers import _report_phase_status_id
 from test.core.behaviors.bt_harness import BTTestScenario
 
@@ -154,7 +154,7 @@ class TestCreateCaseParticipantNode:
                 add_activities.append(obj)
         assert any(
             act.type_ == "Add"
-            and isinstance(act.object_, CaseParticipant)
+            and isinstance(act.object_, as_CaseParticipant)
             and getattr(act.target, "id_", act.target) == case_obj.id_
             for act in add_activities
         )

--- a/test/core/behaviors/case/nodes/test_actor_and_announce_nodes.py
+++ b/test/core/behaviors/case/nodes/test_actor_and_announce_nodes.py
@@ -35,7 +35,9 @@ from vultron.core.models.events.actor import (
 )
 from vultron.semantic_registry import extract_event
 from vultron.wire.as2.factories import announce_vulnerability_case_activity
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 ACTOR_ID = "https://example.org/actors/owner"
 NEW_OWNER_ID = "https://example.org/actors/coordinator"
@@ -63,7 +65,7 @@ class TestAcceptCaseOwnershipTransferNode:
 
     def test_transfers_ownership(self, bridge, dl) -> None:
         """Happy path: case.attributed_to updated to new_owner_id."""
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_=CASE_ID,
             name="OT Node Test",
             attributed_to=ACTOR_ID,
@@ -86,7 +88,7 @@ class TestAcceptCaseOwnershipTransferNode:
 
     def test_idempotent_when_already_owned(self, bridge, dl) -> None:
         """SUCCESS without mutation when case already has the new owner."""
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_=CASE_ID,
             name="OT Node Idempotent",
             attributed_to=NEW_OWNER_ID,
@@ -115,7 +117,7 @@ class TestAcceptCaseOwnershipTransferNode:
 
 @pytest.fixture
 def case():
-    return VulnerabilityCase(id_=CASE_ID2, name="Seed Announce Test")
+    return as_VulnerabilityCase(id_=CASE_ID2, name="Seed Announce Test")
 
 
 @pytest.fixture
@@ -214,12 +216,12 @@ class TestEmitInviteActorToCaseNodePassesRolesNoneToFactory:
             TriggerActivityAdapter,
         )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         # attributed_to triggers genesis_hash computation so the internal
         # commit_log_entry_tree inside EmitInviteActorToCaseNode can bootstrap.
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_=AC3_CASE_ID,
             name="AC2 test case",
             attributed_to=ACTOR_ID,

--- a/test/core/behaviors/case/nodes/test_case_participant_received.py
+++ b/test/core/behaviors/case/nodes/test_case_participant_received.py
@@ -24,8 +24,10 @@ from vultron.core.behaviors.case.nodes.case_participant_received import (
     AddCaseParticipantToCaseReceivedNode,
     RemoveCaseParticipantFromCaseReceivedNode,
 )
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 ACTOR_ID = "https://example.org/actors/owner"
 COORDINATOR_ID = "https://example.org/actors/coordinator"
@@ -45,12 +47,12 @@ def bridge(dl):
 
 @pytest.fixture
 def case():
-    return VulnerabilityCase(id_=CASE_ID, name="CP Node Test Case")
+    return as_VulnerabilityCase(id_=CASE_ID, name="CP Node Test Case")
 
 
 @pytest.fixture
 def participant(case):
-    return CaseParticipant(
+    return as_CaseParticipant(
         id_=PARTICIPANT_ID,
         attributed_to=COORDINATOR_ID,
         context=case.id_,

--- a/test/core/behaviors/case/nodes/test_communication.py
+++ b/test/core/behaviors/case/nodes/test_communication.py
@@ -252,14 +252,14 @@ class TestEmitRejectCaseManagerRoleNode:
     def _seed_dl(self, bt_scenario: BTTestScenario) -> None:
         """Seed the DataLayer with case and participant objects."""
         from vultron.wire.as2.vocab.objects.case_participant import (
-            CaseParticipant,
+            as_CaseParticipant,
         )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
-        case = VulnerabilityCase(id_=self._CASE_ID, name="CM-TEST")
-        participant = CaseParticipant(
+        case = as_VulnerabilityCase(id_=self._CASE_ID, name="CM-TEST")
+        participant = as_CaseParticipant(
             id_=self._PARTICIPANT_ID,
             attributed_to=self._CASE_ACTOR_ID,
             context=self._CASE_ID,
@@ -376,18 +376,18 @@ class TestEmitRejectCaseManagerRoleNode:
             offer_case_manager_role_activity,
         )
         from vultron.wire.as2.vocab.objects.case_participant import (
-            CaseParticipant,
+            as_CaseParticipant,
         )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         # Seed DL so EmitReject can reconstruct the offer
         self._seed_dl(bt_scenario)
 
         # Build a real offer object so StoreActivityNode can persist it
-        case = VulnerabilityCase(id_=self._CASE_ID, name="CM-TEST")
-        participant = CaseParticipant(
+        case = as_VulnerabilityCase(id_=self._CASE_ID, name="CM-TEST")
+        participant = as_CaseParticipant(
             id_=self._PARTICIPANT_ID,
             attributed_to=self._CASE_ACTOR_ID,
             context=self._CASE_ID,

--- a/test/core/behaviors/case/nodes/test_guarded_commit_tree.py
+++ b/test/core/behaviors/case/nodes/test_guarded_commit_tree.py
@@ -134,13 +134,13 @@ def _seeded_scenario(bt_scenario: BTTestScenario) -> BTTestScenario:
 def test_guarded_commit_tree_entry_has_non_empty_hash(
     _seeded_scenario: BTTestScenario,
 ) -> None:
-    """CaseLedgerEntry committed by CaseActor MUST have a non-empty entry_hash.
+    """as_CaseLedgerEntry committed by CaseActor MUST have a non-empty entry_hash.
 
     The CaseActor identity is MANAGER_ACTOR_ID — explicitly seeded in the
     fixture, with no ID derivation at runtime (CM-02-009, Issue #1021).
     """
     from vultron.wire.as2.vocab.objects.case_ledger_entry import (
-        CaseLedgerEntry as WireCaseLedgerEntry,
+        as_CaseLedgerEntry as WireCaseLedgerEntry,
     )
 
     activity = _FakeActivity()
@@ -164,13 +164,13 @@ def test_guarded_commit_tree_entry_has_non_empty_hash(
 def test_guarded_commit_tree_entry_has_utc_received_at(
     _seeded_scenario: BTTestScenario,
 ) -> None:
-    """CaseLedgerEntry committed by CaseActor MUST have a UTC received_at timestamp.
+    """as_CaseLedgerEntry committed by CaseActor MUST have a UTC received_at timestamp.
 
     The CaseActor identity is MANAGER_ACTOR_ID — explicitly seeded in the
     fixture, with no ID derivation at runtime (CM-02-009, Issue #1021).
     """
     from vultron.wire.as2.vocab.objects.case_ledger_entry import (
-        CaseLedgerEntry as WireCaseLedgerEntry,
+        as_CaseLedgerEntry as WireCaseLedgerEntry,
     )
 
     activity = _FakeActivity()
@@ -195,13 +195,13 @@ def test_guarded_commit_tree_entry_has_utc_received_at(
 def test_guarded_commit_tree_entry_references_correct_case_id(
     _seeded_scenario: BTTestScenario,
 ) -> None:
-    """CaseLedgerEntry committed by CaseActor MUST reference the correct case_id.
+    """as_CaseLedgerEntry committed by CaseActor MUST reference the correct case_id.
 
     The CaseActor identity is MANAGER_ACTOR_ID — explicitly seeded in the
     fixture, with no ID derivation at runtime (CM-02-009, Issue #1021).
     """
     from vultron.wire.as2.vocab.objects.case_ledger_entry import (
-        CaseLedgerEntry as WireCaseLedgerEntry,
+        as_CaseLedgerEntry as WireCaseLedgerEntry,
     )
 
     activity = _FakeActivity()

--- a/test/core/behaviors/case/nodes/test_lifecycle.py
+++ b/test/core/behaviors/case/nodes/test_lifecycle.py
@@ -26,7 +26,7 @@ from vultron.core.behaviors.bridge import BTBridge, BTExecutionResult
 from vultron.core.behaviors.case.nodes import CommitCaseLedgerEntryNode
 from vultron.core.models.events.base import MessageSemantics
 from vultron.core.models.vultron_types import VultronCaseActor
-from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
 
 _FACTORY_PATH = (
     "vultron.core.behaviors.case.nodes.lifecycle.create_commit_log_entry_tree"
@@ -264,7 +264,7 @@ def test_activity_payload_is_forwarded_as_payload_snapshot(bridge):
 
 
 def test_activity_payload_inlines_nested_reference_fields(bridge, datalayer):
-    embargo = EmbargoEvent(context=CASE_ID)
+    embargo = as_EmbargoEvent(context=CASE_ID)
     datalayer.save(embargo)
     activity = _FakeActivity(
         activity_id=ACTIVITY_ID,

--- a/test/core/behaviors/case/test_case_proposal_received_tree.py
+++ b/test/core/behaviors/case/test_case_proposal_received_tree.py
@@ -18,12 +18,12 @@
 AC-4: Verifies that
   - The ``PendingCreateCaseActivity`` marker is written after Accept succeeds
     and before Create fires (AC-2).
-  - The marker is removed when Create(VulnerabilityCase) is delivered
+  - The marker is removed when Create(as_VulnerabilityCase) is delivered
     successfully (AC-3).
-  - The marker remains when Create(VulnerabilityCase) delivery fails (AC-2
+  - The marker remains when Create(as_VulnerabilityCase) delivery fails (AC-2
     partial-failure path).
   - The marker stores at minimum: proposal_id, case_actor_id, vendor_uri,
-    and the pre-constructed Create(VulnerabilityCase) payload (AC-1).
+    and the pre-constructed Create(as_VulnerabilityCase) payload (AC-1).
 """
 
 import logging
@@ -46,7 +46,7 @@ from vultron.semantic_registry import extract_event
 # noqa: F401 — imported for vocabulary registration side-effect
 from vultron.wire.as2.vocab.objects.case_proposal import as_CaseProposal
 from vultron.wire.as2.vocab.objects.vulnerability_case import (  # noqa: F401
-    VulnerabilityCase,
+    as_VulnerabilityCase,
 )
 
 
@@ -321,7 +321,7 @@ class TestCreateCaseProposalReceivedBTMarkerWiring:
         return event.model_copy(update={"receiving_actor_id": _CASE_ACTOR_URI})
 
     def test_marker_absent_after_full_success(self, make_payload):
-        """AC-3: Marker is removed when Create(VulnerabilityCase) succeeds."""
+        """AC-3: Marker is removed when Create(as_VulnerabilityCase) succeeds."""
         from vultron.core.use_cases.received.case_proposal import (
             CreateCaseProposalReceivedUseCase,
         )
@@ -398,7 +398,7 @@ class TestCreateCaseProposalReceivedBTMarkerWiring:
         ``_EmitCreateVulnerabilityCaseNode`` (node 4) must share the same
         activity ``id_``.  If they diverge, the retry runner checks the
         marker's ``id_`` against the outbox and — not finding it — enqueues
-        a second ``Create(VulnerabilityCase)`` as a duplicate.
+        a second ``Create(as_VulnerabilityCase)`` as a duplicate.
 
         This test asserts ID consistency by:
         1. Running the full BT with ``_ClearCreateCaseMarkerNode`` no-oped so
@@ -441,5 +441,5 @@ class TestCreateCaseProposalReceivedBTMarkerWiring:
         assert marker_activity_id in outbox, (
             "Activity id_ in the marker's payload must match the id_ in the"
             " outbox. A mismatch causes the retry runner to enqueue a"
-            " duplicate Create(VulnerabilityCase) after crash/restart."
+            " duplicate Create(as_VulnerabilityCase) after crash/restart."
         )

--- a/test/core/behaviors/case/test_create_tree.py
+++ b/test/core/behaviors/case/test_create_tree.py
@@ -382,7 +382,7 @@ def test_create_case_tree_skips_ledger_entry_for_non_case_manager(
     (Issue #1021).
     """
     from vultron.wire.as2.vocab.objects.case_ledger_entry import (
-        CaseLedgerEntry as WireCaseLedgerEntry,
+        as_CaseLedgerEntry as WireCaseLedgerEntry,
     )
 
     tree = create_create_case_tree(case_obj=case_obj, actor_id=actor.id_)
@@ -410,7 +410,7 @@ def test_create_case_tree_case_created_event_uses_case_id(
     nodes/test_guarded_commit_tree.py (CM-02-009, Issue #1021).
     """
     from vultron.wire.as2.vocab.objects.case_ledger_entry import (
-        CaseLedgerEntry as WireCaseLedgerEntry,
+        as_CaseLedgerEntry as WireCaseLedgerEntry,
     )
 
     tree = create_create_case_tree(case_obj=case_obj, actor_id=actor.id_)
@@ -473,7 +473,7 @@ def test_create_case_tree_vendor_produces_no_ledger_entries(
     and is tested in nodes/test_guarded_commit_tree.py (CM-02-009, Issue #1021).
     """
     from vultron.wire.as2.vocab.objects.case_ledger_entry import (
-        CaseLedgerEntry as WireCaseLedgerEntry,
+        as_CaseLedgerEntry as WireCaseLedgerEntry,
     )
 
     tree = create_create_case_tree(case_obj=case_obj, actor_id=actor.id_)
@@ -494,12 +494,12 @@ def test_create_case_tree_hash_and_timestamp_properties_delegated(
 ):
     """Vendor running create_create_case_tree produces zero canonical ledger entries.
 
-    entry_hash and received_at properties of CaseLedgerEntry are verified in
+    entry_hash and received_at properties of as_CaseLedgerEntry are verified in
     nodes/test_guarded_commit_tree.py where CaseActor identity is explicit and
     no ID derivation is required (CM-02-009, Issue #1021).
     """
     from vultron.wire.as2.vocab.objects.case_ledger_entry import (
-        CaseLedgerEntry as WireCaseLedgerEntry,
+        as_CaseLedgerEntry as WireCaseLedgerEntry,
     )
 
     tree = create_create_case_tree(case_obj=case_obj, actor_id=actor.id_)

--- a/test/core/behaviors/case/test_receive_report_case_tree.py
+++ b/test/core/behaviors/case/test_receive_report_case_tree.py
@@ -54,7 +54,7 @@ from vultron.enums.roles import CVDRole
 from vultron.core.use_cases._helpers import _report_phase_status_id
 from vultron.wire.as2.factories import rm_submit_report_activity
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 # ============================================================================
@@ -1024,7 +1024,7 @@ class TestConcurrentExecution:
         if datalayer.read(reporter_actor_id) is None:
             datalayer.create(reporter_actor)
 
-        report = VulnerabilityReport(
+        report = as_VulnerabilityReport(
             id_=report_id,
             name=f"Report {report_id}",
             content="test vuln",

--- a/test/core/behaviors/embargo/nodes/conftest.py
+++ b/test/core/behaviors/embargo/nodes/conftest.py
@@ -15,7 +15,7 @@
 
 """Shared fixtures for test/core/behaviors/embargo/nodes tests.
 
-Imports VulnerabilityCase as a side effect to populate the global vocabulary
+Imports as_VulnerabilityCase as a side effect to populate the global vocabulary
 registry before any test in this package runs.
 """
 
@@ -24,22 +24,22 @@ import pytest
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.core.states.em import EM
-from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
 from vultron.wire.as2.vocab.objects.vulnerability_case import (  # noqa: F401
-    VulnerabilityCase,
+    as_VulnerabilityCase,
 )
 
 
 def make_case_and_embargo(
     case_suffix: str,
     em_state: EM = EM.ACTIVE,
-) -> tuple[VulnerabilityCase, EmbargoEvent]:
-    """Create an in-memory VulnerabilityCase + EmbargoEvent pair."""
-    case = VulnerabilityCase(
+) -> tuple[as_VulnerabilityCase, as_EmbargoEvent]:
+    """Create an in-memory as_VulnerabilityCase + as_EmbargoEvent pair."""
+    case = as_VulnerabilityCase(
         id_=f"https://example.org/cases/case_{case_suffix}",
         name=f"Test Case {case_suffix}",
     )
-    embargo = EmbargoEvent(
+    embargo = as_EmbargoEvent(
         id_=f"https://example.org/cases/case_{case_suffix}/embargo_events/e1",
         context=case.id_,
     )

--- a/test/core/behaviors/embargo/nodes/test_lifecycle.py
+++ b/test/core/behaviors/embargo/nodes/test_lifecycle.py
@@ -30,8 +30,10 @@ from vultron.core.behaviors.embargo.trigger_tree import terminate_embargo_bt
 from vultron.core.states.em import EM
 from vultron.core.states.participant_embargo_consent import PEC
 from vultron.enums.roles import CVDRole
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 from test.core.behaviors.embargo.nodes.conftest import make_case_and_embargo
 
@@ -42,12 +44,12 @@ CASE_MANAGER_ACTOR = "https://example.org/actors/case-manager"
 def _make_case_with_manager(
     suffix: str,
     em_state: EM = EM.ACTIVE,
-) -> tuple[VulnerabilityCase, CaseParticipant, SqliteDataLayer]:
+) -> tuple[as_VulnerabilityCase, as_CaseParticipant, SqliteDataLayer]:
     """Return a populated DataLayer with a case + CASE_MANAGER participant."""
     dl = SqliteDataLayer("sqlite:///:memory:")
     case, _embargo = make_case_and_embargo(suffix, em_state=em_state)
 
-    cm_participant = CaseParticipant(
+    cm_participant = as_CaseParticipant(
         id_=f"{case.id_}/participants/cm",
         attributed_to=CASE_MANAGER_ACTOR,
         case_roles=[CVDRole.CASE_MANAGER],
@@ -104,7 +106,7 @@ class TestTerminateEmbargoBT:
         result = bridge.execute_with_setup(tree, actor_id=ACTOR_ID)
 
         assert result.status == py_trees.common.Status.SUCCESS
-        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        updated = cast(as_VulnerabilityCase, dl.read(case.id_))
         assert updated.current_status.em_state == EM.EXITED
         assert updated.active_embargo is None
         factory.terminate_embargo.assert_called_once()
@@ -131,7 +133,7 @@ class TestTerminateEmbargoBT:
         result = bridge.execute_with_setup(tree, actor_id=ACTOR_ID)
 
         assert result.status == py_trees.common.Status.SUCCESS
-        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        updated = cast(as_VulnerabilityCase, dl.read(case.id_))
         assert updated.current_status.em_state == EM.EXITED
 
     def test_missing_case_manager_returns_failure_before_state_change(self):
@@ -160,7 +162,7 @@ class TestTerminateEmbargoBT:
 
         # BT fails at routing guard — no state mutation occurs (BT-19-001).
         assert result.status == py_trees.common.Status.FAILURE
-        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        updated = cast(as_VulnerabilityCase, dl.read(case.id_))
         assert updated.current_status.em_state == EM.ACTIVE  # unchanged
         assert updated.active_embargo is not None  # unchanged
         factory.terminate_embargo.assert_not_called()
@@ -168,7 +170,7 @@ class TestTerminateEmbargoBT:
     def test_no_active_embargo_returns_failure(self):
         """BT returns FAILURE when the case has no active embargo."""
         case, _, dl = _make_case_with_manager("teb4", em_state=EM.NONE)
-        case_obj = cast(VulnerabilityCase, dl.read(case.id_))
+        case_obj = cast(as_VulnerabilityCase, dl.read(case.id_))
         case_obj.active_embargo = None
         dl.save(case_obj)
 
@@ -189,12 +191,12 @@ class TestTerminateEmbargoBT:
     def test_resets_participant_pec_state(self):
         """Shared BT resets participant embargo_consent_state to NO_EMBARGO."""
         case, _, dl = _make_case_with_manager("teb5", em_state=EM.ACTIVE)
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             id_=f"{case.id_}/participants/p1",
             attributed_to="https://example.org/users/vendor",
         )
         participant.embargo_consent_state = PEC.SIGNATORY.value
-        case_obj = cast(VulnerabilityCase, dl.read(case.id_))
+        case_obj = cast(as_VulnerabilityCase, dl.read(case.id_))
         case_obj.case_participants.append(participant.id_)
         dl.save(case_obj)
         dl.create(participant)
@@ -218,7 +220,7 @@ class TestTerminateEmbargoBT:
         result = bridge.execute_with_setup(tree, actor_id=ACTOR_ID)
 
         assert result.status == py_trees.common.Status.SUCCESS
-        updated_p = cast(CaseParticipant, dl.read(participant.id_))
+        updated_p = cast(as_CaseParticipant, dl.read(participant.id_))
         assert updated_p.embargo_consent_state == PEC.NO_EMBARGO.value
 
     def test_cascade_path_no_builder_returns_failure_when_no_factory(self):
@@ -253,7 +255,7 @@ class TestTerminateEmbargoBT:
         result = bridge.execute_with_setup(tree, actor_id=ACTOR_ID)
 
         assert result.status == py_trees.common.Status.SUCCESS
-        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        updated = cast(as_VulnerabilityCase, dl.read(case.id_))
         assert updated.current_status.em_state == EM.EXITED
         factory.terminate_embargo.assert_called_once()
         outbox = dl.outbox_list_for_actor(ACTOR_ID)
@@ -278,7 +280,7 @@ class TestTerminateEmbargoBT:
         result = bridge.execute_with_setup(tree, actor_id=ACTOR_ID)
 
         assert result.status == py_trees.common.Status.FAILURE
-        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        updated = cast(as_VulnerabilityCase, dl.read(case.id_))
         assert updated.current_status.em_state == EM.ACTIVE  # unchanged
         assert updated.active_embargo is not None  # unchanged
         factory.terminate_embargo.assert_not_called()

--- a/test/core/behaviors/embargo/nodes/test_teardown.py
+++ b/test/core/behaviors/embargo/nodes/test_teardown.py
@@ -27,8 +27,10 @@ from vultron.core.behaviors.embargo.nodes.teardown import (
 )
 from vultron.core.states.em import EM
 from vultron.core.states.participant_embargo_consent import PEC
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 from test.core.behaviors.embargo.nodes.conftest import (
     make_case_and_embargo,
@@ -52,7 +54,7 @@ class TestApplyEmbargoTeardownNode:
         bt.tick()
 
         assert node.status == py_trees.common.Status.SUCCESS
-        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        updated = cast(as_VulnerabilityCase, dl.read(case.id_))
         assert updated.current_status.em_state == EM.EXITED
         assert updated.active_embargo is None
 
@@ -69,7 +71,7 @@ class TestApplyEmbargoTeardownNode:
         bt.tick()
 
         assert node.status == py_trees.common.Status.SUCCESS
-        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        updated = cast(as_VulnerabilityCase, dl.read(case.id_))
         assert updated.current_status.em_state == EM.EXITED
 
     def test_idempotent_when_already_exited(self):
@@ -86,7 +88,7 @@ class TestApplyEmbargoTeardownNode:
         bt.tick()
 
         assert node.status == py_trees.common.Status.SUCCESS
-        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        updated = cast(as_VulnerabilityCase, dl.read(case.id_))
         assert updated.current_status.em_state == EM.EXITED
 
     def test_state_sync_override_for_unexpected_em_state(self, caplog):
@@ -105,14 +107,14 @@ class TestApplyEmbargoTeardownNode:
 
         assert node.status == py_trees.common.Status.SUCCESS
         assert any("state-sync override" in r.message for r in caplog.records)
-        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        updated = cast(as_VulnerabilityCase, dl.read(case.id_))
         assert updated.current_status.em_state == EM.EXITED
 
     def test_resets_participant_embargo_consent(self):
         """Node resets participant PEC state to NO_EMBARGO."""
         dl = SqliteDataLayer("sqlite:///:memory:")
         case, _ = make_case_and_embargo("atn5", em_state=EM.ACTIVE)
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             id_=f"{case.id_}/participants/p1",
             attributed_to="https://example.org/users/finder",
         )
@@ -128,7 +130,7 @@ class TestApplyEmbargoTeardownNode:
         bt.tick()
 
         assert node.status == py_trees.common.Status.SUCCESS
-        updated_p = cast(CaseParticipant, dl.read(participant.id_))
+        updated_p = cast(as_CaseParticipant, dl.read(participant.id_))
         assert updated_p.embargo_consent_state == PEC.NO_EMBARGO.value
 
     def test_returns_success_when_case_missing(self):
@@ -170,7 +172,7 @@ class TestRemoveFromProposedEmbargoesNode:
         bt.tick()
 
         assert node.status == py_trees.common.Status.SUCCESS
-        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        updated = cast(as_VulnerabilityCase, dl.read(case.id_))
         assert embargo.id_ not in [
             e if isinstance(e, str) else getattr(e, "id_", None)
             for e in updated.proposed_embargoes

--- a/test/core/behaviors/inbox/test_process_payload.py
+++ b/test/core/behaviors/inbox/test_process_payload.py
@@ -33,9 +33,11 @@ from vultron.wire.as2.factories import (
     rm_create_report_activity,
 )
 from vultron.wire.as2.vocab.base.objects.object_types import as_Note
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 SENDER_ID = "https://example.org/actors/sender"
@@ -122,7 +124,7 @@ class _StubQueuePort:
 
 @pytest.fixture()
 def report_activity():
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         id_="https://example.org/reports/r-io-1",
         content="test report",
     )
@@ -131,7 +133,7 @@ def report_activity():
 
 @pytest.fixture()
 def case_activity():
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         id_=CASE_ID,
         name="CASE-IO",
     )

--- a/test/core/behaviors/note/conftest.py
+++ b/test/core/behaviors/note/conftest.py
@@ -15,5 +15,5 @@
 
 # noqa: F401 — imported for vocabulary registration side-effect
 from vultron.wire.as2.vocab.objects.vulnerability_case import (  # noqa: F401
-    VulnerabilityCase,
+    as_VulnerabilityCase,
 )

--- a/test/core/behaviors/note/nodes/test_creation.py
+++ b/test/core/behaviors/note/nodes/test_creation.py
@@ -24,7 +24,9 @@ from vultron.core.behaviors.note.nodes.creation import (
     AttachNoteFromResultNode,
     CreateNoteNode,
 )
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 ACTOR_ID = "https://example.org/actors/finder"
 CASE_ID = "https://example.org/cases/case-01"
@@ -96,7 +98,7 @@ class TestCreateNoteNode:
 
 class TestAttachNoteFromResultNode:
     def test_attaches_note_id_from_result_out(self, bridge, dl):
-        dl.create(VulnerabilityCase(id_=CASE_ID, name="Test Case"))
+        dl.create(as_VulnerabilityCase(id_=CASE_ID, name="Test Case"))
         result_out = {"note_id": NOTE_ID}
         node = AttachNoteFromResultNode(case_id=CASE_ID, result_out=result_out)
         result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)

--- a/test/core/behaviors/note/nodes/test_storage.py
+++ b/test/core/behaviors/note/nodes/test_storage.py
@@ -25,7 +25,9 @@ from vultron.core.behaviors.note.nodes.storage import (
     SaveNoteNode,
 )
 from vultron.core.models.note import VultronNote
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 ACTOR_ID = "https://example.org/actors/finder"
 CASE_ID = "https://example.org/cases/case-01"
@@ -63,7 +65,7 @@ class TestSaveNoteNode:
 
 class TestAttachNoteToCaseNode:
     def test_attaches_note_to_case(self, bridge, dl, note):
-        case = VulnerabilityCase(id_=CASE_ID, name="Test Case")
+        case = as_VulnerabilityCase(id_=CASE_ID, name="Test Case")
         dl.create(case)
         dl.save(note)
         tree = AttachNoteToCaseNode(note_id=NOTE_ID, case_id=CASE_ID)
@@ -74,7 +76,7 @@ class TestAttachNoteToCaseNode:
         assert NOTE_ID in refreshed.notes
 
     def test_idempotent_when_note_already_attached(self, bridge, dl, note):
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_=CASE_ID, name="Test Case", notes=[NOTE_ID]
         )
         dl.create(case)

--- a/test/core/behaviors/note/test_add_note_trigger_tree.py
+++ b/test/core/behaviors/note/test_add_note_trigger_tree.py
@@ -37,7 +37,9 @@ from vultron.wire.as2.vocab.objects.case_participant import (
     FinderParticipant,
     VendorParticipant,
 )
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 CASE_ACTOR_ID = "https://example.org/actors/case-actor"
 ACTIVITY_ID = "https://example.org/activities/act-01"
@@ -88,8 +90,8 @@ def bridge(dl):
 def _make_case_with_case_manager(
     store: SqliteDataLayer,
     actor_id: str,
-) -> VulnerabilityCase:
-    case = VulnerabilityCase(name="Test Case")
+) -> as_VulnerabilityCase:
+    case = as_VulnerabilityCase(name="Test Case")
     finder_participant = FinderParticipant(
         attributed_to=actor_id,
         context=case.id_,
@@ -201,7 +203,7 @@ class TestAddNoteToCaseTriggerBT:
 
     def test_failure_when_no_case_manager(self, dl, bridge):
         store, actor = dl
-        case = VulnerabilityCase(name="No Manager Case")
+        case = as_VulnerabilityCase(name="No Manager Case")
         participant = FinderParticipant(
             attributed_to=actor.id_,
             context=case.id_,

--- a/test/core/behaviors/note/test_create_note_tree.py
+++ b/test/core/behaviors/note/test_create_note_tree.py
@@ -26,7 +26,9 @@ from vultron.core.behaviors.note.nodes import (
     SaveNoteNode,
 )
 from vultron.core.models.note import VultronNote
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 ACTOR_ID = "https://example.org/actors/finder"
 CASE_ID = "https://example.org/cases/case-01"
@@ -62,7 +64,7 @@ def note_with_case():
 
 @pytest.fixture
 def case(dl):
-    obj = VulnerabilityCase(id_=CASE_ID, name="Test Case")
+    obj = as_VulnerabilityCase(id_=CASE_ID, name="Test Case")
     dl.create(obj)
     return obj
 

--- a/test/core/behaviors/report/conftest.py
+++ b/test/core/behaviors/report/conftest.py
@@ -1,7 +1,7 @@
 """
 Fixtures for test/core/behaviors/report tests.
 
-Imports VulnerabilityCase (and related wire-layer types) as a side effect so
+Imports as_VulnerabilityCase (and related wire-layer types) as a side effect so
 that the global vocabulary registry is populated before any test in this
 directory runs.  Without this import the registry may be empty when tests run
 in isolation, causing TinyDB's record_to_object() to fall back to returning a
@@ -12,7 +12,7 @@ import pytest
 
 # noqa: F401 — imported for vocabulary registration side-effect
 from vultron.wire.as2.vocab.objects.vulnerability_case import (  # noqa: F401
-    VulnerabilityCase,
+    as_VulnerabilityCase,
 )
 from vultron.semantic_registry import extract_event
 

--- a/test/core/behaviors/report/nodes/conftest.py
+++ b/test/core/behaviors/report/nodes/conftest.py
@@ -31,7 +31,7 @@ from test.core.behaviors.bt_harness import BTTestScenario
 
 # noqa: F401 — imported for vocabulary registration side-effect
 from vultron.wire.as2.vocab.objects.vulnerability_case import (  # noqa: F401
-    VulnerabilityCase as _WireVulnerabilityCase,
+    as_VulnerabilityCase as _WireVulnerabilityCase,
 )
 
 

--- a/test/core/behaviors/report/test_received_report_trees.py
+++ b/test/core/behaviors/report/test_received_report_trees.py
@@ -67,7 +67,9 @@ from vultron.core.use_cases.received.report import (
     CreateReportReceivedUseCase,
     InvalidateReportReceivedUseCase,
 )
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -114,8 +116,8 @@ def _setup_case_with_participant(
     report_id: str = REPORT_ID,
     actor_id: str = ACTOR_ID,
     initial_rm: RM = RM.RECEIVED,
-) -> tuple[VulnerabilityCase, VultronParticipant]:
-    """Create and persist a VulnerabilityCase linked to a report.
+) -> tuple[as_VulnerabilityCase, VultronParticipant]:
+    """Create and persist a as_VulnerabilityCase linked to a report.
 
     Adds a CaseParticipant for *actor_id* so RM transition nodes can find
     the participant record.
@@ -138,7 +140,7 @@ def _setup_case_with_participant(
             )
         ],
     )
-    case = VulnerabilityCase(id_=CASE_ID, name="BT Test Case")
+    case = as_VulnerabilityCase(id_=CASE_ID, name="BT Test Case")
     case.vulnerability_reports.append(report_id)
     case.case_participants.append(participant.id_)
     case.actor_participant_index[actor_id] = participant.id_
@@ -277,7 +279,7 @@ class TestTransitionCaseParticipantRMtoClosed:
         result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
 
         assert result.status == Status.SUCCESS
-        updated_case = cast(VulnerabilityCase, dl.read(CASE_ID))
+        updated_case = cast(as_VulnerabilityCase, dl.read(CASE_ID))
         p_id = updated_case.actor_participant_index[ACTOR_ID]
         participant = cast(VultronParticipant, dl.read(p_id))
         assert participant.participant_statuses[-1].rm_state == RM.CLOSED
@@ -320,7 +322,7 @@ class TestTransitionCaseParticipantRMtoInvalid:
         result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
 
         assert result.status == Status.SUCCESS
-        updated_case = cast(VulnerabilityCase, dl.read(CASE_ID))
+        updated_case = cast(as_VulnerabilityCase, dl.read(CASE_ID))
         p_id = updated_case.actor_participant_index[ACTOR_ID]
         participant = cast(VultronParticipant, dl.read(p_id))
         assert participant.participant_statuses[-1].rm_state == RM.INVALID
@@ -532,7 +534,7 @@ class TestCloseReportReceivedTree:
         assert result.status == Status.SUCCESS
         assert _activity_stored(dl, ACTIVITY_ID)
 
-        updated_case = cast(VulnerabilityCase, dl.read(CASE_ID))
+        updated_case = cast(as_VulnerabilityCase, dl.read(CASE_ID))
         p_id = updated_case.actor_participant_index[ACTOR_ID]
         participant = cast(VultronParticipant, dl.read(p_id))
         assert participant.participant_statuses[-1].rm_state == RM.CLOSED
@@ -577,7 +579,7 @@ class TestCloseReportReceivedUseCase:
         CloseReportReceivedUseCase(dl, event).execute()
 
         assert _activity_stored(dl, ACTIVITY_ID)
-        updated_case = cast(VulnerabilityCase, dl.read(CASE_ID))
+        updated_case = cast(as_VulnerabilityCase, dl.read(CASE_ID))
         p_id = updated_case.actor_participant_index[ACTOR_ID]
         participant = cast(VultronParticipant, dl.read(p_id))
         assert participant.participant_statuses[-1].rm_state == RM.CLOSED
@@ -615,7 +617,7 @@ class TestInvalidateReportReceivedTree:
         assert result.status == Status.SUCCESS
         assert _activity_stored(dl, ACTIVITY_ID)
 
-        updated_case = cast(VulnerabilityCase, dl.read(CASE_ID))
+        updated_case = cast(as_VulnerabilityCase, dl.read(CASE_ID))
         p_id = updated_case.actor_participant_index[ACTOR_ID]
         participant = cast(VultronParticipant, dl.read(p_id))
         assert participant.participant_statuses[-1].rm_state == RM.INVALID
@@ -660,7 +662,7 @@ class TestInvalidateReportReceivedUseCase:
         InvalidateReportReceivedUseCase(dl, event).execute()
 
         assert _activity_stored(dl, ACTIVITY_ID)
-        updated_case = cast(VulnerabilityCase, dl.read(CASE_ID))
+        updated_case = cast(as_VulnerabilityCase, dl.read(CASE_ID))
         p_id = updated_case.actor_participant_index[ACTOR_ID]
         participant = cast(VultronParticipant, dl.read(p_id))
         assert participant.participant_statuses[-1].rm_state == RM.INVALID

--- a/test/core/behaviors/report/test_trigger_report_trees.py
+++ b/test/core/behaviors/report/test_trigger_report_trees.py
@@ -40,7 +40,7 @@ from vultron.errors import VultronInvalidStateTransitionError
 
 # noqa: F401 — vocabulary registration side-effect
 from vultron.wire.as2.vocab.objects.vulnerability_case import (  # noqa: F401
-    VulnerabilityCase,
+    as_VulnerabilityCase,
 )
 
 # ---------------------------------------------------------------------------

--- a/test/core/behaviors/sender/nodes/test_actions.py
+++ b/test/core/behaviors/sender/nodes/test_actions.py
@@ -35,7 +35,9 @@ from vultron.wire.as2.vocab.objects.case_participant import (
     FinderParticipant,
     VendorParticipant,
 )
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 ACTOR_ID = "https://example.org/actors/finder"
 CASE_ACTOR_ID = "https://example.org/actors/case-actor"
@@ -62,8 +64,8 @@ def _make_case_with_case_manager(
     store: SqliteDataLayer,
     actor_id: str,
     case_actor_id: str,
-) -> tuple[VulnerabilityCase, VendorParticipant]:
-    case = VulnerabilityCase(name="Test Case")
+) -> tuple[as_VulnerabilityCase, VendorParticipant]:
+    case = as_VulnerabilityCase(name="Test Case")
     finder_participant = FinderParticipant(
         attributed_to=actor_id,
         context=case.id_,
@@ -114,7 +116,7 @@ class TestResolveCaseManagerNode:
 
     def test_failure_when_no_case_manager(self, dl, bridge):
         store, actor = dl
-        case = VulnerabilityCase(name="No Manager Case")
+        case = as_VulnerabilityCase(name="No Manager Case")
         participant = FinderParticipant(
             attributed_to=actor.id_,
             context=case.id_,

--- a/test/core/behaviors/sender/test_sender_side_bt.py
+++ b/test/core/behaviors/sender/test_sender_side_bt.py
@@ -36,7 +36,9 @@ from vultron.wire.as2.vocab.objects.case_participant import (
     FinderParticipant,
     VendorParticipant,
 )
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 CASE_ACTOR_ID = "https://example.org/actors/case-actor"
 CASE_ID = "https://example.org/cases/test-case"
@@ -62,8 +64,8 @@ def bridge(dl):
 def _make_case_with_case_manager(
     store: SqliteDataLayer,
     actor_id: str,
-) -> VulnerabilityCase:
-    case = VulnerabilityCase(name="Test Case")
+) -> as_VulnerabilityCase:
+    case = as_VulnerabilityCase(name="Test Case")
     finder_participant = FinderParticipant(
         attributed_to=actor_id,
         context=case.id_,
@@ -120,7 +122,7 @@ class TestSenderSideBT:
 
     def test_bt_failure_when_case_manager_absent(self, dl, bridge):
         store, actor = dl
-        case = VulnerabilityCase(name="No Manager")
+        case = as_VulnerabilityCase(name="No Manager")
         participant = FinderParticipant(
             attributed_to=actor.id_,
             context=case.id_,

--- a/test/core/behaviors/status/nodes/test_append.py
+++ b/test/core/behaviors/status/nodes/test_append.py
@@ -38,9 +38,11 @@ from vultron.core.behaviors.status.nodes.append import (
     ValidateRMTransitionNode,
 )
 from vultron.enums.roles import CVDRole
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.case_status import ParticipantStatus
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.case_status import as_ParticipantStatus
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 ACTOR_ID = "https://example.org/actors/vendor"
 CASE_MANAGER_ID = "https://example.org/actors/case-actor"
@@ -67,7 +69,7 @@ def bridge(dl):
 
 @pytest.fixture
 def participant():
-    return CaseParticipant(
+    return as_CaseParticipant(
         id_=PARTICIPANT_ID,
         context=CASE_ID,
         attributed_to=ACTOR_ID,
@@ -77,18 +79,18 @@ def participant():
 
 @pytest.fixture
 def status_obj():
-    return ParticipantStatus(id_=STATUS_ID, context=CASE_ID)
+    return as_ParticipantStatus(id_=STATUS_ID, context=CASE_ID)
 
 
 @pytest.fixture
 def populated_dl(dl, participant, status_obj):
-    case_manager_participant = CaseParticipant(
+    case_manager_participant = as_CaseParticipant(
         id_=CM_PARTICIPANT_ID,
         context=CASE_ID,
         attributed_to=CASE_MANAGER_ID,
         case_roles=[CVDRole.CASE_MANAGER],
     )
-    case = VulnerabilityCase(id_=CASE_ID, name="Test Case")
+    case = as_VulnerabilityCase(id_=CASE_ID, name="Test Case")
     case.add_participant(participant)
     case.add_participant(case_manager_participant)
     dl.create(case)

--- a/test/core/behaviors/status/nodes/test_case_status.py
+++ b/test/core/behaviors/status/nodes/test_case_status.py
@@ -35,8 +35,10 @@ from vultron.core.behaviors.status.nodes.case_status import (
     ValidateCaseStatusTransitionNode,
 )
 from vultron.core.states.em import EM
-from vultron.wire.as2.vocab.objects.case_status import CaseStatus
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_status import as_CaseStatus
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 ACTOR_ID = "https://example.org/actors/vendor"
 CASE_ID = "https://example.org/cases/case-01"
@@ -61,12 +63,12 @@ def bridge(dl):
 
 @pytest.fixture
 def case():
-    return VulnerabilityCase(id_=CASE_ID, name="Test Case")
+    return as_VulnerabilityCase(id_=CASE_ID, name="Test Case")
 
 
 @pytest.fixture
 def status_obj():
-    return CaseStatus(id_=STATUS_ID, context=CASE_ID)
+    return as_CaseStatus(id_=STATUS_ID, context=CASE_ID)
 
 
 @pytest.fixture
@@ -145,9 +147,9 @@ class TestValidateCaseStatusTransitionNode:
         assert result.status == Status.SUCCESS
 
     def test_valid_em_transition_passes(self, populated_bridge, status_obj):
-        # Default case has a CaseStatus with em_state=EM.NONE;
+        # Default case has a as_CaseStatus with em_state=EM.NONE;
         # NONE → PROPOSED is a valid forward transition.
-        new_status = CaseStatus(
+        new_status = as_CaseStatus(
             id_=STATUS2_ID, context=CASE_ID, em_state=EM.PROPOSED
         )
         populated_bridge.datalayer.save(new_status)
@@ -163,9 +165,9 @@ class TestValidateCaseStatusTransitionNode:
         assert result.status == Status.SUCCESS
 
     def test_invalid_em_transition_fails(self, populated_bridge):
-        # Default case has a CaseStatus with em_state=EM.NONE;
+        # Default case has a as_CaseStatus with em_state=EM.NONE;
         # NONE → ACTIVE is invalid (skips PROPOSED).
-        new_status = CaseStatus(
+        new_status = as_CaseStatus(
             id_=STATUS2_ID, context=CASE_ID, em_state=EM.ACTIVE
         )
         populated_bridge.datalayer.save(new_status)

--- a/test/core/behaviors/status/nodes/test_conditions.py
+++ b/test/core/behaviors/status/nodes/test_conditions.py
@@ -29,9 +29,11 @@ from vultron.core.behaviors.status.nodes.conditions import (
     VerifySenderIsParticipantNode,
 )
 from vultron.enums.roles import CVDRole
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.case_status import ParticipantStatus
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.case_status import as_ParticipantStatus
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 ACTOR_ID = "https://example.org/actors/vendor"
 OUTSIDER_ID = "https://example.org/actors/outsider"
@@ -59,7 +61,7 @@ def bridge(dl):
 
 @pytest.fixture
 def participant():
-    return CaseParticipant(
+    return as_CaseParticipant(
         id_=PARTICIPANT_ID,
         context=CASE_ID,
         attributed_to=ACTOR_ID,
@@ -69,7 +71,7 @@ def participant():
 
 @pytest.fixture
 def case_manager_participant():
-    return CaseParticipant(
+    return as_CaseParticipant(
         id_=CM_PARTICIPANT_ID,
         context=CASE_ID,
         attributed_to=CASE_MANAGER_ID,
@@ -79,12 +81,12 @@ def case_manager_participant():
 
 @pytest.fixture
 def status_obj():
-    return ParticipantStatus(id_=STATUS_ID, context=CASE_ID)
+    return as_ParticipantStatus(id_=STATUS_ID, context=CASE_ID)
 
 
 @pytest.fixture
 def populated_dl(dl, participant, case_manager_participant, status_obj):
-    case = VulnerabilityCase(id_=CASE_ID, name="Test Case")
+    case = as_VulnerabilityCase(id_=CASE_ID, name="Test Case")
     case.add_participant(participant)
     case.add_participant(case_manager_participant)
     dl.create(case)

--- a/test/core/behaviors/status/nodes/test_lifecycle.py
+++ b/test/core/behaviors/status/nodes/test_lifecycle.py
@@ -32,9 +32,11 @@ from vultron.core.behaviors.status.nodes.lifecycle import (
     PublicDisclosureBranchNode,
 )
 from vultron.enums.roles import CVDRole
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.case_status import ParticipantStatus
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.case_status import as_ParticipantStatus
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 ACTOR_ID = "https://example.org/actors/vendor"
 CASE_MANAGER_ID = "https://example.org/actors/case-actor"
@@ -56,7 +58,7 @@ def dl():
 
 @pytest.fixture
 def participant():
-    return CaseParticipant(
+    return as_CaseParticipant(
         id_=PARTICIPANT_ID,
         context=CASE_ID,
         attributed_to=ACTOR_ID,
@@ -66,18 +68,18 @@ def participant():
 
 @pytest.fixture
 def status_obj():
-    return ParticipantStatus(id_=STATUS_ID, context=CASE_ID)
+    return as_ParticipantStatus(id_=STATUS_ID, context=CASE_ID)
 
 
 @pytest.fixture
 def populated_dl(dl, participant, status_obj):
-    case_manager_participant = CaseParticipant(
+    case_manager_participant = as_CaseParticipant(
         id_=CM_PARTICIPANT_ID,
         context=CASE_ID,
         attributed_to=CASE_MANAGER_ID,
         case_roles=[CVDRole.CASE_MANAGER],
     )
-    case = VulnerabilityCase(id_=CASE_ID, name="Test Case")
+    case = as_VulnerabilityCase(id_=CASE_ID, name="Test Case")
     case.add_participant(participant)
     case.add_participant(case_manager_participant)
     dl.create(case)

--- a/test/core/behaviors/status/test_add_case_status_bt.py
+++ b/test/core/behaviors/status/test_add_case_status_bt.py
@@ -48,8 +48,10 @@ from vultron.core.use_cases.received.status import (
     AddCaseStatusToCaseReceivedUseCase,
 )
 from vultron.wire.as2.factories import add_status_to_case_activity
-from vultron.wire.as2.vocab.objects.case_status import CaseStatus
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_status import as_CaseStatus
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -84,12 +86,12 @@ def bridge(dl):
 
 @pytest.fixture
 def case():
-    return VulnerabilityCase(id_=CASE_ID, name="BT Case")
+    return as_VulnerabilityCase(id_=CASE_ID, name="BT Case")
 
 
 @pytest.fixture
 def status_obj():
-    return CaseStatus(id_=STATUS_ID, context=CASE_ID)
+    return as_CaseStatus(id_=STATUS_ID, context=CASE_ID)
 
 
 @pytest.fixture
@@ -123,7 +125,7 @@ class TestCheckCaseStatusIdempotencyNode:
     def test_duplicate_status_fails_with_sentinel(self, populated_dl):
         """Status already present → FAILURE with CASE_STATUS_ALREADY_PRESENT."""
         # Pre-load the status onto the case
-        case = cast(VulnerabilityCase, populated_dl.read(CASE_ID))
+        case = cast(as_VulnerabilityCase, populated_dl.read(CASE_ID))
         status = populated_dl.read(STATUS_ID)
         case.case_statuses.append(status)
         populated_dl.save(case)
@@ -167,8 +169,8 @@ class TestValidateCaseStatusTransitionNode:
 
     def test_valid_em_transition_succeeds(self, dl):
         """NONE → PROPOSED is a valid EM transition → SUCCESS."""
-        case = VulnerabilityCase(id_=CASE_ID, name="EM Valid")
-        initial = CaseStatus(
+        case = as_VulnerabilityCase(id_=CASE_ID, name="EM Valid")
+        initial = as_CaseStatus(
             id_=f"{CASE_ID}/statuses/init",
             context=CASE_ID,
             em_state=EM.NONE,
@@ -176,7 +178,7 @@ class TestValidateCaseStatusTransitionNode:
         case.case_statuses.append(initial)
         dl.create(case)
 
-        good_status = CaseStatus(
+        good_status = as_CaseStatus(
             id_=STATUS_ID, context=CASE_ID, em_state=EM.PROPOSED
         )
         dl.create(good_status)
@@ -192,8 +194,8 @@ class TestValidateCaseStatusTransitionNode:
 
     def test_invalid_em_transition_fails(self, dl):
         """NONE → ACTIVE skips PROPOSED — invalid EM transition → FAILURE."""
-        case = VulnerabilityCase(id_=CASE_ID, name="EM Invalid")
-        initial = CaseStatus(
+        case = as_VulnerabilityCase(id_=CASE_ID, name="EM Invalid")
+        initial = as_CaseStatus(
             id_=f"{CASE_ID}/statuses/init",
             context=CASE_ID,
             em_state=EM.NONE,
@@ -201,7 +203,7 @@ class TestValidateCaseStatusTransitionNode:
         case.case_statuses.append(initial)
         dl.create(case)
 
-        bad_status = CaseStatus(
+        bad_status = as_CaseStatus(
             id_=STATUS_ID, context=CASE_ID, em_state=EM.ACTIVE
         )
         dl.create(bad_status)
@@ -217,12 +219,12 @@ class TestValidateCaseStatusTransitionNode:
 
     def test_invalid_pxa_transition_fails(self, dl):
         """pxa → PXA skips intermediate steps — invalid PXA transition → FAILURE."""
-        # The default seed CaseStatus already has pxa_state=CS_pxa.pxa.
+        # The default seed as_CaseStatus already has pxa_state=CS_pxa.pxa.
         # A direct jump from pxa to PXA (all bits set at once) is invalid.
-        case = VulnerabilityCase(id_=CASE_ID, name="PXA Invalid")
+        case = as_VulnerabilityCase(id_=CASE_ID, name="PXA Invalid")
         dl.create(case)
 
-        bad_status = CaseStatus(
+        bad_status = as_CaseStatus(
             id_=STATUS_ID, context=CASE_ID, pxa_state=CS_pxa.PXA
         )
         dl.create(bad_status)
@@ -264,7 +266,7 @@ class TestAppendCaseStatusToCaseNode:
         result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
         assert result.status == Status.SUCCESS
 
-        case = cast(VulnerabilityCase, populated_dl.read(CASE_ID))
+        case = cast(as_VulnerabilityCase, populated_dl.read(CASE_ID))
         status_ids = [getattr(s, "id_", s) for s in case.case_statuses]
         assert STATUS_ID in status_ids
 
@@ -280,10 +282,10 @@ class TestAppendCaseStatusToCaseNode:
 
     def test_status_not_in_dl_uses_fallback(self, dl):
         """Status not in DL; fallback inline object is saved and used."""
-        case = VulnerabilityCase(id_=CASE_ID, name="Fallback Case")
+        case = as_VulnerabilityCase(id_=CASE_ID, name="Fallback Case")
         dl.create(case)
 
-        inline_status = CaseStatus(id_=STATUS_ID, context=CASE_ID)
+        inline_status = as_CaseStatus(id_=STATUS_ID, context=CASE_ID)
         bridge = BTBridge(datalayer=dl)
         node = AppendCaseStatusToCaseNode(
             case_id=CASE_ID,
@@ -293,7 +295,7 @@ class TestAppendCaseStatusToCaseNode:
         result = bridge.execute_with_setup(tree=node, actor_id=ACTOR_ID)
         assert result.status == Status.SUCCESS
 
-        case = cast(VulnerabilityCase, dl.read(CASE_ID))
+        case = cast(as_VulnerabilityCase, dl.read(CASE_ID))
         status_ids = [getattr(s, "id_", s) for s in case.case_statuses]
         assert STATUS_ID in status_ids
 
@@ -306,8 +308,8 @@ class TestAppendCaseStatusToCaseNode:
 class TestAddCaseStatusTree:
     def test_happy_path_appends_status(self, populated_dl, make_payload):
         """Full Sequence: new status is appended to case."""
-        status_obj = cast(CaseStatus, populated_dl.read(STATUS_ID))
-        case_obj = cast(VulnerabilityCase, populated_dl.read(CASE_ID))
+        status_obj = cast(as_CaseStatus, populated_dl.read(STATUS_ID))
+        case_obj = cast(as_VulnerabilityCase, populated_dl.read(CASE_ID))
 
         activity = add_status_to_case_activity(
             status_obj, target=case_obj, actor=ACTOR_ID
@@ -319,7 +321,7 @@ class TestAddCaseStatusTree:
         result = bridge.execute_with_setup(tree=tree, actor_id=ACTOR_ID)
         assert result.status == Status.SUCCESS
 
-        case = cast(VulnerabilityCase, populated_dl.read(CASE_ID))
+        case = cast(as_VulnerabilityCase, populated_dl.read(CASE_ID))
         status_ids = [getattr(s, "id_", s) for s in case.case_statuses]
         assert STATUS_ID in status_ids
 
@@ -328,13 +330,13 @@ class TestAddCaseStatusTree:
     ):
         """Duplicate status → BT FAILURE with CASE_STATUS_ALREADY_PRESENT."""
         # Pre-load the status onto the case
-        case = cast(VulnerabilityCase, populated_dl.read(CASE_ID))
+        case = cast(as_VulnerabilityCase, populated_dl.read(CASE_ID))
         status = populated_dl.read(STATUS_ID)
         case.case_statuses.append(status)
         populated_dl.save(case)
 
-        status_obj = cast(CaseStatus, populated_dl.read(STATUS_ID))
-        case_obj = cast(VulnerabilityCase, populated_dl.read(CASE_ID))
+        status_obj = cast(as_CaseStatus, populated_dl.read(STATUS_ID))
+        case_obj = cast(as_VulnerabilityCase, populated_dl.read(CASE_ID))
 
         activity = add_status_to_case_activity(
             status_obj, target=case_obj, actor=ACTOR_ID
@@ -349,8 +351,8 @@ class TestAddCaseStatusTree:
 
     def test_invalid_em_transition_fails(self, dl, make_payload):
         """Invalid EM transition → BT FAILURE; status not appended."""
-        case = VulnerabilityCase(id_=CASE_ID, name="EM Guard")
-        initial = CaseStatus(
+        case = as_VulnerabilityCase(id_=CASE_ID, name="EM Guard")
+        initial = as_CaseStatus(
             id_=f"{CASE_ID}/statuses/init",
             context=CASE_ID,
             em_state=EM.NONE,
@@ -358,7 +360,7 @@ class TestAddCaseStatusTree:
         case.case_statuses.append(initial)
         dl.create(case)
 
-        bad_status = CaseStatus(
+        bad_status = as_CaseStatus(
             id_=STATUS_ID, context=CASE_ID, em_state=EM.ACTIVE
         )
         dl.create(bad_status)
@@ -373,7 +375,7 @@ class TestAddCaseStatusTree:
         result = bridge.execute_with_setup(tree=tree, actor_id=ACTOR_ID)
         assert result.status == Status.FAILURE
 
-        updated_case = cast(VulnerabilityCase, dl.read(CASE_ID))
+        updated_case = cast(as_VulnerabilityCase, dl.read(CASE_ID))
         status_ids = [getattr(s, "id_", s) for s in updated_case.case_statuses]
         assert STATUS_ID not in status_ids
 
@@ -387,8 +389,8 @@ class TestAddCaseStatusToCaseReceivedUseCase:
     def test_use_case_appends_status(self, make_payload):
         """Use case succeeds: status is appended to case."""
         dl = SqliteDataLayer("sqlite:///:memory:")
-        case = VulnerabilityCase(id_=CASE_ID, name="UC Case")
-        status_obj = CaseStatus(id_=STATUS_ID, context=CASE_ID)
+        case = as_VulnerabilityCase(id_=CASE_ID, name="UC Case")
+        status_obj = as_CaseStatus(id_=STATUS_ID, context=CASE_ID)
         dl.create(case)
         dl.create(status_obj)
 
@@ -399,7 +401,7 @@ class TestAddCaseStatusToCaseReceivedUseCase:
 
         AddCaseStatusToCaseReceivedUseCase(dl, event).execute()
 
-        updated_case = cast(VulnerabilityCase, dl.read(CASE_ID))
+        updated_case = cast(as_VulnerabilityCase, dl.read(CASE_ID))
         status_ids = [getattr(s, "id_", s) for s in updated_case.case_statuses]
         assert STATUS_ID in status_ids
 
@@ -408,8 +410,8 @@ class TestAddCaseStatusToCaseReceivedUseCase:
         import logging
 
         dl = SqliteDataLayer("sqlite:///:memory:")
-        case = VulnerabilityCase(id_=CASE_ID, name="Idempotent Case")
-        status_obj = CaseStatus(id_=STATUS_ID, context=CASE_ID)
+        case = as_VulnerabilityCase(id_=CASE_ID, name="Idempotent Case")
+        status_obj = as_CaseStatus(id_=STATUS_ID, context=CASE_ID)
         case.case_statuses.append(status_obj)
         dl.create(case)
         dl.create(status_obj)
@@ -441,8 +443,8 @@ class TestAddCaseStatusToCaseReceivedUseCase:
         import logging
 
         dl = SqliteDataLayer("sqlite:///:memory:")
-        case = VulnerabilityCase(id_=CASE_ID, name="EM Guard Case")
-        initial = CaseStatus(
+        case = as_VulnerabilityCase(id_=CASE_ID, name="EM Guard Case")
+        initial = as_CaseStatus(
             id_=f"{CASE_ID}/statuses/init",
             context=CASE_ID,
             em_state=EM.NONE,
@@ -450,7 +452,7 @@ class TestAddCaseStatusToCaseReceivedUseCase:
         case.case_statuses.append(initial)
         dl.create(case)
 
-        bad_status = CaseStatus(
+        bad_status = as_CaseStatus(
             id_=STATUS_ID, context=CASE_ID, em_state=EM.ACTIVE
         )
         dl.create(bad_status)
@@ -471,7 +473,7 @@ class TestAddCaseStatusToCaseReceivedUseCase:
             for m in warn_msgs
         ), "Expected WARNING for invalid transition"
 
-        updated_case = cast(VulnerabilityCase, dl.read(CASE_ID))
+        updated_case = cast(as_VulnerabilityCase, dl.read(CASE_ID))
         status_ids = [getattr(s, "id_", s) for s in updated_case.case_statuses]
         assert STATUS_ID not in status_ids
 
@@ -482,11 +484,11 @@ class TestAddCaseStatusToCaseReceivedUseCase:
         import logging
 
         dl = SqliteDataLayer("sqlite:///:memory:")
-        case = VulnerabilityCase(id_=CASE_ID, name="Missing ID Case")
+        case = as_VulnerabilityCase(id_=CASE_ID, name="Missing ID Case")
         dl.create(case)
 
         # Construct a status with no ID to force status_id=None via factory
-        status_obj = CaseStatus(id_=STATUS_ID, context=CASE_ID)
+        status_obj = as_CaseStatus(id_=STATUS_ID, context=CASE_ID)
         activity = add_status_to_case_activity(
             status_obj, target=case, actor=ACTOR_ID
         )

--- a/test/core/behaviors/status/test_add_participant_status_bt.py
+++ b/test/core/behaviors/status/test_add_participant_status_bt.py
@@ -50,9 +50,11 @@ from vultron.core.behaviors.status.nodes import (
 from vultron.core.states.rm import RM
 from vultron.enums.roles import CVDRole
 from vultron.wire.as2.factories import add_status_to_participant_activity
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.case_status import ParticipantStatus
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.case_status import as_ParticipantStatus
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -90,7 +92,7 @@ def bridge(dl):
 
 @pytest.fixture
 def status_obj():
-    return ParticipantStatus(
+    return as_ParticipantStatus(
         id_=STATUS_ID,
         context=CASE_ID,
     )
@@ -98,7 +100,7 @@ def status_obj():
 
 @pytest.fixture
 def participant():
-    return CaseParticipant(
+    return as_CaseParticipant(
         id_=PARTICIPANT_ID,
         context=CASE_ID,
         attributed_to=ACTOR_ID,
@@ -108,7 +110,7 @@ def participant():
 
 @pytest.fixture
 def case_manager_participant():
-    return CaseParticipant(
+    return as_CaseParticipant(
         id_=CM_PARTICIPANT_ID,
         context=CASE_ID,
         attributed_to=CASE_MANAGER_ID,
@@ -118,8 +120,8 @@ def case_manager_participant():
 
 @pytest.fixture
 def case(participant, case_manager_participant):
-    """VulnerabilityCase with vendor and Case Manager participants."""
-    obj = VulnerabilityCase(id_=CASE_ID, name="Test Case")
+    """as_VulnerabilityCase with vendor and Case Manager participants."""
+    obj = as_VulnerabilityCase(id_=CASE_ID, name="Test Case")
     obj.add_participant(participant)
     obj.add_participant(case_manager_participant)
     return obj
@@ -343,7 +345,7 @@ class TestValidateRMTransitionNode:
     ):
         """Backwards RM transition (CLOSED → RECEIVED) is rejected."""
         p = populated_dl.read(PARTICIPANT_ID)
-        closed_status = ParticipantStatus(
+        closed_status = as_ParticipantStatus(
             id_=f"{STATUS_ID}/closed",
             context=CASE_ID,
             rm_state=RM.CLOSED,
@@ -352,7 +354,7 @@ class TestValidateRMTransitionNode:
         populated_dl.save(p)
         populated_dl.create(closed_status)
 
-        regressed_status = ParticipantStatus(
+        regressed_status = as_ParticipantStatus(
             id_=f"{STATUS_ID}/regressed",
             context=CASE_ID,
             rm_state=RM.RECEIVED,
@@ -381,7 +383,7 @@ class TestValidateRMTransitionNode:
     ):
         """RM.CLOSED is terminal; CLOSED -> CLOSED rewrites are rejected."""
         p = populated_dl.read(PARTICIPANT_ID)
-        closed_status = ParticipantStatus(
+        closed_status = as_ParticipantStatus(
             id_=f"{STATUS_ID}/closed",
             context=CASE_ID,
             rm_state=RM.CLOSED,
@@ -390,7 +392,7 @@ class TestValidateRMTransitionNode:
         populated_dl.save(p)
         populated_dl.create(closed_status)
 
-        duplicate_closed_status = ParticipantStatus(
+        duplicate_closed_status = as_ParticipantStatus(
             id_=f"{STATUS_ID}/closed-dup",
             context=CASE_ID,
             rm_state=RM.CLOSED,
@@ -417,7 +419,7 @@ class TestValidateRMTransitionNode:
     def test_accepts_forward_jump(self, populated_dl, populated_bridge):
         """Non-adjacent forward RM jump is accepted (sender authoritative)."""
         p = populated_dl.read(PARTICIPANT_ID)
-        received_status = ParticipantStatus(
+        received_status = as_ParticipantStatus(
             id_=f"{STATUS_ID}/received",
             context=CASE_ID,
             rm_state=RM.RECEIVED,
@@ -426,7 +428,7 @@ class TestValidateRMTransitionNode:
         populated_dl.save(p)
         populated_dl.create(received_status)
 
-        accepted_status = ParticipantStatus(
+        accepted_status = as_ParticipantStatus(
             id_=f"{STATUS_ID}/accepted",
             context=CASE_ID,
             rm_state=RM.ACCEPTED,
@@ -542,7 +544,7 @@ class TestAppendParticipantStatusSubtree:
         self, populated_dl, populated_bridge, participant
     ):
         """A backwards RM transition (CLOSED → RECEIVED) is rejected."""
-        closed_status = ParticipantStatus(
+        closed_status = as_ParticipantStatus(
             id_=f"{STATUS_ID}/prev",
             context=CASE_ID,
             rm_state=RM.CLOSED,
@@ -551,7 +553,7 @@ class TestAppendParticipantStatusSubtree:
         populated_dl.save(participant)
         populated_dl.create(closed_status)
 
-        regressed_status = ParticipantStatus(
+        regressed_status = as_ParticipantStatus(
             id_=f"{STATUS_ID}/regressed",
             context=CASE_ID,
             rm_state=RM.RECEIVED,
@@ -572,7 +574,7 @@ class TestAppendParticipantStatusSubtree:
         self, populated_dl, populated_bridge, participant
     ):
         """Repeated CLOSED updates are rejected and do not append new status."""
-        closed_status = ParticipantStatus(
+        closed_status = as_ParticipantStatus(
             id_=f"{STATUS_ID}/prev",
             context=CASE_ID,
             rm_state=RM.CLOSED,
@@ -581,7 +583,7 @@ class TestAppendParticipantStatusSubtree:
         populated_dl.save(participant)
         populated_dl.create(closed_status)
 
-        duplicate_closed = ParticipantStatus(
+        duplicate_closed = as_ParticipantStatus(
             id_=f"{STATUS_ID}/closed-dup",
             context=CASE_ID,
             rm_state=RM.CLOSED,
@@ -607,7 +609,7 @@ class TestAppendParticipantStatusSubtree:
         self, populated_dl, populated_bridge, participant
     ):
         """A non-adjacent but forward RM jump is accepted (sender authoritative)."""
-        received_status = ParticipantStatus(
+        received_status = as_ParticipantStatus(
             id_=f"{STATUS_ID}/received",
             context=CASE_ID,
             rm_state=RM.RECEIVED,
@@ -616,7 +618,7 @@ class TestAppendParticipantStatusSubtree:
         populated_dl.save(participant)
         populated_dl.create(received_status)
 
-        accepted_status = ParticipantStatus(
+        accepted_status = as_ParticipantStatus(
             id_=f"{STATUS_ID}/accepted",
             context=CASE_ID,
             rm_state=RM.ACCEPTED,
@@ -668,9 +670,9 @@ class TestPublicDisclosureBranchNode:
     ):
         """CASE_MANAGER sender (not CASE_OWNER) → skips teardown, SUCCESS."""
         from vultron.core.states.cs import CS_pxa
-        from vultron.wire.as2.vocab.objects.case_status import CaseStatus
+        from vultron.wire.as2.vocab.objects.case_status import as_CaseStatus
 
-        cs = CaseStatus()
+        cs = as_CaseStatus()
         cs.pxa_state = CS_pxa.Pxa  # public-aware
         status_obj.case_status = cs
         populated_dl.save(status_obj)
@@ -696,11 +698,13 @@ class TestPublicDisclosureBranchNode:
         """
         from vultron.core.states.cs import CS_pxa
         from vultron.core.states.em import EM
-        from vultron.wire.as2.vocab.objects.case_status import CaseStatus
-        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+        from vultron.wire.as2.vocab.objects.case_status import as_CaseStatus
+        from vultron.wire.as2.vocab.objects.embargo_event import (
+            as_EmbargoEvent,
+        )
 
         # Give the case an active embargo in ACTIVE state
-        embargo = EmbargoEvent(
+        embargo = as_EmbargoEvent(
             id_=f"{CASE_ID}/embargo_events/e1", context=CASE_ID
         )
         case.active_embargo = embargo.id_
@@ -708,7 +712,7 @@ class TestPublicDisclosureBranchNode:
         populated_dl.create(embargo)
         populated_dl.save(case)
 
-        cs = CaseStatus()
+        cs = as_CaseStatus()
         cs.pxa_state = CS_pxa.Pxa  # public-aware
         status_obj.case_status = cs
         populated_dl.save(status_obj)
@@ -728,11 +732,11 @@ class TestPublicDisclosureBranchNode:
         from typing import cast as c
 
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         # State was still applied before the broadcast attempt
-        updated = c(VulnerabilityCase, populated_dl.read(CASE_ID))
+        updated = c(as_VulnerabilityCase, populated_dl.read(CASE_ID))
         assert updated.current_status.em_state == EM.EXITED
         assert updated.active_embargo is None
 
@@ -758,7 +762,7 @@ class TestAutoCloseBranchNode:
         case_manager_participant,
     ):
         """When all CVD participants have RM.CLOSED, auto-close branch logs it."""
-        closed_status = ParticipantStatus(
+        closed_status = as_ParticipantStatus(
             id_=f"{STATUS_ID}/closed",
             context=CASE_ID,
             rm_state=RM.CLOSED,
@@ -792,12 +796,12 @@ class TestAddParticipantStatusTree:
     ):
         """End-to-end: known sender → all five steps succeed."""
         activity = add_status_to_participant_activity(
-            status=ParticipantStatus(id_=STATUS_ID, context=CASE_ID),
-            target=CaseParticipant(
+            status=as_ParticipantStatus(id_=STATUS_ID, context=CASE_ID),
+            target=as_CaseParticipant(
                 id_=PARTICIPANT_ID, context=CASE_ID, attributed_to=ACTOR_ID
             ),
             actor=ACTOR_ID,
-            context=VulnerabilityCase(id_=CASE_ID, name="Test"),
+            context=as_VulnerabilityCase(id_=CASE_ID, name="Test"),
         )
         event = make_payload(activity)
         bridge = BTBridge(datalayer=populated_dl)
@@ -817,12 +821,12 @@ class TestAddParticipantStatusTree:
     ):
         """Unknown sender → VerifySenderIsParticipantNode fails, tree halts."""
         activity = add_status_to_participant_activity(
-            status=ParticipantStatus(id_=STATUS_ID, context=CASE_ID),
-            target=CaseParticipant(
+            status=as_ParticipantStatus(id_=STATUS_ID, context=CASE_ID),
+            target=as_CaseParticipant(
                 id_=PARTICIPANT_ID, context=CASE_ID, attributed_to=OUTSIDER_ID
             ),
             actor=OUTSIDER_ID,
-            context=VulnerabilityCase(id_=CASE_ID, name="Test"),
+            context=as_VulnerabilityCase(id_=CASE_ID, name="Test"),
         )
         event = make_payload(activity)
         bridge = BTBridge(datalayer=populated_dl)

--- a/test/core/behaviors/sync/nodes/conftest.py
+++ b/test/core/behaviors/sync/nodes/conftest.py
@@ -17,7 +17,7 @@ from vultron.core.behaviors.sync.nodes.chain import _to_persistable_entry
 from vultron.semantic_registry import extract_event
 from vultron.wire.as2.factories import announce_log_entry_activity
 from vultron.wire.as2.vocab.objects.case_ledger_entry import (
-    CaseLedgerEntry as WireCaseLedgerEntry,
+    as_CaseLedgerEntry as WireCaseLedgerEntry,
 )
 
 OWNER_ACTOR_ID = "https://example.org/actors/vendor"

--- a/test/core/behaviors/sync/nodes/test_effects.py
+++ b/test/core/behaviors/sync/nodes/test_effects.py
@@ -2,7 +2,7 @@
 """Regression tests for ApplyParticipantStatusFromLedgerNode (effects.py).
 
 Covers the critical round-trip serialization bug: a CORE ParticipantStatus
-appended directly to CaseParticipant.participant_statuses was serialized with
+appended directly to as_CaseParticipant.participant_statuses was serialized with
 default field values by Pydantic because the declared list element type
 (WireParticipantStatus) governed serialization rather than the actual runtime
 type.  The fix reads the saved status back from the DataLayer (which
@@ -37,7 +37,7 @@ from vultron.core.models.case_ledger import (
 )
 from vultron.core.states.cs import CS_vfd
 from vultron.core.states.rm import RM
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
 
 _FIXED_CREATED_AT = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
 CASE_GENESIS_HASH = compute_genesis_hash(
@@ -51,8 +51,8 @@ STATUS_ID = f"urn:uuid:{uuid.uuid4()}"
 
 def _make_participant(
     participant_id: str = VENDOR_PARTICIPANT_ID,
-) -> CaseParticipant:
-    return CaseParticipant(
+) -> as_CaseParticipant:
+    return as_CaseParticipant(
         id_=participant_id,
         attributed_to=VENDOR_ACTOR_ID,
         context=CASE_ID,
@@ -68,7 +68,7 @@ def _make_participant_status_snapshot(
     """Return a payload_snapshot dict as produced by build_activity_payload_snapshot.
 
     Uses camelCase keys (wire/alias format) matching how the Case Actor builds
-    the snapshot from an Add(ParticipantStatus, CaseParticipant) activity.
+    the snapshot from an Add(ParticipantStatus, as_CaseParticipant) activity.
     """
     return {
         "object": {
@@ -147,7 +147,7 @@ def test_apply_participant_status_roundtrip_preserves_vfd_state(
     values.  After the fix the saved participant must have the correct vfd_state
     from the ledger entry payload snapshot.
 
-    CaseParticipant always auto-creates one default ParticipantStatus
+    as_CaseParticipant always auto-creates one default ParticipantStatus
     (RM.START, CS_vfd.vfd) on construction.  After applying the ledger entry,
     the participant has the initial default PLUS the new status.  The
     regression manifests as the new status carrying default vfd/rm values
@@ -174,7 +174,7 @@ def test_apply_participant_status_roundtrip_preserves_vfd_state(
 
     assert result.status == Status.SUCCESS
 
-    updated = cast(CaseParticipant, datalayer.read(participant.id_))
+    updated = cast(as_CaseParticipant, datalayer.read(participant.id_))
     assert (
         updated is not None
     ), "Participant must still be readable after status update"
@@ -218,7 +218,7 @@ def test_apply_participant_status_idempotent(
         )
         assert result.status == Status.SUCCESS
 
-    updated = cast(CaseParticipant, datalayer.read(participant.id_))
+    updated = cast(as_CaseParticipant, datalayer.read(participant.id_))
     assert updated is not None
     assert (
         len(updated.participant_statuses) == initial_count + 1

--- a/test/core/behaviors/sync/nodes/test_replay.py
+++ b/test/core/behaviors/sync/nodes/test_replay.py
@@ -28,7 +28,7 @@ from vultron.core.ports.sync_activity import SyncActivityPort
 from vultron.semantic_registry import extract_event
 from vultron.wire.as2.factories import reject_log_entry_activity
 from vultron.wire.as2.vocab.objects.case_ledger_entry import (
-    CaseLedgerEntry as WireCaseLedgerEntry,
+    as_CaseLedgerEntry as WireCaseLedgerEntry,
 )
 
 _ZERO_HASH: str = "0" * 64  # arbitrary hash for test chains

--- a/test/core/behaviors/sync/test_announce_tree.py
+++ b/test/core/behaviors/sync/test_announce_tree.py
@@ -23,12 +23,14 @@ from vultron.core.behaviors.sync.nodes.chain import _to_persistable_entry
 from vultron.semantic_registry import extract_event
 from vultron.wire.as2.factories import announce_log_entry_activity
 from vultron.wire.as2.vocab.objects.case_ledger_entry import (
-    CaseLedgerEntry as WireCaseLedgerEntry,
+    as_CaseLedgerEntry as WireCaseLedgerEntry,
 )
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 # Populate vocabulary registry as side-effect.
-_ = VulnerabilityCase
+_ = as_VulnerabilityCase
 
 OWNER_ACTOR_ID = "https://example.org/actors/vendor"
 PARTICIPANT_ACTOR_ID = "https://example.org/actors/reporter"
@@ -67,7 +69,7 @@ def case_actor(datalayer):
 
 @pytest.fixture
 def case_obj(datalayer):
-    case = VulnerabilityCase(id_=CASE_ID, attributed_to=OWNER_ACTOR_ID)
+    case = as_VulnerabilityCase(id_=CASE_ID, attributed_to=OWNER_ACTOR_ID)
     datalayer.save(case)
     return case
 
@@ -190,8 +192,10 @@ def _make_remove_embargo_entry(
     )
 
 
-def _make_case_with_em_active(datalayer: SqliteDataLayer) -> VulnerabilityCase:
-    case = VulnerabilityCase(
+def _make_case_with_em_active(
+    datalayer: SqliteDataLayer,
+) -> as_VulnerabilityCase:
+    case = as_VulnerabilityCase(
         id_=CASE_ID, name="Test Case", attributed_to=OWNER_ACTOR_ID
     )
     case.current_status.em_state = EM.ACTIVE
@@ -247,7 +251,7 @@ class TestAnnounceLogEntryAppliesEmbargoTeardown:
 
     def test_em_exited_is_idempotent(self, bridge, datalayer, case_actor):
         """Running BT when case is already EM.EXITED must succeed silently."""
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_=CASE_ID, name="Test Case", attributed_to=OWNER_ACTOR_ID
         )
         case.current_status.em_state = EM.EXITED
@@ -296,7 +300,7 @@ class TestAnnounceLogEntryAppliesNoteAttachment:
         """BT attaches note ID to case replica when entry is add_note_to_case.
 
         A non-CaseActor participant must learn about note additions exclusively
-        via Announce(CaseLedgerEntry) fan-out (SYNC-02-002, ADR-0022).
+        via Announce(as_CaseLedgerEntry) fan-out (SYNC-02-002, ADR-0022).
         """
         entry = _make_add_note_entry(0, case_obj.genesis_hash)
         event = _make_event(entry, actor_id=case_actor.id_)
@@ -395,7 +399,7 @@ class TestAnnounceLogEntryAppliesInviteAccept:
         """BT adds new participant to case replica when entry is accept_invite_actor_to_case.
 
         Existing participants (e.g. Finder) must learn about new invitees
-        exclusively via Announce(CaseLedgerEntry) fan-out (SYNC-02-002).
+        exclusively via Announce(as_CaseLedgerEntry) fan-out (SYNC-02-002).
         """
         entry = _make_accept_invite_entry(0, case_obj.genesis_hash)
         event = _make_event(entry, actor_id=case_actor.id_)

--- a/test/core/behaviors/sync/test_reject_tree.py
+++ b/test/core/behaviors/sync/test_reject_tree.py
@@ -23,7 +23,7 @@ from vultron.core.behaviors.sync.nodes.chain import _to_persistable_entry
 from vultron.semantic_registry import extract_event
 from vultron.wire.as2.factories import reject_log_entry_activity
 from vultron.wire.as2.vocab.objects.case_ledger_entry import (
-    CaseLedgerEntry as WireCaseLedgerEntry,
+    as_CaseLedgerEntry as WireCaseLedgerEntry,
 )
 
 OWNER_ACTOR_ID = "https://example.org/actors/vendor"

--- a/test/core/behaviors/test_helpers.py
+++ b/test/core/behaviors/test_helpers.py
@@ -33,7 +33,7 @@ from vultron.core.models.participant import VultronParticipant
 from vultron.core.models.protocols import is_participant_model
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 # Test implementation of abstract base classes
@@ -80,8 +80,8 @@ def bridge(datalayer):
 
 @pytest.fixture
 def sample_report():
-    """Sample VulnerabilityReport for testing CRUD operations."""
-    return VulnerabilityReport(
+    """Sample as_VulnerabilityReport for testing CRUD operations."""
+    return as_VulnerabilityReport(
         id_="https://example.org/objects/test-123",
         name="Test Object",
     )

--- a/test/core/models/test_case.py
+++ b/test/core/models/test_case.py
@@ -262,7 +262,7 @@ class TestWireVulnerabilityCaseFieldParity:
 
     def test_wire_vulnerability_case_field_names_match_core(self):
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase as WireVC,
+            as_VulnerabilityCase as WireVC,
         )
 
         core_fields = set(VulnerabilityCase.model_fields.keys())
@@ -280,7 +280,7 @@ class TestVulnerabilityCaseWireRoundTrip:
 
     def test_to_core_produces_vulnerability_case(self):
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase as WireVC,
+            as_VulnerabilityCase as WireVC,
         )
 
         wire_case = WireVC(
@@ -293,7 +293,7 @@ class TestVulnerabilityCaseWireRoundTrip:
 
     def test_from_core_preserves_id(self):
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase as WireVC,
+            as_VulnerabilityCase as WireVC,
         )
 
         core_case = VulnerabilityCase(
@@ -305,7 +305,7 @@ class TestVulnerabilityCaseWireRoundTrip:
 
     def test_round_trip_preserves_active_embargo(self):
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase as WireVC,
+            as_VulnerabilityCase as WireVC,
         )
 
         core_case = VulnerabilityCase(

--- a/test/core/models/test_case_actor.py
+++ b/test/core/models/test_case_actor.py
@@ -82,7 +82,7 @@ class TestCaseActorWireRoundTrip:
 
     def test_from_core_preserves_id(self):
         from vultron.wire.as2.vocab.objects.case_actor import (
-            CaseActor as WireCaseActor,
+            as_CaseActor as WireCaseActor,
         )
 
         core_actor = CaseActor(
@@ -94,7 +94,7 @@ class TestCaseActorWireRoundTrip:
 
     def test_to_core_preserves_attributed_to(self):
         from vultron.wire.as2.vocab.objects.case_actor import (
-            CaseActor as WireCaseActor,
+            as_CaseActor as WireCaseActor,
         )
 
         wire_actor = WireCaseActor(
@@ -107,7 +107,7 @@ class TestCaseActorWireRoundTrip:
 
     def test_round_trip_preserves_id(self):
         from vultron.wire.as2.vocab.objects.case_actor import (
-            CaseActor as WireCaseActor,
+            as_CaseActor as WireCaseActor,
         )
 
         core_actor = CaseActor(

--- a/test/core/models/test_case_reference.py
+++ b/test/core/models/test_case_reference.py
@@ -108,7 +108,7 @@ class TestCaseReferenceWireRoundTrip:
 
     def test_from_core_preserves_url(self):
         from vultron.wire.as2.vocab.objects.case_reference import (
-            CaseReference as WireCaseReference,
+            as_CaseReference as WireCaseReference,
         )
 
         core_ref = CaseReference(
@@ -123,7 +123,7 @@ class TestCaseReferenceWireRoundTrip:
 
     def test_to_core_produces_core_reference(self):
         from vultron.wire.as2.vocab.objects.case_reference import (
-            CaseReference as WireCaseReference,
+            as_CaseReference as WireCaseReference,
         )
 
         wire_ref = WireCaseReference(url=_URL, tags=["vendor-advisory"])
@@ -134,7 +134,7 @@ class TestCaseReferenceWireRoundTrip:
 
     def test_round_trip_preserves_id(self):
         from vultron.wire.as2.vocab.objects.case_reference import (
-            CaseReference as WireCaseReference,
+            as_CaseReference as WireCaseReference,
         )
 
         core_ref = CaseReference(

--- a/test/core/services/test_embargo_lifecycle.py
+++ b/test/core/services/test_embargo_lifecycle.py
@@ -18,7 +18,7 @@ import pytest
 
 # noqa: F401 — imported for vocabulary registration side-effect
 from vultron.wire.as2.vocab.objects.vulnerability_case import (  # noqa: F401
-    VulnerabilityCase,
+    as_VulnerabilityCase,
 )
 
 from vultron.adapters.driven.datalayer_sqlite import (
@@ -41,7 +41,7 @@ from vultron.core.models.case_participant import (
     FinderParticipant,
     VendorParticipant,
 )
-from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -59,12 +59,12 @@ def _make_case(
     owner_id: str,
     extra_participant_ids: list[str] | None = None,
     em_state: EM = EM.NONE,
-) -> tuple[VulnerabilityCase, list[CaseParticipant]]:
-    """Create a VulnerabilityCase with an owner participant.
+) -> tuple[as_VulnerabilityCase, list[CaseParticipant]]:
+    """Create a as_VulnerabilityCase with an owner participant.
 
     Returns the case and the list of CaseParticipant objects created.
     """
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         name="Test embargo case",
         attributed_to=owner_id,
     )
@@ -98,8 +98,8 @@ def _make_case(
     return case, participants
 
 
-def _make_embargo(dl: SqliteDataLayer, case_id: str) -> EmbargoEvent:
-    embargo = EmbargoEvent(context=case_id)
+def _make_embargo(dl: SqliteDataLayer, case_id: str) -> as_EmbargoEvent:
+    embargo = as_EmbargoEvent(context=case_id)
     dl.create(embargo)
     return embargo
 
@@ -153,7 +153,7 @@ def test_propose_embargo_none_to_proposed(
     assert result.pec_reset is False
     assert result.participant_changes == []
 
-    updated = cast(VulnerabilityCase, dl.read(case.id_))
+    updated = cast(as_VulnerabilityCase, dl.read(case.id_))
     assert updated.current_status.em_state == EM.PROPOSED
     assert embargo.id_ in updated.proposed_embargoes
 
@@ -186,7 +186,7 @@ def test_propose_embargo_idempotent_repropse(
     # EM state did not change, embargo_id already present → nothing mutated
     assert result.case_changed is False
 
-    updated = cast(VulnerabilityCase, dl.read(case.id_))
+    updated = cast(as_VulnerabilityCase, dl.read(case.id_))
     # Must not have been duplicated
     assert updated.proposed_embargoes.count(embargo.id_) == 1
 
@@ -226,7 +226,7 @@ def test_propose_embargo_active_to_revise_cascades_pec(
         assert change.pec_after == PEC.LAPSED.value
 
     # DataLayer state matches
-    updated = cast(VulnerabilityCase, dl.read(case.id_))
+    updated = cast(as_VulnerabilityCase, dl.read(case.id_))
     assert updated.current_status.em_state == EM.REVISE
     for p in participants:
         updated_p = cast(CaseParticipant, dl.read(p.id_))
@@ -475,7 +475,7 @@ def test_accept_embargo_invite_observed_already_active_syncs_embargo(
     # EM stays ACTIVE (already there)
     assert result.em_after == EM.ACTIVE
     # But active_embargo must be updated to point at the new embargo
-    refreshed_case = cast(VulnerabilityCase, dl.read(case.id_))
+    refreshed_case = cast(as_VulnerabilityCase, dl.read(case.id_))
     assert _as_id(refreshed_case.active_embargo) == new_embargo.id_
 
 

--- a/test/core/test_fail_fast_silent_sites.py
+++ b/test/core/test_fail_fast_silent_sites.py
@@ -37,7 +37,6 @@ from vultron.core.behaviors.case.nodes.communication import (
     CreateAndPersistCaseActivityNode,
 )
 from vultron.core.dispatcher import DirectActivityDispatcher
-from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.events import (
     AddNoteToCaseReceivedEvent,
     MessageSemantics,
@@ -45,7 +44,7 @@ from vultron.core.models.events import (
 from vultron.core.models.vultron_types import VultronCaseActor, VultronCase
 from vultron.errors import UnroutableActivityError
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
-    VulnerabilityCase as as_VulnerabilityCase,
+    as_VulnerabilityCase as as_VulnerabilityCase,
 )
 
 _FACTORY_PATH = (
@@ -265,7 +264,7 @@ class TestResolveCaseManagerIdCallers:
 
         scenario = BTTestScenario(actor_id=ACTOR_ID)
         # Seed case with no participants (empty actor_participant_index)
-        case = VulnerabilityCase(id_=CASE_ID, name="No CM")
+        case = as_VulnerabilityCase(id_=CASE_ID, name="No CM")
         scenario.dl.create(case)
 
         node = ResolveCaseManagerNode(case_id=CASE_ID)
@@ -280,7 +279,7 @@ class TestResolveCaseManagerIdCallers:
         )
 
         scenario = BTTestScenario(actor_id=ACTOR_ID)
-        case = VulnerabilityCase(id_=CASE_ID, name="No CM")
+        case = as_VulnerabilityCase(id_=CASE_ID, name="No CM")
         scenario.dl.create(case)
 
         node = CheckIsCaseManagerNode()

--- a/test/core/use_cases/query/test_action_rules.py
+++ b/test/core/use_cases/query/test_action_rules.py
@@ -29,13 +29,15 @@ from vultron.core.use_cases.query.action_rules import (
     GetActionRulesUseCase,
 )
 from vultron.errors import VultronNotFoundError, VultronValidationError
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
 from vultron.wire.as2.vocab.objects.case_status import (
-    CaseStatus,
-    ParticipantStatus,
+    as_CaseStatus,
+    as_ParticipantStatus,
 )
 from vultron.wire.as2.vocab.base.objects.object_types import as_Note
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 ACTOR_ID = "https://example.org/actors/alice"
 CASE_ID = "https://example.org/cases/c1"
@@ -47,23 +49,25 @@ def dl():
     """In-memory DataLayer with a minimal valid case setup."""
     layer = SqliteDataLayer("sqlite:///:memory:")
 
-    # Case: VulnerabilityCase with actor_participant_index
-    case = VulnerabilityCase(
+    # Case: as_VulnerabilityCase with actor_participant_index
+    case = as_VulnerabilityCase(
         id_=CASE_ID,
         name="Test Case",
         case_participants=[PARTICIPANT_ID],
         actor_participant_index={ACTOR_ID: PARTICIPANT_ID},
-        case_statuses=[CaseStatus(em_state=EM.ACTIVE, pxa_state=CS_pxa.Pxa)],
+        case_statuses=[
+            as_CaseStatus(em_state=EM.ACTIVE, pxa_state=CS_pxa.Pxa)
+        ],
     )
     layer.create(case)
 
-    # Participant: CaseParticipant with VENDOR role and ACCEPTED RM state
-    participant = CaseParticipant(
+    # Participant: as_CaseParticipant with VENDOR role and ACCEPTED RM state
+    participant = as_CaseParticipant(
         id_=PARTICIPANT_ID,
         attributed_to=ACTOR_ID,
         case_roles=[CVDRole.VENDOR],
         participant_statuses=[
-            ParticipantStatus(
+            as_ParticipantStatus(
                 context=CASE_ID, rm_state=RM.ACCEPTED, vfd_state=CS_vfd.VFd
             )
         ],
@@ -165,9 +169,9 @@ class TestGetActionRulesUseCase:
             GetActionRulesUseCase(dl=dl, request=req).execute()
 
     def test_no_case_statuses_defaults(self, dl):
-        """When case has no CaseStatus entries, EM/PXA default to None/pxa."""
+        """When case has no as_CaseStatus entries, EM/PXA default to None/pxa."""
         layer = SqliteDataLayer("sqlite:///:memory:")
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_=CASE_ID,
             name="Empty Status Case",
             case_participants=[PARTICIPANT_ID],
@@ -175,12 +179,12 @@ class TestGetActionRulesUseCase:
             case_statuses=[],
         )
         layer.create(case)
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             id_=PARTICIPANT_ID,
             attributed_to=ACTOR_ID,
             case_roles=[CVDRole.REPORTER],
             participant_statuses=[
-                ParticipantStatus(
+                as_ParticipantStatus(
                     context=CASE_ID,
                     rm_state=RM.RECEIVED,
                     vfd_state=CS_vfd.Vfd,
@@ -199,17 +203,17 @@ class TestGetActionRulesUseCase:
         assert result["pxa_state"] == CS_pxa.pxa.name
 
     def test_no_participant_statuses_defaults(self, dl):
-        """When participant has no ParticipantStatus entries, RM/VFD default."""
+        """When participant has no as_ParticipantStatus entries, RM/VFD default."""
         layer = SqliteDataLayer("sqlite:///:memory:")
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_=CASE_ID,
             name="Default Participant Status Case",
             case_participants=[PARTICIPANT_ID],
             actor_participant_index={ACTOR_ID: PARTICIPANT_ID},
-            case_statuses=[CaseStatus(em_state=EM.NO_EMBARGO)],
+            case_statuses=[as_CaseStatus(em_state=EM.NO_EMBARGO)],
         )
         layer.create(case)
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             id_=PARTICIPANT_ID,
             attributed_to=ACTOR_ID,
             context=CASE_ID,
@@ -237,17 +241,19 @@ class TestGetActionRulesUseCase:
             EM.EXITED,
         ]:
             layer = SqliteDataLayer("sqlite:///:memory:")
-            case = VulnerabilityCase(
+            case = as_VulnerabilityCase(
                 id_=CASE_ID,
                 case_participants=[PARTICIPANT_ID],
                 actor_participant_index={ACTOR_ID: PARTICIPANT_ID},
-                case_statuses=[CaseStatus(em_state=em, pxa_state=CS_pxa.pxa)],
+                case_statuses=[
+                    as_CaseStatus(em_state=em, pxa_state=CS_pxa.pxa)
+                ],
             )
             layer.create(case)
-            participant = CaseParticipant(
+            participant = as_CaseParticipant(
                 id_=PARTICIPANT_ID,
                 attributed_to=ACTOR_ID,
-                participant_statuses=[ParticipantStatus(context=CASE_ID)],
+                participant_statuses=[as_ParticipantStatus(context=CASE_ID)],
             )
             layer.create(participant)
 
@@ -262,18 +268,18 @@ class TestGetActionRulesUseCase:
 
     def test_participant_lookup_raises_on_index_mismatch(self):
         layer = SqliteDataLayer("sqlite:///:memory:")
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             id_=PARTICIPANT_ID,
             attributed_to=ACTOR_ID,
             case_roles=[CVDRole.VENDOR],
-            participant_statuses=[ParticipantStatus(context=CASE_ID)],
+            participant_statuses=[as_ParticipantStatus(context=CASE_ID)],
         )
         layer.create(participant)
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_=CASE_ID,
             case_participants=[PARTICIPANT_ID],
             actor_participant_index={ACTOR_ID: "https://example.org/p/wrong"},
-            case_statuses=[CaseStatus()],
+            case_statuses=[as_CaseStatus()],
         )
         layer.create(case)
 
@@ -283,18 +289,18 @@ class TestGetActionRulesUseCase:
 
     def test_participant_lookup_succeeds_without_index_entry(self):
         layer = SqliteDataLayer("sqlite:///:memory:")
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             id_=PARTICIPANT_ID,
             attributed_to=ACTOR_ID,
             case_roles=[CVDRole.VENDOR],
-            participant_statuses=[ParticipantStatus(context=CASE_ID)],
+            participant_statuses=[as_ParticipantStatus(context=CASE_ID)],
         )
         layer.create(participant)
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_=CASE_ID,
             case_participants=[PARTICIPANT_ID],
             actor_participant_index={},
-            case_statuses=[CaseStatus()],
+            case_statuses=[as_CaseStatus()],
         )
         layer.create(case)
 

--- a/test/core/use_cases/received/actor/conftest.py
+++ b/test/core/use_cases/received/actor/conftest.py
@@ -1,7 +1,7 @@
 """
 Fixtures for test/core/use_cases/received tests.
 
-Imports VulnerabilityCase (and related wire-layer types) as a side effect so
+Imports as_VulnerabilityCase (and related wire-layer types) as a side effect so
 that the global vocabulary registry is populated before any test in this
 directory runs.  Without this import the registry may be empty when tests run
 in isolation, causing TinyDB's record_to_object() to fall back to returning a
@@ -10,5 +10,5 @@ raw Document instead of a deserialized domain object.
 
 # noqa: F401 — imported for vocabulary registration side-effect
 from vultron.wire.as2.vocab.objects.vulnerability_case import (  # noqa: F401
-    VulnerabilityCase,
+    as_VulnerabilityCase,
 )

--- a/test/core/use_cases/received/actor/test_announce.py
+++ b/test/core/use_cases/received/actor/test_announce.py
@@ -22,10 +22,12 @@ from vultron.core.use_cases.received.actor.announce import (
     AnnounceVulnerabilityCaseReceivedUseCase,
 )
 from vultron.wire.as2.factories import announce_vulnerability_case_activity
-from vultron.wire.as2.vocab.objects.case_actor import CaseActor
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+from vultron.wire.as2.vocab.objects.case_actor import as_CaseActor
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
 from vultron.enums.roles import CVDRole
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 _OWNER_ID = "https://example.org/actors/owner"
 _CASE_ACTOR_ID = "https://example.org/actors/case-actor"
@@ -45,12 +47,12 @@ def dl():
 
 @pytest.fixture()
 def case():
-    return VulnerabilityCase(id_=_CASE_ID, name="DR-10 Announce Case")
+    return as_VulnerabilityCase(id_=_CASE_ID, name="DR-10 Announce Case")
 
 
 @pytest.fixture()
 def case_actor():
-    return CaseActor(
+    return as_CaseActor(
         id_=_CASE_ACTOR_ID,
         attributed_to=_OWNER_ID,
         context=_CASE_ID,
@@ -78,7 +80,7 @@ class TestAnnounceVulnerabilityCaseReceivedUseCase:
     def test_creates_case_when_absent(self, dl, event, case):
         """MV-10-003: Announce seeding creates the case in the invitee's DL."""
         dl.create(
-            CaseActor(
+            as_CaseActor(
                 id_=_CASE_ACTOR_ID,
                 attributed_to=_OWNER_ID,
                 context=_CASE_ID,
@@ -103,7 +105,7 @@ class TestAnnounceVulnerabilityCaseReceivedUseCase:
     def test_creates_case_when_case_actor_not_yet_known_locally(
         self, dl, event, case
     ):
-        """First-time replica seeding succeeds before the CaseActor is stored."""
+        """First-time replica seeding succeeds before the as_CaseActor is stored."""
         AnnounceVulnerabilityCaseReceivedUseCase(dl, event).execute()
 
         result = dl.read(_CASE_ID)
@@ -157,25 +159,25 @@ class TestAnnounceVulnerabilityCaseReceivedUseCase:
         assert dl.read(_CASE_ID) is None
 
     def test_non_case_object_skips_gracefully(self, dl, make_payload):
-        """No-op when the activity object_ is not a VulnerabilityCase."""
+        """No-op when the activity object_ is not a as_VulnerabilityCase."""
         from vultron.wire.as2.factories import (
             announce_vulnerability_case_activity,
         )
         from vultron.wire.as2.vocab.objects.vulnerability_report import (
-            VulnerabilityReport,
+            as_VulnerabilityReport,
         )
 
         # Build an Announce that wraps a non-case object; we can't use the typed
-        # factory here because it requires VulnerabilityCase,
+        # factory here because it requires as_VulnerabilityCase,
         # so we inject via model_copy to simulate a malformed incoming payload.
-        good_case = VulnerabilityCase(id_=_CASE_ID2, name="Placeholder")
+        good_case = as_VulnerabilityCase(id_=_CASE_ID2, name="Placeholder")
         announce = announce_vulnerability_case_activity(
             good_case, actor=_OWNER_ID
         )
         event = make_payload(announce)
 
         # Replace the object_ on the raw activity with a non-case
-        report = VulnerabilityReport(name="Not a case")
+        report = as_VulnerabilityReport(name="Not a case")
         patched_activity = announce.model_copy(update={"object_": report})
         event = event.model_copy(update={"activity": patched_activity})
 
@@ -186,9 +188,9 @@ class TestAnnounceVulnerabilityCaseReceivedUseCase:
     def test_rejects_announce_from_non_case_actor(
         self, dl, case, make_payload
     ):
-        """PCR-07-003: non-CaseActor senders cannot seed a case replica."""
+        """PCR-07-003: non-as_CaseActor senders cannot seed a case replica."""
         dl.create(
-            CaseActor(
+            as_CaseActor(
                 id_=_CASE_ACTOR_ID,
                 attributed_to=_OWNER_ID,
                 context=_CASE_ID,
@@ -213,30 +215,30 @@ class TestAnnounceVulnerabilityCaseReceivedUseCase:
 
 
 class TestAnnounceStoresEmbeddedParticipants:
-    """Announce(VulnerabilityCase) seeding must store embedded participants.
+    """Announce(as_VulnerabilityCase) seeding must store embedded participants.
 
     Regression tests for #566: ``AnnounceVulnerabilityCaseReceivedUseCase``
     was not calling ``_store_embedded_participants`` after saving the case,
-    so late-joiner replicas never had independent ``CaseParticipant`` records.
+    so late-joiner replicas never had independent ``as_CaseParticipant`` records.
     BT nodes (``CheckParticipantExists``, ``AppendParticipantStatusNode``)
     would then fail with participant-not-found on the Announce path.
     """
 
     @pytest.fixture()
     def case_with_participants(self):
-        """VulnerabilityCase with two embedded participants (inline objects)."""
-        case_actor_p = CaseParticipant(
+        """as_VulnerabilityCase with two embedded participants (inline objects)."""
+        case_actor_p = as_CaseParticipant(
             case_roles=[CVDRole.CASE_MANAGER],
             id_=_CASE_ACTOR_PARTICIPANT_ID,
             attributed_to=_CASE_ACTOR_ID,
             context=_CASE_ID,
         )
-        vendor_p = CaseParticipant(
+        vendor_p = as_CaseParticipant(
             id_=_VENDOR_PARTICIPANT_ID,
             attributed_to=_VENDOR_ID,
             context=_CASE_ID,
         )
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_=_CASE_ID,
             name="DR-10 Announce Case with Participants",
             case_participants=[
@@ -280,7 +282,7 @@ class TestAnnounceStoresEmbeddedParticipants:
     def test_embedded_vendor_participant_stored_after_announce(
         self, dl, announce_with_participants_event
     ):
-        """Vendor CaseParticipant embedded in Announce payload is stored
+        """Vendor as_CaseParticipant embedded in Announce payload is stored
         independently — BT nodes can then look it up by UUID (#566)."""
         AnnounceVulnerabilityCaseReceivedUseCase(
             dl, announce_with_participants_event
@@ -288,7 +290,7 @@ class TestAnnounceStoresEmbeddedParticipants:
 
         stored = dl.read(_VENDOR_PARTICIPANT_ID)
         assert stored is not None, (
-            "Vendor CaseParticipant must be stored as an independent DataLayer "
+            "Vendor as_CaseParticipant must be stored as an independent DataLayer "
             "record after Announce seeding (#566)"
         )
 
@@ -300,7 +302,7 @@ class TestAnnounceStoresEmbeddedParticipants:
         Only inline participant objects are stored; bare ID strings are left
         as-is (they reference objects the receiver doesn't have locally).
         """
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_=_CASE_ID,
             name="Announce with string participants",
             case_participants=[_VENDOR_PARTICIPANT_ID],  # bare string ref
@@ -346,6 +348,6 @@ class TestAnnounceStoresEmbeddedParticipants:
             "exists (idempotent early-return path, #566)"
         )
         assert stored_vendor is not None, (
-            "Vendor CaseParticipant must be stored even when the case already "
+            "Vendor as_CaseParticipant must be stored even when the case already "
             "exists (idempotent early-return path, #566)"
         )

--- a/test/core/use_cases/received/actor/test_case_manager_role.py
+++ b/test/core/use_cases/received/actor/test_case_manager_role.py
@@ -42,14 +42,14 @@ class TestCaseManagerRoleDelegationUseCases:
 
     def _make_offer(self):
         from vultron.wire.as2.vocab.objects.case_participant import (
-            CaseParticipant,
+            as_CaseParticipant,
         )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
-        case = VulnerabilityCase(id_=self._CASE_URI, name="CASE-MGR-TEST")
-        participant = CaseParticipant(
+        case = as_VulnerabilityCase(id_=self._CASE_URI, name="CASE-MGR-TEST")
+        participant = as_CaseParticipant(
             id_=self._PARTICIPANT_URI,
             attributed_to=self._CASE_ACTOR_URI,
             context=self._CASE_URI,
@@ -186,7 +186,7 @@ class TestCaseManagerRoleDelegationUseCases:
         from vultron.core.models.vultron_types import VultronParticipant
         from vultron.enums.roles import CVDRole
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         dl = SqliteDataLayer("sqlite:///:memory:")
@@ -200,7 +200,7 @@ class TestCaseManagerRoleDelegationUseCases:
             name="Reporter",
             case_roles=[CVDRole.FINDER, CVDRole.REPORTER],
         )
-        case = VulnerabilityCase(id_=self._CASE_URI, name="BOOTSTRAP-TEST")
+        case = as_VulnerabilityCase(id_=self._CASE_URI, name="BOOTSTRAP-TEST")
         case.actor_participant_index[reporter_id] = reporter_participant_id
         dl.create(vendor)
         dl.create(reporter_participant)
@@ -238,7 +238,7 @@ class TestCaseManagerRoleDelegationUseCases:
         from vultron.core.models.vultron_types import VultronParticipant
         from vultron.enums.roles import CVDRole
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         dl = SqliteDataLayer("sqlite:///:memory:")
@@ -251,7 +251,7 @@ class TestCaseManagerRoleDelegationUseCases:
             name="Reporter",
             case_roles=[CVDRole.FINDER, CVDRole.REPORTER],
         )
-        case = VulnerabilityCase(id_=self._CASE_URI, name="FALLBACK-TEST")
+        case = as_VulnerabilityCase(id_=self._CASE_URI, name="FALLBACK-TEST")
         # Populate only case_participants; leave actor_participant_index empty
         # (bootstrap path — index not yet populated).
         case.case_participants.append(reporter_participant_id)  # type: ignore[arg-type]
@@ -307,17 +307,17 @@ class TestCaseManagerRoleDelegationUseCases:
         from unittest.mock import MagicMock
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
         from vultron.wire.as2.vocab.objects.case_participant import (
-            CaseParticipant,
+            as_CaseParticipant,
         )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         dl = SqliteDataLayer("sqlite:///:memory:")
 
         # Seed DL so EmitRejectCaseManagerRoleNode can reconstruct the offer
-        case = VulnerabilityCase(id_=self._CASE_URI, name="REJECT-TEST")
-        participant = CaseParticipant(
+        case = as_VulnerabilityCase(id_=self._CASE_URI, name="REJECT-TEST")
+        participant = as_CaseParticipant(
             id_=self._PARTICIPANT_URI,
             attributed_to=self._CASE_ACTOR_URI,
             context=self._CASE_URI,
@@ -362,15 +362,17 @@ class TestCaseManagerRoleDelegationUseCases:
         from unittest.mock import MagicMock, patch
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
         from vultron.wire.as2.vocab.objects.case_participant import (
-            CaseParticipant,
+            as_CaseParticipant,
         )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         dl = SqliteDataLayer("sqlite:///:memory:")
-        case = VulnerabilityCase(id_=self._CASE_URI, name="OUTBOX-FAIL-TEST")
-        participant = CaseParticipant(
+        case = as_VulnerabilityCase(
+            id_=self._CASE_URI, name="OUTBOX-FAIL-TEST"
+        )
+        participant = as_CaseParticipant(
             id_=self._PARTICIPANT_URI,
             attributed_to=self._CASE_ACTOR_URI,
             context=self._CASE_URI,
@@ -407,18 +409,18 @@ class TestCaseManagerRoleDelegationUseCases:
         from unittest.mock import MagicMock
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
         from vultron.wire.as2.vocab.objects.case_participant import (
-            CaseParticipant,
+            as_CaseParticipant,
         )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
         from vultron.adapters.driven.trigger_activity_adapter import (
             TriggerActivityAdapter,
         )
 
         dl = SqliteDataLayer("sqlite:///:memory:")
-        case = VulnerabilityCase(id_=self._CASE_URI, name="ADAPTER-REJECT")
-        participant = CaseParticipant(
+        case = as_VulnerabilityCase(id_=self._CASE_URI, name="ADAPTER-REJECT")
+        participant = as_CaseParticipant(
             id_=self._PARTICIPANT_URI,
             attributed_to=self._CASE_ACTOR_URI,
             context=self._CASE_URI,

--- a/test/core/use_cases/received/actor/test_invite.py
+++ b/test/core/use_cases/received/actor/test_invite.py
@@ -147,17 +147,17 @@ class TestInviteActorUseCases:
     def test_accept_invite_actor_to_case_adds_participant(
         self, monkeypatch, make_payload
     ):
-        """AcceptInviteActorToCaseReceivedUseCase creates a CaseParticipant and adds them to the case."""
+        """AcceptInviteActorToCaseReceivedUseCase creates a as_CaseParticipant and adds them to the case."""
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
         from vultron.wire.as2.vocab.base.objects.actors import as_Organization
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         dl = SqliteDataLayer("sqlite:///:memory:")
         invitee_id = "https://example.org/users/coordinator"
         invitee = as_Organization(id_=invitee_id)
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/caseIA1",
             name="TEST-ACCEPT-INVITE",
         )
@@ -184,7 +184,7 @@ class TestInviteActorUseCases:
 
         case = dl.read(case.id_)
         assert case is not None
-        case = cast(VulnerabilityCase, case)
+        case = cast(as_VulnerabilityCase, case)
         assert invitee_id in case.actor_participant_index
 
     def test_accept_invite_actor_to_case_records_active_embargo(
@@ -194,19 +194,21 @@ class TestInviteActorUseCases:
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
         from vultron.core.states.em import EM
         from vultron.wire.as2.vocab.base.objects.actors import as_Organization
-        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+        from vultron.wire.as2.vocab.objects.embargo_event import (
+            as_EmbargoEvent,
+        )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         dl = SqliteDataLayer("sqlite:///:memory:")
         invitee_id = "https://example.org/users/coordinator"
         invitee = as_Organization(id_=invitee_id)
-        embargo = EmbargoEvent(
+        embargo = as_EmbargoEvent(
             id_="https://example.org/cases/caseIA2/embargo_events/e1",
             content="Active embargo",
         )
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/caseIA2",
             name="TEST-ACCEPT-INVITE-EMBARGO",
         )
@@ -236,7 +238,7 @@ class TestInviteActorUseCases:
 
         case = dl.read(case.id_)
         assert case is not None
-        case = cast(VulnerabilityCase, case)
+        case = cast(as_VulnerabilityCase, case)
         participant_id = case.actor_participant_index.get(invitee_id)
         assert participant_id is not None
         participant_obj = dl.get(id_=participant_id)
@@ -259,7 +261,7 @@ class TestInviteActorUseCases:
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
         from vultron.wire.as2.vocab.base.objects.actors import as_Organization
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
         from vultron.core.states.rm import RM
 
@@ -267,7 +269,7 @@ class TestInviteActorUseCases:
         invitee_id = "https://example.org/users/coordinator_rm1"
         invitee = as_Organization(id_=invitee_id)
         owner_id = "https://example.org/users/owner"
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/caseRM001",
             name="TEST-RM-LIFECYCLE",
         )
@@ -309,7 +311,7 @@ class TestInviteActorUseCases:
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
         from vultron.wire.as2.vocab.base.objects.actors import as_Organization
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
         from vultron.core.models.vultron_types import VultronParticipant
         from vultron.core.states.rm import RM
@@ -329,7 +331,7 @@ class TestInviteActorUseCases:
             name="CaseManager",
             case_roles=[CVDRole.CASE_MANAGER],
         )
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/caseRM002",
             name="TEST-RM-AUTO-ENGAGE",
             case_participants=[case_manager_participant_id],
@@ -384,27 +386,27 @@ class TestInviteActorUseCases:
         self, monkeypatch, make_payload
     ):
         """AcceptInviteActorToCaseReceivedUseCase commits a canonical
-        CaseLedgerEntry with event_type 'accept_invite_actor_to_case'
+        as_CaseLedgerEntry with event_type 'accept_invite_actor_to_case'
         (CM-02-009).
 
         record_event('participant_joined') was removed in #789; the trust
-        guarantee now lives in CaseLedgerEntry.received_at written by
+        guarantee now lives in as_CaseLedgerEntry.received_at written by
         CommitCaseLedgerEntryNode.
         """
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
         from vultron.wire.as2.vocab.base.objects.actors import as_Organization
         from vultron.wire.as2.vocab.objects.case_ledger_entry import (
-            CaseLedgerEntry as WireCaseLedgerEntry,
+            as_CaseLedgerEntry as WireCaseLedgerEntry,
         )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         dl = SqliteDataLayer("sqlite:///:memory:")
         invitee_id = "https://example.org/users/coordinator"
         case_actor_id = "https://example.org/cases/caseIA3/actor"
         invitee = as_Organization(id_=invitee_id)
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/caseIA3",
             name="TEST-ACCEPT-INVITE-EVENT",
             attributed_to=case_actor_id,
@@ -419,12 +421,12 @@ class TestInviteActorUseCases:
         dl.create(case)
         from vultron.enums.roles import CVDRole
         from vultron.wire.as2.vocab.objects.case_participant import (
-            CaseParticipant,
+            as_CaseParticipant,
         )
         from vultron.wire.as2.vocab.base.objects.actors import as_Service
 
         dl.create(as_Service(id_=case_actor_id, context=case.id_))
-        case_manager_participant = CaseParticipant(
+        case_manager_participant = as_CaseParticipant(
             id_=f"{case.id_}/participants/case-actor-p",
             attributed_to=case_actor_id,
             context=case.id_,
@@ -471,7 +473,7 @@ class TestInviteActorUseCases:
             as_Service,
         )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         dl = SqliteDataLayer("sqlite:///:memory:")
@@ -479,7 +481,7 @@ class TestInviteActorUseCases:
         case_actor_id = "https://example.org/actors/case-actor-lj1"
         invitee = as_Organization(id_=invitee_id)
         case_actor = as_Service(id_=case_actor_id, context="unused")
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/caseLJ1",
             name="TEST-LATE-JOIN-BACKFILL",
             attributed_to=case_actor_id,
@@ -496,10 +498,10 @@ class TestInviteActorUseCases:
         dl.create(case)
         from vultron.enums.roles import CVDRole
         from vultron.wire.as2.vocab.objects.case_participant import (
-            CaseParticipant,
+            as_CaseParticipant,
         )
 
-        case_manager_participant = CaseParticipant(
+        case_manager_participant = as_CaseParticipant(
             id_=f"{case.id_}/participants/case-actor-p",
             attributed_to=case_actor_id,
             context=case.id_,
@@ -580,7 +582,7 @@ class TestInviteActorUseCases:
             as_Service,
         )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         dl = SqliteDataLayer("sqlite:///:memory:")
@@ -588,7 +590,7 @@ class TestInviteActorUseCases:
         case_actor_id = "https://example.org/actors/case-actor-lj2"
         invitee = as_Organization(id_=invitee_id)
         case_actor = as_Service(id_=case_actor_id, context="unused")
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/caseLJ2",
             name="TEST-LATE-JOIN-RESUME",
             attributed_to=case_actor_id,
@@ -605,10 +607,10 @@ class TestInviteActorUseCases:
         dl.create(case)
         from vultron.enums.roles import CVDRole
         from vultron.wire.as2.vocab.objects.case_participant import (
-            CaseParticipant,
+            as_CaseParticipant,
         )
 
-        case_manager_participant = CaseParticipant(
+        case_manager_participant = as_CaseParticipant(
             id_=f"{case.id_}/participants/case-actor-p",
             attributed_to=case_actor_id,
             context=case.id_,
@@ -715,7 +717,7 @@ class TestInviteActorUseCases:
             as_Service,
         )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         dl = SqliteDataLayer("sqlite:///:memory:")
@@ -723,7 +725,7 @@ class TestInviteActorUseCases:
         case_actor_id = "https://example.org/actors/case-actor-lj3"
         invitee = as_Organization(id_=invitee_id)
         case_actor = as_Service(id_=case_actor_id, context="unused")
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/caseLJ3",
             name="TEST-LATE-JOIN-NO-MARKER",
             attributed_to=case_actor_id,
@@ -736,10 +738,10 @@ class TestInviteActorUseCases:
         )
         from vultron.enums.roles import CVDRole
         from vultron.wire.as2.vocab.objects.case_participant import (
-            CaseParticipant,
+            as_CaseParticipant,
         )
 
-        case_manager_participant = CaseParticipant(
+        case_manager_participant = as_CaseParticipant(
             id_=f"{case.id_}/participants/case-actor-p",
             attributed_to=case_actor_id,
             context=case.id_,
@@ -819,7 +821,7 @@ class TestInviteActorUseCases:
             as_Service,
         )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         dl = SqliteDataLayer("sqlite:///:memory:")
@@ -827,7 +829,7 @@ class TestInviteActorUseCases:
         case_actor_id = "https://example.org/actors/case-actor-lj4"
         invitee = as_Organization(id_=invitee_id)
         case_actor = as_Service(id_=case_actor_id, context="unused")
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/caseLJ4",
             name="TEST-LATE-JOIN-NO-ANNOUNCE",
             attributed_to=case_actor_id,
@@ -844,10 +846,10 @@ class TestInviteActorUseCases:
         dl.create(case)
         from vultron.enums.roles import CVDRole
         from vultron.wire.as2.vocab.objects.case_participant import (
-            CaseParticipant,
+            as_CaseParticipant,
         )
 
-        case_manager_participant = CaseParticipant(
+        case_manager_participant = as_CaseParticipant(
             id_=f"{case.id_}/participants/case-actor-p",
             attributed_to=case_actor_id,
             context=case.id_,
@@ -914,13 +916,13 @@ class TestAcceptInviteRolesAC4:
         from vultron.enums.roles import CVDRole
         from vultron.wire.as2.vocab.base.objects.actors import as_Organization
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         dl = SqliteDataLayer("sqlite:///:memory:")
         invitee_id = "https://example.org/users/vendor2"
         invitee = as_Organization(id_=invitee_id)
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/ac4-test",
             name="AC-4 roles test",
         )
@@ -957,13 +959,13 @@ class TestAcceptInviteRolesAC4:
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
         from vultron.wire.as2.vocab.base.objects.actors import as_Organization
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         dl = SqliteDataLayer("sqlite:///:memory:")
         invitee_id = "https://example.org/users/vendor3"
         invitee = as_Organization(id_=invitee_id)
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/ac4-neg",
             name="AC-4 negative",
         )

--- a/test/core/use_cases/received/actor/test_offer_case_participant.py
+++ b/test/core/use_cases/received/actor/test_offer_case_participant.py
@@ -49,7 +49,9 @@ from vultron.wire.as2.factories import (
     rm_accept_invite_to_case_activity,
 )
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor, as_Service
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -70,7 +72,7 @@ def _seed_dl_for_case_owner() -> tuple[SqliteDataLayer, str]:
     """
     dl = SqliteDataLayer("sqlite:///:memory:")
     owner_actor = as_Actor(id_=CASE_OWNER_ID)
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         id_=CASE_ID,
         name="OfferRoundTripTest",
         attributed_to=CASE_OWNER_ID,
@@ -88,7 +90,7 @@ def _seed_dl_for_case_actor() -> tuple[SqliteDataLayer, str]:
     """
     dl = SqliteDataLayer("sqlite:///:memory:")
     case_actor = as_Service(id_=CASE_ACTOR_ID)
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         id_=CASE_ID,
         name="OfferRoundTripTest",
         attributed_to=CASE_OWNER_ID,
@@ -294,7 +296,7 @@ def _seed_dl_for_ac1() -> SqliteDataLayer:
 
     dl = SqliteDataLayer("sqlite:///:memory:")
     case_actor = as_Service(id_=AC1_CASE_ACTOR_ID, context=AC1_CASE_ID)
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         id_=AC1_CASE_ID,
         name="AC1RolesThreading",
         attributed_to=AC1_CASE_OWNER_ID,

--- a/test/core/use_cases/received/actor/test_ownership.py
+++ b/test/core/use_cases/received/actor/test_ownership.py
@@ -27,7 +27,7 @@ from vultron.wire.as2.factories import (
     reject_case_ownership_transfer_activity,
 )
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
-    VulnerabilityCase,
+    as_VulnerabilityCase,
 )
 
 
@@ -42,7 +42,7 @@ class TestOwnershipTransferUseCases:
 
         dl = SqliteDataLayer("sqlite:///:memory:")
 
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/case_ot1",
             name="OT Case 1",
         )
@@ -65,7 +65,7 @@ class TestOwnershipTransferUseCases:
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 
         dl = SqliteDataLayer("sqlite:///:memory:")
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/case_ot2",
             name="OT Case 2",
             attributed_to="https://example.org/users/vendor",
@@ -100,7 +100,7 @@ class TestOwnershipTransferUseCases:
         self, monkeypatch, caplog, make_payload
     ):
         """RejectCaseOwnershipTransferReceivedUseCase logs rejection; ownership unchanged."""
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/case_ot3",
             name="OT Case 3",
         )

--- a/test/core/use_cases/received/actor/test_suggest.py
+++ b/test/core/use_cases/received/actor/test_suggest.py
@@ -26,7 +26,9 @@ from vultron.core.use_cases.received.actor.suggest import (
 )
 from vultron.wire.as2.factories import recommend_actor_activity
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 
 class TestOfferActorToCaseReceivedUseCase:
@@ -50,7 +52,7 @@ class TestOfferActorToCaseReceivedUseCase:
         owner_id = (
             local_actor_id if owner_is_local else "https://other.org/actor"
         )
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_=case_id,
             name="OfferActorTest",
             attributed_to=owner_id,

--- a/test/core/use_cases/received/case/conftest.py
+++ b/test/core/use_cases/received/case/conftest.py
@@ -1,7 +1,7 @@
 """
 Fixtures for test/core/use_cases/received tests.
 
-Imports VulnerabilityCase (and related wire-layer types) as a side effect so
+Imports as_VulnerabilityCase (and related wire-layer types) as a side effect so
 that the global vocabulary registry is populated before any test in this
 directory runs.  Without this import the registry may be empty when tests run
 in isolation, causing TinyDB's record_to_object() to fall back to returning a
@@ -10,5 +10,5 @@ raw Document instead of a deserialized domain object.
 
 # noqa: F401 — imported for vocabulary registration side-effect
 from vultron.wire.as2.vocab.objects.vulnerability_case import (  # noqa: F401
-    VulnerabilityCase,
+    as_VulnerabilityCase,
 )

--- a/test/core/use_cases/received/case/test_bootstrap_participants.py
+++ b/test/core/use_cases/received/case/test_bootstrap_participants.py
@@ -15,7 +15,7 @@
 """Tests for embedded-participant storage during case bootstrap (CBT-05-005/006).
 
 Covers:
-  CBT-05-005  Embedded CaseParticipant objects are stored as independent
+  CBT-05-005  Embedded as_CaseParticipant objects are stored as independent
               DataLayer records so BT nodes (CheckParticipantExists,
               AppendParticipantStatusNode) can look them up by UUID.
   CBT-05-006  AddParticipantStatusBT succeeds on the reporter's replica after
@@ -41,12 +41,14 @@ from vultron.wire.as2.factories import (
     create_case_activity,
 )
 from vultron.wire.as2.vocab.objects.case_participant import (
-    CaseParticipant,
+    as_CaseParticipant,
 )
 from vultron.wire.as2.vocab.objects.case_status import (
-    ParticipantStatus as WireParticipantStatus,
+    as_ParticipantStatus as WireParticipantStatus,
 )
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 # ---------------------------------------------------------------------------
 # Shared constants
@@ -92,19 +94,19 @@ def dl():
 
 @pytest.fixture()
 def case_with_two_participants():
-    """VulnerabilityCase with CASE_MANAGER and vendor participants inline."""
-    case_actor_p = CaseParticipant(
+    """as_VulnerabilityCase with CASE_MANAGER and vendor participants inline."""
+    case_actor_p = as_CaseParticipant(
         case_roles=[CVDRole.CASE_MANAGER],
         id_=_PARTICIPANT_ID,
         attributed_to=_CASE_ACTOR_ID,
         context=_CASE_ID,
     )
-    vendor_p = CaseParticipant(
+    vendor_p = as_CaseParticipant(
         id_=_VENDOR_PARTICIPANT_ID,
         attributed_to=_VENDOR_ID,
         context=_CASE_ID,
     )
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         id_=_CASE_ID,
         name="CBT-05-005/006 participant storage case",
         attributed_to=_CASE_ACTOR_ID,
@@ -132,14 +134,14 @@ class TestBootstrapParticipantStorage:
 
     BT nodes ``CheckParticipantExists`` (#561) and ``AppendParticipantStatus``
     (#562) look up participants by UUID via ``datalayer.read(participant_id)``.
-    After a bootstrap ``Create(VulnerabilityCase)`` those participant records
+    After a bootstrap ``Create(as_VulnerabilityCase)`` those participant records
     MUST exist as independent DataLayer entries so the BT nodes can find them.
     """
 
     def test_embedded_participant_stored_after_bootstrap(
         self, dl, create_event
     ):
-        """Embedded CaseParticipant is stored as an independent DataLayer
+        """Embedded as_CaseParticipant is stored as an independent DataLayer
         record after a valid bootstrap (CBT-05-005, fixes #561 and #562).
         """
         link = _build_link()
@@ -213,7 +215,7 @@ class TestM4AddParticipantStatusAfterBootstrap:
 
     Before the fix (PRs #561, #562):
     - ``_store_embedded_participants`` did not persist each embedded participant
-      as an independent DataLayer record, so vendor's ``CaseParticipant`` could
+      as an independent DataLayer record, so vendor's ``as_CaseParticipant`` could
       not be found by its UUID after bootstrap.
     - ``AppendParticipantStatusNode`` did ``dl.read(vendor_participant_id)``
       → ``None`` → ``FAILURE``, leaving finder's replica without the vendor's
@@ -234,7 +236,7 @@ class TestM4AddParticipantStatusAfterBootstrap:
         """AddParticipantStatusBT appends VFd status on finder's replica.
 
         Full M4 path: bootstrap → verify participant stored → receive
-        Add(ParticipantStatus) from case-actor → assert VFd status on vendor
+        Add(as_ParticipantStatus) from case-actor → assert VFd status on vendor
         participant.  Regression for #563.
         """
         _vfd_status_id = f"{_VENDOR_PARTICIPANT_ID}/statuses/vfd-s1"
@@ -247,14 +249,14 @@ class TestM4AddParticipantStatusAfterBootstrap:
         dl.save(link)
 
         # Step 1: bootstrap — _store_embedded_participants saves vendor's
-        # CaseParticipant as an independent DataLayer record (CBT-05-005).
+        # as_CaseParticipant as an independent DataLayer record (CBT-05-005).
         CreateCaseReceivedUseCase(dl, bootstrap_event).execute()
 
         # Step 2: confirm vendor participant is independently stored (core fix).
         stored_p = dl.read(_VENDOR_PARTICIPANT_ID)
         assert (
             stored_p is not None
-        ), "Vendor CaseParticipant must be stored during bootstrap (CBT-05-005)"
+        ), "Vendor as_CaseParticipant must be stored during bootstrap (CBT-05-005)"
 
         # Step 3: vendor self-reports its VFd status to the case actor.
         # actor=_VENDOR_ID passes VerifySenderIsParticipantNode
@@ -282,7 +284,7 @@ class TestM4AddParticipantStatusAfterBootstrap:
         assert (
             updated_p is not None
         ), "Vendor participant must still exist after AddParticipantStatus"
-        updated_p = cast(CaseParticipant, updated_p)
+        updated_p = cast(as_CaseParticipant, updated_p)
         status_ids = [
             getattr(s, "id_", s) for s in updated_p.participant_statuses
         ]
@@ -293,6 +295,6 @@ class TestM4AddParticipantStatusAfterBootstrap:
         # The status object must also exist as an independent DataLayer record.
         stored_status = dl.read(_vfd_status_id)
         assert stored_status is not None, (
-            "ParticipantStatus must be persisted as an independent DataLayer"
+            "as_ParticipantStatus must be persisted as an independent DataLayer"
             " record by AddParticipantStatusToParticipantReceivedUseCase"
         )

--- a/test/core/use_cases/received/case/test_create.py
+++ b/test/core/use_cases/received/case/test_create.py
@@ -45,9 +45,11 @@ from vultron.wire.as2.factories import (
     create_case_activity,
 )
 from vultron.wire.as2.vocab.objects.case_participant import (
-    CaseParticipant,
+    as_CaseParticipant,
 )
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 # ---------------------------------------------------------------------------
 # Shared constants
@@ -70,20 +72,20 @@ _VENDOR_PARTICIPANT_ID = f"{_CASE_ID}/participants/vendor"
 
 
 def _case_with_case_actor_participant() -> tuple:
-    """Build a VulnerabilityCase whose participant list includes a CASE_MANAGER.
+    """Build a as_VulnerabilityCase whose participant list includes a CASE_MANAGER.
 
-    Returns a tuple of (VulnerabilityCase, CaseActorParticipant).  The
+    Returns a tuple of (as_VulnerabilityCase, CaseActorParticipant).  The
     participant is embedded INLINE in the case snapshot (not just an ID),
-    matching what a real bootstrap ``Create(VulnerabilityCase)`` would carry.
+    matching what a real bootstrap ``Create(as_VulnerabilityCase)`` would carry.
     """
-    participant = CaseParticipant(
+    participant = as_CaseParticipant(
         case_roles=[CVDRole.CASE_MANAGER],
         id_=_PARTICIPANT_ID,
         attributed_to=_CASE_ACTOR_ID,
         context=_CASE_ID,
         name="CaseActor",
     )
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         id_=_CASE_ID,
         name="CBT test case",
         case_participants=[participant],
@@ -117,7 +119,7 @@ def dl():
 
 @pytest.fixture()
 def case_with_participant():
-    """Return (VulnerabilityCase, VultronParticipant) with CASE_MANAGER role."""
+    """Return (as_VulnerabilityCase, VultronParticipant) with CASE_MANAGER role."""
     return _case_with_case_actor_participant()
 
 
@@ -256,7 +258,9 @@ class TestAnnounceValidatedByTrustedCaseActorId:
 
     @pytest.fixture()
     def case_obj(self):
-        return VulnerabilityCase(id_=_CASE_ID, name="CBT announce gate case")
+        return as_VulnerabilityCase(
+            id_=_CASE_ID, name="CBT announce gate case"
+        )
 
     @pytest.fixture()
     def announce_from_trusted(self, case_obj):

--- a/test/core/use_cases/received/case/test_helpers.py
+++ b/test/core/use_cases/received/case/test_helpers.py
@@ -39,8 +39,10 @@ from vultron.core.use_cases.received.case.create import (
     CreateCaseReceivedUseCase,
 )
 from vultron.wire.as2.factories import create_case_activity
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 # ---------------------------------------------------------------------------
 # CBT-05-006: Reporter participant seeded with RM.ACCEPTED on bootstrap (#589)
@@ -50,7 +52,7 @@ from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
 class TestBootstrapCreateReporterParticipant:
     """Bootstrap Create must seed the reporter's participant at RM.ACCEPTED.
 
-    When Create(VulnerabilityCase) arrives with participant IDs as bare
+    When Create(as_VulnerabilityCase) arrives with participant IDs as bare
     strings, _store_embedded_participants skips them.  The reporter's own
     participant record would then be absent from their DataLayer, causing
     SvcAddParticipantStatusUseCase._resolve_current_participant_state to
@@ -91,20 +93,20 @@ class TestBootstrapCreateReporterParticipant:
 
     @pytest.fixture()
     def case_with_string_participants(self):
-        """VulnerabilityCase whose participants are bare string IDs.
+        """as_VulnerabilityCase whose participants are bare string IDs.
 
         This is the common wire representation when the sender serialises the
         domain VultronCase (which stores participant IDs, not objects).
         The fixture also includes a CASE_MANAGER participant inline so that
         the bootstrap trust path extracts a trusted_case_actor_id.
         """
-        case_actor_participant = CaseParticipant(
+        case_actor_participant = as_CaseParticipant(
             case_roles=[CVDRole.CASE_MANAGER],
             id_=self._VENDOR_PARTICIPANT_ID,
             attributed_to=self._VENDOR_ID,
             context=self._CASE_ID,
         )
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_=self._CASE_ID,
             name="Bug #589 regression case",
             case_participants=[
@@ -132,7 +134,7 @@ class TestBootstrapCreateReporterParticipant:
     ):
         """Reporter participant must exist in DataLayer after bootstrap (#589).
 
-        When the bootstrap Create(VulnerabilityCase) carries the reporter's
+        When the bootstrap Create(as_VulnerabilityCase) carries the reporter's
         participant as a bare string ID, the DataLayer must still produce a
         standalone participant record for the reporter so that subsequent
         SvcAddParticipantStatusUseCase calls can read it.
@@ -217,13 +219,13 @@ class TestBootstrapReporterUpgradesFromStart:
 
     @pytest.fixture()
     def case_with_string_participants(self):
-        case_actor_participant = CaseParticipant(
+        case_actor_participant = as_CaseParticipant(
             case_roles=[CVDRole.CASE_MANAGER],
             id_=self._VENDOR_PARTICIPANT_ID,
             attributed_to=self._VENDOR_ID,
             context=self._CASE_ID,
         )
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_=self._CASE_ID,
             name="Bug #624 regression case",
             case_participants=[

--- a/test/core/use_cases/received/case/test_update.py
+++ b/test/core/use_cases/received/case/test_update.py
@@ -27,9 +27,11 @@ from vultron.core.use_cases.received.case.update import (
     UpdateCaseReceivedUseCase,
 )
 from vultron.wire.as2.rehydration import rehydrate as real_rehydrate
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.factories import (
     update_case_activity,
 )
@@ -44,14 +46,14 @@ class TestCaseUseCases:
         """update_case applies name/summary/content updates from a full object."""
         dl = SqliteDataLayer("sqlite:///:memory:")
         owner_id = "https://example.org/users/owner"
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/uc1",
             name="Original Name",
             attributed_to=owner_id,
         )
         dl.create(case)
 
-        updated_case = VulnerabilityCase(
+        updated_case = as_VulnerabilityCase(
             id_=case.id_,
             name="Updated Name",
             content="New content",
@@ -75,7 +77,7 @@ class TestCaseUseCases:
 
         stored = dl.read(case.id_)
         assert stored is not None
-        stored = cast(VulnerabilityCase, stored)
+        stored = cast(as_VulnerabilityCase, stored)
         assert stored.name == "Updated Name"
         assert stored.content == "New content"
 
@@ -86,14 +88,14 @@ class TestCaseUseCases:
         dl = SqliteDataLayer("sqlite:///:memory:")
         owner_id = "https://example.org/users/owner"
         non_owner_id = "https://example.org/users/other"
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/uc2",
             name="Original Name",
             attributed_to=owner_id,
         )
         dl.create(case)
 
-        updated_case = VulnerabilityCase(
+        updated_case = as_VulnerabilityCase(
             id_=case.id_,
             name="Hijacked Name",
             attributed_to=owner_id,
@@ -106,7 +108,7 @@ class TestCaseUseCases:
 
         stored = dl.read(case.id_)
         assert stored is not None
-        stored = cast(VulnerabilityCase, stored)
+        stored = cast(as_VulnerabilityCase, stored)
         assert stored.name == "Original Name"
         assert any("not the owner" in r.message for r in caplog.records)
 
@@ -114,14 +116,14 @@ class TestCaseUseCases:
         """update_case with same data produces the same result (last-write-wins)."""
         dl = SqliteDataLayer("sqlite:///:memory:")
         owner_id = "https://example.org/users/owner"
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/uc3",
             name="Original",
             attributed_to=owner_id,
         )
         dl.create(case)
 
-        updated_case = VulnerabilityCase(
+        updated_case = as_VulnerabilityCase(
             id_=case.id_,
             name="Updated",
             attributed_to=owner_id,
@@ -144,7 +146,7 @@ class TestCaseUseCases:
 
         stored = dl.read(case.id_)
         assert stored is not None
-        stored = cast(VulnerabilityCase, stored)
+        stored = cast(as_VulnerabilityCase, stored)
         assert stored.name == "Updated"
 
     def test_update_case_warns_when_participant_has_not_accepted_embargo(
@@ -154,10 +156,10 @@ class TestCaseUseCases:
         dl = SqliteDataLayer("sqlite:///:memory:")
         owner_id = "https://example.org/users/owner"
         actor_id = "https://example.org/users/alice"
-        embargo = EmbargoEvent(id_="https://example.org/embargoes/em1")
+        embargo = as_EmbargoEvent(id_="https://example.org/embargoes/em1")
         dl.create(embargo)
 
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             id_="https://example.org/participants/p1",
             attributed_to=actor_id,
             context="https://example.org/cases/uc4",
@@ -165,7 +167,7 @@ class TestCaseUseCases:
         )
         dl.create(participant)
 
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/uc4",
             name="Original",
             attributed_to=owner_id,
@@ -174,7 +176,7 @@ class TestCaseUseCases:
         case.actor_participant_index[actor_id] = participant.id_
         dl.create(case)
 
-        updated_case = VulnerabilityCase(
+        updated_case = as_VulnerabilityCase(
             id_=case.id_,
             name="Updated",
             attributed_to=owner_id,
@@ -197,10 +199,10 @@ class TestCaseUseCases:
         dl = SqliteDataLayer("sqlite:///:memory:")
         owner_id = "https://example.org/users/owner"
         actor_id = "https://example.org/users/bob"
-        embargo = EmbargoEvent(id_="https://example.org/embargoes/em2")
+        embargo = as_EmbargoEvent(id_="https://example.org/embargoes/em2")
         dl.create(embargo)
 
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             id_="https://example.org/participants/p2",
             attributed_to=actor_id,
             context="https://example.org/cases/uc5",
@@ -208,7 +210,7 @@ class TestCaseUseCases:
         )
         dl.create(participant)
 
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/uc5",
             name="Original",
             attributed_to=owner_id,
@@ -217,7 +219,7 @@ class TestCaseUseCases:
         case.actor_participant_index[actor_id] = participant.id_
         dl.create(case)
 
-        updated_case = VulnerabilityCase(
+        updated_case = as_VulnerabilityCase(
             id_=case.id_,
             name="Updated",
             attributed_to=owner_id,
@@ -238,7 +240,7 @@ class TestCaseUseCases:
         owner_id = "https://example.org/users/owner"
         actor_id = "https://example.org/users/carol"
 
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             id_="https://example.org/participants/p3",
             attributed_to=actor_id,
             context="https://example.org/cases/uc6",
@@ -246,7 +248,7 @@ class TestCaseUseCases:
         )
         dl.create(participant)
 
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/uc6",
             name="Original",
             attributed_to=owner_id,
@@ -255,7 +257,7 @@ class TestCaseUseCases:
         case.actor_participant_index[actor_id] = participant.id_
         dl.create(case)
 
-        updated_case = VulnerabilityCase(
+        updated_case = as_VulnerabilityCase(
             id_=case.id_,
             name="Updated",
             attributed_to=owner_id,
@@ -276,7 +278,7 @@ class TestCaseUseCases:
         owner_id = "https://example.org/users/owner"
         actor_id = "https://example.org/users/alice"
         case_id = "https://example.org/cases/uc6b"
-        embargo = EmbargoEvent(id_="https://example.org/embargoes/em6b")
+        embargo = as_EmbargoEvent(id_="https://example.org/embargoes/em6b")
         dl.create(embargo)
 
         bogus_ref = VultronActivity(
@@ -294,7 +296,7 @@ class TestCaseUseCases:
         )
         dl.create(case_actor)
 
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_=case_id,
             name="Original",
             attributed_to=owner_id,
@@ -303,7 +305,7 @@ class TestCaseUseCases:
         case.actor_participant_index[actor_id] = bogus_ref.id_
         dl.create(case)
 
-        updated_case = VulnerabilityCase(
+        updated_case = as_VulnerabilityCase(
             id_=case_id,
             name="Updated",
             attributed_to=owner_id,
@@ -344,7 +346,7 @@ class TestCaseUseCases:
         )
         dl.create(case_actor)
 
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_=case_id,
             name="Original",
             attributed_to=owner_id,
@@ -354,7 +356,7 @@ class TestCaseUseCases:
         )
         dl.create(case)
 
-        updated_case = VulnerabilityCase(
+        updated_case = as_VulnerabilityCase(
             id_=case_id, name="Updated", attributed_to=owner_id
         )
         activity = update_case_activity(updated_case, actor=owner_id)
@@ -385,12 +387,12 @@ class TestCaseUseCases:
         owner_id = "https://example.org/users/owner"
         case_id = "https://example.org/cases/bc2"
 
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_=case_id, name="Original", attributed_to=owner_id
         )
         dl.create(case)
 
-        updated_case = VulnerabilityCase(
+        updated_case = as_VulnerabilityCase(
             id_=case_id, name="Updated", attributed_to=owner_id
         )
         activity = update_case_activity(updated_case, actor=owner_id)
@@ -401,7 +403,7 @@ class TestCaseUseCases:
 
         stored = dl.read(case_id)
         assert stored is not None
-        stored = cast(VulnerabilityCase, stored)
+        stored = cast(as_VulnerabilityCase, stored)
         assert stored.name == "Updated"
 
     def test_update_case_no_broadcast_when_no_participants(self, make_payload):
@@ -418,12 +420,12 @@ class TestCaseUseCases:
         )
         dl.create(case_actor)
 
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_=case_id, name="Original", attributed_to=owner_id
         )
         dl.create(case)
 
-        updated_case = VulnerabilityCase(
+        updated_case = as_VulnerabilityCase(
             id_=case_id, name="Updated", attributed_to=owner_id
         )
         activity = update_case_activity(updated_case, actor=owner_id)
@@ -452,7 +454,7 @@ class TestCaseUseCases:
         )
         dl.create(case_actor)
 
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_=case_id, name="Original", attributed_to=owner_id
         )
         case.actor_participant_index[alice] = (
@@ -463,7 +465,7 @@ class TestCaseUseCases:
         )
         dl.create(case)
 
-        updated_case = VulnerabilityCase(
+        updated_case = as_VulnerabilityCase(
             id_=case_id, name="Updated", attributed_to=owner_id
         )
         activity = update_case_activity(updated_case, actor=owner_id)

--- a/test/core/use_cases/received/case/test_update_bt.py
+++ b/test/core/use_cases/received/case/test_update_bt.py
@@ -30,7 +30,9 @@ from vultron.core.use_cases.received.case.update import (
     UpdateCaseReceivedUseCase,
 )
 from vultron.wire.as2.factories import update_case_activity
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 
 class TestUpdateCaseBTStructure:
@@ -42,7 +44,7 @@ class TestUpdateCaseBTStructure:
         """UpdateCaseBT keeps ownership, embargo, update, and broadcast in-tree."""
         owner_id = "https://example.org/users/owner"
         case_id = "https://example.org/cases/bt1"
-        updated_case = VulnerabilityCase(
+        updated_case = as_VulnerabilityCase(
             id_=case_id, name="Updated", attributed_to=owner_id
         )
         activity = update_case_activity(updated_case, actor=owner_id)
@@ -79,7 +81,7 @@ class TestUpdateCaseBTStructure:
         )
         dl.create(case_actor)
 
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_=case_id,
             name="Original",
             attributed_to=owner_id,
@@ -89,7 +91,7 @@ class TestUpdateCaseBTStructure:
         )
         dl.create(case)
 
-        updated_case = VulnerabilityCase(
+        updated_case = as_VulnerabilityCase(
             id_=case_id,
             name="Updated",
             attributed_to=owner_id,

--- a/test/core/use_cases/received/conftest.py
+++ b/test/core/use_cases/received/conftest.py
@@ -1,7 +1,7 @@
 """
 Fixtures for test/core/use_cases/received tests.
 
-Imports VulnerabilityCase (and related wire-layer types) as a side effect so
+Imports as_VulnerabilityCase (and related wire-layer types) as a side effect so
 that the global vocabulary registry is populated before any test in this
 directory runs.  Without this import the registry may be empty when tests run
 in isolation, causing TinyDB's record_to_object() to fall back to returning a
@@ -13,7 +13,7 @@ import pytest
 # noqa: F401 — imported for vocabulary registration side-effect
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.wire.as2.vocab.objects.vulnerability_case import (  # noqa: F401
-    VulnerabilityCase,
+    as_VulnerabilityCase,
 )
 
 

--- a/test/core/use_cases/received/test_ack_report_routing.py
+++ b/test/core/use_cases/received/test_ack_report_routing.py
@@ -33,10 +33,12 @@ from vultron.core.models.report import VultronReport
 from vultron.enums.roles import CVDRole
 from vultron.core.use_cases.received.report import AckReportReceivedUseCase
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 # ---------------------------------------------------------------------------
@@ -76,12 +78,12 @@ def _make_case_actor_dl() -> SqliteDataLayer:
     ca_svc = VultronCaseActor(id_=CASE_ACTOR_ID, context=CASE_ID)
     dl.save(ca_svc)
 
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         id_=CASE_ID, name="AckReport Routing Test", attributed_to=CASE_ACTOR_ID
     )
     case.vulnerability_reports.append(REPORT_ID)
 
-    cm_participant = CaseParticipant(
+    cm_participant = as_CaseParticipant(
         attributed_to=CASE_ACTOR_ID,
         context=CASE_ID,
         case_roles=[CVDRole.CASE_MANAGER],
@@ -92,7 +94,7 @@ def _make_case_actor_dl() -> SqliteDataLayer:
     dl.save(case)
 
     # Persist the offer so the emit node can read it.
-    report_obj = VulnerabilityReport(id_=REPORT_ID, name="Test Vuln Report")
+    report_obj = as_VulnerabilityReport(id_=REPORT_ID, name="Test Vuln Report")
     dl.save(report_obj)
     offer = as_Offer(actor=FINDER_ID, object_=report_obj.id_, target=VENDOR_ID)
     offer = as_Offer(id_=OFFER_ID, actor=FINDER_ID, object_=report_obj.id_)

--- a/test/core/use_cases/received/test_ack_validate_report_received.py
+++ b/test/core/use_cases/received/test_ack_validate_report_received.py
@@ -28,7 +28,9 @@ from vultron.core.use_cases.received.report import (
     SubmitReportReceivedUseCase,
     ValidateReportReceivedUseCase,
 )
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 
 class TestAckReportNoStandaloneStatus:
@@ -71,7 +73,7 @@ class TestFullReportFlow:
     """Integration test: Offer(Report) receipt → ValidateReport full flow.
 
     Per IDEA-260408-01-7 and ADR-0015:
-    1. SubmitReportReceivedUseCase creates a VulnerabilityCase at RM.RECEIVED.
+    1. SubmitReportReceivedUseCase creates a as_VulnerabilityCase at RM.RECEIVED.
     2. ValidateReportReceivedUseCase validates without re-creating the case.
     3. Final state: vendor participant at RM.VALID, finder at RM.ACCEPTED.
 
@@ -150,7 +152,7 @@ class TestFullReportFlow:
         SubmitReportReceivedUseCase(dl, self._make_submit_event()).execute()
 
         cases = dl.get_all("VulnerabilityCase")
-        assert len(cases) == 1, "Expected exactly one VulnerabilityCase"
+        assert len(cases) == 1, "Expected exactly one as_VulnerabilityCase"
         case_report_ids = [
             rid
             for c in cases
@@ -160,7 +162,7 @@ class TestFullReportFlow:
         ]
         assert (
             self.REPORT_ID in case_report_ids
-        ), f"VulnerabilityCase must reference report {self.REPORT_ID}"
+        ), f"as_VulnerabilityCase must reference report {self.REPORT_ID}"
 
     def test_full_flow_validate_does_not_recreate_case(self):
         """validate-report does NOT create a new case after Offer(Report) receipt.
@@ -234,7 +236,7 @@ class TestFullReportFlow:
         """Full flow from Offer receipt to validation produces the expected state.
 
         Verifies the combined invariants of ADR-0015:
-        - Exactly one VulnerabilityCase
+        - Exactly one as_VulnerabilityCase
         - Vendor participant has RM.VALID in history after validate-report
         - Finder participant at RM.ACCEPTED (reporter is accepted upon submission)
         """
@@ -247,7 +249,7 @@ class TestFullReportFlow:
         ).execute()
 
         cases = dl.get_all("VulnerabilityCase")
-        assert len(cases) == 1, "Expected exactly one VulnerabilityCase"
+        assert len(cases) == 1, "Expected exactly one as_VulnerabilityCase"
 
         valid_id = _report_phase_status_id(
             self.VENDOR_ID, self.REPORT_ID, RM.VALID.value
@@ -359,7 +361,7 @@ class TestValidateReportReceivedGuardedCommit:
         report = VultronReport(id_=self.REPORT_ID)
         dl.save(report)
 
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/c-guarded",
             name="Guarded Commit Test Case",
         )
@@ -367,10 +369,10 @@ class TestValidateReportReceivedGuardedCommit:
         # Register case actor as CASE_MANAGER
         from vultron.enums.roles import CVDRole
         from vultron.wire.as2.vocab.objects.case_participant import (
-            CaseParticipant,
+            as_CaseParticipant,
         )
 
-        cm_participant = CaseParticipant(
+        cm_participant = as_CaseParticipant(
             attributed_to=self.CASE_ACTOR_ID,
             context=case.id_,
             case_roles=[CVDRole.CASE_MANAGER],
@@ -415,10 +417,10 @@ class TestValidateReportReceivedGuardedCommit:
         from vultron.core.models.report_case_link import VultronReportCaseLink
         from vultron.enums.roles import CVDRole
         from vultron.wire.as2.vocab.objects.case_participant import (
-            CaseParticipant,
+            as_CaseParticipant,
         )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         CASE_ID = "https://example.org/cases/c-commit-positive"
@@ -428,13 +430,13 @@ class TestValidateReportReceivedGuardedCommit:
         report = VultronReport(id_=self.REPORT_ID)
         dl.save(report)
 
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_=CASE_ID,
             name="Guarded Commit Positive Test",
         )
         case.vulnerability_reports.append(self.REPORT_ID)
         # Register the CASE_ACTOR as CASE_MANAGER so CheckIsCaseManagerNode passes
-        cm_participant = CaseParticipant(
+        cm_participant = as_CaseParticipant(
             attributed_to=self.CASE_ACTOR_ID,
             context=CASE_ID,
             case_roles=[CVDRole.CASE_MANAGER],

--- a/test/core/use_cases/received/test_case_participant.py
+++ b/test/core/use_cases/received/test_case_participant.py
@@ -32,18 +32,18 @@ class TestCaseParticipantUseCases:
             as_Remove,
         )
         from vultron.wire.as2.vocab.objects.case_participant import (
-            CaseParticipant,
+            as_CaseParticipant,
         )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         dl = SqliteDataLayer("sqlite:///:memory:")
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/case2",
             name="TEST-REMOVE",
         )
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             id_="https://example.org/cases/case2/participants/coord",
             attributed_to="https://example.org/users/coordinator",
             context=case.id_,
@@ -62,7 +62,7 @@ class TestCaseParticipantUseCases:
 
         RemoveCaseParticipantFromCaseReceivedUseCase(dl, event).execute()
 
-        case = cast(VulnerabilityCase, dl.read(case.id_))
+        case = cast(as_VulnerabilityCase, dl.read(case.id_))
         assert case is not None
         assert participant.id_ not in [
             getattr(p, "id_", p) for p in case.case_participants
@@ -77,19 +77,19 @@ class TestCaseParticipantUseCases:
             as_Remove,
         )
         from vultron.wire.as2.vocab.objects.case_participant import (
-            CaseParticipant,
+            as_CaseParticipant,
         )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         dl = SqliteDataLayer("sqlite:///:memory:")
 
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/case3",
             name="TEST-REMOVE-IDEMPOTENT",
         )
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             id_="https://example.org/cases/case3/participants/coord",
             attributed_to="https://example.org/users/coordinator",
             context=case.id_,
@@ -120,19 +120,19 @@ class TestCaseParticipantUseCases:
             as_Add,
         )
         from vultron.wire.as2.vocab.objects.case_participant import (
-            CaseParticipant,
+            as_CaseParticipant,
         )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         dl = SqliteDataLayer("sqlite:///:memory:")
         actor_id = "https://example.org/users/coordinator"
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/caseAP1",
             name="TEST-ADD-INDEX",
         )
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             id_="https://example.org/cases/caseAP1/participants/coord",
             attributed_to=actor_id,
             context=case.id_,
@@ -150,7 +150,7 @@ class TestCaseParticipantUseCases:
 
         AddCaseParticipantToCaseReceivedUseCase(dl, event).execute()
 
-        case = cast(VulnerabilityCase, dl.read(case.id_))
+        case = cast(as_VulnerabilityCase, dl.read(case.id_))
         assert case is not None
         assert actor_id in case.actor_participant_index
         assert case.actor_participant_index[actor_id] == participant.id_
@@ -164,19 +164,19 @@ class TestCaseParticipantUseCases:
             as_Remove,
         )
         from vultron.wire.as2.vocab.objects.case_participant import (
-            CaseParticipant,
+            as_CaseParticipant,
         )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         dl = SqliteDataLayer("sqlite:///:memory:")
         actor_id = "https://example.org/users/coordinator"
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/caseRM1",
             name="TEST-REMOVE-INDEX",
         )
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             id_="https://example.org/cases/caseRM1/participants/coord",
             attributed_to=actor_id,
             context=case.id_,
@@ -197,6 +197,6 @@ class TestCaseParticipantUseCases:
 
         RemoveCaseParticipantFromCaseReceivedUseCase(dl, event).execute()
 
-        case = cast(VulnerabilityCase, dl.read(case.id_))
+        case = cast(as_VulnerabilityCase, dl.read(case.id_))
         assert case is not None
         assert actor_id not in case.actor_participant_index

--- a/test/core/use_cases/received/test_case_proposal.py
+++ b/test/core/use_cases/received/test_case_proposal.py
@@ -44,7 +44,7 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
 from vultron.wire.as2.vocab.examples._base import gen_report
 from vultron.wire.as2.vocab.objects.case_proposal import as_CaseProposal
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 _CASE_ACTOR_URI = "https://example.org/case-actors/svc-1"
@@ -156,7 +156,7 @@ class TestCreateCaseProposalReceivedUseCase:
         assert is_case_model(case_obj)
 
         report_obj = proposal.object_
-        assert isinstance(report_obj, VulnerabilityReport)
+        assert isinstance(report_obj, as_VulnerabilityReport)
         report_id = report_obj.id_
         assert (
             report_id in case_obj.vulnerability_reports
@@ -389,8 +389,8 @@ class TestAcceptCaseProposalReceivedUseCase:
         dl = SqliteDataLayer("sqlite:///:memory:")
         proposal = _make_proposal()
         assert isinstance(
-            proposal.object_, VulnerabilityReport
-        ), "_make_proposal() must embed a full VulnerabilityReport"
+            proposal.object_, as_VulnerabilityReport
+        ), "_make_proposal() must embed a full as_VulnerabilityReport"
         report_id = proposal.object_.id_
 
         # Seed a VultronReportCaseLink so the use case can find it
@@ -456,7 +456,7 @@ class TestRejectCaseProposalReceivedUseCase:
         """Rejection sets proposal_rejected=True on VultronReportCaseLink (CP-06-004)."""
         dl = SqliteDataLayer("sqlite:///:memory:")
         proposal = _make_proposal()
-        assert isinstance(proposal.object_, VulnerabilityReport)
+        assert isinstance(proposal.object_, as_VulnerabilityReport)
         report_id = proposal.object_.id_
 
         # Seed a VultronReportCaseLink so the use case can find it
@@ -489,7 +489,7 @@ class TestRejectCaseProposalReceivedUseCase:
         """When Reject activity carries a summary, it is stored as rejection_reason (CP-06-004)."""
         dl = SqliteDataLayer("sqlite:///:memory:")
         proposal = _make_proposal()
-        assert isinstance(proposal.object_, VulnerabilityReport)
+        assert isinstance(proposal.object_, as_VulnerabilityReport)
         report_id = proposal.object_.id_
 
         link = VultronReportCaseLink(

--- a/test/core/use_cases/received/test_close_case_routing.py
+++ b/test/core/use_cases/received/test_close_case_routing.py
@@ -30,8 +30,10 @@ from vultron.enums.roles import CVDRole
 from vultron.core.use_cases.received.case.lifecycle import (
     CloseCaseReceivedUseCase,
 )
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -67,13 +69,13 @@ def _make_case_actor_dl() -> SqliteDataLayer:
     ca_svc = VultronCaseActor(id_=CASE_ACTOR_ID, context=CASE_ID)
     dl.save(ca_svc)
 
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         id_=CASE_ID,
         name="CloseCase Routing Test",
         attributed_to=CASE_ACTOR_ID,
     )
 
-    cm_participant = CaseParticipant(
+    cm_participant = as_CaseParticipant(
         attributed_to=CASE_ACTOR_ID,
         context=CASE_ID,
         case_roles=[CVDRole.CASE_MANAGER],
@@ -90,7 +92,7 @@ def _make_close_case_event(
     receiving_actor_id: str | None = CASE_ACTOR_ID,
     leave_actor_id: str = VENDOR_ID,
 ) -> CloseCaseReceivedEvent:
-    """Construct a CloseCaseReceivedEvent (Leave(VulnerabilityCase)).
+    """Construct a CloseCaseReceivedEvent (Leave(as_VulnerabilityCase)).
 
     Args:
         receiving_actor_id: The actor whose inbox is processing this Leave.
@@ -99,7 +101,7 @@ def _make_close_case_event(
             CASE_ACTOR_ID to simulate the AutoCloseBranchNode path where the
             case-actor emits the Leave to itself.
     """
-    case_obj = VulnerabilityCase(id_=CASE_ID)
+    case_obj = as_VulnerabilityCase(id_=CASE_ID)
     activity = VultronActivity(
         id_="https://example.org/activities/leave-case",
         type_="Leave",
@@ -171,7 +173,7 @@ class TestCloseCaseLedgerRouting:
     def test_caseactor_self_leave_commits_close_case_ledger_entry(self):
         """Case-actor-authored Leave (AutoCloseBranchNode path) is committed.
 
-        AutoCloseBranchNode emits Leave(VulnerabilityCase) with
+        AutoCloseBranchNode emits Leave(as_VulnerabilityCase) with
         actor=case_actor_id to signal that all participants have closed.  The
         case-actor must accept its own Leave as a canonical ledger entry
         because the close_case signature IS case-authored (DEMOMA-07-003 step 5).

--- a/test/core/use_cases/received/test_create_report_received.py
+++ b/test/core/use_cases/received/test_create_report_received.py
@@ -31,9 +31,11 @@ from vultron.core.use_cases.received.report import (
     SubmitReportReceivedUseCase,
 )
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Create
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 
@@ -42,7 +44,7 @@ class TestUseCaseExecution:
 
     def test_create_report_executes_with_valid_semantics(self, make_payload):
         """CreateReportReceivedUseCase executes when semantics match."""
-        report = VulnerabilityReport(
+        report = as_VulnerabilityReport(
             name="TEST-002", content="Test vulnerability report"
         )
         create_activity = as_Create(
@@ -56,7 +58,7 @@ class TestUseCaseExecution:
 
     def test_create_case_executes_with_valid_semantics(self, make_payload):
         """CreateCaseReceivedUseCase executes when semantics match."""
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             name="TEST-CASE-002", content="Test vulnerability case"
         )
         create_activity = as_Create(
@@ -71,7 +73,7 @@ class TestUseCaseExecution:
     def test_use_case_executes_with_real_datalayer(self, make_payload):
         """CreateReportReceivedUseCase executes without raising on real DataLayer."""
         dl = SqliteDataLayer("sqlite:///:memory:")
-        report = VulnerabilityReport(
+        report = as_VulnerabilityReport(
             name="TEST-003", content="Test report for shim delegation"
         )
         create_activity = as_Create(
@@ -136,11 +138,11 @@ class TestCreateReportNoStandaloneParticipantStatus:
         stored_report = dl.read("https://example.org/reports/r-store-1")
         assert (
             stored_report is not None
-        ), "VulnerabilityReport should be stored"
+        ), "as_VulnerabilityReport should be stored"
 
 
 class TestDuplicateReportHandling:
-    """Tests that duplicate VulnerabilityReport warnings are not emitted.
+    """Tests that duplicate as_VulnerabilityReport warnings are not emitted.
 
     The inbox endpoint pre-stores nested objects before dispatching to use
     cases.  When the use case then tries to store the same report, the
@@ -176,7 +178,7 @@ class TestDuplicateReportHandling:
     ):
         """SubmitReportReceivedUseCase emits no WARNING when report already stored.
 
-        The inbox endpoint pre-stores the nested VulnerabilityReport before
+        The inbox endpoint pre-stores the nested as_VulnerabilityReport before
         dispatching; the use case must degrade to DEBUG, not WARNING.
         Per D5-6-DUP.
         """
@@ -210,7 +212,7 @@ class TestDuplicateReportHandling:
             r for r in caplog.records if r.levelno >= logging.WARNING
         ]
         assert warning_records == [], (
-            "No WARNING should be emitted when VulnerabilityReport is "
+            "No WARNING should be emitted when as_VulnerabilityReport is "
             f"pre-stored by inbox endpoint; got: {[r.message for r in warning_records]}"
         )
 
@@ -247,6 +249,6 @@ class TestDuplicateReportHandling:
             r for r in caplog.records if r.levelno >= logging.WARNING
         ]
         assert warning_records == [], (
-            "No WARNING should be emitted when VulnerabilityReport is "
+            "No WARNING should be emitted when as_VulnerabilityReport is "
             f"pre-stored by inbox endpoint; got: {[r.message for r in warning_records]}"
         )

--- a/test/core/use_cases/received/test_embargo_ledger_cascade.py
+++ b/test/core/use_cases/received/test_embargo_ledger_cascade.py
@@ -34,8 +34,10 @@ from vultron.wire.as2.factories import (
     em_reject_embargo_activity,
     remove_embargo_from_case_activity,
 )
-from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 
 def _make_embargo_case_with_actor(
@@ -43,14 +45,18 @@ def _make_embargo_case_with_actor(
     author_id: str,
     extra_participants: list[str] | None = None,
     case_manager_actor_id: str | None = None,
-) -> tuple[SqliteDataLayer, VultronCaseActor, VulnerabilityCase, EmbargoEvent]:
+) -> tuple[
+    SqliteDataLayer, VultronCaseActor, as_VulnerabilityCase, as_EmbargoEvent
+]:
     """Return (dl, case_actor, case, embargo) ready for cascade tests.
 
-    Also creates ``CaseParticipant`` objects so actor → participant lookups
+    Also creates ``as_CaseParticipant`` objects so actor → participant lookups
     in the embargo handlers succeed.
     """
     from vultron.enums.roles import CVDRole
-    from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+    from vultron.wire.as2.vocab.objects.case_participant import (
+        as_CaseParticipant,
+    )
 
     dl = SqliteDataLayer("sqlite:///:memory:")
     case_actor_id = f"{case_id}/actor"
@@ -63,25 +69,27 @@ def _make_embargo_case_with_actor(
     )
     dl.create(case_actor)
 
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         id_=case_id,
         name="Embargo Cascade Case",
         attributed_to=author_id,
     )
     p1_id = f"{case_id}/participants/p1"
     case.actor_participant_index[author_id] = p1_id
-    p1 = CaseParticipant(id_=p1_id, context=case_id, attributed_to=author_id)
+    p1 = as_CaseParticipant(
+        id_=p1_id, context=case_id, attributed_to=author_id
+    )
     dl.create(p1)
 
     for pid in extra_participants or []:
         short = pid.rsplit("/", 1)[-1]
         pn_id = f"{case_id}/participants/{short}"
         case.actor_participant_index[pid] = pn_id
-        pn = CaseParticipant(id_=pn_id, context=case_id, attributed_to=pid)
+        pn = as_CaseParticipant(id_=pn_id, context=case_id, attributed_to=pid)
         dl.create(pn)
 
     dl.create(case)
-    case_manager_participant = CaseParticipant(
+    case_manager_participant = as_CaseParticipant(
         id_=f"{case_id}/participants/case-actor-p",
         attributed_to=case_manager_actor_id or case_actor_id,
         context=case_id,
@@ -94,7 +102,7 @@ def _make_embargo_case_with_actor(
     )
     dl.save(case)
 
-    embargo = EmbargoEvent(
+    embargo = as_EmbargoEvent(
         id_=f"{case_id}/embargo_events/e1",
         content="Cascade test embargo",
         context=case_id,
@@ -114,7 +122,7 @@ class TestEmbargoLogEntryCascade:
         dl, case_actor, case, embargo = _make_embargo_case_with_actor(
             case_id, author_id, case_manager_actor_id=author_id
         )
-        case = cast(VulnerabilityCase, dl.read(case.id_))
+        case = cast(as_VulnerabilityCase, dl.read(case.id_))
         assert case is not None
         case.current_status.em_state = EM.PROPOSED
         dl.save(case)
@@ -151,7 +159,7 @@ class TestEmbargoLogEntryCascade:
         dl, case_actor, case, embargo = _make_embargo_case_with_actor(
             case_id, author_id
         )
-        case = cast(VulnerabilityCase, dl.read(case.id_))
+        case = cast(as_VulnerabilityCase, dl.read(case.id_))
         assert case is not None
         case.current_status.em_state = EM.ACTIVE
         case.proposed_embargoes.append(embargo.id_)
@@ -198,7 +206,7 @@ class TestEmbargoLogEntryCascade:
             case_id, author_id
         )
         # EM.NONE: no active embargo — BT will FAIL (IsActiveEmbargoNode)
-        case = cast(VulnerabilityCase, dl.read(case.id_))
+        case = cast(as_VulnerabilityCase, dl.read(case.id_))
         assert case is not None
         case.current_status.em_state = EM.NONE
         dl.save(case)
@@ -277,7 +285,7 @@ class TestEmbargoLogEntryCascade:
         dl, case_actor, case, embargo = _make_embargo_case_with_actor(
             case_id, coordinator_id, case_manager_actor_id=coordinator_id
         )
-        case = cast(VulnerabilityCase, dl.read(case.id_))
+        case = cast(as_VulnerabilityCase, dl.read(case.id_))
         assert case is not None
         case.current_status.em_state = EM.PROPOSED
         dl.save(case)

--- a/test/core/use_cases/received/test_embargo_misc.py
+++ b/test/core/use_cases/received/test_embargo_misc.py
@@ -33,17 +33,19 @@ class TestAnnounceEmbargoEventToCaseReceivedUseCase:
     def test_announce_embargo_is_noop(self, make_payload):
         """execute() is a no-op: EM state and active_embargo are unchanged."""
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
-        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+        from vultron.wire.as2.vocab.objects.embargo_event import (
+            as_EmbargoEvent,
+        )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         dl = SqliteDataLayer("sqlite:///:memory:")
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/case_aem1",
             name="Announce Embargo No-Op Test",
         )
-        embargo = EmbargoEvent(
+        embargo = as_EmbargoEvent(
             id_="https://example.org/cases/case_aem1/embargo_events/e1",
             context=case.id_,
         )
@@ -60,7 +62,7 @@ class TestAnnounceEmbargoEventToCaseReceivedUseCase:
 
         AnnounceEmbargoEventToCaseReceivedUseCase(dl, event).execute()
 
-        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        updated = cast(as_VulnerabilityCase, dl.read(case.id_))
         assert updated is not None
         # State is UNCHANGED — Announce is not the ET message
         assert updated.current_status.em_state == EM.ACTIVE
@@ -83,7 +85,7 @@ class TestAnnounceEmbargoEventToCaseReceivedUseCase:
 
 class TestResetEmbargoConsentWithInlineParticipants:
     """Regression tests for #609: _reset_case_participant_embargo_consent
-    must tolerate inline CaseParticipant objects in case.case_participants,
+    must tolerate inline as_CaseParticipant objects in case.case_participants,
     not just plain string IDs.
     """
 
@@ -91,7 +93,7 @@ class TestResetEmbargoConsentWithInlineParticipants:
         self, make_payload
     ):
         """remove_embargo_from_case must not raise TypeError when
-        case.case_participants holds inline CaseParticipant objects
+        case.case_participants holds inline as_CaseParticipant objects
         (as stored on receiver side after fixes #572/#573).
 
         Regression test for #609.
@@ -100,11 +102,13 @@ class TestResetEmbargoConsentWithInlineParticipants:
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
         from vultron.core.states.participant_embargo_consent import PEC
         from vultron.wire.as2.vocab.objects.case_participant import (
-            CaseParticipant,
+            as_CaseParticipant,
         )
-        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+        from vultron.wire.as2.vocab.objects.embargo_event import (
+            as_EmbargoEvent,
+        )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         py_trees.blackboard.Blackboard.enable_activity_stream()
@@ -117,7 +121,7 @@ class TestResetEmbargoConsentWithInlineParticipants:
         dl = SqliteDataLayer("sqlite:///:memory:")
 
         # Build a participant and store it — it also appears inline in case
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             id_=participant_id,
             context=case_id,
             attributed_to=actor_id,
@@ -126,15 +130,15 @@ class TestResetEmbargoConsentWithInlineParticipants:
         participant.embargo_consent_state = PEC.SIGNATORY
         dl.create(participant)
 
-        embargo = EmbargoEvent(
+        embargo = as_EmbargoEvent(
             id_=f"{case_id}/embargo_events/e1",
             context=case_id,
         )
         dl.create(embargo)
 
-        # Store inline CaseParticipant object (not string ID) in
+        # Store inline as_CaseParticipant object (not string ID) in
         # case_participants — this is the condition that caused #609.
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_=case_id,
             name="Inline Participant Regression Test",
             attributed_to=actor_id,
@@ -155,14 +159,14 @@ class TestResetEmbargoConsentWithInlineParticipants:
         # Must not raise TypeError
         RemoveEmbargoEventFromCaseReceivedUseCase(dl, event).execute()
 
-        updated = cast(VulnerabilityCase, dl.read(case_id))
+        updated = cast(as_VulnerabilityCase, dl.read(case_id))
         assert updated is not None
         assert updated.active_embargo is None
         assert updated.current_status.em_state == EM.EXITED
 
     def test_reset_consent_with_inline_participant_resets_state(self):
         """_reset_case_participant_embargo_consent resets consent state even
-        when case_participants entries are inline wire-layer CaseParticipant
+        when case_participants entries are inline wire-layer as_CaseParticipant
         objects (not string IDs).
 
         Regression test for #609.
@@ -174,10 +178,10 @@ class TestResetEmbargoConsentWithInlineParticipants:
             reset_case_participant_embargo_consent as _reset_case_participant_embargo_consent,
         )
         from vultron.wire.as2.vocab.objects.case_participant import (
-            CaseParticipant,
+            as_CaseParticipant,
         )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         actor_id = "https://example.org/users/finder"
@@ -186,9 +190,9 @@ class TestResetEmbargoConsentWithInlineParticipants:
 
         dl = SqliteDataLayer("sqlite:///:memory:")
 
-        # Wire-layer CaseParticipant with non-default consent state.
+        # Wire-layer as_CaseParticipant with non-default consent state.
         # Stored in the DataLayer separately so dl.read(participant_id) works.
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             id_=participant_id,
             context=case_id,
             attributed_to=actor_id,
@@ -198,7 +202,7 @@ class TestResetEmbargoConsentWithInlineParticipants:
 
         # Inline wire-layer object in case_participants — this is the condition
         # that caused #609 on the receiver side after fixes #572/#573.
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_=case_id,
             name="Reset Consent Inline",
         )

--- a/test/core/use_cases/received/test_embargo_propose_accept_reject.py
+++ b/test/core/use_cases/received/test_embargo_propose_accept_reject.py
@@ -45,23 +45,25 @@ class TestEmbargoProposalLifecycle:
     def test_create_embargo_event_stores_event(
         self, monkeypatch, make_payload
     ):
-        """create_embargo_event persists the EmbargoEvent to the DataLayer."""
+        """create_embargo_event persists the as_EmbargoEvent to the DataLayer."""
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
         from vultron.wire.as2.vocab.base.objects.activities.transitive import (
             as_Create,
         )
-        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+        from vultron.wire.as2.vocab.objects.embargo_event import (
+            as_EmbargoEvent,
+        )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         dl = SqliteDataLayer("sqlite:///:memory:")
 
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/case_cem1",
             name="Create Embargo Test",
         )
-        embargo = EmbargoEvent(
+        embargo = as_EmbargoEvent(
             id_="https://example.org/cases/case_cem1/embargo_events/embargo1",
             content="Proposed embargo",
         )
@@ -79,23 +81,25 @@ class TestEmbargoProposalLifecycle:
         assert stored is not None
 
     def test_create_embargo_event_idempotent(self, monkeypatch, make_payload):
-        """create_embargo_event skips storing a duplicate EmbargoEvent."""
+        """create_embargo_event skips storing a duplicate as_EmbargoEvent."""
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
         from vultron.wire.as2.vocab.base.objects.activities.transitive import (
             as_Create,
         )
-        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+        from vultron.wire.as2.vocab.objects.embargo_event import (
+            as_EmbargoEvent,
+        )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         dl = SqliteDataLayer("sqlite:///:memory:")
 
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/case_cem2",
             name="Create Embargo Idempotent",
         )
-        embargo = EmbargoEvent(
+        embargo = as_EmbargoEvent(
             id_="https://example.org/cases/case_cem2/embargo_events/embargo2",
             content="Proposed embargo",
         )
@@ -119,11 +123,13 @@ class TestEmbargoProposalLifecycle:
     ):
         """invite_to_embargo_on_case persists the EmProposeEmbargoActivity activity."""
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
-        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+        from vultron.wire.as2.vocab.objects.embargo_event import (
+            as_EmbargoEvent,
+        )
 
         dl = SqliteDataLayer("sqlite:///:memory:")
 
-        embargo = EmbargoEvent(
+        embargo = as_EmbargoEvent(
             id_="https://example.org/cases/case_em2/embargo_events/e2",
             content="Proposed embargo",
         )
@@ -148,19 +154,21 @@ class TestEmbargoProposalLifecycle:
     ):
         """accept_invite_to_embargo_on_case activates the embargo on the case (PROPOSED → ACTIVE)."""
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
-        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+        from vultron.wire.as2.vocab.objects.embargo_event import (
+            as_EmbargoEvent,
+        )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         dl = SqliteDataLayer("sqlite:///:memory:")
         coordinator_id = "https://example.org/users/coordinator"
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/case_em3",
             name="EM Accept Test",
             attributed_to=coordinator_id,
         )
-        embargo = EmbargoEvent(
+        embargo = as_EmbargoEvent(
             id_="https://example.org/cases/case_em3/embargo_events/e3",
             content="Embargo",
         )
@@ -188,7 +196,7 @@ class TestEmbargoProposalLifecycle:
 
         case = dl.read(case.id_)
         assert case is not None
-        case = cast(VulnerabilityCase, case)
+        case = cast(as_VulnerabilityCase, case)
         assert case.active_embargo is not None
         assert case.current_status.em_state == EM.ACTIVE
 
@@ -197,19 +205,21 @@ class TestEmbargoProposalLifecycle:
     ):
         """accept_invite_to_embargo_on_case ledgers WARNING when EM state is not on the standard machine path."""
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
-        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+        from vultron.wire.as2.vocab.objects.embargo_event import (
+            as_EmbargoEvent,
+        )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         dl = SqliteDataLayer("sqlite:///:memory:")
         coordinator_id = "https://example.org/users/coordinator"
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/case_em3_warn",
             name="EM Accept Warn Test",
             attributed_to=coordinator_id,
         )
-        embargo = EmbargoEvent(
+        embargo = as_EmbargoEvent(
             id_="https://example.org/cases/case_em3_warn/embargo_events/e3",
             content="Embargo",
         )
@@ -237,7 +247,7 @@ class TestEmbargoProposalLifecycle:
         assert any("state-sync override" in r.message for r in caplog.records)
         case = dl.read(case.id_)
         assert case is not None
-        case = cast(VulnerabilityCase, case)
+        case = cast(as_VulnerabilityCase, case)
         assert case.current_status.em_state == EM.ACTIVE
 
     def test_accept_invite_to_embargo_records_embargo_on_participant(
@@ -246,24 +256,26 @@ class TestEmbargoProposalLifecycle:
         """accept_invite_to_embargo_on_case records embargo ID in participant.accepted_embargo_ids (CM-10-002, CM-10-003)."""
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
         from vultron.wire.as2.vocab.objects.case_participant import (
-            CaseParticipant,
+            as_CaseParticipant,
         )
-        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+        from vultron.wire.as2.vocab.objects.embargo_event import (
+            as_EmbargoEvent,
+        )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         dl = SqliteDataLayer("sqlite:///:memory:")
         coordinator_id = "https://example.org/users/coordinator"
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/case_em5",
             name="EM Accept Participant Test",
         )
-        embargo = EmbargoEvent(
+        embargo = as_EmbargoEvent(
             id_="https://example.org/cases/case_em5/embargo_events/e5",
             content="Embargo",
         )
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             id_="https://example.org/cases/case_em5/participants/coord",
             attributed_to=coordinator_id,
             context=case.id_,
@@ -305,19 +317,21 @@ class TestEmbargoProposalLifecycle:
         after acceptance.
         """
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
-        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+        from vultron.wire.as2.vocab.objects.embargo_event import (
+            as_EmbargoEvent,
+        )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         dl = SqliteDataLayer("sqlite:///:memory:")
         coordinator_id = "https://example.org/users/coordinator"
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/case_em6",
             name="EM Accept Event Test",
             attributed_to=coordinator_id,
         )
-        embargo = EmbargoEvent(
+        embargo = as_EmbargoEvent(
             id_="https://example.org/cases/case_em6/embargo_events/e6",
             content="Embargo",
         )
@@ -342,7 +356,7 @@ class TestEmbargoProposalLifecycle:
 
         case = dl.read(case.id_)
         assert case is not None
-        case = cast(VulnerabilityCase, case)
+        case = cast(as_VulnerabilityCase, case)
         assert (
             case.active_embargo is not None
         ), "Expected active_embargo to be set after embargo acceptance"
@@ -351,9 +365,11 @@ class TestEmbargoProposalLifecycle:
         self, make_payload
     ):
         """reject_invite_to_embargo_on_case ledgers without raising."""
-        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+        from vultron.wire.as2.vocab.objects.embargo_event import (
+            as_EmbargoEvent,
+        )
 
-        embargo = EmbargoEvent(
+        embargo = as_EmbargoEvent(
             id_="https://example.org/cases/case_em4/embargo_events/e4",
             content="Embargo",
         )
@@ -382,9 +398,11 @@ class TestEmbargoProposalLifecycle:
         """SvcAcceptEmbargoUseCase raises VultronInvalidStateTransitionError when EM state does not allow ACCEPT."""
         import pytest
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
-        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+        from vultron.wire.as2.vocab.objects.embargo_event import (
+            as_EmbargoEvent,
+        )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
         from vultron.wire.as2.vocab.base.objects.actors import (
             as_Actor as Actor,
@@ -393,12 +411,12 @@ class TestEmbargoProposalLifecycle:
 
         dl = SqliteDataLayer("sqlite:///:memory:")
         actor = Actor(id_="https://example.org/users/vendor", name="Vendor")
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/case_eval_invalid",
             name="Evaluate Invalid EM State",
             attributed_to=actor.id_,
         )
-        embargo = EmbargoEvent(
+        embargo = as_EmbargoEvent(
             id_="https://example.org/cases/case_eval_invalid/embargo_events/e1",
             context=case.id_,
         )
@@ -424,7 +442,7 @@ class TestEmbargoProposalLifecycle:
         # EM-state validation check (the test's actual assertion target).
         from vultron.enums.roles import CVDRole
         from vultron.wire.as2.vocab.objects.case_participant import (
-            CaseParticipant as CP,
+            as_CaseParticipant as CP,
         )
 
         case_actor = as_Service(

--- a/test/core/use_cases/received/test_embargo_routing_guard.py
+++ b/test/core/use_cases/received/test_embargo_routing_guard.py
@@ -39,9 +39,11 @@ from vultron.wire.as2.factories import (
     em_propose_embargo_activity,
     remove_embargo_from_case_activity,
 )
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -61,7 +63,9 @@ def _make_embargo_case(
     case_id: str,
     author_id: str,
     case_actor_id: str,
-) -> tuple[SqliteDataLayer, VultronCaseActor, VulnerabilityCase, EmbargoEvent]:
+) -> tuple[
+    SqliteDataLayer, VultronCaseActor, as_VulnerabilityCase, as_EmbargoEvent
+]:
     """Return (dl, case_actor, case, embargo) ready for routing tests."""
     dl = SqliteDataLayer("sqlite:///:memory:")
 
@@ -73,17 +77,19 @@ def _make_embargo_case(
     )
     dl.create(case_actor)
 
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         id_=case_id,
         name="Embargo Routing Test",
         attributed_to=author_id,
     )
     p1_id = f"{case_id}/participants/p1"
     case.actor_participant_index[author_id] = p1_id
-    p1 = CaseParticipant(id_=p1_id, context=case_id, attributed_to=author_id)
+    p1 = as_CaseParticipant(
+        id_=p1_id, context=case_id, attributed_to=author_id
+    )
     dl.create(p1)
 
-    cm_participant = CaseParticipant(
+    cm_participant = as_CaseParticipant(
         id_=f"{case_id}/participants/cm",
         attributed_to=case_actor_id,
         context=case_id,
@@ -94,7 +100,7 @@ def _make_embargo_case(
     case.actor_participant_index[case_actor_id] = cm_participant.id_
     dl.save(case)
 
-    embargo = EmbargoEvent(
+    embargo = as_EmbargoEvent(
         id_=f"{case_id}/embargo_events/e1",
         content="Routing test embargo",
         context=case_id,
@@ -202,7 +208,7 @@ class TestAcceptInviteToEmbargoRoutingGuard:
         dl, case_actor, case, embargo = _make_embargo_case(
             self.CASE_ID, self.COORD_ID, self.CASE_ACTOR_ID
         )
-        case = cast(VulnerabilityCase, dl.read(case.id_))
+        case = cast(as_VulnerabilityCase, dl.read(case.id_))
         assert case is not None
         case.current_status.em_state = EM.PROPOSED
         dl.save(case)
@@ -286,7 +292,10 @@ class TestRemoveEmbargoRoutingGuard:
     def _setup(
         self,
     ) -> tuple[
-        SqliteDataLayer, VultronCaseActor, VulnerabilityCase, EmbargoEvent
+        SqliteDataLayer,
+        VultronCaseActor,
+        as_VulnerabilityCase,
+        as_EmbargoEvent,
     ]:
         dl, case_actor, case, embargo = _make_embargo_case(
             self.CASE_ID, self.AUTHOR_ID, self.CASE_ACTOR_ID
@@ -294,7 +303,7 @@ class TestRemoveEmbargoRoutingGuard:
         # Add embargo to proposed list so the BT removal step succeeds.
         read_case = dl.read(case.id_)
         assert read_case is not None
-        case = cast(VulnerabilityCase, read_case)
+        case = cast(as_VulnerabilityCase, read_case)
         case.proposed_embargoes.append(embargo.id_)
         dl.save(case)
         return dl, case_actor, case, embargo

--- a/test/core/use_cases/received/test_embargo_term_revise.py
+++ b/test/core/use_cases/received/test_embargo_term_revise.py
@@ -33,17 +33,19 @@ class TestEmbargoTermRevise:
     ):
         """add_embargo_event_to_case sets the active embargo on the case (PROPOSED → ACTIVE)."""
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
-        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+        from vultron.wire.as2.vocab.objects.embargo_event import (
+            as_EmbargoEvent,
+        )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         dl = SqliteDataLayer("sqlite:///:memory:")
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/case_em1",
             name="EM Test Case",
         )
-        embargo = EmbargoEvent(
+        embargo = as_EmbargoEvent(
             id_="https://example.org/cases/case_em1/embargo_events/e1",
             content="Embargo test",
         )
@@ -63,7 +65,7 @@ class TestEmbargoTermRevise:
 
         case = dl.read(case.id_)
         assert case is not None
-        case = cast(VulnerabilityCase, case)
+        case = cast(as_VulnerabilityCase, case)
         assert case.active_embargo is not None
         assert case.current_status.em_state == EM.ACTIVE
 
@@ -73,17 +75,19 @@ class TestEmbargoTermRevise:
         """add_embargo_event_to_case ledgers WARNING when EM state is not on the standard machine path (state-sync override)."""
         import logging
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
-        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+        from vultron.wire.as2.vocab.objects.embargo_event import (
+            as_EmbargoEvent,
+        )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         dl = SqliteDataLayer("sqlite:///:memory:")
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/case_em1_warn",
             name="EM Warn Test Case",
         )
-        embargo = EmbargoEvent(
+        embargo = as_EmbargoEvent(
             id_="https://example.org/cases/case_em1_warn/embargo_events/e1",
             content="Embargo test",
         )
@@ -104,7 +108,7 @@ class TestEmbargoTermRevise:
         assert any("state-sync override" in r.message for r in caplog.records)
         case = dl.read(case.id_)
         assert case is not None
-        case = cast(VulnerabilityCase, case)
+        case = cast(as_VulnerabilityCase, case)
         # State is still updated (synchronization override proceeds).
         assert case.current_status.em_state == EM.ACTIVE
 
@@ -113,17 +117,19 @@ class TestEmbargoTermRevise:
     ):
         """remove_embargo_event removes embargo from proposed_embargoes."""
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
-        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+        from vultron.wire.as2.vocab.objects.embargo_event import (
+            as_EmbargoEvent,
+        )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         dl = SqliteDataLayer("sqlite:///:memory:")
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/case_rem1",
             name="Remove Embargo Proposed",
         )
-        embargo = EmbargoEvent(
+        embargo = as_EmbargoEvent(
             id_="https://example.org/cases/case_rem1/embargo_events/e1",
             context=case.id_,
         )
@@ -144,7 +150,7 @@ class TestEmbargoTermRevise:
 
         updated = dl.read(case.id_)
         assert updated is not None
-        updated = cast(VulnerabilityCase, updated)
+        updated = cast(as_VulnerabilityCase, updated)
         assert embargo.id_ not in [
             e if isinstance(e, str) else getattr(e, "id_", None)
             for e in updated.proposed_embargoes
@@ -156,20 +162,22 @@ class TestEmbargoTermRevise:
         """remove_embargo_event transitions EM from ACTIVE to EXITED via BT."""
         import py_trees
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
-        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+        from vultron.wire.as2.vocab.objects.embargo_event import (
+            as_EmbargoEvent,
+        )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         py_trees.blackboard.Blackboard.enable_activity_stream()
         py_trees.blackboard.Blackboard.storage.clear()
 
         dl = SqliteDataLayer("sqlite:///:memory:")
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/case_rem2",
             name="Remove Embargo ACTIVE→EXITED",
         )
-        embargo = EmbargoEvent(
+        embargo = as_EmbargoEvent(
             id_="https://example.org/cases/case_rem2/embargo_events/e2",
             context=case.id_,
         )
@@ -190,7 +198,7 @@ class TestEmbargoTermRevise:
 
         updated = dl.read(case.id_)
         assert updated is not None
-        updated = cast(VulnerabilityCase, updated)
+        updated = cast(as_VulnerabilityCase, updated)
         assert updated.active_embargo is None
         assert updated.current_status.em_state == EM.EXITED
 
@@ -200,20 +208,22 @@ class TestEmbargoTermRevise:
         """remove_embargo_event uses state-sync override when EM is PROPOSED but embargo is active."""
         import py_trees
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
-        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+        from vultron.wire.as2.vocab.objects.embargo_event import (
+            as_EmbargoEvent,
+        )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         py_trees.blackboard.Blackboard.enable_activity_stream()
         py_trees.blackboard.Blackboard.storage.clear()
 
         dl = SqliteDataLayer("sqlite:///:memory:")
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/case_rem3",
             name="Remove Embargo unusual state override",
         )
-        embargo = EmbargoEvent(
+        embargo = as_EmbargoEvent(
             id_="https://example.org/cases/case_rem3/embargo_events/e3",
             context=case.id_,
         )
@@ -234,6 +244,6 @@ class TestEmbargoTermRevise:
 
         updated = dl.read(case.id_)
         assert updated is not None
-        updated = cast(VulnerabilityCase, updated)
+        updated = cast(as_VulnerabilityCase, updated)
         assert updated.active_embargo is None
         assert updated.current_status.em_state == EM.EXITED

--- a/test/core/use_cases/received/test_note.py
+++ b/test/core/use_cases/received/test_note.py
@@ -30,7 +30,9 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Remove,
 )
 from vultron.wire.as2.vocab.base.objects.object_types import as_Note
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 
 class TestNoteUseCases:
@@ -81,7 +83,7 @@ class TestNoteUseCases:
     ):
         """create_note attaches the Note to the case when note.context is set."""
         dl = SqliteDataLayer("sqlite:///:memory:")
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/case_cn1",
             name="Context Case",
         )
@@ -102,7 +104,7 @@ class TestNoteUseCases:
 
         refreshed = dl.read(case.id_)
         assert refreshed is not None
-        refreshed = cast(VulnerabilityCase, refreshed)
+        refreshed = cast(as_VulnerabilityCase, refreshed)
         assert note.id_ in refreshed.notes
 
     def test_create_note_attach_to_case_idempotent(
@@ -111,7 +113,7 @@ class TestNoteUseCases:
         """create_note is idempotent when note already attached to case."""
         dl = SqliteDataLayer("sqlite:///:memory:")
         note_id = "https://example.org/notes/note_ctx2"
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/case_cn2",
             name="Idempotent Case",
             notes=[note_id],
@@ -133,16 +135,16 @@ class TestNoteUseCases:
 
         refreshed = dl.read(case.id_)
         assert refreshed is not None
-        refreshed = cast(VulnerabilityCase, refreshed)
+        refreshed = cast(as_VulnerabilityCase, refreshed)
         assert refreshed.notes.count(note_id) == 1
 
     def _setup_case_with_case_manager(
         self, dl: "SqliteDataLayer", case_id: str, case_actor_id: str
-    ) -> "VulnerabilityCase":
-        """Create a VulnerabilityCase with a CaseActor holding CASE_MANAGER."""
+    ) -> "as_VulnerabilityCase":
+        """Create a as_VulnerabilityCase with a CaseActor holding CASE_MANAGER."""
         from vultron.enums.roles import CVDRole
         from vultron.wire.as2.vocab.objects.case_participant import (
-            CaseParticipant,
+            as_CaseParticipant,
         )
 
         case_actor = VultronCaseActor(
@@ -153,11 +155,11 @@ class TestNoteUseCases:
         )
         dl.create(case_actor)
 
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_=case_id,
             name="Note Case",
         )
-        case_mgr_participant = CaseParticipant(
+        case_mgr_participant = as_CaseParticipant(
             id_=f"{case_id}/participants/case-actor-p",
             attributed_to=case_actor_id,
             context=case_id,
@@ -194,7 +196,7 @@ class TestNoteUseCases:
 
         refreshed = dl.read(case_id)
         assert refreshed is not None
-        refreshed = cast(VulnerabilityCase, refreshed)
+        refreshed = cast(as_VulnerabilityCase, refreshed)
         assert note.id_ in refreshed.notes
 
     def test_add_note_to_case_idempotent(self, monkeypatch, make_payload):
@@ -224,7 +226,7 @@ class TestNoteUseCases:
 
         refreshed = dl.read(case_id)
         assert refreshed is not None
-        refreshed = cast(VulnerabilityCase, refreshed)
+        refreshed = cast(as_VulnerabilityCase, refreshed)
         assert refreshed.notes.count(note.id_) == 1
 
     def test_add_note_noop_for_non_case_manager(
@@ -238,7 +240,7 @@ class TestNoteUseCases:
         and commit.
         """
         dl = SqliteDataLayer("sqlite:///:memory:")
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/case_n3_noop",
             name="Noop Case",
         )
@@ -262,7 +264,7 @@ class TestNoteUseCases:
 
         refreshed = dl.read(case.id_)
         assert refreshed is not None
-        refreshed = cast(VulnerabilityCase, refreshed)
+        refreshed = cast(as_VulnerabilityCase, refreshed)
         assert note.id_ not in refreshed.notes
 
     def test_remove_note_from_case_removes_note(
@@ -274,7 +276,7 @@ class TestNoteUseCases:
             id_="https://example.org/notes/note5",
             content="A note",
         )
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/case_n3",
             name="Remove Note Case",
             notes=[note.id_],
@@ -293,7 +295,7 @@ class TestNoteUseCases:
 
         case = dl.read(case.id_)
         assert case is not None
-        case = cast(VulnerabilityCase, case)
+        case = cast(as_VulnerabilityCase, case)
         assert note.id_ not in case.notes
 
     def test_remove_note_from_case_idempotent(self, monkeypatch, make_payload):
@@ -303,7 +305,7 @@ class TestNoteUseCases:
             id_="https://example.org/notes/note6",
             content="A note",
         )
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/case_n4",
             name="Remove Note Idempotent",
         )
@@ -347,7 +349,7 @@ class TestNoteUseCases:
         )
         dl.create(case_actor)
 
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_=case_id,
             name="Log Entry Cascade Case",
             attributed_to=author_id,
@@ -361,10 +363,10 @@ class TestNoteUseCases:
         dl.create(case)
         from vultron.enums.roles import CVDRole
         from vultron.wire.as2.vocab.objects.case_participant import (
-            CaseParticipant,
+            as_CaseParticipant,
         )
 
-        case_manager_participant = CaseParticipant(
+        case_manager_participant = as_CaseParticipant(
             id_=f"{case_id}/participants/case-actor-p",
             attributed_to=case_actor_id,
             context=case_id,
@@ -424,7 +426,7 @@ class TestNoteUseCases:
         )
         dl.create(case_actor)
 
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_=case_id,
             name="No Sync Port Case",
             attributed_to=author_id,
@@ -438,10 +440,10 @@ class TestNoteUseCases:
         dl.create(case)
         from vultron.enums.roles import CVDRole
         from vultron.wire.as2.vocab.objects.case_participant import (
-            CaseParticipant,
+            as_CaseParticipant,
         )
 
-        case_manager_participant = CaseParticipant(
+        case_manager_participant = as_CaseParticipant(
             id_=f"{case_id}/participants/case-actor-p",
             attributed_to=case_actor_id,
             context=case_id,

--- a/test/core/use_cases/received/test_note_routing_guard.py
+++ b/test/core/use_cases/received/test_note_routing_guard.py
@@ -30,8 +30,10 @@ from vultron.enums.roles import CVDRole
 from vultron.core.use_cases.received.note import AddNoteToCaseReceivedUseCase
 from vultron.wire.as2.factories import add_note_to_case_activity
 from vultron.wire.as2.vocab.base.objects.object_types import as_Note
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -68,11 +70,11 @@ def _make_case_actor_dl() -> SqliteDataLayer:
     ca_svc = VultronCaseActor(id_=CASE_ACTOR_ID, context=CASE_ID)
     dl.save(ca_svc)
 
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         id_=CASE_ID, name="AddNote Routing Test", attributed_to=CASE_ACTOR_ID
     )
 
-    cm_participant = CaseParticipant(
+    cm_participant = as_CaseParticipant(
         attributed_to=CASE_ACTOR_ID,
         context=CASE_ID,
         case_roles=[CVDRole.CASE_MANAGER],
@@ -119,7 +121,7 @@ class TestAddNoteToCaseLedgerRouting:
         dl = _make_case_actor_dl()
 
         case = dl.read(CASE_ID)
-        assert isinstance(case, VulnerabilityCase)
+        assert isinstance(case, as_VulnerabilityCase)
         note = as_Note(id_=NOTE_ID, content="Test note content")
         activity = add_note_to_case_activity(
             note=note,
@@ -149,7 +151,7 @@ class TestAddNoteToCaseLedgerRouting:
         dl = _make_case_actor_dl()
 
         case = dl.read(CASE_ID)
-        assert isinstance(case, VulnerabilityCase)
+        assert isinstance(case, as_VulnerabilityCase)
         note = as_Note(id_=NOTE_ID, content="Test note content")
         activity = add_note_to_case_activity(
             note=note,
@@ -181,7 +183,7 @@ class TestAddNoteToCaseLedgerRouting:
         dl = _make_case_actor_dl()
 
         case = dl.read(CASE_ID)
-        assert isinstance(case, VulnerabilityCase)
+        assert isinstance(case, as_VulnerabilityCase)
         note = as_Note(id_=NOTE_ID, content="Test note content")
         activity = add_note_to_case_activity(
             note=note,

--- a/test/core/use_cases/received/test_reject_sync.py
+++ b/test/core/use_cases/received/test_reject_sync.py
@@ -37,7 +37,7 @@ from vultron.core.models.events.sync import RejectLogEntryReceivedEvent
 from vultron.semantic_registry import extract_event
 from vultron.wire.as2.factories import reject_log_entry_activity
 from vultron.wire.as2.vocab.objects.case_ledger_entry import (
-    CaseLedgerEntry as WireCaseLedgerEntry,
+    as_CaseLedgerEntry as WireCaseLedgerEntry,
 )
 
 CASE_ACTOR_URI = "https://example.org/actors/case-actor"
@@ -319,15 +319,15 @@ class TestRejectLedgerEntryReceivedUseCase:
         uc.execute()  # should not raise
 
     def test_replay_triggered_when_case_actor_found(self, dl, entry0, entry1):
-        """When a CaseActor (Service) exists for the case, missing entries are replayed."""
-        from vultron.wire.as2.vocab.objects.case_actor import CaseActor
+        """When a as_CaseActor (Service) exists for the case, missing entries are replayed."""
+        from vultron.wire.as2.vocab.objects.case_actor import as_CaseActor
 
         # Save both entries
         dl.save(entry0)
         dl.save(entry1)
 
-        # Register a CaseActor associated with the case
-        case_actor = CaseActor(
+        # Register a as_CaseActor associated with the case
+        case_actor = as_CaseActor(
             id_=CASE_ACTOR_URI,
             context=CASE_URI,
         )

--- a/test/core/use_cases/received/test_report_case_level.py
+++ b/test/core/use_cases/received/test_report_case_level.py
@@ -32,7 +32,9 @@ from vultron.core.use_cases.received.report import (
     CloseReportReceivedUseCase,
     InvalidateReportReceivedUseCase,
 )
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 
 class TestCaseLevelUseeCases:
@@ -45,7 +47,7 @@ class TestCaseLevelUseeCases:
     def _make_case_with_participant(
         self, dl: SqliteDataLayer, actor_id: str, initial_rm: RM
     ):
-        """Helper: create a VulnerabilityCase with one participant."""
+        """Helper: create a as_VulnerabilityCase with one participant."""
         from vultron.core.models.participant_status import (
             ParticipantStatus,
         )
@@ -62,7 +64,7 @@ class TestCaseLevelUseeCases:
                 )
             ],
         )
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/c1",
             name="Test Case",
         )
@@ -81,7 +83,7 @@ class TestCaseLevelUseeCases:
 
         InvalidateCaseUseCase(dl, case.id_, actor_id).execute()
 
-        updated_case = cast(VulnerabilityCase, dl.read(case.id_))
+        updated_case = cast(as_VulnerabilityCase, dl.read(case.id_))
         participant_id = updated_case.actor_participant_index[actor_id]
         participant = cast(VultronParticipant, dl.read(participant_id))
         assert participant.participant_statuses[-1].rm_state == RM.INVALID
@@ -95,7 +97,7 @@ class TestCaseLevelUseeCases:
 
         CloseCaseUseCase(dl, case.id_, actor_id).execute()
 
-        updated_case = cast(VulnerabilityCase, dl.read(case.id_))
+        updated_case = cast(as_VulnerabilityCase, dl.read(case.id_))
         participant_id = updated_case.actor_participant_index[actor_id]
         participant = cast(VultronParticipant, dl.read(participant_id))
         assert participant.participant_statuses[-1].rm_state == RM.CLOSED
@@ -166,7 +168,7 @@ class TestDereferencePatternInReportUseCases:
                 )
             ],
         )
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/c-deref",
             name="Deref Test Case",
         )
@@ -203,7 +205,7 @@ class TestDereferencePatternInReportUseCases:
 
         InvalidateReportReceivedUseCase(dl, event).execute()
 
-        updated_case = cast(VulnerabilityCase, dl.read(case.id_))
+        updated_case = cast(as_VulnerabilityCase, dl.read(case.id_))
         participant_id = updated_case.actor_participant_index[actor_id]
         participant = cast(VultronParticipant, dl.read(participant_id))
         assert participant.participant_statuses[-1].rm_state == RM.INVALID
@@ -236,7 +238,7 @@ class TestDereferencePatternInReportUseCases:
 
         CloseReportReceivedUseCase(dl, event).execute()
 
-        updated_case = cast(VulnerabilityCase, dl.read(case.id_))
+        updated_case = cast(as_VulnerabilityCase, dl.read(case.id_))
         participant_id = updated_case.actor_participant_index[actor_id]
         participant = cast(VultronParticipant, dl.read(participant_id))
         assert participant.participant_statuses[-1].rm_state == RM.CLOSED

--- a/test/core/use_cases/received/test_status.py
+++ b/test/core/use_cases/received/test_status.py
@@ -34,27 +34,29 @@ from vultron.wire.as2.factories import (
     create_case_status_activity,
     create_status_for_participant_activity,
 )
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
 from vultron.wire.as2.vocab.objects.case_status import (
-    CaseStatus,
-    ParticipantStatus,
+    as_CaseStatus,
+    as_ParticipantStatus,
 )
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 
 class TestStatusUseCases:
     """Tests for case status and participant status handlers."""
 
     def test_create_case_status_stores_status(self, monkeypatch, make_payload):
-        """create_case_status persists the CaseStatus to the DataLayer."""
+        """create_case_status persists the as_CaseStatus to the DataLayer."""
 
         dl = SqliteDataLayer("sqlite:///:memory:")
 
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/case_cs1",
             name="Case Status Test",
         )
-        status = CaseStatus(
+        status = as_CaseStatus(
             id_="https://example.org/cases/case_cs1/statuses/s1",
             context=case.id_,
         )
@@ -70,14 +72,14 @@ class TestStatusUseCases:
         assert stored is not None
 
     def test_create_case_status_idempotent(self, monkeypatch, make_payload):
-        """create_case_status skips storing a duplicate CaseStatus."""
+        """create_case_status skips storing a duplicate as_CaseStatus."""
         dl = SqliteDataLayer("sqlite:///:memory:")
 
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/case_cs2",
             name="Case Status Idempotent",
         )
-        status = CaseStatus(
+        status = as_CaseStatus(
             id_="https://example.org/cases/case_cs2/statuses/s2",
             context=case.id_,
         )
@@ -98,11 +100,11 @@ class TestStatusUseCases:
     ):
         """add_case_status_to_case appends status ID to case.case_statuses."""
         dl = SqliteDataLayer("sqlite:///:memory:")
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/case_cs3",
             name="Add Status Case",
         )
-        status = CaseStatus(
+        status = as_CaseStatus(
             id_="https://example.org/cases/case_cs3/statuses/s3",
             context=case.id_,
         )
@@ -118,7 +120,7 @@ class TestStatusUseCases:
 
         case = dl.read(case.id_)
         assert case is not None
-        case = cast(VulnerabilityCase, case)
+        case = cast(as_VulnerabilityCase, case)
         status_ids = [getattr(s, "id_", s) for s in case.case_statuses]
         assert status.id_ in status_ids
 
@@ -127,12 +129,12 @@ class TestStatusUseCases:
     ):
         """Invalid EM transition is blocked; status is not appended."""
         dl = SqliteDataLayer("sqlite:///:memory:")
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/case_em_guard",
             name="EM Guard Test Case",
         )
         # Seed an existing status with EM.NONE (the initial embargo state)
-        initial_status = CaseStatus(
+        initial_status = as_CaseStatus(
             id_="https://example.org/cases/case_em_guard/statuses/s_init",
             context=case.id_,
             em_state=EM.NONE,
@@ -142,7 +144,7 @@ class TestStatusUseCases:
 
         # Try to add a status with EM.ACTIVE — invalid: NONE → ACTIVE
         # skips the required PROPOSED intermediate state
-        bad_status = CaseStatus(
+        bad_status = as_CaseStatus(
             id_="https://example.org/cases/case_em_guard/statuses/s_bad",
             context=case.id_,
             em_state=EM.ACTIVE,
@@ -158,7 +160,7 @@ class TestStatusUseCases:
 
         updated_case = dl.read(case.id_)
         assert updated_case is not None
-        updated_case = cast(VulnerabilityCase, updated_case)
+        updated_case = cast(as_VulnerabilityCase, updated_case)
         status_ids = [getattr(s, "id_", s) for s in updated_case.case_statuses]
         assert (
             bad_status.id_ not in status_ids
@@ -169,11 +171,11 @@ class TestStatusUseCases:
     ):
         """Valid EM transition is permitted; status is appended."""
         dl = SqliteDataLayer("sqlite:///:memory:")
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_="https://example.org/cases/case_em_valid",
             name="EM Valid Transition Case",
         )
-        initial_status = CaseStatus(
+        initial_status = as_CaseStatus(
             id_="https://example.org/cases/case_em_valid/statuses/s_init",
             context=case.id_,
             em_state=EM.NONE,
@@ -182,7 +184,7 @@ class TestStatusUseCases:
         dl.create(case)
 
         # NONE → PROPOSED is a valid transition
-        good_status = CaseStatus(
+        good_status = as_CaseStatus(
             id_="https://example.org/cases/case_em_valid/statuses/s_good",
             context=case.id_,
             em_state=EM.PROPOSED,
@@ -198,21 +200,21 @@ class TestStatusUseCases:
 
         updated_case = dl.read(case.id_)
         assert updated_case is not None
-        updated_case = cast(VulnerabilityCase, updated_case)
+        updated_case = cast(as_VulnerabilityCase, updated_case)
         status_ids = [getattr(s, "id_", s) for s in updated_case.case_statuses]
         assert good_status.id_ in status_ids
 
     def test_create_participant_status_stores_status(
         self, monkeypatch, make_payload
     ):
-        """create_participant_status persists the ParticipantStatus."""
+        """create_participant_status persists the as_ParticipantStatus."""
         dl = SqliteDataLayer("sqlite:///:memory:")
 
-        pstatus = ParticipantStatus(
+        pstatus = as_ParticipantStatus(
             id_="https://example.org/cases/case_ps1/participants/p1/statuses/s1",
             context="https://example.org/cases/case_ps1",
         )
-        case_ps1 = VulnerabilityCase(
+        case_ps1 = as_VulnerabilityCase(
             id_="https://example.org/cases/case_ps1",
             name="PS Case 1",
         )
@@ -232,16 +234,16 @@ class TestStatusUseCases:
     ):
         """add_participant_status_to_participant appends status to participant."""
         dl = SqliteDataLayer("sqlite:///:memory:")
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             id_="https://example.org/cases/case_ps2/participants/p2",
             context="https://example.org/cases/case_ps2",
             attributed_to="https://example.org/users/vendor",
         )
-        pstatus = ParticipantStatus(
+        pstatus = as_ParticipantStatus(
             id_="https://example.org/cases/case_ps2/participants/p2/statuses/s2",
             context="https://example.org/cases/case_ps2",
         )
-        case_ps2 = VulnerabilityCase(
+        case_ps2 = as_VulnerabilityCase(
             id_="https://example.org/cases/case_ps2",
             name="PS Case 2",
         )
@@ -269,7 +271,7 @@ class TestStatusUseCases:
 
         participant = dl.read(participant.id_)
         assert participant is not None
-        participant = cast(CaseParticipant, participant)
+        participant = cast(as_CaseParticipant, participant)
         status_ids = [
             getattr(s, "id_", s) for s in participant.participant_statuses
         ]
@@ -298,10 +300,10 @@ class TestParticipantStatusLogEntryCascade:
         dl.create(case_actor)
 
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_=case_id,
             name="Status Cascade Case",
             attributed_to=actor_id,
@@ -319,7 +321,7 @@ class TestParticipantStatusLogEntryCascade:
         case.actor_participant_index[case_actor_id] = cm_participant_id
         dl.create(case)
 
-        case_manager_participant = CaseParticipant(
+        case_manager_participant = as_CaseParticipant(
             id_=case_manager_participant_id,
             context=case_id,
             attributed_to=case_actor_id,
@@ -327,14 +329,14 @@ class TestParticipantStatusLogEntryCascade:
         )
         dl.create(case_manager_participant)
 
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             id_=f"{case_id}/participants/p1",
             context=case_id,
             attributed_to=actor_id,
         )
         dl.create(participant)
 
-        cm_participant = CaseParticipant(
+        cm_participant = as_CaseParticipant(
             id_=cm_participant_id,
             context=case_id,
             attributed_to=case_actor_id,
@@ -342,7 +344,7 @@ class TestParticipantStatusLogEntryCascade:
         )
         dl.create(cm_participant)
 
-        pstatus = ParticipantStatus(
+        pstatus = as_ParticipantStatus(
             id_=f"{case_id}/participants/p1/statuses/s1",
             context=case_id,
         )
@@ -353,7 +355,7 @@ class TestParticipantStatusLogEntryCascade:
     def test_cascade_commits_log_entry_on_success(self, make_payload):
         """Cascade commits a CaseLedgerEntry when BT succeeds (AC-2)."""
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         actor_id = "https://example.org/users/vendor"
@@ -361,7 +363,7 @@ class TestParticipantStatusLogEntryCascade:
         dl, case_actor_id, participant, pstatus = self._make_dl(
             case_id, actor_id
         )
-        case = cast(VulnerabilityCase, dl.read(case_id))
+        case = cast(as_VulnerabilityCase, dl.read(case_id))
         assert case is not None
 
         activity = add_status_to_participant_activity(
@@ -394,7 +396,7 @@ class TestParticipantStatusLogEntryCascade:
         for delivery to participants.
         """
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         actor_id = "https://example.org/users/vendor"
@@ -402,7 +404,7 @@ class TestParticipantStatusLogEntryCascade:
         dl, case_actor_id, participant, pstatus = self._make_dl(
             case_id, actor_id
         )
-        case = cast(VulnerabilityCase, dl.read(case_id))
+        case = cast(as_VulnerabilityCase, dl.read(case_id))
         assert case is not None
 
         activity = add_status_to_participant_activity(
@@ -433,16 +435,16 @@ class TestParticipantStatusLogEntryCascade:
     ) -> None:
         """CLOSED->CLOSED rewrites are rejected before log cascade."""
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         actor_id = "https://example.org/users/vendor"
         case_id = "https://example.org/cases/st_le3"
         dl, case_actor_id, participant, _ = self._make_dl(case_id, actor_id)
-        case = cast(VulnerabilityCase, dl.read(case_id))
+        case = cast(as_VulnerabilityCase, dl.read(case_id))
         assert case is not None
 
-        closed_status = ParticipantStatus(
+        closed_status = as_ParticipantStatus(
             id_=f"{case_id}/participants/p1/statuses/closed-existing",
             context=case_id,
             rm_state=RM.CLOSED,
@@ -451,7 +453,7 @@ class TestParticipantStatusLogEntryCascade:
         dl.save(participant)
         dl.create(closed_status)
 
-        duplicate_closed_status = ParticipantStatus(
+        duplicate_closed_status = as_ParticipantStatus(
             id_=f"{case_id}/participants/p1/statuses/closed-duplicate",
             context=case_id,
             rm_state=RM.CLOSED,
@@ -489,7 +491,7 @@ class TestParticipantStatusLogEntryCascade:
     ) -> None:
         """Two equivalent assertions append only one canonical log entry."""
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         actor_id = "https://example.org/users/vendor"
@@ -497,7 +499,7 @@ class TestParticipantStatusLogEntryCascade:
         dl, case_actor_id, participant, pstatus = self._make_dl(
             case_id, actor_id
         )
-        case = cast(VulnerabilityCase, dl.read(case_id))
+        case = cast(as_VulnerabilityCase, dl.read(case_id))
         assert case is not None
 
         activity = add_status_to_participant_activity(
@@ -528,7 +530,7 @@ class TestParticipantStatusLogEntryCascade:
     ) -> None:
         """Peer-side replay of broadcast status must not append canonical entries."""
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         actor_id = "https://example.org/users/vendor"
@@ -537,10 +539,10 @@ class TestParticipantStatusLogEntryCascade:
         dl, case_actor_id, participant, pstatus = self._make_dl(
             case_id, actor_id
         )
-        case = cast(VulnerabilityCase, dl.read(case_id))
+        case = cast(as_VulnerabilityCase, dl.read(case_id))
         assert case is not None
 
-        peer = CaseParticipant(
+        peer = as_CaseParticipant(
             id_=f"{case_id}/participants/p2",
             context=case_id,
             attributed_to=non_case_actor_id,
@@ -577,7 +579,7 @@ class TestParticipantStatusLogEntryCascade:
 
         from vultron.wire.as2.enums import as_TransitiveActivityType
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         reporter_actor_id = "https://example.org/users/vendor"
@@ -586,10 +588,10 @@ class TestParticipantStatusLogEntryCascade:
         dl, case_actor_id, participant, pstatus = self._make_dl(
             case_id, reporter_actor_id
         )
-        case = cast(VulnerabilityCase, dl.read(case_id))
+        case = cast(as_VulnerabilityCase, dl.read(case_id))
         assert case is not None
 
-        finder_participant = CaseParticipant(
+        finder_participant = as_CaseParticipant(
             id_=f"{case_id}/participants/finder",
             context=case_id,
             attributed_to=finder_actor_id,

--- a/test/core/use_cases/received/test_sync.py
+++ b/test/core/use_cases/received/test_sync.py
@@ -36,7 +36,7 @@ from vultron.semantic_registry import extract_event
 from vultron.wire.as2.parser import parse_activity
 from vultron.wire.as2.factories import announce_log_entry_activity
 from vultron.wire.as2.vocab.objects.case_ledger_entry import (
-    CaseLedgerEntry as WireCaseLedgerEntry,
+    as_CaseLedgerEntry as WireCaseLedgerEntry,
 )
 
 ACTOR_URI = "https://example.org/actors/case-actor"
@@ -166,10 +166,10 @@ class TestAnnounceLedgerEntryReceivedUseCase:
         return cast(AnnounceLogEntryReceivedEvent, extract_event(activity))
 
     def test_inline_case_ledger_entry_round_trip(self, first_entry):
-        """parse_activity must preserve inline CaseLedgerEntry fields (BUG-26041501).
+        """parse_activity must preserve inline as_CaseLedgerEntry fields (BUG-26041501).
 
         Simulates the Finder receiving an Announce activity with a full inline
-        CaseLedgerEntry dict via HTTP, and verifies the event's log_entry has all
+        as_CaseLedgerEntry dict via HTTP, and verifies the event's log_entry has all
         domain fields intact after the parse → extract pipeline.
         """
         body = {

--- a/test/core/use_cases/test_reporting_workflow.py
+++ b/test/core/use_cases/test_reporting_workflow.py
@@ -28,9 +28,11 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
 )
 from vultron.wire.as2.vocab.base.objects.activities.base import as_Activity
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 from vultron.core.models.events import MessageSemantics
 from vultron.core.use_cases.received.report import (
@@ -52,7 +54,7 @@ def reporter():
 
 @pytest.fixture
 def report(reporter):
-    return VulnerabilityReport(
+    return as_VulnerabilityReport(
         name="Test Vulnerability Report",
         summary="This is a test vulnerability report.",
         attributed_to=reporter,
@@ -66,7 +68,7 @@ def coordinator():
 
 @pytest.fixture
 def case(report):
-    return VulnerabilityCase(
+    return as_VulnerabilityCase(
         name="Test Vulnerability Case",
         vulnerability_reports=[report],
     )

--- a/test/core/use_cases/test_validate_report_ledger_routing.py
+++ b/test/core/use_cases/test_validate_report_ledger_routing.py
@@ -55,10 +55,12 @@ from vultron.core.use_cases.received.report import (
 from vultron.core.use_cases.triggers.service import TriggerService
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 # ---------------------------------------------------------------------------
@@ -75,7 +77,7 @@ def _make_case_at_received(
     vendor_id: str,
     finder_id: str,
     report_id: str,
-) -> tuple[VulnerabilityCase, as_Offer]:
+) -> tuple[as_VulnerabilityCase, as_Offer]:
     """Create a case at RM.RECEIVED via the receive-report BT.
 
     Mirrors the real production path: Offer(Report) arrives → BT creates a
@@ -91,7 +93,7 @@ def _make_case_at_received(
         create_receive_report_case_tree,
     )
 
-    report_obj = VulnerabilityReport(id_=report_id, name="Test Vul Report")
+    report_obj = as_VulnerabilityReport(id_=report_id, name="Test Vul Report")
     dl.save(report_obj)
     offer = as_Offer(
         actor=finder_id,
@@ -113,10 +115,10 @@ def _make_case_at_received(
     case = dl.find_case_by_report_id(report_id)
     assert (
         case is not None
-    ), "receive_report BT must create a VulnerabilityCase"
+    ), "receive_report BT must create a as_VulnerabilityCase"
     assert isinstance(
-        case, VulnerabilityCase
-    ), f"Expected VulnerabilityCase, got {type(case)}"
+        case, as_VulnerabilityCase
+    ), f"Expected as_VulnerabilityCase, got {type(case)}"
     return case, offer
 
 
@@ -161,7 +163,7 @@ class TestTriggerEmitsToCaseActorOutbox:
 
     def _setup(
         self,
-    ) -> tuple[SqliteDataLayer, VulnerabilityCase, as_Offer, str]:
+    ) -> tuple[SqliteDataLayer, as_VulnerabilityCase, as_Offer, str]:
         """Return (dl, case, offer, case_actor_id) after BT receive-report."""
         dl = _make_dl()
         vendor = as_Service(id_=self.VENDOR_ID, name="Vendor")
@@ -276,14 +278,14 @@ class TestCaseActorReceivedWritesLedgerEntry:
         )
         dl.save(case_actor_svc)
 
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_=self.CASE_ID,
             name="Ledger Routing Test Case",
             attributed_to=self.CASE_ACTOR_ID,
         )
         case.vulnerability_reports.append(self.REPORT_ID)
 
-        cm_participant = CaseParticipant(
+        cm_participant = as_CaseParticipant(
             attributed_to=self.CASE_ACTOR_ID,
             context=self.CASE_ID,
             case_roles=[CVDRole.CASE_MANAGER],
@@ -300,7 +302,7 @@ class TestCaseActorReceivedWritesLedgerEntry:
     ) -> ValidateReportReceivedEvent:
         """Construct a ValidateReportReceivedEvent for the CaseActor's inbox.
 
-        The wire format is Accept(Offer(VulnerabilityReport)).  The activity
+        The wire format is Accept(Offer(as_VulnerabilityReport)).  The activity
         must carry an ``object_`` with ``type_="Offer"`` so the canonical
         signature check in ``_validate_canonical_entry`` sees
         ``("Accept", "Offer")``.
@@ -308,7 +310,7 @@ class TestCaseActorReceivedWritesLedgerEntry:
         if receiving_actor_id is None:
             receiving_actor_id = self.CASE_ACTOR_ID
 
-        # The inner Offer carries the VulnerabilityReport.
+        # The inner Offer carries the as_VulnerabilityReport.
         report_obj = VultronReport(id_=self.REPORT_ID)
         offer_obj = VultronActivity(
             id_=self.OFFER_ID,
@@ -404,12 +406,12 @@ class TestCaseActorReceivedWritesLedgerEntry:
         # Register VENDOR as a case participant so TransitionRMtoValid can
         # persist the status record.
         case = dl.read(self.CASE_ID)
-        assert isinstance(case, VulnerabilityCase)
+        assert isinstance(case, as_VulnerabilityCase)
         from vultron.core.models.case_actor import VultronCaseActor
 
         vendor_svc = VultronCaseActor(id_=self.VENDOR_ID)
         dl.save(vendor_svc)
-        vendor_p = CaseParticipant(
+        vendor_p = as_CaseParticipant(
             attributed_to=self.VENDOR_ID,
             context=self.CASE_ID,
             case_roles=[CVDRole.COORDINATOR],
@@ -505,14 +507,14 @@ class TestFullValidateReportLedgerChain:
         ca_svc = VultronCaseActor(id_=case_actor_id, context=case.id_)
         case_actor_dl.save(ca_svc)
 
-        ca_case = VulnerabilityCase(
+        ca_case = as_VulnerabilityCase(
             id_=case.id_,
             name=case.name or "Test Case",
             attributed_to=case_actor_id,
         )
         ca_case.vulnerability_reports.append(self.REPORT_ID)
 
-        ca_participant = CaseParticipant(
+        ca_participant = as_CaseParticipant(
             attributed_to=case_actor_id,
             context=ca_case.id_,
             case_roles=[CVDRole.CASE_MANAGER],

--- a/test/core/use_cases/triggers/case/test_add_object.py
+++ b/test/core/use_cases/triggers/case/test_add_object.py
@@ -33,9 +33,11 @@ from vultron.core.use_cases.triggers.requests import (
     AddObjectToCaseTriggerRequest,
 )
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 from vultron.adapters.driven.trigger_activity_adapter import (
     TriggerActivityAdapter,
@@ -81,7 +83,7 @@ class TestSvcAddObjectToCaseUseCase:
         """Set up actor and in-memory DataLayer."""
         self.actor, self.dl = _make_actor_dl("Vendor Co")
         # Create a case for testing
-        self.case = VulnerabilityCase(name="Test Case")
+        self.case = as_VulnerabilityCase(name="Test Case")
         self.dl.create(self.case)
         yield
         self.dl.clear_all()
@@ -90,7 +92,7 @@ class TestSvcAddObjectToCaseUseCase:
     def test_add_object_to_case_happy_path(self):
         """SvcAddObjectToCaseUseCase adds an existing object to a case."""
         # Create a report to add
-        report = VulnerabilityReport(
+        report = as_VulnerabilityReport(
             name="Test Report",
             content="Test report content",
         )
@@ -121,7 +123,7 @@ class TestSvcAddObjectToCaseUseCase:
     def test_add_object_to_case_raises_when_actor_not_found(self):
         """SvcAddObjectToCaseUseCase raises VultronNotFoundError when actor
         not found."""
-        report = VulnerabilityReport(
+        report = as_VulnerabilityReport(
             name="Test Report",
             content="Test report content",
         )
@@ -142,7 +144,7 @@ class TestSvcAddObjectToCaseUseCase:
     def test_add_object_to_case_raises_when_case_not_found(self):
         """SvcAddObjectToCaseUseCase raises VultronNotFoundError when case
         not found."""
-        report = VulnerabilityReport(
+        report = as_VulnerabilityReport(
             name="Test Report",
             content="Test report content",
         )
@@ -178,7 +180,7 @@ class TestSvcAddObjectToCaseUseCase:
     def test_add_object_to_case_activity_queued_in_delivery_queue(self):
         """SvcAddObjectToCaseUseCase queues activity in delivery queue for
         outbox_handler."""
-        report = VulnerabilityReport(
+        report = as_VulnerabilityReport(
             name="Test Report",
             content="Test report content",
         )
@@ -209,11 +211,11 @@ class TestSvcAddObjectToCaseUseCase:
 
     def test_add_multiple_objects_to_case(self):
         """SvcAddObjectToCaseUseCase can add multiple objects (called multiple times)."""
-        report1 = VulnerabilityReport(
+        report1 = as_VulnerabilityReport(
             name="Test Report 1",
             content="Test report content 1",
         )
-        report2 = VulnerabilityReport(
+        report2 = as_VulnerabilityReport(
             name="Test Report 2",
             content="Test report content 2",
         )

--- a/test/core/use_cases/triggers/case/test_add_participant_status.py
+++ b/test/core/use_cases/triggers/case/test_add_participant_status.py
@@ -36,7 +36,7 @@ from vultron.core.states.rm import RM
 
 
 class _FakeParticipantStatus:
-    """Minimal stand-in for ParticipantStatus."""
+    """Minimal stand-in for as_ParticipantStatus."""
 
     def __init__(self, rm_state: RM, vfd_state: CS_vfd) -> None:
         self.rm_state = rm_state
@@ -221,10 +221,10 @@ class TestSvcAddParticipantStatusExecuteUpdatesSenderRecord:
         from vultron.enums.roles import CVDRole
         from vultron.wire.as2.vocab.base.objects.actors import as_Service
         from vultron.wire.as2.vocab.objects.case_participant import (
-            CaseParticipant,
+            as_CaseParticipant,
         )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         # Finder actor
@@ -241,14 +241,14 @@ class TestSvcAddParticipantStatusExecuteUpdatesSenderRecord:
         self.dl.create(self.case_actor)
 
         # Case
-        self.case = VulnerabilityCase(name="Test Case #624")
+        self.case = as_VulnerabilityCase(name="Test Case #624")
 
-        self.actor_participant = CaseParticipant(
+        self.actor_participant = as_CaseParticipant(
             attributed_to=actor_id,
             context=self.case.id_,
             case_roles=[CVDRole.FINDER],
         )
-        self.case_manager_participant = CaseParticipant(
+        self.case_manager_participant = as_CaseParticipant(
             attributed_to=self.case_actor.id_,
             context=self.case.id_,
             case_roles=[CVDRole.CASE_MANAGER],
@@ -362,7 +362,7 @@ class TestCreateParticipantStatusNode:
     """CreateParticipantStatusNode creates a status snapshot inside the BT.
 
     These tests verify the BT node that was extracted from the inline
-    ParticipantStatus creation in SvcAddParticipantStatusUseCase.execute()
+    as_ParticipantStatus creation in SvcAddParticipantStatusUseCase.execute()
     as part of the BT-15-001 remediation (issue #850).
     """
 
@@ -381,10 +381,10 @@ class TestCreateParticipantStatusNode:
         from vultron.enums.roles import CVDRole
         from vultron.wire.as2.vocab.base.objects.actors import as_Service
         from vultron.wire.as2.vocab.objects.case_participant import (
-            CaseParticipant,
+            as_CaseParticipant,
         )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         py_trees.blackboard.Blackboard.enable_activity_stream()
@@ -401,14 +401,14 @@ class TestCreateParticipantStatusNode:
         reset_datalayer(self.case_actor.id_)
         self.dl.create(self.case_actor)
 
-        self.case = VulnerabilityCase(name="Test Case BT-15-001")
+        self.case = as_VulnerabilityCase(name="Test Case BT-15-001")
 
-        self.actor_participant = CaseParticipant(
+        self.actor_participant = as_CaseParticipant(
             attributed_to=actor_id,
             context=self.case.id_,
             case_roles=[CVDRole.FINDER],
         )
-        self.case_manager_participant = CaseParticipant(
+        self.case_manager_participant = as_CaseParticipant(
             attributed_to=self.case_actor.id_,
             context=self.case.id_,
             case_roles=[CVDRole.CASE_MANAGER],
@@ -473,10 +473,10 @@ class TestCreateParticipantStatusNode:
         assert result_out["participant_id"] == self.actor_participant.id_
 
     def test_node_persists_status_with_explicit_rm_state(self):
-        """CreateParticipantStatusNode persists ParticipantStatus with given RM."""
+        """CreateParticipantStatusNode persists as_ParticipantStatus with given RM."""
         from vultron.core.states.rm import RM
         from vultron.wire.as2.vocab.objects.case_status import (
-            ParticipantStatus as WireParticipantStatus,
+            as_ParticipantStatus as WireParticipantStatus,
         )
 
         bt_result, result_out = self._run_node(
@@ -487,7 +487,7 @@ class TestCreateParticipantStatusNode:
         assert isinstance(status_id, str), "result_out must contain status_id"
         stored = self.dl.read(status_id)
         # dl.read() reconstructs via find_in_vocabulary, which returns the
-        # wire-layer ParticipantStatus (VultronAS2Object subclass).
+        # wire-layer as_ParticipantStatus (VultronAS2Object subclass).
         assert isinstance(stored, WireParticipantStatus)
         assert stored.rm_state == RM.ACCEPTED
 
@@ -536,7 +536,7 @@ class TestCreateParticipantStatusNode:
         """CreateParticipantStatusNode uses existing RM state when rm_state=None."""
         from vultron.core.states.rm import RM
         from vultron.wire.as2.vocab.objects.case_status import (
-            ParticipantStatus as WireParticipantStatus,
+            as_ParticipantStatus as WireParticipantStatus,
         )
 
         _, result_out = self._run_node(
@@ -547,7 +547,7 @@ class TestCreateParticipantStatusNode:
         assert isinstance(status_id, str), "result_out must contain status_id"
         stored = self.dl.read(status_id)
         # dl.read() reconstructs via find_in_vocabulary, which returns the
-        # wire-layer ParticipantStatus (VultronAS2Object subclass).
+        # wire-layer as_ParticipantStatus (VultronAS2Object subclass).
         assert isinstance(stored, WireParticipantStatus)
         # No prior statuses → defaults to RM.START
         assert stored.rm_state == RM.START

--- a/test/core/use_cases/triggers/case/test_add_report.py
+++ b/test/core/use_cases/triggers/case/test_add_report.py
@@ -33,9 +33,11 @@ from vultron.core.use_cases.triggers.requests import (
     AddReportToCaseTriggerRequest,
 )
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 from vultron.adapters.driven.trigger_activity_adapter import (
     TriggerActivityAdapter,
@@ -81,7 +83,7 @@ class TestSvcAddReportToCaseUseCase:
         """Set up actor and in-memory DataLayer."""
         self.actor, self.dl = _make_actor_dl("Vendor Co")
         # Create a case for testing
-        self.case = VulnerabilityCase(name="Test Case")
+        self.case = as_VulnerabilityCase(name="Test Case")
         self.dl.create(self.case)
         yield
         self.dl.clear_all()
@@ -90,7 +92,7 @@ class TestSvcAddReportToCaseUseCase:
     def test_add_report_to_case_happy_path(self):
         """SvcAddReportToCaseUseCase adds a report to a case."""
         # Create a report
-        report = VulnerabilityReport(
+        report = as_VulnerabilityReport(
             name="Test Report",
             content="Test report content",
         )
@@ -136,8 +138,8 @@ class TestSvcAddReportToCaseUseCase:
     def test_add_report_to_case_raises_when_report_wrong_type(self):
         """SvcAddReportToCaseUseCase raises VultronValidationError when report_id
         is not a VulnerabilityReport."""
-        # Create a wrong type object (VulnerabilityCase instead)
-        case_obj = VulnerabilityCase(name="Not a Report")
+        # Create a wrong type object (as_VulnerabilityCase instead)
+        case_obj = as_VulnerabilityCase(name="Not a Report")
         self.dl.create(case_obj)
 
         request = AddReportToCaseTriggerRequest(
@@ -157,7 +159,7 @@ class TestSvcAddReportToCaseUseCase:
     def test_add_report_to_case_raises_when_case_not_found(self):
         """SvcAddReportToCaseUseCase raises VultronNotFoundError when case
         not found."""
-        report = VulnerabilityReport(
+        report = as_VulnerabilityReport(
             name="Test Report",
             content="Test report content",
         )
@@ -178,7 +180,7 @@ class TestSvcAddReportToCaseUseCase:
     def test_add_report_to_case_activity_queued_in_delivery_queue(self):
         """SvcAddReportToCaseUseCase queues activity in delivery queue for
         outbox_handler."""
-        report = VulnerabilityReport(
+        report = as_VulnerabilityReport(
             name="Test Report",
             content="Test report content",
         )
@@ -210,7 +212,7 @@ class TestSvcAddReportToCaseUseCase:
     def test_add_report_to_case_delegates_to_add_object(self):
         """SvcAddReportToCaseUseCase validates report type then delegates to
         SvcAddObjectToCaseUseCase."""
-        report = VulnerabilityReport(
+        report = as_VulnerabilityReport(
             name="Test Report",
             content="Test report content",
         )
@@ -234,11 +236,11 @@ class TestSvcAddReportToCaseUseCase:
 
     def test_add_multiple_reports_to_case(self):
         """SvcAddReportToCaseUseCase can add multiple reports (called multiple times)."""
-        report1 = VulnerabilityReport(
+        report1 = as_VulnerabilityReport(
             name="Test Report 1",
             content="Test report content 1",
         )
-        report2 = VulnerabilityReport(
+        report2 = as_VulnerabilityReport(
             name="Test Report 2",
             content="Test report content 2",
         )

--- a/test/core/use_cases/triggers/case/test_create.py
+++ b/test/core/use_cases/triggers/case/test_create.py
@@ -31,9 +31,11 @@ from vultron.errors import VultronNotFoundError, VultronValidationError
 from vultron.core.use_cases.triggers.case import SvcCreateCaseUseCase
 from vultron.core.use_cases.triggers.requests import CreateCaseTriggerRequest
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 from vultron.adapters.driven.trigger_activity_adapter import (
     TriggerActivityAdapter,
@@ -72,7 +74,7 @@ def _get_outbox_activity_id(actor, dl: SqliteDataLayer) -> str | None:
 
 
 class TestSvcCreateCaseUseCase:
-    """SvcCreateCaseUseCase creates a VulnerabilityCase and queues activity."""
+    """SvcCreateCaseUseCase creates a as_VulnerabilityCase and queues activity."""
 
     @pytest.fixture(autouse=True)
     def setup(self):
@@ -127,7 +129,7 @@ class TestSvcCreateCaseUseCase:
     def test_create_case_with_linked_report(self):
         """SvcCreateCaseUseCase links a report to the new case."""
         # Create a report first
-        report = VulnerabilityReport(
+        report = as_VulnerabilityReport(
             name="Test Vulnerability Report",
             content="A test report",
         )
@@ -197,8 +199,8 @@ class TestSvcCreateCaseUseCase:
     def test_create_case_raises_when_report_wrong_type(self):
         """SvcCreateCaseUseCase raises VultronValidationError when report_id is
         not a VulnerabilityReport."""
-        # Create a wrong type object (VulnerabilityCase instead)
-        case = VulnerabilityCase(name="Not a Report")
+        # Create a wrong type object (as_VulnerabilityCase instead)
+        case = as_VulnerabilityCase(name="Not a Report")
         self.dl.create(case)
 
         request = CreateCaseTriggerRequest(

--- a/test/core/use_cases/triggers/case/test_defer.py
+++ b/test/core/use_cases/triggers/case/test_defer.py
@@ -18,13 +18,15 @@ from vultron.core.use_cases.triggers.case import (
 )
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.objects.case_participant import (
-    CaseParticipant,
+    as_CaseParticipant,
     FinderParticipant,
 )
 from vultron.wire.as2.vocab.objects.case_status import (
-    ParticipantStatus as WireParticipantStatus,
+    as_ParticipantStatus as WireParticipantStatus,
 )
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 
 def _make_actor(name: str) -> as_Service:
@@ -44,10 +46,10 @@ def _make_case_with_case_manager(
     actor_id: str,
     finder_id: str,
     case_actor_id: str,
-) -> tuple[VulnerabilityCase, CaseParticipant]:
-    case = VulnerabilityCase(name="Test Case")
+) -> tuple[as_VulnerabilityCase, as_CaseParticipant]:
+    case = as_VulnerabilityCase(name="Test Case")
 
-    actor_participant = CaseParticipant(
+    actor_participant = as_CaseParticipant(
         attributed_to=actor_id,
         context=case.id_,
         case_roles=[CVDRole.VENDOR],
@@ -63,7 +65,7 @@ def _make_case_with_case_manager(
         attributed_to=finder_id,
         context=case.id_,
     )
-    case_manager_participant = CaseParticipant(
+    case_manager_participant = as_CaseParticipant(
         attributed_to=case_actor_id,
         context=case.id_,
         case_roles=[CVDRole.CASE_MANAGER],
@@ -113,7 +115,7 @@ class TestDeferCaseRMTransitionViaBT:
 
         updated = self.dl.read(self.vendor_participant.id_)
         assert updated is not None
-        assert isinstance(updated, CaseParticipant)
+        assert isinstance(updated, as_CaseParticipant)
         assert updated.participant_statuses
         assert updated.participant_statuses[-1].rm_state == RM.DEFERRED
 
@@ -144,8 +146,8 @@ class TestDeferCaseRMTransitionViaBT:
     def test_defer_case_rm_not_updated_when_no_participant(self):
         # Build a case with a valid vendor participant (so RM transition
         # succeeds) but no CASE_MANAGER, so ResolveCaseManagerNode fails.
-        case_solo = VulnerabilityCase(name="Solo Case")
-        vendor_participant = CaseParticipant(
+        case_solo = as_VulnerabilityCase(name="Solo Case")
+        vendor_participant = as_CaseParticipant(
             attributed_to=self.vendor.id_,
             context=case_solo.id_,
             case_roles=[CVDRole.VENDOR],

--- a/test/core/use_cases/triggers/case/test_engage.py
+++ b/test/core/use_cases/triggers/case/test_engage.py
@@ -18,10 +18,12 @@ from vultron.core.use_cases.triggers.case import (
 from vultron.errors import VultronValidationError
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.objects.case_participant import (
-    CaseParticipant,
+    as_CaseParticipant,
     FinderParticipant,
 )
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 
 def _make_actor(name: str) -> as_Service:
@@ -41,16 +43,16 @@ def _make_case_with_case_manager(
     actor_id: str,
     finder_id: str,
     case_actor_id: str,
-) -> tuple[VulnerabilityCase, CaseParticipant]:
-    case = VulnerabilityCase(name="Test Case")
+) -> tuple[as_VulnerabilityCase, as_CaseParticipant]:
+    case = as_VulnerabilityCase(name="Test Case")
 
-    actor_participant = CaseParticipant(
+    actor_participant = as_CaseParticipant(
         attributed_to=actor_id,
         context=case.id_,
         case_roles=[CVDRole.VENDOR],
     )
     from vultron.wire.as2.vocab.objects.case_status import (
-        ParticipantStatus as WireParticipantStatus,
+        as_ParticipantStatus as WireParticipantStatus,
     )
 
     actor_participant.participant_statuses.append(
@@ -64,7 +66,7 @@ def _make_case_with_case_manager(
         attributed_to=finder_id,
         context=case.id_,
     )
-    case_manager_participant = CaseParticipant(
+    case_manager_participant = as_CaseParticipant(
         attributed_to=case_actor_id,
         context=case.id_,
         case_roles=[CVDRole.CASE_MANAGER],
@@ -114,12 +116,12 @@ class TestEngageCaseRMTransitionViaBT:
 
         updated = self.dl.read(self.vendor_participant.id_)
         assert updated is not None
-        assert isinstance(updated, CaseParticipant)
+        assert isinstance(updated, as_CaseParticipant)
         assert updated.participant_statuses
         assert updated.participant_statuses[-1].rm_state == RM.ACCEPTED
 
     def test_engage_case_rm_not_updated_when_no_participant(self):
-        case_solo = VulnerabilityCase(name="Solo Case")
+        case_solo = as_VulnerabilityCase(name="Solo Case")
         case_solo.actor_participant_index[self.vendor.id_] = (
             f"{case_solo.id_}/participants/vendor"
         )

--- a/test/core/use_cases/triggers/conftest.py
+++ b/test/core/use_cases/triggers/conftest.py
@@ -1,7 +1,7 @@
 """
 Fixtures for test/core/use_cases/triggers tests.
 
-Import VulnerabilityCase so the vocabulary registry is populated before tests
+Import as_VulnerabilityCase so the vocabulary registry is populated before tests
 run, preventing TinyDB from falling back to raw Documents.
 """
 
@@ -9,7 +9,7 @@ import pytest
 
 # noqa: F401 — imported for vocabulary registration side-effect
 from vultron.wire.as2.vocab.objects.vulnerability_case import (  # noqa: F401
-    VulnerabilityCase,
+    as_VulnerabilityCase,
 )
 
 

--- a/test/core/use_cases/triggers/embargo/conftest.py
+++ b/test/core/use_cases/triggers/embargo/conftest.py
@@ -18,8 +18,10 @@ from vultron.wire.as2.vocab.objects.case_participant import (
     FinderParticipant,
     VendorParticipant,
 )
-from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 
 def _persist_actor(dl: SqliteDataLayer, name: str) -> as_Service:
@@ -30,12 +32,12 @@ def _persist_actor(dl: SqliteDataLayer, name: str) -> as_Service:
 
 def _build_active_embargo_case(
     dl: SqliteDataLayer, owner_id: str, participant_id: str
-) -> tuple[VulnerabilityCase, as_Invite, str]:
-    case = VulnerabilityCase(
+) -> tuple[as_VulnerabilityCase, as_Invite, str]:
+    case = as_VulnerabilityCase(
         name="Embargo regression case",
         attributed_to=owner_id,
     )
-    embargo = EmbargoEvent(context=case.id_)
+    embargo = as_EmbargoEvent(context=case.id_)
     proposal = em_propose_embargo_activity(
         embargo, context=case.id_, actor=owner_id
     )
@@ -75,11 +77,11 @@ def _build_proposed_embargo_case_no_owner_attribution(
     dl: SqliteDataLayer,
     actor_id: str,
     case_manager_id: str,
-) -> tuple[VulnerabilityCase, as_Invite, str]:
+) -> tuple[as_VulnerabilityCase, as_Invite, str]:
     """Build a PROPOSED embargo case with ``attributed_to=None``."""
-    case = VulnerabilityCase(name="No-attribution proposed embargo case")
+    case = as_VulnerabilityCase(name="No-attribution proposed embargo case")
 
-    embargo = EmbargoEvent(context=case.id_)
+    embargo = as_EmbargoEvent(context=case.id_)
     proposal = em_propose_embargo_activity(
         embargo, context=case.id_, actor=case_manager_id
     )
@@ -120,8 +122,8 @@ def _build_proposed_embargo_case_no_owner_attribution(
 
 def _build_exited_case(
     dl: SqliteDataLayer, owner_id: str
-) -> VulnerabilityCase:
-    case = VulnerabilityCase(
+) -> as_VulnerabilityCase:
+    case = as_VulnerabilityCase(
         name="Exited embargo case",
         attributed_to=owner_id,
     )
@@ -132,8 +134,8 @@ def _build_exited_case(
 
 def _build_no_embargo_case_with_case_manager(
     dl: SqliteDataLayer, owner_id: str
-) -> VulnerabilityCase:
-    case = VulnerabilityCase(
+) -> as_VulnerabilityCase:
+    case = as_VulnerabilityCase(
         name="No embargo case",
         attributed_to=owner_id,
     )
@@ -154,13 +156,13 @@ def _build_no_embargo_case_with_case_manager(
 
 def _build_active_embargo_case_with_case_manager(
     dl: SqliteDataLayer, actor_id: str
-) -> VulnerabilityCase:
+) -> as_VulnerabilityCase:
     """Build a case in EM.ACTIVE state with ``actor`` as owner/case-manager."""
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         name="Active embargo revision case",
         attributed_to=actor_id,
     )
-    embargo = EmbargoEvent(context=case.id_)
+    embargo = as_EmbargoEvent(context=case.id_)
 
     owner_participant = VendorParticipant(
         attributed_to=actor_id,

--- a/test/core/use_cases/triggers/embargo/test_accept.py
+++ b/test/core/use_cases/triggers/embargo/test_accept.py
@@ -16,8 +16,10 @@ from vultron.core.use_cases.triggers.requests import (
     AcceptEmbargoTriggerRequest,
 )
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 from .conftest import (
     _build_active_embargo_case,
@@ -53,8 +55,8 @@ def test_non_owner_accept_embargo_on_active_case_updates_participant_only(
 
     assert updated_case is not None
     assert updated_participant is not None
-    updated_case = cast(VulnerabilityCase, updated_case)
-    updated_participant = cast(CaseParticipant, updated_participant)
+    updated_case = cast(as_VulnerabilityCase, updated_case)
+    updated_participant = cast(as_CaseParticipant, updated_participant)
     assert updated_case.current_status.em_state == EM.ACTIVE
     assert updated_case.active_embargo == case.active_embargo
     assert updated_participant.embargo_consent_state == PEC.SIGNATORY.value
@@ -67,7 +69,7 @@ def test_is_case_owner_fail_closed_when_attributed_to_is_none() -> None:
     This prevents any actor from being granted owner privileges on a case with
     missing owner attribution. The function must be fail-closed, not fail-open.
     """
-    case = VulnerabilityCase(name="Orphan case")
+    case = as_VulnerabilityCase(name="Orphan case")
     assert case.attributed_to is None
 
     assert _is_case_owner(case, "https://example.org/alice") is False
@@ -111,8 +113,8 @@ def test_accept_embargo_when_attributed_to_is_none_does_not_activate_em(
 
     assert updated_case is not None
     assert updated_participant is not None
-    updated_case = cast(VulnerabilityCase, updated_case)
-    updated_participant = cast(CaseParticipant, updated_participant)
+    updated_case = cast(as_VulnerabilityCase, updated_case)
+    updated_participant = cast(as_CaseParticipant, updated_participant)
 
     assert updated_case.current_status.em_state == EM.PROPOSED
     assert updated_participant.embargo_consent_state == PEC.SIGNATORY.value

--- a/test/core/use_cases/triggers/embargo/test_propose.py
+++ b/test/core/use_cases/triggers/embargo/test_propose.py
@@ -15,7 +15,9 @@ from vultron.core.use_cases.triggers.requests import (
 )
 from vultron.errors import VultronInvalidStateTransitionError
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 from .conftest import (
     _build_exited_case,
@@ -67,6 +69,6 @@ def test_propose_embargo_updates_case_state_via_bt_path(
     ).execute()
 
     assert "activity" in result
-    updated_case = cast(VulnerabilityCase, finder_dl.read(case.id_))
+    updated_case = cast(as_VulnerabilityCase, finder_dl.read(case.id_))
     assert updated_case.current_status.em_state == EM.PROPOSED
     assert len(updated_case.proposed_embargoes) == 1

--- a/test/core/use_cases/triggers/embargo/test_reject.py
+++ b/test/core/use_cases/triggers/embargo/test_reject.py
@@ -13,8 +13,10 @@ from vultron.core.use_cases.triggers.requests import (
     RejectEmbargoTriggerRequest,
 )
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 from .conftest import _build_active_embargo_case, _persist_actor
 
@@ -46,8 +48,8 @@ def test_non_owner_reject_embargo_on_active_case_updates_participant_only(
 
     assert updated_case is not None
     assert updated_participant is not None
-    updated_case = cast(VulnerabilityCase, updated_case)
-    updated_participant = cast(CaseParticipant, updated_participant)
+    updated_case = cast(as_VulnerabilityCase, updated_case)
+    updated_participant = cast(as_CaseParticipant, updated_participant)
     assert updated_case.current_status.em_state == EM.ACTIVE
     assert updated_case.active_embargo == case.active_embargo
     assert updated_participant.embargo_consent_state == PEC.DECLINED.value

--- a/test/core/use_cases/triggers/embargo/test_revise.py
+++ b/test/core/use_cases/triggers/embargo/test_revise.py
@@ -18,8 +18,10 @@ from vultron.core.use_cases.triggers.requests import (
 )
 from vultron.errors import VultronInvalidStateTransitionError
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 from .conftest import (
     _build_active_embargo_case_with_case_manager,
@@ -45,7 +47,7 @@ def test_propose_embargo_revision_transitions_em_to_revise(
     ).execute()
 
     assert "activity" in result
-    updated_case = cast(VulnerabilityCase, dl.read(case.id_))
+    updated_case = cast(as_VulnerabilityCase, dl.read(case.id_))
     assert updated_case.current_status.em_state == EM.REVISE
     assert len(updated_case.proposed_embargoes) == 2
 
@@ -132,7 +134,7 @@ def test_propose_embargo_revision_in_revise_state_succeeds(
     dl.save(case)
 
     participant_id = case.actor_participant_index[actor.id_]
-    participant_before = cast(CaseParticipant, dl.read(participant_id))
+    participant_before = cast(as_CaseParticipant, dl.read(participant_id))
     pec_before = participant_before.embargo_consent_state
 
     request = ProposeEmbargoRevisionTriggerRequest(
@@ -146,9 +148,9 @@ def test_propose_embargo_revision_in_revise_state_succeeds(
     ).execute()
 
     assert "activity" in result
-    updated_case = cast(VulnerabilityCase, dl.read(case.id_))
+    updated_case = cast(as_VulnerabilityCase, dl.read(case.id_))
     assert updated_case.current_status.em_state == EM.REVISE
     assert len(updated_case.proposed_embargoes) == 2
 
-    participant_after = cast(CaseParticipant, dl.read(participant_id))
+    participant_after = cast(as_CaseParticipant, dl.read(participant_id))
     assert participant_after.embargo_consent_state == pec_before

--- a/test/core/use_cases/triggers/embargo/test_terminate.py
+++ b/test/core/use_cases/triggers/embargo/test_terminate.py
@@ -13,8 +13,10 @@ from vultron.core.use_cases.triggers.requests import (
     TerminateEmbargoTriggerRequest,
 )
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 from .conftest import _build_active_embargo_case, _persist_actor
 
@@ -38,8 +40,10 @@ def test_terminate_embargo_transitions_case_to_exited_via_bt_path(
     ).execute()
 
     assert "activity" in result
-    updated_case = cast(VulnerabilityCase, finder_dl.read(case.id_))
-    updated_participant = cast(CaseParticipant, finder_dl.read(participant_id))
+    updated_case = cast(as_VulnerabilityCase, finder_dl.read(case.id_))
+    updated_participant = cast(
+        as_CaseParticipant, finder_dl.read(participant_id)
+    )
     assert updated_case.current_status.em_state == EM.EXITED
     assert updated_case.active_embargo is None
     assert updated_participant.embargo_consent_state == PEC.NO_EMBARGO.value

--- a/test/core/use_cases/triggers/test_actor_triggers.py
+++ b/test/core/use_cases/triggers/test_actor_triggers.py
@@ -44,9 +44,9 @@ from vultron.errors import VultronNotFoundError, VultronValidationError
 from vultron.wire.as2.factories import rm_invite_to_case_activity
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Invite
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
-    VulnerabilityCase,
+    as_VulnerabilityCase,
     VulnerabilityCaseStub,
 )
 from vultron.adapters.driven.trigger_activity_adapter import (
@@ -92,16 +92,16 @@ def _cleanup_created_dls():
 
 def _make_case_with_case_manager(
     dl: SqliteDataLayer, owner_actor_id: str, case_actor_id: str
-) -> VulnerabilityCase:
-    case = VulnerabilityCase(
+) -> as_VulnerabilityCase:
+    case = as_VulnerabilityCase(
         attributed_to=owner_actor_id, name="Test Case", content="Content"
     )
-    owner_participant = CaseParticipant(
+    owner_participant = as_CaseParticipant(
         attributed_to=owner_actor_id,
         context=case.id_,
         case_roles=[CVDRole.CASE_OWNER],
     )
-    case_manager_participant = CaseParticipant(
+    case_manager_participant = as_CaseParticipant(
         attributed_to=case_actor_id,
         context=case.id_,
         case_roles=[CVDRole.CASE_MANAGER],
@@ -125,7 +125,7 @@ class TestSvcInviteActorToCaseUseCase:
 
         # Seed invitee and case in actor's DL
         dl.create(invitee)
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             attributed_to=actor.id_,
             name="Test Case",
             content="Test case content",
@@ -151,7 +151,7 @@ class TestSvcInviteActorToCaseUseCase:
         actor, dl = _make_actor_dl("Coordinator")
         invitee, _ = _make_actor_dl("Finder")
         dl.create(invitee)
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             attributed_to=actor.id_, name="Test Case", content="Content"
         )
         dl.create(case)
@@ -174,7 +174,7 @@ class TestSvcInviteActorToCaseUseCase:
         actor, dl = _make_actor_dl("Coordinator")
         # invitee NOT seeded in actor's DL
         missing_id = "https://example.org/actors/nobody"
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             attributed_to=actor.id_, name="Test Case", content="Content"
         )
         dl.create(case)
@@ -211,7 +211,7 @@ class TestSvcInviteActorToCaseUseCase:
         actor, dl = _make_actor_dl_with_http_id("Coordinator", _HTTP_ACTOR_ID)
         invitee, _ = _make_actor_dl("Finder")
         dl.create(invitee)
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             attributed_to=_HTTP_ACTOR_ID, name="Test Case", content="Content"
         )
         dl.create(case)
@@ -239,7 +239,7 @@ class TestSvcInviteActorToCaseUseCase:
         actor, dl = _make_actor_dl("Vendor")
         invitee, _ = _make_actor_dl("Coordinator")
         dl.create(invitee)
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             attributed_to=actor.id_, name="PCR Test Case", content="Content"
         )
         dl.create(case)
@@ -289,17 +289,19 @@ class TestInviteRolesAndEmbargoEnrichment:
     def _setup_invite(self, with_embargo=False, with_active_embargo=False):
         """Create actor, invitee, case; optionally add active embargo."""
         from vultron.core.states.em import EM
-        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+        from vultron.wire.as2.vocab.objects.embargo_event import (
+            as_EmbargoEvent,
+        )
 
         actor, dl = _make_actor_dl("CaseOwner")
         invitee, _ = _make_actor_dl("Invitee")
         dl.create(invitee)
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             attributed_to=actor.id_, name="Test Case", content="Content"
         )
         dl.create(case)
         if with_active_embargo:
-            embargo = EmbargoEvent(
+            embargo = as_EmbargoEvent(
                 id_=f"{case.id_}/embargo/e1",
                 content="Active embargo",
             )
@@ -364,11 +366,13 @@ class TestInviteRolesAndEmbargoEnrichment:
         """AC-1: Invite.target stub carries activeEmbargo.endTime and emState=ACTIVE."""
         from datetime import datetime, timezone
 
-        from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+        from vultron.wire.as2.vocab.objects.embargo_event import (
+            as_EmbargoEvent,
+        )
 
         actor, invitee, dl, case = self._setup_invite()
         end_time = datetime(2030, 1, 1, tzinfo=timezone.utc)
-        embargo = EmbargoEvent(
+        embargo = as_EmbargoEvent(
             id_=f"{case.id_}/embargo/e1",
             content="Active embargo",
             end_time=end_time,
@@ -465,7 +469,7 @@ class TestRolesThreadingIntegration:
             as_Service,
         )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
         # Shared DataLayer: both trigger and receive sides use it so the
@@ -478,7 +482,7 @@ class TestRolesThreadingIntegration:
         invitee_id = "https://example.org/actors/invitee-roundtrip"
         invitee = as_Organization(id_=invitee_id)
         dl.create(invitee)
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             attributed_to=owner.id_, name="Roles Round-Trip Test"
         )
         dl.create(case)
@@ -619,7 +623,7 @@ class TestSvcSuggestActorToCaseUseCase:
         actor, dl = _make_actor_dl("Coordinator")
         suggested, _ = _make_actor_dl("Vendor")
         dl.create(suggested)
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             attributed_to=actor.id_, name="Test Case", content="Content"
         )
         dl.create(case)
@@ -642,7 +646,7 @@ class TestSvcAcceptCaseInviteUseCase:
         invitee, dl_invitee = _make_actor_dl("Finder")
         dl_inviter.create(invitee)
 
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             attributed_to=inviter.id_, name="Test Case", content="Content"
         )
         dl_inviter.create(case)
@@ -694,7 +698,7 @@ class TestSvcAcceptCaseInviteUseCase:
         )
         dl_inviter.create(invitee)
 
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             attributed_to=inviter.id_, name="Test Case", content="Content"
         )
         dl_inviter.create(case)
@@ -724,19 +728,19 @@ class TestSvcAcceptCaseInviteUseCase:
 
 def _make_case_with_case_actor(
     dl: SqliteDataLayer, owner_actor_id: str, case_actor_id: str
-) -> tuple[VulnerabilityCase, str]:
-    """Create a VulnerabilityCase with a registered Case Actor service and
+) -> tuple[as_VulnerabilityCase, str]:
+    """Create a as_VulnerabilityCase with a registered Case Actor service and
     CASE_MANAGER participant.  Returns ``(case, case_actor_participant_id)``.
     """
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         attributed_to=owner_actor_id, name="Test Case", content="Content"
     )
-    owner_participant = CaseParticipant(
+    owner_participant = as_CaseParticipant(
         attributed_to=owner_actor_id,
         context=case.id_,
         case_roles=[CVDRole.CASE_OWNER],
     )
-    case_actor_participant = CaseParticipant(
+    case_actor_participant = as_CaseParticipant(
         attributed_to=case_actor_id,
         context=case.id_,
         case_roles=[CVDRole.CASE_MANAGER],
@@ -797,7 +801,7 @@ class TestSvcOfferCaseManagerRoleUseCase:
     def test_offer_raises_when_case_actor_missing(self):
         """VultronNotFoundError when no Case Actor Service exists for the case."""
         actor, dl = _make_actor_dl("Vendor")
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             attributed_to=actor.id_, name="No CaseActor Case", content="..."
         )
         dl.create(case)

--- a/test/core/use_cases/triggers/test_case_engage_defer.py
+++ b/test/core/use_cases/triggers/test_case_engage_defer.py
@@ -50,10 +50,12 @@ from vultron.core.use_cases.triggers.note import (
 )
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.objects.case_participant import (
-    CaseParticipant,
+    as_CaseParticipant,
     FinderParticipant,
 )
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 # ---------------------------------------------------------------------------
 # Test helpers
@@ -77,22 +79,22 @@ def _make_case_with_case_manager(
     actor_id: str,
     finder_id: str,
     case_actor_id: str,
-) -> tuple[VulnerabilityCase, CaseParticipant]:
-    """Create a VulnerabilityCase with all participants in both index and list.
+) -> tuple[as_VulnerabilityCase, as_CaseParticipant]:
+    """Create a as_VulnerabilityCase with all participants in both index and list.
 
     The actor participant is pre-initialized to RM.VALID so that
     engage (→ ACCEPTED) and defer (→ DEFERRED) transitions are valid.
     """
-    case = VulnerabilityCase(name="Test Case")
+    case = as_VulnerabilityCase(name="Test Case")
 
-    actor_participant = CaseParticipant(
+    actor_participant = as_CaseParticipant(
         attributed_to=actor_id,
         context=case.id_,
         case_roles=[CVDRole.VENDOR],
     )
     # Pre-advance actor to RM.VALID so engage/defer transitions will succeed
     from vultron.wire.as2.vocab.objects.case_status import (
-        ParticipantStatus as WireParticipantStatus,
+        as_ParticipantStatus as WireParticipantStatus,
     )
 
     actor_participant.participant_statuses.append(
@@ -106,7 +108,7 @@ def _make_case_with_case_manager(
         attributed_to=finder_id,
         context=case.id_,
     )
-    case_manager_participant = CaseParticipant(
+    case_manager_participant = as_CaseParticipant(
         attributed_to=case_actor_id,
         context=case.id_,
         case_roles=[CVDRole.CASE_MANAGER],
@@ -170,10 +172,10 @@ class TestEngageCaseRMTransitionViaBT:
         # Re-read participant from DataLayer to confirm BT wrote the change
         updated = self.dl.read(self.vendor_participant.id_)
         assert updated is not None
-        assert isinstance(updated, CaseParticipant)
+        assert isinstance(updated, as_CaseParticipant)
         assert (
             updated.participant_statuses
-        ), "Expected at least one ParticipantStatus after engage"
+        ), "Expected at least one as_ParticipantStatus after engage"
         assert (
             updated.participant_statuses[-1].rm_state == RM.ACCEPTED
         ), f"Expected RM.ACCEPTED, got {updated.participant_statuses[-1].rm_state}"
@@ -187,7 +189,7 @@ class TestEngageCaseRMTransitionViaBT:
         an explicit failure.
         """
         # Build a case with only actor_participant_index (not case_participants)
-        case_solo = VulnerabilityCase(name="Solo Case")
+        case_solo = as_VulnerabilityCase(name="Solo Case")
         case_solo.actor_participant_index[self.vendor.id_] = (
             f"{case_solo.id_}/participants/vendor"
         )
@@ -247,10 +249,10 @@ class TestDeferCaseRMTransitionViaBT:
         # Re-read participant from DataLayer to confirm BT wrote the change
         updated = self.dl.read(self.vendor_participant.id_)
         assert updated is not None
-        assert isinstance(updated, CaseParticipant)
+        assert isinstance(updated, as_CaseParticipant)
         assert (
             updated.participant_statuses
-        ), "Expected at least one ParticipantStatus after defer"
+        ), "Expected at least one as_ParticipantStatus after defer"
         assert (
             updated.participant_statuses[-1].rm_state == RM.DEFERRED
         ), f"Expected RM.DEFERRED, got {updated.participant_statuses[-1].rm_state}"
@@ -309,7 +311,7 @@ class TestAddNoteToCaseViaBT:
         # The case's notes list should contain the new note id
         updated_case = self.dl.read(self.case.id_)
         assert updated_case is not None
-        assert isinstance(updated_case, VulnerabilityCase)
+        assert isinstance(updated_case, as_VulnerabilityCase)
         assert (
             len(updated_case.notes) >= 1
         ), "Expected case.notes to contain the new note after BT-driven attachment"

--- a/test/core/use_cases/triggers/test_note_trigger.py
+++ b/test/core/use_cases/triggers/test_note_trigger.py
@@ -47,10 +47,12 @@ from vultron.core.use_cases.triggers.requests import (
 from vultron.errors import VultronValidationError
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.objects.case_participant import (
-    CaseParticipant,
+    as_CaseParticipant,
     FinderParticipant,
 )
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.adapters.driven.trigger_activity_adapter import (
     TriggerActivityAdapter,
 )
@@ -76,32 +78,32 @@ def _make_case_with_case_manager(
     actor_id: str,
     finder_id: str,
     case_actor_id: str,
-) -> tuple[VulnerabilityCase, CaseParticipant]:
-    """Create a VulnerabilityCase with a Finder participant and a Case Actor
+) -> tuple[as_VulnerabilityCase, as_CaseParticipant]:
+    """Create a as_VulnerabilityCase with a Finder participant and a Case Actor
     participant (CVDRole.CASE_MANAGER).
 
-    Returns the case and the Case Manager CaseParticipant.
+    Returns the case and the Case Manager as_CaseParticipant.
 
     The actor participant is pre-initialized to RM.VALID so that
     engage (→ ACCEPTED) and defer (→ DEFERRED) transitions are valid.
     """
     from vultron.core.states.rm import RM
     from vultron.wire.as2.vocab.objects.case_status import (
-        ParticipantStatus as WireParticipantStatus,
+        as_ParticipantStatus as WireParticipantStatus,
     )
 
-    case = VulnerabilityCase(name="Test Case")
+    case = as_VulnerabilityCase(name="Test Case")
 
     finder_participant = FinderParticipant(
         attributed_to=finder_id,
         context=case.id_,
     )
-    case_manager_participant = CaseParticipant(
+    case_manager_participant = as_CaseParticipant(
         attributed_to=case_actor_id,
         context=case.id_,
         case_roles=[CVDRole.CASE_MANAGER],
     )
-    actor_participant = CaseParticipant(
+    actor_participant = as_CaseParticipant(
         attributed_to=actor_id,
         context=case.id_,
         case_roles=[CVDRole.VENDOR],
@@ -236,7 +238,7 @@ class TestSvcAddNoteToCaseUseCase:
         result = self._execute()
         note_id = result["note"]["id"]
         case_obj = self.dl.read(self.case.id_)
-        assert isinstance(case_obj, VulnerabilityCase)
+        assert isinstance(case_obj, as_VulnerabilityCase)
         note_ids = [
             n if isinstance(n, str) else getattr(n, "id_", str(n))
             for n in case_obj.notes
@@ -307,7 +309,7 @@ class TestSvcAddNoteToCaseUseCase:
 
     def test_raises_when_no_case_manager(self):
         """SvcAddNoteToCaseUseCase raises VultronValidationError when no CASE_MANAGER."""
-        solo_case = VulnerabilityCase(name="No Manager Case")
+        solo_case = as_VulnerabilityCase(name="No Manager Case")
         solo_case.actor_participant_index[self.vendor.id_] = (
             f"{solo_case.id_}/participants/vendor"
         )
@@ -363,7 +365,7 @@ class TestSvcAddNoteToCaseUseCase:
         note_id = result["note"]["id"]
 
         case_obj = self.dl.read(self.case.id_)
-        assert isinstance(case_obj, VulnerabilityCase)
+        assert isinstance(case_obj, as_VulnerabilityCase)
         count_before = sum(
             1
             for n in case_obj.notes
@@ -381,7 +383,7 @@ class TestSvcAddNoteToCaseUseCase:
             self.dl.save(case_obj)
 
         case_obj2 = self.dl.read(self.case.id_)
-        assert isinstance(case_obj2, VulnerabilityCase)
+        assert isinstance(case_obj2, as_VulnerabilityCase)
         count_after = sum(
             1
             for n in case_obj2.notes

--- a/test/core/use_cases/triggers/test_report_triggers.py
+++ b/test/core/use_cases/triggers/test_report_triggers.py
@@ -19,7 +19,7 @@ SvcSubmitReportUseCase.
 
 Per notes/triggers-test-coverage.md: each test exercises the use case's
 execute() path against a real in-memory DataLayer and asserts:
-  1. the RM state mutation (ParticipantStatus / CaseParticipant transition);
+  1. the RM state mutation (as_ParticipantStatus / as_CaseParticipant transition);
   2. the outbox effect (activity queued, addressed correctly per PCR-08-001);
   3. the documented failure modes the use case is documented to raise.
 """
@@ -50,16 +50,18 @@ from vultron.wire.as2.factories import rm_submit_report_activity
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.objects.case_participant import (
-    CaseParticipant,
+    as_CaseParticipant,
     FinderParticipant,
 )
 from vultron.wire.as2.vocab.objects.case_status import (
-    ParticipantStatus as WireParticipantStatus,
+    as_ParticipantStatus as WireParticipantStatus,
 )
-from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 # ---------------------------------------------------------------------------
@@ -79,7 +81,7 @@ def _make_actor_dl(actor_name: str) -> tuple[as_Service, SqliteDataLayer]:
 
 def _make_offer(
     dl: SqliteDataLayer,
-    report: VulnerabilityReport,
+    report: as_VulnerabilityReport,
     recipient_id: str,
     actor_id: str,
 ) -> as_Offer:
@@ -98,17 +100,17 @@ def _make_case_with_embargo(
     finder_id: str,
     case_actor_id: str,
     report_id: str,
-) -> VulnerabilityCase:
-    """Build a VulnerabilityCase with finder, vendor, CASE_MANAGER participants,
+) -> as_VulnerabilityCase:
+    """Build a as_VulnerabilityCase with finder, vendor, CASE_MANAGER participants,
     an active embargo, and the report linked via vulnerability_reports."""
-    embargo = EmbargoEvent(context="urn:placeholder")
+    embargo = as_EmbargoEvent(context="urn:placeholder")
     dl.create(embargo)
 
-    case = VulnerabilityCase(name="Test Case")
+    case = as_VulnerabilityCase(name="Test Case")
     case.set_embargo(embargo.id_)
     case.vulnerability_reports.append(report_id)
 
-    vendor_participant = CaseParticipant(
+    vendor_participant = as_CaseParticipant(
         attributed_to=vendor_id,
         context=case.id_,
         case_roles=[CVDRole.VENDOR],
@@ -121,7 +123,7 @@ def _make_case_with_embargo(
         attributed_to=finder_id,
         context=case.id_,
     )
-    case_manager_participant = CaseParticipant(
+    case_manager_participant = as_CaseParticipant(
         attributed_to=case_actor_id,
         context=case.id_,
         case_roles=[CVDRole.CASE_MANAGER],
@@ -160,7 +162,7 @@ class TestSvcValidateReportUseCase:
         self.finder, self.finder_dl = _make_actor_dl("Finder Co")
         self.case_actor, self.case_actor_dl = _make_actor_dl("Case Actor")
 
-        self.report = VulnerabilityReport(
+        self.report = as_VulnerabilityReport(
             name="CVE-TEST",
             content="Vulnerability report content",
             attributed_to=self.finder.id_,
@@ -195,7 +197,7 @@ class TestSvcValidateReportUseCase:
     # --- AC-1: RM state transition -----------------------------------------
 
     def test_validate_report_creates_rm_valid_status_record(self):
-        """execute() creates a ParticipantStatus record for RM.VALID."""
+        """execute() creates a as_ParticipantStatus record for RM.VALID."""
         request = ValidateReportTriggerRequest(
             actor_id=self.vendor.id_,
             offer_id=self.offer.id_,
@@ -213,7 +215,7 @@ class TestSvcValidateReportUseCase:
         assert status_record is not None
 
     def test_validate_report_updates_case_participant_rm_state(self):
-        """execute() advances the CaseParticipant.participant_statuses to RM.VALID."""
+        """execute() advances the as_CaseParticipant.participant_statuses to RM.VALID."""
         request = ValidateReportTriggerRequest(
             actor_id=self.vendor.id_,
             offer_id=self.offer.id_,
@@ -229,7 +231,7 @@ class TestSvcValidateReportUseCase:
         ]
         updated = self.dl.read(vendor_participant_id)
         assert updated is not None
-        assert isinstance(updated, CaseParticipant)
+        assert isinstance(updated, as_CaseParticipant)
         assert updated.participant_statuses
         assert updated.participant_statuses[-1].rm_state == RM.VALID
 
@@ -319,8 +321,8 @@ class TestSvcValidateReportUseCase:
 
     def test_validate_report_raises_when_offer_is_wrong_type(self):
         """VultronValidationError raised when offer_id resolves to wrong type."""
-        # Store a plain VulnerabilityReport (not an Offer) as the offer_id.
-        non_offer = VulnerabilityReport(
+        # Store a plain as_VulnerabilityReport (not an Offer) as the offer_id.
+        non_offer = as_VulnerabilityReport(
             name="Not an offer",
             content="wrong type object",
             attributed_to=self.vendor.id_,
@@ -366,7 +368,7 @@ class TestSvcValidateReportUseCase:
             self.vendor.id_
         ]
         p1 = self.dl.read(vendor_participant_id)
-        assert isinstance(p1, CaseParticipant)
+        assert isinstance(p1, as_CaseParticipant)
         statuses_after_first = list(p1.participant_statuses)
 
         # Second call: CheckRMStateValid short-circuits before TransitionRMtoValid;
@@ -376,7 +378,7 @@ class TestSvcValidateReportUseCase:
         ).execute()
 
         p2 = self.dl.read(vendor_participant_id)
-        assert isinstance(p2, CaseParticipant)
+        assert isinstance(p2, as_CaseParticipant)
         assert len(p2.participant_statuses) == len(
             statuses_after_first
         ), "Second validate re-appended a duplicate RM status entry"
@@ -409,7 +411,7 @@ class TestSvcSubmitReportUseCase:
     # --- AC-2: RM state / persistence mutations ----------------------------
 
     def test_submit_report_persists_vulnerability_report(self):
-        """execute() stores a VulnerabilityReport in the actor's DataLayer."""
+        """execute() stores a as_VulnerabilityReport in the actor's DataLayer."""
         request = SubmitReportTriggerRequest(
             actor_id=self.finder.id_,
             report_name="CVE-TEST",
@@ -428,8 +430,10 @@ class TestSvcSubmitReportUseCase:
         report_id = report_obj.get("id")
         assert report_id is not None, "offer['object']['id'] is missing"
         stored = self.dl.read(report_id)
-        assert stored is not None, "VulnerabilityReport not found in DataLayer"
-        assert isinstance(stored, VulnerabilityReport)
+        assert (
+            stored is not None
+        ), "as_VulnerabilityReport not found in DataLayer"
+        assert isinstance(stored, as_VulnerabilityReport)
         assert stored.name == "CVE-TEST"
 
     def test_submit_report_persists_report_case_link(self):

--- a/test/core/use_cases/triggers/test_service.py
+++ b/test/core/use_cases/triggers/test_service.py
@@ -48,21 +48,23 @@ from vultron.enums.roles import CVDRole
 from vultron.wire.as2.factories import em_propose_embargo_activity
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 FUTURE_DATETIME = datetime(2099, 12, 1, tzinfo=timezone.utc)
 
 
-def _add_case_manager(case: VulnerabilityCase, dl) -> as_Service:
+def _add_case_manager(case: as_VulnerabilityCase, dl) -> as_Service:
     """Add a CASE_MANAGER participant to *case* and return the case actor."""
     case_actor = as_Service(name=f"Case Actor for {case.name}")
     dl.create(case_actor)
-    cm_participant = CaseParticipant(
+    cm_participant = as_CaseParticipant(
         attributed_to=case_actor.id_,
         context=case.id_,
         case_roles=[CVDRole.CASE_MANAGER],
@@ -119,7 +121,7 @@ def reporter(dl):
 
 @pytest.fixture
 def report(dl):
-    report_obj = VulnerabilityReport(
+    report_obj = as_VulnerabilityReport(
         name="Test Vulnerability",
         content="Test content",
     )
@@ -140,7 +142,7 @@ def offer(dl, report, actor, reporter):
 
 @pytest.fixture
 def received_report(dl, actor, reporter, report, offer):
-    """Pre-create a VulnerabilityCase for the report at RM.RECEIVED.
+    """Pre-create a as_VulnerabilityCase for the report at RM.RECEIVED.
 
     Per ADR-0015, the case is created at report receipt.  The validate_report
     BT's EnsureEmbargoExists node requires a case to exist.
@@ -182,8 +184,8 @@ def closed_report(dl, report, actor):
 
 @pytest.fixture
 def case_with_participant(dl, actor):
-    case_obj = VulnerabilityCase(name="TEST-CASE-001")
-    participant = CaseParticipant(
+    case_obj = as_VulnerabilityCase(name="TEST-CASE-001")
+    participant = as_CaseParticipant(
         attributed_to=actor.id_,
         context=case_obj.id_,
     )
@@ -203,7 +205,7 @@ def case_with_participant(dl, actor):
 
 @pytest.fixture
 def case_no_participant(dl):
-    case_obj = VulnerabilityCase(name="TEST-CASE-NO-P")
+    case_obj = as_VulnerabilityCase(name="TEST-CASE-NO-P")
     dl.create(case_obj)
     return case_obj
 
@@ -211,7 +213,7 @@ def case_no_participant(dl):
 @pytest.fixture
 def case_with_case_manager(dl):
     """A bare case with a single CASE_MANAGER participant, no other participants."""
-    case_obj = VulnerabilityCase(name="TEST-CASE-WITH-CM")
+    case_obj = as_VulnerabilityCase(name="TEST-CASE-WITH-CM")
     dl.create(case_obj)
     _add_case_manager(case_obj, dl)
     return case_obj
@@ -219,8 +221,8 @@ def case_with_case_manager(dl):
 
 @pytest.fixture
 def case_with_embargo(dl, actor):
-    case_obj = VulnerabilityCase(name="EMBARGO-CASE-001")
-    embargo = EmbargoEvent(context=case_obj.id_)
+    case_obj = as_VulnerabilityCase(name="EMBARGO-CASE-001")
+    embargo = as_EmbargoEvent(context=case_obj.id_)
     dl.create(embargo)
     case_obj.set_embargo(embargo.id_)
     case_obj.current_status.em_state = EM.ACTIVE
@@ -231,11 +233,11 @@ def case_with_embargo(dl, actor):
 
 @pytest.fixture
 def case_with_proposal(dl, actor):
-    case_obj = VulnerabilityCase(
+    case_obj = as_VulnerabilityCase(
         name="PROPOSAL-CASE-001",
         attributed_to=actor.id_,
     )
-    embargo = EmbargoEvent(context=case_obj.id_)
+    embargo = as_EmbargoEvent(context=case_obj.id_)
     dl.create(embargo)
     proposal = em_propose_embargo_activity(
         embargo, context=case_obj.id_, actor=actor.id_
@@ -250,8 +252,8 @@ def case_with_proposal(dl, actor):
 
 @pytest.fixture
 def non_report_object(dl):
-    """An EmbargoEvent stored in the datalayer — not an Offer."""
-    obj = EmbargoEvent(context="urn:uuid:some-case")
+    """An as_EmbargoEvent stored in the datalayer — not an Offer."""
+    obj = as_EmbargoEvent(context="urn:uuid:some-case")
     dl.create(obj)
     return obj
 
@@ -521,7 +523,7 @@ def test_engage_case_trigger_invalid_case_id_raises_422(dl, actor):
 def test_engage_case_trigger_updates_participant_rm_state(
     dl, actor, case_with_participant
 ):
-    """engage_case_trigger transitions actor's CaseParticipant RM state to ACCEPTED."""
+    """engage_case_trigger transitions actor's as_CaseParticipant RM state to ACCEPTED."""
     TriggerService(
         dl, trigger_activity=TriggerActivityAdapter(dl)
     ).engage_case(actor.id_, case_with_participant.id_)
@@ -595,7 +597,7 @@ def test_defer_case_trigger_invalid_case_id_raises_422(dl, actor):
 def test_defer_case_trigger_updates_participant_rm_state(
     dl, actor, case_with_participant
 ):
-    """defer_case_trigger transitions actor's CaseParticipant RM state to DEFERRED."""
+    """defer_case_trigger transitions actor's as_CaseParticipant RM state to DEFERRED."""
     TriggerService(dl, trigger_activity=TriggerActivityAdapter(dl)).defer_case(
         actor.id_, case_with_participant.id_
     )

--- a/test/core/use_cases/triggers/test_sync.py
+++ b/test/core/use_cases/triggers/test_sync.py
@@ -17,9 +17,9 @@
 from typing import Any
 
 from vultron.core.use_cases._helpers import build_activity_payload_snapshot
-from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 
@@ -36,8 +36,8 @@ def test_extract_activity_snapshot_returns_empty_without_activity() -> None:
 
 
 def test_extract_activity_snapshot_inlines_nested_reference_fields(datalayer):
-    embargo = EmbargoEvent(context="https://example.org/cases/case-001")
-    report = VulnerabilityReport(
+    embargo = as_EmbargoEvent(context="https://example.org/cases/case-001")
+    report = as_VulnerabilityReport(
         name="TEST-REPORT-001",
         content="Demo content",
         context="https://example.org/cases/case-001",
@@ -75,7 +75,7 @@ def test_extract_activity_snapshot_inlines_nested_reference_fields(datalayer):
 def test_extract_activity_snapshot_does_not_inline_cross_context_refs(
     datalayer,
 ):
-    embargo = EmbargoEvent(context="https://example.org/cases/other-case")
+    embargo = as_EmbargoEvent(context="https://example.org/cases/other-case")
     datalayer.save(embargo)
 
     payload = {

--- a/test/core/use_cases/triggers/test_trignotify.py
+++ b/test/core/use_cases/triggers/test_trignotify.py
@@ -65,16 +65,18 @@ from vultron.wire.as2.factories import (
 )
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.objects.case_participant import (
-    CaseParticipant,
+    as_CaseParticipant,
     FinderParticipant,
 )
-from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.adapters.driven.trigger_activity_adapter import (
     TriggerActivityAdapter,
 )
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 from datetime import datetime, timezone
@@ -104,8 +106,8 @@ def _make_case_with_case_manager(
     actor_id: str,
     finder_id: str,
     case_actor_id: str,
-) -> VulnerabilityCase:
-    """Create a VulnerabilityCase with a Finder participant and a Case Actor
+) -> as_VulnerabilityCase:
+    """Create a as_VulnerabilityCase with a Finder participant and a Case Actor
     (CVDRole.CASE_MANAGER).  Persists all objects in *dl*.
 
     The actor participant is pre-initialized to RM.VALID so that
@@ -113,12 +115,12 @@ def _make_case_with_case_manager(
     """
     from vultron.core.states.rm import RM
     from vultron.wire.as2.vocab.objects.case_status import (
-        ParticipantStatus as WireParticipantStatus,
+        as_ParticipantStatus as WireParticipantStatus,
     )
 
-    case = VulnerabilityCase(name="Test Case")
+    case = as_VulnerabilityCase(name="Test Case")
 
-    actor_participant = CaseParticipant(
+    actor_participant = as_CaseParticipant(
         attributed_to=actor_id,
         context=case.id_,
         case_roles=[CVDRole.VENDOR],
@@ -136,7 +138,7 @@ def _make_case_with_case_manager(
         attributed_to=finder_id,
         context=case.id_,
     )
-    case_manager_participant = CaseParticipant(
+    case_manager_participant = as_CaseParticipant(
         attributed_to=case_actor_id,
         context=case.id_,
         case_roles=[CVDRole.CASE_MANAGER],
@@ -159,8 +161,8 @@ def _make_case_with_case_manager(
 
 def _make_two_actor_case(
     dl, vendor_id: str, finder_id: str
-) -> VulnerabilityCase:
-    """Create a VulnerabilityCase with vendor and finder — no CASE_MANAGER.
+) -> as_VulnerabilityCase:
+    """Create a as_VulnerabilityCase with vendor and finder — no CASE_MANAGER.
 
     Both ``case_participants`` and ``actor_participant_index`` are kept in
     sync via ``add_participant()``.  Participant objects are stored in the
@@ -170,14 +172,14 @@ def _make_two_actor_case(
     Use ``_make_case_with_case_manager`` for tests that need PCR-08-001
     routing or an ``EngageCaseTriggerRequest``/``AddParticipantStatusTriggerRequest``.
     """
-    case = VulnerabilityCase(name="Test Case")
-    vendor_participant = CaseParticipant(
+    case = as_VulnerabilityCase(name="Test Case")
+    vendor_participant = as_CaseParticipant(
         id_=f"{case.id_}/participants/vendor",
         attributed_to=vendor_id,
         context=case.id_,
         case_roles=[CVDRole.VENDOR],
     )
-    finder_participant = CaseParticipant(
+    finder_participant = as_CaseParticipant(
         id_=f"{case.id_}/participants/finder",
         attributed_to=finder_id,
         context=case.id_,
@@ -318,7 +320,7 @@ class TestCaseTriggerToField:
 
     def test_engage_case_raises_when_no_case_manager(self):
         """SvcEngageCaseUseCase raises VultronValidationError when no CASE_MANAGER."""
-        case_solo = VulnerabilityCase(name="Solo Case")
+        case_solo = as_VulnerabilityCase(name="Solo Case")
         case_solo.actor_participant_index[self.vendor.id_] = (
             f"{case_solo.id_}/participants/vendor"
         )
@@ -386,7 +388,7 @@ class TestEmbargoTriggerToField:
 
     def test_evaluate_embargo_to_field_addresses_case_actor_only(self):
         """SvcAcceptEmbargoUseCase queues activity addressed only to Case Actor."""
-        embargo = EmbargoEvent(context=self.case.id_)
+        embargo = as_EmbargoEvent(context=self.case.id_)
         self.dl.create(embargo)
         proposal = em_propose_embargo_activity(
             embargo, context=self.case.id_, actor=self.finder.id_
@@ -418,7 +420,7 @@ class TestEmbargoTriggerToField:
 
     def test_terminate_embargo_to_field_addresses_case_actor_only(self):
         """SvcTerminateEmbargoUseCase queues activity addressed only to Case Actor."""
-        embargo = EmbargoEvent(context=self.case.id_)
+        embargo = as_EmbargoEvent(context=self.case.id_)
         self.dl.create(embargo)
         self.case.set_embargo(embargo.id_)
         self.case.current_status.em_state = EM.ACTIVE
@@ -445,7 +447,7 @@ class TestEmbargoTriggerToField:
 
     def test_reject_embargo_to_field_addresses_case_actor_only(self):
         """SvcRejectEmbargoUseCase queues activity addressed only to Case Actor."""
-        embargo = EmbargoEvent(context=self.case.id_)
+        embargo = as_EmbargoEvent(context=self.case.id_)
         self.dl.create(embargo)
         proposal = em_propose_embargo_activity(
             embargo, context=self.case.id_, actor=self.finder.id_
@@ -476,7 +478,7 @@ class TestEmbargoTriggerToField:
 
     def test_propose_embargo_revision_to_field_addresses_case_actor_only(self):
         """SvcProposeEmbargoRevisionUseCase queues activity to only Case Actor."""
-        embargo = EmbargoEvent(context=self.case.id_)
+        embargo = as_EmbargoEvent(context=self.case.id_)
         self.dl.create(embargo)
         self.case.set_embargo(embargo.id_)
         self.case.current_status.em_state = EM.ACTIVE
@@ -521,7 +523,7 @@ class TestReportTriggerToField:
         self.dl.create(self.finder)
         self.dl.create(self.case_actor)
 
-        self.report = VulnerabilityReport(
+        self.report = as_VulnerabilityReport(
             name="CVE-TEST",
             content="Report content",
             attributed_to=self.finder.id_,

--- a/test/demo/test_case_proposal_round_trip.py
+++ b/test/demo/test_case_proposal_round_trip.py
@@ -78,7 +78,7 @@ from test.demo._helpers import make_testclient_call
 from test.demo.conftest import _TestASGIRouter, create_isolated_actor_app
 from vultron.wire.as2.factories import rm_submit_report_activity
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 # ---------------------------------------------------------------------------
@@ -221,7 +221,7 @@ class TestCaseProposalRoundTrip:
             vendor_tc, reporter_base_api, _REPORTER_SLUG, "Reporter CP"
         )
 
-        report = VulnerabilityReport(
+        report = as_VulnerabilityReport(
             attributed_to=reporter_actor_id,
             name="CP-07-003 round-trip report",
             content=(
@@ -270,7 +270,7 @@ class TestCaseProposalRoundTrip:
             vendor_tc, reporter_base_api, _REPORTER_SLUG, "Reporter CP"
         )
 
-        report = VulnerabilityReport(
+        report = as_VulnerabilityReport(
             attributed_to=reporter_actor_id,
             name="CP-07-003 accept round-trip report",
             content=(

--- a/test/demo/test_find_case_by_report.py
+++ b/test/demo/test_find_case_by_report.py
@@ -14,9 +14,11 @@
 
 from unittest.mock import Mock
 
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 from vultron.demo.exchange.receive_report_demo import find_case_by_report
 
@@ -31,13 +33,13 @@ def test_find_case_by_report_with_vulnerability_reports_field():
     cases to not be found even though they existed.
     """
     # Create a test report
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         name="Test Vulnerability Report",
         content="This is a test vulnerability report content.",
     )
 
     # Create a case that references this report via vulnerability_reports field
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         name=f"Case for Report {report.id_}",
         vulnerability_reports=[
             report.id_

--- a/test/demo/test_multi_vendor_demo.py
+++ b/test/demo/test_multi_vendor_demo.py
@@ -130,7 +130,7 @@ class TestVendorCreatesCase:
         assert case.id_ in case_ids
 
         case_data = case_actor_client.get(f"/datalayer/{case.id_}")
-        stored_case = demo.VulnerabilityCase(**case_data)
+        stored_case = demo.as_VulnerabilityCase(**case_data)
         from vultron.demo.scenario.multi_vendor_demo import ref_id as _ref_id
 
         assert _ref_id(stored_case.attributed_to) == vendor_in_vendor.id_
@@ -191,7 +191,7 @@ class TestOwnershipTransfer:
 
         # Confirm initial owner is vendor
         case_data = case_actor_client.get(f"/datalayer/{case.id_}")
-        initial_case = demo.VulnerabilityCase(**case_data)
+        initial_case = demo.as_VulnerabilityCase(**case_data)
         from vultron.demo.scenario.multi_vendor_demo import ref_id as _ref_id
 
         assert _ref_id(initial_case.attributed_to) == vendor_in_vendor.id_
@@ -216,7 +216,7 @@ class TestOwnershipTransfer:
 
         # Verify case ownership transferred to coordinator
         updated_data = case_actor_client.get(f"/datalayer/{case.id_}")
-        updated_case = demo.VulnerabilityCase(**updated_data)
+        updated_case = demo.as_VulnerabilityCase(**updated_data)
         from vultron.demo.scenario.multi_vendor_demo import ref_id as _ref_id
 
         assert (

--- a/test/demo/test_pcr_bootstrap.py
+++ b/test/demo/test_pcr_bootstrap.py
@@ -13,7 +13,7 @@
 
 """Integration tests for PCR-07-006: full case-replica bootstrap sequence.
 
-Verifies: CaseActor sends Announce(VulnerabilityCase) → participant creates
+Verifies: CaseActor sends Announce(as_VulnerabilityCase) → participant creates
 local replica → subsequent case-scoped activities route without deferral.
 
 These tests exercise the full inbox dispatch path against a real in-memory
@@ -26,7 +26,7 @@ AC-1 tests (``TestBootstrapSequence.test_announce_creates_case_replica`` and
 ``test_case_fields_preserved_in_replica``) use a **two-app setup** where a
 separate owner app creates a case by processing a submitted report and then
 validates it.  Validation triggers the CaseActor to emit
-``Announce(VulnerabilityCase)`` via the outbox, which is routed to the
+``Announce(as_VulnerabilityCase)`` via the outbox, which is routed to the
 participant app via ``_TestASGIRouter``.  This exercises the full
 create-case → emit-Announce path, catching regressions where case creation
 no longer sends the announcement (PCR-07-006).
@@ -47,9 +47,11 @@ from vultron.wire.as2.factories import (
     rm_submit_report_activity,
 )
 from vultron.wire.as2.vocab.base.objects.object_types import as_Note
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 # ---------------------------------------------------------------------------
@@ -80,7 +82,7 @@ def participant_setup():
     """One isolated participant app for the AC-2 routing test.
 
     The case replica is seeded directly via a hand-crafted
-    ``Announce(VulnerabilityCase)`` (fast, sufficient for routing coverage).
+    ``Announce(as_VulnerabilityCase)`` (fast, sufficient for routing coverage).
     The ``_TestASGIRouter`` is wired as the ASGI emitter fallback so that any
     outbound deliveries from the participant stay in-process.
 
@@ -219,10 +221,10 @@ def _bootstrap_case_for_participant(
 
     1. Participant submits a ``SubmitReport`` offer to owner's inbox, which
        triggers the ``create_receive_report_case_tree`` BT and creates the
-       preliminary ``VulnerabilityCase`` with embargo.
+       preliminary ``as_VulnerabilityCase`` with embargo.
     2. Owner validates the report (``trigger/validate-report``), which
        triggers the ``create_validate_report_tree`` BT and causes the
-       CaseActor to emit ``Announce(VulnerabilityCase)`` to participant.
+       CaseActor to emit ``Announce(as_VulnerabilityCase)`` to participant.
     3. The Announce is delivered via the outbox → ``_TestASGIRouter`` →
        participant inbox chain.
     4. Participant's inbox handler processes the ``Announce``.
@@ -236,7 +238,7 @@ def _bootstrap_case_for_participant(
         participant_slug: Short slug for the participant actor.
 
     Returns:
-        The ``id_`` of the ``VulnerabilityCase`` created on owner's app.
+        The ``id_`` of the ``as_VulnerabilityCase`` created on owner's app.
     """
     owner_base_api = owner_iso.base_url + "/api/v2"
     participant_base_api = participant_iso.base_url + "/api/v2"
@@ -255,9 +257,9 @@ def _bootstrap_case_for_participant(
 
     # Build the SubmitReport offer and deliver it to owner's inbox.
     # This triggers the create_receive_report_case_tree BT which creates
-    # the preliminary VulnerabilityCase with embargo — required for the
+    # the preliminary as_VulnerabilityCase with embargo — required for the
     # subsequent validate-report step.
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         attributed_to=participant_actor_id,
         name="PCR-07-006 bootstrap test report",
         content=(
@@ -276,14 +278,14 @@ def _bootstrap_case_for_participant(
     # Verify the submit-report BT created the case.
     all_cases = owner_iso.dl.get_all("VulnerabilityCase")
     assert len(all_cases) >= 1, (
-        "Expected at least one VulnerabilityCase in owner's DataLayer "
+        "Expected at least one as_VulnerabilityCase in owner's DataLayer "
         "after SubmitReport inbox delivery, but none was found.  "
         "The create_receive_report_case_tree BT may not have run."
     )
     case_id: str = all_cases[0]["id_"]
 
     # Owner validates the report: this triggers the validate-report BT
-    # and causes the CaseActor to emit Announce(VulnerabilityCase) to
+    # and causes the CaseActor to emit Announce(as_VulnerabilityCase) to
     # participant via the outbox → _TestASGIRouter → inbox chain.
     resp = owner_tc.post(
         f"/api/v2/actors/{_actor_slug(owner_actor_id)}"
@@ -314,10 +316,10 @@ class TestBootstrapSequence:
     """
 
     def test_announce_creates_case_replica(self, two_app_setup):
-        """AC-1: Announce(VulnerabilityCase) creates a local replica.
+        """AC-1: Announce(as_VulnerabilityCase) creates a local replica.
 
         Exercises the full bootstrap sequence: participant submits a report →
-        owner validates it → CaseActor emits ``Announce(VulnerabilityCase)``
+        owner validates it → CaseActor emits ``Announce(as_VulnerabilityCase)``
         via the outbox → participant's inbox receives and processes the
         Announce.
 
@@ -351,7 +353,7 @@ class TestBootstrapSequence:
         try:
             assert actor_dl.inbox_list() == [], (
                 "Participant actor's inbox queue was not drained after "
-                "processing Announce(VulnerabilityCase).  The inbox handler "
+                "processing Announce(as_VulnerabilityCase).  The inbox handler "
                 "may not have run (PCR-07-006 AC-1)."
             )
         finally:
@@ -359,8 +361,8 @@ class TestBootstrapSequence:
 
         replica = participant_iso.dl.read(case_id)
         assert replica is not None, (
-            f"Expected VulnerabilityCase '{case_id}' in participant's "
-            f"DataLayer after Announce(VulnerabilityCase) delivery, but "
+            f"Expected as_VulnerabilityCase '{case_id}' in participant's "
+            f"DataLayer after Announce(as_VulnerabilityCase) delivery, but "
             f"DataLayer has no record of it.  Bootstrap sequence may be "
             f"broken (PCR-07-006 AC-1)."
         )
@@ -384,7 +386,7 @@ class TestBootstrapSequence:
 
         replica = participant_iso.dl.read(case_id)
         assert replica is not None, (
-            f"No VulnerabilityCase replica found for '{case_id}' in "
+            f"No as_VulnerabilityCase replica found for '{case_id}' in "
             "participant's DataLayer after bootstrap sequence."
         )
 
@@ -431,7 +433,7 @@ class TestBootstrapSequence:
         )
 
         # Seed the replica via a direct Announce.
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             id_=_DIRECT_CASE_ID, name="PCR-07-006 Test Case"
         )
         announce = announce_vulnerability_case_activity(

--- a/test/demo/test_pcr_engage_case.py
+++ b/test/demo/test_pcr_engage_case.py
@@ -44,7 +44,7 @@ from test.demo.conftest import _TestASGIRouter, create_isolated_actor_app
 from vultron.adapters.driving.fastapi.outbox_handler import outbox_handler
 from vultron.wire.as2.factories import rm_submit_report_activity
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 # ---------------------------------------------------------------------------
@@ -222,7 +222,7 @@ def _bootstrap_and_engage(
     # Owner's app must know the reporter so outbound Create is routable.
     _create_actor(owner_tc, reporter_base_api, reporter_slug, "Reporter")
 
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         attributed_to=reporter_actor_id,
         name="PCR engage-case integration test report",
         content=(

--- a/test/demo/test_pcr_late_joiner.py
+++ b/test/demo/test_pcr_late_joiner.py
@@ -62,7 +62,7 @@ from test.demo.conftest import _TestASGIRouter, create_isolated_actor_app
 from vultron.adapters.driving.fastapi.outbox_handler import outbox_handler
 from vultron.wire.as2.factories import rm_submit_report_activity
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 # ---------------------------------------------------------------------------
@@ -250,7 +250,7 @@ def _bootstrap_case(
     # Register reporter on owner's app so the router can deliver there.
     _create_actor(owner_tc, reporter_base_api, reporter_slug, "Reporter")
 
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         attributed_to=reporter_actor_id,
         name="PCR-07-007 late-joiner test report",
         content=(

--- a/test/demo/test_sync_ledger_replication.py
+++ b/test/demo/test_sync_ledger_replication.py
@@ -11,7 +11,7 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""SYNC integration tests for single-peer CaseLedgerEntry replication (#901)."""
+"""SYNC integration tests for single-peer as_CaseLedgerEntry replication (#901)."""
 
 from __future__ import annotations
 
@@ -51,11 +51,13 @@ from vultron.wire.as2.factories import (
     reject_log_entry_activity,
 )
 from vultron.wire.as2.vocab.objects.case_ledger_entry import (
-    CaseLedgerEntry as WireCaseLedgerEntry,
+    as_CaseLedgerEntry as WireCaseLedgerEntry,
 )
-from vultron.wire.as2.vocab.objects.case_actor import CaseActor
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_actor import as_CaseActor
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 _CASE_ACTOR_BASE = "http://case-actor-sync-901.test"
 _PEER_BASE = "http://peer-sync-901.test"
@@ -123,7 +125,7 @@ def two_app_setup() -> Iterator[tuple]:
 @pytest.mark.spec("SYNC-07-002")
 @pytest.mark.spec("SYNC-02-003")
 def test_sync_single_peer_happy_path_replication(two_app_setup) -> None:
-    """CaseActor commit should replicate one CaseLedgerEntry to a peer replica."""
+    """as_CaseActor commit should replicate one as_CaseLedgerEntry to a peer replica."""
     case_actor_iso, peer_iso, case_actor_tc, peer_tc = two_app_setup
 
     case_actor_base_api = f"{case_actor_iso.base_url}/api/v2"
@@ -135,22 +137,22 @@ def test_sync_single_peer_happy_path_replication(two_app_setup) -> None:
     peer_actor_id = _create_actor(
         peer_tc, peer_base_api, "peer-sync-901", "Organization"
     )
-    # CaseActor must know peer recipient for outbox routing.
+    # as_CaseActor must know peer recipient for outbox routing.
     _create_actor(
         case_actor_tc, peer_base_api, "peer-sync-901", "Organization"
     )
 
-    case = VulnerabilityCase(name="SYNC-901 integration case")
+    case = as_VulnerabilityCase(name="SYNC-901 integration case")
     case.genesis_hash = compute_genesis_hash(
         case_id=case.id_,
         created_at=datetime.now(timezone.utc),
         case_actor_id=case_actor_id,
     )
-    case_actor_participant = CaseParticipant(
+    case_actor_participant = as_CaseParticipant(
         attributed_to=case_actor_id,
         context=case.id_,
     )
-    peer_participant = CaseParticipant(
+    peer_participant = as_CaseParticipant(
         attributed_to=peer_actor_id,
         context=case.id_,
     )
@@ -178,7 +180,7 @@ def test_sync_single_peer_happy_path_replication(two_app_setup) -> None:
     peer_entry = peer_iso.dl.read(entry_id)
     assert (
         peer_entry is not None
-    ), "Expected peer replica to contain the announced CaseLedgerEntry."
+    ), "Expected peer replica to contain the announced as_CaseLedgerEntry."
     assert peer_entry.case_id == case.id_
     assert peer_entry.log_index == payload["log_index"]
     assert peer_entry.entry_hash == payload["entry_hash"]
@@ -214,12 +216,14 @@ def test_sync_predecessor_mismatch_reject_and_replay(two_app_setup) -> None:
         peer_tc, case_actor_base_api, "case-actor-sync-902", "Service"
     )
 
-    case = VulnerabilityCase(name="SYNC-902 mismatch/replay integration case")
-    case_actor_participant = CaseParticipant(
+    case = as_VulnerabilityCase(
+        name="SYNC-902 mismatch/replay integration case"
+    )
+    case_actor_participant = as_CaseParticipant(
         attributed_to=case_actor_id,
         context=case.id_,
     )
-    peer_participant = CaseParticipant(
+    peer_participant = as_CaseParticipant(
         attributed_to=peer_actor_id,
         context=case.id_,
     )
@@ -230,7 +234,7 @@ def test_sync_predecessor_mismatch_reject_and_replay(two_app_setup) -> None:
     case_actor_iso.dl.save(case_actor_participant)
     case_actor_iso.dl.save(peer_participant)
     case_actor_iso.dl.save(case)
-    case_actor_iso.dl.save(CaseActor(id_=case_actor_id, context=case.id_))
+    case_actor_iso.dl.save(as_CaseActor(id_=case_actor_id, context=case.id_))
 
     entry0 = _make_log_entry(case.id_, 0, case.genesis_hash, "sync_902_base")
     entry1 = _make_log_entry(case.id_, 1, entry0.entry_hash, "sync_902_mid")
@@ -263,7 +267,7 @@ def test_sync_predecessor_mismatch_reject_and_replay(two_app_setup) -> None:
         ]
         assert (
             peer_reject_events
-        ), "Expected peer to emit Reject(CaseLedgerEntry)."
+        ), "Expected peer to emit Reject(as_CaseLedgerEntry)."
         emitted_reject_event = peer_reject_events[-1]
         assert emitted_reject_event.actor_id == peer_actor_id
         assert emitted_reject_event.last_accepted_hash == entry0.entry_hash
@@ -323,9 +327,9 @@ def test_sync_predecessor_mismatch_reject_and_replay(two_app_setup) -> None:
 def test_sync_duplicate_delivery_idempotency(
     two_app_setup, monkeypatch
 ) -> None:
-    """Duplicate delivery of Announce(CaseLedgerEntry) must produce one replica.
+    """Duplicate delivery of Announce(as_CaseLedgerEntry) must produce one replica.
 
-    Delivers the same ``Announce(CaseLedgerEntry)`` twice to the peer actor
+    Delivers the same ``Announce(as_CaseLedgerEntry)`` twice to the peer actor
     and verifies the peer replica contains exactly one copy of the entry
     (SYNC-03-003: replication MUST be idempotent; repeated delivery MUST NOT
     produce duplicate entries).
@@ -342,7 +346,7 @@ def test_sync_duplicate_delivery_idempotency(
         peer_tc, peer_base_api, "peer-sync-903", "Organization"
     )
 
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         name="SYNC-903 duplicate delivery integration case"
     )
     case.genesis_hash = compute_genesis_hash(
@@ -350,11 +354,11 @@ def test_sync_duplicate_delivery_idempotency(
         created_at=datetime.now(timezone.utc),
         case_actor_id=case_actor_id,
     )
-    case_actor_participant = CaseParticipant(
+    case_actor_participant = as_CaseParticipant(
         attributed_to=case_actor_id,
         context=case.id_,
     )
-    peer_participant = CaseParticipant(
+    peer_participant = as_CaseParticipant(
         attributed_to=peer_actor_id,
         context=case.id_,
     )
@@ -364,7 +368,7 @@ def test_sync_duplicate_delivery_idempotency(
     case.actor_participant_index[peer_actor_id] = peer_participant.id_
 
     # Peer needs the case and participants in its DataLayer to process inbound
-    # Announce(CaseLedgerEntry) as a participant, not as a CaseActor owner.
+    # Announce(as_CaseLedgerEntry) as a participant, not as a as_CaseActor owner.
     peer_iso.dl.save(case_actor_participant)
     peer_iso.dl.save(peer_participant)
     peer_iso.dl.save(case)
@@ -389,7 +393,7 @@ def test_sync_duplicate_delivery_idempotency(
         to=[peer_actor_id],
     )
 
-    # Deliver the same Announce(CaseLedgerEntry) twice.
+    # Deliver the same Announce(as_CaseLedgerEntry) twice.
     for _ in range(2):
         handle_inbox_item(
             actor_id=peer_actor_id,
@@ -408,7 +412,7 @@ def test_sync_duplicate_delivery_idempotency(
     ]
     assert (
         len(stored_entries) == 1
-    ), f"Expected exactly 1 CaseLedgerEntry replica, got {len(stored_entries)}"
+    ), f"Expected exactly 1 as_CaseLedgerEntry replica, got {len(stored_entries)}"
     assert stored_entries[0].id_ == entry.id_
 
     # AC-4 guard: each actor app must use its own isolated DataLayer.

--- a/test/demo/test_three_actor_demo.py
+++ b/test/demo/test_three_actor_demo.py
@@ -144,7 +144,7 @@ class TestRunThreeActorDemo:
 
         case_records = case_actor_client.get("/datalayer/VulnerabilityCases/")
         final_cases = [
-            demo.VulnerabilityCase(**case_data)
+            demo.as_VulnerabilityCase(**case_data)
             for case_data in case_records.values()
         ]
         matching_cases = [

--- a/test/demo/test_two_actor_demo.py
+++ b/test/demo/test_two_actor_demo.py
@@ -35,7 +35,9 @@ import vultron.demo.scenario.two_actor_demo as demo
 from test.demo._helpers import make_client, make_testclient_call
 from vultron.adapters.utils import strip_id_prefix
 from vultron.demo.cli import main
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -283,7 +285,7 @@ class TestVendorValidatesReport:
         case = demo.find_case_for_offer(vendor_client, offer.id_)
         assert (
             case is not None
-        ), "Expected VulnerabilityCase to exist after validate-report"
+        ), "Expected as_VulnerabilityCase to exist after validate-report"
         assert case.id_ is not None
 
 
@@ -327,7 +329,7 @@ class TestFinderAsksQuestion:
         )
 
         case_data = vendor_client.get(f"/datalayer/{case.id_}")
-        case = VulnerabilityCase(**case_data)
+        case = as_VulnerabilityCase(**case_data)
         return finder_client, vendor_client, case, finder, vendor
 
     def test_question_note_stored_in_vendor(
@@ -852,7 +854,7 @@ class TestWaitForAllParticipantsRmClosed:
             client=finder_client, actor=finder, case_id=case.id_
         )
         case_data = vendor_client.get(f"/datalayer/{case.id_}")
-        refreshed_case = VulnerabilityCase.model_validate(case_data)
+        refreshed_case = as_VulnerabilityCase.model_validate(case_data)
         result = demo._all_fetchable_participants_rm_closed(
             vendor_client, refreshed_case
         )
@@ -875,7 +877,7 @@ class TestWaitForAllParticipantsRmClosed:
             _setup_case_with_3_participants(base)
         )
         case_data = vendor_client.get(f"/datalayer/{case.id_}")
-        fetched_case = VulnerabilityCase.model_validate(case_data)
+        fetched_case = as_VulnerabilityCase.model_validate(case_data)
         url_based_ids = [
             p_id
             for p_id in fetched_case.actor_participant_index.values()
@@ -993,7 +995,7 @@ class TestDumpCaseLogs:
         finder_client.get_list.return_value = [{"logIndex": 0}]
         vendor_client.get_list.return_value = [{"logIndex": 0}]
 
-        case = demo.VulnerabilityCase(
+        case = demo.as_VulnerabilityCase(
             id_="https://example.org/cases/case-dump-fallback",
             actor_participant_index={
                 "https://example.org/actors/vendor": (
@@ -1062,7 +1064,7 @@ class TestDumpCaseLogs:
         vendor_client.get_list.return_value = [{"logIndex": 0}]
         case_actor_client.get_list.return_value = [{"logIndex": 0}]
 
-        case = demo.VulnerabilityCase(
+        case = demo.as_VulnerabilityCase(
             id_="https://example.org/cases/case-dump-dedicated"
         )
         finder = demo.as_Actor(
@@ -1096,7 +1098,7 @@ class TestDumpCaseLogs:
         vendor_client.get_list.return_value = [{"logIndex": 0}]
         case_actor_client.get_list.return_value = []
 
-        case = demo.VulnerabilityCase(
+        case = demo.as_VulnerabilityCase(
             id_="https://example.org/cases/case-dump-empty-dedicated",
             actor_participant_index={
                 "https://example.org/actors/case-actor-fallback": (
@@ -1251,7 +1253,7 @@ class TestDeliveryIsolation:
         )
         assert resp.status_code in (200, 201)
 
-        # Finder's DataLayer should have no VulnerabilityCase records.
+        # Finder's DataLayer should have no as_VulnerabilityCase records.
         cases = finder_isolated.dl.get_all("VulnerabilityCase")
         assert cases == [], (
             f"Expected no cases in Finder's isolated DataLayer before"
@@ -1366,7 +1368,7 @@ class TestDeliveryIsolation:
         assert offer.id_ is not None
 
         # Vendor validates the report — this triggers BT nodes that create a
-        # VulnerabilityCase and add participants (including Finder).
+        # as_VulnerabilityCase and add participants (including Finder).
         vendor_actor_fresh = demo.get_actor_by_id(vendor_dc, vendor_id)
         demo.vendor_validates_report(
             vendor_client=vendor_dc,
@@ -1374,18 +1376,18 @@ class TestDeliveryIsolation:
             offer_id=offer.id_,
         )
 
-        # A VulnerabilityCase must now exist in Vendor's DataLayer.
+        # A as_VulnerabilityCase must now exist in Vendor's DataLayer.
         case = demo.find_case_for_offer(vendor_dc, offer.id_)
         assert (
             case is not None
-        ), "Expected VulnerabilityCase on Vendor after validate-report"
+        ), "Expected as_VulnerabilityCase on Vendor after validate-report"
 
         # The case announcement should have been delivered to Finder's inbox
         # via the outbox→_TestASGIRouter→inbox chain.  Finder's isolated
         # DataLayer must contain the case.
         finder_case = finder_isolated.dl.read(case.id_)
         assert finder_case is not None, (
-            f"Expected VulnerabilityCase '{case.id_}' to be delivered to"
+            f"Expected as_VulnerabilityCase '{case.id_}' to be delivered to"
             f" Finder's isolated DataLayer via the outbox→inbox path,"
             f" but Finder's DataLayer has no record of it.  This indicates"
             f" the delivery path is broken or the DataLayers are incorrectly"
@@ -1435,7 +1437,7 @@ def _participant_id_and_rm(
 
 def _fetch_case_log(
     client: demo.DataLayerClient,
-    case: demo.VulnerabilityCase,
+    case: demo.as_VulnerabilityCase,
 ) -> list[dict]:
     """Return case ledger entries from the demo DataLayer API endpoint.
 
@@ -1472,7 +1474,7 @@ def _fetch_case_log(
 @pytest.fixture(scope="class")
 def completed_workflow(
     client: TestClient, base: str
-) -> tuple[demo.DataLayerClient, demo.VulnerabilityCase]:
+) -> tuple[demo.DataLayerClient, demo.as_VulnerabilityCase]:
     """Run the full two-actor workflow and return (vendor_client, case).
 
     Uses deterministic actor IDs (``finder-ledger-inv`` /
@@ -1505,7 +1507,7 @@ def completed_workflow(
     )
 
     case = demo.find_case_for_offer(vendor_client, offer.id_)
-    assert case is not None, "Expected VulnerabilityCase after validation"
+    assert case is not None, "Expected as_VulnerabilityCase after validation"
 
     demo.wait_for_case_participants(
         vendor_client=vendor_client,
@@ -1514,7 +1516,7 @@ def completed_workflow(
     )
     # Refresh case to get actor_participant_index populated.
     case_data = vendor_client.get(f"/datalayer/{case.id_}")
-    case = VulnerabilityCase(**case_data)
+    case = as_VulnerabilityCase(**case_data)
 
     # Fix lifecycle.
     demo.actor_notifies_fix_ready(
@@ -1538,7 +1540,7 @@ def completed_workflow(
 
     # Final refresh to pick up any post-closure case-actor state.
     case_data = vendor_client.get(f"/datalayer/{case.id_}")
-    case = VulnerabilityCase(**case_data)
+    case = as_VulnerabilityCase(**case_data)
 
     return vendor_client, case
 
@@ -1572,7 +1574,7 @@ class TestCaseLedgerInvariants:
     def test_add_participant_status_entries_present(
         self,
         completed_workflow: tuple[
-            demo.DataLayerClient, demo.VulnerabilityCase
+            demo.DataLayerClient, demo.as_VulnerabilityCase
         ],
     ) -> None:
         """Combined case log contains at least one add_participant_status entry.
@@ -1601,7 +1603,7 @@ class TestCaseLedgerInvariants:
     def test_all_participants_rm_closed_at_scenario_end(
         self,
         completed_workflow: tuple[
-            demo.DataLayerClient, demo.VulnerabilityCase
+            demo.DataLayerClient, demo.as_VulnerabilityCase
         ],
     ) -> None:
         """All tracked participants end in RM=CLOSED at scenario completion.
@@ -1644,7 +1646,7 @@ class TestCaseLedgerInvariants:
     def test_required_event_types_present_in_case_actor_log(
         self,
         completed_workflow: tuple[
-            demo.DataLayerClient, demo.VulnerabilityCase
+            demo.DataLayerClient, demo.as_VulnerabilityCase
         ],
     ) -> None:
         """Combined case log contains the required baseline event types.

--- a/test/test_behavior_dispatcher.py
+++ b/test/test_behavior_dispatcher.py
@@ -20,9 +20,9 @@ from vultron.errors import VultronValidationError
 from vultron.wire.as2.factories import (
     em_propose_embargo_activity,
 )
-from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
-    VulnerabilityCase,
+    as_VulnerabilityCase,
     VulnerabilityCaseStub,
 )
 
@@ -77,7 +77,7 @@ def test_dispatcher_blocks_gated_semantic_without_contiguous_genesis_prefix():
     )
 
     actor_id = "https://example.org/users/late-joiner"
-    case = VulnerabilityCase(id_="https://example.org/cases/case-gate")
+    case = as_VulnerabilityCase(id_="https://example.org/cases/case-gate")
     event = AddNoteToCaseReceivedEvent(
         activity_id="act-gate-1",
         actor_id=actor_id,
@@ -118,7 +118,7 @@ def test_dispatcher_allows_gated_semantic_with_contiguous_prefix_but_tip_lag():
     )
 
     actor_id = "https://example.org/users/late-joiner"
-    case = VulnerabilityCase(id_="https://example.org/cases/case-gate-ok")
+    case = as_VulnerabilityCase(id_="https://example.org/cases/case-gate-ok")
     event = AddNoteToCaseReceivedEvent(
         activity_id="act-gate-2",
         actor_id=actor_id,
@@ -153,7 +153,9 @@ def test_dispatcher_allows_gated_semantic_without_replication_state():
     )
 
     actor_id = "https://example.org/users/case-owner"
-    case = VulnerabilityCase(id_="https://example.org/cases/case-gate-owner")
+    case = as_VulnerabilityCase(
+        id_="https://example.org/cases/case-gate-owner"
+    )
     event = AddNoteToCaseReceivedEvent(
         activity_id="act-gate-owner",
         actor_id=actor_id,
@@ -179,7 +181,7 @@ def test_dispatcher_blocks_when_case_ledger_prefix_has_gaps():
     )
 
     actor_id = "https://example.org/users/late-joiner-gap"
-    case = VulnerabilityCase(id_="https://example.org/cases/case-gate-gap")
+    case = as_VulnerabilityCase(id_="https://example.org/cases/case-gate-gap")
     event = AddNoteToCaseReceivedEvent(
         activity_id="act-gate-gap",
         actor_id=actor_id,
@@ -268,7 +270,7 @@ def test_dispatcher_resolves_case_for_reject_embargo_invite_gate():
     actor_id = "https://example.org/users/late-joiner"
     case_id = "https://example.org/cases/case-gate-embargo"
     invite = em_propose_embargo_activity(
-        embargo=EmbargoEvent(
+        embargo=as_EmbargoEvent(
             id_=f"{case_id}/embargo_events/e1", content="Embargo proposal"
         ),
         context=case_id,

--- a/test/test_semantic_activity_patterns.py
+++ b/test/test_semantic_activity_patterns.py
@@ -28,9 +28,9 @@ from vultron.wire.as2.vocab.base.objects.actors import (
     as_Person,
     as_Service,
 )
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
-    VulnerabilityCase,
+    as_VulnerabilityCase,
     VulnerabilityCaseStub,
 )
 
@@ -209,7 +209,7 @@ def test_non_overlapping_activity_patterns():
 
 
 def test_offer_case_ownership_transfer_rejects_string_object():
-    """OfferCaseOwnershipTransferActivity must have an inline VulnerabilityCase,
+    """OfferCaseOwnershipTransferActivity must have an inline as_VulnerabilityCase,
     not a bare string URI as object_.
 
     Sending a string URI causes pattern-matching ambiguity: both
@@ -226,9 +226,9 @@ def test_offer_case_ownership_transfer_rejects_string_object():
 
 
 def test_offer_case_ownership_transfer_with_inline_case_dispatches_correctly():
-    """An OfferCaseOwnershipTransferActivity with a full inline VulnerabilityCase
+    """An OfferCaseOwnershipTransferActivity with a full inline as_VulnerabilityCase
     must be classified as OFFER_CASE_OWNERSHIP_TRANSFER, not SUBMIT_REPORT."""
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         id_="https://example.org/cases/urn:uuid:test-case",
         name="TEST-001",
     )
@@ -375,12 +375,12 @@ def test_invite_actor_to_case_without_actor_object_does_not_match():
 
 
 def test_announce_vulnerability_case_pattern_matches():
-    """AnnounceVulnerabilityCasePattern must match Announce(VulnerabilityCase).
+    """AnnounceVulnerabilityCasePattern must match Announce(as_VulnerabilityCase).
 
     DR-10: the pattern must be registered so incoming AnnounceVulnerabilityCase
     activities are routed to AnnounceVulnerabilityCaseReceivedUseCase.
     """
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         id_="https://example.org/cases/case-pattern-001", name="Pattern Test"
     )
     announce = announce_vulnerability_case_activity(
@@ -418,15 +418,15 @@ def test_vulnerability_case_stub_with_summary():
 
 
 def test_rm_invite_projects_full_vulnerability_case_to_stub():
-    """rm_invite_to_case_activity projects a full VulnerabilityCase to a stub.
+    """rm_invite_to_case_activity projects a full as_VulnerabilityCase to a stub.
 
-    DR-10 / MV-10-001: the factory accepts a full VulnerabilityCase as target
+    DR-10 / MV-10-001: the factory accepts a full as_VulnerabilityCase as target
     for projection (CM-17-002 enrichment path) but the resulting wire activity's
     target is always a VulnerabilityCaseStub — full case details never reach
     uninvited parties on the wire.
     """
     actor = as_Actor(id_="https://example.org/actors/alice")
-    full_case = VulnerabilityCase(
+    full_case = as_VulnerabilityCase(
         id_="https://example.org/cases/c1", name="Full"
     )
     activity = rm_invite_to_case_activity(
@@ -436,7 +436,7 @@ def test_rm_invite_projects_full_vulnerability_case_to_stub():
     )
     assert isinstance(
         activity.target, VulnerabilityCaseStub
-    ), "DR-10: wire activity target must be VulnerabilityCaseStub, not full VulnerabilityCase"
+    ), "DR-10: wire activity target must be VulnerabilityCaseStub, not full as_VulnerabilityCase"
     assert activity.target.id_ == full_case.id_
 
 
@@ -452,12 +452,12 @@ _PARTICIPANT_URI = (
 )
 
 
-def _make_case_manager_case() -> VulnerabilityCase:
-    return VulnerabilityCase(id_=_CASE_URI, name="CASE-001")
+def _make_case_manager_case() -> as_VulnerabilityCase:
+    return as_VulnerabilityCase(id_=_CASE_URI, name="CASE-001")
 
 
-def _make_case_actor_participant() -> CaseParticipant:
-    return CaseParticipant(
+def _make_case_actor_participant() -> as_CaseParticipant:
+    return as_CaseParticipant(
         id_=_PARTICIPANT_URI,
         attributed_to=_CASE_ACTOR_URI,
         context=_CASE_URI,
@@ -465,7 +465,7 @@ def _make_case_actor_participant() -> CaseParticipant:
 
 
 def test_offer_case_manager_role_dispatches_correctly():
-    """Offer(VulnerabilityCase, target=CaseParticipant) must be classified as
+    """Offer(as_VulnerabilityCase, target=as_CaseParticipant) must be classified as
     OFFER_CASE_MANAGER_ROLE, not OFFER_CASE_OWNERSHIP_TRANSFER.
 
     DEMOMA-08-002: CASE_MANAGER delegation is a distinct protocol from
@@ -485,10 +485,10 @@ def test_offer_case_manager_role_dispatches_correctly():
 
 
 def test_offer_case_manager_role_not_confused_with_ownership_transfer():
-    """Offer(VulnerabilityCase) without a CaseParticipant target must be
+    """Offer(as_VulnerabilityCase) without a as_CaseParticipant target must be
     classified as OFFER_CASE_OWNERSHIP_TRANSFER, not OFFER_CASE_MANAGER_ROLE.
 
-    The presence of a typed CaseParticipant target is the sole discriminator.
+    The presence of a typed as_CaseParticipant target is the sole discriminator.
     """
     case = _make_case_manager_case()
     offer = offer_case_ownership_transfer_activity(
@@ -502,7 +502,7 @@ def test_offer_case_manager_role_not_confused_with_ownership_transfer():
 
 
 def test_accept_case_manager_role_dispatches_correctly():
-    """Accept(Offer(VulnerabilityCase, target=CaseParticipant)) must be
+    """Accept(Offer(as_VulnerabilityCase, target=as_CaseParticipant)) must be
     classified as ACCEPT_CASE_MANAGER_ROLE."""
     case = _make_case_manager_case()
     participant = _make_case_actor_participant()
@@ -519,7 +519,7 @@ def test_accept_case_manager_role_dispatches_correctly():
 
 
 def test_reject_case_manager_role_dispatches_correctly():
-    """Reject(Offer(VulnerabilityCase, target=CaseParticipant)) must be
+    """Reject(Offer(as_VulnerabilityCase, target=as_CaseParticipant)) must be
     classified as REJECT_CASE_MANAGER_ROLE."""
     case = _make_case_manager_case()
     participant = _make_case_actor_participant()
@@ -538,7 +538,7 @@ def test_reject_case_manager_role_dispatches_correctly():
 def test_offer_case_manager_role_rejects_string_case():
     """offer_case_manager_role_activity must reject a bare string URI as case.
 
-    An inline VulnerabilityCase object is required so the recipient can
+    An inline as_VulnerabilityCase object is required so the recipient can
     distinguish this activity from other Offer types during pattern matching.
     """
     participant = _make_case_actor_participant()
@@ -568,7 +568,7 @@ def test_offer_case_manager_role_rejects_none_target():
 def test_offer_case_manager_role_rejects_string_target():
     """offer_case_manager_role_activity must reject a bare string IRI as target.
 
-    A string target is not a typed CaseParticipant and will not match the
+    A string target is not a typed as_CaseParticipant and will not match the
     CASE_PARTICIPANT constraint in the ActivityPattern, causing the activity
     to be misclassified as OFFER_CASE_OWNERSHIP_TRANSFER.
     """

--- a/test/wire/as2/factories/test_case_factories.py
+++ b/test/wire/as2/factories/test_case_factories.py
@@ -59,10 +59,12 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
 )
 from vultron.wire.as2.vocab.base.objects.actors import as_Person
 from vultron.wire.as2.vocab.base.objects.object_types import as_Note
-from vultron.wire.as2.vocab.objects.case_status import CaseStatus
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_status import as_CaseStatus
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 _ACTOR_URI = "https://example.org/actors/alice"
@@ -70,18 +72,18 @@ _CASE_URI = "https://example.org/cases/case-001"
 
 
 @pytest.fixture
-def sample_case() -> VulnerabilityCase:
-    return VulnerabilityCase(name="Test Case")
+def sample_case() -> as_VulnerabilityCase:
+    return as_VulnerabilityCase(name="Test Case")
 
 
 @pytest.fixture
-def sample_report() -> VulnerabilityReport:
-    return VulnerabilityReport(name="Test Report")
+def sample_report() -> as_VulnerabilityReport:
+    return as_VulnerabilityReport(name="Test Report")
 
 
 @pytest.fixture
-def sample_status() -> CaseStatus:
-    return CaseStatus()
+def sample_status() -> as_CaseStatus:
+    return as_CaseStatus()
 
 
 @pytest.fixture

--- a/test/wire/as2/factories/test_case_participant_factories.py
+++ b/test/wire/as2/factories/test_case_participant_factories.py
@@ -38,8 +38,8 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Create,
     as_Remove,
 )
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.case_status import ParticipantStatus
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.case_status import as_ParticipantStatus
 
 _ACTOR_URI = "https://example.org/actors/alice"
 _CASE_URI = "https://example.org/cases/case-001"
@@ -47,13 +47,13 @@ _PARTICIPANT_URI = "https://example.org/participants/part-001"
 
 
 @pytest.fixture
-def sample_participant() -> CaseParticipant:
-    return CaseParticipant(attributed_to=_ACTOR_URI)
+def sample_participant() -> as_CaseParticipant:
+    return as_CaseParticipant(attributed_to=_ACTOR_URI)
 
 
 @pytest.fixture
-def sample_participant_status() -> ParticipantStatus:
-    return ParticipantStatus(context=_CASE_URI)
+def sample_participant_status() -> as_ParticipantStatus:
+    return as_ParticipantStatus(context=_CASE_URI)
 
 
 # ---------------------------------------------------------------------------

--- a/test/wire/as2/factories/test_embargo_factories.py
+++ b/test/wire/as2/factories/test_embargo_factories.py
@@ -47,15 +47,15 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Reject,
     as_Remove,
 )
-from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
 
 _ACTOR_URI = "https://example.org/actors/alice"
 _CASE_URI = "https://example.org/cases/case-001"
 
 
 @pytest.fixture
-def sample_embargo() -> EmbargoEvent:
-    return EmbargoEvent()
+def sample_embargo() -> as_EmbargoEvent:
+    return as_EmbargoEvent()
 
 
 @pytest.fixture

--- a/test/wire/as2/factories/test_report_factories.py
+++ b/test/wire/as2/factories/test_report_factories.py
@@ -46,7 +46,7 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
 from vultron.wire.as2.vocab.base.objects.object_types import as_Note
 from vultron.wire.as2.vocab.base.objects.actors import as_Person
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 _ACTOR_URI = "https://example.org/actors/alice"
@@ -58,8 +58,8 @@ _RECIPIENT_URI = "https://example.org/actors/vendor"
 
 
 @pytest.fixture
-def sample_report() -> VulnerabilityReport:
-    return VulnerabilityReport(name="Test CVE report")
+def sample_report() -> as_VulnerabilityReport:
+    return as_VulnerabilityReport(name="Test CVE report")
 
 
 @pytest.fixture
@@ -234,7 +234,7 @@ def test_rm_validate_report_kwargs_actor_forwarded(sample_offer, sample_actor):
 def test_rm_validate_report_plain_offer_with_report_succeeds(
     sample_report, sample_actor
 ):
-    """A plain as_Offer carrying a VulnerabilityReport is coerced and accepted."""
+    """A plain as_Offer carrying a as_VulnerabilityReport is coerced and accepted."""
     plain_offer = as_Offer(actor=None, object_=sample_report)
     result = rm_validate_report_activity(offer=plain_offer, actor=sample_actor)
     assert isinstance(result, as_Accept)
@@ -242,7 +242,7 @@ def test_rm_validate_report_plain_offer_with_report_succeeds(
 
 @pytest.mark.spec("AF-04-001")
 def test_rm_validate_report_malformed_offer_raises(sample_actor):
-    """An offer whose object_ is not a VulnerabilityReport must still fail."""
+    """An offer whose object_ is not a as_VulnerabilityReport must still fail."""
     malformed_offer = as_Offer(
         actor=None, object_=as_Note(name="not a report")
     )
@@ -287,7 +287,7 @@ def test_rm_invalidate_report_kwargs_actor_forwarded(
 def test_rm_invalidate_report_plain_offer_with_report_succeeds(
     sample_report, sample_actor
 ):
-    """A plain as_Offer carrying a VulnerabilityReport is coerced and accepted."""
+    """A plain as_Offer carrying a as_VulnerabilityReport is coerced and accepted."""
     plain_offer = as_Offer(actor=None, object_=sample_report)
     result = rm_invalidate_report_activity(
         offer=plain_offer, actor=sample_actor
@@ -297,7 +297,7 @@ def test_rm_invalidate_report_plain_offer_with_report_succeeds(
 
 @pytest.mark.spec("AF-04-001")
 def test_rm_invalidate_report_malformed_offer_raises(sample_actor):
-    """An offer whose object_ is not a VulnerabilityReport must still fail."""
+    """An offer whose object_ is not a as_VulnerabilityReport must still fail."""
     malformed_offer = as_Offer(
         actor=None, object_=as_Note(name="not a report")
     )
@@ -334,7 +334,7 @@ def test_rm_close_report_kwargs_actor_forwarded(sample_offer, sample_actor):
 def test_rm_close_report_plain_offer_with_report_succeeds(
     sample_report, sample_actor
 ):
-    """A plain as_Offer carrying a VulnerabilityReport is coerced and accepted."""
+    """A plain as_Offer carrying a as_VulnerabilityReport is coerced and accepted."""
     plain_offer = as_Offer(actor=None, object_=sample_report)
     result = rm_close_report_activity(offer=plain_offer, actor=sample_actor)
     assert isinstance(result, as_Reject)
@@ -342,7 +342,7 @@ def test_rm_close_report_plain_offer_with_report_succeeds(
 
 @pytest.mark.spec("AF-04-001")
 def test_rm_close_report_malformed_offer_raises(sample_actor):
-    """An offer whose object_ is not a VulnerabilityReport must still fail."""
+    """An offer whose object_ is not a as_VulnerabilityReport must still fail."""
     malformed_offer = as_Offer(
         actor=None, object_=as_Note(name="not a report")
     )
@@ -364,7 +364,7 @@ def test_parse_submit_report_offer_from_dict(sample_report, sample_actor):
     )
     offer_dict = offer.model_dump(by_alias=True)
     report_out, offer_out = parse_submit_report_offer(offer_dict)
-    assert isinstance(report_out, VulnerabilityReport)
+    assert isinstance(report_out, as_VulnerabilityReport)
     assert report_out.id_ == sample_report.id_
 
 
@@ -375,7 +375,7 @@ def test_parse_submit_report_offer_from_plain_offer(
     """parse_submit_report_offer coerces a plain as_Offer correctly."""
     plain_offer = as_Offer(actor=None, object_=sample_report)
     report_out, offer_out = parse_submit_report_offer(plain_offer)
-    assert isinstance(report_out, VulnerabilityReport)
+    assert isinstance(report_out, as_VulnerabilityReport)
     assert report_out.id_ == sample_report.id_
 
 

--- a/test/wire/as2/factories/test_sync_factories.py
+++ b/test/wire/as2/factories/test_sync_factories.py
@@ -34,15 +34,15 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Announce,
     as_Reject,
 )
-from vultron.wire.as2.vocab.objects.case_ledger_entry import CaseLedgerEntry
+from vultron.wire.as2.vocab.objects.case_ledger_entry import as_CaseLedgerEntry
 
 _ACTOR_URI = "https://example.org/actors/alice"
 _LAST_HASH = "abc123def456"
 
 
 @pytest.fixture
-def sample_log_entry() -> CaseLedgerEntry:
-    return CaseLedgerEntry(
+def sample_log_entry() -> as_CaseLedgerEntry:
+    return as_CaseLedgerEntry(
         case_id="https://example.org/cases/case-001",
         log_object_id="https://example.org/activities/act-001",
         event_type="ReportCreated",

--- a/test/wire/as2/test_extractor.py
+++ b/test/wire/as2/test_extractor.py
@@ -36,10 +36,10 @@ def test_find_matching_semantics_returns_correct_semantics_for_create_report():
         as_Create,
     )
     from vultron.wire.as2.vocab.objects.vulnerability_report import (
-        VulnerabilityReport,
+        as_VulnerabilityReport,
     )
 
-    report = VulnerabilityReport(name="VR-001", content="test report")
+    report = as_VulnerabilityReport(name="VR-001", content="test report")
     activity = as_Create(
         actor="https://example.org/finder",
         object_=report,
@@ -87,11 +87,11 @@ def test_extract_intent_report_pass_through_fields():
         as_Create,
     )
     from vultron.wire.as2.vocab.objects.vulnerability_report import (
-        VulnerabilityReport,
+        as_VulnerabilityReport,
     )
 
     now = datetime.now(timezone.utc)
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         name="VR-001",
         summary="Brief summary",
         content="Full content",
@@ -120,11 +120,11 @@ def test_extract_intent_case_pass_through_fields():
         as_Create,
     )
     from vultron.wire.as2.vocab.objects.vulnerability_case import (
-        VulnerabilityCase,
+        as_VulnerabilityCase,
     )
 
     now = datetime.now(timezone.utc)
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         name="CASE-001",
         summary="Case summary",
         published=now,
@@ -144,10 +144,10 @@ def test_extract_intent_embargo_pass_through_fields():
     from vultron.wire.as2.vocab.base.objects.activities.transitive import (
         as_Create,
     )
-    from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+    from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
 
     now = datetime.now(timezone.utc)
-    embargo = EmbargoEvent(
+    embargo = as_EmbargoEvent(
         context="https://example.org/cases/1",
         published=now,
         updated=now,
@@ -196,10 +196,10 @@ def test_extract_intent_activity_origin_field():
         as_Create,
     )
     from vultron.wire.as2.vocab.objects.vulnerability_report import (
-        VulnerabilityReport,
+        as_VulnerabilityReport,
     )
 
-    report = VulnerabilityReport(name="VR-001", content="test")
+    report = as_VulnerabilityReport(name="VR-001", content="test")
     activity = as_Create(
         actor="https://example.org/alice",
         object_=report,
@@ -212,16 +212,16 @@ def test_extract_intent_activity_origin_field():
 
 
 def test_extract_intent_participant_case_roles():
-    """VultronParticipant.case_roles is populated from the wire CaseParticipant."""
+    """VultronParticipant.case_roles is populated from the wire as_CaseParticipant."""
     from vultron.wire.as2.vocab.base.objects.activities.transitive import (
         as_Create,
     )
     from vultron.wire.as2.vocab.objects.case_participant import (
-        CaseParticipant,
+        as_CaseParticipant,
     )
     from vultron.enums.roles import CVDRole
 
-    participant = CaseParticipant(
+    participant = as_CaseParticipant(
         attributed_to="https://example.org/alice",
         context="https://example.org/cases/1",
     )
@@ -240,13 +240,13 @@ def test_extract_intent_participant_case_roles():
 
 
 def test_extract_intent_case_status_name():
-    """CaseStatus.name is populated from the wire CaseStatus."""
+    """as_CaseStatus.name is populated from the wire as_CaseStatus."""
     from vultron.wire.as2.vocab.base.objects.activities.transitive import (
         as_Create,
     )
-    from vultron.wire.as2.vocab.objects.case_status import CaseStatus
+    from vultron.wire.as2.vocab.objects.case_status import as_CaseStatus
 
-    cs = CaseStatus(context="https://example.org/cases/1")
+    cs = as_CaseStatus(context="https://example.org/cases/1")
     # CreateCaseStatusActivity pattern: Create + CASE_STATUS + context=VULNERABILITY_CASE
     activity = as_Create(
         actor="https://example.org/alice",
@@ -261,14 +261,14 @@ def test_extract_intent_case_status_name():
 
 
 def test_extract_intent_participant_status_vfd_state():
-    """ParticipantStatus.vfd_state is populated from the wire ParticipantStatus."""
+    """as_ParticipantStatus.vfd_state is populated from the wire as_ParticipantStatus."""
     from vultron.wire.as2.vocab.base.objects.activities.transitive import (
         as_Create,
     )
-    from vultron.wire.as2.vocab.objects.case_status import ParticipantStatus
+    from vultron.wire.as2.vocab.objects.case_status import as_ParticipantStatus
     from vultron.core.states.cs import CS_vfd
 
-    ps = ParticipantStatus(
+    ps = as_ParticipantStatus(
         context="https://example.org/cases/1",
         vfd_state=CS_vfd.Vfd,
     )

--- a/test/wire/as2/vocab/base/test_registry.py
+++ b/test/wire/as2/vocab/base/test_registry.py
@@ -161,7 +161,7 @@ class TestDynamicDiscovery:
             ), f"Expected AS2 type '{type_name}' in vocabulary"
 
     def test_vocab_bug_26040902_regression(self):
-        """VulnerabilityReport and VulnerabilityCase are in the vocab.
+        """as_VulnerabilityReport and VulnerabilityCase are in the vocab.
 
         Regression test for BUG-26040902: empty vocab registry caused
         ReceiveReportCaseBT to silently fail in Docker (where no test
@@ -171,22 +171,22 @@ class TestDynamicDiscovery:
         dynamic module discovery which registers all types automatically.
         """
         # This import triggers dynamic discovery — no explicit VulnerabilityCase
-        # or VulnerabilityReport import is needed.
+        # or as_VulnerabilityReport import is needed.
         import vultron.wire.as2.vocab  # noqa: F401
 
         assert (
             "VulnerabilityReport" in VOCABULARY
-        ), "BUG-26040902: VulnerabilityReport missing from vocabulary"
+        ), "BUG-26040902: as_VulnerabilityReport missing from vocabulary"
         assert (
             "VulnerabilityCase" in VOCABULARY
         ), "BUG-26040902: VulnerabilityCase missing from vocabulary"
         # Verify the classes are actually correct
         from vultron.wire.as2.vocab.objects.vulnerability_report import (
-            VulnerabilityReport,
+            as_VulnerabilityReport,
         )
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
-        assert VOCABULARY["VulnerabilityReport"] is VulnerabilityReport
-        assert VOCABULARY["VulnerabilityCase"] is VulnerabilityCase
+        assert VOCABULARY["VulnerabilityReport"] is as_VulnerabilityReport
+        assert VOCABULARY["VulnerabilityCase"] is as_VulnerabilityCase

--- a/test/wire/as2/vocab/test_actvitities/test_activities.py
+++ b/test/wire/as2/vocab/test_actvitities/test_activities.py
@@ -18,7 +18,7 @@ from vultron.enums.roles import CVDRole
 from vultron.wire.as2.vocab.activities.case_participant import (
     _CreateParticipantActivity,
 )
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
 
 
 class MyTestCase(unittest.TestCase):
@@ -33,14 +33,14 @@ class MyTestCase(unittest.TestCase):
 
 
 class TestCreateParticipantName(unittest.TestCase):
-    """_CreateParticipantActivity activity name should clearly identify CaseParticipant creation."""
+    """_CreateParticipantActivity activity name should clearly identify as_CaseParticipant creation."""
 
     def setUp(self):
         self.actor_id = "https://vultron.example/organizations/vendorco"
         self.case_id = "https://vultron.example/cases/1"
         self.attributed_to = "https://vultron.example/users/finndervul"
 
-        self.participant = CaseParticipant(
+        self.participant = as_CaseParticipant(
             attributed_to=self.attributed_to,
             context=self.case_id,
             case_roles=[CVDRole.VENDOR],
@@ -52,7 +52,7 @@ class TestCreateParticipantName(unittest.TestCase):
         )
 
     def test_name_contains_case_participant_type(self):
-        """Name must include 'CaseParticipant' to distinguish from creating an actor."""
+        """Name must include 'as_CaseParticipant' to distinguish from creating an actor."""
         assert self.activity.name is not None
         assert "CaseParticipant" in self.activity.name
 

--- a/test/wire/as2/vocab/test_actvitities/test_actor.py
+++ b/test/wire/as2/vocab/test_actvitities/test_actor.py
@@ -28,7 +28,9 @@ from vultron.wire.as2.vocab.base.objects.actors import (
     as_Person,
     as_Service,
 )
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 ACTOR_CLASSES = [
     as_Application,
@@ -70,7 +72,7 @@ class MyTestCase(unittest.TestCase):
     ):
         for actor_class in ACTOR_CLASSES:
             _actor = actor_class(name=actor_class.__name__)
-            _case = VulnerabilityCase(name=f"{actor_class.__name__} Case")
+            _case = as_VulnerabilityCase(name=f"{actor_class.__name__} Case")
             _recommendation = actor._RecommendActorActivity(
                 actor=_actor, object_=_actor, target=_case
             )
@@ -103,7 +105,7 @@ class MyTestCase(unittest.TestCase):
     ):
         for actor_class in ACTOR_CLASSES:
             _actor = actor_class(name=actor_class.__name__)
-            _case = VulnerabilityCase(name=f"{actor_class.__name__} Case")
+            _case = as_VulnerabilityCase(name=f"{actor_class.__name__} Case")
             _object = cls(actor=_actor, object_=_actor, target=_case)
 
             # check activity is correct type

--- a/test/wire/as2/vocab/test_actvitities/test_inline_object_required.py
+++ b/test/wire/as2/vocab/test_actvitities/test_inline_object_required.py
@@ -103,30 +103,30 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
 )
 from vultron.wire.as2.vocab.base.objects.actors import as_Person
 from vultron.wire.as2.vocab.base.objects.object_types import as_Note
-from vultron.wire.as2.vocab.objects.case_ledger_entry import CaseLedgerEntry
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+from vultron.wire.as2.vocab.objects.case_ledger_entry import as_CaseLedgerEntry
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
 from vultron.wire.as2.vocab.objects.case_status import (
-    CaseStatus,
-    ParticipantStatus,
+    as_CaseStatus,
+    as_ParticipantStatus,
 )
-from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
-    VulnerabilityCase,
+    as_VulnerabilityCase,
     VulnerabilityCaseStub,
 )
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 _ACTOR = as_Person(name="Alice")
-_CASE = VulnerabilityCase(name="Test Case")
-_REPORT = VulnerabilityReport(name="CVE-TEST-001")
+_CASE = as_VulnerabilityCase(name="Test Case")
+_REPORT = as_VulnerabilityReport(name="CVE-TEST-001")
 _NOTE = as_Note(name="Test Note")
-_STATUS = CaseStatus()
-_PARTICIPANT_STATUS = ParticipantStatus(context=_CASE.id_)
-_EMBARGO = EmbargoEvent(name="Embargo Event")
-_PARTICIPANT = CaseParticipant(attributed_to=_ACTOR.id_)
-_LOG_ENTRY = CaseLedgerEntry(
+_STATUS = as_CaseStatus()
+_PARTICIPANT_STATUS = as_ParticipantStatus(context=_CASE.id_)
+_EMBARGO = as_EmbargoEvent(name="Embargo Event")
+_PARTICIPANT = as_CaseParticipant(attributed_to=_ACTOR.id_)
+_LOG_ENTRY = as_CaseLedgerEntry(
     case_id=_CASE.id_,
     log_object_id=_REPORT.id_,
     event_type="CREATE_REPORT",
@@ -137,7 +137,7 @@ _STUB = VulnerabilityCaseStub(id_=_CASE.id_)
 _INVITE = _RmInviteToCaseActivity(actor=_ACTOR, object_=_ACTOR, target=_STUB)
 _PROPOSE = _EmProposeEmbargoActivity(
     actor=_ACTOR,
-    object_=EmbargoEvent(name="Embargo Event"),
+    object_=as_EmbargoEvent(name="Embargo Event"),
     context=_CASE.id_,
 )
 _RECOMMEND = _RecommendActorActivity(
@@ -277,12 +277,12 @@ class TestInlineTypedObjectAccepted(unittest.TestCase):
 
     def test_reject_log_entry_accepts_typed(self):
         obj = _RejectLogEntryActivity(actor=_ACTOR.id_, object_=_LOG_ENTRY)
-        assert isinstance(obj.object_, CaseLedgerEntry)
+        assert isinstance(obj.object_, as_CaseLedgerEntry)
 
     def test_announce_log_entry_still_accepts_typed(self):
-        """_AnnounceLogEntryActivity should still accept a CaseLedgerEntry."""
+        """_AnnounceLogEntryActivity should still accept a as_CaseLedgerEntry."""
         obj = _AnnounceLogEntryActivity(actor=_ACTOR.id_, object_=_LOG_ENTRY)
-        assert isinstance(obj.object_, CaseLedgerEntry)
+        assert isinstance(obj.object_, as_CaseLedgerEntry)
 
 
 class TestNoneObjectRejected(unittest.TestCase):

--- a/test/wire/as2/vocab/test_actvitities/test_object_types.py
+++ b/test/wire/as2/vocab/test_actvitities/test_object_types.py
@@ -33,15 +33,17 @@ from vultron.errors import VultronOutboxObjectIntegrityError
 from vultron.wire.as2.vocab.base.links import as_Link
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.base.objects.object_types import as_Note
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
 from vultron.wire.as2.vocab.objects.case_status import (
-    CaseStatus,
-    ParticipantStatus,
+    as_CaseStatus,
+    as_ParticipantStatus,
 )
-from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 _STR_URI = "https://example.org/objects/123"
@@ -74,8 +76,8 @@ def _assert_accepts_inline(cls, obj):
     assert instance.object_ is obj or instance.object_ == obj
 
 
-def _participant_status() -> ParticipantStatus:
-    return ParticipantStatus(context="https://example.org/cases/c1")
+def _participant_status() -> as_ParticipantStatus:
+    return as_ParticipantStatus(context="https://example.org/cases/c1")
 
 
 # ---------------------------------------------------------------------------
@@ -97,7 +99,7 @@ class TestRmCreateReportActivity:
         _assert_rejects_link(self.cls)
 
     def test_accepts_inline_report(self):
-        _assert_accepts_inline(self.cls, VulnerabilityReport())
+        _assert_accepts_inline(self.cls, as_VulnerabilityReport())
 
 
 class TestRmSubmitReportActivity:
@@ -114,7 +116,7 @@ class TestRmSubmitReportActivity:
         _assert_rejects_link(self.cls)
 
     def test_accepts_inline_report(self):
-        _assert_accepts_inline(self.cls, VulnerabilityReport())
+        _assert_accepts_inline(self.cls, as_VulnerabilityReport())
 
 
 class TestRmReadReportActivity:
@@ -129,7 +131,7 @@ class TestRmReadReportActivity:
         _assert_rejects_link(self.cls)
 
     def test_accepts_inline_report(self):
-        _assert_accepts_inline(self.cls, VulnerabilityReport())
+        _assert_accepts_inline(self.cls, as_VulnerabilityReport())
 
 
 # ---------------------------------------------------------------------------
@@ -149,7 +151,7 @@ class TestAddReportToCaseActivity:
         _assert_rejects_link(self.cls)
 
     def test_accepts_inline_report(self):
-        _assert_accepts_inline(self.cls, VulnerabilityReport())
+        _assert_accepts_inline(self.cls, as_VulnerabilityReport())
 
 
 class TestAddStatusToCaseActivity:
@@ -164,7 +166,7 @@ class TestAddStatusToCaseActivity:
         _assert_rejects_link(self.cls)
 
     def test_accepts_inline_case_status(self):
-        _assert_accepts_inline(self.cls, CaseStatus())
+        _assert_accepts_inline(self.cls, as_CaseStatus())
 
 
 class TestCreateCaseActivity:
@@ -179,7 +181,7 @@ class TestCreateCaseActivity:
         _assert_rejects_link(self.cls)
 
     def test_accepts_inline_case(self):
-        _assert_accepts_inline(self.cls, VulnerabilityCase())
+        _assert_accepts_inline(self.cls, as_VulnerabilityCase())
 
 
 class TestCreateCaseStatusActivity:
@@ -196,7 +198,7 @@ class TestCreateCaseStatusActivity:
         _assert_rejects_link(self.cls)
 
     def test_accepts_inline_case_status(self):
-        _assert_accepts_inline(self.cls, CaseStatus())
+        _assert_accepts_inline(self.cls, as_CaseStatus())
 
 
 class TestAddNoteToCaseActivity:
@@ -226,7 +228,7 @@ class TestUpdateCaseActivity:
         _assert_rejects_link(self.cls)
 
     def test_accepts_inline_case(self):
-        _assert_accepts_inline(self.cls, VulnerabilityCase())
+        _assert_accepts_inline(self.cls, as_VulnerabilityCase())
 
 
 class TestRmEngageCaseActivity:
@@ -241,7 +243,7 @@ class TestRmEngageCaseActivity:
         _assert_rejects_link(self.cls)
 
     def test_accepts_inline_case(self):
-        _assert_accepts_inline(self.cls, VulnerabilityCase())
+        _assert_accepts_inline(self.cls, as_VulnerabilityCase())
 
 
 class TestRmDeferCaseActivity:
@@ -256,7 +258,7 @@ class TestRmDeferCaseActivity:
         _assert_rejects_link(self.cls)
 
     def test_accepts_inline_case(self):
-        _assert_accepts_inline(self.cls, VulnerabilityCase())
+        _assert_accepts_inline(self.cls, as_VulnerabilityCase())
 
 
 class TestRmCloseCaseActivity:
@@ -271,7 +273,7 @@ class TestRmCloseCaseActivity:
         _assert_rejects_link(self.cls)
 
     def test_accepts_inline_case(self):
-        _assert_accepts_inline(self.cls, VulnerabilityCase())
+        _assert_accepts_inline(self.cls, as_VulnerabilityCase())
 
 
 class TestRmInviteToCaseActivity:
@@ -308,7 +310,7 @@ class TestEmProposeEmbargoActivity:
         _assert_rejects_link(self.cls)
 
     def test_accepts_inline_embargo_event(self):
-        _assert_accepts_inline(self.cls, EmbargoEvent())
+        _assert_accepts_inline(self.cls, as_EmbargoEvent())
 
 
 class TestActivateEmbargoActivity:
@@ -325,7 +327,7 @@ class TestActivateEmbargoActivity:
         _assert_rejects_link(self.cls)
 
     def test_accepts_inline_embargo_event(self):
-        _assert_accepts_inline(self.cls, EmbargoEvent())
+        _assert_accepts_inline(self.cls, as_EmbargoEvent())
 
 
 class TestAddEmbargoToCaseActivity:
@@ -342,7 +344,7 @@ class TestAddEmbargoToCaseActivity:
         _assert_rejects_link(self.cls)
 
     def test_accepts_inline_embargo_event(self):
-        _assert_accepts_inline(self.cls, EmbargoEvent())
+        _assert_accepts_inline(self.cls, as_EmbargoEvent())
 
 
 class TestAnnounceEmbargoActivity:
@@ -359,7 +361,7 @@ class TestAnnounceEmbargoActivity:
         _assert_rejects_link(self.cls)
 
     def test_accepts_inline_embargo_event(self):
-        _assert_accepts_inline(self.cls, EmbargoEvent())
+        _assert_accepts_inline(self.cls, as_EmbargoEvent())
 
 
 class TestRemoveEmbargoFromCaseActivity:
@@ -376,7 +378,7 @@ class TestRemoveEmbargoFromCaseActivity:
         _assert_rejects_link(self.cls)
 
     def test_accepts_inline_embargo_event(self):
-        _assert_accepts_inline(self.cls, EmbargoEvent())
+        _assert_accepts_inline(self.cls, as_EmbargoEvent())
 
 
 # ---------------------------------------------------------------------------
@@ -400,7 +402,7 @@ class TestRecommendActorActivity:
 
 
 # ---------------------------------------------------------------------------
-# CaseParticipant activities (case_participant.py)
+# as_CaseParticipant activities (case_participant.py)
 # ---------------------------------------------------------------------------
 
 
@@ -418,7 +420,7 @@ class TestCreateParticipantActivity:
         _assert_rejects_link(self.cls)
 
     def test_accepts_inline_participant(self):
-        _assert_accepts_inline(self.cls, CaseParticipant())
+        _assert_accepts_inline(self.cls, as_CaseParticipant())
 
 
 class TestCreateStatusForParticipantActivity:
@@ -469,7 +471,7 @@ class TestAddParticipantToCaseActivity:
         _assert_rejects_link(self.cls)
 
     def test_accepts_inline_participant(self):
-        _assert_accepts_inline(self.cls, CaseParticipant())
+        _assert_accepts_inline(self.cls, as_CaseParticipant())
 
 
 class TestRemoveParticipantFromCaseActivity:
@@ -486,7 +488,7 @@ class TestRemoveParticipantFromCaseActivity:
         _assert_rejects_link(self.cls)
 
     def test_accepts_inline_participant(self):
-        _assert_accepts_inline(self.cls, CaseParticipant())
+        _assert_accepts_inline(self.cls, as_CaseParticipant())
 
 
 # ---------------------------------------------------------------------------
@@ -499,7 +501,7 @@ class TestAnnounceLogEntryActivity:
         _AnnounceLogEntryActivity,
     )
     from vultron.wire.as2.vocab.objects.case_ledger_entry import (
-        CaseLedgerEntry,
+        as_CaseLedgerEntry,
     )
 
     cls = _AnnounceLogEntryActivity
@@ -512,12 +514,12 @@ class TestAnnounceLogEntryActivity:
 
     def test_accepts_inline_log_entry(self):
         from vultron.wire.as2.vocab.objects.case_ledger_entry import (
-            CaseLedgerEntry,
+            as_CaseLedgerEntry,
         )
 
         _assert_accepts_inline(
             self.cls,
-            CaseLedgerEntry(
+            as_CaseLedgerEntry(
                 case_id="https://example.org/cases/c1",
                 log_object_id="https://example.org/cases/c1/events/e1",
                 event_type="test_event",

--- a/test/wire/as2/vocab/test_case_participant.py
+++ b/test/wire/as2/vocab/test_case_participant.py
@@ -13,7 +13,7 @@
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-"""Tests for CaseParticipant model, focusing on accepted_embargo_ids field (CM-10-003)."""
+"""Tests for as_CaseParticipant model, focusing on accepted_embargo_ids field (CM-10-003)."""
 
 import unittest
 from typing import cast
@@ -26,7 +26,7 @@ from vultron.adapters.driven.db_record import (
     record_to_object,
 )
 from vultron.wire.as2.vocab.objects.case_participant import (
-    CaseParticipant,
+    as_CaseParticipant,
     CoordinatorParticipant,
     FinderParticipant,
     VendorParticipant,
@@ -34,25 +34,25 @@ from vultron.wire.as2.vocab.objects.case_participant import (
 
 
 class TestCaseParticipantAcceptedEmbargoIds(unittest.TestCase):
-    """Tests for CaseParticipant.accepted_embargo_ids (CM-10-001, CM-10-003)."""
+    """Tests for as_CaseParticipant.accepted_embargo_ids (CM-10-001, CM-10-003)."""
 
     def setUp(self):
         self.actor_id = "https://example.org/actors/alice"
         self.case_id = "https://example.org/cases/case-001"
         self.embargo_id_1 = "https://example.org/embargoes/emb-001"
         self.embargo_id_2 = "https://example.org/embargoes/emb-002"
-        self.participant = CaseParticipant(
+        self.participant = as_CaseParticipant(
             attributed_to=self.actor_id,
             context=self.case_id,
         )
 
     def test_accepted_embargo_ids_default_empty(self):
-        """New CaseParticipant has empty accepted_embargo_ids by default (CM-10-003)."""
+        """New as_CaseParticipant has empty accepted_embargo_ids by default (CM-10-003)."""
         self.assertEqual([], self.participant.accepted_embargo_ids)
 
     def test_accepted_embargo_ids_can_be_set_at_creation(self):
         """accepted_embargo_ids can be populated at creation time."""
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             attributed_to=self.actor_id,
             context=self.case_id,
             accepted_embargo_ids=[self.embargo_id_1],
@@ -66,7 +66,7 @@ class TestCaseParticipantAcceptedEmbargoIds(unittest.TestCase):
 
     def test_accepted_embargo_ids_tracks_multiple_embargoes(self):
         """accepted_embargo_ids tracks multiple accepted embargoes."""
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             attributed_to=self.actor_id,
             context=self.case_id,
             accepted_embargo_ids=[self.embargo_id_1, self.embargo_id_2],
@@ -77,26 +77,26 @@ class TestCaseParticipantAcceptedEmbargoIds(unittest.TestCase):
 
     def test_accepted_embargo_ids_round_trip_json(self):
         """accepted_embargo_ids survives JSON serialization round-trip."""
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             attributed_to=self.actor_id,
             context=self.case_id,
             accepted_embargo_ids=[self.embargo_id_1, self.embargo_id_2],
         )
         json_str = participant.to_json()
-        restored = CaseParticipant.model_validate_json(json_str)
+        restored = as_CaseParticipant.model_validate_json(json_str)
         self.assertEqual(
             participant.accepted_embargo_ids, restored.accepted_embargo_ids
         )
 
     def test_accepted_embargo_ids_round_trip_object_to_record(self):
         """accepted_embargo_ids survives object_to_record/record_to_object round-trip."""
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             attributed_to=self.actor_id,
             context=self.case_id,
             accepted_embargo_ids=[self.embargo_id_1, self.embargo_id_2],
         )
         record = object_to_record(participant)
-        restored = cast(CaseParticipant, record_to_object(record))
+        restored = cast(as_CaseParticipant, record_to_object(record))
         self.assertEqual(
             participant.accepted_embargo_ids, restored.accepted_embargo_ids
         )
@@ -104,11 +104,11 @@ class TestCaseParticipantAcceptedEmbargoIds(unittest.TestCase):
     def test_accepted_embargo_ids_empty_round_trip(self):
         """Empty accepted_embargo_ids survives object_to_record/record_to_object round-trip."""
         record = object_to_record(self.participant)
-        restored = cast(CaseParticipant, record_to_object(record))
+        restored = cast(as_CaseParticipant, record_to_object(record))
         self.assertEqual([], restored.accepted_embargo_ids)
 
     def test_accepted_embargo_ids_present_in_subclasses(self):
-        """accepted_embargo_ids field is inherited by CaseParticipant subclasses."""
+        """accepted_embargo_ids field is inherited by as_CaseParticipant subclasses."""
         for cls in [
             FinderParticipant,
             VendorParticipant,
@@ -140,7 +140,7 @@ class TestCaseParticipantAcceptedEmbargoIds(unittest.TestCase):
 
 
 class TestCaseParticipantNameField(unittest.TestCase):
-    """Tests for CaseParticipant.name field empty-string validation (CS-08-001)."""
+    """Tests for as_CaseParticipant.name field empty-string validation (CS-08-001)."""
 
     def setUp(self):
         self.actor_id = "https://example.org/actors/alice"
@@ -148,12 +148,12 @@ class TestCaseParticipantNameField(unittest.TestCase):
 
     def test_name_none_accepted(self):
         """name=None is valid when attributed_to is also not set."""
-        participant = CaseParticipant(context=self.case_id, name=None)
+        participant = as_CaseParticipant(context=self.case_id, name=None)
         self.assertIsNone(participant.name)
 
     def test_name_non_empty_accepted(self):
         """name with a non-empty string is valid."""
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             attributed_to=self.actor_id, context=self.case_id, name="Alice"
         )
         self.assertEqual("Alice", participant.name)
@@ -161,7 +161,7 @@ class TestCaseParticipantNameField(unittest.TestCase):
     def test_name_empty_string_rejected(self):
         """name must not be an empty string (CS-08-001)."""
         with pytest.raises(ValidationError) as exc_info:
-            CaseParticipant(
+            as_CaseParticipant(
                 attributed_to=self.actor_id, context=self.case_id, name=""
             )
         assert "must be a non-empty string" in str(exc_info.value)
@@ -169,14 +169,14 @@ class TestCaseParticipantNameField(unittest.TestCase):
     def test_name_whitespace_only_rejected(self):
         """name must not be whitespace-only (CS-08-001)."""
         with pytest.raises(ValidationError) as exc_info:
-            CaseParticipant(
+            as_CaseParticipant(
                 attributed_to=self.actor_id, context=self.case_id, name="   "
             )
         assert "must be a non-empty string" in str(exc_info.value)
 
     def test_participant_case_name_none_accepted(self):
         """participant_case_name=None is valid."""
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             attributed_to=self.actor_id,
             context=self.case_id,
             participant_case_name=None,
@@ -185,7 +185,7 @@ class TestCaseParticipantNameField(unittest.TestCase):
 
     def test_participant_case_name_non_empty_accepted(self):
         """participant_case_name with a non-empty string is valid."""
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             attributed_to=self.actor_id,
             context=self.case_id,
             participant_case_name="My Case",
@@ -195,7 +195,7 @@ class TestCaseParticipantNameField(unittest.TestCase):
     def test_participant_case_name_empty_string_rejected(self):
         """participant_case_name must not be an empty string (CS-08-001)."""
         with pytest.raises(ValidationError) as exc_info:
-            CaseParticipant(
+            as_CaseParticipant(
                 attributed_to=self.actor_id,
                 context=self.case_id,
                 participant_case_name="",
@@ -204,7 +204,7 @@ class TestCaseParticipantNameField(unittest.TestCase):
 
 
 class TestParticipantStatusProperty(unittest.TestCase):
-    """Tests for CaseParticipant.participant_status selection (bug #659).
+    """Tests for as_CaseParticipant.participant_status selection (bug #659).
 
     The property must return the most recently *appended* status, which
     represents this replica's current view. Wire-layer timestamps
@@ -220,12 +220,12 @@ class TestParticipantStatusProperty(unittest.TestCase):
         from vultron.core.states.cs import CS_vfd
         from vultron.core.states.rm import RM
         from vultron.wire.as2.vocab.objects.case_status import (
-            ParticipantStatus,
+            as_ParticipantStatus,
         )
 
         self.CS_vfd = CS_vfd
         self.RM = RM
-        self.ParticipantStatus = ParticipantStatus
+        self.as_ParticipantStatus = as_ParticipantStatus
         self.dt = datetime
         self.tz = timezone
         self.actor_id = "https://example.org/actors/vendor"
@@ -242,7 +242,7 @@ class TestParticipantStatusProperty(unittest.TestCase):
         (clock skew, batched processing, etc.). The property must still
         return the appended VFd entry.
         """
-        appended = self.ParticipantStatus(
+        appended = self.as_ParticipantStatus(
             context=self.case_id,
             attributed_to=self.actor_id,
             rm_state=self.RM.ACCEPTED,
@@ -252,7 +252,7 @@ class TestParticipantStatusProperty(unittest.TestCase):
         )
         # Construct participant with empty list so the validator creates
         # the initial vfd with published=now() (which will be > appended's).
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             attributed_to=self.actor_id, context=self.case_id
         )
         self.assertEqual(1, len(participant.participant_statuses))
@@ -266,7 +266,7 @@ class TestParticipantStatusProperty(unittest.TestCase):
 
     def test_returns_none_when_empty(self):
         """participant_status returns None when the list is empty."""
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             attributed_to=self.actor_id, context=self.case_id
         )
         # init_participant_status_if_empty populates one status by default;
@@ -275,11 +275,11 @@ class TestParticipantStatusProperty(unittest.TestCase):
         self.assertIsNone(participant.participant_status)
 
     def test_returns_single_status_when_only_one_present(self):
-        only = self.ParticipantStatus(
+        only = self.as_ParticipantStatus(
             context=self.case_id,
             attributed_to=self.actor_id,
         )
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             attributed_to=self.actor_id,
             context=self.case_id,
             participant_statuses=[only],

--- a/test/wire/as2/vocab/test_case_reference.py
+++ b/test/wire/as2/vocab/test_case_reference.py
@@ -25,7 +25,7 @@ class TestCaseReference(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        self.reference = cr.CaseReference(
+        self.reference = cr.as_CaseReference(
             url="https://example.org/advisory/",
             name="Example Security Advisory",
             tags=["vendor-advisory", "patch"],
@@ -45,75 +45,75 @@ class TestCaseReference(unittest.TestCase):
     def test_case_reference_url_required(self):
         """Test that url field is required."""
         with pytest.raises(ValidationError):
-            cr.CaseReference()
+            cr.as_CaseReference()
 
     def test_case_reference_url_not_empty(self):
         """Test that url must be non-empty string."""
         with pytest.raises(ValidationError) as exc_info:
-            cr.CaseReference(url="")
+            cr.as_CaseReference(url="")
 
         assert "must be a non-empty string" in str(exc_info.value)
 
     def test_case_reference_url_only(self):
         """Test CaseReference with only url field."""
-        ref = cr.CaseReference(url="https://example.org/")
+        ref = cr.as_CaseReference(url="https://example.org/")
         self.assertEqual("https://example.org/", ref.url)
         self.assertIsNone(ref.name)
         self.assertIsNone(ref.tags)
 
     def test_case_reference_name_optional(self):
         """Test that name field is optional."""
-        ref = cr.CaseReference(url="https://example.org/")
+        ref = cr.as_CaseReference(url="https://example.org/")
         self.assertIsNone(ref.name)
 
     def test_case_reference_name_not_empty(self):
         """Test that name must be non-empty string if provided."""
         with pytest.raises(ValidationError) as exc_info:
-            cr.CaseReference(url="https://example.org/", name="")
+            cr.as_CaseReference(url="https://example.org/", name="")
 
         assert "must be a non-empty string" in str(exc_info.value)
 
     def test_case_reference_name_with_url(self):
         """Test CaseReference with name."""
-        ref = cr.CaseReference(
+        ref = cr.as_CaseReference(
             url="https://example.org/", name="Advisory Title"
         )
         self.assertEqual("Advisory Title", ref.name)
 
     def test_case_reference_tags_optional(self):
         """Test that tags field is optional."""
-        ref = cr.CaseReference(url="https://example.org/")
+        ref = cr.as_CaseReference(url="https://example.org/")
         self.assertIsNone(ref.tags)
 
     def test_case_reference_tags_single_tag(self):
         """Test CaseReference with single tag."""
-        ref = cr.CaseReference(url="https://example.org/", tags=["patch"])
+        ref = cr.as_CaseReference(url="https://example.org/", tags=["patch"])
         self.assertEqual(["patch"], ref.tags)
 
     def test_case_reference_tags_multiple_tags(self):
         """Test CaseReference with multiple tags."""
         tags = ["vendor-advisory", "patch", "exploit"]
-        ref = cr.CaseReference(url="https://example.org/", tags=tags)
+        ref = cr.as_CaseReference(url="https://example.org/", tags=tags)
         self.assertEqual(tags, ref.tags)
 
     def test_case_reference_tags_empty_list_rejected(self):
         """Test that empty tags list is rejected."""
         with pytest.raises(ValidationError) as exc_info:
-            cr.CaseReference(url="https://example.org/", tags=[])
+            cr.as_CaseReference(url="https://example.org/", tags=[])
 
         assert "tags must have at least one element" in str(exc_info.value)
 
     def test_case_reference_tags_not_empty_strings(self):
         """Test that tags cannot contain empty strings."""
         with pytest.raises(ValidationError) as exc_info:
-            cr.CaseReference(url="https://example.org/", tags=["patch", ""])
+            cr.as_CaseReference(url="https://example.org/", tags=["patch", ""])
 
         assert "All tags must be non-empty strings" in str(exc_info.value)
 
     def test_case_reference_invalid_tag_rejected(self):
         """Test that tags not in CASE_REFERENCE_TAG_VOCABULARY are rejected."""
         with pytest.raises(ValidationError) as exc_info:
-            cr.CaseReference(
+            cr.as_CaseReference(
                 url="https://example.org/", tags=["not-a-real-tag"]
             )
 
@@ -129,7 +129,7 @@ class TestCaseReference(unittest.TestCase):
             "vendor-advisory",
         ]
         for tag in valid_tags:
-            ref = cr.CaseReference(url="https://example.org/", tags=[tag])
+            ref = cr.as_CaseReference(url="https://example.org/", tags=[tag])
             self.assertEqual([tag], ref.tags)
 
     def test_case_reference_all_valid_cve_tags(self):
@@ -137,7 +137,7 @@ class TestCaseReference(unittest.TestCase):
         all_tags = list(cr.CASE_REFERENCE_TAG_VOCABULARY)
         # Test each tag individually
         for tag in all_tags:
-            ref = cr.CaseReference(url="https://example.org/", tags=[tag])
+            ref = cr.as_CaseReference(url="https://example.org/", tags=[tag])
             assert ref.tags is not None
             self.assertIn(tag, ref.tags)
 
@@ -145,7 +145,7 @@ class TestCaseReference(unittest.TestCase):
         """Test serialization and deserialization round-trip."""
         ref = self.reference
         json_str = ref.to_json()
-        deserialized = cr.CaseReference.model_validate_json(json_str)
+        deserialized = cr.as_CaseReference.model_validate_json(json_str)
 
         self.assertEqual(ref.url, deserialized.url)
         self.assertEqual(ref.name, deserialized.name)
@@ -153,9 +153,9 @@ class TestCaseReference(unittest.TestCase):
 
     def test_case_reference_round_trip_minimal(self):
         """Test round-trip with minimal fields."""
-        ref = cr.CaseReference(url="https://example.org/")
+        ref = cr.as_CaseReference(url="https://example.org/")
         json_str = ref.to_json()
-        deserialized = cr.CaseReference.model_validate_json(json_str)
+        deserialized = cr.as_CaseReference.model_validate_json(json_str)
 
         self.assertEqual(ref.url, deserialized.url)
         self.assertIsNone(deserialized.name)
@@ -163,29 +163,29 @@ class TestCaseReference(unittest.TestCase):
 
     def test_case_reference_is_vultron_object_type(self):
         """Test that CaseReference has correct type_."""
-        ref = cr.CaseReference(url="https://example.org/")
+        ref = cr.as_CaseReference(url="https://example.org/")
         self.assertEqual(ref.type_, VO_type.CASE_REFERENCE)
 
     def test_case_reference_separate_from_report(self):
         """Test that CaseReference is a distinct type."""
         from vultron.wire.as2.vocab.objects.vulnerability_report import (
-            VulnerabilityReport,
+            as_VulnerabilityReport,
         )
 
-        ref = cr.CaseReference(url="https://example.org/")
-        report = VulnerabilityReport(content="Test report")
+        ref = cr.as_CaseReference(url="https://example.org/")
+        report = as_VulnerabilityReport(content="Test report")
 
         self.assertNotEqual(type(ref), type(report))
         self.assertNotEqual(ref.type_, report.type_)
 
     def test_case_reference_separate_from_vulnerability_record(self):
-        """Test that CaseReference is distinct from VulnerabilityRecord."""
+        """Test that CaseReference is distinct from as_VulnerabilityRecord."""
         from vultron.wire.as2.vocab.objects.vulnerability_record import (
-            VulnerabilityRecord,
+            as_VulnerabilityRecord,
         )
 
-        ref = cr.CaseReference(url="https://example.org/")
-        record = VulnerabilityRecord(name="CVE-2024-1234")
+        ref = cr.as_CaseReference(url="https://example.org/")
+        record = as_VulnerabilityRecord(name="CVE-2024-1234")
 
         self.assertNotEqual(type(ref), type(record))
         self.assertNotEqual(ref.type_, record.type_)
@@ -193,7 +193,7 @@ class TestCaseReference(unittest.TestCase):
     def test_case_reference_multiple_tags_preserved(self):
         """Test that multiple tags are preserved in order."""
         tags = ["vendor-advisory", "patch", "release-notes"]
-        ref = cr.CaseReference(url="https://example.org/", tags=tags)
+        ref = cr.as_CaseReference(url="https://example.org/", tags=tags)
         self.assertEqual(tags, ref.tags)
 
 

--- a/test/wire/as2/vocab/test_case_status.py
+++ b/test/wire/as2/vocab/test_case_status.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-Tests for CaseStatus and ParticipantStatus empty-string field validation
+Tests for as_CaseStatus and as_ParticipantStatus empty-string field validation
 (CS-08-001).
 """
 
@@ -23,8 +23,8 @@ import pytest
 from pydantic import ValidationError
 
 from vultron.wire.as2.vocab.objects.case_status import (
-    CaseStatus,
-    ParticipantStatus,
+    as_CaseStatus,
+    as_ParticipantStatus,
 )
 
 CASE_ID = "https://example.org/cases/case-001"
@@ -32,44 +32,44 @@ ACTOR_ID = "https://example.org/actors/alice"
 
 
 class TestCaseStatusContextField(unittest.TestCase):
-    """Tests for CaseStatus.context empty-string validation (CS-08-001)."""
+    """Tests for as_CaseStatus.context empty-string validation (CS-08-001)."""
 
     def test_context_none_accepted(self):
         """context=None is valid (optional field)."""
-        cs = CaseStatus(context=None)
+        cs = as_CaseStatus(context=None)
         self.assertIsNone(cs.context)
 
     def test_context_non_empty_accepted(self):
         """context with a non-empty string (case ID) is valid."""
-        cs = CaseStatus(context=CASE_ID)
+        cs = as_CaseStatus(context=CASE_ID)
         self.assertEqual(CASE_ID, cs.context)
 
     def test_context_empty_string_rejected(self):
         """context must not be an empty string (CS-08-001)."""
         with pytest.raises(ValidationError) as exc_info:
-            CaseStatus(context="")
+            as_CaseStatus(context="")
         assert "must be a non-empty string" in str(exc_info.value)
 
     def test_context_whitespace_only_rejected(self):
         """context must not be whitespace-only (CS-08-001)."""
         with pytest.raises(ValidationError) as exc_info:
-            CaseStatus(context="   ")
+            as_CaseStatus(context="   ")
         assert "must be a non-empty string" in str(exc_info.value)
 
 
 class TestParticipantStatusTrackingIdField(unittest.TestCase):
-    """Tests for ParticipantStatus.tracking_id empty-string validation (CS-08-001)."""
+    """Tests for as_ParticipantStatus.tracking_id empty-string validation (CS-08-001)."""
 
     def test_tracking_id_none_accepted(self):
         """tracking_id=None is valid (optional field)."""
-        ps = ParticipantStatus(
+        ps = as_ParticipantStatus(
             attributed_to=ACTOR_ID, context=CASE_ID, tracking_id=None
         )
         self.assertIsNone(ps.tracking_id)
 
     def test_tracking_id_non_empty_accepted(self):
         """tracking_id with a non-empty string is valid."""
-        ps = ParticipantStatus(
+        ps = as_ParticipantStatus(
             attributed_to=ACTOR_ID, context=CASE_ID, tracking_id="TICKET-123"
         )
         self.assertEqual("TICKET-123", ps.tracking_id)
@@ -77,7 +77,7 @@ class TestParticipantStatusTrackingIdField(unittest.TestCase):
     def test_tracking_id_empty_string_rejected(self):
         """tracking_id must not be an empty string (CS-08-001)."""
         with pytest.raises(ValidationError) as exc_info:
-            ParticipantStatus(
+            as_ParticipantStatus(
                 attributed_to=ACTOR_ID, context=CASE_ID, tracking_id=""
             )
         assert "must be a non-empty string" in str(exc_info.value)
@@ -85,7 +85,7 @@ class TestParticipantStatusTrackingIdField(unittest.TestCase):
     def test_tracking_id_whitespace_only_rejected(self):
         """tracking_id must not be whitespace-only (CS-08-001)."""
         with pytest.raises(ValidationError) as exc_info:
-            ParticipantStatus(
+            as_ParticipantStatus(
                 attributed_to=ACTOR_ID, context=CASE_ID, tracking_id="   "
             )
         assert "must be a non-empty string" in str(exc_info.value)

--- a/test/wire/as2/vocab/test_embargo_event.py
+++ b/test/wire/as2/vocab/test_embargo_event.py
@@ -11,13 +11,13 @@
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-"""Tests for wire EmbargoEvent domain boundary methods — ADR-0017."""
+"""Tests for wire as_EmbargoEvent domain boundary methods — ADR-0017."""
 
 from datetime import datetime, timezone
 
 from vultron.core.models.embargo_event import EmbargoEvent as CoreEmbargoEvent
 from vultron.wire.as2.vocab.objects.embargo_event import (
-    EmbargoEvent as WireEmbargoEvent,
+    as_EmbargoEvent as WireEmbargoEvent,
 )
 
 _CONTEXT = "https://example.org/cases/abc"
@@ -26,7 +26,7 @@ _START = datetime(2099, 1, 1, tzinfo=timezone.utc)
 
 
 class TestWireEmbargoEventBasics:
-    """Wire EmbargoEvent is an as_Event projection."""
+    """Wire as_EmbargoEvent is an as_Event projection."""
 
     def test_default_type(self):
         e = WireEmbargoEvent()

--- a/test/wire/as2/vocab/test_embargo_policy.py
+++ b/test/wire/as2/vocab/test_embargo_policy.py
@@ -43,7 +43,7 @@ class TestEmbargoPolicyCreation(unittest.TestCase):
     """Test EmbargoPolicy model creation — EP-01-001 through EP-01-003."""
 
     def setUp(self):
-        self.policy = cast(Any, ep_module.EmbargoPolicy)(
+        self.policy = cast(Any, ep_module.as_EmbargoPolicy)(
             actor_id=ACTOR_ID,
             inbox=INBOX,
             preferred_duration="P90D",
@@ -63,7 +63,7 @@ class TestEmbargoPolicyCreation(unittest.TestCase):
         self.assertEqual(VO_type.EMBARGO_POLICY, p.type_)
 
     def test_creation_accepts_timedelta_directly(self):
-        p = ep_module.EmbargoPolicy(
+        p = ep_module.as_EmbargoPolicy(
             actor_id=ACTOR_ID,
             inbox=INBOX,
             preferred_duration=_P60D,
@@ -71,7 +71,7 @@ class TestEmbargoPolicyCreation(unittest.TestCase):
         self.assertEqual(_P60D, p.preferred_duration)
 
     def test_creation_with_required_fields_only(self):
-        p = cast(Any, ep_module.EmbargoPolicy)(
+        p = cast(Any, ep_module.as_EmbargoPolicy)(
             actor_id=ACTOR_ID,
             inbox=INBOX,
             preferred_duration="P60D",
@@ -83,19 +83,21 @@ class TestEmbargoPolicyCreation(unittest.TestCase):
 
     def test_actor_id_required(self):
         with pytest.raises(ValidationError):
-            cast(Any, ep_module.EmbargoPolicy)(
+            cast(Any, ep_module.as_EmbargoPolicy)(
                 inbox=INBOX, preferred_duration="P90D"
             )
 
     def test_inbox_required(self):
         with pytest.raises(ValidationError):
-            cast(Any, ep_module.EmbargoPolicy)(
+            cast(Any, ep_module.as_EmbargoPolicy)(
                 actor_id=ACTOR_ID, preferred_duration="P90D"
             )
 
     def test_preferred_duration_required(self):
         with pytest.raises(ValidationError):
-            cast(Any, ep_module.EmbargoPolicy)(actor_id=ACTOR_ID, inbox=INBOX)
+            cast(Any, ep_module.as_EmbargoPolicy)(
+                actor_id=ACTOR_ID, inbox=INBOX
+            )
 
     def test_as_type_is_embargo_policy(self):
         self.assertEqual(VO_type.EMBARGO_POLICY, self.policy.type_)
@@ -117,12 +119,12 @@ class TestEmbargoPolicyValidation(unittest.TestCase):
         minimum_duration: str | timedelta | None = None,
         maximum_duration: str | timedelta | None = None,
         notes: str | None = None,
-    ) -> ep_module.EmbargoPolicy:
+    ) -> ep_module.as_EmbargoPolicy:
         # cast(Any, ...) allows passing str inputs that Pydantic's field_validator
         # converts to timedelta at runtime (mypy sees the declared timedelta type).
         return cast(
-            ep_module.EmbargoPolicy,
-            cast(Any, ep_module.EmbargoPolicy)(
+            ep_module.as_EmbargoPolicy,
+            cast(Any, ep_module.as_EmbargoPolicy)(
                 actor_id=actor_id,
                 inbox=inbox,
                 preferred_duration=preferred_duration,
@@ -222,7 +224,7 @@ class TestEmbargoPolicySerialization(unittest.TestCase):
     """Test EmbargoPolicy serialization — EP-01-004, DUR-05-001, DUR-05-002."""
 
     def setUp(self):
-        self.policy = cast(Any, ep_module.EmbargoPolicy)(
+        self.policy = cast(Any, ep_module.as_EmbargoPolicy)(
             actor_id=ACTOR_ID,
             inbox=INBOX,
             preferred_duration="P90D",
@@ -276,7 +278,7 @@ class TestEmbargoPolicySerialization(unittest.TestCase):
         dl.create(self.policy)
         stored = dl.read(self.policy.id_)
         self.assertIsNotNone(stored)
-        stored = cast(ep_module.EmbargoPolicy, stored)
+        stored = cast(ep_module.as_EmbargoPolicy, stored)
         self.assertEqual(self.policy.id_, stored.id_)
         self.assertEqual(ACTOR_ID, stored.actor_id)
         self.assertEqual(INBOX, stored.inbox)
@@ -286,7 +288,7 @@ class TestEmbargoPolicySerialization(unittest.TestCase):
 
     def test_roundtrip_timedelta_to_iso8601_and_back(self):
         """DUR-05-001, DUR-05-002: timedelta → 'P90D' → timedelta round-trips correctly."""
-        p = ep_module.EmbargoPolicy(
+        p = ep_module.as_EmbargoPolicy(
             actor_id=ACTOR_ID,
             inbox=INBOX,
             preferred_duration=timedelta(days=90),
@@ -296,7 +298,7 @@ class TestEmbargoPolicySerialization(unittest.TestCase):
         # JSON uses camelCase (alias_generator=to_camel)
         self.assertEqual("P90D", data["preferredDuration"])
         # Reconstruct from JSON
-        p2 = ep_module.EmbargoPolicy.model_validate_json(json_str)
+        p2 = ep_module.as_EmbargoPolicy.model_validate_json(json_str)
         self.assertEqual(timedelta(days=90), p2.preferred_duration)
 
     def test_json_serialization(self):
@@ -307,10 +309,10 @@ class TestEmbargoPolicySerialization(unittest.TestCase):
 
     def test_type_distinctness(self):
         from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            VulnerabilityCase,
+            as_VulnerabilityCase,
         )
 
-        case = VulnerabilityCase()
+        case = as_VulnerabilityCase()
         self.assertNotEqual(self.policy.type_, case.type_)
 
 
@@ -327,7 +329,7 @@ class TestEmbargoPolicyCoreConversion(unittest.TestCase):
         )
 
         self.core_cls = CoreEmbargoPolicy
-        self.wire_cls = ep_module.EmbargoPolicy
+        self.wire_cls = ep_module.as_EmbargoPolicy
         self.core_policy = CoreEmbargoPolicy(
             actor_id=ACTOR_ID,
             inbox=INBOX,

--- a/test/wire/as2/vocab/test_vocab_actor_examples.py
+++ b/test/wire/as2/vocab/test_vocab_actor_examples.py
@@ -18,7 +18,7 @@ Each test asserts:
 - Return type matches the declared return annotation.
 - ``actor`` field is set to the expected actor ID.
 - ``to`` field is set to the expected recipient(s).
-- ``object_`` references the expected actor or CaseParticipant.
+- ``object_`` references the expected actor or as_CaseParticipant.
 """
 
 import unittest
@@ -33,7 +33,7 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Offer,
     as_Reject,
 )
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
 from vultron.wire.as2.vocab.examples._base import (
     _CASE_ACTOR,
     _COORDINATOR,
@@ -139,11 +139,11 @@ class TestOfferCaseParticipant(unittest.TestCase):
         self.assertEqual(self.activity.to, [self.vendor.id_])
 
     def test_object_is_case_participant(self):
-        participant = cast(CaseParticipant, self.activity.object_)
-        self.assertIsInstance(participant, CaseParticipant)
+        participant = cast(as_CaseParticipant, self.activity.object_)
+        self.assertIsInstance(participant, as_CaseParticipant)
 
     def test_participant_attributed_to_coordinator(self):
-        participant = cast(CaseParticipant, self.activity.object_)
+        participant = cast(as_CaseParticipant, self.activity.object_)
         attr = participant.attributed_to
         attr_id = getattr(attr, "id_", None) or attr
         self.assertEqual(attr_id, self.coordinator.id_)

--- a/test/wire/as2/vocab/test_vocab_actor_report_examples.py
+++ b/test/wire/as2/vocab/test_vocab_actor_report_examples.py
@@ -29,7 +29,7 @@ from vultron.wire.as2.vocab.base.objects.actors import (
 )
 from vultron.wire.as2.vocab.base.objects.base import as_Object
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 
@@ -56,7 +56,7 @@ class TestVocabReportExamples(unittest.TestCase):
     def test_report(self):
         report = examples.gen_report()
         self.assertIsInstance(report, as_Object)
-        self.assertIsInstance(report, VulnerabilityReport)
+        self.assertIsInstance(report, as_VulnerabilityReport)
 
         self.assertTrue(hasattr(report, "to_json"))
         json = report.to_json()
@@ -110,7 +110,7 @@ class TestVocabReportExamples(unittest.TestCase):
         self.assertEqual(offer.type_, "Offer")
         self.assertEqual(offer.actor, finder)
 
-        report_ = cast(VulnerabilityReport, offer.object_)
+        report_ = cast(as_VulnerabilityReport, offer.object_)
         self.assertEqual(report, report_)
 
     def test_invalidate_report(self):
@@ -128,7 +128,7 @@ class TestVocabReportExamples(unittest.TestCase):
         self.assertEqual(offer.type_, "Offer")
         self.assertEqual(offer.actor, finder)
 
-        report_ = cast(VulnerabilityReport, offer.object_)
+        report_ = cast(as_VulnerabilityReport, offer.object_)
         self.assertEqual(report, report_)
 
     def test_close_report(self):
@@ -146,7 +146,7 @@ class TestVocabReportExamples(unittest.TestCase):
         self.assertEqual(offer.type_, "Offer")
         self.assertEqual(offer.actor, finder)
 
-        report_ = cast(VulnerabilityReport, offer.object_)
+        report_ = cast(as_VulnerabilityReport, offer.object_)
         self.assertEqual(report, report_)
 
 

--- a/test/wire/as2/vocab/test_vocab_case_examples.py
+++ b/test/wire/as2/vocab/test_vocab_case_examples.py
@@ -29,9 +29,11 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
 )
 from vultron.wire.as2.vocab.base.objects.base import as_Object
 from vultron.wire.as2.vocab.base.objects.object_types import as_Note
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.case_status import CaseStatus
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.case_status import as_CaseStatus
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.core.states.cs import CS_pxa
 from vultron.core.states.em import EM
 
@@ -40,7 +42,7 @@ class TestVocabCaseObjectExamples(unittest.TestCase):
     def test_case(self):
         case = examples.case()
         self.assertIsInstance(case, as_Object)
-        self.assertIsInstance(case, VulnerabilityCase)
+        self.assertIsInstance(case, as_VulnerabilityCase)
 
         self.assertTrue(hasattr(case, "to_json"))
         json = case.to_json()
@@ -48,7 +50,7 @@ class TestVocabCaseObjectExamples(unittest.TestCase):
 
     def test_case_has_genesis_hash(self):
         case = examples.case()
-        self.assertIsInstance(case, VulnerabilityCase)
+        self.assertIsInstance(case, as_VulnerabilityCase)
         self.assertTrue(
             case.genesis_hash,
             "examples.case() genesis_hash must be non-empty (CLP-08-003)",
@@ -56,7 +58,7 @@ class TestVocabCaseObjectExamples(unittest.TestCase):
 
     def test_case_random_id_has_genesis_hash(self):
         case = examples.case(random_id=True)
-        self.assertIsInstance(case, VulnerabilityCase)
+        self.assertIsInstance(case, as_VulnerabilityCase)
         self.assertTrue(
             case.genesis_hash,
             "examples.case(random_id=True) genesis_hash must be non-empty (CLP-08-003)",
@@ -72,7 +74,7 @@ class TestVocabCaseObjectExamples(unittest.TestCase):
         self.assertEqual(create_case.type_, "Create")
         self.assertEqual(create_case.actor, vendor.id_)
 
-        case_from_activity = cast(VulnerabilityCase, create_case.object_)
+        case_from_activity = cast(as_VulnerabilityCase, create_case.object_)
         # Each call to create_case() uses a fresh random-ID case, so we assert
         # the id is non-empty rather than equal to the shared singleton.
         self.assertTrue(case_from_activity.id_)
@@ -80,7 +82,7 @@ class TestVocabCaseObjectExamples(unittest.TestCase):
             case_from_activity.vulnerability_reports[0], report.id_
         )
         participant = cast(
-            CaseParticipant, case_from_activity.case_participants[0]
+            as_CaseParticipant, case_from_activity.case_participants[0]
         )
         self.assertEqual(participant.attributed_to, vendor.id_)
 
@@ -120,7 +122,7 @@ class TestVocabCaseParticipantExamples(unittest.TestCase):
         self.assertEqual(activity.actor, vendor.id_)
         self.assertEqual(activity.target, case.id_)
 
-        participant = cast(CaseParticipant, activity.object_)
+        participant = cast(as_CaseParticipant, activity.object_)
         self.assertEqual(participant.attributed_to, vendor.id_)
         self.assertEqual(participant.name, vendor.name)
         self.assertEqual(participant.context, case.id_)
@@ -138,7 +140,7 @@ class TestVocabCaseParticipantExamples(unittest.TestCase):
         self.assertEqual(activity.actor, vendor.id_)
         self.assertEqual(activity.target, case.id_)
 
-        participant = cast(CaseParticipant, activity.object_)
+        participant = cast(as_CaseParticipant, activity.object_)
         self.assertEqual(participant.attributed_to, finder.id_)
         self.assertEqual(participant.name, finder.name)
         self.assertEqual(participant.context, case.id_)
@@ -156,7 +158,7 @@ class TestVocabCaseParticipantExamples(unittest.TestCase):
         self.assertEqual(activity.actor, vendor.id_)
         self.assertEqual(activity.target, case.id_)
 
-        participant = cast(CaseParticipant, activity.object_)
+        participant = cast(as_CaseParticipant, activity.object_)
         self.assertEqual(participant.attributed_to, coordinator.id_)
         self.assertEqual(participant.name, coordinator.name)
         self.assertEqual(participant.context, case.id_)
@@ -284,7 +286,7 @@ class TestVocabCaseOwnershipExamples(unittest.TestCase):
         self.assertEqual(activity.actor, vendor.id_)
         self.assertEqual(activity.target, coordinator.id_)
 
-        transfer_case = cast(VulnerabilityCase, activity.object_)
+        transfer_case = cast(as_VulnerabilityCase, activity.object_)
         for k, v in transfer_case.to_dict().items():
             if isinstance(v, list):
                 continue
@@ -317,7 +319,7 @@ class TestVocabCaseStatusExamples(unittest.TestCase):
     def test_case_status(self):
         obj = examples.case_status()
         self.assertIsInstance(obj, as_Object)
-        self.assertIsInstance(obj, CaseStatus)
+        self.assertIsInstance(obj, as_CaseStatus)
         self.assertIn(obj.em_state, EM)
         self.assertIn(obj.pxa_state, CS_pxa)
 

--- a/test/wire/as2/vocab/test_vocab_participant_examples.py
+++ b/test/wire/as2/vocab/test_vocab_participant_examples.py
@@ -27,10 +27,10 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
 )
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.base.objects.base import as_Object
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
 from vultron.wire.as2.vocab.objects.case_status import (
-    CaseStatus,
-    ParticipantStatus,
+    as_CaseStatus,
+    as_ParticipantStatus,
 )
 from vultron.core.states.cs import CS_pxa, CS_vfd
 from vultron.core.states.em import EM
@@ -41,7 +41,7 @@ class TestVocabParticipantExamples(unittest.TestCase):
     def test_case_participant(self):
         obj = examples.case_participant()
         self.assertIsInstance(obj, as_Object)
-        self.assertIsInstance(obj, CaseParticipant)
+        self.assertIsInstance(obj, as_CaseParticipant)
 
         self.assertIsNotNone(obj.id_)
         self.assertIsNotNone(obj.name)
@@ -51,7 +51,7 @@ class TestVocabParticipantExamples(unittest.TestCase):
         self.assertIsInstance(obj.participant_statuses, Sequence)
         self.assertGreaterEqual(len(obj.participant_statuses), 1)
         for status in obj.participant_statuses:
-            self.assertIsInstance(status, ParticipantStatus)
+            self.assertIsInstance(status, as_ParticipantStatus)
 
     def test_create_participant(self):
         activity = examples.create_participant()
@@ -65,7 +65,7 @@ class TestVocabParticipantExamples(unittest.TestCase):
 
         self.assertEqual(activity.actor, vendor.id_)
         self.assertEqual(activity.context, case.id_)
-        participant = cast(CaseParticipant, activity.object_)
+        participant = cast(as_CaseParticipant, activity.object_)
         self.assertEqual(participant.attributed_to, coordinator.id_)
         self.assertEqual(participant.context, case.id_)
         self.assertEqual(participant.name, coordinator.name)
@@ -73,7 +73,7 @@ class TestVocabParticipantExamples(unittest.TestCase):
     def test_participant_status(self):
         obj = examples.participant_status()
         self.assertIsInstance(obj, as_Object)
-        self.assertIsInstance(obj, ParticipantStatus)
+        self.assertIsInstance(obj, as_ParticipantStatus)
 
         self.assertIsNotNone(obj.attributed_to)
         self.assertIsNotNone(obj.context)
@@ -82,7 +82,7 @@ class TestVocabParticipantExamples(unittest.TestCase):
         self.assertIn(obj.vfd_state, CS_vfd)
 
         if obj.case_status is not None:
-            self.assertIsInstance(obj.case_status, CaseStatus)
+            self.assertIsInstance(obj.case_status, as_CaseStatus)
             self.assertIn(obj.case_status.em_state, EM)
             self.assertIn(obj.case_status.pxa_state, CS_pxa)
 
@@ -95,7 +95,7 @@ class TestVocabParticipantExamples(unittest.TestCase):
         self.assertEqual(activity.type_, "Create")
 
         self.assertEqual(activity.actor, vendor.id_)
-        self.assertIsInstance(activity.object_, ParticipantStatus)
+        self.assertIsInstance(activity.object_, as_ParticipantStatus)
 
     def test_add_status_to_participant(self):
         activity = examples.add_status_to_participant()
@@ -254,8 +254,8 @@ class TestVocabParticipantExamples(unittest.TestCase):
         self.assertEqual(activity.actor, ca.id_)
         self.assertEqual(activity.to, [v.id_])
 
-        participant = cast(CaseParticipant, activity.object_)
-        self.assertIsInstance(participant, CaseParticipant)
+        participant = cast(as_CaseParticipant, activity.object_)
+        self.assertIsInstance(participant, as_CaseParticipant)
         attr = participant.attributed_to
         attr_id = getattr(attr, "id_", None) or attr
         self.assertEqual(attr_id, coordinator.id_)
@@ -312,7 +312,7 @@ class TestVocabParticipantExamples(unittest.TestCase):
         self.assertEqual(activity.type_, "Remove")
 
         self.assertEqual(activity.actor, vendor.id_)
-        participant = cast(CaseParticipant, activity.object_)
+        participant = cast(as_CaseParticipant, activity.object_)
         self.assertEqual(participant.attributed_to, coord_p.attributed_to)
         self.assertEqual(participant.name, coord_p.name)
         self.assertEqual(participant.context, case.id_)

--- a/test/wire/as2/vocab/test_vulnerability_case.py
+++ b/test/wire/as2/vocab/test_vulnerability_case.py
@@ -1,58 +1,68 @@
-"""Tests for VulnerabilityCase, including set_embargo() bug fix."""
+"""Tests for as_VulnerabilityCase, including set_embargo() bug fix."""
 
 from datetime import datetime, timezone
 from typing import cast
 
 
 from vultron.wire.as2.vocab.objects.case_participant import (
-    CaseParticipant,
+    as_CaseParticipant,
 )
 from vultron.enums.roles import CVDRole
-from vultron.wire.as2.vocab.objects.case_status import CaseStatus
-from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_status import as_CaseStatus
+from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.core.states.em import EM
 
 
 class TestVulnerabilityCase:
     def test_init_has_one_case_status(self):
-        case = VulnerabilityCase()
+        case = as_VulnerabilityCase()
         assert len(case.case_statuses) == 1
 
     def test_current_status_returns_most_recent(self):
-        older = CaseStatus(updated=datetime(2025, 1, 1, tzinfo=timezone.utc))
-        newer = CaseStatus(updated=datetime(2025, 6, 1, tzinfo=timezone.utc))
-        case = VulnerabilityCase()
+        older = as_CaseStatus(
+            updated=datetime(2025, 1, 1, tzinfo=timezone.utc)
+        )
+        newer = as_CaseStatus(
+            updated=datetime(2025, 6, 1, tzinfo=timezone.utc)
+        )
+        case = as_VulnerabilityCase()
         case.case_statuses = [older, newer]
         assert case.current_status is newer
 
     def test_current_status_handles_none_updated(self):
-        cs = CaseStatus()
-        case = VulnerabilityCase()
+        cs = as_CaseStatus()
+        case = as_VulnerabilityCase()
         case.case_statuses = [cs]
         # Should return the only element without error
         assert case.current_status is cs
 
     def test_set_embargo_sets_active_embargo(self):
-        case = VulnerabilityCase()
-        embargo = EmbargoEvent()
+        case = as_VulnerabilityCase()
+        embargo = as_EmbargoEvent()
         case.set_embargo(embargo)
         assert case.active_embargo is embargo
 
     def test_set_embargo_does_not_update_em_state(self):
-        case = VulnerabilityCase()
-        embargo = EmbargoEvent()
+        case = as_VulnerabilityCase()
+        embargo = as_EmbargoEvent()
         assert case.current_status.em_state == EM.NO_EMBARGO
         case.set_embargo(embargo)
         # em_state is the caller's responsibility; set_embargo only sets the embargo ref
         assert case.current_status.em_state == EM.NO_EMBARGO
 
     def test_set_embargo_updates_most_recent_case_status(self):
-        older = CaseStatus(updated=datetime(2025, 1, 1, tzinfo=timezone.utc))
-        newer = CaseStatus(updated=datetime(2025, 6, 1, tzinfo=timezone.utc))
-        case = VulnerabilityCase()
+        older = as_CaseStatus(
+            updated=datetime(2025, 1, 1, tzinfo=timezone.utc)
+        )
+        newer = as_CaseStatus(
+            updated=datetime(2025, 6, 1, tzinfo=timezone.utc)
+        )
+        case = as_VulnerabilityCase()
         case.case_statuses = [older, newer]
-        embargo = EmbargoEvent()
+        embargo = as_EmbargoEvent()
         case.set_embargo(embargo)
         assert case.active_embargo is embargo
         assert newer.em_state == EM.NO_EMBARGO
@@ -63,13 +73,13 @@ class TestActorParticipantIndex:
     """Tests for actor_participant_index consistency (CM-10-002)."""
 
     def test_index_empty_on_new_case(self):
-        case = VulnerabilityCase(id_="https://example.org/cases/c1")
+        case = as_VulnerabilityCase(id_="https://example.org/cases/c1")
         assert case.actor_participant_index == {}
 
     def test_add_participant_updates_index(self):
-        case = VulnerabilityCase(id_="https://example.org/cases/c1")
+        case = as_VulnerabilityCase(id_="https://example.org/cases/c1")
         actor_id = "https://example.org/users/alice"
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             id_="https://example.org/cases/c1/participants/alice",
             attributed_to=actor_id,
             context=case.id_,
@@ -79,8 +89,8 @@ class TestActorParticipantIndex:
         assert case.actor_participant_index[actor_id] == participant.id_
 
     def test_add_participant_appends_to_list(self):
-        case = VulnerabilityCase(id_="https://example.org/cases/c1")
-        participant = CaseParticipant(
+        case = as_VulnerabilityCase(id_="https://example.org/cases/c1")
+        participant = as_CaseParticipant(
             id_="https://example.org/cases/c1/participants/alice",
             attributed_to="https://example.org/users/alice",
             context=case.id_,
@@ -90,9 +100,9 @@ class TestActorParticipantIndex:
 
     def test_add_participant_with_object_attributed_to(self):
         """Index is updated correctly when attributed_to is a full URI string."""
-        case = VulnerabilityCase(id_="https://example.org/cases/c2")
+        case = as_VulnerabilityCase(id_="https://example.org/cases/c2")
         actor_id = "https://example.org/users/bob"
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             case_roles=[CVDRole.VENDOR],
             id_="https://example.org/cases/c2/participants/bob",
             attributed_to=actor_id,
@@ -103,9 +113,9 @@ class TestActorParticipantIndex:
         assert case.actor_participant_index[actor_id] == participant.id_
 
     def test_add_multiple_participants_index_grows(self):
-        case = VulnerabilityCase(id_="https://example.org/cases/c3")
+        case = as_VulnerabilityCase(id_="https://example.org/cases/c3")
         for name in ("alice", "bob", "carol"):
-            p = CaseParticipant(
+            p = as_CaseParticipant(
                 id_=f"https://example.org/cases/c3/participants/{name}",
                 attributed_to=f"https://example.org/users/{name}",
                 context=case.id_,
@@ -115,9 +125,9 @@ class TestActorParticipantIndex:
         assert len(case.case_participants) == 3
 
     def test_remove_participant_removes_from_list_and_index(self):
-        case = VulnerabilityCase(id_="https://example.org/cases/c4")
+        case = as_VulnerabilityCase(id_="https://example.org/cases/c4")
         actor_id = "https://example.org/users/alice"
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             id_="https://example.org/cases/c4/participants/alice",
             attributed_to=actor_id,
             context=case.id_,
@@ -130,7 +140,7 @@ class TestActorParticipantIndex:
         assert participant not in case.case_participants
 
     def test_remove_participant_not_in_case_is_safe(self):
-        case = VulnerabilityCase(id_="https://example.org/cases/c5")
+        case = as_VulnerabilityCase(id_="https://example.org/cases/c5")
         case.remove_participant(
             "https://example.org/cases/c5/participants/ghost"
         )
@@ -139,7 +149,7 @@ class TestActorParticipantIndex:
 
     def test_remove_participant_works_with_string_ids_in_list(self):
         """remove_participant handles cases where list contains string IDs."""
-        case = VulnerabilityCase(id_="https://example.org/cases/c6")
+        case = as_VulnerabilityCase(id_="https://example.org/cases/c6")
         participant_id = "https://example.org/cases/c6/participants/alice"
         case.case_participants.append(participant_id)
         case.actor_participant_index["https://example.org/users/alice"] = (
@@ -160,9 +170,9 @@ class TestActorParticipantIndex:
             record_to_object,
         )
 
-        case = VulnerabilityCase(id_="https://example.org/cases/c7")
+        case = as_VulnerabilityCase(id_="https://example.org/cases/c7")
         actor_id = "https://example.org/users/alice"
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             id_="https://example.org/cases/c7/participants/alice",
             attributed_to=actor_id,
             context=case.id_,
@@ -172,7 +182,7 @@ class TestActorParticipantIndex:
         record = object_to_record(case)
         restored = record_to_object(record)
         assert hasattr(restored, "actor_participant_index")
-        restored = cast(VulnerabilityCase, restored)
+        restored = cast(as_VulnerabilityCase, restored)
         assert (
             restored.actor_participant_index.get(actor_id) == participant.id_
         )

--- a/test/wire/as2/vocab/test_vulnerability_record.py
+++ b/test/wire/as2/vocab/test_vulnerability_record.py
@@ -25,7 +25,7 @@ class TestVulnerabilityRecord(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        self.record = vr.VulnerabilityRecord(
+        self.record = vr.as_VulnerabilityRecord(
             name="CVE-2024-1234",
             aliases=["VU#654321"],
             url="https://example.org/advisory/cve-2024-1234",
@@ -45,30 +45,32 @@ class TestVulnerabilityRecord(unittest.TestCase):
     def test_vulnerability_record_name_required(self):
         """Test that name field is required."""
         with pytest.raises(ValidationError):
-            vr.VulnerabilityRecord()
+            vr.as_VulnerabilityRecord()
 
     def test_vulnerability_record_name_not_empty(self):
         """Test that name must be non-empty string."""
         with pytest.raises(ValidationError) as exc_info:
-            vr.VulnerabilityRecord(name="")
+            vr.as_VulnerabilityRecord(name="")
 
         assert "must be a non-empty string" in str(exc_info.value)
 
     def test_vulnerability_record_aliases_optional(self):
         """Test that aliases field is optional."""
-        record = vr.VulnerabilityRecord(name="CVE-2024-5678")
+        record = vr.as_VulnerabilityRecord(name="CVE-2024-5678")
         self.assertEqual([], record.aliases)
 
     def test_vulnerability_record_aliases_list(self):
         """Test that aliases are stored as list."""
         aliases = ["VU#123456", "VENDOR-2024-001"]
-        record = vr.VulnerabilityRecord(name="CVE-2024-1111", aliases=aliases)
+        record = vr.as_VulnerabilityRecord(
+            name="CVE-2024-1111", aliases=aliases
+        )
         self.assertEqual(aliases, record.aliases)
 
     def test_vulnerability_record_aliases_not_empty_strings(self):
         """Test that aliases cannot contain empty strings."""
         with pytest.raises(ValidationError) as exc_info:
-            vr.VulnerabilityRecord(
+            vr.as_VulnerabilityRecord(
                 name="CVE-2024-1234", aliases=["VU#123456", ""]
             )
 
@@ -76,26 +78,26 @@ class TestVulnerabilityRecord(unittest.TestCase):
 
     def test_vulnerability_record_url_optional(self):
         """Test that url field is optional."""
-        record = vr.VulnerabilityRecord(name="CVE-2024-1234")
+        record = vr.as_VulnerabilityRecord(name="CVE-2024-1234")
         self.assertIsNone(record.url)
 
     def test_vulnerability_record_url_not_empty(self):
         """Test that url must be non-empty string if provided."""
         with pytest.raises(ValidationError) as exc_info:
-            vr.VulnerabilityRecord(name="CVE-2024-1234", url="")
+            vr.as_VulnerabilityRecord(name="CVE-2024-1234", url="")
         assert "must be a non-empty string" in str(exc_info.value)
 
     def test_vulnerability_record_url_whitespace_rejected(self):
         """Test that url cannot be whitespace-only if provided."""
         with pytest.raises(ValidationError) as exc_info:
-            vr.VulnerabilityRecord(name="CVE-2024-1234", url="   ")
+            vr.as_VulnerabilityRecord(name="CVE-2024-1234", url="   ")
         assert "must be a non-empty string" in str(exc_info.value)
 
     def test_vulnerability_record_round_trip(self):
         """Test serialization and deserialization round-trip."""
         record = self.record
         json_str = record.to_json()
-        deserialized = vr.VulnerabilityRecord.model_validate_json(json_str)
+        deserialized = vr.as_VulnerabilityRecord.model_validate_json(json_str)
 
         self.assertEqual(record.name, deserialized.name)
         self.assertEqual(record.aliases, deserialized.aliases)
@@ -112,22 +114,22 @@ class TestVulnerabilityRecord(unittest.TestCase):
         ]
 
         for identifier in identifiers:
-            record = vr.VulnerabilityRecord(name=identifier)
+            record = vr.as_VulnerabilityRecord(name=identifier)
             self.assertEqual(identifier, record.name)
 
     def test_vulnerability_record_is_vultron_object_type(self):
         """Test that VulnerabilityRecord has correct type_."""
-        record = vr.VulnerabilityRecord(name="CVE-2024-1234")
+        record = vr.as_VulnerabilityRecord(name="CVE-2024-1234")
         self.assertEqual(record.type_, VO_type.VULNERABILITY_RECORD)
 
     def test_vulnerability_record_separate_from_report(self):
-        """Test that VulnerabilityRecord is a distinct type from VulnerabilityReport."""
+        """Test that VulnerabilityRecord is a distinct type from as_VulnerabilityReport."""
         from vultron.wire.as2.vocab.objects.vulnerability_report import (
-            VulnerabilityReport,
+            as_VulnerabilityReport,
         )
 
-        record = vr.VulnerabilityRecord(name="CVE-2024-1234")
-        report = VulnerabilityReport(content="Test report")
+        record = vr.as_VulnerabilityRecord(name="CVE-2024-1234")
+        report = as_VulnerabilityReport(content="Test report")
 
         self.assertNotEqual(type(record), type(report))
         self.assertNotEqual(record.type_, report.type_)

--- a/test/wire/as2/vocab/test_vulnerability_report.py
+++ b/test/wire/as2/vocab/test_vulnerability_report.py
@@ -19,7 +19,7 @@ import vultron.wire.as2.vocab.objects.vulnerability_report as vr
 
 class MyTestCase(unittest.TestCase):
     def setUp(self):
-        self.rpt = vr.VulnerabilityReport(
+        self.rpt = vr.as_VulnerabilityReport(
             attributed_to=[
                 "Henry",
             ],

--- a/test/wire/as2/vocab/test_vultron_actor.py
+++ b/test/wire/as2/vocab/test_vultron_actor.py
@@ -12,7 +12,7 @@
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
 """
-Tests for VultronPerson, VultronOrganization, VultronService, and
+Tests for as_VultronPerson, as_VultronOrganization, as_VultronService, and
 VultronActorMixin (EP-01-001).
 """
 
@@ -26,22 +26,22 @@ from vultron.core.models.actor import (
 from vultron.wire.as2.enums import as_ActorType
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.base.registry import VOCABULARY
-from vultron.wire.as2.vocab.objects.embargo_policy import EmbargoPolicy
+from vultron.wire.as2.vocab.objects.embargo_policy import as_EmbargoPolicy
 from vultron.wire.as2.vocab.objects.vultron_actor import (
     VultronActorMixin,
-    VultronApplication,
-    VultronGroup,
-    VultronOrganization,
-    VultronPerson,
-    VultronService,
+    as_VultronApplication,
+    as_VultronGroup,
+    as_VultronOrganization,
+    as_VultronPerson,
+    as_VultronService,
 )
 
 ACTOR_ID = "https://example.org/actors/vendor"
 INBOX = "https://example.org/actors/vendor/inbox"
 
 
-def _make_policy() -> EmbargoPolicy:
-    return EmbargoPolicy(
+def _make_policy() -> as_EmbargoPolicy:
+    return as_EmbargoPolicy(
         actor_id=ACTOR_ID,
         inbox=INBOX,
         preferred_duration=timedelta(days=90),
@@ -52,23 +52,23 @@ def _make_policy() -> EmbargoPolicy:
 
 
 class TestVultronPersonBasics(unittest.TestCase):
-    """VultronPerson retains Person type and supports embargo_policy."""
+    """as_VultronPerson retains Person type and supports embargo_policy."""
 
     def test_as_type_is_person(self):
-        p = VultronPerson(id_="https://example.org/users/alice")
+        p = as_VultronPerson(id_="https://example.org/users/alice")
         self.assertEqual(as_ActorType.PERSON, p.type_)
 
     def test_embargo_policy_defaults_to_none(self):
-        p = VultronPerson(id_="https://example.org/users/alice")
+        p = as_VultronPerson(id_="https://example.org/users/alice")
         self.assertIsNone(p.embargo_policy)
 
     def test_embargo_policy_inline_object(self):
         policy = _make_policy()
-        p = VultronPerson(
+        p = as_VultronPerson(
             id_="https://example.org/users/alice",
             embargo_policy=policy,
         )
-        assert isinstance(p.embargo_policy, EmbargoPolicy)
+        assert isinstance(p.embargo_policy, as_EmbargoPolicy)
         self.assertEqual(policy.id_, p.embargo_policy.id_)
         self.assertEqual(
             timedelta(days=90), p.embargo_policy.preferred_duration
@@ -76,26 +76,28 @@ class TestVultronPersonBasics(unittest.TestCase):
 
     def test_embargo_policy_reference_string(self):
         policy_id = "https://example.org/policies/alice-ep"
-        p = VultronPerson(
+        p = as_VultronPerson(
             id_="https://example.org/users/alice",
             embargo_policy=policy_id,
         )
         self.assertEqual(policy_id, p.embargo_policy)
 
     def test_is_instance_of_mixin(self):
-        p = VultronPerson()
+        p = as_VultronPerson()
         self.assertIsInstance(p, VultronActorMixin)
         self.assertIsInstance(p, as_Actor)
 
     def test_json_round_trip_no_policy(self):
-        p = VultronPerson(name="Alice", id_="https://example.org/users/alice")
+        p = as_VultronPerson(
+            name="Alice", id_="https://example.org/users/alice"
+        )
         j = p.to_json()
         self.assertIn("Person", j)
         self.assertNotIn("embargo_policy", j)
 
     def test_json_round_trip_with_inline_policy(self):
         policy = _make_policy()
-        p = VultronPerson(
+        p = as_VultronPerson(
             name="Alice",
             id_="https://example.org/users/alice",
             embargo_policy=policy,
@@ -107,46 +109,46 @@ class TestVultronPersonBasics(unittest.TestCase):
 
 
 class TestVultronOrganizationBasics(unittest.TestCase):
-    """VultronOrganization retains Organization type and supports
+    """as_VultronOrganization retains Organization type and supports
     embargo_policy."""
 
     def test_as_type_is_organization(self):
-        org = VultronOrganization(id_="https://example.org/orgs/vendor")
+        org = as_VultronOrganization(id_="https://example.org/orgs/vendor")
         self.assertEqual(as_ActorType.ORGANIZATION, org.type_)
 
     def test_embargo_policy_defaults_to_none(self):
-        org = VultronOrganization(id_="https://example.org/orgs/vendor")
+        org = as_VultronOrganization(id_="https://example.org/orgs/vendor")
         self.assertIsNone(org.embargo_policy)
 
     def test_embargo_policy_inline_object(self):
         policy = _make_policy()
-        org = VultronOrganization(
+        org = as_VultronOrganization(
             id_="https://example.org/orgs/vendor",
             embargo_policy=policy,
         )
-        assert isinstance(org.embargo_policy, EmbargoPolicy)
+        assert isinstance(org.embargo_policy, as_EmbargoPolicy)
         self.assertEqual(
             timedelta(days=90), org.embargo_policy.preferred_duration
         )
 
     def test_is_instance_of_mixin(self):
-        org = VultronOrganization()
+        org = as_VultronOrganization()
         self.assertIsInstance(org, VultronActorMixin)
 
 
 class TestVultronServiceBasics(unittest.TestCase):
-    """VultronService retains Service type and supports embargo_policy."""
+    """as_VultronService retains Service type and supports embargo_policy."""
 
     def test_as_type_is_service(self):
-        svc = VultronService(id_="https://example.org/services/bot")
+        svc = as_VultronService(id_="https://example.org/services/bot")
         self.assertEqual(as_ActorType.SERVICE, svc.type_)
 
     def test_embargo_policy_defaults_to_none(self):
-        svc = VultronService(id_="https://example.org/services/bot")
+        svc = as_VultronService(id_="https://example.org/services/bot")
         self.assertIsNone(svc.embargo_policy)
 
     def test_is_instance_of_mixin(self):
-        svc = VultronService()
+        svc = as_VultronService()
         self.assertIsInstance(svc, VultronActorMixin)
 
 
@@ -154,24 +156,24 @@ class TestVultronActorTypePreservation(unittest.TestCase):
     """Subclass types remain distinct and don't override each other."""
 
     def test_person_and_org_have_different_types(self):
-        p = VultronPerson()
-        org = VultronOrganization()
+        p = as_VultronPerson()
+        org = as_VultronOrganization()
         self.assertNotEqual(p.type_, org.type_)
 
     def test_person_type_is_not_service(self):
-        p = VultronPerson()
-        svc = VultronService()
+        p = as_VultronPerson()
+        svc = as_VultronService()
         self.assertNotEqual(p.type_, svc.type_)
 
 
 class TestWireActorVocabularyAndRoundTrip(unittest.TestCase):
     def test_vocabulary_points_to_wire_actor_types(self):
         self.assertIs(VOCABULARY["Actor"], CoreActor)
-        self.assertIs(VOCABULARY["Person"], VultronPerson)
-        self.assertIs(VOCABULARY["Organization"], VultronOrganization)
-        self.assertIs(VOCABULARY["Service"], VultronService)
-        self.assertIs(VOCABULARY["Application"], VultronApplication)
-        self.assertIs(VOCABULARY["Group"], VultronGroup)
+        self.assertIs(VOCABULARY["Person"], as_VultronPerson)
+        self.assertIs(VOCABULARY["Organization"], as_VultronOrganization)
+        self.assertIs(VOCABULARY["Service"], as_VultronService)
+        self.assertIs(VOCABULARY["Application"], as_VultronApplication)
+        self.assertIs(VOCABULARY["Group"], as_VultronGroup)
 
     def test_core_person_to_wire_person_model_validate_round_trip(self):
         core_actor = CoreVultronPerson(
@@ -184,7 +186,7 @@ class TestWireActorVocabularyAndRoundTrip(unittest.TestCase):
             embargo_policy={"policy": "default"},
         )
 
-        wire_actor = VultronPerson.model_validate(
+        wire_actor = as_VultronPerson.model_validate(
             core_actor.model_dump(mode="json")
         )
 

--- a/test/wire/as2/vocab/test_wire_domain_translation.py
+++ b/test/wire/as2/vocab/test_wire_domain_translation.py
@@ -29,16 +29,18 @@ from vultron.core.models.participant_status import (
 from vultron.core.models.report import VultronReport
 from vultron.core.states.em import EM
 from vultron.core.states.rm import RM
-from vultron.wire.as2.vocab.objects.case_actor import CaseActor
-from vultron.wire.as2.vocab.objects.case_ledger_entry import CaseLedgerEntry
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+from vultron.wire.as2.vocab.objects.case_actor import as_CaseActor
+from vultron.wire.as2.vocab.objects.case_ledger_entry import as_CaseLedgerEntry
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
 from vultron.wire.as2.vocab.objects.case_status import (
-    CaseStatus,
-    ParticipantStatus,
+    as_CaseStatus,
+    as_ParticipantStatus,
 )
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 
@@ -51,9 +53,9 @@ def test_vulnerability_report_round_trips_between_core_and_wire():
         content="report body",
     )
 
-    wire = VulnerabilityReport.from_core(core)
+    wire = as_VulnerabilityReport.from_core(core)
 
-    assert isinstance(wire, VulnerabilityReport)
+    assert isinstance(wire, as_VulnerabilityReport)
     assert wire.id_ == core.id_
     assert wire.to_core() == core
 
@@ -66,9 +68,9 @@ def test_case_status_round_trips_between_core_and_wire():
         em_state=EM.PROPOSED,
     )
 
-    wire = CaseStatus.from_core(core)
+    wire = as_CaseStatus.from_core(core)
 
-    assert isinstance(wire, CaseStatus)
+    assert isinstance(wire, as_CaseStatus)
     assert wire.em_state == EM.PROPOSED
     round_tripped = wire.to_core()
     assert round_tripped.id_ == core.id_
@@ -93,9 +95,9 @@ def test_participant_status_from_core_materializes_case_status_reference():
         case_status=core_case_status,
     )
 
-    wire = ParticipantStatus.from_core(core)
+    wire = as_ParticipantStatus.from_core(core)
 
-    assert isinstance(wire.case_status, CaseStatus)
+    assert isinstance(wire.case_status, as_CaseStatus)
     assert wire.case_status.id_ == "https://example.org/cases/1/status/1"
     round_tripped = wire.to_core()
     assert round_tripped.id_ == core.id_
@@ -126,9 +128,9 @@ def test_case_participant_round_trips_between_core_and_wire():
         participant_case_name="Vendor Case Name",
     )
 
-    wire = CaseParticipant.from_core(core)
+    wire = as_CaseParticipant.from_core(core)
 
-    assert isinstance(wire, CaseParticipant)
+    assert isinstance(wire, as_CaseParticipant)
     assert wire.id_ == core.id_
     round_tripped = wire.to_core()
     assert round_tripped.id_ == core.id_
@@ -168,9 +170,9 @@ def test_vulnerability_case_round_trips_between_core_and_wire():
         sibling_cases=["https://example.org/cases/sibling"],
     )
 
-    wire = VulnerabilityCase.from_core(core)
+    wire = as_VulnerabilityCase.from_core(core)
 
-    assert isinstance(wire, VulnerabilityCase)
+    assert isinstance(wire, as_VulnerabilityCase)
     assert wire.id_ == core.id_
     round_tripped = wire.to_core()
     assert round_tripped.id_ == core.id_
@@ -187,7 +189,7 @@ def test_vulnerability_case_round_trips_between_core_and_wire():
 
 
 def test_case_ledger_entry_to_core_returns_domain_model():
-    wire = CaseLedgerEntry(
+    wire = as_CaseLedgerEntry(
         case_id="https://example.org/cases/1",
         log_index=1,
         log_object_id="https://example.org/activities/1",
@@ -210,9 +212,9 @@ def test_case_actor_round_trips_between_core_and_wire():
         context="https://example.org/cases/1",
     )
 
-    wire = CaseActor.from_core(core)
+    wire = as_CaseActor.from_core(core)
 
-    assert isinstance(wire, CaseActor)
+    assert isinstance(wire, as_CaseActor)
     assert wire.id_ == core.id_
     round_tripped = wire.to_core()
     assert round_tripped.id_ == core.id_

--- a/vultron/adapters/driven/sync_activity_adapter.py
+++ b/vultron/adapters/driven/sync_activity_adapter.py
@@ -41,7 +41,7 @@ from vultron.wire.as2.factories import (
     reject_log_entry_activity,
 )
 from vultron.wire.as2.vocab.objects.case_ledger_entry import (
-    CaseLedgerEntry as WireCaseLedgerEntry,
+    as_CaseLedgerEntry as WireCaseLedgerEntry,
 )
 
 logger = logging.getLogger(__name__)

--- a/vultron/adapters/driven/trigger_activity_adapter/actors.py
+++ b/vultron/adapters/driven/trigger_activity_adapter/actors.py
@@ -42,9 +42,11 @@ from vultron.wire.as2.factories.case import (
     offer_case_manager_role_activity,
     reject_case_manager_role_activity,
 )
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.case_status import ParticipantStatus
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.case_status import as_ParticipantStatus
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 from ._base import _DUMP_KWARGS
 
@@ -77,7 +79,7 @@ class _ActorsMixin:
         Case Actor's own ID for self-archival (CLP-10-001).
 
         ``roles`` carries the intended CVD roles for the invitee (CM-17-003).
-        ``target`` may be a core ``VulnerabilityCase`` (projected to an enriched
+        ``target`` may be a core ``as_VulnerabilityCase`` (projected to an enriched
         stub by the factory), a pre-built ``VulnerabilityCaseStub``, or a bare
         URI string.  When ``None``, the case is read from the DataLayer by
         ``case_id`` and passed to the factory with any active embargo entity for
@@ -193,10 +195,10 @@ class _ActorsMixin:
         id_: str | None = None,
         roles: list | None = None,
     ) -> tuple[str, dict[str, Any]]:
-        """Create and persist an Offer(CaseParticipant{actor, roles}, Case).
+        """Create and persist an Offer(as_CaseParticipant{actor, roles}, Case).
 
         Transforms the original Offer(Actor, Case) from a recommending
-        participant into an Offer(CaseParticipant) addressed to the Case Owner.
+        participant into an Offer(as_CaseParticipant) addressed to the Case Owner.
         ``roles`` defaults to ``[CVDRole.VENDOR]`` when ``None`` (CM-16-003).
         ``origin`` carries the original Offer ID for causal traceability
         (CM-16-004).
@@ -234,7 +236,7 @@ class _ActorsMixin:
         """Create and persist an AcceptActorRecommendation activity.
 
         Sent by the CaseActor to the recommender after the Case Owner accepts
-        the Offer(CaseParticipant) (CM-16-006 step 3).
+        the Offer(as_CaseParticipant) (CM-16-006 step 3).
         """
         recommendation = recommend_actor_activity(
             recommended=CoreActor(id_=recommended_id),
@@ -271,7 +273,7 @@ class _ActorsMixin:
         """Create and persist a RejectActorRecommendation activity.
 
         Sent by the CaseActor to the recommender after the Case Owner rejects
-        the Offer(CaseParticipant) (CM-16-007 step 3).
+        the Offer(as_CaseParticipant) (CM-16-007 step 3).
         """
         recommendation = recommend_actor_activity(
             recommended=CoreActor(id_=recommended_id),
@@ -340,8 +342,8 @@ class _ActorsMixin:
         actor: str,
         to: list[str] | None = None,
     ) -> str:
-        """Create and persist an ``Add(CaseParticipant, Case)`` activity."""
-        participant = cast(CaseParticipant, self._dl.read(participant_id))
+        """Create and persist an ``Add(as_CaseParticipant, Case)`` activity."""
+        participant = cast(as_CaseParticipant, self._dl.read(participant_id))
         activity = add_participant_to_case_activity(
             participant=participant, target=case_id, actor=actor, to=to
         )
@@ -362,23 +364,25 @@ class _ActorsMixin:
         actor: str,
         to: list[str] | None = None,
     ) -> str:
-        """Create and persist an ``Add(ParticipantStatus, CaseParticipant)`` activity."""
+        """Create and persist an ``Add(as_ParticipantStatus, as_CaseParticipant)`` activity."""
         raw = self._dl.read(status_id)
         if raw is None:
             raise VultronNotFoundError(
                 "ParticipantStatus",
                 f"status '{status_id}' not found",
             )
-        # Convert from core ParticipantStatus to wire ParticipantStatus
+        # Convert from core as_ParticipantStatus to wire as_ParticipantStatus
         # so that nested fields (case_status, pxa_state) survive the boundary.
         from vultron.core.models.participant_status import (
             ParticipantStatus as CorePS,
         )
 
         if isinstance(raw, CorePS):
-            wire_status: ParticipantStatus = ParticipantStatus.from_core(raw)
+            wire_status: as_ParticipantStatus = as_ParticipantStatus.from_core(
+                raw
+            )
         else:
-            wire_status = cast(ParticipantStatus, raw)
+            wire_status = cast(as_ParticipantStatus, raw)
         activity = add_status_to_participant_activity(
             status=wire_status, target=participant_id, actor=actor, to=to
         )
@@ -399,11 +403,11 @@ class _ActorsMixin:
         actor: str,
         to: list[str] | None = None,
     ) -> str:
-        """Create and persist an ``Offer(VulnerabilityCase, target=CaseParticipant)``
+        """Create and persist an ``Offer(as_VulnerabilityCase, target=as_CaseParticipant)``
         CASE_MANAGER delegation activity.
         """
-        case = cast(VulnerabilityCase, self._dl.read(case_id))
-        participant = cast(CaseParticipant, self._dl.read(participant_id))
+        case = cast(as_VulnerabilityCase, self._dl.read(case_id))
+        participant = cast(as_CaseParticipant, self._dl.read(participant_id))
         activity = offer_case_manager_role_activity(
             case=case, target=participant, actor=actor, to=to
         )
@@ -432,8 +436,8 @@ class _ActorsMixin:
         ``case_id``, ``participant_id``, and ``vendor_id`` so that
         ``Accept.object_`` is a typed ``_OfferCaseManagerRoleActivity``.
         """
-        case = cast(VulnerabilityCase, self._dl.read(case_id))
-        participant = cast(CaseParticipant, self._dl.read(participant_id))
+        case = cast(as_VulnerabilityCase, self._dl.read(case_id))
+        participant = cast(as_CaseParticipant, self._dl.read(participant_id))
         offer = offer_case_manager_role_activity(
             case=case,
             target=participant,
@@ -468,8 +472,8 @@ class _ActorsMixin:
         ``case_id``, ``participant_id``, and ``vendor_id`` so that
         ``Reject.object_`` is a typed ``_OfferCaseManagerRoleActivity``.
         """
-        case = cast(VulnerabilityCase, self._dl.read(case_id))
-        participant = cast(CaseParticipant, self._dl.read(participant_id))
+        case = cast(as_VulnerabilityCase, self._dl.read(case_id))
+        participant = cast(as_CaseParticipant, self._dl.read(participant_id))
         offer = offer_case_manager_role_activity(
             case=case,
             target=participant,

--- a/vultron/adapters/driven/trigger_activity_adapter/cases.py
+++ b/vultron/adapters/driven/trigger_activity_adapter/cases.py
@@ -29,9 +29,11 @@ from vultron.wire.as2.factories.case import (
     create_case_proposal_activity,
 )
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Add
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 from ._base import _DUMP_KWARGS
@@ -40,7 +42,7 @@ logger = logging.getLogger(__name__)
 
 
 class _CasesMixin:
-    """Trigger activity methods for VulnerabilityCase objects."""
+    """Trigger activity methods for as_VulnerabilityCase objects."""
 
     _dl: CaseOutboxPersistence
 
@@ -50,8 +52,8 @@ class _CasesMixin:
         actor: str,
         to: list[str] | None = None,
     ) -> tuple[str, dict[str, Any]]:
-        """Create and persist a ``Create(VulnerabilityCase)`` activity."""
-        case = cast(VulnerabilityCase, self._dl.read(case_id))
+        """Create and persist a ``Create(as_VulnerabilityCase)`` activity."""
+        case = cast(as_VulnerabilityCase, self._dl.read(case_id))
         activity = create_case_activity(case=case, actor=actor, to=to)
         try:
             self._dl.create(activity)
@@ -68,8 +70,8 @@ class _CasesMixin:
         actor: str,
         to: list[str] | None = None,
     ) -> tuple[str, dict[str, Any]]:
-        """Create and persist an ``Accept(VulnerabilityCase)`` engage activity."""
-        case = cast(VulnerabilityCase, self._dl.read(case_id))
+        """Create and persist an ``Accept(as_VulnerabilityCase)`` engage activity."""
+        case = cast(as_VulnerabilityCase, self._dl.read(case_id))
         activity = rm_engage_case_activity(case=case, actor=actor, to=to)
         try:
             self._dl.create(activity)
@@ -86,8 +88,8 @@ class _CasesMixin:
         actor: str,
         to: list[str] | None = None,
     ) -> tuple[str, dict[str, Any]]:
-        """Create and persist a ``TentativeReject(VulnerabilityCase)`` activity."""
-        case = cast(VulnerabilityCase, self._dl.read(case_id))
+        """Create and persist a ``TentativeReject(as_VulnerabilityCase)`` activity."""
+        case = cast(as_VulnerabilityCase, self._dl.read(case_id))
         activity = rm_defer_case_activity(case=case, actor=actor, to=to)
         try:
             self._dl.create(activity)
@@ -104,10 +106,10 @@ class _CasesMixin:
         actor: str,
         to: list[str] | None = None,
     ) -> tuple[str, dict[str, Any]]:
-        """Create and persist a ``Leave(VulnerabilityCase)`` close-case activity."""
+        """Create and persist a ``Leave(as_VulnerabilityCase)`` close-case activity."""
         from vultron.wire.as2.factories import rm_close_case_activity
 
-        case = cast(VulnerabilityCase, self._dl.read(case_id))
+        case = cast(as_VulnerabilityCase, self._dl.read(case_id))
         activity = rm_close_case_activity(case=case, actor=actor, to=to)
         try:
             self._dl.create(activity)
@@ -144,7 +146,7 @@ class _CasesMixin:
         context_id: str,
         to: list[str],
     ) -> str:
-        """Create and persist an ``Announce(VulnerabilityCase)`` activity.
+        """Create and persist an ``Announce(as_VulnerabilityCase)`` activity.
 
         Reads the full case from the DataLayer, constructs the activity with
         the case inline, and persists it.  Returns the activity ID for outbox
@@ -153,7 +155,7 @@ class _CasesMixin:
         Per MV-10-003: the case owner sends this after an ``Accept(Invite)``
         is received and the invitee's embargo consent has been verified.
         """
-        case = cast(VulnerabilityCase, self._dl.read(case_id))
+        case = cast(as_VulnerabilityCase, self._dl.read(case_id))
         activity = announce_vulnerability_case_activity(
             case=case,
             actor=actor,
@@ -180,7 +182,7 @@ class _CasesMixin:
     ) -> tuple[str, dict[str, Any]]:
         """Create and persist a ``Create(as_CaseProposal)`` activity.
 
-        Reads the ``VulnerabilityReport`` identified by ``report_id``,
+        Reads the ``as_VulnerabilityReport`` identified by ``report_id``,
         constructs an ``as_CaseProposal``, and persists
         ``Create(as_CaseProposal)`` to the DataLayer.
 
@@ -196,7 +198,7 @@ class _CasesMixin:
                 f"create_case_proposal: report '{report_id}' not found"
                 " in DataLayer"
             )
-        report = cast(VulnerabilityReport, report_obj)
+        report = cast(as_VulnerabilityReport, report_obj)
         proposal = as_CaseProposal(
             attributed_to=actor,
             object_=report,

--- a/vultron/adapters/driven/trigger_activity_adapter/embargo.py
+++ b/vultron/adapters/driven/trigger_activity_adapter/embargo.py
@@ -26,7 +26,7 @@ from vultron.wire.as2.factories import (
     em_reject_embargo_activity,
     remove_embargo_from_case_activity,
 )
-from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
 
 from ._base import _DUMP_KWARGS
 
@@ -45,8 +45,8 @@ class _EmbargoMixin:
         actor: str,
         to: list[str] | None = None,
     ) -> tuple[str, dict[str, Any]]:
-        """Create and persist an ``Invite(EmbargoEvent, Case)`` proposal."""
-        embargo = cast(EmbargoEvent, self._dl.read(embargo_id))
+        """Create and persist an ``Invite(as_EmbargoEvent, Case)`` proposal."""
+        embargo = cast(as_EmbargoEvent, self._dl.read(embargo_id))
         activity = em_propose_embargo_activity(
             embargo=embargo, context=case_id, actor=actor, to=to
         )
@@ -108,8 +108,8 @@ class _EmbargoMixin:
         actor: str,
         to: list[str] | None = None,
     ) -> tuple[str, dict[str, Any]]:
-        """Create and persist an ``Announce(EmbargoEvent)`` activity."""
-        embargo = cast(EmbargoEvent, self._dl.read(embargo_id))
+        """Create and persist an ``Announce(as_EmbargoEvent)`` activity."""
+        embargo = cast(as_EmbargoEvent, self._dl.read(embargo_id))
         activity = announce_embargo_activity(
             embargo=embargo, context=case_id, actor=actor, to=to
         )
@@ -129,8 +129,8 @@ class _EmbargoMixin:
         actor: str,
         to: list[str] | None = None,
     ) -> tuple[str, dict[str, Any]]:
-        """Create and persist a ``Remove(EmbargoEvent, origin=case)`` ET activity."""
-        embargo = cast(EmbargoEvent, self._dl.read(embargo_id))
+        """Create and persist a ``Remove(as_EmbargoEvent, origin=case)`` ET activity."""
+        embargo = cast(as_EmbargoEvent, self._dl.read(embargo_id))
         activity = remove_embargo_from_case_activity(
             embargo=embargo, origin=case_id, actor=actor, to=to
         )

--- a/vultron/adapters/driven/trigger_activity_adapter/reports.py
+++ b/vultron/adapters/driven/trigger_activity_adapter/reports.py
@@ -26,7 +26,7 @@ from vultron.wire.as2.factories import (
     rm_validate_report_activity,
 )
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 from ._base import _DUMP_KWARGS
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 
 
 class _ReportsMixin:
-    """Trigger activity methods for VulnerabilityReport objects."""
+    """Trigger activity methods for as_VulnerabilityReport objects."""
 
     _dl: CaseOutboxPersistence
 
@@ -46,8 +46,8 @@ class _ReportsMixin:
         to: str,
         target: str,
     ) -> tuple[str, dict[str, Any]]:
-        """Create and persist an ``Offer(VulnerabilityReport)`` activity."""
-        report = cast(VulnerabilityReport, self._dl.read(report_id))
+        """Create and persist an ``Offer(as_VulnerabilityReport)`` activity."""
+        report = cast(as_VulnerabilityReport, self._dl.read(report_id))
         activity = rm_submit_report_activity(
             report=report, to=to, actor=actor, target=target
         )

--- a/vultron/adapters/driving/fastapi/outbox_delivery.py
+++ b/vultron/adapters/driving/fastapi/outbox_delivery.py
@@ -43,7 +43,9 @@ from vultron.errors import (
 )
 from vultron.wire.as2.vocab.base.links import as_Link
 from vultron.wire.as2.vocab.objects.case_proposal import as_CaseProposal
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +55,7 @@ logger = logging.getLogger(__name__)
 # .model_validate() round-trip.
 _STUB_OBJECT_MODEL_MAP: dict[str, type[BaseModel]] = {
     "CaseProposal": as_CaseProposal,
-    "VulnerabilityCase": VulnerabilityCase,
+    "VulnerabilityCase": as_VulnerabilityCase,
 }
 
 _INLINE_OBJECT_ACTIVITY_TYPES: frozenset[str] = frozenset(

--- a/vultron/adapters/driving/fastapi/routers/datalayer.py
+++ b/vultron/adapters/driving/fastapi/routers/datalayer.py
@@ -32,14 +32,14 @@ from vultron.wire.as2.vocab.base.objects.collections import (
     as_OrderedCollection,
 )
 from vultron.wire.as2.vocab.objects.vultron_actor import (
-    VultronApplication,
-    VultronGroup,
-    VultronOrganization,
-    VultronPerson,
-    VultronService,
+    as_VultronApplication,
+    as_VultronGroup,
+    as_VultronOrganization,
+    as_VultronPerson,
+    as_VultronService,
 )
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 router = APIRouter(prefix="/datalayer", tags=["datalayer"])
@@ -79,7 +79,7 @@ def get_offer(
 
 @router.get(
     "/Report/",
-    response_model=VulnerabilityReport,
+    response_model=as_VulnerabilityReport,
     operation_id="datalayer_get_report",
 )
 def get_report(
@@ -88,7 +88,7 @@ def get_report(
     obj = datalayer.read(id)
     if not obj:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
-    return AS2JSONResponse(VulnerabilityReport.model_validate(obj))
+    return AS2JSONResponse(as_VulnerabilityReport.model_validate(obj))
 
 
 @router.get(
@@ -162,7 +162,7 @@ def get_offers(
 
 @router.get(
     "/Reports/",
-    description="Returns all VulnerabilityReport objects.",
+    description="Returns all as_VulnerabilityReport objects.",
     operation_id="datalayer_list_reports",
 )
 def get_reports(
@@ -172,7 +172,7 @@ def get_reports(
 
     return AS2JSONResponse(
         {
-            k: VulnerabilityReport.model_validate(v).model_dump(
+            k: as_VulnerabilityReport.model_validate(v).model_dump(
                 mode="json", by_alias=True, exclude_none=True
             )
             for k, v in results.items()
@@ -181,11 +181,11 @@ def get_reports(
 
 
 _DATALAYER_ACTOR_TYPE_MAP: dict[str, type[as_Actor]] = {
-    "Person": VultronPerson,
-    "Organization": VultronOrganization,
-    "Service": VultronService,
-    "Application": VultronApplication,
-    "Group": VultronGroup,
+    "Person": as_VultronPerson,
+    "Organization": as_VultronOrganization,
+    "Service": as_VultronService,
+    "Application": as_VultronApplication,
+    "Group": as_VultronGroup,
 }
 
 

--- a/vultron/adapters/driving/fastapi/routers/demo_triggers.py
+++ b/vultron/adapters/driving/fastapi/routers/demo_triggers.py
@@ -60,7 +60,7 @@ from vultron.adapters.driving.fastapi.trigger_models import (
 from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
 from vultron.core.models.protocols import is_case_model
 from vultron.wire.as2.vocab.objects.case_ledger_entry import (
-    CaseLedgerEntry as WireCaseLedgerEntry,
+    as_CaseLedgerEntry as WireCaseLedgerEntry,
 )
 from vultron.core.ports.datalayer import ActorScopedDataLayer, DataLayer
 from vultron.core.ports.trigger_service import TriggerServicePort

--- a/vultron/adapters/driving/fastapi/routers/examples.py
+++ b/vultron/adapters/driving/fastapi/routers/examples.py
@@ -23,23 +23,25 @@ from fastapi import APIRouter
 from vultron.adapters.driving.fastapi.responses import AS2JSONResponse
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.base.objects.object_types import as_Note
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
 from vultron.wire.as2.vocab.objects.case_status import (
-    CaseStatus,
-    ParticipantStatus,
+    as_CaseStatus,
+    as_ParticipantStatus,
 )
-from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
-from vultron.wire.as2.vocab.objects.embargo_policy import EmbargoPolicy
+from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
+from vultron.wire.as2.vocab.objects.embargo_policy import as_EmbargoPolicy
 from vultron.wire.as2.vocab.objects.vultron_actor import (
-    VultronApplication,
-    VultronGroup,
-    VultronOrganization,
-    VultronPerson,
-    VultronService,
+    as_VultronApplication,
+    as_VultronGroup,
+    as_VultronOrganization,
+    as_VultronPerson,
+    as_VultronService,
 )
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 from vultron.wire.as2.vocab.examples import vocab_examples
 
@@ -47,9 +49,9 @@ _ACTORS_BASE = "https://example.org/actors"
 _PREFERRED_DURATION = timedelta(days=90)
 
 
-def _embargo_policy(actor_id: str) -> EmbargoPolicy:
-    """Build a minimal EmbargoPolicy for the given actor ID."""
-    return EmbargoPolicy(
+def _embargo_policy(actor_id: str) -> as_EmbargoPolicy:
+    """Build a minimal as_EmbargoPolicy for the given actor ID."""
+    return as_EmbargoPolicy(
         actor_id=actor_id,
         inbox=f"{actor_id}/inbox",
         preferred_duration=_PREFERRED_DURATION,
@@ -95,15 +97,15 @@ def validate_actor(actor: as_Actor) -> AS2JSONResponse:
 
 @router.get(
     "/actors/person",
-    response_model=VultronPerson,
-    description="Get an example VultronPerson actor object.",
+    response_model=as_VultronPerson,
+    description="Get an example as_VultronPerson actor object.",
     operation_id="examples_get_actor_person",
 )
 def get_example_actor_person() -> AS2JSONResponse:
-    """Returns an example VultronPerson actor with an inline EmbargoPolicy."""
+    """Returns an example as_VultronPerson actor with an inline as_EmbargoPolicy."""
     actor_id = f"{_ACTORS_BASE}/alice"
     return AS2JSONResponse(
-        VultronPerson(
+        as_VultronPerson(
             id_=actor_id,
             name="Alice (Example Person)",
             embargo_policy=_embargo_policy(actor_id),
@@ -113,15 +115,15 @@ def get_example_actor_person() -> AS2JSONResponse:
 
 @router.get(
     "/actors/organization",
-    response_model=VultronOrganization,
-    description="Get an example VultronOrganization actor object.",
+    response_model=as_VultronOrganization,
+    description="Get an example as_VultronOrganization actor object.",
     operation_id="examples_get_actor_organization",
 )
 def get_example_actor_organization() -> AS2JSONResponse:
-    """Returns an example VultronOrganization actor with an inline EmbargoPolicy."""
+    """Returns an example as_VultronOrganization actor with an inline as_EmbargoPolicy."""
     actor_id = f"{_ACTORS_BASE}/acme-inc"
     return AS2JSONResponse(
-        VultronOrganization(
+        as_VultronOrganization(
             id_=actor_id,
             name="ACME Inc. (Example Organization)",
             embargo_policy=_embargo_policy(actor_id),
@@ -131,15 +133,15 @@ def get_example_actor_organization() -> AS2JSONResponse:
 
 @router.get(
     "/actors/service",
-    response_model=VultronService,
-    description="Get an example VultronService actor object.",
+    response_model=as_VultronService,
+    description="Get an example as_VultronService actor object.",
     operation_id="examples_get_actor_service",
 )
 def get_example_actor_service() -> AS2JSONResponse:
-    """Returns an example VultronService actor with an inline EmbargoPolicy."""
+    """Returns an example as_VultronService actor with an inline as_EmbargoPolicy."""
     actor_id = f"{_ACTORS_BASE}/vultron-bot"
     return AS2JSONResponse(
-        VultronService(
+        as_VultronService(
             id_=actor_id,
             name="Vultron Bot (Example Service)",
             embargo_policy=_embargo_policy(actor_id),
@@ -149,15 +151,15 @@ def get_example_actor_service() -> AS2JSONResponse:
 
 @router.get(
     "/actors/application",
-    response_model=VultronApplication,
-    description="Get an example VultronApplication actor object.",
+    response_model=as_VultronApplication,
+    description="Get an example as_VultronApplication actor object.",
     operation_id="examples_get_actor_application",
 )
 def get_example_actor_application() -> AS2JSONResponse:
-    """Returns an example VultronApplication actor with an inline EmbargoPolicy."""
+    """Returns an example as_VultronApplication actor with an inline as_EmbargoPolicy."""
     actor_id = f"{_ACTORS_BASE}/vultron-app"
     return AS2JSONResponse(
-        VultronApplication(
+        as_VultronApplication(
             id_=actor_id,
             name="Vultron App (Example Application)",
             embargo_policy=_embargo_policy(actor_id),
@@ -167,15 +169,15 @@ def get_example_actor_application() -> AS2JSONResponse:
 
 @router.get(
     "/actors/group",
-    response_model=VultronGroup,
-    description="Get an example VultronGroup actor object.",
+    response_model=as_VultronGroup,
+    description="Get an example as_VultronGroup actor object.",
     operation_id="examples_get_actor_group",
 )
 def get_example_actor_group() -> AS2JSONResponse:
-    """Returns an example VultronGroup actor with an inline EmbargoPolicy."""
+    """Returns an example as_VultronGroup actor with an inline as_EmbargoPolicy."""
     actor_id = f"{_ACTORS_BASE}/security-team"
     return AS2JSONResponse(
-        VultronGroup(
+        as_VultronGroup(
             id_=actor_id,
             name="Security Team (Example Group)",
             embargo_policy=_embargo_policy(actor_id),
@@ -185,139 +187,139 @@ def get_example_actor_group() -> AS2JSONResponse:
 
 @router.get(
     "/reports",
-    response_model=VulnerabilityReport,
+    response_model=as_VulnerabilityReport,
     description="Get an example Vulnerability Report object.",
     operation_id="examples_get_report",
 )
 def get_example_report() -> AS2JSONResponse:
-    """Returns an example VulnerabilityReport object."""
+    """Returns an example as_VulnerabilityReport object."""
     return AS2JSONResponse(vocab_examples.gen_report())
 
 
 @router.post(
     "/reports",
-    response_model=VulnerabilityReport,
+    response_model=as_VulnerabilityReport,
     summary="Validate Report object format",
     description="Validates a Vulnerability Report object.",
     operation_id="examples_validate_report",
 )
-def validate_report(report: VulnerabilityReport) -> AS2JSONResponse:
-    """Validates a VulnerabilityReport object."""
+def validate_report(report: as_VulnerabilityReport) -> AS2JSONResponse:
+    """Validates a as_VulnerabilityReport object."""
     return AS2JSONResponse(report)
 
 
 @router.get(
     "/cases",
-    response_model=VulnerabilityCase,
+    response_model=as_VulnerabilityCase,
     description="Get an example Vulnerability Case object.",
     operation_id="examples_get_case",
 )
 def get_example_case() -> AS2JSONResponse:
-    """Returns an example VulnerabilityCase object."""
+    """Returns an example as_VulnerabilityCase object."""
     return AS2JSONResponse(vocab_examples.case())
 
 
 @router.post(
     "/cases",
-    response_model=VulnerabilityCase,
+    response_model=as_VulnerabilityCase,
     summary="Validate Case object format",
     description="Validates a Vulnerability Case object.",
     operation_id="examples_validate_case",
 )
-def validate_case(case: VulnerabilityCase) -> AS2JSONResponse:
-    """Validates a VulnerabilityCase object."""
+def validate_case(case: as_VulnerabilityCase) -> AS2JSONResponse:
+    """Validates a as_VulnerabilityCase object."""
     return AS2JSONResponse(case)
 
 
 @router.get(
     "/cases/statuses",
-    response_model=CaseStatus,
+    response_model=as_CaseStatus,
     description="Get an example Case Status object.",
     operation_id="examples_get_case_status",
 )
 def get_example_case_status() -> AS2JSONResponse:
-    """Returns an example CaseStatus object."""
+    """Returns an example as_CaseStatus object."""
     return AS2JSONResponse(vocab_examples.case_status())
 
 
 @router.post(
     "/cases/statuses",
-    response_model=CaseStatus,
-    description="Validates a CaseStatus object.",
+    response_model=as_CaseStatus,
+    description="Validates a as_CaseStatus object.",
     operation_id="examples_validate_case_status",
 )
-def validate_case_status(case_status: CaseStatus) -> AS2JSONResponse:
-    """Validates a CaseStatus object."""
+def validate_case_status(case_status: as_CaseStatus) -> AS2JSONResponse:
+    """Validates a as_CaseStatus object."""
     return AS2JSONResponse(case_status)
 
 
 @router.get(
     "/cases/participants",
-    response_model=CaseParticipant,
+    response_model=as_CaseParticipant,
     description="Get an example Case Participant object.",
     operation_id="examples_get_participant",
 )
 def get_example_participant() -> AS2JSONResponse:
-    """Returns an example CaseParticipant object."""
+    """Returns an example as_CaseParticipant object."""
     return AS2JSONResponse(vocab_examples.case_participant())
 
 
 @router.post(
     "/cases/participants",
-    response_model=CaseParticipant,
+    response_model=as_CaseParticipant,
     summary="Validate Case Participant object format",
     description="Validates a Case Participant object.",
     operation_id="examples_validate_participant",
 )
-def validate_participant(participant: CaseParticipant) -> AS2JSONResponse:
-    """Validates a CaseParticipant object."""
+def validate_participant(participant: as_CaseParticipant) -> AS2JSONResponse:
+    """Validates a as_CaseParticipant object."""
     return AS2JSONResponse(participant)
 
 
 @router.get(
     "/cases/participants/statuses",
-    response_model=ParticipantStatus,
+    response_model=as_ParticipantStatus,
     description="Get an example Participant Status object.",
     operation_id="examples_get_participant_status",
 )
 def get_example_participant_status() -> AS2JSONResponse:
-    """Returns an example ParticipantStatus object."""
+    """Returns an example as_ParticipantStatus object."""
     return AS2JSONResponse(vocab_examples.participant_status())
 
 
 @router.post(
     "/cases/participants/statuses",
-    response_model=ParticipantStatus,
-    description="Validates a ParticipantStatus object.",
+    response_model=as_ParticipantStatus,
+    description="Validates a as_ParticipantStatus object.",
     operation_id="examples_validate_participant_status",
 )
 def validate_participant_status(
-    status: ParticipantStatus,
+    status: as_ParticipantStatus,
 ) -> AS2JSONResponse:
-    """Validates a ParticipantStatus object."""
+    """Validates a as_ParticipantStatus object."""
     return AS2JSONResponse(status)
 
 
 @router.get(
     "/cases/embargoes",
-    response_model=EmbargoEvent,
+    response_model=as_EmbargoEvent,
     description="Get an example Embargo Event object.",
     operation_id="examples_get_embargo",
 )
 def get_example_embargo() -> AS2JSONResponse:
-    """Returns an example EmbargoEvent object."""
+    """Returns an example as_EmbargoEvent object."""
     return AS2JSONResponse(vocab_examples.embargo_event())
 
 
 @router.post(
     "/cases/embargoes",
-    response_model=EmbargoEvent,
+    response_model=as_EmbargoEvent,
     summary="Validate Embargo Event object format",
-    description="Validates an EmbargoEvent object.",
+    description="Validates an as_EmbargoEvent object.",
     operation_id="examples_validate_embargo",
 )
-def validate_embargo(embargo: EmbargoEvent) -> AS2JSONResponse:
-    """Validates an EmbargoEvent object."""
+def validate_embargo(embargo: as_EmbargoEvent) -> AS2JSONResponse:
+    """Validates an as_EmbargoEvent object."""
     return AS2JSONResponse(embargo)
 
 

--- a/vultron/demo/exchange/acknowledge_demo.py
+++ b/vultron/demo/exchange/acknowledge_demo.py
@@ -51,7 +51,7 @@ from typing import Callable, Optional, Sequence, Tuple
 from vultron.adapters.utils import parse_id
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monkeypatching
     BASE_URL,
@@ -141,7 +141,7 @@ def demo_acknowledge_only(
     logger.info("=" * 80)
 
     with demo_step("Step 1: Finder submits vulnerability report to vendor"):
-        report = VulnerabilityReport(
+        report = as_VulnerabilityReport(
             attributed_to=finder.id_,
             content="Possible integer overflow in the network parsing library.",
             name="Network Parser Integer Overflow",
@@ -203,7 +203,7 @@ def demo_acknowledge_then_validate(
     logger.info("=" * 80)
 
     with demo_step("Step 1: Finder submits vulnerability report to vendor"):
-        report = VulnerabilityReport(
+        report = as_VulnerabilityReport(
             attributed_to=finder.id_,
             content=(
                 "SQL injection in the admin login form — confirmed via manual testing."
@@ -282,7 +282,7 @@ def demo_acknowledge_then_invalidate(
     logger.info("=" * 80)
 
     with demo_step("Step 1: Finder submits vulnerability report to vendor"):
-        report = VulnerabilityReport(
+        report = as_VulnerabilityReport(
             attributed_to=finder.id_,
             content=(
                 "Crash when submitting empty form — no security impact confirmed."

--- a/vultron/demo/exchange/case_proposal_demo.py
+++ b/vultron/demo/exchange/case_proposal_demo.py
@@ -55,7 +55,7 @@ from typing import Callable, Optional, Sequence
 
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monkeypatching
     BASE_URL,
@@ -91,7 +91,7 @@ def demo_case_proposal_round_trip(
             case-actor service).
     """
     with demo_step("Step 1: Finder submits vulnerability report to vendor"):
-        report = VulnerabilityReport(
+        report = as_VulnerabilityReport(
             attributed_to=finder.id_,
             name="CP-07-003 demo report",
             content=(

--- a/vultron/demo/exchange/establish_embargo_demo.py
+++ b/vultron/demo/exchange/establish_embargo_demo.py
@@ -50,13 +50,15 @@ from typing import Callable, Optional, Sequence, Tuple
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Create
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.objects.case_participant import (
-    CaseParticipant,
+    as_CaseParticipant,
 )
 from vultron.enums.roles import CVDRole
-from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monkeypatching
     BASE_URL,
@@ -91,9 +93,9 @@ logger = logging.getLogger(__name__)
 
 
 def _make_embargo_event(
-    case: VulnerabilityCase, days: int = 90
-) -> EmbargoEvent:
-    """Create a deterministic EmbargoEvent for a given case."""
+    case: as_VulnerabilityCase, days: int = 90
+) -> as_EmbargoEvent:
+    """Create a deterministic as_EmbargoEvent for a given case."""
     now = datetime.now().astimezone()
     now = now.replace(second=0, microsecond=0)
     end_at = (now + timedelta(days=days)).replace(
@@ -101,7 +103,7 @@ def _make_embargo_event(
     )
     # Use a URL-safe date string (no colons) for the ID path segment
     end_date_str = end_at.strftime("%Y-%m-%d")
-    return EmbargoEvent(
+    return as_EmbargoEvent(
         id_=f"{case.id_}/embargo_events/{days}d-{end_date_str}",
         name=f"Embargo for {case.name}",
         context=case.id_,
@@ -116,7 +118,7 @@ def _setup_two_participant_case(
     finder: as_Actor,
     vendor: as_Actor,
     coordinator: as_Actor,
-) -> VulnerabilityCase:
+) -> as_VulnerabilityCase:
     """
     Set up a case with two participants (vendor + coordinator) as a
     precondition for the embargo workflow.
@@ -129,7 +131,7 @@ def _setup_two_participant_case(
     5. Vendor adds finder as FinderReporter participant
     6. Vendor invites coordinator; coordinator accepts → coordinator added
     """
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         attributed_to=finder.id_,
         content="A use-after-free vulnerability in the network stack.",
         name="Use-After-Free in Network Stack",
@@ -148,7 +150,7 @@ def _setup_two_participant_case(
     )
     post_to_inbox_and_wait(client, vendor.id_, validate_activity)
 
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         attributed_to=vendor.id_,
         name="UAF Case — Network Stack",
         content="Tracking the use-after-free vulnerability in the network stack.",
@@ -162,7 +164,7 @@ def _setup_two_participant_case(
     )
     post_to_inbox_and_wait(client, vendor.id_, add_report_activity)
 
-    participant = CaseParticipant(
+    participant = as_CaseParticipant(
         case_roles=[CVDRole.FINDER, CVDRole.REPORTER],
         attributed_to=finder.id_,
         context=case.id_,

--- a/vultron/demo/exchange/initialize_case_demo.py
+++ b/vultron/demo/exchange/initialize_case_demo.py
@@ -19,10 +19,10 @@ Demonstrates the workflow for initializing a vulnerability case via the Vultron 
 This demo script showcases the case initialization process:
 
 1. Setup: submit a vulnerability report (precondition for case creation)
-2. Create Case: vendor explicitly creates a VulnerabilityCase
+2. Create Case: vendor explicitly creates a as_VulnerabilityCase
 3. Add Vendor as Participant: vendor adds themselves as case creator/owner
 4. Add Report to Case: vendor links the submitted report to the case
-5. Create Participant: vendor creates a CaseParticipant for the finder
+5. Create Participant: vendor creates a as_CaseParticipant for the finder
 6. Add Participant to Case: vendor adds the finder participant to the case
 7. Show final case state
 
@@ -49,14 +49,16 @@ from typing import Callable, Optional, Sequence, Tuple
 # Vultron imports
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Create
 from vultron.wire.as2.vocab.objects.case_participant import (
-    CaseParticipant,
+    as_CaseParticipant,
 )
 from vultron.enums.roles import CVDRole
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monkeypatching
     BASE_URL,
     DataLayerClient,
@@ -92,7 +94,7 @@ def demo_initialize_case(
     Steps:
     1. Finder submits a vulnerability report to vendor inbox
     2. Vendor validates the report (RmValidateReportActivity)
-    3. Vendor explicitly creates a VulnerabilityCase (CreateCaseActivity)
+    3. Vendor explicitly creates a as_VulnerabilityCase (CreateCaseActivity)
     4. Vendor adds themselves as VendorParticipant (case creator/owner)
     5. Vendor adds the report to the case (AddReportToCaseActivity)
     6. Vendor creates a FinderReporterParticipant for the finder
@@ -109,7 +111,7 @@ def demo_initialize_case(
     logger.info("=" * 80)
 
     with demo_step("Step 1: Finder submits vulnerability report to vendor"):
-        report = VulnerabilityReport(
+        report = as_VulnerabilityReport(
             attributed_to=finder.id_,
             content="A remote code execution vulnerability in the web framework.",
             name="Remote Code Execution Vulnerability",
@@ -132,7 +134,7 @@ def demo_initialize_case(
         post_to_inbox_and_wait(client, vendor.id_, validate_activity)
 
     with demo_step("Step 3: Vendor creates vulnerability case"):
-        case = VulnerabilityCase(
+        case = as_VulnerabilityCase(
             attributed_to=vendor.id_,
             name="RCE Case — Web Framework",
             content="Tracking the RCE vulnerability in the web framework.",
@@ -146,7 +148,7 @@ def demo_initialize_case(
             log_case_state(client, case.id_, "after CreateCaseActivity")
 
     with demo_step("Step 4: Vendor adds themselves as case participant"):
-        vendor_participant = CaseParticipant(
+        vendor_participant = as_CaseParticipant(
             case_roles=[CVDRole.VENDOR],
             attributed_to=vendor.id_,
             context=case.id_,
@@ -202,7 +204,7 @@ def demo_initialize_case(
                 )
 
     with demo_step("Step 6: Vendor creates finder participant"):
-        participant = CaseParticipant(
+        participant = as_CaseParticipant(
             case_roles=[CVDRole.FINDER, CVDRole.REPORTER],
             attributed_to=finder.id_,
             context=case.id_,

--- a/vultron/demo/exchange/initialize_participant_demo.py
+++ b/vultron/demo/exchange/initialize_participant_demo.py
@@ -14,7 +14,7 @@
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
 """
-Demonstrates the workflow for initializing a CaseParticipant via the Vultron API.
+Demonstrates the workflow for initializing a as_CaseParticipant via the Vultron API.
 
 This demo script showcases the standalone participant initialization process:
 
@@ -47,12 +47,14 @@ from typing import Callable, Optional, Sequence, Tuple
 # Vultron imports
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.objects.case_participant import (
-    CaseParticipant,
+    as_CaseParticipant,
 )
 from vultron.enums.roles import CVDRole
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monkeypatching
     BASE_URL,
@@ -85,7 +87,7 @@ def setup_case_precondition(
     client: DataLayerClient,
     finder: as_Actor,
     vendor: as_Actor,
-) -> Tuple[VulnerabilityReport, VulnerabilityCase]:
+) -> Tuple[as_VulnerabilityReport, as_VulnerabilityCase]:
     """
     Sets up the precondition for the demo: a case owned by the vendor with
     a validated report and vendor as the only participant.
@@ -98,7 +100,7 @@ def setup_case_precondition(
     """
     logger.info("Setting up case precondition...")
 
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         attributed_to=finder.id_,
         content="An integer overflow vulnerability in the network stack.",
         name="Integer Overflow in Network Stack",
@@ -116,7 +118,7 @@ def setup_case_precondition(
     )
     post_to_inbox_and_wait(client, vendor.id_, validate_activity)
 
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         attributed_to=vendor.id_,
         name="Integer Overflow Case — Network Stack",
         content="Tracking the integer overflow vulnerability in the network stack.",
@@ -140,9 +142,9 @@ def demo_initialize_participant(
     coordinator: as_Actor,
 ):
     """
-    Demonstrates the standalone CaseParticipant initialization workflow.
+    Demonstrates the standalone as_CaseParticipant initialization workflow.
 
-    Precondition: An existing VulnerabilityCase with vendor as the owner and
+    Precondition: An existing as_VulnerabilityCase with vendor as the owner and
     sole participant is set up before the demo begins.
 
     Steps:
@@ -174,7 +176,7 @@ def demo_initialize_participant(
     with demo_step(
         "Step 1: Vendor creates coordinator participant (standalone)"
     ):
-        coordinator_participant = CaseParticipant(
+        coordinator_participant = as_CaseParticipant(
             case_roles=[CVDRole.COORDINATOR],
             attributed_to=coordinator.id_,
             context=case.id_,
@@ -214,7 +216,7 @@ def demo_initialize_participant(
     with demo_step(
         "Step 3: Vendor creates finder/reporter participant (standalone)"
     ):
-        finder_participant = CaseParticipant(
+        finder_participant = as_CaseParticipant(
             case_roles=[CVDRole.FINDER, CVDRole.REPORTER],
             attributed_to=finder.id_,
             context=case.id_,

--- a/vultron/demo/exchange/invite_actor_demo.py
+++ b/vultron/demo/exchange/invite_actor_demo.py
@@ -52,12 +52,14 @@ from typing import Callable, Optional, Sequence, Tuple
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Create
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.objects.case_participant import (
-    CaseParticipant,
+    as_CaseParticipant,
 )
 from vultron.enums.roles import CVDRole
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monkeypatching
     BASE_URL,
@@ -107,14 +109,14 @@ def _setup_initialized_case(
     client: DataLayerClient,
     finder: as_Actor,
     vendor: as_Actor,
-) -> VulnerabilityCase:
+) -> as_VulnerabilityCase:
     """
     Set up an initialized case as a precondition for the invite workflow.
 
     Mirrors demo_initialize_case from initialize_case_demo but returns the
-    VulnerabilityCase so subsequent steps can reference it.
+    as_VulnerabilityCase so subsequent steps can reference it.
     """
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         attributed_to=finder.id_,
         content="A remote code execution vulnerability in the web framework.",
         name="Remote Code Execution Vulnerability",
@@ -133,7 +135,7 @@ def _setup_initialized_case(
     )
     post_to_inbox_and_wait(client, vendor.id_, validate_activity)
 
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         attributed_to=vendor.id_,
         name="RCE Case — Web Framework",
         content="Tracking the RCE vulnerability in the web framework.",
@@ -147,7 +149,7 @@ def _setup_initialized_case(
     )
     post_to_inbox_and_wait(client, vendor.id_, add_report_activity)
 
-    participant = CaseParticipant(
+    participant = as_CaseParticipant(
         case_roles=[CVDRole.FINDER, CVDRole.REPORTER],
         attributed_to=finder.id_,
         context=case.id_,

--- a/vultron/demo/exchange/manage_case_demo.py
+++ b/vultron/demo/exchange/manage_case_demo.py
@@ -30,7 +30,7 @@ Key activities demonstrated:
 - RmSubmitReportActivity (as:Offer) — finder submits a report to vendor
 - RmValidateReportActivity (as:Accept) — vendor validates the report
 - RmInvalidateReportActivity (as:TentativeReject) — vendor invalidates the report
-- CreateCaseActivity (as:Create) — vendor creates a VulnerabilityCase
+- CreateCaseActivity (as:Create) — vendor creates a as_VulnerabilityCase
 - RmEngageCaseActivity (as:Join) — actor actively engages the case (RM → ACCEPTED)
 - RmDeferCaseActivity (as:Ignore) — actor defers the case (RM → DEFERRED)
 - RmCloseCaseActivity (as:Leave) — actor closes the case (RM → CLOSED)
@@ -58,11 +58,13 @@ from typing import Callable, Optional, Sequence, Tuple
 
 # Vultron imports
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
 from vultron.enums.roles import CVDRole
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monkeypatching
     BASE_URL,
@@ -103,14 +105,14 @@ def setup_report_and_case(
     report_content: str,
     case_name: str,
     case_content: str,
-) -> Tuple[VulnerabilityReport, VulnerabilityCase]:
+) -> Tuple[as_VulnerabilityReport, as_VulnerabilityCase]:
     """
     Shared setup: submit and validate a report, create a case, and add the
     vendor as a participant with the report linked.
 
     Returns the created report and case objects.
     """
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         attributed_to=finder.id_,
         content=report_content,
         name=report_name,
@@ -126,7 +128,7 @@ def setup_report_and_case(
     )
     post_to_inbox_and_wait(client, vendor.id_, validate_activity)
 
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         attributed_to=vendor.id_,
         name=case_name,
         content=case_content,
@@ -134,7 +136,7 @@ def setup_report_and_case(
     create_case_act = create_case_activity(case, actor=vendor.id_)
     post_to_inbox_and_wait(client, vendor.id_, create_case_act)
 
-    vendor_participant = CaseParticipant(
+    vendor_participant = as_CaseParticipant(
         case_roles=[CVDRole.VENDOR],
         attributed_to=vendor.id_,
         context=case.id_,
@@ -172,7 +174,7 @@ def demo_engage_path(
 
     Workflow steps:
     1. Finder submits report; vendor validates it
-    2. Vendor creates VulnerabilityCase; adds vendor participant and report
+    2. Vendor creates as_VulnerabilityCase; adds vendor participant and report
     3. Vendor engages the case (RmEngageCaseActivity — RM → ACCEPTED)
     4. Vendor closes the case (RmCloseCaseActivity — RM → CLOSED)
     """
@@ -313,7 +315,7 @@ def demo_invalidate_path(
     logger.info("=" * 80)
 
     with demo_step("Step 1: Finder submits vulnerability report to vendor"):
-        report = VulnerabilityReport(
+        report = as_VulnerabilityReport(
             attributed_to=finder.id_,
             content="The login page shows a different error for valid vs invalid "
             "usernames.",

--- a/vultron/demo/exchange/manage_embargo_demo.py
+++ b/vultron/demo/exchange/manage_embargo_demo.py
@@ -50,13 +50,15 @@ from typing import Callable, Optional, Sequence, Tuple
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Create
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.objects.case_participant import (
-    CaseParticipant,
+    as_CaseParticipant,
 )
 from vultron.enums.roles import CVDRole
-from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monkeypatching
     BASE_URL,
@@ -92,16 +94,16 @@ logger = logging.getLogger(__name__)
 
 
 def _make_embargo_event(
-    case: VulnerabilityCase, days: int = 90, seq: int = 1
-) -> EmbargoEvent:
-    """Create a deterministic EmbargoEvent for a given case."""
+    case: as_VulnerabilityCase, days: int = 90, seq: int = 1
+) -> as_EmbargoEvent:
+    """Create a deterministic as_EmbargoEvent for a given case."""
     now = datetime.now().astimezone()
     now = now.replace(second=0, microsecond=0)
     end_at = (now + timedelta(days=days)).replace(
         hour=0, minute=0, second=0, microsecond=0
     )
     end_date_str = end_at.strftime("%Y-%m-%d")
-    return EmbargoEvent(
+    return as_EmbargoEvent(
         id_=f"{case.id_}/embargo_events/{days}d-{end_date_str}-{seq}",
         name=f"Embargo for {case.name}",
         context=case.id_,
@@ -116,7 +118,7 @@ def _setup_two_participant_case(
     finder: as_Actor,
     vendor: as_Actor,
     coordinator: as_Actor,
-) -> VulnerabilityCase:
+) -> as_VulnerabilityCase:
     """
     Set up a case with two participants (vendor + coordinator) as a
     precondition for the embargo management workflow.
@@ -129,7 +131,7 @@ def _setup_two_participant_case(
     5. Vendor adds finder as FinderReporter participant
     6. Vendor invites coordinator; coordinator accepts → coordinator added
     """
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         attributed_to=finder.id_,
         content="A heap-overflow vulnerability in the authentication library.",
         name="Heap Overflow in Auth Library",
@@ -148,7 +150,7 @@ def _setup_two_participant_case(
     )
     post_to_inbox_and_wait(client, vendor.id_, validate_activity)
 
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         attributed_to=vendor.id_,
         name="Heap Overflow — Auth Library",
         content="Tracking the heap-overflow vulnerability in the auth library.",
@@ -162,7 +164,7 @@ def _setup_two_participant_case(
     )
     post_to_inbox_and_wait(client, vendor.id_, add_report_activity)
 
-    participant = CaseParticipant(
+    participant = as_CaseParticipant(
         case_roles=[CVDRole.FINDER, CVDRole.REPORTER],
         attributed_to=finder.id_,
         context=case.id_,

--- a/vultron/demo/exchange/manage_participants_demo.py
+++ b/vultron/demo/exchange/manage_participants_demo.py
@@ -46,14 +46,16 @@ from typing import Callable, Optional, Sequence, Tuple
 
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.objects.case_participant import (
-    CaseParticipant,
+    as_CaseParticipant,
 )
 from vultron.enums.roles import CVDRole
 from vultron.core.states.participant_embargo_consent import PEC
-from vultron.wire.as2.vocab.objects.case_status import ParticipantStatus
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_status import as_ParticipantStatus
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 from vultron.core.states.rm import RM
 from vultron.core.states.cs import CS_vfd
@@ -94,7 +96,7 @@ def _setup_case_with_vendor(
     client: DataLayerClient,
     finder: as_Actor,
     vendor: as_Actor,
-) -> VulnerabilityCase:
+) -> as_VulnerabilityCase:
     """
     Set up an initialized case owned by the vendor as a precondition for the
     manage-participants workflow.
@@ -102,13 +104,13 @@ def _setup_case_with_vendor(
     Steps:
     1. Finder submits report to vendor
     2. Vendor validates the report
-    3. Vendor creates a VulnerabilityCase
+    3. Vendor creates a as_VulnerabilityCase
     4. Vendor creates a VendorParticipant and adds it to the case
     5. Report is linked to the case
 
-    Returns the created VulnerabilityCase.
+    Returns the created as_VulnerabilityCase.
     """
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         attributed_to=finder.id_,
         content="A use-after-free vulnerability in the memory allocator.",
         name="Use-After-Free in Memory Allocator",
@@ -127,7 +129,7 @@ def _setup_case_with_vendor(
     )
     post_to_inbox_and_wait(client, vendor.id_, validate_activity)
 
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         attributed_to=vendor.id_,
         name="UAF Case — Memory Allocator",
         content="Tracking the use-after-free in the memory allocator.",
@@ -136,7 +138,7 @@ def _setup_case_with_vendor(
     post_to_inbox_and_wait(client, vendor.id_, create_case_act)
     verify_object_stored(client, case.id_)
 
-    vendor_participant = CaseParticipant(
+    vendor_participant = as_CaseParticipant(
         case_roles=[CVDRole.VENDOR],
         attributed_to=vendor.id_,
         context=case.id_,
@@ -177,7 +179,7 @@ def demo_manage_participants_accept(
     3. Coordinator accepts invitation (RmAcceptInviteToCaseActivity)
     4. Vendor creates coordinator participant (CreateParticipantActivity)
     5. Vendor adds coordinator participant to case (AddParticipantToCaseActivity)
-    6. Coordinator creates a ParticipantStatus (CreateStatusForParticipantActivity)
+    6. Coordinator creates a as_ParticipantStatus (CreateStatusForParticipantActivity)
     7. Coordinator adds the status to their participant (AddStatusToParticipantActivity)
     8. Vendor removes coordinator participant from case (RemoveParticipantFromCaseActivity)
     9. Verify coordinator no longer in case participant list
@@ -213,7 +215,7 @@ def demo_manage_participants_accept(
         post_to_inbox_and_wait(client, vendor.id_, accept)
 
     with demo_step("Step 4: Vendor creates coordinator participant"):
-        coordinator_participant = CaseParticipant(
+        coordinator_participant = as_CaseParticipant(
             case_roles=[CVDRole.COORDINATOR],
             attributed_to=coordinator.id_,
             context=case.id_,
@@ -247,8 +249,8 @@ def demo_manage_participants_accept(
                     f"not found in case after add. Participants: {participant_ids}"
                 )
 
-    with demo_step("Step 6: Coordinator creates a ParticipantStatus"):
-        participant_status = ParticipantStatus(
+    with demo_step("Step 6: Coordinator creates a as_ParticipantStatus"):
+        participant_status = as_ParticipantStatus(
             context=coordinator_participant.id_,
             rm_state=RM.ACCEPTED,
             vfd_state=CS_vfd.vfd,
@@ -262,11 +264,11 @@ def demo_manage_participants_accept(
             target=coordinator_participant.id_,
         )
         post_to_inbox_and_wait(client, coordinator.id_, create_status)
-        with demo_check("ParticipantStatus stored in data layer"):
+        with demo_check("as_ParticipantStatus stored in data layer"):
             verify_object_stored(client, participant_status.id_)
 
     with demo_step(
-        "Step 7: Coordinator adds ParticipantStatus to their participant"
+        "Step 7: Coordinator adds as_ParticipantStatus to their participant"
     ):
         add_status = add_status_to_participant_activity(
             participant_status,

--- a/vultron/demo/exchange/receive_report_demo.py
+++ b/vultron/demo/exchange/receive_report_demo.py
@@ -58,9 +58,11 @@ from vultron.adapters.utils import parse_id
 from vultron.wire.as2.vocab.base.objects.activities.base import as_Activity
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monkeypatching
     BASE_URL,
@@ -205,16 +207,16 @@ def verify_activity_in_inbox(
 
 def find_case_by_report(
     client: DataLayerClient, report_id: str
-) -> Optional[VulnerabilityCase]:
+) -> Optional[as_VulnerabilityCase]:
     """
-    Finds a VulnerabilityCase that references a specific report.
+    Finds a as_VulnerabilityCase that references a specific report.
 
     Args:
         client: DataLayerClient instance
         report_id: Full URI of the vulnerability report
 
     Returns:
-        VulnerabilityCase or None: The case if found, None otherwise
+        as_VulnerabilityCase or None: The case if found, None otherwise
     """
     cases = client.get("/datalayer/VulnerabilityCases/")
     if not cases:
@@ -226,13 +228,13 @@ def find_case_by_report(
             # Fetch the full case object
             try:
                 case_obj_data = client.get(f"/datalayer/{case_data}")
-                case_obj = VulnerabilityCase(**case_obj_data)
+                case_obj = as_VulnerabilityCase(**case_obj_data)
             except Exception as e:
                 logger.warning(f"Failed to fetch case {case_data}: {e}")
                 continue
         else:
             # API returned full object
-            case_obj = VulnerabilityCase(**case_data)
+            case_obj = as_VulnerabilityCase(**case_data)
 
         # Check if this case references our report
         if case_obj.vulnerability_reports:
@@ -272,7 +274,7 @@ def demo_validate_report(
     logger.info("=" * 80)
 
     with demo_step("Step 1: Finder submits vulnerability report to vendor"):
-        report = VulnerabilityReport(
+        report = as_VulnerabilityReport(
             attributed_to=finder.id_,
             content="This is a legitimate vulnerability in the authentication module.",
             name="Authentication Bypass Vulnerability",
@@ -350,7 +352,7 @@ def demo_invalidate_report(
     logger.info("=" * 80)
 
     with demo_step("Step 1: Finder submits vulnerability report to vendor"):
-        report = VulnerabilityReport(
+        report = as_VulnerabilityReport(
             attributed_to=finder.id_,
             content="Possible vulnerability in payment processing, needs more investigation.",
             name="Potential Payment Processing Issue",
@@ -429,7 +431,7 @@ def demo_invalidate_and_close_report(
     logger.info("=" * 80)
 
     with demo_step("Step 1: Finder submits vulnerability report to vendor"):
-        report = VulnerabilityReport(
+        report = as_VulnerabilityReport(
             attributed_to=finder.id_,
             content="This is a false positive - not a real vulnerability.",
             name="False Positive Report",

--- a/vultron/demo/exchange/status_updates_demo.py
+++ b/vultron/demo/exchange/status_updates_demo.py
@@ -19,8 +19,8 @@ Demonstrates status updates and notes workflows via the Vultron API.
 This demo script showcases the following workflows:
 
 1. Notes workflow: vendor creates a note on a case → adds it to the case
-2. Case status workflow: vendor creates a CaseStatus → adds it to the case
-3. Participant status workflow: vendor creates a ParticipantStatus for a
+2. Case status workflow: vendor creates a as_CaseStatus → adds it to the case
+3. Participant status workflow: vendor creates a as_ParticipantStatus for a
    participant → adds it to that participant
 
 Each demo starts from an initialized case with a single FinderReporter
@@ -48,17 +48,19 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.base.objects.object_types import as_Note
 from vultron.wire.as2.vocab.objects.case_participant import (
-    CaseParticipant,
+    as_CaseParticipant,
 )
 from vultron.enums.roles import CVDRole
 from vultron.core.states.participant_embargo_consent import PEC
 from vultron.wire.as2.vocab.objects.case_status import (
-    CaseStatus,
-    ParticipantStatus,
+    as_CaseStatus,
+    as_ParticipantStatus,
 )
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 from vultron.core.states.em import EM
 from vultron.core.states.rm import RM
@@ -97,7 +99,7 @@ def _setup_initialized_case(
     client: DataLayerClient,
     finder: as_Actor,
     vendor: as_Actor,
-) -> Tuple[VulnerabilityCase, CaseParticipant]:
+) -> Tuple[as_VulnerabilityCase, as_CaseParticipant]:
     """
     Set up a case with one FinderReporter participant as a precondition
     for the status updates workflow.
@@ -110,7 +112,7 @@ def _setup_initialized_case(
     5. Vendor creates FinderReporter participant
     6. Vendor adds participant to case
     """
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         attributed_to=finder.id_,
         content="A heap buffer overflow in the image parsing library.",
         name="Heap Buffer Overflow in Image Parser",
@@ -129,7 +131,7 @@ def _setup_initialized_case(
     )
     post_to_inbox_and_wait(client, vendor.id_, validate_activity)
 
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         attributed_to=vendor.id_,
         name="Heap Overflow Case — Image Parser",
         content="Tracking the heap buffer overflow in the image parsing library.",
@@ -143,7 +145,7 @@ def _setup_initialized_case(
     )
     post_to_inbox_and_wait(client, vendor.id_, add_report_activity)
 
-    participant = CaseParticipant(
+    participant = as_CaseParticipant(
         case_roles=[CVDRole.FINDER, CVDRole.REPORTER],
         attributed_to=finder.id_,
         context=case.id_,
@@ -249,10 +251,10 @@ def demo_status_workflow(
 ) -> None:
     """
     Demonstrate the status updates workflow:
-    1. Create a CaseStatus
-    2. Add the CaseStatus to the case
-    3. Create a ParticipantStatus
-    4. Add the ParticipantStatus to the participant
+    1. Create a as_CaseStatus
+    2. Add the as_CaseStatus to the case
+    3. Create a as_ParticipantStatus
+    4. Add the as_ParticipantStatus to the participant
     5. Verify side effects
     """
     logger.info("=" * 80)
@@ -261,8 +263,8 @@ def demo_status_workflow(
 
     case, participant = _setup_initialized_case(client, finder, vendor)
 
-    with demo_step("Step 1: Vendor creates CaseStatus"):
-        case_status = CaseStatus(
+    with demo_step("Step 1: Vendor creates as_CaseStatus"):
+        case_status = as_CaseStatus(
             context=case.id_,
             em_state=EM.NO_EMBARGO,
             pxa_state=CS_pxa.pxa,
@@ -271,15 +273,15 @@ def demo_status_workflow(
             case_status, actor=vendor.id_, context=case.id_
         )
         post_to_inbox_and_wait(client, vendor.id_, create_status_activity)
-        with demo_check("CaseStatus stored in data layer"):
+        with demo_check("as_CaseStatus stored in data layer"):
             verify_object_stored(client, case_status.id_)
 
-    with demo_step("Step 2: Vendor adds CaseStatus to case"):
+    with demo_step("Step 2: Vendor adds as_CaseStatus to case"):
         add_status_activity = add_status_to_case_activity(
             case_status, actor=vendor.id_, target=case.id_
         )
         post_to_inbox_and_wait(client, vendor.id_, add_status_activity)
-        with demo_check("CaseStatus present in case"):
+        with demo_check("as_CaseStatus present in case"):
             updated_case = log_case_state(
                 client, case.id_, "after AddStatusToCaseActivity"
             )
@@ -289,12 +291,12 @@ def demo_status_workflow(
                 ]
                 if case_status.id_ not in status_ids:
                     raise ValueError(
-                        f"CaseStatus '{case_status.id_}' not found in case "
+                        f"as_CaseStatus '{case_status.id_}' not found in case "
                         "after AddStatusToCaseActivity"
                     )
 
-    with demo_step("Step 3: Vendor creates ParticipantStatus"):
-        participant_status = ParticipantStatus(
+    with demo_step("Step 3: Vendor creates as_ParticipantStatus"):
+        participant_status = as_ParticipantStatus(
             context=participant.id_,
             rm_state=RM.RECEIVED,
             vfd_state=CS_vfd.vfd,
@@ -307,10 +309,10 @@ def demo_status_workflow(
             participant_status, actor=vendor.id_
         )
         post_to_inbox_and_wait(client, vendor.id_, create_pstatus_activity)
-        with demo_check("ParticipantStatus stored in data layer"):
+        with demo_check("as_ParticipantStatus stored in data layer"):
             verify_object_stored(client, participant_status.id_)
 
-    with demo_step("Step 4: Vendor adds ParticipantStatus to participant"):
+    with demo_step("Step 4: Vendor adds as_ParticipantStatus to participant"):
         add_pstatus_activity = add_status_to_participant_activity(
             participant_status, actor=vendor.id_, target=participant.id_
         )

--- a/vultron/demo/exchange/suggest_actor_demo.py
+++ b/vultron/demo/exchange/suggest_actor_demo.py
@@ -20,15 +20,15 @@ This demo script showcases two suggestion paths per ADR-0026 (CaseActor-routed):
 
 1. Accept path:
    - Finder → CaseActor inbox: Offer(Actor, Case)
-   - CaseActor → Case Owner inbox: Offer(CaseParticipant{actor, roles}, Case)
-   - Case Owner → CaseActor inbox: Accept(Offer(CaseParticipant))
+   - CaseActor → Case Owner inbox: Offer(as_CaseParticipant{actor, roles}, Case)
+   - Case Owner → CaseActor inbox: Accept(Offer(as_CaseParticipant))
    - CaseActor → Finder inbox: AcceptActorRecommendation
    - CaseActor → Coordinator inbox: Invite(CaseStub+embargo+roles)
 
 2. Reject path:
    - Finder → CaseActor inbox: Offer(Actor, Case)
-   - CaseActor → Case Owner inbox: Offer(CaseParticipant{actor, roles}, Case)
-   - Case Owner → CaseActor inbox: Reject(Offer(CaseParticipant))
+   - CaseActor → Case Owner inbox: Offer(as_CaseParticipant{actor, roles}, Case)
+   - Case Owner → CaseActor inbox: Reject(Offer(as_CaseParticipant))
    - CaseActor → Finder inbox: RejectActorRecommendation
 
 In this single-process prototype, vendor acts as both Case Owner and
@@ -49,12 +49,14 @@ from typing import Callable, Optional, Sequence, Tuple
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Create
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.objects.case_participant import (
-    CaseParticipant,
+    as_CaseParticipant,
 )
 from vultron.enums.roles import CVDRole
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monkeypatching
     BASE_URL,
@@ -89,14 +91,14 @@ def _setup_initialized_case(
     client: DataLayerClient,
     finder: as_Actor,
     vendor: as_Actor,
-) -> VulnerabilityCase:
+) -> as_VulnerabilityCase:
     """
     Set up an initialized case as a precondition for the suggest workflow.
 
     Mirrors the setup helper in invite_actor_demo but returns the
-    VulnerabilityCase so subsequent steps can reference it.
+    as_VulnerabilityCase so subsequent steps can reference it.
     """
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         attributed_to=finder.id_,
         content="A remote code execution vulnerability in the web framework.",
         name="Remote Code Execution Vulnerability",
@@ -115,7 +117,7 @@ def _setup_initialized_case(
     )
     post_to_inbox_and_wait(client, vendor.id_, validate_activity)
 
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         attributed_to=vendor.id_,
         name="RCE Case — Web Framework",
         content="Tracking the RCE vulnerability in the web framework.",
@@ -129,7 +131,7 @@ def _setup_initialized_case(
     )
     post_to_inbox_and_wait(client, vendor.id_, add_report_activity)
 
-    participant = CaseParticipant(
+    participant = as_CaseParticipant(
         case_roles=[CVDRole.FINDER, CVDRole.REPORTER],
         attributed_to=finder.id_,
         context=case.id_,
@@ -164,8 +166,8 @@ def demo_suggest_actor_accept(
 
     1. Setup: initialize case
     2. Finder → CaseActor inbox: Offer(Actor, Case)
-    3. CaseActor → Case Owner inbox: Offer(CaseParticipant{actor,roles}, Case)
-    4. Case Owner → CaseActor inbox: Accept(Offer(CaseParticipant))
+    3. CaseActor → Case Owner inbox: Offer(as_CaseParticipant{actor,roles}, Case)
+    4. Case Owner → CaseActor inbox: Accept(Offer(as_CaseParticipant))
     5. Verify acceptance persisted
 
     In this single-process prototype vendor acts as CaseActor.
@@ -197,7 +199,7 @@ def demo_suggest_actor_accept(
             verify_object_stored(client, recommendation.id_)
 
     with demo_step(
-        "Step 3: CaseActor transforms to Offer(CaseParticipant) → Case Owner"
+        "Step 3: CaseActor transforms to Offer(as_CaseParticipant) → Case Owner"
     ):
         # Per ADR-0026/CM-16-004: CaseActor transforms and forwards with
         # origin=original-offer-id.
@@ -212,13 +214,13 @@ def demo_suggest_actor_accept(
                 f"(roles: VENDOR). Origin: {recommendation.id_}"
             ),
         )
-        logger.info(f"Sending Offer(CaseParticipant): {logfmt(cp_offer)}")
+        logger.info(f"Sending Offer(as_CaseParticipant): {logfmt(cp_offer)}")
         post_to_inbox_and_wait(client, vendor.id_, cp_offer)
-        with demo_check("Offer(CaseParticipant) stored in data layer"):
+        with demo_check("Offer(as_CaseParticipant) stored in data layer"):
             verify_object_stored(client, cp_offer.id_)
 
     with demo_step(
-        "Step 4: Case Owner sends Accept(Offer(CaseParticipant)) to CaseActor"
+        "Step 4: Case Owner sends Accept(Offer(as_CaseParticipant)) to CaseActor"
     ):
         # Per ADR-0026/CM-16-006: Accept routes to CaseActor inbox.
         accept = accept_case_participant_offer_activity(
@@ -231,7 +233,7 @@ def demo_suggest_actor_accept(
             ),
         )
         logger.info(
-            f"Sending Accept(Offer(CaseParticipant)): {logfmt(accept)}"
+            f"Sending Accept(Offer(as_CaseParticipant)): {logfmt(accept)}"
         )
         post_to_inbox_and_wait(client, vendor.id_, accept)
         with demo_check("Accept stored in data layer"):
@@ -257,8 +259,8 @@ def demo_suggest_actor_reject(
 
     1. Setup: initialize case
     2. Finder → CaseActor inbox: Offer(Actor, Case)
-    3. CaseActor → Case Owner inbox: Offer(CaseParticipant{actor,roles}, Case)
-    4. Case Owner → CaseActor inbox: Reject(Offer(CaseParticipant))
+    3. CaseActor → Case Owner inbox: Offer(as_CaseParticipant{actor,roles}, Case)
+    4. Case Owner → CaseActor inbox: Reject(Offer(as_CaseParticipant))
     5. Verify no new participant was added
     """
     logger.info("=" * 80)
@@ -289,7 +291,7 @@ def demo_suggest_actor_reject(
             verify_object_stored(client, recommendation.id_)
 
     with demo_step(
-        "Step 3: CaseActor transforms to Offer(CaseParticipant) → Case Owner"
+        "Step 3: CaseActor transforms to Offer(as_CaseParticipant) → Case Owner"
     ):
         cp_offer = offer_case_participant_activity(
             coordinator,
@@ -302,13 +304,13 @@ def demo_suggest_actor_reject(
                 f"(roles: VENDOR). Origin: {recommendation.id_}"
             ),
         )
-        logger.info(f"Sending Offer(CaseParticipant): {logfmt(cp_offer)}")
+        logger.info(f"Sending Offer(as_CaseParticipant): {logfmt(cp_offer)}")
         post_to_inbox_and_wait(client, vendor.id_, cp_offer)
-        with demo_check("Offer(CaseParticipant) stored in data layer"):
+        with demo_check("Offer(as_CaseParticipant) stored in data layer"):
             verify_object_stored(client, cp_offer.id_)
 
     with demo_step(
-        "Step 4: Case Owner sends Reject(Offer(CaseParticipant)) to CaseActor"
+        "Step 4: Case Owner sends Reject(Offer(as_CaseParticipant)) to CaseActor"
     ):
         reject = reject_case_participant_offer_activity(
             cp_offer,
@@ -320,7 +322,7 @@ def demo_suggest_actor_reject(
             ),
         )
         logger.info(
-            f"Sending Reject(Offer(CaseParticipant)): {logfmt(reject)}"
+            f"Sending Reject(Offer(as_CaseParticipant)): {logfmt(reject)}"
         )
         post_to_inbox_and_wait(client, vendor.id_, reject)
 

--- a/vultron/demo/exchange/transfer_ownership_demo.py
+++ b/vultron/demo/exchange/transfer_ownership_demo.py
@@ -52,12 +52,14 @@ from typing import Callable, Optional, Sequence, Tuple
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Create
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.objects.case_participant import (
-    CaseParticipant,
+    as_CaseParticipant,
 )
 from vultron.enums.roles import CVDRole
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 from vultron.demo.utils import (
     DataLayerClient,
@@ -90,14 +92,14 @@ def _setup_initialized_case(
     client: DataLayerClient,
     finder: as_Actor,
     vendor: as_Actor,
-) -> VulnerabilityCase:
+) -> as_VulnerabilityCase:
     """
     Set up an initialized case as a precondition for the transfer workflow.
 
     Mirrors the setup helper in invite_actor_demo but returns the
-    VulnerabilityCase so subsequent steps can reference it.
+    as_VulnerabilityCase so subsequent steps can reference it.
     """
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         attributed_to=finder.id_,
         content="A remote code execution vulnerability in the web framework.",
         name="Remote Code Execution Vulnerability",
@@ -116,7 +118,7 @@ def _setup_initialized_case(
     )
     post_to_inbox_and_wait(client, vendor.id_, validate_activity)
 
-    case = VulnerabilityCase(
+    case = as_VulnerabilityCase(
         attributed_to=vendor.id_,
         name="RCE Case — Web Framework",
         content="Tracking the RCE vulnerability in the web framework.",
@@ -130,7 +132,7 @@ def _setup_initialized_case(
     )
     post_to_inbox_and_wait(client, vendor.id_, add_report_activity)
 
-    participant = CaseParticipant(
+    participant = as_CaseParticipant(
         case_roles=[CVDRole.FINDER, CVDRole.REPORTER],
         attributed_to=finder.id_,
         context=case.id_,

--- a/vultron/demo/exchange/trigger_demo.py
+++ b/vultron/demo/exchange/trigger_demo.py
@@ -44,9 +44,11 @@ from typing import Callable, Optional, Sequence, Tuple
 
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 from vultron.demo.utils import (
     DataLayerClient,
@@ -78,12 +80,12 @@ def _submit_report(
     vendor: as_Actor,
     name: str,
     content: str,
-) -> Tuple[VulnerabilityReport, as_Offer]:
+) -> Tuple[as_VulnerabilityReport, as_Offer]:
     """Finder submits a vulnerability report to the vendor's inbox.
 
     Returns the ``(report, offer)`` pair after verifying both are stored.
     """
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         attributed_to=finder.id_,
         name=name,
         content=content,
@@ -98,8 +100,8 @@ def _submit_report(
 
 def _find_case_for_report(
     client: DataLayerClient, report_id: str
-) -> Optional[VulnerabilityCase]:
-    """Return the first VulnerabilityCase referencing *report_id*, or None."""
+) -> Optional[as_VulnerabilityCase]:
+    """Return the first as_VulnerabilityCase referencing *report_id*, or None."""
     cases = client.get("/datalayer/VulnerabilityCases/")
     if not cases:
         return None
@@ -107,12 +109,12 @@ def _find_case_for_report(
         if isinstance(item, str):
             try:
                 data = client.get(f"/datalayer/{item}")
-                case = VulnerabilityCase(**data)
+                case = as_VulnerabilityCase(**data)
             except Exception as exc:
                 logger.warning("Could not fetch case %s: %s", item, exc)
                 continue
         else:
-            case = VulnerabilityCase(**item)
+            case = as_VulnerabilityCase(**item)
         report_ids = [
             r if isinstance(r, str) else getattr(r, "id_", str(r))
             for r in (case.vulnerability_reports or [])
@@ -177,7 +179,7 @@ def demo_validate_and_engage(
         with demo_check("Case created by validate-report BT"):
             assert (
                 case is not None
-            ), f"No VulnerabilityCase found for report {report.id_}"
+            ), f"No as_VulnerabilityCase found for report {report.id_}"
             logger.info("Found case: %s", case.id_)
 
         response = post_to_trigger(

--- a/vultron/demo/helpers/milestones.py
+++ b/vultron/demo/helpers/milestones.py
@@ -35,8 +35,10 @@ from vultron.demo.helpers.verification import (
     _fetch_participant_data,
 )
 from vultron.demo.utils import DataLayerClient
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +61,7 @@ def verify_case_active(
     Args:
         receiver_client: Client connected to the receiver container.
         reporter_client: Client connected to the reporter container.
-        case_id: Full URI of the ``VulnerabilityCase``.
+        case_id: Full URI of the ``as_VulnerabilityCase``.
         receiver_actor_id: Full URI of the receiver actor.
         reporter_actor_id: Full URI of the reporter actor.
 
@@ -71,7 +73,7 @@ def verify_case_active(
     assert (
         case_data
     ), f"verify_case_active: receiver case {case_id!r} not found"
-    case = VulnerabilityCase.model_validate(case_data)
+    case = as_VulnerabilityCase.model_validate(case_data)
 
     required = {receiver_actor_id, reporter_actor_id}
     missing = required - set(case.actor_participant_index.keys())
@@ -107,7 +109,7 @@ def verify_case_active(
             f"verify_case_active: reporter does not have case replica for"
             f" {case_id!r} — outbox delivery may not have completed"
         )
-    reporter_case = VulnerabilityCase.model_validate(reporter_case_data)
+    reporter_case = as_VulnerabilityCase.model_validate(reporter_case_data)
 
     receiver_embargo_id = _extract_ref_id(case.active_embargo)
     reporter_embargo_id = _extract_ref_id(reporter_case.active_embargo)
@@ -138,7 +140,7 @@ def verify_fix_ready(
     Args:
         receiver_client: Client connected to the receiver container.
         reporter_client: Client connected to the reporter container.
-        case_id: Full URI of the ``VulnerabilityCase``.
+        case_id: Full URI of the ``as_VulnerabilityCase``.
         receiver_actor_id: Full URI of the receiver actor whose
             participant vfd_state to check.
 
@@ -176,7 +178,7 @@ def verify_fix_deployed(
     Args:
         receiver_client: Client connected to the receiver container.
         reporter_client: Client connected to the reporter container.
-        case_id: Full URI of the ``VulnerabilityCase``.
+        case_id: Full URI of the ``as_VulnerabilityCase``.
         receiver_actor_id: Full URI of the receiver actor whose
             participant vfd_state to check.
 
@@ -221,7 +223,7 @@ def verify_publicly_disclosed(
     Args:
         receiver_client: Client connected to the receiver container.
         reporter_client: Client connected to the reporter container.
-        case_id: Full URI of the ``VulnerabilityCase``.
+        case_id: Full URI of the ``as_VulnerabilityCase``.
         receiver_actor_id: Full URI of the receiver actor.
 
     Raises:
@@ -235,7 +237,7 @@ def verify_publicly_disclosed(
         assert (
             case_data
         ), f"verify_publicly_disclosed {label}: case {case_id!r} not found"
-        case = VulnerabilityCase.model_validate(case_data)
+        case = as_VulnerabilityCase.model_validate(case_data)
         if case.current_status.em_state != EM.EXITED:
             raise AssertionError(
                 f"verify_publicly_disclosed {label}: expected EM.EXITED,"
@@ -275,7 +277,7 @@ def verify_case_closed(
     Args:
         receiver_client: Client connected to the receiver container.
         reporter_client: Client connected to the reporter container.
-        case_id: Full URI of the ``VulnerabilityCase``.
+        case_id: Full URI of the ``as_VulnerabilityCase``.
 
     Raises:
         AssertionError: If any non-receiver participant is not RM.CLOSED
@@ -289,12 +291,12 @@ def verify_case_closed(
         assert (
             case_data
         ), f"verify_case_closed {label}: case {case_id!r} not found"
-        case = VulnerabilityCase.model_validate(case_data)
+        case = as_VulnerabilityCase.model_validate(case_data)
         for a_id, p_id in case.actor_participant_index.items():
             p_data = _fetch_participant_data(client, p_id)
             if p_data is None:
                 continue  # remote container — not fetchable here
-            p = CaseParticipant(**p_data)
+            p = as_CaseParticipant(**p_data)
             # Case Manager is a coordinator; skip RM closure check.
             if CVDRole.CASE_MANAGER in (p.case_roles or []):
                 continue

--- a/vultron/demo/helpers/notes.py
+++ b/vultron/demo/helpers/notes.py
@@ -31,7 +31,9 @@ from vultron.demo.utils import (
 )
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.base.objects.object_types import as_Note
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +42,7 @@ def participant_adds_note_to_case(
     posting_client: DataLayerClient,
     watching_client: DataLayerClient,
     poster: as_Actor,
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
     note_name: str,
     note_content: str,
     in_reply_to: Optional[str] = None,
@@ -57,7 +59,7 @@ def participant_adds_note_to_case(
         watching_client: Client connected to the container where note delivery
             should be verified (typically the case host or coordinator).
         poster: The ``as_Actor`` adding the note.
-        case: The ``VulnerabilityCase`` the note belongs to.
+        case: The ``as_VulnerabilityCase`` the note belongs to.
         note_name: Short name / subject for the note.
         note_content: Full text content of the note.
         in_reply_to: Optional ID of the note being replied to.

--- a/vultron/demo/helpers/polling.py
+++ b/vultron/demo/helpers/polling.py
@@ -23,7 +23,9 @@ import time
 from typing import Callable
 
 from vultron.demo.utils import DataLayerClient
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +83,7 @@ def wait_for_case_on_container(
 ) -> None:
     """Poll *client*'s DataLayer until *case_id* appears.
 
-    Proves that an outbox activity (e.g. ``Create(VulnerabilityCase)``) was
+    Proves that an outbox activity (e.g. ``Create(as_VulnerabilityCase)``) was
     delivered to the actor on *client* and its inbox handler processed it.
 
     In single-server integration tests both actors share the same DataLayer so
@@ -90,7 +92,7 @@ def wait_for_case_on_container(
 
     Args:
         client: DataLayerClient connected to the container to poll.
-        case_id: Full URI of the ``VulnerabilityCase`` to wait for.
+        case_id: Full URI of the ``as_VulnerabilityCase`` to wait for.
         timeout_seconds: Maximum time to wait before raising.
         poll_interval: Seconds between DataLayer poll attempts.
 
@@ -122,7 +124,7 @@ def wait_for_finder_case(
 
     Args:
         finder_client: DataLayerClient connected to the Finder container.
-        case_id: Full URI of the ``VulnerabilityCase`` to wait for.
+        case_id: Full URI of the ``as_VulnerabilityCase`` to wait for.
         timeout_seconds: Maximum time to wait before raising.
         poll_interval: Seconds between DataLayer poll attempts.
     """
@@ -142,7 +144,7 @@ def wait_for_case_participants(
 
     Args:
         vendor_client: DataLayerClient for the container to poll.
-        case_id: Full URI of the ``VulnerabilityCase``.
+        case_id: Full URI of the ``as_VulnerabilityCase``.
         expected_count: Minimum number of participants to wait for.
         timeout_seconds: Maximum time to wait before raising.
         poll_interval: Seconds between DataLayer poll attempts.
@@ -154,12 +156,12 @@ def wait_for_case_participants(
     deadline = time.monotonic() + timeout_seconds
     while time.monotonic() < deadline:
         case_data = vendor_client.get(f"/datalayer/{case_id}")
-        case = VulnerabilityCase(**case_data)
+        case = as_VulnerabilityCase(**case_data)
         if len(case.case_participants) >= expected_count:
             return
         time.sleep(poll_interval)
 
-    final_case = VulnerabilityCase(
+    final_case = as_VulnerabilityCase(
         **vendor_client.get(f"/datalayer/{case_id}")
     )
     raise AssertionError(
@@ -193,7 +195,7 @@ def wait_for_note_in_case(
 
     def _check() -> bool:
         case_data = client.get(f"/datalayer/{case_id}")
-        case = VulnerabilityCase(**case_data)
+        case = as_VulnerabilityCase(**case_data)
         note_ids = [
             n if isinstance(n, str) else getattr(n, "id_", str(n))
             for n in case.notes
@@ -225,7 +227,7 @@ def wait_for_finder_log_entry(
 
     Args:
         finder_client: DataLayerClient connected to the Finder container.
-        case_id: Full URI of the ``VulnerabilityCase`` (used for filtering).
+        case_id: Full URI of the ``as_VulnerabilityCase`` (used for filtering).
         entry_hash: ``entry_hash`` value of the expected log entry.
         timeout_seconds: Maximum time to wait before raising.
         poll_interval: Seconds between DataLayer poll attempts.
@@ -283,7 +285,7 @@ def wait_for_contiguous_ledger_coverage(
 
     Args:
         client: DataLayerClient connected to the replica container.
-        case_id: Full URI of the ``VulnerabilityCase``.
+        case_id: Full URI of the ``as_VulnerabilityCase``.
         expected_tail_index: The highest ``log_index`` the replica must hold
             (inclusive).  Typically obtained from the authoritative actor's
             ledger dump before calling this function.
@@ -357,7 +359,7 @@ def wait_for_participant_vfd_state(
 
     Args:
         client: DataLayerClient for the target container.
-        case_id: Full URI of the ``VulnerabilityCase``.
+        case_id: Full URI of the ``as_VulnerabilityCase``.
         actor_id: Full URI of the actor to check.
         expected_states: Set of ``CS_vfd`` values that satisfy the condition.
         timeout_seconds: Maximum time to wait (default: 10 s).
@@ -442,7 +444,7 @@ def wait_for_case_em_terminated(
 
     Args:
         client: DataLayerClient for the target container.
-        case_id: Full URI of the ``VulnerabilityCase``.
+        case_id: Full URI of the ``as_VulnerabilityCase``.
         timeout_seconds: Maximum time to wait.
         poll_interval: Seconds between DataLayer poll attempts.
 
@@ -453,7 +455,7 @@ def wait_for_case_em_terminated(
 
     def _check() -> bool:
         case_data = client.get(f"/datalayer/{case_id}")
-        case = VulnerabilityCase.model_validate(case_data)
+        case = as_VulnerabilityCase.model_validate(case_data)
         return case.current_status.em_state == EM.EXITED
 
     _poll_until(
@@ -477,7 +479,7 @@ def wait_for_all_participants_rm_closed(
 
     Args:
         client: DataLayerClient for the target container.
-        case_id: Full URI of the ``VulnerabilityCase``.
+        case_id: Full URI of the ``as_VulnerabilityCase``.
         timeout_seconds: Maximum time to wait.
         poll_interval: Seconds between DataLayer poll attempts.
 
@@ -491,7 +493,7 @@ def wait_for_all_participants_rm_closed(
 
     def _check() -> bool:
         case_data = client.get(f"/datalayer/{case_id}")
-        case = VulnerabilityCase.model_validate(case_data)
+        case = as_VulnerabilityCase.model_validate(case_data)
         return _all_fetchable_participants_rm_closed(client, case)
 
     _poll_until(

--- a/vultron/demo/helpers/sync.py
+++ b/vultron/demo/helpers/sync.py
@@ -26,7 +26,9 @@ import logging
 from typing import Optional
 
 from vultron.demo.utils import DataLayerClient, post_to_trigger
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +94,7 @@ def trigger_log_commit(
     Args:
         client: DataLayerClient connected to the CaseActor container.
         actor_id: Full URI of the actor committing the log entry.
-        case_id: Full URI of the ``VulnerabilityCase``.
+        case_id: Full URI of the ``as_VulnerabilityCase``.
         event_type: Short machine-readable event descriptor.
         object_id: Optional URI of the primary object.  Defaults to
             *case_id* when not supplied.
@@ -144,7 +146,7 @@ def verify_replica_state(
             (the actor that owns/created the case).
         replica_client: DataLayerClient connected to the replica container
             (the actor that received a replicated copy).
-        case_id: Full URI of the ``VulnerabilityCase`` being verified.
+        case_id: Full URI of the ``as_VulnerabilityCase`` being verified.
         vendor_actor_id: Full URI of the Vendor actor (retained for symmetry).
         reporter_actor_id: Full URI of the Reporter/Finder actor (retained for
             future participant-status checks).
@@ -156,14 +158,14 @@ def verify_replica_state(
     """
     auth_case_data = auth_client.get(f"/datalayer/{case_id}")
     assert auth_case_data, f"Authoritative case {case_id!r} not found"
-    auth_case = VulnerabilityCase.model_validate(auth_case_data)
+    auth_case = as_VulnerabilityCase.model_validate(auth_case_data)
 
     replica_case_data = replica_client.get(f"/datalayer/{case_id}")
     assert replica_case_data, (
         f"Replica does not have a copy of case {case_id!r} — "
         "outbox delivery or inbox processing may have failed"
     )
-    replica_case = VulnerabilityCase.model_validate(replica_case_data)
+    replica_case = as_VulnerabilityCase.model_validate(replica_case_data)
 
     # 1. Same case ID
     assert (
@@ -231,7 +233,7 @@ def verify_finder_replica_state(
     Args:
         finder_client: DataLayerClient connected to the Finder (replica).
         vendor_client: DataLayerClient connected to the Vendor (authoritative).
-        case_id: Full URI of the ``VulnerabilityCase`` being verified.
+        case_id: Full URI of the ``as_VulnerabilityCase`` being verified.
         vendor_actor_id: Full URI of the Vendor actor.
         reporter_actor_id: Full URI of the Reporter/Finder actor.
     """

--- a/vultron/demo/helpers/verification.py
+++ b/vultron/demo/helpers/verification.py
@@ -29,8 +29,10 @@ from vultron.core.states.rm import RM
 from vultron.enums.roles import CVDRole
 from vultron.demo.helpers.seeding import _dl_key
 from vultron.demo.utils import DataLayerClient, ref_id
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -44,26 +46,26 @@ def _fetch_participant(
     client: DataLayerClient,
     case_id: str,
     actor_id: str,
-) -> Optional[CaseParticipant]:
-    """Fetch the CaseParticipant record for *actor_id* in *case_id*.
+) -> Optional[as_CaseParticipant]:
+    """Fetch the as_CaseParticipant record for *actor_id* in *case_id*.
 
     Args:
         client: DataLayerClient for the target container.
-        case_id: Full URI of the ``VulnerabilityCase``.
+        case_id: Full URI of the ``as_VulnerabilityCase``.
         actor_id: Full URI of the actor whose participant record to fetch.
 
     Returns:
-        The ``CaseParticipant`` or ``None`` if the actor or participant
+        The ``as_CaseParticipant`` or ``None`` if the actor or participant
         record is not found.
     """
     try:
         case_data = client.get(f"/datalayer/{case_id}")
-        case = VulnerabilityCase.model_validate(case_data)
+        case = as_VulnerabilityCase.model_validate(case_data)
         participant_id = case.actor_participant_index.get(actor_id)
         if participant_id is None:
             return None
         p_data = client.get(f"/datalayer/{_dl_key(participant_id)}")
-        return CaseParticipant(**p_data)
+        return as_CaseParticipant(**p_data)
     except (httpx.HTTPStatusError, AssertionError):
         return None
 
@@ -93,14 +95,14 @@ def _fetch_participant_data(client: DataLayerClient, p_id: str) -> dict | None:
 
 
 def _require_case_participant_id(
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
     actor_id: str,
     label: str,
 ) -> str:
     """Return the participant ID for *actor_id* in *case* or raise.
 
     Args:
-        case: The ``VulnerabilityCase`` whose index to check.
+        case: The ``as_VulnerabilityCase`` whose index to check.
         actor_id: Full URI of the actor.
         label: Human-readable label for the ``AssertionError`` message.
 
@@ -133,7 +135,7 @@ def _assert_vendor_participant_state(
         AssertionError: If the participant has no statuses or the latest
             RM state is not ``RM.ACCEPTED``.
     """
-    participant = CaseParticipant(
+    participant = as_CaseParticipant(
         **vendor_client.get(f"/datalayer/{_dl_key(participant_id)}")
     )
     latest = participant.participant_status
@@ -145,7 +147,7 @@ def _assert_vendor_participant_state(
         )
 
 
-def _assert_vendor_case_status(case: VulnerabilityCase) -> None:
+def _assert_vendor_case_status(case: as_VulnerabilityCase) -> None:
     """Assert that *case* has ``EM.ACTIVE`` and ``pxa == CS_pxa.pxa``.
 
     Raises:
@@ -163,7 +165,7 @@ def _assert_vendor_case_status(case: VulnerabilityCase) -> None:
 
 
 def _assert_case_notes(
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
     question_note_id: str | None,
     reply_note_id: str | None,
 ) -> None:
@@ -199,7 +201,7 @@ def _check_participant_vfd_state_in(
 
     Args:
         client: DataLayerClient for the target container.
-        case_id: Full URI of the ``VulnerabilityCase``.
+        case_id: Full URI of the ``as_VulnerabilityCase``.
         actor_id: Full URI of the actor to check.
         expected_states: Set of acceptable ``CS_vfd`` values.
         label: Human-readable label for ``AssertionError`` messages.
@@ -224,14 +226,14 @@ def _check_participant_vfd_state_in(
 
 
 def _assert_participant_vfd_pxa(
-    participant: CaseParticipant,
+    participant: as_CaseParticipant,
     label: str,
     vendor_actor_id: str,
 ) -> None:
     """Assert *participant* has VFD and a public-aware pxa_state.
 
     Args:
-        participant: The ``CaseParticipant`` to check.
+        participant: The ``as_CaseParticipant`` to check.
         label: Human-readable label for ``AssertionError`` messages.
         vendor_actor_id: Full URI of the vendor actor (used in error messages).
 
@@ -259,7 +261,7 @@ def _assert_participant_vfd_pxa(
 
 def _all_fetchable_participants_rm_closed(
     client: DataLayerClient,
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
 ) -> bool:
     """Return ``True`` when every fetchable, non-CASE_MANAGER participant is
     ``RM.CLOSED``.
@@ -269,7 +271,7 @@ def _all_fetchable_participants_rm_closed(
 
     Args:
         client: DataLayerClient for the container to query.
-        case: The ``VulnerabilityCase`` whose participant index to walk.
+        case: The ``as_VulnerabilityCase`` whose participant index to walk.
 
     Returns:
         ``True`` if all locally-fetchable non-receiver participants are
@@ -281,7 +283,7 @@ def _all_fetchable_participants_rm_closed(
             continue  # remote container — not fetchable here
         if not p_data:
             return False
-        p = CaseParticipant(**p_data)
+        p = as_CaseParticipant(**p_data)
         if CVDRole.CASE_MANAGER in (p.case_roles or []):
             continue
         latest = p.participant_status
@@ -300,7 +302,7 @@ def verify_receiver_case_state(
     reporter_actor_id: str,
     question_note_id: Optional[str] = None,
     reply_note_id: Optional[str] = None,
-) -> VulnerabilityCase:
+) -> as_VulnerabilityCase:
     """Assert the final authoritative case state on the receiver container.
 
     Verifies that the case references the submitted report, that all required
@@ -311,7 +313,7 @@ def verify_receiver_case_state(
 
     Args:
         receiver_client: Client connected to the receiver container.
-        case_id: Full URI of the ``VulnerabilityCase`` to verify.
+        case_id: Full URI of the ``as_VulnerabilityCase`` to verify.
         report_id: Full URI of the submitted vulnerability report.
         receiver_actor_id: Full URI of the receiver actor.
         reporter_actor_id: Full URI of the reporter actor.
@@ -319,12 +321,12 @@ def verify_receiver_case_state(
         reply_note_id: Optional URI of the reply note to assert present.
 
     Returns:
-        The fetched and validated ``VulnerabilityCase``.
+        The fetched and validated ``as_VulnerabilityCase``.
 
     Raises:
         AssertionError: If any invariant is violated.
     """
-    final_case = VulnerabilityCase(
+    final_case = as_VulnerabilityCase(
         **receiver_client.get(f"/datalayer/{case_id}")
     )
 
@@ -377,7 +379,7 @@ def verify_case_actor_unused(
     Per D5-1-G3, the per-case ``VultronCaseActor`` co-locates in the
     receiver container for D5-2.  The standalone ``case-actor`` service
     participates in the Docker topology but should not hold the created
-    ``VulnerabilityCase``.
+    ``as_VulnerabilityCase``.
 
     Args:
         case_actor_client: Optional client connected to the dedicated

--- a/vultron/demo/helpers/workflow.py
+++ b/vultron/demo/helpers/workflow.py
@@ -39,9 +39,11 @@ from vultron.wire.as2.factories import (
 )
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 logger = logging.getLogger(__name__)
@@ -52,7 +54,7 @@ def reporter_submits_report(
     reporter: as_Actor,
     receiver: as_Actor,
     reporter_client: Optional[DataLayerClient] = None,
-) -> Tuple[VulnerabilityReport, as_Offer]:
+) -> Tuple[as_VulnerabilityReport, as_Offer]:
     """Reporter creates a vulnerability report and submits it to the receiver.
 
     When ``reporter_client`` is provided (e.g. in a multi-container Docker
@@ -106,7 +108,7 @@ def reporter_submits_report(
         with demo_step("Deliver reporter's offer to receiver's inbox"):
             post_to_inbox_and_wait(receiver_client, receiver.id_, offer)
     else:
-        report = VulnerabilityReport(
+        report = as_VulnerabilityReport(
             attributed_to=reporter.id_,
             name="Remote Code Execution in Network Stack",
             content=(
@@ -178,7 +180,7 @@ def receiver_engages_case(
     Args:
         receiver_client: Client connected to the receiver's container.
         receiver: Receiver ``as_Actor``.
-        case_id: Full URI of the ``VulnerabilityCase`` to engage.
+        case_id: Full URI of the ``as_VulnerabilityCase`` to engage.
 
     Returns:
         Response dict from the trigger endpoint (contains the engage
@@ -227,21 +229,21 @@ def _report_id_from_offer_data(
 def _load_case_from_datalayer(
     client: DataLayerClient,
     item: str | dict[str, object],
-) -> VulnerabilityCase | None:
-    """Load a VulnerabilityCase from the DataLayer, handling both IDs and dicts.
+) -> as_VulnerabilityCase | None:
+    """Load a as_VulnerabilityCase from the DataLayer, handling both IDs and dicts.
 
     Args:
         client: DataLayerClient for the container to query.
         item: Either a full case URI string or a raw dict to validate.
 
     Returns:
-        The ``VulnerabilityCase``, or ``None`` if the fetch fails.
+        The ``as_VulnerabilityCase``, or ``None`` if the fetch fails.
     """
     if not isinstance(item, str):
-        return VulnerabilityCase.model_validate(item)
+        return as_VulnerabilityCase.model_validate(item)
 
     try:
-        return VulnerabilityCase.model_validate(
+        return as_VulnerabilityCase.model_validate(
             client.get(f"/datalayer/{item}")
         )
     except Exception as exc:
@@ -252,15 +254,15 @@ def _load_case_from_datalayer(
 def find_case_for_offer(
     client: DataLayerClient,
     offer_id: str,
-) -> Optional[VulnerabilityCase]:
-    """Find the VulnerabilityCase associated with a report offer.
+) -> Optional[as_VulnerabilityCase]:
+    """Find the as_VulnerabilityCase associated with a report offer.
 
     Args:
         client: DataLayerClient connected to the container holding the case.
         offer_id: Full URI of the ``VultronActivity`` offer.
 
     Returns:
-        The matching ``VulnerabilityCase``, or ``None`` if not found.
+        The matching ``as_VulnerabilityCase``, or ``None`` if not found.
     """
     offer_data = client.get(f"/datalayer/{offer_id}")
     if not offer_data:

--- a/vultron/demo/scenario/fvv_demo.py
+++ b/vultron/demo/scenario/fvv_demo.py
@@ -40,9 +40,11 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
 )
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.base.objects.object_types import as_Note
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 from vultron.demo.utils import (  # noqa: F401 — re-exported for test monkeypatching
@@ -148,9 +150,9 @@ def _phase_report_submission(
     as_Actor,
     as_Actor,
     as_Actor,
-    VulnerabilityReport,
+    as_VulnerabilityReport,
     as_Offer,
-    VulnerabilityCase,
+    as_VulnerabilityCase,
 ]:
     """Reset, seed, submit report, validate, engage, invite Vendor2, M1 check."""
     logger.info("─" * 80)
@@ -188,11 +190,11 @@ def _phase_report_submission(
         offer_id=offer.id_,
     )
 
-    with demo_check("VulnerabilityCase exists in Vendor1's DataLayer"):
+    with demo_check("as_VulnerabilityCase exists in Vendor1's DataLayer"):
         case = find_case_for_offer(vendor_client, offer.id_)
         if case is None:
             raise AssertionError(
-                "Expected VulnerabilityCase to be created after validate-report"
+                "Expected as_VulnerabilityCase to be created after validate-report"
             )
         logger.info("Case created: %s", case.id_)
 
@@ -274,7 +276,7 @@ def _phase_report_submission(
             reporter_actor_id=finder.id_,
         )
 
-    case = VulnerabilityCase.model_validate(
+    case = as_VulnerabilityCase.model_validate(
         vendor_client.get(f"/datalayer/{case.id_}")
     )
     return finder, vendor, vendor_in_vendor, vendor2, report, offer, case
@@ -287,7 +289,7 @@ def _phase_sync_verification(
     vendor: as_Actor,
     finder: as_Actor,
     vendor2: as_Actor,
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
 ) -> None:
     """Verify SYNC-2 replication for both Finder and Vendor2 replicas."""
     logger.info("─" * 80)
@@ -365,7 +367,7 @@ def _phase_notes_exchange(
     finder_in_finder: as_Actor,
     vendor_in_vendor: as_Actor,
     vendor2_in_vendor2: as_Actor,
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
 ) -> tuple[as_Note, as_Note, as_Note]:
     """Run a three-way note exchange among Finder, Vendor1, and Vendor2."""
     logger.info("─" * 80)
@@ -424,7 +426,7 @@ def _phase_fix_lifecycle(
     vendor_in_vendor: as_Actor,
     vendor2: as_Actor,
     vendor2_in_vendor2: as_Actor,
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
 ) -> None:
     """Advance both vendors through independent fix-ready and fix-deployed paths."""
     logger.info("─" * 80)
@@ -515,7 +517,7 @@ def _phase_publication(
     vendor2_in_vendor2: as_Actor,
     finder: as_Actor,
     finder_in_finder: as_Actor,
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
 ) -> None:
     """Run publication notifications and verify public disclosure state."""
     logger.info("─" * 80)
@@ -575,7 +577,7 @@ def _phase_case_closure(
     vendor2_in_vendor2: as_Actor,
     finder: as_Actor,
     finder_in_finder: as_Actor,
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
 ) -> None:
     """Close the case from all three participants and verify terminal state."""
     logger.info("─" * 80)
@@ -648,7 +650,7 @@ def _phase_dump_case_ledgers(
     finder: as_Actor,
     vendor: as_Actor,
     vendor2: as_Actor,
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
     demo_name: str = "fvv",
 ) -> None:
     """Dump case ledger entries from each actor container to JSONL files."""

--- a/vultron/demo/scenario/multi_vendor_demo.py
+++ b/vultron/demo/scenario/multi_vendor_demo.py
@@ -54,10 +54,12 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_TransitiveActivity,
 )
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 from vultron.demo.scenario.two_actor_demo import (
     finder_submits_report,
@@ -236,8 +238,8 @@ def vendor_creates_case_on_case_actor(
     case_actor_client: DataLayerClient,
     case_actor: as_Actor,
     vendor: as_Actor,
-    report: VulnerabilityReport,
-) -> VulnerabilityCase:
+    report: as_VulnerabilityReport,
+) -> as_VulnerabilityCase:
     """Vendor creates the authoritative case on the CaseActor container."""
     with demo_step("Vendor creates the case via trigger"):
         result = post_to_trigger(
@@ -255,7 +257,7 @@ def vendor_creates_case_on_case_actor(
             },
         )
     create_case = as_Create.model_validate(result["activity"])
-    case = VulnerabilityCase.model_validate(
+    case = as_VulnerabilityCase.model_validate(
         create_case.object_.model_dump(by_alias=True)  # type: ignore[union-attr]
     )
     with demo_step("Delivering CreateCase activity to CaseActor"):
@@ -271,8 +273,8 @@ def vendor_adds_report_to_case(
     case_actor_client: DataLayerClient,
     case_actor: as_Actor,
     vendor: as_Actor,
-    case: VulnerabilityCase,
-    report: VulnerabilityReport,
+    case: as_VulnerabilityCase,
+    report: as_VulnerabilityReport,
 ) -> None:
     """Link the submitted report to the authoritative case."""
     with demo_step(
@@ -300,7 +302,7 @@ def vendor_offers_case_ownership_to_coordinator(
     case_actor: as_Actor,
     vendor: as_Actor,
     coordinator: as_Actor,
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
 ) -> as_Offer:
     """Vendor records a case ownership offer and delivers it to Coordinator.
 
@@ -335,7 +337,7 @@ def coordinator_accepts_case_ownership(
     case_actor: as_Actor,
     coordinator: as_Actor,
     offer: as_Offer,
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
 ) -> as_Accept:
     """Coordinator accepts the ownership transfer offer on the CaseActor.
 
@@ -356,7 +358,7 @@ def coordinator_accepts_case_ownership(
 
     with demo_check("Case attributed_to updated to Coordinator on CaseActor"):
         case_data = case_actor_client.get(f"/datalayer/{case.id_}")
-        updated_case = VulnerabilityCase(**case_data)
+        updated_case = as_VulnerabilityCase(**case_data)
         coord_segment = coordinator.id_.split("/")[-1]
         if coord_segment not in str(updated_case.attributed_to):
             raise AssertionError(
@@ -370,14 +372,14 @@ def coordinator_accepts_case_ownership(
     return accept
 
 
-def _multi_vendor_report_ids(case: VulnerabilityCase) -> list[str]:
+def _multi_vendor_report_ids(case: as_VulnerabilityCase) -> list[str]:
     return [
         ref_id(report) or str(report) for report in case.vulnerability_reports
     ]
 
 
 def _assert_multi_vendor_active_embargo(
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
     embargo_id: str,
 ) -> None:
     if case.current_status.em_state != EM.ACTIVE:
@@ -391,7 +393,7 @@ def _assert_multi_vendor_active_embargo(
 
 
 def _assert_multi_vendor_participants_present(
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
     actor_ids: tuple[str, ...],
 ) -> None:
     for actor_id in actor_ids:
@@ -403,7 +405,7 @@ def _assert_multi_vendor_participants_present(
 
 def _assert_multi_vendor_embargo_acceptance(
     case_actor_client: DataLayerClient,
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
     actor_ids: tuple[str, ...],
     embargo_id: str,
 ) -> None:
@@ -416,7 +418,7 @@ def _assert_multi_vendor_embargo_acceptance(
                 f"Participant record {participant_id} not found in "
                 "CaseActor DataLayer"
             )
-        participant = CaseParticipant(**participant_data)
+        participant = as_CaseParticipant(**participant_data)
         if embargo_id not in participant.accepted_embargo_ids:
             raise AssertionError(
                 f"Participant {participant_id} did not record acceptance of "
@@ -434,7 +436,7 @@ def verify_multi_vendor_case_state(
     vendor_actor_id: str,
     vendor2_actor_id: str,
     embargo_id: str,
-) -> VulnerabilityCase:
+) -> as_VulnerabilityCase:
     """Assert the authoritative final multi-vendor case state.
 
     Checks:
@@ -444,7 +446,7 @@ def verify_multi_vendor_case_state(
     - The embargo is ACTIVE and all three participants have accepted it.
     - Coordinator and Vendor2 containers do not hold the authoritative case.
     """
-    final_case = VulnerabilityCase(
+    final_case = as_VulnerabilityCase(
         **case_actor_client.get(f"/datalayer/{case_id}")
     )
     actor_ids = (reporter_actor_id, vendor_actor_id, vendor2_actor_id)
@@ -499,7 +501,7 @@ def run_multi_vendor_demo(
     coordinator_id: str | None = None,
     case_actor_id: str | None = None,
     vendor2_id: str | None = None,
-) -> VulnerabilityCase:
+) -> as_VulnerabilityCase:
     """Run the full deterministic multi-vendor ownership-transfer scenario."""
     logger.info("=" * 80)
     logger.info(

--- a/vultron/demo/scenario/three_actor_demo.py
+++ b/vultron/demo/scenario/three_actor_demo.py
@@ -64,10 +64,12 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_TransitiveActivity,
 )
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 from vultron.wire.as2.factories import (
     rm_submit_report_activity,
@@ -201,9 +203,9 @@ def finder_submits_report_to_coordinator(
     coordinator_client: DataLayerClient,
     finder: as_Actor,
     coordinator: as_Actor,
-) -> tuple[VulnerabilityReport, as_Offer]:
+) -> tuple[as_VulnerabilityReport, as_Offer]:
     """Finder submits a report to the Coordinator container."""
-    report = VulnerabilityReport(
+    report = as_VulnerabilityReport(
         attributed_to=finder.id_,
         name="Coordinated disclosure for dependency parser RCE",
         content=(
@@ -231,8 +233,8 @@ def coordinator_creates_case_on_case_actor(
     case_actor_client: DataLayerClient,
     case_actor: as_Actor,
     coordinator: as_Actor,
-    report: VulnerabilityReport,
-) -> VulnerabilityCase:
+    report: as_VulnerabilityReport,
+) -> as_VulnerabilityCase:
     """Create the authoritative case on the dedicated CaseActor container."""
     with demo_step("Coordinator creates the case via trigger"):
         result = post_to_trigger(
@@ -249,7 +251,7 @@ def coordinator_creates_case_on_case_actor(
             },
         )
     create_case = as_Create.model_validate(result["activity"])
-    case = VulnerabilityCase.model_validate(
+    case = as_VulnerabilityCase.model_validate(
         create_case.object_.model_dump(by_alias=True)  # type: ignore[union-attr]
     )
     with demo_step("Delivering CreateCase activity to CaseActor"):
@@ -265,8 +267,8 @@ def coordinator_adds_report_to_case(
     case_actor_client: DataLayerClient,
     case_actor: as_Actor,
     coordinator: as_Actor,
-    case: VulnerabilityCase,
-    report: VulnerabilityReport,
+    case: as_VulnerabilityCase,
+    report: as_VulnerabilityReport,
 ) -> None:
     """Link the submitted report to the authoritative case."""
     with demo_step(
@@ -293,7 +295,7 @@ def coordinator_invites_actor(
     recipient_client: DataLayerClient,
     actor: as_Actor,
     recipient: as_Actor,
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
     case_actor_client: DataLayerClient | None = None,
     case_actor: as_Actor | None = None,
 ) -> as_Activity:
@@ -357,7 +359,7 @@ def actor_accepts_case_invite(
 def coordinator_proposes_embargo(
     case_actor_client: DataLayerClient,
     coordinator: as_Actor,
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
 ) -> tuple[as_Activity, str]:
     """Propose an embargo on the authoritative case."""
     end_time = datetime.now(tz=timezone.utc) + timedelta(days=30)
@@ -405,7 +407,7 @@ def deliver_embargo_proposal(
 def actor_accepts_embargo(
     case_actor_client: DataLayerClient,
     actor: as_Actor,
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
     proposal: as_Activity,
 ) -> None:
     """Accept the active embargo proposal on the authoritative case."""
@@ -422,14 +424,14 @@ def actor_accepts_embargo(
     logger.info("Embargo accepted by %s", actor.name)
 
 
-def _three_actor_report_ids(case: VulnerabilityCase) -> list[str]:
+def _three_actor_report_ids(case: as_VulnerabilityCase) -> list[str]:
     return [
         ref_id(report) or str(report) for report in case.vulnerability_reports
     ]
 
 
 def _assert_three_actor_active_embargo(
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
     embargo_id: str,
 ) -> None:
     if case.current_status.em_state != EM.ACTIVE:
@@ -444,7 +446,7 @@ def _assert_three_actor_active_embargo(
 
 def _assert_three_actor_embargo_acceptance(
     case_actor_client: DataLayerClient,
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
     actor_ids: tuple[str, ...],
     embargo_id: str,
 ) -> None:
@@ -456,7 +458,7 @@ def _assert_three_actor_embargo_acceptance(
             raise AssertionError(
                 f"Participant record {participant_id} not found in CaseActor DataLayer"
             )
-        participant = CaseParticipant(**participant_data)
+        participant = as_CaseParticipant(**participant_data)
         if embargo_id not in participant.accepted_embargo_ids:
             raise AssertionError(
                 f"Participant {participant_id} did not record acceptance of "
@@ -473,9 +475,9 @@ def verify_case_actor_case_state(
     reporter_actor_id: str,
     vendor_actor_id: str,
     embargo_id: str,
-) -> VulnerabilityCase:
+) -> as_VulnerabilityCase:
     """Assert the authoritative final case state on the CaseActor container."""
-    final_case = VulnerabilityCase(
+    final_case = as_VulnerabilityCase(
         **case_actor_client.get(f"/datalayer/{case_id}")
     )
     actor_ids = (coordinator_actor_id, reporter_actor_id, vendor_actor_id)

--- a/vultron/demo/scenario/two_actor_demo.py
+++ b/vultron/demo/scenario/two_actor_demo.py
@@ -35,9 +35,11 @@ from vultron.core.states.cs import CS_vfd
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.base.objects.object_types import as_Note
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 from vultron.demo.utils import (  # noqa: F401 — re-exported for test monkeypatching
@@ -177,7 +179,7 @@ def finder_submits_report(
     finder: as_Actor,
     vendor: as_Actor,
     finder_client: Optional[DataLayerClient] = None,
-) -> Tuple[VulnerabilityReport, as_Offer]:
+) -> Tuple[as_VulnerabilityReport, as_Offer]:
     """Scenario alias for :func:`~vultron.demo.helpers.workflow.reporter_submits_report`.
 
     Maintained for backward compatibility; prefer ``reporter_submits_report``
@@ -230,7 +232,7 @@ def finder_asks_question(
     finder_client: DataLayerClient,
     vendor: as_Actor,
     finder: as_Actor,
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
 ) -> as_Note:
     """Scenario alias: finder adds a question note to the case.
 
@@ -256,7 +258,7 @@ def vendor_replies_to_question(
     finder_client: DataLayerClient,
     vendor: as_Actor,
     finder: as_Actor,
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
     question_note: as_Note,
 ) -> as_Note:
     """Scenario alias: vendor adds a reply note to the case.
@@ -288,7 +290,7 @@ def verify_vendor_case_state(
     reporter_actor_id: str,
     question_note_id: Optional[str] = None,
     reply_note_id: Optional[str] = None,
-) -> VulnerabilityCase:
+) -> as_VulnerabilityCase:
     """Scenario alias for :func:`~vultron.demo.helpers.verification.verify_receiver_case_state`.
 
     Maintained for backward compatibility; prefer
@@ -399,9 +401,9 @@ def _phase_report_submission(
     as_Actor,
     as_Actor,
     as_Actor,
-    VulnerabilityReport,
+    as_VulnerabilityReport,
     as_Offer,
-    VulnerabilityCase,
+    as_VulnerabilityCase,
 ]:
     """Run reset, seeding, report submission, validation, and M1 verification."""
     logger.info("─" * 80)
@@ -435,11 +437,11 @@ def _phase_report_submission(
         offer_id=offer.id_,
     )
 
-    with demo_check("VulnerabilityCase exists in Vendor's DataLayer"):
+    with demo_check("as_VulnerabilityCase exists in Vendor's DataLayer"):
         case = find_case_for_offer(vendor_client, offer.id_)
         if case is None:
             raise AssertionError(
-                "Expected VulnerabilityCase to be created after validate-report"
+                "Expected as_VulnerabilityCase to be created after validate-report"
             )
         logger.info("Case created: %s", case.id_)
 
@@ -481,7 +483,7 @@ def _phase_report_submission(
             reporter_actor_id=finder.id_,
         )
 
-    case = VulnerabilityCase.model_validate(
+    case = as_VulnerabilityCase.model_validate(
         vendor_client.get(f"/datalayer/{case.id_}")
     )
     return finder, vendor, vendor_in_vendor, report, offer, case
@@ -493,9 +495,9 @@ def _phase_notes_exchange(
     finder: as_Actor,
     vendor: as_Actor,
     vendor_in_vendor: as_Actor,
-    case: VulnerabilityCase,
-    report: VulnerabilityReport,
-) -> tuple[as_Note, as_Note, VulnerabilityCase, as_Actor]:
+    case: as_VulnerabilityCase,
+    report: as_VulnerabilityReport,
+) -> tuple[as_Note, as_Note, as_VulnerabilityCase, as_Actor]:
     """Run the question-and-reply note exchange and verify M3 state."""
     logger.info("─" * 80)
     logger.info("Phase 3: Notes exchange")
@@ -540,7 +542,7 @@ def _phase_sync_verification(
     vendor_client: DataLayerClient,
     vendor: as_Actor,
     finder: as_Actor,
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
     case_actor_client: DataLayerClient | None,
 ) -> None:
     """Verify SYNC-2 replication and confirm the dedicated case actor is unused."""
@@ -602,7 +604,7 @@ def _phase_fix_lifecycle(
     vendor_client: DataLayerClient,
     vendor: as_Actor,
     vendor_in_vendor: as_Actor,
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
 ) -> None:
     """Advance the case through fix-ready and fix-deployed milestones."""
     logger.info("─" * 80)
@@ -667,7 +669,7 @@ def _phase_publication(
     vendor_in_vendor: as_Actor,
     finder: as_Actor,
     finder_in_finder: as_Actor,
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
 ) -> None:
     """Run publication notifications and verify public disclosure state."""
     logger.info("─" * 80)
@@ -719,7 +721,7 @@ def _phase_case_closure(
     vendor_in_vendor: as_Actor,
     finder: as_Actor,
     finder_in_finder: as_Actor,
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
 ) -> None:
     """Close the case from both participants and verify terminal state."""
     logger.info("─" * 80)
@@ -782,7 +784,7 @@ def _phase_dump_case_ledgers(
     vendor_client: DataLayerClient,
     finder: as_Actor,
     vendor: as_Actor,
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
     case_actor_client: DataLayerClient | None = None,
     demo_name: str = "two-actor",
 ) -> None:
@@ -804,7 +806,7 @@ def _phase_dump_case_ledgers(
         vendor_client: DataLayerClient for the Vendor container.
         finder: Finder actor object (used to derive the actor object ID).
         vendor: Vendor actor object (used to derive the actor object ID).
-        case: The VulnerabilityCase whose log entries are to be exported.
+        case: The as_VulnerabilityCase whose log entries are to be exported.
         case_actor_client: Optional DataLayerClient for the CaseActor container.
         demo_name: Sub-directory name under the output root (default
             ``"two-actor"``).

--- a/vultron/demo/utils.py
+++ b/vultron/demo/utils.py
@@ -42,7 +42,9 @@ from vultron.wire.as2.vocab.base.objects.activities.base import as_Activity
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.base.objects.base import as_Object
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -413,11 +415,11 @@ def get_offer_from_datalayer(
 
 def log_case_state(
     client: DataLayerClient, case_id: str, label: str
-) -> Optional[VulnerabilityCase]:
+) -> Optional[as_VulnerabilityCase]:
     """Fetch and log the current state of a case."""
     try:
         case_data = client.get(f"/datalayer/{case_id}")
-        case = VulnerabilityCase(**case_data)
+        case = as_VulnerabilityCase(**case_data)
         logger.info(
             f"Case state [{label}]: reports={len(case.vulnerability_reports)}, "
             f"participants={len(case.case_participants)}"

--- a/vultron/wire/as2/factories/actor.py
+++ b/vultron/wire/as2/factories/actor.py
@@ -44,9 +44,9 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Reject,
 )
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
-    VulnerabilityCaseRef,
+    as_VulnerabilityCaseRef,
 )
 
 logger = logging.getLogger(__name__)
@@ -54,7 +54,7 @@ logger = logging.getLogger(__name__)
 
 def recommend_actor_activity(
     recommended: CoreActor | as_Actor,
-    target: VulnerabilityCaseRef | None = None,
+    target: as_VulnerabilityCaseRef | None = None,
     **kwargs,
 ) -> as_Offer:
     """Build an Offer(Actor, target=VulnerabilityCase) — actor recommendation.
@@ -90,7 +90,7 @@ def recommend_actor_activity(
 
 def accept_actor_recommendation_activity(
     offer: as_Offer,
-    target: VulnerabilityCaseRef | None = None,
+    target: as_VulnerabilityCaseRef | None = None,
     **kwargs,
 ) -> as_Accept:
     """Build an Accept(_RecommendActorActivity).
@@ -133,7 +133,7 @@ def accept_actor_recommendation_activity(
 
 def reject_actor_recommendation_activity(
     offer: as_Offer,
-    target: VulnerabilityCaseRef | None = None,
+    target: as_VulnerabilityCaseRef | None = None,
     **kwargs,
 ) -> as_Reject:
     """Build a Reject(_RecommendActorActivity).
@@ -174,14 +174,14 @@ def reject_actor_recommendation_activity(
 
 def offer_case_participant_activity(
     recommended: CoreActor | as_Actor,
-    target: VulnerabilityCaseRef | None = None,
+    target: as_VulnerabilityCaseRef | None = None,
     roles: list[CVDRole] | None = None,
     **kwargs,
 ) -> as_Offer:
-    """Build an Offer(CaseParticipant{actor, roles}, Case) for the Case Owner.
+    """Build an Offer(as_CaseParticipant{actor, roles}, Case) for the Case Owner.
 
     Transforms the original ``Offer(Actor, Case)`` recommendation into a
-    typed ``Offer(CaseParticipant{actor, roles=[VENDOR]}, Case)`` addressed
+    typed ``Offer(as_CaseParticipant{actor, roles=[VENDOR]}, Case)`` addressed
     to the Case Owner.  ``origin`` in ``kwargs`` SHOULD carry the ID of the
     original ``Offer(Actor, Case)`` for causal traceability (CM-16-004).
 
@@ -193,14 +193,14 @@ def offer_case_participant_activity(
             (e.g. ``actor``, ``to``, ``origin``).
 
     Returns:
-        An ``as_Offer`` whose ``object_`` is a ``CaseParticipant``.
+        An ``as_Offer`` whose ``object_`` is a ``as_CaseParticipant``.
 
     Raises:
         VultronActivityConstructionError: If Pydantic validation fails.
     """
     effective_roles = roles if roles is not None else [CVDRole.VENDOR]
     actor_id = getattr(recommended, "id_", None) or str(recommended)
-    participant = CaseParticipant(
+    participant = as_CaseParticipant(
         id_=f"{actor_id}#participant",
         attributed_to=recommended,
         case_roles=effective_roles,
@@ -220,7 +220,7 @@ def offer_case_participant_activity(
 
 def accept_case_participant_offer_activity(
     offer: as_Offer,
-    target: VulnerabilityCaseRef | None = None,
+    target: as_VulnerabilityCaseRef | None = None,
     **kwargs,
 ) -> as_Accept:
     """Build an Accept(_OfferCaseParticipantActivity) from the Case Owner.
@@ -231,7 +231,7 @@ def accept_case_participant_offer_activity(
         **kwargs: Optional AS2 fields forwarded to the constructor.
 
     Returns:
-        An ``as_Accept`` whose ``object_`` is the CaseParticipant offer.
+        An ``as_Accept`` whose ``object_`` is the as_CaseParticipant offer.
 
     Raises:
         VultronActivityConstructionError: If Pydantic validation fails.
@@ -254,7 +254,7 @@ def accept_case_participant_offer_activity(
 
 def reject_case_participant_offer_activity(
     offer: as_Offer,
-    target: VulnerabilityCaseRef | None = None,
+    target: as_VulnerabilityCaseRef | None = None,
     **kwargs,
 ) -> as_Reject:
     """Build a Reject(_OfferCaseParticipantActivity) from the Case Owner.
@@ -265,7 +265,7 @@ def reject_case_participant_offer_activity(
         **kwargs: Optional AS2 fields forwarded to the constructor.
 
     Returns:
-        An ``as_Reject`` whose ``object_`` is the CaseParticipant offer.
+        An ``as_Reject`` whose ``object_`` is the as_CaseParticipant offer.
 
     Raises:
         VultronActivityConstructionError: If Pydantic validation fails.

--- a/vultron/wire/as2/factories/case.py
+++ b/vultron/wire/as2/factories/case.py
@@ -16,7 +16,7 @@
 Factory functions for outbound Vultron case-management activities.
 
 These are the sole public construction API for activities involving
-``VulnerabilityCase`` objects. Internal activity subclasses are
+``as_VulnerabilityCase`` objects. Internal activity subclasses are
 imported here and MUST NOT be imported by callers.
 
 Spec: ``specs/activity-factories.yaml`` AF-01-001 through AF-04-003.
@@ -70,19 +70,19 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
 )
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor, as_ActorRef
 from vultron.wire.as2.vocab.base.objects.object_types import as_Note
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.case_status import CaseStatus
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.case_status import as_CaseStatus
 from vultron.wire.as2.vocab.objects.embargo_event import (
-    EmbargoEvent as WireEmbargoEvent,
+    as_EmbargoEvent as WireEmbargoEvent,
 )
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
-    VulnerabilityCase,
-    VulnerabilityCaseRef,
+    as_VulnerabilityCase,
+    as_VulnerabilityCaseRef,
     VulnerabilityCaseStub,
 )
 from vultron.wire.as2.vocab.objects.case_proposal import as_CaseProposal
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 logger = logging.getLogger(__name__)
@@ -92,7 +92,7 @@ def _project_case_to_stub(
     case: Any,
     embargo_obj: Any,
 ) -> VulnerabilityCaseStub:
-    """Project a ``VulnerabilityCase`` (core or wire) to a ``VulnerabilityCaseStub``.
+    """Project a ``as_VulnerabilityCase`` (core or wire) to a ``VulnerabilityCaseStub``.
 
     When ``em_state == EM.ACTIVE`` and *embargo_obj* is provided, the stub
     carries ``active_embargo`` (ID + ``end_time``) and ``case_status``
@@ -100,7 +100,7 @@ def _project_case_to_stub(
     Falls back to a minimal stub when the case has no active embargo.
 
     Args:
-        case: A core or wire ``VulnerabilityCase`` to project.
+        case: A core or wire ``as_VulnerabilityCase`` to project.
         embargo_obj: The fetched ``EmbargoEvent`` (core or wire), or ``None``.
     """
     case_id = case.id_
@@ -112,7 +112,7 @@ def _project_case_to_stub(
     active_embargo_uri = getattr(case, "active_embargo", None)
     if em_state != EM.ACTIVE or active_embargo_uri is None:
         return VulnerabilityCaseStub(id_=case_id)
-    wire_status = CaseStatus(em_state=em_state)
+    wire_status = as_CaseStatus(em_state=em_state)
     embargo_ref: WireEmbargoEvent | str = active_embargo_uri
     if embargo_obj is not None:
         end_time = getattr(embargo_obj, "end_time", None)
@@ -136,15 +136,15 @@ def _project_case_to_stub(
 
 
 def add_report_to_case_activity(
-    report: VulnerabilityReport,
-    target: VulnerabilityCaseRef | None = None,
+    report: as_VulnerabilityReport,
+    target: as_VulnerabilityCaseRef | None = None,
     **kwargs,
 ) -> as_Add:
-    """Build an Add(VulnerabilityReport, target=VulnerabilityCase).
+    """Build an Add(as_VulnerabilityReport, target=as_VulnerabilityCase).
 
     Args:
-        report: The ``VulnerabilityReport`` to add to the case.
-        target: The ``VulnerabilityCase`` (or its URI) to which the
+        report: The ``as_VulnerabilityReport`` to add to the case.
+        target: The ``as_VulnerabilityCase`` (or its URI) to which the
             report is being added.
         **kwargs: Optional AS2 fields forwarded to the constructor
             (e.g. ``actor``).
@@ -170,15 +170,15 @@ def add_report_to_case_activity(
 
 
 def add_status_to_case_activity(
-    status: CaseStatus,
-    target: VulnerabilityCaseRef | None = None,
+    status: as_CaseStatus,
+    target: as_VulnerabilityCaseRef | None = None,
     **kwargs,
 ) -> as_Add:
-    """Build an Add(CaseStatus, target=VulnerabilityCase).
+    """Build an Add(as_CaseStatus, target=as_VulnerabilityCase).
 
     Args:
-        status: The ``CaseStatus`` to add.
-        target: The ``VulnerabilityCase`` (or its URI) to which the
+        status: The ``as_CaseStatus`` to add.
+        target: The ``as_VulnerabilityCase`` (or its URI) to which the
             status is being added.
         **kwargs: Optional AS2 fields forwarded to the constructor
             (e.g. ``actor``).
@@ -203,13 +203,13 @@ def add_status_to_case_activity(
 
 
 def create_case_activity(
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
     **kwargs,
 ) -> as_Create:
-    """Build a Create(VulnerabilityCase).
+    """Build a Create(as_VulnerabilityCase).
 
     Args:
-        case: The ``VulnerabilityCase`` being created.
+        case: The ``as_VulnerabilityCase`` being created.
         **kwargs: Optional AS2 fields forwarded to the constructor
             (e.g. ``actor``, ``to``).
 
@@ -229,13 +229,13 @@ def create_case_activity(
 
 
 def create_case_status_activity(
-    status: CaseStatus,
+    status: as_CaseStatus,
     **kwargs,
 ) -> as_Create:
-    """Build a Create(CaseStatus).
+    """Build a Create(as_CaseStatus).
 
     Args:
-        status: The ``CaseStatus`` being created.
+        status: The ``as_CaseStatus`` being created.
         **kwargs: Optional AS2 fields forwarded to the constructor
             (e.g. ``actor``, ``to``).
 
@@ -258,14 +258,14 @@ def create_case_status_activity(
 
 def add_note_to_case_activity(
     note: as_Note,
-    target: VulnerabilityCaseRef | None = None,
+    target: as_VulnerabilityCaseRef | None = None,
     **kwargs,
 ) -> as_Add:
-    """Build an Add(Note, target=VulnerabilityCase).
+    """Build an Add(Note, target=as_VulnerabilityCase).
 
     Args:
         note: The ``as_Note`` to add to the case.
-        target: The ``VulnerabilityCase`` (or its URI) to which the
+        target: The ``as_VulnerabilityCase`` (or its URI) to which the
             note is being added.
         **kwargs: Optional AS2 fields forwarded to the constructor
             (e.g. ``actor``).
@@ -286,13 +286,13 @@ def add_note_to_case_activity(
 
 
 def update_case_activity(
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
     **kwargs,
 ) -> as_Update:
-    """Build an Update(VulnerabilityCase).
+    """Build an Update(as_VulnerabilityCase).
 
     Args:
-        case: The updated ``VulnerabilityCase``.
+        case: The updated ``as_VulnerabilityCase``.
         **kwargs: Optional AS2 fields forwarded to the constructor
             (e.g. ``actor``, ``to``).
 
@@ -312,16 +312,16 @@ def update_case_activity(
 
 
 def rm_engage_case_activity(
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
     **kwargs,
 ) -> as_Join:
-    """Build a Join(VulnerabilityCase) — the RA message.
+    """Build a Join(as_VulnerabilityCase) — the RA message.
 
     Signals that the actor is now actively working on the case
     (``RM.ACCEPTED`` state).
 
     Args:
-        case: The ``VulnerabilityCase`` being engaged.
+        case: The ``as_VulnerabilityCase`` being engaged.
         **kwargs: Optional AS2 fields forwarded to the constructor
             (e.g. ``actor``, ``to``).
 
@@ -341,16 +341,16 @@ def rm_engage_case_activity(
 
 
 def rm_defer_case_activity(
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
     **kwargs,
 ) -> as_Ignore:
-    """Build an Ignore(VulnerabilityCase) — the RD message.
+    """Build an Ignore(as_VulnerabilityCase) — the RD message.
 
     Signals that the actor is deferring work on the case
     (``RM.DEFERRED`` state).
 
     Args:
-        case: The ``VulnerabilityCase`` being deferred.
+        case: The ``as_VulnerabilityCase`` being deferred.
         **kwargs: Optional AS2 fields forwarded to the constructor
             (e.g. ``actor``, ``to``).
 
@@ -370,15 +370,15 @@ def rm_defer_case_activity(
 
 
 def rm_close_case_activity(
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
     **kwargs,
 ) -> as_Leave:
-    """Build a Leave(VulnerabilityCase) — the RC message.
+    """Build a Leave(as_VulnerabilityCase) — the RC message.
 
     Signals permanent closure / departure from the case.
 
     Args:
-        case: The ``VulnerabilityCase`` being closed.
+        case: The ``as_VulnerabilityCase`` being closed.
         **kwargs: Optional AS2 fields forwarded to the constructor
             (e.g. ``actor``, ``to``).
 
@@ -398,24 +398,24 @@ def rm_close_case_activity(
 
 
 def offer_case_manager_role_activity(
-    case: VulnerabilityCase,
-    target: CaseParticipant,
+    case: as_VulnerabilityCase,
+    target: as_CaseParticipant,
     **kwargs,
 ) -> as_Offer:
-    """Build an Offer(VulnerabilityCase, target=CaseParticipant) — CASE_MANAGER delegation.
+    """Build an Offer(as_VulnerabilityCase, target=as_CaseParticipant) — CASE_MANAGER delegation.
 
     Distinct from :func:`offer_case_ownership_transfer_activity`: the offering
     actor retains ``CASE_OWNER``; only operational management authority is
     delegated to the Case Actor participant.
 
-    The case MUST be passed as an inline ``VulnerabilityCase`` object and the
-    ``target`` MUST be an inline ``CaseParticipant`` object (not a bare string
+    The case MUST be passed as an inline ``as_VulnerabilityCase`` object and the
+    ``target`` MUST be an inline ``as_CaseParticipant`` object (not a bare string
     IRI) so that pattern matching can distinguish this activity from a
     case-ownership transfer (see DEMOMA-08-002, DEMOMA-08-003).
 
     Args:
-        case: The ``VulnerabilityCase`` for which management is being delegated.
-        target: The ``CaseParticipant`` record of the Case Actor being delegated
+        case: The ``as_VulnerabilityCase`` for which management is being delegated.
+        target: The ``as_CaseParticipant`` record of the Case Actor being delegated
             the CASE_MANAGER role.  Must be an inline typed object — bare string
             IRIs are rejected.
         **kwargs: Optional AS2 fields forwarded to the constructor
@@ -427,12 +427,12 @@ def offer_case_manager_role_activity(
 
     Raises:
         VultronActivityConstructionError: If ``target`` is not an inline
-            ``CaseParticipant`` or if Pydantic validation fails.
+            ``as_CaseParticipant`` or if Pydantic validation fails.
     """
-    if not isinstance(target, CaseParticipant):
+    if not isinstance(target, as_CaseParticipant):
         raise VultronActivityConstructionError(
             "offer_case_manager_role_activity: target must be an inline"
-            " CaseParticipant object, not a bare string IRI or None"
+            " as_CaseParticipant object, not a bare string IRI or None"
         )
     try:
         return _OfferCaseManagerRoleActivity(
@@ -523,18 +523,18 @@ def reject_case_manager_role_activity(
 
 
 def offer_case_ownership_transfer_activity(
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
     target: as_ActorRef | None = None,
     **kwargs,
 ) -> as_Offer:
-    """Build an Offer(VulnerabilityCase, target=Actor) — ownership transfer.
+    """Build an Offer(as_VulnerabilityCase, target=Actor) — ownership transfer.
 
-    The case MUST be passed as an inline ``VulnerabilityCase`` object, not
+    The case MUST be passed as an inline ``as_VulnerabilityCase`` object, not
     a bare string ID, so the recipient can distinguish this activity from
     a ``SUBMIT_REPORT`` Offer during semantic pattern matching.
 
     Args:
-        case: The ``VulnerabilityCase`` whose ownership is being offered.
+        case: The ``as_VulnerabilityCase`` whose ownership is being offered.
         target: The actor (or actor URI) to whom ownership is offered.
         **kwargs: Optional AS2 fields forwarded to the constructor
             (e.g. ``actor``).
@@ -642,7 +642,7 @@ def rm_invite_to_case_activity(
     embargo_obj: Any = None,
     **kwargs,
 ) -> as_Invite:
-    """Build an Invite(Actor, target=VulnerabilityCase) — the RS message.
+    """Build an Invite(Actor, target=as_VulnerabilityCase) — the RS message.
 
     Invites an actor to join a case that already exists.  See
     :func:`vultron.wire.as2.factories.report.rm_submit_report_activity`
@@ -650,7 +650,7 @@ def rm_invite_to_case_activity(
 
     Args:
         invitee: The ``as_Actor`` (or actor URI) being invited.
-        target: The case to join — either a ``VulnerabilityCase`` (core or wire;
+        target: The case to join — either a ``as_VulnerabilityCase`` (core or wire;
             projected to an enriched ``VulnerabilityCaseStub`` via
             :func:`_project_case_to_stub`), a pre-built ``VulnerabilityCaseStub``,
             or a bare URI string.
@@ -659,7 +659,7 @@ def rm_invite_to_case_activity(
             participant roles so ``CreateInviteeParticipantAtAcceptedNode``
             can set them on the new ``VultronParticipant``.
         embargo_obj: The fetched ``EmbargoEvent`` for the case, used when
-            *target* is a ``VulnerabilityCase`` and ``em_state == EM.ACTIVE``
+            *target* is a ``as_VulnerabilityCase`` and ``em_state == EM.ACTIVE``
             to include ``end_time`` in the stub (CM-17-002).
         **kwargs: Optional AS2 fields forwarded to the constructor
             (e.g. ``actor`` for the inviting party).
@@ -697,7 +697,7 @@ def rm_accept_invite_to_case_activity(
     ``in_reply_to`` to the invite's ``id_`` if not provided.
     The ``invite`` MUST be the value returned by
     :func:`rm_invite_to_case_activity`; a plain ``as_Invite`` that does
-    not carry a ``VulnerabilityCase`` target will fail validation.
+    not carry a ``as_VulnerabilityCase`` target will fail validation.
 
     Args:
         invite: The ``_RmInviteToCaseActivity`` being accepted.
@@ -762,17 +762,17 @@ def rm_reject_invite_to_case_activity(
 
 
 def announce_vulnerability_case_activity(
-    case: VulnerabilityCase,
+    case: as_VulnerabilityCase,
     **kwargs,
 ) -> as_Announce:
-    """Build an Announce(VulnerabilityCase) — sent by the case owner.
+    """Build an Announce(as_VulnerabilityCase) — sent by the case owner.
 
     Sent after an ``Accept(Invite)`` is received and the invitee's
     embargo consent has been verified.  The full case object is sent
     inline so the recipient can seed their local DataLayer.
 
     Args:
-        case: The complete ``VulnerabilityCase`` being announced.
+        case: The complete ``as_VulnerabilityCase`` being announced.
         **kwargs: Optional AS2 fields forwarded to the constructor
             (e.g. ``actor``, ``to``).
 
@@ -799,7 +799,7 @@ def bootstrap_replay_question_activity(
     case_id: str,
     **kwargs,
 ) -> as_Question:
-    """Build a Question requesting replay of the bootstrap Create(VulnerabilityCase).
+    """Build a Question requesting replay of the bootstrap Create(as_VulnerabilityCase).
 
     Sent by the receiving actor to the (suspected) case creator when the
     pre-bootstrap inbox queue expires without a valid bootstrap arriving
@@ -827,7 +827,7 @@ def bootstrap_replay_question_activity(
             context=case_id,
             name=kwargs.pop(
                 "name",
-                f"Please resend bootstrap Create(VulnerabilityCase) for {case_id}",
+                f"Please resend bootstrap Create(as_VulnerabilityCase) for {case_id}",
             ),
             **kwargs,
         )
@@ -891,8 +891,8 @@ def accept_case_proposal_activity(
     """Build an ``Accept(as_CaseProposal)`` sent by the case-actor service.
 
     The case-actor service sends this to acknowledge that it will create a
-    ``VulnerabilityCase`` from the vendor's proposal.  A separate
-    ``Create(VulnerabilityCase)`` follows (CP-05-003).
+    ``as_VulnerabilityCase`` from the vendor's proposal.  A separate
+    ``Create(as_VulnerabilityCase)`` follows (CP-05-003).
 
     Args:
         actor_id: URI of the case-actor service that is accepting the proposal.

--- a/vultron/wire/as2/factories/case_participant.py
+++ b/vultron/wire/as2/factories/case_participant.py
@@ -16,7 +16,7 @@
 Factory functions for outbound Vultron case-participant activities.
 
 These are the sole public construction API for activities involving
-``CaseParticipant`` objects. Internal activity subclasses are
+``as_CaseParticipant`` objects. Internal activity subclasses are
 imported here and MUST NOT be imported by callers.
 
 Spec: ``specs/activity-factories.yaml`` AF-01-001 through AF-04-003.
@@ -40,29 +40,29 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Remove,
 )
 from vultron.wire.as2.vocab.objects.case_participant import (
-    CaseParticipant,
-    CaseParticipantRef,
+    as_CaseParticipant,
+    as_CaseParticipantRef,
 )
-from vultron.wire.as2.vocab.objects.case_status import ParticipantStatus
+from vultron.wire.as2.vocab.objects.case_status import as_ParticipantStatus
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
-    VulnerabilityCaseRef,
+    as_VulnerabilityCaseRef,
 )
 
 logger = logging.getLogger(__name__)
 
 
 def create_participant_activity(
-    participant: CaseParticipant,
-    target: VulnerabilityCaseRef | None = None,
+    participant: as_CaseParticipant,
+    target: as_VulnerabilityCaseRef | None = None,
     **kwargs,
 ) -> as_Create:
-    """Build a Create(CaseParticipant).
+    """Build a Create(as_CaseParticipant).
 
     The internal class automatically generates a descriptive ``name``
     field if one is not provided.
 
     Args:
-        participant: The ``CaseParticipant`` being created.
+        participant: The ``as_CaseParticipant`` being created.
         target: The ``VulnerabilityCase`` (or its URI) this participant
             is being created for.
         **kwargs: Optional AS2 fields forwarded to the constructor
@@ -88,15 +88,15 @@ def create_participant_activity(
 
 
 def create_status_for_participant_activity(
-    status: ParticipantStatus,
-    target: CaseParticipantRef | None = None,
+    status: as_ParticipantStatus,
+    target: as_CaseParticipantRef | None = None,
     **kwargs,
 ) -> as_Create:
-    """Build a Create(ParticipantStatus, target=CaseParticipant).
+    """Build a Create(as_ParticipantStatus, target=as_CaseParticipant).
 
     Args:
-        status: The ``ParticipantStatus`` being created.
-        target: The ``CaseParticipant`` (or its URI) for whom the
+        status: The ``as_ParticipantStatus`` being created.
+        target: The ``as_CaseParticipant`` (or its URI) for whom the
             status is being created.
         **kwargs: Optional AS2 fields forwarded to the constructor
             (e.g. ``actor``).
@@ -122,15 +122,15 @@ def create_status_for_participant_activity(
 
 
 def add_status_to_participant_activity(
-    status: ParticipantStatus,
-    target: CaseParticipantRef | None = None,
+    status: as_ParticipantStatus,
+    target: as_CaseParticipantRef | None = None,
     **kwargs,
 ) -> as_Add:
-    """Build an Add(ParticipantStatus, target=CaseParticipant).
+    """Build an Add(as_ParticipantStatus, target=as_CaseParticipant).
 
     Args:
-        status: The ``ParticipantStatus`` to add.
-        target: The ``CaseParticipant`` (or its URI) to which the
+        status: The ``as_ParticipantStatus`` to add.
+        target: The ``as_CaseParticipant`` (or its URI) to which the
             status is being added.
         **kwargs: Optional AS2 fields forwarded to the constructor
             (e.g. ``actor``).
@@ -155,14 +155,14 @@ def add_status_to_participant_activity(
 
 
 def add_participant_to_case_activity(
-    participant: CaseParticipant,
-    target: VulnerabilityCaseRef | None = None,
+    participant: as_CaseParticipant,
+    target: as_VulnerabilityCaseRef | None = None,
     **kwargs,
 ) -> as_Add:
-    """Build an Add(CaseParticipant, target=VulnerabilityCase).
+    """Build an Add(as_CaseParticipant, target=VulnerabilityCase).
 
     Args:
-        participant: The ``CaseParticipant`` to add to the case.
+        participant: The ``as_CaseParticipant`` to add to the case.
         target: The ``VulnerabilityCase`` (or its URI) to which the
             participant is being added.
         **kwargs: Optional AS2 fields forwarded to the constructor
@@ -188,16 +188,16 @@ def add_participant_to_case_activity(
 
 
 def remove_participant_from_case_activity(
-    participant: CaseParticipant,
-    target: VulnerabilityCaseRef | None = None,
+    participant: as_CaseParticipant,
+    target: as_VulnerabilityCaseRef | None = None,
     **kwargs,
 ) -> as_Remove:
-    """Build a Remove(CaseParticipant, target=VulnerabilityCase).
+    """Build a Remove(as_CaseParticipant, target=VulnerabilityCase).
 
     This MUST only be performed by the case owner.
 
     Args:
-        participant: The ``CaseParticipant`` to remove from the case.
+        participant: The ``as_CaseParticipant`` to remove from the case.
         target: The ``VulnerabilityCase`` (or its URI) from which the
             participant is being removed.
         **kwargs: Optional AS2 fields forwarded to the constructor

--- a/vultron/wire/as2/factories/embargo.py
+++ b/vultron/wire/as2/factories/embargo.py
@@ -16,7 +16,7 @@
 Factory functions for outbound Vultron embargo-management activities.
 
 These are the sole public construction API for activities involving
-``EmbargoEvent`` objects. Internal activity subclasses are
+``as_EmbargoEvent`` objects. Internal activity subclasses are
 imported here and MUST NOT be imported by callers.
 
 Spec: ``specs/activity-factories.yaml`` AF-01-001 through AF-04-003.
@@ -50,27 +50,27 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Remove,
 )
 from vultron.wire.as2.vocab.objects.embargo_event import (
-    EmbargoEvent,
-    EmbargoEventRef,
+    as_EmbargoEvent,
+    as_EmbargoEventRef,
 )
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
-    VulnerabilityCaseRef,
+    as_VulnerabilityCaseRef,
 )
 
 logger = logging.getLogger(__name__)
 
 
 def em_propose_embargo_activity(
-    embargo: EmbargoEvent,
-    context: VulnerabilityCaseRef | None = None,
+    embargo: as_EmbargoEvent,
+    context: as_VulnerabilityCaseRef | None = None,
     **kwargs,
 ) -> as_Invite:
-    """Build an Invite(EmbargoEvent) — the EP/EV message.
+    """Build an Invite(as_EmbargoEvent) — the EP/EV message.
 
     Proposes a new embargo for the case.
 
     Args:
-        embargo: The ``EmbargoEvent`` being proposed.
+        embargo: The ``as_EmbargoEvent`` being proposed.
         context: The ``VulnerabilityCase`` (or its URI) for which the
             embargo is being proposed.
         **kwargs: Optional AS2 fields forwarded to the constructor
@@ -97,13 +97,13 @@ def em_propose_embargo_activity(
 
 def em_accept_embargo_activity(
     proposal: as_Invite,
-    context: VulnerabilityCaseRef | None = None,
+    context: as_VulnerabilityCaseRef | None = None,
     **kwargs,
 ) -> as_Accept:
     """Build an Accept(_EmProposeEmbargoActivity) — the EA/EC message.
 
     Per ActivityStreams convention the actor accepts the proposal
-    activity itself, not the ``EmbargoEvent`` being proposed.
+    activity itself, not the ``as_EmbargoEvent`` being proposed.
     The ``proposal`` MUST be the value returned by
     :func:`em_propose_embargo_activity`; a plain ``as_Invite`` will
     fail validation.
@@ -138,13 +138,13 @@ def em_accept_embargo_activity(
 
 def em_reject_embargo_activity(
     proposal: as_Invite,
-    context: VulnerabilityCaseRef | None = None,
+    context: as_VulnerabilityCaseRef | None = None,
     **kwargs,
 ) -> as_Reject:
     """Build a Reject(_EmProposeEmbargoActivity) — the ER/EJ message.
 
     Per ActivityStreams convention the actor rejects the proposal
-    activity itself, not the ``EmbargoEvent`` being proposed.
+    activity itself, not the ``as_EmbargoEvent`` being proposed.
     The ``proposal`` MUST be the value returned by
     :func:`em_propose_embargo_activity`; a plain ``as_Invite`` will
     fail validation.
@@ -178,8 +178,8 @@ def em_reject_embargo_activity(
 
 
 def choose_preferred_embargo_activity(
-    any_of: Sequence[EmbargoEventRef] | None = None,
-    one_of: Sequence[EmbargoEventRef] | None = None,
+    any_of: Sequence[as_EmbargoEventRef] | None = None,
+    one_of: Sequence[as_EmbargoEventRef] | None = None,
     **kwargs,
 ) -> as_Question:
     """Build a Question asking participants to indicate embargo preferences.
@@ -190,9 +190,9 @@ def choose_preferred_embargo_activity(
     specified but not both.
 
     Args:
-        any_of: Sequence of ``EmbargoEventRef`` items — participants
+        any_of: Sequence of ``as_EmbargoEventRef`` items — participants
             may select any subset.
-        one_of: Sequence of ``EmbargoEventRef`` items — participants
+        one_of: Sequence of ``as_EmbargoEventRef`` items — participants
             must select exactly one.
         **kwargs: Optional AS2 fields forwarded to the constructor
             (e.g. ``actor``, ``to``).
@@ -218,19 +218,19 @@ def choose_preferred_embargo_activity(
 
 
 def activate_embargo_activity(
-    embargo: EmbargoEvent,
-    target: VulnerabilityCaseRef | None = None,
+    embargo: as_EmbargoEvent,
+    target: as_VulnerabilityCaseRef | None = None,
     in_reply_to: _EmProposeEmbargoActivity | str | None = None,
     **kwargs,
 ) -> as_Add:
-    """Build an Add(EmbargoEvent) — activates the embargo on the case.
+    """Build an Add(as_EmbargoEvent) — activates the embargo on the case.
 
     Corresponds to the EA/EC message at the case level.  Use this when
     the case owner is activating an embargo in response to a previous
     :func:`em_propose_embargo_activity`.
 
     Args:
-        embargo: The ``EmbargoEvent`` being activated.
+        embargo: The ``as_EmbargoEvent`` being activated.
         target: The ``VulnerabilityCase`` (or its URI) for which the
             embargo is activated.
         in_reply_to: The ``_EmProposeEmbargoActivity`` (or its URI)
@@ -259,18 +259,18 @@ def activate_embargo_activity(
 
 
 def add_embargo_to_case_activity(
-    embargo: EmbargoEvent,
-    target: VulnerabilityCaseRef | None = None,
+    embargo: as_EmbargoEvent,
+    target: as_VulnerabilityCaseRef | None = None,
     **kwargs,
 ) -> as_Add:
-    """Build an Add(EmbargoEvent, target=VulnerabilityCase).
+    """Build an Add(as_EmbargoEvent, target=VulnerabilityCase).
 
     Use when the case owner is adding an embargo without a prior
     proposal.  When activating in response to a prior proposal, prefer
     :func:`activate_embargo_activity` which carries ``in_reply_to``.
 
     Args:
-        embargo: The ``EmbargoEvent`` to add.
+        embargo: The ``as_EmbargoEvent`` to add.
         target: The ``VulnerabilityCase`` (or its URI) to which the
             embargo is being added.
         **kwargs: Optional AS2 fields forwarded to the constructor
@@ -296,14 +296,14 @@ def add_embargo_to_case_activity(
 
 
 def announce_embargo_activity(
-    embargo: EmbargoEvent,
-    context: VulnerabilityCaseRef | None = None,
+    embargo: as_EmbargoEvent,
+    context: as_VulnerabilityCaseRef | None = None,
     **kwargs,
 ) -> as_Announce:
-    """Build an Announce(EmbargoEvent) — announces an active embargo.
+    """Build an Announce(as_EmbargoEvent) — announces an active embargo.
 
     Args:
-        embargo: The ``EmbargoEvent`` being announced.
+        embargo: The ``as_EmbargoEvent`` being announced.
         context: The ``VulnerabilityCase`` (or its URI) for which the
             embargo is active.
         **kwargs: Optional AS2 fields forwarded to the constructor
@@ -327,20 +327,20 @@ def announce_embargo_activity(
 
 
 def remove_embargo_from_case_activity(
-    embargo: EmbargoEvent,
-    origin: VulnerabilityCaseRef | None = None,
+    embargo: as_EmbargoEvent,
+    origin: as_VulnerabilityCaseRef | None = None,
     **kwargs,
 ) -> as_Remove:
-    """Build a Remove(EmbargoEvent, origin=VulnerabilityCase).
+    """Build a Remove(as_EmbargoEvent, origin=VulnerabilityCase).
 
-    Removes an ``EmbargoEvent`` from the ``proposedEmbargoes`` of a
+    Removes an ``as_EmbargoEvent`` from the ``proposedEmbargoes`` of a
     case. This MUST only be performed by the case owner.
 
     Note: this activity uses ``origin`` (not ``target``) for the case
     reference, following the ActivityStreams convention for Remove.
 
     Args:
-        embargo: The ``EmbargoEvent`` to remove.
+        embargo: The ``as_EmbargoEvent`` to remove.
         origin: The ``VulnerabilityCase`` (or its URI) from which
             the embargo is removed.
         **kwargs: Optional AS2 fields forwarded to the constructor

--- a/vultron/wire/as2/factories/report.py
+++ b/vultron/wire/as2/factories/report.py
@@ -16,7 +16,7 @@
 Factory functions for outbound Vultron report-management activities.
 
 These are the sole public construction API for activities involving
-``VulnerabilityReport`` objects.  Internal activity subclasses are
+``as_VulnerabilityReport`` objects.  Internal activity subclasses are
 imported here and MUST NOT be imported by callers.
 
 Spec: ``specs/activity-factories.yaml`` AF-01-001, AF-02-001, AF-03-001
@@ -44,18 +44,18 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
 )
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 
 def rm_create_report_activity(
-    report: VulnerabilityReport,
+    report: as_VulnerabilityReport,
     **kwargs,
 ) -> as_Create:
-    """Build a Create(VulnerabilityReport) — the reporter creates a report.
+    """Build a Create(as_VulnerabilityReport) — the reporter creates a report.
 
     Args:
-        report: The ``VulnerabilityReport`` to create.
+        report: The ``as_VulnerabilityReport`` to create.
         **kwargs: Optional AS2 fields forwarded to the constructor
             (e.g. ``actor``, ``to``).
 
@@ -74,14 +74,14 @@ def rm_create_report_activity(
 
 
 def rm_submit_report_activity(
-    report: VulnerabilityReport,
+    report: as_VulnerabilityReport,
     to: as_Actor | str,
     **kwargs,
 ) -> as_Offer:
-    """Build an Offer(VulnerabilityReport) — the RS message when no case exists.
+    """Build an Offer(as_VulnerabilityReport) — the RS message when no case exists.
 
     Args:
-        report: The ``VulnerabilityReport`` to submit.
+        report: The ``as_VulnerabilityReport`` to submit.
         to: The recipient actor object or actor ID URI string.  The factory
             always normalizes this to a single-element ``to`` list.
         **kwargs: Optional AS2 fields forwarded to the constructor
@@ -103,13 +103,13 @@ def rm_submit_report_activity(
 
 
 def rm_read_report_activity(
-    report: VulnerabilityReport,
+    report: as_VulnerabilityReport,
     **kwargs,
 ) -> as_Read:
-    """Build a Read(VulnerabilityReport) — the RK message when no case exists.
+    """Build a Read(as_VulnerabilityReport) — the RK message when no case exists.
 
     Args:
-        report: The ``VulnerabilityReport`` that was read.
+        report: The ``as_VulnerabilityReport`` that was read.
         **kwargs: Optional AS2 fields forwarded to the constructor
             (e.g. ``actor``, ``to``).
 
@@ -138,7 +138,7 @@ def rm_validate_report_activity(
     subclass returned by :func:`rm_submit_report_activity`) or a plain
     ``as_Offer`` recovered from the datalayer.  Plain offers are coerced
     to ``_RmSubmitReportActivity`` at runtime; offers whose ``object_`` is
-    not a valid ``VulnerabilityReport`` will still fail validation.
+    not a valid ``as_VulnerabilityReport`` will still fail validation.
 
     Args:
         offer: The ``_RmSubmitReportActivity`` offer being accepted.
@@ -174,7 +174,7 @@ def rm_invalidate_report_activity(
     subclass returned by :func:`rm_submit_report_activity`) or a plain
     ``as_Offer`` recovered from the datalayer.  Plain offers are coerced
     to ``_RmSubmitReportActivity`` at runtime; offers whose ``object_`` is
-    not a valid ``VulnerabilityReport`` will still fail validation.
+    not a valid ``as_VulnerabilityReport`` will still fail validation.
 
     Args:
         offer: The ``_RmSubmitReportActivity`` offer being tentatively rejected.
@@ -212,7 +212,7 @@ def rm_close_report_activity(
     subclass returned by :func:`rm_submit_report_activity`) or a plain
     ``as_Offer`` recovered from the datalayer.  Plain offers are coerced
     to ``_RmSubmitReportActivity`` at runtime; offers whose ``object_`` is
-    not a valid ``VulnerabilityReport`` will still fail validation.
+    not a valid ``as_VulnerabilityReport`` will still fail validation.
 
     Args:
         offer: The ``_RmSubmitReportActivity`` offer being closed.
@@ -239,12 +239,12 @@ def rm_close_report_activity(
 
 def parse_submit_report_offer(
     offer_data: dict | as_Offer,
-) -> tuple[VulnerabilityReport, as_Offer]:
+) -> tuple[as_VulnerabilityReport, as_Offer]:
     """Parse a submit-report offer from wire data into its component parts.
 
     Accepts either a raw dict (e.g. from a trigger endpoint JSON response)
     or an ``as_Offer`` instance and coerces it to ``_RmSubmitReportActivity``
-    so the embedded ``VulnerabilityReport`` — including its stable ID — is
+    so the embedded ``as_VulnerabilityReport`` — including its stable ID — is
     preserved.  This is the correct way for the demo and adapter layers to
     extract the report from a trigger response without importing internal
     activity subclasses directly.
@@ -255,12 +255,12 @@ def parse_submit_report_offer(
 
     Returns:
         A ``(report, offer)`` tuple where *report* is the
-        ``VulnerabilityReport`` embedded in the offer and *offer* is the
+        ``as_VulnerabilityReport`` embedded in the offer and *offer* is the
         coerced ``_RmSubmitReportActivity`` suitable for inbox delivery.
 
     Raises:
         VultronActivityConstructionError: If the data cannot be validated as
-            a submit-report offer containing a ``VulnerabilityReport``.
+            a submit-report offer containing a ``as_VulnerabilityReport``.
     """
     try:
         if isinstance(offer_data, dict):

--- a/vultron/wire/as2/factories/sync.py
+++ b/vultron/wire/as2/factories/sync.py
@@ -37,13 +37,13 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Announce,
     as_Reject,
 )
-from vultron.wire.as2.vocab.objects.case_ledger_entry import CaseLedgerEntry
+from vultron.wire.as2.vocab.objects.case_ledger_entry import as_CaseLedgerEntry
 
 logger = logging.getLogger(__name__)
 
 
 def announce_log_entry_activity(
-    entry: CaseLedgerEntry,
+    entry: as_CaseLedgerEntry,
     **kwargs,
 ) -> as_Announce:
     """Build an Announce(CaseLedgerEntry) — fan-out replication to participants.
@@ -74,7 +74,7 @@ def announce_log_entry_activity(
 
 
 def reject_log_entry_activity(
-    entry: CaseLedgerEntry,
+    entry: as_CaseLedgerEntry,
     context: str | None = None,
     **kwargs,
 ) -> as_Reject:

--- a/vultron/wire/as2/vocab/activities/actor.py
+++ b/vultron/wire/as2/vocab/activities/actor.py
@@ -24,9 +24,9 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Reject,
 )
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
-    VulnerabilityCaseRef,
+    as_VulnerabilityCaseRef,
 )
 
 
@@ -36,7 +36,7 @@ class _RecommendActorActivity(as_Offer):
     object_: CoreActor | as_Actor = Field(
         ..., validation_alias="object", serialization_alias="object"
     )
-    target: VulnerabilityCaseRef = None
+    target: as_VulnerabilityCaseRef = None
 
 
 class _AcceptActorRecommendationActivity(as_Accept):
@@ -50,7 +50,7 @@ class _AcceptActorRecommendationActivity(as_Accept):
     object_: _RecommendActorActivity = Field(
         ..., validation_alias="object", serialization_alias="object"
     )
-    target: VulnerabilityCaseRef = None
+    target: as_VulnerabilityCaseRef = None
 
 
 class _RejectActorRecommendationActivity(as_Reject):
@@ -63,7 +63,7 @@ class _RejectActorRecommendationActivity(as_Reject):
     object_: _RecommendActorActivity = Field(
         ..., validation_alias="object", serialization_alias="object"
     )
-    target: VulnerabilityCaseRef = None
+    target: as_VulnerabilityCaseRef = None
 
 
 class _OfferCaseParticipantActivity(as_Offer):
@@ -75,10 +75,10 @@ class _OfferCaseParticipantActivity(as_Offer):
     (CM-16-004, ADR-0026).
     """
 
-    object_: CaseParticipant = Field(
+    object_: as_CaseParticipant = Field(
         ..., validation_alias="object", serialization_alias="object"
     )
-    target: VulnerabilityCaseRef = None
+    target: as_VulnerabilityCaseRef = None
 
 
 class _AcceptCaseParticipantOfferActivity(as_Accept):
@@ -90,7 +90,7 @@ class _AcceptCaseParticipantOfferActivity(as_Accept):
     object_: _OfferCaseParticipantActivity = Field(
         ..., validation_alias="object", serialization_alias="object"
     )
-    target: VulnerabilityCaseRef = None
+    target: as_VulnerabilityCaseRef = None
 
 
 class _RejectCaseParticipantOfferActivity(as_Reject):
@@ -102,7 +102,7 @@ class _RejectCaseParticipantOfferActivity(as_Reject):
     object_: _OfferCaseParticipantActivity = Field(
         ..., validation_alias="object", serialization_alias="object"
     )
-    target: VulnerabilityCaseRef = None
+    target: as_VulnerabilityCaseRef = None
 
 
 # NOTE: Old non-suffixed names were removed intentionally. Use the

--- a/vultron/wire/as2/vocab/activities/case.py
+++ b/vultron/wire/as2/vocab/activities/case.py
@@ -35,15 +35,15 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
 from vultron.core.models.actor import CoreActor
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor, as_ActorRef
 from vultron.wire.as2.vocab.base.objects.object_types import as_Note
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.case_status import CaseStatus
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.case_status import as_CaseStatus
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
-    VulnerabilityCase,
-    VulnerabilityCaseRef,
+    as_VulnerabilityCase,
+    as_VulnerabilityCaseRef,
     VulnerabilityCaseStub,
 )
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 ########################################################################################
@@ -53,14 +53,14 @@ from vultron.wire.as2.vocab.objects.vulnerability_report import (
 
 class _AddReportToCaseActivity(as_Add):
     """Add a VulnerabilityReport to a VulnerabilityCase
-    object_: VulnerabilityReport
-    target: VulnerabilityCase
+    object_: as_VulnerabilityReport
+    target: as_VulnerabilityCase
     """
 
-    object_: VulnerabilityReport = Field(
+    object_: as_VulnerabilityReport = Field(
         ..., validation_alias="object", serialization_alias="object"
     )
-    target: VulnerabilityCaseRef = None
+    target: as_VulnerabilityCaseRef = None
 
 
 # add CaseParticipant to VulnerabilityCase
@@ -73,14 +73,14 @@ class _AddStatusToCaseActivity(as_Add):
     This should only be performed by the case owner.
     Other case participants can add a case status to their participant record, which the case
     owner should then add to the case if appropriate.
-    object_: CaseStatus
-    target: VulnerabilityCase
+    object_: as_CaseStatus
+    target: as_VulnerabilityCase
     """
 
-    object_: CaseStatus = Field(
+    object_: as_CaseStatus = Field(
         ..., validation_alias="object", serialization_alias="object"
     )
-    target: VulnerabilityCaseRef = None
+    target: as_VulnerabilityCaseRef = None
 
 
 ########################################################################################
@@ -91,20 +91,20 @@ class _AddStatusToCaseActivity(as_Add):
 # create a VulnerabilityCase
 class _CreateCaseActivity(as_Create):
     """Create a VulnerabilityCase.
-    object_: VulnerabilityCase
+    object_: as_VulnerabilityCase
     """
 
-    object_: VulnerabilityCase = Field(
+    object_: as_VulnerabilityCase = Field(
         ..., validation_alias="object", serialization_alias="object"
     )
 
 
 class _CreateCaseStatusActivity(as_Create):
     """Create a CaseStatus.
-    object_: CaseStatus
+    object_: as_CaseStatus
     """
 
-    object_: CaseStatus = Field(
+    object_: as_CaseStatus = Field(
         ..., validation_alias="object", serialization_alias="object"
     )
 
@@ -113,22 +113,22 @@ class _CreateCaseStatusActivity(as_Create):
 class _AddNoteToCaseActivity(as_Add):
     """Add a Note to a VulnerabilityCase.
     object_: Note
-    target: VulnerabilityCase
+    target: as_VulnerabilityCase
     """
 
     object_: as_Note = Field(
         ..., validation_alias="object", serialization_alias="object"
     )
-    target: VulnerabilityCaseRef = None
+    target: as_VulnerabilityCaseRef = None
 
 
 # update a VulnerabilityCase
 class _UpdateCaseActivity(as_Update):
     """Update a VulnerabilityCase.
-    object_: VulnerabilityCase
+    object_: as_VulnerabilityCase
     """
 
-    object_: VulnerabilityCase = Field(
+    object_: as_VulnerabilityCase = Field(
         ..., validation_alias="object", serialization_alias="object"
     )
 
@@ -142,10 +142,10 @@ class _UpdateCaseActivity(as_Update):
 class _RmEngageCaseActivity(as_Join):
     """The actor is has joined (i.e., is actively working on) a case.
     This represents the Vultron Message Type RA, and indicates that the actor is now in the RM.ACCEPTED state.
-    object_: VulnerabilityCase
+    object_: as_VulnerabilityCase
     """
 
-    object_: VulnerabilityCase = Field(
+    object_: as_VulnerabilityCase = Field(
         ..., validation_alias="object", serialization_alias="object"
     )
 
@@ -157,10 +157,10 @@ class _RmDeferCaseActivity(as_Ignore):
     it just means that the actor is no longer actively working on it.
     This represents the Vultron Message Type RD, and indicates that the actor is now in the RM.DEFERRED state.
     Contrast with _RmCloseCaseActivity, which indicates that the actor is abandoning the case entirely.
-    object_: VulnerabilityCase
+    object_: as_VulnerabilityCase
     """
 
-    object_: VulnerabilityCase = Field(
+    object_: as_VulnerabilityCase = Field(
         ..., validation_alias="object", serialization_alias="object"
     )
 
@@ -171,10 +171,10 @@ class _RmCloseCaseActivity(as_Leave):
     Case closure is considered a permanent Leave from the case.
     If the case owner (attributedTo) is the actor, then the case is closed for all participants.
     If the actor is not the case owner, then the actor should be removed from the case participants.
-    object_: VulnerabilityCase
+    object_: as_VulnerabilityCase
     """
 
-    object_: VulnerabilityCase = Field(
+    object_: as_VulnerabilityCase = Field(
         ..., validation_alias="object", serialization_alias="object"
     )
 
@@ -188,16 +188,16 @@ class _OfferCaseManagerRoleActivity(as_Offer):
     that pattern matching can distinguish this activity from a case-ownership
     transfer (which carries no typed CaseParticipant target).
 
-    object_: VulnerabilityCase (inline — not a bare string ID)
-    target: CaseParticipant — the Case Actor's participant record
+    object_: as_VulnerabilityCase (inline — not a bare string ID)
+    target: as_CaseParticipant — the Case Actor's participant record
 
     See DEMOMA-08-002, DEMOMA-08-003.
     """
 
-    object_: VulnerabilityCase = Field(
+    object_: as_VulnerabilityCase = Field(
         ..., validation_alias="object", serialization_alias="object"
     )
-    target: CaseParticipant = Field(
+    target: as_CaseParticipant = Field(
         ..., validation_alias="target", serialization_alias="target"
     )
 
@@ -235,11 +235,11 @@ class _OfferCaseOwnershipTransferActivity(as_Offer):
     indistinguishable from a ``SUBMIT_REPORT`` Offer and causes incorrect
     dispatch.
 
-    object_: VulnerabilityCase (inline — not a bare string ID)
+    object_: as_VulnerabilityCase (inline — not a bare string ID)
     target: as_Actor
     """
 
-    object_: VulnerabilityCase = Field(
+    object_: as_VulnerabilityCase = Field(
         ..., validation_alias="object", serialization_alias="object"
     )
     target: as_ActorRef = None
@@ -274,7 +274,7 @@ class _RmInviteToCaseActivity(as_Invite):
     This corresponds to the Vultron Message Type RS when a case already exists.
     See also _RmSubmitReportActivity for the scenario when a case does not exist yet.
     object_: the Actor being invited
-    target: VulnerabilityCase
+    target: as_VulnerabilityCase
     roles: inherited from as_Invite (CM-17-003)
     """
 
@@ -335,6 +335,6 @@ class _AnnounceVulnerabilityCaseActivity(as_Announce):
     ``object_``: :class:`VulnerabilityCase` — the complete case object.
     """
 
-    object_: VulnerabilityCase = Field(
+    object_: as_VulnerabilityCase = Field(
         ..., validation_alias="object", serialization_alias="object"
     )

--- a/vultron/wire/as2/vocab/activities/case_participant.py
+++ b/vultron/wire/as2/vocab/activities/case_participant.py
@@ -27,31 +27,31 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
 )
 from vultron.wire.as2.vocab.base.utils import name_of
 from vultron.wire.as2.vocab.objects.case_participant import (
-    CaseParticipant,
-    CaseParticipantRef,
+    as_CaseParticipant,
+    as_CaseParticipantRef,
 )
 from vultron.wire.as2.vocab.objects.case_status import (
-    ParticipantStatus,
+    as_ParticipantStatus,
 )
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
-    VulnerabilityCaseRef,
+    as_VulnerabilityCaseRef,
 )
 
 
 class _CreateParticipantActivity(as_Create):
-    """Create a new CaseParticipant"""
+    """Create a new as_CaseParticipant"""
 
-    object_: CaseParticipant = Field(
+    object_: as_CaseParticipant = Field(
         ..., validation_alias="object", serialization_alias="object"
     )
-    target: VulnerabilityCaseRef = None
+    target: as_VulnerabilityCaseRef = None
 
     @model_validator(mode="after")
     def set_name(self):
-        """Override default name to clearly identify CaseParticipant creation.
+        """Override default name to clearly identify as_CaseParticipant creation.
 
         Produces a name of the form:
-            "{actor} Create CaseParticipant {participant_id} from {attributed_to} in {case_id}"
+            "{actor} Create as_CaseParticipant {participant_id} from {attributed_to} in {case_id}"
         making it obvious that a participant object is being created for an actor,
         not the actor itself.
         """
@@ -61,7 +61,7 @@ class _CreateParticipantActivity(as_Create):
         parts = []
         if self.actor is not None:
             parts.append(name_of(self.actor))
-        parts.append("Create CaseParticipant")
+        parts.append("Create as_CaseParticipant")
         participant_id = getattr(self.object_, "id_", None)
         if participant_id:
             parts.append(str(participant_id))
@@ -77,47 +77,47 @@ class _CreateParticipantActivity(as_Create):
 
 
 class _CreateStatusForParticipantActivity(as_Create):
-    """Create a new CaseStatus for a CaseParticipant"""
+    """Create a new CaseStatus for a as_CaseParticipant"""
 
-    object_: ParticipantStatus = Field(
+    object_: as_ParticipantStatus = Field(
         ..., validation_alias="object", serialization_alias="object"
     )
-    target: CaseParticipantRef = None
+    target: as_CaseParticipantRef = None
 
 
-# add CaseStatus to CaseParticipant
+# add CaseStatus to as_CaseParticipant
 class _AddStatusToParticipantActivity(as_Add):
-    """Add a CaseStatus to a CaseParticipant
+    """Add a CaseStatus to a as_CaseParticipant
     object_: CaseStatus
-    target: CaseParticipant
+    target: as_CaseParticipant
     """
 
-    object_: ParticipantStatus = Field(
+    object_: as_ParticipantStatus = Field(
         ..., validation_alias="object", serialization_alias="object"
     )
-    target: CaseParticipantRef = None
+    target: as_CaseParticipantRef = None
 
 
 class _AddParticipantToCaseActivity(as_Add):
-    """Add a CaseParticipant to a VulnerabilityCase
-    object_: CaseParticipant
+    """Add a as_CaseParticipant to a VulnerabilityCase
+    object_: as_CaseParticipant
     target: VulnerabilityCase
     """
 
-    object_: CaseParticipant = Field(
+    object_: as_CaseParticipant = Field(
         ..., validation_alias="object", serialization_alias="object"
     )
-    target: VulnerabilityCaseRef = None
+    target: as_VulnerabilityCaseRef = None
 
 
 class _RemoveParticipantFromCaseActivity(as_Remove):
-    """Remove a CaseParticipant from a VulnerabilityCase.
+    """Remove a as_CaseParticipant from a VulnerabilityCase.
     This should only be performed by the case owner.
-    object_: CaseParticipant
+    object_: as_CaseParticipant
     target: VulnerabilityCase
     """
 
-    object_: CaseParticipant = Field(
+    object_: as_CaseParticipant = Field(
         ..., validation_alias="object", serialization_alias="object"
     )
-    target: VulnerabilityCaseRef = None
+    target: as_VulnerabilityCaseRef = None

--- a/vultron/wire/as2/vocab/activities/embargo.py
+++ b/vultron/wire/as2/vocab/activities/embargo.py
@@ -32,24 +32,24 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Remove,
 )
 from vultron.wire.as2.vocab.objects.embargo_event import (
-    EmbargoEvent,
-    EmbargoEventRef,
+    as_EmbargoEvent,
+    as_EmbargoEventRef,
 )
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
-    VulnerabilityCaseRef,
+    as_VulnerabilityCaseRef,
 )
 
 
 class _EmProposeEmbargoActivity(as_Invite):
     """The actor is proposing an embargo on the case.
     This corresponds to the Vultron Message Types EP and EV
-    object_: EmbargoEvent
+    object_: as_EmbargoEvent
     """
 
-    object_: EmbargoEvent = Field(
+    object_: as_EmbargoEvent = Field(
         default=..., validation_alias="object", serialization_alias="object"
     )
-    context: VulnerabilityCaseRef = None
+    context: as_VulnerabilityCaseRef = None
 
 
 _EmProposeEmbargoRef: TypeAlias = ActivityStreamRef[_EmProposeEmbargoActivity]
@@ -59,7 +59,7 @@ class _EmAcceptEmbargoActivity(as_Accept):
     """The actor is accepting an embargo proposal.
     This corresponds to the Vultron Message Types EA and EC.
     Per ActivityStreams convention: Accept(object=<Invite>) — the actor accepts
-    the proposal activity itself, not the EmbargoEvent being proposed.
+    the proposal activity itself, not the as_EmbargoEvent being proposed.
 
     object_: the _EmProposeEmbargoActivity activity being accepted (inline typed
         object required — bare string IDs are rejected at construction time)
@@ -69,14 +69,14 @@ class _EmAcceptEmbargoActivity(as_Accept):
     object_: _EmProposeEmbargoActivity = Field(
         default=..., validation_alias="object", serialization_alias="object"
     )
-    context: VulnerabilityCaseRef = None
+    context: as_VulnerabilityCaseRef = None
 
 
 class _EmRejectEmbargoActivity(as_Reject):
     """The actor is rejecting an embargo proposal.
     This corresponds to the Vultron Message Types ER and EJ.
     Per ActivityStreams convention: Reject(object=<Invite>) — the actor rejects
-    the proposal activity itself, not the EmbargoEvent being proposed.
+    the proposal activity itself, not the as_EmbargoEvent being proposed.
 
     object_: the _EmProposeEmbargoActivity activity being rejected (inline typed
         object required — bare string IDs are rejected at construction time)
@@ -86,7 +86,7 @@ class _EmRejectEmbargoActivity(as_Reject):
     object_: _EmProposeEmbargoActivity = Field(
         default=..., validation_alias="object", serialization_alias="object"
     )
-    context: VulnerabilityCaseRef = None
+    context: as_VulnerabilityCaseRef = None
 
 
 class _ChoosePreferredEmbargoActivity(as_Question):
@@ -98,60 +98,60 @@ class _ChoosePreferredEmbargoActivity(as_Question):
 
     # note: not specifying object_ here because Questions are intransitive
 
-    any_of: Sequence[EmbargoEventRef] | None = None
-    one_of: Sequence[EmbargoEventRef] | None = None
+    any_of: Sequence[as_EmbargoEventRef] | None = None
+    one_of: Sequence[as_EmbargoEventRef] | None = None
 
 
 class _ActivateEmbargoActivity(as_Add):
     """The case owner is activating an embargo on the case.
     This corresponds to the Vultron Message Types EA and EC at the case level
-    object_: the EmbargoEvent being activated
-    target: the VulnerabilityCase for which the EmbargoEvent was proposed
-    in_reply_to: the _EmProposeEmbargoActivity activity that proposed the EmbargoEvent
+    object_: the as_EmbargoEvent being activated
+    target: the VulnerabilityCase for which the as_EmbargoEvent was proposed
+    in_reply_to: the _EmProposeEmbargoActivity activity that proposed the as_EmbargoEvent
     """
 
-    object_: EmbargoEvent = Field(
+    object_: as_EmbargoEvent = Field(
         default=..., validation_alias="object", serialization_alias="object"
     )
-    target: VulnerabilityCaseRef = None
+    target: as_VulnerabilityCaseRef = None
     in_reply_to: _EmProposeEmbargoRef = None
 
 
 class _AddEmbargoToCaseActivity(as_Add):
-    """Add an EmbargoEvent to a case. This should only be performed by the case owner.
+    """Add an as_EmbargoEvent to a case. This should only be performed by the case owner.
     For use when the case owner is activating an embargo on the case without first proposing it to the participants.
     See _ActivateEmbargoActivity for use when the case owner is activating an embargo on the case
     in response to a previous _EmProposeEmbargoActivity activity.
     """
 
-    object_: EmbargoEvent = Field(
+    object_: as_EmbargoEvent = Field(
         default=..., validation_alias="object", serialization_alias="object"
     )
-    target: VulnerabilityCaseRef = None
+    target: as_VulnerabilityCaseRef = None
 
 
 class _AnnounceEmbargoActivity(as_Announce):
     """The case owner is announcing an embargo on the case.
-    object_: the EmbargoEvent being announced
-    context: the VulnerabilityCase for which the EmbargoEvent is active
+    object_: the as_EmbargoEvent being announced
+    context: the VulnerabilityCase for which the as_EmbargoEvent is active
     """
 
-    object_: EmbargoEvent = Field(
+    object_: as_EmbargoEvent = Field(
         default=..., validation_alias="object", serialization_alias="object"
     )
-    context: VulnerabilityCaseRef = None
+    context: as_VulnerabilityCaseRef = None
 
 
-# remove EmbargoEvent from proposedEmbargoes of VulnerabilityCase
+# remove as_EmbargoEvent from proposedEmbargoes of VulnerabilityCase
 # todo: should proposedEmbargoes be its own collection object that can then be used as the origin here?
 class _RemoveEmbargoFromCaseActivity(as_Remove):
-    """Remove an EmbargoEvent from the proposedEmbargoes of a VulnerabilityCase.
+    """Remove an as_EmbargoEvent from the proposedEmbargoes of a VulnerabilityCase.
     This should only be performed by the case owner.
-    object_: EmbargoEvent
+    object_: as_EmbargoEvent
     origin: VulnerabilityCase
     """
 
-    object_: EmbargoEvent = Field(
+    object_: as_EmbargoEvent = Field(
         default=..., validation_alias="object", serialization_alias="object"
     )
-    origin: VulnerabilityCaseRef = None
+    origin: as_VulnerabilityCaseRef = None

--- a/vultron/wire/as2/vocab/activities/report.py
+++ b/vultron/wire/as2/vocab/activities/report.py
@@ -27,14 +27,14 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_TentativeReject,
 )
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 
 class _RmCreateReportActivity(as_Create):
     """The actor is creating a report."""
 
-    object_: VulnerabilityReport = Field(
+    object_: as_VulnerabilityReport = Field(
         ..., validation_alias="object", serialization_alias="object"
     )
 
@@ -43,10 +43,10 @@ class _RmSubmitReportActivity(as_Offer):
     """The actor is submitting a report to another actor
     This corresponds to the Vultron RS message type when no case exists.
     See also _RmInviteToCaseActivity for the scenario when a case already exists.
-    object_: VulnerabilityReport
+    object_: as_VulnerabilityReport
     """
 
-    object_: VulnerabilityReport = Field(
+    object_: as_VulnerabilityReport = Field(
         ..., validation_alias="object", serialization_alias="object"
     )
 
@@ -54,10 +54,10 @@ class _RmSubmitReportActivity(as_Offer):
 class _RmReadReportActivity(as_Read):
     """The actor has read a report.
     This corresponds to the Vultron Message Type RK when no case exists.
-    object_: VulnerabilityReport
+    object_: as_VulnerabilityReport
     """
 
-    object_: VulnerabilityReport = Field(
+    object_: as_VulnerabilityReport = Field(
         ..., validation_alias="object", serialization_alias="object"
     )
 
@@ -67,7 +67,7 @@ class _RmValidateReportActivity(as_Accept):
     Corresponds to the Vultron Message Type RV when no case exists.
     This should be followed by a Create(VulnerabilityCase) activity.
 
-    object_: the _RmSubmitReportActivity offer wrapping the VulnerabilityReport
+    object_: the _RmSubmitReportActivity offer wrapping the as_VulnerabilityReport
         (inline typed object required — bare string IDs are rejected at
         construction time)
     """
@@ -82,7 +82,7 @@ class _RmInvalidateReportActivity(as_TentativeReject):
     Corresponds to the Vultron Message Type RI when no case exists.
     See also _RmRejectInviteToCaseActivity for the scenario when a case already exists.
 
-    object_: the _RmSubmitReportActivity offer wrapping the VulnerabilityReport
+    object_: the _RmSubmitReportActivity offer wrapping the as_VulnerabilityReport
         (inline typed object required — bare string IDs are rejected at
         construction time)
     """
@@ -98,7 +98,7 @@ class _RmCloseReportActivity(as_Reject):
     It can only be emitted when the report is in the RM.INVALID state, because anything past that will
     have an associated VulnerabilityCase object, and closure of the case falls to the _RmCloseCaseActivity activity.
 
-    object_: the _RmSubmitReportActivity offer wrapping the VulnerabilityReport
+    object_: the _RmSubmitReportActivity offer wrapping the as_VulnerabilityReport
         (inline typed object required — bare string IDs are rejected at
         construction time)
     """

--- a/vultron/wire/as2/vocab/activities/sync.py
+++ b/vultron/wire/as2/vocab/activities/sync.py
@@ -28,12 +28,12 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
     as_Reject,
 )
 from vultron.wire.as2.vocab.objects.case_ledger_entry import (
-    CaseLedgerEntry,
+    as_CaseLedgerEntry,
 )
 
 
 class _AnnounceLogEntryActivity(as_Announce):
-    """The CaseActor is announcing a canonical CaseLedgerEntry for replication.
+    """The CaseActor is announcing a canonical as_CaseLedgerEntry for replication.
 
     Sent to each participant actor after a new log entry has been committed
     to the case event log (SYNC-09-002).
@@ -42,7 +42,7 @@ class _AnnounceLogEntryActivity(as_Announce):
         being replicated.
     """
 
-    object_: CaseLedgerEntry = Field(
+    object_: as_CaseLedgerEntry = Field(
         default=...,
         validation_alias="object",
         serialization_alias="object",
@@ -50,24 +50,24 @@ class _AnnounceLogEntryActivity(as_Announce):
 
 
 class _RejectLogEntryActivity(as_Reject):
-    """Participant rejects a ``CaseLedgerEntry`` announcement due to hash-chain mismatch.
+    """Participant rejects a ``as_CaseLedgerEntry`` announcement due to hash-chain mismatch.
 
     Sent by a participant actor to the CaseActor when the incoming
-    ``Announce(CaseLedgerEntry)``'s ``prev_log_hash`` does not match the
+    ``Announce(as_CaseLedgerEntry)``'s ``prev_log_hash`` does not match the
     participant's local tail hash.
 
     The ``context`` field (inherited from ``as_Object``) carries the
     last accepted entry hash as a plain string so the CaseActor can
     determine which entries need to be replayed (SYNC-03-001).
 
-    object_: :class:`~vultron.wire.as2.vocab.objects.case_ledger_entry.CaseLedgerEntry`
+    object_: :class:`~vultron.wire.as2.vocab.objects.case_ledger_entry.as_CaseLedgerEntry`
         that was rejected.
     context: Last accepted entry hash string.
 
     Spec: SYNC-03-001, SYNC-03-002.
     """
 
-    object_: CaseLedgerEntry = Field(
+    object_: as_CaseLedgerEntry = Field(
         default=...,
         validation_alias="object",
         serialization_alias="object",

--- a/vultron/wire/as2/vocab/examples/_base.py
+++ b/vultron/wire/as2/vocab/examples/_base.py
@@ -24,9 +24,11 @@ from vultron.wire.as2.vocab.base.objects.actors import (
     as_Person,
     as_Service,
 )
-from vultron.wire.as2.vocab.objects.vulnerability_case import VulnerabilityCase
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 _EXAMPLE_BASE_URL = "https://demo.vultron.local/"
@@ -59,7 +61,7 @@ _CASE_ACTOR = as_Service(
     id_=f"{case_actor_base_url}/vendorco-case-actor",
 )
 
-_REPORT = VulnerabilityReport(
+_REPORT = as_VulnerabilityReport(
     name="FDR-8675309",
     id_=_make_id("VulnerabilityReport"),
     content="I found a vulnerability!",
@@ -67,7 +69,7 @@ _REPORT = VulnerabilityReport(
         _FINDER.id_,
     ],
 )
-_CASE = VulnerabilityCase(
+_CASE = as_VulnerabilityCase(
     name=f"{_VENDOR.name} Case #{case_number}",
     attributed_to=_VENDOR.id_,
 )
@@ -109,10 +111,10 @@ def case_actor() -> as_Service:
     return _CASE_ACTOR
 
 
-def case(random_id=False) -> VulnerabilityCase:
+def case(random_id=False) -> as_VulnerabilityCase:
     if random_id:
         _case_number = random.randint(10000000, 99999999)
-        _case = VulnerabilityCase(
+        _case = as_VulnerabilityCase(
             name=f"{_VENDOR.name} Case #{_case_number}",
             id_=_make_id("VulnerabilityCase"),
             attributed_to=_VENDOR.id_,
@@ -121,11 +123,11 @@ def case(random_id=False) -> VulnerabilityCase:
     return _CASE
 
 
-def gen_report() -> VulnerabilityReport:
+def gen_report() -> as_VulnerabilityReport:
     """
     Create a vulnerability report
     Returns:
-        a VulnerabilityReport object
+        a as_VulnerabilityReport object
     """
     return _REPORT
 

--- a/vultron/wire/as2/vocab/examples/case.py
+++ b/vultron/wire/as2/vocab/examples/case.py
@@ -31,7 +31,7 @@ from vultron.wire.as2.vocab.examples._base import (
     gen_report,
     vendor,
 )
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
 from vultron.enums.roles import CVDRole
 from vultron.wire.as2.factories import (
     accept_case_ownership_transfer_activity,
@@ -49,7 +49,7 @@ from vultron.wire.as2.factories import (
 def create_case() -> as_Create:
     _case = case(random_id=True)
     _case.add_report(_REPORT.id_)
-    participant = CaseParticipant(
+    participant = as_CaseParticipant(
         case_roles=[CVDRole.VENDOR],
         attributed_to=_VENDOR.id_,
         name=_VENDOR.name,

--- a/vultron/wire/as2/vocab/examples/embargo.py
+++ b/vultron/wire/as2/vocab/examples/embargo.py
@@ -29,7 +29,7 @@ from vultron.wire.as2.vocab.examples._base import (
     case,
     vendor,
 )
-from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEvent
+from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
 from vultron.wire.as2.factories import (
     activate_embargo_activity,
     add_embargo_to_case_activity,
@@ -42,7 +42,7 @@ from vultron.wire.as2.factories import (
 )
 
 
-def embargo_event(days: int = 90) -> EmbargoEvent:
+def embargo_event(days: int = 90) -> as_EmbargoEvent:
     start_at = datetime.now().astimezone(tz=None)
     # zero out the seconds and microseconds
     start_at = start_at.replace(second=0, microsecond=0)
@@ -56,7 +56,7 @@ def embargo_event(days: int = 90) -> EmbargoEvent:
 
     _case = case()
 
-    event = EmbargoEvent(
+    event = as_EmbargoEvent(
         id_=f"{_case.id_}/embargo_events/{end_at.isoformat()}",
         name=f"Embargo for {_case.name}",
         context=_case.id_,

--- a/vultron/wire/as2/vocab/examples/participant.py
+++ b/vultron/wire/as2/vocab/examples/participant.py
@@ -30,8 +30,8 @@ from vultron.wire.as2.vocab.examples.status import (
 from vultron.core.states.cs import CS_vfd
 from vultron.core.states.rm import RM
 from vultron.enums.roles import CVDRole
-from vultron.wire.as2.vocab.objects.case_participant import CaseParticipant
-from vultron.wire.as2.vocab.objects.case_status import ParticipantStatus
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.case_status import as_ParticipantStatus
 from vultron.wire.as2.factories import (
     add_participant_to_case_activity,
     remove_participant_from_case_activity,
@@ -46,7 +46,7 @@ def add_vendor_participant_to_case() -> as_Add:
     _case = case()
 
     shortname = _vendor.id_.split("/")[-1]
-    _vendor_participant = CaseParticipant(
+    _vendor_participant = as_CaseParticipant(
         id_=f"{_case.id_}/participants/{shortname}",
         name=_vendor.name,
         attributed_to=_vendor.id_,
@@ -54,7 +54,7 @@ def add_vendor_participant_to_case() -> as_Add:
         case_roles=[CVDRole.VENDOR],
     )
 
-    _pstatus = ParticipantStatus(
+    _pstatus = as_ParticipantStatus(
         context=_case.id_,
         attributed_to=_vendor.id_,
         rm_state=RM.RECEIVED,
@@ -77,7 +77,7 @@ def add_finder_participant_to_case() -> as_Add:
 
     _finder = finder()
     shortname = _finder.id_.split("/")[-1]
-    _finder_participant = CaseParticipant(
+    _finder_participant = as_CaseParticipant(
         id_=f"{_case.id_}/participants/{shortname}",
         name=_finder.name,
         attributed_to=_finder.id_,
@@ -100,7 +100,7 @@ def add_coordinator_participant_to_case() -> as_Add:
 
     _coordinator = _COORDINATOR
     shortname = _coordinator.id_.split("/")[-1]
-    _coordinator_participant = CaseParticipant(
+    _coordinator_participant = as_CaseParticipant(
         id_=f"{_case.id_}/participants/{shortname}",
         name=_coordinator.name,
         attributed_to=_coordinator.id_,
@@ -164,7 +164,7 @@ def create_participant():
     _vendor = vendor()
     _case = case()
     _coordinator = _COORDINATOR
-    _coord_participant = CaseParticipant(
+    _coord_participant = as_CaseParticipant(
         id_=f"{_case.id_}/participants/{_coordinator.id_}",
         name=_coordinator.name,
         attributed_to=_coordinator.id_,
@@ -180,8 +180,8 @@ def create_participant():
     return _activity
 
 
-def case_participant() -> CaseParticipant:
-    participant = CaseParticipant(
+def case_participant() -> as_CaseParticipant:
+    participant = as_CaseParticipant(
         id_="https://vultron.example/cases/1/participants/vendor",
         name="Vendor",
         attributed_to="https://vultron.example/organizations/vendor",
@@ -192,11 +192,11 @@ def case_participant() -> CaseParticipant:
     return participant
 
 
-def coordinator_participant() -> CaseParticipant:
+def coordinator_participant() -> as_CaseParticipant:
     _actor = _COORDINATOR
     _case = case()
 
-    participant = CaseParticipant(
+    participant = as_CaseParticipant(
         id_=f"{_case.id_}/participants/coordinator",
         name=_actor.name,
         attributed_to=_actor.id_,

--- a/vultron/wire/as2/vocab/examples/status.py
+++ b/vultron/wire/as2/vocab/examples/status.py
@@ -19,8 +19,8 @@ from vultron.wire.as2.vocab.base.objects.activities.transitive import (
 )
 from vultron.wire.as2.vocab.examples._base import case, vendor
 from vultron.wire.as2.vocab.objects.case_status import (
-    CaseStatus,
-    ParticipantStatus,
+    as_CaseStatus,
+    as_ParticipantStatus,
 )
 from vultron.core.states.em import EM
 from vultron.core.states.rm import RM
@@ -35,8 +35,8 @@ from vultron.wire.as2.factories import (
 _EXAMPLE_TIMESTAMP = datetime(2026, 6, 1, 19, 12, tzinfo=timezone.utc)
 
 
-def case_status() -> CaseStatus:
-    status = CaseStatus(
+def case_status() -> as_CaseStatus:
+    status = as_CaseStatus(
         id_="https://vultron.example/cases/1/status/1",
         context="https://vultron.example/cases/1",
         em_state=EM.EMBARGO_MANAGEMENT_NONE,
@@ -68,8 +68,8 @@ def add_status_to_case() -> as_Add:
     return activity
 
 
-def participant_status() -> ParticipantStatus:
-    status = ParticipantStatus(
+def participant_status() -> as_ParticipantStatus:
+    status = as_ParticipantStatus(
         id_="https://vultron.example/cases/1/participants/vendor/status/1",
         context="https://vultron.example/cases/1/participants/vendor",
         attributed_to="https://vultron.example/organizations/vendor",

--- a/vultron/wire/as2/vocab/objects/__init__.py
+++ b/vultron/wire/as2/vocab/objects/__init__.py
@@ -7,7 +7,7 @@
 #  Created, in part, with funding and support from the United States Government
 #  (see Acknowledgments file). This program may include and/or can make use of
 #  certain third party source code, object code, documentation and other files
-#  (“Third Party Software”). See LICENSE.md for more details.
+#  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 """
@@ -31,3 +31,94 @@ def _discover_modules() -> None:
 
 
 _discover_modules()
+
+# ---------------------------------------------------------------------------
+# Explicit re-exports of as_-prefixed wire vocabulary classes (ARCH-14-001)
+# ---------------------------------------------------------------------------
+from vultron.wire.as2.vocab.objects.case_actor import (  # noqa: E402
+    as_CaseActor,
+)
+from vultron.wire.as2.vocab.objects.case_ledger_entry import (  # noqa: E402
+    as_CaseLedgerEntry,
+)
+from vultron.wire.as2.vocab.objects.case_participant import (  # noqa: E402
+    as_CaseParticipant,
+    as_CaseParticipantRef,
+)
+from vultron.wire.as2.vocab.objects.case_reference import (  # noqa: E402
+    as_CaseReference,
+    as_CaseReferenceRef,
+)
+from vultron.wire.as2.vocab.objects.case_status import (  # noqa: E402
+    as_CaseStatus,
+    as_CaseStatusRef,
+    as_ParticipantStatus,
+    as_ParticipantStatusRef,
+)
+from vultron.wire.as2.vocab.objects.embargo_event import (  # noqa: E402
+    as_EmbargoEvent,
+    as_EmbargoEventRef,
+)
+from vultron.wire.as2.vocab.objects.embargo_policy import (  # noqa: E402
+    as_EmbargoPolicy,
+    as_EmbargoPolicyRef,
+)
+from vultron.wire.as2.vocab.objects.vulnerability_case import (  # noqa: E402
+    as_VulnerabilityCase,
+    as_VulnerabilityCaseRef,
+)
+from vultron.wire.as2.vocab.objects.vulnerability_record import (  # noqa: E402
+    as_VulnerabilityRecord,
+    as_VulnerabilityRecordRef,
+)
+from vultron.wire.as2.vocab.objects.vulnerability_report import (  # noqa: E402
+    as_VulnerabilityReport,
+    as_VulnerabilityReportRef,
+)
+from vultron.wire.as2.vocab.objects.vultron_actor import (  # noqa: E402
+    as_VultronApplication,
+    as_VultronApplicationRef,
+    as_VultronGroup,
+    as_VultronGroupRef,
+    as_VultronOrganization,
+    as_VultronOrganizationRef,
+    as_VultronPerson,
+    as_VultronPersonRef,
+    as_VultronService,
+    as_VultronServiceRef,
+)
+
+# ---------------------------------------------------------------------------
+# Backward-compatibility aliases — existing imports keep working unchanged.
+# Callers should migrate to the as_-prefixed names (ARCH-14-001).
+# ---------------------------------------------------------------------------
+CaseActor = as_CaseActor
+CaseLedgerEntry = as_CaseLedgerEntry
+CaseParticipant = as_CaseParticipant
+CaseParticipantRef = as_CaseParticipantRef
+CaseReference = as_CaseReference
+CaseReferenceRef = as_CaseReferenceRef
+CaseStatus = as_CaseStatus
+CaseStatusRef = as_CaseStatusRef
+ParticipantStatus = as_ParticipantStatus
+ParticipantStatusRef = as_ParticipantStatusRef
+EmbargoEvent = as_EmbargoEvent
+EmbargoEventRef = as_EmbargoEventRef
+EmbargoPolicy = as_EmbargoPolicy
+EmbargoPolicyRef = as_EmbargoPolicyRef
+VulnerabilityCase = as_VulnerabilityCase
+VulnerabilityCaseRef = as_VulnerabilityCaseRef
+VulnerabilityRecord = as_VulnerabilityRecord
+VulnerabilityRecordRef = as_VulnerabilityRecordRef
+VulnerabilityReport = as_VulnerabilityReport
+VulnerabilityReportRef = as_VulnerabilityReportRef
+VultronApplication = as_VultronApplication
+VultronApplicationRef = as_VultronApplicationRef
+VultronGroup = as_VultronGroup
+VultronGroupRef = as_VultronGroupRef
+VultronOrganization = as_VultronOrganization
+VultronOrganizationRef = as_VultronOrganizationRef
+VultronPerson = as_VultronPerson
+VultronPersonRef = as_VultronPersonRef
+VultronService = as_VultronService
+VultronServiceRef = as_VultronServiceRef

--- a/vultron/wire/as2/vocab/objects/case_actor.py
+++ b/vultron/wire/as2/vocab/objects/case_actor.py
@@ -21,19 +21,19 @@ from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.objects.base import _scalar_ref_id_or_value
 
 
-class CaseActor(as_Service):
+class as_CaseActor(as_Service):
     """
     A CaseActor is a software service wrapper around a VulnerabilityCase object.
     It provides an inbox/outbox for the case to manage communications related to the case.
     """
 
-    # note: CaseActor doesn't need its own type_, the value inherited from as_Service is sufficient
+    # note: as_CaseActor doesn't need its own type_, the value inherited from as_Service is sufficient
 
     # attributed_to: (Actor) Case Owner
     # context: (VulnerabilityCase) The case this actor is associated with
 
     @classmethod
-    def from_core(cls, core_obj: CoreCaseActor) -> "CaseActor":
+    def from_core(cls, core_obj: CoreCaseActor) -> "as_CaseActor":
         return cls(
             id_=core_obj.id_,
             name=core_obj.name,
@@ -56,4 +56,4 @@ class CaseActor(as_Service):
 if __name__ == "__main__":
     print("This module is intended to be imported, not run directly.")
 
-    print(CaseActor().model_dump_json(indent=2))
+    print(as_CaseActor().model_dump_json(indent=2))

--- a/vultron/wire/as2/vocab/objects/case_ledger_entry.py
+++ b/vultron/wire/as2/vocab/objects/case_ledger_entry.py
@@ -54,7 +54,7 @@ from vultron.core.models.case_ledger_entry import (
 from vultron.wire.as2.vocab.objects.base import VultronAS2Object
 
 
-class CaseLedgerEntry(VultronAS2Object):
+class as_CaseLedgerEntry(VultronAS2Object):
     """Wire-layer representation of a canonical case ledger entry.
 
     All fields mirror
@@ -140,7 +140,7 @@ class CaseLedgerEntry(VultronAS2Object):
     )
 
     @classmethod
-    def from_core(cls, entry: CoreCaseLedgerEntry) -> "CaseLedgerEntry":
+    def from_core(cls, entry: CoreCaseLedgerEntry) -> "as_CaseLedgerEntry":
         """Create a wire :class:`CaseLedgerEntry` from a domain
         :class:`~vultron.core.models.case_ledger_entry.CaseLedgerEntry`.
 
@@ -156,7 +156,7 @@ class CaseLedgerEntry(VultronAS2Object):
 
 
 __all__ = [
-    "CaseLedgerEntry",
+    "as_CaseLedgerEntry",
     "VultronCaseLedgerEntry",
     "VultronCaseLedgerEntryRef",
 ]

--- a/vultron/wire/as2/vocab/objects/case_participant.py
+++ b/vultron/wire/as2/vocab/objects/case_participant.py
@@ -49,15 +49,15 @@ from vultron.wire.as2.vocab.objects.base import (
     _scalar_ref_id_or_value,
 )
 from vultron.wire.as2.vocab.objects.case_status import (
-    ParticipantStatus as WireParticipantStatus,
+    as_ParticipantStatus as WireParticipantStatus,
 )
 
 # Re-export core role subclasses so existing ``from wire import XxxParticipant``
 # imports continue to work without modification.
 __all__ = [
     "CaseActorParticipant",
-    "CaseParticipant",
-    "CaseParticipantRef",
+    "as_CaseParticipant",
+    "as_CaseParticipantRef",
     "CoordinatorParticipant",
     "DeployerParticipant",
     "FinderParticipant",
@@ -69,12 +69,12 @@ __all__ = [
 ]
 
 # Keep the wire name to avoid shadowing the core alias used inside this module.
-ParticipantStatus = WireParticipantStatus
+as_ParticipantStatus = WireParticipantStatus
 
 logger = logging.getLogger(__name__)
 
 
-class CaseParticipant(VultronAS2Object):
+class as_CaseParticipant(VultronAS2Object):
     """
     A CaseParticipant is a wrapper around an Actor in a VulnerabilityCase.
     It is used to track the status of the participant within the context of a specific case, as well as the roles they
@@ -111,7 +111,9 @@ class CaseParticipant(VultronAS2Object):
 
     name: NonEmptyString | None = None
     case_roles: list[CVDRole] = Field(default_factory=list)
-    participant_statuses: list[ParticipantStatus] = Field(default_factory=list)
+    participant_statuses: list[as_ParticipantStatus] = Field(
+        default_factory=list
+    )
     accepted_embargo_ids: list[str] = Field(default_factory=list)
     embargo_consent_state: str = Field(default="NO_EMBARGO")
     participant_case_name: NonEmptyString | None = Field(
@@ -154,7 +156,7 @@ class CaseParticipant(VultronAS2Object):
 
         # participant status is empty, so initialize it with a default status
         self.participant_statuses = [
-            ParticipantStatus(
+            as_ParticipantStatus(
                 context=self.context or self.id_,
                 attributed_to=self.attributed_to,
                 em_consent_state=coerce_em_consent_state(
@@ -175,7 +177,7 @@ class CaseParticipant(VultronAS2Object):
         )
 
     @property
-    def participant_status(self) -> ParticipantStatus | None:
+    def participant_status(self) -> as_ParticipantStatus | None:
         """Return the most recently appended ParticipantStatus.
 
         The list represents this replica's append-only history of status
@@ -196,7 +198,7 @@ class CaseParticipant(VultronAS2Object):
         return self.participant_statuses[-1]
 
     def append_rm_state(self, rm_state: RM, actor: str, context: str) -> bool:
-        """Append a new ParticipantStatus with the given RM state.
+        """Append a new as_ParticipantStatus with the given RM state.
 
         Skips the append (with a WARNING) if the transition from the current
         RM state to rm_state is not valid according to the RM state machine.
@@ -217,7 +219,7 @@ class CaseParticipant(VultronAS2Object):
             )
             return False
         self.participant_statuses.append(
-            ParticipantStatus(
+            as_ParticipantStatus(
                 attributed_to=actor,
                 context=context,
                 rm_state=rm_state,
@@ -301,8 +303,8 @@ class CaseParticipant(VultronAS2Object):
         return list(self.case_roles)
 
     @classmethod
-    def from_core(cls, core_obj: CoreCaseParticipant) -> "CaseParticipant":
-        return cast("CaseParticipant", super().from_core(core_obj))
+    def from_core(cls, core_obj: CoreCaseParticipant) -> "as_CaseParticipant":
+        return cast("as_CaseParticipant", super().from_core(core_obj))
 
     def to_core(self) -> CoreCaseParticipant:
         data = self._to_core_data()
@@ -327,14 +329,14 @@ class CaseParticipant(VultronAS2Object):
 # import XxxParticipant`` imports continue to work unmodified.
 # ---------------------------------------------------------------------------
 
-CaseParticipantRef: TypeAlias = ActivityStreamRef[CaseParticipant]
+as_CaseParticipantRef: TypeAlias = ActivityStreamRef[as_CaseParticipant]
 
 
 def main():
     from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 
     actor = as_Actor(name="Actor Name")
-    cp = CaseParticipant(attributed_to=actor, context="case_id_foo")
+    cp = as_CaseParticipant(attributed_to=actor, context="case_id_foo")
     print(f"### {cp.type_} ###")
     print()
     print(cp.to_json(indent=2))

--- a/vultron/wire/as2/vocab/objects/case_proposal.py
+++ b/vultron/wire/as2/vocab/objects/case_proposal.py
@@ -36,7 +36,7 @@ from vultron.wire.as2.vocab.base.links import ActivityStreamRef
 from vultron.wire.as2.vocab.base.objects.base import ActivityStreamRequiredRef
 from vultron.wire.as2.vocab.objects.base import VultronAS2Object
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReport,
+    as_VulnerabilityReport,
 )
 
 
@@ -58,7 +58,7 @@ class as_CaseProposal(VultronAS2Object):
         type_: Always ``"CaseProposal"``; registered in ``VultronObjectType``.
         attributed_to: Required URI of the vendor actor that originated
             the proposal (CP-01-003).
-        object_: Required inline ``VulnerabilityReport`` around which the
+        object_: Required inline ``as_VulnerabilityReport`` around which the
             case is to be created.  URI-only references are not permitted
             (CP-01-004, AKM-03-001).
         target: Required URI of the prospective case-actor service to
@@ -79,14 +79,14 @@ class as_CaseProposal(VultronAS2Object):
         description="URI of the vendor actor that originated the proposal.",
     )
 
-    # CP-01-004: fully inline VulnerabilityReport; URI references not permitted
+    # CP-01-004: fully inline as_VulnerabilityReport; URI references not permitted
     # at the wire boundary.  ActivityStreamRequiredRef allows the DataLayer to
     # store/restore the dehydrated string ID; _rehydrate_fields expands it back.
-    object_: ActivityStreamRequiredRef[VulnerabilityReport] = Field(
+    object_: ActivityStreamRequiredRef[as_VulnerabilityReport] = Field(
         ...,
         validation_alias="object",
         serialization_alias="object",
-        description="Inline VulnerabilityReport; URI-only refs not permitted (AKM-03-001).",
+        description="Inline as_VulnerabilityReport; URI-only refs not permitted (AKM-03-001).",
     )
 
     # CP-01-005: URI of the prospective case-actor service.

--- a/vultron/wire/as2/vocab/objects/case_reference.py
+++ b/vultron/wire/as2/vocab/objects/case_reference.py
@@ -34,7 +34,7 @@ from vultron.wire.as2.vocab.objects.base import (
 )
 
 
-class CaseReference(VultronAS2Object):
+class as_CaseReference(VultronAS2Object):
     """
     Represents a typed external reference associated with a case.
 
@@ -89,7 +89,7 @@ class CaseReference(VultronAS2Object):
         return v
 
     @classmethod
-    def from_core(cls, core_obj: CoreCaseReference) -> "CaseReference":
+    def from_core(cls, core_obj: CoreCaseReference) -> "as_CaseReference":
         data = core_obj.model_dump(mode="json")
         _strip_core_context(data)
         data["attributed_to"] = _scalar_ref_id_or_value(
@@ -105,14 +105,14 @@ class CaseReference(VultronAS2Object):
         return CoreCaseReference.model_validate(data)
 
 
-CaseReferenceRef: TypeAlias = ActivityStreamRef[CaseReference]
+as_CaseReferenceRef: TypeAlias = ActivityStreamRef[as_CaseReference]
 
 
 def main():
     from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 
     actor = as_Actor()
-    obj = CaseReference(
+    obj = as_CaseReference(
         url="https://example.org/advisory/",
         name="Example Security Advisory",
         tags=["vendor-advisory", "patch"],

--- a/vultron/wire/as2/vocab/objects/case_status.py
+++ b/vultron/wire/as2/vocab/objects/case_status.py
@@ -43,7 +43,7 @@ from vultron.wire.as2.vocab.objects.base import (
 )
 
 
-class CaseStatus(VultronAS2Object):
+class as_CaseStatus(VultronAS2Object):
     """
     Represents the case-level (global, participant-agnostic) status of a VulnerabilityCase.
     """
@@ -88,10 +88,10 @@ class CaseStatus(VultronAS2Object):
         return self
 
     @classmethod
-    def from_core(cls, core_obj: CoreCaseStatus) -> "CaseStatus":
+    def from_core(cls, core_obj: CoreCaseStatus) -> "as_CaseStatus":
         data = core_obj.model_dump(mode="json")
         _strip_core_context(data)
-        return cast("CaseStatus", cls.model_validate(data))
+        return cast("as_CaseStatus", cls.model_validate(data))
 
     def to_core(self) -> CoreCaseStatus:
         data = self._to_core_data()
@@ -104,10 +104,10 @@ class CaseStatus(VultronAS2Object):
         return CoreCaseStatus.model_validate(data)
 
 
-CaseStatusRef: TypeAlias = ActivityStreamRef[CaseStatus]
+as_CaseStatusRef: TypeAlias = ActivityStreamRef[as_CaseStatus]
 
 
-class ParticipantStatus(VultronAS2Object):
+class as_ParticipantStatus(VultronAS2Object):
     """
     Represents the status of a participant with respect to a VulnerabilityCase (participant-specific).
     """
@@ -136,7 +136,7 @@ class ParticipantStatus(VultronAS2Object):
         serialization_alias="cvdRole",
     )
     tracking_id: NonEmptyString | None = None
-    case_status: CaseStatus | None = None
+    case_status: as_CaseStatus | None = None
 
     @field_serializer("rm_state")
     def serialize_rm_state(self, rm_state: RM) -> str:
@@ -185,19 +185,21 @@ class ParticipantStatus(VultronAS2Object):
         return self
 
     @classmethod
-    def from_core(cls, core_obj: CoreParticipantStatus) -> "ParticipantStatus":
+    def from_core(
+        cls, core_obj: CoreParticipantStatus
+    ) -> "as_ParticipantStatus":
         data = core_obj.model_dump(mode="json")
         _strip_core_context(data)
         case_status = data.get("case_status")
         if isinstance(case_status, str):
             # Legacy: case_status stored as bare ID string
-            data["case_status"] = CaseStatus(
+            data["case_status"] = as_CaseStatus(
                 id_=case_status,
                 context=data.get("context"),
                 attributed_to=data.get("attributed_to"),
             )
         # If case_status is a dict (from CoreCaseStatus serialisation),
-        # cls.model_validate will hydrate it into a CaseStatus instance.
+        # cls.model_validate will hydrate it into a as_CaseStatus instance.
         return cls.model_validate(data)
 
     def to_core(self) -> CoreParticipantStatus:
@@ -209,12 +211,12 @@ class ParticipantStatus(VultronAS2Object):
         # Convert embedded CaseStatus wire object (or its serialised dict) to
         # CoreCaseStatus so pxa_state and em_state cross the boundary.
         wire_case_status = data.get("case_status")
-        if isinstance(wire_case_status, CaseStatus):
+        if isinstance(wire_case_status, as_CaseStatus):
             data["case_status"] = wire_case_status.to_core()
         elif isinstance(wire_case_status, dict):
             # _to_core_data() with round_trip=True serialises nested objects
             # as dicts; re-validate and convert.
-            cs_obj = CaseStatus.model_validate(wire_case_status)
+            cs_obj = as_CaseStatus.model_validate(wire_case_status)
             data["case_status"] = cs_obj.to_core()
         else:
             data["case_status"] = None
@@ -223,18 +225,18 @@ class ParticipantStatus(VultronAS2Object):
         return CoreParticipantStatus.model_validate(data)
 
 
-ParticipantStatusRef: TypeAlias = ActivityStreamRef[ParticipantStatus]
+as_ParticipantStatusRef: TypeAlias = ActivityStreamRef[as_ParticipantStatus]
 
 
 def main():
-    cs = CaseStatus()
+    cs = as_CaseStatus()
     print(f"### {cs.type_} ###")
     print()
     print(cs.to_json(indent=2))
     print()
     print()
 
-    ps = ParticipantStatus(
+    ps = as_ParticipantStatus(
         attributed_to="foo",
         context="bar",
         rm_state=RM.RECEIVED,

--- a/vultron/wire/as2/vocab/objects/embargo_event.py
+++ b/vultron/wire/as2/vocab/objects/embargo_event.py
@@ -39,7 +39,7 @@ def _45_days_hence():
     return now + timedelta(days=45)
 
 
-class EmbargoEvent(as_Event):
+class as_EmbargoEvent(as_Event):
     """Wire projection of the core EmbargoEvent domain object.
 
     Represents an embargo on a VulnerabilityCase for AS2 wire exchange.
@@ -80,10 +80,10 @@ class EmbargoEvent(as_Event):
         return self
 
     @classmethod
-    def from_core(cls, core_obj: CoreEmbargoEvent) -> "EmbargoEvent":
+    def from_core(cls, core_obj: CoreEmbargoEvent) -> "as_EmbargoEvent":
         data = core_obj.model_dump(mode="json")
         _strip_core_context(data)
-        return cast("EmbargoEvent", cls.model_validate(data))
+        return cast("as_EmbargoEvent", cls.model_validate(data))
 
     def to_core(self) -> CoreEmbargoEvent:
         data = self.model_dump(mode="python", round_trip=True)
@@ -94,11 +94,11 @@ class EmbargoEvent(as_Event):
         return CoreEmbargoEvent.model_validate(data)
 
 
-EmbargoEventRef: TypeAlias = ActivityStreamRef[EmbargoEvent]
+as_EmbargoEventRef: TypeAlias = ActivityStreamRef[as_EmbargoEvent]
 
 
 def main():
-    obj = EmbargoEvent()
+    obj = as_EmbargoEvent()
     print(obj.to_json(indent=2))
 
 

--- a/vultron/wire/as2/vocab/objects/embargo_policy.py
+++ b/vultron/wire/as2/vocab/objects/embargo_policy.py
@@ -37,7 +37,7 @@ from vultron.wire.as2.vocab.objects.base import (
 )
 
 
-class EmbargoPolicy(VultronAS2Object):
+class as_EmbargoPolicy(VultronAS2Object):
     """Wire projection of the core EmbargoPolicy domain object.
 
     Represents an Actor's stated embargo preferences for AS2 wire exchange.
@@ -108,21 +108,21 @@ class EmbargoPolicy(VultronAS2Object):
         return cast(str, isodate.duration_isoformat(value))
 
     @classmethod
-    def from_core(cls, core_obj: CoreEmbargoPolicy) -> "EmbargoPolicy":
+    def from_core(cls, core_obj: CoreEmbargoPolicy) -> "as_EmbargoPolicy":
         data = core_obj.model_dump(mode="json")
         _strip_core_context(data)
-        return cast("EmbargoPolicy", cls.model_validate(data))
+        return cast("as_EmbargoPolicy", cls.model_validate(data))
 
     def to_core(self) -> CoreEmbargoPolicy:
         data = self._to_core_data()
         return CoreEmbargoPolicy.model_validate(data)
 
 
-EmbargoPolicyRef: TypeAlias = ActivityStreamRef[EmbargoPolicy]
+as_EmbargoPolicyRef: TypeAlias = ActivityStreamRef[as_EmbargoPolicy]
 
 
 def main():
-    obj = EmbargoPolicy(
+    obj = as_EmbargoPolicy(
         actor_id="https://example.org/actors/vendor",
         inbox="https://example.org/actors/vendor/inbox",
         preferred_duration=timedelta(days=90),

--- a/vultron/wire/as2/vocab/objects/vulnerability_case.py
+++ b/vultron/wire/as2/vocab/objects/vulnerability_case.py
@@ -35,22 +35,22 @@ from vultron.wire.as2.vocab.objects.base import (
     _strip_core_context,
 )
 from vultron.wire.as2.vocab.objects.case_participant import (
-    CaseParticipant,
-    CaseParticipantRef,
+    as_CaseParticipant,
+    as_CaseParticipantRef,
 )
 from vultron.wire.as2.vocab.objects.case_status import (
-    CaseStatus,
-    CaseStatusRef,
+    as_CaseStatus,
+    as_CaseStatusRef,
 )
-from vultron.wire.as2.vocab.objects.embargo_event import EmbargoEventRef
+from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEventRef
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    VulnerabilityReportRef,
+    as_VulnerabilityReportRef,
 )
 from vultron.core.models.enums import VultronObjectType as VO_type
 
 
 def init_case_status():
-    return cast(list[CaseStatusRef], [CaseStatus()])
+    return cast(list[as_CaseStatusRef], [as_CaseStatus()])
 
 
 class VulnerabilityCaseStub(VultronAS2Object):
@@ -79,17 +79,17 @@ class VulnerabilityCaseStub(VultronAS2Object):
         default=None, json_schema_extra={"format": "date-time"}
     )
     summary: NonEmptyString | None = None
-    active_embargo: EmbargoEventRef = None
-    case_status: CaseStatusRef = None
+    active_embargo: as_EmbargoEventRef = None
+    case_status: as_CaseStatusRef = None
 
 
 def _materialized_case_statuses(
-    statuses: list[CaseStatusRef],
-) -> list[CaseStatus]:
-    return [status for status in statuses if isinstance(status, CaseStatus)]
+    statuses: list[as_CaseStatusRef],
+) -> list[as_CaseStatus]:
+    return [status for status in statuses if isinstance(status, as_CaseStatus)]
 
 
-class VulnerabilityCase(VultronAS2Object):
+class as_VulnerabilityCase(VultronAS2Object):
     """
     A Vulnerability Case is a container for vulnerability reports, and is used to track the
     lifecycle of the case and its constituent vulnerability reports, including the status of the case itself,
@@ -101,12 +101,14 @@ class VulnerabilityCase(VultronAS2Object):
         validation_alias="type",
         serialization_alias="type",
     )
-    case_participants: list[CaseParticipantRef] = Field(default_factory=list)
-    actor_participant_index: dict[str, str] = Field(default_factory=dict)
-    vulnerability_reports: list[VulnerabilityReportRef] = Field(
+    case_participants: list[as_CaseParticipantRef] = Field(
         default_factory=list
     )
-    case_statuses: list[CaseStatusRef] = Field(
+    actor_participant_index: dict[str, str] = Field(default_factory=dict)
+    vulnerability_reports: list[as_VulnerabilityReportRef] = Field(
+        default_factory=list
+    )
+    case_statuses: list[as_CaseStatusRef] = Field(
         default_factory=init_case_status
     )
     notes: list[as_NoteRef] = Field(default_factory=list)
@@ -118,19 +120,21 @@ class VulnerabilityCase(VultronAS2Object):
     genesis_hash: str = ""
 
     # don't excludeIfNone here to make it explicit when there is no embargo
-    active_embargo: EmbargoEventRef = None
+    active_embargo: as_EmbargoEventRef = None
 
-    proposed_embargoes: list[EmbargoEventRef] = Field(default_factory=list)
+    proposed_embargoes: list[as_EmbargoEventRef] = Field(default_factory=list)
 
     case_activity: list[as_Activity] = Field(default_factory=list)
 
     # case relationships
-    parent_cases: list["VulnerabilityCaseRef"] = Field(default_factory=list)
-    child_cases: list["VulnerabilityCaseRef"] = Field(default_factory=list)
-    sibling_cases: list["VulnerabilityCaseRef"] = Field(default_factory=list)
+    parent_cases: list["as_VulnerabilityCaseRef"] = Field(default_factory=list)
+    child_cases: list["as_VulnerabilityCaseRef"] = Field(default_factory=list)
+    sibling_cases: list["as_VulnerabilityCaseRef"] = Field(
+        default_factory=list
+    )
 
     @model_validator(mode="after")
-    def _compute_genesis_hash_if_missing(self) -> "VulnerabilityCase":
+    def _compute_genesis_hash_if_missing(self) -> "as_VulnerabilityCase":
         """Compute ``genesis_hash`` at construction when not explicitly set.
 
         Mirrors the same validator on the core
@@ -171,11 +175,11 @@ class VulnerabilityCase(VultronAS2Object):
     def set_cs_context(self):
         # set the context of the case status objects to the case id
         for cs in self.case_statuses:
-            if isinstance(cs, CaseStatus):
+            if isinstance(cs, as_CaseStatus):
                 cs.context = self.id_
         return self
 
-    def add_report(self, report: VulnerabilityReportRef) -> None:
+    def add_report(self, report: as_VulnerabilityReportRef) -> None:
         """Add a vulnerability report to the case
 
         Args:
@@ -183,7 +187,7 @@ class VulnerabilityCase(VultronAS2Object):
         """
         self.vulnerability_reports.append(report)
 
-    def add_participant(self, participant: CaseParticipant) -> None:
+    def add_participant(self, participant: as_CaseParticipant) -> None:
         """Add a participant to the case, maintaining the actor_participant_index.
 
         The participant's actor ID (from ``attributed_to``) is recorded in
@@ -191,7 +195,7 @@ class VulnerabilityCase(VultronAS2Object):
         participant by actor ID.
 
         Args:
-            participant: a CaseParticipant object (full object required to
+            participant: a as_CaseParticipant object (full object required to
                          update the index)
         """
         participant_id = participant.id_
@@ -199,7 +203,7 @@ class VulnerabilityCase(VultronAS2Object):
             str(getattr(p, "id_", p)) for p in self.case_participants
         }
         if participant_id not in existing_ids:
-            if isinstance(participant, CaseParticipant):
+            if isinstance(participant, as_CaseParticipant):
                 self.case_participants.append(participant)
             else:
                 self.case_participants.append(participant_id)
@@ -233,7 +237,7 @@ class VulnerabilityCase(VultronAS2Object):
         self.case_participants = [
             p
             for p in self.case_participants
-            if (p.id_ if isinstance(p, CaseParticipant) else p)
+            if (p.id_ if isinstance(p, as_CaseParticipant) else p)
             != participant_id
         ]
 
@@ -246,12 +250,12 @@ class VulnerabilityCase(VultronAS2Object):
             del self.actor_participant_index[actor_id]
 
     @property
-    def current_status(self) -> CaseStatus:
-        """Return the most recent CaseStatus, sorted by updated timestamp."""
+    def current_status(self) -> as_CaseStatus:
+        """Return the most recent as_CaseStatus, sorted by updated timestamp."""
         materialized_statuses = _materialized_case_statuses(self.case_statuses)
         if not materialized_statuses:
             raise ValueError(
-                "VulnerabilityCase has no materialized CaseStatus"
+                "VulnerabilityCase has no materialized as_CaseStatus"
             )
         return max(
             materialized_statuses,
@@ -259,11 +263,11 @@ class VulnerabilityCase(VultronAS2Object):
         )
 
     @property
-    def case_status(self) -> CaseStatus:
-        """Return the most recent CaseStatus (read-only; see case_statuses for history)."""
+    def case_status(self) -> as_CaseStatus:
+        """Return the most recent as_CaseStatus (read-only; see case_statuses for history)."""
         return self.current_status
 
-    def set_embargo(self, embargo: EmbargoEventRef) -> None:
+    def set_embargo(self, embargo: as_EmbargoEventRef) -> None:
         """Set the active embargo for the case
 
         Args:
@@ -283,7 +287,9 @@ class VulnerabilityCase(VultronAS2Object):
             self.case_activity.append(activity)
 
     @classmethod
-    def from_core(cls, core_obj: CoreVulnerabilityCase) -> "VulnerabilityCase":
+    def from_core(
+        cls, core_obj: CoreVulnerabilityCase
+    ) -> "as_VulnerabilityCase":
         data = core_obj.model_dump(mode="json")
         _strip_core_context(data)
         data["case_activity"] = [
@@ -308,7 +314,7 @@ class VulnerabilityCase(VultronAS2Object):
         data["case_participants"] = [
             (
                 participant.to_core()
-                if isinstance(participant, CaseParticipant)
+                if isinstance(participant, as_CaseParticipant)
                 else _ref_id_or_value(participant)
             )
             for participant in self.case_participants
@@ -316,7 +322,7 @@ class VulnerabilityCase(VultronAS2Object):
         data["case_statuses"] = [
             (
                 status.to_core()
-                if isinstance(status, CaseStatus)
+                if isinstance(status, as_CaseStatus)
                 else _ref_id_or_value(status)
             )
             for status in self.case_statuses
@@ -338,11 +344,11 @@ class VulnerabilityCase(VultronAS2Object):
         return CoreVulnerabilityCase.model_validate(data)
 
 
-VulnerabilityCaseRef: TypeAlias = ActivityStreamRef[VulnerabilityCase]
+as_VulnerabilityCaseRef: TypeAlias = ActivityStreamRef[as_VulnerabilityCase]
 
 
 def main():
-    obj = VulnerabilityCase()
+    obj = as_VulnerabilityCase()
     _json = obj.to_json(indent=2)
     print(_json)
     with open("../../../doc/examples/vulnerability_case.json", "w") as fp:

--- a/vultron/wire/as2/vocab/objects/vulnerability_record.py
+++ b/vultron/wire/as2/vocab/objects/vulnerability_record.py
@@ -29,7 +29,7 @@ from vultron.wire.as2.vocab.base.links import ActivityStreamRef
 from vultron.wire.as2.vocab.objects.base import VultronAS2Object
 
 
-class VulnerabilityRecord(VultronAS2Object):
+class as_VulnerabilityRecord(VultronAS2Object):
     """Wire projection of the core VulnerabilityRecord domain object.
 
     Represents a persistent identifier record for a confirmed vulnerability
@@ -67,11 +67,11 @@ class VulnerabilityRecord(VultronAS2Object):
     @classmethod
     def from_core(
         cls, core_obj: CoreVulnerabilityRecord
-    ) -> "VulnerabilityRecord":
-        """Create a wire :class:`VulnerabilityRecord` from a core domain
+    ) -> "as_VulnerabilityRecord":
+        """Create a wire :class:`as_VulnerabilityRecord` from a core domain
         :class:`~vultron.core.models.vulnerability_record.VulnerabilityRecord`.
         """
-        return cast("VulnerabilityRecord", super().from_core(core_obj))
+        return cast("as_VulnerabilityRecord", super().from_core(core_obj))
 
     def to_core(self) -> CoreVulnerabilityRecord:
         """Convert this wire object to a core domain
@@ -82,14 +82,16 @@ class VulnerabilityRecord(VultronAS2Object):
         return CoreVulnerabilityRecord.model_validate(data)
 
 
-VulnerabilityRecordRef: TypeAlias = ActivityStreamRef[VulnerabilityRecord]
+as_VulnerabilityRecordRef: TypeAlias = ActivityStreamRef[
+    as_VulnerabilityRecord
+]
 
 
 def main():
     from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 
     actor = as_Actor()
-    obj = VulnerabilityRecord(
+    obj = as_VulnerabilityRecord(
         name="CVE-2024-1234",
         aliases=["VU#654321"],
         url="https://example.org/advisory/cve-2024-1234",

--- a/vultron/wire/as2/vocab/objects/vulnerability_report.py
+++ b/vultron/wire/as2/vocab/objects/vulnerability_report.py
@@ -31,7 +31,7 @@ from vultron.wire.as2.vocab.objects.base import (
 from vultron.core.models.enums import VultronObjectType as VO_type
 
 
-class VulnerabilityReport(VultronAS2Object):
+class as_VulnerabilityReport(VultronAS2Object):
     """
     Represents a Vulnerability Report as an ActivityStreams Object.
     """
@@ -45,8 +45,8 @@ class VulnerabilityReport(VultronAS2Object):
     @classmethod
     def from_core(
         cls, core_obj: CoreVulnerabilityReport
-    ) -> "VulnerabilityReport":
-        return cast("VulnerabilityReport", super().from_core(core_obj))
+    ) -> "as_VulnerabilityReport":
+        return cast("as_VulnerabilityReport", super().from_core(core_obj))
 
     def to_core(self) -> CoreVulnerabilityReport:
         data = self._to_core_data()
@@ -58,14 +58,16 @@ class VulnerabilityReport(VultronAS2Object):
         return CoreVulnerabilityReport.model_validate(data)
 
 
-VulnerabilityReportRef: TypeAlias = ActivityStreamRef[VulnerabilityReport]
+as_VulnerabilityReportRef: TypeAlias = ActivityStreamRef[
+    as_VulnerabilityReport
+]
 
 
 def main():
     from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 
     reporter = as_Actor()
-    obj = VulnerabilityReport(
+    obj = as_VulnerabilityReport(
         content="Report content goes here",
         attributed_to=[
             reporter,

--- a/vultron/wire/as2/vocab/objects/vultron_actor.py
+++ b/vultron/wire/as2/vocab/objects/vultron_actor.py
@@ -34,7 +34,7 @@ class VultronActorMixin(as_Actor):
     )
 
 
-class VultronPerson(VultronActorMixin):
+class as_VultronPerson(VultronActorMixin):
     type_: Literal[as_ActorType.PERSON] = Field(
         default=as_ActorType.PERSON,
         validation_alias="type",
@@ -42,7 +42,7 @@ class VultronPerson(VultronActorMixin):
     )
 
 
-class VultronOrganization(VultronActorMixin):
+class as_VultronOrganization(VultronActorMixin):
     type_: Literal[as_ActorType.ORGANIZATION] = Field(
         default=as_ActorType.ORGANIZATION,
         validation_alias="type",
@@ -50,7 +50,7 @@ class VultronOrganization(VultronActorMixin):
     )
 
 
-class VultronService(VultronActorMixin):
+class as_VultronService(VultronActorMixin):
     type_: Literal[as_ActorType.SERVICE] = Field(
         default=as_ActorType.SERVICE,
         validation_alias="type",
@@ -58,7 +58,7 @@ class VultronService(VultronActorMixin):
     )
 
 
-class VultronApplication(VultronActorMixin):
+class as_VultronApplication(VultronActorMixin):
     type_: Literal[as_ActorType.APPLICATION] = Field(
         default=as_ActorType.APPLICATION,
         validation_alias="type",
@@ -66,7 +66,7 @@ class VultronApplication(VultronActorMixin):
     )
 
 
-class VultronGroup(VultronActorMixin):
+class as_VultronGroup(VultronActorMixin):
     type_: Literal[as_ActorType.GROUP] = Field(
         default=as_ActorType.GROUP,
         validation_alias="type",
@@ -76,27 +76,29 @@ class VultronGroup(VultronActorMixin):
 
 VOCABULARY["Actor"] = CoreActor
 VOCABULARY["CoreActor"] = CoreActor
-VOCABULARY["Person"] = VultronPerson
-VOCABULARY["Organization"] = VultronOrganization
-VOCABULARY["Service"] = VultronService
-VOCABULARY["Application"] = VultronApplication
-VOCABULARY["Group"] = VultronGroup
+VOCABULARY["Person"] = as_VultronPerson
+VOCABULARY["Organization"] = as_VultronOrganization
+VOCABULARY["Service"] = as_VultronService
+VOCABULARY["Application"] = as_VultronApplication
+VOCABULARY["Group"] = as_VultronGroup
 
 
-VultronPersonRef: TypeAlias = ActivityStreamRef[VultronPerson]
-VultronOrganizationRef: TypeAlias = ActivityStreamRef[VultronOrganization]
-VultronServiceRef: TypeAlias = ActivityStreamRef[VultronService]
-VultronApplicationRef: TypeAlias = ActivityStreamRef[VultronApplication]
-VultronGroupRef: TypeAlias = ActivityStreamRef[VultronGroup]
+as_VultronPersonRef: TypeAlias = ActivityStreamRef[as_VultronPerson]
+as_VultronOrganizationRef: TypeAlias = ActivityStreamRef[
+    as_VultronOrganization
+]
+as_VultronServiceRef: TypeAlias = ActivityStreamRef[as_VultronService]
+as_VultronApplicationRef: TypeAlias = ActivityStreamRef[as_VultronApplication]
+as_VultronGroupRef: TypeAlias = ActivityStreamRef[as_VultronGroup]
 
 
 ActorUnion: TypeAlias = Annotated[
     Union[
-        VultronPerson,
-        VultronOrganization,
-        VultronService,
-        VultronApplication,
-        VultronGroup,
+        as_VultronPerson,
+        as_VultronOrganization,
+        as_VultronService,
+        as_VultronApplication,
+        as_VultronGroup,
     ],
     Field(
         description="A concrete Vultron actor (Person, Organization, Service, Application, or Group)."
@@ -108,14 +110,14 @@ __all__ = [
     "ActorUnion",
     "CoreActor",
     "VultronActorMixin",
-    "VultronApplication",
-    "VultronApplicationRef",
-    "VultronGroup",
-    "VultronGroupRef",
-    "VultronOrganization",
-    "VultronOrganizationRef",
-    "VultronPerson",
-    "VultronPersonRef",
-    "VultronService",
-    "VultronServiceRef",
+    "as_VultronApplication",
+    "as_VultronApplicationRef",
+    "as_VultronGroup",
+    "as_VultronGroupRef",
+    "as_VultronOrganization",
+    "as_VultronOrganizationRef",
+    "as_VultronPerson",
+    "as_VultronPersonRef",
+    "as_VultronService",
+    "as_VultronServiceRef",
 ]


### PR DESCRIPTION
## Summary

- Rename all 16 Vultron-specific wire vocab classes in `vultron/wire/as2/vocab/objects/` to use the `as_` prefix (ARCH-14-001), matching the pre-existing `as_CaseProposal` pattern
- Empty `KNOWN_VIOLATIONS` in `test/architecture/test_wire_vocab_naming.py` to `frozenset()` — all collisions resolved
- Add backward-compat aliases in `__init__.py` (e.g. `CaseActor = as_CaseActor`) to avoid immediate caller breakage

## Classes Renamed

| Old Name | New Name |
|---|---|
| `CaseActor` | `as_CaseActor` |
| `CaseLedgerEntry` | `as_CaseLedgerEntry` |
| `CaseParticipant` | `as_CaseParticipant` |
| `CaseReference` | `as_CaseReference` |
| `CaseStatus` | `as_CaseStatus` |
| `ParticipantStatus` | `as_ParticipantStatus` |
| `EmbargoEvent` | `as_EmbargoEvent` |
| `EmbargoPolicy` | `as_EmbargoPolicy` |
| `VulnerabilityCase` | `as_VulnerabilityCase` |
| `VulnerabilityRecord` | `as_VulnerabilityRecord` |
| `VulnerabilityReport` | `as_VulnerabilityReport` |
| `VultronPerson` | `as_VultronPerson` |
| `VultronOrganization` | `as_VultronOrganization` |
| `VultronService` | `as_VultronService` |
| `VultronApplication` | `as_VultronApplication` |
| `VultronGroup` | `as_VultronGroup` |

Also renamed `TypeAlias` Ref types (e.g. `VulnerabilityCaseRef` → `as_VulnerabilityCaseRef`).

## Key Design Constraints Applied

- `type_` wire format strings (e.g. `"VulnerabilityCase"`) are **not changed** — only Python class names
- `datalayer.by_type("VulnerabilityReport")` calls use the stable type string, not the Python class name
- Error messages and `VultronNotFoundError` resource_type arguments use domain type strings, not Python class names
- `_make_id()` in example builders uses type strings, not class names
- Dynamic import in `actors.py` correctly imports `ParticipantStatus` (core) not `as_ParticipantStatus`

## Changes

- `vultron/wire/as2/vocab/objects/*.py` — 16 class renames + TypeAlias renames
- `vultron/wire/as2/vocab/objects/__init__.py` — explicit re-exports + backward-compat aliases
- `test/architecture/test_wire_vocab_naming.py` — `KNOWN_VIOLATIONS = frozenset()`
- All import sites in `vultron/`, `test/`, `vultron/demo/` updated to use `as_`-prefixed names
- 4 code review findings fixed: `_make_id()` URI bug, error message type strings, `VultronNotFoundError` resource_type

## Verification

- `uv run pytest`: 4786 passed, 38 skipped, 2 xfailed
- `uv run black vultron/ test/`: no reformatting needed
- `uv run flake8 vultron/ test/`: clean
- `uv run mypy`: 0 issues in 1011 source files
- `uv run pyright`: 0 errors, 0 warnings
- Architecture ratchet test `test_wire_vocab_objects_do_not_shadow_core_model_names` passes with empty `KNOWN_VIOLATIONS`

Closes #1387

🤖 Generated with [Claude Code](https://claude.com/claude-code)