### PR TITLE
docs: plan issue #1653 — ratchet test for save_many atomicity

### DIFF
--- a/plan/history/2607/learning/CONCERN-1653.md
+++ b/plan/history/2607/learning/CONCERN-1653.md
@@ -1,0 +1,40 @@
+---
+source: CONCERN-1653
+timestamp: '2026-07-24T14:28:45.168308+00:00'
+title: Ratchet test for multi-object mutation atomicity (save_many)
+type: learning
+---
+
+## Concern
+
+CM-21-004 mandates `save_many()` for multi-object mutations (e.g., case
+ownership transfer: strip roles → update `attributed_to` → grant roles). The
+spec requirement exists, but there is no automated enforcement. A developer
+writing a multi-step mutation can satisfy the functional test without using
+`save_many()`, and the atomicity gap will only surface under failure injection.
+
+A fix commit in PR #1590 silently deleted the accepting-actor self-delivery
+step while appearing to only change a field accessor — the two concerns were
+co-located and the reviewer did not recognise the dependency. `save_many()`
+atomicity prevents partial-write state but does not prevent self-delivery
+omission; both patterns need detection.
+
+## Design questions resolved
+
+1. **What does the ratchet test assert?** Narrow AST-based behavioral check:
+   any BT node `update()` that assigns to `attributed_to` AND calls
+   `dl.save()` (instead of `dl.save_many()`) is a violation. Scoped to
+   `vultron/core/behaviors/` only.
+
+2. **Scope:** Scoped to the ownership-transfer `attributed_to` mutation
+   pattern (CM-21-004). Broad 2+-saves detection deferred — it hit 4
+   pre-existing non-violation sites and would require a large
+   `KNOWN_VIOLATIONS` set immediately.
+
+3. **Self-delivery coverage:** Documented as pitfall entries in
+   `vultron/core/AGENTS.md` and `vultron/demo/AGENTS.md` (Gap B). The
+   existing demo CI integration tests are the runtime enforcement; a unit
+   ratchet for demo script call-sequence is ~3-4x harder and fragile to
+   scenario restructuring.
+
+**Resolved**: 2026-07-24 — implementation tracked in #1661.

--- a/vultron/core/AGENTS.md
+++ b/vultron/core/AGENTS.md
@@ -94,6 +94,28 @@ logic — check for existing records before creating (HP-07-001). Data Layer
 provides unique ID constraints. Report handlers (`create_report`,
 `submit_report`) already follow this pattern.
 
+### Multi-Object Mutations Touching `attributed_to` MUST Use `save_many()`
+
+Any BT node `update()` that mutates `VulnerabilityCase.attributed_to` alongside
+other objects (e.g., stripping/granting `CVDRole.CASE_OWNER` on participant
+records) **MUST** commit all changes via a single `self.datalayer.save_many()`
+call — never via sequential `self.datalayer.save()` calls.
+
+**Why:** Sequential saves create a window where the DataLayer holds partial
+state (e.g., the old owner's `CASE_OWNER` role stripped but the new owner's
+role not yet granted). A crash in that window leaves the case with zero
+`CASE_OWNER` holders — unrecoverable via normal protocol messages. `save_many()`
+wraps all writes in one SQLite transaction that either commits fully or rolls
+back entirely (CM-21-004). See `AcceptCaseOwnershipTransferNode` in
+`vultron/core/behaviors/case/nodes/ownership_transfer.py` for the canonical
+implementation pattern. An AST ratchet in
+`test/architecture/test_attributed_to_requires_save_many.py` enforces this
+(tracked in #1661).
+
+<!-- Source: CONCERN-1653 -->
+
+---
+
 ### Use `isinstance` for Pyright Attribute Narrowing, Not `# type: ignore`
 
 When accessing an attribute that exists on a subtype but not its base type

--- a/vultron/demo/AGENTS.md
+++ b/vultron/demo/AGENTS.md
@@ -112,11 +112,23 @@ activity to the accepting actor's own inbox so that
 
 ```python
 # ✅ Correct — trigger first, then self-deliver
-trigger_accept_ownership_transfer(accepting_client, offer_id)
+accept_result = post_to_trigger(
+    client=accepting_client,
+    actor_id=accepting_actor_id,
+    behavior="accept-case-ownership-transfer",
+    body={"offer_id": offer_id},
+)
+accept_activity = as_TransitiveActivity.model_validate(accept_result["activity"])
 post_to_inbox_and_wait(accepting_client, accepting_participant_id, accept_activity)
 
 # ❌ Wrong — skips local replica update; attributed_to never changes on accepting actor
-trigger_accept_ownership_transfer(accepting_client, offer_id)
+accept_result = post_to_trigger(
+    client=accepting_client,
+    actor_id=accepting_actor_id,
+    behavior="accept-case-ownership-transfer",
+    body={"offer_id": offer_id},
+)
+# missing: extract accept_activity and post_to_inbox_and_wait(...)
 ```
 
 **Why:** PR #1590 silently deleted this self-delivery step in a commit that

--- a/vultron/demo/AGENTS.md
+++ b/vultron/demo/AGENTS.md
@@ -94,3 +94,39 @@ See `specs/multi-actor-demo.yaml` DEMOMA-17-001 for the normative requirement
 `specs/code-style.yaml`).
 
 <!-- Source: ISSUE-1652 -->
+
+---
+
+### Ownership-Transfer Trigger: Always Self-Deliver the Accept to the Accepting Actor's Inbox
+
+When the accepting actor triggers `accept-case-ownership-transfer`, the
+trigger-side BT (`AcceptCaseOwnershipTransferTriggerBT`) queues the
+`Accept(Offer(VulnerabilityCase))` activity addressed only to the **offering**
+actor. The accepting actor's own DataLayer replica is therefore **not** updated
+by that path.
+
+After queuing the trigger, the demo script **MUST** also POST the Accept
+activity to the accepting actor's own inbox so that
+`AcceptCaseOwnershipTransferReceivedUseCase` runs locally and updates
+`case.attributed_to` on the accepting actor's replica.
+
+```python
+# ✅ Correct — trigger first, then self-deliver
+trigger_accept_ownership_transfer(accepting_client, offer_id)
+post_to_inbox_and_wait(accepting_client, accepting_participant_id, accept_activity)
+
+# ❌ Wrong — skips local replica update; attributed_to never changes on accepting actor
+trigger_accept_ownership_transfer(accepting_client, offer_id)
+```
+
+**Why:** PR #1590 silently deleted this self-delivery step in a commit that
+appeared to only change a field accessor. The omission only surfaced under
+the CI integration test — functional tests passed because the offering actor's
+replica updated correctly via the normal outbox delivery path. The demo CI
+integration tests (`test/ci/invariants/`) are the authoritative runtime
+enforcement for this invariant.
+
+See `vultron/demo/scenario/fvcv_handoff_demo.py` and
+`vultron/demo/scenario/fccv_handoff_demo.py` for the correct pattern.
+
+<!-- Source: CONCERN-1653 -->


### PR DESCRIPTION
- Closes #1653

## Summary

- Archives planning learning to `plan/history/2607/learning/CONCERN-1653.md`
- Adds pitfall to `vultron/core/AGENTS.md`: multi-object mutations touching
  `attributed_to` MUST use `save_many()` (CM-21-004; AC-4)
- Adds pitfall to `vultron/demo/AGENTS.md`: ownership-transfer trigger paths
  must self-deliver the Accept to the accepting actor's own inbox (AC-5)
- Implementation (ratchet test) tracked in #1661

## Test plan

- [x] `markdownlint-cli2` clean (pre-commit passed on both commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)