### PR TITLE
Extract-before-reuse rule for demo and codebase DRY

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,11 @@ and dispatcher routing.
 - Raise domain-specific exceptions; do not swallow errors
 - Keep formatting and linting aligned with tooling; do not reformat
   unnecessarily
+- **Prefer extracting shared logic over duplicating it.** Three similar lines
+  of code is a signal to extract; copy-pasting a function body is not
+  acceptable. DRY is a project standard. This applies project-wide; for demo
+  scenarios the rule is stricter — see `vultron/demo/AGENTS.md` §
+  "Extract Before Reuse" and `specs/multi-actor-demo.yaml` DEMOMA-17-001.
 
 ### Markdown Formatting
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,8 +108,8 @@ and dispatcher routing.
   unnecessarily
 - **Prefer extracting shared logic over duplicating it.** Three similar lines
   of code is a signal to extract; copy-pasting a function body is not
-  acceptable. DRY is a project standard. This applies project-wide; for demo
-  scenarios the rule is stricter — see `vultron/demo/AGENTS.md` §
+  acceptable. DRY is a project standard (CS-22-001). For demo scenarios the
+  rule is stricter (MUST) — see `vultron/demo/AGENTS.md` §
   "Extract Before Reuse" and `specs/multi-actor-demo.yaml` DEMOMA-17-001.
 
 ### Markdown Formatting

--- a/plan/history/2607/implementation/ISSUE-1652.md
+++ b/plan/history/2607/implementation/ISSUE-1652.md
@@ -1,0 +1,18 @@
+---
+source: ISSUE-1652
+timestamp: '2026-07-23T21:00:08.583246+00:00'
+title: Extract-before-reuse rule for demo and codebase DRY
+type: implementation
+---
+
+## Issue #1652 — Extract-before-reuse: MUST for vultron/demo, SHOULD for codebase
+
+Added extract-before-reuse rule to three locations:
+
+- `vultron/demo/AGENTS.md`: MUST rule — extract to `helpers/` before writing the second use of any pattern; no copy-paste from existing scenario files
+- `specs/multi-actor-demo.yaml`: DEMOMA-16 group with DEMOMA-16-001 normative MUST spec entry; version bumped 1.0.0 → 1.1.0
+- `AGENTS.md`: DRY SHOULD bullet in Code Organization cross-referencing the demo rule and DEMOMA-16-001
+
+All linters clean; 5372 tests passed.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1657>

--- a/plan/incoming/learnings/20260723-spec-rel-type-related-to-invalid.md
+++ b/plan/incoming/learnings/20260723-spec-rel-type-related-to-invalid.md
@@ -1,0 +1,20 @@
+---
+title: "spec rel_type 'related_to' is not a valid enum value"
+type: learning
+timestamp: "2026-07-23"
+source: ISSUE-1652
+signal: spec-ambiguity
+---
+
+When adding a `relationships` entry to a spec YAML, the `rel_type` field
+must be one of the enumerated values validated by `SpecFile`. The value
+`related_to` is NOT valid and causes a pydantic `ValidationError` at
+`spec-dump` time.
+
+Valid `rel_type` values (as of 2026-07-23):
+`implements`, `supersedes`, `extends`, `depends_on`, `conflicts`, `refines`,
+`derives_from`, `verifies`, `part_of`, `constrains`, `satisfies`.
+
+When the intent is "this spec is loosely related to another", use `refines`
+with a clarifying `note:` field, or omit the relationship altogether if no
+normative link exists.

--- a/specs/code-style.yaml
+++ b/specs/code-style.yaml
@@ -1,7 +1,7 @@
 id: CS
 title: Code Style Specifications
 description: Defines code formatting, import organization, and coding style standards for Python code in the Vultron project.
-version: 1.0.0
+version: 1.1.0
 scope:
 - prototype
 - production
@@ -431,3 +431,25 @@ groups:
       provided the distinction is observable in the model''s behaviour or serialisation (e.g., `BTExecutionResult.errors:
       list[str] | None` where `None` means "no error list was collected" vs `[]` meaning "errors were collected but none occurred").
       AS2 wire-layer fields that use `None` to omit keys from the serialised payload are a common example.'
+
+- id: CS-22
+  title: Extract Before Reuse
+  specs:
+  - id: CS-22-001
+    priority: SHOULD
+    kind: project
+    statement: >-
+      Shared logic SHOULD be extracted to a dedicated helper module before it
+      is used in a second location. Three similar lines of code is a signal to
+      extract; copy-pasting a function body is not acceptable. DRY is a project
+      standard.
+    rationale: >-
+      Every piece of code written by copying an existing implementation
+      propagates latent bugs alongside valid patterns. Reactive DRY-up (e.g.,
+      PR #1629 extracting five helper modules after five scenarios had already
+      been written) is more expensive and less reliable than proactive
+      extraction. Extraction-first keeps the codebase clean incrementally.
+    relationships:
+    - rel_type: constrains
+      spec_id: DEMOMA-17-001
+      note: DEMOMA-17-001 is the MUST-level specialisation of this rule for demo scenario files

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -1798,5 +1798,8 @@ groups:
       prevent recurrence.
     relationships:
     - rel_type: refines
+      spec_id: CS-22-001
+      note: MUST-level specialisation of the project-wide SHOULD rule for demo scenario files
+    - rel_type: refines
       spec_id: DEMOMA-03-001
       note: acceptance test scenario files are also subject to this rule

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -1777,3 +1777,26 @@ groups:
     relationships:
     - rel_type: refines
       spec_id: DEMOCI-04-004
+
+- id: DEMOMA-17
+  title: Demo Code Reuse and DRY
+  specs:
+  - id: DEMOMA-17-001
+    priority: MUST
+    kind: project
+    statement: >-
+      Before writing a second use of a pattern in a scenario file under
+      `vultron/demo/scenario/`, the pattern MUST be extracted to
+      `vultron/demo/helpers/` first. Scenario files MUST NOT copy-paste
+      function bodies, polling loops, verification blocks, or any other
+      logical unit from an existing scenario file.
+    rationale: >-
+      Every scenario written by copying the previous one propagates latent bugs
+      alongside valid patterns. Issue #1632 documented residual duplication
+      remaining after PR #1629 reactively extracted five helper modules from
+      five already-written scenarios. The rule enforces extraction-first to
+      prevent recurrence.
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-03-001
+      note: acceptance test scenario files are also subject to this rule

--- a/vultron/demo/AGENTS.md
+++ b/vultron/demo/AGENTS.md
@@ -59,3 +59,38 @@ just the module import — and clear `PYTHONPATH=/app` devcontainer contaminatio
 (see root `AGENTS.md` § "PYTHONPATH=/app contaminates imports").
 
 <!-- Source: ISSUE-1568 -->
+
+---
+
+### Extract Before Reuse: No Copy-Paste from Existing Scenario Files
+
+Before writing a **second use** of a pattern from an existing scenario file,
+extract it to `vultron/demo/helpers/` first. Do not copy-paste a function body,
+a polling loop, a verification block, or any other logical unit from an
+existing scenario file into a new one.
+
+**Why:** Every demo scenario written by copying the previous one propagates
+latent bugs alongside valid patterns. Issue #1632 documented residual
+duplication remaining after PR #1629 reactively extracted five helper modules.
+Copy-paste is the root cause; extraction-first prevents the problem from
+recurring.
+
+**How to apply:**
+
+1. Before writing a new scenario step, grep `vultron/demo/helpers/` for an
+   existing helper that covers the same pattern.
+2. If one exists, import and call it. Do not inline a copy.
+3. If none exists and this is the second occurrence of the pattern, extract it
+   to the appropriate `helpers/` module first, then call it from both places.
+4. A pattern that appears only once may stay inline, but add a comment marking
+   it as a candidate for extraction when a second use arises.
+
+This rule applies to scenario files in `vultron/demo/scenario/`. Exchange demos
+under `vultron/demo/exchange/` are lower-level and may duplicate less when a
+full helper would add more abstraction than value.
+
+See `specs/multi-actor-demo.yaml` DEMOMA-17-001 for the normative requirement
+(a MUST-level specialisation of the project-wide SHOULD rule CS-22-001 in
+`specs/code-style.yaml`).
+
+<!-- Source: ISSUE-1652 -->


### PR DESCRIPTION
- Closes #1652

## Summary

Adds the extract-before-reuse rule to four locations so it is traceable and enforced.
Rebased from #1657 to resolve a DEMOMA-16 group ID collision with PR #1655 — our DRY
rule group is now **DEMOMA-17**.

- **`specs/code-style.yaml`** (CS-22-001, SHOULD): new spec group CS-22 "Extract Before
  Reuse" — project-wide SHOULD rule; spec version bumped 1.0.0 → 1.1.0.
- **`specs/multi-actor-demo.yaml`** (DEMOMA-17-001, MUST): new group DEMOMA-17 "Demo Code
  Reuse and DRY"; normative MUST spec entry that `refines CS-22-001` (MUST-level
  specialisation for demo scenario files); spec version already 1.1.0 from #1655.
- **`vultron/demo/AGENTS.md`** (MUST): new section "Extract Before Reuse" — before
  writing a second use of any pattern in a scenario file, extract it to
  `vultron/demo/helpers/` first; no copy-paste from existing scenario files. Includes
  why/how-to-apply guidance, references to CS-22-001 and DEMOMA-17-001, and a carve-out
  for lower-level exchange demos.
- **`AGENTS.md`** (SHOULD, project-wide): DRY bullet added to Code Organization section,
  citing CS-22-001 explicitly and pointing to `vultron/demo/AGENTS.md` §
  "Extract Before Reuse" and DEMOMA-17-001 for the stricter demo-layer requirement.

## Test plan

- [x] `PYTHONPATH= uv run spec-dump` parses without errors (CS-22-001 and DEMOMA-17-001
  visible; edges consistent)
- [x] `uv run black vultron/ test/` — no changes
- [x] `uv run flake8 vultron/ test/` — clean
- [x] `uv run mypy` — clean
- [x] `uv run pyright` — clean
- [x] `uv run pytest --tb=short` — 5372 passed, 0 failed
- [x] `mdlint.sh` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)