### PR TITLE
docs: generate docs/reference/specs/ kind pages from spec YAML using markdown-exec

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -18,6 +18,7 @@ protocol with other related standards and protocols, including:
 <div class="grid cards" markdown>
 
 - :material-cube-unfolded: A [Formal Protocol](formal_protocol/index.md) specification for the Vultron Protocol
+- :material-file-document-multiple: [Specifications](specs/general.md) — structured requirements by kind (General, Pattern, Domain, Language, Implementation, Dev Process)
 - :material-format-list-text: An annotated listing of the [Case States](case_states/index.md) of the Vultron Protocol
 - :material-altimeter: [Measuring CVD](measuring_cvd/index.md) — metrics and benchmarks for CVD efficacy
 - :material-book: [User Stories](user_stories/index.md) — requirements captured as user stories

--- a/docs/reference/specs/dev-process.md
+++ b/docs/reference/specs/dev-process.md
@@ -1,0 +1,20 @@
+# Dev Process Specifications
+
+This project's development and maintenance process requirements. These cover
+skill workflows, history management, spec authoring conventions, and parallel
+agentic development practices.
+
+```python exec="true" idprefix=""
+import sys
+from pathlib import Path
+_repo = Path.cwd()
+if str(_repo) not in sys.path:
+    sys.path.insert(0, str(_repo))
+for _k in list(sys.modules.keys()):
+    if _k.startswith("vultron"):
+        del sys.modules[_k]
+from vultron.metadata.specs import load_registry
+from vultron.metadata.specs.docs_render import render_for_kind
+registry = load_registry(_repo / "specs")
+print(render_for_kind("dev-process", registry))
+```

--- a/docs/reference/specs/domain.md
+++ b/docs/reference/specs/domain.md
@@ -1,0 +1,20 @@
+# Domain Specifications
+
+Vultron and CVD protocol requirements that are language-agnostic. These cover
+embargo lifecycle, case management, ActivityStreams semantics, MPCVD state
+machines, and other domain-specific behavioral requirements.
+
+```python exec="true" idprefix=""
+import sys
+from pathlib import Path
+_repo = Path.cwd()
+if str(_repo) not in sys.path:
+    sys.path.insert(0, str(_repo))
+for _k in list(sys.modules.keys()):
+    if _k.startswith("vultron"):
+        del sys.modules[_k]
+from vultron.metadata.specs import load_registry
+from vultron.metadata.specs.docs_render import render_for_kind
+registry = load_registry(_repo / "specs")
+print(render_for_kind("domain", registry))
+```

--- a/docs/reference/specs/general.md
+++ b/docs/reference/specs/general.md
@@ -1,0 +1,20 @@
+# General Specifications
+
+Universal requirements that apply to any project regardless of language or
+domain. These cover idempotency, linter discipline, CI security, and other
+cross-cutting concerns.
+
+```python exec="true" idprefix=""
+import sys
+from pathlib import Path
+_repo = Path.cwd()
+if str(_repo) not in sys.path:
+    sys.path.insert(0, str(_repo))
+for _k in list(sys.modules.keys()):
+    if _k.startswith("vultron"):
+        del sys.modules[_k]
+from vultron.metadata.specs import load_registry
+from vultron.metadata.specs.docs_render import render_for_kind
+registry = load_registry(_repo / "specs")
+print(render_for_kind("general", registry))
+```

--- a/docs/reference/specs/implementation.md
+++ b/docs/reference/specs/implementation.md
@@ -1,0 +1,20 @@
+# Implementation Specifications
+
+Requirements specific to this codebase. These cover file paths under
+`vultron/`, class names in `vultron/core/`, notes frontmatter schema, and
+other implementation-specific details.
+
+```python exec="true" idprefix=""
+import sys
+from pathlib import Path
+_repo = Path.cwd()
+if str(_repo) not in sys.path:
+    sys.path.insert(0, str(_repo))
+for _k in list(sys.modules.keys()):
+    if _k.startswith("vultron"):
+        del sys.modules[_k]
+from vultron.metadata.specs import load_registry
+from vultron.metadata.specs.docs_render import render_for_kind
+registry = load_registry(_repo / "specs")
+print(render_for_kind("implementation", registry))
+```

--- a/docs/reference/specs/language.md
+++ b/docs/reference/specs/language.md
@@ -1,0 +1,20 @@
+# Language Specifications
+
+Python ecosystem requirements applicable to any Python project. These cover
+Pydantic conventions, py_trees API usage, pytest patterns, FastAPI patterns,
+and similar language-specific concerns.
+
+```python exec="true" idprefix=""
+import sys
+from pathlib import Path
+_repo = Path.cwd()
+if str(_repo) not in sys.path:
+    sys.path.insert(0, str(_repo))
+for _k in list(sys.modules.keys()):
+    if _k.startswith("vultron"):
+        del sys.modules[_k]
+from vultron.metadata.specs import load_registry
+from vultron.metadata.specs.docs_render import render_for_kind
+registry = load_registry(_repo / "specs")
+print(render_for_kind("language", registry))
+```

--- a/docs/reference/specs/pattern.md
+++ b/docs/reference/specs/pattern.md
@@ -1,0 +1,20 @@
+# Pattern Specifications
+
+Architectural and framework approach requirements that are language-agnostic
+and not CVD-specific. These cover hexagonal architecture, behavior tree
+composability, event-driven dispatch, and similar structural patterns.
+
+```python exec="true" idprefix=""
+import sys
+from pathlib import Path
+_repo = Path.cwd()
+if str(_repo) not in sys.path:
+    sys.path.insert(0, str(_repo))
+for _k in list(sys.modules.keys()):
+    if _k.startswith("vultron"):
+        del sys.modules[_k]
+from vultron.metadata.specs import load_registry
+from vultron.metadata.specs.docs_render import render_for_kind
+registry = load_registry(_repo / "specs")
+print(render_for_kind("pattern", registry))
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,6 +121,13 @@ nav:
       - Messages: 'reference/formal_protocol/messages.md'
       - Transitions: 'reference/formal_protocol/transitions.md'
       - Protocol Summary: 'reference/formal_protocol/conclusion.md'
+    - Specifications:
+      - General: 'reference/specs/general.md'
+      - Pattern: 'reference/specs/pattern.md'
+      - Domain: 'reference/specs/domain.md'
+      - Language: 'reference/specs/language.md'
+      - Implementation: 'reference/specs/implementation.md'
+      - Dev Process: 'reference/specs/dev-process.md'
     - Case States:
       - 'reference/case_states/index.md'
       - vfdpxa: 'reference/case_states/state_vfdpxa.md'
@@ -258,6 +265,8 @@ not_in_nav: |
   *diagram*.md
   *table*.md
   *.ttl
+  codebase/**
+  reference/codebase/**
   # Maintainer/agent-facing pages intentionally excluded from the published nav
   agents/*.md
   developer/**/*.md

--- a/plan/history/2607/implementation/ISSUE-1479.md
+++ b/plan/history/2607/implementation/ISSUE-1479.md
@@ -1,0 +1,23 @@
+---
+source: ISSUE-1479
+timestamp: '2026-07-17T16:09:11.386958+00:00'
+title: Generate docs/reference/specs/ kind pages from spec YAML using markdown-exec
+type: implementation
+---
+
+## Issue #1479 — docs: generate docs/reference/specs/ kind pages from spec YAML using markdown-exec
+
+Implemented six auto-generated reference pages under docs/reference/specs/ (one per SpecKind), each rendered at build time from specs/*.yaml via markdown-exec.
+
+Key deliverables:
+
+- vultron/metadata/specs/docs_render.py: new MkDocs Material renderer with priority badges, cross-kind anchor links, and ECA details blocks
+- SpecTag.BEHAVIORAL + SpecFile.tags field in schema.py
+- export_yaml round-trip fix in render.py (_file_to_dict now includes tags)
+- 6 new docs pages + nav wiring in mkdocs.yml
+- 36 tests in test_docs_render.py + kind-page coverage guard
+
+Code-review findings fixed: no-op _spec_anchor replace, behavioral heading inversion (H4/H3 → H3/H4).
+DEFER: BehavioralSpec validator name shadow (pre-existing, filed as separate bug).
+
+PR: <https://github.com/CERTCC/Vultron/pull/1485>

--- a/specs/cs-behavior.yaml
+++ b/specs/cs-behavior.yaml
@@ -15,6 +15,8 @@ description: >-
   directly — separating them would create dangling satisfies relationships.
 version: 0.1.0
 kind: domain
+tags:
+- behavioral
 scope:
 - prototype
 - production

--- a/specs/em-behavior.yaml
+++ b/specs/em-behavior.yaml
@@ -15,6 +15,8 @@ description: >-
   directly.
 version: 0.1.0
 kind: domain
+tags:
+- behavioral
 scope:
 - prototype
 - production

--- a/specs/rm-behavior.yaml
+++ b/specs/rm-behavior.yaml
@@ -12,6 +12,8 @@ description: >-
   See also: notes/behavioral-conformance-specs.md for design rationale.
 version: 0.1.0
 kind: domain
+tags:
+- behavioral
 scope:
 - prototype
 - production

--- a/test/metadata/specs/test_docs_render.py
+++ b/test/metadata/specs/test_docs_render.py
@@ -1,0 +1,366 @@
+"""Tests for vultron.metadata.specs.docs_render.render_for_kind (AC-1).
+
+Covers: priority badges, group/file headers, behavioral ECA blocks,
+cross-kind relationship links, ValueError for unknown/empty kind,
+and SpecTag.BEHAVIORAL detection.
+"""
+
+import yaml
+import pytest
+
+from vultron.metadata.specs.registry import load_registry
+from vultron.metadata.specs.schema import SpecKind, SpecTag
+from vultron.metadata.specs.docs_render import render_for_kind
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+GENERAL_YAML = {
+    "id": "GEN",
+    "title": "General Test Specs",
+    "description": "A general kind spec for testing docs_render",
+    "version": "0.1",
+    "kind": "general",
+    "scope": ["production"],
+    "groups": [
+        {
+            "id": "GEN-01",
+            "title": "General Group",
+            "description": "Tests the general kind page renderer",
+            "specs": [
+                {
+                    "id": "GEN-01-001",
+                    "priority": "MUST",
+                    "statement": "GEN-01-001 MUST render correctly",
+                    "rationale": "Required for docs coverage",
+                },
+                {
+                    "id": "GEN-01-002",
+                    "priority": "SHOULD",
+                    "statement": "GEN-01-002 SHOULD appear with a badge",
+                    "relationships": [
+                        {
+                            "rel_type": "satisfies",
+                            "spec_id": "GEN-01-001",
+                        }
+                    ],
+                },
+                {
+                    "id": "GEN-01-003",
+                    "priority": "MAY",
+                    "statement": "GEN-01-003 MAY be optional",
+                },
+                {
+                    "id": "GEN-01-004",
+                    "priority": "MUST_NOT",
+                    "statement": "GEN-01-004 MUST NOT do the bad thing",
+                },
+                {
+                    "id": "GEN-01-005",
+                    "priority": "SHOULD_NOT",
+                    "statement": "GEN-01-005 SHOULD NOT be used",
+                },
+            ],
+        }
+    ],
+}
+
+DOMAIN_YAML = {
+    "id": "DOM",
+    "title": "Domain Test Specs",
+    "description": "A domain kind spec with relationships",
+    "version": "0.1",
+    "kind": "domain",
+    "scope": ["production"],
+    "groups": [
+        {
+            "id": "DOM-01",
+            "title": "Domain Group",
+            "specs": [
+                {
+                    "id": "DOM-01-001",
+                    "priority": "MUST",
+                    "statement": "DOM-01-001 MUST cross-reference GEN-01-001",
+                    "relationships": [
+                        {
+                            "rel_type": "satisfies",
+                            "spec_id": "GEN-01-001",
+                            "note": "fulfills the general rule",
+                        }
+                    ],
+                }
+            ],
+        }
+    ],
+}
+
+BEHAVIORAL_YAML = {
+    "id": "BHV",
+    "title": "Behavioral Test Specs",
+    "description": "A domain spec with BehavioralSpec items",
+    "version": "0.1",
+    "kind": "domain",
+    "tags": ["behavioral"],
+    "scope": ["production"],
+    "groups": [
+        {
+            "id": "BHV-01",
+            "title": "Behavioral Group",
+            "trigger": {"type": "message_received", "value": "EP"},
+            "specs": [
+                {
+                    "id": "BHV-01-001",
+                    "priority": "MUST",
+                    "statement": "BHV-01-001 MUST fire on EP",
+                    "preconditions": [
+                        {
+                            "rm_state": ["ACCEPTED"],
+                            "em_state": ["NONE"],
+                            "cs_pattern": "vfd...",
+                            "description": "Actor is in RM Accepted, EM None, CS matches vfd...",
+                        }
+                    ],
+                    "steps": [
+                        {
+                            "order": 1,
+                            "actor": "Participant",
+                            "action": "Propose embargo",
+                            "expected": "EM transitions to PROPOSED",
+                        }
+                    ],
+                    "postconditions": [
+                        {"description": "EM state is PROPOSED"}
+                    ],
+                }
+            ],
+        }
+    ],
+}
+
+
+@pytest.fixture
+def general_registry(tmp_path):
+    (tmp_path / "gen.yaml").write_text(yaml.dump(GENERAL_YAML))
+    return load_registry(tmp_path)
+
+
+@pytest.fixture
+def cross_kind_registry(tmp_path):
+    (tmp_path / "gen.yaml").write_text(yaml.dump(GENERAL_YAML))
+    (tmp_path / "dom.yaml").write_text(yaml.dump(DOMAIN_YAML))
+    return load_registry(tmp_path)
+
+
+@pytest.fixture
+def behavioral_registry(tmp_path):
+    (tmp_path / "dom.yaml").write_text(yaml.dump(DOMAIN_YAML))
+    (tmp_path / "bhv.yaml").write_text(yaml.dump(BEHAVIORAL_YAML))
+    return load_registry(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# ValueError for unknown / empty kind
+# ---------------------------------------------------------------------------
+
+
+def test_render_for_kind_unknown_raises(general_registry):
+    with pytest.raises(ValueError, match="Unknown SpecKind"):
+        render_for_kind("nonexistent-kind", general_registry)
+
+
+def test_render_for_kind_no_matching_files_raises(general_registry):
+    """Requesting a kind with no files should raise ValueError."""
+    with pytest.raises(ValueError, match="No spec files with kind"):
+        render_for_kind("domain", general_registry)
+
+
+# ---------------------------------------------------------------------------
+# Priority badges
+# ---------------------------------------------------------------------------
+
+
+def test_render_for_kind_must_badge(general_registry):
+    md = render_for_kind("general", general_registry)
+    assert "**MUST**" in md
+
+
+def test_render_for_kind_should_badge(general_registry):
+    md = render_for_kind("general", general_registry)
+    assert "**SHOULD**" in md
+
+
+def test_render_for_kind_may_badge(general_registry):
+    md = render_for_kind("general", general_registry)
+    assert "**MAY**" in md
+
+
+def test_render_for_kind_must_not_badge(general_registry):
+    md = render_for_kind("general", general_registry)
+    assert "**MUST NOT**" in md
+
+
+def test_render_for_kind_should_not_badge(general_registry):
+    md = render_for_kind("general", general_registry)
+    assert "**SHOULD NOT**" in md
+
+
+# ---------------------------------------------------------------------------
+# Structure: file H2, group H3, spec IDs, statements
+# ---------------------------------------------------------------------------
+
+
+def test_render_for_kind_file_title_h2(general_registry):
+    md = render_for_kind("general", general_registry)
+    assert "## General Test Specs" in md
+
+
+def test_render_for_kind_group_title_h3(general_registry):
+    md = render_for_kind("general", general_registry)
+    assert "### General Group" in md
+
+
+def test_render_for_kind_spec_id_in_output(general_registry):
+    md = render_for_kind("general", general_registry)
+    assert "GEN-01-001" in md
+
+
+def test_render_for_kind_statement_in_output(general_registry):
+    md = render_for_kind("general", general_registry)
+    assert "MUST render correctly" in md
+
+
+def test_render_for_kind_rationale_in_output(general_registry):
+    md = render_for_kind("general", general_registry)
+    assert "Required for docs coverage" in md
+
+
+def test_render_for_kind_anchors_present(general_registry):
+    md = render_for_kind("general", general_registry)
+    assert 'id="gen-01-001"' in md
+
+
+# ---------------------------------------------------------------------------
+# Cross-kind relationship links
+# ---------------------------------------------------------------------------
+
+
+def test_render_for_kind_same_kind_link(cross_kind_registry):
+    """Relationship to a spec on the same kind page uses a bare anchor."""
+    md = render_for_kind("general", cross_kind_registry)
+    assert "#gen-01-001" in md
+
+
+def test_render_for_kind_cross_kind_link(cross_kind_registry):
+    """Relationship to a spec on a different kind page uses a relative URL."""
+    md = render_for_kind("domain", cross_kind_registry)
+    assert "../general/#gen-01-001" in md
+
+
+def test_render_for_kind_relationship_label(cross_kind_registry):
+    md = render_for_kind("domain", cross_kind_registry)
+    assert "Satisfies" in md
+
+
+def test_render_for_kind_relationship_note(cross_kind_registry):
+    md = render_for_kind("domain", cross_kind_registry)
+    assert "fulfills the general rule" in md
+
+
+# ---------------------------------------------------------------------------
+# Behavioral ECA block
+# ---------------------------------------------------------------------------
+
+
+def test_render_for_kind_behavioral_section_header(behavioral_registry):
+    md = render_for_kind("domain", behavioral_registry)
+    assert "## Behavioral Specifications" in md
+
+
+def test_render_for_kind_eca_details_block(behavioral_registry):
+    md = render_for_kind("domain", behavioral_registry)
+    assert '??? details "ECA Details"' in md
+
+
+def test_render_for_kind_precondition_text(behavioral_registry):
+    md = render_for_kind("domain", behavioral_registry)
+    assert "Actor is in RM Accepted" in md
+
+
+def test_render_for_kind_precondition_rm_state(behavioral_registry):
+    md = render_for_kind("domain", behavioral_registry)
+    assert "RM state: `ACCEPTED`" in md
+
+
+def test_render_for_kind_precondition_cs_pattern(behavioral_registry):
+    md = render_for_kind("domain", behavioral_registry)
+    assert "CS pattern: `vfd...`" in md
+
+
+def test_render_for_kind_step_text(behavioral_registry):
+    md = render_for_kind("domain", behavioral_registry)
+    assert "Propose embargo" in md
+
+
+def test_render_for_kind_step_expected(behavioral_registry):
+    md = render_for_kind("domain", behavioral_registry)
+    assert "EM transitions to PROPOSED" in md
+
+
+def test_render_for_kind_postcondition_text(behavioral_registry):
+    md = render_for_kind("domain", behavioral_registry)
+    assert "EM state is PROPOSED" in md
+
+
+def test_render_for_kind_trigger_line(behavioral_registry):
+    md = render_for_kind("domain", behavioral_registry)
+    assert "Message Received" in md
+    assert "`EP`" in md
+
+
+# ---------------------------------------------------------------------------
+# SpecTag.BEHAVIORAL enum value
+# ---------------------------------------------------------------------------
+
+
+def test_spec_tag_behavioral_value():
+    assert SpecTag.BEHAVIORAL == "behavioral"
+
+
+def test_spec_tag_behavioral_in_enum():
+    assert SpecTag.BEHAVIORAL in list(SpecTag)
+
+
+# ---------------------------------------------------------------------------
+# SpecFile.tags field acceptance
+# ---------------------------------------------------------------------------
+
+
+def test_spec_file_tags_field_accepted(behavioral_registry):
+    bhv_file = next(f for f in behavioral_registry.files if f.id == "BHV")
+    assert bhv_file.tags is not None
+    assert SpecTag.BEHAVIORAL in bhv_file.tags
+
+
+def test_spec_file_tags_none_by_default(general_registry):
+    gen_file = general_registry.files[0]
+    assert gen_file.tags is None
+
+
+# ---------------------------------------------------------------------------
+# All SpecKind values produce output via real registry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("kind", list(SpecKind))
+def test_render_for_kind_real_registry_produces_output(kind: SpecKind):
+    """Every SpecKind must render non-empty output from the real spec registry."""
+    registry = load_registry()
+    md = render_for_kind(kind.value, registry)
+    assert len(md) > 0
+    # At minimum one spec ID pattern should appear
+    import re
+
+    assert re.search(
+        r"[A-Z]{2,8}-\d{2}-\d{3}", md
+    ), f"No spec IDs found in rendered output for kind={kind.value!r}"

--- a/test/metadata/specs/test_docs_render.py
+++ b/test/metadata/specs/test_docs_render.py
@@ -348,6 +348,42 @@ def test_spec_file_tags_none_by_default(general_registry):
 
 
 # ---------------------------------------------------------------------------
+# BehavioralSpec validator does not shadow StatementSpec validator
+# ---------------------------------------------------------------------------
+
+
+def test_behavioral_spec_empty_scope_raises():
+    """BehavioralSpec must still reject scope=[] (parent validator not shadowed)."""
+    from vultron.metadata.specs.schema import BehavioralSpec, RFC2119Priority
+
+    with pytest.raises(Exception):
+        BehavioralSpec(
+            id="BHV-01-001",
+            priority=RFC2119Priority.MUST,
+            statement="test",
+            scope=[],
+        )
+
+
+def test_behavioral_spec_empty_preconditions_raises():
+    """BehavioralSpec rejects preconditions=[] via its own validator."""
+    from vultron.metadata.specs.schema import (
+        BehavioralSpec,
+        RFC2119Priority,
+        Scope,
+    )
+
+    with pytest.raises(Exception):
+        BehavioralSpec(
+            id="BHV-01-001",
+            priority=RFC2119Priority.MUST,
+            statement="test",
+            scope=[Scope.PRODUCTION],
+            preconditions=[],
+        )
+
+
+# ---------------------------------------------------------------------------
 # All SpecKind values produce output via real registry
 # ---------------------------------------------------------------------------
 

--- a/test/metadata/specs/test_kind_page_coverage.py
+++ b/test/metadata/specs/test_kind_page_coverage.py
@@ -1,0 +1,25 @@
+"""Assert that every SpecKind value has a corresponding docs page (AC-5).
+
+Fails when a new kind is added to the SpecKind enum without a matching
+``docs/reference/specs/<kind-slug>.md`` file, enforcing the
+"new kind → new page" rule.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from vultron.metadata.specs.schema import SpecKind
+
+_DOCS_SPECS_DIR = Path(__file__).parents[3] / "docs" / "reference" / "specs"
+
+
+@pytest.mark.parametrize("kind", list(SpecKind))
+def test_kind_has_docs_page(kind: SpecKind) -> None:
+    """Every SpecKind must have a matching docs/reference/specs/<slug>.md."""
+    slug = kind.value  # StrEnum value is the slug (e.g. "dev-process")
+    page = _DOCS_SPECS_DIR / f"{slug}.md"
+    assert page.exists(), (
+        f"Missing docs page for SpecKind.{kind.name}: "
+        f"expected {page.relative_to(Path(__file__).parents[3])}"
+    )

--- a/vultron/metadata/specs/docs_render.py
+++ b/vultron/metadata/specs/docs_render.py
@@ -1,0 +1,292 @@
+"""MkDocs Material markdown renderer for ``docs/reference/specs/`` pages.
+
+Produces rich reference pages (one per :class:`SpecKind`) from the loaded
+:class:`SpecRegistry`.  Unlike ``render.py`` (agent/LLM export), this module
+targets human readers via the published documentation site.
+
+Usage (in a markdown-exec Python block)::
+
+    from vultron.metadata.specs import load_registry
+    from vultron.metadata.specs.docs_render import render_for_kind
+
+    registry = load_registry()
+    print(render_for_kind("domain", registry))
+"""
+
+from __future__ import annotations
+
+from vultron.metadata.specs.registry import SpecRegistry, load_registry
+from vultron.metadata.specs.schema import (
+    BehavioralSpec,
+    RFC2119Priority,
+    RelationType,
+    Spec,
+    SpecFile,
+    SpecGroup,
+    SpecKind,
+    SpecTag,
+)
+
+# Maps RFC2119 priority to a MkDocs Material badge string.
+_PRIORITY_BADGE: dict[RFC2119Priority, str] = {
+    RFC2119Priority.MUST: ":octicons-dot-fill-24:{ .must } **MUST**",
+    RFC2119Priority.MUST_NOT: ":octicons-dot-fill-24:{ .must-not } **MUST NOT**",
+    RFC2119Priority.SHOULD: ":octicons-dot-fill-24:{ .should } **SHOULD**",
+    RFC2119Priority.SHOULD_NOT: ":octicons-dot-fill-24:{ .should-not } **SHOULD NOT**",
+    RFC2119Priority.MAY: ":octicons-dot-fill-24:{ .may } **MAY**",
+}
+
+# Relationship type label → human-readable prefix
+_REL_LABEL: dict[RelationType, str] = {
+    RelationType.IMPLEMENTS: "Implements",
+    RelationType.SUPERSEDES: "Supersedes",
+    RelationType.EXTENDS: "Extends",
+    RelationType.DEPENDS_ON: "Depends on",
+    RelationType.CONFLICTS: "Conflicts with",
+    RelationType.REFINES: "Refines",
+    RelationType.DERIVES_FROM: "Derives from",
+    RelationType.VERIFIES: "Verifies",
+    RelationType.PART_OF: "Part of",
+    RelationType.CONSTRAINS: "Constrains",
+    RelationType.SATISFIES: "Satisfies",
+}
+
+# SpecKind → URL slug for cross-kind anchor links
+_KIND_SLUG: dict[SpecKind, str] = {
+    SpecKind.GENERAL: "general",
+    SpecKind.PATTERN: "pattern",
+    SpecKind.DOMAIN: "domain",
+    SpecKind.LANGUAGE: "language",
+    SpecKind.IMPLEMENTATION: "implementation",
+    SpecKind.DEV_PROCESS: "dev-process",
+}
+
+
+def _spec_anchor(spec_id: str) -> str:
+    """Return MkDocs-compatible anchor for a spec ID (lower-cased, dashes)."""
+    return spec_id.lower().replace("_", "-")
+
+
+def _cross_link(
+    spec_id: str, target_kind: SpecKind, current_kind: SpecKind
+) -> str:
+    """Return a markdown link to *spec_id* on the correct kind page."""
+    anchor = _spec_anchor(spec_id)
+    if target_kind == current_kind:
+        return f"[{spec_id}](#{anchor})"
+    slug = _KIND_SLUG[target_kind]
+    return f"[{spec_id}](../{slug}/#{anchor})"
+
+
+def _render_relationships(
+    lines: list[str],
+    spec: Spec,
+    registry: SpecRegistry,
+    current_kind: SpecKind,
+) -> None:
+    for rel in spec.relationships or []:
+        label = _REL_LABEL.get(rel.rel_type, rel.rel_type.value)
+        # Resolve target kind from registry if possible; fall back to current
+        try:
+            target_kind = registry.get_effective_kind(rel.spec_id)
+        except KeyError:
+            target = rel.spec_id
+        else:
+            target = _cross_link(rel.spec_id, target_kind, current_kind)
+        note = f" — {rel.note}" if rel.note else ""
+        lines.append(f"    - *{label}*: {target}{note}")
+
+
+def _render_preconditions(lines: list[str], spec: BehavioralSpec) -> None:
+    if not spec.preconditions:
+        return
+    lines.append("        **Preconditions**")
+    lines.append("")
+    for pc in spec.preconditions:
+        lines.append(f"        - {pc.description}")
+        if pc.rm_state:
+            states = ", ".join(s.value for s in pc.rm_state)
+            lines.append(f"          - RM state: `{states}`")
+        if pc.em_state:
+            states = ", ".join(s.value for s in pc.em_state)
+            lines.append(f"          - EM state: `{states}`")
+        if pc.role:
+            roles = ", ".join(r.value for r in pc.role)
+            lines.append(f"          - Role: `{roles}`")
+        if pc.cs_pattern:
+            lines.append(f"          - CS pattern: `{pc.cs_pattern}`")
+    lines.append("")
+
+
+def _render_steps(lines: list[str], spec: BehavioralSpec) -> None:
+    if not spec.steps:
+        return
+    lines.append("        **Steps**")
+    lines.append("")
+    for step in spec.steps:
+        expected = f" → {step.expected}" if step.expected else ""
+        lines.append(
+            f"        {step.order}. [{step.actor}] {step.action}{expected}"
+        )
+    lines.append("")
+
+
+def _render_postconditions(lines: list[str], spec: BehavioralSpec) -> None:
+    if not spec.postconditions:
+        return
+    lines.append("        **Postconditions**")
+    lines.append("")
+    for pc in spec.postconditions:
+        lines.append(f"        - {pc.description}")
+    lines.append("")
+
+
+def _render_behavioral(lines: list[str], spec: BehavioralSpec) -> None:
+    if not any([spec.preconditions, spec.steps, spec.postconditions]):
+        return
+    lines.append("")
+    lines.append('    ??? details "ECA Details"')
+    lines.append("")
+    _render_preconditions(lines, spec)
+    _render_steps(lines, spec)
+    _render_postconditions(lines, spec)
+
+
+def _is_behavioral_file(spec_file: SpecFile) -> bool:
+    return any(
+        isinstance(spec, BehavioralSpec)
+        for group in spec_file.groups
+        for spec in group.specs
+    )
+
+
+def _has_behavioral_tag(spec_file: SpecFile) -> bool:
+    return SpecTag.BEHAVIORAL in (spec_file.tags or [])
+
+
+def _render_spec(
+    lines: list[str],
+    spec: Spec,
+    registry: SpecRegistry,
+    current_kind: SpecKind,
+) -> None:
+    badge = _PRIORITY_BADGE[spec.priority]
+    anchor = _spec_anchor(spec.id)
+    lines.append(f'<a id="{anchor}"></a>')
+    lines.append(f"- **`{spec.id}`** {badge} {spec.statement}")
+    if spec.rationale:
+        lines.append(f"    - *Rationale*: {spec.rationale}")
+    if isinstance(spec, BehavioralSpec):
+        _render_behavioral(lines, spec)
+    _render_relationships(lines, spec, registry, current_kind)
+
+
+def _render_group(
+    lines: list[str],
+    group: SpecGroup,
+    registry: SpecRegistry,
+    current_kind: SpecKind,
+    heading: str = "###",
+) -> None:
+    anchor = _spec_anchor(group.id)
+    lines.append(f"{heading} {group.title} {{#{anchor}}}")
+    lines.append("")
+    if group.description:
+        lines.append(group.description)
+        lines.append("")
+    if group.trigger:
+        trigger_type = group.trigger.type.value.replace("_", " ").title()
+        lines.append(f"*Trigger*: {trigger_type} — `{group.trigger.value}`")
+        lines.append("")
+    for spec in group.specs:
+        _render_spec(lines, spec, registry, current_kind)
+    lines.append("")
+
+
+def _render_file(
+    lines: list[str],
+    spec_file: SpecFile,
+    registry: SpecRegistry,
+    current_kind: SpecKind,
+    is_behavioral_section: bool,
+) -> None:
+    anchor = spec_file.id.lower()
+    if is_behavioral_section:
+        lines.append(f"### {spec_file.title} {{#{anchor}}}")
+        group_heading = "####"
+    else:
+        lines.append(f"## {spec_file.title} {{#{anchor}}}")
+        group_heading = "###"
+    lines.append("")
+    lines.append(spec_file.description)
+    lines.append("")
+    lines.append(
+        f"*File ID*: `{spec_file.id}` | " f"*Version*: {spec_file.version}"
+    )
+    lines.append("")
+    for group in spec_file.groups:
+        _render_group(
+            lines, group, registry, current_kind, heading=group_heading
+        )
+
+
+def render_for_kind(kind: str, registry: SpecRegistry) -> str:
+    """Render all spec files matching *kind* as rich MkDocs Material markdown.
+
+    Args:
+        kind: A :class:`SpecKind` string value (e.g. ``"domain"``).
+        registry: A loaded :class:`SpecRegistry`.
+
+    Returns:
+        A markdown string ready for embedding via markdown-exec.
+
+    Raises:
+        ValueError: If no spec files have this kind in the registry.
+    """
+    try:
+        target_kind = SpecKind(kind)
+    except ValueError:
+        valid = [k.value for k in SpecKind]
+        raise ValueError(f"Unknown SpecKind: {kind!r}. Valid values: {valid}")
+
+    matching = [f for f in registry.files if f.kind == target_kind]
+    if not matching:
+        raise ValueError(
+            f"No spec files with kind={kind!r} found in registry. "
+            "Add a new docs page when you add a new SpecKind."
+        )
+
+    lines: list[str] = []
+
+    # Separate behavioral files (tagged or containing BehavioralSpec items)
+    regular: list[SpecFile] = []
+    behavioral: list[SpecFile] = []
+    for sf in matching:
+        if _has_behavioral_tag(sf) or _is_behavioral_file(sf):
+            behavioral.append(sf)
+        else:
+            regular.append(sf)
+
+    for sf in regular:
+        _render_file(
+            lines, sf, registry, target_kind, is_behavioral_section=False
+        )
+
+    if behavioral:
+        lines.append("## Behavioral Specifications")
+        lines.append("")
+        lines.append(
+            "The following specifications define Event-Condition-Action (ECA) "
+            "behavioral requirements with typed preconditions, ordered steps, "
+            "and postconditions."
+        )
+        lines.append("")
+        for sf in behavioral:
+            _render_file(
+                lines, sf, registry, target_kind, is_behavioral_section=True
+            )
+
+    return "\n".join(lines)
+
+
+__all__ = ["render_for_kind", "load_registry"]

--- a/vultron/metadata/specs/render.py
+++ b/vultron/metadata/specs/render.py
@@ -223,15 +223,18 @@ def _group_to_dict(group: SpecGroup, file: SpecFile) -> dict:
 
 def _file_to_dict(spec_file: SpecFile) -> dict:
     """Serialize a SpecFile to a dict with only authored fields."""
-    return {
+    d: dict = {
         "id": spec_file.id,
         "title": spec_file.title,
         "description": spec_file.description,
         "version": spec_file.version,
         "kind": spec_file.kind.value,
         "scope": [s.value for s in spec_file.scope],
-        "groups": [_group_to_dict(g, spec_file) for g in spec_file.groups],
     }
+    if spec_file.tags is not None:
+        d["tags"] = [t.value for t in spec_file.tags]
+    d["groups"] = [_group_to_dict(g, spec_file) for g in spec_file.groups]
+    return d
 
 
 class _YamlDumper(yaml.SafeDumper):

--- a/vultron/metadata/specs/schema.py
+++ b/vultron/metadata/specs/schema.py
@@ -155,6 +155,7 @@ class SpecTag(StrEnum):
     TESTING = "testing"
     TOOLING = "tooling"
     WIRE_FORMAT = "wire-format"
+    BEHAVIORAL = "behavioral"
 
 
 class LintWarningCode(StrEnum):
@@ -310,6 +311,7 @@ class SpecFile(BaseModel):
     version: NonEmptyStr
     kind: SpecKind
     scope: list[Scope]
+    tags: list[SpecTag] | None = None
     groups: list[SpecGroup]
 
     @field_validator("scope")
@@ -317,6 +319,13 @@ class SpecFile(BaseModel):
     def _scope_nonempty(cls, v: list) -> list:
         if not v:
             raise ValueError("scope must not be empty")
+        return v
+
+    @field_validator("tags")
+    @classmethod
+    def _tags_nonempty_if_present(cls, v: list | None) -> list | None:
+        if v is not None and len(v) == 0:
+            raise ValueError("tags must be non-empty if present")
         return v
 
     @field_validator("groups")

--- a/vultron/metadata/specs/schema.py
+++ b/vultron/metadata/specs/schema.py
@@ -253,7 +253,9 @@ class BehavioralSpec(StatementSpec):
 
     @field_validator("preconditions", "steps", "postconditions")
     @classmethod
-    def _nonempty_if_present(cls, v: list | None, info: object) -> list | None:
+    def _behavioral_nonempty_if_present(
+        cls, v: list | None, info: object
+    ) -> list | None:
         if v is not None and len(v) == 0:
             field_name = getattr(info, "field_name", "list field")
             raise ValueError(f"{field_name} must be non-empty if present")


### PR DESCRIPTION
- closes #1479 

## Summary

six reference pages under `docs/reference/specs/` (one per `SpecKind`), each auto-generated at build time from `specs/*.yaml` via `markdown-exec`. Published docs always reflect the current spec state with zero manual upkeep.

## Changes

- **`vultron/metadata/specs/docs_render.py`** (new): MkDocs Material renderer. `render_for_kind(kind, registry)` emits H2 file headers, H3 group headers, priority badges (octicons), rationale, cross-kind anchor links, and `??? details "ECA Details"` blocks for behavioral specs.
- **`vultron/metadata/specs/schema.py`**: Added `SpecTag.BEHAVIORAL` and `SpecFile.tags: list[SpecTag] | None`.
- **`vultron/metadata/specs/render.py`**: Fixed `_file_to_dict` to include `tags` on export so `export_yaml` round-trips preserve file-level tags.
- **`specs/{rm,em,cs}-behavior.yaml`**: Added `tags: [behavioral]` so behavioral files are grouped in a `## Behavioral Specifications` subsection.
- **`docs/reference/specs/*.md`** (6 new pages): `general`, `pattern`, `domain`, `language`, `implementation`, `dev-process` — each with an `exec` block that purges stale `/app/vultron` from `sys.modules` before importing.
- **`mkdocs.yml`**: Specifications nav section + `not_in_nav` exclusions for `codebase/**` and `reference/codebase/**`.
- **`docs/reference/index.md`**: Grid card linking to the new section.
- **`test/metadata/specs/test_docs_render.py`** (new, 36 tests): badges, structure, cross-kind links, behavioral ECA blocks, ValueError paths.
- **`test/metadata/specs/test_kind_page_coverage.py`** (new): parametrized guard that fails when a new `SpecKind` has no matching page.

### Code-review fixes applied
- `_spec_anchor` had a no-op `.replace("-", "-")` — corrected to `.replace("_", "-")`.
- Behavioral section heading hierarchy was inverted (H4 file / H3 group) — fixed to H3 file / H4 group.

### DEFER (follow-up issue needed)
- `BehavioralSpec._nonempty_if_present` shadows `StatementSpec._nonempty_if_present` in Pydantic v2, leaving `scope`/`tags`/`relationships` non-empty validation inactive on `BehavioralSpec`. Pre-existing issue not introduced by this diff; will file a separate bug.

## Test plan

- [x] `uv run pytest --tb=short` — 4874 passed
- [x] `uv run black vultron/ test/ && uv run flake8 vultron/ test/` — clean
- [x] `uv run mypy && uv run pyright` — 0 errors
- [x] `.github/scripts/mkdocs-build-strict.sh` — ✓ (19 suppressed false-positives, 0 real warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)