### PR TITLE
FUZZ-08a: Collapsed exploit-strategy subtree (Production Collapse 1)

### DIFF
--- a/docs/adr/0027-exploit-strategy-bt-collapse.md
+++ b/docs/adr/0027-exploit-strategy-bt-collapse.md
@@ -1,14 +1,12 @@
 ---
-status: proposed
-date: 2026-07-09
+status: accepted
+date: 2026-07-21
 deciders: [adh]
 ---
 
 # Exploit-Strategy Subtree Collapse: Five Simulator Nodes → EvaluateExploitStrategy
 
-> **PROVISIONAL** — formed at planning time (issue #1200). Subject to revision
-> when the implementation issue for this collapse candidate is worked.
-> Implementation tracked by the issue blocked by #1200.
+*Implemented by issue #1309 (`task/1309-evaluate-exploit-strategy`).*
 
 ## Context and Problem Statement
 
@@ -37,14 +35,15 @@ How should the five simulator nodes collapse in the production BT?
 
 ## Decision Outcome
 
-Chosen option: **Option 2 (lean)** — `HaveExploit` Retriever feeds `EvaluateExploitStrategy`
-Evaluator. The provisional decision is to keep the exploit-repo query as a separate
-Retriever seam (independently swappable) while collapsing the three ProtocolInternal flag
-nodes into the Evaluator's output record.
-
-> **Note**: The choice between options 1 and 2 is **deferred** to the implementation issue.
-> The lean is Option 2 because it preserves independent swapability of the exploit-repo
-> query seam. The implementation issue should finalize this decision before coding.
+Chosen option: **Option 2** — `HaveExploit` Retriever feeds `EvaluateExploitStrategy`
+Evaluator. The exploit-repo query is kept as a separate Retriever seam (independently
+swappable) while collapsing the three ProtocolInternal flag nodes into the Evaluator's
+output record. The exploit-repo query is a distinct
+external data dependency from the strategy evaluation; keeping them as separate
+injection seams allows callers to swap only the repository query (e.g., to a
+different threat-intel platform) without touching the evaluation logic, and
+vice versa. Collapsing to a single Evaluator (Option 1) would force the
+Evaluator implementation to embed the repository query, reducing composability.
 
 ### Consequences
 
@@ -57,12 +56,13 @@ nodes into the Evaluator's output record.
 
 ## More Information
 
-- Planning issue: #1200
+- Planning issue: #1200; implementation issue: #1309
 - Simulator nodes: `HaveExploit`, `ExploitPrioritySet`, `EvaluateExploitPriority`,
   `ExploitDeferred`, `ExploitDesired` (see `notes/bt-fuzzer-nodes-report-management.md`
   § "Exploit Acquisition" and "Production Collapse 1")
-- Implementation blocked by: #1200; also see issue #1249 (target factory function)
-- Provisional output schema: `ExploitStrategyDecision(have_exploit, acquire, rationale)`
-  as a Pydantic BaseModel (lean)
+- Output schema: `ExploitStrategyDecision(have_exploit, acquire, rationale)` (Pydantic BaseModel)
+  in `vultron/core/behaviors/report/acquire_exploit_strategy_tree.py`
+- Fuzzer backend: `EvaluateExploitStrategy` in
+  `vultron/demo/fuzzer/report_management/acquire_exploit.py`
 
-Generated spec requirements: `behavior-tree-integration.yaml` BT-20-001 (provisional)
+Generated spec requirements: `behavior-tree-integration.yaml` BT-20-001

--- a/notes/bt-fuzzer-nodes-report-management.md
+++ b/notes/bt-fuzzer-nodes-report-management.md
@@ -768,11 +768,10 @@ vulnerability, typically to support impact assessment or testing.
 - **Automation potential**: **High** — query against an internal exploit repository or threat-intelligence platform; fully automatable.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.acquire_exploit.HaveExploit`
 - **Call-out point shape**: Retriever — synchronous on-demand query to an internal exploit repository or threat-intelligence platform; returns SUCCESS if a working exploit is already available for this vulnerability, FAILURE otherwise. A boolean is the simplest structured fact (ADR-0024); the on-demand query pattern makes this a Retriever, not a Sentinel.
-- **Factory-fn placement**: FUTURE:
-  `vultron.core.behaviors.report.create_acquire_exploit_strategy_tree`
-  (issue #1249) — early-exit Retriever guard at the top of
-  `AcquireExploit` Selector; may collapse into `EvaluateExploitStrategy`
-  input context per production redesign (see Production Collapse 1 below)
+- **Factory-fn placement**: Implemented (PR #1566) —
+  `vultron.core.behaviors.report.acquire_exploit_strategy_tree.create_acquire_exploit_strategy_tree`
+  (`have_exploit_factory` param) — early-exit Retriever guard at the head of the
+  `AcquireExploitStrategyBT` Selector (Production Collapse 1, ADR-0027)
 
 ### `ExploitPrioritySet`
 
@@ -792,11 +791,9 @@ vulnerability, typically to support impact assessment or testing.
   during the same BT execution cycle; the flag lives on the BT blackboard (per-actor in-process).
   No external agent seam — the flag never crosses an actor boundary.
   (Category 3 per issue #1199 triage — reads a flag written by the protocol's own BT execution.)
-- **Factory-fn placement**: FUTURE:
-  `vultron.core.behaviors.report.create_acquire_exploit_strategy_tree`
-  (issue #1249) — ProtocolInternal condition check after `HaveExploit`;
-  collapses the loop if the priority decision is already on record for this cycle.
-  See Production Collapse 1 below.
+- **Factory-fn placement**: Eliminated (Production Collapse 1, PR #1566) —
+  collapsed into the `EvaluateExploitStrategy` Evaluator's output record;
+  no longer a separate BT leaf or factory parameter.
 
 ### `EvaluateExploitPriority`
 
@@ -813,14 +810,11 @@ vulnerability, typically to support impact assessment or testing.
 - **Automation potential**: **Medium** — SSVC/CVSS scoring inputs are automatable; the final exploit-acquisition priority decision often requires human analyst judgment given organizational and legal context.
 - **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.acquire_exploit.EvaluateExploitPriority`
 - **Call-out point shape**: Evaluator
-- **Factory-fn placement**: Phase 1 stub now exists as of PR #1357 —
-  `vultron.core.behaviors.report.acquire_exploit_tree.create_acquire_exploit_tree`
-  (`evaluate_exploit_priority_factory` param). FUTURE full placement:
-  `vultron.core.behaviors.report.create_acquire_exploit_strategy_tree`
-  (issue #1249) — Evaluator action node in the priority-decision Sequence;
-  writes the `exploit_priority` decision to the blackboard for downstream
-  ProtocolInternal condition nodes (`ExploitDeferred`, `ExploitDesired`).
-  See Production Collapse 1 below — this is the core Evaluator that survives.
+- **Factory-fn placement**: Superseded by Production Collapse 1 (PR #1566) —
+  Phase 1 stub in `create_acquire_exploit_tree` (`evaluate_exploit_priority_factory`)
+  is replaced by `EvaluateExploitStrategy` in
+  `create_acquire_exploit_strategy_tree` (`evaluate_exploit_strategy_factory`).
+  The priority decision is now encoded in `ExploitStrategyDecision.acquire`.
 
 ### `ExploitDeferred`
 
@@ -840,11 +834,9 @@ vulnerability, typically to support impact assessment or testing.
   during the same BT execution cycle; the flag lives on the BT blackboard (per-actor in-process).
   No external agent seam — the flag never crosses an actor boundary.
   (Category 3 per issue #1199 triage — reads a flag written by the protocol's own BT execution.)
-- **Factory-fn placement**: FUTURE:
-  `vultron.core.behaviors.report.create_acquire_exploit_strategy_tree`
-  (issue #1249) — ProtocolInternal condition check after `EvaluateExploitPriority`;
-  early-exits the acquire-exploit Selector when deferral is recorded.
-  See Production Collapse 1 below.
+- **Factory-fn placement**: Eliminated (Production Collapse 1, PR #1566) —
+  collapsed into the `EvaluateExploitStrategy` Evaluator's output record;
+  no longer a separate BT leaf or factory parameter.
 
 ### `ExploitDesired`
 
@@ -863,11 +855,9 @@ vulnerability, typically to support impact assessment or testing.
   during the same BT execution cycle; the flag lives on the BT blackboard (per-actor in-process).
   No external agent seam — the flag never crosses an actor boundary.
   (Category 3 per issue #1199 triage — reads a flag written by the protocol's own BT execution.)
-- **Factory-fn placement**: FUTURE:
-  `vultron.core.behaviors.report.create_acquire_exploit_strategy_tree`
-  (issue #1249) — ProtocolInternal condition check before the acquisition
-  Fallback (`FindExploit → DevelopExploit → PurchaseExploit`).
-  See Production Collapse 1 below.
+- **Factory-fn placement**: Eliminated (Production Collapse 1, PR #1566) —
+  collapsed into the `EvaluateExploitStrategy` Evaluator's output record;
+  no longer a separate BT leaf or factory parameter.
 
 ### `FindExploit`
 
@@ -1957,42 +1947,36 @@ subtrees.
 `EvaluateExploitPriority`, `ExploitDeferred`, `ExploitDesired`
 (see Exploit Acquisition section above)
 
-**Tracked by**: implementation issue for collapse candidate 1 (blocked by #1200)
+**Implemented by**: issue #1309 (PR #1566)
 
 #### Production shape
 
-A single **Evaluator** call-out point — `EvaluateExploitStrategy` — replaces
-the five-node simulator sequence. The Evaluator receives case context
-(vulnerability state, org policy, threat landscape, and optionally the result
-of a prior `HaveExploit` Retriever query) and returns a structured decision
-record.
+The five-node simulator sequence is replaced by two independently-swappable
+call-out points (ADR-0027 Option 2):
 
-The five simulator nodes collapse to:
+1. **`HaveExploit`** (Retriever) — early-exit guard; queries whether a working
+   exploit already exists. Survives as a separate seam for independent swapability.
+2. **`EvaluateExploitStrategy`** (Evaluator) — receives case context and returns
+   a structured `ExploitStrategyDecision` record.
 
-1. One Evaluator call-out point: `EvaluateExploitStrategy`
-2. ProtocolInternal BT condition checks reading its structured output (no
-   external seam — these are internal decision reads, not new call-out points)
+The three ProtocolInternal nodes (`ExploitPrioritySet`, `ExploitDeferred`,
+`ExploitDesired`) are eliminated as separate BT leaves — their decisions become
+internal reads on the Evaluator's output record.
 
-**Open design question**: Does `HaveExploit` survive as a separate Retriever
-node that feeds context into the Evaluator (lean: yes), or does the Evaluator
-query the exploit repo internally as part of its evaluation? Both approaches
-are valid; the Retriever-feeds-Evaluator pattern is preferred because it keeps
-the exploit-repo query seam independently swappable.
-
-**Provisional output schema** (subject to revision — lean: Pydantic BaseModel):
+**Output schema** (Pydantic BaseModel, implemented in
+`vultron.core.behaviors.report.acquire_exploit_strategy_tree`):
 
 ```python
 class ExploitStrategyDecision(BaseModel):
-    have_exploit: bool       # whether a working exploit is already available
-    acquire: bool            # decision: pursue exploit acquisition
-    rationale: str           # reasoning for the decision
+    have_exploit: bool = False  # whether a working exploit is already available
+    acquire: bool = False       # decision: pursue exploit acquisition
+    rationale: str = ""         # reasoning for the decision
 ```
 
-**Target factory function**:
-`vultron.core.behaviors.report.create_acquire_exploit_strategy_tree`
+**Factory function**:
+`vultron.core.behaviors.report.acquire_exploit_strategy_tree.create_acquire_exploit_strategy_tree`
 
-**Spec requirements**: BT-20-001 (provisional — see
-`specs/behavior-tree-integration.yaml`)
+**Spec requirements**: BT-20-001 (see `specs/behavior-tree-integration.yaml`)
 
 ---
 

--- a/plan/history/2607/implementation/ISSUE-1309.md
+++ b/plan/history/2607/implementation/ISSUE-1309.md
@@ -1,0 +1,12 @@
+---
+source: ISSUE-1309
+timestamp: '2026-07-21T17:25:36.818033+00:00'
+title: FUZZ-08a — EvaluateExploitStrategy collapsed subtree (Production Collapse 1)
+type: implementation
+---
+
+## Issue #1309 — FUZZ-08a: EvaluateExploitStrategy collapsed subtree
+
+Implemented ADR-0027 / BT-20-001 Production Collapse 1: replaced five simulator BT nodes with two independently-swappable call-out points (HaveExploit Retriever + EvaluateExploitStrategy Evaluator). Added ExploitStrategyDecision Pydantic model, create_acquire_exploit_strategy_tree() factory with ADR-0025 call-out pattern, 15 new tests, and advanced ADR-0027 to accepted. IMPROVE fix: output_keys type corrected from str to ExploitStrategyDecision. DEFER: blackboard integration tests tracked in #1565.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1566>

--- a/specs/behavior-tree-integration.yaml
+++ b/specs/behavior-tree-integration.yaml
@@ -849,23 +849,24 @@ groups:
     kind: implementation
     statement: >-
       The production `create_acquire_exploit_strategy_tree` factory SHOULD
-      provide a single `EvaluateExploitStrategy` Evaluator call-out point in
-      place of the five simulator nodes (`HaveExploit`, `ExploitPrioritySet`,
-      `EvaluateExploitPriority`, `ExploitDeferred`, `ExploitDesired`). The
-      Evaluator SHOULD receive case context (vulnerability state, org policy,
-      threat landscape) and return a structured decision record containing at
-      minimum the acquire decision and rationale. Whether a separate
-      `HaveExploit` Retriever feeds into the Evaluator's context is an open
-      design question (lean: yes — keep as a separate seam for independent
-      swapability).
+      provide a `HaveExploit` Retriever and an `EvaluateExploitStrategy`
+      Evaluator call-out point in place of the five simulator nodes
+      (`HaveExploit`, `ExploitPrioritySet`, `EvaluateExploitPriority`,
+      `ExploitDeferred`, `ExploitDesired`). The Evaluator SHOULD receive case
+      context (vulnerability state, org policy, threat landscape, and the
+      `HaveExploit` query result) and return a structured
+      `ExploitStrategyDecision` record containing `have_exploit`, `acquire`,
+      and `rationale`. The `HaveExploit` Retriever is kept as a separate seam
+      for independent swapability (ADR-0027, Option 2).
     rationale: >-
-      PROVISIONAL. The five-node simulator sequence encodes a single
-      policy-driven decision ("should we acquire an exploit?") in granular
-      boolean flags that are unnecessary in production. Collapsing to one
-      Evaluator reduces the number of external seams and makes the decision
-      boundary explicit. See `notes/bt-fuzzer-nodes-report-management.md`
+      The five-node simulator sequence encodes a single policy-driven decision
+      ("should we acquire an exploit?") in granular boolean flags that are
+      unnecessary in production. Collapsing to two call-out points (Retriever +
+      Evaluator) reduces seam count while keeping the exploit-repo query
+      independently swappable. Implemented by issue #1309 (PR #1566). See
+      `notes/bt-fuzzer-nodes-report-management.md`
       § "Production Collapse 1: Exploit-strategy subtree" and ADR-0027.
-    tracking_issue: "#1200 (planning); implementation issue TBD (blocked by #1200)"
+    tracking_issue: "#1200 (planning); #1309 (implementation — closed by PR #1566)"
   - id: BT-20-002
     priority: SHOULD
     kind: implementation

--- a/test/core/behaviors/report/test_acquire_exploit_strategy_tree.py
+++ b/test/core/behaviors/report/test_acquire_exploit_strategy_tree.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Tests for the collapsed exploit-strategy behavior tree (Production Collapse 1).
+
+Verifies ADR-0027 / BT-20-001:
+- AC-1: Three ProtocolInternal flag nodes are eliminated as separate leaves.
+- AC-2: HaveExploit survives as an independently-swappable Retriever seam.
+- AC-3: EvaluateExploitStrategy produces ExploitStrategyDecision output.
+- AC-4: ADR-0025 factory pattern applied to both call-out points.
+"""
+
+import pytest
+import py_trees
+
+from vultron.core.behaviors.report.acquire_exploit_strategy_tree import (
+    ExploitStrategyDecision,
+    create_acquire_exploit_strategy_tree,
+)
+from vultron.demo.fuzzer.report_management.acquire_exploit import (
+    EvaluateExploitStrategy,
+    HaveExploit,
+)
+
+CASE_ID = "https://example.org/cases/test-001"
+
+
+def _marker_factory(label):
+    def factory(name):
+        class _Marker(py_trees.behaviour.Behaviour):
+            def update(self):
+                return py_trees.common.Status.SUCCESS
+
+        return _Marker(name=label)
+
+    return factory
+
+
+# ---------------------------------------------------------------------------
+# ExploitStrategyDecision model
+# ---------------------------------------------------------------------------
+
+
+def test_exploit_strategy_decision_defaults():
+    decision = ExploitStrategyDecision()
+    assert decision.have_exploit is False
+    assert decision.acquire is False
+    assert decision.rationale == ""
+
+
+def test_exploit_strategy_decision_fields():
+    decision = ExploitStrategyDecision(
+        have_exploit=True,
+        acquire=True,
+        rationale="High severity, public exploit available.",
+    )
+    assert decision.have_exploit is True
+    assert decision.acquire is True
+    assert decision.rationale == "High severity, public exploit available."
+
+
+# ---------------------------------------------------------------------------
+# Tree structure
+# ---------------------------------------------------------------------------
+
+
+def test_create_tree_returns_behaviour():
+    tree = create_acquire_exploit_strategy_tree(case_id=CASE_ID)
+    assert isinstance(tree, py_trees.behaviour.Behaviour)
+
+
+def test_create_tree_root_name():
+    tree = create_acquire_exploit_strategy_tree(case_id=CASE_ID)
+    assert tree.name == "AcquireExploitStrategyBT"
+
+
+def test_root_is_selector():
+    """Root is a Selector so HaveExploit short-circuits the Evaluator."""
+    tree = create_acquire_exploit_strategy_tree(case_id=CASE_ID)
+    assert isinstance(tree, py_trees.composites.Selector)
+
+
+def test_exactly_two_children():
+    """AC-1: only two leaves — HaveExploit and EvaluateExploitStrategy."""
+    tree = create_acquire_exploit_strategy_tree(case_id=CASE_ID)
+    assert len(tree.children) == 2
+
+
+# ---------------------------------------------------------------------------
+# AC-2: HaveExploit survives as an independently-swappable Retriever seam
+# ---------------------------------------------------------------------------
+
+
+def test_default_have_exploit_is_fuzzer_node():
+    """AC-2: default factory produces a HaveExploit fuzzer node."""
+    tree = create_acquire_exploit_strategy_tree(case_id=CASE_ID)
+    assert isinstance(tree.children[0], HaveExploit)
+
+
+def test_have_exploit_factory_used():
+    """AC-2 + AC-4: custom have_exploit_factory is wired into the tree."""
+    sentinel = {"called": False}
+
+    def custom_factory(name):
+        sentinel["called"] = True
+
+        class _Marker(py_trees.behaviour.Behaviour):
+            def update(self):
+                return py_trees.common.Status.SUCCESS
+
+        return _Marker(name="CustomHaveExploit")
+
+    tree = create_acquire_exploit_strategy_tree(
+        case_id=CASE_ID,
+        have_exploit_factory=custom_factory,
+    )
+    assert sentinel["called"]
+    assert tree.children[0].name == "CustomHaveExploit"
+    assert not isinstance(tree.children[0], HaveExploit)
+
+
+# ---------------------------------------------------------------------------
+# AC-3 + AC-4: EvaluateExploitStrategy Evaluator with structured output
+# ---------------------------------------------------------------------------
+
+
+def test_default_evaluate_exploit_strategy_is_fuzzer_node():
+    """AC-3: default factory produces an EvaluateExploitStrategy fuzzer node."""
+    tree = create_acquire_exploit_strategy_tree(case_id=CASE_ID)
+    assert isinstance(tree.children[1], EvaluateExploitStrategy)
+
+
+def test_evaluate_exploit_strategy_output_key():
+    """AC-3: EvaluateExploitStrategy declares exploit_strategy_decision output."""
+    node = EvaluateExploitStrategy("EvaluateExploitStrategy")
+    assert "exploit_strategy_decision" in node.output_keys
+
+
+def test_evaluate_exploit_strategy_factory_used():
+    """AC-4: custom evaluate_exploit_strategy_factory is wired into the tree."""
+    sentinel = {"called": False}
+
+    def custom_factory(name):
+        sentinel["called"] = True
+
+        class _Marker(py_trees.behaviour.Behaviour):
+            def update(self):
+                return py_trees.common.Status.SUCCESS
+
+        return _Marker(name="CustomEvaluateExploitStrategy")
+
+    tree = create_acquire_exploit_strategy_tree(
+        case_id=CASE_ID,
+        evaluate_exploit_strategy_factory=custom_factory,
+    )
+    assert sentinel["called"]
+    assert tree.children[1].name == "CustomEvaluateExploitStrategy"
+    assert not isinstance(tree.children[1], EvaluateExploitStrategy)
+
+
+# ---------------------------------------------------------------------------
+# AC-1: eliminated nodes are absent as separate leaves
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "eliminated_class_name",
+    ["ExploitPrioritySet", "ExploitDeferred", "ExploitDesired"],
+)
+def test_eliminated_protocol_internal_nodes_absent(eliminated_class_name):
+    """AC-1: three ProtocolInternal flag nodes are not separate leaves."""
+    tree = create_acquire_exploit_strategy_tree(case_id=CASE_ID)
+    leaf_names = [c.__class__.__name__ for c in tree.children]
+    assert eliminated_class_name not in leaf_names
+
+
+# ---------------------------------------------------------------------------
+# AC-4: both factories replaceable simultaneously
+# ---------------------------------------------------------------------------
+
+
+def test_both_factories_replaceable():
+    """AC-4: both factory params can be replaced simultaneously."""
+    tree = create_acquire_exploit_strategy_tree(
+        case_id=CASE_ID,
+        have_exploit_factory=_marker_factory("HE"),
+        evaluate_exploit_strategy_factory=_marker_factory("EES"),
+    )
+    tree_str = py_trees.display.ascii_tree(tree)
+    assert "HE" in tree_str
+    assert "EES" in tree_str
+    assert not isinstance(tree.children[0], HaveExploit)
+    assert not isinstance(tree.children[1], EvaluateExploitStrategy)

--- a/test/core/behaviors/report/test_acquire_exploit_strategy_tree.py
+++ b/test/core/behaviors/report/test_acquire_exploit_strategy_tree.py
@@ -144,6 +144,10 @@ def test_evaluate_exploit_strategy_output_key():
     """AC-3: EvaluateExploitStrategy declares exploit_strategy_decision output."""
     node = EvaluateExploitStrategy("EvaluateExploitStrategy")
     assert "exploit_strategy_decision" in node.output_keys
+    assert (
+        node.output_keys["exploit_strategy_decision"]
+        is ExploitStrategyDecision
+    )
 
 
 def test_evaluate_exploit_strategy_factory_used():

--- a/vultron/core/behaviors/report/acquire_exploit_strategy_tree.py
+++ b/vultron/core/behaviors/report/acquire_exploit_strategy_tree.py
@@ -67,6 +67,8 @@ class ExploitStrategyDecision(BaseModel):
 
 
 def _default_have_exploit_factory(name: str) -> py_trees.behaviour.Behaviour:
+    # Deferred import: avoids circular dependency — demo/acquire_exploit.py
+    # imports ExploitStrategyDecision from this module at module level.
     from vultron.demo.fuzzer.report_management.acquire_exploit import (
         HaveExploit,
     )
@@ -77,6 +79,8 @@ def _default_have_exploit_factory(name: str) -> py_trees.behaviour.Behaviour:
 def _default_evaluate_exploit_strategy_factory(
     name: str,
 ) -> py_trees.behaviour.Behaviour:
+    # Deferred import: avoids circular dependency — demo/acquire_exploit.py
+    # imports ExploitStrategyDecision from this module at module level.
     from vultron.demo.fuzzer.report_management.acquire_exploit import (
         EvaluateExploitStrategy,
     )

--- a/vultron/core/behaviors/report/acquire_exploit_strategy_tree.py
+++ b/vultron/core/behaviors/report/acquire_exploit_strategy_tree.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Collapsed exploit-strategy behavior tree (Production Collapse 1).
+
+Implements ADR-0027 / BT-20-001: replaces the five simulator nodes
+``HaveExploit``, ``ExploitPrioritySet``, ``EvaluateExploitPriority``,
+``ExploitDeferred``, and ``ExploitDesired`` with two independently-swappable
+call-out points:
+
+1. ``HaveExploit`` — Retriever; queries whether a working exploit is already
+   available (exploit repository / threat-intelligence platform).
+2. ``EvaluateExploitStrategy`` — Evaluator; receives case context (including
+   the ``HaveExploit`` query result) and returns a structured
+   :class:`ExploitStrategyDecision` record.
+
+The three ProtocolInternal flag nodes (``ExploitPrioritySet``,
+``ExploitDeferred``, ``ExploitDesired``) are eliminated as separate BT
+leaves — they become internal decision reads on the Evaluator's output record.
+
+References
+----------
+- ADR-0027: ``docs/adr/0027-exploit-strategy-bt-collapse.md``
+- Spec: ``specs/behavior-tree-integration.yaml`` BT-20-001
+- Notes: ``notes/bt-fuzzer-nodes-report-management.md``
+  § "Production Collapse 1: Exploit-strategy subtree → EvaluateExploitStrategy"
+"""
+
+import logging
+
+import py_trees
+from pydantic import BaseModel
+
+from vultron.core.behaviors.call_out_point import CallOutBackendFactory
+
+logger = logging.getLogger(__name__)
+
+
+class ExploitStrategyDecision(BaseModel):
+    """Structured output record for the EvaluateExploitStrategy call-out point.
+
+    Written to the blackboard key ``exploit_strategy_decision`` by the
+    ``EvaluateExploitStrategy`` Evaluator node on SUCCESS (BT-18-001).
+
+    Attributes:
+        have_exploit: Whether a working exploit was already available
+            (populated from the upstream ``HaveExploit`` Retriever result).
+        acquire: Decision — whether to pursue exploit acquisition for this
+            vulnerability.
+        rationale: Human-readable or machine-generated explanation of the
+            acquisition decision.
+    """
+
+    have_exploit: bool = False
+    acquire: bool = False
+    rationale: str = ""
+
+
+def _default_have_exploit_factory(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.acquire_exploit import (
+        HaveExploit,
+    )
+
+    return HaveExploit(name)
+
+
+def _default_evaluate_exploit_strategy_factory(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.acquire_exploit import (
+        EvaluateExploitStrategy,
+    )
+
+    return EvaluateExploitStrategy(name)
+
+
+def create_acquire_exploit_strategy_tree(
+    case_id: str,
+    have_exploit_factory: CallOutBackendFactory = _default_have_exploit_factory,
+    evaluate_exploit_strategy_factory: CallOutBackendFactory = _default_evaluate_exploit_strategy_factory,
+) -> py_trees.behaviour.Behaviour:
+    """Create the collapsed exploit-strategy behavior tree (Production Collapse 1).
+
+    Replaces the five simulator nodes with two independently-swappable
+    call-out points per ADR-0027 / BT-20-001:
+
+    1. ``HaveExploit`` (Retriever) — queries the exploit repository.
+    2. ``EvaluateExploitStrategy`` (Evaluator) — produces a structured
+       :class:`ExploitStrategyDecision` decision record.
+
+    The Evaluator writes ``exploit_strategy_decision`` to the blackboard on
+    SUCCESS; downstream nodes read this key to decide whether to proceed with
+    acquisition (replacing the removed ProtocolInternal flag checks).
+
+    Args:
+        case_id: ID of VulnerabilityCase being processed.
+        have_exploit_factory: Factory for the Retriever call-out point that
+            checks whether a working exploit already exists.  Defaults to
+            the fuzzer backend.
+        evaluate_exploit_strategy_factory: Factory for the Evaluator
+            call-out point that produces the acquisition strategy decision.
+            Defaults to the fuzzer backend.
+
+    Returns:
+        Root Selector node of the collapsed exploit-strategy subtree.
+    """
+    root = py_trees.composites.Selector(
+        name="AcquireExploitStrategyBT",
+        memory=False,
+        children=[
+            have_exploit_factory("HaveExploit"),
+            evaluate_exploit_strategy_factory("EvaluateExploitStrategy"),
+        ],
+    )
+    logger.info(
+        f"Created AcquireExploitStrategyBT (Production Collapse 1) for case={case_id}"
+    )
+    return root

--- a/vultron/demo/fuzzer/report_management/__init__.py
+++ b/vultron/demo/fuzzer/report_management/__init__.py
@@ -75,6 +75,7 @@ from vultron.demo.fuzzer.report_management.monitor_threats import (
 from vultron.demo.fuzzer.report_management.acquire_exploit import (
     DevelopExploit,
     EvaluateExploitPriority,
+    EvaluateExploitStrategy,
     ExploitDeferred,
     ExploitDesired,
     ExploitPrioritySet,
@@ -158,7 +159,7 @@ __all__ = [
     "MonitorExploits",
     "MonitorPublicReports",
     "NoThreatsFound",
-    # exploit acquisition
+    # exploit acquisition (simulator nodes)
     "HaveExploit",
     "ExploitDeferred",
     "ExploitPrioritySet",
@@ -167,6 +168,8 @@ __all__ = [
     "FindExploit",
     "DevelopExploit",
     "PurchaseExploit",
+    # exploit acquisition (production collapse 1 — ADR-0027)
+    "EvaluateExploitStrategy",
     # report closure
     "OtherCloseCriteriaMet",
     "PreCloseAction",

--- a/vultron/demo/fuzzer/report_management/acquire_exploit.py
+++ b/vultron/demo/fuzzer/report_management/acquire_exploit.py
@@ -24,15 +24,25 @@ Nodes are built on the probabilistic base types in
 nodes with semantic docstrings) and BT-16-005 (automation-potential
 categorization).
 
+Also includes the production-collapse nodes for
+``create_acquire_exploit_strategy_tree`` (ADR-0027 / BT-20-001):
+``EvaluateExploitStrategy`` (Evaluator) which replaces the three
+ProtocolInternal flag nodes.
+
 References
 ----------
 - Source: ``vultron/bt/report_management/fuzzer/acquire_exploit.py``
-- Spec: ``specs/behavior-tree-integration.yaml`` BT-16-003, BT-16-004, BT-16-005
+- Spec: ``specs/behavior-tree-integration.yaml`` BT-16-003, BT-16-004, BT-16-005,
+  BT-20-001
 - Notes: ``notes/bt-fuzzer-nodes-report-management.md``
+- ADR: ``docs/adr/0027-exploit-strategy-bt-collapse.md``
 """
 
 from __future__ import annotations
 
+from vultron.core.behaviors.report.acquire_exploit_strategy_tree import (
+    ExploitStrategyDecision,
+)
 from vultron.demo.fuzzer.base import (
     AlmostAlwaysFail,
     AlmostAlwaysSucceed,
@@ -235,3 +245,38 @@ class PurchaseExploit(EvaluatorCallOutPoint, RarelySucceed):
     """
 
     output_keys = {"purchase_exploit_verdict": str}
+
+
+# ---------------------------------------------------------------------------
+# Production Collapse 1 (ADR-0027 / BT-20-001)
+# ---------------------------------------------------------------------------
+
+
+class EvaluateExploitStrategy(EvaluatorCallOutPoint, AlwaysSucceed):
+    """Evaluate the overall exploit-acquisition strategy for this vulnerability.
+
+    Semantic function:
+        Action — receive case context (vulnerability state, organisational
+        policy, threat landscape, and the result of the upstream
+        ``HaveExploit`` Retriever query) and produce a structured
+        :class:`~vultron.core.behaviors.report.acquire_exploit_strategy_tree.ExploitStrategyDecision`
+        record.  Replaces ``ExploitPrioritySet``, ``EvaluateExploitPriority``,
+        ``ExploitDeferred``, and ``ExploitDesired`` in the production BT
+        (ADR-0027 Production Collapse 1).
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (reads case context from caller's DataLayer)
+      Output keys: exploit_strategy_decision: ExploitStrategyDecision
+        (SUCCESS only; default instance written by fuzzer backend)
+
+    Input category: Human decision / policy evaluation.
+
+    Success probability: 1.00 (``AlwaysSucceed``).
+
+    Automation potential: **Medium** — SSVC-based scoring and policy-rule
+    evaluation can automate a strategy recommendation; the final decision
+    to pursue exploit acquisition typically requires human authorisation,
+    especially in regulated environments.
+    """
+
+    output_keys = {"exploit_strategy_decision": ExploitStrategyDecision}


### PR DESCRIPTION
## Summary

Implements ADR-0027 / BT-20-001 (Production Collapse 1): replaces the five simulator
BT nodes (`HaveExploit`, `ExploitPrioritySet`, `EvaluateExploitPriority`, `ExploitDeferred`,
`ExploitDesired`) with two independently-swappable call-out points:

1. **`HaveExploit`** (Retriever) — queries whether a working exploit already exists
2. **`EvaluateExploitStrategy`** (Evaluator) — produces a structured
   `ExploitStrategyDecision(have_exploit, acquire, rationale)` Pydantic record

The three ProtocolInternal flag nodes (`ExploitPrioritySet`, `ExploitDeferred`,
`ExploitDesired`) are eliminated as separate BT leaves.

## Changed files

- `vultron/core/behaviors/report/acquire_exploit_strategy_tree.py` — new; contains
  `ExploitStrategyDecision` model and `create_acquire_exploit_strategy_tree()` factory
  (ADR-0025 call-out pattern, deferred imports satisfy BT-16-001)
- `vultron/demo/fuzzer/report_management/acquire_exploit.py` — adds `EvaluateExploitStrategy`
  fuzzer node with `output_keys = {"exploit_strategy_decision": ExploitStrategyDecision}`
- `vultron/demo/fuzzer/report_management/__init__.py` — exports `EvaluateExploitStrategy`
- `docs/adr/0027-exploit-strategy-bt-collapse.md` — status: accepted; PROVISIONAL callout
  removed; implementation reference added
- `test/core/behaviors/report/test_acquire_exploit_strategy_tree.py` — 15 new tests
  covering AC-1 through AC-4

## Acceptance criteria

- [x] AC-1: Three ProtocolInternal flag nodes absent as separate leaves
- [x] AC-2: `HaveExploit` survives as an independently-swappable Retriever seam
- [x] AC-3: `EvaluateExploitStrategy` produces `ExploitStrategyDecision` output
- [x] AC-4: ADR-0025 factory pattern applied to both call-out points

## IMPROVE applied

- `output_keys` type corrected from `str` to `ExploitStrategyDecision` — the BT
  infrastructure writes `typ()` (a default instance), so the declared type must be
  the correct model, not a string.

## DEFER created

- Issue #1565: integration tests for `output_keys` blackboard write/read contracts
  (live blackboard tick verification)

## Test plan

- [x] `uv run pytest test/core/behaviors/report/test_acquire_exploit_strategy_tree.py` — 15 passed
- [x] `uv run black vultron/ test/ && uv run flake8 vultron/ test/ && uv run mypy && uv run pyright` — 0 errors
- [x] `uv run pytest --tb=short` — 5199 passed, full suite green

Closes #1309

🤖 Generated with [Claude Code](https://claude.com/claude-code)