### PR TITLE
feat(#1518): migrate report/offer semantic reads to VultronOfferRecord

### DIFF
--- a/notes/datalayer-design.md
+++ b/notes/datalayer-design.md
@@ -270,10 +270,9 @@ activity into the API response; the factory already built the object):
 **B — semantic-content reads** (core re-interprets a stored activity for a
 domain fact — the ARCH-09-001 core violations):
 
-- *report/offer*: `triggers/report.py::_resolve_offer_and_report` (reads `Offer`
-  for the embedded `VulnerabilityReport`); `behaviors/report/nodes/emit.py:90`
-  and `behaviors/report/nodes/case_creation.py:191` (read `Offer` for fallback
-  addressing).
+- ~~*report/offer*~~: migrated (#1518). `VultronOfferRecord` now captures
+  offer facts at adapter time (sender) and received-side ingest time (receiver).
+  Core reads `VultronOfferRecord` instead of the stored wire `Offer` activity.
 - *embargo*: `use_cases/received/embargo.py:74,474` (read `Invite` for `context`
   = case id and `object_` = embargo id); `use_cases/triggers/_helpers.py:129`
   and `find_embargo_proposal` / `list_objects("Invite")` (pending proposal);

--- a/plan/history/2607/implementation/ISSUE-1518.md
+++ b/plan/history/2607/implementation/ISSUE-1518.md
@@ -1,0 +1,22 @@
+---
+source: ISSUE-1518
+timestamp: '2026-07-20T17:41:01.099255+00:00'
+title: Migrate report/offer semantic reads to VultronOfferRecord
+type: implementation
+---
+
+## Issue #1518 — Migrate report/offer semantic activity reads off dl.read (core state)
+
+Implemented ADR-0035 DL-06 Category B migration for the report/offer domain. All three core sites that re-read stored wire Offer activities have been migrated to read from the new VultronOfferRecord core state record.
+
+**New:** `VultronOfferRecord` (vultron/core/models/offer_record.py) — captures offer_id, report_id, offer_actor_id, offer_to at adapter time. Wire vocab registration at vultron/wire/as2/vocab/objects/offer_record.py enables dl.read() round-trip.
+
+**Migrated:** _resolve_offer_and_report (report.py), _compute_report_addressees (emit.py),_collect_create_case_addressees (case_creation.py).
+
+**Ratchet:** "Offer" removed from ACTIVITY_TYPE_EXEMPTIONS (AC-3 satisfied).
+
+**Error path:** non-offer IDs now raise VultronNotFoundError (404) instead of VultronValidationError (422).
+
+**Rebase note:** origin/main had concurrent #1517 changes to the same files; resolved one conflict in report.py (_build_tree needed both offer_id=self._offer.offer_id and captured=self._captured from the two branches).
+
+PR: <https://github.com/CERTCC/Vultron/pull/1538>

--- a/plan/incoming/learnings/20260720-rebase-local-changes-overwritten-false-positive.md
+++ b/plan/incoming/learnings/20260720-rebase-local-changes-overwritten-false-positive.md
@@ -1,0 +1,28 @@
+---
+title: "git rebase 'local changes would be overwritten' false positive"
+type: learning
+timestamp: "2026-07-20"
+source: ISSUE-1518
+---
+
+During the create-pr phase, `git rebase origin/main` persistently failed with
+"Your local changes to the following files would be overwritten by merge" even
+though `git status --porcelain` showed a clean working tree and `git diff HEAD`
+was empty. All listed files were already committed in HEAD.
+
+**Root cause (hypothesis):** The origin/main branch had received concurrent
+commits (#1517) that touched the same files as the branch being rebased. Git's
+apply-based rebase mode may pre-check whether the patch can be applied cleanly
+and error on "would overwrite" when both sides touched the same file — even when
+there are no uncommitted local changes. The error message is misleading.
+
+**Fix:** Used `git cherry-pick` onto a fresh branch rooted at origin/main
+instead of `git rebase`. One real content conflict emerged (a single
+`_build_tree` call in report.py needing both `offer_id=self._offer.offer_id`
+from our branch and `captured=self._captured` from #1517). Resolved manually,
+then `cherry-pick --continue`.
+
+**Pattern to apply:** When `git rebase` fails with the "local changes" error
+and the working tree is provably clean, try cherry-picking onto a fresh branch
+from origin/main as an alternative path. The rebase error is NOT evidence of
+uncommitted work.

--- a/test/adapters/driving/fastapi/routers/test_trigger_report.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_report.py
@@ -40,6 +40,7 @@ from vultron.core.use_cases.triggers.service import TriggerService
 from vultron.adapters.driven.trigger_activity_adapter import (
     TriggerActivityAdapter,
 )
+from vultron.core.models.offer_record import VultronOfferRecord
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
@@ -119,6 +120,13 @@ def offer(dl, report, actor, reporter):
         target=actor.id_,
     )
     dl.create(offer_obj)
+    offer_record = VultronOfferRecord(
+        offer_id=offer_obj.id_,
+        report_id=report.id_,
+        offer_actor_id=reporter.id_,
+        offer_to=[actor.id_],
+    )
+    dl.create(offer_record)
     return offer_obj
 
 
@@ -340,15 +348,19 @@ def test_trigger_validate_report_transitions_rm_to_valid(
     ), "Expected a RM.VALID ParticipantStatus after validate-report trigger"
 
 
-def test_trigger_validate_report_non_report_offer_returns_422(
+def test_trigger_validate_report_non_report_offer_returns_404(
     client_triggers, actor, non_report_object
 ):
-    """validate-report rejects an offer_id that is not an Offer of a report."""
+    """validate-report returns 404 when no VultronOfferRecord exists for the offer_id.
+
+    Per ADR-0035: _resolve_offer_and_report reads VultronOfferRecord; a non-offer
+    ID has no record → VultronNotFoundError → HTTP 404.
+    """
     resp = client_triggers.post(
         f"/actors/{actor.id_}/trigger/validate-report",
         json={"offer_id": non_report_object.id_},
     )
-    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
 
 
 # ===========================================================================
@@ -455,15 +467,19 @@ def test_trigger_invalidate_report_with_note_returns_202(
     assert resp.status_code == status.HTTP_202_ACCEPTED
 
 
-def test_trigger_invalidate_report_non_report_offer_returns_422(
+def test_trigger_invalidate_report_non_report_offer_returns_404(
     client_triggers, actor, non_report_object
 ):
-    """invalidate-report rejects an offer_id that is not an Offer of a report."""
+    """invalidate-report returns 404 when no VultronOfferRecord exists for the offer_id.
+
+    Per ADR-0035: _resolve_offer_and_report reads VultronOfferRecord; a non-offer
+    ID has no record → VultronNotFoundError → HTTP 404.
+    """
     resp = client_triggers.post(
         f"/actors/{actor.id_}/trigger/invalidate-report",
         json={"offer_id": non_report_object.id_},
     )
-    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
 
 
 # ===========================================================================
@@ -582,15 +598,19 @@ def test_trigger_reject_report_adds_activity_to_outbox(
     assert len(outbox_after - outbox_before) >= 1
 
 
-def test_trigger_reject_report_non_report_offer_returns_422(
+def test_trigger_reject_report_non_report_offer_returns_404(
     client_triggers, actor, non_report_object
 ):
-    """reject-report rejects an offer_id that is not an Offer of a report."""
+    """reject-report returns 404 when no VultronOfferRecord exists for the offer_id.
+
+    Per ADR-0035: _resolve_offer_and_report reads VultronOfferRecord; a non-offer
+    ID has no record → VultronNotFoundError → HTTP 404.
+    """
     resp = client_triggers.post(
         f"/actors/{actor.id_}/trigger/reject-report",
         json={"offer_id": non_report_object.id_, "note": "Not a report."},
     )
-    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
 
 
 # ===========================================================================
@@ -707,15 +727,19 @@ def test_trigger_close_report_already_closed_returns_409(
     assert data["detail"]["error"] == "Conflict"
 
 
-def test_trigger_close_report_non_report_offer_returns_422(
+def test_trigger_close_report_non_report_offer_returns_404(
     client_triggers, actor, non_report_object
 ):
-    """close-report rejects an offer_id that is not an Offer of a report."""
+    """close-report returns 404 when no VultronOfferRecord exists for the offer_id.
+
+    Per ADR-0035: _resolve_offer_and_report reads VultronOfferRecord; a non-offer
+    ID has no record → VultronNotFoundError → HTTP 404.
+    """
     resp = client_triggers.post(
         f"/actors/{actor.id_}/trigger/close-report",
         json={"offer_id": non_report_object.id_},
     )
-    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
 
 
 # ===========================================================================

--- a/test/architecture/test_dl_read_returns_core_objects.py
+++ b/test/architecture/test_dl_read_returns_core_objects.py
@@ -94,7 +94,6 @@ ACTIVITY_TYPE_EXEMPTIONS: frozenset[str] = frozenset(
         "Like",
         "Listen",
         "Move",
-        "Offer",
         "Question",
         "Read",
         "Reject",

--- a/test/core/behaviors/report/test_nodes.py
+++ b/test/core/behaviors/report/test_nodes.py
@@ -26,7 +26,12 @@ Per GitHub issue #401 and specs/behavior-tree-node-design.yaml.
 import pytest
 from py_trees.composites import Sequence
 
+from vultron.core.behaviors.report.nodes.case_creation import (
+    _collect_create_case_addressees,
+)
+from vultron.core.behaviors.report.nodes.emit import _compute_report_addressees
 from vultron.core.models.case_actor import VultronCaseActor
+from vultron.core.models.offer_record import VultronOfferRecord
 from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models._helpers import _report_phase_status_id
 from vultron.core.models.vultron_types import (
@@ -78,6 +83,13 @@ def offer(
     """Create a test offer and persist it in the scenario DataLayer."""
     obj = VultronOffer(actor=actor.id_, object_=report.id_)
     bt_scenario.dl.create(obj)
+    offer_record = VultronOfferRecord(
+        offer_id=obj.id_,
+        report_id=report.id_,
+        offer_actor_id=actor.id_,
+        offer_to=[],
+    )
+    bt_scenario.dl.create(offer_record)
     return obj
 
 
@@ -507,3 +519,149 @@ def test_update_actor_outbox_logs_case_id_in_message(
     assert cases, "Expected VulnerabilityCase to be created"
     case_id = next(iter(cases))
     assert case_id in caplog.text
+
+
+# ============================================================================
+# AC-4: Domain facts read from VultronOfferRecord, not wire Offer
+# ============================================================================
+
+
+class TestComputeReportAddresseesFallback:
+    """_compute_report_addressees reads from VultronOfferRecord, not wire Offer.
+
+    Per ADR-0035 DL-06-001: when no case is found for a report, the fallback
+    addressee is the offer submitter's actor ID, which must come from the core
+    VultronOfferRecord — not from getattr(offer, "actor", None).
+    """
+
+    def test_returns_offer_actor_when_no_case(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        """Fallback path returns offer_actor_id from VultronOfferRecord."""
+        from typing import cast
+        from vultron.core.ports.case_persistence import CaseOutboxPersistence
+
+        actor_id = "urn:test:actor:1"
+        submitter_id = "urn:test:submitter:1"
+        offer_record = VultronOfferRecord(
+            offer_id="urn:test:offer:1",
+            report_id="urn:test:report:1",
+            offer_actor_id=submitter_id,
+            offer_to=[],
+        )
+        result = _compute_report_addressees(
+            report_id="urn:test:report:no-case",
+            actor_id=actor_id,
+            offer_record=offer_record,
+            dl=cast(CaseOutboxPersistence, bt_scenario.dl),
+        )
+        assert result == [submitter_id]
+
+    def test_returns_none_when_no_offer_record(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        """Fallback path returns None when offer_record is None."""
+        from typing import cast
+        from vultron.core.ports.case_persistence import CaseOutboxPersistence
+
+        result = _compute_report_addressees(
+            report_id="urn:test:report:no-case",
+            actor_id="urn:test:actor:1",
+            offer_record=None,
+            dl=cast(CaseOutboxPersistence, bt_scenario.dl),
+        )
+        assert result is None
+
+    def test_excludes_self_from_addressees(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        """Fallback path excludes actor_id (self) from addressees."""
+        from typing import cast
+        from vultron.core.ports.case_persistence import CaseOutboxPersistence
+
+        actor_id = "urn:test:actor:self"
+        offer_record = VultronOfferRecord(
+            offer_id="urn:test:offer:2",
+            report_id="urn:test:report:2",
+            offer_actor_id=actor_id,
+            offer_to=[],
+        )
+        result = _compute_report_addressees(
+            report_id="urn:test:report:no-case",
+            actor_id=actor_id,
+            offer_record=offer_record,
+            dl=cast(CaseOutboxPersistence, bt_scenario.dl),
+        )
+        assert result is None
+
+
+class TestCollectCreateCaseAddresseesFromRecord:
+    """_collect_create_case_addressees reads offer_to/offer_actor_id from VultronOfferRecord.
+
+    Per ADR-0035 DL-06-001: addressees are computed from the core
+    VultronOfferRecord, not from getattr(offer, "to"/"actor", None).
+    """
+
+    def test_includes_offer_to_recipients(self) -> None:
+        """offer_to list from VultronOfferRecord is included in addressees."""
+        actor_id = "urn:test:actor:creator"
+        recipient_id = "urn:test:recipient:1"
+        offer_record = VultronOfferRecord(
+            offer_id="urn:test:offer:3",
+            report_id="urn:test:report:3",
+            offer_actor_id="urn:test:submitter:3",
+            offer_to=[recipient_id],
+        )
+        result = _collect_create_case_addressees(
+            actor=actor_id,
+            report=None,
+            offer_record=offer_record,
+            actor_id=actor_id,
+        )
+        assert recipient_id in result
+
+    def test_includes_offer_actor_id(self) -> None:
+        """offer_actor_id from VultronOfferRecord is included in addressees."""
+        actor_id = "urn:test:actor:creator"
+        submitter_id = "urn:test:submitter:4"
+        offer_record = VultronOfferRecord(
+            offer_id="urn:test:offer:4",
+            report_id="urn:test:report:4",
+            offer_actor_id=submitter_id,
+            offer_to=[],
+        )
+        result = _collect_create_case_addressees(
+            actor=actor_id,
+            report=None,
+            offer_record=offer_record,
+            actor_id=actor_id,
+        )
+        assert submitter_id in result
+
+    def test_excludes_actor_id_from_addressees(self) -> None:
+        """actor_id (creator) is excluded from the addressee list."""
+        actor_id = "urn:test:actor:creator"
+        offer_record = VultronOfferRecord(
+            offer_id="urn:test:offer:5",
+            report_id="urn:test:report:5",
+            offer_actor_id="urn:test:submitter:5",
+            offer_to=[actor_id],
+        )
+        result = _collect_create_case_addressees(
+            actor=actor_id,
+            report=None,
+            offer_record=offer_record,
+            actor_id=actor_id,
+        )
+        assert actor_id not in result
+
+    def test_no_offer_record_returns_actor_only(self) -> None:
+        """When offer_record is None, only actor is in addressee pool (self-excluded → empty)."""
+        actor_id = "urn:test:actor:creator"
+        result = _collect_create_case_addressees(
+            actor=actor_id,
+            report=None,
+            offer_record=None,
+            actor_id=actor_id,
+        )
+        assert actor_id not in result

--- a/test/core/behaviors/report/test_trigger_report_trees.py
+++ b/test/core/behaviors/report/test_trigger_report_trees.py
@@ -32,6 +32,7 @@ from vultron.core.behaviors.report.trigger_report_trees import (
 )
 from vultron.core.models.activity import VultronOffer
 from vultron.core.models.case_actor import VultronCaseActor
+from vultron.core.models.offer_record import VultronOfferRecord
 from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models.report import VultronReport
 from vultron.core.states.rm import RM
@@ -81,6 +82,13 @@ def offer(
 ) -> VultronOffer:
     obj = VultronOffer(actor=REPORTER_ID, object_=report.id_, target=ACTOR_ID)
     scenario.dl.create(obj)
+    offer_record = VultronOfferRecord(
+        offer_id=obj.id_,
+        report_id=report.id_,
+        offer_actor_id=REPORTER_ID,
+        offer_to=[ACTOR_ID],
+    )
+    scenario.dl.create(offer_record)
     return obj
 
 

--- a/test/core/use_cases/received/test_submit_report_received.py
+++ b/test/core/use_cases/received/test_submit_report_received.py
@@ -476,3 +476,78 @@ class TestOfferAddressingSemantics:
         assert (
             all_cases == []
         ), "Expected no case when receiving actor in target but not in to"
+
+
+class TestSubmitReportStoresOfferRecord:
+    """SubmitReportReceivedUseCase stores VultronOfferRecord for trigger-side lookup.
+
+    Per ADR-0035 DL-06-002: domain facts from the inbound Offer MUST be captured
+    as core state so the receiver's trigger paths (validate/invalidate/close) can
+    look them up without re-reading the stored wire Offer activity.
+    """
+
+    VENDOR_ID = "https://example.org/actors/vendor"
+    FINDER_ID = "https://example.org/users/finder"
+    REPORT_ID = "https://example.org/reports/r-offer-rec-1"
+    OFFER_ID = "https://example.org/activities/offer-rec-1"
+
+    def _make_event_and_dl(self):
+        from vultron.core.models.case_actor import VultronCaseActor
+
+        report = VultronReport(id_=self.REPORT_ID)
+        activity = VultronActivity(
+            id_=self.OFFER_ID,
+            type_="Offer",
+            actor=self.FINDER_ID,
+            to=[self.VENDOR_ID],
+        )
+        event = SubmitReportReceivedEvent(
+            semantic_type=MessageSemantics.SUBMIT_REPORT,
+            activity_id=self.OFFER_ID,
+            actor_id=self.FINDER_ID,
+            object_=report,
+            activity=activity,
+            receiving_actor_id=self.VENDOR_ID,
+        )
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        dl.save(VultronCaseActor(id_=self.VENDOR_ID))
+        return event, dl
+
+    def test_stores_offer_record_on_received(self):
+        """SubmitReportReceivedUseCase creates VultronOfferRecord in DataLayer."""
+        from vultron.core.models.offer_record import VultronOfferRecord
+
+        event, dl = self._make_event_and_dl()
+        SubmitReportReceivedUseCase(
+            dl, event, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
+
+        record_id = VultronOfferRecord.build_id(self.OFFER_ID)
+        record = dl.read(record_id)
+        assert isinstance(
+            record, VultronOfferRecord
+        ), "Expected VultronOfferRecord stored for received Offer"
+        assert record.offer_id == self.OFFER_ID
+        assert record.report_id == self.REPORT_ID
+        assert record.offer_actor_id == self.FINDER_ID
+        assert self.VENDOR_ID in record.offer_to
+
+    def test_offer_record_is_idempotent(self):
+        """Calling SubmitReportReceivedUseCase twice creates only one VultronOfferRecord."""
+        from vultron.core.models.offer_record import VultronOfferRecord
+
+        event, dl = self._make_event_and_dl()
+        SubmitReportReceivedUseCase(
+            dl, event, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
+        SubmitReportReceivedUseCase(
+            dl, event, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
+
+        record_id = VultronOfferRecord.build_id(self.OFFER_ID)
+        records = [
+            r for r in dl.get_all("OfferRecord") if r.get("id_") == record_id
+        ]
+        assert (
+            len(records) == 1
+        ), "Expected exactly one VultronOfferRecord after idempotent calls"

--- a/test/core/use_cases/test_validate_report_ledger_routing.py
+++ b/test/core/use_cases/test_validate_report_ledger_routing.py
@@ -54,6 +54,7 @@ from vultron.core.use_cases.received.report import (
     ValidateReportReceivedUseCase,
 )
 from vultron.core.use_cases.triggers.service import TriggerService
+from vultron.core.models.offer_record import VultronOfferRecord
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
@@ -102,6 +103,13 @@ def _make_case_at_received(
         target=vendor_id,
     )
     dl.create(offer)
+    offer_record = VultronOfferRecord(
+        offer_id=offer.id_,
+        report_id=report_obj.id_,
+        offer_actor_id=finder_id,
+        offer_to=[vendor_id],
+    )
+    dl.create(offer_record)
 
     bridge = BTBridge(
         datalayer=dl, trigger_activity=TriggerActivityAdapter(dl)

--- a/test/core/use_cases/triggers/test_report_triggers.py
+++ b/test/core/use_cases/triggers/test_report_triggers.py
@@ -54,8 +54,9 @@ from vultron.core.use_cases.triggers.requests import (
     SubmitReportTriggerRequest,
     ValidateReportTriggerRequest,
 )
+from vultron.core.models.offer_record import VultronOfferRecord
 from vultron.core.models.report_case_link import VultronReportCaseLink
-from vultron.errors import VultronNotFoundError, VultronValidationError
+from vultron.errors import VultronNotFoundError
 from vultron.wire.as2.factories import rm_submit_report_activity
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
@@ -101,6 +102,13 @@ def _make_offer(
         actor=actor_id,
     )
     dl.create(offer)
+    offer_record = VultronOfferRecord(
+        offer_id=offer.id_,
+        report_id=report.id_,
+        offer_actor_id=actor_id,
+        offer_to=[recipient_id],
+    )
+    dl.create(offer_record)
     return offer
 
 
@@ -329,21 +337,18 @@ class TestSvcValidateReportUseCase:
                 trigger_activity=TriggerActivityAdapter(self.dl),
             ).execute()
 
-    def test_validate_report_raises_when_offer_is_wrong_type(self):
-        """VultronValidationError raised when offer_id resolves to wrong type."""
-        # Store a plain as_VulnerabilityReport (not an Offer) as the offer_id.
-        non_offer = as_VulnerabilityReport(
-            name="Not an offer",
-            content="wrong type object",
-            attributed_to=self.vendor.id_,
-        )
-        self.dl.create(non_offer)
+    def test_validate_report_raises_when_offer_record_missing(self):
+        """VultronNotFoundError raised when no VultronOfferRecord exists for offer_id.
 
+        Per ADR-0035: _resolve_offer_and_report reads VultronOfferRecord, not
+        the stored wire Offer. If no record was written at offer creation time,
+        the lookup returns None → VultronNotFoundError.
+        """
         request = ValidateReportTriggerRequest(
             actor_id=self.vendor.id_,
-            offer_id=non_offer.id_,
+            offer_id="urn:uuid:offer-with-no-record",
         )
-        with pytest.raises(VultronValidationError):
+        with pytest.raises(VultronNotFoundError):
             SvcValidateReportUseCase(
                 self.dl,
                 request,

--- a/test/core/use_cases/triggers/test_service.py
+++ b/test/core/use_cases/triggers/test_service.py
@@ -28,7 +28,6 @@ from vultron.adapters.driven.db_record import object_to_record
 from vultron.errors import (
     VultronInvalidStateTransitionError,
     VultronNotFoundError,
-    VultronValidationError,
 )
 from vultron.core.use_cases.triggers.service import TriggerService
 from vultron.adapters.driven.trigger_activity_adapter import (
@@ -39,6 +38,7 @@ try:
     from pydantic import ValidationError as PydanticValidationError
 except ImportError:
     from pydantic_core import ValidationError as PydanticValidationError
+from vultron.core.models.offer_record import VultronOfferRecord
 from vultron.core.models.report_case_link import VultronReportCaseLink
 from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models._helpers import _report_phase_status_id
@@ -137,6 +137,13 @@ def offer(dl, report, actor, reporter):
         target=actor.id_,
     )
     dl.create(offer_obj)
+    offer_record = VultronOfferRecord(
+        offer_id=offer_obj.id_,
+        report_id=report.id_,
+        offer_actor_id=reporter.id_,
+        offer_to=[actor.id_],
+    )
+    dl.create(offer_record)
     return offer_obj
 
 
@@ -312,11 +319,15 @@ def test_validate_report_trigger_transitions_rm_to_valid(
     ), "Expected a RM.VALID ParticipantStatus after validate_report_trigger"
 
 
-def test_validate_report_trigger_non_report_offer_raises_422(
+def test_validate_report_trigger_non_report_offer_raises_404(
     dl, actor, non_report_object
 ):
-    """validate_report_trigger raises 422 when offer_id is not a report Offer."""
-    with pytest.raises(VultronValidationError):
+    """validate_report_trigger raises 404 when no VultronOfferRecord exists for the offer_id.
+
+    Per ADR-0035: _resolve_offer_and_report reads from the core VultronOfferRecord,
+    not the stored wire activity. A non-offer ID has no record → VultronNotFoundError.
+    """
+    with pytest.raises(VultronNotFoundError):
         TriggerService(
             dl, trigger_activity=TriggerActivityAdapter(dl)
         ).validate_report(actor.id_, non_report_object.id_, None)
@@ -368,11 +379,15 @@ def test_invalidate_report_trigger_adds_activity_to_outbox(
     assert len(after - before) >= 1
 
 
-def test_invalidate_report_trigger_non_report_offer_raises_422(
+def test_invalidate_report_trigger_non_report_offer_raises_404(
     dl, actor, non_report_object
 ):
-    """invalidate_report_trigger raises 422 when offer_id is not a report Offer."""
-    with pytest.raises(VultronValidationError):
+    """invalidate_report_trigger raises 404 when no VultronOfferRecord exists.
+
+    Per ADR-0035: _resolve_offer_and_report reads VultronOfferRecord; no record
+    for non-offer IDs → VultronNotFoundError.
+    """
+    with pytest.raises(VultronNotFoundError):
         TriggerService(
             dl, trigger_activity=TriggerActivityAdapter(dl)
         ).invalidate_report(actor.id_, non_report_object.id_, None)
@@ -424,11 +439,15 @@ def test_reject_report_trigger_adds_activity_to_outbox(
     assert len(after - before) >= 1
 
 
-def test_reject_report_trigger_non_report_offer_raises_422(
+def test_reject_report_trigger_non_report_offer_raises_404(
     dl, actor, non_report_object
 ):
-    """reject_report_trigger raises 422 when offer_id is not a report Offer."""
-    with pytest.raises(VultronValidationError):
+    """reject_report_trigger raises 404 when no VultronOfferRecord exists.
+
+    Per ADR-0035: _resolve_offer_and_report reads VultronOfferRecord; no record
+    for non-offer IDs → VultronNotFoundError.
+    """
+    with pytest.raises(VultronNotFoundError):
         TriggerService(
             dl, trigger_activity=TriggerActivityAdapter(dl)
         ).reject_report(actor.id_, non_report_object.id_, "reason")
@@ -468,11 +487,15 @@ def test_close_report_trigger_unknown_actor_raises_404(dl, offer):
         ).close_report("urn:uuid:no-such", offer.id_, None)
 
 
-def test_close_report_trigger_non_report_offer_raises_422(
+def test_close_report_trigger_non_report_offer_raises_404(
     dl, actor, non_report_object
 ):
-    """close_report_trigger raises 422 when offer_id is not a report Offer."""
-    with pytest.raises(VultronValidationError):
+    """close_report_trigger raises 404 when no VultronOfferRecord exists.
+
+    Per ADR-0035: _resolve_offer_and_report reads VultronOfferRecord; no record
+    for non-offer IDs → VultronNotFoundError.
+    """
+    with pytest.raises(VultronNotFoundError):
         TriggerService(
             dl, trigger_activity=TriggerActivityAdapter(dl)
         ).close_report(actor.id_, non_report_object.id_, None)

--- a/test/core/use_cases/triggers/test_trignotify.py
+++ b/test/core/use_cases/triggers/test_trignotify.py
@@ -26,6 +26,7 @@ from vultron.adapters.driven.datalayer_sqlite import (
     SqliteDataLayer,
     reset_datalayer,
 )
+from vultron.core.models.offer_record import VultronOfferRecord
 from vultron.core.states.em import EM
 from vultron.enums.roles import CVDRole
 from vultron.errors import VultronValidationError
@@ -536,6 +537,13 @@ class TestReportTriggerToField:
             actor=self.finder.id_,
         )
         self.dl.create(self.offer)
+        offer_record = VultronOfferRecord(
+            offer_id=self.offer.id_,
+            report_id=self.report.id_,
+            offer_actor_id=self.finder.id_,
+            offer_to=[self.vendor.id_],
+        )
+        self.dl.create(offer_record)
         yield
         self.dl.clear_all()
         self.dl.close()

--- a/vultron/adapters/driven/trigger_activity_adapter/reports.py
+++ b/vultron/adapters/driven/trigger_activity_adapter/reports.py
@@ -18,6 +18,7 @@
 import logging
 from typing import Any, cast
 
+from vultron.core.models.offer_record import VultronOfferRecord
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.wire.as2.factories import (
     rm_close_report_activity,
@@ -25,6 +26,7 @@ from vultron.wire.as2.factories import (
     rm_submit_report_activity,
     rm_validate_report_activity,
 )
+from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Read
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
     as_VulnerabilityReport,
 )
@@ -57,6 +59,19 @@ class _ReportsMixin:
             logger.warning(
                 "submit_report: activity '%s' already exists — skipping",
                 activity.id_,
+            )
+        offer_record = VultronOfferRecord(
+            offer_id=activity.id_,
+            report_id=report_id,
+            offer_actor_id=actor,
+            offer_to=[to] if isinstance(to, str) else list(to),
+        )
+        try:
+            self._dl.create(offer_record)
+        except ValueError:
+            logger.warning(
+                "submit_report: offer record '%s' already exists — skipping",
+                offer_record.id_,
             )
         return activity.id_, activity.model_dump(**_DUMP_KWARGS)
 
@@ -125,10 +140,6 @@ class _ReportsMixin:
         to: list[str] | None = None,
     ) -> tuple[str, dict[str, Any]]:
         """Create and persist a ``Read(Offer(Report))`` ack-report activity."""
-        from vultron.wire.as2.vocab.base.objects.activities.transitive import (
-            as_Read,
-        )
-
         offer = cast(Any, self._dl.read(offer_id))
         activity = as_Read(object_=offer, actor=actor, to=to)
         try:

--- a/vultron/core/behaviors/report/nodes/case_creation.py
+++ b/vultron/core/behaviors/report/nodes/case_creation.py
@@ -23,6 +23,7 @@ from py_trees.common import Status
 from vultron.core.behaviors.helpers import DataLayerAction
 from vultron.core.models.activity import VultronCreateCaseActivity
 from vultron.core.models.case import VultronCase
+from vultron.core.models.offer_record import VultronOfferRecord
 
 
 def _append_addressee_ids(addressees: list[str], value: object) -> None:
@@ -43,15 +44,20 @@ def _append_addressee_ids(addressees: list[str], value: object) -> None:
 def _collect_create_case_addressees(
     actor: object,
     report: object,
-    offer: object,
+    offer_record: VultronOfferRecord | None,
     actor_id: str,
 ) -> list[str]:
+    """Collect CreateCase notification recipients from actor, report, and offer record.
+
+    Per ADR-0035 DL-06-001: reads offer addressees from the core
+    ``VultronOfferRecord``, not from the stored wire Offer activity.
+    """
     addressees: list[str] = []
     for value in (
         actor,
         getattr(report, "attributed_to", None) if report is not None else None,
-        getattr(offer, "to", None) if offer is not None else None,
-        getattr(offer, "actor", None) if offer is not None else None,
+        offer_record.offer_to if offer_record is not None else None,
+        offer_record.offer_actor_id if offer_record is not None else None,
     ):
         _append_addressee_ids(addressees, value)
     return [
@@ -188,9 +194,15 @@ class CreateCaseActivity(DataLayerAction):
 
             actor = self.datalayer.read(self.actor_id, raise_on_missing=True)
             report = self.datalayer.read(self.report_id, raise_on_missing=True)
-            offer = self.datalayer.read(self.offer_id)
+            record_id = VultronOfferRecord.build_id(self.offer_id)
+            raw_record = self.datalayer.read(record_id)
+            offer_record = (
+                raw_record
+                if isinstance(raw_record, VultronOfferRecord)
+                else None
+            )
             addressees = _collect_create_case_addressees(
-                actor, report, offer, self.actor_id
+                actor, report, offer_record, self.actor_id
             )
             self.logger.info(
                 f"{self.name}: Notifying addressees: {addressees}"

--- a/vultron/core/behaviors/report/nodes/emit.py
+++ b/vultron/core/behaviors/report/nodes/emit.py
@@ -21,6 +21,7 @@ from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerAction
 from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.offer_record import VultronOfferRecord
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.use_cases._helpers import _resolve_case_manager_id
 
@@ -81,11 +82,14 @@ class _EmitCaseActorReportActivityBase(DataLayerAction):
     def _compute_addressees(self) -> list[str] | None:
         """Resolve and validate outbound recipients; return None to fail."""
         assert self.datalayer is not None and self.actor_id is not None
-        offer = self.datalayer.read(self.offer_id)
+        record_id = VultronOfferRecord.build_id(self.offer_id)
+        offer_record = self.datalayer.read(record_id)
+        if not isinstance(offer_record, VultronOfferRecord):
+            offer_record = None
         addressees = _compute_report_addressees(
             self.report_id,
             self.actor_id,
-            offer,
+            offer_record,
             cast(CaseOutboxPersistence, self.datalayer),
         )
         if not addressees:
@@ -182,18 +186,22 @@ class EmitValidateReportActivity(_EmitCaseActorReportActivityBase):
 def _compute_report_addressees(
     report_id: str,
     actor_id: str,
-    offer: object | None,
+    offer_record: VultronOfferRecord | None,
     dl: CaseOutboxPersistence,
 ) -> list[str] | None:
     """Compute outbound recipient list for a report-phase trigger activity.
 
     For case-scoped report activities, route only to the Case Actor. Falls back
-    to the offer submitter when no case is found (no case-scoped routing).
+    to the offer submitter (from the ``VultronOfferRecord``) when no case is
+    found.
+
+    Per ADR-0035 DL-06-001: the offer submitter ID is read from the core
+    ``VultronOfferRecord``, not from the stored wire Offer activity.
 
     Args:
         report_id: VulnerabilityReport ID used to locate the linked case.
         actor_id: Sender's actor ID (excluded from recipient list).
-        offer: The Offer activity object (used for fallback addressing).
+        offer_record: Core offer record capturing the submitter's actor ID.
         dl: DataLayer for case lookup.
 
     Returns:
@@ -206,14 +214,9 @@ def _compute_report_addressees(
             return [case_manager_id]
         return None
 
-    offer_actor = getattr(offer, "actor", None)
-    if offer_actor is None:
+    if offer_record is None:
         return None
-    offer_actor_id = (
-        offer_actor
-        if isinstance(offer_actor, str)
-        else getattr(offer_actor, "id_", None)
-    )
+    offer_actor_id = offer_record.offer_actor_id
     if offer_actor_id and offer_actor_id != actor_id:
         return [offer_actor_id]
     return None

--- a/vultron/core/models/offer_record.py
+++ b/vultron/core/models/offer_record.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Core state record capturing the domain facts from a submitted report Offer.
+
+Per ADR-0035 DL-06-002: every domain fact an actor must remember from a
+received protocol message MUST be recorded as core state at extraction time.
+Core MUST NOT reconstruct such a fact by re-reading the stored activity later.
+
+``VultronOfferRecord`` captures the three domain facts that core uses from the
+Offer(VulnerabilityReport) wire activity:
+
+- ``report_id``: the URI of the embedded ``VulnerabilityReport``
+- ``offer_actor_id``: the URI of the actor that submitted the report (used for
+  fallback addressing when no case is found)
+- ``offer_to``: the original ``to`` field of the Offer (used to compute
+  ``CreateCaseActivity`` addressees)
+
+The record is keyed deterministically by ``offer_id`` via :meth:`build_id`,
+so core can look it up given only the offer ID.
+"""
+
+import urllib.parse
+from typing import Literal
+
+from pydantic import Field, model_validator
+
+from vultron.core.models.base import UriString, VultronObject
+
+
+class VultronOfferRecord(VultronObject):
+    """Core state record for the domain facts carried in a report Offer.
+
+    Stored by the adapter layer (``TriggerActivityAdapter.submit_report``)
+    immediately after the Offer activity is created.  Core reads this record
+    instead of re-reading the stored wire Offer activity.
+    """
+
+    type_: Literal["OfferRecord"] = Field(
+        default="OfferRecord",
+        validation_alias="type",
+        serialization_alias="type",
+    )
+    offer_id: UriString = Field(..., description="URI of the Offer activity")
+    report_id: UriString = Field(
+        ..., description="URI of the embedded VulnerabilityReport"
+    )
+    offer_actor_id: UriString = Field(
+        ..., description="URI of the actor that submitted the Offer"
+    )
+    offer_to: list[str] = Field(
+        default_factory=list,
+        description="'to' recipients from the original Offer",
+    )
+
+    @classmethod
+    def build_id(cls, offer_id: str) -> str:
+        """Return the stable DataLayer ID for *offer_id*."""
+        slug = urllib.parse.quote(offer_id, safe="")
+        return f"offer-record/{slug}"
+
+    @model_validator(mode="after")
+    def _set_id(self) -> "VultronOfferRecord":
+        """Compute ``id_`` deterministically from ``offer_id``."""
+        self.id_ = self.build_id(self.offer_id)
+        return self

--- a/vultron/core/use_cases/received/report.py
+++ b/vultron/core/use_cases/received/report.py
@@ -14,6 +14,7 @@ from vultron.core.models.events.report import (
     SubmitReportReceivedEvent,
     ValidateReportReceivedEvent,
 )
+from vultron.core.models.offer_record import VultronOfferRecord
 from vultron.core.ports.case_persistence import CasePersistence
 from vultron.errors import VultronValidationError
 
@@ -60,6 +61,30 @@ def _store_submit_report_dependencies(
     except ValueError as e:
         logger.debug(
             "SubmitReport activity %s already exists (pre-stored by inbox endpoint): %s",
+            request.activity_id,
+            e,
+        )
+
+    # Per ADR-0035 DL-06-002: capture domain facts from the inbound Offer so
+    # the receiver's trigger-side validate/invalidate/close paths can look up
+    # the offer record without re-reading the stored wire Offer activity.
+    if request.report_id is None:
+        return
+    offer_to: list[str] = list(request.activity.to or [])
+    offer_record = VultronOfferRecord(
+        offer_id=request.activity_id,
+        report_id=request.report_id,
+        offer_actor_id=request.actor_id,
+        offer_to=offer_to,
+    )
+    try:
+        dl.create(offer_record)
+        logger.info(
+            "Stored VultronOfferRecord for offer '%s'", request.activity_id
+        )
+    except ValueError as e:
+        logger.debug(
+            "VultronOfferRecord for offer '%s' already exists: %s",
             request.activity_id,
             e,
         )

--- a/vultron/core/use_cases/triggers/report.py
+++ b/vultron/core/use_cases/triggers/report.py
@@ -38,7 +38,8 @@ from vultron.core.behaviors.report.trigger_report_trees import (
 from vultron.core.behaviors.report.validate_tree import (
     create_validate_report_tree,
 )
-from vultron.core.models.report import VultronReport
+from vultron.core.models.offer_record import VultronOfferRecord
+from vultron.core.models.report import VulnerabilityReport, VultronReport
 from vultron.core.models.report_case_link import VultronReportCaseLink
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.core.use_cases.triggers._base import SvcBTTriggerBase
@@ -59,29 +60,33 @@ logger = logging.getLogger(__name__)
 
 def _resolve_offer_and_report(
     offer_id: str, dl: CaseOutboxPersistence
-) -> tuple[Any, Any]:
-    """Resolve offer and its embedded report; raise domain errors on failure.
+) -> tuple[Any, VulnerabilityReport]:
+    """Resolve the offer record and its embedded report from core state.
 
-    After the DataLayer rehydration pipeline, ``dl.read(offer_id)`` returns an
-    ``RmSubmitReportActivity`` with its ``object_`` already expanded to a
-    ``VulnerabilityReport``.  No manual coercion is needed.
+    Per ADR-0035 DL-06-001: core MUST NOT re-read the stored Offer wire
+    activity to recover semantic content.  The domain facts (report ID,
+    offer actor) are captured in a ``VultronOfferRecord`` at submission time.
     """
-    offer = dl.read(offer_id)
-    if offer is None:
+    record_id = VultronOfferRecord.build_id(offer_id)
+    offer_record = dl.read(record_id)
+    if offer_record is None:
         raise VultronNotFoundError("Offer", offer_id)
-    if getattr(offer, "type_", "") != "Offer":
+    if not isinstance(offer_record, VultronOfferRecord):
         raise VultronValidationError(
-            f"Expected RmSubmitReportActivity for offer '{offer_id}', "
-            f"got type '{getattr(offer, 'type_', 'unknown')}'."
+            f"Expected VultronOfferRecord for offer '{offer_id}', "
+            f"got type '{getattr(offer_record, 'type_', 'unknown')}'."
         )
-    report = getattr(offer, "object_", None)
-    if getattr(report, "type_", "") != "VulnerabilityReport":
+    report = dl.read(offer_record.report_id)
+    if report is None:
+        raise VultronNotFoundError(
+            "VulnerabilityReport", offer_record.report_id
+        )
+    if not isinstance(report, VulnerabilityReport):
         raise VultronValidationError(
-            f"Expected VulnerabilityReport embedded in offer '{offer_id}', "
-            f"got type"
-            f" '{getattr(report, 'type_', 'None' if report is None else 'unknown')}'."
+            f"Expected VulnerabilityReport '{offer_record.report_id}', "
+            f"got type '{getattr(report, 'type_', 'unknown')}'."
         )
-    return offer, report
+    return offer_record, report
 
 
 class SvcValidateReportUseCase(SvcBTTriggerBase):
@@ -106,7 +111,7 @@ class SvcValidateReportUseCase(SvcBTTriggerBase):
     def _build_tree(self) -> py_trees.behaviour.Behaviour:
         return create_validate_report_tree(
             report_id=self._report.id_,
-            offer_id=self._offer.id_,
+            offer_id=self._offer.offer_id,
             captured=self._captured,
         )
 
@@ -127,7 +132,7 @@ class SvcInvalidateReportUseCase(SvcBTTriggerBase):
 
     def _build_tree(self) -> py_trees.behaviour.Behaviour:
         return create_invalidate_report_trigger_tree(
-            offer_id=self._offer.id_,
+            offer_id=self._offer.offer_id,
             report_id=self._report.id_,
             captured=self._captured,
         )
@@ -136,7 +141,7 @@ class SvcInvalidateReportUseCase(SvcBTTriggerBase):
         logger.info(
             "Actor '%s' invalidated offer '%s' (report '%s')",
             self._actor_id,
-            self._offer.id_,
+            self._offer.offer_id,
             self._report.id_,
         )
 
@@ -154,7 +159,7 @@ class SvcRejectReportUseCase(SvcBTTriggerBase):
 
     def _build_tree(self) -> py_trees.behaviour.Behaviour:
         return create_reject_report_trigger_tree(
-            offer_id=self._offer.id_,
+            offer_id=self._offer.offer_id,
             report_id=self._report.id_,
             captured=self._captured,
         )
@@ -164,7 +169,7 @@ class SvcRejectReportUseCase(SvcBTTriggerBase):
         logger.info(
             "Actor '%s' hard-closed offer '%s' (report '%s'); note: %s",
             self._actor_id,
-            self._offer.id_,
+            self._offer.offer_id,
             self._report.id_,
             request.note,
         )
@@ -183,7 +188,7 @@ class SvcCloseReportUseCase(SvcBTTriggerBase):
 
     def _build_tree(self) -> py_trees.behaviour.Behaviour:
         return create_close_report_trigger_tree(
-            offer_id=self._offer.id_,
+            offer_id=self._offer.offer_id,
             report_id=self._report.id_,
             result_out=self._result_out,
             captured=self._captured,
@@ -195,7 +200,7 @@ class SvcCloseReportUseCase(SvcBTTriggerBase):
             "Actor '%s' closed offer '%s' (report '%s') via RM lifecycle;"
             " note: %s",
             self._actor_id,
-            self._offer.id_,
+            self._offer.offer_id,
             self._report.id_,
             request.note,
         )

--- a/vultron/wire/as2/vocab/objects/offer_record.py
+++ b/vultron/wire/as2/vocab/objects/offer_record.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Wire-layer vocabulary registration for :class:`VultronOfferRecord`."""
+
+from vultron.core.models.offer_record import (  # noqa: F401
+    VultronOfferRecord,
+)
+from vultron.wire.as2.vocab.base.registry import VOCABULARY
+
+VOCABULARY["OfferRecord"] = VultronOfferRecord
+
+__all__ = ["VultronOfferRecord"]


### PR DESCRIPTION
- Closes #1518

## Summary

Implements ADR-0035 DL-06 for the report/offer domain: all three core sites that re-read stored wire `Offer` activities to recover semantic content (`report_id`, `offer.actor`, `offer.to`) are migrated to read from the new `VultronOfferRecord` core state record instead.

- **AC-1 (DL-06-001)**: Core no longer re-reads stored wire Offer — all reads go through `VultronOfferRecord`
- **AC-2 (DL-06-002)**: Domain facts captured at adapter time in `submit_report()`
- **AC-3**: `"Offer"` removed from `ACTIVITY_TYPE_EXEMPTIONS` in the DL-05-004 ratchet test
- **AC-4**: Tests verify migrated paths read from `VultronOfferRecord`, not wire Offer

## Changes

**New core state record** (`vultron/core/models/offer_record.py`):
- `VultronOfferRecord` — captures `offer_id`, `report_id`, `offer_actor_id`, `offer_to` from the submitted Offer; keyed deterministically via `build_id(offer_id)` = `"offer-record/<encoded_offer_id>"`
- Wire vocabulary registration at `vultron/wire/as2/vocab/objects/offer_record.py` so `dl.read()` round-trips correctly

**Adapter layer** (`reports.py`):
- `submit_report()` now creates and persists a `VultronOfferRecord` immediately after the wire Offer
- Moved `as_Read` import to module level (pre-PR IMPROVE)

**Three migrated core sites**:
- `report.py` — `_resolve_offer_and_report` reads `VultronOfferRecord` then `VulnerabilityReport`
- `emit.py` — `_compute_report_addressees` uses `offer_record.offer_actor_id` for fallback addressing
- `case_creation.py` — `_collect_create_case_addressees` uses `offer_record.offer_to` and `offer_record.offer_actor_id`

**Review fixes** (commits after original PR push):
- `vultron/core/use_cases/received/report.py`: `_store_submit_report_dependencies()` now also creates `VultronOfferRecord` on the received side so the receiver's trigger paths can look up offer facts without re-reading the wire Offer — fixed CI failure (vendor `validate-report` → 404)
- `test/core/use_cases/received/test_submit_report_received.py`: 2 new tests covering received-side offer record storage and idempotency
- `notes/datalayer-design.md`: mark report/offer Category B as migrated

**Tests**:
- All existing fixtures updated to also create `VultronOfferRecord` alongside wire Offer
- `test_validate_report_raises_when_offer_is_wrong_type` → updated to `VultronNotFoundError` (no record for non-offer ID)
- 4 FastAPI tests: `non_report_offer_returns_422` → `non_report_offer_returns_404` (consistent with new error path)
- AC-4 unit tests added for `_compute_report_addressees` and `_collect_create_case_addressees` in `test_nodes.py`

## Verification

- 5109 unit tests pass (19 new/modified)
- Black, flake8, mypy, pyright clean
- [x] AC-1: Core no longer re-reads stored wire Offer
- [x] AC-2: Domain facts captured at adapter time in `submit_report()`
- [x] AC-3: `"Offer"` removed from `ACTIVITY_TYPE_EXEMPTIONS`
- [x] AC-4: Tests verify migrated paths read from `VultronOfferRecord`

## DEFER

- **#1537**: `submit_report` atomicity gap — Offer and OfferRecord written in two separate unguarded `dl.create()` calls; if the second fails, the offer is permanently unprocessable. Requires transactional DataLayer semantics or compensating-delete pattern; out of scope here.