### PR TITLE
process: pr-ship pipeline — triage → execute → verify

### DIFF
--- a/.agents/skills/dev-status/REFERENCE.md
+++ b/.agents/skills/dev-status/REFERENCE.md
@@ -166,9 +166,9 @@ gh pr list --repo CERTCC/Vultron \
   --jq '.[] | "\(.number): \(.title) [review=\(.reviewDecision // "NONE")] [ci=\(.statusCheckRollup // [] | map(.conclusion) | unique | join(","))]"'
 ```
 
-Use `pr-comprehensive-fix` when any PR has failing checks or pending review
+Use `pr-ship` when any PR has failing checks or pending review
 comments. When all PRs are green and approved, the count is still shown but
-the row skill column should list `pr-comprehensive-fix` (it handles review
+the row skill column should list `pr-ship` (it handles review
 preparation too).
 
 ## Query: Incoming Learnings File Count
@@ -191,7 +191,7 @@ empty (only `.gitkeep` present or directory missing).
 | Ideas (open)          |  {n}  | plan-issue           |
 | Bugs (open)           |  {n}  | bugfix               |
 | Concerns (open)       |  {n}  | process-concerns     |
-| Open PRs              |  {n}  | pr-comprehensive-fix |
+| Open PRs              |  {n}  | pr-ship |
 | Triage (Someday)      |  {n}  | review-priorities    |
 | Ready to build        |  {n}  | build                |
 

--- a/.agents/skills/dev-status/SKILL.md
+++ b/.agents/skills/dev-status/SKILL.md
@@ -56,7 +56,7 @@ Print a single table followed by a "Next up" callout:
 | Ideas (open)           |   1   | plan-issue           |
 | Bugs (open)            |   3   | bugfix               |
 | Concerns (open)        |   0   | —                    |
-| Open PRs               |   2   | pr-comprehensive-fix |
+| Open PRs               |   2   | pr-ship              |
 | Triage (Someday)       |   5   | review-priorities    |
 | Ready to build         |   4   | build                |
 
@@ -81,7 +81,7 @@ list all non-zero conditions as `ask_user` choices):
 2. `process-concerns` — open Concern issues
 3. `plan-issue` — open Idea or Concern issues
 4. `bugfix` — open Bug issues
-5. `pr-comprehensive-fix` — open PRs > 0
+5. `pr-ship` — open PRs > 0
 6. `review-priorities` — triage items > 0 (Schedule=Someday with no Epic)
 7. `build` — ready-to-build count > 0
 8. *(stop)* — all queues empty, nothing actionable

--- a/.agents/skills/pr-comprehensive-fix/SKILL.md
+++ b/.agents/skills/pr-comprehensive-fix/SKILL.md
@@ -1,14 +1,17 @@
 ---
 name: pr-comprehensive-fix
 description: >
-  Complete PR fix workflow that addresses review comments, CI failures, and test issues
-  holistically. Inventory all problems first, fix code batch, run full test suite intelligently
-  (integration tests for demo/adapter changes), and mark comments resolved individually.
-  Use when a PR has multiple problems (review feedback + CI failures) and you want to ensure
-  nothing gets missed.
+  DEPRECATED — use /pr-ship (full pipeline) or /pr-execute (fix phase only)
+  instead. Kept as reference for testing logic and comment resolution strategies
+  absorbed into pr-execute/REFERENCE.md; do not invoke directly for new work.
 ---
 
 # Comprehensive PR Fix Workflow
+
+> **Deprecated.** This skill has been superseded by `pr-execute`, which reads
+> a triage artifact rather than re-discovering problems. `TESTING-LOGIC.md`
+> and `RESOLUTION-GUIDE.md` remain authoritative references consumed by
+> `pr-execute/REFERENCE.md`. Do not invoke `/pr-comprehensive-fix` for new work.
 
 ## Purpose
 

--- a/.agents/skills/pr-execute/REFERENCE.md
+++ b/.agents/skills/pr-execute/REFERENCE.md
@@ -1,0 +1,222 @@
+# PR Execute — Reference
+
+Detailed criteria consumed during execution. Referenced from SKILL.md.
+
+---
+
+## Integration Test Detection
+
+`pr_metadata.needs_integration_tests` is set by `pr-triage`. Execute reads
+this flag — it does not re-detect. The detection logic (for reference) is:
+
+Run **full suite (unit + integration)** if PR modifies any of:
+
+- `demo/` — any demo script or orchestration file
+- `integration_tests/` — any integration test file
+- `adapters/` — driving or driven adapters
+- `vultron/core/behaviors/` — behavior tree logic
+- `vultron/core/use_cases/` — use-case implementations
+- `vultron/wire/as2/extractor.py` — semantic extraction
+
+---
+
+## Test Failure Rules
+
+### All Tests Pass ✅
+
+Proceed to Phase 5.
+
+### Unit Tests Fail ❌
+
+**Default assumption**: current PR changes caused the failure until disproven.
+
+**Action**:
+
+1. Display failure output.
+2. Fix branch-owned issues directly; re-run relevant tests.
+3. Classify as pre-existing **only after**:
+   - Clean-base proof: checkout main (or equivalent), run same test, confirm
+     it fails there too.
+   - At least one causality check: confirm no line in the PR diff plausibly
+     causes the failure.
+4. If pre-existing is proven: create/update a Bug issue with evidence via
+   `manage-github-issue`; wire structured blockers; post a handoff comment.
+5. If evidence is incomplete: treat as PR-owned and continue debugging.
+
+### Integration Tests Fail ❌
+
+**Default assumption**: current PR changes caused the failure until disproven.
+
+**Action**:
+
+1. Display failure output (first 50 lines + last 20 for context).
+2. Perform targeted causality checks against the PR diff.
+3. Allow "unrelated/pre-existing" only with clean-base + causality evidence.
+4. If pre-existing is proven: create/update a Bug issue with evidence; wire
+   blockers via `manage-github-issue`; add a handoff comment.
+5. Stop only after recording blocked/unblocked status with linked evidence.
+
+Integration tests can fail due to: missing environment setup, timing issues
+in demo orchestration, architectural breaking changes, or infrastructure
+problems (docker, network). All require evidence-based triage — not just
+"looks unrelated."
+
+### When to Stop and Report
+
+Stop and surface to the user if:
+
+- Integration test failure with unclear root cause after causality checks
+- 2+ consecutive test failures after fix attempts
+- Test output suggests missing context (env vars, setup, infrastructure)
+- Error suggests architectural issue (breaking change to core logic)
+
+Report the state with linked Bug issue evidence, structured blockers, and
+explicit blocked/unblocked status.
+
+---
+
+## Comment Resolution
+
+For each unresolved review comment, the resolution strategy is:
+
+### ✅ Fully Addressed
+
+The code change directly addresses what was asked.
+
+**Resolution message template**:
+> "Addressed in commit `{commit_ref}`: {one-sentence description of what changed}."
+
+### ⚠️ Partially Addressed
+
+The immediate issue is fixed but something related cannot be addressed now.
+
+**Reply template**:
+> "Addressed the immediate issue in commit `{commit_ref}`. The broader concern
+> around {topic} is tracked in #{issue_number}. Leaving this thread open for
+> the reviewer to close if the immediate fix is sufficient."
+
+### ❌ Cannot Address / Needs Discussion
+
+The comment raises something outside the PR's scope or requiring design work.
+
+**Reply template**:
+> "This would require {brief explanation}. Filed as #{issue_number} for
+> separate treatment. Can we discuss whether this should block merge?"
+
+### Do NOT Resolve If
+
+- The code change doesn't actually address the comment
+- The comment asks for something that requires reviewer decision
+- The comment suggests a breaking change needing discussion
+- The comment is about future work that's been deferred
+
+Leave unresolved and reply — let the reviewer close it when satisfied.
+
+### Architecture/Design Comments
+
+If the comment asks "why X instead of Y":
+
+- If decision is in an ADR or design note: resolve with reference.
+- If it deserves discussion: reply, do not mark resolved.
+
+---
+
+## Execute Artifact Schema
+
+File: `.claude/pr-{number}-execute.json`
+
+```json
+{
+  "schema_version": "1.0",
+  "pr_number": 1234,
+  "timestamp": "2026-01-01T00:00:00Z",
+  "integration_tests_run": true,
+  "final_ci_status": "passing",
+  "results": [
+    {
+      "finding_id": "phase5-missing-nonemptystring-0",
+      "outcome": "fixed",
+      "commit_ref": "abc1234",
+      "issue_number": null,
+      "skip_reason": null,
+      "comment_resolution": "Addressed in commit abc1234: changed field to OptionalNonEmptyString."
+    },
+    {
+      "finding_id": "phase8-unused-import-0",
+      "outcome": "fixed",
+      "commit_ref": "abc1234",
+      "issue_number": null,
+      "skip_reason": null,
+      "comment_resolution": null
+    },
+    {
+      "finding_id": "phase9-distant-refactor-0",
+      "outcome": "deferred-ask",
+      "commit_ref": null,
+      "issue_number": 999,
+      "skip_reason": "Non-trivial, distant cousin — filed as #999, awaiting user decision on fold-in.",
+      "comment_resolution": null
+    }
+  ],
+  "execute_comment_url": "https://github.com/CERTCC/Vultron/pull/1234#issuecomment-..."
+}
+```
+
+### Outcome Values
+
+| Value | Meaning |
+|---|---|
+| `fixed` | Applied inline; commit_ref recorded |
+| `filed` | GitHub issue created; issue_number recorded |
+| `deferred-ask` | Issue filed; user asked whether to fold in; awaiting decision |
+| `skipped` | Could not address; skip_reason explains why |
+
+**Integrity check**: `len(results)` must equal `len(triage.findings)`. Every
+finding must have an outcome. `pr-verify` checks this count and warns if they
+diverge (indicating execute was interrupted before completion).
+
+---
+
+## Execute Comment Format
+
+```markdown
+## PR Execute: #<number> — <title>
+
+**Fixes applied**: <N> commits
+**Issues filed**: <M>
+**Deferred (awaiting your input)**: <K>
+**Tests run**: unit only / unit + integration
+**CI status after push**: ✅ passing / ❌ failing / ⏳ pending
+
+---
+
+### Fixed
+
+| Finding | Commit |
+|---|---|
+| phase5-missing-nonemptystring-0: Field must use OptionalNonEmptyString | `abc1234` |
+| phase8-unused-import-0: Remove unused import | `abc1234` |
+
+### Filed as Issues
+
+| Finding | Issue |
+|---|---|
+| phase9-distant-refactor-0: Refactor dispatcher | #999 |
+
+### Deferred — Awaiting Your Input
+
+| Finding | Issue | Question |
+|---|---|---|
+| phase8-extract-helper-0: Extract helper function | #1000 | Fold into this PR or leave for #1000? |
+
+### Skipped
+
+| Finding | Reason |
+|---|---|
+| phase11-preexisting-test-fail-0 | Pre-existing failure; filed as Bug #1001 with evidence |
+
+---
+
+*Execute artifact: `.claude/pr-<number>-execute.json`*
+*Next step: run `/pr-verify` or wait for CI, then `/pr-ship` will continue automatically.*
+```

--- a/.agents/skills/pr-execute/SKILL.md
+++ b/.agents/skills/pr-execute/SKILL.md
@@ -51,6 +51,9 @@ Run /pr-triage first (or /pr-ship to run the full pipeline).
 For each finding where `decision_outcome` is `fix-now` or `fix-now-expand-scope`
 and `severity` is `FAIL` or `IMPROVE`:
 
+> Note: findings with `severity: NEW-ISSUE` are handled exclusively in Phase 5,
+> regardless of their `decision_outcome`. Do not process them here.
+
 1. Apply the fix (edit files as needed).
 2. Do not commit yet — batch all fixes, then commit once at the end of this phase.
 3. After all fixes are applied: `uv run black <changed files>` then commit:
@@ -64,6 +67,7 @@ and `severity` is `FAIL` or `IMPROVE`:
    ```
 
 4. Record `commit_ref` (short SHA) for each finding addressed in this commit.
+5. Push the branch: `git push` — CI must see the new commits before Phase 4.
 
 ### Phase 3 — CI Remediation
 
@@ -75,7 +79,8 @@ For findings from Phase 11 (CI failures) in the triage artifact:
 3. Fix lint/type/format failures directly (these are always branch-owned).
 4. For test failures: apply the branch-ownership rule from [REFERENCE.md](REFERENCE.md)
    § "Test Failure Rules" before classifying anything as pre-existing.
-5. Commit CI fixes separately from Phase 2 fixes:
+5. Run `uv run black <changed files>` before committing — mirroring Phase 2.
+6. Commit CI fixes separately from Phase 2 fixes:
 
    ```text
    fix(ci): resolve CI failures — <summary>
@@ -83,7 +88,8 @@ For findings from Phase 11 (CI failures) in the triage artifact:
    Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
    ```
 
-6. Record `commit_ref` for each CI finding addressed.
+7. Push the branch: `git push`.
+8. Record `commit_ref` for each CI finding addressed.
 
 ### Phase 4 — Run Test Suite
 

--- a/.agents/skills/pr-execute/SKILL.md
+++ b/.agents/skills/pr-execute/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: pr-execute
+description: >
+  Execution phase of the PR review pipeline. Reads .claude/pr-{number}-triage.json,
+  applies all FAIL/IMPROVE fixes inline, remediates CI failures, files GitHub issues
+  for out-of-scope findings, resolves review thread comments, and writes
+  .claude/pr-{number}-execute.json. Use after /pr-triage, or as the second step
+  of /pr-ship.
+---
+
+# Skill: PR Execute
+
+## Purpose
+
+Execute consumes the closed finding list from `pr-triage` and processes it in
+one batch pass. No new discovery happens here. The finding set is fixed at the
+start; execute either resolves each item or records why it was skipped.
+
+## Quick Start
+
+```bash
+# Execute against the current branch's open PR
+/pr-execute
+
+# Execute against a specific PR number
+/pr-execute 1234
+```
+
+## Prerequisites
+
+`.claude/pr-{number}-triage.json` must exist. If absent, stop immediately:
+
+```text
+❌ No triage artifact found for PR #N.
+Run /pr-triage first (or /pr-ship to run the full pipeline).
+```
+
+## Workflow
+
+### Phase 1 — Load Triage Artifact
+
+1. Detect PR number (current branch or explicit argument).
+2. Read `.claude/pr-{number}-triage.json`.
+3. Validate `schema_version == "1.0"`. If mismatch, stop and report.
+4. Extract `pr_metadata.domains` and invoke `deepen-context` with those hints
+   to load the same domain context that triage used.
+5. Check `pr_metadata.needs_integration_tests` — determines test scope in Phase 4.
+
+### Phase 2 — Apply fix-now Fixes
+
+For each finding where `decision_outcome` is `fix-now` or `fix-now-expand-scope`
+and `severity` is `FAIL` or `IMPROVE`:
+
+1. Apply the fix (edit files as needed).
+2. Do not commit yet — batch all fixes, then commit once at the end of this phase.
+3. After all fixes are applied: `uv run black <changed files>` then commit:
+
+   ```text
+   fix(pr-execute): address <N> findings from triage
+
+   <bullet per finding: phase-name — short description>
+
+   Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+   ```
+
+4. Record `commit_ref` (short SHA) for each finding addressed in this commit.
+
+### Phase 3 — CI Remediation
+
+For findings from Phase 11 (CI failures) in the triage artifact:
+
+1. Fetch current CI failure logs: `gh run list --branch <head_ref> --limit 1`
+   then `gh run view <run-id> --log-failed`.
+2. Parse failure output — identify root causes (lint, type errors, test failures).
+3. Fix lint/type/format failures directly (these are always branch-owned).
+4. For test failures: apply the branch-ownership rule from [REFERENCE.md](REFERENCE.md)
+   § "Test Failure Rules" before classifying anything as pre-existing.
+5. Commit CI fixes separately from Phase 2 fixes:
+
+   ```text
+   fix(ci): resolve CI failures — <summary>
+
+   Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+   ```
+
+6. Record `commit_ref` for each CI finding addressed.
+
+### Phase 4 — Run Test Suite
+
+Based on `pr_metadata.needs_integration_tests`:
+
+**Unit tests only** (flag is false):
+
+```bash
+uv run pytest --tb=short 2>&1 | tail -20
+```
+
+**Full suite** (flag is true):
+
+```bash
+uv run pytest --tb=short 2>&1 | tail -20
+uv run pytest integration_tests/ -v 2>&1 | tail -40
+```
+
+If tests fail: apply the rules from [REFERENCE.md](REFERENCE.md) § "Test Failure
+Rules". Fix branch-owned failures and re-run. If failure is proven pre-existing,
+file a Bug issue with evidence via `manage-github-issue`, wire structured blockers,
+and record the finding outcome as `skipped` with a `skip_reason` referencing the
+issue number.
+
+Do not proceed to Phase 5 until tests pass or all remaining failures are
+documented as pre-existing with linked Bug issues.
+
+### Phase 5 — Handle NEW-ISSUE Findings
+
+For each finding with `severity: NEW-ISSUE`:
+
+**`new-issue-ask`** (non-trivial, distant cousin):
+
+1. File a GitHub issue via `manage-github-issue` capturing the finding description.
+2. Add the issue to Project #24: `bash .agents/skills/shared/add-to-project.sh <N>`.
+3. Record the finding as `outcome: deferred-ask` with the new `issue_number`.
+4. Do NOT fold the work into this PR yet — the deferred-ask items are surfaced
+   in the execute comment and again in pr-verify for the user to decide.
+
+**`new-issue-no-ask`** (requires separate design effort):
+
+1. File a GitHub issue via `manage-github-issue`.
+2. Add to Project #24.
+3. Record as `outcome: filed` with `issue_number`.
+
+### Phase 6 — Resolve Review Thread Comments
+
+For each unresolved review comment on the PR (fetched via
+`gh api repos/CERTCC/Vultron/pulls/<number>/comments`):
+
+Match each comment to the finding(s) it corresponds to. Then per
+[REFERENCE.md](REFERENCE.md) § "Comment Resolution":
+
+- ✅ Fully addressed → resolve with commit reference
+- ⚠️ Partially addressed → reply explaining why; leave for reviewer to close
+- ❌ Cannot address → reply explaining why; reference any filed issue
+
+Do not mark a comment resolved unless the code actually addresses it.
+
+### Phase 7 — Emit Artifact and Post Comment
+
+1. Build the execute artifact in memory throughout Phases 2–6; write it only now.
+   Write `.claude/pr-{number}-execute.json` per the schema in [REFERENCE.md](REFERENCE.md).
+2. Render the execute summary comment (format in [REFERENCE.md](REFERENCE.md)
+   § "Execute Comment Format").
+3. Post comment: `gh pr review <number> --comment --body "<summary>"`
+4. Record `execute_comment_url` in the artifact; re-write the file with the URL.
+5. Print artifact path and outcome summary to stdout.
+
+## No User Prompts (Except One)
+
+Execute runs to completion without user prompts, with one exception:
+
+**`new-issue-ask` findings**: after filing the issue, post a comment noting the
+finding, then stop and ask the user:
+
+> "Found a non-trivial issue (distant cousin): <description> — filed as #N.
+> Should I fold this into the current PR, or leave it for the new issue?
+> (If no response, I'll leave it for the issue and continue.)"
+
+Wait for a response. If no response within the session, record as `deferred-ask`
+and continue. The question is genuine — do not treat silence as approval to
+expand scope.
+
+## Artifact Location
+
+`.claude/pr-{number}-execute.json` — never committed; must be gitignored.

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: pr-review
 description: >
-  Comprehensive pull request review for the Vultron project. Verifies that
-  a PR addresses its originating GitHub issue(s), conforms to Vultron specs
-  and notes, follows AGENTS.md coding rules and naming conventions, has
-  adequate test coverage, and passes linting requirements. Produces a
-  structured PASS/FAIL/IMPROVE/DEFER report, attempts fixes for FAIL and
-  IMPROVE findings, and posts results as a GitHub PR review comment. Use
-  when the user asks to review a PR, validate a PR before merge, or audit
-  a PR against project standards.
+  DEPRECATED — use /pr-ship (full pipeline) or /pr-triage (discovery only)
+  instead. Kept as canonical prose reference for the 11 inspection phases;
+  do not invoke directly for new work.
 ---
 
 # Skill: PR Review
+
+> **Deprecated.** This skill has been superseded by the `pr-triage` →
+> `pr-execute` → `pr-verify` pipeline, invoked via `/pr-ship`. The phase
+> descriptions below remain the authoritative reference for what `pr-triage`
+> inspects. Do not invoke `/pr-review` for new work.
 
 ## Finding Severity
 

--- a/.agents/skills/pr-ship/SKILL.md
+++ b/.agents/skills/pr-ship/SKILL.md
@@ -68,6 +68,14 @@ Before running any phase, check for existing artifacts:
 
 When resuming, print which phase is being skipped and why.
 
+## Execution Model
+
+**Run all steps in a single uninterrupted pass.** Do not end your turn or wait
+for user input between steps. When a sub-skill returns, proceed immediately to
+the next step without pausing. The only valid mid-pipeline stop is a
+`new-issue-ask` prompt inside pr-execute. Every other step transition is
+automatic.
+
 ## Workflow
 
 ### Step 1 — Detect PR
@@ -117,6 +125,8 @@ Otherwise: invoke the `pr-triage` skill with the PR number.
 If triage fails (no findings written, error reported): stop. Do not proceed
 to execute with a missing or malformed artifact.
 
+When pr-triage returns successfully, proceed immediately to Step 5.
+
 ### Step 5 — Run pr-execute (or skip)
 
 If resuming past execute: print `⏩ Skipping execute — artifact found at .claude/pr-{N}-execute.json`
@@ -130,9 +140,13 @@ If execute stops due to a blocking test failure (pre-existing with linked Bug
 issue): report the blocked status and stop pr-ship. The user must resolve the
 blocker before re-running.
 
+When pr-execute returns successfully, proceed immediately to Step 6.
+
 ### Step 6 — Run pr-verify
 
 Invoke the `pr-verify` skill with the PR number.
+
+When pr-verify returns, proceed immediately to Step 7.
 
 ### Step 7 — Final Report
 

--- a/.agents/skills/pr-ship/SKILL.md
+++ b/.agents/skills/pr-ship/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: pr-ship
+description: >
+  End-to-end PR review pipeline. Detects the PR on the current branch, then
+  runs pr-triage → pr-execute → pr-verify in sequence. Supports resume: if
+  artifacts already exist from a prior run, skips forward to the right phase.
+  No user prompts except the one deferred-ask pause in pr-execute. Precondition:
+  an open PR must exist for the current branch (or provide an explicit PR number).
+---
+
+# Skill: PR Ship
+
+## Purpose
+
+Single entry point for the full triage → execute → verify pipeline. Run this
+after pushing a branch with an open PR and let it complete. The only expected
+pause is a `new-issue-ask` finding in execute — all other steps run unattended.
+
+## Quick Start
+
+```bash
+# Run full pipeline for the current branch's PR
+/pr-ship
+
+# Run full pipeline for a specific PR number
+/pr-ship 1234
+```
+
+## Preconditions
+
+1. An open PR must exist for the current branch (or an explicit PR number is
+   provided).
+2. The working tree must be clean (`git status --porcelain` returns empty).
+   Execute will commit fixes — a dirty worktree creates ambiguity about which
+   changes are pre-existing. Stop and report if the worktree is dirty.
+3. `.claude/pr-*.json` files must be gitignored (see below). Stop and warn if
+   not, before writing any artifact.
+
+## Gitignore Check
+
+Before Phase 1, verify that `.claude/pr-*.json` is covered by `.gitignore`.
+
+```bash
+git check-ignore -q .claude/pr-1-triage.json 2>/dev/null
+```
+
+If the check fails (exit non-zero), add the pattern and note it:
+
+```bash
+echo '.claude/pr-*.json' >> .gitignore
+```
+
+Do not commit this change as part of pr-ship — leave it as an uncommitted
+one-liner for the user to include in whatever commit makes sense, or as a
+standalone commit if it would otherwise be lost.
+
+## Resume Behavior
+
+Before running any phase, check for existing artifacts:
+
+| Condition | Action |
+|---|---|
+| No artifacts exist | Run full pipeline: triage → execute → verify |
+| `pr-{N}-triage.json` exists, `pr-{N}-execute.json` absent | Skip triage; start at execute |
+| Both artifacts exist | Skip triage and execute; start at verify |
+| Verify ran and cleaned up (no artifacts) | Pipeline already completed; report last comment URL if available |
+
+When resuming, print which phase is being skipped and why.
+
+## Workflow
+
+### Step 1 — Detect PR
+
+```bash
+gh pr view --json number,title,headRefName,state
+```
+
+Confirm state is `OPEN`. If no PR exists, stop:
+
+```text
+❌ No open PR found for branch <head_ref>.
+Create a PR first, then re-run /pr-ship.
+```
+
+### Step 2 — Worktree Check
+
+```bash
+git status --porcelain
+```
+
+If output is non-empty, stop:
+
+```text
+❌ Working tree is not clean. Stash or commit your changes before running /pr-ship.
+Uncommitted files: <list>
+```
+
+### Step 3 — Gitignore Check
+
+As described in Preconditions above.
+
+### Step 4 — Run pr-triage (or skip)
+
+If resuming past triage: print `⏩ Skipping triage — artifact found at .claude/pr-{N}-triage.json`
+
+Otherwise: invoke the `pr-triage` skill with the PR number.
+
+If triage fails (no findings written, error reported): stop. Do not proceed
+to execute with a missing or malformed artifact.
+
+### Step 5 — Run pr-execute (or skip)
+
+If resuming past execute: print `⏩ Skipping execute — artifact found at .claude/pr-{N}-execute.json`
+
+Otherwise: invoke the `pr-execute` skill with the PR number.
+
+If execute pauses for a `new-issue-ask` decision: wait for the user's response,
+then continue. This is the only interactive pause in the pipeline.
+
+If execute stops due to a blocking test failure (pre-existing with linked Bug
+issue): report the blocked status and stop pr-ship. The user must resolve the
+blocker before re-running.
+
+### Step 6 — Run pr-verify
+
+Invoke the `pr-verify` skill with the PR number.
+
+### Step 7 — Final Report
+
+After verify completes, print:
+
+```text
+PR #N — <title>
+Overall verdict: READY-TO-MERGE / GAPS-FOUND / PENDING-CI
+
+PR URL: https://github.com/CERTCC/Vultron/pull/N
+```
+
+If `GAPS-FOUND`: print which findings are unresolved and suggest re-running
+`/pr-execute` after addressing them manually.
+
+If `PENDING-CI`: print the PR URL and note that CI is still running. Re-run
+`/pr-ship` (or `/pr-verify`) after CI completes to get the final verdict and
+clean up artifacts.
+
+## Failure Handling
+
+If any step fails (unexpected error, not a structured stop):
+
+- Stop immediately at that phase.
+- Report which phase failed.
+- Print artifact paths for any files written so far.
+- Do NOT clean up artifacts — they preserve the work done up to the failure
+  point for manual inspection or resume.
+
+Artifacts are only cleaned up by `pr-verify` on a successful `READY-TO-MERGE`
+or `PENDING-CI` verdict.

--- a/.agents/skills/pr-ship/SKILL.md
+++ b/.agents/skills/pr-ship/SKILL.md
@@ -62,7 +62,8 @@ Before running any phase, check for existing artifacts:
 |---|---|
 | No artifacts exist | Run full pipeline: triage → execute → verify |
 | `pr-{N}-triage.json` exists, `pr-{N}-execute.json` absent | Skip triage; start at execute |
-| Both artifacts exist | Skip triage and execute; start at verify |
+| Both artifacts exist AND last verify verdict was not GAPS-FOUND | Skip triage and execute; start at verify |
+| Both artifacts exist AND last verify verdict was GAPS-FOUND | Delete `.claude/pr-{N}-execute.json`; re-run execute then verify |
 | Verify ran and cleaned up (no artifacts) | Pipeline already completed; report last comment URL if available |
 
 When resuming, print which phase is being skipped and why.
@@ -82,7 +83,19 @@ Confirm state is `OPEN`. If no PR exists, stop:
 Create a PR first, then re-run /pr-ship.
 ```
 
-### Step 2 — Worktree Check
+### Step 2 — Gitignore Check
+
+As described in Preconditions above. **Run this before the worktree check** —
+adding `.claude/pr-*.json` to `.gitignore` (when missing) creates a dirty file.
+Commit the `.gitignore` change immediately if it was written:
+
+```bash
+git add .gitignore && git commit -m "chore: gitignore pr-*.json session artifacts
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+### Step 3 — Worktree Check
 
 ```bash
 git status --porcelain
@@ -94,10 +107,6 @@ If output is non-empty, stop:
 ❌ Working tree is not clean. Stash or commit your changes before running /pr-ship.
 Uncommitted files: <list>
 ```
-
-### Step 3 — Gitignore Check
-
-As described in Preconditions above.
 
 ### Step 4 — Run pr-triage (or skip)
 
@@ -136,8 +145,12 @@ Overall verdict: READY-TO-MERGE / GAPS-FOUND / PENDING-CI
 PR URL: https://github.com/CERTCC/Vultron/pull/N
 ```
 
-If `GAPS-FOUND`: print which findings are unresolved and suggest re-running
-`/pr-execute` after addressing them manually.
+If `GAPS-FOUND`: print which findings are unresolved. To retry:
+
+1. Address the gaps manually (or re-run `/pr-execute` after deleting
+   `.claude/pr-{N}-execute.json` to force re-execution).
+2. Then re-run `/pr-ship` — the resume logic will detect the missing execute
+   artifact and re-run execute before verify.
 
 If `PENDING-CI`: print the PR URL and note that CI is still running. Re-run
 `/pr-ship` (or `/pr-verify`) after CI completes to get the final verdict and

--- a/.agents/skills/pr-triage/REFERENCE.md
+++ b/.agents/skills/pr-triage/REFERENCE.md
@@ -1,0 +1,244 @@
+# PR Triage — Reference
+
+Detailed criteria for each triage phase, the artifact schema, and the comment
+format. Referenced from SKILL.md.
+
+---
+
+## Spec Conformance Criteria
+
+When checking changed code against loaded specs, focus on the spec IDs most
+relevant to the changed file paths:
+
+| Changed path prefix | Primary specs to load |
+|---|---|
+| `vultron/wire/as2/` | `architecture.yaml` (ARCH-14), `code-style.yaml` (CS-08) |
+| `vultron/core/behaviors/` | `behavior-tree-integration.yaml`, `behavior-tree-node-design.yaml` |
+| `vultron/core/use_cases/` | `behavior-tree-integration.yaml` (BT-06, BT-15), `inbox-orchestration.yaml` |
+| `vultron/core/models/` | `architecture.yaml` (ARCH-10, ARCH-12), `code-style.yaml` (CS-20) |
+| `vultron/adapters/` | `outbox.yaml`, `architecture.yaml` (ARCH-14) |
+| `vultron/demo/` | `behavior-tree-integration.yaml` (BT demo patterns) |
+| `docs/`, `notes/`, `specs/` | `project-documentation.yaml` |
+| `plan/history/` | `history-management.yaml` (HM-01–HM-05) |
+
+For each spec ID mentioned in the linked issue or PR body, confirm the
+corresponding requirement is met in the diff.
+
+---
+
+## AGENTS.md Rule Checklist
+
+Check the diff for violations of these non-negotiable rules. Emit **FAIL** for
+confirmed violations.
+
+### Naming
+
+- [ ] Domain class names use CVD-domain vocabulary, not wire-format parallels
+- [ ] `vul` (not `vuln`) as the abbreviation for vulnerability
+- [ ] Wire layer classes in `vultron/wire/as2/vocab/objects/` use `as_` prefix
+- [ ] Core domain classes do NOT use `as_` prefix
+- [ ] Use-case classes follow Received/Svc/\_trigger naming conventions
+
+### Type Safety and Validation
+
+- [ ] No `Optional[str]` fields that accept empty strings — use `NonEmptyString`
+  or `OptionalNonEmptyString`, or add a validator
+- [ ] No new `Any` usages without justification
+- [ ] Pydantic v2 style (`model_validator`, `field_validator`) throughout
+- [ ] Fail-fast domain objects: required fields not typed as `X | None`
+  in concrete subclasses (ARCH-10-001)
+- [ ] Protocol fields stay in sync with concrete implementations (CS-20-001)
+- [ ] `TypeGuard` discriminators use only Protocol-declared fields (CS-20-002)
+
+### BT Integration (if `behaviors/` or `use_cases/` changed)
+
+- [ ] BT nodes do NOT call use-case classes from `update()` (no BT→UC→BT chain)
+- [ ] BT nodes do NOT import from use-case modules
+- [ ] `update()` stays under ~20–30 lines; large nodes decomposed into subtrees
+- [ ] Protocol-significant behavior lives in BT leaf nodes, not in `execute()`
+- [ ] `execute()` does NOT call `dl.save()` / `dl.create()` / `dl.update()` directly
+- [ ] Received-side BTs commit the triggering activity BEFORE applying protocol effects
+- [ ] Guarded-commit BTs are role-gated (CaseActor identity check before commit)
+- [ ] No new `CommitCaseLedgerEntryNode` calls bypassing `BTBridge`
+
+### ActivityStreams / Wire Layer (if `wire/as2/` changed)
+
+- [ ] `SEMANTICS_ACTIVITY_PATTERNS`: specific patterns ordered before general ones
+- [ ] `rehydrate()` called before pattern matching
+- [ ] Outbound activities use factory functions in `vultron.wire.as2.factories`
+- [ ] `as_VulnerabilityCase` (wire) vs `VulnerabilityCase` (core) — correct prefix in each layer
+
+### Use Cases (if `use_cases/` changed)
+
+- [ ] Received-side use cases do NOT spoof another actor's identity
+- [ ] Trigger-side `execute()` delegates SM transitions to `BTBridge`, not inline
+- [ ] No `case_addressees()` on the participant sender side (PCR-08-001/02)
+
+### Adapters (if `adapters/` changed)
+
+- [ ] Stub adapter files raise `NotImplementedError`, not silent no-op
+- [ ] `create_app()` does NOT mutate module-level singletons
+- [ ] Actor IDs are full URIs
+
+### Module Organization
+
+- [ ] No flat `nodes.py` in BT areas (must use `nodes/` subpackage)
+- [ ] New submodules after a split stay under 500 lines
+- [ ] Subpackage `__init__.py` re-exports all public names (including request models)
+
+---
+
+## ADR Check Criteria
+
+Architectural signals that warrant an ADR (per `notes/specs-vs-adrs.md`
+MS-11-001–MS-11-006):
+
+- Introducing a new layer or cross-layer dependency direction
+- Changing the public API or persistence schema
+- Adding a new adapter type (driving or driven)
+- Changing how BT execution is orchestrated (e.g., concurrency model)
+- Adopting a new protocol pattern with broad reuse implications
+- Reversing or superseding a previous architectural decision
+
+**Check procedure:**
+
+1. `gh pr diff <number> -- docs/adr/` — did the PR add or modify an ADR?
+2. `cat docs/adr/index.md` — does an existing ADR cover the area changed?
+3. If the PR's approach contradicts an existing ADR without a new ADR: **FAIL**.
+4. If the change has architectural signals but no ADR: **IMPROVE** with a
+   suggested title for the ADR.
+
+---
+
+## Notes and Docs Currency Criteria
+
+### Domain-to-notes mapping
+
+| Changed domain | Potentially relevant notes files |
+|---|---|
+| `wire/as2/` | `activitystreams-semantics.md`, `vocabulary-registry.md` |
+| `core/behaviors/` | `bt-integration.md` |
+| `core/use_cases/` | `bt-integration.md`, `event-driven-control-flow.md` |
+| `core/models/case` | `case-state-model.md`, `case-communication-model.md` |
+| `adapters/` | `architecture-adapters.md`, `architecture-hexagonal.md` |
+| `core/ports/` | `architecture-hexagonal.md` |
+| Embargo logic | `participant-embargo-consent.md`, `embargo-lifecycle.md` |
+| Case ledger | `case-ledger-authority.md` |
+| Inbox processing | `inbox-orchestration.md` |
+| Participant routing | `case-communication-model.md` |
+
+### Check procedure
+
+1. Identify relevant notes from the table above.
+2. For each relevant note: was it modified in the PR diff? If not: **IMPROVE**.
+3. For each `notes/*.md` file **modified** in the PR: validate frontmatter.
+4. If any modified note has `status: superseded`, flag that it should have
+   been moved to `archived_notes/` instead of edited.
+5. If `docs/` was modified: confirm `uv run mkdocs build --strict` passed
+   (check CI or note it as pending).
+
+---
+
+## Integration Test Detection
+
+Emit a finding (captured as `needs_integration_tests: true` in `pr_metadata`)
+if the PR modifies any of:
+
+- `demo/` — any demo script or orchestration file
+- `integration_tests/` — any integration test file
+- `adapters/` — driving or driven adapters
+- `vultron/core/behaviors/` — behavior tree logic
+- `vultron/core/use_cases/` — use-case implementations
+- `vultron/wire/as2/extractor.py` — semantic extraction
+
+`pr-execute` reads this flag from `pr_metadata` to decide whether to run the
+full suite.
+
+---
+
+## Triage Artifact Schema
+
+File: `.claude/pr-{number}-triage.json`
+
+```json
+{
+  "schema_version": "1.0",
+  "pr_number": 1234,
+  "timestamp": "2026-01-01T00:00:00Z",
+  "pr_metadata": {
+    "title": "...",
+    "head_ref": "task/1234-slug",
+    "base_ref": "main",
+    "linked_issues": [100, 101],
+    "changed_files": ["vultron/core/behaviors/foo.py"],
+    "ci_status": "failing",
+    "domains": ["core/behaviors"],
+    "needs_integration_tests": true
+  },
+  "findings": [
+    {
+      "id": "phase5-missing-nonemptystring-0",
+      "phase": 5,
+      "phase_name": "spec-conformance",
+      "severity": "FAIL",
+      "description": "Field `summary` typed as Optional[str] — must use OptionalNonEmptyString (CS-20-001)",
+      "decision_outcome": "fix-now",
+      "file": "vultron/core/models/case/case.py",
+      "line": 42,
+      "spec_ids": ["CS-20-001"],
+      "adr_refs": [],
+      "notes": null
+    }
+  ],
+  "triage_comment_url": "https://github.com/CERTCC/Vultron/pull/1234#issuecomment-..."
+}
+```
+
+### Finding ID Rules
+
+- Format: `phase{N}-{kebab-description}-{index}`
+- Index is a zero-based integer suffix that guarantees uniqueness within the run
+- Description is a kebab-case slug of the finding (≤ 5 words)
+- Examples: `phase7-bt-node-imports-usecase-0`, `phase11-ci-black-fail-0`
+- Execute and verify use `finding_id` as the stable cross-artifact key
+
+### Decision Outcome Values
+
+| Value | When to use |
+|---|---|
+| `fix-now` | Trivial fix OR non-trivial but same family |
+| `fix-now-expand-scope` | Non-trivial, same family, expands PR scope meaningfully |
+| `new-issue-ask` | Non-trivial, distant cousin — execute files issue then asks user |
+| `new-issue-no-ask` | Requires separate design effort — execute files issue and continues |
+
+---
+
+## Triage Comment Format
+
+```markdown
+## PR Triage: #<number> — <title>
+
+**Linked issues**: #N (<title>)
+**Changed files**: <count> files — <domains>
+**CI status**: ✅ passing / ❌ failing / ⏳ pending
+**Needs integration tests**: yes / no
+
+---
+
+### Findings
+
+| # | Phase | Severity | Description | Outcome |
+|---|---|---|---|---|
+| phase5-missing-nonemptystring-0 | spec-conformance | ❌ FAIL | Field `summary` must use OptionalNonEmptyString | fix-now |
+| phase9-bt-integration-note-stale-0 | notes-currency | ⚠️ IMPROVE | `notes/bt-integration.md` not updated | fix-now |
+| phase8-unused-import-0 | code-review | ⚠️ IMPROVE | Unused import in `behaviors/foo.py:12` | fix-now |
+
+**Total**: 2 FAIL · 1 IMPROVE · 0 NEW-ISSUE
+
+---
+
+*Triage artifact: `.claude/pr-<number>-triage.json`*
+*Next step: run `/pr-execute` or `/pr-ship` to apply fixes.*
+```
+
+Severity emoji: ❌ FAIL · ⚠️ IMPROVE · 🎫 NEW-ISSUE

--- a/.agents/skills/pr-triage/SKILL.md
+++ b/.agents/skills/pr-triage/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: pr-triage
+description: >
+  Pure-discovery phase of the PR review pipeline. Runs all 11 inspection
+  phases (orient through CI status), produces a machine-readable finding list
+  at .claude/pr-{number}-triage.json, and posts a human-readable PR comment.
+  Makes NO code changes. Use as the first step of /pr-ship, or standalone
+  when you want a full finding inventory before deciding whether to execute
+  fixes.
+---
+
+# Skill: PR Triage
+
+## Purpose
+
+Triage closes the finding list before any mutation occurs. All 11 inspection
+phases run to completion; then and only then is the artifact written and the
+comment posted. `pr-execute` reads the artifact — it never re-runs discovery.
+
+## Finding Severity
+
+This skill uses the three-category system from
+`.claude/skills/shared/completeness-doctrine.md`.
+
+| Verdict | Meaning | Required action |
+|---|---|---|
+| **FAIL** | Broken: won't work correctly, spec violated, changed behavior untested | Must be fixed before merge |
+| **IMPROVE** | Works but incomplete: missing adjacent test, stale doc, obvious gap in scope | Fix in the same session |
+| **NEW-ISSUE** | Distinct problem, out of this PR's family | Cut a GitHub issue; apply decision tree |
+
+### Decision-Tree Outcomes
+
+Each finding is tagged with one of four outcomes. Triage records the outcome
+but does NOT act on it — `pr-execute` acts.
+
+| Outcome | Condition | What execute does |
+|---|---|---|
+| `fix-now` | Trivial fix, any conceptual distance | Fix inline, mention in comment |
+| `fix-now-expand-scope` | Non-trivial, same family | Fix inline, expand PR scope |
+| `new-issue-ask` | Non-trivial, distant cousin | File issue, stop and ask user whether to fold in |
+| `new-issue-no-ask` | Requires separate design effort | File issue, continue without asking |
+
+**Same family** means: if you had to explain why you fixed both things in this
+PR, you could do it in one sentence without using the word "also."
+
+## Quick Start
+
+```bash
+# Triage the current branch's open PR
+/pr-triage
+
+# Triage a specific PR
+/pr-triage 1234
+```
+
+## Workflow
+
+### Phase 1 — Orient
+
+1. Invoke `orient-agent` to load baseline context.
+2. Identify the target PR:
+   - If a PR number was provided, use it.
+   - Otherwise detect the PR for the current branch:
+     `gh pr view --json number,title,body,headRefName,baseRefName,files`
+3. Fetch PR metadata: title, body, linked issues, changed files, CI status.
+
+### Phase 2 — Issue Linkage
+
+1. Extract closing references (`Closes #N`, `Fixes #N`) from the PR body.
+2. Fetch each linked issue: `gh issue view N --json title,body,labels`.
+3. Assess: does implementation scope match what the issue describes?
+   Emit findings for scope creep (PR does more than the issue), scope gaps
+   (issue requirements not addressed), and missing issue links.
+
+### Phase 3 — PR Body Format
+
+Check against `.claude/skills/shared/pr-body-guide.md`:
+
+- Closing references at the **top**, one per bullet
+- Required sections present (Summary, Changes, Verification for impl PRs)
+- Test counts in Verification are real numbers, not placeholders
+- Co-authored-by trailer present in all commits
+
+### Phase 4 — Domain Context
+
+1. Identify domains from changed file paths (e.g., `wire/as2/`, `core/behaviors/`,
+   `adapters/`, `demo/`).
+2. Invoke `deepen-context` with hints matching those domains.
+3. Load specs relevant to the changed domains via `load-specs` or
+   `PYTHONPATH= uv run spec-dump`.
+4. Record the domain list in `pr_metadata.domains` — execute re-uses these hints.
+
+### Phase 5 — Spec and Notes Conformance
+
+With specs loaded, check changed code against requirements. See
+[REFERENCE.md](REFERENCE.md) § "Spec Conformance Criteria" for the per-domain
+checklist. Pay particular attention to:
+
+- AGENTS.md Common Pitfalls relevant to the changed code areas
+- Any spec IDs mentioned in the PR body or issue — confirm they are satisfied
+
+### Phase 6 — ADR Check
+
+1. Scan changed files for architectural signals: new layers, new protocols,
+   changes to public APIs, persistence schema changes, new adapters, new BT
+   integration patterns.
+2. Consult `notes/specs-vs-adrs.md` (MS-11-001–MS-11-006) to determine if an
+   ADR was warranted.
+3. Check `docs/adr/index.md` for a relevant existing ADR:
+   - PR *should have* an ADR and none referenced → **IMPROVE**
+   - Existing ADR contradicted without amendment → **FAIL**
+   - New ADR added: verify it follows `docs/adr/_adr-template.md`
+
+### Phase 7 — AGENTS.md Compliance
+
+Check the diff for violations of non-negotiable coding rules. See
+[REFERENCE.md](REFERENCE.md) § "AGENTS.md Rule Checklist".
+
+### Phase 8 — Code Review Sub-Agent
+
+Invoke a `code-review` sub-agent (`agent_type: "code-reviewer"`) against the
+branch diff to surface bugs, logic errors, and security issues. Wait for the
+sub-agent to complete before proceeding — its findings must be merged into the
+finding list before the artifact is written.
+
+### Phase 9 — Notes and Docs Currency
+
+1. **Notes currency**: Identify `notes/*.md` files covering any domain touched
+   by the PR. If an active note was NOT updated: **IMPROVE** — stale guidance
+   is a real cost.
+2. **Notes frontmatter**: For any `notes/*.md` modified in the PR, validate
+   YAML frontmatter per NF-06-001/NF-06-002:
+   - Required fields: `title`, `status`
+   - If `status: superseded`, `superseded_by` must be a non-empty scalar
+3. **Docs link integrity**: If any `docs/` file was modified, flag need to run
+   `uv run mkdocs build --strict`.
+4. **Silent contradiction**: If the PR's behavior change conflicts with an
+   `active` note without updating it: **FAIL**.
+
+### Phase 10 — Test Coverage
+
+- Are new or changed behaviors covered by tests?
+- If any file under `demo/` or `adapters/` was changed: verify the PR body or
+  CI confirms the integration test suite ran.
+- Flag any public function or use-case `execute()` path with no test.
+
+### Phase 11 — Linter / CI Status
+
+1. Check CI status: `gh pr checks <number>`.
+2. Summarize which checks fail if CI is failing.
+3. Note if CI has not yet run.
+
+### Phase 12 — Emit Artifact and Post Comment
+
+This is the only phase that produces output. No mutations before this point.
+
+1. Assign a stable `id` slug to each finding: `phase{N}-{kebab-description}-{index}`
+   where index is a sequential integer suffix that guarantees uniqueness within
+   the run (e.g., `phase5-missing-nonemptystring-0`, `phase5-missing-nonemptystring-1`).
+2. Write `.claude/pr-{number}-triage.json` per the schema in [REFERENCE.md](REFERENCE.md).
+3. Render a human-readable markdown comment from the finding list (format in
+   [REFERENCE.md](REFERENCE.md) § "Triage Comment Format").
+4. Post comment: `gh pr review <number> --comment --body "<report>"`
+5. Record the returned comment URL in the artifact (`triage_comment_url`), then
+   re-write the artifact with the URL filled in.
+6. Print artifact path and finding count summary to stdout.
+
+## Artifact Location
+
+`.claude/pr-{number}-triage.json` — never committed; must be gitignored.
+
+## No Code Changes
+
+Triage never edits files, never commits, never creates issues. Any finding
+that could be resolved right now is recorded with `decision_outcome: fix-now`
+so execute can act on it. Triage just observes.

--- a/.agents/skills/pr-triage/SKILL.md
+++ b/.agents/skills/pr-triage/SKILL.md
@@ -35,8 +35,8 @@ but does NOT act on it — `pr-execute` acts.
 
 | Outcome | Condition | What execute does |
 |---|---|---|
-| `fix-now` | Trivial fix, any conceptual distance | Fix inline, mention in comment |
-| `fix-now-expand-scope` | Non-trivial, same family | Fix inline, expand PR scope |
+| `fix-now` | Trivial fix, any conceptual distance; OR non-trivial but same family (does not meaningfully expand PR scope) | Fix inline, mention in comment |
+| `fix-now-expand-scope` | Non-trivial, same family, and the fix meaningfully expands the PR's stated scope | Fix inline, expand PR scope |
 | `new-issue-ask` | Non-trivial, distant cousin | File issue, stop and ask user whether to fold in |
 | `new-issue-no-ask` | Requires separate design effort | File issue, continue without asking |
 

--- a/.agents/skills/pr-verify/REFERENCE.md
+++ b/.agents/skills/pr-verify/REFERENCE.md
@@ -1,0 +1,57 @@
+# PR Verify — Reference
+
+---
+
+## Verify Comment Format
+
+```markdown
+## PR Verify: #<number> — <title>
+
+**Overall verdict**: ✅ READY-TO-MERGE / ❌ GAPS-FOUND / ⏳ PENDING-CI
+**CI status**: ✅ passing / ❌ failing / ⏳ pending
+**Integrity check**: ✅ all <N> findings accounted for / ❌ INCOMPLETE-EXECUTE (<M> of <N> results found)
+
+---
+
+### Finding Verdicts
+
+| Finding | Severity | Outcome | Verdict |
+|---|---|---|---|
+| phase5-missing-nonemptystring-0 | ❌ FAIL | fixed @ `abc1234` | ✅ CONFIRMED |
+| phase8-unused-import-0 | ⚠️ IMPROVE | fixed @ `abc1234` | ✅ CONFIRMED |
+| phase9-distant-refactor-0 | 🎫 NEW-ISSUE | filed as #999 | 📋 NOTED |
+| phase11-preexisting-test-fail-0 | ❌ FAIL | skipped — pre-existing Bug #1001 | 📋 NOTED |
+
+---
+
+### Deferred Items — Your Decision Needed
+
+The following findings were filed as issues during execute but not folded into
+this PR. Please decide whether to fold them in before merge:
+
+| Finding | Issue | Recommendation |
+|---|---|---|
+| phase8-extract-helper-0 | #1000 | Leave for issue — low effort ratio |
+
+---
+
+*Artifacts cleaned up.* / *Artifacts preserved — re-run `/pr-execute` to address gaps.*
+```
+
+### Verdict Emoji Key
+
+| Symbol | Meaning |
+|---|---|
+| ✅ CONFIRMED | Fix present at HEAD; commit ref valid |
+| ❌ UNRESOLVED | Commit ref found but HEAD does not show the fix |
+| ❌ MISSING-COMMIT | Commit ref not found on branch |
+| 📋 NOTED | filed/skipped/deferred-ask — no code check; issue confirmed open |
+| ⚠️ INCOMPLETE-EXECUTE | Finding count mismatch; execute likely interrupted |
+
+### Overall Verdict Rules
+
+| Verdict | Condition |
+|---|---|
+| `READY-TO-MERGE` | All FAIL findings CONFIRMED; CI green; no INCOMPLETE-EXECUTE |
+| `GAPS-FOUND` | Any FAIL finding UNRESOLVED or MISSING-COMMIT; or INCOMPLETE-EXECUTE |
+| `PENDING-CI` | All findings CONFIRMED but CI not yet green (still running) |

--- a/.agents/skills/pr-verify/REFERENCE.md
+++ b/.agents/skills/pr-verify/REFERENCE.md
@@ -47,11 +47,12 @@ this PR. Please decide whether to fold them in before merge:
 | ❌ MISSING-COMMIT | Commit ref not found on branch |
 | 📋 NOTED | filed/skipped/deferred-ask — no code check; issue confirmed open |
 | ⚠️ INCOMPLETE-EXECUTE | Finding count mismatch; execute likely interrupted |
+| ⚠️ UNVERIFIED-CI-FAILING | CI still failing after execute's push; fix may be correct but cannot be confirmed |
 
 ### Overall Verdict Rules
 
 | Verdict | Condition |
 |---|---|
-| `READY-TO-MERGE` | All FAIL findings CONFIRMED; CI green; no INCOMPLETE-EXECUTE |
-| `GAPS-FOUND` | Any FAIL finding UNRESOLVED or MISSING-COMMIT; or INCOMPLETE-EXECUTE |
-| `PENDING-CI` | All findings CONFIRMED but CI not yet green (still running) |
+| `READY-TO-MERGE` | All FAIL findings CONFIRMED; CI green; no INCOMPLETE-EXECUTE; no UNVERIFIED-CI-FAILING |
+| `GAPS-FOUND` | Any FAIL finding UNRESOLVED or MISSING-COMMIT; or INCOMPLETE-EXECUTE; or any UNVERIFIED-CI-FAILING |
+| `PENDING-CI` | All findings CONFIRMED but CI not yet complete (still running/pending) |

--- a/.agents/skills/pr-verify/SKILL.md
+++ b/.agents/skills/pr-verify/SKILL.md
@@ -49,9 +49,9 @@ comment.
 2. Read `.claude/pr-{number}-execute.json`; validate `schema_version == "1.0"`.
 3. Read `.claude/pr-{number}-triage.json` if present.
 4. **Integrity check**: verify `len(execute.results) == len(triage.findings)`.
-   If counts diverge, flag as `INCOMPLETE-EXECUTE` in the verdict comment —
-   execute was likely interrupted. Do not proceed to Phase 3; skip to Phase 5
-   with an overall verdict of `GAPS-FOUND`.
+   If counts diverge, flag `INCOMPLETE-EXECUTE` and **continue to Phase 2**
+   (CI status must still be checked). After Phase 2, skip Phases 3–4 and go
+   directly to Phase 5 with an overall verdict of `GAPS-FOUND`.
 
 ### Phase 2 — CI and Test Suite Check
 
@@ -59,8 +59,9 @@ comment.
 2. If `execute.integration_tests_run == true`: confirm the integration test CI
    job is green, not just unit tests.
 3. If CI is still failing after execute's pushes: mark all findings as
-   `UNVERIFIED-CI-FAILING` — the code changes may be correct but CI must be
-   green before the PR can be considered ready.
+   `UNVERIFIED-CI-FAILING` and set overall verdict to `GAPS-FOUND` — the code
+   changes may be correct but CI must be green before the PR can be considered
+   ready.
 4. If CI is pending: note it; proceed with spot-checks but mark overall verdict
    as `PENDING-CI`.
 
@@ -98,11 +99,11 @@ For findings with `outcome: filed`, `skipped`, or `deferred-ask`: assign
 
 1. Build the per-finding verdict table.
 2. Determine overall verdict:
-   - `READY-TO-MERGE` — all FAIL findings `CONFIRMED`, CI green or pending,
-     no `INCOMPLETE-EXECUTE`
+   - `READY-TO-MERGE` — all FAIL findings `CONFIRMED`, CI green,
+     no `INCOMPLETE-EXECUTE`, no `UNVERIFIED-CI-FAILING`
    - `GAPS-FOUND` — any FAIL finding is `UNRESOLVED` or `MISSING-COMMIT`, or
-     `INCOMPLETE-EXECUTE` was flagged
-   - `PENDING-CI` — all findings confirmed but CI not yet green
+     `INCOMPLETE-EXECUTE` was flagged, or any finding is `UNVERIFIED-CI-FAILING`
+   - `PENDING-CI` — all findings confirmed but CI not yet complete (pending)
 3. If `deferred-ask` items exist: list them explicitly for user decision.
 4. Post comment: `gh pr review <number> --comment --body "<verdict>"`
 

--- a/.agents/skills/pr-verify/SKILL.md
+++ b/.agents/skills/pr-verify/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: pr-verify
+description: >
+  Verification phase of the PR review pipeline. Reads .claude/pr-{number}-execute.json,
+  spot-checks each claimed fix against HEAD (not just the commit diff), validates CI
+  and test suite, and posts a per-finding verdict comment on the PR. Cleans up both
+  artifact files as its final step. Makes NO code changes. Use after /pr-execute,
+  or as the third step of /pr-ship.
+---
+
+# Skill: PR Verify
+
+## Purpose
+
+Verify closes the loop. It checks what execute *claimed* to do against what
+actually exists at HEAD, posts a verdict, and cleans up the session artifacts.
+It does not fix anything — if gaps are found, they are flagged for the user to
+re-run `/pr-execute` or fix manually.
+
+## Quick Start
+
+```bash
+# Verify the current branch's open PR
+/pr-verify
+
+# Verify a specific PR
+/pr-verify 1234
+```
+
+## Prerequisites
+
+`.claude/pr-{number}-execute.json` must exist. If absent, stop immediately:
+
+```text
+❌ No execute artifact found for PR #N.
+Run /pr-execute first (or /pr-ship to run the full pipeline).
+```
+
+Also requires `.claude/pr-{number}-triage.json` for finding descriptions. If
+the triage artifact is missing but the execute artifact exists, proceed using
+only the execute artifact data — but note the missing triage artifact in the
+comment.
+
+## Workflow
+
+### Phase 1 — Load Artifacts
+
+1. Detect PR number (current branch or explicit argument).
+2. Read `.claude/pr-{number}-execute.json`; validate `schema_version == "1.0"`.
+3. Read `.claude/pr-{number}-triage.json` if present.
+4. **Integrity check**: verify `len(execute.results) == len(triage.findings)`.
+   If counts diverge, flag as `INCOMPLETE-EXECUTE` in the verdict comment —
+   execute was likely interrupted. Do not proceed to Phase 3; skip to Phase 5
+   with an overall verdict of `GAPS-FOUND`.
+
+### Phase 2 — CI and Test Suite Check
+
+1. `gh pr checks <number>` — fetch current CI status.
+2. If `execute.integration_tests_run == true`: confirm the integration test CI
+   job is green, not just unit tests.
+3. If CI is still failing after execute's pushes: mark all findings as
+   `UNVERIFIED-CI-FAILING` — the code changes may be correct but CI must be
+   green before the PR can be considered ready.
+4. If CI is pending: note it; proceed with spot-checks but mark overall verdict
+   as `PENDING-CI`.
+
+### Phase 3 — Spot-Verify FAIL Findings
+
+For each finding with `severity: FAIL` and `outcome: fixed`:
+
+1. Confirm `commit_ref` exists on the PR branch:
+   `git log --oneline <commit_ref>` must not error.
+2. **Check the file at HEAD** (not just the commit diff) — verify the corrected
+   state is present in the current working tree. A fix that was applied and
+   then reverted shows a clean diff at the commit ref but a broken HEAD.
+   - If `file` and `line` are recorded in the triage finding: read the file at
+     that location and confirm the fix is present.
+   - If no file/line: diff the relevant section against the commit ref to
+     confirm the change persists.
+3. Assign verdict:
+   - `CONFIRMED` — fix present at HEAD, commit ref valid
+   - `UNRESOLVED` — commit ref exists but HEAD does not show the fix
+   - `MISSING-COMMIT` — commit ref not found on branch
+
+### Phase 4 — Spot-Verify IMPROVE Findings
+
+Lighter check:
+
+1. Confirm `commit_ref` exists on the branch.
+2. Check the file at HEAD for the improvement (same HEAD-check as Phase 3).
+3. Assign `CONFIRMED` or `UNRESOLVED`.
+
+For findings with `outcome: filed`, `skipped`, or `deferred-ask`: assign
+`NOTED` — no code check needed, just confirm the issue number is real:
+`gh issue view <issue_number> --json number,state` must return an open issue.
+
+### Phase 5 — Render Verdict and Post Comment
+
+1. Build the per-finding verdict table.
+2. Determine overall verdict:
+   - `READY-TO-MERGE` — all FAIL findings `CONFIRMED`, CI green or pending,
+     no `INCOMPLETE-EXECUTE`
+   - `GAPS-FOUND` — any FAIL finding is `UNRESOLVED` or `MISSING-COMMIT`, or
+     `INCOMPLETE-EXECUTE` was flagged
+   - `PENDING-CI` — all findings confirmed but CI not yet green
+3. If `deferred-ask` items exist: list them explicitly for user decision.
+4. Post comment: `gh pr review <number> --comment --body "<verdict>"`
+
+See [REFERENCE.md](REFERENCE.md) § "Verify Comment Format" for the template.
+
+### Phase 6 — Cleanup
+
+Only runs if overall verdict is `READY-TO-MERGE` or `PENDING-CI` (i.e., no
+gaps that require re-running execute).
+
+1. Delete `.claude/pr-{number}-triage.json`
+2. Delete `.claude/pr-{number}-execute.json`
+3. Print:
+
+   ```text
+   Artifacts cleaned up.
+   PR #N is READY-TO-MERGE / PENDING-CI.
+   ```
+
+If verdict is `GAPS-FOUND`: do NOT delete artifacts. The user or a retry of
+`/pr-execute` will need them.
+
+## This Skill Does Not Fix
+
+If `UNRESOLVED` or `MISSING-COMMIT` findings appear, verify posts the gap and
+stops. The user re-runs `/pr-execute` or fixes manually. Verify never mutates
+files, never commits, never creates issues.

--- a/.agents/skills/shared/completeness-doctrine.md
+++ b/.agents/skills/shared/completeness-doctrine.md
@@ -39,7 +39,7 @@ domain, or design space) requires a judgment call:
 When unattended: choose whatever seems most correct, document the reasoning
 explicitly in a learning file, and let the user review and override.
 
-## Finding Severity (build, pr-review, bugfix)
+## Finding Severity (build, pr-triage, bugfix)
 
 Both FAIL and IMPROVE require action before the PR merges:
 

--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,5 @@ devlogs
 plan/history/*/README.md
 .devcontainer/devcontainer.env
 .claude/settings.local.json
+.claude/pr-*.json
+.idea/


### PR DESCRIPTION
## Summary

- Introduces a structured three-phase PR review pipeline (`pr-triage` → `pr-execute` → `pr-verify`) that separates discovery from execution, eliminating the O(n) re-loop caused by interleaving finding and fixing.
- Adds `pr-ship` as a single entry-point wrapper with artifact-based resume support if the agent is interrupted mid-run.
- Deprecates `pr-review` and `pr-comprehensive-fix` in place (kept as prose reference; not deleted).

## Changes

**New skills:**

- `.agents/skills/pr-triage/` — pure discovery, 11 inspection phases, writes `.claude/pr-{N}-triage.json`, posts finding-list comment; no code mutations
- `.agents/skills/pr-execute/` — reads triage artifact, batch-fixes FAIL/IMPROVE, remediates CI, files out-of-scope issues, resolves review threads, writes `.claude/pr-{N}-execute.json`; pauses only for `new-issue-ask` items
- `.agents/skills/pr-verify/` — spot-checks fixes at HEAD (not just commit diffs), verdicts per finding, posts verdict comment, cleans up artifacts on `READY-TO-MERGE` or `PENDING-CI`
- `.agents/skills/pr-ship/` — wrapper that detects PR, checks clean worktree, runs triage→execute→verify with resume logic

**Modified:**

- `.agents/skills/pr-review/SKILL.md` — deprecation notice pointing to `pr-ship`
- `.agents/skills/pr-comprehensive-fix/SKILL.md` — deprecation notice pointing to `pr-execute`
- `.gitignore` — adds `.claude/pr-*.json` (session artifacts) and `.idea/` (JetBrains)

## Verification

- [x] All four new skill directories present under `.agents/skills/`
- [x] `pr-review` and `pr-comprehensive-fix` show deprecation notices
- [x] `.claude/pr-*.json` confirmed gitignored
- [x] Markdown lint passes (verified by pre-commit hook on commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)