### PR TITLE
docs: plan issue #1611 — notes/ file-size limits as spec requirements

### DIFF
--- a/specs/project-documentation.yaml
+++ b/specs/project-documentation.yaml
@@ -16,6 +16,27 @@ groups:
     priority: SHOULD
     kind: project
     statement: Large modules with multiple responsibilities SHOULD be refactored into smaller cohesive modules
+  - id: PD-01-002
+    priority: SHOULD
+    kind: project
+    statement: >-
+      `notes/*.md` files SHOULD NOT exceed 500 lines. Files that outgrow this limit SHOULD be split
+      along topic-cluster boundaries into separate focused files, each covering a single coherent "Load
+      when" scenario.
+    rationale: >-
+      Large notes files force agents to filter through irrelevant content to find the specific context
+      they need, increasing context window waste and the risk of missing relevant guidance. Splitting
+      at topic-cluster boundaries keeps each file narrowly focused on one "Load when" scenario.
+  - id: PD-01-003
+    priority: SHOULD
+    kind: project
+    statement: >-
+      A `notes/*.md` file whose content spans multiple "Load when" scenarios that never co-occur in
+      the same task context SHOULD be split into separate files, one per scenario cluster.
+    rationale: >-
+      When a notes file covers several distinct agent tasks, any single load brings in guidance
+      irrelevant to the current task. Single-scenario files make context loading precise and
+      predictable.
 - id: PD-03
   title: Documentation Currency
   specs:


### PR DESCRIPTION
- Closes #1611

## Summary

Adds two new spec requirements to `specs/project-documentation.yaml` (PD-01
group) derived from the planning session for concern #1611:

- **PD-01-002**: `notes/*.md` files SHOULD NOT exceed 500 lines; files that
  outgrow this SHOULD be split along topic-cluster boundaries.
- **PD-01-003**: A notes file spanning multiple "Load when" scenarios that
  never co-occur SHOULD be split into separate files, one per scenario cluster.

## Changes

- `specs/project-documentation.yaml` — two new entries in the PD-01 group

## Notes

Implementation work (splitting the five largest notes files, promoting BT-IDM
rules to specs, updating cross-references) is tracked in #1612.

🤖 Generated with [Claude Code](https://claude.com/claude-code)