### PR TITLE
feat(#1519): eliminate 3 DL-06 Category-B embargo Invite re-reads

### DIFF
--- a/notes/datalayer-design.md
+++ b/notes/datalayer-design.md
@@ -273,10 +273,13 @@ domain fact — the ARCH-09-001 core violations):
 - ~~*report/offer*~~: migrated (#1518). `VultronOfferRecord` now captures
   offer facts at adapter time (sender) and received-side ingest time (receiver).
   Core reads `VultronOfferRecord` instead of the stored wire `Offer` activity.
-- *embargo*: `use_cases/received/embargo.py:74,474` (read `Invite` for `context`
-  = case id and `object_` = embargo id); `use_cases/triggers/_helpers.py:129`
-  and `find_embargo_proposal` / `list_objects("Invite")` (pending proposal);
-  `dispatcher.py:196` (read `Invite` for `context`).
+- ~~*embargo*~~: migrated (#1519). `pending_embargo_proposal_index: dict[str,
+  str]` (embargo_id → proposal_id) added to `VulnerabilityCase`; populated on
+  receive (`InviteToEmbargoOnCaseReceivedUseCase`) and trigger
+  (`SvcProposeEmbargoUseCase._handle_result`). All `dl.read(invite_id)` and
+  `list_objects("Invite")` semantic reads in `received/embargo.py`,
+  `triggers/_helpers.py`, and `dispatcher.py` removed. `Invite` removed from
+  DL-05-004 exemptions.
 - *actor/participant*: `use_cases/received/actor/offer_case_participant.py:128,193`
   (read the original recommendation `Offer` for the recommender's actor id);
   `use_cases/triggers/actor.py:163` (read `Invite` for a type check).

--- a/plan/history/2607/implementation/ISSUE-1519.md
+++ b/plan/history/2607/implementation/ISSUE-1519.md
@@ -1,0 +1,25 @@
+---
+source: ISSUE-1519
+timestamp: '2026-07-20T19:01:05.814640+00:00'
+title: Migrate embargo Invite/proposal semantic activity reads off dl.read
+type: implementation
+---
+
+## Issue #1519 — Migrate embargo Invite/proposal semantic activity reads off dl.read (core state)
+
+Eliminated all 3 DL-06 Category-B wire re-reads of stored `Invite` AS2 Activities from core code. Replaced with `pending_embargo_proposal_index: dict[str, str]` (embargo_id → proposal_id) on `VulnerabilityCase`.
+
+Sites closed:
+
+1. `dispatcher._extract_case_id` — removed `dl.read(invite_id)` special case; added `case_id`/`embargo_id` properties to `RejectInviteToEmbargoOnCaseReceivedEvent`
+2. `_resolve_case_for_embargo_acceptance` — removed `dl.read(invite_id)` fallback
+3. `RejectInviteToEmbargoOnCaseReceivedUseCase.execute()` — used `request.case_id`/`request.embargo_id` from event properties
+4. `find_embargo_proposal` / `dl.list_objects("Invite")` — replaced with `find_embargo_proposal_id(case)` reading core state index
+
+Index populated from receive-side (`InviteToEmbargoOnCaseReceivedUseCase`) and trigger-side (`SvcProposeEmbargoUseCase._handle_result`).
+
+Architecture ratchet tightened: `"Invite"` removed from `ACTIVITY_TYPE_EXEMPTIONS` (DL-05-004).
+
+10 new AC-5 tests in `test/core/use_cases/received/test_embargo_proposal_index.py`. All 5127 tests pass.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1541>

--- a/test/adapters/driving/fastapi/routers/conftest.py
+++ b/test/adapters/driving/fastapi/routers/conftest.py
@@ -239,6 +239,7 @@ def case_with_proposal(dl, actor):
     dl.create(proposal)
     case_obj.current_status.em_state = EM.PROPOSED
     case_obj.proposed_embargoes.append(embargo.id_)
+    case_obj.pending_embargo_proposal_index[embargo.id_] = proposal.id_
     dl.create(case_obj)
     _add_case_manager(case_obj, dl)
     return case_obj, proposal, embargo

--- a/test/architecture/test_dl_read_returns_core_objects.py
+++ b/test/architecture/test_dl_read_returns_core_objects.py
@@ -88,7 +88,6 @@ ACTIVITY_TYPE_EXEMPTIONS: frozenset[str] = frozenset(
         "Flag",
         "Follow",
         "Ignore",
-        "Invite",
         "Join",
         "Leave",
         "Like",

--- a/test/core/test_fail_fast_silent_sites.py
+++ b/test/core/test_fail_fast_silent_sites.py
@@ -213,7 +213,6 @@ class TestExtractCaseIdRaisesUnroutableActivityError:
         Test the internal method directly so the raise behaviour is explicit
         even if the caller (_handle) catches it.
         """
-        mock_dl = MagicMock()
         dispatcher = DirectActivityDispatcher(use_case_map={})
         event = AddNoteToCaseReceivedEvent(
             activity_id=ACTIVITY_ID,
@@ -222,7 +221,7 @@ class TestExtractCaseIdRaisesUnroutableActivityError:
         )
 
         with pytest.raises(UnroutableActivityError) as exc_info:
-            dispatcher._extract_case_id(event, mock_dl)
+            dispatcher._extract_case_id(event)
 
         exc = exc_info.value
         assert exc.activity_id == ACTIVITY_ID

--- a/test/core/use_cases/received/test_embargo_proposal_index.py
+++ b/test/core/use_cases/received/test_embargo_proposal_index.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""AC-5 tests: embargo accept/reject/no-op correlate via core state index.
+
+Verifies that:
+  - InviteToEmbargoOnCaseReceivedUseCase populates pending_embargo_proposal_index
+  - SvcAcceptEmbargoUseCase resolves proposal from core state (no Invite DL read)
+  - SvcRejectEmbargoUseCase resolves proposal from core state (no Invite DL read)
+  - Counter-proposal case: first pending proposal used when no proposal_id given
+  - No-op: VultronNotFoundError raised when pending_embargo_proposal_index is empty
+  - RejectInviteToEmbargoOnCaseReceivedEvent.case_id comes from inner_context_id
+"""
+
+from typing import cast
+
+import pytest
+
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.adapters.driven.trigger_activity_adapter import (
+    TriggerActivityAdapter,
+)
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.states.em import EM
+from vultron.core.models.events.embargo import (
+    InviteToEmbargoOnCaseReceivedEvent,
+    RejectInviteToEmbargoOnCaseReceivedEvent,
+)
+from vultron.core.use_cases.received.embargo import (
+    InviteToEmbargoOnCaseReceivedUseCase,
+    RejectInviteToEmbargoOnCaseReceivedUseCase,
+)
+from vultron.core.use_cases.triggers.embargo import (
+    SvcAcceptEmbargoUseCase,
+    SvcProposeEmbargoUseCase,
+    SvcRejectEmbargoUseCase,
+)
+from vultron.core.use_cases.triggers.requests import (
+    AcceptEmbargoTriggerRequest,
+    RejectEmbargoTriggerRequest,
+)
+from vultron.errors import VultronNotFoundError
+from vultron.semantic_registry import extract_event
+from vultron.wire.as2.factories import em_propose_embargo_activity
+from vultron.wire.as2.vocab.base.objects.actors import as_Service
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
+
+
+def _make_case_with_case_manager(dl, actor_id, em_state=EM.PROPOSED):
+    """Create and persist a VulnerabilityCase with a CASE_MANAGER participant."""
+    from vultron.enums.roles import CVDRole
+
+    case = as_VulnerabilityCase(
+        name="Proposal Index Test",
+        attributed_to=actor_id,
+    )
+    case.current_status.em_state = em_state
+    dl.create(case)
+
+    case_manager = as_Service(name="CaseManager")
+    dl.create(case_manager)
+    cm_p = as_CaseParticipant(
+        attributed_to=case_manager.id_,
+        context=case.id_,
+        case_roles=[CVDRole.CASE_MANAGER],
+    )
+    dl.create(cm_p)
+    case.actor_participant_index[case_manager.id_] = cm_p.id_
+    dl.save(case)
+    return case, case_manager
+
+
+class TestInviteToEmbargoRecordsIndex:
+    """InviteToEmbargoOnCaseReceivedUseCase must populate pending_embargo_proposal_index."""
+
+    def test_invite_populates_pending_embargo_proposal_index(self):
+        """After receiving EP, case.pending_embargo_proposal_index maps embargo → invite."""
+        actor_id = "https://example.org/actors/vendor"
+        dl = SqliteDataLayer("sqlite:///:memory:")
+
+        actor = as_Service(id_=actor_id, name="Vendor")
+        dl.create(actor)
+        case, _cm = _make_case_with_case_manager(
+            dl, actor_id, em_state=EM.NONE
+        )
+
+        embargo = as_EmbargoEvent(
+            id_=f"{case.id_}/embargo_events/e1",
+            context=case.id_,
+        )
+        dl.create(embargo)
+
+        proposal = em_propose_embargo_activity(
+            embargo,
+            context=case.id_,
+            actor=actor_id,
+        )
+        raw_event = extract_event(proposal)
+        event = cast(
+            InviteToEmbargoOnCaseReceivedEvent,
+            raw_event.model_copy(update={"receiving_actor_id": actor_id}),
+        )
+
+        InviteToEmbargoOnCaseReceivedUseCase(dl, event).execute()
+
+        updated_case = dl.read(case.id_)
+        assert isinstance(updated_case, VulnerabilityCase)
+        assert (
+            proposal.id_
+            in updated_case.pending_embargo_proposal_index.values()
+        )
+        assert embargo.id_ in updated_case.pending_embargo_proposal_index
+
+    def test_invite_index_idempotent(self):
+        """Receiving the same EP twice does not duplicate the index entry."""
+        actor_id = "https://example.org/actors/vendor-idem"
+        dl = SqliteDataLayer("sqlite:///:memory:")
+
+        actor = as_Service(id_=actor_id, name="Vendor")
+        dl.create(actor)
+        case, _cm = _make_case_with_case_manager(
+            dl, actor_id, em_state=EM.NONE
+        )
+
+        embargo = as_EmbargoEvent(
+            id_=f"{case.id_}/embargo_events/e_idem",
+            context=case.id_,
+        )
+        dl.create(embargo)
+
+        proposal = em_propose_embargo_activity(
+            embargo,
+            context=case.id_,
+            actor=actor_id,
+        )
+        raw_event = extract_event(proposal)
+        event = cast(
+            InviteToEmbargoOnCaseReceivedEvent,
+            raw_event.model_copy(update={"receiving_actor_id": actor_id}),
+        )
+
+        InviteToEmbargoOnCaseReceivedUseCase(dl, event).execute()
+        InviteToEmbargoOnCaseReceivedUseCase(dl, event).execute()
+
+        updated_case = dl.read(case.id_)
+        assert isinstance(updated_case, VulnerabilityCase)
+        assert len(updated_case.pending_embargo_proposal_index) == 1
+
+
+class TestProposeTriggerRecordsIndex:
+    """SvcProposeEmbargoUseCase must populate pending_embargo_proposal_index."""
+
+    def test_propose_trigger_populates_index(self):
+        """After triggering a proposal, case.pending_embargo_proposal_index is populated."""
+        from datetime import datetime, timezone, timedelta
+
+        from vultron.core.use_cases.triggers.requests import (
+            ProposeEmbargoTriggerRequest,
+        )
+
+        actor_id = "https://example.org/actors/coordinator"
+        dl = SqliteDataLayer("sqlite:///:memory:")
+
+        actor = as_Service(id_=actor_id, name="Coordinator")
+        dl.create(actor)
+        case, _cm = _make_case_with_case_manager(
+            dl, actor_id, em_state=EM.NONE
+        )
+
+        end_time = datetime.now(timezone.utc) + timedelta(days=90)
+        request = ProposeEmbargoTriggerRequest(
+            actor_id=actor_id,
+            case_id=case.id_,
+            end_time=end_time,
+        )
+        result = SvcProposeEmbargoUseCase(
+            dl, request, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
+
+        assert "activity" in result
+        updated_case = dl.read(case.id_)
+        assert isinstance(updated_case, VulnerabilityCase)
+        assert len(updated_case.pending_embargo_proposal_index) == 1
+        proposal_ids = list(
+            updated_case.pending_embargo_proposal_index.values()
+        )
+        assert proposal_ids[0] == result["activity"]["id"]
+
+
+class TestAcceptRejectFromCoreState:
+    """accept/reject trigger use cases must resolve proposal from core state."""
+
+    def _make_proposed_case(self, dl, actor_id, actor):
+        """Build a PROPOSED case with index populated."""
+        case, _cm = _make_case_with_case_manager(
+            dl, actor_id, em_state=EM.PROPOSED
+        )
+        embargo = as_EmbargoEvent(
+            id_=f"{case.id_}/embargo_events/e1",
+            context=case.id_,
+        )
+        dl.create(embargo)
+        proposal = em_propose_embargo_activity(
+            embargo,
+            context=case.id_,
+            actor=actor_id,
+        )
+        dl.create(proposal)
+        case_obj = dl.read(case.id_)
+        case_obj.proposed_embargoes.append(embargo.id_)
+        case_obj.pending_embargo_proposal_index[embargo.id_] = proposal.id_
+        dl.save(case_obj)
+        return case, embargo, proposal
+
+    def test_accept_uses_core_state_index(self):
+        """SvcAcceptEmbargoUseCase activates embargo using core state (no Invite DL read)."""
+        actor_id = "https://example.org/actors/accept-actor"
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        actor = as_Service(id_=actor_id, name="AcceptActor")
+        dl.create(actor)
+
+        case, embargo, proposal = self._make_proposed_case(dl, actor_id, actor)
+
+        request = AcceptEmbargoTriggerRequest(
+            actor_id=actor_id,
+            case_id=case.id_,
+            proposal_id=proposal.id_,
+        )
+        result = SvcAcceptEmbargoUseCase(
+            dl, request, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
+
+        assert "activity" in result
+        updated_case = dl.read(case.id_)
+        assert isinstance(updated_case, VulnerabilityCase)
+        assert updated_case.current_status.em_state == EM.ACTIVE
+
+    def test_accept_without_proposal_id_uses_first_pending(self):
+        """SvcAcceptEmbargoUseCase finds first pending proposal from index when no proposal_id given."""
+        actor_id = "https://example.org/actors/accept-auto"
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        actor = as_Service(id_=actor_id, name="AcceptAutoActor")
+        dl.create(actor)
+
+        case, _embargo, _proposal = self._make_proposed_case(
+            dl, actor_id, actor
+        )
+
+        request = AcceptEmbargoTriggerRequest(
+            actor_id=actor_id,
+            case_id=case.id_,
+        )
+        result = SvcAcceptEmbargoUseCase(
+            dl, request, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
+
+        assert "activity" in result
+        updated_case = dl.read(case.id_)
+        assert isinstance(updated_case, VulnerabilityCase)
+        assert updated_case.current_status.em_state == EM.ACTIVE
+
+    def test_reject_uses_core_state_index(self):
+        """SvcRejectEmbargoUseCase resolves embargo from core state (no Invite DL read)."""
+        actor_id = "https://example.org/actors/reject-actor"
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        actor = as_Service(id_=actor_id, name="RejectActor")
+        dl.create(actor)
+
+        case, _embargo, proposal = self._make_proposed_case(
+            dl, actor_id, actor
+        )
+
+        request = RejectEmbargoTriggerRequest(
+            actor_id=actor_id,
+            case_id=case.id_,
+            proposal_id=proposal.id_,
+        )
+        result = SvcRejectEmbargoUseCase(
+            dl, request, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
+
+        assert "activity" in result
+        updated_case = dl.read(case.id_)
+        assert isinstance(updated_case, VulnerabilityCase)
+        # Owner-reject drives EM to NONE; non-owner records rejection only.
+        assert updated_case.current_status.em_state in (EM.NONE, EM.PROPOSED)
+
+    def test_accept_raises_notfound_when_index_empty(self):
+        """SvcAcceptEmbargoUseCase raises VultronNotFoundError when no pending proposal in index."""
+        actor_id = "https://example.org/actors/accept-noproposal"
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        actor = as_Service(id_=actor_id, name="AcceptNoProposalActor")
+        dl.create(actor)
+
+        case, _cm = _make_case_with_case_manager(
+            dl, actor_id, em_state=EM.PROPOSED
+        )
+
+        request = AcceptEmbargoTriggerRequest(
+            actor_id=actor_id,
+            case_id=case.id_,
+        )
+        with pytest.raises(VultronNotFoundError):
+            SvcAcceptEmbargoUseCase(
+                dl, request, trigger_activity=TriggerActivityAdapter(dl)
+            ).execute()
+
+    def test_reject_raises_notfound_when_index_empty(self):
+        """SvcRejectEmbargoUseCase raises VultronNotFoundError when no pending proposal in index."""
+        actor_id = "https://example.org/actors/reject-noproposal"
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        actor = as_Service(id_=actor_id, name="RejectNoProposalActor")
+        dl.create(actor)
+
+        case, _cm = _make_case_with_case_manager(
+            dl, actor_id, em_state=EM.PROPOSED
+        )
+
+        request = RejectEmbargoTriggerRequest(
+            actor_id=actor_id,
+            case_id=case.id_,
+        )
+        with pytest.raises(VultronNotFoundError):
+            SvcRejectEmbargoUseCase(
+                dl, request, trigger_activity=TriggerActivityAdapter(dl)
+            ).execute()
+
+
+class TestRejectEventCarriesCaseAndEmbargoIds:
+    """RejectInviteToEmbargoOnCaseReceivedEvent must carry case_id and embargo_id from inner_context/object."""
+
+    def test_reject_event_case_id_from_inner_context(self):
+        """RejectInviteToEmbargoOnCaseReceivedEvent.case_id equals inner_context_id."""
+        from vultron.wire.as2.factories import em_reject_embargo_activity
+
+        case_id = "https://example.org/cases/reject-case"
+        embargo_id = f"{case_id}/embargo_events/e1"
+        actor_id = "https://example.org/actors/rejector"
+        proposal_id = f"{case_id}/proposals/p1"
+
+        embargo = as_EmbargoEvent(id_=embargo_id)
+        proposal = em_propose_embargo_activity(
+            embargo=embargo,
+            context=case_id,
+            actor=actor_id,
+            id_=proposal_id,
+        )
+        reject_activity = em_reject_embargo_activity(
+            proposal=proposal,
+            context=case_id,
+            actor=actor_id,
+        )
+
+        raw_event = extract_event(reject_activity)
+        event = cast(RejectInviteToEmbargoOnCaseReceivedEvent, raw_event)
+
+        assert event.case_id == case_id
+        assert event.embargo_id == embargo_id
+        assert event.invite_id == proposal_id
+
+    def test_reject_use_case_uses_event_case_id_not_dl_read(self, monkeypatch):
+        """RejectInviteToEmbargoOnCaseReceivedUseCase uses case_id from event, not dl.read(invite_id)."""
+        from unittest.mock import patch
+        from vultron.wire.as2.factories import em_reject_embargo_activity
+
+        actor_id = "https://example.org/actors/rej-actor"
+        dl = SqliteDataLayer("sqlite:///:memory:")
+
+        actor = as_Service(id_=actor_id, name="RejActor")
+        dl.create(actor)
+        case, _cm = _make_case_with_case_manager(
+            dl, actor_id, em_state=EM.PROPOSED
+        )
+        embargo = as_EmbargoEvent(
+            id_=f"{case.id_}/embargo_events/e1",
+            context=case.id_,
+        )
+        dl.create(embargo)
+        proposal = em_propose_embargo_activity(
+            embargo=embargo, context=case.id_, actor=actor_id
+        )
+        dl.create(proposal)
+
+        reject_activity = em_reject_embargo_activity(
+            proposal=proposal,
+            context=case.id_,
+            actor=actor_id,
+        )
+        raw_event = extract_event(reject_activity)
+        event = cast(
+            RejectInviteToEmbargoOnCaseReceivedEvent,
+            raw_event.model_copy(update={"receiving_actor_id": actor_id}),
+        )
+
+        dl_read_calls = []
+        original_read = dl.read
+
+        def spy_read(obj_id):
+            dl_read_calls.append(obj_id)
+            return original_read(obj_id)
+
+        with patch.object(dl, "read", side_effect=spy_read):
+            RejectInviteToEmbargoOnCaseReceivedUseCase(dl, event).execute()
+
+        # dl.read must NOT have been called with the proposal/invite ID
+        assert (
+            proposal.id_ not in dl_read_calls
+        ), f"dl.read({proposal.id_!r}) was called — invite wire re-read must be eliminated"
+
+        assert event.case_id == case.id_
+        assert event.embargo_id == embargo.id_

--- a/test/core/use_cases/received/test_embargo_propose_accept_reject.py
+++ b/test/core/use_cases/received/test_embargo_propose_accept_reject.py
@@ -459,6 +459,7 @@ class TestEmbargoProposalLifecycle:
         )
         dl.create(cm_p)
         case.actor_participant_index[case_actor.id_] = cm_p.id_
+        case.pending_embargo_proposal_index[embargo.id_] = proposal.id_
         dl.save(case)
 
         request = AcceptEmbargoTriggerRequest(

--- a/test/core/use_cases/triggers/embargo/conftest.py
+++ b/test/core/use_cases/triggers/embargo/conftest.py
@@ -62,6 +62,7 @@ def _build_active_embargo_case(
     }
     case.current_status.em_state = EM.ACTIVE
     case.proposed_embargoes.append(embargo.id_)
+    case.pending_embargo_proposal_index[embargo.id_] = proposal.id_
     case.set_embargo(embargo.id_)
 
     dl.create(case)
@@ -110,6 +111,7 @@ def _build_proposed_embargo_case_no_owner_attribution(
     }
     case.current_status.em_state = EM.PROPOSED
     case.proposed_embargoes.append(embargo.id_)
+    case.pending_embargo_proposal_index[embargo.id_] = proposal.id_
 
     dl.create(case)
     dl.create(embargo)

--- a/test/core/use_cases/triggers/test_service.py
+++ b/test/core/use_cases/triggers/test_service.py
@@ -252,6 +252,7 @@ def case_with_proposal(dl, actor):
     dl.create(proposal)
     case_obj.current_status.em_state = EM.PROPOSED
     case_obj.proposed_embargoes.append(embargo.id_)
+    case_obj.pending_embargo_proposal_index[embargo.id_] = proposal.id_
     dl.create(case_obj)
     _add_case_manager(case_obj, dl)
     return case_obj, proposal, embargo

--- a/test/core/use_cases/triggers/test_trignotify.py
+++ b/test/core/use_cases/triggers/test_trignotify.py
@@ -397,6 +397,7 @@ class TestEmbargoTriggerToField:
         self.dl.create(proposal)
         self.case.current_status.em_state = EM.PROPOSED
         self.case.proposed_embargoes.append(embargo.id_)
+        self.case.pending_embargo_proposal_index[embargo.id_] = proposal.id_
         self.dl.save(self.case)
 
         request = AcceptEmbargoTriggerRequest(
@@ -456,6 +457,7 @@ class TestEmbargoTriggerToField:
         self.dl.create(proposal)
         self.case.current_status.em_state = EM.PROPOSED
         self.case.proposed_embargoes.append(embargo.id_)
+        self.case.pending_embargo_proposal_index[embargo.id_] = proposal.id_
         self.dl.save(self.case)
 
         request = RejectEmbargoTriggerRequest(

--- a/test/test_behavior_dispatcher.py
+++ b/test/test_behavior_dispatcher.py
@@ -281,6 +281,7 @@ def test_dispatcher_resolves_case_for_reject_embargo_invite_gate():
         activity_id="act-gate-4",
         actor_id=actor_id,
         object_=invite,
+        inner_context=VulnerabilityCaseStub(id_=case_id),
         activity=VultronActivity(type_="Reject", actor=actor_id),
     )
     state_id = VultronReplicationState(
@@ -311,9 +312,6 @@ def test_dispatcher_resolves_case_for_reject_embargo_invite_gate():
     with pytest.raises(VultronValidationError):
         dispatcher.dispatch(event, mock_dl)
 
-    assert any(
-        call.args == (invite.id_,) for call in mock_dl.read.call_args_list
-    )
     assert any(
         call.args == (state_id,) for call in mock_dl.read.call_args_list
     )

--- a/vultron/core/dispatcher.py
+++ b/vultron/core/dispatcher.py
@@ -134,7 +134,7 @@ class DispatcherBase:
         sender_id = event.actor_id
         if not sender_id:
             return
-        case_id = self._extract_case_id(event, dl)
+        case_id = self._extract_case_id(event)
         highest_contiguous_index, has_case_entries = (
             self._highest_contiguous_case_log_index(case_id, dl)
         )
@@ -178,7 +178,7 @@ class DispatcherBase:
             expected += 1
         return expected - 1, True
 
-    def _extract_case_id(self, event: "VultronEvent", dl: "DataLayer") -> str:
+    def _extract_case_id(self, event: "VultronEvent") -> str:
         if (
             event.semantic_type
             == MessageSemantics.ADD_PARTICIPANT_STATUS_TO_PARTICIPANT
@@ -187,19 +187,6 @@ class DispatcherBase:
             status_context = getattr(status_obj, "context", None)
             if isinstance(status_context, str) and status_context:
                 return status_context
-        if (
-            event.semantic_type
-            == MessageSemantics.REJECT_INVITE_TO_EMBARGO_ON_CASE
-        ):
-            invite_id = getattr(event, "invite_id", None)
-            if isinstance(invite_id, str) and invite_id:
-                invite = dl.read(invite_id)
-                invite_context = getattr(invite, "context", None)
-                if isinstance(invite_context, str) and invite_context:
-                    return invite_context
-                invite_context_id = getattr(invite, "context_id", None)
-                if isinstance(invite_context_id, str) and invite_context_id:
-                    return invite_context_id
         for attr in (
             "case_id",
             "inner_context_id",

--- a/vultron/core/models/case.py
+++ b/vultron/core/models/case.py
@@ -69,6 +69,9 @@ class VulnerabilityCase(CoreObject):
     notes: list[str] = Field(default_factory=list)
     active_embargo: str | None = None
     proposed_embargoes: list[str] = Field(default_factory=list)
+    pending_embargo_proposal_index: dict[str, str] = Field(
+        default_factory=dict
+    )
     case_activity: list[str] = Field(default_factory=list)
     genesis_hash: str = Field(
         default="",

--- a/vultron/core/models/events/embargo.py
+++ b/vultron/core/models/events/embargo.py
@@ -150,3 +150,19 @@ class RejectInviteToEmbargoOnCaseReceivedEvent(VultronEvent):
     @property
     def invite(self) -> "VultronActivity | None":
         return cast("VultronActivity | None", self.object_)
+
+    @property
+    def embargo_id(self) -> str | None:
+        return self.inner_object_id
+
+    @property
+    def embargo(self) -> "VultronEmbargoEvent | None":
+        return cast("VultronEmbargoEvent | None", self.inner_object)
+
+    @property
+    def case_id(self) -> str | None:
+        return self.inner_context_id
+
+    @property
+    def case(self) -> "VultronCase | None":
+        return cast("VultronCase | None", self.inner_context)

--- a/vultron/core/use_cases/received/embargo.py
+++ b/vultron/core/use_cases/received/embargo.py
@@ -16,7 +16,6 @@ from vultron.core.ports.case_persistence import (
     CasePersistence,
     CaseOutboxPersistence,
 )
-from vultron.core.models._helpers import _as_id
 from vultron.core.use_cases._helpers import (
     _idempotent_create,
     add_activity_to_outbox,
@@ -63,29 +62,28 @@ def _resolve_case_for_embargo_acceptance(
     if request.case_id:
         return dl.read(request.case_id)
 
-    if request.invite_id is None:
-        logger.error(
-            "accept_invite_to_embargo_on_case: missing invite_id on request"
-        )
-        return None
+    logger.error(
+        "accept_invite_to_embargo_on_case: missing case_id on request"
+        " (invite '%s')",
+        request.invite_id,
+    )
+    return None
 
-    invite = dl.read(request.invite_id)
-    if invite is None:
-        logger.error(
-            "accept_invite_to_embargo_on_case: invite '%s' not found",
-            request.invite_id,
-        )
-        return None
 
-    context_id = _as_id(getattr(invite, "context", None))
-    if context_id is None:
-        logger.error(
-            "accept_invite_to_embargo_on_case: cannot determine case from "
-            "invite '%s'",
-            request.invite_id,
-        )
-        return None
-    return dl.read(context_id)
+def _record_embargo_proposal_index(
+    dl: CasePersistence,
+    case_id: str,
+    embargo_id: str,
+    proposal_id: str,
+) -> None:
+    """Record embargo_id → proposal_id in case core state (ADR-0035 DL-06)."""
+    case = dl.read(case_id)
+    if not isinstance(case, VulnerabilityCase):
+        return
+    if case.pending_embargo_proposal_index.get(embargo_id) == proposal_id:
+        return
+    case.pending_embargo_proposal_index[embargo_id] = proposal_id
+    dl.save(case)
 
 
 class CreateEmbargoEventReceivedUseCase:
@@ -333,6 +331,15 @@ class InviteToEmbargoOnCaseReceivedUseCase:
                 result.feedback_message,
             )
 
+        # Record embargo_id → invite_id in core state so accept/reject
+        # trigger use cases can correlate without re-reading the Invite wire
+        # activity (ADR-0035 DL-06).
+        embargo_id = request.object_id
+        if case_id and embargo_id and invite_id:
+            _record_embargo_proposal_index(
+                self._dl, case_id, embargo_id, invite_id
+            )
+
 
 class AcceptInviteToEmbargoOnCaseReceivedUseCase:
     def __init__(
@@ -465,14 +472,8 @@ class RejectInviteToEmbargoOnCaseReceivedUseCase:
             invite_id,
         )
 
-        # Extract case and embargo IDs from the stored invite activity.
-        case_id: str | None = None
-        embargo_id: str | None = None
-        if invite_id:
-            invite = self._dl.read(invite_id)
-            if invite is not None:
-                case_id = _as_id(getattr(invite, "context", None))
-                embargo_id = _as_id(getattr(invite, "object_", None))
+        case_id = request.case_id
+        embargo_id = request.embargo_id
 
         if not case_id:
             logger.warning(

--- a/vultron/core/use_cases/triggers/_helpers.py
+++ b/vultron/core/use_cases/triggers/_helpers.py
@@ -59,37 +59,17 @@ def resolve_case(case_id: str, dl: CasePersistence) -> VulnerabilityCase:
     return case_raw
 
 
-def find_embargo_proposal(case_id: str, dl: CasePersistence):
-    """
-    Find the first stored EmProposeEmbargoActivity for the given case.
+def find_embargo_proposal_id(case: VulnerabilityCase) -> str | None:
+    """Return the first pending embargo proposal ID from core state.
 
-    Returns None if no matching proposal is found.
+    Looks up ``case.pending_embargo_proposal_index`` (embargo_id → proposal_id)
+    and returns the first proposal ID found.  Returns None if no pending
+    proposal is recorded.  ADR-0035: no DL wire re-read.
     """
-    for obj in dl.list_objects("Invite"):
-        context = getattr(obj, "context", None)
-        c_id = (
-            context
-            if isinstance(context, str)
-            else getattr(context, "id_", str(context))
-        )
-        if c_id != case_id:
-            continue
-        embargo_ref = getattr(obj, "object_", None)
-        if embargo_ref is None:
-            continue
-        embargo_id = (
-            embargo_ref
-            if isinstance(embargo_ref, str)
-            else getattr(embargo_ref, "id_", None)
-        )
-        if embargo_id is None:
-            continue
-        emb = dl.read(embargo_id)
-        if emb is not None and str(getattr(emb, "type_", "")) in (
-            "Event",
-            "EmbargoEvent",
-        ):
-            return obj
+    index = case.pending_embargo_proposal_index
+    for proposal_id in index.values():
+        if proposal_id:
+            return proposal_id
     return None
 
 
@@ -117,45 +97,51 @@ def _is_case_owner(case: object | None, actor_id: str) -> bool:
 
 
 def _resolve_embargo_proposal(
-    case: VulnerabilityCase, proposal_id: str | None, dl: CaseOutboxPersistence
-):
-    """Resolve the embargo proposal for a case."""
-    from vultron.errors import VultronNotFoundError, VultronValidationError
+    case: VulnerabilityCase,
+    proposal_id: str | None,
+) -> str:
+    """Return the proposal ID for a pending embargo on *case*.
+
+    When *proposal_id* is provided it is used directly (after verifying it
+    appears in ``case.pending_embargo_proposal_index``).  When absent, the
+    first entry in the index is used.  Raises ``VultronNotFoundError`` when
+    no pending proposal can be located.  ADR-0035: no DL wire re-read.
+    """
+    from vultron.errors import VultronNotFoundError
+
+    index = case.pending_embargo_proposal_index
 
     if proposal_id:
-        proposal = dl.read(proposal_id)
-        if proposal is None:
+        if proposal_id not in index.values():
             raise VultronNotFoundError("EmbargoProposal", proposal_id)
-    else:
-        proposal = find_embargo_proposal(case.id_, dl)
-        if proposal is None:
-            raise VultronNotFoundError(
-                "EmbargoProposal",
-                f"(pending for case '{case.id_}')",
-            )
+        return proposal_id
 
-    if getattr(proposal, "type_", "") != "Invite":
-        raise VultronValidationError(
-            f"Expected an EmProposeEmbargoActivity (embargo proposal), got "
-            f"type '{getattr(proposal, 'type_', 'unknown')}'."
+    resolved = find_embargo_proposal_id(case)
+    if resolved is None:
+        raise VultronNotFoundError(
+            "EmbargoProposal",
+            f"(pending for case '{case.id_}')",
         )
-    return proposal
+    return resolved
 
 
-def _resolve_embargo_id_from_proposal(proposal: object) -> str:
-    """Return the embargo ID referenced by a proposal."""
+def _resolve_embargo_id_from_proposal_id(
+    case: VulnerabilityCase,
+    proposal_id: str,
+) -> str:
+    """Return the embargo ID for *proposal_id* from ``case.pending_embargo_proposal_index``.
+
+    The index maps embargo_id → proposal_id; this function inverts the lookup.
+    Raises ``VultronValidationError`` when the proposal_id is not found.
+    """
     from vultron.errors import VultronValidationError
 
-    embargo_id = getattr(getattr(proposal, "object_", None), "id_", None)
-    if embargo_id is not None and not isinstance(embargo_id, str):
-        raise VultronValidationError(
-            "Proposal embargo event reference must have a string ID."
-        )
-    if not embargo_id:
-        raise VultronValidationError(
-            "Proposal is missing an embargo event reference."
-        )
-    return embargo_id
+    for embargo_id, pid in case.pending_embargo_proposal_index.items():
+        if pid == proposal_id:
+            return embargo_id
+    raise VultronValidationError(
+        f"No embargo found for proposal '{proposal_id}' in case '{case.id_}'."
+    )
 
 
 def send_case_actor_activity(

--- a/vultron/core/use_cases/triggers/embargo/accept.py
+++ b/vultron/core/use_cases/triggers/embargo/accept.py
@@ -26,7 +26,7 @@ from vultron.core.behaviors.embargo.trigger_tree import (
 from vultron.core.use_cases.triggers._base import SvcEmbargoTriggerBase
 from vultron.core.use_cases.triggers._helpers import (
     _is_case_owner,
-    _resolve_embargo_id_from_proposal,
+    _resolve_embargo_id_from_proposal_id,
     _resolve_embargo_proposal,
     resolve_actor,
     resolve_case,
@@ -47,10 +47,12 @@ class SvcAcceptEmbargoUseCase(SvcEmbargoTriggerBase):
         actor = resolve_actor(request.actor_id, dl)
         self._actor_id = actor.id_
         self._case = resolve_case(request.case_id, dl)
-        self._proposal = _resolve_embargo_proposal(
-            self._case, request.proposal_id, dl
+        self._proposal_id = _resolve_embargo_proposal(
+            self._case, request.proposal_id
         )
-        self._embargo_id = _resolve_embargo_id_from_proposal(self._proposal)
+        self._embargo_id = _resolve_embargo_id_from_proposal_id(
+            self._case, self._proposal_id
+        )
 
         embargo = dl.read(self._embargo_id)
         if embargo is None:
@@ -61,7 +63,7 @@ class SvcAcceptEmbargoUseCase(SvcEmbargoTriggerBase):
     def _build_tree(self) -> py_trees.behaviour.Behaviour:
         def _build_activities(case_manager_id: str) -> list[str]:
             accept_id, accept_dict = self._factory.accept_embargo(
-                proposal_id=self._proposal.id_,
+                proposal_id=self._proposal_id,
                 case_id=self._case.id_,
                 actor=self._actor_id,
                 to=[case_manager_id],
@@ -86,7 +88,7 @@ class SvcAcceptEmbargoUseCase(SvcEmbargoTriggerBase):
                 "Actor '%s' accepted embargo proposal '%s'; activated embargo"
                 " '%s' on case '%s' (EM %s → %s)",
                 self._actor_id,
-                self._proposal.id_,
+                self._proposal_id,
                 self._embargo_id,
                 self._case.id_,
                 lr.em_before,
@@ -98,7 +100,7 @@ class SvcAcceptEmbargoUseCase(SvcEmbargoTriggerBase):
                 " participant consent for embargo '%s' on case '%s'"
                 " (EM unchanged at %s)",
                 self._actor_id,
-                self._proposal.id_,
+                self._proposal_id,
                 self._embargo_id,
                 self._case.id_,
                 lr.em_after,

--- a/vultron/core/use_cases/triggers/embargo/propose.py
+++ b/vultron/core/use_cases/triggers/embargo/propose.py
@@ -57,6 +57,7 @@ class SvcProposeEmbargoUseCase(SvcEmbargoTriggerBase):
                 to=[case_manager_id],
             )
             self._captured["activity"] = proposal_dict
+            self._captured["proposal_id"] = proposal_id
             return [proposal_id]
 
         return propose_embargo_trigger_bt(
@@ -65,6 +66,18 @@ class SvcProposeEmbargoUseCase(SvcEmbargoTriggerBase):
             result_out=self._result_out,
             activity_builder=_build_activities,
         )
+
+    def _handle_result(self) -> None:
+        super()._handle_result()
+        proposal_id = self._captured.get("proposal_id")
+        if isinstance(proposal_id, str) and proposal_id:
+            from vultron.core.use_cases.received.embargo import (
+                _record_embargo_proposal_index,
+            )
+
+            _record_embargo_proposal_index(
+                self._dl, self._case.id_, self._embargo.id_, proposal_id
+            )
 
     def _log_lifecycle_result(self) -> None:
         lr = self._lifecycle_result

--- a/vultron/core/use_cases/triggers/embargo/reject.py
+++ b/vultron/core/use_cases/triggers/embargo/reject.py
@@ -26,7 +26,7 @@ from vultron.core.behaviors.embargo.trigger_tree import (
 from vultron.core.use_cases.triggers._base import SvcEmbargoTriggerBase
 from vultron.core.use_cases.triggers._helpers import (
     _is_case_owner,
-    _resolve_embargo_id_from_proposal,
+    _resolve_embargo_id_from_proposal_id,
     _resolve_embargo_proposal,
     resolve_actor,
     resolve_case,
@@ -46,15 +46,17 @@ class SvcRejectEmbargoUseCase(SvcEmbargoTriggerBase):
         actor = resolve_actor(request.actor_id, dl)
         self._actor_id = actor.id_
         self._case = resolve_case(request.case_id, dl)
-        self._proposal = _resolve_embargo_proposal(
-            self._case, request.proposal_id, dl
+        self._proposal_id = _resolve_embargo_proposal(
+            self._case, request.proposal_id
         )
-        self._embargo_id = _resolve_embargo_id_from_proposal(self._proposal)
+        self._embargo_id = _resolve_embargo_id_from_proposal_id(
+            self._case, self._proposal_id
+        )
 
     def _build_tree(self) -> py_trees.behaviour.Behaviour:
         def _build_activities(case_manager_id: str) -> list[str]:
             reject_id, reject_dict = self._factory.reject_embargo(
-                proposal_id=self._proposal.id_,
+                proposal_id=self._proposal_id,
                 case_id=self._case.id_,
                 actor=self._actor_id,
                 to=[case_manager_id],
@@ -79,7 +81,7 @@ class SvcRejectEmbargoUseCase(SvcEmbargoTriggerBase):
                 "Actor '%s' rejected embargo proposal '%s' on case '%s'"
                 " (EM %s → %s)",
                 self._actor_id,
-                self._proposal.id_,
+                self._proposal_id,
                 self._case.id_,
                 lr.em_before,
                 lr.em_after,
@@ -90,7 +92,7 @@ class SvcRejectEmbargoUseCase(SvcEmbargoTriggerBase):
                 " participant consent for embargo '%s' on case '%s'"
                 " (EM unchanged at %s)",
                 self._actor_id,
-                self._proposal.id_,
+                self._proposal_id,
                 self._embargo_id,
                 self._case.id_,
                 lr.em_after,

--- a/vultron/wire/as2/vocab/objects/vulnerability_case.py
+++ b/vultron/wire/as2/vocab/objects/vulnerability_case.py
@@ -124,6 +124,10 @@ class as_VulnerabilityCase(VultronAS2Object):
 
     proposed_embargoes: list[as_EmbargoEventRef] = Field(default_factory=list)
 
+    pending_embargo_proposal_index: dict[str, str] = Field(
+        default_factory=dict
+    )
+
     case_activity: list[as_Activity] = Field(default_factory=list)
 
     # case relationships


### PR DESCRIPTION
- Closes #1519

## Issue #1519 — Migrate embargo Invite/proposal semantic activity reads off dl.read (core state)

### What changed

Eliminates all 3 DL-06 Category-B wire re-reads of stored `Invite` AS2 Activities from core code, replacing them with domain-level `pending_embargo_proposal_index: dict[str, str]` (embargo_id → proposal_id) on `VulnerabilityCase`. Complies with ADR-0035: core MUST NOT re-read stored wire activities to recover semantic content.

**Re-read sites closed:**
1. `dispatcher._extract_case_id` — removed 11-line special-case calling `dl.read(invite_id)`; `RejectInviteToEmbargoOnCaseReceivedEvent.case_id` now exposed directly via `inner_context_id` so the general attribute loop handles it
2. `_resolve_case_for_embargo_acceptance` — removed `dl.read(invite_id)` fallback; `AcceptInviteToEmbargoOnCaseReceivedEvent.case_id` already came from the extractor
3. `RejectInviteToEmbargoOnCaseReceivedUseCase.execute()` — used `request.case_id` / `request.embargo_id` from new event properties instead of `dl.read(invite_id)`
4. `find_embargo_proposal` / `dl.list_objects("Invite")` — replaced with `find_embargo_proposal_id(case)` reading `pending_embargo_proposal_index`

**Index populated from two paths:**
- Receive-side: `InviteToEmbargoOnCaseReceivedUseCase` after BT execution
- Trigger-side: `SvcProposeEmbargoUseCase._handle_result` after activity creation

**Architecture ratchet:** `"Invite"` removed from `ACTIVITY_TYPE_EXEMPTIONS` in DL-05-004 test.

### Files changed

| Area | Change |
|---|---|
| `vultron/core/models/case.py` | Add `pending_embargo_proposal_index` field |
| `vultron/wire/as2/vocab/objects/vulnerability_case.py` | Same field on wire class |
| `vultron/core/models/events/embargo.py` | Add `case_id`, `embargo_id`, `embargo`, `case` properties to `RejectInviteToEmbargoOnCaseReceivedEvent` |
| `vultron/core/dispatcher.py` | Remove `dl` param from `_extract_case_id`; remove REJECT special case |
| `vultron/core/use_cases/received/embargo.py` | Remove 3 `dl.read(invite_id)` calls; add `_record_embargo_proposal_index`; populate index in `InviteToEmbargoOnCaseReceivedUseCase` |
| `vultron/core/use_cases/triggers/propose.py` | Capture `proposal_id`; add `_handle_result` to populate index |
| `vultron/core/use_cases/triggers/_helpers.py` | Replace `find_embargo_proposal`/`_resolve_embargo_proposal`/`_resolve_embargo_id_from_proposal` with no-DL core-state equivalents |
| `vultron/core/use_cases/triggers/embargo/accept.py` + `reject.py` | Use `self._proposal_id` (str); use `_resolve_embargo_id_from_proposal_id` |
| `test/core/use_cases/received/test_embargo_proposal_index.py` | **New**: 10 AC-5 tests |
| 7 test files | Populate `pending_embargo_proposal_index` in fixtures |
| `test/architecture/test_dl_read_returns_core_objects.py` | Remove `"Invite"` from exemptions |
| `notes/datalayer-design.md` | Mark embargo Category-B as migrated |

## Test plan

- [x] `uv run pytest test/core/use_cases/received/test_embargo_proposal_index.py` — 10/10 pass
- [x] `uv run pytest --tb=short` — 5127 passed, 39 skipped, 2 xfailed
- [x] `uv run black vultron/ test/` — no changes
- [x] `uv run flake8 vultron/ test/` — no issues
- [x] `uv run mypy` — success
- [x] `uv run pyright` — 0 errors, 0 warnings
- [x] AC-1: pending embargo proposal represented as core state (`pending_embargo_proposal_index`)
- [x] AC-2: case_id/embargo_id come from core state / domain event properties
- [x] AC-3: `dl.read(invite_id)` / `list_objects("Invite")` removed from core
- [x] AC-4: `"Invite"` removed from DL-05-004 exemption set
- [x] AC-5: tests cover accept, reject, counter/no-op correlation via core state

🤖 Generated with [Claude Code](https://claude.com/claude-code)