### PR TITLE
docs: plan issue #1680 — report header show first and last entry timestamps

### DIFF
--- a/plan/history/2607/idea/IDEA-1680.md
+++ b/plan/history/2607/idea/IDEA-1680.md
@@ -1,0 +1,16 @@
+---
+source: IDEA-1680
+timestamp: '2026-07-24T19:08:00.268341+00:00'
+title: 'Report header: show first and last entry timestamps'
+type: idea
+---
+
+The `vultron-demo-report` header currently shows only event count, case count, and replica list. It should also show the timestamp of the first and last ledger entry so readers can immediately orient to the case timeline span without scanning the table.
+
+When reviewing reports from CI runs or comparing across scenarios, knowing the time range at a glance (e.g. "15:31:20Z – 15:31:27Z") is more useful than counting rows. The timestamps are already available on every `CaseTimelineEvent.received_at`.
+
+In `render_markdown` / `render_html`, compute `min(e.received_at for e in events)` and `max(...)` and add a `- Time range: {first} – {last}` line to the per-case section header. Handle the single-event and no-event edge cases.
+
+**Processed**: 2026-07-24 — implementation tracked in #1697.
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1696>.
+Spec: `specs/demo-report.yaml` (DRPT-04-006).

--- a/specs/demo-report.yaml
+++ b/specs/demo-report.yaml
@@ -6,7 +6,7 @@ description: >-
   report of who did what, with what activity, and in what order. Covers input discovery,
   the distilled intermediate data model, markdown and HTML rendering, the per-actor
   replica-presence matrix, friendly naming, and test requirements.
-version: 1.2.0
+version: 1.3.0
 scope:
 - prototype
 tags:
@@ -211,6 +211,30 @@ groups:
       browser via `webbrowser.open()`, and MUST provide a flag (e.g.
       `--no-open`) that suppresses the browser launch (required for
       non-interactive and CI use).
+  - id: DRPT-04-006
+    priority: SHOULD
+    kind: project
+    statement: >-
+      Each per-case section SHOULD display the time range of its events as
+      `Time range: {first} – {last}`, where `{first}` and `{last}` are the
+      minimum and maximum `receivedAt` timestamps (full ISO 8601 strings) among
+      the case's canonical events. The line MUST be omitted when no events in
+      the case carry a `receivedAt` timestamp. When all events share the same
+      timestamp, both bounds MUST be shown (`{ts} – {ts}`). In markdown, the
+      time range MUST appear as a bullet line between the case heading and the
+      event table. In HTML, it MUST appear as a `<p class="meta">` element
+      between the `<h2>` heading and the `<table>`.
+    rationale: >-
+      When reviewing reports from CI runs or comparing across scenarios,
+      knowing the time range at a glance (e.g. "15:31:20Z – 15:31:27Z") is
+      more useful than counting rows. Per-case placement is necessary because
+      `log_index` restarts at 0 per case and cases may span non-overlapping
+      time windows (DRPT-02-006).
+    relationships:
+    - rel_type: extends
+      spec_id: DRPT-04-001
+    - rel_type: extends
+      spec_id: DRPT-04-002
 - id: DRPT-05
   title: Testing
   specs:


### PR DESCRIPTION
- Closes #1680

## Summary

- Add `DRPT-04-006` to `specs/demo-report.yaml` (version 1.2.0 → 1.3.0)
- Requirement: each per-case section in the report SHOULD display its time
  range as `Time range: {first} – {last}` using the min/max `receivedAt`
  timestamps among the case's canonical events
- Omit when no events carry a `receivedAt` timestamp
- Per-case placement is necessary because `log_index` restarts at 0 per case
  and cases may span non-overlapping windows (DRPT-02-006)

## Changes

- `specs/demo-report.yaml`: new `DRPT-04-006` entry in the Rendering group;
  version bumped from 1.2.0 to 1.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)