### PR TITLE
fix(docker): improve layer caching across all build targets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -61,5 +61,5 @@ wip_notes
 .copilot
 .devcontainer
 
-# Docker build files (not needed in app images; individual files copied explicitly)
-docker
+# Dockerfile itself is not needed inside app images; demo-entrypoint.sh is still required
+docker/Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -59,3 +59,7 @@ wip_notes
 .agents
 .github
 .copilot
+.devcontainer
+
+# Docker build files (not needed in app images; individual files copied explicitly)
+docker

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,14 +8,15 @@ ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 RUN python -m venv "${VIRTUAL_ENV}"
 
-FROM base AS dependencies
+FROM base AS dep-layer
 
-# Install third-party dependencies in a dedicated layer so that changing
-# application source does not bust the dependency-install cache.
-# Only a change to pyproject.toml or uv.lock triggers a re-install.
+# Install all third-party + dev packages (but not the project package itself) so
+# that a source-only change never busts this expensive layer.
 COPY pyproject.toml uv.lock /app/
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-install-project
+    uv sync --frozen --no-install-project --dev
+
+FROM dep-layer AS dependencies
 
 # Copy the full application source and install the project package
 # (including console-script entry points such as vultron-demo).
@@ -25,10 +26,11 @@ ENV PYTHONPATH=/app
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen
 
-FROM dependencies AS test
-# Install pytest and dev dependencies
-RUN uv sync --frozen --dev
-# Run the unit tests
+FROM dep-layer AS test
+COPY . /app/
+ENV PYTHONPATH=/app
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --dev
 CMD ["uv", "run", "pytest"]
 
 FROM dependencies AS docs
@@ -42,11 +44,10 @@ RUN mkdir -p /app/data
 CMD ["uv","run","uvicorn","vultron.adapters.driving.fastapi.main:app","--host","0.0.0.0","--port","7999","--reload"]
 
 FROM dependencies AS demo
-COPY docker/demo-entrypoint.sh /app/demo-entrypoint.sh
-RUN chmod +x /app/demo-entrypoint.sh
+COPY --chmod=755 docker/demo-entrypoint.sh /app/demo-entrypoint.sh
 ENTRYPOINT ["/app/demo-entrypoint.sh"]
 
-FROM dependencies AS dev
+FROM dep-layer AS dev
 
 # Clear VIRTUAL_ENV so uv resolves the project venv from the workspace path,
 # not /app/.venv (which is valid for app stages but wrong for devcontainer use).
@@ -92,7 +93,9 @@ ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt \
     SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
     CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 
-# Bake dev dependencies (pytest, mypy, black, etc.) into the image layer
+# Install project source (after all heavy system tooling is cached)
+COPY . /app/
+ENV PYTHONPATH=/app
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --dev
 


### PR DESCRIPTION
Closes #1587

## Summary

- Introduces a `dep-layer` stage that installs all third-party + dev packages (but not the project package itself), so source-only changes never bust the expensive dependency install layer
- Branches `test` and `dev` from `dep-layer` instead of `dependencies`, keeping heavy system tooling and dep installation decoupled from source changes
- Adds `--mount=type=cache` to the missing `uv sync` in the `test` stage
- Moves `COPY . /app/` in the `dev` stage to after all apt/Node/AWS CLI/gh/Claude Code installs so those layers survive source edits
- Replaces two-step `COPY` + `RUN chmod` with `COPY --chmod=755` in the `demo` stage
- Excludes `.devcontainer/` and `docker/` from `COPY . /app/` via `.dockerignore`

## Test plan

- [ ] `docker build --target test .` passes with no test failures
- [ ] `docker build --target dependencies .` succeeds and `vultron-demo` entry point is present
- [ ] `docker build --target dev .` succeeds and dev tools (gh, node, aws) are available
- [ ] Make a source-only change (edit a `.py` file) and rebuild — confirm dep-install layers are cached (no pip/uv download output)
- [ ] Make a `pyproject.toml` change and rebuild — confirm dep-install layers correctly invalidate

🤖 Generated with [Claude Code](https://claude.com/claude-code)