### PR TITLE
feat(#680): add queue-depth observability to OutboxMonitor

### DIFF
--- a/plan/history/2607/implementation/ISSUE-680.md
+++ b/plan/history/2607/implementation/ISSUE-680.md
@@ -1,0 +1,19 @@
+---
+source: ISSUE-680
+timestamp: '2026-07-20T19:16:10.136629+00:00'
+title: Add queue-depth observability to OutboxMonitor
+type: implementation
+---
+
+## Issue #680 — Add queue-depth observability to OutboxMonitor
+
+Extends `OutboxMonitor.drain_all()` with two levels of observability:
+
+- DEBUG-level drain-pass summary (total pending items across all actors) on every pass — OX-09-004
+- WARNING per actor when outbox depth exceeds configurable `depth_warn_threshold` — OX-09-005
+
+Also adds `depth_warn_threshold` parameter with negative-value guard, refactors `drain_all()` to call `outbox_list()` once per actor (snapshot into `depths` dict), and hoists pre-existing inline imports to module level.
+
+8 new tests; 37 total pass. All linters clean.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1542>

--- a/test/adapters/driving/fastapi/test_outbox_monitor.py
+++ b/test/adapters/driving/fastapi/test_outbox_monitor.py
@@ -27,6 +27,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.adapters.driving.fastapi.outbox_monitor import OutboxMonitor
 
 # ---------------------------------------------------------------------------
@@ -389,10 +390,6 @@ def test_notify_is_safe_before_start():
 
 def test_register_new_actors_sets_callback_on_sqlite_dl():
     """_register_new_actors() calls set_enqueue_callback on SqliteDataLayer DLs."""
-    from unittest.mock import MagicMock
-
-    from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
-
     sqlite_dl = MagicMock(spec=SqliteDataLayer)
     monitor = _make_monitor(actor_dls={"alice": sqlite_dl})
 
@@ -425,8 +422,6 @@ def test_register_new_actors_skips_non_sqlite_dl():
 
 def test_register_new_actors_idempotent():
     """_register_new_actors() only registers each actor once."""
-    from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
-
     sqlite_dl = MagicMock(spec=SqliteDataLayer)
     monitor = _make_monitor(actor_dls={"alice": sqlite_dl})
 
@@ -451,8 +446,6 @@ def test_monitor_wakes_on_enqueue_not_on_poll_timeout():
 
     AC-4(a): monitor wakes within one event-loop tick after the callback fires.
     """
-    from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
-
     sqlite_dl = MagicMock(spec=SqliteDataLayer)
     sqlite_dl.outbox_list.return_value = []
     shared = MagicMock()
@@ -538,8 +531,6 @@ def test_callback_injection_and_clearing_roundtrip():
     AC-4(c): After injection the DL notifies the monitor; after clearing
     (set_enqueue_callback(None)) no further notification occurs.
     """
-    from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
-
     dl = SqliteDataLayer(
         "sqlite:///:memory:", actor_id="https://example.org/alice"
     )
@@ -588,3 +579,145 @@ def test_stop_clears_loop_reference():
         assert monitor._loop is None
 
     asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Queue-depth observability — OX-09-004 (DEBUG summary) and OX-09-005 (WARNING)
+# ---------------------------------------------------------------------------
+
+
+def _mock_dl_with_depth(depth: int) -> MagicMock:
+    """Return a mock DataLayer whose outbox_list returns `depth` items."""
+    dl = MagicMock()
+    dl.outbox_list.return_value = [f"urn:test:act-{i}" for i in range(depth)]
+    return dl
+
+
+def test_drain_all_logs_debug_summary_with_no_items(caplog):
+    """drain_all emits a DEBUG log with total=0 when all outboxes are empty."""
+    monitor = _make_monitor(actor_dls={"alice": _mock_dl_with_depth(0)})
+    with patch(
+        "vultron.adapters.driving.fastapi.outbox_monitor.outbox_handler",
+        new_callable=AsyncMock,
+    ):
+        with caplog.at_level("DEBUG"):
+            asyncio.run(monitor.drain_all())
+
+    debug_msgs = [r.message for r in caplog.records if r.levelname == "DEBUG"]
+    assert any(
+        "drain pass" in m and "total pending: 0" in m for m in debug_msgs
+    )
+
+
+def test_drain_all_logs_debug_summary_with_items(caplog):
+    """drain_all emits a DEBUG log showing total pending count across actors."""
+    monitor = _make_monitor(
+        actor_dls={
+            "alice": _mock_dl_with_depth(3),
+            "bob": _mock_dl_with_depth(2),
+        }
+    )
+    with patch(
+        "vultron.adapters.driving.fastapi.outbox_monitor.outbox_handler",
+        new_callable=AsyncMock,
+    ):
+        with caplog.at_level("DEBUG"):
+            asyncio.run(monitor.drain_all())
+
+    debug_msgs = [r.message for r in caplog.records if r.levelname == "DEBUG"]
+    assert any("total pending: 5" in m and "2 actors" in m for m in debug_msgs)
+
+
+def test_drain_all_no_warning_when_threshold_not_set(caplog):
+    """drain_all emits no WARNING when depth_warn_threshold is None (default)."""
+    monitor = _make_monitor(actor_dls={"alice": _mock_dl_with_depth(100)})
+    with patch(
+        "vultron.adapters.driving.fastapi.outbox_monitor.outbox_handler",
+        new_callable=AsyncMock,
+    ):
+        with caplog.at_level("WARNING"):
+            asyncio.run(monitor.drain_all())
+
+    warn_msgs = [r.message for r in caplog.records if r.levelname == "WARNING"]
+    assert not any("exceeds threshold" in m for m in warn_msgs)
+
+
+def test_drain_all_warns_when_depth_exceeds_threshold(caplog):
+    """drain_all emits a WARNING identifying the actor when depth > threshold."""
+    monitor = OutboxMonitor(
+        poll_interval=0.01,
+        actor_datalayers_factory=lambda: {"alice": _mock_dl_with_depth(5)},
+        shared_dl=MagicMock(),
+        depth_warn_threshold=3,
+    )
+    with patch(
+        "vultron.adapters.driving.fastapi.outbox_monitor.outbox_handler",
+        new_callable=AsyncMock,
+    ):
+        with caplog.at_level("WARNING"):
+            asyncio.run(monitor.drain_all())
+
+    warn_msgs = [r.message for r in caplog.records if r.levelname == "WARNING"]
+    assert any("alice" in m and "exceeds threshold" in m for m in warn_msgs)
+
+
+def test_drain_all_no_warning_when_depth_equals_threshold(caplog):
+    """drain_all does NOT warn when depth equals (not exceeds) the threshold."""
+    monitor = OutboxMonitor(
+        poll_interval=0.01,
+        actor_datalayers_factory=lambda: {"alice": _mock_dl_with_depth(3)},
+        shared_dl=MagicMock(),
+        depth_warn_threshold=3,
+    )
+    with patch(
+        "vultron.adapters.driving.fastapi.outbox_monitor.outbox_handler",
+        new_callable=AsyncMock,
+    ):
+        with caplog.at_level("WARNING"):
+            asyncio.run(monitor.drain_all())
+
+    warn_msgs = [r.message for r in caplog.records if r.levelname == "WARNING"]
+    assert not any("exceeds threshold" in m for m in warn_msgs)
+
+
+def test_drain_all_warns_only_for_actors_exceeding_threshold(caplog):
+    """drain_all warns only for actors whose depth exceeds the threshold."""
+    monitor = OutboxMonitor(
+        poll_interval=0.01,
+        actor_datalayers_factory=lambda: {
+            "alice": _mock_dl_with_depth(10),
+            "bob": _mock_dl_with_depth(2),
+        },
+        shared_dl=MagicMock(),
+        depth_warn_threshold=5,
+    )
+    with patch(
+        "vultron.adapters.driving.fastapi.outbox_monitor.outbox_handler",
+        new_callable=AsyncMock,
+    ):
+        with caplog.at_level("WARNING"):
+            asyncio.run(monitor.drain_all())
+
+    warn_msgs = [r.message for r in caplog.records if r.levelname == "WARNING"]
+    assert any("alice" in m and "exceeds threshold" in m for m in warn_msgs)
+    assert not any("bob" in m and "exceeds threshold" in m for m in warn_msgs)
+
+
+def test_depth_warn_threshold_negative_raises():
+    """Passing a negative depth_warn_threshold raises ValueError at construction."""
+    with pytest.raises(ValueError, match="non-negative"):
+        OutboxMonitor(depth_warn_threshold=-1)
+
+
+def test_drain_all_calls_outbox_list_exactly_once_per_actor():
+    """drain_all calls outbox_list() exactly once per actor, not twice."""
+    dl = _mock_dl_with_depth(2)
+    monitor = _make_monitor(actor_dls={"alice": dl})
+
+    with patch(
+        "vultron.adapters.driving.fastapi.outbox_monitor.outbox_handler",
+        new_callable=AsyncMock,
+    ):
+        asyncio.run(monitor.drain_all())
+
+    dl.outbox_list.assert_called_once()

--- a/vultron/adapters/driving/fastapi/outbox_monitor.py
+++ b/vultron/adapters/driving/fastapi/outbox_monitor.py
@@ -29,6 +29,8 @@ Spec coverage:
 - OX-09-001: Monitor wakes immediately on enqueue via callback.
 - OX-09-002: Safety-net poll interval retained for missed notifications.
 - OX-09-003: Callback injected as Callable; no monitor import in DL layer.
+- OX-09-004: DEBUG-level queue-depth summary on each drain pass.
+- OX-09-005: WARNING when any actor's outbox exceeds depth_warn_threshold.
 """
 
 import asyncio
@@ -80,6 +82,9 @@ class OutboxMonitor:
         emitter: ``ActivityEmitter`` implementation for HTTP delivery.
             Defaults to ``DemoHttpDeliveryAdapter`` (resolved inside
             :func:`outbox_handler`).
+        depth_warn_threshold: When set, emit a WARNING log for any actor
+            whose outbox depth exceeds this value on a drain pass.  ``None``
+            (default) disables the warning (OX-09-005).
     """
 
     def __init__(
@@ -90,11 +95,17 @@ class OutboxMonitor:
         ) = None,
         shared_dl: DataLayer | None = None,
         emitter: ActivityEmitter | None = None,
+        depth_warn_threshold: int | None = None,
     ) -> None:
+        if depth_warn_threshold is not None and depth_warn_threshold < 0:
+            raise ValueError(
+                f"depth_warn_threshold must be non-negative, got {depth_warn_threshold}"
+            )
         self._poll_interval = poll_interval
         self._actor_datalayers_factory = actor_datalayers_factory
         self._shared_dl = shared_dl
         self._emitter = emitter
+        self._depth_warn_threshold = depth_warn_threshold
         self._task: asyncio.Task | None = None
         self._running = False
         self._wakeup_event: asyncio.Event | None = None
@@ -103,6 +114,10 @@ class OutboxMonitor:
 
     async def drain_all(self) -> None:
         """Process all registered actor outboxes once.
+
+        Logs total pending items at DEBUG level on every pass (OX-09-004).
+        Emits a WARNING for any actor whose depth exceeds
+        ``depth_warn_threshold`` when that parameter is set (OX-09-005).
 
         Skips actors whose outbox is empty.  Delivery errors for a single
         actor are caught, logged at ERROR level, and do not abort processing
@@ -118,8 +133,29 @@ class OutboxMonitor:
             self._shared_dl if self._shared_dl is not None else get_datalayer()
         )
 
+        depths: dict[str, int] = {
+            actor_id: len(dl.outbox_list())
+            for actor_id, dl in actor_dls.items()
+        }
+        total = sum(depths.values())
+        logger.debug(
+            "OutboxMonitor: drain pass - total pending: %d across %d actors",
+            total,
+            len(actor_dls),
+        )
+        if self._depth_warn_threshold is not None:
+            for actor_id, depth in depths.items():
+                if depth > self._depth_warn_threshold:
+                    logger.warning(
+                        "OutboxMonitor: actor '%s' outbox depth %d"
+                        " exceeds threshold %d",
+                        actor_id,
+                        depth,
+                        self._depth_warn_threshold,
+                    )
+
         for actor_id, dl in actor_dls.items():
-            if not dl.outbox_list():
+            if not depths[actor_id]:
                 continue
             try:
                 await outbox_handler(


### PR DESCRIPTION
- Closes #680

## Summary

Adds queue-depth observability to `OutboxMonitor.drain_all()` per OX-09-004 and OX-09-005.

## Changes

| File | Change |
|---|---|
| `vultron/adapters/driving/fastapi/outbox_monitor.py` | Add `depth_warn_threshold: int | None = None` param; add DEBUG summary log on every drain pass; add per-actor WARNING when depth exceeds threshold; validate negative threshold at construction |
| `test/adapters/driving/fastapi/test_outbox_monitor.py` | Add 8 new tests (6 observability, 1 negative-threshold guard, 1 single-call assertion); hoist pre-existing inline `SqliteDataLayer` imports to module level |

**Spec coverage:**
- OX-09-004: `drain_all()` logs total pending outbox items at DEBUG on every pass
- OX-09-005: WARNING emitted with actor ID and depth when any actor exceeds `depth_warn_threshold`

## Verification

- [x] `uv run pytest test/adapters/driving/fastapi/test_outbox_monitor.py` — 37/37 pass
- [x] `uv run pytest --tb=short` — full suite passes
- [x] `uv run black vultron/ test/` — no changes
- [x] `uv run flake8 vultron/ test/` — no issues
- [x] `uv run mypy` — success
- [x] `uv run pyright` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)