### PR TITLE
test: ratchet integration script VALID_SCENARIOS against CI scenario set

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -131,27 +131,28 @@ docker compose -f docker-compose-multi-actor.yml up --abort-on-container-exit de
 This is the canonical single-command acceptance run for the current
 FV scenario.
 
-### Run the D5-3 three-actor acceptance scenario
+### Run the FVV scenario
 
-The same compose file can also run the coordinator-based D5-3 flow:
+The FVV scenario (Finder + Vendor + Vendor2, no Coordinator) runs all three
+vendor containers:
 
 ```bash
 # From the docker/ directory:
-DEMO=three-actor docker compose -f docker-compose-multi-actor.yml \
+DEMO=fvv docker compose -f docker-compose-multi-actor.yml \
     up --abort-on-container-exit demo-runner
 ```
 
-This starts Finder, Vendor, Coordinator, and CaseActor, resets their
-DataLayers, seeds all peers, and runs the deterministic three-actor scenario
-end to end.
+### Run the FVCV-extension or FVCV-handoff scenario
 
-### Run the D5-4 multi-vendor acceptance scenario
-
-The multi-vendor (ownership-transfer) scenario uses all five actor services:
+The FVCV scenarios use all five actor services (Finder, Vendor, Coordinator,
+Vendor2, CaseActor):
 
 ```bash
 # From the docker/ directory:
-DEMO=multi-vendor docker compose -f docker-compose-multi-actor.yml \
+DEMO=fvcv-extension docker compose -f docker-compose-multi-actor.yml \
+    up --abort-on-container-exit demo-runner
+
+DEMO=fvcv-handoff docker compose -f docker-compose-multi-actor.yml \
     up --abort-on-container-exit demo-runner
 ```
 
@@ -216,7 +217,7 @@ docker compose -f docker-compose-multi-actor.yml run --rm \
     vultron-demo seed
 ```
 
-The D5-2 and D5-3 demos reset state and handle peer registration
+The current demo scenarios reset state and handle peer registration
 automatically. Manual seeding remains useful for debugging or for future
 scenarios that do not use the `demo-runner` workflow.
 

--- a/docker/docker-compose-multi-actor.yml
+++ b/docker/docker-compose-multi-actor.yml
@@ -245,7 +245,7 @@ services:
       - VULTRON_CASE_ACTOR_BASE_URL=http://case-actor:7999/api/v2
       - VULTRON_VENDOR2_BASE_URL=http://vendor2:7999/api/v2
       # Run the selected multi-actor demo non-interactively. Override DEMO
-      # at runtime (for example, DEMO=three-actor) to switch scenarios.
+      # at runtime (for example, DEMO=fvv) to switch scenarios.
       - DEMO=${DEMO:-fv}
       - DEVLOGS_DIR=/app/devlogs
     volumes:

--- a/test/demo/test_integration_script_scenarios.py
+++ b/test/demo/test_integration_script_scenarios.py
@@ -1,0 +1,100 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Ratchet: VALID_SCENARIOS in the integration test script must match CI.
+
+When a new demo scenario is added to .github/workflows/demo-integration.yml
+(per DEMOCI-02-003), the shell script's VALID_SCENARIOS list must be updated
+in the same PR.  This test catches the drift that triggered issue #1585.
+
+Source of truth: the DEMO=<name> values in demo-integration.yml.
+Checked artifact: VALID_SCENARIOS in run_multi_actor_integration_test.sh.
+"""
+
+import re
+from pathlib import Path
+
+import yaml
+
+_REPO_ROOT = Path(__file__).parents[2]
+_CI_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "demo-integration.yml"
+_INTEGRATION_SCRIPT = (
+    _REPO_ROOT
+    / "integration_tests"
+    / "demo"
+    / "run_multi_actor_integration_test.sh"
+)
+
+# Matches lines like:   DEMO=fvcv-extension \
+_CI_DEMO_RE = re.compile(r"^\s+DEMO=([a-z][a-z0-9-]+)\s", re.MULTILINE)
+
+# Matches the assignment line:  VALID_SCENARIOS="fv fvv fvcv-extension fvcv-handoff"
+_VALID_SCENARIOS_RE = re.compile(r'^VALID_SCENARIOS="([^"]+)"')
+
+
+def _ci_scenarios() -> set[str]:
+    """Return the set of scenario names run by demo-integration.yml."""
+    text = _CI_WORKFLOW.read_text()
+    return {m.group(1) for m in _CI_DEMO_RE.finditer(text)}
+
+
+def _script_scenarios() -> set[str]:
+    """Return the set of scenario names declared in VALID_SCENARIOS."""
+    for line in _INTEGRATION_SCRIPT.read_text().splitlines():
+        m = _VALID_SCENARIOS_RE.match(line)
+        if m:
+            return set(m.group(1).split())
+    raise AssertionError(
+        f"Could not find VALID_SCENARIOS assignment in {_INTEGRATION_SCRIPT}"
+    )
+
+
+class TestIntegrationScriptScenarios:
+    """VALID_SCENARIOS must stay in sync with the CI workflow."""
+
+    def test_ci_workflow_exists(self):
+        assert _CI_WORKFLOW.exists(), f"CI workflow not found: {_CI_WORKFLOW}"
+
+    def test_integration_script_exists(self):
+        assert (
+            _INTEGRATION_SCRIPT.exists()
+        ), f"Integration script not found: {_INTEGRATION_SCRIPT}"
+
+    def test_valid_scenarios_matches_ci(self):
+        """VALID_SCENARIOS must equal the DEMO= values in demo-integration.yml.
+
+        Failure here means a new scenario was added to CI without updating the
+        script (or vice versa).  Fix both files in the same PR per DEMOCI-02-003.
+        """
+        ci = _ci_scenarios()
+        script = _script_scenarios()
+        assert script == ci, (
+            f"VALID_SCENARIOS in run_multi_actor_integration_test.sh {sorted(script)!r} "
+            f"does not match DEMO= values in demo-integration.yml {sorted(ci)!r}.\n"
+            f"In script but not CI: {sorted(script - ci)!r}\n"
+            f"In CI but not script: {sorted(ci - script)!r}\n"
+            "Update both files in the same PR (DEMOCI-02-003)."
+        )
+
+    def test_ci_workflow_is_valid_yaml(self):
+        """demo-integration.yml must parse as valid YAML."""
+        text = _CI_WORKFLOW.read_text()
+        result = yaml.safe_load(text)
+        assert isinstance(
+            result, dict
+        ), "Expected a YAML mapping at the top level"
+
+    def test_at_least_one_scenario_in_ci(self):
+        """CI must define at least one scenario (guards against empty parse)."""
+        ci = _ci_scenarios()
+        assert len(ci) >= 1, "No DEMO= lines found in demo-integration.yml"


### PR DESCRIPTION
## Summary

Adds a test that enforces `VALID_SCENARIOS` in
`integration_tests/demo/run_multi_actor_integration_test.sh` stays in sync
with the `DEMO=` values in `.github/workflows/demo-integration.yml`.

## Changes

- **`test/demo/test_integration_script_scenarios.py`** — new test module;
  parses both files and asserts their scenario sets are equal, with a clear
  failure message naming the drift when they diverge (per DEMOCI-02-003).

## Verification

- [x] `uv run pytest test/demo/test_integration_script_scenarios.py -m ""` — 5 passed
- [x] Black, flake8 clean

## Background

This is the automated guard that would have caught the stale `three-actor` /
`multi-vendor` entries cleaned up in #1622. The source of truth is the
`DEMO=<name>` lines in `demo-integration.yml`; the checked artifact is
the `VALID_SCENARIOS` assignment in the shell script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)