### PR TITLE
fix(#1454): enforce P/X/A embargo-eligibility as precondition guards

### DIFF
--- a/notes/embargo-lifecycle.md
+++ b/notes/embargo-lifecycle.md
@@ -3,8 +3,9 @@ title: Embargo Lifecycle — Architecture and Implementation Notes
 status: active
 description: >
   Target architecture for EM state management; the inline-EMAdapter
-  instantiation anti-pattern in trigger use cases; and the fragmentation
-  concern that motivates the EmbargoLifecycle service (see #538).
+  instantiation anti-pattern in trigger use cases; P/X/A embargo-eligibility
+  precondition guards in EmbargoLifecycle; and the fragmentation concern that
+  motivates the EmbargoLifecycle service (see #538).
 related_specs:
   - specs/case-management.yaml
   - specs/embargo-policy.yaml
@@ -13,6 +14,7 @@ related_notes:
   - notes/participant-embargo-consent.md
 relevant_packages:
   - vultron/core/states/em.py
+  - vultron/core/services/embargo_lifecycle.py
   - vultron/core/use_cases/triggers/embargo.py
   - vultron/core/use_cases/received/embargo.py
   - vultron/bt/embargo_management
@@ -95,31 +97,66 @@ transition logic with no shared validation or invariant enforcement.
 
 ---
 
-## Target Architecture
+## Current Architecture (Implemented)
 
-[#538](https://github.com/CERTCC/Vultron/issues/538) proposes a single
-`vultron/core/services/embargo_lifecycle.py` module with an
-`EmbargoLifecycle` service class that owns all EM + PEC transition logic.
+`EmbargoLifecycle` exists at `vultron/core/services/embargo_lifecycle.py` and
+owns all EM + PEC transition logic (implemented per
+[#538](https://github.com/CERTCC/Vultron/issues/538),
+[#746](https://github.com/CERTCC/Vultron/issues/746),
+[#747](https://github.com/CERTCC/Vultron/issues/747)).
 
-**Planned interface sketch** (from #538):
+**Actual public interface**:
 
 ```python
 class EmbargoLifecycle:
     def __init__(self, persistence: CasePersistence) -> None: ...
-    def propose(self, case_id: str, actor_id: str, ...) -> EM: ...
-    def accept(self, case_id: str, actor_id: str, proposal_id: str) -> EM: ...
-    def reject(self, case_id: str, actor_id: str, proposal_id: str) -> EM: ...
-    def terminate(self, case_id: str, actor_id: str) -> EM: ...
+    def propose_embargo(
+        self, *, case_id, embargo_id, actor_id, transition_mode=STRICT
+    ) -> EmbargoLifecycleResult: ...
+    def accept_embargo_invite(
+        self, *, case_id, embargo_id, actor_id, transition_mode=STRICT
+    ) -> EmbargoLifecycleResult: ...
+    def reject_embargo_invite(
+        self, *, case_id, embargo_id, actor_id, transition_mode=STRICT
+    ) -> EmbargoLifecycleResult: ...
+    def terminate_active_embargo(
+        self, *, case_id, actor_id, transition_mode=STRICT
+    ) -> EmbargoLifecycleResult: ...
+    def record_participant_consent(
+        self, *, case_id, actor_id, pec_trigger, embargo_id=None
+    ) -> EmbargoLifecycleResult: ...
 ```
 
-Once `EmbargoLifecycle` exists:
+**`TransitionMode`**: `STRICT` enforces valid transitions and precondition
+guards (used by trigger-side BT behaviors).  `OBSERVED` syncs local state
+unconditionally to match a remote party's assertion (used by received-side use
+cases — bypasses all guards).
 
-- Trigger use cases become thin orchestrators: resolve actors/cases → call
-  `EmbargoLifecycle` → build and send the outbound activity.
-- Received use cases call the same service in `OBSERVED` mode (state-sync
-  without re-enforcing proposal workflow).
-- BT behaviors call the same service, eliminating the parallel BT-side
-  implementation.
+**P/X/A embargo-eligibility guards** (added in
+[#1454](https://github.com/CERTCC/Vultron/issues/1454)): `EmbargoLifecycle`
+enforces EMB-01-002, EMB-02-002, and EMB-04-002 via
+`_assert_pxa_embargo_eligible()` in STRICT mode:
+
+- `propose_embargo()` — raises when `pxa_state != CS_pxa.pxa` (any of P/X/A set)
+- `accept_embargo_invite()` — raises when owner would drive EM to ACTIVE with
+  P/X/A set; non-owner consent recording is not blocked
+- `reject_embargo_invite()` — raises when EM is REVISE and P/X/A is set (caller
+  MUST use `terminate_active_embargo()` instead)
+
+Note: the received-side path (`received/embargo.py`) does not yet use
+`EmbargoLifecycle`; it lacks these guards for inbound EP/EA processing.
+Tracked as a gap (see `specs/em-behavior.yaml` EMB-01-002, EMB-02-002).
+
+**Auto-terminate on publication** (CS.P event): handled by
+`PublicDisclosureBranchNode` in `vultron/core/behaviors/status/nodes/lifecycle.py`,
+which delegates to the shared `terminate_embargo_bt` factory. This is the
+cascade path for AC-2 of issue #1454.
+
+Trigger use cases are thin orchestrators: resolve actors/cases → call
+`EmbargoLifecycle` → build and send the outbound activity.
+BT behaviors use `ProposeEmbargoLifecycleNode`, `AcceptEmbargoLifecycleNode`,
+`RejectEmbargoLifecycleNode`, and `TerminateEmbargoLifecycleNode` which all
+catch `VultronError` and return `Status.FAILURE`.
 
 ---
 
@@ -143,11 +180,18 @@ This follow-up is tracked in a separate issue blocked by #538.
 
 When implementing any code that transitions embargo state:
 
-1. **Check whether `EmbargoLifecycle` exists** (`vultron/core/services/`).
-   If it does, use it — do not re-instantiate `create_em_machine()` inline.
-2. **If `EmbargoLifecycle` is not yet implemented** (pre-#538), follow the
-   existing pattern in `triggers/embargo.py` but leave a `# TODO(#538)`
-   comment so the inline instantiation is discoverable for cleanup.
-3. **Always cascade PEC** when EM state changes: `ACTIVE → REVISE` must
-   trigger `_cascade_pec_revise`; termination must trigger `_cascade_pec_reset`.
-   The PEC cascade is not optional.
+1. **Always use `EmbargoLifecycle`** (`vultron/core/services/embargo_lifecycle.py`).
+   Never instantiate `create_em_machine()` + `EMAdapter` inline.
+2. **P/X/A precondition**: STRICT mode guards `propose_embargo()` and
+   `accept_embargo_invite()` (owner-only) against PXA-set cases.  If your
+   caller receives `VultronInvalidStateTransitionError`, the case is no longer
+   embargo-eligible — do not attempt to retry; emit ER to the proposer.
+3. **REVISE+PXA reject**: `reject_embargo_invite()` raises in STRICT mode when
+   EM is REVISE and P/X/A is set — the correct path is
+   `terminate_active_embargo()` per EMB-04-002.
+4. **PEC cascade is automatic**: `propose_embargo()` cascades `SIGNATORY →
+   LAPSED` on `ACTIVE → REVISE`; `terminate_active_embargo()` resets all PEC
+   to `NO_EMBARGO`. Callers do not need to do this manually.
+5. **OBSERVED mode** (received-side): pass
+   `transition_mode=TransitionMode.OBSERVED` to sync local state with a remote
+   assertion. All guards and PEC cascades are bypassed in OBSERVED mode.

--- a/notes/embargo-lifecycle.md
+++ b/notes/embargo-lifecycle.md
@@ -143,9 +143,14 @@ enforces EMB-01-002, EMB-02-002, and EMB-04-002 via
 - `reject_embargo_invite()` — raises when EM is REVISE and P/X/A is set (caller
   MUST use `terminate_active_embargo()` instead)
 
-Note: the received-side path (`received/embargo.py`) does not yet use
-`EmbargoLifecycle`; it lacks these guards for inbound EP/EA processing.
-Tracked as a gap (see `specs/em-behavior.yaml` EMB-01-002, EMB-02-002).
+The received-side path (`received/embargo.py`) does not use `EmbargoLifecycle`
+for EM state transitions (those still use inline BT execution), but EMB-01-002
+and EMB-02-002 are enforced as explicit pre-flight guards in
+`InviteToEmbargoOnCaseReceivedUseCase.execute()` and
+`AcceptInviteToEmbargoOnCaseReceivedUseCase.execute()` respectively (implemented
+in [#1484](https://github.com/CERTCC/Vultron/issues/1484)). Migrating the
+received-side EM transitions to `EmbargoLifecycle` (AC-3 of #1484) is still
+pending.
 
 **Auto-terminate on publication** (CS.P event): handled by
 `PublicDisclosureBranchNode` in `vultron/core/behaviors/status/nodes/lifecycle.py`,

--- a/plan/history/2607/implementation/ISSUE-1454.md
+++ b/plan/history/2607/implementation/ISSUE-1454.md
@@ -8,3 +8,5 @@ type: implementation
 ## Issue #1454 — Model P/X/A embargo-eligibility rules as precondition guards
 
 Implemented AC-1 through AC-3. Added `_assert_pxa_embargo_eligible()` static helper to `EmbargoLifecycle`. Guards enforce EMB-01-002 (propose), EMB-02-002 (accept, owner-only), and EMB-04-002 (reject from REVISE). OBSERVED mode bypasses all guards. 79 tests cover all 7 ineligible CS_pxa states parametrically. PR: <https://github.com/CERTCC/Vultron/pull/1483>
+
+Received-side EMB-01-002 and EMB-02-002 guards added in issue #1484 (on branch task/1454-pxa-embargo-precondition-guards): pre-flight checks in `InviteToEmbargoOnCaseReceivedUseCase` and `AcceptInviteToEmbargoOnCaseReceivedUseCase` block processing and emit ER when P/X/A is set. Dispatcher wired to inject `trigger_activity` for both semantics. AC-3 (migrate received-side to EmbargoLifecycle) pending.

--- a/plan/history/2607/implementation/ISSUE-1454.md
+++ b/plan/history/2607/implementation/ISSUE-1454.md
@@ -1,0 +1,10 @@
+---
+source: ISSUE-1454
+timestamp: '2026-07-17T15:40:02.229907+00:00'
+title: '#1454: P/X/A embargo-eligibility precondition guards'
+type: implementation
+---
+
+## Issue #1454 — Model P/X/A embargo-eligibility rules as precondition guards
+
+Implemented AC-1 through AC-3. Added `_assert_pxa_embargo_eligible()` static helper to `EmbargoLifecycle`. Guards enforce EMB-01-002 (propose), EMB-02-002 (accept, owner-only), and EMB-04-002 (reject from REVISE). OBSERVED mode bypasses all guards. 79 tests cover all 7 ineligible CS_pxa states parametrically. PR: <https://github.com/CERTCC/Vultron/pull/1483>

--- a/test/core/services/test_embargo_lifecycle.py
+++ b/test/core/services/test_embargo_lifecycle.py
@@ -9,6 +9,12 @@ Coverage required by #746 AC-5 (propose_embargo STRICT) and #747 AC-1 to AC-7:
   - reject_embargo_invite STRICT and OBSERVED, owner vs. non-owner
   - terminate_active_embargo STRICT and OBSERVED, PEC cascade
   - record_participant_consent for ACCEPT, DECLINE, INVITE, RESET triggers
+
+Coverage added by #1454 (AC-1 to AC-3): P/X/A embargo-eligibility guards
+  - propose_embargo STRICT raises when pxa_state != pxa (all P/X/A variants)
+  - propose_embargo OBSERVED bypasses guard
+  - accept_embargo_invite STRICT raises when pxa_state != pxa
+  - accept_embargo_invite OBSERVED bypasses guard
 """
 
 from collections.abc import Generator
@@ -30,6 +36,7 @@ from vultron.core.services.embargo_lifecycle import (
     EmbargoLifecycleResult,
     TransitionMode,
 )
+from vultron.core.states.cs import CS_pxa
 from vultron.core.states.em import EM
 from vultron.core.states.participant_embargo_consent import PEC, PEC_Trigger
 from vultron.enums.roles import CVDRole
@@ -837,3 +844,256 @@ def test_record_participant_consent_actor_not_in_case(
 
     assert result.participant_changes == []
     assert result.case_changed is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: P/X/A embargo-eligibility guards (#1454)
+# ---------------------------------------------------------------------------
+
+# All non-pxa CS_pxa states trigger the guard.
+_PXA_INELIGIBLE_STATES = [
+    CS_pxa.Pxa,  # public aware
+    CS_pxa.pXa,  # exploit published
+    CS_pxa.pxA,  # attacks observed
+    CS_pxa.PXa,  # public + exploit
+    CS_pxa.PxA,  # public + attacks
+    CS_pxa.pXA,  # exploit + attacks
+    CS_pxa.PXA,  # all three set
+]
+
+
+@pytest.mark.parametrize("pxa_state", _PXA_INELIGIBLE_STATES)
+def test_propose_embargo_strict_raises_when_pxa_set(
+    owner_and_dl: tuple[as_Service, SqliteDataLayer],
+    pxa_state: CS_pxa,
+) -> None:
+    """STRICT propose raises when any of P/X/A is set (EMB-01-002)."""
+    owner, dl = owner_and_dl
+    case, _ = _make_case(dl, owner.id_, em_state=EM.NONE)
+    case.current_status.pxa_state = pxa_state
+    dl.save(case)
+    embargo = _make_embargo(dl, case.id_)
+
+    lifecycle = EmbargoLifecycle(persistence=dl)
+    with pytest.raises(VultronInvalidStateTransitionError):
+        lifecycle.propose_embargo(
+            case_id=case.id_,
+            embargo_id=embargo.id_,
+            actor_id=owner.id_,
+        )
+
+
+def test_propose_embargo_strict_allowed_when_pxa_clear(
+    owner_and_dl: tuple[as_Service, SqliteDataLayer],
+) -> None:
+    """STRICT propose succeeds when pxa_state is fully clear (pxa)."""
+    owner, dl = owner_and_dl
+    case, _ = _make_case(dl, owner.id_, em_state=EM.NONE)
+    # pxa_state defaults to CS_pxa.pxa — no mutation needed
+    embargo = _make_embargo(dl, case.id_)
+
+    lifecycle = EmbargoLifecycle(persistence=dl)
+    result = lifecycle.propose_embargo(
+        case_id=case.id_,
+        embargo_id=embargo.id_,
+        actor_id=owner.id_,
+    )
+
+    assert result.em_after == EM.PROPOSED
+
+
+@pytest.mark.parametrize("pxa_state", _PXA_INELIGIBLE_STATES)
+def test_propose_embargo_observed_bypasses_pxa_guard(
+    owner_and_dl: tuple[as_Service, SqliteDataLayer],
+    pxa_state: CS_pxa,
+) -> None:
+    """OBSERVED mode bypasses P/X/A guard and syncs to PROPOSED."""
+    owner, dl = owner_and_dl
+    case, _ = _make_case(dl, owner.id_, em_state=EM.NONE)
+    case.current_status.pxa_state = pxa_state
+    dl.save(case)
+    embargo = _make_embargo(dl, case.id_)
+
+    lifecycle = EmbargoLifecycle(persistence=dl)
+    result = lifecycle.propose_embargo(
+        case_id=case.id_,
+        embargo_id=embargo.id_,
+        actor_id=owner.id_,
+        transition_mode=TransitionMode.OBSERVED,
+    )
+
+    assert result.em_after == EM.PROPOSED
+
+
+@pytest.mark.parametrize("pxa_state", _PXA_INELIGIBLE_STATES)
+def test_accept_embargo_invite_strict_raises_when_pxa_set(
+    owner_and_dl: tuple[as_Service, SqliteDataLayer],
+    pxa_state: CS_pxa,
+) -> None:
+    """STRICT accept raises when any of P/X/A is set (EMB-02-002)."""
+    owner, dl = owner_and_dl
+    case, participants = _make_case(dl, owner.id_, em_state=EM.PROPOSED)
+    case.current_status.pxa_state = pxa_state
+    dl.save(case)
+    embargo = _make_embargo(dl, case.id_)
+
+    # Seed owner to INVITED so the PEC transition would be valid
+    owner_p = cast(CaseParticipant, dl.read(participants[0].id_))
+    owner_p.embargo_consent_state = PEC.INVITED
+    dl.save(owner_p)
+
+    lifecycle = EmbargoLifecycle(persistence=dl)
+    with pytest.raises(VultronInvalidStateTransitionError):
+        lifecycle.accept_embargo_invite(
+            case_id=case.id_,
+            embargo_id=embargo.id_,
+            actor_id=owner.id_,
+        )
+
+
+def test_accept_embargo_invite_strict_allowed_when_pxa_clear(
+    owner_and_dl: tuple[as_Service, SqliteDataLayer],
+) -> None:
+    """STRICT accept succeeds when pxa_state is fully clear (pxa)."""
+    owner, dl = owner_and_dl
+    case, participants = _make_case(dl, owner.id_, em_state=EM.PROPOSED)
+    embargo = _make_embargo(dl, case.id_)
+
+    owner_p = cast(CaseParticipant, dl.read(participants[0].id_))
+    owner_p.embargo_consent_state = PEC.INVITED
+    dl.save(owner_p)
+
+    lifecycle = EmbargoLifecycle(persistence=dl)
+    result = lifecycle.accept_embargo_invite(
+        case_id=case.id_,
+        embargo_id=embargo.id_,
+        actor_id=owner.id_,
+    )
+
+    assert result.em_after == EM.ACTIVE
+
+
+@pytest.mark.parametrize("pxa_state", _PXA_INELIGIBLE_STATES)
+def test_accept_embargo_invite_observed_bypasses_pxa_guard(
+    owner_and_dl: tuple[as_Service, SqliteDataLayer],
+    pxa_state: CS_pxa,
+) -> None:
+    """OBSERVED mode bypasses P/X/A guard and syncs to ACTIVE."""
+    owner, dl = owner_and_dl
+    case, _ = _make_case(dl, owner.id_, em_state=EM.PROPOSED)
+    case.current_status.pxa_state = pxa_state
+    dl.save(case)
+    embargo = _make_embargo(dl, case.id_)
+
+    lifecycle = EmbargoLifecycle(persistence=dl)
+    result = lifecycle.accept_embargo_invite(
+        case_id=case.id_,
+        embargo_id=embargo.id_,
+        actor_id=owner.id_,
+        transition_mode=TransitionMode.OBSERVED,
+    )
+
+    assert result.em_after == EM.ACTIVE
+
+
+@pytest.mark.parametrize("pxa_state", _PXA_INELIGIBLE_STATES)
+def test_accept_embargo_invite_strict_non_owner_pxa_set_does_not_raise(
+    owner_and_dl: tuple[as_Service, SqliteDataLayer],
+    pxa_state: CS_pxa,
+) -> None:
+    """Non-owner STRICT accept with P/X/A set still records PEC (no guard)."""
+    owner, dl = owner_and_dl
+    finder = _make_actor(dl, "Finder Org")
+    case, _ = _make_case(
+        dl, owner.id_, extra_participant_ids=[finder.id_], em_state=EM.PROPOSED
+    )
+    case.current_status.pxa_state = pxa_state
+    dl.save(case)
+    embargo = _make_embargo(dl, case.id_)
+
+    finder_participant_id = case.actor_participant_index.get(finder.id_)
+    assert finder_participant_id is not None
+    finder_p = cast(CaseParticipant, dl.read(finder_participant_id))
+    finder_p.embargo_consent_state = PEC.INVITED
+    dl.save(finder_p)
+
+    lifecycle = EmbargoLifecycle(persistence=dl)
+    # Non-owner: does NOT drive EM state, guard must NOT raise (EMB-02-002)
+    result = lifecycle.accept_embargo_invite(
+        case_id=case.id_,
+        embargo_id=embargo.id_,
+        actor_id=finder.id_,
+    )
+
+    assert result.em_after == EM.PROPOSED  # EM unchanged
+    refreshed = cast(CaseParticipant, dl.read(finder_participant_id))
+    assert refreshed.embargo_consent_state == PEC.SIGNATORY.value
+
+
+# ---------------------------------------------------------------------------
+# Tests: reject_embargo_invite P/X/A guard (EMB-04-002)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("pxa_state", _PXA_INELIGIBLE_STATES)
+def test_reject_embargo_invite_strict_revise_pxa_raises(
+    owner_and_dl: tuple[as_Service, SqliteDataLayer],
+    pxa_state: CS_pxa,
+) -> None:
+    """STRICT reject from REVISE+PXA raises (EMB-04-002: must terminate, not revert)."""
+    owner, dl = owner_and_dl
+    case, _ = _make_case(dl, owner.id_, em_state=EM.REVISE)
+    case.current_status.pxa_state = pxa_state
+    dl.save(case)
+    embargo = _make_embargo(dl, case.id_)
+
+    lifecycle = EmbargoLifecycle(persistence=dl)
+    with pytest.raises(VultronInvalidStateTransitionError):
+        lifecycle.reject_embargo_invite(
+            case_id=case.id_,
+            embargo_id=embargo.id_,
+            actor_id=owner.id_,
+        )
+
+
+def test_reject_embargo_invite_strict_proposed_pxa_allowed(
+    owner_and_dl: tuple[as_Service, SqliteDataLayer],
+) -> None:
+    """STRICT reject from PROPOSED+PXA is allowed (PROPOSED→NO_EMBARGO, no active embargo)."""
+    owner, dl = owner_and_dl
+    case, _ = _make_case(dl, owner.id_, em_state=EM.PROPOSED)
+    case.current_status.pxa_state = CS_pxa.Pxa  # public aware
+    dl.save(case)
+    embargo = _make_embargo(dl, case.id_)
+
+    lifecycle = EmbargoLifecycle(persistence=dl)
+    result = lifecycle.reject_embargo_invite(
+        case_id=case.id_,
+        embargo_id=embargo.id_,
+        actor_id=owner.id_,
+    )
+
+    assert result.em_after == EM.NONE
+
+
+@pytest.mark.parametrize("pxa_state", _PXA_INELIGIBLE_STATES)
+def test_reject_embargo_invite_observed_revise_pxa_bypasses_guard(
+    owner_and_dl: tuple[as_Service, SqliteDataLayer],
+    pxa_state: CS_pxa,
+) -> None:
+    """OBSERVED reject from REVISE+PXA bypasses the guard (state-sync)."""
+    owner, dl = owner_and_dl
+    case, _ = _make_case(dl, owner.id_, em_state=EM.REVISE)
+    case.current_status.pxa_state = pxa_state
+    dl.save(case)
+    embargo = _make_embargo(dl, case.id_)
+
+    lifecycle = EmbargoLifecycle(persistence=dl)
+    result = lifecycle.reject_embargo_invite(
+        case_id=case.id_,
+        embargo_id=embargo.id_,
+        actor_id=owner.id_,
+        transition_mode=TransitionMode.OBSERVED,
+    )
+
+    assert result.em_after == EM.ACTIVE

--- a/test/core/use_cases/received/test_embargo_propose_accept_reject.py
+++ b/test/core/use_cases/received/test_embargo_propose_accept_reject.py
@@ -16,6 +16,8 @@ import logging
 from typing import Any, cast
 from unittest.mock import MagicMock
 
+import pytest
+
 from vultron.adapters.driven.db_record import StorableRecord
 from vultron.adapters.driven.trigger_activity_adapter import (
     TriggerActivityAdapter,
@@ -468,3 +470,273 @@ class TestEmbargoProposalLifecycle:
             SvcAcceptEmbargoUseCase(
                 dl, request, trigger_activity=TriggerActivityAdapter(dl)
             ).execute()
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared by PXA guard tests
+# ---------------------------------------------------------------------------
+
+_PXA_INELIGIBLE_STATES = [
+    "Pxa",
+    "pXa",
+    "pxA",
+    "PXa",
+    "PxA",
+    "pXA",
+    "PXA",
+]
+
+
+def _make_pxa_case(
+    dl,
+    case_id: str,
+    coordinator_id: str,
+    embargo_id: str,
+    pxa_state_name: str,
+    em_state=EM.PROPOSED,
+):
+    """Return (case, embargo, proposal) with pxa_state set."""
+    from vultron.core.states.cs import CS_pxa
+    from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
+    from vultron.wire.as2.vocab.objects.vulnerability_case import (
+        as_VulnerabilityCase,
+    )
+
+    case = as_VulnerabilityCase(
+        id_=case_id,
+        name="PXA Guard Test",
+        attributed_to=coordinator_id,
+    )
+    case.current_status.em_state = em_state
+    case.current_status.pxa_state = CS_pxa[pxa_state_name]
+    embargo = as_EmbargoEvent(id_=embargo_id, content="PXA test embargo")
+    proposal = em_propose_embargo_activity(
+        embargo,
+        context=case.id_,
+        actor=coordinator_id,
+        id_=f"{case_id}/proposals/p1",
+    )
+    dl.create(case)
+    dl.create(embargo)
+    dl.create(proposal)
+    return case, embargo, proposal
+
+
+class TestInviteToEmbargoReceivedPxaGuard:
+    """EMB-01-002: EP received when P/X/A set — block processing and emit ER."""
+
+    COORD_ID = "https://example.org/actors/coord-ep-pxa"
+    CASE_ID = "https://example.org/cases/c-ep-pxa"
+    EMBARGO_ID = f"{CASE_ID}/embargo_events/e1"
+
+    @pytest.mark.parametrize("pxa_state_name", _PXA_INELIGIBLE_STATES)
+    def test_pxa_set_blocks_ep_processing(self, make_payload, pxa_state_name):
+        """invite_to_embargo_on_case does not run BT when P/X/A is set (EMB-01-002)."""
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case_id = f"{self.CASE_ID}/{pxa_state_name}"
+        embargo_id = f"{case_id}/embargo_events/e1"
+        case, embargo, proposal = _make_pxa_case(
+            dl,
+            case_id=case_id,
+            coordinator_id=self.COORD_ID,
+            embargo_id=embargo_id,
+            pxa_state_name=pxa_state_name,
+            em_state=EM.NONE,
+        )
+
+        event = make_payload(proposal, receiving_actor_id=self.COORD_ID)
+        InviteToEmbargoOnCaseReceivedUseCase(dl, event).execute()
+
+        # BT was not run: EM state must remain NONE (no PROPOSED transition)
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            as_VulnerabilityCase,
+        )
+
+        updated = cast(as_VulnerabilityCase, dl.read(case.id_))
+        assert updated is not None
+        assert updated.current_status.em_state == EM.NONE
+
+    @pytest.mark.parametrize("pxa_state_name", _PXA_INELIGIBLE_STATES)
+    def test_pxa_set_emits_er_when_trigger_activity_provided(
+        self, make_payload, pxa_state_name
+    ):
+        """invite_to_embargo_on_case emits ER when trigger_activity is available and P/X/A set (EMB-01-002)."""
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case_id = f"{self.CASE_ID}/{pxa_state_name}/er"
+        embargo_id = f"{case_id}/embargo_events/e1"
+        case, embargo, proposal = _make_pxa_case(
+            dl,
+            case_id=case_id,
+            coordinator_id=self.COORD_ID,
+            embargo_id=embargo_id,
+            pxa_state_name=pxa_state_name,
+            em_state=EM.NONE,
+        )
+
+        trigger_activity = TriggerActivityAdapter(dl)
+        event = make_payload(proposal, receiving_actor_id=self.COORD_ID)
+        InviteToEmbargoOnCaseReceivedUseCase(
+            dl, event, trigger_activity=trigger_activity
+        ).execute()
+
+        # ER activity must be in the outbox
+        outbox = dl.outbox_list_for_actor(self.COORD_ID)
+        assert len(outbox) == 1, f"Expected 1 ER in outbox; got {outbox}"
+
+    def test_pxa_clear_allows_ep_processing(self, make_payload):
+        """invite_to_embargo_on_case runs normally when pxa_state is clear."""
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+        from vultron.wire.as2.vocab.objects.embargo_event import (
+            as_EmbargoEvent,
+        )
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            as_VulnerabilityCase,
+        )
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case_id = f"{self.CASE_ID}/clear"
+        coordinator_id = self.COORD_ID
+
+        case = as_VulnerabilityCase(
+            id_=case_id, name="PXA clear", attributed_to=coordinator_id
+        )
+        dl.create(case)
+        embargo = as_EmbargoEvent(
+            id_=f"{case_id}/embargo_events/e1", content="clear embargo"
+        )
+        dl.create(embargo)
+        proposal = em_propose_embargo_activity(
+            embargo,
+            context=case,
+            actor=coordinator_id,
+            id_=f"{case_id}/proposals/p1",
+        )
+        dl.create(proposal)
+
+        event = make_payload(proposal, receiving_actor_id=coordinator_id)
+        InviteToEmbargoOnCaseReceivedUseCase(dl, event).execute()
+
+        # Proposal must be stored (BT ran CreateAndStoreInviteNode)
+        stored = dl.read(proposal.id_)
+        assert stored is not None
+
+
+class TestAcceptInviteToEmbargoReceivedPxaGuard:
+    """EMB-02-002: EA received when P/X/A set — block processing and emit ER."""
+
+    COORD_ID = "https://example.org/actors/coord-ea-pxa"
+    CASE_ID = "https://example.org/cases/c-ea-pxa"
+
+    @pytest.mark.parametrize("pxa_state_name", _PXA_INELIGIBLE_STATES)
+    def test_pxa_set_blocks_ea_processing(self, make_payload, pxa_state_name):
+        """accept_invite_to_embargo_on_case does not activate embargo when P/X/A set (EMB-02-002)."""
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case_id = f"{self.CASE_ID}/{pxa_state_name}"
+        embargo_id = f"{case_id}/embargo_events/e1"
+        case, embargo, proposal = _make_pxa_case(
+            dl,
+            case_id=case_id,
+            coordinator_id=self.COORD_ID,
+            embargo_id=embargo_id,
+            pxa_state_name=pxa_state_name,
+            em_state=EM.PROPOSED,
+        )
+
+        accept = em_accept_embargo_activity(
+            proposal, context=case, actor=self.COORD_ID
+        )
+        event = make_payload(accept, receiving_actor_id=self.COORD_ID)
+        AcceptInviteToEmbargoOnCaseReceivedUseCase(dl, event).execute()
+
+        # BT was not run: EM state must remain PROPOSED (not ACTIVE)
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            as_VulnerabilityCase,
+        )
+
+        updated = cast(as_VulnerabilityCase, dl.read(case.id_))
+        assert updated is not None
+        assert updated.current_status.em_state == EM.PROPOSED
+
+    @pytest.mark.parametrize("pxa_state_name", _PXA_INELIGIBLE_STATES)
+    def test_pxa_set_emits_er_when_trigger_activity_provided(
+        self, make_payload, pxa_state_name
+    ):
+        """accept_invite_to_embargo_on_case emits ER when trigger_activity available and P/X/A set (EMB-02-002)."""
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case_id = f"{self.CASE_ID}/{pxa_state_name}/er"
+        embargo_id = f"{case_id}/embargo_events/e1"
+        case, embargo, proposal = _make_pxa_case(
+            dl,
+            case_id=case_id,
+            coordinator_id=self.COORD_ID,
+            embargo_id=embargo_id,
+            pxa_state_name=pxa_state_name,
+            em_state=EM.PROPOSED,
+        )
+
+        accept = em_accept_embargo_activity(
+            proposal, context=case, actor=self.COORD_ID
+        )
+        trigger_activity = TriggerActivityAdapter(dl)
+        event = make_payload(accept, receiving_actor_id=self.COORD_ID)
+        AcceptInviteToEmbargoOnCaseReceivedUseCase(
+            dl, event, trigger_activity=trigger_activity
+        ).execute()
+
+        # ER activity must be in the outbox
+        outbox = dl.outbox_list_for_actor(self.COORD_ID)
+        assert len(outbox) == 1, f"Expected 1 ER in outbox; got {outbox}"
+
+    def test_pxa_clear_allows_ea_processing(self, make_payload):
+        """accept_invite_to_embargo_on_case activates embargo normally when pxa_state is clear."""
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+        from vultron.wire.as2.vocab.objects.embargo_event import (
+            as_EmbargoEvent,
+        )
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            as_VulnerabilityCase,
+        )
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case_id = f"{self.CASE_ID}/clear"
+        coordinator_id = self.COORD_ID
+
+        case = as_VulnerabilityCase(
+            id_=case_id, name="PXA clear EA", attributed_to=coordinator_id
+        )
+        case.current_status.em_state = EM.PROPOSED
+        dl.create(case)
+        embargo = as_EmbargoEvent(
+            id_=f"{case_id}/embargo_events/e1", content="clear embargo"
+        )
+        dl.create(embargo)
+        proposal = em_propose_embargo_activity(
+            embargo,
+            context=case,
+            actor=coordinator_id,
+            id_=f"{case_id}/proposals/p1",
+        )
+        dl.create(proposal)
+
+        accept = em_accept_embargo_activity(
+            proposal, context=case, actor=coordinator_id
+        )
+        event = make_payload(accept, receiving_actor_id=coordinator_id)
+        AcceptInviteToEmbargoOnCaseReceivedUseCase(dl, event).execute()
+
+        # Embargo should be activated (BT ran SetEmbargoActiveNode)
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            as_VulnerabilityCase,
+        )
+
+        updated = cast(as_VulnerabilityCase, dl.read(case.id_))
+        assert updated is not None
+        assert updated.current_status.em_state == EM.ACTIVE

--- a/vultron/adapters/driving/fastapi/inbox_port_factories.py
+++ b/vultron/adapters/driving/fastapi/inbox_port_factories.py
@@ -114,12 +114,10 @@ def _submit_report_port_factory(dl: DataLayer) -> dict[str, Any]:
 _SYNC_PORT_SEMANTICS = frozenset(
     {
         MessageSemantics.ADD_EMBARGO_EVENT_TO_CASE,
-        MessageSemantics.ACCEPT_INVITE_TO_EMBARGO_ON_CASE,
         MessageSemantics.ANNOUNCE_CASE_LEDGER_ENTRY,
         MessageSemantics.ADD_NOTE_TO_CASE,
         MessageSemantics.CLOSE_CASE,
         MessageSemantics.INVITE_ACTOR_TO_CASE,
-        MessageSemantics.INVITE_TO_EMBARGO_ON_CASE,
         MessageSemantics.REJECT_CASE_LEDGER_ENTRY,
         MessageSemantics.REJECT_INVITE_TO_EMBARGO_ON_CASE,
         MessageSemantics.REMOVE_EMBARGO_EVENT_FROM_CASE,
@@ -142,15 +140,19 @@ _TRIGGER_ACTIVITY_PORT_SEMANTICS = frozenset(
 # which fans out Announce(CaseLedgerEntry) via sync_port (SYNC-02-002),
 # AND also need trigger_activity for outbound wire-activity construction
 # (e.g. Announce(VulnerabilityCase) broadcast).
+# INVITE_TO_EMBARGO_ON_CASE and ACCEPT_INVITE_TO_EMBARGO_ON_CASE need
+# trigger_activity to emit ER when P/X/A is set (EMB-01-002, EMB-02-002).
 # NOTE: SUBMIT_REPORT is intentionally absent here — it uses
 # _submit_report_port_factory (below) which also injects actor_config.
 _SYNC_AND_TRIGGER_PORT_SEMANTICS = frozenset(
     {
         MessageSemantics.ACK_REPORT,
+        MessageSemantics.ACCEPT_INVITE_TO_EMBARGO_ON_CASE,
         MessageSemantics.ADD_PARTICIPANT_STATUS_TO_PARTICIPANT,
         MessageSemantics.ACCEPT_INVITE_ACTOR_TO_CASE,
         MessageSemantics.DEFER_CASE,
         MessageSemantics.ENGAGE_CASE,
+        MessageSemantics.INVITE_TO_EMBARGO_ON_CASE,
         MessageSemantics.OFFER_CASE_MANAGER_ROLE,
     }
 )

--- a/vultron/core/services/embargo_lifecycle.py
+++ b/vultron/core/services/embargo_lifecycle.py
@@ -48,6 +48,7 @@ from transitions import MachineError
 
 from vultron.core.models.protocols import is_case_model, is_participant_model
 from vultron.core.ports.case_persistence import CasePersistence
+from vultron.core.states.cs import CS_pxa
 from vultron.core.states.em import EM, EM_Trigger, EMAdapter, create_em_machine
 from vultron.core.states.participant_embargo_consent import (
     PEC,
@@ -192,7 +193,9 @@ class EmbargoLifecycle:
         Raises:
             VultronNotFoundError: If *case_id* does not resolve to a case.
             VultronInvalidStateTransitionError: If the current EM state does
-                not allow a PROPOSE transition (``STRICT`` mode only).
+                not allow a PROPOSE transition (``STRICT`` mode only), or if
+                any of P/X/A is set on the case (``STRICT`` mode only,
+                per EMB-01-002).
         """
         # Load and validate case
         case = self._persistence.read(case_id)
@@ -200,6 +203,13 @@ class EmbargoLifecycle:
             raise VultronNotFoundError("VulnerabilityCase", case_id)
 
         em_before = EM(case.current_status.em_state)
+
+        if transition_mode == TransitionMode.STRICT:
+            self._assert_pxa_embargo_eligible(
+                CS_pxa(case.current_status.pxa_state),
+                case_id,
+                "propose embargo",
+            )
 
         # OBSERVED fallback: ACTIVE/REVISE stays in REVISE; otherwise PROPOSED
         fallback = (
@@ -294,7 +304,10 @@ class EmbargoLifecycle:
         Raises:
             VultronNotFoundError: If *case_id* does not resolve to a case.
             VultronInvalidStateTransitionError: If the EM state does not allow
-                an ACCEPT transition (``STRICT`` mode, owner only).
+                an ACCEPT transition (``STRICT`` mode, owner only), or if the
+                owner would drive EM to ACTIVE but P/X/A is set (``STRICT``
+                mode, owner only, per EMB-02-002).  Non-owner callers record
+                PEC state only and are not blocked by P/X/A.
         """
         case = self._persistence.read(case_id)
         if not is_case_model(case):
@@ -312,6 +325,13 @@ class EmbargoLifecycle:
         )
 
         if is_owner and not already_active:
+            # Guard only applies when owner would drive the EM machine (EMB-02-002).
+            if transition_mode == TransitionMode.STRICT:
+                self._assert_pxa_embargo_eligible(
+                    CS_pxa(case.current_status.pxa_state),
+                    case_id,
+                    "accept embargo invite",
+                )
             em_after = self._drive_em_transition(
                 case_id=case_id,
                 em_before=em_before,
@@ -382,6 +402,10 @@ class EmbargoLifecycle:
             - ``PROPOSED → NO_EMBARGO``  (initial proposal rejected)
             - ``REVISE → ACTIVE``        (revision rejected; returns to active)
 
+        Per EMB-04-002, a REVISE rejection that would return the case to ACTIVE
+        is blocked in STRICT mode when P/X/A is set — callers must invoke
+        :meth:`terminate_active_embargo` (ET) instead.
+
         For any actor the actor's participant record is updated: PEC
         transitions to ``DECLINED`` and *embargo_id* is removed from
         ``accepted_embargo_ids`` (pocket-veto semantics).
@@ -398,7 +422,9 @@ class EmbargoLifecycle:
         Raises:
             VultronNotFoundError: If *case_id* does not resolve to a case.
             VultronInvalidStateTransitionError: If the EM state does not allow
-                a REJECT transition (``STRICT`` mode, owner only).
+                a REJECT transition (``STRICT`` mode, owner only), or if the
+                case is in REVISE state with P/X/A set (``STRICT`` mode only,
+                per EMB-04-002 — use terminate_active_embargo instead).
         """
         case = self._persistence.read(case_id)
         if not is_case_model(case):
@@ -411,6 +437,17 @@ class EmbargoLifecycle:
         is_owner = _as_id(case.attributed_to) == actor_id
 
         if is_owner:
+            # In STRICT mode, block REVISE→ACTIVE when P/X/A is set (EMB-04-002):
+            # the case must be terminated (ET), not returned to ACTIVE.
+            if (
+                transition_mode == TransitionMode.STRICT
+                and em_before == EM.REVISE
+            ):
+                self._assert_pxa_embargo_eligible(
+                    CS_pxa(case.current_status.pxa_state),
+                    case_id,
+                    "reject embargo revision (use terminate_active_embargo when P/X/A is set)",
+                )
             # OBSERVED fallback: REVISE reject → ACTIVE; otherwise → NO_EMBARGO
             fallback = EM.ACTIVE if em_before == EM.REVISE else EM.NONE
             em_after = self._drive_em_transition(
@@ -645,6 +682,28 @@ class EmbargoLifecycle:
     # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _assert_pxa_embargo_eligible(
+        pxa_state: CS_pxa,
+        case_id: str,
+        operation: str,
+    ) -> None:
+        """Raise if the case is no longer embargo-eligible due to P/X/A.
+
+        Per EMB-01-002 and EMB-02-002: once any of P, X, or A is set
+        (i.e. ``pxa_state != CS_pxa.pxa``), no new embargo may be proposed
+        or accepted.  This guard is only applied in STRICT mode.
+
+        Raises:
+            VultronInvalidStateTransitionError: When ``pxa_state != CS_pxa.pxa``.
+        """
+        if pxa_state != CS_pxa.pxa:
+            raise VultronInvalidStateTransitionError(
+                f"Cannot {operation} on case '{case_id}': public awareness,"
+                f" exploit publication, or attack observation is set"
+                f" (pxa_state='{pxa_state.name}')."
+            )
 
     def _drive_em_transition(
         self,

--- a/vultron/core/use_cases/received/embargo.py
+++ b/vultron/core/use_cases/received/embargo.py
@@ -16,16 +16,35 @@ from vultron.core.ports.case_persistence import (
     CasePersistence,
     CaseOutboxPersistence,
 )
-from vultron.core.use_cases._helpers import _as_id, _idempotent_create
+from vultron.core.use_cases._helpers import (
+    _as_id,
+    _idempotent_create,
+    add_activity_to_outbox,
+)
 from vultron.core.models.protocols import (
     PersistableModel,
     is_case_model,
 )
+from vultron.core.states.cs import CS_pxa
 
 if TYPE_CHECKING:
     from vultron.core.ports.sync_activity import SyncActivityPort
+    from vultron.core.ports.trigger_activity import TriggerActivityPort
 
 logger = logging.getLogger(__name__)
+
+
+def _pxa_embargo_ineligible(dl: CasePersistence, case_id: str) -> bool:
+    """Return True when P/X/A is set on the case (EMB-01-002, EMB-02-002).
+
+    Reads the case from the DataLayer; returns False (eligible) when the case
+    cannot be resolved so normal processing can continue.
+    """
+    case = dl.read(case_id)
+    if not is_case_model(case):
+        return False
+    pxa_state = CS_pxa(case.current_status.pxa_state)
+    return pxa_state != CS_pxa.pxa
 
 
 def _resolve_case_for_embargo_acceptance(
@@ -212,10 +231,12 @@ class InviteToEmbargoOnCaseReceivedUseCase:
         dl: CaseOutboxPersistence,
         request: InviteToEmbargoOnCaseReceivedEvent,
         sync_port: "SyncActivityPort | None" = None,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: InviteToEmbargoOnCaseReceivedEvent = request
         self._sync_port = sync_port
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> None:
         from py_trees.common import Status
@@ -240,6 +261,39 @@ class InviteToEmbargoOnCaseReceivedUseCase:
                 "invite_to_embargo_on_case: missing receiving_actor_id"
                 " — skipping"
             )
+            return
+
+        # EMB-01-002: MUST NOT process EP when P/X/A is set; MUST emit ER.
+        if case_id and _pxa_embargo_ineligible(self._dl, case_id):
+            logger.info(
+                "invite_to_embargo_on_case: P/X/A set on case '%s'"
+                " — rejecting EP '%s' (EMB-01-002)",
+                case_id,
+                invite_id,
+            )
+            if self._trigger_activity is not None:
+                _idempotent_create(
+                    self._dl,
+                    request.activity_type,
+                    invite_id,
+                    request.activity,
+                    "InviteToEmbargoOnCase",
+                    invite_id,
+                )
+                reject_id, _ = self._trigger_activity.reject_embargo(
+                    proposal_id=invite_id,
+                    case_id=case_id,
+                    actor=receiving_actor_id,
+                    to=[request.actor_id],
+                )
+                add_activity_to_outbox(receiving_actor_id, reject_id, self._dl)
+            else:
+                logger.warning(
+                    "invite_to_embargo_on_case: trigger_activity unavailable"
+                    " — ER not emitted for EP '%s' on case '%s'",
+                    invite_id,
+                    case_id,
+                )
             return
 
         # Single BT execution under receiving_actor_id (ADR-0022 / CLP-10-005).
@@ -276,10 +330,12 @@ class AcceptInviteToEmbargoOnCaseReceivedUseCase:
         dl: CaseOutboxPersistence,
         request: AcceptInviteToEmbargoOnCaseReceivedEvent,
         sync_port: "SyncActivityPort | None" = None,
+        trigger_activity: "TriggerActivityPort | None" = None,
     ) -> None:
         self._dl = dl
         self._request: AcceptInviteToEmbargoOnCaseReceivedEvent = request
         self._sync_port = sync_port
+        self._trigger_activity = trigger_activity
 
     def execute(self) -> None:
         from py_trees.common import Status
@@ -313,6 +369,31 @@ class AcceptInviteToEmbargoOnCaseReceivedUseCase:
         case_id = _case.id_
         accepting_actor_id = request.actor_id
         invite_id = request.invite_id or ""
+
+        # EMB-02-002: MUST NOT process EA to transition EM to Active when P/X/A
+        # is set; MUST emit ER instead.
+        if _pxa_embargo_ineligible(self._dl, case_id):
+            logger.info(
+                "accept_invite_to_embargo_on_case: P/X/A set on case '%s'"
+                " — rejecting EA (EMB-02-002)",
+                case_id,
+            )
+            if self._trigger_activity is not None and invite_id:
+                reject_id, _ = self._trigger_activity.reject_embargo(
+                    proposal_id=invite_id,
+                    case_id=case_id,
+                    actor=receiving_actor_id,
+                    to=[request.actor_id],
+                )
+                add_activity_to_outbox(receiving_actor_id, reject_id, self._dl)
+            else:
+                logger.warning(
+                    "accept_invite_to_embargo_on_case: trigger_activity"
+                    " unavailable or missing invite_id — ER not emitted"
+                    " for EA on case '%s'",
+                    case_id,
+                )
+            return
 
         # Single BT execution under receiving_actor_id (ADR-0022 / CLP-10-005).
         # accepting_actor_id is threaded into the tree as a node constructor arg


### PR DESCRIPTION
- Closes #1454

## Summary

Implements AC-1 through AC-3 for #1454: P/X/A embargo-eligibility rules modeled
as precondition guards in `EmbargoLifecycle`, enforcing EMB-01-002, EMB-02-002,
and EMB-04-002.

## Changes

- **`_assert_pxa_embargo_eligible()`** — new static helper that raises
  `VultronInvalidStateTransitionError` when `pxa_state != CS_pxa.pxa`; called
  in STRICT mode only (OBSERVED bypasses all guards for state-sync)
- **`propose_embargo()`** — STRICT guard before any EM transition (EMB-01-002:
  MUST NOT process EP when P/X/A set)
- **`accept_embargo_invite()`** — STRICT guard scoped to owner-only EM
  transitions; non-owners recording PEC consent are not blocked (EMB-02-002
  restricts EM-level accept only, not PEC recording)
- **`reject_embargo_invite()`** — STRICT guard for REVISE+PXA: raises when the
  reject would return the case to ACTIVE while P/X/A is set (EMB-04-002: must
  terminate instead)
- **`test/core/services/test_embargo_lifecycle.py`** — 79 tests total (up from
  27); all 7 ineligible `CS_pxa` states covered parametrically for each guarded
  operation

## Verification

- [x] AC-1: `propose_embargo()` STRICT raises for all 7 P/X/A-ineligible states
  (EMB-01-002); OBSERVED bypasses
- [x] AC-2: Auto-terminate on CS.P via `PublicDisclosureBranchNode` (pre-existing
  from #1204; not changed by this PR)
- [x] AC-3: Guards raise `VultronInvalidStateTransitionError` with descriptive
  message; parametric tests confirm allowed vs. rejected paths
- [x] AC-4: No `PublicCase` or P/X/A staged type introduced (LST-01-001)
- [x] `uv run pytest test/core/services/test_embargo_lifecycle.py` — 79 passed
- [x] `uv run pytest --tb=short` — 4884 passed, full suite clean
- [x] `uv run black vultron/ test/ && uv run flake8 vultron/ test/ && uv run mypy && uv run pyright` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)