### PR TITLE
BT: emit Accept(CaseManagerRole) to ledger after role accepted

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1686.md
+++ b/plan/history/2607/implementation/ISSUE-1686.md
@@ -1,0 +1,21 @@
+---
+source: ISSUE-1686
+timestamp: '2026-07-24T19:24:35.524743+00:00'
+title: 'BT: emit Accept(CaseManagerRole) to ledger after role accepted'
+type: implementation
+---
+
+## Issue #1686 — BT: emit Accept(CaseManagerRole) after case-manager role accepted
+
+Root cause: `AutoAcceptCaseManagerRoleNode.update()` called `_call_factory()` then `_enqueue_accept()` with no ledger commit between them.
+
+Fix:
+
+- `accept_case_manager_role` adapter method changed to return `(id, dict)` — inline snapshot captured before DL storage
+- New `_commit_accept_to_ledger(accept_id, payload_snapshot)` runs `create_commit_log_entry_tree` via BTBridge with `disposition="recorded"` before `_enqueue_accept`
+- Added `("Accept", "Offer")` to `_CASE_AUTHORED_SIGNATURES` in `chain.py`
+- Port contract updated: `TriggerActivityPort.accept_case_manager_role` → `tuple[str, dict[str, Any]]`
+- 5 new tests in `TestAutoAcceptCaseManagerRoleNode`; 3 existing tests updated
+
+Branch: task/1686-emit-accept-case-manager-role (pushed, PR creation blocked by GitHub API server error)
+Validation: 5381 passed, 0 failed

--- a/plan/incoming/learnings/20260724-accept-offer-case-authored-signature.md
+++ b/plan/incoming/learnings/20260724-accept-offer-case-authored-signature.md
@@ -1,0 +1,23 @@
+---
+title: "CASE_AUTHORED_SIGNATURES must include Accept(Offer) for CaseManagerRole delegation"
+type: learning
+timestamp: "2026-07-24T19:52:00Z"
+source: ISSUE-1686
+signal: design-question
+---
+
+When implementing the ledger commit for `Accept(CaseManagerRole)`, CLP-07-003
+blocked the commit because `("Accept", "Offer")` was not in
+`_CASE_AUTHORED_SIGNATURES`.  The CaseActor is the legitimate author of this
+activity (it is accepting the delegation offer on the case's behalf), so the
+signature must be allowed for CaseActor authorship.
+
+Decision: added `("Accept", "Offer")` to `_CASE_AUTHORED_SIGNATURES` in
+`vultron/core/behaviors/sync/nodes/chain.py`.
+
+Rationale: the `_CASE_AUTHORED_SIGNATURES` set is intended to enumerate
+activities where it is *correct* for the CaseActor service to appear as the
+author.  `Accept(CaseManagerRole)` fits that definition.  The existing
+`("Accept", "Offer")` entry in `_CANONICAL_PAYLOAD_SIGNATURES` covers
+`validate_report` where the actor is a *participant*, not the CaseActor — so
+there was no conflict, just an incomplete allowlist.

--- a/plan/incoming/learnings/20260724-github-api-500-during-pr-creation.md
+++ b/plan/incoming/learnings/20260724-github-api-500-during-pr-creation.md
@@ -1,0 +1,15 @@
+---
+title: "GitHub REST and GraphQL APIs returned HTTP 500 during PR creation (2026-07-24)"
+type: learning
+timestamp: "2026-07-24T19:52:00Z"
+source: ISSUE-1686
+signal: tooling-issue
+---
+
+Both `gh pr create` (GraphQL) and the REST `/repos/.../pulls` endpoint returned
+HTTP 500 errors on 2026-07-24 around 19:20–19:52 UTC.  All other API calls
+(branch lookup, compare, issue edit) succeeded normally.
+
+Branch `task/1686-emit-accept-case-manager-role` is pushed and ready.  PR must
+be opened manually at:
+<https://github.com/CERTCC/Vultron/compare/main...task/1686-emit-accept-case-manager-role>

--- a/test/adapters/driven/trigger_activity_adapter/test_actors.py
+++ b/test/adapters/driven/trigger_activity_adapter/test_actors.py
@@ -315,7 +315,7 @@ class TestAcceptCaseManagerRole:
             actor=_ACTOR,
         )
 
-        activity_id = adapter.accept_case_manager_role(
+        activity_id, _ = adapter.accept_case_manager_role(
             offer_id=offer_id,
             case_id=case.id_,
             participant_id=participant.id_,
@@ -335,7 +335,7 @@ class TestAcceptCaseManagerRole:
             actor=_ACTOR,
         )
 
-        activity_id = adapter.accept_case_manager_role(
+        activity_id, _ = adapter.accept_case_manager_role(
             offer_id=offer_id,
             case_id=case.id_,
             participant_id=participant.id_,

--- a/test/core/behaviors/case/nodes/test_communication.py
+++ b/test/core/behaviors/case/nodes/test_communication.py
@@ -434,3 +434,148 @@ class TestEmitRejectCaseManagerRoleNode:
             actor=self._CASE_ACTOR_ID,
             to=[self._VENDOR_ID],
         )
+
+
+# ---------------------------------------------------------------------------
+# TestAutoAcceptCaseManagerRoleNode
+# ---------------------------------------------------------------------------
+
+
+class TestAutoAcceptCaseManagerRoleNode:
+    """AutoAcceptCaseManagerRoleNode commits ledger entry before enqueuing."""
+
+    _OFFER_ID = "https://example.org/activities/offer-cm-002"
+    _CASE_ID = "https://example.org/cases/case-cm-002"
+    _PARTICIPANT_ID = (
+        "https://example.org/participants/urn:uuid:case-actor-cm-002"
+    )
+    _VENDOR_ID = "https://example.org/actors/vendor-cm2"
+    _CASE_ACTOR_ID = "https://example.org/actors/case-actor-cm2"
+
+    def _make_node(self) -> AutoAcceptCaseManagerRoleNode:
+        return AutoAcceptCaseManagerRoleNode(
+            offer_id=self._OFFER_ID,
+            case_id=self._CASE_ID,
+            participant_id=self._PARTICIPANT_ID,
+            vendor_id=self._VENDOR_ID,
+        )
+
+    def _seed_dl(self, bt_scenario: BTTestScenario) -> None:
+        from vultron.wire.as2.vocab.objects.case_participant import (
+            as_CaseParticipant,
+        )
+        from vultron.wire.as2.vocab.objects.vulnerability_case import (
+            as_VulnerabilityCase,
+        )
+
+        # attributed_to triggers genesis_hash computation (CLP-08-001).
+        case = as_VulnerabilityCase(
+            id_=self._CASE_ID,
+            name="CM-TEST-2",
+            attributed_to=self._VENDOR_ID,
+        )
+        participant = as_CaseParticipant(
+            id_=self._PARTICIPANT_ID,
+            attributed_to=self._CASE_ACTOR_ID,
+            context=self._CASE_ID,
+        )
+        bt_scenario.dl.create(case)
+        bt_scenario.dl.create(participant)
+
+    def test_succeeds_and_records_outbox_item(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        """Returns SUCCESS and records accept activity ID in actor's outbox."""
+        self._seed_dl(bt_scenario)
+
+        result = bt_scenario.run(
+            self._make_node(),
+            actor_id=self._CASE_ACTOR_ID,
+        )
+        bt_scenario.assert_success(result)
+
+    def test_ledger_entry_created_with_correct_event_type(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        """A CaseLedgerEntry with event_type 'accept_case_manager_role' is committed."""
+        from vultron.core.models.case_ledger_entry import (
+            VultronCaseLedgerEntry,
+        )
+
+        self._seed_dl(bt_scenario)
+
+        bt_scenario.run(
+            self._make_node(),
+            actor_id=self._CASE_ACTOR_ID,
+        )
+
+        entries = bt_scenario.dl.list_objects("CaseLedgerEntry")
+        accept_entries = [
+            e
+            for e in entries
+            if isinstance(e, VultronCaseLedgerEntry)
+            and e.event_type == "accept_case_manager_role"
+        ]
+        assert len(accept_entries) == 1, (
+            "Expected exactly one 'accept_case_manager_role' ledger entry, "
+            f"found {len(accept_entries)}"
+        )
+
+    def test_ledger_entry_is_recorded_not_rejected(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        """The committed ledger entry has disposition 'recorded' (canonical)."""
+        from vultron.core.models.case_ledger_entry import (
+            VultronCaseLedgerEntry,
+        )
+
+        self._seed_dl(bt_scenario)
+
+        bt_scenario.run(
+            self._make_node(),
+            actor_id=self._CASE_ACTOR_ID,
+        )
+
+        entries = bt_scenario.dl.list_objects("CaseLedgerEntry")
+        accept_entries = [
+            e
+            for e in entries
+            if isinstance(e, VultronCaseLedgerEntry)
+            and e.event_type == "accept_case_manager_role"
+        ]
+        assert (
+            accept_entries
+        ), "Expected at least one 'accept_case_manager_role' ledger entry"
+        assert accept_entries[0].disposition == "recorded"
+
+    def test_accept_activity_persisted_to_datalayer(
+        self, bt_scenario: BTTestScenario
+    ) -> None:
+        """The Accept activity is stored in the DataLayer after SUCCESS."""
+        self._seed_dl(bt_scenario)
+
+        bt_scenario.run(
+            self._make_node(),
+            actor_id=self._CASE_ACTOR_ID,
+        )
+
+        stored_accepts = bt_scenario.dl.list_objects("Accept")
+        assert len(stored_accepts) >= 1
+
+    def test_fails_when_trigger_factory_is_none(self) -> None:
+        """Returns FAILURE when trigger_activity_factory is not available."""
+        from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+        from vultron.core.behaviors.bridge import BTBridge
+
+        dl = SqliteDataLayer("sqlite:///:memory:")
+        bridge = BTBridge(
+            datalayer=dl,
+            is_leader=lambda: True,
+            trigger_activity=None,
+        )
+        py_trees.blackboard.Blackboard.storage.clear()
+        result = bridge.execute_with_setup(
+            tree=self._make_node(),
+            actor_id=self._CASE_ACTOR_ID,
+        )
+        assert result.status == py_trees.common.Status.FAILURE

--- a/test/core/behaviors/case/nodes/test_communication.py
+++ b/test/core/behaviors/case/nodes/test_communication.py
@@ -493,6 +493,10 @@ class TestAutoAcceptCaseManagerRoleNode:
             actor_id=self._CASE_ACTOR_ID,
         )
         bt_scenario.assert_success(result)
+        outbox = bt_scenario.dl.outbox_list_for_actor(self._CASE_ACTOR_ID)
+        assert (
+            len(outbox) >= 1
+        ), "Expected at least one outbox item after auto-accept"
 
     def test_ledger_entry_created_with_correct_event_type(
         self, bt_scenario: BTTestScenario

--- a/test/core/use_cases/received/actor/test_case_manager_role.py
+++ b/test/core/use_cases/received/actor/test_case_manager_role.py
@@ -148,7 +148,8 @@ class TestCaseManagerRoleDelegationUseCases:
 
         trigger = MagicMock()
         trigger.accept_case_manager_role.return_value = (
-            "https://example.org/activities/accept-1"
+            "https://example.org/activities/accept-1",
+            {"type": "Accept", "actor": self._CASE_ACTOR_URI},
         )
 
         OfferCaseManagerRoleReceivedUseCase(
@@ -369,8 +370,12 @@ class TestCaseManagerRoleDelegationUseCases:
         )
 
         dl = SqliteDataLayer("sqlite:///:memory:")
+        # attributed_to triggers genesis_hash computation (CLP-08-001); required
+        # for the ledger commit that precedes the outbox enqueue.
         case = as_VulnerabilityCase(
-            id_=self._CASE_URI, name="OUTBOX-FAIL-TEST"
+            id_=self._CASE_URI,
+            name="OUTBOX-FAIL-TEST",
+            attributed_to=self._VENDOR_URI,
         )
         participant = as_CaseParticipant(
             id_=self._PARTICIPANT_URI,
@@ -385,7 +390,24 @@ class TestCaseManagerRoleDelegationUseCases:
 
         trigger = MagicMock()
         trigger.accept_case_manager_role.return_value = (
-            "https://example.org/activities/accept-outbox-fail"
+            "https://example.org/activities/accept-outbox-fail",
+            {
+                "type": "Accept",
+                "actor": self._CASE_ACTOR_URI,
+                "context": self._CASE_URI,
+                "object": {
+                    "type": "Offer",
+                    "id": "https://example.org/activities/offer-placeholder",
+                    "object": {
+                        "type": "VulnerabilityCase",
+                        "id": self._CASE_URI,
+                    },
+                    "target": {
+                        "type": "CaseParticipant",
+                        "id": self._PARTICIPANT_URI,
+                    },
+                },
+            },
         )
 
         # Accept creation succeeds, but outbox enqueue fails.

--- a/vultron/adapters/driven/trigger_activity_adapter/actors.py
+++ b/vultron/adapters/driven/trigger_activity_adapter/actors.py
@@ -480,12 +480,16 @@ class _ActorsMixin:
         vendor_id: str,
         actor: str,
         to: list[str] | None = None,
-    ) -> str:
+    ) -> tuple[str, dict[str, Any]]:
         """Create and persist an ``Accept(_OfferCaseManagerRoleActivity)``.
 
         Ephemerally reconstructs the original Offer from ``offer_id``,
         ``case_id``, ``participant_id``, and ``vendor_id`` so that
         ``Accept.object_`` is a typed ``_OfferCaseManagerRoleActivity``.
+
+        Returns ``(activity_id, activity_dict)`` where ``activity_dict`` is
+        the full inline serialization captured before the activity is stored,
+        suitable for use as a canonical payload snapshot.
         """
         case = _to_wire(self._dl.read(case_id), as_VulnerabilityCase)
         participant = _to_wire(
@@ -500,6 +504,7 @@ class _ActorsMixin:
         activity = accept_case_manager_role_activity(
             offer=offer, actor=actor, to=to
         )
+        activity_dict = activity.model_dump(**_DUMP_KWARGS)
         try:
             self._dl.create(activity)
         except ValueError:
@@ -508,7 +513,7 @@ class _ActorsMixin:
                 " — skipping",
                 activity.id_,
             )
-        return activity.id_
+        return activity.id_, activity_dict
 
     def reject_case_manager_role(
         self,

--- a/vultron/core/behaviors/case/nodes/delegation.py
+++ b/vultron/core/behaviors/case/nodes/delegation.py
@@ -33,7 +33,11 @@ from typing import Any, cast
 import py_trees
 from py_trees.common import Status
 
+from vultron.core.behaviors.bridge import BTBridge
 from vultron.core.behaviors.helpers import DataLayerAction
+from vultron.core.behaviors.sync.commit_tree import (
+    create_commit_log_entry_tree,
+)
 from vultron.core.ports.case_persistence import CaseOutboxPersistence
 
 logger = logging.getLogger(__name__)
@@ -237,8 +241,8 @@ class AutoAcceptCaseManagerRoleNode(DataLayerAction):
         self.participant_id = participant_id
         self.vendor_id = vendor_id
 
-    def _call_factory(self) -> str:
-        """Create the Accept activity. Raises on failure (safe to catch)."""
+    def _call_factory(self) -> tuple[str, dict]:
+        """Create the Accept activity. Returns (id, inline_dict). Raises on failure."""
         assert self.trigger_activity_factory is not None
         assert self.actor_id is not None
         return self.trigger_activity_factory.accept_case_manager_role(
@@ -281,11 +285,53 @@ class AutoAcceptCaseManagerRoleNode(DataLayerAction):
             return Status.FAILURE
         return None
 
+    def _commit_accept_to_ledger(
+        self, accept_id: str, payload_snapshot: dict
+    ) -> bool:
+        """Commit the Accept(CaseManagerRole) activity to the case ledger.
+
+        ``payload_snapshot`` is the inline serialization of the Accept captured
+        at creation time (before DL storage may flatten nested objects).
+
+        Returns True on success.  Callers MUST check the return value and
+        propagate FAILURE when False — a missing ledger entry breaks the
+        hash chain and violates DEMOMA-08-009.
+        """
+        assert self.datalayer is not None
+        assert self.actor_id is not None
+        # Normalize context to case_id (CLP-10-006: payloadSnapshot.context
+        # must equal the case URI for canonical recorded entries).
+        if payload_snapshot.get("context") != self.case_id:
+            payload_snapshot = dict(payload_snapshot)
+            payload_snapshot["context"] = self.case_id
+        commit_tree = create_commit_log_entry_tree(
+            case_id=self.case_id,
+            object_id=accept_id,
+            event_type="accept_case_manager_role",
+            payload_snapshot=payload_snapshot,
+            disposition="recorded",
+        )
+        result = BTBridge(
+            datalayer=cast(CaseOutboxPersistence, self.datalayer)
+        ).execute_with_setup(
+            tree=commit_tree,
+            actor_id=self.actor_id,
+        )
+        if result.status != Status.SUCCESS:
+            self.logger.error(
+                "%s: ledger commit failed for Accept '%s' on offer '%s'",
+                self.name,
+                accept_id,
+                self.offer_id,
+            )
+            return False
+        return True
+
     def update(self) -> Status:
         if (f := self._validate_context()) is not None:
             return f
         try:
-            accept_id = self._call_factory()
+            accept_id, payload_snapshot = self._call_factory()
         except Exception as exc:
             self.logger.error(
                 "%s: error creating Accept for offer '%s': %s",
@@ -294,9 +340,12 @@ class AutoAcceptCaseManagerRoleNode(DataLayerAction):
                 exc,
             )
             return Status.FAILURE
+        if not self._commit_accept_to_ledger(accept_id, payload_snapshot):
+            return Status.FAILURE
         self._enqueue_accept(accept_id)
         self.logger.info(
-            "%s: auto-accepted offer '%s' as '%s'; queued Accept '%s'",
+            "%s: auto-accepted offer '%s' as '%s'; ledgered and queued"
+            " Accept '%s'",
             self.name,
             self.offer_id,
             self.actor_id,

--- a/vultron/core/behaviors/sync/nodes/chain.py
+++ b/vultron/core/behaviors/sync/nodes/chain.py
@@ -71,6 +71,8 @@ _CASE_AUTHORED_SIGNATURES: frozenset[tuple[str, str]] = frozenset(
         ("Offer", "VulnerabilityCase"),
         # Leave(VulnerabilityCase): case-actor's AutoCloseBranchNode when all reach RM.CLOSED.
         ("Leave", "VulnerabilityCase"),
+        # Accept(Offer): case-actor accepts CaseManagerRole delegation offer.
+        ("Accept", "Offer"),
     }
 )
 _INLINE_OBJECT_KEYS: frozenset[str] = frozenset(

--- a/vultron/core/ports/trigger_activity.py
+++ b/vultron/core/ports/trigger_activity.py
@@ -456,7 +456,7 @@ class TriggerActivityPort(Protocol):
         vendor_id: str,
         actor: str,
         to: list[str] | None = None,
-    ) -> str:
+    ) -> tuple[str, dict[str, Any]]:
         """Create and persist an ``Accept(_OfferCaseManagerRoleActivity)``.
 
         Ephemerally reconstructs the original Offer (using ``offer_id``,
@@ -464,7 +464,9 @@ class TriggerActivityPort(Protocol):
         the Accept so that ``Accept.object_`` is a typed
         ``_OfferCaseManagerRoleActivity``, not a bare string IRI.
 
-        Returns the activity ID.
+        Returns ``(activity_id, activity_dict)`` where ``activity_dict`` is
+        the full inline serialization of the Accept (with nested Offer
+        inlined), suitable for use as a canonical payload snapshot.
         """
         ...
 


### PR DESCRIPTION
- Closes #1686

## Summary

`AutoAcceptCaseManagerRoleNode` accepted the CASE_MANAGER delegation offer and
enqueued the `Accept` activity to the outbox, but never committed a ledger
entry. Every demo scenario jumped directly from `offer_case_manager_role` to
`validate_report` with no `accept_case_manager_role` entry.

### Root cause

`AutoAcceptCaseManagerRoleNode.update()` called `_call_factory()` then
`_enqueue_accept()` with no ledger commit step in between.

## Changes

- **`vultron/adapters/driven/trigger_activity_adapter/actors.py`**: `accept_case_manager_role`
  now returns `(activity_id, activity_dict)` — inline dict captured before DL
  storage so nested Offer is fully inlined for canonical snapshot validation.
- **`vultron/core/behaviors/case/nodes/delegation.py`**: New
  `_commit_accept_to_ledger(accept_id, payload_snapshot)` runs
  `create_commit_log_entry_tree` via `BTBridge` with `disposition="recorded"`
  before `_enqueue_accept`.
- **`vultron/core/behaviors/sync/nodes/chain.py`**: Added `("Accept", "Offer")`
  to `_CASE_AUTHORED_SIGNATURES` — CaseActor is the legitimate author of
  `Accept(CaseManagerRole)`.
- **`vultron/core/ports/trigger_activity.py`**: Port contract updated —
  `accept_case_manager_role` now declares `-> tuple[str, dict[str, Any]]`.
- **`test/core/behaviors/case/nodes/test_communication.py`**: 5 new
  `TestAutoAcceptCaseManagerRoleNode` tests; 1 existing test strengthened with
  outbox assertion.
- **`test/core/use_cases/received/actor/test_case_manager_role.py`**: 3 tests
  updated for new return type and genesis hash requirement.

## Verification

- [x] 5 new `TestAutoAcceptCaseManagerRoleNode` tests (SUCCESS+outbox, ledger
  event_type, disposition=recorded, Accept persisted, FAILURE without factory)
- [x] 3 existing tests updated for new return type and genesis hash requirement
- [x] Full suite: 5381 passed, 0 failed
- [x] Black, flake8, mypy, pyright clean (CI green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)