### PR TITLE
feat(demoma): rename vendor2 service to actor5; add DEMOMA-13 spec group and seed-coordinator2.yaml

### DIFF
--- a/.github/workflows/demo-integration.yml
+++ b/.github/workflows/demo-integration.yml
@@ -117,7 +117,7 @@ jobs:
           mkdir -p /tmp/demo-logs
           docker compose -f "$COMPOSE_FILE" logs \
             > /tmp/demo-logs/combined.log 2>&1
-          for svc in finder vendor coordinator case-actor vendor2 demo-runner; do
+          for svc in finder vendor coordinator case-actor actor5 demo-runner; do
             docker compose -f "$COMPOSE_FILE" logs "$svc" \
               > "/tmp/demo-logs/${svc}.log" 2>&1 || true
           done

--- a/docker/docker-compose-multi-actor.yml
+++ b/docker/docker-compose-multi-actor.yml
@@ -1,7 +1,7 @@
 # Multi-Actor Vultron Demo — Docker Compose Configuration
 #
 # Defines five isolated actor services (finder, vendor, coordinator,
-# vendor2, case-actor), each
+# actor5, case-actor), each
 # with its own DataLayer volume, health check, and network membership.
 #
 # DEMO-MA-02-001: Each actor service has a /health/ready healthcheck.
@@ -59,7 +59,7 @@
 #   vultron-network   Shared bridge network connecting all services.
 #
 # ─── Startup and seeding ──────────────────────────────────────────────────
-# The API server containers (finder, vendor, coordinator, vendor2,
+# The API server containers (finder, vendor, coordinator, actor5,
 # case-actor) do NOT auto-seed actor records on startup. The `demo-runner`
 # service resets the relevant containers and seeds actors automatically,
 # producing a deterministic acceptance run with a single `docker compose up
@@ -191,25 +191,30 @@ services:
       # Ephemeral host port → container 7999.  Set CASE_ACTOR_HOST_PORT to pin.
       - "${CASE_ACTOR_HOST_PORT:-0}:7999"
 
-  # ── Vendor2 actor ─────────────────────────────────────────────────────────
-  # Second vendor container used in Demo Scenario 3 (D5-4: multi-vendor with
-  # ownership transfer). Coordinator invites Vendor2 after taking over the
-  # case from the original Vendor.
-  vendor2:
+  # ── Actor5 (neutral fifth actor slot) ────────────────────────────────────
+  # Fifth actor container with a scenario-neutral name.  Different scenarios
+  # seed this container with different actor identities:
+  #   - fvv, fvcv-extension, fvcv-handoff: seeded as Vendor2
+  #   - fccv-extension: seeded as Coordinator2
+  # The neutral service name avoids hard-coding a specific CVD role.
+  actor5:
     <<: *actor-service
     environment:
       - PYTHONPATH=/app
-      - VULTRON_SERVER__BASE_URL=http://vendor2:7999/api/v2/
+      - VULTRON_SERVER__BASE_URL=http://actor5:7999/api/v2/
       - VULTRON_DATABASE__DB_URL=sqlite:////app/data/mydb.sqlite
-      - VULTRON_ACTOR_ID=http://vendor2:7999/api/v2/actors/vendor2
-      - VULTRON_SEED_CONFIG=/app/docker/seed-configs/seed-vendor2.yaml
+      # VULTRON_ACTOR_ID: default identity for fvv/fvcv-* scenarios.
+      # Override by passing a different VULTRON_SEED_CONFIG at runtime
+      # (e.g. seed-coordinator2.yaml for fccv-extension).
+      - VULTRON_ACTOR_ID=http://actor5:7999/api/v2/actors/vendor2
+      - VULTRON_SEED_CONFIG=/app/docker/seed-configs/seed-actor5.yaml
       - VULTRON_SERVER__LOG_LEVEL=${VULTRON_SERVER__LOG_LEVEL:-INFO}
     volumes:
       - "../vultron:/app/vultron"
-      - vendor2-data:/app/data
+      - actor5-data:/app/data
     ports:
-      # Ephemeral host port → container 7999.  Set VENDOR2_HOST_PORT to pin.
-      - "${VENDOR2_HOST_PORT:-0}:7999"
+      # Ephemeral host port → container 7999.  Set ACTOR5_HOST_PORT to pin.
+      - "${ACTOR5_HOST_PORT:-0}:7999"
 
   # ── Demo orchestration container ──────────────────────────────────────────
   # Runs the configured multi-actor acceptance workflow. The script resets
@@ -234,7 +239,7 @@ services:
         condition: service_healthy
       case-actor:
         condition: service_healthy
-      vendor2:
+      actor5:
         condition: service_healthy
     environment:
       - PYTHONPATH=/app
@@ -243,7 +248,7 @@ services:
       - VULTRON_VENDOR_BASE_URL=http://vendor:7999/api/v2
       - VULTRON_COORDINATOR_BASE_URL=http://coordinator:7999/api/v2
       - VULTRON_CASE_ACTOR_BASE_URL=http://case-actor:7999/api/v2
-      - VULTRON_VENDOR2_BASE_URL=http://vendor2:7999/api/v2
+      - VULTRON_VENDOR2_BASE_URL=http://actor5:7999/api/v2
       # Run the selected multi-actor demo non-interactively. Override DEMO
       # at runtime (for example, DEMO=fvv) to switch scenarios.
       - DEMO=${DEMO:-fv}
@@ -270,4 +275,4 @@ volumes:
   vendor-data:
   coordinator-data:
   case-actor-data:
-  vendor2-data:
+  actor5-data:

--- a/docker/seed-configs/seed-actor5.yaml
+++ b/docker/seed-configs/seed-actor5.yaml
@@ -1,7 +1,7 @@
 local_actor:
   name: Vendor2
   actor_type: Organization
-  id: http://vendor2:7999/api/v2/actors/vendor2
+  id: http://actor5:7999/api/v2/actors/vendor2
 
 peers:
   - name: Finder

--- a/docker/seed-configs/seed-case-actor.yaml
+++ b/docker/seed-configs/seed-case-actor.yaml
@@ -15,4 +15,4 @@ peers:
     id: http://coordinator:7999/api/v2/actors/coordinator
   - name: Vendor2
     actor_type: Organization
-    id: http://vendor2:7999/api/v2/actors/vendor2
+    id: http://actor5:7999/api/v2/actors/vendor2

--- a/docker/seed-configs/seed-coordinator.yaml
+++ b/docker/seed-configs/seed-coordinator.yaml
@@ -15,4 +15,4 @@ peers:
     id: http://case-actor:7999/api/v2/actors/case-actor
   - name: Vendor2
     actor_type: Organization
-    id: http://vendor2:7999/api/v2/actors/vendor2
+    id: http://actor5:7999/api/v2/actors/vendor2

--- a/docker/seed-configs/seed-coordinator2.yaml
+++ b/docker/seed-configs/seed-coordinator2.yaml
@@ -1,9 +1,12 @@
 local_actor:
-  name: Finder
-  actor_type: Person
-  id: http://finder:7999/api/v2/actors/finder
+  name: Coordinator2
+  actor_type: Service
+  id: http://actor5:7999/api/v2/actors/coordinator2
 
 peers:
+  - name: Finder
+    actor_type: Person
+    id: http://finder:7999/api/v2/actors/finder
   - name: Vendor
     actor_type: Organization
     id: http://vendor:7999/api/v2/actors/vendor
@@ -13,6 +16,3 @@ peers:
   - name: CaseActor
     actor_type: Service
     id: http://case-actor:7999/api/v2/actors/case-actor
-  - name: Vendor2
-    actor_type: Organization
-    id: http://actor5:7999/api/v2/actors/vendor2

--- a/docker/seed-configs/seed-vendor.yaml
+++ b/docker/seed-configs/seed-vendor.yaml
@@ -15,4 +15,4 @@ peers:
     id: http://case-actor:7999/api/v2/actors/case-actor
   - name: Vendor2
     actor_type: Organization
-    id: http://vendor2:7999/api/v2/actors/vendor2
+    id: http://actor5:7999/api/v2/actors/vendor2

--- a/docker/service-colors.env
+++ b/docker/service-colors.env
@@ -20,5 +20,5 @@ finder=#007BC0
 vendor=#008F91
 coordinator=#C41230
 case-actor=#FDB515
-vendor2=#043673
+actor5=#043673
 demo-runner=#E0E0E0

--- a/integration_tests/demo/run_multi_actor_integration_test.sh
+++ b/integration_tests/demo/run_multi_actor_integration_test.sh
@@ -28,7 +28,7 @@
 #   VENDOR_HOST_PORT      Pin a specific host port for the vendor service.
 #   CASE_ACTOR_HOST_PORT  Pin a specific host port for the case-actor service.
 #   COORDINATOR_HOST_PORT Pin a specific host port for the coordinator service.
-#   VENDOR2_HOST_PORT     Pin a specific host port for the vendor2 service.
+#   ACTOR5_HOST_PORT      Pin a specific host port for the actor5 service.
 #   COMPOSE_SERVICE_COLORS
 #                         Path to a service-colors.env file that maps service
 #                         names to hex colors (default: docker/service-colors.env).

--- a/notes/demo-ci-diagnostics.md
+++ b/notes/demo-ci-diagnostics.md
@@ -203,7 +203,7 @@ mkdir -p /tmp/demo-logs
 docker compose -f docker/docker-compose-multi-actor.yml logs \
   > /tmp/demo-logs/combined.log 2>&1
 
-for svc in finder vendor coordinator case-actor vendor2 demo-runner; do
+for svc in finder vendor coordinator case-actor actor5 demo-runner; do
   docker compose -f docker/docker-compose-multi-actor.yml logs "$svc" \
     > "/tmp/demo-logs/${svc}.log" 2>&1 || true
 done
@@ -262,7 +262,7 @@ Each JSONL line is a `CaseLedgerEntry` object. Key fields:
 Path in artifact: `/tmp/demo-logs/`
 
 Files: `combined.log`, `finder.log`, `vendor.log`, `coordinator.log`,
-`case-actor.log`, `vendor2.log`, `demo-runner.log`.
+`case-actor.log`, `actor5.log`, `demo-runner.log`.
 
 **Correlating JSONL artifacts with container logs**: Use the `case_id`
 from a failing JSONL entry as a grep anchor in the container logs, then

--- a/plan/history/2607/implementation/ISSUE-1619.md
+++ b/plan/history/2607/implementation/ISSUE-1619.md
@@ -1,0 +1,12 @@
+---
+source: ISSUE-1619
+timestamp: '2026-07-23T19:24:00.087508+00:00'
+title: rename vendor2 service to actor5; add seed-coordinator2.yaml
+type: implementation
+---
+
+## Issue #1619 — FCCV-extension: add DEMOMA-13 spec group and rename vendor2 service to actor5
+
+Renamed the `vendor2` Docker Compose service to scenario-neutral `actor5`, allowing different scenarios to seed it with different actor identities. Added `seed-coordinator2.yaml` for the FCCV-extension scenario. Resolved a merge conflict with #1638 (matrix CI refactor).
+
+PR: <https://github.com/CERTCC/Vultron/pull/1648>

--- a/plan/incoming/learnings/20260723-freshen-branch-conflict-cleanup-bug.md
+++ b/plan/incoming/learnings/20260723-freshen-branch-conflict-cleanup-bug.md
@@ -1,0 +1,29 @@
+---
+title: freshen-branch.sh leaves temp branch on conflict when abort silently fails
+type: learning
+timestamp: "2026-07-23"
+source: ISSUE-1619
+signal: tooling-issue
+---
+
+When `freshen-branch.sh` encounters a cherry-pick conflict, its `else` block
+calls `git cherry-pick --abort 2>/dev/null || true` then `git checkout
+"$TASK_BRANCH"`. If the abort itself fails (e.g. because the cherry-pick state
+is partially written), `|| true` swallows the error, but the subsequent
+`git checkout "$TASK_BRANCH"` fails with "you need to resolve your current
+index first" — and because the script uses `set -euo pipefail` with no `||
+true` on that line, the script exits immediately, leaving the repo on the
+temp branch with conflict markers in the working tree (temp branch is not
+deleted).
+
+**Recovery steps** (used on ISSUE-1619):
+
+1. Confirm branch with `git branch --show-current` (will be `temp-freshen-*`).
+2. Manually resolve conflict markers in the conflicted file.
+3. `git add <conflicted-file>` then `git cherry-pick --continue --no-edit`.
+4. `git branch -f "$TASK_BRANCH" HEAD && git checkout "$TASK_BRANCH" && git branch -D "$TEMP"`.
+
+**Suggested fix**: replace `git checkout "$TASK_BRANCH"` in the else block
+with `git checkout "$TASK_BRANCH" 2>/dev/null || git checkout -` so the
+temp-branch deletion and exit-1 still happen even when a concurrent git
+lock or unresolved state blocks the checkout.

--- a/test/demo/test_integration_script_scenarios.py
+++ b/test/demo/test_integration_script_scenarios.py
@@ -17,7 +17,7 @@ When a new demo scenario is added to .github/workflows/demo-integration.yml
 (per DEMOCI-02-003), the shell script's VALID_SCENARIOS list must be updated
 in the same PR.  This test catches the drift that triggered issue #1585.
 
-Source of truth: the DEMO=<name> values in demo-integration.yml.
+Source of truth: the ``demo:`` matrix entries in demo-integration.yml.
 Checked artifact: VALID_SCENARIOS in run_multi_actor_integration_test.sh.
 """
 
@@ -35,8 +35,10 @@ _INTEGRATION_SCRIPT = (
     / "run_multi_actor_integration_test.sh"
 )
 
-# Matches lines like:   DEMO=fvcv-extension \
-_CI_DEMO_RE = re.compile(r"^\s+DEMO=([a-z][a-z0-9-]+)\s", re.MULTILINE)
+# Matches matrix include entries like:   - demo: fvcv-extension
+_CI_DEMO_RE = re.compile(
+    r"^\s+-\s+demo:\s+([a-z][a-z0-9-]+)\s*$", re.MULTILINE
+)
 
 # Matches the assignment line:  VALID_SCENARIOS="fv fvv fvcv-extension fvcv-handoff"
 _VALID_SCENARIOS_RE = re.compile(r'^VALID_SCENARIOS="([^"]+)"')
@@ -71,7 +73,7 @@ class TestIntegrationScriptScenarios:
         ), f"Integration script not found: {_INTEGRATION_SCRIPT}"
 
     def test_valid_scenarios_matches_ci(self):
-        """VALID_SCENARIOS must equal the DEMO= values in demo-integration.yml.
+        """VALID_SCENARIOS must equal the demo: matrix entries in demo-integration.yml.
 
         Failure here means a new scenario was added to CI without updating the
         script (or vice versa).  Fix both files in the same PR per DEMOCI-02-003.

--- a/test/demo/test_multi_actor_compose.py
+++ b/test/demo/test_multi_actor_compose.py
@@ -44,7 +44,7 @@ _EXPECTED_SERVICE_DEFAULTS: dict[str, int] = {
     "vendor": 0,
     "case-actor": 0,
     "coordinator": 0,
-    "vendor2": 0,
+    "actor5": 0,
 }
 
 # Pattern that matches Docker Compose env-var substitution with a default,

--- a/test/demo/test_multi_actor_seed.py
+++ b/test/demo/test_multi_actor_seed.py
@@ -36,7 +36,7 @@ FINDER_ID = "http://finder:7999/api/v2/actors/finder"
 VENDOR_ID = "http://vendor:7999/api/v2/actors/vendor"
 COORDINATOR_ID = "http://coordinator:7999/api/v2/actors/coordinator"
 CASE_ACTOR_ID = "http://case-actor:7999/api/v2/actors/case-actor"
-VENDOR2_ID = "http://vendor2:7999/api/v2/actors/vendor2"
+VENDOR2_ID = "http://actor5:7999/api/v2/actors/vendor2"
 
 # Path to the docker/seed-configs/ directory (relative to project root).
 _REPO_ROOT = Path(__file__).parents[2]
@@ -191,7 +191,7 @@ class TestSeedConfigCrossConsistency:
             "seed-vendor.yaml",
             "seed-coordinator.yaml",
             "seed-case-actor.yaml",
-            "seed-vendor2.yaml",
+            "seed-actor5.yaml",
         ):
             cfg = _load_seed_config(filename)
             assert cfg is not None
@@ -202,7 +202,7 @@ class TestSeedConfigCrossConsistency:
             "seed-vendor.yaml",
             "seed-coordinator.yaml",
             "seed-case-actor.yaml",
-            "seed-vendor2.yaml",
+            "seed-actor5.yaml",
         ):
             cfg = _load_seed_config(filename)
             assert (
@@ -215,7 +215,7 @@ class TestSeedConfigCrossConsistency:
             ("seed-vendor.yaml", VENDOR_ID),
             ("seed-coordinator.yaml", COORDINATOR_ID),
             ("seed-case-actor.yaml", CASE_ACTOR_ID),
-            ("seed-vendor2.yaml", VENDOR2_ID),
+            ("seed-actor5.yaml", VENDOR2_ID),
         ]:
             cfg = _load_seed_config(filename)
             peer_ids = {p.id_ for p in cfg.peers}
@@ -230,7 +230,7 @@ class TestSeedConfigCrossConsistency:
             VENDOR_ID: _load_seed_config("seed-vendor.yaml"),
             COORDINATOR_ID: _load_seed_config("seed-coordinator.yaml"),
             CASE_ACTOR_ID: _load_seed_config("seed-case-actor.yaml"),
-            VENDOR2_ID: _load_seed_config("seed-vendor2.yaml"),
+            VENDOR2_ID: _load_seed_config("seed-actor5.yaml"),
         }
         for own_id, cfg in configs.items():
             for other_id, other_cfg in configs.items():
@@ -351,7 +351,7 @@ class TestSeedCLIWithDeterministicId:
             "seed-vendor.yaml",
             "seed-coordinator.yaml",
             "seed-case-actor.yaml",
-            "seed-vendor2.yaml",
+            "seed-actor5.yaml",
         ):
             config_path = _SEED_CONFIGS_DIR / filename
             calls, exit_code = self._run_seed_with_config(config_path)

--- a/test/docker/test_compose_env_vars.py
+++ b/test/docker/test_compose_env_vars.py
@@ -43,7 +43,7 @@ COMPOSE_FILE = (
     / "docker-compose-multi-actor.yml"
 )
 
-ACTOR_SERVICES = ("finder", "vendor", "coordinator", "case-actor", "vendor2")
+ACTOR_SERVICES = ("finder", "vendor", "coordinator", "case-actor", "actor5")
 
 #: Legacy env var names that must not appear in actor-service environments.
 LEGACY_ENV_VARS = ("VULTRON_BASE_URL", "VULTRON_DB_URL")

--- a/vultron/demo/scenario/fccv_handoff_demo.py
+++ b/vultron/demo/scenario/fccv_handoff_demo.py
@@ -129,7 +129,7 @@ FINDER_ACTOR_ID = "http://finder:7999/api/v2/actors/finder"
 C1_ACTOR_ID = "http://vendor:7999/api/v2/actors/vendor"
 C2_ACTOR_ID = "http://coordinator:7999/api/v2/actors/coordinator"
 CASE_ACTOR_ACTOR_ID = "http://case-actor:7999/api/v2/actors/case-actor"
-VENDOR_ACTOR_ID = "http://vendor2:7999/api/v2/actors/vendor2"
+VENDOR_ACTOR_ID = "http://actor5:7999/api/v2/actors/vendor2"
 
 
 def reset_containers(

--- a/vultron/demo/scenario/fvcv_extension_demo.py
+++ b/vultron/demo/scenario/fvcv_extension_demo.py
@@ -120,7 +120,7 @@ VENDOR2_BASE_URL = os.environ.get(
 FINDER_ACTOR_ID = "http://finder:7999/api/v2/actors/finder"
 VENDOR_ACTOR_ID = "http://vendor:7999/api/v2/actors/vendor"
 COORDINATOR_ACTOR_ID = "http://coordinator:7999/api/v2/actors/coordinator"
-VENDOR2_ACTOR_ID = "http://vendor2:7999/api/v2/actors/vendor2"
+VENDOR2_ACTOR_ID = "http://actor5:7999/api/v2/actors/vendor2"
 
 
 def reset_containers(

--- a/vultron/demo/scenario/fvcv_handoff_demo.py
+++ b/vultron/demo/scenario/fvcv_handoff_demo.py
@@ -123,7 +123,7 @@ FINDER_ACTOR_ID = "http://finder:7999/api/v2/actors/finder"
 VENDOR_ACTOR_ID = "http://vendor:7999/api/v2/actors/vendor"
 COORDINATOR_ACTOR_ID = "http://coordinator:7999/api/v2/actors/coordinator"
 CASE_ACTOR_ACTOR_ID = "http://case-actor:7999/api/v2/actors/case-actor"
-VENDOR2_ACTOR_ID = "http://vendor2:7999/api/v2/actors/vendor2"
+VENDOR2_ACTOR_ID = "http://actor5:7999/api/v2/actors/vendor2"
 
 
 def reset_containers(

--- a/vultron/demo/scenario/fvv_demo.py
+++ b/vultron/demo/scenario/fvv_demo.py
@@ -116,7 +116,7 @@ VENDOR2_BASE_URL = os.environ.get(
 # Deterministic actor IDs from docker-compose-multi-actor.yml (D5-1-G3).
 FINDER_ACTOR_ID = "http://finder:7999/api/v2/actors/finder"
 VENDOR_ACTOR_ID = "http://vendor:7999/api/v2/actors/vendor"
-VENDOR2_ACTOR_ID = "http://vendor2:7999/api/v2/actors/vendor2"
+VENDOR2_ACTOR_ID = "http://actor5:7999/api/v2/actors/vendor2"
 
 
 def reset_containers(

--- a/vultron/demo/scenario/multi_vendor_demo.py
+++ b/vultron/demo/scenario/multi_vendor_demo.py
@@ -123,7 +123,7 @@ FINDER_ACTOR_ID = "http://finder:7999/api/v2/actors/finder"
 VENDOR_ACTOR_ID = "http://vendor:7999/api/v2/actors/vendor"
 CASE_ACTOR_ID = "http://case-actor:7999/api/v2/actors/case-actor"
 COORDINATOR_ACTOR_ID = "http://coordinator:7999/api/v2/actors/coordinator"
-VENDOR2_ACTOR_ID = "http://vendor2:7999/api/v2/actors/vendor2"
+VENDOR2_ACTOR_ID = "http://actor5:7999/api/v2/actors/vendor2"
 
 
 def seed_containers(


### PR DESCRIPTION
- Closes #1619

## Summary

Renames the `vendor2` Docker Compose service to the scenario-neutral `actor5`
slot, allowing different scenarios to seed it with different actor identities
(Vendor2 for fvv/fvcv-* scenarios; Coordinator2 for fccv-extension). Adds
`seed-coordinator2.yaml` for the upcoming FCCV-extension scenario. The
DEMOMA-13 spec group was already merged via #1618.

## Changes

- **AC-1** (already satisfied): `specs/multi-actor-demo.yaml` DEMOMA-13 group present from #1618
- **AC-2**: `docker/docker-compose-multi-actor.yml` — service `vendor2` → `actor5`; volume `vendor2-data` → `actor5-data`; `VULTRON_VENDOR2_BASE_URL` updated to `http://actor5:7999/api/v2`; health-check dep updated; `VULTRON_ACTOR_ID` default set to `/actors/vendor2` with comment explaining override pattern
- **AC-3**: `seed-vendor2.yaml` renamed to `seed-actor5.yaml` with actor ID updated to `actor5:7999` hostname; new `seed-coordinator2.yaml` added for `coordinator2` actor; peer entries in `seed-case-actor.yaml`, `seed-coordinator.yaml`, `seed-finder.yaml`, `seed-vendor.yaml` updated to `actor5:7999` DNS
- **AC-4**: `fvcv_extension_demo.py`, `fvcv_handoff_demo.py`, `fvv_demo.py`, `multi_vendor_demo.py`, `fccv_handoff_demo.py` — `VENDOR2_ACTOR_ID`/`VENDOR_ACTOR_ID` updated to `actor5:7999` hostname
- **AC-5**: `.github/workflows/demo-integration.yml` — log-collection loop updated from `vendor2` to `actor5`
- **Tests fixed**: `test/demo/test_multi_actor_seed.py`, `test/demo/test_multi_actor_compose.py`, `test/docker/test_compose_env_vars.py` updated to match renamed service and new actor IDs
- `integration_tests/demo/run_multi_actor_integration_test.sh` comment updated: `VENDOR2_HOST_PORT` → `ACTOR5_HOST_PORT`
- Conflict resolved: `demo-integration.yml` was refactored to a matrix strategy in #1638; conflict resolved by keeping the matrix structure and applying only the `vendor2` → `actor5` rename

## Test plan

- [x] `uv run black` — clean
- [x] `uv run flake8` — clean
- [x] `uv run mypy` — 0 issues
- [x] `uv run pyright` — 0 errors/warnings
- [x] `uv run pytest --tb=short` — 5372 passed, 212 skipped, 2 xfailed (pre-existing)
- [ ] Docker integration tests (fv, fvv, fvcv-extension, fvcv-handoff, fccv-handoff, fcv) run via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)