### PR TITLE
docs: plan issue #1212 — FVCV-extension demo scenario

### DIFF
--- a/notes/demo-future-ideas.md
+++ b/notes/demo-future-ideas.md
@@ -41,14 +41,14 @@ be treated as working implementations.
 
 ### Core multi-party scenarios
 
-| Scenario | Issue | Description | Blocked by |
-|----------|-------|-------------|------------|
-| FCV | #1234 | F reports to C; C invites V; three-actor coordination | — |
-| FVCV-extension | #1212 | V1 retains ownership; C is participant; C suggests V2 | — |
-| FVCV-handoff | #1214 | V1 transfers ownership to C; C invites V2 | #1212 |
-| FCCV-extension | #1215 | C1 retains case; C2 is participant; C2 asks C1 to invite V | — |
-| FCCV-handoff | #1216 | C1 transfers to C2; C2 invites V | #1215 |
-| FCVCV | #1217 | F+C1+V1+C2+V2 (5 actors) | #1212, #1215 |
+| Scenario | Issue | Description | Blocked by | Status |
+|----------|-------|-------------|------------|--------|
+| FCV | #1234 | F reports to C; C invites V; three-actor coordination | — | planned |
+| FVCV-extension | #1212 | V1 retains ownership; C is participant; C suggests V2 | — | **planned — impl tracked in #1535** |
+| FVCV-handoff | #1214 | V1 transfers ownership to C; C invites V2 | #1212 | planned |
+| FCCV-extension | #1215 | C1 retains case; C2 is participant; C2 asks C1 to invite V | — | planned |
+| FCCV-handoff | #1216 | C1 transfers to C2; C2 invites V | #1215 | planned |
+| FCVCV | #1217 | F+C1+V1+C2+V2 (5 actors) | #1212, #1215 | planned |
 
 ### Role-expansion scenarios
 

--- a/plan/history/2607/idea/IDEA-1212.md
+++ b/plan/history/2607/idea/IDEA-1212.md
@@ -1,0 +1,50 @@
+---
+source: IDEA-1212
+timestamp: '2026-07-20T17:05:13.300056+00:00'
+title: FVCV-extension demo scenario — V1 retains ownership, C is participant, C suggests
+  V2
+type: idea
+---
+
+## Summary
+
+A four-actor demo scenario where Finder reports to Vendor1, Vendor1 creates the case and
+retains ownership but engages a Coordinator as a participant. The Coordinator suggests
+adding Vendor2. Vendor1 invites Vendor2. This is the 'extension' variant: ownership
+never transfers.
+
+## Motivation
+
+Demonstrates a realistic pattern where a vendor seeks coordinator help without giving up
+case control — the coordinator acts as a facilitator/advisor rather than taking over.
+
+## Rough Approach
+
+- Finder → Vendor1 (RS)
+- Vendor1 creates case (retains CASE_OWNER)
+- Vendor1 invites Finder to case
+- Vendor1 invites Coordinator as a participant (not as case manager)
+- Coordinator suggests Vendor2 (RecommendActorActivity → CaseActor)
+- CaseActor relays recommendation to Vendor1 (CASE_OWNER must approve invite)
+- Vendor1 (via trigger) approves: CaseActor sends Invite to Vendor2
+- Vendor2 accepts
+- All four actors coordinate to closure
+
+## Acceptance Criteria
+
+- [ ] Vendor1 remains CASE_OWNER throughout
+- [ ] Coordinator holds CVDRole.COORDINATOR (not CASE_MANAGER)
+- [ ] Vendor2 is invited via the recommendation path, not direct invite by Coordinator
+- [ ] Four participants in final case state
+- [ ] Scenario runs deterministically
+
+## References
+
+- Parent idea: #1131
+- Related: FVCV-handoff (separate issue, blocked by this one)
+- Existing multi_vendor_demo may contain reusable setup patterns (last modified 2026-06-16)
+
+**Processed**: 2026-07-20 — implementation tracked in #1535.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1536>.
+Spec: `specs/case-management.yaml` CM-20.
+Spec: `specs/multi-actor-demo.yaml` DEMOMA-10.

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -951,7 +951,6 @@ groups:
       spec_id: CLP-10-006
 - id: CM-18
   title: Participant Embargo Consent State Machine
-  kind: domain
   specs:
   - id: CM-18-001
     priority: MUST
@@ -1007,7 +1006,6 @@ groups:
       spec_id: CM-18-003
 - id: CM-19
   title: Participant Index Discipline
-  kind: domain
   specs:
   - id: CM-19-001
     priority: MUST
@@ -1042,7 +1040,6 @@ groups:
 
 - id: CM-20
   title: Coordinator-as-Participant Role Constraints
-  kind: domain
   specs:
   - id: CM-20-001
     priority: MUST
@@ -1050,17 +1047,18 @@ groups:
       A Coordinator invited to a case as a regular participant MUST hold
       `CVDRole.COORDINATOR` in their `case_roles` list and MUST NOT hold
       `CVDRole.CASE_MANAGER`. The `CASE_MANAGER` role is reserved for the
-      CaseActor service (CBT-01-003) and MUST NOT be assigned to a human or
-      organizational Coordinator actor that joins a case as a facilitating
-      participant rather than as the case management service.
+      CaseActor service (CBT-01-003) and MUST NOT be assigned to any
+      organizational or human participant joining a case as a facilitation
+      actor rather than as the case management service.
     rationale: >-
-      The distinction between "Coordinator as participant" and "CASE_MANAGER
-      service actor" is a core ownership invariant: `CASE_MANAGER` grants
-      write authority to the canonical ledger (CLP-09). Assigning
-      `CASE_MANAGER` to a human Coordinator who is merely facilitating
-      coordination — not replacing the case management service — would grant
-      unintended ledger write authority and violate the single-writer regime
-      (SYNC-13).
+      `CASE_OWNER` is the role that confers case administration authority
+      (CM-02-001, CM-02-004, CM-02-005). `CASE_MANAGER` is a distinct role
+      reserved exclusively for the CaseActor service; it grants write
+      authority to the canonical ledger (CLP-09) and MUST NOT be held by any
+      participant actor regardless of their organizational role. These two
+      constraints are independent: a Coordinator participant lacks both
+      `CASE_OWNER` (they are not the case administrator) and `CASE_MANAGER`
+      (they are not the case management service).
     relationships:
     - rel_type: refines
       spec_id: CBT-01-003
@@ -1072,11 +1070,11 @@ groups:
       Coordinator participant MUST include `CVDRole.COORDINATOR` and MUST NOT
       include `CVDRole.CASE_MANAGER` or `CVDRole.CASE_OWNER`.
     rationale: >-
-      The Case Owner retains ownership throughout the expansion scenario
-      (CM-02-001). A suggested Coordinator does not take over case administration;
-      they participate as a facilitator. Role assignments at invite time must
-      reflect the actual intended function, not the actor's general organizational
-      role.
+      Invitation and case ownership transfer are distinct protocol operations.
+      An `Offer(Actor, Case)` invite adds a participant; it does not transfer
+      `CASE_OWNER` authority (CM-02-001) or the `CASE_MANAGER` service role
+      (CM-20-001). Role assignments at invite time must reflect the invited
+      actor's actual function in the case, not their organizational identity.
     relationships:
     - rel_type: refines
       spec_id: CM-20-001

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -1039,3 +1039,66 @@ groups:
     relationships:
     - rel_type: refines
       spec_id: CM-19-001
+
+- id: CM-20
+  title: Coordinator-as-Participant Role Constraints
+  kind: domain
+  specs:
+  - id: CM-20-001
+    priority: MUST
+    statement: >-
+      A Coordinator invited to a case as a regular participant MUST hold
+      `CVDRole.COORDINATOR` in their `case_roles` list and MUST NOT hold
+      `CVDRole.CASE_MANAGER`. The `CASE_MANAGER` role is reserved for the
+      CaseActor service (CBT-01-003) and MUST NOT be assigned to a human or
+      organizational Coordinator actor that joins a case as a facilitating
+      participant rather than as the case management service.
+    rationale: >-
+      The distinction between "Coordinator as participant" and "CASE_MANAGER
+      service actor" is a core ownership invariant: `CASE_MANAGER` grants
+      write authority to the canonical ledger (CLP-09). Assigning
+      `CASE_MANAGER` to a human Coordinator who is merely facilitating
+      coordination — not replacing the case management service — would grant
+      unintended ledger write authority and violate the single-writer regime
+      (SYNC-13).
+    relationships:
+    - rel_type: refines
+      spec_id: CBT-01-003
+  - id: CM-20-002
+    priority: MUST
+    statement: >-
+      When a Coordinator is suggested via the `Offer(Actor, Case)` path (CM-16)
+      and the Case Owner approves the invitation, the roles assigned to the
+      Coordinator participant MUST include `CVDRole.COORDINATOR` and MUST NOT
+      include `CVDRole.CASE_MANAGER` or `CVDRole.CASE_OWNER`.
+    rationale: >-
+      The Case Owner retains ownership throughout the expansion scenario
+      (CM-02-001). A suggested Coordinator does not take over case administration;
+      they participate as a facilitator. Role assignments at invite time must
+      reflect the actual intended function, not the actor's general organizational
+      role.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-20-001
+    - rel_type: refines
+      spec_id: CM-16-004
+  - id: CM-20-003
+    priority: MUST
+    statement: >-
+      When a Coordinator participant (holding `CVDRole.COORDINATOR` without
+      `CVDRole.CASE_MANAGER`) suggests that another actor be added to the case
+      via `Offer(Actor, Case)`, the suggestion MUST route through the CaseActor
+      inbox per ADR-0026 (CM-16-001). The Case Owner — not the Coordinator — MUST
+      remain the sole decision-maker for approving or rejecting the invitation
+      (CM-02-001).
+    rationale: >-
+      A Coordinator-as-participant should be able to exercise their facilitation
+      role (suggesting additional vendors) without requiring ownership transfer.
+      The CaseActor-routed suggest flow (ADR-0026) already provides this:
+      the Coordinator sends `Offer(Actor, Case)` to the CaseActor, which records
+      and forwards it to the Case Owner for approval.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-16-001
+    - rel_type: refines
+      spec_id: CM-20-001

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -386,14 +386,14 @@ groups:
 
 - id: DEMOMA-10
   title: FVCV-Extension Scenario (Vendor1 retains ownership; Coordinator is participant; Coordinator suggests Vendor2)
-  kind: domain
   specs:
   - id: DEMOMA-10-001
     priority: MUST
     statement: >-
-      The FVCV-extension scenario MUST seed four independent actor containers — Finder,
-      Vendor1, Coordinator, and Vendor2 — with the CaseActor co-located in the Vendor1
-      container; each container MUST have its own isolated DataLayer.
+      The FVCV-extension scenario MUST involve four actor identities — Finder, Vendor1,
+      Coordinator, and Vendor2 — each with its own isolated DataLayer; the CaseActor
+      MUST run as a separate actor identity with its own container and DataLayer, not
+      co-located in the Vendor1 container.
     relationships:
     - rel_type: refines
       spec_id: DEMOMA-01-001
@@ -453,19 +453,19 @@ groups:
   - id: DEMOMA-10-007
     priority: MUST
     statement: >-
-      The FVCV-extension scenario MUST run deterministically end-to-end via a single
-      `docker compose` command; the scenario script MUST verify SYNC-2 replica
-      convergence for Finder, Coordinator, and Vendor2 replicas against the authoritative
-      Vendor1 state after each major protocol event.
+      The FVCV-extension scenario MUST run deterministically end-to-end; the scenario
+      script MUST verify SYNC-2 replica convergence for Finder, Coordinator, and Vendor2
+      replicas against the authoritative Vendor1 state after each major protocol event.
     relationships:
     - rel_type: refines
       spec_id: DEMOMA-09-004
   - id: DEMOMA-10-008
     priority: MUST
+    kind: implementation
     statement: >-
-      The PR that introduces the FVCV-extension scenario MUST add a dedicated parallel
-      CI job to `.github/workflows/demo-integration.yml` that runs the scenario using
-      `DEMO=fvcv_extension`; the job MUST run concurrently with existing demo CI jobs.
+      The implementation of the FVCV-extension scenario MUST add a dedicated parallel
+      CI job that runs the scenario concurrently with existing demo CI jobs; the scenario
+      MUST be runnable end-to-end via a single orchestration command (e.g., `docker compose`).
     relationships:
     - rel_type: refines
       spec_id: DEMOMA-09-005

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -383,3 +383,89 @@ groups:
     relationships:
     - rel_type: refines
       spec_id: DEMOCI-03-004
+
+- id: DEMOMA-10
+  title: FVCV-Extension Scenario (Vendor1 retains ownership; Coordinator is participant; Coordinator suggests Vendor2)
+  kind: domain
+  specs:
+  - id: DEMOMA-10-001
+    priority: MUST
+    statement: >-
+      The FVCV-extension scenario MUST seed four independent actor containers — Finder,
+      Vendor1, Coordinator, and Vendor2 — with the CaseActor co-located in the Vendor1
+      container; each container MUST have its own isolated DataLayer.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-01-001
+  - id: DEMOMA-10-002
+    priority: MUST
+    statement: >-
+      Vendor1 MUST create the case (RM→ACCEPTED) and retain `CVDRole.CASE_OWNER`
+      throughout the entire scenario. Ownership MUST NOT transfer to the Coordinator.
+    rationale: >-
+      This scenario demonstrates the "extension" variant: a vendor seeks facilitation
+      help without surrendering case control, in contrast to the FVCV-handoff variant
+      where ownership transfers.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-02-001
+  - id: DEMOMA-10-003
+    priority: MUST
+    statement: >-
+      Vendor1 MUST invite the Coordinator to the case using the standard
+      `invite-actor-to-case` trigger; the Coordinator MUST accept and become a
+      participant holding `CVDRole.COORDINATOR` and NOT `CVDRole.CASE_MANAGER`.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-20-001
+  - id: DEMOMA-10-004
+    priority: MUST
+    statement: >-
+      The Coordinator MUST suggest Vendor2 to the case via `Offer(Actor, Case)` routed
+      to the CaseActor inbox (ADR-0026, CM-16-001). The CaseActor MUST transform the
+      offer into `Offer(CaseParticipant{actor=Vendor2, roles=[vendor]}, Case)` and
+      forward it to Vendor1 (the Case Owner) for approval.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-16-001
+    - rel_type: refines
+      spec_id: CM-20-003
+  - id: DEMOMA-10-005
+    priority: MUST
+    statement: >-
+      Vendor1 MUST approve the Coordinator's suggestion by accepting the transformed
+      `Offer(CaseParticipant)` from the CaseActor. The CaseActor MUST then send
+      `Invite(CaseStub+embargo)` to Vendor2 on Vendor1's behalf (CM-17).
+    relationships:
+    - rel_type: refines
+      spec_id: CM-17-001
+    - rel_type: refines
+      spec_id: CM-20-002
+  - id: DEMOMA-10-006
+    priority: MUST
+    statement: >-
+      The FVCV-extension scenario MUST reach a final state with four participants —
+      Finder, Vendor1, Coordinator, and Vendor2 (plus the CaseActor) — and MUST
+      advance to VFDPxa CS with EM.EXITED and RM.CLOSED for all participants.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-03-002
+  - id: DEMOMA-10-007
+    priority: MUST
+    statement: >-
+      The FVCV-extension scenario MUST run deterministically end-to-end via a single
+      `docker compose` command; the scenario script MUST verify SYNC-2 replica
+      convergence for Finder, Coordinator, and Vendor2 replicas against the authoritative
+      Vendor1 state after each major protocol event.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-09-004
+  - id: DEMOMA-10-008
+    priority: MUST
+    statement: >-
+      The PR that introduces the FVCV-extension scenario MUST add a dedicated parallel
+      CI job to `.github/workflows/demo-integration.yml` that runs the scenario using
+      `DEMO=fvcv_extension`; the job MUST run concurrently with existing demo CI jobs.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-09-005


### PR DESCRIPTION
- Closes #1212

## Summary

Planning output for Idea #1212 (FVCV-extension demo scenario: V1 retains
ownership, Coordinator is participant, Coordinator suggests V2). Adds spec
requirements and notes updates; implementation is tracked in #1535.

## Changes

- **`specs/case-management.yaml`** — new CM-20 section: *Coordinator-as-Participant
  Role Constraints* (CM-20-001 through CM-20-003). Normalizes the rule that a
  Coordinator invited as a case participant MUST hold `CVDRole.COORDINATOR` and
  MUST NOT hold `CVDRole.CASE_MANAGER`; captures the CaseActor-routed suggest
  path requirement for Coordinator-as-participant actors.
- **`specs/multi-actor-demo.yaml`** — new DEMOMA-10 section: *FVCV-Extension
  Scenario* (DEMOMA-10-001 through DEMOMA-10-008). Specifies seeding, role
  invariants, suggest→approve→invite chain, final state, determinism,
  replica convergence, and CI job requirements for the scenario.
- **`notes/demo-future-ideas.md`** — adds Status column to the planned-scenarios
  table; marks FVCV-extension (#1212) as planned with impl issue reference (#1535);
  fills placeholder cells for remaining planned scenarios.

## Related

- Implementation: #1535
- Parent epic: #1277
- ADR: `docs/adr/0026-caseactor-routed-actor-suggestion.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)