### PR TITLE
docs: plan issue #1234 — FCV demo scenario spec (DEMOMA-12)

### DIFF
--- a/notes/demo-future-ideas.md
+++ b/notes/demo-future-ideas.md
@@ -44,7 +44,7 @@ be treated as working implementations.
 
 | Scenario | Issue | Description | Blocked by | Status |
 |----------|-------|-------------|------------|--------|
-| FCV | #1234 | F reports to C; C invites V; three-actor coordination | — | planned |
+| FCV | #1234 | F reports to C; C invites V; three-actor coordination | invariant harness refactor | planned (spec: DEMOMA-12) |
 | FVCV-handoff | #1214 | V1 transfers ownership to C; C invites V2 | — | planned (tracked in impl issue) |
 | FCCV-extension | #1215 | C1 retains case; C2 is participant; C2 asks C1 to invite V | — | planned |
 | FCCV-handoff | #1216 | C1 transfers to C2; C2 invites V | #1215 | planned |

--- a/plan/history/2607/idea/IDEA-1234.md
+++ b/plan/history/2607/idea/IDEA-1234.md
@@ -1,0 +1,32 @@
+---
+source: IDEA-1234
+timestamp: '2026-07-22T15:03:08.480714+00:00'
+title: Implement FCV demo scenario (Finder + Coordinator + Vendor)
+type: idea
+---
+
+## Outcome
+
+Converted to spec + implementation issues. DEMOMA-12 group (8 requirements)
+added to `specs/multi-actor-demo.yaml` covering four-container FCV topology,
+Coordinator-as-CASE_OWNER semantics, direct Vendor invitation path,
+final-state requirements, CI job mandate, and per-scenario invariant test
+file requirement.
+
+## Key decisions
+
+- **Coordinator role**: holds CASE_OWNER only; CaseActor service holds CASE_MANAGER
+  (standard protocol — issue AC wording was imprecise)
+- **Container topology**: 4 containers (finder, coordinator, vendor, case-actor),
+  mirroring FVCV-extension; all already present in docker-compose-multi-actor.yml
+- **File naming**: new `fcv_demo.py`; `three_actor_demo.py` stays deprecated with
+  `@deprecated` decorator (Python 3.13 `warnings.deprecated`) applied in Issue A
+- **Vendor invitation path**: direct `invite-actor-to-case` (no suggestion workflow)
+- **Invariant harness**: separate refactor issue (#1592) must land first; FCV is
+  blocked-by it; DEMOMA-12-008 mandates a per-scenario invariant test file
+
+## Outputs
+
+- Docs PR: <https://github.com/CERTCC/Vultron/pull/1591> (`Closes #1234`)
+- Impl issue A: #1593 — feat: implement FCV demo scenario (child of #1277, blocked-by #1592)
+- Impl issue B: #1592 — refactor: modularize case-ledger invariant harness (child of #1093)

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -682,8 +682,8 @@ groups:
     statement: >-
       The Coordinator MUST receive the Finder's report (RM→RECEIVED), validate it
       (RM→VALID), and engage the case (RM→ACCEPTED), which triggers CaseActor
-      creation co-located on the Coordinator's container. The Coordinator MUST hold
-      `CVDRole.CASE_OWNER` throughout the entire scenario. Ownership MUST NOT
+      creation on the Coordinator's container. The Coordinator MUST hold
+      `CVDRole.CASE_OWNER` throughout the entire scenario; ownership MUST NOT
       transfer to any other actor.
     rationale: >-
       FCV is the canonical Coordinator-as-owner scenario: Finder reports to
@@ -691,6 +691,27 @@ groups:
       is owner) and FVCV-extension (Vendor retains ownership). The CaseActor
       service actor holds CASE_MANAGER alongside COORDINATOR role per glossary;
       the Coordinator human actor holds CASE_OWNER only.
+    preconditions:
+    - description: >-
+        Finder and Coordinator containers running; no VulnerabilityCase exists
+        for this report; Coordinator auto_create_case=True
+    steps:
+    - order: 1
+      actor: finder
+      action: POST submit-report trigger directed at Coordinator
+      expected: Report delivered to Coordinator inbox
+    - order: 2
+      actor: coordinator
+      action: BT processes inbound report; RM transitions RECEIVED→VALID→ACCEPTED
+      expected: VulnerabilityCase created; CaseActor spawned on Coordinator container
+    - order: 3
+      actor: coordinator
+      action: Coordinator assigned CVDRole.CASE_OWNER on the new case
+      expected: Coordinator holds CASE_OWNER; CaseActor holds CASE_MANAGER
+    postconditions:
+    - description: >-
+        VulnerabilityCase exists; Coordinator RM=ACCEPTED, CVDRole=CASE_OWNER;
+        CaseActor running with CASE_MANAGER; no ownership transfer has occurred
     relationships:
     - rel_type: refines
       spec_id: CM-02-001
@@ -702,6 +723,29 @@ groups:
       trigger after case creation. Finder MUST accept the invitation and become a
       full SIGNATORY participant with a case replica in their DataLayer before
       Vendor is invited.
+    preconditions:
+    - description: >-
+        VulnerabilityCase exists; Coordinator holds CASE_OWNER (DEMOMA-12-002
+        postconditions satisfied); Finder is not yet a case participant
+    steps:
+    - order: 1
+      actor: coordinator
+      action: POST invite-actor-to-case trigger for Finder
+      expected: Invite(Actor, Case) delivered to Finder inbox
+    - order: 2
+      actor: demo_script
+      action: Poll Finder DataLayer until Invite(Actor, Case) is visible
+      expected: Invitation record present in Finder replica
+    - order: 3
+      actor: finder
+      action: POST accept-case-invite trigger
+      expected: >-
+        Finder transitions to SIGNATORY; CaseActor emits Announce(VulnerabilityCase)
+        to seed Finder replica
+    postconditions:
+    - description: >-
+        Finder is SIGNATORY with a seeded case replica; Vendor invitation has
+        not yet been issued
     relationships:
     - rel_type: refines
       spec_id: CM-20-001
@@ -720,6 +764,30 @@ groups:
       the ADR-0026 suggest/approve chain is for participants recommending actors to
       the case owner, not for the owner inviting directly. Polling before accept
       is required for determinism (per DEMOMA-11-009 pattern).
+    preconditions:
+    - description: >-
+        Finder is SIGNATORY (DEMOMA-12-003 postconditions satisfied);
+        Vendor is not yet a case participant
+    steps:
+    - order: 1
+      actor: coordinator
+      action: POST invite-actor-to-case trigger for Vendor
+      expected: Invite(Actor, Case) delivered to Vendor inbox
+    - order: 2
+      actor: demo_script
+      action: Poll Vendor DataLayer until Invite(Actor, Case) is visible
+      expected: Invitation record present in Vendor replica
+    - order: 3
+      actor: vendor
+      action: POST accept-case-invite trigger
+      expected: >-
+        Vendor transitions to SIGNATORY; CaseActor emits Announce(VulnerabilityCase)
+        to seed Vendor replica with full case history
+    postconditions:
+    - description: >-
+        Vendor is SIGNATORY with a seeded case replica containing full history
+        from genesis; all three actors (Finder, Coordinator, Vendor) plus
+        CaseActor are now case participants
     relationships:
     - rel_type: refines
       spec_id: CM-17-001
@@ -761,21 +829,38 @@ groups:
     priority: MUST
     kind: project
     statement: >-
-      The implementation MUST ship a dedicated per-scenario case-ledger invariant
-      test file (`test/ci/test_case_ledger_invariants_fcv.py`) built on the shared
-      invariant library introduced by the harness refactor issue. The FCV test MUST
-      assert the following invariants specific to this scenario in addition to the
-      universal chain/hash/RM-closed checks: (1) `validate_report` event present
-      in case-actor log; (2) `invite_actor_to_case` present at least twice (Finder
-      + Vendor invitations); (3) `close_case` present; (4) CS transitions VFd, VFD,
-      and public-aware (P) all observed in `add_participant_status_to_participant`
-      entries; (5) Vendor replica holds the complete log from genesis (full history
-      backfill required as Vendor is a late joiner).
+      The FCV implementation MUST ship a dedicated per-scenario case-ledger
+      invariant test file (`test/ci/invariants/test_fcv_invariants.py`) built
+      exclusively on the shared invariant library introduced by the harness
+      refactor issue (DEMOMA-12-008 is satisfied only when that shared library
+      exists). The test file MUST NOT duplicate universal invariant logic;
+      universal chain/hash/RM-closed checks MUST be imported from the shared
+      library, not re-implemented inline.
     rationale: >-
-      Scenario-specific invariants prevent the scenario from accidentally omitting
-      protocol steps that are not exercised by the universal invariants. Each
-      scenario MUST define its own event-type and late-joiner invariants so that
-      CI catches regressions in the steps unique to that scenario.
+      Requiring use of the shared library enforces the DRY constraint across
+      scenarios. A file that copies invariant logic is not compliant even if
+      it tests the correct things.
     relationships:
     - rel_type: refines
       spec_id: DEMOMA-12-006
+  - id: DEMOMA-12-009
+    priority: MUST
+    kind: project
+    statement: >-
+      The FCV per-scenario invariant test file MUST assert the following
+      scenario-specific checks in addition to the universal library checks:
+      (1) `validate_report` event present in case-actor log; (2)
+      `invite_actor_to_case` present at least twice (Finder invitation +
+      Vendor invitation); (3) `close_case` present; (4) CS transitions VFd,
+      VFD, and public-aware (P) all observed in
+      `add_participant_status_to_participant` entries for the Vendor actor;
+      (5) Vendor replica holds the complete log from genesis (full history
+      backfill, as Vendor is a late joiner).
+    rationale: >-
+      Scenario-specific invariants prevent the FCV scenario from accidentally
+      omitting protocol steps not covered by universal checks. Explicitly
+      enumerating them here means CI will catch regressions in the steps
+      unique to FCV.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-12-008

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -656,3 +656,126 @@ groups:
     relationships:
     - rel_type: refines
       spec_id: DEMOMA-10-007
+
+- id: DEMOMA-12
+  title: FCV Scenario (Finder reports to Coordinator; Coordinator invites Vendor)
+  specs:
+  - id: DEMOMA-12-001
+    priority: MUST
+    kind: project
+    statement: >-
+      The FCV scenario MUST involve four actor identities — Finder, Coordinator,
+      Vendor, and CaseActor — each with its own isolated DataLayer and separate
+      container. The CaseActor MUST run as a separate actor identity with its own
+      container and DataLayer, not co-located on the Coordinator container.
+    rationale: >-
+      FCV is the canonical three-party coordination baseline. Using four separate
+      containers (Finder, Coordinator, Vendor, CaseActor) matches the FVCV-extension
+      topology (DEMOMA-10-001) and ensures the demo exercises true multi-container
+      message delivery rather than in-process calls.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-01-001
+  - id: DEMOMA-12-002
+    priority: MUST
+    kind: project
+    statement: >-
+      The Coordinator MUST receive the Finder's report (RM→RECEIVED), validate it
+      (RM→VALID), and engage the case (RM→ACCEPTED), which triggers CaseActor
+      creation co-located on the Coordinator's container. The Coordinator MUST hold
+      `CVDRole.CASE_OWNER` throughout the entire scenario. Ownership MUST NOT
+      transfer to any other actor.
+    rationale: >-
+      FCV is the canonical Coordinator-as-owner scenario: Finder reports to
+      Coordinator, Coordinator creates the case. This contrasts with FVV (Vendor
+      is owner) and FVCV-extension (Vendor retains ownership). The CaseActor
+      service actor holds CASE_MANAGER alongside COORDINATOR role per glossary;
+      the Coordinator human actor holds CASE_OWNER only.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-02-001
+  - id: DEMOMA-12-003
+    priority: MUST
+    kind: project
+    statement: >-
+      The Coordinator MUST invite Finder to the case using the `invite-actor-to-case`
+      trigger after case creation. Finder MUST accept the invitation and become a
+      full SIGNATORY participant with a case replica in their DataLayer before
+      Vendor is invited.
+    relationships:
+    - rel_type: refines
+      spec_id: CM-20-001
+  - id: DEMOMA-12-004
+    priority: MUST
+    kind: project
+    statement: >-
+      The Coordinator MUST invite Vendor to the case using the `invite-actor-to-case`
+      trigger directly (not via a suggestion/approval chain). Vendor MUST accept via
+      the `accept-case-invite` trigger. The CaseActor MUST then emit
+      `Announce(VulnerabilityCase)` to seed Vendor's case replica. The demo script
+      MUST poll Vendor's DataLayer for the arriving invitation before driving the
+      accept step.
+    rationale: >-
+      Coordinator is CASE_OWNER, so a direct `invite-actor-to-case` is correct;
+      the ADR-0026 suggest/approve chain is for participants recommending actors to
+      the case owner, not for the owner inviting directly. Polling before accept
+      is required for determinism (per DEMOMA-11-009 pattern).
+    relationships:
+    - rel_type: refines
+      spec_id: CM-17-001
+  - id: DEMOMA-12-005
+    priority: MUST
+    kind: project
+    statement: >-
+      The FCV scenario MUST reach a final state with three participants — Finder,
+      Coordinator, and Vendor (plus the CaseActor) — and MUST advance to VFDPxa
+      CS with EM.EXITED and RM.CLOSED for all participants. Only Vendor's fix path
+      (VFD) is tracked; Coordinator and Finder have no VENDOR role and therefore
+      no vendor fix path.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-03-002
+  - id: DEMOMA-12-006
+    priority: MUST
+    kind: project
+    statement: >-
+      The FCV scenario MUST run deterministically end-to-end and MUST verify SYNC-2
+      replica convergence for Finder and Vendor replicas against the authoritative
+      Coordinator/CaseActor state after each major protocol event.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-09-004
+  - id: DEMOMA-12-007
+    priority: MUST
+    kind: project
+    statement: >-
+      The implementation of the FCV scenario MUST add a dedicated parallel CI job
+      (`DEMO=fcv`) to `.github/workflows/demo-integration.yml` in the same PR, so
+      CI failures are independently reported per DEMOCI-03-003.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOCI-03-002
+    - rel_type: refines
+      spec_id: DEMOCI-03-003
+  - id: DEMOMA-12-008
+    priority: MUST
+    kind: project
+    statement: >-
+      The implementation MUST ship a dedicated per-scenario case-ledger invariant
+      test file (`test/ci/test_case_ledger_invariants_fcv.py`) built on the shared
+      invariant library introduced by the harness refactor issue. The FCV test MUST
+      assert the following invariants specific to this scenario in addition to the
+      universal chain/hash/RM-closed checks: (1) `validate_report` event present
+      in case-actor log; (2) `invite_actor_to_case` present at least twice (Finder
+      + Vendor invitations); (3) `close_case` present; (4) CS transitions VFd, VFD,
+      and public-aware (P) all observed in `add_participant_status_to_participant`
+      entries; (5) Vendor replica holds the complete log from genesis (full history
+      backfill required as Vendor is a late joiner).
+    rationale: >-
+      Scenario-specific invariants prevent the scenario from accidentally omitting
+      protocol steps that are not exercised by the universal invariants. Each
+      scenario MUST define its own event-type and late-joiner invariants so that
+      CI catches regressions in the steps unique to that scenario.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-12-006

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -693,8 +693,10 @@ groups:
       the Coordinator human actor holds CASE_OWNER only.
     preconditions:
     - description: >-
-        Finder and Coordinator containers running; no VulnerabilityCase exists
-        for this report; Coordinator auto_create_case=True
+        All four containers running (Finder, Coordinator, Vendor, CaseActor);
+        no VulnerabilityCase exists for this report; Coordinator
+        auto_create_case=True; Coordinator pre-configured with the dedicated
+        CaseActor container URL
     steps:
     - order: 1
       actor: finder
@@ -703,18 +705,39 @@ groups:
     - order: 2
       actor: coordinator
       action: BT processes inbound report; RM transitions RECEIVED→VALID→ACCEPTED
-      expected: VulnerabilityCase created; CaseActor spawned on Coordinator container
+      expected: >-
+        VulnerabilityCase created; CaseActor registered on the separate
+        CaseActor container (not co-located on the Coordinator container,
+        per DEMOMA-12-001); default embargo initialized to EM.ACTIVE
+        (EP-04-001); EM.ACTIVE is established at case creation before
+        any participant invitation
     - order: 3
       actor: coordinator
       action: Coordinator assigned CVDRole.CASE_OWNER on the new case
       expected: Coordinator holds CASE_OWNER; CaseActor holds CASE_MANAGER
+    - order: 4
+      actor: coordinator
+      action: >-
+        Coordinator sends trust-bootstrap Create(VulnerabilityCase) to Finder
+        (CBT-01-001); Finder is the original report submitter so MUST receive
+        this one-time bootstrap to trust the CaseActor identity
+      expected: >-
+        Finder receives Create(VulnerabilityCase) carrying Coordinator as
+        CASE_OWNER and CaseActor as COORDINATOR; Finder trusts CaseActor
+        for this case
     postconditions:
     - description: >-
         VulnerabilityCase exists; Coordinator RM=ACCEPTED, CVDRole=CASE_OWNER;
-        CaseActor running with CASE_MANAGER; no ownership transfer has occurred
+        CaseActor running with CASE_MANAGER on its own container; EM.ACTIVE
+        established; trust bootstrap delivered to Finder; no ownership
+        transfer has occurred
     relationships:
     - rel_type: refines
       spec_id: CM-02-001
+    - rel_type: refines
+      spec_id: CBT-01-001
+    - rel_type: refines
+      spec_id: EP-04-001
   - id: DEMOMA-12-003
     priority: MUST
     kind: project
@@ -725,23 +748,28 @@ groups:
       Vendor is invited.
     preconditions:
     - description: >-
-        VulnerabilityCase exists; Coordinator holds CASE_OWNER (DEMOMA-12-002
-        postconditions satisfied); Finder is not yet a case participant
+        DEMOMA-12-002 postconditions satisfied: VulnerabilityCase exists,
+        Coordinator RM=ACCEPTED, CVDRole=CASE_OWNER, EM.ACTIVE, trust bootstrap
+        Create(VulnerabilityCase) already delivered to Finder (CBT-01-001);
+        Finder has trusted CaseActor identity but is not yet a formal case
+        participant (no Invite/Accept exchange has occurred)
     steps:
     - order: 1
       actor: coordinator
       action: POST invite-actor-to-case trigger for Finder
-      expected: Invite(Actor, Case) delivered to Finder inbox
+      expected: >-
+        Invite(Actor, Case) sent from CaseActor (not Coordinator) to Finder
+        inbox (PCR-08-007); invitation record present in Finder DataLayer
     - order: 2
       actor: demo_script
       action: Poll Finder DataLayer until Invite(Actor, Case) is visible
       expected: Invitation record present in Finder replica
     - order: 3
       actor: finder
-      action: POST accept-case-invite trigger
+      action: POST accept-case-invite trigger directed to CaseActor (PCR-08-008)
       expected: >-
-        Finder transitions to SIGNATORY; CaseActor emits Announce(VulnerabilityCase)
-        to seed Finder replica
+        Finder transitions to SIGNATORY (MV-10-006); CaseActor emits
+        Announce(VulnerabilityCase) to seed Finder replica (PCR-02-002)
     postconditions:
     - description: >-
         Finder is SIGNATORY with a seeded case replica; Vendor invitation has
@@ -799,10 +827,15 @@ groups:
       Coordinator, and Vendor (plus the CaseActor) — and MUST advance to VFDPxa
       CS with EM.EXITED and RM.CLOSED for all participants. Only Vendor's fix path
       (VFD) is tracked; Coordinator and Finder have no VENDOR role and therefore
-      no vendor fix path.
+      no vendor fix path. EM.EXITED is the terminal state; the causal chain is
+      EM.ACTIVE (established at case creation per EP-04-001) → triggered by CS.P
+      (DEMOMA-07-003(4)) → EM.EXITED. Demo scripts MUST verify EM.ACTIVE
+      at the case-creation milestone and EM.EXITED at the final milestone.
     relationships:
     - rel_type: refines
       spec_id: DEMOMA-03-002
+    - rel_type: refines
+      spec_id: EP-04-001
   - id: DEMOMA-12-006
     priority: MUST
     kind: project
@@ -832,10 +865,11 @@ groups:
       The FCV implementation MUST ship a dedicated per-scenario case-ledger
       invariant test file (`test/ci/invariants/test_fcv_invariants.py`) built
       exclusively on the shared invariant library introduced by the harness
-      refactor issue (DEMOMA-12-008 is satisfied only when that shared library
-      exists). The test file MUST NOT duplicate universal invariant logic;
-      universal chain/hash/RM-closed checks MUST be imported from the shared
-      library, not re-implemented inline.
+      refactor (issue #1592). DEMOMA-12-008 is satisfied only when that shared
+      library exists; the FCV invariant test file is blocked by #1592. The test
+      file MUST NOT duplicate universal invariant logic; universal
+      chain/hash/RM-closed checks MUST be imported from the shared library,
+      not re-implemented inline.
     rationale: >-
       Requiring use of the shared library enforces the DRY constraint across
       scenarios. A file that copies invariant logic is not compliant even if
@@ -851,9 +885,13 @@ groups:
       scenario-specific checks in addition to the universal library checks:
       (1) `validate_report` event present in case-actor log; (2)
       `invite_actor_to_case` present at least twice (Finder invitation +
-      Vendor invitation); (3) `close_case` present; (4) CS transitions VFd,
-      VFD, and public-aware (P) all observed in
-      `add_participant_status_to_participant` entries for the Vendor actor;
+      Vendor invitation); (3) `close_case` present; (4) CS transitions VFd
+      and VFD observed in `add_participant_status_to_participant` entries for
+      the Vendor actor (Vendor fix path); public-aware (P) transition observed
+      in `add_participant_status_to_participant` entries for the Coordinator
+      actor, since the Coordinator (as CASE_OWNER) is the party that triggers
+      CS.P (DEMOMA-07-003(4)); the P-set CS state MUST also be visible in all
+      replicas via Announce(CaseLedgerEntry) fan-out;
       (5) Vendor replica holds the complete log from genesis (full history
       backfill, as Vendor is a late joiner).
     rationale: >-


### PR DESCRIPTION
## Summary

- Adds DEMOMA-12 spec group (8 requirements) formalising the FCV
  (Finder → Coordinator → Vendor) three-actor demo scenario
- Notes invariant harness refactor as a blocker in `notes/demo-future-ideas.md`

## Changes

| File | Change |
|------|--------|
| `specs/multi-actor-demo.yaml` | New `DEMOMA-12` group: topology, role semantics, invitation path, final-state, CI-job, and per-scenario invariant-test requirements |
| `notes/demo-future-ideas.md` | FCV row updated: references DEMOMA-12 spec and marks harness refactor as blocker |

Closes #1234

🤖 Generated with [Claude Code](https://claude.com/claude-code)