### PR TITLE
feat: migrate embargo_lifecycle.py em_state guards to ReadEmStateNode/WriteEmStateNode

### DIFF
--- a/.agents/skills/load-specs/REFERENCE.md
+++ b/.agents/skills/load-specs/REFERENCE.md
@@ -46,16 +46,16 @@ Edge `rel_type` values: `constrains`, `depends_on`, `derives_from`, `implements`
 
 ```bash
 # Full dump
-uv run spec-dump
+PYTHONPATH= uv run spec-dump
 
 # Write to file
-uv run spec-dump > /tmp/specs.json
+PYTHONPATH= uv run spec-dump > /tmp/specs.json
 
 # Count requirements
-uv run spec-dump | python -c "import json,sys; r=json.load(sys.stdin); print(len(r['requirements']))"
+PYTHONPATH= uv run spec-dump | python -c "import json,sys; r=json.load(sys.stdin); print(len(r['requirements']))"
 
 # Filter MUST requirements
-uv run spec-dump | python -c "
+PYTHONPATH= uv run spec-dump | python -c "
 import json, sys
 data = json.load(sys.stdin)
 musts = [r for r in data['requirements'] if r['priority'] == 'MUST']

--- a/.agents/skills/load-specs/SKILL.md
+++ b/.agents/skills/load-specs/SKILL.md
@@ -22,7 +22,7 @@ outputs:
 # Skill: Load Specs
 
 ```bash
-uv run spec-dump
+PYTHONPATH= uv run spec-dump
 ```
 
 Do **not** read raw `specs/*.yaml` files directly — the JSON export resolves inheritance and flattens group nesting. See [REFERENCE.md](REFERENCE.md) for the full output structure and field definitions.

--- a/.agents/skills/orient-agent/SKILL.md
+++ b/.agents/skills/orient-agent/SKILL.md
@@ -20,7 +20,7 @@ Read `docs/reference/glossary.md`.
 
 ### Step 2 — Load specs
 
-Run `uv run spec-dump 2>&1`. Capture the output. Do **not** read raw
+Run `PYTHONPATH= uv run spec-dump 2>&1`. Capture the output. Do **not** read raw
 `specs/*.yaml` files directly.
 
 ### Step 3 — Read agent rules, completeness doctrine, active notes index, and ADR index

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -87,7 +87,7 @@ Check against `.agents/skills/shared/pr-body-guide.md`:
 1. Identify domains from changed file paths (e.g., `wire/as2/`, `core/behaviors/`,
    `adapters/`, `demo/`).
 2. Invoke `deepen-context` with hints matching those domains.
-3. Load specs relevant to the changed domains via `load-specs` or `uv run spec-dump`.
+3. Load specs relevant to the changed domains via `load-specs` or `PYTHONPATH= uv run spec-dump`.
 
 ### Phase 5 — Spec and Notes Conformance
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,8 @@ Agents MUST follow these rules when generating, modifying, or reviewing code.
 
 ## Agent Quickstart
 
-- **Load specs first**: `uv run spec-dump` (or `load-specs` skill) — never read
-  raw `specs/*.yaml`.
+- **Load specs first**: `PYTHONPATH= uv run spec-dump` — never read raw
+  `specs/*.yaml`. The `PYTHONPATH=` prefix is required; see pitfall below.
 - Pipeline: FastAPI inbox → AS2 parser → semantic extraction
   (`vultron/wire/as2/extractor.py`) → dispatcher → use-case callable
   (`vultron/core/use_cases/`).
@@ -158,7 +158,7 @@ See `notes/parallel-development.md`.
 
 ## Change Protocol
 
-For non-trivial changes: state assumptions → load specs (`uv run spec-dump`) →
+For non-trivial changes: state assumptions → load specs (`PYTHONPATH= uv run spec-dump`) →
 review `notes/` → describe intent → apply minimal diff → update/add tests →
 call out risks.
 
@@ -366,6 +366,12 @@ See [notes/agents-md-structure.md](notes/agents-md-structure.md) for routing pol
   [notes/datalayer-design.md](notes/datalayer-design.md).
 - **Always Use `uv run <tool>` in Devcontainer** — bare entrypoints use baked
   image, not mounted working tree. See #1460.
+- **`PYTHONPATH=/app` Contaminates Imports** — the devcontainer sets
+  `PYTHONPATH=/app`, which causes `uv run spec-dump` (and any other entry
+  point) to resolve `vultron` imports from the stale baked image at `/app`
+  instead of the editable install. Always prefix with `PYTHONPATH=` to clear
+  it: `PYTHONPATH= uv run spec-dump`. Same applies to any `uv run <entrypoint>`
+  that touches `vultron.*` modules.
 - **Walrus Operator for Single-Assignment Guard Blocks** —
   `if (f := self._require_factory()) is not None: return f`.
 - **Silent `None` Returns and Fake `SUCCESS` Are the Same Bug** — raise

--- a/plan/history/2607/implementation/ISSUE-1474.md
+++ b/plan/history/2607/implementation/ISSUE-1474.md
@@ -1,0 +1,18 @@
+---
+source: ISSUE-1474
+timestamp: '2026-07-20T21:07:09.439094+00:00'
+title: Migrate embargo_lifecycle em_state guards to BT nodes
+type: implementation
+---
+
+## Issue #1474 — Migrate core/services/embargo_lifecycle.py guards to BT nodes
+
+Extracted the 5 inline em_state reads and 4 em_state mutations from EmbargoLifecycle service methods into named ReadEmStateNode (DataLayerCondition) and WriteEmStateNode (DataLayerAction) BT nodes.
+
+- New file: vultron/core/behaviors/embargo/nodes/em_state.py
+- All BT callers (lifecycle.py, proposal.py, case/nodes/embargo.py) now pass em_before via ReadEmStateNode
+- Service uses caller_owns_em_io guard to skip read/write when em_before is supplied
+- 15 new tests in test_em_state.py; 4 new service-layer tests in TestCallerOwnsEmIo
+- Follow-up #1554 tracks remaining inline accesses in SetEmbargoActiveNode / ApplyEmbargoTeardownNode (state-sync override paths)
+
+PR: <https://github.com/CERTCC/Vultron/pull/1555>

--- a/plan/incoming/learnings/20260720-caller-owns-em-io-guard-pattern.md
+++ b/plan/incoming/learnings/20260720-caller-owns-em-io-guard-pattern.md
@@ -1,0 +1,33 @@
+---
+title: "caller_owns_em_io guard pattern for BT/service layer handoff"
+type: learning
+timestamp: "2026-07-20"
+source: ISSUE-1474
+---
+
+When a BT node needs to read state before calling a service and write state after,
+use a `caller_owns_em_io` bool in the service method to distinguish two paths:
+
+- **BT path** (`em_before` passed): caller already read and will write state via
+  named BT nodes. Service skips its own DataLayer read/write.
+- **Legacy path** (`em_before=None`): service reads and writes internally as before.
+
+This preserves backward compatibility for callers that haven't been updated yet,
+while letting BT nodes own the DataLayer IO for the operations they orchestrate.
+
+The guard pattern:
+
+```python
+caller_owns_em_io = em_before is not None
+if not caller_owns_em_io:
+    em_before = EM(case.current_status.em_state)
+assert em_before is not None  # for mypy: guaranteed by branch above
+# ...compute em_after...
+if not caller_owns_em_io and em_after != em_before:
+    case.current_status.em_state = em_after
+    case_mutated = True
+```
+
+The `assert em_before is not None` after the conditional is required for mypy to
+narrow the type from `EM | None` to `EM`; without it mypy keeps the union and
+flags downstream uses.

--- a/plan/incoming/learnings/20260720-pythonpath-app-contaminates-uv-run.md
+++ b/plan/incoming/learnings/20260720-pythonpath-app-contaminates-uv-run.md
@@ -1,0 +1,33 @@
+---
+title: PYTHONPATH=/app contaminates uv run entrypoints in devcontainer
+type: learning
+timestamp: 2026-07-20T00:00:00Z
+source: ISSUE-1474 build session
+---
+
+The devcontainer sets `PYTHONPATH=/app` in the shell environment. When `uv run
+spec-dump` (or any `uv run <entrypoint>`) is invoked, Python resolves `vultron`
+imports from `/app` (the stale baked Docker image) instead of the editable
+install at `/workspaces/vultron_pinky`. This causes errors like:
+
+```text
+ValidationError: 1 validation error for SpecFile
+kind
+  Field required
+```
+
+because `/app/vultron/metadata/specs/schema.py` is from an older version that
+required `kind` at the file level, while the spec YAMLs have been migrated to
+require it at the item level.
+
+**Fix**: prefix all `uv run <entrypoint>` calls that import from `vultron` with
+`PYTHONPATH=` to clear the contaminated env var:
+
+```bash
+PYTHONPATH= uv run spec-dump
+PYTHONPATH= uv run pytest ...
+```
+
+AGENTS.md, orient-agent/SKILL.md, load-specs/SKILL.md, and
+load-specs/REFERENCE.md have all been updated to use `PYTHONPATH= uv run
+spec-dump`.

--- a/test/core/behaviors/case/nodes/test_embargo.py
+++ b/test/core/behaviors/case/nodes/test_embargo.py
@@ -21,6 +21,7 @@ Per specs/case-management.yaml CM-02, OX-03-001, CM-14-003.
 
 from datetime import datetime, timedelta, timezone
 from typing import Any, cast
+from unittest.mock import MagicMock
 
 import pytest
 from py_trees.common import Status
@@ -248,7 +249,9 @@ class TestInitializeDefaultEmbargoNode:
                         kwargs["transition_mode"].value,
                     )
                 )
-                return object()
+                result = MagicMock()
+                result.em_after = kwargs.get("em_before", EM.NONE)
+                return result
 
             def accept_embargo_invite(self, **kwargs: Any) -> Any:
                 calls.append(

--- a/test/core/behaviors/embargo/nodes/test_em_state.py
+++ b/test/core/behaviors/embargo/nodes/test_em_state.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Unit tests for ReadEmStateNode and WriteEmStateNode (em_state.py).
+
+Verifies AC-1, AC-2 of issue #1474: the em_state read/write BT nodes
+follow DataLayerCondition / DataLayerAction base class patterns and
+correctly replace the inline em_state accesses that previously lived in
+the EmbargoLifecycle service methods.
+"""
+
+from unittest.mock import MagicMock, PropertyMock
+
+import py_trees
+
+from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+from vultron.core.behaviors.embargo.nodes.em_state import (
+    ReadEmStateNode,
+    WriteEmStateNode,
+)
+from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.states.em import EM
+from vultron.wire.as2.vocab.objects.vulnerability_case import (  # noqa: F401
+    as_VulnerabilityCase,
+)
+
+from test.core.behaviors.embargo.nodes.conftest import (
+    make_case_and_embargo,
+    setup_blackboard,
+)
+
+
+class TestReadEmStateNodeInheritance:
+    """ReadEmStateNode follows the DataLayerCondition base class pattern (AC-2)."""
+
+    def test_is_data_layer_condition(self):
+        """ReadEmStateNode inherits from DataLayerCondition."""
+        node = ReadEmStateNode(
+            case_id="https://example.org/cases/test",
+            result_out={},
+        )
+        assert isinstance(node, DataLayerCondition)
+
+
+class TestReadEmStateNode:
+    """ReadEmStateNode reads em_state from a case and stores it in result_out."""
+
+    def test_returns_success_and_populates_em_before(self):
+        """SUCCESS when case found with valid em_state; stores EM in result_out."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = make_case_and_embargo("rsn1", em_state=EM.ACTIVE)
+        dl.create(case)
+        setup_blackboard(dl)
+
+        result_out: dict = {}
+        node = ReadEmStateNode(case_id=case.id_, result_out=result_out)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.SUCCESS
+        assert result_out["em_before"] == EM.ACTIVE
+
+    def test_reads_revise_state(self):
+        """SUCCESS when em_state is REVISE; returns EM.REVISE in result_out."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = make_case_and_embargo("rsn2", em_state=EM.REVISE)
+        dl.create(case)
+        setup_blackboard(dl)
+
+        result_out: dict = {}
+        node = ReadEmStateNode(case_id=case.id_, result_out=result_out)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.SUCCESS
+        assert result_out["em_before"] == EM.REVISE
+
+    def test_reads_none_state(self):
+        """SUCCESS when em_state is NONE; returns EM.NONE in result_out."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = make_case_and_embargo("rsn3", em_state=EM.NONE)
+        case.active_embargo = None
+        dl.create(case)
+        setup_blackboard(dl)
+
+        result_out: dict = {}
+        node = ReadEmStateNode(case_id=case.id_, result_out=result_out)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.SUCCESS
+        assert result_out["em_before"] == EM.NONE
+
+    def test_returns_failure_when_case_missing(self):
+        """FAILURE when case_id is not in the DataLayer."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        setup_blackboard(dl)
+
+        result_out: dict = {}
+        node = ReadEmStateNode(
+            case_id="https://example.org/cases/nonexistent",
+            result_out=result_out,
+        )
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.FAILURE
+        assert "error" in result_out
+
+    def test_returns_failure_when_datalayer_not_set(self):
+        """FAILURE when datalayer is None (direct invocation without BTBridge)."""
+        result_out: dict = {}
+        node = ReadEmStateNode(
+            case_id="https://example.org/cases/any",
+            result_out=result_out,
+        )
+        node.datalayer = None  # explicitly unset
+
+        status = node.update()
+
+        assert status == py_trees.common.Status.FAILURE
+
+    def test_returns_failure_when_current_status_raises_value_error(self):
+        """FAILURE when case.current_status raises ValueError (no materialized status)."""
+        from vultron.core.models.case import VulnerabilityCase
+
+        mock_case = MagicMock(spec=VulnerabilityCase)
+        type(mock_case).current_status = PropertyMock(
+            side_effect=ValueError("no materialized CaseStatus")
+        )
+        mock_dl = MagicMock()
+        mock_dl.read.return_value = mock_case
+
+        result_out: dict = {}
+        node = ReadEmStateNode(
+            case_id="https://example.org/cases/any",
+            result_out=result_out,
+        )
+        node.datalayer = mock_dl
+
+        status = node.update()
+
+        assert status == py_trees.common.Status.FAILURE
+        assert "error" in result_out
+
+
+class TestWriteEmStateNodeInheritance:
+    """WriteEmStateNode follows the DataLayerAction base class pattern (AC-2)."""
+
+    def test_is_data_layer_action(self):
+        """WriteEmStateNode inherits from DataLayerAction."""
+        node = WriteEmStateNode(
+            case_id="https://example.org/cases/test",
+            result_out={},
+        )
+        assert isinstance(node, DataLayerAction)
+
+
+class TestWriteEmStateNode:
+    """WriteEmStateNode writes em_after from result_out to the case."""
+
+    def test_writes_em_after_and_persists(self):
+        """SUCCESS and em_state updated on case when result_out has em_after."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = make_case_and_embargo("wsn1", em_state=EM.PROPOSED)
+        case.active_embargo = None
+        dl.create(case)
+        setup_blackboard(dl)
+
+        result_out: dict = {"em_after": EM.ACTIVE}
+        node = WriteEmStateNode(case_id=case.id_, result_out=result_out)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.SUCCESS
+
+        updated_case = dl.read(case.id_)
+        assert isinstance(updated_case, VulnerabilityCase)
+        assert updated_case.current_status.em_state == EM.ACTIVE
+
+    def test_idempotent_when_already_at_target(self):
+        """SUCCESS without saving when em_state already equals em_after."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = make_case_and_embargo("wsn2", em_state=EM.ACTIVE)
+        dl.create(case)
+        setup_blackboard(dl)
+
+        result_out: dict = {"em_after": EM.ACTIVE}
+        node = WriteEmStateNode(case_id=case.id_, result_out=result_out)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.SUCCESS
+
+    def test_returns_failure_when_em_after_missing(self):
+        """FAILURE when result_out['em_after'] is absent."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = make_case_and_embargo("wsn3", em_state=EM.ACTIVE)
+        dl.create(case)
+        setup_blackboard(dl)
+
+        result_out: dict = {}  # no em_after key
+        node = WriteEmStateNode(case_id=case.id_, result_out=result_out)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.FAILURE
+
+    def test_returns_failure_when_em_after_not_em_type(self):
+        """FAILURE when result_out['em_after'] is not an EM enum value."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = make_case_and_embargo("wsn4", em_state=EM.ACTIVE)
+        dl.create(case)
+        setup_blackboard(dl)
+
+        result_out: dict = {"em_after": "ACTIVE"}  # string, not EM enum
+        node = WriteEmStateNode(case_id=case.id_, result_out=result_out)
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.FAILURE
+
+    def test_returns_failure_when_case_missing(self):
+        """FAILURE when case_id not found in the DataLayer."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        setup_blackboard(dl)
+
+        result_out: dict = {"em_after": EM.EXITED}
+        node = WriteEmStateNode(
+            case_id="https://example.org/cases/nonexistent",
+            result_out=result_out,
+        )
+        bt = py_trees.trees.BehaviourTree(root=node)
+        bt.setup()
+        bt.tick()
+
+        assert node.status == py_trees.common.Status.FAILURE
+
+    def test_returns_failure_when_datalayer_not_set(self):
+        """FAILURE when datalayer is None (direct invocation without BTBridge)."""
+        result_out: dict = {"em_after": EM.EXITED}
+        node = WriteEmStateNode(
+            case_id="https://example.org/cases/any",
+            result_out=result_out,
+        )
+        node.datalayer = None
+
+        status = node.update()
+
+        assert status == py_trees.common.Status.FAILURE
+
+
+class TestReadWriteEmStateIntegration:
+    """Round-trip: ReadEmStateNode → WriteEmStateNode applies the state change."""
+
+    def test_read_then_write_transitions_em_state(self):
+        """Read PROPOSED, write ACTIVE: case persists EM.ACTIVE."""
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        case, _ = make_case_and_embargo("rw1", em_state=EM.PROPOSED)
+        case.active_embargo = None
+        dl.create(case)
+        setup_blackboard(dl)
+
+        result_out: dict = {}
+
+        read_node = ReadEmStateNode(case_id=case.id_, result_out=result_out)
+        read_node.datalayer = dl
+        assert read_node.update() == py_trees.common.Status.SUCCESS
+        assert result_out["em_before"] == EM.PROPOSED
+
+        result_out["em_after"] = EM.ACTIVE
+        write_node = WriteEmStateNode(case_id=case.id_, result_out=result_out)
+        write_node.datalayer = dl
+        assert write_node.update() == py_trees.common.Status.SUCCESS
+
+        updated_case = dl.read(case.id_)
+        assert isinstance(updated_case, VulnerabilityCase)
+        assert updated_case.current_status.em_state == EM.ACTIVE

--- a/test/core/services/test_embargo_lifecycle.py
+++ b/test/core/services/test_embargo_lifecycle.py
@@ -15,6 +15,10 @@ Coverage added by #1454 (AC-1 to AC-3): P/X/A embargo-eligibility guards
   - propose_embargo OBSERVED bypasses guard
   - accept_embargo_invite STRICT raises when pxa_state != pxa
   - accept_embargo_invite OBSERVED bypasses guard
+
+Coverage added by #1474 (AC-1): caller_owns_em_io guard
+  - service does not write em_state when em_before is supplied (BT path)
+  - service still writes em_state when em_before is not supplied (legacy path)
 """
 
 from collections.abc import Generator
@@ -1097,3 +1101,101 @@ def test_reject_embargo_invite_observed_revise_pxa_bypasses_guard(
     )
 
     assert result.em_after == EM.ACTIVE
+
+
+# ---------------------------------------------------------------------------
+# #1474 AC-1: caller_owns_em_io guard tests
+# ---------------------------------------------------------------------------
+
+
+class TestCallerOwnsEmIo:
+    """When em_before is supplied, the service skips its own em_state read/write."""
+
+    def test_propose_does_not_write_em_state_when_em_before_supplied(
+        self,
+        owner_and_dl: tuple[as_Service, SqliteDataLayer],
+    ) -> None:
+        """propose_embargo does not mutate em_state when em_before is supplied."""
+        owner, dl = owner_and_dl
+        case, _ = _make_case(dl, owner.id_, em_state=EM.NONE)
+        embargo = _make_embargo(dl, case.id_)
+
+        lifecycle = EmbargoLifecycle(persistence=dl)
+        result = lifecycle.propose_embargo(
+            case_id=case.id_,
+            embargo_id=embargo.id_,
+            actor_id=owner.id_,
+            transition_mode=TransitionMode.STRICT,
+            em_before=EM.NONE,
+        )
+
+        assert result.em_after == EM.PROPOSED
+        # Service must NOT have written em_state; it stays at the initial value
+        refreshed = cast(as_VulnerabilityCase, dl.read(case.id_))
+        assert refreshed.current_status.em_state == EM.NONE
+
+    def test_propose_still_writes_em_state_on_legacy_path(
+        self,
+        owner_and_dl: tuple[as_Service, SqliteDataLayer],
+    ) -> None:
+        """propose_embargo writes em_state when em_before is not supplied (legacy)."""
+        owner, dl = owner_and_dl
+        case, _ = _make_case(dl, owner.id_, em_state=EM.NONE)
+        embargo = _make_embargo(dl, case.id_)
+
+        lifecycle = EmbargoLifecycle(persistence=dl)
+        result = lifecycle.propose_embargo(
+            case_id=case.id_,
+            embargo_id=embargo.id_,
+            actor_id=owner.id_,
+            transition_mode=TransitionMode.STRICT,
+        )
+
+        assert result.em_after == EM.PROPOSED
+        refreshed = cast(as_VulnerabilityCase, dl.read(case.id_))
+        assert refreshed.current_status.em_state == EM.PROPOSED
+
+    def test_reject_does_not_write_em_state_when_em_before_supplied(
+        self,
+        owner_and_dl: tuple[as_Service, SqliteDataLayer],
+    ) -> None:
+        """reject_embargo_invite does not mutate em_state when em_before is supplied."""
+        owner, dl = owner_and_dl
+        case, _ = _make_case(dl, owner.id_, em_state=EM.PROPOSED)
+        embargo = _make_embargo(dl, case.id_)
+
+        lifecycle = EmbargoLifecycle(persistence=dl)
+        result = lifecycle.reject_embargo_invite(
+            case_id=case.id_,
+            embargo_id=embargo.id_,
+            actor_id=owner.id_,
+            transition_mode=TransitionMode.STRICT,
+            em_before=EM.PROPOSED,
+        )
+
+        assert result.em_after == EM.NONE
+        refreshed = cast(as_VulnerabilityCase, dl.read(case.id_))
+        assert refreshed.current_status.em_state == EM.PROPOSED
+
+    def test_terminate_does_not_write_em_state_when_em_before_supplied(
+        self,
+        owner_and_dl: tuple[as_Service, SqliteDataLayer],
+    ) -> None:
+        """terminate_active_embargo does not mutate em_state when em_before is supplied."""
+        owner, dl = owner_and_dl
+        case, _ = _make_case(dl, owner.id_, em_state=EM.ACTIVE)
+        embargo = _make_embargo(dl, case.id_)
+        case.active_embargo = embargo.id_
+        dl.save(case)
+
+        lifecycle = EmbargoLifecycle(persistence=dl)
+        result = lifecycle.terminate_active_embargo(
+            case_id=case.id_,
+            actor_id=owner.id_,
+            transition_mode=TransitionMode.STRICT,
+            em_before=EM.ACTIVE,
+        )
+
+        assert result.em_after == EM.EXITED
+        refreshed = cast(as_VulnerabilityCase, dl.read(case.id_))
+        assert refreshed.current_status.em_state == EM.ACTIVE

--- a/vultron/core/behaviors/case/nodes/embargo.py
+++ b/vultron/core/behaviors/case/nodes/embargo.py
@@ -226,13 +226,47 @@ class AdvanceEMStateToActiveNode(DataLayerAction):
             )
             return Status.FAILURE
 
+        status = self._propose_with_em_io(case_id, embargo_id)
+        if status != Status.SUCCESS:
+            return status
+
+        self.blackboard.default_embargo_initialized = True
+        return Status.SUCCESS
+
+    def _propose_with_em_io(self, case_id: str, embargo_id: str) -> Status:
+        """Run propose_embargo with ReadEmStateNode / WriteEmStateNode (AC-1)."""
+        assert (
+            self.datalayer is not None
+        )  # caller guards; here for type narrowing
+        assert self.actor_id is not None
+
+        from vultron.core.behaviors.embargo.nodes.em_state import (
+            ReadEmStateNode,
+            WriteEmStateNode,
+        )
+
+        em_result_out: dict[str, object] = {}
+        read_node = ReadEmStateNode(case_id=case_id, result_out=em_result_out)
+        read_node.datalayer = self.datalayer
+        if read_node.update() != Status.SUCCESS:
+            self.logger.error(
+                "%s: Failed to read em_state for case '%s': %s",
+                self.name,
+                case_id,
+                read_node.feedback_message,
+            )
+            return Status.FAILURE
+        em_before = em_result_out["em_before"]
+        assert isinstance(em_before, EM)
+
         lifecycle = EmbargoLifecycle(persistence=self.datalayer)
         try:
-            lifecycle.propose_embargo(
+            result = lifecycle.propose_embargo(
                 case_id=case_id,
                 embargo_id=embargo_id,
                 actor_id=self.actor_id,
                 transition_mode=TransitionMode.STRICT,
+                em_before=em_before,
             )
         except VultronError as exc:
             self.logger.error(
@@ -244,7 +278,21 @@ class AdvanceEMStateToActiveNode(DataLayerAction):
             )
             return Status.FAILURE
 
-        self.blackboard.default_embargo_initialized = True
+        if result.em_after != em_before:
+            em_result_out["em_after"] = result.em_after
+            write_node = WriteEmStateNode(
+                case_id=case_id, result_out=em_result_out
+            )
+            write_node.datalayer = self.datalayer
+            if write_node.update() != Status.SUCCESS:
+                self.logger.error(
+                    "%s: Failed to write em_state for case '%s': %s",
+                    self.name,
+                    case_id,
+                    write_node.feedback_message,
+                )
+                return Status.FAILURE
+
         return Status.SUCCESS
 
 

--- a/vultron/core/behaviors/embargo/__init__.py
+++ b/vultron/core/behaviors/embargo/__init__.py
@@ -14,6 +14,7 @@ from vultron.core.behaviors.embargo.nodes import (
     PersistEmbargoEventNode,
     ProposeEmbargoLifecycleNode,
     ReadEmbargoIdNode,
+    ReadEmStateNode,
     RecordParticipantAcceptanceNode,
     RejectEmbargoLifecycleNode,
     RemoveFromProposedEmbargoesNode,
@@ -24,6 +25,7 @@ from vultron.core.behaviors.embargo.nodes import (
     UpdateParticipantEmbargoPecNode,
     ValidateCaseExistsNode,
     ValidateEmbargoRevisionStateNode,
+    WriteEmStateNode,
 )
 
 __all__ = [
@@ -36,6 +38,7 @@ __all__ = [
     "PersistEmbargoEventNode",
     "ProposeEmbargoLifecycleNode",
     "ReadEmbargoIdNode",
+    "ReadEmStateNode",
     "RecordParticipantAcceptanceNode",
     "RejectEmbargoLifecycleNode",
     "RemoveFromProposedEmbargoesNode",
@@ -46,4 +49,5 @@ __all__ = [
     "UpdateParticipantEmbargoPecNode",
     "ValidateCaseExistsNode",
     "ValidateEmbargoRevisionStateNode",
+    "WriteEmStateNode",
 ]

--- a/vultron/core/behaviors/embargo/nodes/__init__.py
+++ b/vultron/core/behaviors/embargo/nodes/__init__.py
@@ -21,6 +21,10 @@ Re-exports all public node classes from submodules for backward compatibility.
 from vultron.core.behaviors.embargo.nodes.cascade import (
     PersistEmbargoEventNode,
 )
+from vultron.core.behaviors.embargo.nodes.em_state import (
+    ReadEmStateNode,
+    WriteEmStateNode,
+)
 from vultron.core.behaviors.embargo.nodes.conditions import (
     HasActiveEmbargoNode,
     HasCaseStatusesNode,
@@ -58,6 +62,9 @@ __all__ = [
     "HasCaseStatusesNode",
     "LookupParticipantNode",
     "OptionalLookupParticipantNode",
+    # EM state read/write (AC-1 of issue #1474)
+    "ReadEmStateNode",
+    "WriteEmStateNode",
     # Teardown
     "ApplyEmbargoTeardownNode",
     "RemoveFromProposedEmbargoesNode",

--- a/vultron/core/behaviors/embargo/nodes/em_state.py
+++ b/vultron/core/behaviors/embargo/nodes/em_state.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""EM state read/write BT nodes for the embargo lifecycle.
+
+These nodes extract the em_state guard reads and mutations that previously
+lived in ``vultron/core/services/embargo_lifecycle.py``, moving them into
+the BT layer as named ``DataLayerCondition`` / ``DataLayerAction`` nodes.
+
+AC-1 of issue #1474: the service layer no longer directly inspects or
+mutates ``case.current_status.em_state`` — that responsibility belongs here.
+AC-2: nodes follow the ``DataLayerCondition`` / ``DataLayerAction`` base class
+pattern from ``vultron/core/behaviors/helpers.py``.
+AC-3: ``WriteEmStateNode`` is idempotent — when the current state already
+equals the target it returns SUCCESS without calling ``datalayer.save``.
+Callers that require an active embargo (e.g. terminate / accept) must place
+a ``HasActiveEmbargoNode`` guard earlier in the BT sequence to enforce the
+``EmbargoedCase`` precondition before reaching this node.
+"""
+
+from py_trees.common import Status
+
+from vultron.core.behaviors.helpers import (
+    DataLayerAction,
+    DataLayerCondition,
+)
+from vultron.core.models.case import VulnerabilityCase
+from vultron.core.states.em import EM
+from vultron.errors import VultronValidationError
+
+
+class ReadEmStateNode(DataLayerCondition):
+    """Read the current EM state from a case and write it to result_out.
+
+    Replaces the inline ``em_before = EM(case.current_status.em_state)`` reads
+    that previously appeared in every ``EmbargoLifecycle`` service method.
+
+    On success the EM enum value is stored in ``result_out["em_before"]``
+    so downstream service calls can receive it as a parameter rather than
+    re-reading the DataLayer.
+
+    Returns SUCCESS when the case is found and a valid EM state is available.
+    Returns FAILURE when:
+    - the DataLayer is unavailable,
+    - the case cannot be found, or
+    - the EM state field cannot be coerced to a valid ``EM`` enum value.
+
+    Blackboard contract:
+    - Reads: ``datalayer`` (set by BTBridge)
+    - Writes: nothing (side-effects flow through ``result_out``)
+    """
+
+    def __init__(
+        self,
+        case_id: str,
+        result_out: dict[str, object],
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._case_id = case_id
+        self._result_out = result_out
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.feedback_message = "DataLayer not available"
+            return Status.FAILURE
+
+        case = self.datalayer.read(self._case_id)
+        if not isinstance(case, VulnerabilityCase):
+            err = VultronValidationError(
+                f"Case '{self._case_id}' not found or invalid."
+            )
+            self._result_out["error"] = err
+            self.feedback_message = str(err)
+            return Status.FAILURE
+
+        try:
+            em_state = EM(case.current_status.em_state)
+        except (ValueError, KeyError):
+            err = VultronValidationError(
+                f"Case '{self._case_id}' has no materialized CaseStatus"
+                f" or an invalid em_state value."
+            )
+            self._result_out["error"] = err
+            self.feedback_message = str(err)
+            self.logger.warning("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
+
+        self._result_out["em_before"] = em_state
+        self.feedback_message = (
+            f"Case '{self._case_id}' em_state={em_state.value}"
+        )
+        self.logger.debug("%s: %s", self.name, self.feedback_message)
+        return Status.SUCCESS
+
+
+class WriteEmStateNode(DataLayerAction):
+    """Write a computed EM state back to the case and persist it.
+
+    Replaces the inline ``case.current_status.em_state = em_after`` mutations
+    that previously appeared in every ``EmbargoLifecycle`` service method.
+
+    Reads the target EM value from ``result_out["em_after"]`` (written by the
+    preceding service-call node) and applies it to the case only when the
+    value differs from the current state (idempotent).
+
+    Returns SUCCESS when:
+    - the case is persisted with the new EM state, or
+    - the current state already equals the target (idempotent no-op).
+
+    Returns FAILURE when:
+    - the DataLayer is unavailable,
+    - the case cannot be found, or
+    - ``result_out["em_after"]`` is absent or not a valid ``EM`` enum value.
+
+    AC-3: where the operation semantics require an active embargo (e.g.
+    ``TerminateEmbargoLifecycleNode``), the caller should wrap the BT
+    sequence with a prior ``HasActiveEmbargoNode`` guard that enforces the
+    ``EmbargoedCase`` precondition before this node is reached.
+
+    Blackboard contract:
+    - Reads: ``datalayer`` (set by BTBridge)
+    - Writes: nothing (DataLayer mutation is the side effect)
+    """
+
+    def __init__(
+        self,
+        case_id: str,
+        result_out: dict[str, object],
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._case_id = case_id
+        self._result_out = result_out
+
+    def update(self) -> Status:
+        if self.datalayer is None:
+            self.feedback_message = "DataLayer not available"
+            return Status.FAILURE
+
+        em_after = self._result_out.get("em_after")
+        if not isinstance(em_after, EM):
+            self.feedback_message = (
+                f"result_out['em_after'] missing or not an EM value"
+                f" (got {em_after!r})"
+            )
+            self.logger.warning("%s: %s", self.name, self.feedback_message)
+            return Status.FAILURE
+
+        case = self.datalayer.read(self._case_id)
+        if not isinstance(case, VulnerabilityCase):
+            self.feedback_message = (
+                f"Case '{self._case_id}' not found or invalid."
+            )
+            return Status.FAILURE
+
+        current_em = case.current_status.em_state
+        if current_em == em_after:
+            self.feedback_message = (
+                f"Case '{self._case_id}' em_state already"
+                f" {em_after.value} — no-op"
+            )
+            self.logger.debug("%s: %s", self.name, self.feedback_message)
+            return Status.SUCCESS
+
+        case.current_status.em_state = em_after
+        self.datalayer.save(case)
+        self.feedback_message = (
+            f"Case '{self._case_id}' em_state {current_em} → {em_after.value}"
+        )
+        self.logger.info("%s: %s", self.name, self.feedback_message)
+        return Status.SUCCESS

--- a/vultron/core/behaviors/embargo/nodes/lifecycle.py
+++ b/vultron/core/behaviors/embargo/nodes/lifecycle.py
@@ -20,6 +20,10 @@ from typing import Any
 import py_trees
 from py_trees.common import Status
 
+from vultron.core.behaviors.embargo.nodes.em_state import (
+    ReadEmStateNode,
+    WriteEmStateNode,
+)
 from vultron.core.behaviors.helpers import DataLayerAction
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.services.embargo_lifecycle import (
@@ -37,7 +41,6 @@ from vultron.core.use_cases._helpers import add_activity_to_outbox
 from vultron.errors import (
     VultronError,
     VultronInvalidStateTransitionError,
-    VultronValidationError,
 )
 
 
@@ -47,6 +50,9 @@ class ValidateEmbargoRevisionStateNode(DataLayerAction):
     Returns SUCCESS when EM state is ACTIVE or REVISE.  Returns FAILURE
     (with error in ``result_out``) for any other state — revision proposals
     require an active embargo; use propose-embargo for initial proposals.
+
+    Uses ``ReadEmStateNode`` to read the EM state (AC-1 of issue #1474) rather
+    than reading ``case.current_status.em_state`` inline.
     """
 
     def __init__(
@@ -64,20 +70,18 @@ class ValidateEmbargoRevisionStateNode(DataLayerAction):
             self.feedback_message = "DataLayer not available"
             return Status.FAILURE
 
-        case = self.datalayer.read(self._case_id)
-        if not isinstance(case, VulnerabilityCase):
-            not_found = VultronValidationError(
-                f"Case '{self._case_id}' not found or invalid."
-            )
-            self._result_out["error"] = not_found
-            self.feedback_message = str(not_found)
+        # AC-1: read em_state via named BT node, not inline.
+        read_node = ReadEmStateNode(
+            case_id=self._case_id, result_out=self._result_out
+        )
+        read_node.datalayer = self.datalayer
+        read_status = read_node.update()
+        if read_status != Status.SUCCESS:
+            self.feedback_message = read_node.feedback_message
             return Status.FAILURE
 
-        try:
-            em_state = case.current_status.em_state
-        except ValueError:
-            em_state = None
-        if em_state is None or not is_em_embargo_active(em_state):
+        em_state = self._result_out.get("em_before")
+        if not isinstance(em_state, EM) or not is_em_embargo_active(em_state):
             bad_state = VultronInvalidStateTransitionError(
                 f"Cannot propose embargo revision: case '{self._case_id}'"
                 f" EM state '{em_state}' does not allow a revision proposal."
@@ -91,7 +95,14 @@ class ValidateEmbargoRevisionStateNode(DataLayerAction):
 
 
 class _EmbargoLifecycleNode(DataLayerAction):
-    """Base node for EmbargoLifecycle strict-mode transitions."""
+    """Base node for EmbargoLifecycle strict-mode transitions.
+
+    Orchestrates the em_state read/compute/write cycle via named BT nodes
+    (AC-1 of issue #1474):
+    1. ``ReadEmStateNode`` reads ``em_state`` → ``result_out["em_before"]``.
+    2. The subclass ``_transition()`` calls the service with ``em_before``.
+    3. ``WriteEmStateNode`` writes ``result_out["em_after"]`` back to the case.
+    """
 
     def __init__(
         self, result_out: dict[str, object], name: str | None = None
@@ -99,8 +110,14 @@ class _EmbargoLifecycleNode(DataLayerAction):
         super().__init__(name=name or self.__class__.__name__)
         self._result_out = result_out
 
+    def _case_id(self) -> str:
+        raise NotImplementedError
+
     def _transition(
-        self, lifecycle: EmbargoLifecycle, actor_id: str
+        self,
+        _lifecycle: EmbargoLifecycle,
+        _actor_id: str,
+        _em_before: EM,
     ) -> EmbargoLifecycleResult:
         raise NotImplementedError
 
@@ -109,15 +126,40 @@ class _EmbargoLifecycleNode(DataLayerAction):
             self.feedback_message = "DataLayer or actor_id not available"
             return Status.FAILURE
 
+        # AC-1: read em_state via named BT node, not inline service code.
+        read_node = ReadEmStateNode(
+            case_id=self._case_id(), result_out=self._result_out
+        )
+        read_node.datalayer = self.datalayer
+        read_status = read_node.update()
+        if read_status != Status.SUCCESS:
+            self.feedback_message = read_node.feedback_message
+            return Status.FAILURE
+        em_before = self._result_out["em_before"]
+        assert isinstance(em_before, EM)
+
         lifecycle = EmbargoLifecycle(persistence=self.datalayer)
         try:
-            result = self._transition(lifecycle, self.actor_id)
+            result = self._transition(lifecycle, self.actor_id, em_before)
         except VultronError as exc:
             self._result_out["error"] = exc
             self.feedback_message = str(exc)
             return Status.FAILURE
 
         self._result_out["lifecycle_result"] = result
+        self._result_out["em_after"] = result.em_after
+
+        # AC-1: write em_state via named BT node, not inline service code.
+        if result.em_after != em_before:
+            write_node = WriteEmStateNode(
+                case_id=self._case_id(), result_out=self._result_out
+            )
+            write_node.datalayer = self.datalayer
+            write_status = write_node.update()
+            if write_status != Status.SUCCESS:
+                self.feedback_message = write_node.feedback_message
+                return Status.FAILURE
+
         return Status.SUCCESS
 
 
@@ -132,17 +174,24 @@ class ProposeEmbargoLifecycleNode(_EmbargoLifecycleNode):
         name: str | None = None,
     ) -> None:
         super().__init__(result_out=result_out, name=name)
-        self._case_id = case_id
+        self._case_id_value = case_id
         self._embargo_id = embargo_id
 
+    def _case_id(self) -> str:
+        return self._case_id_value
+
     def _transition(
-        self, lifecycle: EmbargoLifecycle, actor_id: str
+        self,
+        lifecycle: EmbargoLifecycle,
+        actor_id: str,
+        em_before: EM,
     ) -> EmbargoLifecycleResult:
         return lifecycle.propose_embargo(
-            case_id=self._case_id,
+            case_id=self._case_id_value,
             embargo_id=self._embargo_id,
             actor_id=actor_id,
             transition_mode=TransitionMode.STRICT,
+            em_before=em_before,
         )
 
 
@@ -157,17 +206,24 @@ class AcceptEmbargoLifecycleNode(_EmbargoLifecycleNode):
         name: str | None = None,
     ) -> None:
         super().__init__(result_out=result_out, name=name)
-        self._case_id = case_id
+        self._case_id_value = case_id
         self._embargo_id = embargo_id
 
+    def _case_id(self) -> str:
+        return self._case_id_value
+
     def _transition(
-        self, lifecycle: EmbargoLifecycle, actor_id: str
+        self,
+        lifecycle: EmbargoLifecycle,
+        actor_id: str,
+        em_before: EM,
     ) -> EmbargoLifecycleResult:
         return lifecycle.accept_embargo_invite(
-            case_id=self._case_id,
+            case_id=self._case_id_value,
             embargo_id=self._embargo_id,
             actor_id=actor_id,
             transition_mode=TransitionMode.STRICT,
+            em_before=em_before,
         )
 
 
@@ -182,22 +238,34 @@ class RejectEmbargoLifecycleNode(_EmbargoLifecycleNode):
         name: str | None = None,
     ) -> None:
         super().__init__(result_out=result_out, name=name)
-        self._case_id = case_id
+        self._case_id_value = case_id
         self._embargo_id = embargo_id
 
+    def _case_id(self) -> str:
+        return self._case_id_value
+
     def _transition(
-        self, lifecycle: EmbargoLifecycle, actor_id: str
+        self,
+        lifecycle: EmbargoLifecycle,
+        actor_id: str,
+        em_before: EM,
     ) -> EmbargoLifecycleResult:
         return lifecycle.reject_embargo_invite(
-            case_id=self._case_id,
+            case_id=self._case_id_value,
             embargo_id=self._embargo_id,
             actor_id=actor_id,
             transition_mode=TransitionMode.STRICT,
+            em_before=em_before,
         )
 
 
 class TerminateEmbargoLifecycleNode(_EmbargoLifecycleNode):
-    """Apply STRICT terminate-active-embargo transition."""
+    """Apply STRICT terminate-active-embargo transition.
+
+    AC-3: terminate semantics require an active embargo; the upstream
+    ``HasActiveEmbargoNode`` guard in ``terminate_embargo_bt`` enforces that
+    the case satisfies ``EmbargoedCase`` preconditions before this node runs.
+    """
 
     def __init__(
         self,
@@ -206,15 +274,22 @@ class TerminateEmbargoLifecycleNode(_EmbargoLifecycleNode):
         name: str | None = None,
     ) -> None:
         super().__init__(result_out=result_out, name=name)
-        self._case_id = case_id
+        self._case_id_value = case_id
+
+    def _case_id(self) -> str:
+        return self._case_id_value
 
     def _transition(
-        self, lifecycle: EmbargoLifecycle, actor_id: str
+        self,
+        lifecycle: EmbargoLifecycle,
+        actor_id: str,
+        em_before: EM,
     ) -> EmbargoLifecycleResult:
         return lifecycle.terminate_active_embargo(
-            case_id=self._case_id,
+            case_id=self._case_id_value,
             actor_id=actor_id,
             transition_mode=TransitionMode.STRICT,
+            em_before=em_before,
         )
 
 

--- a/vultron/core/behaviors/embargo/nodes/proposal.py
+++ b/vultron/core/behaviors/embargo/nodes/proposal.py
@@ -197,13 +197,41 @@ class RecordParticipantAcceptanceNode(DataLayerAction):
             self.feedback_message = "actor_id not available"
             return Status.FAILURE
 
+        # AC-1: read em_state via named BT node before calling the service.
+        from vultron.core.behaviors.embargo.nodes.em_state import (
+            ReadEmStateNode,
+            WriteEmStateNode,
+        )
+
+        em_result_out: dict[str, object] = {}
+        read_node = ReadEmStateNode(
+            case_id=self.case_id, result_out=em_result_out
+        )
+        read_node.datalayer = self.datalayer
+        if read_node.update() != Status.SUCCESS:
+            self.feedback_message = read_node.feedback_message
+            return Status.FAILURE
+        em_before = em_result_out["em_before"]
+        assert isinstance(em_before, EM)
+
         service = EmbargoLifecycle(persistence=self.datalayer)
         result = service.accept_embargo_invite(
             case_id=self.case_id,
             embargo_id=self.embargo_id,
             actor_id=actor_id,
             transition_mode=TransitionMode.OBSERVED,
+            em_before=em_before,
         )
+
+        if result.em_after != em_before:
+            em_result_out["em_after"] = result.em_after
+            write_node = WriteEmStateNode(
+                case_id=self.case_id, result_out=em_result_out
+            )
+            write_node.datalayer = self.datalayer
+            if write_node.update() != Status.SUCCESS:
+                self.feedback_message = write_node.feedback_message
+                return Status.FAILURE
 
         if result.em_after == EM.ACTIVE and result.em_before not in (
             EM.PROPOSED,

--- a/vultron/core/services/embargo_lifecycle.py
+++ b/vultron/core/services/embargo_lifecycle.py
@@ -165,6 +165,7 @@ class EmbargoLifecycle:
         embargo_id: str,
         actor_id: str | None = None,
         transition_mode: TransitionMode = TransitionMode.STRICT,
+        em_before: EM | None = None,
     ) -> EmbargoLifecycleResult:
         """Propose or counter-propose an embargo on a case.
 
@@ -187,6 +188,13 @@ class EmbargoLifecycle:
                 ``OBSERVED`` syncs local state even when the transition would
                 not normally be valid, forcing ``PROPOSED`` (or ``REVISE``
                 when the local state is ``ACTIVE``/``REVISE``).
+            em_before: When provided by the caller (e.g. from
+                ``ReadEmStateNode``), the service uses this value directly and
+                skips the internal ``case.current_status.em_state`` read.  The
+                caller is then responsible for writing the returned ``em_after``
+                via ``WriteEmStateNode`` (AC-1 of issue #1474).  When ``None``
+                the service reads ``em_state`` from the case itself (legacy /
+                non-BT callers).
 
         Returns:
             :class:`EmbargoLifecycleResult` describing what changed.
@@ -203,7 +211,12 @@ class EmbargoLifecycle:
         if not isinstance(case, VulnerabilityCase):
             raise VultronNotFoundError("VulnerabilityCase", case_id)
 
-        em_before = EM(case.current_status.em_state)
+        # When em_before is supplied by the BT caller (ReadEmStateNode), use it
+        # directly; otherwise read from the case (legacy / non-BT callers).
+        caller_owns_em_io = em_before is not None
+        if not caller_owns_em_io:
+            em_before = EM(case.current_status.em_state)
+        assert em_before is not None  # guaranteed by the branch above
 
         if transition_mode == TransitionMode.STRICT:
             self._assert_pxa_embargo_eligible(
@@ -230,10 +243,12 @@ class EmbargoLifecycle:
         if em_before == EM.ACTIVE and em_after == EM.REVISE:
             participant_changes = self._cascade_pec_revise(case)
 
-        # Mutate case — track whether anything actually changed
+        # Mutate case — track whether anything actually changed.
+        # When the BT caller owns em I/O (caller_owns_em_io), skip the em_state
+        # write here — the caller's WriteEmStateNode handles it.
         case_mutated = False
 
-        if em_after != em_before:
+        if not caller_owns_em_io and em_after != em_before:
             case.current_status.em_state = em_after
             case_mutated = True
 
@@ -283,6 +298,7 @@ class EmbargoLifecycle:
         embargo_id: str,
         actor_id: str,
         transition_mode: TransitionMode = TransitionMode.STRICT,
+        em_before: EM | None = None,
     ) -> EmbargoLifecycleResult:
         """Accept an embargo invite on a case.
 
@@ -298,6 +314,9 @@ class EmbargoLifecycle:
             embargo_id: ID of the ``EmbargoEvent`` being accepted.
             actor_id: ID of the accepting actor.
             transition_mode: ``STRICT`` (default) or ``OBSERVED``.
+            em_before: When provided by the caller (e.g. from
+                ``ReadEmStateNode``), the service uses this value directly and
+                skips the internal read/write of ``case.current_status.em_state``.
 
         Returns:
             :class:`EmbargoLifecycleResult` describing what changed.
@@ -314,7 +333,12 @@ class EmbargoLifecycle:
         if not isinstance(case, VulnerabilityCase):
             raise VultronNotFoundError("VulnerabilityCase", case_id)
 
-        em_before = EM(case.current_status.em_state)
+        # When em_before is supplied by the BT caller (ReadEmStateNode), use it
+        # directly; otherwise read from the case (legacy / non-BT callers).
+        caller_owns_em_io = em_before is not None
+        if not caller_owns_em_io:
+            em_before = EM(case.current_status.em_state)
+        assert em_before is not None  # guaranteed by the branch above
         em_after = em_before
         case_mutated = False
         case_embargo_changed = False
@@ -341,8 +365,9 @@ class EmbargoLifecycle:
                 fallback_dest=EM.ACTIVE,
                 actor_id=actor_id,
             )
-            # Sync em_state and active_embargo whenever owner accepted
-            if em_after != em_before:
+            # When the BT caller owns em I/O, skip the em_state write here —
+            # the caller's WriteEmStateNode handles it.
+            if not caller_owns_em_io and em_after != em_before:
                 case.current_status.em_state = em_after
                 case_mutated = True
             # Sync active_embargo independently: handle OBSERVED mode where
@@ -396,6 +421,7 @@ class EmbargoLifecycle:
         embargo_id: str,
         actor_id: str,
         transition_mode: TransitionMode = TransitionMode.STRICT,
+        em_before: EM | None = None,
     ) -> EmbargoLifecycleResult:
         """Reject an embargo proposal or revision on a case.
 
@@ -416,6 +442,9 @@ class EmbargoLifecycle:
             embargo_id: ID of the ``EmbargoEvent`` being rejected.
             actor_id: ID of the rejecting actor.
             transition_mode: ``STRICT`` (default) or ``OBSERVED``.
+            em_before: When provided by the caller (e.g. from
+                ``ReadEmStateNode``), the service uses this value directly and
+                skips the internal read/write of ``case.current_status.em_state``.
 
         Returns:
             :class:`EmbargoLifecycleResult` describing what changed.
@@ -431,7 +460,12 @@ class EmbargoLifecycle:
         if not isinstance(case, VulnerabilityCase):
             raise VultronNotFoundError("VulnerabilityCase", case_id)
 
-        em_before = EM(case.current_status.em_state)
+        # When em_before is supplied by the BT caller (ReadEmStateNode), use it
+        # directly; otherwise read from the case (legacy / non-BT callers).
+        caller_owns_em_io = em_before is not None
+        if not caller_owns_em_io:
+            em_before = EM(case.current_status.em_state)
+        assert em_before is not None  # guaranteed by the branch above
         em_after = em_before
         case_mutated = False
 
@@ -459,7 +493,9 @@ class EmbargoLifecycle:
                 fallback_dest=fallback,
                 actor_id=actor_id,
             )
-            if em_after != em_before:
+            # When the BT caller owns em I/O, skip the em_state write here —
+            # the caller's WriteEmStateNode handles it.
+            if not caller_owns_em_io and em_after != em_before:
                 case.current_status.em_state = em_after
                 case_mutated = True
 
@@ -494,6 +530,7 @@ class EmbargoLifecycle:
         case_id: str,
         actor_id: str | None = None,
         transition_mode: TransitionMode = TransitionMode.STRICT,
+        em_before: EM | None = None,
     ) -> EmbargoLifecycleResult:
         """Terminate the active embargo on a case.
 
@@ -505,6 +542,9 @@ class EmbargoLifecycle:
             case_id: ID of the ``VulnerabilityCase`` to update.
             actor_id: Optional ID of the terminating actor (logging only).
             transition_mode: ``STRICT`` (default) or ``OBSERVED``.
+            em_before: When provided by the caller (e.g. from
+                ``ReadEmStateNode``), the service uses this value directly and
+                skips the internal read/write of ``case.current_status.em_state``.
 
         Returns:
             :class:`EmbargoLifecycleResult` describing what changed.
@@ -520,7 +560,12 @@ class EmbargoLifecycle:
         if not isinstance(case, VulnerabilityCase):
             raise VultronNotFoundError("VulnerabilityCase", case_id)
 
-        em_before = EM(case.current_status.em_state)
+        # When em_before is supplied by the BT caller (ReadEmStateNode), use it
+        # directly; otherwise read from the case (legacy / non-BT callers).
+        caller_owns_em_io = em_before is not None
+        if not caller_owns_em_io:
+            em_before = EM(case.current_status.em_state)
+        assert em_before is not None  # guaranteed by the branch above
 
         # In STRICT mode, require an active embargo to be identified
         embargo_id = _as_id(case.active_embargo)
@@ -538,7 +583,10 @@ class EmbargoLifecycle:
             actor_id=actor_id,
         )
 
-        case.current_status.em_state = em_after
+        # When the BT caller owns em I/O, skip the em_state write here —
+        # the caller's WriteEmStateNode handles it.
+        if not caller_owns_em_io:
+            case.current_status.em_state = em_after
         case.active_embargo = None
 
         participant_changes = self._cascade_pec_reset(case)
@@ -570,6 +618,7 @@ class EmbargoLifecycle:
         actor_id: str,
         pec_trigger: PEC_Trigger,
         embargo_id: str | None = None,
+        em_before: EM | None = None,
     ) -> EmbargoLifecycleResult:
         """Apply a PEC trigger to a single participant without changing EM state.
 
@@ -585,6 +634,9 @@ class EmbargoLifecycle:
             pec_trigger: The PEC trigger to apply.
             embargo_id: Optional ID of the relevant ``EmbargoEvent``; used
                 to maintain ``accepted_embargo_ids`` on ACCEPT/DECLINE.
+            em_before: When provided by the caller (e.g. from
+                ``ReadEmStateNode``), the service uses this value directly and
+                skips the internal ``case.current_status.em_state`` read.
 
         Returns:
             :class:`EmbargoLifecycleResult` with ``em_before == em_after``
@@ -596,7 +648,11 @@ class EmbargoLifecycle:
         if not isinstance(case, VulnerabilityCase):
             raise VultronNotFoundError("VulnerabilityCase", case_id)
 
-        em_state = EM(case.current_status.em_state)
+        em_state = (
+            em_before
+            if em_before is not None
+            else EM(case.current_status.em_state)
+        )
 
         participant_id = case.actor_participant_index.get(actor_id)
         if not participant_id:


### PR DESCRIPTION
## Summary

Migrates the 5 inline `em_before = EM(case.current_status.em_state)` reads and 4
`case.current_status.em_state = em_after` mutations from
`vultron/core/services/embargo_lifecycle.py` (service layer) into two named BT nodes:
`ReadEmStateNode` (`DataLayerCondition`) and `WriteEmStateNode` (`DataLayerAction`).

## Acceptance Criteria

- **AC-1** ✅ All BT callers now pass `em_before` via `ReadEmStateNode`; the service
  skips its own em_state read/write when `em_before` is supplied
  (`caller_owns_em_io` guard). Legacy callers without `em_before` remain backward
  compatible (service still reads/writes internally).
- **AC-2** ✅ `ReadEmStateNode` inherits from `DataLayerCondition`;
  `WriteEmStateNode` inherits from `DataLayerAction`.
- **AC-3** ✅ `WriteEmStateNode` is idempotent — returns SUCCESS without saving
  when `em_state` already equals the target value.

## Changes

- **NEW** `vultron/core/behaviors/embargo/nodes/em_state.py` — `ReadEmStateNode`,
  `WriteEmStateNode`
- **REFACTORED** `vultron/core/services/embargo_lifecycle.py` — all 5 methods
  accept optional `em_before: EM | None = None`; `caller_owns_em_io` guard skips
  em_state read/write when caller supplies it
- **REFACTORED** `vultron/core/behaviors/embargo/nodes/lifecycle.py` —
  `_EmbargoLifecycleNode.update()` sequences `ReadEmStateNode → service call →
  WriteEmStateNode`; `ValidateEmbargoRevisionStateNode` updated to use
  `ReadEmStateNode`
- **UPDATED** `vultron/core/behaviors/embargo/nodes/proposal.py` —
  `RecordParticipantAcceptanceNode` now passes `em_before` via `ReadEmStateNode`
- **UPDATED** `vultron/core/behaviors/case/nodes/embargo.py` —
  `AdvanceEMStateToActiveNode` now passes `em_before` via `ReadEmStateNode`;
  `_propose_with_em_io` helper extracted to keep cyclomatic complexity within limit
- **NEW** `test/core/behaviors/embargo/nodes/test_em_state.py` — 15 tests
- **NEW** `TestCallerOwnsEmIo` in `test/core/services/test_embargo_lifecycle.py` —
  4 tests verifying service does not write em_state when `em_before` is supplied,
  and does write when not supplied

## Notes

Two BT nodes (`SetEmbargoActiveNode` in `lifecycle.py:433,443` and
`ApplyEmbargoTeardownNode` in `teardown.py:80,98`) still access `em_state` inline as
deliberate state-sync override paths. These were out of scope here and tracked in
follow-up #1554.

The split-write design (service saves case fields, `WriteEmStateNode` saves `em_state`
in a second pass) means a concurrent reader between these two saves sees an
intermediate state (e.g. `proposed_embargoes` updated but `em_state` not yet
transitioned). This is a known concurrency gap documented for future work.

## Test Plan

- [x] 15 new tests in `test_em_state.py` covering `ReadEmStateNode` and
  `WriteEmStateNode` error cases, inheritance, and round-trip integration
- [x] 4 new service-layer tests in `TestCallerOwnsEmIo` verifying the
  `caller_owns_em_io` guard on `propose`, `reject`, and `terminate`
- [x] Full test suite: 5158 passed, 0 failed
- [x] mypy, pyright, flake8 all clean

Closes #1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)