### PR TITLE
refactor(#1488): extract factory calls to _emit()/_call_factory() helpers

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1488.md
+++ b/plan/history/2607/implementation/ISSUE-1488.md
@@ -1,0 +1,16 @@
+---
+source: ISSUE-1488
+timestamp: '2026-07-17T18:14:41.401315+00:00'
+title: ISSUE-1488 extract factory calls to _emit() helpers
+type: implementation
+---
+
+## Issue #1488 — inline factory calls exceed BTND-07-003 god-node limit
+
+Refactored 6 BT leaf node files, extracting inline factory calls from `update()` methods into named helpers (`_emit`, `_call_factory`, `_emit_accept`, `_emit_close_case`). All `update()` bodies reduced to ≤30 lines.
+
+Code review (pre-PR) caught one correctness regression: `ProposeCaseToActorNode._emit()` incorrectly moved `record_outbox_item` inside the try/except, which would have silenced outbox failures and allowed duplicate CaseProposal retries. Fixed before the PR opened.
+
+Follow-up #1492 created for full AC-3 compliance (`EmitSubmitReportActivity` extending `_EmitCaseActorReportActivityBase`).
+
+PR: <https://github.com/CERTCC/Vultron/pull/1493>

--- a/vultron/core/behaviors/case/nodes/actor.py
+++ b/vultron/core/behaviors/case/nodes/actor.py
@@ -392,14 +392,10 @@ class ProposeCaseToActorNode(DataLayerAction):
 
     def _emit(self, actor_id: str, report_id: str, case_actor_id: str) -> str:
         assert self.trigger_activity_factory is not None
-        assert self.datalayer is not None
         activity_id, _ = self.trigger_activity_factory.create_case_proposal(
             actor=actor_id,
             report_id=report_id,
             case_actor_id=case_actor_id,
-        )
-        cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
-            actor_id, activity_id
         )
         return activity_id
 
@@ -430,6 +426,9 @@ class ProposeCaseToActorNode(DataLayerAction):
             self.logger.warning("%s: %s", self.name, self.feedback_message)
             return Status.FAILURE
 
+        cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
+            self.actor_id, activity_id
+        )
         self.logger.info(
             "%s: Queued Create(as_CaseProposal) '%s' to outbox"
             " for case-actor '%s' (case '%s')",

--- a/vultron/core/behaviors/case/nodes/actor.py
+++ b/vultron/core/behaviors/case/nodes/actor.py
@@ -101,24 +101,60 @@ class EmitInviteActorToCaseNode(DataLayerAction):
             pass
         return None
 
+    def _emit(
+        self,
+        actor_id: str,
+        cc: list[str] | None,
+        roles: list[str] | None,
+        case: Any,
+    ) -> tuple[str, dict]:
+        assert self.trigger_activity_factory is not None
+        assert self.datalayer is not None
+        activity_id, activity_dict = (
+            self.trigger_activity_factory.invite_actor_to_case(
+                invitee_id=self.invitee_id,
+                case_id=self.case_id,
+                actor=actor_id,
+                to=[self.invitee_id],
+                cc=cc,
+                attributed_to=self.attributed_to,
+                roles=roles,
+                target=case if is_case_model(case) else None,
+            )
+        )
+        # CM-16-009/AC-7a: ledger commit before outbox write; disposition="rejected"
+        # bypasses canonical-payload validation (Invite is not a ledger event type).
+        commit_tree = create_commit_log_entry_tree(
+            case_id=self.case_id,
+            object_id=self.invitee_id,
+            event_type="invite_actor_to_case",
+            disposition="rejected",
+        )
+        result = BTBridge(
+            datalayer=cast(CaseOutboxPersistence, self.datalayer)
+        ).execute_with_setup(tree=commit_tree, actor_id=actor_id)
+        if result.status != Status.SUCCESS:
+            raise RuntimeError(
+                f"ledger correlation commit failed for "
+                f"invite_actor_to_case/{self.invitee_id}"
+            )
+        cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
+            actor_id, activity_id
+        )
+        return activity_id, activity_dict
+
     def update(self) -> Status:
         if self.datalayer is None or self.actor_id is None:
             self.feedback_message = "DataLayer or actor_id not available"
             return Status.FAILURE
-
-        factory = self.trigger_activity_factory
-        if factory is None:
+        if self.trigger_activity_factory is None:
             self.feedback_message = (
                 "trigger_activity_factory not in blackboard"
             )
             self.logger.error(self.feedback_message)
             return Status.FAILURE
 
-        # Add case_actor_id to cc: so ASGI self-delivery routes the Invite
-        # to the CaseActor's inbox for canonical ledger archival (CLP-10-001).
         cc = [self.case_actor_id] if self.case_actor_id else None
-
-        # CM-17-003: read intended roles for the invitee.
         roles = self._read_suggested_roles()
         if roles is not None and not roles:
             self.feedback_message = (
@@ -127,45 +163,10 @@ class EmitInviteActorToCaseNode(DataLayerAction):
             )
             self.logger.error(self.feedback_message)
             return Status.FAILURE
-
-        # CM-17-002: pass the full case object so the adapter+factory can
-        # project it to an enriched stub (with end_time) when em_state==ACTIVE.
         case = self.datalayer.read(self.case_id)
-
         try:
-            activity_id, activity_dict = factory.invite_actor_to_case(
-                invitee_id=self.invitee_id,
-                case_id=self.case_id,
-                actor=self.actor_id,
-                to=[self.invitee_id],
-                cc=cc,
-                attributed_to=self.attributed_to,
-                roles=roles,
-                target=case if is_case_model(case) else None,
-            )
-            # Commit a local correlation marker first so duplicate checks work
-            # on retry even if the outbox write below fails (CM-16-009/AC-7a).
-            # disposition="rejected" bypasses canonical-payload validation since
-            # Invite(Actor, Case) is not a canonical ledger event type.
-            commit_tree = create_commit_log_entry_tree(
-                case_id=self.case_id,
-                object_id=self.invitee_id,
-                event_type="invite_actor_to_case",
-                disposition="rejected",
-            )
-            result = BTBridge(
-                datalayer=cast(CaseOutboxPersistence, self.datalayer)
-            ).execute_with_setup(
-                tree=commit_tree,
-                actor_id=self.actor_id,
-            )
-            if result.status != Status.SUCCESS:
-                raise RuntimeError(
-                    f"ledger correlation commit failed for "
-                    f"invite_actor_to_case/{self.invitee_id}"
-                )
-            cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
-                self.actor_id, activity_id
+            activity_id, activity_dict = self._emit(
+                self.actor_id, cc, roles, case
             )
             if self._captured is not None:
                 self._captured["activity"] = activity_dict
@@ -176,7 +177,6 @@ class EmitInviteActorToCaseNode(DataLayerAction):
                 self.case_id,
             )
             return Status.SUCCESS
-
         except Exception as e:
             self.feedback_message = f"EmitInviteActorToCase failed: {e}"
             self.logger.error(self.feedback_message)
@@ -390,13 +390,24 @@ class ProposeCaseToActorNode(DataLayerAction):
             return raw
         return str(getattr(raw, "id_", raw))
 
+    def _emit(self, actor_id: str, report_id: str, case_actor_id: str) -> str:
+        assert self.trigger_activity_factory is not None
+        assert self.datalayer is not None
+        activity_id, _ = self.trigger_activity_factory.create_case_proposal(
+            actor=actor_id,
+            report_id=report_id,
+            case_actor_id=case_actor_id,
+        )
+        cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
+            actor_id, activity_id
+        )
+        return activity_id
+
     def update(self) -> Status:
         if self.datalayer is None or self.actor_id is None:
             self.feedback_message = "DataLayer or actor_id not available"
             return Status.FAILURE
-
-        factory = self.trigger_activity_factory
-        if factory is None:
+        if self.trigger_activity_factory is None:
             self.feedback_message = (
                 "trigger_activity_factory not in blackboard"
             )
@@ -413,19 +424,12 @@ class ProposeCaseToActorNode(DataLayerAction):
             return Status.FAILURE
 
         try:
-            activity_id, _ = factory.create_case_proposal(
-                actor=self.actor_id,
-                report_id=report_id,
-                case_actor_id=case_actor_id,
-            )
+            activity_id = self._emit(self.actor_id, report_id, case_actor_id)
         except Exception as exc:
             self.feedback_message = f"create_case_proposal failed: {exc}"
             self.logger.warning("%s: %s", self.name, self.feedback_message)
             return Status.FAILURE
 
-        cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
-            self.actor_id, activity_id
-        )
         self.logger.info(
             "%s: Queued Create(as_CaseProposal) '%s' to outbox"
             " for case-actor '%s' (case '%s')",

--- a/vultron/core/behaviors/case/nodes/delegation.py
+++ b/vultron/core/behaviors/case/nodes/delegation.py
@@ -116,13 +116,31 @@ class CreateOfferCaseManagerActivityNode(DataLayerAction):
             key="activity_id", access=py_trees.common.Access.WRITE
         )
 
+    def _emit(
+        self,
+        case_id: str,
+        case_actor_id: str,
+        participant_id: str,
+        recipients: list,
+    ) -> str:
+        """Call offer_case_manager_role factory and return the activity_id.
+
+        Raises on factory failure so update() can handle it.
+        """
+        assert self.trigger_activity_factory is not None
+        return self.trigger_activity_factory.offer_case_manager_role(
+            case_id=case_id,
+            participant_id=participant_id,
+            actor=case_actor_id,
+            to=recipients,
+        )
+
     def update(self) -> Status:
         if self.datalayer is None or self.actor_id is None:
             self.logger.error(
                 f"{self.name}: DataLayer or actor_id not available"
             )
             return Status.FAILURE
-
         if self.trigger_activity_factory is None:
             self.logger.error(
                 f"{self.name}: trigger_activity_factory not available"
@@ -147,13 +165,8 @@ class CreateOfferCaseManagerActivityNode(DataLayerAction):
             return Status.FAILURE
 
         try:
-            activity_id = (
-                self.trigger_activity_factory.offer_case_manager_role(
-                    case_id=case_id,
-                    participant_id=participant_id,
-                    actor=case_actor_id,
-                    to=recipients,
-                )
+            activity_id = self._emit(
+                case_id, case_actor_id, participant_id, recipients
             )
             self.blackboard.activity_id = activity_id
             if self._captured is not None:
@@ -176,7 +189,6 @@ class CreateOfferCaseManagerActivityNode(DataLayerAction):
                 case_id,
             )
             return Status.SUCCESS
-
         except Exception as e:
             self.logger.error(
                 f"{self.name}: Error sending Offer(CaseManagerRole): {e}"
@@ -224,13 +236,28 @@ class AutoAcceptCaseManagerRoleNode(DataLayerAction):
         self.participant_id = participant_id
         self.vendor_id = vendor_id
 
+    def _emit_accept(self, actor_id: str) -> str:
+        """Call accept_case_manager_role factory and return accept_id.
+
+        Step 1 only — does NOT write to outbox (intentional split; see update()).
+        Raises on failure so update() can return FAILURE before any outbox write.
+        """
+        assert self.trigger_activity_factory is not None
+        return self.trigger_activity_factory.accept_case_manager_role(
+            offer_id=self.offer_id,
+            case_id=self.case_id,
+            participant_id=self.participant_id,
+            vendor_id=self.vendor_id,
+            actor=actor_id,
+            to=[self.vendor_id],
+        )
+
     def update(self) -> Status:
         if self.datalayer is None or self.actor_id is None:
             self.logger.error(
                 "%s: DataLayer or actor_id not available", self.name
             )
             return Status.FAILURE
-
         if self.trigger_activity_factory is None:
             self.logger.warning(
                 "%s: trigger_activity_factory not available"
@@ -239,7 +266,6 @@ class AutoAcceptCaseManagerRoleNode(DataLayerAction):
                 self.offer_id,
             )
             return Status.FAILURE
-
         if not self.case_id or not self.participant_id:
             self.logger.warning(
                 "%s: missing case_id or participant_id for offer '%s'"
@@ -250,18 +276,9 @@ class AutoAcceptCaseManagerRoleNode(DataLayerAction):
             return Status.FAILURE
 
         # Step 1: create and persist the Accept activity.
-        # Nothing has been written yet; any exception here is safe to
-        # convert to FAILURE so the AcceptOrReject Selector can fall back
-        # to EmitRejectCaseManagerRoleNode.
+        # Exception → FAILURE so AcceptOrReject Selector can fall back to Reject.
         try:
-            accept_id = self.trigger_activity_factory.accept_case_manager_role(
-                offer_id=self.offer_id,
-                case_id=self.case_id,
-                participant_id=self.participant_id,
-                vendor_id=self.vendor_id,
-                actor=self.actor_id,
-                to=[self.vendor_id],
-            )
+            accept_id = self._emit_accept(self.actor_id)
         except Exception as exc:
             self.logger.error(
                 "%s: error creating Accept activity for offer '%s': %s",
@@ -271,17 +288,13 @@ class AutoAcceptCaseManagerRoleNode(DataLayerAction):
             )
             return Status.FAILURE
 
-        # Step 2: enqueue the Accept activity to the outbox.
-        # The Accept is now persisted in the DataLayer.  If outbox enqueue
-        # fails here, we MUST NOT return FAILURE — the AcceptOrReject
-        # Selector would then fall through to EmitRejectCaseManagerRoleNode,
+        # Step 2: enqueue Accept — MUST NOT return FAILURE here.
+        # Accept is persisted; if outbox enqueue fails, propagate the exception
+        # so BTBridge fails hard rather than falling through to Reject and
         # producing contradictory protocol state (Accept stored, Reject sent).
-        # Let the exception propagate so BTBridge fails the tree hard,
-        # preserving the persisted Accept without triggering a spurious Reject.
         cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
             self.actor_id, accept_id
         )
-
         self.logger.info(
             "%s: auto-accepted offer '%s' as actor '%s';"
             " queued Accept '%s' to outbox",
@@ -330,13 +343,27 @@ class EmitRejectCaseManagerRoleNode(DataLayerAction):
         self.participant_id = participant_id
         self.vendor_id = vendor_id
 
+    def _emit(self, actor_id: str) -> str:
+        """Call reject_case_manager_role factory and return reject_id.
+
+        Raises on failure so update() can handle it.
+        """
+        assert self.trigger_activity_factory is not None
+        return self.trigger_activity_factory.reject_case_manager_role(
+            offer_id=self.offer_id,
+            case_id=self.case_id,
+            participant_id=self.participant_id,
+            vendor_id=self.vendor_id,
+            actor=actor_id,
+            to=[self.vendor_id],
+        )
+
     def update(self) -> Status:
         if self.datalayer is None or self.actor_id is None:
             self.logger.error(
                 "%s: DataLayer or actor_id not available", self.name
             )
             return Status.FAILURE
-
         if self.trigger_activity_factory is None:
             self.logger.warning(
                 "%s: trigger_activity_factory not available"
@@ -345,7 +372,6 @@ class EmitRejectCaseManagerRoleNode(DataLayerAction):
                 self.offer_id,
             )
             return Status.FAILURE
-
         if not self.case_id or not self.participant_id:
             self.logger.warning(
                 "%s: missing case_id or participant_id for offer '%s'"
@@ -354,16 +380,8 @@ class EmitRejectCaseManagerRoleNode(DataLayerAction):
                 self.offer_id,
             )
             return Status.FAILURE
-
         try:
-            reject_id = self.trigger_activity_factory.reject_case_manager_role(
-                offer_id=self.offer_id,
-                case_id=self.case_id,
-                participant_id=self.participant_id,
-                vendor_id=self.vendor_id,
-                actor=self.actor_id,
-                to=[self.vendor_id],
-            )
+            reject_id = self._emit(self.actor_id)
             cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
                 self.actor_id, reject_id
             )

--- a/vultron/core/behaviors/embargo/nodes/lifecycle.py
+++ b/vultron/core/behaviors/embargo/nodes/lifecycle.py
@@ -275,6 +275,27 @@ class SendTerminateEmbargoActivityNode(DataLayerAction):
             access=py_trees.common.Access.READ,
         )
 
+    def _emit(
+        self, actor_id: str, embargo_id: str, case_manager_id: str
+    ) -> None:
+        """Call terminate_embargo factory and record outbox item.
+
+        Raises on any factory or outbox failure so update() can handle it.
+        """
+        assert self.trigger_activity_factory is not None
+        assert self.datalayer is not None
+        announce_id, _ = self.trigger_activity_factory.terminate_embargo(
+            embargo_id=embargo_id,
+            case_id=self._case_id,
+            actor=actor_id,
+            to=[case_manager_id],
+        )
+        add_activity_to_outbox(
+            actor_id,
+            announce_id,
+            self.datalayer,  # type: ignore[arg-type]
+        )
+
     def update(self) -> Status:
         if self.trigger_activity_factory is None:
             self.feedback_message = (
@@ -283,37 +304,23 @@ class SendTerminateEmbargoActivityNode(DataLayerAction):
             )
             self.logger.warning("%s: %s", self.name, self.feedback_message)
             return Status.FAILURE
-
         if self.datalayer is None or self.actor_id is None:
             self.feedback_message = "DataLayer or actor_id not available"
             return Status.FAILURE
-
         try:
             embargo_id: str = self.blackboard.embargo_id
             case_manager_id: str = self.blackboard.case_manager_id
         except KeyError as exc:
             self.feedback_message = f"Required blackboard key missing: {exc}"
             return Status.FAILURE
-
         try:
-            announce_id, _ = self.trigger_activity_factory.terminate_embargo(
-                embargo_id=embargo_id,
-                case_id=self._case_id,
-                actor=self.actor_id,
-                to=[case_manager_id],
-            )
-            add_activity_to_outbox(
-                self.actor_id,
-                announce_id,
-                self.datalayer,  # type: ignore[arg-type]
-            )
+            self._emit(self.actor_id, embargo_id, case_manager_id)
         except Exception as exc:
             self.feedback_message = (
                 f"activity dispatch failed for case '{self._case_id}': {exc}"
             )
             self.logger.warning("%s: %s", self.name, self.feedback_message)
             return Status.FAILURE
-
         return Status.SUCCESS
 
 

--- a/vultron/core/behaviors/note/nodes/creation.py
+++ b/vultron/core/behaviors/note/nodes/creation.py
@@ -43,32 +43,34 @@ class CreateNoteNode(DataLayerAction):
         self.result_out = result_out
         self.in_reply_to = in_reply_to
 
+    def _call_factory(self, actor_id: str) -> tuple[str, dict]:
+        """Call ``create_note`` on the trigger-activity factory."""
+        assert self.trigger_activity_factory is not None
+        return self.trigger_activity_factory.create_note(
+            name=self.note_name,
+            content=self.note_content,
+            context_id=self.case_id,
+            attributed_to=actor_id,
+            in_reply_to=self.in_reply_to,
+        )
+
     def update(self) -> Status:
         if self.datalayer is None:
             self.feedback_message = "DataLayer not available"
             self.logger.error(f"{self.name}: {self.feedback_message}")
             return Status.FAILURE
-
         if self.trigger_activity_factory is None:
             self.feedback_message = (
                 "trigger_activity_factory not available in blackboard"
             )
             self.logger.error(f"{self.name}: {self.feedback_message}")
             return Status.FAILURE
-
         if self.actor_id is None:
             self.feedback_message = "actor_id not available in blackboard"
             self.logger.error(f"{self.name}: {self.feedback_message}")
             return Status.FAILURE
-
         try:
-            note_id, note_dict = self.trigger_activity_factory.create_note(
-                name=self.note_name,
-                content=self.note_content,
-                context_id=self.case_id,
-                attributed_to=self.actor_id,
-                in_reply_to=self.in_reply_to,
-            )
+            note_id, note_dict = self._call_factory(self.actor_id)
             self.result_out["note_id"] = note_id
             self.result_out["note_dict"] = note_dict
             self.feedback_message = f"Created note '{note_id}'"

--- a/vultron/core/behaviors/report/nodes/emit.py
+++ b/vultron/core/behaviors/report/nodes/emit.py
@@ -285,27 +285,30 @@ class EmitSubmitReportActivity(DataLayerAction):
         self.recipient_id = recipient_id
         self._captured = captured
 
+    def _call_factory(self, actor_id: str) -> tuple[str, dict]:
+        """Call ``submit_report`` on the trigger-activity factory."""
+        assert self.trigger_activity_factory is not None
+        return self.trigger_activity_factory.submit_report(
+            report_id=self.report_id,
+            actor=actor_id,
+            to=self.recipient_id,
+            target=self.recipient_id,
+        )
+
     def update(self) -> Status:
         if self.datalayer is None or self.actor_id is None:
             self.logger.error(
                 "%s: DataLayer or actor_id not available", self.name
             )
             return Status.FAILURE
-
         if self.trigger_activity_factory is None:
             self.logger.warning(
                 "%s: no TriggerActivityPort — cannot emit SubmitReport offer",
                 self.name,
             )
             return Status.FAILURE
-
         try:
-            offer_id, offer_dict = self.trigger_activity_factory.submit_report(
-                report_id=self.report_id,
-                actor=self.actor_id,
-                to=self.recipient_id,
-                target=self.recipient_id,
-            )
+            offer_id, offer_dict = self._call_factory(self.actor_id)
             cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
                 self.actor_id, offer_id
             )
@@ -318,7 +321,6 @@ class EmitSubmitReportActivity(DataLayerAction):
                 self.recipient_id,
             )
             return Status.SUCCESS
-
         except Exception as e:
             self.logger.error(
                 "%s: Error emitting submit-report offer: %s", self.name, e

--- a/vultron/core/behaviors/status/nodes/lifecycle.py
+++ b/vultron/core/behaviors/status/nodes/lifecycle.py
@@ -21,7 +21,7 @@ all-participants-closed auto-close branch (step 5).
 
 import logging
 import threading
-from typing import Any
+from typing import Any, cast
 
 import py_trees
 from py_trees.common import Status
@@ -34,6 +34,7 @@ from vultron.core.models.protocols import (
     is_case_model,
     is_participant_model,
 )
+from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.states.rm import RM
 from vultron.enums.roles import CVDRole
 from vultron.core.use_cases._helpers import _as_id
@@ -234,6 +235,24 @@ class AutoCloseBranchNode(DataLayerAction):
                 return False
         return True
 
+    def _emit_close_case(self, actor_id: str, case_manager_id: str) -> str:
+        """Call close_case factory and record outbox item, return activity_id.
+
+        Raises on factory or outbox failure so update() can log and continue.
+        """
+        assert self.trigger_activity_factory is not None
+        assert self.datalayer is not None
+        assert self.case_id is not None
+        activity_id, _ = self.trigger_activity_factory.close_case(
+            case_id=self.case_id,
+            actor=actor_id,
+            to=[case_manager_id],
+        )
+        cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
+            actor_id, activity_id
+        )
+        return activity_id
+
     def update(self) -> Status:
         if self.datalayer is None or not self.case_id:
             return Status.SUCCESS
@@ -241,7 +260,6 @@ class AutoCloseBranchNode(DataLayerAction):
         case = self.datalayer.read(self.case_id)
         if not is_case_model(case):
             return Status.SUCCESS
-
         if not self._all_participants_closed(case):
             return Status.SUCCESS
 
@@ -271,7 +289,6 @@ class AutoCloseBranchNode(DataLayerAction):
             self.case_id,
             case_manager_id,
         )
-
         if self.trigger_activity_factory is None:
             self.logger.warning(
                 "AutoCloseBranch: no TriggerActivityPort — cannot emit"
@@ -281,19 +298,8 @@ class AutoCloseBranchNode(DataLayerAction):
             return Status.SUCCESS
 
         try:
-            activity_id, _ = self.trigger_activity_factory.close_case(
-                case_id=self.case_id,
-                actor=self.actor_id or "",
-                to=[case_manager_id],
-            )
-            from typing import cast as _cast
-
-            from vultron.core.ports.case_persistence import (
-                CaseOutboxPersistence,
-            )
-
-            _cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
-                self.actor_id or "", activity_id
+            activity_id = self._emit_close_case(
+                self.actor_id or "", case_manager_id
             )
             self.logger.info(
                 "AutoCloseBranch: emitted close_case activity '%s'"


### PR DESCRIPTION
## Summary

- Extracts inline factory calls from `update()` methods in 6 BT leaf node files into named helper methods (`_emit`, `_call_factory`, `_emit_accept`, `_emit_close_case`), reducing all `update()` bodies to ≤30 lines (BTND-07-003)
- Adds `EmitSubmitReportActivity._call_factory(actor_id)` pattern consistent with the `_EmitCaseActorReportActivityBase` hook (AC-3)
- Promotes `cast`/`CaseOutboxPersistence` imports to module level in `status/nodes/lifecycle.py`, removing inline imports

## Changes

| File | Helper added | AC |
|---|---|---|
| `report/nodes/emit.py` | `EmitSubmitReportActivity._call_factory(actor_id)` | AC-3 |
| `note/nodes/creation.py` | `CreateNoteNode._call_factory(actor_id)` | AC-2 |
| `embargo/nodes/lifecycle.py` | `SendTerminateEmbargoActivityNode._emit(actor_id, embargo_id, case_manager_id)` | AC-2 |
| `case/nodes/delegation.py` | `CreateOfferCaseManagerActivityNode._emit(...)`, `AutoAcceptCaseManagerRoleNode._emit_accept(actor_id)`, `EmitRejectCaseManagerRoleNode._emit(actor_id)` | AC-2 |
| `case/nodes/actor.py` | `EmitInviteActorToCaseNode._emit(...)`, `ProposeCaseToActorNode._emit(...)` | AC-2 |
| `status/nodes/lifecycle.py` | `AutoCloseBranchNode._emit_close_case(actor_id, case_manager_id)` | AC-2 |

**Note:** `AutoAcceptCaseManagerRoleNode._emit_accept()` contains only the factory call — the outbox write is deliberately kept in `update()` to preserve the safety invariant (Accept persisted + Reject suppressed). Same for `ProposeCaseToActorNode._emit()` — outbox write stays outside the try block to ensure a transient outbox failure propagates rather than silently returning FAILURE and risking a duplicate CaseProposal on retry.

**Follow-up:** #1492 — `EmitSubmitReportActivity` still extends `DataLayerAction` directly rather than `_EmitCaseActorReportActivityBase` (full AC-3 compliance requires extending the base, which differs in `__init__`, `addressees` handling, and `captured` support).

## Verification

- `uv run black` — clean (4 files reformatted)
- `uv run flake8` — clean
- `uv run mypy` — clean (0 issues across 6 files)
- `uv run pyright` — clean (0 errors)
- `uv run pytest test/` — 4943 passed, 0 failed
- `test_btnd07_structure.py::test_leaf_module_line_count` — all pass (actor.py trimmed to 499 lines)

Closes #1488

🤖 Generated with [Claude Code](https://claude.com/claude-code)