### PR TITLE
refactor(#1504): remove duck-typing Protocols; replace with concrete isinstance checks

### DIFF
--- a/notes/bt-integration.md
+++ b/notes/bt-integration.md
@@ -1069,7 +1069,7 @@ def _read_case_obj(self, case_id: str) -> VulnerabilityCase:
         obj = self.blackboard[case_id]
     except KeyError:
         raise BtNodePreconditionError(f"case {case_id!r} not in blackboard")
-    if not is_case_model(obj):
+    if not isinstance(obj, VulnerabilityCase):
         raise BtNodePreconditionError(
             f"blackboard entry {case_id!r} is not a VulnerabilityCase"
         )

--- a/notes/codebase-structure.md
+++ b/notes/codebase-structure.md
@@ -500,12 +500,12 @@ This module is importable from both the `behaviors/` layer and the
 `use_cases/_helpers.py`. All callers import from `use_cases._helpers` directly.
 The `triggers/_helpers.py` re-export bridge is no longer needed or present.
 
-**Corollary**: Core domain model classes (e.g., `VultronCase`) should
-implement the same interface methods as their wire-layer counterparts so that
-Protocol guards like `is_case_model()` return `True` for both families.
-Avoid making the Protocol guard depend on the concrete wire-layer class, and
-never use methods that may be removed as discriminators — use Protocol-declared
-fields instead (see BUILD_LEARNINGS entry IS-CASE-MODEL-DISCRIMINATOR-888).
+**Corollary**: The duck-typing Protocol guards (`is_case_model()` etc.) were
+removed in PR #1529 (ADR-0034 / DL-05-003). Core code now uses concrete
+`isinstance(obj, VulnerabilityCase)` checks directly. The old corollary about
+keeping domain model classes structurally compatible with wire types no longer
+applies — the DataLayer read path (ADR-0034) ensures `dl.read()` returns core
+objects, so `isinstance` always holds.
 
 ### FastAPI response_model Filtering
 

--- a/notes/datalayer-design.md
+++ b/notes/datalayer-design.md
@@ -187,14 +187,13 @@ of the coupling before designing the refactor.
 types (`vultron/wire/as2/vocab/objects/`, `as_`-prefixed), for any persisted
 `type_` that has a registered core counterpart in `CORE_VOCABULARY`.
 
-The current read path reconstructs via `find_in_vocabulary()` (the **wire**
-`VOCABULARY`), so core BT nodes and use cases receive `as_VulnerabilityCase`
-etc. and work around it with the duck-typing Protocols and `TypeGuard`
-helpers in `vultron/core/models/protocols.py` (`CaseModel`, `is_case_model()`,
-…). Those Protocols evade — rather than honour — ARCH-01-001: they hide a
-runtime `core → wire` dependency from mypy/pyright.
+**Implemented (PR #1529):** The read path now reconstructs domain entities via
+`CORE_VOCABULARY`, so `dl.read()` returns core objects. The duck-typing
+Protocols and `TypeGuard` helpers (`CaseModel`, `is_case_model()`, etc.) in
+`vultron/core/models/protocols.py` were removed; core uses direct
+`isinstance()` checks against concrete core classes (DL-05-003).
 
-Target end-state (DL-05-001 through DL-05-004):
+DL-05 end-state achieved (all four requirements met):
 
 1. The adapter reconstructs registered domain entities via
    `find_in_core_vocabulary()` / `CORE_VOCABULARY`, so reads/writes of domain

--- a/plan/history/2607/implementation/ISSUE-1504.md
+++ b/plan/history/2607/implementation/ISSUE-1504.md
@@ -1,0 +1,24 @@
+---
+source: ISSUE-1504
+timestamp: '2026-07-20T14:27:38.892948+00:00'
+title: 'Remove DataLayer duck-typing Protocols from core (issue #1504)'
+type: implementation
+---
+
+## Issue #1504 — Remove DataLayer duck-typing Protocols from core
+
+Removed CaseModel, ParticipantModel, ParticipantStatusModel, LogEntryModel Protocols
+and is_case_model/is_participant_model/is_participant_status_model/is_log_entry_model
+TypeGuard helpers from vultron/core/models/protocols.py. Replaced every call site (72
+files) with direct isinstance() checks against concrete core domain classes.
+
+The duck-typing workaround was made obsolete by ADR-0034/DL-05-003 (DataLayer read path
+returns core objects). The architecture constraint (ARCH-01-001, no wire imports in core)
+no longer requires structural typing — isinstance() against core types is clean.
+
+Special receive-side boundary in announce.py uses dual check (isinstance OR type_==)
+to accept both wire and core objects at the AS2 receive boundary per ADR-0032.
+
+Tests using MagicMock now require spec=VulnerabilityCase to pass isinstance guards.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1529>

--- a/plan/incoming/learnings/20260720-git-rebase-duplicate-pick-on-large-branch.md
+++ b/plan/incoming/learnings/20260720-git-rebase-duplicate-pick-on-large-branch.md
@@ -1,0 +1,32 @@
+---
+title: git rebase fails with "local changes would be overwritten" when branch diverged far from main
+type: learning
+timestamp: 2026-07-20
+source: ISSUE-1504
+---
+
+When a branch diverges many commits from `origin/main` and the single implementation
+commit touches 70+ files, `git rebase origin/main` can fail with:
+
+> "Your local changes to the following files would be overwritten by merge"
+
+even with a clean working tree. This appears to be a git sequencer quirk where the
+rebase applies the commit but then re-adds a duplicate pick to the todo list.
+
+**Workaround**:
+
+```bash
+git rebase --abort
+git checkout -b temp-branch origin/main
+git cherry-pick <implementation-commit-hash>
+git branch -f task/<branch-name> HEAD
+git checkout task/<branch-name>
+git branch -d temp-branch
+git push ...
+```
+
+This creates the rebased state cleanly without the sequencer confusion.
+
+**Prevention**: Keep branches short-lived and rebase frequently to avoid large
+divergence. The build skill's Phase 0 (`git fetch && git reset --hard origin/main`)
+should be run immediately before starting work to root the branch at current main.

--- a/plan/incoming/learnings/20260720-mock-spec-required-for-isinstance-guards.md
+++ b/plan/incoming/learnings/20260720-mock-spec-required-for-isinstance-guards.md
@@ -1,0 +1,19 @@
+---
+title: MagicMock requires spec= when code uses isinstance() guards
+type: learning
+timestamp: 2026-07-20
+source: ISSUE-1504
+---
+
+When migrating from duck-typing guards (TypeGuard helpers that use `getattr`)
+to `isinstance()` checks, test mocks using bare `MagicMock()` break silently:
+the isinstance check returns False and the test hits the wrong branch.
+
+Fix: use `MagicMock(spec=ConcreteClass)` so `isinstance(mock, ConcreteClass)`
+returns True. This applies to every test that:
+
+1. Creates a mock case, participant, or ledger entry, AND
+2. Passes it through code that now uses `isinstance(x, VulnerabilityCase)` etc.
+
+Symptom: test passes but verifies the wrong code path (e.g., "case not found"
+instead of the intended ValueError branch).

--- a/plan/incoming/learnings/20260720-receive-boundary-dual-isinstance-check.md
+++ b/plan/incoming/learnings/20260720-receive-boundary-dual-isinstance-check.md
@@ -1,0 +1,32 @@
+---
+title: Receive-side boundary needs dual isinstance OR type_ check for wire objects
+type: learning
+timestamp: 2026-07-20
+source: ISSUE-1504
+---
+
+Core received-side use cases process incoming wire-layer activities before the
+objects are stored in the DataLayer. At this boundary, `case_obj` is a wire-layer
+`as_VulnerabilityCase`, not a core `VulnerabilityCase` — so `isinstance(case_obj,
+VulnerabilityCase)` returns False.
+
+The fix without importing wire types in core: use a dual check:
+
+```python
+if (
+    not isinstance(case_obj, VulnerabilityCase)
+    and getattr(case_obj, "type_", None) != "VulnerabilityCase"
+):
+    # reject — neither core type nor wire type claiming to be a VulnerabilityCase
+    return
+```
+
+This pattern:
+
+- Accepts core `VulnerabilityCase` objects (from dl.read())
+- Accepts wire `as_VulnerabilityCase` objects (from incoming activities)
+- Rejects anything else
+- Does NOT import from `vultron/wire/` — preserves ARCH-01-001
+
+Applies to `vultron/core/use_cases/received/actor/announce.py` and any future
+received-side use case that processes wire objects at the entry point.

--- a/test/core/behaviors/embargo/nodes/test_lifecycle.py
+++ b/test/core/behaviors/embargo/nodes/test_lifecycle.py
@@ -411,8 +411,9 @@ class TestValidateEmbargoRevisionStateNode:
         """
         from unittest.mock import MagicMock, PropertyMock
 
-        mock_case = MagicMock()
-        mock_case.type_ = "VulnerabilityCase"
+        from vultron.core.models.case import VulnerabilityCase
+
+        mock_case = MagicMock(spec=VulnerabilityCase)
         mock_case.case_participants = []
         mock_case.case_statuses = []
         type(mock_case).current_status = PropertyMock(

--- a/test/core/behaviors/report/test_validate_tree.py
+++ b/test/core/behaviors/report/test_validate_tree.py
@@ -745,7 +745,7 @@ def test_validate_report_tree_case_has_active_embargo(
     receive_report_case_tree).  validate_report verifies the embargo exists
     via EnsureEmbargoExists and only succeeds when it does.
     """
-    from vultron.core.models.protocols import is_case_model
+    from vultron.core.models.case import VulnerabilityCase
 
     tree = create_validate_report_tree(
         report_id=report.id_,
@@ -765,7 +765,9 @@ def test_validate_report_tree_case_has_active_embargo(
 
     case_ids = list(cases.keys())
     case_obj = datalayer.read(case_ids[0])
-    assert is_case_model(case_obj), "Expected a valid CaseModel"
+    assert isinstance(
+        case_obj, VulnerabilityCase
+    ), "Expected a VulnerabilityCase"
     assert case_obj.active_embargo is not None, (
         "VulnerabilityCase must have active_embargo set so participants "
         "can learn about the embargo from the Create(Case) activity"

--- a/test/core/behaviors/status/nodes/test_case_status.py
+++ b/test/core/behaviors/status/nodes/test_case_status.py
@@ -34,6 +34,7 @@ from vultron.core.behaviors.status.nodes.case_status import (
     CheckCaseStatusIdempotencyNode,
     ValidateCaseStatusTransitionNode,
 )
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.states.em import EM
 from vultron.wire.as2.vocab.objects.case_status import as_CaseStatus
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
@@ -203,9 +204,8 @@ class TestValidateCaseStatusTransitionNode:
             em_state=EM.ACTIVE,
         )
 
-        # Build a mock case that passes is_case_model but raises on current_status.
-        mock_case = MagicMock()
-        mock_case.type_ = "VulnerabilityCase"
+        # Use spec=VulnerabilityCase so isinstance() passes, but override current_status to raise.
+        mock_case = MagicMock(spec=VulnerabilityCase)
         mock_case.case_participants = []
         mock_case.case_statuses = []
         type(mock_case).current_status = PropertyMock(

--- a/test/core/behaviors/test_helpers.py
+++ b/test/core/behaviors/test_helpers.py
@@ -30,7 +30,7 @@ from vultron.core.behaviors.helpers import (
 from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.models.case import VultronCase
 from vultron.core.models.participant import VultronParticipant
-from vultron.core.models.protocols import is_participant_model
+from vultron.core.models.case_participant import CaseParticipant
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
     as_VulnerabilityReport,
@@ -221,7 +221,7 @@ def test_find_participant_by_actor_id_success_writes_blackboard(
 
         def update(self) -> Status:
             found = self.blackboard.get("found_participant")
-            if not is_participant_model(found):
+            if not isinstance(found, CaseParticipant):
                 self.feedback_message = "No participant found on blackboard"
                 return Status.FAILURE
             self.feedback_message = f"Found participant {found.id_}"

--- a/test/core/use_cases/received/test_case_proposal.py
+++ b/test/core/use_cases/received/test_case_proposal.py
@@ -29,7 +29,7 @@ from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.core.models.pending_create_case_activity import (
     PendingCreateCaseActivity,
 )
-from vultron.core.models.protocols import is_case_model
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.report_case_link import VultronReportCaseLink
 from vultron.core.use_cases.received.case_proposal import (
     AcceptCaseProposalReceivedUseCase,
@@ -94,7 +94,7 @@ class TestCreateCaseProposalReceivedUseCase:
         cases = [
             obj
             for obj in dl.list_objects("VulnerabilityCase")
-            if is_case_model(obj)
+            if isinstance(obj, VulnerabilityCase)
         ]
         assert (
             len(cases) == 1
@@ -153,7 +153,7 @@ class TestCreateCaseProposalReceivedUseCase:
         case_rows = dl.list_objects("VulnerabilityCase")
         assert case_rows, "No VulnerabilityCase created"
         case_obj = dl.read(case_rows[0].id_)
-        assert is_case_model(case_obj)
+        assert isinstance(case_obj, VulnerabilityCase)
 
         report_obj = proposal.object_
         assert isinstance(report_obj, as_VulnerabilityReport)
@@ -238,7 +238,7 @@ class TestCreateCaseProposalIdempotency:
         all_cases = [
             obj
             for obj in dl.list_objects("VulnerabilityCase")
-            if is_case_model(obj)
+            if isinstance(obj, VulnerabilityCase)
         ]
         assert (
             len(all_cases) == 1
@@ -352,7 +352,7 @@ class TestCreateCaseProposalIdempotencyIntegration:
         cases_after_first = [
             obj
             for obj in dl.list_objects("VulnerabilityCase")
-            if is_case_model(obj)
+            if isinstance(obj, VulnerabilityCase)
         ]
         assert (
             len(cases_after_first) == 1
@@ -365,7 +365,7 @@ class TestCreateCaseProposalIdempotencyIntegration:
         all_cases = [
             obj
             for obj in dl.list_objects("VulnerabilityCase")
-            if is_case_model(obj)
+            if isinstance(obj, VulnerabilityCase)
         ]
         assert (
             len(all_cases) == 1

--- a/test/core/use_cases/received/test_embargo_ledger_cascade.py
+++ b/test/core/use_cases/received/test_embargo_ledger_cascade.py
@@ -18,7 +18,6 @@ from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.adapters.driven.sync_activity_adapter import SyncActivityAdapter
 from vultron.core.models.case_actor import VultronCaseActor
 from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
-from vultron.core.models.protocols import is_log_entry_model
 from vultron.core.states.em import EM
 from vultron.core.use_cases.received.embargo import (
     AcceptInviteToEmbargoOnCaseReceivedUseCase,
@@ -140,7 +139,7 @@ class TestEmbargoLogEntryCascade:
         entries = [
             obj
             for obj in dl.list_objects("CaseLedgerEntry")
-            if is_log_entry_model(obj)
+            if isinstance(obj, VultronCaseLedgerEntry)
             and cast(VultronCaseLedgerEntry, obj).case_id == case_id
         ]
         assert len(entries) == 1
@@ -179,7 +178,7 @@ class TestEmbargoLogEntryCascade:
         entries = [
             obj
             for obj in dl.list_objects("CaseLedgerEntry")
-            if is_log_entry_model(obj)
+            if isinstance(obj, VultronCaseLedgerEntry)
             and cast(VultronCaseLedgerEntry, obj).case_id == case_id
         ]
         assert len(entries) == 1
@@ -224,7 +223,7 @@ class TestEmbargoLogEntryCascade:
         entries = [
             obj
             for obj in dl.list_objects("CaseLedgerEntry")
-            if is_log_entry_model(obj)
+            if isinstance(obj, VultronCaseLedgerEntry)
             and cast(VultronCaseLedgerEntry, obj).case_id == case_id
         ]
         # Cascade must fire even on BT FAILURE.
@@ -271,7 +270,7 @@ class TestEmbargoLogEntryCascade:
         entries = [
             obj
             for obj in dl.list_objects("CaseLedgerEntry")
-            if is_log_entry_model(obj)
+            if isinstance(obj, VultronCaseLedgerEntry)
             and cast(VultronCaseLedgerEntry, obj).case_id == case_id
         ]
         assert len(entries) == 0, (
@@ -316,7 +315,7 @@ class TestEmbargoLogEntryCascade:
         entries = [
             obj
             for obj in dl.list_objects("CaseLedgerEntry")
-            if is_log_entry_model(obj)
+            if isinstance(obj, VultronCaseLedgerEntry)
             and cast(VultronCaseLedgerEntry, obj).case_id == case_id
         ]
         assert len(entries) == 1
@@ -354,7 +353,7 @@ class TestEmbargoLogEntryCascade:
         entries = [
             obj
             for obj in dl.list_objects("CaseLedgerEntry")
-            if is_log_entry_model(obj)
+            if isinstance(obj, VultronCaseLedgerEntry)
             and cast(VultronCaseLedgerEntry, obj).case_id == case_id
         ]
         assert len(entries) == 1

--- a/test/core/use_cases/received/test_embargo_misc.py
+++ b/test/core/use_cases/received/test_embargo_misc.py
@@ -175,7 +175,6 @@ class TestResetEmbargoConsentWithInlineParticipants:
         Regression test for #609.
         """
         from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
-        from vultron.core.models.protocols import is_case_model
         from vultron.core.states.participant_embargo_consent import PEC
         from vultron.core.use_cases._helpers import (
             reset_case_participant_embargo_consent as _reset_case_participant_embargo_consent,
@@ -203,21 +202,21 @@ class TestResetEmbargoConsentWithInlineParticipants:
         participant.embargo_consent_state = PEC.SIGNATORY.value
         dl.create(participant)
 
-        # Inline wire-layer object in case_participants — this is the condition
-        # that caused #609 on the receiver side after fixes #572/#573.
-        case = as_VulnerabilityCase(
+        # Wire-layer case stored in DataLayer; dl.read() returns core type (ADR-0034).
+        wire_case = as_VulnerabilityCase(
             id_=case_id,
             name="Reset Consent Inline",
         )
-        case.case_participants.append(participant)
-        dl.create(case)
+        wire_case.case_participants.append(participant)
+        dl.create(wire_case)
 
-        assert is_case_model(
-            case
-        ), "VulnerabilityCase should satisfy CaseModel"
+        from vultron.core.models.case import VulnerabilityCase
+
+        core_case = dl.read(case_id)
+        assert isinstance(core_case, VulnerabilityCase)
 
         # Must not raise TypeError
-        _reset_case_participant_embargo_consent(dl, case)
+        _reset_case_participant_embargo_consent(dl, core_case)
 
         updated_participant = dl.read(participant_id)
         assert updated_participant is not None

--- a/test/core/use_cases/received/test_note.py
+++ b/test/core/use_cases/received/test_note.py
@@ -18,7 +18,6 @@ from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.adapters.driven.sync_activity_adapter import SyncActivityAdapter
 from vultron.core.models.case_actor import VultronCaseActor
 from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
-from vultron.core.models.protocols import is_log_entry_model
 from vultron.core.use_cases.received.note import (
     AddNoteToCaseReceivedUseCase,
     CreateNoteReceivedUseCase,
@@ -398,7 +397,7 @@ class TestNoteUseCases:
         entries = [
             obj
             for obj in dl.list_objects("CaseLedgerEntry")
-            if is_log_entry_model(obj)
+            if isinstance(obj, VultronCaseLedgerEntry)
             and cast(VultronCaseLedgerEntry, obj).case_id == case_id
         ]
         assert len(entries) == 1
@@ -475,7 +474,7 @@ class TestNoteUseCases:
         entries = [
             obj
             for obj in dl.list_objects("CaseLedgerEntry")
-            if is_log_entry_model(obj)
+            if isinstance(obj, VultronCaseLedgerEntry)
             and cast(VultronCaseLedgerEntry, obj).case_id == case_id
         ]
         assert len(entries) == 1

--- a/test/core/use_cases/received/test_status.py
+++ b/test/core/use_cases/received/test_status.py
@@ -19,7 +19,6 @@ from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.adapters.driven.sync_activity_adapter import SyncActivityAdapter
 from vultron.core.models.case_actor import VultronCaseActor
 from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
-from vultron.core.models.protocols import is_log_entry_model
 from vultron.core.states.em import EM
 from vultron.core.states.rm import RM
 from vultron.core.use_cases.received.status import (
@@ -381,7 +380,7 @@ class TestParticipantStatusLogEntryCascade:
         entries = [
             obj
             for obj in dl.list_objects("CaseLedgerEntry")
-            if is_log_entry_model(obj)
+            if isinstance(obj, VultronCaseLedgerEntry)
             and cast(VultronCaseLedgerEntry, obj).case_id == case_id
         ]
         assert len(entries) == 1
@@ -422,7 +421,7 @@ class TestParticipantStatusLogEntryCascade:
         entries = [
             obj
             for obj in dl.list_objects("CaseLedgerEntry")
-            if is_log_entry_model(obj)
+            if isinstance(obj, VultronCaseLedgerEntry)
             and cast(VultronCaseLedgerEntry, obj).case_id == case_id
         ]
         assert len(entries) == 1
@@ -477,7 +476,7 @@ class TestParticipantStatusLogEntryCascade:
         entries = [
             obj
             for obj in dl.list_objects("CaseLedgerEntry")
-            if is_log_entry_model(obj)
+            if isinstance(obj, VultronCaseLedgerEntry)
             and cast(VultronCaseLedgerEntry, obj).case_id == case_id
         ]
         assert entries == []
@@ -520,7 +519,7 @@ class TestParticipantStatusLogEntryCascade:
         entries = [
             obj
             for obj in dl.list_objects("CaseLedgerEntry")
-            if is_log_entry_model(obj)
+            if isinstance(obj, VultronCaseLedgerEntry)
             and cast(VultronCaseLedgerEntry, obj).case_id == case_id
         ]
         assert len(entries) == 1
@@ -566,7 +565,7 @@ class TestParticipantStatusLogEntryCascade:
         entries = [
             obj
             for obj in dl.list_objects("CaseLedgerEntry")
-            if is_log_entry_model(obj)
+            if isinstance(obj, VultronCaseLedgerEntry)
             and cast(VultronCaseLedgerEntry, obj).case_id == case_id
         ]
         assert entries == []
@@ -624,7 +623,7 @@ class TestParticipantStatusLogEntryCascade:
         entries = [
             cast(VultronCaseLedgerEntry, obj)
             for obj in dl.list_objects("CaseLedgerEntry")
-            if is_log_entry_model(obj)
+            if isinstance(obj, VultronCaseLedgerEntry)
             and cast(VultronCaseLedgerEntry, obj).case_id == case_id
         ]
         assert len(entries) == 1

--- a/test/core/use_cases/test_helpers.py
+++ b/test/core/use_cases/test_helpers.py
@@ -43,7 +43,6 @@ import pytest
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_participant import CaseParticipant
-from vultron.core.models.protocols import CaseModel, is_case_model
 from vultron.enums.roles import CVDRole
 from vultron.core.use_cases._helpers import (
     _resolve_case_manager_id,
@@ -75,14 +74,16 @@ def participant() -> CaseParticipant:
 @pytest.fixture()
 def seeded_case(
     dl: SqliteDataLayer, participant: CaseParticipant
-) -> CaseModel:
+) -> VulnerabilityCase:
     """Case with participant stored in DL and registered on both surfaces."""
     dl.create(participant)
     case = VulnerabilityCase(id_=_CASE_ID, name="Test Case")
     case.add_participant(participant)
     dl.create(case)
     stored = dl.read(_CASE_ID)
-    assert is_case_model(stored), "seeded_case: DL did not return a CaseModel"
+    assert isinstance(
+        stored, VulnerabilityCase
+    ), "seeded_case: DL did not return a VulnerabilityCase"
     return stored
 
 
@@ -90,7 +91,7 @@ class TestResolveCaseParticipantIdForActor:
     """Contract tests for resolve_case_participant_id_for_actor."""
 
     def test_happy_path_returns_canonical_id(
-        self, seeded_case: CaseModel, dl: SqliteDataLayer
+        self, seeded_case: VulnerabilityCase, dl: SqliteDataLayer
     ) -> None:
         """Both surfaces consistent: canonical participant ID is returned."""
         result = resolve_case_participant_id_for_actor(
@@ -113,7 +114,7 @@ class TestResolveCaseParticipantIdForActor:
         dl.create(case)
 
         stored = dl.read(_CASE_ID)
-        assert is_case_model(stored)
+        assert isinstance(stored, VulnerabilityCase)
         result = resolve_case_participant_id_for_actor(stored, _ACTOR_ID, dl)
         assert result == _PARTICIPANT_ID
 
@@ -132,12 +133,12 @@ class TestResolveCaseParticipantIdForActor:
         # Re-read from DL: the DL normalises inline objects to typed records.
         # The case must still resolve via the inline-then-rehydrated path.
         stored = dl.read(_CASE_ID)
-        assert is_case_model(stored)
+        assert isinstance(stored, VulnerabilityCase)
         result = resolve_case_participant_id_for_actor(stored, _ACTOR_ID, dl)
         assert result == _PARTICIPANT_ID
 
     def test_not_found_returns_none(
-        self, seeded_case: CaseModel, dl: SqliteDataLayer
+        self, seeded_case: VulnerabilityCase, dl: SqliteDataLayer
     ) -> None:
         """Actor not in case at all → None returned without error."""
         unknown_id = "https://example.org/actors/unknown"
@@ -160,7 +161,7 @@ class TestResolveCaseParticipantIdForActor:
         dl.create(case)
 
         stored = dl.read(_CASE_ID)
-        assert is_case_model(stored)
+        assert isinstance(stored, VulnerabilityCase)
         with pytest.raises(
             VultronValidationError, match="actor_participant_index"
         ):
@@ -183,7 +184,7 @@ class TestResolveCaseParticipantIdForActor:
         dl.create(case)
 
         stored = dl.read(_CASE_ID)
-        assert is_case_model(stored)
+        assert isinstance(stored, VulnerabilityCase)
         with pytest.raises(VultronValidationError, match="divergence"):
             resolve_case_participant_id_for_actor(stored, _ACTOR_ID, dl)
 
@@ -216,7 +217,7 @@ class TestResolveCaseParticipantIdForActor:
         dl.create(case)
 
         stored = dl.read(_CASE_ID)
-        assert is_case_model(stored)
+        assert isinstance(stored, VulnerabilityCase)
         with pytest.raises(
             VultronValidationError, match="multiple participants"
         ):
@@ -280,7 +281,7 @@ class TestResolveCaseManagerId:
         case.case_participants.append(_CM_PARTICIPANT_ID)
         cm_dl.create(case)
         stored = cm_dl.read(_CM_CASE_ID)
-        assert is_case_model(stored)
+        assert isinstance(stored, VulnerabilityCase)
         result = _resolve_case_manager_id(stored, cm_dl)
         assert result == _CM_ACTOR_ID
 
@@ -292,7 +293,7 @@ class TestResolveCaseManagerId:
         """Inline participant object (bootstrap path): returns attributed_to."""
         case = VulnerabilityCase(id_=_CM_CASE_ID, name="CM Inline Test")
         case.case_participants.append(cm_participant)  # type: ignore[arg-type]
-        result = _resolve_case_manager_id(cast(CaseModel, case), cm_dl)
+        result = _resolve_case_manager_id(cast(VulnerabilityCase, case), cm_dl)
         assert result == _CM_ACTOR_ID
 
     def test_no_case_manager_returns_none(
@@ -306,7 +307,7 @@ class TestResolveCaseManagerId:
         case.case_participants.append(_VENDOR_PARTICIPANT_ID)
         cm_dl.create(case)
         stored = cm_dl.read(_CM_CASE_ID)
-        assert is_case_model(stored)
+        assert isinstance(stored, VulnerabilityCase)
         result = _resolve_case_manager_id(stored, cm_dl)
         assert result is None
 
@@ -318,7 +319,7 @@ class TestResolveCaseManagerId:
         case = VulnerabilityCase(id_=_CM_CASE_ID, name="Empty Test")
         cm_dl.create(case)
         stored = cm_dl.read(_CM_CASE_ID)
-        assert is_case_model(stored)
+        assert isinstance(stored, VulnerabilityCase)
         result = _resolve_case_manager_id(stored, cm_dl)
         assert result is None
 
@@ -336,7 +337,7 @@ class TestResolveCaseManagerId:
         case.case_participants.append(_CM_PARTICIPANT_ID)
         cm_dl.create(case)
         stored = cm_dl.read(_CM_CASE_ID)
-        assert is_case_model(stored)
+        assert isinstance(stored, VulnerabilityCase)
         result = _resolve_case_manager_id(stored, cm_dl)
         assert result == _CM_ACTOR_ID
 
@@ -349,7 +350,7 @@ class TestResolveCaseManagerId:
         case.case_participants.append(_CM_PARTICIPANT_ID)  # not in DL
         cm_dl.create(case)
         stored = cm_dl.read(_CM_CASE_ID)
-        assert is_case_model(stored)
+        assert isinstance(stored, VulnerabilityCase)
         result = _resolve_case_manager_id(stored, cm_dl)
         assert result is None
 
@@ -365,6 +366,6 @@ class TestResolveCaseManagerId:
         case.actor_participant_index[_CM_ACTOR_ID] = _CM_PARTICIPANT_ID
         cm_dl.create(case)
         stored = cm_dl.read(_CM_CASE_ID)
-        assert is_case_model(stored)
+        assert isinstance(stored, VulnerabilityCase)
         result = _resolve_case_manager_id(stored, cm_dl)
         assert result == _CM_ACTOR_ID

--- a/vultron/adapters/driven/datalayer_sqlite/queries.py
+++ b/vultron/adapters/driven/datalayer_sqlite/queries.py
@@ -22,9 +22,9 @@ from sqlalchemy import func
 from sqlmodel import Session, select
 
 from vultron.adapters.driven.db_record import Record
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.protocols import PersistableModel
 from vultron.core.models.report_case_link import VultronReportCaseLink
-from vultron.core.models.protocols import is_case_model
 from vultron.core.ports.datalayer import StorableRecord
 
 from .schema import VultronObjectRecord, matches_short_id
@@ -312,7 +312,7 @@ def find_case_by_report_id(
     if isinstance(report_link, VultronReportCaseLink):
         if report_link.case_id is not None:
             linked_case = dl.read(report_link.case_id)
-            if is_case_model(linked_case):
+            if isinstance(linked_case, VulnerabilityCase):
                 return linked_case
 
     with Session(dl._engine) as session:

--- a/vultron/adapters/driven/sync_activity_adapter.py
+++ b/vultron/adapters/driven/sync_activity_adapter.py
@@ -15,8 +15,8 @@
 
 """Adapter implementing :class:`~vultron.core.ports.sync_activity.SyncActivityPort`.
 
-Converts log entry objects (satisfying
-:class:`~vultron.core.models.protocols.LogEntryModel`) to wire-layer
+Converts :class:`~vultron.core.models.case_ledger_entry.CaseLedgerEntry`
+objects to wire-layer
 :class:`~vultron.wire.as2.vocab.objects.case_ledger_entry.CaseLedgerEntry`
 objects, builds the appropriate AS2 activity via factory functions, persists
 the activity, and queues it to the actor's outbox for delivery.
@@ -33,7 +33,7 @@ See also:
 
 import logging
 
-from vultron.core.models.protocols import LogEntryModel
+from vultron.core.models.case_ledger_entry import CaseLedgerEntry
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.use_cases._helpers import add_activity_to_outbox
 from vultron.wire.as2.factories import (
@@ -57,7 +57,7 @@ class SyncActivityAdapter:
     def __init__(self, dl: CaseOutboxPersistence) -> None:
         self._dl = dl
 
-    def _to_wire(self, entry: LogEntryModel) -> WireCaseLedgerEntry:
+    def _to_wire(self, entry: CaseLedgerEntry) -> WireCaseLedgerEntry:
         """Convert a log entry to its wire-layer representation."""
         return WireCaseLedgerEntry.model_validate(
             entry.model_dump(mode="json")
@@ -65,7 +65,7 @@ class SyncActivityAdapter:
 
     def send_reject_log_entry(
         self,
-        entry: LogEntryModel,
+        entry: CaseLedgerEntry,
         tail_hash: str,
         actor_id: str,
         to: list[str],
@@ -91,7 +91,7 @@ class SyncActivityAdapter:
 
     def send_announce_log_entry(
         self,
-        entry: LogEntryModel,
+        entry: CaseLedgerEntry,
         actor_id: str,
         to: list[str],
     ) -> None:

--- a/vultron/adapters/driven/trigger_activity_adapter/actors.py
+++ b/vultron/adapters/driven/trigger_activity_adapter/actors.py
@@ -23,7 +23,7 @@ import logging
 from typing import Any, cast
 
 from vultron.core.models.actor import CoreActor
-from vultron.core.models.protocols import CaseModel, is_case_model
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.use_cases._helpers import _as_id
 from vultron.errors import VultronNotFoundError, VultronValidationError
@@ -70,7 +70,7 @@ class _ActorsMixin:
         id_: str | None = None,
         attributed_to: str | None = None,
         roles: list[str] | None = None,
-        target: CaseModel | None = None,
+        target: VulnerabilityCase | None = None,
     ) -> tuple[str, dict[str, Any]]:
         """Create and persist an ``Invite(Actor, Case)`` activity.
 
@@ -97,11 +97,11 @@ class _ActorsMixin:
         resolved: Any = target
         if resolved is None:
             resolved = self._dl.read(case_id)
-            if not is_case_model(resolved):
+            if not isinstance(resolved, VulnerabilityCase):
                 resolved = case_id
 
         embargo_obj = None
-        if is_case_model(resolved):
+        if isinstance(resolved, VulnerabilityCase):
             active_embargo_uri = getattr(resolved, "active_embargo", None)
             if active_embargo_uri:
                 embargo_obj = self._dl.read(active_embargo_uri)

--- a/vultron/adapters/driving/fastapi/inbox_handler.py
+++ b/vultron/adapters/driving/fastapi/inbox_handler.py
@@ -33,7 +33,7 @@ from typing import Any, cast
 from vultron.wire.as2.rehydration import rehydrate
 from vultron.core.dispatcher import get_dispatcher
 from vultron.core.models.events import MessageSemantics, VultronEvent
-from vultron.core.models.protocols import is_case_model
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.ports.datalayer import ActorScopedDataLayer, DataLayer
 from vultron.core.ports.dispatcher import ActivityDispatcher
 from vultron.core.ports.emitter import ActivityEmitter
@@ -242,7 +242,7 @@ def _dispatch_or_defer_inbox_item(
     if (
         case_id is not None
         and event.semantic_type != MessageSemantics.ANNOUNCE_VULNERABILITY_CASE
-        and not is_case_model(dl.read(case_id))
+        and not isinstance(dl.read(case_id), VulnerabilityCase)
     ):
         expired = _expire_pending_case_activities(
             case_id=case_id,

--- a/vultron/adapters/driving/fastapi/inbox_orchestration.py
+++ b/vultron/adapters/driving/fastapi/inbox_orchestration.py
@@ -42,7 +42,7 @@ from vultron.adapters.driving.fastapi.routers.actors._inbox import (
     _store_nested_inbox_object,
 )
 from vultron.core.models.events import VultronEvent
-from vultron.core.models.protocols import is_case_model
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.ports.datalayer import ActorScopedDataLayer, DataLayer
 from vultron.core.ports.dispatcher import ActivityDispatcher
 from vultron.wire.as2.errors import VultronParseError
@@ -266,7 +266,7 @@ class FastAPIQueuePort:
 
     def is_case_known(self, case_id: str) -> bool:
         """Return ``True`` if the case replica is locally available."""
-        return is_case_model(self._dl.read(case_id))
+        return isinstance(self._dl.read(case_id), VulnerabilityCase)
 
     def queue(
         self,

--- a/vultron/adapters/driving/fastapi/inbox_pending_queue.py
+++ b/vultron/adapters/driving/fastapi/inbox_pending_queue.py
@@ -27,7 +27,7 @@ from datetime import timezone
 from vultron.config import get_config
 from vultron.core.models.events import VultronEvent
 from vultron.core.models.pending_case_inbox import VultronPendingCaseInbox
-from vultron.core.models.protocols import is_case_model
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.ports.datalayer import ActorScopedDataLayer, DataLayer
 from vultron.wire.as2.factories.case import bootstrap_replay_question_activity
 from vultron.wire.as2.vocab.base.objects.activities.base import as_Activity
@@ -206,7 +206,7 @@ def _replay_pending_case_activities(
             when not provided (best-effort; expiry Warning is still
             logged).
     """
-    if not is_case_model(dl.read(case_id)):
+    if not isinstance(dl.read(case_id), VulnerabilityCase):
         return
 
     pending_id = VultronPendingCaseInbox.build_id(case_id)

--- a/vultron/adapters/driving/fastapi/inbox_pipeline.py
+++ b/vultron/adapters/driving/fastapi/inbox_pipeline.py
@@ -29,7 +29,7 @@ from vultron.adapters.driving.fastapi.inbox_pending_queue import (
     _replay_pending_case_activities,
 )
 from vultron.core.models.events import MessageSemantics, VultronEvent
-from vultron.core.models.protocols import is_case_model
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.ports.datalayer import ActorScopedDataLayer, DataLayer
 from vultron.core.ports.dispatcher import ActivityDispatcher
 from vultron.wire.as2.rehydration import rehydrate
@@ -104,7 +104,7 @@ class InboxPipeline:
                 case_id is not None
                 and event.semantic_type
                 != MessageSemantics.ANNOUNCE_VULNERABILITY_CASE
-                and not is_case_model(self._dl.read(case_id))
+                and not isinstance(self._dl.read(case_id), VulnerabilityCase)
             ):
                 if _expire_pending_case_activities(
                     case_id=case_id,

--- a/vultron/adapters/driving/fastapi/routers/actors/_routes.py
+++ b/vultron/adapters/driving/fastapi/routers/actors/_routes.py
@@ -46,7 +46,8 @@ from vultron.core.models.actor import (
     CoreActor,
     VultronOrganization,
 )
-from vultron.core.models.protocols import PersistableModel, is_case_model
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.protocols import PersistableModel
 from vultron.core.ports.datalayer import DataLayer
 from vultron.core.use_cases.query.action_rules import (
     ActionRulesRequest,
@@ -252,9 +253,9 @@ def get_action_rules(
     try:
         actor_obj = dl.read(actor_id) or dl.find_actor_by_short_id(actor_id)
         case_obj = dl.read(case_id)
-        if case_obj is None or not is_case_model(case_obj):
+        if case_obj is None or not isinstance(case_obj, VulnerabilityCase):
             case_obj = dl.find_case_by_short_id(case_id)
-        if case_obj is None or not is_case_model(case_obj):
+        if case_obj is None or not isinstance(case_obj, VulnerabilityCase):
             raise VultronNotFoundError("VulnerabilityCase", case_id)
         canonical_actor_id = actor_id
         if actor_obj is not None and hasattr(actor_obj, "id_"):

--- a/vultron/adapters/driving/fastapi/routers/demo_triggers.py
+++ b/vultron/adapters/driving/fastapi/routers/demo_triggers.py
@@ -58,7 +58,7 @@ from vultron.adapters.driving.fastapi.trigger_models import (
     SyncLogEntryRequest,
 )
 from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
-from vultron.core.models.protocols import is_case_model
+from vultron.core.models.case import VulnerabilityCase
 from vultron.wire.as2.vocab.objects.case_ledger_entry import (
     as_CaseLedgerEntry as WireCaseLedgerEntry,
 )
@@ -70,9 +70,9 @@ router = APIRouter(prefix="/actors", tags=["Demo Triggers"])
 
 def _resolve_case_id(case_key: str, dl: DataLayer) -> str:
     case_obj = dl.read(case_key)
-    if case_obj is None or not is_case_model(case_obj):
+    if case_obj is None or not isinstance(case_obj, VulnerabilityCase):
         case_obj = dl.find_case_by_short_id(case_key)
-    if case_obj is None or not is_case_model(case_obj):
+    if case_obj is None or not isinstance(case_obj, VulnerabilityCase):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Case not found.",

--- a/vultron/core/behaviors/case/accept_invite_tree.py
+++ b/vultron/core/behaviors/case/accept_invite_tree.py
@@ -46,13 +46,10 @@ from vultron.core.behaviors.case.nodes import (
     create_receive_activity_tree,
 )
 from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
-from vultron.core.models.protocols import (
-    LogEntryModel,
-    is_log_entry_model,
-    is_participant_model,
-)
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.case_ledger_entry import CaseLedgerEntry
+from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.models.replication_state import VultronReplicationState
-from vultron.core.models.protocols import is_case_model
 from vultron.core.models.vultron_types import VultronParticipant
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.ports.sync_activity import SyncActivityPort
@@ -136,10 +133,10 @@ class CapturePreCommitBackfillTargetNode(DataLayerAction):
             self.blackboard.pre_commit_backfill_target = -1
             return Status.SUCCESS
 
-        entries: list[LogEntryModel] = [
+        entries: list[CaseLedgerEntry] = [
             obj
             for obj in self.datalayer.list_objects("CaseLedgerEntry")
-            if is_log_entry_model(obj) and obj.case_id == self.case_id
+            if isinstance(obj, CaseLedgerEntry) and obj.case_id == self.case_id
         ]
         target = entries[-1].log_index if entries else -1
         self.blackboard.pre_commit_backfill_target = target
@@ -184,7 +181,7 @@ class CheckInviteeNotAlreadyParticipantNode(DataLayerCondition):
             return Status.FAILURE
 
         case = self.datalayer.read(self.case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.logger.warning(
                 "%s: case '%s' not found",
                 self.name,
@@ -325,7 +322,7 @@ class CreateInviteeParticipantAtAcceptedNode(DataLayerAction):
             return Status.FAILURE
 
         case = self.blackboard.get("invitee_case")
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.logger.error(
                 "%s: invitee_case not found in blackboard", self.name
             )
@@ -342,7 +339,7 @@ class CreateInviteeParticipantAtAcceptedNode(DataLayerAction):
                 )
                 return Status.FAILURE
             existing = self.datalayer.read(participant_id)
-            if not is_participant_model(existing):
+            if not isinstance(existing, CaseParticipant):
                 self.logger.error(
                     "%s: expected existing participant '%s'",
                     self.name,
@@ -442,7 +439,7 @@ class _CheckEmbargoActiveStateNode(DataLayerAction):
 
     def update(self) -> Status:
         case = self.blackboard.get("invitee_case")
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.logger.error("%s: invitee_case not available", self.name)
             # Initialize key so downstream nodes can safely read it.
             self.blackboard.active_embargo_id = None
@@ -564,9 +561,9 @@ class PersistInviteeParticipantNode(DataLayerAction):
 
         participant = self.blackboard.get("new_invite_participant")
         case = self.blackboard.get("invitee_case")
-        if not isinstance(
-            participant, VultronParticipant
-        ) or not is_case_model(case):
+        if not isinstance(participant, VultronParticipant) or not isinstance(
+            case, VulnerabilityCase
+        ):
             self.logger.error(
                 "%s: new_invite_participant or invitee_case missing",
                 self.name,
@@ -614,7 +611,7 @@ class BackfillCanonicalLedgerToInviteeNode(DataLayerAction):
         except (AttributeError, KeyError):
             self._sync_port = None
 
-    def _resolve_backfill_target(self, entries: list[LogEntryModel]) -> int:
+    def _resolve_backfill_target(self, entries: list[CaseLedgerEntry]) -> int:
         """Resolve the backfill target index.
 
         Reads ``pre_commit_backfill_target`` from the blackboard when set to a
@@ -647,10 +644,10 @@ class BackfillCanonicalLedgerToInviteeNode(DataLayerAction):
             )
             return Status.FAILURE
 
-        entries: list[LogEntryModel] = [
+        entries: list[CaseLedgerEntry] = [
             obj
             for obj in self.datalayer.list_objects("CaseLedgerEntry")
-            if is_log_entry_model(obj) and obj.case_id == self.case_id
+            if isinstance(obj, CaseLedgerEntry) and obj.case_id == self.case_id
         ]
         entries.sort(key=lambda log_entry: log_entry.log_index)
 

--- a/vultron/core/behaviors/case/announce_case_received_tree.py
+++ b/vultron/core/behaviors/case/announce_case_received_tree.py
@@ -27,21 +27,21 @@ from vultron.core.behaviors.case.nodes.announce import SeedAnnouncedCaseNode
 from vultron.core.models.events.actor import (
     AnnounceVulnerabilityCaseReceivedEvent,
 )
-from vultron.core.models.protocols import CaseModel
+from vultron.core.models.case import VulnerabilityCase
 
 logger = logging.getLogger(__name__)
 
 
 def create_announce_vulnerability_case_received_tree(
     case_id: str,
-    case_obj: CaseModel,
+    case_obj: VulnerabilityCase,
     request: AnnounceVulnerabilityCaseReceivedEvent,
 ) -> py_trees.behaviour.Behaviour:
     """Create the BT for ``AnnounceVulnerabilityCaseReceivedUseCase``.
 
     Args:
         case_id: URI of the announced case.
-        case_obj: The ``CaseModel`` instance extracted from the activity.
+        case_obj: The ``VulnerabilityCase`` instance extracted from the activity.
         request: The received event carrying the full activity context.
 
     Returns:

--- a/vultron/core/behaviors/case/nodes/actor.py
+++ b/vultron/core/behaviors/case/nodes/actor.py
@@ -42,7 +42,7 @@ from vultron.core.behaviors.helpers import DataLayerAction
 from vultron.core.behaviors.sync.commit_tree import (
     create_commit_log_entry_tree,
 )
-from vultron.core.models.protocols import is_case_model
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.enums.roles import CVDRole, serialize_roles
 from vultron.core.use_cases._helpers import _as_id
@@ -122,7 +122,7 @@ class EmitInviteActorToCaseNode(DataLayerAction):
             cc=cc,
             attributed_to=self.attributed_to,
             roles=roles,
-            target=case if is_case_model(case) else None,
+            target=case if isinstance(case, VulnerabilityCase) else None,
         )
         # Commit a local correlation marker first so duplicate checks work
         # on retry even if the outbox write below fails (CM-16-009/AC-7a).
@@ -253,7 +253,7 @@ class AcceptCaseOwnershipTransferNode(DataLayerAction):
     def _read_case(self) -> Any | None:
         assert self.datalayer is not None
         case = self.datalayer.read(self.case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.feedback_message = f"case '{self.case_id}' not found"
             self.logger.warning("%s: %s", self.name, self.feedback_message)
             return None
@@ -366,7 +366,7 @@ class ProposeCaseToActorNode(DataLayerAction):
             return None
 
         case = self.datalayer.read(case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.feedback_message = f"Case '{case_id}' not found"
             self.logger.error("%s: %s", self.name, self.feedback_message)
             return None

--- a/vultron/core/behaviors/case/nodes/announce.py
+++ b/vultron/core/behaviors/case/nodes/announce.py
@@ -32,7 +32,7 @@ from vultron.core.behaviors.helpers import DataLayerAction
 from vultron.core.models.events.actor import (
     AnnounceVulnerabilityCaseReceivedEvent,
 )
-from vultron.core.models.protocols import CaseModel
+from vultron.core.models.case import VulnerabilityCase
 
 
 class SeedAnnouncedCaseNode(DataLayerAction):
@@ -50,7 +50,7 @@ class SeedAnnouncedCaseNode(DataLayerAction):
     def __init__(
         self,
         case_id: str,
-        case_obj: CaseModel,
+        case_obj: VulnerabilityCase,
         request: AnnounceVulnerabilityCaseReceivedEvent,
         name: str | None = None,
     ) -> None:

--- a/vultron/core/behaviors/case/nodes/case_participant_received.py
+++ b/vultron/core/behaviors/case/nodes/case_participant_received.py
@@ -26,7 +26,8 @@ BTND-07-003.
 from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerAction
-from vultron.core.models.protocols import is_case_model, is_participant_model
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.use_cases._helpers import _as_id
 
 
@@ -59,7 +60,7 @@ class AddCaseParticipantToCaseReceivedNode(DataLayerAction):
         participant = self.datalayer.read(self.participant_id)
         case = self.datalayer.read(self.case_id)
 
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.feedback_message = f"case '{self.case_id}' not found"
             self.logger.warning(
                 "%s: case '%s' not found",
@@ -68,7 +69,7 @@ class AddCaseParticipantToCaseReceivedNode(DataLayerAction):
             )
             return Status.FAILURE
 
-        if not is_participant_model(participant):
+        if not isinstance(participant, CaseParticipant):
             self.feedback_message = (
                 f"participant '{self.participant_id}' not found"
             )
@@ -120,7 +121,7 @@ class RemoveCaseParticipantFromCaseReceivedNode(DataLayerAction):
 
         case = self.datalayer.read(self.case_id)
 
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.feedback_message = f"case '{self.case_id}' not found"
             self.logger.warning(
                 "%s: case '%s' not found",

--- a/vultron/core/behaviors/case/nodes/case_setup.py
+++ b/vultron/core/behaviors/case/nodes/case_setup.py
@@ -34,7 +34,7 @@ import py_trees
 from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerAction
-from vultron.core.models.protocols import is_case_model
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.vultron_types import (
     VultronCase,
     VultronCaseActor,
@@ -157,7 +157,7 @@ class RecordOfferReceivedEventNode(DataLayerAction):
             return Status.FAILURE
 
         case = self.datalayer.read(case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.logger.error(
                 f"{self.name}: Case {case_id} not found in DataLayer"
             )
@@ -204,7 +204,7 @@ class RecordCaseCreatedEventNode(DataLayerAction):
                 f"{self.name}: case_for_creation_events missing or invalid"
             )
             return Status.FAILURE
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.logger.error(
                 f"{self.name}: case_for_creation_events missing or invalid"
             )
@@ -405,7 +405,7 @@ class RegisterCaseActorParticipantNode(DataLayerAction):
             return Status.FAILURE
 
         case = self.datalayer.read(case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.logger.error(
                 "%s: Case '%s' not found; cannot register CaseActor participant",
                 self.name,

--- a/vultron/core/behaviors/case/nodes/communication.py
+++ b/vultron/core/behaviors/case/nodes/communication.py
@@ -36,7 +36,7 @@ import py_trees
 from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerAction
-from vultron.core.models.protocols import is_case_model
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.vultron_types import VultronCreateCaseActivity
 
 logger = logging.getLogger(__name__)
@@ -79,7 +79,7 @@ class CollectCaseAddresseesNode(DataLayerAction):
             return Status.FAILURE
 
         case_obj = self.datalayer.read(case_id)
-        if is_case_model(case_obj):
+        if isinstance(case_obj, VulnerabilityCase):
             addressees = [
                 actor_id
                 for actor_id in case_obj.actor_participant_index.keys()

--- a/vultron/core/behaviors/case/nodes/conditions.py
+++ b/vultron/core/behaviors/case/nodes/conditions.py
@@ -35,7 +35,7 @@ from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerCondition
 from vultron.config.actor import ActorConfig
-from vultron.core.models.protocols import is_case_model
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.use_cases._helpers import _resolve_case_manager_id
 
 
@@ -248,7 +248,7 @@ class CheckIsCaseManagerNode(DataLayerCondition):
                 f"{self.name}: case '{case_id}' not found in DataLayer"
             )
             return Status.FAILURE
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.logger.warning(
                 f"{self.name}: object '{case_id}' is not a VulnerabilityCase"
             )

--- a/vultron/core/behaviors/case/nodes/embargo.py
+++ b/vultron/core/behaviors/case/nodes/embargo.py
@@ -39,7 +39,7 @@ from py_trees.common import Status
 from vultron.core.behaviors.helpers import DataLayerAction
 from vultron.core.models.embargo_event import EmbargoEvent
 from vultron.core.models.enums import VultronObjectType
-from vultron.core.models.protocols import is_case_model
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.ports.case_persistence import CasePersistence
 from vultron.core.services.embargo_lifecycle import (
     EmbargoLifecycle,
@@ -199,7 +199,7 @@ class AdvanceEMStateToActiveNode(DataLayerAction):
             return Status.FAILURE
 
         stored_case = self.datalayer.read(case_id, raise_on_missing=False)
-        if not is_case_model(stored_case):
+        if not isinstance(stored_case, VulnerabilityCase):
             self.logger.error(
                 "%s: Case %s not found in DataLayer", self.name, case_id
             )
@@ -287,7 +287,7 @@ class AttachEmbargoToCaseNode(DataLayerAction):
             return Status.FAILURE
 
         stored_case = self.datalayer.read(case_id, raise_on_missing=False)
-        if not is_case_model(stored_case):
+        if not isinstance(stored_case, VulnerabilityCase):
             self.logger.error(
                 "%s: Case %s not found in DataLayer", self.name, case_id
             )
@@ -352,7 +352,7 @@ class SeedOwnerAsSignatoryNode(DataLayerAction):
             return Status.SUCCESS
 
         stored_case = self.datalayer.read(case_id, raise_on_missing=False)
-        if not is_case_model(stored_case):
+        if not isinstance(stored_case, VulnerabilityCase):
             self.logger.error(
                 "%s: Case %s not found in DataLayer", self.name, case_id
             )

--- a/vultron/core/behaviors/case/nodes/participant/_bootstrap.py
+++ b/vultron/core/behaviors/case/nodes/participant/_bootstrap.py
@@ -26,7 +26,7 @@ from vultron.core.behaviors.case.nodes.participant.common import (
     _ensure_reporter_participant,
 )
 from vultron.core.behaviors.helpers import DataLayerAction
-from vultron.core.models.protocols import CaseModel
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.report_case_link import VultronReportCaseLink
 
 
@@ -49,7 +49,7 @@ class EnsureReporterParticipantAtAcceptedNode(DataLayerAction):
     def __init__(
         self,
         link: VultronReportCaseLink,
-        case_obj: CaseModel,
+        case_obj: VulnerabilityCase,
         case_id: str,
         name: str | None = None,
     ) -> None:

--- a/vultron/core/behaviors/case/nodes/participant/common.py
+++ b/vultron/core/behaviors/case/nodes/participant/common.py
@@ -24,12 +24,9 @@ from vultron.core.models.participant_status import (
     coerce_cvd_roles,
     coerce_em_consent_state,
 )
-from vultron.core.models.protocols import (
-    CaseModel,
-    is_case_model,
-    is_participant_status_model,
-)
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.report_case_link import VultronReportCaseLink
+from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.models.vultron_types import VultronParticipant
 from vultron.core.ports.case_persistence import (
     CaseOutboxPersistence,
@@ -51,7 +48,7 @@ def _create_and_attach_participant(
     case_id: str,
     actor_id_for_index: str,
     node_logger: logging.Logger,
-) -> CaseModel | None:
+) -> VulnerabilityCase | None:
     """
     Create participant if needed and attach it to the case (unsaved return).
 
@@ -72,7 +69,7 @@ def _create_and_attach_participant(
         )
 
     stored_case = dl.read(case_id)
-    if not is_case_model(stored_case):
+    if not isinstance(stored_case, VulnerabilityCase):
         node_logger.error("Case %s not found in DataLayer", case_id)
         return None
 
@@ -81,7 +78,7 @@ def _create_and_attach_participant(
     )
     if existing_participant_id is not None:
         existing_participant = dl.read(existing_participant_id)
-        if existing_participant is not None:
+        if isinstance(existing_participant, CaseParticipant):
             stored_case.add_participant(existing_participant)
             node_logger.debug(
                 "Participant already registered for actor '%s' in case '%s'",
@@ -114,7 +111,9 @@ def _get_or_create_accepted_status(
 
     # CLP-07-007: context must use the case URI once a case exists.
     case_obj = dl.find_case_by_report_id(report_id)
-    context = case_obj.id_ if is_case_model(case_obj) else report_id
+    context = (
+        case_obj.id_ if isinstance(case_obj, VulnerabilityCase) else report_id
+    )
 
     accepted_status_id = _report_phase_status_id(
         actor_id,
@@ -122,7 +121,7 @@ def _get_or_create_accepted_status(
         RM.ACCEPTED.value,
     )
     existing = dl.read(accepted_status_id)
-    if is_participant_status_model(existing):
+    if isinstance(existing, ParticipantStatus):
         should_update_role = existing.cvd_role != cvd_role
         should_backfill_consent = (
             existing.em_consent_state is None and em_consent_state is not None
@@ -251,7 +250,7 @@ def _queue_participant_add_notification(
 def _ensure_reporter_participant(
     dl: CasePersistence,
     link: VultronReportCaseLink,
-    case_obj: CaseModel,
+    case_obj: VulnerabilityCase,
     case_id: str,
 ) -> None:
     """Ensure the reporter's participant record is at RM.ACCEPTED (#589, #624).

--- a/vultron/core/behaviors/case/nodes/participant/owner.py
+++ b/vultron/core/behaviors/case/nodes/participant/owner.py
@@ -32,7 +32,7 @@ from vultron.core.behaviors.case.nodes.participant.common import (
 from vultron.core.behaviors.helpers import DataLayerAction
 from vultron.config.actor import ActorConfig
 from vultron.core.models.participant_status import ParticipantStatus
-from vultron.core.models.protocols import is_case_model
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.vultron_types import VultronCase, VultronParticipant
 from vultron.core.ports.case_persistence import CasePersistence
 from vultron.core.states.participant_embargo_consent import PEC
@@ -302,7 +302,7 @@ class PersistOwnerCaseNode(DataLayerAction):
             self.logger.error("%s: DataLayer not available", self.name)
             return Status.FAILURE
         stored_case = self.blackboard.get(self._participant_case_key)
-        if not is_case_model(stored_case):
+        if not isinstance(stored_case, VulnerabilityCase):
             self.logger.error(
                 "%s: %s missing in blackboard",
                 self.name,
@@ -359,7 +359,11 @@ class AdvanceOwnerRmToAcceptedNode(DataLayerAction):
         case_id = case_id_obj if isinstance(case_id_obj, str) else None
         if case_id is None:
             stored_case = self.blackboard.get(self._participant_case_key)
-            case_id = stored_case.id_ if is_case_model(stored_case) else None
+            case_id = (
+                stored_case.id_
+                if isinstance(stored_case, VulnerabilityCase)
+                else None
+            )
         if case_id is None:
             self.logger.error("%s: case_id not available", self.name)
             return Status.FAILURE
@@ -417,7 +421,7 @@ class RecordOwnerJoinedEventNode(DataLayerAction):
 
         stored_case = self.blackboard.get(self._participant_case_key)
         participant = self.blackboard.get(self._new_case_participant_key)
-        if not is_case_model(stored_case) or not isinstance(
+        if not isinstance(stored_case, VulnerabilityCase) or not isinstance(
             participant, VultronParticipant
         ):
             self.logger.error(

--- a/vultron/core/behaviors/case/nodes/participant/participant_add.py
+++ b/vultron/core/behaviors/case/nodes/participant/participant_add.py
@@ -37,10 +37,7 @@ from vultron.core.models.participant_status import (
     ParticipantStatus,
     coerce_cvd_roles,
 )
-from vultron.core.models.protocols import (
-    is_case_model,
-    is_participant_status_model,
-)
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.vultron_types import VultronParticipant
 from vultron.core.states.participant_embargo_consent import PEC
 from vultron.enums.roles import CVDRole
@@ -138,8 +135,8 @@ class CreateParticipantNode(DataLayerAction):
         accepted_status = self.blackboard.get(
             self._participant_accepted_status_key
         )
-        if accepted_status is not None and not is_participant_status_model(
-            accepted_status
+        if accepted_status is not None and not isinstance(
+            accepted_status, ParticipantStatus
         ):
             self.logger.error(
                 "%s: %s has invalid type",
@@ -258,7 +255,7 @@ class RecordParticipantAddedEventNode(DataLayerAction):
 
         stored_case = self.blackboard.get(self._participant_case_key)
         participant_id = self.blackboard.get(self._new_participant_id_key)
-        if not is_case_model(stored_case) or not isinstance(
+        if not isinstance(stored_case, VulnerabilityCase) or not isinstance(
             participant_id, str
         ):
             self.logger.error(
@@ -292,7 +289,7 @@ class CaseHasActiveEmbargoNode(DataLayerAction):
 
     def update(self) -> Status:
         stored_case = self.blackboard.get(self._participant_case_key)
-        if not is_case_model(stored_case):
+        if not isinstance(stored_case, VulnerabilityCase):
             self.logger.error(
                 "%s: %s missing in blackboard",
                 self.name,
@@ -325,7 +322,7 @@ class CaseHasNoActiveEmbargoNode(DataLayerAction):
 
     def update(self) -> Status:
         stored_case = self.blackboard.get(self._participant_case_key)
-        if not is_case_model(stored_case):
+        if not isinstance(stored_case, VulnerabilityCase):
             self.logger.error(
                 "%s: %s missing in blackboard",
                 self.name,
@@ -372,7 +369,7 @@ class SeedParticipantAsSignatoryNode(DataLayerAction):
 
         stored_case = self.blackboard.get(self._participant_case_key)
         participant = self.blackboard.get(self._new_case_participant_key)
-        if not is_case_model(stored_case) or not isinstance(
+        if not isinstance(stored_case, VulnerabilityCase) or not isinstance(
             participant, VultronParticipant
         ):
             self.logger.error(

--- a/vultron/core/behaviors/case/nodes/participant/status.py
+++ b/vultron/core/behaviors/case/nodes/participant/status.py
@@ -27,7 +27,8 @@ from vultron.core.models.participant_status import (
     coerce_cvd_roles,
     coerce_em_consent_state,
 )
-from vultron.core.models.protocols import is_case_model, is_participant_model
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.states.cs import CS_pxa, CS_vfd
 from vultron.core.states.em import EM
 from vultron.core.states.rm import RM
@@ -72,7 +73,7 @@ class CreateParticipantStatusNode(DataLayerAction):
             return Status.FAILURE
 
         case = dl.read(self._case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.logger.error(
                 "%s: Case '%s' not found in DataLayer",
                 self.name,
@@ -110,13 +111,13 @@ class CreateParticipantStatusNode(DataLayerAction):
         participant_obj = dl.read(participant_id)
         participant_roles = (
             participant_obj.roles
-            if is_participant_model(participant_obj)
+            if isinstance(participant_obj, CaseParticipant)
             else []
         )
         status_roles = coerce_cvd_roles(participant_roles)
         raw_consent = (
             getattr(participant_obj, "embargo_consent_state", None)
-            if is_participant_model(participant_obj)
+            if isinstance(participant_obj, CaseParticipant)
             else None
         )
         em_consent_state = coerce_em_consent_state(raw_consent)

--- a/vultron/core/behaviors/case/nodes/update.py
+++ b/vultron/core/behaviors/case/nodes/update.py
@@ -32,7 +32,7 @@ from vultron.core.behaviors.helpers import (
     DataLayerCondition,
 )
 from vultron.core.models.events.case import UpdateCaseReceivedEvent
-from vultron.core.models.protocols import is_case_model
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.use_cases._helpers import _as_id
 
 
@@ -52,7 +52,7 @@ class CheckCaseUpdateOwnerNode(DataLayerCondition):
             return Status.FAILURE
 
         case = self.datalayer.read(self.case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.feedback_message = f"case '{self.case_id}' not found"
             self.logger.warning(
                 "%s: case '%s' not found in DataLayer",
@@ -96,7 +96,7 @@ class CaptureCaseUpdateBroadcastExclusionsNode(DataLayerCondition):
             return Status.FAILURE
 
         case = self.datalayer.read(self.case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.feedback_message = f"case '{self.case_id}' not found"
             self.logger.warning(
                 "%s: case '%s' not found in DataLayer",
@@ -132,7 +132,7 @@ class ApplyCaseUpdateNode(DataLayerAction):
             return Status.FAILURE
 
         stored_case = self.datalayer.read(self.case_id)
-        if not is_case_model(stored_case):
+        if not isinstance(stored_case, VulnerabilityCase):
             self.logger.warning(
                 "%s: case '%s' not found in DataLayer",
                 self.name,
@@ -177,7 +177,7 @@ class BroadcastCaseUpdateNode(DataLayerAction):
             return Status.FAILURE
 
         case = self.datalayer.read(self.case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.feedback_message = f"case '{self.case_id}' not found"
             self.logger.warning(
                 "%s: case '%s' not found in DataLayer",

--- a/vultron/core/behaviors/case/update_support.py
+++ b/vultron/core/behaviors/case/update_support.py
@@ -21,7 +21,7 @@ import logging
 from typing import Any, cast
 
 from vultron.core.models.events.case import UpdateCaseReceivedEvent
-from vultron.core.models.protocols import is_participant_model
+from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.models.vultron_types import VultronActivity
 from vultron.core.ports.case_persistence import (
     CaseOutboxPersistence,
@@ -64,7 +64,7 @@ def find_excluded_actor_ids(case: Any, dl: CasePersistence) -> set[str]:
                 participant_id,
             )
             continue
-        if not is_participant_model(participant):
+        if not isinstance(participant, CaseParticipant):
             continue
         accepted_ids = getattr(participant, "accepted_embargo_ids", []) or []
         if embargo_id not in accepted_ids:

--- a/vultron/core/behaviors/embargo/announce_teardown_tree.py
+++ b/vultron/core/behaviors/embargo/announce_teardown_tree.py
@@ -22,7 +22,7 @@ Provides factory functions for embargo-related BTs:
 activity (protocol ET message).  Sequence:
 
     RemoveEmbargoFromCaseBT (Sequence)
-    ├─ ValidateCaseExistsNode          # case must exist and pass is_case_model
+    ├─ ValidateCaseExistsNode          # case must exist as VulnerabilityCase
     ├─ GuardedCommitCaseLedgerEntryBT  # record receipt before effects (CLP-10-006)
     ├─ RemoveFromProposedEmbargoesNode # idempotent proposed-list cleanup
     └─ TeardownIfActive (Selector)     # run teardown if active; skip silently

--- a/vultron/core/behaviors/embargo/nodes/conditions.py
+++ b/vultron/core/behaviors/embargo/nodes/conditions.py
@@ -19,17 +19,15 @@ import py_trees
 from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerCondition
-from vultron.core.models.protocols import (
-    is_case_model,
-    is_participant_model,
-)
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.case_participant import CaseParticipant
 from vultron.errors import VultronInvalidStateTransitionError
 
 
 class ValidateCaseExistsNode(DataLayerCondition):
     """Check that the target case exists in the DataLayer.
 
-    Returns SUCCESS if the case is found and passes ``is_case_model``.
+    Returns SUCCESS if the case is found and is a ``VulnerabilityCase``.
     Returns FAILURE otherwise, halting the parent Sequence.
     """
 
@@ -43,7 +41,7 @@ class ValidateCaseExistsNode(DataLayerCondition):
             return Status.FAILURE
 
         case = self.datalayer.read(self.case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.feedback_message = (
                 f"Case '{self.case_id}' not found or not a valid case model"
             )
@@ -74,7 +72,7 @@ class IsActiveEmbargoNode(DataLayerCondition):
             return Status.FAILURE
 
         case = self.datalayer.read(self.case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.feedback_message = f"Case '{self.case_id}' not found"
             return Status.FAILURE
 
@@ -122,7 +120,7 @@ class LookupParticipantNode(DataLayerCondition):
             return Status.FAILURE
 
         case = self.datalayer.read(self.case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.feedback_message = f"Case '{self.case_id}' not found"
             self.logger.warning("%s: %s", self.name, self.feedback_message)
             return Status.FAILURE
@@ -143,7 +141,7 @@ class LookupParticipantNode(DataLayerCondition):
             return Status.FAILURE
 
         participant = self.datalayer.read(participant_id)
-        if not is_participant_model(participant):
+        if not isinstance(participant, CaseParticipant):
             self.feedback_message = (
                 f"Participant '{participant_id}' not found or invalid"
             )
@@ -203,7 +201,7 @@ class OptionalLookupParticipantNode(DataLayerCondition):
             return Status.SUCCESS
 
         case = self.datalayer.read(self.case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.feedback_message = f"Case '{self.case_id}' not found — skipping participant lookup"
             self.logger.debug("%s: %s", self.name, self.feedback_message)
             return Status.SUCCESS
@@ -229,7 +227,7 @@ class OptionalLookupParticipantNode(DataLayerCondition):
             return Status.SUCCESS
 
         participant = self.datalayer.read(participant_id)
-        if not is_participant_model(participant):
+        if not isinstance(participant, CaseParticipant):
             self.feedback_message = (
                 f"Participant '{participant_id}' not found or invalid"
                 " — skipping PEC update"
@@ -275,7 +273,7 @@ class HasActiveEmbargoNode(DataLayerCondition):
             return Status.FAILURE
 
         case = self.datalayer.read(self.case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.feedback_message = f"Case '{self.case_id}' not found"
             return Status.FAILURE
 
@@ -322,7 +320,7 @@ class HasCaseStatusesNode(DataLayerCondition):
             return Status.FAILURE
 
         case = self.datalayer.read(self.case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.feedback_message = f"Case '{self.case_id}' not found"
             return Status.FAILURE
 

--- a/vultron/core/behaviors/embargo/nodes/lifecycle.py
+++ b/vultron/core/behaviors/embargo/nodes/lifecycle.py
@@ -21,7 +21,7 @@ import py_trees
 from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerAction
-from vultron.core.models.protocols import is_case_model
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.services.embargo_lifecycle import (
     EmbargoLifecycle,
     EmbargoLifecycleResult,
@@ -65,7 +65,7 @@ class ValidateEmbargoRevisionStateNode(DataLayerAction):
             return Status.FAILURE
 
         case = self.datalayer.read(self._case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             not_found = VultronValidationError(
                 f"Case '{self._case_id}' not found or invalid."
             )
@@ -243,7 +243,7 @@ class ReadEmbargoIdNode(DataLayerAction):
             return Status.FAILURE
 
         case = self.datalayer.read(self._case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.feedback_message = f"Case '{self._case_id}' not found"
             return Status.FAILURE
 
@@ -347,7 +347,7 @@ class SetEmbargoActiveNode(DataLayerAction):
     def _read_case(self) -> Any | None:
         assert self.datalayer is not None
         case = self.datalayer.read(self.case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.feedback_message = f"Case '{self.case_id}' not found"
             self.logger.warning("%s: %s", self.name, self.feedback_message)
             return None

--- a/vultron/core/behaviors/embargo/nodes/proposal.py
+++ b/vultron/core/behaviors/embargo/nodes/proposal.py
@@ -19,7 +19,7 @@ import py_trees
 from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerAction
-from vultron.core.models.protocols import is_participant_model
+from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.services.embargo_lifecycle import (
     EmbargoLifecycle,
     TransitionMode,
@@ -72,7 +72,7 @@ class UpdateParticipantEmbargoPecNode(DataLayerAction):
             )
             return Status.SUCCESS
 
-        if not is_participant_model(participant):
+        if not isinstance(participant, CaseParticipant):
             self.logger.warning(
                 "%s: invalid participant on blackboard", self.name
             )
@@ -260,7 +260,7 @@ class RemoveStaleAcceptanceNode(DataLayerAction):
             )
             return Status.SUCCESS
 
-        if not is_participant_model(participant):
+        if not isinstance(participant, CaseParticipant):
             self.logger.debug(
                 "%s: invalid participant on blackboard", self.name
             )

--- a/vultron/core/behaviors/embargo/nodes/teardown.py
+++ b/vultron/core/behaviors/embargo/nodes/teardown.py
@@ -19,7 +19,7 @@ import py_trees
 from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerAction
-from vultron.core.models.protocols import is_case_model
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.states.em import EM, is_valid_em_transition
 from vultron.core.use_cases._helpers import (
     _as_id,
@@ -72,7 +72,7 @@ class ApplyEmbargoTeardownNode(DataLayerAction):
             case_id = entry.case_id
 
         case = self.datalayer.read(case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.feedback_message = f"Case '{case_id}' not found"
             self.logger.warning("%s: %s", self.name, self.feedback_message)
             return Status.SUCCESS
@@ -129,7 +129,7 @@ class RemoveFromProposedEmbargoesNode(DataLayerAction):
             return Status.FAILURE
 
         case = self.datalayer.read(self.case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.feedback_message = f"Case '{self.case_id}' not found"
             return Status.FAILURE
 

--- a/vultron/core/behaviors/helpers.py
+++ b/vultron/core/behaviors/helpers.py
@@ -32,10 +32,8 @@ import py_trees
 from pydantic import BaseModel
 from py_trees.common import Status
 
-from vultron.core.models.protocols import (
-    is_case_model,
-    is_participant_model,
-)
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.ports.case_persistence import (
     CasePersistence,
     CaseOutboxPersistence,
@@ -269,7 +267,7 @@ class FindParticipantByActorIdNode(DataLayerCondition):
                 participant_obj = self.datalayer.read(
                     participant_ref, raise_on_missing=False
                 )
-            if not is_participant_model(participant_obj):
+            if not isinstance(participant_obj, CaseParticipant):
                 continue
             if (
                 self._participant_actor_id(participant_obj)
@@ -301,7 +299,7 @@ class FindParticipantByActorIdNode(DataLayerCondition):
             return Status.FAILURE
 
         case_obj = self.datalayer.read(self.case_id, raise_on_missing=False)
-        if not is_case_model(case_obj):
+        if not isinstance(case_obj, VulnerabilityCase):
             self.feedback_message = f"Case {self.case_id} not found"
             self.logger.debug("%s: %s", self.name, self.feedback_message)
             return Status.FAILURE

--- a/vultron/core/behaviors/note/nodes/creation.py
+++ b/vultron/core/behaviors/note/nodes/creation.py
@@ -20,7 +20,7 @@ from typing import Any
 from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerAction
-from vultron.core.models.protocols import is_case_model
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.use_cases._helpers import _as_id
 
 
@@ -111,7 +111,7 @@ class AttachNoteFromResultNode(DataLayerAction):
             return fail
 
         case: Any = self.datalayer.read(self.case_id)  # type: ignore[union-attr]
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.feedback_message = f"case '{self.case_id}' not found"
             self.logger.warning(f"{self.name}: {self.feedback_message}")
             return Status.FAILURE

--- a/vultron/core/behaviors/note/nodes/storage.py
+++ b/vultron/core/behaviors/note/nodes/storage.py
@@ -21,7 +21,7 @@ from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerAction
 from vultron.core.models.note import VultronNote
-from vultron.core.models.protocols import is_case_model
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.use_cases._helpers import _as_id
 
 
@@ -73,7 +73,7 @@ class AttachNoteToCaseNode(DataLayerAction):
             return Status.FAILURE
 
         case: Any = self.datalayer.read(self.case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.logger.warning(
                 f"{self.name}: case '{self.case_id}' not found"
                 " — cannot attach note"

--- a/vultron/core/behaviors/report/nodes/emit.py
+++ b/vultron/core/behaviors/report/nodes/emit.py
@@ -20,7 +20,7 @@ from typing import cast
 from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerAction
-from vultron.core.models.protocols import is_case_model
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.use_cases._helpers import _resolve_case_manager_id
 
@@ -173,7 +173,7 @@ def _compute_report_addressees(
         List of recipient URIs, or None when no recipients can be determined.
     """
     case = dl.find_case_by_report_id(report_id)
-    if is_case_model(case):
+    if isinstance(case, VulnerabilityCase):
         case_manager_id = _resolve_case_manager_id(case, dl)
         if case_manager_id and case_manager_id != actor_id:
             return [case_manager_id]

--- a/vultron/core/behaviors/report/nodes/rm_transitions.py
+++ b/vultron/core/behaviors/report/nodes/rm_transitions.py
@@ -19,7 +19,7 @@ from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerAction
 from vultron.core.models.participant_status import ParticipantStatus
-from vultron.core.models.protocols import is_case_model
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.states.participant_embargo_consent import PEC
 from vultron.core.states.rm import RM
 from vultron.enums.roles import CVDRole
@@ -66,7 +66,7 @@ def _transition_case_participant_rm(
         return Status.FAILURE
 
     case = node.datalayer.find_case_by_report_id(report_id)
-    if not is_case_model(case):
+    if not isinstance(case, VulnerabilityCase):
         node.logger.warning(
             "%s: no case found for report '%s' — RM state not updated",
             node.name,
@@ -158,7 +158,11 @@ class TransitionRMtoValid(DataLayerAction):
         try:
             # CLP-07-007: context must use the case URI once a case exists.
             case = self.datalayer.find_case_by_report_id(self.report_id)
-            context = case.id_ if is_case_model(case) else self.report_id
+            context = (
+                case.id_
+                if isinstance(case, VulnerabilityCase)
+                else self.report_id
+            )
 
             status = ParticipantStatus(
                 id_=_report_phase_status_id(
@@ -183,7 +187,7 @@ class TransitionRMtoValid(DataLayerAction):
                 actor_id,
             )
 
-            if is_case_model(case):
+            if isinstance(case, VulnerabilityCase):
                 update_participant_rm_state(
                     case.id_, actor_id, RM.VALID, self.datalayer
                 )
@@ -237,7 +241,11 @@ class TransitionRMtoInvalid(DataLayerAction):
         try:
             # CLP-07-007: context must use the case URI once a case exists.
             case = self.datalayer.find_case_by_report_id(self.report_id)
-            context = case.id_ if is_case_model(case) else self.report_id
+            context = (
+                case.id_
+                if isinstance(case, VulnerabilityCase)
+                else self.report_id
+            )
 
             status = ParticipantStatus(
                 id_=_report_phase_status_id(
@@ -311,7 +319,11 @@ class TransitionRMtoClosed(DataLayerAction):
         try:
             # CLP-07-007: context must use the case URI once a case exists.
             case = self.datalayer.find_case_by_report_id(self.report_id)
-            context = case.id_ if is_case_model(case) else self.report_id
+            context = (
+                case.id_
+                if isinstance(case, VulnerabilityCase)
+                else self.report_id
+            )
 
             status = ParticipantStatus(
                 id_=_report_phase_status_id(

--- a/vultron/core/behaviors/sender/nodes/actions.py
+++ b/vultron/core/behaviors/sender/nodes/actions.py
@@ -21,7 +21,7 @@ import py_trees
 from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerAction
-from vultron.core.models.protocols import is_case_model
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.use_cases._helpers import _resolve_case_manager_id
 from vultron.core.use_cases._helpers import add_activity_to_outbox
 
@@ -46,7 +46,7 @@ class ResolveCaseManagerNode(DataLayerAction):
             return Status.FAILURE
 
         case = self.datalayer.read(self.case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.feedback_message = (
                 f"Case '{self.case_id}' not found or wrong type"
             )

--- a/vultron/core/behaviors/status/nodes/append.py
+++ b/vultron/core/behaviors/status/nodes/append.py
@@ -27,10 +27,9 @@ import py_trees
 from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
-from vultron.core.models.protocols import (
-    PersistableModel,
-    is_participant_model,
-)
+from vultron.core.models.case_participant import CaseParticipant
+from vultron.core.models.participant_status import ParticipantStatus
+from vultron.core.models.protocols import PersistableModel
 from vultron.core.states.rm import (
     RM,
     is_monotonic_rm_forward,
@@ -117,7 +116,7 @@ class LoadParticipantNode(DataLayerAction):
             return Status.FAILURE
 
         participant = self.datalayer.read(self.participant_id)
-        if not is_participant_model(participant):
+        if not isinstance(participant, CaseParticipant):
             self.feedback_message = (
                 f"Participant '{self.participant_id}' not found"
             )
@@ -407,10 +406,8 @@ class AppendStatusAndSaveParticipantNode(DataLayerAction):
             )
             return Status.FAILURE
 
-        from vultron.core.models.protocols import ParticipantStatusModel
-
         participant.participant_statuses.append(
-            cast(ParticipantStatusModel, status_obj)
+            cast(ParticipantStatus, status_obj)
         )
         self.datalayer.save(participant)
         self.logger.info(
@@ -455,7 +452,7 @@ class CheckParticipantRMNotClosedNode(DataLayerCondition):
             return Status.FAILURE
 
         participant = self.datalayer.read(self.participant_id)
-        if not is_participant_model(participant):
+        if not isinstance(participant, CaseParticipant):
             self.logger.debug(
                 "%s: participant '%s' not found — allowing (no terminal check)",
                 self.name,

--- a/vultron/core/behaviors/status/nodes/case_status.py
+++ b/vultron/core/behaviors/status/nodes/case_status.py
@@ -25,7 +25,9 @@ from typing import Any
 from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
-from vultron.core.models.protocols import PersistableModel, is_case_model
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.case_status import CaseStatus
+from vultron.core.models.protocols import PersistableModel
 from vultron.core.states.cs import is_valid_pxa_transition
 from vultron.core.states.em import is_valid_em_transition
 from vultron.core.use_cases._helpers import _as_id
@@ -68,7 +70,7 @@ class CheckCaseStatusIdempotencyNode(DataLayerCondition):
             return Status.FAILURE
 
         case = self.datalayer.read(self.case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.feedback_message = f"Case '{self.case_id}' not found"
             self.logger.warning(
                 "CheckCaseStatusIdempotency: %s", self.feedback_message
@@ -149,7 +151,7 @@ class ValidateCaseStatusTransitionNode(DataLayerCondition):
             return Status.FAILURE
 
         case = self.datalayer.read(self.case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.feedback_message = f"Case '{self.case_id}' not found"
             self.logger.warning(
                 "ValidateCaseStatusTransition: %s", self.feedback_message
@@ -230,7 +232,7 @@ class AppendCaseStatusToCaseNode(DataLayerAction):
             return Status.FAILURE
 
         case = self.datalayer.read(self.case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.feedback_message = f"Case '{self.case_id}' not found"
             self.logger.warning(
                 "AppendCaseStatusToCase: %s", self.feedback_message
@@ -245,6 +247,14 @@ class AppendCaseStatusToCaseNode(DataLayerAction):
             )
             return Status.FAILURE
 
+        if not isinstance(status_obj, CaseStatus):
+            self.feedback_message = (
+                f"Status '{self.status_id}' is not a CaseStatus"
+            )
+            self.logger.warning(
+                "AppendCaseStatusToCase: %s", self.feedback_message
+            )
+            return Status.FAILURE
         case.case_statuses.append(status_obj)
         self.datalayer.save(case)
         self.logger.info(

--- a/vultron/core/behaviors/status/nodes/lifecycle.py
+++ b/vultron/core/behaviors/status/nodes/lifecycle.py
@@ -30,11 +30,9 @@ from vultron.core.behaviors.embargo.trigger_tree import terminate_embargo_bt
 from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.use_cases._helpers import _resolve_case_manager_id
-from vultron.core.models.protocols import (
-    PersistableModel,
-    is_case_model,
-    is_participant_model,
-)
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.case_participant import CaseParticipant
+from vultron.core.models.protocols import PersistableModel
 from vultron.core.states.rm import RM
 from vultron.enums.roles import CVDRole
 from vultron.core.use_cases._helpers import _as_id
@@ -105,7 +103,7 @@ class _PublicDisclosureSkipConditionNode(DataLayerCondition):
         sender_participant = self.datalayer.read(sender_participant_id)
         roles = (
             sender_participant.roles
-            if is_participant_model(sender_participant)
+            if isinstance(sender_participant, CaseParticipant)
             else []
         )
         return CVDRole.CASE_OWNER in roles
@@ -118,7 +116,7 @@ class _PublicDisclosureSkipConditionNode(DataLayerCondition):
             return Status.SUCCESS
 
         case = self.datalayer.read(self.case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             return Status.SUCCESS
 
         if not self._sender_is_case_owner(case):
@@ -218,7 +216,7 @@ class AutoCloseBranchNode(DataLayerAction):
             p = self.datalayer.read(p_id)
             if p is None:
                 return False
-            roles = p.roles if is_participant_model(p) else []
+            roles = p.roles if isinstance(p, CaseParticipant) else []
             if CVDRole.CASE_MANAGER in roles:
                 continue
             statuses = getattr(p, "participant_statuses", [])
@@ -285,7 +283,9 @@ class AutoCloseBranchNode(DataLayerAction):
         if self.datalayer is None or not self.case_id:
             return Status.SUCCESS
         case = self.datalayer.read(self.case_id)
-        if not is_case_model(case) or not self._all_participants_closed(case):
+        if not isinstance(
+            case, VulnerabilityCase
+        ) or not self._all_participants_closed(case):
             return Status.SUCCESS
         if not self._claim_close():
             return Status.SUCCESS

--- a/vultron/core/behaviors/sync/nodes/chain.py
+++ b/vultron/core/behaviors/sync/nodes/chain.py
@@ -26,7 +26,7 @@ from vultron.core.behaviors.helpers import DataLayerAction
 from vultron.core.models._helpers import _now_utc
 from vultron.core.models.case_ledger import HashChainLedgerRecord
 from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
-from vultron.core.models.protocols import is_log_entry_model
+from vultron.core.models.case_ledger_entry import CaseLedgerEntry
 from vultron.core.sync_helpers import _find_equivalent_recorded_entry
 from vultron.core.sync_helpers import _reconstruct_tail_hash
 from vultron.errors import VultronCanonicalEntryError
@@ -83,7 +83,7 @@ def _require_log_entry(
     entry = getattr(activity, "log_entry", None)
     if entry is None:
         entry = getattr(activity, "object_", None)
-    if is_log_entry_model(entry):
+    if isinstance(entry, CaseLedgerEntry):
         if isinstance(entry, VultronCaseLedgerEntry):
             return entry
         return VultronCaseLedgerEntry.model_validate(
@@ -100,7 +100,7 @@ def _require_case_id_from_activity(activity: Any, node_name: str) -> str:
         entry = getattr(activity, "rejected_entry", None)
     if entry is None:
         entry = getattr(activity, "object_", None)
-    if is_log_entry_model(entry):
+    if isinstance(entry, CaseLedgerEntry):
         return entry.case_id
     raise VultronError(f"{node_name}: could not resolve case_id from activity")
 
@@ -315,7 +315,7 @@ class UpdateReplicationStateNode(DataLayerAction):
         entry = getattr(activity, "rejected_entry", None)
         if entry is None:
             entry = getattr(activity, "object_", None)
-        if not is_log_entry_model(entry):
+        if not isinstance(entry, CaseLedgerEntry):
             raise VultronError(
                 f"{self.name}: activity did not carry a VultronCaseLedgerEntry"
             )

--- a/vultron/core/behaviors/sync/nodes/conditions.py
+++ b/vultron/core/behaviors/sync/nodes/conditions.py
@@ -24,7 +24,7 @@ from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerCondition
 from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
-from vultron.core.models.protocols import is_log_entry_model
+from vultron.core.models.case_ledger_entry import CaseLedgerEntry
 from vultron.core.ports.case_persistence import CasePersistence
 from vultron.core.sync_helpers import is_ledger_fresh_for_case
 from vultron.errors import VultronError
@@ -56,7 +56,7 @@ def _require_log_entry(
     entry = getattr(activity, "log_entry", None)
     if entry is None:
         entry = getattr(activity, "object_", None)
-    if is_log_entry_model(entry):
+    if isinstance(entry, CaseLedgerEntry):
         if isinstance(entry, VultronCaseLedgerEntry):
             return entry
         return VultronCaseLedgerEntry.model_validate(

--- a/vultron/core/behaviors/sync/nodes/effects.py
+++ b/vultron/core/behaviors/sync/nodes/effects.py
@@ -43,7 +43,7 @@ from py_trees.common import Status
 from vultron.core.behaviors.helpers import DataLayerAction
 from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.models.participant_status import ParticipantStatus
-from vultron.core.models.protocols import is_case_model, is_participant_model
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.use_cases._helpers import _as_id
 
 logger = logging.getLogger(__name__)
@@ -123,7 +123,7 @@ class ApplyParticipantStatusFromLedgerNode(DataLayerAction):
             return Status.SUCCESS
 
         participant = self.datalayer.read(participant_id)
-        if not is_participant_model(participant):
+        if not isinstance(participant, CaseParticipant):
             self.logger.debug(
                 "%s: participant '%s' not found in local DataLayer"
                 " — skipping (non-fatal, partial case view)",
@@ -177,8 +177,6 @@ class ApplyParticipantStatusFromLedgerNode(DataLayerAction):
         # via the DataLayer reconstructs the object through the
         # vocabulary registry, returning the wire-format class that
         # round-trips correctly.
-        from vultron.core.models.protocols import ParticipantStatusModel
-
         status_from_dl = self.datalayer.read(status_id)
         if status_from_dl is None:
             self.logger.warning(
@@ -190,7 +188,7 @@ class ApplyParticipantStatusFromLedgerNode(DataLayerAction):
             return Status.SUCCESS
 
         participant.participant_statuses.append(
-            cast(ParticipantStatusModel, status_from_dl)
+            cast(ParticipantStatus, status_from_dl)
         )
         self.datalayer.save(participant)
 
@@ -252,7 +250,7 @@ class ApplyNoteFromLedgerNode(DataLayerAction):
             return Status.SUCCESS
 
         case = self.datalayer.read(case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.logger.debug(
                 "%s: case '%s' not found in local DataLayer"
                 " — skipping (non-fatal, partial case view)",
@@ -331,7 +329,7 @@ class ApplyInviteAcceptFromLedgerNode(DataLayerAction):
             return Status.SUCCESS
 
         case = self.datalayer.read(case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             self.logger.debug(
                 "%s: case '%s' not found in local DataLayer"
                 " — skipping (non-fatal, partial case view)",

--- a/vultron/core/behaviors/sync/nodes/receive.py
+++ b/vultron/core/behaviors/sync/nodes/receive.py
@@ -24,7 +24,7 @@ from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
 from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
-from vultron.core.models.protocols import is_log_entry_model
+from vultron.core.models.case_ledger_entry import CaseLedgerEntry
 from vultron.core.ports.sync_activity import SyncActivityPort
 from vultron.errors import VultronError
 
@@ -37,7 +37,7 @@ def _require_log_entry(
     entry = getattr(activity, "log_entry", None)
     if entry is None:
         entry = getattr(activity, "object_", None)
-    if is_log_entry_model(entry):
+    if isinstance(entry, CaseLedgerEntry):
         if isinstance(entry, VultronCaseLedgerEntry):
             return entry
         return VultronCaseLedgerEntry.model_validate(

--- a/vultron/core/behaviors/sync/nodes/replay.py
+++ b/vultron/core/behaviors/sync/nodes/replay.py
@@ -23,11 +23,10 @@ import py_trees
 from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerAction
-from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
-from vultron.core.models.protocols import (
-    LogEntryModel,
-    is_case_model,
-    is_log_entry_model,
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.case_ledger_entry import (
+    CaseLedgerEntry,
+    VultronCaseLedgerEntry,
 )
 from vultron.core.ports.sync_activity import SyncActivityPort
 from vultron.core.use_cases._helpers import case_addressees
@@ -42,7 +41,7 @@ def _require_log_entry(
     entry = getattr(activity, "log_entry", None)
     if entry is None:
         entry = getattr(activity, "object_", None)
-    if is_log_entry_model(entry):
+    if isinstance(entry, CaseLedgerEntry):
         if isinstance(entry, VultronCaseLedgerEntry):
             return entry
         return VultronCaseLedgerEntry.model_validate(
@@ -59,7 +58,7 @@ def _require_rejected_entry(
     entry = getattr(activity, "rejected_entry", None)
     if entry is None:
         entry = getattr(activity, "object_", None)
-    if is_log_entry_model(entry):
+    if isinstance(entry, CaseLedgerEntry):
         if isinstance(entry, VultronCaseLedgerEntry):
             return entry
         return VultronCaseLedgerEntry.model_validate(
@@ -154,10 +153,11 @@ class CollectAndSortCaseLedgerEntriesNode(DataLayerAction):
                 f"{self.name}: Reject(CaseLedgerEntry) missing peer actor_id"
             )
 
-        entries: list[LogEntryModel] = [
+        entries: list[CaseLedgerEntry] = [
             obj
             for obj in self.datalayer.list_objects("CaseLedgerEntry")
-            if is_log_entry_model(obj) and obj.case_id == entry.case_id
+            if isinstance(obj, CaseLedgerEntry)
+            and obj.case_id == entry.case_id
         ]
         entries.sort(key=lambda log_entry: log_entry.log_index)
 
@@ -183,7 +183,7 @@ class FindDivergenceIndexNode(DataLayerAction):
 
     def update(self) -> Status:
         entries = cast(
-            list[LogEntryModel], self.blackboard.replay_case_ledger_entries
+            list[CaseLedgerEntry], self.blackboard.replay_case_ledger_entries
         )
         from_hash = self.blackboard.activity.last_accepted_hash
         from_index = -1
@@ -242,7 +242,7 @@ class SendMissingEntriesNode(DataLayerAction):
         entry = cast(VultronCaseLedgerEntry, self.blackboard.replay_entry)
         peer_id = cast(str, self.blackboard.replay_peer_id)
         entries = cast(
-            list[LogEntryModel], self.blackboard.replay_case_ledger_entries
+            list[CaseLedgerEntry], self.blackboard.replay_case_ledger_entries
         )
         from_index = cast(int, self.blackboard.replay_from_index)
 
@@ -305,7 +305,7 @@ class CollectLogEntryRecipientsNode(DataLayerAction):
 
         entry = cast(VultronCaseLedgerEntry, self.blackboard.log_entry)
         case_obj = self.datalayer.read(self.case_id)
-        if not is_case_model(case_obj):
+        if not isinstance(case_obj, VulnerabilityCase):
             self.logger.warning(
                 "%s: case '%s' not found; skipping fan-out for '%s'",
                 self.name,

--- a/vultron/core/models/protocols.py
+++ b/vultron/core/models/protocols.py
@@ -13,18 +13,19 @@
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-"""Protocol types for domain model objects used by core use cases.
+"""Protocol types for structural contracts at DataLayer port boundaries.
 
-Both wire-layer types (e.g. VulnerabilityCase) and domain types (e.g.
-VultronCase) conform structurally to these Protocols, so use cases can call
-methods on DataLayer results without importing wire-layer classes.
+Only Protocols that cannot be replaced by concrete ``isinstance`` checks
+belong here. The duck-typing workaround Protocols (``CaseModel``,
+``ParticipantModel``, ``ParticipantStatusModel``, ``LogEntryModel``) were
+removed in favour of direct ``isinstance`` checks against core domain classes
+(ADR-0034, DL-05-003).
 """
 
 from typing import Any, Mapping, Protocol, TypeGuard
 
-from vultron.core.states.cs import CS_pxa, CS_vfd
+from vultron.core.states.cs import CS_pxa
 from vultron.core.states.em import EM
-from vultron.core.states.rm import RM
 
 
 class PersistableModel(Protocol):
@@ -46,54 +47,6 @@ class CaseStatusModel(Protocol):
     pxa_state: CS_pxa
 
 
-class ParticipantStatusModel(PersistableModel, Protocol):
-    """Duck-type protocol for a persisted ParticipantStatus record.
-
-    Satisfied by both the core :class:`~vultron.core.models.participant_status.ParticipantStatus`
-    and the wire-layer type returned by the DataLayer vocabulary registry.
-    """
-
-    rm_state: RM
-    vfd_state: CS_vfd
-    context: str
-    cvd_role: list
-    em_consent_state: Any | None
-
-
-class CaseModel(PersistableModel, Protocol):
-    case_participants: list
-    vulnerability_reports: list
-    active_embargo: object
-    actor_participant_index: dict[str, str]
-    attributed_to: object
-    notes: list
-    case_statuses: list
-    proposed_embargoes: list
-    name: str | None
-
-    def set_embargo(self, embargo_id: str) -> None: ...
-    def add_participant(self, participant: object) -> None: ...
-    def remove_participant(self, participant_id: str) -> None: ...
-
-    @property
-    def current_status(self) -> CaseStatusModel: ...
-
-
-class ParticipantModel(PersistableModel, Protocol):
-    accepted_embargo_ids: list
-    embargo_consent_state: str
-    participant_statuses: list[ParticipantStatusModel]
-    attributed_to: object
-    case_roles: list
-
-    @property
-    def roles(self) -> list: ...
-
-    def append_rm_state(
-        self, rm_state: RM, actor: str, context: str
-    ) -> bool: ...
-
-
 class OutboxCollectionModel(Protocol):
     items: list[object]
 
@@ -103,75 +56,5 @@ class ActorModel(PersistableModel, Protocol):
     outbox: OutboxCollectionModel
 
 
-def is_case_model(obj: PersistableModel | None) -> TypeGuard[CaseModel]:
-    return bool(
-        obj is not None
-        and getattr(obj, "type_", None) == "VulnerabilityCase"
-        and hasattr(obj, "case_participants")
-        and hasattr(obj, "case_statuses")
-    )
-
-
-def is_participant_model(
-    obj: PersistableModel | object | None,
-) -> TypeGuard[ParticipantModel]:
-    return bool(
-        obj is not None
-        and getattr(obj, "type_", None) == "CaseParticipant"
-        and hasattr(obj, "participant_statuses")
-        and hasattr(obj, "append_rm_state")
-    )
-
-
-def is_participant_status_model(
-    obj: object | None,
-) -> "TypeGuard[ParticipantStatusModel]":
-    """Return True if *obj* duck-types as a ParticipantStatus record.
-
-    Checks ``type_ == "ParticipantStatus"`` rather than using ``isinstance``
-    so it works for both the core model and the wire-layer type returned by
-    the DataLayer vocabulary registry (CLP-07-007).
-    """
-    return bool(
-        obj is not None
-        and getattr(obj, "type_", None) == "ParticipantStatus"
-        and hasattr(obj, "rm_state")
-        and hasattr(obj, "context")
-    )
-
-
 def has_outbox(obj: PersistableModel | None) -> TypeGuard[ActorModel]:
     return bool(obj is not None and hasattr(obj, "outbox"))
-
-
-class LogEntryModel(PersistableModel, Protocol):
-    """Protocol for a persisted canonical case ledger entry.
-
-    Satisfied by :class:`~vultron.core.models.case_ledger_entry.VultronCaseLedgerEntry`.
-    Used by the receive-side use case without importing from wire layer.
-    """
-
-    case_id: str
-    log_index: int
-    disposition: str
-    term: int | None
-    log_object_id: str
-    event_type: str
-    payload_snapshot: dict
-    prev_log_hash: str
-    entry_hash: str
-    received_at: Any
-    reason_code: str | None
-    reason_detail: str | None
-
-
-def is_log_entry_model(obj: object | None) -> TypeGuard[LogEntryModel]:
-    """Return True if *obj* satisfies the :class:`LogEntryModel` protocol."""
-    return bool(
-        obj is not None
-        and getattr(obj, "type_", None) == "CaseLedgerEntry"
-        and hasattr(obj, "case_id")
-        and hasattr(obj, "log_index")
-        and hasattr(obj, "prev_log_hash")
-        and hasattr(obj, "entry_hash")
-    )

--- a/vultron/core/ports/sync_activity.py
+++ b/vultron/core/ports/sync_activity.py
@@ -28,7 +28,7 @@ See also:
 
 from typing import Protocol
 
-from vultron.core.models.protocols import LogEntryModel
+from vultron.core.models.case_ledger_entry import CaseLedgerEntry
 
 
 class SyncActivityPort(Protocol):
@@ -45,7 +45,7 @@ class SyncActivityPort(Protocol):
 
     def send_reject_log_entry(
         self,
-        entry: LogEntryModel,
+        entry: CaseLedgerEntry,
         tail_hash: str,
         actor_id: str,
         to: list[str],
@@ -66,7 +66,7 @@ class SyncActivityPort(Protocol):
 
     def send_announce_log_entry(
         self,
-        entry: LogEntryModel,
+        entry: CaseLedgerEntry,
         actor_id: str,
         to: list[str],
     ) -> None:

--- a/vultron/core/ports/trigger_activity.py
+++ b/vultron/core/ports/trigger_activity.py
@@ -43,7 +43,7 @@ See also:
 
 from typing import Any, Protocol
 
-from vultron.core.models.protocols import CaseModel
+from vultron.core.models.case import VulnerabilityCase
 
 
 class TriggerActivityPort(Protocol):
@@ -266,7 +266,7 @@ class TriggerActivityPort(Protocol):
         id_: str | None = None,
         attributed_to: str | None = None,
         roles: list[str] | None = None,
-        target: CaseModel | None = None,
+        target: VulnerabilityCase | None = None,
     ) -> tuple[str, dict[str, Any]]:
         """Create and persist an ``Invite(Actor, Case)`` activity.
 

--- a/vultron/core/services/embargo_lifecycle.py
+++ b/vultron/core/services/embargo_lifecycle.py
@@ -46,7 +46,8 @@ from typing import Any
 from pydantic import BaseModel, Field
 from transitions import MachineError
 
-from vultron.core.models.protocols import is_case_model, is_participant_model
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.ports.case_persistence import CasePersistence
 from vultron.core.states.cs import CS_pxa
 from vultron.core.states.em import EM, EM_Trigger, EMAdapter, create_em_machine
@@ -199,7 +200,7 @@ class EmbargoLifecycle:
         """
         # Load and validate case
         case = self._persistence.read(case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             raise VultronNotFoundError("VulnerabilityCase", case_id)
 
         em_before = EM(case.current_status.em_state)
@@ -310,7 +311,7 @@ class EmbargoLifecycle:
                 PEC state only and are not blocked by P/X/A.
         """
         case = self._persistence.read(case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             raise VultronNotFoundError("VulnerabilityCase", case_id)
 
         em_before = EM(case.current_status.em_state)
@@ -427,7 +428,7 @@ class EmbargoLifecycle:
                 per EMB-04-002 — use terminate_active_embargo instead).
         """
         case = self._persistence.read(case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             raise VultronNotFoundError("VulnerabilityCase", case_id)
 
         em_before = EM(case.current_status.em_state)
@@ -516,7 +517,7 @@ class EmbargoLifecycle:
                 ``None``.
         """
         case = self._persistence.read(case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             raise VultronNotFoundError("VulnerabilityCase", case_id)
 
         em_before = EM(case.current_status.em_state)
@@ -592,7 +593,7 @@ class EmbargoLifecycle:
             when the transition was valid.
         """
         case = self._persistence.read(case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             raise VultronNotFoundError("VulnerabilityCase", case_id)
 
         em_state = EM(case.current_status.em_state)
@@ -614,7 +615,7 @@ class EmbargoLifecycle:
             )
 
         participant = self._persistence.read(participant_id)
-        if not is_participant_model(participant):
+        if not isinstance(participant, CaseParticipant):
             return EmbargoLifecycleResult(
                 em_before=em_state,
                 em_after=em_state,
@@ -772,7 +773,7 @@ class EmbargoLifecycle:
             return []
 
         participant = self._persistence.read(participant_id)
-        if not is_participant_model(participant):
+        if not isinstance(participant, CaseParticipant):
             return []
 
         pec_before = participant.embargo_consent_state
@@ -825,7 +826,7 @@ class EmbargoLifecycle:
             return []
 
         participant = self._persistence.read(participant_id)
-        if not is_participant_model(participant):
+        if not isinstance(participant, CaseParticipant):
             return []
 
         pec_before = participant.embargo_consent_state
@@ -869,7 +870,7 @@ class EmbargoLifecycle:
             if participant_id is None:
                 continue
             participant = self._persistence.read(participant_id)
-            if not is_participant_model(participant):
+            if not isinstance(participant, CaseParticipant):
                 continue
             if participant.embargo_consent_state == PEC.NO_EMBARGO.value:
                 continue
@@ -903,7 +904,7 @@ class EmbargoLifecycle:
             if participant_id is None:
                 continue
             participant = self._persistence.read(participant_id)
-            if not is_participant_model(participant):
+            if not isinstance(participant, CaseParticipant):
                 continue
             if participant.embargo_consent_state == PEC.SIGNATORY.value:
                 pec_before = participant.embargo_consent_state

--- a/vultron/core/sync_helpers.py
+++ b/vultron/core/sync_helpers.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Any
 
-from vultron.core.models.protocols import LogEntryModel, is_log_entry_model
+from vultron.core.models.case_ledger_entry import CaseLedgerEntry
 from vultron.core.ports.case_persistence import CasePersistence
 from vultron.errors import VultronValidationError
 
@@ -75,10 +75,10 @@ def is_ledger_fresh_for_case(
         fresh; a human-readable explanation when stale or when genesis
         metadata is unavailable.
     """
-    entries: list[LogEntryModel] = [
+    entries: list[CaseLedgerEntry] = [
         obj
         for obj in dl.list_objects("CaseLedgerEntry")
-        if is_log_entry_model(obj) and obj.case_id == case_id
+        if isinstance(obj, CaseLedgerEntry) and obj.case_id == case_id
     ]
 
     if not entries:
@@ -154,10 +154,10 @@ def _reconstruct_tail_hash(
         VultronValidationError: When the ledger is empty and the per-case
             genesis hash cannot be found in the DataLayer.
     """
-    entries: list[LogEntryModel] = [
+    entries: list[CaseLedgerEntry] = [
         obj
         for obj in dl.list_objects("CaseLedgerEntry")
-        if is_log_entry_model(obj) and obj.case_id == case_id
+        if isinstance(obj, CaseLedgerEntry) and obj.case_id == case_id
     ]
 
     if not entries:
@@ -183,17 +183,17 @@ def _find_equivalent_recorded_entry(
     event_type: str,
     payload_snapshot: dict[str, Any],
     dl: CasePersistence,
-) -> LogEntryModel | None:
+) -> CaseLedgerEntry | None:
     """Return an already-recorded canonical entry with equivalent semantics.
 
     "Equivalent" means same case, object, event type, and payload snapshot.
     This supports idempotent handling of participant retries without appending
     duplicate canonical entries for the same logical assertion.
     """
-    matches: list[LogEntryModel] = [
+    matches: list[CaseLedgerEntry] = [
         entry
         for obj in dl.list_objects("CaseLedgerEntry")
-        if is_log_entry_model(obj)
+        if isinstance(obj, CaseLedgerEntry)
         for entry in [obj]
         if entry.case_id == case_id
         and entry.disposition == "recorded"

--- a/vultron/core/use_cases/_helpers.py
+++ b/vultron/core/use_cases/_helpers.py
@@ -9,11 +9,8 @@ import logging
 import uuid
 from typing import Any
 
-from vultron.core.models.protocols import (
-    CaseModel,
-    is_case_model,
-    is_participant_model,
-)
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.models.report_case_link import VultronReportCaseLink
 from vultron.core.ports.case_persistence import (
     CasePersistence,
@@ -256,7 +253,7 @@ def resolve_case(case_id: str, dl: CasePersistence):
     case_raw = dl.read(case_id)
     if case_raw is None:
         raise VultronNotFoundError("VulnerabilityCase", case_id)
-    if not is_case_model(case_raw):
+    if not isinstance(case_raw, VulnerabilityCase):
         raise VultronValidationError(
             f"Expected VulnerabilityCase, got {type(case_raw).__name__}."
         )
@@ -279,7 +276,7 @@ def update_participant_rm_state(
     called from the BT nodes layer).
     """
     case_obj = dl.read(case_id)
-    if not is_case_model(case_obj):
+    if not isinstance(case_obj, VulnerabilityCase):
         logger.warning(
             "update_participant_rm_state: case '%s' not found or wrong type",
             case_id,
@@ -294,7 +291,7 @@ def update_participant_rm_state(
         else:
             participant_raw = participant_ref
 
-        if not is_participant_model(participant_raw):
+        if not isinstance(participant_raw, CaseParticipant):
             continue
 
         participant = participant_raw
@@ -348,7 +345,7 @@ def update_participant_rm_state(
 
 
 def _resolve_case_manager_id(
-    case: CaseModel, dl: CasePersistence
+    case: VulnerabilityCase, dl: CasePersistence
 ) -> str | None:
     """Return the actor ID of the Case Manager (CVDRole.CASE_MANAGER).
 
@@ -369,7 +366,7 @@ def _resolve_case_manager_id(
     # Primary path: fast index lookup (normal post-bootstrap operation).
     for p_id in case.actor_participant_index.values():
         p = dl.read(p_id)
-        if not is_participant_model(p):
+        if not isinstance(p, CaseParticipant):
             continue
         if CVDRole.CASE_MANAGER in p.roles:
             manager_actor_id = getattr(p, "attributed_to", None)
@@ -382,7 +379,7 @@ def _resolve_case_manager_id(
         if not isinstance(participant_ref, str):
             # Inline participant object — no DataLayer read needed.
             if (
-                is_participant_model(participant_ref)
+                isinstance(participant_ref, CaseParticipant)
                 and CVDRole.CASE_MANAGER in participant_ref.roles
             ):
                 attributed = getattr(participant_ref, "attributed_to", None)
@@ -392,7 +389,7 @@ def _resolve_case_manager_id(
             # Already checked via the index; skip to avoid duplicates.
             continue
         p = dl.read(participant_ref)
-        if not is_participant_model(p):
+        if not isinstance(p, CaseParticipant):
             continue
         if CVDRole.CASE_MANAGER in p.roles:
             manager_actor_id = getattr(p, "attributed_to", None)
@@ -401,7 +398,7 @@ def _resolve_case_manager_id(
 
 
 def resolve_case_participant_id_for_actor(
-    case: CaseModel,
+    case: VulnerabilityCase,
     actor_id: str,
     dl: CasePersistence,
 ) -> str | None:
@@ -418,10 +415,10 @@ def resolve_case_participant_id_for_actor(
             continue
         participant_obj = (
             participant_ref
-            if is_participant_model(participant_ref)
+            if isinstance(participant_ref, CaseParticipant)
             else dl.read(participant_id)
         )
-        if not is_participant_model(participant_obj):
+        if not isinstance(participant_obj, CaseParticipant):
             continue
         participant_actor_id = _as_id(participant_obj.attributed_to)
         if participant_actor_id == actor_id:
@@ -459,7 +456,7 @@ def resolve_case_participant_id_for_actor(
 
 
 def reset_case_participant_embargo_consent(
-    dl: CasePersistence, case: CaseModel
+    dl: CasePersistence, case: VulnerabilityCase
 ) -> None:
     """Reset all participants' embargo consent state to NO_EMBARGO.
 
@@ -479,7 +476,7 @@ def reset_case_participant_embargo_consent(
         if participant_id is None:
             continue
         participant = dl.read(participant_id)
-        if not is_participant_model(participant):
+        if not isinstance(participant, CaseParticipant):
             continue
         if participant.embargo_consent_state != PEC.NO_EMBARGO.value:
             participant.embargo_consent_state = apply_pec_trigger(
@@ -488,7 +485,9 @@ def reset_case_participant_embargo_consent(
             dl.save(participant)
 
 
-def case_addressees(case: CaseModel, excluding_actor_id: str) -> list[str]:
+def case_addressees(
+    case: VulnerabilityCase, excluding_actor_id: str
+) -> list[str]:
     """Return actor IDs for all case participants except *excluding_actor_id*.
 
     Uses ``case.actor_participant_index`` (a ``dict[actor_id, participant_id]``)

--- a/vultron/core/use_cases/query/action_rules.py
+++ b/vultron/core/use_cases/query/action_rules.py
@@ -23,7 +23,8 @@ from typing import cast
 from vultron.core.case_states.patterns.potential_actions import (
     action as get_actions,
 )
-from vultron.core.models.protocols import CaseModel, ParticipantModel
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.ports.case_persistence import CasePersistence
 from vultron.core.scoring.utils import enum2title
 from vultron.core.states.cs import CS_pxa, CS_vfd
@@ -44,7 +45,7 @@ class ActionRulesRequest(BaseModel):
 
 
 def _resolve_participant_id_from_actor(
-    case: CaseModel, actor_id: str, dl: CasePersistence
+    case: VulnerabilityCase, actor_id: str, dl: CasePersistence
 ) -> str:
     """Resolve a case-scoped participant ID from an actor ID."""
     participant_id = resolve_case_participant_id_for_actor(case, actor_id, dl)
@@ -83,7 +84,7 @@ class GetActionRulesUseCase:
         # 2. Resolve the actor's CaseParticipant in the selected case.
         participant_id = _resolve_participant_id_from_actor(case, actor_id, dl)
 
-        participant = cast(ParticipantModel | None, dl.read(participant_id))
+        participant = cast(CaseParticipant | None, dl.read(participant_id))
         if participant is None:
             raise VultronNotFoundError("CaseParticipant", participant_id)
         participant_actor_id = (

--- a/vultron/core/use_cases/received/actor/announce.py
+++ b/vultron/core/use_cases/received/actor/announce.py
@@ -11,7 +11,7 @@ from vultron.core.behaviors.case.announce_case_received_tree import (
 from vultron.core.models.events.actor import (
     AnnounceVulnerabilityCaseReceivedEvent,
 )
-from vultron.core.models.protocols import is_case_model
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.report_case_link import VultronReportCaseLink
 from vultron.core.ports.case_persistence import CasePersistence
 from vultron.core.use_cases._helpers import _as_id, _find_case_actor_id
@@ -76,7 +76,10 @@ class AnnounceVulnerabilityCaseReceivedUseCase:
             )
             return
 
-        if not is_case_model(case_obj):
+        if (
+            not isinstance(case_obj, VulnerabilityCase)
+            and getattr(case_obj, "type_", None) != "VulnerabilityCase"
+        ):
             logger.warning(
                 "AnnounceVulnerabilityCase: object in activity '%s' is not a"
                 " VulnerabilityCase (%s) — skipping",

--- a/vultron/core/use_cases/received/actor/case_manager_role.py
+++ b/vultron/core/use_cases/received/actor/case_manager_role.py
@@ -14,7 +14,8 @@ from vultron.core.models.events.actor import (
     OfferCaseManagerRoleReceivedEvent,
     RejectCaseManagerRoleReceivedEvent,
 )
-from vultron.core.models.protocols import is_case_model, is_participant_model
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.ports.case_persistence import (
     CaseOutboxPersistence,
     CasePersistence,
@@ -127,7 +128,7 @@ class AcceptCaseManagerRoleReceivedUseCase:
         # Primary path: fast index lookup.
         for p_id in getattr(case, "actor_participant_index", {}).values():
             p = self._dl.read(p_id)
-            if is_participant_model(p) and (
+            if isinstance(p, CaseParticipant) and (
                 CVDRole.REPORTER in p.roles or CVDRole.FINDER in p.roles
             ):
                 return _as_id(getattr(p, "attributed_to", None))
@@ -139,7 +140,7 @@ class AcceptCaseManagerRoleReceivedUseCase:
         )
         for participant_ref in getattr(case, "case_participants", []):
             if not isinstance(participant_ref, str):
-                if is_participant_model(participant_ref) and (
+                if isinstance(participant_ref, CaseParticipant) and (
                     CVDRole.REPORTER in participant_ref.roles
                     or CVDRole.FINDER in participant_ref.roles
                 ):
@@ -150,7 +151,7 @@ class AcceptCaseManagerRoleReceivedUseCase:
             if participant_ref in indexed_ids:
                 continue
             p = self._dl.read(participant_ref)
-            if is_participant_model(p) and (
+            if isinstance(p, CaseParticipant) and (
                 CVDRole.REPORTER in p.roles or CVDRole.FINDER in p.roles
             ):
                 return _as_id(getattr(p, "attributed_to", None))
@@ -193,7 +194,7 @@ class AcceptCaseManagerRoleReceivedUseCase:
             return
 
         case = self._dl.read(case_id)
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             logger.warning(
                 "AcceptCaseManagerRoleReceived: case '%s' not found"
                 " — skipping trust bootstrap",

--- a/vultron/core/use_cases/received/case/_helpers.py
+++ b/vultron/core/use_cases/received/case/_helpers.py
@@ -9,7 +9,7 @@ from vultron.core.behaviors.case.nodes.participant.common import (  # noqa: F401
 from vultron.core.behaviors.case.update_support import (
     find_excluded_actor_ids,
 )
-from vultron.core.models.protocols import CaseModel
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.report_case_link import VultronReportCaseLink
 from vultron.core.ports.case_persistence import CasePersistence
 
@@ -38,7 +38,7 @@ def _find_report_case_link(
 
 
 def _check_participant_embargo_acceptance(
-    case: CaseModel, dl: CasePersistence
+    case: VulnerabilityCase, dl: CasePersistence
 ) -> set[str]:
     """Check which participants have not accepted the active embargo.
 
@@ -49,7 +49,7 @@ def _check_participant_embargo_acceptance(
 
 
 def _store_embedded_participants(
-    case_obj: CaseModel, dl: CasePersistence, case_id: str
+    case_obj: VulnerabilityCase, dl: CasePersistence, case_id: str
 ) -> None:
     """Persist embedded participant objects from a case snapshot.
 

--- a/vultron/core/use_cases/received/case/create.py
+++ b/vultron/core/use_cases/received/case/create.py
@@ -7,7 +7,7 @@ from vultron.core.behaviors.case.nodes.participant import (
     EnsureReporterParticipantAtAcceptedNode,
 )
 from vultron.core.models.events.case import CreateCaseReceivedEvent
-from vultron.core.models.protocols import CaseModel, is_case_model
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.report_case_link import VultronReportCaseLink
 from vultron.core.ports.case_persistence import CasePersistence
 
@@ -61,14 +61,14 @@ class CreateCaseReceivedUseCase:
             return
 
         case_obj_raw = request.case
-        if not is_case_model(case_obj_raw):
+        if not isinstance(case_obj_raw, VulnerabilityCase):
             logger.warning(
                 "create_case_received: case object for case '%s' does not "
-                "satisfy CaseModel protocol — skipping",
+                "is not a VulnerabilityCase — skipping",
                 case_id,
             )
             return
-        case_obj: CaseModel = case_obj_raw
+        case_obj: VulnerabilityCase = case_obj_raw
         link = _find_report_case_link(actor_id, self._dl)
 
         if link is not None:
@@ -85,7 +85,7 @@ class CreateCaseReceivedUseCase:
         self,
         actor_id: str,
         case_id: str,
-        case_obj: CaseModel,
+        case_obj: VulnerabilityCase,
         link: VultronReportCaseLink,
     ) -> None:
         """Validate trust and seed the case replica."""
@@ -124,11 +124,9 @@ class CreateCaseReceivedUseCase:
         )
 
         # Seed the local case replica
-        from vultron.core.models.protocols import is_case_model
-
         # Idempotency guard (CBT-01-006, ID-04-004)
         existing = self._dl.read(case_id)
-        if is_case_model(existing):
+        if isinstance(existing, VulnerabilityCase):
             logger.info(
                 "create_case_received: case '%s' already exists as replica "
                 "— skipping re-seed",

--- a/vultron/core/use_cases/received/case/engage_defer.py
+++ b/vultron/core/use_cases/received/case/engage_defer.py
@@ -9,7 +9,7 @@ from vultron.core.models.events.case import (
     DeferCaseReceivedEvent,
     EngageCaseReceivedEvent,
 )
-from vultron.core.models.protocols import is_case_model
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.ports.case_persistence import CasePersistence
 
 from ._helpers import _store_embedded_participants
@@ -52,7 +52,7 @@ class EngageCaseReceivedUseCase:
         # locate them by UUID.  Mirrors the Create (#564) and Announce (#566)
         # paths (CBT-05-005, fixes #573).
         case_obj = request.case
-        if is_case_model(case_obj):
+        if isinstance(case_obj, VulnerabilityCase):
             _store_embedded_participants(case_obj, self._dl, case_id)
 
         logger.info(

--- a/vultron/core/use_cases/received/case/lifecycle.py
+++ b/vultron/core/use_cases/received/case/lifecycle.py
@@ -13,7 +13,7 @@ from vultron.core.models.events.case import (
     AddReportToCaseReceivedEvent,
     CloseCaseReceivedEvent,
 )
-from vultron.core.models.protocols import is_case_model
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.ports.case_persistence import (
     CaseOutboxPersistence,
     CasePersistence,
@@ -42,7 +42,7 @@ class AddReportToCaseReceivedUseCase:
             return
         case = self._dl.read(case_id)
 
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             logger.warning("add_report_to_case: case '%s' not found", case_id)
             return
 

--- a/vultron/core/use_cases/received/case/update.py
+++ b/vultron/core/use_cases/received/case/update.py
@@ -4,7 +4,7 @@ import logging
 
 from vultron.core.behaviors.case.update_support import broadcast_case_update
 from vultron.core.models.events.case import UpdateCaseReceivedEvent
-from vultron.core.models.protocols import CaseModel
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 
 logger = logging.getLogger(__name__)
@@ -54,7 +54,7 @@ class UpdateCaseReceivedUseCase:
     def _broadcast_case_update(
         self,
         case_id: str,
-        case: CaseModel,
+        case: VulnerabilityCase,
         excluded_actor_ids: set[str] | None = None,
     ) -> None:
         """Broadcast an Announce activity for the updated case to participants.

--- a/vultron/core/use_cases/received/embargo.py
+++ b/vultron/core/use_cases/received/embargo.py
@@ -21,10 +21,8 @@ from vultron.core.use_cases._helpers import (
     _idempotent_create,
     add_activity_to_outbox,
 )
-from vultron.core.models.protocols import (
-    PersistableModel,
-    is_case_model,
-)
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.protocols import PersistableModel
 from vultron.core.states.cs import (
     CS_pxa,
     is_pxa_attacks_observed,
@@ -46,7 +44,7 @@ def _pxa_embargo_ineligible(dl: CasePersistence, case_id: str) -> bool:
     cannot be resolved so normal processing can continue.
     """
     case = dl.read(case_id)
-    if not is_case_model(case):
+    if not isinstance(case, VulnerabilityCase):
         return False
     try:
         pxa_state = CS_pxa(case.current_status.pxa_state)
@@ -374,7 +372,7 @@ class AcceptInviteToEmbargoOnCaseReceivedUseCase:
             return
 
         _case = _resolve_case_for_embargo_acceptance(self._dl, request)
-        if not is_case_model(_case):
+        if not isinstance(_case, VulnerabilityCase):
             logger.error("accept_invite_to_embargo_on_case: case not found")
             return
 

--- a/vultron/core/use_cases/received/note.py
+++ b/vultron/core/use_cases/received/note.py
@@ -19,7 +19,7 @@ from vultron.core.ports.case_persistence import (
     CaseOutboxPersistence,
     CasePersistence,
 )
-from vultron.core.models.protocols import is_case_model
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.use_cases._helpers import _as_id
 
 if TYPE_CHECKING:
@@ -141,7 +141,7 @@ class RemoveNoteFromCaseReceivedUseCase:
             return
         case = self._dl.read(case_id)
 
-        if not is_case_model(case):
+        if not isinstance(case, VulnerabilityCase):
             logger.warning(
                 "remove_note_from_case: case '%s' not found", case_id
             )

--- a/vultron/core/use_cases/triggers/_helpers.py
+++ b/vultron/core/use_cases/triggers/_helpers.py
@@ -24,10 +24,7 @@ framework imports allowed here.
 import logging
 from collections.abc import Callable
 
-from vultron.core.models.protocols import (
-    CaseModel,
-    is_case_model,
-)
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.ports.case_persistence import (
     CasePersistence,
     CaseOutboxPersistence,
@@ -48,14 +45,14 @@ def resolve_actor(actor_id: str, dl: CasePersistence):
     return actor
 
 
-def resolve_case(case_id: str, dl: CasePersistence) -> CaseModel:
+def resolve_case(case_id: str, dl: CasePersistence) -> VulnerabilityCase:
     """Resolve a VulnerabilityCase by ID; raise domain error if absent or wrong type."""
     case_raw = dl.read(case_id)
-    if case_raw is None or not is_case_model(case_raw):
+    if case_raw is None or not isinstance(case_raw, VulnerabilityCase):
         case_raw = dl.find_case_by_short_id(case_id)
     if case_raw is None:
         raise VultronNotFoundError("VulnerabilityCase", case_id)
-    if not is_case_model(case_raw):
+    if not isinstance(case_raw, VulnerabilityCase):
         raise VultronValidationError(
             f"Expected VulnerabilityCase, got {type(case_raw).__name__}."
         )
@@ -120,7 +117,7 @@ def _is_case_owner(case: object | None, actor_id: str) -> bool:
 
 
 def _resolve_embargo_proposal(
-    case: CaseModel, proposal_id: str | None, dl: CaseOutboxPersistence
+    case: VulnerabilityCase, proposal_id: str | None, dl: CaseOutboxPersistence
 ):
     """Resolve the embargo proposal for a case."""
     from vultron.errors import VultronNotFoundError, VultronValidationError

--- a/vultron/core/use_cases/triggers/sync.py
+++ b/vultron/core/use_cases/triggers/sync.py
@@ -28,10 +28,7 @@ from __future__ import annotations
 
 import logging
 
-from vultron.core.models.protocols import (
-    LogEntryModel,
-    is_log_entry_model,
-)
+from vultron.core.models.case_ledger_entry import CaseLedgerEntry
 from vultron.core.ports.case_persistence import (
     CaseOutboxPersistence,
 )
@@ -71,10 +68,10 @@ def replay_missing_entries_trigger(
 
     Spec: SYNC-03-002.
     """
-    entries: list[LogEntryModel] = [
+    entries: list[CaseLedgerEntry] = [
         obj
         for obj in dl.list_objects("CaseLedgerEntry")
-        if is_log_entry_model(obj) and obj.case_id == case_id
+        if isinstance(obj, CaseLedgerEntry) and obj.case_id == case_id
     ]
 
     if not entries:

--- a/vultron/wire/as2/factories/case.py
+++ b/vultron/wire/as2/factories/case.py
@@ -28,7 +28,7 @@ from typing import Any, cast
 from pydantic import ValidationError
 
 from vultron.core.models.actor import CoreActor
-from vultron.core.models.protocols import is_case_model
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.states.em import EM
 from vultron.wire.as2.factories.errors import VultronActivityConstructionError
 from vultron.wire.as2.vocab.base.objects.activities.intransitive import (
@@ -670,7 +670,7 @@ def rm_invite_to_case_activity(
     Raises:
         VultronActivityConstructionError: If Pydantic validation fails.
     """
-    if is_case_model(target):
+    if isinstance(target, (VulnerabilityCase, as_VulnerabilityCase)):
         target = _project_case_to_stub(target, embargo_obj)
     if roles is not None:
         kwargs["roles"] = roles


### PR DESCRIPTION
- Closes #1504

## Summary

Removes four duck-typing Protocol workarounds (`CaseModel`, `ParticipantModel`,
`ParticipantStatusModel`, `LogEntryModel`) and their `TypeGuard` helpers
(`is_case_model`, `is_participant_model`, `is_participant_status_model`,
`is_log_entry_model`) from `vultron/core/models/protocols.py`.

Every call site (72 files) is replaced with direct `isinstance()` checks against
concrete core domain classes: `VulnerabilityCase`, `CaseParticipant`,
`ParticipantStatus`, `CaseLedgerEntry`.

## Why

These Protocols existed only because `dl.read()` once returned wire-layer objects.
Core code could not `isinstance(x, VulnerabilityCase)` without importing from
`vultron/wire/`, violating ARCH-01-001. ADR-0034 / DL-05-003 fixed the DataLayer
read path to return core objects, making the duck-typing workaround obsolete.

Remaining Protocols in `protocols.py` (`PersistableModel`, `CaseStatusModel`,
`OutboxCollectionModel`, `ActorModel`, `has_outbox`) are kept — they represent
legitimate port-boundary contracts, not workarounds.

## Changes

- **`vultron/core/models/protocols.py`**: Remove `CaseModel`, `ParticipantModel`, `ParticipantStatusModel`, `LogEntryModel` and their four `TypeGuard` helpers; update module docstring.
- **72 core + adapter files**: Replace `is_case_model()` / `is_participant_model()` / `is_participant_status_model()` / `is_log_entry_model()` with direct `isinstance()` checks against the corresponding concrete core class.
- **`vultron/core/use_cases/received/actor/announce.py`**: Receive-side boundary uses dual `isinstance OR type_==` check (see Key design decisions).
- **`vultron/core/behaviors/status/nodes/case_status.py`**: Adds explicit `isinstance(status_obj, CaseStatus)` guard in `AppendCaseStatusToCaseNode`.
- **Test files** (10 files): Update `MagicMock` to use `spec=` on mocked core objects so `isinstance()` guards pass.
- **`plan/history/2607/implementation/ISSUE-1504.md`**: Archive history entry.
- **`plan/incoming/learnings/`**: Three new learning entries (mock spec=, receive boundary, git rebase workaround).

## Key design decisions

- **Receive-side boundary** (`received/actor/announce.py`): incoming AS2 activities
  carry wire-layer `as_VulnerabilityCase` objects before they're stored. This
  boundary case uses a dual check (`isinstance(x, VulnerabilityCase) or
  getattr(x, "type_", None) == "VulnerabilityCase"`) to accept both wire and core
  types without importing from `vultron/wire/` (ADR-0032).
- **MagicMock in tests** must use `spec=VulnerabilityCase` to pass `isinstance`
  guards (duck-typed mocks no longer pass).

## Verification

- [x] `uv run pytest --tb=short` — 5075 passed, 38 skipped, 2 xfailed (clean)
- [x] `uv run black vultron/ test/ && uv run flake8 vultron/ test/ && uv run mypy && uv run pyright` — all clean
- [x] Architecture test `test_core_no_wire_imports.py` confirms no new wire imports in core
- [x] `grep -rn "is_case_model\|is_participant_model\|is_participant_status_model\|is_log_entry_model" vultron/ test/` — zero hits
- [x] AC-1: Core call sites use `isinstance(x, <core class>)` narrowing
- [x] AC-2: Core type hints reference concrete core classes
- [x] AC-3: Workaround Protocols and TypeGuard helpers removed (legitimate Protocols retained with justification)
- [x] AC-4: `vultron/core/` does not import wire; architecture ratchet stays green
- [x] AC-5: Full test suite + mypy/pyright/flake8/black clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)