### PR TITLE
feat(#1520): eliminate 3 DL-06 Category-B actor/participant semantic reads

### DIFF
--- a/notes/datalayer-design.md
+++ b/notes/datalayer-design.md
@@ -280,9 +280,14 @@ domain fact — the ARCH-09-001 core violations):
   `list_objects("Invite")` semantic reads in `received/embargo.py`,
   `triggers/_helpers.py`, and `dispatcher.py` removed. `Invite` removed from
   DL-05-004 exemptions.
-- *actor/participant*: `use_cases/received/actor/offer_case_participant.py:128,193`
-  (read the original recommendation `Offer` for the recommender's actor id);
-  `use_cases/triggers/actor.py:163` (read `Invite` for a type check).
+- ~~*actor/participant*~~: migrated (#1520). `recommendation_recommender_index:
+  dict[str, str]` (recommendation_id → recommender_actor_id) added to
+  `VulnerabilityCase`; populated in `OfferActorToCaseReceivedUseCase.execute()`.
+  `AcceptOfferCaseParticipantReceivedUseCase` and
+  `RejectOfferCaseParticipantReceivedUseCase` now read
+  `case.recommendation_recommender_index.get(recommendation_id)` instead of
+  `dl.read(recommendation_id)`. Redundant `invite_type != "Invite"` check
+  removed from `SvcAcceptCaseInviteUseCase._prepare()`.
 - *Fix*: capture the fact as core state at extraction time; read it from core.
 
 **C — envelope reconstitution** (verbatim original needed for a reply):

--- a/plan/history/2607/implementation/ISSUE-1520.md
+++ b/plan/history/2607/implementation/ISSUE-1520.md
@@ -1,0 +1,22 @@
+---
+source: ISSUE-1520
+timestamp: '2026-07-20T20:32:52.299025+00:00'
+title: Migrate actor/participant recommendation + invite semantic reads off dl.read
+type: implementation
+---
+
+## Issue #1520 — Migrate actor/participant recommendation + invite semantic reads off dl.read (core state)
+
+Eliminated three DL-06 Category-B semantic re-reads from core per ADR-0035:
+
+- AcceptOfferCaseParticipantReceivedUseCase: replaced dl.read(recommendation_id) with case.recommendation_recommender_index.get(recommendation_id)
+- RejectOfferCaseParticipantReceivedUseCase: same
+- SvcAcceptCaseInviteUseCase._prepare(): removed redundant invite type-check; kept existence guard only
+
+Added recommendation_recommender_index: dict[str, str] field to VulnerabilityCase and as_VulnerabilityCase. Populated via_record_recommendation_recommender() module-level helper in OfferActorToCaseReceivedUseCase.execute() after local-actor guard, to avoid CLP-10-005 AST ratchet violation and prevent orphaned state on skip.
+
+AC-5 tests added: recommender notification via core state (Accept + Reject paths), write-side population test, and type-check removal documentation test.
+
+Follow-up: #1552 — move index write into BT leaf node.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1553>

--- a/test/core/use_cases/received/actor/test_offer_case_participant.py
+++ b/test/core/use_cases/received/actor/test_offer_case_participant.py
@@ -223,6 +223,50 @@ class TestAcceptOfferCaseParticipantReceivedUseCase:
             AcceptOfferCaseParticipantReceivedUseCase(dl, mock_event).execute()
         assert any("missing" in r.message.lower() for r in caplog.records)
 
+    def test_recommender_notified_via_core_state(self):
+        """AC-5: recommender notification emitted; recommender read from core state.
+
+        Seeds recommendation_recommender_index on the case (as
+        OfferActorToCaseReceivedUseCase does at ingestion time), then runs
+        AcceptOfferCaseParticipantReceivedUseCase and asserts that at least
+        two outbox activities are queued — one Invite to the invitee and one
+        AcceptActorRecommendation to the recommender — confirming the recommender
+        ID came from core state, not from a dl.read(recommendation_id) re-read.
+        """
+        from vultron.core.models.case import VulnerabilityCase
+
+        RECOMMENDATION_ID = "https://example.org/activities/orig-offer-001"
+
+        dl, actor_id = _seed_dl_for_case_actor()
+        # Seed the recommender index as OfferActorToCaseReceivedUseCase would.
+        case = dl.read(CASE_ID)
+        assert isinstance(case, VulnerabilityCase)
+        case.recommendation_recommender_index[RECOMMENDATION_ID] = (
+            RECOMMENDER_ID
+        )
+        dl.save(case)
+
+        event = self._event()
+        AcceptOfferCaseParticipantReceivedUseCase(
+            dl, event, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
+
+        outbox = dl.outbox_list_for_actor(actor_id)
+        assert len(outbox) >= 2, (
+            "Expected at least two outbox activities (Accept notification to "
+            f"recommender + Invite to invitee); got {len(outbox)}"
+        )
+        # At least one queued activity must be addressed to the recommender.
+        addressed_to_recommender = [
+            act_id
+            for act_id in outbox
+            if RECOMMENDER_ID in (getattr(dl.read(act_id), "to", None) or [])
+        ]
+        assert addressed_to_recommender, (
+            f"No outbox activity addressed to recommender '{RECOMMENDER_ID}'; "
+            "recommender lookup must read from core state (recommendation_recommender_index)"
+        )
+
 
 # ---------------------------------------------------------------------------
 # RejectOfferCaseParticipantReceivedUseCase (CaseActor inbox)
@@ -273,6 +317,45 @@ class TestRejectOfferCaseParticipantReceivedUseCase:
         with caplog.at_level(logging.WARNING):
             RejectOfferCaseParticipantReceivedUseCase(dl, mock_event).execute()
         assert any("missing" in r.message.lower() for r in caplog.records)
+
+    def test_recommender_notified_via_core_state(self):
+        """AC-5: recommender notification emitted on reject; recommender from core state.
+
+        Seeds recommendation_recommender_index on the case and asserts that
+        RejectOfferCaseParticipantReceivedUseCase queues a RejectActorRecommendation
+        addressed to the recommender, read from core state.
+        """
+        from vultron.core.models.case import VulnerabilityCase
+
+        RECOMMENDATION_ID = "https://example.org/activities/orig-offer-001"
+
+        dl, actor_id = _seed_dl_for_case_actor()
+        case = dl.read(CASE_ID)
+        assert isinstance(case, VulnerabilityCase)
+        case.recommendation_recommender_index[RECOMMENDATION_ID] = (
+            RECOMMENDER_ID
+        )
+        dl.save(case)
+
+        event = self._event()
+        RejectOfferCaseParticipantReceivedUseCase(
+            dl, event, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
+
+        outbox = dl.outbox_list_for_actor(actor_id)
+        assert len(outbox) >= 1, (
+            "Expected at least one outbox activity (RejectActorRecommendation "
+            f"to recommender); got {len(outbox)}"
+        )
+        addressed_to_recommender = [
+            act_id
+            for act_id in outbox
+            if RECOMMENDER_ID in (getattr(dl.read(act_id), "to", None) or [])
+        ]
+        assert addressed_to_recommender, (
+            f"No outbox activity addressed to recommender '{RECOMMENDER_ID}'; "
+            "recommender lookup must read from core state (recommendation_recommender_index)"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/test/core/use_cases/received/actor/test_suggest.py
+++ b/test/core/use_cases/received/actor/test_suggest.py
@@ -135,3 +135,45 @@ class TestOfferActorToCaseReceivedUseCase:
             OfferActorToCaseReceivedUseCase(dl, mock_event).execute()
 
         assert any("missing" in r.message.lower() for r in caplog.records)
+
+    def test_offer_actor_populates_recommendation_recommender_index(
+        self, make_payload
+    ):
+        """AC-1 (write-side): execute() writes activity_id→recommender_id to core state.
+
+        Verifies that OfferActorToCaseReceivedUseCase populates
+        VulnerabilityCase.recommendation_recommender_index so downstream
+        Accept/Reject use cases can look up the recommender without re-reading
+        the stored wire Offer (ADR-0035 DL-06-002).
+        """
+        from typing import cast
+
+        from vultron.core.models.case import VulnerabilityCase
+
+        dl, local_actor_id, case_id = self._setup_dl()
+        recommender_id = "https://example.org/actors/finder"
+        recommended_id = "https://example.org/actors/vendor-new"
+        recommended = as_Actor(id_=recommended_id)
+
+        activity = recommend_actor_activity(
+            recommended,
+            target=case_id,
+            actor=recommender_id,
+            to=[local_actor_id],
+        )
+        event = make_payload(activity)
+        activity_id = activity.id_
+
+        OfferActorToCaseReceivedUseCase(
+            dl, event, trigger_activity=TriggerActivityAdapter(dl)
+        ).execute()
+
+        case = cast(VulnerabilityCase, dl.read(case_id))
+        assert isinstance(case, VulnerabilityCase)
+        assert (
+            case.recommendation_recommender_index.get(activity_id)
+            == recommender_id
+        ), (
+            "recommendation_recommender_index must map activity_id → recommender_id "
+            "after OfferActorToCaseReceivedUseCase runs (ADR-0035 DL-06-002)"
+        )

--- a/test/core/use_cases/triggers/test_actor_triggers.py
+++ b/test/core/use_cases/triggers/test_actor_triggers.py
@@ -690,6 +690,47 @@ class TestSvcAcceptCaseInviteUseCase:
                 dl, request, trigger_activity=TriggerActivityAdapter(dl)
             ).execute()
 
+    def test_accept_no_type_check_on_invite(self):
+        """AC-2: type check removed — _prepare() only guards existence (ADR-0035 DL-06).
+
+        The semantic type-check ('invite_type != Invite') was removed.
+        _prepare() now only raises VultronNotFoundError when the invite is
+        absent; passing an existing invite_id must reach the BT execution
+        stage regardless of the stored object's type_.  Invites are always
+        stored as as_Invite objects by invite_actor_to_case(), so this test
+        uses a real Invite — it confirms no VultronValidationError is raised,
+        which was the removed guard's error type.
+        """
+        inviter, dl_inviter = _make_actor_dl("Coordinator")
+        invitee, dl_invitee = _make_actor_dl("Finder")
+        dl_inviter.create(invitee)
+
+        case = as_VulnerabilityCase(
+            attributed_to=inviter.id_, name="Test Case", content="Content"
+        )
+        dl_inviter.create(case)
+
+        invite = rm_invite_to_case_activity(
+            invitee,
+            target=VulnerabilityCaseStub(id_=case.id_),
+            actor=inviter.id_,
+            to=[invitee.id_],
+        )
+        dl_invitee.create(inviter)
+        dl_invitee.create(invite)
+
+        request = AcceptCaseInviteTriggerRequest(
+            actor_id=invitee.id_,
+            invite_id=invite.id_,
+        )
+        # Should not raise VultronValidationError (type check removed per DL-06)
+        result = SvcAcceptCaseInviteUseCase(
+            dl_invitee,
+            request,
+            trigger_activity=TriggerActivityAdapter(dl_invitee),
+        ).execute()
+        assert "activity" in result
+
     def test_accept_normalises_short_uuid_actor_id(self):
         """DR-09: short UUID in actor_id is resolved to full URI."""
         inviter, dl_inviter = _make_actor_dl("Coordinator")

--- a/vultron/core/behaviors/case/nodes/suggest_actor/__init__.py
+++ b/vultron/core/behaviors/case/nodes/suggest_actor/__init__.py
@@ -38,6 +38,7 @@ from vultron.core.behaviors.case.nodes.suggest_actor.emit import (
     EmitNoteDuplicateRecommendationToOwnerNode,
     EmitOfferCaseParticipantToOwnerNode,
     EmitRejectActorRecommendationNode,
+    RecordRecommendationRecommenderNode,
 )
 
 __all__ = [
@@ -48,4 +49,5 @@ __all__ = [
     "EmitRejectActorRecommendationNode",
     "InviteInFlightNode",
     "PendingOfferCaseParticipantNode",
+    "RecordRecommendationRecommenderNode",
 ]

--- a/vultron/core/behaviors/case/nodes/suggest_actor/__init__.py
+++ b/vultron/core/behaviors/case/nodes/suggest_actor/__init__.py
@@ -17,8 +17,9 @@
 
 Submodules:
 
-- ``emit``: Outbound activity emission nodes
-  (``EmitOfferCaseParticipantToOwnerNode``,
+- ``emit``: Outbound activity emission nodes and state-write nodes
+  (``RecordRecommendationRecommenderNode``,
+  ``EmitOfferCaseParticipantToOwnerNode``,
   ``EmitAcceptActorRecommendationNode``,
   ``EmitRejectActorRecommendationNode``,
   ``EmitNoteDuplicateRecommendationToOwnerNode``)

--- a/vultron/core/behaviors/case/nodes/suggest_actor/emit.py
+++ b/vultron/core/behaviors/case/nodes/suggest_actor/emit.py
@@ -454,4 +454,5 @@ __all__ = [
     "EmitNoteDuplicateRecommendationToOwnerNode",
     "EmitOfferCaseParticipantToOwnerNode",
     "EmitRejectActorRecommendationNode",
+    "RecordRecommendationRecommenderNode",
 ]

--- a/vultron/core/behaviors/case/nodes/suggest_actor/emit.py
+++ b/vultron/core/behaviors/case/nodes/suggest_actor/emit.py
@@ -17,6 +17,9 @@
 
 Node classes:
 
+- :class:`RecordRecommendationRecommenderNode` — writes
+  ``recommendation_id → recommender_id`` into
+  ``VulnerabilityCase.recommendation_recommender_index`` (ADR-0035 DL-06-002).
 - :class:`EmitOfferCaseParticipantToOwnerNode` — transforms
   ``Offer(Actor, Case)`` into ``Offer(CaseParticipant)`` and DMs the Case Owner
   (CM-16-004).
@@ -39,8 +42,61 @@ from vultron.core.behaviors.helpers import DataLayerAction
 from vultron.core.behaviors.sync.commit_tree import (
     create_commit_log_entry_tree,
 )
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 from vultron.enums.roles import CVDRole
+
+
+class RecordRecommendationRecommenderNode(DataLayerAction):
+    """Write recommendation_id → recommender_id into core case state.
+
+    Runs as the first effect node in ``RecommendActorToCaseBT`` so downstream
+    Accept/Reject use cases can look up the recommender without re-reading the
+    stored wire Offer (ADR-0035 DL-06-002, CLP-10-005).
+
+    Idempotent: no-op when the index already holds the correct mapping.
+    Returns SUCCESS unconditionally so the tree continues even when the case
+    cannot be found (the subsequent routing nodes will handle that failure).
+    """
+
+    def __init__(
+        self,
+        recommendation_id: str,
+        recommender_id: str,
+        case_id: str,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self.recommendation_id = recommendation_id
+        self.recommender_id = recommender_id
+        self.case_id = case_id
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            return Status.SUCCESS
+
+        case = self.datalayer.read(self.case_id)
+        if not isinstance(case, VulnerabilityCase):
+            return Status.SUCCESS
+
+        if (
+            case.recommendation_recommender_index.get(self.recommendation_id)
+            != self.recommender_id
+        ):
+            case.recommendation_recommender_index[self.recommendation_id] = (
+                self.recommender_id
+            )
+            self.datalayer.save(case)
+            self.logger.debug(
+                "%s: recorded recommender '%s' for recommendation '%s'"
+                " in case '%s'",
+                self.name,
+                self.recommender_id,
+                self.recommendation_id,
+                self.case_id,
+            )
+
+        return Status.SUCCESS
 
 
 class EmitOfferCaseParticipantToOwnerNode(DataLayerAction):

--- a/vultron/core/behaviors/case/suggest_actor_tree.py
+++ b/vultron/core/behaviors/case/suggest_actor_tree.py
@@ -52,6 +52,7 @@ from vultron.core.behaviors.case.nodes.suggest_actor import (
     EmitRejectActorRecommendationNode,
     InviteInFlightNode,
     PendingOfferCaseParticipantNode,
+    RecordRecommendationRecommenderNode,
 )
 
 logger = logging.getLogger(__name__)
@@ -211,7 +212,14 @@ def create_recommend_actor_to_case_received_tree(
         name="RecommendActorToCaseBT",
         case_id=case_id,
         precondition_guards=[],
-        effect_nodes=[duplicate_or_fresh_selector],
+        effect_nodes=[
+            RecordRecommendationRecommenderNode(
+                recommendation_id=recommendation_id,
+                recommender_id=recommender_id,
+                case_id=case_id,
+            ),
+            duplicate_or_fresh_selector,
+        ],
     )
 
 

--- a/vultron/core/models/case.py
+++ b/vultron/core/models/case.py
@@ -72,6 +72,9 @@ class VulnerabilityCase(CoreObject):
     pending_embargo_proposal_index: dict[str, str] = Field(
         default_factory=dict
     )
+    recommendation_recommender_index: dict[str, str] = Field(
+        default_factory=dict
+    )
     case_activity: list[str] = Field(default_factory=list)
     genesis_hash: str = Field(
         default="",

--- a/vultron/core/use_cases/received/actor/offer_case_participant.py
+++ b/vultron/core/use_cases/received/actor/offer_case_participant.py
@@ -32,6 +32,7 @@ from vultron.core.behaviors.case.suggest_actor_tree import (
     create_receive_offer_case_participant_tree,
     create_reject_actor_recommendation_received_tree,
 )
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.events.actor import (
     AcceptOfferCaseParticipantReceivedEvent,
     OfferCaseParticipantReceivedEvent,
@@ -124,11 +125,12 @@ class AcceptOfferCaseParticipantReceivedUseCase:
         invitee_id = getattr(raw_invitee, "id_", raw_invitee)
         recommendation_id = getattr(inner_offer, "origin", None)
         recommender_id = None
-        if recommendation_id:
-            stored_offer = self._dl.read(recommendation_id)
-            if stored_offer is not None:
-                raw_actor = getattr(stored_offer, "actor", None)
-                recommender_id = getattr(raw_actor, "id_", raw_actor)
+        if recommendation_id and case_id:
+            case = self._dl.read(case_id)
+            if isinstance(case, VulnerabilityCase):
+                recommender_id = case.recommendation_recommender_index.get(
+                    recommendation_id
+                )
 
         if not case_id or not invitee_id:
             logger.warning(
@@ -189,11 +191,12 @@ class RejectOfferCaseParticipantReceivedUseCase:
         recommended_id = getattr(raw_invitee, "id_", None) or request.object_id
         recommendation_id = getattr(inner_offer, "origin", None)
         recommender_id = None
-        if recommendation_id:
-            stored_offer = self._dl.read(recommendation_id)
-            if stored_offer is not None:
-                raw_actor = getattr(stored_offer, "actor", None)
-                recommender_id = getattr(raw_actor, "id_", raw_actor)
+        if recommendation_id and case_id:
+            case = self._dl.read(case_id)
+            if isinstance(case, VulnerabilityCase):
+                recommender_id = case.recommendation_recommender_index.get(
+                    recommendation_id
+                )
 
         if not case_id:
             logger.warning(

--- a/vultron/core/use_cases/received/actor/suggest.py
+++ b/vultron/core/use_cases/received/actor/suggest.py
@@ -7,7 +7,6 @@ from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.case.suggest_actor_tree import (
     create_recommend_actor_to_case_received_tree,
 )
-from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.events.actor import (
     OfferActorToCaseReceivedEvent,
 )
@@ -20,31 +19,18 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _record_recommendation_recommender(
-    dl: CasePersistence,
-    case_id: str,
-    recommendation_id: str,
-    recommender_id: str,
-) -> None:
-    """Record recommendation_id → recommender_id in case core state (ADR-0035 DL-06)."""
-    case = dl.read(case_id)
-    if not isinstance(case, VulnerabilityCase):
-        return
-    if (
-        case.recommendation_recommender_index.get(recommendation_id)
-        == recommender_id
-    ):
-        return
-    case.recommendation_recommender_index[recommendation_id] = recommender_id
-    dl.save(case)
-
-
 class OfferActorToCaseReceivedUseCase:
     """CaseActor received Offer(Actor, Case) from a recommending participant.
 
     Delegates to :func:`create_recommend_actor_to_case_received_tree` via
     BTBridge to commit the ledger entry and DM Offer(CaseParticipant) to the
     Case Owner (CM-16-002..004, ADR-0026).
+
+    The BT's first effect node (RecordRecommendationRecommenderNode) writes
+    recommendation_id → recommender_id into
+    VulnerabilityCase.recommendation_recommender_index so downstream
+    Accept/Reject use cases can look up the recommender without re-reading the
+    stored wire Offer (ADR-0035 DL-06-002, CLP-10-005).
     """
 
     def __init__(
@@ -81,12 +67,6 @@ class OfferActorToCaseReceivedUseCase:
                 activity_id,
             )
             return
-
-        # ADR-0035 DL-06: record recommender as core state so Accept/Reject
-        # use cases can look it up without re-reading the stored wire Offer.
-        _record_recommendation_recommender(
-            self._dl, case_id, activity_id, recommender_id
-        )
 
         offer_content = getattr(request.activity, "content", None)
         if offer_content is not None and not isinstance(offer_content, str):

--- a/vultron/core/use_cases/received/actor/suggest.py
+++ b/vultron/core/use_cases/received/actor/suggest.py
@@ -7,6 +7,7 @@ from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.case.suggest_actor_tree import (
     create_recommend_actor_to_case_received_tree,
 )
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.events.actor import (
     OfferActorToCaseReceivedEvent,
 )
@@ -17,6 +18,25 @@ if TYPE_CHECKING:
     from vultron.core.ports.trigger_activity import TriggerActivityPort
 
 logger = logging.getLogger(__name__)
+
+
+def _record_recommendation_recommender(
+    dl: CasePersistence,
+    case_id: str,
+    recommendation_id: str,
+    recommender_id: str,
+) -> None:
+    """Record recommendation_id → recommender_id in case core state (ADR-0035 DL-06)."""
+    case = dl.read(case_id)
+    if not isinstance(case, VulnerabilityCase):
+        return
+    if (
+        case.recommendation_recommender_index.get(recommendation_id)
+        == recommender_id
+    ):
+        return
+    case.recommendation_recommender_index[recommendation_id] = recommender_id
+    dl.save(case)
 
 
 class OfferActorToCaseReceivedUseCase:
@@ -61,6 +81,12 @@ class OfferActorToCaseReceivedUseCase:
                 activity_id,
             )
             return
+
+        # ADR-0035 DL-06: record recommender as core state so Accept/Reject
+        # use cases can look it up without re-reading the stored wire Offer.
+        _record_recommendation_recommender(
+            self._dl, case_id, activity_id, recommender_id
+        )
 
         offer_content = getattr(request.activity, "content", None)
         if offer_content is not None and not isinstance(offer_content, str):

--- a/vultron/core/use_cases/triggers/actor.py
+++ b/vultron/core/use_cases/triggers/actor.py
@@ -42,10 +42,7 @@ from vultron.core.use_cases.triggers.requests import (
     OfferCaseManagerRoleTriggerRequest,
     SuggestActorToCaseTriggerRequest,
 )
-from vultron.errors import (
-    VultronNotFoundError,
-    VultronValidationError,
-)
+from vultron.errors import VultronNotFoundError
 
 logger = logging.getLogger(__name__)
 
@@ -160,16 +157,9 @@ class SvcAcceptCaseInviteUseCase(SvcBTTriggerBase):
         actor = resolve_actor(request.actor_id, self._dl)
         self._actor_id = actor.id_
 
-        raw_invite = self._dl.read(request.invite_id)
-        if raw_invite is None:
+        if self._dl.read(request.invite_id) is None:
             raise VultronNotFoundError(
                 "RmInviteToCaseActivity", request.invite_id
-            )
-
-        invite_type = getattr(raw_invite, "type_", "")
-        if invite_type != "Invite":
-            raise VultronValidationError(
-                f"'{request.invite_id}' is not an RmInviteToCaseActivity"
             )
 
         self._invite_id = request.invite_id

--- a/vultron/wire/as2/vocab/objects/vulnerability_case.py
+++ b/vultron/wire/as2/vocab/objects/vulnerability_case.py
@@ -128,6 +128,10 @@ class as_VulnerabilityCase(VultronAS2Object):
         default_factory=dict
     )
 
+    recommendation_recommender_index: dict[str, str] = Field(
+        default_factory=dict
+    )
+
     case_activity: list[as_Activity] = Field(default_factory=list)
 
     # case relationships


### PR DESCRIPTION
- closes #1520
- closes #1552 

## Summary

Closes #1520. Eliminates three `dl.read(activity_id)` semantic re-reads from core per ADR-0035 DL-06 (Category B migration from audit #1506):

- `AcceptOfferCaseParticipantReceivedUseCase.execute()` — no longer reads stored recommendation `Offer` to recover recommender actor id
- `RejectOfferCaseParticipantReceivedUseCase.execute()` — same
- `SvcAcceptCaseInviteUseCase._prepare()` — no longer reads stored `Invite` purely to type-check it

### Approach

**Recommender lookup (AC-1/AC-3):** Added `recommendation_recommender_index: dict[str, str]` (recommendation_id → recommender_actor_id) to `VulnerabilityCase` and its wire counterpart `as_VulnerabilityCase`. `OfferActorToCaseReceivedUseCase.execute()` populates the index via `_record_recommendation_recommender()` (module-level helper, not inside `execute()` body, per CLP-10-005 AST ratchet) after local-actor guard passes. `AcceptOfferCaseParticipantReceivedUseCase` and `RejectOfferCaseParticipantReceivedUseCase` now read `case.recommendation_recommender_index.get(recommendation_id)` instead of calling `dl.read(recommendation_id)`.

**Invite type check (AC-2/AC-3):** Removed the `invite_type != "Invite"` guard in `SvcAcceptCaseInviteUseCase._prepare()`. Invites are always stored as `as_Invite` objects by `invite_actor_to_case()` — the type check was redundant. Existence check (`dl.read(...) is None`) retained. Removed now-unused `VultronValidationError` import.

**AC-4:** Neither `"Invite"` nor `"Offer"` were in `ACTIVITY_TYPE_EXEMPTIONS` — no ratchet changes needed.

**AC-5:** Added `test_recommender_notified_via_core_state` to both Accept and Reject test classes; added `test_offer_actor_populates_recommendation_recommender_index` (write-side AC-1); added `test_accept_no_type_check_on_invite` documenting removed guard.

### Follow-up

#1552 — move `recommendation_recommender_index` write into a BT leaf node (CLP-10-005 refinement; out of scope here).

## Test plan

- [x] `uv run pytest test/core/use_cases/received/actor/ test/core/use_cases/triggers/test_actor_triggers.py test/architecture/` — 116 passed
- [x] `uv run pytest` — 5142 passed, 0 failed
- [x] `uv run black vultron/ test/` — clean
- [x] `uv run flake8 vultron/ test/` — clean
- [x] `uv run mypy` — no issues
- [x] `uv run pyright` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)