### PR TITLE
chore(#1510): close already-resolved issue; record build learning

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1510.md
+++ b/plan/history/2607/implementation/ISSUE-1510.md
@@ -1,0 +1,20 @@
+---
+source: ISSUE-1510
+timestamp: '2026-07-20T19:20:41.563407+00:00'
+title: 'Close already-resolved issue #1510'
+type: implementation
+---
+
+## Issue #1510 — refactor: make offer_case_manager_role() return (activity_id, activity_dict)
+
+PR: <https://github.com/CERTCC/Vultron/pull/1543>
+
+All acceptance criteria were already satisfied on `main` by PR #1517 (commit
+`085c2f1d`) before this build run claimed the issue:
+
+- `TriggerActivityPort.offer_case_manager_role()` returns `tuple[str, dict[str, Any]]`
+- `CreateOfferCaseManagerActivityNode._emit()` no longer calls `datalayer.read()` for captured data
+- 128 relevant tests pass; all four linters clean
+
+Closed #1510 with an explanatory comment referencing PR #1517. Recorded a
+learning file documenting the "already fixed before claim" pattern.

--- a/plan/incoming/learnings/20260720-issue-already-fixed-in-prior-pr.md
+++ b/plan/incoming/learnings/20260720-issue-already-fixed-in-prior-pr.md
@@ -1,0 +1,27 @@
+---
+title: Issue 1510 already fixed by PR 1517 before it was claimed
+type: learning
+timestamp: "2026-07-20T00:00:00Z"
+source: ISSUE-1510
+---
+
+## Observation
+
+Issue #1510 (make `offer_case_manager_role()` return `(activity_id, activity_dict)`) was
+still OPEN when selected by the build skill, but all acceptance criteria were already
+satisfied by commit `085c2f1d` in PR #1517 ("Migrate Category-A plumbing re-reads").
+
+PR #1517 addressed the same inefficiency for five `TriggerActivityPort` methods, including
+`offer_case_manager_role`. The issue was not closed when #1517 merged because the PR did
+not include a `Closes #1510` footer.
+
+## Action taken
+
+Closed issue #1510 with a comment referencing PR #1517 and confirming all ACs were met.
+No code changes were required.
+
+## Pattern to apply
+
+When an issue selected for build has all ACs satisfied on current main, close it
+immediately with a reference to the relevant commit/PR and record a learning.
+Do not attempt to re-implement already-merged work.


### PR DESCRIPTION
- Closes #1510

## Summary

Issue #1510 was already fully resolved by PR #1517 (commit `085c2f1d`) before
this build run claimed it. All three acceptance criteria were met on `main`:

- `TriggerActivityPort.offer_case_manager_role()` returns `tuple[str, dict[str, Any]]`
- `CreateOfferCaseManagerActivityNode._emit()` no longer calls `datalayer.read()` for captured data
- Tests and linters all pass clean

## Changes

- `plan/incoming/learnings/20260720-issue-already-fixed-in-prior-pr.md` — records
  the pattern: when a claimed issue's ACs are already satisfied on `main`, close
  it immediately with a reference to the relevant commit/PR rather than
  re-implementing.

## Verification

- Issue #1510 closed with explanatory comment referencing PR #1517
- 128 relevant tests pass; black/flake8/mypy/pyright all exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)