### PR TITLE
relocate legacy bt CVD demo out of vultron/demo and add demo→bt import ratchet

### DIFF
--- a/docs/reference/code/bt/vultrabot_demo.md
+++ b/docs/reference/code/bt/vultrabot_demo.md
@@ -15,13 +15,13 @@ The Behavior Tree for this demo is essentially the entire tree defined in the
     # run the demo
     $ vultrabot
     # or
-    $ vultrabot --cvd
-    
+    $ vultrabot_cvd
+
     # print the tree and exit
-    $ vultrabot --cvd --print-tree
-    
+    $ vultrabot --print-tree
+
     # if vultron package is not installed
-    $ python -m vultron.bt.base.demo.vultrabot
+    $ python -m vultron.bt.base.demo.cvd
     ```
 
 When the tree is run, it will look something like this:
@@ -34,6 +34,6 @@ The full tree is too large to display here, but you can run the demo to see it.
 
 ## Demo Code
 
-::: vultron.demo.vultrabot
+::: vultron.bt.base.demo.cvd
     options:
         heading_level: 3

--- a/docs/reference/code/demo/demos.md
+++ b/docs/reference/code/demo/demos.md
@@ -85,6 +85,6 @@ Each script can be run standalone via
 
 ## vultrabot (CVD BT Demo)
 
-::: vultron.demo.vultrabot
-    options:
-        heading_level: 3
+The CVD behaviour-tree self-simulation demo now lives in the legacy simulator
+tree alongside its siblings (pacman, robot); see
+[Vultrabot Demo](../bt/vultrabot_demo.md) for its documentation and source.

--- a/docs/reference/codebase/STRUCTURE.md
+++ b/docs/reference/codebase/STRUCTURE.md
@@ -33,8 +33,8 @@
 - **Sub-app for dev/tests**: `vultron.adapters.driving.fastapi.app:app_v2`
 - **CLI scripts**:
   - `vultron-demo` → `vultron.demo.cli:main`
-  - `vultrabot` → `vultron.scripts.vultrabot:main`
-  - `vultrabot_cvd` → `vultron.demo.vultrabot:main`
+  - `vultrabot` → `vultron.bt.base.demo.cvd:main`
+  - `vultrabot_cvd` → `vultron.bt.base.demo.cvd:main`
   - `spec-dump` / `spec-dump-llm-json` → `vultron.metadata.specs.render:main_llm_json`
   - `spec-lint` → `vultron.metadata.specs.lint:main`
   - `append-history` → `vultron.metadata.history.cli:main`

--- a/notes/documentation-strategy.md
+++ b/notes/documentation-strategy.md
@@ -38,8 +38,8 @@ with the ActivityStreams adoption.
 
 ### Generation 2: State-based model and simulation
 
-**Files**: `vultron/case_states/**/*.py`, `vultron/bt/**/*.py`,
-`vultron/demo/vultrabot.py`
+**Files**: `vultron/case_states/**/*.py`, `vultron/bt/**/*.py`
+(including `vultron/bt/base/demo/cvd.py`)
 
 These were some of the earliest Python implementations, based on:
 
@@ -50,7 +50,8 @@ These were some of the earliest Python implementations, based on:
 - [*Designing Vultron*](
   https://www.sei.cmu.edu/documents/1954/2022_003_001_887202.pdf)
   (CMU/SEI-2022-SR-019) — basis for the behavior tree simulator in
-  `vultron/bt/**/*.py` and `vultron/demo/vultrabot.py`.
+  `vultron/bt/**/*.py` (including the CVD self-simulation demo
+  `vultron/bt/base/demo/cvd.py`).
 
 These implementations came **before** the decision to use ActivityStreams
 vocabulary. They remain valuable as reference implementations for protocol

--- a/plan/history/2607/implementation/ISSUE-1568.md
+++ b/plan/history/2607/implementation/ISSUE-1568.md
@@ -1,0 +1,25 @@
+---
+source: ISSUE-1568
+timestamp: '2026-07-21T19:14:44.870456+00:00'
+title: relocate legacy bt CVD demo out of vultron/demo
+type: implementation
+---
+
+## Issue #1568 — ARCH: relocate legacy bt demos out of vultron/demo and add demo→bt import ratchet
+
+Relocated the CVD self-simulation demo from `vultron/demo/vultrabot.py` to
+`vultron/bt/base/demo/cvd.py` (joining pacman/robot siblings) and added an AST
+ratchet (`test/architecture/test_demo_no_bt_imports.py`) enforcing ARCH-01-006
+— `vultron/demo/` MUST NOT import `vultron/bt/**` except the CLI aggregator
+(`KNOWN_VIOLATIONS = {vultron/demo/cli.py}`).
+
+Repointed the `vultrabot` and `vultrabot_cvd` console scripts at the relocated
+module; `vultrabot` had been broken (pointed at deleted
+`vultron/scripts/vultrabot.py`). Made `main(args=None)` self-parse args so
+console-script entry points work while preserving the click-CLI Namespace path.
+Updated the relocated test import and doc references.
+
+Full suite green (5910 passed); black/flake8/mypy/pyright clean; mkdocs build
+succeeds with zero new strict warnings.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1569>

--- a/plan/incoming/learnings/20260721-bt-demo-main-must-accept-no-args-for-console-scripts.md
+++ b/plan/incoming/learnings/20260721-bt-demo-main-must-accept-no-args-for-console-scripts.md
@@ -1,0 +1,47 @@
+---
+title: BT demo main() must be callable with no args to work as a console-script entry point
+type: learning
+timestamp: 2026-07-21T00:00:00Z
+source: ISSUE-1568
+---
+
+## Observation
+
+The `vultron/bt/base/demo/` demos (`pacman`, `robot`, `cvd`) define
+`def main(args): ...` — the `args` positional is provided by their
+`if __name__ == "__main__"` block, which calls `_parse_args()` first.
+
+But `pyproject.toml` `[project.scripts]` entry points invoke `main()` with
+**no arguments** (e.g. `vultrabot_pacman="...pacman:main"`). So
+`uv run vultrabot_pacman` fails immediately with:
+
+```text
+TypeError: main() missing 1 required positional argument: 'args'
+```
+
+This was latently broken for `vultrabot_pacman`/`vultrabot_robot` and for the
+`vultrabot` entry point (which additionally pointed at a deleted module).
+
+## Fix
+
+Make `main` self-parse when called with no args, preserving the path used by
+`vultron/demo/cli.py`'s click sub-group (which passes a `SimpleNamespace` via
+`_bt_args()`):
+
+```python
+def main(args=None) -> None:
+    if args is None:
+        args = _parse_args()
+    ...
+```
+
+## Pattern to apply
+
+When wiring a `vultron/bt/base/demo/` module (or any module) to a
+`[project.scripts]` entry point, verify the target callable is invocable with
+zero arguments. If it currently takes a parsed-args positional, give it an
+`args=None` default and fall back to `_parse_args()`. Test the actual console
+script (`PYTHONPATH= uv run <script>`), not just the module import — and
+remember the devcontainer's `PYTHONPATH=/app` must be cleared or the stale
+baked image shadows the relocated module (see
+[[20260720-pythonpath-app-contaminates-uv-run]]).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,8 +66,8 @@ dynamic = ["version",]
 [project.scripts]
 vultrabot_pacman="vultron.bt.base.demo.pacman:main"
 vultrabot_robot="vultron.bt.base.demo.robot:main"
-vultrabot_cvd="vultron.demo.vultrabot:main"
-vultrabot="vultron.scripts.vultrabot:main"
+vultrabot_cvd="vultron.bt.base.demo.cvd:main"
+vultrabot="vultron.bt.base.demo.cvd:main"
 vultron-demo="vultron.demo.cli:main"
 spec-dump="vultron.metadata.specs.render:main_llm_json"
 spec-dump-llm-json="vultron.metadata.specs.render:main_llm_json"

--- a/test/architecture/test_demo_no_bt_imports.py
+++ b/test/architecture/test_demo_no_bt_imports.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Architecture boundary test: demo layer must not import the legacy simulator.
+
+``vultron/demo/`` demonstrates the **production** protocol (API server, core,
+and wire layers).  It MUST NOT import from the frozen legacy ``vultron/bt/``
+custom-engine simulator — neither at module level nor via deferred (local)
+imports.
+
+Spec: ARCH-01-006 (refines ARCH-01-001)
+
+The sole permitted exception is the unified demo CLI aggregator
+(``vultron/demo/cli.py``, mandated by DC-01-001), which surfaces the standalone
+``vultron/bt/``-based behaviour-tree demos (pacman, robot, cvd) as a
+``vultrabot`` sub-group.
+
+Ratchet pattern
+---------------
+``KNOWN_VIOLATIONS`` documents every permitted/pending violation.  The test
+asserts::
+
+    actual_violations == KNOWN_VIOLATIONS
+
+This means:
+
+* **Adding a new violation** causes the test to **fail** immediately.
+* **Removing the documented exception** (or fixing it) also causes the test to
+  **fail** until the resolved entry is removed from ``KNOWN_VIOLATIONS``.
+
+Follows the ARCH-18 bidirectional-equality pattern used by
+``test/architecture/test_core_no_wire_imports.py``.
+"""
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parents[2]  # test/architecture/ → test/ → repo root
+
+_BT_MODULE = "vultron.bt"
+
+_DEMO_ROOT = REPO_ROOT / "vultron" / "demo"
+
+
+def _imports_from_bt(source_path: Path) -> bool:
+    """Return True if *source_path* contains any import from vultron.bt.
+
+    Detects both top-level and deferred (local) imports, catching violations
+    like ``import vultron.bt.base.demo.pacman`` placed inside a function body.
+    """
+    try:
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module == _BT_MODULE or module.startswith(_BT_MODULE + "."):
+                return True
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == _BT_MODULE or alias.name.startswith(
+                    _BT_MODULE + "."
+                ):
+                    return True
+    return False
+
+
+def _collect_violations() -> frozenset[str]:
+    """Return repo-relative paths of demo files that import from vultron.bt."""
+    violations: set[str] = set()
+    for py_file in _DEMO_ROOT.rglob("*.py"):
+        if "__pycache__" in py_file.parts:
+            continue
+        if _imports_from_bt(py_file):
+            violations.add(py_file.relative_to(REPO_ROOT).as_posix())
+    return frozenset(violations)
+
+
+# ---------------------------------------------------------------------------
+# Known / permitted violations.
+# Only the unified demo CLI aggregator may import the standalone bt-tree demos
+# (pacman, robot, cvd) to surface them as the ``vultrabot`` sub-group. This is
+# the single documented bridge to the legacy simulator (ARCH-01-006, DC-01-001).
+# ---------------------------------------------------------------------------
+KNOWN_VIOLATIONS: frozenset[str] = frozenset({"vultron/demo/cli.py"})
+
+
+def test_demo_does_not_import_bt():
+    """vultron/demo/ must not import from vultron/bt/ except the CLI aggregator.
+
+    Spec: ARCH-01-006
+
+    See module docstring for the ratchet strategy.
+    """
+    actual = _collect_violations()
+    new_violations = actual - KNOWN_VIOLATIONS
+    resolved = KNOWN_VIOLATIONS - actual
+
+    diff_lines: list[str] = []
+    if new_violations:
+        diff_lines.append(
+            "NEW violations (demo must not import from the legacy bt simulator):"
+        )
+        diff_lines.extend(f"  + {v}" for v in sorted(new_violations))
+    if resolved:
+        diff_lines.append(
+            "RESOLVED violations (remove these entries from KNOWN_VIOLATIONS):"
+        )
+        diff_lines.extend(f"  - {v}" for v in sorted(resolved))
+
+    assert actual == KNOWN_VIOLATIONS, "\n\n" + "\n".join(diff_lines)

--- a/test/bt/test_vultrabot.py
+++ b/test/bt/test_vultrabot.py
@@ -15,7 +15,7 @@ import unittest
 from io import StringIO
 from unittest.mock import patch
 
-from vultron.demo import vultrabot
+from vultron.bt.base.demo import cvd as vultrabot
 
 
 class MyTestCase(unittest.TestCase):

--- a/vultron/bt/base/demo/cvd.py
+++ b/vultron/bt/base/demo/cvd.py
@@ -35,7 +35,7 @@ pd.set_option("display.max_columns", 500)
 pd.set_option("display.width", 1000)
 
 
-def main(args) -> None:
+def main(args=None) -> None:
     """
     Instantiates a `CvdProtocolBt` object and runs it until either it closes or 1000 ticks have passed.
     This demo is basically simulating a CVD agent coordinating a CVD case with itself.
@@ -65,6 +65,8 @@ def main(args) -> None:
          This demo is not intended to be a fully realistic simulation of a CVD case. It is only intended
          to demonstrate the behavior of the Vultron behavior tree.
     """
+    if args is None:
+        args = _parse_args()
     _setup_logger(args)
 
     if args.print_tree:

--- a/vultron/demo/cli.py
+++ b/vultron/demo/cli.py
@@ -55,7 +55,7 @@ from vultron.demo.seed_config import SeedConfig
 from vultron.demo.utils import DataLayerClient, BASE_URL, seed_actor
 import vultron.bt.base.demo.pacman as pacman_demo
 import vultron.bt.base.demo.robot as robot_demo
-import vultron.demo.vultrabot as cvd_vultrabot_demo
+import vultron.bt.base.demo.cvd as cvd_vultrabot_demo
 
 # Ordered list of (sub-command name, demo module) pairs.
 # Order defines execution sequence for the `all` sub-command (DC-01-003).


### PR DESCRIPTION
- Closes #1568

## Summary

Relocates the legacy-simulator CVD self-simulation demo from `vultron/demo/vultrabot.py` to `vultron/bt/base/demo/cvd.py` (joining its `pacman`/`robot` siblings) and enforces the demo→bt boundary with a new AST ratchet test (ARCH-01-006). This resolves the `vultron/demo/` → `vultron/bt/` import-boundary violation from Idea #1375 by relocating — not re-laundering through core.

## Changes

- **`vultron/bt/base/demo/cvd.py`** (renamed from `vultron/demo/vultrabot.py`, 98% identical): no behavior change to the CVD self-simulation; `main(args)` → `main(args=None)` with an `if args is None: args = _parse_args()` guard so console-script entry points (which call `main()` with no args) work, while preserving the click-CLI path that passes a `SimpleNamespace`.
- **`pyproject.toml`**: `vultrabot_cvd` and `vultrabot` console scripts both repointed at `vultron.bt.base.demo.cvd:main`. `vultrabot` previously pointed at the deleted `vultron/scripts/vultrabot.py` and was broken.
- **`vultron/demo/cli.py`**: imports the relocated `cvd` module; remains the ONLY `vultron/demo/` file importing `vultron/bt/**`.
- **`test/architecture/test_demo_no_bt_imports.py`** (new): AST ratchet enforcing `actual == KNOWN_VIOLATIONS` with `KNOWN_VIOLATIONS = frozenset({'vultron/demo/cli.py'})`; detects both top-level and deferred `vultron/bt` imports; mirrors the ARCH-18 `test_core_no_wire_imports.py` pattern.
- **`test/bt/test_vultrabot.py`**: imports the relocated module (`vultron.bt.base.demo.cvd`).
- **`docs/reference/code/bt/vultrabot_demo.md`, `docs/reference/code/demo/demos.md`, `docs/reference/codebase/STRUCTURE.md`, `notes/documentation-strategy.md`**: updated module-path references to the relocated `cvd` module.

## Verification

- Full suite green: 5910 passed, 39 skipped, 5 xfailed (run with `-m ""` to include demo tests)
- Black, flake8, mypy, pyright clean
- `uv run vultrabot` and `uv run vultrabot_cvd` both run end-to-end (and the click sub-command `vultron-demo vultrabot cvd`)
- `mkdocs build` succeeds; introduces zero new strict warnings vs origin/main (the 20 pre-existing strict warnings are unrelated tech debt)
- [x] AC-1: vultrabot.py relocated to bt/base/demo/cvd.py, no behavior change
- [x] AC-2: cli.py imports relocated module; only demo file importing bt
- [x] AC-3: console scripts updated; both vultrabot and vultrabot_cvd work
- [x] AC-4: Docker vultrabot_demo target runs `uv run vultrabot` (now resolves)
- [x] AC-5: test/bt/test_vultrabot.py updated, tests pass
- [x] AC-6: doc references updated (demo README needed no change — only references the still-working CLI sub-group)
- [x] AC-7: AST ratchet added with documented KNOWN_VIOLATIONS
- [x] AC-8: full suite green including demo tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)