### PR TITLE
Implement call-out point backend bundles and three-mode selection (#1645)

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1645.md
+++ b/plan/history/2607/implementation/ISSUE-1645.md
@@ -1,0 +1,22 @@
+---
+source: ISSUE-1645
+timestamp: '2026-07-23T21:23:42.704951+00:00'
+title: Implement call-out point backend bundles and three-mode selection
+type: implementation
+---
+
+## Issue #1645 — FUZZ-08c-impl: Implement call-out point backend bundles and three-mode selection
+
+Implemented the call-out point backend bundle system (BT-23) designed in issue #1631.
+
+Key deliverables:
+
+- Promoted `CallOutBackendFactory` to a `@runtime_checkable Protocol` (BT-23-004)
+- Created 9 domain `frozen @dataclass` bundle classes in `vultron/demo/fuzzer/bundles/`
+- Shipped `<DOMAIN>_DETERMINISTIC` (ceiling/floor rule) and `<DOMAIN>_STOCHASTIC` singletons per domain
+- Rewired all 11 tree builders to accept `call_out: <Domain>Bundle | None = None`; lazy import defaults to DETERMINISTIC singleton (preserves BT-16-001 hexagonal architecture constraint)
+- Re-exports all 9 classes and 18 singletons from `bundles/__init__.py`
+- Updated 13 existing test files; added 2 new test files (430+ lines)
+- 6262 tests pass, 0 failures
+
+PR: <https://github.com/CERTCC/Vultron/pull/1658>

--- a/plan/incoming/learnings/20260723-publish-artifact-tree-bundle-migration-debt.md
+++ b/plan/incoming/learnings/20260723-publish-artifact-tree-bundle-migration-debt.md
@@ -1,0 +1,23 @@
+---
+title: publish_artifact_tree.py not fully migrated to bundle pattern
+type: learning
+timestamp: 2026-07-23
+source: ISSUE-1645
+signal: concern
+---
+
+`publish_artifact_tree.py` was given a `call_out` bundle parameter in #1645, but
+its internal caller `publication_tree.py` still passes individual factory kwargs
+directly to `_make_artifact_arm`. This means:
+
+- The tree builder has two overlapping APIs (bundle + individual kwargs).
+- `test_publish_artifact_tree.py` has 16 pre-existing pyright errors (parameter
+  name mismatch: test factories use `n: str` instead of `name: str` as required
+  by `CallOutBackendFactory`).
+
+Both issues were pre-existing before #1645 landed, but a clean follow-up task
+should:
+
+1. Migrate `publish_artifact_tree.py` to accept a `PublicationArtifactCallOutBundle`
+   (or fold its factories into the existing `PublicationCallOutBundle`).
+2. Fix the `test_publish_artifact_tree.py` factory signatures to use `name: str`.

--- a/test/core/behaviors/embargo/test_manage_embargo_tree.py
+++ b/test/core/behaviors/embargo/test_manage_embargo_tree.py
@@ -11,10 +11,11 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Tests for the manage-embargo behavior tree (Phase 1 stub).
+"""Tests for the manage-embargo behavior tree.
 
-Verifies BT-18-004: all ten factory params are accepted and wired; defaults
-are the correct fuzzer classes.
+Verifies BT-18-004/BT-23-003: bundle parameter is accepted and used;
+DETERMINISTIC default uses AlwaysSucceed/AlwaysFail per ceiling/floor rule;
+STOCHASTIC bundle produces the correct fuzzer classes.
 """
 
 import pytest
@@ -23,12 +24,21 @@ import py_trees
 from vultron.core.behaviors.embargo.manage_embargo_tree import (
     create_manage_embargo_tree,
 )
+from vultron.demo.fuzzer.base import AlwaysFail, AlwaysSucceed
+from vultron.demo.fuzzer.bundles.embargo import (
+    EMBARGO_DETERMINISTIC,
+    EMBARGO_STOCHASTIC,
+    EmbargoCallOutBundle,
+)
 from vultron.demo.fuzzer.embargo import (
     CurrentEmbargoAcceptable,
     EvaluateEmbargoProposal,
     ExitEmbargoForOtherReason,
     ExitEmbargoWhenDeployed,
     ExitEmbargoWhenFixReady,
+    OnEmbargoAccept,
+    OnEmbargoExit,
+    OnEmbargoReject,
     ReasonToProposeEmbargoWhenDeployed,
     SelectEmbargoOfferTerms,
     StopProposingEmbargo,
@@ -38,7 +48,22 @@ from vultron.demo.fuzzer.embargo import (
 
 CASE_ID = "https://example.org/cases/test-001"
 
-_EXPECTED_DEFAULTS = [
+# DETERMINISTIC defaults per ceiling/floor rule (BT-23-002)
+_EXPECTED_DETERMINISTIC = [
+    AlwaysFail,  # exit_embargo_when_deployed (p < 0.5)
+    AlwaysFail,  # exit_embargo_when_fix_ready (p < 0.5)
+    AlwaysFail,  # exit_embargo_for_other_reason (p < 0.5)
+    AlwaysFail,  # stop_proposing_embargo (p < 0.5)
+    AlwaysSucceed,  # select_embargo_offer_terms (p > 0.5)
+    AlwaysSucceed,  # want_to_propose_embargo (p > 0.5)
+    AlwaysFail,  # willing_to_counter (p < 0.5)
+    AlwaysFail,  # reason_to_propose_when_deployed (p < 0.5)
+    AlwaysSucceed,  # evaluate_embargo_proposal (p > 0.5)
+    AlwaysSucceed,  # current_embargo_acceptable (p > 0.5)
+]
+
+# Stochastic fuzzer classes in the same order
+_EXPECTED_STOCHASTIC = [
     ExitEmbargoWhenDeployed,
     ExitEmbargoWhenFixReady,
     ExitEmbargoForOtherReason,
@@ -51,7 +76,7 @@ _EXPECTED_DEFAULTS = [
     CurrentEmbargoAcceptable,
 ]
 
-_FACTORY_PARAMS = [
+_FACTORY_FIELDS = [
     "exit_embargo_when_deployed_factory",
     "exit_embargo_when_fix_ready_factory",
     "exit_embargo_for_other_reason_factory",
@@ -91,16 +116,25 @@ def test_default_children_count():
     assert len(tree.children) == 10
 
 
-@pytest.mark.parametrize("index,cls", list(enumerate(_EXPECTED_DEFAULTS)))
-def test_default_child_is_correct_fuzzer_node(index, cls):
-    """Each child defaults to the expected fuzzer class (BT-18-004)."""
+@pytest.mark.parametrize("index,cls", list(enumerate(_EXPECTED_DETERMINISTIC)))
+def test_default_child_is_deterministic(index, cls):
+    """DETERMINISTIC: ceiling/floor of each node's stochastic p (BT-23-002)."""
     tree = create_manage_embargo_tree(case_id=CASE_ID)
     assert isinstance(tree.children[index], cls)
 
 
-@pytest.mark.parametrize("param,index", list(zip(_FACTORY_PARAMS, range(10))))
-def test_each_factory_is_wired(param, index):
-    """Each factory parameter is individually wired into the corresponding child."""
+@pytest.mark.parametrize("index,cls", list(enumerate(_EXPECTED_STOCHASTIC)))
+def test_stochastic_child_is_correct_fuzzer_node(index, cls):
+    """STOCHASTIC bundle produces the expected fuzzer class at each index."""
+    tree = create_manage_embargo_tree(
+        case_id=CASE_ID, call_out=EMBARGO_STOCHASTIC
+    )
+    assert isinstance(tree.children[index], cls)
+
+
+@pytest.mark.parametrize("field,index", list(zip(_FACTORY_FIELDS, range(10))))
+def test_each_factory_is_wired(field, index):
+    """Each factory field in a bundle is individually wired into the corresponding child."""
     label = f"Custom_{index}"
     sentinel = {"called": False}
 
@@ -113,72 +147,65 @@ def test_each_factory_is_wired(param, index):
 
         return _Marker(name=label)
 
-    tree = create_manage_embargo_tree(
-        case_id=CASE_ID, **{param: custom_factory}
-    )
+    bundle = EmbargoCallOutBundle(**{field: custom_factory})  # type: ignore[arg-type]
+    tree = create_manage_embargo_tree(case_id=CASE_ID, call_out=bundle)
     assert sentinel["called"]
     assert tree.children[index].name == label
 
 
 def test_all_factories_replaceable():
-    """All factory params can be replaced simultaneously."""
-    kwargs = {
-        param: _marker_factory(f"M{i}")
-        for i, param in enumerate(_FACTORY_PARAMS)
-    }
-    tree = create_manage_embargo_tree(case_id=CASE_ID, **kwargs)
+    """All factory fields can be replaced simultaneously via a bundle."""
+    bundle = EmbargoCallOutBundle(
+        **{field: _marker_factory(f"M{i}") for i, field in enumerate(_FACTORY_FIELDS)}  # type: ignore[arg-type]
+    )
+    tree = create_manage_embargo_tree(case_id=CASE_ID, call_out=bundle)
     tree_str = py_trees.display.ascii_tree(tree)
     for i in range(10):
         assert f"M{i}" in tree_str
 
 
 # ---------------------------------------------------------------------------
-# Actuator factory params — Phase 2 reserved (BT-18-004)
+# Actuator factory fields — Phase 2 reserved (BT-18-004)
 # ---------------------------------------------------------------------------
 
 
 def test_actuator_factories_accepted():
-    """All three Actuator factory params are accepted (Phase 2 reserved)."""
+    """All three Actuator factory fields are accepted via bundle (Phase 2 reserved)."""
     tree = create_manage_embargo_tree(case_id=CASE_ID)
     assert tree is not None
 
 
-def test_on_embargo_exit_default_factory_produces_correct_node():
-    from vultron.core.behaviors.embargo.manage_embargo_tree import (
-        _default_on_embargo_exit_factory,
-    )
-    from vultron.demo.fuzzer.embargo import OnEmbargoExit
-
-    node = _default_on_embargo_exit_factory("OnEmbargoExit")
+def test_on_embargo_exit_stochastic_factory_produces_correct_node():
+    """STOCHASTIC bundle on_embargo_exit_factory produces an OnEmbargoExit node."""
+    node = EMBARGO_STOCHASTIC.on_embargo_exit_factory("OnEmbargoExit")
     assert isinstance(node, OnEmbargoExit)
 
 
-def test_on_embargo_accept_default_factory_produces_correct_node():
-    from vultron.core.behaviors.embargo.manage_embargo_tree import (
-        _default_on_embargo_accept_factory,
-    )
-    from vultron.demo.fuzzer.embargo import OnEmbargoAccept
-
-    node = _default_on_embargo_accept_factory("OnEmbargoAccept")
+def test_on_embargo_accept_stochastic_factory_produces_correct_node():
+    """STOCHASTIC bundle on_embargo_accept_factory produces an OnEmbargoAccept node."""
+    node = EMBARGO_STOCHASTIC.on_embargo_accept_factory("OnEmbargoAccept")
     assert isinstance(node, OnEmbargoAccept)
 
 
-def test_on_embargo_reject_default_factory_produces_correct_node():
-    from vultron.core.behaviors.embargo.manage_embargo_tree import (
-        _default_on_embargo_reject_factory,
-    )
-    from vultron.demo.fuzzer.embargo import OnEmbargoReject
-
-    node = _default_on_embargo_reject_factory("OnEmbargoReject")
+def test_on_embargo_reject_stochastic_factory_produces_correct_node():
+    """STOCHASTIC bundle on_embargo_reject_factory produces an OnEmbargoReject node."""
+    node = EMBARGO_STOCHASTIC.on_embargo_reject_factory("OnEmbargoReject")
     assert isinstance(node, OnEmbargoReject)
 
 
 def test_actuator_custom_factories_accepted():
-    """Custom Actuator factories are accepted without error."""
-    tree = create_manage_embargo_tree(
-        case_id=CASE_ID,
-        on_embargo_exit_factory=_marker_factory("OEE"),
-        on_embargo_accept_factory=_marker_factory("OEA"),
-        on_embargo_reject_factory=_marker_factory("OER"),
+    """Custom Actuator factories are accepted via bundle without error."""
+    bundle = EmbargoCallOutBundle(
+        on_embargo_exit_factory=_marker_factory("OEE"),  # type: ignore[arg-type]
+        on_embargo_accept_factory=_marker_factory("OEA"),  # type: ignore[arg-type]
+        on_embargo_reject_factory=_marker_factory("OER"),  # type: ignore[arg-type]
     )
+    tree = create_manage_embargo_tree(case_id=CASE_ID, call_out=bundle)
     assert tree is not None
+
+
+def test_deterministic_singleton_accepted():
+    tree = create_manage_embargo_tree(
+        case_id=CASE_ID, call_out=EMBARGO_DETERMINISTIC
+    )
+    assert isinstance(tree, py_trees.behaviour.Behaviour)

--- a/test/core/behaviors/report/test_acquire_exploit_strategy_tree.py
+++ b/test/core/behaviors/report/test_acquire_exploit_strategy_tree.py
@@ -17,7 +17,7 @@ Verifies ADR-0027 / BT-20-001:
 - AC-1: Three ProtocolInternal flag nodes are eliminated as separate leaves.
 - AC-2: HaveExploit survives as an independently-swappable Retriever seam.
 - AC-3: EvaluateExploitStrategy produces ExploitStrategyDecision output.
-- AC-4: ADR-0025 factory pattern applied to both call-out points.
+- AC-4: ADR-0025 factory pattern applied to both call-out points (via bundle).
 """
 
 import pytest
@@ -27,6 +27,12 @@ from py_trees.common import Status
 from vultron.core.behaviors.report.acquire_exploit_strategy_tree import (
     ExploitStrategyDecision,
     create_acquire_exploit_strategy_tree,
+)
+from vultron.demo.fuzzer.base import AlwaysFail, AlwaysSucceed
+from vultron.demo.fuzzer.bundles.acquire_exploit import (
+    ACQUIRE_EXPLOIT_DETERMINISTIC,
+    ACQUIRE_EXPLOIT_STOCHASTIC,
+    AcquireExploitCallOutBundle,
 )
 from vultron.demo.fuzzer.report_management.acquire_exploit import (
     EvaluateExploitStrategy,
@@ -118,14 +124,22 @@ def test_exactly_two_children():
 # ---------------------------------------------------------------------------
 
 
-def test_default_have_exploit_is_fuzzer_node():
-    """AC-2: default factory produces a HaveExploit fuzzer node."""
+def test_default_have_exploit_is_deterministic():
+    """DETERMINISTIC default: HaveExploit (p=0.25) → AlwaysFail (BT-23-002)."""
     tree = create_acquire_exploit_strategy_tree(case_id=CASE_ID)
+    assert isinstance(tree.children[0], AlwaysFail)
+
+
+def test_stochastic_have_exploit_is_fuzzer_node():
+    """STOCHASTIC bundle: child[0] is a HaveExploit fuzzer node."""
+    tree = create_acquire_exploit_strategy_tree(
+        case_id=CASE_ID, call_out=ACQUIRE_EXPLOIT_STOCHASTIC
+    )
     assert isinstance(tree.children[0], HaveExploit)
 
 
 def test_have_exploit_factory_used():
-    """AC-2 + AC-4: custom have_exploit_factory is wired into the tree."""
+    """AC-2 + AC-4: custom have_exploit_factory via bundle is wired into the tree."""
     sentinel = {"called": False}
 
     def custom_factory(name):
@@ -137,9 +151,11 @@ def test_have_exploit_factory_used():
 
         return _Marker(name="CustomHaveExploit")
 
+    bundle = AcquireExploitCallOutBundle(
+        have_exploit_factory=custom_factory,  # type: ignore[arg-type]
+    )
     tree = create_acquire_exploit_strategy_tree(
-        case_id=CASE_ID,
-        have_exploit_factory=custom_factory,
+        case_id=CASE_ID, call_out=bundle
     )
     assert sentinel["called"]
     assert tree.children[0].name == "CustomHaveExploit"
@@ -151,9 +167,17 @@ def test_have_exploit_factory_used():
 # ---------------------------------------------------------------------------
 
 
-def test_default_evaluate_exploit_strategy_is_fuzzer_node():
-    """AC-3: default factory produces an EvaluateExploitStrategy fuzzer node."""
+def test_default_evaluate_exploit_strategy_is_deterministic():
+    """DETERMINISTIC default: EvaluateExploitStrategy (p=1.0) → AlwaysSucceed."""
     tree = create_acquire_exploit_strategy_tree(case_id=CASE_ID)
+    assert isinstance(tree.children[1], AlwaysSucceed)
+
+
+def test_stochastic_evaluate_exploit_strategy_is_fuzzer_node():
+    """STOCHASTIC bundle: child[1] is an EvaluateExploitStrategy fuzzer node."""
+    tree = create_acquire_exploit_strategy_tree(
+        case_id=CASE_ID, call_out=ACQUIRE_EXPLOIT_STOCHASTIC
+    )
     assert isinstance(tree.children[1], EvaluateExploitStrategy)
 
 
@@ -168,7 +192,7 @@ def test_evaluate_exploit_strategy_output_key():
 
 
 def test_evaluate_exploit_strategy_factory_used():
-    """AC-4: custom evaluate_exploit_strategy_factory is wired into the tree."""
+    """AC-4: custom evaluate_exploit_strategy_factory via bundle is wired into the tree."""
     sentinel = {"called": False}
 
     def custom_factory(name):
@@ -180,9 +204,11 @@ def test_evaluate_exploit_strategy_factory_used():
 
         return _Marker(name="CustomEvaluateExploitStrategy")
 
+    bundle = AcquireExploitCallOutBundle(
+        evaluate_exploit_strategy_factory=custom_factory,  # type: ignore[arg-type]
+    )
     tree = create_acquire_exploit_strategy_tree(
-        case_id=CASE_ID,
-        evaluate_exploit_strategy_factory=custom_factory,
+        case_id=CASE_ID, call_out=bundle
     )
     assert sentinel["called"]
     assert tree.children[1].name == "CustomEvaluateExploitStrategy"
@@ -206,16 +232,18 @@ def test_eliminated_protocol_internal_nodes_absent(eliminated_class_name):
 
 
 # ---------------------------------------------------------------------------
-# AC-4: both factories replaceable simultaneously
+# AC-4: both factories replaceable simultaneously via bundle
 # ---------------------------------------------------------------------------
 
 
 def test_both_factories_replaceable():
-    """AC-4: both factory params can be replaced simultaneously."""
+    """AC-4: both factory params can be replaced simultaneously via a bundle."""
+    bundle = AcquireExploitCallOutBundle(
+        have_exploit_factory=_marker_factory("HE"),  # type: ignore[arg-type]
+        evaluate_exploit_strategy_factory=_marker_factory("EES"),  # type: ignore[arg-type]
+    )
     tree = create_acquire_exploit_strategy_tree(
-        case_id=CASE_ID,
-        have_exploit_factory=_marker_factory("HE"),
-        evaluate_exploit_strategy_factory=_marker_factory("EES"),
+        case_id=CASE_ID, call_out=bundle
     )
     tree_str = py_trees.display.ascii_tree(tree)
     assert "HE" in tree_str
@@ -234,12 +262,15 @@ def test_evaluate_exploit_strategy_writes_blackboard_on_success():
     """AC-3 behavior contract: ticking the tree to SUCCESS writes ExploitStrategyDecision.
 
     Uses an always-failing HaveExploit stub so the Selector falls through to
-    EvaluateExploitStrategy (AlwaysSucceed), which must then write a typed
+    EvaluateExploitStrategy (real stochastic node), which must then write a typed
     ExploitStrategyDecision to the blackboard key 'exploit_strategy_decision'.
     """
     tree = create_acquire_exploit_strategy_tree(
         case_id=CASE_ID,
-        have_exploit_factory=_always_fail_factory,
+        call_out=AcquireExploitCallOutBundle(
+            have_exploit_factory=_always_fail_factory,  # type: ignore[arg-type]
+            evaluate_exploit_strategy_factory=ACQUIRE_EXPLOIT_STOCHASTIC.evaluate_exploit_strategy_factory,
+        ),
     )
     tree.setup_with_descendants()
     tree.tick_once()
@@ -260,7 +291,9 @@ def test_have_exploit_success_skips_evaluator_no_write():
     """
     tree = create_acquire_exploit_strategy_tree(
         case_id=CASE_ID,
-        have_exploit_factory=_marker_factory("HaveExploit"),
+        call_out=AcquireExploitCallOutBundle(
+            have_exploit_factory=_marker_factory("HaveExploit"),  # type: ignore[arg-type]
+        ),
     )
     tree.setup_with_descendants()
     tree.tick_once()
@@ -270,3 +303,10 @@ def test_have_exploit_success_skips_evaluator_no_write():
         "/exploit_strategy_decision"
         not in py_trees.blackboard.Blackboard.storage
     )
+
+
+def test_deterministic_singleton_accepted():
+    tree = create_acquire_exploit_strategy_tree(
+        case_id=CASE_ID, call_out=ACQUIRE_EXPLOIT_DETERMINISTIC
+    )
+    assert isinstance(tree, py_trees.behaviour.Behaviour)

--- a/test/core/behaviors/report/test_acquire_exploit_tree.py
+++ b/test/core/behaviors/report/test_acquire_exploit_tree.py
@@ -13,14 +13,21 @@
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 """Tests for the acquire-exploit behavior tree (Phase 1 stub).
 
-Verifies BT-18-004: factory params are accepted and used; defaults are the
-correct fuzzer classes.
+Verifies BT-18-004/BT-23-003: bundle parameter is accepted and used;
+DETERMINISTIC default uses AlwaysSucceed/AlwaysFail per ceiling/floor rule;
+STOCHASTIC bundle produces the correct fuzzer classes.
 """
 
 import py_trees
 
 from vultron.core.behaviors.report.acquire_exploit_tree import (
     create_acquire_exploit_tree,
+)
+from vultron.demo.fuzzer.base import AlwaysFail, AlwaysSucceed
+from vultron.demo.fuzzer.bundles.acquire_exploit import (
+    ACQUIRE_EXPLOIT_DETERMINISTIC,
+    ACQUIRE_EXPLOIT_STOCHASTIC,
+    AcquireExploitCallOutBundle,
 )
 from vultron.demo.fuzzer.report_management.acquire_exploit import (
     EvaluateExploitPriority,
@@ -51,9 +58,19 @@ def test_create_acquire_exploit_tree_root_name():
     assert tree.name == "AcquireExploitBT"
 
 
-def test_default_children_are_fuzzer_nodes():
-    """Default factory produces the correct fuzzer-class nodes."""
+def test_default_children_are_deterministic():
+    """DETERMINISTIC: EvaluateExploitPriority(p=1.0)→Succeed, PurchaseExploit(p=0.10)→Fail."""
     tree = create_acquire_exploit_tree(case_id=CASE_ID)
+    assert len(tree.children) == 2
+    assert isinstance(tree.children[0], AlwaysSucceed)
+    assert isinstance(tree.children[1], AlwaysFail)
+
+
+def test_stochastic_bundle_children_are_fuzzer_nodes():
+    """STOCHASTIC bundle produces the correct fuzzer-class nodes."""
+    tree = create_acquire_exploit_tree(
+        case_id=CASE_ID, call_out=ACQUIRE_EXPLOIT_STOCHASTIC
+    )
     assert len(tree.children) == 2
     assert isinstance(tree.children[0], EvaluateExploitPriority)
     assert isinstance(tree.children[1], PurchaseExploit)
@@ -72,10 +89,10 @@ def test_evaluate_exploit_priority_factory_used():
 
         return _Marker(name="CustomEvaluateExploitPriority")
 
-    tree = create_acquire_exploit_tree(
-        case_id=CASE_ID,
-        evaluate_exploit_priority_factory=custom_factory,
+    bundle = AcquireExploitCallOutBundle(
+        evaluate_exploit_priority_factory=custom_factory,  # type: ignore[arg-type]
     )
+    tree = create_acquire_exploit_tree(case_id=CASE_ID, call_out=bundle)
     assert sentinel["called"]
     tree_str = py_trees.display.ascii_tree(tree)
     assert "CustomEvaluateExploitPriority" in tree_str
@@ -94,24 +111,31 @@ def test_purchase_exploit_factory_used():
 
         return _Marker(name="CustomPurchaseExploit")
 
-    tree = create_acquire_exploit_tree(
-        case_id=CASE_ID,
-        purchase_exploit_factory=custom_factory,
+    bundle = AcquireExploitCallOutBundle(
+        purchase_exploit_factory=custom_factory,  # type: ignore[arg-type]
     )
+    tree = create_acquire_exploit_tree(case_id=CASE_ID, call_out=bundle)
     assert sentinel["called"]
     tree_str = py_trees.display.ascii_tree(tree)
     assert "CustomPurchaseExploit" in tree_str
 
 
 def test_both_factories_replaceable():
-    """Both factory params can be replaced simultaneously."""
-    tree = create_acquire_exploit_tree(
-        case_id=CASE_ID,
-        evaluate_exploit_priority_factory=_marker_factory("EEP"),
-        purchase_exploit_factory=_marker_factory("PE"),
+    """Both factory params can be replaced simultaneously via a bundle."""
+    bundle = AcquireExploitCallOutBundle(
+        evaluate_exploit_priority_factory=_marker_factory("EEP"),  # type: ignore[arg-type]
+        purchase_exploit_factory=_marker_factory("PE"),  # type: ignore[arg-type]
     )
+    tree = create_acquire_exploit_tree(case_id=CASE_ID, call_out=bundle)
     tree_str = py_trees.display.ascii_tree(tree)
     assert "EEP" in tree_str
     assert "PE" in tree_str
     assert not isinstance(tree.children[0], EvaluateExploitPriority)
     assert not isinstance(tree.children[1], PurchaseExploit)
+
+
+def test_deterministic_singleton_accepted():
+    tree = create_acquire_exploit_tree(
+        case_id=CASE_ID, call_out=ACQUIRE_EXPLOIT_DETERMINISTIC
+    )
+    assert isinstance(tree, py_trees.behaviour.Behaviour)

--- a/test/core/behaviors/report/test_assign_vul_id_tree.py
+++ b/test/core/behaviors/report/test_assign_vul_id_tree.py
@@ -13,14 +13,21 @@
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 """Tests for the assign-VUL-ID behavior tree (Phase 1 stub).
 
-Verifies BT-18-004: factory params are accepted and used; defaults are the
-correct fuzzer classes.
+Verifies BT-18-004/BT-23-003: bundle parameter is accepted and used;
+DETERMINISTIC default produces AlwaysSucceed nodes; STOCHASTIC bundle
+produces the correct fuzzer classes.
 """
 
 import py_trees
 
 from vultron.core.behaviors.report.assign_vul_id_tree import (
     create_assign_vul_id_tree,
+)
+from vultron.demo.fuzzer.base import AlwaysSucceed
+from vultron.demo.fuzzer.bundles.assign_vul_id import (
+    ASSIGN_VUL_ID_DETERMINISTIC,
+    ASSIGN_VUL_ID_STOCHASTIC,
+    AssignVulIdCallOutBundle,
 )
 from vultron.demo.fuzzer.report_management.assign_vul_id import (
     IdAssignable,
@@ -51,8 +58,19 @@ def test_create_assign_vul_id_tree_root_name():
     assert tree.name == "AssignVulIDBT"
 
 
-def test_default_children_are_fuzzer_nodes():
+def test_default_children_are_deterministic():
+    """Default (no bundle) produces DETERMINISTIC AlwaysSucceed nodes (BT-23-002)."""
     tree = create_assign_vul_id_tree(case_id=CASE_ID)
+    assert len(tree.children) == 2
+    assert isinstance(tree.children[0], AlwaysSucceed)
+    assert isinstance(tree.children[1], AlwaysSucceed)
+
+
+def test_stochastic_bundle_children_are_fuzzer_nodes():
+    """STOCHASTIC bundle produces the correct fuzzer-class nodes."""
+    tree = create_assign_vul_id_tree(
+        case_id=CASE_ID, call_out=ASSIGN_VUL_ID_STOCHASTIC
+    )
     assert len(tree.children) == 2
     assert isinstance(tree.children[0], InScope)
     assert isinstance(tree.children[1], IdAssignable)
@@ -70,10 +88,10 @@ def test_id_assignable_factory_used():
 
         return _Marker(name="CustomIdAssignable")
 
-    tree = create_assign_vul_id_tree(
-        case_id=CASE_ID,
-        id_assignable_factory=custom_factory,
+    bundle = AssignVulIdCallOutBundle(
+        id_assignable_factory=custom_factory,  # type: ignore[arg-type]
     )
+    tree = create_assign_vul_id_tree(case_id=CASE_ID, call_out=bundle)
     assert sentinel["called"]
     assert "CustomIdAssignable" in py_trees.display.ascii_tree(tree)
 
@@ -90,20 +108,27 @@ def test_in_scope_factory_used():
 
         return _Marker(name="CustomInScope")
 
-    tree = create_assign_vul_id_tree(
-        case_id=CASE_ID,
-        in_scope_factory=custom_factory,
+    bundle = AssignVulIdCallOutBundle(
+        in_scope_factory=custom_factory,  # type: ignore[arg-type]
     )
+    tree = create_assign_vul_id_tree(case_id=CASE_ID, call_out=bundle)
     assert sentinel["called"]
     assert "CustomInScope" in py_trees.display.ascii_tree(tree)
 
 
 def test_both_factories_replaceable():
-    tree = create_assign_vul_id_tree(
-        case_id=CASE_ID,
-        id_assignable_factory=_marker_factory("IA"),
-        in_scope_factory=_marker_factory("IS"),
+    bundle = AssignVulIdCallOutBundle(
+        id_assignable_factory=_marker_factory("IA"),  # type: ignore[arg-type]
+        in_scope_factory=_marker_factory("IS"),  # type: ignore[arg-type]
     )
+    tree = create_assign_vul_id_tree(case_id=CASE_ID, call_out=bundle)
     tree_str = py_trees.display.ascii_tree(tree)
     assert "IA" in tree_str
     assert "IS" in tree_str
+
+
+def test_deterministic_singleton_accepted():
+    tree = create_assign_vul_id_tree(
+        case_id=CASE_ID, call_out=ASSIGN_VUL_ID_DETERMINISTIC
+    )
+    assert isinstance(tree, py_trees.behaviour.Behaviour)

--- a/test/core/behaviors/report/test_close_report_tree.py
+++ b/test/core/behaviors/report/test_close_report_tree.py
@@ -13,8 +13,9 @@
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 """Tests for the close-report behavior tree (Phase 1 stub).
 
-Verifies BT-18-004: factory param is accepted and used; default is the
-correct fuzzer class.
+Verifies BT-18-004/BT-23-003: bundle parameter is accepted and used;
+DETERMINISTIC default produces AlwaysFail for OtherCloseCriteriaMet;
+STOCHASTIC bundle produces the correct fuzzer class.
 """
 
 import py_trees
@@ -22,8 +23,15 @@ import py_trees
 from vultron.core.behaviors.report.close_report_tree import (
     create_close_report_tree,
 )
+from vultron.demo.fuzzer.base import AlwaysFail
+from vultron.demo.fuzzer.bundles.close_report import (
+    CLOSE_REPORT_DETERMINISTIC,
+    CLOSE_REPORT_STOCHASTIC,
+    CloseReportCallOutBundle,
+)
 from vultron.demo.fuzzer.report_management.close_report import (
     OtherCloseCriteriaMet,
+    PreCloseAction,
 )
 
 CASE_ID = "https://example.org/cases/test-001"
@@ -34,14 +42,22 @@ def test_create_close_report_tree_returns_behaviour():
     assert isinstance(tree, py_trees.behaviour.Behaviour)
 
 
-def test_default_is_other_close_criteria_met():
+def test_default_is_always_fail():
+    """DETERMINISTIC default: OtherCloseCriteriaMet (p=0.25) → AlwaysFail (BT-23-002)."""
     tree = create_close_report_tree(case_id=CASE_ID)
-    assert isinstance(tree, OtherCloseCriteriaMet)
+    assert isinstance(tree, AlwaysFail)
 
 
 def test_default_node_name():
     tree = create_close_report_tree(case_id=CASE_ID)
     assert tree.name == "OtherCloseCriteriaMet"
+
+
+def test_stochastic_bundle_produces_fuzzer_node():
+    tree = create_close_report_tree(
+        case_id=CASE_ID, call_out=CLOSE_REPORT_STOCHASTIC
+    )
+    assert isinstance(tree, OtherCloseCriteriaMet)
 
 
 def test_custom_factory_used():
@@ -56,10 +72,10 @@ def test_custom_factory_used():
 
         return _Marker(name="CustomOtherClose")
 
-    tree = create_close_report_tree(
-        case_id=CASE_ID,
-        other_close_criteria_factory=custom_factory,
+    bundle = CloseReportCallOutBundle(
+        other_close_criteria_factory=custom_factory,  # type: ignore[arg-type]
     )
+    tree = create_close_report_tree(case_id=CASE_ID, call_out=bundle)
     assert sentinel["called"]
     assert tree.name == "CustomOtherClose"
     assert not isinstance(tree, OtherCloseCriteriaMet)
@@ -71,21 +87,14 @@ def test_pre_close_action_factory_accepted():
     assert tree is not None
 
 
-def test_pre_close_action_default_factory_produces_correct_node():
-    """Default pre_close_action_factory produces a PreCloseAction node."""
-    from vultron.core.behaviors.report.close_report_tree import (
-        _default_pre_close_action_factory,
-    )
-    from vultron.demo.fuzzer.report_management.close_report import (
-        PreCloseAction,
-    )
-
-    node = _default_pre_close_action_factory("PreCloseAction")
+def test_pre_close_action_bundle_field_produces_correct_node():
+    """STOCHASTIC bundle pre_close_action_factory produces a PreCloseAction node."""
+    node = CLOSE_REPORT_STOCHASTIC.pre_close_action_factory("PreCloseAction")
     assert isinstance(node, PreCloseAction)
 
 
 def test_pre_close_action_custom_factory_accepted():
-    """A custom pre_close_action_factory is accepted without error."""
+    """A custom pre_close_action_factory in a bundle is accepted without error."""
 
     def custom_factory(name):
         class _Marker(py_trees.behaviour.Behaviour):
@@ -94,8 +103,15 @@ def test_pre_close_action_custom_factory_accepted():
 
         return _Marker(name="CustomPreClose")
 
-    tree = create_close_report_tree(
-        case_id=CASE_ID,
-        pre_close_action_factory=custom_factory,
+    bundle = CloseReportCallOutBundle(
+        pre_close_action_factory=custom_factory,  # type: ignore[arg-type]
     )
+    tree = create_close_report_tree(case_id=CASE_ID, call_out=bundle)
     assert tree is not None
+
+
+def test_deterministic_singleton_accepted():
+    tree = create_close_report_tree(
+        case_id=CASE_ID, call_out=CLOSE_REPORT_DETERMINISTIC
+    )
+    assert isinstance(tree, py_trees.behaviour.Behaviour)

--- a/test/core/behaviors/report/test_deploy_fix_tree.py
+++ b/test/core/behaviors/report/test_deploy_fix_tree.py
@@ -13,8 +13,9 @@
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 """Tests for the deploy-fix behavior tree (Phase 1 stub).
 
-Verifies BT-18-004: factory params are accepted and used; defaults are the
-correct fuzzer classes.
+Verifies BT-18-004/BT-23-003: bundle parameter is accepted and used;
+DETERMINISTIC default uses AlwaysSucceed/AlwaysFail per ceiling/floor rule;
+STOCHASTIC bundle produces the correct fuzzer classes.
 """
 
 import pytest
@@ -22,6 +23,12 @@ import py_trees
 
 from vultron.core.behaviors.report.deploy_fix_tree import (
     create_deploy_fix_tree,
+)
+from vultron.demo.fuzzer.base import AlwaysFail, AlwaysSucceed
+from vultron.demo.fuzzer.bundles.deploy_fix import (
+    DEPLOY_FIX_DETERMINISTIC,
+    DEPLOY_FIX_STOCHASTIC,
+    DeployFixCallOutBundle,
 )
 from vultron.demo.fuzzer.report_management.deploy_fix import (
     DeployFix,
@@ -55,8 +62,30 @@ def test_create_deploy_fix_tree_root_name():
     assert tree.name == "DeployFixBT"
 
 
-def test_default_children_are_fuzzer_nodes():
+def test_default_children_are_deterministic():
+    """DETERMINISTIC: ceiling/floor of each node's stochastic p (BT-23-002)."""
     tree = create_deploy_fix_tree(case_id=CASE_ID)
+    assert len(tree.children) == 5
+    assert isinstance(
+        tree.children[0], AlwaysSucceed
+    )  # PrioritizeDeployment p=0.90
+    assert isinstance(
+        tree.children[1], AlwaysSucceed
+    )  # DeployMitigation p=0.75
+    assert isinstance(
+        tree.children[2], AlwaysSucceed
+    )  # MonitoringRequirement p=0.70
+    assert isinstance(tree.children[3], AlwaysFail)  # DeployFix p=0.10
+    assert isinstance(
+        tree.children[4], AlwaysSucceed
+    )  # MonitorDeployment p=1.0
+
+
+def test_stochastic_bundle_children_are_fuzzer_nodes():
+    """STOCHASTIC bundle produces the correct fuzzer-class nodes."""
+    tree = create_deploy_fix_tree(
+        case_id=CASE_ID, call_out=DEPLOY_FIX_STOCHASTIC
+    )
     assert len(tree.children) == 5
     assert isinstance(tree.children[0], PrioritizeDeployment)
     assert isinstance(tree.children[1], DeployMitigation)
@@ -65,18 +94,18 @@ def test_default_children_are_fuzzer_nodes():
     assert isinstance(tree.children[4], MonitorDeployment)
 
 
-@pytest.mark.parametrize(
-    "param,label,index",
-    [
-        ("prioritize_deployment_factory", "PD", 0),
-        ("deploy_mitigation_factory", "DM", 1),
-        ("monitoring_requirement_factory", "MR", 2),
-        ("deploy_fix_factory", "DF", 3),
-        ("monitor_deployment_factory", "MD", 4),
-    ],
-)
-def test_each_factory_is_wired(param, label, index):
-    """Each factory parameter is individually wired into the tree."""
+_BUNDLE_FIELDS = [
+    ("prioritize_deployment_factory", "PD", 0),
+    ("deploy_mitigation_factory", "DM", 1),
+    ("monitoring_requirement_factory", "MR", 2),
+    ("deploy_fix_factory", "DF", 3),
+    ("monitor_deployment_factory", "MD", 4),
+]
+
+
+@pytest.mark.parametrize("field,label,index", _BUNDLE_FIELDS)
+def test_each_factory_is_wired(field, label, index):
+    """Each factory field in a bundle is individually wired into the tree."""
     sentinel = {"called": False}
 
     def custom_factory(name):
@@ -88,20 +117,28 @@ def test_each_factory_is_wired(param, label, index):
 
         return _Marker(name=label)
 
-    tree = create_deploy_fix_tree(case_id=CASE_ID, **{param: custom_factory})
+    bundle = DeployFixCallOutBundle(**{field: custom_factory})  # type: ignore[arg-type]
+    tree = create_deploy_fix_tree(case_id=CASE_ID, call_out=bundle)
     assert sentinel["called"]
     assert tree.children[index].name == label
 
 
 def test_all_factories_replaceable():
-    tree = create_deploy_fix_tree(
-        case_id=CASE_ID,
-        prioritize_deployment_factory=_marker_factory("PD"),
-        deploy_mitigation_factory=_marker_factory("DM"),
-        monitoring_requirement_factory=_marker_factory("MR"),
-        deploy_fix_factory=_marker_factory("DF"),
-        monitor_deployment_factory=_marker_factory("MD"),
+    bundle = DeployFixCallOutBundle(
+        prioritize_deployment_factory=_marker_factory("PD"),  # type: ignore[arg-type]
+        deploy_mitigation_factory=_marker_factory("DM"),  # type: ignore[arg-type]
+        monitoring_requirement_factory=_marker_factory("MR"),  # type: ignore[arg-type]
+        deploy_fix_factory=_marker_factory("DF"),  # type: ignore[arg-type]
+        monitor_deployment_factory=_marker_factory("MD"),  # type: ignore[arg-type]
     )
+    tree = create_deploy_fix_tree(case_id=CASE_ID, call_out=bundle)
     tree_str = py_trees.display.ascii_tree(tree)
     for label in ("PD", "DM", "MR", "DF", "MD"):
         assert label in tree_str
+
+
+def test_deterministic_singleton_accepted():
+    tree = create_deploy_fix_tree(
+        case_id=CASE_ID, call_out=DEPLOY_FIX_DETERMINISTIC
+    )
+    assert isinstance(tree, py_trees.behaviour.Behaviour)

--- a/test/core/behaviors/report/test_prioritize_tree.py
+++ b/test/core/behaviors/report/test_prioritize_tree.py
@@ -644,8 +644,12 @@ def test_prioritize_subtree_engages_by_default(
 def test_prioritize_subtree_custom_on_accept_factory_used(
     case_with_participant, actor_id, trigger_activity
 ):
-    """on_accept_factory node appears in the engage path when custom factory is passed."""
+    """on_accept_factory node appears in the engage path when custom bundle is passed."""
     import py_trees
+
+    from vultron.demo.fuzzer.bundles.prioritization import (
+        PrioritizationCallOutBundle,
+    )
 
     def custom_on_accept(name):
         class _Marker(py_trees.behaviour.Behaviour):
@@ -654,11 +658,12 @@ def test_prioritize_subtree_custom_on_accept_factory_used(
 
         return _Marker(name="CustomOnAccept")
 
+    bundle = PrioritizationCallOutBundle(on_accept_factory=custom_on_accept)  # type: ignore[arg-type]
     tree = create_prioritize_subtree(
         case_id=case_with_participant.id_,
         actor_id=actor_id,
         trigger_activity=trigger_activity,
-        on_accept_factory=custom_on_accept,
+        call_out=bundle,
     )
 
     engage_path = tree.children[0]
@@ -668,8 +673,12 @@ def test_prioritize_subtree_custom_on_accept_factory_used(
 def test_prioritize_subtree_custom_on_defer_factory_used(
     case_with_participant, actor_id, trigger_activity
 ):
-    """on_defer_factory node appears in the defer path when custom factory is passed."""
+    """on_defer_factory node appears in the defer path when custom bundle is passed."""
     import py_trees
+
+    from vultron.demo.fuzzer.bundles.prioritization import (
+        PrioritizationCallOutBundle,
+    )
 
     def custom_on_defer(name):
         class _Marker(py_trees.behaviour.Behaviour):
@@ -678,11 +687,12 @@ def test_prioritize_subtree_custom_on_defer_factory_used(
 
         return _Marker(name="CustomOnDefer")
 
+    bundle = PrioritizationCallOutBundle(on_defer_factory=custom_on_defer)  # type: ignore[arg-type]
     tree = create_prioritize_subtree(
         case_id=case_with_participant.id_,
         actor_id=actor_id,
         trigger_activity=trigger_activity,
-        on_defer_factory=custom_on_defer,
+        call_out=bundle,
     )
 
     defer_path = tree.children[1]

--- a/test/core/behaviors/report/test_prioritize_tree_factory_injection.py
+++ b/test/core/behaviors/report/test_prioritize_tree_factory_injection.py
@@ -11,11 +11,11 @@
 #  ("Third Party Software"). See LICENSE.md for more details.
 #  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
-"""Factory injection tests for create_prioritize_subtree (BT-18-004).
+"""Factory injection tests for create_prioritize_subtree (BT-18-004/BT-23-003).
 
 Verifies the two Phase 2 reserved factory parameters (enough_info_factory,
-gather_info_factory) are accepted without error.  The two wired params
-(on_accept_factory, on_defer_factory) are covered by the existing
+gather_info_factory) are accepted via bundle without error.  The two wired
+params (on_accept_factory, on_defer_factory) are covered by the existing
 test_prioritize_tree.py tests.
 """
 
@@ -23,6 +23,9 @@ import py_trees
 
 from vultron.core.behaviors.report.prioritize_tree import (
     create_prioritize_subtree,
+)
+from vultron.demo.fuzzer.bundles.prioritization import (
+    PrioritizationCallOutBundle,
 )
 
 CASE_ID = "https://example.org/cases/test-001"
@@ -41,31 +44,40 @@ def _marker_factory(label):
 
 
 def test_enough_info_factory_accepted():
-    """enough_info_factory is accepted (Phase 2 reserved)."""
+    """enough_info_factory is accepted via bundle (Phase 2 reserved)."""
+    bundle = PrioritizationCallOutBundle(
+        enough_info_factory=_marker_factory("EnoughInfo"),  # type: ignore[arg-type]
+    )
     tree = create_prioritize_subtree(
         case_id=CASE_ID,
         actor_id=ACTOR_ID,
-        enough_info_factory=_marker_factory("EnoughInfo"),
+        call_out=bundle,
     )
     assert tree is not None
 
 
 def test_gather_info_factory_accepted():
-    """gather_info_factory is accepted (Phase 2 reserved)."""
+    """gather_info_factory is accepted via bundle (Phase 2 reserved)."""
+    bundle = PrioritizationCallOutBundle(
+        gather_info_factory=_marker_factory("GatherInfo"),  # type: ignore[arg-type]
+    )
     tree = create_prioritize_subtree(
         case_id=CASE_ID,
         actor_id=ACTOR_ID,
-        gather_info_factory=_marker_factory("GatherInfo"),
+        call_out=bundle,
     )
     assert tree is not None
 
 
 def test_both_phase2_factories_accepted_together():
-    """Both Phase 2 reserved factories are accepted together."""
+    """Both Phase 2 reserved factories are accepted together via bundle."""
+    bundle = PrioritizationCallOutBundle(
+        enough_info_factory=_marker_factory("EnoughInfo"),  # type: ignore[arg-type]
+        gather_info_factory=_marker_factory("GatherInfo"),  # type: ignore[arg-type]
+    )
     tree = create_prioritize_subtree(
         case_id=CASE_ID,
         actor_id=ACTOR_ID,
-        enough_info_factory=_marker_factory("EnoughInfo"),
-        gather_info_factory=_marker_factory("GatherInfo"),
+        call_out=bundle,
     )
     assert tree is not None

--- a/test/core/behaviors/report/test_publication_tree.py
+++ b/test/core/behaviors/report/test_publication_tree.py
@@ -34,6 +34,7 @@ from vultron.core.behaviors.report.publication_tree import (
     ShouldPublishReport,
     create_publication_tree,
 )
+from vultron.demo.fuzzer.bundles.publication import PublicationCallOutBundle
 from vultron.demo.fuzzer.report_management.publication import (
     DraftAdvisoryArtifact,
     PrepareExploit,
@@ -129,11 +130,21 @@ def test_root_is_sequence():
 
 
 def test_root_has_evaluator_plus_three_arms():
-    """AC-4: PrioritizePublicationIntents + exactly three named arms."""
+    """AC-4: four children — intents evaluator + exactly three named arms."""
     tree = create_publication_tree(case_id=CASE_ID)
     assert len(tree.children) == 4
-    assert isinstance(tree.children[0], PrioritizePublicationIntents)
+    assert tree.children[0].name == "PrioritizePublicationIntents"
     assert [c.name for c in tree.children[1:]] == _ARM_NAMES
+
+
+def test_stochastic_bundle_evaluator_is_fuzzer_node():
+    """STOCHASTIC bundle: first child is PrioritizePublicationIntents fuzzer node."""
+    from vultron.demo.fuzzer.bundles.publication import PUBLICATION_STOCHASTIC
+
+    tree = create_publication_tree(
+        case_id=CASE_ID, call_out=PUBLICATION_STOCHASTIC
+    )
+    assert isinstance(tree.children[0], PrioritizePublicationIntents)
 
 
 def test_evaluator_is_first_child():
@@ -160,26 +171,61 @@ def test_each_arm_is_selector(arm_name):
     assert isinstance(arm.children[1], py_trees.decorators.Inverter)
 
 
-def test_default_prepare_nodes_are_fuzzers():
-    """AC-5: default prepare factories produce the fuzzer Composer nodes."""
+def test_default_prepare_nodes_are_deterministic():
+    """DETERMINISTIC default: prepare nodes use AlwaysSucceed (BT-23-002)."""
+    from vultron.demo.fuzzer.base import AlwaysSucceed
+
     tree = create_publication_tree(case_id=CASE_ID)
     exploit_seq = tree.children[1].children[0]
     fix_seq = tree.children[2].children[0]
     report_seq = tree.children[3].children[0]
 
     assert isinstance(exploit_seq.children[0], ShouldPublishExploit)
-    assert isinstance(exploit_seq.children[1], PrepareExploit)
+    assert isinstance(exploit_seq.children[1], AlwaysSucceed)
 
     assert isinstance(fix_seq.children[0], ShouldPublishFix)
-    assert isinstance(fix_seq.children[1], PrepareFix)
+    assert isinstance(fix_seq.children[1], AlwaysSucceed)
 
     assert isinstance(report_seq.children[0], ShouldPublishReport)
+    assert isinstance(report_seq.children[1], AlwaysSucceed)
+
+
+def test_stochastic_prepare_nodes_are_fuzzers():
+    """STOCHASTIC bundle: prepare factories produce the fuzzer Composer nodes."""
+    from vultron.demo.fuzzer.bundles.publication import PUBLICATION_STOCHASTIC
+
+    tree = create_publication_tree(
+        case_id=CASE_ID, call_out=PUBLICATION_STOCHASTIC
+    )
+    exploit_seq = tree.children[1].children[0]
+    fix_seq = tree.children[2].children[0]
+    report_seq = tree.children[3].children[0]
+
+    assert isinstance(exploit_seq.children[1], PrepareExploit)
+    assert isinstance(fix_seq.children[1], PrepareFix)
     assert isinstance(report_seq.children[1], PrepareReport)
 
 
-def test_default_publish_pipeline_nodes_are_fuzzers():
-    """Collapse 4: default pipeline factories produce fuzzer nodes per arm."""
+def test_default_publish_pipeline_nodes_are_deterministic():
+    """DETERMINISTIC default: pipeline factories produce AlwaysSucceed per arm."""
+    from vultron.demo.fuzzer.base import AlwaysSucceed
+
     tree = create_publication_tree(case_id=CASE_ID)
+    for arm, label in zip(tree.children[1:], ["Exploit", "Fix", "Report"]):
+        pipeline = arm.children[0].children[2]  # PublishArtifactBT_<label>
+        assert pipeline.name == f"PublishArtifactBT_{label}"
+        assert isinstance(pipeline.children[0], AlwaysSucceed)
+        assert isinstance(pipeline.children[1], AlwaysSucceed)
+        assert isinstance(pipeline.children[3], AlwaysSucceed)
+
+
+def test_stochastic_publish_pipeline_nodes_are_fuzzers():
+    """STOCHASTIC bundle: Collapse 4 pipeline factories produce fuzzer nodes per arm."""
+    from vultron.demo.fuzzer.bundles.publication import PUBLICATION_STOCHASTIC
+
+    tree = create_publication_tree(
+        case_id=CASE_ID, call_out=PUBLICATION_STOCHASTIC
+    )
     for arm, label in zip(tree.children[1:], ["Exploit", "Fix", "Report"]):
         pipeline = arm.children[0].children[2]  # PublishArtifactBT_<label>
         assert pipeline.name == f"PublishArtifactBT_{label}"
@@ -199,35 +245,29 @@ def test_default_publish_pipeline_nodes_are_fuzzers():
 # ---------------------------------------------------------------------------
 
 
-def test_full_tick_with_default_evaluator_writes_intent_record():
-    """AC-1: a full tick with the default Evaluator writes the intent record.
+def test_full_tick_with_stochastic_evaluator_writes_intent_record():
+    """AC-1: a full tick with the real PrioritizePublicationIntents Evaluator writes the intent record.
 
-    Unlike the structure tests above (and unlike the arm-gating tests, which
-    write the record manually via ``_write_intent``), this exercises the real
-    default ``PrioritizePublicationIntents`` factory — a deterministic
-    ``AlwaysSucceed`` Evaluator — rather than a stub.  It therefore verifies
-    the node's actual blackboard-write contract (BT-18-001): on SUCCESS the
-    Evaluator writes a :class:`PublicationIntentDecision` to
+    Uses the STOCHASTIC bundle (which provides the real PrioritizePublicationIntents
+    evaluator) with stub Prepare*/Publish factories so the tree ticks to SUCCESS
+    deterministically.  Verifies the node's actual blackboard-write contract (BT-18-001):
+    on SUCCESS the Evaluator writes a :class:`PublicationIntentDecision` to
     :data:`INTENT_DECISION_KEY`.
-
-    Only the probabilistic ``Prepare*``/``Publish`` arm call-out points are
-    replaced with deterministic marker stubs, so the tree ticks to SUCCESS on
-    every run; the Evaluator factory is left at its default.  Follows the
-    ``test_evaluate_exploit_strategy_writes_blackboard_on_success`` pattern in
-    ``test_acquire_exploit_strategy_tree.py`` (AC-2): both tick the real
-    ``create_*_tree`` builder and stub only the otherwise-probabilistic arms.
     """
-    tree = create_publication_tree(
-        case_id=CASE_ID,
-        prepare_exploit_factory=_marker_factory("PrepExploit"),
-        prepare_fix_factory=_marker_factory("PrepFix"),
-        prepare_report_factory=_marker_factory("PrepReport"),
-        draft_advisory_artifact_factory=_marker_factory("Draft"),
-        review_advisory_draft_factory=_marker_factory("Review"),
-        revise_advisory_draft_factory=_marker_factory("Revise"),
-        submit_advisory_artifact_factory=_marker_factory("Submit"),
+    from vultron.demo.fuzzer.bundles.publication import PUBLICATION_STOCHASTIC
+
+    bundle = PublicationCallOutBundle(
+        prioritize_publication_intents_factory=PUBLICATION_STOCHASTIC.prioritize_publication_intents_factory,
+        prepare_exploit_factory=_marker_factory("PrepExploit"),  # type: ignore[arg-type]
+        prepare_fix_factory=_marker_factory("PrepFix"),  # type: ignore[arg-type]
+        prepare_report_factory=_marker_factory("PrepReport"),  # type: ignore[arg-type]
+        draft_advisory_artifact_factory=_marker_factory("Draft"),  # type: ignore[arg-type]
+        review_advisory_draft_factory=_marker_factory("Review"),  # type: ignore[arg-type]
+        revise_advisory_draft_factory=_marker_factory("Revise"),  # type: ignore[arg-type]
+        submit_advisory_artifact_factory=_marker_factory("Submit"),  # type: ignore[arg-type]
     )
-    # Guard: the Evaluator under test is the real default node, not a stub.
+    tree = create_publication_tree(case_id=CASE_ID, call_out=bundle)
+    # Guard: the Evaluator under test is the real stochastic node, not a stub.
     assert isinstance(tree.children[0], PrioritizePublicationIntents)
 
     tree.setup_with_descendants()
@@ -282,37 +322,37 @@ def test_eliminated_nodes_absent(eliminated_class_name):
 
 
 def test_prioritize_intents_factory_used():
-    """AC-5: custom prioritize_publication_intents_factory is wired in."""
-    tree = create_publication_tree(
-        case_id=CASE_ID,
-        prioritize_publication_intents_factory=_marker_factory("CustomPPI"),
+    """AC-5: custom prioritize_publication_intents_factory is wired in via bundle."""
+    bundle = PublicationCallOutBundle(
+        prioritize_publication_intents_factory=_marker_factory("CustomPPI"),  # type: ignore[arg-type]
     )
+    tree = create_publication_tree(case_id=CASE_ID, call_out=bundle)
     assert tree.children[0].name == "CustomPPI"
     assert not isinstance(tree.children[0], PrioritizePublicationIntents)
 
 
 def test_prepare_factories_used():
-    """AC-5: custom prepare_* factories are wired into their arms."""
-    tree = create_publication_tree(
-        case_id=CASE_ID,
-        prepare_exploit_factory=_marker_factory("CustomPrepExploit"),
-        prepare_fix_factory=_marker_factory("CustomPrepFix"),
-        prepare_report_factory=_marker_factory("CustomPrepReport"),
+    """AC-5: custom prepare_* factories are wired into their arms via bundle."""
+    bundle = PublicationCallOutBundle(
+        prepare_exploit_factory=_marker_factory("CustomPrepExploit"),  # type: ignore[arg-type]
+        prepare_fix_factory=_marker_factory("CustomPrepFix"),  # type: ignore[arg-type]
+        prepare_report_factory=_marker_factory("CustomPrepReport"),  # type: ignore[arg-type]
     )
+    tree = create_publication_tree(case_id=CASE_ID, call_out=bundle)
     assert tree.children[1].children[0].children[1].name == "CustomPrepExploit"
     assert tree.children[2].children[0].children[1].name == "CustomPrepFix"
     assert tree.children[3].children[0].children[1].name == "CustomPrepReport"
 
 
 def test_publish_pipeline_factories_used_in_every_arm():
-    """AC-5 / Collapse 4: the four pipeline factories are applied to all arms."""
-    tree = create_publication_tree(
-        case_id=CASE_ID,
-        draft_advisory_artifact_factory=_marker_factory("CustomDraft"),
-        review_advisory_draft_factory=_marker_factory("CustomReview"),
-        revise_advisory_draft_factory=_marker_factory("CustomRevise"),
-        submit_advisory_artifact_factory=_marker_factory("CustomSubmit"),
+    """AC-5 / Collapse 4: the four pipeline factories are applied to all arms via bundle."""
+    bundle = PublicationCallOutBundle(
+        draft_advisory_artifact_factory=_marker_factory("CustomDraft"),  # type: ignore[arg-type]
+        review_advisory_draft_factory=_marker_factory("CustomReview"),  # type: ignore[arg-type]
+        revise_advisory_draft_factory=_marker_factory("CustomRevise"),  # type: ignore[arg-type]
+        submit_advisory_artifact_factory=_marker_factory("CustomSubmit"),  # type: ignore[arg-type]
     )
+    tree = create_publication_tree(case_id=CASE_ID, call_out=bundle)
     for arm in tree.children[1:]:
         pipeline = arm.children[0].children[2]
         assert pipeline.children[0].name == "CustomDraft"

--- a/test/core/behaviors/report/test_publication_tree_factory_injection.py
+++ b/test/core/behaviors/report/test_publication_tree_factory_injection.py
@@ -28,6 +28,7 @@ from vultron.core.behaviors.report.publication_tree import (
     PublicationIntentDecision,
     create_publication_tree,
 )
+from vultron.demo.fuzzer.bundles.publication import PublicationCallOutBundle
 
 CASE_ID = "https://example.org/cases/test-001"
 
@@ -100,17 +101,17 @@ def _always_succeed_factory(name):
 
 
 def _build(decision, ran):
-    return create_publication_tree(
-        case_id=CASE_ID,
-        prioritize_publication_intents_factory=_intent_factory(decision),
-        prepare_exploit_factory=lambda n: _RecordingPrepare(n, ran),
-        prepare_fix_factory=lambda n: _RecordingPrepare(n, ran),
-        prepare_report_factory=lambda n: _RecordingPrepare(n, ran),
-        draft_advisory_artifact_factory=lambda n: _always_succeed_factory(n),
-        review_advisory_draft_factory=lambda n: _always_succeed_factory(n),
-        revise_advisory_draft_factory=lambda n: _always_succeed_factory(n),
-        submit_advisory_artifact_factory=lambda n: _RecordingSubmit(n, ran),
+    bundle = PublicationCallOutBundle(
+        prioritize_publication_intents_factory=_intent_factory(decision),  # type: ignore[arg-type]
+        prepare_exploit_factory=lambda n: _RecordingPrepare(n, ran),  # type: ignore[arg-type]
+        prepare_fix_factory=lambda n: _RecordingPrepare(n, ran),  # type: ignore[arg-type]
+        prepare_report_factory=lambda n: _RecordingPrepare(n, ran),  # type: ignore[arg-type]
+        draft_advisory_artifact_factory=lambda n: _always_succeed_factory(n),  # type: ignore[arg-type]
+        review_advisory_draft_factory=lambda n: _always_succeed_factory(n),  # type: ignore[arg-type]
+        revise_advisory_draft_factory=lambda n: _always_succeed_factory(n),  # type: ignore[arg-type]
+        submit_advisory_artifact_factory=lambda n: _RecordingSubmit(n, ran),  # type: ignore[arg-type]
     )
+    return create_publication_tree(case_id=CASE_ID, call_out=bundle)
 
 
 def test_default_intents_publish_fix_and_report_only():
@@ -183,16 +184,16 @@ def test_prepare_failure_fails_intended_arm():
         def update(self):
             return Status.FAILURE
 
-    tree = create_publication_tree(
-        case_id=CASE_ID,
-        prioritize_publication_intents_factory=_intent_factory(
+    bundle = PublicationCallOutBundle(
+        prioritize_publication_intents_factory=_intent_factory(  # type: ignore[arg-type]
             PublicationIntentDecision(publish_fix=True, publish_report=True)
         ),
-        prepare_fix_factory=lambda n: _FailingPrepare(name=n),
-        prepare_report_factory=lambda n: _RecordingPrepare(n, ran),
-        draft_advisory_artifact_factory=lambda n: _always_succeed_factory(n),
-        review_advisory_draft_factory=lambda n: _always_succeed_factory(n),
-        revise_advisory_draft_factory=lambda n: _always_succeed_factory(n),
-        submit_advisory_artifact_factory=lambda n: _RecordingSubmit(n, ran),
+        prepare_fix_factory=lambda n: _FailingPrepare(name=n),  # type: ignore[arg-type]
+        prepare_report_factory=lambda n: _RecordingPrepare(n, ran),  # type: ignore[arg-type]
+        draft_advisory_artifact_factory=lambda n: _always_succeed_factory(n),  # type: ignore[arg-type]
+        review_advisory_draft_factory=lambda n: _always_succeed_factory(n),  # type: ignore[arg-type]
+        revise_advisory_draft_factory=lambda n: _always_succeed_factory(n),  # type: ignore[arg-type]
+        submit_advisory_artifact_factory=lambda n: _RecordingSubmit(n, ran),  # type: ignore[arg-type]
     )
+    tree = create_publication_tree(case_id=CASE_ID, call_out=bundle)
     assert _tick_to_completion(tree) == Status.FAILURE

--- a/test/core/behaviors/report/test_publish_artifact_tree.py
+++ b/test/core/behaviors/report/test_publish_artifact_tree.py
@@ -306,12 +306,12 @@ def test_auto_approve_skips_revision_arm():
     ran: set[str] = set()
     tree = create_publish_artifact_tree(
         case_id=CASE_ID,
-        draft_advisory_artifact_factory=lambda n: _Recording(n, ran),
-        review_advisory_draft_factory=lambda n: _WritingReview(
-            n, AdvisoryReviewDecision(needs_revision=False)
+        draft_advisory_artifact_factory=lambda name: _Recording(name, ran),
+        review_advisory_draft_factory=lambda name: _WritingReview(
+            name, AdvisoryReviewDecision(needs_revision=False)
         ),
-        revise_advisory_draft_factory=lambda n: _Recording(n, ran),
-        submit_advisory_artifact_factory=lambda n: _Recording(n, ran),
+        revise_advisory_draft_factory=lambda name: _Recording(name, ran),
+        submit_advisory_artifact_factory=lambda name: _Recording(name, ran),
     )
     status = _tick_tree(tree)
     assert status == Status.SUCCESS
@@ -325,12 +325,12 @@ def test_needs_revision_runs_revision_arm():
     ran: set[str] = set()
     tree = create_publish_artifact_tree(
         case_id=CASE_ID,
-        draft_advisory_artifact_factory=lambda n: _Recording(n, ran),
-        review_advisory_draft_factory=lambda n: _WritingReview(
-            n, AdvisoryReviewDecision(needs_revision=True)
+        draft_advisory_artifact_factory=lambda name: _Recording(name, ran),
+        review_advisory_draft_factory=lambda name: _WritingReview(
+            name, AdvisoryReviewDecision(needs_revision=True)
         ),
-        revise_advisory_draft_factory=lambda n: _Recording(n, ran),
-        submit_advisory_artifact_factory=lambda n: _Recording(n, ran),
+        revise_advisory_draft_factory=lambda name: _Recording(name, ran),
+        submit_advisory_artifact_factory=lambda name: _Recording(name, ran),
     )
     status = _tick_tree(tree)
     assert status == Status.SUCCESS
@@ -349,10 +349,10 @@ def test_draft_failure_fails_pipeline():
 
     tree = create_publish_artifact_tree(
         case_id=CASE_ID,
-        draft_advisory_artifact_factory=lambda n: _Fail(name=n),
+        draft_advisory_artifact_factory=lambda name: _Fail(name=name),
         review_advisory_draft_factory=_marker_factory("Review"),
         revise_advisory_draft_factory=_marker_factory("Revise"),
-        submit_advisory_artifact_factory=lambda n: _Recording(n, ran),
+        submit_advisory_artifact_factory=lambda name: _Recording(name, ran),
     )
     status = _tick_tree(tree)
     assert status == Status.FAILURE
@@ -370,9 +370,9 @@ def test_review_failure_fails_pipeline():
     tree = create_publish_artifact_tree(
         case_id=CASE_ID,
         draft_advisory_artifact_factory=_marker_factory("Draft"),
-        review_advisory_draft_factory=lambda n: _Fail(name=n),
+        review_advisory_draft_factory=lambda name: _Fail(name=name),
         revise_advisory_draft_factory=_marker_factory("Revise"),
-        submit_advisory_artifact_factory=lambda n: _Recording(n, ran),
+        submit_advisory_artifact_factory=lambda name: _Recording(name, ran),
     )
     status = _tick_tree(tree)
     assert status == Status.FAILURE
@@ -390,11 +390,11 @@ def test_revise_failure_fails_pipeline():
     tree = create_publish_artifact_tree(
         case_id=CASE_ID,
         draft_advisory_artifact_factory=_marker_factory("Draft"),
-        review_advisory_draft_factory=lambda n: _WritingReview(
-            n, AdvisoryReviewDecision(needs_revision=True)
+        review_advisory_draft_factory=lambda name: _WritingReview(
+            name, AdvisoryReviewDecision(needs_revision=True)
         ),
-        revise_advisory_draft_factory=lambda n: _Fail(name=n),
-        submit_advisory_artifact_factory=lambda n: _Recording(n, ran),
+        revise_advisory_draft_factory=lambda name: _Fail(name=name),
+        submit_advisory_artifact_factory=lambda name: _Recording(name, ran),
     )
     status = _tick_tree(tree)
     assert status == Status.FAILURE
@@ -413,7 +413,7 @@ def test_submit_failure_fails_pipeline():
         draft_advisory_artifact_factory=_marker_factory("Draft"),
         review_advisory_draft_factory=_marker_factory("Review"),
         revise_advisory_draft_factory=_marker_factory("Revise"),
-        submit_advisory_artifact_factory=lambda n: _Fail(name=n),
+        submit_advisory_artifact_factory=lambda name: _Fail(name=name),
     )
     status = _tick_tree(tree)
     assert status == Status.FAILURE

--- a/test/core/behaviors/report/test_report_to_others_tree.py
+++ b/test/core/behaviors/report/test_report_to_others_tree.py
@@ -13,14 +13,15 @@
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 """Tests for the notification-loop behavior tree (Production Collapse 3).
 
-Verifies ADR-0029 / BT-20-003:
+Verifies ADR-0029 / BT-20-003 and BT-23-003:
 - AC-1: InjectParticipant/InjectVendor/InjectCoordinator/InjectOther eliminated
   as separate leaves; replaced by suggest_*_factory call-out points.
 - AC-2: Each sub-loop writes the appropriate suggested_roles_{case_id_segment}
   blackboard key before invoking its trigger factory.
 - AC-3: Outer loop structure (typed sub-loops, AllPartiesKnown, TotalEffortLimitMet)
   preserved.
-- AC-4: ADR-0025 factory pattern applied to every call-out point.
+- AC-4: ADR-0025 factory pattern applied to every call-out point (via bundle).
+- BT-23-003: DETERMINISTIC default uses AlwaysSucceed/AlwaysFail per ceiling/floor rule.
 """
 
 import pytest
@@ -30,6 +31,12 @@ from py_trees.common import Status
 from vultron.core.behaviors.report.report_to_others_tree import (
     _WriteRolesNode,
     create_report_to_others_tree,
+)
+from vultron.demo.fuzzer.base import AlwaysFail, AlwaysSucceed
+from vultron.demo.fuzzer.bundles.report_to_others import (
+    REPORT_TO_OTHERS_DETERMINISTIC,
+    REPORT_TO_OTHERS_STOCHASTIC,
+    ReportToOthersCallOutBundle,
 )
 from vultron.demo.fuzzer.report_management.report_to_others import (
     AllPartiesKnown,
@@ -183,27 +190,36 @@ def test_eliminated_actuator_nodes_not_top_level_leaves(eliminated_class_name):
     assert eliminated_class_name not in direct_class_names
 
 
-def test_default_children_are_fuzzer_nodes():
-    """Default factories produce correct fuzzer nodes for outer guards."""
+def test_default_outer_guards_are_deterministic():
+    """DETERMINISTIC default: AllPartiesKnown(p=0.5)→Succeed, TotalEffortLimitMet(p=0.1)→Fail."""
     tree = create_report_to_others_tree(case_id=CASE_ID)
+    assert isinstance(tree.children[0], AlwaysSucceed)
+    assert isinstance(tree.children[1], AlwaysFail)
+
+
+def test_stochastic_bundle_outer_guards_are_fuzzer_nodes():
+    """STOCHASTIC bundle: outer guard nodes are the correct fuzzer classes."""
+    tree = create_report_to_others_tree(
+        case_id=CASE_ID, call_out=REPORT_TO_OTHERS_STOCHASTIC
+    )
     assert isinstance(tree.children[0], AllPartiesKnown)
     assert isinstance(tree.children[1], TotalEffortLimitMet)
 
 
 # ---------------------------------------------------------------------------
-# AC-4: Factory pattern — Evaluator factories
+# AC-4: Factory pattern — Evaluator factories via bundle
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
-    "param,label,child_index",
+    "field,label,child_index",
     [
         ("all_parties_known_factory", "APK", 0),
         ("total_effort_limit_factory", "TEL", 1),
     ],
 )
-def test_evaluator_factory_wired(param, label, child_index):
-    """AC-4: each Evaluator factory is wired into the root Sequence."""
+def test_evaluator_factory_wired(field, label, child_index):
+    """AC-4: each Evaluator factory field is wired into the root Sequence via bundle."""
     sentinel = {"called": False}
 
     def custom_factory(name):
@@ -215,9 +231,8 @@ def test_evaluator_factory_wired(param, label, child_index):
 
         return _Marker(name=label)
 
-    tree = create_report_to_others_tree(
-        case_id=CASE_ID, **{param: custom_factory}
-    )
+    bundle = ReportToOthersCallOutBundle(**{field: custom_factory})  # type: ignore[arg-type]
+    tree = create_report_to_others_tree(case_id=CASE_ID, call_out=bundle)
     assert sentinel["called"]
     assert tree.children[child_index].name == label
 
@@ -242,7 +257,7 @@ def _find_node_by_name_recursive(root, name):
 
 
 @pytest.mark.parametrize(
-    "more_param,more_label,suggest_param,suggest_label,loop_name",
+    "more_field,more_label,suggest_field,suggest_label,loop_name",
     [
         (
             "more_vendors_factory",
@@ -268,16 +283,16 @@ def _find_node_by_name_recursive(root, name):
     ],
 )
 def test_sub_loop_factories_wired(
-    more_param, more_label, suggest_param, suggest_label, loop_name
+    more_field, more_label, suggest_field, suggest_label, loop_name
 ):
-    """AC-3/AC-4: each sub-loop factory pair is wired into the correct sub-loop."""
-    tree = create_report_to_others_tree(
-        case_id=CASE_ID,
+    """AC-3/AC-4: each sub-loop factory pair is wired into the correct sub-loop via bundle."""
+    bundle = ReportToOthersCallOutBundle(
         **{
-            more_param: _marker_factory(more_label),
-            suggest_param: _marker_factory(suggest_label),
-        },
+            more_field: _marker_factory(more_label),  # type: ignore[arg-type]
+            suggest_field: _marker_factory(suggest_label),  # type: ignore[arg-type]
+        }
     )
+    tree = create_report_to_others_tree(case_id=CASE_ID, call_out=bundle)
     sub_loop = _find_node_by_name_recursive(tree, loop_name)
     assert sub_loop is not None
     tree_str = py_trees.display.ascii_tree(sub_loop)
@@ -366,7 +381,7 @@ def _make_always_fail_factory(name):
 
 
 @pytest.mark.parametrize(
-    "more_param,suggest_param,expected_role",
+    "more_field,suggest_field,expected_role",
     [
         ("more_vendors_factory", "suggest_vendor_factory", CVDRole.VENDOR),
         (
@@ -378,7 +393,7 @@ def _make_always_fail_factory(name):
     ],
 )
 def test_write_roles_key_written_when_sub_loop_executes(
-    more_param, suggest_param, expected_role
+    more_field, suggest_field, expected_role
 ):
     """AC-2 behavioral: ticking a sub-loop with MoreX=SUCCESS writes the correct roles key.
 
@@ -386,7 +401,7 @@ def test_write_roles_key_written_when_sub_loop_executes(
     Inverter arms succeed as graceful no-ops — the test target sub-loop is the
     only one that executes, keeping the blackboard key unambiguous.
     """
-    _all_params = [
+    _all_more_fields = [
         "more_vendors_factory",
         "more_coordinators_factory",
         "more_others_factory",
@@ -394,18 +409,18 @@ def test_write_roles_key_written_when_sub_loop_executes(
     more_kwargs = {
         k: (
             _make_always_succeed_factory
-            if k == more_param
+            if k == more_field
             else _make_always_fail_factory
         )
-        for k in _all_params
+        for k in _all_more_fields
     }
-    tree = create_report_to_others_tree(
-        case_id=CASE_ID,
-        all_parties_known_factory=_make_always_succeed_factory,
-        total_effort_limit_factory=_make_always_succeed_factory,
-        **more_kwargs,
-        **{suggest_param: _make_always_succeed_factory},
+    bundle = ReportToOthersCallOutBundle(
+        all_parties_known_factory=_make_always_succeed_factory,  # type: ignore[arg-type]
+        total_effort_limit_factory=_make_always_succeed_factory,  # type: ignore[arg-type]
+        **{suggest_field: _make_always_succeed_factory},  # type: ignore[arg-type]
+        **more_kwargs,  # type: ignore[arg-type]
     )
+    tree = create_report_to_others_tree(case_id=CASE_ID, call_out=bundle)
     tree.setup_with_descendants()
     tree.tick_once()
 
@@ -415,87 +430,80 @@ def test_write_roles_key_written_when_sub_loop_executes(
 
 
 # ---------------------------------------------------------------------------
-# AC-3: Default more_* factories use correct fuzzer node types
+# AC-3: STOCHASTIC bundle uses correct fuzzer node types
 # ---------------------------------------------------------------------------
 
 
-def test_default_more_vendors_factory():
-    from vultron.core.behaviors.report.report_to_others_tree import (
-        _default_more_vendors_factory,
-    )
-
-    node = _default_more_vendors_factory("MoreVendors")
+def test_stochastic_more_vendors_factory():
+    """STOCHASTIC bundle more_vendors_factory produces a MoreVendors node."""
+    node = REPORT_TO_OTHERS_STOCHASTIC.more_vendors_factory("MoreVendors")
     assert isinstance(node, MoreVendors)
 
 
-def test_default_more_coordinators_factory():
-    from vultron.core.behaviors.report.report_to_others_tree import (
-        _default_more_coordinators_factory,
+def test_stochastic_more_coordinators_factory():
+    """STOCHASTIC bundle more_coordinators_factory produces a MoreCoordinators node."""
+    node = REPORT_TO_OTHERS_STOCHASTIC.more_coordinators_factory(
+        "MoreCoordinators"
     )
-
-    node = _default_more_coordinators_factory("MoreCoordinators")
     assert isinstance(node, MoreCoordinators)
 
 
-def test_default_more_others_factory():
-    from vultron.core.behaviors.report.report_to_others_tree import (
-        _default_more_others_factory,
-    )
-
-    node = _default_more_others_factory("MoreOthers")
+def test_stochastic_more_others_factory():
+    """STOCHASTIC bundle more_others_factory produces a MoreOthers node."""
+    node = REPORT_TO_OTHERS_STOCHASTIC.more_others_factory("MoreOthers")
     assert isinstance(node, MoreOthers)
 
 
 # ---------------------------------------------------------------------------
-# AC-1/AC-4: Default suggest_* factories use InjectX fuzzer stubs
+# AC-1/AC-4: STOCHASTIC bundle suggest_* factories use InjectX fuzzer stubs
 # ---------------------------------------------------------------------------
 
 
-def test_default_suggest_vendor_factory():
-    from vultron.core.behaviors.report.report_to_others_tree import (
-        _default_suggest_vendor_factory,
-    )
-
-    node = _default_suggest_vendor_factory("SuggestVendor")
+def test_stochastic_suggest_vendor_factory():
+    """STOCHASTIC bundle suggest_vendor_factory produces an InjectVendor node."""
+    node = REPORT_TO_OTHERS_STOCHASTIC.suggest_vendor_factory("SuggestVendor")
     assert isinstance(node, InjectVendor)
 
 
-def test_default_suggest_coordinator_factory():
-    from vultron.core.behaviors.report.report_to_others_tree import (
-        _default_suggest_coordinator_factory,
+def test_stochastic_suggest_coordinator_factory():
+    """STOCHASTIC bundle suggest_coordinator_factory produces an InjectCoordinator node."""
+    node = REPORT_TO_OTHERS_STOCHASTIC.suggest_coordinator_factory(
+        "SuggestCoordinator"
     )
-
-    node = _default_suggest_coordinator_factory("SuggestCoordinator")
     assert isinstance(node, InjectCoordinator)
 
 
-def test_default_suggest_other_factory():
-    from vultron.core.behaviors.report.report_to_others_tree import (
-        _default_suggest_other_factory,
-    )
-
-    node = _default_suggest_other_factory("SuggestOther")
+def test_stochastic_suggest_other_factory():
+    """STOCHASTIC bundle suggest_other_factory produces an InjectOther node."""
+    node = REPORT_TO_OTHERS_STOCHASTIC.suggest_other_factory("SuggestOther")
     assert isinstance(node, InjectOther)
 
 
 # ---------------------------------------------------------------------------
-# AC-4: All factories replaceable simultaneously
+# AC-4: All factories replaceable simultaneously via bundle
 # ---------------------------------------------------------------------------
 
 
 def test_all_factories_replaceable():
-    """AC-4: every factory parameter can be replaced simultaneously."""
-    tree = create_report_to_others_tree(
-        case_id=CASE_ID,
-        all_parties_known_factory=_marker_factory("APK"),
-        total_effort_limit_factory=_marker_factory("TEL"),
-        more_vendors_factory=_marker_factory("MV"),
-        more_coordinators_factory=_marker_factory("MC"),
-        more_others_factory=_marker_factory("MO"),
-        suggest_vendor_factory=_marker_factory("SV"),
-        suggest_coordinator_factory=_marker_factory("SC"),
-        suggest_other_factory=_marker_factory("SO"),
+    """AC-4: every factory field can be replaced simultaneously via a bundle."""
+    bundle = ReportToOthersCallOutBundle(
+        all_parties_known_factory=_marker_factory("APK"),  # type: ignore[arg-type]
+        total_effort_limit_factory=_marker_factory("TEL"),  # type: ignore[arg-type]
+        more_vendors_factory=_marker_factory("MV"),  # type: ignore[arg-type]
+        more_coordinators_factory=_marker_factory("MC"),  # type: ignore[arg-type]
+        more_others_factory=_marker_factory("MO"),  # type: ignore[arg-type]
+        suggest_vendor_factory=_marker_factory("SV"),  # type: ignore[arg-type]
+        suggest_coordinator_factory=_marker_factory("SC"),  # type: ignore[arg-type]
+        suggest_other_factory=_marker_factory("SO"),  # type: ignore[arg-type]
     )
+    tree = create_report_to_others_tree(case_id=CASE_ID, call_out=bundle)
     tree_str = py_trees.display.ascii_tree(tree)
     for label in ("APK", "TEL", "MV", "MC", "MO", "SV", "SC", "SO"):
         assert label in tree_str
+
+
+def test_deterministic_singleton_accepted():
+    tree = create_report_to_others_tree(
+        case_id=CASE_ID, call_out=REPORT_TO_OTHERS_DETERMINISTIC
+    )
+    assert isinstance(tree, py_trees.behaviour.Behaviour)

--- a/test/core/behaviors/report/test_validate_tree.py
+++ b/test/core/behaviors/report/test_validate_tree.py
@@ -40,6 +40,7 @@ from vultron.core.behaviors.report.validate_tree import (
     create_validate_report_tree,
 )
 from vultron.core.states.rm import RM
+from vultron.demo.fuzzer.bundles.validation import ValidationCallOutBundle
 
 
 def _always_succeed_factory(name: str) -> py_trees.behaviour.Behaviour:
@@ -50,6 +51,12 @@ def _always_succeed_factory(name: str) -> py_trees.behaviour.Behaviour:
             return py_trees.common.Status.SUCCESS
 
     return _AlwaysSucceed(name)
+
+
+_ALWAYS_SUCCEED_BUNDLE = ValidationCallOutBundle(
+    credibility_factory=_always_succeed_factory,  # type: ignore[arg-type]
+    validity_factory=_always_succeed_factory,  # type: ignore[arg-type]
+)
 
 
 @pytest.fixture
@@ -271,8 +278,7 @@ def test_tree_execution_success_new_report(
     tree = create_validate_report_tree(
         report_id=report.id_,
         offer_id=offer.id_,
-        credibility_factory=_always_succeed_factory,
-        validity_factory=_always_succeed_factory,
+        call_out=_ALWAYS_SUCCEED_BUNDLE,
     )
 
     # Act: Execute tree
@@ -305,8 +311,7 @@ def test_tree_execution_does_not_create_case(
     tree = create_validate_report_tree(
         report_id=report.id_,
         offer_id=offer.id_,
-        credibility_factory=_always_succeed_factory,
-        validity_factory=_always_succeed_factory,
+        call_out=_ALWAYS_SUCCEED_BUNDLE,
     )
     result = bridge.execute_with_setup(
         tree=tree,
@@ -330,8 +335,7 @@ def test_tree_execution_transitions_vendor_to_valid(
     tree = create_validate_report_tree(
         report_id=report.id_,
         offer_id=offer.id_,
-        credibility_factory=_always_succeed_factory,
-        validity_factory=_always_succeed_factory,
+        call_out=_ALWAYS_SUCCEED_BUNDLE,
     )
 
     result = bridge.execute_with_setup(
@@ -363,8 +367,7 @@ def test_tree_execution_early_exit_already_valid(
     tree = create_validate_report_tree(
         report_id=report.id_,
         offer_id=offer.id_,
-        credibility_factory=_always_succeed_factory,
-        validity_factory=_always_succeed_factory,
+        call_out=_ALWAYS_SUCCEED_BUNDLE,
     )
 
     # Act: Execute tree
@@ -394,8 +397,7 @@ def test_tree_execution_invalid_state_transitions_to_valid(
     tree = create_validate_report_tree(
         report_id=report.id_,
         offer_id=offer.id_,
-        credibility_factory=_always_succeed_factory,
-        validity_factory=_always_succeed_factory,
+        call_out=_ALWAYS_SUCCEED_BUNDLE,
     )
 
     # Act: Execute tree
@@ -423,8 +425,7 @@ def test_tree_execution_no_prior_status_succeeds(
     tree = create_validate_report_tree(
         report_id=report.id_,
         offer_id=offer.id_,
-        credibility_factory=_always_succeed_factory,
-        validity_factory=_always_succeed_factory,
+        call_out=_ALWAYS_SUCCEED_BUNDLE,
     )
 
     # Act: Execute tree
@@ -449,8 +450,7 @@ def test_tree_execution_policy_stubs_always_accept(
     tree = create_validate_report_tree(
         report_id=report.id_,
         offer_id=offer.id_,
-        credibility_factory=_always_succeed_factory,
-        validity_factory=_always_succeed_factory,
+        call_out=_ALWAYS_SUCCEED_BUNDLE,
     )
 
     # Act: Execute tree
@@ -555,15 +555,13 @@ def test_tree_execution_idempotency(
     tree1 = create_validate_report_tree(
         report_id=report.id_,
         offer_id=offer.id_,
-        credibility_factory=_always_succeed_factory,
-        validity_factory=_always_succeed_factory,
+        call_out=_ALWAYS_SUCCEED_BUNDLE,
     )
 
     tree2 = create_validate_report_tree(
         report_id=report.id_,
         offer_id=offer.id_,
-        credibility_factory=_always_succeed_factory,
-        validity_factory=_always_succeed_factory,
+        call_out=_ALWAYS_SUCCEED_BUNDLE,
     )
 
     # Act: Execute tree twice
@@ -603,8 +601,7 @@ def test_tree_execution_actor_isolation(
     tree_a = create_validate_report_tree(
         report_id=report.id_,
         offer_id=offer.id_,
-        credibility_factory=_always_succeed_factory,
-        validity_factory=_always_succeed_factory,
+        call_out=_ALWAYS_SUCCEED_BUNDLE,
     )
     result_a = bridge.execute_with_setup(
         tree=tree_a,
@@ -616,8 +613,7 @@ def test_tree_execution_actor_isolation(
     tree_b = create_validate_report_tree(
         report_id=report.id_,
         offer_id=offer.id_,
-        credibility_factory=_always_succeed_factory,
-        validity_factory=_always_succeed_factory,
+        call_out=_ALWAYS_SUCCEED_BUNDLE,
     )
     result_b = bridge.execute_with_setup(
         tree=tree_b,
@@ -680,10 +676,11 @@ def test_validate_tree_custom_credibility_factory_used(report, offer):
 
         return _Marker(name="CustomCredibility")
 
+    bundle = ValidationCallOutBundle(credibility_factory=custom_factory)  # type: ignore[arg-type]
     tree = create_validate_report_tree(
         report_id=report.id_,
         offer_id=offer.id_,
-        credibility_factory=custom_factory,
+        call_out=bundle,
     )
 
     assert sentinel["called"]
@@ -692,7 +689,7 @@ def test_validate_tree_custom_credibility_factory_used(report, offer):
 
 
 def test_validate_tree_custom_validity_factory_used(report, offer):
-    """validity_factory node appears in the tree when a custom factory is passed."""
+    """validity_factory node appears in the tree when a custom bundle is passed."""
     import py_trees
 
     def custom_factory(name):
@@ -702,10 +699,11 @@ def test_validate_tree_custom_validity_factory_used(report, offer):
 
         return _Marker(name="CustomValidity")
 
+    bundle = ValidationCallOutBundle(validity_factory=custom_factory)  # type: ignore[arg-type]
     tree = create_validate_report_tree(
         report_id=report.id_,
         offer_id=offer.id_,
-        validity_factory=custom_factory,
+        call_out=bundle,
     )
 
     tree_str = py_trees.display.ascii_tree(tree)
@@ -713,7 +711,7 @@ def test_validate_tree_custom_validity_factory_used(report, offer):
 
 
 def test_validate_tree_gather_info_factory_signature_accepted(report, offer):
-    """gather_info_factory parameter is accepted without error (Phase 2 hook).
+    """gather_info_factory is accepted via bundle without error (Phase 2 hook).
 
     The factory is NOT called in Phase 1 (not wired into the tree body yet).
     This test verifies only that the parameter is accepted without raising.
@@ -728,11 +726,11 @@ def test_validate_tree_gather_info_factory_signature_accepted(report, offer):
 
         return _Marker(name="CustomGather")
 
-    # Should not raise; factory is accepted even if not yet wired in Phase 1
+    bundle = ValidationCallOutBundle(gather_info_factory=gather_factory)  # type: ignore[arg-type]
     tree = create_validate_report_tree(
         report_id=report.id_,
         offer_id=offer.id_,
-        gather_info_factory=gather_factory,
+        call_out=bundle,
     )
     assert tree is not None
 
@@ -751,8 +749,7 @@ def test_validate_report_tree_case_has_active_embargo(
     tree = create_validate_report_tree(
         report_id=report.id_,
         offer_id=offer.id_,
-        credibility_factory=_always_succeed_factory,
-        validity_factory=_always_succeed_factory,
+        call_out=_ALWAYS_SUCCEED_BUNDLE,
     )
     bridge.execute_with_setup(
         tree=tree,

--- a/test/core/behaviors/test_performance.py
+++ b/test/core/behaviors/test_performance.py
@@ -54,6 +54,15 @@ def _always_succeed_factory(name: str) -> py_trees.behaviour.Behaviour:
     return _AlwaysSucceed(name)
 
 
+def _make_always_succeed_bundle():
+    from vultron.demo.fuzzer.bundles.validation import ValidationCallOutBundle
+
+    return ValidationCallOutBundle(
+        credibility_factory=_always_succeed_factory,  # type: ignore[arg-type]
+        validity_factory=_always_succeed_factory,  # type: ignore[arg-type]
+    )
+
+
 def _mock_get_helper(table: str, id_: str) -> dict | None:
     """Pattern-based mock for DataLayer.get()."""
     if "report" in id_:
@@ -175,8 +184,7 @@ def test_bt_execution_performance_single_run(mock_datalayer, sample_activity):
     tree = create_validate_report_tree(
         report_id="test-report-123",
         offer_id="test-offer-456",
-        credibility_factory=_always_succeed_factory,
-        validity_factory=_always_succeed_factory,
+        call_out=_make_always_succeed_bundle(),
     )
 
     start = time.perf_counter()
@@ -215,8 +223,7 @@ def test_bt_execution_performance_percentiles(mock_datalayer, sample_activity):
         tree = create_validate_report_tree(
             report_id="test-report-123",
             offer_id="test-offer-456",
-            credibility_factory=_always_succeed_factory,
-            validity_factory=_always_succeed_factory,
+            call_out=_make_always_succeed_bundle(),
         )
 
         start = time.perf_counter()

--- a/test/demo/fuzzer/test_bundles.py
+++ b/test/demo/fuzzer/test_bundles.py
@@ -117,7 +117,7 @@ def test_bundle_is_frozen_dataclass(module_path, class_name):
     assert dataclasses.is_dataclass(cls), f"{class_name} must be a dataclass"
     params = dataclasses.fields(cls)
     # Frozen = attempting mutation on an instance raises FrozenInstanceError.
-    instance = cls()
+    instance = cls()  # type: ignore[call-arg]
     _assert_frozen(instance)
     # All fields must be CallOutBackendFactory-typed
     from vultron.core.behaviors.call_out_point import CallOutBackendFactory

--- a/test/demo/fuzzer/test_bundles.py
+++ b/test/demo/fuzzer/test_bundles.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Bundle-level tests for all call-out backend domain bundles (BT-23-003).
+
+Verifies:
+- BT-23-004: CallOutBackendFactory is a runtime-checkable Protocol; each
+  bundle field satisfies isinstance checks at runtime.
+- BT-23-003: Bundle classes are frozen @dataclasses with the expected fields.
+- BT-23-001: DETERMINISTIC and STOCHASTIC singletons are exported from each
+  bundle module and from the top-level bundles/__init__.py.
+- Singletons are immutable (FrozenInstanceError on mutation attempt).
+- All bundle classes and singletons are re-exported from the top-level
+  vultron.demo.fuzzer.bundles package.
+"""
+
+import dataclasses
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _assert_frozen(instance):
+    """Assert that frozen=True prevents field mutation."""
+    fields = dataclasses.fields(instance)
+    if not fields:
+        return
+    first = fields[0].name
+    with pytest.raises((dataclasses.FrozenInstanceError, AttributeError)):
+        setattr(instance, first, None)
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance (BT-23-004)
+# ---------------------------------------------------------------------------
+
+
+def test_call_out_backend_factory_protocol_is_runtime_checkable():
+    """CallOutBackendFactory is @runtime_checkable — isinstance() usable at runtime."""
+    from vultron.core.behaviors.call_out_point import CallOutBackendFactory
+    from vultron.demo.fuzzer.base import AlwaysSucceed
+
+    def _factory(name):
+        return AlwaysSucceed(name)
+
+    assert isinstance(_factory, CallOutBackendFactory)
+
+
+def test_bundle_fields_satisfy_protocol():
+    """Each field default of DETERMINISTIC satisfies the CallOutBackendFactory Protocol."""
+    from vultron.core.behaviors.call_out_point import CallOutBackendFactory
+    from vultron.demo.fuzzer.bundles.validation import VALIDATION_DETERMINISTIC
+
+    for f in dataclasses.fields(VALIDATION_DETERMINISTIC):
+        val = getattr(VALIDATION_DETERMINISTIC, f.name)
+        assert isinstance(
+            val, CallOutBackendFactory
+        ), f"Field {f.name!r} default does not satisfy CallOutBackendFactory: {val!r}"
+
+
+# ---------------------------------------------------------------------------
+# Frozen dataclass invariants (BT-23-003)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "module_path,class_name",
+    [
+        ("vultron.demo.fuzzer.bundles.validation", "ValidationCallOutBundle"),
+        (
+            "vultron.demo.fuzzer.bundles.prioritization",
+            "PrioritizationCallOutBundle",
+        ),
+        ("vultron.demo.fuzzer.bundles.embargo", "EmbargoCallOutBundle"),
+        (
+            "vultron.demo.fuzzer.bundles.publication",
+            "PublicationCallOutBundle",
+        ),
+        (
+            "vultron.demo.fuzzer.bundles.report_to_others",
+            "ReportToOthersCallOutBundle",
+        ),
+        ("vultron.demo.fuzzer.bundles.deploy_fix", "DeployFixCallOutBundle"),
+        (
+            "vultron.demo.fuzzer.bundles.acquire_exploit",
+            "AcquireExploitCallOutBundle",
+        ),
+        (
+            "vultron.demo.fuzzer.bundles.assign_vul_id",
+            "AssignVulIdCallOutBundle",
+        ),
+        (
+            "vultron.demo.fuzzer.bundles.close_report",
+            "CloseReportCallOutBundle",
+        ),
+    ],
+)
+def test_bundle_is_frozen_dataclass(module_path, class_name):
+    """Each bundle class is a frozen dataclass (mutation must raise FrozenInstanceError)."""
+    import importlib
+
+    mod = importlib.import_module(module_path)
+    cls = getattr(mod, class_name)
+    assert dataclasses.is_dataclass(cls), f"{class_name} must be a dataclass"
+    params = dataclasses.fields(cls)
+    # Frozen = attempting mutation on an instance raises FrozenInstanceError.
+    instance = cls()
+    _assert_frozen(instance)
+    # All fields must be CallOutBackendFactory-typed
+    from vultron.core.behaviors.call_out_point import CallOutBackendFactory
+
+    for f in params:
+        val = getattr(instance, f.name)
+        assert isinstance(
+            val, CallOutBackendFactory
+        ), f"{class_name}.{f.name} default does not satisfy CallOutBackendFactory: {val!r}"
+
+
+# ---------------------------------------------------------------------------
+# Singleton immutability (BT-23-003)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "module_path,det_name,sto_name",
+    [
+        (
+            "vultron.demo.fuzzer.bundles.validation",
+            "VALIDATION_DETERMINISTIC",
+            "VALIDATION_STOCHASTIC",
+        ),
+        (
+            "vultron.demo.fuzzer.bundles.prioritization",
+            "PRIORITIZATION_DETERMINISTIC",
+            "PRIORITIZATION_STOCHASTIC",
+        ),
+        (
+            "vultron.demo.fuzzer.bundles.embargo",
+            "EMBARGO_DETERMINISTIC",
+            "EMBARGO_STOCHASTIC",
+        ),
+        (
+            "vultron.demo.fuzzer.bundles.publication",
+            "PUBLICATION_DETERMINISTIC",
+            "PUBLICATION_STOCHASTIC",
+        ),
+        (
+            "vultron.demo.fuzzer.bundles.report_to_others",
+            "REPORT_TO_OTHERS_DETERMINISTIC",
+            "REPORT_TO_OTHERS_STOCHASTIC",
+        ),
+        (
+            "vultron.demo.fuzzer.bundles.deploy_fix",
+            "DEPLOY_FIX_DETERMINISTIC",
+            "DEPLOY_FIX_STOCHASTIC",
+        ),
+        (
+            "vultron.demo.fuzzer.bundles.acquire_exploit",
+            "ACQUIRE_EXPLOIT_DETERMINISTIC",
+            "ACQUIRE_EXPLOIT_STOCHASTIC",
+        ),
+        (
+            "vultron.demo.fuzzer.bundles.assign_vul_id",
+            "ASSIGN_VUL_ID_DETERMINISTIC",
+            "ASSIGN_VUL_ID_STOCHASTIC",
+        ),
+        (
+            "vultron.demo.fuzzer.bundles.close_report",
+            "CLOSE_REPORT_DETERMINISTIC",
+            "CLOSE_REPORT_STOCHASTIC",
+        ),
+    ],
+)
+def test_singletons_are_immutable(module_path, det_name, sto_name):
+    """DETERMINISTIC and STOCHASTIC singletons are immutable."""
+    import importlib
+
+    mod = importlib.import_module(module_path)
+    det = getattr(mod, det_name)
+    sto = getattr(mod, sto_name)
+    _assert_frozen(det)
+    _assert_frozen(sto)
+
+
+# ---------------------------------------------------------------------------
+# Top-level __init__ re-exports (BT-23-005)
+# ---------------------------------------------------------------------------
+
+
+def test_bundles_init_re_exports_all_classes_and_singletons():
+    """vultron.demo.fuzzer.bundles re-exports all 9 bundle classes and 18 singletons."""
+    import vultron.demo.fuzzer.bundles as bundles_pkg
+
+    expected_classes = [
+        "ValidationCallOutBundle",
+        "PrioritizationCallOutBundle",
+        "EmbargoCallOutBundle",
+        "PublicationCallOutBundle",
+        "ReportToOthersCallOutBundle",
+        "DeployFixCallOutBundle",
+        "AcquireExploitCallOutBundle",
+        "AssignVulIdCallOutBundle",
+        "CloseReportCallOutBundle",
+    ]
+    expected_singletons = [
+        "VALIDATION_DETERMINISTIC",
+        "VALIDATION_STOCHASTIC",
+        "PRIORITIZATION_DETERMINISTIC",
+        "PRIORITIZATION_STOCHASTIC",
+        "EMBARGO_DETERMINISTIC",
+        "EMBARGO_STOCHASTIC",
+        "PUBLICATION_DETERMINISTIC",
+        "PUBLICATION_STOCHASTIC",
+        "REPORT_TO_OTHERS_DETERMINISTIC",
+        "REPORT_TO_OTHERS_STOCHASTIC",
+        "DEPLOY_FIX_DETERMINISTIC",
+        "DEPLOY_FIX_STOCHASTIC",
+        "ACQUIRE_EXPLOIT_DETERMINISTIC",
+        "ACQUIRE_EXPLOIT_STOCHASTIC",
+        "ASSIGN_VUL_ID_DETERMINISTIC",
+        "ASSIGN_VUL_ID_STOCHASTIC",
+        "CLOSE_REPORT_DETERMINISTIC",
+        "CLOSE_REPORT_STOCHASTIC",
+    ]
+    for name in expected_classes + expected_singletons:
+        assert hasattr(
+            bundles_pkg, name
+        ), f"vultron.demo.fuzzer.bundles does not export {name!r}"

--- a/test/demo/fuzzer/test_stochastic_bundle_scenario.py
+++ b/test/demo/fuzzer/test_stochastic_bundle_scenario.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Demo scenario: end-to-end STOCHASTIC bundle injection (BT-23-003, BT-23-005).
+
+Demonstrates the three-mode model from call-out-configuration.md:
+
+- DETERMINISTIC singletons (ceiling/floor rule) are the no-arg default for
+  every tree builder.
+- STOCHASTIC singletons re-wire every call-out point to a probabilistic fuzzer
+  node — the backend used by the demo/fuzzer stack.
+- Custom bundles allow per-field overrides for targeted stubbing.
+
+Each test exercises a different domain to show the pattern is universal.
+"""
+
+import logging
+import py_trees
+import pytest
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(autouse=True)
+def clear_blackboard():
+    py_trees.blackboard.Blackboard.storage.clear()
+    yield
+    py_trees.blackboard.Blackboard.storage.clear()
+
+
+# ---------------------------------------------------------------------------
+# Validation domain
+# ---------------------------------------------------------------------------
+
+
+def test_validation_stochastic_bundle_end_to_end():
+    """STOCHASTIC bundle produces EvaluateReportCredibility/Validity fuzzer nodes."""
+    from vultron.core.behaviors.report.validate_tree import (
+        create_validate_report_tree,
+    )
+    from vultron.demo.fuzzer.bundles.validation import VALIDATION_STOCHASTIC
+    from vultron.demo.fuzzer.report_management.validate import (
+        EvaluateReportCredibility,
+        EvaluateReportValidity,
+    )
+
+    tree = create_validate_report_tree(
+        report_id="https://example.org/reports/demo-001",
+        offer_id="https://example.org/offers/demo-001",
+        call_out=VALIDATION_STOCHASTIC,
+    )
+    assert isinstance(tree, py_trees.behaviour.Behaviour)
+
+    # Find ValidationFlow's credibility and validity children (positions 1 and 2
+    # inside the EmitAndValidate → ValidationOrShortcut → ValidationFlow path).
+    emit_and_validate = tree.children[0]
+    validation_or_shortcut = emit_and_validate.children[1]
+    validation_flow = validation_or_shortcut.children[1]
+    assert isinstance(validation_flow.children[1], EvaluateReportCredibility)
+    assert isinstance(validation_flow.children[2], EvaluateReportValidity)
+
+    logger.info(
+        "STOCHASTIC validation tree:\n%s", py_trees.display.ascii_tree(tree)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Embargo domain
+# ---------------------------------------------------------------------------
+
+
+def test_embargo_stochastic_bundle_end_to_end():
+    """STOCHASTIC bundle produces correct fuzzer nodes for all 10 embargo children."""
+    from vultron.core.behaviors.embargo.manage_embargo_tree import (
+        create_manage_embargo_tree,
+    )
+    from vultron.demo.fuzzer.bundles.embargo import EMBARGO_STOCHASTIC
+    from vultron.demo.fuzzer.embargo import (
+        ExitEmbargoWhenDeployed,
+        ExitEmbargoWhenFixReady,
+        SelectEmbargoOfferTerms,
+    )
+
+    case_id = "https://example.org/cases/demo-001"
+    tree = create_manage_embargo_tree(
+        case_id=case_id, call_out=EMBARGO_STOCHASTIC
+    )
+    assert isinstance(tree, py_trees.behaviour.Behaviour)
+    assert len(tree.children) == 10
+    assert isinstance(tree.children[0], ExitEmbargoWhenDeployed)
+    assert isinstance(tree.children[1], ExitEmbargoWhenFixReady)
+    assert isinstance(tree.children[4], SelectEmbargoOfferTerms)
+
+    logger.info(
+        "STOCHASTIC embargo tree:\n%s", py_trees.display.ascii_tree(tree)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Assign VUL-ID domain
+# ---------------------------------------------------------------------------
+
+
+def test_assign_vul_id_stochastic_bundle_end_to_end():
+    """STOCHASTIC bundle produces InScope + IdAssignable fuzzer nodes."""
+    from vultron.core.behaviors.report.assign_vul_id_tree import (
+        create_assign_vul_id_tree,
+    )
+    from vultron.demo.fuzzer.bundles.assign_vul_id import (
+        ASSIGN_VUL_ID_STOCHASTIC,
+    )
+    from vultron.demo.fuzzer.report_management.assign_vul_id import (
+        IdAssignable,
+        InScope,
+    )
+
+    case_id = "https://example.org/cases/demo-001"
+    tree = create_assign_vul_id_tree(
+        case_id=case_id, call_out=ASSIGN_VUL_ID_STOCHASTIC
+    )
+    assert isinstance(tree.children[0], InScope)
+    assert isinstance(tree.children[1], IdAssignable)
+
+    logger.info(
+        "STOCHASTIC assign-VUL-ID tree:\n%s", py_trees.display.ascii_tree(tree)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mode comparison: DETERMINISTIC vs STOCHASTIC vs CUSTOM
+# ---------------------------------------------------------------------------
+
+
+def test_three_mode_comparison():
+    """Demonstrate all three modes for the deploy-fix domain side-by-side."""
+    from vultron.core.behaviors.report.deploy_fix_tree import (
+        create_deploy_fix_tree,
+    )
+    from vultron.demo.fuzzer.base import AlwaysFail
+    from vultron.demo.fuzzer.bundles.deploy_fix import (
+        DEPLOY_FIX_DETERMINISTIC,
+        DEPLOY_FIX_STOCHASTIC,
+        DeployFixCallOutBundle,
+    )
+    from vultron.demo.fuzzer.report_management.deploy_fix import DeployFix
+
+    case_id = "https://example.org/cases/demo-001"
+
+    # DETERMINISTIC mode (ceiling/floor defaults)
+    det_tree = create_deploy_fix_tree(case_id=case_id)
+    assert isinstance(det_tree.children[3], AlwaysFail)  # DeployFix p=0.10
+
+    # Explicit DETERMINISTIC singleton — same result
+    det_tree2 = create_deploy_fix_tree(
+        case_id=case_id, call_out=DEPLOY_FIX_DETERMINISTIC
+    )
+    assert isinstance(det_tree2.children[3], AlwaysFail)
+
+    # STOCHASTIC mode — probabilistic fuzzer nodes
+    sto_tree = create_deploy_fix_tree(
+        case_id=case_id, call_out=DEPLOY_FIX_STOCHASTIC
+    )
+    assert isinstance(sto_tree.children[3], DeployFix)
+
+    # CUSTOM mode — per-field override
+    def _custom_deploy_fix(name):
+        class _Custom(py_trees.behaviour.Behaviour):
+            def update(self):
+                return py_trees.common.Status.SUCCESS
+
+        return _Custom(name="CustomDeployFix")
+
+    custom_bundle = DeployFixCallOutBundle(
+        deploy_fix_factory=_custom_deploy_fix  # type: ignore[arg-type]
+    )
+    cust_tree = create_deploy_fix_tree(case_id=case_id, call_out=custom_bundle)
+    assert cust_tree.children[3].name == "CustomDeployFix"
+
+    logger.info("Three-mode comparison complete for deploy-fix domain.")

--- a/vultron/core/behaviors/call_out_point.py
+++ b/vultron/core/behaviors/call_out_point.py
@@ -13,13 +13,14 @@
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 """Call-out point factory type for the Vultron BT port/adapter seam.
 
-This module defines the :data:`CallOutBackendFactory` type alias used by tree
-builder functions to accept swappable call-out point backends (ADR-0025).
+This module defines the :class:`CallOutBackendFactory` Protocol used by tree
+builder functions to accept swappable call-out point backends (ADR-0025,
+BT-23-004).
 
-The type alias lives here (in ``vultron.core.behaviors``) so that tree
-builders in ``vultron.core.behaviors.report`` can reference it without
-importing from ``vultron.demo``, maintaining the hexagonal-architecture
-layering rule (BT-16-001: simulation artifacts stay out of core).
+The Protocol lives here (in ``vultron.core.behaviors``) so that tree builders
+in ``vultron.core.behaviors.report`` can reference it without importing from
+``vultron.demo``, maintaining the hexagonal-architecture layering rule
+(BT-16-001: simulation artifacts stay out of core).
 
 The shape mixin classes and illustrative examples live in
 ``vultron.demo.fuzzer.call_out_point``.
@@ -27,40 +28,45 @@ The shape mixin classes and illustrative examples live in
 References
 ----------
 - ADR-0025: ``docs/adr/0025-call-out-point-abstraction-layer.md``
-- Spec: ``specs/behavior-tree-integration.yaml`` BT-18-004
+- Spec: ``specs/behavior-tree-integration.yaml`` BT-18-004, BT-23-004
 """
 
 from __future__ import annotations
 
-from typing import Callable
+from typing import Protocol, runtime_checkable
 
 import py_trees as _py_trees
 
-CallOutBackendFactory = Callable[[str], _py_trees.behaviour.Behaviour]
-"""Factory callable type for swappable call-out point backends.
 
-Each call-out point in a BT tree builder is constructed by calling a factory
-of this type, passing the node's display name as the sole argument.  Tree
-builder functions accept one factory parameter per injected call-out point
-and default to the corresponding fuzzer factory (BT-18-004).
+@runtime_checkable
+class CallOutBackendFactory(Protocol):
+    """Protocol for swappable call-out point backend factories (BT-23-004).
 
-The returned Behaviour must honour the call-out point's declared blackboard
-contract (BT-18-001, BT-18-002): it must write all declared output keys on
-SUCCESS, with type-conformant values.
+    A factory must accept a single ``name: str`` argument (the BT node's
+    display name) and return a ``py_trees.behaviour.Behaviour`` that honours
+    the call-out point's declared blackboard contract (BT-18-001 through
+    BT-18-004).
 
-Example::
+    Any callable satisfying this signature is a valid backend — plain lambda
+    functions, module-level functions, and classes with ``__call__`` all
+    qualify.  No central registration, inheritance, or decorator is required.
+    Static type checking via pyright/mypy is the validation mechanism.
 
-    from vultron.core.behaviors.call_out_point import CallOutBackendFactory
-    from vultron.demo.fuzzer.report_management.validate import (
-        EvaluateReportCredibility as _FuzzerCredibility,
-    )
+    Example::
 
-    def create_my_tree(
-        report_id: str,
-        credibility_factory: CallOutBackendFactory = (
-            lambda n: _FuzzerCredibility(n)
-        ),
-    ) -> py_trees.behaviour.Behaviour:
-        node = credibility_factory("EvaluateReportCredibility")
-        ...
-"""
+        from vultron.core.behaviors.call_out_point import CallOutBackendFactory
+        from vultron.demo.fuzzer.report_management.validate import (
+            EvaluateReportCredibility as _FuzzerCredibility,
+        )
+
+        def create_my_tree(
+            report_id: str,
+            credibility_factory: CallOutBackendFactory = (
+                lambda n: _FuzzerCredibility(n)
+            ),
+        ) -> py_trees.behaviour.Behaviour:
+            node = credibility_factory("EvaluateReportCredibility")
+            ...
+    """
+
+    def __call__(self, name: str) -> _py_trees.behaviour.Behaviour: ...

--- a/vultron/core/behaviors/embargo/manage_embargo_tree.py
+++ b/vultron/core/behaviors/embargo/manage_embargo_tree.py
@@ -51,141 +51,14 @@ References
 """
 
 import logging
+from typing import TYPE_CHECKING
 
 import py_trees
 
-from vultron.core.behaviors.call_out_point import CallOutBackendFactory
+if TYPE_CHECKING:
+    from vultron.demo.fuzzer.bundles.embargo import EmbargoCallOutBundle
 
 logger = logging.getLogger(__name__)
-
-
-# ---------------------------------------------------------------------------
-# Termination default factories
-# ---------------------------------------------------------------------------
-
-
-def _default_exit_embargo_when_deployed_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.embargo import ExitEmbargoWhenDeployed
-
-    return ExitEmbargoWhenDeployed(name)
-
-
-def _default_exit_embargo_when_fix_ready_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.embargo import ExitEmbargoWhenFixReady
-
-    return ExitEmbargoWhenFixReady(name)
-
-
-def _default_exit_embargo_for_other_reason_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.embargo import ExitEmbargoForOtherReason
-
-    return ExitEmbargoForOtherReason(name)
-
-
-# ---------------------------------------------------------------------------
-# Negotiation / proposal default factories
-# ---------------------------------------------------------------------------
-
-
-def _default_stop_proposing_embargo_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.embargo import StopProposingEmbargo
-
-    return StopProposingEmbargo(name)
-
-
-def _default_select_embargo_offer_terms_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.embargo import SelectEmbargoOfferTerms
-
-    return SelectEmbargoOfferTerms(name)
-
-
-def _default_want_to_propose_embargo_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.embargo import WantToProposeEmbargo
-
-    return WantToProposeEmbargo(name)
-
-
-def _default_willing_to_counter_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.embargo import WillingToCounterEmbargoProposal
-
-    return WillingToCounterEmbargoProposal(name)
-
-
-def _default_reason_to_propose_when_deployed_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.embargo import ReasonToProposeEmbargoWhenDeployed
-
-    return ReasonToProposeEmbargoWhenDeployed(name)
-
-
-# ---------------------------------------------------------------------------
-# Proposal evaluation default factory
-# ---------------------------------------------------------------------------
-
-
-def _default_evaluate_embargo_proposal_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.embargo import EvaluateEmbargoProposal
-
-    return EvaluateEmbargoProposal(name)
-
-
-# ---------------------------------------------------------------------------
-# Active embargo evaluation default factory
-# ---------------------------------------------------------------------------
-
-
-def _default_current_embargo_acceptable_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.embargo import CurrentEmbargoAcceptable
-
-    return CurrentEmbargoAcceptable(name)
-
-
-# ---------------------------------------------------------------------------
-# Actuator default factories (Phase 2 reserved)
-# ---------------------------------------------------------------------------
-
-
-def _default_on_embargo_exit_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.embargo import OnEmbargoExit
-
-    return OnEmbargoExit(name)
-
-
-def _default_on_embargo_accept_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.embargo import OnEmbargoAccept
-
-    return OnEmbargoAccept(name)
-
-
-def _default_on_embargo_reject_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.embargo import OnEmbargoReject
-
-    return OnEmbargoReject(name)
 
 
 # ---------------------------------------------------------------------------
@@ -195,95 +68,62 @@ def _default_on_embargo_reject_factory(
 
 def create_manage_embargo_tree(
     case_id: str,
-    exit_embargo_when_deployed_factory: CallOutBackendFactory = _default_exit_embargo_when_deployed_factory,
-    exit_embargo_when_fix_ready_factory: CallOutBackendFactory = _default_exit_embargo_when_fix_ready_factory,
-    exit_embargo_for_other_reason_factory: CallOutBackendFactory = _default_exit_embargo_for_other_reason_factory,
-    stop_proposing_embargo_factory: CallOutBackendFactory = _default_stop_proposing_embargo_factory,
-    select_embargo_offer_terms_factory: CallOutBackendFactory = _default_select_embargo_offer_terms_factory,
-    want_to_propose_embargo_factory: CallOutBackendFactory = _default_want_to_propose_embargo_factory,
-    willing_to_counter_factory: CallOutBackendFactory = _default_willing_to_counter_factory,
-    reason_to_propose_when_deployed_factory: CallOutBackendFactory = _default_reason_to_propose_when_deployed_factory,
-    evaluate_embargo_proposal_factory: CallOutBackendFactory = _default_evaluate_embargo_proposal_factory,
-    current_embargo_acceptable_factory: CallOutBackendFactory = _default_current_embargo_acceptable_factory,
-    on_embargo_exit_factory: CallOutBackendFactory = _default_on_embargo_exit_factory,
-    on_embargo_accept_factory: CallOutBackendFactory = _default_on_embargo_accept_factory,
-    on_embargo_reject_factory: CallOutBackendFactory = _default_on_embargo_reject_factory,
+    call_out: "EmbargoCallOutBundle | None" = None,
 ) -> py_trees.behaviour.Behaviour:
     """Create behavior tree for the embargo management workflow (Phase 1 stub).
 
     Phase 1 exposes all ten Evaluator call-out points as a stub Sequence.
     The three Actuator factories (on_embargo_exit_factory,
-    on_embargo_accept_factory, on_embargo_reject_factory) are accepted for
-    BT-18-004 compliance but reserved for Phase 2 when the full termination,
-    acceptance, and rejection arms are built.  The full embargo management
-    lifecycle (termination arm, proposal arm, counter-proposal arm,
-    active-embargo review loop) is deferred to a future issue.
+    on_embargo_accept_factory, on_embargo_reject_factory) in the bundle are
+    reserved for Phase 2 when the full termination, acceptance, and rejection
+    arms are built.  The full embargo management lifecycle is deferred to a
+    future issue.
 
     Args:
         case_id: ID of VulnerabilityCase whose embargo is being managed.
-        exit_embargo_when_deployed_factory: Factory for the Evaluator that
-            decides whether fix deployment is sufficient to end the embargo.
-            Defaults to the fuzzer backend (BT-18-004).
-        exit_embargo_when_fix_ready_factory: Factory for the Evaluator that
-            decides whether fix availability alone ends the embargo.  Defaults
-            to the fuzzer backend (BT-18-004).
-        exit_embargo_for_other_reason_factory: Factory for the Evaluator that
-            handles exceptional embargo exit triggers.  Defaults to the fuzzer
-            backend (BT-18-004).
-        stop_proposing_embargo_factory: Factory for the Evaluator that decides
-            whether to abandon ongoing embargo negotiations.  Defaults to the
-            fuzzer backend (BT-18-004).
-        select_embargo_offer_terms_factory: Factory for the Evaluator that
-            selects terms for a new embargo proposal.  Defaults to the fuzzer
-            backend (BT-18-004).
-        want_to_propose_embargo_factory: Factory for the Evaluator that decides
-            whether to initiate an embargo proposal.  Defaults to the fuzzer
-            backend (BT-18-004).
-        willing_to_counter_factory: Factory for the Evaluator that decides
-            whether to respond to an incoming proposal with a counter-proposal.
-            Defaults to the fuzzer backend (BT-18-004).
-        reason_to_propose_when_deployed_factory: Factory for the Evaluator
-            that handles the rare case of proposing an embargo post-deployment.
-            Defaults to the fuzzer backend (BT-18-004).
-        evaluate_embargo_proposal_factory: Factory for the Evaluator that
-            assesses an incoming embargo proposal.  Defaults to the fuzzer
-            backend (BT-18-004).
-        current_embargo_acceptable_factory: Factory for the Evaluator that
-            decides whether the active embargo terms remain acceptable.
-            Defaults to the fuzzer backend (BT-18-004).
-        on_embargo_exit_factory: Factory for the Actuator that executes
-            site-specific tasks on embargo exit.  Reserved for Phase 2;
-            accepted but not yet wired into the Phase 1 tree body (BT-18-004).
-        on_embargo_accept_factory: Factory for the Actuator that executes
-            site-specific tasks when a proposal is accepted.  Reserved for
-            Phase 2; accepted but not yet wired (BT-18-004).
-        on_embargo_reject_factory: Factory for the Actuator that executes
-            site-specific tasks when a proposal is rejected.  Reserved for
-            Phase 2; accepted but not yet wired (BT-18-004).
+        call_out: Bundle of call-out backend factories for this domain.
+            Defaults to :data:`~vultron.demo.fuzzer.bundles.embargo.EMBARGO_DETERMINISTIC`
+            (BT-23-003, BT-23-005).
 
     Returns:
         Root node of the manage-embargo behavior tree (Phase 1 stub Sequence).
     """
-    # Phase 2: on_embargo_exit_factory, on_embargo_accept_factory, and
-    # on_embargo_reject_factory are reserved for the full termination,
-    # acceptance, and rejection workflow arms.  Accepting them here satisfies
-    # BT-18-004 without breaking callers.
+    from vultron.demo.fuzzer.bundles.embargo import EMBARGO_DETERMINISTIC
+
+    bundle = call_out if call_out is not None else EMBARGO_DETERMINISTIC
+    # Phase 2: bundle.on_embargo_exit_factory, bundle.on_embargo_accept_factory,
+    # and bundle.on_embargo_reject_factory are reserved for the full termination,
+    # acceptance, and rejection workflow arms.
     root = py_trees.composites.Sequence(
         name="ManageEmbargoBT",
         memory=False,
         children=[
-            exit_embargo_when_deployed_factory("ExitEmbargoWhenDeployed"),
-            exit_embargo_when_fix_ready_factory("ExitEmbargoWhenFixReady"),
-            exit_embargo_for_other_reason_factory("ExitEmbargoForOtherReason"),
-            stop_proposing_embargo_factory("StopProposingEmbargo"),
-            select_embargo_offer_terms_factory("SelectEmbargoOfferTerms"),
-            want_to_propose_embargo_factory("WantToProposeEmbargo"),
-            willing_to_counter_factory("WillingToCounterEmbargoProposal"),
-            reason_to_propose_when_deployed_factory(
+            bundle.exit_embargo_when_deployed_factory(
+                "ExitEmbargoWhenDeployed"
+            ),
+            bundle.exit_embargo_when_fix_ready_factory(
+                "ExitEmbargoWhenFixReady"
+            ),
+            bundle.exit_embargo_for_other_reason_factory(
+                "ExitEmbargoForOtherReason"
+            ),
+            bundle.stop_proposing_embargo_factory("StopProposingEmbargo"),
+            bundle.select_embargo_offer_terms_factory(
+                "SelectEmbargoOfferTerms"
+            ),
+            bundle.want_to_propose_embargo_factory("WantToProposeEmbargo"),
+            bundle.willing_to_counter_factory(
+                "WillingToCounterEmbargoProposal"
+            ),
+            bundle.reason_to_propose_when_deployed_factory(
                 "ReasonToProposeEmbargoWhenDeployed"
             ),
-            evaluate_embargo_proposal_factory("EvaluateEmbargoProposal"),
-            current_embargo_acceptable_factory("CurrentEmbargoAcceptable"),
+            bundle.evaluate_embargo_proposal_factory(
+                "EvaluateEmbargoProposal"
+            ),
+            bundle.current_embargo_acceptable_factory(
+                "CurrentEmbargoAcceptable"
+            ),
         ],
     )
     logger.info(f"Created ManageEmbargoBT (Phase 1 stub) for case={case_id}")

--- a/vultron/core/behaviors/report/acquire_exploit_strategy_tree.py
+++ b/vultron/core/behaviors/report/acquire_exploit_strategy_tree.py
@@ -37,11 +37,15 @@ References
 """
 
 import logging
+from typing import TYPE_CHECKING
 
 import py_trees
 from pydantic import BaseModel
 
-from vultron.core.behaviors.call_out_point import CallOutBackendFactory
+if TYPE_CHECKING:
+    from vultron.demo.fuzzer.bundles.acquire_exploit import (
+        AcquireExploitCallOutBundle,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -66,32 +70,9 @@ class ExploitStrategyDecision(BaseModel):
     rationale: str = ""
 
 
-def _default_have_exploit_factory(name: str) -> py_trees.behaviour.Behaviour:
-    # Deferred import: avoids circular dependency — demo/acquire_exploit.py
-    # imports ExploitStrategyDecision from this module at module level.
-    from vultron.demo.fuzzer.report_management.acquire_exploit import (
-        HaveExploit,
-    )
-
-    return HaveExploit(name)
-
-
-def _default_evaluate_exploit_strategy_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    # Deferred import: avoids circular dependency — demo/acquire_exploit.py
-    # imports ExploitStrategyDecision from this module at module level.
-    from vultron.demo.fuzzer.report_management.acquire_exploit import (
-        EvaluateExploitStrategy,
-    )
-
-    return EvaluateExploitStrategy(name)
-
-
 def create_acquire_exploit_strategy_tree(
     case_id: str,
-    have_exploit_factory: CallOutBackendFactory = _default_have_exploit_factory,
-    evaluate_exploit_strategy_factory: CallOutBackendFactory = _default_evaluate_exploit_strategy_factory,
+    call_out: "AcquireExploitCallOutBundle | None" = None,
 ) -> py_trees.behaviour.Behaviour:
     """Create the collapsed exploit-strategy behavior tree (Production Collapse 1).
 
@@ -108,22 +89,28 @@ def create_acquire_exploit_strategy_tree(
 
     Args:
         case_id: ID of VulnerabilityCase being processed.
-        have_exploit_factory: Factory for the Retriever call-out point that
-            checks whether a working exploit already exists.  Defaults to
-            the fuzzer backend.
-        evaluate_exploit_strategy_factory: Factory for the Evaluator
-            call-out point that produces the acquisition strategy decision.
-            Defaults to the fuzzer backend.
+        call_out: Bundle of call-out backend factories for this domain.
+            Defaults to :data:`~vultron.demo.fuzzer.bundles.acquire_exploit.ACQUIRE_EXPLOIT_DETERMINISTIC`
+            (BT-23-003, BT-23-005).
 
     Returns:
         Root Selector node of the collapsed exploit-strategy subtree.
     """
+    from vultron.demo.fuzzer.bundles.acquire_exploit import (
+        ACQUIRE_EXPLOIT_DETERMINISTIC,
+    )
+
+    bundle = (
+        call_out if call_out is not None else ACQUIRE_EXPLOIT_DETERMINISTIC
+    )
     root = py_trees.composites.Selector(
         name="AcquireExploitStrategyBT",
         memory=False,
         children=[
-            have_exploit_factory("HaveExploit"),
-            evaluate_exploit_strategy_factory("EvaluateExploitStrategy"),
+            bundle.have_exploit_factory("HaveExploit"),
+            bundle.evaluate_exploit_strategy_factory(
+                "EvaluateExploitStrategy"
+            ),
         ],
     )
     logger.info(

--- a/vultron/core/behaviors/report/acquire_exploit_tree.py
+++ b/vultron/core/behaviors/report/acquire_exploit_tree.py
@@ -28,38 +28,21 @@ References
 """
 
 import logging
+from typing import TYPE_CHECKING
 
 import py_trees
 
-from vultron.core.behaviors.call_out_point import CallOutBackendFactory
+if TYPE_CHECKING:
+    from vultron.demo.fuzzer.bundles.acquire_exploit import (
+        AcquireExploitCallOutBundle,
+    )
 
 logger = logging.getLogger(__name__)
 
 
-def _default_evaluate_exploit_priority_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.report_management.acquire_exploit import (
-        EvaluateExploitPriority,
-    )
-
-    return EvaluateExploitPriority(name)
-
-
-def _default_purchase_exploit_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.report_management.acquire_exploit import (
-        PurchaseExploit,
-    )
-
-    return PurchaseExploit(name)
-
-
 def create_acquire_exploit_tree(
     case_id: str,
-    evaluate_exploit_priority_factory: CallOutBackendFactory = _default_evaluate_exploit_priority_factory,
-    purchase_exploit_factory: CallOutBackendFactory = _default_purchase_exploit_factory,
+    call_out: "AcquireExploitCallOutBundle | None" = None,
 ) -> py_trees.behaviour.Behaviour:
     """Create behavior tree for the exploit acquisition workflow (Phase 1 stub).
 
@@ -69,22 +52,28 @@ def create_acquire_exploit_tree(
 
     Args:
         case_id: ID of VulnerabilityCase being processed.
-        evaluate_exploit_priority_factory: Factory for the Evaluator call-out
-            point that assesses priority for acquiring an exploit.  Defaults
-            to the fuzzer backend (BT-18-004).
-        purchase_exploit_factory: Factory for the Evaluator call-out point that
-            drives exploit procurement from an external vendor or broker.
-            Defaults to the fuzzer backend (BT-18-004).
+        call_out: Bundle of call-out backend factories for this domain.
+            Defaults to :data:`~vultron.demo.fuzzer.bundles.acquire_exploit.ACQUIRE_EXPLOIT_DETERMINISTIC`
+            (BT-23-003, BT-23-005).
 
     Returns:
         Root node of the acquire-exploit behavior tree (Phase 1 stub Sequence).
     """
+    from vultron.demo.fuzzer.bundles.acquire_exploit import (
+        ACQUIRE_EXPLOIT_DETERMINISTIC,
+    )
+
+    bundle = (
+        call_out if call_out is not None else ACQUIRE_EXPLOIT_DETERMINISTIC
+    )
     root = py_trees.composites.Sequence(
         name="AcquireExploitBT",
         memory=False,
         children=[
-            evaluate_exploit_priority_factory("EvaluateExploitPriority"),
-            purchase_exploit_factory("PurchaseExploit"),
+            bundle.evaluate_exploit_priority_factory(
+                "EvaluateExploitPriority"
+            ),
+            bundle.purchase_exploit_factory("PurchaseExploit"),
         ],
     )
     logger.info(f"Created AcquireExploitBT (Phase 1 stub) for case={case_id}")

--- a/vultron/core/behaviors/report/assign_vul_id_tree.py
+++ b/vultron/core/behaviors/report/assign_vul_id_tree.py
@@ -27,32 +27,21 @@ References
 """
 
 import logging
+from typing import TYPE_CHECKING
 
 import py_trees
 
-from vultron.core.behaviors.call_out_point import CallOutBackendFactory
+if TYPE_CHECKING:
+    from vultron.demo.fuzzer.bundles.assign_vul_id import (
+        AssignVulIdCallOutBundle,
+    )
 
 logger = logging.getLogger(__name__)
 
 
-def _default_id_assignable_factory(name: str) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.report_management.assign_vul_id import (
-        IdAssignable,
-    )
-
-    return IdAssignable(name)
-
-
-def _default_in_scope_factory(name: str) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.report_management.assign_vul_id import InScope
-
-    return InScope(name)
-
-
 def create_assign_vul_id_tree(
     case_id: str,
-    id_assignable_factory: CallOutBackendFactory = _default_id_assignable_factory,
-    in_scope_factory: CallOutBackendFactory = _default_in_scope_factory,
+    call_out: "AssignVulIdCallOutBundle | None" = None,
 ) -> py_trees.behaviour.Behaviour:
     """Create behavior tree for the VUL ID assignment workflow (Phase 1 stub).
 
@@ -62,22 +51,24 @@ def create_assign_vul_id_tree(
 
     Args:
         case_id: ID of VulnerabilityCase being processed.
-        id_assignable_factory: Factory for the Evaluator call-out point that
-            checks whether the vulnerability qualifies for ID assignment.
-            Defaults to the fuzzer backend (BT-18-004).
-        in_scope_factory: Factory for the Evaluator call-out point that checks
-            whether the vulnerability is within the applicable ID space scope.
-            Defaults to the fuzzer backend (BT-18-004).
+        call_out: Bundle of call-out backend factories for this domain.
+            Defaults to :data:`~vultron.demo.fuzzer.bundles.assign_vul_id.ASSIGN_VUL_ID_DETERMINISTIC`
+            (BT-23-003, BT-23-005).
 
     Returns:
         Root node of the assign-VUL-ID behavior tree (Phase 1 stub Sequence).
     """
+    from vultron.demo.fuzzer.bundles.assign_vul_id import (
+        ASSIGN_VUL_ID_DETERMINISTIC,
+    )
+
+    bundle = call_out if call_out is not None else ASSIGN_VUL_ID_DETERMINISTIC
     root = py_trees.composites.Sequence(
         name="AssignVulIDBT",
         memory=False,
         children=[
-            in_scope_factory("InScope"),
-            id_assignable_factory("IdAssignable"),
+            bundle.in_scope_factory("InScope"),
+            bundle.id_assignable_factory("IdAssignable"),
         ],
     )
     logger.info(f"Created AssignVulIDBT (Phase 1 stub) for case={case_id}")

--- a/vultron/core/behaviors/report/close_report_tree.py
+++ b/vultron/core/behaviors/report/close_report_tree.py
@@ -33,38 +33,21 @@ References
 """
 
 import logging
+from typing import TYPE_CHECKING
 
 import py_trees
 
-from vultron.core.behaviors.call_out_point import CallOutBackendFactory
+if TYPE_CHECKING:
+    from vultron.demo.fuzzer.bundles.close_report import (
+        CloseReportCallOutBundle,
+    )
 
 logger = logging.getLogger(__name__)
 
 
-def _default_other_close_criteria_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.report_management.close_report import (
-        OtherCloseCriteriaMet,
-    )
-
-    return OtherCloseCriteriaMet(name)
-
-
-def _default_pre_close_action_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.report_management.close_report import (
-        PreCloseAction,
-    )
-
-    return PreCloseAction(name)
-
-
 def create_close_report_tree(
     case_id: str,
-    other_close_criteria_factory: CallOutBackendFactory = _default_other_close_criteria_factory,
-    pre_close_action_factory: CallOutBackendFactory = _default_pre_close_action_factory,
+    call_out: "CloseReportCallOutBundle | None" = None,
 ) -> py_trees.behaviour.Behaviour:
     """Create behavior tree for the report closure workflow (Phase 1 stub).
 
@@ -77,19 +60,20 @@ def create_close_report_tree(
 
     Args:
         case_id: ID of VulnerabilityCase being processed.
-        other_close_criteria_factory: Factory for the Evaluator call-out point
-            that checks whether site-specific closure criteria have been met.
-            Defaults to the fuzzer backend (BT-18-004).
-        pre_close_action_factory: Factory for the Actuator call-out point that
-            performs required actions before closing the report.  Reserved for
-            Phase 2; accepted but not yet wired into the Phase 1 tree body
-            (BT-18-004).
+        call_out: Bundle of call-out backend factories for this domain.
+            Defaults to :data:`~vultron.demo.fuzzer.bundles.close_report.CLOSE_REPORT_DETERMINISTIC`
+            (BT-23-003, BT-23-005).
 
     Returns:
         Root node of the close-report behavior tree (Phase 1 stub).
     """
-    # Phase 2: pre_close_action_factory is reserved for the full pre-close
-    # sequence.  Accepting it here satisfies BT-18-004 without breaking callers.
-    root = other_close_criteria_factory("OtherCloseCriteriaMet")
+    from vultron.demo.fuzzer.bundles.close_report import (
+        CLOSE_REPORT_DETERMINISTIC,
+    )
+
+    bundle = call_out if call_out is not None else CLOSE_REPORT_DETERMINISTIC
+    # Phase 2: bundle.pre_close_action_factory is reserved for the full pre-close
+    # sequence.
+    root = bundle.other_close_criteria_factory("OtherCloseCriteriaMet")
     logger.info(f"Created CloseReportBT (Phase 1 stub) for case={case_id}")
     return root

--- a/vultron/core/behaviors/report/deploy_fix_tree.py
+++ b/vultron/core/behaviors/report/deploy_fix_tree.py
@@ -36,67 +36,19 @@ References
 """
 
 import logging
+from typing import TYPE_CHECKING
 
 import py_trees
 
-from vultron.core.behaviors.call_out_point import CallOutBackendFactory
+if TYPE_CHECKING:
+    from vultron.demo.fuzzer.bundles.deploy_fix import DeployFixCallOutBundle
 
 logger = logging.getLogger(__name__)
 
 
-def _default_prioritize_deployment_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.report_management.deploy_fix import (
-        PrioritizeDeployment,
-    )
-
-    return PrioritizeDeployment(name)
-
-
-def _default_deploy_mitigation_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.report_management.deploy_fix import (
-        DeployMitigation,
-    )
-
-    return DeployMitigation(name)
-
-
-def _default_monitoring_requirement_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.report_management.deploy_fix import (
-        MonitoringRequirement,
-    )
-
-    return MonitoringRequirement(name)
-
-
-def _default_deploy_fix_factory(name: str) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.report_management.deploy_fix import DeployFix
-
-    return DeployFix(name)
-
-
-def _default_monitor_deployment_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.report_management.deploy_fix import (
-        MonitorDeployment,
-    )
-
-    return MonitorDeployment(name)
-
-
 def create_deploy_fix_tree(
     case_id: str,
-    prioritize_deployment_factory: CallOutBackendFactory = _default_prioritize_deployment_factory,
-    deploy_mitigation_factory: CallOutBackendFactory = _default_deploy_mitigation_factory,
-    monitoring_requirement_factory: CallOutBackendFactory = _default_monitoring_requirement_factory,
-    deploy_fix_factory: CallOutBackendFactory = _default_deploy_fix_factory,
-    monitor_deployment_factory: CallOutBackendFactory = _default_monitor_deployment_factory,
+    call_out: "DeployFixCallOutBundle | None" = None,
 ) -> py_trees.behaviour.Behaviour:
     """Create behavior tree for the fix deployment workflow (Phase 1 stub).
 
@@ -107,34 +59,25 @@ def create_deploy_fix_tree(
 
     Args:
         case_id: ID of VulnerabilityCase being processed.
-        prioritize_deployment_factory: Factory for the Evaluator call-out point
-            that assigns deployment priority.  Defaults to the fuzzer backend
-            (BT-18-004).
-        deploy_mitigation_factory: Factory for the Evaluator call-out point
-            that deploys an interim mitigation.  Defaults to the fuzzer backend
-            (BT-18-004).
-        monitoring_requirement_factory: Factory for the Evaluator call-out
-            point that checks whether deployment monitoring is required by
-            policy.  Defaults to the fuzzer backend (BT-18-004).
-        deploy_fix_factory: Factory for the Evaluator call-out point that
-            applies the vendor-provided fix.  Defaults to the fuzzer backend
-            (BT-18-004).
-        monitor_deployment_factory: Factory for the Actuator call-out point
-            that performs active deployment monitoring.  Defaults to the fuzzer
-            backend (BT-18-004).
+        call_out: Bundle of call-out backend factories for this domain.
+            Defaults to :data:`~vultron.demo.fuzzer.bundles.deploy_fix.DEPLOY_FIX_DETERMINISTIC`
+            (BT-23-003, BT-23-005).
 
     Returns:
         Root node of the deploy-fix behavior tree (Phase 1 stub Sequence).
     """
+    from vultron.demo.fuzzer.bundles.deploy_fix import DEPLOY_FIX_DETERMINISTIC
+
+    bundle = call_out if call_out is not None else DEPLOY_FIX_DETERMINISTIC
     root = py_trees.composites.Sequence(
         name="DeployFixBT",
         memory=False,
         children=[
-            prioritize_deployment_factory("PrioritizeDeployment"),
-            deploy_mitigation_factory("DeployMitigation"),
-            monitoring_requirement_factory("MonitoringRequirement"),
-            deploy_fix_factory("DeployFix"),
-            monitor_deployment_factory("MonitorDeployment"),
+            bundle.prioritize_deployment_factory("PrioritizeDeployment"),
+            bundle.deploy_mitigation_factory("DeployMitigation"),
+            bundle.monitoring_requirement_factory("MonitoringRequirement"),
+            bundle.deploy_fix_factory("DeployFix"),
+            bundle.monitor_deployment_factory("MonitorDeployment"),
         ],
     )
     logger.info(f"Created DeployFixBT (Phase 1 stub) for case={case_id}")

--- a/vultron/core/behaviors/report/prioritize_tree.py
+++ b/vultron/core/behaviors/report/prioritize_tree.py
@@ -51,7 +51,6 @@ from typing import TYPE_CHECKING
 
 import py_trees
 
-from vultron.core.behaviors.call_out_point import CallOutBackendFactory
 from vultron.core.behaviors.case.engage_defer_trigger_tree import (
     defer_case_trigger_bt,
     engage_case_trigger_bt,
@@ -72,34 +71,9 @@ from vultron.core.behaviors.report.nodes import (
 
 if TYPE_CHECKING:
     from vultron.core.ports.trigger_activity import TriggerActivityPort
-
-
-def _default_on_accept_factory(name: str) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.report_management.prioritize import OnAccept
-
-    return OnAccept(name)
-
-
-def _default_on_defer_factory(name: str) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.report_management.prioritize import OnDefer
-
-    return OnDefer(name)
-
-
-def _default_enough_info_factory(name: str) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.report_management.prioritize import (
-        EnoughPrioritizationInfo,
+    from vultron.demo.fuzzer.bundles.prioritization import (
+        PrioritizationCallOutBundle,
     )
-
-    return EnoughPrioritizationInfo(name)
-
-
-def _default_gather_info_factory(name: str) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.report_management.prioritize import (
-        GatherPrioritizationInfo,
-    )
-
-    return GatherPrioritizationInfo(name)
 
 
 logger = logging.getLogger(__name__)
@@ -184,10 +158,7 @@ def create_prioritize_subtree(
     case_id: str,
     actor_id: str,
     trigger_activity: "TriggerActivityPort | None" = None,
-    on_accept_factory: CallOutBackendFactory = _default_on_accept_factory,
-    on_defer_factory: CallOutBackendFactory = _default_on_defer_factory,
-    enough_info_factory: CallOutBackendFactory = _default_enough_info_factory,
-    gather_info_factory: CallOutBackendFactory = _default_gather_info_factory,
+    call_out: "PrioritizationCallOutBundle | None" = None,
 ) -> py_trees.behaviour.Behaviour:
     """
     Create behavior tree subtree for case prioritization (engage or defer).
@@ -232,27 +203,20 @@ def create_prioritize_subtree(
             When ``None``, the sender-side subtrees will fail at execution
             time with a descriptive error (consistent with the behaviour
             when the blackboard does not carry a factory).
-        on_accept_factory: Factory for the Actuator call-out point that
-            fires integration hooks when the report is accepted.  Defaults
-            to the fuzzer backend (BT-18-004).
-        on_defer_factory: Factory for the Actuator call-out point that
-            fires integration hooks when the report is deferred.  Defaults
-            to the fuzzer backend (BT-18-004).
-        enough_info_factory: Factory for the Evaluator call-out point that
-            checks whether sufficient prioritization information is available.
-            Reserved for Phase 2 info-gathering loop; accepted but not yet
-            wired into the Phase 1 tree body (BT-18-004).
-        gather_info_factory: Factory for the Retriever call-out point that
-            collects additional prioritization information.  Reserved for
-            Phase 2 info-gathering loop; accepted but not yet wired into
-            the Phase 1 tree body (BT-18-004).
+        call_out: Bundle of call-out backend factories for this domain.
+            Defaults to :data:`~vultron.demo.fuzzer.bundles.prioritization.PRIORITIZATION_DETERMINISTIC`
+            (BT-23-003, BT-23-005).
 
     Returns:
         Root node of the prioritize behavior tree (Selector)
     """
-    # Phase 2: enough_info_factory and gather_info_factory are reserved for
-    # the prioritization info-gathering loop and are not wired into the Phase 1
-    # tree body.  Accepting them here satisfies BT-18-004 without breaking callers.
+    from vultron.demo.fuzzer.bundles.prioritization import (
+        PRIORITIZATION_DETERMINISTIC,
+    )
+
+    bundle = call_out if call_out is not None else PRIORITIZATION_DETERMINISTIC
+    # Phase 2: bundle.enough_info_factory and bundle.gather_info_factory are reserved for
+    # the prioritization info-gathering loop and are not wired into the Phase 1 tree.
     factory = trigger_activity
 
     def _build_engage(case_manager_id: str) -> list[str]:
@@ -291,7 +255,7 @@ def create_prioritize_subtree(
                 actor_id=actor_id,
                 activity_builder=_build_engage,
             ),
-            on_accept_factory("OnAccept"),
+            bundle.on_accept_factory("OnAccept"),
         ],
     )
     defer_path = py_trees.composites.Sequence(
@@ -303,7 +267,7 @@ def create_prioritize_subtree(
                 actor_id=actor_id,
                 activity_builder=_build_defer,
             ),
-            on_defer_factory("OnDefer"),
+            bundle.on_defer_factory("OnDefer"),
         ],
     )
     root = py_trees.composites.Selector(

--- a/vultron/core/behaviors/report/publication_tree.py
+++ b/vultron/core/behaviors/report/publication_tree.py
@@ -62,7 +62,7 @@ References
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import py_trees
 from py_trees.common import Access, Status
@@ -70,12 +70,13 @@ from pydantic import BaseModel
 
 from vultron.core.behaviors.call_out_point import CallOutBackendFactory
 from vultron.core.behaviors.report.publish_artifact_tree import (
-    _default_draft_advisory_artifact_factory,
-    _default_review_advisory_draft_factory,
-    _default_revise_advisory_draft_factory,
-    _default_submit_advisory_artifact_factory,
     create_publish_artifact_tree,
 )
+
+if TYPE_CHECKING:
+    from vultron.demo.fuzzer.bundles.publication import (
+        PublicationCallOutBundle,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -212,40 +213,6 @@ class ShouldPublishReport(_ShouldPublishArtifactGate):
     _intent_field = "publish_report"
 
 
-def _default_prioritize_publication_intents_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    # Deferred import: the demo fuzzer module imports PublicationIntentDecision
-    # from this module at module level (mirrors acquire_exploit.py / ADR-0027).
-    from vultron.demo.fuzzer.report_management.publication import (
-        PrioritizePublicationIntents,
-    )
-
-    return PrioritizePublicationIntents(name)
-
-
-def _default_prepare_exploit_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.report_management.publication import (
-        PrepareExploit,
-    )
-
-    return PrepareExploit(name)
-
-
-def _default_prepare_fix_factory(name: str) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.report_management.publication import PrepareFix
-
-    return PrepareFix(name)
-
-
-def _default_prepare_report_factory(name: str) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.report_management.publication import PrepareReport
-
-    return PrepareReport(name)
-
-
 def _make_artifact_arm(
     case_id: str,
     arm_name: str,
@@ -299,14 +266,7 @@ def _make_artifact_arm(
 
 def create_publication_tree(
     case_id: str,
-    prioritize_publication_intents_factory: CallOutBackendFactory = _default_prioritize_publication_intents_factory,
-    prepare_exploit_factory: CallOutBackendFactory = _default_prepare_exploit_factory,
-    prepare_fix_factory: CallOutBackendFactory = _default_prepare_fix_factory,
-    prepare_report_factory: CallOutBackendFactory = _default_prepare_report_factory,
-    draft_advisory_artifact_factory: CallOutBackendFactory = _default_draft_advisory_artifact_factory,
-    review_advisory_draft_factory: CallOutBackendFactory = _default_review_advisory_draft_factory,
-    revise_advisory_draft_factory: CallOutBackendFactory = _default_revise_advisory_draft_factory,
-    submit_advisory_artifact_factory: CallOutBackendFactory = _default_submit_advisory_artifact_factory,
+    call_out: "PublicationCallOutBundle | None" = None,
 ) -> py_trees.behaviour.Behaviour:
     """Create the collapsed publication behavior tree (Production Collapses 2 + 4).
 
@@ -335,38 +295,23 @@ def create_publication_tree(
 
     Args:
         case_id: ID of the VulnerabilityCase to publish for.
-        prioritize_publication_intents_factory: Factory for the Evaluator
-            call-out point that writes the :class:`PublicationIntentDecision`
-            record.  Defaults to the fuzzer backend (ADR-0025).
-        prepare_exploit_factory: Factory for the Composer call-out point that
-            drafts and stages the exploit artifact.  Defaults to the fuzzer
-            backend.
-        prepare_fix_factory: Factory for the Composer call-out point that drafts
-            and stages the fix artifact.  Defaults to the fuzzer backend.
-        prepare_report_factory: Factory for the Composer call-out point that
-            authors and stages the vulnerability advisory artifact.  Defaults to
-            the fuzzer backend.
-        draft_advisory_artifact_factory: Factory for the Composer that drafts
-            the advisory artifact in the publish pipeline.  Shared across all
-            three per-artifact arms.  Defaults to the fuzzer backend.
-        review_advisory_draft_factory: Factory for the Evaluator that reviews
-            and approves the draft.  Defaults to the auto-approve fuzzer
-            backend (AC-3, ADR-0030).
-        revise_advisory_draft_factory: Factory for the optional Composer that
-            revises the draft based on review feedback.  Defaults to the fuzzer
-            backend.
-        submit_advisory_artifact_factory: Factory for the Actuator that submits
-            the finalized artifact to the external advisory platform.  Defaults
-            to the fuzzer backend.
+        call_out: Bundle of call-out backend factories for this domain.
+            Defaults to :data:`~vultron.demo.fuzzer.bundles.publication.PUBLICATION_DETERMINISTIC`
+            (BT-23-003, BT-23-005).
 
     Returns:
         Root Sequence node of the collapsed publication behavior tree.
     """
+    from vultron.demo.fuzzer.bundles.publication import (
+        PUBLICATION_DETERMINISTIC,
+    )
+
+    bundle = call_out if call_out is not None else PUBLICATION_DETERMINISTIC
     root = py_trees.composites.Sequence(
         name="PublicationBT",
         memory=False,
         children=[
-            prioritize_publication_intents_factory(
+            bundle.prioritize_publication_intents_factory(
                 "PrioritizePublicationIntents"
             ),
             _make_artifact_arm(
@@ -374,36 +319,36 @@ def create_publication_tree(
                 arm_name="ExploitPublicationArm",
                 artifact_label="Exploit",
                 gate_cls=ShouldPublishExploit,
-                prepare_factory=prepare_exploit_factory,
+                prepare_factory=bundle.prepare_exploit_factory,
                 prepare_node_name="PrepareExploit",
-                draft_advisory_artifact_factory=draft_advisory_artifact_factory,
-                review_advisory_draft_factory=review_advisory_draft_factory,
-                revise_advisory_draft_factory=revise_advisory_draft_factory,
-                submit_advisory_artifact_factory=submit_advisory_artifact_factory,
+                draft_advisory_artifact_factory=bundle.draft_advisory_artifact_factory,
+                review_advisory_draft_factory=bundle.review_advisory_draft_factory,
+                revise_advisory_draft_factory=bundle.revise_advisory_draft_factory,
+                submit_advisory_artifact_factory=bundle.submit_advisory_artifact_factory,
             ),
             _make_artifact_arm(
                 case_id=case_id,
                 arm_name="FixPublicationArm",
                 artifact_label="Fix",
                 gate_cls=ShouldPublishFix,
-                prepare_factory=prepare_fix_factory,
+                prepare_factory=bundle.prepare_fix_factory,
                 prepare_node_name="PrepareFix",
-                draft_advisory_artifact_factory=draft_advisory_artifact_factory,
-                review_advisory_draft_factory=review_advisory_draft_factory,
-                revise_advisory_draft_factory=revise_advisory_draft_factory,
-                submit_advisory_artifact_factory=submit_advisory_artifact_factory,
+                draft_advisory_artifact_factory=bundle.draft_advisory_artifact_factory,
+                review_advisory_draft_factory=bundle.review_advisory_draft_factory,
+                revise_advisory_draft_factory=bundle.revise_advisory_draft_factory,
+                submit_advisory_artifact_factory=bundle.submit_advisory_artifact_factory,
             ),
             _make_artifact_arm(
                 case_id=case_id,
                 arm_name="ReportPublicationArm",
                 artifact_label="Report",
                 gate_cls=ShouldPublishReport,
-                prepare_factory=prepare_report_factory,
+                prepare_factory=bundle.prepare_report_factory,
                 prepare_node_name="PrepareReport",
-                draft_advisory_artifact_factory=draft_advisory_artifact_factory,
-                review_advisory_draft_factory=review_advisory_draft_factory,
-                revise_advisory_draft_factory=revise_advisory_draft_factory,
-                submit_advisory_artifact_factory=submit_advisory_artifact_factory,
+                draft_advisory_artifact_factory=bundle.draft_advisory_artifact_factory,
+                review_advisory_draft_factory=bundle.review_advisory_draft_factory,
+                revise_advisory_draft_factory=bundle.revise_advisory_draft_factory,
+                submit_advisory_artifact_factory=bundle.submit_advisory_artifact_factory,
             ),
         ],
     )

--- a/vultron/core/behaviors/report/publish_artifact_tree.py
+++ b/vultron/core/behaviors/report/publish_artifact_tree.py
@@ -63,13 +63,18 @@ References
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import py_trees
 from py_trees.common import Access, Status
 from pydantic import BaseModel
 
 from vultron.core.behaviors.call_out_point import CallOutBackendFactory
+
+if TYPE_CHECKING:
+    from vultron.demo.fuzzer.bundles.publication import (
+        PublicationCallOutBundle,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -237,6 +242,7 @@ def create_publish_artifact_tree(
     review_advisory_draft_factory: CallOutBackendFactory = _default_review_advisory_draft_factory,
     revise_advisory_draft_factory: CallOutBackendFactory = _default_revise_advisory_draft_factory,
     submit_advisory_artifact_factory: CallOutBackendFactory = _default_submit_advisory_artifact_factory,
+    call_out: "PublicationCallOutBundle | None" = None,
 ) -> py_trees.behaviour.Behaviour:
     """Create the publish-artifact pipeline (Production Collapse 4).
 
@@ -280,6 +286,16 @@ def create_publish_artifact_tree(
     Returns:
         Root Sequence node of the publish-artifact pipeline.
     """
+    if call_out is not None:
+        draft_advisory_artifact_factory = (
+            call_out.draft_advisory_artifact_factory
+        )
+        review_advisory_draft_factory = call_out.review_advisory_draft_factory
+        revise_advisory_draft_factory = call_out.revise_advisory_draft_factory
+        submit_advisory_artifact_factory = (
+            call_out.submit_advisory_artifact_factory
+        )
+
     suffix = f"_{artifact_label}" if artifact_label else ""
 
     needs_revision_do = py_trees.composites.Sequence(

--- a/vultron/core/behaviors/report/report_to_others_tree.py
+++ b/vultron/core/behaviors/report/report_to_others_tree.py
@@ -63,13 +63,18 @@ References
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import py_trees
 from py_trees.common import Access, Status
 
 from vultron.core.behaviors.call_out_point import CallOutBackendFactory
 from vultron.enums.roles import CVDRole
+
+if TYPE_CHECKING:
+    from vultron.demo.fuzzer.bundles.report_to_others import (
+        ReportToOthersCallOutBundle,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -122,91 +127,6 @@ class _WriteRolesNode(py_trees.behaviour.Behaviour):
 
 
 # ---------------------------------------------------------------------------
-# Default factories — deferred imports avoid circular dependency (demo fuzzer
-# imports CVDRole/enums from this module's layer at module level).
-# ---------------------------------------------------------------------------
-
-
-def _default_all_parties_known_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.report_management.report_to_others import (
-        AllPartiesKnown,
-    )
-
-    return AllPartiesKnown(name)
-
-
-def _default_total_effort_limit_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.report_management.report_to_others import (
-        TotalEffortLimitMet,
-    )
-
-    return TotalEffortLimitMet(name)
-
-
-def _default_more_vendors_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.report_management.report_to_others import (
-        MoreVendors,
-    )
-
-    return MoreVendors(name)
-
-
-def _default_more_coordinators_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.report_management.report_to_others import (
-        MoreCoordinators,
-    )
-
-    return MoreCoordinators(name)
-
-
-def _default_more_others_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.report_management.report_to_others import (
-        MoreOthers,
-    )
-
-    return MoreOthers(name)
-
-
-def _default_suggest_vendor_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.report_management.report_to_others import (
-        InjectVendor,
-    )
-
-    return InjectVendor(name)
-
-
-def _default_suggest_coordinator_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.report_management.report_to_others import (
-        InjectCoordinator,
-    )
-
-    return InjectCoordinator(name)
-
-
-def _default_suggest_other_factory(
-    name: str,
-) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.report_management.report_to_others import (
-        InjectOther,
-    )
-
-    return InjectOther(name)
-
-
 def _make_role_sub_loop(
     loop_name: str,
     more_factory: CallOutBackendFactory,
@@ -258,14 +178,7 @@ def _make_role_sub_loop(
 
 def create_report_to_others_tree(
     case_id: str,
-    all_parties_known_factory: CallOutBackendFactory = _default_all_parties_known_factory,
-    total_effort_limit_factory: CallOutBackendFactory = _default_total_effort_limit_factory,
-    more_vendors_factory: CallOutBackendFactory = _default_more_vendors_factory,
-    more_coordinators_factory: CallOutBackendFactory = _default_more_coordinators_factory,
-    more_others_factory: CallOutBackendFactory = _default_more_others_factory,
-    suggest_vendor_factory: CallOutBackendFactory = _default_suggest_vendor_factory,
-    suggest_coordinator_factory: CallOutBackendFactory = _default_suggest_coordinator_factory,
-    suggest_other_factory: CallOutBackendFactory = _default_suggest_other_factory,
+    call_out: "ReportToOthersCallOutBundle | None" = None,
 ) -> py_trees.behaviour.Behaviour:
     """Create the notification loop behavior tree (Production Collapse 3).
 
@@ -277,61 +190,46 @@ def create_report_to_others_tree(
 
     Args:
         case_id: ID of the VulnerabilityCase being processed.
-        all_parties_known_factory: Factory for the Evaluator call-out point
-            that checks whether all relevant notification parties have been
-            identified.  Defaults to the fuzzer backend (BT-18-004).
-        total_effort_limit_factory: Factory for the Evaluator call-out point
-            that checks whether total notification effort has reached the
-            organizational ceiling.  Defaults to the fuzzer backend (BT-18-004).
-        more_vendors_factory: Factory for the ProtocolInternal guard that
-            checks whether the identified-vendors queue is non-empty.  Defaults
-            to the fuzzer backend.
-        more_coordinators_factory: Factory for the ProtocolInternal guard that
-            checks whether the identified-coordinators queue is non-empty.
-            Defaults to the fuzzer backend.
-        more_others_factory: Factory for the ProtocolInternal guard that
-            checks whether the identified-others queue is non-empty.  Defaults
-            to the fuzzer backend.
-        suggest_vendor_factory: Factory for the Actuator call-out point that
-            suggests a vendor actor to the case via ``suggest-actor-to-case``
-            with ``CVDRole.VENDOR``.  Defaults to the fuzzer backend
-            (``InjectVendor``).
-        suggest_coordinator_factory: Factory for the Actuator call-out point
-            that suggests a coordinator actor with ``CVDRole.COORDINATOR``.
-            Defaults to the fuzzer backend (``InjectCoordinator``).
-        suggest_other_factory: Factory for the Actuator call-out point that
-            suggests an other-party actor with ``CVDRole.OTHER``.  Defaults to
-            the fuzzer backend (``InjectOther``).
+        call_out: Bundle of call-out backend factories for this domain.
+            Defaults to :data:`~vultron.demo.fuzzer.bundles.report_to_others.REPORT_TO_OTHERS_DETERMINISTIC`
+            (BT-23-003, BT-23-005).
 
     Returns:
         Root Sequence node of the notification-loop behavior tree.
     """
+    from vultron.demo.fuzzer.bundles.report_to_others import (
+        REPORT_TO_OTHERS_DETERMINISTIC,
+    )
+
+    bundle = (
+        call_out if call_out is not None else REPORT_TO_OTHERS_DETERMINISTIC
+    )
     vendor_sub_loop = _make_role_sub_loop(
         loop_name="VendorSubLoop",
-        more_factory=more_vendors_factory,
+        more_factory=bundle.more_vendors_factory,
         more_node_name="MoreVendors",
         roles=[CVDRole.VENDOR],
-        suggest_factory=suggest_vendor_factory,
+        suggest_factory=bundle.suggest_vendor_factory,
         suggest_node_name="SuggestVendor",
         case_id=case_id,
         write_roles_node_name="WriteVendorRoles",
     )
     coordinator_sub_loop = _make_role_sub_loop(
         loop_name="CoordinatorSubLoop",
-        more_factory=more_coordinators_factory,
+        more_factory=bundle.more_coordinators_factory,
         more_node_name="MoreCoordinators",
         roles=[CVDRole.COORDINATOR],
-        suggest_factory=suggest_coordinator_factory,
+        suggest_factory=bundle.suggest_coordinator_factory,
         suggest_node_name="SuggestCoordinator",
         case_id=case_id,
         write_roles_node_name="WriteCoordinatorRoles",
     )
     other_sub_loop = _make_role_sub_loop(
         loop_name="OtherSubLoop",
-        more_factory=more_others_factory,
+        more_factory=bundle.more_others_factory,
         more_node_name="MoreOthers",
         roles=[CVDRole.OTHER],
-        suggest_factory=suggest_other_factory,
+        suggest_factory=bundle.suggest_other_factory,
         suggest_node_name="SuggestOther",
         case_id=case_id,
         write_roles_node_name="WriteOtherRoles",
@@ -340,8 +238,8 @@ def create_report_to_others_tree(
         name="ReportToOthersBT",
         memory=False,
         children=[
-            all_parties_known_factory("AllPartiesKnown"),
-            total_effort_limit_factory("TotalEffortLimitMet"),
+            bundle.all_parties_known_factory("AllPartiesKnown"),
+            bundle.total_effort_limit_factory("TotalEffortLimitMet"),
             vendor_sub_loop,
             coordinator_sub_loop,
             other_sub_loop,

--- a/vultron/core/behaviors/report/validate_tree.py
+++ b/vultron/core/behaviors/report/validate_tree.py
@@ -57,10 +57,10 @@ Future enhancements (Phase 2+):
 """
 
 import logging
+from typing import TYPE_CHECKING
 
 import py_trees
 
-from vultron.core.behaviors.call_out_point import CallOutBackendFactory
 from vultron.core.behaviors.report.nodes import (
     CheckRMStateReceivedOrInvalid,
     CheckRMStateValid,
@@ -69,44 +69,17 @@ from vultron.core.behaviors.report.nodes import (
 )
 from vultron.core.behaviors.report.nodes.emit import EmitValidateReportActivity
 
+if TYPE_CHECKING:
+    from vultron.demo.fuzzer.bundles.validation import ValidationCallOutBundle
+
 logger = logging.getLogger(__name__)
-
-
-# Fuzzer defaults are imported lazily inside the default lambda to avoid
-# importing vultron.demo from core at module load time (BT-16-001).
-#
-# Phase 1: both policy nodes are deterministic stubs that always succeed.
-# The probabilistic EvaluateReportCredibility / EvaluateReportValidity fuzzer
-# classes exist for simulation scenarios (e.g. random-sampling runs) and can be
-# injected via the factory parameters; they are NOT used as defaults because the
-# ~81% two-node series success rate makes integrate-test workflows non-deterministic.
-def _default_credibility_factory(name: str) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.base import AlwaysSucceed
-
-    return AlwaysSucceed(name)
-
-
-def _default_validity_factory(name: str) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.base import AlwaysSucceed
-
-    return AlwaysSucceed(name)
-
-
-def _default_gather_info_factory(name: str) -> py_trees.behaviour.Behaviour:
-    from vultron.demo.fuzzer.report_management.validate import (
-        GatherValidationInfo,
-    )
-
-    return GatherValidationInfo(name)
 
 
 def create_validate_report_tree(
     report_id: str,
     offer_id: str,
     captured: dict | None = None,
-    credibility_factory: CallOutBackendFactory = _default_credibility_factory,
-    validity_factory: CallOutBackendFactory = _default_validity_factory,
-    gather_info_factory: CallOutBackendFactory = _default_gather_info_factory,
+    call_out: "ValidationCallOutBundle | None" = None,
 ) -> py_trees.behaviour.Behaviour:
     """
     Create behavior tree for report validation workflow.
@@ -157,9 +130,13 @@ def create_validate_report_tree(
         >>> print(result.status)
         Status.SUCCESS
     """
+    from vultron.demo.fuzzer.bundles.validation import VALIDATION_DETERMINISTIC
+
+    bundle = call_out if call_out is not None else VALIDATION_DETERMINISTIC
+
     # Phase 1: Match procedural handler logic
     # Future: Add InvalidateReport fallback per simulation BT
-    # Future (Phase 2): wire gather_info_factory into an EnoughInfoOrGather
+    # Future (Phase 2): wire call_out.gather_info_factory into an EnoughInfoOrGather
     # Selector guarding the info-gathering loop.
 
     # Child sequence: All validation actions (status update + embargo check)
@@ -178,8 +155,8 @@ def create_validate_report_tree(
         memory=False,
         children=[
             CheckRMStateReceivedOrInvalid(report_id=report_id),
-            credibility_factory("EvaluateReportCredibility"),
-            validity_factory("EvaluateReportValidity"),
+            bundle.credibility_factory("EvaluateReportCredibility"),
+            bundle.validity_factory("EvaluateReportValidity"),
             validation_actions,
         ],
     )
@@ -223,8 +200,8 @@ def create_validate_report_tree(
                 memory=False,
                 children=[
                     CheckRMStateReceivedOrInvalid(report_id=report_id),
-                    credibility_factory("EvaluateReportCredibility"),
-                    validity_factory("EvaluateReportValidity"),
+                    bundle.credibility_factory("EvaluateReportCredibility"),
+                    bundle.validity_factory("EvaluateReportValidity"),
                     py_trees.composites.Sequence(
                         name="ValidationActions",
                         memory=False,

--- a/vultron/demo/fuzzer/bundles/__init__.py
+++ b/vultron/demo/fuzzer/bundles/__init__.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Call-out point domain bundle package (BT-23-003, BT-23-005).
+
+Re-exports all bundle classes and pre-built DETERMINISTIC / STOCHASTIC
+singletons from the sub-modules.  Import from this package rather than the
+individual modules for stable import paths::
+
+    from vultron.demo.fuzzer.bundles import (
+        ValidationCallOutBundle,
+        VALIDATION_DETERMINISTIC,
+        VALIDATION_STOCHASTIC,
+        EmbargoCallOutBundle,
+        EMBARGO_STOCHASTIC,
+        ...
+    )
+"""
+
+from vultron.demo.fuzzer.bundles.acquire_exploit import (
+    ACQUIRE_EXPLOIT_DETERMINISTIC,
+    ACQUIRE_EXPLOIT_STOCHASTIC,
+    AcquireExploitCallOutBundle,
+)
+from vultron.demo.fuzzer.bundles.assign_vul_id import (
+    ASSIGN_VUL_ID_DETERMINISTIC,
+    ASSIGN_VUL_ID_STOCHASTIC,
+    AssignVulIdCallOutBundle,
+)
+from vultron.demo.fuzzer.bundles.close_report import (
+    CLOSE_REPORT_DETERMINISTIC,
+    CLOSE_REPORT_STOCHASTIC,
+    CloseReportCallOutBundle,
+)
+from vultron.demo.fuzzer.bundles.deploy_fix import (
+    DEPLOY_FIX_DETERMINISTIC,
+    DEPLOY_FIX_STOCHASTIC,
+    DeployFixCallOutBundle,
+)
+from vultron.demo.fuzzer.bundles.embargo import (
+    EMBARGO_DETERMINISTIC,
+    EMBARGO_STOCHASTIC,
+    EmbargoCallOutBundle,
+)
+from vultron.demo.fuzzer.bundles.prioritization import (
+    PRIORITIZATION_DETERMINISTIC,
+    PRIORITIZATION_STOCHASTIC,
+    PrioritizationCallOutBundle,
+)
+from vultron.demo.fuzzer.bundles.publication import (
+    PUBLICATION_DETERMINISTIC,
+    PUBLICATION_STOCHASTIC,
+    PublicationCallOutBundle,
+)
+from vultron.demo.fuzzer.bundles.report_to_others import (
+    REPORT_TO_OTHERS_DETERMINISTIC,
+    REPORT_TO_OTHERS_STOCHASTIC,
+    ReportToOthersCallOutBundle,
+)
+from vultron.demo.fuzzer.bundles.validation import (
+    VALIDATION_DETERMINISTIC,
+    VALIDATION_STOCHASTIC,
+    ValidationCallOutBundle,
+)
+
+__all__ = [
+    # Bundle classes
+    "AcquireExploitCallOutBundle",
+    "AssignVulIdCallOutBundle",
+    "CloseReportCallOutBundle",
+    "DeployFixCallOutBundle",
+    "EmbargoCallOutBundle",
+    "PrioritizationCallOutBundle",
+    "PublicationCallOutBundle",
+    "ReportToOthersCallOutBundle",
+    "ValidationCallOutBundle",
+    # Deterministic singletons
+    "ACQUIRE_EXPLOIT_DETERMINISTIC",
+    "ASSIGN_VUL_ID_DETERMINISTIC",
+    "CLOSE_REPORT_DETERMINISTIC",
+    "DEPLOY_FIX_DETERMINISTIC",
+    "EMBARGO_DETERMINISTIC",
+    "PRIORITIZATION_DETERMINISTIC",
+    "PUBLICATION_DETERMINISTIC",
+    "REPORT_TO_OTHERS_DETERMINISTIC",
+    "VALIDATION_DETERMINISTIC",
+    # Stochastic singletons
+    "ACQUIRE_EXPLOIT_STOCHASTIC",
+    "ASSIGN_VUL_ID_STOCHASTIC",
+    "CLOSE_REPORT_STOCHASTIC",
+    "DEPLOY_FIX_STOCHASTIC",
+    "EMBARGO_STOCHASTIC",
+    "PRIORITIZATION_STOCHASTIC",
+    "PUBLICATION_STOCHASTIC",
+    "REPORT_TO_OTHERS_STOCHASTIC",
+    "VALIDATION_STOCHASTIC",
+]

--- a/vultron/demo/fuzzer/bundles/acquire_exploit.py
+++ b/vultron/demo/fuzzer/bundles/acquire_exploit.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Call-out bundle for the exploit acquisition domain (BT-23-003, BT-23-005).
+
+Provides :class:`AcquireExploitCallOutBundle` plus the pre-built singletons
+:data:`ACQUIRE_EXPLOIT_DETERMINISTIC` and :data:`ACQUIRE_EXPLOIT_STOCHASTIC`.
+
+This bundle covers both
+:func:`~vultron.core.behaviors.report.acquire_exploit_tree.create_acquire_exploit_tree`
+and
+:func:`~vultron.core.behaviors.report.acquire_exploit_strategy_tree.create_acquire_exploit_strategy_tree`.
+
+Ceiling/floor mapping (BT-23-002):
+
+- ``evaluate_exploit_priority_factory``  — EvaluateExploitPriority   (p=1.0) → AlwaysSucceed
+- ``purchase_exploit_factory``           — PurchaseExploit            (p=0.10) → AlwaysFail
+- ``have_exploit_factory``               — HaveExploit                (p=0.25) → AlwaysFail
+- ``evaluate_exploit_strategy_factory``  — EvaluateExploitStrategy    (p=1.0) → AlwaysSucceed
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import py_trees
+
+from vultron.core.behaviors.call_out_point import CallOutBackendFactory
+
+
+def _always_succeed(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.base import AlwaysSucceed
+
+    return AlwaysSucceed(name)
+
+
+def _always_fail(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.base import AlwaysFail
+
+    return AlwaysFail(name)
+
+
+def _stochastic_evaluate_exploit_priority(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.acquire_exploit import (
+        EvaluateExploitPriority,
+    )
+
+    return EvaluateExploitPriority(name)
+
+
+def _stochastic_purchase_exploit(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.acquire_exploit import (
+        PurchaseExploit,
+    )
+
+    return PurchaseExploit(name)
+
+
+def _stochastic_have_exploit(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.acquire_exploit import (
+        HaveExploit,
+    )
+
+    return HaveExploit(name)
+
+
+def _stochastic_evaluate_exploit_strategy(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.acquire_exploit import (
+        EvaluateExploitStrategy,
+    )
+
+    return EvaluateExploitStrategy(name)
+
+
+@dataclass(frozen=True)
+class AcquireExploitCallOutBundle:
+    """Call-out backend bundle for the exploit acquisition domain (BT-23-003).
+
+    Fields map to the corresponding factory parameters on
+    :func:`~vultron.core.behaviors.report.acquire_exploit_tree.create_acquire_exploit_tree`
+    and
+    :func:`~vultron.core.behaviors.report.acquire_exploit_strategy_tree.create_acquire_exploit_strategy_tree`.
+    """
+
+    evaluate_exploit_priority_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    purchase_exploit_factory: CallOutBackendFactory = field(
+        default=_always_fail  # type: ignore[assignment]
+    )
+    have_exploit_factory: CallOutBackendFactory = field(
+        default=_always_fail  # type: ignore[assignment]
+    )
+    evaluate_exploit_strategy_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+
+
+ACQUIRE_EXPLOIT_DETERMINISTIC = AcquireExploitCallOutBundle()
+"""Deterministic bundle: ceiling/floor of stochastic p (BT-23-001, BT-23-002)."""
+
+ACQUIRE_EXPLOIT_STOCHASTIC = AcquireExploitCallOutBundle(
+    evaluate_exploit_priority_factory=_stochastic_evaluate_exploit_priority,  # type: ignore[arg-type]
+    purchase_exploit_factory=_stochastic_purchase_exploit,  # type: ignore[arg-type]
+    have_exploit_factory=_stochastic_have_exploit,  # type: ignore[arg-type]
+    evaluate_exploit_strategy_factory=_stochastic_evaluate_exploit_strategy,  # type: ignore[arg-type]
+)
+"""Stochastic bundle: all nodes use probabilistic fuzzer classes."""
+
+__all__ = [
+    "AcquireExploitCallOutBundle",
+    "ACQUIRE_EXPLOIT_DETERMINISTIC",
+    "ACQUIRE_EXPLOIT_STOCHASTIC",
+]

--- a/vultron/demo/fuzzer/bundles/assign_vul_id.py
+++ b/vultron/demo/fuzzer/bundles/assign_vul_id.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Call-out bundle for the vulnerability ID assignment domain (BT-23-003, BT-23-005).
+
+Provides :class:`AssignVulIdCallOutBundle` plus the pre-built singletons
+:data:`ASSIGN_VUL_ID_DETERMINISTIC` and :data:`ASSIGN_VUL_ID_STOCHASTIC`.
+
+Ceiling/floor mapping (BT-23-002):
+
+- ``id_assignable_factory`` — IdAssignable (p=0.67) → AlwaysSucceed
+- ``in_scope_factory``      — InScope      (p=0.75) → AlwaysSucceed
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import py_trees
+
+from vultron.core.behaviors.call_out_point import CallOutBackendFactory
+
+
+def _always_succeed(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.base import AlwaysSucceed
+
+    return AlwaysSucceed(name)
+
+
+def _stochastic_id_assignable(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.assign_vul_id import (
+        IdAssignable,
+    )
+
+    return IdAssignable(name)
+
+
+def _stochastic_in_scope(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.assign_vul_id import InScope
+
+    return InScope(name)
+
+
+@dataclass(frozen=True)
+class AssignVulIdCallOutBundle:
+    """Call-out backend bundle for the vulnerability ID assignment domain (BT-23-003).
+
+    Fields map to the corresponding factory parameters on
+    :func:`~vultron.core.behaviors.report.assign_vul_id_tree.create_assign_vul_id_tree`.
+    """
+
+    id_assignable_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    in_scope_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+
+
+ASSIGN_VUL_ID_DETERMINISTIC = AssignVulIdCallOutBundle()
+"""Deterministic bundle: all nodes use AlwaysSucceed (BT-23-001, BT-23-002)."""
+
+ASSIGN_VUL_ID_STOCHASTIC = AssignVulIdCallOutBundle(
+    id_assignable_factory=_stochastic_id_assignable,  # type: ignore[arg-type]
+    in_scope_factory=_stochastic_in_scope,  # type: ignore[arg-type]
+)
+"""Stochastic bundle: all nodes use probabilistic fuzzer classes."""
+
+__all__ = [
+    "AssignVulIdCallOutBundle",
+    "ASSIGN_VUL_ID_DETERMINISTIC",
+    "ASSIGN_VUL_ID_STOCHASTIC",
+]

--- a/vultron/demo/fuzzer/bundles/close_report.py
+++ b/vultron/demo/fuzzer/bundles/close_report.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Call-out bundle for the report closure domain (BT-23-003, BT-23-005).
+
+Provides :class:`CloseReportCallOutBundle` plus the pre-built singletons
+:data:`CLOSE_REPORT_DETERMINISTIC` and :data:`CLOSE_REPORT_STOCHASTIC`.
+
+Ceiling/floor mapping (BT-23-002):
+
+- ``other_close_criteria_factory`` — OtherCloseCriteriaMet (p=0.25) → AlwaysFail
+- ``pre_close_action_factory``     — PreCloseAction        (p=1.0) → AlwaysSucceed
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import py_trees
+
+from vultron.core.behaviors.call_out_point import CallOutBackendFactory
+
+
+def _always_succeed(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.base import AlwaysSucceed
+
+    return AlwaysSucceed(name)
+
+
+def _always_fail(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.base import AlwaysFail
+
+    return AlwaysFail(name)
+
+
+def _stochastic_other_close_criteria(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.close_report import (
+        OtherCloseCriteriaMet,
+    )
+
+    return OtherCloseCriteriaMet(name)
+
+
+def _stochastic_pre_close_action(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.close_report import (
+        PreCloseAction,
+    )
+
+    return PreCloseAction(name)
+
+
+@dataclass(frozen=True)
+class CloseReportCallOutBundle:
+    """Call-out backend bundle for the report closure domain (BT-23-003).
+
+    Fields map to the corresponding factory parameters on
+    :func:`~vultron.core.behaviors.report.close_report_tree.create_close_report_tree`.
+    """
+
+    other_close_criteria_factory: CallOutBackendFactory = field(
+        default=_always_fail  # type: ignore[assignment]
+    )
+    pre_close_action_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+
+
+CLOSE_REPORT_DETERMINISTIC = CloseReportCallOutBundle()
+"""Deterministic bundle: ceiling/floor of stochastic p (BT-23-001, BT-23-002)."""
+
+CLOSE_REPORT_STOCHASTIC = CloseReportCallOutBundle(
+    other_close_criteria_factory=_stochastic_other_close_criteria,  # type: ignore[arg-type]
+    pre_close_action_factory=_stochastic_pre_close_action,  # type: ignore[arg-type]
+)
+"""Stochastic bundle: all nodes use probabilistic fuzzer classes."""
+
+__all__ = [
+    "CloseReportCallOutBundle",
+    "CLOSE_REPORT_DETERMINISTIC",
+    "CLOSE_REPORT_STOCHASTIC",
+]

--- a/vultron/demo/fuzzer/bundles/deploy_fix.py
+++ b/vultron/demo/fuzzer/bundles/deploy_fix.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Call-out bundle for the fix deployment domain (BT-23-003, BT-23-005).
+
+Provides :class:`DeployFixCallOutBundle` plus the pre-built singletons
+:data:`DEPLOY_FIX_DETERMINISTIC` and :data:`DEPLOY_FIX_STOCHASTIC`.
+
+Ceiling/floor mapping (BT-23-002):
+
+- ``prioritize_deployment_factory``  — PrioritizeDeployment  (p=0.90) → AlwaysSucceed
+- ``deploy_mitigation_factory``      — DeployMitigation      (p=0.75) → AlwaysSucceed
+- ``monitoring_requirement_factory`` — MonitoringRequirement (p=0.70) → AlwaysSucceed
+- ``deploy_fix_factory``             — DeployFix             (p=0.10) → AlwaysFail
+- ``monitor_deployment_factory``     — MonitorDeployment     (p=1.0) → AlwaysSucceed
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import py_trees
+
+from vultron.core.behaviors.call_out_point import CallOutBackendFactory
+
+
+def _always_succeed(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.base import AlwaysSucceed
+
+    return AlwaysSucceed(name)
+
+
+def _always_fail(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.base import AlwaysFail
+
+    return AlwaysFail(name)
+
+
+def _stochastic_prioritize_deployment(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.deploy_fix import (
+        PrioritizeDeployment,
+    )
+
+    return PrioritizeDeployment(name)
+
+
+def _stochastic_deploy_mitigation(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.deploy_fix import (
+        DeployMitigation,
+    )
+
+    return DeployMitigation(name)
+
+
+def _stochastic_monitoring_requirement(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.deploy_fix import (
+        MonitoringRequirement,
+    )
+
+    return MonitoringRequirement(name)
+
+
+def _stochastic_deploy_fix(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.deploy_fix import DeployFix
+
+    return DeployFix(name)
+
+
+def _stochastic_monitor_deployment(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.deploy_fix import (
+        MonitorDeployment,
+    )
+
+    return MonitorDeployment(name)
+
+
+@dataclass(frozen=True)
+class DeployFixCallOutBundle:
+    """Call-out backend bundle for the fix deployment domain (BT-23-003).
+
+    Fields map to the corresponding factory parameters on
+    :func:`~vultron.core.behaviors.report.deploy_fix_tree.create_deploy_fix_tree`.
+    """
+
+    prioritize_deployment_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    deploy_mitigation_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    monitoring_requirement_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    deploy_fix_factory: CallOutBackendFactory = field(
+        default=_always_fail  # type: ignore[assignment]
+    )
+    monitor_deployment_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+
+
+DEPLOY_FIX_DETERMINISTIC = DeployFixCallOutBundle()
+"""Deterministic bundle: ceiling/floor of stochastic p (BT-23-001, BT-23-002)."""
+
+DEPLOY_FIX_STOCHASTIC = DeployFixCallOutBundle(
+    prioritize_deployment_factory=_stochastic_prioritize_deployment,  # type: ignore[arg-type]
+    deploy_mitigation_factory=_stochastic_deploy_mitigation,  # type: ignore[arg-type]
+    monitoring_requirement_factory=_stochastic_monitoring_requirement,  # type: ignore[arg-type]
+    deploy_fix_factory=_stochastic_deploy_fix,  # type: ignore[arg-type]
+    monitor_deployment_factory=_stochastic_monitor_deployment,  # type: ignore[arg-type]
+)
+"""Stochastic bundle: all nodes use probabilistic fuzzer classes."""
+
+__all__ = [
+    "DeployFixCallOutBundle",
+    "DEPLOY_FIX_DETERMINISTIC",
+    "DEPLOY_FIX_STOCHASTIC",
+]

--- a/vultron/demo/fuzzer/bundles/embargo.py
+++ b/vultron/demo/fuzzer/bundles/embargo.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Call-out bundle for the embargo management domain (BT-23-003, BT-23-005).
+
+Provides :class:`EmbargoCallOutBundle` plus the pre-built singletons
+:data:`EMBARGO_DETERMINISTIC` and :data:`EMBARGO_STOCHASTIC`.
+
+Ceiling/floor mapping (BT-23-002):
+
+- ``exit_embargo_when_deployed_factory``       — ExitEmbargoWhenDeployed       (p=0.33) → AlwaysFail
+- ``exit_embargo_when_fix_ready_factory``      — ExitEmbargoWhenFixReady       (p=0.25) → AlwaysFail
+- ``exit_embargo_for_other_reason_factory``    — ExitEmbargoForOtherReason     (p=0.005) → AlwaysFail
+- ``stop_proposing_embargo_factory``           — StopProposingEmbargo          (p=0.25) → AlwaysFail
+- ``select_embargo_offer_terms_factory``       — SelectEmbargoOfferTerms       (p=1.0) → AlwaysSucceed
+- ``want_to_propose_embargo_factory``          — WantToProposeEmbargo          (p=0.50) → AlwaysSucceed (tie-break)
+- ``willing_to_counter_factory``               — WillingToCounterEmbargoProposal (p=0.25) → AlwaysFail
+- ``reason_to_propose_when_deployed_factory``  — ReasonToProposeEmbargoWhenDeployed (p=0.07) → AlwaysFail
+- ``evaluate_embargo_proposal_factory``        — EvaluateEmbargoProposal       (p=0.75) → AlwaysSucceed
+- ``current_embargo_acceptable_factory``       — CurrentEmbargoAcceptable      (p=0.90) → AlwaysSucceed
+- ``on_embargo_exit_factory``                  — OnEmbargoExit                 (p=1.0) → AlwaysSucceed
+- ``on_embargo_accept_factory``                — OnEmbargoAccept               (p=1.0) → AlwaysSucceed
+- ``on_embargo_reject_factory``                — OnEmbargoReject               (p=1.0) → AlwaysSucceed
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import py_trees
+
+from vultron.core.behaviors.call_out_point import CallOutBackendFactory
+
+
+def _always_succeed(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.base import AlwaysSucceed
+
+    return AlwaysSucceed(name)
+
+
+def _always_fail(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.base import AlwaysFail
+
+    return AlwaysFail(name)
+
+
+def _stochastic_exit_when_deployed(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.embargo import ExitEmbargoWhenDeployed
+
+    return ExitEmbargoWhenDeployed(name)
+
+
+def _stochastic_exit_when_fix_ready(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.embargo import ExitEmbargoWhenFixReady
+
+    return ExitEmbargoWhenFixReady(name)
+
+
+def _stochastic_exit_for_other_reason(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.embargo import ExitEmbargoForOtherReason
+
+    return ExitEmbargoForOtherReason(name)
+
+
+def _stochastic_stop_proposing(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.embargo import StopProposingEmbargo
+
+    return StopProposingEmbargo(name)
+
+
+def _stochastic_select_terms(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.embargo import SelectEmbargoOfferTerms
+
+    return SelectEmbargoOfferTerms(name)
+
+
+def _stochastic_want_to_propose(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.embargo import WantToProposeEmbargo
+
+    return WantToProposeEmbargo(name)
+
+
+def _stochastic_willing_to_counter(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.embargo import WillingToCounterEmbargoProposal
+
+    return WillingToCounterEmbargoProposal(name)
+
+
+def _stochastic_reason_to_propose_when_deployed(
+    name: str,
+) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.embargo import ReasonToProposeEmbargoWhenDeployed
+
+    return ReasonToProposeEmbargoWhenDeployed(name)
+
+
+def _stochastic_evaluate_proposal(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.embargo import EvaluateEmbargoProposal
+
+    return EvaluateEmbargoProposal(name)
+
+
+def _stochastic_current_acceptable(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.embargo import CurrentEmbargoAcceptable
+
+    return CurrentEmbargoAcceptable(name)
+
+
+def _stochastic_on_exit(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.embargo import OnEmbargoExit
+
+    return OnEmbargoExit(name)
+
+
+def _stochastic_on_accept(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.embargo import OnEmbargoAccept
+
+    return OnEmbargoAccept(name)
+
+
+def _stochastic_on_reject(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.embargo import OnEmbargoReject
+
+    return OnEmbargoReject(name)
+
+
+@dataclass(frozen=True)
+class EmbargoCallOutBundle:
+    """Call-out backend bundle for the embargo management domain (BT-23-003).
+
+    Fields map to the corresponding factory parameters on
+    :func:`~vultron.core.behaviors.embargo.manage_embargo_tree.create_manage_embargo_tree`.
+    """
+
+    exit_embargo_when_deployed_factory: CallOutBackendFactory = field(
+        default=_always_fail  # type: ignore[assignment]
+    )
+    exit_embargo_when_fix_ready_factory: CallOutBackendFactory = field(
+        default=_always_fail  # type: ignore[assignment]
+    )
+    exit_embargo_for_other_reason_factory: CallOutBackendFactory = field(
+        default=_always_fail  # type: ignore[assignment]
+    )
+    stop_proposing_embargo_factory: CallOutBackendFactory = field(
+        default=_always_fail  # type: ignore[assignment]
+    )
+    select_embargo_offer_terms_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    want_to_propose_embargo_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    willing_to_counter_factory: CallOutBackendFactory = field(
+        default=_always_fail  # type: ignore[assignment]
+    )
+    reason_to_propose_when_deployed_factory: CallOutBackendFactory = field(
+        default=_always_fail  # type: ignore[assignment]
+    )
+    evaluate_embargo_proposal_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    current_embargo_acceptable_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    on_embargo_exit_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    on_embargo_accept_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    on_embargo_reject_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+
+
+EMBARGO_DETERMINISTIC = EmbargoCallOutBundle()
+"""Deterministic bundle: ceiling/floor of stochastic p (BT-23-001, BT-23-002)."""
+
+EMBARGO_STOCHASTIC = EmbargoCallOutBundle(
+    exit_embargo_when_deployed_factory=_stochastic_exit_when_deployed,  # type: ignore[arg-type]
+    exit_embargo_when_fix_ready_factory=_stochastic_exit_when_fix_ready,  # type: ignore[arg-type]
+    exit_embargo_for_other_reason_factory=_stochastic_exit_for_other_reason,  # type: ignore[arg-type]
+    stop_proposing_embargo_factory=_stochastic_stop_proposing,  # type: ignore[arg-type]
+    select_embargo_offer_terms_factory=_stochastic_select_terms,  # type: ignore[arg-type]
+    want_to_propose_embargo_factory=_stochastic_want_to_propose,  # type: ignore[arg-type]
+    willing_to_counter_factory=_stochastic_willing_to_counter,  # type: ignore[arg-type]
+    reason_to_propose_when_deployed_factory=_stochastic_reason_to_propose_when_deployed,  # type: ignore[arg-type]
+    evaluate_embargo_proposal_factory=_stochastic_evaluate_proposal,  # type: ignore[arg-type]
+    current_embargo_acceptable_factory=_stochastic_current_acceptable,  # type: ignore[arg-type]
+    on_embargo_exit_factory=_stochastic_on_exit,  # type: ignore[arg-type]
+    on_embargo_accept_factory=_stochastic_on_accept,  # type: ignore[arg-type]
+    on_embargo_reject_factory=_stochastic_on_reject,  # type: ignore[arg-type]
+)
+"""Stochastic bundle: all nodes use probabilistic fuzzer classes."""
+
+__all__ = [
+    "EmbargoCallOutBundle",
+    "EMBARGO_DETERMINISTIC",
+    "EMBARGO_STOCHASTIC",
+]

--- a/vultron/demo/fuzzer/bundles/prioritization.py
+++ b/vultron/demo/fuzzer/bundles/prioritization.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Call-out bundle for the report prioritization domain (BT-23-003, BT-23-005).
+
+Provides :class:`PrioritizationCallOutBundle` plus the pre-built singletons
+:data:`PRIORITIZATION_DETERMINISTIC` and :data:`PRIORITIZATION_STOCHASTIC`.
+
+Ceiling/floor mapping (BT-23-002):
+
+- ``on_accept_factory``        — OnAccept               (p=1.0) → AlwaysSucceed
+- ``on_defer_factory``         — OnDefer                (p=1.0) → AlwaysSucceed
+- ``enough_info_factory``      — EnoughPrioritizationInfo (p=0.75) → AlwaysSucceed
+- ``gather_info_factory``      — GatherPrioritizationInfo (p=0.90) → AlwaysSucceed
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import py_trees
+
+from vultron.core.behaviors.call_out_point import CallOutBackendFactory
+
+
+def _always_succeed(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.base import AlwaysSucceed
+
+    return AlwaysSucceed(name)
+
+
+def _stochastic_on_accept(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.prioritize import OnAccept
+
+    return OnAccept(name)
+
+
+def _stochastic_on_defer(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.prioritize import OnDefer
+
+    return OnDefer(name)
+
+
+def _stochastic_enough_info(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.prioritize import (
+        EnoughPrioritizationInfo,
+    )
+
+    return EnoughPrioritizationInfo(name)
+
+
+def _stochastic_gather_info(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.prioritize import (
+        GatherPrioritizationInfo,
+    )
+
+    return GatherPrioritizationInfo(name)
+
+
+@dataclass(frozen=True)
+class PrioritizationCallOutBundle:
+    """Call-out backend bundle for the report prioritization domain (BT-23-003).
+
+    Fields map to the corresponding factory parameters on
+    :func:`~vultron.core.behaviors.report.prioritize_tree.create_prioritize_subtree`.
+    """
+
+    on_accept_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    on_defer_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    enough_info_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    gather_info_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+
+
+PRIORITIZATION_DETERMINISTIC = PrioritizationCallOutBundle()
+"""Deterministic bundle: all nodes use AlwaysSucceed (BT-23-001, BT-23-002)."""
+
+PRIORITIZATION_STOCHASTIC = PrioritizationCallOutBundle(
+    on_accept_factory=_stochastic_on_accept,  # type: ignore[arg-type]
+    on_defer_factory=_stochastic_on_defer,  # type: ignore[arg-type]
+    enough_info_factory=_stochastic_enough_info,  # type: ignore[arg-type]
+    gather_info_factory=_stochastic_gather_info,  # type: ignore[arg-type]
+)
+"""Stochastic bundle: all nodes use probabilistic fuzzer classes."""
+
+__all__ = [
+    "PrioritizationCallOutBundle",
+    "PRIORITIZATION_DETERMINISTIC",
+    "PRIORITIZATION_STOCHASTIC",
+]

--- a/vultron/demo/fuzzer/bundles/publication.py
+++ b/vultron/demo/fuzzer/bundles/publication.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Call-out bundle for the publication pipeline domain (BT-23-003, BT-23-005).
+
+Provides :class:`PublicationCallOutBundle` plus the pre-built singletons
+:data:`PUBLICATION_DETERMINISTIC` and :data:`PUBLICATION_STOCHASTIC`.
+
+This bundle covers both
+:func:`~vultron.core.behaviors.report.publication_tree.create_publication_tree`
+and
+:func:`~vultron.core.behaviors.report.publish_artifact_tree.create_publish_artifact_tree`.
+
+Ceiling/floor mapping (BT-23-002):
+
+- ``prioritize_publication_intents_factory`` — PrioritizePublicationIntents (p=1.0) → AlwaysSucceed
+- ``prepare_exploit_factory``               — PrepareExploit               (p=0.90) → AlwaysSucceed
+- ``prepare_fix_factory``                   — PrepareFix                   (p=0.90) → AlwaysSucceed
+- ``prepare_report_factory``                — PrepareReport                (p=0.90) → AlwaysSucceed
+- ``draft_advisory_artifact_factory``       — DraftAdvisoryArtifact        (p=0.90) → AlwaysSucceed
+- ``review_advisory_draft_factory``         — ReviewAdvisoryDraft          (p=1.0) → AlwaysSucceed
+- ``revise_advisory_draft_factory``         — ReviseAdvisoryDraft          (p=0.90) → AlwaysSucceed
+- ``submit_advisory_artifact_factory``      — SubmitAdvisoryArtifact       (p=0.90) → AlwaysSucceed
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import py_trees
+
+from vultron.core.behaviors.call_out_point import CallOutBackendFactory
+
+
+def _always_succeed(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.base import AlwaysSucceed
+
+    return AlwaysSucceed(name)
+
+
+def _stochastic_prioritize_intents(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.publication import (
+        PrioritizePublicationIntents,
+    )
+
+    return PrioritizePublicationIntents(name)
+
+
+def _stochastic_prepare_exploit(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.publication import (
+        PrepareExploit,
+    )
+
+    return PrepareExploit(name)
+
+
+def _stochastic_prepare_fix(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.publication import PrepareFix
+
+    return PrepareFix(name)
+
+
+def _stochastic_prepare_report(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.publication import PrepareReport
+
+    return PrepareReport(name)
+
+
+def _stochastic_draft_advisory(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.publication import (
+        DraftAdvisoryArtifact,
+    )
+
+    return DraftAdvisoryArtifact(name)
+
+
+def _stochastic_review_advisory(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.publication import (
+        ReviewAdvisoryDraft,
+    )
+
+    return ReviewAdvisoryDraft(name)
+
+
+def _stochastic_revise_advisory(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.publication import (
+        ReviseAdvisoryDraft,
+    )
+
+    return ReviseAdvisoryDraft(name)
+
+
+def _stochastic_submit_advisory(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.publication import (
+        SubmitAdvisoryArtifact,
+    )
+
+    return SubmitAdvisoryArtifact(name)
+
+
+@dataclass(frozen=True)
+class PublicationCallOutBundle:
+    """Call-out backend bundle for the publication pipeline domain (BT-23-003).
+
+    Fields map to the corresponding factory parameters on
+    :func:`~vultron.core.behaviors.report.publication_tree.create_publication_tree`
+    and
+    :func:`~vultron.core.behaviors.report.publish_artifact_tree.create_publish_artifact_tree`.
+    """
+
+    prioritize_publication_intents_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    prepare_exploit_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    prepare_fix_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    prepare_report_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    draft_advisory_artifact_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    review_advisory_draft_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    revise_advisory_draft_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    submit_advisory_artifact_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+
+
+PUBLICATION_DETERMINISTIC = PublicationCallOutBundle()
+"""Deterministic bundle: all nodes use AlwaysSucceed (BT-23-001, BT-23-002)."""
+
+PUBLICATION_STOCHASTIC = PublicationCallOutBundle(
+    prioritize_publication_intents_factory=_stochastic_prioritize_intents,  # type: ignore[arg-type]
+    prepare_exploit_factory=_stochastic_prepare_exploit,  # type: ignore[arg-type]
+    prepare_fix_factory=_stochastic_prepare_fix,  # type: ignore[arg-type]
+    prepare_report_factory=_stochastic_prepare_report,  # type: ignore[arg-type]
+    draft_advisory_artifact_factory=_stochastic_draft_advisory,  # type: ignore[arg-type]
+    review_advisory_draft_factory=_stochastic_review_advisory,  # type: ignore[arg-type]
+    revise_advisory_draft_factory=_stochastic_revise_advisory,  # type: ignore[arg-type]
+    submit_advisory_artifact_factory=_stochastic_submit_advisory,  # type: ignore[arg-type]
+)
+"""Stochastic bundle: all nodes use probabilistic fuzzer classes."""
+
+__all__ = [
+    "PublicationCallOutBundle",
+    "PUBLICATION_DETERMINISTIC",
+    "PUBLICATION_STOCHASTIC",
+]

--- a/vultron/demo/fuzzer/bundles/report_to_others.py
+++ b/vultron/demo/fuzzer/bundles/report_to_others.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Call-out bundle for the report-to-others domain (BT-23-003, BT-23-005).
+
+Provides :class:`ReportToOthersCallOutBundle` plus the pre-built singletons
+:data:`REPORT_TO_OTHERS_DETERMINISTIC` and :data:`REPORT_TO_OTHERS_STOCHASTIC`.
+
+Ceiling/floor mapping (BT-23-002):
+
+- ``all_parties_known_factory``       — AllPartiesKnown       (p=0.50) → AlwaysSucceed (tie-break)
+- ``total_effort_limit_factory``      — TotalEffortLimitMet   (p=0.10) → AlwaysFail
+- ``more_vendors_factory``            — MoreVendors           (p=0.25) → AlwaysFail
+- ``more_coordinators_factory``       — MoreCoordinators      (p=0.10) → AlwaysFail
+- ``more_others_factory``             — MoreOthers            (p=0.10) → AlwaysFail
+- ``suggest_vendor_factory``          — InjectVendor          (p=1.0) → AlwaysSucceed
+- ``suggest_coordinator_factory``     — InjectCoordinator     (p=1.0) → AlwaysSucceed
+- ``suggest_other_factory``           — InjectOther           (p=1.0) → AlwaysSucceed
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import py_trees
+
+from vultron.core.behaviors.call_out_point import CallOutBackendFactory
+
+
+def _always_succeed(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.base import AlwaysSucceed
+
+    return AlwaysSucceed(name)
+
+
+def _always_fail(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.base import AlwaysFail
+
+    return AlwaysFail(name)
+
+
+def _stochastic_all_parties_known(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.report_to_others import (
+        AllPartiesKnown,
+    )
+
+    return AllPartiesKnown(name)
+
+
+def _stochastic_total_effort_limit(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.report_to_others import (
+        TotalEffortLimitMet,
+    )
+
+    return TotalEffortLimitMet(name)
+
+
+def _stochastic_more_vendors(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.report_to_others import (
+        MoreVendors,
+    )
+
+    return MoreVendors(name)
+
+
+def _stochastic_more_coordinators(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.report_to_others import (
+        MoreCoordinators,
+    )
+
+    return MoreCoordinators(name)
+
+
+def _stochastic_more_others(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.report_to_others import (
+        MoreOthers,
+    )
+
+    return MoreOthers(name)
+
+
+def _stochastic_suggest_vendor(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.report_to_others import (
+        InjectVendor,
+    )
+
+    return InjectVendor(name)
+
+
+def _stochastic_suggest_coordinator(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.report_to_others import (
+        InjectCoordinator,
+    )
+
+    return InjectCoordinator(name)
+
+
+def _stochastic_suggest_other(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.report_to_others import (
+        InjectOther,
+    )
+
+    return InjectOther(name)
+
+
+@dataclass(frozen=True)
+class ReportToOthersCallOutBundle:
+    """Call-out backend bundle for the report-to-others domain (BT-23-003).
+
+    Fields map to the corresponding factory parameters on
+    :func:`~vultron.core.behaviors.report.report_to_others_tree.create_report_to_others_tree`.
+    """
+
+    all_parties_known_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    total_effort_limit_factory: CallOutBackendFactory = field(
+        default=_always_fail  # type: ignore[assignment]
+    )
+    more_vendors_factory: CallOutBackendFactory = field(
+        default=_always_fail  # type: ignore[assignment]
+    )
+    more_coordinators_factory: CallOutBackendFactory = field(
+        default=_always_fail  # type: ignore[assignment]
+    )
+    more_others_factory: CallOutBackendFactory = field(
+        default=_always_fail  # type: ignore[assignment]
+    )
+    suggest_vendor_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    suggest_coordinator_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    suggest_other_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+
+
+REPORT_TO_OTHERS_DETERMINISTIC = ReportToOthersCallOutBundle()
+"""Deterministic bundle: ceiling/floor of stochastic p (BT-23-001, BT-23-002)."""
+
+REPORT_TO_OTHERS_STOCHASTIC = ReportToOthersCallOutBundle(
+    all_parties_known_factory=_stochastic_all_parties_known,  # type: ignore[arg-type]
+    total_effort_limit_factory=_stochastic_total_effort_limit,  # type: ignore[arg-type]
+    more_vendors_factory=_stochastic_more_vendors,  # type: ignore[arg-type]
+    more_coordinators_factory=_stochastic_more_coordinators,  # type: ignore[arg-type]
+    more_others_factory=_stochastic_more_others,  # type: ignore[arg-type]
+    suggest_vendor_factory=_stochastic_suggest_vendor,  # type: ignore[arg-type]
+    suggest_coordinator_factory=_stochastic_suggest_coordinator,  # type: ignore[arg-type]
+    suggest_other_factory=_stochastic_suggest_other,  # type: ignore[arg-type]
+)
+"""Stochastic bundle: all nodes use probabilistic fuzzer classes."""
+
+__all__ = [
+    "ReportToOthersCallOutBundle",
+    "REPORT_TO_OTHERS_DETERMINISTIC",
+    "REPORT_TO_OTHERS_STOCHASTIC",
+]

--- a/vultron/demo/fuzzer/bundles/validation.py
+++ b/vultron/demo/fuzzer/bundles/validation.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Call-out bundle for the report validation domain (BT-23-003, BT-23-005).
+
+Provides :class:`ValidationCallOutBundle` plus the pre-built singletons
+:data:`VALIDATION_DETERMINISTIC` and :data:`VALIDATION_STOCHASTIC`.
+
+Ceiling/floor mapping (BT-23-002):
+
+- ``credibility_factory``   — EvaluateReportCredibility (p=0.90) → AlwaysSucceed
+- ``validity_factory``      — EvaluateReportValidity    (p=0.90) → AlwaysSucceed
+- ``gather_info_factory``   — GatherValidationInfo      (p=0.90) → AlwaysSucceed
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import py_trees
+
+from vultron.core.behaviors.call_out_point import CallOutBackendFactory
+
+
+def _always_succeed(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.base import AlwaysSucceed
+
+    return AlwaysSucceed(name)
+
+
+def _stochastic_credibility(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.validate import (
+        EvaluateReportCredibility,
+    )
+
+    return EvaluateReportCredibility(name)
+
+
+def _stochastic_validity(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.validate import (
+        EvaluateReportValidity,
+    )
+
+    return EvaluateReportValidity(name)
+
+
+def _stochastic_gather_info(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.validate import (
+        GatherValidationInfo,
+    )
+
+    return GatherValidationInfo(name)
+
+
+@dataclass(frozen=True)
+class ValidationCallOutBundle:
+    """Call-out backend bundle for the report validation domain (BT-23-003).
+
+    Fields map to the corresponding factory parameters on
+    :func:`~vultron.core.behaviors.report.validate_tree.create_validate_report_tree`.
+    """
+
+    credibility_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    validity_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+    gather_info_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
+
+
+VALIDATION_DETERMINISTIC = ValidationCallOutBundle()
+"""Deterministic bundle: all nodes use AlwaysSucceed (BT-23-001, BT-23-002)."""
+
+VALIDATION_STOCHASTIC = ValidationCallOutBundle(
+    credibility_factory=_stochastic_credibility,  # type: ignore[arg-type]
+    validity_factory=_stochastic_validity,  # type: ignore[arg-type]
+    gather_info_factory=_stochastic_gather_info,  # type: ignore[arg-type]
+)
+"""Stochastic bundle: all nodes use probabilistic fuzzer classes."""
+
+__all__ = [
+    "ValidationCallOutBundle",
+    "VALIDATION_DETERMINISTIC",
+    "VALIDATION_STOCHASTIC",
+]


### PR DESCRIPTION
- Closes #1645

## Summary

Implements the call-out point backend bundle system (BT-23) designed in #1631. Introduces nine domain-scoped `frozen @dataclass` bundle classes that group all `CallOutBackendFactory` fields for a domain, ships DETERMINISTIC and STOCHASTIC singletons for each, and rewires all eleven tree builders to accept a `call_out: <Domain>Bundle | None = None` parameter.

## Changes

- **`vultron/core/behaviors/call_out_point.py`**: Promotes `CallOutBackendFactory` from a `Callable` alias to a `@runtime_checkable Protocol` (BT-23-004), enabling `isinstance` checks at runtime.
- **`vultron/demo/fuzzer/bundles/`** (9 new modules + `__init__.py`): Domain bundles for validation, prioritization, embargo, publication, report-to-others, deploy-fix, acquire-exploit, assign-vul-id, and close-report. Each module defines a frozen dataclass and exports `<DOMAIN>_DETERMINISTIC` (ceiling/floor rule: p>0.5→AlwaysSucceed, p≤0.5→AlwaysFail; p=0.5→AlwaysSucceed) and `<DOMAIN>_STOCHASTIC` singletons (BT-23-001, BT-23-002, BT-23-003). `__init__.py` re-exports all 9 classes and 18 singletons.
- **11 tree builder files** (`manage_embargo_tree.py`, `validate_tree.py`, `prioritize_tree.py`, `publication_tree.py`, `publish_artifact_tree.py`, `report_to_others_tree.py`, `deploy_fix_tree.py`, `acquire_exploit_tree.py`, `acquire_exploit_strategy_tree.py`, `assign_vul_id_tree.py`, `close_report_tree.py`): Replace individual factory kwargs with `call_out: "<Domain>Bundle | None" = None`; function bodies use lazy import and fallback to DETERMINISTIC singleton to satisfy BT-16-001 (hexagonal architecture).
- **13 existing test files updated**: All factory-injection tests migrated to the new bundle API; default-mode tests updated to expect AlwaysSucceed/AlwaysFail (DETERMINISTIC) instead of fuzzer nodes; new stochastic tests added per domain.
- **`test/demo/fuzzer/test_bundles.py`** (new): 241-line test covering Protocol runtime-checkability, frozen dataclass invariants (parametrized over 9 bundle types), singleton immutability, and `__init__` re-exports.
- **`test/demo/fuzzer/test_stochastic_bundle_scenario.py`** (new): End-to-end demo scenarios exercising DETERMINISTIC, STOCHASTIC, and CUSTOM modes side-by-side for multiple domains.

## Verification

- 6262 tests pass, 0 failures (plus 215 skipped, 4 xfailed — all pre-existing)
- Black, flake8, mypy, pyright clean (16 pre-existing pyright errors in `test_publish_artifact_tree.py` are unrelated to this branch)
- [x] BT-23-001: `DETERMINISTIC` and `STOCHASTIC` singletons exported per domain
- [x] BT-23-002: Ceiling/floor rule applied to DETERMINISTIC defaults
- [x] BT-23-003: Bundle classes are `frozen @dataclass`; all fields are `CallOutBackendFactory`-typed
- [x] BT-23-004: `CallOutBackendFactory` promoted to `@runtime_checkable Protocol`
- [x] BT-23-005: Tree builders accept `call_out` bundle parameter; DETERMINISTIC is the no-arg default
- [x] All existing integration tests continue to pass