### PR TITLE
fix: add compensating delete in submit_report for VultronOfferRecord failure

### DIFF
--- a/test/adapters/driven/trigger_activity_adapter/test_reports.py
+++ b/test/adapters/driven/trigger_activity_adapter/test_reports.py
@@ -16,6 +16,7 @@
 import pytest
 
 from vultron.core.models.offer_record import VultronOfferRecord
+from vultron.wire.as2.vocab.activities.report import _RmSubmitReportActivity
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
     as_VulnerabilityReport,
 )
@@ -110,10 +111,6 @@ class TestSubmitReport:
             )
 
         # The Offer activity must have been rolled back.
-        from vultron.wire.as2.vocab.activities.report import (
-            _RmSubmitReportActivity,
-        )
-
         activities = list(dl.list_objects("Offer"))
         assert not any(
             isinstance(a, _RmSubmitReportActivity) for a in activities
@@ -144,6 +141,36 @@ class TestSubmitReport:
 
         # The Offer activity MUST still be present — no compensating delete.
         assert dl.read(offer_id) is not None
+
+    def test_original_error_raised_when_compensating_delete_also_fails(
+        self, adapter, dl
+    ):
+        """Original RuntimeError propagates even when compensating delete raises."""
+        report = _make_report(dl)
+
+        original_create = dl.create
+        original_delete = dl.delete
+
+        def failing_create(obj):
+            if isinstance(obj, VultronOfferRecord):
+                raise RuntimeError("simulated DB failure")
+            return original_create(obj)
+
+        def failing_delete(table, id_):
+            raise OSError("delete also broken")
+
+        dl.create = failing_create
+        dl.delete = failing_delete
+
+        with pytest.raises(RuntimeError, match="simulated DB failure"):
+            adapter.submit_report(
+                report_id=report.id_,
+                actor=_ACTOR,
+                to=_COORDINATOR,
+                target=_CASE_ID,
+            )
+
+        dl.delete = original_delete
 
 
 class TestCloseReport:

--- a/test/adapters/driven/trigger_activity_adapter/test_reports.py
+++ b/test/adapters/driven/trigger_activity_adapter/test_reports.py
@@ -13,6 +13,9 @@
 
 """Unit tests for TriggerActivityAdapter report-domain methods."""
 
+import pytest
+
+from vultron.core.models.offer_record import VultronOfferRecord
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
     as_VulnerabilityReport,
 )
@@ -64,6 +67,82 @@ class TestSubmitReport:
             target=_CASE_ID,
         )
 
+        assert dl.read(offer_id) is not None
+
+    def test_persists_offer_record(self, adapter, dl):
+        report = _make_report(dl)
+
+        offer_id, _ = adapter.submit_report(
+            report_id=report.id_,
+            actor=_ACTOR,
+            to=_COORDINATOR,
+            target=_CASE_ID,
+        )
+
+        record_id = VultronOfferRecord.build_id(offer_id)
+        record = dl.read(record_id)
+        assert record is not None
+        assert isinstance(record, VultronOfferRecord)
+        assert record.offer_id == offer_id
+        assert record.report_id == report.id_
+        assert record.offer_actor_id == _ACTOR
+        assert _COORDINATOR in record.offer_to
+
+    def test_compensating_delete_on_offer_record_failure(self, adapter, dl):
+        """Offer activity is rolled back when VultronOfferRecord creation fails."""
+        report = _make_report(dl)
+
+        original_create = dl.create
+
+        def failing_create(obj):
+            if isinstance(obj, VultronOfferRecord):
+                raise RuntimeError("simulated DB failure")
+            return original_create(obj)
+
+        dl.create = failing_create
+
+        with pytest.raises(RuntimeError, match="simulated DB failure"):
+            adapter.submit_report(
+                report_id=report.id_,
+                actor=_ACTOR,
+                to=_COORDINATOR,
+                target=_CASE_ID,
+            )
+
+        # The Offer activity must have been rolled back.
+        from vultron.wire.as2.vocab.activities.report import (
+            _RmSubmitReportActivity,
+        )
+
+        activities = list(dl.list_objects("Offer"))
+        assert not any(
+            isinstance(a, _RmSubmitReportActivity) for a in activities
+        ), "Offer activity should have been deleted by compensating rollback"
+
+    def test_no_compensating_delete_on_duplicate_offer_record(
+        self, adapter, dl
+    ):
+        """ValueError on offer record create does not trigger compensating delete."""
+        report = _make_report(dl)
+
+        original_create = dl.create
+
+        def offer_record_raises_value_error(obj):
+            if isinstance(obj, VultronOfferRecord):
+                raise ValueError("already exists")
+            return original_create(obj)
+
+        dl.create = offer_record_raises_value_error
+
+        # Call succeeds (ValueError is swallowed by the idempotent guard).
+        offer_id, _ = adapter.submit_report(
+            report_id=report.id_,
+            actor=_ACTOR,
+            to=_COORDINATOR,
+            target=_CASE_ID,
+        )
+
+        # The Offer activity MUST still be present — no compensating delete.
         assert dl.read(offer_id) is not None
 
 

--- a/test/adapters/driven/trigger_activity_adapter/test_reports.py
+++ b/test/adapters/driven/trigger_activity_adapter/test_reports.py
@@ -16,7 +16,6 @@
 import pytest
 
 from vultron.core.models.offer_record import VultronOfferRecord
-from vultron.wire.as2.vocab.activities.report import _RmSubmitReportActivity
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
     as_VulnerabilityReport,
 )
@@ -110,10 +109,11 @@ class TestSubmitReport:
                 target=_CASE_ID,
             )
 
-        # The Offer activity must have been rolled back.
+        # The Offer activity must have been rolled back — list_objects("Offer")
+        # should return no entries after the compensating delete.
         activities = list(dl.list_objects("Offer"))
-        assert not any(
-            isinstance(a, _RmSubmitReportActivity) for a in activities
+        assert (
+            len(activities) == 0
         ), "Offer activity should have been deleted by compensating rollback"
 
     def test_no_compensating_delete_on_duplicate_offer_record(

--- a/vultron/adapters/driven/trigger_activity_adapter/reports.py
+++ b/vultron/adapters/driven/trigger_activity_adapter/reports.py
@@ -73,6 +73,19 @@ class _ReportsMixin:
                 "submit_report: offer record '%s' already exists — skipping",
                 offer_record.id_,
             )
+        except Exception:
+            # Compensating delete: remove the Offer activity so the pair is
+            # never left in a half-written state. If the delete itself fails,
+            # log and re-raise the original error so the caller sees it.
+            try:
+                self._dl.delete(activity.type_, activity.id_)
+            except Exception:
+                logger.exception(
+                    "submit_report: compensating delete of activity '%s' also"
+                    " failed; DataLayer may be in inconsistent state",
+                    activity.id_,
+                )
+            raise
         return activity.id_, activity.model_dump(**_DUMP_KWARGS)
 
     def validate_report(


### PR DESCRIPTION
- Closes #1537

## Summary

In `TriggerActivityAdapter.submit_report()`, the wire Offer activity and
the `VultronOfferRecord` are written in two separate `dl.create()` calls
with no transactional boundary between them. If `dl.create(offer_record)`
raises a non-`ValueError` exception, the Offer activity would remain in the
DataLayer without its matching `VultronOfferRecord`, making the offer
permanently unprocessable.

This PR adds a compensating delete: if `dl.create(offer_record)` raises
anything other than `ValueError`, the code attempts `dl.delete(activity.type_,
activity.id_)` before re-raising, restoring atomicity without requiring
DataLayer transaction support.

If the compensating delete itself fails, the error is logged at EXCEPTION
level (with traceback) and the original exception is re-raised.

`ValueError` is still treated as an idempotent duplicate and silently
skipped (existing behaviour preserved).

## Changed files

- `vultron/adapters/driven/trigger_activity_adapter/reports.py` — adds
  `except Exception` clause with compensating delete and re-raise.
- `test/adapters/driven/trigger_activity_adapter/test_reports.py` — adds
  four new tests: `test_persists_offer_record` (happy path),
  `test_compensating_delete_on_offer_record_failure` (RuntimeError path,
  verifies rollback), `test_no_compensating_delete_on_duplicate_offer_record`
  (ValueError path, verifies activity is preserved).

## Test plan

- [x] `uv run pytest test/adapters/driven/trigger_activity_adapter/test_reports.py` — 9 passed
- [x] `uv run pytest test/adapters/driven/ test/core/` — 2408 passed
- [x] `uv run black vultron/ test/` — no changes
- [x] `uv run flake8 vultron/ test/ && uv run mypy && uv run pyright` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)