### PR TITLE
docs: plan issue #1631 — call-out point configuration system design

### DIFF
--- a/docs/adr/0025-call-out-point-abstraction-layer.md
+++ b/docs/adr/0025-call-out-point-abstraction-layer.md
@@ -189,16 +189,89 @@ The concrete form:
 - `specs/behavior-tree-integration.yaml` BT-18 captures the blackboard
   contract requirements that every call-out point implementation must satisfy.
 
+## Bundle Selection Mechanism (2026-07-23 amendment)
+
+The original ADR left open the question of **how running code chooses which
+factory to inject**. Issue #1631 (planning session 2026-07-23) resolved this
+design gap. The resulting mechanism is implemented by #1152 (FUZZ-08c).
+
+### Three-mode model
+
+There are three logical backend modes:
+
+| Mode | Backends | Default? |
+|---|---|---|
+| `DETERMINISTIC` | `AlwaysSucceed` / `AlwaysFail` (ceiling/floor of stochastic p) | **Yes** |
+| `STOCHASTIC` | Probabilistic fuzzer classes | No — explicit opt-in |
+| `REAL` | Production implementations | No — deferred to FUZZ-08d–08h |
+
+Deterministic is the default everywhere. The p=0.5 tie-breaking direction is
+`AlwaysSucceed` (happy-path forward progress).
+
+### Domain bundle dataclasses
+
+Individual per-node factory kwargs on tree builders are replaced by a single
+**typed bundle parameter** (`call_out: <Domain>CallOutBundle`). Each bundle is
+a `frozen @dataclass` that holds all `CallOutBackendFactory` fields for a
+domain area. Two pre-built module-level singletons exist per domain:
+`<DOMAIN>_DETERMINISTIC` and `<DOMAIN>_STOCHASTIC`.
+
+```python
+@dataclass(frozen=True)
+class ValidationCallOutBundle:
+    credibility_factory: CallOutBackendFactory = AlwaysSucceed
+    validity_factory: CallOutBackendFactory = AlwaysSucceed
+    gather_info_factory: CallOutBackendFactory = AlwaysSucceed
+
+VALIDATION_DETERMINISTIC = ValidationCallOutBundle()
+VALIDATION_STOCHASTIC = ValidationCallOutBundle(
+    credibility_factory=EvaluateReportCredibility,
+    validity_factory=EvaluateReportValidity,
+    gather_info_factory=GatherValidationInfo,
+)
+```
+
+### CallOutBackendFactory as a Protocol
+
+`CallOutBackendFactory` is promoted from a `Callable` type alias to a
+`typing.Protocol` for static type checking:
+
+```python
+class CallOutBackendFactory(Protocol):
+    def __call__(self, name: str) -> py_trees.behaviour.Behaviour: ...
+```
+
+Duck-typing suffices; no central registration or base class is required.
+
+### Extensibility and future production surface
+
+A new backend is any callable matching `CallOutBackendFactory` that honours the
+blackboard contract (BT-18-001 through BT-18-004). Pass it to the relevant
+bundle field. No registry or decorator is needed.
+
+YAML/CLI configuration of backends is deferred to the production path (a future
+issue in the FUZZ-08d–08h series or a production-config successor issue). The
+bundle dataclass structure is the natural target for that mapping.
+
+### Personality / bias bundles (future)
+
+The bundle pattern supports actor-level behavioural variation in multi-actor
+simulation (e.g. a "recalcitrant embargo negotiator" vs. a "cooperative" one)
+by instantiating bundles with biased probability factories. This is a future
+design question tracked as a separate type:Idea issue.
+
 ## More Information
 
 - ADR-0024: Coordination Agent Taxonomy (call-out point concept and the four
   agent shapes)
 - `notes/coordination-agents.md`: design notes for coordination agents
   including the two integration surfaces (call-in vs. call-out)
+- `notes/call-out-configuration.md`: bundle/mode design decisions (2026-07-23)
 - `notes/bt-fuzzer-nodes.md` and sub-files: per-node catalog with automation
   potential ratings and agent-shape classifications (completed by #1150)
 - Implementation chain: #1150 (catalog update) → #1151 (exemplars) →
   #1152 (demo scenario wiring) → FUZZ-08d–08g (shape rollout)
 
 Generated spec requirements: `specs/behavior-tree-integration.yaml`
-BT-18-001 through BT-18-004.
+BT-18-001 through BT-18-004 (factory injection seam);
+BT-23-001 through BT-23-005 (bundle selection mechanism, added 2026-07-23).

--- a/notes/README.md
+++ b/notes/README.md
@@ -267,6 +267,17 @@ Operationalizes `specs/behavior-tree-node-design.yaml` (BTND-01 through BTND-04)
 **Load when**: designing a new BT node or subtree, auditing existing nodes for
 composability violations, or refactoring near-duplicate BT implementations.
 
+**`call-out-configuration.md`**
+Design decisions for how running code selects backend factories for call-out
+point nodes in BT tree builders: three-mode model (DETERMINISTIC /
+STOCHASTIC / REAL), domain bundle dataclasses, pre-built singletons,
+`CallOutBackendFactory` Protocol, default direction rule (ceiling/floor of
+stochastic p), and the extension points for YAML/CLI config and personality
+bundles. Derived from #1631 planning; implemented by #1152.
+**Load when**: implementing or extending call-out point backend injection in
+demo scenarios or tests; designing the bundle/singleton layout in
+`vultron/demo/fuzzer/bundles/`; understanding the three-mode backend model.
+
 **`bt-fuzzer-nodes.md`**
 Index and background for the fuzzer node catalog. Fuzzer nodes are stub
 implementations in the legacy BT simulation (`vultron/bt/`) that stand in for

--- a/notes/call-out-configuration.md
+++ b/notes/call-out-configuration.md
@@ -272,7 +272,7 @@ This enables scenarios such as a "recalcitrant embargo negotiator" paired
 with a "cooperative embargo negotiator" to explore interaction dynamics.
 
 Personality/bias bundles are tracked as a separate design question in
-issue #PERSONALITY_ISSUE_PLACEHOLDER (type:Idea, to be created). The bundle
+issue #1646 (type:Idea). The bundle
 dataclass structure defined here is sufficient to support personality variants
 without modification; no new mechanism is needed.
 

--- a/notes/call-out-configuration.md
+++ b/notes/call-out-configuration.md
@@ -287,4 +287,4 @@ the bundle/singleton/Protocol pattern as the resolved design. See
 `docs/adr/0025-call-out-point-abstraction-layer.md` § "Bundle Selection
 Mechanism (2026-07-23 amendment)".
 
-Normative requirements: `specs/behavior-tree-integration.yaml` BT-21.
+Normative requirements: `specs/behavior-tree-integration.yaml` BT-23.

--- a/notes/call-out-configuration.md
+++ b/notes/call-out-configuration.md
@@ -1,0 +1,290 @@
+---
+title: "Call-Out Point Configuration System — Backend Selection Design"
+status: active
+description: >
+  Design decisions for how running code selects backend factories for call-out
+  point nodes in BT tree builders. Covers the three-mode model, domain bundle
+  dataclasses, pre-built singletons, and extension points. Derived from the
+  planning session for issue #1631.
+related_specs:
+  - specs/behavior-tree-integration.yaml
+related_notes:
+  - notes/coordination-agents.md
+  - notes/bt-fuzzer-nodes.md
+  - notes/configuration.md
+relevant_packages:
+  - vultron/core/behaviors
+  - vultron/demo/fuzzer
+  - vultron/demo/exchange
+---
+
+# Call-Out Point Configuration System — Backend Selection Design
+
+## Background
+
+ADR-0025 established the factory-based injection pattern for call-out points:
+tree-building functions accept `CallOutBackendFactory` kwargs and default to
+fuzzer/deterministic backends (BT-18-004). After #1151 delivered the exemplar
+implementations, one design gap remained: **how does running code — a demo
+scenario, a test fixture, or eventually a production actor — decide which
+factory to inject for each call-out point?**
+
+This note documents the decisions reached in the #1631 planning session.
+The pattern is implemented by #1152 (FUZZ-08c).
+
+---
+
+## Three-Mode Model
+
+There are three logical modes for call-out point backends:
+
+| Mode | Backends used | When used |
+|---|---|---|
+| `DETERMINISTIC` | `AlwaysSucceed` / `AlwaysFail` (ceiling/floor of stochastic p) | Default for all demo and test scenarios |
+| `STOCHASTIC` | Probabilistic fuzzer classes (`UsuallySucceed`, `ProbablyFail`, …) | Opt-in for simulation / fuzz-testing scenarios |
+| `REAL` | Production implementations (data lookups, policy engines, agents) | Deferred to FUZZ-08d through FUZZ-08h |
+
+**Test vs. demo** is a call-context distinction, not a mode distinction.
+`DETERMINISTIC` backends are identical whether used in a pytest fixture or a
+demo script.
+
+### Default direction rule
+
+The default for any tree builder is `DETERMINISTIC`. `STOCHASTIC` is always
+opt-in.
+
+Within `DETERMINISTIC`, the backend for each node is derived from its
+stochastic counterpart by the **ceiling/floor rule**:
+
+- If the fuzzer node's success probability `p > 0.5` → `AlwaysSucceed`
+- If `p < 0.5` → `AlwaysFail`
+- If `p == 0.5` → `AlwaysSucceed` (happy path; see below)
+
+The `p == 0.5` tie-breaking default is `AlwaysSucceed` because the intended
+use of the deterministic bundle is a **happy-path demonstration** in which the
+protocol makes forward progress. Scenarios that need to exercise failure paths
+should use a pessimistic bundle or inject an explicit `AlwaysFail` factory.
+
+Currently there are four `p=0.5` nodes (all default to `AlwaysSucceed`):
+
+| Node | Domain | Rationale |
+|---|---|---|
+| `FollowUpOnErrorMessage` | Messaging | Happy path = can compose a follow-up |
+| `WantToProposeEmbargo` | Embargo | Happy path = want to propose |
+| `AllPartiesKnown` | Reporting to others | Happy path = all parties identified |
+| `NotificationsComplete` | Reporting to others | Happy path = notifications done |
+
+---
+
+## Domain Bundle Dataclasses
+
+Call-out factories are grouped into **domain bundles** — one frozen
+`@dataclass` per domain area. Each bundle holds exactly the set of
+`CallOutBackendFactory` fields consumed by the tree builders in that domain.
+Two **pre-built singleton instances** are provided per domain:
+`<DOMAIN>_DETERMINISTIC` and `<DOMAIN>_STOCHASTIC`.
+
+### Structure pattern
+
+```python
+from __future__ import annotations
+from dataclasses import dataclass, field
+import py_trees
+
+from vultron.core.behaviors.call_out_point import CallOutBackendFactory
+
+
+@dataclass(frozen=True)
+class ValidationCallOutBundle:
+    """Call-out backend bundle for the report validation workflow."""
+
+    credibility_factory: CallOutBackendFactory = field(
+        default_factory=lambda: _default_credibility_factory
+    )
+    validity_factory: CallOutBackendFactory = field(
+        default_factory=lambda: _default_validity_factory
+    )
+    gather_info_factory: CallOutBackendFactory = field(
+        default_factory=lambda: _default_gather_info_factory
+    )
+
+
+# Pre-built singletons (import once, use everywhere)
+VALIDATION_DETERMINISTIC = ValidationCallOutBundle(
+    credibility_factory=lambda n: AlwaysSucceed(n),
+    validity_factory=lambda n: AlwaysSucceed(n),
+    gather_info_factory=lambda n: AlwaysSucceed(n),
+)
+VALIDATION_STOCHASTIC = ValidationCallOutBundle(
+    credibility_factory=lambda n: EvaluateReportCredibility(n),
+    validity_factory=lambda n: EvaluateReportValidity(n),
+    gather_info_factory=lambda n: GatherValidationInfo(n),
+)
+```
+
+### Tree builder integration
+
+Tree builders replace individual factory kwargs with a single typed bundle
+parameter:
+
+```python
+def create_validate_report_tree(
+    report_id: str,
+    offer_id: str,
+    captured: dict | None = None,
+    call_out: ValidationCallOutBundle = VALIDATION_DETERMINISTIC,
+) -> py_trees.behaviour.Behaviour:
+    credibility_node = call_out.credibility_factory("EvaluateReportCredibility")
+    validity_node    = call_out.validity_factory("EvaluateReportValidity")
+    ...
+```
+
+Demo and test code imports the pre-built singleton:
+
+```python
+from vultron.demo.fuzzer.bundles.validation import VALIDATION_STOCHASTIC
+
+tree = create_validate_report_tree(
+    report_id=report.id,
+    offer_id=offer.id,
+    call_out=VALIDATION_STOCHASTIC,
+)
+```
+
+### Domain areas
+
+One bundle is defined per domain area (matching the `vultron/demo/fuzzer/`
+sub-module layout):
+
+| Bundle class | Domain | Tree builder(s) |
+|---|---|---|
+| `ValidationCallOutBundle` | Report validation | `create_validate_report_tree` |
+| `PrioritizationCallOutBundle` | Report prioritization | `create_prioritize_subtree` |
+| `EmbargoCallOutBundle` | Embargo management | `create_manage_embargo_tree` |
+| `PublicationCallOutBundle` | Publication pipeline | `create_publication_tree`, `create_publish_artifact_tree` |
+| `ReportToOthersCallOutBundle` | Reporting to others | `create_report_to_others_tree` |
+| `DeployFixCallOutBundle` | Fix deployment | `create_deploy_fix_tree` |
+| `AcquireExploitCallOutBundle` | Exploit acquisition | `create_acquire_exploit_tree`, `create_acquire_exploit_strategy_tree` |
+| `AssignVulIdCallOutBundle` | Vulnerability ID assignment | `create_assign_vul_id_tree` |
+| `CloseReportCallOutBundle` | Report closure | `create_close_report_tree` |
+
+### Module layout
+
+```text
+vultron/demo/fuzzer/
+  bundles/
+    __init__.py     ← re-exports all bundle classes and singletons
+    validation.py   ← ValidationCallOutBundle + singletons
+    prioritization.py
+    embargo.py
+    publication.py
+    report_to_others.py
+    deploy_fix.py
+    acquire_exploit.py
+    assign_vul_id.py
+    close_report.py
+```
+
+---
+
+## CallOutBackendFactory as a Protocol
+
+The `CallOutBackendFactory` type alias is promoted to a `typing.Protocol` so
+static type checkers (mypy, pyright) can verify that a new backend callable
+matches the expected signature:
+
+```python
+# vultron/core/behaviors/call_out_point.py
+from typing import Protocol, runtime_checkable
+
+import py_trees
+
+
+@runtime_checkable
+class CallOutBackendFactory(Protocol):
+    """Protocol for call-out point backend factories.
+
+    A factory must accept a single ``name: str`` argument (the BT node's
+    display name) and return a ``py_trees.behaviour.Behaviour`` that honours
+    the call-out point's declared blackboard contract (BT-18-001 through
+    BT-18-004).
+    """
+
+    def __call__(self, name: str) -> py_trees.behaviour.Behaviour:
+        ...
+```
+
+Any callable that satisfies this signature (including plain lambdas and module-
+level functions) is a valid backend. No registration, inheritance, or decorator
+is required. Static type checking via pyright/mypy is the validation mechanism.
+
+---
+
+## Extensibility
+
+To add a new backend for a call-out point:
+
+1. Implement a callable matching `CallOutBackendFactory` — a function or class
+   that accepts `name: str` and returns a `py_trees.behaviour.Behaviour`
+   honouring the blackboard contract (BT-18-001 through BT-18-004).
+2. Instantiate the domain bundle with the new factory in the relevant field:
+
+   ```python
+   my_bundle = ValidationCallOutBundle(
+       credibility_factory=MyRealCredibilityEvaluator,
+   )
+   ```
+
+3. Pass the bundle to the tree builder.
+
+No central registry, decorator, or base class is required for the backend
+itself. The bundle dataclass enforces completeness (all fields must be
+supplied; unspecified fields use the bundle class defaults).
+
+### Future: YAML/CLI configuration surface
+
+YAML or CLI configuration of call-out backends is deferred to the production
+path (FUZZ-08d through FUZZ-08h or a follow-on production-config issue). The
+production configuration surface will map domain names + mode strings to bundle
+singletons or factory class paths. The bundle dataclass structure defined here
+is the natural target for that mapping.
+
+---
+
+## Future: Personality / Bias Bundles
+
+The three-mode model (deterministic / stochastic / real) is the foundation;
+personality variants are a future layer on top. A **personality bundle** is
+a domain bundle instantiated with factories that have a *biased* probability
+distribution, allowing actor-level behavioural differences in multi-actor
+simulation:
+
+```python
+# Example (not yet implemented)
+PESSIMISTIC_EMBARGO = EmbargoCallOutBundle(
+    want_to_propose_embargo_factory=lambda n: AlwaysFail(n),      # never proposes
+    current_embargo_acceptable_factory=lambda n: UsuallyFail(n),  # rarely accepts
+    ...
+)
+```
+
+This enables scenarios such as a "recalcitrant embargo negotiator" paired
+with a "cooperative embargo negotiator" to explore interaction dynamics.
+
+Personality/bias bundles are tracked as a separate design question in
+issue #PERSONALITY_ISSUE_PLACEHOLDER (type:Idea, to be created). The bundle
+dataclass structure defined here is sufficient to support personality variants
+without modification; no new mechanism is needed.
+
+---
+
+## Relationship to ADR-0025
+
+ADR-0025 established the factory injection seam but left the question of
+"how does running code choose which factory" explicitly open ("formed in sand,
+not concrete"). This note fills that gap. ADR-0025 has been updated to reflect
+the bundle/singleton/Protocol pattern as the resolved design. See
+`docs/adr/0025-call-out-point-abstraction-layer.md` § "Bundle Selection
+Mechanism (2026-07-23 amendment)".
+
+Normative requirements: `specs/behavior-tree-integration.yaml` BT-21.

--- a/plan/history/2607/idea/IDEA-1631.md
+++ b/plan/history/2607/idea/IDEA-1631.md
@@ -1,0 +1,52 @@
+---
+source: IDEA-1631
+timestamp: '2026-07-23T18:00:02.161802+00:00'
+title: 'FUZZ-08c-design: Call-out point configuration system — how running code selects
+  backend factories'
+type: idea
+---
+
+## Summary
+
+Before #1152 (FUZZ-08c: Wire call-out point nodes into demo scenarios) can be
+implemented, the call-out point configuration system needed to be designed.
+The current state: all trigger use cases hardcode fuzzer (probabilistic)
+factory defaults. There is no mechanism for running code to select a
+different backend at runtime without changing code.
+
+This issue answered: **how does running code choose which backend factory to
+use for each call-out point?**
+
+## Decisions Reached
+
+**Three-mode model**: DETERMINISTIC (AlwaysSucceed/AlwaysFail derived by
+ceiling/floor of stochastic p), STOCHASTIC (probabilistic fuzzer classes),
+REAL (production implementations, deferred). DETERMINISTIC is the default.
+
+**Default direction rule**: p > 0.5 → AlwaysSucceed; p < 0.5 → AlwaysFail;
+p == 0.5 → AlwaysSucceed (happy-path tie-break). Four p=0.5 nodes exist, all
+default to AlwaysSucceed.
+
+**Domain bundle dataclasses**: frozen @dataclass per domain area; tree
+builders accept a single `call_out: <Domain>CallOutBundle` parameter;
+pre-built `<DOMAIN>_DETERMINISTIC` and `<DOMAIN>_STOCHASTIC` singletons
+prevent non-DRY bundle construction at call sites.
+
+**CallOutBackendFactory as Protocol**: promoted from Callable type alias to
+typing.Protocol for static type checking (mypy/pyright). Duck-typing
+sufficient; no central registry required.
+
+**Configuration surface**: Python construction only for now (demo scripts
+import pre-built singletons). YAML/CLI surface deferred to production path.
+
+**ADR**: ADR-0025 amended with "Bundle Selection Mechanism (2026-07-23)"
+section.
+
+**Spec entries**: specs/behavior-tree-integration.yaml BT-23-001 through
+BT-23-005 (version bumped 1.0.0 → 1.1.0).
+
+**Processed**: 2026-07-23 — implementation tracked in #1645. Personality/bias
+bundles tracked in #1646.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1644>.
+Spec: `specs/behavior-tree-integration.yaml` BT-23.
+Notes: `notes/call-out-configuration.md`.

--- a/specs/behavior-tree-integration.yaml
+++ b/specs/behavior-tree-integration.yaml
@@ -4,7 +4,7 @@ description: Requirements for integrating py_trees behavior trees into Vultron h
   model, state management via the DataLayer, handler integration patterns, actor isolation, concurrency constraints, and failure
   diagnosis. Complex protocol workflows such as report validation, case creation, and embargo management must be implemented
   as BT nodes or subtrees.
-version: 1.0.0
+version: 1.1.0
 scope:
 - prototype
 - production
@@ -770,3 +770,119 @@ groups:
     relationships:
     - rel_type: refines
       spec_id: BTND-02-001
+- id: BT-23
+  title: Call-Out Point Backend Selection
+  description: >
+    Requirements for how running code selects and injects backend factories into
+    BT tree builders. Covers the three-mode model (deterministic / stochastic /
+    real), the domain bundle dataclass pattern, pre-built singletons, the
+    CallOutBackendFactory Protocol, and the default direction rule. Derived from
+    the planning session for issue #1631.
+  specs:
+  - id: BT-23-001
+    priority: MUST
+    kind: project
+    statement: >
+      Call-out point backends MUST be organised into three logical modes:
+      DETERMINISTIC (AlwaysSucceed/AlwaysFail derived from the ceiling/floor of
+      stochastic probabilities), STOCHASTIC (probabilistic fuzzer classes), and
+      REAL (production implementations — currently deferred to FUZZ-08d through
+      FUZZ-08h). The DETERMINISTIC mode MUST be the default for all tree
+      builders, integration tests, and demo scenarios that do not explicitly
+      opt into STOCHASTIC or REAL.
+    rationale: >
+      Deterministic defaults make integration tests and demo scenarios
+      repeatable without per-call-site configuration. The probabilistic
+      (stochastic) mode is useful only for simulation and fuzz-testing; making
+      it the default (as in the original fuzzer heritage) causes non-determinism
+      in CI. The three-mode naming also documents the intended migration path:
+      DETERMINISTIC → REAL as production implementations are built.
+    relationships:
+    - rel_type: extends
+      spec_id: BT-18-004
+      note: >
+        BT-18-004 requires factory injection; BT-23-001 specifies that the
+        default factory must be the DETERMINISTIC backend, not the stochastic
+        fuzzer.
+  - id: BT-23-002
+    priority: MUST
+    kind: project
+    statement: >
+      The DETERMINISTIC backend for each call-out point MUST be derived from
+      its STOCHASTIC counterpart using the ceiling/floor rule: if the stochastic
+      success probability p > 0.5, the deterministic backend is AlwaysSucceed;
+      if p < 0.5, AlwaysFail; if p == 0.5, AlwaysSucceed (happy-path default).
+    rationale: >
+      Grounding the deterministic backend in the stochastic probability
+      preserves the semantic intent of each node. Nodes that the simulation
+      expects to usually succeed (high p) map to AlwaysSucceed; nodes that
+      usually fail map to AlwaysFail. The p==0.5 tie-breaking rule selects the
+      happy-path direction so that deterministic demo scenarios make forward
+      protocol progress.
+    relationships:
+    - rel_type: refines
+      spec_id: BT-23-001
+  - id: BT-23-003
+    priority: MUST
+    kind: project
+    statement: >
+      Call-out point factories for a domain area MUST be collected into a
+      domain bundle — a frozen @dataclass (one per domain area) whose fields are
+      typed CallOutBackendFactory values. Each bundle class MUST provide
+      module-level singleton instances for the DETERMINISTIC and STOCHASTIC
+      modes (e.g. VALIDATION_DETERMINISTIC, VALIDATION_STOCHASTIC). Tree
+      builders that accept call-out factories MUST accept the bundle as a single
+      typed parameter (e.g. call_out: ValidationCallOutBundle) rather than
+      individual per-node factory kwargs.
+    rationale: >
+      Individual per-node factory kwargs accumulate quickly (a tree builder may
+      have 5–10 call-out points); a bundle dataclass keeps the tree builder
+      signature clean while enforcing completeness (all fields must be supplied).
+      Pre-built singletons avoid non-DRY construction in every demo script and
+      test fixture that wants the standard deterministic or stochastic behaviour.
+      The frozen constraint prevents accidental mutation after construction.
+    relationships:
+    - rel_type: refines
+      spec_id: BT-23-001
+    - rel_type: extends
+      spec_id: BT-18-004
+      note: Replaces the individual factory-kwarg API with the bundle API.
+  - id: BT-23-004
+    priority: MUST
+    kind: project
+    statement: >
+      The CallOutBackendFactory type MUST be defined as a typing.Protocol (not
+      a bare Callable type alias). The Protocol MUST declare a single __call__
+      method accepting name: str and returning py_trees.behaviour.Behaviour.
+      Static type checking (mypy/pyright) is the validation mechanism; no
+      central registration or base class inheritance is required.
+    rationale: >
+      A Protocol produces IDE completion and pyright/mypy enforcement of the
+      factory signature without requiring runtime registration overhead. Duck-
+      typing via Protocol is consistent with how other ports in the codebase are
+      typed (vultron/core/ports/use_case.py), and avoids the coupling risk of a
+      central registry (name-key typos are silent runtime failures rather than
+      static errors).
+    relationships:
+    - rel_type: refines
+      spec_id: BT-23-003
+    - rel_type: extends
+      spec_id: BT-18-004
+  - id: BT-23-005
+    priority: SHOULD
+    kind: project
+    statement: >
+      Domain bundle classes SHOULD follow the naming convention
+      <Domain>CallOutBundle (e.g. ValidationCallOutBundle,
+      EmbargoCallOutBundle) and SHOULD be defined in
+      vultron/demo/fuzzer/bundles/<domain>.py. The pre-built singletons SHOULD
+      be named <DOMAIN>_DETERMINISTIC and <DOMAIN>_STOCHASTIC (e.g.
+      VALIDATION_DETERMINISTIC, EMBARGO_STOCHASTIC).
+    rationale: >
+      Consistent naming makes the available bundles discoverable without reading
+      the implementation. The bundles/ sub-package is co-located with the fuzzer
+      nodes they reference, respecting the BT-16-001 rule that simulation
+      artefacts stay in vultron/demo/ and do not appear in vultron/core/.
+    relationships:
+    - rel_type: refines
+      spec_id: BT-23-003


### PR DESCRIPTION
## Summary

- Closes #1631

- Add `notes/call-out-configuration.md`: three-mode model
  (DETERMINISTIC/STOCHASTIC/REAL), domain bundle dataclasses, pre-built
  singletons, `CallOutBackendFactory` Protocol, ceiling/floor default
  direction rule, p=0.5 tie-breaking table, extensibility and future
  YAML/personality extension points
- Add `specs/behavior-tree-integration.yaml` BT-23-001–BT-23-005:
  normative requirements for the bundle selection mechanism; bump spec
  version 1.0.0 → 1.1.0
- Amend `docs/adr/0025-call-out-point-abstraction-layer.md`: add "Bundle
  Selection Mechanism (2026-07-23 amendment)" section filling the
  "formed in sand" design gap; update More Information references
- Update `notes/README.md`: index entry for `call-out-configuration.md`

## Changes

### notes/call-out-configuration.md (new)

Covers: three-mode model (DETERMINISTIC/STOCHASTIC/REAL); the
ceiling/floor default direction rule deriving deterministic backends from
stochastic probabilities; p=0.5 tie-breaking table (4 nodes, all
`AlwaysSucceed`); frozen `@dataclass` domain bundle pattern with pre-built
singletons; `CallOutBackendFactory` promoted to `typing.Protocol`; module
layout for `vultron/demo/fuzzer/bundles/`; future YAML/CLI and
personality/bias extension points.

### specs/behavior-tree-integration.yaml (BT-23, version 1.1.0)

- BT-23-001: Three-mode model; DETERMINISTIC MUST be the default
- BT-23-002: Ceiling/floor rule for deriving deterministic backends
- BT-23-003: Domain bundle `@dataclass` + pre-built singletons; single
  `call_out=` param on tree builders
- BT-23-004: `CallOutBackendFactory` MUST be a `typing.Protocol`
- BT-23-005: Naming conventions (`<Domain>CallOutBundle`,
  `<DOMAIN>_DETERMINISTIC`, `vultron/demo/fuzzer/bundles/`)

### docs/adr/0025-call-out-point-abstraction-layer.md (amended)

Added "Bundle Selection Mechanism (2026-07-23 amendment)" section with
three-mode table, bundle dataclass sketch, Protocol definition, and
extensibility/future-surface notes. Updated More Information references
to include `notes/call-out-configuration.md` and BT-23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)