### PR TITLE
feat(#1480): populate SpecTag tags across all 65 spec YAML files

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1480.md
+++ b/plan/history/2607/implementation/ISSUE-1480.md
@@ -1,0 +1,16 @@
+---
+source: ISSUE-1480
+timestamp: '2026-07-17T19:38:16.782805+00:00'
+title: populate SpecTag tags across all 65 spec YAML files
+type: implementation
+---
+
+## Issue #1480 — populate SpecTag tags across all 65 spec YAML files
+
+Implemented file-level `tags:` entries across all 65 `specs/*.yaml` files using the `SpecTag` controlled vocabulary.
+
+Updated `effective_tags()` in `registry.py` to support file-level tag inheritance, added `SpecRegistry.get_effective_tags(spec_id)` for registry-based resolution, updated `lint.py`, `render.py`, and `llm_export.py` to use inherited tags, and added `tags` attribute to graph nodes in `_build_graph`.
+
+Added 5 tests covering inheritance, override, empty fallback, graph node population, and `export_json` output consistency.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1501>

--- a/specs/activity-factories.yaml
+++ b/specs/activity-factories.yaml
@@ -10,6 +10,9 @@ kind: domain
 scope:
 - prototype
 - production
+tags:
+- messaging
+- wire-format
 groups:
 - id: AF-01
   title: Purpose and Scope

--- a/specs/actor-knowledge-model.yaml
+++ b/specs/actor-knowledge-model.yaml
@@ -11,6 +11,10 @@ kind: domain
 scope:
 - prototype
 - production
+tags:
+- messaging
+- protocol
+- federation
 groups:
 - id: AKM-01
   title: DataLayer Isolation (MUST)

--- a/specs/agentic-readiness.yaml
+++ b/specs/agentic-readiness.yaml
@@ -9,6 +9,8 @@ kind: pattern
 scope:
 - prototype
 - production
+tags:
+- tooling
 groups:
 - id: AR-01
   title: API Discoverability

--- a/specs/architecture.yaml
+++ b/specs/architecture.yaml
@@ -11,6 +11,8 @@ kind: pattern
 scope:
 - prototype
 - production
+tags:
+- code-style
 groups:
 - id: ARCH-01
   title: Layer Separation

--- a/specs/behavior-tree-integration.yaml
+++ b/specs/behavior-tree-integration.yaml
@@ -11,6 +11,8 @@ kind: pattern
 scope:
 - prototype
 - production
+tags:
+- behavior-tree
 groups:
 - id: BT-01
   title: BT Execution Model

--- a/specs/behavior-tree-node-design.yaml
+++ b/specs/behavior-tree-node-design.yaml
@@ -10,6 +10,8 @@ scope:
 
 - prototype
 - production
+tags:
+- behavior-tree
 groups:
 - id: BTND-01
   title: Node Parameterization

--- a/specs/bt-composability.yaml
+++ b/specs/bt-composability.yaml
@@ -11,6 +11,8 @@ kind: pattern
 scope:
 - prototype
 - production
+tags:
+- behavior-tree
 groups:
 - id: BTC-01
   title: Simulator Reference Workflow

--- a/specs/bugfix-workflow.yaml
+++ b/specs/bugfix-workflow.yaml
@@ -8,6 +8,8 @@ kind: dev-process
 scope:
 - prototype
 - production
+tags:
+- tooling
 groups:
 - id: BFW-01
   title: Phase 2 — Clarification (MUST)

--- a/specs/build-workflow.yaml
+++ b/specs/build-workflow.yaml
@@ -10,6 +10,8 @@ kind: dev-process
 scope:
   - prototype
   - production
+tags:
+- tooling
 groups:
   - id: BW-01
     title: Incoming Learnings Queue Content Policy

--- a/specs/case-bootstrap-trust.yaml
+++ b/specs/case-bootstrap-trust.yaml
@@ -10,6 +10,9 @@ kind: domain
 scope:
   - prototype
   - production
+tags:
+- protocol
+- state-machine
 groups:
   - id: CBT-01
     title: Original Report-Submission Bootstrap

--- a/specs/case-ledger-processing.yaml
+++ b/specs/case-ledger-processing.yaml
@@ -11,6 +11,9 @@ kind: domain
 scope:
 - prototype
 - production
+tags:
+- protocol
+- persistence
 groups:
 - id: CLP-01
   title: Assertion Intake

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -11,6 +11,9 @@ scope:
 
 - prototype
 - production
+tags:
+- protocol
+- state-machine
 groups:
 - id: CM-01
   title: Actor Isolation

--- a/specs/case-proposal.yaml
+++ b/specs/case-proposal.yaml
@@ -10,6 +10,9 @@ kind: domain
 scope:
   - prototype
   - production
+tags:
+- protocol
+- messaging
 groups:
   - id: CP-01
     title: Wire Vocabulary

--- a/specs/ci-security.yaml
+++ b/specs/ci-security.yaml
@@ -6,6 +6,9 @@ kind: general
 scope:
 - prototype
 - production
+tags:
+- ci-cd
+- security
 groups:
 - id: CISEC-01
   title: Action Version Pinning

--- a/specs/code-style.yaml
+++ b/specs/code-style.yaml
@@ -6,6 +6,8 @@ kind: language
 scope:
 - prototype
 - production
+tags:
+- code-style
 groups:
 - id: CS-01
   title: Code Formatting

--- a/specs/configuration.yaml
+++ b/specs/configuration.yaml
@@ -10,6 +10,8 @@ scope:
 
 - prototype
 - production
+tags:
+- configuration
 groups:
 - id: CFG-01
   title: Module Placement and Config API

--- a/specs/cs-behavior.yaml
+++ b/specs/cs-behavior.yaml
@@ -10,6 +10,8 @@ version: 0.1.0
 kind: domain
 tags:
 - behavioral
+- state-machine
+- protocol
 scope:
 - prototype
 - production

--- a/specs/datalayer.yaml
+++ b/specs/datalayer.yaml
@@ -7,6 +7,8 @@ kind: implementation
 scope:
 - prototype
 - production
+tags:
+- persistence
 groups:
 - id: DL-01
   title: Auto-Rehydration on Read

--- a/specs/demo-ci.yaml
+++ b/specs/demo-ci.yaml
@@ -10,6 +10,9 @@ kind: implementation
 scope:
   - prototype
   - production
+tags:
+- ci-cd
+- demo
 groups:
   - id: DEMOCI-01
     title: Demo Runner Failure Signalling

--- a/specs/demo-cli.yaml
+++ b/specs/demo-cli.yaml
@@ -9,6 +9,8 @@ kind: implementation
 scope:
 - prototype
 - production
+tags:
+- demo
 groups:
 - id: DC-01
   title: CLI Interface

--- a/specs/demo-report.yaml
+++ b/specs/demo-report.yaml
@@ -10,6 +10,8 @@ version: 1.0.0
 kind: implementation
 scope:
 - prototype
+tags:
+- demo
 groups:
 - id: DRPT-01
   title: Tool Structure and Invocation

--- a/specs/diataxis-requirements.yaml
+++ b/specs/diataxis-requirements.yaml
@@ -7,6 +7,8 @@ kind: general
 scope:
 - prototype
 - production
+tags:
+- documentation
 groups:
 - id: DF-01
   title: General architecture

--- a/specs/dispatch-routing.yaml
+++ b/specs/dispatch-routing.yaml
@@ -9,6 +9,8 @@ kind: implementation
 scope:
 - prototype
 - production
+tags:
+- messaging
 groups:
 - id: DR-01
   title: Dispatcher Protocol

--- a/specs/docs-build-workflow.yaml
+++ b/specs/docs-build-workflow.yaml
@@ -12,6 +12,9 @@ kind: implementation
 scope:
   - prototype
   - production
+tags:
+- ci-cd
+- documentation
 groups:
   - id: DOCBW-01
     title: Workflow File Name and Display Name

--- a/specs/duration.yaml
+++ b/specs/duration.yaml
@@ -9,6 +9,8 @@ kind: domain
 scope:
 - prototype
 - production
+tags:
+- protocol
 groups:
 - id: DUR-01
   title: Representation Format

--- a/specs/em-behavior.yaml
+++ b/specs/em-behavior.yaml
@@ -9,6 +9,8 @@ version: 0.1.0
 kind: domain
 tags:
 - behavioral
+- state-machine
+- protocol
 scope:
 - prototype
 - production

--- a/specs/embargo-policy.yaml
+++ b/specs/embargo-policy.yaml
@@ -9,6 +9,9 @@ kind: domain
 scope:
 - prototype
 - production
+tags:
+- protocol
+- state-machine
 groups:
 - id: EP-01
   title: Policy Record Format

--- a/specs/encryption.yaml
+++ b/specs/encryption.yaml
@@ -9,6 +9,8 @@ kind: domain
 scope:
 - prototype
 - production
+tags:
+- security
 groups:
 - id: ENC-01
   title: Key Management

--- a/specs/error-handling.yaml
+++ b/specs/error-handling.yaml
@@ -9,6 +9,8 @@ kind: language
 scope:
 - prototype
 - production
+tags:
+- error-handling
 groups:
 - id: EH-01
   title: Exception Hierarchy

--- a/specs/event-driven-control-flow.yaml
+++ b/specs/event-driven-control-flow.yaml
@@ -9,6 +9,9 @@ kind: pattern
 scope:
 - prototype
 - production
+tags:
+- messaging
+- behavior-tree
 groups:
 - id: EDF-01
   title: Definitions

--- a/specs/handler-protocol.yaml
+++ b/specs/handler-protocol.yaml
@@ -8,6 +8,9 @@ scope:
 
 - prototype
 - production
+tags:
+- messaging
+- protocol
 groups:
 - id: HP-00
   title: Protocol Semantics

--- a/specs/history-management.yaml
+++ b/specs/history-management.yaml
@@ -9,6 +9,9 @@ kind: dev-process
 scope:
   - prototype
   - production
+tags:
+- tooling
+- documentation
 groups:
   - id: HM-01
     title: History File Location and Structure

--- a/specs/http-protocol.yaml
+++ b/specs/http-protocol.yaml
@@ -6,6 +6,8 @@ kind: pattern
 scope:
 - prototype
 - production
+tags:
+- wire-format
 groups:
 - id: HTTP-01
   title: Content-Type Validation

--- a/specs/idempotency.yaml
+++ b/specs/idempotency.yaml
@@ -8,6 +8,8 @@ kind: general
 scope:
 - prototype
 - production
+tags:
+- idempotency
 groups:
 - id: ID-01
   title: Activity ID Uniqueness

--- a/specs/inbox-endpoint.yaml
+++ b/specs/inbox-endpoint.yaml
@@ -9,6 +9,8 @@ kind: domain
 scope:
 - prototype
 - production
+tags:
+- messaging
 groups:
 - id: IE-02
   title: Endpoint Configuration

--- a/specs/inbox-orchestration.yaml
+++ b/specs/inbox-orchestration.yaml
@@ -9,6 +9,9 @@ kind: pattern
 scope:
 - prototype
 - production
+tags:
+- messaging
+- behavior-tree
 groups:
 - id: IO-01
   title: InboxOutcome Model

--- a/specs/inbox-pipeline.yaml
+++ b/specs/inbox-pipeline.yaml
@@ -10,6 +10,8 @@ kind: implementation
 scope:
 - prototype
 - production
+tags:
+- messaging
 groups:
 - id: IBP-01
   title: InboxPipeline Class Contract

--- a/specs/lifecycle-staged-types.yaml
+++ b/specs/lifecycle-staged-types.yaml
@@ -10,6 +10,9 @@ kind: domain
 scope:
 - prototype
 - production
+tags:
+- protocol
+- state-machine
 groups:
 - id: LST-01
   title: Field-Set Governing Principle

--- a/specs/message-semantics-mapping.yaml
+++ b/specs/message-semantics-mapping.yaml
@@ -12,6 +12,9 @@ kind: domain
 scope:
 - prototype
 - production
+tags:
+- messaging
+- protocol
 groups:
 - id: MSM-01
   title: RM Protocol Message Shorthands

--- a/specs/message-validation.yaml
+++ b/specs/message-validation.yaml
@@ -9,6 +9,9 @@ kind: domain
 scope:
 - prototype
 - production
+tags:
+- messaging
+- wire-format
 groups:
 - id: MV-01
   title: Activity Structure Validation

--- a/specs/meta-specifications.yaml
+++ b/specs/meta-specifications.yaml
@@ -7,6 +7,9 @@ kind: general
 scope:
 - prototype
 - production
+tags:
+- documentation
+- tooling
 groups:
 - id: MS-01
   title: File Structure

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -8,6 +8,8 @@ kind: implementation
 scope:
 - prototype
 - production
+tags:
+- demo
 groups:
 - id: DEMOMA-00
   title: Cross-Actor Communication

--- a/specs/notes-frontmatter.yaml
+++ b/specs/notes-frontmatter.yaml
@@ -8,6 +8,9 @@ kind: implementation
 scope:
 - prototype
 - production
+tags:
+- documentation
+- tooling
 groups:
 - id: NF-01
   title: Frontmatter Schema (MUST)

--- a/specs/object-ids.yaml
+++ b/specs/object-ids.yaml
@@ -9,6 +9,9 @@ kind: domain
 scope:
 - prototype
 - production
+tags:
+- wire-format
+- protocol
 groups:
 - id: OID-01
   title: ID Format

--- a/specs/observability.yaml
+++ b/specs/observability.yaml
@@ -8,6 +8,8 @@ kind: general
 scope:
 - prototype
 - production
+tags:
+- observability
 groups:
 - id: OB-05
   title: Health Checks

--- a/specs/outbox.yaml
+++ b/specs/outbox.yaml
@@ -9,6 +9,8 @@ kind: implementation
 scope:
 - prototype
 - production
+tags:
+- messaging
 groups:
 - id: OX-01
   title: Outbox Structure

--- a/specs/parallel-development.yaml
+++ b/specs/parallel-development.yaml
@@ -10,6 +10,8 @@ kind: dev-process
 scope:
   - prototype
   - production
+tags:
+- tooling
 groups:
   - id: PAD-01
     title: Issue Hierarchy

--- a/specs/participant-case-replica.yaml
+++ b/specs/participant-case-replica.yaml
@@ -9,6 +9,9 @@ kind: domain
 scope:
 - prototype
 - production
+tags:
+- protocol
+- state-machine
 groups:
 - id: PCR-01
   title: Replica Identity (No Stub CaseActor)

--- a/specs/participant-role-management.yaml
+++ b/specs/participant-role-management.yaml
@@ -10,6 +10,8 @@ kind: domain
 scope:
   - prototype
   - production
+tags:
+- protocol
 groups:
   - id: PRM-01
     title: Role Read API

--- a/specs/project-documentation.yaml
+++ b/specs/project-documentation.yaml
@@ -7,6 +7,8 @@ kind: implementation
 scope:
 - prototype
 - production
+tags:
+- documentation
 groups:
 - id: PD-01
   title: File Size Guidelines

--- a/specs/prototype-shortcuts.yaml
+++ b/specs/prototype-shortcuts.yaml
@@ -8,6 +8,8 @@ kind: implementation
 scope:
 - prototype
 - production
+tags:
+- tooling
 groups:
 - id: PROTO-01
   title: Authentication

--- a/specs/response-format.yaml
+++ b/specs/response-format.yaml
@@ -9,6 +9,8 @@ kind: domain
 scope:
 - prototype
 - production
+tags:
+- wire-format
 groups:
 - id: RF-01
   title: Response Activity Structure

--- a/specs/rm-behavior.yaml
+++ b/specs/rm-behavior.yaml
@@ -9,6 +9,8 @@ version: 0.1.0
 kind: domain
 tags:
 - behavioral
+- state-machine
+- protocol
 scope:
 - prototype
 - production

--- a/specs/semantic-extraction.yaml
+++ b/specs/semantic-extraction.yaml
@@ -9,6 +9,9 @@ kind: domain
 scope:
 - prototype
 - production
+tags:
+- messaging
+- wire-format
 groups:
 - id: SE-01
   title: Pattern Matching

--- a/specs/spec-registry.yaml
+++ b/specs/spec-registry.yaml
@@ -9,6 +9,9 @@ kind: implementation
 scope:
 - prototype
 - production
+tags:
+- tooling
+- documentation
 groups:
 - id: SR-01
   title: YAML File Format (MUST)

--- a/specs/state-machine.yaml
+++ b/specs/state-machine.yaml
@@ -11,6 +11,9 @@ kind: domain
 scope:
 - prototype
 - production
+tags:
+- state-machine
+- protocol
 groups:
 - id: SM-01
   title: State Enum Design

--- a/specs/structured-logging.yaml
+++ b/specs/structured-logging.yaml
@@ -8,6 +8,9 @@ kind: language
 scope:
 - prototype
 - production
+tags:
+- logging
+- observability
 groups:
 - id: SL-01
   title: Log Format

--- a/specs/sync-behavior-trees.yaml
+++ b/specs/sync-behavior-trees.yaml
@@ -10,6 +10,8 @@ kind: pattern
 scope:
   - prototype
   - production
+tags:
+- behavior-tree
 relationships:
   - rel_type: extends
     spec_id: BT-06-001

--- a/specs/sync-ledger-replication.yaml
+++ b/specs/sync-ledger-replication.yaml
@@ -9,6 +9,9 @@ kind: domain
 scope:
 - prototype
 - production
+tags:
+- protocol
+- persistence
 groups:
 - id: SYNC-01
   title: Append-Only Log

--- a/specs/tech-stack.yaml
+++ b/specs/tech-stack.yaml
@@ -8,6 +8,8 @@ kind: language
 scope:
 - prototype
 - production
+tags:
+- tooling
 groups:
 - id: IMPLTS-01
   title: Runtime and Language

--- a/specs/testability.yaml
+++ b/specs/testability.yaml
@@ -9,6 +9,8 @@ kind: language
 scope:
 - prototype
 - production
+tags:
+- testing
 groups:
 - id: TB-01
   title: Testing Framework

--- a/specs/traceability.yaml
+++ b/specs/traceability.yaml
@@ -8,6 +8,9 @@ kind: implementation
 scope:
 - prototype
 - production
+tags:
+- documentation
+- tooling
 groups:
 - id: TRACE-01
   title: Traceability Matrix

--- a/specs/triggerable-behaviors.yaml
+++ b/specs/triggerable-behaviors.yaml
@@ -10,6 +10,9 @@ kind: domain
 scope:
 - prototype
 - production
+tags:
+- messaging
+- protocol
 groups:
 - id: TRIG-01
   title: Endpoint Format

--- a/specs/use-case-organization.yaml
+++ b/specs/use-case-organization.yaml
@@ -9,6 +9,8 @@ kind: implementation
 scope:
 - prototype
 - production
+tags:
+- code-style
 groups:
 - id: UCORG-01
   title: Package Layout

--- a/specs/vocabulary-model.yaml
+++ b/specs/vocabulary-model.yaml
@@ -10,6 +10,8 @@ kind: domain
 scope:
 - prototype
 - production
+tags:
+- wire-format
 groups:
 - id: VM-01
   title: Vocabulary Registration

--- a/specs/vultron-as2-mapping.yaml
+++ b/specs/vultron-as2-mapping.yaml
@@ -10,6 +10,9 @@ kind: domain
 scope:
 - prototype
 - production
+tags:
+- messaging
+- wire-format
 groups:
 - id: VAM-01
   title: General Mapping Conventions

--- a/specs/vultron-protocol-spec.yaml
+++ b/specs/vultron-protocol-spec.yaml
@@ -10,6 +10,10 @@ kind: domain
 scope:
 - prototype
 - production
+tags:
+- protocol
+- state-machine
+- messaging
 groups:
 - id: VP-01
   title: Participant State Tracking

--- a/test/metadata/specs/test_render.py
+++ b/test/metadata/specs/test_render.py
@@ -152,6 +152,38 @@ def test_export_json_filter_by_tags_no_match(loaded_registry):
     assert data == {}
 
 
+def test_export_json_inherited_tags_present_in_output(tmp_path):
+    """export_json output must include inherited file-level tags in the record."""
+    data = {
+        "id": "TST",
+        "title": "Test",
+        "description": "Test",
+        "version": "0.1",
+        "kind": "general",
+        "scope": ["production"],
+        "tags": ["protocol"],
+        "groups": [
+            {
+                "id": "TST-01",
+                "title": "Group",
+                "specs": [
+                    {
+                        "id": "TST-01-001",
+                        "priority": "MUST",
+                        "statement": "TST-01-001 MUST pass",
+                    }
+                ],
+            }
+        ],
+    }
+    (tmp_path / "test.yaml").write_text(yaml.dump(data))
+    registry = load_registry(tmp_path)
+    json_str = export_json(registry, tags=["protocol"])
+    parsed = json.loads(json_str)
+    assert "TST-01-001" in parsed
+    assert parsed["TST-01-001"]["tags"] == ["protocol"]
+
+
 # ---------------------------------------------------------------------------
 # render_registry_markdown
 # ---------------------------------------------------------------------------

--- a/test/metadata/specs/test_schema.py
+++ b/test/metadata/specs/test_schema.py
@@ -524,6 +524,119 @@ def test_effective_scope_inherits_from_file(spec_dir):
     assert registry.get_effective_scope("TST-01-001") == [Scope.PRODUCTION]
 
 
+def test_effective_tags_file_level_inherited(tmp_path):
+    data = {
+        "id": "TST",
+        "title": "Test",
+        "description": "Test",
+        "version": "0.1",
+        "kind": "general",
+        "scope": ["production"],
+        "tags": ["protocol"],
+        "groups": [
+            {
+                "id": "TST-01",
+                "title": "Group",
+                "specs": [
+                    {
+                        "id": "TST-01-001",
+                        "priority": "MUST",
+                        "statement": "TST-01-001 MUST pass",
+                    }
+                ],
+            }
+        ],
+    }
+    (tmp_path / "test.yaml").write_text(yaml.dump(data))
+    registry = load_registry(tmp_path)
+    assert registry.get_effective_tags("TST-01-001") == [SpecTag.PROTOCOL]
+
+
+def test_effective_tags_spec_overrides_file(tmp_path):
+    data = {
+        "id": "TST",
+        "title": "Test",
+        "description": "Test",
+        "version": "0.1",
+        "kind": "general",
+        "scope": ["production"],
+        "tags": ["protocol"],
+        "groups": [
+            {
+                "id": "TST-01",
+                "title": "Group",
+                "specs": [
+                    {
+                        "id": "TST-01-001",
+                        "priority": "MUST",
+                        "statement": "TST-01-001 MUST pass",
+                        "tags": ["testing"],
+                    }
+                ],
+            }
+        ],
+    }
+    (tmp_path / "test.yaml").write_text(yaml.dump(data))
+    registry = load_registry(tmp_path)
+    assert registry.get_effective_tags("TST-01-001") == [SpecTag.TESTING]
+
+
+def test_effective_tags_empty_when_neither_spec_nor_file(tmp_path):
+    data = {
+        "id": "TST",
+        "title": "Test",
+        "description": "Test",
+        "version": "0.1",
+        "kind": "general",
+        "scope": ["production"],
+        "groups": [
+            {
+                "id": "TST-01",
+                "title": "Group",
+                "specs": [
+                    {
+                        "id": "TST-01-001",
+                        "priority": "MUST",
+                        "statement": "TST-01-001 MUST pass",
+                    }
+                ],
+            }
+        ],
+    }
+    (tmp_path / "test.yaml").write_text(yaml.dump(data))
+    registry = load_registry(tmp_path)
+    assert registry.get_effective_tags("TST-01-001") == []
+
+
+def test_effective_tags_graph_node_populated(tmp_path):
+    data = {
+        "id": "TST",
+        "title": "Test",
+        "description": "Test",
+        "version": "0.1",
+        "kind": "general",
+        "scope": ["production"],
+        "tags": ["protocol"],
+        "groups": [
+            {
+                "id": "TST-01",
+                "title": "Group",
+                "specs": [
+                    {
+                        "id": "TST-01-001",
+                        "priority": "MUST",
+                        "statement": "TST-01-001 MUST pass",
+                    }
+                ],
+            }
+        ],
+    }
+    (tmp_path / "test.yaml").write_text(yaml.dump(data))
+    registry = load_registry(tmp_path)
+    node_tags = registry.graph.nodes["TST-01-001"]["tags"]
+    assert node_tags == ["protocol"]
+
+
 def test_effective_kind_spec_override(tmp_path):
     data = {
         "id": "TST",

--- a/vultron/metadata/specs/lint.py
+++ b/vultron/metadata/specs/lint.py
@@ -152,7 +152,7 @@ def lint(spec_dir: Path, adr_dir: Path | None = None) -> int:
                 f"{_RATIONALE_WARN_CHARS} characters"
             )
 
-        tags = spec.tags or []
+        tags = registry.get_effective_tags(spec_id)
         if not tags and LintWarningCode.MISSING_TAGS not in suppressed:
             warnings.append(f"[WARN] {spec_id}: no tags defined")
 

--- a/vultron/metadata/specs/llm_export.py
+++ b/vultron/metadata/specs/llm_export.py
@@ -57,7 +57,7 @@ def _spec_record(
         "scope": [s.value for s in effective_scope(spec, group, file)],
     }
 
-    tags = effective_tags(spec)
+    tags = effective_tags(spec, file)
     if tags:
         rec["tags"] = [t.value for t in tags]
 
@@ -151,7 +151,7 @@ def _matches_filters(
     eff_scope_values = {
         item.value for item in effective_scope(spec, group, file)
     }
-    eff_tag_values = {item.value for item in effective_tags(spec)}
+    eff_tag_values = {item.value for item in effective_tags(spec, file)}
 
     if kind and eff_kind.value != kind:
         return False

--- a/vultron/metadata/specs/registry.py
+++ b/vultron/metadata/specs/registry.py
@@ -50,9 +50,18 @@ def effective_scope(
     return file.scope
 
 
-def effective_tags(spec: Spec) -> list[SpecTag]:
-    """Return tags for *spec*, defaulting to empty list when absent."""
-    return spec.tags if spec.tags is not None else []
+def effective_tags(spec: Spec, file: SpecFile | None = None) -> list[SpecTag]:
+    """Return effective tags for *spec*, inheriting from *file* when absent.
+
+    Spec-level tags take priority; when a spec has no tags, the file-level
+    tags are returned so that a file-level ``tags:`` entry satisfies the
+    per-item lint check for all specs in the file.
+    """
+    if spec.tags is not None:
+        return spec.tags
+    if file is not None and file.tags is not None:
+        return file.tags
+    return []
 
 
 class SpecRegistry(BaseModel):
@@ -95,6 +104,7 @@ class SpecRegistry(BaseModel):
                 priority=spec.priority.value,
                 kind=effective_kind(spec, group, file).value,
                 scope=[s.value for s in effective_scope(spec, group, file)],
+                tags=[t.value for t in effective_tags(spec, file)],
                 file_id=file.id,
                 group_id=group.id,
                 type=spec_type,
@@ -162,6 +172,12 @@ class SpecRegistry(BaseModel):
         spec = self.get(spec_id)
         group, file = self._spec_context[spec_id]
         return effective_scope(spec, group, file)
+
+    def get_effective_tags(self, spec_id: SpecIdStr) -> list[SpecTag]:
+        """Return the resolved ``tags`` for *spec_id* via file inheritance."""
+        spec = self.get(spec_id)
+        _, file = self._spec_context[spec_id]
+        return effective_tags(spec, file)
 
     def validate_cross_references(self) -> list[str]:
         """Return error strings for any dangling relationship targets

--- a/vultron/metadata/specs/render.py
+++ b/vultron/metadata/specs/render.py
@@ -23,7 +23,6 @@ from pathlib import Path
 
 from vultron.metadata.specs.registry import (
     SpecRegistry,
-    effective_tags,
     load_registry,
 )
 from vultron.metadata.specs.schema import (
@@ -294,7 +293,7 @@ def export_json(
     for spec_id, spec in registry.all_specs.items():
         eff_kind = registry.get_effective_kind(spec_id)
         eff_scope = registry.get_effective_scope(spec_id)
-        eff_tags = effective_tags(spec)
+        eff_tags = registry.get_effective_tags(spec_id)
 
         if kind and eff_kind.value != kind:
             continue
@@ -304,7 +303,10 @@ def export_json(
             continue
         if priority and spec.priority.value != priority:
             continue
-        result[spec_id] = spec.model_dump(mode="json")
+        record = spec.model_dump(mode="json")
+        if eff_tags and record.get("tags") is None:
+            record["tags"] = [t.value for t in eff_tags]
+        result[spec_id] = record
 
     return json.dumps(result, indent=2)
 


### PR DESCRIPTION
- Closes #1480

## Summary

- Added file-level `tags:` entries to all 65 `specs/*.yaml` files using the `SpecTag` controlled vocabulary.
- Updated `effective_tags()` in `registry.py` to support file-level tag inheritance (spec-level tags override; file-level tags fall back when spec has none).
- Added `SpecRegistry.get_effective_tags(spec_id)` method for consistent registry-based resolution.
- Updated `lint.py`, `render.py`, and `llm_export.py` to use the inherited tags.
- Added `tags` attribute to graph nodes in `_build_graph` (consistent with `kind` and `scope`).
- Fixed `export_json` to include inherited file-level tags in serialized output records.
- Added 5 tests covering file-level inheritance, spec-level override, empty fallback, graph node population, and `export_json` output correctness.

## Changes

**Core inheritance logic** (`vultron/metadata/specs/registry.py`):
- `effective_tags(spec, file=None)` now falls back to `file.tags` when `spec.tags` is `None`.
- `get_effective_tags(spec_id)` resolves tags via the registry's `_spec_context`.
- `_build_graph` stores resolved `tags` as a node attribute.

**Lint** (`vultron/metadata/specs/lint.py`): uses `registry.get_effective_tags(spec_id)` so file-level tags satisfy the per-item check.

**Export** (`vultron/metadata/specs/render.py`, `llm_export.py`): both use effective (inherited) tags for filtering and output.

**Spec YAML files** (`specs/*.yaml`): all 65 files now have a `tags:` field at the file level. The three behavioral spec files (`rm-behavior.yaml`, `cs-behavior.yaml`, `em-behavior.yaml`) have `[behavioral, state-machine, protocol]`.

## Verification

- `uv run python -m vultron.metadata.specs.lint specs/` — 0 MISSING_TAGS warnings, 0 hard errors
- `uv run black vultron/ test/ && uv run flake8 vultron/ test/ && uv run mypy && uv run pyright` — all clean
- `uv run pytest --tb=short` — 5051 passed (5 new tests added)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)