### PR TITLE
feat(demo): in-process stochastic bundle demo scenario

### DIFF
--- a/notes/call-out-configuration.md
+++ b/notes/call-out-configuration.md
@@ -41,7 +41,7 @@ There are three logical modes for call-out point backends:
 | Mode | Backends used | When used |
 |---|---|---|
 | `DETERMINISTIC` | `AlwaysSucceed` / `AlwaysFail` (ceiling/floor of stochastic p) | Default for all demo and test scenarios |
-| `STOCHASTIC` | Probabilistic fuzzer classes (`UsuallySucceed`, `ProbablyFail`, …) | Opt-in for simulation / fuzz-testing scenarios |
+| `STOCHASTIC` | Probabilistic fuzzer classes (`UsuallySucceed`, `ProbablyFail`, …) | Opt-in for simulation / fuzz-testing scenarios. Canonical entry point: `vultron/demo/fuzzer/stochastic_demo.py` (run via `python -m vultron.demo.fuzzer.stochastic_demo`). |
 | `REAL` | Production implementations (data lookups, policy engines, agents) | Deferred to FUZZ-08d through FUZZ-08h |
 
 **Test vs. demo** is a call-context distinction, not a mode distinction.

--- a/plan/history/2607/implementation/ISSUE-1672.md
+++ b/plan/history/2607/implementation/ISSUE-1672.md
@@ -1,0 +1,16 @@
+---
+source: ISSUE-1672
+timestamp: '2026-07-27T15:16:59.074538+00:00'
+title: In-process STOCHASTIC bundle demo scenario
+type: implementation
+---
+
+## Issue #1672 — In-process STOCHASTIC bundle demo scenario with call-out point outcome logging
+
+Added `vultron/demo/fuzzer/stochastic_demo.py` and 4 companion tests in `test/demo/fuzzer/test_stochastic_demo.py`.
+
+The demo exercises STOCHASTIC call-out point bundles across validation, prioritization, and embargo domains in a single in-process run. Each tick logs node name + SUCCESS/FAILURE. The embargo domain additionally runs the full ManageEmbargoBT tree via BTBridge + in-memory SqliteDataLayer.
+
+Satisfies all 6 acceptance criteria including issue #1152 AC-4 (probabilistic fuzzer backend with outcome logging).
+
+PR: <https://github.com/CERTCC/Vultron/pull/1711>

--- a/test/demo/fuzzer/test_stochastic_demo.py
+++ b/test/demo/fuzzer/test_stochastic_demo.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""Tests for the in-process STOCHASTIC bundle demo scenario (issue #1672 AC-4).
+
+Verifies that :func:`run_stochastic_demo` runs without error and produces
+outcome log lines in the expected format.
+"""
+
+import logging
+
+import py_trees
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clear_blackboard():
+    py_trees.blackboard.Blackboard.storage.clear()
+    yield
+    py_trees.blackboard.Blackboard.storage.clear()
+
+
+def test_stochastic_demo_runs_without_error():
+    """run_stochastic_demo() completes without raising an exception (AC-4)."""
+    from vultron.demo.fuzzer.stochastic_demo import run_stochastic_demo
+
+    run_stochastic_demo(n_ticks=2)
+
+
+def test_stochastic_demo_produces_outcome_log_lines(caplog):
+    """run_stochastic_demo() emits call-out point outcome lines (AC-2, AC-4).
+
+    Each outcome line must contain:
+    - the literal string 'call-out point outcome'
+    - a node= segment
+    - a result= segment with SUCCESS, FAILURE, or INVALID
+    """
+    from vultron.demo.fuzzer.stochastic_demo import run_stochastic_demo
+
+    with caplog.at_level(
+        logging.INFO, logger="vultron.demo.fuzzer.stochastic_demo"
+    ):
+        run_stochastic_demo(n_ticks=2)
+
+    outcome_lines = [
+        r.message
+        for r in caplog.records
+        if "call-out point outcome" in r.message
+    ]
+    assert len(outcome_lines) > 0, "Expected at least one outcome log line"
+
+    for line in outcome_lines:
+        assert "node=" in line, f"Missing node= in: {line}"
+        assert "result=" in line, f"Missing result= in: {line}"
+        result_value = line.split("result=")[-1].strip()
+        assert result_value in {
+            "SUCCESS",
+            "FAILURE",
+            "INVALID",
+        }, f"Unexpected result value in: {line}"
+
+
+def test_stochastic_demo_covers_all_three_domains(caplog):
+    """Outcome lines span validation, prioritization, and embargo domains (AC-1)."""
+    from vultron.demo.fuzzer.stochastic_demo import run_stochastic_demo
+
+    with caplog.at_level(
+        logging.INFO, logger="vultron.demo.fuzzer.stochastic_demo"
+    ):
+        run_stochastic_demo(n_ticks=1)
+
+    messages = " ".join(r.message for r in caplog.records)
+
+    # Validation domain nodes
+    assert "EvaluateReportCredibility" in messages
+    assert "EvaluateReportValidity" in messages
+
+    # Prioritization domain nodes
+    assert "OnAccept" in messages or "OnDefer" in messages
+
+    # Embargo domain nodes
+    assert "ExitEmbargoWhenDeployed" in messages
+    assert "WantToProposeEmbargo" in messages
+
+
+def test_stochastic_demo_module_importable():
+    """Module is importable as vultron.demo.fuzzer.stochastic_demo (AC-3)."""
+    import importlib
+
+    mod = importlib.import_module("vultron.demo.fuzzer.stochastic_demo")
+    assert hasattr(mod, "run_stochastic_demo")
+    assert callable(mod.run_stochastic_demo)

--- a/vultron/demo/fuzzer/stochastic_demo.py
+++ b/vultron/demo/fuzzer/stochastic_demo.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 Carnegie Mellon University and Contributors.
+#  - see Contributors.md for a full list of Contributors
+#  - see ContributionInstructions.md for information on how you can Contribute to this project
+#  Vultron Multiparty Coordinated Vulnerability Disclosure Protocol Prototype is
+#  licensed under a MIT (SEI)-style license, please see LICENSE.md distributed
+#  with this Software or contact permission@sei.cmu.edu for full terms.
+#  Created, in part, with funding and support from the United States Government
+#  (see Acknowledgments file). This program may include and/or can make use of
+#  certain third party source code, object code, documentation and other files
+#  ("Third Party Software"). See LICENSE.md for more details.
+#  Carnegie Mellon®, CERT® and CERT Coordination Center® are registered in the
+#  U.S. Patent and Trademark Office by Carnegie Mellon University
+"""In-process STOCHASTIC bundle demo scenario (BT-23-001, BT-23-003).
+
+Exercises STOCHASTIC call-out point bundles across validation, prioritization,
+and embargo domains in a single in-process run.  No HTTP server required.
+
+For each domain:
+
+1. All call-out point nodes from the STOCHASTIC bundle singleton are
+   instantiated and ticked ``N_TICKS`` times.  Each tick logs the node name
+   and SUCCESS/FAILURE result so the probabilistic spread is visible.
+
+2. The embargo domain additionally runs the full ``ManageEmbargoBT`` tree
+   (10 call-out nodes) via the BTBridge + an in-memory DataLayer to show
+   the complete tree execution path.
+
+Run as a module::
+
+    python -m vultron.demo.fuzzer.stochastic_demo
+
+Or import :func:`run_stochastic_demo` to call it programmatically.
+
+References
+----------
+- notes/call-out-configuration.md — three-mode model and bundle design
+- specs/behavior-tree-integration.yaml — BT-23-001, BT-23-003
+- Issue #1672 — AC-1 through AC-6
+"""
+
+from __future__ import annotations
+
+import logging
+
+import py_trees
+
+logger = logging.getLogger(__name__)
+
+# Number of ticks per call-out point node in the standalone tick loop.
+N_TICKS = 5
+
+# Actor / resource IDs used in the full-tree embargo run.
+_DEMO_ACTOR_ID = "https://example.org/actors/demo-actor"
+_DEMO_CASE_ID = "https://example.org/cases/demo-case-001"
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _log_outcome(node: py_trees.behaviour.Behaviour, tick: int) -> None:
+    logger.info(
+        "call-out point outcome | tick=%d | node=%s | result=%s",
+        tick,
+        node.name,
+        node.status.value,
+    )
+
+
+def _tick_node(node: py_trees.behaviour.Behaviour, tick: int) -> None:
+    node.tick_once()
+    _log_outcome(node, tick)
+
+
+def _run_domain_nodes(
+    domain: str,
+    nodes: list[py_trees.behaviour.Behaviour],
+    n_ticks: int = N_TICKS,
+) -> None:
+    """Setup and tick every node in a domain for n_ticks iterations."""
+    logger.info("--- domain: %s (%d call-out points) ---", domain, len(nodes))
+    for node in nodes:
+        node.setup()
+    for tick in range(1, n_ticks + 1):
+        for node in nodes:
+            # Reset to INVALID so each tick is independent
+            node.stop(py_trees.common.Status.INVALID)
+            _tick_node(node, tick)
+
+
+# ---------------------------------------------------------------------------
+# Domain-specific node lists
+# ---------------------------------------------------------------------------
+
+
+def _validation_nodes() -> list[py_trees.behaviour.Behaviour]:
+    from vultron.demo.fuzzer.bundles.validation import VALIDATION_STOCHASTIC
+
+    return [
+        VALIDATION_STOCHASTIC.credibility_factory("EvaluateReportCredibility"),
+        VALIDATION_STOCHASTIC.validity_factory("EvaluateReportValidity"),
+        VALIDATION_STOCHASTIC.gather_info_factory("GatherValidationInfo"),
+    ]
+
+
+def _prioritization_nodes() -> list[py_trees.behaviour.Behaviour]:
+    from vultron.demo.fuzzer.bundles.prioritization import (
+        PRIORITIZATION_STOCHASTIC,
+    )
+
+    return [
+        PRIORITIZATION_STOCHASTIC.on_accept_factory("OnAccept"),
+        PRIORITIZATION_STOCHASTIC.on_defer_factory("OnDefer"),
+        PRIORITIZATION_STOCHASTIC.enough_info_factory(
+            "EnoughPrioritizationInfo"
+        ),
+        PRIORITIZATION_STOCHASTIC.gather_info_factory(
+            "GatherPrioritizationInfo"
+        ),
+    ]
+
+
+def _embargo_nodes() -> list[py_trees.behaviour.Behaviour]:
+    from vultron.demo.fuzzer.bundles.embargo import EMBARGO_STOCHASTIC
+
+    return [
+        EMBARGO_STOCHASTIC.exit_embargo_when_deployed_factory(
+            "ExitEmbargoWhenDeployed"
+        ),
+        EMBARGO_STOCHASTIC.exit_embargo_when_fix_ready_factory(
+            "ExitEmbargoWhenFixReady"
+        ),
+        EMBARGO_STOCHASTIC.exit_embargo_for_other_reason_factory(
+            "ExitEmbargoForOtherReason"
+        ),
+        EMBARGO_STOCHASTIC.stop_proposing_embargo_factory(
+            "StopProposingEmbargo"
+        ),
+        EMBARGO_STOCHASTIC.select_embargo_offer_terms_factory(
+            "SelectEmbargoOfferTerms"
+        ),
+        EMBARGO_STOCHASTIC.want_to_propose_embargo_factory(
+            "WantToProposeEmbargo"
+        ),
+        EMBARGO_STOCHASTIC.willing_to_counter_factory(
+            "WillingToCounterEmbargoProposal"
+        ),
+        EMBARGO_STOCHASTIC.reason_to_propose_when_deployed_factory(
+            "ReasonToProposeEmbargoWhenDeployed"
+        ),
+        EMBARGO_STOCHASTIC.evaluate_embargo_proposal_factory(
+            "EvaluateEmbargoProposal"
+        ),
+        EMBARGO_STOCHASTIC.current_embargo_acceptable_factory(
+            "CurrentEmbargoAcceptable"
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Full-tree embargo run via BTBridge
+# ---------------------------------------------------------------------------
+
+
+def _run_embargo_full_tree(n_ticks: int = N_TICKS) -> None:
+    """Run the full ManageEmbargoBT tree via BTBridge and in-memory DataLayer."""
+    from vultron.adapters.driven.datalayer_sqlite import SqliteDataLayer
+    from vultron.adapters.driven.trigger_activity_adapter import (
+        TriggerActivityAdapter,
+    )
+    from vultron.core.behaviors.bridge import BTBridge
+    from vultron.core.behaviors.embargo.manage_embargo_tree import (
+        create_manage_embargo_tree,
+    )
+    from vultron.demo.fuzzer.bundles.embargo import EMBARGO_STOCHASTIC
+
+    logger.info(
+        "--- domain: embargo (full tree via BTBridge, %d ticks) ---", n_ticks
+    )
+
+    dl = SqliteDataLayer("sqlite:///:memory:")
+    bridge = BTBridge(
+        datalayer=dl,
+        trigger_activity=TriggerActivityAdapter(dl),
+    )
+
+    for tick in range(1, n_ticks + 1):
+        py_trees.blackboard.Blackboard.storage.clear()
+        tree = create_manage_embargo_tree(
+            case_id=_DEMO_CASE_ID,
+            call_out=EMBARGO_STOCHASTIC,
+        )
+        result = bridge.execute_with_setup(
+            tree,
+            actor_id=_DEMO_ACTOR_ID,
+        )
+        for node in tree.iterate():
+            if not isinstance(node, py_trees.composites.Composite):
+                _log_outcome(node, tick)
+        logger.info(
+            "ManageEmbargoBT tick=%d root_status=%s",
+            tick,
+            result.status.value,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def run_stochastic_demo(n_ticks: int = N_TICKS) -> None:
+    """Run the full STOCHASTIC bundle demo across all three domains.
+
+    Args:
+        n_ticks: Number of ticks per call-out point node (default: ``N_TICKS``).
+    """
+    logger.info("=== Stochastic Bundle Demo — start ===")
+
+    py_trees.blackboard.Blackboard.storage.clear()
+    try:
+        _run_domain_nodes("validation", _validation_nodes(), n_ticks)
+        _run_domain_nodes("prioritization", _prioritization_nodes(), n_ticks)
+        _run_domain_nodes(
+            "embargo (standalone nodes)", _embargo_nodes(), n_ticks
+        )
+        _run_embargo_full_tree(n_ticks)
+    finally:
+        py_trees.blackboard.Blackboard.storage.clear()
+
+    logger.info("=== Stochastic Bundle Demo — complete ===")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(levelname)s %(name)s %(message)s",
+    )
+    run_stochastic_demo()


### PR DESCRIPTION
- Closes #1672

## Summary

Adds a runnable in-process demo that exercises STOCHASTIC call-out point bundles across the validation, prioritization, and embargo domains, logging each node name and SUCCESS/FAILURE result per BT tick — no HTTP server required.

## Changes

- **`vultron/demo/fuzzer/stochastic_demo.py`**: New 244-line script. Instantiates all STOCHASTIC bundle call-out nodes per domain and ticks them N_TICKS (5) times, logging outcomes. The embargo domain additionally runs the full `ManageEmbargoBT` tree via `BTBridge` + an in-memory `SqliteDataLayer` to demonstrate end-to-end tree execution. Entry point: `python -m vultron.demo.fuzzer.stochastic_demo` or `run_stochastic_demo()`.
- **`test/demo/fuzzer/test_stochastic_demo.py`**: 4 companion tests covering: no-error execution, outcome log format (node= and result= fields, valid status values), three-domain coverage (validation/prioritization/embargo nodes present), and module importability as `vultron.demo.fuzzer.stochastic_demo`.

## Verification

- 5436 unit tests pass (4 new), 0 failures, 2 xfailed (pre-existing)
- Black, flake8, mypy, pyright all clean
- [x] AC-1: Script exercises STOCHASTIC bundles for validation, prioritization, and embargo domains
- [x] AC-2: Output logs each call-out point outcome: node name + SUCCESS/FAILURE per tick
- [x] AC-3: Script runnable as `python -m vultron.demo.fuzzer.stochastic_demo`
- [x] AC-4: Companion test in `test/demo/fuzzer/` verifies the script runs and produces outcome log lines
- [x] AC-5: All existing integration tests pass unchanged
- [x] AC-6: Satisfies issue #1152 AC-4 — at least one scenario exercises a probabilistic fuzzer backend with call-out point outcome logging