### PR TITLE
docs: plan concern #1506 — core reads wire AS2 activities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -830,6 +830,25 @@ Short entries are reproduced here; longer ones are referenced below.
   `specs/datalayer.yaml` DL-05-001 through DL-05-004, and
   [notes/datalayer-design.md](notes/datalayer-design.md) § "Read Path MUST
   Return Core Objects".
+- **Core MUST NOT Re-Read a Wire Activity for Semantic Content — Split
+  Semantic vs. Envelope Needs** — `dl.read(activity_id)` in `vultron/core/` to
+  recover a domain fact from a stored AS2 Activity (e.g. reading a stored
+  `Offer` for its embedded report, or an `Invite` for its case/embargo id) is a
+  boundary violation (ARCH-09-001, ARCH-03-001): the activity is being used as
+  the system of record for a fact that should live in core. The domain fact MUST
+  be captured as **core state** at the point the extractor first interprets the
+  inbound activity, and core reads it from there; message-to-message correlation
+  (Accept→Invite) MUST resolve through a **core-entity relationship**, never a
+  wire re-read. This is NOT a license to clone each AS2 Activity into a 1:1 core
+  class — model only the domain fact, in domain vocabulary. Reading a stored
+  activity back is sanctioned ONLY to reconstitute the **verbatim original**
+  envelope for an outbound reply's inline `object_` (activity ids are
+  non-regenerable `urn:uuid:` values and the Actor Knowledge Model requires the
+  full inline original), and ONLY via a wire/adapter-owned seam that treats the
+  payload as opaque — never core interpreting it. See ADR-0035,
+  `specs/datalayer.yaml` DL-06-001 through DL-06-005, and
+  [notes/datalayer-design.md](notes/datalayer-design.md) § "Activity Read-Back:
+  Semantic Content vs. Envelope Reconstitution".
 - **Emit Nodes in Case-Scoped Trigger BTs Must Fail Fast on Missing CaseActor**
   — After switching case-scoped trigger routing from `case_addressees()` to
   CaseActor-only routing, emit nodes must fail fast (FAILURE or immediate

--- a/docs/adr/0035-core-activity-representation-and-envelope-reconstitution.md
+++ b/docs/adr/0035-core-activity-representation-and-envelope-reconstitution.md
@@ -1,0 +1,172 @@
+---
+status: accepted
+date: 2026-07-17
+deciders: Vultron maintainers
+consulted: notes/datalayer-design.md, notes/domain-model-separation.md, ADR-0034, ADR-0017
+informed: CERT/CC Vultron contributors
+---
+
+# Core Activity Representation and Envelope Reconstitution
+
+## Context and Problem Statement
+
+Vultron is a set of communicating **core** state machines. Each Actor is an
+isolated process: it owns a DataLayer of core domain objects, and (per the Actor
+Knowledge Model) its knowledge of the world is bounded strictly by what it has
+received. No actor can reach into another actor's DataLayer. Wire (AS2) exists
+solely as the transport by which one actor's core state informs another's — an
+AS2 Activity is an **envelope carrying a core domain fact** across the process
+boundary, not a domain object in its own right.
+
+ADR-0017 established that wire is a **projection of core**, and ARCH-09-001
+requires core models to be as rich as or richer than their wire counterparts.
+The 29 AS2 protocol Activities (`Offer`, `Invite`, `Accept`, `Reject`, …) break
+this: they were built wire-first and were never given a core counterpart. For
+these types the projection is **inverted** — wire is the only representation,
+and is therefore richer than core.
+
+The concrete consequence: when an actor must remember what a message told it
+(the case id an `Invite` carried, the recommender an `Offer` named, the report
+embedded in a submit `Offer`, the pending embargo proposal for a case), there is
+**no core object to hold that fact**, so core reaches back through the DataLayer
+and re-reads the stored wire envelope — `dl.read(activity_id)` inside
+`vultron/core/`. Concern #1506 audited these sites. ADR-0034 recognised activity
+read-back as a boundary violation but explicitly scoped it **out** and deferred
+it to a separate concern; this ADR is that concern's decision.
+
+The `dl.read(activity_id)` call in core is a **symptom**. The root cause is a
+**missing layer of core domain representation for protocol facts**. A second,
+subtler question surfaced during analysis: emitting a reply (e.g. an `Accept`)
+requires the full inline **verbatim original** activity in the reply's `object_`
+(the Actor Knowledge Model forbids bare URIs), and activity ids are
+non-regenerable random `urn:uuid:` values — so the original envelope cannot be
+losslessly reconstructed from core state. Does that legitimise reading a stored
+activity back?
+
+## Decision Drivers
+
+- Restore "wire is a projection of core" (ADR-0017) and ARCH-09-001: every
+  domain fact an actor remembers MUST have a home in core.
+- Honour ARCH-03-001 (AS2↔domain mapping happens in exactly one place, the
+  semantic extractor) — core MUST NOT re-interpret an activity a second time.
+- Honour ARCH-01-002 / DL-05: wire vocabulary types MUST NOT enter core through
+  the persistence port.
+- Do not regress into cloning each AS2 Activity into a 1:1 core Activity class —
+  the generic-event-mirroring-AS2 anti-pattern `notes/domain-model-separation.md`
+  warns against.
+- Satisfy the Actor Knowledge Model's requirement that replies embed the full
+  inline original activity, given that activity ids are not regenerable.
+- Keep the migration measurable and regression-proof via the DL-05-004 ratchet.
+
+## Considered Options
+
+- **A. Give protocol facts a core representation; correlate via core entities;
+  confine verbatim reconstitution to a wire/adapter seam.** The extractor
+  records the domain fact each inbound message carries as core state (a
+  transition on an existing core entity or a purpose-built core record) at
+  interpretation time. Core reads that core state; correlation between messages
+  (Accept→Invite) flows through a core-entity relationship. Verbatim envelope
+  reconstitution for replies reads a stored activity back only through a
+  wire/adapter-owned seam that treats the payload as opaque.
+- **B. Clone each AS2 Activity into a 1:1 core Activity class.** Give every
+  protocol message a mirror core type and read that instead. Rejected: this
+  duplicates the wire envelope into core rather than modelling the domain fact,
+  reproduces AS2-shaped fields (`object_`, `target`, `context`) in core
+  vocabulary, and is the exact anti-pattern `notes/domain-model-separation.md`
+  cautions against. It relocates the violation without curing it.
+- **C. Pure read-relocation / lossless re-projection.** Stop storing activities;
+  reconstruct any needed envelope by re-projecting core state through the
+  serializer on demand. Rejected: activity ids are random `urn:uuid:` values, so
+  re-projection produces a different id and serialization every time — it cannot
+  reproduce the verbatim original the Actor Knowledge Model requires for reply
+  `object_`. Lossless reconstitution from core state is not achievable.
+
+## Decision Outcome
+
+Chosen option: **A**, because it is the only option that gives protocol facts a
+true core home (curing the ARCH-09-001 inversion rather than relocating it,
+rejecting B) while still satisfying the Actor Knowledge Model's verbatim-reply
+requirement given non-regenerable ids (which C cannot meet).
+
+The decision splits two needs that `dl.read(activity_id)` conflates today:
+
+| Need | Source of truth | Rule |
+|---|---|---|
+| **Semantic content** — what a message *means* (case id, embargo id, recommender, embedded report) | **Core state** | MUST come from a core entity; core MUST NOT re-read the activity to interpret it (DL-06-001, DL-06-002). |
+| **Correlation** — which prior message this one answers | **Core-entity relationship** | MUST resolve through a domain relationship, not a wire re-read (DL-06-003). |
+| **Envelope reconstitution** — embedding the verbatim original in a reply's `object_` / `in_reply_to` | **Stored opaque activity payload** | MAY read a stored activity, but only via a wire/adapter-owned seam that never interprets it (DL-06-004). |
+
+### Decision details
+
+1. **Protocol facts get a core representation.** The semantic extractor — the
+   single interpretation site (ARCH-03-001) — records each domain fact a
+   received message carries as core state at interpretation time, either as a
+   state transition on an existing core entity or as a purpose-built core record.
+   This is **not** a 1:1 clone of the AS2 Activity: model only the domain fact,
+   in domain vocabulary, capturing only what handlers use (DL-06-002).
+2. **Core reads facts from core state, never from the wire envelope.** Core code
+   MUST NOT call `dl.read(activity_id)` / `dl.list_objects(<activity_type>)` to
+   recover semantic content (DL-06-001).
+3. **Correlation is a core-entity relationship.** When a message references a
+   prior one, core correlates through the core entity the prior message created
+   or updated — not by re-reading the referenced activity (DL-06-003).
+4. **Verbatim reconstitution is a wire/adapter seam.** Reading a stored activity
+   payload back to embed the verbatim original in an outbound reply is permitted,
+   but owned by the wire/adapter layer and treated as opaque; core never reads it
+   to interpret meaning. Such a seam is **not** counted as a core boundary
+   violation under DL-05-004 (DL-06-004). `CaseLedgerEntry.payloadSnapshot` is the
+   existing precedent for opaque, write-only activity retention.
+5. **The ratchet shrinks to zero.** As each core semantic read is migrated off
+   activity read-back, its AS2 Activity type is removed from the DL-05-004
+   exemption set; the set MUST reach zero, leaving only the DL-06-004 seam
+   (DL-06-005).
+
+The migration itself is out of scope for this decision — this concern's
+deliverable is the audit and the implementation issues. The audited sites and
+their classification are recorded in `notes/datalayer-design.md`.
+
+### Consequences
+
+- Good, because protocol facts gain a canonical core home, restoring "wire is a
+  projection of core" (ADR-0017, ARCH-09-001) and removing the runtime
+  `core → wire` dependency (ARCH-01-002).
+- Good, because interpretation happens exactly once, at the extractor
+  (ARCH-03-001); core stops maintaining a second, drifting reading of the same
+  message.
+- Good, because the verbatim-reply requirement is met honestly (via retained
+  opaque envelopes) instead of via unachievable lossless re-projection.
+- Good, because the DL-05-004 ratchet gives the migration a measurable,
+  regression-proof target of zero core semantic activity reads.
+- Neutral, because activities may still be persisted — as opaque
+  audit/ledger/reply-envelope blobs — provided core never interprets them.
+- Bad, because the migration is wide (report, embargo, actor/participant
+  subsystems) and staged across multiple implementation issues; the exemption
+  set shrinks incrementally rather than at once.
+
+## Validation
+
+- The DL-05-004 architecture ratchet asserts no `vultron.wire.as2` vocabulary
+  type escapes `dl.read()` / `dl.list_objects()` into `vultron/core/`, with a
+  shrink-only exemption set; DL-06-005 ties the exemption set to zero.
+- `test/architecture/test_core_no_wire_imports.py` continues to enforce that
+  core does not import wire.
+- Per-migration PRs remove the migrated Activity type from the exemption set and
+  add tests that the domain fact is read from core state.
+
+## More Information
+
+- Concern #1506 — the driving audit (core reads wire AS2 Activities back from the
+  DataLayer); parent Epic #1394 (Architecture Hardening).
+- ADR-0034 — DataLayer Port Returns Core Domain Objects; recognised activity
+  read-back as a tracked separate concern (this one) and established the
+  core-object read contract (DL-05) this ADR extends.
+- ADR-0017 — Domain/Wire Object Separation; "wire is a projection of core".
+- ADR-0009 — Hexagonal Architecture; the enclosing ARCH-01/03/09 rules.
+- ADR-0019 — Separate the Case Ledger from the Per-Actor Process Log;
+  `payloadSnapshot` precedent for opaque activity retention.
+- `notes/datalayer-design.md` § "Read Path MUST Return Core Objects" and
+  § "Activity Read-Back: Semantic Content vs. Envelope Reconstitution".
+- `notes/domain-model-separation.md` — domain events as the bridge; the
+  anti-pattern of cloning AS2 shapes into core.
+
+Generated spec requirements: `datalayer.yaml` DL-06-001 through DL-06-005.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -89,6 +89,8 @@ General information about architectural decision records is available at <https:
   Types](0032-validate-at-edge-promote-to-core.md)
 - [ADR-0034 DataLayer Port Returns Core Domain
   Objects](0034-datalayer-returns-core-objects.md)
+- [ADR-0035 Core Activity Representation and Envelope
+  Reconstitution](0035-core-activity-representation-and-envelope-reconstitution.md)
 
 ## Proposed ADRs
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -253,6 +253,8 @@ nav:
       - vultron/enums/ Neutral Layer: 'adr/0031-vultron-enums-neutral-layer.md'
       - Validate at Edge, Promote to Core: 'adr/0032-validate-at-edge-promote-to-core.md'
       - Lifecycle-Staged Domain Types: 'adr/0033-lifecycle-staged-case-types.md'
+      - DataLayer Returns Core Objects: 'adr/0034-datalayer-returns-core-objects.md'
+      - Core Activity Representation and Envelope Reconstitution: 'adr/0035-core-activity-representation-and-envelope-reconstitution.md'
   - About:
     - Contributing: 'about/contributing.md'
     - FAQ: 'about/faq.md'

--- a/notes/datalayer-design.md
+++ b/notes/datalayer-design.md
@@ -211,9 +211,97 @@ Target end-state (DL-05-001 through DL-05-004):
 cannot be returned as core objects. Core code that reads a stored wire
 Activity back from the DataLayer (e.g. `dl.read(offer_id)` returning an
 `as_Offer`) is itself a boundary violation (ARCH-01-002, ARCH-03-001), but
-migrating it out of core is tracked as a **separate concern**, not part of
-the DL-05 entity work. Until then, the ratchet exemption set enumerates these
-Activity types explicitly so it can only shrink.
+migrating it out of core is tracked as a **separate concern** (#1506, decided
+in ADR-0035), not part of the DL-05 entity work. Until then, the ratchet
+exemption set enumerates these Activity types explicitly so it can only shrink.
+
+## Activity Read-Back: Semantic Content vs. Envelope Reconstitution (ADR-0035, DL-06)
+
+**Decided (ADR-0035).** `dl.read(activity_id)` in `vultron/core/` is a
+*symptom*. The root cause is that the 29 AS2 protocol Activities (`Offer`,
+`Invite`, `Accept`, …) were built wire-first and never given a core counterpart,
+inverting "wire is a projection of core" (ADR-0017) and violating ARCH-09-001.
+Because the domain fact each message carries has no home in core, core reaches
+back through the DataLayer to re-read the stored wire envelope.
+
+Vultron is a set of communicating **core** state machines; wire exists only to
+carry a core fact from one isolated actor to another (Actor Knowledge Model). An
+AS2 Activity is an **envelope**, not a domain object. The fix splits two needs
+that `dl.read(activity_id)` conflates:
+
+| Need | Source of truth | Rule |
+|---|---|---|
+| **Semantic content** — what a message *means* | **Core state** | Core MUST NOT re-read the activity to interpret it (DL-06-001, DL-06-002). |
+| **Correlation** — which prior message this answers | **Core-entity relationship** | Resolve through a domain relationship, not a wire re-read (DL-06-003). |
+| **Envelope reconstitution** — verbatim original in a reply's `object_` | **Stored opaque activity payload** | MAY read a stored activity, but only via a wire/adapter seam that never interprets it (DL-06-004). |
+
+The extractor (the single interpretation site, ARCH-03-001) records each domain
+fact as core state at interpretation time — a transition on an existing core
+entity or a purpose-built core record. This is **not** a 1:1 clone of the AS2
+Activity into core (the generic-event-mirroring-AS2 anti-pattern in
+`notes/domain-model-separation.md`); model only the domain fact, in domain
+vocabulary, capturing only what handlers use.
+
+**Why the envelope seam is legitimate, not anathema.** Activity ids are
+non-regenerable random `urn:uuid:` values (`vultron/wire/as2/vocab/base/utils.py`),
+and the Actor Knowledge Model requires a reply to embed the *full inline
+original* activity — so a reply's `object_` cannot be produced by re-projecting
+core state. The original envelope must be retained and read back verbatim.
+Confining that read to a wire/adapter-owned seam that treats the payload as
+opaque keeps semantic authority in core. `CaseLedgerEntry.payloadSnapshot` is
+the existing precedent for opaque, write-only activity retention.
+
+### Audited core activity read-back sites (concern #1506)
+
+Classification of every `dl.read(activity_id)` / activity `list_objects()` site
+in `vultron/core/` at audit time. Categories A/B need migration; C is the
+sanctioned seam; D is not an activity read (covered by DL-05 / #1503).
+
+**A — plumbing re-reads** (re-read only to `model_dump()` the just-emitted
+activity into the API response; the factory already built the object):
+
+- `vultron/core/use_cases/triggers/report.py` — `_handle_result` in
+  `SvcValidateReportUseCase`, `SvcInvalidateReportUseCase`, `SvcRejectReportUseCase`,
+  `SvcCloseReportUseCase` (4 sites).
+- `vultron/core/behaviors/case/nodes/delegation.py:160` — re-reads the
+  just-created `Offer(CaseManagerRole)`.
+- *Fix*: `TriggerActivityPort` returns `(activity_id, activity_dict)`; delete the
+  re-reads. Not even a semantic read.
+
+**B — semantic-content reads** (core re-interprets a stored activity for a
+domain fact — the ARCH-09-001 core violations):
+
+- *report/offer*: `triggers/report.py::_resolve_offer_and_report` (reads `Offer`
+  for the embedded `VulnerabilityReport`); `behaviors/report/nodes/emit.py:90`
+  and `behaviors/report/nodes/case_creation.py:191` (read `Offer` for fallback
+  addressing).
+- *embargo*: `use_cases/received/embargo.py:74,474` (read `Invite` for `context`
+  = case id and `object_` = embargo id); `use_cases/triggers/_helpers.py:129`
+  and `find_embargo_proposal` / `list_objects("Invite")` (pending proposal);
+  `dispatcher.py:196` (read `Invite` for `context`).
+- *actor/participant*: `use_cases/received/actor/offer_case_participant.py:128,193`
+  (read the original recommendation `Offer` for the recommender's actor id);
+  `use_cases/triggers/actor.py:163` (read `Invite` for a type check).
+- *Fix*: capture the fact as core state at extraction time; read it from core.
+
+**C — envelope reconstitution** (verbatim original needed for a reply):
+
+- Reply factories (`rm_accept_invite_to_case_activity`, embargo/report/actor
+  Accept/Reject) require the full inline original activity in `object_`.
+- *Fix*: verify whether any live reply path actually needs verbatim
+  reconstitution today; if so, provide a wire/adapter-owned opaque envelope seam
+  (DL-06-004). May be near-empty in current code.
+
+**D — not activities** (core entities, covered by DL-05 / #1503, out of scope):
+
+- `dispatcher.py:147` (`VultronReplicationState`); `received/actor/announce.py:29`
+  (`VultronReportCaseLink`); `list_objects("CaseLedgerEntry")` reads; case /
+  participant / status / marker reads.
+
+Implementation is tracked in the issues filed from concern #1506 (blocked by
+that concern, children of Epic #1394). As each B site migrates, remove its
+Activity type from the DL-05-004 exemption set (DL-06-005) until the set reaches
+zero.
 
 ## Vocabulary Registry Entanglement Across Wire, Core, and DataLayer
 

--- a/plan/history/2607/learning/CONCERN-1506.md
+++ b/plan/history/2607/learning/CONCERN-1506.md
@@ -1,0 +1,61 @@
+---
+source: CONCERN-1506
+timestamp: '2026-07-17T22:45:04.805141+00:00'
+title: Core reads wire AS2 activities back from the DataLayer
+type: learning
+---
+
+## Original concern
+
+Separate from the entity read path (#1496 / #1503), core BT nodes and use cases
+read persisted **wire AS2 Activities** back from the DataLayer via
+`dl.read(activity_id)` — e.g. `report/nodes/emit.py` and
+`report/nodes/case_creation.py` read a stored `as_Offer`;
+`report/nodes/storage.py` even documents "`dl.read()` does not work for
+`VultronActivity`". AS2 Activities are wire-only (no core counterpart), so this
+is a genuine boundary violation, not something the DL-05 entity work fixes.
+
+This is a **Concern** whose deliverable is to generate implementation issues:
+audit every site, classify each, and spin off the migration work.
+
+- **ARCH-01-002**: core functions MUST accept and return domain types only.
+- **ARCH-03-001**: AS2↔domain mapping MUST happen in exactly one location.
+- **ARCH-09-001**: core models are as rich as/richer than wire.
+
+## Resolution
+
+**Resolved**: 2026-07-17 — planned via `plan-issue`.
+
+Diagnosis: `dl.read(activity_id)` in core is a **symptom**; the root cause is
+that the 29 AS2 protocol Activities were built wire-first and never given a core
+counterpart, inverting "wire is a projection of core" (ADR-0017) and violating
+ARCH-09-001. Vultron is a set of communicating **core** state machines; wire is
+only the transport between isolated cores (Actor Knowledge Model), and an AS2
+Activity is an envelope carrying a core fact — not a domain object.
+
+Decision (ADR-0035) splits two needs `dl.read(activity_id)` conflates:
+
+- **Semantic content** — MUST come from core state, captured by the extractor at
+  interpretation time; core MUST NOT re-read the activity. Correlation between
+  messages (Accept→Invite) flows through a core-entity relationship, not a wire
+  re-read. This is NOT a license to clone each AS2 Activity into a 1:1 core class.
+- **Envelope reconstitution** — reconstituting the verbatim original activity for
+  a reply's inline `object_` MAY read a stored activity back (activity ids are
+  non-regenerable `urn:uuid:` values; the Actor Knowledge Model requires the full
+  inline original), but only via a wire/adapter-owned opaque seam — never core
+  interpreting it.
+
+Audited sites classified A (plumbing re-reads) / B (semantic-content reads,
+split by domain) / C (envelope reconstitution) / D (not activities; covered by
+DL-05 / #1503).
+
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1516>
+Spec: `specs/datalayer.yaml` DL-06-001 through DL-06-005 (new DL-06 group).
+Notes: `notes/datalayer-design.md` § "Activity Read-Back: Semantic Content vs.
+Envelope Reconstitution" (includes the audited site inventory).
+ADR: `docs/adr/0035-core-activity-representation-and-envelope-reconstitution.md`.
+
+Implementation tracked in issues #1517 (A — plumbing), #1518 (B —
+report/offer), #1519 (B — embargo), #1520 (B — actor/participant), and #1521
+(C — envelope seam). All blocked by #1506, children of Epic #1394, added to
+Project #24.

--- a/specs/datalayer.yaml
+++ b/specs/datalayer.yaml
@@ -2,7 +2,7 @@ id: DL
 title: DataLayer Port
 description: Behavioural contract that all DataLayer adapter implementations MUST satisfy. Covers auto-rehydration on read,
   type-safe write operations, and port isolation.
-version: 1.2.0
+version: 1.3.0
 kind: implementation
 scope:
 - prototype
@@ -178,6 +178,103 @@ groups:
     rationale: >
       Prevents regression back to wire-object leakage. Activity read-back from core is itself a boundary violation tracked
       separately; the enumerated exemption set documents the remaining debt and ratchets toward zero.
+    tags:
+    - persistence
+    - testing
+    - wire-format
+- id: DL-06
+  title: Activity Read-Back and the Semantic/Envelope Split
+  description: >
+    Core code MUST NOT read a persisted wire AS2 Activity back from the DataLayer to recover its semantic content. AS2
+    protocol Activities are wire-only envelopes with no registered core counterpart (the DL-05-004 exemption set); the
+    domain fact each carries MUST live as core state. Reading a stored activity is permitted only to reconstitute the
+    verbatim envelope for an outbound reply, and only through a wire/adapter-owned seam — never core interpreting it.
+    Decided in ADR-0035; extends DL-05 and ARCH-09-001.
+  specs:
+  - id: DL-06-001
+    priority: MUST_NOT
+    statement: >
+      Core code (`vultron/core/`) MUST NOT call `dl.read(activity_id)` or `dl.list_objects(<activity_type>)` to recover
+      the semantic content of a persisted wire AS2 Activity (e.g. reading a stored `Offer` to obtain the embedded report,
+      or a stored `Invite` to obtain its case or embargo id). The domain fact MUST be obtained from core state instead.
+    rationale: >
+      AS2 protocol Activities are wire-only envelopes with no core counterpart, so reading one back into core hands a
+      `vultron.wire.as2` type to core code (ARCH-01-002) and re-interprets an activity the semantic extractor already
+      interpreted once (ARCH-03-001). The activity is being used as the system of record for a domain fact, inverting the
+      rule that wire is a projection of core (ARCH-09-001). Decided in ADR-0035; source concern #1506.
+    relationships:
+    - rel_type: implements
+      spec_id: ARCH-09-001
+    - rel_type: implements
+      spec_id: ARCH-03-001
+    tags:
+    - persistence
+    - wire-format
+  - id: DL-06-002
+    priority: MUST
+    statement: >
+      Every domain fact an actor must remember from a received protocol message MUST be recorded as core state — either a
+      state transition on an existing core entity or a purpose-built core record — at the point the semantic extractor
+      first interprets the inbound activity. Core MUST NOT reconstruct such a fact by re-reading the stored activity later.
+    rationale: >
+      Core is the sole system of record for domain facts (the Actor Knowledge Model bounds an actor's knowledge to what it
+      has received, and that knowledge is held as core state). Capturing the fact once at extraction time removes the need
+      for core to reach back through the wire envelope. This does NOT mean cloning each AS2 Activity into a 1:1 core
+      Activity class; model only the domain fact each message conveys, in domain vocabulary, capturing only what handlers
+      use. Decided in ADR-0035.
+    relationships:
+    - rel_type: implements
+      spec_id: ARCH-03-001
+    tags:
+    - persistence
+    - wire-format
+  - id: DL-06-003
+    priority: MUST
+    statement: >
+      When an inbound protocol message references a prior message (e.g. an Accept answering an Invite, a counter-offer
+      answering an Offer), core MUST correlate them through a core-entity relationship (e.g. "the pending embargo proposal
+      for this case", "the invitation for this actor"), NOT by re-reading the referenced wire activity from the DataLayer.
+    rationale: >
+      Correlation is a domain relationship between core facts. Recovering it by re-reading the referenced activity
+      reintroduces the DL-06-001 violation and depends on the wire envelope surviving as a semantic record. When the prior
+      message was first received it MUST have created or updated the core entity that the later message now correlates to.
+      Decided in ADR-0035.
+    tags:
+    - persistence
+    - wire-format
+  - id: DL-06-004
+    priority: MUST
+    statement: >
+      Reconstituting the verbatim original activity for an outbound reply's inline `object_` / `in_reply_to` field (as the
+      Actor Knowledge Model requires) MAY read a stored activity payload back, but this retrieval MUST be owned by the
+      wire/adapter layer and treat the stored activity as an opaque envelope; core code MUST NOT read the activity to
+      interpret its meaning. Such a wire/adapter-owned envelope seam is NOT counted as a core boundary violation under
+      DL-05-004.
+    rationale: >
+      Activity IDs are non-regenerable random `urn:uuid:` values and the Actor Knowledge Model requires a reply to embed
+      the full inline original activity, so verbatim reconstitution cannot be produced by re-projecting core state — the
+      original envelope (with its original id) must be retained and read back. Confining that read to a wire/adapter seam
+      that never interprets the payload keeps semantic authority in core while satisfying transport needs. `CaseLedgerEntry`
+      `payloadSnapshot` is the existing precedent for opaque, write-only activity retention. Decided in ADR-0035.
+    relationships:
+    - rel_type: refines
+      spec_id: DL-05-004
+    tags:
+    - persistence
+    - wire-format
+  - id: DL-06-005
+    priority: MUST
+    statement: >
+      As each core semantic read is migrated off activity read-back (per DL-06-001 through DL-06-003), the corresponding
+      AS2 Activity type MUST be removed from the DL-05-004 ratchet exemption set. The exemption set MUST reach zero once
+      all core semantic activity reads are migrated; the only remaining sanctioned activity reads are the wire/adapter
+      envelope-reconstitution seam of DL-06-004.
+    rationale: >
+      Ties the migration to an enforceable, monotonically shrinking ratchet so progress is measurable and regressions are
+      blocked. Decided in ADR-0035; source concern #1506.
+    relationships:
+    - rel_type: refines
+      spec_id: DL-05-004
     tags:
     - persistence
     - testing


### PR DESCRIPTION
- Closes #1506

## Summary

Plans Concern #1506 (core reads wire AS2 Activities back from the DataLayer).
The `dl.read(activity_id)` calls in `vultron/core/` are a **symptom**; the root
cause is that the 29 AS2 protocol Activities were built wire-first and never
given a core counterpart, inverting "wire is a projection of core" (ADR-0017)
and violating ARCH-09-001. Core reaches back through the wire envelope because
the domain fact has no home in core.

The decision splits two needs that `dl.read(activity_id)` conflates:

- **Semantic content** — MUST come from core state; core MUST NOT re-read the
  activity to interpret it, and correlation between messages flows through a
  core-entity relationship, not a wire re-read.
- **Envelope reconstitution** — reconstituting the *verbatim original* activity
  for an outbound reply's inline `object_` MAY read a stored activity back
  (activity ids are non-regenerable `urn:uuid:` values and the Actor Knowledge
  Model requires the full inline original), but only via a wire/adapter-owned
  seam that treats the payload as opaque — never core interpreting it.

This is a docs-only planning PR. The migration itself is tracked in the
implementation issues filed from this concern (blocked by #1506, children of
Epic #1394).

## Changes

- **`docs/adr/0035-core-activity-representation-and-envelope-reconstitution.md`**
  — new ADR extending ADR-0034; records the semantic-content-vs-envelope
  decision and rejected alternatives (1:1 activity cloning; lossless
  re-projection; pure read-relocation).
- **`specs/datalayer.yaml`** — new **DL-06** group (DL-06-001 through DL-06-005)
  enforcing the split and tying the DL-05-004 exemption set to zero; version
  1.2.0 → 1.3.0.
- **`notes/datalayer-design.md`** — new § "Activity Read-Back: Semantic Content
  vs. Envelope Reconstitution" with the audited A/B/C/D site inventory.
- **`AGENTS.md`** — new Common Pitfalls entry naming the semantic-vs-envelope
  split.
- **`docs/adr/index.md`**, **`mkdocs.yml`** — add ADR-0034 and ADR-0035 to the
  index and nav.