### PR TITLE
docs: plan issue #810 — route two-actor demo case-actor to dedicated container

### DIFF
--- a/notes/case-proposal.md
+++ b/notes/case-proposal.md
@@ -195,7 +195,7 @@ corresponding `MessageSemantics` value.
 
 Before dynamic case-actor spawning (#812) is implemented, the two-actor demo
 needs a way to route case-actor creation to the dedicated case-actor container
-rather than creating the actor locally in the vendor container (DEMAMA-01-001).
+rather than creating the actor locally in the vendor container (DEMOMA-01-001).
 
 `DemoCreateCaseActorNode` is an **Actuator** call-out point (ADR-0024, § Actuator
 shape): it receives a trigger (case initialization) and causes the side effect of

--- a/notes/case-proposal.md
+++ b/notes/case-proposal.md
@@ -189,6 +189,46 @@ corresponding `MessageSemantics` value.
 
 ---
 
+## Demo Layer: `DemoCreateCaseActorNode` (Actuator stub for spawning)
+
+**Source**: 2026-07-21 planning session, issue #810.
+
+Before dynamic case-actor spawning (#812) is implemented, the two-actor demo
+needs a way to route case-actor creation to the dedicated case-actor container
+rather than creating the actor locally in the vendor container (DEMAMA-01-001).
+
+`DemoCreateCaseActorNode` is an **Actuator** call-out point (ADR-0024, § Actuator
+shape): it receives a trigger (case initialization) and causes the side effect of
+registering the pre-configured case-actor service in the vendor's DataLayer, then
+returns SUCCESS or FAILURE. It does not produce a content artifact.
+
+### What it does
+
+1. Reads the pre-configured case-actor URL from the environment
+   (`VULTRON_CASE_ACTOR_ID`, e.g.
+   `http://case-actor:7999/api/v2/actors/case-actor`) or from config.
+2. Writes that URL to the BT blackboard as `case_actor_id` — simulating what
+   the dynamic spawning protocol (#812) will eventually provide at runtime.
+3. Delegates to the standard `CreateCaseActorNode` registration sequence
+   (`CreateCaseActorServiceNode` + `RegisterCaseActorParticipantNode`) using the
+   pre-set `case_actor_id`.
+
+### Location
+
+`DemoCreateCaseActorNode` lives in `vultron/demo/` (demo layer), not in
+`vultron/core/`. The two-actor demo wires it in place of the core
+`CreateCaseActorNode` via the demo-level case-creation BT. Core
+`CreateCaseActorNode` is unchanged.
+
+### Temporary nature
+
+This node is a demo artifact. Issue #812 (dynamic spawning) will replace it with
+real spawning logic; at that point `DemoCreateCaseActorNode` can be removed and
+the core `CreateCaseActorNode` will receive the spawned URL via the spawning
+protocol's response.
+
+---
+
 ## Open Questions
 
 None — all design decisions were resolved in the planning session.

--- a/plan/history/2607/idea/IDEA-810.md
+++ b/plan/history/2607/idea/IDEA-810.md
@@ -1,0 +1,40 @@
+---
+source: IDEA-810
+timestamp: '2026-07-21T20:25:57.383082+00:00'
+title: Route two-actor demo case-actor creation to dedicated container
+type: idea
+---
+
+## Outcome
+
+Planned. Docs updated and impl issue created.
+
+## What Was Decided
+
+- `DemoCreateCaseActorNode` is an **ADR-0024 Actuator-shape** stub that reads
+  the pre-configured case-actor URL (e.g. `VULTRON_CASE_ACTOR_ID`), writes it
+  to the BT blackboard as `case_actor_id`, and delegates to the standard
+  `CreateCaseActorNode` registration sequence. Lives in `vultron/demo/` (demo
+  layer); core is unchanged.
+- `DEMOMA-06-004` updated to require a dedicated case-actor container with its
+  own isolated DataLayer (replacing the prior co-location requirement).
+- `DEMOMA-06-005` added: demo must verify the case-actor container holds the
+  canonical ledger after the demo completes.
+- Root problem: `ResolveCaseActorUrlsNode` always derives `case_actor_id` from
+  the vendor's own `server_base_url`, so it cannot route to a separate
+  container. AC-3 explicitly requires bypassing this node in the demo tree.
+- AC-7 added (not in original issue): two-actor seeding must register the
+  case-actor container as a peer actor on both Finder and Vendor containers
+  before the BT runs.
+- Static case-actor URL is a **demo artifact only** — the production end-state
+  is dynamic spawning (#812) where the URL is resolved at runtime.
+
+## Docs PR
+
+<https://github.com/CERTCC/Vultron/pull/1571>
+
+## Implementation Issue
+
+# 1572 — feat(demo): route two-actor demo case-actor creation to dedicated container
+
+(blocked-by #810, child of epic #1092, size:M, 7 ACs)

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -223,7 +223,7 @@ groups:
       using the pre-configured case-actor service URL, not create the case-actor record
       locally in the vendor container's DataLayer
     rationale: >-
-      Routing case-actor creation to its own container satisfies DEMAMA-01-001 (each actor
+      Routing case-actor creation to its own container satisfies DEMOMA-01-001 (each actor
       in its own container) and exercises the CaseProposal protocol (ADR-0023) in the
       two-actor scenario. The demo uses DemoCreateCaseActorNode as an Actuator-shape
       ADR-0024 stub: it reads the pre-configured case-actor URL and writes it to the BT

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -218,9 +218,32 @@ groups:
     priority: MUST
     kind: implementation
     statement: >-
-      The two-actor demo Docker topology MUST use exactly two containers (finder and vendor);
-      the Case Actor MUST be an actor record co-located in the vendor container with its own
-      actor ID and inbox URL, not a separate container
+      The two-actor demo Docker topology MUST use a dedicated case-actor container with its
+      own isolated DataLayer; the Vendor MUST route case-actor creation to that container
+      using the pre-configured case-actor service URL, not create the case-actor record
+      locally in the vendor container's DataLayer
+    rationale: >-
+      Routing case-actor creation to its own container satisfies DEMAMA-01-001 (each actor
+      in its own container) and exercises the CaseProposal protocol (ADR-0023) in the
+      two-actor scenario. The demo uses DemoCreateCaseActorNode as an Actuator-shape
+      ADR-0024 stub: it reads the pre-configured case-actor URL and writes it to the BT
+      blackboard as case_actor_id, then delegates to the standard registration sequence.
+      This is a temporary demo artifact; issue #812 will replace it with real dynamic
+      spawning.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-01-001
+  - id: DEMOMA-06-005
+    priority: MUST
+    kind: implementation
+    statement: >-
+      The two-actor demo MUST verify that the case-actor container's DataLayer holds the
+      canonical case ledger after the demo completes; the demo script MUST dump the
+      case-actor's ledger from the dedicated case-actor container, not from the vendor
+      container's co-located sub-actor
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-06-004
 - id: DEMOMA-07
   title: ParticipantStatus Trigger Pattern
   specs:


### PR DESCRIPTION
- Closes #810

## Summary

Updates the two-actor demo spec and design notes to route case-actor creation
to a dedicated case-actor container rather than co-locating it in the vendor
container's DataLayer.

## Changes

- **`specs/multi-actor-demo.yaml`**: Updates `DEMOMA-06-004` to require a
  dedicated case-actor container with its own isolated DataLayer (replacing the
  prior co-location requirement), adds `DEMOMA-06-005` requiring the demo to
  verify the case-actor container holds the canonical ledger, and adds a
  `rationale` block referencing the `DemoCreateCaseActorNode` stub design and
  ADR-0024.
- **`notes/case-proposal.md`**: Adds design note for `DemoCreateCaseActorNode`
  — an ADR-0024 Actuator-shape stub that reads the pre-configured case-actor
  URL, writes it to the BT blackboard as `case_actor_id`, and delegates to the
  standard `CreateCaseActorNode` registration sequence. Describes its temporary
  nature pending dynamic spawning (#812).
- **`plan/history/2607/idea/IDEA-810.md`**: History entry for the planning
  session; records the key decisions and links to implementation issue #1572.