### PR TITLE
fix: actor outbox endpoint returns empty items after ADR-0034 (#1515)

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1515.md
+++ b/plan/history/2607/implementation/ISSUE-1515.md
@@ -1,0 +1,15 @@
+---
+source: ISSUE-1515
+timestamp: '2026-07-20T13:41:03.314294+00:00'
+title: fix actor outbox endpoint empty items after ADR-0034
+type: implementation
+---
+
+Issue #1515: GET /datalayer/Actors/{actor_id}/outbox/ always returned empty items
+after PR #1512 (ADR-0034) changed dl.read() to return CoreActor objects.
+CoreActor.outbox is a plain str URI; coercing it to as_Actor via model_validate
+produced an empty as_OrderedCollection with no items. Root cause: endpoint read
+from the actor object field instead of the DataLayer queue. Fix: replaced
+actor-coercion path in get_actor_outbox with
+CaseOutboxPersistence.outbox_list_for_actor(actor_id). Added three regression
+tests. PR: <https://github.com/CERTCC/Vultron/pull/1522>

--- a/plan/incoming/learnings/20260720-actor-outbox-endpoint-must-query-queue-not-actor-field.md
+++ b/plan/incoming/learnings/20260720-actor-outbox-endpoint-must-query-queue-not-actor-field.md
@@ -1,0 +1,37 @@
+---
+title: Actor outbox endpoint must query DataLayer queue, not actor.outbox field
+type: learning
+timestamp: 2026-07-20T00:00:00Z
+source: ISSUE-1515
+---
+
+## Observation
+
+`GET /datalayer/Actors/{actor_id}/outbox/` used to call `dl.read(actor_id)`,
+then `as_Actor.model_validate(actor_obj.model_dump(...))`, and then iterate
+over `actor.outbox.items`.
+
+After ADR-0034 / PR #1512, `dl.read()` returns a `CoreActor` whose `outbox`
+field is a plain `str | None` URI — not an `as_OrderedCollection`.
+`as_Actor._coerce_uri_to_collection` converts that URI to an
+`as_OrderedCollection(id_=uri)` with an empty `items` list, so the endpoint
+silently returned zero items regardless of the actor's actual outbox queue.
+
+## Fix
+
+Replace the actor-object coercion path with a direct DataLayer queue query:
+
+```python
+activity_ids = cast(CaseOutboxPersistence, datalayer).outbox_list_for_actor(actor_id)
+outbox = as_OrderedCollection(id_=f"{actor_id}/outbox")
+outbox.items = [rehydrate(aid, dl=datalayer) for aid in activity_ids]
+```
+
+The actor `read()` result is still used only for the 404 guard.
+
+## Generalisation
+
+Any endpoint that needs the *contents* of an actor's outbox queue must call
+`outbox_list_for_actor(actor_id)` directly — not look at `actor.outbox.items`,
+which is always empty after ADR-0034. The actor object's `outbox` field is now
+only a URI pointer to the collection endpoint, not the collection itself.

--- a/test/adapters/driving/fastapi/routers/test_datalayer.py
+++ b/test/adapters/driving/fastapi/routers/test_datalayer.py
@@ -155,3 +155,62 @@ def test_specific_routes_not_shadowed_by_catch_all(
     assert response.status_code == status.HTTP_200_OK
     data = response.json()
     assert offer.id_ in data
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for #1515: GET /Actors/{actor_id}/outbox/ must return
+# the actor's actual queued outbox items, not an empty collection.
+# ---------------------------------------------------------------------------
+
+
+def test_get_actor_outbox_returns_404_for_unknown_actor(client_datalayer):
+    """Non-existent actor returns 404."""
+    response = client_datalayer.get("/datalayer/Actors/no-such-actor/outbox/")
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_get_actor_outbox_returns_empty_items_when_queue_is_empty(
+    client_datalayer, datalayer
+):
+    """Existing actor with no queued outbox items returns an empty items list."""
+    from vultron.adapters.driven.db_record import object_to_record
+    from vultron.wire.as2.vocab.base.objects.actors import as_Service
+
+    actor = as_Service(name="test-empty-outbox")
+    datalayer.create(object_to_record(actor))
+
+    response = client_datalayer.get(f"/datalayer/Actors/{actor.id_}/outbox/")
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    assert body.get("type") == "OrderedCollection"
+    assert body.get("orderedItems", body.get("items", None)) == []
+
+
+def test_get_actor_outbox_returns_queued_activity_ids(
+    client_datalayer, datalayer, offer
+):
+    """After enqueuing an activity for an actor, the endpoint must return it.
+
+    Regression for #1515: ADR-0034 changed dl.read() to return CoreActor
+    (outbox=str URI), so the old as_Actor.model_validate() path produced
+    an empty as_OrderedCollection with no items.
+    """
+    from vultron.adapters.driven.db_record import object_to_record
+    from vultron.wire.as2.vocab.base.objects.actors import as_Service
+
+    actor = as_Service(name="test-nonempty-outbox")
+    datalayer.create(object_to_record(actor))
+
+    # Persist the activity and record it in the actor's outbox queue.
+    datalayer.create(object_to_record(offer))
+    datalayer.record_outbox_item(actor.id_, offer.id_)
+
+    response = client_datalayer.get(f"/datalayer/Actors/{actor.id_}/outbox/")
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    assert body.get("type") == "OrderedCollection"
+    items = body.get("orderedItems", body.get("items", []))
+    assert len(items) == 1
+    item = items[0]
+    # Rehydrated item should have the activity's id
+    assert item.get("id") == offer.id_

--- a/vultron/adapters/driving/fastapi/routers/datalayer.py
+++ b/vultron/adapters/driving/fastapi/routers/datalayer.py
@@ -17,19 +17,18 @@ Provides a backend API router for basic Vultron data layer operations.
 """
 
 import logging
-from copy import deepcopy
-from typing import Any
+from typing import Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from vultron.adapters.driven.datalayer import get_shared_dl
 from vultron.adapters.driven.db_record import Record, record_to_object
 from vultron.adapters.driving.fastapi.responses import AS2JSONResponse
+from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.ports.datalayer import DataLayer
 from vultron.wire.as2.rehydration import rehydrate
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
-from vultron.wire.as2.vocab.base.objects.base import as_Object
 from vultron.wire.as2.vocab.base.objects.collections import (
     as_OrderedCollection,
 )
@@ -259,20 +258,17 @@ def get_actor_outbox(
     if not actor_obj:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
 
-    actor = as_Actor.model_validate(
-        actor_obj.model_dump(by_alias=True, serialize_as_any=True)
-    )
+    # dl.read() now returns a CoreActor whose outbox field is a plain URI
+    # string (ADR-0034 / PR #1512).  The old as_Actor.model_validate() path
+    # converted that URI to an empty as_OrderedCollection with no items.
+    # Instead, query the DataLayer queue directly for the actor's outbox IDs.
+    activity_ids = cast(
+        CaseOutboxPersistence, datalayer
+    ).outbox_list_for_actor(actor_id)
 
-    if not actor.outbox:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
-
-    # make a copy
-    outbox = deepcopy(actor.outbox)
-
+    outbox = as_OrderedCollection(id_=f"{actor_id}/outbox")
     outbox.items = [
-        rehydrate(item, dl=datalayer)
-        for item in outbox.items
-        if isinstance(item, str) or isinstance(item, as_Object)
+        rehydrate(activity_id, dl=datalayer) for activity_id in activity_ids
     ]
 
     return AS2JSONResponse(outbox)


### PR DESCRIPTION
- Closes #1515

## Summary

`GET /datalayer/Actors/{actor_id}/outbox/` always returned an empty `items`
list after PR #1512 (ADR-0034) changed `dl.read()` to return `CoreActor`
objects. `CoreActor.outbox` is a plain `str` URI; coercing it to
`as_Actor` via `model_validate` produced an empty `as_OrderedCollection`
with no items.

## Changes

- `vultron/adapters/driving/fastapi/routers/datalayer.py`: replaced the
  actor-coercion path in `get_actor_outbox` with a direct
  `CaseOutboxPersistence.outbox_list_for_actor(actor_id)` query; actor
  `read()` result is retained only as a 404 guard.
- `test/adapters/driving/fastapi/routers/test_datalayer.py`: added three
  regression tests — 404 for unknown actor, empty items for zero-queue
  actor, and non-empty items after `record_outbox_item`.

## Verification

- New regression tests confirm the fix (previously failing).
- Full unit suite: 5078 passed, 38 skipped, 2 xfailed — no regressions.
- All four linters (black, flake8, mypy, pyright) pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)