### PR TITLE
feat(#1565): BT-18-001 blackboard write contract tests

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1565.md
+++ b/plan/history/2607/implementation/ISSUE-1565.md
@@ -1,0 +1,21 @@
+---
+source: ISSUE-1565
+timestamp: '2026-07-22T15:38:50.839725+00:00'
+title: BT-18-001 blackboard write contract tests
+type: implementation
+---
+
+## Issue #1565 — BT-18-001 blackboard write contract integration tests
+
+Added behavior-contract integration tests for all four acquire_exploit call-out points with non-empty output_keys.
+
+### Changes
+
+- `test_acquire_exploit_strategy_tree.py`: added `clear_blackboard` autouse fixture; `test_evaluate_exploit_strategy_writes_blackboard_on_success` (ticks AcquireExploitStrategyBT Selector with always-fail HaveExploit stub, asserts ExploitStrategyDecision on blackboard); `test_have_exploit_success_skips_evaluator_no_write` (Selector short-circuit, no key written).
+- `test_call_out_point.py`: parametrized `test_acquire_exploit_node_writes_blackboard_on_success` covering EvaluateExploitPriority, _DeterministicDevelopExploit,_DeterministicPurchaseExploit; deterministic subclasses inherit production output_keys.
+
+### Deferred
+
+- #1594: behavior-contract test for PrioritizePublicationIntents (Collapse 2 parity).
+
+PR: <https://github.com/CERTCC/Vultron/pull/1596>

--- a/plan/incoming/learnings/20260722-bt-contract-tests-inherit-production-classes.md
+++ b/plan/incoming/learnings/20260722-bt-contract-tests-inherit-production-classes.md
@@ -1,0 +1,31 @@
+---
+title: Deterministic BT test wrappers must inherit production node classes
+type: learning
+timestamp: 2026-07-22
+source: ISSUE-1565
+---
+
+When writing behavior-contract tests for probabilistic call-out-point nodes
+(e.g., `DevelopExploit(OftenSucceed)`, `PurchaseExploit(RarelySucceed)`), the
+deterministic wrapper must subclass the **production node** with `AlwaysSucceed`
+as a secondary base — not a fresh class that only inherits from the abstract
+mixin and `AlwaysSucceed`.
+
+Correct pattern:
+
+```python
+class _DeterministicDevelopExploit(DevelopExploit, AlwaysSucceed):
+    pass
+```
+
+Wrong pattern (does NOT catch regressions in `DevelopExploit.output_keys`):
+
+```python
+class _Wrapper(ComposerCallOutPoint, AlwaysSucceed):
+    output_keys = {"developed_exploit_artifact": str}  # duplicated, not inherited
+```
+
+The second form would pass even if `DevelopExploit.output_keys` was emptied or
+renamed, because it declares its own independent `output_keys`. The first form
+inherits `output_keys` from the production class, so any regression there is
+caught immediately.

--- a/test/core/behaviors/report/test_acquire_exploit_strategy_tree.py
+++ b/test/core/behaviors/report/test_acquire_exploit_strategy_tree.py
@@ -22,6 +22,7 @@ Verifies ADR-0027 / BT-20-001:
 
 import pytest
 import py_trees
+from py_trees.common import Status
 
 from vultron.core.behaviors.report.acquire_exploit_strategy_tree import (
     ExploitStrategyDecision,
@@ -39,11 +40,27 @@ def _marker_factory(label):
     def factory(name):
         class _Marker(py_trees.behaviour.Behaviour):
             def update(self):
-                return py_trees.common.Status.SUCCESS
+                return Status.SUCCESS
 
         return _Marker(name=label)
 
     return factory
+
+
+def _always_fail_factory(name):
+    class _AlwaysFail(py_trees.behaviour.Behaviour):
+        def update(self):
+            return Status.FAILURE
+
+    return _AlwaysFail(name=name)
+
+
+@pytest.fixture(autouse=True)
+def clear_blackboard():
+    """Clear py_trees global blackboard state between tests."""
+    py_trees.blackboard.Blackboard.storage.clear()
+    yield
+    py_trees.blackboard.Blackboard.storage.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -205,3 +222,51 @@ def test_both_factories_replaceable():
     assert "EES" in tree_str
     assert not isinstance(tree.children[0], HaveExploit)
     assert not isinstance(tree.children[1], EvaluateExploitStrategy)
+
+
+# ---------------------------------------------------------------------------
+# AC-3: Behavior contract — EvaluateExploitStrategy writes typed value to
+# the blackboard on SUCCESS when ticked inside the real tree
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_exploit_strategy_writes_blackboard_on_success():
+    """AC-3 behavior contract: ticking the tree to SUCCESS writes ExploitStrategyDecision.
+
+    Uses an always-failing HaveExploit stub so the Selector falls through to
+    EvaluateExploitStrategy (AlwaysSucceed), which must then write a typed
+    ExploitStrategyDecision to the blackboard key 'exploit_strategy_decision'.
+    """
+    tree = create_acquire_exploit_strategy_tree(
+        case_id=CASE_ID,
+        have_exploit_factory=_always_fail_factory,
+    )
+    tree.setup_with_descendants()
+    tree.tick_once()
+
+    assert tree.status == Status.SUCCESS
+    assert (
+        "/exploit_strategy_decision" in py_trees.blackboard.Blackboard.storage
+    )
+    val = py_trees.blackboard.Blackboard.storage["/exploit_strategy_decision"]
+    assert isinstance(val, ExploitStrategyDecision)
+
+
+def test_have_exploit_success_skips_evaluator_no_write():
+    """When HaveExploit succeeds, EvaluateExploitStrategy never runs.
+
+    The Selector short-circuits on the first SUCCESS; the Evaluator's output
+    key must therefore be absent from the blackboard.
+    """
+    tree = create_acquire_exploit_strategy_tree(
+        case_id=CASE_ID,
+        have_exploit_factory=_marker_factory("HaveExploit"),
+    )
+    tree.setup_with_descendants()
+    tree.tick_once()
+
+    assert tree.status == Status.SUCCESS
+    assert (
+        "/exploit_strategy_decision"
+        not in py_trees.blackboard.Blackboard.storage
+    )

--- a/test/demo/fuzzer/test_call_out_point.py
+++ b/test/demo/fuzzer/test_call_out_point.py
@@ -27,6 +27,7 @@ import py_trees
 from py_trees.common import Status
 
 from vultron.core.behaviors.call_out_point import CallOutBackendFactory
+from vultron.demo.fuzzer.base import AlwaysSucceed as _AlwaysSucceed
 from vultron.demo.fuzzer.call_out_point import (
     ActuatorCallOutPoint,
     ComposerCallOutPoint,
@@ -684,3 +685,63 @@ def test_actuator_node_does_not_write_blackboard_on_success():
 
     assert status == Status.SUCCESS
     assert "/actuator_test_key" not in py_trees.blackboard.Blackboard.storage
+
+
+# ---------------------------------------------------------------------------
+# BT-18-001 behavior contracts — acquire_exploit nodes write typed values to
+# the blackboard when ticked to SUCCESS inside a real py_trees Selector tree.
+#
+# EvaluateExploitStrategy (Collapse 1) is covered by its own tree test at
+# test/core/behaviors/report/test_acquire_exploit_strategy_tree.py.
+# The three nodes below are the remaining acquire_exploit call-out points
+# with non-empty output_keys: EvaluateExploitPriority (AlwaysSucceed base),
+# DevelopExploit (OftenSucceed — deterministic wrapper required per BT Factory
+# Determinism rule), and PurchaseExploit (RarelySucceed — same rule).
+# ---------------------------------------------------------------------------
+
+
+class _DeterministicDevelopExploit(DevelopExploit, _AlwaysSucceed):
+    """DevelopExploit with AlwaysSucceed override for deterministic test ticks."""
+
+
+class _DeterministicPurchaseExploit(PurchaseExploit, _AlwaysSucceed):
+    """PurchaseExploit with AlwaysSucceed override for deterministic test ticks."""
+
+
+def _make_always_succeed_selector(node):
+    """Wrap *node* in a minimal Selector so setup_with_descendants() applies."""
+    return py_trees.composites.Selector(
+        name="TestSelector", memory=False, children=[node]
+    )
+
+
+_ACQUIRE_EXPLOIT_CONTRACT_NODES = [
+    (EvaluateExploitPriority, "exploit_priority_verdict", str),
+    (_DeterministicDevelopExploit, "developed_exploit_artifact", str),
+    (_DeterministicPurchaseExploit, "purchase_exploit_verdict", str),
+]
+
+
+@pytest.mark.parametrize(
+    "node_cls, output_key, expected_type", _ACQUIRE_EXPLOIT_CONTRACT_NODES
+)
+def test_acquire_exploit_node_writes_blackboard_on_success(
+    node_cls, output_key, expected_type
+):
+    """BT-18-001: ticking a call-out point to SUCCESS writes the declared type.
+
+    Creates a real Selector tree, ticks it once to SUCCESS, and asserts that
+    the blackboard key holds an instance of the declared output type.
+    Probabilistic nodes (DevelopExploit, PurchaseExploit) use deterministic
+    subclasses that inherit production output_keys but override update() via
+    AlwaysSucceed.
+    """
+    node = node_cls(node_cls.__name__)
+    tree = _make_always_succeed_selector(node)
+    tree.setup_with_descendants()
+    tree.tick_once()
+
+    assert tree.status == Status.SUCCESS
+    assert f"/{output_key}" in py_trees.blackboard.Blackboard.storage
+    val = py_trees.blackboard.Blackboard.storage[f"/{output_key}"]
+    assert isinstance(val, expected_type)


### PR DESCRIPTION
- Closes #1565

## Summary

Adds behavior-contract integration tests for all four `acquire_exploit` call-out-point nodes (BT-18-001): verifies that ticking each node to SUCCESS in a real `py_trees` tree writes a typed value to the declared blackboard key.

## Acceptance criteria

- AC-1: all four call-out-point nodes produce a typed blackboard write when ticked to SUCCESS in a real tree.
- AC-2: parametrized integration test covers all three `acquire_exploit` nodes (excluding `EvaluateExploitStrategy`, which is covered by the tree test above).
- AC-3: probabilistic nodes use deterministic wrappers that inherit production classes (not raw base classes).

## Changes

- **`test/core/behaviors/report/test_acquire_exploit_strategy_tree.py`**: adds `clear_blackboard` autouse fixture; adds `test_evaluate_exploit_strategy_writes_blackboard_on_success` (ticks `AcquireExploitStrategyBT` Selector with always-fail `HaveExploit` stub, forces `EvaluateExploitStrategy` to run, asserts `ExploitStrategyDecision` written); adds `test_have_exploit_success_skips_evaluator_no_write` (confirms Selector short-circuits when `HaveExploit` succeeds, leaving no `exploit_strategy_decision` key).
- **`test/demo/fuzzer/test_call_out_point.py`**: adds parametrized `test_acquire_exploit_node_writes_blackboard_on_success` covering `EvaluateExploitPriority`, `_DeterministicDevelopExploit`, `_DeterministicPurchaseExploit`; deterministic subclasses inherit production `output_keys` (not raw base classes).
- **`plan/incoming/learnings/20260722-bt-contract-tests-inherit-production-classes.md`**: captures the deterministic-wrapper inheritance rule for future BT contract tests.
- **`plan/history/2607/implementation/ISSUE-1565.md`**: implementation history entry.

## Verification

- [x] `PYTHONPATH= uv run pytest test/core/behaviors/report/test_acquire_exploit_strategy_tree.py` — 17 passed
- [x] `PYTHONPATH= uv run pytest test/demo/fuzzer/test_call_out_point.py -m ""` — 266 passed (includes 3 new parametrized contract tests)
- [x] `uv run flake8 vultron/ test/` — clean
- [x] `uv run mypy` — clean
- [x] `uv run pyright` — clean
- [x] `PYTHONPATH= uv run pytest --tb=short` — 5304 passed
- [x] AC-1: EvaluateExploitStrategy covered by `test_evaluate_exploit_strategy_writes_blackboard_on_success`; EvaluateExploitPriority, DevelopExploit, PurchaseExploit covered by parametrized test.
- [x] AC-2: parametrized test covers all three `acquire_exploit` nodes (EvaluateExploitStrategy is covered by its own tree test).
- [x] AC-3: `_DeterministicDevelopExploit(DevelopExploit, AlwaysSucceed)` and `_DeterministicPurchaseExploit(PurchaseExploit, AlwaysSucceed)` inherit production `output_keys`.

## DEFER

- #1594: behavior-contract test for `PrioritizePublicationIntents` in the publication tree (existing tree tests replace it with a stub; adding this for Collapse 2 parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)