### PR TITLE
fix: serialize concurrent inbox BackgroundTasks with per-actor asyncio.Lock (#1525)

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1525.md
+++ b/plan/history/2607/implementation/ISSUE-1525.md
@@ -1,0 +1,56 @@
+---
+source: ISSUE-1525
+timestamp: '2026-07-20T16:48:33.230339+00:00'
+title: fix concurrent inbox background tasks out-of-order processing
+type: implementation
+---
+
+## Issue #1525 — Flaky CI: FVV Demo Integration times out in `wait_for_contiguous_ledger_coverage`
+
+### Symptoms
+
+The FVV demo integration test intermittently timed out (15 s) waiting for all
+ledger entries to be present on a replica's DataLayer during case closure.
+The timeout was flaky — same code, same environment, so infrastructure was
+ruled out; the root cause had to be a code-level race.
+
+### Root Cause
+
+`post_actor_inbox` (sync `def`) schedules `run_inbox_pipeline` as a FastAPI
+`BackgroundTask`.  When two HTTP POSTs for the same actor arrive close
+together (common during fan-out from `FanOutLogEntryNode`), each creates a
+separate asyncio Task.  Within a single Task, `process_payload` is
+synchronous and has no `await` points, so it runs atomically.  But if the
+asyncio event loop schedules Task_{N+1} before Task_N has stored its ledger
+entry, the hash-chain check in `CheckHashMatchesNode` sees:
+
+    tail = hash(N-1)     entry_{N+1}.prev_log_hash = hash(N)  → MISMATCH
+
+This triggers a Reject → Replay cycle that may not converge before the demo
+timeout.
+
+The existing `_BT_GLOBAL_LOCK` (`threading.RLock`) guards the BT blackboard
+from thread-pool concurrency but does **not** prevent asyncio-level task
+interleaving — these are orthogonal concerns.
+
+The outbox was confirmed FIFO (`.order_by(col(QueueEntry.id))`); the problem
+is exclusively on the inbox receive side.
+
+### Fix
+
+Added `_actor_inbox_locks: dict[str, asyncio.Lock]` and `_get_actor_lock()`
+in `vultron/adapters/driving/fastapi/inbox_orchestration.py`.
+`run_inbox_pipeline` acquires the per-actor lock before `process_payload` and
+the inbox replay loop, and releases it before `outbox_handler` so HTTP
+delivery for a second actor is not blocked.
+
+### Regression Test
+
+`test/adapters/driving/fastapi/test_inbox_orchestration_lock.py` — uses
+`asyncio.gather` to schedule two pipelines for the same actor concurrently,
+forcing the scheduler to interleave them.  With the lock both entries are
+stored; without it entry N+1 fails the hash-chain check.
+
+### PR
+
+<https://github.com/CERTCC/Vultron/pull/1533>

--- a/plan/history/2607/learning/ISSUE-1525.md
+++ b/plan/history/2607/learning/ISSUE-1525.md
@@ -1,7 +1,7 @@
 ---
 title: "Per-actor asyncio.Lock required to serialize concurrent inbox BackgroundTasks"
 type: learning
-timestamp: "2026-07-20"
+timestamp: "2026-07-20T00:00:00+00:00"
 source: ISSUE-1525
 ---
 

--- a/plan/incoming/learnings/20260720-asyncio-background-task-inbox-serialization.md
+++ b/plan/incoming/learnings/20260720-asyncio-background-task-inbox-serialization.md
@@ -1,0 +1,48 @@
+---
+title: "Per-actor asyncio.Lock required to serialize concurrent inbox BackgroundTasks"
+type: learning
+timestamp: "2026-07-20"
+source: ISSUE-1525
+---
+
+## Observation
+
+FastAPI `BackgroundTask` schedules async coroutines as asyncio Tasks.
+When two HTTP POSTs arrive for the same actor at nearly the same time (common
+in demo flows where the CaseActor fans out to multiple participants in a tight
+loop), each POST creates its own asyncio Task for `run_inbox_pipeline`.
+
+`process_payload` is synchronous and has no `await` points, so within a single
+Task it runs atomically.  But if the asyncio event loop schedules Task_{N+1}
+before Task_N has completed, Task_{N+1}'s hash-chain check sees tail =
+hash(N-1) while entry_{N+1}.prev_log_hash = hash(N) → MISMATCH → Reject →
+Replay.  In a demo context the replay may not converge within 15 s, causing
+`wait_for_contiguous_ledger_coverage` to time out.
+
+## Fix
+
+Added a per-actor `asyncio.Lock` (`_actor_inbox_locks` dict keyed by
+`actor_id`) in `vultron/adapters/driving/fastapi/inbox_orchestration.py`.
+`run_inbox_pipeline` acquires the lock before calling `process_payload` and
+releases it before `outbox_handler`, so:
+
+- Entries for the same actor are processed in arrival order.
+- HTTP delivery (outbox) can proceed concurrently, so entries for a SECOND
+  actor are not blocked while the first actor's outbox is being drained.
+
+## Pitfall
+
+The existing `_BT_GLOBAL_LOCK` (`threading.RLock`) protects against
+thread-level concurrency from the sync thread pool but does NOT protect against
+asyncio-level task interleaving within the single event loop thread.  These are
+orthogonal concerns requiring orthogonal primitives.
+
+## Test pattern
+
+Regression test at `test/adapters/driving/fastapi/test_inbox_orchestration_lock.py`
+uses `asyncio.gather` to run two pipelines for the same actor concurrently,
+which forces the scheduler to interleave them.  With the lock, both entries are
+stored; without it, the second fails the hash-chain check.
+
+This project does NOT use `pytest-asyncio`.  Async tests are wrapped in a sync
+`def test_...()` that calls `asyncio.run(_run())`.

--- a/test/adapters/driving/fastapi/test_inbox_orchestration_lock.py
+++ b/test/adapters/driving/fastapi/test_inbox_orchestration_lock.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python
+"""Regression test: concurrent inbox BackgroundTasks must serialize per actor.
+
+Two concurrent ``run_inbox_pipeline`` calls for the same actor can interleave
+at the asyncio level if the event loop schedules the second task before the
+first has finished storing its ledger entry.  When entries arrive in wrong
+asyncio-scheduling order, the hash-chain check fails → Reject → Replay loop
+that may not converge within the demo timeout (issue #1525).
+
+The fix: ``run_inbox_pipeline`` acquires a per-actor ``asyncio.Lock`` before
+calling ``process_payload``.  This test verifies the lock is in place by
+forcing a scheduling inversion and confirming both entries are stored.
+"""
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock
+
+import py_trees
+import pytest
+
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.adapters.driving.fastapi.inbox_orchestration import (
+    _get_actor_lock,
+    run_inbox_pipeline,
+)
+from vultron.core.models.case_ledger import (
+    HashChainLedgerRecord,
+    compute_genesis_hash,
+)
+from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
+from vultron.core.behaviors.sync.nodes.chain import _to_persistable_entry
+from vultron.wire.as2.factories import announce_log_entry_activity
+from vultron.wire.as2.vocab.objects.case_actor import as_CaseActor
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.case_ledger_entry import (
+    as_CaseLedgerEntry as WireCaseLedgerEntry,
+)
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
+
+_CASE_ACTOR_ID = "https://example.org/actors/case-actor-lock-test"
+_PEER_ID = "https://example.org/actors/peer-lock-test"
+_CASE_ID = "https://example.org/cases/case-lock-test"
+
+
+@pytest.fixture(autouse=True)
+def clear_blackboard():
+    py_trees.blackboard.Blackboard.storage.clear()
+    yield
+    py_trees.blackboard.Blackboard.storage.clear()
+
+
+@pytest.fixture(autouse=True)
+def clear_actor_locks():
+    """Remove any cached per-actor locks between tests."""
+    from vultron.adapters.driving.fastapi import inbox_orchestration
+
+    inbox_orchestration._actor_inbox_locks.clear()
+    yield
+    inbox_orchestration._actor_inbox_locks.clear()
+
+
+@pytest.fixture
+def dl():
+    db = SqliteDataLayer("sqlite:///:memory:")
+    yield db
+    db.close()
+
+
+@pytest.fixture
+def seeded_dl(dl):
+    """DataLayer seeded with a case, genesis hash, and two chained entries."""
+    created_at = datetime.now(timezone.utc)
+    genesis_hash = compute_genesis_hash(
+        case_id=_CASE_ID,
+        created_at=created_at,
+        case_actor_id=_CASE_ACTOR_ID,
+    )
+    case = as_VulnerabilityCase(id_=_CASE_ID, name="lock-test-case")
+    case.genesis_hash = genesis_hash
+
+    case_actor_participant = as_CaseParticipant(
+        attributed_to=_CASE_ACTOR_ID, context=_CASE_ID
+    )
+    peer_participant = as_CaseParticipant(
+        attributed_to=_PEER_ID, context=_CASE_ID
+    )
+    case.case_participants.append(case_actor_participant.id_)
+    case.case_participants.append(peer_participant.id_)
+    case.actor_participant_index[_CASE_ACTOR_ID] = case_actor_participant.id_
+    case.actor_participant_index[_PEER_ID] = peer_participant.id_
+
+    case_actor_svc = as_CaseActor(
+        id_=f"{_CASE_ACTOR_ID}/case-actor",
+        attributed_to=_CASE_ACTOR_ID,
+        context=_CASE_ID,
+    )
+
+    dl.save(case_actor_participant)
+    dl.save(peer_participant)
+    dl.save(case)
+    dl.save(case_actor_svc)
+
+    _snapshot = {
+        "actor": _CASE_ACTOR_ID,
+        "type": "Announce",
+        "object": {"type": "VulnerabilityCase"},
+        "context": _CASE_ID,
+    }
+    entry0 = _to_persistable_entry(
+        HashChainLedgerRecord(
+            case_id=_CASE_ID,
+            log_index=0,
+            object_id=_CASE_ID,
+            event_type="test_event_0",
+            payload_snapshot=_snapshot,
+            prev_log_hash=genesis_hash,
+        )
+    )
+    entry1 = _to_persistable_entry(
+        HashChainLedgerRecord(
+            case_id=_CASE_ID,
+            log_index=1,
+            object_id=_CASE_ID,
+            event_type="test_event_1",
+            payload_snapshot=_snapshot,
+            prev_log_hash=entry0.entry_hash,
+        )
+    )
+
+    return dl, [entry0, entry1]
+
+
+def _make_announce_body(entry: VultronCaseLedgerEntry) -> dict[str, Any]:
+    wire_entry = WireCaseLedgerEntry.model_validate(
+        entry.model_dump(mode="json")
+    )
+    activity = announce_log_entry_activity(
+        entry=wire_entry,
+        actor=_CASE_ACTOR_ID,
+        to=[_PEER_ID],
+    )
+    return activity.model_dump(mode="json", by_alias=True, exclude_none=True)
+
+
+def test_get_actor_lock_returns_same_lock_for_same_actor():
+    """_get_actor_lock returns the same asyncio.Lock for the same actor_id."""
+
+    async def _run():
+        lock_a = _get_actor_lock("actor-1")
+        lock_b = _get_actor_lock("actor-1")
+        lock_c = _get_actor_lock("actor-2")
+        assert lock_a is lock_b
+        assert lock_a is not lock_c
+        assert isinstance(lock_a, asyncio.Lock)
+
+    asyncio.run(_run())
+
+
+def test_get_actor_lock_different_actors_do_not_share_lock():
+    """_get_actor_lock returns distinct locks for different actor IDs."""
+
+    async def _run():
+        lock_a = _get_actor_lock("actor-alpha")
+        lock_b = _get_actor_lock("actor-beta")
+        assert lock_a is not lock_b
+
+    asyncio.run(_run())
+
+
+def test_concurrent_inbox_tasks_serialize_processing(seeded_dl) -> None:
+    """Concurrent run_inbox_pipeline calls for the same actor serialize correctly.
+
+    Without the per-actor lock, if the asyncio event loop schedules the
+    second task's process_payload before the first task has stored entry0,
+    entry1's hash-chain check fails (prev_log_hash != tail_hash).
+
+    With the lock, entry0 is fully stored before entry1 is processed, so
+    both entries end up in the peer's DataLayer.
+
+    This test runs both tasks concurrently via asyncio.gather to reproduce
+    the race scenario.  The lock guarantees correct ordering.
+    """
+    dl, entries = seeded_dl
+    entry0, entry1 = entries
+
+    actor_dl = dl.clone_for_actor(_PEER_ID)
+
+    body0 = _make_announce_body(entry0)
+    body1 = _make_announce_body(entry1)
+
+    null_emitter = AsyncMock()
+    null_emitter.emit = AsyncMock()
+
+    from vultron.adapters.driving.fastapi.inbox_handler import make_dispatcher
+
+    dispatcher = make_dispatcher()
+
+    async def _run():
+        await asyncio.gather(
+            run_inbox_pipeline(
+                body0, body0, dl, actor_dl, _PEER_ID, dispatcher, null_emitter
+            ),
+            run_inbox_pipeline(
+                body1, body1, dl, actor_dl, _PEER_ID, dispatcher, null_emitter
+            ),
+        )
+
+    asyncio.run(_run())
+
+    stored0 = dl.read(entry0.id_)
+    stored1 = dl.read(entry1.id_)
+
+    assert (
+        stored0 is not None
+    ), f"Entry0 (log_index=0) was not stored. hash={entry0.entry_hash[:16]}…"
+    assert stored1 is not None, (
+        f"Entry1 (log_index=1) was not stored — likely a hash-chain mismatch "
+        f"race: entry1 was processed before entry0 was stored (issue #1525). "
+        f"hash={entry1.entry_hash[:16]}…"
+    )

--- a/vultron/adapters/driving/fastapi/inbox_orchestration.py
+++ b/vultron/adapters/driving/fastapi/inbox_orchestration.py
@@ -28,6 +28,7 @@ IO-03-003).
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
+import asyncio
 import logging
 from typing import Any, cast
 
@@ -51,6 +52,21 @@ from vultron.wire.as2.rehydration import rehydrate
 from vultron.wire.as2.vocab.base.objects.activities.base import as_Activity
 
 logger = logging.getLogger(__name__)
+
+# Per-actor asyncio locks that serialise concurrent inbox background tasks.
+# When multiple HTTP POSTs arrive for the same actor simultaneously, each
+# creates a separate asyncio Task (BackgroundTask).  Without serialisation,
+# the second task's process_payload can run before the first has stored its
+# ledger entry, causing a hash-chain mismatch → spurious Reject → Replay loop
+# that may not converge within the demo timeout (issue #1525).
+_actor_inbox_locks: dict[str, asyncio.Lock] = {}
+
+
+def _get_actor_lock(actor_id: str) -> asyncio.Lock:
+    """Return the per-actor asyncio.Lock for *actor_id*, creating it on first use."""
+    if actor_id not in _actor_inbox_locks:
+        _actor_inbox_locks[actor_id] = asyncio.Lock()
+    return _actor_inbox_locks[actor_id]
 
 
 def _is_inline_ledger_entry_announce(activity: as_Activity) -> bool:
@@ -344,27 +360,33 @@ async def run_inbox_pipeline(
         actor_id=actor_id,
     )
 
-    outcome = process_payload(payload, ingress, dispatch_adp, queue)
-    logger.info(
-        "run_inbox_pipeline: status=%s context_id=%s",
-        outcome.status,
-        outcome.context_id,
-    )
-
-    # Process any replayed activities (pushed back to the queue by
-    # DeferCheckNode/DispatchNode replay after bootstrap).
-    stored_ingress = StoredActivityIngressAdapter(dl=dl)
-    while actor_dl.inbox_list():
-        item_id = actor_dl.inbox_pop()
-        if item_id is None:
-            break
-        replay_outcome = process_payload(
-            item_id, stored_ingress, dispatch_adp, queue
-        )
+    # Serialise concurrent inbox background tasks for this actor so that
+    # process_payload for entry N+1 never starts before entry N has been
+    # stored.  Without this lock, two HTTP POSTs that arrive close together
+    # create two asyncio Tasks that can run in any order; if entry N+1's
+    # task runs first, the hash-chain check fails → spurious Reject (issue #1525).
+    async with _get_actor_lock(actor_id):
+        outcome = process_payload(payload, ingress, dispatch_adp, queue)
         logger.info(
-            "run_inbox_pipeline: replayed status=%s context_id=%s",
-            replay_outcome.status,
-            replay_outcome.context_id,
+            "run_inbox_pipeline: status=%s context_id=%s",
+            outcome.status,
+            outcome.context_id,
         )
+
+        # Process any replayed activities (pushed back to the queue by
+        # DeferCheckNode/DispatchNode replay after bootstrap).
+        stored_ingress = StoredActivityIngressAdapter(dl=dl)
+        while actor_dl.inbox_list():
+            item_id = actor_dl.inbox_pop()
+            if item_id is None:
+                break
+            replay_outcome = process_payload(
+                item_id, stored_ingress, dispatch_adp, queue
+            )
+            logger.info(
+                "run_inbox_pipeline: replayed status=%s context_id=%s",
+                replay_outcome.status,
+                replay_outcome.context_id,
+            )
 
     await outbox_handler(actor_id, actor_dl, shared_dl=dl, emitter=emitter)


### PR DESCRIPTION
## Summary

Fixes #1525 — flaky CI timeout in `wait_for_contiguous_ledger_coverage` during FVV demo case closure.

- Root cause: two HTTP POSTs for the same actor arrive close together, each scheduling a separate asyncio `BackgroundTask`. The event loop can run entry N+1's `process_payload` before entry N has been stored → hash-chain mismatch → spurious Reject → Replay loop that doesn't converge within 15 s.
- Fix: per-actor `asyncio.Lock` (`_actor_inbox_locks` dict) acquired in `run_inbox_pipeline` around `process_payload` + replay loop; released before `outbox_handler` so HTTP delivery is never blocked.
- Note: the existing `_BT_GLOBAL_LOCK` (`threading.RLock`) protects the BT blackboard from thread-pool concurrency — it does NOT prevent asyncio task interleaving, which is a separate concern requiring a separate primitive.

## Changes

- `vultron/adapters/driving/fastapi/inbox_orchestration.py` — add `_actor_inbox_locks`, `_get_actor_lock()`, wrap `process_payload` + replay loop with `async with _get_actor_lock(actor_id):`
- `test/adapters/driving/fastapi/test_inbox_orchestration_lock.py` — regression test using `asyncio.gather` to force concurrent scheduling; both chained entries must be stored

## Verification

```
uv run pytest test/adapters/driving/fastapi/test_inbox_orchestration_lock.py -v
# 3 passed in 1.8s

uv run pytest --tb=short 2>&1 | tail -3
# 5092 passed, 38 skipped, 696 deselected, 2 xfailed in 110s

uv run pytest -m integration --tb=short 2>&1 | tail -3
# 693 passed, 5130 deselected, 3 xfailed in 38s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)