### PR TITLE
docs: plan issue #1677 — AutoClose BT god-node decomposition

### DIFF
--- a/plan/history/2607/learning/CONCERN-1677.md
+++ b/plan/history/2607/learning/CONCERN-1677.md
@@ -1,0 +1,64 @@
+---
+source: CONCERN-1677
+timestamp: '2026-07-27T17:55:33.442654+00:00'
+title: 'Case-actor close-ready condition: AutoCloseBranchNode is a god node'
+type: learning
+---
+
+## Summary
+
+Case-actor should autonomously decide to emit `close_case` once all participants
+have reached RM=CLOSED. Currently the demo puppeteer performs this check
+externally (`wait_for_all_participants_rm_closed`) and then instructs each
+participant to close the case via trigger endpoints. There is no BT-level
+condition node that case-actor evaluates to determine readiness for closure.
+
+## Category
+
+Protocol / BT behavior gap
+
+## Severity
+
+Medium — correct behavior occurs in the demo but only because the script
+enforces the right ordering. A real deployment would have no such guarantee.
+
+## Evidence
+
+`vultron/demo/scenario/fv_demo.py` `_phase_case_closure()`: each actor is told
+to close via `actor_closes_case()` calls followed by
+`wait_for_all_participants_rm_closed()`. The wait is a postcondition check in the
+demo, not a precondition evaluated by case-actor's BT.
+
+No BT node named `CloseReadyConditionNode` or equivalent exists in
+`vultron/core/behaviors/`.
+
+## Impact if Ignored
+
+Case-actor can emit `close_case` before all participants have agreed, violating
+the protocol invariant that case closure requires consensus. In a real
+multi-party deployment this could close a case while participants still have
+open work.
+
+## Suggested Action
+
+Design and implement a `CloseReadyConditionNode` (or equivalent guard) in the
+case-actor BT that checks all known participants are at RM=CLOSED before the
+`close_case` emit is reached. The demo script's external wait can then serve as
+a test oracle rather than a control mechanism.
+
+## Resolution
+
+2026-07-27 — `AutoCloseBranchNode` in
+`vultron/core/behaviors/status/nodes/lifecycle.py` already implements the
+all-participants-RM-CLOSED check and emits `close_case` autonomously. However,
+the check and emit logic is buried inside `update()` (god-node pattern,
+BT-IDM-03 violation). The concern was partially addressed but the BT structure
+violation remains.
+
+Implementation tracked in #1716 (decompose `AutoCloseBranchNode` into
+`AllParticipantsRMClosedConditionNode` + `CloseNotYetEmittedConditionNode` +
+routing guard + emit node as a proper BT Sequence, per DEMOMA-07-006).
+
+Docs PR: <https://github.com/CERTCC/Vultron/pull/1715>.
+Spec: `specs/multi-actor-demo.yaml` DEMOMA-07-006.
+Notes: `vultron/core/behaviors/AGENTS.md`.

--- a/specs/multi-actor-demo.yaml
+++ b/specs/multi-actor-demo.yaml
@@ -4,7 +4,7 @@ description: >-
   Requirements for multi-actor demo scenarios, Docker Compose orchestration, actor isolation,
   acceptance testing, and reproducibility. Includes per-scenario required
   event-type lists for the case-ledger invariant harness.
-version: 1.1.0
+version: 1.2.0
 scope:
 
 - prototype
@@ -311,18 +311,86 @@ groups:
     priority: MUST
     kind: project
     statement: >-
-      The Case Actor received handler for ADD_PARTICIPANT_STATUS_TO_PARTICIPANT MUST:
-      (1) verify the activity actor is a known case participant,
+      The Case Actor received handler for ADD_PARTICIPANT_STATUS_TO_PARTICIPANT MUST
+      implement the following ordered steps as a BT Sequence:
+      (1) verify the activity actor is a known case participant (precondition guard),
       (2) update the participant status record,
       (3) propagate the update to all other case participants via Announce(CaseLedgerEntry)
       fan-out (per ADR-0019 and SYNC-02-002) — NOT via a direct raw Add(ParticipantStatus)
       re-broadcast,
       (4) if CS.P is newly set by the Case Owner, trigger embargo teardown automatically,
-      (5) if all participants are RM.CLOSED, close the case automatically
+      (5) if all participants are RM.CLOSED, close the case automatically.
+      Each step MUST be implemented as a distinct BT node or subtree so that the protocol
+      logic is visible in the tree structure and not hidden inside node update() methods.
+    testable: true
+    trigger:
+      type: message_received
+      value: ADD_PARTICIPANT_STATUS_TO_PARTICIPANT
+    preconditions:
+    - description: Receiving actor is CASE_MANAGER (Case Actor)
+    - description: Inbound activity actor is a known case participant
+    steps:
+    - order: 1
+      actor: case_actor
+      action: Verify inbound activity actor is a known case participant
+      expected: >-
+        Actor found in case.actor_participant_index; FAILURE if unknown sender
+    - order: 2
+      actor: case_actor
+      action: Append ParticipantStatus to the participant record
+      expected: Participant's latest status reflects the newly received state
+    - order: 3
+      actor: case_actor
+      action: >-
+        Commit a canonical CaseLedgerEntry and fan-out Announce(CaseLedgerEntry)
+        to all known case participants
+      expected: >-
+        All peers receive the status update via the canonical log path
+        (ADR-0019, SYNC-02-002); no raw Add(ParticipantStatus) re-broadcast emitted
+    - order: 4
+      actor: case_actor
+      action: >-
+        If the new ParticipantStatus indicates CS.P (public awareness) and the
+        sender holds CASE_OWNER role and an active embargo exists,
+        emit ET (Embargo Termination) to initiate teardown
+      expected: Embargo teardown triggered; EM transitions to EXITED
+    - order: 5
+      actor: case_actor
+      action: >-
+        If all non-CASE_MANAGER participants have RM.CLOSED as their latest status
+        and no Leave(VulnerabilityCase) has already been emitted for this case,
+        emit Leave(VulnerabilityCase) to the Case Actor to close the case
+      expected: close_case activity queued; case closure initiated
+    postconditions:
+    - description: >-
+        Participant record updated; CaseLedgerEntry committed and broadcast;
+        embargo teardown triggered if CS.P+CASE_OWNER; case closed if all RM.CLOSED
     relationships:
     - rel_type: refines
       spec_id: SYNC-02-002
       note: step 3 propagation must use canonical Announce(CaseLedgerEntry) fan-out
+  - id: DEMOMA-07-006
+    priority: MUST
+    kind: project
+    statement: >-
+      The all-participants-RM-CLOSED check (DEMOMA-07-003 step 5) MUST be implemented
+      as a DataLayerCondition BT node (not as procedural logic inside a DataLayerAction
+      node's update() method). The condition node MUST: (a) iterate all
+      actor_participant_index entries, (b) skip participants holding CVDRole.CASE_MANAGER,
+      and (c) return FAILURE if any remaining participant's latest status rm_state is not
+      RM.CLOSED. The emit step that follows MUST also check that no Leave(VulnerabilityCase)
+      has already been written to the outbox for the case (idempotency via DataLayer
+      query, not via a process-level in-memory set).
+    testable: true
+    relationships:
+    - rel_type: refines
+      spec_id: DEMOMA-07-003
+      note: >-
+        Mandates BT node decomposition for step 5 close-ready precondition;
+        prohibits god-node pattern (BT-IDM-03)
+    - rel_type: refines
+      spec_id: BT-06-001
+      note: all protocol-significant behavior must be in the BT
   - id: DEMOMA-07-004
     priority: SHOULD
     kind: project

--- a/vultron/core/behaviors/AGENTS.md
+++ b/vultron/core/behaviors/AGENTS.md
@@ -1,0 +1,88 @@
+# AGENTS.md — `vultron/core/behaviors/`
+
+Agent guidance for implementing and reviewing BT nodes and subtrees in this
+package.
+
+---
+
+## No God Nodes (BT-IDM-03)
+
+A BT leaf node's `update()` method MUST NOT exceed ~20–30 lines. If it does,
+it is doing too much.
+
+**What belongs in the tree structure, not in a node:**
+
+- Precondition checks (use `DataLayerCondition` subclasses)
+- Routing guards (use condition nodes before state-mutation nodes;
+  see BT-19-001)
+- Idempotency checks (use a `DataLayerCondition` that queries the DataLayer
+  for existing outbox or state records — not a module-level in-memory set)
+- Multi-step action sequences (compose as a `Sequence` of simple leaf nodes)
+
+**References:**
+
+- `notes/bt-canonical-reference.md` § "BT-IDM-03: God BT nodes"
+- `specs/behavior-tree-node-design.yaml` BTND-02-001 through BTND-02-004
+- `notes/bt-pitfalls.md` — per-pitfall debugging notes
+
+**Violation example** — the `AutoCloseBranchNode` prior to #1677 buried
+`_all_participants_closed()`, `_claim_close()`, `_resolve_case_manager_id()`,
+and `_emit_close_case()` all inside `update()`. Each should be a separate
+leaf node in a `Sequence`. See DEMOMA-07-006.
+
+---
+
+## Idempotency — DataLayer over Process State
+
+BT condition nodes that guard "has this action already fired?" MUST query the
+DataLayer (outbox or domain objects), not a module-level in-memory set or dict.
+Process-level sets do not survive restarts and are invisible to the BT audit
+trail.
+
+The adapter-level `ValueError` on duplicate `dl.create()` provides a safety
+net, but the BT-level guard should be authoritative.
+
+---
+
+## Precondition Pattern — Condition Before Action
+
+Use the Sequence-with-precondition pattern, not the "skip-unless" Selector
+framing:
+
+```text
+# PREFERRED
+Sequence
+  ├─ AllParticipantsRMClosedConditionNode   # FAILURE → whole Sequence skips
+  ├─ CloseNotYetEmittedConditionNode        # FAILURE → whole Sequence skips
+  ├─ ResolveCaseManagerNode                 # routing guard
+  └─ EmitCloseCaseNode                      # action
+
+# AVOID — hides the skip logic
+Selector
+  ├─ SkipUnlessConditionNode (SUCCESS = skip)
+  └─ ActionNode
+```
+
+The Sequence framing keeps all conditions readable left-to-right in the tree.
+
+**Reference:** BTND-08-001, BTND-08-002,
+`notes/bt-design-patterns.md` § "Negative-Guard Anti-Pattern".
+
+---
+
+## Routing Guards Must Precede State Mutation
+
+Resolve routing prerequisites (e.g., Case Manager ID) in a read-only condition
+or guard node BEFORE any state-mutation or emit node. See BT-19-001, BT-19-002.
+
+---
+
+## See Also
+
+- `notes/bt-integration.md` — architecture decisions, actor isolation,
+  concurrency model
+- `notes/bt-canonical-reference.md` — subtree map, BT-IDM anti-patterns
+- `notes/bt-pitfalls.md` — blackboard, idempotency, role guards
+- `notes/bt-design-patterns.md` — idiomatic BT construction patterns
+- `specs/behavior-tree-integration.yaml` — BT-06 through BT-22 requirements
+- `specs/behavior-tree-node-design.yaml` — BTND node design requirements


### PR DESCRIPTION
- Closes #1677

## Summary

- Refactors `DEMOMA-07-003` from a prose multi-step statement into full ECA
  behavioral spec format (trigger / preconditions / steps / postconditions)
  in `specs/multi-actor-demo.yaml`
- Adds `DEMOMA-07-006`: the all-participants-RM-CLOSED check **MUST** be a
  `DataLayerCondition` BT node; idempotency via DataLayer outbox query rather
  than a process-level in-memory set; prohibits the god-node pattern
  (BT-IDM-03) at this seam
- Creates `vultron/core/behaviors/AGENTS.md` with guidance on god-node
  avoidance, DataLayer-based idempotency, precondition-before-action Sequence
  pattern, and routing-guard ordering
- Bumps `specs/multi-actor-demo.yaml` version 1.1.0 → 1.2.0

## Test plan

- [ ] `PYTHONPATH= uv run spec-dump` passes cleanly (spec registry validates
  new entries)
- [ ] `markdownlint-cli2` passes on `vultron/core/behaviors/AGENTS.md`
- [ ] Implementation issue created and tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)