### PR TITLE
docs(specs): add docs/reference/specs/index.md

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -18,7 +18,7 @@ protocol with other related standards and protocols, including:
 <div class="grid cards" markdown>
 
 - :material-cube-unfolded: A [Formal Protocol](formal_protocol/index.md) specification for the Vultron Protocol
-- :material-file-document-multiple: [Specifications](specs/general.md) — structured requirements by kind (General, Pattern, Domain, Language, Implementation, Dev Process)
+- :material-file-document-multiple: [Specifications](specs/index.md) — structured requirements by kind (General, Pattern, Domain, Language, Implementation, Dev Process)
 - :material-format-list-text: An annotated listing of the [Case States](case_states/index.md) of the Vultron Protocol
 - :material-altimeter: [Measuring CVD](measuring_cvd/index.md) — metrics and benchmarks for CVD efficacy
 - :material-book: [User Stories](user_stories/index.md) — requirements captured as user stories

--- a/docs/reference/specs/index.md
+++ b/docs/reference/specs/index.md
@@ -1,0 +1,15 @@
+# Specifications
+
+Structured requirements for the Vultron protocol and its implementation,
+organized by kind. Each page is generated directly from the `specs/*.yaml`
+source files at documentation build time, so the content always reflects
+the current state of the specification.
+
+| Kind | Description |
+|------|-------------|
+| [General](general.md) | Universal requirements that apply to any project regardless of language or domain |
+| [Pattern](pattern.md) | Language-agnostic architectural and framework approach requirements |
+| [Domain](domain.md) | Vultron and CVD protocol requirements, including behavioral (ECA) specifications |
+| [Language](language.md) | Python ecosystem requirements applicable to any Python project |
+| [Implementation](implementation.md) | Requirements specific to this codebase |
+| [Dev Process](dev-process.md) | Development and maintenance process requirements |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,6 +122,7 @@ nav:
       - Transitions: 'reference/formal_protocol/transitions.md'
       - Protocol Summary: 'reference/formal_protocol/conclusion.md'
     - Specifications:
+      - 'reference/specs/index.md'
       - General: 'reference/specs/general.md'
       - Pattern: 'reference/specs/pattern.md'
       - Domain: 'reference/specs/domain.md'


### PR DESCRIPTION
## Summary

- Adds `docs/reference/specs/index.md` — a landing page for the Specifications section with a table linking to each of the six kind-specific pages.
- Updates `docs/reference/index.md` grid card to point to `specs/index.md` instead of `specs/general.md`.
- Adds `reference/specs/index.md` to the `mkdocs.yml` nav under Specifications.

Follow-up to #1479 / PR #1485.

## Test plan

- [x] `.github/scripts/mkdocs-build-strict.sh` — ✓ (0 real warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)