### PR TITLE
docs: plan issue #1152 — add PrioritizationCallOutBundle field table

### DIFF
--- a/notes/call-out-configuration.md
+++ b/notes/call-out-configuration.md
@@ -168,6 +168,21 @@ sub-module layout):
 | `AssignVulIdCallOutBundle` | Vulnerability ID assignment | `create_assign_vul_id_tree` |
 | `CloseReportCallOutBundle` | Report closure | `create_close_report_tree` |
 
+### PrioritizationCallOutBundle fields
+
+| Field | Node replaced | p (stochastic) | Deterministic default |
+|---|---|---|---|
+| `evaluate_priority_factory` | `EvaluateCasePriority` | 1.0 → `AlwaysSucceed` | `AlwaysSucceed` (always engage; SSVC deferred — PROTO-05-001) |
+| `on_accept_factory` | `OnAccept` | 1.0 → `AlwaysSucceed` | `AlwaysSucceed` |
+| `on_defer_factory` | `OnDefer` | 1.0 → `AlwaysSucceed` | `AlwaysSucceed` |
+| `enough_info_factory` | `EnoughPrioritizationInfo` | 0.75 → `AlwaysSucceed` | `AlwaysSucceed` (Phase 2 reserved) |
+| `gather_info_factory` | `GatherPrioritizationInfo` | 0.90 → `AlwaysSucceed` | `AlwaysSucceed` (Phase 2 reserved) |
+
+`evaluate_priority_factory` is the production SSVC seam (PROTO-05-001). In DETERMINISTIC
+mode it resolves `AlwaysSucceed` so all cases are engaged. In STOCHASTIC mode it uses the
+`EvaluateCasePriority` fuzzer node. A real SSVC evaluator would implement
+`CallOutBackendFactory` and be passed here — no other code change required.
+
 ### Module layout
 
 ```text

--- a/plan/history/2607/idea/IDEA-1152.md
+++ b/plan/history/2607/idea/IDEA-1152.md
@@ -1,0 +1,59 @@
+---
+source: IDEA-1152
+timestamp: '2026-07-24T16:51:16.002017+00:00'
+title: 'FUZZ-08c: Wire call-out point nodes into demo scenarios'
+type: idea
+---
+
+## Summary
+
+Wire the call-out point abstraction (from #1151) into Vultron's demo BTs
+by: (1) auditing existing BT trees for baked-in policy nodes, (2) refactoring
+those nodes to explicit call-out points with deterministic backends, and
+(3) demonstrating the framework with one randomised (fuzzer-backend) demo run.
+
+## Scope
+
+1. **Audit**: Review existing BT trees used by demo scenarios for implicit
+   policy decisions — nodes that hardcode a choice (always accept, always
+   propose embargo, etc.) where a call-out point would better express
+   the intent. Use the shape classifications from #1150 as a guide.
+
+2. **Externalize**: Refactor the identified policy nodes into call-out points
+   using the abstraction from #1151. Use deterministic backends
+   (`AlwaysSucceed` / `AlwaysFail`) initially so existing demo runs are
+   unaffected and pass unchanged.
+
+3. **Randomised demo**: Produce one demo scenario (new or modified existing)
+   that uses probabilistic fuzzer backends for at least one call-out point,
+   demonstrating that backend injection works end-to-end. The deterministic
+   scenarios MUST remain unaffected.
+
+4. **Integration tests**: All existing integration tests MUST continue to pass.
+
+## Key Findings (grill-me)
+
+- Infrastructure (bundles, call_out params on all major tree builders) was
+  largely delivered by prior PRs (#1151 + BT-23 work).
+- The one remaining implicit policy node not yet injectable: `EvaluateCasePriority`
+  in `create_prioritize_subtree` — hardcoded direct instantiation, not going
+  through `PrioritizationCallOutBundle`.
+- `EvaluateReportCredibility` and `EvaluateReportValidity` already injectable
+  via `ValidationCallOutBundle`.
+- `policy.py` contains `AlwaysAcceptPolicy` / `AlwaysPrioritizePolicy` Python
+  objects (not BT nodes) — separate concern, not in scope for wiring.
+- No new ADR needed — ADR-0025 already covers the bundle/factory pattern.
+- Production policy config surface (toggleable per-domain policy overrides via
+  YAML/env) is deferred to Productionization epic (#1184).
+
+## Decisions
+
+- AC count doesn't matter; wire what's genuinely a policy seam.
+- In-process STOCHASTIC demo (no HTTP server) satisfies AC-4.
+- Policy configurability captured as follow-on Idea #1673 under epic #1184.
+- `notes/call-out-configuration.md` updated with full PrioritizationCallOutBundle
+  field table including the new `evaluate_priority_factory` SSVC seam.
+
+**Processed**: 2026-07-24 — implementation tracked in #1671, #1672.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1670>.
+Notes: `notes/call-out-configuration.md`.


### PR DESCRIPTION
## Summary

Plan docs for #1152 (FUZZ-08c: Wire call-out point nodes into demo scenarios).

Adds a `PrioritizationCallOutBundle` field table to
`notes/call-out-configuration.md`, documenting the new
`evaluate_priority_factory` field (the SSVC seam per PROTO-05-001) alongside
the four existing fields with their stochastic probabilities and deterministic
defaults.

- Closes #1152

## Changes

- `notes/call-out-configuration.md` — add `PrioritizationCallOutBundle` domain
  table with all five fields, deterministic defaults, and SSVC cross-reference
  (PROTO-05-001)

🤖 Generated with [Claude Code](https://claude.com/claude-code)