### PR TITLE
test(ci): add finder late-joiner backfill checks to FVV and FVCV-extension invariants

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1600.md
+++ b/plan/history/2607/implementation/ISSUE-1600.md
@@ -1,0 +1,16 @@
+---
+source: ISSUE-1600
+timestamp: '2026-07-23T19:08:18.236034+00:00'
+title: Add finder late-joiner backfill invariant tests for FVV and FVCV-extension
+type: implementation
+---
+
+## Issue #1600 — test(ci): add finder late-joiner backfill checks to FVV and FVCV-extension invariants
+
+Added `test_fvv_finder_late_joiner_has_full_history` to FVV invariant file and
+`test_fvcv_extension_finder_late_joiner_has_full_history` +
+`test_fvcv_extension_coordinator_late_joiner_has_full_history` to the
+FVCV-extension invariant file. All three tests use `check_late_joiner_has_full_history`
+with `early_actor="vendor"` and skip automatically when devlogs are absent.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1647>

--- a/test/ci/invariants/test_fvcv_extension_invariants.py
+++ b/test/ci/invariants/test_fvcv_extension_invariants.py
@@ -10,6 +10,8 @@ Actor set: ``finder``, ``vendor``, ``coordinator``, ``vendor2``,
 FVCV-extension-specific invariants:
 - ``invite_actor_to_case`` appears at least twice (Finder, then Vendor2).
 - Vendor2 is a late joiner — replica holds the complete log from genesis.
+- Finder is a late joiner — replica holds the complete log from genesis.
+- Coordinator is a late joiner — replica holds the complete log from genesis.
 - CS transitions VFd and VFD observed in vendor-actor status entries.
 
 All tests are tagged ``@pytest.mark.case_ledger_invariants``.  They skip
@@ -303,5 +305,49 @@ def test_fvcv_extension_vendor2_late_joiner_has_full_history(
         )
     violations = check_late_joiner_has_full_history(
         fvcv_extension_replicas, early_actor="vendor", late_actor="vendor2"
+    )
+    assert not violations, "\n".join(violations)
+
+
+@pytest.mark.case_ledger_invariants
+def test_fvcv_extension_finder_late_joiner_has_full_history(
+    fvcv_extension_replicas: dict[str, list[dict]],
+) -> None:
+    """Finder replica contains all logIndex values present in vendor replica.
+
+    Finder is seeded by the CaseActor's trust-bootstrap Announce; the
+    CaseActor must backfill all prior entries to Finder.
+    Spec: DEMOMA-10-007 (SYNC-2 convergence).
+    """
+    if not fvcv_extension_replicas.get(
+        "vendor"
+    ) or not fvcv_extension_replicas.get("finder"):
+        pytest.skip(
+            "vendor or finder replica absent; cannot check late-joiner invariant"
+        )
+    violations = check_late_joiner_has_full_history(
+        fvcv_extension_replicas, early_actor="vendor", late_actor="finder"
+    )
+    assert not violations, "\n".join(violations)
+
+
+@pytest.mark.case_ledger_invariants
+def test_fvcv_extension_coordinator_late_joiner_has_full_history(
+    fvcv_extension_replicas: dict[str, list[dict]],
+) -> None:
+    """Coordinator replica contains all logIndex values present in vendor replica.
+
+    Coordinator joins after case creation when Vendor1 invites them; the
+    CaseActor must backfill all prior entries to Coordinator.
+    Spec: DEMOMA-10-007 (SYNC-2 convergence).
+    """
+    if not fvcv_extension_replicas.get(
+        "vendor"
+    ) or not fvcv_extension_replicas.get("coordinator"):
+        pytest.skip(
+            "vendor or coordinator replica absent; cannot check late-joiner invariant"
+        )
+    violations = check_late_joiner_has_full_history(
+        fvcv_extension_replicas, early_actor="vendor", late_actor="coordinator"
     )
     assert not violations, "\n".join(violations)

--- a/test/ci/invariants/test_fvv_invariants.py
+++ b/test/ci/invariants/test_fvv_invariants.py
@@ -11,6 +11,7 @@ Universal invariants (1–15) are applied via ``common.py``.
 FVV-specific invariants:
 - ``invite_actor_to_case`` appears at least once (Vendor1 invites Vendor2).
 - Vendor2 replica holds the complete log from genesis (late-joiner backfill).
+- Finder replica holds the complete log from genesis (late-joiner backfill).
 
 All tests are tagged ``@pytest.mark.case_ledger_invariants``.  They skip
 automatically when ``devlogs/fvv/`` is absent.
@@ -287,5 +288,26 @@ def test_fvv_vendor2_late_joiner_has_full_history(
         )
     violations = check_late_joiner_has_full_history(
         fvv_replicas, early_actor="vendor", late_actor="vendor2"
+    )
+    assert not violations, "\n".join(violations)
+
+
+@pytest.mark.case_ledger_invariants
+def test_fvv_finder_late_joiner_has_full_history(
+    fvv_replicas: dict[str, list[dict]],
+) -> None:
+    """Finder replica contains all logIndex values present in vendor replica.
+
+    Finder is seeded by the CaseActor's trust-bootstrap Announce after
+    Vendor1 validates the report; the CaseActor must backfill all prior
+    entries to Finder.
+    Spec: DEMOMA-09-004 (SYNC-2 convergence).
+    """
+    if not fvv_replicas.get("vendor") or not fvv_replicas.get("finder"):
+        pytest.skip(
+            "vendor or finder replica absent; cannot check late-joiner invariant"
+        )
+    violations = check_late_joiner_has_full_history(
+        fvv_replicas, early_actor="vendor", late_actor="finder"
     )
     assert not violations, "\n".join(violations)


### PR DESCRIPTION
- Closes #1600

## Summary

Adds finder (and coordinator) late-joiner backfill invariant tests to the FVV
and FVCV-extension invariant files. Both scenarios have actors that join after
case creation via CaseActor trust-bootstrap and must receive a full ledger
backfill; those invariants were missing from the stub files added in #1592.

## Changes

- **`test/ci/invariants/test_fvv_invariants.py`**: add
  `test_fvv_finder_late_joiner_has_full_history` — Finder is seeded by the
  CaseActor trust-bootstrap Announce after Vendor1 validates the report; asserts
  full backfill from genesis (Spec: DEMOMA-09-004)
- **`test/ci/invariants/test_fvcv_extension_invariants.py`**: add
  `test_fvcv_extension_finder_late_joiner_has_full_history` and
  `test_fvcv_extension_coordinator_late_joiner_has_full_history` — Finder and
  Coordinator both join via CaseActor trust-bootstrap; assert full backfill
  (Spec: DEMOMA-10-007). Updated module docstring to list all invariants.
- **`plan/history/2607/implementation/ISSUE-1600.md`**: history entry

## Verification

- [x] `uv run pytest test/ci/invariants/ -m ""` — all new tests collect and
  skip when devlogs absent (exit 0, skip message: "vendor or … replica absent")
- [x] Black, flake8, mypy, pyright — all pass
- [x] Full unit suite: `uv run pytest` — 5372 passed, 0 failures
- [x] CI: fvv and fvcv-extension Demo Integration jobs pass against real demo
  artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)