### PR TITLE
docs: plan issue #1456 — per-machine dimension objects for CaseStatus/ParticipantStatus

### DIFF
--- a/docs/adr/0036-status-dimension-objects.md
+++ b/docs/adr/0036-status-dimension-objects.md
@@ -1,0 +1,153 @@
+---
+status: proposed
+date: 2026-07-21
+deciders: Allen D. Householder
+consulted: Claude Code (design session)
+---
+
+# Per-Machine Dimension Objects for CaseStatus and ParticipantStatus
+
+## Context and Problem Statement
+
+`CaseStatus` and `ParticipantStatus` each pack several **independent** state
+machines into flat enum fields:
+
+- `CaseStatus.em_state: EM` — the case-level Embargo Management state
+- `CaseStatus.pxa_state: CS_pxa` — the public/exploit/attack case state
+- `ParticipantStatus.rm_state: RM` — the per-participant Report Management state
+- `ParticipantStatus.vfd_state: CS_vfd` — the per-participant vendor fix path
+- `ParticipantStatus.em_consent_state: PEC | None` — per-participant embargo consent
+
+These machines are genuinely independent, but their transition logic is
+scattered: `EmbargoLifecycle` owns EM + PEC transitions, BT nodes own
+RM/vfd transitions, and neither surface expresses what *inputs* each machine
+can accept or what guards apply.  Callers must know which external service
+(or BT node, or inline `EMAdapter`) to call for each machine — there is no
+single, self-describing owner.
+
+The `notes/lifecycle-staged-types.md` design note and ADR-0033 both identify
+this decomposition as a natural follow-on to lifecycle-staged types, with the
+key observation: *staged types make illegal **shapes** unrepresentable;
+dimension objects make illegal **transitions** unrepresentable.*
+
+This ADR records the design choices made for that decomposition.
+
+## Decision Drivers
+
+- Give each state machine one home: the dimension object both holds state and
+  owns transition validation for that machine.
+- Compose naturally with the predicate/state-group model from ADR-0033: guards
+  (`is_rm_validated()`, etc.) become methods on the dimension object rather than
+  free-standing helpers.
+- Do not proliferate identity-bearing objects — dimension objects are embedded
+  value objects inside `CaseStatus`/`ParticipantStatus`, not independently
+  persisted domain entities.
+- Preserve DataLayer round-trip compatibility; no stored "dimension type"
+  discriminator.
+- Keep the wire/AS2 projection consistent: `as_CaseStatus` and
+  `as_ParticipantStatus` project dimension object fields to the wire format.
+
+## Considered Options
+
+### Option A — Lightweight Pydantic `BaseModel` dimension objects (chosen)
+
+Each dimension is a small Pydantic model holding one state enum and owning
+an immutable `transition()` method that validates the trigger, applies the
+state machine rules, and returns a new dimension object with the updated state.
+Guards (`is_validated()`, `is_active()`, etc.) are additional methods.
+
+Names:
+
+| Object | Replaces | Embedded in |
+|---|---|---|
+| `EmDimension` | `CaseStatus.em_state: EM` | `CaseStatus` |
+| `PxaDimension` | `CaseStatus.pxa_state: CS_pxa` | `CaseStatus` |
+| `RmDimension` | `ParticipantStatus.rm_state: RM` | `ParticipantStatus` |
+| `VfdDimension` | `ParticipantStatus.vfd_state: CS_vfd` | `ParticipantStatus` |
+| `PecDimension` | `ParticipantStatus.em_consent_state: PEC \| None` | `ParticipantStatus` |
+
+The naming `*Dimension` avoids collision with the existing `VfdState` and
+`PxaState` NamedTuples in `vultron/core/states/cs.py`.
+
+### Option B — Full `CoreObject` subclasses with `type_` and `CORE_VOCABULARY` entry
+
+Dimension objects would be independently addressable domain objects with `id_`,
+`type_`, and auto-registration in `CORE_VOCABULARY`.
+
+Rejected: dimension objects are always embedded inside
+`CaseStatus`/`ParticipantStatus`; there is no use case for querying or
+persisting them independently.  Adding `CoreObject` overhead for embedded value
+objects bloats the schema and creates unnecessary `CORE_VOCABULARY` entries.
+
+### Option C — Property shims alongside existing flat enum fields
+
+Add `.em`, `.rm`, etc. as computed properties returning temporary dimension
+objects while keeping `em_state`, `rm_state`, etc. as the canonical fields.
+
+Rejected: perpetuates the two-representation problem indefinitely and
+produces an extended half-migrated state.
+
+## Decision Outcome
+
+**Chosen option: Option A — lightweight Pydantic `BaseModel` dimension objects.**
+
+### Governing principles
+
+1. **Lightweight BaseModel, not CoreObject** — dimension objects carry no `id_`,
+   `type_`, or `CORE_VOCABULARY` entry.  They are embedded value objects owned
+   by their enclosing `CaseStatus` or `ParticipantStatus`.
+2. **Immutable `transition()`** — transitions return a *new* dimension object
+   with the updated state; they never mutate `self`.  This is consistent with
+   Pydantic's design and with the append-only history model.
+3. **Replace, not alias** — flat enum fields (`em_state`, `rm_state`, etc.) are
+   removed and replaced by embedded dimension object fields (`em`, `rm`, etc.).
+   No shim properties.
+4. **Both layers in scope** — domain model (`vultron/core/models/`) and
+   wire/AS2 projection (`vultron/wire/as2/vocab/objects/case_status.py`) are
+   migrated in the same implementation.
+5. **Full call-site migration** — all ~308 active-codebase call sites that
+   access the flat enum fields are updated.  `vultron/bt/` (legacy simulator)
+   is excluded.
+6. **No stored data to migrate** — there are no extant persisted records
+   requiring backward-compat deserialization.
+
+### Consequences
+
+- **Good**: each state machine has one home; the dimension object is the
+  authoritative owner of transition validation and guard predicates.
+- **Good**: type signatures express which machines a function works with
+  (`def accept_embargo(em: EmDimension) -> EmDimension`).
+- **Good**: composable with staged types from ADR-0033 — predicates like
+  `is_rm_validated()` become `rm.is_validated()` methods.
+- **Neutral**: call-site migration is large (~308 sites across ~82 files in
+  `vultron/` and `test/` excluding `vultron/bt/`).
+- **Neutral**: the wire AS2 projection (`as_CaseStatus`, `as_ParticipantStatus`)
+  must update `from_core()` / `to_core()` to handle nested dimension dicts.
+
+## Validation
+
+- `RmDimension.transition()` raises on an invalid trigger; returns new
+  `RmDimension` with updated state on a valid one.
+- `EmDimension`, `PxaDimension`, `VfdDimension`, `PecDimension` follow the
+  same contract.
+- `CaseStatus` / `ParticipantStatus` DataLayer round-trip: persist, `dl.read()`,
+  and assert dimension objects are correctly rehydrated.
+- All 308 migrated call sites pass type-checker and test suite.
+- Wire round-trip: `as_CaseStatus.from_core(core_status).to_core()` produces an
+  equivalent `CaseStatus` with correct dimension values.
+
+## More Information
+
+Related:
+
+- ADR-0033 — Lifecycle-Staged Domain Types (predecessor; establishes the
+  field-set governing principle and predicates model).
+- ADR-0032 — Validate at the Edge, Promote to Strict Core Types.
+- ADR-0017 — Domain/Wire Object Separation (staged types live on the core branch).
+- `notes/lifecycle-staged-types.md` § "Future Direction: Per-Dimension Status
+  Decomposition" — the trailhead for this decision.
+- `notes/status-dimension-objects.md` — full design guidance and implementation
+  notes.
+- `specs/status-dimension-objects.yaml` — normative requirements (SDO-01 through SDO-04).
+- #1456 — source Idea.
+- #1394 — parent Epic (Architecture Hardening).

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -93,6 +93,8 @@ General information about architectural decision records is available at <https:
   Objects](0034-datalayer-returns-core-objects.md)
 - [ADR-0035 Core Activity Representation and Envelope
   Reconstitution](0035-core-activity-representation-and-envelope-reconstitution.md)
+- [ADR-0036 Per-Machine Dimension Objects for CaseStatus and
+  ParticipantStatus](0036-status-dimension-objects.md)
 
 ## Proposed ADRs
 

--- a/notes/README.md
+++ b/notes/README.md
@@ -319,6 +319,15 @@ configuration.
 
 ## Case and Data Model
 
+**`status-dimension-objects.md`**
+Design guidance for per-machine dimension objects decomposed from `CaseStatus`
+and `ParticipantStatus` (ADR-0036): naming table, `BaseModel`-not-`CoreObject`
+rationale, immutable `transition()` pattern, wire projection notes, call-site
+migration mapping (~308 active sites), and `EmbargoLifecycle` migration priority.
+**Load when**: implementing or reviewing dimension-object migration, working on
+`specs/status-dimension-objects.yaml` (SDO) requirements, or understanding how
+`EmDimension`/`RmDimension`/etc. embed inside status objects.
+
 **`lifecycle-staged-types.md`**
 Design guidance for lifecycle-staged domain types (ADR-0033): the field-set
 governing principle (a milestone earns a type only when it changes the

--- a/notes/lifecycle-staged-types.md
+++ b/notes/lifecycle-staged-types.md
@@ -157,3 +157,7 @@ Where it gets messier: it is a wire- and persistence-visible schema change
 (rehydration, `CORE_VOCABULARY`, AS2 projection, and the append-only
 history model all interact), so it deserves its **own ADR** and must not be
 folded into the staged-types work. Tracked as a separate Idea issue.
+
+**Resolved**: ADR-0036 and `specs/status-dimension-objects.yaml` capture the
+design and normative requirements. See `notes/status-dimension-objects.md`
+for implementation guidance.

--- a/notes/status-dimension-objects.md
+++ b/notes/status-dimension-objects.md
@@ -1,0 +1,219 @@
+---
+title: Status Dimension Objects
+status: active
+description: >
+  Design guidance for per-machine dimension objects decomposed from CaseStatus
+  and ParticipantStatus: naming, BaseModel contract, immutable transition()
+  pattern, wire projection, and call-site migration scope.
+related_specs:
+  - specs/status-dimension-objects.yaml
+related_notes:
+  - notes/lifecycle-staged-types.md
+  - notes/case-state-model.md
+  - notes/embargo-lifecycle.md
+relevant_packages:
+  - vultron/core/models/case_status.py
+  - vultron/core/models/participant_status.py
+  - vultron/core/states/
+  - vultron/wire/as2/vocab/objects/case_status.py
+---
+
+# Status Dimension Objects
+
+Design note for ADR-0036. Records *why* the dimension-object design is shaped
+the way it is; the normative requirements live in
+`specs/status-dimension-objects.yaml` (SDO-01 through SDO-04), and the
+decision record is `docs/adr/0036-status-dimension-objects.md`.
+
+This is the natural follow-on to ADR-0033 (Lifecycle-Staged Domain Types):
+staged types make illegal *shapes* unrepresentable; dimension objects make
+illegal *transitions* unrepresentable.
+
+---
+
+## The Problem
+
+`CaseStatus` and `ParticipantStatus` pack several independent state machines
+into flat enum fields:
+
+```python
+# CaseStatus (before)
+em_state: EM = EM.NO_EMBARGO
+pxa_state: CS_pxa = CS_pxa.pxa
+
+# ParticipantStatus (before)
+rm_state: RM = RM.START
+vfd_state: CS_vfd = CS_vfd.vfd
+em_consent_state: PEC | None = None
+```
+
+These machines are genuinely independent, but callers must know:
+
+- *which external service* handles each transition (EM + PEC → `EmbargoLifecycle`;
+  RM/vfd → BT nodes or `EmbargoLifecycle` indirectly; PXA → BT lifecycle nodes).
+- *which guards apply* before calling (P/X/A embargo-eligibility checks, RM
+  terminal guards, etc.).
+
+There is no single, self-describing owner per machine. Bugs fixed in
+`EmbargoLifecycle` do not automatically close gaps in BT nodes that
+independently mutate `em_state`.
+
+---
+
+## The Solution: Dimension Objects
+
+Decompose each machine into a small Pydantic `BaseModel` — a *dimension object*
+— that holds one state enum field and owns:
+
+- An immutable `transition(trigger)` method that validates the trigger,
+  applies the machine rules, and returns a **new** dimension object.
+- Guard predicates as methods (`is_validated()`, `is_active()`, etc.).
+
+```python
+# CaseStatus (after)
+em: EmDimension = Field(default_factory=EmDimension)
+pxa: PxaDimension = Field(default_factory=PxaDimension)
+
+# ParticipantStatus (after)
+rm: RmDimension = Field(default_factory=RmDimension)
+vfd: VfdDimension = Field(default_factory=VfdDimension)
+consent: PecDimension | None = None
+```
+
+---
+
+## Naming
+
+| Dimension object | State enum | Replaces |
+|---|---|---|
+| `EmDimension` | `EM` | `CaseStatus.em_state` |
+| `PxaDimension` | `CS_pxa` | `CaseStatus.pxa_state` |
+| `RmDimension` | `RM` | `ParticipantStatus.rm_state` |
+| `VfdDimension` | `CS_vfd` | `ParticipantStatus.vfd_state` |
+| `PecDimension` | `PEC` | `ParticipantStatus.em_consent_state` |
+
+The `*Dimension` suffix was chosen to avoid collision with the existing
+`VfdState` and `PxaState` NamedTuples in `vultron/core/states/cs.py`.
+
+---
+
+## BaseModel, not CoreObject
+
+Dimension objects are **embedded value objects**. They do NOT have:
+
+- `id_` (no independent identity)
+- `type_` with a Literal value (no CORE_VOCABULARY registration)
+- `published`, `updated`, `attributed_to` (no provenance metadata)
+
+They are always embedded inside `CaseStatus` or `ParticipantStatus`, which
+already carry identity. Adding `CoreObject` overhead would bloat the schema
+and create spurious CORE_VOCABULARY entries.
+
+---
+
+## Immutable transition() Pattern
+
+```python
+class RmDimension(BaseModel):
+    state: RM = RM.START
+
+    def transition(self, trigger: RM_Trigger) -> "RmDimension":
+        """Return a new RmDimension with the updated state.
+
+        Raises VultronInvalidStateTransitionError if the trigger is invalid
+        for the current state.
+        """
+        next_state = _apply_rm_transition(self.state, trigger)
+        return self.model_copy(update={"state": next_state})
+
+    def is_validated(self) -> bool:
+        return self.state in RM_VALIDATED
+
+    def is_active(self) -> bool:
+        return self.state in RM_ACTIVE
+```
+
+Callers replace the field rather than mutating in place:
+
+```python
+# Before (mutable, brittle)
+participant_status.rm_state = RM.VALID
+
+# After (immutable, explicit)
+participant_status = participant_status.model_copy(
+    update={"rm": participant_status.rm.transition(RM_Trigger.VALIDATE)}
+)
+```
+
+This is consistent with the append-only history model: a status record is
+never mutated; a new record is appended with the updated dimension values.
+
+---
+
+## Wire Projection
+
+`as_CaseStatus` and `as_ParticipantStatus` project dimension objects to the
+wire format. The `from_core()` / `to_core()` methods must handle the nested
+dimension-object dict shape:
+
+```python
+# from_core() — core dimension objects → wire flat fields (for backward wire compat)
+# OR — wire flat fields remain nested dicts (simpler, no backward wire compat needed
+#       since there are no extant records to preserve)
+```
+
+Because there are no extant persisted records to preserve, the simplest
+approach is to match the wire JSON shape to the new nested structure and
+update `from_core()` / `to_core()` accordingly.
+
+---
+
+## Call-Site Migration Scope
+
+There are approximately 308 call sites in `vultron/` and `test/` (excluding
+`vultron/bt/`) that access the old flat enum fields. The migration pattern
+is mechanical:
+
+| Old access pattern | New access pattern |
+|---|---|
+| `status.em_state` | `status.em.state` |
+| `status.pxa_state` | `status.pxa.state` |
+| `status.rm_state` | `status.rm.state` |
+| `status.vfd_state` | `status.vfd.state` |
+| `status.em_consent_state` | `status.consent.state` (or `None` check) |
+| `CaseStatus(em_state=EM.ACTIVE, ...)` | `CaseStatus(em=EmDimension(state=EM.ACTIVE), ...)` |
+
+The `vultron/bt/` legacy simulator is **out of scope** — it uses the custom
+BT engine and accesses enums directly; migrating it is a separate effort.
+
+---
+
+## Relationship to Existing Predicates
+
+The existing state-group tuples and `is_*()` free-standing helpers in
+`vultron/core/states/` continue to work; they accept the raw enum values that
+dimension objects hold. Over time, callers should prefer the dimension-object
+methods (`rm.is_validated()`) over the free-standing helpers
+(`is_rm_validated(status.rm_state)`).
+
+---
+
+## Relationship to EmbargoLifecycle
+
+`EmbargoLifecycle` currently mutates `em_state` and `em_consent_state` fields
+directly on `CaseStatus`/`ParticipantStatus`. After this migration, it MUST
+use the dimension-object transition pattern:
+
+```python
+# Before
+case_status.em_state = new_em_state
+
+# After
+updated_em = EmDimension(state=new_em_state)
+# ... or via transition():
+updated_em = case_status.em.transition(EM_Trigger.ACTIVATE)
+case_status = case_status.model_copy(update={"em": updated_em})
+```
+
+This is the single most complex migration site (`embargo_lifecycle.py` has
+~17 flat-field accesses). The impl agent should prioritize this file.

--- a/plan/history/2607/idea/IDEA-1456.md
+++ b/plan/history/2607/idea/IDEA-1456.md
@@ -1,0 +1,26 @@
+---
+source: IDEA-1456
+timestamp: '2026-07-21T16:28:43.320023+00:00'
+title: Decompose CaseStatus/ParticipantStatus into per-machine dimension objects
+type: idea
+---
+
+A natural next layer after lifecycle-staged types (#1362 / ADR-0033):
+decompose `CaseStatus` and `ParticipantStatus` — which today pack several
+independent state machines into flat enum fields — into **per-machine dimension
+objects**, each owning its own state and its own `transition()`/guard method.
+
+For example:
+
+- `ParticipantStatus` → `{rm: RmDimension, vfd: VfdDimension, consent: PecDimension}`
+- `CaseStatus` → `{em: EmDimension, pxa: PxaDimension}`
+
+Staged types make illegal *shapes* unrepresentable; dimension objects make
+illegal *transitions* unrepresentable.
+
+**Processed**: 2026-07-21 — design decisions recorded in ADR-0036; normative
+requirements in `specs/status-dimension-objects.yaml`; implementation guidance
+in `notes/status-dimension-objects.md`; implementation tracked in #1563.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1562>.
+Spec: `specs/status-dimension-objects.yaml`.
+Notes: `notes/status-dimension-objects.md`.

--- a/specs/README.md
+++ b/specs/README.md
@@ -75,6 +75,7 @@ Load additional files only when the task touches the relevant area. See the
 | Behavior Trees | `behavior-tree-integration.yaml`, `behavior-tree-node-design.yaml`, `bt-composability.yaml`, `triggerable-behaviors.yaml`, `vultron/core/use_cases/triggers/AGENTS.md` |
 | Case / state management | `case-management.yaml`, `state-machine.yaml`, `case-ledger-processing.yaml` |
 | Lifecycle-staged domain types | `lifecycle-staged-types.yaml`, `notes/lifecycle-staged-types.md` |
+| Status dimension objects (per-machine EM/PXA/RM/VFD/PEC decomposition) | `status-dimension-objects.yaml`, `notes/status-dimension-objects.md` |
 | CaseProposal protocol (distributed case actor initialization) | `case-proposal.yaml` |
 | Protocol conformance | `vultron-protocol-spec.yaml`, `vultron-as2-mapping.yaml`, `message-semantics-mapping.yaml` |
 | Wire vocabulary | `vocabulary-model.yaml` |
@@ -480,6 +481,7 @@ is reserved for `testability.yaml`).
 | `PROTO` | `prototype-shortcuts.yaml` |
 | `RF` | `response-format.yaml` |
 | `SE` | `semantic-extraction.yaml` |
+| `SDO` | `status-dimension-objects.yaml` |
 | `SM` | `state-machine.yaml` |
 | `SL` | `structured-logging.yaml` |
 | `PCR` | `participant-case-replica.yaml` |

--- a/specs/status-dimension-objects.yaml
+++ b/specs/status-dimension-objects.yaml
@@ -1,0 +1,175 @@
+id: SDO
+title: Status Dimension Objects
+description: >-
+  Normative requirements for per-machine dimension objects decomposed from
+  CaseStatus and ParticipantStatus. Each independent state machine (EM, PXA,
+  RM, VFD, PEC) is represented by a lightweight Pydantic BaseModel that holds
+  its state enum and owns immutable transition() validation and guard methods.
+version: 0.1.0
+scope:
+  - prototype
+  - production
+tags:
+  - protocol
+  - state-machine
+groups:
+  - id: SDO-01
+    title: Dimension Object Base Contract
+    specs:
+      - id: SDO-01-001
+        priority: MUST
+        kind: domain
+        statement: >-
+          Each status dimension (EM, PXA, RM, VFD, PEC) MUST be implemented as
+          a lightweight Pydantic BaseModel subclass (not a CoreObject subclass)
+          that holds exactly one state enum field and owns the transition
+          validation and guard methods for that machine.
+        rationale: >-
+          Dimension objects are embedded value objects; they have no independent
+          identity and do not require CORE_VOCABULARY registration or AS2 id_.
+          See ADR-0036.
+      - id: SDO-01-002
+        priority: MUST_NOT
+        kind: domain
+        statement: >-
+          Dimension objects MUST NOT be registered in CORE_VOCABULARY or given
+          an id_ field.
+        rationale: >-
+          They are always embedded in CaseStatus or ParticipantStatus, which
+          already carries identity. Independent registration would create
+          unnecessary schema complexity. See ADR-0036.
+      - id: SDO-01-003
+        priority: MUST
+        kind: domain
+        statement: >-
+          The five dimension objects MUST be named: EmDimension (EM state),
+          PxaDimension (CS_pxa state), RmDimension (RM state), VfdDimension
+          (CS_vfd state), and PecDimension (PEC state).
+        rationale: >-
+          The "Dimension" suffix avoids collision with existing VfdState and
+          PxaState NamedTuples in vultron/core/states/cs.py. See ADR-0036.
+
+  - id: SDO-02
+    title: transition() Contract
+    specs:
+      - id: SDO-02-001
+        priority: MUST
+        kind: domain
+        statement: >-
+          Each dimension object MUST implement a transition(trigger) method that
+          validates the trigger against the current state, applies the state
+          machine rules, and returns a NEW dimension object with the updated
+          state.
+        rationale: >-
+          Immutable transitions are consistent with Pydantic's design philosophy
+          and with the append-only status history model. Callers replace the
+          embedded field rather than mutating the existing object. See ADR-0036.
+      - id: SDO-02-002
+        priority: MUST
+        kind: domain
+        statement: >-
+          A dimension object's transition() MUST raise a descriptive exception
+          (VultronInvalidStateTransitionError or a subclass) when the trigger is
+          not valid for the current state.
+        rationale: >-
+          Fail-fast at the boundary; never return None or silently no-op on an
+          invalid transition. See ADR-0032 and ARCH-15-001.
+        relationships:
+          - rel_type: depends_on
+            spec_id: ARCH-15-001
+      - id: SDO-02-003
+        priority: MUST_NOT
+        kind: domain
+        statement: >-
+          transition() MUST NOT mutate self. The caller MUST use the returned
+          dimension object as the updated state.
+        rationale: >-
+          Mutation of embedded Pydantic models is fragile and inconsistent with
+          the append-only history model. See ADR-0036.
+
+  - id: SDO-03
+    title: CaseStatus and ParticipantStatus Field Shape
+    specs:
+      - id: SDO-03-001
+        priority: MUST
+        kind: domain
+        statement: >-
+          CaseStatus MUST replace its flat enum fields (em_state: EM,
+          pxa_state: CS_pxa) with embedded dimension object fields:
+          em: EmDimension and pxa: PxaDimension.
+        rationale: >-
+          Flat enum fields provide no transition validation or guard methods.
+          Dimension objects make illegal transitions unrepresentable. See ADR-0036.
+      - id: SDO-03-002
+        priority: MUST
+        kind: domain
+        statement: >-
+          ParticipantStatus MUST replace its flat enum fields (rm_state: RM,
+          vfd_state: CS_vfd, em_consent_state: PEC | None) with embedded
+          dimension object fields: rm: RmDimension, vfd: VfdDimension, and
+          consent: PecDimension | None.
+        rationale: >-
+          Same rationale as SDO-03-001. See ADR-0036.
+      - id: SDO-03-003
+        priority: MUST_NOT
+        kind: domain
+        statement: >-
+          The old flat enum fields (em_state, pxa_state, rm_state, vfd_state,
+          em_consent_state) MUST NOT be retained as aliases or shim properties
+          after the migration is complete.
+        rationale: >-
+          Keeping both representations creates an extended half-migrated state
+          and perpetuates the flat-enum problem. See ADR-0036.
+      - id: SDO-03-004
+        priority: MUST
+        kind: domain
+        statement: >-
+          CaseStatus and ParticipantStatus MUST remain round-trippable through
+          the DataLayer after the dimension-object migration: a persisted record
+          MUST rehydrate correctly to the new dimension-object shape.
+        rationale: >-
+          DataLayer round-trip compatibility is a binding design constraint per
+          LST-05-003 and ADR-0033. The dimension fields serialize as nested dicts
+          that rehydrate via Pydantic model_validate. See ADR-0036.
+        relationships:
+          - rel_type: depends_on
+            spec_id: LST-05-003
+
+  - id: SDO-04
+    title: Wire Projection and Migration Scope
+    specs:
+      - id: SDO-04-001
+        priority: MUST
+        kind: domain
+        statement: >-
+          The wire-layer projections as_CaseStatus and as_ParticipantStatus
+          MUST be updated in the same implementation as the core model changes
+          so that from_core() and to_core() correctly handle the new
+          dimension-object field shape.
+        rationale: >-
+          Deferring wire changes creates an extended period of core/wire
+          divergence requiring shim adapters. Both layers are in scope per
+          ADR-0036.
+      - id: SDO-04-002
+        priority: MUST
+        kind: domain
+        statement: >-
+          All call sites in vultron/ and test/ (excluding vultron/bt/) that
+          access the old flat enum fields (em_state, pxa_state, rm_state,
+          vfd_state, em_consent_state) MUST be migrated to use the new
+          dimension object accessors (e.g. .em.state, .rm.state) in the same
+          implementation.
+        rationale: >-
+          A partial migration leaves the codebase in an incoherent state with
+          two representations active simultaneously. See ADR-0036.
+      - id: SDO-04-003
+        priority: MUST_NOT
+        kind: domain
+        statement: >-
+          The vultron/bt/ legacy simulation layer MUST NOT be migrated to
+          dimension objects as part of this implementation.
+        rationale: >-
+          vultron/bt/ uses the custom BT engine and is not part of the active
+          prototype. It accesses RM/EM/PEC state enums directly and is explicitly
+          excluded from prototype handler work per codebase conventions. See
+          notes/codebase-structure.md.


### PR DESCRIPTION
## Summary

- Plans GitHub issue #1456: decompose `CaseStatus` and `ParticipantStatus`
  into per-machine dimension objects (`EmDimension`, `PxaDimension`,
  `RmDimension`, `VfdDimension`, `PecDimension`)
- Documents design decisions that were evaluated during the planning session
  (BaseModel vs CoreObject; immutable vs mutable transition(); both-layers vs
  core-only scope; naming to avoid NamedTuple collision in `cs.py`)

## Changes

- **`docs/adr/0036-status-dimension-objects.md`** — new ADR recording design
  choices and consequences
- **`specs/status-dimension-objects.yaml`** — normative requirements SDO-01
  through SDO-04 covering dimension object contract, `transition()` semantics,
  `CaseStatus`/`ParticipantStatus` field shape, and wire + call-site migration
  scope
- **`notes/status-dimension-objects.md`** — implementation guidance including
  naming table, `transition()` pattern, wire projection notes, call-site
  migration mapping (~308 active sites), `EmbargoLifecycle` migration priority
- **`docs/adr/index.md`** — add ADR-0036 entry
- **`specs/README.md`** — add SDO topic row and prefix registry entry
- **`notes/lifecycle-staged-types.md`** — mark "Future Direction" trailhead as
  resolved with ADR-0036 cross-reference

Closes #1456

🤖 Generated with [Claude Code](https://claude.com/claude-code)