### PR TITLE
test(#1594): behavior-contract test for default PrioritizePublicationIntents

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1594.md
+++ b/plan/history/2607/implementation/ISSUE-1594.md
@@ -1,0 +1,28 @@
+---
+source: ISSUE-1594
+timestamp: '2026-07-22T16:01:07.590164+00:00'
+title: BT-18-001 behavior-contract test for default PrioritizePublicationIntents
+type: implementation
+---
+
+## Issue #1594 — BT-18-001 follow-up: behavior contract test for PrioritizePublicationIntents in publication tree
+
+PR: <https://github.com/CERTCC/Vultron/pull/1597>
+
+Closed a coverage gap identified during review of the #1565 blackboard-contract
+work: no test exercised the **real default** `PrioritizePublicationIntents`
+Evaluator's blackboard-write contract — all prior tick/gating tests either
+stubbed the Evaluator or wrote the intent record manually.
+
+Added `test_full_tick_with_default_evaluator_writes_intent_record` to
+`test/core/behaviors/report/test_publication_tree.py`. It builds
+`create_publication_tree()` with the default `PrioritizePublicationIntents`
+factory (deterministic `AlwaysSucceed`), replacing only the probabilistic
+`Prepare*`/`Publish` arm call-out points with deterministic marker stubs so the
+full tree ticks to `SUCCESS` on every run, then asserts
+`/publication_intent_decision` holds a `PublicationIntentDecision` instance
+(BT-18-001). Mirrors the `*_writes_blackboard_on_success` pattern in
+`test/demo/fuzzer/test_call_out_point.py`.
+
+Test-only change (49 insertions, size:S). Both ACs satisfied. Full suite:
+5303 passed, 39 skipped, 2 pre-existing xfails. All four linters clean.

--- a/plan/incoming/learnings/20260722-publication-tree-full-tick-determinism-split.md
+++ b/plan/incoming/learnings/20260722-publication-tree-full-tick-determinism-split.md
@@ -1,0 +1,55 @@
+---
+title: Full-tree tick tests must stub only the probabilistic call-out points, not the deterministic Evaluator under test
+type: learning
+timestamp: 2026-07-22T00:00:00Z
+source: ISSUE-1594
+---
+
+## Observation
+
+To write a behavior-contract test that ticks `create_publication_tree()` to
+SUCCESS and verifies the **default** `PrioritizePublicationIntents` Evaluator's
+blackboard write, you have to reckon with a determinism split among the
+collapsed publication tree's call-out points:
+
+- `PrioritizePublicationIntents` is `EvaluatorCallOutPoint + AlwaysSucceed`
+  (`success_rate = 1.0`) — deterministic, and the node whose contract is under
+  test. It must be left at its **default** factory, or the test proves nothing.
+- The arm nodes `PrepareExploit` / `PrepareFix` / `PrepareReport` (`AlmostAlways
+  Succeed`, 0.90) and `Publish` (`AlmostAlwaysSucceed`, 0.90) are
+  **probabilistic**. Left at default they make the full-tree tick flaky.
+
+So the correct recipe is: keep `prioritize_publication_intents_factory` at its
+default, and inject deterministic marker-factory stubs for **only** the
+`prepare_*_factory` and `publish_factory` params. The existing `_marker_factory`
+helper in `test_publication_tree.py` already returns an unconditional-SUCCESS
+stub for exactly this. Add an `isinstance(tree.children[0],
+PrioritizePublicationIntents)` guard so a future refactor that accidentally
+stubs the Evaluator fails loudly rather than silently gutting the test.
+
+With the default `PublicationIntentDecision` (publish fix + report, withhold
+exploit) the exploit arm is a graceful `Inverter` no-op while the fix/report
+arms run their stubs — so the root `Sequence` reaches SUCCESS.
+
+The blackboard storage key carries a leading slash (`/publication_intent_
+decision`); assert against `py_trees.blackboard.Blackboard.storage`, and rely on
+the file's `autouse` `clear_blackboard` fixture to keep the assertion
+non-vacuous.
+
+## Stale-issue-body note
+
+Issue #1594's body referenced a `_FixedIntents` stub "in all existing tick
+tests" — that symbol no longer exists in `test_publication_tree.py` (the arm
+tests now write the record directly via `_write_intent`). The *intent* of the
+AC was still correct and current; verify the described test-file state in code
+before mirroring a pattern named in an issue body. See
+[[20260721-issue-1484-already-implemented]] for the general "verify issue claims
+against current code first" pattern.
+
+## Pattern to apply
+
+When ticking a collapsed FUZZ-08x tree to SUCCESS to test one call-out point's
+contract, check each leaf's fuzzer base type: leave the node-under-test at its
+default factory, and inject deterministic stubs for every *other* probabilistic
+call-out point in the tick path. Never stub the node whose contract you are
+asserting.

--- a/test/core/behaviors/report/test_publication_tree.py
+++ b/test/core/behaviors/report/test_publication_tree.py
@@ -174,6 +174,55 @@ def test_default_prepare_and_publish_nodes_are_fuzzers():
 
 
 # ---------------------------------------------------------------------------
+# Behavior-contract integration (BT-18-001): the DEFAULT
+# PrioritizePublicationIntents Evaluator writes a PublicationIntentDecision to
+# the blackboard when the full tree is ticked to SUCCESS.
+# ---------------------------------------------------------------------------
+
+
+def test_full_tick_with_default_evaluator_writes_intent_record():
+    """AC-1: a full tick with the default Evaluator writes the intent record.
+
+    Unlike the structure tests above (and unlike the arm-gating tests, which
+    write the record manually via ``_write_intent``), this exercises the real
+    default ``PrioritizePublicationIntents`` factory — a deterministic
+    ``AlwaysSucceed`` Evaluator — rather than a stub.  It therefore verifies
+    the node's actual blackboard-write contract (BT-18-001): on SUCCESS the
+    Evaluator writes a :class:`PublicationIntentDecision` to
+    :data:`INTENT_DECISION_KEY`.
+
+    Only the probabilistic ``Prepare*``/``Publish`` arm call-out points are
+    replaced with deterministic marker stubs, so the tree ticks to SUCCESS on
+    every run; the Evaluator factory is left at its default.  Mirrors the
+    ``*_writes_blackboard_on_success`` pattern in
+    ``test/demo/fuzzer/test_call_out_point.py`` (AC-2).
+    """
+    tree = create_publication_tree(
+        case_id=CASE_ID,
+        prepare_exploit_factory=_marker_factory("PrepExploit"),
+        prepare_fix_factory=_marker_factory("PrepFix"),
+        prepare_report_factory=_marker_factory("PrepReport"),
+        publish_factory=_marker_factory("Pub"),
+    )
+    # Guard: the Evaluator under test is the real default node, not a stub.
+    assert isinstance(tree.children[0], PrioritizePublicationIntents)
+
+    tree.setup_with_descendants()
+    tree.tick_once()
+
+    # AC-1: the full tree reaches SUCCESS deterministically.  With the default
+    # decision (publish fix + report, withhold exploit) the exploit arm is a
+    # graceful Inverter no-op while the fix and report arms run their stubs.
+    assert tree.status == Status.SUCCESS
+
+    # AC-1: the Evaluator wrote a PublicationIntentDecision to the blackboard.
+    storage_key = f"/{INTENT_DECISION_KEY}"
+    assert storage_key in py_trees.blackboard.Blackboard.storage
+    decision = py_trees.blackboard.Blackboard.storage[storage_key]
+    assert isinstance(decision, PublicationIntentDecision)
+
+
+# ---------------------------------------------------------------------------
 # AC-1 + AC-2: eliminated nodes are absent as leaves anywhere in the tree
 # ---------------------------------------------------------------------------
 

--- a/test/core/behaviors/report/test_publication_tree.py
+++ b/test/core/behaviors/report/test_publication_tree.py
@@ -193,9 +193,10 @@ def test_full_tick_with_default_evaluator_writes_intent_record():
 
     Only the probabilistic ``Prepare*``/``Publish`` arm call-out points are
     replaced with deterministic marker stubs, so the tree ticks to SUCCESS on
-    every run; the Evaluator factory is left at its default.  Mirrors the
-    ``*_writes_blackboard_on_success`` pattern in
-    ``test/demo/fuzzer/test_call_out_point.py`` (AC-2).
+    every run; the Evaluator factory is left at its default.  Follows the
+    ``test_evaluate_exploit_strategy_writes_blackboard_on_success`` pattern in
+    ``test_acquire_exploit_strategy_tree.py`` (AC-2): both tick the real
+    ``create_*_tree`` builder and stub only the otherwise-probabilistic arms.
     """
     tree = create_publication_tree(
         case_id=CASE_ID,


### PR DESCRIPTION
- Closes #1594

## Summary

Adds the missing BT-18-001 behavior-contract integration test for the
publication tree. All prior tick/gating tests either replace
`PrioritizePublicationIntents` with a stub or write the intent record manually
via `_write_intent`, so no test exercised the **real default** Evaluator's
blackboard-write contract. This closes that coverage gap.

## Changes

- Add `test_full_tick_with_default_evaluator_writes_intent_record` to
  `test/core/behaviors/report/test_publication_tree.py`:
  - Builds `create_publication_tree()` with the **default**
    `PrioritizePublicationIntents` factory (a deterministic `AlwaysSucceed`
    Evaluator), replacing only the probabilistic `Prepare*`/`Publish` arm
    call-out points with deterministic marker stubs so the full tree ticks to
    SUCCESS on every run.
  - Guards that `tree.children[0]` is the real `PrioritizePublicationIntents`
    node (not a stub).
  - Ticks via `setup_with_descendants()` + `tick_once()` and asserts the tree
    reaches `Status.SUCCESS`.
  - Asserts `/publication_intent_decision` holds a `PublicationIntentDecision`
    instance (BT-18-001).
- Mirrors the `*_writes_blackboard_on_success` pattern in
  `test/demo/fuzzer/test_call_out_point.py` (AC-2).

## Acceptance Criteria

- **AC-1** ✅ Behavior-contract integration test ticks the full tree with the
  default `PrioritizePublicationIntents` and asserts the blackboard key holds a
  `PublicationIntentDecision` instance.
- **AC-2** ✅ Follows the established `*_writes_blackboard_on_success` pattern.

## Verification

- `uv run black vultron/ test/` — clean
- `uv run flake8 vultron/ test/ && uv run mypy && uv run pyright` — clean
  (0 errors)
- `uv run pytest --tb=short` — 5303 passed, 39 skipped, 2 xfailed (pre-existing
  ADR-0017 xfails, unrelated)
- Test-only change; no production (`vultron/`) code modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)