### PR TITLE
docs: plan issue #1214 — FVCV-handoff scenario specs

### DIFF
--- a/notes/demo-future-ideas.md
+++ b/notes/demo-future-ideas.md
@@ -45,7 +45,7 @@ be treated as working implementations.
 | Scenario | Issue | Description | Blocked by | Status |
 |----------|-------|-------------|------------|--------|
 | FCV | #1234 | F reports to C; C invites V; three-actor coordination | — | planned |
-| FVCV-handoff | #1214 | V1 transfers ownership to C; C invites V2 | #1212 | planned |
+| FVCV-handoff | #1214 | V1 transfers ownership to C; C invites V2 | — | planned (tracked in impl issue) |
 | FCCV-extension | #1215 | C1 retains case; C2 is participant; C2 asks C1 to invite V | — | planned |
 | FCCV-handoff | #1216 | C1 transfers to C2; C2 invites V | #1215 | planned |
 | FCVCV | #1217 | F+C1+V1+C2+V2 (5 actors) | #1212, #1215 | planned |

--- a/plan/history/2607/idea/IDEA-1214.md
+++ b/plan/history/2607/idea/IDEA-1214.md
@@ -1,0 +1,32 @@
+---
+source: IDEA-1214
+timestamp: '2026-07-21T16:24:12.403666+00:00'
+title: FVCV-handoff — V1 transfers case ownership to C, C invites V2
+type: idea
+---
+
+## Summary
+
+A four-actor demo scenario where Finder reports to Vendor1, Vendor1 initially
+owns the case but then offers case ownership to a Coordinator. The Coordinator
+accepts and becomes CASE_OWNER, then invites Vendor2. This is the 'handoff'
+variant: ownership transfers mid-scenario.
+
+## Motivation
+
+Demonstrates the ownership transfer protocol (OFFER_CASE_OWNERSHIP_TRANSFER)
+in a realistic context — a vendor who realizes they need a coordinator to reach
+additional affected parties transfers control to the coordinator.
+
+## Acceptance Criteria
+
+- Coordinator is CASE_OWNER after handoff; Vendor1 is participant
+- Vendor2 is invited by Coordinator (not Vendor1) after the transfer
+- EM state transitions correctly through the ownership change
+- CaseActor `attributed_to` is updated to Coordinator after transfer
+- Scenario runs deterministically
+
+**Processed**: 2026-07-21 — implementation tracked in #1561.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1560>.
+Spec: `specs/triggerable-behaviors.yaml` (TRIG-11).
+Spec: `specs/multi-actor-demo.yaml` (DEMOMA-11).

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -515,3 +515,96 @@ groups:
     relationships:
     - rel_type: refines
       spec_id: DEMOMA-09-005
+
+- id: DEMOMA-11
+  title: FVCV-Handoff Scenario (Vendor1 transfers ownership to Coordinator; Coordinator invites Vendor2)
+  specs:
+  - id: DEMOMA-11-001
+    priority: MUST
+    kind: implementation
+    statement: >-
+      The FVCV-handoff scenario MUST involve four actor identities with isolated
+      DataLayers and a separate CaseActor container, as required by DEMOMA-10-001.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-10-001
+  - id: DEMOMA-11-002
+    priority: MUST
+    kind: implementation
+    statement: >-
+      Vendor1 MUST create the case as CASE_OWNER and then transfer ownership to the
+      Coordinator via `offer-case-ownership-transfer` and `accept-case-ownership-transfer`
+      trigger endpoints (TRIG-11-001, TRIG-11-002). After the handoff, Coordinator MUST
+      hold `CVDRole.CASE_OWNER` and Vendor1 MUST become a plain participant.
+    rationale: >-
+      This is the defining contrast with FVCV-extension (DEMOMA-10-002): ownership
+      transfers mid-scenario rather than staying with Vendor1 throughout.
+    relationships:
+    - rel_type: refines
+      spec_id: TRIG-11-001
+    - rel_type: refines
+      spec_id: TRIG-11-002
+  - id: DEMOMA-11-003
+    priority: MUST
+    kind: implementation
+    statement: >-
+      After becoming CASE_OWNER, the Coordinator MUST invite Vendor2 directly using
+      the `invite-actor-to-case` trigger, not via a recommendation/approval chain.
+      Vendor2 MUST accept and receive a case replica seeded by the CaseActor
+      Announce(VulnerabilityCase).
+    rationale: >-
+      In FVCV-extension, Vendor1 approves a Coordinator suggestion. In FVCV-handoff,
+      the Coordinator is the owner and invites directly — no approval step is needed.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-10-003
+  - id: DEMOMA-11-004
+    priority: MUST
+    kind: implementation
+    statement: >-
+      The `CaseActor.attributed_to` field MUST be updated to the Coordinator's actor
+      ID after the ownership transfer completes. All participants MUST observe the
+      updated `attributed_to` in their case replicas.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-10-002
+  - id: DEMOMA-11-005
+    priority: MUST
+    kind: implementation
+    statement: >-
+      The EM state machine MUST transition correctly through the ownership change:
+      an active embargo initiated before the transfer MUST remain ACTIVE and all
+      participants (including Vendor2 after joining) MUST be subject to it.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-10-006
+  - id: DEMOMA-11-006
+    priority: MUST
+    kind: implementation
+    statement: >-
+      The FVCV-handoff scenario MUST reach a final state with four participants —
+      Finder, Vendor1, Coordinator, and Vendor2 (plus CaseActor) — and MUST advance
+      to VFDPxa CS with EM.EXITED and RM.CLOSED for all participants, as required by
+      DEMOMA-10-006.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-10-006
+  - id: DEMOMA-11-007
+    priority: MUST
+    kind: implementation
+    statement: >-
+      The FVCV-handoff scenario MUST run deterministically and MUST verify SYNC-2
+      replica convergence for all non-owning participants after each major protocol
+      event, as required by DEMOMA-10-007.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-10-007
+  - id: DEMOMA-11-008
+    priority: MUST
+    kind: implementation
+    statement: >-
+      The implementation of the FVCV-handoff scenario MUST add a dedicated parallel
+      CI job and a CLI entry point, as required by DEMOMA-10-008.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-10-008

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -5,6 +5,7 @@ description: >-
   acceptance testing, and reproducibility.
 version: 1.0.0
 scope:
+
 - prototype
 - production
 tags:
@@ -532,13 +533,19 @@ groups:
     priority: MUST
     kind: implementation
     statement: >-
-      Vendor1 MUST create the case as CASE_OWNER and then transfer ownership to the
-      Coordinator via `offer-case-ownership-transfer` and `accept-case-ownership-transfer`
-      trigger endpoints (TRIG-11-001, TRIG-11-002). After the handoff, Coordinator MUST
-      hold `CVDRole.CASE_OWNER` and Vendor1 MUST become a plain participant.
+      Vendor1 MUST create the case as CASE_OWNER and MUST invite Coordinator as a
+      participant. Coordinator MUST accept the invitation and hold a case replica in
+      their DataLayer before the ownership-transfer handshake begins.
+      Vendor1 then MUST transfer ownership via `offer-case-ownership-transfer` and
+      `accept-case-ownership-transfer` trigger endpoints (TRIG-11-001, TRIG-11-002).
+      After the handoff, Coordinator MUST hold `CVDRole.CASE_OWNER` and Vendor1
+      MUST become a plain participant.
     rationale: >-
       This is the defining contrast with FVCV-extension (DEMOMA-10-002): ownership
       transfers mid-scenario rather than staying with Vendor1 throughout.
+      The Coordinator must already hold a case replica before accepting ownership,
+      because `AcceptCaseOwnershipTransferNode` reads the case from the DataLayer
+      and returns FAILURE if the case is not found.
     relationships:
     - rel_type: refines
       spec_id: TRIG-11-001
@@ -550,11 +557,15 @@ groups:
     statement: >-
       After becoming CASE_OWNER, the Coordinator MUST invite Vendor2 directly using
       the `invite-actor-to-case` trigger, not via a recommendation/approval chain.
-      Vendor2 MUST accept and receive a case replica seeded by the CaseActor
-      Announce(VulnerabilityCase).
+      Vendor2 MUST receive and accept the invitation via the `accept-case-invite`
+      trigger; the CaseActor MUST then emit `Announce(VulnerabilityCase)` to seed
+      Vendor2's case replica (MV-10-003/MV-10-004). The demo script MUST poll
+      Vendor2's DataLayer for the arriving invitation before driving the accept step.
     rationale: >-
       In FVCV-extension, Vendor1 approves a Coordinator suggestion. In FVCV-handoff,
       the Coordinator is the owner and invites directly — no approval step is needed.
+      The Vendor2 accept-invite step is mandatory: per MV-10-004 an Invite alone does
+      not seed the replica; the CaseActor's Announce fires only after Accept(Invite).
     relationships:
     - rel_type: refines
       spec_id: DEMOMA-10-003
@@ -608,3 +619,24 @@ groups:
     relationships:
     - rel_type: refines
       spec_id: DEMOMA-10-008
+  - id: DEMOMA-11-009
+    priority: MUST
+    kind: implementation
+    statement: >-
+      The demo script MUST include polling wait steps between asynchronous protocol
+      boundaries: (a) after emitting the ownership-transfer offer, poll Coordinator's
+      DataLayer for the stored `Offer(VulnerabilityCase)` before driving the accept
+      trigger; (b) after Coordinator accepts, poll Vendor1's case replica until
+      `attributed_to` reflects the Coordinator's ID before proceeding; (c) after
+      Coordinator invites Vendor2, poll Vendor2's DataLayer for the arriving
+      `Invite(Actor, Case)` before driving the accept trigger; (d) after Vendor2
+      accepts the invitation, poll Vendor2's DataLayer for the case replica seeded
+      by the CaseActor's `Announce(VulnerabilityCase)`.
+    rationale: >-
+      Each of these polling steps was required in FVCV-extension (see ISSUE-1535
+      post-review fixes). Omitting any wait step causes the scenario to proceed on
+      state that has not yet been committed to the target actor's DataLayer,
+      producing consistent CI failures rather than intermittent flakes.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-10-007

--- a/specs/triggerable-behaviors.yaml
+++ b/specs/triggerable-behaviors.yaml
@@ -265,3 +265,65 @@ groups:
     relationships:
     - rel_type: refines
       spec_id: TRIG-08-004
+
+- id: TRIG-11
+  title: Case Ownership Transfer Triggers
+  specs:
+  - id: TRIG-11-001
+    priority: MUST
+    kind: domain
+    statement: >-
+      The system MUST expose an `offer-case-ownership-transfer` trigger at
+      `POST /actors/{actor_id}/trigger/offer-case-ownership-transfer` that accepts
+      a `case_id` and `transferee_id` in its request body and emits an
+      `Offer(VulnerabilityCase)` (ownership transfer variant) from the requesting
+      actor to the specified transferee.
+    rationale: >-
+      Without this trigger, demo scripts must inject ownership-transfer offers
+      directly into the transferee's inbox, which bypasses the offering actor's BT
+      execution and violates DEMOMA-05-001. A trigger endpoint ensures the full
+      hexagonal stack is exercised for both sides of the handshake.
+    relationships:
+    - rel_type: refines
+      spec_id: TRIG-01-001
+    - rel_type: refines
+      spec_id: TRIG-02-004
+  - id: TRIG-11-002
+    priority: MUST
+    kind: domain
+    statement: >-
+      The system MUST expose an `accept-case-ownership-transfer` trigger at
+      `POST /actors/{actor_id}/trigger/accept-case-ownership-transfer` that accepts
+      an `offer_id` in its request body and emits an `Accept(Offer(VulnerabilityCase))`
+      (ownership transfer variant) from the requesting actor back to the offering actor.
+    rationale: >-
+      Symmetry with TRIG-11-001: the accepting actor must also be puppeteered through
+      a trigger so that its BT execution is exercised, consistent with DEMOMA-05-001.
+    relationships:
+    - rel_type: refines
+      spec_id: TRIG-01-001
+    - rel_type: refines
+      spec_id: TRIG-02-004
+  - id: TRIG-11-003
+    priority: SHOULD
+    kind: domain
+    statement: >-
+      The `offer-case-ownership-transfer` trigger request body SHOULD accept an
+      optional `content` field (free-text message) to include in the offer activity,
+      consistent with the factory function signature for
+      `offer_case_ownership_transfer_activity`.
+    relationships:
+    - rel_type: refines
+      spec_id: TRIG-11-001
+  - id: TRIG-11-004
+    priority: MUST
+    kind: domain
+    statement: >-
+      Both ownership-transfer triggers MUST return an `activity` field in their
+      response body containing the emitted ActivityStreams object, consistent with the
+      response contract for all other trigger endpoints (TRIG-05-001).
+    relationships:
+    - rel_type: refines
+      spec_id: TRIG-11-001
+    - rel_type: refines
+      spec_id: TRIG-11-002


### PR DESCRIPTION
## Summary

Plan docs for the FVCV-handoff demo scenario (#1214): Vendor1 creates case,
transfers ownership to Coordinator via a mid-scenario handoff, Coordinator
then invites Vendor2.

- Closes #1214

## Changes

- **`specs/triggerable-behaviors.yaml`** — new TRIG-11 group with four
  requirements for two new trigger endpoints:
  `offer-case-ownership-transfer` (TRIG-11-001, TRIG-11-003, TRIG-11-004)
  and `accept-case-ownership-transfer` (TRIG-11-002, TRIG-11-004).
  These endpoints are required so the demo can puppeteer actors through
  the ownership handshake without inbox injection (DEMOMA-05-001).

- **`specs/multi-actor-demo.yaml`** — new DEMOMA-11 group with eight
  requirements for the FVCV-handoff scenario. Written DRY: each requirement
  refines its DEMOMA-10 (FVCV-extension) counterpart rather than duplicating
  the full text, capturing only the handoff-specific delta
  (ownership transfer, Coordinator-led direct invite, post-transfer
  attributed_to update).

- **`notes/demo-future-ideas.md`** — removes stale "Blocked by: #1212"
  notation; blocker #1212 (FVCV-extension) is now closed.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)