### PR TITLE
skill(pr-review): replace DEFER with decision-tree scoping

### DIFF
--- a/.agents/skills/pr-review/REFERENCE.md
+++ b/.agents/skills/pr-review/REFERENCE.md
@@ -187,11 +187,12 @@ All checks passing.
 Severity levels:
 
 - **✅ PASS** — no issues
-- **⚠️ WARN** — should be addressed but not blocking
+- **⚠️ IMPROVE** — works but incomplete; fix in this session
 - **❌ FAIL** — must be addressed before merge
+- **🎫 NEW-ISSUE** — distinct problem; issue cut, decision pending (see SKILL.md decision tree)
 
 Overall rating:
 
 - PASS if all phases are PASS
-- WARN if any phase is WARN and none are FAIL
+- IMPROVE if any phase is IMPROVE and none are FAIL
 - FAIL if any phase is FAIL

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -23,14 +23,26 @@ There is no WARN category — every finding is resolved here or explicitly gated
 |---|---|---|
 | **FAIL** | Broken: won't work correctly, spec violated, changed behavior untested | Fix before the PR merges |
 | **IMPROVE** | Works but incomplete: missing adjacent test, stale doc, extractable helper, obvious gap in scope | Fix in this session; document in a follow-up commit and PR comment |
-| **DEFER** | Genuinely out of scope | Create a follow-up GitHub issue immediately; surface to user for acknowledgment; do not defer unilaterally |
+| **NEW-ISSUE** | Distinct problem, out of this PR's family | Cut a GitHub issue; decide below whether to fold it in or leave it |
 
-For FAIL and IMPROVE findings that are within reach: attempt the fix in the
-same session, then commit the changes and note them in a PR comment so the
-history is clear. Do not just flag and stop.
+For FAIL and IMPROVE findings: attempt the fix in the same session, commit the
+changes, and note them in a PR comment. Do not just flag and stop.
 
-DEFER is a high gate — use it only when fixing would require touching code
-substantially outside the files already changed in this PR.
+### Deciding what belongs in this PR
+
+The scope boundary is **the problem the issue describes and its close relatives**
+— not just the files already in the diff.
+
+Use this decision tree for anything you find beyond the original issue:
+
+1. **Trivial fix, any conceptual distance** → fix it now, mention it in the PR comment. Don't cut an issue.
+2. **Non-trivial, same family** → fix it now. Expand the PR scope. Cut a GitHub issue if useful for tracking, but close it in this same PR.
+3. **Non-trivial, distant cousin** → cut a GitHub issue, then ask the user: "I found X — should I fold it into this PR or leave it for the new issue?" Give a recommendation based on effort ratio (if fixing now is cheaper than reloading context later, lean toward fixing now).
+4. **Requires separate design effort** (you recognize the problem but don't have the solution, or solving it requires deep investigation of a different domain) → cut a GitHub issue, keep this PR focused, do not ask.
+
+**Same family** means: if you had to explain why you fixed both things in this PR, you could do it in one sentence without using the word "also." Siblings, cousins, aunts/uncles of the original problem — things that share the same parent concept. Distant cousins share an ancestor if you trace far enough, but the connection requires too many hops to justify expanding this PR.
+
+**Never** create a NEW-ISSUE finding and leave it unaddressed in the report without following the decision tree above.
 
 ## Quick Start
 
@@ -144,12 +156,13 @@ against the branch diff to surface bugs, logic errors, and security issues.
    fix now, before generating the report. Commit the changes. The PR history
    must show that the review finding was addressed, not just noted.
 
-2. For **DEFER** findings: create the follow-up GitHub issue immediately, then
-   surface each deferred item to the user for acknowledgment before posting the
-   review.
+2. For **NEW-ISSUE** findings: apply the decision tree from the Finding Severity
+   section above. Cut any needed GitHub issues first, then ask the user before
+   folding distant-cousin work into this PR. Do not create issues and then treat
+   user acknowledgment as a formality — the question is genuine.
 
 3. Produce a structured report grouped by phase, with **PASS / FAIL / IMPROVE /
-   DEFER** for each area. See [REFERENCE.md](REFERENCE.md) § "Report Format".
+   NEW-ISSUE** for each area. See [REFERENCE.md](REFERENCE.md) § "Report Format".
    For any finding that was fixed in step 1, mark it as `FIXED` in the report
    with the commit reference.
 


### PR DESCRIPTION
## Summary

- Replaces the vague DEFER verdict with NEW-ISSUE and an explicit decision tree
- Reframes scope boundary from \"files in the diff\" to \"problem the issue describes and its close relatives\"
- Fixes the Phase 12 sequence so user acknowledgment is a genuine gate, not a rubber stamp

## Problem

The DEFER verdict was causing a recurring dance: agent defers something, user approves, agent does the deferred thing immediately — netting zero reduction in open issues and adding ceremony with no value. Roughly 9 in 10 DEFERs were agents avoiding work rather than making a genuine scoping call.

## Changes

**SKILL.md**
- DEFER verdict replaced with NEW-ISSUE
- Decision tree added with four cases keyed on effort × conceptual distance:
  1. Trivial fix, any distance → fix it, mention in PR
  2. Non-trivial, same family → fix now, expand PR scope
  3. Non-trivial, distant cousin → cut issue, then ask with a recommendation
  4. Requires separate design effort → cut issue, keep PR focused, don't ask
- \"Same family\" defined by the one-sentence test: can you explain both fixes without using \"also\"?
- Scope boundary explicitly set to the problem the issue describes, not just files in the diff

**REFERENCE.md**
- Report format verdict set updated to match (PASS / IMPROVE / FAIL / NEW-ISSUE)

## Verification

- [ ] Run `/pr-review` on a PR and confirm no unprompted DEFER/NEW-ISSUE findings appear
- [ ] Confirm agent asks before folding distant-cousin work in

🤖 Generated with [Claude Code](https://claude.com/claude-code)