### PR TITLE
fix(sync): buffer out-of-order Announce(CaseLedgerEntry) at case closure

### DIFF
--- a/docs/adr/0037-buffer-out-of-order-ledger-entries.md
+++ b/docs/adr/0037-buffer-out-of-order-ledger-entries.md
@@ -1,0 +1,125 @@
+---
+status: accepted
+date: 2026-07-21
+deciders: Allen D. Householder
+consulted: []
+informed: []
+---
+
+# Buffer Out-of-Order `Announce(CaseLedgerEntry)` Instead of Dropping
+
+## Context and Problem Statement
+
+Participant replicas receive the canonical recorded log from the CaseActor as a
+stream of `Announce(CaseLedgerEntry)` activities. That stream travels over a
+transport with **no ordering guarantee**, and Vultron may not be the only
+protocol implementation on the wire, so a replica can receive an entry before
+its hash-chain predecessor arrives.
+
+The original receive path (`CheckHashOrRejectOnMismatchNode`) treated any entry
+whose `prev_log_hash` did not match the local tail as a divergence: it **dropped**
+the entry and sent a `Reject(CaseLedgerEntry)` so the CaseActor would replay the
+missing prefix. At case closure this stalled a late-joining replica (Vendor2 in
+the FVV/FVCV demos) indefinitely and `wait_for_contiguous_ledger_coverage` timed
+out (issue #1556). How should a replica handle an entry that is valid but
+arrives before its predecessor?
+
+## Decision Drivers
+
+- Convergence must not depend on `Announce` delivery order (SYNC-10-004 requires
+  a contiguous prefix; the transport does not provide ordering).
+- The fix must interoperate with unknown implementations — we cannot assume the
+  sender retries, or that any recovery message is delivered in order either.
+- Must preserve the effects-before-persist invariant (SYNC-12-001) and the
+  DataLayer-presence-means-committed invariant (SYNC-13-001).
+- Bounded memory under a broken or hostile peer that streams far-future entries.
+
+## Considered Options
+
+- **A. Repair the `Reject → replay` loop only** — keep dropping out-of-order
+  entries; make the CaseActor reliably process the participant's Reject and
+  replay the missing prefix promptly.
+- **B. Receiver-side buffering** — hold out-of-order entries locally and apply
+  them in hash-chain order once their predecessor arrives.
+- **C. Both** — buffering plus a hardened replay loop.
+
+## Decision Outcome
+
+Chosen option: **B, receiver-side buffering** (which subsumes most of C).
+
+Option A alone is insufficient: the replay path re-announces each missing entry
+as a *separate* `Announce`, which travels the same unordered transport and can
+reorder again — hitting the very same drop. Repairing replay narrows the race
+but cannot close it under adversarial reordering. Buffering, by contrast, makes
+convergence **order-independent**: any valid entry is retained until the entry
+that closes its gap arrives, then drained in order.
+
+Buffering also makes the existing `Reject → replay` recovery order-robust *for
+free*, because replayed entries flow through the same (now buffering) receive
+path. We therefore did **not** redesign the replay loop; we keep sending the
+`Reject` at buffer time purely as the backstop for entries that are genuinely
+*lost* (never delivered) rather than merely reordered. A companion correctness
+fix makes `SyncActivityAdapter.send_reject_log_entry` enqueue against the
+explicit receiving `actor_id` (like the announce path) instead of the DataLayer's
+own scope, so the Reject is delivered correctly even from a shared or
+differently-scoped DataLayer.
+
+### Consequences
+
+- Good: a late-joining replica converges to a contiguous prefix within a few
+  seconds of the tail arriving, regardless of `Announce` order (SYNC-10-004).
+- Good: no new dependence on sender retry behavior — robust against other
+  implementations and lossy/reordering transports.
+- Good: the buffer is a non-ledger holding area (SYNC-13-003), so the
+  "DataLayer presence ⇒ committed + effects applied" invariant is preserved.
+- Neutral: buffered state is in-memory and lost on restart; the SYNC-10 catch-up
+  gate re-syncs any gap after restart, so no durability is required.
+- Bad: adds a per-actor in-memory structure and a drain step on the receive
+  path; bounded by a size cap with farthest-ahead eviction (recoverable via the
+  Reject backstop).
+
+## Validation
+
+- `LedgerGapBuffer` unit tests (`test/core/models/test_ledger_gap_buffer.py`):
+  O(1) drain-next, multi-hop cascade, per-case isolation, duplicate/fork
+  handling, size-bound eviction, per-actor registry.
+- Out-of-order regression tests through `AnnounceLedgerEntryReceivedUseCase`
+  (`test/core/use_cases/received/test_sync.py`): fully-reversed delivery,
+  single-gap click-into-place, multi-gap cascade, shuffled-replay convergence —
+  each asserting no entry is permanently dropped.
+
+## Pros and Cons of the Options
+
+### A. Repair the `Reject → replay` loop only
+
+- Good, because it reuses the existing recovery mechanism with no new state.
+- Bad, because replay re-announces entries individually over the same unordered
+  transport, so the reorder-and-drop race reappears — it cannot guarantee
+  convergence under adversarial ordering.
+- Bad, because correctness depends on the CaseActor reliably processing every
+  Reject during a rapid closure fan-out, which is exactly what failed.
+
+### B. Receiver-side buffering
+
+- Good, because convergence becomes independent of delivery order.
+- Good, because it needs no cooperation from the sender or transport.
+- Good, because it makes the replay path order-robust as a side effect.
+- Neutral, because it introduces bounded, ephemeral per-actor state.
+- Bad, because a misbehaving peer could stream far-future entries (mitigated by
+  the size cap + eviction).
+
+### C. Both
+
+- Good, because it is the most defensive.
+- Bad, because once B is in place a separate replay redesign is redundant for
+  this failure mode — extra surface area for no additional guarantee.
+
+## More Information
+
+Design rationale and the hash-chain "teeth of the zipper" argument (why
+indefinite buffering is safe) are recorded in
+`notes/sync-ledger-replication.md` § "Out-of-Order Delivery and the Ledger Gap
+Buffer". Implemented in PR #1564 (closes #1556).
+
+Generated spec requirements: `sync-ledger-replication.yaml` SYNC-14-001 through
+SYNC-14-006 and the clarification to SYNC-08-005; `outbox.yaml` OX-02-003.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -95,6 +95,8 @@ General information about architectural decision records is available at <https:
   Reconstitution](0035-core-activity-representation-and-envelope-reconstitution.md)
 - [ADR-0036 Per-Machine Dimension Objects for CaseStatus and
   ParticipantStatus](0036-status-dimension-objects.md)
+- [ADR-0037 Buffer Out-of-Order `Announce(CaseLedgerEntry)` Instead of
+  Dropping](0037-buffer-out-of-order-ledger-entries.md)
 
 ## Proposed ADRs
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -255,6 +255,8 @@ nav:
       - Lifecycle-Staged Domain Types: 'adr/0033-lifecycle-staged-case-types.md'
       - DataLayer Returns Core Objects: 'adr/0034-datalayer-returns-core-objects.md'
       - Core Activity Representation and Envelope Reconstitution: 'adr/0035-core-activity-representation-and-envelope-reconstitution.md'
+      - Per-Machine Dimension Objects for CaseStatus and ParticipantStatus: 'adr/0036-status-dimension-objects.md'
+      - Buffer Out-of-Order Announce(CaseLedgerEntry) Instead of Dropping: 'adr/0037-buffer-out-of-order-ledger-entries.md'
   - About:
     - Contributing: 'about/contributing.md'
     - FAQ: 'about/faq.md'

--- a/notes/sync-ledger-replication.md
+++ b/notes/sync-ledger-replication.md
@@ -384,6 +384,54 @@ entry "appear" in the peer DL must seed the case on the peer instead.
 
 ---
 
+## Out-of-Order Delivery and the Ledger Gap Buffer (SYNC-10-004)
+
+`Announce(CaseLedgerEntry)` travels over a transport with **no ordering
+guarantee**, and Vultron may not be the only protocol implementation on the
+wire. A participant replica can therefore receive an entry before its
+hash-chain predecessor. The bare reject-on-mismatch path
+(`CheckHashOrRejectOnMismatchNode` → `SendRejectLogEntryNode`) *dropped* such an
+entry and relied on a `Reject → replay` round-trip to redeliver it. That
+recovery is itself order-fragile — `SendMissingEntriesNode` replays each missing
+entry as a *separate* `Announce`, which can reorder again and hit the same drop
+— so under adversarial reordering an entry could be lost indefinitely
+(issue #1556, observed as Vendor2 stalling at case closure in the FVV demo).
+
+**Resolution: receiver-side buffering makes convergence order-independent.**
+
+- `LedgerGapBuffer` (`vultron/core/models/ledger_gap_buffer.py`) is an
+  actor-local, per-case, in-memory store of forward-gap entries, mirroring
+  `PendingAssertionStore`: per-actor module-level registry, ephemeral (lost on
+  restart; the SYNC-10 catch-up gate re-syncs), **not** a DataLayer entity. This
+  is the "clearly separate, non-ledger holding area" sanctioned by SYNC-13-003 —
+  presence of a `CaseLedgerEntry` in the DataLayer still means "effects applied
+  and entry committed" (SYNC-13-001).
+- **Keyed on `prev_log_hash`** (the entry's upstream tooth). The successor of a
+  just-persisted tail is exactly `buffer[new_tail.entry_hash]` — an O(1) lookup,
+  so a contiguous buffered run of *k* entries drains in O(k). Keying on `id_`,
+  `entry_hash`, or a plain list would make find-next O(n) and the cascade O(n²).
+- **On mismatch:** if the entry is a genuine *forward* gap
+  (`log_index > tail_index + 1`) it is buffered; a `Reject(CaseLedgerEntry)` is
+  **still always sent** as the backstop for entries that are genuinely *lost*
+  (never delivered) rather than merely reordered. Stale/at-or-behind-tail
+  entries are not buffered — they fall straight through to the reject.
+- **On commit:** `AnnounceLedgerEntryReceivedUseCase` drains the buffer — for
+  each newly committed tail it re-runs the announce receive BT on the buffered
+  successor, reusing the exact effects-before-persist path (SYNC-12-001) and
+  cascading until no buffered entry extends the tail.
+- **Bounded:** the buffer caps per-case size and evicts the entry farthest ahead
+  of the gap (highest `log_index`) with a WARNING; eviction is recoverable via
+  the Reject already sent, so it never has to re-trigger recovery itself.
+
+Because replayed entries flow through the *same* receive path, buffering also
+makes the `Reject → replay` recovery order-robust for free — no separate
+redesign of the replay loop was needed. A companion fix made
+`SyncActivityAdapter.send_reject_log_entry` enqueue against the explicit
+receiving `actor_id` (via `add_activity_to_outbox` / `record_outbox_item`)
+instead of the DL's own scope (`outbox_append`), matching
+`send_announce_log_entry` so a reject is delivered correctly even from a
+shared/differently-scoped DataLayer.
+
 ## Pre-SYNC-13 Upgrade Path
 
 Nodes that ran pre-SYNC-13 code may hold stale `{entry: stored, effects: not-applied}`

--- a/plan/history/2607/implementation/ISSUE-1556.md
+++ b/plan/history/2607/implementation/ISSUE-1556.md
@@ -1,0 +1,41 @@
+---
+source: ISSUE-1556
+timestamp: '2026-07-21T16:58:38.160714+00:00'
+title: SYNC out-of-order Announce(CaseLedgerEntry) buffering
+type: implementation
+---
+
+## Symptoms
+
+At case closure a late-joining replica (Vendor2 in the FVV/FVCV demos) received
+`Announce(CaseLedgerEntry)` activities out of order and permanently dropped the
+ones whose `prev_log_hash` did not match its local tail, stalling with a gapped
+ledger. `wait_for_contiguous_ledger_coverage` timed out.
+
+## Root cause
+
+The receive path dropped forward-gap entries and relied on a `Reject → replay`
+round-trip that is itself order-fragile (each replayed entry is a separate
+`Announce` that can reorder again and hit the same drop). Under an unordered
+transport an entry could be lost indefinitely. A secondary defect:
+`SyncActivityAdapter.send_reject_log_entry` enqueued via scope-dependent
+`outbox_append` instead of explicit-actor `record_outbox_item`.
+
+## Fix
+
+Receiver-side buffering makes convergence order-independent (SYNC-10-004):
+
+- New `LedgerGapBuffer` (actor-local, per-case, in-memory, ephemeral; mirrors
+  `PendingAssertionStore`), keyed on `prev_log_hash` for O(1) drain-next and
+  O(k) cascades; size-bounded with farthest-ahead eviction.
+- On mismatch, buffer genuine forward gaps and still send the Reject as the
+  loss backstop; after each commit, drain buffered successors by re-running the
+  announce BT (reusing the SYNC-12-001 effects-before-persist path).
+- `send_reject_log_entry` now uses `add_activity_to_outbox` (explicit actor).
+
+Replay is order-robust for free since replayed entries flow through the same
+receive path. Tests: `LedgerGapBuffer` unit tests + reversed / single-gap /
+multi-gap-cascade / shuffled-replay regression tests through
+`AnnounceLedgerEntryReceivedUseCase`.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1564>

--- a/plan/incoming/learnings/20260721-ledger-gap-buffer-key-on-prev-hash.md
+++ b/plan/incoming/learnings/20260721-ledger-gap-buffer-key-on-prev-hash.md
@@ -1,0 +1,38 @@
+---
+title: "Buffer out-of-order ledger entries keyed on prev_log_hash for O(1) drain"
+type: learning
+timestamp: "2026-07-21"
+source: ISSUE-1556
+---
+
+`Announce(CaseLedgerEntry)` has no delivery-ordering guarantee (and Vultron may
+not be the only implementation on the wire), so a replica can receive an entry
+before its hash-chain predecessor. The old receive path dropped such an entry
+and relied on a `Reject → replay` round-trip that is itself order-fragile
+(`SendMissingEntriesNode` replays each entry as a separate `Announce`), so under
+reordering an entry could be lost indefinitely.
+
+**Fix:** receiver-side `LedgerGapBuffer` (`vultron/core/models/ledger_gap_buffer.py`)
+makes convergence order-independent. Key design choices:
+
+- **Key on `prev_log_hash`, not `id_`/`entry_hash`/a list.** The drain question
+  is "what buffered entry extends my new tail?" — that entry is exactly
+  `buffer[new_tail.entry_hash]` (because `entry.prev_log_hash ==
+  predecessor.entry_hash`). O(1) per hop → O(k) cascade. Any other key makes
+  find-next O(n) and the cascade O(n²).
+- **Hash-chaining makes indefinite buffering safe.** A held entry waits for the
+  exact predecessor hash ("teeth of the zipper"), so a fork/rewrite can't
+  masquerade as the successor. Expiry is therefore pure memory hygiene
+  (size-bound eviction of the farthest-ahead entry), never a correctness knob.
+- **Mirror `PendingAssertionStore`**: actor-local, per-case, in-memory,
+  module-level per-actor registry, ephemeral. It is the "clearly separate,
+  non-ledger holding area" SYNC-13-003 sanctions — DataLayer presence still
+  means "committed + effects applied" (SYNC-13-001).
+- **Drain by re-running the announce BT** on each buffered successor rather than
+  duplicating apply-effects logic — reuses the exact effects-before-persist path
+  (SYNC-12-001) for free.
+
+Buffering also makes the `Reject → replay` recovery order-robust automatically,
+because replayed entries flow through the same receive path — no separate replay
+redesign was needed. Keep sending the `Reject` at buffer time as the backstop
+for entries that are genuinely lost (never delivered) rather than reordered.

--- a/plan/incoming/learnings/20260721-reject-outbox-must-use-explicit-actor-queue.md
+++ b/plan/incoming/learnings/20260721-reject-outbox-must-use-explicit-actor-queue.md
@@ -1,0 +1,26 @@
+---
+title: "Sync reject outbox must enqueue against explicit actor_id, not DL scope"
+type: learning
+timestamp: "2026-07-21"
+source: ISSUE-1556
+---
+
+`SyncActivityAdapter.send_reject_log_entry` used `self._dl.outbox_append(id)`,
+which enqueues against the DataLayer's *own* `_actor_id` scope and wakes
+`_enqueue_callback(dl._actor_id)`. Its sibling `send_announce_log_entry` used
+`add_activity_to_outbox(actor_id, id, dl)` → `record_outbox_item(actor_id, id)`,
+which enqueues against the *explicit* recipient actor regardless of the DL's
+scope. When the reject is emitted from a shared or differently-scoped DataLayer,
+`outbox_append` can queue it to the wrong (or empty-scope) outbox — a plausible
+contributor to "the CaseActor never processes the participant's Reject" at
+closure fan-out.
+
+**Rule:** any adapter that emits an activity *on behalf of a specific actor*
+must enqueue with `record_outbox_item(actor_id, …)` / `add_activity_to_outbox`,
+never the scope-dependent `outbox_append`. `outbox_append` is only correct when
+the DL is already scoped to the emitting actor and that scope is guaranteed.
+
+Test impact: tests asserting the reject lands in `dl.outbox_list()` (the
+DL-scope queue) must switch to `dl.outbox_list_for_actor(receiving_actor_id)`
+and set `receiving_actor_id` on the event (the inbox pipeline always does this
+in production).

--- a/specs/outbox.yaml
+++ b/specs/outbox.yaml
@@ -37,6 +37,21 @@ groups:
     priority: MUST
     kind: implementation
     statement: Each outbox activity MUST conform to ActivityStreams 2.0 structure
+  - id: OX-02-003
+    priority: MUST
+    kind: implementation
+    statement: >-
+      When an adapter enqueues an activity on behalf of a specific emitting actor, it MUST
+      enqueue against that actor's outbox explicitly (e.g. record_outbox_item(actor_id, ...)),
+      NOT via a scope-dependent append that targets the DataLayer instance's own actor scope.
+      A scope-dependent append is correct only when the DataLayer is guaranteed to be scoped
+      to the emitting actor.
+    rationale: >-
+      SyncActivityAdapter.send_reject_log_entry used the scope-dependent outbox_append while
+      its sibling send_announce_log_entry used the explicit-actor record_outbox_item; from a
+      shared or differently-scoped DataLayer the reject could be queued to the wrong (or
+      empty-scope) outbox, so the CaseActor never received the participant's
+      Reject(CaseLedgerEntry). See ADR-0037 (docs/adr/0037-buffer-out-of-order-ledger-entries.md).
 - id: OX-03
   title: Outbox Delivery
   specs:

--- a/specs/sync-ledger-replication.yaml
+++ b/specs/sync-ledger-replication.yaml
@@ -203,6 +203,13 @@ groups:
     kind: domain
     statement: 'Reject-on-divergence: entries that do not extend the current hash chain MUST be rejected and MUST trigger
       resynchronization'
+    rationale: >-
+      "Rejected" means "not applied and not persisted as the current tail"; it
+      does NOT require discarding the entry. A forward-gap entry (a valid entry
+      whose predecessor has not yet arrived) MAY be retained in the non-ledger
+      holding area of SYNC-14 pending its predecessor, and MUST still trigger
+      resynchronization (the Reject remains the backstop for genuinely lost
+      entries). See ADR-0037 (docs/adr/0037-buffer-out-of-order-ledger-entries.md).
 - id: SYNC-10
   title: Catch-Up Gate Before New Actions
   specs:
@@ -357,3 +364,76 @@ groups:
       inline object obtained during parsing, without requiring a DataLayer round-trip; the
       SYNC-12-003 already-stored gate MUST remain the sole mechanism that distinguishes
       first delivery from repeat delivery.
+- id: SYNC-14
+  title: Out-of-Order Entry Buffering and Drain
+  description: >-
+    Announce(CaseLedgerEntry) is delivered over a transport with no ordering guarantee, and
+    Vultron may not be the only implementation on the wire, so a replica can receive an entry
+    before its hash-chain predecessor. Dropping such an entry and relying on a reject/replay
+    round-trip does not converge under adversarial reordering, because replay re-announces
+    entries individually over the same unordered transport (they can reorder and be dropped
+    again). These requirements make replica convergence independent of delivery order by
+    holding forward-gap entries in a non-ledger buffer and draining them in hash-chain order
+    once the entry that closes the gap is committed. Rationale: ADR-0037
+    (docs/adr/0037-buffer-out-of-order-ledger-entries.md).
+  specs:
+  - id: SYNC-14-001
+    priority: MUST
+    kind: domain
+    statement: >-
+      When a participant receives a valid Announce(CaseLedgerEntry) whose prev_log_hash does
+      not match its current chain tail but whose log_index is strictly greater than
+      tail_index + 1 (a forward gap), the participant MUST NOT permanently discard the entry;
+      it MUST retain the entry in a holding area pending arrival of its predecessor.
+    rationale: >-
+      The hash chain makes indefinite retention safe: a held entry is applied only when an
+      entry whose entry_hash equals the held entry's prev_log_hash is committed, so a
+      fork/rewrite cannot masquerade as the predecessor.
+  - id: SYNC-14-002
+    priority: MUST
+    kind: domain
+    statement: >-
+      A forward-gap entry that is buffered MUST still trigger resynchronization (SYNC-08-005)
+      — the participant MUST send Reject(CaseLedgerEntry) carrying its last accepted hash so
+      the CaseActor replays entries that are genuinely lost (never delivered) rather than
+      merely reordered.
+  - id: SYNC-14-003
+    priority: MUST
+    kind: domain
+    statement: >-
+      After a participant commits a CaseLedgerEntry, it MUST drain the holding area: for each
+      newly committed tail, it MUST locate the buffered entry (if any) whose prev_log_hash
+      equals the new tail's entry_hash, apply that entry, and repeat, cascading until no
+      buffered entry extends the current tail.
+  - id: SYNC-14-004
+    priority: MUST
+    kind: domain
+    statement: >-
+      Draining a buffered entry MUST apply the entry's domain effects before persisting it
+      (SYNC-12-001) and MUST NOT re-apply effects for an entry already present in the local
+      ledger (SYNC-12-003); the drain path MUST be the same apply-then-persist path used for
+      in-order delivery.
+    relationships:
+    - rel_type: depends_on
+      spec_id: SYNC-12-001
+      note: The drain MUST preserve the effects-before-persist invariant per applied entry
+  - id: SYNC-14-005
+    priority: MUST_NOT
+    kind: domain
+    statement: >-
+      The out-of-order holding area MUST NOT be the canonical ledger/DataLayer store; a
+      buffered entry MUST NOT be persisted as a CaseLedgerEntry until it is drained (i.e.
+      until its predecessor is present), so that presence of a CaseLedgerEntry in the
+      DataLayer continues to mean "committed and effects applied" (SYNC-13-001).
+    relationships:
+    - rel_type: depends_on
+      spec_id: SYNC-13-001
+      note: Buffering in the DataLayer would break the presence-means-committed invariant
+  - id: SYNC-14-006
+    priority: SHOULD
+    kind: domain
+    statement: >-
+      The holding area SHOULD be bounded in size per case; when full it SHOULD evict the
+      entry farthest ahead of the current gap (highest log_index) and log a warning. Eviction
+      is recoverable because SYNC-14-002 already sent a Reject, so eviction MUST NOT be relied
+      upon to trigger recovery by itself.

--- a/test/core/behaviors/sync/nodes/test_receive.py
+++ b/test/core/behaviors/sync/nodes/test_receive.py
@@ -10,7 +10,10 @@ from test.core.behaviors.sync.nodes.conftest import (
     _make_entry,
     _make_event,
 )
+import py_trees
+
 from vultron.core.behaviors.sync.nodes import (
+    BufferOutOfOrderEntryNode,
     CheckHashMatchesNode,
     CheckHashOrRejectOnMismatchNode,
     SendRejectLogEntryNode,
@@ -25,7 +28,14 @@ def test_check_hash_or_reject_on_mismatch_is_selector_with_condition_and_action(
     assert tree.name == "CheckHashOrRejectOnMismatch"
     assert len(tree.children) == 2
     assert isinstance(tree.children[0], CheckHashMatchesNode)
-    assert isinstance(tree.children[1], SendRejectLogEntryNode)
+    # Second child buffers a forward gap (so it is not dropped) and then
+    # always sends the reject as the loss backstop (issue #1556).
+    buffer_and_reject = tree.children[1]
+    assert isinstance(buffer_and_reject, py_trees.composites.Sequence)
+    buffer_decorator, reject_node = buffer_and_reject.children
+    assert isinstance(buffer_decorator, py_trees.decorators.FailureIsSuccess)
+    assert isinstance(buffer_decorator.children[0], BufferOutOfOrderEntryNode)
+    assert isinstance(reject_node, SendRejectLogEntryNode)
 
 
 def test_check_hash_matches_node_succeeds_when_hash_matches(

--- a/test/core/behaviors/sync/nodes/test_receive.py
+++ b/test/core/behaviors/sync/nodes/test_receive.py
@@ -18,6 +18,7 @@ from vultron.core.behaviors.sync.nodes import (
     CheckHashOrRejectOnMismatchNode,
     SendRejectLogEntryNode,
 )
+from vultron.core.models.ledger_gap_buffer import LedgerGapBuffer
 from vultron.core.ports.sync_activity import SyncActivityPort
 
 _ZERO_HASH: str = "0" * 64  # arbitrary hash for test chains
@@ -109,3 +110,59 @@ def test_check_hash_or_reject_on_mismatch_short_circuits_on_match(
 
     assert result.status == Status.SUCCESS
     sync_port.send_reject_log_entry.assert_not_called()
+
+
+class TestBufferOutOfOrderEntryNode:
+    """Direct unit tests for BufferOutOfOrderEntryNode.update() branch paths."""
+
+    def test_buffers_genuine_forward_gap(self, bridge, case_actor):
+        """An entry two indices ahead of the tail is a forward gap — buffered → SUCCESS."""
+        gap_buffer = LedgerGapBuffer()
+        # tail_index=0; entry at log_index=2 is a forward gap (> tail+1).
+        entry = _make_entry(2, "deadbeef" * 8)
+        event = _make_event(entry, actor_id=case_actor.id_)
+
+        result = bridge.execute_with_setup(
+            tree=BufferOutOfOrderEntryNode(name="BufferOutOfOrderEntry"),
+            actor_id=PARTICIPANT_ACTOR_ID,
+            activity=event,
+            tail_index=0,
+            gap_buffer=gap_buffer,
+        )
+
+        assert result.status == Status.SUCCESS
+        assert gap_buffer.depth(entry.case_id) == 1
+
+    def test_does_not_buffer_at_tail_entry(self, bridge, case_actor):
+        """An entry at log_index == tail_index + 1 is not a forward gap — FAILURE."""
+        gap_buffer = LedgerGapBuffer()
+        # tail_index=0; entry at log_index=1 is the expected next, not a gap.
+        entry = _make_entry(1, "deadbeef" * 8)
+        event = _make_event(entry, actor_id=case_actor.id_)
+
+        result = bridge.execute_with_setup(
+            tree=BufferOutOfOrderEntryNode(name="BufferOutOfOrderEntry"),
+            actor_id=PARTICIPANT_ACTOR_ID,
+            activity=event,
+            tail_index=0,
+            gap_buffer=gap_buffer,
+        )
+
+        assert result.status == Status.FAILURE
+        assert gap_buffer.depth(entry.case_id) == 0
+
+    def test_returns_failure_when_no_gap_buffer_injected(
+        self, bridge, case_actor
+    ):
+        """Without a gap_buffer on the blackboard, node returns FAILURE silently."""
+        entry = _make_entry(5, "deadbeef" * 8)
+        event = _make_event(entry, actor_id=case_actor.id_)
+
+        result = bridge.execute_with_setup(
+            tree=BufferOutOfOrderEntryNode(name="BufferOutOfOrderEntry"),
+            actor_id=PARTICIPANT_ACTOR_ID,
+            activity=event,
+            tail_index=0,
+        )
+
+        assert result.status == Status.FAILURE

--- a/test/core/models/test_ledger_gap_buffer.py
+++ b/test/core/models/test_ledger_gap_buffer.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Unit tests for :class:`LedgerGapBuffer` (issue #1556, SYNC-10-004)."""
+
+import pytest
+
+from vultron.core.models.case_ledger import HashChainLedgerRecord
+from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
+from vultron.core.models.ledger_gap_buffer import (
+    LedgerGapBuffer,
+    _reset_buffers,
+    get_ledger_gap_buffer,
+)
+
+CASE_A = "https://example.org/cases/a"
+CASE_B = "https://example.org/cases/b"
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry():
+    _reset_buffers()
+    yield
+    _reset_buffers()
+
+
+def _entry(
+    log_index: int, prev_hash: str, case_id: str = CASE_A
+) -> VultronCaseLedgerEntry:
+    chain = HashChainLedgerRecord(
+        case_id=case_id,
+        log_index=log_index,
+        object_id=f"{case_id}/activities/act-{log_index}",
+        event_type="test_event",
+        payload_snapshot={"log_index": log_index},
+        prev_log_hash=prev_hash,
+    )
+    return VultronCaseLedgerEntry(
+        case_id=chain.case_id,
+        log_index=chain.log_index,
+        disposition=chain.disposition,
+        term=chain.term,
+        log_object_id=chain.object_id,
+        event_type=chain.event_type,
+        payload_snapshot=dict(chain.payload_snapshot),
+        prev_log_hash=chain.prev_log_hash,
+        entry_hash=chain.entry_hash,
+    )
+
+
+def _chain(length: int, case_id: str = CASE_A) -> list[VultronCaseLedgerEntry]:
+    entries: list[VultronCaseLedgerEntry] = []
+    prev = "0" * 64
+    for i in range(length):
+        entry = _entry(i, prev, case_id)
+        entries.append(entry)
+        prev = entry.entry_hash
+    return entries
+
+
+class TestBufferAndTakeNext:
+    def test_take_next_returns_none_when_empty(self):
+        buf = LedgerGapBuffer()
+        assert buf.take_next(CASE_A, "0" * 64) is None
+
+    def test_buffer_then_take_next_by_predecessor_hash(self):
+        buf = LedgerGapBuffer()
+        e0, e1 = _chain(2)
+        assert buf.buffer(e1) is True
+        assert buf.depth(CASE_A) == 1
+        # e1's predecessor is e0; keyed on e1.prev_log_hash == e0.entry_hash.
+        taken = buf.take_next(CASE_A, e0.entry_hash)
+        assert taken is not None
+        assert taken.log_index == 1
+        assert buf.depth(CASE_A) == 0
+
+    def test_take_next_wrong_tail_returns_none(self):
+        buf = LedgerGapBuffer()
+        _e0, e1, _e2 = _chain(3)
+        buf.buffer(e1)
+        # A tail hash that nothing extends yields None (entry stays buffered).
+        assert buf.take_next(CASE_A, "deadbeef" * 8) is None
+        assert buf.depth(CASE_A) == 1
+
+    def test_cascade_drain_in_order(self):
+        """A contiguous buffered run drains one hop at a time in O(1) lookups."""
+        entries = _chain(5)  # 0..4
+        buf = LedgerGapBuffer()
+        for e in entries[1:]:  # buffer 1,2,3,4
+            buf.buffer(e)
+        assert buf.depth(CASE_A) == 4
+
+        tail = entries[0].entry_hash  # pretend 0 was just persisted
+        drained = []
+        while (nxt := buf.take_next(CASE_A, tail)) is not None:
+            drained.append(nxt.log_index)
+            tail = nxt.entry_hash
+        assert drained == [1, 2, 3, 4]
+        assert buf.depth(CASE_A) == 0
+
+    def test_cases_are_isolated(self):
+        buf = LedgerGapBuffer()
+        a0, a1 = _chain(2, CASE_A)
+        b0, b1 = _chain(2, CASE_B)
+        buf.buffer(a1)
+        buf.buffer(b1)
+        assert buf.depth(CASE_A) == 1
+        assert buf.depth(CASE_B) == 1
+        # Draining case A's tail must not touch case B.
+        assert buf.take_next(CASE_A, a0.entry_hash) is not None
+        assert buf.depth(CASE_B) == 1
+        assert buf.take_next(CASE_B, b0.entry_hash) is not None
+
+
+class TestDuplicatesAndForks:
+    def test_exact_duplicate_is_noop(self):
+        buf = LedgerGapBuffer()
+        _e0, e1 = _chain(2)
+        assert buf.buffer(e1) is True
+        assert buf.buffer(e1) is True
+        assert buf.depth(CASE_A) == 1
+
+    def test_fork_replaces_and_warns(self, caplog):
+        buf = LedgerGapBuffer()
+        _e0, e1 = _chain(2)
+        # A second entry sharing e1's prev_log_hash but a different content
+        # hash is a fork; the newer one replaces it (WARNING logged).
+        fork = _entry(1, e1.prev_log_hash)
+        object.__setattr__(fork, "entry_hash", "f" * 64)
+        buf.buffer(e1)
+        with caplog.at_level("WARNING"):
+            buf.buffer(fork)
+        assert buf.depth(CASE_A) == 1
+        assert any("forked" in r.message for r in caplog.records)
+
+
+class TestSizeBound:
+    def test_zero_max_disables_buffering(self):
+        buf = LedgerGapBuffer(max_entries=0)
+        _e0, e1 = _chain(2)
+        assert buf.buffer(e1) is False
+        assert buf.depth(CASE_A) == 0
+
+    def test_full_buffer_evicts_farthest_ahead(self, caplog):
+        """When full, the farthest-ahead entry is evicted to admit a closer one."""
+        entries = _chain(6)  # 0..5
+        buf = LedgerGapBuffer(max_entries=2)
+        # Buffer the two farthest-ahead entries (4, 5).
+        buf.buffer(entries[4])
+        buf.buffer(entries[5])
+        assert buf.depth(CASE_A) == 2
+        # A closer entry (2) should evict the farthest (5) and be admitted.
+        with caplog.at_level("WARNING"):
+            assert buf.buffer(entries[2]) is True
+        assert buf.depth(CASE_A) == 2
+        # Index 5 (farthest) is gone; index 2 present.
+        assert buf.take_next(CASE_A, entries[1].entry_hash) is not None
+        assert buf.take_next(CASE_A, entries[4].entry_hash) is None
+
+    def test_full_buffer_drops_incoming_when_it_is_farthest(self, caplog):
+        entries = _chain(6)
+        buf = LedgerGapBuffer(max_entries=2)
+        buf.buffer(entries[2])
+        buf.buffer(entries[3])
+        with caplog.at_level("WARNING"):
+            # index 5 is farther ahead than everything buffered → dropped.
+            assert buf.buffer(entries[5]) is False
+        assert buf.depth(CASE_A) == 2
+
+
+class TestRegistry:
+    def test_get_ledger_gap_buffer_is_per_actor_singleton(self):
+        a = get_ledger_gap_buffer("actor-1")
+        b = get_ledger_gap_buffer("actor-1")
+        c = get_ledger_gap_buffer("actor-2")
+        assert a is b
+        assert a is not c
+
+    def test_reset_buffers_clears_registry(self):
+        a = get_ledger_gap_buffer("actor-1")
+        _reset_buffers()
+        assert get_ledger_gap_buffer("actor-1") is not a

--- a/test/core/use_cases/received/test_sync.py
+++ b/test/core/use_cases/received/test_sync.py
@@ -24,6 +24,7 @@ from vultron.core.models.case_ledger import (
 )
 from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
 from vultron.core.models.events import MessageSemantics
+from vultron.core.models.ledger_gap_buffer import LedgerGapBuffer
 from vultron.core.ports.sync_activity import SyncActivityPort
 from vultron.core.use_cases.received.sync import (
     AnnounceLedgerEntryReceivedUseCase,
@@ -155,6 +156,9 @@ class TestReconstructTailHash:
         assert tail_index == 0
 
 
+RECEIVER_URI = "https://example.org/actors/reporter"
+
+
 class TestAnnounceLedgerEntryReceivedUseCase:
     def _make_event(
         self, entry: VultronCaseLedgerEntry
@@ -163,7 +167,11 @@ class TestAnnounceLedgerEntryReceivedUseCase:
             entry.model_dump(mode="json")
         )
         activity = announce_log_entry_activity(wire_entry, actor=ACTOR_URI)
-        return cast(AnnounceLogEntryReceivedEvent, extract_event(activity))
+        event = cast(AnnounceLogEntryReceivedEvent, extract_event(activity))
+        # The inbox adapter always sets receiving_actor_id in production; set
+        # it here so the reject is enqueued against the receiving actor's
+        # outbox (matching send_announce_log_entry's explicit-actor queueing).
+        return event.model_copy(update={"receiving_actor_id": RECEIVER_URI})
 
     def test_inline_case_ledger_entry_round_trip(self, first_entry):
         """parse_activity must preserve inline as_CaseLedgerEntry fields (BUG-26041501).
@@ -222,8 +230,8 @@ class TestAnnounceLedgerEntryReceivedUseCase:
         # Bad entry still not stored
         assert dl.read(bad_entry.id_) is None
 
-        # A Reject activity should be queued in the outbox
-        queued = dl.outbox_list()
+        # A Reject activity should be queued in the receiving actor's outbox
+        queued = dl.outbox_list_for_actor(RECEIVER_URI)
         assert len(queued) == 1
 
         reject_obj = dl.read(queued[0])
@@ -246,7 +254,7 @@ class TestAnnounceLedgerEntryReceivedUseCase:
             dl, event, sync_port=sync_port
         ).execute()
 
-        queued = dl.outbox_list()
+        queued = dl.outbox_list_for_actor(RECEIVER_URI)
         reject_obj = dl.read(queued[0])
         assert getattr(reject_obj, "context", None) == first_entry.entry_hash
 
@@ -260,7 +268,7 @@ class TestAnnounceLedgerEntryReceivedUseCase:
             dl, event, sync_port=sync_port
         ).execute()
 
-        queued = dl.outbox_list()
+        queued = dl.outbox_list_for_actor(RECEIVER_URI)
         reject_obj = dl.read(queued[0])
         to_field = getattr(reject_obj, "to", None) or []
         assert ACTOR_URI in to_field
@@ -298,3 +306,169 @@ class TestAnnounceLedgerEntryReceivedUseCase:
         )
         assert event.log_entry is not None
         assert event.log_entry.case_id == CASE_URI
+
+
+class TestOutOfOrderAnnounceBuffering:
+    """Out-of-order ``Announce(CaseLedgerEntry)`` must not permanently drop
+    entries; the replica converges to a contiguous prefix regardless of
+    delivery order (issue #1556, SYNC-10-004).
+    """
+
+    @pytest.fixture
+    def gap_buffer(self) -> LedgerGapBuffer:
+        return LedgerGapBuffer()
+
+    def _make_event(
+        self, entry: VultronCaseLedgerEntry
+    ) -> AnnounceLogEntryReceivedEvent:
+        wire_entry = WireCaseLedgerEntry.model_validate(
+            entry.model_dump(mode="json")
+        )
+        activity = announce_log_entry_activity(wire_entry, actor=ACTOR_URI)
+        return cast(AnnounceLogEntryReceivedEvent, extract_event(activity))
+
+    def _chain(
+        self, case: VulnerabilityCase, length: int
+    ) -> list[VultronCaseLedgerEntry]:
+        """Build a valid hash chain of *length* entries anchored on genesis."""
+        entries: list[VultronCaseLedgerEntry] = []
+        prev = case.genesis_hash
+        for i in range(length):
+            entry = _make_entry(CASE_URI, i, prev)
+            entries.append(entry)
+            prev = entry.entry_hash
+        return entries
+
+    def _present_indices(self, dl: SqliteDataLayer) -> set[int]:
+        return {
+            obj.log_index
+            for obj in dl.list_objects("CaseLedgerEntry")
+            if getattr(obj, "case_id", None) == CASE_URI
+            and isinstance(obj, VultronCaseLedgerEntry)
+        }
+
+    def test_reversed_delivery_converges_to_contiguous_prefix(
+        self, dl, case_with_genesis, gap_buffer
+    ):
+        """Delivering a 3-entry chain fully reversed (2, 1, 0) must leave all
+        three entries stored — no entry is permanently dropped.
+        """
+        e0, e1, e2 = self._chain(case_with_genesis, 3)
+        sync_port = MagicMock(spec=SyncActivityPort)
+
+        # Reverse order: the two later entries arrive before their predecessor.
+        for entry in (e2, e1, e0):
+            AnnounceLedgerEntryReceivedUseCase(
+                dl,
+                self._make_event(entry),
+                sync_port=sync_port,
+                gap_buffer=gap_buffer,
+            ).execute()
+
+        assert self._present_indices(dl) == {0, 1, 2}
+
+    def test_single_gap_then_predecessor_clicks_into_place(
+        self, dl, case_with_genesis, gap_buffer
+    ):
+        """Index 1 arriving before index 0 must be buffered and applied once
+        index 0 lands (the minimal out-of-order case).
+        """
+        e0, e1 = self._chain(case_with_genesis, 2)
+        sync_port = MagicMock(spec=SyncActivityPort)
+
+        AnnounceLedgerEntryReceivedUseCase(
+            dl,
+            self._make_event(e1),
+            sync_port=sync_port,
+            gap_buffer=gap_buffer,
+        ).execute()
+        # Before the predecessor arrives, nothing is stored but the entry is
+        # held in the buffer (not dropped).
+        assert self._present_indices(dl) == set()
+        assert gap_buffer.depth(CASE_URI) == 1
+
+        AnnounceLedgerEntryReceivedUseCase(
+            dl,
+            self._make_event(e0),
+            sync_port=sync_port,
+            gap_buffer=gap_buffer,
+        ).execute()
+        assert self._present_indices(dl) == {0, 1}
+        assert gap_buffer.depth(CASE_URI) == 0
+
+    def test_multi_gap_cascade_drains_all_successors(
+        self, dl, case_with_genesis, gap_buffer
+    ):
+        """With 4, 5 and 6 buffered, delivering 3 must cascade-drain all of
+        them once the gap at index 3 is closed.
+
+        Mirrors the maintainer's zipper example: 0,1,2 present, later entries
+        buffered, the predecessor arrives → the whole contiguous run clicks
+        into place in one drain.
+        """
+        e0, e1, e2, e3, e4, e5, e6 = self._chain(case_with_genesis, 7)
+        sync_port = MagicMock(spec=SyncActivityPort)
+
+        # Establish a contiguous prefix 0,1,2.
+        for entry in (e0, e1, e2):
+            AnnounceLedgerEntryReceivedUseCase(
+                dl,
+                self._make_event(entry),
+                sync_port=sync_port,
+                gap_buffer=gap_buffer,
+            ).execute()
+        assert self._present_indices(dl) == {0, 1, 2}
+
+        # 4, 5 and 6 arrive out of order (all forward gaps) and are buffered.
+        for entry in (e4, e5, e6):
+            AnnounceLedgerEntryReceivedUseCase(
+                dl,
+                self._make_event(entry),
+                sync_port=sync_port,
+                gap_buffer=gap_buffer,
+            ).execute()
+        assert self._present_indices(dl) == {0, 1, 2}
+        assert gap_buffer.depth(CASE_URI) == 3
+
+        # 3 lands → cascade should drain 4, 5, 6 as well.
+        AnnounceLedgerEntryReceivedUseCase(
+            dl,
+            self._make_event(e3),
+            sync_port=sync_port,
+            gap_buffer=gap_buffer,
+        ).execute()
+        assert self._present_indices(dl) == {0, 1, 2, 3, 4, 5, 6}
+        assert gap_buffer.depth(CASE_URI) == 0
+
+    def test_replayed_entries_out_of_order_still_converge(
+        self, dl, case_with_genesis, gap_buffer
+    ):
+        """The CaseActor replay path (SYNC-03-002) sends each missing entry as
+        a separate ``Announce`` over an unordered transport.  Those replays flow
+        through the *same* receive path, so out-of-order replays are buffered
+        and drained just like normal fan-out — the participant converges
+        regardless of replay delivery order (issue #1556 finding: replay was
+        order-fragile before buffering).
+        """
+        # Participant is stuck at index 0; the CaseActor replays 1..4.
+        entries = self._chain(case_with_genesis, 5)
+        sync_port = MagicMock(spec=SyncActivityPort)
+        AnnounceLedgerEntryReceivedUseCase(
+            dl,
+            self._make_event(entries[0]),
+            sync_port=sync_port,
+            gap_buffer=gap_buffer,
+        ).execute()
+        assert self._present_indices(dl) == {0}
+
+        # Replayed entries arrive in a shuffled order (3, 1, 4, 2).
+        for entry in (entries[3], entries[1], entries[4], entries[2]):
+            AnnounceLedgerEntryReceivedUseCase(
+                dl,
+                self._make_event(entry),
+                sync_port=sync_port,
+                gap_buffer=gap_buffer,
+            ).execute()
+
+        assert self._present_indices(dl) == {0, 1, 2, 3, 4}
+        assert gap_buffer.depth(CASE_URI) == 0

--- a/vultron/adapters/driven/sync_activity_adapter.py
+++ b/vultron/adapters/driven/sync_activity_adapter.py
@@ -82,7 +82,10 @@ class SyncActivityAdapter:
             to=to,
         )
         self._dl.save(reject)
-        self._dl.outbox_append(reject.id_)
+        # Enqueue against *actor_id* explicitly (not the DL's own scope) so the
+        # reject is delivered correctly even when ``self._dl`` is a shared or
+        # differently-scoped DataLayer — matching send_announce_log_entry.
+        add_activity_to_outbox(actor_id, reject.id_, self._dl)
         logger.info(
             "sync adapter: queued Reject(CaseLedgerEntry) '%s' → %s",
             reject.id_,

--- a/vultron/core/behaviors/sync/nodes/__init__.py
+++ b/vultron/core/behaviors/sync/nodes/__init__.py
@@ -48,6 +48,7 @@ from vultron.core.behaviors.sync.nodes.conditions import (
     _require_log_entry,  # noqa: F401
 )
 from vultron.core.behaviors.sync.nodes.receive import (
+    BufferOutOfOrderEntryNode,
     CheckHashMatchesNode,
     CheckHashOrRejectOnMismatchNode,
     LogDeliveryConfirmationNode,
@@ -89,6 +90,7 @@ __all__ = [
     "LogDeliveryConfirmationNode",
     "PersistReceivedLogEntryNode",
     "CheckHashMatchesNode",
+    "BufferOutOfOrderEntryNode",
     "SendRejectLogEntryNode",
     "CheckHashOrRejectOnMismatchNode",
     # chain

--- a/vultron/core/behaviors/sync/nodes/receive.py
+++ b/vultron/core/behaviors/sync/nodes/receive.py
@@ -25,6 +25,7 @@ from py_trees.common import Status
 from vultron.core.behaviors.helpers import DataLayerAction, DataLayerCondition
 from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
 from vultron.core.models.case_ledger_entry import CaseLedgerEntry
+from vultron.core.models.ledger_gap_buffer import LedgerGapBuffer
 from vultron.core.ports.sync_activity import SyncActivityPort
 from vultron.errors import VultronError
 
@@ -106,6 +107,89 @@ class CheckHashMatchesNode(DataLayerCondition):
         return Status.FAILURE
 
 
+class BufferOutOfOrderEntryNode(DataLayerAction):
+    """Hold a forward-gap ledger entry so it is not permanently dropped.
+
+    When a received entry's ``prev_log_hash`` does not match the local tail
+    *and* the entry sits ahead of the tail (``log_index > tail_index + 1``),
+    it is a genuine forward gap: a predecessor has not yet been delivered.
+    Because delivery is not ordered (and Vultron may not be the only
+    implementation on the wire), dropping such an entry can lose it
+    permanently.  This node parks the entry in the actor-local
+    :class:`~vultron.core.models.ledger_gap_buffer.LedgerGapBuffer` keyed by its
+    ``prev_log_hash`` so the receive path can drain it once its predecessor
+    arrives (issue #1556, SYNC-10-004).
+
+    Returns SUCCESS when the entry was buffered, FAILURE otherwise (buffering
+    disabled, no gap buffer injected, a stale/duplicate entry at-or-behind the
+    tail, or the size bound dropped it).  Its status only structures the
+    enclosing tree — a ``Reject(CaseLedgerEntry)`` is sent on **every** mismatch
+    regardless of whether buffering succeeded, so the CaseActor's replay remains
+    the backstop against a predecessor that is genuinely lost (never delivered)
+    rather than merely reordered.  The entry is deliberately NOT persisted here;
+    the drain applies effects before persisting, honouring SYNC-12-001.
+    """
+
+    def __init__(self, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self._gap_buffer: LedgerGapBuffer | None = None
+
+    def setup(self, **kwargs: Any) -> None:
+        super().setup(**kwargs)
+        self.blackboard.register_key(
+            key="activity", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="tail_index", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="gap_buffer", access=py_trees.common.Access.READ
+        )
+
+    def initialise(self) -> None:
+        super().initialise()
+        try:
+            self._gap_buffer = cast(
+                LedgerGapBuffer, self.blackboard.gap_buffer
+            )
+        except (AttributeError, KeyError):
+            self._gap_buffer = None
+
+    def update(self) -> Status:
+        if self._gap_buffer is None:
+            return Status.FAILURE
+
+        entry = _require_log_entry(self.blackboard.activity, self.name)
+        try:
+            tail_index = cast(int, self.blackboard.tail_index)
+        except (AttributeError, KeyError):
+            return Status.FAILURE
+
+        # Only buffer genuine *forward* gaps.  An entry at or behind the tail
+        # index is stale, a duplicate, or a fork — not a reorder we can heal by
+        # waiting, so let it fall through to the rejection path.
+        if entry.log_index <= tail_index + 1:
+            self.logger.debug(
+                "%s: entry index=%d is not a forward gap (tail_index=%d) — "
+                "not buffering",
+                self.name,
+                entry.log_index,
+                tail_index,
+            )
+            return Status.FAILURE
+
+        if self._gap_buffer.buffer(entry):
+            self.logger.info(
+                "%s: buffered out-of-order entry '%s' (index=%d) pending "
+                "predecessor",
+                self.name,
+                entry.id_,
+                entry.log_index,
+            )
+            return Status.SUCCESS
+        return Status.FAILURE
+
+
 class SendRejectLogEntryNode(DataLayerAction):
     def __init__(self, name: str | None = None) -> None:
         super().__init__(name=name or self.__class__.__name__)
@@ -166,12 +250,46 @@ class SendRejectLogEntryNode(DataLayerAction):
 
 
 class CheckHashOrRejectOnMismatchNode(py_trees.composites.Selector):
+    """Accept a chain-extending entry, or buffer-and-reject a mismatch.
+
+    Structure::
+
+        Selector(CheckHashOrRejectOnMismatch)
+          CheckHashMatches                      ← SUCCESS: entry extends tail
+          Sequence(BufferAndReject)
+            FailureIsSuccess(BufferOutOfOrderEntry)  ← buffer forward gaps; the
+                                                        wrapper lets the reject
+                                                        fire whether or not the
+                                                        entry was buffered
+            SendRejectLogEntry                  ← FAILURE: reject sent, entry
+                                                  not persisted this pass
+
+    When the hash matches, the Selector short-circuits SUCCESS and the parent
+    Sequence proceeds to apply effects and persist.  On a mismatch, the entry
+    is buffered when it is a genuine forward gap (so it is not permanently
+    dropped) and a ``Reject(CaseLedgerEntry)`` is always sent as the loss
+    backstop; the Selector then returns FAILURE so ``PersistReceivedLogEntry``
+    does not run for the out-of-order entry (issue #1556, SYNC-10-004).
+    """
+
     def __init__(self, name: str | None = None) -> None:
         super().__init__(
             name=name or self.__class__.__name__,
             memory=False,
             children=[
                 CheckHashMatchesNode(name="CheckHashMatches"),
-                SendRejectLogEntryNode(name="SendRejectLogEntry"),
+                py_trees.composites.Sequence(
+                    name="BufferAndReject",
+                    memory=False,
+                    children=[
+                        py_trees.decorators.FailureIsSuccess(
+                            name="BufferIfForwardGap",
+                            child=BufferOutOfOrderEntryNode(
+                                name="BufferOutOfOrderEntry"
+                            ),
+                        ),
+                        SendRejectLogEntryNode(name="SendRejectLogEntry"),
+                    ],
+                ),
             ],
         )

--- a/vultron/core/models/ledger_gap_buffer.py
+++ b/vultron/core/models/ledger_gap_buffer.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Actor-local in-memory buffer for out-of-order ``Announce(CaseLedgerEntry)``.
+
+Because ``Announce(CaseLedgerEntry)`` activities are delivered over a
+transport that provides **no ordering guarantee** (and Vultron may not be the
+only protocol implementation on the wire), a participant replica can receive a
+ledger entry before its hash-chain predecessor arrives.  Dropping such an entry
+(as the bare reject-on-mismatch path does) makes convergence depend on a
+reject → replay round-trip that may itself reorder — so under adversarial
+delivery an entry can be permanently lost.
+
+:class:`LedgerGapBuffer` holds those *forward-gap* entries and lets the receive
+path drain them in hash-chain order once their predecessor lands, making
+convergence **order-independent** (issue #1556, SYNC-10-004).
+
+Design:
+
+- **Keyed on ``prev_log_hash``** (the entry's upstream "tooth").  The successor
+  of a just-persisted entry is exactly ``buffer[new_tail.entry_hash]`` — an
+  O(1) lookup, so a cascade of *k* contiguous buffered entries drains in O(k).
+- **Actor-local, per-case, in-memory** — mirrors
+  :class:`~vultron.core.models.pending_assertion.PendingAssertionStore`.  It is
+  **not** persisted and **not** a DataLayer entity: SYNC-13 defines presence of
+  a ``CaseLedgerEntry`` in the DataLayer to mean "effects applied and entry
+  committed", so a not-yet-appliable entry MUST live in a clearly separate,
+  non-ledger holding area (SYNC-13-003).  Buffered entries are lost on restart;
+  the catch-up gate (SYNC-10) re-syncs any gap after restart.
+- **Size-bounded** — a broken or hostile peer could stream unbounded
+  far-future entries, so the buffer caps its size and evicts the entry farthest
+  ahead of the gap (highest ``log_index``) with a WARNING.  Recovery of an
+  evicted entry is covered by the ``Reject(CaseLedgerEntry)`` that the receive
+  path still sends when it buffers, so eviction never has to re-trigger
+  recovery itself.
+
+Spec: SYNC-10-004, SYNC-12-001, SYNC-13-003.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
+
+logger = logging.getLogger(__name__)
+
+#: Default maximum number of buffered forward-gap entries per (actor, case).
+#: Sized generously relative to any realistic in-flight reorder window while
+#: still bounding memory against a misbehaving peer.
+DEFAULT_LEDGER_GAP_BUFFER_MAX: int = 256
+
+#: Module-level per-actor registry.  Keyed by actor URI string.  Pure
+#: in-memory — no DataLayer interaction (mirrors ``pending_assertion._STORES``).
+_BUFFERS: dict[str, "LedgerGapBuffer"] = {}
+
+
+class LedgerGapBuffer:
+    """Actor-local, per-case store of out-of-order ledger entries.
+
+    Entries are keyed by ``prev_log_hash`` within each ``case_id`` so that the
+    successor of a newly persisted tail can be found in O(1).
+
+    Args:
+        max_entries: Maximum number of buffered entries per case before the
+            farthest-ahead entry is evicted.  Defaults to
+            :data:`DEFAULT_LEDGER_GAP_BUFFER_MAX`.  A non-positive value
+            disables buffering entirely (every :meth:`buffer` call is dropped),
+            which restores the legacy drop-on-mismatch behaviour.
+    """
+
+    def __init__(
+        self, max_entries: int = DEFAULT_LEDGER_GAP_BUFFER_MAX
+    ) -> None:
+        self.max_entries = max_entries
+        # case_id -> {prev_log_hash -> entry}
+        self._by_case: dict[str, dict[str, VultronCaseLedgerEntry]] = {}
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def buffer(self, entry: VultronCaseLedgerEntry) -> bool:
+        """Hold *entry* until its hash-chain predecessor arrives.
+
+        Keyed by ``entry.prev_log_hash``.  If an entry is already buffered
+        under the same predecessor hash, the new one replaces it only when the
+        content hash differs (a fork/rewrite under a misbehaving peer), logged
+        at WARNING; an exact duplicate is a no-op.
+
+        When the per-case buffer is full, the entry farthest ahead of the gap
+        (highest ``log_index``) is evicted with a WARNING before the new entry
+        is stored — unless the new entry is itself the farthest ahead, in which
+        case it is dropped.
+
+        Args:
+            entry: The forward-gap :class:`VultronCaseLedgerEntry` to hold.
+
+        Returns:
+            ``True`` if the entry is now buffered; ``False`` if buffering is
+            disabled or the entry was dropped by the size bound.
+        """
+        if self.max_entries <= 0:
+            return False
+
+        case_map = self._by_case.setdefault(entry.case_id, {})
+
+        existing = case_map.get(entry.prev_log_hash)
+        if existing is not None and existing.entry_hash == entry.entry_hash:
+            return True  # exact duplicate — already held
+        if existing is not None:
+            logger.warning(
+                "ledger_gap_buffer: replacing forked buffered entry for case "
+                "%s prev_log_hash=%.16s… (old index=%d, new index=%d)",
+                entry.case_id,
+                entry.prev_log_hash,
+                existing.log_index,
+                entry.log_index,
+            )
+
+        if (
+            existing is None
+            and len(case_map) >= self.max_entries
+            and not self._evict_farthest(case_map, entry)
+        ):
+            return False
+
+        case_map[entry.prev_log_hash] = entry
+        logger.debug(
+            "ledger_gap_buffer: buffered out-of-order entry for case %s "
+            "(index=%d, prev_log_hash=%.16s…); buffer depth=%d",
+            entry.case_id,
+            entry.log_index,
+            entry.prev_log_hash,
+            len(case_map),
+        )
+        return True
+
+    def take_next(
+        self, case_id: str, tail_hash: str
+    ) -> VultronCaseLedgerEntry | None:
+        """Pop and return the buffered successor of *tail_hash*, if any.
+
+        The successor is the entry whose ``prev_log_hash == tail_hash`` — an
+        O(1) dict lookup.  Returns ``None`` when no buffered entry extends the
+        given tail.
+
+        Args:
+            case_id: URI of the case whose buffer to drain.
+            tail_hash: ``entry_hash`` of the replica's current chain tail.
+        """
+        case_map = self._by_case.get(case_id)
+        if not case_map:
+            return None
+        entry = case_map.pop(tail_hash, None)
+        if entry is not None and not case_map:
+            # Drop the now-empty per-case sub-dict to keep the buffer tidy.
+            self._by_case.pop(case_id, None)
+        return entry
+
+    def depth(self, case_id: str) -> int:
+        """Return the number of entries currently buffered for *case_id*."""
+        return len(self._by_case.get(case_id, {}))
+
+    def __len__(self) -> int:
+        """Return the total number of buffered entries across all cases."""
+        return sum(len(m) for m in self._by_case.values())
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _evict_farthest(
+        case_map: dict[str, VultronCaseLedgerEntry],
+        incoming: VultronCaseLedgerEntry,
+    ) -> bool:
+        """Evict the buffered entry with the highest ``log_index``.
+
+        Returns ``True`` if room was made for *incoming*; ``False`` when
+        *incoming* is itself the farthest-ahead entry (so it is dropped rather
+        than evicting a closer-to-gap entry that is more likely to drain soon).
+        """
+        farthest_key, farthest = max(
+            case_map.items(), key=lambda kv: kv[1].log_index
+        )
+        if incoming.log_index >= farthest.log_index:
+            logger.warning(
+                "ledger_gap_buffer: buffer full for case %s (max=%d); "
+                "dropping incoming far-future entry index=%d",
+                incoming.case_id,
+                len(case_map),
+                incoming.log_index,
+            )
+            return False
+        case_map.pop(farthest_key, None)
+        logger.warning(
+            "ledger_gap_buffer: buffer full for case %s (max=%d); evicted "
+            "farthest-ahead entry index=%d to make room for index=%d",
+            incoming.case_id,
+            len(case_map) + 1,
+            farthest.log_index,
+            incoming.log_index,
+        )
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Module-level per-actor registry (production convenience)
+# ---------------------------------------------------------------------------
+
+
+def get_ledger_gap_buffer(
+    actor_id: str,
+    max_entries: int = DEFAULT_LEDGER_GAP_BUFFER_MAX,
+) -> LedgerGapBuffer:
+    """Return (or lazily create) the per-actor :class:`LedgerGapBuffer`.
+
+    The returned buffer is the *singleton* for *actor_id* in this process.
+    This is pure in-memory state — no DataLayer interaction.
+
+    In unit tests, prefer constructing a :class:`LedgerGapBuffer` directly and
+    injecting it, then call :func:`_reset_buffers` in a teardown fixture to
+    prevent cross-test leakage.
+
+    Args:
+        actor_id: URI of the actor whose buffer to retrieve / create.
+        max_entries: Used only when creating a new buffer for this actor.
+            Ignored when the buffer already exists.
+    """
+    if actor_id not in _BUFFERS:
+        _BUFFERS[actor_id] = LedgerGapBuffer(max_entries=max_entries)
+    return _BUFFERS[actor_id]
+
+
+def _reset_buffers() -> None:
+    """Clear the global per-actor buffer registry.
+
+    **Test-only.**  Call from a teardown fixture to prevent cross-test leakage
+    of buffered-entry state.
+    """
+    _BUFFERS.clear()
+
+
+__all__ = [
+    "DEFAULT_LEDGER_GAP_BUFFER_MAX",
+    "LedgerGapBuffer",
+    "get_ledger_gap_buffer",
+    "_reset_buffers",
+]

--- a/vultron/core/use_cases/received/sync.py
+++ b/vultron/core/use_cases/received/sync.py
@@ -22,7 +22,7 @@ from typing import cast
 
 from py_trees.common import Status
 
-from vultron.core.behaviors.bridge import BTBridge
+from vultron.core.behaviors.bridge import BTBridge, BTExecutionResult
 from vultron.core.behaviors.sync.announce_tree import (
     create_announce_log_entry_tree,
 )
@@ -32,6 +32,10 @@ from vultron.core.behaviors.sync.reject_tree import (
 from vultron.core.models.events.sync import (
     AnnounceLogEntryReceivedEvent,
     RejectLogEntryReceivedEvent,
+)
+from vultron.core.models.ledger_gap_buffer import (
+    LedgerGapBuffer,
+    get_ledger_gap_buffer,
 )
 from vultron.core.models.pending_assertion import (
     PendingAssertionStore,
@@ -43,7 +47,8 @@ from vultron.core.ports.case_persistence import (
     CaseOutboxPersistence,
 )
 from vultron.core.ports.sync_activity import SyncActivityPort
-from vultron.core.sync_helpers import _reconstruct_tail_hash  # noqa: F401
+from vultron.core.sync_helpers import _reconstruct_tail_hash
+from vultron.errors import VultronValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -114,7 +119,15 @@ class AnnounceLedgerEntryReceivedUseCase:
     future emits for the same ``(case_id, event_type, log_object_id)``
     triple are no longer suppressed (SYNC-11-003).
 
-    Spec: SYNC-02-003, SYNC-03-001 through SYNC-03-003, SYNC-11-003.
+    Out-of-order delivery is tolerated: a received entry whose predecessor has
+    not yet arrived is held in an actor-local
+    :class:`~vultron.core.models.ledger_gap_buffer.LedgerGapBuffer` rather than
+    dropped, and buffered successors are drained in hash-chain order as soon as
+    the entry that closes the gap is committed.  This makes convergence
+    independent of ``Announce`` delivery order (issue #1556, SYNC-10-004).
+
+    Spec: SYNC-02-003, SYNC-03-001 through SYNC-03-003, SYNC-10-004,
+    SYNC-11-003, SYNC-12-001.
     """
 
     def __init__(
@@ -123,11 +136,13 @@ class AnnounceLedgerEntryReceivedUseCase:
         request: AnnounceLogEntryReceivedEvent,
         sync_port: SyncActivityPort | None = None,
         pending_assertions: PendingAssertionStore | None = None,
+        gap_buffer: LedgerGapBuffer | None = None,
     ) -> None:
         self._dl = dl
         self._request = request
         self._sync_port = sync_port
         self._pending_assertions = pending_assertions
+        self._gap_buffer = gap_buffer
 
     def execute(self) -> None:
         request = self._request
@@ -140,6 +155,11 @@ class AnnounceLedgerEntryReceivedUseCase:
             )
             return
 
+        receiving_actor_id = request.receiving_actor_id or "unknown"
+        gap_buffer = self._gap_buffer
+        if gap_buffer is None and request.receiving_actor_id:
+            gap_buffer = get_ledger_gap_buffer(request.receiving_actor_id)
+
         logger.info(
             "sync: received log-entry announcement '%s' for case '%s' "
             "from actor '%s' (log_index=%d)",
@@ -148,12 +168,17 @@ class AnnounceLedgerEntryReceivedUseCase:
             request.actor_id,
             entry.log_index,
         )
-        result = BTBridge(datalayer=self._dl).execute_with_setup(
-            tree=create_announce_log_entry_tree(),
-            actor_id=request.receiving_actor_id or "unknown",
-            activity=request,
-            sync_port=self._sync_port,
-        )
+        result = self._run_announce_bt(request, receiving_actor_id, gap_buffer)
+
+        # Whenever an entry is committed, its successor may already be waiting
+        # in the gap buffer; drain the contiguous run keyed on the new tail
+        # (SYNC-10-004).  Draining also runs after a mismatch, in case an
+        # earlier-arrived predecessor is somehow already present.
+        if gap_buffer is not None:
+            self._drain_buffered_successors(
+                entry.case_id, receiving_actor_id, gap_buffer
+            )
+
         if result.status == Status.FAILURE:
             logger.debug(
                 "sync: announce BT returned FAILURE for '%s': %s",
@@ -164,16 +189,81 @@ class AnnounceLedgerEntryReceivedUseCase:
         # Clear pending assertion for this entry regardless of BT outcome
         # (SYNC-11-003): both "recorded" and "rejected" dispositions confirm
         # the assertion has been processed by the log authority.
-        receiving_actor_id = request.receiving_actor_id or ""
         store = self._pending_assertions
-        if store is None and receiving_actor_id:
-            store = get_pending_assertion_store(receiving_actor_id)
+        if store is None and request.receiving_actor_id:
+            store = get_pending_assertion_store(request.receiving_actor_id)
         if store is not None:
             store.clear(
                 entry.case_id,
                 entry.event_type,
                 entry.log_object_id,
             )
+
+    def _run_announce_bt(
+        self,
+        request: AnnounceLogEntryReceivedEvent,
+        receiving_actor_id: str,
+        gap_buffer: LedgerGapBuffer | None,
+    ) -> BTExecutionResult:
+        """Run the announce receive BT for *request* with the gap buffer wired."""
+        return BTBridge(datalayer=self._dl).execute_with_setup(
+            tree=create_announce_log_entry_tree(),
+            actor_id=receiving_actor_id,
+            activity=request,
+            sync_port=self._sync_port,
+            gap_buffer=gap_buffer,
+        )
+
+    def _drain_buffered_successors(
+        self,
+        case_id: str,
+        receiving_actor_id: str,
+        gap_buffer: LedgerGapBuffer,
+    ) -> None:
+        """Apply buffered entries that now extend the local chain, in order.
+
+        After each committed entry, look up the buffered successor keyed by the
+        new tail hash and re-run the announce BT on it — reusing the exact
+        effects-before-persist path (SYNC-12-001).  Cascades until no buffered
+        entry extends the current tail.  A drained entry that fails to apply is
+        re-buffered so a later retry (or CaseActor replay) can pick it up.
+        """
+        while True:
+            try:
+                tail_hash, _ = _reconstruct_tail_hash(case_id, self._dl)
+            except VultronValidationError:
+                # No genesis anchor yet — nothing can be drained.
+                return
+            successor = gap_buffer.take_next(case_id, tail_hash)
+            if successor is None:
+                return
+
+            logger.info(
+                "sync: draining buffered entry '%s' (log_index=%d) for case "
+                "'%s' now that its predecessor has arrived",
+                successor.id_,
+                successor.log_index,
+                case_id,
+            )
+            drain_event = self._request.model_copy(
+                update={"object_": successor}
+            )
+            result = self._run_announce_bt(
+                drain_event, receiving_actor_id, gap_buffer
+            )
+            if (
+                result.status == Status.FAILURE
+                and self._dl.read(successor.id_) is None
+            ):
+                # Application failed and the entry was not persisted; hold it
+                # again so a future arrival or CaseActor replay can retry.
+                gap_buffer.buffer(successor)
+                logger.warning(
+                    "sync: buffered entry '%s' failed to apply on drain — "
+                    "re-buffered pending retry",
+                    successor.id_,
+                )
+                return
 
 
 class RejectLedgerEntryReceivedUseCase:


### PR DESCRIPTION
- Closes #1556

## Summary

At case closure a late-joining replica (Vendor2 in the FVV/FVCV demos) could
receive `Announce(CaseLedgerEntry)` activities **out of order**. On a
`prev_log_hash` mismatch the receive path *dropped* the entry and relied on a
`Reject → replay` round-trip to redeliver it. That recovery is itself
order-fragile — `SendMissingEntriesNode` replays each missing entry as a
*separate* `Announce`, which can reorder again and hit the same drop — so under
an unordered transport an entry could be lost indefinitely and the replica
would stall with a gapped ledger (`wait_for_contiguous_ledger_coverage` times
out).

Because delivery ordering is not guaranteed (and Vultron may not be the only
implementation on the wire), the durable fix is **receiver-side buffering**,
which makes convergence independent of delivery order (SYNC-10-004).

## Changes

- **`LedgerGapBuffer`** (`vultron/core/models/ledger_gap_buffer.py`) — a new
  actor-local, per-case, in-memory, ephemeral store mirroring
  `PendingAssertionStore` (per-actor module-level registry). It is the
  "clearly separate, non-ledger holding area" sanctioned by SYNC-13-003;
  DataLayer presence still means "committed + effects applied" (SYNC-13-001).
  - **Keyed on `prev_log_hash`** so the successor of a just-persisted tail is
    an O(1) lookup and a contiguous run drains in O(k). Hash-chaining makes
    indefinite buffering safe (a held entry waits for the exact predecessor
    hash), so eviction is pure memory hygiene (bounded size; evict farthest-
    ahead entry with a WARNING), never a correctness knob.
- **Receive path** (`nodes/receive.py`, `announce_tree.py` via the restructured
  `CheckHashOrRejectOnMismatchNode`) — on a hash mismatch that is a genuine
  *forward* gap (`log_index > tail_index + 1`), buffer the entry **and still
  send** `Reject(CaseLedgerEntry)` as the loss backstop. New
  `BufferOutOfOrderEntryNode`.
- **Drain cascade** (`use_cases/received/sync.py`) — after each committed entry,
  `AnnounceLedgerEntryReceivedUseCase` drains buffered successors by re-running
  the announce BT on each, reusing the exact effects-before-persist path
  (SYNC-12-001) and cascading until no buffered entry extends the tail.
- **Reject outbox scoping** (`sync_activity_adapter.py`) —
  `send_reject_log_entry` now enqueues against the explicit receiving
  `actor_id` via `add_activity_to_outbox` (like `send_announce_log_entry`)
  instead of the scope-dependent `outbox_append`. A plausible contributor to
  "the CaseActor never processes the Reject" under a shared/mis-scoped
  DataLayer.

Because replayed entries flow through the same receive path, the `Reject →
replay` recovery is now order-robust for free — no separate replay redesign was
needed.

## Verification

- New unit tests: `test/core/models/test_ledger_gap_buffer.py` (O(1) drain,
  cascade, case isolation, dedup/fork, size-bound eviction, registry).
- New regression tests in `test/core/use_cases/received/test_sync.py` driving
  `AnnounceLedgerEntryReceivedUseCase`: fully-reversed delivery, single-gap
  click-into-place, multi-gap cascade, and shuffled-replay convergence — each
  asserting no entry is permanently dropped. (The reversed-delivery test fails
  on `main`.)
- Updated `test_receive.py` for the new buffer-and-reject tree structure and
  the three reject-outbox tests for explicit-actor queueing.
- `black`, `flake8`, `mypy` (1035 files), `pyright` all clean; full unit suite
  and FVV demo regression tests pass.

The demo `wait_for_contiguous_ledger_coverage` default is already at its
original 15s (the 40s band-aid was reverted in 70d97c77); no further change
needed now that convergence is fast and order-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Design artifacts (added)

Following review, the decision and its testable requirements are now captured:

- **ADR-0037** — records why receiver-side buffering was chosen over repairing
  the reject→replay loop alone.
- **SYNC-14** (Out-of-Order Entry Buffering and Drain) — 6 requirements plus a
  clarification to **SYNC-08-005** that a forward-gap entry MAY be buffered
  pending its predecessor.
- **OX-02-003** — on-behalf-of-actor emissions MUST enqueue against the explicit
  `actor_id` (the reject-outbox fix).
- ADR-0036 and ADR-0037 added to the mkdocs nav (0036 was an oversight from the
  main merge). `mkdocs build --strict` passes.