### PR TITLE
Report: map actor URIs to semantic names via payload-snapshot extraction

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1682.md
+++ b/plan/history/2607/implementation/ISSUE-1682.md
@@ -1,0 +1,24 @@
+---
+source: ISSUE-1682
+timestamp: '2026-07-27T14:12:41.578750+00:00'
+title: 'Report: map actor URIs to semantic names'
+type: implementation
+---
+
+## Issue #1682 — Report: map actor URIs to semantic names/roles instead of hex fragments
+
+Implemented URI-to-display-name resolution for the demo report tool. Actor URIs using UUID-based paths (e.g. `actors/9e580519-…`) now resolve to semantic names (e.g. "Vendor", "Finder") instead of hex-fragment labels like "A1e7 421f B727".
+
+### Changes
+
+- `collect_actor_names()` — scans all payload snapshots for AS2 actor objects with both `id` and `name` fields; builds URI→name map with sorted/deterministic first-writer-wins resolution
+- `_collect_actor_names_from_obj()` — recursive scanner for nested actor objects
+- `friendly_actor_name()` — updated with optional `actor_names` parameter; resolves from map before URI heuristic
+- `CaseTimelineEvent` — three new display name fields (`actor_display_name`, `target_display_name`, `activity_target_display_name`)
+- `actor_label` / `target_label` properties — prefer resolved display names
+- `_ACTOR_LIKE_TYPES` — added `Application` and `CaseActor` (F2 code review fix)
+- 14 new tests in `TestActorNameResolution`
+- `specs/demo-report.yaml` v1.3.0→v1.4.0: added DRPT-03-003 and DRPT-05-004
+- DEFER #1706: list-valued AS2 fields not yet scanned
+
+PR: <https://github.com/CERTCC/Vultron/pull/1708>

--- a/specs/demo-report.yaml
+++ b/specs/demo-report.yaml
@@ -6,7 +6,7 @@ description: >-
   report of who did what, with what activity, and in what order. Covers input discovery,
   the distilled intermediate data model, markdown and HTML rendering, the per-actor
   replica-presence matrix, friendly naming, and test requirements.
-version: 1.3.0
+version: 1.4.0
 scope:
 - prototype
 tags:
@@ -174,6 +174,29 @@ groups:
     rationale: >-
       Per IDEA-1286: prefer "Finder submitted report" over
       "https://…/actors/finder submitted urn:uuid:…".
+  - id: DRPT-03-003
+    priority: MUST
+    kind: project
+    statement: >-
+      The tool MUST build a URI-to-display-name map during timeline construction
+      by scanning all payload snapshots for actor objects (type
+      `Organization`, `Person`, `Service`, `Application`, `Group`, `Actor`,
+      `CaseActor`) that carry both an `id` (URI) and a non-empty `name` field.
+      Actor labels MUST use the resolved display name when available, and MUST
+      fall back to the URI path-segment heuristic only when no entry is found
+      in the map. This ensures that UUID-based actor URIs (e.g.
+      `actors/9e580519-…`) resolve to semantic names (e.g. "Vendor", "Finder")
+      rather than hex-fragment labels.
+    rationale: >-
+      Actor URIs may be UUID-based when the actor was created with a generated
+      identifier rather than a slug.  Without name resolution, `friendly_actor_name`
+      produces labels like "A1e7 421f B727" that violate DRPT-03-001's prohibition
+      on opaque identifiers.  The `name` field is present on inline actor objects
+      in wire payloads (e.g. `Organization` objects in `Invite` or `Accept`
+      activities), making payload-scan the correct extraction point.
+    relationships:
+    - rel_type: extends
+      spec_id: DRPT-03-001
   - id: DRPT-03-002
     priority: SHOULD
     kind: project
@@ -276,3 +299,16 @@ groups:
       A CLI smoke test MUST invoke the entry point against a tiny fixture
       directory, assert exit code 0, assert an output file is written, and
       assert that `--no-open` suppresses any browser launch.
+  - id: DRPT-05-004
+    priority: MUST
+    kind: project
+    statement: >-
+      Unit tests MUST cover actor name resolution (DRPT-03-003): assert that
+      `collect_actor_names` extracts URI-to-name mappings from inline actor
+      objects in payload snapshots, that `build_timeline` populates
+      `actor_display_name` on events whose actor URI is in the map, and that
+      `actor_label` returns the display name rather than a hex-fragment label
+      for UUID-based actor URIs.
+    relationships:
+    - rel_type: verifies
+      spec_id: DRPT-03-003

--- a/test/demo/test_report.py
+++ b/test/demo/test_report.py
@@ -30,6 +30,7 @@ from vultron.demo.report import (
     CaseTimelineEvent,
     ReportError,
     build_timeline,
+    collect_actor_names,
     discover_replicas,
     event_phrase,
     friendly_actor_name,
@@ -776,6 +777,232 @@ class TestCli:
         rc = main(["--output", str(out_file)])
         assert rc == 0
         assert out_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# DRPT-03 — actor name resolution from payload snapshots
+# ---------------------------------------------------------------------------
+
+#: A UUID-based actor URI that produces a hex-fragment label without name resolution.
+_UUID_ACTOR_URI = (
+    "http://vendor:7999/api/v2/actors/9e580519-a1e7-421f-b727-9c09af18815a"
+)
+
+
+def _entry_with_named_actor(**overrides):
+    """A camelCase ledger entry whose actor is an inline Organization with a name."""
+    return _camel_entry(
+        payloadSnapshot={
+            "type": "Accept",
+            "actor": {
+                "id": _UUID_ACTOR_URI,
+                "type": "Organization",
+                "name": "Vendor",
+            },
+            "object": {"id": "urn:uuid:rep1", "type": "VulnerabilityReport"},
+        },
+        **overrides,
+    )
+
+
+def _entry_with_uuid_actor(**overrides):
+    """A camelCase ledger entry whose actor is a bare UUID-based URI."""
+    return _camel_entry(
+        payloadSnapshot={
+            "type": "Accept",
+            "actor": _UUID_ACTOR_URI,
+            "object": {"id": "urn:uuid:rep2", "type": "VulnerabilityReport"},
+        },
+        **overrides,
+    )
+
+
+class TestActorNameResolution:
+    def test_collect_actor_names_extracts_id_name_pairs(self):
+        replicas = {"vendor": [_entry_with_named_actor()]}
+        names = collect_actor_names(replicas)
+        assert _UUID_ACTOR_URI in names
+        assert names[_UUID_ACTOR_URI] == "Vendor"
+
+    def test_collect_actor_names_ignores_objects_without_name(self):
+        entry = _camel_entry(
+            payloadSnapshot={
+                "type": "Accept",
+                "actor": {"id": _UUID_ACTOR_URI, "type": "Organization"},
+                "object": {"id": "urn:uuid:r", "type": "VulnerabilityReport"},
+            }
+        )
+        names = collect_actor_names({"vendor": [entry]})
+        assert _UUID_ACTOR_URI not in names
+
+    def test_collect_actor_names_first_writer_wins(self):
+        """When two entries carry the same URI, the first name is kept."""
+        e1 = _entry_with_named_actor(entryHash="a" * 64)
+        e2 = _camel_entry(
+            entryHash="b" * 64,
+            payloadSnapshot={
+                "type": "Accept",
+                "actor": {
+                    "id": _UUID_ACTOR_URI,
+                    "type": "Organization",
+                    "name": "SomeOtherName",
+                },
+                "object": {"id": "urn:uuid:r2", "type": "VulnerabilityReport"},
+            },
+        )
+        names = collect_actor_names({"vendor": [e1, e2]})
+        assert names[_UUID_ACTOR_URI] == "Vendor"
+
+    def test_collect_actor_names_empty_name_ignored(self):
+        entry = _camel_entry(
+            payloadSnapshot={
+                "type": "Accept",
+                "actor": {
+                    "id": _UUID_ACTOR_URI,
+                    "type": "Organization",
+                    "name": "   ",
+                },
+                "object": {"id": "urn:uuid:r", "type": "VulnerabilityReport"},
+            }
+        )
+        names = collect_actor_names({"vendor": [entry]})
+        assert _UUID_ACTOR_URI not in names
+
+    def test_friendly_actor_name_uses_actor_names_map(self):
+        names = {_UUID_ACTOR_URI: "Vendor"}
+        assert (
+            friendly_actor_name(_UUID_ACTOR_URI, actor_names=names) == "Vendor"
+        )
+
+    def test_friendly_actor_name_falls_back_without_map(self):
+        """Without actor_names, UUID-based URIs get a hex-fragment label, not 'Vendor'."""
+        label = friendly_actor_name(_UUID_ACTOR_URI)
+        assert label != "Vendor"
+
+    def test_friendly_actor_name_falls_back_for_unknown_uri(self):
+        names = {"http://other/actors/someone": "Someone"}
+        label = friendly_actor_name(
+            "http://vendor:7999/api/v2/actors/finder", actor_names=names
+        )
+        assert label == "Finder"
+
+    def test_build_timeline_populates_actor_display_name(self):
+        """actor_display_name is set when the actor URI appears in payloads."""
+        entry_with_name = _entry_with_named_actor(entryHash="a" * 64)
+        entry_uuid_only = _entry_with_uuid_actor(
+            entryHash="b" * 64, logIndex=1
+        )
+        replicas = {"vendor": [entry_with_name, entry_uuid_only]}
+        events = build_timeline(replicas)
+        by_hash = {e.entry_hash: e for e in events}
+        named = by_hash["a" * 64]
+        uuid_only = by_hash["b" * 64]
+        # Both events share the same actor URI; the name is resolved for both
+        # because collect_actor_names scans all entries before assigning.
+        assert named.actor_display_name == "Vendor"
+        assert uuid_only.actor_display_name == "Vendor"
+
+    def test_actor_label_uses_display_name_over_uri_heuristic(self):
+        """actor_label returns display name instead of hex-fragment label."""
+        entry = _entry_with_named_actor()
+        replicas = {"vendor": [entry]}
+        events = build_timeline(replicas)
+        assert events[0].actor_label == "Vendor"
+
+    def test_actor_label_fallback_when_no_display_name(self):
+        """When no display name is found, actor_label falls back to URI segment."""
+        entry = _camel_entry(
+            payloadSnapshot={
+                "type": "Accept",
+                "actor": "http://vendor:7999/api/v2/actors/finder",
+                "object": {"id": "urn:uuid:r", "type": "VulnerabilityReport"},
+            }
+        )
+        replicas = {"vendor": [entry]}
+        events = build_timeline(replicas)
+        assert events[0].actor_label == "Finder"
+
+    def test_build_timeline_populates_target_display_name(self):
+        """target_display_name is set when the target URI is a known actor."""
+        entry = _camel_entry(
+            payloadSnapshot={
+                "type": "Invite",
+                "actor": "http://vendor:7999/api/v2/actors/case-actor",
+                "object": {
+                    "id": _UUID_ACTOR_URI,
+                    "type": "Organization",
+                    "name": "Vendor",
+                },
+            }
+        )
+        replicas = {"vendor": [entry]}
+        events = build_timeline(replicas)
+        assert events[0].target_display_name == "Vendor"
+        assert events[0].target_label == "Vendor"
+
+    def test_build_timeline_populates_activity_target_display_name(self):
+        """activity_target_display_name is set when activity_target_ref is a known actor."""
+        entry = _camel_entry(
+            eventType="accept_invite_actor_to_case",
+            payloadSnapshot={
+                "type": "Accept",
+                "actor": "http://vendor:7999/api/v2/actors/case-actor",
+                "object": {
+                    "type": "Invite",
+                    "object": {
+                        "id": _UUID_ACTOR_URI,
+                        "type": "Organization",
+                        "name": "Vendor",
+                    },
+                    "target": {
+                        "id": "urn:uuid:case1",
+                        "type": "VulnerabilityCase",
+                    },
+                },
+            },
+        )
+        replicas = {"vendor": [entry]}
+        events = build_timeline(replicas)
+        # activity_target_ref is "urn:uuid:case1" — not an actor, so no display name.
+        # But the object (Vendor) should have its target_display_name set.
+        assert events[0].target_display_name == "Vendor"
+        # activity_target is a VulnerabilityCase URI, not an actor, so no display name.
+        assert events[0].activity_target_display_name is None
+
+    def test_build_timeline_populates_activity_target_display_name_uuid_actor(
+        self,
+    ):
+        """activity_target_display_name set when activity_target is a UUID actor."""
+        entry = _camel_entry(
+            eventType="offer_case_manager_role",
+            payloadSnapshot={
+                "type": "Offer",
+                "actor": "http://vendor:7999/api/v2/actors/case-actor",
+                "object": {
+                    "id": "urn:uuid:case1",
+                    "type": "VulnerabilityCase",
+                },
+                "target": {
+                    "id": _UUID_ACTOR_URI,
+                    "type": "Organization",
+                    "name": "Vendor",
+                    "attributedTo": _UUID_ACTOR_URI,
+                },
+            },
+        )
+        replicas = {"vendor": [entry]}
+        events = build_timeline(replicas)
+        assert events[0].activity_target_display_name == "Vendor"
+        assert events[0].target_label == "case → Vendor"
+
+    def test_summary_no_hex_fragments_with_uuid_actor(self):
+        """DRPT-03-001: summaries must not contain hex fragments for UUID actors."""
+        entry = _entry_with_named_actor()
+        replicas = {"vendor": [entry]}
+        events = build_timeline(replicas)
+        summary = events[0].summary
+        assert "9e580519" not in summary
+        assert "Vendor" in summary
 
 
 # ---------------------------------------------------------------------------

--- a/vultron/demo/report.py
+++ b/vultron/demo/report.py
@@ -168,6 +168,77 @@ def _dimension_state(
 
 
 # ---------------------------------------------------------------------------
+# Actor name extraction
+# ---------------------------------------------------------------------------
+
+#: ActivityStreams actor types whose ``name`` field, when present, maps the
+#: ``id`` to a human-readable display name (e.g. "Vendor", "Finder").
+_NAME_BEARING_TYPES = frozenset(
+    {
+        "Organization",
+        "Person",
+        "Service",
+        "Application",
+        "Group",
+        "Actor",
+        "CaseActor",
+    }
+)
+
+
+def _collect_actor_names_from_obj(
+    obj: Any,
+    out: dict[str, str],
+) -> None:
+    """Recursively scan ``obj`` for actor dicts carrying ``id`` + ``name``.
+
+    Populates ``out`` with ``{id: name}`` mappings for every actor-like object
+    found at any nesting level in the payload.  Only the first ``name`` seen for
+    a given ``id`` is recorded (first-writer-wins so earlier, more authoritative
+    entries dominate).
+    """
+    if not isinstance(obj, dict):
+        return
+    obj_type = obj.get("type") or obj.get("type_")
+    obj_id = obj.get("id") or obj.get("id_")
+    obj_name = obj.get("name")
+    if (
+        obj_type in _NAME_BEARING_TYPES
+        and obj_id
+        and obj_name
+        and isinstance(obj_id, str)
+        and isinstance(obj_name, str)
+        and obj_name.strip()
+        and obj_id not in out
+    ):
+        out[obj_id] = obj_name.strip()
+    # Recurse into common nested keys.
+    for key in ("actor", "object", "object_", "target", "origin"):
+        _collect_actor_names_from_obj(obj.get(key), out)
+
+
+def collect_actor_names(
+    replicas: dict[str, list[dict[str, Any]]],
+) -> dict[str, str]:
+    """Build a URI→display-name map by scanning all raw ledger entries.
+
+    Walks every payload snapshot in ``replicas`` looking for actor objects
+    that carry both an ``id`` (URI) and a ``name`` field.  Returns a
+    ``{uri: name}`` mapping used to resolve UUID-based actor URIs to semantic
+    labels (e.g. "Vendor", "Finder") in the rendered report.
+    """
+    names: dict[str, str] = {}
+    for actor_key in sorted(replicas):
+        for raw in replicas[actor_key]:
+            payload = _first(
+                raw, "payload_snapshot", "payloadSnapshot", default={}
+            )
+            if isinstance(payload, dict):
+                _collect_actor_names_from_obj(payload, names)
+    return names
+
+
+# ---------------------------------------------------------------------------
 # Friendly naming (DRPT-03)
 # ---------------------------------------------------------------------------
 
@@ -176,7 +247,16 @@ _WRAPPER_TYPES = frozenset({"Accept", "Reject", "Offer", "Invite"})
 
 #: Wire types that resolve to actor names; use friendly_actor_name on their id instead of a generic noun.
 _ACTOR_LIKE_TYPES = frozenset(
-    {"Organization", "Actor", "Service", "Person", "Group", "CaseParticipant"}
+    {
+        "Organization",
+        "Actor",
+        "Service",
+        "Application",
+        "Person",
+        "Group",
+        "CaseParticipant",
+        "CaseActor",
+    }
 )
 
 #: Wire object type → friendly noun for event summaries and the target column.
@@ -264,14 +344,21 @@ def _looks_like_hex_token(token: str) -> bool:
     )
 
 
-def friendly_actor_name(actor_uri: str | None) -> str:
+def friendly_actor_name(
+    actor_uri: str | None,
+    actor_names: dict[str, str] | None = None,
+) -> str:
     """Return a short, friendly actor label derived from an actor URI.
 
-    Uses the last path segment of the URI (``.../actors/finder`` → "Finder").
-    Returns an em dash when no acting actor is recorded (e.g. genesis entries).
+    Checks ``actor_names`` first (a URI→display-name map built from payload
+    snapshots); falls back to the last URI path segment when no entry is found
+    (``…/actors/finder`` → "Finder").  Returns an em dash when no acting actor
+    is recorded (e.g. genesis entries).
     """
     if not actor_uri:
         return "—"
+    if actor_names and actor_uri in actor_names:
+        return actor_names[actor_uri]
     segment = actor_uri.rstrip("/").rsplit("/", 1)[-1]
     return _titleize(segment) or segment
 
@@ -366,10 +453,13 @@ class CaseTimelineEvent(BaseModel):
     disposition: str = "recorded"
     event_type: str = ""
     actor_uri: str | None = None
+    actor_display_name: str | None = None
     target_ref: str | None = None
     target_type: str | None = None
+    target_display_name: str | None = None
     activity_target_ref: str | None = None
     activity_target_type: str | None = None
+    activity_target_display_name: str | None = None
     received_at: str | None = None
     rm_state: str | None = None
     em_state: str | None = None
@@ -474,20 +564,46 @@ class CaseTimelineEvent(BaseModel):
 
     @property
     def actor_label(self) -> str:
-        """Friendly acting-actor name (DRPT-03-001)."""
+        """Friendly acting-actor name (DRPT-03-001).
+
+        Returns the display name from the wire payload when available (resolves
+        UUID-based actor URIs to names like "Vendor"), otherwise falls back to
+        the URI path-segment heuristic.
+        """
+        if self.actor_display_name:
+            return self.actor_display_name
         return friendly_actor_name(self.actor_uri)
 
     @property
     def target_label(self) -> str | None:
         """Friendly target label; ``object → destination`` when both are present.
 
-        Actor-like object types (Organization, …) resolve to a name via the
-        URI rather than a generic type noun.
+        Actor-like object types (Organization, …) resolve to a display name
+        when one was extracted from payload snapshots; otherwise falls back to
+        the URI path-segment heuristic via :func:`friendly_actor_name`.
         """
-        obj_label = friendly_object_label(self.target_type, self.target_ref)
-        dest_label = friendly_object_label(
-            self.activity_target_type, self.activity_target_ref
-        )
+        obj_label: str | None
+        dest_label: str | None
+        # Prefer the pre-resolved display name (covers UUID-based URIs and the
+        # None-type fallback path in friendly_object_label).
+        if self.target_display_name:
+            obj_label = self.target_display_name
+        elif self.target_type in _ACTOR_LIKE_TYPES:
+            obj_label = friendly_actor_name(self.target_ref)
+        else:
+            obj_label = friendly_object_label(
+                self.target_type, self.target_ref
+            )
+
+        if self.activity_target_display_name:
+            dest_label = self.activity_target_display_name
+        elif self.activity_target_type in _ACTOR_LIKE_TYPES:
+            dest_label = friendly_actor_name(self.activity_target_ref)
+        else:
+            dest_label = friendly_object_label(
+                self.activity_target_type, self.activity_target_ref
+            )
+
         if obj_label and dest_label:
             return f"{obj_label} → {dest_label}"
         return obj_label or dest_label
@@ -586,7 +702,14 @@ def build_timeline(
     Entries with ``disposition != "recorded"`` are silently skipped; they are
     local-only correlation markers with empty payloads that must not appear in
     the report (DRPT-02-007).
+
+    Actor URIs are resolved to display names extracted from inline actor objects
+    in the payload snapshots (e.g. Organization objects carrying a ``name``
+    field).  This resolves UUID-based actor URIs (which produce hex-fragment
+    labels) to semantic names like "Vendor" or "Finder".
     """
+    actor_names = collect_actor_names(replicas)
+
     by_key: dict[str, CaseTimelineEvent] = {}
     presence: dict[str, set[str]] = {}
 
@@ -608,6 +731,17 @@ def build_timeline(
     events: list[CaseTimelineEvent] = []
     for key, event in by_key.items():
         event.present_in = sorted(presence[key])
+        if event.actor_uri and event.actor_uri in actor_names:
+            event.actor_display_name = actor_names[event.actor_uri]
+        if event.target_ref and event.target_ref in actor_names:
+            event.target_display_name = actor_names[event.target_ref]
+        if (
+            event.activity_target_ref
+            and event.activity_target_ref in actor_names
+        ):
+            event.activity_target_display_name = actor_names[
+                event.activity_target_ref
+            ]
         events.append(event)
 
     # Group by case first so distinct cases discovered under one input


### PR DESCRIPTION
- Closes #1682

## Summary

Actor URIs using UUID-based paths (e.g. `actors/9e580519-a1e7-421f-b727-9c09af18815a`)
previously produced hex-fragment labels like "A1e7 421f B727" in the case timeline
report. This PR resolves them to semantic display names (e.g. "Vendor", "Finder") by
extracting actor names from inline actor objects in payload snapshots.

## Changes

- **`vultron/demo/report.py`**:
  - Added `_NAME_BEARING_TYPES` — AS2 actor types that carry meaningful `name` fields
  - Added `_collect_actor_names_from_obj()` — recursive scanner that extracts
    `{id: name}` from actor-like payload objects
  - Added `collect_actor_names()` — public function that builds the URI→name map by
    scanning all raw replicas (sorted for deterministic first-writer-wins resolution)
  - Updated `friendly_actor_name()` — added optional `actor_names` dict parameter;
    returns the resolved name when the URI is in the map
  - Added `actor_display_name`, `target_display_name`, `activity_target_display_name`
    fields to `CaseTimelineEvent` — populated during `build_timeline`
  - Updated `actor_label` property — uses `actor_display_name` before falling back
    to the URI heuristic
  - Updated `target_label` property — prefers pre-resolved display names for both
    the primary object and the activity target
  - Added `Application` and `CaseActor` to `_ACTOR_LIKE_TYPES` — consistent with
    the new `_NAME_BEARING_TYPES` set

- **`test/demo/test_report.py`**:
  - Added `TestActorNameResolution` class (14 tests) covering:
    - `collect_actor_names` extraction, empty-name filtering, first-writer-wins
    - `friendly_actor_name` with/without actor_names map
    - `build_timeline` populating all three display name fields
    - `actor_label` returning display name over hex fragment
    - `target_label` and `activity_target_display_name` resolution
    - Summary containing no hex fragments for UUID actors

- **`specs/demo-report.yaml`** (v1.2.0 → v1.4.0):
  - Absorbed v1.3.0 spec changes from plan PRs on this branch:
    - DRPT-02-007 (filter `disposition=rejected` entries from build_timeline)
    - DRPT-04-006 (per-case time-range display — spec entry; implementation in #1697)
  - Added DRPT-03-003 requiring URI-to-display-name map construction
  - Added DRPT-05-004 requiring test coverage of the name resolution feature

## DEFER

- #1706: `collect_actor_names` does not scan list-valued AS2 fields (no current
  demo scenario produces them; trivially additive when needed)
- #1697: DRPT-04-006 per-case time-range display (spec added here; implementation tracked separately)

## Test plan

- [x] `uv run pytest test/demo/test_report.py -m ""` → 80 passed
- [x] `uv run black`, `flake8`, `mypy`, `pyright` all clean
- [x] Full suite: 5436 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)