### PR TITLE
docs: plan issue #1375 — demo must not import from vultron/bt

### DIFF
--- a/notes/codebase-structure.md
+++ b/notes/codebase-structure.md
@@ -210,6 +210,33 @@ MUST NOT be confused with `vultron/bt/` or `vultron/core/behaviors/`.
 See `notes/bt-integration.md` for architectural decisions about the BT
 layer.
 
+### Demo layer MUST NOT import the legacy simulator (ARCH-01-006)
+
+`vultron/demo/` demonstrates the **production** protocol (API server, core, and
+wire layers). It MUST NOT import from the legacy `vultron/bt/` simulator, with
+one exception: the unified demo CLI aggregator `vultron/demo/cli.py`
+(mandated by DC-01-001) is permitted to import the standalone `vultron/bt/`
+behaviour-tree demos (pacman, robot, cvd) so it can surface them as a
+`vultrabot` sub-group. Demo *logic* modules — `scenario/`, `exchange/`,
+`helpers/`, `fuzzer/` — MUST stay free of any `vultron/bt/` import.
+
+The standalone behaviour-tree demos live **inside** the simulator tree, at
+`vultron/bt/base/demo/` (`pacman.py`, `robot.py`, `cvd.py`). The CVD
+self-simulation demo `cvd.py` was relocated there from `vultron/demo/vultrabot.py`
+(issue #1375); it is a demo *of* the legacy simulator, not of the production
+protocol, so it belongs with its siblings.
+
+**Relocate, don't re-launder.** When a `vultron/demo/` module genuinely needs
+legacy-simulator symbols (`CvdProtocolBt`, `CVDRolesFlag`, `show_graph`, etc.),
+the fix is to move that module into `vultron/bt/base/demo/` — NOT to re-export
+the legacy symbols through `vultron/core/`. Re-exporting simulator internals via
+the core domain would pull the frozen legacy engine into the production
+dependency graph, a worse layering violation than the one being fixed.
+
+Enforced by the AST ratchet `test/architecture/test_demo_no_bt_imports.py`
+(`KNOWN_VIOLATIONS` lists only `vultron/demo/cli.py`), following the ARCH-18
+bidirectional-equality pattern.
+
 ---
 
 ## Demo Script Lifecycle Logging: `demo_step` / `demo_check`

--- a/plan/history/2607/idea/IDEA-1375.md
+++ b/plan/history/2607/idea/IDEA-1375.md
@@ -1,0 +1,57 @@
+---
+source: IDEA-1375
+timestamp: '2026-07-21T18:09:43.456207+00:00'
+title: demo must not import from vultron/bt
+type: idea
+---
+
+## Original Idea
+
+**ARCH: vultron/demo must not import from vultron/bt** (Idea #1375, under Epic #427)
+
+The demo layer (`vultron/demo/`) imported from the legacy BT simulator layer
+(`vultron/bt/`), violating the intended import direction. The issue proposed
+re-exporting needed symbols through `vultron/core/` or a new adapter seam, and
+enforcing the boundary with a lint/test rule.
+
+## Resolution — Planned 2026-07-21
+
+Investigation found only **two** files under `vultron/demo/` actually import
+`vultron/bt/**` (the rest were docstring `- Source:` provenance comments):
+
+- `vultron/demo/vultrabot.py` — a CVD self-simulation built on the **legacy**
+  `vultron/bt/` custom engine (sibling of the `pacman`/`robot` demos already in
+  `vultron/bt/base/demo/`).
+- `vultron/demo/cli.py` — the unified demo CLI aggregator (mandated by
+  DC-01-001), whose `vultrabot` sub-group surfaces the standalone bt-tree demos.
+
+All demo *logic* (`scenario/`, `exchange/`, `helpers/`, `fuzzer/`) was already
+bt-free — Epic #427's FUZZ-A already re-homed the fuzzer nodes.
+
+**Key decision — relocate, don't re-launder.** The issue's original AC
+("re-export symbols through `vultron/core/`") was rejected as an anti-pattern:
+laundering the frozen legacy simulator through the core domain would be a worse
+layering violation than the one being fixed. Agreed plan:
+
+1. Relocate `vultron/demo/vultrabot.py` → `vultron/bt/base/demo/cvd.py`
+   (joining its `pacman`/`robot` siblings).
+2. Keep `vultron/demo/cli.py` as the single documented, permitted demo→bt
+   importer (it is the unified aggregator entry point, not demo logic).
+3. Enforce with an AST ratchet (`test/architecture/test_demo_no_bt_imports.py`,
+   `KNOWN_VIOLATIONS = {vultron/demo/cli.py}`, ARCH-18 bidirectional equality).
+
+Also uncovered a live bug: the `vultrabot` console-script entry point
+(`pyproject.toml`) pointed at the deleted `vultron/scripts/vultrabot.py`,
+breaking the `vultrabot-demo` Docker service (`docker/Dockerfile` target
+`vultrabot_demo`). The relocation repairs this.
+
+**ADR determination:** spec-only (no new ADR). ARCH-01-006 is a natural
+extension of the already-decided hexagonal layering (ADR-0009), mirroring how
+ARCH-01-005 (production adapters MUST NOT import demo) was captured as a spec
+entry, not its own ADR.
+
+**Docs PR:** <https://github.com/CERTCC/Vultron/pull/1567> (closes #1375 on merge).
+Spec: `specs/architecture.yaml` ARCH-01-006.
+Notes: `notes/codebase-structure.md` § "Demo layer MUST NOT import the legacy simulator".
+
+**Implementation tracked in:** #1568 (size:M, child of Epic #427, blocked-by #1375).

--- a/specs/architecture.yaml
+++ b/specs/architecture.yaml
@@ -70,6 +70,27 @@ groups:
     relationships:
     - rel_type: refines
       spec_id: ARCH-01-001
+  - id: ARCH-01-006
+    priority: MUST_NOT
+    kind: pattern
+    statement: >-
+      Demo-layer modules (`vultron/demo/**`) MUST NOT import from the legacy
+      simulator package (`vultron/bt/**`). The sole permitted exception is the
+      unified demo CLI aggregator (`vultron/demo/cli.py`, mandated by DC-01-001),
+      which surfaces the standalone `vultron/bt/`-based behaviour-tree demos
+      (pacman, robot, cvd) as a sub-group. Demo *logic* modules
+      (`vultron/demo/scenario/`, `vultron/demo/exchange/`, `vultron/demo/helpers/`,
+      `vultron/demo/fuzzer/`) MUST remain free of any `vultron/bt/` import.
+    rationale: >-
+      `vultron/demo/` demonstrates the production protocol; `vultron/bt/` is the
+      frozen legacy custom-engine simulator slated for retirement (see
+      `notes/codebase-structure.md` "Module Boundary"). Coupling demo logic to the
+      legacy simulator undermines the decoupling `vultron/demo/fuzzer/` was created
+      to achieve. `cli.py` is exempt as a thin aggregator entry point — the single
+      documented bridge to the bt-tree demos. Derives from ADR-0009 (hexagonal).
+    relationships:
+    - rel_type: refines
+      spec_id: ARCH-01-001
 - id: ARCH-02
   title: SemanticIntent Enum
   specs:


### PR DESCRIPTION
- Closes #1375

## Summary

Plans the resolution of the `vultron/demo/` → `vultron/bt/` import-boundary
violation (Idea #1375, under Epic #427).

Investigation found only **two** files under `vultron/demo/` actually import
`vultron/bt/**`, and both launch the **legacy `vultron/bt/` custom-engine
simulator**, not the production protocol:

- `vultron/demo/vultrabot.py` — a CVD self-simulation built on the legacy
  engine (sibling of the `pacman`/`robot` demos already living in
  `vultron/bt/base/demo/`).
- `vultron/demo/cli.py` — the unified demo CLI aggregator (mandated by
  DC-01-001), whose `vultrabot` sub-group surfaces the standalone bt-tree
  demos.

All demo *logic* (`scenario/`, `exchange/`, `helpers/`, `fuzzer/`) is already
bt-free. The issue's literal AC ("re-export needed symbols through
`vultron/core/`") was rejected as an anti-pattern — it would pull the frozen
legacy simulator into the production dependency graph. The agreed fix is
**relocation**: move the CVD self-sim into `vultron/bt/base/demo/cvd.py`, and
keep `cli.py` as the single documented, permitted demo→bt importer.

## Changes

- **`specs/architecture.yaml`** — new `ARCH-01-006` (MUST_NOT): demo modules
  MUST NOT import `vultron/bt/**`; the `cli.py` aggregator is the sole
  exception. Rationale derives from ADR-0009 (hexagonal architecture).
- **`notes/codebase-structure.md`** — documents the demo→bt boundary, the
  "relocate, don't re-launder" rule, and the planned AST ratchet enforcement
  (`test/architecture/test_demo_no_bt_imports.py`, `KNOWN_VIOLATIONS =
  {vultron/demo/cli.py}`).

Implementation is tracked in a follow-up issue (relocation + entry-point/Docker
rewiring + ratchet test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)