### PR TITLE
docs(#1426): annotate behavior logic docs with RMB/EMB/CSB spec IDs

### DIFF
--- a/docs/howto/process_implementation.md
+++ b/docs/howto/process_implementation.md
@@ -96,3 +96,40 @@ Some portions of this process can be automated:
 - IDS and IPS signatures might be deployed prior to fix availability to act as an early warning of adversary activity.
 
 - Well-known code publication and malware analysis platforms can be monitored for evidence of exploit publication or use.
+
+## Conformance Levels
+
+Independent implementors can achieve different levels of protocol conformance.
+The Vultron Protocol defines four levels, each building on the previous:
+
+**L1 — Syntax**
+: Well-formed messages that conform to the wire format.
+  This level is covered by the [wire format specifications](../reference/specs/language.md).
+
+**L2 — Semantic**
+: Correct state transitions in response to received messages and local events.
+  This level is covered by the [Vultron Protocol spec (VP)](../reference/specs/general.md) and the
+  [Transition Functions](../reference/formal_protocol/transitions.md).
+
+**L3 — Behavioral**
+: Correct observable outputs — the right messages emitted and the right states reached
+  in response to a given (input state + received message/event) combination.
+  This level is covered by the domain behavioral specifications:
+
+    - [RMB — Report Management Behavioral Requirements](../reference/specs/domain.md#rmb)
+    - [EMB — Embargo Management Behavioral Requirements](../reference/specs/domain.md#emb)
+    - [CSB — CVD Case State Behavioral Requirements](../reference/specs/domain.md#csb)
+
+**L4 — Process**
+: Correct internal decision structure — for example, precondition checks before state writes
+  before protocol effects, audit-log ordering, and idempotency guarantees.
+  This level is enforceable only through a reference implementation.
+  The `vultron/core/behaviors/` behavior tree layer in this repository provides the
+  reference implementation for L4.
+
+!!! tip "Start with L2"
+
+    Most implementations will naturally achieve L1 by using a compliant message serializer.
+    L2 conformance is the practical minimum for interoperability: a Participant that transitions
+    states correctly can exchange messages with any other L2-conformant Participant.
+    L3 adds observable-output guarantees that matter for multi-party coordination correctness.

--- a/docs/reference/formal_protocol/transitions.md
+++ b/docs/reference/formal_protocol/transitions.md
@@ -34,56 +34,56 @@ Because it only reflects an individual Participant's report handling status,
 the RM process operates largely independent of both the EM and CS processes.
 Otherwise,
 
-!!! note ""
+!!! note "[RMB-13](../../reference/specs/domain.md#rmb-13)"
 
     Participants MUST be in RM $Accepted$ to send a report ($RS$) to
     someone else.
 
-!!! note ""
+!!! note "[RMB-11](../../reference/specs/domain.md#rmb-11)"
 
     Participants SHOULD send $RI$ when the report validation process
     ends in an $invalid$ determination.
 
-!!! note ""
+!!! note "[RMB-10](../../reference/specs/domain.md#rmb-10)"
 
     Participants SHOULD send $RV$ when the report validation process
     ends in a $valid$ determination.
 
-!!! note ""
+!!! note "[RMB-12](../../reference/specs/domain.md#rmb-12)"
 
     Participants SHOULD send $RD$ when the report prioritization process
     ends in a $deferred$ decision.
 
-!!! note ""
+!!! note "[RMB-13](../../reference/specs/domain.md#rmb-13)"
 
     Participants SHOULD send $RA$ when the report prioritization process
     ends in an $accept$ decision.
 
-!!! note ""
+!!! note "[RMB-14](../../reference/specs/domain.md#rmb-14)"
 
     Participants SHOULD send $RC$ when the report is closed.
 
-!!! note ""
+!!! note "[RMB-07](../../reference/specs/domain.md#rmb-07)"
 
     Participants SHOULD send $RE$ regardless of the state when any error
     is encountered.
 
-!!! note ""
+!!! note "[RMB-14](../../reference/specs/domain.md#rmb-14)"
 
     Recipients MAY ignore messages received on $Closed$ cases.
 
-!!! note ""
-  
+!!! note "[RMB-08](../../reference/specs/domain.md#rmb-08)"
+
     Recipients SHOULD send $RK$ in acknowledgment of any $R*$ message
     except $RK$ itself.
 
-!!! note ""
+!!! note "[RMB-01](../../reference/specs/domain.md#rmb-01)"
 
     Vendor Recipients should send both $CV$ and $RK$ in response to a
     report submission ($RS$). If the report is new to the Vendor, it
     MUST transition $q^{cs} \xrightarrow{\mathbf{V}}Vfd\cdot\cdot\cdot$.
 
-!!! note ""
+!!! note "[RMB-02](../../reference/specs/domain.md#rmb-02) — [RMB-06](../../reference/specs/domain.md#rmb-06)"
 
     Any $R*$ message, aside from $RS$, received by recipient in
     $q^{rm} \in S$ is an error because it indicates the sender thought
@@ -91,7 +91,7 @@ Otherwise,
     Recipient SHOULD respond with both an $RE$ to signal the error and
     $GI$ to find out what the sender expected.
 
-!!! note ""
+!!! note "[RMB-07](../../reference/specs/domain.md#rmb-07)"
 
     Recipients SHOULD acknowledge $RE$ messages ($RK$) and inquire
     ($GI$) as to the nature of the error.
@@ -144,40 +144,40 @@ expected response message.
 The appropriate Participant behavior in the EM process depends on whether the case state
 $q^{cs}$ is in $\cdot\cdot\cdot pxa$ or not.
 
-!!! note ""
+!!! note "[EMB-01](../../reference/specs/domain.md#emb-01) — [EMB-02](../../reference/specs/domain.md#emb-02)"
 
     Participants SHALL NOT negotiate embargoes where the vulnerability
     or its exploit is public or attacks are known to have occurred.
 
-!!! note ""
+!!! note "[EMB-01](../../reference/specs/domain.md#emb-01)"
 
     Participants MAY begin embargo negotiations before sending the
     report itself in an $RS$ message. Therefore, it is *not* an error
     for an $E*$ message to arrive while the Recipient is unaware of the
     report ($q^{rm} \in S$).
 
-!!! note ""
+!!! note "[EMB-06](../../reference/specs/domain.md#emb-06)"
 
     Participants MAY reject any embargo proposals or revisions for any
     reason.
 
-!!! note ""
+!!! note "[EMB-13](../../reference/specs/domain.md#emb-13)"
 
     If information about the vulnerability or an exploit for it has been
     made public, Participants SHALL terminate the embargo
     ($q^{cs} \in \{\cdot\cdot\cdot P \cdot\cdot, \cdot\cdot\cdot\cdot X \cdot\}$).
 
-!!! note ""
+!!! note "[EMB-13](../../reference/specs/domain.md#emb-13)"
 
     If attacks are known to have occurred, Participants SHOULD terminate
     the embargo ($q^{cs} \in \cdot\cdot\cdot\cdot\cdot A$).
 
-!!! note ""
+!!! note "[EMB-01](../../reference/specs/domain.md#emb-01) — [EMB-07](../../reference/specs/domain.md#emb-07)"
 
     Participants SHOULD send $EK$ in acknowledgment of any other $E*$
     message except $EK$ itself.
 
-!!! note ""
+!!! note "[EMB-08](../../reference/specs/domain.md#emb-08)"
 
     Participants SHOULD acknowledge ($EK$) and inquire ($GI$) about the
     nature of any error reported by an incoming $EE$ message.
@@ -258,13 +258,13 @@ However, this is not the case for the remainder of the CS substates.
 As above, the appropriate Participant response to receiving CS messages (namely, those surrounding *Public Awareness*,
 *Exploit Public*, or *Attacks Observed*) depends on the state of the EM process.
 
-!!! note ""
+!!! note "[CSB-12](../../reference/specs/domain.md#csb-12) — [CSB-13](../../reference/specs/domain.md#csb-13)"
 
     Participants SHALL initiate embargo termination upon becoming aware
     of publicly available information about the vulnerability or its
     exploit code.
 
-!!! note ""
+!!! note "[CSB-14](../../reference/specs/domain.md#csb-14)"
 
     Participants SHOULD initiate embargo termination upon becoming aware
     of attacks against an otherwise unpublished vulnerability.

--- a/docs/topics/behavior_logic/cvd_bt.md
+++ b/docs/topics/behavior_logic/cvd_bt.md
@@ -1,5 +1,14 @@
 # CVD Behavior Tree
 
+## Related Requirements
+
+This top-level tree integrates all CVD behavioral requirements.
+See the [Domain Specifications](../../reference/specs/domain.md) for the full specification:
+
+- [RMB](../../reference/specs/domain.md#rmb) — Report Management behavioral requirements
+- [EMB](../../reference/specs/domain.md#emb) — Embargo Management behavioral requirements
+- [CSB](../../reference/specs/domain.md#csb) — Case State behavioral requirements
+
 We begin at the root node of the CVD Behavior Tree shown in the figure below.
 The root node is a simple loop that continues until an interrupt condition is met, representing the idea
 that the CVD practice is meant to be continuous. In other words, we are intentionally not specifying the interrupt condition.

--- a/docs/topics/behavior_logic/deployment_bt.md
+++ b/docs/topics/behavior_logic/deployment_bt.md
@@ -1,5 +1,18 @@
 # Deployment Behavior
 
+## Requirements
+
+The behavioral requirements for this tree are specified in the
+[Domain Specifications](../../reference/specs/domain.md):
+
+- [CSB-11](../../reference/specs/domain.md#csb-11) — Enter CS D (Fix Deployed)
+
+!!! note "Implementation approach"
+
+    The behavior tree diagram below illustrates one conformant implementation of these requirements.
+    Implementations are not required to use behavior trees — any approach that satisfies the
+    requirements above is conformant.
+
 The Deployment Behavior Tree is shown in the figure below.
 The goal of this behavior is either for (A) the case to reach the $q^{cs} \in D$ state or (B) for the Participant to be
 comfortable with remaining in a *Deferred* deployment state.

--- a/docs/topics/behavior_logic/do_work_bt.md
+++ b/docs/topics/behavior_logic/do_work_bt.md
@@ -1,5 +1,14 @@
 # Do Work Behavior Tree
 
+## Related Requirements
+
+This orchestrating node coordinates multiple CVD work streams, each of which has its own behavioral requirements.
+See the [Domain Specifications](../../reference/specs/domain.md) for the full specification:
+
+- [RMB](../../reference/specs/domain.md#rmb) — Report Management behavioral requirements
+- [EMB](../../reference/specs/domain.md#emb) — Embargo Management behavioral requirements
+- [CSB](../../reference/specs/domain.md#csb) — Case State behavioral requirements
+
 Although it is not directly addressed by the [formal Vultron Protocol](../../reference/formal_protocol/index.md), the *do work* node
 of the [RM Behavior Tree](rm_bt.md) is where much of the CVD effort happens.
 As a result, it is worth spending some time reviewing what some of the underlying work actually entails.

--- a/docs/topics/behavior_logic/em_bt.md
+++ b/docs/topics/behavior_logic/em_bt.md
@@ -1,5 +1,21 @@
 # Embargo Management Behavior Tree
 
+## Requirements
+
+The behavioral requirements for this tree are specified in the
+[Domain Specifications](../../reference/specs/domain.md):
+
+- [EMB-10](../../reference/specs/domain.md#emb-10) — Enter EM Proposed
+- [EMB-11](../../reference/specs/domain.md#emb-11) — Enter EM Active
+- [EMB-12](../../reference/specs/domain.md#emb-12) — Enter EM Revise
+- [EMB-13](../../reference/specs/domain.md#emb-13) — Enter EM Exited
+
+!!! note "Implementation approach"
+
+    The behavior tree diagram below illustrates one conformant implementation of these requirements.
+    Implementations are not required to use behavior trees — any approach that satisfies the
+    requirements above is conformant.
+
 The Embargo Management Behavior Tree is shown in the figure below.
 It follows the state transition function in the
 [Embargo Management Process Model](../process_models/em/index.md#em-state-transitions).

--- a/docs/topics/behavior_logic/em_eval_bt.md
+++ b/docs/topics/behavior_logic/em_eval_bt.md
@@ -1,5 +1,18 @@
 # Evaluate Proposed Embargo Behavior
 
+## Requirements
+
+The behavioral requirements for this tree are specified in the
+[Domain Specifications](../../reference/specs/domain.md):
+
+- [EMB-11](../../reference/specs/domain.md#emb-11) — Enter EM Active
+
+!!! note "Implementation approach"
+
+    The behavior tree diagram below illustrates one conformant implementation of these requirements.
+    Implementations are not required to use behavior trees — any approach that satisfies the
+    requirements above is conformant.
+
 The acceptance or counterproposal of an embargo is handled by the Evaluate Proposed Embargo Behavior Tree shown in the
 figure below.
 

--- a/docs/topics/behavior_logic/em_propose_bt.md
+++ b/docs/topics/behavior_logic/em_propose_bt.md
@@ -1,5 +1,19 @@
 # Propose Embargo Behavior
 
+## Requirements
+
+The behavioral requirements for this tree are specified in the
+[Domain Specifications](../../reference/specs/domain.md):
+
+- [EMB-10](../../reference/specs/domain.md#emb-10) — Enter EM Proposed
+- [EMB-12](../../reference/specs/domain.md#emb-12) — Enter EM Revise
+
+!!! note "Implementation approach"
+
+    The behavior tree diagram below illustrates one conformant implementation of these requirements.
+    Implementations are not required to use behavior trees — any approach that satisfies the
+    requirements above is conformant.
+
 The Propose Embargo Behavior Tree is shown in the figure below.
 
 ```mermaid

--- a/docs/topics/behavior_logic/em_terminate_bt.md
+++ b/docs/topics/behavior_logic/em_terminate_bt.md
@@ -1,5 +1,18 @@
 # Terminate Embargo Behavior
 
+## Requirements
+
+The behavioral requirements for this tree are specified in the
+[Domain Specifications](../../reference/specs/domain.md):
+
+- [EMB-13](../../reference/specs/domain.md#emb-13) — Enter EM Exited
+
+!!! note "Implementation approach"
+
+    The behavior tree diagram below illustrates one conformant implementation of these requirements.
+    Implementations are not required to use behavior trees — any approach that satisfies the
+    requirements above is conformant.
+
 The Terminate Embargo Behavior Tree is shown in the diagram below.
 It consists of two major behaviors depending on whether an embargo has been established or not.
 

--- a/docs/topics/behavior_logic/fix_dev_bt.md
+++ b/docs/topics/behavior_logic/fix_dev_bt.md
@@ -1,5 +1,19 @@
 # Fix Development Behavior
 
+## Requirements
+
+The behavioral requirements for this tree are specified in the
+[Domain Specifications](../../reference/specs/domain.md):
+
+- [CSB-09](../../reference/specs/domain.md#csb-09) — Enter CS V (Vendor Aware)
+- [CSB-10](../../reference/specs/domain.md#csb-10) — Enter CS F (Fix Ready)
+
+!!! note "Implementation approach"
+
+    The behavior tree diagram below illustrates one conformant implementation of these requirements.
+    Implementations are not required to use behavior trees — any approach that satisfies the
+    requirements above is conformant.
+
 The Fix Development Behavior Tree is shown below.
 
 ```mermaid

--- a/docs/topics/behavior_logic/index.md
+++ b/docs/topics/behavior_logic/index.md
@@ -1,5 +1,18 @@
 # Modeling an MPCVD AI Using Behavior Trees
 
+!!! info "Normative requirements for the behaviors described here"
+
+    The machine-readable behavioral conformance requirements underlying the trees in this section
+    are located in the [Domain Specifications](../../reference/specs/domain.md):
+
+    - [RMB — Report Management Behavioral Requirements](../../reference/specs/domain.md#rmb)
+    - [EMB — Embargo Management Behavioral Requirements](../../reference/specs/domain.md#emb)
+    - [CSB — CVD Case State Behavioral Requirements](../../reference/specs/domain.md#csb)
+
+    Each page in this section lists the relevant spec group IDs in its **Requirements** section.
+    The behavior tree diagrams illustrate one conformant implementation; implementations are not
+    required to use behavior trees.
+
 With the formal definition of the Vultron Protocol behind us, we now turn our
 attention to reflect on one of many possible paths toward
 implementation. We find that Behavior Trees have a number of desirable

--- a/docs/topics/behavior_logic/monitor_threats_bt.md
+++ b/docs/topics/behavior_logic/monitor_threats_bt.md
@@ -1,5 +1,20 @@
 # Monitor Threats Behavior Tree
 
+## Requirements
+
+The behavioral requirements for this tree are specified in the
+[Domain Specifications](../../reference/specs/domain.md):
+
+- [CSB-12](../../reference/specs/domain.md#csb-12) — Enter CS P (Public Aware)
+- [CSB-13](../../reference/specs/domain.md#csb-13) — Enter CS X (Exploit Public)
+- [CSB-14](../../reference/specs/domain.md#csb-14) — Enter CS A (Attacks Observed)
+
+!!! note "Implementation approach"
+
+    The behavior tree diagram below illustrates one conformant implementation of these requirements.
+    Implementations are not required to use behavior trees — any approach that satisfies the
+    requirements above is conformant.
+
 The Monitor Threats Behavior Tree is shown below.
 
 ```mermaid

--- a/docs/topics/behavior_logic/msg_cs_bt.md
+++ b/docs/topics/behavior_logic/msg_cs_bt.md
@@ -1,5 +1,25 @@
 # Process CS Messages Behavior
 
+## Requirements
+
+The behavioral requirements for this tree are specified in the
+[Domain Specifications](../../reference/specs/domain.md):
+
+- [CSB-01](../../reference/specs/domain.md#csb-01) — Receive CV (Vendor Aware)
+- [CSB-02](../../reference/specs/domain.md#csb-02) — Receive CF (Fix Ready)
+- [CSB-03](../../reference/specs/domain.md#csb-03) — Receive CD (Fix Deployed)
+- [CSB-04](../../reference/specs/domain.md#csb-04) — Receive CP (Public Aware)
+- [CSB-05](../../reference/specs/domain.md#csb-05) — Receive CX (Exploit Public)
+- [CSB-06](../../reference/specs/domain.md#csb-06) — Receive CA (Attacks Observed)
+- [CSB-07](../../reference/specs/domain.md#csb-07) — Receive CE (CS Error)
+- [CSB-08](../../reference/specs/domain.md#csb-08) — Receive CK (CS Acknowledgment)
+
+!!! note "Implementation approach"
+
+    The behavior tree diagram below illustrates one conformant implementation of these requirements.
+    Implementations are not required to use behavior trees — any approach that satisfies the
+    requirements above is conformant.
+
 The Process CS Messages Behavior Tree is shown below.
 
 ```mermaid

--- a/docs/topics/behavior_logic/msg_em_bt.md
+++ b/docs/topics/behavior_logic/msg_em_bt.md
@@ -1,5 +1,26 @@
 # Process EM Messages Behavior
 
+## Requirements
+
+The behavioral requirements for this tree are specified in the
+[Domain Specifications](../../reference/specs/domain.md):
+
+- [EMB-01](../../reference/specs/domain.md#emb-01) — Receive EP (Embargo Proposed)
+- [EMB-02](../../reference/specs/domain.md#emb-02) — Receive EA (Embargo Accepted)
+- [EMB-03](../../reference/specs/domain.md#emb-03) — Receive EV (Embargo Revision Proposed)
+- [EMB-04](../../reference/specs/domain.md#emb-04) — Receive EJ (Embargo Revision Rejected)
+- [EMB-05](../../reference/specs/domain.md#emb-05) — Receive EC (Embargo Revision Accepted)
+- [EMB-06](../../reference/specs/domain.md#emb-06) — Receive ER (Embargo Rejected)
+- [EMB-07](../../reference/specs/domain.md#emb-07) — Receive ET (Embargo Terminated)
+- [EMB-08](../../reference/specs/domain.md#emb-08) — Receive EE (Embargo Error)
+- [EMB-09](../../reference/specs/domain.md#emb-09) — Receive EK (Embargo Acknowledgment)
+
+!!! note "Implementation approach"
+
+    The behavior tree diagram below illustrates one conformant implementation of these requirements.
+    Implementations are not required to use behavior trees — any approach that satisfies the
+    requirements above is conformant.
+
 The Process EM Messages Behavior Tree is shown below.
 
 ```mermaid

--- a/docs/topics/behavior_logic/msg_intro_bt.md
+++ b/docs/topics/behavior_logic/msg_intro_bt.md
@@ -1,5 +1,50 @@
 # Receiving and Processing Messages Behavior
 
+## Requirements
+
+The behavioral requirements for the message-receive behaviors are specified in the
+[Domain Specifications](../../reference/specs/domain.md):
+
+**Report Management Messages** ([RMB](../../reference/specs/domain.md#rmb)):
+
+- [RMB-01](../../reference/specs/domain.md#rmb-01) — Receive RS (Report Submission)
+- [RMB-02](../../reference/specs/domain.md#rmb-02) — Receive RI (Report Invalid)
+- [RMB-03](../../reference/specs/domain.md#rmb-03) — Receive RV (Report Valid)
+- [RMB-04](../../reference/specs/domain.md#rmb-04) — Receive RD (Report Deferred)
+- [RMB-05](../../reference/specs/domain.md#rmb-05) — Receive RA (Report Accepted)
+- [RMB-06](../../reference/specs/domain.md#rmb-06) — Receive RC (Report Closed)
+- [RMB-07](../../reference/specs/domain.md#rmb-07) — Receive RE (Report Error)
+- [RMB-08](../../reference/specs/domain.md#rmb-08) — Receive RK (Report Acknowledgment)
+
+**Embargo Management Messages** ([EMB](../../reference/specs/domain.md#emb)):
+
+- [EMB-01](../../reference/specs/domain.md#emb-01) — Receive EP (Embargo Proposed)
+- [EMB-02](../../reference/specs/domain.md#emb-02) — Receive EA (Embargo Accepted)
+- [EMB-03](../../reference/specs/domain.md#emb-03) — Receive EV (Embargo Revision Proposed)
+- [EMB-04](../../reference/specs/domain.md#emb-04) — Receive EJ (Embargo Revision Rejected)
+- [EMB-05](../../reference/specs/domain.md#emb-05) — Receive EC (Embargo Revision Accepted)
+- [EMB-06](../../reference/specs/domain.md#emb-06) — Receive ER (Embargo Rejected)
+- [EMB-07](../../reference/specs/domain.md#emb-07) — Receive ET (Embargo Terminated)
+- [EMB-08](../../reference/specs/domain.md#emb-08) — Receive EE (Embargo Error)
+- [EMB-09](../../reference/specs/domain.md#emb-09) — Receive EK (Embargo Acknowledgment)
+
+**Case State Messages** ([CSB](../../reference/specs/domain.md#csb)):
+
+- [CSB-01](../../reference/specs/domain.md#csb-01) — Receive CV (Vendor Aware)
+- [CSB-02](../../reference/specs/domain.md#csb-02) — Receive CF (Fix Ready)
+- [CSB-03](../../reference/specs/domain.md#csb-03) — Receive CD (Fix Deployed)
+- [CSB-04](../../reference/specs/domain.md#csb-04) — Receive CP (Public Aware)
+- [CSB-05](../../reference/specs/domain.md#csb-05) — Receive CX (Exploit Public)
+- [CSB-06](../../reference/specs/domain.md#csb-06) — Receive CA (Attacks Observed)
+- [CSB-07](../../reference/specs/domain.md#csb-07) — Receive CE (CS Error)
+- [CSB-08](../../reference/specs/domain.md#csb-08) — Receive CK (CS Acknowledgment)
+
+!!! note "Implementation approach"
+
+    The behavior tree diagram below illustrates one conformant implementation of these requirements.
+    Implementations are not required to use behavior trees — any approach that satisfies the
+    requirements above is conformant.
+
 Now we return to the [CVD Behavior Tree](cvd_bt.md) to pick up the last unexplored branch, Receive Messages.
 The Receive Messages Behavior Tree is shown below.
 

--- a/docs/topics/behavior_logic/msg_rm_bt.md
+++ b/docs/topics/behavior_logic/msg_rm_bt.md
@@ -1,5 +1,25 @@
 # Process RM Messages Behavior
 
+## Requirements
+
+The behavioral requirements for this tree are specified in the
+[Domain Specifications](../../reference/specs/domain.md):
+
+- [RMB-01](../../reference/specs/domain.md#rmb-01) — Receive RS (Report Submission)
+- [RMB-02](../../reference/specs/domain.md#rmb-02) — Receive RI (Report Invalid)
+- [RMB-03](../../reference/specs/domain.md#rmb-03) — Receive RV (Report Valid)
+- [RMB-04](../../reference/specs/domain.md#rmb-04) — Receive RD (Report Deferred)
+- [RMB-05](../../reference/specs/domain.md#rmb-05) — Receive RA (Report Accepted)
+- [RMB-06](../../reference/specs/domain.md#rmb-06) — Receive RC (Report Closed)
+- [RMB-07](../../reference/specs/domain.md#rmb-07) — Receive RE (Report Error)
+- [RMB-08](../../reference/specs/domain.md#rmb-08) — Receive RK (Report Acknowledgment)
+
+!!! note "Implementation approach"
+
+    The behavior tree diagram below illustrates one conformant implementation of these requirements.
+    Implementations are not required to use behavior trees — any approach that satisfies the
+    requirements above is conformant.
+
 The Process RM Messages Behavior Tree is shown below.
 
 ```mermaid

--- a/docs/topics/behavior_logic/publication_bt.md
+++ b/docs/topics/behavior_logic/publication_bt.md
@@ -1,5 +1,18 @@
 # Publication Behavior
 
+## Requirements
+
+The behavioral requirements for this tree are specified in the
+[Domain Specifications](../../reference/specs/domain.md):
+
+- [CSB-12](../../reference/specs/domain.md#csb-12) — Enter CS P (Public Aware)
+
+!!! note "Implementation approach"
+
+    The behavior tree diagram below illustrates one conformant implementation of these requirements.
+    Implementations are not required to use behavior trees — any approach that satisfies the
+    requirements above is conformant.
+
 The Publication Behavior Tree is shown in the following diagram.
 (A) It begins by ensuring that the Participant knows what they intend to publish (A1), followed by a check to
 see if that publication has been achieved (A2).

--- a/docs/topics/behavior_logic/reporting_bt.md
+++ b/docs/topics/behavior_logic/reporting_bt.md
@@ -1,5 +1,15 @@
 # Reporting Behavior
 
+## Related Requirements
+
+This tree covers the report-sending (initiator) side of the RM process.
+Behavioral requirements for receiving RM messages are specified in the
+[Domain Specifications](../../reference/specs/domain.md):
+
+- [RMB-01](../../reference/specs/domain.md#rmb-01) — Receive RS (Report Submission) — what the recipient does when this tree sends a report
+
+See the full [RMB](../../reference/specs/domain.md#rmb) section for all RM behavioral requirements.
+
 The [*CERT Guide to Coordinated Vulnerability Disclosure*](https://certcc.github.io/CERT-Guide-to-CVD){:target="_blank"}
 describes the reporting phase as the process of identifying parties that need to be informed about the vulnerability
 and then notifying them.

--- a/docs/topics/behavior_logic/rm_bt.md
+++ b/docs/topics/behavior_logic/rm_bt.md
@@ -1,5 +1,23 @@
 # Report Management Behavior Tree
 
+## Requirements
+
+The behavioral requirements for this tree are specified in the
+[Domain Specifications](../../reference/specs/domain.md):
+
+- [RMB-09](../../reference/specs/domain.md#rmb-09) — Enter RM Received
+- [RMB-10](../../reference/specs/domain.md#rmb-10) — Enter RM Valid
+- [RMB-11](../../reference/specs/domain.md#rmb-11) — Enter RM Invalid
+- [RMB-12](../../reference/specs/domain.md#rmb-12) — Enter RM Deferred
+- [RMB-13](../../reference/specs/domain.md#rmb-13) — Enter RM Accepted
+- [RMB-14](../../reference/specs/domain.md#rmb-14) — Enter RM Closed
+
+!!! note "Implementation approach"
+
+    The behavior tree diagram below illustrates one conformant implementation of these requirements.
+    Implementations are not required to use behavior trees — any approach that satisfies the
+    requirements above is conformant.
+
 A Behavior Tree for the Report Management model is shown in the figure below.
 The Report Management process is represented by a Fallback node. Note
 that we assume that completing the process will require multiple *ticks*

--- a/docs/topics/behavior_logic/rm_closure_bt.md
+++ b/docs/topics/behavior_logic/rm_closure_bt.md
@@ -1,5 +1,18 @@
 # Report Closure Behavior
 
+## Requirements
+
+The behavioral requirements for this tree are specified in the
+[Domain Specifications](../../reference/specs/domain.md):
+
+- [RMB-14](../../reference/specs/domain.md#rmb-14) — Enter RM Closed
+
+!!! note "Implementation approach"
+
+    The behavior tree diagram below illustrates one conformant implementation of these requirements.
+    Implementations are not required to use behavior trees — any approach that satisfies the
+    requirements above is conformant.
+
 The Report Closure Behavior Tree is shown below.
 As usual, the post-condition is checked before proceeding.
 (A) If the case is already *Closed* ($q^{rm} \in C$), we're done.

--- a/docs/topics/behavior_logic/rm_prioritization_bt.md
+++ b/docs/topics/behavior_logic/rm_prioritization_bt.md
@@ -1,5 +1,19 @@
 # Report Prioritization Behavior
 
+## Requirements
+
+The behavioral requirements for this tree are specified in the
+[Domain Specifications](../../reference/specs/domain.md):
+
+- [RMB-12](../../reference/specs/domain.md#rmb-12) — Enter RM Deferred
+- [RMB-13](../../reference/specs/domain.md#rmb-13) — Enter RM Accepted
+
+!!! note "Implementation approach"
+
+    The behavior tree diagram below illustrates one conformant implementation of these requirements.
+    Implementations are not required to use behavior trees — any approach that satisfies the
+    requirements above is conformant.
+
 The Report Prioritization Behavior Tree is shown in the figure below.
 It bears some structural similarity to the Report Validation Behavior Tree just described: An initial
 post-condition check (A) falls back to the main process (B) leading toward

--- a/docs/topics/behavior_logic/rm_validation_bt.md
+++ b/docs/topics/behavior_logic/rm_validation_bt.md
@@ -1,5 +1,19 @@
 # Report Validation Behavior
 
+## Requirements
+
+The behavioral requirements for this tree are specified in the
+[Domain Specifications](../../reference/specs/domain.md):
+
+- [RMB-10](../../reference/specs/domain.md#rmb-10) — Enter RM Valid
+- [RMB-11](../../reference/specs/domain.md#rmb-11) — Enter RM Invalid
+
+!!! note "Implementation approach"
+
+    The behavior tree diagram below illustrates one conformant implementation of these requirements.
+    Implementations are not required to use behavior trees — any approach that satisfies the
+    requirements above is conformant.
+
 A Report Validation Behavior Tree is shown in the next figure. To begin with (A), if the report is already
 *Valid*, no further action is needed from this behavior.
 

--- a/docs/topics/behavior_logic/vuldisco_bt.md
+++ b/docs/topics/behavior_logic/vuldisco_bt.md
@@ -1,5 +1,18 @@
 # Vulnerability Discovery Behavior
 
+## Requirements
+
+The behavioral requirements for this tree are specified in the
+[Domain Specifications](../../reference/specs/domain.md):
+
+- [CSB-09](../../reference/specs/domain.md#csb-09) — Enter CS V (Vendor Aware)
+
+!!! note "Implementation approach"
+
+    The behavior tree diagram below illustrates one conformant implementation of these requirements.
+    Implementations are not required to use behavior trees — any approach that satisfies the
+    requirements above is conformant.
+
 CVD is built on the idea that vulnerabilities exist to be found. There are two ways for a CVD Participant to
 find out about a vulnerability. Either they discover it themselves, or they hear about it from someone else.
 The discovery behavior is modeled by the Discover Vulnerability Behavior Tree shown in the figure below.

--- a/plan/history/2607/implementation/ISSUE-1426.md
+++ b/plan/history/2607/implementation/ISSUE-1426.md
@@ -1,0 +1,10 @@
+---
+source: ISSUE-1426
+timestamp: '2026-07-17T18:19:36.483623+00:00'
+title: annotate behavior logic docs with RMB/EMB/CSB spec IDs
+type: implementation
+---
+
+## Issue #1426 — docs: annotate behavior logic docs with RMB/EMB/CSB spec IDs
+
+Annotated 20 `docs/topics/behavior_logic/` pages with Requirements sections listing the relevant RMB/EMB/CSB behavioral conformance spec group IDs. Added implementation-approach admonitions demoting BT diagrams to one conformant approach. Updated `transitions.md` normative note blocks with inline spec ID citations. Added Conformance Levels section (L1–L4) to `process_implementation.md`. PR: <https://github.com/CERTCC/Vultron/pull/1494>


### PR DESCRIPTION
- Closes #1426

## Summary

Annotates 20 `docs/topics/behavior_logic/` pages with `## Requirements` sections listing the
RMB/EMB/CSB behavioral conformance spec group IDs governing each behavior tree. Demotes BT
diagrams to "implementation approach" sidebars clarifying they illustrate one conformant
approach (not a requirement). Adds inline spec ID citations to `transitions.md` normative
note blocks. Adds `## Conformance Levels` section (L1–L4) to `process_implementation.md`.

## Changes

### `docs/topics/behavior_logic/`

- `index.md`: added `!!! info` block linking to RMB, EMB, CSB spec sections
- 16 files with direct spec groups: added `## Requirements` section +
  implementation-approach admonition (RMB groups → RM docs, EMB groups → EM docs,
  CSB groups → CS docs)
- 3 files with no direct spec groups (`cvd_bt`, `do_work_bt`, `reporting_bt`): added
  `## Related Requirements` pointing to spec sections
- `id_assignment_bt.md`, `acquire_exploit_bt.md`, `msg_other_bt.md`: no applicable
  RMB/EMB/CSB spec groups; left unchanged

### `docs/reference/formal_protocol/transitions.md`

- Replaced 14 empty `!!! note ""` blocks with labelled notes citing the relevant
  RMB/EMB/CSB group IDs

### `docs/howto/process_implementation.md`

- Added `## Conformance Levels` section explaining L1 (Syntax), L2 (Semantic),
  L3 (Behavioral — RMB/EMB/CSB), L4 (Process/reference-impl only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)