### PR TITLE
Wire EvaluateCasePriority into PrioritizationCallOutBundle

### DIFF
--- a/notes/bt-fuzzer-rm-prioritization.md
+++ b/notes/bt-fuzzer-rm-prioritization.md
@@ -158,4 +158,29 @@ models the process of deciding whether to accept (engage with) or defer
   `create_engage_case_tree`), after `TransitionParticipantRMtoAccepted` and
   the sender-side subtree
 
+### `EvaluateCasePriority`
+
+- **Node name**: `EvaluateCasePriority`
+- **btz type**: `AlwaysSucceed` (p=1.00)
+- **Source file**: `vultron/demo/fuzzer/report_management/prioritize.py`
+- **Parent tree**: `RMPrioritizeBt`
+- **Semantic function**: Decision — evaluate case priority to determine
+  whether the local actor should engage (accept) or defer the case. This
+  is the SSVC integration seam: a production backend replaces this stub
+  with a real priority evaluator.
+- **Input dependency**: Human decision / Policy engine; SSVC scoring,
+  asset inventory lookups, and policy-based engage/defer decisions.
+- **Notes**: Always succeeds in simulation (always engage); SSVC
+  evaluation deferred to PROTO-05-001.
+- **Automation potential**: **High** — SSVC scoring, asset inventory
+  lookups, and policy-based engage/defer decisions are fully automatable.
+- **New-arch cross-ref**: `vultron.demo.fuzzer.report_management.prioritize.EvaluateCasePriority`
+- **Call-out point shape**: Evaluator — `EvaluatorCallOutPoint`; outputs
+  `evaluate_case_priority_verdict: str` on SUCCESS.
+- **Factory-fn placement**:
+  `vultron.core.behaviors.report.prioritize_tree.create_prioritize_subtree` —
+  injected via `bundle.evaluate_priority_factory("EvaluateCasePriority")`
+  in the engage path (first child of `EngageCaseTriggerBT` Sequence),
+  replacing the former hardcoded direct instantiation (BT-18-004).
+
 ---

--- a/plan/history/2607/implementation/ISSUE-1671.md
+++ b/plan/history/2607/implementation/ISSUE-1671.md
@@ -1,0 +1,22 @@
+---
+source: ISSUE-1671
+timestamp: '2026-07-27T15:06:14.197630+00:00'
+title: Wire EvaluateCasePriority into PrioritizationCallOutBundle
+type: implementation
+---
+
+## Issue #1671 — Wire EvaluateCasePriority into PrioritizationCallOutBundle
+
+Completed wiring of `EvaluateCasePriority` as a proper injectable call-out point
+in `PrioritizationCallOutBundle` per BT-18-004 and BT-23-003.
+
+Changes:
+
+- Added `EvaluateCasePriority` fuzzer stub to `prioritize.py` (SSVC seam, PROTO-05-001)
+- Added `evaluate_priority_factory` field to `PrioritizationCallOutBundle` with
+  `AlwaysSucceed` deterministic default and `_stochastic_evaluate_priority` in stochastic singleton
+- Replaced hardcoded `EvaluateCasePriority(case_id=case_id)` in `create_prioritize_subtree`
+  with `bundle.evaluate_priority_factory("EvaluateCasePriority")`
+- Added factory injection test (AC-4) and updated defer test from monkeypatch to factory injection
+
+PR: <https://github.com/CERTCC/Vultron/pull/1710>

--- a/test/core/behaviors/report/test_prioritize_tree.py
+++ b/test/core/behaviors/report/test_prioritize_tree.py
@@ -700,26 +700,33 @@ def test_prioritize_subtree_custom_on_defer_factory_used(
 
 
 def test_prioritize_subtree_defers_when_engage_path_fails(
-    monkeypatch,
     bridge,
     datalayer,
     actor_id,
     trigger_activity,
     case_with_manager,
 ):
-    """PrioritizeBT falls back to defer when engage preconditions fail."""
-    from vultron.core.behaviors.report import prioritize_tree
+    """PrioritizeBT falls back to defer when evaluate_priority_factory returns FAILURE."""
+    import py_trees
 
-    monkeypatch.setattr(
-        prioritize_tree.EvaluateCasePriority,
-        "update",
-        lambda self: Status.FAILURE,
+    from vultron.demo.fuzzer.bundles.prioritization import (
+        PrioritizationCallOutBundle,
+    )
+
+    def _always_fail(name: str) -> py_trees.behaviour.Behaviour:
+        from vultron.demo.fuzzer.base import AlwaysFail
+
+        return AlwaysFail(name)
+
+    bundle = PrioritizationCallOutBundle(
+        evaluate_priority_factory=_always_fail,  # type: ignore[arg-type]
     )
 
     tree = create_prioritize_subtree(
         case_id=case_with_manager.id_,
         actor_id=actor_id,
         trigger_activity=trigger_activity,
+        call_out=bundle,
     )
     result = bridge.execute_with_setup(tree=tree, actor_id=actor_id)
 

--- a/test/core/behaviors/report/test_prioritize_tree_factory_injection.py
+++ b/test/core/behaviors/report/test_prioritize_tree_factory_injection.py
@@ -13,10 +13,10 @@
 #  U.S. Patent and Trademark Office by Carnegie Mellon University
 """Factory injection tests for create_prioritize_subtree (BT-18-004/BT-23-003).
 
-Verifies the two Phase 2 reserved factory parameters (enough_info_factory,
-gather_info_factory) are accepted via bundle without error.  The two wired
-params (on_accept_factory, on_defer_factory) are covered by the existing
-test_prioritize_tree.py tests.
+Verifies that evaluate_priority_factory is injected into the engage path and
+that custom factories replace the default node in the tree (AC-4 for #1671).
+Also verifies the two Phase 2 reserved factory parameters (enough_info_factory,
+gather_info_factory) are accepted via bundle without error.
 """
 
 import py_trees
@@ -41,6 +41,36 @@ def _marker_factory(label):
         return _Marker(name=label)
 
     return factory
+
+
+def test_evaluate_priority_factory_replaces_default_node():
+    """Custom evaluate_priority_factory replaces the default node in the engage path (AC-4)."""
+    CUSTOM_LABEL = "CustomEvaluator-sentinel"
+    bundle = PrioritizationCallOutBundle(
+        evaluate_priority_factory=_marker_factory(CUSTOM_LABEL),  # type: ignore[arg-type]
+    )
+    tree = create_prioritize_subtree(
+        case_id=CASE_ID,
+        actor_id=ACTOR_ID,
+        call_out=bundle,
+    )
+    # Engage path is tree.children[0]; its first child is the evaluate_priority node
+    engage_path = tree.children[0]
+    assert engage_path.children[0].name == CUSTOM_LABEL
+
+
+def test_evaluate_priority_factory_default_is_always_succeed():
+    """Default evaluate_priority_factory produces an AlwaysSucceed node named EvaluateCasePriority."""
+    from vultron.demo.fuzzer.base import AlwaysSucceed
+
+    tree = create_prioritize_subtree(
+        case_id=CASE_ID,
+        actor_id=ACTOR_ID,
+    )
+    engage_path = tree.children[0]
+    node = engage_path.children[0]
+    assert node.name == "EvaluateCasePriority"
+    assert isinstance(node, AlwaysSucceed)
 
 
 def test_enough_info_factory_accepted():

--- a/vultron/core/behaviors/report/prioritize_tree.py
+++ b/vultron/core/behaviors/report/prioritize_tree.py
@@ -64,7 +64,6 @@ from vultron.core.behaviors.case.nodes.update import (
 )
 from vultron.core.behaviors.report.nodes import (
     CheckParticipantExists,
-    EvaluateCasePriority,
     TransitionParticipantRMtoAccepted,
     TransitionParticipantRMtoDeferred,
 )
@@ -249,7 +248,7 @@ def create_prioritize_subtree(
         name="EngagePath",
         memory=False,
         children=[
-            EvaluateCasePriority(case_id=case_id),
+            bundle.evaluate_priority_factory("EvaluateCasePriority"),
             engage_case_trigger_bt(
                 case_id=case_id,
                 actor_id=actor_id,

--- a/vultron/core/behaviors/report/prioritize_tree.py
+++ b/vultron/core/behaviors/report/prioritize_tree.py
@@ -41,9 +41,9 @@ Structure:
     ├─ GuardedCommitCaseLedgerEntryBT         # Record receipt before effects (CLP-10-006)
     └─ TransitionParticipantRMtoDeferred   # Update RM state to DEFERRED
 
-Note: EvaluateCasePriority (in nodes.py) is the stub node for the outgoing
-direction — when the local actor decides whether to engage or defer. It is
-not used in these receive-side trees but is exported for future use.
+EvaluateCasePriority is now injected via bundle.evaluate_priority_factory
+in create_prioritize_subtree (BT-18-004). The core class in
+nodes/conditions.py is no longer instantiated directly here.
 """
 
 import logging

--- a/vultron/demo/fuzzer/bundles/prioritization.py
+++ b/vultron/demo/fuzzer/bundles/prioritization.py
@@ -18,10 +18,11 @@ Provides :class:`PrioritizationCallOutBundle` plus the pre-built singletons
 
 Ceiling/floor mapping (BT-23-002):
 
-- ``on_accept_factory``        — OnAccept               (p=1.0) → AlwaysSucceed
-- ``on_defer_factory``         — OnDefer                (p=1.0) → AlwaysSucceed
-- ``enough_info_factory``      — EnoughPrioritizationInfo (p=0.75) → AlwaysSucceed
-- ``gather_info_factory``      — GatherPrioritizationInfo (p=0.90) → AlwaysSucceed
+- ``evaluate_priority_factory`` — EvaluateCasePriority  (p=1.0) → AlwaysSucceed
+- ``on_accept_factory``         — OnAccept               (p=1.0) → AlwaysSucceed
+- ``on_defer_factory``          — OnDefer                (p=1.0) → AlwaysSucceed
+- ``enough_info_factory``       — EnoughPrioritizationInfo (p=0.75) → AlwaysSucceed
+- ``gather_info_factory``       — GatherPrioritizationInfo (p=0.90) → AlwaysSucceed
 """
 
 from __future__ import annotations
@@ -37,6 +38,14 @@ def _always_succeed(name: str) -> py_trees.behaviour.Behaviour:
     from vultron.demo.fuzzer.base import AlwaysSucceed
 
     return AlwaysSucceed(name)
+
+
+def _stochastic_evaluate_priority(name: str) -> py_trees.behaviour.Behaviour:
+    from vultron.demo.fuzzer.report_management.prioritize import (
+        EvaluateCasePriority,
+    )
+
+    return EvaluateCasePriority(name)
 
 
 def _stochastic_on_accept(name: str) -> py_trees.behaviour.Behaviour:
@@ -75,6 +84,9 @@ class PrioritizationCallOutBundle:
     :func:`~vultron.core.behaviors.report.prioritize_tree.create_prioritize_subtree`.
     """
 
+    evaluate_priority_factory: CallOutBackendFactory = field(
+        default=_always_succeed  # type: ignore[assignment]
+    )
     on_accept_factory: CallOutBackendFactory = field(
         default=_always_succeed  # type: ignore[assignment]
     )
@@ -93,6 +105,7 @@ PRIORITIZATION_DETERMINISTIC = PrioritizationCallOutBundle()
 """Deterministic bundle: all nodes use AlwaysSucceed (BT-23-001, BT-23-002)."""
 
 PRIORITIZATION_STOCHASTIC = PrioritizationCallOutBundle(
+    evaluate_priority_factory=_stochastic_evaluate_priority,  # type: ignore[arg-type]
     on_accept_factory=_stochastic_on_accept,  # type: ignore[arg-type]
     on_defer_factory=_stochastic_on_defer,  # type: ignore[arg-type]
     enough_info_factory=_stochastic_enough_info,  # type: ignore[arg-type]

--- a/vultron/demo/fuzzer/report_management/prioritize.py
+++ b/vultron/demo/fuzzer/report_management/prioritize.py
@@ -138,6 +138,31 @@ class OnAccept(ActuatorCallOutPoint, AlwaysSucceed):
     """
 
 
+class EvaluateCasePriority(EvaluatorCallOutPoint, AlwaysSucceed):
+    """Evaluate whether to engage or defer a case using prioritization policy.
+
+    Semantic function:
+        Decision — evaluate case priority to determine whether the local
+        actor should engage (accept) or defer the case.  This is the SSVC
+        integration seam: a production backend replaces this stub with a
+        real priority evaluator.
+
+    Blackboard contract (BT-18-001):
+      Input keys:  (none — evaluates case context from construction time)
+      Output keys: evaluate_case_priority_verdict: str  (SUCCESS only)
+
+    Input category: Human decision / Policy engine.
+
+    Success probability: 1.00 (``AlwaysSucceed``): always engage in the
+    stochastic simulation (SSVC deferred — PROTO-05-001).
+
+    Automation potential: **High** — SSVC scoring, asset inventory lookups,
+    and policy-based engage/defer decisions are fully automatable.
+    """
+
+    output_keys = {"evaluate_case_priority_verdict": str}
+
+
 class OnDefer(ActuatorCallOutPoint, AlwaysSucceed):
     """Execute site-specific tasks when a report is deferred.
 


### PR DESCRIPTION
- Closes #1671

## Summary

Wires `EvaluateCasePriority` into `PrioritizationCallOutBundle` as a
proper injectable call-out point per BT-18-004 and BT-23-003.

Previously, `create_prioritize_subtree` hardcoded
`EvaluateCasePriority(case_id=case_id)` directly in the engage path,
bypassing the bundle injection seam. This change completes the bundle
coverage for the prioritization domain.

## Changes

- **`vultron/demo/fuzzer/report_management/prioritize.py`** — adds
  `EvaluateCasePriority` fuzzer stub (`EvaluatorCallOutPoint`,
  `AlwaysSucceed`, p=1.0; SSVC seam per PROTO-05-001)
- **`vultron/demo/fuzzer/bundles/prioritization.py`** — adds
  `evaluate_priority_factory` field to `PrioritizationCallOutBundle`
  (deterministic default: `AlwaysSucceed`) and
  `_stochastic_evaluate_priority` factory wired into
  `PRIORITIZATION_STOCHASTIC`
- **`vultron/core/behaviors/report/prioritize_tree.py`** — replaces
  hardcoded `EvaluateCasePriority(case_id=case_id)` with
  `bundle.evaluate_priority_factory("EvaluateCasePriority")`; removes
  now-unused direct import
- **`test/core/behaviors/report/test_prioritize_tree_factory_injection.py`**
  — adds `test_evaluate_priority_factory_replaces_default_node` (AC-4)
  and `test_evaluate_priority_factory_default_is_always_succeed`
- **`test/core/behaviors/report/test_prioritize_tree.py`** — updates
  defer test to use factory injection (`AlwaysFail` bundle) instead of
  monkeypatching the removed direct import

## Verification

- [x] `uv run pytest test/core/behaviors/report/test_prioritize_tree_factory_injection.py` — 5 pass
- [x] `uv run pytest test/core/behaviors/report/test_prioritize_tree.py` — 18 pass
- [x] `uv run pytest --tb=short` — full suite clean (5438 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)