### PR TITLE
feat(#1521): audit Category-C envelope reconstitution; confirm seam correct; add reconstitution tests

### DIFF
--- a/notes/datalayer-design.md
+++ b/notes/datalayer-design.md
@@ -292,11 +292,28 @@ domain fact — the ARCH-09-001 core violations):
 
 **C — envelope reconstitution** (verbatim original needed for a reply):
 
-- Reply factories (`rm_accept_invite_to_case_activity`, embargo/report/actor
-  Accept/Reject) require the full inline original activity in `object_`.
-- *Fix*: verify whether any live reply path actually needs verbatim
-  reconstitution today; if so, provide a wire/adapter-owned opaque envelope seam
-  (DL-06-004). May be near-empty in current code.
+Audited by #1521. Four live reply paths need the verbatim original activity
+inline in the reply's `object_`:
+
+- `TriggerActivityAdapter.accept_case_invite` (`actors.py`) — reads the
+  stored `Invite` and passes it verbatim to `rm_accept_invite_to_case_activity`.
+- `TriggerActivityAdapter.accept_embargo` (`embargo.py`) — reads the stored
+  embargo proposal `Invite` and passes it to `em_accept_embargo_activity`.
+- `TriggerActivityAdapter.reject_embargo` (`embargo.py`) — same pattern for
+  `em_reject_embargo_activity`.
+- `TriggerActivityAdapter.accept_case_participant_offer` (`actors.py`) —
+  reads the stored `Offer(CaseParticipant)` and passes it to
+  `accept_case_participant_offer_activity`.
+
+**All four reads are already in the adapter layer** (`vultron/adapters/driven/
+trigger_activity_adapter/`), not in `vultron/core/`. They satisfy DL-06-004:
+the payload is treated opaquely (passed straight to the factory without any
+semantic interpretation). No new seam is needed; the correct seam already
+exists. The DL-05-004 exemption set does not need modification for these sites
+because they are not core reads.
+
+Tests verifying verbatim reconstitution (id preserved in `in_reply_to` /
+`object.id`) are in `test/adapters/driven/trigger_activity_adapter/`.
 
 **D — not activities** (core entities, covered by DL-05 / #1503, out of scope):
 

--- a/plan/history/2607/implementation/ISSUE-1521.md
+++ b/plan/history/2607/implementation/ISSUE-1521.md
@@ -1,0 +1,13 @@
+---
+source: ISSUE-1521
+timestamp: '2026-07-21T16:18:01.395755+00:00'
+title: Audit Category-C envelope reconstitution; confirm seam correct; add reconstitution
+  tests
+type: implementation
+---
+
+## Issue #1521 — Envelope reconstitution: verify need, then provide a wire/adapter-owned opaque seam
+
+Audited all live reply-construction paths against DL-06-004 (ADR-0035 Category C). Four adapter methods (`accept_case_invite`, `accept_case_participant_offer`, `accept_embargo`, `reject_embargo`) read stored wire activities for verbatim envelope reconstitution. All four are already in the adapter layer (`vultron/adapters/driven/trigger_activity_adapter/`); no new seam was needed. Added 4 tests verifying inline `object_` and `in_reply_to` preservation. Notes updated with full audit findings.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1559>

--- a/test/adapters/driven/trigger_activity_adapter/test_actors.py
+++ b/test/adapters/driven/trigger_activity_adapter/test_actors.py
@@ -132,6 +132,47 @@ class TestAcceptCaseInvite:
         with pytest.raises(VultronValidationError):
             adapter.accept_case_invite(invite_id=invite_id, actor=_INVITEE)
 
+    def test_verbatim_reconstitution_preserves_invite_id(self, adapter, dl):
+        """Accept(Invite) must embed the original invite id in in_reply_to.
+
+        DL-06-004: envelope reconstitution reads the stored invite and embeds
+        the verbatim original as the ``object_`` of the Accept.  The
+        ``in_reply_to`` field (set automatically by the factory's
+        model_validator) MUST equal the original invite id.
+        """
+        invite_id = self._make_invite(dl)
+
+        activity_id, _ = adapter.accept_case_invite(
+            invite_id=invite_id,
+            actor=_INVITEE,
+        )
+
+        accept = dl.read(activity_id)
+        assert accept is not None
+        assert getattr(accept, "in_reply_to", None) == invite_id
+
+    def test_verbatim_reconstitution_preserves_inline_object(
+        self, adapter, dl
+    ):
+        """Accept(Invite) object_ must be a full inline object, not a bare URI.
+
+        DL-06-004: the original invite activity is reconstituted verbatim as
+        the ``object_`` of the Accept; it must have its own ``id`` field set
+        (i.e., not be a bare string reference).
+        """
+        invite_id = self._make_invite(dl)
+
+        _, activity_dict = adapter.accept_case_invite(
+            invite_id=invite_id,
+            actor=_INVITEE,
+        )
+
+        obj = activity_dict.get("object")
+        assert isinstance(
+            obj, dict
+        ), "object_ must be an inline dict, not a URI"
+        assert obj.get("id") == invite_id
+
 
 class TestSuggestActorToCase:
     def test_returns_id_and_dict(self, adapter):

--- a/test/adapters/driven/trigger_activity_adapter/test_actors.py
+++ b/test/adapters/driven/trigger_activity_adapter/test_actors.py
@@ -20,7 +20,10 @@ CASE_MANAGER delegation.
 import pytest
 
 from vultron.errors import VultronValidationError
-from vultron.wire.as2.factories import rm_invite_to_case_activity
+from vultron.wire.as2.factories import (
+    offer_case_participant_activity,
+    rm_invite_to_case_activity,
+)
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
@@ -250,6 +253,55 @@ class TestOfferCaseManagerRole:
         )
 
         assert dl.read(activity_id) is not None
+
+
+class TestAcceptCaseParticipantOffer:
+    def _make_cp_offer(self, dl) -> str:
+        vendor = as_Service(id_=_INVITEE, name="Vendor")
+        dl.create(vendor)
+        offer = offer_case_participant_activity(
+            recommended=vendor,
+            actor=_ACTOR,
+            to=[_ACTOR],
+        )
+        # Store the nested CaseParticipant so _rehydrate_fields can expand the
+        # dehydrated object_ URI back to a full participant when reading the offer.
+        dl.create(offer.object_)
+        dl.create(offer)
+        return offer.id_
+
+    def test_returns_id_and_dict(self, adapter, dl):
+        cp_offer_id = self._make_cp_offer(dl)
+
+        activity_id, activity_dict = adapter.accept_case_participant_offer(
+            cp_offer_id=cp_offer_id,
+            actor=_ACTOR,
+        )
+
+        assert activity_id
+        assert isinstance(activity_dict, dict)
+
+    def test_verbatim_reconstitution_preserves_inline_object(
+        self, adapter, dl
+    ):
+        """Accept(Offer(CaseParticipant)) object_ must embed the original offer inline.
+
+        DL-06-004: the adapter reads the stored offer activity and passes it
+        verbatim as ``object_`` of the Accept.  The serialised dict MUST
+        contain the offer id as ``object.id``, not a bare URI string.
+        """
+        cp_offer_id = self._make_cp_offer(dl)
+
+        _, activity_dict = adapter.accept_case_participant_offer(
+            cp_offer_id=cp_offer_id,
+            actor=_ACTOR,
+        )
+
+        obj = activity_dict.get("object")
+        assert isinstance(
+            obj, dict
+        ), "object_ must be an inline dict, not a URI"
+        assert obj.get("id") == cp_offer_id
 
 
 class TestAcceptCaseManagerRole:

--- a/test/adapters/driven/trigger_activity_adapter/test_embargo.py
+++ b/test/adapters/driven/trigger_activity_adapter/test_embargo.py
@@ -90,6 +90,29 @@ class TestAcceptEmbargo:
 
         assert dl.read(activity_id) is not None
 
+    def test_verbatim_reconstitution_preserves_proposal_as_inline_object(
+        self, adapter, dl
+    ):
+        """Accept(Invite) object_ must embed the original proposal inline.
+
+        DL-06-004: the adapter reads the stored proposal activity and passes
+        it verbatim as ``object_`` of the Accept.  The serialised dict MUST
+        contain the proposal id as ``object.id``, not a bare URI string.
+        """
+        proposal_id, _ = _make_proposal(adapter, dl)
+
+        _, activity_dict = adapter.accept_embargo(
+            proposal_id=proposal_id,
+            case_id=_CASE_ID,
+            actor=_PEER,
+        )
+
+        obj = activity_dict.get("object")
+        assert isinstance(
+            obj, dict
+        ), "object_ must be an inline dict, not a URI"
+        assert obj.get("id") == proposal_id
+
 
 class TestRejectEmbargo:
     def test_returns_id_and_dict(self, adapter, dl):
@@ -115,6 +138,29 @@ class TestRejectEmbargo:
         )
 
         assert dl.read(activity_id) is not None
+
+    def test_verbatim_reconstitution_preserves_proposal_as_inline_object(
+        self, adapter, dl
+    ):
+        """Reject(Invite) object_ must embed the original proposal inline.
+
+        DL-06-004: the adapter reads the stored proposal activity and passes
+        it verbatim as ``object_`` of the Reject.  The serialised dict MUST
+        contain the proposal id as ``object.id``, not a bare URI string.
+        """
+        proposal_id, _ = _make_proposal(adapter, dl)
+
+        _, activity_dict = adapter.reject_embargo(
+            proposal_id=proposal_id,
+            case_id=_CASE_ID,
+            actor=_PEER,
+        )
+
+        obj = activity_dict.get("object")
+        assert isinstance(
+            obj, dict
+        ), "object_ must be an inline dict, not a URI"
+        assert obj.get("id") == proposal_id
 
 
 class TestAnnounceEmbargo:


### PR DESCRIPTION
## Summary

Closes #1521.

Audited all live reply-construction paths in `vultron/` for DL-06-004
(ADR-0035 Category C): "Envelope reconstitution — verbatim original needed
for a reply."

**Findings:** Four paths in `TriggerActivityAdapter` read a stored wire
activity to embed it verbatim as `object_` in the reply:

| Method | File | Activity read |
|---|---|---|
| `accept_case_invite` | `actors.py` | stored `Invite` |
| `accept_case_participant_offer` | `actors.py` | stored `Offer(CaseParticipant)` |
| `accept_embargo` | `embargo.py` | stored `Invite` (embargo proposal) |
| `reject_embargo` | `embargo.py` | stored `Invite` (embargo proposal) |

**All four reads are already in the adapter layer** (`vultron/adapters/driven/trigger_activity_adapter/`), not in `vultron/core/`.
They satisfy DL-06-004: the payload is passed verbatim to the factory
without semantic interpretation by core.  **No new seam is needed.**

## Changes

- `notes/datalayer-design.md` — replace Category-C placeholder with full
  audit results; also record the #1520 Category-B migration that was
  already committed.
- `test/adapters/driven/trigger_activity_adapter/test_actors.py` — two new
  tests in `TestAcceptCaseInvite` verifying verbatim reconstitution:
  `in_reply_to` equals the original invite id; `object` in the serialised
  dict is a full inline dict (not a bare URI).
- `test/adapters/driven/trigger_activity_adapter/test_embargo.py` — two new
  tests in `TestAcceptEmbargo` and `TestRejectEmbargo` verifying
  `object.id` equals the original proposal id.

## Test plan

- [ ] `PYTHONPATH= uv run pytest test/adapters/driven/trigger_activity_adapter/test_actors.py test/adapters/driven/trigger_activity_adapter/test_embargo.py -v` — all 5 new tests pass
- [ ] `PYTHONPATH= uv run pytest --tb=short` — full suite green
- [ ] `uv run black vultron/ test/ && uv run flake8 vultron/ test/ && uv run mypy && uv run pyright` — all linters exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)