### PR TITLE
feat(#1517): eliminate 5 DL-06 plumbing re-reads — TriggerActivityPort returns (id, dict)

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1517.md
+++ b/plan/history/2607/implementation/ISSUE-1517.md
@@ -1,0 +1,18 @@
+---
+source: ISSUE-1517
+timestamp: '2026-07-20T17:01:45.176655+00:00'
+title: 'Migrate 5 DL-06 Category-A plumbing re-reads (Issue #1517)'
+type: implementation
+---
+
+## Issue #1517 — Migrate Category-A plumbing re-reads: TriggerActivityPort returns (id, dict)
+
+Removed 5 `dl.read(activity_id)` plumbing re-reads from core (ADR-0035 DL-06 Category A).
+
+All 4 report use cases (`SvcValidateReportUseCase`, `SvcInvalidateReportUseCase`, `SvcRejectReportUseCase`, `SvcCloseReportUseCase`) previously used an outbox snapshot diff approach (`before = outbox_ids(...)` → run BT → compute `new_items = after - before` → `dl.read(activity_id)`) in `_handle_result()`. Replaced with `captured` dict threading: `self._captured` is passed to tree factories → emit nodes → `captured["activity"] = activity_dict` written at emit time.
+
+Site 5 in `delegation.py:CreateOfferCaseManagerActivityNode._emit` dropped a `dl.read(activity_id)` + `model_dump` chain; now unpacks `(activity_id, activity_dict)` from `offer_case_manager_role`.
+
+`TriggerActivityPort.offer_case_manager_role` return type: `str` → `tuple[str, dict[str, Any]]`.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1534>

--- a/test/adapters/driven/trigger_activity_adapter/test_actors.py
+++ b/test/adapters/driven/trigger_activity_adapter/test_actors.py
@@ -183,23 +183,25 @@ class TestAddParticipantToCase:
 
 
 class TestOfferCaseManagerRole:
-    def test_returns_activity_id(self, adapter, dl):
+    def test_returns_activity_id_and_dict(self, adapter, dl):
         case = _make_case(dl)
         participant = _make_participant(dl, case.id_)
 
-        activity_id = adapter.offer_case_manager_role(
+        activity_id, activity_dict = adapter.offer_case_manager_role(
             case_id=case.id_,
             participant_id=participant.id_,
             actor=_ACTOR,
         )
 
         assert activity_id
+        assert isinstance(activity_dict, dict)
+        assert activity_dict.get("type") == "Offer"
 
     def test_persists_offer_activity(self, adapter, dl):
         case = _make_case(dl)
         participant = _make_participant(dl, case.id_)
 
-        activity_id = adapter.offer_case_manager_role(
+        activity_id, _ = adapter.offer_case_manager_role(
             case_id=case.id_,
             participant_id=participant.id_,
             actor=_ACTOR,
@@ -214,7 +216,7 @@ class TestAcceptCaseManagerRole:
         case = _make_case(dl)
         participant = _make_participant(dl, case.id_)
 
-        offer_id = adapter.offer_case_manager_role(
+        offer_id, _ = adapter.offer_case_manager_role(
             case_id=case.id_,
             participant_id=participant.id_,
             actor=_ACTOR,
@@ -234,7 +236,7 @@ class TestAcceptCaseManagerRole:
         case = _make_case(dl)
         participant = _make_participant(dl, case.id_)
 
-        offer_id = adapter.offer_case_manager_role(
+        offer_id, _ = adapter.offer_case_manager_role(
             case_id=case.id_,
             participant_id=participant.id_,
             actor=_ACTOR,

--- a/test/core/use_cases/triggers/test_report_triggers.py
+++ b/test/core/use_cases/triggers/test_report_triggers.py
@@ -41,10 +41,16 @@ from vultron.core.states.rm import RM
 from vultron.enums.roles import CVDRole
 from vultron.core.models._helpers import _report_phase_status_id
 from vultron.core.use_cases.triggers.report import (
+    SvcCloseReportUseCase,
+    SvcInvalidateReportUseCase,
+    SvcRejectReportUseCase,
     SvcSubmitReportUseCase,
     SvcValidateReportUseCase,
 )
 from vultron.core.use_cases.triggers.requests import (
+    CloseReportTriggerRequest,
+    InvalidateReportTriggerRequest,
+    RejectReportTriggerRequest,
     SubmitReportTriggerRequest,
     ValidateReportTriggerRequest,
 )
@@ -357,6 +363,21 @@ class TestSvcValidateReportUseCase:
                 trigger_activity=None,
             ).execute()
 
+    def test_validate_report_returns_activity_dict(self):
+        """execute() returns result['activity'] as Accept(Offer) dict (AC-3, DL-06-001)."""
+        request = ValidateReportTriggerRequest(
+            actor_id=self.vendor.id_,
+            offer_id=self.offer.id_,
+        )
+        result = SvcValidateReportUseCase(
+            self.dl,
+            request,
+            trigger_activity=TriggerActivityAdapter(self.dl),
+        ).execute()
+
+        assert result.get("activity") is not None
+        assert result["activity"].get("type") == "Accept"
+
     def test_validate_report_idempotent_when_already_valid(self):
         """Second execute() on an already-VALID report does not re-transition RM."""
         request = ValidateReportTriggerRequest(
@@ -386,6 +407,155 @@ class TestSvcValidateReportUseCase:
         assert len(p2.participant_statuses) == len(
             statuses_after_first
         ), "Second validate re-appended a duplicate RM status entry"
+
+
+# ---------------------------------------------------------------------------
+# SvcInvalidateReportUseCase / SvcRejectReportUseCase / SvcCloseReportUseCase
+# ---------------------------------------------------------------------------
+
+
+class _ReportTriggerBase:
+    """Shared fixture for use cases that act on a received offer."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.vendor, self.dl = _make_actor_dl("Vendor Co")
+        self.finder, self.finder_dl = _make_actor_dl("Finder Co")
+        self.case_actor, self.case_actor_dl = _make_actor_dl("Case Actor")
+
+        self.report = as_VulnerabilityReport(
+            name="CVE-TEST",
+            content="Vulnerability report content",
+            attributed_to=self.finder.id_,
+        )
+        self.dl.create(self.report)
+
+        self.offer = _make_offer(
+            self.dl,
+            self.report,
+            self.vendor.id_,
+            actor_id=self.finder.id_,
+        )
+
+        self.case = _make_case_with_embargo(
+            self.dl,
+            self.vendor.id_,
+            self.finder.id_,
+            self.case_actor.id_,
+            self.report.id_,
+        )
+        yield
+        self.dl.clear_all()
+        self.dl.close()
+        self.finder_dl.clear_all()
+        self.finder_dl.close()
+        self.case_actor_dl.clear_all()
+        self.case_actor_dl.close()
+        reset_datalayer(self.vendor.id_)
+        reset_datalayer(self.finder.id_)
+        reset_datalayer(self.case_actor.id_)
+
+
+class TestSvcInvalidateReportUseCase(_ReportTriggerBase):
+    """execute() path tests for SvcInvalidateReportUseCase."""
+
+    def test_invalidate_report_returns_activity_dict(self):
+        """execute() returns result['activity'] with type 'TentativeReject' (DL-06-001)."""
+        request = InvalidateReportTriggerRequest(
+            actor_id=self.vendor.id_,
+            offer_id=self.offer.id_,
+        )
+        result = SvcInvalidateReportUseCase(
+            self.dl,
+            request,
+            trigger_activity=TriggerActivityAdapter(self.dl),
+        ).execute()
+
+        assert result.get("activity") is not None
+        assert result["activity"].get("type") == "TentativeReject"
+
+    def test_invalidate_report_queues_activity_in_outbox(self):
+        """execute() enqueues at least one activity in the actor's outbox."""
+        request = InvalidateReportTriggerRequest(
+            actor_id=self.vendor.id_,
+            offer_id=self.offer.id_,
+        )
+        before = set(self.dl.outbox_list_for_actor(self.vendor.id_))
+        SvcInvalidateReportUseCase(
+            self.dl,
+            request,
+            trigger_activity=TriggerActivityAdapter(self.dl),
+        ).execute()
+        after = set(self.dl.outbox_list_for_actor(self.vendor.id_))
+        assert len(after - before) >= 1
+
+
+class TestSvcRejectReportUseCase(_ReportTriggerBase):
+    """execute() path tests for SvcRejectReportUseCase."""
+
+    def test_reject_report_returns_activity_dict(self):
+        """execute() returns result['activity'] with type 'Reject' (DL-06-001)."""
+        request = RejectReportTriggerRequest(
+            actor_id=self.vendor.id_,
+            offer_id=self.offer.id_,
+        )
+        result = SvcRejectReportUseCase(
+            self.dl,
+            request,
+            trigger_activity=TriggerActivityAdapter(self.dl),
+        ).execute()
+
+        assert result.get("activity") is not None
+        assert result["activity"].get("type") == "Reject"
+
+    def test_reject_report_queues_activity_in_outbox(self):
+        """execute() enqueues at least one activity in the actor's outbox."""
+        request = RejectReportTriggerRequest(
+            actor_id=self.vendor.id_,
+            offer_id=self.offer.id_,
+        )
+        before = set(self.dl.outbox_list_for_actor(self.vendor.id_))
+        SvcRejectReportUseCase(
+            self.dl,
+            request,
+            trigger_activity=TriggerActivityAdapter(self.dl),
+        ).execute()
+        after = set(self.dl.outbox_list_for_actor(self.vendor.id_))
+        assert len(after - before) >= 1
+
+
+class TestSvcCloseReportUseCase(_ReportTriggerBase):
+    """execute() path tests for SvcCloseReportUseCase."""
+
+    def test_close_report_returns_activity_dict(self):
+        """execute() returns result['activity'] as Reject(Offer) dict (DL-06-001)."""
+        request = CloseReportTriggerRequest(
+            actor_id=self.vendor.id_,
+            offer_id=self.offer.id_,
+        )
+        result = SvcCloseReportUseCase(
+            self.dl,
+            request,
+            trigger_activity=TriggerActivityAdapter(self.dl),
+        ).execute()
+
+        assert result.get("activity") is not None
+        assert result["activity"].get("type") == "Reject"
+
+    def test_close_report_queues_activity_in_outbox(self):
+        """execute() enqueues at least one activity in the actor's outbox."""
+        request = CloseReportTriggerRequest(
+            actor_id=self.vendor.id_,
+            offer_id=self.offer.id_,
+        )
+        before = set(self.dl.outbox_list_for_actor(self.vendor.id_))
+        SvcCloseReportUseCase(
+            self.dl,
+            request,
+            trigger_activity=TriggerActivityAdapter(self.dl),
+        ).execute()
+        after = set(self.dl.outbox_list_for_actor(self.vendor.id_))
+        assert len(after - before) >= 1
 
 
 # ---------------------------------------------------------------------------

--- a/vultron/adapters/driven/trigger_activity_adapter/actors.py
+++ b/vultron/adapters/driven/trigger_activity_adapter/actors.py
@@ -404,9 +404,11 @@ class _ActorsMixin:
         participant_id: str,
         actor: str,
         to: list[str] | None = None,
-    ) -> str:
+    ) -> tuple[str, dict]:
         """Create and persist an ``Offer(as_VulnerabilityCase, target=as_CaseParticipant)``
         CASE_MANAGER delegation activity.
+
+        Returns ``(activity_id, activity_dict)``.
         """
         case = _to_wire(self._dl.read(case_id), as_VulnerabilityCase)
         participant = _to_wire(
@@ -423,7 +425,7 @@ class _ActorsMixin:
                 " — skipping",
                 activity.id_,
             )
-        return activity.id_
+        return activity.id_, activity.model_dump(**_DUMP_KWARGS)
 
     def accept_case_manager_role(
         self,

--- a/vultron/core/behaviors/case/nodes/delegation.py
+++ b/vultron/core/behaviors/case/nodes/delegation.py
@@ -145,24 +145,16 @@ class CreateOfferCaseManagerActivityNode(DataLayerAction):
         recipients: list,
     ) -> str:
         assert self.trigger_activity_factory is not None
-        assert self.datalayer is not None
-        activity_id = self.trigger_activity_factory.offer_case_manager_role(
-            case_id=case_id,
-            participant_id=participant_id,
-            actor=case_actor_id,
-            to=recipients,
+        activity_id, activity_dict = (
+            self.trigger_activity_factory.offer_case_manager_role(
+                case_id=case_id,
+                participant_id=participant_id,
+                actor=case_actor_id,
+                to=recipients,
+            )
         )
         if self._captured is not None:
-            activity_obj = self.datalayer.read(activity_id)
-            if activity_obj is not None and hasattr(
-                activity_obj, "model_dump"
-            ):
-                self._captured["activity"] = activity_obj.model_dump(
-                    mode="json",
-                    by_alias=True,
-                    serialize_as_any=True,
-                    exclude_none=True,
-                )
+            self._captured["activity"] = activity_dict
         return activity_id
 
     def _validate_context(self) -> Status | None:

--- a/vultron/core/behaviors/report/nodes/emit.py
+++ b/vultron/core/behaviors/report/nodes/emit.py
@@ -34,21 +34,32 @@ class _EmitCaseActorReportActivityBase(DataLayerAction):
 
     Subclasses must override ``_call_factory`` to invoke the appropriate
     ``TriggerActivityPort`` method and return ``(activity_id, activity_dict)``.
+
+    When *captured* is provided, the activity dict is stored as
+    ``captured["activity"]`` on success, eliminating any need for a
+    follow-up ``dl.read(activity_id)`` call (AC-1, AC-2, DL-06-001).
     """
 
     def __init__(
-        self, offer_id: str, report_id: str, name: str | None = None
+        self,
+        offer_id: str,
+        report_id: str,
+        captured: dict | None = None,
+        name: str | None = None,
     ) -> None:
         """Initialize the base emit node.
 
         Args:
             offer_id: ID of the Offer activity being acted upon.
             report_id: ID of the VulnerabilityReport (for address resolution).
+            captured: Optional dict; ``captured["activity"]`` is set to the
+                serialised activity dict on success.
             name: Optional custom node name.
         """
         super().__init__(name=name or self.__class__.__name__)
         self.offer_id = offer_id
         self.report_id = report_id
+        self._captured = captured
 
     def _call_factory(
         self, actor_id: str, addressees: list[str]
@@ -108,10 +119,12 @@ class _EmitCaseActorReportActivityBase(DataLayerAction):
             addressees = self._compute_addressees()
             if not addressees:
                 return Status.FAILURE
-            activity_id, _ = self._call_factory(self.actor_id, addressees)  # type: ignore[arg-type]
+            activity_id, activity_dict = self._call_factory(self.actor_id, addressees)  # type: ignore[arg-type]
             cast(CaseOutboxPersistence, self.datalayer).record_outbox_item(
                 self.actor_id, activity_id  # type: ignore[arg-type]
             )
+            if self._captured is not None:
+                self._captured["activity"] = activity_dict
             self.logger.info(
                 "Actor '%s' emitted %s for offer '%s'",
                 self.actor_id,
@@ -138,6 +151,20 @@ class EmitValidateReportActivity(_EmitCaseActorReportActivityBase):
     Per issue #1029 AC-1: validate_tree.py transitions from
     ``_requires_trigger_activity = False`` to having a proper emit node.
     """
+
+    def __init__(
+        self,
+        offer_id: str,
+        report_id: str,
+        captured: dict | None = None,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(
+            offer_id=offer_id,
+            report_id=report_id,
+            captured=captured,
+            name=name,
+        )
 
     def _call_factory(
         self, actor_id: str, addressees: list[str]
@@ -202,6 +229,20 @@ class EmitInvalidateReportActivity(_EmitCaseActorReportActivityBase):
     procedural calls in ``execute()``.
     """
 
+    def __init__(
+        self,
+        offer_id: str,
+        report_id: str,
+        captured: dict | None = None,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(
+            offer_id=offer_id,
+            report_id=report_id,
+            captured=captured,
+            name=name,
+        )
+
     def _call_factory(
         self, actor_id: str, addressees: list[str]
     ) -> tuple[str, dict]:
@@ -226,6 +267,20 @@ class EmitCloseReportActivity(_EmitCaseActorReportActivityBase):
     procedural calls in ``execute()``.
     """
 
+    def __init__(
+        self,
+        offer_id: str,
+        report_id: str,
+        captured: dict | None = None,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(
+            offer_id=offer_id,
+            report_id=report_id,
+            captured=captured,
+            name=name,
+        )
+
     def _call_factory(
         self, actor_id: str, addressees: list[str]
     ) -> tuple[str, dict]:
@@ -246,6 +301,20 @@ class EmitAckReportActivity(_EmitCaseActorReportActivityBase):
     activity must be addressed to the CaseActor so the CaseActor can commit
     a canonical ledger entry.
     """
+
+    def __init__(
+        self,
+        offer_id: str,
+        report_id: str,
+        captured: dict | None = None,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(
+            offer_id=offer_id,
+            report_id=report_id,
+            captured=captured,
+            name=name,
+        )
 
     def _call_factory(
         self, actor_id: str, addressees: list[str]

--- a/vultron/core/behaviors/report/trigger_report_trees.py
+++ b/vultron/core/behaviors/report/trigger_report_trees.py
@@ -51,6 +51,7 @@ logger = logging.getLogger(__name__)
 def create_invalidate_report_trigger_tree(
     offer_id: str,
     report_id: str,
+    captured: dict | None = None,
 ) -> py_trees.behaviour.Behaviour:
     """Create the BT for the invalidate-report trigger workflow.
 
@@ -66,6 +67,8 @@ def create_invalidate_report_trigger_tree(
     Args:
         offer_id: ID of the Offer being invalidated.
         report_id: ID of the VulnerabilityReport.
+        captured: Optional dict; ``captured["activity"]`` is set to the
+            serialised activity dict on success (DL-06-001, AC-1).
 
     Returns:
         Root node of the ``InvalidateReportTriggerBT`` Sequence.
@@ -77,6 +80,7 @@ def create_invalidate_report_trigger_tree(
             EmitInvalidateReportActivity(
                 offer_id=offer_id,
                 report_id=report_id,
+                captured=captured,
             ),
             TransitionRMtoInvalid(
                 report_id=report_id,
@@ -95,6 +99,7 @@ def create_invalidate_report_trigger_tree(
 def create_reject_report_trigger_tree(
     offer_id: str,
     report_id: str,
+    captured: dict | None = None,
 ) -> py_trees.behaviour.Behaviour:
     """Create the BT for the reject-report trigger workflow.
 
@@ -112,6 +117,8 @@ def create_reject_report_trigger_tree(
     Args:
         offer_id: ID of the Offer being rejected.
         report_id: ID of the VulnerabilityReport.
+        captured: Optional dict; ``captured["activity"]`` is set to the
+            serialised activity dict on success (DL-06-001, AC-1).
 
     Returns:
         Root node of the ``RejectReportTriggerBT`` Sequence.
@@ -123,6 +130,7 @@ def create_reject_report_trigger_tree(
             EmitCloseReportActivity(
                 offer_id=offer_id,
                 report_id=report_id,
+                captured=captured,
             ),
             TransitionRMtoClosed(
                 report_id=report_id,
@@ -142,6 +150,7 @@ def create_close_report_trigger_tree(
     offer_id: str,
     report_id: str,
     result_out: dict,
+    captured: dict | None = None,
 ) -> py_trees.behaviour.Behaviour:
     """Create the BT for the close-report trigger workflow.
 
@@ -169,6 +178,8 @@ def create_close_report_trigger_tree(
             ``result_out["error"]`` is set to a
             ``VultronInvalidStateTransitionError`` when the report is already
             closed.
+        captured: Optional dict; ``captured["activity"]`` is set to the
+            serialised activity dict on success (DL-06-001, AC-1).
 
     Returns:
         Root node of the ``CloseReportTriggerBT`` Sequence.
@@ -184,6 +195,7 @@ def create_close_report_trigger_tree(
             EmitCloseReportActivity(
                 offer_id=offer_id,
                 report_id=report_id,
+                captured=captured,
             ),
             TransitionRMtoClosed(
                 report_id=report_id,

--- a/vultron/core/behaviors/report/validate_tree.py
+++ b/vultron/core/behaviors/report/validate_tree.py
@@ -103,6 +103,7 @@ def _default_gather_info_factory(name: str) -> py_trees.behaviour.Behaviour:
 def create_validate_report_tree(
     report_id: str,
     offer_id: str,
+    captured: dict | None = None,
     credibility_factory: CallOutBackendFactory = _default_credibility_factory,
     validity_factory: CallOutBackendFactory = _default_validity_factory,
     gather_info_factory: CallOutBackendFactory = _default_gather_info_factory,
@@ -126,6 +127,8 @@ def create_validate_report_tree(
     Args:
         report_id: ID of VulnerabilityReport to validate
         offer_id: ID of Offer activity containing the report
+        captured: Optional dict; ``captured["activity"]`` is set to the
+            serialised activity dict on success (DL-06-001, AC-1).
         credibility_factory: Factory for the Evaluator call-out point that
             assesses report credibility.  Defaults to the fuzzer backend
             (BT-18-004).  The produced node must honour the blackboard
@@ -196,7 +199,9 @@ def create_validate_report_tree(
         name="EmitAndValidate",
         memory=False,
         children=[
-            EmitValidateReportActivity(offer_id=offer_id, report_id=report_id),
+            EmitValidateReportActivity(
+                offer_id=offer_id, report_id=report_id, captured=captured
+            ),
             validation_or_shortcut,
         ],
     )

--- a/vultron/core/ports/trigger_activity.py
+++ b/vultron/core/ports/trigger_activity.py
@@ -423,14 +423,14 @@ class TriggerActivityPort(Protocol):
         participant_id: str,
         actor: str,
         to: list[str] | None = None,
-    ) -> str:
+    ) -> tuple[str, dict[str, Any]]:
         """Create and persist an ``Offer(VulnerabilityCase, target=CaseParticipant)``
         CASE_MANAGER delegation activity.
 
         ``participant_id`` must refer to an existing ``CaseParticipant`` with
         ``CASE_MANAGER`` role (the Case Actor participant).
 
-        Returns the activity ID.
+        Returns ``(activity_id, activity_dict)``.
         """
         ...
 

--- a/vultron/core/use_cases/triggers/report.py
+++ b/vultron/core/use_cases/triggers/report.py
@@ -42,7 +42,6 @@ from vultron.core.models.report import VultronReport
 from vultron.core.models.report_case_link import VultronReportCaseLink
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.use_cases.triggers._base import SvcBTTriggerBase
-from vultron.core.use_cases._helpers import outbox_ids
 from vultron.core.use_cases.triggers._helpers import (
     resolve_actor,
 )
@@ -103,24 +102,16 @@ class SvcValidateReportUseCase(SvcBTTriggerBase):
         self._offer, self._report = _resolve_offer_and_report(
             request.offer_id, self._dl
         )
-        self._before = outbox_ids(self._actor_id, self._dl)
 
     def _build_tree(self) -> py_trees.behaviour.Behaviour:
         return create_validate_report_tree(
             report_id=self._report.id_,
             offer_id=self._offer.id_,
+            captured=self._captured,
         )
 
     def _handle_result(self) -> None:
-        after = outbox_ids(self._actor_id, self._dl)
-        new_items = after - self._before
-        if new_items:
-            activity_id = next(iter(new_items))
-            activity_obj = self._dl.read(activity_id)
-            if activity_obj is not None:
-                self._captured["activity"] = activity_obj.model_dump(
-                    by_alias=True, exclude_none=True
-                )
+        pass
 
 
 class SvcInvalidateReportUseCase(SvcBTTriggerBase):
@@ -133,24 +124,15 @@ class SvcInvalidateReportUseCase(SvcBTTriggerBase):
         self._offer, self._report = _resolve_offer_and_report(
             request.offer_id, self._dl
         )
-        self._before = outbox_ids(self._actor_id, self._dl)
 
     def _build_tree(self) -> py_trees.behaviour.Behaviour:
         return create_invalidate_report_trigger_tree(
             offer_id=self._offer.id_,
             report_id=self._report.id_,
+            captured=self._captured,
         )
 
     def _handle_result(self) -> None:
-        after = outbox_ids(self._actor_id, self._dl)
-        new_items = after - self._before
-        if new_items:
-            activity_id = next(iter(new_items))
-            activity_obj = self._dl.read(activity_id)
-            if activity_obj is not None:
-                self._captured["activity"] = activity_obj.model_dump(
-                    by_alias=True, exclude_none=True
-                )
         logger.info(
             "Actor '%s' invalidated offer '%s' (report '%s')",
             self._actor_id,
@@ -169,24 +151,15 @@ class SvcRejectReportUseCase(SvcBTTriggerBase):
         self._offer, self._report = _resolve_offer_and_report(
             request.offer_id, self._dl
         )
-        self._before = outbox_ids(self._actor_id, self._dl)
 
     def _build_tree(self) -> py_trees.behaviour.Behaviour:
         return create_reject_report_trigger_tree(
             offer_id=self._offer.id_,
             report_id=self._report.id_,
+            captured=self._captured,
         )
 
     def _handle_result(self) -> None:
-        after = outbox_ids(self._actor_id, self._dl)
-        new_items = after - self._before
-        if new_items:
-            activity_id = next(iter(new_items))
-            activity_obj = self._dl.read(activity_id)
-            if activity_obj is not None:
-                self._captured["activity"] = activity_obj.model_dump(
-                    by_alias=True, exclude_none=True
-                )
         request = cast(RejectReportTriggerRequest, self._request)
         logger.info(
             "Actor '%s' hard-closed offer '%s' (report '%s'); note: %s",
@@ -207,25 +180,16 @@ class SvcCloseReportUseCase(SvcBTTriggerBase):
         self._offer, self._report = _resolve_offer_and_report(
             request.offer_id, self._dl
         )
-        self._before = outbox_ids(self._actor_id, self._dl)
 
     def _build_tree(self) -> py_trees.behaviour.Behaviour:
         return create_close_report_trigger_tree(
             offer_id=self._offer.id_,
             report_id=self._report.id_,
             result_out=self._result_out,
+            captured=self._captured,
         )
 
     def _handle_result(self) -> None:
-        after = outbox_ids(self._actor_id, self._dl)
-        new_items = after - self._before
-        if new_items:
-            activity_id = next(iter(new_items))
-            activity_obj = self._dl.read(activity_id)
-            if activity_obj is not None:
-                self._captured["activity"] = activity_obj.model_dump(
-                    by_alias=True, exclude_none=True
-                )
         request = cast(CloseReportTriggerRequest, self._request)
         logger.info(
             "Actor '%s' closed offer '%s' (report '%s') via RM lifecycle;"


### PR DESCRIPTION
## Summary

Closes #1517.

Migrates 5 Category-A plumbing re-reads (ADR-0035 / DL-06) where core
called `dl.read(activity_id)` to recover an activity that the factory had
just built.

**Sites removed:**

| # | File | Old pattern |
|---|------|-------------|
| 1 | `use_cases/triggers/report.py` — `SvcValidateReportUseCase._handle_result` | outbox snapshot diff → `dl.read` |
| 2 | `use_cases/triggers/report.py` — `SvcInvalidateReportUseCase._handle_result` | outbox snapshot diff → `dl.read` |
| 3 | `use_cases/triggers/report.py` — `SvcRejectReportUseCase._handle_result` | outbox snapshot diff → `dl.read` |
| 4 | `use_cases/triggers/report.py` — `SvcCloseReportUseCase._handle_result` | outbox snapshot diff → `dl.read` |
| 5 | `behaviors/case/nodes/delegation.py` — `CreateOfferCaseManagerActivityNode._emit` | `dl.read(activity_id)` → `model_dump` |

**Approach:** Thread `self._captured` (already a `dict` on the use case) down
into the BT tree factories, into the emit nodes.  Each emit node now unpacks
`activity_id, activity_dict = factory.method(...)` and writes
`captured["activity"] = activity_dict` directly, mirroring the existing pattern
in `EmitSubmitReportActivity`.

`TriggerActivityPort.offer_case_manager_role` return type updated from `str`
to `tuple[str, dict[str, Any]]`; adapter implementation updated to match.

## Acceptance Criteria

- [x] AC-1: `TriggerActivityPort.offer_case_manager_role` returns `(activity_id, activity_dict)` 
- [x] AC-2: All 5 `dl.read(activity_id)` plumbing re-reads removed
- [x] AC-3: API response shape `{"activity": ...}` unchanged — `captured["activity"]` still populated from `model_dump(**_DUMP_KWARGS)` at emit time
- [x] AC-4: No new `dl.read(<activity_id>)` for response capture

## Test plan

- [x] Updated `test/adapters/driven/trigger_activity_adapter/test_actors.py`: unpack tuple in `TestOfferCaseManagerRole` and `TestAcceptCaseManagerRole`; added `test_returns_activity_id_and_dict` with dict-shape assertions
- [x] `uv run black / flake8` — clean
- [x] `uv run mypy` — 0 issues
- [x] `uv run pyright` — 0 errors, 0 warnings
- [x] `uv run pytest` — 5089 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)