### PR TITLE
feat(#1312): Publish leaf → draft-review-submit pipeline (Production Collapse 4)

### DIFF
--- a/docs/adr/0030-publish-leaf-draft-review-submit-pipeline.md
+++ b/docs/adr/0030-publish-leaf-draft-review-submit-pipeline.md
@@ -1,15 +1,16 @@
 ---
-status: proposed
-date: 2026-07-09
+status: accepted
+date: 2026-07-22
 deciders: [adh]
 ---
 
 # Publish Leaf Expansion: Single Actuator → Draft-Review-Submit Pipeline
 
-> **PROVISIONAL** — formed at planning time (issue #1200). Subject to revision
-> when the implementation issue for this collapse candidate is worked.
-> Implementation tracked by the issue blocked by #1200 and the implementation
-> issue for ADR-0028 (publication intents).
+> Implemented by issue #1312 (`task/1607-signal-taxonomy` branch).  The
+> four-step pipeline (Option 2) was adopted as specified.  The open design
+> question about participant-comment broadcast in the review phase (AC-4) was
+> **deferred** to a follow-on issue — the pipeline functions without it using
+> the default auto-approve `ReviewAdvisoryDraft` Evaluator.
 
 ## Context and Problem Statement
 

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -103,6 +103,8 @@ General information about architectural decision records is available at <https:
   Intent-Record-Driven Arms](0028-publication-intent-bt-collapse.md)
 - [ADR-0029 Notification Loop Collapse: InjectParticipant →
   suggest-actor-to-case Protocol](0029-notification-loop-suggest-actor.md)
+- [ADR-0030 Publish Leaf Expansion: Single Actuator →
+  Draft-Review-Submit Pipeline](0030-publish-leaf-draft-review-submit-pipeline.md)
 
 ## Proposed ADRs
 
@@ -110,9 +112,6 @@ General information about architectural decision records is available at <https:
   `process_payload` Seam](0020-inbox-bt-orchestration.md)
 - [ADR-0027 Exploit-Strategy Subtree Collapse: Five Simulator Nodes →
   EvaluateExploitStrategy](0027-exploit-strategy-bt-collapse.md) *(provisional)*
-- [ADR-0030 Publish Leaf Expansion: Single Actuator →
-  Draft-Review-Submit Pipeline](0030-publish-leaf-draft-review-submit-pipeline.md)
-  *(provisional)*
 - [ADR-0033 Lifecycle-Staged Domain Types Anchored on Guaranteed-Field
   Changes](0033-lifecycle-staged-case-types.md)
 

--- a/notes/bt-fuzzer-nodes-report-management.md
+++ b/notes/bt-fuzzer-nodes-report-management.md
@@ -2117,7 +2117,7 @@ Tree structure::
 (see Publication section above; also see Production Collapse 2 for the
 per-artifact preparation context)
 
-**Tracked by**: implementation issue for collapse candidate 4 (blocked by #1200 and collapse candidate 2 impl issue)
+**Implemented by**: issue #1312 (`task/1607-signal-taxonomy` branch, 2026-07-22, ADR-0030 accepted)
 
 #### Production shape
 
@@ -2136,25 +2136,25 @@ PublishArtifactBT (Sequence)
 └── SubmitAdvisoryArtifact (Actuator)   — submit finalized artifact to advisory platform
 ```
 
-**Open design question**: Should the review phase include a
-"broadcast draft to case participants for comment" step before the Evaluator
-runs? This would involve emitting an outbound Activity (a protocol-visible
-action) and optionally waiting for participant responses — resembling the
-`Accept/Reject` question pattern used elsewhere in the protocol. This is
-captured here as an open question; the implementation issue should design
-the review-phase protocol before wiring the BT.
+**Open design question (deferred)**: Whether the review phase should include
+a "broadcast draft to case participants for comment" step was explicitly
+deferred in issue #1312 to a follow-on issue. The pipeline functions without
+it — the default `ReviewAdvisoryDraft` Evaluator is an auto-approve
+`AlwaysSucceed` stub (AC-3, ADR-0030). When the follow-on issue is addressed,
+the participant-comment broadcast would involve emitting an outbound Activity
+(a protocol-visible action) and optionally waiting for participant responses
+— resembling the `Accept/Reject` question pattern used elsewhere.
 
 **Impact on existing `Publish` Actuator nodes**: Each per-artifact arm in
 Production Collapse 2 (`ExploitReady → Publish`, `PrepareFix → Publish`,
 `PrepareReport → Publish`) has its own `Publish` Actuator. In production,
 those Actuators are each replaced by this full `PublishArtifactBT` subtree.
 
-**Target factory function**:
-`vultron.core.behaviors.report.create_publish_artifact_tree` (new; called
-from within `create_publication_tree`)
+**Implemented factory function**:
+`vultron.core.behaviors.report.publish_artifact_tree.create_publish_artifact_tree`
+(called from `create_publication_tree` per arm via `_make_artifact_arm`)
 
-**Spec requirements**: BT-20-004 (provisional — see
-`specs/behavior-tree-integration.yaml`)
+**Spec requirements**: BT-20-004 (see `specs/behavior-tree-integration.yaml`)
 
 ---
 

--- a/plan/history/2607/implementation/ISSUE-1312.md
+++ b/plan/history/2607/implementation/ISSUE-1312.md
@@ -1,0 +1,20 @@
+---
+source: ISSUE-1312
+timestamp: '2026-07-22T19:00:49.561199+00:00'
+title: 'FUZZ-08d: Publish leaf → draft-review-submit pipeline (Production Collapse
+  4)'
+type: implementation
+---
+
+## Issue #1312 — FUZZ-08d: Publish leaf → draft-review-submit pipeline (Production Collapse 4)
+
+Implemented Production Collapse 4 (ADR-0030 / BT-20-004). Replaced the single `Publish` Actuator
+leaf in each per-artifact arm of `create_publication_tree` with a four-step pipeline:
+DraftAdvisoryArtifact → ReviewAdvisoryDraft → optional ReviseAdvisoryDraft → SubmitAdvisoryArtifact.
+
+New module `publish_artifact_tree.py` with `AdvisoryReviewDecision`, `_NeedsRevisionGate`, and
+`create_publish_artifact_tree()`. Four new fuzzer nodes added to `publication.py`.
+`publication_tree.py` `publish_factory` parameter removed and replaced with four pipeline factory
+parameters. ADR-0030 accepted. BT-20-004 PROVISIONAL marker removed.
+
+All 5385 tests pass. PR: <https://github.com/CERTCC/Vultron/pull/1617>

--- a/plan/incoming/learnings/20260722-ac4-participant-comment-deferred.md
+++ b/plan/incoming/learnings/20260722-ac4-participant-comment-deferred.md
@@ -1,0 +1,20 @@
+---
+title: "AC-4 participant-comment broadcast deferred from #1312"
+type: learning
+timestamp: "2026-07-22"
+source: ISSUE-1312
+signal: spec-ambiguity
+---
+
+ADR-0030 left the participant-comment broadcast in the review phase as an
+"open design question" to be resolved at implementation time. Issue #1312
+resolved it by explicitly deferring to a follow-on issue. The pipeline
+functions without it because the default `ReviewAdvisoryDraft` Evaluator
+is an auto-approve `AlwaysSucceed` stub (AC-3).
+
+The interpretation made: the broadcast step (emitting an outbound Activity
+and waiting for Accept/Reject responses) is out of scope for this collapse
+candidate. A follow-on issue should design the review-phase protocol before
+wiring the broadcast into the BT.
+
+Impact: BT-20-004 statement notes this deferral; ADR-0030 rationale records it.

--- a/plan/incoming/learnings/20260722-advisory-review-decision-approved-field.md
+++ b/plan/incoming/learnings/20260722-advisory-review-decision-approved-field.md
@@ -1,0 +1,24 @@
+---
+title: "AdvisoryReviewDecision.approved field is informational, not a pipeline gate"
+type: learning
+timestamp: "2026-07-22"
+source: ISSUE-1312
+signal: design-question
+---
+
+The `AdvisoryReviewDecision` model has an `approved: bool = True` field that
+was initially documented as "permits submission to the advisory platform".
+At implementation time the pre-PR code review flagged this as a
+documentation-code inconsistency: the pipeline never reads `approved`; only
+`needs_revision` is read (by `_NeedsRevisionGate`).
+
+Decision made: `approved` is metadata for the `ReviewAdvisoryDraft` backend
+to record its decision. A backend that needs to block submission without
+requesting edits (e.g. legal hold) MUST return `Status.FAILURE` from
+`update()` so the Sequence fails. Gating on `approved=False` is deferred
+to a follow-on design question (see AC-4 in issue #1312).
+
+The docstring in `publish_artifact_tree.py` was updated to reflect this
+before the PR landed. A future issue should decide whether an explicit
+`approved=False` guard should be added to the pipeline, or whether the
+convention of returning FAILURE from the Evaluator is sufficient.

--- a/specs/behavior-tree-integration.yaml
+++ b/specs/behavior-tree-integration.yaml
@@ -691,11 +691,12 @@ groups:
       node reviews and approves the draft, and (3) an Actuator node submits the finalized artifact to the external advisory
       platform. An optional revision Composer MAY be included between the Evaluator and Actuator. Whether the review phase
       includes a broadcast-for-participant-comment step is an open design question to be resolved at implementation time.'
-    rationale: 'PROVISIONAL. The single `Publish` simulator leaf stands in for a full advisory publication workflow. In production,
-      drafting, review, and submission are distinct operations with separate external seams. The Actuator shape for submission
-      is confirmed by ADR-0024 (Actuator amendment, 2026-07-07). See `notes/bt-fuzzer-nodes-report-management.md` § "Production
-      Collapse 4: Publish leaf" and ADR-0030.'
-    tracking_issue: '#1200 (planning); implementation issue TBD (blocked by #1200 and implementation issue for BT-20-002)'
+    rationale: 'The single `Publish` simulator leaf stood in for a full advisory publication workflow. In production, drafting,
+      review, and submission are distinct operations with separate external seams. The Actuator shape for submission is confirmed
+      by ADR-0024 (Actuator amendment, 2026-07-07). See `notes/bt-fuzzer-nodes-report-management.md` § "Production Collapse 4:
+      Publish leaf" and ADR-0030 (accepted 2026-07-22). The participant-comment broadcast question in the review phase was deferred
+      to a follow-on issue (AC-4, issue #1312).'
+    tracking_issue: '#1200 (planning); #1312 (implemented)'
 - id: BT-21
   title: Fuzzer Node Replacement Lifecycle
   specs:

--- a/test/core/behaviors/report/test_publication_tree.py
+++ b/test/core/behaviors/report/test_publication_tree.py
@@ -11,14 +11,15 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Tests for the collapsed publication behavior tree (Production Collapse 2).
+"""Tests for the collapsed publication behavior tree (Production Collapses 2 + 4).
 
-Verifies ADR-0028 / BT-20-002:
+Verifies ADR-0028 / BT-20-002 and ADR-0030 / BT-20-004:
 - AC-1: PublicationIntentsSet flag check eliminated (not a leaf).
 - AC-2: NoPublishExploit / NoPublishFix / NoPublishReport bypass leaves eliminated.
 - AC-3: PrioritizePublicationIntents returns a typed PublicationIntentDecision.
 - AC-4: Three named per-artifact arms gated by the intent-record booleans.
 - AC-5: ADR-0025 factory pattern applied to every call-out point.
+- Collapse 4: single Publish leaf replaced by draft-review-submit pipeline subtree.
 """
 
 import pytest
@@ -34,11 +35,14 @@ from vultron.core.behaviors.report.publication_tree import (
     create_publication_tree,
 )
 from vultron.demo.fuzzer.report_management.publication import (
+    DraftAdvisoryArtifact,
     PrepareExploit,
     PrepareFix,
     PrepareReport,
     PrioritizePublicationIntents,
-    Publish,
+    ReviewAdvisoryDraft,
+    ReviseAdvisoryDraft,
+    SubmitAdvisoryArtifact,
 )
 
 CASE_ID = "https://example.org/cases/test-001"
@@ -145,16 +149,19 @@ def test_each_arm_is_selector(arm_name):
     arm = next(c for c in tree.children if c.name == arm_name)
     assert isinstance(arm, py_trees.composites.Selector)
     assert len(arm.children) == 2
-    # First child: the Do<Arm> Sequence (gate → prepare → publish).
+    # First child: the Do<Arm> Sequence (gate → prepare → PublishArtifactBT_*).
     do_seq = arm.children[0]
     assert isinstance(do_seq, py_trees.composites.Sequence)
     assert len(do_seq.children) == 3
+    # Third child of the Sequence is the publish pipeline subtree (Sequence).
+    assert isinstance(do_seq.children[2], py_trees.composites.Sequence)
+    assert do_seq.children[2].name.startswith("PublishArtifactBT_")
     # Second child: an Inverter skip guard.
     assert isinstance(arm.children[1], py_trees.decorators.Inverter)
 
 
-def test_default_prepare_and_publish_nodes_are_fuzzers():
-    """AC-5: default factories produce the fuzzer Composer/Actuator nodes."""
+def test_default_prepare_nodes_are_fuzzers():
+    """AC-5: default prepare factories produce the fuzzer Composer nodes."""
     tree = create_publication_tree(case_id=CASE_ID)
     exploit_seq = tree.children[1].children[0]
     fix_seq = tree.children[2].children[0]
@@ -162,15 +169,27 @@ def test_default_prepare_and_publish_nodes_are_fuzzers():
 
     assert isinstance(exploit_seq.children[0], ShouldPublishExploit)
     assert isinstance(exploit_seq.children[1], PrepareExploit)
-    assert isinstance(exploit_seq.children[2], Publish)
 
     assert isinstance(fix_seq.children[0], ShouldPublishFix)
     assert isinstance(fix_seq.children[1], PrepareFix)
-    assert isinstance(fix_seq.children[2], Publish)
 
     assert isinstance(report_seq.children[0], ShouldPublishReport)
     assert isinstance(report_seq.children[1], PrepareReport)
-    assert isinstance(report_seq.children[2], Publish)
+
+
+def test_default_publish_pipeline_nodes_are_fuzzers():
+    """Collapse 4: default pipeline factories produce fuzzer nodes per arm."""
+    tree = create_publication_tree(case_id=CASE_ID)
+    for arm, label in zip(tree.children[1:], ["Exploit", "Fix", "Report"]):
+        pipeline = arm.children[0].children[2]  # PublishArtifactBT_<label>
+        assert pipeline.name == f"PublishArtifactBT_{label}"
+        assert isinstance(pipeline.children[0], DraftAdvisoryArtifact)
+        assert isinstance(pipeline.children[1], ReviewAdvisoryDraft)
+        # children[2] is the RevisionArm Selector
+        revision_arm = pipeline.children[2]
+        do_revise = revision_arm.children[0]
+        assert isinstance(do_revise.children[1], ReviseAdvisoryDraft)
+        assert isinstance(pipeline.children[3], SubmitAdvisoryArtifact)
 
 
 # ---------------------------------------------------------------------------
@@ -203,7 +222,10 @@ def test_full_tick_with_default_evaluator_writes_intent_record():
         prepare_exploit_factory=_marker_factory("PrepExploit"),
         prepare_fix_factory=_marker_factory("PrepFix"),
         prepare_report_factory=_marker_factory("PrepReport"),
-        publish_factory=_marker_factory("Pub"),
+        draft_advisory_artifact_factory=_marker_factory("Draft"),
+        review_advisory_draft_factory=_marker_factory("Review"),
+        revise_advisory_draft_factory=_marker_factory("Revise"),
+        submit_advisory_artifact_factory=_marker_factory("Submit"),
     )
     # Guard: the Evaluator under test is the real default node, not a stub.
     assert isinstance(tree.children[0], PrioritizePublicationIntents)
@@ -282,16 +304,24 @@ def test_prepare_factories_used():
     assert tree.children[3].children[0].children[1].name == "CustomPrepReport"
 
 
-def test_publish_factory_used_in_every_arm():
-    """AC-5: the single publish_factory is applied to all three arms."""
+def test_publish_pipeline_factories_used_in_every_arm():
+    """AC-5 / Collapse 4: the four pipeline factories are applied to all arms."""
     tree = create_publication_tree(
         case_id=CASE_ID,
-        publish_factory=_marker_factory("CustomPublish"),
+        draft_advisory_artifact_factory=_marker_factory("CustomDraft"),
+        review_advisory_draft_factory=_marker_factory("CustomReview"),
+        revise_advisory_draft_factory=_marker_factory("CustomRevise"),
+        submit_advisory_artifact_factory=_marker_factory("CustomSubmit"),
     )
     for arm in tree.children[1:]:
-        do_seq = arm.children[0]
-        assert do_seq.children[2].name == "CustomPublish"
-        assert not isinstance(do_seq.children[2], Publish)
+        pipeline = arm.children[0].children[2]
+        assert pipeline.children[0].name == "CustomDraft"
+        assert pipeline.children[1].name == "CustomReview"
+        # pipeline.children[2] is RevisionArm; do_revise seq child[1] is revise node
+        do_revise = pipeline.children[2].children[0]
+        assert do_revise.children[1].name == "CustomRevise"
+        assert pipeline.children[3].name == "CustomSubmit"
+        assert not isinstance(pipeline.children[3], SubmitAdvisoryArtifact)
 
 
 # ---------------------------------------------------------------------------

--- a/test/core/behaviors/report/test_publication_tree_factory_injection.py
+++ b/test/core/behaviors/report/test_publication_tree_factory_injection.py
@@ -11,11 +11,12 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""End-to-end tick tests for create_publication_tree (Production Collapse 2).
+"""End-to-end tick tests for create_publication_tree (Production Collapses 2 + 4).
 
 Verifies that the intent record produced by the Evaluator actually gates which
-per-artifact arms perform Prepare→Publish work, and that a not-intended arm is
-a graceful SUCCESS no-op (ADR-0028 / BT-20-002, AC-4).
+per-artifact arms perform Prepare→Submit work, and that a not-intended arm is
+a graceful SUCCESS no-op (ADR-0028 / BT-20-002, AC-4).  The terminal publish
+leaf has been replaced by the draft-review-submit pipeline (ADR-0030 / BT-20-004).
 """
 
 import py_trees
@@ -51,7 +52,7 @@ class _RecordingPrepare(py_trees.behaviour.Behaviour):
         return Status.SUCCESS
 
 
-class _RecordingPublish(py_trees.behaviour.Behaviour):
+class _RecordingSubmit(py_trees.behaviour.Behaviour):
     """Actuator stand-in that records that it ran and always succeeds."""
 
     def __init__(self, name, ran):
@@ -90,6 +91,14 @@ def _tick_to_completion(tree):
     return bt.root.status
 
 
+def _always_succeed_factory(name):
+    class _AlwaysSucceed(py_trees.behaviour.Behaviour):
+        def update(self):
+            return Status.SUCCESS
+
+    return _AlwaysSucceed(name=name)
+
+
 def _build(decision, ran):
     return create_publication_tree(
         case_id=CASE_ID,
@@ -97,7 +106,10 @@ def _build(decision, ran):
         prepare_exploit_factory=lambda n: _RecordingPrepare(n, ran),
         prepare_fix_factory=lambda n: _RecordingPrepare(n, ran),
         prepare_report_factory=lambda n: _RecordingPrepare(n, ran),
-        publish_factory=lambda n: _RecordingPublish(n, ran),
+        draft_advisory_artifact_factory=lambda n: _always_succeed_factory(n),
+        review_advisory_draft_factory=lambda n: _always_succeed_factory(n),
+        revise_advisory_draft_factory=lambda n: _always_succeed_factory(n),
+        submit_advisory_artifact_factory=lambda n: _RecordingSubmit(n, ran),
     )
 
 
@@ -107,13 +119,20 @@ def test_default_intents_publish_fix_and_report_only():
     tree = _build(PublicationIntentDecision(), ran)
     assert _tick_to_completion(tree) == Status.SUCCESS
     assert "PrepareExploit" not in ran
-    assert "PublishExploit" not in ran
+    assert not any(
+        n.startswith("SubmitAdvisoryArtifact") and "Exploit" in n for n in ran
+    )
     assert {
         "PrepareFix",
-        "PublishFix",
         "PrepareReport",
-        "PublishReport",
     } <= ran
+    # The Submit nodes (not just Prepare) ran for the intended arms.
+    assert any(
+        n.startswith("SubmitAdvisoryArtifact") and "Fix" in n for n in ran
+    )
+    assert any(
+        n.startswith("SubmitAdvisoryArtifact") and "Report" in n for n in ran
+    )
 
 
 def test_all_intended_runs_every_arm():
@@ -128,12 +147,19 @@ def test_all_intended_runs_every_arm():
     assert _tick_to_completion(tree) == Status.SUCCESS
     assert {
         "PrepareExploit",
-        "PublishExploit",
         "PrepareFix",
-        "PublishFix",
         "PrepareReport",
-        "PublishReport",
     } <= ran
+    # All three submit nodes ran (names are e.g. "SubmitAdvisoryArtifact_Exploit")
+    assert any(
+        n.startswith("SubmitAdvisoryArtifact") and "Exploit" in n for n in ran
+    )
+    assert any(
+        n.startswith("SubmitAdvisoryArtifact") and "Fix" in n for n in ran
+    )
+    assert any(
+        n.startswith("SubmitAdvisoryArtifact") and "Report" in n for n in ran
+    )
 
 
 def test_none_intended_is_graceful_success_noop():
@@ -164,6 +190,9 @@ def test_prepare_failure_fails_intended_arm():
         ),
         prepare_fix_factory=lambda n: _FailingPrepare(name=n),
         prepare_report_factory=lambda n: _RecordingPrepare(n, ran),
-        publish_factory=lambda n: _RecordingPublish(n, ran),
+        draft_advisory_artifact_factory=lambda n: _always_succeed_factory(n),
+        review_advisory_draft_factory=lambda n: _always_succeed_factory(n),
+        revise_advisory_draft_factory=lambda n: _always_succeed_factory(n),
+        submit_advisory_artifact_factory=lambda n: _RecordingSubmit(n, ran),
     )
     assert _tick_to_completion(tree) == Status.FAILURE

--- a/test/core/behaviors/report/test_publish_artifact_tree.py
+++ b/test/core/behaviors/report/test_publish_artifact_tree.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Tests for the publish-artifact behavior tree (Production Collapse 4).
+
+Verifies ADR-0030 / BT-20-004:
+- AC-1: Single Publish leaf replaced by Composer→Evaluator→Composer(opt)→Actuator pipeline.
+- AC-2: _NeedsRevisionGate reads AdvisoryReviewDecision.needs_revision correctly.
+- AC-3: Default auto-approve path skips the optional revision arm.
+- AC-5: All four pipeline stages are independently injectable.
+"""
+
+import pytest
+import py_trees
+from py_trees.common import Access, Status
+
+from vultron.core.behaviors.report.publish_artifact_tree import (
+    DRAFT_ARTIFACT_KEY,
+    REVIEW_DECISION_KEY,
+    AdvisoryReviewDecision,
+    _NeedsRevisionGate,
+    create_publish_artifact_tree,
+)
+from vultron.demo.fuzzer.report_management.publication import (
+    DraftAdvisoryArtifact,
+    ReviewAdvisoryDraft,
+    ReviseAdvisoryDraft,
+    SubmitAdvisoryArtifact,
+)
+
+CASE_ID = "https://example.org/cases/test-001"
+
+
+@pytest.fixture(autouse=True)
+def clear_blackboard():
+    """Clear py_trees global blackboard state between tests."""
+    py_trees.blackboard.Blackboard.storage.clear()
+    yield
+    py_trees.blackboard.Blackboard.storage.clear()
+
+
+def _marker_factory(label):
+    def factory(name):
+        class _Marker(py_trees.behaviour.Behaviour):
+            def update(self):
+                return Status.SUCCESS
+
+        return _Marker(name=label)
+
+    return factory
+
+
+# ---------------------------------------------------------------------------
+# AdvisoryReviewDecision model
+# ---------------------------------------------------------------------------
+
+
+def test_review_decision_defaults():
+    """Defaults encode the auto-approve path: approved, no revision needed."""
+    d = AdvisoryReviewDecision()
+    assert d.approved is True
+    assert d.needs_revision is False
+    assert d.feedback == ""
+
+
+def test_review_decision_needs_revision():
+    d = AdvisoryReviewDecision(
+        approved=False, needs_revision=True, feedback="Fix title."
+    )
+    assert d.approved is False
+    assert d.needs_revision is True
+    assert d.feedback == "Fix title."
+
+
+# ---------------------------------------------------------------------------
+# _NeedsRevisionGate
+# ---------------------------------------------------------------------------
+
+
+def _write_review(decision):
+    bb = py_trees.blackboard.Client(name="test-writer")
+    bb.register_key(key=REVIEW_DECISION_KEY, access=Access.WRITE)
+    setattr(bb, REVIEW_DECISION_KEY, decision)
+
+
+def test_needs_revision_gate_true():
+    """Gate returns SUCCESS when needs_revision=True."""
+    _write_review(AdvisoryReviewDecision(needs_revision=True))
+    gate = _NeedsRevisionGate()
+    gate.setup()
+    assert gate.update() == Status.SUCCESS
+
+
+def test_needs_revision_gate_false():
+    """Gate returns FAILURE when needs_revision=False (auto-approve path)."""
+    _write_review(AdvisoryReviewDecision(needs_revision=False))
+    gate = _NeedsRevisionGate()
+    gate.setup()
+    assert gate.update() == Status.FAILURE
+
+
+def test_needs_revision_gate_missing_record_is_failure():
+    """Gate returns FAILURE when no review decision has been written."""
+    gate = _NeedsRevisionGate()
+    gate.setup()
+    assert gate.update() == Status.FAILURE
+
+
+@pytest.mark.parametrize(
+    "bad_value", ["needs_revision", {"needs_revision": True}, 42]
+)
+def test_needs_revision_gate_wrong_type_is_failure(bad_value):
+    """Gate returns FAILURE for a present-but-wrong-type value (contract violation)."""
+    bb = py_trees.blackboard.Client(name="bad-writer")
+    bb.register_key(key=REVIEW_DECISION_KEY, access=Access.WRITE)
+    setattr(bb, REVIEW_DECISION_KEY, bad_value)
+    gate = _NeedsRevisionGate()
+    gate.setup()
+    assert gate.update() == Status.FAILURE
+
+
+def test_needs_revision_gate_custom_name():
+    gate = _NeedsRevisionGate(name="CustomGate")
+    assert gate.name == "CustomGate"
+
+
+# ---------------------------------------------------------------------------
+# Tree structure
+# ---------------------------------------------------------------------------
+
+
+def test_create_tree_returns_behaviour():
+    tree = create_publish_artifact_tree(case_id=CASE_ID)
+    assert isinstance(tree, py_trees.behaviour.Behaviour)
+
+
+def test_create_tree_root_name_no_label():
+    tree = create_publish_artifact_tree(case_id=CASE_ID)
+    assert tree.name == "PublishArtifactBT"
+
+
+def test_create_tree_root_name_with_label():
+    tree = create_publish_artifact_tree(
+        case_id=CASE_ID, artifact_label="Exploit"
+    )
+    assert tree.name == "PublishArtifactBT_Exploit"
+
+
+def test_root_is_sequence():
+    tree = create_publish_artifact_tree(case_id=CASE_ID)
+    assert isinstance(tree, py_trees.composites.Sequence)
+
+
+def test_root_has_four_children():
+    """AC-1: pipeline has exactly 4 children: Draft, Review, RevisionArm, Submit."""
+    tree = create_publish_artifact_tree(case_id=CASE_ID)
+    assert len(tree.children) == 4
+
+
+def test_draft_is_first_child():
+    tree = create_publish_artifact_tree(case_id=CASE_ID)
+    assert isinstance(tree.children[0], DraftAdvisoryArtifact)
+
+
+def test_review_is_second_child():
+    tree = create_publish_artifact_tree(case_id=CASE_ID)
+    assert isinstance(tree.children[1], ReviewAdvisoryDraft)
+
+
+def test_revision_arm_is_third_child():
+    """AC-1: optional revision arm is a Selector (positive gate with Inverter skip)."""
+    tree = create_publish_artifact_tree(case_id=CASE_ID)
+    revision_arm = tree.children[2]
+    assert isinstance(revision_arm, py_trees.composites.Selector)
+    assert revision_arm.name.startswith("RevisionArm")
+    assert len(revision_arm.children) == 2
+    # First: DoRevise Sequence(NeedsRevisionGate, ReviseAdvisoryDraft)
+    do_revise = revision_arm.children[0]
+    assert isinstance(do_revise, py_trees.composites.Sequence)
+    assert len(do_revise.children) == 2
+    assert isinstance(do_revise.children[0], _NeedsRevisionGate)
+    assert isinstance(do_revise.children[1], ReviseAdvisoryDraft)
+    # Second: Inverter(NeedsRevisionGate) skip guard
+    assert isinstance(revision_arm.children[1], py_trees.decorators.Inverter)
+
+
+def test_submit_is_fourth_child():
+    tree = create_publish_artifact_tree(case_id=CASE_ID)
+    assert isinstance(tree.children[3], SubmitAdvisoryArtifact)
+
+
+def test_artifact_label_applied_to_all_node_names():
+    """artifact_label suffix appears in child node names."""
+    tree = create_publish_artifact_tree(case_id=CASE_ID, artifact_label="Fix")
+    assert tree.children[0].name == "DraftAdvisoryArtifact_Fix"
+    assert tree.children[1].name == "ReviewAdvisoryDraft_Fix"
+    assert tree.children[2].name == "RevisionArm_Fix"
+    assert tree.children[3].name == "SubmitAdvisoryArtifact_Fix"
+
+
+# ---------------------------------------------------------------------------
+# AC-5: factory injection
+# ---------------------------------------------------------------------------
+
+
+def test_draft_factory_used():
+    tree = create_publish_artifact_tree(
+        case_id=CASE_ID,
+        draft_advisory_artifact_factory=_marker_factory("CustomDraft"),
+    )
+    assert tree.children[0].name == "CustomDraft"
+    assert not isinstance(tree.children[0], DraftAdvisoryArtifact)
+
+
+def test_review_factory_used():
+    tree = create_publish_artifact_tree(
+        case_id=CASE_ID,
+        review_advisory_draft_factory=_marker_factory("CustomReview"),
+    )
+    assert tree.children[1].name == "CustomReview"
+    assert not isinstance(tree.children[1], ReviewAdvisoryDraft)
+
+
+def test_revise_factory_used():
+    tree = create_publish_artifact_tree(
+        case_id=CASE_ID,
+        revise_advisory_draft_factory=_marker_factory("CustomRevise"),
+    )
+    do_revise = tree.children[2].children[0]
+    assert do_revise.children[1].name == "CustomRevise"
+    assert not isinstance(do_revise.children[1], ReviseAdvisoryDraft)
+
+
+def test_submit_factory_used():
+    tree = create_publish_artifact_tree(
+        case_id=CASE_ID,
+        submit_advisory_artifact_factory=_marker_factory("CustomSubmit"),
+    )
+    assert tree.children[3].name == "CustomSubmit"
+    assert not isinstance(tree.children[3], SubmitAdvisoryArtifact)
+
+
+# ---------------------------------------------------------------------------
+# AC-3: auto-approve path skips revision (integration ticks)
+# ---------------------------------------------------------------------------
+
+
+class _WritingReview(py_trees.behaviour.Behaviour):
+    """Evaluator stub that writes a fixed AdvisoryReviewDecision."""
+
+    def __init__(self, name, decision):
+        super().__init__(name=name)
+        self._decision = decision
+
+    def setup(self, **kwargs):
+        self.blackboard = self.attach_blackboard_client(name=self.name)
+        self.blackboard.register_key(
+            key=REVIEW_DECISION_KEY, access=Access.WRITE
+        )
+
+    def update(self):
+        setattr(self.blackboard, REVIEW_DECISION_KEY, self._decision)
+        return Status.SUCCESS
+
+
+class _Recording(py_trees.behaviour.Behaviour):
+    def __init__(self, name, ran):
+        super().__init__(name=name)
+        self._ran = ran
+
+    def update(self):
+        self._ran.add(self.name)
+        return Status.SUCCESS
+
+
+def _tick_tree(tree):
+    bt = py_trees.trees.BehaviourTree(root=tree)
+    bt.setup()
+    for _ in range(10):
+        bt.tick()
+        if bt.root.status in (Status.SUCCESS, Status.FAILURE):
+            break
+    return bt.root.status
+
+
+def test_auto_approve_skips_revision_arm():
+    """AC-3: when the Evaluator sets needs_revision=False, revision does not run."""
+    ran: set[str] = set()
+    tree = create_publish_artifact_tree(
+        case_id=CASE_ID,
+        draft_advisory_artifact_factory=lambda n: _Recording(n, ran),
+        review_advisory_draft_factory=lambda n: _WritingReview(
+            n, AdvisoryReviewDecision(needs_revision=False)
+        ),
+        revise_advisory_draft_factory=lambda n: _Recording(n, ran),
+        submit_advisory_artifact_factory=lambda n: _Recording(n, ran),
+    )
+    status = _tick_tree(tree)
+    assert status == Status.SUCCESS
+    assert "DraftAdvisoryArtifact" in ran
+    assert "SubmitAdvisoryArtifact" in ran
+    assert "ReviseAdvisoryDraft" not in ran
+
+
+def test_needs_revision_runs_revision_arm():
+    """When the Evaluator sets needs_revision=True, revision runs before submit."""
+    ran: set[str] = set()
+    tree = create_publish_artifact_tree(
+        case_id=CASE_ID,
+        draft_advisory_artifact_factory=lambda n: _Recording(n, ran),
+        review_advisory_draft_factory=lambda n: _WritingReview(
+            n, AdvisoryReviewDecision(needs_revision=True)
+        ),
+        revise_advisory_draft_factory=lambda n: _Recording(n, ran),
+        submit_advisory_artifact_factory=lambda n: _Recording(n, ran),
+    )
+    status = _tick_tree(tree)
+    assert status == Status.SUCCESS
+    assert "DraftAdvisoryArtifact" in ran
+    assert "ReviseAdvisoryDraft" in ran
+    assert "SubmitAdvisoryArtifact" in ran
+
+
+def test_draft_failure_fails_pipeline():
+    """A Draft failure propagates to the root Sequence."""
+    ran: set[str] = set()
+
+    class _Fail(py_trees.behaviour.Behaviour):
+        def update(self):
+            return Status.FAILURE
+
+    tree = create_publish_artifact_tree(
+        case_id=CASE_ID,
+        draft_advisory_artifact_factory=lambda n: _Fail(name=n),
+        review_advisory_draft_factory=_marker_factory("Review"),
+        revise_advisory_draft_factory=_marker_factory("Revise"),
+        submit_advisory_artifact_factory=lambda n: _Recording(n, ran),
+    )
+    status = _tick_tree(tree)
+    assert status == Status.FAILURE
+    assert "SubmitAdvisoryArtifact" not in ran
+
+
+def test_review_failure_fails_pipeline():
+    """A Review failure propagates to the root Sequence."""
+    ran: set[str] = set()
+
+    class _Fail(py_trees.behaviour.Behaviour):
+        def update(self):
+            return Status.FAILURE
+
+    tree = create_publish_artifact_tree(
+        case_id=CASE_ID,
+        draft_advisory_artifact_factory=_marker_factory("Draft"),
+        review_advisory_draft_factory=lambda n: _Fail(name=n),
+        revise_advisory_draft_factory=_marker_factory("Revise"),
+        submit_advisory_artifact_factory=lambda n: _Recording(n, ran),
+    )
+    status = _tick_tree(tree)
+    assert status == Status.FAILURE
+    assert "SubmitAdvisoryArtifact" not in ran
+
+
+def test_revise_failure_fails_pipeline():
+    """When revision is required, a Revise failure propagates to root."""
+    ran: set[str] = set()
+
+    class _Fail(py_trees.behaviour.Behaviour):
+        def update(self):
+            return Status.FAILURE
+
+    tree = create_publish_artifact_tree(
+        case_id=CASE_ID,
+        draft_advisory_artifact_factory=_marker_factory("Draft"),
+        review_advisory_draft_factory=lambda n: _WritingReview(
+            n, AdvisoryReviewDecision(needs_revision=True)
+        ),
+        revise_advisory_draft_factory=lambda n: _Fail(name=n),
+        submit_advisory_artifact_factory=lambda n: _Recording(n, ran),
+    )
+    status = _tick_tree(tree)
+    assert status == Status.FAILURE
+    assert "SubmitAdvisoryArtifact" not in ran
+
+
+# ---------------------------------------------------------------------------
+# Blackboard contract: DraftAdvisoryArtifact writes DRAFT_ARTIFACT_KEY
+# ---------------------------------------------------------------------------
+
+
+def test_draft_artifact_key_is_declared():
+    """AC-1: DraftAdvisoryArtifact declares the draft_advisory_artifact output key."""
+    assert DRAFT_ARTIFACT_KEY in DraftAdvisoryArtifact.output_keys
+    assert DraftAdvisoryArtifact.output_keys[DRAFT_ARTIFACT_KEY] is str
+
+
+def test_review_decision_key_is_declared():
+    """AC-1: ReviewAdvisoryDraft declares the advisory_review_decision output key."""
+    assert REVIEW_DECISION_KEY in ReviewAdvisoryDraft.output_keys
+    assert (
+        ReviewAdvisoryDraft.output_keys[REVIEW_DECISION_KEY]
+        is AdvisoryReviewDecision
+    )

--- a/test/core/behaviors/report/test_publish_artifact_tree.py
+++ b/test/core/behaviors/report/test_publish_artifact_tree.py
@@ -191,7 +191,9 @@ def test_revision_arm_is_third_child():
     assert isinstance(do_revise.children[0], _NeedsRevisionGate)
     assert isinstance(do_revise.children[1], ReviseAdvisoryDraft)
     # Second: Inverter(NeedsRevisionGate) skip guard
-    assert isinstance(revision_arm.children[1], py_trees.decorators.Inverter)
+    skip_guard = revision_arm.children[1]
+    assert isinstance(skip_guard, py_trees.decorators.Inverter)
+    assert isinstance(skip_guard.children[0], _NeedsRevisionGate)
 
 
 def test_submit_is_fourth_child():
@@ -200,11 +202,17 @@ def test_submit_is_fourth_child():
 
 
 def test_artifact_label_applied_to_all_node_names():
-    """artifact_label suffix appears in child node names."""
+    """artifact_label suffix appears in all node names including internal revision arm nodes."""
     tree = create_publish_artifact_tree(case_id=CASE_ID, artifact_label="Fix")
     assert tree.children[0].name == "DraftAdvisoryArtifact_Fix"
     assert tree.children[1].name == "ReviewAdvisoryDraft_Fix"
-    assert tree.children[2].name == "RevisionArm_Fix"
+    revision_arm = tree.children[2]
+    assert revision_arm.name == "RevisionArm_Fix"
+    do_revise = revision_arm.children[0]
+    assert do_revise.name == "DoRevise_Fix"
+    assert do_revise.children[0].name == "NeedsRevision_Fix"
+    skip_guard = revision_arm.children[1]
+    assert skip_guard.children[0].name == "NeedsRevisionSkip_Fix"
     assert tree.children[3].name == "SubmitAdvisoryArtifact_Fix"
 
 
@@ -391,6 +399,24 @@ def test_revise_failure_fails_pipeline():
     status = _tick_tree(tree)
     assert status == Status.FAILURE
     assert "SubmitAdvisoryArtifact" not in ran
+
+
+def test_submit_failure_fails_pipeline():
+    """When Submit fails, the root Sequence returns FAILURE."""
+
+    class _Fail(py_trees.behaviour.Behaviour):
+        def update(self):
+            return Status.FAILURE
+
+    tree = create_publish_artifact_tree(
+        case_id=CASE_ID,
+        draft_advisory_artifact_factory=_marker_factory("Draft"),
+        review_advisory_draft_factory=_marker_factory("Review"),
+        revise_advisory_draft_factory=_marker_factory("Revise"),
+        submit_advisory_artifact_factory=lambda n: _Fail(name=n),
+    )
+    status = _tick_tree(tree)
+    assert status == Status.FAILURE
 
 
 # ---------------------------------------------------------------------------

--- a/test/demo/fuzzer/report_management/test_publication.py
+++ b/test/demo/fuzzer/report_management/test_publication.py
@@ -3,7 +3,11 @@
 import pytest
 import py_trees
 
-from vultron.demo.fuzzer.call_out_point import ComposerCallOutPoint
+from vultron.demo.fuzzer.call_out_point import (
+    ActuatorCallOutPoint,
+    ComposerCallOutPoint,
+    EvaluatorCallOutPoint,
+)
 from vultron.demo.fuzzer.base import (
     AlmostAlwaysFail,
     AlmostAlwaysSucceed,
@@ -14,6 +18,7 @@ from vultron.demo.fuzzer.base import (
 )
 from vultron.demo.fuzzer.report_management.publication import (
     AllPublished,
+    DraftAdvisoryArtifact,
     ExploitReady,
     NoPublishExploit,
     NoPublishFix,
@@ -27,6 +32,9 @@ from vultron.demo.fuzzer.report_management.publication import (
     ReprioritizeExploit,
     ReprioritizeFix,
     ReprioritizeReport,
+    ReviewAdvisoryDraft,
+    ReviseAdvisoryDraft,
+    SubmitAdvisoryArtifact,
 )
 
 _ALL_NODES = [
@@ -44,6 +52,11 @@ _ALL_NODES = [
     NoPublishReport,
     PrepareReport,
     ReprioritizeReport,
+    # Production Collapse 4 nodes (ADR-0030 / BT-20-004)
+    DraftAdvisoryArtifact,
+    ReviewAdvisoryDraft,
+    ReviseAdvisoryDraft,
+    SubmitAdvisoryArtifact,
 ]
 
 
@@ -258,3 +271,98 @@ def test_prepare_report_success_rate():
 
 def test_reprioritize_report_success_rate():
     assert ReprioritizeReport.success_rate == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Production Collapse 4 nodes (ADR-0030 / BT-20-004)
+# ---------------------------------------------------------------------------
+
+
+def test_draft_advisory_artifact_is_composer():
+    assert issubclass(DraftAdvisoryArtifact, ComposerCallOutPoint)
+
+
+def test_draft_advisory_artifact_base_type():
+    assert issubclass(DraftAdvisoryArtifact, AlmostAlwaysSucceed)
+
+
+def test_draft_advisory_artifact_success_rate():
+    assert DraftAdvisoryArtifact.success_rate == pytest.approx(0.90)
+
+
+def test_draft_advisory_artifact_output_key_declared():
+    from vultron.core.behaviors.report.publish_artifact_tree import (
+        DRAFT_ARTIFACT_KEY,
+    )
+
+    assert DRAFT_ARTIFACT_KEY in DraftAdvisoryArtifact.output_keys
+
+
+def test_draft_advisory_artifact_output_key_type_is_str():
+    from vultron.core.behaviors.report.publish_artifact_tree import (
+        DRAFT_ARTIFACT_KEY,
+    )
+
+    assert DraftAdvisoryArtifact.output_keys[DRAFT_ARTIFACT_KEY] is str
+
+
+def test_review_advisory_draft_is_evaluator():
+    assert issubclass(ReviewAdvisoryDraft, EvaluatorCallOutPoint)
+
+
+def test_review_advisory_draft_base_type():
+    assert issubclass(ReviewAdvisoryDraft, AlwaysSucceed)
+
+
+def test_review_advisory_draft_success_rate():
+    assert ReviewAdvisoryDraft.success_rate == pytest.approx(1.0)
+
+
+def test_review_advisory_draft_output_key_declared():
+    from vultron.core.behaviors.report.publish_artifact_tree import (
+        REVIEW_DECISION_KEY,
+        AdvisoryReviewDecision,
+    )
+
+    assert REVIEW_DECISION_KEY in ReviewAdvisoryDraft.output_keys
+    assert (
+        ReviewAdvisoryDraft.output_keys[REVIEW_DECISION_KEY]
+        is AdvisoryReviewDecision
+    )
+
+
+def test_revise_advisory_draft_is_composer():
+    assert issubclass(ReviseAdvisoryDraft, ComposerCallOutPoint)
+
+
+def test_revise_advisory_draft_base_type():
+    assert issubclass(ReviseAdvisoryDraft, AlmostAlwaysSucceed)
+
+
+def test_revise_advisory_draft_success_rate():
+    assert ReviseAdvisoryDraft.success_rate == pytest.approx(0.90)
+
+
+def test_revise_advisory_draft_output_key_declared():
+    from vultron.core.behaviors.report.publish_artifact_tree import (
+        DRAFT_ARTIFACT_KEY,
+    )
+
+    assert DRAFT_ARTIFACT_KEY in ReviseAdvisoryDraft.output_keys
+
+
+def test_submit_advisory_artifact_is_actuator():
+    assert issubclass(SubmitAdvisoryArtifact, ActuatorCallOutPoint)
+
+
+def test_submit_advisory_artifact_base_type():
+    assert issubclass(SubmitAdvisoryArtifact, AlmostAlwaysSucceed)
+
+
+def test_submit_advisory_artifact_success_rate():
+    assert SubmitAdvisoryArtifact.success_rate == pytest.approx(0.90)
+
+
+def test_submit_advisory_artifact_no_output_keys():
+    """Actuator is a side-effect node — it declares no output keys."""
+    assert SubmitAdvisoryArtifact.output_keys == {}

--- a/vultron/core/behaviors/report/publication_tree.py
+++ b/vultron/core/behaviors/report/publication_tree.py
@@ -11,10 +11,13 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Collapsed publication behavior tree (Production Collapse 2).
+"""Collapsed publication behavior tree (Production Collapse 2 + 4).
 
-Implements ADR-0028 / BT-20-002.  Replaces the twelve simulator publication
-nodes (``PublicationIntentsSet``, ``PrioritizePublicationIntents``,
+Implements ADR-0028 / BT-20-002 (Production Collapse 2) and ADR-0030 /
+BT-20-004 (Production Collapse 4).
+
+Production Collapse 2 replaces the twelve simulator publication nodes
+(``PublicationIntentsSet``, ``PrioritizePublicationIntents``,
 ``NoPublishExploit``, ``ExploitReady``, ``PrepareExploit``,
 ``ReprioritizeExploit``, ``NoPublishFix``, ``PrepareFix``, ``ReprioritizeFix``,
 ``NoPublishReport``, ``PrepareReport``, ``ReprioritizeReport``) with a single
@@ -25,7 +28,7 @@ Evaluator that drives three named per-artifact arms:
 2. Three named per-artifact arms (exploit, fix, report).  Each arm is gated by
    a ``ShouldPublish*`` condition that reads the intent record; when the
    artifact is intended, the arm runs its ``Prepare*`` Composer followed by the
-   ``Publish`` Actuator, otherwise the arm is a graceful no-op.
+   publish pipeline, otherwise the arm is a graceful no-op.
 
 The ``PublicationIntentsSet`` flag check and the ``NoPublish*`` bypass leaves
 are eliminated — they were ProtocolInternal structural artifacts of the
@@ -36,19 +39,22 @@ single source of truth for which arms execute.
 Arm shape (positive-condition gate with Inverter skip, per BTND-08-001)::
 
     ExploitPublicationArm (Selector)
-    ├── Sequence(ShouldPublishExploit, PrepareExploit, Publish)
+    ├── Sequence(ShouldPublishExploit, PrepareExploit, PublishArtifactBT)
     └── Inverter(ShouldPublishExploit)   # SUCCESS no-op when not intended
 
-The ``Publish`` Actuator is kept as a single leaf per arm here; expanding it
-into a draft-review-submit pipeline is tracked separately by ADR-0030 /
-BT-20-004 (Production Collapse 4).
+Production Collapse 4 expands the single ``Publish`` Actuator in each arm
+into the draft-review-submit pipeline from
+:func:`~vultron.core.behaviors.report.publish_artifact_tree.create_publish_artifact_tree`
+(ADR-0030 / BT-20-004).  The per-arm ``Prepare*`` Composer still runs first;
+the publish pipeline follows it inside the same Sequence.
 
 References
 ----------
 - ADR-0028: ``docs/adr/0028-publication-intent-bt-collapse.md``
-- Spec: ``specs/behavior-tree-integration.yaml`` BT-20-002
+- ADR-0030: ``docs/adr/0030-publish-leaf-draft-review-submit-pipeline.md``
+- Spec: ``specs/behavior-tree-integration.yaml`` BT-20-002, BT-20-004
 - Notes: ``notes/bt-fuzzer-nodes-report-management.md``
-  § "Production Collapse 2: Publication-intent subtree → Evaluator + per-artifact arms"
+  § "Production Collapse 2" and "Production Collapse 4"
 - Precedent: ``vultron.core.behaviors.report.acquire_exploit_strategy_tree``
   (Production Collapse 1, ADR-0027)
 """
@@ -63,6 +69,13 @@ from py_trees.common import Access, Status
 from pydantic import BaseModel
 
 from vultron.core.behaviors.call_out_point import CallOutBackendFactory
+from vultron.core.behaviors.report.publish_artifact_tree import (
+    _default_draft_advisory_artifact_factory,
+    _default_review_advisory_draft_factory,
+    _default_revise_advisory_draft_factory,
+    _default_submit_advisory_artifact_factory,
+    create_publish_artifact_tree,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -233,33 +246,29 @@ def _default_prepare_report_factory(name: str) -> py_trees.behaviour.Behaviour:
     return PrepareReport(name)
 
 
-def _default_publish_factory(name: str) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.report_management.publication import Publish
-
-    return Publish(name)
-
-
 def _make_artifact_arm(
+    case_id: str,
     arm_name: str,
+    artifact_label: str,
     gate_cls: type[_ShouldPublishArtifactGate],
     prepare_factory: CallOutBackendFactory,
     prepare_node_name: str,
-    publish_factory: CallOutBackendFactory,
-    publish_node_name: str,
+    draft_advisory_artifact_factory: CallOutBackendFactory,
+    review_advisory_draft_factory: CallOutBackendFactory,
+    revise_advisory_draft_factory: CallOutBackendFactory,
+    submit_advisory_artifact_factory: CallOutBackendFactory,
 ) -> py_trees.behaviour.Behaviour:
     """Build one intent-gated per-artifact publication arm.
 
     Shape (positive-condition gate with Inverter skip, per BTND-08-001)::
 
         Selector(arm_name)
-        ├── Sequence(gate, Prepare, Publish)
+        ├── Sequence(gate, Prepare, PublishArtifactBT)
         └── Inverter(gate)   # SUCCESS no-op when the artifact is not intended
 
-    When the artifact IS intended, the Sequence runs; a genuine Prepare/Publish
-    failure fails the Sequence, the Inverter (gate is SUCCESS → FAILURE) also
-    fails, and the FAILURE propagates to the parent ``PublicationBT``.  When the
-    artifact is NOT intended, the Sequence short-circuits and the Inverter
-    (gate is FAILURE → SUCCESS) turns the arm into a graceful no-op.
+    The ``PublishArtifactBT`` subtree is the draft-review-submit pipeline from
+    :func:`~vultron.core.behaviors.report.publish_artifact_tree.create_publish_artifact_tree`
+    (Production Collapse 4, ADR-0030 / BT-20-004).
     """
     do_publish = py_trees.composites.Sequence(
         name=f"Do{arm_name}",
@@ -267,7 +276,14 @@ def _make_artifact_arm(
         children=[
             gate_cls(),
             prepare_factory(prepare_node_name),
-            publish_factory(publish_node_name),
+            create_publish_artifact_tree(
+                case_id=case_id,
+                artifact_label=artifact_label,
+                draft_advisory_artifact_factory=draft_advisory_artifact_factory,
+                review_advisory_draft_factory=review_advisory_draft_factory,
+                revise_advisory_draft_factory=revise_advisory_draft_factory,
+                submit_advisory_artifact_factory=submit_advisory_artifact_factory,
+            ),
         ],
     )
     skip_if_not_intended = py_trees.decorators.Inverter(
@@ -287,23 +303,35 @@ def create_publication_tree(
     prepare_exploit_factory: CallOutBackendFactory = _default_prepare_exploit_factory,
     prepare_fix_factory: CallOutBackendFactory = _default_prepare_fix_factory,
     prepare_report_factory: CallOutBackendFactory = _default_prepare_report_factory,
-    publish_factory: CallOutBackendFactory = _default_publish_factory,
+    draft_advisory_artifact_factory: CallOutBackendFactory = _default_draft_advisory_artifact_factory,
+    review_advisory_draft_factory: CallOutBackendFactory = _default_review_advisory_draft_factory,
+    revise_advisory_draft_factory: CallOutBackendFactory = _default_revise_advisory_draft_factory,
+    submit_advisory_artifact_factory: CallOutBackendFactory = _default_submit_advisory_artifact_factory,
 ) -> py_trees.behaviour.Behaviour:
-    """Create the collapsed publication behavior tree (Production Collapse 2).
+    """Create the collapsed publication behavior tree (Production Collapses 2 + 4).
 
-    Implements ADR-0028 / BT-20-002: a single ``PrioritizePublicationIntents``
-    Evaluator writes a :class:`PublicationIntentDecision` record whose boolean
-    fields gate three named per-artifact arms (exploit, fix, report).  The
-    ``PublicationIntentsSet`` flag check, the ``NoPublish*`` bypass leaves, and
-    the ``ReprioritizeX`` Evaluators are eliminated.
+    Implements ADR-0028 / BT-20-002 (Production Collapse 2) and ADR-0030 /
+    BT-20-004 (Production Collapse 4).
+
+    A single ``PrioritizePublicationIntents`` Evaluator writes a
+    :class:`PublicationIntentDecision` record whose boolean fields gate three
+    named per-artifact arms (exploit, fix, report).  Each arm runs a
+    ``Prepare*`` Composer followed by the draft-review-submit pipeline from
+    :func:`~vultron.core.behaviors.report.publish_artifact_tree.create_publish_artifact_tree`.
 
     Tree structure::
 
         PublicationBT (Sequence)
         ├── PrioritizePublicationIntents (Evaluator → writes intent record)
         ├── ExploitPublicationArm (Selector, gated on publish_exploit)
+        │   ├── Sequence(ShouldPublishExploit, PrepareExploit, PublishArtifactBT_Exploit)
+        │   └── Inverter(ShouldPublishExploit)
         ├── FixPublicationArm (Selector, gated on publish_fix)
+        │   ├── Sequence(ShouldPublishFix, PrepareFix, PublishArtifactBT_Fix)
+        │   └── Inverter(ShouldPublishFix)
         └── ReportPublicationArm (Selector, gated on publish_report)
+            ├── Sequence(ShouldPublishReport, PrepareReport, PublishArtifactBT_Report)
+            └── Inverter(ShouldPublishReport)
 
     Args:
         case_id: ID of the VulnerabilityCase to publish for.
@@ -318,11 +346,18 @@ def create_publication_tree(
         prepare_report_factory: Factory for the Composer call-out point that
             authors and stages the vulnerability advisory artifact.  Defaults to
             the fuzzer backend.
-        publish_factory: Factory for the Actuator call-out point that submits a
-            prepared artifact to the external advisory platform.  Called once
-            per arm; defaults to the fuzzer backend.  Expanding this single
-            Actuator into a draft-review-submit pipeline is tracked by ADR-0030
-            / BT-20-004.
+        draft_advisory_artifact_factory: Factory for the Composer that drafts
+            the advisory artifact in the publish pipeline.  Shared across all
+            three per-artifact arms.  Defaults to the fuzzer backend.
+        review_advisory_draft_factory: Factory for the Evaluator that reviews
+            and approves the draft.  Defaults to the auto-approve fuzzer
+            backend (AC-3, ADR-0030).
+        revise_advisory_draft_factory: Factory for the optional Composer that
+            revises the draft based on review feedback.  Defaults to the fuzzer
+            backend.
+        submit_advisory_artifact_factory: Factory for the Actuator that submits
+            the finalized artifact to the external advisory platform.  Defaults
+            to the fuzzer backend.
 
     Returns:
         Root Sequence node of the collapsed publication behavior tree.
@@ -335,32 +370,45 @@ def create_publication_tree(
                 "PrioritizePublicationIntents"
             ),
             _make_artifact_arm(
+                case_id=case_id,
                 arm_name="ExploitPublicationArm",
+                artifact_label="Exploit",
                 gate_cls=ShouldPublishExploit,
                 prepare_factory=prepare_exploit_factory,
                 prepare_node_name="PrepareExploit",
-                publish_factory=publish_factory,
-                publish_node_name="PublishExploit",
+                draft_advisory_artifact_factory=draft_advisory_artifact_factory,
+                review_advisory_draft_factory=review_advisory_draft_factory,
+                revise_advisory_draft_factory=revise_advisory_draft_factory,
+                submit_advisory_artifact_factory=submit_advisory_artifact_factory,
             ),
             _make_artifact_arm(
+                case_id=case_id,
                 arm_name="FixPublicationArm",
+                artifact_label="Fix",
                 gate_cls=ShouldPublishFix,
                 prepare_factory=prepare_fix_factory,
                 prepare_node_name="PrepareFix",
-                publish_factory=publish_factory,
-                publish_node_name="PublishFix",
+                draft_advisory_artifact_factory=draft_advisory_artifact_factory,
+                review_advisory_draft_factory=review_advisory_draft_factory,
+                revise_advisory_draft_factory=revise_advisory_draft_factory,
+                submit_advisory_artifact_factory=submit_advisory_artifact_factory,
             ),
             _make_artifact_arm(
+                case_id=case_id,
                 arm_name="ReportPublicationArm",
+                artifact_label="Report",
                 gate_cls=ShouldPublishReport,
                 prepare_factory=prepare_report_factory,
                 prepare_node_name="PrepareReport",
-                publish_factory=publish_factory,
-                publish_node_name="PublishReport",
+                draft_advisory_artifact_factory=draft_advisory_artifact_factory,
+                review_advisory_draft_factory=review_advisory_draft_factory,
+                revise_advisory_draft_factory=revise_advisory_draft_factory,
+                submit_advisory_artifact_factory=submit_advisory_artifact_factory,
             ),
         ],
     )
     logger.info(
-        f"Created PublicationBT (Production Collapse 2) for case={case_id}"
+        "Created PublicationBT (Production Collapses 2+4) for case=%s",
+        case_id,
     )
     return root

--- a/vultron/core/behaviors/report/publish_artifact_tree.py
+++ b/vultron/core/behaviors/report/publish_artifact_tree.py
@@ -185,6 +185,8 @@ class _NeedsRevisionGate(py_trees.behaviour.Behaviour):
 def _default_draft_advisory_artifact_factory(
     name: str,
 ) -> py_trees.behaviour.Behaviour:
+    # Deferred import: demo/publication.py imports AdvisoryReviewDecision from
+    # this module at module level, creating a circular dependency.
     from vultron.demo.fuzzer.report_management.publication import (
         DraftAdvisoryArtifact,
     )
@@ -195,6 +197,8 @@ def _default_draft_advisory_artifact_factory(
 def _default_review_advisory_draft_factory(
     name: str,
 ) -> py_trees.behaviour.Behaviour:
+    # Deferred import: avoids circular dependency — demo/publication.py imports
+    # AdvisoryReviewDecision from this module at module level.
     from vultron.demo.fuzzer.report_management.publication import (
         ReviewAdvisoryDraft,
     )
@@ -205,6 +209,8 @@ def _default_review_advisory_draft_factory(
 def _default_revise_advisory_draft_factory(
     name: str,
 ) -> py_trees.behaviour.Behaviour:
+    # Deferred import: avoids circular dependency — demo/publication.py imports
+    # AdvisoryReviewDecision from this module at module level.
     from vultron.demo.fuzzer.report_management.publication import (
         ReviseAdvisoryDraft,
     )
@@ -215,6 +221,8 @@ def _default_revise_advisory_draft_factory(
 def _default_submit_advisory_artifact_factory(
     name: str,
 ) -> py_trees.behaviour.Behaviour:
+    # Deferred import: avoids circular dependency — demo/publication.py imports
+    # AdvisoryReviewDecision from this module at module level.
     from vultron.demo.fuzzer.report_management.publication import (
         SubmitAdvisoryArtifact,
     )

--- a/vultron/core/behaviors/report/publish_artifact_tree.py
+++ b/vultron/core/behaviors/report/publish_artifact_tree.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Publish artifact behavior tree (Production Collapse 4).
+
+Implements ADR-0030 / BT-20-004.  Replaces the single ``Publish`` Actuator
+leaf used in each per-artifact arm of :func:`~vultron.core.behaviors.report.
+publication_tree.create_publication_tree` with a multi-step pipeline:
+
+1. ``DraftAdvisoryArtifact`` (Composer) — draft the advisory artifact from
+   case data (CSAF/CVE JSON/advisory text).
+2. ``ReviewAdvisoryDraft`` (Evaluator) — review and approve the draft.
+3. ``ReviseAdvisoryDraft`` (Composer, optional) — revise the draft based on
+   review feedback (optional arm; skipped when the Evaluator approves
+   without requesting changes).
+4. ``SubmitAdvisoryArtifact`` (Actuator) — submit the finalized artifact to
+   the external advisory platform.
+
+Open design question (AC-4): whether the review phase should include a
+broadcast-for-participant-comment step has been resolved at this implementation
+by **deferring** it to a follow-on issue.  The broadcast would involve emitting
+an outbound Activity (a protocol-visible action); that scope is out of bounds
+for this task.  The pipeline functions without it — the Evaluator review step
+has a default auto-approve implementation (``AlwaysSucceed``) so the tree
+operates correctly before a real review agent is available (AC-3).
+
+Tree structure per artifact::
+
+    PublishArtifactBT (Sequence)
+    ├── DraftAdvisoryArtifact (Composer)       — writes draft_advisory_artifact key
+    ├── ReviewAdvisoryDraft   (Evaluator)      — writes advisory_review_decision key
+    ├── RevisionArm           (Selector)       — optional revision; graceful no-op
+    │   ├── Sequence(NeedsRevision, ReviseAdvisoryDraft)
+    │   └── Inverter(NeedsRevision)
+    └── SubmitAdvisoryArtifact (Actuator)      — submits to advisory platform
+
+The ``NeedsRevision`` condition reads the ``AdvisoryReviewDecision.needs_revision``
+boolean written by the Evaluator.  When the Evaluator sets
+``needs_revision=False`` (the default auto-approve path), the revision arm is
+a graceful ``Inverter(NeedsRevision)`` no-op.  When ``needs_revision=True`` the
+revision Composer runs.
+
+References
+----------
+- ADR-0030: ``docs/adr/0030-publish-leaf-draft-review-submit-pipeline.md``
+- Spec: ``specs/behavior-tree-integration.yaml`` BT-20-004
+- Notes: ``notes/bt-fuzzer-nodes-report-management.md``
+  § "Production Collapse 4: Publish leaf → draft-review-submit pipeline"
+- Precedent: ``vultron.core.behaviors.report.publication_tree``
+  (Production Collapse 2, ADR-0028)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import py_trees
+from py_trees.common import Access, Status
+from pydantic import BaseModel
+
+from vultron.core.behaviors.call_out_point import CallOutBackendFactory
+
+logger = logging.getLogger(__name__)
+
+#: Blackboard key written by ``DraftAdvisoryArtifact`` Composer on SUCCESS.
+DRAFT_ARTIFACT_KEY = "draft_advisory_artifact"
+
+#: Blackboard key written by ``ReviewAdvisoryDraft`` Evaluator on SUCCESS.
+REVIEW_DECISION_KEY = "advisory_review_decision"
+
+
+class AdvisoryReviewDecision(BaseModel):
+    """Structured output record for the ReviewAdvisoryDraft call-out point.
+
+    Written to the blackboard key :data:`REVIEW_DECISION_KEY` by the
+    ``ReviewAdvisoryDraft`` Evaluator node on SUCCESS (BT-18-001).
+
+    The ``needs_revision`` field drives the optional revision arm: when
+    ``True``, the ``ReviseAdvisoryDraft`` Composer runs before
+    ``SubmitAdvisoryArtifact``; when ``False`` (the default auto-approve
+    path), the revision arm is a graceful no-op and the pipeline proceeds
+    directly to submission.
+
+    The ``approved`` field is metadata for the ``ReviewAdvisoryDraft``
+    backend to record its decision.  The pipeline does not gate submission on
+    it — a backend that needs to block submission without requesting edits
+    (e.g. a legal hold) MUST return ``Status.FAILURE`` from ``update()`` so
+    the Sequence fails.  Gating submission on ``approved=False`` is tracked
+    as a follow-on design question (see AC-4 in issue #1312).
+
+    The default instance (``approved=True``, ``needs_revision=False``) encodes
+    the auto-approve path used when no real review agent is available (AC-3).
+
+    Attributes:
+        approved: Informational flag indicating the Evaluator's approval
+            decision.  Not read by the pipeline tree.
+        needs_revision: Whether the draft requires revision before submission.
+            When ``True``, the optional ``ReviseAdvisoryDraft`` Composer runs.
+        feedback: Human-readable or machine-generated review feedback.
+    """
+
+    approved: bool = True
+    needs_revision: bool = False
+    feedback: str = ""
+
+
+class _NeedsRevisionGate(py_trees.behaviour.Behaviour):
+    """ProtocolInternal gate: read the review decision and check needs_revision.
+
+    Reads the :class:`AdvisoryReviewDecision` written to :data:`REVIEW_DECISION_KEY`
+    by ``ReviewAdvisoryDraft`` and returns SUCCESS when ``needs_revision`` is
+    True, FAILURE otherwise (including when no decision has been recorded).
+
+    Used as the gate in the optional revision arm so that the arm is a graceful
+    no-op when the Evaluator approves without requesting changes (BTND-08-001).
+    """
+
+    logger: logging.Logger  # type: ignore[assignment]
+
+    def __init__(self, name: str | None = None) -> None:
+        super().__init__(name=name or self.__class__.__name__)
+        self.logger = logging.getLogger(  # type: ignore[assignment]
+            f"{self.__class__.__module__}.{self.__class__.__name__}"
+        )
+
+    def setup(self, **kwargs: Any) -> None:
+        """Register READ access to the shared review-decision blackboard key."""
+        self.blackboard = self.attach_blackboard_client(name=self.name)
+        self.blackboard.register_key(
+            key=REVIEW_DECISION_KEY, access=Access.READ
+        )
+
+    def update(self) -> Status:
+        """Return SUCCESS when the review decision requests revision.
+
+        Returns:
+            SUCCESS when the decision record's ``needs_revision`` field is
+            truthy; FAILURE when it is falsy or when no decision has been
+            written (i.e., the auto-approve path, which skips revision).
+        """
+        if not self.blackboard.exists(REVIEW_DECISION_KEY):
+            self.logger.debug(
+                "%s: no %s on blackboard — skipping revision",
+                self.name,
+                REVIEW_DECISION_KEY,
+            )
+            return Status.FAILURE
+
+        decision = self.blackboard.get(REVIEW_DECISION_KEY)
+        if not isinstance(decision, AdvisoryReviewDecision):
+            self.logger.warning(
+                "%s: %s holds %s, not an AdvisoryReviewDecision — "
+                "skipping revision",
+                self.name,
+                REVIEW_DECISION_KEY,
+                type(decision).__name__,
+            )
+            return Status.FAILURE
+
+        if decision.needs_revision:
+            self.logger.debug(
+                "%s: review requests revision — running revision arm",
+                self.name,
+            )
+            return Status.SUCCESS
+
+        self.logger.debug(
+            "%s: review approved without revision — skipping revision arm",
+            self.name,
+        )
+        return Status.FAILURE
+
+
+def _default_draft_advisory_artifact_factory(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.publication import (
+        DraftAdvisoryArtifact,
+    )
+
+    return DraftAdvisoryArtifact(name)
+
+
+def _default_review_advisory_draft_factory(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.publication import (
+        ReviewAdvisoryDraft,
+    )
+
+    return ReviewAdvisoryDraft(name)
+
+
+def _default_revise_advisory_draft_factory(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.publication import (
+        ReviseAdvisoryDraft,
+    )
+
+    return ReviseAdvisoryDraft(name)
+
+
+def _default_submit_advisory_artifact_factory(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.publication import (
+        SubmitAdvisoryArtifact,
+    )
+
+    return SubmitAdvisoryArtifact(name)
+
+
+def create_publish_artifact_tree(
+    case_id: str,
+    artifact_label: str = "",
+    draft_advisory_artifact_factory: CallOutBackendFactory = _default_draft_advisory_artifact_factory,
+    review_advisory_draft_factory: CallOutBackendFactory = _default_review_advisory_draft_factory,
+    revise_advisory_draft_factory: CallOutBackendFactory = _default_revise_advisory_draft_factory,
+    submit_advisory_artifact_factory: CallOutBackendFactory = _default_submit_advisory_artifact_factory,
+) -> py_trees.behaviour.Behaviour:
+    """Create the publish-artifact pipeline (Production Collapse 4).
+
+    Replaces the single ``Publish`` Actuator leaf in each per-artifact arm of
+    :func:`~vultron.core.behaviors.report.publication_tree.create_publication_tree`
+    with a four-step pipeline per ADR-0030 / BT-20-004.
+
+    Tree structure::
+
+        PublishArtifactBT (Sequence)
+        ├── DraftAdvisoryArtifact (Composer)
+        ├── ReviewAdvisoryDraft   (Evaluator)
+        ├── RevisionArm           (Selector — optional; no-op when approved)
+        │   ├── Sequence(NeedsRevision, ReviseAdvisoryDraft)
+        │   └── Inverter(NeedsRevision)
+        └── SubmitAdvisoryArtifact (Actuator)
+
+    The open design question from ADR-0030 (participant-comment broadcast
+    in the review phase) is deferred — see AC-4 in issue #1312.
+
+    Args:
+        case_id: ID of the VulnerabilityCase being published.
+        artifact_label: Short label suffix for node names (e.g. "Exploit",
+            "Fix", "Report"); used to distinguish per-arm pipeline instances
+            in the py_trees display tree.  Optional — defaults to empty string.
+        draft_advisory_artifact_factory: Factory for the Composer call-out
+            point that drafts the advisory artifact from case data.  Defaults
+            to the fuzzer backend (ADR-0025).
+        review_advisory_draft_factory: Factory for the Evaluator call-out
+            point that reviews and approves the draft.  The default
+            auto-approve fuzzer implementation allows the pipeline to function
+            before a real review agent is available (AC-3, ADR-0030).
+        revise_advisory_draft_factory: Factory for the optional Composer
+            call-out point that revises the draft based on review feedback.
+            Runs only when the Evaluator sets ``needs_revision=True``.
+            Defaults to the fuzzer backend.
+        submit_advisory_artifact_factory: Factory for the Actuator call-out
+            point that submits the finalized artifact to the external advisory
+            platform.  Defaults to the fuzzer backend.
+
+    Returns:
+        Root Sequence node of the publish-artifact pipeline.
+    """
+    suffix = f"_{artifact_label}" if artifact_label else ""
+
+    needs_revision_do = py_trees.composites.Sequence(
+        name=f"DoRevise{suffix}",
+        memory=False,
+        children=[
+            _NeedsRevisionGate(name=f"NeedsRevision{suffix}"),
+            revise_advisory_draft_factory(f"ReviseAdvisoryDraft{suffix}"),
+        ],
+    )
+    needs_revision_skip = py_trees.decorators.Inverter(
+        name=f"SkipRevisionIfApproved{suffix}",
+        child=_NeedsRevisionGate(name=f"NeedsRevisionSkip{suffix}"),
+    )
+    revision_arm = py_trees.composites.Selector(
+        name=f"RevisionArm{suffix}",
+        memory=False,
+        children=[needs_revision_do, needs_revision_skip],
+    )
+
+    root = py_trees.composites.Sequence(
+        name=f"PublishArtifactBT{suffix}",
+        memory=False,
+        children=[
+            draft_advisory_artifact_factory(f"DraftAdvisoryArtifact{suffix}"),
+            review_advisory_draft_factory(f"ReviewAdvisoryDraft{suffix}"),
+            revision_arm,
+            submit_advisory_artifact_factory(
+                f"SubmitAdvisoryArtifact{suffix}"
+            ),
+        ],
+    )
+    logger.info(
+        "Created PublishArtifactBT%s (Production Collapse 4) for case=%s",
+        suffix,
+        case_id,
+    )
+    return root

--- a/vultron/demo/fuzzer/report_management/publication.py
+++ b/vultron/demo/fuzzer/report_management/publication.py
@@ -44,6 +44,9 @@ References
 
 from __future__ import annotations
 
+from vultron.core.behaviors.report.publish_artifact_tree import (
+    AdvisoryReviewDecision,
+)
 from vultron.core.behaviors.report.publication_tree import (
     PublicationIntentDecision,
 )
@@ -389,3 +392,115 @@ class ReprioritizeReport(EvaluatorCallOutPoint, AlwaysSucceed):
     """
 
     output_keys = {"reprioritize_report_verdict": str}
+
+
+# ---------------------------------------------------------------------------
+# Production Collapse 4 (ADR-0030 / BT-20-004): Publish leaf pipeline nodes
+# ---------------------------------------------------------------------------
+
+
+class DraftAdvisoryArtifact(ComposerCallOutPoint, AlmostAlwaysSucceed):
+    """Draft the advisory artifact from case data.
+
+    Semantic function:
+        Action — generate a draft advisory artifact (CSAF JSON, CVE record,
+        advisory text, or equivalent) from case data.  In production this
+        would involve a templating engine or LLM-driven composition step
+        that pulls vulnerability details, fix information, and affected
+        product data from the case record.  The fuzzer succeeds almost
+        always, allowing the rest of the pipeline to be exercised.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — reads case context from caller's DataLayer)
+      Output keys: draft_advisory_artifact: str  (SUCCESS only)
+
+    Input category: System integration / Composer.
+
+    Success probability: 0.90 (``AlmostAlwaysSucceed``).
+
+    Automation potential: **Medium–High** — structured artifact generation
+    from well-formed case data (CSAF templates, CVE JSON schema) is
+    automatable; narrative advisory text may benefit from human review.
+    """
+
+    output_keys = {"draft_advisory_artifact": str}
+
+
+class ReviewAdvisoryDraft(EvaluatorCallOutPoint, AlwaysSucceed):
+    """Review and approve the advisory draft.
+
+    Semantic function:
+        Action — review the drafted advisory artifact and produce an
+        :class:`~vultron.core.behaviors.report.publish_artifact_tree.
+        AdvisoryReviewDecision` record indicating approval status and
+        whether revision is required.  The default fuzzer implementation
+        always approves (``needs_revision=False``) so the pipeline
+        functions end-to-end before a real review agent is available
+        (AC-3, ADR-0030).  A real backend may involve human editorial
+        review, automated QA checks, or both.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  draft_advisory_artifact: str  (reads the Composer output)
+      Output keys: advisory_review_decision: AdvisoryReviewDecision
+        (SUCCESS only; default instance written by fuzzer backend)
+
+    Input category: Human decision / QA integration.
+
+    Success probability: 1.00 (``AlwaysSucceed``).
+
+    Automation potential: **Medium** — automated schema validation and
+    completeness checks are feasible; editorial approval and legal review
+    typically require human judgment.
+    """
+
+    output_keys = {"advisory_review_decision": AdvisoryReviewDecision}
+
+
+class ReviseAdvisoryDraft(ComposerCallOutPoint, AlmostAlwaysSucceed):
+    """Revise the advisory draft based on review feedback.
+
+    Semantic function:
+        Action — incorporate feedback from ``ReviewAdvisoryDraft`` and
+        produce a revised advisory artifact.  This node runs only when the
+        Evaluator sets ``needs_revision=True``; when the Evaluator approves
+        without requesting changes the revision arm is a graceful no-op.
+        The fuzzer succeeds almost always.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  advisory_review_decision: AdvisoryReviewDecision
+        (reads the Evaluator output for feedback guidance)
+      Output keys: draft_advisory_artifact: str  (overwrites on SUCCESS)
+
+    Input category: Human decision / Composer.
+
+    Success probability: 0.90 (``AlmostAlwaysSucceed``).
+
+    Automation potential: **Low–Medium** — structured revision based on
+    machine-readable feedback is partially automatable; editorial revisions
+    typically require human involvement.
+    """
+
+    output_keys = {"draft_advisory_artifact": str}
+
+
+class SubmitAdvisoryArtifact(ActuatorCallOutPoint, AlmostAlwaysSucceed):
+    """Submit the finalized advisory artifact to the external advisory platform.
+
+    Semantic function:
+        Action — submit the reviewed (and optionally revised) advisory
+        artifact to the target advisory platform (NVD, CVE.org, CMS,
+        package repository, or equivalent) via an API call.  In production
+        this is the final side-effecting step; the fuzzer succeeds almost
+        always, matching the original ``Publish`` Actuator probability.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — artifact context from construction time)
+      Output keys: (none — side effect: publish artifact to advisory platform)
+
+    Input category: System integration / Actuator.
+
+    Success probability: 0.90 (``AlmostAlwaysSucceed``).
+
+    Automation potential: **High** — advisory platform APIs (NVD, CVE.org,
+    CMS, package repository) enable fully automated artifact submission.
+    """


### PR DESCRIPTION
## Summary

Implements **Production Collapse 4** (ADR-0030 / BT-20-004): replaces the single
`Publish` Actuator leaf in each per-artifact arm of `create_publication_tree` with
a four-step pipeline per artifact:

```
PublishArtifactBT_{label} (Sequence)
├── DraftAdvisoryArtifact  (Composer)          — writes draft_advisory_artifact
├── ReviewAdvisoryDraft    (Evaluator)          — writes advisory_review_decision
├── RevisionArm            (Selector, optional) — runs when needs_revision=True
│   ├── Sequence(NeedsRevisionGate, ReviseAdvisoryDraft)
│   └── Inverter(NeedsRevisionGate)
└── SubmitAdvisoryArtifact (Actuator)           — side-effect, no output keys
```

- **New module**: `vultron/core/behaviors/report/publish_artifact_tree.py` —
  `AdvisoryReviewDecision` model, `_NeedsRevisionGate`, four default factory
  functions, `create_publish_artifact_tree()`
- **`publication_tree.py`** updated: `publish_factory` parameter removed; four
  pipeline factory parameters added; `_make_artifact_arm` now calls
  `create_publish_artifact_tree` with `artifact_label` suffix per arm
- **Four new fuzzer nodes** in `publication.py`:
  `DraftAdvisoryArtifact`, `ReviewAdvisoryDraft`, `ReviseAdvisoryDraft`,
  `SubmitAdvisoryArtifact`
- **ADR-0030** status updated from `proposed` → `accepted`
- **BT-20-004** spec updated: `PROVISIONAL` removed, `tracking_issue` updated
- **Notes** updated: Production Collapse 4 section reflects implementation

## Acceptance criteria

- AC-1 ✅ `Publish` single leaf replaced by Composer → Evaluator → optional Composer → Actuator pipeline
- AC-2 ✅ `AdvisoryReviewDecision` Pydantic model drives `_NeedsRevisionGate`
- AC-3 ✅ Default auto-approve path (`ReviewAdvisoryDraft` `AlwaysSucceed`) skips revision arm
- AC-4 ✅ Participant-comment broadcast **deferred** to follow-on issue (pipeline functions without it)
- AC-5 ✅ All four pipeline stages independently injectable per arm via factory params
- AC-6 ✅ ADR-0030 accepted before this PR lands

## Test plan

- [ ] `test/core/behaviors/report/test_publish_artifact_tree.py` — new (413 lines): model,
  gate unit tests, tree structure, factory injection, auto-approve vs. needs-revision tick paths,
  failure propagation
- [ ] `test/core/behaviors/report/test_publication_tree.py` — updated: Collapse 4 pipeline
  structure, default fuzzer node assertions, four-factory injection test
- [ ] `test/core/behaviors/report/test_publication_tree_factory_injection.py` — updated:
  submit-node assertions strengthened (startswith "SubmitAdvisoryArtifact")
- [ ] `test/demo/fuzzer/report_management/test_publication.py` — new nodes added to
  `_ALL_NODES`, Collapse 4 node-specific contract tests appended
- [ ] `uv run pytest test/core/behaviors/report/` — 321 passed
- [ ] `uv run pytest --tb=short` — 5385 passed, 0 failures

Closes #1312

🤖 Generated with [Claude Code](https://claude.com/claude-code)