### PR TITLE
docs(#1607): add upward-reflection signal taxonomy to build/bugfix/learn skills

### DIFF
--- a/.agents/skills/bugfix/SKILL.md
+++ b/.agents/skills/bugfix/SKILL.md
@@ -144,24 +144,9 @@ focus hints from Phase 2 (e.g., `"wire layer"`, `"BT integration"`), then:
      BODY    = issue number, symptoms, root cause, fix summary, PR link
      ```
 
-   - Before writing learning files, run the **upward-reflection checklist**. For
-     each item, if the answer is "yes", a learning file with the matching
-     `signal:` tag is required:
-
-     | Signal type | Question to ask |
-     |---|---|
-     | `spec-gap` | Was any behaviour fixed/tested that has no existing spec entry? |
-     | `spec-ambiguity` | Was any requirement unclear during root-cause analysis? |
-     | `spec-contradiction` | Did two requirements appear to conflict? |
-     | `design-question` | Was any structural decision made beyond the fix scope? |
-     | `concern` | Was a deeper fragility or risk encountered beyond this bug? |
-     | `tooling-issue` | Was any environment or tooling problem encountered? |
-     | `process-issue` | Was the issue body stale or the bug already fixed? |
-
-     Record each triggered signal as an individual learning file in
-     `plan/incoming/learnings/` (filename: `YYYYMMDD-SLUG.md`; frontmatter:
-     `title`, `type: learning`, `timestamp`, `source`, and optionally
-     `signal: <type>`).
+   - Run the **upward-reflection checklist** per
+     `.agents/skills/shared/upward-reflection.md`. Record each triggered signal
+     as a learning file.
    - Compute diff size: ≤50 → `size:S`; 51–300 → `size:M`; 301+ → `size:L`.
      Update the `size:` label.
    - Invoke the `create-pr` skill to push and open the PR:

--- a/.agents/skills/bugfix/SKILL.md
+++ b/.agents/skills/bugfix/SKILL.md
@@ -144,9 +144,24 @@ focus hints from Phase 2 (e.g., `"wire layer"`, `"BT integration"`), then:
      BODY    = issue number, symptoms, root cause, fix summary, PR link
      ```
 
-   - Record observations as individual learning files in `plan/incoming/learnings/`
-     (filename: `YYYYMMDD-SLUG.md`; frontmatter: `title`, `type: learning`,
-     `timestamp`, `source`).
+   - Before writing learning files, run the **upward-reflection checklist**. For
+     each item, if the answer is "yes", a learning file with the matching
+     `signal:` tag is required:
+
+     | Signal type | Question to ask |
+     |---|---|
+     | `spec-gap` | Was any behaviour fixed/tested that has no existing spec entry? |
+     | `spec-ambiguity` | Was any requirement unclear during root-cause analysis? |
+     | `spec-contradiction` | Did two requirements appear to conflict? |
+     | `design-question` | Was any structural decision made beyond the fix scope? |
+     | `concern` | Was a deeper fragility or risk encountered beyond this bug? |
+     | `tooling-issue` | Was any environment or tooling problem encountered? |
+     | `process-issue` | Was the issue body stale or the bug already fixed? |
+
+     Record each triggered signal as an individual learning file in
+     `plan/incoming/learnings/` (filename: `YYYYMMDD-SLUG.md`; frontmatter:
+     `title`, `type: learning`, `timestamp`, `source`, and optionally
+     `signal: <type>`).
    - Compute diff size: ≤50 → `size:S`; 51–300 → `size:M`; 301+ → `size:L`.
      Update the `size:` label.
    - Invoke the `create-pr` skill to push and open the PR:

--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -235,9 +235,28 @@ draft commit and use `git diff main...HEAD` normally.
    BODY    = "## Issue #<N> — <title>\n\n<completion summary, PR link>"
    ```
 
-5. Record observations as individual learning files in `plan/incoming/learnings/`
-   (filename: `YYYYMMDD-SLUG.md`; frontmatter: `title`, `type: learning`,
-   `timestamp`, `source`). Do not write completion summaries here.
+5. Before writing learning files, run the **upward-reflection checklist** — a
+   mandatory scan for signals that belong in the upstream queue. For each item,
+   if the answer is "yes", a learning file with the matching `signal:` tag is
+   required:
+
+   | Signal type | Question to ask |
+   |---|---|
+   | `spec-gap` | Was any behaviour implemented that has no existing spec entry? |
+   | `spec-ambiguity` | Was any requirement unclear? What interpretation was made? |
+   | `spec-contradiction` | Did two requirements appear to conflict? |
+   | `design-question` | Was an architectural decision made beyond what the issue specified? |
+   | `concern` | Was any fragility, risk, or technical debt encountered that should be tracked as a GitHub Concern issue? |
+   | `tooling-issue` | Was any environment or tooling problem encountered? |
+   | `process-issue` | Was the issue body stale, the issue already implemented, or tracking otherwise broken? |
+
+   Record each triggered signal as an individual learning file in
+   `plan/incoming/learnings/` (filename: `YYYYMMDD-SLUG.md`; frontmatter:
+   `title`, `type: learning`, `timestamp`, `source`, and optionally
+   `signal: <type>`). Do not write completion summaries here.
+
+   A session with no learning files is valid only if the checklist was run and
+   every answer was "no". Skipping the checklist is not allowed.
 
 6. Invoke `commit` if any learning files were created in `plan/incoming/learnings/`.
 

--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -235,28 +235,9 @@ draft commit and use `git diff main...HEAD` normally.
    BODY    = "## Issue #<N> — <title>\n\n<completion summary, PR link>"
    ```
 
-5. Before writing learning files, run the **upward-reflection checklist** — a
-   mandatory scan for signals that belong in the upstream queue. For each item,
-   if the answer is "yes", a learning file with the matching `signal:` tag is
-   required:
-
-   | Signal type | Question to ask |
-   |---|---|
-   | `spec-gap` | Was any behaviour implemented that has no existing spec entry? |
-   | `spec-ambiguity` | Was any requirement unclear? What interpretation was made? |
-   | `spec-contradiction` | Did two requirements appear to conflict? |
-   | `design-question` | Was an architectural decision made beyond what the issue specified? |
-   | `concern` | Was any fragility, risk, or technical debt encountered that should be tracked as a GitHub Concern issue? |
-   | `tooling-issue` | Was any environment or tooling problem encountered? |
-   | `process-issue` | Was the issue body stale, the issue already implemented, or tracking otherwise broken? |
-
-   Record each triggered signal as an individual learning file in
-   `plan/incoming/learnings/` (filename: `YYYYMMDD-SLUG.md`; frontmatter:
-   `title`, `type: learning`, `timestamp`, `source`, and optionally
-   `signal: <type>`). Do not write completion summaries here.
-
-   A session with no learning files is valid only if the checklist was run and
-   every answer was "no". Skipping the checklist is not allowed.
+5. Run the **upward-reflection checklist** per
+   `.agents/skills/shared/upward-reflection.md`. Record each triggered signal
+   as a learning file. Do not write completion summaries here.
 
 6. Invoke `commit` if any learning files were created in `plan/incoming/learnings/`.
 

--- a/.agents/skills/learn/SKILL.md
+++ b/.agents/skills/learn/SKILL.md
@@ -116,16 +116,32 @@ on what constitutes a complete lesson — loaded by `orient-agent` in Phase 1.
 
 Identify what the build process and codebase scan have surfaced that is not
 yet captured in durable docs. Consider both incoming learning files and
-open GitHub Concern issues:
+open GitHub Concern issues.
 
-1. Missing requirements — behavior exists in code but has no spec.
-2. Ambiguous or untestable requirements — reality diverges from what's written.
-3. Redundant or contradictory requirements across spec files.
-4. Agent guidance patterns that keep recurring in `plan/incoming/learnings/`
-   but are not yet in `AGENTS.md`.
-5. Open GitHub `type:Concern` issues that reveal missing spec requirements or
+**Prioritise by signal type.** Learning files tagged with `signal:` in their
+frontmatter carry higher-urgency signals and MUST be addressed before general
+pattern promotion. Process in this order:
+
+1. `signal: spec-gap` — behaviour in code with no spec entry. Write the missing
+   spec requirement.
+2. `signal: spec-contradiction` — two requirements that conflict. Resolve the
+   conflict and update both affected spec entries.
+3. `signal: spec-ambiguity` — requirement was unclear; an interpretation was made
+   during build. Clarify the requirement so future agents don't have to guess.
+4. `signal: design-question` — architectural decision made mid-build. Determine
+   whether an ADR or notes update is warranted.
+5. `signal: concern` — fragility or risk. Create or update a GitHub Concern
+   issue if not already tracked.
+6. `signal: tooling-issue` / `signal: process-issue` — environment or tracking
+   problems. Update `AGENTS.md` or the affected skill with the fix.
+7. Untagged entries — general observations and patterns:
+   - Missing requirements — behavior exists in code but has no spec.
+   - Ambiguous or untestable requirements — reality diverges from what's written.
+   - Redundant or contradictory requirements across spec files.
+   - Agent guidance patterns that keep recurring but are not yet in `AGENTS.md`.
+8. Open GitHub `type:Concern` issues that reveal missing spec requirements or
    durable design notes.
-6. Recent completed-task insights — when needed, run `uv run show-history
+9. Recent completed-task insights — when needed, run `uv run show-history
    --month YYMM` to identify which history entries contain architectural
    lessons, then open those entry files.
 

--- a/.agents/skills/shared/README.md
+++ b/.agents/skills/shared/README.md
@@ -8,6 +8,7 @@ Shared scripts and reference documents referenced by multiple skills.
 |---|---|---|
 | `completeness-doctrine.md` | Project quality standard: what "done" means, finding severity taxonomy (FAIL/IMPROVE/DEFER), scope expansion rules | `orient-agent` Step 3 — in context for every workflow |
 | `pr-body-guide.md` | PR body templates and formatting rules | `build`, `bugfix`, `plan-issue` |
+| `upward-reflection.md` | Mandatory end-of-session signal checklist (spec-gap, spec-ambiguity, etc.) and learning-file format | `build` Phase 8, `bugfix` Phase 3 |
 
 ## Scripts
 

--- a/.agents/skills/shared/upward-reflection.md
+++ b/.agents/skills/shared/upward-reflection.md
@@ -19,5 +19,9 @@ Record each triggered signal as an individual learning file in
 `title`, `type: learning`, `timestamp`, `source`, and optionally
 `signal: <type>`). Do not write completion summaries here.
 
+When archiving a tagged entry with `append-history`, pass the signal type via
+`--signal <type>` (e.g. `uv run append-history learning --signal spec-gap ...`).
+For `--from-file` archiving, the `signal:` frontmatter field is preserved verbatim.
+
 A session with no learning files is valid only if this checklist was run and
 every answer was "no". Skipping the checklist is not allowed.

--- a/.agents/skills/shared/upward-reflection.md
+++ b/.agents/skills/shared/upward-reflection.md
@@ -1,0 +1,23 @@
+# Upward-Reflection Checklist
+
+Before writing learning files at the end of a `build` or `bugfix` session, run
+this checklist. For each signal type, if the answer is "yes", a learning file
+with the matching `signal:` tag is required (BW-07-001, BW-07-002).
+
+| Signal type | Question to ask |
+|---|---|
+| `spec-gap` | Was any behaviour implemented or fixed that has no existing spec entry? |
+| `spec-ambiguity` | Was any requirement unclear? What interpretation was made? |
+| `spec-contradiction` | Did two requirements appear to conflict? |
+| `design-question` | Was an architectural decision made beyond what the issue specified? |
+| `concern` | Was any fragility, risk, or technical debt encountered that should be tracked as a GitHub Concern issue? |
+| `tooling-issue` | Was any environment or tooling problem encountered? |
+| `process-issue` | Was the issue body stale, the issue already implemented, or tracking otherwise broken? |
+
+Record each triggered signal as an individual learning file in
+`plan/incoming/learnings/` (filename: `YYYYMMDD-SLUG.md`; frontmatter:
+`title`, `type: learning`, `timestamp`, `source`, and optionally
+`signal: <type>`). Do not write completion summaries here.
+
+A session with no learning files is valid only if this checklist was run and
+every answer was "no". Skipping the checklist is not allowed.

--- a/notes/agentic-workflow.md
+++ b/notes/agentic-workflow.md
@@ -170,12 +170,34 @@ each have an observation to record.
 
 ### What belongs here
 
-- Observations about unclear or missing spec requirements discovered during
-  implementation (e.g., "The specs don't say what to do when X")
+Entries fall into two tiers. Add an optional `signal:` frontmatter field to
+mark the tier explicitly (see BW-07-002).
+
+**Tier 1 — high-urgency signals** (tag with `signal: <type>`):
+
+- `spec-gap` — behaviour implemented in code with no corresponding spec entry
+- `spec-ambiguity` — a requirement was unclear; record what interpretation was
+  made so `learn` can clarify it
+- `spec-contradiction` — two requirements appeared to conflict; record which
+  were at odds and how the conflict was resolved
+- `design-question` — an architectural decision was made mid-build beyond what
+  the issue specified; record the rationale for `learn` to evaluate
+- `concern` — a fragility, risk, or debt item encountered that should be
+  tracked as a GitHub Concern issue
+
+**Tier 2 — general observations** (no `signal:` tag required):
+
+- `tooling-issue` — environment or tooling problems (e.g., `PYTHONPATH`
+  contamination, `git rebase` sequencer quirks)
+- `process-issue` — tracking failures (stale issue body, issue already
+  implemented, missing `Closes` footer)
 - Constraints or invariants discovered in the code that aren't documented
-- Open questions raised during implementation that need a decision
 - Patterns that keep recurring and should become `AGENTS.md` guidance
 - Gotchas or pitfalls encountered that should be preserved for future runs
+
+The `build` and `bugfix` skills MUST run the upward-reflection checklist
+(BW-07-001) before writing learning files to ensure Tier-1 signals are not
+silently omitted.
 
 ### What does NOT belong here
 

--- a/plan/history/2607/implementation/ISSUE-1607.md
+++ b/plan/history/2607/implementation/ISSUE-1607.md
@@ -1,0 +1,20 @@
+---
+source: ISSUE-1607
+timestamp: '2026-07-22T17:44:50.502944+00:00'
+title: Add upward-reflection signal taxonomy to build/bugfix/learn skills
+type: implementation
+---
+
+## Issue #1607 — build/bugfix skills signal taxonomy
+
+Added mandatory upward-reflection checklist and typed signal taxonomy to
+`build/SKILL.md`, `bugfix/SKILL.md`, `learn/SKILL.md`,
+`notes/agentic-workflow.md`, and `specs/build-workflow.yaml`.
+
+Agents now scan for seven signal types (spec-gap, spec-ambiguity,
+spec-contradiction, design-question, concern, tooling-issue, process-issue)
+before closing any build or bugfix session. An optional `signal:` frontmatter
+field in learning files lets the `learn` skill triage by urgency. BW-07 spec
+group added with three normative requirements.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1610>

--- a/specs/build-workflow.yaml
+++ b/specs/build-workflow.yaml
@@ -263,3 +263,52 @@ groups:
           The `update-plan` skill MUST NOT instruct agents to write to
           `plan/incoming/learnings/`. Observations discovered during gap
           analysis MUST be written directly to `notes/*.md` files.
+  - id: BW-07
+    title: Upward-Reflection Signal Taxonomy
+    kind: process
+    specs:
+      - id: BW-07-001
+        priority: MUST
+        kind: process
+        statement: >-
+          Before recording learning files at the end of a `build` or
+          `bugfix` session, the agent MUST run an upward-reflection
+          checklist that explicitly asks whether each of the following
+          signal types was encountered: `spec-gap`, `spec-ambiguity`,
+          `spec-contradiction`, `design-question`, `concern`,
+          `tooling-issue`, `process-issue`. A session with no learning
+          files is valid only if the checklist was completed and every
+          answer was "no".
+        rationale: >-
+          Without a mandatory checklist, agents default to recording
+          only tactical tips-and-tricks. The checklist ensures that
+          higher-signal problems (missing specs, contradictions,
+          architectural risks) are captured and flow upstream to `learn`.
+      - id: BW-07-002
+        priority: SHOULD
+        kind: protocol
+        statement: >-
+          Incoming learning files SHOULD include an optional `signal:`
+          frontmatter field set to one of the defined signal types
+          (`spec-gap`, `spec-ambiguity`, `spec-contradiction`,
+          `design-question`, `concern`, `tooling-issue`,
+          `process-issue`) when the entry represents one of those
+          categories. Entries that do not fit any category MAY omit the
+          field.
+        rationale: >-
+          Tagged entries allow the `learn` skill to triage by urgency
+          without reading every file body. `spec-gap` and
+          `spec-contradiction` entries are the highest priority.
+      - id: BW-07-003
+        priority: MUST
+        kind: process
+        statement: >-
+          The `learn` skill MUST process learning files tagged with
+          `signal: spec-gap` and `signal: spec-contradiction` before
+          processing untagged entries or entries with lower-urgency
+          signal types.
+        rationale: >-
+          These signal types represent cases where the specification
+          has diverged from reality or contains internal conflicts.
+          Deferring them risks future build sessions making the same
+          gap-driven interpretations independently.

--- a/test/metadata/test_append_history.py
+++ b/test/metadata/test_append_history.py
@@ -491,6 +491,17 @@ _LEARNING_CONTENT = (
     "\n"
     "Guard ast.Lambda in the scope walker.\n"
 )
+_LEARNING_CONTENT_WITH_SIGNAL = (
+    "---\n"
+    f"title: '{_LEARNING_TITLE}'\n"
+    "type: learning\n"
+    "timestamp: '2026-06-22T10:00:00+00:00'\n"
+    f"source: {_LEARNING_SOURCE}\n"
+    "signal: spec-gap\n"
+    "---\n"
+    "\n"
+    "Guard ast.Lambda in the scope walker.\n"
+)
 
 
 def _make_incoming_file(
@@ -669,3 +680,68 @@ def _run_with_cmd(
         stdout=stdout_buf.getvalue(),
         stderr=stderr_buf.getvalue(),
     )
+
+
+class TestSignalFlag:
+    """--signal flag: emitted in frontmatter for learning entries (BW-07-002)."""
+
+    def test_signal_written_to_frontmatter(self, fake_repo: Path) -> None:
+        result = _run_append(
+            "learning",
+            body=_IDEA_BODY,
+            title="Spec gap found",
+            source="20260622-SPEC-GAP",
+            extra_args=["--signal", "spec-gap"],
+        )
+        assert result.returncode == 0
+        content = Path(result.stdout.strip()).read_text()
+        assert "signal: spec-gap" in content
+
+    def test_signal_absent_when_not_provided(self, fake_repo: Path) -> None:
+        result = _run_append(
+            "learning",
+            body=_IDEA_BODY,
+            title="Untagged learning",
+            source="20260622-UNTAGGED",
+        )
+        assert result.returncode == 0
+        content = Path(result.stdout.strip()).read_text()
+        assert "signal:" not in content
+
+    def test_signal_on_non_learning_type_rejected(
+        self, fake_repo: Path
+    ) -> None:
+        result = _run_append(
+            "idea",
+            body=_IDEA_BODY,
+            title="Idea with signal",
+            source="IDEA-WITH-SIGNAL",
+            extra_args=["--signal", "spec-gap"],
+        )
+        assert result.returncode != 0
+        assert "learning" in result.stderr
+
+    def test_unknown_signal_value_rejected(self, fake_repo: Path) -> None:
+        result = _run_append(
+            "learning",
+            body=_IDEA_BODY,
+            title="Bad signal",
+            source="20260622-BAD-SIGNAL",
+            extra_args=["--signal", "not-a-real-signal"],
+        )
+        assert result.returncode != 0
+        assert "unknown signal" in result.stderr.lower()
+
+    def test_from_file_preserves_signal_field(
+        self, fake_repo: Path, tmp_path: Path
+    ) -> None:
+        """--from-file path preserves signal: frontmatter verbatim."""
+        src = _make_incoming_file(
+            tmp_path,
+            content=_LEARNING_CONTENT_WITH_SIGNAL,
+            filename=f"{_LEARNING_SOURCE}.md",
+        )
+        result = _run_from_file(src)
+        assert result.returncode == 0
+        content = Path(result.stdout.strip()).read_text()
+        assert "signal: spec-gap" in content

--- a/test/metadata/test_history_models.py
+++ b/test/metadata/test_history_models.py
@@ -10,7 +10,7 @@ import datetime
 import pytest
 from pydantic import ValidationError
 
-from vultron.metadata.history.types import HistoryEntryType
+from vultron.metadata.history.types import HistoryEntryType, LearningSignalType
 
 _UTC = datetime.timezone.utc
 
@@ -183,6 +183,47 @@ class TestHistoryEntryFrontmatter:
                     "type": "bogus",
                     "timestamp": ts,
                     "source": "SRC-4",
+                }
+            )
+
+    def test_signal_field_accepted(self, model_cls) -> None:  # type: ignore[no-untyped-def]
+        """Optional signal field is parsed and stored (BW-07-002)."""
+        ts = datetime.datetime(2026, 4, 28, 12, 0, 0, tzinfo=_UTC)
+        m = model_cls.model_validate(
+            {
+                "title": "T",
+                "type": "learning",
+                "timestamp": ts,
+                "source": "SRC-7",
+                "signal": "spec-gap",
+            }
+        )
+        assert m.signal == LearningSignalType.spec_gap
+
+    def test_signal_field_optional(self, model_cls) -> None:  # type: ignore[no-untyped-def]
+        """Entries without signal: are valid; signal defaults to None."""
+        ts = datetime.datetime(2026, 4, 28, 12, 0, 0, tzinfo=_UTC)
+        m = model_cls.model_validate(
+            {
+                "title": "T",
+                "type": "learning",
+                "timestamp": ts,
+                "source": "SRC-8",
+            }
+        )
+        assert m.signal is None
+
+    def test_invalid_signal_rejected(self, model_cls) -> None:  # type: ignore[no-untyped-def]
+        """Unknown signal values are rejected by Pydantic."""
+        ts = datetime.datetime(2026, 4, 28, 12, 0, 0, tzinfo=_UTC)
+        with pytest.raises(ValidationError):
+            model_cls.model_validate(
+                {
+                    "title": "T",
+                    "type": "learning",
+                    "timestamp": ts,
+                    "source": "SRC-9",
+                    "signal": "not-a-signal",
                 }
             )
 

--- a/vultron/metadata/history/cli.py
+++ b/vultron/metadata/history/cli.py
@@ -56,7 +56,7 @@ from vultron.metadata.history.models import (
     NewHistoryEntry,
 )
 from vultron.metadata.history.readme_gen import regenerate_readme
-from vultron.metadata.history.types import HistoryEntryType
+from vultron.metadata.history.types import HistoryEntryType, LearningSignalType
 
 _UTC = datetime.timezone.utc
 
@@ -149,6 +149,7 @@ def _build_content(
     source: str,
     body: str,
     timestamp: datetime.datetime | None = None,
+    signal: LearningSignalType | None = None,
 ) -> str:
     """Construct the full entry markdown (frontmatter + body).
 
@@ -160,23 +161,34 @@ def _build_content(
     so that YAML parsers treat it as a string rather than a native datetime
     (ensuring round-trip fidelity of the UTC offset, HM-06-001).
 
+    The optional *signal* field is only emitted for ``learning`` entries and
+    only when a value is provided (BW-07-002).
+
     Returns:
         Full markdown string beginning with a YAML frontmatter block.
     """
     if timestamp is not None:
         entry = NewHistoryEntry(
-            type=entry_type, title=title, source=source, timestamp=timestamp
+            type=entry_type,
+            title=title,
+            source=source,
+            timestamp=timestamp,
+            signal=signal,
         )
     else:
-        entry = NewHistoryEntry(type=entry_type, title=title, source=source)
+        entry = NewHistoryEntry(
+            type=entry_type, title=title, source=source, signal=signal
+        )
 
-    fm = {
+    fm: dict[str, object] = {
         "title": entry.title,
         "type": str(entry.type.value),
         "source": entry.source,
         # Store as a plain string so YAML parsers don't strip the tz offset.
         "timestamp": entry.timestamp.isoformat(),
     }
+    if entry.signal is not None:
+        fm["signal"] = str(entry.signal.value)
     fm_yaml = yaml.safe_dump(fm, default_flow_style=False, allow_unicode=True)
     sep = "\n" if body and not body.startswith("\n") else ""
     return f"---\n{fm_yaml}---\n{sep}{body}"
@@ -242,6 +254,16 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="DATETIME",
         default=None,
         help=argparse.SUPPRESS,  # backfill only
+    )
+    valid_signals = ", ".join(s.value for s in LearningSignalType)
+    parser.add_argument(
+        "--signal",
+        metavar="TYPE",
+        default=None,
+        help=(
+            f"Optional signal classification for learning entries (BW-07-002). "
+            f"One of: {valid_signals}. Ignored for non-learning entry types."
+        ),
     )
     return parser
 
@@ -358,6 +380,24 @@ def _parse_timestamp(value: str | None) -> datetime.datetime | None:
         _fail(str(exc))
 
 
+def _parse_signal(
+    value: str | None, entry_type: HistoryEntryType
+) -> LearningSignalType | None:
+    """Parse and validate the optional ``--signal`` flag value."""
+    if value is None:
+        return None
+    if entry_type != HistoryEntryType.learning:
+        _fail(
+            f"--signal is only valid for 'learning' entries, "
+            f"not '{entry_type}'"
+        )
+    try:
+        return LearningSignalType(value)
+    except ValueError:
+        valid = ", ".join(s.value for s in LearningSignalType)
+        _fail(f"unknown signal type '{value}'. Valid values: {valid}")
+
+
 def _check_from_file_conflicts(args: argparse.Namespace) -> None:
     """Fail if --from-file is combined with incompatible normal-mode flags."""
     conflicts = []
@@ -444,10 +484,11 @@ def main() -> None:
     entry_type = _parse_entry_type(args.entry_type)
     body = _read_body(args.file)
     timestamp = _parse_timestamp(args.timestamp)
+    signal = _parse_signal(args.signal, entry_type)
 
     try:
         content = _build_content(
-            entry_type, args.title, args.source, body, timestamp
+            entry_type, args.title, args.source, body, timestamp, signal
         )
         # Future-date check only for explicit --timestamp overrides (HM-06-004).
         # Auto-generated timestamps from NewHistoryEntry.default_factory are

--- a/vultron/metadata/history/models.py
+++ b/vultron/metadata/history/models.py
@@ -19,7 +19,7 @@ import datetime
 
 from pydantic import BaseModel, Field, field_validator
 
-from vultron.metadata.history.types import HistoryEntryType
+from vultron.metadata.history.types import HistoryEntryType, LearningSignalType
 
 _UTC = datetime.timezone.utc
 
@@ -44,6 +44,7 @@ class _HistoryEntryBase(BaseModel):
     title: str
     type: HistoryEntryType
     source: str
+    signal: LearningSignalType | None = None
 
     @field_validator("title", "source", mode="before")
     @classmethod

--- a/vultron/metadata/history/types.py
+++ b/vultron/metadata/history/types.py
@@ -16,3 +16,20 @@ class HistoryEntryType(StrEnum):
     implementation = "implementation"
     learning = "learning"
     priority = "priority"
+
+
+class LearningSignalType(StrEnum):
+    """Optional signal classification for ``learning`` history entries (BW-07-002).
+
+    Tags the urgency tier of a learning so the ``learn`` skill can triage
+    without reading every file body.  ``spec-gap`` and ``spec-contradiction``
+    are the highest priority (BW-07-003).
+    """
+
+    spec_gap = "spec-gap"
+    spec_ambiguity = "spec-ambiguity"
+    spec_contradiction = "spec-contradiction"
+    design_question = "design-question"
+    concern = "concern"
+    tooling_issue = "tooling-issue"
+    process_issue = "process-issue"


### PR DESCRIPTION
- Closes #1607

## Summary

The `build` and `bugfix` skills were only recording tactical observations
(how-to tips, pitfalls) — never surfacing spec gaps, contradictions,
ambiguities, or concerns that belong in the upstream `learn` queue. This PR
adds a mandatory upward-reflection checklist and a typed signal taxonomy to fix
the signal gap.

## Changes

- **`.agents/skills/build/SKILL.md`** — Phase 8 step 5: replace vague "record
  observations" with a mandatory upward-reflection checklist table; agents must
  explicitly scan for `spec-gap`, `spec-ambiguity`, `spec-contradiction`,
  `design-question`, `concern`, `tooling-issue`, `process-issue` before
  closing; a session with no learning files is valid only if the checklist was
  run and every answer was "no".
- **`.agents/skills/bugfix/SKILL.md`** — Phase 3 Finalize: same checklist
  table with bugfix-appropriate question wording; adds optional `signal:`
  frontmatter field to learning file format.
- **`.agents/skills/learn/SKILL.md`** — Phase 2 gap analysis: add
  "Prioritise by signal type" section; `signal: spec-gap` and
  `signal: spec-contradiction` entries must be addressed first; ordered
  processing list replaces the flat unordered list.
- **`notes/agentic-workflow.md`** — incoming learnings content policy: replace
  flat bullet list with two-tier taxonomy (Tier 1 high-urgency signals; Tier 2
  general observations); cross-reference BW-07-001/BW-07-002.
- **`specs/build-workflow.yaml`** — add BW-07 group (Upward-Reflection Signal
  Taxonomy) with three requirements: BW-07-001 (MUST run checklist),
  BW-07-002 (SHOULD tag entries with `signal:`), BW-07-003 (MUST prioritise
  spec-gap/spec-contradiction in `learn`).

## Design note

The `signal:` frontmatter field is **optional** (BW-07-002 is SHOULD) so
existing learning files remain valid. Only the checklist step itself is
mandatory (BW-07-001 is MUST). This avoids a big-bang migration of the
existing queue while still ensuring new sessions produce typed signals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)