### PR TITLE
docs(#1446): document pre-SYNC-13 upgrade path in sync-ledger-replication notes

### DIFF
--- a/notes/README.md
+++ b/notes/README.md
@@ -364,9 +364,12 @@ model.
 **`sync-ledger-replication.md`**
 Log-centric architecture overview: hash-chain design rationale, log position
 in activity `context`, implementation phases (SYNC-1–4), system invariants,
-and open questions for the replicated case event log.
+open questions for the replicated case event log, SYNC-13 ledger write-ownership
+boundary, and pre-SYNC-13 upgrade path.
 **Load when**: designing multi-actor case synchronization, evaluating the
-hash-chain log approach, or scoping the SYNC-1–4 implementation phases.
+hash-chain log approach, scoping the SYNC-1–4 implementation phases, or
+investigating the SYNC-12/SYNC-13 effects-before-persist and write-ownership
+invariants.
 
 **`participant-case-replica.md`**
 Design notes for participant case replicas: per-actor case copies, the

--- a/notes/sync-ledger-replication.md
+++ b/notes/sync-ledger-replication.md
@@ -382,6 +382,27 @@ its per-case genesis hash) before it can validate a replicated
 CLP-08-005). Tests that previously relied on the adapter pre-store to make the
 entry "appear" in the peer DL must seed the case on the peer instead.
 
+---
+
+## Pre-SYNC-13 Upgrade Path
+
+Nodes that ran pre-SYNC-13 code may hold stale `{entry: stored, effects: not-applied}`
+state. This arises because `_store_nested_inbox_object` formerly persisted a
+`CaseLedgerEntry` during parse without applying the entry's domain effects. When such
+a node later receives the same `Announce(CaseLedgerEntry)`, `CheckLedgerEntryAlreadyStoredNode`
+(SYNC-12-003) fires SUCCESS and the entire `ProcessAndStore` subtree — including
+`LogEntryEventEffects` — is skipped. The entry's effects are never applied, and the
+node's derived state (e.g., participant list, EM state) remains stale.
+
+**Resolution: Accept.** No repair path is implemented. The pre-SYNC-13 code was a
+bug in pre-production code with no extant deployed nodes or cases. The correct recovery
+for any node in this state is to wipe its local DataLayer for the affected case and
+re-sync from the CaseActor. Re-sync replays all `Announce(CaseLedgerEntry)` entries
+from the beginning; each entry passes the `CheckLedgerEntryAlreadyStoredNode` gate
+(FAILURE — not yet stored), so `ProcessAndStore` runs and effects are applied correctly.
+
+This is tracked as issue #1446.
+
 ## Related
 
 - `specs/sync-ledger-replication.yaml` — normative requirements

--- a/plan/history/2607/implementation/ISSUE-1446.md
+++ b/plan/history/2607/implementation/ISSUE-1446.md
@@ -1,0 +1,14 @@
+---
+source: ISSUE-1446
+timestamp: '2026-07-17T13:59:26.983098+00:00'
+title: Document pre-SYNC-13 upgrade path (migration guard accept)
+type: implementation
+---
+
+## Issue #1446 — Migration guard: detect already-persisted entries with unapplied effects (SYNC-12)
+
+Decided Accept (no repair path) — the stale {entry: stored, effects: not-applied} state arose from a pre-production bug in the ingress adapter (pre-SYNC-13 code), with no extant deployed nodes or cases. SYNC-13 (PR #1447) closes the gap going forward.
+
+Added "Pre-SYNC-13 Upgrade Path" section to notes/sync-ledger-replication.md: nodes in stale state must wipe their local DataLayer and re-sync from the CaseActor. Also updated notes/README.md to surface the SYNC-12/SYNC-13 write-ownership and upgrade-path content in the file's index entry.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1478>


### PR DESCRIPTION
- Closes #1446

## Summary

Adds a "Pre-SYNC-13 Upgrade Path" section to `notes/sync-ledger-replication.md` documenting the Accept decision: nodes with stale `{entry: stored, effects: not-applied}` state from pre-SYNC-13 code must wipe their local DataLayer and re-sync from the CaseActor. No repair path is implemented because the stale state arose from a bug in pre-production code with no extant deployed nodes.

Also updates `notes/README.md` to surface the SYNC-12/SYNC-13 and upgrade-path content in the file's index entry.

## Changes

- `notes/sync-ledger-replication.md`: add Pre-SYNC-13 Upgrade Path section with recovery guidance; add `---` separator before the section
- `notes/README.md`: extend `sync-ledger-replication.md` description to cover SYNC-12/SYNC-13 write-ownership invariants and upgrade path