### PR TITLE
fix(#1614): allow .devcontainer/certs through .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -60,6 +60,7 @@ wip_notes
 .github
 .copilot
 .devcontainer
+!.devcontainer/certs
 
 # Dockerfile itself is not needed inside app images; demo-entrypoint.sh is still required
 docker/Dockerfile


### PR DESCRIPTION
## Summary

- `.dockerignore` excluded the entire `.devcontainer/` directory, but `docker/Dockerfile` (line 62) does `COPY .devcontainer/certs ...` in the `dev` build stage.
- Adds `!.devcontainer/certs` negation rule so that directory is available in the Docker build context.
- Regression introduced by #1588.

Fixes #1614.

## Test plan

- [ ] Run `start-dev.sh` and confirm the image builds without the `CopyIgnoredFile` / `not found` error
- [ ] Confirm `.devcontainer/certs` contents are present inside the running container at `/usr/local/share/ca-certificates/custom/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)