### PR TITLE
feat(#1584): rename two-actor demo to FV demo

### DIFF
--- a/.github/workflows/demo-integration.yml
+++ b/.github/workflows/demo-integration.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   demo:
-    name: Two-Actor Demo Integration
+    name: FV Demo Integration
     runs-on: ubuntu-latest
     # DEMOCI-02-009: 15-minute cap to prevent indefinite hangs.
     timeout-minutes: 15
@@ -53,16 +53,16 @@ jobs:
           cache-scope: demo-integration
           cache-from-extra-scope: demo-integration-main
 
-      # DEMOCI-02-005, DEMOCI-02-006: run two-actor demo; detect failure via
+      # DEMOCI-02-005, DEMOCI-02-006: run FV demo; detect failure via
       # exit code of the demo-runner container.
       # DEMOCI-02-008: set DEBUG log level at CI runtime so actor containers
       # emit full tracebacks and state-machine detail.
       - name: Create devlogs directory
         run: mkdir -p devlogs
 
-      - name: Run two-actor demo
+      - name: Run FV demo
         run: |
-          DEMO=two-actor \
+          DEMO=fv \
           VULTRON_SERVER__LOG_LEVEL=DEBUG \
             docker compose -f docker/docker-compose-multi-actor.yml \
             up --abort-on-container-exit --exit-code-from demo-runner
@@ -71,7 +71,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: two-actor-case-logs
+          name: fv-case-logs
           path: devlogs/
           retention-days: 30
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -116,7 +116,7 @@ variable to use a fixed host port, or inspect the assigned port with
 | `VULTRON_ACTOR_ID`    | *(set per service)*       | Deterministic full actor URI          |
 | `VULTRON_SEED_CONFIG` | *(set per service)*       | Seed config JSON for local + peers    |
 
-### Run the D5-2 two-actor acceptance scenario
+### Run the D5-2 FV acceptance scenario
 
 The `demo-runner` service now performs the D5-2 scenario end to end:
 it waits for healthy actor services, resets container state to a clean
@@ -129,7 +129,7 @@ docker compose -f docker-compose-multi-actor.yml up --abort-on-container-exit de
 ```
 
 This is the canonical single-command acceptance run for the current
-two-actor scenario.
+FV scenario.
 
 ### Run the D5-3 three-actor acceptance scenario
 
@@ -163,7 +163,7 @@ volumes on exit for a clean baseline:
 
 ```bash
 # From the repository root:
-./integration_tests/demo/run_multi_actor_integration_test.sh two-actor
+./integration_tests/demo/run_multi_actor_integration_test.sh fv
 ./integration_tests/demo/run_multi_actor_integration_test.sh three-actor
 ./integration_tests/demo/run_multi_actor_integration_test.sh multi-vendor
 ```
@@ -171,7 +171,7 @@ volumes on exit for a clean baseline:
 Or via the Makefile targets:
 
 ```bash
-make integration-test-multi-actor    # two-actor
+make integration-test-multi-actor    # fv
 make integration-test-three-actor    # three-actor
 make integration-test-multi-vendor   # multi-vendor
 ```

--- a/docker/docker-compose-multi-actor.yml
+++ b/docker/docker-compose-multi-actor.yml
@@ -163,7 +163,7 @@ services:
 
   # ── CaseActor ─────────────────────────────────────────────────────────────
   # Hosts the VultronCaseActor that manages case state and broadcasts updates
-  # to all case participants.  For D5-2 (two-actor scenario), CaseActor MAY
+  # to all case participants.  For D5-2 (FV scenario), CaseActor MAY
   # run in the vendor container instead; this dedicated service is required
   # for D5-3 and later (three-actor scenarios).
   #
@@ -246,7 +246,7 @@ services:
       - VULTRON_VENDOR2_BASE_URL=http://vendor2:7999/api/v2
       # Run the selected multi-actor demo non-interactively. Override DEMO
       # at runtime (for example, DEMO=three-actor) to switch scenarios.
-      - DEMO=${DEMO:-two-actor}
+      - DEMO=${DEMO:-fv}
       - DEVLOGS_DIR=/app/devlogs
     volumes:
       - "../vultron:/app/vultron"

--- a/docs/codebase/CONCERNS.md
+++ b/docs/codebase/CONCERNS.md
@@ -44,7 +44,7 @@
 
 | Area | Why fragile | Churn signal | Safe change strategy |
 |------|-------------|-------------|----------------------|
-| `vultron/demo/scenario/two_actor_demo.py` | Demo exercises many layers; any layer change can break it | 35 commits in 90 days (highest churn in production source) | Run `uv run pytest -m integration` before touching demo scenarios |
+| `vultron/demo/scenario/fv_demo.py` | Demo exercises many layers; any layer change can break it | 35 commits in 90 days (highest churn in production source) | Run `uv run pytest -m integration` before touching demo scenarios |
 | `vultron/core/use_cases/received/` | Received-side use cases are actively evolving | `status.py` 23, `embargo.py` 22, `case.py` 20, `actor.py` 18 commits in 90 days | Add tests for each received use case before modifying; verify with architecture tests |
 | `vultron/core/behaviors/case/nodes/` | BT node refactoring converted `nodes.py` to a package | 21 commits on package + 18 on `__init__.py` | Test BT execution before any node reorganization |
 | `vultron/adapters/driving/fastapi/inbox_handler.py` | Inbox pipeline evolves with use-case changes | 21 commits in 90 days | Integration-test the inbox flow end-to-end after changes |

--- a/docs/howto/demos/fvv-demo.md
+++ b/docs/howto/demos/fvv-demo.md
@@ -267,8 +267,8 @@ docker compose -f docker/docker-compose-multi-actor.yml down -v
 
 ## Next steps
 
-- **Run the two-actor demo first** — see
-  [Tutorial: Run the Two-Actor Demo](../../tutorials/two-actor-demo.md) for
+- **Run the FV demo first** — see
+  [Tutorial: Run the FV Demo](../../tutorials/fv-demo.md) for
   a simpler scenario that introduces the core patterns.
 - **Read the scenario source** — the FVV demo script is at
   `vultron/demo/scenario/fvv_demo.py`; shared helpers are in

--- a/docs/reference/codebase/CONCERNS.md
+++ b/docs/reference/codebase/CONCERNS.md
@@ -41,7 +41,7 @@
 
 | Area | Why fragile | Churn signal | Safe change strategy |
 |------|-------------|-------------|----------------------|
-| `vultron/demo/scenario/two_actor_demo.py` | Demo exercises many layers; any layer change can break it | 35 commits in 90 days (highest churn in production source) | Run `uv run pytest -m integration` before touching demo scenarios |
+| `vultron/demo/scenario/fv_demo.py` | Demo exercises many layers; any layer change can break it | 35 commits in 90 days (highest churn in production source) | Run `uv run pytest -m integration` before touching demo scenarios |
 | `vultron/core/use_cases/received/` | Received-side use cases are actively evolving | `status.py` 23, `embargo.py` 22, `case.py` 20, `actor.py` 18 commits in 90 days | Add tests for each received use case before modifying; verify with architecture tests |
 | `vultron/core/behaviors/case/nodes/` | BT node refactoring converted `nodes.py` to a package | 21 commits on package + 18 on `__init__.py` | Test BT execution before any node reorganization |
 | `vultron/adapters/driving/fastapi/inbox_handler.py` | Inbox pipeline evolves with use-case changes | 21 commits in 90 days | Integration-test the inbox flow end-to-end after changes |

--- a/docs/reference/fv-demo-protocol.md
+++ b/docs/reference/fv-demo-protocol.md
@@ -1,6 +1,6 @@
 # FV Demo — Protocol Reference
 
-This document is a **technical reference** for the fv
+This document is a **technical reference** for the FV
 (Finder + Vendor) CVD demo. It is written for developers who want to
 understand the message-level protocol interactions and build custom
 actors that interoperate with the Vultron protocol.
@@ -12,7 +12,7 @@ For a hands-on tutorial on running the demo, see
 
 ## Actors and Topology
 
-The fv demo uses **two Docker containers** and **three logical
+The FV demo uses **two Docker containers** and **three logical
 actors**:
 
 | Actor | CVD Role(s) | Container | Actor ID pattern |
@@ -473,7 +473,7 @@ RECEIVED → VALID → ACCEPTED → ... → CLOSED
 NONE → PROPOSED → ACTIVE → EXITED
 ```
 
-(In the fv demo, `PROPOSED` is skipped — both participants
+(In the FV demo, `PROPOSED` is skipped — both participants
 are set to `SIGNATORY` at case creation time, moving directly to
 `ACTIVE`.)
 
@@ -497,7 +497,7 @@ vfdpxa → Vfdpxa → VFdpxa → VFDpxa → VFDPxa
 ## Activity Types Used in the Demo
 
 The following table maps each ActivityStreams activity type used in
-the fv demo to its `MessageSemantics` value and the phase
+the FV demo to its `MessageSemantics` value and the phase
 where it appears:
 
 | AS2 Activity | MessageSemantics | Phase | Direction |

--- a/docs/reference/fv-demo-protocol.md
+++ b/docs/reference/fv-demo-protocol.md
@@ -1,6 +1,6 @@
-# Two-Actor Demo — Protocol Reference
+# FV Demo — Protocol Reference
 
-This document is a **technical reference** for the two-actor
+This document is a **technical reference** for the fv
 (Finder + Vendor) CVD demo. It is written for developers who want to
 understand the message-level protocol interactions and build custom
 actors that interoperate with the Vultron protocol.
@@ -12,7 +12,7 @@ For a hands-on tutorial on running the demo, see
 
 ## Actors and Topology
 
-The two-actor demo uses **two Docker containers** and **three logical
+The fv demo uses **two Docker containers** and **three logical
 actors**:
 
 | Actor | CVD Role(s) | Container | Actor ID pattern |
@@ -473,7 +473,7 @@ RECEIVED → VALID → ACCEPTED → ... → CLOSED
 NONE → PROPOSED → ACTIVE → EXITED
 ```
 
-(In the two-actor demo, `PROPOSED` is skipped — both participants
+(In the fv demo, `PROPOSED` is skipped — both participants
 are set to `SIGNATORY` at case creation time, moving directly to
 `ACTIVE`.)
 
@@ -497,7 +497,7 @@ vfdpxa → Vfdpxa → VFdpxa → VFDpxa → VFDPxa
 ## Activity Types Used in the Demo
 
 The following table maps each ActivityStreams activity type used in
-the two-actor demo to its `MessageSemantics` value and the phase
+the fv demo to its `MessageSemantics` value and the phase
 where it appears:
 
 | AS2 Activity | MessageSemantics | Phase | Direction |
@@ -533,7 +533,7 @@ simulation — it is a live protocol run.
 
 | File | Role |
 |:-----|:-----|
-| `vultron/demo/scenario/two_actor_demo.py` | Demo orchestration script |
+| `vultron/demo/scenario/fv_demo.py` | Demo orchestration script |
 | `vultron/demo/helpers/` | Shared helper modules (actions, milestones, notes, polling, seeding, sync, verification, workflow) |
 | `vultron/adapters/driving/fastapi/routers/demo_triggers.py` | Demo trigger endpoints |
 | `vultron/adapters/driving/fastapi/routers/actors.py` | Inbox endpoint |

--- a/docs/tutorials/container_demos.md
+++ b/docs/tutorials/container_demos.md
@@ -40,7 +40,7 @@ required.
 
 | Scenario       | DEMO value     | Actors                                               |
 |:---------------|:---------------|:-----------------------------------------------------|
-| Two-actor      | `two-actor`    | Finder + Vendor + CaseActor                          |
+| FV             | `fv`            | Finder + Vendor + CaseActor                          |
 | Three-actor    | `three-actor`  | Finder + Vendor + Coordinator + CaseActor            |
 | Multi-vendor   | `multi-vendor` | Finder + Vendor + Coordinator + Vendor2 + CaseActor  |
 
@@ -66,9 +66,9 @@ cd Vultron
 
 ---
 
-## Step 2 — Run the two-actor scenario
+## Step 2 — Run the FV scenario
 
-The **two-actor** scenario (D5-2) is the simplest: a Finder discovers a
+The **FV** scenario (D5-2) is the simplest: a Finder discovers a
 vulnerability and submits a report to a Vendor, who validates it, engages the
 case, adds the Finder as a participant, and exchanges notes with them. The
 CaseActor is co-located in the Vendor container.
@@ -92,10 +92,10 @@ Docker builds the images on the first run (this takes a few minutes) and then:
 A successful run ends with:
 
 ```text
-[multi-actor-integration] SUCCESS: scenario 'two-actor' passed.
+[multi-actor-integration] SUCCESS: scenario 'fv' passed.
 ```
 
-### What the two-actor demo does
+### What the FV demo does
 
 | Step | Actor     | Action                                               |
 |:-----|:----------|:-----------------------------------------------------|
@@ -273,7 +273,7 @@ verifies the exit code, and removes all volumes automatically:
 
 ```bash
 # From the repository root:
-./integration_tests/demo/run_multi_actor_integration_test.sh two-actor
+./integration_tests/demo/run_multi_actor_integration_test.sh fv
 ./integration_tests/demo/run_multi_actor_integration_test.sh three-actor
 ./integration_tests/demo/run_multi_actor_integration_test.sh multi-vendor
 ```
@@ -281,7 +281,7 @@ verifies the exit code, and removes all volumes automatically:
 Or via the Makefile targets:
 
 ```bash
-make integration-test-multi-actor    # two-actor
+make integration-test-multi-actor    # fv
 make integration-test-three-actor    # three-actor
 make integration-test-multi-vendor   # multi-vendor
 ```
@@ -293,7 +293,7 @@ make integration-test-multi-vendor   # multi-vendor
     `PROJECT_NAME` to run multiple scenarios in parallel:
 
     ```bash
-    PROJECT_NAME=vultron-it-two   DEMO=two-actor   \
+    PROJECT_NAME=vultron-it-two   DEMO=fv   \
         ./integration_tests/demo/run_multi_actor_integration_test.sh
     PROJECT_NAME=vultron-it-three DEMO=three-actor \
         ./integration_tests/demo/run_multi_actor_integration_test.sh

--- a/docs/tutorials/fv-demo.md
+++ b/docs/tutorials/fv-demo.md
@@ -1,6 +1,6 @@
-# Tutorial: Run the Two-Actor Demo
+# Tutorial: Run the FV Demo
 
-In this tutorial, we will run the **two-actor CVD demo** end-to-end using
+In this tutorial, we will run the **fv CVD demo** end-to-end using
 Docker Compose. This demo models a complete Coordinated Vulnerability
 Disclosure (CVD) workflow between a Finder (vulnerability reporter) and a
 Vendor (software maintainer).
@@ -17,7 +17,7 @@ By the end of this tutorial, we will have:
 
 !!! info "What we will learn"
 
-    The two-actor demo exercises the **full VFDPxa lifecycle**: a case moves
+    The fv demo exercises the **full VFDPxa lifecycle**: a case moves
     from report submission all the way through fix-ready, fix-deployed, public
     disclosure, embargo teardown, and case closure on both participant replicas.
 
@@ -82,7 +82,7 @@ docker compose -f docker/docker-compose-multi-actor.yml \
     up --abort-on-container-exit demo-runner
 ```
 
-The two-actor scenario is the **default** — no `DEMO` environment variable is
+The fv scenario is the **default** — no `DEMO` environment variable is
 required.
 
 Docker builds the images on the first run (this takes a few minutes). On
@@ -342,12 +342,12 @@ We have:
   [Running the Multi-Actor Container Demos](container_demos.md) to run
   three-actor and multi-vendor workflows.
 - **Understand the message-level protocol** — the
-  [Two-Actor Demo Protocol Reference](../reference/two-actor-demo-protocol.md)
+  [FV Demo Protocol Reference](../reference/fv-demo-protocol.md)
   documents every ActivityStreams activity exchanged during this demo,
   including sequence diagrams, per-phase narratives, and example AS2 JSON
   payloads.
 - **Read the scenario source** — the demo script is at
-  `vultron/demo/scenario/two_actor_demo.py`; shared helpers are in
+  `vultron/demo/scenario/fv_demo.py`; shared helpers are in
   `vultron/demo/helpers/`.
 - **Explore the single-container demos** — see
   [Run the Receive-Report Demo](receive_report_demo.md) and

--- a/docs/tutorials/fv-demo.md
+++ b/docs/tutorials/fv-demo.md
@@ -1,6 +1,6 @@
 # Tutorial: Run the FV Demo
 
-In this tutorial, we will run the **fv CVD demo** end-to-end using
+In this tutorial, we will run the **FV CVD demo** end-to-end using
 Docker Compose. This demo models a complete Coordinated Vulnerability
 Disclosure (CVD) workflow between a Finder (vulnerability reporter) and a
 Vendor (software maintainer).
@@ -17,7 +17,7 @@ By the end of this tutorial, we will have:
 
 !!! info "What we will learn"
 
-    The fv demo exercises the **full VFDPxa lifecycle**: a case moves
+    The FV demo exercises the **full VFDPxa lifecycle**: a case moves
     from report submission all the way through fix-ready, fix-deployed, public
     disclosure, embargo teardown, and case closure on both participant replicas.
 
@@ -82,7 +82,7 @@ docker compose -f docker/docker-compose-multi-actor.yml \
     up --abort-on-container-exit demo-runner
 ```
 
-The fv scenario is the **default** — no `DEMO` environment variable is
+The FV scenario is the **default** — no `DEMO` environment variable is
 required.
 
 Docker builds the images on the first run (this takes a few minutes). On

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -10,11 +10,11 @@
   and the full RM case lifecycle using the remaining `vultron-demo`
   sub-commands.
 - [Running the Multi-Actor Container Demos](container_demos.md) — run the
-  two-actor, three-actor, and multi-vendor container scenarios to see the
+  FV, three-actor, and multi-vendor container scenarios to see the
   full Vultron Protocol in action across isolated participant containers.
-- [Run the Two-Actor Demo](two-actor-demo.md) — step through the full
+- [Run the FV Demo](fv-demo.md) — step through the full
   VFDPxa CVD lifecycle (report → case creation → fix lifecycle → public
-  disclosure → case closure) with the two-actor scenario.
+  disclosure → case closure) with the FV scenario.
 
 ## Further reading
 

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -56,7 +56,7 @@ Three scenarios are supported:
 
 | Scenario      | Actors                                      |
 |:--------------|:--------------------------------------------|
-| `two-actor`   | Finder + Vendor + CaseActor                 |
+| `fv`          | Finder + Vendor + CaseActor                 |
 | `three-actor` | Finder + Vendor + Coordinator + CaseActor   |
 | `multi-vendor`| Finder + Vendor + Coordinator + Vendor2 + CaseActor |
 
@@ -76,7 +76,7 @@ make integration-test-multi-vendor
 Or directly, passing the scenario as a positional argument:
 
 ```bash
-./integration_tests/demo/run_multi_actor_integration_test.sh two-actor
+./integration_tests/demo/run_multi_actor_integration_test.sh fv
 ./integration_tests/demo/run_multi_actor_integration_test.sh three-actor
 ./integration_tests/demo/run_multi_actor_integration_test.sh multi-vendor
 ```
@@ -103,7 +103,7 @@ with a running development stack. Override it to run multiple scenarios in
 parallel:
 
 ```bash
-PROJECT_NAME=vultron-it-two   DEMO=two-actor   ./integration_tests/demo/run_multi_actor_integration_test.sh
+PROJECT_NAME=vultron-it-fv   DEMO=fv   ./integration_tests/demo/run_multi_actor_integration_test.sh
 PROJECT_NAME=vultron-it-three DEMO=three-actor ./integration_tests/demo/run_multi_actor_integration_test.sh
 ```
 

--- a/integration_tests/demo/run_multi_actor_integration_test.sh
+++ b/integration_tests/demo/run_multi_actor_integration_test.sh
@@ -16,7 +16,7 @@
 #               services use a bind mount) to save significant startup time.
 #               Run without --no-build at least once, or after changing
 #               pyproject.toml, uv.lock, or docker/Dockerfile.
-#   SCENARIO    One of: two-actor (default), three-actor, multi-vendor
+#   SCENARIO    One of: fv (default), three-actor, multi-vendor
 #
 # Environment variables:
 #   DEMO                  Alternative way to specify the scenario (overridden by
@@ -79,9 +79,9 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
-DEMO="${SCENARIO_ARG:-${DEMO:-two-actor}}"
+DEMO="${SCENARIO_ARG:-${DEMO:-fv}}"
 
-VALID_SCENARIOS="two-actor three-actor multi-vendor"
+VALID_SCENARIOS="fv three-actor multi-vendor"
 if ! echo "${VALID_SCENARIOS}" | grep -qw "${DEMO}"; then
     echo "ERROR: unknown scenario '${DEMO}'. Valid options: ${VALID_SCENARIOS}" >&2
     exit 1

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,7 +10,7 @@ nav:
     - Run the Receive-Report Demo: 'tutorials/receive_report_demo.md'
     - Running the Other Demos: 'tutorials/other_demos.md'
     - Running the Multi-Actor Container Demos: 'tutorials/container_demos.md'
-    - Run the Two-Actor Demo: 'tutorials/two-actor-demo.md'
+    - Run the FV Demo: 'tutorials/fv-demo.md'
   - Explanation:
     - 'topics/index.md'
     - Background:
@@ -213,7 +213,7 @@ nav:
     - User Stories:
       - 'reference/user_stories/index.md'
       - Traceability Matrix: 'reference/user_stories/traceability.md'
-    - Two-Actor Demo Protocol: 'reference/two-actor-demo-protocol.md'
+    - FV Demo Protocol: 'reference/fv-demo-protocol.md'
     - SSVC Crosswalk: 'reference/ssvc_crosswalk.md'
     - Decision Records:
       - 'adr/index.md'

--- a/notes/README.md
+++ b/notes/README.md
@@ -444,11 +444,11 @@ implementation guidance. Implementation is tracked in issue #1156.
 inbox/outbox pipeline (see issue #1156 and its children).
 
 **`demo-future-ideas.md`**
-Extended multi-actor demo scenario sketches: Two-Actor (Finder + Vendor),
+Extended multi-actor demo scenario sketches: FV (Finder + Vendor),
 Three-Actor (Finder + Vendor + Coordinator), MultiParty (ownership transfer).
 Describes what each scenario would demonstrate and open design questions.
 **Load when**: designing new demo scripts or extending the existing demo suite
-beyond the current two-actor scenario.
+beyond the current FV scenario.
 
 **`vultron/core/use_cases/triggers/AGENTS.md`**
 Trigger classification guidance: demo-specific vs general-purpose

--- a/notes/case-communication-model.md
+++ b/notes/case-communication-model.md
@@ -16,7 +16,7 @@ related_notes:
   - notes/case-ledger-authority.md
   - notes/event-driven-control-flow.md
   - notes/participant-case-replica.md
-  - notes/two-actor-demo.md
+  - notes/fv-demo.md
 relevant_packages:
   - vultron/core/use_cases/triggers
   - vultron/core/use_cases/received

--- a/notes/case-proposal.md
+++ b/notes/case-proposal.md
@@ -183,7 +183,7 @@ corresponding `MessageSemantics` value.
 
 | Issue | Relationship |
 |-------|-------------|
-| #810 | **Blocked by this**: demo routing to dedicated case-actor container requires the CaseProposal protocol to be in place before `CreateCaseActorNode` can be adapted for the demo layer. Note: the current two-actor demo passes all convergence invariants (all 26 invariants PASS as of #1025 review), confirming that #810 is architectural improvement work rather than a blocking bug. |
+| #810 | **Blocked by this**: demo routing to dedicated case-actor container requires the CaseProposal protocol to be in place before `CreateCaseActorNode` can be adapted for the demo layer. Note: the current FV demo passes all convergence invariants (all 26 invariants PASS as of #1025 review), confirming that #810 is architectural improvement work rather than a blocking bug. |
 | #811 | Spec + ADR for CaseActor dynamic spawning — a broader concern; CaseProposal is a prerequisite input. |
 | #812 | Implementation of CaseActor dynamic spawning — blocked by #811 and this work. |
 
@@ -193,7 +193,7 @@ corresponding `MessageSemantics` value.
 
 **Source**: 2026-07-21 planning session, issue #810.
 
-Before dynamic case-actor spawning (#812) is implemented, the two-actor demo
+Before dynamic case-actor spawning (#812) is implemented, the FV demo
 needs a way to route case-actor creation to the dedicated case-actor container
 rather than creating the actor locally in the vendor container (DEMOMA-01-001).
 
@@ -216,7 +216,7 @@ returns SUCCESS or FAILURE. It does not produce a content artifact.
 ### Location
 
 `DemoCreateCaseActorNode` lives in `vultron/demo/` (demo layer), not in
-`vultron/core/`. The two-actor demo wires it in place of the core
+`vultron/core/`. The FV demo wires it in place of the core
 `CreateCaseActorNode` via the demo-level case-creation BT. Core
 `CreateCaseActorNode` is unchanged.
 

--- a/notes/demo-ci-diagnostics.md
+++ b/notes/demo-ci-diagnostics.md
@@ -29,7 +29,7 @@ root cause with this guide.
 
 ## Overview
 
-The Demo Integration CI job runs a two-actor Vultron scenario end-to-end
+The Demo Integration CI job runs an FV (Finder + Vendor) Vultron scenario end-to-end
 inside Docker, collects JSONL case-ledger replica files, and then runs the
 `case_ledger_invariants` harness against those files. Failures come from
 one of three layers, each with its own diagnostic surface.
@@ -158,7 +158,7 @@ Implications for diagnostics:
 - Name test helpers accordingly (for example, `_fetch_case_log`, not
   `_fetch_case_actor_log`).
 - When you need per-replica assertions, use replica JSONL artifacts under
-  `devlogs/two-actor/<actor>/<case>-case-ledger.jsonl` instead of the demo
+  `devlogs/fv/<actor>/<case>-case-ledger.jsonl` instead of the demo
   endpoint.
 
 ---
@@ -174,7 +174,7 @@ cd docker
 docker compose -f docker-compose-multi-actor.yml build
 cd ..
 mkdir -p devlogs
-DEMO=two-actor \
+DEMO=fv \
 VULTRON_SERVER__LOG_LEVEL=DEBUG \
   docker compose -f docker/docker-compose-multi-actor.yml \
   up --abort-on-container-exit --exit-code-from demo-runner
@@ -217,16 +217,16 @@ docker compose -f docker/docker-compose-multi-actor.yml down -v
 CI uploads two artifact bundles on failure. Both are available from the
 Actions run summary page under **Artifacts**.
 
-### `two-actor-case-logs` (always uploaded)
+### `fv-case-logs` (always uploaded)
 
 Path in artifact: `devlogs/`
 
 JSONL file layout:
 
 ```text
-devlogs/two-actor/finder/<case-id-slug>-case-ledger.jsonl
-devlogs/two-actor/vendor/<case-id-slug>-case-ledger.jsonl
-devlogs/two-actor/case-actor/<case-id-slug>-case-ledger.jsonl
+devlogs/fv/finder/<case-id-slug>-case-ledger.jsonl
+devlogs/fv/vendor/<case-id-slug>-case-ledger.jsonl
+devlogs/fv/case-actor/<case-id-slug>-case-ledger.jsonl
 ```
 
 These are the replica files the invariant harness reads. Download and place

--- a/notes/demo-future-ideas.md
+++ b/notes/demo-future-ideas.md
@@ -23,7 +23,7 @@ Scenarios are named by the sequence of actor roles involved:
 
 | Scenario | File | Description |
 |----------|------|-------------|
-| FV | `vultron/demo/scenario/two_actor_demo.py` | Finder + Vendor; simple coordination |
+| FV | `vultron/demo/scenario/fv_demo.py` | Finder + Vendor; simple coordination |
 | FVV | `vultron/demo/scenario/fvv_demo.py` | Finder → Vendor1 → Vendor2; no coordinator; independent fix paths (implements #1265) |
 | FVCV-extension | `vultron/demo/scenario/fvcv_extension_demo.py` | V1 retains ownership; C is participant; C suggests V2 via ADR-0026 flow; Vendor1 approves; CaseActor invites V2 (implements #1535) |
 
@@ -91,7 +91,7 @@ See also: #1079 (multi-coordinator motivation from FIRSTCON 2026)
 
 ---
 
-## Two-Actor Demo: Finder, Vendor coordinate in separate containers
+## FV Demo: Finder, Vendor coordinate in separate containers
 
 Two actors, a finder and vendor, running in separate containers,
 communicating through the Vultron Protocol. Finder reports vulnerability to
@@ -120,7 +120,7 @@ published, which triggers a case status update reflecting public
 awareness. Finder reports they have published as well. Then the
 coordinator closes the case.
 
-## MultiParty Demo: Two-Actor expands to Coordinator and more Vendors
+## MultiParty Demo: FV expands to Coordinator and more Vendors
 
 A demo in which the process initially looks like scenario 1 above and an
 embargo is established, but
@@ -147,7 +147,7 @@ CaseActor is probably also a "spin up on demand" container that gets
 instantiated when a case is created.
 
 > **Note (2026-07-06)**: These sketch descriptions are superseded by the
-> structured scenario table above. The Two-Actor scenario is implemented.
+> structured scenario table above. The FV scenario is implemented.
 > Three-Actor (FCV) is planned for re-implementation in #1234 (the existing
 > file is deprecated). MultiParty corresponds to FVCV-handoff (#1214).
 > See epic #1093 for the full planned scenario set.

--- a/notes/demo-interactive-ui.md
+++ b/notes/demo-interactive-ui.md
@@ -8,7 +8,7 @@ description: >
   WebSocket event streaming, and the relationship to existing demo scripts.
 related_notes:
   - notes/demo-future-ideas.md
-  - notes/two-actor-demo.md
+  - notes/fv-demo.md
 related_specs:
   - specs/multi-actor-demo.yaml
   - specs/event-driven-control-flow.yaml
@@ -77,7 +77,7 @@ who manages the multi-party disclosure.
 `case-actor`)
 
 **Status**: Existing code must be removed and reconstructed on the
-rebuilt two-actor foundation.
+rebuilt FV foundation.
 
 ### Scenario C — Multi-Vendor: Supply Chain
 
@@ -122,7 +122,7 @@ of them; the priority order above governs what gets interactive first.
 
 ### Scripted Baseline
 
-The Python demo scripts (`two_actor_demo.py`, etc.) remain as
+The Python demo scripts (`fv_demo.py`, etc.) remain as
 **automated puppeteers** that take the happy-path branch at every
 decision point. They are not replaced by the UI; they are a
 complementary way to drive the same trigger endpoints. Critically, the
@@ -233,11 +233,11 @@ WebSocket events to animate the message flow.
 
 ## Development Sequence
 
-1. **Finish two-actor happy path** (current work) — automated scripted
+1. **Finish FV happy path** (current work) — automated scripted
    demo with milestone verification.
-2. **Build the interactive UI** on top of the two-actor demo — ReactFlow
+2. **Build the interactive UI** on top of the FV demo — ReactFlow
    graph + swimlane timeline + WebSocket event stream + CYOA branching
-   for the two-actor scenario.
+   for the FV scenario.
 3. **Port three-actor scenario** (removing and reconstructing from old
    broken code) — the UI is already ready; plug in additional actor
    nodes and swim lanes.
@@ -254,7 +254,7 @@ new implementations.
 
 This design fits into the roadmap at two points:
 
-- **Now** (completing two-actor): foundational scenario is the
+- **Now** (completing FV):: foundational scenario is the
   prerequisite for the UI.
 - **Later** (full protocol behavior): the CYOA branching model is the
   natural home for failure-mode scenarios — embargo collapse, vendor

--- a/notes/embargo-default-semantics.md
+++ b/notes/embargo-default-semantics.md
@@ -67,7 +67,7 @@ be updated to assert `EM.ACTIVE`:
 - `test/core/behaviors/case/test_receive_report_case_tree.py` — assertions
   in the `InitializeDefaultEmbargoNode` test class
 - Any demo-level integration tests that check the final embargo state after
-  case creation (e.g., `test/demo/test_two_actor_demo.py` or similar)
+  case creation (e.g., `test/demo/test_fv_demo.py` or similar)
 
 ---
 

--- a/notes/event-driven-control-flow.md
+++ b/notes/event-driven-control-flow.md
@@ -266,7 +266,7 @@ are bypassed by design.
 Demonstrate full multi-actor workflows. These MUST use trigger endpoints
 ("puppeteering") so the system's own BT and outbox logic is exercised.
 
-- **Examples**: `two_actor_demo.py`, `three_actor_demo.py`,
+- **Examples**: `fv_demo.py`, `three_actor_demo.py`,
   `multi_vendor_demo.py`
 - **Pattern**: Call trigger endpoint on sending actor's container → actor's
   BT runs → activity added to outbox → outbox handler delivers to recipient

--- a/notes/fv-demo.md
+++ b/notes/fv-demo.md
@@ -1,8 +1,8 @@
 ---
-title: Two-Actor Demo Design
+title: FV Demo Design
 status: active
 description: >
-  Authoritative design note for the two-actor (Reporter + Vendor) CVD demo.
+  Authoritative design note for the FV (Finder + Vendor) CVD demo.
   Covers the complete workflow from report submission through case closure,
   the Case Actor handoff mechanism, the CASE_MANAGER role, milestone
   verifications, and the puppeteering-only trigger constraint.
@@ -29,7 +29,7 @@ relevant_packages:
   - vultron/core/behaviors/case
 ---
 
-# Two-Actor Demo Design
+# FV Demo Design
 
 **Source**: 2026-05-07 design session (grill-me).
 
@@ -37,7 +37,7 @@ relevant_packages:
 
 ## Purpose
 
-The two-actor demo is the foundational scenario for the Vultron prototype.
+The FV demo is the foundational scenario for the Vultron prototype.
 It demonstrates a complete, clean CVD workflow between a Reporter (Finder) and
 a Vendor, with a dedicated Case Actor managing case state. All other demo
 scenarios build on this one — if it fails, nothing else works.
@@ -59,7 +59,7 @@ aware, no exploit public, no active attacks.
 is an actor record co-located in the vendor container with its own distinct
 actor ID and inbox URL (e.g.,
 `http://vendor:7999/api/v2/actors/{case_actor_uuid}`). No separate
-`case-actor` container is used for the two-actor demo.
+`case-actor` container is used for the FV demo.
 
 ### CASE_MANAGER vs CASE_ACTOR terminology
 
@@ -294,5 +294,5 @@ Do not close these issues before implementation confirms their status.
 
 - `archived_notes/demo-review-26042001.md` — archived; point-in-time bug analysis
   from 2026-04-20 that informed the demo redesign
-- `archived_notes/two-actor-feedback.md` — detailed bug feedback from
+- `archived_notes/FV-feedback.md` — detailed bug feedback from
   earlier demo runs

--- a/plan/history/2607/implementation/ISSUE-1584.md
+++ b/plan/history/2607/implementation/ISSUE-1584.md
@@ -1,0 +1,15 @@
+---
+source: ISSUE-1584
+timestamp: '2026-07-22T18:46:39.371463+00:00'
+title: Rename two-actor demo to FV demo
+type: implementation
+---
+
+## Issue #1584 — feat(#1557): rename two-actor demo to FV demo
+
+Implemented full rename of "two-actor demo" → "FV demo" across 41 files:
+Python source rename (two_actor_demo.py → fv_demo.py), CLI subcommand (two-actor → fv),
+Docker Compose DEMO default, CI workflow artifact name, devlogs path, docs, notes, specs, test file.
+All 11 acceptance criteria satisfied. 5354 tests pass, all linters clean.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1616>

--- a/specs/case-ledger-processing.yaml
+++ b/specs/case-ledger-processing.yaml
@@ -326,7 +326,7 @@ groups:
       while still routing the activity through the CaseActor''s inbox for archival. See OX-08-004 for the updated addressing
       policy and ADR-0021 for the full end-to-end path.'
     verification: For each entry in `EXPECTED_EVENT_TYPES`, a test verifies that the CaseActor's canonical ledger contains
-      at least one entry with that `eventType` after a full two-actor demo run.
+      at least one entry with that `eventType` after a full FV demo run.
   - id: CLP-10-002
     priority: MUST
     kind: project

--- a/specs/demo-ci.yaml
+++ b/specs/demo-ci.yaml
@@ -147,8 +147,8 @@ groups:
         kind: project
         statement: >-
           The demo workflow MUST build the Docker images using
-          docker/docker-compose-multi-actor.yml and run the two-actor demo
-          scenario (DEMO=two-actor) as the initial CI scenario.
+          docker/docker-compose-multi-actor.yml and run the FV demo
+          scenario (DEMO=fv) as the initial CI scenario.
 
       - id: DEMOCI-02-006
         priority: MUST
@@ -183,7 +183,7 @@ groups:
           The demo workflow job MUST have a timeout of 15 minutes
           (timeout-minutes: 15).
         rationale: >-
-          The two-actor demo currently takes 3–5 minutes; a 15-minute cap
+          The FV demo currently takes 3–5 minutes; a 15-minute cap
           prevents an indefinite CI hang if a container gets stuck, while
           providing sufficient headroom for slow runners.
 
@@ -209,7 +209,7 @@ groups:
           scenarios (e.g., three-actor, multi-vendor) as each scenario
           reaches a stable, reproducible state.
         rationale: >-
-          Starting with the two-actor scenario lets CI run reliably while
+          Starting with the FV scenario lets CI run reliably while
           more complex scenarios are still being developed. Additional
           scenarios add coverage without blocking CI on unstable demos.
 
@@ -238,7 +238,7 @@ groups:
           PR that introduces the scenario script; the job MUST use
           `--abort-on-container-exit --exit-code-from demo-runner`,
           `timeout-minutes: 15`, and the same teardown and log-upload steps
-          as the two-actor job (DEMOCI-02-006, DEMOCI-02-009, DEMOCI-02-010)
+          as the FV job (DEMOCI-02-006, DEMOCI-02-009, DEMOCI-02-010)
         rationale: >-
           Running scenarios in series would make CI proportionally slower with
           each scenario added. Parallel jobs keep wall-clock time bounded and

--- a/specs/demo-report.yaml
+++ b/specs/demo-report.yaml
@@ -36,7 +36,7 @@ groups:
       unset) and MUST discover input files by recursively globbing
       `**/*-case-ledger.jsonl` beneath it.
     rationale: >-
-      This mirrors the layout written by `two_actor_demo._phase_dump_case_ledgers`
+      This mirrors the layout written by `fv_demo._phase_dump_case_ledgers`
       (`{DEVLOGS_DIR}/{demo_name}/{actor_name}/{case_id_slug}-case-ledger.jsonl`)
       and read by `test/ci/test_case_ledger_invariants.py`.
   - id: DRPT-01-003

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -184,23 +184,23 @@ groups:
     - rel_type: refines
       spec_id: DEMOMA-05-001
 - id: DEMOMA-06
-  title: Two-Actor Scenario Workflow
+  title: FV Scenario Workflow
   trigger:
     type: scenario_start
-    value: two-actor
+    value: fv
   specs:
   - id: DEMOMA-06-001
     priority: MUST
     kind: project
     statement: >-
-      The two-actor (Reporter + Vendor) demo scenario MUST execute a complete CVD lifecycle
+      The FV (Finder + Vendor) demo scenario MUST execute a complete CVD lifecycle
       ending in final case state VFDPxa (Vendor aware, Fix ready, Fix Deployed, Public aware,
       no exploit public, no active attacks)
   - id: DEMOMA-06-002
     priority: MUST
     kind: project
     statement: >-
-      The two-actor scenario script MUST verify milestones M1 through M7 in order,
+      The FV scenario script MUST verify milestones M1 through M7 in order,
       checking both the Vendor and Finder DataLayers at each checkpoint.
     preconditions:
     - description: Two-actor scenario executing; Vendor, Finder, and CaseActor containers
@@ -248,7 +248,7 @@ groups:
       expected: All participants RM state = CLOSED; case record marked closed
     postconditions:
     - description: >-
-        All milestones M1-M7 verified; two-actor scenario complete in final state
+        All milestones M1-M7 verified; FV scenario complete in final state
         VFDPxa with EM.EXITED and all participants RM.CLOSED
   - id: DEMOMA-06-003
     priority: MUST
@@ -261,14 +261,14 @@ groups:
     priority: MUST
     kind: project
     statement: >-
-      The two-actor demo Docker topology MUST use a dedicated case-actor container with its
+      The FV demo Docker topology MUST use a dedicated case-actor container with its
       own isolated DataLayer; the Vendor MUST route case-actor creation to that container
       using the pre-configured case-actor service URL, not create the case-actor record
       locally in the vendor container's DataLayer
     rationale: >-
       Routing case-actor creation to its own container satisfies DEMOMA-01-001 (each actor
       in its own container) and exercises the CaseProposal protocol (ADR-0023) in the
-      two-actor scenario. The demo uses DemoCreateCaseActorNode as an Actuator-shape
+      FV scenario. The demo uses DemoCreateCaseActorNode as an Actuator-shape
       ADR-0024 stub: it reads the pre-configured case-actor URL and writes it to the BT
       blackboard as case_actor_id, then delegates to the standard registration sequence.
       This is a temporary demo artifact; issue #812 will replace it with real dynamic
@@ -280,7 +280,7 @@ groups:
     priority: MUST
     kind: project
     statement: >-
-      The two-actor demo MUST verify that the case-actor container's DataLayer holds the
+      The FV demo MUST verify that the case-actor container's DataLayer holds the
       canonical case ledger after the demo completes; the demo script MUST dump the
       case-actor's ledger from the dedicated case-actor container, not from the vendor
       container's co-located sub-actor
@@ -499,7 +499,7 @@ groups:
     statement: >-
       The PR that introduces the FVV scenario script MUST also add a dedicated parallel
       CI job to `.github/workflows/demo-integration.yml` that runs the FVV scenario
-      using `DEMO=fvv`; the job MUST run concurrently with (not after) the two-actor
+      using `DEMO=fvv`; the job MUST run concurrently with (not after) the FV
       job so that total CI wall-clock time does not grow linearly with scenario count
     relationships:
     - rel_type: refines

--- a/test/ci/README-case-log-ratchet.md
+++ b/test/ci/README-case-log-ratchet.md
@@ -11,7 +11,7 @@ universal invariant check functions live in
 
 | Scenario | Test file |
 |----------|-----------|
-| FV (two-actor) | `test/ci/invariants/test_fv_invariants.py` |
+| FV | `test/ci/invariants/test_fv_invariants.py` |
 | FVV (three-actor) | `test/ci/invariants/test_fvv_invariants.py` |
 | FVCV-extension | `test/ci/invariants/test_fvcv_extension_invariants.py` |
 | FVCV-handoff | `test/ci/invariants/test_fvcv_handoff_invariants.py` |
@@ -182,18 +182,18 @@ exit code.
 
 ## JSONL Artifact Location
 
-The two-actor demo writes one JSONL file per actor under:
+The FV demo writes one JSONL file per actor under:
 
 ```text
 devlogs/<demo_name>/<actor_name>/<case_id_slug>-case-ledger.jsonl
 ```
 
-For the standard two-actor run this produces:
+For the standard FV run this produces:
 
 ```text
-devlogs/two-actor/finder/...jsonl
-devlogs/two-actor/vendor/...jsonl
-devlogs/two-actor/case-actor/...jsonl
+devlogs/fv/finder/...jsonl
+devlogs/fv/vendor/...jsonl
+devlogs/fv/case-actor/...jsonl
 ```
 
 These files are collected by the `Upload case ledger JSONL files` step in

--- a/test/ci/invariants/test_fv_invariants.py
+++ b/test/ci/invariants/test_fv_invariants.py
@@ -1,11 +1,11 @@
-"""Case-ledger invariant tests for the two-actor FV (Finder + Vendor) scenario.
+"""Case-ledger invariant tests for the FV (Finder + Vendor) scenario.
 
-Reads JSONL case-ledger replica files from ``devlogs/two-actor/`` and
+Reads JSONL case-ledger replica files from ``devlogs/fv/`` and
 asserts all universal invariants via the shared ``common`` library plus
 FV-specific checks.
 
 All tests are tagged ``@pytest.mark.case_ledger_invariants``.  They skip
-automatically when ``devlogs/`` or ``devlogs/two-actor/`` is absent, so they
+automatically when ``devlogs/`` or ``devlogs/fv/`` is absent, so they
 are safe to include in the regular unit-test collection.
 
 Spec: CLP-07.
@@ -34,7 +34,7 @@ from test.ci.invariants.common import (
     load_devlogs,
 )
 
-_DEMO_NAME = "two-actor"
+_DEMO_NAME = "fv"
 
 #: Expected protocol eventTypes in a complete FV run.
 _FV_EXPECTED_EVENT_TYPES = [
@@ -132,7 +132,7 @@ def test_invariant_5_expected_event_types_present(
 ) -> None:
     """Each expected protocol eventType appears at least once.
 
-    Note: ``ack_report`` is intentionally excluded — the two-actor demo uses
+    Note: ``ack_report`` is intentionally excluded — the FV demo uses
     ``auto_create_case=True``, so no pre-case ACK is emitted (see #1133).
     """
     violations = check_event_type_present(fv_replicas, event_type_val)
@@ -279,7 +279,7 @@ def test_invariant_15_cs_state_transitions_observed(
 # FV-specific invariants
 # ---------------------------------------------------------------------------
 #
-# The two-actor (FV) scenario has no scenario-specific ledger invariant beyond
+# The FV scenario has no scenario-specific ledger invariant beyond
 # the universal set: the Finder joins by submitting a report (which creates the
 # case), never via an ``invite_actor_to_case`` activity, so no invite event is
 # expected in this ledger.  Scenarios that invite a mid-case participant (FVV,

--- a/test/demo/test_fv_demo.py
+++ b/test/demo/test_fv_demo.py
@@ -11,7 +11,7 @@
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-"""Unit tests for the two-actor (Finder + Vendor) multi-container demo (D5-1-G5).
+"""Unit tests for the FV (Finder + Vendor) multi-container demo (D5-1-G5).
 
 Uses a single TestClient (one FastAPI app instance) to simulate two containers.
 Both DataLayerClient instances route through the same TestClient but address
@@ -31,7 +31,7 @@ from _pytest.monkeypatch import MonkeyPatch
 from click.testing import CliRunner
 from fastapi.testclient import TestClient
 
-import vultron.demo.scenario.two_actor_demo as demo
+import vultron.demo.scenario.fv_demo as demo
 from test.demo._helpers import make_client, make_testclient_call
 from vultron.adapters.utils import strip_id_prefix
 from vultron.demo.cli import main
@@ -151,7 +151,7 @@ class TestResetContainers:
         case_actor_client.get.return_value = {}
 
         with patch(
-            "vultron.demo.scenario.two_actor_demo.reset_datalayer",
+            "vultron.demo.scenario.fv_demo.reset_datalayer",
             return_value={"status": "ok"},
         ) as reset_mock:
             demo.reset_containers(
@@ -960,7 +960,7 @@ class TestVerifyM1State:
 
 @pytest.mark.timeout(30)
 class TestRunTwoActorDemo:
-    """Test the complete two-actor workflow via run_two_actor_demo."""
+    """Test the complete FV workflow via run_fv_demo."""
 
     def test_full_workflow_succeeds(
         self, client: TestClient, base: str, caplog
@@ -972,7 +972,7 @@ class TestRunTwoActorDemo:
         vendor_id = f"{base}/actors/vendor-full-test"
 
         with caplog.at_level(logging.ERROR):
-            demo.run_two_actor_demo(
+            demo.run_fv_demo(
                 finder_client=finder_client,
                 vendor_client=vendor_client,
                 finder_id=finder_id,
@@ -1031,22 +1031,13 @@ class TestDumpCaseLogs:
 
         case_slug = "https_example.org_cases_case-dump-fallback"
         assert (
-            tmp_path
-            / "two-actor"
-            / "finder"
-            / f"{case_slug}-case-ledger.jsonl"
+            tmp_path / "fv" / "finder" / f"{case_slug}-case-ledger.jsonl"
         ).exists()
         assert (
-            tmp_path
-            / "two-actor"
-            / "vendor"
-            / f"{case_slug}-case-ledger.jsonl"
+            tmp_path / "fv" / "vendor" / f"{case_slug}-case-ledger.jsonl"
         ).exists()
         assert (
-            tmp_path
-            / "two-actor"
-            / "case-actor"
-            / f"{case_slug}-case-ledger.jsonl"
+            tmp_path / "fv" / "case-actor" / f"{case_slug}-case-ledger.jsonl"
         ).exists()
         assert any(
             "/actors/case-actor-demo/demo/cases/case-dump-fallback/log"
@@ -1137,15 +1128,14 @@ class TestDumpCaseLogs:
 
 
 class TestTwoActorCLI:
-    """Test the two-actor CLI sub-command registration and invocation."""
+    """Test the fv CLI sub-command registration and invocation."""
 
     def test_cli_command_registered(self):
         runner = CliRunner()
-        result = runner.invoke(main, ["two-actor", "--help"])
+        result = runner.invoke(main, ["fv", "--help"])
         assert result.exit_code == 0
         assert (
-            "two-actor" in result.output.lower()
-            or "finder" in result.output.lower()
+            "fv" in result.output.lower() or "finder" in result.output.lower()
         )
 
     def test_cli_runs_demo(self, client: TestClient, base: str):
@@ -1155,14 +1145,14 @@ class TestTwoActorCLI:
 
         patched_run = MagicMock()
         with patch(
-            "vultron.demo.scenario.two_actor_demo.run_two_actor_demo",
+            "vultron.demo.scenario.fv_demo.run_fv_demo",
             patched_run,
         ):
             runner = CliRunner()
             result = runner.invoke(
                 main,
                 [
-                    "two-actor",
+                    "fv",
                     "--skip-health-check",
                     "--finder-url",
                     base,
@@ -1475,7 +1465,7 @@ def _fetch_case_log(
 def completed_workflow(
     client: TestClient, base: str
 ) -> tuple[demo.DataLayerClient, demo.as_VulnerabilityCase]:
-    """Run the full two-actor workflow and return (vendor_client, case).
+    """Run the full FV workflow and return (vendor_client, case).
 
     Uses deterministic actor IDs (``finder-ledger-inv`` /
     ``vendor-ledger-inv``) to avoid collisions with other test classes
@@ -1546,7 +1536,7 @@ def completed_workflow(
 
 
 class TestCaseLedgerInvariants:
-    """In-process case-ledger invariant checks for the two-actor scenario.
+    """In-process case-ledger invariant checks for the FV scenario.
 
     Adapts invariants 5 and 7 from ``test/ci/test_case_ledger_invariants.py``
     to run against the live in-process DataLayer state rather than parsed JSONL
@@ -1560,7 +1550,7 @@ class TestCaseLedgerInvariants:
     """
 
     #: Baseline event types that must appear in the combined case log after a
-    #: complete two-actor CVD run.  These are the types observed in the
+    #: complete FV CVD run.  These are the types observed in the
     #: single-DataLayer in-process test environment and do not correspond
     #: directly to CI invariant 5 (whose full set requires CaseActor
     #: commit-path completeness — see issue #789).

--- a/test/metadata/specs/test_schema.py
+++ b/test/metadata/specs/test_schema.py
@@ -722,9 +722,9 @@ def test_trigger_state_entered():
 
 
 def test_trigger_scenario_start():
-    t = Trigger(type=TriggerType.SCENARIO_START, value="two-actor")
+    t = Trigger(type=TriggerType.SCENARIO_START, value="fv")
     assert t.type == TriggerType.SCENARIO_START
-    assert t.value == "two-actor"
+    assert t.value == "fv"
 
 
 # ---------------------------------------------------------------------------

--- a/vultron/demo/README.md
+++ b/vultron/demo/README.md
@@ -40,7 +40,7 @@ distinct techniques:
 
 | Sub-command    | What it demonstrates                                      |
 |----------------|-----------------------------------------------------------|
-| `two-actor`    | Two-actor (Finder + Vendor) multi-container CVD workflow  |
+| `fv`           | FV (Finder + Vendor) multi-container CVD workflow         |
 | `three-actor`  | Three-actor (+ Coordinator) multi-container CVD workflow  |
 | `multi-vendor` | Ownership transfer + second vendor multi-container demo   |
 
@@ -125,7 +125,7 @@ Each demo script remains directly invokable as a Python module:
 
 ```bash
 uv run python -m vultron.demo.exchange.receive_report_demo
-uv run python -m vultron.demo.scenario.two_actor_demo
+uv run python -m vultron.demo.scenario.fv_demo
 ```
 
 ## Unified CLI (`vultron-demo`)

--- a/vultron/demo/cli.py
+++ b/vultron/demo/cli.py
@@ -51,7 +51,7 @@ import vultron.demo.scenario.multi_vendor_demo as multi_vendor_demo
 import vultron.demo.scenario.three_actor_demo as three_actor_demo
 import vultron.demo.exchange.transfer_ownership_demo as transfer_ownership_demo
 import vultron.demo.exchange.trigger_demo as trigger_demo
-import vultron.demo.scenario.two_actor_demo as two_actor_demo
+import vultron.demo.scenario.fv_demo as fv_demo
 from vultron.demo.seed_config import SeedConfig
 from vultron.demo.utils import DataLayerClient, BASE_URL, seed_actor
 import vultron.bt.base.demo.pacman as pacman_demo
@@ -264,15 +264,15 @@ def seed(
 
 
 # ---------------------------------------------------------------------------
-# Two-actor sub-command — multi-container Finder + Vendor demo (D5-1-G5)
+# FV sub-command — multi-container Finder + Vendor demo (D5-1-G5)
 # ---------------------------------------------------------------------------
 
 
-@main.command(name="two-actor")
+@main.command(name="fv")
 @click.option(
     "--finder-url",
     envvar="VULTRON_FINDER_BASE_URL",
-    default=two_actor_demo.FINDER_BASE_URL,
+    default=fv_demo.FINDER_BASE_URL,
     show_default=True,
     help="Base URL of the Finder container API "
     "(env: VULTRON_FINDER_BASE_URL).",
@@ -280,7 +280,7 @@ def seed(
 @click.option(
     "--vendor-url",
     envvar="VULTRON_VENDOR_BASE_URL",
-    default=two_actor_demo.VENDOR_BASE_URL,
+    default=fv_demo.VENDOR_BASE_URL,
     show_default=True,
     help="Base URL of the Vendor container API "
     "(env: VULTRON_VENDOR_BASE_URL).",
@@ -298,7 +298,7 @@ def seed(
 @click.option(
     "--case-actor-url",
     envvar="VULTRON_CASE_ACTOR_BASE_URL",
-    default=two_actor_demo.CASE_ACTOR_BASE_URL,
+    default=fv_demo.CASE_ACTOR_BASE_URL,
     show_default=True,
     help="Base URL of the CaseActor container API "
     "(env: VULTRON_CASE_ACTOR_BASE_URL).",
@@ -309,7 +309,7 @@ def seed(
     default=False,
     help="Skip container availability checks.",
 )
-def two_actor(
+def fv(
     finder_url: str,
     vendor_url: str,
     finder_id: str | None,
@@ -317,7 +317,7 @@ def two_actor(
     case_actor_url: str,
     skip_health_check: bool,
 ) -> None:
-    """Run the two-actor (Finder + Vendor) multi-container CVD demo (D5-1-G5).
+    """Run the FV (Finder + Vendor) multi-container CVD demo (D5-1-G5).
 
     Orchestrates a complete CVD workflow across two separate API server
     containers.  Requires both containers to be running and reachable at
@@ -337,7 +337,7 @@ def two_actor(
       6. Finder accepts the invitation (Vendor's inbox).
       7. Verify final state on both containers.
     """
-    two_actor_demo.main(
+    fv_demo.main(
         skip_health_check=skip_health_check,
         finder_url=finder_url,
         vendor_url=vendor_url,

--- a/vultron/demo/helpers/seeding.py
+++ b/vultron/demo/helpers/seeding.py
@@ -415,7 +415,7 @@ def reset_containers(
 
     Keeping the reset loop here (rather than in a scenario module) allows any
     multi-container scenario to reuse it without importing from
-    ``two_actor_demo``.  Callers are responsible for supplying the concrete
+    ``fv_demo``.  Callers are responsible for supplying the concrete
     ``reset_fn`` (typically ``reset_datalayer`` from their own module namespace
     so that test-suite mock patches continue to intercept the call).
 

--- a/vultron/demo/helpers/sync.py
+++ b/vultron/demo/helpers/sync.py
@@ -18,7 +18,7 @@ all case participants, and :func:`verify_replica_state` to assert that a
 replica actor's case state matches the authoritative actor.
 
 ``verify_finder_replica_state`` is a backward-compatible wrapper that maps
-the two-actor demo roles (Vendor = authoritative, Finder = replica) onto
+the FV demo roles (Vendor = authoritative, Finder = replica) onto
 the generic ``verify_replica_state`` parameters.
 """
 
@@ -226,7 +226,7 @@ def verify_finder_replica_state(
 ) -> None:
     """Backward-compatible wrapper for :func:`verify_replica_state`.
 
-    In the two-actor demo the Vendor is the authoritative case owner and the
+    In the FV demo the Vendor is the authoritative case owner and the
     Finder holds a replicated copy, so *vendor_client* maps to *auth_client*
     and *finder_client* maps to *replica_client*.
 

--- a/vultron/demo/helpers/verification.py
+++ b/vultron/demo/helpers/verification.py
@@ -14,7 +14,7 @@
 """Scenario-verification primitives shared across demo workflows.
 
 Lower-level assertion helpers used by milestone verification functions in the
-individual scenario modules (e.g. ``two_actor_demo.py``).  Keeping them here
+individual scenario modules (e.g. ``fv_demo.py``).  Keeping them here
 avoids duplication when future multi-actor scenarios need the same checks.
 """
 

--- a/vultron/demo/helpers/workflow.py
+++ b/vultron/demo/helpers/workflow.py
@@ -14,7 +14,7 @@
 """Workflow step helpers shared across demo scenarios.
 
 Provides generic CVD workflow actions — report submission, report validation,
-and case lookup — that can be reused across two-actor, three-actor, and
+and case lookup — that can be reused across FV, three-actor, and
 multi-vendor demo scenarios.  Each function is named after the CVD role that
 performs the action (reporter, coordinator) rather than any scenario-specific
 persona (finder, vendor).

--- a/vultron/demo/scenario/README.md
+++ b/vultron/demo/scenario/README.md
@@ -24,7 +24,7 @@ illustrate individual message semantics in isolation.
 
 | Sub-command    | Script                 | What it demonstrates                                          |
 |----------------|------------------------|---------------------------------------------------------------|
-| `two-actor`    | `two_actor_demo.py`    | Two-actor (Finder + Vendor) CVD workflow                      |
+| `fv`           | `fv_demo.py`           | FV (Finder + Vendor) CVD workflow                             |
 | `three-actor`  | `three_actor_demo.py`  | Three-actor (Finder + Vendor + Coordinator) CVD workflow      |
 | `multi-vendor` | `multi_vendor_demo.py` | Multi-vendor workflow with ownership transfer                 |
 
@@ -34,7 +34,7 @@ Scenario demos require multiple running containers. Use the multi-actor
 Docker Compose file:
 
 ```bash
-# Two-actor scenario (default)
+# FV scenario (default)
 cd docker && docker compose -f docker-compose-multi-actor.yml up
 
 # Three-actor scenario
@@ -47,7 +47,7 @@ DEMO=multi-vendor cd docker && docker compose -f docker-compose-multi-actor.yml 
 Or with the unified CLI (after starting the appropriate containers):
 
 ```bash
-vultron-demo two-actor
+vultron-demo fv
 vultron-demo three-actor
 vultron-demo multi-vendor
 ```

--- a/vultron/demo/scenario/fv_demo.py
+++ b/vultron/demo/scenario/fv_demo.py
@@ -13,7 +13,7 @@
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 
-"""Two-actor (Finder + Vendor) multi-container CVD workflow demo.
+"""FV (Finder + Vendor) multi-container CVD workflow demo.
 
 Orchestrates the full VFDPxa lifecycle across separate Finder and Vendor
 containers. The scenario module now delegates common workflow, notes, and
@@ -150,7 +150,7 @@ def reset_containers(
     vendor_client: DataLayerClient,
     case_actor_client: DataLayerClient | None = None,
 ) -> None:
-    """Reset all containers used by the two-actor demo to a clean baseline.
+    """Reset all containers used by the FV demo to a clean baseline.
 
     D5-2 requires repeatable, single-command execution. Resetting each
     container's DataLayer at the start of the run ensures the demo does
@@ -786,7 +786,7 @@ def _phase_dump_case_ledgers(
     vendor: as_Actor,
     case: as_VulnerabilityCase,
     case_actor_client: DataLayerClient | None = None,
-    demo_name: str = "two-actor",
+    demo_name: str = "fv",
 ) -> None:
     """Dump case ledger entries from each actor container to JSONL files.
 
@@ -808,8 +808,7 @@ def _phase_dump_case_ledgers(
         vendor: Vendor actor object (used to derive the actor object ID).
         case: The as_VulnerabilityCase whose log entries are to be exported.
         case_actor_client: Optional DataLayerClient for the CaseActor container.
-        demo_name: Sub-directory name under the output root (default
-            ``"two-actor"``).
+        demo_name: Sub-directory name under the output root (default ``"fv"``).
     """
     logger.info("─" * 80)
     logger.info("Phase: Case log JSONL export")
@@ -894,16 +893,16 @@ def _phase_dump_case_ledgers(
             logger.info("Wrote %d log entries → %s", len(entries), out_file)
 
 
-def run_two_actor_demo(
+def run_fv_demo(
     finder_client: DataLayerClient,
     vendor_client: DataLayerClient,
     case_actor_client: DataLayerClient | None = None,
     finder_id: str | None = None,
     vendor_id: str | None = None,
 ) -> None:
-    """Orchestrate the complete two-actor (Finder + Vendor) CVD workflow."""
+    """Orchestrate the complete FV (Finder + Vendor) CVD workflow."""
     logger.info("=" * 80)
-    logger.info("TWO-ACTOR DEMO: Reporter + Coordinator CVD Workflow (VFDPxa)")
+    logger.info("FV DEMO: Finder + Vendor CVD Workflow (VFDPxa)")
     logger.info("=" * 80)
     logger.info("Finder container: %s", finder_client.base_url)
     logger.info("Vendor container: %s", vendor_client.base_url)
@@ -971,7 +970,7 @@ def run_two_actor_demo(
     )
 
     logger.info("=" * 80)
-    logger.info("TWO-ACTOR DEMO COMPLETE ✓  (VFDPxa full lifecycle)")
+    logger.info("FV DEMO COMPLETE ✓  (VFDPxa full lifecycle)")
     logger.info("=" * 80)
 
 
@@ -988,7 +987,7 @@ def main(
     finder_id: str | None = None,
     vendor_id: str | None = None,
 ) -> None:
-    """Entry point for the two-actor multi-container CVD workflow demo.
+    """Entry point for the FV (Finder + Vendor) multi-container CVD workflow demo.
 
     Args:
         skip_health_check: Skip the server availability check (useful for
@@ -1029,7 +1028,7 @@ def main(
                 sys.exit(1)
 
     try:
-        run_two_actor_demo(
+        run_fv_demo(
             finder_client=finder_client,
             vendor_client=vendor_client,
             case_actor_client=case_actor_client,

--- a/vultron/demo/scenario/multi_vendor_demo.py
+++ b/vultron/demo/scenario/multi_vendor_demo.py
@@ -61,7 +61,7 @@ from vultron.wire.as2.vocab.objects.vulnerability_case import (
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
     as_VulnerabilityReport,
 )
-from vultron.demo.scenario.two_actor_demo import (
+from vultron.demo.scenario.fv_demo import (
     finder_submits_report,
     get_actor_by_id,
     vendor_validates_report,

--- a/vultron/demo/scenario/three_actor_demo.py
+++ b/vultron/demo/scenario/three_actor_demo.py
@@ -15,7 +15,7 @@
 
 """Three-actor (Finder + Vendor + Coordinator) multi-container CVD demo.
 
-This scenario extends the D5-2 two-actor workflow by introducing a dedicated
+This scenario extends the D5-2 FV workflow by introducing a dedicated
 Coordinator and an authoritative CaseActor container. The workflow remains
 fully deterministic for repeatable acceptance runs:
 
@@ -38,7 +38,7 @@ import sys
 import warnings
 
 from vultron.core.states.em import is_em_embargo_active
-from vultron.demo.scenario.two_actor_demo import (
+from vultron.demo.scenario.fv_demo import (
     get_actor_by_id,
     wait_for_case_participants,
 )

--- a/vultron/metadata/specs/schema.py
+++ b/vultron/metadata/specs/schema.py
@@ -71,7 +71,7 @@ class Trigger(BaseModel):
     ``type`` identifies the category of trigger; ``value`` names the specific
     message (e.g. ``"EP"``) or state (e.g. ``"RM.VALID"``) within that
     category. For ``scenario_start`` triggers, ``value`` names the scenario
-    (e.g. ``"two-actor"``, ``"fvv"``).
+    (e.g. ``"fv"``, ``"fvv"``).
     """
 
     type: TriggerType


### PR DESCRIPTION
## Summary

Renames every occurrence of "two-actor demo" to "FV demo" (Finder + Vendor) throughout the codebase, consistent with the naming scheme used by FVV, FVCV, and FVCV-extension demos.

Closes #1584.

## Changes

- **Python source**: `two_actor_demo.py` → `fv_demo.py`; `run_two_actor_demo` → `run_fv_demo`; `demo_name` default `"two-actor"` → `"fv"` (AC-1)
- **Imports**: all importers (`multi_vendor_demo.py`, `three_actor_demo.py`, `cli.py`) updated; no `two_actor_demo` import remains (AC-2)
- **CLI**: subcommand `two-actor` → `fv`; `vultron-demo fv` works (AC-3)
- **Docker Compose**: `DEMO=${DEMO:-fv}` default (AC-4)
- **CI workflow**: job name, step names, `DEMO=fv`, artifact `fv-case-logs` (AC-5)
- **Devlogs path**: `_DEMO_NAME = "fv"` in `test_fv_invariants.py`; all prose (AC-6)
- **Docs**: `fv-demo.md`, `fv-demo-protocol.md`; mkdocs nav updated (AC-7)
- **Notes/specs**: `notes/`, `specs/multi-actor-demo.yaml`, `specs/demo-ci.yaml`, `specs/demo-report.yaml` updated (AC-8)
- **Test file**: `test_two_actor_demo.py` → `test_fv_demo.py` (AC-9)
- **CI README ratchet**: `devlogs/fv/` reference updated (AC-10)
- **Linters**: black, flake8, mypy, pyright all pass; 5354 tests pass (AC-11)

## Test plan

- [x] `uv run black vultron/ test/` — clean
- [x] `uv run flake8 vultron/ test/` — clean
- [x] `uv run mypy` — 0 issues
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest --tb=short` — 5354 passed, 0 failed
- [x] `uv run mkdocs build --strict` — build succeeds (pre-existing print-site plugin ordering warning, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)