### PR TITLE
feat(#1513): extract has_case_statuses predicate; wire into action_rules.py

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1513.md
+++ b/plan/history/2607/implementation/ISSUE-1513.md
@@ -1,0 +1,19 @@
+---
+source: ISSUE-1513
+timestamp: '2026-07-20T19:41:00.621124+00:00'
+title: Extract has_case_statuses predicate; wire into action_rules.py
+type: implementation
+---
+
+## Issue #1513 — Wire HasCaseStatusesNode into action_rules.py (AC-5 remaining site)
+
+Extracted `has_case_statuses(case)` into `vultron/core/models/_helpers.py` as the shared predicate for the "case has at least one CaseStatus entry" check (LST-05 / AC-5, Option B — DRY over inline guards).
+
+Wired the predicate into both call sites:
+
+- `HasCaseStatusesNode.update()` in `vultron/core/behaviors/embargo/nodes/conditions.py`
+- `GetActionRulesUseCase.execute()` in `vultron/core/use_cases/query/action_rules.py`
+
+Added three unit tests covering non-empty → True, explicit-empty → False, and default-construction → False.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1544>

--- a/test/core/models/test_helpers.py
+++ b/test/core/models/test_helpers.py
@@ -106,3 +106,39 @@ def test_report_phase_status_id_different_states():
     id_received = _report_phase_status_id("actor1", "report1", "RECEIVED")
     id_valid = _report_phase_status_id("actor1", "report1", "VALID")
     assert id_received != id_valid
+
+
+# --- has_case_statuses ----------------------------------------------------
+
+
+def test_has_case_statuses_true_when_non_empty():
+    from vultron.core.models._helpers import has_case_statuses
+    from vultron.core.models.case import VulnerabilityCase
+    from vultron.core.models.case_status import CaseStatus
+
+    case = VulnerabilityCase(
+        id_="https://example.org/cases/x1",
+        case_statuses=[CaseStatus(context="https://example.org/cases/x1")],
+    )
+    assert has_case_statuses(case) is True
+
+
+def test_has_case_statuses_false_when_empty():
+    from vultron.core.models._helpers import has_case_statuses
+    from vultron.core.models.case import VulnerabilityCase
+
+    # No attributed_to → _init_case_statuses skips seeding → stays empty
+    case = VulnerabilityCase(
+        id_="https://example.org/cases/x2",
+        case_statuses=[],
+    )
+    assert has_case_statuses(case) is False
+
+
+def test_has_case_statuses_false_when_default():
+    """VulnerabilityCase without attributed_to keeps case_statuses empty."""
+    from vultron.core.models._helpers import has_case_statuses
+    from vultron.core.models.case import VulnerabilityCase
+
+    case = VulnerabilityCase(id_="https://example.org/cases/x3")
+    assert has_case_statuses(case) is False

--- a/vultron/core/behaviors/embargo/nodes/conditions.py
+++ b/vultron/core/behaviors/embargo/nodes/conditions.py
@@ -19,6 +19,7 @@ import py_trees
 from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerCondition
+from vultron.core.models._helpers import has_case_statuses
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_participant import CaseParticipant
 from vultron.errors import VultronInvalidStateTransitionError
@@ -324,7 +325,7 @@ class HasCaseStatusesNode(DataLayerCondition):
             self.feedback_message = f"Case '{self.case_id}' not found"
             return Status.FAILURE
 
-        if not case.case_statuses:
+        if not has_case_statuses(case):
             self.feedback_message = (
                 f"Case '{self.case_id}' has no CaseStatus entries"
             )

--- a/vultron/core/models/_helpers.py
+++ b/vultron/core/models/_helpers.py
@@ -15,9 +15,14 @@
 
 """Shared helper utilities for core domain model types."""
 
+from __future__ import annotations
+
 import uuid
 from datetime import datetime, timezone
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from vultron.core.models.case import VulnerabilityCase
 
 
 def _now_utc() -> datetime:
@@ -44,6 +49,16 @@ def _as_id(obj: Any) -> str | None:
     if isinstance(id_, str):
         return id_
     return str(obj)
+
+
+def has_case_statuses(case: VulnerabilityCase) -> bool:
+    """Return True when *case* has at least one CaseStatus entry.
+
+    Use this as the single shared predicate wherever code must distinguish
+    "no status history yet" from "at least one status recorded" — in both
+    BT condition nodes and plain use-case guards (LST-05 / AC-5).
+    """
+    return bool(case.case_statuses)
 
 
 def _report_phase_status_id(

--- a/vultron/core/use_cases/query/action_rules.py
+++ b/vultron/core/use_cases/query/action_rules.py
@@ -23,6 +23,7 @@ from typing import cast
 from vultron.core.case_states.patterns.potential_actions import (
     action as get_actions,
 )
+from vultron.core.models._helpers import has_case_statuses
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_participant import CaseParticipant
 from vultron.core.ports.case_persistence import CasePersistence
@@ -108,7 +109,7 @@ class GetActionRulesUseCase:
         # 4. Get shared case states from the current CaseStatus
         em_state: EM = EM.EMBARGO_MANAGEMENT_NONE
         pxa_state: CS_pxa = CS_pxa.pxa
-        if case.case_statuses:
+        if has_case_statuses(case):
             current_cs = case.current_status
             em_state = current_cs.em_state
             pxa_state = current_cs.pxa_state


### PR DESCRIPTION
- Closes #1513

## Summary

Extracts a `has_case_statuses(case)` predicate into `vultron/core/models/_helpers.py` — the layer-neutral utility module — so the `if case.case_statuses:` truthiness check is defined once and shared between `HasCaseStatusesNode` (BT condition node) and `GetActionRulesUseCase` (pure query use case).

- **`vultron/core/models/_helpers.py`**: adds `has_case_statuses(case: VulnerabilityCase) -> bool` (Option B from issue body; DRY over Option A)
- **`vultron/core/behaviors/embargo/nodes/conditions.py`**: `HasCaseStatusesNode.update()` now calls `has_case_statuses()` instead of the inline `not case.case_statuses` guard
- **`vultron/core/use_cases/query/action_rules.py`**: `GetActionRulesUseCase.execute()` now calls `has_case_statuses()` instead of the inline `case.case_statuses` guard
- **`test/core/models/test_helpers.py`**: three new tests cover non-empty → True, explicit empty → False, default construction → False

The `TYPE_CHECKING` guard in `_helpers.py` avoids a circular import at runtime; `from __future__ import annotations` (PEP 563) makes the annotation a string at runtime.

## Test plan

- [x] `uv run pytest --tb=short` — 5138 passed, 0 failed
- [x] `uv run black vultron/ test/` — no changes
- [x] `uv run flake8 vultron/ test/` — clean
- [x] `uv run mypy` — no issues (1028 source files)
- [x] `uv run pyright` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)