### PR TITLE
refactor(#1625): DRY up vultron/demo exchange scripts into shared helpers

### DIFF
--- a/vultron/demo/exchange/acknowledge_demo.py
+++ b/vultron/demo/exchange/acknowledge_demo.py
@@ -44,22 +44,22 @@ When run as a script, this module will:
 
 # Standard library imports
 import logging
-import sys
 from typing import Callable, Optional, Sequence, Tuple
 
 # Vultron imports
-from vultron.adapters.utils import parse_id
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
     as_VulnerabilityReport,
 )
+from vultron.demo.helpers.runner import run_exchange_demos
+from vultron.demo.helpers.verification import (
+    verify_activity_in_inbox,
+)  # noqa: F401
 from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monkeypatching
     BASE_URL,
     DataLayerClient,
-    check_server_availability,
     demo_check,
     demo_step,
-    demo_environment,
     logfmt,
     post_to_inbox_and_wait,
     verify_object_stored,
@@ -75,56 +75,11 @@ from vultron.wire.as2.factories import (
 logger = logging.getLogger(__name__)
 
 
-def get_actor_by_id(
-    client: DataLayerClient, actor_id: str
-) -> Optional[as_Actor]:
-    """Retrieve an actor by ID from the DataLayer, or ``None`` if not found."""
-    actors_data = client.get("/actors/")
-    for actor_data in actors_data:
-        actor = as_Actor(**actor_data)
-        if actor.id_ == actor_id:
-            return actor
-    return None
-
-
-def get_item_id(item):
-    """Extract the ``id_`` string from an activity item or return the item as-is."""
-    if item is None:
-        return None
-    if isinstance(item, str):
-        return item
-    return getattr(item, "id_", None)
-
-
-def verify_activity_in_inbox(
-    client: DataLayerClient, actor_id: str, activity_id: str
-) -> bool:
-    """Check whether ``activity_id`` appears in the actor's inbox.
-
-    Returns:
-        ``True`` if found; ``False`` otherwise.
-
-    Raises:
-        ValueError: If the actor cannot be found or has no inbox.
-    """
-    actor = get_actor_by_id(client, actor_id)
-    if not actor or not actor.inbox:
-        raise ValueError(f"Actor {actor_id} not found or has no inbox")
-    logger.info(
-        f"Actor {parse_id(actor_id)['object_id']} inbox has "
-        f"{len(actor.inbox.items)} items"
-    )
-    for item in actor.inbox.items:
-        item_id = get_item_id(item)
-        if item_id == activity_id:
-            logger.info(f"✓ Found activity in inbox: {logfmt(item)}")
-            return True
-    logger.warning(f"Activity {activity_id} not found in inbox")
-    return False
-
-
 def demo_acknowledge_only(
-    client: DataLayerClient, finder: as_Actor, vendor: as_Actor
+    client: DataLayerClient,
+    finder: as_Actor,
+    vendor: as_Actor,
+    coordinator: Optional[as_Actor] = None,
 ):
     """
     Demonstrates a bare acknowledgement: the vendor reads the report without
@@ -187,7 +142,10 @@ def demo_acknowledge_only(
 
 
 def demo_acknowledge_then_validate(
-    client: DataLayerClient, finder: as_Actor, vendor: as_Actor
+    client: DataLayerClient,
+    finder: as_Actor,
+    vendor: as_Actor,
+    coordinator: Optional[as_Actor] = None,
 ):
     """
     Demonstrates acknowledge followed by validation.
@@ -265,7 +223,10 @@ def demo_acknowledge_then_validate(
 
 
 def demo_acknowledge_then_invalidate(
-    client: DataLayerClient, finder: as_Actor, vendor: as_Actor
+    client: DataLayerClient,
+    finder: as_Actor,
+    vendor: as_Actor,
+    coordinator: Optional[as_Actor] = None,
 ):
     """
     Demonstrates acknowledge followed by invalidation.
@@ -359,66 +320,10 @@ def main(
     skip_health_check: bool = False,
     demos: Optional[Sequence] = None,
 ):
-    """
-    Main entry point for the acknowledge demo script.
-
-    Args:
-        skip_health_check: Skip the server availability check (useful for testing)
-        demos: Optional sequence of demo functions to run. Defaults to all three.
-    """
-    client = DataLayerClient()
-
-    if not skip_health_check and not check_server_availability(client):
-        logger.error("=" * 80)
-        logger.error("ERROR: API server is not available")
-        logger.error("=" * 80)
-        logger.error(f"Cannot connect to: {client.base_url}")
-        logger.error("Please ensure the Vultron API server is running.")
-        logger.error("You can start it with:")
-        logger.error(
-            "  uv run uvicorn vultron.api.main:app --host localhost --port 7999"
-        )
-        logger.error("=" * 80)
-        sys.exit(1)
-
-    selected = (
-        _ALL_DEMOS
-        if demos is None
-        else [(name, fn) for name, fn in _ALL_DEMOS if fn in demos]
+    """Main entry point for the acknowledge demo script."""
+    run_exchange_demos(
+        _ALL_DEMOS, skip_health_check=skip_health_check, demos=demos
     )
-    total = len(selected)
-    errors = []
-
-    for demo_name, demo_fn in selected:
-        try:
-            with demo_environment(client) as (finder, vendor, coordinator):
-                demo_fn(client, finder, vendor)
-        except Exception as e:
-            logger.error(f"{demo_name} failed: {e}", exc_info=True)
-            errors.append((demo_name, str(e)))
-
-    logger.info("=" * 80)
-    logger.info("ALL DEMOS COMPLETE")
-    logger.info("=" * 80)
-
-    if errors:
-        logger.error("")
-        logger.error("=" * 80)
-        logger.error("ERROR SUMMARY")
-        logger.error("=" * 80)
-        logger.error(f"Total demos: {total}")
-        logger.error(f"Failed demos: {len(errors)}")
-        logger.error(f"Successful demos: {total - len(errors)}")
-        logger.error("")
-        for demo_name, error in errors:
-            logger.error(f"{demo_name}:")
-            logger.error(f"  {error}")
-            logger.error("")
-        logger.error("=" * 80)
-    else:
-        logger.info("")
-        logger.info(f"✓ All {total} demos completed successfully!")
-        logger.info("")
 
 
 if __name__ == "__main__":

--- a/vultron/demo/exchange/establish_embargo_demo.py
+++ b/vultron/demo/exchange/establish_embargo_demo.py
@@ -43,169 +43,33 @@ inboxes.
 """
 
 import logging
-import sys
-from datetime import datetime, timedelta
 from typing import Callable, Optional, Sequence, Tuple
 
 from vultron.core.states.em import is_em_embargo_active
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Create
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
-from vultron.wire.as2.vocab.objects.case_participant import (
-    as_CaseParticipant,
-)
-from vultron.enums.roles import CVDRole
-from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
-from vultron.wire.as2.vocab.objects.vulnerability_case import (
-    as_VulnerabilityCase,
-)
-from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    as_VulnerabilityReport,
-)
+from vultron.demo.helpers.embargo import make_embargo_event
+from vultron.demo.helpers.runner import run_exchange_demos
+from vultron.demo.helpers.workflow import setup_two_participant_case
 from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monkeypatching
     BASE_URL,
     DataLayerClient,
-    check_server_availability,
     demo_check,
     demo_step,
-    get_offer_from_datalayer,
     log_case_state,
     logfmt,
-    demo_environment,
     post_to_inbox_and_wait,
-    verify_object_stored,
     setup_demo_logging,
 )
 from vultron.wire.as2.factories import (
     activate_embargo_activity,
-    add_participant_to_case_activity,
-    add_report_to_case_activity,
     announce_embargo_activity,
-    create_case_activity,
     em_accept_embargo_activity,
     em_propose_embargo_activity,
     em_reject_embargo_activity,
-    rm_accept_invite_to_case_activity,
-    rm_invite_to_case_activity,
-    rm_submit_report_activity,
-    rm_validate_report_activity,
 )
 
 logger = logging.getLogger(__name__)
-
-
-def _make_embargo_event(
-    case: as_VulnerabilityCase, days: int = 90
-) -> as_EmbargoEvent:
-    """Create a deterministic as_EmbargoEvent for a given case."""
-    now = datetime.now().astimezone()
-    now = now.replace(second=0, microsecond=0)
-    end_at = (now + timedelta(days=days)).replace(
-        hour=0, minute=0, second=0, microsecond=0
-    )
-    # Use a URL-safe date string (no colons) for the ID path segment
-    end_date_str = end_at.strftime("%Y-%m-%d")
-    return as_EmbargoEvent(
-        id_=f"{case.id_}/embargo_events/{days}d-{end_date_str}",
-        name=f"Embargo for {case.name}",
-        context=case.id_,
-        start_time=now,
-        end_time=end_at,
-        content=f"Proposed {days}-day embargo for {case.name}.",
-    )
-
-
-def _setup_two_participant_case(
-    client: DataLayerClient,
-    finder: as_Actor,
-    vendor: as_Actor,
-    coordinator: as_Actor,
-) -> as_VulnerabilityCase:
-    """
-    Set up a case with two participants (vendor + coordinator) as a
-    precondition for the embargo workflow.
-
-    Steps:
-    1. Finder submits report to vendor
-    2. Vendor validates report
-    3. Vendor creates case
-    4. Vendor adds report to case
-    5. Vendor adds finder as FinderReporter participant
-    6. Vendor invites coordinator; coordinator accepts → coordinator added
-    """
-    report = as_VulnerabilityReport(
-        attributed_to=finder.id_,
-        content="A use-after-free vulnerability in the network stack.",
-        name="Use-After-Free in Network Stack",
-    )
-    report_offer = rm_submit_report_activity(
-        report, actor=finder.id_, to=vendor.id_
-    )
-    post_to_inbox_and_wait(client, vendor.id_, report_offer)
-    verify_object_stored(client, report.id_)
-
-    offer = get_offer_from_datalayer(client, vendor.id_, report_offer.id_)
-    validate_activity = rm_validate_report_activity(
-        offer,
-        actor=vendor.id_,
-        content="Confirmed — use-after-free via unsanitized network input.",
-    )
-    post_to_inbox_and_wait(client, vendor.id_, validate_activity)
-
-    case = as_VulnerabilityCase(
-        attributed_to=vendor.id_,
-        name="UAF Case — Network Stack",
-        content="Tracking the use-after-free vulnerability in the network stack.",
-    )
-    create_case_act = create_case_activity(case, actor=vendor.id_)
-    post_to_inbox_and_wait(client, vendor.id_, create_case_act)
-    verify_object_stored(client, case.id_)
-
-    add_report_activity = add_report_to_case_activity(
-        report, actor=vendor.id_, target=case.id_
-    )
-    post_to_inbox_and_wait(client, vendor.id_, add_report_activity)
-
-    participant = as_CaseParticipant(
-        case_roles=[CVDRole.FINDER, CVDRole.REPORTER],
-        attributed_to=finder.id_,
-        context=case.id_,
-    )
-    create_participant_activity = as_Create(
-        actor=vendor.id_,
-        object_=participant,
-        context=case.id_,
-    )
-    post_to_inbox_and_wait(client, vendor.id_, create_participant_activity)
-    verify_object_stored(client, participant.id_)
-
-    add_participant_activity = add_participant_to_case_activity(
-        participant, actor=vendor.id_, target=case.id_
-    )
-    post_to_inbox_and_wait(client, vendor.id_, add_participant_activity)
-
-    # Invite coordinator and have them accept
-    invite = rm_invite_to_case_activity(
-        coordinator,
-        actor=vendor.id_,
-        target=case.id_,
-        to=[coordinator.id_],
-        content=f"Inviting you to participate in {case.name}.",
-    )
-    post_to_inbox_and_wait(client, coordinator.id_, invite)
-
-    accept = rm_accept_invite_to_case_activity(
-        invite,
-        actor=coordinator.id_,
-        to=[vendor.id_],
-        content=f"Accepting invitation to {case.name}.",
-    )
-    post_to_inbox_and_wait(client, vendor.id_, accept)
-
-    log_case_state(client, case.id_, "after setup (two participants)")
-    logger.info(
-        "✓ Setup: Case initialized with vendor and coordinator participants"
-    )
-    return case
 
 
 def demo_propose_embargo_accept(
@@ -232,10 +96,10 @@ def demo_propose_embargo_accept(
     logger.info("DEMO: Establish Embargo — Propose/Accept Path")
     logger.info("=" * 80)
 
-    case = _setup_two_participant_case(client, finder, vendor, coordinator)
+    case = setup_two_participant_case(client, finder, vendor, coordinator)
 
     with demo_step("Step 2: Coordinator proposes embargo"):
-        embargo = _make_embargo_event(case, days=90)
+        embargo = make_embargo_event(case, days=90)
         create_embargo = as_Create(
             actor=vendor.id_,
             object_=embargo,
@@ -329,10 +193,10 @@ def demo_propose_embargo_reject(
     logger.info("DEMO: Establish Embargo — Propose/Reject Path")
     logger.info("=" * 80)
 
-    case = _setup_two_participant_case(client, finder, vendor, coordinator)
+    case = setup_two_participant_case(client, finder, vendor, coordinator)
 
     with demo_step("Step 2: Coordinator proposes embargo"):
-        embargo = _make_embargo_event(case, days=45)
+        embargo = make_embargo_event(case, days=45)
         create_embargo = as_Create(
             actor=vendor.id_,
             object_=embargo,
@@ -396,66 +260,10 @@ def main(
     skip_health_check: bool = False,
     demos: Optional[Sequence] = None,
 ) -> None:
-    """
-    Main entry point for the establish_embargo demo script.
-
-    Args:
-        skip_health_check: Skip server availability check (useful for testing)
-        demos: Optional sequence of demo functions to run. Defaults to all.
-    """
-    client = DataLayerClient()
-
-    if not skip_health_check and not check_server_availability(client):
-        logger.error("=" * 80)
-        logger.error("ERROR: API server is not available")
-        logger.error("=" * 80)
-        logger.error(f"Cannot connect to: {client.base_url}")
-        logger.error("")
-        logger.error("Please ensure the Vultron API server is running:")
-        logger.error(
-            "  uv run uvicorn vultron.api.main:app --host localhost --port 7999"
-        )
-        logger.error("=" * 80)
-        sys.exit(1)
-
-    selected = (
-        _ALL_DEMOS
-        if demos is None
-        else [(name, fn) for name, fn in _ALL_DEMOS if fn in demos]
+    """Main entry point for the establish_embargo demo script."""
+    run_exchange_demos(
+        _ALL_DEMOS, skip_health_check=skip_health_check, demos=demos
     )
-    total = len(selected)
-    errors = []
-
-    for demo_name, demo_fn in selected:
-        try:
-            with demo_environment(client) as (finder, vendor, coordinator):
-                demo_fn(client, finder, vendor, coordinator)
-        except Exception as e:
-            logger.error(f"{demo_name} failed: {e}", exc_info=True)
-            errors.append((demo_name, str(e)))
-
-    logger.info("=" * 80)
-    logger.info("ALL DEMOS COMPLETE")
-    logger.info("=" * 80)
-
-    if errors:
-        logger.error("")
-        logger.error("=" * 80)
-        logger.error("ERROR SUMMARY")
-        logger.error("=" * 80)
-        logger.error(f"Total demos: {total}")
-        logger.error(f"Failed demos: {len(errors)}")
-        logger.error(f"Successful demos: {total - len(errors)}")
-        logger.error("")
-        for demo_name, error in errors:
-            logger.error(f"{demo_name}:")
-            logger.error(f"  {error}")
-            logger.error("")
-        logger.error("=" * 80)
-    else:
-        logger.info("")
-        logger.info(f"✓ All {total} demos completed successfully!")
-        logger.info("")
 
 
 if __name__ == "__main__":

--- a/vultron/demo/exchange/initialize_case_demo.py
+++ b/vultron/demo/exchange/initialize_case_demo.py
@@ -43,7 +43,6 @@ prototype design. Actors post activities directly to each other's inboxes.
 
 # Standard library imports
 import logging
-import sys
 from typing import Callable, Optional, Sequence, Tuple
 
 # Vultron imports
@@ -62,13 +61,11 @@ from vultron.wire.as2.vocab.objects.vulnerability_case import (
 from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monkeypatching
     BASE_URL,
     DataLayerClient,
-    check_server_availability,
     demo_check,
     demo_step,
     get_offer_from_datalayer,
     log_case_state,
     logfmt,
-    demo_environment,
     post_to_inbox_and_wait,
     ref_id,
     verify_object_stored,
@@ -82,11 +79,16 @@ from vultron.wire.as2.factories import (
     rm_validate_report_activity,
 )
 
+from vultron.demo.helpers.runner import run_exchange_demos
+
 logger = logging.getLogger(__name__)
 
 
 def demo_initialize_case(
-    client: DataLayerClient, finder: as_Actor, vendor: as_Actor
+    client: DataLayerClient,
+    finder: as_Actor,
+    vendor: as_Actor,
+    coordinator: Optional[as_Actor] = None,
 ):
     """
     Demonstrates the full case initialization workflow.
@@ -249,67 +251,11 @@ _ALL_DEMOS: Sequence[Tuple[str, Callable[..., None]]] = [
 def main(
     skip_health_check: bool = False,
     demos: Optional[Sequence] = None,
-):
-    """
-    Main entry point for the initialize_case demo script.
-
-    Args:
-        skip_health_check: Skip server availability check (useful for testing)
-        demos: Optional sequence of demo functions to run. Defaults to all.
-    """
-    client = DataLayerClient()
-
-    if not skip_health_check and not check_server_availability(client):
-        logger.error("=" * 80)
-        logger.error("ERROR: API server is not available")
-        logger.error("=" * 80)
-        logger.error(f"Cannot connect to: {client.base_url}")
-        logger.error("")
-        logger.error("Please ensure the Vultron API server is running:")
-        logger.error(
-            "  uv run uvicorn vultron.api.main:app --host localhost --port 7999"
-        )
-        logger.error("=" * 80)
-        sys.exit(1)
-
-    selected = (
-        _ALL_DEMOS
-        if demos is None
-        else [(name, fn) for name, fn in _ALL_DEMOS if fn in demos]
+) -> None:
+    """Main entry point for the initialize case demo demo script."""
+    run_exchange_demos(
+        _ALL_DEMOS, skip_health_check=skip_health_check, demos=demos
     )
-    total = len(selected)
-    errors = []
-
-    for demo_name, demo_fn in selected:
-        try:
-            with demo_environment(client) as (finder, vendor, coordinator):
-                demo_fn(client, finder, vendor)
-        except Exception as e:
-            logger.error(f"{demo_name} failed: {e}", exc_info=True)
-            errors.append((demo_name, str(e)))
-
-    logger.info("=" * 80)
-    logger.info("ALL DEMOS COMPLETE")
-    logger.info("=" * 80)
-
-    if errors:
-        logger.error("")
-        logger.error("=" * 80)
-        logger.error("ERROR SUMMARY")
-        logger.error("=" * 80)
-        logger.error(f"Total demos: {total}")
-        logger.error(f"Failed demos: {len(errors)}")
-        logger.error(f"Successful demos: {total - len(errors)}")
-        logger.error("")
-        for demo_name, error in errors:
-            logger.error(f"{demo_name}:")
-            logger.error(f"  {error}")
-            logger.error("")
-        logger.error("=" * 80)
-    else:
-        logger.info("")
-        logger.info(f"✓ All {total} demos completed successfully!")
-        logger.info("")
 
 
 if __name__ == "__main__":

--- a/vultron/demo/exchange/initialize_participant_demo.py
+++ b/vultron/demo/exchange/initialize_participant_demo.py
@@ -41,7 +41,6 @@ When run as a script, this module will:
 
 # Standard library imports
 import logging
-import sys
 from typing import Callable, Optional, Sequence, Tuple
 
 # Vultron imports
@@ -59,13 +58,11 @@ from vultron.wire.as2.vocab.objects.vulnerability_report import (
 from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monkeypatching
     BASE_URL,
     DataLayerClient,
-    check_server_availability,
     demo_check,
     demo_step,
     get_offer_from_datalayer,
     log_case_state,
     logfmt,
-    demo_environment,
     post_to_inbox_and_wait,
     ref_id,
     verify_object_stored,
@@ -79,6 +76,8 @@ from vultron.wire.as2.factories import (
     rm_submit_report_activity,
     rm_validate_report_activity,
 )
+
+from vultron.demo.helpers.runner import run_exchange_demos
 
 logger = logging.getLogger(__name__)
 
@@ -278,67 +277,11 @@ _ALL_DEMOS: Sequence[Tuple[str, Callable[..., None]]] = [
 def main(
     skip_health_check: bool = False,
     demos: Optional[Sequence] = None,
-):
-    """
-    Main entry point for the initialize_participant demo script.
-
-    Args:
-        skip_health_check: Skip server availability check (useful for testing)
-        demos: Optional sequence of demo functions to run. Defaults to all.
-    """
-    client = DataLayerClient()
-
-    if not skip_health_check and not check_server_availability(client):
-        logger.error("=" * 80)
-        logger.error("ERROR: API server is not available")
-        logger.error("=" * 80)
-        logger.error(f"Cannot connect to: {client.base_url}")
-        logger.error("")
-        logger.error("Please ensure the Vultron API server is running:")
-        logger.error(
-            "  uv run uvicorn vultron.api.main:app --host localhost --port 7999"
-        )
-        logger.error("=" * 80)
-        sys.exit(1)
-
-    selected = (
-        _ALL_DEMOS
-        if demos is None
-        else [(name, fn) for name, fn in _ALL_DEMOS if fn in demos]
+) -> None:
+    """Main entry point for the initialize participant demo demo script."""
+    run_exchange_demos(
+        _ALL_DEMOS, skip_health_check=skip_health_check, demos=demos
     )
-    total = len(selected)
-    errors = []
-
-    for demo_name, demo_fn in selected:
-        try:
-            with demo_environment(client) as (finder, vendor, coordinator):
-                demo_fn(client, finder, vendor, coordinator)
-        except Exception as e:
-            logger.error(f"{demo_name} failed: {e}", exc_info=True)
-            errors.append((demo_name, str(e)))
-
-    logger.info("=" * 80)
-    logger.info("ALL DEMOS COMPLETE")
-    logger.info("=" * 80)
-
-    if errors:
-        logger.error("")
-        logger.error("=" * 80)
-        logger.error("ERROR SUMMARY")
-        logger.error("=" * 80)
-        logger.error(f"Total demos: {total}")
-        logger.error(f"Failed demos: {len(errors)}")
-        logger.error(f"Successful demos: {total - len(errors)}")
-        logger.error("")
-        for demo_name, error in errors:
-            logger.error(f"{demo_name}:")
-            logger.error(f"  {error}")
-            logger.error("")
-        logger.error("=" * 80)
-    else:
-        logger.info("")
-        logger.info(f"✓ All {total} demos completed successfully!")
-        logger.info("")
 
 
 if __name__ == "__main__":

--- a/vultron/demo/exchange/invite_actor_demo.py
+++ b/vultron/demo/exchange/invite_actor_demo.py
@@ -45,46 +45,27 @@ inboxes.
 
 # Standard library imports
 import logging
-import sys
 from typing import Callable, Optional, Sequence, Tuple
 
 # Vultron imports
-from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Create
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
-from vultron.wire.as2.vocab.objects.case_participant import (
-    as_CaseParticipant,
-)
-from vultron.enums.roles import CVDRole
-from vultron.wire.as2.vocab.objects.vulnerability_case import (
-    as_VulnerabilityCase,
-)
-from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    as_VulnerabilityReport,
-)
+from vultron.demo.helpers.runner import run_exchange_demos
+from vultron.demo.helpers.workflow import setup_initialized_case
 from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monkeypatching
     BASE_URL,
     DataLayerClient,
-    check_server_availability,
     demo_check,
     demo_step,
-    get_offer_from_datalayer,
-    demo_environment,
     log_case_state,
     logfmt,
     post_to_inbox_and_wait,
     ref_id,
-    verify_object_stored,
     setup_demo_logging,
 )
 from vultron.wire.as2.factories import (
-    add_participant_to_case_activity,
-    add_report_to_case_activity,
-    create_case_activity,
     rm_accept_invite_to_case_activity,
     rm_invite_to_case_activity,
     rm_reject_invite_to_case_activity,
-    rm_submit_report_activity,
-    rm_validate_report_activity,
 )
 
 logger = logging.getLogger(__name__)
@@ -103,73 +84,6 @@ def _get_case_actor_id(client: DataLayerClient, case_id: str) -> str | None:
         if actor.get("type") == "Service" and actor.get("context") == case_id:
             return actor.get("id")
     return None
-
-
-def _setup_initialized_case(
-    client: DataLayerClient,
-    finder: as_Actor,
-    vendor: as_Actor,
-) -> as_VulnerabilityCase:
-    """
-    Set up an initialized case as a precondition for the invite workflow.
-
-    Mirrors demo_initialize_case from initialize_case_demo but returns the
-    as_VulnerabilityCase so subsequent steps can reference it.
-    """
-    report = as_VulnerabilityReport(
-        attributed_to=finder.id_,
-        content="A remote code execution vulnerability in the web framework.",
-        name="Remote Code Execution Vulnerability",
-    )
-    report_offer = rm_submit_report_activity(
-        report, actor=finder.id_, to=vendor.id_
-    )
-    post_to_inbox_and_wait(client, vendor.id_, report_offer)
-    verify_object_stored(client, report.id_)
-
-    offer = get_offer_from_datalayer(client, vendor.id_, report_offer.id_)
-    validate_activity = rm_validate_report_activity(
-        offer,
-        actor=vendor.id_,
-        content="Confirmed — remote code execution via unsanitized input.",
-    )
-    post_to_inbox_and_wait(client, vendor.id_, validate_activity)
-
-    case = as_VulnerabilityCase(
-        attributed_to=vendor.id_,
-        name="RCE Case — Web Framework",
-        content="Tracking the RCE vulnerability in the web framework.",
-    )
-    create_case_act = create_case_activity(case, actor=vendor.id_)
-    post_to_inbox_and_wait(client, vendor.id_, create_case_act)
-    verify_object_stored(client, case.id_)
-
-    add_report_activity = add_report_to_case_activity(
-        report, actor=vendor.id_, target=case.id_
-    )
-    post_to_inbox_and_wait(client, vendor.id_, add_report_activity)
-
-    participant = as_CaseParticipant(
-        case_roles=[CVDRole.FINDER, CVDRole.REPORTER],
-        attributed_to=finder.id_,
-        context=case.id_,
-    )
-    create_participant_activity = as_Create(
-        actor=vendor.id_,
-        object_=participant,
-        context=case.id_,
-    )
-    post_to_inbox_and_wait(client, vendor.id_, create_participant_activity)
-    verify_object_stored(client, participant.id_)
-
-    add_participant_activity = add_participant_to_case_activity(
-        participant, actor=vendor.id_, target=case.id_
-    )
-    post_to_inbox_and_wait(client, vendor.id_, add_participant_activity)
-
-    log_case_state(client, case.id_, "after setup")
-    logger.info("✓ Setup: Case initialized with report and finder participant")
-    return case
 
 
 def demo_invite_actor_accept(
@@ -195,7 +109,7 @@ def demo_invite_actor_accept(
     logger.info("DEMO: Invite Actor — Accept Path")
     logger.info("=" * 80)
 
-    case = _setup_initialized_case(client, finder, vendor)
+    case = setup_initialized_case(client, finder, vendor)
 
     # PCR-08-007: the invite MUST be sent from the Case Actor's identity.
     # The Case Actor is registered as a Service in the DataLayer after case creation.
@@ -275,7 +189,7 @@ def demo_invite_actor_reject(
     logger.info("DEMO: Invite Actor — Reject Path")
     logger.info("=" * 80)
 
-    case = _setup_initialized_case(client, finder, vendor)
+    case = setup_initialized_case(client, finder, vendor)
 
     initial_case = log_case_state(client, case.id_, "initial")
     initial_count = len(initial_case.case_participants) if initial_case else 0
@@ -333,66 +247,10 @@ def main(
     skip_health_check: bool = False,
     demos: Optional[Sequence] = None,
 ) -> None:
-    """
-    Main entry point for the invite_actor demo script.
-
-    Args:
-        skip_health_check: Skip server availability check (useful for testing)
-        demos: Optional sequence of demo functions to run. Defaults to all.
-    """
-    client = DataLayerClient()
-
-    if not skip_health_check and not check_server_availability(client):
-        logger.error("=" * 80)
-        logger.error("ERROR: API server is not available")
-        logger.error("=" * 80)
-        logger.error(f"Cannot connect to: {client.base_url}")
-        logger.error("")
-        logger.error("Please ensure the Vultron API server is running:")
-        logger.error(
-            "  uv run uvicorn vultron.api.main:app --host localhost --port 7999"
-        )
-        logger.error("=" * 80)
-        sys.exit(1)
-
-    selected = (
-        _ALL_DEMOS
-        if demos is None
-        else [(name, fn) for name, fn in _ALL_DEMOS if fn in demos]
+    """Main entry point for the invite_actor demo script."""
+    run_exchange_demos(
+        _ALL_DEMOS, skip_health_check=skip_health_check, demos=demos
     )
-    total = len(selected)
-    errors = []
-
-    for demo_name, demo_fn in selected:
-        try:
-            with demo_environment(client) as (finder, vendor, coordinator):
-                demo_fn(client, finder, vendor, coordinator)
-        except Exception as e:
-            logger.error(f"{demo_name} failed: {e}", exc_info=True)
-            errors.append((demo_name, str(e)))
-
-    logger.info("=" * 80)
-    logger.info("ALL DEMOS COMPLETE")
-    logger.info("=" * 80)
-
-    if errors:
-        logger.error("")
-        logger.error("=" * 80)
-        logger.error("ERROR SUMMARY")
-        logger.error("=" * 80)
-        logger.error(f"Total demos: {total}")
-        logger.error(f"Failed demos: {len(errors)}")
-        logger.error(f"Successful demos: {total - len(errors)}")
-        logger.error("")
-        for demo_name, error in errors:
-            logger.error(f"{demo_name}:")
-            logger.error(f"  {error}")
-            logger.error("")
-        logger.error("=" * 80)
-    else:
-        logger.info("")
-        logger.info(f"✓ All {total} demos completed successfully!")
-        logger.info("")
 
 
 if __name__ == "__main__":

--- a/vultron/demo/exchange/manage_case_demo.py
+++ b/vultron/demo/exchange/manage_case_demo.py
@@ -53,7 +53,6 @@ When run as a script, this module will:
 
 # Standard library imports
 import logging
-import sys
 from typing import Callable, Optional, Sequence, Tuple
 
 # Vultron imports
@@ -69,13 +68,11 @@ from vultron.wire.as2.vocab.objects.vulnerability_report import (
 from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monkeypatching
     BASE_URL,
     DataLayerClient,
-    check_server_availability,
     demo_check,
     demo_step,
     get_offer_from_datalayer,
     log_case_state,
     logfmt,
-    demo_environment,
     post_to_inbox_and_wait,
     ref_id,
     verify_object_stored,
@@ -93,6 +90,8 @@ from vultron.wire.as2.factories import (
     rm_submit_report_activity,
     rm_validate_report_activity,
 )
+
+from vultron.demo.helpers.runner import run_exchange_demos
 
 logger = logging.getLogger(__name__)
 
@@ -166,7 +165,10 @@ def setup_report_and_case(
 
 
 def demo_engage_path(
-    client: DataLayerClient, finder: as_Actor, vendor: as_Actor
+    client: DataLayerClient,
+    finder: as_Actor,
+    vendor: as_Actor,
+    coordinator: Optional[as_Actor] = None,
 ):
     """
     Demonstrates the full happy-path case management workflow:
@@ -224,7 +226,10 @@ def demo_engage_path(
 
 
 def demo_defer_reengage_path(
-    client: DataLayerClient, finder: as_Actor, vendor: as_Actor
+    client: DataLayerClient,
+    finder: as_Actor,
+    vendor: as_Actor,
+    coordinator: Optional[as_Actor] = None,
 ):
     """
     Demonstrates the defer-and-re-engage path:
@@ -297,7 +302,10 @@ def demo_defer_reengage_path(
 
 
 def demo_invalidate_path(
-    client: DataLayerClient, finder: as_Actor, vendor: as_Actor
+    client: DataLayerClient,
+    finder: as_Actor,
+    vendor: as_Actor,
+    coordinator: Optional[as_Actor] = None,
 ):
     """
     Demonstrates the invalidation path: submit → invalidate → close_report.
@@ -371,69 +379,11 @@ _ALL_DEMOS: Sequence[Tuple[str, Callable[..., None]]] = [
 def main(
     skip_health_check: bool = False,
     demos: Optional[Sequence] = None,
-):
-    """
-    Main entry point for the manage_case demo script.
-
-    Args:
-        skip_health_check: Skip the server availability check (useful for
-            testing)
-        demos: Optional sequence of demo functions to run. Defaults to all
-            three.
-    """
-    client = DataLayerClient()
-
-    if not skip_health_check and not check_server_availability(client):
-        logger.error("=" * 80)
-        logger.error("ERROR: API server is not available")
-        logger.error("=" * 80)
-        logger.error(f"Cannot connect to: {client.base_url}")
-        logger.error("Please ensure the Vultron API server is running.")
-        logger.error("You can start it with:")
-        logger.error(
-            "  uv run uvicorn vultron.api.main:app --host localhost --port 7999"
-        )
-        logger.error("=" * 80)
-        sys.exit(1)
-
-    selected = (
-        _ALL_DEMOS
-        if demos is None
-        else [(name, fn) for name, fn in _ALL_DEMOS if fn in demos]
+) -> None:
+    """Main entry point for the manage case demo demo script."""
+    run_exchange_demos(
+        _ALL_DEMOS, skip_health_check=skip_health_check, demos=demos
     )
-    total = len(selected)
-    errors = []
-
-    for demo_name, demo_fn in selected:
-        try:
-            with demo_environment(client) as (finder, vendor, coordinator):
-                demo_fn(client, finder, vendor)
-        except Exception as e:
-            logger.error(f"{demo_name} failed: {e}", exc_info=True)
-            errors.append((demo_name, str(e)))
-
-    logger.info("=" * 80)
-    logger.info("ALL DEMOS COMPLETE")
-    logger.info("=" * 80)
-
-    if errors:
-        logger.error("")
-        logger.error("=" * 80)
-        logger.error("ERROR SUMMARY")
-        logger.error("=" * 80)
-        logger.error(f"Total demos: {total}")
-        logger.error(f"Failed demos: {len(errors)}")
-        logger.error(f"Successful demos: {total - len(errors)}")
-        logger.error("")
-        for demo_name, error in errors:
-            logger.error(f"{demo_name}:")
-            logger.error(f"  {error}")
-            logger.error("")
-        logger.error("=" * 80)
-    else:
-        logger.info("")
-        logger.info(f"✓ All {total} demos completed successfully!")
-        logger.info("")
 
 
 if __name__ == "__main__":

--- a/vultron/demo/exchange/manage_embargo_demo.py
+++ b/vultron/demo/exchange/manage_embargo_demo.py
@@ -43,168 +43,34 @@ inboxes.
 """
 
 import logging
-import sys
-from datetime import datetime, timedelta
 from typing import Callable, Optional, Sequence, Tuple
 
 from vultron.core.states.em import is_em_embargo_active
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Create
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
-from vultron.wire.as2.vocab.objects.case_participant import (
-    as_CaseParticipant,
-)
-from vultron.enums.roles import CVDRole
-from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
-from vultron.wire.as2.vocab.objects.vulnerability_case import (
-    as_VulnerabilityCase,
-)
-from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    as_VulnerabilityReport,
-)
+from vultron.demo.helpers.embargo import make_embargo_event
+from vultron.demo.helpers.runner import run_exchange_demos
+from vultron.demo.helpers.workflow import setup_two_participant_case
 from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monkeypatching
     BASE_URL,
     DataLayerClient,
-    check_server_availability,
     demo_check,
     demo_step,
-    get_offer_from_datalayer,
     log_case_state,
     logfmt,
-    demo_environment,
     post_to_inbox_and_wait,
-    verify_object_stored,
     setup_demo_logging,
 )
 from vultron.wire.as2.factories import (
     activate_embargo_activity,
-    add_participant_to_case_activity,
-    add_report_to_case_activity,
     announce_embargo_activity,
-    create_case_activity,
     em_accept_embargo_activity,
     em_propose_embargo_activity,
     em_reject_embargo_activity,
     remove_embargo_from_case_activity,
-    rm_accept_invite_to_case_activity,
-    rm_invite_to_case_activity,
-    rm_submit_report_activity,
-    rm_validate_report_activity,
 )
 
 logger = logging.getLogger(__name__)
-
-
-def _make_embargo_event(
-    case: as_VulnerabilityCase, days: int = 90, seq: int = 1
-) -> as_EmbargoEvent:
-    """Create a deterministic as_EmbargoEvent for a given case."""
-    now = datetime.now().astimezone()
-    now = now.replace(second=0, microsecond=0)
-    end_at = (now + timedelta(days=days)).replace(
-        hour=0, minute=0, second=0, microsecond=0
-    )
-    end_date_str = end_at.strftime("%Y-%m-%d")
-    return as_EmbargoEvent(
-        id_=f"{case.id_}/embargo_events/{days}d-{end_date_str}-{seq}",
-        name=f"Embargo for {case.name}",
-        context=case.id_,
-        start_time=now,
-        end_time=end_at,
-        content=f"Proposed {days}-day embargo for {case.name}.",
-    )
-
-
-def _setup_two_participant_case(
-    client: DataLayerClient,
-    finder: as_Actor,
-    vendor: as_Actor,
-    coordinator: as_Actor,
-) -> as_VulnerabilityCase:
-    """
-    Set up a case with two participants (vendor + coordinator) as a
-    precondition for the embargo management workflow.
-
-    Steps:
-    1. Finder submits report to vendor
-    2. Vendor validates report
-    3. Vendor creates case
-    4. Vendor adds report to case
-    5. Vendor adds finder as FinderReporter participant
-    6. Vendor invites coordinator; coordinator accepts → coordinator added
-    """
-    report = as_VulnerabilityReport(
-        attributed_to=finder.id_,
-        content="A heap-overflow vulnerability in the authentication library.",
-        name="Heap Overflow in Auth Library",
-    )
-    report_offer = rm_submit_report_activity(
-        report, actor=finder.id_, to=vendor.id_
-    )
-    post_to_inbox_and_wait(client, vendor.id_, report_offer)
-    verify_object_stored(client, report.id_)
-
-    offer = get_offer_from_datalayer(client, vendor.id_, report_offer.id_)
-    validate_activity = rm_validate_report_activity(
-        offer,
-        actor=vendor.id_,
-        content="Confirmed — heap overflow via malformed auth token.",
-    )
-    post_to_inbox_and_wait(client, vendor.id_, validate_activity)
-
-    case = as_VulnerabilityCase(
-        attributed_to=vendor.id_,
-        name="Heap Overflow — Auth Library",
-        content="Tracking the heap-overflow vulnerability in the auth library.",
-    )
-    create_case_act = create_case_activity(case, actor=vendor.id_)
-    post_to_inbox_and_wait(client, vendor.id_, create_case_act)
-    verify_object_stored(client, case.id_)
-
-    add_report_activity = add_report_to_case_activity(
-        report, actor=vendor.id_, target=case.id_
-    )
-    post_to_inbox_and_wait(client, vendor.id_, add_report_activity)
-
-    participant = as_CaseParticipant(
-        case_roles=[CVDRole.FINDER, CVDRole.REPORTER],
-        attributed_to=finder.id_,
-        context=case.id_,
-    )
-    create_participant_activity = as_Create(
-        actor=vendor.id_,
-        object_=participant,
-        context=case.id_,
-    )
-    post_to_inbox_and_wait(client, vendor.id_, create_participant_activity)
-    verify_object_stored(client, participant.id_)
-
-    add_participant_activity = add_participant_to_case_activity(
-        participant, actor=vendor.id_, target=case.id_
-    )
-    post_to_inbox_and_wait(client, vendor.id_, add_participant_activity)
-
-    invite = rm_invite_to_case_activity(
-        coordinator,
-        actor=vendor.id_,
-        target=case.id_,
-        to=[coordinator.id_],
-        content=f"Inviting you to participate in {case.name}.",
-    )
-    post_to_inbox_and_wait(client, coordinator.id_, invite)
-
-    accept = rm_accept_invite_to_case_activity(
-        invite,
-        actor=coordinator.id_,
-        to=[vendor.id_],
-        content=f"Accepting invitation to {case.name}.",
-    )
-    post_to_inbox_and_wait(client, vendor.id_, accept)
-
-    log_case_state(client, case.id_, "after setup (two participants)")
-    logger.info(
-        "✓ Setup: Case initialized with vendor and coordinator participants"
-    )
-    return case
 
 
 def demo_activate_then_terminate(
@@ -233,10 +99,10 @@ def demo_activate_then_terminate(
     logger.info("DEMO: Manage Embargo — Activate/Terminate Path")
     logger.info("=" * 80)
 
-    case = _setup_two_participant_case(client, finder, vendor, coordinator)
+    case = setup_two_participant_case(client, finder, vendor, coordinator)
 
     with demo_step("Step 2: Coordinator proposes embargo"):
-        embargo = _make_embargo_event(case, days=90, seq=1)
+        embargo = make_embargo_event(case, days=90, seq=1)
         create_embargo = as_Create(
             actor=vendor.id_,
             object_=embargo,
@@ -364,10 +230,10 @@ def demo_reject_then_repropose(
     logger.info("DEMO: Manage Embargo — Reject/Repropose Path")
     logger.info("=" * 80)
 
-    case = _setup_two_participant_case(client, finder, vendor, coordinator)
+    case = setup_two_participant_case(client, finder, vendor, coordinator)
 
     with demo_step("Step 2: Coordinator proposes first embargo (45-day)"):
-        embargo_v1 = _make_embargo_event(case, days=45, seq=1)
+        embargo_v1 = make_embargo_event(case, days=45, seq=1)
         create_embargo_v1 = as_Create(
             actor=vendor.id_,
             object_=embargo_v1,
@@ -419,7 +285,7 @@ def demo_reject_then_repropose(
                 )
 
     with demo_step("Step 5: Coordinator proposes revised embargo (90-day)"):
-        embargo_v2 = _make_embargo_event(case, days=90, seq=2)
+        embargo_v2 = make_embargo_event(case, days=90, seq=2)
         create_embargo_v2 = as_Create(
             actor=vendor.id_,
             object_=embargo_v2,
@@ -497,66 +363,10 @@ def main(
     skip_health_check: bool = False,
     demos: Optional[Sequence] = None,
 ) -> None:
-    """
-    Main entry point for the manage_embargo demo script.
-
-    Args:
-        skip_health_check: Skip server availability check (useful for testing)
-        demos: Optional sequence of demo functions to run. Defaults to all.
-    """
-    client = DataLayerClient()
-
-    if not skip_health_check and not check_server_availability(client):
-        logger.error("=" * 80)
-        logger.error("ERROR: API server is not available")
-        logger.error("=" * 80)
-        logger.error(f"Cannot connect to: {client.base_url}")
-        logger.error("")
-        logger.error("Please ensure the Vultron API server is running:")
-        logger.error(
-            "  uv run uvicorn vultron.api.main:app --host localhost --port 7999"
-        )
-        logger.error("=" * 80)
-        sys.exit(1)
-
-    selected = (
-        _ALL_DEMOS
-        if demos is None
-        else [(name, fn) for name, fn in _ALL_DEMOS if fn in demos]
+    """Main entry point for the manage_embargo demo script."""
+    run_exchange_demos(
+        _ALL_DEMOS, skip_health_check=skip_health_check, demos=demos
     )
-    total = len(selected)
-    errors = []
-
-    for demo_name, demo_fn in selected:
-        try:
-            with demo_environment(client) as (finder, vendor, coordinator):
-                demo_fn(client, finder, vendor, coordinator)
-        except Exception as e:
-            logger.error(f"{demo_name} failed: {e}", exc_info=True)
-            errors.append((demo_name, str(e)))
-
-    logger.info("=" * 80)
-    logger.info("ALL DEMOS COMPLETE")
-    logger.info("=" * 80)
-
-    if errors:
-        logger.error("")
-        logger.error("=" * 80)
-        logger.error("ERROR SUMMARY")
-        logger.error("=" * 80)
-        logger.error(f"Total demos: {total}")
-        logger.error(f"Failed demos: {len(errors)}")
-        logger.error(f"Successful demos: {total - len(errors)}")
-        logger.error("")
-        for demo_name, error in errors:
-            logger.error(f"{demo_name}:")
-            logger.error(f"  {error}")
-            logger.error("")
-        logger.error("=" * 80)
-    else:
-        logger.info("")
-        logger.info(f"✓ All {total} demos completed successfully!")
-        logger.info("")
 
 
 if __name__ == "__main__":

--- a/vultron/demo/exchange/manage_participants_demo.py
+++ b/vultron/demo/exchange/manage_participants_demo.py
@@ -41,7 +41,6 @@ When run as a script, this module will:
 """
 
 import logging
-import sys
 from typing import Callable, Optional, Sequence, Tuple
 
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
@@ -62,13 +61,11 @@ from vultron.core.states.cs import CS_vfd
 from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monkeypatching
     BASE_URL,
     DataLayerClient,
-    check_server_availability,
     demo_check,
     demo_step,
     get_offer_from_datalayer,
     log_case_state,
     logfmt,
-    demo_environment,
     post_to_inbox_and_wait,
     ref_id,
     verify_object_stored,
@@ -88,6 +85,8 @@ from vultron.wire.as2.factories import (
     rm_submit_report_activity,
     rm_validate_report_activity,
 )
+
+from vultron.demo.helpers.runner import run_exchange_demos
 
 logger = logging.getLogger(__name__)
 
@@ -394,66 +393,10 @@ def main(
     skip_health_check: bool = False,
     demos: Optional[Sequence] = None,
 ) -> None:
-    """
-    Main entry point for the manage_participants demo script.
-
-    Args:
-        skip_health_check: Skip server availability check (useful for testing)
-        demos: Optional sequence of demo functions to run. Defaults to all.
-    """
-    client = DataLayerClient()
-
-    if not skip_health_check and not check_server_availability(client):
-        logger.error("=" * 80)
-        logger.error("ERROR: API server is not available")
-        logger.error("=" * 80)
-        logger.error(f"Cannot connect to: {client.base_url}")
-        logger.error("")
-        logger.error("Please ensure the Vultron API server is running:")
-        logger.error(
-            "  uv run uvicorn vultron.api.main:app --host localhost --port 7999"
-        )
-        logger.error("=" * 80)
-        sys.exit(1)
-
-    selected = (
-        _ALL_DEMOS
-        if demos is None
-        else [(name, fn) for name, fn in _ALL_DEMOS if fn in demos]
+    """Main entry point for the manage participants demo demo script."""
+    run_exchange_demos(
+        _ALL_DEMOS, skip_health_check=skip_health_check, demos=demos
     )
-    total = len(selected)
-    errors = []
-
-    for demo_name, demo_fn in selected:
-        try:
-            with demo_environment(client) as (finder, vendor, coordinator):
-                demo_fn(client, finder, vendor, coordinator)
-        except Exception as e:
-            logger.error(f"{demo_name} failed: {e}", exc_info=True)
-            errors.append((demo_name, str(e)))
-
-    logger.info("=" * 80)
-    logger.info("ALL DEMOS COMPLETE")
-    logger.info("=" * 80)
-
-    if errors:
-        logger.error("")
-        logger.error("=" * 80)
-        logger.error("ERROR SUMMARY")
-        logger.error("=" * 80)
-        logger.error(f"Total demos: {total}")
-        logger.error(f"Failed demos: {len(errors)}")
-        logger.error(f"Successful demos: {total - len(errors)}")
-        logger.error("")
-        for demo_name, error in errors:
-            logger.error(f"{demo_name}:")
-            logger.error(f"  {error}")
-            logger.error("")
-        logger.error("=" * 80)
-    else:
-        logger.info("")
-        logger.info(f"✓ All {total} demos completed successfully!")
-        logger.info("")
 
 
 if __name__ == "__main__":

--- a/vultron/demo/exchange/receive_report_demo.py
+++ b/vultron/demo/exchange/receive_report_demo.py
@@ -50,7 +50,6 @@ The BT logs will show tree structure before execution and final state after comp
 # Standard library imports
 import json
 import logging
-import sys
 from typing import Callable, Optional, Sequence, Tuple
 
 # Vultron imports
@@ -64,17 +63,20 @@ from vultron.wire.as2.vocab.objects.vulnerability_case import (
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
     as_VulnerabilityReport,
 )
+from vultron.demo.helpers.runner import run_exchange_demos
+from vultron.demo.helpers.verification import (
+    verify_activity_in_inbox,
+)  # noqa: F401
 from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monkeypatching
     BASE_URL,
     DataLayerClient,
-    check_server_availability,
+    check_server_availability,  # noqa: F401 — imported by test_health_check_retry
     demo_check,
     demo_step,
     get_offer_from_datalayer,
     logfmt,
     post_to_inbox_and_wait,
     ref_id,
-    demo_environment,
     postfmt,
     verify_object_stored,
     setup_demo_logging,
@@ -110,99 +112,6 @@ def submit_to_inbox(
     )
 
     return client.post(f"/actors/{vendor_id}/inbox/", json=postfmt(activity))
-
-
-def get_actor_by_id(
-    client: DataLayerClient, actor_id: str
-) -> Optional[as_Actor]:
-    """
-    Retrieves an actor by ID from the API.
-
-    Args:
-        client: DataLayerClient instance
-        actor_id: Full URI of the actor
-
-    Returns:
-        as_Actor or None: The actor if found, None otherwise
-    """
-    actors_data = client.get("/actors/")
-    for actor_data in actors_data:
-        actor = as_Actor(**actor_data)
-        if actor.id_ == actor_id:
-            return actor
-    return None
-
-
-def get_item_id(item: Optional[str | object]) -> Optional[str]:
-    """
-    Extract ID from an ActivityStreams collection item.
-
-    Per ActivityStreams spec, collection items can be:
-    - Full objects (with id_ attribute)
-    - Links (with id_ attribute)
-    - String URIs (the string IS the ID)
-    - None (for optional fields)
-
-    Args:
-        item: Collection item (object, link, string, or None)
-
-    Returns:
-        str: The ID of the item, or None if item is None
-    """
-    if item is None:
-        return None
-    if isinstance(item, str):
-        return item  # String IS the ID
-    return getattr(item, "id_", None)
-
-
-def verify_activity_in_inbox(
-    client: DataLayerClient, actor_id: str, activity_id: str
-) -> bool:
-    """
-    Verifies that an activity appears in an actor's inbox.
-
-    Args:
-        client: DataLayerClient instance
-        actor_id: Full URI of the actor
-        activity_id: Full URI of the activity to find
-
-    Returns:
-        bool: True if activity found in inbox, False otherwise
-
-    Raises:
-        ValueError: If actor not found or has no inbox
-    """
-    actor = get_actor_by_id(client, actor_id)
-    if not actor or not actor.inbox:
-        raise ValueError(f"Actor {actor_id} not found or has no inbox")
-
-    logger.info(
-        f"Actor {parse_id(actor_id)['object_id']} inbox has {len(actor.inbox.items)} items"
-    )
-
-    # Log all inbox items for debugging
-    logger.debug(f"Looking for activity ID: {activity_id}")
-    for item in actor.inbox.items:
-        item_id = get_item_id(item)
-        logger.debug(f"Inbox item ID: {item_id}")
-        if item_id == activity_id:
-            logger.info(f"✓ Found activity in inbox: {logfmt(item)}")
-            return True
-
-    # If not found, log what we have for debugging
-    logger.warning(f"Activity {activity_id} not found in inbox")
-    logger.warning(f"Inbox contains {len(actor.inbox.items)} items:")
-    for item in actor.inbox.items:
-        item_id = get_item_id(item)
-        # Handle both string items and object items for logging
-        if isinstance(item, str):
-            logger.warning(f"  - {item_id} (type: string URI)")
-        else:
-            item_type = getattr(item, "type_", "unknown")
-            logger.warning(f"  - {item_id} (type: {item_type})")
-
-    return False
 
 
 def find_case_by_report(
@@ -254,7 +163,10 @@ def find_case_by_report(
 
 
 def demo_validate_report(
-    client: DataLayerClient, finder: as_Actor, vendor: as_Actor
+    client: DataLayerClient,
+    finder: as_Actor,
+    vendor: as_Actor,
+    coordinator: Optional[as_Actor] = None,
 ):
     """
     Demonstrates the workflow where a vendor validates a report and creates a case.
@@ -332,7 +244,10 @@ def demo_validate_report(
 
 
 def demo_invalidate_report(
-    client: DataLayerClient, finder: as_Actor, vendor: as_Actor
+    client: DataLayerClient,
+    finder: as_Actor,
+    vendor: as_Actor,
+    coordinator: Optional[as_Actor] = None,
 ):
     """
     Demonstrates the workflow where a vendor invalidates a report.
@@ -411,7 +326,10 @@ def demo_invalidate_report(
 
 
 def demo_invalidate_and_close_report(
-    client: DataLayerClient, finder: as_Actor, vendor: as_Actor
+    client: DataLayerClient,
+    finder: as_Actor,
+    vendor: as_Actor,
+    coordinator: Optional[as_Actor] = None,
 ):
     """
     Demonstrates the workflow where a vendor invalidates a report and closes it.
@@ -525,76 +443,10 @@ def main(
     skip_health_check: bool = False,
     demos: Optional[Sequence] = None,
 ):
-    """
-    Main entry point for the demo script.
-
-    Args:
-        skip_health_check: Skip the server availability check (useful for testing)
-        demos: Optional sequence of demo functions to run. Defaults to all three.
-            Pass a subset (e.g. ``[demo_validate_report]``) to run only those demos.
-
-    Runs demonstration workflows to showcase the different outcomes
-    when processing vulnerability reports.
-    """
-    client = DataLayerClient()
-
-    # Check if server is available before proceeding
-    if not skip_health_check and not check_server_availability(client):
-        logger.error("=" * 80)
-        logger.error("ERROR: API server is not available")
-        logger.error("=" * 80)
-        logger.error(f"Cannot connect to: {client.base_url}")
-        logger.error("")
-        logger.error("Please ensure the Vultron API server is running.")
-        logger.error("You can start it with:")
-        logger.error(
-            "  uv run uvicorn vultron.api.main:app --host localhost --port 7999"
-        )
-        logger.error("=" * 80)
-        sys.exit(1)
-
-    selected = (
-        _ALL_DEMOS
-        if demos is None
-        else [(name, fn) for name, fn in _ALL_DEMOS if fn in demos]
+    """Main entry point for the receive_report demo script."""
+    run_exchange_demos(
+        _ALL_DEMOS, skip_health_check=skip_health_check, demos=demos
     )
-    total = len(selected)
-
-    # Track errors for summary
-    errors = []
-
-    # Run selected demos with different reports, each with clean environment
-    for demo_name, demo_fn in selected:
-        try:
-            with demo_environment(client) as (finder, vendor, coordinator):
-                demo_fn(client, finder, vendor)
-        except Exception as e:
-            logger.error(f"{demo_name} failed: {e}", exc_info=True)
-            errors.append((demo_name, str(e)))
-
-    logger.info("=" * 80)
-    logger.info("ALL DEMOS COMPLETE")
-    logger.info("=" * 80)
-
-    # Display error summary
-    if errors:
-        logger.error("")
-        logger.error("=" * 80)
-        logger.error("ERROR SUMMARY")
-        logger.error("=" * 80)
-        logger.error(f"Total demos: {total}")
-        logger.error(f"Failed demos: {len(errors)}")
-        logger.error(f"Successful demos: {total - len(errors)}")
-        logger.error("")
-        for demo_name, error in errors:
-            logger.error(f"{demo_name}:")
-            logger.error(f"  {error}")
-            logger.error("")
-        logger.error("=" * 80)
-    else:
-        logger.info("")
-        logger.info(f"✓ All {total} demos completed successfully!")
-        logger.info("")
 
 
 if __name__ == "__main__":

--- a/vultron/demo/exchange/receive_report_demo.py
+++ b/vultron/demo/exchange/receive_report_demo.py
@@ -67,6 +67,7 @@ from vultron.demo.helpers.runner import run_exchange_demos
 from vultron.demo.helpers.verification import (
     verify_activity_in_inbox,
 )  # noqa: F401
+from vultron.demo.helpers.workflow import find_case_by_report_id
 from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monkeypatching
     BASE_URL,
     DataLayerClient,
@@ -76,7 +77,6 @@ from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monk
     get_offer_from_datalayer,
     logfmt,
     post_to_inbox_and_wait,
-    ref_id,
     postfmt,
     verify_object_stored,
     setup_demo_logging,
@@ -117,49 +117,19 @@ def submit_to_inbox(
 def find_case_by_report(
     client: DataLayerClient, report_id: str
 ) -> Optional[as_VulnerabilityCase]:
-    """
-    Finds a as_VulnerabilityCase that references a specific report.
+    """Find the ``as_VulnerabilityCase`` that references *report_id*.
+
+    Public name kept for backward compatibility — imported by
+    ``test/demo/test_find_case_by_report.py``.
 
     Args:
         client: DataLayerClient instance
         report_id: Full URI of the vulnerability report
 
     Returns:
-        as_VulnerabilityCase or None: The case if found, None otherwise
+        The matching case, or ``None`` if not found.
     """
-    cases = client.get("/datalayer/VulnerabilityCases/")
-    if not cases:
-        return None
-
-    for case_data in cases:
-        # Handle case where API returns list of IDs instead of full objects
-        if isinstance(case_data, str):
-            # Fetch the full case object
-            try:
-                case_obj_data = client.get(f"/datalayer/{case_data}")
-                case_obj = as_VulnerabilityCase(**case_obj_data)
-            except Exception as e:
-                logger.warning(f"Failed to fetch case {case_data}: {e}")
-                continue
-        else:
-            # API returned full object
-            case_obj = as_VulnerabilityCase(**case_data)
-
-        # Check if this case references our report
-        if case_obj.vulnerability_reports:
-            # Extract IDs from reports (handle both string IDs and full objects)
-            report_ids = []
-            for r in case_obj.vulnerability_reports:
-                if isinstance(r, str):
-                    report_ids.append(r)
-                else:
-                    report_ids.append(ref_id(r) or str(r))
-
-            if report_id in report_ids:
-                logger.info(f"Found case for report: {logfmt(case_obj)}")
-                return case_obj
-
-    return None
+    return find_case_by_report_id(client, report_id)
 
 
 def demo_validate_report(

--- a/vultron/demo/exchange/status_updates_demo.py
+++ b/vultron/demo/exchange/status_updates_demo.py
@@ -38,7 +38,6 @@ When run as a script, this module will:
 """
 
 import logging
-import sys
 from typing import Optional, Sequence, Tuple
 
 from vultron.wire.as2.vocab.base.objects.activities.transitive import (
@@ -68,12 +67,10 @@ from vultron.core.states.cs import CS_pxa, CS_vfd
 from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monkeypatching
     BASE_URL,
     DataLayerClient,
-    check_server_availability,
     demo_check,
     demo_step,
     get_offer_from_datalayer,
     log_case_state,
-    demo_environment,
     post_to_inbox_and_wait,
     ref_id,
     verify_object_stored,
@@ -91,6 +88,8 @@ from vultron.wire.as2.factories import (
     rm_submit_report_activity,
     rm_validate_report_activity,
 )
+
+from vultron.demo.helpers.runner import run_exchange_demos
 
 logger = logging.getLogger(__name__)
 
@@ -339,66 +338,10 @@ def main(
     skip_health_check: bool = False,
     demos: Optional[Sequence] = None,
 ) -> None:
-    """
-    Main entry point for the status_updates demo script.
-
-    Args:
-        skip_health_check: Skip server availability check (useful for testing)
-        demos: Optional sequence of demo functions to run. Defaults to all.
-    """
-    client = DataLayerClient()
-
-    if not skip_health_check and not check_server_availability(client):
-        logger.error("=" * 80)
-        logger.error("ERROR: API server is not available")
-        logger.error("=" * 80)
-        logger.error(f"Cannot connect to: {client.base_url}")
-        logger.error("")
-        logger.error("Please ensure the Vultron API server is running:")
-        logger.error(
-            "  uv run uvicorn vultron.api.main:app --host localhost --port 7999"
-        )
-        logger.error("=" * 80)
-        sys.exit(1)
-
-    selected = (
-        _ALL_DEMOS
-        if demos is None
-        else [(name, fn) for name, fn in _ALL_DEMOS if fn in demos]
+    """Main entry point for the status updates demo demo script."""
+    run_exchange_demos(
+        _ALL_DEMOS, skip_health_check=skip_health_check, demos=demos
     )
-    total = len(selected)
-    errors = []
-
-    for demo_name, demo_fn in selected:
-        try:
-            with demo_environment(client) as (finder, vendor, coordinator):
-                demo_fn(client, finder, vendor, coordinator)
-        except Exception as e:
-            logger.error(f"{demo_name} failed: {e}", exc_info=True)
-            errors.append((demo_name, str(e)))
-
-    logger.info("=" * 80)
-    logger.info("ALL DEMOS COMPLETE")
-    logger.info("=" * 80)
-
-    if errors:
-        logger.error("")
-        logger.error("=" * 80)
-        logger.error("ERROR SUMMARY")
-        logger.error("=" * 80)
-        logger.error(f"Total demos: {total}")
-        logger.error(f"Failed demos: {len(errors)}")
-        logger.error(f"Successful demos: {total - len(errors)}")
-        logger.error("")
-        for demo_name, error in errors:
-            logger.error(f"{demo_name}:")
-            logger.error(f"  {error}")
-            logger.error("")
-        logger.error("=" * 80)
-    else:
-        logger.info("")
-        logger.info(f"✓ All {total} demos completed successfully!")
-        logger.info("")
 
 
 if __name__ == "__main__":

--- a/vultron/demo/exchange/status_updates_demo.py
+++ b/vultron/demo/exchange/status_updates_demo.py
@@ -58,9 +58,6 @@ from vultron.wire.as2.vocab.objects.case_status import (
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
     as_VulnerabilityCase,
 )
-from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    as_VulnerabilityReport,
-)
 from vultron.core.states.em import EM
 from vultron.core.states.rm import RM
 from vultron.core.states.cs import CS_pxa, CS_vfd
@@ -69,7 +66,6 @@ from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monk
     DataLayerClient,
     demo_check,
     demo_step,
-    get_offer_from_datalayer,
     log_case_state,
     post_to_inbox_and_wait,
     ref_id,
@@ -78,18 +74,15 @@ from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monk
 )
 from vultron.wire.as2.factories import (
     add_note_to_case_activity,
-    add_participant_to_case_activity,
-    add_report_to_case_activity,
     add_status_to_case_activity,
     add_status_to_participant_activity,
-    create_case_activity,
     create_case_status_activity,
     create_status_for_participant_activity,
-    rm_submit_report_activity,
-    rm_validate_report_activity,
 )
 
 from vultron.demo.helpers.runner import run_exchange_demos
+from vultron.demo.helpers.verification import _fetch_participant
+from vultron.demo.helpers.workflow import setup_initialized_case
 
 logger = logging.getLogger(__name__)
 
@@ -99,71 +92,17 @@ def _setup_initialized_case(
     finder: as_Actor,
     vendor: as_Actor,
 ) -> Tuple[as_VulnerabilityCase, as_CaseParticipant]:
+    """Set up a case with one FinderReporter participant.
+
+    Delegates to the shared :func:`~vultron.demo.helpers.workflow.setup_initialized_case`
+    and then looks up the finder's participant record for callers that need it.
     """
-    Set up a case with one FinderReporter participant as a precondition
-    for the status updates workflow.
-
-    Steps:
-    1. Finder submits report to vendor
-    2. Vendor validates report
-    3. Vendor creates case
-    4. Vendor adds report to case
-    5. Vendor creates FinderReporter participant
-    6. Vendor adds participant to case
-    """
-    report = as_VulnerabilityReport(
-        attributed_to=finder.id_,
-        content="A heap buffer overflow in the image parsing library.",
-        name="Heap Buffer Overflow in Image Parser",
-    )
-    report_offer = rm_submit_report_activity(
-        report, actor=finder.id_, to=vendor.id_
-    )
-    post_to_inbox_and_wait(client, vendor.id_, report_offer)
-    verify_object_stored(client, report.id_)
-
-    offer = get_offer_from_datalayer(client, vendor.id_, report_offer.id_)
-    validate_activity = rm_validate_report_activity(
-        offer,
-        actor=vendor.id_,
-        content="Confirmed — heap buffer overflow via malformed image input.",
-    )
-    post_to_inbox_and_wait(client, vendor.id_, validate_activity)
-
-    case = as_VulnerabilityCase(
-        attributed_to=vendor.id_,
-        name="Heap Overflow Case — Image Parser",
-        content="Tracking the heap buffer overflow in the image parsing library.",
-    )
-    create_case_act = create_case_activity(case, actor=vendor.id_)
-    post_to_inbox_and_wait(client, vendor.id_, create_case_act)
-    verify_object_stored(client, case.id_)
-
-    add_report_activity = add_report_to_case_activity(
-        report, actor=vendor.id_, target=case.id_
-    )
-    post_to_inbox_and_wait(client, vendor.id_, add_report_activity)
-
-    participant = as_CaseParticipant(
-        case_roles=[CVDRole.FINDER, CVDRole.REPORTER],
-        attributed_to=finder.id_,
-        context=case.id_,
-    )
-    create_participant_activity = as_Create(
-        actor=vendor.id_,
-        object_=participant,
-        context=case.id_,
-    )
-    post_to_inbox_and_wait(client, vendor.id_, create_participant_activity)
-    verify_object_stored(client, participant.id_)
-
-    add_participant_activity = add_participant_to_case_activity(
-        participant, actor=vendor.id_, target=case.id_
-    )
-    post_to_inbox_and_wait(client, vendor.id_, add_participant_activity)
-
-    log_case_state(client, case.id_, "after setup")
-    logger.info("✓ Setup: Case initialized with one participant")
+    case = setup_initialized_case(client, finder, vendor)
+    participant = _fetch_participant(client, case.id_, finder.id_)
+    if participant is None:
+        raise ValueError(
+            f"Finder participant not found in case {case.id_} after setup"
+        )
     return case, participant
 
 

--- a/vultron/demo/exchange/suggest_actor_demo.py
+++ b/vultron/demo/exchange/suggest_actor_demo.py
@@ -42,116 +42,31 @@ be demonstrated in isolation.
 
 # Standard library imports
 import logging
-import sys
 from typing import Callable, Optional, Sequence, Tuple
 
 # Vultron imports
-from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Create
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
-from vultron.wire.as2.vocab.objects.case_participant import (
-    as_CaseParticipant,
-)
-from vultron.enums.roles import CVDRole
-from vultron.wire.as2.vocab.objects.vulnerability_case import (
-    as_VulnerabilityCase,
-)
-from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    as_VulnerabilityReport,
-)
+from vultron.demo.helpers.runner import run_exchange_demos
+from vultron.demo.helpers.workflow import setup_initialized_case
 from vultron.demo.utils import (  # noqa: F401 — BASE_URL needed for test monkeypatching
     BASE_URL,
     DataLayerClient,
-    check_server_availability,
     demo_check,
     demo_step,
-    get_offer_from_datalayer,
     log_case_state,
     logfmt,
-    demo_environment,
     post_to_inbox_and_wait,
     verify_object_stored,
     setup_demo_logging,
 )
 from vultron.wire.as2.factories import (
     accept_case_participant_offer_activity,
-    add_participant_to_case_activity,
-    add_report_to_case_activity,
-    create_case_activity,
     offer_case_participant_activity,
     recommend_actor_activity,
     reject_case_participant_offer_activity,
-    rm_submit_report_activity,
-    rm_validate_report_activity,
 )
 
 logger = logging.getLogger(__name__)
-
-
-def _setup_initialized_case(
-    client: DataLayerClient,
-    finder: as_Actor,
-    vendor: as_Actor,
-) -> as_VulnerabilityCase:
-    """
-    Set up an initialized case as a precondition for the suggest workflow.
-
-    Mirrors the setup helper in invite_actor_demo but returns the
-    as_VulnerabilityCase so subsequent steps can reference it.
-    """
-    report = as_VulnerabilityReport(
-        attributed_to=finder.id_,
-        content="A remote code execution vulnerability in the web framework.",
-        name="Remote Code Execution Vulnerability",
-    )
-    report_offer = rm_submit_report_activity(
-        report, actor=finder.id_, to=vendor.id_
-    )
-    post_to_inbox_and_wait(client, vendor.id_, report_offer)
-    verify_object_stored(client, report.id_)
-
-    offer = get_offer_from_datalayer(client, vendor.id_, report_offer.id_)
-    validate_activity = rm_validate_report_activity(
-        offer,
-        actor=vendor.id_,
-        content="Confirmed — remote code execution via unsanitized input.",
-    )
-    post_to_inbox_and_wait(client, vendor.id_, validate_activity)
-
-    case = as_VulnerabilityCase(
-        attributed_to=vendor.id_,
-        name="RCE Case — Web Framework",
-        content="Tracking the RCE vulnerability in the web framework.",
-    )
-    create_case_act = create_case_activity(case, actor=vendor.id_)
-    post_to_inbox_and_wait(client, vendor.id_, create_case_act)
-    verify_object_stored(client, case.id_)
-
-    add_report_activity = add_report_to_case_activity(
-        report, actor=vendor.id_, target=case.id_
-    )
-    post_to_inbox_and_wait(client, vendor.id_, add_report_activity)
-
-    participant = as_CaseParticipant(
-        case_roles=[CVDRole.FINDER, CVDRole.REPORTER],
-        attributed_to=finder.id_,
-        context=case.id_,
-    )
-    create_participant_activity = as_Create(
-        actor=vendor.id_,
-        object_=participant,
-        context=case.id_,
-    )
-    post_to_inbox_and_wait(client, vendor.id_, create_participant_activity)
-    verify_object_stored(client, participant.id_)
-
-    add_participant_activity = add_participant_to_case_activity(
-        participant, actor=vendor.id_, target=case.id_
-    )
-    post_to_inbox_and_wait(client, vendor.id_, add_participant_activity)
-
-    log_case_state(client, case.id_, "after setup")
-    logger.info("✓ Setup: Case initialized with report and finder participant")
-    return case
 
 
 def demo_suggest_actor_accept(
@@ -176,7 +91,7 @@ def demo_suggest_actor_accept(
     logger.info("DEMO: Suggest Actor — Accept Path (ADR-0026)")
     logger.info("=" * 80)
 
-    case = _setup_initialized_case(client, finder, vendor)
+    case = setup_initialized_case(client, finder, vendor)
 
     with demo_step(
         "Step 2: Finder sends Offer(Actor, Case) to CaseActor inbox"
@@ -267,7 +182,7 @@ def demo_suggest_actor_reject(
     logger.info("DEMO: Suggest Actor — Reject Path (ADR-0026)")
     logger.info("=" * 80)
 
-    case = _setup_initialized_case(client, finder, vendor)
+    case = setup_initialized_case(client, finder, vendor)
 
     initial_case = log_case_state(client, case.id_, "initial")
     initial_count = len(initial_case.case_participants) if initial_case else 0
@@ -353,66 +268,10 @@ def main(
     skip_health_check: bool = False,
     demos: Optional[Sequence] = None,
 ) -> None:
-    """
-    Main entry point for the suggest_actor demo script.
-
-    Args:
-        skip_health_check: Skip server availability check (useful for testing)
-        demos: Optional sequence of demo functions to run. Defaults to all.
-    """
-    client = DataLayerClient()
-
-    if not skip_health_check and not check_server_availability(client):
-        logger.error("=" * 80)
-        logger.error("ERROR: API server is not available")
-        logger.error("=" * 80)
-        logger.error(f"Cannot connect to: {client.base_url}")
-        logger.error("")
-        logger.error("Please ensure the Vultron API server is running:")
-        logger.error(
-            "  uv run uvicorn vultron.api.main:app --host localhost --port 7999"
-        )
-        logger.error("=" * 80)
-        sys.exit(1)
-
-    selected = (
-        _ALL_DEMOS
-        if demos is None
-        else [(name, fn) for name, fn in _ALL_DEMOS if fn in demos]
+    """Main entry point for the suggest_actor demo script."""
+    run_exchange_demos(
+        _ALL_DEMOS, skip_health_check=skip_health_check, demos=demos
     )
-    total = len(selected)
-    errors = []
-
-    for demo_name, demo_fn in selected:
-        try:
-            with demo_environment(client) as (finder, vendor, coordinator):
-                demo_fn(client, finder, vendor, coordinator)
-        except Exception as e:
-            logger.error(f"{demo_name} failed: {e}", exc_info=True)
-            errors.append((demo_name, str(e)))
-
-    logger.info("=" * 80)
-    logger.info("ALL DEMOS COMPLETE")
-    logger.info("=" * 80)
-
-    if errors:
-        logger.error("")
-        logger.error("=" * 80)
-        logger.error("ERROR SUMMARY")
-        logger.error("=" * 80)
-        logger.error(f"Total demos: {total}")
-        logger.error(f"Failed demos: {len(errors)}")
-        logger.error(f"Successful demos: {total - len(errors)}")
-        logger.error("")
-        for demo_name, error in errors:
-            logger.error(f"{demo_name}:")
-            logger.error(f"  {error}")
-            logger.error("")
-        logger.error("=" * 80)
-    else:
-        logger.info("")
-        logger.info(f"✓ All {total} demos completed successfully!")
-        logger.info("")
 
 
 if __name__ == "__main__":

--- a/vultron/demo/exchange/transfer_ownership_demo.py
+++ b/vultron/demo/exchange/transfer_ownership_demo.py
@@ -45,29 +45,16 @@ inboxes.
 
 # Standard library imports
 import logging
-import sys
 from typing import Callable, Optional, Sequence, Tuple
 
 # Vultron imports
-from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Create
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
-from vultron.wire.as2.vocab.objects.case_participant import (
-    as_CaseParticipant,
-)
-from vultron.enums.roles import CVDRole
-from vultron.wire.as2.vocab.objects.vulnerability_case import (
-    as_VulnerabilityCase,
-)
-from vultron.wire.as2.vocab.objects.vulnerability_report import (
-    as_VulnerabilityReport,
-)
+from vultron.demo.helpers.runner import run_exchange_demos
+from vultron.demo.helpers.workflow import setup_initialized_case
 from vultron.demo.utils import (
     DataLayerClient,
-    check_server_availability,
     demo_check,
     demo_step,
-    demo_environment,
-    get_offer_from_datalayer,
     log_case_state,
     logfmt,
     post_to_inbox_and_wait,
@@ -76,83 +63,11 @@ from vultron.demo.utils import (
 )
 from vultron.wire.as2.factories import (
     accept_case_ownership_transfer_activity,
-    add_participant_to_case_activity,
-    add_report_to_case_activity,
-    create_case_activity,
     offer_case_ownership_transfer_activity,
     reject_case_ownership_transfer_activity,
-    rm_submit_report_activity,
-    rm_validate_report_activity,
 )
 
 logger = logging.getLogger(__name__)
-
-
-def _setup_initialized_case(
-    client: DataLayerClient,
-    finder: as_Actor,
-    vendor: as_Actor,
-) -> as_VulnerabilityCase:
-    """
-    Set up an initialized case as a precondition for the transfer workflow.
-
-    Mirrors the setup helper in invite_actor_demo but returns the
-    as_VulnerabilityCase so subsequent steps can reference it.
-    """
-    report = as_VulnerabilityReport(
-        attributed_to=finder.id_,
-        content="A remote code execution vulnerability in the web framework.",
-        name="Remote Code Execution Vulnerability",
-    )
-    report_offer = rm_submit_report_activity(
-        report, actor=finder.id_, to=vendor.id_
-    )
-    post_to_inbox_and_wait(client, vendor.id_, report_offer)
-    verify_object_stored(client, report.id_)
-
-    offer = get_offer_from_datalayer(client, vendor.id_, report_offer.id_)
-    validate_activity = rm_validate_report_activity(
-        offer,
-        actor=vendor.id_,
-        content="Confirmed — remote code execution via unsanitized input.",
-    )
-    post_to_inbox_and_wait(client, vendor.id_, validate_activity)
-
-    case = as_VulnerabilityCase(
-        attributed_to=vendor.id_,
-        name="RCE Case — Web Framework",
-        content="Tracking the RCE vulnerability in the web framework.",
-    )
-    create_case_act = create_case_activity(case, actor=vendor.id_)
-    post_to_inbox_and_wait(client, vendor.id_, create_case_act)
-    verify_object_stored(client, case.id_)
-
-    add_report_activity = add_report_to_case_activity(
-        report, actor=vendor.id_, target=case.id_
-    )
-    post_to_inbox_and_wait(client, vendor.id_, add_report_activity)
-
-    participant = as_CaseParticipant(
-        case_roles=[CVDRole.FINDER, CVDRole.REPORTER],
-        attributed_to=finder.id_,
-        context=case.id_,
-    )
-    create_participant_activity = as_Create(
-        actor=vendor.id_,
-        object_=participant,
-        context=case.id_,
-    )
-    post_to_inbox_and_wait(client, vendor.id_, create_participant_activity)
-    verify_object_stored(client, participant.id_)
-
-    add_participant_activity = add_participant_to_case_activity(
-        participant, actor=vendor.id_, target=case.id_
-    )
-    post_to_inbox_and_wait(client, vendor.id_, add_participant_activity)
-
-    log_case_state(client, case.id_, "after setup")
-    logger.info("✓ Setup: Case initialized with report and finder participant")
-    return case
 
 
 def demo_transfer_ownership_accept(
@@ -179,7 +94,7 @@ def demo_transfer_ownership_accept(
     logger.info("DEMO: Transfer Ownership — Accept Path")
     logger.info("=" * 80)
 
-    case = _setup_initialized_case(client, finder, vendor)
+    case = setup_initialized_case(client, finder, vendor)
 
     # Confirm initial owner is vendor
     initial_case = log_case_state(client, case.id_, "initial")
@@ -250,7 +165,7 @@ def demo_transfer_ownership_reject(
     logger.info("DEMO: Transfer Ownership — Reject Path")
     logger.info("=" * 80)
 
-    case = _setup_initialized_case(client, finder, vendor)
+    case = setup_initialized_case(client, finder, vendor)
 
     initial_case = log_case_state(client, case.id_, "initial")
     if initial_case is None:
@@ -309,66 +224,10 @@ def main(
     skip_health_check: bool = False,
     demos: Optional[Sequence] = None,
 ) -> None:
-    """
-    Main entry point for the transfer_ownership demo script.
-
-    Args:
-        skip_health_check: Skip server availability check (useful for testing)
-        demos: Optional sequence of demo functions to run. Defaults to all.
-    """
-    client = DataLayerClient()
-
-    if not skip_health_check and not check_server_availability(client):
-        logger.error("=" * 80)
-        logger.error("ERROR: API server is not available")
-        logger.error("=" * 80)
-        logger.error(f"Cannot connect to: {client.base_url}")
-        logger.error("")
-        logger.error("Please ensure the Vultron API server is running:")
-        logger.error(
-            "  uv run uvicorn vultron.api.main:app --host localhost --port 7999"
-        )
-        logger.error("=" * 80)
-        sys.exit(1)
-
-    selected = (
-        _ALL_DEMOS
-        if demos is None
-        else [(name, fn) for name, fn in _ALL_DEMOS if fn in demos]
+    """Main entry point for the transfer_ownership demo script."""
+    run_exchange_demos(
+        _ALL_DEMOS, skip_health_check=skip_health_check, demos=demos
     )
-    total = len(selected)
-    errors = []
-
-    for demo_name, demo_fn in selected:
-        try:
-            with demo_environment(client) as (finder, vendor, coordinator):
-                demo_fn(client, finder, vendor, coordinator)
-        except Exception as e:
-            logger.error(f"{demo_name} failed: {e}", exc_info=True)
-            errors.append((demo_name, str(e)))
-
-    logger.info("=" * 80)
-    logger.info("ALL DEMOS COMPLETE")
-    logger.info("=" * 80)
-
-    if errors:
-        logger.error("")
-        logger.error("=" * 80)
-        logger.error("ERROR SUMMARY")
-        logger.error("=" * 80)
-        logger.error(f"Total demos: {total}")
-        logger.error(f"Failed demos: {len(errors)}")
-        logger.error(f"Successful demos: {total - len(errors)}")
-        logger.error("")
-        for demo_name, error in errors:
-            logger.error(f"{demo_name}:")
-            logger.error(f"  {error}")
-            logger.error("")
-        logger.error("=" * 80)
-    else:
-        logger.info("")
-        logger.info(f"✓ All {total} demos completed successfully!")
-        logger.info("")
 
 
 if __name__ == "__main__":

--- a/vultron/demo/exchange/trigger_demo.py
+++ b/vultron/demo/exchange/trigger_demo.py
@@ -39,7 +39,6 @@ the response body and that the vendor's outbox is updated accordingly.
 
 import json
 import logging
-import sys
 from typing import Callable, Optional, Sequence, Tuple
 
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
@@ -52,9 +51,7 @@ from vultron.wire.as2.vocab.objects.vulnerability_report import (
 )
 from vultron.demo.utils import (
     DataLayerClient,
-    check_server_availability,
     demo_check,
-    demo_environment,
     demo_step,
     get_offer_from_datalayer,
     post_to_inbox_and_wait,
@@ -65,6 +62,8 @@ from vultron.demo.utils import (
 from vultron.wire.as2.factories import (
     rm_submit_report_activity,
 )
+
+from vultron.demo.helpers.runner import run_exchange_demos
 
 logger = logging.getLogger(__name__)
 
@@ -130,7 +129,10 @@ def _find_case_for_report(
 
 
 def demo_validate_and_engage(
-    client: DataLayerClient, finder: as_Actor, vendor: as_Actor
+    client: DataLayerClient,
+    finder: as_Actor,
+    vendor: as_Actor,
+    coordinator: Optional[as_Actor] = None,
 ) -> None:
     """Demonstrate proactive validation and case engagement via trigger endpoints.
 
@@ -211,7 +213,10 @@ def demo_validate_and_engage(
 
 
 def demo_invalidate_and_close(
-    client: DataLayerClient, finder: as_Actor, vendor: as_Actor
+    client: DataLayerClient,
+    finder: as_Actor,
+    vendor: as_Actor,
+    coordinator: Optional[as_Actor] = None,
 ) -> None:
     """Demonstrate proactive invalidation and report closure via trigger endpoints.
 
@@ -299,68 +304,10 @@ def main(
     skip_health_check: bool = False,
     demos: Optional[Sequence] = None,
 ) -> None:
-    """Main entry point for the trigger demo.
-
-    Args:
-        skip_health_check: Skip the server availability check (useful for
-            testing).
-        demos: Optional sequence of demo functions to run.  Defaults to all
-            two.
-    """
-    client = DataLayerClient()
-
-    if not skip_health_check and not check_server_availability(client):
-        logger.error("=" * 80)
-        logger.error("ERROR: API server is not available")
-        logger.error("=" * 80)
-        logger.error(f"Cannot connect to: {client.base_url}")
-        logger.error("Please ensure the Vultron API server is running.")
-        logger.error("You can start it with:")
-        logger.error(
-            "  uv run uvicorn vultron.api.main:app --host localhost --port 7999"
-        )
-        logger.error("=" * 80)
-        sys.exit(1)
-
-    selected = (
-        _ALL_DEMOS
-        if demos is None
-        else [(name, fn) for name, fn in _ALL_DEMOS if fn in demos]
+    """Main entry point for the trigger demo demo script."""
+    run_exchange_demos(
+        _ALL_DEMOS, skip_health_check=skip_health_check, demos=demos
     )
-    total = len(selected)
-    errors = []
-
-    for demo_name, demo_fn in selected:
-        try:
-            with demo_environment(client) as (finder, vendor, _coordinator):
-                demo_fn(client, finder, vendor)
-        except Exception as exc:
-            logger.error("%s failed: %s", demo_name, exc, exc_info=True)
-            errors.append((demo_name, str(exc)))
-
-    logger.info("=" * 80)
-    logger.info("ALL TRIGGER DEMOS COMPLETE")
-    logger.info("=" * 80)
-
-    if errors:
-        logger.error("")
-        logger.error("=" * 80)
-        logger.error("ERROR SUMMARY")
-        logger.error("=" * 80)
-        logger.error("Total demos: %d", total)
-        logger.error("Failed demos: %d", len(errors))
-        logger.error("Successful demos: %d", total - len(errors))
-        logger.error("")
-        for demo_name, error in errors:
-            logger.error("%s:", demo_name)
-            logger.error("  %s", error)
-            logger.error("")
-        logger.error("=" * 80)
-        sys.exit(1)
-    else:
-        logger.info("")
-        logger.info("✓ All %d trigger demos completed successfully!", total)
-        logger.info("")
 
 
 if __name__ == "__main__":

--- a/vultron/demo/exchange/trigger_demo.py
+++ b/vultron/demo/exchange/trigger_demo.py
@@ -43,9 +43,6 @@ from typing import Callable, Optional, Sequence, Tuple
 
 from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
-from vultron.wire.as2.vocab.objects.vulnerability_case import (
-    as_VulnerabilityCase,
-)
 from vultron.wire.as2.vocab.objects.vulnerability_report import (
     as_VulnerabilityReport,
 )
@@ -64,6 +61,7 @@ from vultron.wire.as2.factories import (
 )
 
 from vultron.demo.helpers.runner import run_exchange_demos
+from vultron.demo.helpers.workflow import find_case_for_offer
 
 logger = logging.getLogger(__name__)
 
@@ -95,32 +93,6 @@ def _submit_report(
         verify_object_stored(client, report.id_)
         verify_object_stored(client, offer.id_)
     return report, offer
-
-
-def _find_case_for_report(
-    client: DataLayerClient, report_id: str
-) -> Optional[as_VulnerabilityCase]:
-    """Return the first as_VulnerabilityCase referencing *report_id*, or None."""
-    cases = client.get("/datalayer/VulnerabilityCases/")
-    if not cases:
-        return None
-    for item in cases:
-        if isinstance(item, str):
-            try:
-                data = client.get(f"/datalayer/{item}")
-                case = as_VulnerabilityCase(**data)
-            except Exception as exc:
-                logger.warning("Could not fetch case %s: %s", item, exc)
-                continue
-        else:
-            case = as_VulnerabilityCase(**item)
-        report_ids = [
-            r if isinstance(r, str) else getattr(r, "id_", str(r))
-            for r in (case.vulnerability_reports or [])
-        ]
-        if report_id in report_ids:
-            return case
-    return None
 
 
 # ---------------------------------------------------------------------------
@@ -177,11 +149,9 @@ def demo_validate_and_engage(
             logger.info("Resulting activity type: %s", activity.get("type"))
 
     with demo_step("Step 3: Vendor triggers engage-case"):
-        case = _find_case_for_report(client, report.id_)
+        case = find_case_for_offer(client, stored_offer.id_)
         with demo_check("Case created by validate-report BT"):
-            assert (
-                case is not None
-            ), f"No as_VulnerabilityCase found for report {report.id_}"
+            assert case is not None, f"No case found for report {report.id_}"
             logger.info("Found case: %s", case.id_)
 
         response = post_to_trigger(

--- a/vultron/demo/helpers/__init__.py
+++ b/vultron/demo/helpers/__init__.py
@@ -34,8 +34,8 @@ Sub-modules
   ``verify_receiver_case_state``, and ``verify_case_actor_unused``.
 - :mod:`~vultron.demo.helpers.workflow` — ``reporter_submits_report``,
   ``receiver_validates_report``, ``receiver_engages_case``,
-  ``find_case_for_offer``, ``setup_initialized_case``, and
-  ``setup_two_participant_case``.
+  ``find_case_by_report_id``, ``find_case_for_offer``,
+  ``setup_initialized_case``, and ``setup_two_participant_case``.
 - :mod:`~vultron.demo.helpers.notes` — ``participant_adds_note_to_case``.
 - :mod:`~vultron.demo.helpers.milestones` — lifecycle milestone verifiers
   (``verify_case_active``, ``verify_fix_ready``, ``verify_fix_deployed``,
@@ -109,6 +109,7 @@ from vultron.demo.helpers.verification import (  # noqa: F401
 from vultron.demo.helpers.workflow import (  # noqa: F401
     _load_case_from_datalayer,
     _report_id_from_offer_data,
+    find_case_by_report_id,
     find_case_for_offer,
     receiver_engages_case,
     receiver_validates_report,

--- a/vultron/demo/helpers/__init__.py
+++ b/vultron/demo/helpers/__init__.py
@@ -22,16 +22,20 @@ Sub-modules
   ``wait_for_*`` helpers.
 - :mod:`~vultron.demo.helpers.actions` — ``actor_notifies_state_change``
   and named CVD lifecycle action wrappers.
+- :mod:`~vultron.demo.helpers.embargo` — ``make_embargo_event`` factory.
+- :mod:`~vultron.demo.helpers.runner` — ``run_exchange_demos`` and
+  ``check_all_containers``.
 - :mod:`~vultron.demo.helpers.seeding` — ``_dl_key``, ``get_actor_by_id``,
   ``seed_containers``, ``seed_containers_fvv``, and ``reset_containers``.
 - :mod:`~vultron.demo.helpers.sync` — SYNC-2 ``trigger_log_commit`` and
   ``verify_replica_state``.
 - :mod:`~vultron.demo.helpers.verification` — lower-level participant and
-  case-state assertion primitives, plus ``verify_receiver_case_state``
-  and ``verify_case_actor_unused``.
+  case-state assertion primitives, plus ``verify_activity_in_inbox``,
+  ``verify_receiver_case_state``, and ``verify_case_actor_unused``.
 - :mod:`~vultron.demo.helpers.workflow` — ``reporter_submits_report``,
-  ``receiver_validates_report``, ``receiver_engages_case``, and
-  ``find_case_for_offer``.
+  ``receiver_validates_report``, ``receiver_engages_case``,
+  ``find_case_for_offer``, ``setup_initialized_case``, and
+  ``setup_two_participant_case``.
 - :mod:`~vultron.demo.helpers.notes` — ``participant_adds_note_to_case``.
 - :mod:`~vultron.demo.helpers.milestones` — lifecycle milestone verifiers
   (``verify_case_active``, ``verify_fix_ready``, ``verify_fix_deployed``,
@@ -44,6 +48,13 @@ from vultron.demo.helpers.actions import (  # noqa: F401
     actor_notifies_fix_ready,
     actor_notifies_published,
     actor_notifies_state_change,
+)
+from vultron.demo.helpers.embargo import (  # noqa: F401
+    make_embargo_event,
+)
+from vultron.demo.helpers.runner import (  # noqa: F401
+    check_all_containers,
+    run_exchange_demos,
 )
 from vultron.demo.helpers.milestones import (  # noqa: F401
     verify_case_active,
@@ -91,6 +102,7 @@ from vultron.demo.helpers.verification import (  # noqa: F401
     _fetch_participant,
     _fetch_participant_data,
     _require_case_participant_id,
+    verify_activity_in_inbox,
     verify_case_actor_unused,
     verify_receiver_case_state,
 )
@@ -101,4 +113,6 @@ from vultron.demo.helpers.workflow import (  # noqa: F401
     receiver_engages_case,
     receiver_validates_report,
     reporter_submits_report,
+    setup_initialized_case,
+    setup_two_participant_case,
 )

--- a/vultron/demo/helpers/embargo.py
+++ b/vultron/demo/helpers/embargo.py
@@ -1,0 +1,61 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Embargo object factory helpers shared across demo scenarios."""
+
+from datetime import datetime, timedelta
+from typing import Optional
+
+from vultron.wire.as2.vocab.objects.embargo_event import as_EmbargoEvent
+from vultron.wire.as2.vocab.objects.vulnerability_case import (
+    as_VulnerabilityCase,
+)
+
+
+def make_embargo_event(
+    case: as_VulnerabilityCase,
+    days: int = 90,
+    seq: Optional[int] = None,
+) -> as_EmbargoEvent:
+    """Create a deterministic :class:`as_EmbargoEvent` for *case*.
+
+    The event's ``id_`` encodes the duration and end-date so it is unique
+    per case/duration pair.  Pass *seq* to distinguish multiple events with
+    the same duration within a single case (e.g., in the reject-then-repropose
+    demo where two embargo events differ only by sequence number).
+
+    Args:
+        case: The :class:`as_VulnerabilityCase` this embargo event belongs to.
+        days: Embargo duration in days (default 90).
+        seq: Optional integer sequence suffix appended to the event ID to
+            ensure uniqueness within a multi-proposal workflow.  When
+            ``None`` the suffix is omitted.
+
+    Returns:
+        A new :class:`as_EmbargoEvent` with start/end times set.
+    """
+    now = datetime.now().astimezone()
+    now = now.replace(second=0, microsecond=0)
+    end_at = (now + timedelta(days=days)).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    end_date_str = end_at.strftime("%Y-%m-%d")
+    suffix = f"-{seq}" if seq is not None else ""
+    return as_EmbargoEvent(
+        id_=f"{case.id_}/embargo_events/{days}d-{end_date_str}{suffix}",
+        name=f"Embargo for {case.name}",
+        context=case.id_,
+        start_time=now,
+        end_time=end_at,
+        content=f"Proposed {days}-day embargo for {case.name}.",
+    )

--- a/vultron/demo/helpers/polling.py
+++ b/vultron/demo/helpers/polling.py
@@ -153,20 +153,19 @@ def wait_for_case_participants(
         AssertionError: If the participant count is not reached within
             *timeout_seconds*.
     """
-    deadline = time.monotonic() + timeout_seconds
-    while time.monotonic() < deadline:
+
+    def _check() -> bool:
         case_data = vendor_client.get(f"/datalayer/{case_id}")
         case = as_VulnerabilityCase(**case_data)
-        if len(case.case_participants) >= expected_count:
-            return
-        time.sleep(poll_interval)
+        return len(case.case_participants) >= expected_count
 
-    final_case = as_VulnerabilityCase(
-        **vendor_client.get(f"/datalayer/{case_id}")
-    )
-    raise AssertionError(
-        "Timed out waiting for participant count "
-        f"{expected_count}; found {len(final_case.case_participants)}"
+    _poll_until(
+        _check,
+        timeout_seconds,
+        poll_interval,
+        f"Timed out waiting for participant count {expected_count} in case "
+        f"{case_id!r}",
+        swallow_exceptions=True,
     )
 
 

--- a/vultron/demo/helpers/runner.py
+++ b/vultron/demo/helpers/runner.py
@@ -1,0 +1,134 @@
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+
+"""Demo runner helpers shared across exchange demos.
+
+Provides :func:`run_exchange_demos` for the standard ``main()`` loop used
+by every exchange demo module, and :func:`check_all_containers` for
+multi-container health checks used by scenario demos.
+"""
+
+import logging
+import sys
+from typing import Callable, Optional, Sequence, Tuple
+
+from vultron.demo.utils import (
+    DataLayerClient,
+    check_server_availability,
+    demo_environment,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def run_exchange_demos(
+    all_demos: Sequence[Tuple[str, Callable]],
+    skip_health_check: bool = False,
+    demos: Optional[Sequence] = None,
+) -> None:
+    """Run an exchange demo module's demo suite.
+
+    This is the standard ``main()`` body shared by all exchange demo modules.
+    It performs a health check (unless skipped), iterates over the selected
+    demo functions inside a fresh :func:`~vultron.demo.utils.demo_environment`
+    context for each demo, accumulates errors, and logs a summary.
+
+    Each demo callable must accept
+    ``(client, finder, vendor, coordinator)`` as positional arguments.
+
+    Args:
+        all_demos: Sequence of ``(name, callable)`` pairs — the module-level
+            ``_ALL_DEMOS`` list.
+        skip_health_check: When ``True``, skip the server availability check.
+            Useful in integration tests where the server is already known
+            to be running.
+        demos: Optional subset of demo *callables* to run.  When provided,
+            only entries whose callable appears in this sequence are executed.
+            When ``None``, all entries in *all_demos* are run.
+    """
+    client = DataLayerClient()
+
+    if not skip_health_check and not check_server_availability(client):
+        logger.error("=" * 80)
+        logger.error("ERROR: API server is not available")
+        logger.error("=" * 80)
+        logger.error("Cannot connect to: %s", client.base_url)
+        logger.error("")
+        logger.error("Please ensure the Vultron API server is running:")
+        logger.error(
+            "  uv run uvicorn vultron.api.main:app --host localhost --port 7999"
+        )
+        logger.error("=" * 80)
+        sys.exit(1)
+
+    selected = (
+        all_demos
+        if demos is None
+        else [(name, fn) for name, fn in all_demos if fn in demos]
+    )
+    total = len(selected)
+    errors = []
+
+    for demo_name, demo_fn in selected:
+        try:
+            with demo_environment(client) as (finder, vendor, coordinator):
+                demo_fn(client, finder, vendor, coordinator)
+        except Exception as e:
+            logger.error("%s failed: %s", demo_name, e, exc_info=True)
+            errors.append((demo_name, str(e)))
+
+    logger.info("=" * 80)
+    logger.info("ALL DEMOS COMPLETE")
+    logger.info("=" * 80)
+
+    if errors:
+        logger.error("")
+        logger.error("=" * 80)
+        logger.error("ERROR SUMMARY")
+        logger.error("=" * 80)
+        logger.error("Total demos: %d", total)
+        logger.error("Failed demos: %d", len(errors))
+        logger.error("Successful demos: %d", total - len(errors))
+        logger.error("")
+        for demo_name, error in errors:
+            logger.error("%s:", demo_name)
+            logger.error("  %s", error)
+            logger.error("")
+        logger.error("=" * 80)
+    else:
+        logger.info("")
+        logger.info("✓ All %d demos completed successfully!", total)
+        logger.info("")
+
+
+def check_all_containers(
+    labeled_clients: Sequence[Tuple[str, DataLayerClient]],
+) -> None:
+    """Check availability of all containers, exiting with status 1 on failure.
+
+    Args:
+        labeled_clients: Sequence of ``(label, client)`` pairs.  *label* is
+            used only in error messages; *client* provides the ``base_url``
+            to health-check.
+
+    Raises:
+        SystemExit: If any container is not reachable.
+    """
+    for label, client in labeled_clients:
+        if not check_server_availability(client):
+            logger.error(
+                "Container '%s' is not reachable at %s",
+                label,
+                client.base_url,
+            )
+            sys.exit(1)

--- a/vultron/demo/helpers/verification.py
+++ b/vultron/demo/helpers/verification.py
@@ -23,6 +23,7 @@ from typing import Optional
 
 import httpx2 as httpx
 
+from vultron.adapters.utils import parse_id
 from vultron.core.states.cs import (
     CS_pxa,
     CS_vfd,
@@ -33,8 +34,8 @@ from vultron.core.states.cs import (
 from vultron.core.states.em import is_em_embargo_active
 from vultron.core.states.rm import RM
 from vultron.enums.roles import CVDRole
-from vultron.demo.helpers.seeding import _dl_key
-from vultron.demo.utils import DataLayerClient, ref_id
+from vultron.demo.helpers.seeding import _dl_key, get_actor_by_id
+from vultron.demo.utils import DataLayerClient, logfmt, ref_id
 from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
     as_VulnerabilityCase,
@@ -301,6 +302,42 @@ def _all_fetchable_participants_rm_closed(
         if latest.rm_state != RM.CLOSED:
             return False
     return True
+
+
+def verify_activity_in_inbox(
+    client: DataLayerClient,
+    actor_id: str,
+    activity_id: str,
+) -> bool:
+    """Check whether *activity_id* appears in the actor's inbox.
+
+    Args:
+        client: DataLayerClient for the target container.
+        actor_id: Full URI of the actor whose inbox to check.
+        activity_id: Full URI of the activity to find.
+
+    Returns:
+        ``True`` if found; ``False`` otherwise.
+
+    Raises:
+        ValueError: If the actor cannot be found or has no inbox.
+    """
+    actor = get_actor_by_id(client, actor_id)
+    if not actor.inbox:
+        raise ValueError(f"Actor {actor_id} has no inbox")
+    actor_obj_id = parse_id(actor_id)["object_id"]
+    logger.info(
+        "Actor %s inbox has %d items",
+        actor_obj_id,
+        len(actor.inbox.items),
+    )
+    for item in actor.inbox.items:
+        item_id = item if isinstance(item, str) else getattr(item, "id_", None)
+        if item_id == activity_id:
+            logger.info("✓ Found activity in inbox: %s", logfmt(item))
+            return True
+    logger.warning("Activity %s not found in inbox", activity_id)
+    return False
 
 
 def verify_receiver_case_state(

--- a/vultron/demo/helpers/workflow.py
+++ b/vultron/demo/helpers/workflow.py
@@ -264,6 +264,41 @@ def _load_case_from_datalayer(
         return None
 
 
+def find_case_by_report_id(
+    client: DataLayerClient,
+    report_id: str,
+) -> Optional[as_VulnerabilityCase]:
+    """Find the first ``as_VulnerabilityCase`` referencing *report_id*.
+
+    Args:
+        client: DataLayerClient connected to the container holding the case.
+        report_id: Full URI of the ``as_VulnerabilityReport``.
+
+    Returns:
+        The matching ``as_VulnerabilityCase``, or ``None`` if not found.
+    """
+    cases_data = client.get("/datalayer/VulnerabilityCases/")
+    if not cases_data:
+        return None
+
+    for item in cases_data:
+        case = _load_case_from_datalayer(client, item)
+        if case is None:
+            continue
+
+        report_ids = [
+            (
+                report
+                if isinstance(report, str)
+                else getattr(report, "id_", str(report))
+            )
+            for report in (case.vulnerability_reports or [])
+        ]
+        if report_id in report_ids:
+            return case
+    return None
+
+
 def find_case_for_offer(
     client: DataLayerClient,
     offer_id: str,
@@ -285,26 +320,7 @@ def find_case_for_offer(
     if not report_id:
         return None
 
-    cases_data = client.get("/datalayer/VulnerabilityCases/")
-    if not cases_data:
-        return None
-
-    for item in cases_data:
-        case = _load_case_from_datalayer(client, item)
-        if case is None:
-            continue
-
-        report_ids = [
-            (
-                report
-                if isinstance(report, str)
-                else getattr(report, "id_", str(report))
-            )
-            for report in (case.vulnerability_reports or [])
-        ]
-        if report_id in report_ids:
-            return case
-    return None
+    return find_case_by_report_id(client, report_id)
 
 
 def setup_initialized_case(

--- a/vultron/demo/helpers/workflow.py
+++ b/vultron/demo/helpers/workflow.py
@@ -28,17 +28,30 @@ from vultron.demo.utils import (
     DataLayerClient,
     demo_check,
     demo_step,
+    get_offer_from_datalayer,
+    log_case_state,
     post_to_inbox_and_wait,
     post_to_trigger,
     ref_id,
     verify_object_stored,
 )
+from vultron.enums.roles import CVDRole
 from vultron.wire.as2.factories import (
+    add_participant_to_case_activity,
+    add_report_to_case_activity,
+    create_case_activity,
     parse_submit_report_offer,
+    rm_accept_invite_to_case_activity,
+    rm_invite_to_case_activity,
     rm_submit_report_activity,
+    rm_validate_report_activity,
 )
-from vultron.wire.as2.vocab.base.objects.activities.transitive import as_Offer
+from vultron.wire.as2.vocab.base.objects.activities.transitive import (
+    as_Create,
+    as_Offer,
+)
 from vultron.wire.as2.vocab.base.objects.actors import as_Actor
+from vultron.wire.as2.vocab.objects.case_participant import as_CaseParticipant
 from vultron.wire.as2.vocab.objects.vulnerability_case import (
     as_VulnerabilityCase,
 )
@@ -292,3 +305,188 @@ def find_case_for_offer(
         if report_id in report_ids:
             return case
     return None
+
+
+def setup_initialized_case(
+    client: DataLayerClient,
+    finder: as_Actor,
+    vendor: as_Actor,
+) -> as_VulnerabilityCase:
+    """Create a fully initialised case ready for invitation/suggestion workflows.
+
+    Performs the standard 7-step setup shared by ``invite_actor_demo``,
+    ``suggest_actor_demo``, and ``transfer_ownership_demo``:
+
+    1. Finder submits report → vendor inbox
+    2. Vendor validates the report
+    3. Vendor creates the case
+    4. Vendor adds the report to the case
+    5. Vendor creates the finder participant record
+    6. Vendor adds the finder participant to the case
+    7. Logs final case state
+
+    Args:
+        client: DataLayerClient for the shared (or single) container.
+        finder: The finder/reporter ``as_Actor``.
+        vendor: The receiving vendor ``as_Actor`` who creates the case.
+
+    Returns:
+        The newly created ``as_VulnerabilityCase``.
+    """
+    report = as_VulnerabilityReport(
+        attributed_to=finder.id_,
+        content="A remote code execution vulnerability in the web framework.",
+        name="Remote Code Execution Vulnerability",
+    )
+    report_offer = rm_submit_report_activity(
+        report, actor=finder.id_, to=vendor.id_
+    )
+    post_to_inbox_and_wait(client, vendor.id_, report_offer)
+    verify_object_stored(client, report.id_)
+
+    offer = get_offer_from_datalayer(client, vendor.id_, report_offer.id_)
+    validate_activity = rm_validate_report_activity(
+        offer,
+        actor=vendor.id_,
+        content="Confirmed — remote code execution via unsanitized input.",
+    )
+    post_to_inbox_and_wait(client, vendor.id_, validate_activity)
+
+    case = as_VulnerabilityCase(
+        attributed_to=vendor.id_,
+        name="RCE Case — Web Framework",
+        content="Tracking the RCE vulnerability in the web framework.",
+    )
+    create_case_act = create_case_activity(case, actor=vendor.id_)
+    post_to_inbox_and_wait(client, vendor.id_, create_case_act)
+    verify_object_stored(client, case.id_)
+
+    add_report_activity = add_report_to_case_activity(
+        report, actor=vendor.id_, target=case.id_
+    )
+    post_to_inbox_and_wait(client, vendor.id_, add_report_activity)
+
+    participant = as_CaseParticipant(
+        case_roles=[CVDRole.FINDER, CVDRole.REPORTER],
+        attributed_to=finder.id_,
+        context=case.id_,
+    )
+    create_participant_activity = as_Create(
+        actor=vendor.id_,
+        object_=participant,
+        context=case.id_,
+    )
+    post_to_inbox_and_wait(client, vendor.id_, create_participant_activity)
+    verify_object_stored(client, participant.id_)
+
+    add_participant_activity = add_participant_to_case_activity(
+        participant, actor=vendor.id_, target=case.id_
+    )
+    post_to_inbox_and_wait(client, vendor.id_, add_participant_activity)
+
+    log_case_state(client, case.id_, "after setup")
+    logger.info("✓ Setup: Case initialized with report and finder participant")
+    return case
+
+
+def setup_two_participant_case(
+    client: DataLayerClient,
+    finder: as_Actor,
+    vendor: as_Actor,
+    coordinator: as_Actor,
+) -> as_VulnerabilityCase:
+    """Create a case with two participants (vendor + coordinator) as a precondition.
+
+    Performs the 6-step shared setup used by ``establish_embargo_demo`` and
+    ``manage_embargo_demo``:
+
+    1. Finder submits report → vendor inbox
+    2. Vendor validates the report
+    3. Vendor creates the case
+    4. Vendor adds the report to the case
+    5. Vendor creates and adds the finder participant
+    6. Vendor invites coordinator; coordinator accepts → coordinator added
+
+    Args:
+        client: DataLayerClient for the shared (or single) container.
+        finder: The finder/reporter ``as_Actor``.
+        vendor: The receiving vendor ``as_Actor`` who creates the case.
+        coordinator: The coordinator ``as_Actor`` to invite.
+
+    Returns:
+        The newly created ``as_VulnerabilityCase`` with vendor and coordinator
+        as participants.
+    """
+    report = as_VulnerabilityReport(
+        attributed_to=finder.id_,
+        content="A use-after-free vulnerability in the network stack.",
+        name="Use-After-Free in Network Stack",
+    )
+    report_offer = rm_submit_report_activity(
+        report, actor=finder.id_, to=vendor.id_
+    )
+    post_to_inbox_and_wait(client, vendor.id_, report_offer)
+    verify_object_stored(client, report.id_)
+
+    offer = get_offer_from_datalayer(client, vendor.id_, report_offer.id_)
+    validate_activity = rm_validate_report_activity(
+        offer,
+        actor=vendor.id_,
+        content="Confirmed — use-after-free via unsanitized network input.",
+    )
+    post_to_inbox_and_wait(client, vendor.id_, validate_activity)
+
+    case = as_VulnerabilityCase(
+        attributed_to=vendor.id_,
+        name="UAF Case — Network Stack",
+        content="Tracking the use-after-free vulnerability in the network stack.",
+    )
+    create_case_act = create_case_activity(case, actor=vendor.id_)
+    post_to_inbox_and_wait(client, vendor.id_, create_case_act)
+    verify_object_stored(client, case.id_)
+
+    add_report_activity = add_report_to_case_activity(
+        report, actor=vendor.id_, target=case.id_
+    )
+    post_to_inbox_and_wait(client, vendor.id_, add_report_activity)
+
+    participant = as_CaseParticipant(
+        case_roles=[CVDRole.FINDER, CVDRole.REPORTER],
+        attributed_to=finder.id_,
+        context=case.id_,
+    )
+    create_participant_activity = as_Create(
+        actor=vendor.id_,
+        object_=participant,
+        context=case.id_,
+    )
+    post_to_inbox_and_wait(client, vendor.id_, create_participant_activity)
+    verify_object_stored(client, participant.id_)
+
+    add_participant_activity = add_participant_to_case_activity(
+        participant, actor=vendor.id_, target=case.id_
+    )
+    post_to_inbox_and_wait(client, vendor.id_, add_participant_activity)
+
+    invite = rm_invite_to_case_activity(
+        coordinator,
+        actor=vendor.id_,
+        target=case.id_,
+        to=[coordinator.id_],
+        content=f"Inviting you to participate in {case.name}.",
+    )
+    post_to_inbox_and_wait(client, coordinator.id_, invite)
+
+    accept = rm_accept_invite_to_case_activity(
+        invite,
+        actor=coordinator.id_,
+        to=[vendor.id_],
+        content=f"Accepting invitation to {case.name}.",
+    )
+    post_to_inbox_and_wait(client, vendor.id_, accept)
+
+    log_case_state(client, case.id_, "after setup (two participants)")
+    logger.info(
+        "✓ Setup: Case initialized with vendor and coordinator participants"
+    )
+    return case


### PR DESCRIPTION
## Summary

- **New `helpers/runner.py`**: `run_exchange_demos()` centralised runner eliminates the duplicated health-check / `demo_environment` / error-accumulation boilerplate that lived in every exchange demo's `main()`. `check_all_containers()` handles multi-container health checks.
- **New `helpers/embargo.py`**: `make_embargo_event()` factory unifies two previously-diverged local `_make_embargo_event()` functions from `establish_embargo_demo` and `manage_embargo_demo`. `seq=None|int` controls whether an ID suffix is appended.
- **`helpers/workflow.py`** gains `setup_initialized_case()` (7-step case init), `setup_two_participant_case()` (6-step 2-participant setup), and `find_case_by_report_id()`, extracted from demos that each carried private copies.
- **`helpers/verification.py`** gains `verify_activity_in_inbox()`, extracted from local duplicates in `acknowledge_demo` and `receive_report_demo`.
- **`helpers/polling.py`**: `wait_for_case_participants()` now uses `_poll_until()` instead of a hand-rolled deadline loop.
- **12 exchange demos** converted to `run_exchange_demos()`: acknowledge, establish\_embargo, initialize\_case, initialize\_participant, invite\_actor, manage\_case, manage\_embargo, manage\_participants, receive\_report, status\_updates, suggest\_actor, transfer\_ownership, trigger.
- **`trigger_demo`**: deleted `_find_case_for_report()`; call site uses `find_case_for_offer()` from `helpers.workflow`.
- **`status_updates_demo`**: 60-line `_setup_initialized_case()` replaced with a thin wrapper delegating to `setup_initialized_case()` + `_fetch_participant()`.
- **`receive_report_demo`**: `find_case_by_report()` simplified to delegate to `find_case_by_report_id()`; public name preserved for test compatibility.
- All 2-actor demo functions widened to `(client, finder, vendor, coordinator: Optional[as_Actor] = None)` for uniform runner arity.
- `case_proposal_demo.py` intentionally excluded (different `main()` structure, no `_ALL_DEMOS`).
- `manage_participants_demo._setup_case_with_vendor()` intentionally kept — it creates a VENDOR-only participant (no FINDER/REPORTER), which is genuinely distinct from the shared `setup_initialized_case()`.

Net change: **−1048 lines** across all commits.

## Test plan

- [x] `uv run pytest test/demo/ -m "" -x -q --timeout=30` — all demo tests pass, 3 pre-existing xfail (multi-container pre-CBT pattern, issue #464)
- [x] `uv run pytest -m "" --tb=short` — 6196 passed, 141 skipped, 5 xfailed (full suite)
- [x] Pre-commit hooks (black, flake8) pass clean on all commits

Closes #1625
Closes #1632
Part of epic #1598 (Demo Infrastructure Improvements)

🤖 Generated with [Claude Code](https://claude.com/claude-code)