### PR TITLE
Report: surface PEC state per participant in timeline

### DIFF
--- a/plan/history/2607/implementation/ISSUE-1685.md
+++ b/plan/history/2607/implementation/ISSUE-1685.md
@@ -1,0 +1,19 @@
+---
+source: ISSUE-1685
+timestamp: '2026-07-27T16:32:09.471843+00:00'
+title: 'Report: surface PEC state per participant'
+type: implementation
+---
+
+## Issue #1685 — Report: surface PEC (Participant Embargo Consent) state per participant
+
+Added `pec_state` field to `CaseTimelineEvent` in the demo report tool,
+extracted from `ParticipantStatus` payload snapshots. The extractor handles
+all five wire spellings: ADR-0036 dimension-object shape
+(`{"consent": {"state": "SIGNATORY"}}`), plus four flat aliases
+(`emConsentState`, `em_consent_state`, `embargoConsentState`,
+`embargo_consent_state`). Added a dedicated PEC column between EM and CS in
+both markdown and HTML renderers. Added DRPT-02-008 to specs/demo-report.yaml
+and bumped spec version to 1.5.0. Added 12 new tests.
+
+PR: <https://github.com/CERTCC/Vultron/pull/1712>

--- a/specs/demo-report.yaml
+++ b/specs/demo-report.yaml
@@ -6,7 +6,7 @@ description: >-
   report of who did what, with what activity, and in what order. Covers input discovery,
   the distilled intermediate data model, markdown and HTML rendering, the per-actor
   replica-presence matrix, friendly naming, and test requirements.
-version: 1.4.0
+version: 1.5.0
 scope:
 - prototype
 tags:
@@ -158,6 +158,29 @@ groups:
     relationships:
     - rel_type: refines
       spec_id: DRPT-02-004
+  - id: DRPT-02-008
+    priority: MUST
+    kind: project
+    statement: >-
+      Each distilled event MUST carry the per-participant Embargo Consent state
+      (`pec_state`) extracted from the `ParticipantStatus` payload snapshot,
+      where present. The extractor MUST handle the ADR-0036 dimension-object
+      shape (`{"consent": {"state": "SIGNATORY"}}`), the legacy flat camelCase
+      alias (`emConsentState`), the legacy flat snake_case alias
+      (`em_consent_state`), the camelCase long form (`embargoConsentState`), and
+      the snake_case long form (`embargo_consent_state`). Both renderers MUST
+      include a `PEC` column in the event table and populate it from
+      `pec_state`.
+    rationale: >-
+      The case-level EM column shows only the shared embargo state (NONE,
+      PROPOSED, ACTIVE, REVISE, EXITED).  Per-participant embargo consent
+      (NO_EMBARGO, INVITED, SIGNATORY, LAPSED, DECLINED) is a distinct
+      five-state machine tracked on `ParticipantStatus`; without a dedicated
+      PEC column, embargo acceptance and lapse events are invisible in the
+      report.
+    relationships:
+    - rel_type: extends
+      spec_id: DRPT-02-002
 - id: DRPT-03
   title: Friendly Naming
   specs:

--- a/test/demo/test_report.py
+++ b/test/demo/test_report.py
@@ -161,6 +161,93 @@ class TestCaseTimelineEventParsing:
         assert event.rm_state == "CLOSED"
         assert event.vfd_state == "VFD"
 
+    def test_pec_state_from_consent_dimension_object(self):
+        """PEC state extracted from ADR-0036 consent dimension object."""
+        raw = _snake_entry(
+            payload_snapshot={
+                "type": "Add",
+                "actor": "http://finder:7999/api/v2/actors/finder",
+                "object": {
+                    "id": "urn:uuid:ps2",
+                    "type": "ParticipantStatus",
+                    "consent": {"state": "SIGNATORY"},
+                },
+            }
+        )
+        event = CaseTimelineEvent.from_raw(raw)
+        assert event.pec_state == "SIGNATORY"
+
+    def test_pec_state_from_flat_em_consent_state(self):
+        """Legacy emConsentState flat field tolerated."""
+        raw = _camel_entry(
+            eventType="add_participant_status_to_participant",
+            payloadSnapshot={
+                "type": "Add",
+                "actor": "http://vendor:7999/api/v2/actors/vendor",
+                "object": {
+                    "id": "urn:uuid:ps3",
+                    "type": "ParticipantStatus",
+                    "emConsentState": "INVITED",
+                },
+            },
+        )
+        event = CaseTimelineEvent.from_raw(raw)
+        assert event.pec_state == "INVITED"
+
+    def test_pec_state_from_flat_embargo_consent_state(self):
+        """Legacy embargoConsentState flat field tolerated."""
+        raw = _camel_entry(
+            eventType="add_participant_status_to_participant",
+            payloadSnapshot={
+                "type": "Add",
+                "actor": "http://vendor:7999/api/v2/actors/vendor",
+                "object": {
+                    "id": "urn:uuid:ps4",
+                    "type": "ParticipantStatus",
+                    "embargoConsentState": "DECLINED",
+                },
+            },
+        )
+        event = CaseTimelineEvent.from_raw(raw)
+        assert event.pec_state == "DECLINED"
+
+    def test_pec_state_from_flat_em_consent_state_snake(self):
+        """Legacy em_consent_state snake_case short form tolerated."""
+        raw = _snake_entry(
+            payload_snapshot={
+                "type": "Add",
+                "actor": "http://finder:7999/api/v2/actors/finder",
+                "object": {
+                    "id": "urn:uuid:ps5",
+                    "type": "ParticipantStatus",
+                    "em_consent_state": "SIGNATORY",
+                },
+            }
+        )
+        event = CaseTimelineEvent.from_raw(raw)
+        assert event.pec_state == "SIGNATORY"
+
+    def test_pec_state_from_flat_embargo_consent_state_snake(self):
+        """Legacy embargo_consent_state snake_case long form tolerated."""
+        raw = _snake_entry(
+            payload_snapshot={
+                "type": "Add",
+                "actor": "http://finder:7999/api/v2/actors/finder",
+                "object": {
+                    "id": "urn:uuid:ps6",
+                    "type": "ParticipantStatus",
+                    "embargo_consent_state": "LAPSED",
+                },
+            }
+        )
+        event = CaseTimelineEvent.from_raw(raw)
+        assert event.pec_state == "LAPSED"
+
+    def test_pec_state_absent_when_not_in_payload(self):
+        """pec_state is None when no consent field is present."""
+        event = CaseTimelineEvent.from_raw(_camel_entry())
+        assert event.pec_state is None
+
     def test_em_state_from_case_status(self):
         raw = _camel_entry(
             eventType="add_case_status_to_case",
@@ -580,6 +667,7 @@ class TestMarkdownRenderer:
         # Distilled field columns + one column per actor.
         assert "| finder | vendor |" in header
         assert "Actor" in header and "Event" in header
+        assert "| PEC |" in header
         # Separator row present.
         sep_idx = lines.index(header) + 1
         assert set(lines[sep_idx].replace("|", "").split()) == {"---"}
@@ -705,6 +793,90 @@ class TestHtmlRenderer:
         out = render_html(build_timeline({"vendor": [raw]}), ["vendor"])
         assert "<h2>Case urn:case:&lt;x&gt;</h2>" in out
         assert "<x>" not in out
+
+
+# ---------------------------------------------------------------------------
+# DRPT-02-008 — PEC column in renderers
+# ---------------------------------------------------------------------------
+
+
+def _pec_entry(pec_value: str, **overrides):
+    """A raw ledger entry carrying a ParticipantStatus with a consent dimension."""
+    return _camel_entry(
+        eventType="add_participant_status_to_participant",
+        payloadSnapshot={
+            "type": "Add",
+            "actor": "http://vendor:7999/api/v2/actors/vendor",
+            "object": {
+                "id": "urn:uuid:ps_pec",
+                "type": "ParticipantStatus",
+                "consent": {"state": pec_value},
+                "rm": {"state": "ACCEPTED"},
+            },
+        },
+        **overrides,
+    )
+
+
+class TestPecColumn:
+    def test_pec_state_appears_in_markdown_table(self):
+        replicas = {"vendor": [_pec_entry("SIGNATORY")]}
+        md = render_markdown(build_timeline(replicas), ["vendor"])
+        assert "| PEC |" in md
+        assert "SIGNATORY" in md
+
+    def test_pec_state_absent_renders_empty_cell_markdown(self):
+        """An entry without PEC state renders an empty PEC cell, not an error."""
+        replicas = {"vendor": [_camel_entry()]}
+        md = render_markdown(build_timeline(replicas), ["vendor"])
+        assert "| PEC |" in md
+
+    def test_pec_state_appears_in_html_table(self):
+        replicas = {"vendor": [_pec_entry("LAPSED")]}
+        out = render_html(build_timeline(replicas), ["vendor"])
+        assert "<th>PEC</th>" in out
+        assert "LAPSED" in out
+
+    def test_pec_state_absent_renders_empty_cell_html(self):
+        replicas = {"vendor": [_camel_entry()]}
+        out = render_html(build_timeline(replicas), ["vendor"])
+        assert "<th>PEC</th>" in out
+
+    def test_pec_flat_em_consent_state_extracted(self):
+        """Legacy emConsentState flat field surfaces in the report."""
+        raw = _camel_entry(
+            eventType="add_participant_status_to_participant",
+            payloadSnapshot={
+                "type": "Add",
+                "actor": "http://vendor:7999/api/v2/actors/vendor",
+                "object": {
+                    "id": "urn:uuid:ps_flat",
+                    "type": "ParticipantStatus",
+                    "emConsentState": "INVITED",
+                },
+            },
+        )
+        replicas = {"vendor": [raw]}
+        md = render_markdown(build_timeline(replicas), ["vendor"])
+        assert "INVITED" in md
+
+    def test_pec_flat_embargo_consent_state_extracted(self):
+        """Legacy embargoConsentState camelCase form surfaces in the report."""
+        raw = _camel_entry(
+            eventType="add_participant_status_to_participant",
+            payloadSnapshot={
+                "type": "Add",
+                "actor": "http://vendor:7999/api/v2/actors/vendor",
+                "object": {
+                    "id": "urn:uuid:ps_long",
+                    "type": "ParticipantStatus",
+                    "embargoConsentState": "DECLINED",
+                },
+            },
+        )
+        replicas = {"vendor": [raw]}
+        md = render_markdown(build_timeline(replicas), ["vendor"])
+        assert "DECLINED" in md
 
 
 # ---------------------------------------------------------------------------

--- a/vultron/demo/report.py
+++ b/vultron/demo/report.py
@@ -449,8 +449,12 @@ class CaseTimelineEvent(BaseModel):
             ``Accept(Invite(object=Org, target=Case))``).
         activity_target_type: Wire type of the destination/target object.
         received_at: Server-generated receipt timestamp (``receivedAt``).
-        rm_state / em_state / vfd_state / pxa_state: Resulting state-machine
-            dimensions extracted from the payload snapshot, where present.
+        rm_state / em_state / pec_state / vfd_state / pxa_state: Resulting
+            state-machine dimensions extracted from the payload snapshot, where
+            present. ``pec_state`` is the per-participant Embargo Consent state
+            (NO_EMBARGO, INVITED, SIGNATORY, LAPSED, DECLINED), extracted from
+            the ``consent`` dimension object or legacy ``emConsentState`` /
+            ``embargoConsentState`` flat fields.
         present_in: Sorted actor-directory names whose replicas hold this
             entry (the per-actor replica-presence indicator, DRPT-02-005).
     """
@@ -471,6 +475,7 @@ class CaseTimelineEvent(BaseModel):
     received_at: str | None = None
     rm_state: str | None = None
     em_state: str | None = None
+    pec_state: str | None = None
     vfd_state: str | None = None
     pxa_state: str | None = None
     present_in: list[str] = Field(default_factory=list)
@@ -562,6 +567,14 @@ class CaseTimelineEvent(BaseModel):
             received_at=str(received) if received else None,
             rm_state=_dimension_state(candidates, "rm", "rmState", "rm_state"),
             em_state=_dimension_state(candidates, "em", "emState", "em_state"),
+            pec_state=_dimension_state(
+                candidates,
+                "consent",
+                "emConsentState",
+                "em_consent_state",
+                "embargoConsentState",
+                "embargo_consent_state",
+            ),
             vfd_state=_dimension_state(
                 candidates, "vfd", "vfdState", "vfd_state"
             ),
@@ -791,6 +804,7 @@ _TABLE_HEADERS = [
     "Target",
     "RM",
     "EM",
+    "PEC",
     "CS",
     "Entry",
 ]
@@ -852,6 +866,7 @@ def _render_markdown_case(
             _md_cell(event.target_label or ""),
             _md_cell(event.rm_state or ""),
             _md_cell(event.em_state or ""),
+            _md_cell(event.pec_state or ""),
             _md_cell(event.cs_state or ""),
             _md_cell(event.short_hash),
         ]
@@ -960,6 +975,7 @@ def _render_html_case_table(
             ),
             _html_cell(event.rm_state or ""),
             _html_cell(event.em_state or ""),
+            _html_cell(event.pec_state or ""),
             _html_cell(event.cs_state or ""),
             _html_cell(event.short_hash, title=event.entry_hash or None),
         ]


### PR DESCRIPTION
- Closes #1685

## Summary

Surfaces per-participant Embargo Consent (PEC) state in the demo scenario
report tool. The case-level EM column shows the shared embargo state
(PROPOSED, ACTIVE, …); the new PEC column shows each participant's
individual consent stance (NO_EMBARGO, INVITED, SIGNATORY, LAPSED,
DECLINED) extracted from `ParticipantStatus` payloads.

## Changes

- **`vultron/demo/report.py`**: Added `pec_state: str | None` field to
  `CaseTimelineEvent`; extraction via `_dimension_state` handles all four
  alias spellings (`consent`/dimension-object, `emConsentState`,
  `em_consent_state`, `embargoConsentState`, `embargo_consent_state`);
  added `PEC` column to `_TABLE_HEADERS` and both renderers.
- **`specs/demo-report.yaml`**: Added DRPT-02-008 requiring PEC extraction
  and rendering; bumped version to 1.5.0.
- **`test/demo/test_report.py`**: Added 12 tests covering all five alias
  spellings (dimension-object shape + four flat forms), None-when-absent,
  and PEC column presence in both markdown and HTML renderers.

## Test plan

- [x] `uv run pytest test/demo/test_report.py -m ""` — 110 passed
- [x] Full suite `uv run pytest --tb=short` — 5445 passed, 0 failed
- [x] Black, flake8, mypy, pyright — all clean
- [x] `PYTHONPATH= uv run spec-dump` — parses DRPT v1.5.0 without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)