### PR TITLE
feat(#1563): decompose CaseStatus/ParticipantStatus into per-machine dimension objects

### DIFF
--- a/docs/adr/0036-status-dimension-objects.md
+++ b/docs/adr/0036-status-dimension-objects.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-07-21
 deciders: Allen D. Householder
 consulted: Claude Code (design session)

--- a/plan/history/2607/implementation/ISSUE-1563.md
+++ b/plan/history/2607/implementation/ISSUE-1563.md
@@ -1,0 +1,12 @@
+---
+source: ISSUE-1563
+timestamp: '2026-07-21T20:29:27.104868+00:00'
+title: Decompose CaseStatus/ParticipantStatus into per-machine dimension objects
+type: implementation
+---
+
+## Issue #1563 — Decompose CaseStatus/ParticipantStatus into per-machine dimension objects
+
+Introduced five dimension classes (EmDimension, PxaDimension, RmDimension, VfdDimension, PecDimension) in vultron/core/models/dimensions.py. Replaced flat enum fields on core CaseStatus and ParticipantStatus with typed dimension objects. Wire-layer models retain flat fields; bidirectional migration validators ensure JSON compatibility. Updated 35+ test files and all BT behavior nodes that access state-machine fields.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1573>

--- a/test/adapters/driving/fastapi/routers/test_trigger_accept_embargo.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_accept_embargo.py
@@ -192,7 +192,7 @@ def test_trigger_accept_embargo_activates_embargo(
     assert resp.status_code == status.HTTP_202_ACCEPTED
 
     updated_case = dl.read(case_obj.id_)
-    assert updated_case.current_status.em_state == EM.ACTIVE
+    assert updated_case.current_status.em.state == EM.ACTIVE
     assert updated_case.active_embargo is not None
 
 
@@ -209,7 +209,7 @@ def test_trigger_accept_embargo_without_proposal_id_uses_first_proposal(
     assert resp.status_code == status.HTTP_202_ACCEPTED
 
     updated_case = dl.read(case_obj.id_)
-    assert updated_case.current_status.em_state == EM.ACTIVE
+    assert updated_case.current_status.em.state == EM.ACTIVE
 
 
 def test_accept_embargo_schedules_outbox_handler(

--- a/test/adapters/driving/fastapi/routers/test_trigger_case.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_case.py
@@ -275,7 +275,7 @@ def test_trigger_engage_case_updates_participant_rm_state(
         )
         if p_actor_id == actor.id_ and p_obj.participant_statuses:
             latest = p_obj.participant_statuses[-1]
-            if latest.rm_state == RM.ACCEPTED:
+            if latest.rm.state == RM.ACCEPTED:
                 found_accepted = True
                 break
     assert found_accepted, "Participant RM state was not updated to ACCEPTED"
@@ -428,7 +428,7 @@ def test_trigger_defer_case_updates_participant_rm_state(
         )
         if p_actor_id == actor.id_ and p_obj.participant_statuses:
             latest = p_obj.participant_statuses[-1]
-            if latest.rm_state == RM.DEFERRED:
+            if latest.rm.state == RM.DEFERRED:
                 found_deferred = True
                 break
     assert found_deferred, "Participant RM state was not updated to DEFERRED"

--- a/test/adapters/driving/fastapi/routers/test_trigger_propose_embargo.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_propose_embargo.py
@@ -226,7 +226,7 @@ def test_trigger_propose_embargo_updates_em_state_to_proposed(
     assert resp.status_code == status.HTTP_202_ACCEPTED
 
     updated_case = dl.read(case_without_participant.id_)
-    assert updated_case.current_status.em_state == EM.PROPOSED
+    assert updated_case.current_status.em.state == EM.PROPOSED
 
 
 def test_trigger_propose_embargo_from_active_updates_em_state_to_revise(
@@ -242,7 +242,7 @@ def test_trigger_propose_embargo_from_active_updates_em_state_to_revise(
     assert resp.status_code == status.HTTP_202_ACCEPTED
 
     updated_case = dl.read(case_obj.id_)
-    assert updated_case.current_status.em_state == EM.REVISE
+    assert updated_case.current_status.em.state == EM.REVISE
 
 
 def test_trigger_propose_embargo_exited_returns_409(
@@ -250,7 +250,7 @@ def test_trigger_propose_embargo_exited_returns_409(
 ):
     """propose-embargo returns HTTP 409 when EM state is EXITED."""
     case_obj = dl.read(case_without_participant.id_)
-    case_obj.current_status.em_state = EM.EXITED
+    case_obj.current_status.em.state = EM.EXITED
     dl.update(case_obj.id_, object_to_record(case_obj))
 
     resp = client_triggers.post(

--- a/test/adapters/driving/fastapi/routers/test_trigger_propose_embargo_revision.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_propose_embargo_revision.py
@@ -156,7 +156,7 @@ def test_trigger_propose_embargo_revision_sets_em_state_to_revise(
     assert resp.status_code == status.HTTP_202_ACCEPTED
 
     updated_case = dl.read(case_obj.id_)
-    assert updated_case.current_status.em_state == EM.REVISE
+    assert updated_case.current_status.em.state == EM.REVISE
 
 
 def test_trigger_propose_embargo_revision_adds_activity_to_outbox(

--- a/test/adapters/driving/fastapi/routers/test_trigger_reject_embargo.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_reject_embargo.py
@@ -131,7 +131,7 @@ def test_trigger_reject_embargo_sets_em_state_to_no_embargo(
     assert resp.status_code == status.HTTP_202_ACCEPTED
 
     updated_case = dl.read(case_obj.id_)
-    assert updated_case.current_status.em_state == EM.NO_EMBARGO
+    assert updated_case.current_status.em.state == EM.NO_EMBARGO
 
 
 def test_trigger_reject_embargo_adds_activity_to_outbox(

--- a/test/adapters/driving/fastapi/routers/test_trigger_report.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_report.py
@@ -27,6 +27,7 @@ from fastapi import FastAPI, status
 from fastapi.testclient import TestClient
 
 from vultron.core.models.participant_status import ParticipantStatus
+from vultron.core.models.dimensions import RmDimension
 from vultron.core.models._helpers import _report_phase_status_id
 from vultron.adapters.driving.fastapi.deps import (
     get_canonical_actor_dl,
@@ -188,7 +189,7 @@ def closed_report(dl, report, actor):
         id_=_report_phase_status_id(actor.id_, report.id_, RM.CLOSED.value),
         context=report.id_,
         attributed_to=actor.id_,
-        rm_state=RM.CLOSED,
+        rm=RmDimension(state=RM.CLOSED),
     )
     dl.create(status)
     return report

--- a/test/adapters/driving/fastapi/routers/test_trigger_terminate_embargo.py
+++ b/test/adapters/driving/fastapi/routers/test_trigger_terminate_embargo.py
@@ -163,7 +163,7 @@ def test_trigger_terminate_embargo_updates_em_state_to_exited(
     assert resp.status_code == status.HTTP_202_ACCEPTED
 
     updated_case = dl.read(case_obj.id_)
-    assert updated_case.current_status.em_state == EM.EXITED
+    assert updated_case.current_status.em.state == EM.EXITED
 
 
 def test_trigger_terminate_embargo_clears_active_embargo(
@@ -193,7 +193,7 @@ def test_trigger_terminate_embargo_invalid_em_state_returns_409(
     """
     case_obj, _ = case_with_embargo
     stored = dl.read(case_obj.id_)
-    stored.current_status.em_state = EM.PROPOSED
+    stored.current_status.em.state = EM.PROPOSED
     dl.update(stored.id_, object_to_record(stored))
 
     resp = client_triggers.post(

--- a/test/core/behaviors/case/conftest.py
+++ b/test/core/behaviors/case/conftest.py
@@ -20,6 +20,7 @@ from vultron.wire.as2.vocab.objects.vulnerability_case import (  # noqa: F401
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.core.behaviors.bridge import BTBridge
+from vultron.core.models.dimensions import RmDimension
 from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models.vultron_types import VultronCaseActor
 from vultron.core.states.rm import RM
@@ -88,7 +89,7 @@ def reporter_accepted_status(datalayer, reporter_actor_id, report):
         ),
         context=report.id_,
         attributed_to=reporter_actor_id,
-        rm_state=RM.ACCEPTED,
+        rm=RmDimension(state=RM.ACCEPTED),
     )
     datalayer.create(status)
     return status
@@ -105,7 +106,7 @@ def vendor_received_status(datalayer, actor_id, report):
         id_=_report_phase_status_id(actor_id, report.id_, RM.RECEIVED.value),
         context=report.id_,
         attributed_to=actor_id,
-        rm_state=RM.RECEIVED,
+        rm=RmDimension(state=RM.RECEIVED),
     )
     datalayer.create(status)
     return status

--- a/test/core/behaviors/case/nodes/participant/test_owner.py
+++ b/test/core/behaviors/case/nodes/participant/test_owner.py
@@ -219,6 +219,6 @@ class TestCreateCaseOwnerParticipant:
         participant_id = stored_case.actor_participant_index[actor_id]
         participant = cast(Any, bt_scenario.dl.read(participant_id))
         rm_states = [
-            status.rm_state for status in participant.participant_statuses
+            status.rm.state for status in participant.participant_statuses
         ]
         assert RM.ACCEPTED in rm_states

--- a/test/core/behaviors/case/nodes/participant/test_participant_add.py
+++ b/test/core/behaviors/case/nodes/participant/test_participant_add.py
@@ -35,6 +35,7 @@ from vultron.core.behaviors.case.nodes.participant import (
     SeedParticipantAsSignatoryNode,
 )
 from vultron.core.models.embargo_event import EmbargoEvent
+from vultron.core.models.dimensions import PecDimension, RmDimension
 from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models.vultron_types import (
     VultronCase,
@@ -200,8 +201,8 @@ class TestCreateCaseParticipantNode:
             id_=status_id,
             context=report_id,
             attributed_to=actor_id,
-            rm_state=RM.ACCEPTED,
-            em_consent_state=PEC.SIGNATORY,
+            rm=RmDimension(state=RM.ACCEPTED),
+            consent=PecDimension(state=PEC.SIGNATORY),
             cvd_role=[CVDRole.FINDER],
         )
         bt_scenario.dl.create(existing)
@@ -218,7 +219,9 @@ class TestCreateCaseParticipantNode:
 
         refreshed = cast(Any, bt_scenario.dl.read(status_id))
         assert refreshed is not None
-        assert refreshed.em_consent_state == PEC.SIGNATORY
+        assert (
+            refreshed.consent.state if refreshed.consent else None
+        ) == PEC.SIGNATORY
 
     def test_backfills_context_to_case_uri_for_existing_status(
         self,
@@ -241,8 +244,8 @@ class TestCreateCaseParticipantNode:
             id_=status_id,
             context=report.id_,
             attributed_to=actor_id,
-            rm_state=RM.ACCEPTED,
-            em_consent_state=PEC.NO_EMBARGO,
+            rm=RmDimension(state=RM.ACCEPTED),
+            consent=PecDimension(state=PEC.NO_EMBARGO),
             cvd_role=[CVDRole.FINDER],
         )
         bt_scenario.dl.create(stale)

--- a/test/core/behaviors/case/nodes/test_embargo.py
+++ b/test/core/behaviors/case/nodes/test_embargo.py
@@ -127,7 +127,7 @@ class TestInitializeDefaultEmbargoNode:
         )
 
         stored_case = cast(Any, bt_scenario.dl.read(case_obj.id_))
-        assert stored_case.current_status.em_state == EM.ACTIVE
+        assert stored_case.current_status.em.state == EM.ACTIVE
 
     def test_fails_without_case_id(
         self,

--- a/test/core/behaviors/case/test_bug_26040902_regression.py
+++ b/test/core/behaviors/case/test_bug_26040902_regression.py
@@ -91,6 +91,7 @@ def test_receive_report_case_bt_succeeds_without_conftest_imports(
         VultronReport,
     )
     from vultron.core.states.rm import RM
+    from vultron.core.models.dimensions import RmDimension
     from vultron.core.models._helpers import _report_phase_status_id
     from vultron.wire.as2.vocab.base.registry import VOCABULARY
 
@@ -136,7 +137,7 @@ def test_receive_report_case_bt_succeeds_without_conftest_imports(
         ),
         context=_report_id,
         attributed_to=_reporter_actor_id,
-        rm_state=RM.ACCEPTED,
+        rm=RmDimension(state=RM.ACCEPTED),
     )
     dl.create(reporter_status)
 
@@ -144,7 +145,7 @@ def test_receive_report_case_bt_succeeds_without_conftest_imports(
         id_=_report_phase_status_id(_actor_id, _report_id, RM.RECEIVED.value),
         context=_report_id,
         attributed_to=_actor_id,
-        rm_state=RM.RECEIVED,
+        rm=RmDimension(state=RM.RECEIVED),
     )
     dl.create(vendor_status)
 

--- a/test/core/behaviors/case/test_create_tree.py
+++ b/test/core/behaviors/case/test_create_tree.py
@@ -356,7 +356,9 @@ def test_create_case_tree_vendor_participant_seeded_with_rm_valid(
             continue
         statuses = participant.participant_statuses
         assert statuses, "Participant has no status history"
-        latest_rm = getattr(statuses[-1], "rm_state", None)
+        latest_rm = (
+            statuses[-1].rm.state if hasattr(statuses[-1], "rm") else None
+        )
         assert (
             latest_rm == RM.VALID
         ), f"Expected initial rm_state=RM.VALID, got {latest_rm}"

--- a/test/core/behaviors/case/test_receive_report_case_tree.py
+++ b/test/core/behaviors/case/test_receive_report_case_tree.py
@@ -45,6 +45,7 @@ from vultron.core.behaviors.case.nodes import (
 from vultron.core.behaviors.case.receive_report_case_tree import (
     create_receive_report_case_tree,
 )
+from vultron.core.models.dimensions import RmDimension
 from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models.vultron_types import VultronCaseActor
 from vultron.core.states.em import EM
@@ -536,7 +537,7 @@ class TestParticipantCreation:
             statuses = participant.participant_statuses
             assert statuses, "Case-owner participant has no status history"
             latest = statuses[-1]
-            rm = getattr(latest, "rm_state", None)
+            rm = latest.rm.state if hasattr(latest, "rm") else None
             assert (
                 rm == RM.RECEIVED
             ), f"Expected case-owner rm_state=RM.RECEIVED, got {rm}"
@@ -589,7 +590,7 @@ class TestParticipantCreation:
             statuses = participant.participant_statuses
             assert statuses, "Finder participant has no status history"
             latest = statuses[-1]
-            rm = getattr(latest, "rm_state", None)
+            rm = latest.rm.state if hasattr(latest, "rm") else None
             assert (
                 rm == RM.ACCEPTED
             ), f"Expected reporter rm_state=RM.ACCEPTED, got {rm}"
@@ -684,7 +685,7 @@ class TestParticipantCreation:
                 continue
             statuses = participant.participant_statuses
             assert statuses
-            rm = getattr(statuses[-1], "rm_state", None)
+            rm = statuses[-1].rm.state if hasattr(statuses[-1], "rm") else None
             assert rm == RM.RECEIVED, f"Expected RM.RECEIVED, got {rm}"
             break
 
@@ -751,13 +752,13 @@ class TestEmbargoInitialization:
         case = datalayer.find_case_by_report_id(report.id_)
         assert case is not None
         assert case.active_embargo is not None
-        assert case.current_status.em_state != EM.NONE, (
+        assert case.current_status.em.state != EM.NONE, (
             f"Expected em_state != NONE after embargo init,"
-            f" got {case.current_status.em_state}"
+            f" got {case.current_status.em.state}"
         )
-        assert case.current_status.em_state == EM.ACTIVE, (
+        assert case.current_status.em.state == EM.ACTIVE, (
             f"Expected em_state == ACTIVE after embargo init,"
-            f" got {case.current_status.em_state}"
+            f" got {case.current_status.em.state}"
         )
 
     def test_tree_records_embargo_initialized_event(
@@ -1048,7 +1049,7 @@ class TestConcurrentExecution:
                 ),
                 context=report_id,
                 attributed_to=actor_to_seed,
-                rm_state=rm_val,
+                rm=RmDimension(state=rm_val),
             )
             datalayer.create(status)
 

--- a/test/core/behaviors/embargo/nodes/test_em_state.py
+++ b/test/core/behaviors/embargo/nodes/test_em_state.py
@@ -194,7 +194,7 @@ class TestWriteEmStateNode:
 
         updated_case = dl.read(case.id_)
         assert isinstance(updated_case, VulnerabilityCase)
-        assert updated_case.current_status.em_state == EM.ACTIVE
+        assert updated_case.current_status.em.state == EM.ACTIVE
 
     def test_idempotent_when_already_at_target(self):
         """SUCCESS without saving when em_state already equals em_after."""
@@ -296,4 +296,4 @@ class TestReadWriteEmStateIntegration:
 
         updated_case = dl.read(case.id_)
         assert isinstance(updated_case, VulnerabilityCase)
-        assert updated_case.current_status.em_state == EM.ACTIVE
+        assert updated_case.current_status.em.state == EM.ACTIVE

--- a/test/core/behaviors/embargo/nodes/test_lifecycle.py
+++ b/test/core/behaviors/embargo/nodes/test_lifecycle.py
@@ -31,6 +31,7 @@ from vultron.core.states.em import EM
 from vultron.core.states.participant_embargo_consent import PEC
 from vultron.enums.roles import CVDRole
 from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.core.models.case import VulnerabilityCase
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
     as_VulnerabilityCase,
 )
@@ -106,8 +107,8 @@ class TestTerminateEmbargoBT:
         result = bridge.execute_with_setup(tree, actor_id=ACTOR_ID)
 
         assert result.status == py_trees.common.Status.SUCCESS
-        updated = cast(as_VulnerabilityCase, dl.read(case.id_))
-        assert updated.current_status.em_state == EM.EXITED
+        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        assert updated.current_status.em.state == EM.EXITED
         assert updated.active_embargo is None
         factory.terminate_embargo.assert_called_once()
 
@@ -133,8 +134,8 @@ class TestTerminateEmbargoBT:
         result = bridge.execute_with_setup(tree, actor_id=ACTOR_ID)
 
         assert result.status == py_trees.common.Status.SUCCESS
-        updated = cast(as_VulnerabilityCase, dl.read(case.id_))
-        assert updated.current_status.em_state == EM.EXITED
+        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        assert updated.current_status.em.state == EM.EXITED
 
     def test_missing_case_manager_returns_failure_before_state_change(self):
         """AC-5: Missing CASE_MANAGER → FAILURE; EM state and active_embargo unchanged."""
@@ -162,8 +163,8 @@ class TestTerminateEmbargoBT:
 
         # BT fails at routing guard — no state mutation occurs (BT-19-001).
         assert result.status == py_trees.common.Status.FAILURE
-        updated = cast(as_VulnerabilityCase, dl.read(case.id_))
-        assert updated.current_status.em_state == EM.ACTIVE  # unchanged
+        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        assert updated.current_status.em.state == EM.ACTIVE  # unchanged
         assert updated.active_embargo is not None  # unchanged
         factory.terminate_embargo.assert_not_called()
 
@@ -255,8 +256,8 @@ class TestTerminateEmbargoBT:
         result = bridge.execute_with_setup(tree, actor_id=ACTOR_ID)
 
         assert result.status == py_trees.common.Status.SUCCESS
-        updated = cast(as_VulnerabilityCase, dl.read(case.id_))
-        assert updated.current_status.em_state == EM.EXITED
+        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        assert updated.current_status.em.state == EM.EXITED
         factory.terminate_embargo.assert_called_once()
         outbox = dl.outbox_list_for_actor(ACTOR_ID)
         assert "https://example.org/activities/act1" in outbox
@@ -280,8 +281,8 @@ class TestTerminateEmbargoBT:
         result = bridge.execute_with_setup(tree, actor_id=ACTOR_ID)
 
         assert result.status == py_trees.common.Status.FAILURE
-        updated = cast(as_VulnerabilityCase, dl.read(case.id_))
-        assert updated.current_status.em_state == EM.ACTIVE  # unchanged
+        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        assert updated.current_status.em.state == EM.ACTIVE  # unchanged
         assert updated.active_embargo is not None  # unchanged
         factory.terminate_embargo.assert_not_called()
 

--- a/test/core/behaviors/embargo/nodes/test_teardown.py
+++ b/test/core/behaviors/embargo/nodes/test_teardown.py
@@ -28,6 +28,7 @@ from vultron.core.behaviors.embargo.nodes.teardown import (
 from vultron.core.states.em import EM
 from vultron.core.states.participant_embargo_consent import PEC
 from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
+from vultron.core.models.case import VulnerabilityCase
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
     as_VulnerabilityCase,
 )
@@ -54,8 +55,8 @@ class TestApplyEmbargoTeardownNode:
         bt.tick()
 
         assert node.status == py_trees.common.Status.SUCCESS
-        updated = cast(as_VulnerabilityCase, dl.read(case.id_))
-        assert updated.current_status.em_state == EM.EXITED
+        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        assert updated.current_status.em.state == EM.EXITED
         assert updated.active_embargo is None
 
     def test_transitions_em_revise_to_exited(self):
@@ -71,8 +72,8 @@ class TestApplyEmbargoTeardownNode:
         bt.tick()
 
         assert node.status == py_trees.common.Status.SUCCESS
-        updated = cast(as_VulnerabilityCase, dl.read(case.id_))
-        assert updated.current_status.em_state == EM.EXITED
+        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        assert updated.current_status.em.state == EM.EXITED
 
     def test_idempotent_when_already_exited(self):
         """Node returns SUCCESS without modifying state when already EXITED."""
@@ -88,8 +89,8 @@ class TestApplyEmbargoTeardownNode:
         bt.tick()
 
         assert node.status == py_trees.common.Status.SUCCESS
-        updated = cast(as_VulnerabilityCase, dl.read(case.id_))
-        assert updated.current_status.em_state == EM.EXITED
+        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        assert updated.current_status.em.state == EM.EXITED
 
     def test_state_sync_override_for_unexpected_em_state(self, caplog):
         """Node logs WARNING and applies override for non-standard EM state."""
@@ -107,8 +108,8 @@ class TestApplyEmbargoTeardownNode:
 
         assert node.status == py_trees.common.Status.SUCCESS
         assert any("state-sync override" in r.message for r in caplog.records)
-        updated = cast(as_VulnerabilityCase, dl.read(case.id_))
-        assert updated.current_status.em_state == EM.EXITED
+        updated = cast(VulnerabilityCase, dl.read(case.id_))
+        assert updated.current_status.em.state == EM.EXITED
 
     def test_resets_participant_embargo_consent(self):
         """Node resets participant PEC state to NO_EMBARGO."""

--- a/test/core/behaviors/report/nodes/test_conditions.py
+++ b/test/core/behaviors/report/nodes/test_conditions.py
@@ -27,6 +27,7 @@ from vultron.core.behaviors.report.nodes.conditions import (
 from vultron.core.models.case import VultronCase
 from vultron.core.models.case_actor import VultronCaseActor
 from vultron.core.models.participant import VultronParticipant
+from vultron.core.models.dimensions import RmDimension
 from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models.report import VultronReport
 from vultron.core.states.rm import RM
@@ -44,7 +45,7 @@ def test_check_rm_state_valid_when_valid(
         id_=_report_phase_status_id(actor.id_, report.id_, RM.VALID.value),
         context=report.id_,
         attributed_to=actor.id_,
-        rm_state=RM.VALID,
+        rm=RmDimension(state=RM.VALID),
     )
     bt_scenario.seed(status)
 
@@ -64,7 +65,7 @@ def test_check_rm_state_valid_when_received(
         id_=_report_phase_status_id(actor.id_, report.id_, RM.RECEIVED.value),
         context=report.id_,
         attributed_to=actor.id_,
-        rm_state=RM.RECEIVED,
+        rm=RmDimension(state=RM.RECEIVED),
     )
     bt_scenario.seed(status)
 
@@ -96,7 +97,7 @@ def test_check_rm_state_received_or_invalid_when_received(
         id_=_report_phase_status_id(actor.id_, report.id_, RM.RECEIVED.value),
         context=report.id_,
         attributed_to=actor.id_,
-        rm_state=RM.RECEIVED,
+        rm=RmDimension(state=RM.RECEIVED),
     )
     bt_scenario.seed(status)
 
@@ -117,7 +118,7 @@ def test_check_rm_state_received_or_invalid_when_invalid(
         id_=_report_phase_status_id(actor.id_, report.id_, RM.INVALID.value),
         context=report.id_,
         attributed_to=actor.id_,
-        rm_state=RM.INVALID,
+        rm=RmDimension(state=RM.INVALID),
     )
     bt_scenario.seed(status)
 
@@ -138,7 +139,7 @@ def test_check_rm_state_received_or_invalid_when_valid(
         id_=_report_phase_status_id(actor.id_, report.id_, RM.VALID.value),
         context=report.id_,
         attributed_to=actor.id_,
-        rm_state=RM.VALID,
+        rm=RmDimension(state=RM.VALID),
     )
     bt_scenario.seed(status)
 

--- a/test/core/behaviors/report/nodes/test_participant.py
+++ b/test/core/behaviors/report/nodes/test_participant.py
@@ -25,6 +25,7 @@ from vultron.core.behaviors.report.nodes.participant import (
 from vultron.core.models.case import VultronCase
 from vultron.core.models.case_actor import VultronCaseActor
 from vultron.core.models.participant import VultronParticipant
+from vultron.core.models.dimensions import RmDimension
 from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models.report import VultronReport
 from vultron.core.states.rm import RM
@@ -47,12 +48,12 @@ def case_with_participant(
             ParticipantStatus(
                 attributed_to=actor.id_,
                 context=case_id,
-                rm_state=RM.RECEIVED,
+                rm=RmDimension(state=RM.RECEIVED),
             ),
             ParticipantStatus(
                 attributed_to=actor.id_,
                 context=case_id,
-                rm_state=RM.VALID,
+                rm=RmDimension(state=RM.VALID),
             ),
         ],
     )
@@ -101,7 +102,7 @@ def test_transition_participant_rm_to_accepted(
 
     updated_participant = cast(Any, bt_scenario.dl.read(participant.id_))
     assert updated_participant is not None
-    assert updated_participant.participant_statuses[-1].rm_state == RM.ACCEPTED
+    assert updated_participant.participant_statuses[-1].rm.state == RM.ACCEPTED
 
 
 def test_transition_participant_rm_to_accepted_is_idempotent(
@@ -136,7 +137,7 @@ def test_transition_participant_rm_to_accepted_is_idempotent(
     accepted_entries = [
         status
         for status in updated_participant.participant_statuses
-        if status.rm_state == RM.ACCEPTED
+        if status.rm.state == RM.ACCEPTED
     ]
     assert len(accepted_entries) == 1
 
@@ -174,7 +175,7 @@ def test_transition_participant_rm_to_deferred(
 
     updated_participant = cast(Any, bt_scenario.dl.read(participant.id_))
     assert updated_participant is not None
-    assert updated_participant.participant_statuses[-1].rm_state == RM.DEFERRED
+    assert updated_participant.participant_statuses[-1].rm.state == RM.DEFERRED
 
 
 def test_transition_participant_rm_to_deferred_is_idempotent(
@@ -209,7 +210,7 @@ def test_transition_participant_rm_to_deferred_is_idempotent(
     deferred_entries = [
         status
         for status in updated_participant.participant_statuses
-        if status.rm_state == RM.DEFERRED
+        if status.rm.state == RM.DEFERRED
     ]
     assert len(deferred_entries) == 1
 

--- a/test/core/behaviors/report/test_nodes.py
+++ b/test/core/behaviors/report/test_nodes.py
@@ -49,6 +49,7 @@ from vultron.core.behaviors.report.nodes import (
     TransitionRMtoValid,
     UpdateActorOutbox,
 )
+from vultron.core.models.dimensions import RmDimension
 from vultron.core.states.rm import RM
 from test.core.behaviors.bt_harness import BTTestScenario
 
@@ -106,7 +107,7 @@ def test_check_rm_state_valid_when_valid(
         id_=_report_phase_status_id(actor.id_, report.id_, RM.VALID.value),
         context=report.id_,
         attributed_to=actor.id_,
-        rm_state=RM.VALID,
+        rm=RmDimension(state=RM.VALID),
     )
     bt_scenario.seed(status)
 
@@ -124,7 +125,7 @@ def test_check_rm_state_valid_when_received(
         id_=_report_phase_status_id(actor.id_, report.id_, RM.RECEIVED.value),
         context=report.id_,
         attributed_to=actor.id_,
-        rm_state=RM.RECEIVED,
+        rm=RmDimension(state=RM.RECEIVED),
     )
     bt_scenario.seed(status)
 
@@ -152,7 +153,7 @@ def test_check_rm_state_received_or_invalid_when_received(
         id_=_report_phase_status_id(actor.id_, report.id_, RM.RECEIVED.value),
         context=report.id_,
         attributed_to=actor.id_,
-        rm_state=RM.RECEIVED,
+        rm=RmDimension(state=RM.RECEIVED),
     )
     bt_scenario.seed(status)
 
@@ -170,7 +171,7 @@ def test_check_rm_state_received_or_invalid_when_invalid(
         id_=_report_phase_status_id(actor.id_, report.id_, RM.INVALID.value),
         context=report.id_,
         attributed_to=actor.id_,
-        rm_state=RM.INVALID,
+        rm=RmDimension(state=RM.INVALID),
     )
     bt_scenario.seed(status)
 
@@ -188,7 +189,7 @@ def test_check_rm_state_received_or_invalid_when_valid(
         id_=_report_phase_status_id(actor.id_, report.id_, RM.VALID.value),
         context=report.id_,
         attributed_to=actor.id_,
-        rm_state=RM.VALID,
+        rm=RmDimension(state=RM.VALID),
     )
     bt_scenario.seed(status)
 

--- a/test/core/behaviors/report/test_prioritize_tree.py
+++ b/test/core/behaviors/report/test_prioritize_tree.py
@@ -32,6 +32,7 @@ from vultron.core.models.events.case import (
     DeferCaseReceivedEvent,
     EngageCaseReceivedEvent,
 )
+from vultron.core.models.dimensions import RmDimension
 from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models.vultron_types import (
     VultronCase,
@@ -65,12 +66,12 @@ def _make_participant_in_valid_state(
             ParticipantStatus(
                 attributed_to=attributed_to,
                 context=context,
-                rm_state=RM.RECEIVED,
+                rm=RmDimension(state=RM.RECEIVED),
             ),
             ParticipantStatus(
                 attributed_to=attributed_to,
                 context=context,
-                rm_state=RM.VALID,
+                rm=RmDimension(state=RM.VALID),
             ),
         ],
     )
@@ -324,7 +325,7 @@ def test_engage_case_tree_success(
     participant_id = "https://example.org/participants/vendor-cp-001"
     updated_participant = datalayer.read(participant_id)
     latest_status = updated_participant.participant_statuses[-1]
-    assert latest_status.rm_state == RM.ACCEPTED
+    assert latest_status.rm.state == RM.ACCEPTED
 
 
 def test_engage_case_tree_fails_no_participant(
@@ -383,7 +384,7 @@ def test_defer_case_tree_success(
     participant_id = "https://example.org/participants/vendor-cp-001"
     updated_participant = datalayer.read(participant_id)
     latest_status = updated_participant.participant_statuses[-1]
-    assert latest_status.rm_state == RM.DEFERRED
+    assert latest_status.rm.state == RM.DEFERRED
 
 
 def test_defer_case_tree_fails_no_participant(
@@ -459,9 +460,9 @@ def test_engage_only_affects_target_actor(bridge, datalayer, report):
 
     updated_a = datalayer.read(participant_a.id_)
     updated_b = datalayer.read(participant_b.id_)
-    assert updated_a.participant_statuses[-1].rm_state == RM.ACCEPTED
+    assert updated_a.participant_statuses[-1].rm.state == RM.ACCEPTED
     # actor_b's RM state must be unchanged (START, from default init)
-    assert updated_b.participant_statuses[-1].rm_state != RM.ACCEPTED
+    assert updated_b.participant_statuses[-1].rm.state != RM.ACCEPTED
 
 
 # ============================================================================
@@ -493,12 +494,12 @@ def test_engage_case_tree_idempotent(
     updated_case = datalayer.read(case_with_participant.id_)
     participant_id = updated_case.case_participants[0]
     participant = datalayer.read(participant_id)
-    assert participant.participant_statuses[-1].rm_state == RM.ACCEPTED
+    assert participant.participant_statuses[-1].rm.state == RM.ACCEPTED
     # Second execution must NOT append a duplicate status entry
     accepted_entries = [
         s
         for s in participant.participant_statuses
-        if s.rm_state == RM.ACCEPTED
+        if s.rm.state == RM.ACCEPTED
     ]
     assert len(accepted_entries) == 1
 
@@ -527,12 +528,12 @@ def test_defer_case_tree_idempotent(
     updated_case = datalayer.read(case_with_participant.id_)
     participant_id = updated_case.case_participants[0]
     participant = datalayer.read(participant_id)
-    assert participant.participant_statuses[-1].rm_state == RM.DEFERRED
+    assert participant.participant_statuses[-1].rm.state == RM.DEFERRED
     # Second execution must NOT append a duplicate status entry
     deferred_entries = [
         s
         for s in participant.participant_statuses
-        if s.rm_state == RM.DEFERRED
+        if s.rm.state == RM.DEFERRED
     ]
     assert len(deferred_entries) == 1
 
@@ -626,7 +627,7 @@ def test_prioritize_subtree_engages_by_default(
     # Participant RM state must be ACCEPTED
     participant_id = "https://example.org/participants/vendor-cp-002"
     updated_participant = datalayer.read(participant_id)
-    assert updated_participant.participant_statuses[-1].rm_state == RM.ACCEPTED
+    assert updated_participant.participant_statuses[-1].rm.state == RM.ACCEPTED
 
     # An engage activity must have been created and added to outbox
     outbox_items = datalayer.clone_for_actor(actor_id).outbox_list()
@@ -716,7 +717,7 @@ def test_prioritize_subtree_defers_when_engage_path_fails(
 
     participant_id = "https://example.org/participants/vendor-cp-002"
     updated_participant = datalayer.read(participant_id)
-    assert updated_participant.participant_statuses[-1].rm_state == RM.DEFERRED
+    assert updated_participant.participant_statuses[-1].rm.state == RM.DEFERRED
 
     outbox_items = datalayer.clone_for_actor(actor_id).outbox_list()
     assert len(outbox_items) == 1

--- a/test/core/behaviors/report/test_received_report_trees.py
+++ b/test/core/behaviors/report/test_received_report_trees.py
@@ -58,6 +58,7 @@ from vultron.core.models.events.report import (
     InvalidateReportReceivedEvent,
 )
 from vultron.core.models.participant import VultronParticipant
+from vultron.core.models.dimensions import RmDimension
 from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models.report import VultronReport as CoreReport
 from vultron.core.states.rm import RM
@@ -134,7 +135,7 @@ def _setup_case_with_participant(
         context=CASE_ID,
         participant_statuses=[
             ParticipantStatus(
-                rm_state=initial_rm,
+                rm=RmDimension(state=initial_rm),
                 context=CASE_ID,
                 attributed_to=actor_id,
             )
@@ -282,7 +283,7 @@ class TestTransitionCaseParticipantRMtoClosed:
         updated_case = cast(as_VulnerabilityCase, dl.read(CASE_ID))
         p_id = updated_case.actor_participant_index[ACTOR_ID]
         participant = cast(VultronParticipant, dl.read(p_id))
-        assert participant.participant_statuses[-1].rm_state == RM.CLOSED
+        assert participant.participant_statuses[-1].rm.state == RM.CLOSED
 
     def test_no_case_is_soft_pass(self, dl, bridge, caplog):
         """No case for report → WARNING logged, SUCCESS returned (soft pass)."""
@@ -325,7 +326,7 @@ class TestTransitionCaseParticipantRMtoInvalid:
         updated_case = cast(as_VulnerabilityCase, dl.read(CASE_ID))
         p_id = updated_case.actor_participant_index[ACTOR_ID]
         participant = cast(VultronParticipant, dl.read(p_id))
-        assert participant.participant_statuses[-1].rm_state == RM.INVALID
+        assert participant.participant_statuses[-1].rm.state == RM.INVALID
 
     def test_no_case_is_soft_pass(self, dl, bridge, caplog):
         """No case for report → WARNING logged, SUCCESS returned (soft pass)."""
@@ -537,7 +538,7 @@ class TestCloseReportReceivedTree:
         updated_case = cast(as_VulnerabilityCase, dl.read(CASE_ID))
         p_id = updated_case.actor_participant_index[ACTOR_ID]
         participant = cast(VultronParticipant, dl.read(p_id))
-        assert participant.participant_statuses[-1].rm_state == RM.CLOSED
+        assert participant.participant_statuses[-1].rm.state == RM.CLOSED
 
     def test_no_case_soft_pass_with_warning(self, dl, caplog):
         """No case linked to report → WARNING, BT still SUCCESS."""
@@ -582,7 +583,7 @@ class TestCloseReportReceivedUseCase:
         updated_case = cast(as_VulnerabilityCase, dl.read(CASE_ID))
         p_id = updated_case.actor_participant_index[ACTOR_ID]
         participant = cast(VultronParticipant, dl.read(p_id))
-        assert participant.participant_statuses[-1].rm_state == RM.CLOSED
+        assert participant.participant_statuses[-1].rm.state == RM.CLOSED
 
     def test_use_case_warns_when_no_case(self, caplog):
         """Use case ledgers WARNING when no case is found for the report."""
@@ -620,7 +621,7 @@ class TestInvalidateReportReceivedTree:
         updated_case = cast(as_VulnerabilityCase, dl.read(CASE_ID))
         p_id = updated_case.actor_participant_index[ACTOR_ID]
         participant = cast(VultronParticipant, dl.read(p_id))
-        assert participant.participant_statuses[-1].rm_state == RM.INVALID
+        assert participant.participant_statuses[-1].rm.state == RM.INVALID
 
     def test_no_case_soft_pass_with_warning(self, dl, caplog):
         """No case linked to report → WARNING, BT still SUCCESS."""
@@ -665,7 +666,7 @@ class TestInvalidateReportReceivedUseCase:
         updated_case = cast(as_VulnerabilityCase, dl.read(CASE_ID))
         p_id = updated_case.actor_participant_index[ACTOR_ID]
         participant = cast(VultronParticipant, dl.read(p_id))
-        assert participant.participant_statuses[-1].rm_state == RM.INVALID
+        assert participant.participant_statuses[-1].rm.state == RM.INVALID
 
     def test_use_case_warns_when_no_case(self, caplog):
         """Use case ledgers WARNING when no case is found for the report."""

--- a/test/core/behaviors/report/test_trigger_report_trees.py
+++ b/test/core/behaviors/report/test_trigger_report_trees.py
@@ -33,6 +33,7 @@ from vultron.core.behaviors.report.trigger_report_trees import (
 from vultron.core.models.activity import VultronOffer
 from vultron.core.models.case_actor import VultronCaseActor
 from vultron.core.models.offer_record import VultronOfferRecord
+from vultron.core.models.dimensions import RmDimension
 from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models.report import VultronReport
 from vultron.core.states.rm import RM
@@ -101,7 +102,7 @@ def closed_status(
         id_=_report_phase_status_id(ACTOR_ID, report.id_, RM.CLOSED.value),
         context=report.id_,
         attributed_to=ACTOR_ID,
-        rm_state=RM.CLOSED,
+        rm=RmDimension(state=RM.CLOSED),
     )
     scenario.dl.create(status)
     return status

--- a/test/core/behaviors/report/test_validate_tree.py
+++ b/test/core/behaviors/report/test_validate_tree.py
@@ -28,6 +28,7 @@ from py_trees.common import Status
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.core.models.participant_status import ParticipantStatus
+from vultron.core.models.dimensions import RmDimension
 from vultron.core.models._helpers import _report_phase_status_id
 from vultron.core.models.vultron_types import (
     VultronCaseActor,
@@ -355,7 +356,7 @@ def test_tree_execution_early_exit_already_valid(
         id_=_report_phase_status_id(actor_id, report.id_, RM.VALID.value),
         context=report.id_,
         attributed_to=actor_id,
-        rm_state=RM.VALID,
+        rm=RmDimension(state=RM.VALID),
     )
     datalayer.create(valid_status)
 
@@ -386,7 +387,7 @@ def test_tree_execution_invalid_state_transitions_to_valid(
         id_=_report_phase_status_id(actor_id, report.id_, RM.INVALID.value),
         context=report.id_,
         attributed_to=actor_id,
-        rm_state=RM.INVALID,
+        rm=RmDimension(state=RM.INVALID),
     )
     datalayer.create(invalid_status)
 

--- a/test/core/behaviors/status/test_add_participant_status_bt.py
+++ b/test/core/behaviors/status/test_add_participant_status_bt.py
@@ -731,13 +731,11 @@ class TestPublicDisclosureBranchNode:
 
         from typing import cast as c
 
-        from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            as_VulnerabilityCase,
-        )
+        from vultron.core.models.case import VulnerabilityCase
 
         # State was still applied before the broadcast attempt
-        updated = c(as_VulnerabilityCase, populated_dl.read(CASE_ID))
-        assert updated.current_status.em_state == EM.EXITED
+        updated = c(VulnerabilityCase, populated_dl.read(CASE_ID))
+        assert updated.current_status.em.state == EM.EXITED
         assert updated.active_embargo is None
 
 

--- a/test/core/behaviors/sync/nodes/test_effects.py
+++ b/test/core/behaviors/sync/nodes/test_effects.py
@@ -37,6 +37,7 @@ from vultron.core.models.case_ledger import (
 )
 from vultron.core.states.cs import CS_vfd
 from vultron.core.states.rm import RM
+from vultron.core.models.participant_status import ParticipantStatus
 from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
 
 _FIXED_CREATED_AT = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
@@ -185,15 +186,15 @@ def test_apply_participant_status_roundtrip_preserves_vfd_state(
 
     # The last (newest) status in the list must carry the values from the
     # ledger snapshot, not Pydantic serialization defaults.
-    new_status = updated.participant_statuses[-1]
-    assert new_status.vfd_state == CS_vfd.VFd, (
-        f"vfd_state must be VFd, got {new_status.vfd_state!r} — "
+    new_status = cast(ParticipantStatus, updated.participant_statuses[-1])
+    assert new_status.vfd.state == CS_vfd.VFd, (
+        f"vfd.state must be VFd, got {new_status.vfd.state!r} — "
         "likely caused by CORE ParticipantStatus serialization mismatch "
-        "when appended to list[WireParticipantStatus]"
+        "when appended to participant_statuses"
     )
     assert (
-        new_status.rm_state == RM.ACCEPTED
-    ), f"rm_state must be ACCEPTED, got {new_status.rm_state!r}"
+        new_status.rm.state == RM.ACCEPTED
+    ), f"rm.state must be ACCEPTED, got {new_status.rm.state!r}"
 
 
 def test_apply_participant_status_idempotent(

--- a/test/core/behaviors/sync/test_announce_tree.py
+++ b/test/core/behaviors/sync/test_announce_tree.py
@@ -225,7 +225,7 @@ class TestAnnounceLogEntryAppliesEmbargoTeardown:
         assert result.status == Status.SUCCESS
         updated = datalayer.read(CASE_ID)
         assert updated is not None
-        assert updated.current_status.em_state == EM.EXITED
+        assert updated.current_status.em.state == EM.EXITED
 
     def test_already_stored_entry_early_exits_successfully(
         self, bridge, datalayer, case_actor
@@ -287,7 +287,7 @@ class TestAnnounceLogEntryAppliesEmbargoTeardown:
         assert result.status == Status.SUCCESS
         updated = datalayer.read(CASE_ID)
         assert updated is not None
-        assert updated.current_status.em_state == EM.EXITED
+        assert updated.current_status.em.state == EM.EXITED
 
 
 NOTE_ID = "https://example.org/notes/test-note-1"

--- a/test/core/models/test_case_participant.py
+++ b/test/core/models/test_case_participant.py
@@ -14,6 +14,7 @@ from vultron.core.models.case_participant import (
     VendorParticipant,
     VultronParticipant,
 )
+from vultron.core.models.dimensions import RmDimension
 from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.states.rm import RM
 from vultron.enums.roles import CVDRole, validate_roles
@@ -126,18 +127,18 @@ class TestInitParticipantStatusIfEmpty:
     def test_seeded_status_rm_start(self):
         """The seeded status starts at RM.START."""
         p = _make()
-        assert p.participant_statuses[0].rm_state == RM.START
+        assert p.participant_statuses[0].rm.state == RM.START
 
     def test_pre_populated_list_preserved(self):
         """When participant_statuses is non-empty the validator does not replace it."""
         existing = ParticipantStatus(
             context=_CONTEXT,
             attributed_to=_ACTOR,
-            rm_state=RM.ACCEPTED,
+            rm=RmDimension(state=RM.ACCEPTED),
         )
         p = _make(participant_statuses=[existing])
         assert len(p.participant_statuses) == 1
-        assert p.participant_statuses[0].rm_state == RM.ACCEPTED
+        assert p.participant_statuses[0].rm.state == RM.ACCEPTED
 
 
 # ---------------------------------------------------------------------------
@@ -154,7 +155,7 @@ class TestParticipantStatusProperty:
         second = ParticipantStatus(
             context=_CONTEXT,
             attributed_to=_ACTOR,
-            rm_state=RM.ACCEPTED,
+            rm=RmDimension(state=RM.ACCEPTED),
         )
         p.participant_statuses.append(second)
         assert p.participant_status is second
@@ -185,7 +186,7 @@ class TestAppendRmState:
         assert p.append_rm_state(RM.RECEIVED, _ACTOR, _CONTEXT) is True
         assert len(p.participant_statuses) == 2
         assert p.participant_status is not None
-        assert p.participant_status.rm_state == RM.RECEIVED
+        assert p.participant_status.rm.state == RM.RECEIVED
 
     def test_invalid_transition_blocked(self):
         """An invalid RM transition (START → ACCEPTED) is rejected and returns False."""
@@ -261,7 +262,7 @@ class TestAcceptedStatusOnReporterSubclasses:
         """Subclass starts with RM.ACCEPTED participant status."""
         p = cls(attributed_to=_ACTOR, context=_CONTEXT)
         assert p.participant_status is not None
-        assert p.participant_status.rm_state == RM.ACCEPTED
+        assert p.participant_status.rm.state == RM.ACCEPTED
 
     @pytest.mark.parametrize(
         "cls", [FinderParticipant, VendorParticipant, CoordinatorParticipant]
@@ -270,7 +271,7 @@ class TestAcceptedStatusOnReporterSubclasses:
         """Non-reporter subclasses start at RM.START."""
         p = cls(attributed_to=_ACTOR, context=_CONTEXT)
         assert p.participant_status is not None
-        assert p.participant_status.rm_state == RM.START
+        assert p.participant_status.rm.state == RM.START
 
 
 # ---------------------------------------------------------------------------

--- a/test/core/models/test_dimensions.py
+++ b/test/core/models/test_dimensions.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python
+"""Unit tests for vultron/core/models/dimensions.py."""
+
+import pytest
+
+from vultron.core.models.dimensions import (
+    EmDimension,
+    PecDimension,
+    PxaDimension,
+    RmDimension,
+    VfdDimension,
+)
+from vultron.core.states.cs import CS_pxa, CS_vfd
+from vultron.core.states.em import EM, EM_Trigger
+from vultron.core.states.participant_embargo_consent import PEC, PEC_Trigger
+from vultron.core.states.rm import RM, RM_Trigger
+from vultron.errors import VultronInvalidStateTransitionError
+
+
+class TestEmDimension:
+    def test_default_state(self):
+        d = EmDimension()
+        assert d.state == EM.NO_EMBARGO
+
+    def test_construct_from_enum(self):
+        d = EmDimension(state=EM.ACTIVE)
+        assert d.state == EM.ACTIVE
+
+    def test_construct_from_string(self):
+        d = EmDimension(state="ACTIVE")
+        assert d.state == EM.ACTIVE
+
+    def test_no_embargo_alias(self):
+        d = EmDimension(state="NO_EMBARGO")
+        assert d.state == EM.NO_EMBARGO
+
+    def test_transition_returns_new_object(self):
+        d = EmDimension(state=EM.NO_EMBARGO)
+        d2 = d.transition(EM_Trigger.PROPOSE)
+        assert d2 is not d
+        assert d.state == EM.NO_EMBARGO  # original unchanged
+        assert d2.state == EM.PROPOSED
+
+    def test_transition_invalid_raises(self):
+        d = EmDimension(state=EM.NO_EMBARGO)
+        with pytest.raises(VultronInvalidStateTransitionError):
+            d.transition(EM_Trigger.TERMINATE)
+
+    def test_is_active_true(self):
+        assert EmDimension(state=EM.ACTIVE).is_active()
+
+    def test_is_active_revise(self):
+        assert EmDimension(state=EM.REVISE).is_active()
+
+    def test_is_active_false(self):
+        assert not EmDimension(state=EM.NO_EMBARGO).is_active()
+
+    def test_is_proposed(self):
+        assert EmDimension(state=EM.PROPOSED).is_proposed()
+        assert not EmDimension(state=EM.ACTIVE).is_proposed()
+
+    def test_is_exited(self):
+        assert EmDimension(state=EM.EXITED).is_exited()
+        assert not EmDimension(state=EM.ACTIVE).is_exited()
+
+    def test_is_none(self):
+        assert EmDimension(state=EM.NO_EMBARGO).is_none()
+        assert not EmDimension(state=EM.ACTIVE).is_none()
+
+    def test_serialization_roundtrip(self):
+        d = EmDimension(state=EM.ACTIVE)
+        json_str = d.model_dump_json()
+        d2 = EmDimension.model_validate_json(json_str)
+        assert d2.state == EM.ACTIVE
+
+
+class TestPxaDimension:
+    def test_default_state(self):
+        d = PxaDimension()
+        assert d.state == CS_pxa.pxa
+
+    def test_construct_from_enum(self):
+        d = PxaDimension(state=CS_pxa.Pxa)
+        assert d.state == CS_pxa.Pxa
+
+    def test_construct_from_string(self):
+        d = PxaDimension(state="pxa")
+        assert d.state == CS_pxa.pxa
+
+    def test_is_embargo_eligible(self):
+        assert PxaDimension(state=CS_pxa.pxa).is_embargo_eligible()
+        assert not PxaDimension(state=CS_pxa.Pxa).is_embargo_eligible()
+
+    def test_is_public_aware(self):
+        assert PxaDimension(state=CS_pxa.Pxa).is_public_aware()
+        assert not PxaDimension(state=CS_pxa.pxa).is_public_aware()
+
+
+class TestRmDimension:
+    def test_default_state(self):
+        d = RmDimension()
+        assert d.state == RM.START
+
+    def test_construct_from_enum(self):
+        d = RmDimension(state=RM.RECEIVED)
+        assert d.state == RM.RECEIVED
+
+    def test_construct_from_string(self):
+        d = RmDimension(state="RECEIVED")
+        assert d.state == RM.RECEIVED
+
+    def test_transition_returns_new_object(self):
+        d = RmDimension(state=RM.START)
+        d2 = d.transition(RM_Trigger.RECEIVE)
+        assert d2 is not d
+        assert d.state == RM.START
+        assert d2.state == RM.RECEIVED
+
+    def test_transition_invalid_raises(self):
+        d = RmDimension(state=RM.CLOSED)
+        with pytest.raises(VultronInvalidStateTransitionError):
+            d.transition(RM_Trigger.RECEIVE)
+
+    def test_is_validated(self):
+        assert RmDimension(state=RM.VALID).is_validated()
+        assert not RmDimension(state=RM.RECEIVED).is_validated()
+
+    def test_is_accepted(self):
+        assert RmDimension(state=RM.ACCEPTED).is_accepted()
+        assert not RmDimension(state=RM.START).is_accepted()
+
+    def test_is_closed(self):
+        assert RmDimension(state=RM.CLOSED).is_closed()
+        assert not RmDimension(state=RM.ACCEPTED).is_closed()
+
+    def test_is_terminal(self):
+        assert RmDimension(state=RM.CLOSED).is_terminal()
+        assert not RmDimension(state=RM.ACCEPTED).is_terminal()
+
+    def test_serialization_roundtrip(self):
+        d = RmDimension(state=RM.ACCEPTED)
+        d2 = RmDimension.model_validate_json(d.model_dump_json())
+        assert d2.state == RM.ACCEPTED
+
+
+class TestVfdDimension:
+    def test_default_state(self):
+        d = VfdDimension()
+        assert d.state == CS_vfd.vfd
+
+    def test_construct_from_string(self):
+        d = VfdDimension(state="Vfd")
+        assert d.state == CS_vfd.Vfd
+
+    def test_is_vendor_aware(self):
+        assert VfdDimension(state=CS_vfd.Vfd).is_vendor_aware()
+        assert not VfdDimension(state=CS_vfd.vfd).is_vendor_aware()
+
+    def test_is_fix_ready(self):
+        assert VfdDimension(state=CS_vfd.VFd).is_fix_ready()
+        assert not VfdDimension(state=CS_vfd.vfd).is_fix_ready()
+
+    def test_is_fix_deployed(self):
+        assert VfdDimension(state=CS_vfd.VFD).is_fix_deployed()
+        assert not VfdDimension(state=CS_vfd.vfd).is_fix_deployed()
+
+
+class TestPecDimension:
+    def test_default_state(self):
+        d = PecDimension()
+        assert d.state == PEC.NO_EMBARGO
+
+    def test_construct_from_enum(self):
+        d = PecDimension(state=PEC.SIGNATORY)
+        assert d.state == PEC.SIGNATORY
+
+    def test_construct_from_string(self):
+        d = PecDimension(state="INVITED")
+        assert d.state == PEC.INVITED
+
+    def test_transition_returns_new_object(self):
+        d = PecDimension(state=PEC.NO_EMBARGO)
+        d2 = d.transition(PEC_Trigger.INVITE)
+        assert d2 is not d
+        assert d.state == PEC.NO_EMBARGO
+        assert d2.state == PEC.INVITED
+
+    def test_transition_invalid_raises(self):
+        d = PecDimension(state=PEC.NO_EMBARGO)
+        with pytest.raises(VultronInvalidStateTransitionError):
+            d.transition(PEC_Trigger.ACCEPT)
+
+    def test_is_signatory(self):
+        assert PecDimension(state=PEC.SIGNATORY).is_signatory()
+        assert not PecDimension(state=PEC.INVITED).is_signatory()
+
+    def test_is_declined(self):
+        assert PecDimension(state=PEC.DECLINED).is_declined()
+        assert not PecDimension(state=PEC.SIGNATORY).is_declined()
+
+    def test_is_invited(self):
+        assert PecDimension(state=PEC.INVITED).is_invited()
+        assert not PecDimension(state=PEC.SIGNATORY).is_invited()
+
+    def test_is_lapsed(self):
+        assert PecDimension(state=PEC.LAPSED).is_lapsed()
+        assert not PecDimension(state=PEC.SIGNATORY).is_lapsed()
+
+    def test_serialization_roundtrip(self):
+        d = PecDimension(state=PEC.SIGNATORY)
+        d2 = PecDimension.model_validate_json(d.model_dump_json())
+        assert d2.state == PEC.SIGNATORY

--- a/test/core/models/test_dimensions.py
+++ b/test/core/models/test_dimensions.py
@@ -27,11 +27,11 @@ class TestEmDimension:
         assert d.state == EM.ACTIVE
 
     def test_construct_from_string(self):
-        d = EmDimension(state="ACTIVE")
+        d = EmDimension.model_validate({"state": "ACTIVE"})
         assert d.state == EM.ACTIVE
 
     def test_no_embargo_alias(self):
-        d = EmDimension(state="NO_EMBARGO")
+        d = EmDimension.model_validate({"state": "NO_EMBARGO"})
         assert d.state == EM.NO_EMBARGO
 
     def test_transition_returns_new_object(self):
@@ -84,7 +84,7 @@ class TestPxaDimension:
         assert d.state == CS_pxa.Pxa
 
     def test_construct_from_string(self):
-        d = PxaDimension(state="pxa")
+        d = PxaDimension.model_validate({"state": "pxa"})
         assert d.state == CS_pxa.pxa
 
     def test_is_embargo_eligible(self):
@@ -106,7 +106,7 @@ class TestRmDimension:
         assert d.state == RM.RECEIVED
 
     def test_construct_from_string(self):
-        d = RmDimension(state="RECEIVED")
+        d = RmDimension.model_validate({"state": "RECEIVED"})
         assert d.state == RM.RECEIVED
 
     def test_transition_returns_new_object(self):
@@ -149,7 +149,7 @@ class TestVfdDimension:
         assert d.state == CS_vfd.vfd
 
     def test_construct_from_string(self):
-        d = VfdDimension(state="Vfd")
+        d = VfdDimension.model_validate({"state": "Vfd"})
         assert d.state == CS_vfd.Vfd
 
     def test_is_vendor_aware(self):
@@ -175,7 +175,7 @@ class TestPecDimension:
         assert d.state == PEC.SIGNATORY
 
     def test_construct_from_string(self):
-        d = PecDimension(state="INVITED")
+        d = PecDimension.model_validate({"state": "INVITED"})
         assert d.state == PEC.INVITED
 
     def test_transition_returns_new_object(self):

--- a/test/core/models/test_staged_case.py
+++ b/test/core/models/test_staged_case.py
@@ -26,6 +26,7 @@ from vultron.core.models.case_participant import (
     VendorParticipant,
 )
 from vultron.core.models.case_status import CaseStatus
+from vultron.core.models.dimensions import EmDimension
 from vultron.core.models.registry import CORE_VOCABULARY
 from vultron.core.models.staged_case import Case, EmbargoedCase, IncomingReport
 from vultron.core.states.em import EM
@@ -72,7 +73,7 @@ def _embargoed_case_data() -> VulnerabilityCase:
         CaseStatus(
             context=vc.id_,
             attributed_to=_ACTOR,
-            em_state=EM.ACTIVE,
+            em=EmDimension(state=EM.ACTIVE),
         )
     ]
     return vc
@@ -247,7 +248,7 @@ class TestEmbargoedCase:
     def test_valid_with_active_embargo_and_active_em_state(self):
         ec = EmbargoedCase.model_validate(_embargoed_case_data())
         assert ec.active_embargo == _EMBARGO_ID
-        assert ec.current_status.em_state == EM.ACTIVE
+        assert ec.current_status.em.state == EM.ACTIVE
 
     def test_valid_with_revise_em_state(self):
         vc = _embargoed_case_data()
@@ -255,11 +256,11 @@ class TestEmbargoedCase:
             CaseStatus(
                 context=vc.id_,
                 attributed_to=_ACTOR,
-                em_state=EM.REVISE,
+                em=EmDimension(state=EM.REVISE),
             )
         ]
         ec = EmbargoedCase.model_validate(vc)
-        assert ec.current_status.em_state == EM.REVISE
+        assert ec.current_status.em.state == EM.REVISE
 
     def test_raises_when_active_embargo_is_none(self):
         vc = _minimal_case()
@@ -273,7 +274,7 @@ class TestEmbargoedCase:
             CaseStatus(
                 context=vc.id_,
                 attributed_to=_ACTOR,
-                em_state=EM.NO_EMBARGO,
+                em=EmDimension(state=EM.NO_EMBARGO),
             )
         ]
         with pytest.raises(VultronValidationError, match="em_state"):
@@ -285,7 +286,7 @@ class TestEmbargoedCase:
             CaseStatus(
                 context=vc.id_,
                 attributed_to=_ACTOR,
-                em_state=EM.PROPOSED,
+                em=EmDimension(state=EM.PROPOSED),
             )
         ]
         with pytest.raises(VultronValidationError, match="em_state"):
@@ -297,7 +298,7 @@ class TestEmbargoedCase:
             CaseStatus(
                 context=vc.id_,
                 attributed_to=_ACTOR,
-                em_state=EM.EXITED,
+                em=EmDimension(state=EM.EXITED),
             )
         ]
         with pytest.raises(VultronValidationError, match="em_state"):

--- a/test/core/services/test_embargo_lifecycle.py
+++ b/test/core/services/test_embargo_lifecycle.py
@@ -35,6 +35,7 @@ from vultron.adapters.driven.datalayer_sqlite import (
     SqliteDataLayer,
     reset_datalayer,
 )
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.services.embargo_lifecycle import (
     EmbargoLifecycle,
     EmbargoLifecycleResult,
@@ -164,8 +165,8 @@ def test_propose_embargo_none_to_proposed(
     assert result.pec_reset is False
     assert result.participant_changes == []
 
-    updated = cast(as_VulnerabilityCase, dl.read(case.id_))
-    assert updated.current_status.em_state == EM.PROPOSED
+    updated = cast(VulnerabilityCase, dl.read(case.id_))
+    assert updated.current_status.em.state == EM.PROPOSED
     assert embargo.id_ in updated.proposed_embargoes
 
 
@@ -197,7 +198,7 @@ def test_propose_embargo_idempotent_repropse(
     # EM state did not change, embargo_id already present → nothing mutated
     assert result.case_changed is False
 
-    updated = cast(as_VulnerabilityCase, dl.read(case.id_))
+    updated = cast(VulnerabilityCase, dl.read(case.id_))
     # Must not have been duplicated
     assert updated.proposed_embargoes.count(embargo.id_) == 1
 
@@ -237,8 +238,8 @@ def test_propose_embargo_active_to_revise_cascades_pec(
         assert change.pec_after == PEC.LAPSED.value
 
     # DataLayer state matches
-    updated = cast(as_VulnerabilityCase, dl.read(case.id_))
-    assert updated.current_status.em_state == EM.REVISE
+    updated = cast(VulnerabilityCase, dl.read(case.id_))
+    assert updated.current_status.em.state == EM.REVISE
     for p in participants:
         updated_p = cast(CaseParticipant, dl.read(p.id_))
         assert updated_p.embargo_consent_state == PEC.LAPSED.value
@@ -486,7 +487,7 @@ def test_accept_embargo_invite_observed_already_active_syncs_embargo(
     # EM stays ACTIVE (already there)
     assert result.em_after == EM.ACTIVE
     # But active_embargo must be updated to point at the new embargo
-    refreshed_case = cast(as_VulnerabilityCase, dl.read(case.id_))
+    refreshed_case = cast(VulnerabilityCase, dl.read(case.id_))
     assert _as_id(refreshed_case.active_embargo) == new_embargo.id_
 
 
@@ -1131,8 +1132,8 @@ class TestCallerOwnsEmIo:
 
         assert result.em_after == EM.PROPOSED
         # Service must NOT have written em_state; it stays at the initial value
-        refreshed = cast(as_VulnerabilityCase, dl.read(case.id_))
-        assert refreshed.current_status.em_state == EM.NONE
+        refreshed = cast(VulnerabilityCase, dl.read(case.id_))
+        assert refreshed.current_status.em.state == EM.NONE
 
     def test_propose_still_writes_em_state_on_legacy_path(
         self,
@@ -1152,8 +1153,8 @@ class TestCallerOwnsEmIo:
         )
 
         assert result.em_after == EM.PROPOSED
-        refreshed = cast(as_VulnerabilityCase, dl.read(case.id_))
-        assert refreshed.current_status.em_state == EM.PROPOSED
+        refreshed = cast(VulnerabilityCase, dl.read(case.id_))
+        assert refreshed.current_status.em.state == EM.PROPOSED
 
     def test_reject_does_not_write_em_state_when_em_before_supplied(
         self,
@@ -1174,8 +1175,8 @@ class TestCallerOwnsEmIo:
         )
 
         assert result.em_after == EM.NONE
-        refreshed = cast(as_VulnerabilityCase, dl.read(case.id_))
-        assert refreshed.current_status.em_state == EM.PROPOSED
+        refreshed = cast(VulnerabilityCase, dl.read(case.id_))
+        assert refreshed.current_status.em.state == EM.PROPOSED
 
     def test_terminate_does_not_write_em_state_when_em_before_supplied(
         self,
@@ -1197,5 +1198,5 @@ class TestCallerOwnsEmIo:
         )
 
         assert result.em_after == EM.EXITED
-        refreshed = cast(as_VulnerabilityCase, dl.read(case.id_))
-        assert refreshed.current_status.em_state == EM.ACTIVE
+        refreshed = cast(VulnerabilityCase, dl.read(case.id_))
+        assert refreshed.current_status.em.state == EM.ACTIVE

--- a/test/core/use_cases/received/actor/test_invite.py
+++ b/test/core/use_cases/received/actor/test_invite.py
@@ -298,7 +298,7 @@ class TestInviteActorUseCases:
         participant_id = updated_case.actor_participant_index.get(invitee_id)
         participant_obj = cast(Any, dl.get(id_=participant_id))
         latest_status = participant_obj.participant_statuses[-1]
-        assert latest_status.rm_state == RM.ACCEPTED
+        assert latest_status.rm.state == RM.ACCEPTED
 
     def test_accept_invite_no_identity_spoofing(self, make_payload):
         """PCR-07-008: AcceptInviteActorToCaseReceivedUseCase MUST NOT emit
@@ -377,9 +377,9 @@ class TestInviteActorUseCases:
         participant_obj = cast(Any, dl.get(id_=participant_id))
         assert participant_obj is not None
         latest_status = participant_obj.participant_statuses[-1]
-        assert latest_status.rm_state == RM.ACCEPTED, (
+        assert latest_status.rm.state == RM.ACCEPTED, (
             f"Expected RM.ACCEPTED after BT transition, "
-            f"got {latest_status.rm_state}"
+            f"got {latest_status.rm.state}"
         )
 
     def test_accept_invite_actor_to_case_records_case_event(

--- a/test/core/use_cases/received/case/test_helpers.py
+++ b/test/core/use_cases/received/case/test_helpers.py
@@ -30,6 +30,7 @@ import pytest
 
 from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.core.models.participant import VultronParticipant
+from vultron.core.models.dimensions import RmDimension
 from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models.report import VultronReport
 from vultron.core.models.report_case_link import VultronReportCaseLink
@@ -168,7 +169,7 @@ class TestBootstrapCreateReporterParticipant:
             "after bootstrap (#589)"
         )
         latest = statuses[-1]
-        rm_state = getattr(latest, "rm_state", None)
+        rm_state = latest.rm.state if hasattr(latest, "rm") else None
         assert rm_state == RM.ACCEPTED, (
             f"Reporter participant must have rm_state=RM.ACCEPTED after "
             f"bootstrap; got {rm_state!r} (#589)"
@@ -248,7 +249,7 @@ class TestBootstrapReporterUpgradesFromStart:
     def _pre_seed_participant(self, dl, rm_state: RM) -> VultronParticipant:
         """Store a finder participant at the given rm_state before bootstrap."""
         status = ParticipantStatus(
-            rm_state=rm_state,
+            rm=RmDimension(state=rm_state),
             context=self._CASE_ID,
             attributed_to=self._FINDER_ID,
         )
@@ -280,7 +281,7 @@ class TestBootstrapReporterUpgradesFromStart:
         assert stored is not None
         statuses = getattr(stored, "participant_statuses", [])
         assert statuses, "Reporter participant must have at least one status"
-        latest_rm = statuses[-1].rm_state
+        latest_rm = statuses[-1].rm.state
         assert latest_rm == RM.ACCEPTED, (
             f"Reporter participant must be upgraded to RM.ACCEPTED from "
             f"RM.START; got {latest_rm!r} (#624)"
@@ -302,7 +303,7 @@ class TestBootstrapReporterUpgradesFromStart:
             "Reporter participant already at RM.ACCEPTED must not gain extra "
             f"statuses; got {len(statuses)} (#624)"
         )
-        assert statuses[0].rm_state == RM.ACCEPTED
+        assert statuses[0].rm.state == RM.ACCEPTED
 
     def test_reporter_participant_noop_if_already_closed(
         self, base_dl, make_payload, case_with_string_participants
@@ -320,4 +321,4 @@ class TestBootstrapReporterUpgradesFromStart:
             "Reporter participant at RM.CLOSED must not gain extra statuses "
             f"(it is already beyond ACCEPTED); got {len(statuses)} (#624)"
         )
-        assert statuses[0].rm_state == RM.CLOSED
+        assert statuses[0].rm.state == RM.CLOSED

--- a/test/core/use_cases/received/test_embargo_ledger_cascade.py
+++ b/test/core/use_cases/received/test_embargo_ledger_cascade.py
@@ -34,6 +34,7 @@ from vultron.wire.as2.factories import (
     remove_embargo_from_case_activity,
 )
 from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
+from vultron.core.models.case import VulnerabilityCase
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
     as_VulnerabilityCase,
 )
@@ -121,9 +122,9 @@ class TestEmbargoLogEntryCascade:
         dl, case_actor, case, embargo = _make_embargo_case_with_actor(
             case_id, author_id, case_manager_actor_id=author_id
         )
-        case_read = cast(as_VulnerabilityCase, dl.read(case.id_))
+        case_read = cast(VulnerabilityCase, dl.read(case.id_))
         assert case_read is not None
-        case_read.current_status.em_state = EM.PROPOSED
+        case_read.current_status.em.state = EM.PROPOSED
         dl.save(case_read)
 
         case_ref = as_VulnerabilityCase(id_=case_id)
@@ -159,9 +160,9 @@ class TestEmbargoLogEntryCascade:
         dl, case_actor, case, embargo = _make_embargo_case_with_actor(
             case_id, author_id
         )
-        case = cast(as_VulnerabilityCase, dl.read(case.id_))
+        case = cast(VulnerabilityCase, dl.read(case.id_))
         assert case is not None
-        case.current_status.em_state = EM.ACTIVE
+        case.current_status.em.state = EM.ACTIVE
         case.proposed_embargoes.append(embargo.id_)
         case.active_embargo = embargo.id_  # type: ignore[assignment]
         dl.save(case)
@@ -206,9 +207,9 @@ class TestEmbargoLogEntryCascade:
             case_id, author_id
         )
         # EM.NONE: no active embargo — BT will FAIL (IsActiveEmbargoNode)
-        case = cast(as_VulnerabilityCase, dl.read(case.id_))
+        case = cast(VulnerabilityCase, dl.read(case.id_))
         assert case is not None
-        case.current_status.em_state = EM.NONE
+        case.current_status.em.state = EM.NONE
         dl.save(case)
 
         activity = remove_embargo_from_case_activity(
@@ -285,9 +286,9 @@ class TestEmbargoLogEntryCascade:
         dl, case_actor, case, embargo = _make_embargo_case_with_actor(
             case_id, coordinator_id, case_manager_actor_id=coordinator_id
         )
-        case = cast(as_VulnerabilityCase, dl.read(case.id_))
+        case = cast(VulnerabilityCase, dl.read(case.id_))
         assert case is not None
-        case.current_status.em_state = EM.PROPOSED
+        case.current_status.em.state = EM.PROPOSED
         dl.save(case)
 
         proposal = em_propose_embargo_activity(

--- a/test/core/use_cases/received/test_embargo_misc.py
+++ b/test/core/use_cases/received/test_embargo_misc.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.states.em import EM
 from vultron.core.use_cases.received.embargo import (
     AnnounceEmbargoEventToCaseReceivedUseCase,
@@ -65,10 +66,10 @@ class TestAnnounceEmbargoEventToCaseReceivedUseCase:
 
         AnnounceEmbargoEventToCaseReceivedUseCase(dl, event).execute()
 
-        updated = cast(as_VulnerabilityCase, dl.read(case.id_))
+        updated = cast(VulnerabilityCase, dl.read(case.id_))
         assert updated is not None
         # State is UNCHANGED — Announce is not the ET message
-        assert updated.current_status.em_state == EM.ACTIVE
+        assert updated.current_status.em.state == EM.ACTIVE
         assert updated.active_embargo is not None
 
     def test_announce_embargo_logs_info(self, make_payload, caplog):
@@ -162,10 +163,10 @@ class TestResetEmbargoConsentWithInlineParticipants:
         # Must not raise TypeError
         RemoveEmbargoEventFromCaseReceivedUseCase(dl, event).execute()
 
-        updated = cast(as_VulnerabilityCase, dl.read(case_id))
+        updated = cast(VulnerabilityCase, dl.read(case_id))
         assert updated is not None
         assert updated.active_embargo is None
-        assert updated.current_status.em_state == EM.EXITED
+        assert updated.current_status.em.state == EM.EXITED
 
     def test_reset_consent_with_inline_participant_resets_state(self):
         """_reset_case_participant_embargo_consent resets consent state even

--- a/test/core/use_cases/received/test_embargo_proposal_index.py
+++ b/test/core/use_cases/received/test_embargo_proposal_index.py
@@ -249,7 +249,7 @@ class TestAcceptRejectFromCoreState:
         assert "activity" in result
         updated_case = dl.read(case.id_)
         assert isinstance(updated_case, VulnerabilityCase)
-        assert updated_case.current_status.em_state == EM.ACTIVE
+        assert updated_case.current_status.em.state == EM.ACTIVE
 
     def test_accept_without_proposal_id_uses_first_pending(self):
         """SvcAcceptEmbargoUseCase finds first pending proposal from index when no proposal_id given."""
@@ -273,7 +273,7 @@ class TestAcceptRejectFromCoreState:
         assert "activity" in result
         updated_case = dl.read(case.id_)
         assert isinstance(updated_case, VulnerabilityCase)
-        assert updated_case.current_status.em_state == EM.ACTIVE
+        assert updated_case.current_status.em.state == EM.ACTIVE
 
     def test_reject_uses_core_state_index(self):
         """SvcRejectEmbargoUseCase resolves embargo from core state (no Invite DL read)."""
@@ -299,7 +299,7 @@ class TestAcceptRejectFromCoreState:
         updated_case = dl.read(case.id_)
         assert isinstance(updated_case, VulnerabilityCase)
         # Owner-reject drives EM to NONE; non-owner records rejection only.
-        assert updated_case.current_status.em_state in (EM.NONE, EM.PROPOSED)
+        assert updated_case.current_status.em.state in (EM.NONE, EM.PROPOSED)
 
     def test_accept_raises_notfound_when_index_empty(self):
         """SvcAcceptEmbargoUseCase raises VultronNotFoundError when no pending proposal in index."""

--- a/test/core/use_cases/received/test_embargo_propose_accept_reject.py
+++ b/test/core/use_cases/received/test_embargo_propose_accept_reject.py
@@ -22,6 +22,7 @@ from vultron.adapters.driven.db_record import StorableRecord
 from vultron.adapters.driven.trigger_activity_adapter import (
     TriggerActivityAdapter,
 )
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.states.em import EM
 from vultron.core.use_cases.received.embargo import (
     AcceptInviteToEmbargoOnCaseReceivedUseCase,
@@ -198,9 +199,9 @@ class TestEmbargoProposalLifecycle:
 
         case = dl.read(case.id_)
         assert case is not None
-        case = cast(as_VulnerabilityCase, case)
+        case = cast(VulnerabilityCase, case)
         assert case.active_embargo is not None
-        assert case.current_status.em_state == EM.ACTIVE
+        assert case.current_status.em.state == EM.ACTIVE
 
     def test_accept_invite_to_embargo_warns_on_non_standard_transition(
         self, monkeypatch, make_payload, caplog
@@ -249,8 +250,8 @@ class TestEmbargoProposalLifecycle:
         assert any("state-sync override" in r.message for r in caplog.records)
         case = dl.read(case.id_)
         assert case is not None
-        case = cast(as_VulnerabilityCase, case)
-        assert case.current_status.em_state == EM.ACTIVE
+        case = cast(VulnerabilityCase, case)
+        assert case.current_status.em.state == EM.ACTIVE
 
     def test_accept_invite_to_embargo_records_embargo_on_participant(
         self, monkeypatch, make_payload
@@ -551,13 +552,9 @@ class TestInviteToEmbargoReceivedPxaGuard:
         InviteToEmbargoOnCaseReceivedUseCase(dl, event).execute()
 
         # BT was not run: EM state must remain NONE (no PROPOSED transition)
-        from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            as_VulnerabilityCase,
-        )
-
-        updated = cast(as_VulnerabilityCase, dl.read(case.id_))
+        updated = cast(VulnerabilityCase, dl.read(case.id_))
         assert updated is not None
-        assert updated.current_status.em_state == EM.NONE
+        assert updated.current_status.em.state == EM.NONE
 
     @pytest.mark.parametrize("pxa_state_name", _PXA_INELIGIBLE_STATES)
     def test_pxa_set_emits_er_when_trigger_activity_provided(
@@ -656,13 +653,9 @@ class TestAcceptInviteToEmbargoReceivedPxaGuard:
         AcceptInviteToEmbargoOnCaseReceivedUseCase(dl, event).execute()
 
         # BT was not run: EM state must remain PROPOSED (not ACTIVE)
-        from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            as_VulnerabilityCase,
-        )
-
-        updated = cast(as_VulnerabilityCase, dl.read(case.id_))
+        updated = cast(VulnerabilityCase, dl.read(case.id_))
         assert updated is not None
-        assert updated.current_status.em_state == EM.PROPOSED
+        assert updated.current_status.em.state == EM.PROPOSED
 
     @pytest.mark.parametrize("pxa_state_name", _PXA_INELIGIBLE_STATES)
     def test_pxa_set_emits_er_when_trigger_activity_provided(
@@ -734,10 +727,6 @@ class TestAcceptInviteToEmbargoReceivedPxaGuard:
         AcceptInviteToEmbargoOnCaseReceivedUseCase(dl, event).execute()
 
         # Embargo should be activated (BT ran SetEmbargoActiveNode)
-        from vultron.wire.as2.vocab.objects.vulnerability_case import (
-            as_VulnerabilityCase,
-        )
-
-        updated = cast(as_VulnerabilityCase, dl.read(case.id_))
+        updated = cast(VulnerabilityCase, dl.read(case.id_))
         assert updated is not None
-        assert updated.current_status.em_state == EM.ACTIVE
+        assert updated.current_status.em.state == EM.ACTIVE

--- a/test/core/use_cases/received/test_embargo_routing_guard.py
+++ b/test/core/use_cases/received/test_embargo_routing_guard.py
@@ -41,6 +41,7 @@ from vultron.wire.as2.factories import (
 )
 from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
 from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
+from vultron.core.models.case import VulnerabilityCase
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
     as_VulnerabilityCase,
 )
@@ -208,9 +209,9 @@ class TestAcceptInviteToEmbargoRoutingGuard:
         dl, case_actor, case, embargo = _make_embargo_case(
             self.CASE_ID, self.COORD_ID, self.CASE_ACTOR_ID
         )
-        case = cast(as_VulnerabilityCase, dl.read(case.id_))
+        case = cast(VulnerabilityCase, dl.read(case.id_))
         assert case is not None
-        case.current_status.em_state = EM.PROPOSED
+        case.current_status.em.state = EM.PROPOSED
         dl.save(case)
 
         proposal = em_propose_embargo_activity(

--- a/test/core/use_cases/received/test_embargo_term_revise.py
+++ b/test/core/use_cases/received/test_embargo_term_revise.py
@@ -14,6 +14,7 @@
 
 from typing import cast
 
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.states.em import EM
 from vultron.core.use_cases.received.embargo import (
     AddEmbargoEventToCaseReceivedUseCase,
@@ -65,9 +66,9 @@ class TestEmbargoTermRevise:
 
         case = dl.read(case.id_)
         assert case is not None
-        case = cast(as_VulnerabilityCase, case)
+        case = cast(VulnerabilityCase, case)
         assert case.active_embargo is not None
-        assert case.current_status.em_state == EM.ACTIVE
+        assert case.current_status.em.state == EM.ACTIVE
 
     def test_add_embargo_event_to_case_warns_on_non_standard_transition(
         self, monkeypatch, make_payload, caplog
@@ -108,9 +109,9 @@ class TestEmbargoTermRevise:
         assert any("state-sync override" in r.message for r in caplog.records)
         case = dl.read(case.id_)
         assert case is not None
-        case = cast(as_VulnerabilityCase, case)
+        case = cast(VulnerabilityCase, case)
         # State is still updated (synchronization override proceeds).
-        assert case.current_status.em_state == EM.ACTIVE
+        assert case.current_status.em.state == EM.ACTIVE
 
     def test_remove_embargo_from_proposed_clears_proposed_list(
         self, make_payload
@@ -198,9 +199,9 @@ class TestEmbargoTermRevise:
 
         updated = dl.read(case.id_)
         assert updated is not None
-        updated = cast(as_VulnerabilityCase, updated)
+        updated = cast(VulnerabilityCase, updated)
         assert updated.active_embargo is None
-        assert updated.current_status.em_state == EM.EXITED
+        assert updated.current_status.em.state == EM.EXITED
 
     def test_remove_active_embargo_unusual_state_uses_override(
         self, caplog, make_payload
@@ -244,6 +245,6 @@ class TestEmbargoTermRevise:
 
         updated = dl.read(case.id_)
         assert updated is not None
-        updated = cast(as_VulnerabilityCase, updated)
+        updated = cast(VulnerabilityCase, updated)
         assert updated.active_embargo is None
-        assert updated.current_status.em_state == EM.EXITED
+        assert updated.current_status.em.state == EM.EXITED

--- a/test/core/use_cases/received/test_report_case_level.py
+++ b/test/core/use_cases/received/test_report_case_level.py
@@ -23,6 +23,7 @@ from vultron.core.models.events.report import (
 )
 from vultron.core.models.participant import VultronParticipant
 from vultron.core.models.report import VultronReport
+from vultron.core.models.dimensions import RmDimension
 from vultron.core.states.rm import RM
 from vultron.core.use_cases.received.case import (
     CloseCaseUseCase,
@@ -58,7 +59,7 @@ class TestCaseLevelUseeCases:
             context="https://example.org/cases/c1",
             participant_statuses=[
                 ParticipantStatus(
-                    rm_state=initial_rm,
+                    rm=RmDimension(state=initial_rm),
                     context="https://example.org/cases/c1",
                     attributed_to=actor_id,
                 )
@@ -86,7 +87,7 @@ class TestCaseLevelUseeCases:
         updated_case = cast(as_VulnerabilityCase, dl.read(case.id_))
         participant_id = updated_case.actor_participant_index[actor_id]
         participant = cast(VultronParticipant, dl.read(participant_id))
-        assert participant.participant_statuses[-1].rm_state == RM.INVALID
+        assert participant.participant_statuses[-1].rm.state == RM.INVALID
 
     def test_close_case_transitions_participant_to_closed(self):
         """CloseCaseUseCase sets participant RM state to CLOSED."""
@@ -100,7 +101,7 @@ class TestCaseLevelUseeCases:
         updated_case = cast(as_VulnerabilityCase, dl.read(case.id_))
         participant_id = updated_case.actor_participant_index[actor_id]
         participant = cast(VultronParticipant, dl.read(participant_id))
-        assert participant.participant_statuses[-1].rm_state == RM.CLOSED
+        assert participant.participant_statuses[-1].rm.state == RM.CLOSED
 
     def test_invalidate_case_noop_on_missing_case(self, caplog):
         """InvalidateCaseUseCase warns when case_id is not found."""
@@ -162,7 +163,7 @@ class TestDereferencePatternInReportUseCases:
             context="https://example.org/cases/c-deref",
             participant_statuses=[
                 ParticipantStatus(
-                    rm_state=initial_rm,
+                    rm=RmDimension(state=initial_rm),
                     context="https://example.org/cases/c-deref",
                     attributed_to=actor_id,
                 )
@@ -208,7 +209,7 @@ class TestDereferencePatternInReportUseCases:
         updated_case = cast(as_VulnerabilityCase, dl.read(case.id_))
         participant_id = updated_case.actor_participant_index[actor_id]
         participant = cast(VultronParticipant, dl.read(participant_id))
-        assert participant.participant_statuses[-1].rm_state == RM.INVALID
+        assert participant.participant_statuses[-1].rm.state == RM.INVALID
 
     def test_close_report_delegates_to_case(self):
         """CloseReportReceivedUseCase dereferences and sets RM.CLOSED."""
@@ -241,7 +242,7 @@ class TestDereferencePatternInReportUseCases:
         updated_case = cast(as_VulnerabilityCase, dl.read(case.id_))
         participant_id = updated_case.actor_participant_index[actor_id]
         participant = cast(VultronParticipant, dl.read(participant_id))
-        assert participant.participant_statuses[-1].rm_state == RM.CLOSED
+        assert participant.participant_statuses[-1].rm.state == RM.CLOSED
 
     def test_invalidate_report_warns_when_no_case(self, caplog):
         """InvalidateReportReceivedUseCase warns when no case linked to report."""

--- a/test/core/use_cases/received/test_submit_report_received.py
+++ b/test/core/use_cases/received/test_submit_report_received.py
@@ -176,7 +176,11 @@ class TestSubmitReportCreatesCase:
             for s in all_statuses
             if (s.get("data_", {}) or {}).get("attributed_to")
             == self.FINDER_ID
-            and (s.get("data_", {}) or {}).get("rm_state") == RM.ACCEPTED.value
+            and (
+                (s.get("data_", {}) or {}).get("rm_state") == RM.ACCEPTED.value
+                or (s.get("data_", {}) or {}).get("rm", {}).get("state")
+                == RM.ACCEPTED.value
+            )
         ]
         assert (
             len(finder_accepted) >= 1

--- a/test/core/use_cases/triggers/case/test_add_participant_status.py
+++ b/test/core/use_cases/triggers/case/test_add_participant_status.py
@@ -27,6 +27,7 @@ from typing import cast
 
 import pytest
 
+from vultron.core.models.dimensions import RmDimension, VfdDimension
 from vultron.core.states.cs import CS_vfd
 from vultron.core.states.rm import RM
 
@@ -39,8 +40,8 @@ class _FakeParticipantStatus:
     """Minimal stand-in for as_ParticipantStatus."""
 
     def __init__(self, rm_state: RM, vfd_state: CS_vfd) -> None:
-        self.rm_state = rm_state
-        self.vfd_state = vfd_state
+        self.rm = RmDimension(state=rm_state)
+        self.vfd = VfdDimension(state=vfd_state)
 
 
 class _FakeParticipantWithStatuses:
@@ -161,9 +162,12 @@ def test_resolve_participant_state_defaults_when_participant_not_found():
 def test_resolve_participant_state_defaults_when_invalid_rm_type():
     """Falls back to RM.START when rm_state is not an RM enum value."""
 
+    class _BadRmAttr:
+        state = "not-an-rm"
+
     class _BadStatus:
-        rm_state = "not-an-rm"
-        vfd_state = CS_vfd.VFd
+        rm = _BadRmAttr()
+        vfd = VfdDimension(state=CS_vfd.VFd)
 
     participant = _FakeParticipantWithStatuses([_BadStatus()])
     dl = _FakeDL(stored=participant)
@@ -180,9 +184,12 @@ def test_resolve_participant_state_defaults_when_invalid_rm_type():
 def test_resolve_participant_state_defaults_when_invalid_vfd_type():
     """Falls back to CS_vfd.vfd when vfd_state is not a CS_vfd enum value."""
 
+    class _BadVfdAttr:
+        state = "not-a-cs-vfd"
+
     class _BadStatus:
-        rm_state = RM.VALID
-        vfd_state = "not-a-cs-vfd"
+        rm = RmDimension(state=RM.VALID)
+        vfd = _BadVfdAttr()
 
     participant = _FakeParticipantWithStatuses([_BadStatus()])
     dl = _FakeDL(stored=participant)
@@ -485,7 +492,7 @@ class TestCreateParticipantStatusNode:
         assert isinstance(status_id, str), "result_out must contain status_id"
         stored = self.dl.read(status_id)
         assert isinstance(stored, ParticipantStatus)
-        assert stored.rm_state == RM.ACCEPTED
+        assert stored.rm.state == RM.ACCEPTED
 
     def test_node_appends_status_to_participant(self):
         """CreateParticipantStatusNode appends the status to participant_statuses."""
@@ -542,4 +549,4 @@ class TestCreateParticipantStatusNode:
         stored = self.dl.read(status_id)
         assert isinstance(stored, ParticipantStatus)
         # No prior statuses → defaults to RM.START
-        assert stored.rm_state == RM.START
+        assert stored.rm.state == RM.START

--- a/test/core/use_cases/triggers/case/test_defer.py
+++ b/test/core/use_cases/triggers/case/test_defer.py
@@ -118,7 +118,7 @@ class TestDeferCaseRMTransitionViaBT:
         assert updated is not None
         assert isinstance(updated, CaseParticipant)
         assert updated.participant_statuses
-        assert updated.participant_statuses[-1].rm_state == RM.DEFERRED
+        assert updated.participant_statuses[-1].rm.state == RM.DEFERRED
 
     def test_defer_case_actor_not_found_raises_error(self):
         request = DeferCaseTriggerRequest(

--- a/test/core/use_cases/triggers/case/test_engage.py
+++ b/test/core/use_cases/triggers/case/test_engage.py
@@ -119,7 +119,7 @@ class TestEngageCaseRMTransitionViaBT:
         assert updated is not None
         assert isinstance(updated, CaseParticipant)
         assert updated.participant_statuses
-        assert updated.participant_statuses[-1].rm_state == RM.ACCEPTED
+        assert updated.participant_statuses[-1].rm.state == RM.ACCEPTED
 
     def test_engage_case_rm_not_updated_when_no_participant(self):
         case_solo = as_VulnerabilityCase(name="Solo Case")

--- a/test/core/use_cases/triggers/embargo/test_accept.py
+++ b/test/core/use_cases/triggers/embargo/test_accept.py
@@ -6,6 +6,7 @@ from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.adapters.driven.trigger_activity_adapter import (
     TriggerActivityAdapter,
 )
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.states.em import EM
 from vultron.core.states.participant_embargo_consent import PEC
 from vultron.core.use_cases.triggers.embargo import (
@@ -55,9 +56,9 @@ def test_non_owner_accept_embargo_on_active_case_updates_participant_only(
 
     assert updated_case is not None
     assert updated_participant is not None
-    updated_case = cast(as_VulnerabilityCase, updated_case)
+    updated_case = cast(VulnerabilityCase, updated_case)
     updated_participant = cast(as_CaseParticipant, updated_participant)
-    assert updated_case.current_status.em_state == EM.ACTIVE
+    assert updated_case.current_status.em.state == EM.ACTIVE
     assert updated_case.active_embargo == case.active_embargo
     assert updated_participant.embargo_consent_state == PEC.SIGNATORY.value
     assert case.active_embargo in updated_participant.accepted_embargo_ids
@@ -113,8 +114,8 @@ def test_accept_embargo_when_attributed_to_is_none_does_not_activate_em(
 
     assert updated_case is not None
     assert updated_participant is not None
-    updated_case = cast(as_VulnerabilityCase, updated_case)
+    updated_case = cast(VulnerabilityCase, updated_case)
     updated_participant = cast(as_CaseParticipant, updated_participant)
 
-    assert updated_case.current_status.em_state == EM.PROPOSED
+    assert updated_case.current_status.em.state == EM.PROPOSED
     assert updated_participant.embargo_consent_state == PEC.SIGNATORY.value

--- a/test/core/use_cases/triggers/embargo/test_propose.py
+++ b/test/core/use_cases/triggers/embargo/test_propose.py
@@ -15,9 +15,6 @@ from vultron.core.use_cases.triggers.requests import (
 )
 from vultron.errors import VultronInvalidStateTransitionError
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
-from vultron.wire.as2.vocab.objects.vulnerability_case import (
-    as_VulnerabilityCase,
-)
 
 from .conftest import (
     _build_exited_case,
@@ -56,6 +53,8 @@ def test_propose_embargo_updates_case_state_via_bt_path(
     """ProposeEmbargo transitions EM.NONE → EM.PROPOSED and queues activity."""
     from typing import cast
 
+    from vultron.core.models.case import VulnerabilityCase
+
     finder, finder_dl = finder_actor_and_dl
     case = _build_no_embargo_case_with_case_manager(finder_dl, finder.id_)
     request = ProposeEmbargoTriggerRequest(
@@ -69,6 +68,6 @@ def test_propose_embargo_updates_case_state_via_bt_path(
     ).execute()
 
     assert "activity" in result
-    updated_case = cast(as_VulnerabilityCase, finder_dl.read(case.id_))
-    assert updated_case.current_status.em_state == EM.PROPOSED
+    updated_case = cast(VulnerabilityCase, finder_dl.read(case.id_))
+    assert updated_case.current_status.em.state == EM.PROPOSED
     assert len(updated_case.proposed_embargoes) == 1

--- a/test/core/use_cases/triggers/embargo/test_reject.py
+++ b/test/core/use_cases/triggers/embargo/test_reject.py
@@ -6,6 +6,7 @@ from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.adapters.driven.trigger_activity_adapter import (
     TriggerActivityAdapter,
 )
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.states.em import EM
 from vultron.core.states.participant_embargo_consent import PEC
 from vultron.core.use_cases.triggers.embargo import SvcRejectEmbargoUseCase
@@ -14,9 +15,6 @@ from vultron.core.use_cases.triggers.requests import (
 )
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
-from vultron.wire.as2.vocab.objects.vulnerability_case import (
-    as_VulnerabilityCase,
-)
 
 from .conftest import _build_active_embargo_case, _persist_actor
 
@@ -48,8 +46,8 @@ def test_non_owner_reject_embargo_on_active_case_updates_participant_only(
 
     assert updated_case is not None
     assert updated_participant is not None
-    updated_case = cast(as_VulnerabilityCase, updated_case)
+    updated_case = cast(VulnerabilityCase, updated_case)
     updated_participant = cast(as_CaseParticipant, updated_participant)
-    assert updated_case.current_status.em_state == EM.ACTIVE
+    assert updated_case.current_status.em.state == EM.ACTIVE
     assert updated_case.active_embargo == case.active_embargo
     assert updated_participant.embargo_consent_state == PEC.DECLINED.value

--- a/test/core/use_cases/triggers/embargo/test_revise.py
+++ b/test/core/use_cases/triggers/embargo/test_revise.py
@@ -9,6 +9,7 @@ from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.adapters.driven.trigger_activity_adapter import (
     TriggerActivityAdapter,
 )
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.states.em import EM
 from vultron.core.use_cases.triggers.embargo import (
     SvcProposeEmbargoRevisionUseCase,
@@ -19,9 +20,6 @@ from vultron.core.use_cases.triggers.requests import (
 from vultron.errors import VultronInvalidStateTransitionError
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
-from vultron.wire.as2.vocab.objects.vulnerability_case import (
-    as_VulnerabilityCase,
-)
 
 from .conftest import (
     _build_active_embargo_case_with_case_manager,
@@ -47,8 +45,8 @@ def test_propose_embargo_revision_transitions_em_to_revise(
     ).execute()
 
     assert "activity" in result
-    updated_case = cast(as_VulnerabilityCase, dl.read(case.id_))
-    assert updated_case.current_status.em_state == EM.REVISE
+    updated_case = cast(VulnerabilityCase, dl.read(case.id_))
+    assert updated_case.current_status.em.state == EM.REVISE
     assert len(updated_case.proposed_embargoes) == 2
 
 
@@ -148,8 +146,8 @@ def test_propose_embargo_revision_in_revise_state_succeeds(
     ).execute()
 
     assert "activity" in result
-    updated_case = cast(as_VulnerabilityCase, dl.read(case.id_))
-    assert updated_case.current_status.em_state == EM.REVISE
+    updated_case = cast(VulnerabilityCase, dl.read(case.id_))
+    assert updated_case.current_status.em.state == EM.REVISE
     assert len(updated_case.proposed_embargoes) == 2
 
     participant_after = cast(as_CaseParticipant, dl.read(participant_id))

--- a/test/core/use_cases/triggers/embargo/test_terminate.py
+++ b/test/core/use_cases/triggers/embargo/test_terminate.py
@@ -7,6 +7,7 @@ from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
 from vultron.adapters.driven.trigger_activity_adapter import (
     TriggerActivityAdapter,
 )
+from vultron.core.models.case import VulnerabilityCase
 from vultron.core.states.em import EM
 from vultron.core.states.participant_embargo_consent import PEC
 from vultron.core.use_cases.triggers.embargo import SvcTerminateEmbargoUseCase
@@ -16,9 +17,6 @@ from vultron.core.use_cases.triggers.requests import (
 from vultron.errors import VultronInvalidStateTransitionError
 from vultron.wire.as2.vocab.base.objects.actors import as_Service
 from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
-from vultron.wire.as2.vocab.objects.vulnerability_case import (
-    as_VulnerabilityCase,
-)
 
 from .conftest import (
     _build_active_embargo_case,
@@ -46,11 +44,11 @@ def test_terminate_embargo_transitions_case_to_exited_via_bt_path(
     ).execute()
 
     assert "activity" in result
-    updated_case = cast(as_VulnerabilityCase, finder_dl.read(case.id_))
+    updated_case = cast(VulnerabilityCase, finder_dl.read(case.id_))
     updated_participant = cast(
         as_CaseParticipant, finder_dl.read(participant_id)
     )
-    assert updated_case.current_status.em_state == EM.EXITED
+    assert updated_case.current_status.em.state == EM.EXITED
     assert updated_case.active_embargo is None
     assert updated_participant.embargo_consent_state == PEC.NO_EMBARGO.value
 

--- a/test/core/use_cases/triggers/test_case_engage_defer.py
+++ b/test/core/use_cases/triggers/test_case_engage_defer.py
@@ -179,8 +179,8 @@ class TestEngageCaseRMTransitionViaBT:
             updated.participant_statuses
         ), "Expected at least one as_ParticipantStatus after engage"
         assert (
-            updated.participant_statuses[-1].rm_state == RM.ACCEPTED
-        ), f"Expected RM.ACCEPTED, got {updated.participant_statuses[-1].rm_state}"
+            updated.participant_statuses[-1].rm.state == RM.ACCEPTED
+        ), f"Expected RM.ACCEPTED, got {updated.participant_statuses[-1].rm.state}"
 
     def test_engage_case_rm_not_updated_when_no_participant(self):
         """When participant is NOT in case_participants, the BT transitions
@@ -256,8 +256,8 @@ class TestDeferCaseRMTransitionViaBT:
             updated.participant_statuses
         ), "Expected at least one as_ParticipantStatus after defer"
         assert (
-            updated.participant_statuses[-1].rm_state == RM.DEFERRED
-        ), f"Expected RM.DEFERRED, got {updated.participant_statuses[-1].rm_state}"
+            updated.participant_statuses[-1].rm.state == RM.DEFERRED
+        ), f"Expected RM.DEFERRED, got {updated.participant_statuses[-1].rm.state}"
 
 
 # ---------------------------------------------------------------------------

--- a/test/core/use_cases/triggers/test_report_triggers.py
+++ b/test/core/use_cases/triggers/test_report_triggers.py
@@ -251,7 +251,7 @@ class TestSvcValidateReportUseCase:
         assert updated is not None
         assert isinstance(updated, CaseParticipant)
         assert updated.participant_statuses
-        assert updated.participant_statuses[-1].rm_state == RM.VALID
+        assert updated.participant_statuses[-1].rm.state == RM.VALID
 
     # --- AC-2: outbox effect -----------------------------------------------
 

--- a/test/core/use_cases/triggers/test_service.py
+++ b/test/core/use_cases/triggers/test_service.py
@@ -40,6 +40,7 @@ except ImportError:
     from pydantic_core import ValidationError as PydanticValidationError
 from vultron.core.models.offer_record import VultronOfferRecord
 from vultron.core.models.report_case_link import VultronReportCaseLink
+from vultron.core.models.dimensions import RmDimension
 from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models._helpers import _report_phase_status_id
 from vultron.core.states.em import EM
@@ -183,7 +184,7 @@ def closed_report(dl, report, actor):
         id_=_report_phase_status_id(actor.id_, report.id_, RM.CLOSED.value),
         context=report.id_,
         attributed_to=actor.id_,
-        rm_state=RM.CLOSED,
+        rm=RmDimension(state=RM.CLOSED),
     )
     dl.create(status)
     return report
@@ -565,7 +566,7 @@ def test_engage_case_trigger_updates_participant_rm_state(
             else getattr(actor_ref, "id_", str(actor_ref))
         )
         if p_actor_id == actor.id_ and p_obj.participant_statuses:
-            assert p_obj.participant_statuses[-1].rm_state == RM.ACCEPTED
+            assert p_obj.participant_statuses[-1].rm.state == RM.ACCEPTED
             return
     pytest.fail("Participant RM state was not updated to ACCEPTED")
 
@@ -639,7 +640,7 @@ def test_defer_case_trigger_updates_participant_rm_state(
             else getattr(actor_ref, "id_", str(actor_ref))
         )
         if p_actor_id == actor.id_ and p_obj.participant_statuses:
-            assert p_obj.participant_statuses[-1].rm_state == RM.DEFERRED
+            assert p_obj.participant_statuses[-1].rm.state == RM.DEFERRED
             return
     pytest.fail("Participant RM state was not updated to DEFERRED")
 
@@ -668,7 +669,7 @@ def test_propose_embargo_trigger_transitions_em_state_to_proposed(
         dl, trigger_activity=TriggerActivityAdapter(dl)
     ).propose_embargo(actor.id_, case_with_case_manager.id_, FUTURE_DATETIME)
     updated = dl.read(case_with_case_manager.id_)
-    assert updated.current_status.em_state == EM.PROPOSED
+    assert updated.current_status.em.state == EM.PROPOSED
 
 
 def test_propose_embargo_trigger_exited_raises_409(
@@ -676,7 +677,7 @@ def test_propose_embargo_trigger_exited_raises_409(
 ):
     """propose_embargo_trigger raises 409 when EM state is EXITED."""
     case_obj = dl.read(case_no_participant.id_)
-    case_obj.current_status.em_state = EM.EXITED
+    case_obj.current_status.em.state = EM.EXITED
     dl.update(case_obj.id_, object_to_record(case_obj))
 
     with pytest.raises(VultronInvalidStateTransitionError):
@@ -755,7 +756,7 @@ def test_evaluate_embargo_trigger_activates_embargo(
         dl, trigger_activity=TriggerActivityAdapter(dl)
     ).accept_embargo(actor.id_, case_obj.id_, proposal.id_)
     updated = dl.read(case_obj.id_)
-    assert updated.current_status.em_state == EM.ACTIVE
+    assert updated.current_status.em.state == EM.ACTIVE
     assert updated.active_embargo is not None
 
 
@@ -769,7 +770,7 @@ def test_evaluate_embargo_trigger_without_proposal_id_finds_first(
     ).accept_embargo(actor.id_, case_obj.id_, None)
     assert isinstance(result, dict)
     updated = dl.read(case_obj.id_)
-    assert updated.current_status.em_state == EM.ACTIVE
+    assert updated.current_status.em.state == EM.ACTIVE
 
 
 def test_evaluate_embargo_trigger_no_proposal_raises_404(
@@ -822,7 +823,7 @@ def test_terminate_embargo_trigger_sets_em_state_to_exited(
         dl, trigger_activity=TriggerActivityAdapter(dl)
     ).terminate_embargo(actor.id_, case_obj.id_)
     updated = dl.read(case_obj.id_)
-    assert updated.current_status.em_state == EM.EXITED
+    assert updated.current_status.em.state == EM.EXITED
 
 
 def test_terminate_embargo_trigger_clears_active_embargo(

--- a/test/demo/test_multi_vendor_demo.py
+++ b/test/demo/test_multi_vendor_demo.py
@@ -261,7 +261,7 @@ class TestRunMultiVendorDemo:
         )
 
         assert len(final_case.case_participants) == 3
-        assert demo.is_em_embargo_active(final_case.current_status.em_state)
+        assert demo.is_em_embargo_active(final_case.current_status.em.state)  # type: ignore[attr-defined]
         # Coordinator ownership was verified inside run_multi_vendor_demo
         # via verify_multi_vendor_case_state (would have raised on failure).
 

--- a/test/demo/test_three_actor_demo.py
+++ b/test/demo/test_three_actor_demo.py
@@ -151,7 +151,7 @@ class TestRunThreeActorDemo:
             case
             for case in final_cases
             if len(case.case_participants) == 3
-            and demo.is_em_embargo_active(case.current_status.em_state)
+            and demo.is_em_embargo_active(case.current_status.em.state)  # type: ignore[attr-defined]
         ]
         assert len(matching_cases) == 1
         final_case = matching_cases[0]

--- a/test/wire/as2/test_extractor.py
+++ b/test/wire/as2/test_extractor.py
@@ -280,4 +280,4 @@ def test_extract_intent_participant_status_vfd_state():
 
     s = cast(Any, event).status
     assert s is not None
-    assert s.vfd_state == CS_vfd.Vfd
+    assert s.vfd.state == CS_vfd.Vfd

--- a/test/wire/as2/vocab/test_wire_domain_translation.py
+++ b/test/wire/as2/vocab/test_wire_domain_translation.py
@@ -27,6 +27,7 @@ from vultron.core.models.participant_status import (
     ParticipantStatus as CoreParticipantStatus,
 )
 from vultron.core.models.report import VultronReport
+from vultron.core.models.dimensions import EmDimension, RmDimension
 from vultron.core.states.em import EM
 from vultron.core.states.rm import RM
 from vultron.wire.as2.vocab.objects.case_actor import as_CaseActor
@@ -65,7 +66,7 @@ def test_case_status_round_trips_between_core_and_wire():
         id_="https://example.org/cases/1/status/1",
         attributed_to="https://example.org/actors/vendor",
         context="https://example.org/cases/1",
-        em_state=EM.PROPOSED,
+        em=EmDimension(state=EM.PROPOSED),
     )
 
     wire = as_CaseStatus.from_core(core)
@@ -76,8 +77,8 @@ def test_case_status_round_trips_between_core_and_wire():
     assert round_tripped.id_ == core.id_
     assert round_tripped.attributed_to == core.attributed_to
     assert round_tripped.context == core.context
-    assert round_tripped.em_state == core.em_state
-    assert round_tripped.pxa_state == core.pxa_state
+    assert round_tripped.em.state == core.em.state
+    assert round_tripped.pxa.state == core.pxa.state
 
 
 def test_participant_status_from_core_materializes_case_status_reference():
@@ -85,13 +86,13 @@ def test_participant_status_from_core_materializes_case_status_reference():
         id_="https://example.org/cases/1/status/1",
         context="https://example.org/cases/1",
         attributed_to="https://example.org/actors/vendor",
-        em_state=EM.NO_EMBARGO,
+        em=EmDimension(state=EM.NO_EMBARGO),
     )
     core = CoreParticipantStatus(
         id_="https://example.org/cases/1/participants/1/status/1",
         attributed_to="https://example.org/actors/vendor",
         context="https://example.org/cases/1",
-        rm_state=RM.ACCEPTED,
+        rm=RmDimension(state=RM.ACCEPTED),
         case_status=core_case_status,
     )
 
@@ -103,11 +104,11 @@ def test_participant_status_from_core_materializes_case_status_reference():
     assert round_tripped.id_ == core.id_
     assert round_tripped.attributed_to == core.attributed_to
     assert round_tripped.context == core.context
-    assert round_tripped.rm_state == core.rm_state
-    assert round_tripped.vfd_state == core.vfd_state
+    assert round_tripped.rm.state == core.rm.state
+    assert round_tripped.vfd.state == core.vfd.state
     assert isinstance(round_tripped.case_status, CoreCaseStatus)
     assert round_tripped.case_status.id_ == core_case_status.id_
-    assert round_tripped.case_status.em_state == core_case_status.em_state
+    assert round_tripped.case_status.em.state == core_case_status.em.state
 
 
 def test_case_participant_round_trips_between_core_and_wire():
@@ -121,7 +122,7 @@ def test_case_participant_round_trips_between_core_and_wire():
                 id_="https://example.org/cases/1/participants/vendor/status/1",
                 attributed_to="https://example.org/actors/vendor",
                 context="https://example.org/cases/1",
-                rm_state=RM.ACCEPTED,
+                rm=RmDimension(state=RM.ACCEPTED),
             )
         ],
         accepted_embargo_ids=["https://example.org/embargoes/1"],
@@ -137,7 +138,7 @@ def test_case_participant_round_trips_between_core_and_wire():
     assert round_tripped.attributed_to == core.attributed_to
     assert round_tripped.context == core.context
     assert round_tripped.accepted_embargo_ids == core.accepted_embargo_ids
-    assert round_tripped.participant_statuses[0].rm_state == RM.ACCEPTED
+    assert round_tripped.participant_statuses[0].rm.state == RM.ACCEPTED
 
 
 def test_vulnerability_case_round_trips_between_core_and_wire():
@@ -145,7 +146,7 @@ def test_vulnerability_case_round_trips_between_core_and_wire():
         id_="https://example.org/cases/1/status/1",
         attributed_to="https://example.org/actors/vendor",
         context="https://example.org/cases/1",
-        em_state=EM.PROPOSED,
+        em=EmDimension(state=EM.PROPOSED),
     )
     participant = VultronParticipant(
         id_="https://example.org/cases/1/participants/vendor",

--- a/vultron/core/behaviors/case/accept_invite_tree.py
+++ b/vultron/core/behaviors/case/accept_invite_tree.py
@@ -446,7 +446,7 @@ class _CheckEmbargoActiveStateNode(DataLayerAction):
             return Status.FAILURE
 
         active_embargo_id = _as_id(case.active_embargo)
-        em_state = case.current_status.em_state
+        em_state = case.current_status.em.state
         if active_embargo_id and em_state == EM.ACTIVE:
             self.blackboard.active_embargo_id = active_embargo_id
             return Status.SUCCESS

--- a/vultron/core/behaviors/case/nodes/embargo.py
+++ b/vultron/core/behaviors/case/nodes/embargo.py
@@ -45,6 +45,7 @@ from vultron.core.services.embargo_lifecycle import (
     EmbargoLifecycle,
     TransitionMode,
 )
+from vultron.core.models.dimensions import EmDimension
 from vultron.core.states.em import EM
 from vultron.core.states.participant_embargo_consent import PEC
 from vultron.core.models._helpers import _as_id
@@ -344,7 +345,7 @@ class AttachEmbargoToCaseNode(DataLayerAction):
         active_embargo_id = _as_id(stored_case.active_embargo)
         if active_embargo_id is None:
             stored_case.active_embargo = embargo_id
-            stored_case.current_status.em_state = EM.ACTIVE
+            stored_case.current_status.em = EmDimension(state=EM.ACTIVE)
             self.datalayer.save(stored_case)
             self.logger.info(
                 "Attached embargo '%s' to case '%s' as active_embargo",

--- a/vultron/core/behaviors/case/nodes/participant/common.py
+++ b/vultron/core/behaviors/case/nodes/participant/common.py
@@ -19,6 +19,11 @@ import logging
 from typing import TYPE_CHECKING, Any, cast
 
 from vultron.core.models.enums import VultronObjectType
+from vultron.core.models.dimensions import (
+    PecDimension,
+    RmDimension,
+    VfdDimension,
+)
 from vultron.core.models.participant_status import (
     ParticipantStatus,
     coerce_cvd_roles,
@@ -124,8 +129,8 @@ def _get_or_create_accepted_status(
     if isinstance(existing, ParticipantStatus):
         should_update_role = existing.cvd_role != cvd_role
         should_backfill_consent = (
-            existing.em_consent_state is None and em_consent_state is not None
-        )
+            existing.consent.state if existing.consent is not None else None
+        ) is None and em_consent_state is not None
         # AC-3: backfill context if it still holds the report URI.
         should_backfill_context = (
             existing.context == report_id and context != report_id
@@ -136,8 +141,8 @@ def _get_or_create_accepted_status(
             or should_backfill_context
         ):
             existing.cvd_role = cvd_role
-            if should_backfill_consent:
-                existing.em_consent_state = em_consent_state
+            if should_backfill_consent and em_consent_state is not None:
+                existing.consent = PecDimension(state=em_consent_state)
             if should_backfill_context:
                 existing.context = context
             dl.save(existing)
@@ -148,11 +153,15 @@ def _get_or_create_accepted_status(
         return ParticipantStatus(
             id_=existing.id_,
             context=existing.context,
-            rm_state=existing.rm_state,
-            vfd_state=existing.vfd_state,
+            rm=RmDimension(state=existing.rm.state),
+            vfd=VfdDimension(state=existing.vfd.state),
             attributed_to=getattr(existing, "attributed_to", actor_id),
             cvd_role=existing.cvd_role,
-            em_consent_state=existing.em_consent_state,
+            consent=(
+                PecDimension(state=existing.consent.state)
+                if existing.consent is not None
+                else None
+            ),
         )
 
     node_logger.info(
@@ -164,10 +173,14 @@ def _get_or_create_accepted_status(
     accepted_status = ParticipantStatus(
         id_=accepted_status_id,
         context=context,
-        rm_state=RM.ACCEPTED,
+        rm=RmDimension(state=RM.ACCEPTED),
         attributed_to=actor_id,
         cvd_role=cvd_role,
-        em_consent_state=em_consent_state,
+        consent=(
+            PecDimension(state=em_consent_state)
+            if em_consent_state is not None
+            else None
+        ),
     )
     try:
         dl.create(accepted_status)
@@ -188,8 +201,10 @@ def resolve_participant_state_from_dl(
         statuses = getattr(participant_obj, "participant_statuses")
         if statuses:
             latest = statuses[-1]
-            raw_rm = getattr(latest, "rm_state", RM.START)
-            raw_vfd = getattr(latest, "vfd_state", CS_vfd.vfd)
+            raw_rm = latest.rm.state if hasattr(latest, "rm") else RM.START
+            raw_vfd = (
+                latest.vfd.state if hasattr(latest, "vfd") else CS_vfd.vfd
+            )
             rm_state = raw_rm if isinstance(raw_rm, RM) else RM.START
             vfd_state = raw_vfd if isinstance(raw_vfd, CS_vfd) else CS_vfd.vfd
             return rm_state, vfd_state
@@ -320,7 +335,7 @@ def _ensure_reporter_participant(
     existing = dl.read(participant_id)
     if existing is not None:
         statuses = getattr(existing, "participant_statuses", []) or []
-        latest_rm = statuses[-1].rm_state if statuses else RM.START
+        latest_rm = statuses[-1].rm.state if statuses else RM.START
         if is_rm_at_least(latest_rm, RM.ACCEPTED):
             logger.debug(
                 "ensure_reporter_participant: participant '%s' already "
@@ -334,10 +349,10 @@ def _ensure_reporter_participant(
         return
 
     status = ParticipantStatus(
-        rm_state=RM.ACCEPTED,
+        rm=RmDimension(state=RM.ACCEPTED),
         context=case_id,
         attributed_to=reporter_actor_id,
-        em_consent_state=PEC.NO_EMBARGO,
+        consent=PecDimension(state=PEC.NO_EMBARGO),
         cvd_role=[CVDRole.REPORTER],
     )
     participant = VultronParticipant(
@@ -378,12 +393,17 @@ def _upgrade_participant_to_accepted(
     appending to ``CaseParticipant.participant_statuses``.
     """
     logger = logging.getLogger(__name__)
+    _coerced_consent = coerce_em_consent_state(
+        getattr(existing, "embargo_consent_state", None)
+    )
     upgrade_status = ParticipantStatus(
-        rm_state=RM.ACCEPTED,
+        rm=RmDimension(state=RM.ACCEPTED),
         context=case_id,
         attributed_to=reporter_actor_id,
-        em_consent_state=coerce_em_consent_state(
-            getattr(existing, "embargo_consent_state", None)
+        consent=(
+            PecDimension(state=_coerced_consent)
+            if _coerced_consent is not None
+            else None
         ),
         cvd_role=coerce_cvd_roles(getattr(existing, "roles", [])),
     )

--- a/vultron/core/behaviors/case/nodes/participant/owner.py
+++ b/vultron/core/behaviors/case/nodes/participant/owner.py
@@ -31,6 +31,7 @@ from vultron.core.behaviors.case.nodes.participant.common import (
 )
 from vultron.core.behaviors.helpers import DataLayerAction
 from vultron.config.actor import ActorConfig
+from vultron.core.models.dimensions import PecDimension, RmDimension
 from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.vultron_types import VultronCase, VultronParticipant
@@ -66,17 +67,17 @@ def _build_owner_initial_status(
             return ParticipantStatus(
                 id_=status_id,
                 context=case_id,
-                rm_state=initial_rm_state,
+                rm=RmDimension(state=initial_rm_state),
                 attributed_to=actor_id,
-                em_consent_state=PEC.NO_EMBARGO,
+                consent=PecDimension(state=PEC.NO_EMBARGO),
                 cvd_role=[CVDRole.CASE_OWNER],
             )
 
     return ParticipantStatus(
         context=case_id,
-        rm_state=initial_rm_state,
+        rm=RmDimension(state=initial_rm_state),
         attributed_to=actor_id,
-        em_consent_state=PEC.NO_EMBARGO,
+        consent=PecDimension(state=PEC.NO_EMBARGO),
         cvd_role=[CVDRole.CASE_OWNER],
     )
 

--- a/vultron/core/behaviors/case/nodes/participant/status.py
+++ b/vultron/core/behaviors/case/nodes/participant/status.py
@@ -29,6 +29,13 @@ from vultron.core.models.participant_status import (
 )
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_participant import CaseParticipant
+from vultron.core.models.dimensions import (
+    EmDimension,
+    PecDimension,
+    PxaDimension,
+    RmDimension,
+    VfdDimension,
+)
 from vultron.core.states.cs import CS_pxa, CS_vfd
 from vultron.core.states.em import EM
 from vultron.core.states.rm import RM
@@ -40,7 +47,9 @@ def _resolve_em_state(case: object) -> EM:
         current_status = case.current_status  # type: ignore[attr-defined]
     except (AttributeError, ValueError):
         return EM.NONE
-    em_state = getattr(current_status, "em_state", None)
+    em_state = (
+        current_status.em.state if hasattr(current_status, "em") else None
+    )
     return em_state if em_state is not None else EM.NONE
 
 
@@ -101,8 +110,8 @@ class CreateParticipantStatusNode(DataLayerAction):
             case_status = CaseStatus(
                 context=self._case_id,
                 attributed_to=self._actor_id,
-                em_state=_resolve_em_state(case),
-                pxa_state=self._pxa_state,
+                em=EmDimension(state=_resolve_em_state(case)),
+                pxa=PxaDimension(state=self._pxa_state),
             )
 
         current_rm, current_vfd = resolve_participant_state_from_dl(
@@ -121,17 +130,30 @@ class CreateParticipantStatusNode(DataLayerAction):
             else None
         )
         em_consent_state = coerce_em_consent_state(raw_consent)
+        consent_dim = (
+            PecDimension(state=em_consent_state)
+            if em_consent_state is not None
+            else None
+        )
 
         status = ParticipantStatus(
             context=self._case_id,
             attributed_to=self._actor_id,
-            rm_state=(
-                self._rm_state if self._rm_state is not None else current_rm
+            rm=RmDimension(
+                state=(
+                    self._rm_state
+                    if self._rm_state is not None
+                    else current_rm
+                )
             ),
-            vfd_state=(
-                self._vfd_state if self._vfd_state is not None else current_vfd
+            vfd=VfdDimension(
+                state=(
+                    self._vfd_state
+                    if self._vfd_state is not None
+                    else current_vfd
+                )
             ),
-            em_consent_state=em_consent_state,
+            consent=consent_dim,
             cvd_role=status_roles,
             case_status=case_status,
         )

--- a/vultron/core/behaviors/embargo/nodes/conditions.py
+++ b/vultron/core/behaviors/embargo/nodes/conditions.py
@@ -303,7 +303,7 @@ class HasCaseStatusesNode(DataLayerCondition):
     the ``EMBARGO_MANAGEMENT_NONE`` / ``pxa`` defaults (LST-05 / AC-5).
 
     Use this as a precondition node in BT sequences that read
-    ``case.current_status.em_state`` or ``case.current_status.pxa_state``
+    ``case.current_status.em.state`` or ``case.current_status.pxa.state``
     to avoid a ``ValueError`` from an empty status list.
     """
 

--- a/vultron/core/behaviors/embargo/nodes/em_state.py
+++ b/vultron/core/behaviors/embargo/nodes/em_state.py
@@ -37,6 +37,7 @@ from vultron.core.behaviors.helpers import (
     DataLayerCondition,
 )
 from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.dimensions import EmDimension
 from vultron.core.states.em import EM
 from vultron.errors import VultronValidationError
 
@@ -87,8 +88,8 @@ class ReadEmStateNode(DataLayerCondition):
             return Status.FAILURE
 
         try:
-            em_state = EM(case.current_status.em_state)
-        except (ValueError, KeyError):
+            em_state = case.current_status.em.state
+        except (ValueError, KeyError, AttributeError):
             err = VultronValidationError(
                 f"Case '{self._case_id}' has no materialized CaseStatus"
                 f" or an invalid em_state value."
@@ -166,7 +167,7 @@ class WriteEmStateNode(DataLayerAction):
             )
             return Status.FAILURE
 
-        current_em = case.current_status.em_state
+        current_em = case.current_status.em.state
         if current_em == em_after:
             self.feedback_message = (
                 f"Case '{self._case_id}' em_state already"
@@ -175,7 +176,7 @@ class WriteEmStateNode(DataLayerAction):
             self.logger.debug("%s: %s", self.name, self.feedback_message)
             return Status.SUCCESS
 
-        case.current_status.em_state = em_after
+        case.current_status.em = EmDimension(state=em_after)
         self.datalayer.save(case)
         self.feedback_message = (
             f"Case '{self._case_id}' em_state {current_em} → {em_after.value}"

--- a/vultron/core/behaviors/embargo/nodes/lifecycle.py
+++ b/vultron/core/behaviors/embargo/nodes/lifecycle.py
@@ -26,6 +26,7 @@ from vultron.core.behaviors.embargo.nodes.em_state import (
 )
 from vultron.core.behaviors.helpers import DataLayerAction
 from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.dimensions import EmDimension
 from vultron.core.services.embargo_lifecycle import (
     EmbargoLifecycle,
     EmbargoLifecycleResult,
@@ -430,7 +431,7 @@ class SetEmbargoActiveNode(DataLayerAction):
 
     def _apply_transition(self, case: Any) -> None:
         """Apply EM → ACTIVE transition and persist; warn on non-standard path."""
-        current_em = case.current_status.em_state
+        current_em = case.current_status.em.state
         if not is_valid_em_transition(current_em, EM.ACTIVE):
             self.logger.warning(
                 "%s: EM transition %s → ACTIVE is not a standard machine"
@@ -440,7 +441,7 @@ class SetEmbargoActiveNode(DataLayerAction):
                 self.case_id,
             )
         case.set_embargo(self.embargo_id)
-        case.current_status.em_state = EM.ACTIVE
+        case.current_status.em = EmDimension(state=EM.ACTIVE)
         assert self.datalayer is not None
         self.datalayer.save(case)
         self.feedback_message = (

--- a/vultron/core/behaviors/embargo/nodes/teardown.py
+++ b/vultron/core/behaviors/embargo/nodes/teardown.py
@@ -20,6 +20,7 @@ from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerAction
 from vultron.core.models.case import VulnerabilityCase
+from vultron.core.models.dimensions import EmDimension
 from vultron.core.states.em import EM, is_valid_em_transition
 from vultron.core.use_cases._helpers import (
     _as_id,
@@ -77,7 +78,7 @@ class ApplyEmbargoTeardownNode(DataLayerAction):
             self.logger.warning("%s: %s", self.name, self.feedback_message)
             return Status.SUCCESS
 
-        current_em = case.current_status.em_state
+        current_em = case.current_status.em.state
 
         if current_em == EM.EXITED:
             self.feedback_message = (
@@ -95,7 +96,7 @@ class ApplyEmbargoTeardownNode(DataLayerAction):
                 case_id,
             )
 
-        case.current_status.em_state = EM.EXITED
+        case.current_status.em = EmDimension(state=EM.EXITED)
         case.active_embargo = None
         reset_case_participant_embargo_consent(self.datalayer, case)
         self.datalayer.save(case)

--- a/vultron/core/behaviors/report/nodes/rm_transitions.py
+++ b/vultron/core/behaviors/report/nodes/rm_transitions.py
@@ -18,6 +18,7 @@
 from py_trees.common import Status
 
 from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.models.dimensions import PecDimension, RmDimension
 from vultron.core.models.participant_status import ParticipantStatus
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.states.participant_embargo_consent import PEC
@@ -170,8 +171,8 @@ class TransitionRMtoValid(DataLayerAction):
                 ),
                 context=context,
                 attributed_to=actor_id,
-                rm_state=RM.VALID,
-                em_consent_state=PEC.NO_EMBARGO,
+                rm=RmDimension(state=RM.VALID),
+                consent=PecDimension(state=PEC.NO_EMBARGO),
                 cvd_role=[CVDRole.REPORTER],
             )
             _idempotent_create(
@@ -253,8 +254,8 @@ class TransitionRMtoInvalid(DataLayerAction):
                 ),
                 context=context,
                 attributed_to=self.actor_id,
-                rm_state=RM.INVALID,
-                em_consent_state=PEC.NO_EMBARGO,
+                rm=RmDimension(state=RM.INVALID),
+                consent=PecDimension(state=PEC.NO_EMBARGO),
                 cvd_role=[CVDRole.REPORTER],
             )
             _idempotent_create(
@@ -331,8 +332,8 @@ class TransitionRMtoClosed(DataLayerAction):
                 ),
                 context=context,
                 attributed_to=self.actor_id,
-                rm_state=RM.CLOSED,
-                em_consent_state=PEC.NO_EMBARGO,
+                rm=RmDimension(state=RM.CLOSED),
+                consent=PecDimension(state=PEC.NO_EMBARGO),
                 cvd_role=[CVDRole.REPORTER],
             )
             _idempotent_create(

--- a/vultron/core/behaviors/status/nodes/append.py
+++ b/vultron/core/behaviors/status/nodes/append.py
@@ -193,8 +193,8 @@ class ResolveAndPersistStatusObjectNode(DataLayerAction):
     Tries the DataLayer first; if not found, uses ``status_obj_fallback``,
     saves it, then re-reads the canonical wire-format record.
 
-    Validates that the resolved object is a ParticipantStatus (has rm_state and
-    vfd_state attributes).
+    Validates that the resolved object is a ParticipantStatus (has rm and
+    vfd attributes).
 
     Writes the resolved status object to the blackboard under the key
     ``append_status_status_obj``.
@@ -240,9 +240,7 @@ class ResolveAndPersistStatusObjectNode(DataLayerAction):
             )
             return Status.FAILURE
 
-        if not hasattr(status_obj, "rm_state") or not hasattr(
-            status_obj, "vfd_state"
-        ):
+        if not hasattr(status_obj, "rm") or not hasattr(status_obj, "vfd"):
             self.feedback_message = (
                 f"Object '{self.status_id}' is not a ParticipantStatus"
             )
@@ -301,7 +299,9 @@ class ValidateRMTransitionNode(DataLayerCondition):
             )
             return Status.FAILURE
 
-        new_rm_state = getattr(status_obj, "rm_state", None)
+        new_rm_state = (
+            status_obj.rm.state if hasattr(status_obj, "rm") else None
+        )
         current_status = getattr(participant, "participant_status", None)
 
         if new_rm_state is None or current_status is None:
@@ -311,7 +311,7 @@ class ValidateRMTransitionNode(DataLayerCondition):
             )
             return Status.SUCCESS
 
-        current_rm = current_status.rm_state
+        current_rm = current_status.rm.state
         if current_rm == RM.CLOSED:
             self.feedback_message = (
                 "Participant is already in terminal RM.CLOSED state"
@@ -464,7 +464,9 @@ class CheckParticipantRMNotClosedNode(DataLayerCondition):
         if current_status is None:
             return Status.SUCCESS
 
-        current_rm = getattr(current_status, "rm_state", None)
+        current_rm = (
+            current_status.rm.state if hasattr(current_status, "rm") else None
+        )
         if current_rm != RM.CLOSED:
             return Status.SUCCESS
 

--- a/vultron/core/behaviors/status/nodes/case_status.py
+++ b/vultron/core/behaviors/status/nodes/case_status.py
@@ -171,18 +171,20 @@ class ValidateCaseStatusTransitionNode(DataLayerCondition):
             )
             return Status.FAILURE
 
+        em_dim = getattr(status_obj, "em", None)
+        pxa_dim = getattr(status_obj, "pxa", None)
         if not self._check_transition(
             "EM",
-            current_status.em_state,
-            getattr(status_obj, "em_state", None),
+            current_status.em.state,
+            em_dim.state if em_dim is not None else None,
             is_valid_em_transition,
         ):
             return Status.FAILURE
 
         if not self._check_transition(
             "PXA",
-            current_status.pxa_state,
-            getattr(status_obj, "pxa_state", None),
+            current_status.pxa.state,
+            pxa_dim.state if pxa_dim is not None else None,
             is_valid_pxa_transition,
         ):
             return Status.FAILURE

--- a/vultron/core/behaviors/status/nodes/lifecycle.py
+++ b/vultron/core/behaviors/status/nodes/lifecycle.py
@@ -78,8 +78,15 @@ class _PublicDisclosureSkipConditionNode(DataLayerCondition):
         """Return True if the status signals public awareness (CS.P is set)."""
         from vultron.core.states.cs import CS_pxa
 
-        case_status = getattr(self.status_obj, "case_status", None)
-        pxa_state = getattr(case_status, "pxa_state", None)
+        case_status: object = getattr(self.status_obj, "case_status", None)
+        if case_status is None:
+            pxa_state = None
+        elif hasattr(case_status, "pxa"):
+            pxa_state = getattr(case_status, "pxa").state
+        elif hasattr(case_status, "pxa_state"):
+            pxa_state = getattr(case_status, "pxa_state")
+        else:
+            pxa_state = None
         if pxa_state is None:
             return False
         try:
@@ -232,7 +239,9 @@ class AutoCloseBranchNode(DataLayerAction):
                 latest = latest_ref
             if latest is None:
                 return False
-            rm_state = getattr(latest, "rm_state", None)
+            rm_state = (
+                getattr(latest, "rm").state if hasattr(latest, "rm") else None
+            )
             if rm_state is None or rm_state != RM.CLOSED:
                 return False
         return True

--- a/vultron/core/models/case_participant.py
+++ b/vultron/core/models/case_participant.py
@@ -39,6 +39,7 @@ from typing import Literal
 from pydantic import Field, field_serializer, field_validator, model_validator
 
 from vultron.core.models.base import CoreObject, NonEmptyString
+from vultron.core.models.dimensions import PecDimension, RmDimension
 from vultron.core.models.participant_status import (
     ParticipantStatus,
     coerce_cvd_roles,
@@ -102,12 +103,15 @@ class CaseParticipant(CoreObject):
         """Seed ``participant_statuses`` with a default entry when empty."""
         if self.participant_statuses:
             return self
+        _consent_state = coerce_em_consent_state(self.embargo_consent_state)
         self.participant_statuses = [
             ParticipantStatus(
                 context=self.context or self.id_,
                 attributed_to=self.attributed_to,
-                em_consent_state=coerce_em_consent_state(
-                    self.embargo_consent_state
+                consent=(
+                    PecDimension(state=_consent_state)
+                    if _consent_state is not None
+                    else None
                 ),
                 cvd_role=coerce_cvd_roles(self.case_roles),
             ),
@@ -119,8 +123,11 @@ class CaseParticipant(CoreObject):
             return
         latest = self.participant_statuses[-1]
         latest.cvd_role = coerce_cvd_roles(self.case_roles)
-        latest.em_consent_state = coerce_em_consent_state(
-            self.embargo_consent_state
+        _consent_state = coerce_em_consent_state(self.embargo_consent_state)
+        latest.consent = (
+            PecDimension(state=_consent_state)
+            if _consent_state is not None
+            else None
         )
 
     @property
@@ -149,7 +156,7 @@ class CaseParticipant(CoreObject):
             ``True`` when the status was appended, ``False`` when blocked.
         """
         current = (
-            self.participant_statuses[-1].rm_state
+            self.participant_statuses[-1].rm.state
             if self.participant_statuses
             else RM.START
         )
@@ -161,13 +168,16 @@ class CaseParticipant(CoreObject):
                 self.id_,
             )
             return False
+        _consent_state = coerce_em_consent_state(self.embargo_consent_state)
         self.participant_statuses.append(
             ParticipantStatus(
-                rm_state=rm_state,
+                rm=RmDimension(state=rm_state),
                 context=context,
                 attributed_to=actor,
-                em_consent_state=coerce_em_consent_state(
-                    self.embargo_consent_state
+                consent=(
+                    PecDimension(state=_consent_state)
+                    if _consent_state is not None
+                    else None
                 ),
                 cvd_role=coerce_cvd_roles(self.case_roles),
             )
@@ -280,13 +290,16 @@ class ReporterParticipant(CaseParticipant):
 
     @model_validator(mode="after")
     def _set_accepted_status(self) -> ReporterParticipant:
+        _consent_state = coerce_em_consent_state(self.embargo_consent_state)
         self.participant_statuses = [
             ParticipantStatus(
                 context=self.context or self.id_,
                 attributed_to=self.attributed_to,
-                rm_state=RM.ACCEPTED,
-                em_consent_state=coerce_em_consent_state(
-                    self.embargo_consent_state
+                rm=RmDimension(state=RM.ACCEPTED),
+                consent=(
+                    PecDimension(state=_consent_state)
+                    if _consent_state is not None
+                    else None
                 ),
                 cvd_role=coerce_cvd_roles(self.case_roles),
             )
@@ -309,13 +322,16 @@ class FinderReporterParticipant(CaseParticipant):
 
     @model_validator(mode="after")
     def _set_accepted_status(self) -> FinderReporterParticipant:
+        _consent_state = coerce_em_consent_state(self.embargo_consent_state)
         self.participant_statuses = [
             ParticipantStatus(
                 context=self.context or self.id_,
                 attributed_to=self.attributed_to,
-                rm_state=RM.ACCEPTED,
-                em_consent_state=coerce_em_consent_state(
-                    self.embargo_consent_state
+                rm=RmDimension(state=RM.ACCEPTED),
+                consent=(
+                    PecDimension(state=_consent_state)
+                    if _consent_state is not None
+                    else None
                 ),
                 cvd_role=coerce_cvd_roles(self.case_roles),
             )

--- a/vultron/core/models/case_status.py
+++ b/vultron/core/models/case_status.py
@@ -15,14 +15,13 @@
 
 """Domain representation of a case status snapshot."""
 
-from typing import Literal
+from typing import Any, Literal
 
-from pydantic import ConfigDict, Field, field_serializer, field_validator
+from pydantic import ConfigDict, Field, model_validator
 from pydantic.alias_generators import to_camel
 
-from vultron.core.states.em import EM
-from vultron.core.states.cs import CS_pxa
 from vultron.core.models.base import CoreObject, NonEmptyString
+from vultron.core.models.dimensions import EmDimension, PxaDimension
 
 
 class CaseStatus(CoreObject):
@@ -35,6 +34,9 @@ class CaseStatus(CoreObject):
     ``context`` (case ID) is required — a status snapshot without a case
     context is not meaningful.  ``attributed_to`` (reporting actor) is
     optional but must be non-empty when present.
+
+    ``em`` and ``pxa`` are dimension objects that own the EM and PXA state
+    machines respectively (ADR-0036, SDO-03-001).
     """
 
     model_config = ConfigDict(alias_generator=to_camel)
@@ -48,29 +50,41 @@ class CaseStatus(CoreObject):
     attributed_to: NonEmptyString | None = (
         None  # pyright: ignore[reportGeneralTypeIssues]
     )
-    em_state: EM = EM.NO_EMBARGO
-    pxa_state: CS_pxa = CS_pxa.pxa
+    em: EmDimension = Field(default_factory=EmDimension)
+    pxa: PxaDimension = Field(default_factory=PxaDimension)
 
-    @field_serializer("em_state")
-    def _serialize_em_state(self, v: EM) -> str:
-        return v.name
-
-    @field_serializer("pxa_state")
-    def _serialize_pxa_state(self, v: CS_pxa) -> str:
-        return v.name
-
-    @field_validator("em_state", mode="before")
+    @model_validator(mode="before")
     @classmethod
-    def _validate_em_state(cls, v: object) -> EM:
-        if isinstance(v, str):
-            if v in EM.__members__:
-                return EM[v]
-            return EM(v)
-        return v  # type: ignore[return-value]
+    def _migrate_flat_fields(cls, data: Any) -> Any:
+        """Accept legacy flat ``em_state``/``pxa_state`` wire-format inputs.
 
-    @field_validator("pxa_state", mode="before")
-    @classmethod
-    def _validate_pxa_state(cls, v: object) -> CS_pxa:
-        if isinstance(v, str):
-            return CS_pxa[v]
-        return v  # type: ignore[return-value]
+        Wire-layer ``as_CaseStatus`` serialises these as flat string fields.
+        When the DataLayer reconstitutes a stored ``VulnerabilityCase``, the
+        nested ``case_statuses`` dicts may still carry these keys.  Map them
+        to the dimension-object keys so ``model_validate`` succeeds.
+        Handles both snake_case and camelCase alias forms.
+        """
+        if not isinstance(data, dict):
+            return data
+        _SENTINEL = object()
+        em_raw = data.get("em_state", _SENTINEL)
+        if em_raw is _SENTINEL:
+            em_raw = data.get("emState", _SENTINEL)
+        if em_raw is not _SENTINEL and em_raw is not None and "em" not in data:
+            data = dict(data)
+            data.pop("em_state", None)
+            data.pop("emState", None)
+            data["em"] = {"state": em_raw}
+        pxa_raw = data.get("pxa_state", _SENTINEL)
+        if pxa_raw is _SENTINEL:
+            pxa_raw = data.get("pxaState", _SENTINEL)
+        if (
+            pxa_raw is not _SENTINEL
+            and pxa_raw is not None
+            and "pxa" not in data
+        ):
+            data = dict(data)
+            data.pop("pxa_state", None)
+            data.pop("pxaState", None)
+            data["pxa"] = {"state": pxa_raw}
+        return data

--- a/vultron/core/models/dimensions.py
+++ b/vultron/core/models/dimensions.py
@@ -154,7 +154,7 @@ class EmDimension(BaseModel):
         new_state = _apply_transition(
             self.state, trigger, _em_transitions, "EmDimension"
         )
-        return self.model_copy(update={"state": EM(new_state)})
+        return self.model_copy(update={"state": EM(str(new_state))})
 
     def is_active(self) -> bool:
         return self.state in (EM.ACTIVE, EM.REVISE)
@@ -237,7 +237,7 @@ class RmDimension(BaseModel):
         new_state = _apply_transition(
             self.state, trigger, _rm_transitions, "RmDimension"
         )
-        return self.model_copy(update={"state": RM(new_state)})
+        return self.model_copy(update={"state": RM(str(new_state))})
 
     def is_validated(self) -> bool:
         return self.state in RM_VALIDATED
@@ -319,7 +319,7 @@ class PecDimension(BaseModel):
         new_state = _apply_transition(
             self.state, trigger, _pec_transitions, "PecDimension"
         )
-        return self.model_copy(update={"state": PEC(new_state)})
+        return self.model_copy(update={"state": PEC(str(new_state))})
 
     def is_signatory(self) -> bool:
         return self.state == PEC.SIGNATORY

--- a/vultron/core/models/dimensions.py
+++ b/vultron/core/models/dimensions.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Per-machine dimension objects for CaseStatus and ParticipantStatus.
+
+Each dimension object is a lightweight Pydantic BaseModel that holds one state
+enum and owns immutable transition() validation and guard methods for that
+state machine. Transitions return a new dimension object; they never mutate
+self.
+
+Design: ADR-0036, spec: specs/status-dimension-objects.yaml (SDO-01 to SDO-04).
+"""
+
+from pydantic import BaseModel, field_serializer, field_validator
+
+from vultron.core.states.cs import (
+    CS_pxa,
+    CS_vfd,
+    PXA_ATTACKS_OBSERVED,
+    PXA_EXPLOIT_PUBLIC,
+    PXA_PUBLIC_AWARE,
+    PxaState,
+    VFD_FIX_DEPLOYED,
+    VFD_FIX_READY,
+    VFD_VENDOR_AWARE,
+    VfdState,
+    PXA_Trigger,
+    VFD_Trigger,
+    _pxa_transitions,
+    _vfd_transitions,
+)
+from vultron.core.states.em import (
+    EM,
+    EM_Trigger,
+    _transitions as _em_transitions,
+)
+from vultron.core.states.participant_embargo_consent import (
+    PEC,
+    PEC_Trigger,
+    _transitions as _pec_transitions,
+)
+from vultron.core.states.rm import (
+    RM,
+    RM_Trigger,
+    RM_VALIDATED,
+    _transitions as _rm_transitions,
+)
+from vultron.errors import VultronInvalidStateTransitionError
+
+
+def _coerce_em(v: object) -> EM:
+    if isinstance(v, EM):
+        return v
+    if isinstance(v, str):
+        return EM[v]
+    raise ValueError(f"Cannot coerce {v!r} to EM")
+
+
+def _coerce_rm(v: object) -> RM:
+    if isinstance(v, RM):
+        return v
+    if isinstance(v, str):
+        return RM[v]
+    raise ValueError(f"Cannot coerce {v!r} to RM")
+
+
+def _coerce_pec(v: object) -> PEC:
+    if isinstance(v, PEC):
+        return v
+    if isinstance(v, str):
+        return PEC[v]
+    raise ValueError(f"Cannot coerce {v!r} to PEC")
+
+
+def _coerce_pxa(v: object) -> CS_pxa:
+    if isinstance(v, CS_pxa):
+        return v
+    if isinstance(v, str):
+        return CS_pxa[v]
+    if isinstance(v, (list, tuple)) and len(v) == 3:
+        return CS_pxa(PxaState(*v))
+    raise ValueError(f"Cannot coerce {v!r} to CS_pxa")
+
+
+def _coerce_vfd(v: object) -> CS_vfd:
+    if isinstance(v, CS_vfd):
+        return v
+    if isinstance(v, str):
+        return CS_vfd[v]
+    if isinstance(v, (list, tuple)) and len(v) == 3:
+        return CS_vfd(VfdState(*v))
+    raise ValueError(f"Cannot coerce {v!r} to CS_vfd")
+
+
+def _apply_transition(
+    current_state: object,
+    trigger: object,
+    transitions: list[dict],
+    machine_name: str,
+) -> object:
+    """Return the destination state for (current_state, trigger).
+
+    Raises VultronInvalidStateTransitionError when no matching transition exists.
+    Supports wildcard source "*" (PEC RESET).
+    """
+    for t in transitions:
+        src = t.get("source")
+        if src != current_state and src != "*":
+            continue
+        if t.get("trigger") != trigger:
+            continue
+        return t["dest"]
+    raise VultronInvalidStateTransitionError(
+        f"{machine_name}: state '{current_state}' does not accept trigger"
+        f" '{trigger}'."
+    )
+
+
+class EmDimension(BaseModel):
+    """Embargo Management state dimension object.
+
+    Holds the case-level EM state and owns immutable transition validation.
+    Replaces CaseStatus.em_state (SDO-01-001, SDO-03-001).
+    """
+
+    state: EM = EM.NO_EMBARGO
+
+    @field_validator("state", mode="before")
+    @classmethod
+    def validate_state(cls, v: object) -> EM:
+        return _coerce_em(v)
+
+    @field_serializer("state")
+    def serialize_state(self, v: EM) -> str:
+        return v.name
+
+    def transition(self, trigger: EM_Trigger) -> "EmDimension":
+        """Return a new EmDimension with the state after applying *trigger*.
+
+        Raises VultronInvalidStateTransitionError on invalid trigger.
+        """
+        new_state = _apply_transition(
+            self.state, trigger, _em_transitions, "EmDimension"
+        )
+        return self.model_copy(update={"state": EM(new_state)})
+
+    def is_active(self) -> bool:
+        return self.state in (EM.ACTIVE, EM.REVISE)
+
+    def is_proposed(self) -> bool:
+        return self.state == EM.PROPOSED
+
+    def is_exited(self) -> bool:
+        return self.state == EM.EXITED
+
+    def is_none(self) -> bool:
+        return self.state == EM.NONE
+
+
+class PxaDimension(BaseModel):
+    """PXA (public/exploit/attacks) case state dimension object.
+
+    Holds the participant-agnostic public state and owns immutable transition
+    validation.  Replaces CaseStatus.pxa_state (SDO-01-001, SDO-03-001).
+    """
+
+    state: CS_pxa = CS_pxa.pxa
+
+    @field_validator("state", mode="before")
+    @classmethod
+    def validate_state(cls, v: object) -> CS_pxa:
+        return _coerce_pxa(v)
+
+    @field_serializer("state")
+    def serialize_state(self, v: CS_pxa) -> str:
+        return v.name
+
+    def transition(self, trigger: PXA_Trigger) -> "PxaDimension":
+        """Return a new PxaDimension with the state after applying *trigger*.
+
+        Raises VultronInvalidStateTransitionError on invalid trigger.
+        """
+        new_state = _apply_transition(
+            self.state, trigger, _pxa_transitions, "PxaDimension"
+        )
+        return self.model_copy(update={"state": CS_pxa(new_state)})
+
+    def is_public_aware(self) -> bool:
+        return self.state in PXA_PUBLIC_AWARE
+
+    def is_exploit_public(self) -> bool:
+        return self.state in PXA_EXPLOIT_PUBLIC
+
+    def is_attacks_observed(self) -> bool:
+        return self.state in PXA_ATTACKS_OBSERVED
+
+    def is_embargo_eligible(self) -> bool:
+        """Return True when no P/X/A bit is set (EMB-01-002, EMB-02-002)."""
+        return self.state == CS_pxa.pxa
+
+
+class RmDimension(BaseModel):
+    """Report Management state dimension object.
+
+    Holds the per-participant RM state and owns immutable transition validation.
+    Replaces ParticipantStatus.rm_state (SDO-01-001, SDO-03-002).
+    """
+
+    state: RM = RM.START
+
+    @field_validator("state", mode="before")
+    @classmethod
+    def validate_state(cls, v: object) -> RM:
+        return _coerce_rm(v)
+
+    @field_serializer("state")
+    def serialize_state(self, v: RM) -> str:
+        return v.name
+
+    def transition(self, trigger: RM_Trigger) -> "RmDimension":
+        """Return a new RmDimension with the state after applying *trigger*.
+
+        Raises VultronInvalidStateTransitionError on invalid trigger.
+        """
+        new_state = _apply_transition(
+            self.state, trigger, _rm_transitions, "RmDimension"
+        )
+        return self.model_copy(update={"state": RM(new_state)})
+
+    def is_validated(self) -> bool:
+        return self.state in RM_VALIDATED
+
+    def is_accepted(self) -> bool:
+        return self.state == RM.ACCEPTED
+
+    def is_closed(self) -> bool:
+        return self.state == RM.CLOSED
+
+    def is_terminal(self) -> bool:
+        return self.state == RM.CLOSED
+
+
+class VfdDimension(BaseModel):
+    """VFD (vendor/fix/deploy) vendor fix path dimension object.
+
+    Holds the per-participant vendor fix path state and owns immutable
+    transition validation.  Replaces ParticipantStatus.vfd_state
+    (SDO-01-001, SDO-03-002).
+    """
+
+    state: CS_vfd = CS_vfd.vfd
+
+    @field_validator("state", mode="before")
+    @classmethod
+    def validate_state(cls, v: object) -> CS_vfd:
+        return _coerce_vfd(v)
+
+    @field_serializer("state")
+    def serialize_state(self, v: CS_vfd) -> str:
+        return v.name
+
+    def transition(self, trigger: VFD_Trigger) -> "VfdDimension":
+        """Return a new VfdDimension with the state after applying *trigger*.
+
+        Raises VultronInvalidStateTransitionError on invalid trigger.
+        """
+        new_state = _apply_transition(
+            self.state, trigger, _vfd_transitions, "VfdDimension"
+        )
+        return self.model_copy(update={"state": CS_vfd(new_state)})
+
+    def is_vendor_aware(self) -> bool:
+        return self.state in VFD_VENDOR_AWARE
+
+    def is_fix_ready(self) -> bool:
+        return self.state in VFD_FIX_READY
+
+    def is_fix_deployed(self) -> bool:
+        return self.state in VFD_FIX_DEPLOYED
+
+
+class PecDimension(BaseModel):
+    """Participant Embargo Consent dimension object.
+
+    Holds a single participant's embargo consent state and owns immutable
+    transition validation.  Replaces ParticipantStatus.em_consent_state
+    (SDO-01-001, SDO-03-002).
+    """
+
+    state: PEC = PEC.NO_EMBARGO
+
+    @field_validator("state", mode="before")
+    @classmethod
+    def validate_state(cls, v: object) -> PEC:
+        return _coerce_pec(v)
+
+    @field_serializer("state")
+    def serialize_state(self, v: PEC) -> str:
+        return v.name
+
+    def transition(self, trigger: PEC_Trigger) -> "PecDimension":
+        """Return a new PecDimension with the state after applying *trigger*.
+
+        Raises VultronInvalidStateTransitionError on invalid trigger.
+        Supports the RESET wildcard ("*" → NO_EMBARGO from any state).
+        """
+        new_state = _apply_transition(
+            self.state, trigger, _pec_transitions, "PecDimension"
+        )
+        return self.model_copy(update={"state": PEC(new_state)})
+
+    def is_signatory(self) -> bool:
+        return self.state == PEC.SIGNATORY
+
+    def is_declined(self) -> bool:
+        return self.state == PEC.DECLINED
+
+    def is_invited(self) -> bool:
+        return self.state == PEC.INVITED
+
+    def is_lapsed(self) -> bool:
+        return self.state == PEC.LAPSED

--- a/vultron/core/models/participant_status.py
+++ b/vultron/core/models/participant_status.py
@@ -15,17 +15,26 @@
 
 """Domain representation of a participant RM-state status record."""
 
-from typing import Literal
+from typing import Any, Literal
 
-from pydantic import ConfigDict, Field, field_serializer, field_validator
+from pydantic import (
+    ConfigDict,
+    Field,
+    field_serializer,
+    field_validator,
+    model_validator,
+)
 from pydantic.alias_generators import to_camel
 
-from vultron.core.states.rm import RM
-from vultron.core.states.cs import CS_vfd
 from vultron.core.states.participant_embargo_consent import PEC
 from vultron.enums.roles import CVDRole
 from vultron.core.models.base import CoreObject, NonEmptyString
 from vultron.core.models.case_status import CaseStatus
+from vultron.core.models.dimensions import (
+    PecDimension,
+    RmDimension,
+    VfdDimension,
+)
 
 
 def coerce_em_consent_state(value: object) -> PEC | None:
@@ -76,7 +85,10 @@ class ParticipantStatus(CoreObject):
     associated with a specific case.
 
     ``case_status`` embeds the participant's perspective on the case-level
-    state (em_state and pxa_state) via a nested :class:`CaseStatus` object.
+    state (em and pxa) via a nested :class:`CaseStatus` object.
+
+    ``rm``, ``vfd``, and ``consent`` are dimension objects that own the RM,
+    VFD, and PEC state machines respectively (ADR-0036, SDO-03-002).
     """
 
     model_config = ConfigDict(alias_generator=to_camel)
@@ -87,45 +99,53 @@ class ParticipantStatus(CoreObject):
         serialization_alias="type",
     )
     context: NonEmptyString  # pyright: ignore[reportGeneralTypeIssues]
-    rm_state: RM = RM.START
-    vfd_state: CS_vfd = CS_vfd.vfd
+    rm: RmDimension = Field(default_factory=RmDimension)
+    vfd: VfdDimension = Field(default_factory=VfdDimension)
     case_engagement: bool = True
     embargo_adherence: bool = True
-    em_consent_state: PEC | None = None
+    consent: PecDimension | None = None
     cvd_role: list[CVDRole] = Field(default_factory=lambda: [CVDRole.OTHER])
     tracking_id: NonEmptyString | None = None
     case_status: CaseStatus | None = None
 
-    @field_serializer("rm_state")
-    def _serialize_rm_state(self, v: RM) -> str:
-        return v.name
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_flat_fields(cls, data: Any) -> Any:
+        """Accept legacy flat ``rm_state``/``vfd_state``/``em_consent_state`` wire-format inputs.
 
-    @field_serializer("vfd_state")
-    def _serialize_vfd_state(self, v: CS_vfd) -> str:
-        return v.name
+        Handles both snake_case (``rm_state``) and camelCase alias (``rmState``) keys
+        since ``model_validator(mode='before')`` runs before alias normalization.
+        """
+        if not isinstance(data, dict):
+            return data
+        data = dict(data)
+        _SENTINEL = object()
+        rm_raw = data.pop("rm_state", _SENTINEL)
+        if rm_raw is _SENTINEL:
+            rm_raw = data.pop("rmState", _SENTINEL)
+        if rm_raw is not _SENTINEL and rm_raw is not None and "rm" not in data:
+            data["rm"] = {"state": rm_raw}
+        vfd_raw = data.pop("vfd_state", _SENTINEL)
+        if vfd_raw is _SENTINEL:
+            vfd_raw = data.pop("vfdState", _SENTINEL)
+        if (
+            vfd_raw is not _SENTINEL
+            and vfd_raw is not None
+            and "vfd" not in data
+        ):
+            data["vfd"] = {"state": vfd_raw}
+        pec_raw = data.pop("em_consent_state", _SENTINEL)
+        if pec_raw is _SENTINEL:
+            pec_raw = data.pop("emConsentState", _SENTINEL)
+        if pec_raw is not _SENTINEL and "consent" not in data:
+            data["consent"] = (
+                {"state": pec_raw} if pec_raw is not None else None
+            )
+        return data
 
     @field_serializer("cvd_role")
     def _serialize_cvd_role(self, roles: list[CVDRole]) -> list[str]:
         return [role.name for role in roles]
-
-    @field_validator("rm_state", mode="before")
-    @classmethod
-    def _validate_rm_state(cls, v: object) -> RM:
-        if isinstance(v, str):
-            return RM[v]
-        return v  # type: ignore[return-value]
-
-    @field_validator("vfd_state", mode="before")
-    @classmethod
-    def _validate_vfd_state(cls, v: object) -> CS_vfd:
-        if isinstance(v, str):
-            return CS_vfd[v]
-        return v  # type: ignore[return-value]
-
-    @field_validator("em_consent_state", mode="before")
-    @classmethod
-    def _validate_em_consent_state(cls, v: object) -> PEC | None:
-        return coerce_em_consent_state(v)
 
     @field_validator("cvd_role", mode="before")
     @classmethod

--- a/vultron/core/models/protocols.py
+++ b/vultron/core/models/protocols.py
@@ -22,10 +22,10 @@ removed in favour of direct ``isinstance`` checks against core domain classes
 (ADR-0034, DL-05-003).
 """
 
-from typing import Any, Mapping, Protocol, TypeGuard
+from typing import TYPE_CHECKING, Any, Mapping, Protocol, TypeGuard
 
-from vultron.core.states.cs import CS_pxa
-from vultron.core.states.em import EM
+if TYPE_CHECKING:
+    from vultron.core.models.dimensions import EmDimension, PxaDimension
 
 
 class PersistableModel(Protocol):
@@ -43,8 +43,8 @@ class PersistableModel(Protocol):
 
 
 class CaseStatusModel(Protocol):
-    em_state: EM
-    pxa_state: CS_pxa
+    em: "EmDimension"
+    pxa: "PxaDimension"
 
 
 class OutboxCollectionModel(Protocol):

--- a/vultron/core/models/staged_case.py
+++ b/vultron/core/models/staged_case.py
@@ -141,7 +141,7 @@ class EmbargoedCase(Case):
                 "(LST-02-003)."
             )
         try:
-            em_state = self.current_status.em_state
+            em_state = self.current_status.em.state
         except ValueError as exc:
             raise VultronValidationError(
                 "EmbargoedCase requires at least one materialized CaseStatus; "

--- a/vultron/core/services/embargo_lifecycle.py
+++ b/vultron/core/services/embargo_lifecycle.py
@@ -48,6 +48,7 @@ from transitions import MachineError
 
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.case_participant import CaseParticipant
+from vultron.core.models.dimensions import EmDimension
 from vultron.core.ports.case_persistence import CasePersistence
 from vultron.core.states.cs import CS_pxa
 from vultron.core.states.em import EM, EM_Trigger, EMAdapter, create_em_machine
@@ -215,12 +216,12 @@ class EmbargoLifecycle:
         # directly; otherwise read from the case (legacy / non-BT callers).
         caller_owns_em_io = em_before is not None
         if not caller_owns_em_io:
-            em_before = EM(case.current_status.em_state)
+            em_before = case.current_status.em.state
         assert em_before is not None  # guaranteed by the branch above
 
         if transition_mode == TransitionMode.STRICT:
             self._assert_pxa_embargo_eligible(
-                CS_pxa(case.current_status.pxa_state),
+                case.current_status.pxa.state,
                 case_id,
                 "propose embargo",
             )
@@ -249,7 +250,7 @@ class EmbargoLifecycle:
         case_mutated = False
 
         if not caller_owns_em_io and em_after != em_before:
-            case.current_status.em_state = em_after
+            case.current_status.em = EmDimension(state=em_after)
             case_mutated = True
 
         # Idempotent append: normalise existing refs to strings before checking
@@ -337,7 +338,7 @@ class EmbargoLifecycle:
         # directly; otherwise read from the case (legacy / non-BT callers).
         caller_owns_em_io = em_before is not None
         if not caller_owns_em_io:
-            em_before = EM(case.current_status.em_state)
+            em_before = case.current_status.em.state
         assert em_before is not None  # guaranteed by the branch above
         em_after = em_before
         case_mutated = False
@@ -353,7 +354,7 @@ class EmbargoLifecycle:
             # Guard only applies when owner would drive the EM machine (EMB-02-002).
             if transition_mode == TransitionMode.STRICT:
                 self._assert_pxa_embargo_eligible(
-                    CS_pxa(case.current_status.pxa_state),
+                    case.current_status.pxa.state,
                     case_id,
                     "accept embargo invite",
                 )
@@ -368,7 +369,7 @@ class EmbargoLifecycle:
             # When the BT caller owns em I/O, skip the em_state write here —
             # the caller's WriteEmStateNode handles it.
             if not caller_owns_em_io and em_after != em_before:
-                case.current_status.em_state = em_after
+                case.current_status.em = EmDimension(state=em_after)
                 case_mutated = True
             # Sync active_embargo independently: handle OBSERVED mode where
             # em_after == em_before == ACTIVE but active_embargo points elsewhere
@@ -464,7 +465,7 @@ class EmbargoLifecycle:
         # directly; otherwise read from the case (legacy / non-BT callers).
         caller_owns_em_io = em_before is not None
         if not caller_owns_em_io:
-            em_before = EM(case.current_status.em_state)
+            em_before = case.current_status.em.state
         assert em_before is not None  # guaranteed by the branch above
         em_after = em_before
         case_mutated = False
@@ -479,7 +480,7 @@ class EmbargoLifecycle:
                 and em_before == EM.REVISE
             ):
                 self._assert_pxa_embargo_eligible(
-                    CS_pxa(case.current_status.pxa_state),
+                    case.current_status.pxa.state,
                     case_id,
                     "reject embargo revision (use terminate_active_embargo when P/X/A is set)",
                 )
@@ -496,7 +497,7 @@ class EmbargoLifecycle:
             # When the BT caller owns em I/O, skip the em_state write here —
             # the caller's WriteEmStateNode handles it.
             if not caller_owns_em_io and em_after != em_before:
-                case.current_status.em_state = em_after
+                case.current_status.em = EmDimension(state=em_after)
                 case_mutated = True
 
         participant_changes = self._record_actor_pec_rejection(
@@ -564,7 +565,7 @@ class EmbargoLifecycle:
         # directly; otherwise read from the case (legacy / non-BT callers).
         caller_owns_em_io = em_before is not None
         if not caller_owns_em_io:
-            em_before = EM(case.current_status.em_state)
+            em_before = case.current_status.em.state
         assert em_before is not None  # guaranteed by the branch above
 
         # In STRICT mode, require an active embargo to be identified
@@ -586,7 +587,7 @@ class EmbargoLifecycle:
         # When the BT caller owns em I/O, skip the em_state write here —
         # the caller's WriteEmStateNode handles it.
         if not caller_owns_em_io:
-            case.current_status.em_state = em_after
+            case.current_status.em = EmDimension(state=em_after)
         case.active_embargo = None
 
         participant_changes = self._cascade_pec_reset(case)
@@ -651,7 +652,7 @@ class EmbargoLifecycle:
         em_state = (
             em_before
             if em_before is not None
-            else EM(case.current_status.em_state)
+            else case.current_status.em.state
         )
 
         participant_id = case.actor_participant_index.get(actor_id)

--- a/vultron/core/use_cases/_helpers.py
+++ b/vultron/core/use_cases/_helpers.py
@@ -275,7 +275,7 @@ def update_participant_rm_state(
         if p_actor_id == actor_id:
             if participant.participant_statuses:
                 latest = participant.participant_statuses[-1]
-                if latest.rm_state == new_rm_state:
+                if latest.rm.state == new_rm_state:
                     logger.info(
                         "Participant '%s' already in RM state %s in case '%s' "
                         "(idempotent)",

--- a/vultron/core/use_cases/query/action_rules.py
+++ b/vultron/core/use_cases/query/action_rules.py
@@ -103,16 +103,16 @@ class GetActionRulesUseCase:
         vfd_state: CS_vfd = CS_vfd.vfd
         if participant.participant_statuses:
             latest = participant.participant_statuses[-1]
-            rm_state = latest.rm_state
-            vfd_state = latest.vfd_state
+            rm_state = latest.rm.state
+            vfd_state = latest.vfd.state
 
         # 4. Get shared case states from the current CaseStatus
         em_state: EM = EM.EMBARGO_MANAGEMENT_NONE
         pxa_state: CS_pxa = CS_pxa.pxa
         if has_case_statuses(case):
             current_cs = case.current_status
-            em_state = current_cs.em_state
-            pxa_state = current_cs.pxa_state
+            em_state = current_cs.em.state
+            pxa_state = current_cs.pxa.state
 
         # 5. Build the combined 6-character CS state string (VFD + PXA)
         cs_state = vfd_state.name + pxa_state.name

--- a/vultron/core/use_cases/received/embargo.py
+++ b/vultron/core/use_cases/received/embargo.py
@@ -23,7 +23,6 @@ from vultron.core.use_cases._helpers import (
 from vultron.core.models.case import VulnerabilityCase
 from vultron.core.models.protocols import PersistableModel
 from vultron.core.states.cs import (
-    CS_pxa,
     is_pxa_attacks_observed,
     is_pxa_exploit_public,
     is_pxa_public_aware,
@@ -45,10 +44,7 @@ def _pxa_embargo_ineligible(dl: CasePersistence, case_id: str) -> bool:
     case = dl.read(case_id)
     if not isinstance(case, VulnerabilityCase):
         return False
-    try:
-        pxa_state = CS_pxa(case.current_status.pxa_state)
-    except ValueError:
-        return False
+    pxa_state = case.current_status.pxa.state
     return (
         is_pxa_public_aware(pxa_state)
         or is_pxa_exploit_public(pxa_state)

--- a/vultron/wire/as2/extractor/_builders.py
+++ b/vultron/wire/as2/extractor/_builders.py
@@ -13,9 +13,19 @@ from typing import Any, Callable
 from vultron.core.models._helpers import _now_utc as _core_now_utc
 from vultron.core.models.base import VultronObject
 from vultron.core.models.case_ledger_entry import VultronCaseLedgerEntry
+from vultron.core.models.dimensions import (
+    EmDimension,
+    PecDimension,
+    PxaDimension,
+    RmDimension,
+    VfdDimension,
+)
 from vultron.core.models.enums import VultronObjectType as VOtype
 from vultron.core.models.participant_status import coerce_cvd_roles
+from vultron.core.states.cs import CS_pxa, CS_vfd
+from vultron.core.states.em import EM
 from vultron.core.states.participant_embargo_consent import PEC
+from vultron.core.states.rm import RM
 from vultron.core.models.vultron_types import (
     CaseStatus,
     EmbargoEvent,
@@ -319,6 +329,48 @@ def _build_case_ledger_entry_object(obj: object) -> dict[str, Any]:
     return {}
 
 
+def _coerce_em(raw: object) -> EM:
+    if isinstance(raw, EM):
+        return raw
+    if isinstance(raw, str):
+        return EM[raw] if raw in EM.__members__ else EM(raw)
+    return EM.NO_EMBARGO
+
+
+def _coerce_pxa(raw: object) -> CS_pxa:
+    if isinstance(raw, CS_pxa):
+        return raw
+    if isinstance(raw, str):
+        return CS_pxa[raw]
+    return CS_pxa.pxa
+
+
+def _coerce_rm(raw: object) -> RM:
+    if isinstance(raw, RM):
+        return raw
+    if isinstance(raw, str):
+        return RM[raw]
+    return RM.START
+
+
+def _coerce_vfd(raw: object) -> CS_vfd:
+    if isinstance(raw, CS_vfd):
+        return raw
+    if isinstance(raw, str):
+        return CS_vfd[raw]
+    return CS_vfd.vfd
+
+
+def _coerce_pec_or_none(raw: object) -> PEC | None:
+    if raw is None:
+        return None
+    if isinstance(raw, PEC):
+        return raw
+    if isinstance(raw, str):
+        return PEC[raw]
+    return None
+
+
 def _build_case_status_object(obj: object) -> dict[str, Any]:
     object_id = _get_id(obj)
     case_context = _get_id(getattr(obj, "context", None))
@@ -330,10 +382,12 @@ def _build_case_status_object(obj: object) -> dict[str, Any]:
                 name=getattr(obj, "name", None),
                 context=case_context,
                 attributed_to=attributed_to,
-                em_state=getattr(obj, "em_state", None)
-                or CaseStatus.model_fields["em_state"].default,
-                pxa_state=getattr(obj, "pxa_state", None)
-                or CaseStatus.model_fields["pxa_state"].default,
+                em=EmDimension(
+                    state=_coerce_em(getattr(obj, "em_state", None))
+                ),
+                pxa=PxaDimension(
+                    state=_coerce_pxa(getattr(obj, "pxa_state", None))
+                ),
             )
         }
     return {}
@@ -345,7 +399,7 @@ def _build_participant_status_object(obj: object) -> dict[str, Any]:
     wire_case_status = getattr(obj, "case_status", None)
     if object_id:
         # Extract embedded CaseStatus into a CaseStatus core object so
-        # that pxa_state and em_state are propagated across the wire boundary.
+        # that pxa and em are propagated across the wire boundary.
         core_case_status: CaseStatus | None = None
         if wire_case_status is not None:
             cs_id = _get_id(wire_case_status)
@@ -360,25 +414,37 @@ def _build_participant_status_object(obj: object) -> dict[str, Any]:
                     id_=cs_id,
                     context=cs_context,
                     attributed_to=cs_attributed_to,
-                    em_state=getattr(wire_case_status, "em_state", None)
-                    or CaseStatus.model_fields["em_state"].default,
-                    pxa_state=getattr(wire_case_status, "pxa_state", None)
-                    or CaseStatus.model_fields["pxa_state"].default,
+                    em=EmDimension(
+                        state=_coerce_em(
+                            getattr(wire_case_status, "em_state", None)
+                        )
+                    ),
+                    pxa=PxaDimension(
+                        state=_coerce_pxa(
+                            getattr(wire_case_status, "pxa_state", None)
+                        )
+                    ),
                 )
+        raw_pec = getattr(obj, "em_consent_state", None)
+        pec_val = _coerce_pec_or_none(
+            PEC[raw_pec] if isinstance(raw_pec, str) else raw_pec
+        )
         return {
             "object_": ParticipantStatus(
                 id_=object_id,
                 name=getattr(obj, "name", None),
                 context=ctx,
                 attributed_to=_get_id(getattr(obj, "attributed_to", None)),
-                rm_state=getattr(obj, "rm_state", None)
-                or ParticipantStatus.model_fields["rm_state"].default,
-                vfd_state=getattr(obj, "vfd_state", None)
-                or ParticipantStatus.model_fields["vfd_state"].default,
-                em_consent_state=(
-                    PEC[getattr(obj, "em_consent_state")]
-                    if isinstance(getattr(obj, "em_consent_state", None), str)
-                    else getattr(obj, "em_consent_state", None)
+                rm=RmDimension(
+                    state=_coerce_rm(getattr(obj, "rm_state", None))
+                ),
+                vfd=VfdDimension(
+                    state=_coerce_vfd(getattr(obj, "vfd_state", None))
+                ),
+                consent=(
+                    PecDimension(state=pec_val)
+                    if pec_val is not None
+                    else None
                 ),
                 cvd_role=coerce_cvd_roles(
                     getattr(obj, "cvd_role", getattr(obj, "cvd_roles", None))

--- a/vultron/wire/as2/factories/case.py
+++ b/vultron/wire/as2/factories/case.py
@@ -108,7 +108,11 @@ def _project_case_to_stub(
         current_status = case.current_status
     except (ValueError, AttributeError):
         return VulnerabilityCaseStub(id_=case_id)
-    em_state = getattr(current_status, "em_state", None)
+    # Support both core CaseStatus (.em.state) and wire as_CaseStatus (.em_state)
+    if hasattr(current_status, "em") and hasattr(current_status.em, "state"):
+        em_state = current_status.em.state
+    else:
+        em_state = getattr(current_status, "em_state", None)
     active_embargo_uri = getattr(case, "active_embargo", None)
     if em_state != EM.ACTIVE or active_embargo_uri is None:
         return VulnerabilityCaseStub(id_=case_id)

--- a/vultron/wire/as2/vocab/objects/case_participant.py
+++ b/vultron/wire/as2/vocab/objects/case_participant.py
@@ -36,6 +36,7 @@ from vultron.core.models.case_participant import (
     VultronParticipant,
 )
 from vultron.core.models.participant_status import (
+    ParticipantStatus as CoreParticipantStatus,
     coerce_cvd_roles,
     coerce_em_consent_state,
 )
@@ -304,7 +305,27 @@ class as_CaseParticipant(VultronAS2Object):
 
     @classmethod
     def from_core(cls, core_obj: CoreCaseParticipant) -> "as_CaseParticipant":
-        return cast("as_CaseParticipant", super().from_core(core_obj))
+        data = core_obj.model_dump(mode="json")
+        from vultron.wire.as2.vocab.objects.base import _strip_core_context
+
+        _strip_core_context(data)
+        # Project each CoreParticipantStatus via as_ParticipantStatus.from_core
+        # so that dimension objects are flattened to wire flat fields.
+        data["participant_statuses"] = [
+            (
+                WireParticipantStatus.from_core(
+                    CoreParticipantStatus.model_validate(ps)
+                )
+                if isinstance(ps, dict)
+                else (
+                    WireParticipantStatus.from_core(ps)
+                    if isinstance(ps, CoreParticipantStatus)
+                    else ps
+                )
+            )
+            for ps in (data.get("participant_statuses") or [])
+        ]
+        return cast("as_CaseParticipant", cls.model_validate(data))
 
     def to_core(self) -> CoreCaseParticipant:
         data = self._to_core_data()

--- a/vultron/wire/as2/vocab/objects/case_status.py
+++ b/vultron/wire/as2/vocab/objects/case_status.py
@@ -14,7 +14,7 @@ Provides Case Status objects for the Vultron ActivityStreams Vocabulary.
 #  Created, in part, with funding and support from the United States Government
 #  (see Acknowledgments file). This program may include and/or can make use of
 #  certain third party source code, object code, documentation and other files
-#  (“Third Party Software”). See LICENSE.md for more details.
+#  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
@@ -26,6 +26,13 @@ from vultron.core.models.case_status import CaseStatus as CoreCaseStatus
 from vultron.core.models.participant_status import (
     ParticipantStatus as CoreParticipantStatus,
     coerce_cvd_roles,
+)
+from vultron.core.models.dimensions import (
+    EmDimension,
+    PecDimension,
+    PxaDimension,
+    RmDimension,
+    VfdDimension,
 )
 from vultron.core.states.em import EM
 from vultron.core.states.rm import RM
@@ -39,8 +46,51 @@ from vultron.wire.as2.vocab.base.objects.base import as_Object
 from vultron.wire.as2.vocab.objects.base import (
     VultronAS2Object,
     _scalar_ref_id_or_value,
-    _strip_core_context,
 )
+
+
+def _coerce_em(v: object) -> EM:
+    if isinstance(v, EM):
+        return v
+    if isinstance(v, str):
+        if v in EM.__members__:
+            return EM[v]
+        return EM(v)
+    return EM.NO_EMBARGO
+
+
+def _coerce_pxa(v: object) -> CS_pxa:
+    if isinstance(v, CS_pxa):
+        return v
+    if isinstance(v, str):
+        return CS_pxa[v]
+    return CS_pxa.pxa
+
+
+def _coerce_rm(v: object) -> RM:
+    if isinstance(v, RM):
+        return v
+    if isinstance(v, str):
+        return RM[v]
+    return RM.START
+
+
+def _coerce_vfd(v: object) -> CS_vfd:
+    if isinstance(v, CS_vfd):
+        return v
+    if isinstance(v, str):
+        return CS_vfd[v]
+    return CS_vfd.vfd
+
+
+def _coerce_pec_or_none(v: object) -> PEC | None:
+    if v is None:
+        return None
+    if isinstance(v, PEC):
+        return v
+    if isinstance(v, str):
+        return PEC[v]
+    return None
 
 
 class as_CaseStatus(VultronAS2Object):
@@ -66,32 +116,59 @@ class as_CaseStatus(VultronAS2Object):
     def serialize_pxa_state(self, pxa_state: CS_pxa) -> str:
         return pxa_state.name
 
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_core_dimension_format(cls, data: object) -> object:
+        """Map core dimension-object format (``em: {state: ...}``) to flat wire fields."""
+        if not isinstance(data, dict):
+            return data
+        data = dict(data)
+        if (
+            "em" in data
+            and isinstance(data["em"], dict)
+            and "em_state" not in data
+        ):
+            data["em_state"] = data.pop("em", {}).get("state")
+        if (
+            "pxa" in data
+            and isinstance(data["pxa"], dict)
+            and "pxa_state" not in data
+        ):
+            data["pxa_state"] = data.pop("pxa", {}).get("state")
+        return data
+
     @field_validator("em_state", mode="before")
-    def validate_em_state(cls, v):
-        if isinstance(v, str):
-            #
-            if v in EM.__members__:
-                return EM[v]
-            return EM(v)
-        return v
+    @classmethod
+    def validate_em_state(cls, v: object) -> EM:
+        return _coerce_em(v)
 
     @field_validator("pxa_state", mode="before")
-    def validate_pxa_state(cls, v):
-        if isinstance(v, str):
-            return CS_pxa[v]
-        return v
+    @classmethod
+    def validate_pxa_state(cls, v: object) -> CS_pxa:
+        return _coerce_pxa(v)
 
     @model_validator(mode="after")
-    def set_name(self):
+    def set_name(self) -> "as_CaseStatus":
         if self.name is None:
             self.name = " ".join([self.em_state.name, self.pxa_state.name])
         return self
 
     @classmethod
     def from_core(cls, core_obj: CoreCaseStatus) -> "as_CaseStatus":
-        data = core_obj.model_dump(mode="json")
-        _strip_core_context(data)
-        return cast("as_CaseStatus", cls.model_validate(data))
+        # Project dimension objects to flat EM/PXA enum fields for wire format.
+        return cast(
+            "as_CaseStatus",
+            cls.model_validate(
+                {
+                    "id": core_obj.id_,
+                    "type": VO_type.CASE_STATUS,
+                    "context": core_obj.context,
+                    "attributed_to": core_obj.attributed_to,
+                    "em_state": core_obj.em.state.name,
+                    "pxa_state": core_obj.pxa.state.name,
+                }
+            ),
+        )
 
     def to_core(self) -> CoreCaseStatus:
         data = self._to_core_data()
@@ -99,8 +176,11 @@ class as_CaseStatus(VultronAS2Object):
             data.get("attributed_to")
         )
         data["context"] = _scalar_ref_id_or_value(data.get("context"))
-        if isinstance(data.get("pxa_state"), str):
-            data["pxa_state"] = CS_pxa[data["pxa_state"]]
+        # Map wire flat fields to dimension objects for the core model.
+        em_raw = data.pop("em_state", None)
+        pxa_raw = data.pop("pxa_state", None)
+        data["em"] = EmDimension(state=_coerce_em(em_raw))
+        data["pxa"] = PxaDimension(state=_coerce_pxa(pxa_raw))
         return CoreCaseStatus.model_validate(data)
 
 
@@ -138,6 +218,34 @@ class as_ParticipantStatus(VultronAS2Object):
     tracking_id: NonEmptyString | None = None
     case_status: as_CaseStatus | None = None
 
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_core_dimension_format(cls, data: object) -> object:
+        """Map core dimension-object format back to flat wire fields on round-trip."""
+        if not isinstance(data, dict):
+            return data
+        data = dict(data)
+        if (
+            "rm" in data
+            and isinstance(data["rm"], dict)
+            and "rm_state" not in data
+        ):
+            data["rm_state"] = data.pop("rm", {}).get("state")
+        if (
+            "vfd" in data
+            and isinstance(data["vfd"], dict)
+            and "vfd_state" not in data
+        ):
+            data["vfd_state"] = data.pop("vfd", {}).get("state")
+        if (
+            "consent" in data
+            and isinstance(data["consent"], dict)
+            and "emConsentState" not in data
+            and "em_consent_state" not in data
+        ):
+            data["emConsentState"] = data.pop("consent", {}).get("state")
+        return data
+
     @field_serializer("rm_state")
     def serialize_rm_state(self, rm_state: RM) -> str:
         return rm_state.name
@@ -147,27 +255,23 @@ class as_ParticipantStatus(VultronAS2Object):
         return vfd_state.name
 
     @field_validator("rm_state", mode="before")
-    def validate_rm_state(cls, v):
-        if isinstance(v, str):
-            return RM[v]
-        return v
+    @classmethod
+    def validate_rm_state(cls, v: object) -> RM:
+        return _coerce_rm(v)
 
     @field_validator("vfd_state", mode="before")
-    def validate_vfd_state(cls, v):
-        if isinstance(v, str):
-            return CS_vfd[v]
-        return v
+    @classmethod
+    def validate_vfd_state(cls, v: object) -> CS_vfd:
+        return _coerce_vfd(v)
 
     @field_validator("em_consent_state", mode="before")
-    def validate_em_consent_state(cls, v):
-        if v is None:
-            return None
-        if isinstance(v, str):
-            return PEC[v]
-        return v
+    @classmethod
+    def validate_em_consent_state(cls, v: object) -> PEC | None:
+        return _coerce_pec_or_none(v)
 
     @field_validator("cvd_role", mode="before")
-    def validate_cvd_role(cls, v):
+    @classmethod
+    def validate_cvd_role(cls, v: object) -> list[CVDRole]:
         return coerce_cvd_roles(v)
 
     @field_serializer("cvd_role")
@@ -175,7 +279,7 @@ class as_ParticipantStatus(VultronAS2Object):
         return [role.name for role in cvd_role]
 
     @model_validator(mode="after")
-    def set_name(self):
+    def set_name(self) -> "as_ParticipantStatus":
         if self.name is None:
             parts = [self.rm_state.name, self.vfd_state.name]
             if self.case_status is not None:
@@ -188,19 +292,30 @@ class as_ParticipantStatus(VultronAS2Object):
     def from_core(
         cls, core_obj: CoreParticipantStatus
     ) -> "as_ParticipantStatus":
-        data = core_obj.model_dump(mode="json")
-        _strip_core_context(data)
-        case_status = data.get("case_status")
-        if isinstance(case_status, str):
-            # Legacy: case_status stored as bare ID string
-            data["case_status"] = as_CaseStatus(
-                id_=case_status,
-                context=data.get("context"),
-                attributed_to=data.get("attributed_to"),
+        # Project dimension objects to flat enum fields for wire format.
+        consent_state = (
+            core_obj.consent.state if core_obj.consent is not None else None
+        )
+        wire_data: dict = {
+            "id": core_obj.id_,
+            "type": VO_type.PARTICIPANT_STATUS,
+            "context": core_obj.context,
+            "attributed_to": core_obj.attributed_to,
+            "rm_state": core_obj.rm.state.name,
+            "vfd_state": core_obj.vfd.state.name,
+            "case_engagement": core_obj.case_engagement,
+            "embargo_adherence": core_obj.embargo_adherence,
+            "emConsentState": (
+                consent_state.name if consent_state is not None else None
+            ),
+            "cvdRole": [r.name for r in core_obj.cvd_role],
+            "tracking_id": core_obj.tracking_id,
+        }
+        if core_obj.case_status is not None:
+            wire_data["case_status"] = as_CaseStatus.from_core(
+                core_obj.case_status
             )
-        # If case_status is a dict (from CoreCaseStatus serialisation),
-        # cls.model_validate will hydrate it into a as_CaseStatus instance.
-        return cls.model_validate(data)
+        return cast("as_ParticipantStatus", cls.model_validate(wire_data))
 
     def to_core(self) -> CoreParticipantStatus:
         data = self._to_core_data()
@@ -208,27 +323,35 @@ class as_ParticipantStatus(VultronAS2Object):
             data.get("attributed_to")
         )
         data["context"] = _scalar_ref_id_or_value(data.get("context"))
+        # Map wire flat fields to dimension objects for the core model.
+        rm_raw = data.pop("rm_state", None)
+        vfd_raw = data.pop("vfd_state", None)
+        pec_raw = data.pop("em_consent_state", None)
+        data["rm"] = RmDimension(state=_coerce_rm(rm_raw))
+        data["vfd"] = VfdDimension(state=_coerce_vfd(vfd_raw))
+        pec_coerced = _coerce_pec_or_none(pec_raw)
+        data["consent"] = (
+            PecDimension(state=pec_coerced)
+            if pec_coerced is not None
+            else None
+        )
         # Convert embedded CaseStatus wire object (or its serialised dict) to
-        # CoreCaseStatus so pxa_state and em_state cross the boundary.
+        # CoreCaseStatus so em and pxa cross the boundary.
         wire_case_status = data.get("case_status")
         if isinstance(wire_case_status, as_CaseStatus):
             data["case_status"] = wire_case_status.to_core()
         elif isinstance(wire_case_status, dict):
-            # _to_core_data() with round_trip=True serialises nested objects
-            # as dicts; re-validate and convert.
             cs_obj = as_CaseStatus.model_validate(wire_case_status)
             data["case_status"] = cs_obj.to_core()
         else:
             data["case_status"] = None
-        if isinstance(data.get("vfd_state"), str):
-            data["vfd_state"] = CS_vfd[data["vfd_state"]]
         return CoreParticipantStatus.model_validate(data)
 
 
 as_ParticipantStatusRef: TypeAlias = ActivityStreamRef[as_ParticipantStatus]
 
 
-def main():
+def main() -> None:
     cs = as_CaseStatus()
     print(f"### {cs.type_} ###")
     print()


### PR DESCRIPTION
## Summary

- Introduces five dimension classes (`EmDimension`, `PxaDimension`, `RmDimension`, `VfdDimension`, `PecDimension`) in `vultron/core/models/dimensions.py`, each wrapping a single state-machine enum with `state`, `transition()`, and derived predicates (`is_active`, `is_proposed`, etc.)
- Replaces flat `em_state`/`pxa_state`/`rm_state`/`vfd_state`/`emConsentState` fields on core `CaseStatus` and `ParticipantStatus` with typed dimension-object fields (`em: EmDimension`, `pxa: PxaDimension`, `rm: RmDimension`, `vfd: VfdDimension`, `consent: PecDimension | None`)
- Wire-layer models (`as_CaseStatus`, `as_ParticipantStatus`) retain flat fields; round-trip adapters (`_migrate_flat_fields` on core, `_migrate_core_dimension_format` on wire) ensure JSON compatibility in both directions

## Changes

- **`vultron/core/models/dimensions.py`** (new): five dimension classes with `field_validator`/`field_serializer` for alias-safe coercion on all three StrEnum types that have canonical aliases (`EM.NO_EMBARGO = EM.NONE`, etc.)
- **`vultron/core/models/case_status.py`**: `CaseStatus` fields changed from flat enums to dimension objects; `_migrate_flat_fields` model_validator accepts both snake_case and camelCase legacy flat fields
- **`vultron/core/models/participant_status.py`**: `ParticipantStatus` fields changed; `consent: PecDimension | None`
- **`vultron/wire/as2/vocab/objects/case_status.py`**: `as_CaseStatus` and `as_ParticipantStatus` gain `_migrate_core_dimension_format` to map core JSON (`rm: {"state": "CLOSED"}`) back to flat wire fields during REST API round-trips
- **BT behavior nodes**: updated to access `.em.state`, `.pxa.state`, `.rm.state`, `.vfd.state` on core types via dimension objects; `getattr`/`hasattr` guards for polymorphic code paths that may receive wire or core objects
- **Test suite**: 35+ test files updated — `cast(VulnerabilityCase, dl.read(...))` replaces incorrect `cast(as_VulnerabilityCase, ...)`, constructor calls updated from `rm_state=` flat kwargs to `rm=RmDimension(state=...)`, unused wire-type imports removed

## Verification

- `uv run pytest`: 5219 passed, 0 failed
- `uv run mypy`: 3 pre-existing errors only (no new errors)
- `uv run pyright`: 0 errors
- `uv run flake8`: clean
- Demo regression (`test_case_manager_does_not_block_rm_closure_check`) fixed by `_migrate_core_dimension_format` on `as_ParticipantStatus`

Closes #1563

🤖 Generated with [Claude Code](https://claude.com/claude-code)