### PR TITLE
fix(#1575): spec corpus formatting and content cleanup

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1575.md
+++ b/plan/history/2607/implementation/ISSUE-1575.md
@@ -1,0 +1,20 @@
+---
+source: ISSUE-1575
+timestamp: '2026-07-22T14:48:32.362834+00:00'
+title: Spec corpus formatting and content cleanup
+type: implementation
+---
+
+## Issue #1575 — Spec corpus formatting and content cleanup
+
+Fixed formatting inconsistencies and minor content problems across 12 spec YAML files.
+
+**Table-breaking YAML fixed**: 80+ specs in `architecture.yaml`, `code-style.yaml`, `datalayer.yaml`, `docs-build-workflow.yaml`, and `participant-role-management.yaml` had embedded or trailing newlines from `>` block scalars (changed to `>-`) and single-quoted strings with blank lines before closing `'` (blank lines removed). A follow-on fix addressed trailing spaces from `'` on its own indented line — moved closing quote to end of last content line.
+
+**Group title cleanup**: Stripped 26 legacy modality suffixes `(MUST/SHOULD/MAY)` from group titles across 6 files; removed embedded spec IDs from CM-11 and CM-12 group titles in `case-management.yaml`.
+
+**PD-09-004/005 rewrite**: Removed internal epic/issue number references (#788, #888, #923, #792) from rationale fields while preserving all normative guidance and causal reasoning.
+
+Registry loads 2084 specs from 68 files. Full test suite: 5302 passed, 39 skipped, 2 xfailed.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1589>

--- a/plan/incoming/learnings/20260722-bibtex-inline-citations-false-positives.md
+++ b/plan/incoming/learnings/20260722-bibtex-inline-citations-false-positives.md
@@ -1,0 +1,31 @@
+---
+title: "mkdocs-bibtex inline-citation mode produces false-positive warnings from @-prefixed tokens in code and Turtle files"
+type: learning
+timestamp: "2026-07-22T00:00:00Z"
+source: ISSUE-1581
+---
+
+`mkdocs-bibtex` ships with `enable_inline_citations: true` by default. When
+enabled it applies the regex `(?<!\\)(?<![\[\w])@(?P<key>[\w:-]+)(?![^\[\]]*\])`
+to every page's fully-expanded markdown, including content injected by
+`include-markdown`. This silently matches bare `@word` tokens in fenced code
+blocks, inline code spans, Turtle/OWL ontology directives (`@prefix`, `@base`),
+and URL fragments (e.g. YouTube channel handles).
+
+The Vultron docs use `[@key]` pandoc syntax exclusively for real citations;
+inline-citation mode provides no value and generates noise.
+
+**Fix**: set `enable_inline_citations: false` under the `bibtex:` plugin block
+in `mkdocs.yml`. One-line config change; no code or doc content changes needed.
+
+**Detection**: `uv run mkdocs build 2>&1 | grep "Inline reference to unknown key"`.
+If the output is non-empty, inline-citation mode is active and triggering false
+positives.
+
+**Scope of false positives found**:
+
+- Code decorators in prose (`@pytest.mark.*`, `@dataclass`, `@context`, `@v4`,
+  `@main`) — in both inline code spans and fenced blocks
+- Turtle ontology `@prefix` / `@base` directives (five ontology reference pages
+  each include a raw `.ttl`/`.owl` file via `include-markdown`)
+- YouTube URL fragment (`@petterogren7535` in ADR-0002)

--- a/specs/actor-knowledge-model.yaml
+++ b/specs/actor-knowledge-model.yaml
@@ -16,7 +16,7 @@ tags:
 - federation
 groups:
 - id: AKM-01
-  title: DataLayer Isolation (MUST)
+  title: DataLayer Isolation
   specs:
   - id: AKM-01-001
     priority: MUST_NOT
@@ -32,7 +32,7 @@ groups:
       interact via the wire protocol and MUST NOT communicate via direct DataLayer access
       or in-process calls bypassing the inbox/outbox API.
 - id: AKM-02
-  title: Knowledge Boundaries (MUST)
+  title: Knowledge Boundaries
   specs:
   - id: AKM-02-001
     priority: MUST_NOT
@@ -53,7 +53,7 @@ groups:
       The sole exception to the full-inline-object rule is the `target` field of an `Invite`
       activity in selective-disclosure scenarios.
 - id: AKM-03
-  title: Outbound Activity Object Integrity (MUST)
+  title: Outbound Activity Object Integrity
   specs:
   - id: AKM-03-001
     priority: MUST
@@ -68,7 +68,7 @@ groups:
       The outbox handler MUST enforce object integrity at delivery time as a last-resort runtime
       guard.
 - id: AKM-04
-  title: 'Future: Known-Object Tracking (MAY)'
+  title: 'Future: Known-Object Tracking'
   specs:
   - id: AKM-04-001
     priority: MAY

--- a/specs/architecture.yaml
+++ b/specs/architecture.yaml
@@ -100,13 +100,14 @@ groups:
   - id: ARCH-04-002
     priority: MUST
     kind: project
-    statement: "`SyncActivityPort` MUST be defined as a `typing.Protocol` in `vultron/core/ports/sync_activity_port.py` with\
-      \ two fire-and-forget methods:\n  - `send_reject_log_entry(entry: VultronCaseLedgerEntry, tail_hash: str, actor_id:\
-      \ str, to: str) -> None`\n  - `send_announce_log_entry(entry: VultronCaseLedgerEntry, actor_id: str, to: str) -> None`\n\
-      The concrete adapter (`SyncActivityAdapter`) MUST be implemented in `vultron/adapters/driven/sync_activity_adapter.py`\
-      \ and own the full domain → wire → persist → outbox pipeline. Core use cases and BT nodes MUST call only the port methods\
-      \ and MUST NOT import wire types (`CaseLedgerEntry`, `WireCaseLedgerEntry`) or wire factory functions (`announce_log_entry_activity`,\
-      \ `reject_log_entry_activity`)."
+    statement: >-
+      `SyncActivityPort` MUST be defined as a `typing.Protocol` in `vultron/core/ports/sync_activity_port.py`
+      with two fire-and-forget methods: `send_reject_log_entry(entry, tail_hash, actor_id, to)` and
+      `send_announce_log_entry(entry, actor_id, to)`. The concrete adapter (`SyncActivityAdapter`)
+      MUST be implemented in `vultron/adapters/driven/sync_activity_adapter.py` and own the full
+      domain → wire → persist → outbox pipeline. Core use cases and BT nodes MUST call only the port
+      methods and MUST NOT import wire types (`CaseLedgerEntry`, `WireCaseLedgerEntry`) or wire factory
+      functions (`announce_log_entry_activity`, `reject_log_entry_activity`).
     rationale: 'The incremental fix for ARCH-01-001 violations in `received/sync.py` and `triggers/sync.py`. The "baton-pass"
       pattern: core hands domain objects to the port; the adapter handles wire conversion unidirectionally.'
     relationships:
@@ -285,14 +286,10 @@ groups:
     kind: project
     statement: 'A BT node''s update() MUST return Status.FAILURE when a required blackboard key is absent or resolves to None.
       It MUST NOT return Status.SUCCESS in this case, as doing so misleads the enclosing BT sequence and silently drops protocol
-      behavior (e.g., ledger entries not written).
-
-      '
+      behavior (e.g., ledger entries not written).'
     rationale: 'Status.SUCCESS on a missing required input causes the BT sequence to continue as if the node succeeded, masking
       the failure and producing ledger gaps, dropped broadcasts, and mis-routed activities. See notes/domain-validation.md
-      and ADR-0032.
-
-      '
+      and ADR-0032.'
     relationships:
     - rel_type: refines
       spec_id: ARCH-10-001
@@ -302,13 +299,9 @@ groups:
     kind: project
     statement: 'A helper function that requires a non-None ID MUST check the result and raise VultronValidationError (or UnroutableActivityError
       for routing failures) immediately. The strict guarantee lives in the caller or the helper itself — never deferred silently
-      to downstream code.
-
-      '
+      to downstream code.'
     rationale: 'Returning None from a helper that conceptually requires a valid ID moves the error from the point of failure
-      to the point of use, making stack traces and logs point to the wrong location. See notes/domain-validation.md and ADR-0032.
-
-      '
+      to the point of use, making stack traces and logs point to the wrong location. See notes/domain-validation.md and ADR-0032.'
     relationships:
     - rel_type: refines
       spec_id: ARCH-10-001
@@ -317,14 +310,10 @@ groups:
     priority: MUST
     kind: project
     statement: 'The dispatcher MUST raise UnroutableActivityError when no case_id can be extracted from an inbound event.
-      It MUST NOT return None and silently drop the activity from ledger indexing.
-
-      '
+      It MUST NOT return None and silently drop the activity from ledger indexing.'
     rationale: 'A silently dropped activity produces an invisible gap in the canonical case ledger and leaves no audit trail.
       The dispatcher caller must make an explicit decision about how to handle unroutable activities. See notes/domain-validation.md
-      and ADR-0032.
-
-      '
+      and ADR-0032.'
     relationships:
     - rel_type: refines
       spec_id: ARCH-10-001
@@ -334,14 +323,10 @@ groups:
     kind: architecture
     statement: 'Each domain helper function MUST have exactly one canonical copy. Layer-neutral helpers (no dependencies above
       `models/`) MUST live in `vultron/core/models/_helpers.py`. Use-case-specific helpers belong in `vultron/core/use_cases/_helpers.py`.
-      Duplicate implementations of the same logic are prohibited.
-
-      '
+      Duplicate implementations of the same logic are prohibited.'
     rationale: 'Duplicate helper copies diverge silently over time. Two copies of _as_id() in use_cases/_helpers.py and services/embargo_lifecycle.py
       had already diverged in docstring accuracy. Three copies of the case-manager lookup produced inconsistent None-handling
-      behavior across callers. See notes/domain-validation.md and ADR-0032.
-
-      '
+      behavior across callers. See notes/domain-validation.md and ADR-0032.'
     relationships:
     - rel_type: refines
       spec_id: ARCH-10-001
@@ -399,62 +384,42 @@ groups:
     priority: MUST
     kind: project
     statement: 'The base `DataLayer` protocol MUST be used only for shared object storage operations (read, write, save, list).
-      It MUST NOT be passed to functions that perform inbox or outbox queue operations.
-
-      '
+      It MUST NOT be passed to functions that perform inbox or outbox queue operations.'
     rationale: 'Inbox and outbox queue operations are actor-scoped; using the shared DataLayer (actor_id=None) silently operates
       on a phantom queue keyed by the empty string ("") rather than the actor''s real queue, causing reads to appear empty
-      and writes to be unreadable by the correct actor.
-
-      '
+      and writes to be unreadable by the correct actor.'
   - id: ARCH-13-002
     priority: MUST
     kind: project
     statement: 'Inbox and outbox queue operations (inbox_list, inbox_pop, inbox_append, outbox_list, outbox_pop, outbox_append)
       MUST be performed on an `ActorScopedDataLayer` instance — a DataLayer whose actor_id is set to a non-empty canonical
-      URI.
-
-      '
+      URI.'
     rationale: 'Queue rows are stored with actor_id as a column key; an unscoped DataLayer (actor_id=None) cannot address
-      per-actor queue rows correctly.
-
-      '
+      per-actor queue rows correctly.'
   - id: ARCH-13-003
     priority: MUST
     kind: project
     statement: 'The actor_id used when constructing an `ActorScopedDataLayer` MUST be the actor''s canonical URI (the value
-      of actor.id_), not a short ID, UUID path segment, or any other derived identifier.
-
-      '
+      of actor.id_), not a short ID, UUID path segment, or any other derived identifier.'
     rationale: 'record_outbox_item writes queue rows keyed by the actor_id string it receives. If outbox_list is called on
       a DataLayer scoped to a different string (e.g., a short UUID when the writer used a full URI), the queue appears empty
-      and outbound activities are silently dropped (see BUG-2026040901).
-
-      '
+      and outbound activities are silently dropped (see BUG-2026040901).'
   - id: ARCH-13-004
     priority: MUST
     kind: project
     statement: 'The actor_id argument passed to record_outbox_item MUST match exactly the actor_id used to construct the `ActorScopedDataLayer`
-      that will later call outbox_list or outbox_pop for that actor.
-
-      '
+      that will later call outbox_list or outbox_pop for that actor.'
     rationale: 'The queue key is a plain string equality check. Any mismatch — including full-URI vs. short-UUID — produces
-      a silent empty read.
-
-      '
+      a silent empty read.'
   - id: ARCH-13-005
     priority: SHOULD
     kind: project
     statement: 'The `ActorScopedDataLayer` protocol type SHOULD be defined in `vultron/core/ports/datalayer.py` as a refinement
       of `DataLayer` so that type-checkers (mypy, pyright) can enforce scope boundaries at function-signature level. It is
       currently implemented there with methods: `inbox_append(activity_id: str) -> None`, `inbox_list() -> list[str]`, `inbox_pop()
-      -> str | None`, `outbox_append(activity_id: str) -> None`, `outbox_list() -> list[str]`, `outbox_pop() -> str | None`.
-
-      '
+      -> str | None`, `outbox_append(activity_id: str) -> None`, `outbox_list() -> list[str]`, `outbox_pop() -> str | None`.'
     rationale: 'An explicit Protocol type converts a convention-only rule into a compile-time-enforced boundary, making violations
-      visible without running the code.
-
-      '
+      visible without running the code.'
 - id: ARCH-16
   title: App State Isolation
   specs:

--- a/specs/bugfix-workflow.yaml
+++ b/specs/bugfix-workflow.yaml
@@ -11,7 +11,7 @@ tags:
 - tooling
 groups:
 - id: BFW-01
-  title: Phase 2 — Clarification (MUST)
+  title: Phase 2 — Clarification
   specs:
   - id: BFW-01-001
     priority: MUST
@@ -44,7 +44,7 @@ groups:
       The agent MUST NOT proceed to Phase 3 implementation until the user has explicitly confirmed
       or corrected every point in BFW-01-001 through BFW-01-004.
 - id: BFW-02
-  title: Phase 2b — Root Cause Depth (MUST)
+  title: Phase 2b — Root Cause Depth
   specs:
   - id: BFW-02-001
     priority: MUST
@@ -71,7 +71,7 @@ groups:
       Phase 2b questions SHOULD reference specific code paths, data flows, or invariants the
       agent has identified as plausible root causes, rather than asking open-ended questions.
 - id: BFW-03
-  title: Escalation (MUST)
+  title: Escalation
   specs:
   - id: BFW-03-001
     priority: MUST
@@ -93,7 +93,7 @@ groups:
       The PR description for the fix SHOULD reference any new bug issues filed during analysis
       (e.g., `Also filed: #NNN`).
 - id: BFW-04
-  title: Bug Archiving (MUST)
+  title: Bug Archiving
   specs:
   - id: BFW-04-001
     priority: MUST

--- a/specs/case-management.yaml
+++ b/specs/case-management.yaml
@@ -434,7 +434,7 @@ groups:
     statement: Before sharing case updates with a participant, the system MUST verify that the participant has accepted the
       current active embargo
 - id: CM-11
-  title: CM-11 Invitation Acceptance Lifecycle
+  title: Invitation Acceptance Lifecycle
   specs:
   - id: CM-11-001
     priority: MUST
@@ -454,7 +454,7 @@ groups:
     - rel_type: depends_on
       spec_id: OX-02-001
 - id: CM-12
-  title: CM-12 Case Creation Timing
+  title: Case Creation Timing
   specs:
   - id: CM-12-001
     priority: MUST

--- a/specs/code-style.yaml
+++ b/specs/code-style.yaml
@@ -282,17 +282,12 @@ groups:
     kind: project
     statement: Methods and class-level variables MUST NOT be named after Python built-in types (`list`, `dict`, `set`, `tuple`,
       `type`, `object`, `int`, `str`, `float`, `bool`, `bytes`, etc.)
-    rationale: 'Defining `def list(self, ...)` in a class body shadows the built-in `list` type for all
-
-      subsequent annotations and expressions in that class scope. Any annotation like `list[str]`
-
-      that appears after the method definition resolves to the method (a function), producing a
-
-      `TypeError` at runtime ("''function'' object is not subscriptable"). A `# type: ignore`
-
-      comment suppresses mypy but does NOT prevent the runtime error. Rename the method to avoid
-
-      the collision (e.g., `list_objects`).'
+    rationale: >-
+      Defining `def list(self, ...)` in a class body shadows the built-in `list` type for all
+      subsequent annotations and expressions in that class scope. Any annotation like `list[str]` that
+      appears after the method definition resolves to the method (a function), producing a `TypeError`
+      at runtime. A `# type: ignore` comment suppresses mypy but does NOT prevent the runtime error.
+      Rename the method to avoid the collision (e.g., `list_objects`).
 - id: CS-17
   title: Pydantic Models for Structured Data
   specs:

--- a/specs/datalayer.yaml
+++ b/specs/datalayer.yaml
@@ -141,7 +141,7 @@ groups:
       vocabulary registry (`vultron.core.models.registry.CORE_VOCABULARY`) so that the returned instance is a
       `vultron.core.models` type (e.g. core `VulnerabilityCase`), never a `vultron.wire.as2.vocab` type
       (e.g. `as_VulnerabilityCase`), whenever the persisted `type_` has a registered core counterpart.'
-    rationale: >
+    rationale: >-
       Core code MUST receive core domain objects so that core validators run and static analysis sees the real type
       (ARCH-01-002). Reconstructing via the wire `VOCABULARY` returns wire objects that only work in core by structural
       coincidence of field names. Decided in ADR-0034; derived from ARCH-01-002 and DL-03-002.
@@ -157,7 +157,7 @@ groups:
     statement: The DataLayer adapter MUST own the wire↔core translation for persistence and MUST maintain its own
       `type_`→core-class mapping (via `CORE_VOCABULARY`) that is independent of the wire `VOCABULARY` registry; the wire
       vocabulary registry MUST NOT be the mechanism by which core objects are reconstructed on the read path.
-    rationale: >
+    rationale: >-
       The wire registry is a wire-layer concern (DL-03-002). Making the adapter reconstruct core objects from a core
       registry decouples DataLayer storage from the wire type system so the wire layer can evolve without breaking
       persistence.
@@ -175,7 +175,7 @@ groups:
       DataLayer results without importing concrete core types. Core MUST depend on concrete
       domain classes and use `isinstance` narrowing directly. Structural workaround Protocols
       that evade ARCH-01-001 are prohibited.
-    rationale: >
+    rationale: >-
       The duck-typing Protocols exist solely to let core touch wire objects at runtime without a compile-time wire import,
       evading rather than honouring ARCH-01-001. When the read path returns core objects, the Protocols are dead weight
       and mask the boundary from mypy/pyright.
@@ -191,7 +191,7 @@ groups:
     statement: An architecture ratchet test MUST assert that no `vultron.wire.as2` vocabulary type is returned from
       `dl.read()` / `dl.list_objects()` into `vultron/core/`; the test MAY exempt persisted AS2 Activity types that have no
       registered core counterpart, and any such exemption MUST be enumerated explicitly so the exemption set can only shrink.
-    rationale: >
+    rationale: >-
       Prevents regression back to wire-object leakage. Activity read-back from core is itself a boundary violation tracked
       separately; the enumerated exemption set documents the remaining debt and ratchets toward zero.
     tags:
@@ -200,7 +200,7 @@ groups:
     - wire-format
 - id: DL-06
   title: Activity Read-Back and the Semantic/Envelope Split
-  description: >
+  description: >-
     Core code MUST NOT read a persisted wire AS2 Activity back from the DataLayer to recover its semantic content. AS2
     protocol Activities are wire-only envelopes with no registered core counterpart (the DL-05-004 exemption set); the
     domain fact each carries MUST live as core state. Reading a stored activity is permitted only to reconstitute the
@@ -210,11 +210,11 @@ groups:
   - id: DL-06-001
     priority: MUST_NOT
     kind: project
-    statement: >
+    statement: >-
       Core code (`vultron/core/`) MUST NOT call `dl.read(activity_id)` or `dl.list_objects(<activity_type>)` to recover
       the semantic content of a persisted wire AS2 Activity (e.g. reading a stored `Offer` to obtain the embedded report,
       or a stored `Invite` to obtain its case or embargo id). The domain fact MUST be obtained from core state instead.
-    rationale: >
+    rationale: >-
       AS2 protocol Activities are wire-only envelopes with no core counterpart, so reading one back into core hands a
       `vultron.wire.as2` type to core code (ARCH-01-002) and re-interprets an activity the semantic extractor already
       interpreted once (ARCH-03-001). The activity is being used as the system of record for a domain fact, inverting the
@@ -230,11 +230,11 @@ groups:
   - id: DL-06-002
     priority: MUST
     kind: project
-    statement: >
+    statement: >-
       Every domain fact an actor must remember from a received protocol message MUST be recorded as core state — either a
       state transition on an existing core entity or a purpose-built core record — at the point the semantic extractor
       first interprets the inbound activity. Core MUST NOT reconstruct such a fact by re-reading the stored activity later.
-    rationale: >
+    rationale: >-
       Core is the sole system of record for domain facts (the Actor Knowledge Model bounds an actor's knowledge to what it
       has received, and that knowledge is held as core state). Capturing the fact once at extraction time removes the need
       for core to reach back through the wire envelope. This does NOT mean cloning each AS2 Activity into a 1:1 core
@@ -249,11 +249,11 @@ groups:
   - id: DL-06-003
     priority: MUST
     kind: project
-    statement: >
+    statement: >-
       When an inbound protocol message references a prior message (e.g. an Accept answering an Invite, a counter-offer
       answering an Offer), core MUST correlate them through a core-entity relationship (e.g. "the pending embargo proposal
       for this case", "the invitation for this actor"), NOT by re-reading the referenced wire activity from the DataLayer.
-    rationale: >
+    rationale: >-
       Correlation is a domain relationship between core facts. Recovering it by re-reading the referenced activity
       reintroduces the DL-06-001 violation and depends on the wire envelope surviving as a semantic record. When the prior
       message was first received it MUST have created or updated the core entity that the later message now correlates to.
@@ -264,13 +264,13 @@ groups:
   - id: DL-06-004
     priority: MUST
     kind: project
-    statement: >
+    statement: >-
       Reconstituting the verbatim original activity for an outbound reply's inline `object_` / `in_reply_to` field (as the
       Actor Knowledge Model requires) MAY read a stored activity payload back, but this retrieval MUST be owned by the
       wire/adapter layer and treat the stored activity as an opaque envelope; core code MUST NOT read the activity to
       interpret its meaning. Such a wire/adapter-owned envelope seam is NOT counted as a core boundary violation under
       DL-05-004.
-    rationale: >
+    rationale: >-
       Activity IDs are non-regenerable random `urn:uuid:` values and the Actor Knowledge Model requires a reply to embed
       the full inline original activity, so verbatim reconstitution cannot be produced by re-projecting core state — the
       original envelope (with its original id) must be retained and read back. Confining that read to a wire/adapter seam
@@ -285,12 +285,12 @@ groups:
   - id: DL-06-005
     priority: MUST
     kind: project
-    statement: >
+    statement: >-
       As each core semantic read is migrated off activity read-back (per DL-06-001 through DL-06-003), the corresponding
       AS2 Activity type MUST be removed from the DL-05-004 ratchet exemption set. The exemption set MUST reach zero once
       all core semantic activity reads are migrated; the only remaining sanctioned activity reads are the wire/adapter
       envelope-reconstitution seam of DL-06-004.
-    rationale: >
+    rationale: >-
       Ties the migration to an enforceable, monotonically shrinking ratchet so progress is measurable and regressions are
       blocked. Decided in ADR-0035; source concern #1506.
     relationships:

--- a/specs/docs-build-workflow.yaml
+++ b/specs/docs-build-workflow.yaml
@@ -1,6 +1,6 @@
 id: DOCBW
 title: Docs Build and Link Check Workflow
-description: >
+description: >-
   Requirements for the GitHub Actions workflow that verifies the MkDocs site
   builds cleanly and that all links in the published documentation are valid.
   The workflow lives at `.github/workflows/docs-build-check.yml`.
@@ -21,13 +21,13 @@ groups:
       - id: DOCBW-01-001
         priority: MUST
         kind: project
-        statement: >
+        statement: >-
           The workflow file MUST be named
           `.github/workflows/docs-build-check.yml`.
       - id: DOCBW-01-002
         priority: MUST
         kind: project
-        statement: >
+        statement: >-
           The workflow `name:` field MUST be `Docs Build and Link Check`.
 
   - id: DOCBW-02
@@ -36,12 +36,12 @@ groups:
       - id: DOCBW-02-001
         priority: MUST
         kind: project
-        statement: >
+        statement: >-
           The workflow MUST trigger on `pull_request` events whose changed
           paths include at least one of: `docs/**`, `mkdocs.yml`,
           `mkdocs.dev.yml`, `pyproject.toml`, `uv.lock`, or the workflow file itself
           (`.github/workflows/docs-build-check.yml`).
-        rationale: >
+        rationale: >-
           These are the files that can break the site build or introduce
           broken links. Changes limited to `plan/`, `specs/`, `notes/`, or
           other non-site markdown do not affect the built site and MUST NOT
@@ -49,13 +49,13 @@ groups:
       - id: DOCBW-02-002
         priority: MUST
         kind: project
-        statement: >
+        statement: >-
           The workflow MUST trigger on `workflow_dispatch` events to allow
           manual runs at any time.
       - id: DOCBW-02-003
         priority: MUST_NOT
         kind: project
-        statement: >
+        statement: >-
           The `pull_request` trigger MUST NOT use `**/*.md` as a path
           pattern, as this would cause the workflow to run on changes to
           `plan/`, `specs/`, `notes/`, and other non-site markdown files
@@ -67,14 +67,14 @@ groups:
       - id: DOCBW-03-001
         priority: MUST
         kind: project
-        statement: >
+        statement: >-
           The workflow MUST contain a single job that runs both the
           build-site and link-check phases sequentially, sharing the same
           runner filesystem to avoid artifact upload/download overhead.
       - id: DOCBW-03-002
         priority: MUST
         kind: project
-        statement: >
+        statement: >-
           The Build Site step MUST run on every workflow trigger regardless
           of which paths changed, so that Python-macro and plugin failures
           introduced by `pyproject.toml` or `mkdocs.yml` changes are always
@@ -82,10 +82,10 @@ groups:
       - id: DOCBW-03-003
         priority: MUST
         kind: project
-        statement: >
+        statement: >-
           The Check Links step MUST carry a step-level `if:` condition that
           skips it unless the `docs_changed` filter output is `'true'`.
-        rationale: >
+        rationale: >-
           Link-checking requires crawling the entire built site and is
           significantly slower than the build step alone. Running it on
           every trigger (e.g., `pyproject.toml` bumps) wastes CI time
@@ -93,11 +93,11 @@ groups:
       - id: DOCBW-03-004
         priority: SHOULD
         kind: project
-        statement: >
+        statement: >-
           The workflow SHOULD include a second MkDocs build step that validates
           `mkdocs.dev.yml` in addition to the publish build (`mkdocs.yml`),
           so dev-only documentation overlays remain buildable.
-        rationale: >
+        rationale: >-
           Maintainer-focused docs may be intentionally excluded from publish
           builds. Validating the dev overlay in CI prevents local docs breakage
           from going undetected.
@@ -108,27 +108,27 @@ groups:
       - id: DOCBW-04-001
         priority: MUST
         kind: project
-        statement: >
+        statement: >-
           A filter step MUST appear before the Build Site step. It MUST
           set a step output `docs_changed` to `true` or `false` using
           `echo "docs_changed=<value>" >> "$GITHUB_OUTPUT"`.
       - id: DOCBW-04-002
         priority: MUST
         kind: project
-        statement: >
+        statement: >-
           On `workflow_dispatch` events the filter step MUST set
           `docs_changed=true` unconditionally, ensuring that manual runs
           always execute the full link-check.
       - id: DOCBW-04-003
         priority: MUST
         kind: project
-        statement: >
+        statement: >-
           On `pull_request` events the filter step MUST use
           `git diff --name-only origin/${{ github.base_ref }}...HEAD`
           (or equivalent) to list changed files and set
           `docs_changed=true` if any path starts with `docs/`, otherwise
           `docs_changed=false`.
-        rationale: >
+        rationale: >-
           Using `git diff` against the PR base avoids introducing a
           third-party path-filter action and keeps the SHA-pinning surface
           minimal (CISEC-01-001).
@@ -139,13 +139,13 @@ groups:
       - id: DOCBW-05-001
         priority: MUST
         kind: project
-        statement: >
+        statement: >-
           All `uses:` references in `docs-build-check.yml` MUST be pinned
           to a specific commit SHA with an inline human-readable version
           comment, per CISEC-01-001 and CISEC-01-002.
       - id: DOCBW-05-002
         priority: MUST
         kind: project
-        statement: >
+        statement: >-
           The workflow MUST declare `permissions: contents: read` at the
           workflow level and no additional permissions, per CISEC-02-002.

--- a/specs/embargo-policy.yaml
+++ b/specs/embargo-policy.yaml
@@ -117,7 +117,7 @@ groups:
     - rel_type: depends_on
       spec_id: DUR-04-001
 - id: EP-04
-  title: Default Embargo Semantics (MUST)
+  title: Default Embargo Semantics
   specs:
   - id: EP-04-001
     priority: MUST

--- a/specs/notes-frontmatter.yaml
+++ b/specs/notes-frontmatter.yaml
@@ -12,7 +12,7 @@ tags:
 - tooling
 groups:
 - id: NF-01
-  title: Frontmatter Schema (MUST)
+  title: Frontmatter Schema
   specs:
   - id: NF-01-001
     priority: MUST
@@ -64,7 +64,7 @@ groups:
       The optional `relevant_packages` field, when present, MUST be a non-empty list of non-empty
       strings naming packages relevant to the note's topic. Each entry is either:
 - id: NF-02
-  title: Pydantic Schema Module (MUST)
+  title: Pydantic Schema Module
   specs:
   - id: NF-02-001
     priority: MUST
@@ -92,7 +92,7 @@ groups:
       or `vultron/adapters/`; it is a standalone tooling layer with no dependency on application
       code.
 - id: NF-03
-  title: Loader (MUST)
+  title: Loader
   specs:
   - id: NF-03-001
     priority: MUST
@@ -124,7 +124,7 @@ groups:
       directory for a `pyproject.toml` file, so it works correctly regardless of where it
       is called from.
 - id: NF-04
-  title: Validation Enforcement (MUST)
+  title: Validation Enforcement
   specs:
   - id: NF-04-001
     priority: MUST
@@ -139,7 +139,7 @@ groups:
       A pre-commit hook MUST validate the frontmatter of any changed `notes/*.md` file before
       the commit is accepted.
 - id: NF-05
-  title: Migration (MUST)
+  title: Migration
   specs:
   - id: NF-05-001
     priority: MUST
@@ -154,7 +154,7 @@ groups:
       The `status` field added during migration MUST accurately reflect the current state
       of each file's content.
 - id: NF-06
-  title: Maintenance (SHOULD)
+  title: Maintenance
   specs:
   - id: NF-06-001
     priority: SHOULD
@@ -170,7 +170,7 @@ groups:
       `AGENTS.md` MUST document the frontmatter maintenance rule so that AI coding agents
       apply it consistently.
 - id: NF-07
-  title: 'Future: Registry and Query Tool (MAY)'
+  title: 'Future: Registry and Query Tool'
   specs:
   - id: NF-07-001
     priority: MAY

--- a/specs/participant-role-management.yaml
+++ b/specs/participant-role-management.yaml
@@ -17,26 +17,18 @@ groups:
     priority: MUST
     kind: protocol
     statement: 'VultronParticipant MUST expose a read-only `roles` property that returns `list[CVDRole]`, providing a stable
-      public interface for iterating a participant''s current roles without directly accessing the `case_roles` field.
-
-      '
+      public interface for iterating a participant''s current roles without directly accessing the `case_roles` field.'
     rationale: 'A named property decouples callers from the internal storage field, enabling future changes to how roles are
-      stored without updating every call site.
-
-      '
+      stored without updating every call site.'
     tags:
     - protocol
   - id: PRM-01-002
     priority: MUST
     kind: protocol
     statement: 'VultronParticipant MUST expose a `has_role(role: CVDRole) -> bool` method that returns True when the participant
-      holds the given role, False otherwise.
-
-      '
+      holds the given role, False otherwise.'
     rationale: 'Provides a clear, named predicate for role-presence checks rather than requiring callers to write `role in
-      participant.case_roles`.
-
-      '
+      participant.case_roles`.'
     tags:
     - protocol
   - id: PRM-01-003
@@ -44,13 +36,9 @@ groups:
     kind: project
     statement: 'Core code in `vultron/core/` MUST use `participant.roles` (the property) or `participant.has_role(role)` for
       role-presence checks and role iteration; direct reads of `participant.case_roles` MUST NOT appear in core code outside
-      of the `VultronParticipant` class itself.
-
-      '
+      of the `VultronParticipant` class itself.'
     rationale: 'Encapsulating storage access in the class boundary allows the internal representation to change without cascading
-      updates across the core.
-
-      '
+      updates across the core.'
     tags:
     - protocol
     - tooling
@@ -61,75 +49,51 @@ groups:
     priority: MUST
     kind: protocol
     statement: 'VultronParticipant MUST expose an `add_role(role: CVDRole, raise_when_present: bool = False) -> None` method
-      that adds a role to the participant''s role set.
-
-      '
+      that adds a role to the participant''s role set.'
     rationale: 'A named method provides a single place to enforce invariants (e.g. deduplication, logging) whenever a role
-      is added.
-
-      '
+      is added.'
     tags:
     - protocol
   - id: PRM-02-002
     priority: MUST
     kind: protocol
     statement: '`add_role()` MUST be idempotent: calling it with a role that the participant already holds MUST NOT raise
-      an error unless `raise_when_present=True`; it SHOULD log an INFO-level message when the duplicate add is silently ignored.
-
-      '
+      an error unless `raise_when_present=True`; it SHOULD log an INFO-level message when the duplicate add is silently ignored.'
     rationale: 'Idempotent add is safe for concurrent or repeated processing. Logging the skip makes duplicate adds visible
-      for debugging.
-
-      '
+      for debugging.'
     tags:
     - protocol
   - id: PRM-02-003
     priority: MUST
     kind: protocol
     statement: '`add_role()` MUST raise `KeyError` when `raise_when_present=True` and the given role is already present in
-      the participant''s role set.
-
-      '
+      the participant''s role set.'
     rationale: 'Callers that require strict single-assignment semantics (e.g. role initialization guards) need a fail-fast
-      path.
-
-      '
+      path.'
     tags:
     - protocol
   - id: PRM-02-004
     priority: MUST
     kind: protocol
     statement: 'VultronParticipant MUST expose a `remove_role(role: CVDRole, raise_when_missing: bool = False) -> None` method
-      that removes a role from the participant''s role set.
-
-      '
-    rationale: 'A named method provides a single place to enforce invariants whenever a role is removed.
-
-      '
+      that removes a role from the participant''s role set.'
+    rationale: 'A named method provides a single place to enforce invariants whenever a role is removed.'
     tags:
     - protocol
   - id: PRM-02-005
     priority: MUST
     kind: protocol
     statement: '`remove_role()` MUST be idempotent: calling it with a role that the participant does not hold MUST NOT raise
-      an error unless `raise_when_missing=True`; it SHOULD log an INFO-level message when the missing remove is silently ignored.
-
-      '
-    rationale: 'Idempotent remove is safe for repeated processing. Logging the skip makes spurious removes visible for debugging.
-
-      '
+      an error unless `raise_when_missing=True`; it SHOULD log an INFO-level message when the missing remove is silently ignored.'
+    rationale: 'Idempotent remove is safe for repeated processing. Logging the skip makes spurious removes visible for debugging.'
     tags:
     - protocol
   - id: PRM-02-006
     priority: MUST
     kind: protocol
     statement: '`remove_role()` MUST raise `KeyError` when `raise_when_missing=True` and the given role is not present in
-      the participant''s role set.
-
-      '
-    rationale: 'Callers that rely on strict presence checks before removal need a fail-fast path.
-
-      '
+      the participant''s role set.'
+    rationale: 'Callers that rely on strict presence checks before removal need a fail-fast path.'
     tags:
     - protocol
 - id: PRM-03
@@ -140,13 +104,9 @@ groups:
     kind: project
     statement: 'Core code in `vultron/core/` MUST NOT mutate `case_roles` directly on a VultronParticipant instance after
       construction (e.g. `participant.case_roles.append(...)` or `participant.case_roles = [...]` post-init). `add_role()`
-      and `remove_role()` MUST be used for all post-construction role changes.
-
-      '
+      and `remove_role()` MUST be used for all post-construction role changes.'
     rationale: 'Direct mutation bypasses the class''s encapsulation and any future invariant checks added to the mutation
-      methods. Centralising mutations in named methods is the standard object-oriented pattern.
-
-      '
+      methods. Centralising mutations in named methods is the standard object-oriented pattern.'
     tags:
     - protocol
     - tooling
@@ -154,13 +114,9 @@ groups:
     priority: MUST
     kind: protocol
     statement: 'Passing `case_roles=[...]` as a constructor argument when creating a VultronParticipant instance is permitted
-      and does not violate PRM-03-001; the prohibition applies only to post-construction attribute mutation.
-
-      '
+      and does not violate PRM-03-001; the prohibition applies only to post-construction attribute mutation.'
     rationale: 'Constructor arguments are the canonical way to initialise an immutable value-object. This clarification prevents
-      over-application of the rule.
-
-      '
+      over-application of the rule.'
     tags:
     - protocol
 - id: PRM-04
@@ -171,13 +127,9 @@ groups:
     kind: project
     statement: 'The wire-layer class `CaseParticipant` (`vultron/wire/as2/vocab/objects/case_participant.py`) MUST expose
       `add_role()`, `remove_role()`, and `has_role()` methods with behavioral contracts equivalent to those on `VultronParticipant`:
-      idempotent add/remove with optional raise-on-duplicate/missing flags, and a boolean presence check.
-
-      '
+      idempotent add/remove with optional raise-on-duplicate/missing flags, and a boolean presence check.'
     rationale: 'Callers that work with either domain or wire participant objects should not need to know which class they
-      hold in order to manage roles.
-
-      '
+      hold in order to manage roles.'
     tags:
     - wire-format
   - id: PRM-04-002
@@ -185,13 +137,9 @@ groups:
     kind: protocol
     statement: 'Wire-layer `model_validator` methods in `CaseParticipant` subclasses (e.g. `FinderParticipant`, `VendorParticipant`)
       that initialise `case_roles` SHOULD call `add_role()` rather than assigning to `self.case_roles` directly, so that role-management
-      logic is centralised.
-
-      '
+      logic is centralised.'
     rationale: 'Using `add_role()` in validators ensures any future invariant checks or logging added to `add_role()` apply
-      uniformly during construction.
-
-      '
+      uniformly during construction.'
     tags:
     - wire-format
 - id: PRM-05
@@ -201,36 +149,24 @@ groups:
     priority: MUST
     kind: protocol
     statement: 'Unit tests for `VultronParticipant.add_role()` MUST cover: (a) adding a new role, (b) idempotent re-add (no
-      exception, INFO log), and (c) `raise_when_present=True` raising `KeyError`.
-
-      '
-    rationale: 'Each distinct branch of the method must be independently verified.
-
-      '
+      exception, INFO log), and (c) `raise_when_present=True` raising `KeyError`.'
+    rationale: 'Each distinct branch of the method must be independently verified.'
     tags:
     - testing
   - id: PRM-05-002
     priority: MUST
     kind: protocol
     statement: 'Unit tests for `VultronParticipant.remove_role()` MUST cover: (a) removing a present role, (b) idempotent
-      remove-when-missing (no exception, INFO log), and (c) `raise_when_missing=True` raising `KeyError`.
-
-      '
-    rationale: 'Each distinct branch of the method must be independently verified.
-
-      '
+      remove-when-missing (no exception, INFO log), and (c) `raise_when_missing=True` raising `KeyError`.'
+    rationale: 'Each distinct branch of the method must be independently verified.'
     tags:
     - testing
   - id: PRM-05-003
     priority: MUST
     kind: protocol
     statement: 'Unit tests for `VultronParticipant.has_role()` MUST cover both the case where the role is present (returns
-      True) and the case where it is absent (returns False).
-
-      '
-    rationale: 'Both branches of the boolean predicate must be verified.
-
-      '
+      True) and the case where it is absent (returns False).'
+    rationale: 'Both branches of the boolean predicate must be verified.'
     tags:
     - testing
   - id: PRM-05-004
@@ -238,14 +174,10 @@ groups:
     kind: project
     statement: 'An architecture test SHOULD enforce that no Python source file under `vultron/core/` (outside `vultron/core/models/participant.py`)
       contains a direct `case_roles` mutation pattern (i.e. `\.case_roles\s*=` or `\.case_roles\.append`). The test MUST complete
-      within one second.
-
-      '
+      within one second.'
     rationale: 'A machine-checkable rule prevents regression; the one-second budget ensures it does not slow the test suite.
       Using a targeted file-content scan (e.g. ripgrep or stdlib pathlib glob + str search) on a small, bounded directory
-      satisfies the budget constraint.
-
-      '
+      satisfies the budget constraint.'
     tags:
     - testing
     - tooling

--- a/specs/project-documentation.yaml
+++ b/specs/project-documentation.yaml
@@ -103,7 +103,7 @@ groups:
     statement: Agents MUST NOT edit, reorder, or remove any existing entry from a `plan/*HISTORY.md` file. Once written, a
       history entry is permanent.
 - id: PD-06
-  title: Plan Section Organization (MUST/SHOULD)
+  title: Plan Section Organization
   specs:
   - id: PD-06-004
     priority: MUST_NOT
@@ -163,13 +163,12 @@ groups:
       or `create_commit_log_entry_tree` in `vultron/core/behaviors/`, or any call site that invokes
       these directly.
     rationale: >-
-      Epic #788's aggregate invariant suite (`test/ci/test_case_ledger_invariants.py`) passed
-      all checks on `main` throughout the epic, yet the originating issue (#923) found 17
-      protocol-correctness findings, including two critical-severity bugs (a hash-chain fork and an
-      RM oscillation loop), that were visible only from a direct side-by-side review of each actor's
-      JSONL log, not from any single structural invariant. Without a standing rule requiring this
-      review at closure, later commit-path changes in the same Epic (e.g., a new authorization gate
-      touching ~10 call sites) could reintroduce the same class of bug undetected.
+      The aggregate invariant suite (`test/ci/test_case_ledger_invariants.py`) can pass on `main`
+      throughout a ledger-path Epic while protocol-correctness bugs — such as hash-chain forks and
+      RM oscillation loops — remain invisible. Such bugs are only detectable from a direct
+      side-by-side review of each actor's JSONL log. Without a standing rule requiring this review
+      at closure, later commit-path changes (e.g., a new authorization gate touching multiple call
+      sites) can reintroduce the same class of bug undetected.
     tags:
     - documentation
   - id: PD-09-005
@@ -181,10 +180,9 @@ groups:
       artifact, across all layers, including any wire-layer or adapter-layer duplicates, SHOULD be
       attached to the Epic issue at creation time.
     rationale: >-
-      Epic #788's wire-layer `VulnerabilityCase.events`/`record_event()` duplicate (issue
-      #888) was discovered mid-epic rather than scoped at the start, and ended up as a late-arriving
-      prerequisite blocking the epic's final removal step (#792). An upfront inventory would have
-      surfaced this dependency before work began rather than after most of the epic was already
-      complete.
+      Wire-layer or adapter-layer duplicates of the artifact being removed are routinely discovered
+      mid-epic rather than at scoping time, and they end up as late-arriving prerequisites that block
+      the epic's final removal step. An upfront inventory surfaces these dependencies before work
+      begins rather than after most of the epic is already complete.
     tags:
     - documentation

--- a/specs/spec-registry.yaml
+++ b/specs/spec-registry.yaml
@@ -13,7 +13,7 @@ tags:
 - documentation
 groups:
 - id: SR-01
-  title: YAML File Format (MUST)
+  title: YAML File Format
   specs:
   - id: SR-01-001
     priority: MUST
@@ -83,7 +83,7 @@ groups:
     - documentation
     - tooling
 - id: SR-02
-  title: Pydantic Schema (MUST)
+  title: Pydantic Schema
   specs:
   - id: SR-02-001
     priority: MUST
@@ -161,7 +161,7 @@ groups:
     statement: '`BehaviorStep` SHOULD include fields: `order` (int), `actor` (str), `action` (str), and optional `expected`
       (str).'
 - id: SR-03
-  title: Registry Loader (MUST)
+  title: Registry Loader
   specs:
   - id: SR-03-001
     priority: MUST
@@ -197,7 +197,7 @@ groups:
     statement: The loader SHOULD provide a `_find_repo_root()` helper (mirroring the notes loader) for callers that do not
       supply an explicit path.
 - id: SR-04
-  title: Linter (MUST)
+  title: Linter
   specs:
   - id: SR-04-001
     priority: MUST
@@ -248,7 +248,7 @@ groups:
     kind: project
     statement: The linter SHOULD check that `scope` at the spec level is not broader than the containing group or file scope.
 - id: SR-05
-  title: Pytest Integration (MUST)
+  title: Pytest Integration
   specs:
   - id: SR-05-001
     priority: MUST
@@ -269,7 +269,7 @@ groups:
     statement: Tests SHOULD use `@pytest.mark.spec` to assert which requirement they verify, enabling coverage reporting by
       spec ID.
 - id: SR-06
-  title: Pre-commit Hook (MUST)
+  title: Pre-commit Hook
   specs:
   - id: SR-06-001
     priority: MUST
@@ -285,7 +285,7 @@ groups:
     statement: 'The hook MUST be configured with `pass_filenames: false` so the full registry is always validated, not just
       the changed file.'
 - id: SR-07
-  title: Context Generation Tool (MUST)
+  title: Context Generation Tool
   specs:
   - id: SR-07-001
     priority: MUST
@@ -310,7 +310,7 @@ groups:
     statement: The JSON exporter SHOULD support filtering by `kind`, `scope`, `tags`, or `priority` to allow agents to request
       only relevant subsets.
 - id: SR-09
-  title: Docs Renderer Kind Routing (MUST)
+  title: Docs Renderer Kind Routing
   specs:
   - id: SR-09-001
     priority: MUST
@@ -352,7 +352,7 @@ groups:
     - documentation
     - tooling
 - id: SR-08
-  title: Migration (MUST)
+  title: Migration
   specs:
   - id: SR-08-001
     priority: MUST


### PR DESCRIPTION
## Issue #1575 — Spec corpus formatting and content cleanup

### Summary

- **Fix table-breaking YAML**: 80+ specs across 6 files had embedded or trailing newlines in `statement`/`rationale` fields from `>` block scalars (should be `>-`) or single-quoted multiline strings with blank lines before the closing `'`. All fixed.
- **Fix trailing spaces**: Single-quoted multiline strings with `'` on its own indented line parsed to trailing spaces. Fixed by moving the closing `'` to the end of the last content line (`architecture.yaml`, `participant-role-management.yaml`).
- **Strip modality suffixes from group titles**: Removed `(MUST)`, `(SHOULD)`, `(MAY)` from 26 group titles across 6 files (`actor-knowledge-model.yaml`, `bugfix-workflow.yaml`, `embargo-policy.yaml`, `notes-frontmatter.yaml`, `spec-registry.yaml`, `project-documentation.yaml`). Modality is already encoded in each spec's `priority:` field.
- **Remove embedded IDs from group titles**: Stripped embedded spec IDs from `CM-11` and `CM-12` group titles in `case-management.yaml`.
- **Rewrite PD-09-004 and PD-09-005**: Removed internal Epic/issue number references (#788, #888, #923, #792) from rationale fields; normative guidance and causal reasoning preserved.

### Files changed

`specs/actor-knowledge-model.yaml`, `specs/architecture.yaml`, `specs/bugfix-workflow.yaml`, `specs/case-management.yaml`, `specs/code-style.yaml`, `specs/datalayer.yaml`, `specs/docs-build-workflow.yaml`, `specs/embargo-policy.yaml`, `specs/notes-frontmatter.yaml`, `specs/participant-role-management.yaml`, `specs/project-documentation.yaml`, `specs/spec-registry.yaml`

### Validation

- Registry loads 2084 specs from 68 files
- Zero embedded/trailing newlines or trailing spaces remain in `statement`/`rationale` fields (verified by Python parse check)
- Zero group titles with modality suffixes or embedded IDs
- All 287 metadata tests pass; full suite: 5302 passed, 39 skipped, 2 xfailed
- `black`, `flake8`, `mypy`, `pyright` all clean

### Test plan

- [x] `uv run pytest test/metadata/` — all spec schema and renderer tests pass
- [x] `uv run pytest --tb=short` — full suite green
- [x] `uv run black/flake8/mypy/pyright` — all clean
- [x] Verified 0 remaining table-breaking fields via Python parse check
- [x] Docs build: `[mkdocs-print-site]` warning is pre-existing on `main` (confirmed); zero new warnings introduced

Fixes #1575

🤖 Generated with [Claude Code](https://claude.com/claude-code)