### PR TITLE
history: archive idea IDEA-1557 — Rename two-actor demo to FV demo

### DIFF
--- a/plan/history/2607/idea/IDEA-1557.md
+++ b/plan/history/2607/idea/IDEA-1557.md
@@ -1,0 +1,32 @@
+---
+source: IDEA-1557
+timestamp: '2026-07-22T14:24:03.776278+00:00'
+title: Rename "two-actor demo" to "FV demo"
+type: idea
+---
+
+## Summary
+
+Rename every occurrence of the opaque "two-actor demo" label to the
+role-initial "FV demo" (Finder + Vendor), consistent with the naming scheme
+used across all other demo scenarios (FVV, FVCV, FVCV-extension, etc.).
+
+## Motivation
+
+The name "two-actor" describes participant *count*, not *roles*. CI job names
+and scenario identifiers using "FV", "FVV", or "FVCV" are self-documenting;
+"two-actor" forces readers to mentally map count → roles.
+
+## Scope (resolved in planning)
+
+- Module: `two_actor_demo.py` → `fv_demo.py`; `run_two_actor_demo` → `run_fv_demo`
+- CLI: `vultron-demo two-actor` → `vultron-demo fv` (alias removed)
+- Docker: `DEMO=two-actor` → `DEMO=fv`
+- CI: job name, artifact name (`two-actor-case-logs` → `fv-case-logs`)
+- devlogs: `devlogs/two-actor/` → `devlogs/fv/`
+- Docs: `two-actor-demo.md` → `fv-demo.md`; `two-actor-demo-protocol.md` → `fv-demo-protocol.md`
+- Specs + notes: prose references updated
+- Integration test script: `two-actor` → `fv` only; full audit in follow-on
+
+**Processed**: 2026-07-22 — implementation tracked in #1584.
+Follow-on: #1585 (integration test script audit).


### PR DESCRIPTION
## Summary

- Archives planned Idea #1557 (rename two-actor demo to FV demo) to `plan/history/`
- Implementation tracked in #1584; follow-on audit in #1585

## Test plan

- [ ] History file present at `plan/history/2607/idea/IDEA-1557.md`
- [ ] Markdownlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)