### PR TITLE
feat(report): add per-case time range to report header (DRPT-04-006)

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1697.md
+++ b/plan/history/2607/implementation/ISSUE-1697.md
@@ -1,0 +1,12 @@
+---
+source: ISSUE-1697
+timestamp: '2026-07-27T13:40:17.931481+00:00'
+title: Add per-case time range to report header (DRPT-04-006)
+type: implementation
+---
+
+## Issue #1697 — Implement DRPT-04-006: per-case time range in report header
+
+Added `_case_time_range` helper and emitted `Time range: {first} – {last}` in both markdown and HTML renderers, between the case heading and event table. Omitted when all `received_at` values are None. 11 new tests added covering helper edge cases and both renderer paths. All 4 ACs satisfied.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1704>

--- a/test/demo/test_report.py
+++ b/test/demo/test_report.py
@@ -29,6 +29,7 @@ from vultron.demo import report
 from vultron.demo.report import (
     CaseTimelineEvent,
     ReportError,
+    _case_time_range,
     build_timeline,
     discover_replicas,
     event_phrase,
@@ -647,6 +648,152 @@ class TestHtmlRenderer:
         out = render_html(build_timeline({"vendor": [raw]}), ["vendor"])
         assert "<h2>Case urn:case:&lt;x&gt;</h2>" in out
         assert "<x>" not in out
+
+
+# ---------------------------------------------------------------------------
+# DRPT-04-006 — per-case time range
+# ---------------------------------------------------------------------------
+
+
+class TestCaseTimeRange:
+    def test_no_timestamps_returns_none_none(self):
+        events = [
+            CaseTimelineEvent.from_raw(_camel_entry(receivedAt=None)),
+            CaseTimelineEvent.from_raw(
+                _camel_entry(entryHash="b" * 64, logIndex=1, receivedAt=None)
+            ),
+        ]
+        assert _case_time_range(events) == (None, None)
+
+    def test_empty_list_returns_none_none(self):
+        assert _case_time_range([]) == (None, None)
+
+    def test_returns_min_max_for_multi_event_case(self):
+        events = [
+            CaseTimelineEvent(
+                case_id="urn:case:1",
+                log_index=0,
+                entry_hash="a" * 64,
+                received_at="2026-07-01T10:00:00Z",
+            ),
+            CaseTimelineEvent(
+                case_id="urn:case:1",
+                log_index=1,
+                entry_hash="b" * 64,
+                received_at="2026-07-01T12:00:00Z",
+            ),
+            CaseTimelineEvent(
+                case_id="urn:case:1",
+                log_index=2,
+                entry_hash="c" * 64,
+                received_at="2026-07-01T11:00:00Z",
+            ),
+        ]
+        first, last = _case_time_range(events)
+        assert first == "2026-07-01T10:00:00Z"
+        assert last == "2026-07-01T12:00:00Z"
+
+    def test_single_timestamp_min_equals_max(self):
+        events = [
+            CaseTimelineEvent(
+                case_id="urn:case:1",
+                log_index=0,
+                entry_hash="a" * 64,
+                received_at="2026-07-01T10:00:00Z",
+            ),
+        ]
+        first, last = _case_time_range(events)
+        assert first == last == "2026-07-01T10:00:00Z"
+
+    def test_ignores_none_timestamps_in_mixed_list(self):
+        events = [
+            CaseTimelineEvent(
+                case_id="urn:case:1",
+                log_index=0,
+                entry_hash="a" * 64,
+                received_at=None,
+            ),
+            CaseTimelineEvent(
+                case_id="urn:case:1",
+                log_index=1,
+                entry_hash="b" * 64,
+                received_at="2026-07-01T10:00:00Z",
+            ),
+        ]
+        first, last = _case_time_range(events)
+        assert first == last == "2026-07-01T10:00:00Z"
+
+
+class TestMarkdownRendererTimeRange:
+    def test_time_range_bullet_present_when_timestamps_exist(self):
+        replicas = {"vendor": [_camel_entry()]}
+        events = build_timeline(replicas)
+        md = render_markdown(events, ["vendor"])
+        assert (
+            "- Time range: 2026-07-01T12:00:00Z – 2026-07-01T12:00:00Z" in md
+        )
+
+    def test_time_range_bullet_omitted_when_no_timestamps(self):
+        replicas = {"vendor": [_camel_entry(receivedAt=None)]}
+        events = build_timeline(replicas)
+        md = render_markdown(events, ["vendor"])
+        assert "Time range:" not in md
+
+    def test_time_range_shows_min_max_across_events(self):
+        replicas = {
+            "vendor": [
+                _camel_entry(
+                    logIndex=0,
+                    entryHash="a" * 64,
+                    receivedAt="2026-07-01T10:00:00Z",
+                ),
+                _camel_entry(
+                    logIndex=1,
+                    entryHash="b" * 64,
+                    receivedAt="2026-07-01T14:00:00Z",
+                ),
+            ],
+        }
+        events = build_timeline(replicas)
+        md = render_markdown(events, ["vendor"])
+        assert "2026-07-01T10:00:00Z" in md
+        assert "2026-07-01T14:00:00Z" in md
+        assert "Time range:" in md
+
+
+class TestHtmlRendererTimeRange:
+    def test_time_range_meta_present_when_timestamps_exist(self):
+        replicas = {"vendor": [_camel_entry()]}
+        events = build_timeline(replicas)
+        out = render_html(events, ["vendor"])
+        assert '<p class="meta">Time range: 2026-07-01T12:00:00Z' in out
+
+    def test_time_range_meta_omitted_when_no_timestamps(self):
+        replicas = {"vendor": [_camel_entry(receivedAt=None)]}
+        events = build_timeline(replicas)
+        out = render_html(events, ["vendor"])
+        assert "Time range:" not in out
+
+    def test_time_range_shows_min_max_across_events(self):
+        replicas = {
+            "vendor": [
+                _camel_entry(
+                    logIndex=0,
+                    entryHash="a" * 64,
+                    receivedAt="2026-07-01T09:00:00Z",
+                ),
+                _camel_entry(
+                    logIndex=1,
+                    entryHash="b" * 64,
+                    receivedAt="2026-07-01T15:00:00Z",
+                ),
+            ],
+        }
+        events = build_timeline(replicas)
+        out = render_html(events, ["vendor"])
+        assert "2026-07-01T09:00:00Z" in out
+        assert "2026-07-01T15:00:00Z" in out
+        assert "Time range:" in out
 
 
 # ---------------------------------------------------------------------------

--- a/test/demo/test_report.py
+++ b/test/demo/test_report.py
@@ -30,6 +30,7 @@ from vultron.demo.report import (
     CaseTimelineEvent,
     ReportError,
     _case_time_range,
+    _parse_timestamp,
     build_timeline,
     discover_replicas,
     event_phrase,
@@ -655,6 +656,21 @@ class TestHtmlRenderer:
 # ---------------------------------------------------------------------------
 
 
+class TestParseTimestamp:
+    def test_z_suffix_parsed(self):
+        dt = _parse_timestamp("2026-07-01T12:00:00Z")
+        assert dt.tzinfo is not None
+
+    def test_offset_notation_parsed(self):
+        dt = _parse_timestamp("2026-07-01T12:00:00+00:00")
+        assert dt.tzinfo is not None
+
+    def test_z_and_offset_equal(self):
+        assert _parse_timestamp("2026-07-01T12:00:00Z") == _parse_timestamp(
+            "2026-07-01T12:00:00+00:00"
+        )
+
+
 class TestCaseTimeRange:
     def test_no_timestamps_returns_none_none(self):
         events = [
@@ -722,6 +738,26 @@ class TestCaseTimeRange:
         ]
         first, last = _case_time_range(events)
         assert first == last == "2026-07-01T10:00:00Z"
+
+    def test_z_and_offset_notation_compared_chronologically(self):
+        """Z suffix and +00:00 offset represent the same instant; sort by value."""
+        events = [
+            CaseTimelineEvent(
+                case_id="urn:case:1",
+                log_index=0,
+                entry_hash="a" * 64,
+                received_at="2026-07-01T12:00:00+00:00",
+            ),
+            CaseTimelineEvent(
+                case_id="urn:case:1",
+                log_index=1,
+                entry_hash="b" * 64,
+                received_at="2026-07-01T10:00:00Z",
+            ),
+        ]
+        first, last = _case_time_range(events)
+        assert first == "2026-07-01T10:00:00Z"
+        assert last == "2026-07-01T12:00:00+00:00"
 
 
 class TestMarkdownRendererTimeRange:

--- a/vultron/demo/report.py
+++ b/vultron/demo/report.py
@@ -659,6 +659,21 @@ def _md_cell(text: str) -> str:
     return text.replace("|", "\\|").replace("\n", " ")
 
 
+def _case_time_range(
+    events: list[CaseTimelineEvent],
+) -> tuple[str | None, str | None]:
+    """Return ``(min_received_at, max_received_at)`` for a list of events.
+
+    Uses string ``min``/``max`` over non-None ``received_at`` values (ISO 8601
+    timestamps sort lexicographically). Returns ``(None, None)`` when no event
+    carries a timestamp (DRPT-04-006).
+    """
+    timestamps = [e.received_at for e in events if e.received_at is not None]
+    if not timestamps:
+        return None, None
+    return min(timestamps), max(timestamps)
+
+
 def _render_markdown_case(
     lines: list[str], events: list[CaseTimelineEvent], actors: list[str]
 ) -> None:
@@ -706,6 +721,10 @@ def render_markdown(events: list[CaseTimelineEvent], actors: list[str]) -> str:
     for case_id, case_events in by_case.items():
         lines.append(f"## Case {_md_cell(case_id or '(unknown)')}")
         lines.append("")
+        first, last = _case_time_range(case_events)
+        if first is not None and last is not None:
+            lines.append(f"- Time range: {_md_cell(first)} – {_md_cell(last)}")
+            lines.append("")
         _render_markdown_case(lines, case_events, actors)
         lines.append("")
 
@@ -810,8 +829,16 @@ def render_html(events: list[CaseTimelineEvent], actors: list[str]) -> str:
     by_case = group_events_by_case(events)
     sections: list[str] = []
     for case_id, case_events in by_case.items():
+        first, last = _case_time_range(case_events)
+        time_range_html = ""
+        if first is not None and last is not None:
+            time_range_html = (
+                f'<p class="meta">Time range: {html.escape(first)}'
+                f" – {html.escape(last)}</p>\n"
+            )
         sections.append(
             f"<h2>Case {html.escape(case_id or '(unknown)')}</h2>\n"
+            + time_range_html
             + _render_html_case_table(case_events, actors)
         )
 

--- a/vultron/demo/report.py
+++ b/vultron/demo/report.py
@@ -51,6 +51,7 @@ import logging
 import os
 import sys
 import webbrowser
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -659,19 +660,38 @@ def _md_cell(text: str) -> str:
     return text.replace("|", "\\|").replace("\n", " ")
 
 
+def _parse_timestamp(ts: str) -> datetime:
+    """Parse an ISO 8601 timestamp string to a timezone-aware datetime.
+
+    Handles both ``Z`` suffix (``fromisoformat`` requires ``+00:00`` on
+    Python < 3.11) and ``+00:00`` offset forms.
+    """
+    return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+
 def _case_time_range(
     events: list[CaseTimelineEvent],
 ) -> tuple[str | None, str | None]:
     """Return ``(min_received_at, max_received_at)`` for a list of events.
 
-    Uses string ``min``/``max`` over non-None ``received_at`` values (ISO 8601
-    timestamps sort lexicographically). Returns ``(None, None)`` when no event
-    carries a timestamp (DRPT-04-006).
+    Parses each ``received_at`` string via :func:`_parse_timestamp` so
+    comparison is chronological regardless of offset notation (``Z`` vs
+    ``+00:00``) or future microsecond precision changes. Returns ``(None,
+    None)`` when no event carries a timestamp (DRPT-04-006).
     """
-    timestamps = [e.received_at for e in events if e.received_at is not None]
-    if not timestamps:
+    pairs: list[tuple[str, datetime]] = []
+    for e in events:
+        if e.received_at is None:
+            continue
+        try:
+            pairs.append((e.received_at, _parse_timestamp(e.received_at)))
+        except ValueError:
+            logger.debug("Skipping unparseable received_at: %r", e.received_at)
+    if not pairs:
         return None, None
-    return min(timestamps), max(timestamps)
+    first_str, _ = min(pairs, key=lambda p: p[1])
+    last_str, _ = max(pairs, key=lambda p: p[1])
+    return first_str, last_str
 
 
 def _render_markdown_case(


### PR DESCRIPTION
- Closes #1697

## Summary

- Adds `_case_time_range(events)` helper returning `(min_received_at, max_received_at)` via string min/max over non-None timestamps; returns `(None, None)` when no events carry a timestamp (AC-1)
- `render_markdown` now emits `- Time range: {first} – {last}` between the `## Case` heading and the event table; omitted when both values are `None` (AC-2)
- `render_html` now emits `<p class="meta">Time range: {first} – {last}</p>` between the `<h2>` heading and the `<table>`; omitted when both values are `None` (AC-3)
- Tests added: 11 new tests covering helper edge cases (empty list, all-None, mixed, multi-event, single-event) and both renderer paths (present and omitted) (AC-4)

## Test plan

- [x] `uv run pytest test/demo/test_report.py -m "" --tb=short` → 77 passed
- [x] Full suite: 5436 passed, 0 failures
- [x] `uv run black`, `uv run flake8`, `uv run mypy`, `uv run pyright` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)