### PR TITLE
refactor(#1509): migrate all inline DataLayer guards to _require_* helpers

### DIFF
--- a/test/core/behaviors/test_helpers.py
+++ b/test/core/behaviors/test_helpers.py
@@ -615,6 +615,119 @@ def test_condition_logger_name_includes_class(bridge, datalayer):
     assert "AlwaysTrueCondition" in node.logger.name
 
 
+# Tests for _require_* guard helpers on DataLayerCondition
+
+
+def test_condition_require_datalayer_returns_failure_when_none():
+    """_require_datalayer() returns FAILURE when datalayer is not set."""
+    node = AlwaysTrueCondition(name="GuardTest")
+    # datalayer defaults to None (no bridge/setup)
+    result = node._require_datalayer()
+    assert result == Status.FAILURE
+    assert node.feedback_message == "DataLayer not available"
+
+
+def test_condition_require_datalayer_returns_none_when_set(datalayer):
+    """_require_datalayer() returns None (no failure) when datalayer is set."""
+    node = AlwaysTrueCondition(name="GuardTest")
+    node.datalayer = datalayer
+    result = node._require_datalayer()
+    assert result is None
+
+
+def test_condition_require_datalayer_and_actor_returns_failure_when_both_none():
+    """_require_datalayer_and_actor() returns FAILURE when both are None."""
+    node = AlwaysTrueCondition(name="GuardTest")
+    result = node._require_datalayer_and_actor()
+    assert result == Status.FAILURE
+
+
+def test_condition_require_datalayer_and_actor_returns_failure_when_actor_none(
+    datalayer,
+):
+    """_require_datalayer_and_actor() returns FAILURE when only actor_id is None."""
+    node = AlwaysTrueCondition(name="GuardTest")
+    node.datalayer = datalayer
+    node.actor_id = None
+    result = node._require_datalayer_and_actor()
+    assert result == Status.FAILURE
+
+
+def test_condition_require_datalayer_and_actor_returns_failure_when_datalayer_none():
+    """_require_datalayer_and_actor() returns FAILURE when only datalayer is None."""
+    node = AlwaysTrueCondition(name="GuardTest")
+    node.actor_id = "https://example.org/actors/a1"
+    result = node._require_datalayer_and_actor()
+    assert result == Status.FAILURE
+
+
+def test_condition_require_datalayer_and_actor_returns_none_when_both_set(
+    datalayer,
+):
+    """_require_datalayer_and_actor() returns None when both datalayer and actor_id are set."""
+    node = AlwaysTrueCondition(name="GuardTest")
+    node.datalayer = datalayer
+    node.actor_id = "https://example.org/actors/a1"
+    result = node._require_datalayer_and_actor()
+    assert result is None
+
+
+# Tests for _require_* guard helpers on DataLayerAction
+
+
+def test_action_require_datalayer_returns_failure_when_none():
+    """DataLayerAction._require_datalayer() returns FAILURE when datalayer is not set."""
+    node = NoOpAction(name="GuardTest")
+    result = node._require_datalayer()
+    assert result == Status.FAILURE
+    assert node.feedback_message == "DataLayer not available"
+
+
+def test_action_require_datalayer_returns_none_when_set(datalayer):
+    """DataLayerAction._require_datalayer() returns None when datalayer is set."""
+    node = NoOpAction(name="GuardTest")
+    node.datalayer = datalayer
+    result = node._require_datalayer()
+    assert result is None
+
+
+def test_action_require_datalayer_and_actor_returns_failure_when_none():
+    """DataLayerAction._require_datalayer_and_actor() returns FAILURE when both None."""
+    node = NoOpAction(name="GuardTest")
+    result = node._require_datalayer_and_actor()
+    assert result == Status.FAILURE
+
+
+def test_action_require_datalayer_and_actor_returns_none_when_both_set(
+    datalayer,
+):
+    """DataLayerAction._require_datalayer_and_actor() returns None when both set."""
+    node = NoOpAction(name="GuardTest")
+    node.datalayer = datalayer
+    node.actor_id = "https://example.org/actors/a1"
+    result = node._require_datalayer_and_actor()
+    assert result is None
+
+
+def test_action_require_factory_returns_failure_when_none():
+    """DataLayerAction._require_factory() returns FAILURE when factory is not set."""
+    node = NoOpAction(name="GuardTest")
+    result = node._require_factory()
+    assert result == Status.FAILURE
+    assert node.feedback_message == "trigger_activity_factory not available"
+
+
+def test_action_require_factory_returns_none_when_set():
+    """DataLayerAction._require_factory() returns None when factory is set."""
+    from unittest.mock import MagicMock
+    from vultron.core.ports.trigger_activity import TriggerActivityPort
+
+    node = NoOpAction(name="GuardTest")
+    node.trigger_activity_factory = MagicMock(spec=TriggerActivityPort)
+    result = node._require_factory()
+    assert result is None
+
+
 def test_action_logger_emits_via_caplog(bridge, datalayer, caplog):
     """Log messages from BT action nodes propagate to caplog (not silently dropped)."""
     import logging

--- a/vultron/core/behaviors/case/accept_case_proposal_received_tree.py
+++ b/vultron/core/behaviors/case/accept_case_proposal_received_tree.py
@@ -59,9 +59,9 @@ class _RecordCaseActorAcceptanceNode(DataLayerAction):
         super().setup(**kwargs)
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         link_id = VultronReportCaseLink.build_id(self._report_id)
         link = self.datalayer.read(link_id)

--- a/vultron/core/behaviors/case/accept_invite_tree.py
+++ b/vultron/core/behaviors/case/accept_invite_tree.py
@@ -176,9 +176,9 @@ class CheckInviteeNotAlreadyParticipantNode(DataLayerCondition):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         case = self.datalayer.read(self.case_id)
         if not isinstance(case, VulnerabilityCase):
@@ -317,9 +317,9 @@ class CreateInviteeParticipantAtAcceptedNode(DataLayerAction):
             return []
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         case = self.blackboard.get("invitee_case")
         if not isinstance(case, VulnerabilityCase):
@@ -552,9 +552,9 @@ class PersistInviteeParticipantNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         if self.blackboard.get("invitee_already_participant"):
             return Status.SUCCESS
@@ -631,12 +631,10 @@ class BackfillCanonicalLedgerToInviteeNode(DataLayerAction):
         return entries[-1].log_index if entries else -1
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
-        if self.actor_id is None:
-            self.logger.error("%s: actor_id not available", self.name)
-            return Status.FAILURE
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
         if self._sync_port is None:
             self.logger.error(
                 "%s: sync_port not injected; cannot perform join-time backfill",
@@ -751,11 +749,10 @@ class EmitAnnounceCaseToInviteeNode(DataLayerAction):
         self.invitee_id = invitee_id
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.logger.error(
-                "%s: DataLayer or actor_id not available", self.name
-            )
-            return Status.FAILURE
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
 
         factory = self.trigger_activity_factory
         if factory is None:

--- a/vultron/core/behaviors/case/case_proposal_received_tree.py
+++ b/vultron/core/behaviors/case/case_proposal_received_tree.py
@@ -79,8 +79,9 @@ class _CheckMarkerExistsNode(DataLayerAction):
         self._proposal_id = proposal_id
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         marker_id = PendingCreateCaseActivity.build_id(self._proposal_id)
         existing = self.datalayer.read(marker_id)
@@ -123,8 +124,9 @@ class _LoadExistingCaseNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         if self._report_id is None:
             return Status.FAILURE
@@ -166,9 +168,10 @@ class _CreateCaseFromProposalNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.feedback_message = "DataLayer or actor_id not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
 
         case = VultronCase(attributed_to=self.actor_id)
         if self._report_id is not None:
@@ -235,9 +238,10 @@ class _EmitAcceptCaseProposalNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.feedback_message = "DataLayer or actor_id not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
 
         try:
             case_id: str | None = self.blackboard.get("case_id")
@@ -300,9 +304,10 @@ class _EmitCreateVulnerabilityCaseNode(DataLayerAction):
         self._vendor_uri = vendor_uri
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.feedback_message = "DataLayer or actor_id not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
 
         # Read the pre-built payload from the marker to guarantee id_ consistency
         # with CP-05-005 retry logic.
@@ -398,9 +403,10 @@ class _WriteCreateCaseMarkerNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.feedback_message = "DataLayer or actor_id not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
 
         try:
             case_id = self.blackboard.get("case_id")

--- a/vultron/core/behaviors/case/create_case_trigger_tree.py
+++ b/vultron/core/behaviors/case/create_case_trigger_tree.py
@@ -49,10 +49,10 @@ class _CreateCaseRecordNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.feedback_message = "DataLayer or actor_id not available"
-            return Status.FAILURE
-
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
         case = VultronCase(
             name=self._case_name,
             content=self._case_content,

--- a/vultron/core/behaviors/case/nodes/actor.py
+++ b/vultron/core/behaviors/case/nodes/actor.py
@@ -145,13 +145,11 @@ class EmitInviteActorToCaseNode(DataLayerAction):
         return activity_id, activity_dict
 
     def update(self) -> Status:
-        fail = self._require_datalayer_and_actor()
-        if fail is not None:
-            return fail
-        fail = self._require_factory()
-        if fail is not None:
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        if (f := self._require_factory()) is not None:
             self.logger.error(self.feedback_message)
-            return fail
+            return f
 
         try:
             activity_id, activity_dict = self._emit(
@@ -201,13 +199,11 @@ class EmitAcceptCaseInviteNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        fail = self._require_datalayer_and_actor()
-        if fail is not None:
-            return fail
-        fail = self._require_factory()
-        if fail is not None:
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        if (f := self._require_factory()) is not None:
             self.logger.error(self.feedback_message)
-            return fail
+            return f
 
         try:
             activity_id, activity_dict = self._emit()
@@ -260,10 +256,9 @@ class AcceptCaseOwnershipTransferNode(DataLayerAction):
         return case
 
     def update(self) -> Status:
-        fail = self._require_datalayer()
-        if fail is not None:
+        if (f := self._require_datalayer()) is not None:
             self.logger.error("%s: DataLayer not available", self.name)
-            return fail
+            return f
 
         case = self._read_case()
         if case is None:
@@ -410,13 +405,11 @@ class ProposeCaseToActorNode(DataLayerAction):
         return activity_id
 
     def update(self) -> Status:
-        fail = self._require_datalayer_and_actor()
-        if fail is not None:
-            return fail
-        fail = self._require_factory()
-        if fail is not None:
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        if (f := self._require_factory()) is not None:
             self.logger.error("%s: %s", self.name, self.feedback_message)
-            return fail
+            return f
 
         ids = self._read_blackboard_ids()
         if ids is None:

--- a/vultron/core/behaviors/case/nodes/announce.py
+++ b/vultron/core/behaviors/case/nodes/announce.py
@@ -60,11 +60,9 @@ class SeedAnnouncedCaseNode(DataLayerAction):
         self._request = request
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
-
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         # Local import avoids a behaviors → use_cases circular dependency.
         # The helpers are pure utility functions with no BT knowledge.
         from vultron.core.use_cases.received.actor.announce import (

--- a/vultron/core/behaviors/case/nodes/case_participant_received.py
+++ b/vultron/core/behaviors/case/nodes/case_participant_received.py
@@ -52,11 +52,9 @@ class AddCaseParticipantToCaseReceivedNode(DataLayerAction):
         self.case_id = case_id
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
-
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         participant = self.datalayer.read(self.participant_id)
         case = self.datalayer.read(self.case_id)
 
@@ -114,10 +112,9 @@ class RemoveCaseParticipantFromCaseReceivedNode(DataLayerAction):
         self.case_id = case_id
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         case = self.datalayer.read(self.case_id)
 

--- a/vultron/core/behaviors/case/nodes/case_setup.py
+++ b/vultron/core/behaviors/case/nodes/case_setup.py
@@ -76,10 +76,9 @@ class PersistCase(DataLayerAction):
         self.case_obj = case_obj
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error(f"{self.name}: DataLayer not available")
-            return Status.FAILURE
-
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         try:
             self.datalayer.save(self.case_obj)
             self.logger.info(
@@ -143,10 +142,9 @@ class RecordOfferReceivedEventNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error(f"{self.name}: DataLayer not available")
-            return Status.FAILURE
-
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         try:
             case_id = self.blackboard.get("case_id")
         except KeyError:
@@ -184,9 +182,9 @@ class RecordCaseCreatedEventNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error(f"{self.name}: DataLayer not available")
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         try:
             case_id = self.blackboard.get("case_id")
@@ -286,9 +284,9 @@ class ReuseExistingCaseActorParticipantNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         participant_id = self.blackboard.get("case_actor_participant_id")
         case_actor_id = self.blackboard.get("case_actor_id")
         if not isinstance(participant_id, str) or not isinstance(
@@ -333,12 +331,10 @@ class CreateCaseActorServiceNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.logger.error(
-                "%s: DataLayer or actor_id not available",
-                self.name,
-            )
-            return Status.FAILURE
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
         case_id = self.blackboard.get("case_id")
         case_actor_id = self.blackboard.get("case_actor_id")
         if not isinstance(case_id, str) or not isinstance(case_actor_id, str):
@@ -389,9 +385,9 @@ class RegisterCaseActorParticipantNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         case_id = self.blackboard.get("case_id")
         case_actor_id = self.blackboard.get("case_actor_id")

--- a/vultron/core/behaviors/case/nodes/communication.py
+++ b/vultron/core/behaviors/case/nodes/communication.py
@@ -61,12 +61,10 @@ class CollectCaseAddresseesNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.logger.error(
-                f"{self.name}: DataLayer or actor_id not available"
-            )
-            return Status.FAILURE
-
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
         try:
             case_id = self.blackboard.get("case_id")
         except KeyError:
@@ -155,11 +153,10 @@ class CreateAndPersistCaseActivityNode(DataLayerAction):
         return addressees
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.logger.error(
-                f"{self.name}: DataLayer or actor_id not available"
-            )
-            return Status.FAILURE
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
 
         case_id = self._read_case_id()
         if case_id is None:

--- a/vultron/core/behaviors/case/nodes/conditions.py
+++ b/vultron/core/behaviors/case/nodes/conditions.py
@@ -109,10 +109,9 @@ class CheckCaseAlreadyExists(DataLayerCondition):
         self.case_id = case_id
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error(f"{self.name}: DataLayer not available")
-            return Status.FAILURE
-
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         try:
             existing = self.datalayer.read(self.case_id)
             if existing is None:
@@ -163,10 +162,9 @@ class CheckCaseExistsForReport(DataLayerCondition):
         self.report_id = report_id
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error(f"{self.name}: DataLayer not available")
-            return Status.FAILURE
-
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         try:
             existing = self.datalayer.find_case_by_report_id(self.report_id)
             if existing is None:
@@ -224,11 +222,10 @@ class CheckIsCaseManagerNode(DataLayerCondition):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.logger.error(
-                f"{self.name}: DataLayer or actor_id not available"
-            )
-            return Status.FAILURE
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
 
         try:
             case_id = self._case_id or self.blackboard.get("case_id")

--- a/vultron/core/behaviors/case/nodes/delegation.py
+++ b/vultron/core/behaviors/case/nodes/delegation.py
@@ -62,11 +62,8 @@ class ResolveCaseManagerOfferContextNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.logger.error(
-                f"{self.name}: DataLayer or actor_id not available"
-            )
-            return Status.FAILURE
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
 
         case_id = self.blackboard.get("case_id")
         case_actor_id = self.blackboard.get("case_actor_id")

--- a/vultron/core/behaviors/case/nodes/embargo.py
+++ b/vultron/core/behaviors/case/nodes/embargo.py
@@ -91,10 +91,9 @@ class ResolveEmbargoDurationNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
-
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         duration = _preferred_embargo_duration(
             self.datalayer, self.name, self.logger
         )
@@ -123,10 +122,9 @@ class CreateEmbargoEventNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
-
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         case_id = self.blackboard.get("case_id")
         if not isinstance(case_id, str):
             self.logger.error("%s: case_id not found in blackboard", self.name)
@@ -183,11 +181,10 @@ class AdvanceEMStateToActiveNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.logger.error(
-                "%s: DataLayer or actor_id not available", self.name
-            )
-            return Status.FAILURE
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
 
         case_id = self.blackboard.get("case_id")
         embargo_id = self.blackboard.get("default_embargo_id")
@@ -321,9 +318,9 @@ class AttachEmbargoToCaseNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         case_id = self.blackboard.get("case_id")
         embargo_id = self.blackboard.get("default_embargo_id")
@@ -382,11 +379,10 @@ class SeedOwnerAsSignatoryNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.logger.error(
-                "%s: DataLayer or actor_id not available", self.name
-            )
-            return Status.FAILURE
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
 
         case_id = self.blackboard.get("case_id")
         if not isinstance(case_id, str):

--- a/vultron/core/behaviors/case/nodes/lifecycle.py
+++ b/vultron/core/behaviors/case/nodes/lifecycle.py
@@ -147,12 +147,10 @@ class CommitCaseLedgerEntryNode(DataLayerAction):
         return object_id, event_type, payload_snapshot
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.logger.error(
-                f"{self.name}: DataLayer or actor_id not available"
-            )
-            return Status.FAILURE
-
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
         case_id = self._resolve_case_id()
         if not case_id:
             self.logger.error(

--- a/vultron/core/behaviors/case/nodes/participant/_bootstrap.py
+++ b/vultron/core/behaviors/case/nodes/participant/_bootstrap.py
@@ -59,10 +59,9 @@ class EnsureReporterParticipantAtAcceptedNode(DataLayerAction):
         self.case_id = case_id
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
-
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         _ensure_reporter_participant(
             self.datalayer,
             self.link,

--- a/vultron/core/behaviors/case/nodes/participant/owner.py
+++ b/vultron/core/behaviors/case/nodes/participant/owner.py
@@ -114,13 +114,10 @@ class ResolveOwnerInitialStatusNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.logger.error(
-                "%s: DataLayer or actor_id not available",
-                self.name,
-            )
-            return Status.FAILURE
-
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
         try:
             case_id = _resolve_case_id(self.blackboard, self.case_obj)
         except KeyError:
@@ -234,12 +231,10 @@ class AttachOwnerParticipantToCaseNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.logger.error(
-                "%s: DataLayer or actor_id not available",
-                self.name,
-            )
-            return Status.FAILURE
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
         try:
             case_id_obj = self.blackboard.get("case_id")
         except KeyError:
@@ -295,9 +290,9 @@ class PersistOwnerCaseNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         stored_case = self.blackboard.get(self._participant_case_key)
         if not isinstance(stored_case, VulnerabilityCase):
             self.logger.error(
@@ -343,12 +338,10 @@ class AdvanceOwnerRmToAcceptedNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.logger.error(
-                "%s: DataLayer or actor_id not available",
-                self.name,
-            )
-            return Status.FAILURE
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
         try:
             case_id_obj = self.blackboard.get("case_id")
         except KeyError:
@@ -412,9 +405,9 @@ class RecordOwnerJoinedEventNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         stored_case = self.blackboard.get(self._participant_case_key)
         participant = self.blackboard.get(self._new_case_participant_key)

--- a/vultron/core/behaviors/case/nodes/participant/participant_add.py
+++ b/vultron/core/behaviors/case/nodes/participant/participant_add.py
@@ -71,10 +71,9 @@ class ResolveParticipantAcceptedStatusNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
-
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         result = _get_or_create_accepted_status(
             self.datalayer,
             self.participant_actor_id,
@@ -190,10 +189,9 @@ class AttachParticipantToCaseNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
-
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         case_id = self.blackboard.get("case_id")
         participant = self.blackboard.get(self._new_case_participant_key)
         if not isinstance(case_id, str):
@@ -249,9 +247,9 @@ class RecordParticipantAddedEventNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         stored_case = self.blackboard.get(self._participant_case_key)
         participant_id = self.blackboard.get(self._new_participant_id_key)
@@ -363,9 +361,9 @@ class SeedParticipantAsSignatoryNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         stored_case = self.blackboard.get(self._participant_case_key)
         participant = self.blackboard.get(self._new_case_participant_key)
@@ -427,11 +425,10 @@ class QueueAddParticipantNotificationNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.logger.error(
-                "%s: DataLayer or actor_id not available", self.name
-            )
-            return Status.FAILURE
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
 
         case_id = self.blackboard.get("case_id")
         participant_id = self.blackboard.get(self._new_participant_id_key)

--- a/vultron/core/behaviors/case/nodes/suggest_actor/conditions.py
+++ b/vultron/core/behaviors/case/nodes/suggest_actor/conditions.py
@@ -57,9 +57,9 @@ class ActorAlreadyParticipantNode(DataLayerAction):
         self.case_id = case_id
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         case_obj = self.datalayer.read(self.case_id)
         index = getattr(case_obj, "actor_participant_index", {}) or {}
         if self.recommended_id in index:
@@ -96,9 +96,9 @@ class InviteInFlightNode(DataLayerAction):
         self.case_id = case_id
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         pair = self.datalayer.find_protocol_pair(
             case_id=self.case_id,
             request_event_type="invite_actor_to_case",
@@ -140,9 +140,9 @@ class PendingOfferCaseParticipantNode(DataLayerAction):
         self.case_id = case_id
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         pair = self.datalayer.find_protocol_pair(
             case_id=self.case_id,
             request_event_type="offer_case_participant",

--- a/vultron/core/behaviors/case/nodes/suggest_actor/emit.py
+++ b/vultron/core/behaviors/case/nodes/suggest_actor/emit.py
@@ -153,18 +153,16 @@ class EmitOfferCaseParticipantToOwnerNode(DataLayerAction):
         return [CVDRole.VENDOR]
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.feedback_message = "DataLayer or actor_id not available"
-            return Status.FAILURE
-
-        factory = self.trigger_activity_factory
-        if factory is None:
-            self.feedback_message = (
-                "trigger_activity_factory not in blackboard"
-            )
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
+        if (f := self._require_factory()) is not None:
             self.logger.error(self.feedback_message)
-            return Status.FAILURE
+            return f
+        assert self.trigger_activity_factory is not None
 
+        factory = self.trigger_activity_factory  # guaranteed non-None
         roles = self._read_suggested_roles()
         if not roles:
             self.feedback_message = (
@@ -257,18 +255,16 @@ class EmitAcceptActorRecommendationNode(DataLayerAction):
         self.case_id = case_id
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.feedback_message = "DataLayer or actor_id not available"
-            return Status.FAILURE
-
-        factory = self.trigger_activity_factory
-        if factory is None:
-            self.feedback_message = (
-                "trigger_activity_factory not in blackboard"
-            )
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
+        if (f := self._require_factory()) is not None:
             self.logger.error(self.feedback_message)
-            return Status.FAILURE
+            return f
+        assert self.trigger_activity_factory is not None
 
+        factory = self.trigger_activity_factory  # guaranteed non-None
         try:
             activity_id, _ = factory.emit_accept_actor_recommendation(
                 recommender_id=self.recommender_id,
@@ -316,18 +312,16 @@ class EmitRejectActorRecommendationNode(DataLayerAction):
         self.case_id = case_id
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.feedback_message = "DataLayer or actor_id not available"
-            return Status.FAILURE
-
-        factory = self.trigger_activity_factory
-        if factory is None:
-            self.feedback_message = (
-                "trigger_activity_factory not in blackboard"
-            )
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
+        if (f := self._require_factory()) is not None:
             self.logger.error(self.feedback_message)
-            return Status.FAILURE
+            return f
+        assert self.trigger_activity_factory is not None
 
+        factory = self.trigger_activity_factory  # guaranteed non-None
         try:
             activity_id, _ = factory.emit_reject_actor_recommendation(
                 recommender_id=self.recommender_id,
@@ -387,18 +381,16 @@ class EmitNoteDuplicateRecommendationToOwnerNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.feedback_message = "DataLayer or actor_id not available"
-            return Status.FAILURE
-
-        factory = self.trigger_activity_factory
-        if factory is None:
-            self.feedback_message = (
-                "trigger_activity_factory not in blackboard"
-            )
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
+        if (f := self._require_factory()) is not None:
             self.logger.error(self.feedback_message)
-            return Status.FAILURE
+            return f
+        assert self.trigger_activity_factory is not None
 
+        factory = self.trigger_activity_factory  # guaranteed non-None
         try:
             case_obj = self.datalayer.read(self.case_id)
             raw_owner = getattr(case_obj, "attributed_to", None)

--- a/vultron/core/behaviors/case/nodes/update.py
+++ b/vultron/core/behaviors/case/nodes/update.py
@@ -44,13 +44,10 @@ class CheckCaseUpdateOwnerNode(DataLayerCondition):
         self.case_id = case_id
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.feedback_message = "DataLayer or actor_id not available"
-            self.logger.error(
-                "%s: DataLayer or actor_id not available", self.name
-            )
-            return Status.FAILURE
-
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
         case = self.datalayer.read(self.case_id)
         if not isinstance(case, VulnerabilityCase):
             self.feedback_message = f"case '{self.case_id}' not found"
@@ -90,10 +87,9 @@ class CaptureCaseUpdateBroadcastExclusionsNode(DataLayerCondition):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         case = self.datalayer.read(self.case_id)
         if not isinstance(case, VulnerabilityCase):
@@ -125,11 +121,10 @@ class ApplyCaseUpdateNode(DataLayerAction):
         self.request = request
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.logger.error(
-                "%s: DataLayer or actor_id not available", self.name
-            )
-            return Status.FAILURE
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
 
         stored_case = self.datalayer.read(self.case_id)
         if not isinstance(stored_case, VulnerabilityCase):
@@ -171,10 +166,9 @@ class BroadcastCaseUpdateNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         case = self.datalayer.read(self.case_id)
         if not isinstance(case, VulnerabilityCase):

--- a/vultron/core/behaviors/case/reject_case_proposal_received_tree.py
+++ b/vultron/core/behaviors/case/reject_case_proposal_received_tree.py
@@ -57,9 +57,9 @@ class _RecordCaseProposalRejectionNode(DataLayerAction):
         super().setup(**kwargs)
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         link_id = VultronReportCaseLink.build_id(self._report_id)
         link = self.datalayer.read(link_id)

--- a/vultron/core/behaviors/embargo/nodes/cascade.py
+++ b/vultron/core/behaviors/embargo/nodes/cascade.py
@@ -29,9 +29,9 @@ class PersistEmbargoEventNode(DataLayerAction):
         self._embargo = embargo
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         try:
             self.datalayer.create(self._embargo)
         except ValueError:

--- a/vultron/core/behaviors/embargo/nodes/conditions.py
+++ b/vultron/core/behaviors/embargo/nodes/conditions.py
@@ -37,9 +37,9 @@ class ValidateCaseExistsNode(DataLayerCondition):
         self.case_id = case_id
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         case = self.datalayer.read(self.case_id)
         if not isinstance(case, VulnerabilityCase):
@@ -68,9 +68,9 @@ class IsActiveEmbargoNode(DataLayerCondition):
         self.embargo_id = embargo_id
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         case = self.datalayer.read(self.case_id)
         if not isinstance(case, VulnerabilityCase):
@@ -116,9 +116,9 @@ class LookupParticipantNode(DataLayerCondition):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         case = self.datalayer.read(self.case_id)
         if not isinstance(case, VulnerabilityCase):
@@ -269,9 +269,9 @@ class HasActiveEmbargoNode(DataLayerCondition):
         self._result_out = result_out
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         case = self.datalayer.read(self.case_id)
         if not isinstance(case, VulnerabilityCase):
@@ -316,9 +316,9 @@ class HasCaseStatusesNode(DataLayerCondition):
         self.case_id = case_id
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         case = self.datalayer.read(self.case_id)
         if not isinstance(case, VulnerabilityCase):

--- a/vultron/core/behaviors/embargo/nodes/em_state.py
+++ b/vultron/core/behaviors/embargo/nodes/em_state.py
@@ -73,9 +73,9 @@ class ReadEmStateNode(DataLayerCondition):
         self._result_out = result_out
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         case = self.datalayer.read(self._case_id)
         if not isinstance(case, VulnerabilityCase):
@@ -146,9 +146,9 @@ class WriteEmStateNode(DataLayerAction):
         self._result_out = result_out
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         em_after = self._result_out.get("em_after")
         if not isinstance(em_after, EM):

--- a/vultron/core/behaviors/embargo/nodes/lifecycle.py
+++ b/vultron/core/behaviors/embargo/nodes/lifecycle.py
@@ -66,9 +66,9 @@ class ValidateEmbargoRevisionStateNode(DataLayerAction):
         self._result_out = result_out
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         # AC-1: read em_state via named BT node, not inline.
         read_node = ReadEmStateNode(
@@ -122,9 +122,10 @@ class _EmbargoLifecycleNode(DataLayerAction):
         raise NotImplementedError
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.feedback_message = "DataLayer or actor_id not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
 
         # AC-1: read em_state via named BT node, not inline service code.
         read_node = ReadEmStateNode(
@@ -313,9 +314,9 @@ class ReadEmbargoIdNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         case = self.datalayer.read(self._case_id)
         if not isinstance(case, VulnerabilityCase):
@@ -360,17 +361,18 @@ class SendTerminateEmbargoActivityNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.trigger_activity_factory is None:
+        if (f := self._require_factory()) is not None:
             self.feedback_message = (
                 "trigger_activity_factory not available"
                 " — broadcast FAILURE (BT-14-001)"
             )
             self.logger.warning("%s: %s", self.name, self.feedback_message)
-            return Status.FAILURE
-
-        if self.datalayer is None or self.actor_id is None:
-            self.feedback_message = "DataLayer or actor_id not available"
-            return Status.FAILURE
+            return f
+        assert self.trigger_activity_factory is not None
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
 
         try:
             embargo_id: str = self.blackboard.embargo_id
@@ -450,9 +452,9 @@ class SetEmbargoActiveNode(DataLayerAction):
         self.logger.info("%s: %s", self.name, self.feedback_message)
 
     def update(self) -> Status:
-        fail = self._require_datalayer()
-        if fail is not None:
-            return fail
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         case = self._read_case()
         if case is None:

--- a/vultron/core/behaviors/embargo/nodes/proposal.py
+++ b/vultron/core/behaviors/embargo/nodes/proposal.py
@@ -181,9 +181,9 @@ class RecordParticipantAcceptanceNode(DataLayerAction):
     def update(self) -> Status:
         from vultron.core.states.em import EM
 
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         # Use accepting_actor_id when provided (ADR-0022 single-BT pattern:
         # tree executes under receiving_actor_id but acceptance is recorded

--- a/vultron/core/behaviors/embargo/nodes/teardown.py
+++ b/vultron/core/behaviors/embargo/nodes/teardown.py
@@ -59,9 +59,9 @@ class ApplyEmbargoTeardownNode(DataLayerAction):
             )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         if self.case_id is not None:
             case_id = self.case_id
@@ -124,9 +124,9 @@ class RemoveFromProposedEmbargoesNode(DataLayerAction):
         self.embargo_id = embargo_id
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         case = self.datalayer.read(self.case_id)
         if not isinstance(case, VulnerabilityCase):

--- a/vultron/core/behaviors/helpers.py
+++ b/vultron/core/behaviors/helpers.py
@@ -106,6 +106,13 @@ class DataLayerCondition(py_trees.behaviour.Behaviour):
             return Status.FAILURE
         return None
 
+    def _require_datalayer_and_actor(self) -> Status | None:
+        """Return FAILURE if ``datalayer`` or ``actor_id`` is not set, else None."""
+        if self.datalayer is None or self.actor_id is None:
+            self.feedback_message = "DataLayer or actor_id not available"
+            return Status.FAILURE
+        return None
+
     def update(self) -> Status:
         """
         Evaluate condition. Override in subclasses.

--- a/vultron/core/behaviors/helpers.py
+++ b/vultron/core/behaviors/helpers.py
@@ -99,6 +99,13 @@ class DataLayerCondition(py_trees.behaviour.Behaviour):
         if self.actor_id is None:
             self.logger.error(f"{self.name}: actor_id not found in blackboard")
 
+    def _require_datalayer(self) -> Status | None:
+        """Return FAILURE if ``self.datalayer`` is not set, else None."""
+        if self.datalayer is None:
+            self.feedback_message = "DataLayer not available"
+            return Status.FAILURE
+        return None
+
     def update(self) -> Status:
         """
         Evaluate condition. Override in subclasses.
@@ -293,10 +300,9 @@ class FindParticipantByActorIdNode(DataLayerCondition):
         return matched_participant, matched_participant_id, None
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            self.logger.error("%s: %s", self.name, self.feedback_message)
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         case_obj = self.datalayer.read(self.case_id, raise_on_missing=False)
         if not isinstance(case_obj, VulnerabilityCase):
@@ -389,9 +395,9 @@ class ReadObject(DataLayerCondition):
         Returns:
             SUCCESS if object found, FAILURE if not found or error
         """
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         try:
             record = self.datalayer.read(self.object_id)
@@ -461,9 +467,8 @@ class UpdateObject(DataLayerAction):
         Returns:
             SUCCESS if update completes, FAILURE if error occurs
         """
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
 
         try:
             # Try to read current record from blackboard
@@ -564,9 +569,9 @@ class CreateObject(DataLayerAction):
         Returns:
             SUCCESS if creation completes, FAILURE if error occurs
         """
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         try:
             # Ensure object_data has required 'id_' field
@@ -643,11 +648,10 @@ class UpdateActorOutbox(DataLayerAction):
         Returns:
             SUCCESS if outbox updated, FAILURE on error
         """
-        if self.datalayer is None or self.actor_id is None:
-            self.logger.error(
-                f"{self.name}: DataLayer or actor_id not available"
-            )
-            return Status.FAILURE
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
 
         try:
             activity_id = self.blackboard.get("activity_id")

--- a/vultron/core/behaviors/inbox/nodes/dead_letter.py
+++ b/vultron/core/behaviors/inbox/nodes/dead_letter.py
@@ -49,10 +49,9 @@ class StoreDeadLetterRecordNode(DataLayerAction):
         self._request = request
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         request = self._request
         unresolvable_uri = request.object_id or ""

--- a/vultron/core/behaviors/note/nodes/creation.py
+++ b/vultron/core/behaviors/note/nodes/creation.py
@@ -44,22 +44,13 @@ class CreateNoteNode(DataLayerAction):
         self.in_reply_to = in_reply_to
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            self.logger.error(f"{self.name}: {self.feedback_message}")
-            return Status.FAILURE
-
-        if self.trigger_activity_factory is None:
-            self.feedback_message = (
-                "trigger_activity_factory not available in blackboard"
-            )
-            self.logger.error(f"{self.name}: {self.feedback_message}")
-            return Status.FAILURE
-
-        if self.actor_id is None:
-            self.feedback_message = "actor_id not available in blackboard"
-            self.logger.error(f"{self.name}: {self.feedback_message}")
-            return Status.FAILURE
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
+        if (f := self._require_factory()) is not None:
+            return f
+        assert self.trigger_activity_factory is not None
 
         try:
             note_id, note_dict = self.trigger_activity_factory.create_note(
@@ -105,10 +96,9 @@ class AttachNoteFromResultNode(DataLayerAction):
         if note_id is None:
             return Status.FAILURE
 
-        fail = self._require_datalayer()
-        if fail is not None:
+        if (f := self._require_datalayer()) is not None:
             self.logger.error(f"{self.name}: {self.feedback_message}")
-            return fail
+            return f
 
         case: Any = self.datalayer.read(self.case_id)  # type: ignore[union-attr]
         if not isinstance(case, VulnerabilityCase):

--- a/vultron/core/behaviors/note/nodes/storage.py
+++ b/vultron/core/behaviors/note/nodes/storage.py
@@ -33,9 +33,9 @@ class SaveNoteNode(DataLayerAction):
         self.note_obj = note_obj
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error(f"{self.name}: DataLayer not available")
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         try:
             self.datalayer.save(self.note_obj)
@@ -68,9 +68,9 @@ class AttachNoteToCaseNode(DataLayerAction):
             )
             return Status.SUCCESS
 
-        if self.datalayer is None:
-            self.logger.error(f"{self.name}: DataLayer not available")
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         case: Any = self.datalayer.read(self.case_id)
         if not isinstance(case, VulnerabilityCase):

--- a/vultron/core/behaviors/report/nodes/case_creation.py
+++ b/vultron/core/behaviors/report/nodes/case_creation.py
@@ -96,12 +96,10 @@ class CreateCaseNode(DataLayerAction):
         Returns:
             SUCCESS if case created, FAILURE on error
         """
-        if self.datalayer is None or self.actor_id is None:
-            self.logger.error(
-                f"{self.name}: DataLayer or actor_id not available"
-            )
-            return Status.FAILURE
-
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
         try:
             report_obj = self.datalayer.read(
                 self.report_id, raise_on_missing=True
@@ -178,12 +176,10 @@ class CreateCaseActivity(DataLayerAction):
         Returns:
             SUCCESS if activity created, FAILURE on error
         """
-        if self.datalayer is None or self.actor_id is None:
-            self.logger.error(
-                f"{self.name}: DataLayer or actor_id not available"
-            )
-            return Status.FAILURE
-
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
         try:
             case_id = self.blackboard.get("case_id")
             if case_id is None:

--- a/vultron/core/behaviors/report/nodes/conditions.py
+++ b/vultron/core/behaviors/report/nodes/conditions.py
@@ -64,9 +64,9 @@ class CheckRMStateValid(DataLayerCondition):
         Returns:
             SUCCESS if report is RM.VALID, FAILURE otherwise
         """
-        if self.datalayer is None:
-            self.logger.error(f"{self.name}: DataLayer not available")
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         actor_id = (
             self.sender_actor_id if self.sender_actor_id else self.actor_id
         )
@@ -126,9 +126,9 @@ class CheckRMStateReceivedOrInvalid(DataLayerCondition):
         Returns:
             SUCCESS if report is in acceptable state, FAILURE otherwise
         """
-        if self.datalayer is None:
-            self.logger.error(f"{self.name}: DataLayer not available")
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         actor_id = (
             self.sender_actor_id if self.sender_actor_id else self.actor_id
         )
@@ -183,10 +183,9 @@ class EnsureEmbargoExists(DataLayerCondition):
         Returns:
             SUCCESS if case has active_embargo, FAILURE otherwise
         """
-        if self.datalayer is None:
-            self.logger.error(f"{self.name}: DataLayer not available")
-            return Status.FAILURE
-
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         case = self.datalayer.find_case_by_report_id(self.report_id)
         if case is None:
             self.logger.warning(
@@ -390,9 +389,9 @@ class CheckReportNotClosed(DataLayerCondition):
             FAILURE (+ ``result_out["error"]``) when already closed or
             the DataLayer/actor_id is unavailable.
         """
-        if self.datalayer is None:
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         if self.actor_id is None:
             self.logger.error("%s: actor_id not available", self.name)
             return Status.FAILURE

--- a/vultron/core/behaviors/report/nodes/participant.py
+++ b/vultron/core/behaviors/report/nodes/participant.py
@@ -54,10 +54,9 @@ class TransitionParticipantRMtoAccepted(DataLayerAction):
         Returns:
             SUCCESS if transition persisted, FAILURE on error
         """
-        if self.datalayer is None:
-            self.logger.error(f"{self.name}: DataLayer not available")
-            return Status.FAILURE
-
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         try:
             if self.actor_id is None:
                 self.logger.error(f"{self.name}: actor_id not available")
@@ -103,10 +102,9 @@ class TransitionParticipantRMtoDeferred(DataLayerAction):
         Returns:
             SUCCESS if transition persisted, FAILURE on error
         """
-        if self.datalayer is None:
-            self.logger.error(f"{self.name}: DataLayer not available")
-            return Status.FAILURE
-
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         try:
             if self.actor_id is None:
                 self.logger.error(f"{self.name}: actor_id not available")

--- a/vultron/core/behaviors/report/nodes/rm_transitions.py
+++ b/vultron/core/behaviors/report/nodes/rm_transitions.py
@@ -141,11 +141,9 @@ class TransitionRMtoValid(DataLayerAction):
         Returns:
             SUCCESS if status updated, FAILURE on error
         """
-        if self.datalayer is None:
-            self.logger.error(
-                f"{self.name}: DataLayer or actor_id not available"
-            )
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         actor_id = (
             self.sender_actor_id if self.sender_actor_id else self.actor_id
         )
@@ -232,12 +230,10 @@ class TransitionRMtoInvalid(DataLayerAction):
         Returns:
             SUCCESS if status updated, FAILURE on error
         """
-        if self.datalayer is None or self.actor_id is None:
-            self.logger.error(
-                f"{self.name}: DataLayer or actor_id not available"
-            )
-            return Status.FAILURE
-
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
         try:
             # CLP-07-007: context must use the case URI once a case exists.
             case = self.datalayer.find_case_by_report_id(self.report_id)
@@ -310,12 +306,10 @@ class TransitionRMtoClosed(DataLayerAction):
         Returns:
             SUCCESS if status updated, FAILURE on error
         """
-        if self.datalayer is None or self.actor_id is None:
-            self.logger.error(
-                "%s: DataLayer or actor_id not available", self.name
-            )
-            return Status.FAILURE
-
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
         try:
             # CLP-07-007: context must use the case URI once a case exists.
             case = self.datalayer.find_case_by_report_id(self.report_id)
@@ -385,12 +379,10 @@ class TransitionCaseParticipantRMtoClosed(DataLayerAction):
             FAILURE if the DataLayer is unavailable or the transition is
             blocked.
         """
-        if self.datalayer is None or self.actor_id is None:
-            self.logger.error(
-                "%s: DataLayer or actor_id not available", self.name
-            )
-            return Status.FAILURE
-
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
         return _transition_case_participant_rm(self, self.report_id, RM.CLOSED)
 
 
@@ -423,12 +415,10 @@ class TransitionCaseParticipantRMtoInvalid(DataLayerAction):
             FAILURE if the DataLayer is unavailable or the transition is
             blocked.
         """
-        if self.datalayer is None or self.actor_id is None:
-            self.logger.error(
-                "%s: DataLayer or actor_id not available", self.name
-            )
-            return Status.FAILURE
-
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
         return _transition_case_participant_rm(
             self, self.report_id, RM.INVALID
         )

--- a/vultron/core/behaviors/report/nodes/storage.py
+++ b/vultron/core/behaviors/report/nodes/storage.py
@@ -72,10 +72,9 @@ class StoreReportNode(DataLayerAction):
             SUCCESS always (including no-op if report_id is empty or
             report_obj is None); FAILURE if the DataLayer is unavailable.
         """
-        if self.datalayer is None:
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
-
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         if not self.report_id:
             self.logger.debug("%s: no report_id — skipping store", self.name)
             return Status.SUCCESS
@@ -133,10 +132,9 @@ class StoreActivityNode(DataLayerAction):
             FAILURE if the DataLayer is unavailable or activity_obj is None
             when activity_id is set (precondition violation).
         """
-        if self.datalayer is None:
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
-
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         if not self.activity_id:
             self.logger.debug("%s: no activity_id — skipping store", self.name)
             return Status.SUCCESS

--- a/vultron/core/behaviors/sender/nodes/actions.py
+++ b/vultron/core/behaviors/sender/nodes/actions.py
@@ -41,9 +41,10 @@ class ResolveCaseManagerNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.feedback_message = "DataLayer or actor_id not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
 
         case = self.datalayer.read(self.case_id)
         if not isinstance(case, VulnerabilityCase):
@@ -123,9 +124,10 @@ class QueueToOutboxNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.feedback_message = "DataLayer or actor_id not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
 
         try:
             activity_ids: list[str] = self.blackboard.activity_ids

--- a/vultron/core/behaviors/status/nodes/append.py
+++ b/vultron/core/behaviors/status/nodes/append.py
@@ -111,9 +111,9 @@ class LoadParticipantNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         participant = self.datalayer.read(self.participant_id)
         if not isinstance(participant, CaseParticipant):
@@ -221,9 +221,9 @@ class ResolveAndPersistStatusObjectNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         status_obj = self.datalayer.read(self.status_id)
         if not hasattr(status_obj, "id_"):
@@ -391,9 +391,9 @@ class AppendStatusAndSaveParticipantNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         participant = self.blackboard.get("append_status_participant")
         status_obj = self.blackboard.get("append_status_status_obj")
@@ -447,9 +447,9 @@ class CheckParticipantRMNotClosedNode(DataLayerCondition):
         self.status_id = status_id
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         participant = self.datalayer.read(self.participant_id)
         if not isinstance(participant, CaseParticipant):

--- a/vultron/core/behaviors/status/nodes/case_status.py
+++ b/vultron/core/behaviors/status/nodes/case_status.py
@@ -65,9 +65,9 @@ class CheckCaseStatusIdempotencyNode(DataLayerCondition):
         self.status_id = status_id
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         case = self.datalayer.read(self.case_id)
         if not isinstance(case, VulnerabilityCase):
@@ -146,9 +146,9 @@ class ValidateCaseStatusTransitionNode(DataLayerCondition):
         return False
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         case = self.datalayer.read(self.case_id)
         if not isinstance(case, VulnerabilityCase):
@@ -227,9 +227,9 @@ class AppendCaseStatusToCaseNode(DataLayerAction):
         return status_obj if hasattr(status_obj, "id_") else None
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         case = self.datalayer.read(self.case_id)
         if not isinstance(case, VulnerabilityCase):

--- a/vultron/core/behaviors/status/nodes/conditions.py
+++ b/vultron/core/behaviors/status/nodes/conditions.py
@@ -69,9 +69,8 @@ class VerifySenderIsParticipantNode(FindParticipantByActorIdNode):
         return str(context) if context else None
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
 
         case_id = self._resolve_case_id()
         if case_id is None:

--- a/vultron/core/behaviors/sync/nodes/chain.py
+++ b/vultron/core/behaviors/sync/nodes/chain.py
@@ -259,10 +259,9 @@ class ReconstructChainTailNode(DataLayerAction):
             )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
-
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         if self._case_id is not None:
             case_id = self._case_id
         else:
@@ -302,10 +301,9 @@ class UpdateReplicationStateNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
-
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         from vultron.core.models.replication_state import (
             VultronReplicationState,
         )
@@ -388,9 +386,9 @@ class CreateLogEntryNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         from vultron.core.use_cases._helpers import _find_case_actor_id
 
@@ -460,9 +458,9 @@ class PersistLogEntryNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         entry = cast(VultronCaseLedgerEntry, self.blackboard.log_entry)
         try:

--- a/vultron/core/behaviors/sync/nodes/conditions.py
+++ b/vultron/core/behaviors/sync/nodes/conditions.py
@@ -85,12 +85,10 @@ class CheckIsOwnCaseActorNode(DataLayerCondition):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.logger.error(
-                "%s: DataLayer or actor_id not available", self.name
-            )
-            return Status.FAILURE
-
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
         entry = _require_log_entry(self.blackboard.activity, self.name)
         case_actor = _find_case_actor(
             self.datalayer, entry.case_id, self.actor_id
@@ -118,11 +116,10 @@ class CheckIsNotOwnCaseActorNode(DataLayerCondition):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.logger.error(
-                "%s: DataLayer or actor_id not available", self.name
-            )
-            return Status.FAILURE
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
 
         entry = _require_log_entry(self.blackboard.activity, self.name)
         case_actor = _find_case_actor(
@@ -166,9 +163,9 @@ class CheckLedgerEntryAlreadyStoredNode(DataLayerCondition):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         entry = _require_log_entry(self.blackboard.activity, self.name)
         if self.datalayer.read(entry.id_) is None:
@@ -357,9 +354,9 @@ class CheckLedgerFreshnessNode(DataLayerCondition):
             )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         if self._case_id is not None:
             case_id = self._case_id

--- a/vultron/core/behaviors/sync/nodes/effects.py
+++ b/vultron/core/behaviors/sync/nodes/effects.py
@@ -97,10 +97,9 @@ class ApplyParticipantStatusFromLedgerNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
-
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         from vultron.core.behaviors.sync.nodes.conditions import (
             _require_log_entry,
         )
@@ -227,10 +226,9 @@ class ApplyNoteFromLedgerNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
-
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         from vultron.core.behaviors.sync.nodes.conditions import (
             _require_log_entry,
         )
@@ -307,9 +305,9 @@ class ApplyInviteAcceptFromLedgerNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.feedback_message = "DataLayer not available"
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
 
         from vultron.core.behaviors.sync.nodes.conditions import (
             _require_log_entry,

--- a/vultron/core/behaviors/sync/nodes/receive.py
+++ b/vultron/core/behaviors/sync/nodes/receive.py
@@ -74,10 +74,9 @@ class PersistReceivedLogEntryNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
-
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         entry = _require_log_entry(self.blackboard.activity, self.name)
         self.datalayer.save(entry)
         self.logger.info(

--- a/vultron/core/behaviors/sync/nodes/replay.py
+++ b/vultron/core/behaviors/sync/nodes/replay.py
@@ -103,10 +103,9 @@ class FindCaseActorNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
-
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         entry = _require_rejected_entry(self.blackboard.activity, self.name)
         case_actor = _find_case_actor(self.datalayer, entry.case_id)
         if case_actor is None:
@@ -141,10 +140,9 @@ class CollectAndSortCaseLedgerEntriesNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
-
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         activity = self.blackboard.activity
         entry = _require_rejected_entry(activity, self.name)
         peer_id = activity.actor_id
@@ -231,9 +229,9 @@ class SendMissingEntriesNode(DataLayerAction):
             self._sync_port = None
 
     def update(self) -> Status:
-        if self.datalayer is None:
-            self.logger.error("%s: DataLayer not available", self.name)
-            return Status.FAILURE
+        if (f := self._require_datalayer()) is not None:
+            return f
+        assert self.datalayer is not None
         if self._sync_port is None:
             raise VultronError(
                 f"{self.name}: sync_port must be injected to replay entries"
@@ -297,11 +295,10 @@ class CollectLogEntryRecipientsNode(DataLayerAction):
         )
 
     def update(self) -> Status:
-        if self.datalayer is None or self.actor_id is None:
-            self.logger.error(
-                "%s: DataLayer or actor_id not available", self.name
-            )
-            return Status.FAILURE
+        if (f := self._require_datalayer_and_actor()) is not None:
+            return f
+        assert self.datalayer is not None
+        assert self.actor_id is not None
 
         entry = cast(VultronCaseLedgerEntry, self.blackboard.log_entry)
         case_obj = self.datalayer.read(self.case_id)


### PR DESCRIPTION
- Closes #1509

## Summary

Completes the post-BTND-07-003 sweep: migrates every remaining FAILURE-returning inline `if self.datalayer is None` / `if self.actor_id is None` guard in `update()` methods to the canonical walrus-operator helper pattern introduced by #1499.

Also adds `DataLayerCondition._require_datalayer_and_actor()` to `helpers.py` so that `DataLayerCondition` subclasses (which already populate `self.actor_id` in `initialise()`) can use the combined guard without the `AttributeError` that occurred when the migration scripts could not distinguish `DataLayerCondition` from `DataLayerAction` subclasses.

## Changes

- `vultron/core/behaviors/helpers.py`: Add `_require_datalayer_and_actor()` to `DataLayerCondition`, mirroring the existing `DataLayerAction` implementation
- 23 files across `case/`, `report/`, and `sync/` sub-packages: migrate all remaining FAILURE-returning inline datalayer guards in `update()` methods to `_require_datalayer()` or `_require_datalayer_and_actor()`
- SUCCESS-returning guards, non-`update()` methods, and the BT-14-001 warning log in `SendTerminateEmbargoActivityNode` are preserved unchanged
- `test/core/behaviors/test_helpers.py`: Add 12 direct unit tests for `_require_datalayer()`, `_require_datalayer_and_actor()`, and `_require_factory()` on both `DataLayerCondition` and `DataLayerAction`

## Verification

- [x] `uv run pytest test/core/behaviors/` — 917 passed (905 pre-existing + 12 new)
- [x] `uv run black --check vultron/core/behaviors/` — all 119 files unchanged
- [x] `uv run flake8 vultron/core/behaviors/` — clean
- [x] `uv run pyright vultron/core/behaviors/helpers.py` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)