### PR TITLE
fix: wait for EM teardown to propagate to finder before notify-published in fvcv-extension

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1690.md
+++ b/plan/history/2607/implementation/ISSUE-1690.md
@@ -1,0 +1,22 @@
+---
+source: ISSUE-1690
+timestamp: '2026-07-24T20:44:07.284386+00:00'
+title: 'fix: fvcv-extension EM wait before finder notify-published'
+type: implementation
+---
+
+## Issue #1690 — fvcv-extension: add wait_for_case_em_terminated before finder notify-published
+
+Added `wait_for_case_em_terminated(client=finder_client)` inside a `demo_check`
+block before `actor_notifies_published` for finder in `_phase_publication` of
+`fvcv_extension_demo.py`. Without this guard finder could ledger a
+participant-status update with `EM=ACTIVE` after the embargo was already removed
+at the CaseActor, producing an out-of-causal-order entry visible in the report
+as row 23 (finder updated participant status, EM=ACTIVE) appearing after row 22
+(case-actor removed embargo).
+
+Added `TestPhasePublicationEmWaitOrdering` regression test in
+`test/demo/test_fvcv_extension_demo.py` verifying the EM wait precedes
+finder's notify-published call using call-log tracking via `side_effect` closures.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1702>

--- a/test/demo/test_fvcv_extension_demo.py
+++ b/test/demo/test_fvcv_extension_demo.py
@@ -261,6 +261,104 @@ class TestFindCaseInviteForActor:
 
 
 # ---------------------------------------------------------------------------
+# Publication phase ordering tests
+# ---------------------------------------------------------------------------
+
+
+class TestPhasePublicationEmWaitOrdering:
+    """Verify that wait_for_case_em_terminated is called on finder's client
+    before actor_notifies_published is called for finder.
+
+    Regression test for issue #1690: finder previously called notify-published
+    before the EM teardown had propagated to its replica, producing an
+    out-of-causal-order EM=ACTIVE ledger entry after embargo removal.
+    """
+
+    def _make_actor(self, id_: str = "urn:test:actor"):
+        actor = MagicMock()
+        actor.id_ = id_
+        return actor
+
+    def _make_client(self):
+        return MagicMock()
+
+    def test_finder_em_wait_precedes_finder_notify_published(self):
+        """wait_for_case_em_terminated(finder) must be called before
+        actor_notifies_published for finder.
+        """
+        case_id = "urn:test:case-1"
+        call_log: list[str] = []
+
+        finder_client = self._make_client()
+        vendor_client = self._make_client()
+        coordinator_client = self._make_client()
+        vendor2_client = self._make_client()
+
+        finder = self._make_actor("urn:test:finder")
+        finder_in_finder = self._make_actor("urn:test:finder")
+        vendor = self._make_actor("urn:test:vendor")
+        vendor_in_vendor = self._make_actor("urn:test:vendor")
+        vendor2 = self._make_actor("urn:test:vendor2")
+        vendor2_in_vendor2 = self._make_actor("urn:test:vendor2")
+        coordinator = self._make_actor("urn:test:coordinator")
+        coordinator_in_coordinator = self._make_actor("urn:test:coordinator")
+
+        case = MagicMock()
+        case.id_ = case_id
+
+        def track_em_wait(client, case_id, **kwargs):
+            if client is finder_client:
+                call_log.append("em_wait_finder")
+
+        def track_notify_published(client, actor, case_id, **kwargs):
+            if client is finder_client:
+                call_log.append("notify_published_finder")
+
+        with (
+            patch.object(
+                demo,
+                "wait_for_case_em_terminated",
+                side_effect=track_em_wait,
+            ),
+            patch.object(
+                demo,
+                "actor_notifies_published",
+                side_effect=track_notify_published,
+            ),
+            patch.object(demo, "verify_publicly_disclosed"),
+            patch.object(demo, "demo_check"),
+        ):
+            demo._phase_publication(
+                finder_client=finder_client,
+                vendor_client=vendor_client,
+                coordinator_client=coordinator_client,
+                vendor2_client=vendor2_client,
+                vendor=vendor,
+                vendor_in_vendor=vendor_in_vendor,
+                vendor2=vendor2,
+                vendor2_in_vendor2=vendor2_in_vendor2,
+                finder=finder,
+                finder_in_finder=finder_in_finder,
+                coordinator=coordinator,
+                coordinator_in_coordinator=coordinator_in_coordinator,
+                case=case,
+            )
+
+        assert (
+            "em_wait_finder" in call_log
+        ), "wait_for_case_em_terminated was not called for finder_client"
+        assert (
+            "notify_published_finder" in call_log
+        ), "actor_notifies_published was not called for finder"
+        em_idx = call_log.index("em_wait_finder")
+        pub_idx = call_log.index("notify_published_finder")
+        assert em_idx < pub_idx, (
+            f"wait_for_case_em_terminated (pos {em_idx}) must precede "
+            f"actor_notifies_published for finder (pos {pub_idx})"
+        )
+
+
+# ---------------------------------------------------------------------------
 # CLI integration test
 # ---------------------------------------------------------------------------
 

--- a/vultron/demo/scenario/fvcv_extension_demo.py
+++ b/vultron/demo/scenario/fvcv_extension_demo.py
@@ -777,6 +777,15 @@ def _phase_publication(
         actor=coordinator_in_coordinator,
         case_id=case.id_,
     )
+
+    with demo_check(
+        "Embargo terminated (EM.EXITED) propagated to Finder before notify-published"
+    ):
+        wait_for_case_em_terminated(
+            client=finder_client,
+            case_id=case.id_,
+        )
+
     actor_notifies_published(
         client=finder_client,
         actor=finder_in_finder,


### PR DESCRIPTION
- Closes #1690

## Summary

In `_phase_publication`, finder called `actor_notifies_published` before
`wait_for_case_em_terminated(finder_client)` confirmed that the embargo
teardown had propagated to its replica. This produced an out-of-causal-order
`EM=ACTIVE` ledger entry for finder after the embargo was already removed at
the CaseActor (visible in the report as row 23 appearing after row 22).

## Changes

- `vultron/demo/scenario/fvcv_extension_demo.py`: add
  `wait_for_case_em_terminated(client=finder_client, case_id=case.id_)`
  inside a `demo_check` block immediately before finder's
  `actor_notifies_published` call in `_phase_publication`. Matches the
  identical guard already present in `fvcv_handoff_demo.py`.
- `test/demo/test_fvcv_extension_demo.py`: add
  `TestPhasePublicationEmWaitOrdering` regression test that verifies the
  EM wait is called on finder's client before finder's notify-published call,
  using call-log tracking via `side_effect` closures.

## Test plan

- [x] `uv run pytest test/demo/test_fvcv_extension_demo.py -m ""` — 14 passed
- [x] Full suite: 5417 passed, 224 skipped, 2 xfailed
- [x] Black, flake8, mypy, pyright all clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)