### PR TITLE
docs(#1488): BTND-07-005 — DRY BT guard boilerplate reuse requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -402,6 +402,16 @@ Short entries are reproduced here; longer ones are referenced below.
   simple leaf nodes; the tree structure becomes the workflow documentation.
   See [notes/bt-integration.md](notes/bt-integration.md)
   § "DO NOT: God BT nodes with long `update()` methods".
+- **BT Emit Nodes: Inherit Base Classes, Never Reimplement Guard Boilerplate**
+  — Before writing `if self.datalayer is None`, `if self.actor_id is None`, or
+  `if self.trigger_activity_factory is None` in a new BT node's `update()`,
+  check whether a base class already handles these guards. `DataLayerAction`
+  provides `self.datalayer`, `self.actor_id`, and `self.trigger_activity_factory`
+  resolution. Emit nodes that route report-phase activities through the CaseActor
+  SHOULD inherit from `_EmitCaseActorReportActivityBase` and override only
+  `_call_factory()`. Reimplementing this boilerplate per-class is the root cause
+  of god-node `update()` methods: each copy accumulates independently and must be
+  fixed separately. See `specs/behavior-tree-node-design.yaml` BTND-07-005.
 - **Flat `nodes.py` in BT Areas Is Non-Compliant** — BT-bearing process
   areas under `vultron/core/behaviors/` MUST use a `nodes/` subpackage for
   leaf nodes and MUST keep tree composition in root `*_tree.py` modules.

--- a/plan/history/2607/learning/CONCERN-1488.md
+++ b/plan/history/2607/learning/CONCERN-1488.md
@@ -1,0 +1,55 @@
+---
+source: CONCERN-1488
+timestamp: '2026-07-17T18:56:00.086972+00:00'
+title: inline factory calls in update() methods exceed BTND-07-003 god-node limit
+type: learning
+---
+
+## Concern
+
+During the review of PR #1481 (split `suggest_actor_tree.py`), god-node decomposition was applied to `emit.py`'s four `update()` methods. The `_emit()` helper pattern used there has broad applicability: at least 9 other `update()` methods across 5 files follow the same inline factory call pattern and several already exceed the ~20–30 line BTND-07-003 limit.
+
+## Affected files and approximate update() line counts
+
+| File | Class | Lines |
+|---|---|---|
+| `case/nodes/actor.py` | `EmitInviteActorToCaseNode` | ~80 |
+| `status/nodes/lifecycle.py` | `AutoCloseBranchNode` | ~73 |
+| `case/nodes/delegation.py` | `AutoAcceptCaseManagerRoleNode` | ~67 |
+| `case/nodes/delegation.py` | `CreateOfferCaseManagerActivityNode` | ~66 |
+| `case/nodes/delegation.py` | `EmitRejectCaseManagerRoleNode` | ~54 |
+| `case/nodes/actor.py` | `ProposeCaseToActorNode` | ~45 |
+| `embargo/nodes/lifecycle.py` | `SendTerminateEmbargoActivityNode` | ~40 |
+| `report/nodes/emit.py` | `EmitSubmitReportActivity` | ~39 |
+| `note/nodes/creation.py` | `CreateNoteNode` | ~35 |
+
+## Pattern
+
+Each `update()` method assigns `factory = self.trigger_activity_factory`, then
+calls `factory.some_method(...)` inline along with pre/post-condition logic,
+logging, and outbox writes. The fix is mechanical: extract the factory call into
+`_emit()` (or `_build_*()` for content construction) so `update()` only
+orchestrates.
+
+`report/nodes/emit.py` already has a good model: a `_call_factory()` hook in a
+base class that subclasses override. `EmitSubmitReportActivity` is the one
+outlier that missed that pattern.
+
+## Root cause
+
+Both: no generalized base class existed AND code was copied from early procedural
+implementations. The `_EmitCaseActorReportActivityBase` pattern existed only in
+`report/nodes/emit.py` and was never generalized or documented as the expected
+approach for all emit nodes.
+
+## Spec/notes gaps identified
+
+- `BTND-07-005` added to `specs/behavior-tree-node-design.yaml`: MUST search for
+  existing base classes before reimplementing guard/factory boilerplate.
+- AGENTS.md pitfall added: "BT Emit Nodes: Inherit Base Classes, Never Reimplement
+  Guard Boilerplate" — names `DataLayerAction` and `_EmitCaseActorReportActivityBase`
+  explicitly.
+
+**Resolved**: 2026-07-17 — implementation tracked in #1499.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1498>.
+Spec: `specs/behavior-tree-node-design.yaml` BTND-07-005.

--- a/specs/behavior-tree-node-design.yaml
+++ b/specs/behavior-tree-node-design.yaml
@@ -456,6 +456,35 @@ groups:
     verification: >-
       For each BT-bearing area, scan `nodes/` modules and fail compliance when any leaf
       module exceeds 500 lines.
+  - id: BTND-07-005
+    priority: MUST
+    statement: >-
+      Before implementing guard, validation, or factory-call boilerplate in a new BT
+      leaf node's `update()` method, the implementer MUST search `vultron/core/behaviors/`
+      for an existing base class or helper that already provides that boilerplate and
+      inherit or reuse it. In particular: (1) `DataLayerAction` already provides
+      `self.datalayer`, `self.actor_id`, and `self.trigger_activity_factory`
+      resolution — do not re-implement these lookups inline; (2) existing emit-node
+      base classes (e.g., `_EmitCaseActorReportActivityBase`) already implement the
+      standard guard + factory-dispatch + outbox-write pattern — subclass them and
+      override `_call_factory()` rather than writing a new `update()` from scratch;
+      (3) if no suitable base class exists, extract the shared pattern into one and
+      document it for future reuse.
+    rationale: >-
+      The most common cause of god-node `update()` methods is copy-paste of guard and
+      factory-call boilerplate from prior nodes. Each copy drifts independently,
+      accumulates line count, and must be fixed separately. A shared base class keeps
+      `update()` methods to a single try-block orchestration with all logic in
+      overridable hooks, satisfying BTND-07-003 and the DRY principle simultaneously.
+    relationships:
+    - rel_type: refines
+      spec_id: BTND-07-003
+    verification: >-
+      When reviewing a new or modified BT leaf node, confirm that its `update()` method
+      does not re-implement boilerplate already available in a parent class or shared
+      helper. Flag any inline `if self.datalayer is None`, `if self.actor_id is None`,
+      or `if self.trigger_activity_factory is None` guard blocks that duplicate logic
+      already present in an existing base class.
 - id: BTND-08
   title: Positive-Precondition Condition Node Naming
   kind: pattern


### PR DESCRIPTION
- closes #1488 

## Summary

- Adds `BTND-07-005` to `specs/behavior-tree-node-design.yaml`: agents MUST
  search for existing base classes before reimplementing guard/factory
  boilerplate in `update()` methods; names `DataLayerAction` and
  `_EmitCaseActorReportActivityBase` as canonical reuse targets
- Adds **BT Emit Nodes: Inherit Base Classes, Never Reimplement Guard
  Boilerplate** pitfall to `AGENTS.md`; provides concrete class names so
  agents can locate the right base class without a codebase scan

## Changes

- `specs/behavior-tree-node-design.yaml` — new `BTND-07-005` entry under
  `BTND-07` group
- `AGENTS.md` — new pitfall entry in **Common Pitfalls** section, placed
  immediately after the existing "Avoid God BT Nodes" entry

## Context

These docs gaps were surfaced by concern #1488. The root cause of god-node
`update()` methods is copy-paste of guard/factory boilerplate that should be
in a shared base class. This change encodes the reuse requirement normatively
so future implementation agents can find the right pattern before writing new
code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)