### PR TITLE
fix(report): extract CS/EM state from caseStatuses array in VulnerabilityCase payloads

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1684.md
+++ b/plan/history/2607/implementation/ISSUE-1684.md
@@ -1,0 +1,18 @@
+---
+source: ISSUE-1684
+timestamp: '2026-07-27T13:54:40.818865+00:00'
+title: 'fix(report): extract CS/EM state from caseStatuses array'
+type: implementation
+---
+
+## Issue #1684 — Report: extract CS/EM state from caseStatuses array in VulnerabilityCase payloads
+
+Fixed `_candidate_dicts` in `vultron/demo/report.py` to iterate items of any
+`caseStatuses`/`case_statuses` list found on a visited node. Previously, EM/CS
+state carried in the `caseStatuses` array on `VulnerabilityCase` payloads was
+never reached, leaving EM and CS columns blank for early timeline rows.
+
+Added 3 tests: camelCase array extraction, snake_case key tolerance, and
+corrupt non-list guard.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1705>

--- a/test/demo/test_report.py
+++ b/test/demo/test_report.py
@@ -175,6 +175,61 @@ class TestCaseTimelineEventParsing:
         event = CaseTimelineEvent.from_raw(raw)
         assert event.em_state == "ACTIVE"
 
+    def test_em_state_from_case_statuses_array(self):
+        """EM/CS state extracted from caseStatuses array on VulnerabilityCase."""
+        raw = _camel_entry(
+            eventType="offer_case_manager_role",
+            payloadSnapshot={
+                "type": "Offer",
+                "actor": "http://vendor:7999/api/v2/actors/case-actor",
+                "object": {
+                    "id": "urn:uuid:case1",
+                    "type": "VulnerabilityCase",
+                    "caseStatuses": [
+                        {"em": {"state": "ACTIVE"}, "pxa": {"state": "Pxa"}},
+                    ],
+                },
+            },
+        )
+        event = CaseTimelineEvent.from_raw(raw)
+        assert event.em_state == "ACTIVE"
+        assert event.pxa_state == "Pxa"
+
+    def test_em_state_from_case_statuses_snake_key(self):
+        """case_statuses (snake_case) is also traversed."""
+        raw = _camel_entry(
+            eventType="offer_case_manager_role",
+            payloadSnapshot={
+                "type": "Offer",
+                "actor": "http://vendor:7999/api/v2/actors/case-actor",
+                "object": {
+                    "id": "urn:uuid:case1",
+                    "type": "VulnerabilityCase",
+                    "case_statuses": [
+                        {"em": {"state": "PROPOSED"}, "pxa": {"state": "pxa"}},
+                    ],
+                },
+            },
+        )
+        event = CaseTimelineEvent.from_raw(raw)
+        assert event.em_state == "PROPOSED"
+
+    def test_case_statuses_non_list_does_not_crash(self):
+        """A non-list caseStatuses value (e.g. corrupt data) is silently ignored."""
+        raw = _camel_entry(
+            payloadSnapshot={
+                "type": "Offer",
+                "actor": "http://vendor:7999/api/v2/actors/case-actor",
+                "object": {
+                    "id": "urn:uuid:case1",
+                    "type": "VulnerabilityCase",
+                    "caseStatuses": "not-a-list",
+                },
+            },
+        )
+        event = CaseTimelineEvent.from_raw(raw)
+        assert event.em_state is None
+
     def test_missing_actor_yields_em_dash_label(self):
         raw = _camel_entry(payloadSnapshot={"type": "Create"})
         event = CaseTimelineEvent.from_raw(raw)

--- a/vultron/demo/report.py
+++ b/vultron/demo/report.py
@@ -128,7 +128,9 @@ def _candidate_dicts(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
 
     A ``ParticipantStatus``/``CaseStatus`` may be encoded directly in the
     payload snapshot or nested under an ``Add`` activity's ``object`` (and a
-    ``CaseStatus`` may itself nest under ``caseStatus``). This flattens those
+    ``CaseStatus`` may itself nest under ``caseStatus``). ``VulnerabilityCase``
+    payloads carry a ``caseStatuses`` array; each item in that list is also
+    added so EM/CS state on early rows is not missed. This flattens all those
     layers so dimension-state extraction can search all of them.
     """
     seen: list[dict[str, Any]] = []
@@ -139,6 +141,11 @@ def _candidate_dicts(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
         seen.append(node)
         for key in ("object", "object_", "caseStatus", "case_status"):
             _add(node.get(key))
+        for list_key in ("caseStatuses", "case_statuses"):
+            items = node.get(list_key)
+            if isinstance(items, list):
+                for item in items:
+                    _add(item)
 
     _add(snapshot)
     return seen


### PR DESCRIPTION
- Closes #1684

## Summary

Fixes `_candidate_dicts` in `vultron/demo/report.py` to iterate items of any
`caseStatuses`/`case_statuses` list on visited nodes, so EM/CS state carried
in `VulnerabilityCase` payloads is no longer missed on early timeline rows.

## Changes

- **`vultron/demo/report.py`**: `_candidate_dicts` now iterates
  `caseStatuses`/`case_statuses` list items, adding each to the candidate set
  for dimension-state extraction. Previously only scalar keys (`object`,
  `caseStatus`, etc.) were followed, so EM/CS state on `VulnerabilityCase`
  rows (e.g. the `offer_case_manager_role` row 0) was never reached.
- **`test/demo/test_report.py`**: 3 new tests — camelCase `caseStatuses` path
  extracts `em_state`/`pxa_state`, snake_case `case_statuses` key is also
  traversed, and a non-list `caseStatuses` value (corrupt data) is silently
  ignored.

## Verification

- All 69 unit tests pass (3 new)
- Black, flake8, mypy, pyright clean
- [x] AC-1: `_candidate_dicts` iterates `caseStatuses` array items