### PR TITLE
refactor(specs): delta-framing cleanup, spec splits, and new SR-10 group

### DIFF
--- a/specs/activity-factories.yaml
+++ b/specs/activity-factories.yaml
@@ -157,15 +157,6 @@ groups:
 - id: AF-07
   title: TypeAlias Cleanup
   specs:
-  - id: AF-07-001
-    priority: MUST
-    kind: domain
-    statement: The unused `OfferRef` TypeAlias in `vocab/activities/report.py` MUST be removed
-  - id: AF-07-002
-    priority: MUST
-    kind: domain
-    statement: >-
-      The unused `RmInviteToCaseRef` TypeAlias in `vocab/activities/case.py` MUST be removed
   - id: AF-07-003
     priority: SHOULD
     kind: domain

--- a/specs/architecture.yaml
+++ b/specs/architecture.yaml
@@ -420,9 +420,10 @@ groups:
     kind: pattern
     statement: >
       Each domain helper function MUST have exactly one canonical copy.
-      Duplicate implementations of the same logic (e.g., multiple copies of
-      _as_id() or case-manager lookup functions) MUST be removed; all callers
-      MUST import from the canonical location in vultron/core/use_cases/_helpers.py.
+      Layer-neutral helpers (no dependencies above `models/`) MUST live in
+      `vultron/core/models/_helpers.py`. Use-case-specific helpers belong in
+      `vultron/core/use_cases/_helpers.py`. Duplicate implementations of the
+      same logic are prohibited.
     rationale: >
       Duplicate helper copies diverge silently over time. Two copies of
       _as_id() in use_cases/_helpers.py and services/embargo_lifecycle.py had

--- a/specs/behavior-tree-node-design.yaml
+++ b/specs/behavior-tree-node-design.yaml
@@ -4,7 +4,7 @@ description: >-
   Formal requirements for BT node parameterization, composability, and reuse in the core
   behaviors package. Covers node context injection, blackboard hygiene, module ownership,
   and the fractal composability pattern that applies at every depth of the tree hierarchy.
-version: 1.0.0
+version: 1.1.0
 scope:
 
 - prototype
@@ -140,18 +140,27 @@ groups:
     - rel_type: refines
       spec_id: BTND-03-001
   - id: BTND-03-005
+    priority: MUST_NOT
+    kind: language
+    statement: >-
+      Blackboard keys MUST NOT contain forward-slash characters.
+    rationale: >-
+      py_trees parses forward-slashes as namespacing separators; a key containing `/`
+      silently creates a sub-namespace and will not be found by flat-key readers.
+    relationships:
+    - rel_type: refines
+      spec_id: BTND-03-004
+  - id: BTND-03-008
     priority: MUST
     kind: language
     statement: >-
-      Blackboard keys MUST NOT contain forward-slash characters. Keys MUST follow the
-      `{noun}_{id_segment}` naming convention where the noun names the value and `id_segment`
-      is the execution-scoped correlation ID (last path or colon-delimited segment). Flat,
-      unscoped keys (e.g., `result`, `status`) are only permitted for top-level handoff keys
-      that are consumed in the same tick cycle and cannot collide.
+      Blackboard keys MUST follow the `{noun}_{id_segment}` naming convention where the
+      noun names the value and `id_segment` is the execution-scoped correlation ID (last
+      path or colon-delimited segment). Flat, unscoped keys (e.g., `result`, `status`)
+      are only permitted for top-level handoff keys that are consumed in the same tick
+      cycle and cannot collide.
     rationale: >-
-      py_trees parses forward-slashes as namespacing separators; a key containing `/`
-      silently creates a sub-namespace and will not be found by flat-key readers. The
-      `{noun}_{id_segment}` convention generalizes BTND-03-004 to all keys, not just
+      The `{noun}_{id_segment}` convention generalizes BTND-03-004 to all keys, not just
       inter-node handoffs.
     relationships:
     - rel_type: refines
@@ -216,10 +225,8 @@ groups:
     priority: MUST_NOT
     kind: implementation
     statement: >-
-      `behaviors/` modules MUST NOT import from `use_cases/` modules. The import direction
-      is one-way: use-cases drive BT trees; BT nodes MUST NOT import use-case classes or
-      functions. Shared logic needed by both MUST be extracted to a common helper in
-      `vultron/core/` or `vultron/core/behaviors/helpers.py`.
+      `behaviors/` modules MUST NOT import from `use_cases/` modules. BT nodes MUST NOT
+      import use-case classes or functions.
     rationale: >-
       Importing use-cases from behaviors inverts the composition hierarchy (behaviors are
       the implementation layer of use-cases, not their consumers) and introduces circular
@@ -229,6 +236,15 @@ groups:
       spec_id: BTND-04-001
     - rel_type: refines
       spec_id: ARCH-04-001
+  - id: BTND-04-004
+    priority: MUST
+    kind: implementation
+    statement: >-
+      Logic shared between `behaviors/` and `use_cases/` MUST be extracted to a common
+      helper in `vultron/core/` or `vultron/core/behaviors/helpers.py`.
+    relationships:
+    - rel_type: refines
+      spec_id: BTND-04-003
 - id: BTND-05
   title: Actor Configuration for Participant Nodes
   specs:
@@ -401,21 +417,13 @@ groups:
       BT node classes for a given protocol step MUST be organized into a `nodes/`
       subpackage rather than a single flat `nodes.py` module. This applies to all
       BT-bearing process areas in `vultron/core/behaviors/` regardless of current node
-      count or file size — the `nodes/` subpackage is the standard organizational unit
-      for leaf node implementations. Submodules MUST be grouped by semantic concern
-      (e.g., `conditions.py`, `case_setup.py`, `participant.py`, `embargo.py`,
-      `communication.py`, `lifecycle.py`). The package `__init__.py` MUST re-export all
-      public node names to preserve import compatibility with callers.
+      count or file size.
     rationale: >-
       A flat `nodes.py` becomes a high-churn, high-blast-radius file where every change
-      — regardless of which workflow step it touches — modifies the same module. This
-      makes code review shallow, increases the risk of duplicate method definitions
-      silently shadowing correct logic, and degrades test maintainability. Applying the
-      `nodes/` subpackage pattern uniformly (not just when a file grows large) keeps the
-      hierarchy consistent across all process areas and prevents gradual accumulation that
-      creates a large-file problem later. Grouping by semantic concern reduces diff scope,
-      improves discoverability, and lets reviewers focus on the affected concern in
-      isolation.
+      — regardless of which workflow step it touches — modifies the same module. Applying
+      the `nodes/` subpackage pattern uniformly (not just when a file grows large) keeps
+      the hierarchy consistent and prevents gradual accumulation that creates a large-file
+      problem later.
     relationships:
     - rel_type: refines
       spec_id: BT-06-004
@@ -424,6 +432,28 @@ groups:
       subpackage and does not retain a flat `nodes.py` module at the area root.
       Helper-only areas that do not define BT tree composition or BT leaf nodes are
       exempt.
+  - id: BTND-07-006
+    priority: MUST
+    kind: pattern
+    statement: >-
+      Within a `nodes/` subpackage, submodules MUST be grouped by semantic concern
+      (e.g., `conditions.py`, `case_setup.py`, `participant.py`, `embargo.py`,
+      `communication.py`, `lifecycle.py`).
+    rationale: >-
+      Grouping by semantic concern reduces diff scope, improves discoverability, and
+      lets reviewers focus on the affected concern in isolation.
+    relationships:
+    - rel_type: refines
+      spec_id: BTND-07-001
+  - id: BTND-07-007
+    priority: MUST
+    kind: pattern
+    statement: >-
+      The `nodes/` subpackage `__init__.py` MUST re-export all public node names to
+      preserve import compatibility with callers.
+    relationships:
+    - rel_type: refines
+      spec_id: BTND-07-001
   - id: BTND-07-002
     priority: SHOULD
     kind: pattern

--- a/specs/behavior-tree-node-design.yaml
+++ b/specs/behavior-tree-node-design.yaml
@@ -247,8 +247,9 @@ groups:
     priority: MUST
     kind: domain
     statement: >-
-      `CreateInitialVendorParticipant` MUST be replaced by a `CreateCaseOwnerParticipant`
-      node that:
+      The BT node for creating the initial case participant MUST be role-agnostic. It MUST NOT
+      assume any specific CVD role (e.g., Vendor). It MUST treat the actor as the case owner
+      regardless of their CVD role(s). The correct node is `CreateCaseOwnerParticipant`.
     rationale: >-
       "Vendor" is a demo-specific assumption. In the general protocol a coordinator, deployer,
       or other role may equally receive a report and become the case owner. The node MUST
@@ -260,9 +261,8 @@ groups:
     priority: MUST
     kind: domain
     statement: >-
-      The `CreateFinderParticipantNode` backward-compatibility alias (currently `CreateFinderParticipantNode
-      = CreateCaseParticipantNode`) MUST be removed. All call sites MUST use `CreateCaseParticipantNode`
-      directly with an explicit `roles` parameter.
+      The generic participant creation node is `CreateCaseParticipantNode`. Callers MUST pass
+      an explicit `roles` parameter; no role-specific subclasses or alias names are permitted.
     rationale: >-
       Alias names carry the old "finder-specific" framing and mislead readers about the node's
       actual generality.

--- a/specs/build-workflow.yaml
+++ b/specs/build-workflow.yaml
@@ -5,7 +5,7 @@ description: >-
   and bugfix skills to pass implementation observations upstream to the learn skill. Covers
   what belongs in the queue, what must not go there, file naming and format, how the learn
   skill processes and archives entries, and the learning history entry type.
-version: 2.0.0
+version: 2.1.0
 scope:
   - prototype
   - production
@@ -41,10 +41,17 @@ groups:
         statement: >-
           The `build` and `bugfix` skills MUST NOT write completion summaries
           or task-status narratives to `plan/incoming/learnings/`.
-          Completion summaries MUST be archived exclusively via
-          `uv run append-history implementation`.
         relationships:
           - rel_type: depends_on
+            spec_id: HM-05-001
+      - id: BW-01-005
+        priority: MUST
+        kind: dev-process
+        statement: >-
+          Completion summaries from the `build` and `bugfix` skills MUST be
+          archived exclusively via `uv run append-history implementation`.
+        relationships:
+          - rel_type: implements
             spec_id: HM-05-001
       - id: BW-01-003
         priority: MUST
@@ -53,27 +60,42 @@ groups:
           Each incoming learning file MUST be named `YYYYMMDD-SLUG.md`
           where `YYYYMMDD` is the creation date and `SLUG` is a short
           uppercase identifier matching the `source` frontmatter field
-          (e.g., `20260622-AST-RATCHET-LAMBDA.md`). The file MUST be
-          committed as part of the originating PR so the learning is
-          permanently linked to the work that produced it.
+          (e.g., `20260622-AST-RATCHET-LAMBDA.md`).
         rationale: >-
           Using individual files instead of a shared flat file eliminates
           merge conflicts when multiple PRs each have an observation to
           record. The date prefix provides filesystem sort order.
+      - id: BW-01-006
+        priority: MUST
+        kind: dev-process
+        statement: >-
+          Incoming learning files MUST be committed as part of the
+          originating PR so the learning is permanently linked to the
+          work that produced it.
+        relationships:
+          - rel_type: refines
+            spec_id: BW-01-003
       - id: BW-01-004
         priority: MUST_NOT
         kind: dev-process
         statement: >-
           Skills other than `build` and `bugfix` MUST NOT create files in
-          `plan/incoming/learnings/`. The `update-plan` skill MUST write
-          observations and open questions directly to appropriate
-          `notes/*.md` files. It MUST NOT use the incoming learnings queue
-          as an intermediate staging area.
+          `plan/incoming/learnings/`.
         rationale: >-
           `plan/incoming/learnings/` is specifically a channel for
           code-execution insights flowing from build/bugfix to learn.
           Gap-analysis observations from `update-plan` are a different
           signal and belong in notes directly.
+      - id: BW-01-007
+        priority: MUST
+        kind: dev-process
+        statement: >-
+          The `update-plan` skill MUST write observations and open questions
+          directly to appropriate `notes/*.md` files. It MUST NOT use
+          `plan/incoming/learnings/` as an intermediate staging area.
+        relationships:
+          - rel_type: refines
+            spec_id: BW-01-004
   - id: BW-02
     title: Incoming Learnings File Format
     kind: domain
@@ -98,13 +120,21 @@ groups:
         priority: MUST
         kind: domain
         statement: >-
-          The `source` field MUST match the filename stem
-          (`YYYYMMDD-SLUG`). The `timestamp` field MUST reflect the
-          actual creation time of the observation (not today's date if
-          the entry was written for a historical run).
+          The `source` field in an incoming learning file MUST match the
+          filename stem (`YYYYMMDD-SLUG`).
         relationships:
           - rel_type: depends_on
             spec_id: HM-02-001
+      - id: BW-02-003
+        priority: MUST
+        kind: domain
+        statement: >-
+          The `timestamp` field in an incoming learning file MUST reflect the
+          actual creation time of the observation (not the current date if the
+          entry was written for a historical run).
+        relationships:
+          - rel_type: depends_on
+            spec_id: HM-06-001
   - id: BW-03
     title: learn Skill Processing
     kind: dev-process
@@ -152,12 +182,19 @@ groups:
         kind: implementation
         statement: >-
           The `learning` entry type MUST exist in `HistoryEntryType` in
-          `vultron/metadata/history/types.py`.  The `learn` skill MUST
-          use `uv run append-history --from-file` to archive each
-          processed incoming learning file.
+          `vultron/metadata/history/types.py`.
         relationships:
           - rel_type: refines
             spec_id: HM-02-002
+      - id: BW-04-003
+        priority: MUST
+        kind: dev-process
+        statement: >-
+          The `learn` skill MUST use `uv run append-history --from-file`
+          to archive each processed incoming learning file.
+        relationships:
+          - rel_type: implements
+            spec_id: BW-04-001
       - id: BW-04-002
         priority: MUST
         kind: implementation

--- a/specs/case-ledger-processing.yaml
+++ b/specs/case-ledger-processing.yaml
@@ -6,7 +6,7 @@ description: >-
   Covers the commit authorization model, per-case genesis hash derivation, the canonical
   entry criteria that separate the case ledger from the process log, and the CaseActor
   inbox routing path that enables ledger entry authorship.
-version: 1.0.0
+version: 1.1.0
 scope:
 - prototype
 - production
@@ -503,19 +503,14 @@ groups:
     priority: MUST
     kind: domain
     statement: >-
-      A received-side use case's `execute()` method MUST do exactly three
-      things: build one BT via a tree-factory function in
-      `vultron/core/behaviors/`, call `BTBridge.execute_with_setup()` exactly
-      once with `actor_id=receiving_actor_id` to run it, and handle the
-      result (log/extract output per the existing Procedural Glue Exception).
-      `execute()` MUST NOT perform any other domain-significant work — no
-      direct DataLayer mutation, no second `execute_with_setup()` call, and
-      no direct import or call of `create_guarded_commit_case_ledger_entry_tree`
-      (or any other guarded-commit factory). Any operation that is currently
-      procedural code in `execute()` (including the use case's main
-      operation, if not already a BT) MUST be expressed as a node in the
-      single tree; the guarded-commit subtree MUST be composed as a child
-      of that same tree-factory function, not invoked separately
+      A received-side use case's `execute()` method MUST do exactly three things:
+      build one BT via a tree-factory function in `vultron/core/behaviors/`, call
+      `BTBridge.execute_with_setup()` exactly once with `actor_id=receiving_actor_id`
+      to run it, and handle the result (log/extract output per the existing Procedural
+      Glue Exception). `execute()` MUST NOT perform any other domain-significant work
+      — no direct DataLayer mutation, no second `execute_with_setup()` call, and no
+      direct import or call of `create_guarded_commit_case_ledger_entry_tree` (or any
+      other guarded-commit factory).
     rationale: >-
       CLP-10-002/CLP-10-003 (ADR-0021) correctly require a pre-flight guard
       before committing, and correctly require the guard to compare against
@@ -550,6 +545,27 @@ groups:
       it catches every known violation but a reviewer MUST still confirm no
       other domain-significant code remains in `execute()` when closing each
       migration.
+  - id: CLP-10-007
+    priority: MUST
+    kind: domain
+    statement: >-
+      Any operation that is procedural code in `execute()` (including the use case's
+      main operation) MUST be expressed as a node in the single BT tree built by the
+      tree-factory function.
+    relationships:
+    - rel_type: refines
+      spec_id: CLP-10-005
+  - id: CLP-10-008
+    priority: MUST
+    kind: domain
+    statement: >-
+      The guarded-commit subtree MUST be composed as a child of the tree-factory
+      function, not invoked as a separate `execute_with_setup()` call.
+    relationships:
+    - rel_type: refines
+      spec_id: CLP-10-005
+    - rel_type: refines
+      spec_id: CLP-10-002
   - id: CLP-10-006
     priority: MUST
     kind: domain

--- a/specs/datalayer.yaml
+++ b/specs/datalayer.yaml
@@ -170,11 +170,11 @@ groups:
   - id: DL-05-003
     priority: MUST_NOT
     kind: implementation
-    statement: Core code (`vultron/core/`) MUST NOT rely on structural duck-typing Protocols (e.g. the `CaseModel`,
-      `ParticipantModel`, `ParticipantStatusModel`, `LogEntryModel` Protocols and the `is_case_model()` /
-      `is_participant_model()` / `is_log_entry_model()` `TypeGuard` helpers in `vultron/core/models/protocols.py`) as a
-      means of accepting DataLayer results without importing concrete core types; once DL-05-001 holds, core MUST depend on
-      concrete core domain classes (real `isinstance` narrowing) and the workaround Protocols MUST be removed.
+    statement: >-
+      Core code (`vultron/core/`) MUST NOT use structural duck-typing Protocols to accept
+      DataLayer results without importing concrete core types. Core MUST depend on concrete
+      domain classes and use `isinstance` narrowing directly. Structural workaround Protocols
+      that evade ARCH-01-001 are prohibited.
     rationale: >
       The duck-typing Protocols exist solely to let core touch wire objects at runtime without a compile-time wire import,
       evading rather than honouring ARCH-01-001. When the read path returns core objects, the Protocols are dead weight

--- a/specs/history-management.yaml
+++ b/specs/history-management.yaml
@@ -42,16 +42,6 @@ groups:
           (see HM-03-006). This file is a **gitignored local cache** — it MUST
           NOT be committed to the repository. To view the history index, use
           `uv run show-history [--month YYMM | --all]`.
-      - id: HM-01-004
-        priority: MUST
-        kind: dev-process
-        statement: >-
-          The legacy monolithic history files (`plan/IMPLEMENTATION_HISTORY.md`,
-          `plan/IDEA-HISTORY.md`, `plan/PRIORITY_HISTORY.md`) MUST be moved
-          to `plan/history/` at their top level as static archives. A static
-          `plan/history/README.md` MUST be created explaining that these files
-          predate the structured format and were superseded on the migration
-          date.
       - id: HM-01-005
         priority: MUST_NOT
         kind: dev-process
@@ -262,18 +252,9 @@ groups:
         priority: MUST
         kind: domain
         statement: >-
-          `HistoryEntryFrontmatter` MUST accept exactly one of `timestamp` or
-          the legacy `date` field. If both are present, validation MUST fail
-          with a clear error. If neither is present, validation MUST fail.
-      - id: HM-06-003
-        priority: MUST
-        kind: domain
-        statement: >-
-          When the legacy `date` field is present and `timestamp` is absent,
-          `HistoryEntryFrontmatter` MUST normalise the entry by converting
-          `date` to a `timestamp` equal to midnight UTC on that date
-          (e.g., `date: 2026-04-28` → `timestamp: 2026-04-28T00:00:00+00:00`).
-          After normalisation all downstream code MUST use `timestamp` only.
+          `HistoryEntryFrontmatter` MUST require a `timestamp` field
+          (timezone-aware ISO 8601 datetime in UTC). Validation MUST fail
+          with a clear error if `timestamp` is absent or malformed.
       - id: HM-06-004
         priority: MUST
         kind: domain

--- a/specs/history-management.yaml
+++ b/specs/history-management.yaml
@@ -207,17 +207,13 @@ groups:
         kind: dev-process
         statement: >-
           The `build` skill MUST use `uv run append-history implementation`
-          to write completion summaries instead of directly appending to
-          `plan/IMPLEMENTATION_HISTORY.md`. References to direct file paths
-          for history files MUST be replaced with `append-history` invocations.
+          to write completion summaries.
       - id: HM-05-002
         priority: MUST
         kind: dev-process
         statement: >-
           The `ingest-idea` skill MUST use `uv run append-history idea` to
-          archive processed ideas instead of directly appending to
-          `plan/IDEA-HISTORY.md`. References to direct file paths MUST be
-          replaced with `append-history` invocations.
+          archive processed ideas.
       - id: HM-05-003
         priority: MUST
         kind: dev-process
@@ -313,7 +309,7 @@ groups:
         priority: MUST
         kind: implementation
         statement: >-
-          All existing skill documentation (`ingest-idea`, `build`, `learn`)
-          and `notes/history-management.md` MUST be updated to use the new
-          `--title`/`--source` interface. References to the old
-          frontmatter-in-stdin pattern MUST be removed.
+          Skill documentation (`ingest-idea`, `build`, `learn`) and
+          `notes/history-management.md` MUST use the `--title`/`--source`
+          interface for `append-history`. The frontmatter-in-stdin pattern
+          MUST NOT be used.

--- a/specs/history-management.yaml
+++ b/specs/history-management.yaml
@@ -4,7 +4,7 @@ description: >-
   Defines the structure, location, entry format, and tooling for managing project history
   files using per-entry write-once files organized by month and type, managed by the
   `append-history` CLI tool.
-version: 1.2.0
+version: 1.3.0
 scope:
   - prototype
   - production
@@ -20,9 +20,12 @@ groups:
         priority: MUST
         kind: dev-process
         statement: >-
-          All project history files MUST reside under `plan/history/`. The
-          top-level `plan/` directory MUST NOT contain any new `*HISTORY.md`
-          files after this spec is adopted.
+          All project history files MUST reside under `plan/history/`.
+      - id: HM-01-006
+        priority: MUST_NOT
+        kind: dev-process
+        statement: >-
+          The top-level `plan/` directory MUST NOT contain any `*HISTORY.md` files.
       - id: HM-01-002
         priority: MUST
         kind: dev-process
@@ -78,9 +81,16 @@ groups:
           Valid `type` values MUST be defined as a `StrEnum` named
           `HistoryEntryType` in `vultron/metadata/history/types.py`. Current
           values are `idea`, `implementation`, `learning`, and `priority`.
-          Adding a new type MUST only require adding a member to this enum;
-          no other code changes are required for the tool to accept the new
-          type.
+      - id: HM-02-005
+        priority: MUST
+        kind: domain
+        statement: >-
+          Adding a new history entry type MUST only require adding a member to
+          the `HistoryEntryType` enum; no other code changes are required for
+          the tool to accept the new type.
+        relationships:
+        - rel_type: refines
+          spec_id: HM-02-002
       - id: HM-02-003
         priority: MUST
         kind: domain
@@ -107,9 +117,16 @@ groups:
         kind: implementation
         statement: >-
           The tool MUST be invokable as `uv run append-history <type>` where
-          `<type>` is one of the valid `HistoryEntryType` values (see
-          HM-02-002). Passing an unrecognised type MUST produce a clear error
-          message and exit non-zero.
+          `<type>` is one of the valid `HistoryEntryType` values (see HM-02-002).
+      - id: HM-03-009
+        priority: MUST
+        kind: implementation
+        statement: >-
+          Passing an unrecognised `<type>` to `append-history` MUST produce a
+          clear error message and exit non-zero.
+        relationships:
+        - rel_type: refines
+          spec_id: HM-03-001
       - id: HM-03-002
         priority: MUST
         kind: implementation
@@ -138,30 +155,36 @@ groups:
         priority: MUST
         kind: implementation
         statement: >-
-          The tool MUST create `plan/history/YYMM/<type>/` if it does not
-          already exist before writing the entry file. The `plan/history/YYMM/`
-          directory MUST also be created if it does not exist.
+          The tool MUST create `plan/history/YYMM/` and `plan/history/YYMM/<type>/`
+          if they do not already exist before writing the entry file.
       - id: HM-03-006
         priority: MUST
         kind: implementation
         statement: >-
-          After writing a new entry file, the tool MUST regenerate a local
-          `plan/history/YYMM/README.md` by scanning only the known-type
+          After writing a new entry file, the tool MUST regenerate
+          `plan/history/YYMM/README.md` by scanning the known-type
           subdirectories (`idea/`, `implementation/`, `learning/`, `priority/`),
           reading each entry file's frontmatter, and writing a summary table
-          sorted by timestamp descending. The file is gitignored — it MUST NOT
-          be staged or committed. Use `uv run show-history` to view the index.
+          sorted by timestamp descending.
         notes: >-
           The scan is restricted to known HistoryEntryType subdirectories to
           avoid parsing non-standard frontmatter in other subdirs (e.g.
-          report/).
+          report/). The gitignore constraint is specified in HM-01-003.
       - id: HM-03-007
         priority: MUST
         kind: implementation
         statement: >-
-          The tool's Python module MUST reside under `vultron/metadata/history/`
-          as a sibling of `vultron/metadata/specs/`. The entry point function
-          MUST be `vultron.metadata.history.cli:main`.
+          The `append-history` tool's Python module MUST reside under
+          `vultron/metadata/history/` as a sibling of `vultron/metadata/specs/`.
+      - id: HM-03-010
+        priority: MUST
+        kind: implementation
+        statement: >-
+          The `append-history` entry point function MUST be
+          `vultron.metadata.history.cli:main`.
+        relationships:
+        - rel_type: refines
+          spec_id: HM-03-007
       - id: HM-03-008
         priority: MUST
         kind: implementation
@@ -241,9 +264,16 @@ groups:
         statement: >-
           Every new history entry MUST include a `timestamp` field containing a
           tz-aware ISO 8601 datetime string in UTC (e.g.,
-          `"2026-05-01T15:30:00+00:00"`). The `append-history` tool MUST
-          populate this field automatically from the current system clock when
-          creating new entries.
+          `"2026-05-01T15:30:00+00:00"`).
+      - id: HM-06-007
+        priority: MUST
+        kind: implementation
+        statement: >-
+          The `append-history` tool MUST populate the `timestamp` field
+          automatically from the current system clock when creating new entries.
+        relationships:
+        - rel_type: implements
+          spec_id: HM-06-001
       - id: HM-06-002
         priority: MUST
         kind: domain
@@ -264,10 +294,24 @@ groups:
         priority: MUST
         kind: domain
         statement: >-
-          All `timestamp` values MUST be timezone-aware. Naive datetime values
-          (those without a UTC offset) MUST be rejected with a clear error
-          message. All stored and compared timestamps MUST be normalised to
-          UTC.
+          All `timestamp` values MUST be timezone-aware.
+      - id: HM-06-008
+        priority: MUST
+        kind: domain
+        statement: >-
+          Naive datetime values (those without a UTC offset) MUST be rejected
+          with a clear error message.
+        relationships:
+        - rel_type: refines
+          spec_id: HM-06-005
+      - id: HM-06-009
+        priority: MUST
+        kind: domain
+        statement: >-
+          All stored and compared timestamps MUST be normalised to UTC.
+        relationships:
+        - rel_type: refines
+          spec_id: HM-06-005
       - id: HM-06-006
         priority: MUST
         kind: domain
@@ -286,25 +330,52 @@ groups:
         kind: implementation
         statement: >-
           The `append-history <type>` command MUST accept `--title` and
-          `--source` as required named arguments. The tool MUST construct the
-          YAML frontmatter block internally from these arguments plus the
-          auto-generated `timestamp`.
+          `--source` as required named arguments.
+      - id: HM-07-005
+        priority: MUST
+        kind: implementation
+        statement: >-
+          The tool MUST construct the YAML frontmatter block internally from
+          the `--title`, `--source`, and auto-generated `timestamp` arguments;
+          callers MUST NOT supply frontmatter content.
+        relationships:
+        - rel_type: refines
+          spec_id: HM-07-001
       - id: HM-07-002
         priority: MUST_NOT
         kind: implementation
         statement: >-
-          Callers of `append-history` MUST NOT include a YAML frontmatter
-          block in the content they supply via stdin or `--file`. The content
-          MUST be the body text only; the tool prepends the generated
-          frontmatter.
+          Callers of `append-history` MUST NOT include a YAML frontmatter block
+          in the content they supply via stdin or `--file`.
+        relationships:
+        - rel_type: refines
+          spec_id: HM-07-005
       - id: HM-07-003
         priority: MUST
         kind: implementation
         statement: >-
           The tool MUST accept a hidden `--timestamp` argument for backfill
-          use only (e.g., migrating pre-existing entries). This argument MUST
-          accept an ISO 8601 datetime string with a UTC offset. The standard
-          future-date validation (HM-06-004) MUST apply to this override value.
+          use only (e.g., migrating pre-existing entries).
+      - id: HM-07-006
+        priority: MUST
+        kind: implementation
+        statement: >-
+          The `--timestamp` override argument MUST accept an ISO 8601 datetime
+          string with a UTC offset.
+        relationships:
+        - rel_type: refines
+          spec_id: HM-07-003
+      - id: HM-07-007
+        priority: MUST
+        kind: implementation
+        statement: >-
+          The standard future-date validation (HM-06-004) MUST apply to values
+          supplied via the `--timestamp` override argument.
+        relationships:
+        - rel_type: refines
+          spec_id: HM-07-003
+        - rel_type: implements
+          spec_id: HM-06-004
       - id: HM-07-004
         priority: MUST
         kind: implementation

--- a/specs/meta-specifications.yaml
+++ b/specs/meta-specifications.yaml
@@ -2,7 +2,7 @@ id: MS
 title: Meta-Specification Style Guide
 description: Normative rules for authoring specification files in this project. Covers file structure, requirement format,
   IDs, writing rules, cross-references, lifecycle, quality criteria, and the delineation between spec files and ADRs.
-version: 1.0.0
+version: 1.1.0
 scope:
 - prototype
 - production
@@ -91,11 +91,20 @@ groups:
   - id: MS-04-003
     priority: MUST
     kind: general
-    statement: Requirement IDs MUST be stable; once assigned, an ID MUST NOT be renumbered. Superseded requirements MUST be
-      removed entirely rather than left in place as deprecated.
-    rationale: Stable IDs preserve traceability in git history; deprecated-but-present requirements create confusion for agents.
+    statement: Requirement IDs MUST be stable; once assigned, an ID MUST NOT be renumbered.
+    rationale: Stable IDs preserve traceability in git history.
     tags:
     - documentation
+  - id: MS-04-005
+    priority: MUST
+    kind: general
+    statement: Superseded requirements MUST be removed entirely rather than left in place as deprecated.
+    rationale: Deprecated-but-present requirements create confusion for agents and future implementers.
+    tags:
+    - documentation
+    relationships:
+    - rel_type: refines
+      spec_id: MS-04-003
   - id: MS-04-004
     priority: MUST
     kind: general

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -301,18 +301,11 @@ groups:
     priority: MUST
     kind: implementation
     statement: >-
-      The CASE_MANAGER role delegation (Vendor hands operational management to Case Actor)
-      MUST be implemented as a distinct protocol mechanism from OFFER_CASE_OWNERSHIP_TRANSFER;
-      CASE_MANAGER delegation allows the Vendor to retain CASE_OWNER while delegating
-      operational authority.
-      Wire vocab types (`_OfferCaseManagerRoleActivity`, `_AcceptCaseManagerRoleActivity`,
-      `_RejectCaseManagerRoleActivity`), extractor patterns, factory functions,
-      `MessageSemantics` values (`OFFER_CASE_MANAGER_ROLE`, `ACCEPT_CASE_MANAGER_ROLE`,
-      `REJECT_CASE_MANAGER_ROLE`), and received-side use cases are already implemented.
-      The remaining gaps are: (1) these use cases are not registered in the semantic
-      registry (`vultron/semantic_registry/__init__.py`), and
-      (2) trigger-side use cases (`SvcOfferCaseManagerRoleUseCase` and peers) are not yet
-      implemented. See DEMOMA-08-006 through DEMOMA-08-009 for the downstream specs.
+      CASE_MANAGER role delegation MUST be implemented as a distinct protocol mechanism from
+      OFFER_CASE_OWNERSHIP_TRANSFER. CASE_MANAGER delegation allows the Vendor to retain
+      CASE_OWNER while delegating operational authority to a service actor. The three-message
+      handshake (Offer/Accept/Reject) MUST use distinct `MessageSemantics` values:
+      `OFFER_CASE_MANAGER_ROLE`, `ACCEPT_CASE_MANAGER_ROLE`, `REJECT_CASE_MANAGER_ROLE`.
   - id: DEMOMA-08-006
     priority: MUST
     kind: implementation

--- a/specs/parallel-development.yaml
+++ b/specs/parallel-development.yaml
@@ -5,7 +5,7 @@ description: >-
   GitHub Issues. Defines the issue hierarchy, label taxonomy, task claiming protocol,
   size labeling, orphan recovery, and revised workflows for the build, ingest-idea,
   review-priorities, and update-plan skills.
-version: 1.0.0
+version: 1.1.0
 scope:
   - prototype
   - production
@@ -33,9 +33,23 @@ groups:
         priority: MUST
         kind: dev-process
         statement: >-
-          Epic Issues MUST correspond to a named priority group in
-          PRIORITIES.md. Task Issues MUST be sub-issues of their parent Epic.
+          Epic Issues MUST correspond to a named priority group in PRIORITIES.md.
+      - id: PAD-01-005
+        priority: MUST
+        kind: dev-process
+        statement: >-
+          Task Issues MUST be sub-issues of their parent Epic.
+        relationships:
+        - rel_type: refines
+          spec_id: PAD-01-002
+      - id: PAD-01-006
+        priority: MUST
+        kind: dev-process
+        statement: >-
           Subtask Issues MUST be sub-issues of their parent Task.
+        relationships:
+        - rel_type: refines
+          spec_id: PAD-01-002
       - id: PAD-01-004
         priority: SHOULD
         kind: dev-process
@@ -67,8 +81,15 @@ groups:
         statement: >-
           A `stale-claim` label MUST be applied by the sweeper job (PAD-10)
           when a claimed Issue has no open PR and the claim branch has not
-          received a commit within 3 days. Agents MUST skip Issues that carry
-          this label.
+          received a commit within 3 days.
+      - id: PAD-02-011
+        priority: MUST
+        kind: dev-process
+        statement: >-
+          Agents MUST skip Issues that carry the `stale-claim` label.
+        relationships:
+        - rel_type: refines
+          spec_id: PAD-04-003
       - id: PAD-02-005
         priority: MUST
         kind: dev-process
@@ -92,9 +113,17 @@ groups:
           priority group title (e.g., `group:architecture-hardening` for
           "Priority 473: Architecture Hardening"). Priority ordering is expressed
           in PRIORITIES.md; embedding numbers in label names causes conflicts
-          when priorities are reordered. When creating a new `group:` label on
-          GitHub, the label description MUST use the priority group title (not
-          the number) so it remains accurate if the priority number changes.
+          when priorities are reordered.
+      - id: PAD-02-012
+        priority: MUST
+        kind: dev-process
+        statement: >-
+          When creating a new `group:` label on GitHub, the label description
+          MUST use the priority group title (not the priority number) so it
+          remains accurate if the priority number changes.
+        relationships:
+        - rel_type: refines
+          spec_id: PAD-02-007
       - id: PAD-02-008
         priority: MUST
         kind: dev-process
@@ -108,9 +137,16 @@ groups:
         statement: >-
           Epic Issues MUST be created using the GitHub `Epic` issue type (via
           GraphQL `createIssue` with the appropriate `issueTypeId`) and MUST
-          carry the `group:<name>` label matching their priority group. The
-          `create-epic` skill MUST be used to create Epic Issues to ensure
-          consistent wiring of sub-issues.
+          carry the `group:<name>` label matching their priority group.
+      - id: PAD-02-013
+        priority: MUST
+        kind: dev-process
+        statement: >-
+          The `create-epic` skill MUST be used to create Epic Issues to ensure
+          consistent wiring of sub-issues and correct issue type assignment.
+        relationships:
+        - rel_type: implements
+          spec_id: PAD-02-009
       - id: PAD-02-010
         priority: MUST
         kind: dev-process
@@ -207,8 +243,16 @@ groups:
         kind: dev-process
         statement: >-
           The `build` skill MUST invoke the `code-review` agent before
-          opening a PR. The review MUST run against the current branch diff
+          opening a PR.
+      - id: PAD-07-005
+        priority: MUST
+        kind: dev-process
+        statement: >-
+          The `code-review` agent MUST run against the current branch diff
           relative to `main`.
+        relationships:
+        - rel_type: refines
+          spec_id: PAD-07-001
       - id: PAD-07-002
         priority: MUST
         kind: dev-process
@@ -223,8 +267,17 @@ groups:
         kind: dev-process
         statement: >-
           The `build` skill MUST resolve all `[BLOCKING]` findings before
-          opening a PR. After resolving, it MUST re-run the code review to
-          confirm no new `[BLOCKING]` findings were introduced.
+          opening a PR.
+      - id: PAD-07-006
+        priority: MUST
+        kind: dev-process
+        statement: >-
+          After resolving `[BLOCKING]` findings, the `build` skill MUST re-run
+          the code review to confirm no new `[BLOCKING]` findings were
+          introduced.
+        relationships:
+        - rel_type: refines
+          spec_id: PAD-07-003
       - id: PAD-07-004
         priority: SHOULD
         kind: dev-process
@@ -249,7 +302,12 @@ groups:
         statement: >-
           The `build` skill MUST open a GitHub Pull Request with "Closes #N"
           in the body after completing implementation and passing all
-          validations. It MUST NOT commit directly to `main`.
+          validations.
+      - id: PAD-08-004
+        priority: MUST_NOT
+        kind: dev-process
+        statement: >-
+          The `build` skill MUST NOT commit directly to `main`.
       - id: PAD-08-003
         priority: MUST
         kind: dev-process

--- a/specs/participant-case-replica.yaml
+++ b/specs/participant-case-replica.yaml
@@ -4,7 +4,7 @@ description: >-
   Requirements for how each Vultron Actor maintains and manages its local copy (replica) of
   a VulnerabilityCase. Covers replica identity, bootstrap, update authority, case-context
   message routing, reporter case discovery, and unknown-context handling.
-version: 1.0.0
+version: 1.1.0
 scope:
 - prototype
 - production
@@ -227,9 +227,21 @@ groups:
     priority: MUST_NOT
     kind: domain
     statement: >-
-      The `CaseLedgerEntry + broadcast` cascade MUST NOT be manually triggered by demo scripts or
-      external clients. It MUST fire automatically as a consequence of the Case Actor processing
-      any accepted participant message, not only via explicit demo endpoint invocation.
+      The `CaseLedgerEntry + broadcast` cascade MUST NOT be manually triggered by demo
+      scripts or external clients.
+    relationships:
+    - rel_type: refines
+      spec_id: PCR-08-003
+  - id: PCR-08-013
+    priority: MUST
+    kind: domain
+    statement: >-
+      The `CaseLedgerEntry + broadcast` cascade MUST fire automatically as a consequence
+      of the Case Actor processing any accepted participant message, not only via explicit
+      demo endpoint invocation.
+    relationships:
+    - rel_type: refines
+      spec_id: PCR-08-003
   - id: PCR-08-005
     priority: MUST
     kind: domain
@@ -271,32 +283,45 @@ groups:
     kind: domain
     statement: >-
       The Case Actor MUST process `RmAcceptInviteToCaseActivity` and record the invitee's
-      RM state transition (VALID → ACCEPTED) in its own DataLayer. The case owner MUST NOT
-      author or emit any RM state-change activity on behalf of the invitee.
+      RM state transition (VALID → ACCEPTED) in its own DataLayer.
     relationships:
     - rel_type: refines
       spec_id: PCR-08-001
     - rel_type: refines
       spec_id: PCR-08-003
+  - id: PCR-08-014
+    priority: MUST_NOT
+    kind: domain
+    statement: >-
+      The case owner MUST NOT author or emit any RM state-change activity on behalf of
+      the invitee.
+    relationships:
+    - rel_type: refines
+      spec_id: PCR-08-010
   - id: PCR-08-010
     priority: MUST_NOT
     kind: domain
     statement: >-
       A received-side use case MUST NOT construct or emit an ActivityStreams activity with
-      `actor` set to a different actor's ID (identity spoofing). It MUST NOT execute a
-      Behavior Tree with `actor_id` set to any actor other than the one whose DataLayer
-      is active for that use case invocation.
+      `actor` set to a different actor's ID (identity spoofing).
     relationships:
     - rel_type: refines
       spec_id: PCR-08-001
+  - id: PCR-08-015
+    priority: MUST_NOT
+    kind: domain
+    statement: >-
+      A received-side use case MUST NOT execute a Behavior Tree with `actor_id` set to
+      any actor other than the one whose DataLayer is active for that use case invocation.
+    relationships:
+    - rel_type: refines
+      spec_id: PCR-08-010
   - id: PCR-08-011
     priority: MUST
     kind: domain
     statement: >-
       An emit node in a case-scoped trigger BT MUST resolve the CaseActor
-      recipient before enqueueing and MUST fail fast (return FAILURE or raise
-      immediately) when no routable CaseActor can be found. The node MUST NOT
-      silently enqueue an activity with a `None` or empty `to` field.
+      recipient before enqueueing the activity.
     rationale: >-
       When case-scoped trigger routing was changed from `case_addressees()` to
       CaseActor-only routing, emit nodes that returned without setting `to`
@@ -314,6 +339,24 @@ groups:
       spec_id: PCR-08-002
       note: Using case_addressees() or None as the recipient in a trigger BT is
         the specific violation this requirement prevents
+  - id: PCR-08-016
+    priority: MUST
+    kind: domain
+    statement: >-
+      An emit node in a case-scoped trigger BT MUST fail fast (return FAILURE or raise
+      immediately) when no routable CaseActor can be found.
+    relationships:
+    - rel_type: refines
+      spec_id: PCR-08-011
+  - id: PCR-08-017
+    priority: MUST_NOT
+    kind: domain
+    statement: >-
+      An emit node in a case-scoped trigger BT MUST NOT silently enqueue an activity
+      with a `None` or empty `to` field.
+    relationships:
+    - rel_type: refines
+      spec_id: PCR-08-011
   - id: PCR-08-012
     priority: MUST
     kind: domain
@@ -382,15 +425,21 @@ groups:
     priority: MUST
     kind: domain
     statement: >-
-      Integration tests MUST verify that `RmInviteToCaseActivity` carries `actor` set to the
-      Case Actor's ID, and that the invitee's `RmAcceptInviteToCaseActivity` is processed
-      by the Case Actor (not the case owner). Tests MUST assert that no RM state-change
-      activity is emitted with `actor` set to the invitee's ID from the case owner's context.
+      Integration tests MUST verify that `RmInviteToCaseActivity` carries `actor` set to
+      the Case Actor's ID, and that the invitee's `RmAcceptInviteToCaseActivity` is
+      processed by the Case Actor (not the case owner).
     relationships:
     - rel_type: verifies
       spec_id: PCR-08-007
     - rel_type: verifies
       spec_id: PCR-08-008
+  - id: PCR-07-009
+    priority: MUST
+    kind: domain
+    statement: >-
+      Integration tests MUST assert that no RM state-change activity is emitted with
+      `actor` set to the invitee's ID from the case owner's context.
+    relationships:
     - rel_type: verifies
       spec_id: PCR-08-009
     - rel_type: verifies

--- a/specs/spec-registry.yaml
+++ b/specs/spec-registry.yaml
@@ -18,7 +18,9 @@ groups:
   - id: SR-01-001
     priority: MUST
     kind: implementation
-    statement: Each `specs/*.md` file MUST be replaced by a `specs/*.yaml` file with the same kebab-case topic name.
+    statement: >-
+      Specifications MUST be maintained as YAML files in `specs/` following the topic-file naming
+      convention. Markdown spec files are not permitted.
   - id: SR-01-002
     priority: MUST
     kind: implementation
@@ -350,7 +352,9 @@ groups:
   - id: SR-08-003
     priority: MUST
     kind: implementation
-    statement: After migration, the `specs/*.md` files MUST be deleted; the YAML files are the sole source of truth.
+    statement: >-
+      YAML files in `specs/` are the sole authoritative source for project specifications. No other
+      format or location holds normative spec content.
   - id: SR-08-004
     priority: MUST
     kind: implementation

--- a/specs/spec-registry.yaml
+++ b/specs/spec-registry.yaml
@@ -377,3 +377,58 @@ groups:
     kind: implementation
     statement: A migration script SHOULD be provided to convert a single `specs/*.md` file to the YAML format as a starting
       point; manual review and cleanup is expected.
+- id: SR-10
+  title: Spec Statement Semantics
+  specs:
+  - id: SR-10-001
+    priority: MUST
+    kind: dev-process
+    statement: >-
+      A spec statement MUST describe an invariant property of the finished system — what it
+      must always be true, always do, or never do. It MUST NOT describe a migration step,
+      a one-time task, or a before/after transition.
+    rationale: >-
+      Specs are transferable knowledge for any implementer. A statement like "X must be
+      replaced by Y" is meaningless once the replacement is done, and misleading before it
+      is. The correct home for migration tasks is an issue tracker. If a migration produces
+      a lasting architectural rule, that rule — not the migration instruction — belongs in
+      the spec.
+    tags:
+    - documentation
+  - id: SR-10-002
+    priority: MUST
+    kind: dev-process
+    statement: >-
+      A spec statement MUST be written in the present tense and describe the system as it
+      must perpetually be. Phrases that signal migration-task framing — "must be replaced
+      by", "must be removed", "must be updated to", "once X is done", "after migration" —
+      MUST NOT appear in a spec statement unless they refer to a runtime state transition
+      (e.g. a state machine trigger), not a code change.
+    rationale: >-
+      Temporal or conditional framing ("once X holds, Y must go away") creates specs whose
+      satisfaction is permanent after a single event. Such specs cannot be re-tested on
+      subsequent builds and do not communicate ongoing constraints to future maintainers
+      or implementers.
+    tags:
+    - documentation
+    relationships:
+    - rel_type: refines
+      spec_id: SR-10-001
+  - id: SR-10-003
+    priority: SHOULD
+    kind: dev-process
+    statement: >-
+      When a spec's statement has become vacuously satisfied (the migration it described is
+      complete and no ongoing constraint survives), the spec SHOULD be deleted. When a
+      residual constraint does survive, the statement SHOULD be rewritten to express only
+      that constraint, dropping all migration-task language.
+    rationale: >-
+      A vacuously satisfied spec creates false confidence: it always passes any check, so
+      it neither constrains nor informs. A partially-stale spec that mixes a completed
+      migration instruction with a surviving rule misleads readers about which clause is
+      still normative. Deletion or rewrite keeps the registry honest.
+    tags:
+    - documentation
+    relationships:
+    - rel_type: refines
+      spec_id: SR-10-001

--- a/specs/spec-registry.yaml
+++ b/specs/spec-registry.yaml
@@ -4,7 +4,7 @@ description: >-
   Requirements for the structured spec registry: YAML spec files governed by Pydantic models,
   with linting, pytest integration, and context-generation tooling. The registry provides a
   single source of truth for spec IDs, prefixes, titles, and cross-reference validation.
-version: 1.0.0
+version: 1.1.0
 scope:
 - prototype
 - production
@@ -212,9 +212,23 @@ groups:
   - id: SR-04-003
     priority: MUST
     kind: implementation
-    statement: The linter MUST be invokable as a CLI command via the `spec-lint` console entry point (`uv run spec-lint`)
-      and via `python -m vultron.metadata.specs.lint [spec_dir]`. Both invocations MUST produce identical output. When `spec_dir`
-      is omitted from the module invocation, it defaults to `specs/` relative to the current working directory.
+    statement: The linter MUST be invokable both as `uv run spec-lint` (console entry point) and as
+      `python -m vultron.metadata.specs.lint [spec_dir]` (module invocation).
+  - id: SR-04-009
+    priority: MUST
+    kind: implementation
+    statement: Both invocation forms of the spec linter MUST produce identical output for the same input.
+    relationships:
+    - rel_type: refines
+      spec_id: SR-04-003
+  - id: SR-04-010
+    priority: MUST
+    kind: implementation
+    statement: When `spec_dir` is omitted from the module invocation, the linter MUST default to
+      `specs/` relative to the current working directory.
+    relationships:
+    - rel_type: refines
+      spec_id: SR-04-003
   - id: SR-04-004
     priority: MUST
     kind: implementation
@@ -345,10 +359,6 @@ groups:
     kind: implementation
     statement: All existing `specs/*.md` files MUST be migrated to `specs/*.yaml` using a lossless conversion that preserves
       all requirement text, IDs, and relationships.
-  - id: SR-08-002
-    priority: MUST
-    kind: implementation
-    statement: The migration MUST produce YAML files that pass the spec linter with zero errors.
   - id: SR-08-003
     priority: MUST
     kind: implementation
@@ -370,8 +380,16 @@ groups:
   - id: SR-08-006
     priority: MUST_NOT
     kind: implementation
-    statement: The original `specs/*.md` requirement files MUST NOT be deleted until the YAML files have passed the spec linter
-      with zero errors and all agent/skill references have been updated to YAML paths.
+    statement: The original `specs/*.md` requirement files MUST NOT be deleted until the YAML files
+      have passed the spec linter with zero errors.
+  - id: SR-08-008
+    priority: MUST_NOT
+    kind: implementation
+    statement: The original `specs/*.md` requirement files MUST NOT be deleted until all agent and
+      skill references have been updated to use `specs/*.yaml` paths.
+    relationships:
+    - rel_type: refines
+      spec_id: SR-08-005
   - id: SR-08-007
     priority: SHOULD
     kind: implementation
@@ -400,10 +418,7 @@ groups:
     kind: dev-process
     statement: >-
       A spec statement MUST be written in the present tense and describe the system as it
-      must perpetually be. Phrases that signal migration-task framing — "must be replaced
-      by", "must be removed", "must be updated to", "once X is done", "after migration" —
-      MUST NOT appear in a spec statement unless they refer to a runtime state transition
-      (e.g. a state machine trigger), not a code change.
+      must perpetually be.
     rationale: >-
       Temporal or conditional framing ("once X holds, Y must go away") creates specs whose
       satisfaction is permanent after a single event. Such specs cannot be re-tested on
@@ -414,6 +429,19 @@ groups:
     relationships:
     - rel_type: refines
       spec_id: SR-10-001
+  - id: SR-10-004
+    priority: MUST_NOT
+    kind: dev-process
+    statement: >-
+      Phrases that signal migration-task framing — "must be replaced by", "must be removed",
+      "must be updated to", "once X is done", "after migration" — MUST NOT appear in a spec
+      statement unless they refer to a runtime state transition (e.g. a state machine trigger),
+      not a code change.
+    tags:
+    - documentation
+    relationships:
+    - rel_type: refines
+      spec_id: SR-10-002
   - id: SR-10-003
     priority: SHOULD
     kind: dev-process

--- a/specs/state-machine.yaml
+++ b/specs/state-machine.yaml
@@ -145,9 +145,8 @@ groups:
     priority: MUST
     kind: domain
     statement: >-
-      Transient RM status for reports (e.g., `ReportStatus` in the in-memory `STATUS` dict)
-      MUST be replaced by persisted participant-level state once a report is associated with
-      a case and a `CaseParticipant` record exists
+      RM state for reports MUST be persisted as participant-level state in `CaseParticipant`
+      records. In-memory transient RM state is not permitted.
 - id: SM-07
   title: State Subsets and Guards
   specs:


### PR DESCRIPTION
## Summary

Removes migration-task framing from spec items across 13 spec files. The PR
does two complementary things: (1) fixes delta-framed or stale spec content
(4 deletions, 9 rewrites), and (2) splits dense multi-claim spec statements
into single-claim items across seven spec files (BW, HM, PAD, PCR, SR, BTND,
CLP/MS). Also adds a new **SR-10 — Spec Statement Semantics** group that
codifies the "steady-state, present-tense requirements only" rule.

## Changes

- **`specs/activity-factories.yaml`**: Delete AF-07-001/AF-07-002 — the
  `OfferRef`/`RmInviteToCaseRef` TypeAliases they required to be removed
  are already gone from the codebase
- **`specs/architecture.yaml`**: ARCH-15-004 — correct canonical helper
  path from `use_cases/_helpers.py` to `core/models/_helpers.py`
- **`specs/behavior-tree-node-design.yaml`** (v1.1.0): Rewrite BTND-05-002
  (was a dangling colon with no body) and BTND-05-003 to present-tense
  design rules; split BTND-03-005, BTND-07-001 into single-claim items
  (BTND-03-008, BTND-04-004, BTND-07-006, BTND-07-007)
- **`specs/build-workflow.yaml`** (v2.1.0): Split BW-01-004, BW-02-002,
  BW-04-001, HM-03-001 into single-claim items; new IDs BW-01-005 through
  BW-01-007, BW-02-003, BW-04-003
- **`specs/case-ledger-processing.yaml`** (v1.1.0): Split CLP-10-005 into
  CLP-10-005 + CLP-10-007 + CLP-10-008 (single-claim items)
- **`specs/datalayer.yaml`**: Rewrite DL-05-003 to present-tense (remove
  "once DL-05-001 holds" conditional framing)
- **`specs/history-management.yaml`** (v1.3.0): Delete HM-01-004
  (monolithic file migration — already done); delete HM-06-003 (legacy
  `date` field normalization — `date` field was never added); rewrite
  HM-06-002 to require `timestamp` directly; split 10+ dense items into
  single-claim specs (HM-01-006, HM-02-005, HM-03-009/010, HM-06-007-009,
  HM-07-005-007)
- **`specs/meta-specifications.yaml`** (v1.1.0): Split MS-04-003 into
  MS-04-003 + MS-04-005 (stable IDs vs. superseded-must-be-deleted)
- **`specs/multi-actor-demo.yaml`**: Rewrite DEMOMA-08-002 to drop
  implementation-status paragraph; keep pure design rule
- **`specs/parallel-development.yaml`** (v1.1.0): Split PAD-01-002,
  PAD-02-004, PAD-02-007, PAD-02-009, PAD-07-001, PAD-07-003, PAD-08-001
  into single-claim items; new IDs PAD-01-005/006, PAD-02-011-013,
  PAD-07-005/006, PAD-08-004
- **`specs/participant-case-replica.yaml`** (v1.1.0): Split PCR-08-004,
  PCR-08-009, PCR-08-010, PCR-08-011 into single-claim items; new IDs
  PCR-08-013-017; split PCR-07-008 into PCR-07-008/009
- **`specs/spec-registry.yaml`** (v1.1.0): Rewrite SR-01-001 and SR-08-003
  to present-tense; delete SR-08-002 (migration-linter-must-pass); split
  SR-04-003 into SR-04-003 + SR-04-009 + SR-04-010; split SR-08-006 into
  SR-08-006 + SR-08-008; add new **SR-10** group (4 specs: SR-10-001
  through SR-10-004) codifying present-tense/steady-state spec writing rules
- **`specs/state-machine.yaml`**: Rewrite SM-06-002 to drop "must be
  replaced" framing → "RM state MUST be persisted in CaseParticipant"

## Verification

- [x] `PYTHONPATH= uv run spec-lint` passes with zero errors (only
  pre-existing advisory warnings, none new)
- [x] `PYTHONPATH= uv run spec-dump` produces 2078 unique spec IDs, no
  duplicates
- [x] Pre-commit hooks pass (flake8, spec registry linter)
- [x] CI: CodeQL, Analyze (actions), Analyze (python) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)