### PR TITLE
specs: plan concern #1491 — spec kind mismatches at group and item level

### DIFF
--- a/plan/history/2607/learning/CONCERN-1491.md
+++ b/plan/history/2607/learning/CONCERN-1491.md
@@ -1,0 +1,50 @@
+---
+source: CONCERN-1491
+timestamp: '2026-07-20T14:14:35.677051+00:00'
+title: 'specs: audit and fix kind mismatches at file, group, and item level'
+type: learning
+---
+
+## Background
+
+Issue #1490 fixed the 7 spec files where the *file-level* `kind:` was clearly wrong.
+However, miscategorization exists at all three levels of the spec hierarchy —
+file, group, and individual item — and the levels interact through inheritance.
+
+## How kind inheritance works
+
+The `kind:` field cascades downward as a default:
+
+- **File-level** `kind:` is the default for all groups and items in that file
+- **Group-level** `kind:` overrides the file default for all items in that group
+- **Item-level** `kind:` overrides both, regardless of what the file or group says
+
+This means **file and group kinds are purely a boilerplate-reduction convenience**.
+The semantically important thing is that **each individual spec item ends up in the
+correct category**. File and group kinds should reflect the majority of their
+contents, but exceptions at any level must be overridden explicitly.
+
+## Problem
+
+Mixed-content files and groups cause specs to appear on the wrong category page.
+The audit in #1490 only addressed file-level kind errors. Group-level and
+item-level mismatches have never been systematically reviewed.
+
+## Key finding during planning
+
+`render_for_kind()` in `docs_render.py` filters by **file-level kind only** —
+group/item kind overrides affect `spec-dump`/LLM export but are silently ignored
+in published docs. This means adding YAML overrides alone is insufficient to fix
+the wrong-page problem; the renderer must be updated to use `effective_kind()`.
+
+## Work required
+
+1. Update `render_for_kind()` to route groups by effective kind; groups with
+   mixed-kind items appear on each matching page; non-matching items suppressed.
+2. Audit all ~60 spec files bottom-up (item → group → file kind) and add
+   group/item overrides as needed.
+3. Add a linter warning for kind drift (suppressible via `lint_suppress`).
+
+**Resolved**: 2026-07-20 — implementation tracked in #1528.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1527>.
+Spec: `specs/spec-registry.yaml` (SR-09-001 through SR-09-004).

--- a/specs/spec-registry.yaml
+++ b/specs/spec-registry.yaml
@@ -237,6 +237,61 @@ groups:
     priority: SHOULD
     statement: The JSON exporter SHOULD support filtering by `kind`, `scope`, `tags`, or `priority` to allow agents to request
       only relevant subsets.
+- id: SR-09
+  title: Docs Renderer Kind Routing (MUST)
+  specs:
+  - id: SR-09-001
+    priority: MUST
+    statement: >-
+      The `render_for_kind(kind, registry)` function MUST route each spec group to the docs page
+      matching its effective kind, where effective kind is resolved by `effective_kind()` (item
+      overrides group, group overrides file).
+    rationale: >-
+      Filtering by file-level kind only causes group- and item-level kind overrides to be silently
+      ignored in published docs, placing specs on the wrong category page despite correct YAML
+      metadata.
+    tags:
+    - documentation
+    - tooling
+  - id: SR-09-002
+    priority: MUST
+    statement: >-
+      When a group contains items of mixed kinds, the group MUST appear on each docs page for which
+      it has at least one item whose effective kind matches that page. Items whose effective kind does
+      not match the current page MUST be suppressed (not rendered) on that page.
+    rationale: >-
+      Showing items on every page where their group appears would duplicate content and mislead
+      readers about a spec's portability tier. Suppressing non-matching items keeps each page
+      accurate while preserving group context.
+    tags:
+    - documentation
+    - tooling
+  - id: SR-09-003
+    priority: MUST
+    statement: >-
+      The `SpecFile`-level `kind` field MUST reflect the majority kind of its groups (after
+      resolving effective group kind from the majority of their items). Group-level `kind` overrides
+      MUST reflect the majority kind of their items. These invariants MUST be enforced by the spec
+      linter.
+    rationale: >-
+      File and group kinds exist solely as boilerplate-reduction defaults. If the declared kind does
+      not match the actual majority of its children, it misleads both agents consuming spec-dump
+      output and the docs renderer.
+    tags:
+    - documentation
+    - tooling
+  - id: SR-09-004
+    priority: SHOULD
+    statement: >-
+      The spec linter SHOULD emit an advisory warning when a group-level `kind` does not match
+      the majority effective kind of its items, and when a file-level `kind` does not match the
+      majority effective group kind. The warning SHOULD be suppressible via `lint_suppress`.
+    rationale: >-
+      Automated detection of kind drift prevents the category-page placement errors that motivated
+      issue #1491 from recurring silently.
+    tags:
+    - documentation
+    - tooling
 - id: SR-08
   title: Migration (MUST)
   specs:


### PR DESCRIPTION
- Closes #1491

## Summary

- Adds `SR-09` group to `specs/spec-registry.yaml` with four requirements
  formalizing how `render_for_kind()` MUST route spec groups and items to
  docs pages by effective kind (not file-level kind)
- Specifies that file/group `kind` fields MUST reflect the majority of their
  children, enforced by the spec linter
- Adds linter advisory warning for kind drift (suppressible via `lint_suppress`)

## Changes

- `specs/spec-registry.yaml`: new SR-09 group (SR-09-001 through SR-09-004)

🤖 Generated with [Claude Code](https://claude.com/claude-code)