### PR TITLE
docs: plan #1650 — CI linter + metaspec enforcing ECA format for DEMOMA scenario groups

### DIFF
--- a/.github/workflows/spec-check.yml
+++ b/.github/workflows/spec-check.yml
@@ -1,0 +1,37 @@
+# Spec registry linter — runs when specs/ changes.
+#
+# Validates ECA format enforcement (MS-13-004) and all other spec-lint hard
+# errors. Kept separate from python-app.yml so spec-only PRs don't trigger
+# the full test/lint suite unnecessarily, and so spec changes always get an
+# independent status check. See CONCERN-1650.
+
+name: Spec Check
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "specs/**"
+      - "vultron/metadata/specs/**"
+      - ".github/workflows/spec-check.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "specs/**"
+      - "vultron/metadata/specs/**"
+      - ".github/workflows/spec-check.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  spec-lint:
+    name: Spec Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up Python and uv
+        uses: ./.github/actions/setup-python-uv
+      - name: Run spec-lint
+        run: PYTHONPATH= uv run spec-lint specs/

--- a/notes/behavioral-conformance-specs.md
+++ b/notes/behavioral-conformance-specs.md
@@ -351,6 +351,13 @@ items describing ordered protocol exchanges use `BehavioralSpec`; items expressi
 terminal-state requirements or infrastructure constraints (`MUST reach final state X`,
 `MUST add a CI job`) remain `StatementSpec`.
 
+Since MS-13-004 (CONCERN-1650), `spec-lint` hard-errors when a `scenario_start`
+group contains no `BehavioralSpec` item with non-empty `steps`. The
+`.github/workflows/spec-check.yml` CI workflow enforces this on every `specs/**`
+change. New scenario spec authors should ensure at least one `BehavioralSpec`
+item with a non-empty `steps` list is present, or the spec-lint CI check will
+fail.
+
 ### Protocol behavioral groups
 
 Protocol behavioral groups (RMB, EMB, CSB) always use `BehavioralSpec`. See the

--- a/plan/history/2607/learning/CONCERN-1650.md
+++ b/plan/history/2607/learning/CONCERN-1650.md
@@ -1,0 +1,18 @@
+---
+source: CONCERN-1650
+timestamp: '2026-07-24T15:12:06.825058+00:00'
+title: CI linter + metaspec enforcing ECA format for DEMOMA scenario groups
+type: learning
+---
+
+DEMOMA scenario workflow specs were written as prose ordered-MUST
+statements rather than the ECA format (trigger/preconditions/steps/postconditions)
+used by the rest of the spec corpus. PR #1605 retrofitted existing groups, but
+there was no enforcement preventing regression on new groups. The Vendor-role
+precondition gap (DEMOMA-12, CONCERN-1634) was partly enabled by prose
+postconditions that carried no typed caller obligations.
+
+**Resolved**: 2026-07-24 — implementation tracked in #1665.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1664>.
+Spec: `specs/meta-specifications.yaml` (MS-13-004).
+Notes: `specs/multi-actor-demo.yaml` (DEMOMA-14 ECA fix).

--- a/specs/meta-specifications.yaml
+++ b/specs/meta-specifications.yaml
@@ -394,3 +394,19 @@ groups:
       workflows from message_received and state_entered behavioral groups.
     tags:
     - documentation
+  - id: MS-13-004
+    priority: MUST
+    kind: process
+    statement: >-
+      A spec group with trigger type scenario_start MUST contain at least one
+      BehavioralSpec item with a non-empty steps field describing the ordered
+      protocol exchange.
+    rationale: >-
+      Mixed groups are permitted — terminal-state assertions and infrastructure
+      constraints MAY remain StatementSpec — but the sequential workflow itself
+      MUST be expressed as BehavioralSpec so that conformance tooling and CI can
+      verify ECA structure without parsing prose. This requirement is enforced by
+      spec-lint (SR-04-003); a group with only StatementSpec items causes a hard
+      error. See CONCERN-1650 for the regression that prompted this rule.
+    tags:
+    - documentation

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -1462,8 +1462,14 @@ groups:
         All five containers running (Finder, C1, C2, Vendor, CaseActor);
         all actors seeded and cross-registered.
     steps:
-    - description: Finder submits a VulnerabilityReport to C1's inbox.
-    - description: C1 validates the report and engages the case.
+    - order: 1
+      actor: finder
+      action: POST submit-report trigger to C1
+      expected: C1 creates VulnerabilityCase; RM→RECEIVED on C1
+    - order: 2
+      actor: demo-script
+      action: POST validate-report and engage-case triggers on C1
+      expected: C1 RM→VALID then RM→ACCEPTED; C1 holds CVDRole.CASE_OWNER
     postconditions:
     - description: C1 holds CVDRole.CASE_OWNER and case attributed_to=C1.
     relationships:
@@ -1482,8 +1488,14 @@ groups:
     preconditions:
     - description: C1 is CASE_OWNER; case attributed_to=C1.
     steps:
-    - description: C1 invites C2 to the case with CVDRole.COORDINATOR.
-    - description: C2 accepts the invitation; becomes a participant.
+    - order: 1
+      actor: c1
+      action: POST invite-actor-to-case trigger targeting C2 (CVDRole.COORDINATOR)
+      expected: C1 sends Invite activity to CaseActor; CaseActor forwards to C2
+    - order: 2
+      actor: c2
+      action: POST accept-case-invite trigger
+      expected: C2 becomes a participant with CVDRole.COORDINATOR
     postconditions:
     - description: C2 is a participant; CVDRole.COORDINATOR; case attributed_to=C1.
     relationships:
@@ -1505,13 +1517,16 @@ groups:
     preconditions:
     - description: C2 is a participant; case attributed_to=C1.
     steps:
-    - description: >-
-        C1 triggers offer-case-ownership-transfer (TRIG-11-001) targeting C2.
-    - description: C1 delivers the Offer activity to C2's inbox.
-    - description: >-
-        C2 triggers accept-case-ownership-transfer (TRIG-11-002) referencing
-        the Offer.
-    - description: C2 delivers the Accept activity to C2's own inbox (local use case).
+    - order: 1
+      actor: c1
+      action: POST offer-case-ownership-transfer trigger targeting C2
+      expected: C1 sends Offer activity to C2's inbox via CaseActor
+    - order: 2
+      actor: c2
+      action: POST accept-case-ownership-transfer trigger referencing the Offer
+      expected: >-
+        case attributed_to=C2 on C1's and C2's DataLayers; C2 holds
+        CVDRole.CASE_OWNER; C1 holds CVDRole.COORDINATOR
     postconditions:
     - description: case attributed_to=C2 on C1's and C2's DataLayers.
     - description: C2 holds CVDRole.CASE_OWNER; C1 holds CVDRole.COORDINATOR.
@@ -1533,9 +1548,14 @@ groups:
     preconditions:
     - description: case attributed_to=C2; C2 is CASE_OWNER.
     steps:
-    - description: C2 invites Vendor to the case.
-    - description: Vendor accepts the invitation.
-    - description: Vendor's Accept is delivered to CaseActor's inbox.
+    - order: 1
+      actor: c2
+      action: POST invite-actor-to-case trigger for Vendor
+      expected: C2 sends Invite activity to CaseActor; CaseActor forwards to Vendor
+    - order: 2
+      actor: vendor
+      action: POST accept-case-invite trigger directed to CaseActor
+      expected: Vendor becomes a participant; Accept delivered to CaseActor inbox
     postconditions:
     - description: Vendor is a participant; all five actors have case replicas.
     relationships:

--- a/test/metadata/specs/test_lint.py
+++ b/test/metadata/specs/test_lint.py
@@ -341,3 +341,94 @@ def test_lint_missing_item_kind_is_hard_error(tmp_path):
     _write_yaml(tmp_path, data)
     result = lint(tmp_path)
     assert result == 1
+
+
+# ---------------------------------------------------------------------------
+# scenario_start group must contain a BehavioralSpec with steps (MS-13-004)
+# ---------------------------------------------------------------------------
+
+
+def _scenario_start_group(with_behavioral_spec: bool):
+    """Return a minimal spec file with one scenario_start group.
+
+    When ``with_behavioral_spec`` is True the group contains a BehavioralSpec
+    item with steps; otherwise it contains only a StatementSpec item.
+    """
+    if with_behavioral_spec:
+        workflow_item = {
+            "id": "SCN-01-002",
+            "priority": "MUST",
+            "kind": "project",
+            "statement": "SCN-01-002 MUST execute the scenario workflow",
+            "rationale": "ECA required",
+            "tags": ["demo"],
+            "preconditions": [{"description": "Actors running"}],
+            "steps": [
+                {"order": 1, "actor": "finder", "action": "Submit report"}
+            ],
+            "postconditions": [{"description": "Case created"}],
+        }
+    else:
+        workflow_item = {
+            "id": "SCN-01-002",
+            "priority": "MUST",
+            "kind": "project",
+            "statement": "SCN-01-002 MUST reach final state VFDPxa",
+            "rationale": "Terminal state required",
+            "tags": ["demo"],
+        }
+
+    return {
+        "id": "SCN",
+        "title": "Scenario Spec",
+        "description": "Scenario spec file",
+        "version": "0.1",
+        "scope": ["prototype"],
+        "groups": [
+            {
+                "id": "SCN-01",
+                "title": "FV Scenario",
+                "trigger": {"type": "scenario_start", "value": "fv"},
+                "specs": [
+                    {
+                        "id": "SCN-01-001",
+                        "priority": "MUST",
+                        "kind": "project",
+                        "statement": "SCN-01-001 MUST reach VFDPxa",
+                        "rationale": "Terminal state",
+                        "tags": ["demo"],
+                    },
+                    workflow_item,
+                ],
+            }
+        ],
+    }
+
+
+def test_scenario_start_with_behavioral_spec_passes(tmp_path, capsys):
+    """scenario_start group with a BehavioralSpec+steps item must pass."""
+    _write_yaml(tmp_path, _scenario_start_group(with_behavioral_spec=True))
+    result = lint(tmp_path)
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "MS-13-004" not in captured.err
+
+
+def test_scenario_start_without_behavioral_spec_fails(tmp_path, capsys):
+    """scenario_start group with only StatementSpec items must be a hard error."""
+    _write_yaml(tmp_path, _scenario_start_group(with_behavioral_spec=False))
+    result = lint(tmp_path)
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "SCN-01" in captured.err
+    assert "MS-13-004" in captured.err
+
+
+def test_non_scenario_start_group_not_checked(tmp_path, capsys):
+    """Groups without a scenario_start trigger are not subject to MS-13-004."""
+    data = _minimal_spec()  # no trigger on group TST-01
+    _write_yaml(tmp_path, data)
+    result = lint(tmp_path)
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "MS-13-004" not in captured.err

--- a/vultron/metadata/specs/lint.py
+++ b/vultron/metadata/specs/lint.py
@@ -22,6 +22,7 @@ from vultron.metadata.specs.registry import (
 from vultron.metadata.specs.schema import (
     BehavioralSpec,
     LintWarningCode,
+    TriggerType,
 )
 
 _RATIONALE_WARN_CHARS = 500
@@ -116,6 +117,32 @@ def _check_missing_kind(registry: SpecRegistry) -> list[str]:
     return errors
 
 
+def _check_scenario_start_groups(registry: SpecRegistry) -> list[str]:
+    """Hard error when a scenario_start group has no BehavioralSpec with steps.
+
+    Enforces MS-13-004: mixed groups are permitted, but at least one item must
+    be a BehavioralSpec with a non-empty steps list.
+    """
+    errors: list[str] = []
+    for spec_file in registry.files:
+        for group in spec_file.groups:
+            if (
+                group.trigger is None
+                or group.trigger.type != TriggerType.SCENARIO_START
+            ):
+                continue
+            has_eca = any(
+                isinstance(spec, BehavioralSpec) and bool(spec.steps)
+                for spec in group.specs
+            )
+            if not has_eca:
+                errors.append(
+                    f"Group '{group.id}' has trigger type scenario_start but "
+                    f"contains no BehavioralSpec item with steps (MS-13-004)"
+                )
+    return errors
+
+
 def lint(spec_dir: Path, adr_dir: Path | None = None) -> int:
     """Validate the spec registry in ``spec_dir``.
 
@@ -148,6 +175,7 @@ def lint(spec_dir: Path, adr_dir: Path | None = None) -> int:
     hard_errors.extend(registry.validate_cross_references())
     hard_errors.extend(_check_prefix_consistency(registry))
     hard_errors.extend(_check_spec_id_prefix_consistency(registry))
+    hard_errors.extend(_check_scenario_start_groups(registry))
 
     for spec_id, spec in registry.all_specs.items():
         suppressed = set(spec.lint_suppress or [])


### PR DESCRIPTION
- Closes #1650

## Summary

Adds a `spec-lint` CI workflow and a new `MS-13-004` metaspec rule that
hard-gate ECA format (`preconditions`/`steps`/`postconditions`) on
`scenario_start` spec groups, preventing regression to prose ordered-MUST
statements in new DEMOMA scenario specs.

## Changes

- **`specs/meta-specifications.yaml`**: adds `MS-13-004` — a `scenario_start`
  group MUST contain at least one `BehavioralSpec` item with non-empty `steps`
- **`vultron/metadata/specs/lint.py`**: adds `_check_scenario_start_groups()`
  hard-error check; wired into `lint()` alongside existing checks
- **`.github/workflows/spec-check.yml`**: new workflow running `spec-lint` on
  `specs/**` changes as an independent required status check
- **`test/metadata/specs/test_lint.py`**: three new tests covering pass
  (scenario_start with BehavioralSpec+steps), fail (scenario_start with
  only StatementSpec), and skip (non-scenario_start group)
- **`specs/multi-actor-demo.yaml`**: fixes `DEMOMA-14` (fccv-handoff) steps
  from `description:`-keyed prose to proper `BehaviorStep`
  (`order`/`actor`/`action`/`expected`) — the exact regression the new
  linter check now prevents
- **`notes/behavioral-conformance-specs.md`**: adds MS-13-004 enforcement note
  under § "Demo scenario groups"

## Verification

- All 22 unit tests pass (3 new)
- Black, flake8, mypy, pyright clean
- [x] AC-1: `spec-lint` exits 1 when a `scenario_start` group has no
  `BehavioralSpec` item with steps
- [x] AC-2: MS-13-004 spec entry present in `specs/meta-specifications.yaml`
- [x] AC-3: `.github/workflows/spec-check.yml` runs on `specs/**` changes
- [x] AC-4: Tests pass for pass/fail/non-scenario cases