### PR TITLE
docs: plan concern #1496 — DataLayer returns core objects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -812,6 +812,24 @@ Short entries are reproduced here; longer ones are referenced below.
   never on `CaseModel` — and when `record_event()` was removed from
   `VulnerabilityCase`, 440 test failures cascaded before the root cause was
   traced. See `specs/code-style.yaml` CS-20-002.
+- **`dl.read()` Returns Core Objects — Core MUST NOT Receive or Duck-Type Wire
+  Objects** — The DataLayer read path (`dl.read()`, `dl.list_objects()`) MUST
+  return **core** domain objects (`vultron/core/models/`), never **wire**
+  vocabulary types (`vultron/wire/as2/vocab/objects/`, `as_`-prefixed), for any
+  persisted `type_` with a registered `CORE_VOCABULARY` counterpart. Do NOT add
+  new structural duck-typing Protocols or `TypeGuard` helpers (the
+  `CaseModel` / `is_case_model()` family in `vultron/core/models/protocols.py`)
+  to let core operate on DataLayer results without importing concrete core
+  types — that pattern evades ARCH-01-001 by hiding a runtime `core → wire`
+  dependency from mypy/pyright, and it only works by structural coincidence of
+  field names. Core code MUST depend on concrete core classes and real
+  `isinstance` narrowing. The one recognised exception is persisted AS2
+  Activities (`vultron/wire/as2/vocab/activities/`), which have no core
+  counterpart; core reading those back from the DataLayer is a tracked
+  boundary violation, not a sanctioned pattern. See ADR-0034,
+  `specs/datalayer.yaml` DL-05-001 through DL-05-004, and
+  [notes/datalayer-design.md](notes/datalayer-design.md) § "Read Path MUST
+  Return Core Objects".
 - **Emit Nodes in Case-Scoped Trigger BTs Must Fail Fast on Missing CaseActor**
   — After switching case-scoped trigger routing from `case_addressees()` to
   CaseActor-only routing, emit nodes must fail fast (FAILURE or immediate

--- a/docs/adr/0034-datalayer-returns-core-objects.md
+++ b/docs/adr/0034-datalayer-returns-core-objects.md
@@ -1,0 +1,141 @@
+---
+status: accepted
+date: 2026-07-17
+deciders: Vultron maintainers
+consulted: notes/datalayer-design.md, notes/domain-model-separation.md
+informed: CERT/CC Vultron contributors
+---
+
+# DataLayer Port Returns Core Domain Objects
+
+## Context and Problem Statement
+
+The SQLite DataLayer adapter reconstructs persisted objects through the wire
+vocabulary registry (`find_in_vocabulary()` in
+`vultron/adapters/driven/db_record.py`). As a result, `dl.read()` and
+`dl.list_objects()` return **wire-layer** types (e.g. `as_VulnerabilityCase`
+from `vultron/wire/as2/vocab/objects/`) rather than **core** domain types
+(e.g. `VulnerabilityCase` from `vultron/core/models/`).
+
+Core BT nodes and use cases call `dl.read()` and operate on the result. To
+avoid a compile-time `core → wire` import (forbidden by ARCH-01-001), core
+depends on structural duck-typing Protocols and `TypeGuard` helpers in
+`vultron/core/models/protocols.py` (`CaseModel`, `is_case_model()`, etc.).
+These let core call methods on wire objects at runtime without importing the
+wire classes. The boundary "works" only because wire and core types share
+field names and the same `type_` string value.
+
+This produces three problems:
+
+1. **Core validators never run on stored data.** A wire object satisfies core
+   call sites by structural coincidence; core's domain invariants are never
+   enforced on DataLayer-sourced data.
+2. **The Protocols evade rather than honour ARCH-01-001.** They hide a runtime
+   `core → wire` dependency from static analysis; mypy/pyright pass while core
+   operates on wire objects.
+3. **The seam is fragile.** After ADR-0017 / issue #1387 renamed wire classes
+   to the `as_` prefix (`as_VulnerabilityCase`), the classes are now genuinely
+   distinct — but the runtime boundary violation remains, held together only by
+   the shared `type_` string and field names.
+
+It was also unclear where wire↔core translation belongs. This ADR records that
+decision. Source concern: #1496 (parent Epic #1394).
+
+## Decision Drivers
+
+- Restore the hexagonal boundary: core functions MUST accept and return domain
+  types only (ARCH-01-002); core MUST NOT import wire (ARCH-01-001).
+- Keep the wire vocabulary registry a wire-layer concern (DL-03-002); the
+  DataLayer must not depend on it to reconstruct core objects.
+- Prefer a translation boundary that is enforced by types and a ratchet, not by
+  structural coincidence.
+- Keep the change reversible in stages and reviewable (the core-side cleanup
+  touches ~45 files).
+
+## Considered Options
+
+- **A. Adapter reconstructs and returns core objects natively.** The DataLayer
+  read path reconstructs persisted domain entities via the core vocabulary
+  registry (`CORE_VOCABULARY`). `dl.read()` / `dl.list_objects()` return core
+  types. Wire types never enter core. The adapter may still use wire types
+  internally, but the port contract is a core object.
+- **B. Use cases convert wire → core at each boundary.** DataLayer keeps
+  returning wire objects; each core site calls `model_validate` to convert.
+  Rejected: scatters conversion across ~45+ sites and is explicitly prohibited
+  by DL-01-004 (no `model_validate` on `dl.read()` results in core).
+- **C. Physically split into a wire-owned DataLayer and a core-owned
+  DataLayer.** Two persistence scopes. Rejected for this decision: changes
+  persistence topology and per-actor isolation (ADR-0012); far larger than the
+  concern requires. Left as possible future work.
+
+## Decision Outcome
+
+Chosen option: **A — the adapter reconstructs and returns core objects
+natively**, because it is the only option that satisfies ARCH-01-002 without
+scattering conversion logic (rejecting B) and without re-architecting
+persistence topology (rejecting C).
+
+### Decision details
+
+1. **Port contract is a core object.** For every persisted `type_` that has a
+   registered core counterpart, `dl.read(id)` and `dl.list_objects(type_key)`
+   return an instance of the core `vultron/core/models` class, reconstructed via
+   `CORE_VOCABULARY` (DL-05-001).
+2. **The adapter owns wire↔core translation** and maintains its own
+   `type_`→core-class mapping independent of the wire `VOCABULARY` registry
+   (DL-05-002, DL-03-002). Whether the adapter uses wire types as intermediate
+   values internally is an implementation detail hidden behind the port.
+3. **The duck-typing Protocols are removed.** Once reads return core objects,
+   core depends on concrete core classes (real `isinstance` narrowing); the
+   workaround Protocols and `TypeGuard` helpers in
+   `vultron/core/models/protocols.py` are deleted (DL-05-003).
+4. **AS2 Activities are the recognised exception.** Persisted AS2 Activity types
+   (the protocol message types in `vultron/wire/as2/vocab/activities/`) have no
+   core counterpart, so they cannot be returned as core objects. Core code that
+   reads stored wire Activities back from the DataLayer (e.g. reading a stored
+   `as_Offer`) is itself a boundary violation, but migrating it out of core is
+   **out of scope for this decision** and tracked as a separate concern. Until
+   then, the ratchet exemption set (DL-05-004) enumerates these types explicitly
+   so it can only shrink.
+5. **A ratchet test enforces the contract** (DL-05-004): no `vultron.wire.as2`
+   vocabulary type may be returned from `dl.read()` / `dl.list_objects()` into
+   `vultron/core/`, except the enumerated Activity exemptions.
+
+### Consequences
+
+- Good, because core validators run on DataLayer-sourced data and the
+  wire→core runtime dependency disappears (ARCH-01-001, ARCH-01-002).
+- Good, because the DataLayer stops depending on the wire vocabulary registry to
+  reconstruct core objects, so the wire layer can evolve independently
+  (DL-03-002).
+- Good, because ~70 files of duck-typing scaffolding collapse to concrete-type
+  usage, restoring static-analysis visibility of the boundary.
+- Neutral, because the adapter may retain wire types internally; only the port
+  contract changes.
+- Bad, because the core-side cleanup is wide (~45 files using guards, ~25 using
+  Protocol hints) and is staged across multiple implementation issues.
+- Bad, because Activity read-back from core remains a known, tracked violation
+  until a follow-on concern migrates it.
+
+## Validation
+
+- An architecture ratchet test asserts no `vultron.wire.as2` vocabulary type
+  escapes `dl.read()` / `dl.list_objects()` into `vultron/core/`, with an
+  enumerated (shrink-only) exemption set for AS2 Activity types (DL-05-004).
+- `test/architecture/test_core_no_wire_imports.py` continues to enforce that
+  core does not import wire.
+- Existing DataLayer round-trip tests confirm that a saved core object reads
+  back as the same core type.
+
+## More Information
+
+- Concern #1496 — the driving report (DataLayer returns wire objects to core).
+- Epic #1394 — Architecture Hardening; parent of the implementation work.
+- ADR-0017 — Domain/Wire Object Separation (shared-base, two-branch hierarchy);
+  established the distinct core and wire class hierarchies this ADR relies on.
+- ADR-0009 — Hexagonal Architecture; the enclosing rule (ARCH-01-001,
+  ARCH-01-002) this ADR operationalizes for the persistence port.
+- ADR-0012 — Per-Actor DataLayer Isolation; relevant to the rejected Option C.
+- Generated spec requirements: `datalayer.yaml` DL-05-001 through DL-05-004.
+- `notes/datalayer-design.md` § "Vocabulary Registry Entanglement Across Wire,
+  Core, and DataLayer" — the analysis this decision resolves.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -87,6 +87,8 @@ General information about architectural decision records is available at <https:
   Cross-Cutting Enumerations](0031-vultron-enums-neutral-layer.md)
 - [ADR-0032 Validate at the Edge, Promote to Strict Core
   Types](0032-validate-at-edge-promote-to-core.md)
+- [ADR-0034 DataLayer Port Returns Core Domain
+  Objects](0034-datalayer-returns-core-objects.md)
 
 ## Proposed ADRs
 

--- a/notes/datalayer-design.md
+++ b/notes/datalayer-design.md
@@ -180,6 +180,41 @@ Research needed: audit all current callers of `object_to_record()`,
 `record_to_object()`, and `find_in_vocabulary()` to understand the scope
 of the coupling before designing the refactor.
 
+## Read Path MUST Return Core Objects (ADR-0034, DL-05)
+
+**Decided (ADR-0034):** `dl.read()` and `dl.list_objects()` MUST return
+**core** domain objects (`vultron/core/models/`), never **wire** vocabulary
+types (`vultron/wire/as2/vocab/objects/`, `as_`-prefixed), for any persisted
+`type_` that has a registered core counterpart in `CORE_VOCABULARY`.
+
+The current read path reconstructs via `find_in_vocabulary()` (the **wire**
+`VOCABULARY`), so core BT nodes and use cases receive `as_VulnerabilityCase`
+etc. and work around it with the duck-typing Protocols and `TypeGuard`
+helpers in `vultron/core/models/protocols.py` (`CaseModel`, `is_case_model()`,
+…). Those Protocols evade — rather than honour — ARCH-01-001: they hide a
+runtime `core → wire` dependency from mypy/pyright.
+
+Target end-state (DL-05-001 through DL-05-004):
+
+1. The adapter reconstructs registered domain entities via
+   `find_in_core_vocabulary()` / `CORE_VOCABULARY`, so reads/writes of domain
+   entities are core → core.
+2. The adapter owns wire↔core translation and keeps its own
+   `type_`→core-class mapping, independent of the wire `VOCABULARY`.
+3. The duck-typing Protocols in `protocols.py` are removed; core depends on
+   concrete core classes (real `isinstance` narrowing).
+4. A ratchet test asserts no `vultron.wire.as2` vocabulary type escapes
+   `dl.read()` / `dl.list_objects()` into `vultron/core/`.
+
+**Recognised exception — AS2 Activities.** The 29 protocol message types
+(`vultron/wire/as2/vocab/activities/`) have no core counterpart, so they
+cannot be returned as core objects. Core code that reads a stored wire
+Activity back from the DataLayer (e.g. `dl.read(offer_id)` returning an
+`as_Offer`) is itself a boundary violation (ARCH-01-002, ARCH-03-001), but
+migrating it out of core is tracked as a **separate concern**, not part of
+the DL-05 entity work. Until then, the ratchet exemption set enumerates these
+Activity types explicitly so it can only shrink.
+
 ## Vocabulary Registry Entanglement Across Wire, Core, and DataLayer
 
 The vocabulary registry in `vultron/wire/as2/vocab/` was created before

--- a/plan/history/2607/learning/CONCERN-1496.md
+++ b/plan/history/2607/learning/CONCERN-1496.md
@@ -1,0 +1,57 @@
+---
+source: CONCERN-1496
+timestamp: '2026-07-17T19:47:36.423160+00:00'
+title: DataLayer returns wire objects to core instead of core objects
+type: learning
+---
+
+## Original Concern
+
+`SqliteDataLayer` reconstructs stored objects using the wire `VOCABULARY`
+registry (`find_in_vocabulary()`), so `dl.read()` returns wire-layer types
+(e.g. `as_VulnerabilityCase`) rather than core types. BT nodes and use cases in
+`core/` receive wire objects and work around this via duck-typing Protocols in
+`core/models/protocols.py` (`CaseModel`, `is_case_model()`, etc.). Core
+validators never run on DataLayer-sourced data; the boundary is enforced only
+by structural coincidence between wire and core field names and a shared `type_`
+string. The Protocols evade rather than honour ARCH-01-001 by hiding a runtime
+`core → wire` dependency from mypy/pyright.
+
+After ADR-0017 / #1387 renamed wire classes to the `as_` prefix, the classes
+are now genuinely distinct — but the runtime boundary violation remained.
+
+It was also unclear where wire↔core translation belongs (adapter-converts vs
+use-case-converts).
+
+## Resolution
+
+**Resolved**: 2026-07-17 — planned via `plan-issue`.
+
+Decision (ADR-0034): the DataLayer port returns **core** domain objects for any
+persisted type with a registered `CORE_VOCABULARY` counterpart; the adapter owns
+wire↔core translation via its own `type_`→core-class mapping independent of the
+wire `VOCABULARY`; the duck-typing Protocols are removed. Rejected alternatives:
+use-case-side conversion (DL-01-004), physical DataLayer split (ADR-0012 topology
+change).
+
+**Flow separation** discovered during planning:
+
+- **Flow A (domain entities)** — clean core→core round-trip; the concern's
+  target. Fixed by the implementation Tasks below.
+- **Flow B (wire Activity read-back)** — core reads stored `as_Offer` etc. via
+  `dl.read(activity_id)`. AS2 Activities are wire-only (no core counterpart), so
+  this is a distinct boundary violation. Because its deliverable is to generate
+  more implementation issues, it was filed as a new **Concern** (#1506), not a
+  Task.
+
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1502>.
+Spec: `specs/datalayer.yaml` DL-05-001 through DL-05-004 (v1.2.0).
+Notes: `notes/datalayer-design.md` § "Read Path MUST Return Core Objects".
+ADR: `docs/adr/0034-datalayer-returns-core-objects.md`.
+
+Implementation tracked in:
+
+- #1503 — DataLayer read path returns core objects (reconstruct via CORE_VOCABULARY)
+- #1504 — Remove DataLayer duck-typing Protocols from core (blocked by #1503)
+- #1505 — Architecture ratchet: no wire vocab type escapes dl.read into core
+- #1506 — (Concern) Core reads wire AS2 Activities back from the DataLayer — audit + plan migration

--- a/specs/datalayer.yaml
+++ b/specs/datalayer.yaml
@@ -2,7 +2,7 @@ id: DL
 title: DataLayer Port
 description: Behavioural contract that all DataLayer adapter implementations MUST satisfy. Covers auto-rehydration on read,
   type-safe write operations, and port isolation.
-version: 1.1.0
+version: 1.2.0
 kind: implementation
 scope:
 - prototype
@@ -115,3 +115,68 @@ groups:
       code MUST prefer typed `read()`, `list()`, or dedicated typed helper methods, and migration work MUST remove the
       deprecated methods once existing call sites have been replaced.'
     rationale: The narrow port should converge on typed domain-object access rather than preserve raw-record escape hatches.
+- id: DL-05
+  title: Core-Object Read Contract
+  description: The DataLayer read path MUST return core domain objects for every persisted type that has a registered core
+    counterpart. Wire-layer vocabulary types MUST NOT be handed to core code through the persistence port.
+  specs:
+  - id: DL-05-001
+    priority: MUST
+    statement: '`dl.read(id)` and `dl.list_objects(type_key)` MUST reconstruct persisted domain entities using the core
+      vocabulary registry (`vultron.core.models.registry.CORE_VOCABULARY`) so that the returned instance is a
+      `vultron.core.models` type (e.g. core `VulnerabilityCase`), never a `vultron.wire.as2.vocab` type
+      (e.g. `as_VulnerabilityCase`), whenever the persisted `type_` has a registered core counterpart.'
+    rationale: >
+      Core code MUST receive core domain objects so that core validators run and static analysis sees the real type
+      (ARCH-01-002). Reconstructing via the wire `VOCABULARY` returns wire objects that only work in core by structural
+      coincidence of field names. Decided in ADR-0034; derived from ARCH-01-002 and DL-03-002.
+    relationships:
+    - rel_type: implements
+      spec_id: ARCH-01-002
+    tags:
+    - persistence
+    - wire-format
+  - id: DL-05-002
+    priority: MUST
+    statement: The DataLayer adapter MUST own the wire↔core translation for persistence and MUST maintain its own
+      `type_`→core-class mapping (via `CORE_VOCABULARY`) that is independent of the wire `VOCABULARY` registry; the wire
+      vocabulary registry MUST NOT be the mechanism by which core objects are reconstructed on the read path.
+    rationale: >
+      The wire registry is a wire-layer concern (DL-03-002). Making the adapter reconstruct core objects from a core
+      registry decouples DataLayer storage from the wire type system so the wire layer can evolve without breaking
+      persistence.
+    relationships:
+    - rel_type: implements
+      spec_id: DL-03-002
+    tags:
+    - persistence
+    - wire-format
+  - id: DL-05-003
+    priority: MUST_NOT
+    statement: Core code (`vultron/core/`) MUST NOT rely on structural duck-typing Protocols (e.g. the `CaseModel`,
+      `ParticipantModel`, `ParticipantStatusModel`, `LogEntryModel` Protocols and the `is_case_model()` /
+      `is_participant_model()` / `is_log_entry_model()` `TypeGuard` helpers in `vultron/core/models/protocols.py`) as a
+      means of accepting DataLayer results without importing concrete core types; once DL-05-001 holds, core MUST depend on
+      concrete core domain classes (real `isinstance` narrowing) and the workaround Protocols MUST be removed.
+    rationale: >
+      The duck-typing Protocols exist solely to let core touch wire objects at runtime without a compile-time wire import,
+      evading rather than honouring ARCH-01-001. When the read path returns core objects, the Protocols are dead weight
+      and mask the boundary from mypy/pyright.
+    relationships:
+    - rel_type: implements
+      spec_id: ARCH-01-001
+    tags:
+    - persistence
+    - wire-format
+  - id: DL-05-004
+    priority: MUST
+    statement: An architecture ratchet test MUST assert that no `vultron.wire.as2` vocabulary type is returned from
+      `dl.read()` / `dl.list_objects()` into `vultron/core/`; the test MAY exempt persisted AS2 Activity types that have no
+      registered core counterpart, and any such exemption MUST be enumerated explicitly so the exemption set can only shrink.
+    rationale: >
+      Prevents regression back to wire-object leakage. Activity read-back from core is itself a boundary violation tracked
+      separately; the enumerated exemption set documents the remaining debt and ratchets toward zero.
+    tags:
+    - persistence
+    - testing
+    - wire-format


### PR DESCRIPTION
- Closes #1496

## Summary

Plans CONCERN #1496 (DataLayer returns wire objects to core/BT code instead of
core objects). Records the architectural decision that the DataLayer read path
MUST return core domain objects, and adds the enforceable spec requirements.

## Changes

- **ADR-0034** (`docs/adr/0034-datalayer-returns-core-objects.md`): the
  DataLayer port returns core objects for any persisted type with a registered
  `CORE_VOCABULARY` counterpart; the adapter owns wire↔core translation via its
  own type→class mapping independent of the wire `VOCABULARY`; the duck-typing
  Protocols in `protocols.py` are removed. Persisted AS2 Activities are the
  recognised exception (tracked separately). Rejected alternatives:
  use-case-side conversion, physical DataLayer split.
- **specs/datalayer.yaml**: new group **DL-05 "Core-Object Read Contract"**
  (DL-05-001 … DL-05-004, incl. a ratchet requirement); DL bumped to 1.2.0.
- **notes/datalayer-design.md**: new § "Read Path MUST Return Core Objects
  (ADR-0034, DL-05)".
- **AGENTS.md**: new Common Pitfall — `dl.read()` returns core objects; no
  duck-typing Protocols as a workaround.

## Reference

- Parent Epic: #1394 (Architecture Hardening)
- Related: ADR-0017 (domain/wire separation), ADR-0009 (hexagonal), #1387
  (`as_` prefix migration, now complete)