### PR TITLE
fix: disable bibtex inline citations to eliminate false-positive @-key warnings

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -312,6 +312,7 @@ theme:
 plugins:
   - bibtex:
       bib_file: 'references.bib'
+      enable_inline_citations: false
   - include-markdown:
       comments: false
   - mkdocstrings:

--- a/plan/history/2607/implementation/ISSUE-1581.md
+++ b/plan/history/2607/implementation/ISSUE-1581.md
@@ -1,0 +1,8 @@
+---
+source: ISSUE-1581
+timestamp: '2026-07-22T13:53:24.742907+00:00'
+title: Disable bibtex inline citations to eliminate false-positive @-key warnings
+type: implementation
+---
+
+Fixed #1581. The mkdocs-bibtex plugin's inline-citation regex matched bare @word patterns in code blocks and Turtle ontology directives, emitting 18 spurious WARNING lines per build. Set enable_inline_citations: false in mkdocs.yml under the bibtex: plugin. All real citations use [@key] pandoc syntax; inline mode was unused. One-line config change; zero tests needed (verification is uv run mkdocs build producing no bibtex warnings). PR: <https://github.com/CERTCC/Vultron/pull/1582>


### PR DESCRIPTION
- Closes #1581

## Summary

The `mkdocs build` was emitting 18 spurious `WARNING - Inline reference to
unknown key <X>` messages from the `mkdocs-bibtex` plugin on every build.
These warnings tripped up agents and cluttered CI output.

## Root Cause

`mkdocs-bibtex` ships with `enable_inline_citations: true` by default. This
feature applies the regex `(?<!\\)(?<![\[\w])@(?P<key>[\w:-]+)(?![^\[\]]*\])`
to every page's expanded markdown, matching any bare `@word` not immediately
preceded by `[` or `\`. Three categories of content produced false positives:

- **Code blocks** — `@pytest.mark.integration`, `@context`, `@v4`, `@main`,
  `@dataclass` appearing in fenced code blocks or inline code spans
- **Turtle/OWL ontology files** — `@prefix` and `@base` directives in five
  ontology reference pages that include raw `.ttl`/`.owl` files via
  `include-markdown`
- **YouTube URL** — `https://www.youtube.com/@petterogren7535` in ADR-0002

The project uses `[@key]` pandoc citation syntax exclusively for real
citations; the inline-citation feature was unused.

## Changes

- `mkdocs.yml`: add `enable_inline_citations: false` under the `bibtex:` plugin

## Verification

```
$ uv run mkdocs build 2>&1 | grep -i "bibtex\|unknown key\|inline reference"
(no output — zero warnings)
```