### PR TITLE
feat(states): add RM/vfd/EM/pxa ratchet predicates and state-group tuples

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1453.md
+++ b/plan/history/2607/implementation/ISSUE-1453.md
@@ -1,0 +1,19 @@
+---
+source: ISSUE-1453
+timestamp: '2026-07-17T15:19:26.475966+00:00'
+title: Add RM/vfd/EM/pxa ratchet predicates and state-group tuples
+type: implementation
+---
+
+## Issue #1453 — Add RM/vfd/EM/pxa ratchet predicates and state-group tuples
+
+Implemented LST-04-001 ratchet predicates and state-group tuples in vultron/core/states/:
+
+- RM: RM_VALIDATED tuple + is_rm_validated() (excludes RM.CLOSED, reachable without validation)
+- EM: EM_EMBARGO_ACTIVE tuple + is_em_embargo_active() (ACTIVE + REVISE states)
+- vfd: VFD_VENDOR_AWARE/FIX_READY/FIX_DEPLOYED tuples + is_vfd_*() predicates
+- pxa: PXA_PUBLIC_AWARE/EXPLOIT_PUBLIC/ATTACKS_OBSERVED tuples + is_pxa_*() predicates
+- New test file test/core/states/test_ratchet_predicates.py with parametrized + exhaustive coverage
+- Fixed CS_pxa docstring: pXa/pXA are ephemeral not invalid states
+
+PR: <https://github.com/CERTCC/Vultron/pull/1482>

--- a/test/core/states/test_ratchet_predicates.py
+++ b/test/core/states/test_ratchet_predicates.py
@@ -1,0 +1,230 @@
+"""
+Unit tests for RM/vfd/EM/pxa ratchet predicates and state-group tuples.
+
+Spec coverage:
+- LST-04-001: RM and vfd ratchets and EM and pxa ratchets are modeled as
+  state-group tuples and is_*() predicates, extending the existing helpers.
+"""
+
+import pytest
+
+from vultron.core.states.cs import (
+    CS_pxa,
+    CS_vfd,
+    PXA_ATTACKS_OBSERVED,
+    PXA_EXPLOIT_PUBLIC,
+    PXA_PUBLIC_AWARE,
+    VFD_FIX_DEPLOYED,
+    VFD_FIX_READY,
+    VFD_VENDOR_AWARE,
+    is_pxa_attacks_observed,
+    is_pxa_exploit_public,
+    is_pxa_public_aware,
+    is_vfd_fix_deployed,
+    is_vfd_fix_ready,
+    is_vfd_vendor_aware,
+)
+from vultron.core.states.em import EM, EM_EMBARGO_ACTIVE, is_em_embargo_active
+from vultron.core.states.rm import RM, RM_VALIDATED, is_rm_validated
+
+# ---------------------------------------------------------------------------
+# RM ratchet
+# ---------------------------------------------------------------------------
+
+
+class TestRmValidated:
+    def test_rm_validated_tuple_contents(self):
+        assert isinstance(RM_VALIDATED, tuple)
+        assert set(RM_VALIDATED) == {RM.VALID, RM.DEFERRED, RM.ACCEPTED}
+
+    @pytest.mark.parametrize("state", [RM.VALID, RM.DEFERRED, RM.ACCEPTED])
+    def test_is_rm_validated_true(self, state):
+        assert is_rm_validated(state) is True
+
+    @pytest.mark.parametrize(
+        "state", [RM.START, RM.RECEIVED, RM.INVALID, RM.CLOSED]
+    )
+    def test_is_rm_validated_false(self, state):
+        assert is_rm_validated(state) is False
+
+    def test_closed_excluded(self):
+        """CLOSED is reachable from INVALID without passing through VALID."""
+        assert is_rm_validated(RM.CLOSED) is False
+
+    def test_invalid_excluded(self):
+        assert is_rm_validated(RM.INVALID) is False
+
+
+# ---------------------------------------------------------------------------
+# vfd milestone groups and predicates
+# ---------------------------------------------------------------------------
+
+
+class TestVfdVendorAware:
+    def test_tuple_contents(self):
+        assert isinstance(VFD_VENDOR_AWARE, tuple)
+        assert set(VFD_VENDOR_AWARE) == {CS_vfd.Vfd, CS_vfd.VFd, CS_vfd.VFD}
+
+    @pytest.mark.parametrize("state", [CS_vfd.Vfd, CS_vfd.VFd, CS_vfd.VFD])
+    def test_true(self, state):
+        assert is_vfd_vendor_aware(state) is True
+
+    def test_false_vfd(self):
+        assert is_vfd_vendor_aware(CS_vfd.vfd) is False
+
+
+class TestVfdFixReady:
+    def test_tuple_contents(self):
+        assert isinstance(VFD_FIX_READY, tuple)
+        assert set(VFD_FIX_READY) == {CS_vfd.VFd, CS_vfd.VFD}
+
+    @pytest.mark.parametrize("state", [CS_vfd.VFd, CS_vfd.VFD])
+    def test_true(self, state):
+        assert is_vfd_fix_ready(state) is True
+
+    @pytest.mark.parametrize("state", [CS_vfd.vfd, CS_vfd.Vfd])
+    def test_false(self, state):
+        assert is_vfd_fix_ready(state) is False
+
+
+class TestVfdFixDeployed:
+    def test_tuple_contents(self):
+        assert isinstance(VFD_FIX_DEPLOYED, tuple)
+        assert set(VFD_FIX_DEPLOYED) == {CS_vfd.VFD}
+
+    def test_true(self):
+        assert is_vfd_fix_deployed(CS_vfd.VFD) is True
+
+    @pytest.mark.parametrize("state", [CS_vfd.vfd, CS_vfd.Vfd, CS_vfd.VFd])
+    def test_false(self, state):
+        assert is_vfd_fix_deployed(state) is False
+
+
+class TestVfdMilestoneImplication:
+    """Fix deployed implies fix ready implies vendor aware."""
+
+    def test_deployed_implies_ready(self):
+        for s in VFD_FIX_DEPLOYED:
+            assert is_vfd_fix_ready(s)
+
+    def test_ready_implies_vendor_aware(self):
+        for s in VFD_FIX_READY:
+            assert is_vfd_vendor_aware(s)
+
+
+# ---------------------------------------------------------------------------
+# EM active/negotiating
+# ---------------------------------------------------------------------------
+
+
+class TestEmEmbargoActive:
+    def test_tuple_contents(self):
+        assert isinstance(EM_EMBARGO_ACTIVE, tuple)
+        assert set(EM_EMBARGO_ACTIVE) == {EM.ACTIVE, EM.REVISE}
+
+    @pytest.mark.parametrize("state", [EM.ACTIVE, EM.REVISE])
+    def test_true(self, state):
+        assert is_em_embargo_active(state) is True
+
+    @pytest.mark.parametrize("state", [EM.NONE, EM.PROPOSED, EM.EXITED])
+    def test_false(self, state):
+        assert is_em_embargo_active(state) is False
+
+    def test_proposed_excluded(self):
+        """PROPOSED means negotiation only; embargo not yet in force."""
+        assert is_em_embargo_active(EM.PROPOSED) is False
+
+    def test_exited_excluded(self):
+        assert is_em_embargo_active(EM.EXITED) is False
+
+
+# ---------------------------------------------------------------------------
+# pxa public-state groups and predicates
+# ---------------------------------------------------------------------------
+
+
+class TestPxaPublicAware:
+    def test_tuple_contents(self):
+        assert isinstance(PXA_PUBLIC_AWARE, tuple)
+        assert set(PXA_PUBLIC_AWARE) == {
+            CS_pxa.Pxa,
+            CS_pxa.PxA,
+            CS_pxa.PXa,
+            CS_pxa.PXA,
+        }
+
+    @pytest.mark.parametrize(
+        "state", [CS_pxa.Pxa, CS_pxa.PxA, CS_pxa.PXa, CS_pxa.PXA]
+    )
+    def test_true(self, state):
+        assert is_pxa_public_aware(state) is True
+
+    @pytest.mark.parametrize(
+        "state", [CS_pxa.pxa, CS_pxa.pxA, CS_pxa.pXa, CS_pxa.pXA]
+    )
+    def test_false(self, state):
+        assert is_pxa_public_aware(state) is False
+
+
+class TestPxaExploitPublic:
+    def test_tuple_contents(self):
+        assert isinstance(PXA_EXPLOIT_PUBLIC, tuple)
+        assert set(PXA_EXPLOIT_PUBLIC) == {
+            CS_pxa.pXa,
+            CS_pxa.pXA,
+            CS_pxa.PXa,
+            CS_pxa.PXA,
+        }
+
+    @pytest.mark.parametrize(
+        "state", [CS_pxa.pXa, CS_pxa.pXA, CS_pxa.PXa, CS_pxa.PXA]
+    )
+    def test_true(self, state):
+        assert is_pxa_exploit_public(state) is True
+
+    @pytest.mark.parametrize(
+        "state", [CS_pxa.pxa, CS_pxa.Pxa, CS_pxa.pxA, CS_pxa.PxA]
+    )
+    def test_false(self, state):
+        assert is_pxa_exploit_public(state) is False
+
+
+class TestPxaAttacksObserved:
+    def test_tuple_contents(self):
+        assert isinstance(PXA_ATTACKS_OBSERVED, tuple)
+        assert set(PXA_ATTACKS_OBSERVED) == {
+            CS_pxa.pxA,
+            CS_pxa.PxA,
+            CS_pxa.pXA,
+            CS_pxa.PXA,
+        }
+
+    @pytest.mark.parametrize(
+        "state", [CS_pxa.pxA, CS_pxa.PxA, CS_pxa.pXA, CS_pxa.PXA]
+    )
+    def test_true(self, state):
+        assert is_pxa_attacks_observed(state) is True
+
+    @pytest.mark.parametrize(
+        "state", [CS_pxa.pxa, CS_pxa.Pxa, CS_pxa.pXa, CS_pxa.PXa]
+    )
+    def test_false(self, state):
+        assert is_pxa_attacks_observed(state) is False
+
+
+class TestPxaExhaustive:
+    """Every CS_pxa state is correctly classified across all three predicates."""
+
+    ALL = list(CS_pxa)
+
+    def test_public_aware_coverage(self):
+        positive = {s for s in self.ALL if is_pxa_public_aware(s)}
+        assert positive == set(PXA_PUBLIC_AWARE)
+
+    def test_exploit_public_coverage(self):
+        positive = {s for s in self.ALL if is_pxa_exploit_public(s)}
+        assert positive == set(PXA_EXPLOIT_PUBLIC)
+
+    def test_attacks_observed_coverage(self):
+        positive = {s for s in self.ALL if is_pxa_attacks_observed(s)}
+        assert positive == set(PXA_ATTACKS_OBSERVED)

--- a/vultron/core/states/__init__.py
+++ b/vultron/core/states/__init__.py
@@ -11,17 +11,42 @@ from vultron.core.states.cs import (
     ExploitPublication,
     FixDeployment,
     FixReadiness,
+    PXA_ATTACKS_OBSERVED,
+    PXA_EXPLOIT_PUBLIC,
+    PXA_PUBLIC_AWARE,
     PublicAwareness,
     PxaState,
     State,
+    VFD_FIX_DEPLOYED,
+    VFD_FIX_READY,
+    VFD_VENDOR_AWARE,
     VendorAwareness,
     VfdState,
     all_states,
+    is_pxa_attacks_observed,
+    is_pxa_exploit_public,
+    is_pxa_public_aware,
+    is_vfd_fix_deployed,
+    is_vfd_fix_ready,
+    is_vfd_vendor_aware,
     pxa,
     state_string_to_enum2,
     state_string_to_enums,
     vfd,
 )
-from vultron.core.states.em import EM, EM_NEGOTIATING
-from vultron.core.states.rm import RM, RM_ACTIVE, RM_CLOSABLE, RM_UNCLOSED
+from vultron.core.states.em import (
+    EM,
+    EM_EMBARGO_ACTIVE,
+    EM_NEGOTIATING,
+    is_em_embargo_active,
+)
+from vultron.core.states.rm import (
+    RM,
+    RM_ACTIVE,
+    RM_CLOSABLE,
+    RM_UNCLOSED,
+    RM_VALIDATED,
+    is_rm_at_least,
+    is_rm_validated,
+)
 from vultron.enums.roles import CVDRole, serialize_roles, validate_roles

--- a/vultron/core/states/cs.py
+++ b/vultron/core/states/cs.py
@@ -184,7 +184,9 @@ class CS_pxa(Enum):
     - `Pxa` indicates the public is aware, no exploit has been published, and no attacks have been observed.
     - `pxA` indicates the public is unaware, no exploit has been published, and attacks have been observed.
     - `PxA` indicates the public is aware, no exploit has been published, and attacks have been observed.
-    - `Pxa` indicates the public is aware, an exploit has been published, and no attacks have been observed.
+    - `pXa` indicates the public is unaware, an exploit has been published, and no attacks have been observed.
+    - `pXA` indicates the public is unaware, an exploit has been published, and attacks have been observed.
+    - `PXa` indicates the public is aware, an exploit has been published, and no attacks have been observed.
     - `PXA` indicates the public is aware, an exploit has been published, and attacks have been observed.
 
     Note that pXa and pXA are ephemeral states: the pX→PX invariant means that once an exploit is

--- a/vultron/core/states/cs.py
+++ b/vultron/core/states/cs.py
@@ -187,7 +187,8 @@ class CS_pxa(Enum):
     - `Pxa` indicates the public is aware, an exploit has been published, and no attacks have been observed.
     - `PXA` indicates the public is aware, an exploit has been published, and attacks have been observed.
 
-    Note that pXa and pXA are not valid states because once an exploit is published, the public is aware.
+    Note that pXa and pXA are ephemeral states: the pX→PX invariant means that once an exploit is
+    published the public immediately becomes aware, so these states resolve to PXa/PXA in practice.
     """
 
     # pxa
@@ -401,6 +402,124 @@ def state_string_to_enum2(
 
 
 all_states = list(CS)
+
+# --- vfd milestone groups and predicates (LST-04-001) ---
+
+# Vendor is aware of the vulnerability (V bit set).
+VFD_VENDOR_AWARE = (CS_vfd.Vfd, CS_vfd.VFd, CS_vfd.VFD)
+
+# Fix has been developed and is ready (F bit set); implies vendor awareness.
+VFD_FIX_READY = (CS_vfd.VFd, CS_vfd.VFD)
+
+# Fix has been deployed (D bit set); implies fix readiness and vendor awareness.
+VFD_FIX_DEPLOYED = (CS_vfd.VFD,)
+
+
+def is_vfd_vendor_aware(state: CS_vfd) -> bool:
+    """Return True if the vendor is aware of the vulnerability (V bit set).
+
+    Examples::
+
+        is_vfd_vendor_aware(CS_vfd.Vfd)  # True
+        is_vfd_vendor_aware(CS_vfd.VFd)  # True
+        is_vfd_vendor_aware(CS_vfd.VFD)  # True
+        is_vfd_vendor_aware(CS_vfd.vfd)  # False
+    """
+    return state in VFD_VENDOR_AWARE
+
+
+def is_vfd_fix_ready(state: CS_vfd) -> bool:
+    """Return True if the fix is ready (F bit set; implies vendor awareness).
+
+    Examples::
+
+        is_vfd_fix_ready(CS_vfd.VFd)  # True
+        is_vfd_fix_ready(CS_vfd.VFD)  # True
+        is_vfd_fix_ready(CS_vfd.Vfd)  # False
+        is_vfd_fix_ready(CS_vfd.vfd)  # False
+    """
+    return state in VFD_FIX_READY
+
+
+def is_vfd_fix_deployed(state: CS_vfd) -> bool:
+    """Return True if the fix is deployed (D bit set).
+
+    Examples::
+
+        is_vfd_fix_deployed(CS_vfd.VFD)  # True
+        is_vfd_fix_deployed(CS_vfd.VFd)  # False
+        is_vfd_fix_deployed(CS_vfd.vfd)  # False
+    """
+    return state in VFD_FIX_DEPLOYED
+
+
+# --- pxa milestone groups and predicates (LST-04-001) ---
+
+# Public is aware of the vulnerability (P bit set).
+PXA_PUBLIC_AWARE = (
+    CS_pxa.Pxa,
+    CS_pxa.PxA,
+    CS_pxa.PXa,
+    CS_pxa.PXA,
+)
+
+# Exploit code is publicly available (X bit set).
+# Includes ephemeral pXa/pXA states (X set, P not yet set); those resolve to
+# PXa/PXA immediately via the pX→PX invariant but are valid enum values.
+PXA_EXPLOIT_PUBLIC = (
+    CS_pxa.pXa,
+    CS_pxa.pXA,
+    CS_pxa.PXa,
+    CS_pxa.PXA,
+)
+
+# Attacks have been observed in the wild (A bit set).
+PXA_ATTACKS_OBSERVED = (
+    CS_pxa.pxA,
+    CS_pxa.PxA,
+    CS_pxa.pXA,
+    CS_pxa.PXA,
+)
+
+
+def is_pxa_public_aware(state: CS_pxa) -> bool:
+    """Return True if the public is aware of the vulnerability (P bit set).
+
+    Examples::
+
+        is_pxa_public_aware(CS_pxa.Pxa)  # True
+        is_pxa_public_aware(CS_pxa.PXA)  # True
+        is_pxa_public_aware(CS_pxa.pxa)  # False
+    """
+    return state in PXA_PUBLIC_AWARE
+
+
+def is_pxa_exploit_public(state: CS_pxa) -> bool:
+    """Return True if exploit code is publicly available (X bit set).
+
+    Note: pX is transient — the pX→PX invariant means an exploit being public
+    without public awareness is ephemeral; in practice P will also be set.
+    This predicate reflects the X bit only.
+
+    Examples::
+
+        is_pxa_exploit_public(CS_pxa.pXa)  # True
+        is_pxa_exploit_public(CS_pxa.PXA)  # True
+        is_pxa_exploit_public(CS_pxa.Pxa)  # False
+    """
+    return state in PXA_EXPLOIT_PUBLIC
+
+
+def is_pxa_attacks_observed(state: CS_pxa) -> bool:
+    """Return True if attacks have been observed in the wild (A bit set).
+
+    Examples::
+
+        is_pxa_attacks_observed(CS_pxa.pxA)  # True
+        is_pxa_attacks_observed(CS_pxa.PXA)  # True
+        is_pxa_attacks_observed(CS_pxa.pxa)  # False
+    """
+    return state in PXA_ATTACKS_OBSERVED
 
 
 class VFD_Trigger(StrEnum):

--- a/vultron/core/states/em.py
+++ b/vultron/core/states/em.py
@@ -144,6 +144,26 @@ def create_em_machine() -> Machine:
 # Example: EM_NEGOTIATING groups states where embargo negotiation is ongoing
 EM_NEGOTIATING = (EM.PROPOSED, EM.REVISE)
 
+# States where an embargo is currently in force.
+# Per the EM machine, once ACTIVE the embargo never returns to NONE/PROPOSED.
+EM_EMBARGO_ACTIVE = (EM.ACTIVE, EM.REVISE)
+
+
+def is_em_embargo_active(state: EM) -> bool:
+    """Return True if an embargo is currently in force (ACTIVE or REVISE).
+
+    The REVISE state retains the active embargo while a revision is negotiated;
+    the embargo remains in force until EXITED.
+
+    Examples::
+
+        is_em_embargo_active(EM.ACTIVE)   # True
+        is_em_embargo_active(EM.REVISE)   # True
+        is_em_embargo_active(EM.PROPOSED) # False
+        is_em_embargo_active(EM.EXITED)   # False
+    """
+    return state in EM_EMBARGO_ACTIVE
+
 
 if __name__ == "__main__":
     M = create_em_machine()

--- a/vultron/core/states/rm.py
+++ b/vultron/core/states/rm.py
@@ -88,6 +88,15 @@ RM_ACTIVE = (
     RM.ACCEPTED,
 )
 
+# States at or past RM.VALID on the valid path (the "validated ratchet").
+# RM.CLOSED is excluded because it is also reachable from RM.INVALID without
+# passing through validation.
+RM_VALIDATED = (
+    RM.VALID,
+    RM.DEFERRED,
+    RM.ACCEPTED,
+)
+
 
 class RM_Trigger(StrEnum):
     """
@@ -195,6 +204,24 @@ def is_rm_at_least(state: RM, threshold: RM) -> bool:
         is_rm_at_least(RM.START,    RM.ACCEPTED)  # False
     """
     return _RM_PROGRESS.get(state, 0) >= _RM_PROGRESS.get(threshold, 0)
+
+
+def is_rm_validated(state: RM) -> bool:
+    """Return True if *state* is on the validated path (VALID, DEFERRED, or ACCEPTED).
+
+    RM.CLOSED is excluded because it is reachable via RM.INVALID without passing
+    through validation; use ``is_rm_at_least(state, RM.VALID)`` when you need to
+    include CLOSED in a broader "at-or-past" check.
+
+    Examples::
+
+        is_rm_validated(RM.VALID)     # True
+        is_rm_validated(RM.ACCEPTED)  # True
+        is_rm_validated(RM.DEFERRED)  # True
+        is_rm_validated(RM.CLOSED)    # False
+        is_rm_validated(RM.INVALID)   # False
+    """
+    return state in RM_VALIDATED
 
 
 def create_rm_machine() -> Machine:


### PR DESCRIPTION
## Summary

- Add `RM_VALIDATED` tuple and `is_rm_validated()` predicate to `vultron/core/states/rm.py` (LST-04-001)
- Add `EM_EMBARGO_ACTIVE` tuple and `is_em_embargo_active()` predicate to `vultron/core/states/em.py`
- Add `VFD_VENDOR_AWARE`, `VFD_FIX_READY`, `VFD_FIX_DEPLOYED` tuples and `is_vfd_*()` predicates to `vultron/core/states/cs.py`
- Add `PXA_PUBLIC_AWARE`, `PXA_EXPLOIT_PUBLIC`, `PXA_ATTACKS_OBSERVED` tuples and `is_pxa_*()` predicates to `vultron/core/states/cs.py`
- Re-export all new symbols from `vultron/core/states/__init__.py`

Closes #1453

## Changes

### `vultron/core/states/rm.py`
- `RM_VALIDATED = (RM.VALID, RM.DEFERRED, RM.ACCEPTED)` — validated-path states; excludes `RM.CLOSED` because it is reachable from `RM.INVALID` without passing through validation
- `is_rm_validated(state)` — returns `True` when state is on the validated path

### `vultron/core/states/em.py`
- `EM_EMBARGO_ACTIVE = (EM.ACTIVE, EM.REVISE)` — embargo-in-force states; `EM.REVISE` retains the active embargo while a revision is negotiated
- `is_em_embargo_active(state)` — returns `True` when an embargo is currently in force

### `vultron/core/states/cs.py`
- `VFD_VENDOR_AWARE`, `VFD_FIX_READY`, `VFD_FIX_DEPLOYED` milestone groups (monotonic vfd path)
- `is_vfd_vendor_aware()`, `is_vfd_fix_ready()`, `is_vfd_fix_deployed()` predicates
- `PXA_PUBLIC_AWARE`, `PXA_EXPLOIT_PUBLIC`, `PXA_ATTACKS_OBSERVED` milestone groups (all 8 pxa states covered)
- `is_pxa_public_aware()`, `is_pxa_exploit_public()`, `is_pxa_attacks_observed()` predicates
- Fixed `CS_pxa` class docstring: `pXa`/`pXA` are ephemeral states (the pX→PX invariant means they resolve to `PXa`/`PXA` in practice), not "not valid states"

### `test/core/states/test_ratchet_predicates.py` (new)
- Parametrized tests for all new predicates with positive and negative boundary cases
- Exhaustive `TestPxaExhaustive` class verifying every `CS_pxa` state is correctly classified across all three predicate groups

## Verification

```
uv run black vultron/ test/  # all unchanged
uv run flake8 vultron/ test/ # clean
uv run mypy                  # no issues in 1015 files
uv run pyright               # 0 errors
uv run pytest --tb=short     # 4897 passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)