### PR TITLE
docs: plan issue #1649 — invariant harness hard gate + per-scenario event types

### DIFF
--- a/notes/README.md
+++ b/notes/README.md
@@ -493,6 +493,16 @@ bulk module-rename lessons, and known documentation gaps.
 **Load when**: adding or moving modules, following established code
 organization conventions, or orienting to the module boundary rules.
 
+**`demo-ci-invariants.md`**
+Design notes for the case-ledger invariant harness in demo CI: the
+separate-job pattern (DEMOCI-04) that gives the invariant harness its own
+independent pass/fail status even when the demo itself fails, the per-scenario
+required event-type lists (DEMOMA-16), the table of required types per
+scenario, and the spec-test sync rule.
+**Load when**: modifying the demo CI workflow (`demo-integration.yml`),
+adding or changing a scenario's expected event types, or debugging a silent
+invariant harness failure in CI.
+
 **`codebase-structure-fastapi-patterns.md`**
 FastAPI and test infrastructure patterns: router test override pattern
 (`_shared_dl`, `dependency_overrides`), circular import fix pattern

--- a/notes/demo-ci-invariants.md
+++ b/notes/demo-ci-invariants.md
@@ -1,0 +1,87 @@
+---
+title: Demo CI Invariant Harness Design
+status: active
+related_specs:
+  - specs/demo-ci.yaml
+  - specs/multi-actor-demo.yaml
+---
+
+# Demo CI Invariant Harness Design
+
+Design notes for the case-ledger invariant harness in the demo CI workflow.
+
+---
+
+## Separate CI Job Pattern (DEMOCI-04)
+
+**Problem**: When the demo run and the invariant harness share the same CI
+job, a primary demo failure draws reviewer attention away from invariant
+failures. In PR #1590, a missing notes-exchange phase failed silently across
+multiple fix cycles because the invariant failure was masked by the demo
+failure in the same job output.
+
+**Solution**: The invariant harness for each scenario runs as a **separate
+parallel CI job** that depends on the demo job via `needs:` and always runs
+(`if: always()`). The invariant job downloads the case-log JSONL artifact
+uploaded by the demo job and runs pytest against it.
+
+This gives each scenario two independent pass/fail status entries on the PR:
+one for the demo run, one for the invariant harness. Reviewers can see both
+signals even when the demo itself fails.
+
+**Job relationship per scenario matrix entry:**
+
+```text
+demo (matrix: fv) → uploads devlogs artifact
+    ↓ (needs: demo, if: always())
+invariant-harness (matrix: fv) → downloads artifact → runs pytest
+```
+
+---
+
+## Per-Scenario Expected Event Types (DEMOMA-16)
+
+**Problem**: All per-scenario `_XXX_EXPECTED_EVENT_TYPES` lists historically
+contained only the four universal types (`validate_report`,
+`add_participant_status_to_participant`, `close_case`, `add_note_to_case`),
+regardless of the scenario's actual protocol coverage. This allowed
+scenario-specific phases to regress silently (e.g. `invite_actor_to_case`
+missing from a scenario that requires it).
+
+**Design**: Each scenario defines its own required event-type list that
+extends the four universal types with scenario-specific required phases.
+The spec requirements in `specs/multi-actor-demo.yaml` DEMOMA-16-001 through
+DEMOMA-16-008 are the normative source; the test constants implement them.
+
+### Scenario required event types
+
+| Scenario | Universal 4 | Additional required |
+|---|---|---|
+| FV | validate_report, add_participant_status_to_participant, close_case, add_note_to_case | (none) |
+| FVV | same | invite_actor_to_case |
+| FVCV-extension | same | invite_actor_to_case, offer_case_participant |
+| FVCV-handoff | same | invite_actor_to_case, accept_invite_actor_to_case |
+| FCCV-handoff | same | invite_actor_to_case, accept_invite_actor_to_case |
+| FCV | same | invite_actor_to_case |
+
+### Relationship to scenario-specific test functions
+
+The expected-event-types list (Invariant 5) checks **presence** of an event
+at least once. Scenarios that require an event to appear **N or more times**
+(e.g. `invite_actor_to_case` at least twice in FCV, FVCV-*, FCCV-*) use
+separate `test_XXX_<event>_at_least_N` functions built on
+`check_event_type_count`. These two mechanisms complement each other.
+
+---
+
+## Keeping Spec and Code in Sync
+
+When a scenario phase is added or removed, update both:
+
+1. The DEMOMA-16-XXX spec requirement in `specs/multi-actor-demo.yaml`.
+2. The corresponding `_XXX_EXPECTED_EVENT_TYPES` constant in
+   `test/ci/invariants/test_XXX_invariants.py`.
+
+Both MUST change in the same PR per DEMOMA-16-008. Failure to update the spec
+is a latent silent-failure risk; failure to update the test means the new spec
+requirement is untested.

--- a/plan/history/2607/learning/CONCERN-1649.md
+++ b/plan/history/2607/learning/CONCERN-1649.md
@@ -1,0 +1,20 @@
+---
+source: CONCERN-1649
+timestamp: '2026-07-23T20:55:08.945867+00:00'
+title: Invariant harness hard gate + per-scenario invariant sets
+type: learning
+---
+
+## Concern
+
+The demo invariant harness (`EXPECTED_EVENT_TYPES`) runs as an `if: always()` CI job. When a demo run also fails, the invariant failure is easy to miss — reviewers focus on the primary failure. In PR #1590, a missing notes-exchange phase failed silently across multiple fix cycles for this exact reason.
+
+Additionally, the current common event-type list assumes all scenarios share the same required phases. Scenarios have unique required phases that must not be collapsed into a single shared list.
+
+**Resolved**: 2026-07-23 — implementation tracked in #1656.
+
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1655>.
+
+Spec: `specs/demo-ci.yaml` (DEMOCI-04), `specs/multi-actor-demo.yaml` (DEMOMA-16).
+
+Notes: `notes/demo-ci-invariants.md`.

--- a/specs/demo-ci.yaml
+++ b/specs/demo-ci.yaml
@@ -4,8 +4,9 @@ description: >-
   Requirements for a GitHub Actions workflow that builds and runs Vultron demo
   containers on pull requests, and for hardening the demo runner to exit non-zero
   when the demo fails — closing the gap where tests pass while the demo produces
-  silent failures.
-version: 1.1.0
+  silent failures. Includes requirements for the invariant harness to run as an
+  independent CI gate so failures are visible even when the demo itself also fails.
+version: 1.2.0
 scope:
   - prototype
   - production
@@ -270,3 +271,73 @@ groups:
         relationships:
           - rel_type: refines
             spec_id: DEMOCI-03-004
+
+  - id: DEMOCI-04
+    title: Invariant Harness as an Independent CI Gate
+    specs:
+      - id: DEMOCI-04-001
+        priority: MUST
+        kind: project
+        statement: >-
+          The case-ledger invariant harness for each demo scenario MUST run as
+          a separate CI job (distinct from the demo-runner job), so that
+          invariant failures produce an independent pass/fail status on the
+          pull request that is visible even when the demo job also fails.
+        rationale: >-
+          When both the demo run and the invariant harness are co-located in the
+          same CI job, a primary demo failure draws reviewer attention away from
+          invariant failures. In PR #1590, a missing notes-exchange phase failed
+          silently across multiple fix cycles because the invariant failure was
+          masked by the demo failure in the same job output.
+        relationships:
+          - rel_type: refines
+            spec_id: DEMOCI-03-003
+
+      - id: DEMOCI-04-002
+        priority: MUST
+        kind: project
+        statement: >-
+          The invariant-harness job MUST declare a `needs:` dependency on the
+          demo job for the same scenario matrix entry, and MUST use
+          `if: always()` so it runs regardless of whether the demo job passed
+          or failed.
+        rationale: >-
+          The purpose of the separate invariant job is to provide a signal even
+          when the demo itself fails. Using `if: always()` and `needs:` on the
+          demo job ensures the invariant job runs after artifacts are uploaded
+          and never skips due to a demo failure.
+        relationships:
+          - rel_type: refines
+            spec_id: DEMOCI-04-001
+
+      - id: DEMOCI-04-003
+        priority: MUST
+        kind: project
+        statement: >-
+          The invariant-harness job MUST download the scenario's case-log
+          JSONL artifact produced by the demo job before running pytest, so
+          that the harness reads the actual output of the demo run that
+          completed in that workflow execution.
+        relationships:
+          - rel_type: refines
+            spec_id: DEMOCI-04-001
+
+      - id: DEMOCI-04-004
+        priority: MUST
+        kind: project
+        statement: >-
+          Each demo scenario's invariant test file (e.g.
+          `test/ci/invariants/test_fv_invariants.py`) MUST include a
+          per-scenario expected-event-types list that is comprehensive for that
+          scenario: it MUST cover all protocol phases that the scenario is
+          designed to exercise, not only the four universal phases shared by
+          all scenarios.
+        rationale: >-
+          A shared minimal list (validate_report, add_participant_status_to_participant,
+          close_case, add_note_to_case) does not guard against a scenario-specific
+          phase (e.g. notes-exchange) regressing silently. Each scenario's
+          expected-event-types list must reflect what that scenario is designed
+          to prove end-to-end.
+        relationships:
+          - rel_type: refines
+            spec_id: DEMOCI-03-005

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -2,8 +2,9 @@ id: DEMOMA
 title: Multi-Actor Demo
 description: >-
   Requirements for multi-actor demo scenarios, Docker Compose orchestration, actor isolation,
-  acceptance testing, and reproducibility.
-version: 1.0.0
+  acceptance testing, and reproducibility. Includes per-scenario required
+  event-type lists for the case-ledger invariant harness.
+version: 1.1.0
 scope:
 
 - prototype
@@ -1642,3 +1643,137 @@ groups:
       spec_id: DEMOMA-06-002
     - rel_type: refines
       spec_id: DEMOMA-12-005
+- id: DEMOMA-16
+  title: Per-Scenario Required Event Types for the Invariant Harness
+  description: >-
+    Each scenario defines a minimum set of protocol event types that MUST
+    appear in the authoritative (case-actor) case-ledger log for a complete,
+    correct run. These lists are implemented as the per-scenario
+    `_XXX_EXPECTED_EVENT_TYPES` constants in the corresponding
+    `test/ci/invariants/test_XXX_invariants.py` file and are checked by
+    Invariant 5 (test_invariant_5_expected_event_types_present). They
+    complement, and do not replace, the scenario-specific invariant test
+    functions that use `check_event_type_count` for events that must appear
+    multiple times.
+  specs:
+  - id: DEMOMA-16-001
+    priority: MUST
+    kind: project
+    statement: >-
+      The four universal event types — `validate_report`,
+      `add_participant_status_to_participant`, `close_case`, and
+      `add_note_to_case` — MUST appear at least once in the authoritative
+      case-actor log for every multi-actor demo scenario.
+    rationale: >-
+      These four types represent the minimal protocol coverage shared by all
+      scenarios: report validation, participant state tracking, case
+      closure, and at least one note (notes-exchange phase). Any scenario
+      that does not produce all four has not completed the basic CVD
+      lifecycle.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-03-002
+
+  - id: DEMOMA-16-002
+    priority: MUST
+    kind: project
+    statement: >-
+      In addition to the four universal types (DEMOMA-16-001), the FV scenario
+      MUST verify that its expected-event-types list is restricted to types that
+      the FV scenario actually produces. FV does not include an
+      `invite_actor_to_case` phase; the Finder joins by submitting a report,
+      not via an invitation.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-16-001
+    - rel_type: refines
+      spec_id: DEMOMA-06-002
+
+  - id: DEMOMA-16-003
+    priority: MUST
+    kind: project
+    statement: >-
+      The FVV scenario expected-event-types list MUST include
+      `invite_actor_to_case` in addition to the four universal types
+      (DEMOMA-16-001), because Vendor1 invites Vendor2 into the case.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-16-001
+    - rel_type: refines
+      spec_id: DEMOMA-09-002
+
+  - id: DEMOMA-16-004
+    priority: MUST
+    kind: project
+    statement: >-
+      The FVCV-extension scenario expected-event-types list MUST include
+      `invite_actor_to_case` and `offer_case_participant` in addition to the
+      four universal types (DEMOMA-16-001), because Vendor1 invites
+      Coordinator, and Coordinator uses the ADR-0026 suggest-actor flow
+      (`offer_case_participant`) to propose Vendor2.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-16-001
+    - rel_type: refines
+      spec_id: DEMOMA-10-001
+
+  - id: DEMOMA-16-005
+    priority: MUST
+    kind: project
+    statement: >-
+      The FVCV-handoff scenario expected-event-types list MUST include
+      `invite_actor_to_case` and `accept_invite_actor_to_case` in addition
+      to the four universal types (DEMOMA-16-001), because Vendor1 invites
+      Coordinator, the Coordinator accepts and becomes the new CASE_OWNER,
+      and Coordinator then invites Vendor2 who also accepts.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-16-001
+    - rel_type: refines
+      spec_id: DEMOMA-11-001
+
+  - id: DEMOMA-16-006
+    priority: MUST
+    kind: project
+    statement: >-
+      The FCCV-handoff scenario expected-event-types list MUST include
+      `invite_actor_to_case` and `accept_invite_actor_to_case` in addition
+      to the four universal types (DEMOMA-16-001), because C1 invites C2,
+      C2 accepts and becomes the new CASE_OWNER, and C2 then invites the
+      Vendor who also accepts.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-16-001
+    - rel_type: refines
+      spec_id: DEMOMA-14-009
+
+  - id: DEMOMA-16-007
+    priority: MUST
+    kind: project
+    statement: >-
+      The FCV scenario expected-event-types list MUST include
+      `invite_actor_to_case` in addition to the four universal types
+      (DEMOMA-16-001), because the Coordinator invites both the Finder
+      and the Vendor into the case.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-16-001
+    - rel_type: refines
+      spec_id: DEMOMA-12-008
+
+  - id: DEMOMA-16-008
+    priority: MUST
+    kind: project
+    statement: >-
+      The per-scenario expected-event-types list in each
+      `test/ci/invariants/test_XXX_invariants.py` file MUST be kept in
+      sync with the corresponding DEMOMA-16-XXX spec requirement; when a
+      new scenario phase is added or removed, both the spec and the test
+      list MUST be updated in the same PR.
+    rationale: >-
+      The test list is the code-level implementation of the spec requirement.
+      Allowing them to drift reintroduces the silent-failure risk that
+      motivated issue #1649.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOCI-04-004

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -241,6 +241,27 @@ assert against `py_trees.blackboard.Blackboard.storage` and rely on the
 
 ---
 
+## Invariant Harness Failures Are Independent of Demo Failures (DEMOCI-04)
+
+The case-ledger invariant harness (`test/ci/invariants/`) runs as a **separate
+CI job** from the demo run. When adding or modifying a scenario test file:
+
+- Do NOT add the invariant harness step back into the demo job — the two must
+  stay in separate jobs so each gets its own PR status check.
+- When a demo run and its invariants both fail, **always check the invariant
+  job separately** — invariant failures can point to a different root cause
+  than the demo failure.
+
+**Per-scenario expected-event-types**: each `_XXX_EXPECTED_EVENT_TYPES` list
+must be comprehensive for its scenario (see `notes/demo-ci-invariants.md` and
+DEMOMA-16-001 through DEMOMA-16-008). When adding a new scenario phase that
+produces a new `event_type`, update both the spec requirement and the test
+constant in the same PR.
+
+<!-- Source: CONCERN-1649, PR-1590 -->
+
+---
+
 ## Genesis-Hash Path Must Be Tested with a Stored Case (CLP-08-995)
 
 `is_ledger_fresh_for_case` skips genesis-hash check when no case is stored


### PR DESCRIPTION
- Closes #1649

## Summary

Plans CONCERN-1649: the demo CI invariant harness must run as an
independent job (hard gate) and each scenario's expected-event-type list
must be comprehensive for that scenario.

## Changes

- **`specs/demo-ci.yaml` v1.1.0→1.2.0**: adds DEMOCI-04 group (4
  requirements) specifying that the case-ledger invariant harness MUST run
  as a separate parallel CI job with its own pass/fail status, using
  `needs:` + `if: always()` on the demo job, downloading the case-log
  artifact, and checking comprehensive per-scenario event-type lists.

- **`specs/multi-actor-demo.yaml` v1.0.0→1.1.0**: adds DEMOMA-16 group
  (8 requirements) defining the four universal required event types shared
  by all scenarios and the additional scenario-specific types for FV, FVV,
  FVCV-extension, FVCV-handoff, FCCV-handoff, and FCV.

- **`notes/demo-ci-invariants.md`** (new): design note explaining the
  separate-job pattern, per-scenario event-type table, and spec-test sync
  rule for future implementors.

- **`notes/README.md`**: indexes the new notes file.

- **`test/AGENTS.md`**: pitfall entry for invariant harness job isolation
  and per-scenario event-type list maintenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)