### PR TITLE
docs(#1630): add DEMOCI-03-005 — matrix entry must declare test_file

### DIFF
--- a/plan/history/2607/idea/IDEA-1630.md
+++ b/plan/history/2607/idea/IDEA-1630.md
@@ -1,0 +1,12 @@
+---
+source: IDEA-1630
+timestamp: '2026-07-23T13:49:04.106550+00:00'
+title: convert demo CI to matrix
+type: idea
+---
+
+Use a matrix strategy in the demo CI workflow to allow DRY up duplication as we expand into more demo scenarios. Every demo scenario so far has just copied the previous one instead of following DRY principles. The approach: extract common job structure into a single job with a matrix strategy for parameters.
+
+**Processed**: 2026-07-23 — implementation tracked in #1637.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1636>.
+Spec: `specs/demo-ci.yaml` (DEMOCI-03-005).

--- a/specs/demo-ci.yaml
+++ b/specs/demo-ci.yaml
@@ -5,7 +5,7 @@ description: >-
   containers on pull requests, and for hardening the demo runner to exit non-zero
   when the demo fails — closing the gap where tests pass while the demo produces
   silent failures.
-version: 1.0.0
+version: 1.1.0
 scope:
   - prototype
   - production
@@ -250,3 +250,23 @@ groups:
             spec_id: DEMOCI-03-003
           - rel_type: refines
             spec_id: DEMOCI-03-002
+
+      - id: DEMOCI-03-005
+        priority: MUST
+        kind: project
+        statement: >-
+          Each matrix entry in the demo CI workflow MUST declare an explicit
+          `test_file` field naming the scenario-specific invariant test file
+          (e.g. `test/ci/invariants/test_fv_invariants.py`). The case-ledger
+          invariant step MUST invoke pytest with that file path directly rather
+          than using the `-m case_ledger_invariants` marker alone.
+        rationale: >-
+          Using the marker alone relies on each test file skipping when its
+          devlogs directory is absent — an implicit, fragile coupling between
+          the filesystem state and test selection. An explicit file path makes
+          the scenario-to-test relationship declarative and visible in the
+          workflow definition, so adding a new matrix entry also requires
+          explicitly naming the test file that validates it.
+        relationships:
+          - rel_type: refines
+            spec_id: DEMOCI-03-004


### PR DESCRIPTION
- Closes #1630

## Summary

Adds DEMOCI-03-005 to `specs/demo-ci.yaml`: each demo CI matrix entry
MUST declare an explicit `test_file` field; the invariant step MUST
invoke pytest with that file path directly rather than relying on the
`-m case_ledger_invariants` marker alone.

## Changes

- **`specs/demo-ci.yaml`**: Add DEMOCI-03-005 under the DEMOCI-03
  group; bump spec version 1.0.0 → 1.1.0. The new entry captures the
  planning decision that the matrix `{demo, test_file}` tuple makes
  the scenario-to-test mapping declarative rather than relying on the
  implicit filesystem-skip behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)