### PR TITLE
fix(report): filter disposition=rejected entries from build_timeline

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1683.md
+++ b/plan/history/2607/implementation/ISSUE-1683.md
@@ -1,0 +1,14 @@
+---
+source: ISSUE-1683
+timestamp: '2026-07-24T18:51:58.093322+00:00'
+title: Filter disposition=rejected entries from report build_timeline
+type: implementation
+---
+
+## Issue #1683 — Report: filter disposition=rejected entries from output
+
+Added a 2-line guard in `build_timeline` (`if event.disposition != "recorded": continue`) to skip local-only correlation markers before they reach the timeline. These rejected entries had empty `payloadSnapshot` values and produced `—` actor labels and empty target columns in the rendered report.
+
+Changes: `vultron/demo/report.py` (guard + docstring), `specs/demo-report.yaml` (new DRPT-02-007), `test/demo/test_report.py` (2 new tests).
+
+PR: <https://github.com/CERTCC/Vultron/pull/1694>

--- a/specs/demo-report.yaml
+++ b/specs/demo-report.yaml
@@ -6,7 +6,7 @@ description: >-
   report of who did what, with what activity, and in what order. Covers input discovery,
   the distilled intermediate data model, markdown and HTML rendering, the per-actor
   replica-presence matrix, friendly naming, and test requirements.
-version: 1.2.0
+version: 1.3.0
 scope:
 - prototype
 tags:

--- a/specs/demo-report.yaml
+++ b/specs/demo-report.yaml
@@ -142,6 +142,22 @@ groups:
     relationships:
     - rel_type: refines
       spec_id: DRPT-02-004
+  - id: DRPT-02-007
+    priority: MUST
+    kind: project
+    statement: >-
+      `build_timeline` MUST skip entries whose `disposition` field is not
+      `"recorded"` (e.g. `"rejected"`). Rejected entries are local-only
+      correlation markers with empty `payloadSnapshot` values; including them
+      in the report produces `—` actor labels and empty target columns that
+      violate the CLP spec and mislead readers.
+    rationale: >-
+      The AGENTS.md pitfall "disposition=rejected for Local-Only Correlation
+      Markers" documents that rejected entries must not appear in output
+      intended for human consumption.
+    relationships:
+    - rel_type: refines
+      spec_id: DRPT-02-004
 - id: DRPT-03
   title: Friendly Naming
   specs:

--- a/test/demo/test_report.py
+++ b/test/demo/test_report.py
@@ -318,6 +318,30 @@ class TestBuildTimeline:
         events = build_timeline({"vendor": [a, b]})
         assert len(events) == 2
 
+    def test_rejected_entries_excluded(self):
+        """disposition=rejected entries are silently dropped (DRPT-02-007)."""
+        recorded = _camel_entry(logIndex=0, entryHash="a" * 64)
+        rejected = _camel_entry(
+            logIndex=1,
+            entryHash="b" * 64,
+            disposition="rejected",
+            payloadSnapshot={},
+        )
+        events = build_timeline({"vendor": [recorded, rejected]})
+        assert len(events) == 1
+        assert events[0].log_index == 0
+
+    def test_only_rejected_entries_yields_empty_timeline(self):
+        """A replica with only rejected entries produces an empty timeline."""
+        r1 = _camel_entry(
+            logIndex=0, entryHash="a" * 64, disposition="rejected"
+        )
+        r2 = _camel_entry(
+            logIndex=1, entryHash="b" * 64, disposition="rejected"
+        )
+        events = build_timeline({"vendor": [r1, r2]})
+        assert events == []
+
 
 # ---------------------------------------------------------------------------
 # DRPT-02-006 — multi-case partitioning (no cross-case interleaving)

--- a/vultron/demo/report.py
+++ b/vultron/demo/report.py
@@ -496,6 +496,10 @@ def build_timeline(
     per-source key for degenerate hashless entries), records which actors'
     replicas hold each entry, and orders the result by ``log_index`` ascending
     (DRPT-02-004, DRPT-02-005).
+
+    Entries with ``disposition != "recorded"`` are silently skipped; they are
+    local-only correlation markers with empty payloads that must not appear in
+    the report (DRPT-02-007).
     """
     by_key: dict[str, CaseTimelineEvent] = {}
     presence: dict[str, set[str]] = {}
@@ -503,6 +507,8 @@ def build_timeline(
     for actor_name in sorted(replicas):
         for raw in replicas[actor_name]:
             event = CaseTimelineEvent.from_raw(raw)
+            if event.disposition != "recorded":
+                continue
             if event.entry_hash:
                 key = event.entry_hash
             else:


### PR DESCRIPTION
- Closes #1683

## Summary

`build_timeline` now skips entries where `disposition != "recorded"` before
adding them to `by_key`. Rejected entries are local-only correlation markers
with empty `payloadSnapshot` values; including them in the report produced
`—` actor labels and empty target columns (violating the CLP spec).

## Changes

- **`vultron/demo/report.py`**: added 2-line guard in `build_timeline`
  (`if event.disposition != "recorded": continue`) with docstring update
  referencing DRPT-02-007
- **`specs/demo-report.yaml`**: added DRPT-02-007
- **`test/demo/test_report.py`**: two new tests —
  `test_rejected_entries_excluded` and
  `test_only_rejected_entries_yields_empty_timeline`

## Advisory

`CaseTimelineEvent.summary` still appends `[rejected]` and `render_html`
still emits a `class="rejected"` row for non-recorded entries. These paths
are unreachable through the normal `build_timeline → render` pipeline but
remain valid for direct callers of the public API. No change made; both are
defensive code.

## Verification

- `uv run pytest test/demo/test_report.py -m ""` — 62 passed (includes 2 new)
- Full unit suite: 5417 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)